### PR TITLE
fix(native-chat): render structured session errors

### DIFF
--- a/src/renderer/src/components/native-chat/structured-agent-session-error-message.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-error-message.ts
@@ -1,0 +1,27 @@
+/** Extract a useful message from either an Error or a JSON RPC error payload. */
+export function structuredAgentSessionErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  if (typeof error === 'object' && error !== null) {
+    const record = error as { code?: unknown; message?: unknown }
+    if (typeof record.message === 'string' && record.message.trim()) {
+      return record.message
+    }
+    if (typeof record.code === 'string' && record.code.trim()) {
+      return record.code
+    }
+    try {
+      const serialized = JSON.stringify(error)
+      if (serialized) {
+        return serialized
+      }
+    } catch {
+      // Fall through to the primitive coercion below.
+    }
+  }
+  return String(error)
+}

--- a/src/renderer/src/components/native-chat/structured-agent-session-read-owner.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-read-owner.ts
@@ -16,6 +16,7 @@ import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 import { callStructuredAgentSession } from '@/runtime/structured-agent-session-client'
 import { NATIVE_CHAT_INITIAL_LIMIT } from './native-chat-pagination'
 import { startStructuredAgentSessionReadTransport } from './structured-agent-session-read-transport'
+import { structuredAgentSessionErrorMessage } from './structured-agent-session-error-message'
 
 export type StructuredAgentSessionReadSnapshot = {
   state: StructuredAgentSessionState
@@ -231,7 +232,7 @@ function createReadOwner(
         }
       } catch (error) {
         if (!shouldStop()) {
-          apply({ type: 'error', message: String(error) })
+          apply({ type: 'error', message: structuredAgentSessionErrorMessage(error) })
         }
       } finally {
         if (!shouldStop()) {

--- a/src/renderer/src/components/native-chat/structured-agent-session-read-transport.test.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-read-transport.test.ts
@@ -132,4 +132,20 @@ describe('structured agent-session read transport generations', () => {
       vi.useRealTimers()
     }
   })
+
+  it('renders the message from a JSON RPC error payload', async () => {
+    const applyError = vi.fn()
+    const transport = start(() => undefined, applyError)
+    await flushPromises()
+
+    attempts[0].onError({
+      code: 'agent_session_ownership_unknown',
+      message: 'This host holds no attached session by that id.'
+    })
+
+    expect(applyError).toHaveBeenCalledExactlyOnceWith(
+      'This host holds no attached session by that id.'
+    )
+    transport.dispose()
+  })
 })

--- a/src/renderer/src/components/native-chat/structured-agent-session-read-transport.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-read-transport.ts
@@ -4,6 +4,7 @@ import { createStructuredAgentSessionEventCoalescer } from '../../../../shared/s
 import { shouldAdvanceStructuredResumeCursor } from '../../../../shared/structured-agent-session-reducer'
 import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 import { subscribeStructuredAgentSession } from '@/runtime/structured-agent-session-client'
+import { structuredAgentSessionErrorMessage } from './structured-agent-session-error-message'
 
 function createReconnectScheduler(args: { shouldStop: () => boolean; reconnect: () => void }) {
   let timer: ReturnType<typeof setTimeout> | null = null
@@ -126,7 +127,7 @@ export function startStructuredAgentSessionReadTransport(args: {
           }
           closedDuringOpen = true
           connected = false
-          args.applyError(String(error))
+          args.applyError(structuredAgentSessionErrorMessage(error))
           reconnectScheduler.schedule()
         },
         () => {
@@ -152,7 +153,7 @@ export function startStructuredAgentSessionReadTransport(args: {
         return
       }
       connected = false
-      args.applyError(String(error))
+      args.applyError(structuredAgentSessionErrorMessage(error))
       reconnectScheduler.schedule()
     } finally {
       if (currentOpenGeneration === openGeneration) {
@@ -175,7 +176,7 @@ export function startStructuredAgentSessionReadTransport(args: {
       })
       .catch((error) => {
         if (!shouldStop()) {
-          args.applyError(String(error))
+          args.applyError(structuredAgentSessionErrorMessage(error))
         }
       })
   }
@@ -191,7 +192,7 @@ export function startStructuredAgentSessionReadTransport(args: {
     })
     .catch((error) => {
       if (!shouldStopInitialRead()) {
-        args.applyError(String(error))
+        args.applyError(structuredAgentSessionErrorMessage(error))
         reconnectScheduler.schedule()
       }
     })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |

<!-- /orca-pr-loc -->

## Summary

- render the message from structured agent-session JSON RPC errors instead of `[object Object]`
- normalize errors from initial reads, reconnects, pagination, and subscription callbacks
- add regression coverage for `agent_session_ownership_unknown` wire payloads

## Root cause

`subscribeStructuredAgentSession` passes `response.error` as a plain `{ code, message }` object, while the read transport coerced it with `String(error)`. The browser therefore displayed `[object Object]` in both the full-pane error and composer error.

## Validation

- `pnpm test src/renderer/src/components/native-chat/structured-agent-session-read-transport.test.ts src/renderer/src/components/native-chat/use-structured-agent-session-read.test.tsx src/renderer/src/components/native-chat/native-chat-view-state.test.ts`
- `pnpm tc`
- `pnpm exec oxlint ...` (changed files)

Electron dev app launched with CDP identity for this worktree; the fresh isolated profile did not contain a persisted structured-session failure to replay.