### PR TITLE
fix(browser): scroll oversized viewport presets

### DIFF
--- a/src/main/browser/browser-guest-wheel-zoom-scroll.test.ts
+++ b/src/main/browser/browser-guest-wheel-zoom-scroll.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setupGuestMouseWheelZoomForwarding } from './browser-guest-wheel-zoom'
+
+describe('guest viewport wheel forwarding', () => {
+  const rendererSend = vi.fn()
+  const guestOn = vi.fn()
+
+  beforeEach(() => {
+    rendererSend.mockReset()
+    guestOn.mockReset()
+  })
+
+  function trigger(
+    active: boolean,
+    mouse: Partial<Electron.MouseWheelInputEvent>
+  ): ReturnType<typeof vi.fn> {
+    setupGuestMouseWheelZoomForwarding({
+      browserTabId: 'tab-1',
+      guest: { on: guestOn } as unknown as Electron.WebContents,
+      resolveRenderer: () => ({ send: rendererSend }) as unknown as Electron.WebContents,
+      isViewportPresetActive: () => active
+    })
+    const handler = guestOn.mock.calls.at(-1)![1] as (
+      event: Electron.Event,
+      input: Electron.MouseInputEvent
+    ) => void
+    const preventDefault = vi.fn()
+    handler({ preventDefault } as unknown as Electron.Event, {
+      type: 'mouseWheel',
+      x: 0,
+      y: 0,
+      modifiers: [],
+      deltaX: 0,
+      deltaY: 0,
+      ...mouse
+    })
+    return preventDefault
+  }
+
+  it('forwards plain wheel deltas only for an active preset', () => {
+    const preventDefault = trigger(true, { deltaX: 24, deltaY: 120 })
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(rendererSend).toHaveBeenCalledWith('ui:scrollBrowserPage', {
+      browserPageId: 'tab-1',
+      deltaX: 24,
+      deltaY: 120
+    })
+
+    trigger(false, { deltaY: 120 })
+    expect(rendererSend).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores zero deltas and preserves ctrl-wheel zoom routing', () => {
+    const zeroPreventDefault = trigger(true, {})
+    expect(zeroPreventDefault).not.toHaveBeenCalled()
+
+    const zoomPreventDefault = trigger(true, { modifiers: ['ctrl'], deltaY: -120 })
+    expect(zoomPreventDefault).toHaveBeenCalledTimes(1)
+    expect(rendererSend).toHaveBeenLastCalledWith('ui:zoomBrowserPage', 'in')
+  })
+})

--- a/src/main/browser/browser-guest-wheel-zoom-scroll.test.ts
+++ b/src/main/browser/browser-guest-wheel-zoom-scroll.test.ts
@@ -18,7 +18,8 @@ describe('guest viewport wheel forwarding', () => {
       browserTabId: 'tab-1',
       guest: { on: guestOn } as unknown as Electron.WebContents,
       resolveRenderer: () => ({ send: rendererSend }) as unknown as Electron.WebContents,
-      isViewportPresetActive: () => active
+      isViewportPresetActive: () => active,
+      canViewportScroll: () => active
     })
     const handler = guestOn.mock.calls.at(-1)![1] as (
       event: Electron.Event,
@@ -58,5 +59,34 @@ describe('guest viewport wheel forwarding', () => {
     const zoomPreventDefault = trigger(true, { modifiers: ['ctrl'], deltaY: -120 })
     expect(zoomPreventDefault).toHaveBeenCalledTimes(1)
     expect(rendererSend).toHaveBeenLastCalledWith('ui:zoomBrowserPage', 'in')
+  })
+
+  it('leaves fitting presets and host-edge wheels to the guest page', () => {
+    setupGuestMouseWheelZoomForwarding({
+      browserTabId: 'tab-1',
+      guest: { on: guestOn } as unknown as Electron.WebContents,
+      resolveRenderer: () => ({ send: rendererSend }) as unknown as Electron.WebContents,
+      isViewportPresetActive: () => true,
+      canViewportScroll: () => false
+    })
+    const handler = guestOn.mock.calls.at(-1)![1] as (
+      event: Electron.Event,
+      input: Electron.MouseWheelInputEvent
+    ) => void
+    const preventDefault = vi.fn()
+    handler(
+      { preventDefault } as unknown as Electron.Event,
+      {
+        type: 'mouseWheel',
+        x: 0,
+        y: 0,
+        modifiers: [],
+        deltaX: 0,
+        deltaY: 120
+      } as Electron.MouseWheelInputEvent
+    )
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(rendererSend).not.toHaveBeenCalled()
   })
 })

