### PR TITLE
fix(linux): strip AppImage desktop switches before CLI redirect

### DIFF
--- a/src/main/startup/appimage-cli-redirect.test.ts
+++ b/src/main/startup/appimage-cli-redirect.test.ts
@@ -130,6 +130,20 @@ describe('AppImage CLI redirect', () => {
     ).toEqual(['serve', '--not-a-serve-flag'])
   })
 
+  it('keeps malformed boolean desktop flags visible to the CLI parser', () => {
+    expect(
+      getAppImageCliArgs(
+        ['AppRun', 'serve', '--no-sandbox=true'],
+        { APPIMAGE: '/opt/orca' },
+        {
+          platform: 'linux',
+          isPackaged: true,
+          commandNames
+        }
+      )
+    ).toEqual(['serve', '--no-sandbox=true'])
+  })
+
   it('removes no-sandbox before forwarding CLI help', () => {
     expect(
       getAppImageCliArgs(

--- a/src/main/startup/appimage-cli-redirect.test.ts
+++ b/src/main/startup/appimage-cli-redirect.test.ts
@@ -116,6 +116,20 @@ describe('AppImage CLI redirect', () => {
     ).toEqual(['serve', '--disable-features=FedCm'])
   })
 
+  it('keeps unknown CLI flags visible to the CLI parser', () => {
+    expect(
+      getAppImageCliArgs(
+        ['AppRun', 'serve', '--not-a-serve-flag'],
+        { APPIMAGE: '/opt/orca' },
+        {
+          platform: 'linux',
+          isPackaged: true,
+          commandNames
+        }
+      )
+    ).toEqual(['serve', '--not-a-serve-flag'])
+  })
+
   it('removes no-sandbox before forwarding CLI help', () => {
     expect(
       getAppImageCliArgs(


### PR DESCRIPTION
## ELI5

On Linux AppImage launches, desktop-only Electron/Chromium switches can appear next to Orca CLI arguments. When `stably-orca serve` receives `--disable-features`, the CLI rejects it as an unknown `serve` flag even though the user did not pass it. This filters that desktop switch before Orca hands arguments to the CLI.

## What Changed

- Split AppImage desktop switch filtering into boolean and value-taking switches.
- Strip `--disable-features=...` and `--disable-features ...` before forwarding AppImage CLI launches.
- Keep existing `--no-sandbox` filtering behavior.
- Add regression coverage for `serve` with injected Chromium feature switches.
- Add a guard test proving unknown user CLI flags are still forwarded to the CLI parser instead of being silently swallowed.

## Why

The AppImage redirect boundary is where Orca decides whether a packaged Linux launch is a desktop launch or a direct CLI launch. Filtering here keeps desktop-only Electron switches out of Node-mode CLI parsing while preserving normal CLI validation for user-provided flags.

This is adjacent to #17343, which focuses on the AppImage `--no-sandbox` fallback. This PR handles the separate `--disable-features` switch reported by #17412.

## Linked Issue

Fixes #17412

## Visual Proof

N/A — Linux AppImage CLI argument forwarding only; no rendered UI changes.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local focused checks passed on Windows:

- `node_modules\.bin\vitest.cmd run --config config/vitest.config.ts src/main/startup/appimage-cli-redirect.test.ts src/main/startup/serve-mode-argv.test.ts src/cli/serve-electron-flag-parity.test.ts src/cli/index-serve-command.test.ts` — 4 files / 42 tests passed
- `node_modules\.bin\oxlint.cmd src/main/startup/appimage-cli-redirect.ts src/main/startup/appimage-cli-redirect.test.ts`
- `node_modules\.bin\tsc.cmd --noEmit -p config/tsconfig.node.json`
- `corepack pnpm exec lint-staged`

Full `pnpm test` is blocked in this local Windows checkout by native dependency rebuild / MAX_PATH behavior before Vitest runs. The affected focused tests were run directly and pass.

## AI Disclosure

Implemented with AI assistance from OpenAI Codex (GPT-5) under contributor direction; contributor reviewed the issue scope and requested the fix.

## Review

Self-reviewed for scope, CLI argument preservation, and regression coverage. The fix intentionally strips only known AppImage desktop switches so genuine unknown CLI flags remain visible to the CLI parser.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security impact is limited to argument routing; no permissions or shell execution behavior changes. Cross-platform impact is Linux AppImage-only. SSH, mobile, remote wire compatibility, shortcuts, and UI styling are not affected.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
