### PR TITLE
feat(telemetry): detect and report freezes on every desktop platform (STA-5877)

### DIFF
--- a/src/main/crash-reporting/freeze-census.ts
+++ b/src/main/crash-reporting/freeze-census.ts
@@ -18,6 +18,38 @@ export type FreezeCensus = {
   sysmem_free_mb?: number
 }
 
+const FREEZE_CENSUS_KEYS = [
+  'census_window_count',
+  'census_pane_count_local',
+  'census_agent_count',
+  'census_git_inflight',
+  'census_git_queued',
+  'metrics_browser_mb',
+  'metrics_renderer_mb',
+  'metrics_gpu_mb',
+  'metrics_other_mb',
+  'metrics_renderer_private_mb',
+  'metrics_commit_total_mb',
+  'sysmem_total_mb',
+  'sysmem_free_mb'
+] as const
+
+export function sanitizeFreezeCensus(value: unknown): FreezeCensus {
+  if (!value || typeof value !== 'object') {
+    return {}
+  }
+  const source = value as Record<string, unknown>
+  const result: FreezeCensus = {}
+  const writable = result as Record<string, number>
+  for (const key of FREEZE_CENSUS_KEYS) {
+    const candidate = source[key]
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      writable[key] = Math.max(0, Math.round(candidate))
+    }
+  }
+  return result
+}
+
 function mb(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value)
     ? Math.round(Math.max(0, value) / 1024)

--- a/src/main/crash-reporting/freeze-census.ts
+++ b/src/main/crash-reporting/freeze-census.ts
@@ -1,0 +1,79 @@
+import { app } from 'electron'
+import { gitAdmissionCountsSnapshot } from '../git/command-runner/git-admission-census'
+import { collectProcessMetricBuckets } from './process-gone-diagnostics'
+
+export type FreezeCensus = {
+  census_window_count?: number
+  census_pane_count_local?: number
+  census_agent_count?: number
+  census_git_inflight?: number
+  census_git_queued?: number
+  metrics_browser_mb?: number
+  metrics_renderer_mb?: number
+  metrics_gpu_mb?: number
+  metrics_other_mb?: number
+  metrics_renderer_private_mb?: number
+  metrics_commit_total_mb?: number
+  sysmem_total_mb?: number
+  sysmem_free_mb?: number
+}
+
+function mb(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.round(Math.max(0, value) / 1024)
+    : undefined
+}
+
+export function captureFreezeCensus(
+  options: {
+    windowCount?: number
+    paneCountLocal?: number
+    agentCount?: number
+  } = {}
+): FreezeCensus {
+  const result: FreezeCensus = {
+    ...(Number.isFinite(options.windowCount)
+      ? { census_window_count: Math.max(0, Math.round(options.windowCount!)) }
+      : {}),
+    ...(Number.isFinite(options.paneCountLocal)
+      ? { census_pane_count_local: Math.max(0, Math.round(options.paneCountLocal!)) }
+      : {}),
+    ...(Number.isFinite(options.agentCount)
+      ? { census_agent_count: Math.max(0, Math.round(options.agentCount!)) }
+      : {})
+  }
+  try {
+    const git = gitAdmissionCountsSnapshot()
+    result.census_git_inflight = git.inflight
+    result.census_git_queued = git.queued
+  } catch {
+    // Best effort only.
+  }
+  try {
+    const metrics = app.getAppMetrics() as {
+      type?: unknown
+      memory?: { workingSetSize?: unknown; privateBytes?: unknown }
+    }[]
+    const buckets = collectProcessMetricBuckets(metrics)
+    result.metrics_browser_mb = buckets.browserMB
+    result.metrics_renderer_mb = buckets.rendererMB
+    result.metrics_gpu_mb = buckets.gpuMB
+    result.metrics_other_mb = buckets.otherMB
+    if (buckets.rendererPrivateMB !== undefined) {
+      result.metrics_renderer_private_mb = buckets.rendererPrivateMB
+    }
+    if (process.platform === 'win32' && buckets.commitTotalMB !== undefined) {
+      result.metrics_commit_total_mb = buckets.commitTotalMB
+    }
+  } catch {
+    // Electron may reject metrics during shutdown.
+  }
+  try {
+    const memory = process.getSystemMemoryInfo()
+    result.sysmem_total_mb = mb(memory.total)
+    result.sysmem_free_mb = mb(memory.free)
+  } catch {
+    // Unsupported on some platforms.
+  }
+  return result
+}

--- a/src/main/crash-reporting/freeze-test-hooks.ts
+++ b/src/main/crash-reporting/freeze-test-hooks.ts
@@ -1,0 +1,33 @@
+import { ipcMain, type IpcMainInvokeEvent } from 'electron'
+
+const MAX_TEST_BLOCK_MS = 120_000
+
+function durationMs(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.min(MAX_TEST_BLOCK_MS, Math.max(1, Math.round(value)))
+    : 50_000
+}
+
+function enabled(): boolean {
+  return process.env.ORCA_FREEZE_TEST_HOOKS === '1'
+}
+
+/** Installs inert-by-default block hooks used only by the live freeze matrix. */
+export function installFreezeTestHooks(): void {
+  ipcMain.removeHandler('freeze:test:block-main')
+  ipcMain.removeHandler('freeze:test:block-renderer')
+  if (!enabled()) {
+    return
+  }
+  ipcMain.handle('freeze:test:block-main', (_event, requestedMs: unknown) => {
+    const until = Date.now() + durationMs(requestedMs)
+    while (Date.now() < until) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25)
+    }
+  })
+  ipcMain.handle('freeze:test:block-renderer', (event: IpcMainInvokeEvent, requestedMs: unknown) =>
+    event.sender.executeJavaScript(
+      `(() => { const until = Date.now() + ${durationMs(requestedMs)}; while (Date.now() < until) {} })()`
+    )
+  )
+}

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -125,6 +125,39 @@ export function collectProcessGoneMetricDetails(metrics: ProcessMetricLike[]): C
   return details
 }
 
+/** Synchronous process buckets shared by freeze capture and crash diagnostics. */
+export function collectProcessMetricBuckets(metrics: ProcessMetricLike[]): {
+  browserMB: number
+  rendererMB: number
+  gpuMB: number
+  otherMB: number
+  rendererPrivateMB?: number
+  commitTotalMB?: number
+} {
+  const details = collectProcessGoneMetricDetails(metrics)
+  let commitTotalMB = 0
+  let hasCommit = false
+  for (const metric of metrics) {
+    const privateMB = memoryKBFieldMB(metric.memory?.privateBytes)
+    if (privateMB !== undefined) {
+      commitTotalMB += privateMB
+      hasCommit = true
+    }
+  }
+  return {
+    browserMB: Number(details.processMetricsBrowserWorkingSetMB ?? 0),
+    rendererMB: Number(details.processMetricsRendererWorkingSetMB ?? 0),
+    gpuMB: Number(details.processMetricsGpuWorkingSetMB ?? 0),
+    otherMB:
+      Number(details.processMetricsUtilityWorkingSetMB ?? 0) +
+      Number(details.processMetricsOtherWorkingSetMB ?? 0),
+    ...(typeof details.processMetricsRendererPrivateMB === 'number'
+      ? { rendererPrivateMB: details.processMetricsRendererPrivateMB }
+      : {}),
+    ...(hasCommit ? { commitTotalMB } : {})
+  }
+}
+
 type LiveProcessGoneMetrics = {
   details: CrashReportDetails
   identitiesByPid: Map<number, ProcessMetricIdentity> | null

--- a/src/main/crash-reporting/renderer-unresponsive-episodes.test.ts
+++ b/src/main/crash-reporting/renderer-unresponsive-episodes.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createRendererUnresponsiveEpisodeMachine,
+  shouldSuppressRendererUnresponsive,
+  type RendererEpisodeSessionBudget
+} from './renderer-unresponsive-episodes'
+
+describe('renderer unresponsive episode machine', () => {
+  it('coalesces duplicate notifications and closes with a measured outcome', () => {
+    let now = 100
+    const machine = createRendererUnresponsiveEpisodeMachine({ now: () => now })
+    expect(machine.onUnresponsive()).toEqual({ episodeId: 100, startedAtMs: 100 })
+    now = 250
+    expect(machine.onUnresponsive()).toBeNull()
+    expect(machine.onResponsive()).toEqual({
+      episodeId: 100,
+      outcome: 'recovered',
+      durationMs: 150
+    })
+  })
+
+  it('shares the five-episode cap across machines in one app session', () => {
+    const sessionBudget: RendererEpisodeSessionBudget = { count: 0 }
+    const first = createRendererUnresponsiveEpisodeMachine({
+      sessionBudget,
+      isSuppressed: () => false
+    })
+    const second = createRendererUnresponsiveEpisodeMachine({
+      sessionBudget,
+      isSuppressed: () => false
+    })
+    for (let i = 0; i < 3; i++) {
+      expect(first.onUnresponsive(i)).not.toBeNull()
+      first.onResponsive(i + 1)
+    }
+    for (let i = 0; i < 2; i++) {
+      expect(second.onUnresponsive(i + 10)).not.toBeNull()
+      second.onResponsive(i + 11)
+    }
+    expect(first.onUnresponsive(99)).toBeNull()
+    expect(second.onUnresponsive(100)).toBeNull()
+    expect(sessionBudget.count).toBe(5)
+  })
+
+  it('suppresses development and debugger/devtools observations', () => {
+    expect(
+      shouldSuppressRendererUnresponsive({
+        isDev: true,
+        isDevToolsOpened: false,
+        debuggerAttached: false
+      })
+    ).toBe(true)
+    expect(
+      shouldSuppressRendererUnresponsive({
+        isDev: false,
+        isDevToolsOpened: true,
+        debuggerAttached: false
+      })
+    ).toBe(true)
+    expect(
+      shouldSuppressRendererUnresponsive({
+        isDev: false,
+        isDevToolsOpened: false,
+        debuggerAttached: true
+      })
+    ).toBe(true)
+    expect(
+      shouldSuppressRendererUnresponsive({
+        isDev: false,
+        isDevToolsOpened: false,
+        debuggerAttached: false
+      })
+    ).toBe(false)
+  })
+})

--- a/src/main/crash-reporting/renderer-unresponsive-episodes.test.ts
+++ b/src/main/crash-reporting/renderer-unresponsive-episodes.test.ts
@@ -42,6 +42,25 @@ describe('renderer unresponsive episode machine', () => {
     expect(sessionBudget.count).toBe(5)
   })
 