--- a/src/main/browser/browser-guest-wheel-zoom.ts
+++ b/src/main/browser/browser-guest-wheel-zoom.ts
@@ -68,17 +68,34 @@ export function setupGuestMouseWheelZoomForwarding(args: {
   browserTabId: string
   guest: Electron.WebContents
   resolveRenderer: ResolveRenderer
+  isViewportPresetActive?: () => boolean
 }): () => void {
-  const { browserTabId, guest, resolveRenderer } = args
+  const { browserTabId, guest, resolveRenderer, isViewportPresetActive } = args
   const handler = (event: Electron.Event, mouse: Electron.MouseInputEvent): void => {
     const direction = resolveGuestMouseWheelZoomDirection(mouse)
-    if (!direction) {
+    if (direction) {
+      // Why: wheel input over a focused webview never reaches renderer DOM handlers, so consume and forward here.
+      event.preventDefault()
+      markGuestWheelZoom(guest, direction)
+      resolveRenderer(browserTabId)?.send('ui:zoomBrowserPage', direction)
       return
     }
-    // Why: wheel input over a focused webview never reaches renderer DOM handlers, so consume and forward here.
+    if (!isViewportPresetActive?.() || mouse.type !== 'mouseWheel') {
+      return
+    }
+    const { deltaX, deltaY } = mouse as Electron.MouseWheelInputEvent
+    const safeDeltaX = typeof deltaX === 'number' && Number.isFinite(deltaX) ? deltaX : 0
+    const safeDeltaY = typeof deltaY === 'number' && Number.isFinite(deltaY) ? deltaY : 0
+    if (safeDeltaX === 0 && safeDeltaY === 0) {
+      return
+    }
+    // Why: the host owns panning once emulation makes the guest viewport larger than the pane.
     event.preventDefault()
-    markGuestWheelZoom(guest, direction)
-    resolveRenderer(browserTabId)?.send('ui:zoomBrowserPage', direction)
+    resolveRenderer(browserTabId)?.send('ui:scrollBrowserPage', {
+      browserPageId: browserTabId,
+      deltaX: safeDeltaX,
+      deltaY: safeDeltaY
+    })
   }
 
   guest.on('before-mouse-event', handler)

--- a/src/main/browser/browser-guest-wheel-zoom.ts
+++ b/src/main/browser/browser-guest-wheel-zoom.ts
@@ -69,8 +69,17 @@ export function setupGuestMouseWheelZoomForwarding(args: {
   guest: Electron.WebContents
   resolveRenderer: ResolveRenderer
   isViewportPresetActive?: () => boolean
+  canViewportScroll?: (mouse: Electron.MouseWheelInputEvent) => boolean
+  onViewportWheelConsumed?: (deltaX: number, deltaY: number) => void
 }): () => void {
-  const { browserTabId, guest, resolveRenderer, isViewportPresetActive } = args
+  const {
+    browserTabId,
+    guest,
+    resolveRenderer,
+    isViewportPresetActive,
+    canViewportScroll,
+    onViewportWheelConsumed
+  } = args
   const handler = (event: Electron.Event, mouse: Electron.MouseInputEvent): void => {
     const direction = resolveGuestMouseWheelZoomDirection(mouse)
     if (direction) {
@@ -80,7 +89,11 @@ export function setupGuestMouseWheelZoomForwarding(args: {
       resolveRenderer(browserTabId)?.send('ui:zoomBrowserPage', direction)
       return
     }
-    if (!isViewportPresetActive?.() || mouse.type !== 'mouseWheel') {
+    if (
+      !isViewportPresetActive?.() ||
+      mouse.type !== 'mouseWheel' ||
+      !canViewportScroll?.(mouse as Electron.MouseWheelInputEvent)
+    ) {
       return
     }
     const { deltaX, deltaY } = mouse as Electron.MouseWheelInputEvent
@@ -91,6 +104,7 @@ export function setupGuestMouseWheelZoomForwarding(args: {
     }
     // Why: the host owns panning once emulation makes the guest viewport larger than the pane.
     event.preventDefault()
+    onViewportWheelConsumed?.(safeDeltaX, safeDeltaY)
     resolveRenderer(browserTabId)?.send('ui:scrollBrowserPage', {
       browserPageId: browserTabId,
       deltaX: safeDeltaX,

--- a/src/main/browser/browser-manager-viewport-partial-failure.test.ts
+++ b/src/main/browser/browser-manager-viewport-partial-failure.test.ts
@@ -90,6 +90,11 @@ describe('browserManager viewport partial failure', () => {
       } as Electron.MouseWheelInputEvent
     )
     expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(renderer.send).toHaveBeenCalledWith('ui:scrollBrowserPage', {
+      browserPageId: 'tab-partial-apply',
+      deltaX: 0,
+      deltaY: 120
+    })
   })
 
   it('keeps host panning available when metrics setup fails', async () => {

--- a/src/main/browser/browser-manager-viewport-partial-failure.test.ts
+++ b/src/main/browser/browser-manager-viewport-partial-failure.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  appGetPathMock: vi.fn(() => '/downloads'),
+  shellOpenExternalMock: vi.fn(),
+  browserWindowFromWebContentsMock: vi.fn(),
+  menuBuildFromTemplateMock: vi.fn(),
+  guestOffMock: vi.fn(),
+  guestOnMock: vi.fn(),
+  guestSetBackgroundThrottlingMock: vi.fn(),
+  guestSetWindowOpenHandlerMock: vi.fn(),
+  guestOpenDevToolsMock: vi.fn(),
+  webContentsFromIdMock: vi.fn(),
+  screenGetCursorScreenPointMock: vi.fn(() => ({ x: 0, y: 0 })),
+  openPopupWithOriginBarMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: mocks.appGetPathMock },
+  BrowserWindow: { fromWebContents: mocks.browserWindowFromWebContentsMock },
+  clipboard: { writeText: vi.fn() },
+  shell: { openExternal: mocks.shellOpenExternalMock },
+  Menu: { buildFromTemplate: mocks.menuBuildFromTemplateMock },
+  screen: { getCursorScreenPoint: mocks.screenGetCursorScreenPointMock },
+  webContents: { fromId: mocks.webContentsFromIdMock }
+}))
+vi.mock('./popup-origin-bar-window', () => ({
+  openPopupWithOriginBar: mocks.openPopupWithOriginBarMock
+}))
+
+import { browserManager } from './browser-manager'
+import {
+  rendererWebContentsId,
+  resetBrowserManagerMocks,
+  resetBrowserManagerState
+} from './browser-manager-test-harness'
+import { createViewportGuestFactory } from './browser-manager-viewport-test-fixtures'
+
+const makeGuest = createViewportGuestFactory(mocks)
+const OVERRIDE = { width: 375, height: 667, deviceScaleFactor: 2, mobile: true } as const
+
+describe('browserManager viewport partial failure', () => {
+  beforeEach(() => {
+    resetBrowserManagerMocks(mocks)
+    resetBrowserManagerState()
+  })
+
+  it('keeps wheel routing active when follow-up setup fails after metrics apply', async () => {
+    const { guest, debuggerSendCommand } = makeGuest(42421)
+    debuggerSendCommand.mockImplementation((method: string) =>
+      method === 'Emulation.setTouchEmulationEnabled'
+        ? Promise.reject(new Error('touch setup failed'))
+        : Promise.resolve(undefined)
+    )
+    mocks.webContentsFromIdMock.mockReturnValue(guest)
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'tab-partial-apply',
+      webContentsId: guest.id as number,
+      rendererWebContentsId
+    })
+    const renderer = { isDestroyed: vi.fn(() => false), send: vi.fn() }
+    mocks.webContentsFromIdMock.mockImplementation((id: number) =>
+      id === rendererWebContentsId ? renderer : guest
+    )
+    await expect(browserManager.setViewportOverride('tab-partial-apply', OVERRIDE)).resolves.toBe(
+      false
+    )
+    browserManager.setViewportScrollState('tab-partial-apply', rendererWebContentsId, {
+      scrollLeft: 0,
+      scrollTop: 0,
+      maxScrollLeft: 400,
+      maxScrollTop: 300
+    })
+
+    const beforeMouseEvent = mocks.guestOnMock.mock.calls.find(
+      ([event]) => event === 'before-mouse-event'
+    )?.[1] as ((event: Electron.Event, mouse: Electron.MouseInputEvent) => void) | undefined
+    expect(beforeMouseEvent).toBeDefined()
+    const preventDefault = vi.fn()
+    beforeMouseEvent?.(
+      { preventDefault } as unknown as Electron.Event,
+      {
+        type: 'mouseWheel',
+        x: 0,
+        y: 0,
+        modifiers: [],
+        deltaX: 0,
+        deltaY: 120
+      } as Electron.MouseWheelInputEvent
+    )
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/browser/browser-manager-viewport-partial-failure.test.ts
+++ b/src/main/browser/browser-manager-viewport-partial-failure.test.ts
@@ -73,7 +73,7 @@ describe('browserManager viewport partial failure', () => {
       maxScrollTop: 300
     })
 
-    const beforeMouseEvent = mocks.guestOnMock.mock.calls.find(
+    const beforeMouseEvent = mocks.guestOnMock.mock.calls.findLast(
       ([event]) => event === 'before-mouse-event'
     )?.[1] as ((event: Electron.Event, mouse: Electron.MouseInputEvent) => void) | undefined
     expect(beforeMouseEvent).toBeDefined()
@@ -90,5 +90,59 @@ describe('browserManager viewport partial failure', () => {
       } as Electron.MouseWheelInputEvent
     )
     expect(preventDefault).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps host panning available when metrics setup fails', async () => {
+    const { guest, debuggerSendCommand } = makeGuest(42422)
+    debuggerSendCommand.mockImplementation((method: string) =>
+      method === 'Emulation.setDeviceMetricsOverride'
+        ? Promise.reject(new Error('metrics setup failed'))
+        : Promise.resolve(undefined)
+    )
+    mocks.webContentsFromIdMock.mockReturnValue(guest)
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'tab-metrics-failed',
+      webContentsId: guest.id as number,
+      rendererWebContentsId
+    })
+    const renderer = { isDestroyed: vi.fn(() => false), send: vi.fn() }
+    mocks.webContentsFromIdMock.mockImplementation((id: number) =>
+      id === rendererWebContentsId ? renderer : guest
+    )
+
+    await expect(browserManager.setViewportOverride('tab-metrics-failed', OVERRIDE)).resolves.toBe(
+      false
+    )
+    browserManager.setViewportScrollState('tab-metrics-failed', rendererWebContentsId, {
+      scrollLeft: 0,
+      scrollTop: 0,
+      maxScrollLeft: 400,
+      maxScrollTop: 300
+    })
+
+    const beforeMouseEvent = mocks.guestOnMock.mock.calls.findLast(
+      ([event]) => event === 'before-mouse-event'
+    )?.[1] as ((event: Electron.Event, mouse: Electron.MouseInputEvent) => void) | undefined
+    expect(beforeMouseEvent).toBeDefined()
+    const preventDefault = vi.fn()
+    beforeMouseEvent?.(
+      { preventDefault } as unknown as Electron.Event,
+      {
+        type: 'mouseWheel',
+        x: 0,
+        y: 0,
+        modifiers: [],
+        deltaX: 0,
+        deltaY: 120
+      } as Electron.MouseWheelInputEvent
+    )
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(renderer.send).toHaveBeenCalledWith('ui:scrollBrowserPage', {
+      browserPageId: 'tab-metrics-failed',
+      deltaX: 0,
+      deltaY: 120
+    })
   })
 })

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -265,8 +265,8 @@ export class BrowserManager {
   // Why: presence means the preset requires a CDP UA override (installed or in flight), so navigation
   // can re-issue it against the target URL's identity.
   private readonly viewportUaOverrideMobileByTabId = new Map<string, boolean>()
-  // Why: host-side wheel panning is only valid while a local emulated viewport is active on
-  // the guest that owns this tab; replacement guests must not inherit a retired guest's state.
+  // Why: host-side wheel panning follows the requested local viewport on the owning guest;
+  // replacement guests must not inherit a retired guest's state.
   private readonly viewportPresetActiveByTabId = new Map<
     string,
     { guestWebContentsId: number; active: boolean }
@@ -1937,6 +1937,14 @@ export class BrowserManager {
   ): Promise<boolean> {
     // Why: chain per-tab so rapid toggles don't interleave CDP commands and the last-requested override wins.
     const expectedWebContentsId = this.webContentsIdByTabId.get(browserTabId)
+    if (expectedWebContentsId !== undefined) {
+      // Keep host panning available while CDP applies the requested dimensions. The guest id fence
+      // prevents this intent from leaking to a replacement guest; clearing the preset removes it.
+      this.viewportPresetActiveByTabId.set(browserTabId, {
+        guestWebContentsId: expectedWebContentsId,
+        active: override !== null
+      })
+    }
     // The renderer resizes the host before CDP completes; discard the old geometry until it
     // reports the new pane bounds so a pending preset cannot route wheel input using stale limits.
     this.viewportScrollStateByTabId.delete(browserTabId)

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -56,7 +56,8 @@ import type {
   BrowserCertificateFailure,
   BrowserLoadError,
   BrowserSessionUserAgentMode,
-  BrowserViewportOverride
+  BrowserViewportOverride,
+  BrowserViewportScrollState
 } from '../../shared/browser-workspace-types'
 import {
   type BrowserAnnotationViewportBridgeOptions,
@@ -264,8 +265,13 @@ export class BrowserManager {
   // Why: presence means the preset requires a CDP UA override (installed or in flight), so navigation
   // can re-issue it against the target URL's identity.
   private readonly viewportUaOverrideMobileByTabId = new Map<string, boolean>()
-  // Why: host-side wheel panning is only valid while a local emulated viewport is active.
-  private readonly viewportPresetActiveByTabId = new Map<string, boolean>()
+  // Why: host-side wheel panning is only valid while a local emulated viewport is active on
+  // the guest that owns this tab; replacement guests must not inherit a retired guest's state.
+  private readonly viewportPresetActiveByTabId = new Map<
+    string,
+    { guestWebContentsId: number; active: boolean }
+  >()
+  private readonly viewportScrollStateByTabId = new Map<string, BrowserViewportScrollState>()
   // Why: the confirmed CDP identity outranks getUserAgent; pending intent keeps rapid navigations
   // ordered without claiming a failed write was installed.
   private readonly authUserAgentOverrideStateByGuestId = new Map<
@@ -303,6 +309,36 @@ export class BrowserManager {
 
   setDictationShortcutForwardingPredicate(predicate: (() => boolean) | null): void {
     this.shouldForwardDictationShortcut = predicate
+  }
+
+  setViewportScrollState(
+    browserTabId: string,
+    rendererWebContentsId: number,
+    state: BrowserViewportScrollState
+  ): void {
+    if (this.rendererWebContentsIdByTabId.get(browserTabId) !== rendererWebContentsId) {
+      return
+    }
+    if (
+      ![state.scrollLeft, state.scrollTop, state.maxScrollLeft, state.maxScrollTop].every(
+        (value) => typeof value === 'number' && Number.isFinite(value) && value >= 0
+      )
+    ) {
+      return
+    }
+    this.viewportScrollStateByTabId.set(browserTabId, state)
+  }
+
+  recordViewportScrollDelta(browserTabId: string, deltaX: number, deltaY: number): void {
+    const state = this.viewportScrollStateByTabId.get(browserTabId)
+    if (!state) {
+      return
+    }
+    this.viewportScrollStateByTabId.set(browserTabId, {
+      ...state,
+      scrollLeft: Math.min(state.maxScrollLeft, Math.max(0, state.scrollLeft + deltaX)),
+      scrollTop: Math.min(state.maxScrollTop, Math.max(0, state.scrollTop + deltaY))
+    })
   }
 
   setBrowserGuestStateChangedListener(listener: ((worktreeId: string) => void) | null): void {
@@ -1397,6 +1433,8 @@ export class BrowserManager {
     const previousWebContentsId = this.webContentsIdByTabId.get(browserTabId)
     if (previousWebContentsId !== undefined && previousWebContentsId !== webContentsId) {
       this.retireStaleGuestWebContents(previousWebContentsId)
+      this.viewportPresetActiveByTabId.delete(browserTabId)
+      this.viewportScrollStateByTabId.delete(browserTabId)
     }
     this.webContentsIdByTabId.set(browserTabId, webContentsId)
     this.tabIdByWebContentsId.set(webContentsId, browserTabId)
@@ -1482,6 +1520,7 @@ export class BrowserManager {
     this.viewportOpsByTabId.delete(browserTabId)
     this.viewportUaOverrideMobileByTabId.delete(browserTabId)
     this.viewportPresetActiveByTabId.delete(browserTabId)
+    this.viewportScrollStateByTabId.delete(browserTabId)
     if (wcId !== undefined) {
       this.pendingNavigationByGuestId.delete(wcId)
     }
@@ -1517,6 +1556,8 @@ export class BrowserManager {
     const previousWebContentsId = this.webContentsIdByTabId.get(browserPageId)
     if (previousWebContentsId !== undefined && previousWebContentsId !== webContentsId) {
       this.retireStaleGuestWebContents(previousWebContentsId)
+      this.viewportPresetActiveByTabId.delete(browserPageId)
+      this.viewportScrollStateByTabId.delete(browserPageId)
     }
     this.webContentsIdByTabId.set(browserPageId, webContentsId)
     this.tabIdByWebContentsId.set(webContentsId, browserPageId)
@@ -1559,6 +1600,7 @@ export class BrowserManager {
     this.userAgentModeByPageId.clear()
     this.viewportUaOverrideMobileByTabId.clear()
     this.viewportPresetActiveByTabId.clear()
+    this.viewportScrollStateByTabId.clear()
     this.authUserAgentOverrideStateByGuestId.clear()
     this.pendingNavigationByGuestId.clear()
     this.pendingLoadFailuresByGuestId.clear()
@@ -1894,10 +1936,14 @@ export class BrowserManager {
     override: BrowserViewportOverride | null
   ): Promise<boolean> {
     // Why: chain per-tab so rapid toggles don't interleave CDP commands and the last-requested override wins.
+    const expectedWebContentsId = this.webContentsIdByTabId.get(browserTabId)
+    // The renderer resizes the host before CDP completes; discard the old geometry until it
+    // reports the new pane bounds so a pending preset cannot route wheel input using stale limits.
+    this.viewportScrollStateByTabId.delete(browserTabId)
     const prev = this.viewportOpsByTabId.get(browserTabId) ?? Promise.resolve()
     const next = prev
       .catch(() => {})
-      .then(() => this.doSetViewportOverrideImpl(browserTabId, override))
+      .then(() => this.doSetViewportOverrideImpl(browserTabId, override, expectedWebContentsId))
     this.viewportOpsByTabId.set(browserTabId, next)
     try {
       return await next
@@ -1962,10 +2008,11 @@ export class BrowserManager {
 
   private async doSetViewportOverrideImpl(
     browserTabId: string,
-    override: BrowserViewportOverride | null
+    override: BrowserViewportOverride | null,
+    expectedWebContentsId: number | undefined
   ): Promise<boolean> {
     const webContentsId = this.webContentsIdByTabId.get(browserTabId)
-    if (!webContentsId) {
+    if (!webContentsId || webContentsId !== expectedWebContentsId) {
       return false
     }
     const guest = webContents.fromId(webContentsId)
@@ -1998,6 +2045,12 @@ export class BrowserManager {
           deviceScaleFactor: override.deviceScaleFactor,
           mobile: override.mobile
         })
+        if (this.webContentsIdByTabId.get(browserTabId) === webContentsId) {
+          this.viewportPresetActiveByTabId.set(browserTabId, {
+            guestWebContentsId: webContentsId,
+            active: true
+          })
+        }
         await dbg.sendCommand('Emulation.setTouchEmulationEnabled', {
           enabled: override.mobile,
           maxTouchPoints: override.mobile ? 5 : 0
@@ -2011,6 +2064,12 @@ export class BrowserManager {
         }
       } else {
         await dbg.sendCommand('Emulation.clearDeviceMetricsOverride', {})
+        if (this.webContentsIdByTabId.get(browserTabId) === webContentsId) {
+          this.viewportPresetActiveByTabId.set(browserTabId, {
+            guestWebContentsId: webContentsId,
+            active: false
+          })
+        }
         await dbg.sendCommand('Emulation.setTouchEmulationEnabled', {
           enabled: false,
           maxTouchPoints: 0
@@ -2041,7 +2100,9 @@ export class BrowserManager {
           throw error
         }
       }
-      this.viewportPresetActiveByTabId.set(browserTabId, override !== null)
+      if (this.webContentsIdByTabId.get(browserTabId) !== webContentsId) {
+        return false
+      }
       return true
     } catch {
       return false
@@ -2229,8 +2290,36 @@ export class BrowserManager {
         guest,
         resolveRenderer: (tabId) =>
           resolveRendererWebContents(this.rendererWebContentsIdByTabId, tabId),
-        isViewportPresetActive: () => this.viewportPresetActiveByTabId.get(browserTabId) === true
+        isViewportPresetActive: () => {
+          const state = this.viewportPresetActiveByTabId.get(browserTabId)
+          return state?.guestWebContentsId === guest.id && state.active
+        },
+        canViewportScroll: (mouse) => this.canViewportScroll(browserTabId, mouse),
+        onViewportWheelConsumed: (deltaX, deltaY) =>
+          this.recordViewportScrollDelta(browserTabId, deltaX, deltaY)
       })
+    )
+  }
+
+  private canViewportScroll(browserTabId: string, mouse: Electron.MouseWheelInputEvent): boolean {
+    const state = this.viewportScrollStateByTabId.get(browserTabId)
+    if (!state) {
+      return false
+    }
+    const deltaX = typeof mouse.deltaX === 'number' ? mouse.deltaX : 0
+    const deltaY = typeof mouse.deltaY === 'number' ? mouse.deltaY : 0
+    const canScrollAxis = (delta: number, position: number, maximum: number): boolean => {
+      if (delta < 0) {
+        return position > 0
+      }
+      if (delta > 0) {
+        return position < maximum
+      }
+      return false
+    }
+    return (
+      canScrollAxis(deltaX, state.scrollLeft, state.maxScrollLeft) ||
+      canScrollAxis(deltaY, state.scrollTop, state.maxScrollTop)
     )
   }
 

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -264,6 +264,8 @@ export class BrowserManager {
   // Why: presence means the preset requires a CDP UA override (installed or in flight), so navigation
   // can re-issue it against the target URL's identity.
   private readonly viewportUaOverrideMobileByTabId = new Map<string, boolean>()
+  // Why: host-side wheel panning is only valid while a local emulated viewport is active.
+  private readonly viewportPresetActiveByTabId = new Map<string, boolean>()
   // Why: the confirmed CDP identity outranks getUserAgent; pending intent keeps rapid navigations
   // ordered without claiming a failed write was installed.
   private readonly authUserAgentOverrideStateByGuestId = new Map<
@@ -1479,6 +1481,7 @@ export class BrowserManager {
     // Why: drop the viewport-op chain so the Map doesn't retain a promise keyed to a destroyed guest.
     this.viewportOpsByTabId.delete(browserTabId)
     this.viewportUaOverrideMobileByTabId.delete(browserTabId)
+    this.viewportPresetActiveByTabId.delete(browserTabId)
     if (wcId !== undefined) {
       this.pendingNavigationByGuestId.delete(wcId)
     }
@@ -1555,6 +1558,7 @@ export class BrowserManager {
     this.sessionProfileIdByPageId.clear()
     this.userAgentModeByPageId.clear()
     this.viewportUaOverrideMobileByTabId.clear()
+    this.viewportPresetActiveByTabId.clear()
     this.authUserAgentOverrideStateByGuestId.clear()
     this.pendingNavigationByGuestId.clear()
     this.pendingLoadFailuresByGuestId.clear()
@@ -2037,6 +2041,7 @@ export class BrowserManager {
           throw error
         }
       }
+      this.viewportPresetActiveByTabId.set(browserTabId, override !== null)
       return true
     } catch {
       return false
@@ -2223,7 +2228,8 @@ export class BrowserManager {
         browserTabId,
         guest,
         resolveRenderer: (tabId) =>
-          resolveRendererWebContents(this.rendererWebContentsIdByTabId, tabId)
+          resolveRendererWebContents(this.rendererWebContentsIdByTabId, tabId),
+        isViewportPresetActive: () => this.viewportPresetActiveByTabId.get(browserTabId) === true
       })
     )
   }

--- a/src/main/ipc/browser-guest-view-ipc.ts
+++ b/src/main/ipc/browser-guest-view-ipc.ts
@@ -17,6 +17,7 @@ import {
 export function registerBrowserGuestViewHandlers(): void {
   ipcMain.removeHandler('browser:openDevTools')
   ipcMain.removeHandler('browser:setViewportOverride')
+  ipcMain.removeAllListeners?.('browser:reportViewportScrollState')
   ipcMain.removeHandler('browser:setAnnotationViewportBridge')
   ipcMain.removeHandler('browser:acceptDownload')
   ipcMain.removeHandler('browser:cancelDownload')
@@ -67,6 +68,36 @@ export function registerBrowserGuestViewHandlers(): void {
         }
       }
       return browserManager.setViewportOverride(args.browserPageId, args.override)
+    }
+  )
+
+  ipcMain.on?.(
+    'browser:reportViewportScrollState',
+    (
+      event,
+      args: {
+        browserPageId?: unknown
+        state?: {
+          scrollLeft?: unknown
+          scrollTop?: unknown
+          maxScrollLeft?: unknown
+          maxScrollTop?: unknown
+        }
+      }
+    ) => {
+      if (!isTrustedBrowserRenderer(event.sender) || typeof args?.browserPageId !== 'string') {
+        return
+      }
+      const state = args.state
+      if (!state) {
+        return
+      }
+      browserManager.setViewportScrollState(args.browserPageId, event.sender.id, {
+        scrollLeft: Number(state.scrollLeft),
+        scrollTop: Number(state.scrollTop),
+        maxScrollLeft: Number(state.maxScrollLeft),
+        maxScrollTop: Number(state.maxScrollTop)
+      })
     }
   )
 

--- a/src/preload/api/browser-api.ts
+++ b/src/preload/api/browser-api.ts
@@ -36,7 +36,8 @@ import type {
   BrowserSessionProfileCreateOptions,
   BrowserSessionProfileScope,
   BrowserSessionProfileSource,
-  BrowserViewportOverride
+  BrowserViewportOverride,
+  BrowserViewportScrollState
 } from '../../shared/browser-workspace-types'
 import type {
   BrowserClientPageRendererOutcome,
@@ -77,6 +78,10 @@ export type BrowserApi = {
     browserPageId: string
     override: BrowserViewportOverride | null
   }) => Promise<boolean>
+  reportViewportScrollState?: (args: {
+    browserPageId: string
+    state: BrowserViewportScrollState
+  }) => void
   setAnnotationViewportBridge: (args: BrowserSetAnnotationViewportBridgeArgs) => Promise<boolean>
   /** Publishes a client-hosted page's url/title to its runtime over that runtime's host lease. */
   publishClientPageMetadata: (args: {

--- a/src/preload/api/ui-command-event-api.ts
+++ b/src/preload/api/ui-command-event-api.ts
@@ -106,6 +106,9 @@ export type UiCommandEventApi = {
   onReloadBrowserPage: (callback: () => void) => () => void
   onBrowserHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void
   onZoomBrowserPage: (callback: (direction: 'in' | 'out' | 'reset') => void) => () => void
+  onScrollBrowserPage?: (
+    callback: (event: { browserPageId: string; deltaX: number; deltaY: number }) => void
+  ) => () => void
   onHardReloadBrowserPage: (callback: () => void) => () => void
   onCloseActiveTab: (callback: (payload?: CloseActiveTabPayload) => void) => () => void
   onCloseFloatingItem: (callback: (payload: { sourceId: string }) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2780,6 +2780,16 @@ const api = {
       override: BrowserViewportOverride | null
     }): Promise<boolean> => ipcRenderer.invoke('browser:setViewportOverride', args),
 
+    reportViewportScrollState: (args: {
+      browserPageId: string
+      state: {
+        scrollLeft: number
+        scrollTop: number
+        maxScrollLeft: number
+        maxScrollTop: number
+      }
+    }): void => ipcRenderer.send('browser:reportViewportScrollState', args),
+
     setAnnotationViewportBridge: (args): Promise<boolean> =>
       ipcRenderer.invoke('browser:setAnnotationViewportBridge', args),
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4027,6 +4027,16 @@ const api = {
       ipcRenderer.on('ui:zoomBrowserPage', listener)
       return () => ipcRenderer.removeListener('ui:zoomBrowserPage', listener)
     },
+    onScrollBrowserPage: (
+      callback: (event: { browserPageId: string; deltaX: number; deltaY: number }) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        payload: { browserPageId: string; deltaX: number; deltaY: number }
+      ) => callback(payload)
+      ipcRenderer.on('ui:scrollBrowserPage', listener)
+      return () => ipcRenderer.removeListener('ui:scrollBrowserPage', listener)
+    },
     onHardReloadBrowserPage: (callback: () => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent) => callback()
       ipcRenderer.on('ui:hardReloadBrowserPage', listener)

--- a/src/renderer/src/components/browser-pane/annotate/browser-guest-annotate-overlays.tsx
+++ b/src/renderer/src/components/browser-pane/annotate/browser-guest-annotate-overlays.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom'
 import type { MutableRefObject, RefObject } from 'react'
 import { Copy, Image } from 'lucide-react'
 import {
@@ -35,6 +36,7 @@ export function BrowserGuestAnnotateOverlays({
   annotationSend,
   grabAnnotations,
   containerRef,
+  markupPortalContainer,
   webviewRef,
   browserOverlayViewport,
   worktreeId
@@ -44,6 +46,7 @@ export function BrowserGuestAnnotateOverlays({
   annotationSend: ReturnType<typeof useBrowserPageAnnotationSend>
   grabAnnotations: ReturnType<typeof useBrowserPageGrabAnnotations>
   containerRef: RefObject<HTMLDivElement | null>
+  markupPortalContainer?: HTMLDivElement | null
   webviewRef: MutableRefObject<Electron.WebviewTag | null>
   browserOverlayViewport: BrowserOverlayViewport
   worktreeId: string
@@ -61,6 +64,7 @@ export function BrowserGuestAnnotateOverlays({
     dismissGrabToast,
     setGrabToast
   } = grabAnnotations
+  const markupTarget = markupPortalContainer ?? containerRef.current
   const {
     browserAnnotations,
     browserAnnotationTrayOpen,
@@ -78,14 +82,17 @@ export function BrowserGuestAnnotateOverlays({
 
   return (
     <>
-      {markup.isActive && markup.baseImage ? (
-        <MarkupOverlay
-          baseImage={markup.baseImage}
-          busy={markup.state === 'composing'}
-          onComplete={(input) => void markup.complete(input)}
-          onCancel={markup.cancel}
-        />
-      ) : null}
+      {markup.isActive && markup.baseImage && markupTarget
+        ? createPortal(
+            <MarkupOverlay
+              baseImage={markup.baseImage}
+              busy={markup.state === 'composing'}
+              onComplete={(input) => void markup.complete(input)}
+              onCancel={markup.cancel}
+            />,
+            markupTarget
+          )
+        : null}
       {pendingAnnotationPayload ? (
         <PendingBrowserAnnotationCard
           payload={pendingAnnotationPayload}

--- a/src/renderer/src/components/browser-pane/annotate/use-browser-page-annotation-viewport-tracking.ts
+++ b/src/renderer/src/components/browser-pane/annotate/use-browser-page-annotation-viewport-tracking.ts
@@ -1,0 +1,48 @@
+import { useEffect, type Dispatch, type SetStateAction } from 'react'
+import type { BrowserOverlayViewport } from '../describe-page/browser-annotation-geometry'
+import { subscribeBrowserPageViewportScroll } from '../host-guest/browser-page-viewport'
+
+export function useBrowserPageAnnotationViewportTracking({
+  isActive,
+  pendingAnnotation,
+  annotationCount,
+  container,
+  scroller,
+  setBrowserOverlayViewport
+}: {
+  isActive: boolean
+  pendingAnnotation: unknown
+  annotationCount: number
+  container: HTMLDivElement | null
+  scroller: HTMLDivElement | null
+  setBrowserOverlayViewport: Dispatch<SetStateAction<BrowserOverlayViewport>>
+}): void {
+  useEffect(() => {
+    if (!isActive || (!pendingAnnotation && annotationCount === 0)) {
+      return
+    }
+    let frame: number | null = null
+    const bump = (): void => {
+      if (frame !== null) {
+        return
+      }
+      frame = window.requestAnimationFrame(() => {
+        frame = null
+        setBrowserOverlayViewport((current) => ({ ...current, version: current.version + 1 }))
+      })
+    }
+    const observer =
+      typeof ResizeObserver === 'undefined' || !container ? null : new ResizeObserver(bump)
+    if (observer && container) {
+      observer.observe(container)
+    }
+    const unsubscribe = subscribeBrowserPageViewportScroll(scroller, bump)
+    return () => {
+      observer?.disconnect()
+      unsubscribe()
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame)
+      }
+    }
+  }, [annotationCount, container, isActive, pendingAnnotation, scroller, setBrowserOverlayViewport])
+}

--- a/src/renderer/src/components/browser-pane/annotate/use-browser-page-grab-annotations.ts
+++ b/src/renderer/src/components/browser-pane/annotate/use-browser-page-grab-annotations.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_BROWSER_ANNOTATION_PRIORITY,
   type BrowserOverlayViewport
 } from '../describe-page/browser-annotation-geometry'
+import { useBrowserPageAnnotationViewportTracking } from './use-browser-page-annotation-viewport-tracking'
 import { runBrowserGrabActionShortcut } from './browser-page-grab-action'
 import type { BrowserPageGrabToastState, GrabIntent } from '../describe-page/browser-page-types'
 
@@ -47,6 +48,8 @@ export function useBrowserPageGrabAnnotations({
   isActive,
   grab,
   containerRef,
+  trackingContainer,
+  trackingScroller,
   webviewRef,
   setBrowserOverlayViewport,
   browserAnnotationsLength,
@@ -63,6 +66,8 @@ export function useBrowserPageGrabAnnotations({
   isActive: boolean
   grab: GrabModeHook
   containerRef: MutableRefObject<HTMLDivElement | null>
+  trackingContainer?: HTMLDivElement | null
+  trackingScroller?: HTMLDivElement | null
   webviewRef: MutableRefObject<Electron.WebviewTag | null>
   setBrowserOverlayViewport: Dispatch<SetStateAction<BrowserOverlayViewport>>
   browserAnnotationsLength: number
@@ -179,32 +184,17 @@ export function useBrowserPageGrabAnnotations({
     showGrabToast
   ])
 
-  useEffect(() => {
-    if (!isActive || (!pendingAnnotationPayload && browserAnnotationsLength === 0)) {
-      return
-    }
-
-    const observedContainer = containerRef.current
-    const resizeObserver =
-      typeof ResizeObserver === 'undefined' || !observedContainer
-        ? null
-        : new ResizeObserver(() => {
-            setBrowserOverlayViewport((current) => ({ ...current, version: current.version + 1 }))
-          })
-    if (resizeObserver && observedContainer) {
-      resizeObserver.observe(observedContainer)
-    }
-
-    return () => {
-      resizeObserver?.disconnect()
-    }
-  }, [
-    browserAnnotationsLength,
-    containerRef,
+  useBrowserPageAnnotationViewportTracking({
     isActive,
-    pendingAnnotationPayload,
+    pendingAnnotation: pendingAnnotationPayload,
+    annotationCount: browserAnnotationsLength,
+    container: trackingContainer ?? containerRef.current,
+    scroller:
+      trackingScroller ??
+      containerRef.current?.querySelector<HTMLDivElement>('[data-browser-page-scroller]') ??
+      null,
     setBrowserOverlayViewport
-  ])
+  })
 
   const startGrabIntent = useCallback(
     (nextIntent: GrabIntent): void => {

--- a/src/renderer/src/components/browser-pane/annotate/use-browser-page-markup-capture.ts
+++ b/src/renderer/src/components/browser-pane/annotate/use-browser-page-markup-capture.ts
@@ -7,17 +7,15 @@ import {
 } from './useMarkupMode'
 
 export function useBrowserPageMarkupCapture(
-  webviewRef: MutableRefObject<Electron.WebviewTag | null>,
-  containerRef: MutableRefObject<HTMLDivElement | null>
+  webviewRef: MutableRefObject<Electron.WebviewTag | null>
 ): MarkupModeController {
   return useMarkupMode({
     getCaptureContext: useCallback((): MarkupCaptureContext | null => {
       const webview = webviewRef.current
-      const container = containerRef.current
-      if (!webview || !container) {
+      if (!webview) {
         return null
       }
-      const rect = container.getBoundingClientRect()
+      const rect = webview.getBoundingClientRect()
       if (rect.width <= 0 || rect.height <= 0) {
         return null
       }
@@ -27,7 +25,7 @@ export function useBrowserPageMarkupCapture(
         cssHeight: rect.height,
         outputScale: window.devicePixelRatio || 1
       }
-    }, [containerRef, webviewRef]),
+    }, [webviewRef]),
     onDeliver: deliverMarkupToClipboard
   })
 }

--- a/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-pane.tsx
+++ b/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-pane.tsx
@@ -8,7 +8,12 @@ import { ORCA_BROWSER_BLANK_URL } from '../../../../../shared/constants'
 import type { BrowserPage as BrowserPageState } from '../../../../../shared/browser-workspace-types'
 import { normalizeExternalBrowserUrl } from '../../../../../shared/browser-url'
 import { getLiveBrowserUrl } from '../describe-page/live-browser-url-registry'
-import { ensureBrowserPageViewport } from '../host-guest/browser-page-viewport'
+import { getBrowserViewportPreset } from '../../../../../shared/browser-viewport-presets'
+import {
+  ensureBrowserPageViewport,
+  scrollBrowserPageViewport,
+  setBrowserPageViewportPresetSize
+} from '../host-guest/browser-page-viewport'
 import { isBrowserPagePanePaintable } from '../host-guest/browser-page-paintability'
 import { getShareableBrowserArtifactFile } from '../describe-page/browser-artifact-upload'
 import { useGrabMode } from '../annotate/useGrabMode'
@@ -76,10 +81,30 @@ export function BrowserPagePane({
   })
   const pageViewport = ensureBrowserPageViewport(browserTab.id, workspaceId)
   const pageViewportContainer = pageViewport?.container ?? null
+  const pageViewportScroller = pageViewport?.scroller ?? null
   const containerRef = useRef<HTMLDivElement | null>(pageViewportContainer)
   useLayoutEffect(() => {
     containerRef.current = pageViewportContainer
   }, [pageViewportContainer])
+  useLayoutEffect(() => {
+    const preset = getBrowserViewportPreset(browserTab.viewportPresetId ?? null)
+    setBrowserPageViewportPresetSize(
+      browserTab.id,
+      preset ? { width: preset.width, height: preset.height } : null
+    )
+  }, [browserTab.id, browserTab.viewportPresetId])
+  useEffect(() => {
+    const subscribe = window.api.ui.onScrollBrowserPage
+    if (!subscribe || !pageViewportScroller || !browserTab.viewportPresetId) {
+      return
+    }
+    return subscribe((event) => {
+      if (event.browserPageId !== browserTab.id) {
+        return
+      }
+      scrollBrowserPageViewport(browserTab.id, event.deltaX, event.deltaY)
+    })
+  }, [browserTab.id, browserTab.viewportPresetId, pageViewportScroller])
   const chromeHeaderRef = useRef<HTMLDivElement | null>(null)
   const webviewRef = useRef<Electron.WebviewTag | null>(null)
   const addressBarInputRef = useRef<HTMLInputElement | null>(null)
@@ -140,12 +165,14 @@ export function BrowserPagePane({
     worktreeId
   })
   const grab = useGrabMode(browserTab.id)
-  const markup = useBrowserPageMarkupCapture(webviewRef, containerRef)
+  const markup = useBrowserPageMarkupCapture(webviewRef)
   const grabAnnotations = useBrowserPageGrabAnnotations({
     browserTabId: browserTab.id,
     isActive,
     grab,
     containerRef,
+    trackingContainer: pageViewport?.container ?? null,
+    trackingScroller: pageViewport?.scroller ?? null,
     webviewRef,
     setBrowserOverlayViewport,
     browserAnnotationsLength: annotationSend.browserAnnotations.length,
@@ -363,6 +390,7 @@ export function BrowserPagePane({
               sshRouted={Boolean(sessionPartition?.startsWith('persist:orca-browser-v1-'))}
               isBlankTab={isBlankTab}
               containerRef={containerRef}
+              markupPortalContainer={pageViewport?.content ?? null}
               browserOverlayViewport={browserOverlayViewport}
               worktreeId={worktreeId}
               grab={grab}

--- a/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-pane.tsx
+++ b/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-pane.tsx
@@ -43,6 +43,7 @@ import { useBrowserPageWebviewLifecycle } from '../host-guest/use-browser-page-w
 import { useBrowserPageWebviewPartition } from '../host-guest/use-browser-page-webview-partition'
 import { useBrowserPageWebviewUrlSync } from '../navigate/use-browser-page-webview-url-sync'
 import { useBrowserPageZoomFeedback } from '../host-guest/use-browser-page-zoom-feedback'
+import { useBrowserPageViewportScrollReporting } from '../host-guest/use-browser-page-viewport-scroll-reporting'
 
 export function BrowserPagePane({
   browserTab,
@@ -93,6 +94,7 @@ export function BrowserPagePane({
       preset ? { width: preset.width, height: preset.height } : null
     )
   }, [browserTab.id, browserTab.viewportPresetId])
+  useBrowserPageViewportScrollReporting(browserTab.id, pageViewportScroller)
   useEffect(() => {
     const subscribe = window.api.ui.onScrollBrowserPage
     if (!subscribe || !pageViewportScroller || !browserTab.viewportPresetId) {

--- a/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-pane.tsx
+++ b/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-pane.tsx
@@ -94,7 +94,11 @@ export function BrowserPagePane({
       preset ? { width: preset.width, height: preset.height } : null
     )
   }, [browserTab.id, browserTab.viewportPresetId])
-  useBrowserPageViewportScrollReporting(browserTab.id, pageViewportScroller)
+  useBrowserPageViewportScrollReporting(
+    browserTab.id,
+    pageViewportScroller,
+    browserTab.viewportPresetId ?? null
+  )
   useEffect(() => {
     const subscribe = window.api.ui.onScrollBrowserPage
     if (!subscribe || !pageViewportScroller || !browserTab.viewportPresetId) {

--- a/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-viewport-overlays.tsx
+++ b/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-viewport-overlays.tsx
@@ -39,6 +39,7 @@ export function BrowserPageViewportOverlays({
   sshRouted,
   isBlankTab,
   containerRef,
+  markupPortalContainer,
   browserOverlayViewport,
   worktreeId,
   grab,
@@ -63,6 +64,7 @@ export function BrowserPageViewportOverlays({
   sshRouted: boolean
   isBlankTab: boolean
   containerRef: RefObject<HTMLDivElement | null>
+  markupPortalContainer: HTMLDivElement | null
   browserOverlayViewport: BrowserOverlayViewport
   worktreeId: string
   grab: GrabModeHook
@@ -77,6 +79,7 @@ export function BrowserPageViewportOverlays({
         grab={grab}
         annotationSend={annotationSend}
         grabAnnotations={grabAnnotations}
+        markupPortalContainer={markupPortalContainer}
         containerRef={containerRef}
         webviewRef={webviewRef}
         browserOverlayViewport={browserOverlayViewport}

--- a/src/renderer/src/components/browser-pane/host-guest/attach-browser-page-webview.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/attach-browser-page-webview.ts
@@ -84,22 +84,28 @@ export function attachBrowserPageWebview(
     syncNavigationState
   } = args
 
-  let container = ensureBrowserPageViewport(browserTabId, workspaceId)?.container ?? null
-  if (!container) {
+  const viewport = ensureBrowserPageViewport(browserTabId, workspaceId)
+  let container = viewport?.container ?? null
+  let webviewContainer = viewport?.content ?? null
+  if (!container || !webviewContainer) {
     return
   }
 
   const ensuredWebview = ensureBrowserPageWebview({
     browserTabId,
-    container,
+    container: webviewContainer,
     inputLocked: inputLockedRef.current,
     webviewPartition,
-    resolveContainer: () => ensureBrowserPageViewport(browserTabId, workspaceId)?.container ?? null
+    resolveContainer: () => ensureBrowserPageViewport(browserTabId, workspaceId)?.content ?? null
   })
   if (!ensuredWebview) {
     return
   }
-  container = ensuredWebview.container
+  container = ensureBrowserPageViewport(browserTabId, workspaceId)?.container ?? null
+  webviewContainer = ensuredWebview.container
+  if (!container || !webviewContainer) {
+    return
+  }
   const webview = ensuredWebview.webview
   const needsInitialNavigation = ensuredWebview.created
   seedLiveBrowserUrl(browserTabId, redactKagiSessionToken(browserTabUrlRef.current))

--- a/src/renderer/src/components/browser-pane/host-guest/browser-page-viewport.test.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-page-viewport.test.ts
@@ -8,6 +8,8 @@ import {
   parkBrowserPageViewport,
   registerBrowserOverlaySlotViewport,
   removeBrowserPageViewport,
+  scrollBrowserPageViewport,
+  setBrowserPageViewportPresetSize,
   subscribeBrowserOverlaySlotViewport,
   syncBrowserPageChromeInset
 } from './browser-page-viewport'
@@ -23,6 +25,7 @@ function mountSlotViewport(workspaceTabId: string): HTMLDivElement {
 afterEach(() => {
   for (const id of ['page-1', 'page-2']) {
     removeBrowserPageViewport(id)
+    setBrowserPageViewportPresetSize(id, null)
   }
   for (const id of ['workspace-1']) {
     getBrowserOverlaySlotViewport(id)?.remove()
@@ -31,6 +34,58 @@ afterEach(() => {
 })
 
 describe('ensureBrowserPageViewport', () => {
+  it('provides a scroll surface for an oversized preset content host', () => {
+    mountSlotViewport('workspace-1')
+    const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
+
+    const scroller = viewport.container.querySelector('[data-browser-page-scroller]')
+    const content = viewport.container.querySelector('[data-browser-page-content]')
+
+    expect(scroller).not.toBeNull()
+    expect(content).not.toBeNull()
+  })
+
+  it('sizes and clears the host surface without changing responsive defaults', () => {
+    mountSlotViewport('workspace-1')
+    const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
+
+    expect(viewport.content.style.width).toBe('100%')
+    expect(viewport.content.style.height).toBe('100%')
+    expect(viewport.scroller.style.overflow).toBe('')
+
+    setBrowserPageViewportPresetSize('page-1', { width: 1440, height: 900 })
+    expect(viewport.content.style.width).toBe('1440px')
+    expect(viewport.content.style.height).toBe('900px')
+    expect(viewport.scroller.style.overflow).toBe('auto')
+
+    setBrowserPageViewportPresetSize('page-1', null)
+    expect(viewport.content.style.width).toBe('100%')
+    expect(viewport.content.style.height).toBe('100%')
+    expect(viewport.scroller.style.overflow).toBe('')
+  })
+
+  it('restores a preset after the viewport shell is rebuilt', () => {
+    mountSlotViewport('workspace-1')
+    setBrowserPageViewportPresetSize('page-1', { width: 1024, height: 768 })
+    removeBrowserPageViewport('page-1')
+
+    const rebuilt = ensureBrowserPageViewport('page-1', 'workspace-1')!
+    expect(rebuilt.content.style.width).toBe('1024px')
+    expect(rebuilt.content.style.height).toBe('768px')
+    expect(rebuilt.scroller.style.overflow).toBe('auto')
+  })
+
+  it('routes host wheel deltas to the preset scroller', () => {
+    mountSlotViewport('workspace-1')
+    const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
+    setBrowserPageViewportPresetSize('page-1', { width: 1920, height: 1080 })
+
+    scrollBrowserPageViewport('page-1', 32, 48)
+
+    expect(viewport.scroller.scrollLeft).toBe(32)
+    expect(viewport.scroller.scrollTop).toBe(48)
+  })
+
   it('creates a flex viewport with chrome inset and container under the slot root', () => {
     const root = mountSlotViewport('workspace-1')
     const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')

--- a/src/renderer/src/components/browser-pane/host-guest/browser-page-viewport.test.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-page-viewport.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   applyBrowserPageViewportLayout,
   ensureBrowserPageViewport,
+  getBrowserPageViewportScrollState,
   getBrowserOverlaySlotViewport,
   getBrowserPageViewportContainer,
   parkBrowserPageViewport,
@@ -84,6 +85,26 @@ describe('ensureBrowserPageViewport', () => {
 
     expect(viewport.scroller.scrollLeft).toBe(32)
     expect(viewport.scroller.scrollTop).toBe(48)
+  })
+
+  it('reports host scroll position and available range for wheel routing', () => {
+    mountSlotViewport('workspace-1')
+    const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
+    Object.defineProperties(viewport.scroller, {
+      scrollLeft: { configurable: true, value: 12 },
+      scrollTop: { configurable: true, value: 18 },
+      scrollWidth: { configurable: true, value: 900 },
+      scrollHeight: { configurable: true, value: 700 },
+      clientWidth: { configurable: true, value: 500 },
+      clientHeight: { configurable: true, value: 400 }
+    })
+
+    expect(getBrowserPageViewportScrollState('page-1')).toEqual({
+      scrollLeft: 12,
+      scrollTop: 18,
+      maxScrollLeft: 400,
+      maxScrollTop: 300
+    })
   })
 
   it('creates a flex viewport with chrome inset and container under the slot root', () => {

--- a/src/renderer/src/components/browser-pane/host-guest/browser-page-viewport.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-page-viewport.ts
@@ -14,6 +14,13 @@ type BrowserPageViewport = {
   content: HTMLDivElement
 }
 
+export type BrowserPageViewportScrollState = {
+  scrollLeft: number
+  scrollTop: number
+  maxScrollLeft: number
+  maxScrollTop: number
+}
+
 const browserPageViewports = new Map<string, BrowserPageViewport>()
 
 // Why: React measures the chrome only on mount, but shells are rebuilt without a
@@ -169,6 +176,21 @@ export function scrollBrowserPageViewport(
   }
   scroller.scrollLeft += deltaX
   scroller.scrollTop += deltaY
+}
+
+export function getBrowserPageViewportScrollState(
+  browserPageId: string
+): BrowserPageViewportScrollState | null {
+  const scroller = browserPageViewports.get(browserPageId)?.scroller
+  if (!scroller) {
+    return null
+  }
+  return {
+    scrollLeft: Math.max(0, scroller.scrollLeft),
+    scrollTop: Math.max(0, scroller.scrollTop),
+    maxScrollLeft: Math.max(0, scroller.scrollWidth - scroller.clientWidth),
+    maxScrollTop: Math.max(0, scroller.scrollHeight - scroller.clientHeight)
+  }
 }
 
 export function subscribeBrowserPageViewportScroll(

--- a/src/renderer/src/components/browser-pane/host-guest/browser-page-viewport.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-page-viewport.ts
@@ -10,6 +10,8 @@ type BrowserPageViewport = {
   shell: HTMLDivElement
   chromeInset: HTMLDivElement
   container: HTMLDivElement
+  scroller: HTMLDivElement
+  content: HTMLDivElement
 }
 
 const browserPageViewports = new Map<string, BrowserPageViewport>()
@@ -18,6 +20,7 @@ const browserPageViewports = new Map<string, BrowserPageViewport>()
 // re-measure (guest recovery/replacement, profile switch, slot remount). Remembering
 // the inset keeps geometry a property of attaching a guest, not of the first mount.
 const browserPageChromeInsetHeights = new Map<string, number>()
+const browserPageViewportPresetSizes = new Map<string, { width: number; height: number }>()
 
 const slotRootListeners = new Map<string, Set<() => void>>()
 
@@ -107,12 +110,76 @@ export function ensureBrowserPageViewport(
   container.dataset.browserPageContainer = ''
   container.className = 'relative flex min-h-0 flex-1 overflow-hidden bg-background'
 
+  const scroller = document.createElement('div')
+  scroller.dataset.browserPageScroller = ''
+  scroller.className = 'scrollbar-sleek relative min-h-0 min-w-0 flex-1 overflow-hidden'
+
+  const content = document.createElement('div')
+  content.dataset.browserPageContent = ''
+  content.className = 'relative mx-auto'
+
+  scroller.appendChild(content)
+  container.appendChild(scroller)
+
   shell.append(chromeInset, container)
   root.appendChild(shell)
 
-  const viewport = { shell, chromeInset, container }
+  const viewport = { shell, chromeInset, container, scroller, content }
   browserPageViewports.set(browserPageId, viewport)
+  applyViewportPresetSizeStyles(viewport, browserPageViewportPresetSizes.get(browserPageId) ?? null)
   return viewport
+}
+
+function applyViewportPresetSizeStyles(
+  viewport: BrowserPageViewport,
+  size: { width: number; height: number } | null
+): void {
+  viewport.content.style.width = size ? `${size.width}px` : '100%'
+  viewport.content.style.height = size ? `${size.height}px` : '100%'
+  viewport.scroller.style.overflow = size ? 'auto' : ''
+}
+
+export function setBrowserPageViewportPresetSize(
+  browserPageId: string,
+  size: { width: number; height: number } | null
+): void {
+  if (size) {
+    browserPageViewportPresetSizes.set(browserPageId, size)
+  } else {
+    browserPageViewportPresetSizes.delete(browserPageId)
+  }
+  const viewport = browserPageViewports.get(browserPageId)
+  if (viewport) {
+    applyViewportPresetSizeStyles(viewport, size)
+  }
+}
+
+export function clearBrowserPageViewportPresetSize(browserPageId: string): void {
+  setBrowserPageViewportPresetSize(browserPageId, null)
+}
+
+export function scrollBrowserPageViewport(
+  browserPageId: string,
+  deltaX: number,
+  deltaY: number
+): void {
+  const scroller = browserPageViewports.get(browserPageId)?.scroller
+  if (!scroller) {
+    return
+  }
+  scroller.scrollLeft += deltaX
+  scroller.scrollTop += deltaY
+}
+
+export function subscribeBrowserPageViewportScroll(
+  scroller: HTMLDivElement | null,
+  listener: () => void
+): () => void {
+  if (!scroller) {
+    return () => {}
+  }
+  scroller.addEventListener('scroll', listener, { passive: true })
+  return () => scroller.removeEventListener('scroll', listener)
 }
 
 export function removeBrowserPageViewport(browserPageId: string): void {

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-scroll-reporting.test.tsx
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-scroll-reporting.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  ensureBrowserPageViewport,
+  registerBrowserOverlaySlotViewport,
+  removeBrowserPageViewport,
+  setBrowserPageViewportPresetSize
+} from './browser-page-viewport'
+import { useBrowserPageViewportScrollReporting } from './use-browser-page-viewport-scroll-reporting'
+
+describe('useBrowserPageViewportScrollReporting', () => {
+  const reportViewportScrollState = vi.fn()
+
+  afterEach(() => {
+    cleanup()
+    reportViewportScrollState.mockReset()
+    removeBrowserPageViewport('page-1')
+    setBrowserPageViewportPresetSize('page-1', null)
+    registerBrowserOverlaySlotViewport('workspace-1', null)
+    vi.unstubAllGlobals()
+  })
+
+  it('reports again when the preset changes and host scroll bounds are rebuilt', () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    registerBrowserOverlaySlotViewport('workspace-1', root)
+    const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
+    Object.defineProperties(viewport.scroller, {
+      scrollWidth: { configurable: true, value: 1440 },
+      scrollHeight: { configurable: true, value: 900 },
+      clientWidth: { configurable: true, value: 600 },
+      clientHeight: { configurable: true, value: 500 }
+    })
+    vi.stubGlobal('window', {
+      api: { browser: { reportViewportScrollState } }
+    })
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    const hook = renderHook(
+      ({ presetId }: { presetId: string | null }) =>
+        useBrowserPageViewportScrollReporting('page-1', viewport.scroller, presetId),
+      { initialProps: { presetId: null as string | null } }
+    )
+
+    expect(reportViewportScrollState).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      setBrowserPageViewportPresetSize('page-1', { width: 1440, height: 900 })
+      hook.rerender({ presetId: 'laptop-l' })
+    })
+
+    expect(reportViewportScrollState).toHaveBeenCalledTimes(2)
+    expect(reportViewportScrollState).toHaveBeenLastCalledWith({
+      browserPageId: 'page-1',
+      state: {
+        scrollLeft: 0,
+        scrollTop: 0,
+        maxScrollLeft: 840,
+        maxScrollTop: 400
+      }
+    })
+  })
+})

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-scroll-reporting.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-scroll-reporting.ts
@@ -6,7 +6,8 @@ import {
 
 export function useBrowserPageViewportScrollReporting(
   browserPageId: string,
-  scroller: HTMLDivElement | null
+  scroller: HTMLDivElement | null,
+  viewportPresetId: string | null
 ): void {
   useEffect(() => {
     let reportFrame: number | null = null
@@ -45,5 +46,5 @@ export function useBrowserPageViewportScrollReporting(
         cancelAnimationFrame(reportFrame)
       }
     }
-  }, [browserPageId, scroller])
+  }, [browserPageId, scroller, viewportPresetId])
 }

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-scroll-reporting.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-viewport-scroll-reporting.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react'
+import {
+  getBrowserPageViewportScrollState,
+  type BrowserPageViewportScrollState
+} from './browser-page-viewport'
+
+export function useBrowserPageViewportScrollReporting(
+  browserPageId: string,
+  scroller: HTMLDivElement | null
+): void {
+  useEffect(() => {
+    let reportFrame: number | null = null
+    const send = (): void => {
+      reportFrame = null
+      const state: BrowserPageViewportScrollState | null =
+        getBrowserPageViewportScrollState(browserPageId)
+      if (state) {
+        window.api.browser.reportViewportScrollState?.({ browserPageId, state })
+      }
+    }
+    const report = (): void => {
+      if (typeof requestAnimationFrame === 'undefined') {
+        send()
+        return
+      }
+      if (reportFrame === null) {
+        reportFrame = requestAnimationFrame(send)
+      }
+    }
+    report()
+    if (!scroller) {
+      return () => {
+        if (reportFrame !== null && typeof cancelAnimationFrame !== 'undefined') {
+          cancelAnimationFrame(reportFrame)
+        }
+      }
+    }
+    scroller.addEventListener('scroll', report, { passive: true })
+    const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(report)
+    resizeObserver?.observe(scroller)
+    return () => {
+      scroller.removeEventListener('scroll', report)
+      resizeObserver?.disconnect()
+      if (reportFrame !== null && typeof cancelAnimationFrame !== 'undefined') {
+        cancelAnimationFrame(reportFrame)
+      }
+    }
+  }, [browserPageId, scroller])
+}

--- a/src/renderer/src/components/browser-pane/host-guest/webview-registry.test.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/webview-registry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const viewportMocks = vi.hoisted(() => ({
+  clearBrowserPageViewportPresetSize: vi.fn(),
   removeBrowserPageViewport: vi.fn()
 }))
 
@@ -33,6 +34,7 @@ describe('webview registry drag listeners', () => {
     removedListeners = []
     unregisterGuestMock = vi.fn()
     viewportMocks.removeBrowserPageViewport.mockReset()
+    viewportMocks.clearBrowserPageViewportPresetSize.mockReset()
 
     vi.stubGlobal('window', {
       addEventListener: vi.fn(
@@ -219,6 +221,7 @@ describe('webview registry drag listeners', () => {
     registerPersistentWebview('page-1', createWebview())
     await destroyPersistentWebview('page-1')
     expect(getExplicitBrowserPageZoomLevel('page-1')).toBeNull()
+    expect(viewportMocks.clearBrowserPageViewportPresetSize).toHaveBeenCalledWith('page-1')
     expect(viewportMocks.removeBrowserPageViewport).toHaveBeenCalledWith('page-1')
   })
 

--- a/src/renderer/src/components/browser-pane/host-guest/webview-registry.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/webview-registry.ts
@@ -1,5 +1,8 @@
 import { clearLiveBrowserUrl } from '../describe-page/live-browser-url-registry'
-import { removeBrowserPageViewport } from './browser-page-viewport'
+import {
+  clearBrowserPageViewportPresetSize,
+  removeBrowserPageViewport
+} from './browser-page-viewport'
 import { forgetExplicitBrowserPageZoomLevel } from './browser-page-zoom'
 import {
   acquireWebviewsDragPassthrough,
@@ -250,6 +253,7 @@ function removePersistentWebview(
     // Why: the viewport can outlive a missing webview entry; tear it down on
     // explicit close paths so overlay slots do not leak parked shells.
     if (!preserveViewport) {
+      clearBrowserPageViewportPresetSize(browserTabId)
       removeBrowserPageViewport(browserTabId)
     }
     registeredWebContentsIds.delete(browserTabId)
@@ -263,6 +267,7 @@ function removePersistentWebview(
   webview.remove()
   unregisterPersistentWebview(browserTabId)
   if (!preserveViewport) {
+    clearBrowserPageViewportPresetSize(browserTabId)
     removeBrowserPageViewport(browserTabId)
   }
   registeredWebContentsIds.delete(browserTabId)

--- a/src/renderer/src/components/browser-pane/workspace-doc/use-doc-preview-guest-tools.ts
+++ b/src/renderer/src/components/browser-pane/workspace-doc/use-doc-preview-guest-tools.ts
@@ -50,7 +50,7 @@ export function useDocPreviewGuestTools({
 
   const grabElementShortcut = useShortcutLabel('browser.grabElement')
   const grab = useGrabMode(toolTargetId)
-  const markup = useBrowserPageMarkupCapture(webviewRef, containerRef)
+  const markup = useBrowserPageMarkupCapture(webviewRef)
   const annotationSend = useBrowserPageAnnotationSend({ browserTabId: previewId, worktreeId })
   const grabAnnotations = useBrowserPageGrabAnnotations({
     browserTabId: previewId,

--- a/src/renderer/src/web/preload-api/web-browser-api.ts
+++ b/src/renderer/src/web/preload-api/web-browser-api.ts
@@ -10,6 +10,7 @@ export function createBrowserApi(): NonNullable<Partial<PreloadApi>['browser']> 
     unregisterGuest: () => Promise.resolve(),
     openDevTools: () => Promise.resolve(false),
     setViewportOverride: () => Promise.resolve(false),
+    reportViewportScrollState: () => {},
     setAnnotationViewportBridge: () => Promise.resolve(false),
     // A web client never hosts pages, so it has no lease to publish over.
     publishClientPageMetadata: () => Promise.resolve({ status: 'refused' as const }),

--- a/src/shared/browser-workspace-types.ts
+++ b/src/shared/browser-workspace-types.ts
@@ -52,6 +52,13 @@ export type BrowserViewportOverride = {
   mobile: boolean
 }
 
+export type BrowserViewportScrollState = {
+  scrollLeft: number
+  scrollTop: number
+  maxScrollLeft: number
+  maxScrollTop: number
+}
+
 /**
  * A page that shows a workspace document rather than a URL. The document is the identity: the grant
  * and the `orca-preview://` URL it is served over are minted when the page mounts and replaced on a


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​392 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​392 |
| Prod | 19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​490 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​59 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​431 |

<!-- /orca-pr-loc -->

## Summary
- Fixes #13293 for local managed browser pages.
- Keeps the pane as the pinned surface and mounts preset-sized content inside a host scroller.
- Forwards wheel deltas from focused Electron webviews to that host scroller only while a preset is active.
- Preserves pane-pinned overlays, annotation alignment, recovery, responsive mode, and explicit-close cleanup.

## Validation
- Red structural oracle failed on origin/main because no host scroller existed.
- Focused Vitest: 74 tests passed across viewport, webview-registry, and guest-wheel suites.
- `pnpm tc:web` passed.
- Changed-code quality gate passed (oxlint, type-aware lint, React Doctor).
- Electron CDP: Laptop L produced a 1440px content host in a 518px pane; real mouse wheel moved host `scrollLeft` from 0 to 240.

Remote streamed and client-hosted browser paths do not expose the Viewport Size menu, so no remote wire change is included.
