### PR TITLE
feat(appearance): window background image texture layer (#7714)

### DIFF
--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -18,6 +18,7 @@ import { applyBrowserSessionProxies } from '../browser/browser-session-proxy'
 import { browserSessionRegistry } from '../browser/browser-session-registry'
 import { normalizeProxyBypassRules, normalizeProxyUrl } from '../../shared/network-proxy'
 import { normalizeAppIconId } from '../../shared/app-icon'
+import { sanitizeAppBackgroundImageSettingsUpdate } from '../../shared/app-background-image'
 import { normalizeUiLanguage } from '../../shared/ui-language'
 import { applyAppIcon } from '../app-icon'
 import { normalizeTerminalCustomThemes } from '../../shared/terminal-custom-themes'
@@ -160,6 +161,7 @@ export function registerSettingsHandlers(
     if ('appIcon' in args) {
       sanitizedArgs.appIcon = normalizeAppIconId(args.appIcon)
     }
+    Object.assign(sanitizedArgs, sanitizeAppBackgroundImageSettingsUpdate(args))
     if ('terminalCustomThemes' in args) {
       sanitizedArgs.terminalCustomThemes = normalizeTerminalCustomThemes(args.terminalCustomThemes)
     }

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -309,6 +309,9 @@ export function registerShellHandlers(store: Store): void {
       }
 
       const buffer = await readFile(filePath)
+      if (buffer.length > MAX_APP_BACKGROUND_IMAGE_UPLOAD_BYTES) {
+        throw new Error('Background image must be 4MB or smaller.')
+      }
       return {
         dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
         fileName: basename(filePath)

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -8,6 +8,10 @@ import type {
   ShellOpenLocalPathResult
 } from '../../shared/shell-open-types'
 import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
+import {
+  APP_BACKGROUND_IMAGE_MIME_TYPES,
+  MAX_APP_BACKGROUND_IMAGE_UPLOAD_BYTES
+} from '../../shared/app-background-image'
 import type { Store } from '../persistence'
 import {
   EXTERNAL_EDITOR_CLI_COMMAND,
@@ -272,6 +276,36 @@ export function registerShellHandlers(store: Store): void {
       const stats = await stat(filePath)
       if (stats.size > MAX_REPO_ICON_UPLOAD_BYTES) {
         throw new Error('Repo icon image must be 256KB or smaller.')
+      }
+
+      const buffer = await readFile(filePath)
+      return {
+        dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
+        fileName: basename(filePath)
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'shell:pickAppBackgroundImage',
+    async (): Promise<{ dataUrl: string; fileName: string } | null> => {
+      const result = await dialog.showOpenDialog({
+        properties: ['openFile'],
+        filters: [{ name: 'Background images', extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif'] }]
+      })
+      if (result.canceled || result.filePaths.length === 0) {
+        return null
+      }
+
+      const filePath = result.filePaths[0]
+      const mimeType = APP_BACKGROUND_IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
+      if (!mimeType) {
+        throw new Error('Background images must be PNG, JPEG, WebP, or GIF files.')
+      }
+
+      const stats = await stat(filePath)
+      if (stats.size > MAX_APP_BACKGROUND_IMAGE_UPLOAD_BYTES) {
+        throw new Error('Background image must be 4MB or smaller.')
       }
 
       const buffer = await readFile(filePath)

--- a/src/preload/api/shell-api.ts
+++ b/src/preload/api/shell-api.ts
@@ -26,6 +26,10 @@ export type ShellApi = {
     dataUrl: string
     fileName: string
   } | null>
+  pickAppBackgroundImage: () => Promise<{
+    dataUrl: string
+    fileName: string
+  } | null>
   pickAudio: () => Promise<string | null>
   pickDirectory: (args: { defaultPath?: string }) => Promise<string | null>
   copyFile: (args: { srcPath: string; destPath: string }) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2640,6 +2640,9 @@ const api = {
     pickRepoIconImage: (): Promise<{ dataUrl: string; fileName: string } | null> =>
       ipcRenderer.invoke('shell:pickRepoIconImage'),
 
+    pickAppBackgroundImage: (): Promise<{ dataUrl: string; fileName: string } | null> =>
+      ipcRenderer.invoke('shell:pickAppBackgroundImage'),
+
     pickAudio: (): Promise<string | null> => ipcRenderer.invoke('shell:pickAudio'),
 
     pickDirectory: (args: { defaultPath?: string }): Promise<string | null> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import PinnedTabCloseDialog from './components/terminal-pane/PinnedTabCloseDialo
 import RunningTerminalCloseDialog from './components/terminal-pane/RunningTerminalCloseDialog'
 import WorktreeBaseFallbackDialog from './components/WorktreeBaseFallbackDialog'
 import { useUnreadDockBadge } from './hooks/useUnreadDockBadge'
+import { AppBackgroundImageLayer } from './app-shell/AppBackgroundImageLayer'
 import { AppBackgroundServices } from './app-shell/AppBackgroundServices'
 import { AppRootSurfaces } from './app-shell/AppRootSurfaces'
 import { AppWorkspaceShell } from './app-shell/AppWorkspaceShell'
@@ -108,6 +109,7 @@ function App(): React.JSX.Element {
       <WorktreeBaseFallbackDialog />
       <PinnedTabCloseDialog />
       <RunningTerminalCloseDialog />
+      <AppBackgroundImageLayer />
       {/* Why: Electron's drag-region hit-test is DOM-order-based (ignores z-index); render last so WindowControls stay clickable. */}
       {hasCustomTitleBar && <WindowControls />}
     </div>

--- a/src/renderer/src/app-shell/AppBackgroundImageLayer.tsx
+++ b/src/renderer/src/app-shell/AppBackgroundImageLayer.tsx
@@ -1,0 +1,21 @@
+import type React from 'react'
+import { resolveAppBackgroundImageStyle } from '@/lib/app-background-image-style'
+import { useAppStore } from '../store'
+
+/** Fixed texture layer over the whole window; inert for pointer, focus, and a11y.
+ *  Drawn above surfaces (not behind) because Orca surfaces are opaque — a
+ *  low-opacity wash is what makes the image visible without token surgery. */
+export function AppBackgroundImageLayer(): React.JSX.Element | null {
+  const appBackgroundImage = useAppStore((s) => s.settings?.appBackgroundImage)
+  const appBackgroundImageOpacity = useAppStore((s) => s.settings?.appBackgroundImageOpacity)
+  const appBackgroundImageFit = useAppStore((s) => s.settings?.appBackgroundImageFit)
+  const style = resolveAppBackgroundImageStyle({
+    appBackgroundImage,
+    appBackgroundImageOpacity,
+    appBackgroundImageFit
+  })
+  if (!style) {
+    return null
+  }
+  return <div aria-hidden className="pointer-events-none fixed inset-0 z-[130]" style={style} />
+}

--- a/src/renderer/src/components/settings/AppBackgroundImageSetting.tsx
+++ b/src/renderer/src/components/settings/AppBackgroundImageSetting.tsx
@@ -1,0 +1,152 @@
+import type React from 'react'
+import { toast } from 'sonner'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import {
+  DEFAULT_APP_BACKGROUND_IMAGE_FIT,
+  DEFAULT_APP_BACKGROUND_IMAGE_OPACITY,
+  MAX_APP_BACKGROUND_IMAGE_OPACITY,
+  type AppBackgroundImageFit
+} from '../../../../shared/app-background-image'
+import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
+import { NumberField, SettingsRow, SettingsSegmentedControl } from './SettingsFormControls'
+
+type AppBackgroundImageSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function AppBackgroundImageSetting({
+  settings,
+  updateSettings
+}: AppBackgroundImageSettingProps): React.JSX.Element {
+  const hasImage = Boolean(settings.appBackgroundImage)
+
+  const handlePickImage = async (): Promise<void> => {
+    try {
+      const result = await window.api.shell.pickAppBackgroundImage()
+      if (!result) {
+        return
+      }
+      updateSettings({ appBackgroundImage: result.dataUrl })
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : translate(
+              'auto.components.settings.AppBackgroundImageSetting.pickFailed',
+              'Could not load that image.'
+            )
+      )
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <SettingsRow
+        alignTop
+        label={translate(
+          'auto.components.settings.AppBackgroundImageSetting.title',
+          'Window Background Image'
+        )}
+        description={translate(
+          'auto.components.settings.AppBackgroundImageSetting.rowDescription',
+          'Draw an image as a subtle texture across the whole window.'
+        )}
+        control={
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={handlePickImage}>
+              {hasImage
+                ? translate(
+                    'auto.components.settings.AppBackgroundImageSetting.replaceImage',
+                    'Replace Image…'
+                  )
+                : translate(
+                    'auto.components.settings.AppBackgroundImageSetting.chooseImage',
+                    'Choose Image…'
+                  )}
+            </Button>
+            {hasImage ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => updateSettings({ appBackgroundImage: undefined })}
+              >
+                {translate('auto.components.settings.AppBackgroundImageSetting.remove', 'Remove')}
+              </Button>
+            ) : null}
+          </div>
+        }
+      />
+      {hasImage ? (
+        <div className="space-y-2">
+          <NumberField
+            label={translate(
+              'auto.components.settings.AppBackgroundImageSetting.opacity',
+              'Texture Strength'
+            )}
+            description={translate(
+              'auto.components.settings.AppBackgroundImageSetting.opacityDescription',
+              'Controls how visible the image is over the window.'
+            )}
+            value={settings.appBackgroundImageOpacity ?? DEFAULT_APP_BACKGROUND_IMAGE_OPACITY}
+            defaultValue={DEFAULT_APP_BACKGROUND_IMAGE_OPACITY}
+            min={0}
+            max={MAX_APP_BACKGROUND_IMAGE_OPACITY}
+            step={0.01}
+            suffix={`0 to ${MAX_APP_BACKGROUND_IMAGE_OPACITY}`}
+            onChange={(appBackgroundImageOpacity) => updateSettings({ appBackgroundImageOpacity })}
+          />
+          <SettingsRow
+            label={translate('auto.components.settings.AppBackgroundImageSetting.fit', 'Image Fit')}
+            description={translate(
+              'auto.components.settings.AppBackgroundImageSetting.fitDescription',
+              'How the image is scaled to the window.'
+            )}
+            control={
+              <SettingsSegmentedControl<AppBackgroundImageFit>
+                size="sm"
+                value={settings.appBackgroundImageFit ?? DEFAULT_APP_BACKGROUND_IMAGE_FIT}
+                onChange={(appBackgroundImageFit) => updateSettings({ appBackgroundImageFit })}
+                ariaLabel={translate(
+                  'auto.components.settings.AppBackgroundImageSetting.fit',
+                  'Image Fit'
+                )}
+                options={[
+                  {
+                    value: 'cover',
+                    label: translate(
+                      'auto.components.settings.AppBackgroundImageSetting.fitCover',
+                      'Cover'
+                    )
+                  },
+                  {
+                    value: 'contain',
+                    label: translate(
+                      'auto.components.settings.AppBackgroundImageSetting.fitContain',
+                      'Contain'
+                    )
+                  },
+                  {
+                    value: 'stretch',
+                    label: translate(
+                      'auto.components.settings.AppBackgroundImageSetting.fitStretch',
+                      'Stretch'
+                    )
+                  },
+                  {
+                    value: 'center',
+                    label: translate(
+                      'auto.components.settings.AppBackgroundImageSetting.fitCenter',
+                      'Center'
+                    )
+                  }
+                ]}
+              />
+            }
+          />
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -15,6 +15,7 @@ import {
   getAppIconEntries,
   getAppearancePaneSearchEntries,
   getLanguageEntries,
+  getAppBackgroundImageEntry,
   getLayoutEntries,
   getMenuBarIconEntries,
   getSidebarEntries,
@@ -157,6 +158,7 @@ export function AppearancePane({
     ...getStatusBarEntries(),
     ...getSidebarEntries(),
     ...getLayoutEntries(),
+    getAppBackgroundImageEntry(),
     getLeftSidebarAppearanceEntry(),
     getWorkspaceCardLayoutEntry()
   ]

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -14,12 +14,14 @@ import {
 } from './SettingsFormControls'
 import { useAvailableStatusBarToggles } from '../status-bar/use-available-status-bar-toggles'
 import {
+  getAppBackgroundImageEntry,
   getLayoutEntries,
   getSidebarEntries,
   getStatusBarToggles,
   getUsagePercentageDisplayEntry
 } from './appearance-search'
 import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from './appearance-usage-percentage-search'
+import { AppBackgroundImageSetting } from './AppBackgroundImageSetting'
 import { LeftSidebarAppearanceSetting } from './LeftSidebarAppearanceSetting'
 import {
   getLeftSidebarAppearanceEntry,
@@ -75,6 +77,7 @@ export function AppearanceWindowSidebarSection({
   const visibleStatusBarToggles = useAvailableStatusBarToggles(getStatusBarToggles())
   const usagePercentageDisplayEntry = getUsagePercentageDisplayEntry()
   const leftSidebarAppearanceEntry = getLeftSidebarAppearanceEntry()
+  const appBackgroundImageEntry = getAppBackgroundImageEntry()
   const sidebarEntries = getSidebarEntries()
   const workspaceCardLayoutEntry = getWorkspaceCardLayoutEntry()
   const layoutEntries = getLayoutEntries()
@@ -122,6 +125,16 @@ export function AppearanceWindowSidebarSection({
           forceVisible={forceVisiblePrimary}
         >
           <LeftSidebarAppearanceSetting settings={settings} updateSettings={updateSettings} />
+        </SearchableSetting>
+
+        <SearchableSetting
+          title={appBackgroundImageEntry.title}
+          description={appBackgroundImageEntry.description}
+          keywords={appBackgroundImageEntry.keywords}
+          className="space-y-2"
+          forceVisible={forceVisiblePrimary}
+        >
+          <AppBackgroundImageSetting settings={settings} updateSettings={updateSettings} />
         </SearchableSetting>
 
         <SearchableSetting

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -16,6 +16,35 @@ export {
   getUsagePercentageDisplayEntry
 }
 
+export const getAppBackgroundImageEntry = createLocalizedCatalog((): SettingsSearchEntry => ({
+  title: translate(
+    'auto.components.settings.appearance.search.appBackgroundImage.title',
+    'Window Background Image'
+  ),
+  description: translate(
+    'auto.components.settings.appearance.search.appBackgroundImage.description',
+    'Draw an image as a subtle texture across the whole window.'
+  ),
+  keywords: [
+    ...translateSearchKeyword(
+      'auto.components.settings.appearance.search.appBackgroundImage.background',
+      'background'
+    ),
+    ...translateSearchKeyword(
+      'auto.components.settings.appearance.search.appBackgroundImage.image',
+      'image'
+    ),
+    ...translateSearchKeyword(
+      'auto.components.settings.appearance.search.appBackgroundImage.wallpaper',
+      'wallpaper'
+    ),
+    ...translateSearchKeyword(
+      'auto.components.settings.appearance.search.appBackgroundImage.texture',
+      'texture'
+    )
+  ]
+}))
+
 export const getThemeEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   {
     title: translate('auto.components.settings.appearance.search.71e06350b4', 'Theme'),
@@ -240,6 +269,7 @@ function buildAppearancePaneSearchEntries(
     ...getTitlebarEntries(),
     ...getStatusBarEntries(),
     ...getSidebarEntries(),
+    getAppBackgroundImageEntry(),
     ...getAppIconEntries(),
     ...getSystemTrayEntries(options),
     ...getMenuBarIconEntries(options)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8963,7 +8963,11 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Usage percentages",
-            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining."
+            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining.",
+            "appBackgroundImage": {
+              "title": "Window Background Image",
+              "description": "Draw an image as a subtle texture across the whole window."
+            }
           }
         },
         "auto": {
@@ -11522,6 +11526,22 @@
         },
         "NativeChatSupportedAgents": {
           "label": "Supported agents:"
+        },
+        "AppBackgroundImageSetting": {
+          "pickFailed": "Could not load that image.",
+          "title": "Window Background Image",
+          "rowDescription": "Draw an image as a subtle texture across the whole window.",
+          "replaceImage": "Replace Image…",
+          "chooseImage": "Choose Image…",
+          "remove": "Remove",
+          "opacity": "Texture Strength",
+          "opacityDescription": "Controls how visible the image is over the window.",
+          "fit": "Image Fit",
+          "fitDescription": "How the image is scaled to the window.",
+          "fitCover": "Cover",
+          "fitContain": "Contain",
+          "fitStretch": "Stretch",
+          "fitCenter": "Center"
         }
       },
       "right": {

--- a/src/renderer/src/lib/app-background-image-style.test.ts
+++ b/src/renderer/src/lib/app-background-image-style.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { resolveAppBackgroundImageStyle } from './app-background-image-style'
+import {
+  DEFAULT_APP_BACKGROUND_IMAGE_OPACITY,
+  MAX_APP_BACKGROUND_IMAGE_OPACITY
+} from '../../../shared/app-background-image'
+
+const PNG_DATA_URL = 'data:image/png;base64,iVBORw0KGgo='
+
+describe('resolveAppBackgroundImageStyle', () => {
+  it('returns undefined without a configured image', () => {
+    expect(resolveAppBackgroundImageStyle(undefined)).toBeUndefined()
+    expect(resolveAppBackgroundImageStyle({})).toBeUndefined()
+    expect(resolveAppBackgroundImageStyle({ appBackgroundImage: 'not-a-data-url' })).toBeUndefined()
+  })
+
+  it('builds a style from the image with defaults applied', () => {
+    expect(resolveAppBackgroundImageStyle({ appBackgroundImage: PNG_DATA_URL })).toEqual({
+      backgroundImage: `url("${PNG_DATA_URL}")`,
+      backgroundSize: 'cover',
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+      opacity: DEFAULT_APP_BACKGROUND_IMAGE_OPACITY
+    })
+  })
+
+  it('maps each fit to its background-size', () => {
+    const sizeFor = (
+      fit: 'cover' | 'contain' | 'stretch' | 'center'
+    ): string | number | undefined =>
+      resolveAppBackgroundImageStyle({
+        appBackgroundImage: PNG_DATA_URL,
+        appBackgroundImageFit: fit
+      })?.backgroundSize
+    expect(sizeFor('cover')).toBe('cover')
+    expect(sizeFor('contain')).toBe('contain')
+    expect(sizeFor('stretch')).toBe('100% 100%')
+    expect(sizeFor('center')).toBe('auto')
+  })
+
+  it('clamps opacity so the UI stays readable', () => {
+    expect(
+      resolveAppBackgroundImageStyle({
+        appBackgroundImage: PNG_DATA_URL,
+        appBackgroundImageOpacity: 5
+      })?.opacity
+    ).toBe(MAX_APP_BACKGROUND_IMAGE_OPACITY)
+  })
+})

--- a/src/renderer/src/lib/app-background-image-style.ts
+++ b/src/renderer/src/lib/app-background-image-style.ts
@@ -1,0 +1,38 @@
+import type { CSSProperties } from 'react'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import {
+  normalizeAppBackgroundImage,
+  normalizeAppBackgroundImageFit,
+  normalizeAppBackgroundImageOpacity,
+  type AppBackgroundImageFit
+} from '../../../shared/app-background-image'
+
+type AppBackgroundImageSettings = Pick<
+  GlobalSettings,
+  'appBackgroundImage' | 'appBackgroundImageOpacity' | 'appBackgroundImageFit'
+>
+
+const FIT_BACKGROUND_SIZE: Record<AppBackgroundImageFit, string> = {
+  cover: 'cover',
+  contain: 'contain',
+  stretch: '100% 100%',
+  center: 'auto'
+}
+
+/** Undefined (render nothing) unless a valid background image is configured. */
+export function resolveAppBackgroundImageStyle(
+  settings: AppBackgroundImageSettings | null | undefined
+): CSSProperties | undefined {
+  const image = normalizeAppBackgroundImage(settings?.appBackgroundImage)
+  if (!image) {
+    return undefined
+  }
+  const fit = normalizeAppBackgroundImageFit(settings?.appBackgroundImageFit)
+  return {
+    backgroundImage: `url("${image}")`,
+    backgroundSize: FIT_BACKGROUND_SIZE[fit],
+    backgroundPosition: 'center',
+    backgroundRepeat: 'no-repeat',
+    opacity: normalizeAppBackgroundImageOpacity(settings?.appBackgroundImageOpacity)
+  }
+}

--- a/src/renderer/src/web/preload-api/web-shell-api.ts
+++ b/src/renderer/src/web/preload-api/web-shell-api.ts
@@ -23,6 +23,7 @@ export function createShellApi(): NonNullable<Partial<PreloadApi>['shell']> {
     pickAttachment: () => Promise.resolve(null),
     pickImage: () => Promise.resolve(null),
     pickRepoIconImage: () => Promise.resolve(null),
+    pickAppBackgroundImage: () => Promise.resolve(null),
     pickAudio: () => Promise.resolve(null),
     pickDirectory: () => Promise.resolve(null),
     copyFile: () => Promise.resolve()

--- a/src/shared/app-background-image.test.ts
+++ b/src/shared/app-background-image.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  sanitizeAppBackgroundImageSettingsUpdate,
+  DEFAULT_APP_BACKGROUND_IMAGE_FIT,
+  DEFAULT_APP_BACKGROUND_IMAGE_OPACITY,
+  MAX_APP_BACKGROUND_IMAGE_OPACITY,
+  normalizeAppBackgroundImage,
+  normalizeAppBackgroundImageFit,
+  normalizeAppBackgroundImageOpacity
+} from './app-background-image'
+
+const PNG_DATA_URL = 'data:image/png;base64,iVBORw0KGgo='
+
+describe('normalizeAppBackgroundImage', () => {
+  it('accepts an inline image data URL', () => {
+    expect(normalizeAppBackgroundImage(PNG_DATA_URL)).toBe(PNG_DATA_URL)
+    expect(normalizeAppBackgroundImage('data:image/jpeg;base64,/9j/4AAQ')).toBe(
+      'data:image/jpeg;base64,/9j/4AAQ'
+    )
+  })
+
+  it('rejects non-strings and empty values', () => {
+    expect(normalizeAppBackgroundImage(undefined)).toBeUndefined()
+    expect(normalizeAppBackgroundImage(null)).toBeUndefined()
+    expect(normalizeAppBackgroundImage(42)).toBeUndefined()
+    expect(normalizeAppBackgroundImage('')).toBeUndefined()
+  })
+
+  it('rejects non-image and non-data URLs', () => {
+    expect(normalizeAppBackgroundImage('https://example.com/bg.png')).toBeUndefined()
+    expect(normalizeAppBackgroundImage('data:text/html;base64,PGI+')).toBeUndefined()
+    expect(normalizeAppBackgroundImage('data:image/svg+xml;base64,PHN2Zz4=')).toBeUndefined()
+    expect(normalizeAppBackgroundImage('file:///tmp/bg.png')).toBeUndefined()
+  })
+
+  it('rejects data URLs with non-base64 payload characters', () => {
+    expect(normalizeAppBackgroundImage('data:image/png;base64,abc"onerror="x')).toBeUndefined()
+  })
+
+  it('rejects a payload over the size cap', () => {
+    const oversized = `data:image/png;base64,${'A'.repeat(6 * 1024 * 1024)}`
+    expect(normalizeAppBackgroundImage(oversized)).toBeUndefined()
+  })
+})
+
+describe('normalizeAppBackgroundImageOpacity', () => {
+  it('clamps into the visible-but-readable range', () => {
+    expect(normalizeAppBackgroundImageOpacity(-1)).toBe(0)
+    expect(normalizeAppBackgroundImageOpacity(0.2)).toBe(0.2)
+    expect(normalizeAppBackgroundImageOpacity(1)).toBe(MAX_APP_BACKGROUND_IMAGE_OPACITY)
+  })
+
+  it('falls back to the default for non-numbers', () => {
+    expect(normalizeAppBackgroundImageOpacity(undefined)).toBe(DEFAULT_APP_BACKGROUND_IMAGE_OPACITY)
+    expect(normalizeAppBackgroundImageOpacity(Number.NaN)).toBe(
+      DEFAULT_APP_BACKGROUND_IMAGE_OPACITY
+    )
+    expect(normalizeAppBackgroundImageOpacity('0.5')).toBe(DEFAULT_APP_BACKGROUND_IMAGE_OPACITY)
+  })
+})
+
+describe('normalizeAppBackgroundImageFit', () => {
+  it('keeps known fits and defaults the rest', () => {
+    expect(normalizeAppBackgroundImageFit('contain')).toBe('contain')
+    expect(normalizeAppBackgroundImageFit('stretch')).toBe('stretch')
+    expect(normalizeAppBackgroundImageFit('tile')).toBe(DEFAULT_APP_BACKGROUND_IMAGE_FIT)
+    expect(normalizeAppBackgroundImageFit(undefined)).toBe(DEFAULT_APP_BACKGROUND_IMAGE_FIT)
+  })
+})
+
+describe('sanitizeAppBackgroundImageSettingsUpdate', () => {
+  it('leaves absent keys absent so unrelated updates stay untouched', () => {
+    expect(sanitizeAppBackgroundImageSettingsUpdate({})).toEqual({})
+  })
+
+  it('normalizes each present key', () => {
+    expect(
+      sanitizeAppBackgroundImageSettingsUpdate({
+        appBackgroundImage: 'javascript:alert(1)',
+        appBackgroundImageOpacity: 9,
+        appBackgroundImageFit: 'tile'
+      })
+    ).toEqual({
+      appBackgroundImage: undefined,
+      appBackgroundImageOpacity: MAX_APP_BACKGROUND_IMAGE_OPACITY,
+      appBackgroundImageFit: DEFAULT_APP_BACKGROUND_IMAGE_FIT
+    })
+  })
+
+  it('keeps a valid update intact', () => {
+    expect(
+      sanitizeAppBackgroundImageSettingsUpdate({
+        appBackgroundImage: PNG_DATA_URL,
+        appBackgroundImageOpacity: 0.12,
+        appBackgroundImageFit: 'contain'
+      })
+    ).toEqual({
+      appBackgroundImage: PNG_DATA_URL,
+      appBackgroundImageOpacity: 0.12,
+      appBackgroundImageFit: 'contain'
+    })
+  })
+})

--- a/src/shared/app-background-image.ts
+++ b/src/shared/app-background-image.ts
@@ -1,0 +1,74 @@
+export const APP_BACKGROUND_IMAGE_FITS = ['cover', 'contain', 'stretch', 'center'] as const
+export type AppBackgroundImageFit = (typeof APP_BACKGROUND_IMAGE_FITS)[number]
+
+export const DEFAULT_APP_BACKGROUND_IMAGE_FIT: AppBackgroundImageFit = 'cover'
+export const DEFAULT_APP_BACKGROUND_IMAGE_OPACITY = 0.08
+/** Capped because the layer draws over the whole window; full opacity would hide the UI. */
+export const MAX_APP_BACKGROUND_IMAGE_OPACITY = 0.35
+
+export const MAX_APP_BACKGROUND_IMAGE_UPLOAD_BYTES = 4 * 1024 * 1024
+/** Base64 inflates ~4/3 over the 4MB file cap, plus the data: prefix. */
+const MAX_APP_BACKGROUND_IMAGE_DATA_URL_LENGTH = 6 * 1024 * 1024
+
+export const APP_BACKGROUND_IMAGE_MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif'
+}
+
+const APP_BACKGROUND_IMAGE_DATA_URL_RE =
+  /^data:image\/(?:png|jpeg|webp|gif);base64,[A-Za-z0-9+/]+={0,2}$/
+
+/** Undefined (no background) for anything but an inline image data URL within the size cap. */
+export function normalizeAppBackgroundImage(value: unknown): string | undefined {
+  if (
+    typeof value !== 'string' ||
+    value.length > MAX_APP_BACKGROUND_IMAGE_DATA_URL_LENGTH ||
+    !APP_BACKGROUND_IMAGE_DATA_URL_RE.test(value)
+  ) {
+    return undefined
+  }
+  return value
+}
+
+export function normalizeAppBackgroundImageOpacity(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_APP_BACKGROUND_IMAGE_OPACITY
+  }
+  return Math.min(MAX_APP_BACKGROUND_IMAGE_OPACITY, Math.max(0, value))
+}
+
+export function normalizeAppBackgroundImageFit(value: unknown): AppBackgroundImageFit {
+  return APP_BACKGROUND_IMAGE_FITS.includes(value as AppBackgroundImageFit)
+    ? (value as AppBackgroundImageFit)
+    : DEFAULT_APP_BACKGROUND_IMAGE_FIT
+}
+
+export type AppBackgroundImageSettingsUpdate = {
+  appBackgroundImage?: string
+  appBackgroundImageOpacity?: number
+  appBackgroundImageFit?: AppBackgroundImageFit
+}
+
+/** Sanitizes only the app-background keys present on the update, leaving absent keys absent. */
+export function sanitizeAppBackgroundImageSettingsUpdate(args: {
+  appBackgroundImage?: unknown
+  appBackgroundImageOpacity?: unknown
+  appBackgroundImageFit?: unknown
+}): AppBackgroundImageSettingsUpdate {
+  const update: AppBackgroundImageSettingsUpdate = {}
+  if ('appBackgroundImage' in args) {
+    update.appBackgroundImage = normalizeAppBackgroundImage(args.appBackgroundImage)
+  }
+  if ('appBackgroundImageOpacity' in args) {
+    update.appBackgroundImageOpacity = normalizeAppBackgroundImageOpacity(
+      args.appBackgroundImageOpacity
+    )
+  }
+  if ('appBackgroundImageFit' in args) {
+    update.appBackgroundImageFit = normalizeAppBackgroundImageFit(args.appBackgroundImageFit)
+  }
+  return update
+}

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -5,6 +5,7 @@ import type { GitLabProjectSettings } from './gitlab-types'
 import type { TaskProvider } from './task-providers'
 import type { KeybindingOverrides, TerminalShortcutPolicy } from './keybindings'
 import type { AppIconId } from './app-icon'
+import type { AppBackgroundImageFit } from './app-background-image'
 import type { SourceControlAiSettings } from './source-control-ai-types'
 import type { ClaudeAgentTeamsMode } from './claude-agent-teams-tmux-compat'
 import type { TerminalCustomTheme } from './terminal-custom-themes'
@@ -78,6 +79,10 @@ export type GlobalSettings = {
   leftSidebarAppearanceMode: LeftSidebarAppearanceMode
   leftSidebarTintColor?: string
   leftSidebarTintOpacity?: number
+  /** Inline image data URL drawn as a fixed low-opacity texture layer over the whole window. */
+  appBackgroundImage?: string
+  appBackgroundImageOpacity?: number
+  appBackgroundImageFit?: AppBackgroundImageFit
   uiLanguage: UiLanguage
   appIcon: AppIconId
   appFontFamily: string


### PR DESCRIPTION
## ELI5

You can now pick a picture and Orca draws it as a faint texture across the whole window — every pane, sidebar, and dialog gets the same subtle wallpaper feel. Strength and fit are adjustable, Remove puts everything back exactly how it was, and if you never touch the setting nothing changes.

## What Changed

- **Settings**: `appBackgroundImage` (inline `data:image/*` URL), `appBackgroundImageOpacity` (0–0.35, default 0.08), `appBackgroundImageFit` (`cover` | `contain` | `stretch` | `center`) on `GlobalSettings`. Sanitized in the main settings IPC via one shared `sanitizeAppBackgroundImageSettingsUpdate()` in `src/shared/app-background-image.ts` (strict data-URL regex, size cap, opacity clamp, closed fit set).
- **Picker**: new `shell:pickAppBackgroundImage` IPC (native dialog → size-capped data URL, 4MB, png/jpeg/webp/gif), modelled on `shell:pickRepoIconImage`. The web client mirror returns `null`, so the control is inert on web — remote/SSH workspaces are unaffected because this is purely client-side chrome.
- **Rendering**: `AppBackgroundImageLayer` in the app shell — one fixed, `pointer-events-none`, `aria-hidden` div at `z-[130]` mounted before `WindowControls` (drag-region hit-testing is DOM-order-based). Renders `null` when no image is set, so the default path adds zero DOM.
- **UI**: Appearance → Window & Sidebar → *Window Background Image*: Choose/Replace/Remove, Texture Strength (same `NumberField` grammar as the sidebar tint), Image Fit segmented control. Registered in settings search (`background`, `image`, `wallpaper`, `texture`).

## Why

#7714 asks for custom background images in the IDE. The open PRs cover the terminal panel (#15836, #8870) and the terminal + sidebars (#15525); this PR covers the remaining **full-window** slice with a deliberately small surface. Drawing a capped-opacity layer *over* the chrome (the approach VS Code's popular background extensions use) means no theme-token surgery and no per-surface transparency changes — dark/light themes, custom terminal themes, and every existing surface render exactly as before, with the texture washed uniformly on top. The 0.35 opacity cap guarantees the UI can never be made unreadable/unrecoverable from inside the app.

## Linked Issue

Part of #7714 (full-window area; terminal/sidebar areas are covered by #15836 / #15525).

## Visual Proof

Captured on macOS via the isolated e2e harness (fresh profile, seeded repo), texture strength 0.18 for visibility (default is a subtler 0.08).

| Before (default) | After (image set) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/chris-albert/orca/visual-proof/app-background-image/before.png) | ![after](https://raw.githubusercontent.com/chris-albert/orca/visual-proof/app-background-image/after.png) |

The new settings row (found via settings search → "background image"):

![settings](https://raw.githubusercontent.com/chris-albert/orca/visual-proof/app-background-image/settings.png)

<sub>Images live on an orphan `visual-proof/*` branch of my fork, not in the PR diff.</sub>

## Testing

- `pnpm tc`, `pnpm test` (new suites: `src/shared/app-background-image.test.ts`, `src/renderer/src/lib/app-background-image-style.test.ts`), `pnpm lint` quality gates, localization catalog synced.
- Manually verified on macOS (Apple Silicon) via the isolated e2e harness: fresh profile → default look unchanged → set image → texture renders across workspace + settings → Remove restores default.
- Not run on Linux/Windows hardware; the change is platform-neutral (standard dialog/CSS, no paths, no shortcuts).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Built with Claude Code (Claude Fable 5), driven and reviewed by the PR author.

## Review

Self-review notes: cross-platform (no platform APIs beyond `dialog.showOpenDialog`; no path handling in renderer), SSH/remote (setting lives in client-side global settings; web preload mirror inert), performance (layer renders `null` unless configured; data URL read once into settings like repo icons), security (main-process sanitization allows only `data:image/(png|jpeg|webp|gif);base64,` with strict base64 charset and size cap — no remote URLs, no `file:`, no SVG; renderer resolver re-validates before painting), backwards compatibility (three optional fields; older profiles unaffected).

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The opacity cap (0.35) is a safety choice, not a technical limit — happy to tune the cap, default, or move the section elsewhere if the team prefers a different shape.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgY8UxaixycxK78Tgg1uqe