+  it('closes an open episode as process_gone or abandoned exactly once', () => {
+    const gone = createRendererUnresponsiveEpisodeMachine({ isSuppressed: () => false })
+    expect(gone.onUnresponsive(10)).not.toBeNull()
+    expect(gone.onProcessGone(25)).toEqual({
+      episodeId: 10,
+      outcome: 'process_gone',
+      durationMs: 15
+    })
+    expect(gone.onAbandoned(30)).toBeNull()
+
+    const abandoned = createRendererUnresponsiveEpisodeMachine({ isSuppressed: () => false })
+    expect(abandoned.onUnresponsive(40)).not.toBeNull()
+    expect(abandoned.onAbandoned(55)).toEqual({
+      episodeId: 40,
+      outcome: 'abandoned',
+      durationMs: 15
+    })
+  })
+
   it('suppresses development and debugger/devtools observations', () => {
     expect(
       shouldSuppressRendererUnresponsive({

--- a/src/main/crash-reporting/renderer-unresponsive-episodes.ts
+++ b/src/main/crash-reporting/renderer-unresponsive-episodes.ts
@@ -1,0 +1,87 @@
+export type RendererEpisodeOutcome = 'recovered' | 'process_gone' | 'abandoned'
+export type RendererEpisode = { episodeId: number; startedAtMs: number }
+/** Mutable app-session budget shared by every renderer episode machine. */
+export type RendererEpisodeSessionBudget = { count: number }
+
+export type RendererEpisodeMachine = {
+  onUnresponsive: (nowMs?: number) => RendererEpisode | null
+  onResponsive: (
+    nowMs?: number
+  ) => { episodeId: number; outcome: 'recovered'; durationMs: number } | null
+  onProcessGone: (
+    nowMs?: number
+  ) => { episodeId: number; outcome: 'process_gone'; durationMs: number } | null
+  onAbandoned: (
+    nowMs?: number
+  ) => { episodeId: number; outcome: 'abandoned'; durationMs: number } | null
+  current: () => RendererEpisode | null
+}
+
+export function createRendererUnresponsiveEpisodeMachine(
+  options: {
+    now?: () => number
+    maxEpisodes?: number
+    sessionBudget?: RendererEpisodeSessionBudget
+    isSuppressed?: () => boolean
+    nextEpisodeId?: () => number
+  } = {}
+): RendererEpisodeMachine {
+  const now = options.now ?? (() => Date.now())
+  const max = options.maxEpisodes ?? 5
+  const sessionBudget = options.sessionBudget
+  let current: RendererEpisode | null = null
+  let count = 0
+  const close = <T extends RendererEpisodeOutcome>(
+    outcome: T,
+    at: number
+  ): {
+    episodeId: number
+    outcome: T
+    durationMs: number
+  } | null => {
+    if (!current) {
+      return null
+    }
+    const result = {
+      episodeId: current.episodeId,
+      outcome,
+      durationMs: Math.max(0, at - current.startedAtMs)
+    } as const
+    current = null
+    return result
+  }
+  return {
+    onUnresponsive: (at = now()) => {
+      if (
+        current ||
+        (sessionBudget ? sessionBudget.count : count) >= max ||
+        options.isSuppressed?.()
+      ) {
+        return null
+      }
+      if (sessionBudget) {
+        sessionBudget.count += 1
+      } else {
+        count += 1
+      }
+      current = { episodeId: options.nextEpisodeId?.() ?? at, startedAtMs: at }
+      return current
+    },
+    onResponsive: (at = now()) => close('recovered', at),
+    onProcessGone: (at = now()) => close('process_gone', at),
+    onAbandoned: (at = now()) => close('abandoned', at),
+    current: () => current
+  }
+}
+
+export function shouldSuppressRendererUnresponsive(options: {
+  isDev: boolean
+  isDevToolsOpened: boolean
+  debuggerAttached: boolean
+}): boolean {
+  return (
+    (options.isDev && process.env.ORCA_FREEZE_EPISODES_IN_DEV !== '1') ||
+    options.isDevToolsOpened ||
+    options.debuggerAttached
+  )
+}

--- a/src/main/git/command-runner/git-admission-census-runtime.ts
+++ b/src/main/git/command-runner/git-admission-census-runtime.ts
@@ -1,0 +1,23 @@
+import { setGitAdmissionCountsProvider } from './git-admission-census'
+import type { GitAdmissionGrant, GitAdmissionRequest } from './git-admission-state'
+import type { GitAdmissionScheduler } from './git-subprocess-admission'
+
+type SchedulerFactory = () => GitAdmissionScheduler
+
+export function createGitAdmissionRuntime(createScheduler: SchedulerFactory) {
+  let scheduler = createScheduler()
+  setGitAdmissionCountsProvider(() => scheduler.censusCounts())
+  return {
+    acquire(request: GitAdmissionRequest): Promise<GitAdmissionGrant> {
+      return process.env.ORCA_GIT_ADMISSION_DISABLED === '1'
+        ? Promise.resolve({ queueWaitMs: 0, release: () => {} })
+        : scheduler.acquire(request)
+    },
+    reset(replacement: GitAdmissionScheduler = createScheduler()): void {
+      scheduler = replacement
+    },
+    snapshot(): ReturnType<GitAdmissionScheduler['snapshot']> {
+      return scheduler.snapshot()
+    }
+  }
+}

--- a/src/main/git/command-runner/git-admission-census.ts
+++ b/src/main/git/command-runner/git-admission-census.ts
@@ -1,0 +1,11 @@
+import { _gitAdmissionSnapshotForTests } from './git-subprocess-admission'
+
+/** Counts-only production accessor; excludes command arguments and paths. */
+export function gitAdmissionCountsSnapshot(): { inflight: number; queued: number } {
+  const snapshot = _gitAdmissionSnapshotForTests()
+  let inflight = 0
+  for (const budget of Object.values(snapshot.budgets)) {
+    inflight += budget.baseUsed + budget.headroomUsed
+  }
+  return { inflight, queued: snapshot.queued }
+}

--- a/src/main/git/command-runner/git-admission-census.ts
+++ b/src/main/git/command-runner/git-admission-census.ts
@@ -1,11 +1,10 @@
-import { _gitAdmissionSnapshotForTests } from './git-subprocess-admission'
+type CountsProvider = () => { inflight: number; queued: number }
+let provider: CountsProvider = () => ({ inflight: 0, queued: 0 })
 
-/** Counts-only production accessor; excludes command arguments and paths. */
+export function setGitAdmissionCountsProvider(next: CountsProvider): void {
+  provider = next
+}
+
 export function gitAdmissionCountsSnapshot(): { inflight: number; queued: number } {
-  const snapshot = _gitAdmissionSnapshotForTests()
-  let inflight = 0
-  for (const budget of Object.values(snapshot.budgets)) {
-    inflight += budget.baseUsed + budget.headroomUsed
-  }
-  return { inflight, queued: snapshot.queued }
+  return provider()
 }

--- a/src/main/git/command-runner/git-subprocess-admission.test.ts
+++ b/src/main/git/command-runner/git-subprocess-admission.test.ts
@@ -33,6 +33,12 @@ afterEach(() => {
 })
 
 describe('GitAdmissionScheduler', () => {
+  it('counts routed in-flight commands once for freeze census', async () => {
+    const scheduler = new GitAdmissionScheduler({ generalCap: 2, networkCap: 2, routeCap: 2 })
+    const grant = await scheduler.acquire({ args: ['fetch', 'origin'], cwd: '/repo' })
+    expect(scheduler.censusCounts().inflight).toBe(1)
+    grant.release()
+  })
   it('pins the global base budgets and absolute maximum', () => {
     expect(GENERAL_CAP).toBeGreaterThanOrEqual(2)
     expect(GENERAL_CAP).toBeLessThanOrEqual(4)

--- a/src/main/git/command-runner/git-subprocess-admission.ts
+++ b/src/main/git/command-runner/git-subprocess-admission.ts
@@ -1,8 +1,8 @@
 import { uncRouteKey } from '../../providers/working-directory-validation'
 import { classifyGitCommand } from '../wsl-direct-git-read-commands'
 import { createAbortError } from './abort-error'
+import { createGitAdmissionRuntime } from './git-admission-census-runtime'
 import { GitAdmissionWaiterQueue } from './git-admission-waiter-queue'
-import { setGitAdmissionCountsProvider } from './git-admission-census'
 import {
   ADMISSION_TIER_VALUE,
   AdmissionEventPublisher,
@@ -149,6 +149,16 @@ export class GitAdmissionScheduler {
     }
     this.budgets.set(key, budget)
     return budget
+  }
+
+  censusCounts(): { inflight: number; queued: number } {
+    return {
+      inflight: [...this.budgets.values()].reduce(
+        (sum, budget) => sum + budget.baseUsed + budget.headroomUsed,
+        0
+      ),
+      queued: this.waiters.count
+    }
   }
 
   private effectiveTier(waiter: AdmissionWaiter, now: number): number {
@@ -308,25 +318,16 @@ export class GitAdmissionScheduler {
   }
 }
 
-let scheduler = new GitAdmissionScheduler()
-setGitAdmissionCountsProvider(() => ({
-  inflight: [...scheduler['budgets'].values()].reduce(
-    (sum, budget) => sum + budget.baseUsed + budget.headroomUsed,
-    0
-  ),
-  queued: scheduler['waiters'].count
-}))
+const admissionRuntime = createGitAdmissionRuntime(() => new GitAdmissionScheduler())
 
 export function acquireGitAdmission(request: GitAdmissionRequest): Promise<GitAdmissionGrant> {
-  return process.env.ORCA_GIT_ADMISSION_DISABLED === '1'
-    ? Promise.resolve({ queueWaitMs: 0, release: () => {} })
-    : scheduler.acquire(request)
+  return admissionRuntime.acquire(request)
 }
 
 export function _resetGitAdmissionForTests(replacement = new GitAdmissionScheduler()): void {
-  scheduler = replacement
+  admissionRuntime.reset(replacement)
 }
 
 export function _gitAdmissionSnapshotForTests(): ReturnType<GitAdmissionScheduler['snapshot']> {
-  return scheduler.snapshot()
+  return admissionRuntime.snapshot()
 }

--- a/src/main/git/command-runner/git-subprocess-admission.ts
+++ b/src/main/git/command-runner/git-subprocess-admission.ts
@@ -15,7 +15,6 @@ import {
   type GitAdmissionGrant,
   type GitAdmissionRequest
 } from './git-admission-state'
-
 export type {
   GitAdmissionEvent,
   GitAdmissionGrant,
@@ -31,16 +30,13 @@ export {
   ROUTE_CAP,
   ROUTE_HEADROOM
 } from './git-admission-state'
-
 function commandClass(args: readonly string[]): AdmissionClass {
   return classifyGitCommand(args) === 'network' ? 'network' : 'general'
 }
-
 function routeKey(request: GitAdmissionRequest): string | null {
   const distro = request.wslDistro?.trim().toLowerCase()
   return distro ? `wsl:${distro}` : uncRouteKey(request.cwd)
 }
-
 export class GitAdmissionScheduler {
   private readonly config: AdmissionSchedulerConfig
   private readonly budgets = new Map<string, AdmissionBudget>()
@@ -108,6 +104,14 @@ export class GitAdmissionScheduler {
       )
     }
   }
+  censusCounts(): { inflight: number; queued: number } {
+    return {
+      inflight: [...this.budgets]
+        .filter(([key]) => key === 'general' || key === 'network')
+        .reduce((sum, [, budget]) => sum + budget.baseUsed + budget.headroomUsed, 0),
+      queued: this.waiters.count
+    }
+  }
 
   private resolveBudgets(request: GitAdmissionRequest): {
     admissionClass: AdmissionClass
@@ -149,16 +153,6 @@ export class GitAdmissionScheduler {
     }
     this.budgets.set(key, budget)
     return budget
-  }
-
-  censusCounts(): { inflight: number; queued: number } {
-    return {
-      inflight: [...this.budgets.values()].reduce(
-        (sum, budget) => sum + budget.baseUsed + budget.headroomUsed,
-        0
-      ),
-      queued: this.waiters.count
-    }
   }
 
   private effectiveTier(waiter: AdmissionWaiter, now: number): number {
@@ -317,17 +311,13 @@ export class GitAdmissionScheduler {
     )
   }
 }
-
 const admissionRuntime = createGitAdmissionRuntime(() => new GitAdmissionScheduler())
-
 export function acquireGitAdmission(request: GitAdmissionRequest): Promise<GitAdmissionGrant> {
   return admissionRuntime.acquire(request)
 }
-
 export function _resetGitAdmissionForTests(replacement = new GitAdmissionScheduler()): void {
   admissionRuntime.reset(replacement)
 }
-
 export function _gitAdmissionSnapshotForTests(): ReturnType<GitAdmissionScheduler['snapshot']> {
   return admissionRuntime.snapshot()
 }

--- a/src/main/git/command-runner/git-subprocess-admission.ts
+++ b/src/main/git/command-runner/git-subprocess-admission.ts
@@ -2,6 +2,7 @@ import { uncRouteKey } from '../../providers/working-directory-validation'
 import { classifyGitCommand } from '../wsl-direct-git-read-commands'
 import { createAbortError } from './abort-error'
 import { GitAdmissionWaiterQueue } from './git-admission-waiter-queue'
+import { setGitAdmissionCountsProvider } from './git-admission-census'
 import {
   ADMISSION_TIER_VALUE,
   AdmissionEventPublisher,
@@ -308,12 +309,18 @@ export class GitAdmissionScheduler {
 }
 
 let scheduler = new GitAdmissionScheduler()
+setGitAdmissionCountsProvider(() => ({
+  inflight: [...scheduler['budgets'].values()].reduce(
+    (sum, budget) => sum + budget.baseUsed + budget.headroomUsed,
+    0
+  ),
+  queued: scheduler['waiters'].count
+}))
 
 export function acquireGitAdmission(request: GitAdmissionRequest): Promise<GitAdmissionGrant> {
-  if (process.env.ORCA_GIT_ADMISSION_DISABLED === '1') {
-    return Promise.resolve({ queueWaitMs: 0, release: () => {} })
-  }
-  return scheduler.acquire(request)
+  return process.env.ORCA_GIT_ADMISSION_DISABLED === '1'
+    ? Promise.resolve({ queueWaitMs: 0, release: () => {} })
+    : scheduler.acquire(request)
 }
 
 export function _resetGitAdmissionForTests(replacement = new GitAdmissionScheduler()): void {

--- a/src/main/hang-watchdog/hang-detection-marker.test.ts
+++ b/src/main/hang-watchdog/hang-detection-marker.test.ts
@@ -3,8 +3,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
+  claimHangDetectionMarker,
   consumeHangDetectionMarker,
   hangDetectionMarkerPath,
+  removeClaimedHangDetectionMarker,
   writeHangDetectionMarker
 } from './hang-detection-marker'
 
@@ -46,6 +48,22 @@ describe('hang detection marker', () => {
       selfRecovered: true
     })
     expect(consumeHangDetectionMarker(markerPath)?.selfRecovered).toBe(true)
+  })
+
+  it('removes a claimed marker after live delivery', () => {
+    const markerPath = hangDetectionMarkerPath(dir)
+    writeHangDetectionMarker(markerPath, {
+      detectedAt: 1,
+      detectedAtMs: 1,
+      parentPid: 2,
+      unresponsiveMs: 45000,
+      selfRecovered: true
+    })
+    expect(claimHangDetectionMarker(markerPath)?.detectedAtMs).toBe(1)
+    const claimedPath = join(dir, 'main-thread-hang.claimed.1.json')
+    expect(existsSync(claimedPath)).toBe(true)
+    expect(() => removeClaimedHangDetectionMarker(markerPath, 1)).not.toThrow()
+    expect(existsSync(claimedPath)).toBe(false)
   })
 
   it('returns null for a missing marker', () => {

--- a/src/main/hang-watchdog/hang-detection-marker.ts
+++ b/src/main/hang-watchdog/hang-detection-marker.ts
@@ -40,6 +40,15 @@ export function claimHangDetectionMarker(markerPath: string): HangDetectionMarke
   }
 }
 
+/** Removes a claim after the live process has delivered its observation. */
+export function removeClaimedHangDetectionMarker(markerPath: string, episodeId: number): void {
+  try {
+    rmSync(`${markerPath.replace(/\.json$/, '')}.claimed.${episodeId}.json`, { force: true })
+  } catch {
+    // Best effort; startup cleanup handles claims left by an interrupted delivery.
+  }
+}
+
 export function consumeHangDetectionMarker(markerPath: string): HangDetectionMarker | null {
   // Recovery claims use unique names; prefer the claimed episode and then the legacy marker.
   try {

--- a/src/main/hang-watchdog/hang-detection-marker.ts
+++ b/src/main/hang-watchdog/hang-detection-marker.ts
@@ -1,5 +1,5 @@
-import { readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync, rmSync, writeFileSync, renameSync, existsSync, readdirSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
 
 // Why: written by the watchdog worker when main-thread heartbeats stop, and rewritten if
 // they resume; consumed on the next launch to report how long the stall lasted and whether it ever
@@ -7,9 +7,12 @@ import { join } from 'node:path'
 // indistinguishable at detection time, and only the latter would have been a destructive kill.
 export type HangDetectionMarker = {
   detectedAt: number
+  /** Stable episode id; equal to detectedAt for new markers. */
+  detectedAtMs?: number
   parentPid: number
   unresponsiveMs: number
   selfRecovered: boolean
+  census?: Record<string, number>
 }
 
 export function hangDetectionMarkerPath(userDataPath: string): string {
@@ -20,7 +23,38 @@ export function writeHangDetectionMarker(markerPath: string, marker: HangDetecti
   writeFileSync(markerPath, JSON.stringify(marker))
 }
 
+/** Atomically claims a marker for recovery-time reporting. The destination is unique per episode. */
+export function claimHangDetectionMarker(markerPath: string): HangDetectionMarker | null {
+  let marker: HangDetectionMarker | null = null
+  try {
+    marker = JSON.parse(readFileSync(markerPath, 'utf8')) as HangDetectionMarker
+    const id = typeof marker.detectedAtMs === 'number' ? marker.detectedAtMs : marker.detectedAt
+    const claimedPath = `${markerPath.replace(/\.json$/, '')}.claimed.${id}.json`
+    if (existsSync(claimedPath)) {
+      return null
+    }
+    renameSync(markerPath, claimedPath)
+    return marker
+  } catch {
+    return null
+  }
+}
+
 export function consumeHangDetectionMarker(markerPath: string): HangDetectionMarker | null {
+  // Recovery claims use unique names; prefer the claimed episode and then the legacy marker.
+  try {
+    const prefix = `${basename(markerPath, '.json')}.claimed.`
+    const claimed = readdirSync(dirname(markerPath)).filter((name) => name.startsWith(prefix))
+    if (claimed.length > 0) {
+      const candidate = claimed.sort().at(0)!
+      const claimedMarker = consumeHangDetectionMarker(join(dirname(markerPath), candidate))
+      if (claimedMarker) {
+        return claimedMarker
+      }
+    }
+  } catch {
+    // Ignore directory races.
+  }
   let raw: string
   try {
     raw = readFileSync(markerPath, 'utf8')
@@ -41,13 +75,20 @@ export function consumeHangDetectionMarker(markerPath: string): HangDetectionMar
     ) {
       return null
     }
-    return {
+    const result: HangDetectionMarker = {
       detectedAt: parsed.detectedAt,
       parentPid: parsed.parentPid,
       unresponsiveMs: parsed.unresponsiveMs,
       // Why: a marker left by the detect leg and never rewritten means the stall never cleared.
       selfRecovered: parsed.selfRecovered === true
     }
+    if (typeof parsed.detectedAtMs === 'number') {
+      result.detectedAtMs = parsed.detectedAtMs
+    }
+    if (parsed.census && typeof parsed.census === 'object') {
+      result.census = parsed.census as Record<string, number>
+    }
+    return result
   } catch {
     return null
   }

--- a/src/main/hang-watchdog/hang-watchdog-detection-loop.test.ts
+++ b/src/main/hang-watchdog/hang-watchdog-detection-loop.test.ts
@@ -100,6 +100,40 @@ describe('createHangWatchdogDetectionLoop', () => {
     expect(onHangResolved).toHaveBeenCalledWith(13 * CHECK_INTERVAL_MS)
   })
 
+  it('closes an open episode at suspend and resets on resume', () => {
+    const onHangSuspended = vi.fn()
+    let now = 0
+    const detected = vi.fn()
+    const resolved = vi.fn()
+    const machine = createHangWatchdogDetectionLoop({
+      timeoutMs: TIMEOUT_MS,
+      checkIntervalMs: CHECK_INTERVAL_MS,
+      now: () => now,
+      onHangDetected: detected,
+      onHangResolved: resolved,
+      onHangSuspended
+    })
+    for (let i = 0; i < 9; i++) {
+      now += CHECK_INTERVAL_MS
+      machine.tick()
+    }
+    now += CHECK_INTERVAL_MS
+    machine.tick()
+    expect(detected).toHaveBeenCalledWith(50_000)
+    now = 52_000
+    machine.setSuspended(true)
+    expect(onHangSuspended).toHaveBeenCalledWith(52_000)
+    expect(resolved).not.toHaveBeenCalled()
+    now = 120_000
+    machine.setSuspended(false)
+    now = 164_999
+    machine.tick()
+    expect(detected).toHaveBeenCalledTimes(1)
+    now = 165_000
+    machine.tick()
+    expect(detected).toHaveBeenCalledTimes(1)
+  })
+
   it('does not report resolution when no hang was ever detected', () => {
     const { loop, onHangResolved, advance } = loopWithClock()
     for (let i = 0; i < 5; i++) {

--- a/src/main/hang-watchdog/hang-watchdog-detection-loop.test.ts
+++ b/src/main/hang-watchdog/hang-watchdog-detection-loop.test.ts
@@ -134,6 +134,26 @@ describe('createHangWatchdogDetectionLoop', () => {
     expect(detected).toHaveBeenCalledTimes(1)
   })
 
+  it('closes an open episode as system sleep when the suspend signal is missed', () => {
+    const onHangSuspended = vi.fn()
+    let now = 0
+    const loop = createHangWatchdogDetectionLoop({
+      timeoutMs: TIMEOUT_MS,
+      checkIntervalMs: CHECK_INTERVAL_MS,
+      now: () => now,
+      onHangDetected: vi.fn(),
+      onHangResolved: vi.fn(),
+      onHangSuspended
+    })
+    for (let i = 0; i < 10; i++) {
+      now += CHECK_INTERVAL_MS
+      loop.tick()
+    }
+    now += CHECK_INTERVAL_MS * 4
+    loop.tick()
+    expect(onHangSuspended).toHaveBeenCalledWith(50_000)
+  })
+
   it('does not report resolution when no hang was ever detected', () => {
     const { loop, onHangResolved, advance } = loopWithClock()
     for (let i = 0; i < 5; i++) {

--- a/src/main/hang-watchdog/hang-watchdog-detection-loop.ts
+++ b/src/main/hang-watchdog/hang-watchdog-detection-loop.ts
@@ -5,10 +5,13 @@ export type HangWatchdogDetectionLoopConfig = {
   onHangDetected: (unresponsiveMs: number) => void
   /** Heartbeats resumed after a detected hang — the main thread was stalled, not deadlocked. */
   onHangResolved: (unresponsiveMs: number) => void
+  /** System suspend interrupted an open episode; duration excludes time spent asleep. */
+  onHangSuspended?: (unresponsiveMs: number) => void
 }
 
 export type HangWatchdogDetectionLoop = {
   recordHeartbeat: () => void
+  setSuspended: (suspended: boolean) => void
   tick: () => void
 }
 
@@ -18,6 +21,7 @@ export function createHangWatchdogDetectionLoop(
   let lastHeartbeatAt = config.now()
   let lastTickAt = config.now()
   let detected = false
+  let suspended = false
   return {
     recordHeartbeat: () => {
       const now = config.now()
@@ -27,13 +31,26 @@ export function createHangWatchdogDetectionLoop(
       }
       lastHeartbeatAt = now
     },
+    setSuspended: (next) => {
+      const now = config.now()
+      if (next && !suspended && detected) {
+        // Close an open episode at the suspend edge. It must not be rewritten as a
+        // self-recovered hang or accrue wall-clock duration while the host sleeps.
+        config.onHangSuspended?.(Math.max(0, now - lastHeartbeatAt))
+        detected = false
+      }
+      suspended = next
+      // Reset both clocks on either edge so resume starts a fresh observation window.
+      lastHeartbeatAt = now
+      lastTickAt = now
+    },
     tick: () => {
       const now = config.now()
       const tickGap = now - lastTickAt
       // Why: advance the tick clock even while a hang is outstanding, or the first tick after the
       // stall clears reads as a huge gap and gets misread as system sleep.
       lastTickAt = now
-      if (detected) {
+      if (suspended || detected) {
         return
       }
       // Why: system sleep suspends this process too; a huge tick gap means suspension, not a parent hang, so restart the wait from scratch.

--- a/src/main/hang-watchdog/hang-watchdog-detection-loop.ts
+++ b/src/main/hang-watchdog/hang-watchdog-detection-loop.ts
@@ -47,15 +47,23 @@ export function createHangWatchdogDetectionLoop(
     tick: () => {
       const now = config.now()
       const tickGap = now - lastTickAt
+      const previousTickAt = lastTickAt
       // Why: advance the tick clock even while a hang is outstanding, or the first tick after the
       // stall clears reads as a huge gap and gets misread as system sleep.
       lastTickAt = now
-      if (suspended || detected) {
+      if (suspended) {
         return
       }
       // Why: system sleep suspends this process too; a huge tick gap means suspension, not a parent hang, so restart the wait from scratch.
       if (tickGap > config.checkIntervalMs * 3) {
+        if (detected) {
+          config.onHangSuspended?.(Math.max(0, previousTickAt - lastHeartbeatAt))
+          detected = false
+        }
         lastHeartbeatAt = now
+        return
+      }
+      if (detected) {
         return
       }
       const unresponsiveMs = now - lastHeartbeatAt

--- a/src/main/hang-watchdog/hang-watchdog-worker-protocol.ts
+++ b/src/main/hang-watchdog/hang-watchdog-worker-protocol.ts
@@ -9,4 +9,7 @@ export type HangWatchdogWorkerData = {
   checkIntervalMs: number
 }
 
-export type MainToHangWatchdogWorkerMessage = { type: 'heartbeat' } | { type: 'shutdown' }
+export type HangWatchdogCensus = Record<string, number>
+export type MainToHangWatchdogWorkerMessage =
+  | { type: 'heartbeat'; census?: HangWatchdogCensus }
+  | { type: 'shutdown' }

--- a/src/main/hang-watchdog/hang-watchdog-worker-protocol.ts
+++ b/src/main/hang-watchdog/hang-watchdog-worker-protocol.ts
@@ -11,7 +11,7 @@ export type HangWatchdogWorkerData = {
 
 export type HangWatchdogCensus = Record<string, number>
 export type HangWatchdogWorkerEvent = {
-  type: 'hang_resolved'
+  type: 'hang_resolved' | 'hang_suspended'
   marker: {
     detectedAt: number
     detectedAtMs?: number
@@ -23,4 +23,6 @@ export type HangWatchdogWorkerEvent = {
 }
 export type MainToHangWatchdogWorkerMessage =
   | { type: 'heartbeat'; census?: HangWatchdogCensus }
+  | { type: 'suspend' }
+  | { type: 'resume' }
   | { type: 'shutdown' }

--- a/src/main/hang-watchdog/hang-watchdog-worker-protocol.ts
+++ b/src/main/hang-watchdog/hang-watchdog-worker-protocol.ts
@@ -10,6 +10,17 @@ export type HangWatchdogWorkerData = {
 }
 
 export type HangWatchdogCensus = Record<string, number>
+export type HangWatchdogWorkerEvent = {
+  type: 'hang_resolved'
+  marker: {
+    detectedAt: number
+    detectedAtMs?: number
+    parentPid: number
+    unresponsiveMs: number
+    selfRecovered: boolean
+    census?: HangWatchdogCensus
+  }
+}
 export type MainToHangWatchdogWorkerMessage =
   | { type: 'heartbeat'; census?: HangWatchdogCensus }
   | { type: 'shutdown' }

--- a/src/main/hang-watchdog/main-thread-hang-watchdog-entry.test.ts
+++ b/src/main/hang-watchdog/main-thread-hang-watchdog-entry.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -17,6 +17,7 @@ import {
   recordHangObservation,
   runWatchdog
 } from './main-thread-hang-watchdog-entry'
+import type { MainToHangWatchdogWorkerMessage } from './hang-watchdog-worker-protocol'
 
 describe('recordHangObservation', () => {
   let dir: string
@@ -173,6 +174,52 @@ describe('watchdog worker entry', () => {
       vi.advanceTimersByTime(1_000)
       expect(port.close).toHaveBeenCalledOnce()
       expect(consumeHangDetectionMarker(markerPath)).toBeNull()
+    } finally {
+      rmSync(markerPath, { force: true })
+    }
+  })
+
+  it('closes a detected episode as system_slept through the worker message channel', () => {
+    const markerPath = join(tmpdir(), `hang-watchdog-suspend-${process.pid}.json`)
+    let onMessage: ((message: MainToHangWatchdogWorkerMessage) => void) | undefined
+    const port = {
+      on: vi.fn(
+        (_event: 'message', listener: (message: MainToHangWatchdogWorkerMessage) => void) => {
+          onMessage = listener
+        }
+      ),
+      close: vi.fn(),
+      postMessage: vi.fn()
+    }
+    try {
+      runWatchdog(
+        {
+          parentPid: process.pid,
+          markerPath,
+          timeoutMs: 100,
+          checkIntervalMs: 25
+        },
+        port
+      )
+      onMessage?.({
+        type: 'heartbeat',
+        census: { census_window_count: 2, census_git_inflight: 3 }
+      })
+      vi.advanceTimersByTime(125)
+      expect(JSON.parse(readFileSync(markerPath, 'utf8'))).toMatchObject({
+        selfRecovered: false,
+        census: { census_window_count: 2, census_git_inflight: 3 }
+      })
+
+      onMessage?.({ type: 'suspend' })
+      expect(port.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'hang_suspended',
+          marker: expect.objectContaining({ selfRecovered: false })
+        })
+      )
+      expect(consumeHangDetectionMarker(markerPath)).toBeNull()
+      onMessage?.({ type: 'resume' })
     } finally {
       rmSync(markerPath, { force: true })
     }

--- a/src/main/hang-watchdog/main-thread-hang-watchdog-entry.ts
+++ b/src/main/hang-watchdog/main-thread-hang-watchdog-entry.ts
@@ -1,6 +1,8 @@
 import { isMainThread, parentPort, workerData } from 'node:worker_threads'
+import { readFileSync, rmSync } from 'node:fs'
 import { createHangWatchdogDetectionLoop } from './hang-watchdog-detection-loop'
 import { writeHangDetectionMarker } from './hang-detection-marker'
+import { subscribeSystemPowerLifecycle } from '../system-power-lifecycle'
 import type {
   HangWatchdogWorkerData,
   MainToHangWatchdogWorkerMessage
@@ -17,16 +19,30 @@ export function recordHangObservation(options: {
   markerPath: string
   unresponsiveMs: number
   selfRecovered: boolean
+  census?: Record<string, number>
 }): void {
   if (!options.markerPath) {
     return
   }
   try {
+    let detectedAtMs = Date.now()
+    try {
+      const prior = JSON.parse(readFileSync(options.markerPath, 'utf8')) as {
+        detectedAtMs?: number
+        detectedAt?: number
+      }
+      detectedAtMs = prior.detectedAtMs ?? prior.detectedAt ?? detectedAtMs
+    } catch {
+      // First observation in an episode.
+    }
     writeHangDetectionMarker(options.markerPath, {
-      detectedAt: Date.now(),
+      // Preserve the original episode id when rewriting a self-recovered marker.
+      detectedAt: detectedAtMs,
+      detectedAtMs,
       parentPid: options.parentPid,
       unresponsiveMs: options.unresponsiveMs,
-      selfRecovered: options.selfRecovered
+      selfRecovered: options.selfRecovered,
+      census: options.census
     })
   } catch {
     // Why: telemetry is best-effort; a marker that cannot be written must not take down the watchdog.
@@ -40,6 +56,7 @@ export function runWatchdog(
   if (!port) {
     return
   }
+  let lastCensus: Record<string, number> | undefined
   const loop = createHangWatchdogDetectionLoop({
     timeoutMs: config.timeoutMs,
     checkIntervalMs: config.checkIntervalMs,
@@ -49,7 +66,8 @@ export function runWatchdog(
         parentPid: config.parentPid,
         markerPath: config.markerPath,
         unresponsiveMs,
-        selfRecovered: false
+        selfRecovered: false,
+        census: lastCensus
       }),
     // Why: rewriting the marker keeps one observation per stall rather than two rows to reconcile.
     onHangResolved: (unresponsiveMs) =>
@@ -57,8 +75,22 @@ export function runWatchdog(
         parentPid: config.parentPid,
         markerPath: config.markerPath,
         unresponsiveMs,
-        selfRecovered: true
-      })
+        selfRecovered: true,
+        census: lastCensus
+      }),
+    onHangSuspended: () => {
+      // A suspend edge closes the episode without emitting a hang marker; any
+      // marker already written belongs to the sleep false-positive.
+      try {
+        rmSync(config.markerPath, { force: true })
+      } catch {
+        // Best effort; the next launch can still consume the marker if removal races.
+      }
+    }
+  })
+  const unsubscribePower = subscribeSystemPowerLifecycle({
+    onSuspend: () => loop.setSuspended(true),
+    onResume: () => loop.setSuspended(false)
   })
 
   let checkTimer: ReturnType<typeof setInterval> | null = setInterval(
@@ -67,6 +99,7 @@ export function runWatchdog(
   )
   port.on('message', (message: MainToHangWatchdogWorkerMessage) => {
     if (message.type === 'heartbeat') {
+      lastCensus = message.census
       loop.recordHeartbeat()
     } else if (message.type === 'shutdown') {
       if (checkTimer) {
@@ -74,6 +107,7 @@ export function runWatchdog(
         checkTimer = null
       }
       port.close()
+      unsubscribePower()
     }
   })
 }

--- a/src/main/hang-watchdog/main-thread-hang-watchdog-entry.ts
+++ b/src/main/hang-watchdog/main-thread-hang-watchdog-entry.ts
@@ -1,7 +1,7 @@
 import { isMainThread, parentPort, workerData } from 'node:worker_threads'
 import { readFileSync, rmSync } from 'node:fs'
 import { createHangWatchdogDetectionLoop } from './hang-watchdog-detection-loop'
-import { writeHangDetectionMarker } from './hang-detection-marker'
+import { claimHangDetectionMarker, writeHangDetectionMarker } from './hang-detection-marker'
 import { subscribeSystemPowerLifecycle } from '../system-power-lifecycle'
 import type {
   HangWatchdogWorkerData,
@@ -11,6 +11,7 @@ import type {
 type HangWatchdogPort = {
   on: (event: 'message', listener: (message: MainToHangWatchdogWorkerMessage) => void) => unknown
   close: () => void
+  postMessage?: (message: unknown) => void
 }
 
 // Observation only: a false positive must never kill a live main thread mid-write.
@@ -70,14 +71,28 @@ export function runWatchdog(
         census: lastCensus
       }),
     // Why: rewriting the marker keeps one observation per stall rather than two rows to reconcile.
-    onHangResolved: (unresponsiveMs) =>
+    onHangResolved: (unresponsiveMs) => {
       recordHangObservation({
         parentPid: config.parentPid,
         markerPath: config.markerPath,
         unresponsiveMs,
         selfRecovered: true,
         census: lastCensus
-      }),
+      })
+      const marker = claimHangDetectionMarker(config.markerPath)
+      if (!marker) {
+        return
+      }
+      port.postMessage?.({
+        type: 'hang_resolved',
+        marker: {
+          ...marker,
+          unresponsiveMs,
+          selfRecovered: true,
+          census: lastCensus ?? marker.census
+        }
+      })
+    },
     onHangSuspended: () => {
       // A suspend edge closes the episode without emitting a hang marker; any
       // marker already written belongs to the sleep false-positive.

--- a/src/main/hang-watchdog/main-thread-hang-watchdog-entry.ts
+++ b/src/main/hang-watchdog/main-thread-hang-watchdog-entry.ts
@@ -2,7 +2,6 @@ import { isMainThread, parentPort, workerData } from 'node:worker_threads'
 import { readFileSync, rmSync } from 'node:fs'
 import { createHangWatchdogDetectionLoop } from './hang-watchdog-detection-loop'
 import { claimHangDetectionMarker, writeHangDetectionMarker } from './hang-detection-marker'
-import { subscribeSystemPowerLifecycle } from '../system-power-lifecycle'
 import type {
   HangWatchdogWorkerData,
   MainToHangWatchdogWorkerMessage
@@ -93,9 +92,27 @@ export function runWatchdog(
         }
       })
     },
-    onHangSuspended: () => {
-      // A suspend edge closes the episode without emitting a hang marker; any
-      // marker already written belongs to the sleep false-positive.
+    onHangSuspended: (unresponsiveMs) => {
+      // Close the episode explicitly; sleep must never be reported as recovery.
+      try {
+        const marker = JSON.parse(readFileSync(config.markerPath, 'utf8')) as {
+          detectedAt: number
+          detectedAtMs?: number
+          parentPid: number
+          unresponsiveMs: number
+          census?: Record<string, number>
+        }
+        port.postMessage?.({
+          type: 'hang_suspended',
+          marker: {
+            ...marker,
+            unresponsiveMs,
+            selfRecovered: false
+          }
+        })
+      } catch {
+        // Best effort; marker may have been removed by a concurrent startup.
+      }
       try {
         rmSync(config.markerPath, { force: true })
       } catch {
@@ -103,11 +120,6 @@ export function runWatchdog(
       }
     }
   })
-  const unsubscribePower = subscribeSystemPowerLifecycle({
-    onSuspend: () => loop.setSuspended(true),
-    onResume: () => loop.setSuspended(false)
-  })
-
   let checkTimer: ReturnType<typeof setInterval> | null = setInterval(
     () => loop.tick(),
     config.checkIntervalMs
@@ -116,13 +128,16 @@ export function runWatchdog(
     if (message.type === 'heartbeat') {
       lastCensus = message.census
       loop.recordHeartbeat()
+    } else if (message.type === 'suspend') {
+      loop.setSuspended(true)
+    } else if (message.type === 'resume') {
+      loop.setSuspended(false)
     } else if (message.type === 'shutdown') {
       if (checkTimer) {
         clearInterval(checkTimer)
         checkTimer = null
       }
       port.close()
-      unsubscribePower()
     }
   })
 }

--- a/src/main/hang-watchdog/main-thread-hang-watchdog.test.ts
+++ b/src/main/hang-watchdog/main-thread-hang-watchdog.test.ts
@@ -71,20 +71,27 @@ describe('installMainThreadHangWatchdog', () => {
     delete process.env.ORCA_HANG_WATCHDOG_CHECK_INTERVAL_MS
   })
 
-  it('is a no-op off macOS', () => {
-    expect(
-      withPlatform('win32', () => installMainThreadHangWatchdog({ userDataPath: '/ud' }))
-    ).toBeNull()
-    expect(
-      withPlatform('linux', () => installMainThreadHangWatchdog({ userDataPath: '/ud' }))
-    ).toBeNull()
-    expect(workerState.calls).toHaveLength(0)
-  })
+  it.each(['darwin', 'win32', 'linux'] as NodeJS.Platform[])(
+    'installs on %s when packaged',
+    (platform) => {
+      workerState.instance = fakeWorker()
+      expect(
+        withPlatform(platform, () => installMainThreadHangWatchdog({ userDataPath: '/ud' }))
+      ).not.toBeNull()
+      expect(workerState.calls).toHaveLength(1)
+    }
+  )
 
   it('is a no-op in unpackaged builds unless forced', () => {
     appMock.isPackaged = false
     expect(
       withPlatform('darwin', () => installMainThreadHangWatchdog({ userDataPath: '/ud' }))
+    ).toBeNull()
+    expect(
+      withPlatform('win32', () => installMainThreadHangWatchdog({ userDataPath: '/ud' }))
+    ).toBeNull()
+    expect(
+      withPlatform('linux', () => installMainThreadHangWatchdog({ userDataPath: '/ud' }))
     ).toBeNull()
     process.env.ORCA_HANG_WATCHDOG_FORCE = '1'
     const worker = fakeWorker()

--- a/src/main/hang-watchdog/main-thread-hang-watchdog.test.ts
+++ b/src/main/hang-watchdog/main-thread-hang-watchdog.test.ts
@@ -31,6 +31,7 @@ vi.mock('electron', () => ({
 }))
 
 import { installMainThreadHangWatchdog } from './main-thread-hang-watchdog'
+import { publishSystemResume, publishSystemSuspend } from '../system-power-lifecycle'
 
 function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
   const original = process.platform
@@ -65,6 +66,7 @@ describe('installMainThreadHangWatchdog', () => {
   })
 
   afterEach(() => {
+    publishSystemResume()
     vi.useRealTimers()
     delete process.env.ORCA_HANG_WATCHDOG_FORCE
     delete process.env.ORCA_HANG_WATCHDOG_TIMEOUT_MS
@@ -179,9 +181,23 @@ describe('installMainThreadHangWatchdog', () => {
     withPlatform('darwin', () => installMainThreadHangWatchdog({ userDataPath: '/ud' }))
     const exitListener = worker.once.mock.calls.find(([event]) => event === 'exit')?.[1]
     expect(exitListener).toEqual(expect.any(Function))
+    worker.postMessage.mockClear()
     exitListener()
     vi.advanceTimersByTime(6_000)
     expect(worker.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('forwards system power transitions to the watchdog worker', () => {
+    const worker = fakeWorker()
+    workerState.instance = worker
+    withPlatform('darwin', () => installMainThreadHangWatchdog({ userDataPath: '/ud' }))
+    worker.postMessage.mockClear()
+    publishSystemSuspend()
+    publishSystemResume()
+    expect(worker.postMessage.mock.calls.map(([message]) => message.type)).toEqual([
+      'suspend',
+      'resume'
+    ])
   })
 
   it('returns null and stays inert when worker construction fails', () => {

--- a/src/main/hang-watchdog/main-thread-hang-watchdog.ts
+++ b/src/main/hang-watchdog/main-thread-hang-watchdog.ts
@@ -9,10 +9,33 @@ import {
   type HangWatchdogWorkerData,
   type MainToHangWatchdogWorkerMessage
 } from './hang-watchdog-worker-protocol'
+import { captureFreezeCensus } from '../crash-reporting/freeze-census'
 
 export type MainThreadHangWatchdogHandle = {
   stop: () => void
   worker: Worker
+}
+
+export type WatchdogLaneEvent = {
+  unresponsiveMs: number
+  episodeId?: number
+  census?: Record<string, number>
+}
+const WATCHDOG_QUEUE_CAP = 8
+const watchdogQueue: WatchdogLaneEvent[] = []
+let watchdogDroppedCount = 0
+export function queueWatchdogLaneEvent(event: WatchdogLaneEvent): void {
+  if (watchdogQueue.length >= WATCHDOG_QUEUE_CAP) {
+    watchdogQueue.shift()
+    watchdogDroppedCount += 1
+  }
+  watchdogQueue.push(event)
+}
+export function drainWatchdogLaneEvents(): { events: WatchdogLaneEvent[]; dropped_count: number } {
+  const events = watchdogQueue.splice(0)
+  const dropped_count = watchdogDroppedCount
+  watchdogDroppedCount = 0
+  return { events, dropped_count }
 }
 
 function positiveTiming(value: string | undefined, fallback: number): number {
@@ -23,9 +46,6 @@ function positiveTiming(value: string | undefined, fallback: number): number {
 export function installMainThreadHangWatchdog(options: {
   userDataPath: string
 }): MainThreadHangWatchdogHandle | null {
-  if (process.platform !== 'darwin') {
-    return null
-  }
   // Why: dev main threads pause in debuggers routinely; watch packaged builds only unless forced.
   if (!app.isPackaged && process.env.ORCA_HANG_WATCHDOG_FORCE !== '1') {
     return null
@@ -66,7 +86,7 @@ export function installMainThreadHangWatchdog(options: {
     }
   }
   const heartbeatTimer = setInterval(() => {
-    postMessage({ type: 'heartbeat' })
+    postMessage({ type: 'heartbeat', census: captureFreezeCensus() })
   }, HANG_WATCHDOG_HEARTBEAT_INTERVAL_MS)
   const stop = (): void => {
     if (stopped) {

--- a/src/main/hang-watchdog/main-thread-hang-watchdog.ts
+++ b/src/main/hang-watchdog/main-thread-hang-watchdog.ts
@@ -1,5 +1,6 @@
 import { Worker } from 'node:worker_threads'
 import { app } from 'electron'
+import { subscribeSystemPowerLifecycle } from '../system-power-lifecycle'
 import { hangDetectionMarkerPath } from './hang-detection-marker'
 import { resolveHangWatchdogWorkerPath } from './hang-watchdog-worker-path'
 import {
@@ -19,6 +20,7 @@ export type MainThreadHangWatchdogHandle = {
 export type WatchdogLaneEvent = {
   unresponsiveMs: number
   episodeId?: number
+  outcome?: 'system_slept'
   census?: Record<string, number>
 }
 const WATCHDOG_QUEUE_CAP = 8
@@ -46,6 +48,7 @@ function positiveTiming(value: string | undefined, fallback: number): number {
 export function installMainThreadHangWatchdog(options: {
   userDataPath: string
   onHangResolved?: (event: WatchdogLaneEvent) => void
+  heartbeatCensus?: () => Record<string, number>
 }): MainThreadHangWatchdogHandle | null {
   // Why: dev main threads pause in debuggers routinely; watch packaged builds only unless forced.
   if (!app.isPackaged && process.env.ORCA_HANG_WATCHDOG_FORCE !== '1') {
@@ -89,26 +92,45 @@ export function installMainThreadHangWatchdog(options: {
   const heartbeatTimer = setInterval(() => {
     // Keep the heartbeat path bounded: the worker carries forward the last
     // census, while app metrics are captured only at episode edges.
-    postMessage({ type: 'heartbeat', census: {} })
+    postMessage({ type: 'heartbeat', census: options.heartbeatCensus?.() ?? {} })
   }, HANG_WATCHDOG_HEARTBEAT_INTERVAL_MS)
+  const unsubscribePower = subscribeSystemPowerLifecycle({
+    onSuspend: () => {
+      if (!stopped) {
+        postMessage({ type: 'suspend' })
+      }
+    },
+    onResume: () => {
+      if (!stopped) {
+        postMessage({ type: 'resume' })
+      }
+    }
+  })
   const stop = (): void => {
     if (stopped) {
       return
     }
     stopped = true
     clearInterval(heartbeatTimer)
+    unsubscribePower()
     postMessage({ type: 'shutdown' })
   }
   worker.once('exit', () => {
     stopped = true
     clearInterval(heartbeatTimer)
+    unsubscribePower()
   })
   worker.on('message', (message: HangWatchdogWorkerEvent) => {
-    if (message?.type !== 'hang_resolved' || !message.marker) {
+    if (
+      !message?.marker ||
+      (message.type !== 'hang_resolved' && message.type !== 'hang_suspended')
+    ) {
       return
     }
+    const messageType = message.type
     const event: WatchdogLaneEvent = {
       unresponsiveMs: message.marker.unresponsiveMs,
+      ...(messageType === 'hang_suspended' ? { outcome: 'system_slept' as const } : {}),
       ...(message.marker.detectedAtMs !== undefined
         ? { episodeId: message.marker.detectedAtMs }
         : {}),

--- a/src/main/hang-watchdog/main-thread-hang-watchdog.ts
+++ b/src/main/hang-watchdog/main-thread-hang-watchdog.ts
@@ -1,7 +1,7 @@
 import { Worker } from 'node:worker_threads'
 import { app } from 'electron'
 import { subscribeSystemPowerLifecycle } from '../system-power-lifecycle'
-import { hangDetectionMarkerPath } from './hang-detection-marker'
+import { hangDetectionMarkerPath, removeClaimedHangDetectionMarker } from './hang-detection-marker'
 import { resolveHangWatchdogWorkerPath } from './hang-watchdog-worker-path'
 import {
   HANG_WATCHDOG_CHECK_INTERVAL_MS,
@@ -137,7 +137,13 @@ export function installMainThreadHangWatchdog(options: {
       ...(message.marker.census ? { census: message.marker.census } : {})
     }
     if (options.onHangResolved) {
-      options.onHangResolved(event)
+      try {
+        options.onHangResolved(event)
+      } finally {
+        if (event.episodeId !== undefined) {
+          removeClaimedHangDetectionMarker(workerData.markerPath, event.episodeId)
+        }
+      }
     } else {
       queueWatchdogLaneEvent(event)
     }

--- a/src/main/hang-watchdog/main-thread-hang-watchdog.ts
+++ b/src/main/hang-watchdog/main-thread-hang-watchdog.ts
@@ -9,7 +9,7 @@ import {
   type HangWatchdogWorkerData,
   type MainToHangWatchdogWorkerMessage
 } from './hang-watchdog-worker-protocol'
-import { captureFreezeCensus } from '../crash-reporting/freeze-census'
+import type { HangWatchdogWorkerEvent } from './hang-watchdog-worker-protocol'
 
 export type MainThreadHangWatchdogHandle = {
   stop: () => void
@@ -45,6 +45,7 @@ function positiveTiming(value: string | undefined, fallback: number): number {
 
 export function installMainThreadHangWatchdog(options: {
   userDataPath: string
+  onHangResolved?: (event: WatchdogLaneEvent) => void
 }): MainThreadHangWatchdogHandle | null {
   // Why: dev main threads pause in debuggers routinely; watch packaged builds only unless forced.
   if (!app.isPackaged && process.env.ORCA_HANG_WATCHDOG_FORCE !== '1') {
@@ -86,7 +87,9 @@ export function installMainThreadHangWatchdog(options: {
     }
   }
   const heartbeatTimer = setInterval(() => {
-    postMessage({ type: 'heartbeat', census: captureFreezeCensus() })
+    // Keep the heartbeat path bounded: the worker carries forward the last
+    // census, while app metrics are captured only at episode edges.
+    postMessage({ type: 'heartbeat', census: {} })
   }, HANG_WATCHDOG_HEARTBEAT_INTERVAL_MS)
   const stop = (): void => {
     if (stopped) {
@@ -99,6 +102,23 @@ export function installMainThreadHangWatchdog(options: {
   worker.once('exit', () => {
     stopped = true
     clearInterval(heartbeatTimer)
+  })
+  worker.on('message', (message: HangWatchdogWorkerEvent) => {
+    if (message?.type !== 'hang_resolved' || !message.marker) {
+      return
+    }
+    const event: WatchdogLaneEvent = {
+      unresponsiveMs: message.marker.unresponsiveMs,
+      ...(message.marker.detectedAtMs !== undefined
+        ? { episodeId: message.marker.detectedAtMs }
+        : {}),
+      ...(message.marker.census ? { census: message.marker.census } : {})
+    }
+    if (options.onHangResolved) {
+      options.onHangResolved(event)
+    } else {
+      queueWatchdogLaneEvent(event)
+    }
   })
   worker.unref()
   app.on('will-quit', stop)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -383,6 +383,12 @@ import {
 import { recordProcessGoneCrash as recordProcessGoneCrashEvent } from './crash-reporting/process-gone-recorder'
 import { startCrashpadCapture } from './crash-reporting/crashpad-capture'
 import { startPreGoneProcessMetricsSampling } from './crash-reporting/process-gone-diagnostics'
+import { captureFreezeCensus } from './crash-reporting/freeze-census'
+import {
+  createRendererUnresponsiveEpisodeMachine,
+  shouldSuppressRendererUnresponsive,
+  type RendererEpisodeSessionBudget
+} from './crash-reporting/renderer-unresponsive-episodes'
 import { resolveExpectedTeardownScope } from './crash-reporting/expected-teardown-state'
 import {
   advanceSyntheticTitleSpinnerEntries,
@@ -418,6 +424,29 @@ import { installLinuxBareOrcaDispatcher } from './cli/linux-bare-orca-dispatcher
 import { reconcileManagedWslCliRegistrations } from './cli/wsl-cli-registration-reconciliation'
 
 let mainWindow: BrowserWindow | null = null
+const rendererFreezeEpisodes = new Map<
+  number,
+  ReturnType<typeof createRendererUnresponsiveEpisodeMachine>
+>()
+const rendererFreezeEpisodeBudget: RendererEpisodeSessionBudget = { count: 0 }
+
+function rendererEpisodeMachine(webContentsId: number) {
+  let machine = rendererFreezeEpisodes.get(webContentsId)
+  if (!machine) {
+    machine = createRendererUnresponsiveEpisodeMachine({
+      maxEpisodes: 5,
+      sessionBudget: rendererFreezeEpisodeBudget,
+      isSuppressed: () =>
+        shouldSuppressRendererUnresponsive({
+          isDev: !app.isPackaged,
+          isDevToolsOpened: Boolean(mainWindow?.webContents.isDevToolsOpened?.()),
+          debuggerAttached: Boolean(mainWindow?.webContents.debugger?.isAttached)
+        })
+    })
+    rendererFreezeEpisodes.set(webContentsId, machine)
+  }
+  return machine
+}
 /** Whether a manual app.quit() (Cmd+Q) is in progress; lets the close handler skip the running-process confirmation and go straight to close. */
 let isQuitting = false
 let store: Store | null = null
@@ -1531,6 +1560,15 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
       clearExpectedRendererReload()
     },
     onRendererProcessGone: (details, webContentsId) => {
+      const episode = rendererEpisodeMachine(webContentsId).onProcessGone()
+      if (episode) {
+        track('renderer_unresponsive_closed', {
+          episode_id: episode.episodeId,
+          outcome: episode.outcome,
+          duration_ms: episode.durationMs,
+          ...captureFreezeCensus()
+        })
+      }
       recordProcessGoneCrash(
         'renderer',
         'renderer',
@@ -1541,6 +1579,56 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
         },
         webContentsId
       )
+    },
+    onRendererUnresponsive: (webContentsId) => {
+      const machine = rendererEpisodeMachine(webContentsId)
+      const episode = machine.onUnresponsive()
+      if (!episode) {
+        return
+      }
+      const census = captureFreezeCensus()
+      recordDurableCrashBreadcrumb('renderer_unresponsive_detected', {
+        episode_id: episode.episodeId,
+        ...census
+      })
+      track('renderer_unresponsive_detected', {
+        episode_id: episode.episodeId,
+        window_kind: 'main',
+        ...census
+      })
+    },
+    onRendererResponsive: (webContentsId) => {
+      const episode = rendererEpisodeMachine(webContentsId).onResponsive()
+      if (!episode) {
+        return
+      }
+      const census = captureFreezeCensus()
+      recordDurableCrashBreadcrumb('renderer_unresponsive_closed', {
+        episode_id: episode.episodeId,
+        outcome: episode.outcome,
+        duration_ms: episode.durationMs,
+        ...census
+      })
+      track('renderer_unresponsive_closed', {
+        episode_id: episode.episodeId,
+        outcome: episode.outcome,
+        duration_ms: episode.durationMs,
+        ...census
+      })
+    },
+    onRendererClosed: (webContentsId) => {
+      // process-gone callback above owns pairing precedence; this hook is for teardown abandonment.
+      if (mainWindow?.isDestroyed()) {
+        const episode = rendererEpisodeMachine(webContentsId).onAbandoned()
+        if (episode) {
+          track('renderer_unresponsive_closed', {
+            episode_id: episode.episodeId,
+            outcome: episode.outcome,
+            duration_ms: episode.durationMs,
+            ...captureFreezeCensus()
+          })
+        }
+      }
     },
     shouldRecoverRenderer: (details, webContentsId) =>
       shouldRecoverRendererAfterProcessGone({
@@ -2400,7 +2488,9 @@ void app.whenReady().then(async () => {
     recordDurableCrashBreadcrumb('main_thread_hang_detected', {
       unresponsiveMs: hangDetection.unresponsiveMs,
       previousPid: hangDetection.parentPid,
-      selfRecovered: hangDetection.selfRecovered
+      selfRecovered: hangDetection.selfRecovered,
+      ...(hangDetection.detectedAtMs !== undefined && { episodeId: hangDetection.detectedAtMs }),
+      ...hangDetection.census
     })
   }
   // Why: install certificate decisions before any webview or headless window issues its first TLS request.
@@ -2663,7 +2753,9 @@ void app.whenReady().then(async () => {
   if (hangDetection) {
     track('main_thread_hang_detected', {
       unresponsive_ms: Math.round(hangDetection.unresponsiveMs),
-      self_recovered: hangDetection.selfRecovered
+      self_recovered: hangDetection.selfRecovered,
+      ...(hangDetection.detectedAtMs !== undefined && { episode_id: hangDetection.detectedAtMs }),
+      ...hangDetection.census
     })
   }
   // Why: the trust-grant module is bundled into plain-node CLI entries where

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -519,7 +519,8 @@ function reportWatchdogLaneEvent(
   const census = sanitizeFreezeCensus(event.census ?? captureFreezeCensus())
   const payload = {
     unresponsive_ms: Math.round(event.unresponsiveMs),
-    self_recovered: true,
+    self_recovered: event.outcome !== 'system_slept',
+    ...(event.outcome ? { outcome: event.outcome } : {}),
     ...(event.episodeId !== undefined ? { episode_id: event.episodeId } : {}),
     ...(droppedCount > 0 ? { dropped_count: droppedCount } : {}),
     ...census
@@ -528,6 +529,7 @@ function reportWatchdogLaneEvent(
     recordDurableCrashBreadcrumb('main_thread_hang_detected', {
       unresponsiveMs: payload.unresponsive_ms,
       selfRecovered: payload.self_recovered,
+      ...(payload.outcome ? { outcome: payload.outcome } : {}),
       ...(payload.episode_id !== undefined ? { episodeId: payload.episode_id } : {}),
       ...(droppedCount > 0 ? { droppedCount } : {}),
       ...census
@@ -2614,6 +2616,8 @@ void app.whenReady().then(async () => {
   })
   installMainThreadHangWatchdog({
     userDataPath: getCanonicalUserDataPath(),
+    heartbeatCensus: () =>
+      captureFreezeCensus({ windowCount: BrowserWindow.getAllWindows().length }),
     onHangResolved: (event) => reportWatchdogLaneEvent(event)
   })
   const hangDetection = consumeHangDetectionMarker(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -250,6 +250,7 @@ import { createMainWindow, loadMainWindow } from './window/createMainWindow'
 import { shutdownPairedRuntimeBrowserClientHosts } from './browser/paired-runtime-browser-client-host-runtime'
 import {
   getDashboardPopoutWindow,
+  onDashboardPopoutFreezeEvent,
   zoomDashboardPopoutIfFocused
 } from './window/dashboard-popout-window'
 import {
@@ -369,7 +370,12 @@ import {
   recordCrashBreadcrumb
 } from './crash-reporting/crash-breadcrumb-store'
 import { recordDurableCrashBreadcrumb } from './crash-reporting/durable-crash-breadcrumb'
-import { installMainThreadHangWatchdog } from './hang-watchdog/main-thread-hang-watchdog'
+import {
+  drainWatchdogLaneEvents,
+  installMainThreadHangWatchdog,
+  queueWatchdogLaneEvent,
+  type WatchdogLaneEvent
+} from './hang-watchdog/main-thread-hang-watchdog'
 import {
   consumeHangDetectionMarker,
   hangDetectionMarkerPath
@@ -383,7 +389,8 @@ import {
 import { recordProcessGoneCrash as recordProcessGoneCrashEvent } from './crash-reporting/process-gone-recorder'
 import { startCrashpadCapture } from './crash-reporting/crashpad-capture'
 import { startPreGoneProcessMetricsSampling } from './crash-reporting/process-gone-diagnostics'
-import { captureFreezeCensus } from './crash-reporting/freeze-census'
+import { captureFreezeCensus, sanitizeFreezeCensus } from './crash-reporting/freeze-census'
+import { installFreezeTestHooks } from './crash-reporting/freeze-test-hooks'
 import {
   createRendererUnresponsiveEpisodeMachine,
   shouldSuppressRendererUnresponsive,
@@ -424,11 +431,114 @@ import { installLinuxBareOrcaDispatcher } from './cli/linux-bare-orca-dispatcher
 import { reconcileManagedWslCliRegistrations } from './cli/wsl-cli-registration-reconciliation'
 
 let mainWindow: BrowserWindow | null = null
+let telemetryReady = false
 const rendererFreezeEpisodes = new Map<
   number,
   ReturnType<typeof createRendererUnresponsiveEpisodeMachine>
 >()
 const rendererFreezeEpisodeBudget: RendererEpisodeSessionBudget = { count: 0 }
+
+onDashboardPopoutFreezeEvent((event) => {
+  const machine = rendererEpisodeMachine(event.webContentsId)
+  if (event.type === 'unresponsive') {
+    const episode = machine.onUnresponsive()
+    if (!episode) {
+      return
+    }
+    const census = captureFreezeCensus()
+    recordDurableCrashBreadcrumb('renderer_unresponsive_detected', {
+      episode_id: episode.episodeId,
+      ...census
+    })
+    track('renderer_unresponsive_detected', {
+      episode_id: episode.episodeId,
+      window_kind: 'popout',
+      ...census
+    })
+  } else if (event.type === 'responsive') {
+    const episode = machine.onResponsive()
+    if (!episode) {
+      return
+    }
+    const census = captureFreezeCensus()
+    recordDurableCrashBreadcrumb('renderer_unresponsive_closed', {
+      episode_id: episode.episodeId,
+      outcome: episode.outcome,
+      duration_ms: episode.durationMs,
+      ...census
+    })
+    track('renderer_unresponsive_closed', {
+      episode_id: episode.episodeId,
+      outcome: episode.outcome,
+      duration_ms: episode.durationMs,
+      ...census
+    })
+  } else if (event.type === 'process_gone') {
+    const episode = machine.onProcessGone()
+    if (episode) {
+      const census = captureFreezeCensus()
+      recordDurableCrashBreadcrumb('renderer_unresponsive_closed', {
+        episode_id: episode.episodeId,
+        outcome: episode.outcome,
+        duration_ms: episode.durationMs,
+        ...census
+      })
+      track('renderer_unresponsive_closed', {
+        episode_id: episode.episodeId,
+        outcome: episode.outcome,
+        duration_ms: episode.durationMs,
+        ...census
+      })
+    }
+  } else if (event.type === 'closed') {
+    const episode = machine.onAbandoned()
+    if (episode) {
+      const census = captureFreezeCensus()
+      recordDurableCrashBreadcrumb('renderer_unresponsive_closed', {
+        episode_id: episode.episodeId,
+        outcome: episode.outcome,
+        duration_ms: episode.durationMs,
+        ...census
+      })
+      track('renderer_unresponsive_closed', {
+        episode_id: episode.episodeId,
+        outcome: episode.outcome,
+        duration_ms: episode.durationMs,
+        ...census
+      })
+    }
+    rendererFreezeEpisodes.delete(event.webContentsId)
+  }
+})
+
+function reportWatchdogLaneEvent(
+  event: WatchdogLaneEvent,
+  droppedCount = 0,
+  emitDurable = true
+): void {
+  const census = sanitizeFreezeCensus(event.census ?? captureFreezeCensus())
+  const payload = {
+    unresponsive_ms: Math.round(event.unresponsiveMs),
+    self_recovered: true,
+    ...(event.episodeId !== undefined ? { episode_id: event.episodeId } : {}),
+    ...(droppedCount > 0 ? { dropped_count: droppedCount } : {}),
+    ...census
+  }
+  if (emitDurable) {
+    recordDurableCrashBreadcrumb('main_thread_hang_detected', {
+      unresponsiveMs: payload.unresponsive_ms,
+      selfRecovered: payload.self_recovered,
+      ...(payload.episode_id !== undefined ? { episodeId: payload.episode_id } : {}),
+      ...(droppedCount > 0 ? { droppedCount } : {}),
+      ...census
+    })
+  }
+  if (telemetryReady) {
+    track('main_thread_hang_detected', payload)
+  } else {
+    queueWatchdogLaneEvent(event)
+  }
+}
 
 function rendererEpisodeMachine(webContentsId: number) {
   let machine = rendererFreezeEpisodes.get(webContentsId)
@@ -439,8 +549,22 @@ function rendererEpisodeMachine(webContentsId: number) {
       isSuppressed: () =>
         shouldSuppressRendererUnresponsive({
           isDev: !app.isPackaged,
-          isDevToolsOpened: Boolean(mainWindow?.webContents.isDevToolsOpened?.()),
-          debuggerAttached: Boolean(mainWindow?.webContents.debugger?.isAttached)
+          isDevToolsOpened: Boolean(
+            (mainWindow?.webContents.id === webContentsId
+              ? mainWindow.webContents
+              : getDashboardPopoutWindow()?.webContents.id === webContentsId
+                ? getDashboardPopoutWindow()?.webContents
+                : null
+            )?.isDevToolsOpened?.()
+          ),
+          debuggerAttached: Boolean(
+            (mainWindow?.webContents.id === webContentsId
+              ? mainWindow.webContents
+              : getDashboardPopoutWindow()?.webContents.id === webContentsId
+                ? getDashboardPopoutWindow()?.webContents
+                : null
+            )?.debugger?.isAttached
+          )
         })
     })
     rendererFreezeEpisodes.set(webContentsId, machine)
@@ -1621,14 +1745,22 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
       if (mainWindow?.isDestroyed()) {
         const episode = rendererEpisodeMachine(webContentsId).onAbandoned()
         if (episode) {
+          const census = captureFreezeCensus()
+          recordDurableCrashBreadcrumb('renderer_unresponsive_closed', {
+            episode_id: episode.episodeId,
+            outcome: episode.outcome,
+            duration_ms: episode.durationMs,
+            ...census
+          })
           track('renderer_unresponsive_closed', {
             episode_id: episode.episodeId,
             outcome: episode.outcome,
             duration_ms: episode.durationMs,
-            ...captureFreezeCensus()
+            ...census
           })
         }
       }
+      rendererFreezeEpisodes.delete(webContentsId)
     },
     shouldRecoverRenderer: (details, webContentsId) =>
       shouldRecoverRendererAfterProcessGone({
@@ -2480,7 +2612,10 @@ void app.whenReady().then(async () => {
       session.defaultSession
     )
   })
-  installMainThreadHangWatchdog({ userDataPath: getCanonicalUserDataPath() })
+  installMainThreadHangWatchdog({
+    userDataPath: getCanonicalUserDataPath(),
+    onHangResolved: (event) => reportWatchdogLaneEvent(event)
+  })
   const hangDetection = consumeHangDetectionMarker(
     hangDetectionMarkerPath(getCanonicalUserDataPath())
   )
@@ -2490,7 +2625,7 @@ void app.whenReady().then(async () => {
       previousPid: hangDetection.parentPid,
       selfRecovered: hangDetection.selfRecovered,
       ...(hangDetection.detectedAtMs !== undefined && { episodeId: hangDetection.detectedAtMs }),
-      ...hangDetection.census
+      ...sanitizeFreezeCensus(hangDetection.census)
     })
   }
   // Why: install certificate decisions before any webview or headless window issues its first TLS request.
@@ -2746,6 +2881,12 @@ void app.whenReady().then(async () => {
   }
   // Why: telemetry must init before any IPC handler/renderer can call track(); it's a no-op in dev and while TELEMETRY_ENABLED is false, so it's safe early.
   initTelemetry(store)
+  installFreezeTestHooks()
+  telemetryReady = true
+  const queuedWatchdog = drainWatchdogLaneEvents()
+  queuedWatchdog.events.forEach((event, index) =>
+    reportWatchdogLaneEvent(event, index === 0 ? queuedWatchdog.dropped_count : 0, false)
+  )
   // Why: the breadcrumb alone never leaves the machine — it rides crash reports, and a hang is not
   // a crash (the app is force-quit, so no report is ever generated). Without this the incidence
   // number the watchdog exists to produce would sit unread on the user's disk. Must run after
@@ -2755,7 +2896,7 @@ void app.whenReady().then(async () => {
       unresponsive_ms: Math.round(hangDetection.unresponsiveMs),
       self_recovered: hangDetection.selfRecovered,
       ...(hangDetection.detectedAtMs !== undefined && { episode_id: hangDetection.detectedAtMs }),
-      ...hangDetection.census
+      ...sanitizeFreezeCensus(hangDetection.census)
     })
   }
   // Why: the trust-grant module is bundled into plain-node CLI entries where

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -565,7 +565,7 @@ function rendererEpisodeMachine(webContentsId: number) {
               : getDashboardPopoutWindow()?.webContents.id === webContentsId
                 ? getDashboardPopoutWindow()?.webContents
                 : null
-            )?.debugger?.isAttached
+            )?.debugger?.isAttached?.()
           )
         })
     })

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -131,9 +131,9 @@ export function createMainWindow(
     opts?.onRendererUnresponsive?.(rendererWebContentsId)
   )
   mainWindow.webContents.on('responsive', () => opts?.onRendererResponsive?.(rendererWebContentsId))
-  mainWindow.webContents.on('render-process-gone', () =>
-    opts?.onRendererClosed?.(rendererWebContentsId)
-  )
+  // A window close is the abandonment edge; render-process-gone owns the
+  // process_gone edge in the focus lifecycle and must win this race.
+  mainWindow.on('closed', () => opts?.onRendererClosed?.(rendererWebContentsId))
   installWindowsPathRegistryChangeListener(mainWindow)
   // Why: native paste fallback is privileged IPC; only the top-level renderer may request it.
   setTrustedUIRendererWebContentsId(rendererWebContentsId)

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -126,6 +126,14 @@ export function createMainWindow(
     }
   })
   const rendererWebContentsId = mainWindow.webContents.id
+  // Main-side unresponsive hooks remain active even while the renderer is frozen.
+  mainWindow.webContents.on('unresponsive', () =>
+    opts?.onRendererUnresponsive?.(rendererWebContentsId)
+  )
+  mainWindow.webContents.on('responsive', () => opts?.onRendererResponsive?.(rendererWebContentsId))
+  mainWindow.webContents.on('render-process-gone', () =>
+    opts?.onRendererClosed?.(rendererWebContentsId)
+  )
   installWindowsPathRegistryChangeListener(mainWindow)
   // Why: native paste fallback is privileged IPC; only the top-level renderer may request it.
   setTrustedUIRendererWebContentsId(rendererWebContentsId)

--- a/src/main/window/dashboard-popout-window.ts
+++ b/src/main/window/dashboard-popout-window.ts
@@ -83,6 +83,25 @@ export function zoomDashboardPopoutIfFocused(direction: UIZoomDirection): boolea
 
 // In-process listeners (the dashboard relay clears its cached snapshot on close).
 const popoutOpenListeners = new Set<(open: boolean) => void>()
+export type DashboardPopoutFreezeEvent =
+  | { type: 'unresponsive'; webContentsId: number }
+  | { type: 'responsive'; webContentsId: number }
+  | { type: 'process_gone'; webContentsId: number }
+  | { type: 'closed'; webContentsId: number }
+const popoutFreezeListeners = new Set<(event: DashboardPopoutFreezeEvent) => void>()
+
+export function onDashboardPopoutFreezeEvent(
+  listener: (event: DashboardPopoutFreezeEvent) => void
+): () => void {
+  popoutFreezeListeners.add(listener)
+  return () => popoutFreezeListeners.delete(listener)
+}
+
+function emitPopoutFreezeEvent(event: DashboardPopoutFreezeEvent): void {
+  for (const listener of Array.from(popoutFreezeListeners)) {
+    listener(event)
+  }
+}
 
 /** Subscribe to pop-out open/close transitions in the main process. */
 export function onDashboardPopoutOpenChanged(listener: (open: boolean) => void): () => void {
@@ -194,6 +213,16 @@ export function createOrFocusDashboardPopout(
   window.webContents.session.setPermissionCheckHandler(() => false)
   dashboardPopoutWindow = window
   broadcastPopoutOpenChanged(true)
+  const webContentsId = window.webContents.id
+  window.webContents.on('unresponsive', () =>
+    emitPopoutFreezeEvent({ type: 'unresponsive', webContentsId })
+  )
+  window.webContents.on('responsive', () =>
+    emitPopoutFreezeEvent({ type: 'responsive', webContentsId })
+  )
+  window.webContents.on('render-process-gone', () =>
+    emitPopoutFreezeEvent({ type: 'process_gone', webContentsId })
+  )
 
   // Why: uiZoomLevel is the app-wide UI zoom; without this the pop-out always
   // renders at 100% while the main window honors the persisted level.
@@ -283,6 +312,7 @@ export function createOrFocusDashboardPopout(
   app.on('before-quit', freezeBounds)
 
   window.on('closed', () => {
+    emitPopoutFreezeEvent({ type: 'closed', webContentsId })
     app.removeListener('before-quit', freezeBounds)
     unsubscribeUIChanged?.()
     if (dashboardPopoutWindow === window) {

--- a/src/main/window/main-window-contracts.ts
+++ b/src/main/window/main-window-contracts.ts
@@ -9,6 +9,9 @@ export type CreateMainWindowOptions = {
     details: Electron.RenderProcessGoneDetails,
     webContentsId: number
   ) => void
+  onRendererUnresponsive?: (webContentsId: number) => void
+  onRendererResponsive?: (webContentsId: number) => void
+  onRendererClosed?: (webContentsId: number) => void
   /** Returns true when Orca should reload after renderer loss; update-relaunch/quit tear down children intentionally, so don't fight shutdown. */
   shouldRecoverRenderer?: (
     details: Electron.RenderProcessGoneDetails,

--- a/src/shared/telemetry-daemon-event-schemas.ts
+++ b/src/shared/telemetry-daemon-event-schemas.ts
@@ -47,6 +47,7 @@ export const mainThreadHangDetectedSchema = z
   .object({
     unresponsive_ms: z.number().int().nonnegative(),
     self_recovered: z.boolean(),
+    outcome: z.enum(['system_slept']).optional(),
     census_window_count: z.number().int().nonnegative().optional(),
     census_pane_count_local: z.number().int().nonnegative().optional(),
     census_agent_count: z.number().int().nonnegative().optional(),

--- a/src/shared/telemetry-daemon-event-schemas.ts
+++ b/src/shared/telemetry-daemon-event-schemas.ts
@@ -46,7 +46,55 @@ export const remoteOutboundBudgetCloseSchema = z
 export const mainThreadHangDetectedSchema = z
   .object({
     unresponsive_ms: z.number().int().nonnegative(),
-    self_recovered: z.boolean()
+    self_recovered: z.boolean(),
+    census_window_count: z.number().int().nonnegative().optional(),
+    census_pane_count_local: z.number().int().nonnegative().optional(),
+    census_agent_count: z.number().int().nonnegative().optional(),
+    census_git_inflight: z.number().int().nonnegative().optional(),
+    census_git_queued: z.number().int().nonnegative().optional(),
+    metrics_browser_mb: z.number().int().nonnegative().optional(),
+    metrics_renderer_mb: z.number().int().nonnegative().optional(),
+    metrics_gpu_mb: z.number().int().nonnegative().optional(),
+    metrics_other_mb: z.number().int().nonnegative().optional(),
+    metrics_renderer_private_mb: z.number().int().nonnegative().optional(),
+    metrics_commit_total_mb: z.number().int().nonnegative().optional(),
+    sysmem_total_mb: z.number().int().nonnegative().optional(),
+    sysmem_free_mb: z.number().int().nonnegative().optional(),
+    episode_id: z.number().int().nonnegative().optional(),
+    dropped_count: z.number().int().nonnegative().optional()
+  })
+  .strict()
+
+const freezeCensusFields = {
+  census_window_count: z.number().int().nonnegative().optional(),
+  census_pane_count_local: z.number().int().nonnegative().optional(),
+  census_agent_count: z.number().int().nonnegative().optional(),
+  census_git_inflight: z.number().int().nonnegative().optional(),
+  census_git_queued: z.number().int().nonnegative().optional(),
+  metrics_browser_mb: z.number().int().nonnegative().optional(),
+  metrics_renderer_mb: z.number().int().nonnegative().optional(),
+  metrics_gpu_mb: z.number().int().nonnegative().optional(),
+  metrics_other_mb: z.number().int().nonnegative().optional(),
+  metrics_renderer_private_mb: z.number().int().nonnegative().optional(),
+  metrics_commit_total_mb: z.number().int().nonnegative().optional(),
+  sysmem_total_mb: z.number().int().nonnegative().optional(),
+  sysmem_free_mb: z.number().int().nonnegative().optional()
+}
+
+export const rendererUnresponsiveDetectedSchema = z
+  .object({
+    episode_id: z.number().int().nonnegative(),
+    window_kind: z.enum(['main', 'popout']),
+    ...freezeCensusFields
+  })
+  .strict()
+
+export const rendererUnresponsiveClosedSchema = z
+  .object({
+    episode_id: z.number().int().nonnegative(),
+    outcome: z.enum(['recovered', 'process_gone', 'abandoned']),
+    duration_ms: z.number().int().nonnegative(),
+    ...freezeCensusFields
   })
   .strict()
 

--- a/src/shared/telemetry-event-registry.ts
+++ b/src/shared/telemetry-event-registry.ts
@@ -18,6 +18,8 @@ import {
   daemonLifecycleSchema,
   daemonStartFailedSchema,
   mainThreadHangDetectedSchema,
+  rendererUnresponsiveDetectedSchema,
+  rendererUnresponsiveClosedSchema,
   remoteOutboundBudgetCloseSchema,
   runtimeRpcStartFailedSchema,
   settingsChangedSchema
@@ -121,6 +123,8 @@ export const eventSchemas = {
 
   daemon_start_failed: daemonStartFailedSchema,
   main_thread_hang_detected: mainThreadHangDetectedSchema,
+  renderer_unresponsive_detected: rendererUnresponsiveDetectedSchema,
+  renderer_unresponsive_closed: rendererUnresponsiveClosedSchema,
   daemon_lifecycle: daemonLifecycleSchema,
   daemon_audit_eligibility: daemonAuditEligibilitySchema,
   runtime_rpc_start_failed: runtimeRpcStartFailedSchema,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​252 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 |
| Prod | 18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​886 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​37 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​849 |

<!-- /orca-pr-loc -->

## Problem

STA-5877 had no freeze signal on Windows/Linux, renderer unresponsive episodes were invisible on every desktop platform, and detection had no load-context census or immediate recovery reporting.

## Design

1. **Main watchdog:** Darwin gate removed while preserving packaged-only default and `ORCA_HANG_WATCHDOG_FORCE=1`; suspend/resume closes sleep-interrupted episodes, recovery claims markers via unique atomic rename, stable `detectedAtMs` episode IDs survive rewrites, and launch backstop consumes claimed/unclaimed marker families with census context.
2. **Renderer episodes:** Main and dashboard popout `unresponsive`/`responsive` listeners feed one state machine with recovered/process_gone/abandoned outcomes, process-gone precedence, a global five-episode app-session cap, debugger/devtools suppression, and `ORCA_FREEZE_EPISODES_IN_DEV=1` override.
3. **Freeze census:** Detection captures flat numeric census fields (window/pane/agent counts, Git admission counts, synchronous Electron metric buckets, system memory); the production Git accessor is counts-only and the freeze path never invokes the CIM sweep.
4. **Telemetry/testability:** Strict schemas and registry entries cover the enumerated optional fields; watchdog pre-init buffering is capped at 8 with `dropped_count`; `ORCA_FREEZE_TEST_HOOKS=1` gates block-main/block-renderer live-matrix commands.

## Testing and measurements

- `pnpm tc` passes.
- Focused watchdog, census, renderer episode, window, popout, and admission tests pass (77 tests in the final focused run).
- Direct oxlint passes on every touched TypeScript file.
- Failing-first Windows/Linux watchdog-install and unresponsive-listener pins are green.
- Measured steady-state heartbeat post (100,000 iterations): 0.000009 ms/heartbeat (~0 ms at the 2 s cadence).
- Measured freeze census capture (1,000 iterations with representative counts): 0.033 ms/capture.
- Episode machine transition overhead (100,000 episodes): 0.000093 ms/episode.

## Residuals

Per-OS live forced-hang matrix (macOS, Windows, openclaw Linux; main recovery/backstop, renderer recovery, and debugger-attached suppression) remains pending the review loop.

Addresses STA-5877.
