### PR TITLE
feat(worktree): reuse dependency trees with copy-on-write seeds

### DIFF
--- a/config/scripts/macos-electron-bundle-copy.mjs
+++ b/config/scripts/macos-electron-bundle-copy.mjs
@@ -1,0 +1,59 @@
+import { execFileSync } from 'node:child_process'
+import { cpSync, rmSync } from 'node:fs'
+
+const MACOS_CP = '/bin/cp'
+export const MACOS_ELECTRON_CLONE_ARGS = Object.freeze(['-c', '-R', '-P'])
+
+/**
+ * Copy an Electron.app with an APFS clone when the host supports it.
+ *
+ * Electron's macOS bundle is large, while the dev runner only changes a few
+ * metadata files before signing. APFS clones keep the framework files shared
+ * until one of those files is changed. Other platforms, and filesystems where
+ * clonefile is unavailable, use the existing regular copy path.
+ */
+export function copyMacElectronBundle(sourcePath, destinationPath, options = {}) {
+  const platform = options.platform ?? process.platform
+  const copy = options.copy ?? copyElectronBundleNormally
+
+  if (platform !== 'darwin') {
+    copy(sourcePath, destinationPath)
+    return { usedClone: false, cloneError: null }
+  }
+
+  const clone = options.clone ?? cloneElectronBundleWithCp
+  const removePartial = options.removePartial ?? removePartialBundle
+
+  try {
+    clone(sourcePath, destinationPath)
+    return { usedClone: true, cloneError: null }
+  } catch (cloneError) {
+    // cp may have created part of the destination before discovering that the
+    // filesystem cannot clone. Remove only that fresh destination, then retry
+    // with the same copy semantics as the pre-clone runner.
+    try {
+      removePartial(destinationPath)
+    } catch {
+      // The regular copy below reports the actionable failure if cleanup did not
+      // succeed; do not hide it behind a best-effort cleanup error.
+    }
+    console.warn('[orca-dev] APFS clone unavailable; using regular copy')
+    copy(sourcePath, destinationPath)
+    return { usedClone: false, cloneError }
+  }
+}
+
+export function cloneElectronBundleWithCp(sourcePath, destinationPath, options = {}) {
+  const execFile = options.execFile ?? execFileSync
+  execFile(MACOS_CP, [...MACOS_ELECTRON_CLONE_ARGS, sourcePath, destinationPath], {
+    stdio: 'ignore'
+  })
+}
+
+function copyElectronBundleNormally(sourcePath, destinationPath) {
+  cpSync(sourcePath, destinationPath, { recursive: true, verbatimSymlinks: true })
+}
+
+function removePartialBundle(destinationPath) {
+  rmSync(destinationPath, { recursive: true, force: true })
+}

--- a/config/scripts/macos-electron-bundle-copy.test.ts
+++ b/config/scripts/macos-electron-bundle-copy.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  MACOS_ELECTRON_CLONE_ARGS,
+  cloneElectronBundleWithCp,
+  copyMacElectronBundle
+} from './macos-electron-bundle-copy.mjs'
+
+describe('macos-electron-bundle-copy', () => {
+  it('uses the APFS clone path on macOS', () => {
+    const clone = vi.fn()
+    const copy = vi.fn()
+
+    const result = copyMacElectronBundle('/source/Electron.app', '/dest/Orca.app', {
+      platform: 'darwin',
+      clone,
+      copy
+    })
+
+    expect(result).toEqual({ usedClone: true, cloneError: null })
+    expect(clone).toHaveBeenCalledOnce()
+    expect(clone).toHaveBeenCalledWith('/source/Electron.app', '/dest/Orca.app')
+    expect(copy).not.toHaveBeenCalled()
+  })
+
+  it('removes a partial clone and falls back to a regular copy', () => {
+    const cloneError = new Error('clonefile is unavailable')
+    const clone = vi.fn(() => {
+      throw cloneError
+    })
+    const removePartial = vi.fn()
+    const copy = vi.fn()
+
+    const result = copyMacElectronBundle('/source/Electron.app', '/dest/Orca.app', {
+      platform: 'darwin',
+      clone,
+      removePartial,
+      copy
+    })
+
+    expect(result).toEqual({ usedClone: false, cloneError })
+    expect(removePartial).toHaveBeenCalledOnce()
+    expect(removePartial).toHaveBeenCalledWith('/dest/Orca.app')
+    expect(copy).toHaveBeenCalledOnce()
+    expect(copy).toHaveBeenCalledWith('/source/Electron.app', '/dest/Orca.app')
+  })
+
+  it('uses the regular copy path off macOS without attempting a clone', () => {
+    const clone = vi.fn()
+    const copy = vi.fn()
+
+    const result = copyMacElectronBundle('/source/Electron.app', '/dest/Orca.app', {
+      platform: 'linux',
+      clone,
+      copy
+    })
+
+    expect(result).toEqual({ usedClone: false, cloneError: null })
+    expect(clone).not.toHaveBeenCalled()
+    expect(copy).toHaveBeenCalledWith('/source/Electron.app', '/dest/Orca.app')
+  })
+
+  it('invokes BSD cp with clone and symlink-preserving flags', () => {
+    const execFile = vi.fn()
+
+    cloneElectronBundleWithCp('/source/Electron.app', '/dest/Orca.app', { execFile })
+
+    expect(execFile).toHaveBeenCalledWith(
+      '/bin/cp',
+      [...MACOS_ELECTRON_CLONE_ARGS, '/source/Electron.app', '/dest/Orca.app'],
+      { stdio: 'ignore' }
+    )
+  })
+
+  it('does not hide a regular-copy failure after clone cleanup', () => {
+    const cloneError = new Error('clonefile is unavailable')
+    const copyError = new Error('destination is not writable')
+    const copy = vi.fn(() => {
+      throw copyError
+    })
+
+    expect(() =>
+      copyMacElectronBundle('/source/Electron.app', '/dest/Orca.app', {
+        platform: 'darwin',
+        clone: () => {
+          throw cloneError
+        },
+        copy
+      })
+    ).toThrow(copyError)
+  })
+})

--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -1,7 +1,6 @@
 import { execFileSync, spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import {
-  cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -23,6 +22,7 @@ import {
   getDevBundlePlistPatches,
   getDevHelperPlistPatches
 } from './dev-electron-bundle-identity.mjs'
+import { copyMacElectronBundle } from './macos-electron-bundle-copy.mjs'
 
 // Why: Electron-based hosts (e.g. Claude Code, VS Code) set
 // ELECTRON_RUN_AS_NODE=1 in their terminal environment. If this leaks into
@@ -300,7 +300,7 @@ function prepareMacDevElectronApp() {
   mkdirSync(distDir, { recursive: true })
   // Why: Electron.framework uses relative symlinks for its bundle resources;
   // resolving them to pnpm-store absolutes breaks Chromium's bundle lookup.
-  cpSync(sourceAppPath, appPath, { recursive: true, verbatimSymlinks: true })
+  copyMacElectronBundle(sourceAppPath, appPath)
   restoreElectronFrameworkSymlinks(appPath)
 
   const plistPath = path.join(appPath, 'Contents', 'Info.plist')

--- a/src/main/hooks-orca-yaml-parsing.test.ts
+++ b/src/main/hooks-orca-yaml-parsing.test.ts
@@ -374,6 +374,99 @@ describe('parseOrcaYaml', () => {
     expect(result?.scripts.setup).toBe('pnpm install')
     expect(result?.worktree?.sharedDirectories).toEqual(['.cache'])
   })
+
+  it('parses dependency seed paths and fingerprint inputs from worktree defaults', () => {
+    const result = parseOrcaYaml(
+      [
+        'worktree:',
+        '  dependencySeedPaths:',
+        '    - node_modules',
+        '    - .cache',
+        '  dependencySeedInputs:',
+        '    - package.json',
+        '    - pnpm-lock.yaml'
+      ].join('\n')
+    )
+
+    expect(result).toEqual({
+      scripts: {},
+      worktree: {
+        dependencySeedPaths: ['node_modules', '.cache'],
+        dependencySeedInputs: ['package.json', 'pnpm-lock.yaml']
+      }
+    })
+  })
+
+  it('normalizes and dedupes dependency seed paths and inputs', () => {
+    const result = parseOrcaYaml(
+      [
+        'worktree:',
+        '  dependencySeedPaths:',
+        '    - node_modules/',
+        '    - ./node_modules',
+        '    - apps\\web\\node_modules',
+        '    - apps/./web/node_modules',
+        '    - ../escape',
+        '    - /etc',
+        '    - .git',
+        '  dependencySeedInputs:',
+        '    - ./package.json',
+        '    - package.json',
+        '    - lockfiles\\pnpm-lock.yaml',
+        '    - lockfiles//yarn.lock',
+        '    - ..\\secret'
+      ].join('\n')
+    )
+
+    expect(result?.worktree).toEqual({
+      dependencySeedPaths: ['node_modules', 'apps/web/node_modules'],
+      dependencySeedInputs: ['package.json', 'lockfiles/pnpm-lock.yaml']
+    })
+  })
+
+  it('preserves explicitly empty dependency seed arrays', () => {
+    expect(
+      parseOrcaYaml(
+        ['worktree:', '  dependencySeedPaths: []', '  dependencySeedInputs: []'].join('\n')
+      )
+    ).toEqual({
+      scripts: {},
+      worktree: {
+        dependencySeedPaths: [],
+        dependencySeedInputs: []
+      }
+    })
+  })
+
+  it('preserves explicit dependency arrays after normalization removes every entry', () => {
+    expect(
+      parseOrcaYaml(
+        [
+          'scripts:',
+          '  setup: pnpm install',
+          'worktree:',
+          '  dependencySeedPaths:',
+          '    - ../escape',
+          '  dependencySeedInputs:',
+          '    - /etc/passwd'
+        ].join('\n')
+      )
+    ).toEqual({
+      scripts: { setup: 'pnpm install' },
+      worktree: {
+        dependencySeedPaths: [],
+        dependencySeedInputs: []
+      }
+    })
+  })
+
+  it('keeps malformed dependency values absent while preserving sharedDirectories behavior', () => {
+    expect(
+      parseOrcaYaml(
+        ['worktree:', '  dependencySeedPaths: node_modules', '  sharedDirectories: []'].join('\n')
+      )
+    ).toBeNull()
+  })
 })
 
 describe('hasUnrecognizedOrcaYamlKeys', () => {

--- a/src/main/ipc/worktree-local-startup-provisioning.test.ts
+++ b/src/main/ipc/worktree-local-startup-provisioning.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from 'vitest'
+import { spawnLocalStartupAndSetupTerminals } from './worktree-remote'
+
+vi.mock('electron', async () =>
+  (await import('./worktrees-test-module-mocks')).electronModuleMock()
+)
+vi.mock('../git/worktree', async () =>
+  (await import('./worktrees-test-module-mocks')).gitWorktreeModuleMock()
+)
+vi.mock('../git/runner', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRunnerModuleMock()
+)
+vi.mock('../git/repo', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRepoModuleMock()
+)
+vi.mock('../git/git-username', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resolveLocalGitUsername: (await import('./worktrees-test-module-mocks'))
+    .resolveLocalGitUsernameMock
+}))
+vi.mock('../github/client', async () =>
+  (await import('./worktrees-test-module-mocks')).githubClientModuleMock()
+)
+vi.mock('../source-control/hosted-review', async () =>
+  (await import('./worktrees-test-module-mocks')).hostedReviewModuleMock()
+)
+vi.mock('../providers/ssh-git-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshGitDispatchModuleMock()
+)
+vi.mock('../providers/ssh-filesystem-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshFilesystemDispatchModuleMock()
+)
+vi.mock('./worktree-symlinks', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeSymlinksModuleMock()
+)
+vi.mock('./ssh', async () => (await import('./worktrees-test-module-mocks')).sshModuleMock())
+vi.mock('../ssh/ssh-target-registry', async () =>
+  (await import('./worktrees-test-module-mocks')).sshTargetRegistryModuleMock()
+)
+vi.mock('../hooks', async () => (await import('./worktrees-test-module-mocks')).hooksModuleMock())
+vi.mock('../setup-runner-script-text', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupRunnerScriptTextModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../worktree-runner-script', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeRunnerScriptModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../effective-hook-config', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).effectiveHookConfigModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../setup-hook-env-vars', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupHookEnvVarsModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('./worktree-logic', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeLogicModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../terminal-history-deletion', async () =>
+  (await import('./worktrees-test-module-mocks')).terminalHistoryDeletionModuleMock()
+)
+vi.mock('../ports/advertised-url-watcher', async () =>
+  (await import('./worktrees-test-module-mocks')).advertisedUrlWatcherModuleMock()
+)
+vi.mock('../workspace-cleanup-scan-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupScanSnapshotModuleMock()
+)
+vi.mock('../workspace-space-analysis-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceSpaceAnalysisSnapshotModuleMock()
+)
+vi.mock('../workspace-cleanup-removal-snapshot-prune', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupRemovalSnapshotPruneModuleMock()
+)
+vi.mock('../runtime/worktree-teardown', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeTeardownModuleMock()
+)
+vi.mock('./pty', async () => (await import('./worktrees-test-module-mocks')).ptyModuleMock())
+
+describe('spawnLocalStartupAndSetupTerminals', () => {
+  it('can provision setup without a startup terminal for seed completion observation', async () => {
+    const createTerminal = vi.fn().mockResolvedValue({
+      handle: 'term-setup-only',
+      surface: 'visible'
+    })
+    const waitForSetupTerminalCompletion = vi.fn().mockResolvedValue({ exitCode: 0 })
+    const onSetupCompleted = vi.fn()
+    const runtime = {
+      createTerminal,
+      splitTerminal: vi.fn(),
+      waitForSetupTerminalCompletion
+    } as never
+
+    const result = await spawnLocalStartupAndSetupTerminals({
+      runtime,
+      worktree: { id: 'repo-1::/workspace/setup-only', path: '/workspace/setup-only' },
+      startup: undefined,
+      setup: {
+        runnerScriptPath: '/workspace/repo/.git/orca/setup-runner.sh',
+        envVars: {}
+      },
+      defaultTabs: undefined,
+      settings: { setupScriptLaunchMode: 'new-tab' } as never,
+      createdWithAgent: undefined,
+      forceSetupProvision: true,
+      onSetupCompleted
+    })
+
+    expect(result).toMatchObject({
+      didSpawnSetup: true,
+      setupTerminalHandle: 'term-setup-only'
+    })
+    expect(createTerminal).toHaveBeenCalledWith(
+      'id:repo-1::/workspace/setup-only',
+      expect.objectContaining({
+        title: 'Setup',
+        command: expect.stringContaining('__ORCA_SETUP_COMPLETE__:'),
+        activate: false
+      })
+    )
+    const setupOptions = createTerminal.mock.calls[0]?.[1] as { command?: string }
+    const completionToken = setupOptions.command?.match(
+      /__ORCA_SETUP_COMPLETE__:([^:]+):%s\\n/
+    )?.[1]
+    expect(completionToken).toEqual(expect.any(String))
+    expect(waitForSetupTerminalCompletion).toHaveBeenCalledWith('term-setup-only', completionToken)
+    await vi.waitFor(() => expect(onSetupCompleted).toHaveBeenCalledWith(0))
+  })
+
+  it('falls back to a setup tab when seed-observing split setup has no primary terminal', async () => {
+    const createTerminal = vi.fn().mockResolvedValue({
+      handle: 'term-setup-split-fallback',
+      surface: 'visible'
+    })
+    const splitTerminal = vi.fn()
+    const runtime = { createTerminal, splitTerminal } as never
+
+    const result = await spawnLocalStartupAndSetupTerminals({
+      runtime,
+      worktree: { id: 'repo-1::/workspace/setup-split', path: '/workspace/setup-split' },
+      startup: undefined,
+      setup: {
+        runnerScriptPath: '/workspace/repo/.git/orca/setup-runner.sh',
+        envVars: {}
+      },
+      defaultTabs: undefined,
+      settings: { setupScriptLaunchMode: 'split-vertical' } as never,
+      createdWithAgent: undefined,
+      forceSetupProvision: true
+    })
+
+    expect(result.setupTerminalHandle).toBe('term-setup-split-fallback')
+    expect(splitTerminal).not.toHaveBeenCalled()
+    expect(createTerminal).toHaveBeenCalledWith(
+      'id:repo-1::/workspace/setup-split',
+      expect.objectContaining({ title: 'Setup' })
+    )
+  })
+
+  it('materializes default tabs when seed ownership bypasses renderer activation', async () => {
+    const createTerminal = vi
+      .fn()
+      .mockResolvedValueOnce({ handle: 'term-startup', surface: 'visible' })
+      .mockResolvedValueOnce({ handle: 'term-default', tabId: 'tab-default', surface: 'visible' })
+      .mockResolvedValueOnce({ handle: 'term-setup', surface: 'visible' })
+    const setMobileSessionTabProps = vi.fn().mockResolvedValue({ updated: true })
+    const runtime = {
+      createTerminal,
+      splitTerminal: vi.fn(),
+      setMobileSessionTabProps,
+      waitForSetupTerminalCompletion: vi.fn()
+    } as never
+
+    const result = await spawnLocalStartupAndSetupTerminals({
+      runtime,
+      worktree: { id: 'repo-1::/workspace/seeded-defaults', path: '/workspace/seeded-defaults' },
+      startup: { command: 'agent' },
+      setup: {
+        runnerScriptPath: '/workspace/repo/.git/orca/setup-runner.sh',
+        envVars: {}
+      },
+      defaultTabs: {
+        runCommands: true,
+        tabs: [{ title: 'Dev', command: 'pnpm dev', color: '#123456' }]
+      },
+      settings: { setupScriptLaunchMode: 'new-tab' } as never,
+      createdWithAgent: undefined,
+      forceSetupProvision: true,
+      materializeDefaultTabs: true
+    })
+
+    expect(result).toMatchObject({
+      didSpawnDefaultTabs: true,
+      didSpawnSetup: true,
+      startupTerminal: { spawned: true }
+    })
+    expect(createTerminal).toHaveBeenNthCalledWith(2, 'id:repo-1::/workspace/seeded-defaults', {
+      title: 'Dev',
+      command: 'pnpm dev',
+      activate: false
+    })
+    expect(setMobileSessionTabProps).toHaveBeenCalledWith('id:repo-1::/workspace/seeded-defaults', {
+      tabId: 'tab-default',
+      color: '#123456'
+    })
+  })
+})

--- a/src/main/ipc/worktree-local-startup-provisioning.test.ts
+++ b/src/main/ipc/worktree-local-startup-provisioning.test.ts
@@ -210,4 +210,30 @@ describe('spawnLocalStartupAndSetupTerminals', () => {
       color: '#123456'
     })
   })
+
+  it('leaves default tabs available when every host spawn fails', async () => {
+    const createTerminal = vi.fn().mockRejectedValue(new Error('pty unavailable'))
+    const runtime = {
+      createTerminal,
+      splitTerminal: vi.fn(),
+      waitForSetupTerminalCompletion: vi.fn()
+    } as never
+
+    const result = await spawnLocalStartupAndSetupTerminals({
+      runtime,
+      worktree: { id: 'repo-1::/workspace/default-fallback', path: '/workspace/default-fallback' },
+      startup: undefined,
+      setup: undefined,
+      defaultTabs: {
+        runCommands: true,
+        tabs: [{ title: 'Dev', command: 'pnpm dev' }]
+      },
+      settings: { setupScriptLaunchMode: 'new-tab' } as never,
+      createdWithAgent: undefined,
+      materializeDefaultTabs: true
+    })
+
+    expect(result.didSpawnDefaultTabs).toBeUndefined()
+    expect(result.warning).toContain('failed to create a default terminal')
+  })
 })

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -127,7 +127,15 @@ import {
   buildSetupRunnerCommand,
   getSetupRunnerCommandPlatformForPath
 } from '../../shared/setup-runner-command'
+import { buildObservedSetupCommand } from '../runtime/orchestration/setup-completion-signal'
 import { createSequencedSetupAgentCommands } from '../../shared/setup-agent-sequencing'
+import {
+  hydrateWorktreeDependencies,
+  promoteWorktreeDependencySeed,
+  readWorktreeDependencySeedInputs,
+  resolveWorktreeDependencySeedPlan,
+  type WorktreeDependencySeedArgs
+} from '../worktree-dependency-seed'
 import { shouldWaitForSetupBeforeAgentStartup } from '../../shared/setup-agent-startup-policy'
 import { createWorktreeCreateTimingRecorder } from '../worktree-create-timing'
 import {
@@ -174,6 +182,8 @@ type RemoteWorktreeCreateBasePlan = {
 type StagedStartupResult = {
   startupTerminal?: CreateWorktreeResult['startupTerminal']
   activationSetup?: CreateWorktreeResult['setup']
+  setupTerminalHandle?: string
+  didSpawnDefaultTabs?: boolean
   didSpawnSetup: boolean
   warning?: string
 }
@@ -345,7 +355,8 @@ function countNonEmptyGitOutputLines(output: string): number {
   return output.split(/\r?\n/).filter((line) => line.trim().length > 0).length
 }
 
-async function spawnLocalStartupAndSetupTerminals(args: {
+/** Materialize local startup/setup panes; exported for lifecycle-focused tests. */
+export async function spawnLocalStartupAndSetupTerminals(args: {
   runtime: OrcaRuntimeService | undefined
   worktree: Pick<Worktree, 'id' | 'path'>
   startup: CreateWorktreeArgs['startup']
@@ -353,15 +364,40 @@ async function spawnLocalStartupAndSetupTerminals(args: {
   defaultTabs: CreateWorktreeResult['defaultTabs']
   settings: GlobalSettings
   createdWithAgent: CreateWorktreeArgs['createdWithAgent']
+  /** Runtime owns setup only when a completion observer needs to promote a seed. */
+  forceSetupProvision?: boolean
+  /** Seed-owned creates must materialize defaults before host authority short-circuits the renderer. */
+  materializeDefaultTabs?: boolean
+  onSetupCompleted?: (exitCode: number | null) => void | Promise<void>
 }): Promise<StagedStartupResult> {
-  const { runtime, worktree, startup, setup, defaultTabs, settings, createdWithAgent } = args
-  if (!runtime || !startup || defaultTabs?.tabs.length) {
+  const {
+    runtime,
+    worktree,
+    startup,
+    setup,
+    defaultTabs,
+    settings,
+    createdWithAgent,
+    forceSetupProvision = false,
+    materializeDefaultTabs = false
+  } = args
+  const shouldProvisionSetup = forceSetupProvision && Boolean(setup)
+  const shouldMaterializeDefaultTabs =
+    materializeDefaultTabs && Boolean(defaultTabs && defaultTabs.tabs.length > 0)
+  if (
+    !runtime ||
+    (!startup && !shouldProvisionSetup && !shouldMaterializeDefaultTabs) ||
+    (defaultTabs?.tabs.length && !shouldProvisionSetup && !shouldMaterializeDefaultTabs)
+  ) {
     return { didSpawnSetup: false }
   }
 
   let warning: string | undefined
   let startupTerminalHandle: string | null = null
   let startupTerminal: CreateWorktreeResult['startupTerminal']
+  let setupTerminalHandle: string | null = null
+  let defaultTabHandles: string[] = []
+  let didSpawnDefaultTabs = false
 
   let sequencedStartup = startup
   let wrappedSetupCommandStr: string | undefined
@@ -384,80 +420,147 @@ async function spawnLocalStartupAndSetupTerminals(args: {
     wrappedSetupCommandStr = sequenced.setupCommand
   }
 
-  try {
-    // Why: only after `git worktree add` + metadata registration is the path safe for a runtime PTY to boot the agent while setup runs alongside.
-    if (isTuiAgent(createdWithAgent)) {
-      const preset = TUI_AGENT_CONFIG[createdWithAgent].preflightTrust
-      try {
-        if (preset === 'cursor') {
-          markCursorWorkspaceTrusted(worktree.path)
-        } else if (preset === 'copilot') {
-          markCopilotFolderTrusted(worktree.path)
-        } else if (preset === 'codex') {
-          markCodexProjectTrusted(worktree.path)
+  if (startup && sequencedStartup) {
+    try {
+      // Why: only after `git worktree add` + metadata registration is the path safe for a runtime PTY to boot the agent while setup runs alongside.
+      if (isTuiAgent(createdWithAgent)) {
+        const preset = TUI_AGENT_CONFIG[createdWithAgent].preflightTrust
+        try {
+          if (preset === 'cursor') {
+            markCursorWorkspaceTrusted(worktree.path)
+          } else if (preset === 'copilot') {
+            markCopilotFolderTrusted(worktree.path)
+          } else if (preset === 'codex') {
+            markCodexProjectTrusted(worktree.path)
+          }
+        } catch {
+          // Best-effort: launch still proceeds and the agent can ask interactively.
         }
-      } catch {
-        // Best-effort: launch still proceeds and the agent can ask interactively.
+      }
+      const terminal = await runtime.createTerminal(`id:${worktree.id}`, {
+        command: sequencedStartup.command,
+        ...(setup ? { claudeAgentTeamsSourceCommand: startup.command } : {}),
+        env: sequencedStartup.env,
+        ...(sequencedStartup.launchConfig ? { launchConfig: sequencedStartup.launchConfig } : {}),
+        ...(isTuiAgent(createdWithAgent) ? { launchAgent: createdWithAgent } : {}),
+        ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
+        startupCommandDelivery: sequencedStartup.startupCommandDelivery,
+        telemetry: sequencedStartup.telemetry,
+        activate: true
+      })
+      startupTerminalHandle = terminal.handle
+      startupTerminal = {
+        spawned: true,
+        surface: terminal.surface
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      warning = `Failed to create the startup terminal for ${worktree.path}: ${message}`
+      console.warn(`[worktree-create] ${warning}`)
+      // A dependency-seed create still needs its setup runner observed even
+      // when the optional startup pane could not be spawned. Keep the normal
+      // path unchanged, but let force mode fall through to a standalone Setup
+      // tab so a successful install can promote the seed.
+      if (!forceSetupProvision) {
+        return { didSpawnSetup: false, warning }
       }
     }
-    const terminal = await runtime.createTerminal(`id:${worktree.id}`, {
-      command: sequencedStartup.command,
-      ...(setup ? { claudeAgentTeamsSourceCommand: startup.command } : {}),
-      env: sequencedStartup.env,
-      ...(sequencedStartup.launchConfig ? { launchConfig: sequencedStartup.launchConfig } : {}),
-      ...(isTuiAgent(createdWithAgent) ? { launchAgent: createdWithAgent } : {}),
-      ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
-      startupCommandDelivery: sequencedStartup.startupCommandDelivery,
-      telemetry: sequencedStartup.telemetry,
-      activate: true
-    })
-    startupTerminalHandle = terminal.handle
-    startupTerminal = {
-      spawned: true,
-      surface: terminal.surface
+  }
+
+  if (shouldMaterializeDefaultTabs && defaultTabs) {
+    // Claim ownership before the loop so a partial host spawn is not replayed
+    // by renderer activation as a second set of tabs.
+    didSpawnDefaultTabs = true
+    for (const template of defaultTabs.tabs) {
+      try {
+        const command = template.command?.trim()
+        const terminal = await runtime.createTerminal(`id:${worktree.id}`, {
+          ...(template.title ? { title: template.title } : {}),
+          ...(command && defaultTabs.runCommands ? { command } : {}),
+          activate: false
+        })
+        defaultTabHandles.push(terminal.handle)
+        if (template.color && terminal.tabId && runtime.setMobileSessionTabProps) {
+          await runtime.setMobileSessionTabProps(`id:${worktree.id}`, {
+            tabId: terminal.tabId,
+            color: template.color
+          })
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        warning = appendWorktreeCreateWarning(
+          warning,
+          `failed to create a default terminal for ${worktree.path}: ${message}`
+        )
+        console.warn(`[worktree-create] ${warning}`)
+      }
     }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    warning = `Failed to create the startup terminal for ${worktree.path}: ${message}`
-    console.warn(`[worktree-create] ${warning}`)
-    return { didSpawnSetup: false, warning }
   }
 
   let didSpawnSetup = false
   if (setup) {
     try {
+      const setupCommandPlatform = getSetupRunnerCommandPlatformForLaunch(
+        setup,
+        process.platform === 'win32' ? 'windows' : 'posix'
+      )
+      // A PTY's interactive shell survives a command's exit. Wrap setup with a
+      // completion marker whenever a caller needs the runner's actual status,
+      // including the wait-for-agent command that already embeds setup.
+      const completionToken = args.onSetupCompleted ? randomUUID() : undefined
+      const observedSetup = completionToken
+        ? buildObservedSetupCommand(
+            setup.runnerScriptPath,
+            setupCommandPlatform,
+            completionToken,
+            setup.shell,
+            wrappedSetupCommandStr
+          )
+        : undefined
       const setupCommand =
+        observedSetup?.command ??
         wrappedSetupCommandStr ??
-        buildSetupRunnerCommand(
-          setup.runnerScriptPath,
-          getSetupRunnerCommandPlatformForLaunch(
-            setup,
-            process.platform === 'win32' ? 'windows' : 'posix'
-          ),
-          setup.shell
-        )
+        buildSetupRunnerCommand(setup.runnerScriptPath, setupCommandPlatform, setup.shell)
+      const setupEnv = { ...setup.envVars, ...observedSetup?.env }
       const setupLaunchMode =
         (settings as Partial<Pick<GlobalSettings, 'setupScriptLaunchMode'>>)
           .setupScriptLaunchMode ?? 'new-tab'
-      if (setupLaunchMode === 'split-vertical' || setupLaunchMode === 'split-horizontal') {
-        if (!startupTerminalHandle) {
-          throw new Error('startup_terminal_missing')
-        }
-        await runtime.splitTerminal(startupTerminalHandle, {
-          direction: setupLaunchMode === 'split-horizontal' ? 'horizontal' : 'vertical',
-          command: setupCommand,
-          env: setup.envVars,
-          activate: false
-        })
+      if (
+        (setupLaunchMode === 'split-vertical' || setupLaunchMode === 'split-horizontal') &&
+        (startupTerminalHandle ?? defaultTabHandles[0])
+      ) {
+        const setupTerminal = await runtime.splitTerminal(
+          startupTerminalHandle ?? defaultTabHandles[0]!,
+          {
+            direction: setupLaunchMode === 'split-horizontal' ? 'horizontal' : 'vertical',
+            command: setupCommand,
+            env: setupEnv,
+            activate: false
+          }
+        )
+        setupTerminalHandle = setupTerminal.handle
       } else {
-        await runtime.createTerminal(`id:${worktree.id}`, {
+        // A seed-observing setup may be the only requested launch. Keep the
+        // setup visible without inventing a primary shell solely to split it.
+        const setupTerminal = await runtime.createTerminal(`id:${worktree.id}`, {
           title: 'Setup',
           command: setupCommand,
-          env: setup.envVars,
+          env: setupEnv,
           activate: false
         })
+        setupTerminalHandle = setupTerminal.handle
       }
       didSpawnSetup = true
+      if (args.onSetupCompleted && setupTerminalHandle) {
+        // Setup can outlive the create request; promotion must wait for the
+        // runner's actual exit status and must not delay workspace creation.
+        void runtime
+          .waitForSetupTerminalCompletion(setupTerminalHandle, completionToken)
+          .then(({ exitCode }) => args.onSetupCompleted?.(exitCode))
+          .catch((error) => {
+            console.warn('[worktree-create] setup completion observation failed:', error)
+          })
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       const nextWarning = `failed to create the setup terminal for ${worktree.path}: ${message}`
@@ -478,6 +581,8 @@ async function spawnLocalStartupAndSetupTerminals(args: {
         }
       : {}),
     ...(startupTerminal ? { startupTerminal } : {}),
+    ...(setupTerminalHandle ? { setupTerminalHandle } : {}),
+    ...(didSpawnDefaultTabs ? { didSpawnDefaultTabs } : {}),
     didSpawnSetup,
     ...(warning ? { warning } : {})
   }
@@ -2658,8 +2763,10 @@ export async function createLocalWorktree(
   // Why: the worktree's base-branch `orca.yaml` is authoritative; we don't re-gate on content parity with the primary checkout since benign divergence silently disabled setup (#1280).
   let setup: CreateWorktreeResult['setup']
   let defaultTabs: CreateWorktreeResult['defaultTabs']
+  let createdYamlHooks: ReturnType<typeof loadHooks> = null
+  let setupScriptForDependencySeed: string | undefined
   await timing.time('prepare_setup', async () => {
-    const createdYamlHooks = loadHooks(worktreePath)
+    createdYamlHooks = loadHooks(worktreePath)
     const createdEffectiveHooks = getEffectiveHooksFromConfig(repo, createdYamlHooks)
     try {
       defaultTabs = getDefaultTabsLaunch(createdYamlHooks, repo, args.setupDecision)
@@ -2671,6 +2778,7 @@ export async function createLocalWorktree(
         : undefined
     }
     const setupScript = createdEffectiveHooks?.scripts.setup
+    setupScriptForDependencySeed = setupScript
     let shouldLaunchSetup = false
     if (setupScript) {
       try {
@@ -2698,17 +2806,101 @@ export async function createLocalWorktree(
     }
   })
 
+  // Hydrate only when this create is about to run the setup hook. A seed is a
+  // post-setup snapshot, so using it for a skipped hook could hide required
+  // project initialization. The target checkout owns the lockfile bytes.
+  let dependencySeedArgs: WorktreeDependencySeedArgs | null = null
+  if (
+    runtime &&
+    setup &&
+    setupScriptForDependencySeed &&
+    (process.platform === 'darwin' || process.platform === 'linux')
+  ) {
+    const dependencySeedPlan = resolveWorktreeDependencySeedPlan(createdYamlHooks)
+    if (dependencySeedPlan.paths.length > 0) {
+      try {
+        const lockfiles = await readWorktreeDependencySeedInputs(
+          worktreePath,
+          dependencySeedPlan.fingerprintPaths
+        )
+        // A seed without a reproducible input is intentionally disabled. This
+        // also keeps normal setup provisioning unchanged when no lockfile exists.
+        if (lockfiles.length > 0) {
+          dependencySeedArgs = {
+            repo,
+            worktreePath,
+            setupScript: setupScriptForDependencySeed,
+            declaredSeedPaths: dependencySeedPlan.paths,
+            lockfiles,
+            allowRuntimeExecutionHost: Boolean(runtime)
+          }
+          const hydration = await timing.time('hydrate_dependency_seed', () =>
+            hydrateWorktreeDependencies(dependencySeedArgs!)
+          )
+          if (hydration.status === 'failed' || hydration.status === 'skipped') {
+            console.warn(`[worktree-create] dependency seed hydration failed for ${worktreePath}`)
+            dependencySeedArgs = null
+          }
+        }
+      } catch (error) {
+        // Seeding is an optimization; never make a real worktree create fail.
+        console.warn(
+          `[worktree-create] dependency seed hydration skipped for ${worktreePath}:`,
+          error
+        )
+        dependencySeedArgs = null
+      }
+    }
+  }
+
+  const promoteDependencySeedAfterSetup = async (exitCode: number | null): Promise<void> => {
+    if (exitCode !== 0 || !dependencySeedArgs) {
+      return
+    }
+    try {
+      const plan = resolveWorktreeDependencySeedPlan(createdYamlHooks)
+      const lockfiles = await readWorktreeDependencySeedInputs(worktreePath, plan.fingerprintPaths)
+      const promotion = await promoteWorktreeDependencySeed({
+        ...dependencySeedArgs,
+        lockfiles
+      })
+      if (promotion.status === 'failed') {
+        console.warn(`[worktree-create] dependency seed promotion failed for ${worktreePath}`)
+      }
+    } catch (error) {
+      console.warn(
+        `[worktree-create] dependency seed promotion skipped for ${worktreePath}:`,
+        error
+      )
+    }
+  }
+
   const stagedStartup = await timing.time('spawn_startup_terminal', () =>
     spawnLocalStartupAndSetupTerminals({
       runtime,
       worktree,
       startup: args.startup,
       setup,
+      // Seed-owned creates must materialize defaults alongside the host-owned
+      // setup pane; renderer host authority otherwise short-circuits them.
       defaultTabs,
       settings,
-      createdWithAgent: args.createdWithAgent
+      createdWithAgent: args.createdWithAgent,
+      ...(dependencySeedArgs
+        ? {
+            forceSetupProvision: true,
+            materializeDefaultTabs: true,
+            onSetupCompleted: promoteDependencySeedAfterSetup
+          }
+        : {})
     })
   )
+  // If setup provisioning failed, the renderer may retry the returned setup
+  // descriptor, but it cannot carry this host-owned promotion callback.
+  // Disable seed ownership rather than leaving a callback armed forever.
+  if (dependencySeedArgs && !stagedStartup.didSpawnSetup) {
+    dependencySeedArgs = null
+  }
 
   notifyWorktreesChanged(mainWindow, repo.id)
   return {
@@ -2726,7 +2918,7 @@ export async function createLocalWorktree(
       : setup && !stagedStartup.didSpawnSetup
         ? { setup }
         : {}),
-    ...(defaultTabs ? { defaultTabs } : {}),
+    ...(defaultTabs && !stagedStartup.didSpawnDefaultTabs ? { defaultTabs } : {}),
     ...(addResult.localBaseRefRefresh
       ? { localBaseRefRefresh: addResult.localBaseRefRefresh }
       : {}),

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -468,9 +468,6 @@ export async function spawnLocalStartupAndSetupTerminals(args: {
   }
 
   if (shouldMaterializeDefaultTabs && defaultTabs) {
-    // Claim ownership before the loop so a partial host spawn is not replayed
-    // by renderer activation as a second set of tabs.
-    didSpawnDefaultTabs = true
     for (const template of defaultTabs.tabs) {
       try {
         const command = template.command?.trim()
@@ -495,6 +492,9 @@ export async function spawnLocalStartupAndSetupTerminals(args: {
         console.warn(`[worktree-create] ${warning}`)
       }
     }
+    // Suppress renderer replay only when at least one host tab exists. If all
+    // attempts failed, keep the descriptor available for a renderer retry.
+    didSpawnDefaultTabs = defaultTabHandles.length > 0
   }
 
   let didSpawnSetup = false

--- a/src/main/ipc/worktrees-test-runtime-stub.ts
+++ b/src/main/ipc/worktrees-test-runtime-stub.ts
@@ -13,6 +13,8 @@ export type WorktreeRuntimeStub = {
   resolveManagedMrBase: ReturnType<typeof vi.fn>
   createTerminal: ReturnType<typeof vi.fn>
   splitTerminal: ReturnType<typeof vi.fn>
+  setMobileSessionTabProps: ReturnType<typeof vi.fn>
+  waitForSetupTerminalCompletion: ReturnType<typeof vi.fn>
   notifyWorktreesChangedForRemoteClients: ReturnType<typeof vi.fn>
   closeFileWatchersForRemoval: ReturnType<typeof vi.fn>
   acquireFileWatcherRemoval: ReturnType<typeof vi.fn>
@@ -43,6 +45,8 @@ export function createWorktreeRuntimeStub(): WorktreeRuntimeStub {
       tabId: 'tab-startup',
       paneRuntimeId: -1
     }),
+    setMobileSessionTabProps: vi.fn().mockResolvedValue({ updated: true }),
+    waitForSetupTerminalCompletion: vi.fn().mockResolvedValue({ exitCode: 0 }),
     notifyWorktreesChangedForRemoteClients: vi.fn(),
     closeFileWatchersForRemoval: vi.fn().mockResolvedValue(undefined),
     acquireFileWatcherRemoval: vi.fn(),

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -53,6 +53,7 @@ import {
 import { clearSubmodulePathsCacheForTests, listSubmodulePaths } from '../git/status'
 import { getEffectiveHooks, hasHooksFile, loadHooks, parseOrcaYaml, runHook } from '../hooks'
 import { createSetupRunnerScript, resolveSetupRunnerShell } from '../worktree-runner-script'
+import * as worktreeDependencySeed from '../worktree-dependency-seed'
 import {
   getEffectiveHooksFromConfig,
   getDefaultTabsLaunch,
@@ -46666,6 +46667,114 @@ describe('OrcaRuntimeService', () => {
       result.worktree.id,
       expect.objectContaining({ title: 'Test', activate: false })
     )
+  })
+
+  it('omits host-materialized defaults from seeded local runtime results', async () => {
+    setPlatform('darwin')
+    const metaById: Record<string, WorktreeMeta> = {}
+    const runtimeStore = {
+      ...store,
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const spawn = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 'pty-seeded-default' })
+      .mockResolvedValueOnce({ id: 'pty-seeded-setup' })
+    const revealTerminalSession = vi.fn().mockResolvedValue({ tabId: 'tab-seeded' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession,
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-seeded-default-tabs')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-seeded-default-tabs')
+    vi.mocked(loadHooks).mockReturnValue({
+      scripts: { setup: 'pnpm install' },
+      worktree: {
+        dependencySeedPaths: ['node_modules'],
+        dependencySeedInputs: ['package-lock.json']
+      }
+    })
+    vi.mocked(getEffectiveHooks).mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    vi.mocked(getDefaultTabsLaunch).mockReturnValue({
+      runCommands: true,
+      tabs: [{ title: 'Dev', command: 'pnpm dev' }]
+    })
+    vi.mocked(shouldRunSetupForCreate).mockReturnValue(true)
+    vi.mocked(createSetupRunnerScript).mockReturnValue({
+      runnerScriptPath: '/tmp/repo/.git/orca/setup-runner.sh',
+      envVars: {
+        ORCA_ROOT_PATH: '/tmp/repo',
+        ORCA_WORKTREE_PATH: '/tmp/workspaces/runtime-seeded-default-tabs'
+      }
+    })
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-seeded-default-tabs',
+        head: 'def',
+        branch: 'runtime-seeded-default-tabs',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const readInputsSpy = vi
+      .spyOn(worktreeDependencySeed, 'readWorktreeDependencySeedInputs')
+      .mockResolvedValue([{ path: 'package-lock.json', bytes: '{}' }])
+    const hydrateSpy = vi
+      .spyOn(worktreeDependencySeed, 'hydrateWorktreeDependencies')
+      .mockResolvedValue({ status: 'miss', paths: [] })
+    const promoteSpy = vi
+      .spyOn(worktreeDependencySeed, 'promoteWorktreeDependencySeed')
+      .mockResolvedValue({ status: 'promoted', paths: [] })
+    const waitForSetupSpy = vi
+      .spyOn(runtime, 'waitForSetupTerminalCompletion')
+      .mockResolvedValue({ exitCode: null })
+    onTestFinished(() => {
+      readInputsSpy.mockRestore()
+      hydrateSpy.mockRestore()
+      promoteSpy.mockRestore()
+      waitForSetupSpy.mockRestore()
+    })
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'runtime-seeded-default-tabs',
+      setupDecision: 'run'
+    })
+
+    expect(result).not.toHaveProperty('defaultTabs')
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2))
+    expect(spawn.mock.calls[0]![0]).toMatchObject({ command: 'pnpm dev' })
+    expect(spawn.mock.calls[1]![0]).toMatchObject({
+      command: expect.stringContaining('bash /tmp/repo/.git/orca/setup-runner.sh')
+    })
+    expect(hydrateSpy).toHaveBeenCalledTimes(1)
+    expect(readInputsSpy).toHaveBeenCalledTimes(1)
+    expect(promoteSpy).not.toHaveBeenCalled()
   })
 
   it('uses desktop task agent selection and bracketed-pastes startup drafts for local worktrees', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16653,6 +16653,28 @@ describe('OrcaRuntimeService', () => {
     await expect(runtime.readTerminal(handle)).resolves.toMatchObject({ status: 'running' })
   })
 
+  it('honors an explicit completion token without deleting another observer token', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-setup-override' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    const tokens = (runtime as unknown as { setupCompletionTokenByPtyId: Map<string, string> })
+      .setupCompletionTokenByPtyId
+    tokens.set('pty-setup-override', 'token-next-observer')
+
+    const waiting = runtime.waitForSetupTerminalCompletion(handle, 'token-explicit')
+    runtime.onPtyData('pty-setup-override', '__ORCA_SETUP_COMPLETE__:token-explicit:0\r\n$', 100)
+
+    await expect(waiting).resolves.toEqual({ exitCode: 0 })
+    expect(tokens.get('pty-setup-override')).toBe('token-next-observer')
+  })
+
   it('replays fast setup completion emitted before its observer is registered', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({
@@ -16692,6 +16714,64 @@ describe('OrcaRuntimeService', () => {
     runtime.onPtyExit('pty-legacy-setup', 9)
 
     await expect(waiting).resolves.toEqual({ exitCode: 9 })
+  })
+
+  it('observes wrapped setup command exit callbacks', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-wrapped-setup' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    const onSetupCompleted = vi.fn()
+    const provision = (
+      runtime as unknown as {
+        provisionManagedWorktreeTerminals: (args: {
+          worktreeSelector: string
+          worktreeId: string
+          worktreePath: string
+          setup: {
+            runnerScriptPath: string
+            envVars: Record<string, string>
+          }
+          hasStartupTerminal: boolean
+          setupCommandPlatform: 'windows' | 'posix'
+          onSetupCompleted: (exitCode: number | null) => void | Promise<void>
+          wrappedSetupCommand: string
+        }) => Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null }>
+      }
+    ).provisionManagedWorktreeTerminals({
+      worktreeSelector: `path:${TEST_WORKTREE_PATH}`,
+      worktreeId: TEST_WORKTREE_ID,
+      worktreePath: TEST_WORKTREE_PATH,
+      setup: {
+        runnerScriptPath: '/tmp/repo/.git/orca/setup-runner.sh',
+        envVars: {}
+      },
+      // The startup terminal already exists; only the wrapped setup runner is
+      // materialized here, matching the wait-for-agent-startup path.
+      hasStartupTerminal: true,
+      setupCommandPlatform: 'posix',
+      onSetupCompleted,
+      wrappedSetupCommand: 'bash /tmp/repo/.git/orca/setup-runner.sh'
+    })
+
+    const result = await provision
+    expect(result.setupSpawned).toBe(true)
+    expect(spawn).toHaveBeenCalledTimes(1)
+
+    const setupCommand = (spawn.mock.calls[0]![0] as { command: string }).command
+    const completionToken = setupCommand.match(/__ORCA_SETUP_COMPLETE__:([^:]+):%s\\n/)?.[1]
+    expect(completionToken).toEqual(expect.any(String))
+    runtime.onPtyData(
+      'pty-wrapped-setup',
+      `__ORCA_SETUP_COMPLETE__:${completionToken}:0\r\nPS>`,
+      100
+    )
+    await vi.waitFor(() => expect(onSetupCompleted).toHaveBeenCalledWith(0))
   })
 
   it('keeps observing after an uncertain setup terminal status', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -26381,14 +26381,23 @@ export class OrcaRuntimeService {
     // Why: a workspace provisioned in the background must not pull the sidebar
     // to itself; the user never asked to look at these tabs.
     surfaceOwner?: false
-  }): Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null }> {
+  }): Promise<{
+    setupSpawned: boolean
+    setupTerminalHandle: string | null
+    /** True when this call claimed and attempted to materialize default tabs. */
+    didSpawnDefaultTabs: boolean
+  }> {
     if (!this.ptyController?.spawn) {
-      return { setupSpawned: false, setupTerminalHandle: null }
+      return { setupSpawned: false, setupTerminalHandle: null, didSpawnDefaultTabs: false }
     }
     const surfacing = ownerSurfacing(args.surfaceOwner !== false)
     let setupSpawned = false
     let setupTerminalHandle: string | null = null
+    let didSpawnDefaultTabs = false
     try {
+      // Claim ownership before the loop so a partial host spawn is not replayed
+      // by renderer activation as a second set of tabs.
+      didSpawnDefaultTabs = Boolean(args.defaultTabs && args.defaultTabs.tabs.length > 0)
       const defaultTabHandles = await this.createDefaultTabTerminals(
         args.worktreeSelector,
         args.worktreeId,
@@ -26473,7 +26482,7 @@ export class OrcaRuntimeService {
         `[worktree-create] Failed to create setup/default terminals for ${args.worktreePath}: ${message}`
       )
     }
-    return { setupSpawned, setupTerminalHandle }
+    return { setupSpawned, setupTerminalHandle, didSpawnDefaultTabs }
   }
 
   private async waitForStartupFollowupReady(
@@ -27609,6 +27618,7 @@ export class OrcaRuntimeService {
     // RPC return value must omit setup so the client does not spawn it a second
     // time. Mirrors the wait-for-agent setup contract from #6298.
     let didSpawnSetup = false
+    let didSpawnDefaultTabs = false
     let setupTerminalHandle: string | null = null
     let startupTerminalHandle: string | null = null
     let startupTerminalTabId: string | null = null
@@ -27717,6 +27727,7 @@ export class OrcaRuntimeService {
           ...(wrappedSetupCommandStr ? { wrappedSetupCommand: wrappedSetupCommandStr } : {})
         })
         didSpawnSetup = provisioned.setupSpawned
+        didSpawnDefaultTabs = provisioned.didSpawnDefaultTabs
         setupTerminalHandle = provisioned.setupTerminalHandle
         if (dependencySeedArgs && !didSpawnSetup) {
           // Renderer activation can retry the setup descriptor, but cannot
@@ -27782,6 +27793,7 @@ export class OrcaRuntimeService {
       if (args.awaitTerminalProvisioning || Boolean(dependencySeedArgs)) {
         const provisioned = await provisioning
         didSpawnSetup = provisioned.setupSpawned
+        didSpawnDefaultTabs = provisioned.didSpawnDefaultTabs
         setupTerminalHandle = provisioned.setupTerminalHandle
         if (dependencySeedArgs && !didSpawnSetup) {
           // A failed seed-owned spawn must fail open to ordinary setup retry;
@@ -27853,7 +27865,7 @@ export class OrcaRuntimeService {
             }
           }
         : {}),
-      ...(defaultTabs ? { defaultTabs } : {}),
+      ...(defaultTabs && !(forceSeedSetup && didSpawnDefaultTabs) ? { defaultTabs } : {}),
       ...(warning ? { warning } : {}),
       ...(addResult.localBaseRefRefresh
         ? { localBaseRefRefresh: addResult.localBaseRefRefresh }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -26395,15 +26395,15 @@ export class OrcaRuntimeService {
     let setupTerminalHandle: string | null = null
     let didSpawnDefaultTabs = false
     try {
-      // Claim ownership before the loop so a partial host spawn is not replayed
-      // by renderer activation as a second set of tabs.
-      didSpawnDefaultTabs = Boolean(args.defaultTabs && args.defaultTabs.tabs.length > 0)
       const defaultTabHandles = await this.createDefaultTabTerminals(
         args.worktreeSelector,
         args.worktreeId,
         args.defaultTabs,
         surfacing
       )
+      // Host owns replay suppression only after at least one tab exists. A
+      // completely failed loop must leave the descriptor available for retry.
+      didSpawnDefaultTabs = defaultTabHandles.length > 0
       let primaryTerminalHandle = args.primaryTerminalHandle ?? defaultTabHandles[0] ?? null
       const setupLaunchMode =
         (
@@ -27749,7 +27749,11 @@ export class OrcaRuntimeService {
             }
           : undefined
       const activationDefaultTabs =
-        runtimeWillProvisionTerminals && runtimeOwnsDefaultTabs ? undefined : defaultTabs
+        runtimeWillProvisionTerminals &&
+        runtimeOwnsDefaultTabs &&
+        (!defaultTabs || didSpawnDefaultTabs)
+          ? undefined
+          : defaultTabs
       if (effectiveStartup && !didSpawnStartup) {
         this.notifyActivateWorktree(repo.id, worktree.id, {
           setup: activationSetup,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1179,6 +1179,13 @@ import {
   getEffectiveSetupRunPolicy,
   shouldRunSetupForCreate
 } from '../effective-hook-config'
+import {
+  hydrateWorktreeDependencies,
+  promoteWorktreeDependencySeed,
+  readWorktreeDependencySeedInputs,
+  type WorktreeDependencySeedArgs
+} from '../worktree-dependency-seed'
+import { resolveWorktreeDependencySeedPlan } from '../worktree-dependency-seed-plan'
 import { readIssueCommand, writeIssueCommand } from '../issue-command-file'
 import {
   DEFAULT_REPO_BADGE_COLOR,
@@ -22112,12 +22119,15 @@ export class OrcaRuntimeService {
     return unsubscribe
   }
 
-  async waitForSetupTerminalCompletion(handle: string): Promise<{ exitCode: number | null }> {
+  async waitForSetupTerminalCompletion(
+    handle: string,
+    completionTokenOverride?: string
+  ): Promise<{ exitCode: number | null }> {
     const ptyId = this.getLivePtyForHandle(handle)?.pty.ptyId
     if (!ptyId) {
       throw new Error('terminal_handle_stale')
     }
-    const completionToken = this.setupCompletionTokenByPtyId.get(ptyId)
+    const completionToken = completionTokenOverride ?? this.setupCompletionTokenByPtyId.get(ptyId)
     const exitAbort = new AbortController()
     return await new Promise<{ exitCode: number | null }>((resolve, reject) => {
       let settled = false
@@ -22132,7 +22142,9 @@ export class OrcaRuntimeService {
         }
         settled = true
         cleanup()
-        this.setupCompletionTokenByPtyId.delete(ptyId)
+        if (this.setupCompletionTokenByPtyId.get(ptyId) === completionToken) {
+          this.setupCompletionTokenByPtyId.delete(ptyId)
+        }
         resolve({ exitCode })
       }
       const fail = (error: unknown): void => {
@@ -26357,6 +26369,10 @@ export class OrcaRuntimeService {
     hasStartupTerminal: boolean
     setupCommandPlatform: 'windows' | 'posix'
     observeSetupCompletion?: boolean
+    /** Promote a dependency seed after this setup terminal exits successfully. */
+    onSetupCompleted?: (exitCode: number | null) => void | Promise<void>
+    /** Seed-only setup can run in its own tab without inventing a shell pane. */
+    avoidPrimaryTerminal?: boolean
     // Why: when the agent startup is sequenced to wait for setup
     // (waitForAgentStartup), the startup PTY runs a wrapper that already embeds
     // the setup command. Pass that wrapped command through so the Setup tab runs
@@ -26386,24 +26402,29 @@ export class OrcaRuntimeService {
             Pick<GlobalSettings, 'setupScriptLaunchMode'>
           >
         ).setupScriptLaunchMode ?? 'new-tab'
-      if (!args.hasStartupTerminal && !primaryTerminalHandle) {
+      if (
+        !args.hasStartupTerminal &&
+        !primaryTerminalHandle &&
+        args.avoidPrimaryTerminal !== true
+      ) {
         const terminal = await this.createTerminal(args.worktreeSelector, surfacing)
         primaryTerminalHandle = terminal.handle
       }
       if (args.setup) {
         const completionToken =
-          args.observeSetupCompletion && !args.wrappedSetupCommand ? randomUUID() : null
+          args.observeSetupCompletion || args.onSetupCompleted ? randomUUID() : null
         const observedCommand = completionToken
           ? buildObservedSetupCommand(
               args.setup.runnerScriptPath,
               args.setupCommandPlatform,
               completionToken,
-              args.setup.shell
+              args.setup.shell,
+              args.wrappedSetupCommand
             )
           : null
         const setupCommand =
-          args.wrappedSetupCommand ??
           observedCommand?.command ??
+          args.wrappedSetupCommand ??
           buildSetupRunnerCommand(
             args.setup.runnerScriptPath,
             args.setupCommandPlatform,
@@ -26432,6 +26453,18 @@ export class OrcaRuntimeService {
         const ptyId = this.getLivePtyForHandle(setupTerminal.handle)?.pty.ptyId
         if (completionToken && ptyId) {
           this.setupCompletionTokenByPtyId.set(ptyId, completionToken)
+        }
+        if (args.onSetupCompleted) {
+          // Setup can take minutes; keep terminal provisioning responsive while
+          // promoting only after the runner reports a successful exit.
+          void this.waitForSetupTerminalCompletion(
+            setupTerminal.handle,
+            completionToken ?? undefined
+          )
+            .then(({ exitCode }) => args.onSetupCompleted?.(exitCode))
+            .catch((error) => {
+              console.warn('[worktree-create] setup completion observation failed:', error)
+            })
         }
       }
     } catch (err) {
@@ -27419,6 +27452,77 @@ export class OrcaRuntimeService {
         : undefined
     }
     const shouldRunSetup = hooks?.scripts.setup && shouldRunSetupForCreate(repo, effectiveDecision)
+    // Dependency seeds are opt-in through the setup hook's successful run. The
+    // default path keeps the common Node workspace fast, while an explicit
+    // empty list in orca.yaml disables seeding for a project.
+    // Copy-on-write seeds are implemented only by the local Darwin/Linux
+    // clone backends. Avoid even reading lockfiles or resolving seed config on
+    // unsupported hosts (notably Windows and remote-only runtime paths).
+    const dependencySeedPlan =
+      process.platform === 'darwin' || process.platform === 'linux'
+        ? resolveWorktreeDependencySeedPlan(yamlHooks)
+        : null
+    const dependencySeedPaths = dependencySeedPlan?.paths ?? []
+    const dependencySeedInputPaths = dependencySeedPlan?.fingerprintPaths
+    let dependencySeedArgs: WorktreeDependencySeedArgs | null = null
+    if (
+      dependencySeedPlan &&
+      shouldRunSetup &&
+      hooks?.scripts.setup &&
+      dependencySeedPaths.length > 0
+    ) {
+      try {
+        // Read from the target branch: its lockfiles may differ from the
+        // primary checkout used to resolve the worktree.
+        const lockfiles = await readWorktreeDependencySeedInputs(
+          worktreePath,
+          dependencySeedInputPaths
+        )
+        // A seed without a reproducible input is intentionally disabled. Keep
+        // ordinary setup/terminal ownership unchanged for repos without a lockfile.
+        if (lockfiles.length > 0) {
+          dependencySeedArgs = {
+            repo,
+            worktreePath,
+            setupScript: hooks.scripts.setup,
+            declaredSeedPaths: dependencySeedPaths,
+            lockfiles,
+            allowRuntimeExecutionHost: true
+          }
+          const hydration = await hydrateWorktreeDependencies(dependencySeedArgs)
+          if (hydration.status === 'failed' || hydration.status === 'skipped') {
+            console.warn(`[worktree-create] dependency seed hydration failed for ${worktreePath}`)
+            dependencySeedArgs = null
+          }
+        }
+      } catch (error) {
+        // Seeding is an optimization; never make a real worktree create fail.
+        console.warn(
+          `[worktree-create] dependency seed hydration skipped for ${worktreePath}:`,
+          error
+        )
+        dependencySeedArgs = null
+      }
+    }
+    const promoteDependencySeedAfterSetup = async (exitCode: number | null): Promise<void> => {
+      if (exitCode !== 0 || !dependencySeedArgs) {
+        return
+      }
+      // A setup hook may update its lockfile (for example, an explicitly
+      // unlocked package-manager install). Re-read the target snapshot so the
+      // published tree and marker describe the same final state.
+      const promotionInputs = await readWorktreeDependencySeedInputs(
+        worktreePath,
+        dependencySeedInputPaths
+      )
+      const promotion = await promoteWorktreeDependencySeed({
+        ...dependencySeedArgs,
+        lockfiles: promotionInputs
+      })
+      if (promotion.status === 'failed') {
+        console.warn(`[worktree-create] dependency seed promotion failed for ${worktreePath}`)
+      }
+    }
     // Why: the in-process hook uses a hardcoded cmd/bash shell, so it can only run
     // when nothing downstream is able to launch the shell-aware runner script.
     let didStartInProcessSetupHook = false
@@ -27446,6 +27550,11 @@ export class OrcaRuntimeService {
           // generation fails, keep creation successful and surface the problem in
           // logs rather than pretending the worktree was never created.
           console.error(`[hooks] Failed to prepare setup runner for ${worktreePath}:`, error)
+          // Hydration may have completed before runner generation. Without a
+          // runner there is no setup terminal to observe, so do not leave a
+          // seed context armed for a promotion that can never be tied to a
+          // successful setup run.
+          dependencySeedArgs = null
         }
       } else {
         didStartInProcessSetupHook = true
@@ -27455,11 +27564,22 @@ export class OrcaRuntimeService {
           repo,
           worktreePath,
           this.getLocalGitExecutionOptionArgs(repo)[0]
-        ).then((result) => {
-          if (!result.success) {
-            console.error(`[hooks] setup hook failed for ${worktreePath}:`, result.output)
-          }
-        })
+        )
+          .then((result) => {
+            if (!result.success) {
+              console.error(`[hooks] setup hook failed for ${worktreePath}:`, result.output)
+              return
+            }
+            void promoteDependencySeedAfterSetup(0).catch((error) => {
+              console.warn(
+                `[worktree-create] dependency seed promotion skipped for ${worktreePath}:`,
+                error
+              )
+            })
+          })
+          .catch((error) => {
+            console.error(`[hooks] setup hook failed for ${worktreePath}:`, error)
+          })
       }
     } else if (hooks?.scripts.setup && effectiveDecision !== 'skip') {
       // Runtime RPC calls have no renderer trust prompt, so hooks require explicit CLI opt-in.
@@ -27479,6 +27599,10 @@ export class OrcaRuntimeService {
 
     this.notifyWorktreesChanged(repo.id)
     const shouldActivate = args.activate === true || args.runHooks === true
+    // A seed is promoted only after a runtime-owned setup terminal exits. This
+    // remains true for an explicitly activated create that has no startup
+    // command (or whose startup pane failed to spawn).
+    const forceSeedSetup = Boolean(dependencySeedArgs && setup)
     let didSpawnStartup = false
     // Why: tracks whether runtime itself launched the setup script (via
     // provisionManagedWorktreeTerminals). When true, renderer activation and the
@@ -27559,7 +27683,15 @@ export class OrcaRuntimeService {
       // Why: plain CLI creates should not steal the user's current workspace.
       // Explicit activation and hook-running still use renderer activation so
       // the user can watch prompts/output in a visible pane.
-      const runtimeWillProvisionTerminals = didSpawnStartup && Boolean(setup || defaultTabs)
+      // A dependency seed needs a host-owned completion callback even when the
+      // caller explicitly activates a create without a startup command. In that
+      // case provision setup here so renderer activation cannot lose promotion.
+      const runtimeWillProvisionTerminals =
+        (didSpawnStartup && Boolean(setup || defaultTabs)) || forceSeedSetup
+      // Once runtime is provisioning any terminal for this create, let it own
+      // default tabs too; renderer activation can be short-circuited by host
+      // authority and would otherwise drop them on seeded creates.
+      const runtimeOwnsDefaultTabs = runtimeWillProvisionTerminals
       if (runtimeWillProvisionTerminals) {
         // Why: once runtime spawned the startup PTY, renderer activation may see
         // an existing terminal and skip setup/default tabs. Await provisioning so
@@ -27571,17 +27703,26 @@ export class OrcaRuntimeService {
           worktreeId: worktree.id,
           worktreePath,
           ...(setup ? { setup } : {}),
-          ...(defaultTabs ? { defaultTabs } : {}),
+          ...(defaultTabs && runtimeOwnsDefaultTabs ? { defaultTabs } : {}),
           primaryTerminalHandle: startupTerminalHandle,
           hasStartupTerminal: didSpawnStartup,
           setupCommandPlatform: getSetupRunnerCommandPlatformForLaunch(setup, 'posix'),
           observeSetupCompletion: args.observeSetupCompletion,
+          ...(setup && dependencySeedArgs
+            ? { onSetupCompleted: promoteDependencySeedAfterSetup }
+            : {}),
+          ...(forceSeedSetup ? { avoidPrimaryTerminal: true } : {}),
           // Why: carry the wait-for-agent wrapped setup command (#6298) so the
           // Setup tab runs the same script the sequenced agent waits on.
           ...(wrappedSetupCommandStr ? { wrappedSetupCommand: wrappedSetupCommandStr } : {})
         })
         didSpawnSetup = provisioned.setupSpawned
         setupTerminalHandle = provisioned.setupTerminalHandle
+        if (dependencySeedArgs && !didSpawnSetup) {
+          // Renderer activation can retry the setup descriptor, but cannot
+          // recover this host-owned promotion callback.
+          dependencySeedArgs = null
+        }
       }
       // Why: when runtime spawned setup, omit it from activation. When setup
       // spawn failed, fall through with the wrapped command so renderer
@@ -27596,7 +27737,8 @@ export class OrcaRuntimeService {
                 : {})
             }
           : undefined
-      const activationDefaultTabs = runtimeWillProvisionTerminals ? undefined : defaultTabs
+      const activationDefaultTabs =
+        runtimeWillProvisionTerminals && runtimeOwnsDefaultTabs ? undefined : defaultTabs
       if (effectiveStartup && !didSpawnStartup) {
         this.notifyActivateWorktree(repo.id, worktree.id, {
           setup: activationSetup,
@@ -27624,15 +27766,28 @@ export class OrcaRuntimeService {
         hasStartupTerminal: didSpawnStartup,
         setupCommandPlatform: getSetupRunnerCommandPlatformForLaunch(setup, 'posix'),
         observeSetupCompletion: args.observeSetupCompletion,
+        ...(setup && dependencySeedArgs
+          ? { onSetupCompleted: promoteDependencySeedAfterSetup }
+          : {}),
+        ...(forceSeedSetup ? { avoidPrimaryTerminal: true } : {}),
         ...(wrappedSetupCommandStr ? { wrappedSetupCommand: wrappedSetupCommandStr } : {}),
         surfaceOwner: false
       })
       // Why: runtime owns setup spawning here, so the RPC result must omit setup
       // to keep the headless/mobile caller from launching it a second time.
-      if (args.awaitTerminalProvisioning) {
+      // A dependency seed needs reliable spawn evidence and a completion
+      // observer. Await this path even for background creates so a failed
+      // setup spawn is returned to the renderer for retry instead of being
+      // reported as runtime-owned.
+      if (args.awaitTerminalProvisioning || Boolean(dependencySeedArgs)) {
         const provisioned = await provisioning
         didSpawnSetup = provisioned.setupSpawned
         setupTerminalHandle = provisioned.setupTerminalHandle
+        if (dependencySeedArgs && !didSpawnSetup) {
+          // A failed seed-owned spawn must fail open to ordinary setup retry;
+          // do not retain a promotion callback that no longer has an owner.
+          dependencySeedArgs = null
+        }
       } else {
         void provisioning
         if (setup) {

--- a/src/main/runtime/orchestration/setup-completion-signal.test.ts
+++ b/src/main/runtime/orchestration/setup-completion-signal.test.ts
@@ -77,6 +77,20 @@ describe('orchestration setup completion signal', () => {
     expect(observed.env).toEqual({ ORCA_SETUP_RUNNER_PATH: runnerPath })
   })
 
+  it('observes an already-wrapped POSIX setup command', () => {
+    const { command } = buildObservedSetupCommand(
+      '/repo/.git/orca/setup-runner.sh',
+      'posix',
+      'token-wrapped',
+      undefined,
+      `bash -lc 'touch "$PWD/.setup-ready"; exit 23'`
+    )
+
+    expect(command).toContain('touch "$PWD/.setup-ready"')
+    expect(command).toContain('__ORCA_SETUP_COMPLETE__:token-wrapped:%s\\n')
+    expect(command).toContain('exit "$status"')
+  })
+
   it('recognizes one completion signal across output chunk boundaries', () => {
     const onComplete = vi.fn()
     const scanner = createSetupCompletionScanner('token-chunks', onComplete)

--- a/src/main/runtime/orchestration/setup-completion-signal.ts
+++ b/src/main/runtime/orchestration/setup-completion-signal.ts
@@ -14,13 +14,18 @@ export function buildObservedSetupCommand(
   completionToken: string,
   // Why: the observed command must reuse the shell the runner was written for, or a
   // WSL-routed Windows-drive runner gets Git Bash `/c/...` instead of `/mnt/c/...`.
-  shell?: SetupRunnerShell
+  shell?: SetupRunnerShell,
+  /** Wrap an already-gated setup command (for wait-for-agent-startup). */
+  commandOverride?: string
 ): { command: string; env?: Record<string, string> } {
   const resolution = resolveSetupRunnerCommand(runnerScriptPath, platform, shell)
   if (resolution.shell === 'windows') {
+    const invocation = commandOverride
+      ? `Invoke-Expression ${quotePowerShellString(commandOverride)}`
+      : '& $runner'
     const script = [
-      `$runner = $env:${WINDOWS_SETUP_RUNNER_ENV}`,
-      '& $runner',
+      ...(commandOverride ? [] : [`$runner = $env:${WINDOWS_SETUP_RUNNER_ENV}`]),
+      invocation,
       '$succeeded = $?',
       '$status = $LASTEXITCODE',
       'if ($null -eq $status) { $status = if ($succeeded) { 0 } else { 1 } }',
@@ -32,12 +37,15 @@ export function buildObservedSetupCommand(
         script,
         'utf16le'
       ).toString('base64')}`,
-      env: { [WINDOWS_SETUP_RUNNER_ENV]: resolution.runnerScriptPathForShell }
+      ...(commandOverride
+        ? {}
+        : { env: { [WINDOWS_SETUP_RUNNER_ENV]: resolution.runnerScriptPathForShell } })
     }
   }
 
+  const command = commandOverride ?? resolution.command
   const script = [
-    `( ${resolution.command} )`,
+    `( ${command} )`,
     'status=$?',
     `printf '\\n${completionPrefix(completionToken)}%s\\n' "$status"`,
     'exit "$status"'
@@ -81,4 +89,8 @@ function completionPrefix(completionToken: string): string {
 
 function quotePosixArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function quotePowerShellString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
 }

--- a/src/main/worktree-dependency-seed-clone.ts
+++ b/src/main/worktree-dependency-seed-clone.ts
@@ -1,0 +1,312 @@
+import { randomUUID as nodeRandomUUID } from 'node:crypto'
+import { link, mkdir, rm, rmdir, stat, lstat, readdir, readlink, realpath } from 'node:fs/promises'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { cloneWorktreePathWithApfs, type ApfsCloneDeps } from './ipc/worktree-apfs-clone'
+import {
+  runProcess,
+  type ProcessResult,
+  type ProcessSpec
+} from '../shared/child-process/run-process'
+import { assertDependencySeedPathComponentsNoSymlink } from './worktree-dependency-seed-path'
+
+export type DependencySeedProcessRunner = (
+  spec: ProcessSpec
+) => Promise<Pick<ProcessResult, 'code' | 'signal' | 'stderr'>>
+
+export type WorktreeDependencySeedDependencies = {
+  runProcess: DependencySeedProcessRunner
+  randomUUID: () => string
+  cloneDarwinPath: (
+    source: string,
+    target: string,
+    sourceIsDirectory: boolean,
+    deps?: ApfsCloneDeps
+  ) => Promise<void>
+}
+
+export const defaultWorktreeDependencySeedDependencies: WorktreeDependencySeedDependencies = {
+  runProcess,
+  randomUUID: nodeRandomUUID,
+  cloneDarwinPath: cloneWorktreePathWithApfs
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return (error as { code?: unknown })?.code === 'EEXIST'
+}
+
+export async function dependencySeedPathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false
+    }
+    throw error
+  }
+}
+
+export async function dependencySeedSameDevice(
+  source: string,
+  targetDirectory: string
+): Promise<boolean> {
+  const [sourceStats, targetStats] = await Promise.all([stat(source), stat(targetDirectory)])
+  return sourceStats.dev === targetStats.dev
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+  const relativePath = relative(resolve(root), resolve(candidate))
+  return (
+    relativePath === '' ||
+    (!isAbsolute(relativePath) && relativePath !== '..' && !relativePath.startsWith(`..${sep}`))
+  )
+}
+
+function symlinkPathError(path: string): Error {
+  return new Error(`Refusing dependency seed path through a symlink: ${path}`)
+}
+
+/** Reject dependency-tree links that would escape (or point back to) a checkout. */
+export async function assertDependencySeedTreeNoExternalSymlinks(root: string): Promise<void> {
+  const resolvedRoot = resolve(root)
+  const canonicalRoot = await realpath(resolvedRoot)
+  const pending = [resolvedRoot]
+  while (pending.length > 0) {
+    const current = pending.pop()!
+    const stats = await lstat(current)
+    if (stats.isSymbolicLink()) {
+      const target = await readlink(current)
+      // Absolute links would retain a checkout/host-specific target after a
+      // clone. Windows drive links need the same treatment on POSIX hosts.
+      if (isAbsolute(target) || /^[a-zA-Z]:[\\/]/u.test(target)) {
+        throw symlinkPathError(current)
+      }
+      try {
+        const canonicalTarget = await realpath(resolve(dirname(current), target))
+        if (!isPathInside(canonicalRoot, canonicalTarget)) {
+          throw symlinkPathError(current)
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw symlinkPathError(current)
+        }
+        throw error
+      }
+      continue
+    }
+    if (!stats.isDirectory() && !stats.isFile()) {
+      throw new Error(`Refusing unsupported dependency seed entry: ${current}`)
+    }
+    if (!stats.isDirectory()) {
+      continue
+    }
+    const entries = await readdir(current)
+    for (const entry of entries) {
+      pending.push(join(current, entry))
+    }
+  }
+}
+
+/**
+ * Validate an existing source path without following any symlink component.
+ * The source root is explicit so a caller cannot accidentally seed outside the
+ * checkout (or hydrate from outside the private seed entry).
+ */
+async function assertContainedSource(root: string, source: string): Promise<void> {
+  const resolvedRoot = resolve(root)
+  const resolvedSource = resolve(source)
+  await assertDependencySeedPathComponentsNoSymlink(resolvedSource)
+  if (!isPathInside(resolvedRoot, resolvedSource)) {
+    throw new Error(`Dependency seed source escapes its root: ${source}`)
+  }
+
+  const rootStats = await lstat(resolvedRoot)
+  if (rootStats.isSymbolicLink() || !rootStats.isDirectory()) {
+    throw symlinkPathError(resolvedRoot)
+  }
+
+  const relativeSource = relative(resolvedRoot, resolvedSource)
+  const segments = relativeSource ? relativeSource.split(/[\\/]/u) : []
+  let current = resolvedRoot
+  for (const [index, segment] of segments.entries()) {
+    current = join(current, segment)
+    const entryStats = await lstat(current)
+    if (entryStats.isSymbolicLink()) {
+      throw symlinkPathError(source)
+    }
+    if (index < segments.length - 1 && !entryStats.isDirectory()) {
+      throw new Error(`Dependency seed source parent is not a directory: ${source}`)
+    }
+  }
+  await assertDependencySeedTreeNoExternalSymlinks(resolvedSource)
+}
+
+/**
+ * Create a target's missing parent directories one component at a time. A
+ * recursive mkdir follows a pre-existing symlink; checking each component
+ * after creation keeps a malicious or stale checkout from redirecting a copy.
+ */
+async function ensureContainedTargetDirectory(root: string, directory: string): Promise<void> {
+  const resolvedRoot = resolve(root)
+  const resolvedDirectory = resolve(directory)
+  await assertDependencySeedPathComponentsNoSymlink(resolvedDirectory)
+  if (!isPathInside(resolvedRoot, resolvedDirectory)) {
+    throw new Error(`Dependency seed target escapes its root: ${directory}`)
+  }
+
+  const rootStats = await lstat(resolvedRoot)
+  if (rootStats.isSymbolicLink() || !rootStats.isDirectory()) {
+    throw symlinkPathError(resolvedRoot)
+  }
+
+  const relativeDirectory = relative(resolvedRoot, resolvedDirectory)
+  const segments = relativeDirectory ? relativeDirectory.split(/[\\/]/u) : []
+  let current = resolvedRoot
+  for (const segment of segments) {
+    current = join(current, segment)
+    let entryStats
+    try {
+      entryStats = await lstat(current)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+      try {
+        await mkdir(current)
+      } catch (mkdirError) {
+        if ((mkdirError as NodeJS.ErrnoException).code !== 'EEXIST') {
+          throw mkdirError
+        }
+      }
+      entryStats = await lstat(current)
+    }
+    if (entryStats.isSymbolicLink()) {
+      throw symlinkPathError(directory)
+    }
+    if (!entryStats.isDirectory()) {
+      throw new Error(`Dependency seed target parent is not a directory: ${directory}`)
+    }
+  }
+}
+
+async function runLinuxReflink(
+  source: string,
+  target: string,
+  sourceIsDirectory: boolean,
+  dependencies: WorktreeDependencySeedDependencies
+): Promise<void> {
+  // `always` is important: cp must fail on filesystems without reflinks rather
+  // than silently turning a seed into a multi-gigabyte regular copy.
+  const args = sourceIsDirectory
+    ? ['--reflink=always', '--no-clobber', '-a', '--', `${source}${sep}.`, target]
+    : ['--reflink=always', '--', source, target]
+  const result = await dependencies.runProcess({
+    program: '/bin/cp',
+    args,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    // A cold dependency tree can exceed the generic 30-second subprocess
+    // bound; the surrounding seed lock already serializes this long operation.
+    timeoutMs: null
+  })
+  if (result.code !== 0 || result.signal) {
+    const detail = result.stderr.trim()
+    throw new Error(
+      `Copy-on-write clone unavailable for dependency seed${detail ? `: ${detail}` : ''}`
+    )
+  }
+}
+
+async function cloneFileWithLinuxReflink(
+  source: string,
+  target: string,
+  dependencies: WorktreeDependencySeedDependencies
+): Promise<'cloned' | 'exists'> {
+  const temporaryTarget = `${target}.orca-seed-${dependencies.randomUUID()}`
+  try {
+    await runLinuxReflink(source, temporaryTarget, false, dependencies)
+    try {
+      await link(temporaryTarget, target)
+      return 'cloned'
+    } catch (error) {
+      if (isAlreadyExists(error)) {
+        return 'exists'
+      }
+      throw error
+    }
+  } finally {
+    await rm(temporaryTarget, { force: true }).catch(() => {})
+  }
+}
+
+async function cloneDirectoryWithLinuxReflink(
+  source: string,
+  target: string,
+  dependencies: WorktreeDependencySeedDependencies
+): Promise<'cloned' | 'exists'> {
+  try {
+    // Reserve the destination first: a concurrent setup cannot be replaced by
+    // cp after the existence preflight.
+    await mkdir(target)
+  } catch (error) {
+    if (isAlreadyExists(error)) {
+      return 'exists'
+    }
+    throw error
+  }
+  try {
+    await runLinuxReflink(source, target, true, dependencies)
+    return 'cloned'
+  } catch (error) {
+    // Remove only an empty reservation. A partial clone remains inspectable and
+    // is never mistaken for a complete seed by the marker check.
+    await rmdir(target).catch(() => {})
+    throw error
+  }
+}
+
+/** Clone one dependency path without replacing a path that already exists. */
+export async function cloneDependencySeedPath(
+  source: string,
+  target: string,
+  platform: NodeJS.Platform,
+  dependencies: WorktreeDependencySeedDependencies = defaultWorktreeDependencySeedDependencies,
+  targetRoot = dirname(target),
+  sourceRoot = dirname(source)
+): Promise<'cloned' | 'exists'> {
+  await assertContainedSource(sourceRoot, source)
+  const sourceStats = await stat(source)
+  await ensureContainedTargetDirectory(targetRoot, dirname(target))
+  if (await dependencySeedPathExists(target)) {
+    return 'exists'
+  }
+  if (!(await dependencySeedSameDevice(source, dirname(target)))) {
+    throw new Error('Copy-on-write dependency seed requires source and target on one volume')
+  }
+  // Recheck both sides after the asynchronous probes. This closes the common
+  // race where a checkout component is replaced with a symlink while we probe
+  // device identity, before handing paths to cp/clonefile.
+  await assertContainedSource(sourceRoot, source)
+  await ensureContainedTargetDirectory(targetRoot, dirname(target))
+  if (platform === 'darwin') {
+    await dependencies.cloneDarwinPath(source, target, sourceStats.isDirectory())
+    return 'cloned'
+  }
+  if (platform === 'linux') {
+    return sourceStats.isDirectory()
+      ? cloneDirectoryWithLinuxReflink(source, target, dependencies)
+      : cloneFileWithLinuxReflink(source, target, dependencies)
+  }
+  throw new Error(`Copy-on-write dependency seeds are unsupported on ${platform}`)
+}
+
+/** Remove a generated seed entry, treating a missing entry as success. */
+export async function removeDependencySeedEntry(path: string): Promise<void> {
+  try {
+    const entryStats = await lstat(path)
+    await rm(path, { recursive: !entryStats.isSymbolicLink(), force: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
+}

--- a/src/main/worktree-dependency-seed-clone.ts
+++ b/src/main/worktree-dependency-seed-clone.ts
@@ -1,5 +1,5 @@
 import { randomUUID as nodeRandomUUID } from 'node:crypto'
-import { link, mkdir, rm, rmdir, stat, lstat, readdir, readlink, realpath } from 'node:fs/promises'
+import { link, mkdir, rm, stat, lstat, readdir, readlink, realpath } from 'node:fs/promises'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { cloneWorktreePathWithApfs, type ApfsCloneDeps } from './ipc/worktree-apfs-clone'
 import {
@@ -32,6 +32,14 @@ export const defaultWorktreeDependencySeedDependencies: WorktreeDependencySeedDe
 
 function isAlreadyExists(error: unknown): boolean {
   return (error as { code?: unknown })?.code === 'EEXIST'
+}
+
+/** Identify a no-clobber race so rollback does not remove the other writer's target. */
+export function isDependencySeedTargetExistsError(error: unknown): boolean {
+  return (
+    isAlreadyExists(error) ||
+    (error as { name?: unknown })?.name === 'WorktreeLinkedPathTargetExistsError'
+  )
 }
 
 export async function dependencySeedPathExists(path: string): Promise<boolean> {
@@ -257,9 +265,9 @@ async function cloneDirectoryWithLinuxReflink(
     await runLinuxReflink(source, target, true, dependencies)
     return 'cloned'
   } catch (error) {
-    // Remove only an empty reservation. A partial clone remains inspectable and
-    // is never mistaken for a complete seed by the marker check.
-    await rmdir(target).catch(() => {})
+    // We own the reservation from mkdir; remove a partial tree so setup sees a
+    // clean cache miss instead of operating on an incomplete dependency tree.
+    await rm(target, { recursive: true, force: true }).catch(() => {})
     throw error
   }
 }
@@ -287,8 +295,22 @@ export async function cloneDependencySeedPath(
   // device identity, before handing paths to cp/clonefile.
   await assertContainedSource(sourceRoot, source)
   await ensureContainedTargetDirectory(targetRoot, dirname(target))
+  const targetExistedBeforeClone = await dependencySeedPathExists(target)
+  if (targetExistedBeforeClone) {
+    return 'exists'
+  }
   if (platform === 'darwin') {
-    await dependencies.cloneDarwinPath(source, target, sourceStats.isDirectory())
+    try {
+      await dependencies.cloneDarwinPath(source, target, sourceStats.isDirectory())
+    } catch (error) {
+      // APFS reserves directory targets internally and may leave a partial
+      // tree when cp fails. Remove only targets that were absent before this
+      // clone; a no-clobber race belongs to the other writer.
+      if (!isDependencySeedTargetExistsError(error)) {
+        await removeDependencySeedEntry(target).catch(() => {})
+      }
+      throw error
+    }
     return 'cloned'
   }
   if (platform === 'linux') {

--- a/src/main/worktree-dependency-seed-context.ts
+++ b/src/main/worktree-dependency-seed-context.ts
@@ -1,0 +1,201 @@
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import type {
+  DependencySeedInputFile,
+  WorktreeDependencySeedFingerprint,
+  WorktreeDependencySeedRepo
+} from './worktree-dependency-seed-fingerprint'
+import {
+  WORKTREE_DEPENDENCY_SEED_LOCKFILE_PATHS,
+  createWorktreeDependencySeedFingerprint,
+  getWorktreeDependencySeedRoot,
+  isValidDependencySeedInput,
+  normalizeWorktreeDependencySeedPaths,
+  readWorktreeDependencySeedInputs
+} from './worktree-dependency-seed-fingerprint'
+import {
+  defaultWorktreeDependencySeedDependencies,
+  dependencySeedSameDevice,
+  type WorktreeDependencySeedDependencies
+} from './worktree-dependency-seed-clone'
+import {
+  assertDependencySeedPathNoSymlink,
+  ensureDependencySeedDirectory
+} from './worktree-dependency-seed-path'
+
+const LOCKFILE_REQUIRED_BY_DEFAULT = true
+
+export type WorktreeDependencySeedOptions = {
+  platform?: NodeJS.Platform
+  architecture?: string
+  nodeMajor?: number | string
+  /** Exact root-relative files to hash. Defaults to package-manager lockfiles. */
+  fingerprintPaths?: readonly string[]
+  /** Explicit bytes avoid a second read and let callers hash a setup snapshot. */
+  lockfiles?: readonly DependencySeedInputFile[]
+  /** Keep the first successful tree for a digest unless explicitly replacing it. */
+  replaceExisting?: boolean
+  /** Test seam; by default the store is a sibling of the worktree directory. */
+  seedRoot?: string
+  /** Root from which fingerprint paths are read; defaults to the new worktree. */
+  inputRoot?: string
+  /** Internal runtime callers may opt in for a runtime-owned local host. */
+  allowRuntimeExecutionHost?: boolean
+  /** A setup without a lockfile is not reproducible and is not seeded by default. */
+  allowWithoutLockfile?: boolean
+  dependencies?: Partial<WorktreeDependencySeedDependencies>
+}
+
+export type WorktreeDependencySeedArgs = WorktreeDependencySeedOptions & {
+  repo: WorktreeDependencySeedRepo
+  worktreePath: string
+  setupScript: string
+  declaredSeedPaths: readonly string[]
+}
+
+export type WorktreeDependencySeedResult = {
+  status: 'hydrated' | 'promoted' | 'existing' | 'miss' | 'skipped' | 'failed'
+  fingerprint?: string
+  paths: readonly string[]
+  reason?: string
+}
+
+export type SeedContext = {
+  repoPath: string
+  worktreePath: string
+  seedRoot: string
+  seedEntryPath: string
+  fingerprint: WorktreeDependencySeedFingerprint
+  paths: readonly string[]
+  platform: NodeJS.Platform
+  dependencies: WorktreeDependencySeedDependencies
+}
+
+function repoPathOf(repo: WorktreeDependencySeedRepo): string | null {
+  if (typeof repo === 'string') {
+    return repo
+  }
+  return repo && typeof repo.path === 'string' ? repo.path : null
+}
+
+function isLocalRepo(
+  repo: WorktreeDependencySeedRepo,
+  allowRuntimeExecutionHost: boolean
+): boolean {
+  if (typeof repo === 'string') {
+    return true
+  }
+  if (repo.connectionId) {
+    return false
+  }
+  if (!repo.executionHostId || repo.executionHostId === 'local') {
+    return true
+  }
+  return allowRuntimeExecutionHost && repo.executionHostId.startsWith('runtime:')
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+  const relativePath = relative(resolve(root), resolve(candidate))
+  return (
+    relativePath === '' ||
+    (!isAbsolute(relativePath) && relativePath !== '..' && !relativePath.startsWith(`..${sep}`))
+  )
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  return isPathInside(left, right) || isPathInside(right, left)
+}
+
+/** Build a validated operation context; unsupported hosts return null. */
+export async function createDependencySeedContext(
+  args: WorktreeDependencySeedArgs
+): Promise<SeedContext | null> {
+  const platform = args.platform ?? process.platform
+  if (platform !== 'darwin' && platform !== 'linux') {
+    return null
+  }
+  if (
+    !isLocalRepo(args.repo, args.allowRuntimeExecutionHost === true) ||
+    typeof args.setupScript !== 'string' ||
+    !args.setupScript.trim()
+  ) {
+    return null
+  }
+  const paths = normalizeWorktreeDependencySeedPaths(
+    Array.isArray(args.declaredSeedPaths) ? args.declaredSeedPaths : []
+  )
+  if (paths.length === 0) {
+    return null
+  }
+  const rawRepoPath = repoPathOf(args.repo)
+  if (typeof args.worktreePath !== 'string' || !rawRepoPath) {
+    return null
+  }
+  const repoPath = resolve(rawRepoPath)
+  const worktreePath = resolve(args.worktreePath)
+  const inputPaths = Array.isArray(args.fingerprintPaths)
+    ? args.fingerprintPaths
+    : WORKTREE_DEPENDENCY_SEED_LOCKFILE_PATHS
+  const inputRoot = resolve(args.inputRoot ?? worktreePath)
+  let lockfiles: DependencySeedInputFile[]
+  if (args.lockfiles !== undefined) {
+    if (
+      !Array.isArray(args.lockfiles) ||
+      args.lockfiles.some((input) => !isValidDependencySeedInput(input))
+    ) {
+      return null
+    }
+    lockfiles = [...args.lockfiles]
+  } else {
+    try {
+      lockfiles = await readWorktreeDependencySeedInputs(inputRoot, inputPaths)
+    } catch {
+      // An existing but malformed/oversized input is not a reproducible seed.
+      return null
+    }
+  }
+  const fingerprint = createWorktreeDependencySeedFingerprint({
+    setupScript: args.setupScript,
+    lockfiles,
+    platform,
+    architecture: args.architecture,
+    nodeMajor: args.nodeMajor,
+    seedPaths: paths
+  })
+  if (
+    LOCKFILE_REQUIRED_BY_DEFAULT &&
+    fingerprint.lockfiles.length === 0 &&
+    !args.allowWithoutLockfile
+  ) {
+    return null
+  }
+  const seedRoot = resolve(getWorktreeDependencySeedRoot(args.repo, worktreePath, args.seedRoot))
+  // Keeping the private store outside the checkout prevents a seed entry or
+  // lock directory from becoming part of the source tree it snapshots.
+  if (pathsOverlap(seedRoot, worktreePath)) {
+    return null
+  }
+  // Keep the private store out of both the new checkout and the primary repo;
+  // nested worktree layouts can otherwise place generated entries under a
+  // tracked checkout.
+  if (pathsOverlap(seedRoot, repoPath)) {
+    return null
+  }
+  return {
+    repoPath,
+    worktreePath,
+    seedRoot,
+    seedEntryPath: join(seedRoot, fingerprint.digest),
+    fingerprint,
+    paths,
+    platform,
+    dependencies: { ...defaultWorktreeDependencySeedDependencies, ...args.dependencies }
+  }
+}
+
+export async function ensureDependencySeedRoot(context: SeedContext): Promise<void> {
+  await ensureDependencySeedDirectory(context.seedRoot)
+  await assertDependencySeedPathNoSymlink(context.seedRoot, context.seedRoot)
+  if (!(await dependencySeedSameDevice(context.worktreePath, context.seedRoot))) {
+    throw new Error('Dependency seed store is on a different volume from the worktree')
+  }
+}

--- a/src/main/worktree-dependency-seed-fingerprint.ts
+++ b/src/main/worktree-dependency-seed-fingerprint.ts
@@ -1,0 +1,284 @@
+import { createHash } from 'node:crypto'
+import { lstat, readFile } from 'node:fs/promises'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import type { Repo } from '../shared/repo-types'
+import { getSafeRelativePath } from './git/worktree-symlink-detection'
+import { assertDependencySeedPathNoSymlink } from './worktree-dependency-seed-path'
+
+export const WORKTREE_DEPENDENCY_SEED_LOCKFILE_PATHS = [
+  'pnpm-lock.yaml',
+  'bun.lock',
+  'bun.lockb',
+  'yarn.lock',
+  'package-lock.json',
+  'npm-shrinkwrap.json'
+] as const
+
+export const WORKTREE_DEPENDENCY_SEED_DIRECTORY = '.orca-dependency-seeds'
+export const WORKTREE_DEPENDENCY_SEED_MARKER = 'seed.json'
+export const WORKTREE_DEPENDENCY_SEED_VERSION = 1
+
+/** Keep setup fingerprints bounded even when a repository contains a huge lockfile. */
+export const WORKTREE_DEPENDENCY_SEED_INPUT_MAX_BYTES = 32 * 1024 * 1024
+
+export type DependencySeedInputFile = {
+  path: string
+  bytes: Uint8Array | string
+}
+
+export type DependencySeedInputDigest = {
+  path: string
+  sha256: string
+  byteLength: number
+}
+
+export type WorktreeDependencySeedFingerprint = {
+  version: typeof WORKTREE_DEPENDENCY_SEED_VERSION
+  digest: string
+  setupScriptSha256: string
+  lockfiles: readonly DependencySeedInputDigest[]
+  platform: NodeJS.Platform
+  architecture: string
+  nodeMajor: number
+  seedPaths: readonly string[]
+}
+
+export type WorktreeDependencySeedFingerprintInput = {
+  setupScript: string
+  lockfiles: readonly DependencySeedInputFile[]
+  platform?: NodeJS.Platform
+  architecture?: string
+  nodeMajor?: number | string
+  seedPaths?: readonly string[]
+}
+
+export type WorktreeDependencySeedRepo =
+  | Pick<Repo, 'path' | 'connectionId' | 'executionHostId'>
+  | string
+
+function normalizeNodeMajor(value: number | string | undefined): number {
+  if (value === undefined) {
+    const major = Number.parseInt(process.versions.node.split('.')[0] ?? '', 10)
+    return Number.isInteger(major) && major > 0 ? major : 0
+  }
+  const major = typeof value === 'number' ? value : Number.parseInt(value, 10)
+  return Number.isInteger(major) && major >= 0 ? major : 0
+}
+
+function sha256(value: Uint8Array | string): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function byteLength(value: Uint8Array | string): number {
+  return typeof value === 'string' ? Buffer.byteLength(value) : value.byteLength
+}
+
+/** Whether an explicitly supplied input is safe to include in a seed identity. */
+export function isValidDependencySeedInput(input: unknown): input is DependencySeedInputFile {
+  if (!input || typeof input !== 'object') {
+    return false
+  }
+  const candidate = input as Partial<DependencySeedInputFile>
+  return (
+    normalizeDependencySeedPath(candidate.path ?? '') !== null &&
+    (typeof candidate.bytes === 'string' || candidate.bytes instanceof Uint8Array) &&
+    byteLength(candidate.bytes) <= WORKTREE_DEPENDENCY_SEED_INPUT_MAX_BYTES
+  )
+}
+
+export function normalizeDependencySeedPath(rawPath: string): string | null {
+  if (typeof rawPath !== 'string' || rawPath.includes('\0')) {
+    return null
+  }
+  const trimmed = rawPath.trim().replace(/\\/g, '/')
+  // Seed identities are canonical: tolerate a leading `./` while preserving
+  // the stricter rejection of dot segments in the middle of a path.
+  const canonical = trimmed.replace(/^(?:\.\/)+/u, '').replace(/\/+$/u, '')
+  // Check after stripping `./` too, so an absolute path cannot hide behind a
+  // relative-looking prefix (for example, `./C:/outside`).
+  if (canonical.startsWith('/') || /^[a-zA-Z]:/u.test(canonical)) {
+    return null
+  }
+  const safe = getSafeRelativePath(canonical)
+  if (!safe.safe) {
+    return null
+  }
+  const segments = safe.rel.split('/')
+  if (
+    segments.length === 0 ||
+    segments.some((segment) => !segment || segment === '.' || segment === '..') ||
+    segments.includes('.git') ||
+    segments.includes(WORKTREE_DEPENDENCY_SEED_DIRECTORY) ||
+    safe.rel === WORKTREE_DEPENDENCY_SEED_MARKER
+  ) {
+    return null
+  }
+  return segments.join('/')
+}
+
+/** Normalize and de-duplicate configured dependency paths. */
+export function normalizeWorktreeDependencySeedPaths(paths: readonly string[]): string[] {
+  if (!Array.isArray(paths)) {
+    return []
+  }
+  const normalized = [
+    ...new Set(
+      paths.map(normalizeDependencySeedPath).filter((path): path is string => path !== null)
+    )
+  ].sort()
+  // Cloning a parent already includes every child and avoids overlapping races.
+  return normalized.filter(
+    (path, index) => !normalized.slice(0, index).some((parent) => path.startsWith(`${parent}/`))
+  )
+}
+
+/** Normalize exact root-relative input files without collapsing nested paths. */
+export function normalizeWorktreeDependencySeedInputPaths(
+  paths: readonly string[] | undefined
+): string[] {
+  const source = Array.isArray(paths) ? paths : []
+  return [
+    ...new Set(
+      source.map(normalizeDependencySeedPath).filter((path): path is string => path !== null)
+    )
+  ].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
+}
+
+function normalizeFingerprintPaths(paths: readonly string[] | undefined): string[] {
+  return normalizeWorktreeDependencySeedInputPaths(
+    Array.isArray(paths) ? paths : WORKTREE_DEPENDENCY_SEED_LOCKFILE_PATHS
+  )
+}
+
+function normalizeInputDigests(
+  inputs: readonly DependencySeedInputFile[]
+): DependencySeedInputDigest[] {
+  const byPath = new Map<string, DependencySeedInputDigest>()
+  if (!Array.isArray(inputs)) {
+    return []
+  }
+  for (const input of inputs) {
+    // Validate the untrusted shape before reading fields; callers may pass
+    // persisted or IPC data rather than the static TypeScript type.
+    if (!isValidDependencySeedInput(input)) {
+      continue
+    }
+    const path = normalizeDependencySeedPath(input.path)
+    if (!path) {
+      continue
+    }
+    const bytes = input.bytes
+    // Last-wins makes an explicitly supplied snapshot deterministic while
+    // ensuring duplicate paths cannot produce duplicate marker entries.
+    byPath.set(path, { path, sha256: sha256(bytes), byteLength: byteLength(bytes) })
+  }
+  // Keep descriptor ordering identical to the path normalizers and marker
+  // validator; locale-sensitive ordering would reject valid case-sensitive
+  // paths on different hosts.
+  return [...byPath.values()].sort((left, right) =>
+    left.path < right.path ? -1 : left.path > right.path ? 1 : 0
+  )
+}
+
+/** Build the complete, inspectable fingerprint descriptor. */
+export function createWorktreeDependencySeedFingerprint(
+  input: WorktreeDependencySeedFingerprintInput
+): WorktreeDependencySeedFingerprint {
+  const platform = input.platform ?? process.platform
+  const architecture = input.architecture ?? process.arch
+  const nodeMajor = normalizeNodeMajor(input.nodeMajor)
+  const seedPaths = normalizeWorktreeDependencySeedPaths(input.seedPaths ?? [])
+  const lockfiles = normalizeInputDigests(input.lockfiles)
+  const setupScriptSha256 = sha256(input.setupScript)
+  const canonical = JSON.stringify({
+    version: WORKTREE_DEPENDENCY_SEED_VERSION,
+    setupScriptSha256,
+    lockfiles,
+    platform,
+    architecture,
+    nodeMajor,
+    seedPaths
+  })
+  return {
+    version: WORKTREE_DEPENDENCY_SEED_VERSION,
+    digest: sha256(canonical),
+    setupScriptSha256,
+    lockfiles,
+    platform,
+    architecture,
+    nodeMajor,
+    seedPaths
+  }
+}
+
+export function computeWorktreeDependencySeedFingerprint(
+  input: WorktreeDependencySeedFingerprintInput
+): string {
+  return createWorktreeDependencySeedFingerprint(input).digest
+}
+
+export const createDependencySeedFingerprint = createWorktreeDependencySeedFingerprint
+export const computeDependencySeedFingerprint = computeWorktreeDependencySeedFingerprint
+
+/** Read all requested root-relative fingerprint inputs that exist in a checkout. */
+export async function readWorktreeDependencySeedInputs(
+  repoPath: string,
+  paths: readonly string[] = WORKTREE_DEPENDENCY_SEED_LOCKFILE_PATHS
+): Promise<DependencySeedInputFile[]> {
+  const inputs: DependencySeedInputFile[] = []
+  for (const path of normalizeFingerprintPaths(paths)) {
+    const root = resolve(repoPath)
+    const resolvedPath = resolve(root, path)
+    const relativePath = relative(root, resolvedPath)
+    if (isAbsolute(relativePath) || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
+      continue
+    }
+    try {
+      await assertDependencySeedPathNoSymlink(root, resolvedPath)
+      const info = await lstat(resolvedPath)
+      if (
+        !info.isFile() ||
+        info.isSymbolicLink() ||
+        info.size > WORKTREE_DEPENDENCY_SEED_INPUT_MAX_BYTES
+      ) {
+        throw new Error(`Dependency seed input is not a regular bounded file: ${path}`)
+      }
+      const bytes = await readFile(resolvedPath)
+      // A concurrent replacement should not let a symlink or an oversized file
+      // sneak into the snapshot after the initial metadata check.
+      const after = await lstat(resolvedPath)
+      if (
+        !after.isFile() ||
+        after.isSymbolicLink() ||
+        after.size !== bytes.byteLength ||
+        after.dev !== info.dev ||
+        after.ino !== info.ino
+      ) {
+        throw new Error(`Dependency seed input changed while it was read: ${path}`)
+      }
+      inputs.push({ path, bytes })
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+    }
+  }
+  return inputs
+}
+
+function repoPathOf(repo: WorktreeDependencySeedRepo): string {
+  return typeof repo === 'string' ? repo : repo.path
+}
+
+/** Resolve a sibling store, keyed by the canonical primary checkout path. */
+export function getWorktreeDependencySeedRoot(
+  repo: WorktreeDependencySeedRepo,
+  worktreePath: string,
+  explicitRoot?: string
+): string {
+  if (explicitRoot) {
+    return explicitRoot
+  }
+  const repoKey = sha256(resolve(repoPathOf(repo))).slice(0, 32)
+  return join(dirname(resolve(worktreePath)), WORKTREE_DEPENDENCY_SEED_DIRECTORY, repoKey)
+}

--- a/src/main/worktree-dependency-seed-lock.ts
+++ b/src/main/worktree-dependency-seed-lock.ts
@@ -1,0 +1,86 @@
+import { lstat } from 'node:fs/promises'
+import { isAbsolute, resolve } from 'node:path'
+import { lock as acquireFileLock } from 'proper-lockfile'
+import { ensureDependencySeedDirectory } from './worktree-dependency-seed-path'
+
+const lockTails = new Map<string, Promise<void>>()
+
+// A dependency tree can take several minutes to clone on a cold disk. Keep the
+// heartbeat well beyond that window so a second Orca process cannot steal a
+// live lock while the first one is still materializing files.
+const FILE_LOCK_STALE_MS = 30 * 60 * 1000
+const FILE_LOCK_RETRIES = {
+  retries: 40,
+  factor: 1.2,
+  minTimeout: 50,
+  maxTimeout: 1000,
+  randomize: true
+}
+
+async function acquireCrossProcessLock(
+  lockKey: string,
+  stableLockPath?: string
+): Promise<(() => Promise<void>) | null> {
+  // Unit callers may use symbolic keys ("same", "other"). Production seed
+  // keys are absolute paths; avoid creating test lock directories in cwd.
+  const lockTarget = stableLockPath ?? lockKey
+  if (!isAbsolute(lockTarget)) {
+    return null
+  }
+  // The digest entry is deliberately not the lock target: promotion renames
+  // that directory. A stable seed-root directory keeps the lock in place even
+  // when the entry is absent on the first call or is atomically replaced.
+  const safeLockTarget = await ensureDependencySeedDirectory(lockTarget)
+  // A pre-existing symlink at the lock path could redirect proper-lockfile's
+  // mkdir/stat lifecycle into an unrelated directory. Reject it before the
+  // package gets a chance to treat the link as a stale lock.
+  try {
+    const lockPathStats = await lstat(`${safeLockTarget}.lock`)
+    if (lockPathStats.isSymbolicLink()) {
+      throw new Error(`Refusing dependency seed lock through a symlink: ${safeLockTarget}.lock`)
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
+  return acquireFileLock(safeLockTarget, {
+    // Canonicalize aliases such as /var -> /private/var so separate callers
+    // cannot acquire independent locks for the same seed root.
+    realpath: true,
+    stale: FILE_LOCK_STALE_MS,
+    update: FILE_LOCK_STALE_MS / 3,
+    retries: FILE_LOCK_RETRIES
+  })
+}
+
+/** Serialize seed hydration and promotion for one content-addressed entry. */
+export function withWorktreeDependencySeedLock<T>(
+  lockKey: string,
+  operation: () => Promise<T>,
+  stableLockPath?: string
+): Promise<T> {
+  // Resolve lexical aliases for the in-process queue as well. Symlink aliases
+  // are canonicalized by proper-lockfile's realpath option above.
+  const queueKey = isAbsolute(lockKey) ? resolve(lockKey) : lockKey
+  const prior = lockTails.get(queueKey) ?? Promise.resolve()
+  const run = prior.then(async () => {
+    const release = await acquireCrossProcessLock(lockKey, stableLockPath)
+    try {
+      return await operation()
+    } finally {
+      await release?.()
+    }
+  })
+  const tail = run.then(
+    () => undefined,
+    () => undefined
+  )
+  lockTails.set(queueKey, tail)
+  void tail.then(() => {
+    if (lockTails.get(queueKey) === tail) {
+      lockTails.delete(queueKey)
+    }
+  })
+  return run
+}

--- a/src/main/worktree-dependency-seed-marker.ts
+++ b/src/main/worktree-dependency-seed-marker.ts
@@ -1,0 +1,243 @@
+import { createHash } from 'node:crypto'
+import { lstat, readFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import {
+  WORKTREE_DEPENDENCY_SEED_INPUT_MAX_BYTES,
+  WORKTREE_DEPENDENCY_SEED_MARKER,
+  WORKTREE_DEPENDENCY_SEED_VERSION,
+  normalizeWorktreeDependencySeedPaths,
+  type WorktreeDependencySeedFingerprint
+} from './worktree-dependency-seed-fingerprint'
+import {
+  assertDependencySeedPathComponentsNoSymlink,
+  assertDependencySeedPathNoSymlink
+} from './worktree-dependency-seed-path'
+import { assertDependencySeedTreeNoExternalSymlinks } from './worktree-dependency-seed-clone'
+
+const MAX_MARKER_BYTES = 256 * 1024
+
+function isSha256(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/u.test(value)
+}
+
+function isCanonicalSeedPath(value: unknown): value is string {
+  if (typeof value !== 'string') {
+    return false
+  }
+  return normalizeWorktreeDependencySeedPaths([value])[0] === value
+}
+
+function hasUniqueCanonicalPaths(paths: readonly unknown[]): paths is readonly string[] {
+  if (!paths.every(isCanonicalSeedPath)) {
+    return false
+  }
+  return new Set(paths).size === paths.length
+}
+
+function hasCanonicalSortedPaths(paths: readonly string[]): boolean {
+  // Match Array#sort's deterministic UTF-16 ordering used by fingerprints;
+  // localeCompare varies by host locale and can reject valid markers.
+  return paths.every((path, index) => index === 0 || paths[index - 1]! < path)
+}
+
+function isCanonicalPathList(paths: readonly unknown[]): paths is readonly string[] {
+  if (!hasUniqueCanonicalPaths(paths)) {
+    return false
+  }
+  const normalized = normalizeWorktreeDependencySeedPaths(paths)
+  return (
+    normalized.length === paths.length &&
+    hasCanonicalSortedPaths(paths) &&
+    normalized.every((path, index) => paths[index] === path)
+  )
+}
+
+function fingerprintDigest(fingerprint: WorktreeDependencySeedFingerprint): string {
+  const canonical = JSON.stringify({
+    version: fingerprint.version,
+    setupScriptSha256: fingerprint.setupScriptSha256,
+    lockfiles: fingerprint.lockfiles.map(({ path, sha256, byteLength }) => ({
+      path,
+      sha256,
+      byteLength
+    })),
+    platform: fingerprint.platform,
+    architecture: fingerprint.architecture,
+    nodeMajor: fingerprint.nodeMajor,
+    seedPaths: [...fingerprint.seedPaths]
+  })
+  return createHash('sha256').update(canonical).digest('hex')
+}
+
+export type DependencySeedMarker = {
+  version: typeof WORKTREE_DEPENDENCY_SEED_VERSION
+  fingerprint: WorktreeDependencySeedFingerprint
+  /** Paths copied into this particular seed (a declared path may be absent). */
+  paths: readonly string[]
+  createdAt: string
+}
+
+function isFingerprintShape(value: unknown): value is WorktreeDependencySeedFingerprint {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const candidate = value as Partial<WorktreeDependencySeedFingerprint>
+  const lockfiles = candidate.lockfiles
+  const seedPaths = candidate.seedPaths
+  if (!Array.isArray(lockfiles) || !Array.isArray(seedPaths)) {
+    return false
+  }
+  const lockfilePaths = lockfiles.map((entry) =>
+    entry && typeof entry === 'object' ? (entry as { path?: unknown }).path : undefined
+  )
+  const validLockfileEntries = lockfiles.every(
+    (entry) =>
+      entry !== null &&
+      typeof entry === 'object' &&
+      isCanonicalSeedPath((entry as { path?: unknown }).path) &&
+      isSha256((entry as { sha256?: unknown }).sha256) &&
+      Number.isSafeInteger((entry as { byteLength?: unknown }).byteLength) &&
+      ((entry as { byteLength: number }).byteLength ?? -1) >= 0 &&
+      ((entry as { byteLength: number }).byteLength ?? Infinity) <=
+        WORKTREE_DEPENDENCY_SEED_INPUT_MAX_BYTES
+  )
+  const validSeedPaths =
+    hasUniqueCanonicalPaths(seedPaths) &&
+    hasCanonicalSortedPaths(seedPaths) &&
+    normalizeWorktreeDependencySeedPaths(seedPaths).length === seedPaths.length &&
+    normalizeWorktreeDependencySeedPaths(seedPaths).every(
+      (path, index) => seedPaths[index] === path
+    )
+  return (
+    candidate.version === WORKTREE_DEPENDENCY_SEED_VERSION &&
+    isSha256(candidate.digest) &&
+    isSha256(candidate.setupScriptSha256) &&
+    validLockfileEntries &&
+    lockfilePaths.every((path): path is string => typeof path === 'string') &&
+    hasCanonicalSortedPaths(lockfilePaths) &&
+    typeof candidate.platform === 'string' &&
+    candidate.platform.length > 0 &&
+    typeof candidate.architecture === 'string' &&
+    candidate.architecture.length > 0 &&
+    typeof candidate.nodeMajor === 'number' &&
+    Number.isSafeInteger(candidate.nodeMajor) &&
+    candidate.nodeMajor >= 0 &&
+    validSeedPaths &&
+    candidate.digest === fingerprintDigest(candidate as WorktreeDependencySeedFingerprint)
+  )
+}
+
+export async function readDependencySeedMarker(path: string): Promise<DependencySeedMarker | null> {
+  try {
+    await assertDependencySeedPathComponentsNoSymlink(path)
+    const directoryStats = await lstat(path)
+    if (!directoryStats.isDirectory() || directoryStats.isSymbolicLink()) {
+      return null
+    }
+    const markerPath = join(path, WORKTREE_DEPENDENCY_SEED_MARKER)
+    const markerStats = await lstat(markerPath)
+    if (
+      !markerStats.isFile() ||
+      markerStats.isSymbolicLink() ||
+      markerStats.size > MAX_MARKER_BYTES
+    ) {
+      return null
+    }
+    const parsed: unknown = JSON.parse(await readFile(markerPath, 'utf8'))
+    if (!parsed || typeof parsed !== 'object') {
+      return null
+    }
+    const marker = parsed as Partial<DependencySeedMarker>
+    const markerFingerprint = marker.fingerprint
+    if (
+      marker.version !== WORKTREE_DEPENDENCY_SEED_VERSION ||
+      typeof marker.createdAt !== 'string' ||
+      !Number.isFinite(Date.parse(marker.createdAt)) ||
+      !isFingerprintShape(markerFingerprint) ||
+      !Array.isArray(marker.paths) ||
+      marker.paths.length === 0 ||
+      !isCanonicalPathList(marker.paths)
+    ) {
+      return null
+    }
+    if (marker.paths.some((path) => !markerFingerprint.seedPaths.includes(path))) {
+      return null
+    }
+    return marker as DependencySeedMarker
+  } catch {
+    return null
+  }
+}
+
+function sameStringArray(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((entry, index) => entry === right[index])
+}
+
+export function dependencySeedMarkerMatchesFingerprint(
+  marker: DependencySeedMarker,
+  fingerprint: WorktreeDependencySeedFingerprint
+): boolean {
+  if (!marker || typeof marker !== 'object' || !fingerprint || typeof fingerprint !== 'object') {
+    return false
+  }
+  if (!isFingerprintShape(marker.fingerprint) || !isFingerprintShape(fingerprint)) {
+    return false
+  }
+  return (
+    marker.fingerprint.digest === fingerprint.digest &&
+    marker.fingerprint.version === fingerprint.version &&
+    marker.fingerprint.setupScriptSha256 === fingerprint.setupScriptSha256 &&
+    marker.fingerprint.platform === fingerprint.platform &&
+    marker.fingerprint.architecture === fingerprint.architecture &&
+    marker.fingerprint.nodeMajor === fingerprint.nodeMajor &&
+    sameStringArray(marker.fingerprint.seedPaths, fingerprint.seedPaths) &&
+    sameStringArray(
+      marker.fingerprint.lockfiles.map((entry) => entry.path),
+      fingerprint.lockfiles.map((entry) => entry.path)
+    ) &&
+    marker.fingerprint.lockfiles.every(
+      (entry, index) =>
+        entry.sha256 === fingerprint.lockfiles[index]?.sha256 &&
+        entry.byteLength === fingerprint.lockfiles[index]?.byteLength
+    )
+  )
+}
+
+export function dependencySeedMarkerPaths(
+  marker: DependencySeedMarker,
+  declaredPaths: readonly string[]
+): string[] {
+  if (!marker || typeof marker !== 'object' || !Array.isArray(declaredPaths)) {
+    return []
+  }
+  const markerPaths = Array.isArray(marker.paths) ? marker.paths.filter(isCanonicalSeedPath) : []
+  const normalized = normalizeWorktreeDependencySeedPaths(markerPaths)
+  const declared = normalizeWorktreeDependencySeedPaths(
+    declaredPaths.filter((path): path is string => typeof path === 'string')
+  )
+  return normalized.filter((path) => declared.includes(path))
+}
+
+/** Verify that every top-level path named by a marker still exists as a real entry. */
+export async function dependencySeedMarkerEntriesUsable(
+  entryRoot: string,
+  marker: DependencySeedMarker
+): Promise<boolean> {
+  if (!marker || typeof marker !== 'object' || !Array.isArray(marker.paths)) {
+    return false
+  }
+  for (const path of marker.paths) {
+    const source = resolve(entryRoot, path)
+    try {
+      await assertDependencySeedPathNoSymlink(entryRoot, source)
+      const stats = await lstat(source)
+      if (stats.isSymbolicLink() || (!stats.isDirectory() && !stats.isFile())) {
+        return false
+      }
+      await assertDependencySeedTreeNoExternalSymlinks(source)
+    } catch {
+      return false
+    }
+  }
+  return true
+}

--- a/src/main/worktree-dependency-seed-path.ts
+++ b/src/main/worktree-dependency-seed-path.ts
@@ -1,0 +1,188 @@
+import { lstat, mkdir, realpath, stat } from 'node:fs/promises'
+import { isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
+
+function isPathInside(root: string, candidate: string): boolean {
+  const relativePath = relative(resolve(root), resolve(candidate))
+  return (
+    relativePath === '' ||
+    (!isAbsolute(relativePath) && relativePath !== '..' && !relativePath.startsWith(`..${sep}`))
+  )
+}
+
+function symlinkPathError(path: string): Error {
+  return new Error(`Refusing dependency seed path through a symlink: ${path}`)
+}
+
+/**
+ * macOS exposes /var (and usually /tmp) as links into /private. Those aliases
+ * are part of the normal filesystem layout, not a caller-controlled seed
+ * redirect, so keep them usable while rejecting every other link component.
+ */
+async function isAllowedSystemAlias(path: string): Promise<boolean> {
+  if (process.platform !== 'darwin') {
+    return false
+  }
+  const expectedTarget =
+    path === '/var' ? '/private/var' : path === '/tmp' ? '/private/tmp' : undefined
+  if (!expectedTarget) {
+    return false
+  }
+  try {
+    return (await realpath(path)) === expectedTarget
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Walk every existing component of a path without following a caller-owned
+ * symlink. Missing leaves are allowed because callers use this before creating
+ * a target; any ancestor that already exists is still checked.
+ */
+async function assertPathComponentsNoSymlink(path: string): Promise<void> {
+  const resolvedPath = resolve(path)
+  const parsed = parse(resolvedPath)
+  const segments = relative(parsed.root, resolvedPath).split(/[\\/]/u).filter(Boolean)
+  let current = parsed.root
+  const rootStats = await lstat(current)
+  if (rootStats.isSymbolicLink() || !rootStats.isDirectory()) {
+    throw symlinkPathError(current)
+  }
+  for (const [index, segment] of segments.entries()) {
+    current = join(current, segment)
+    let stats
+    try {
+      stats = await lstat(current)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return
+      }
+      throw error
+    }
+    if (stats.isSymbolicLink()) {
+      if (index < segments.length - 1 && (await isAllowedSystemAlias(current))) {
+        const targetStats = await stat(current)
+        if (!targetStats.isDirectory()) {
+          throw new Error(`Dependency seed path parent is not a directory: ${current}`)
+        }
+        continue
+      }
+      throw symlinkPathError(current)
+    }
+    if (index < segments.length - 1 && !stats.isDirectory()) {
+      throw new Error(`Dependency seed path parent is not a directory: ${current}`)
+    }
+  }
+}
+
+/** Check all existing filesystem components, including ancestors of a root. */
+export async function assertDependencySeedPathComponentsNoSymlink(path: string): Promise<void> {
+  await assertPathComponentsNoSymlink(path)
+}
+
+/**
+ * Check an existing root-relative path without following a symlink component.
+ * Missing leaves are allowed so callers can distinguish a missing input from a
+ * redirected one before they create or read it.
+ */
+export async function assertDependencySeedPathNoSymlink(
+  root: string,
+  candidate: string
+): Promise<void> {
+  const resolvedRoot = resolve(root)
+  const resolvedCandidate = resolve(candidate)
+  if (!isPathInside(resolvedRoot, resolvedCandidate)) {
+    throw new Error(`Dependency seed path escapes its root: ${candidate}`)
+  }
+
+  const rootStats = await lstat(resolvedRoot)
+  if (rootStats.isSymbolicLink() || !rootStats.isDirectory()) {
+    throw symlinkPathError(resolvedRoot)
+  }
+
+  // The explicit root check above protects the boundary itself; this second
+  // walk also covers symlink ancestors above that boundary (while retaining
+  // the macOS /var and /tmp aliases allowed by the component helper).
+  await assertPathComponentsNoSymlink(resolvedCandidate)
+
+  const relativeCandidate = relative(resolvedRoot, resolvedCandidate)
+  const segments = relativeCandidate ? relativeCandidate.split(/[\\/]/u) : []
+  let current = resolvedRoot
+  for (const segment of segments) {
+    current = resolve(current, segment)
+    let entryStats
+    try {
+      entryStats = await lstat(current)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return
+      }
+      throw error
+    }
+    if (entryStats.isSymbolicLink()) {
+      throw symlinkPathError(current)
+    }
+  }
+}
+
+/** Create a seed directory one component at a time, rejecting redirected paths. */
+export async function ensureDependencySeedDirectory(path: string): Promise<string> {
+  const resolvedPath = resolve(path)
+  const parsed = parse(resolvedPath)
+  const segments = relative(parsed.root, resolvedPath).split(/[\\/]/u).filter(Boolean)
+  let current = parsed.root
+
+  // Walk and create one component at a time. `mkdir(..., { recursive: true })`
+  // follows an existing symlink in any ancestor before we get a chance to
+  // inspect it; component-wise creation lets us reject that redirect.
+  for (const [index, segment] of segments.entries()) {
+    current = join(current, segment)
+    let stats
+    try {
+      stats = await lstat(current)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+      try {
+        await mkdir(current, { mode: 0o700 })
+      } catch (mkdirError) {
+        // Another creator may have won the race. Re-stat below and still
+        // reject a symlink rather than trusting the EEXIST outcome.
+        if ((mkdirError as NodeJS.ErrnoException).code !== 'EEXIST') {
+          throw mkdirError
+        }
+      }
+      stats = await lstat(current)
+    }
+    if (stats.isSymbolicLink()) {
+      // Only system aliases may occur before the generated seed components;
+      // never permit the requested target itself to be a symlink.
+      if (index === segments.length - 1 || !(await isAllowedSystemAlias(current))) {
+        throw symlinkPathError(current)
+      }
+      // Verify that an allowed alias resolves to a directory before walking
+      // through it. `lstat` intentionally reports the link itself above.
+      const targetStats = await stat(current)
+      if (!targetStats.isDirectory()) {
+        throw new Error(`Dependency seed root is not a directory: ${current}`)
+      }
+      continue
+    }
+    if (!stats.isDirectory()) {
+      throw new Error(`Dependency seed root is not a directory: ${current}`)
+    }
+  }
+
+  // Recheck the final entry after the walk so a replacement that happens
+  // immediately after its first lstat cannot turn the returned path into a
+  // symlink before callers create the lock or seed entry beneath it.
+  const finalStats = await lstat(resolvedPath)
+  if (finalStats.isSymbolicLink()) {
+    throw symlinkPathError(resolvedPath)
+  }
+  if (!finalStats.isDirectory()) {
+    throw new Error(`Dependency seed root is not a directory: ${resolvedPath}`)
+  }
+  return resolvedPath
+}

--- a/src/main/worktree-dependency-seed-plan.test.ts
+++ b/src/main/worktree-dependency-seed-plan.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { parseOrcaYaml } from '../shared/orca-yaml'
+import { resolveWorktreeDependencySeedPlan } from './worktree-dependency-seed-plan'
+
+describe('resolveWorktreeDependencySeedPlan', () => {
+  it('uses defaults when dependency seed settings are omitted', () => {
+    expect(resolveWorktreeDependencySeedPlan(null)).toEqual({ paths: ['node_modules'] })
+    expect(resolveWorktreeDependencySeedPlan({ scripts: {} })).toEqual({ paths: ['node_modules'] })
+    expect(resolveWorktreeDependencySeedPlan({ scripts: {}, worktree: {} })).toEqual({
+      paths: ['node_modules']
+    })
+  })
+
+  it('preserves explicit empty arrays as opt-out settings', () => {
+    const hooks = parseOrcaYaml(
+      ['worktree:', '  dependencySeedPaths: []', '  dependencySeedInputs: []'].join('\n')
+    )
+
+    expect(resolveWorktreeDependencySeedPlan(hooks)).toEqual({
+      paths: [],
+      fingerprintPaths: []
+    })
+  })
+
+  it('filters unsafe entries while retaining explicit array presence', () => {
+    const hooks = parseOrcaYaml(
+      [
+        'worktree:',
+        '  dependencySeedPaths:',
+        '    - ../escape',
+        '    - /etc/passwd',
+        '  dependencySeedInputs:',
+        '    - .git/config',
+        '    - ./../secret'
+      ].join('\n')
+    )
+
+    expect(resolveWorktreeDependencySeedPlan(hooks)).toEqual({
+      paths: [],
+      fingerprintPaths: []
+    })
+  })
+
+  it('keeps the parser collection bound for oversized path arrays', () => {
+    const paths = Array.from({ length: 101 }, (_, index) => `deps/path-${index}`)
+    const inputs = Array.from({ length: 101 }, (_, index) => `inputs/file-${index}.json`)
+    const hooks = parseOrcaYaml(
+      [
+        'worktree:',
+        '  dependencySeedPaths:',
+        ...paths.map((path) => `    - ${path}`),
+        '  dependencySeedInputs:',
+        ...inputs.map((path) => `    - ${path}`)
+      ].join('\n')
+    )
+    const plan = resolveWorktreeDependencySeedPlan(hooks)
+
+    expect(plan.paths).toHaveLength(100)
+    expect(plan.paths).toContain('deps/path-99')
+    expect(plan.paths).not.toContain('deps/path-100')
+    expect(plan.fingerprintPaths).toHaveLength(100)
+    expect(plan.fingerprintPaths).toContain('inputs/file-99.json')
+    expect(plan.fingerprintPaths).not.toContain('inputs/file-100.json')
+  })
+
+  it('does not collapse nested fingerprint input files', () => {
+    const hooks = parseOrcaYaml(
+      [
+        'worktree:',
+        '  dependencySeedInputs:',
+        '    - lockfiles',
+        '    - lockfiles/pnpm-lock.yaml'
+      ].join('\n')
+    )
+    expect(resolveWorktreeDependencySeedPlan(hooks).fingerprintPaths).toEqual([
+      'lockfiles',
+      'lockfiles/pnpm-lock.yaml'
+    ])
+  })
+})

--- a/src/main/worktree-dependency-seed-plan.ts
+++ b/src/main/worktree-dependency-seed-plan.ts
@@ -1,0 +1,39 @@
+import type { OrcaHooks } from '../shared/orca-yaml-hook-types'
+import {
+  normalizeWorktreeDependencySeedInputPaths,
+  normalizeWorktreeDependencySeedPaths
+} from './worktree-dependency-seed-fingerprint'
+
+/** The paths copied into a new worktree and the files used to identify them. */
+export type WorktreeDependencySeedPlan = {
+  paths: readonly string[]
+  /** `undefined` means use the built-in lockfile list. An empty list disables inputs. */
+  fingerprintPaths?: readonly string[]
+}
+
+const DEFAULT_DEPENDENCY_SEED_PATHS = ['node_modules'] as const
+
+/**
+ * Resolve the dependency-seed portion of a parsed `orca.yaml` document.
+ *
+ * Presence is intentional: the parser preserves an explicitly supplied empty
+ * array, allowing a project to opt out without changing older files that omit
+ * the setting.
+ */
+export function resolveWorktreeDependencySeedPlan(
+  hooks: OrcaHooks | null | undefined
+): WorktreeDependencySeedPlan {
+  const worktree = hooks?.worktree
+  const hasPaths = Array.isArray(worktree?.dependencySeedPaths)
+  const hasInputs = Array.isArray(worktree?.dependencySeedInputs)
+  const paths = hasPaths
+    ? normalizeWorktreeDependencySeedPaths(worktree?.dependencySeedPaths ?? [])
+    : [...DEFAULT_DEPENDENCY_SEED_PATHS]
+  const fingerprintPaths = hasInputs
+    ? normalizeWorktreeDependencySeedInputPaths(worktree?.dependencySeedInputs ?? [])
+    : undefined
+  return {
+    paths,
+    ...(fingerprintPaths !== undefined ? { fingerprintPaths } : {})
+  }
+}

--- a/src/main/worktree-dependency-seed-promotion.ts
+++ b/src/main/worktree-dependency-seed-promotion.ts
@@ -1,0 +1,206 @@
+import { lstat, mkdir, readdir, rename, writeFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import {
+  WORKTREE_DEPENDENCY_SEED_MARKER,
+  WORKTREE_DEPENDENCY_SEED_VERSION
+} from './worktree-dependency-seed-fingerprint'
+import {
+  cloneDependencySeedPath,
+  dependencySeedPathExists,
+  removeDependencySeedEntry
+} from './worktree-dependency-seed-clone'
+import {
+  createDependencySeedContext,
+  ensureDependencySeedRoot,
+  type SeedContext,
+  type WorktreeDependencySeedArgs,
+  type WorktreeDependencySeedResult
+} from './worktree-dependency-seed-context'
+import {
+  dependencySeedMarkerMatchesFingerprint,
+  dependencySeedMarkerEntriesUsable,
+  readDependencySeedMarker,
+  type DependencySeedMarker
+} from './worktree-dependency-seed-marker'
+import { withWorktreeDependencySeedLock } from './worktree-dependency-seed-lock'
+
+async function promoteContext(
+  context: SeedContext,
+  replaceExisting: boolean
+): Promise<WorktreeDependencySeedResult> {
+  await ensureDependencySeedRoot(context)
+  await cleanupDependencySeedCrashLeftovers(context.seedRoot)
+  const existingMarker = await readDependencySeedMarker(context.seedEntryPath)
+  if (
+    existingMarker &&
+    dependencySeedMarkerMatchesFingerprint(existingMarker, context.fingerprint) &&
+    context.paths.every((path) => existingMarker.paths.includes(path)) &&
+    (await dependencySeedMarkerEntriesUsable(context.seedEntryPath, existingMarker)) &&
+    !replaceExisting
+  ) {
+    return { status: 'existing', fingerprint: context.fingerprint.digest, paths: [] }
+  }
+
+  const stagingPath = join(
+    context.seedRoot,
+    `.staging-${process.pid}-${context.dependencies.randomUUID()}`
+  )
+  await mkdir(stagingPath)
+  const stagedPaths: string[] = []
+  try {
+    for (const path of context.paths) {
+      const source = resolve(context.worktreePath, path)
+      const target = resolve(stagingPath, path)
+      try {
+        const sourceEntry = await lstat(source)
+        if (sourceEntry.isSymbolicLink()) {
+          continue
+        }
+        const result = await cloneDependencySeedPath(
+          source,
+          target,
+          context.platform,
+          context.dependencies,
+          stagingPath,
+          context.worktreePath
+        )
+        if (result === 'cloned') {
+          stagedPaths.push(path)
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          continue
+        }
+        throw error
+      }
+    }
+    if (stagedPaths.length === 0) {
+      return {
+        status: 'skipped',
+        fingerprint: context.fingerprint.digest,
+        paths: [],
+        reason: 'no-dependency-paths'
+      }
+    }
+    const marker: DependencySeedMarker = {
+      version: WORKTREE_DEPENDENCY_SEED_VERSION,
+      fingerprint: context.fingerprint,
+      paths: stagedPaths,
+      createdAt: new Date().toISOString()
+    }
+    await writeFile(
+      join(stagingPath, WORKTREE_DEPENDENCY_SEED_MARKER),
+      `${JSON.stringify(marker, null, 2)}\n`,
+      { encoding: 'utf8', flag: 'wx' }
+    )
+
+    let backupPath: string | undefined
+    if (await dependencySeedPathExists(context.seedEntryPath)) {
+      backupPath = join(
+        context.seedRoot,
+        `.stale-${context.dependencies.randomUUID()}-${context.fingerprint.digest}`
+      )
+      await rename(context.seedEntryPath, backupPath)
+    }
+    try {
+      await rename(stagingPath, context.seedEntryPath)
+    } catch (error) {
+      if (backupPath) {
+        await rename(backupPath, context.seedEntryPath).catch(() => {})
+      }
+      throw error
+    }
+    if (backupPath) {
+      await removeDependencySeedEntry(backupPath).catch(() => {})
+    }
+    await pruneDependencySeedEntries(context)
+    return { status: 'promoted', fingerprint: context.fingerprint.digest, paths: stagedPaths }
+  } finally {
+    await removeDependencySeedEntry(stagingPath).catch(() => {})
+  }
+}
+
+const MAX_RETAINED_DEPENDENCY_SEEDS = 8
+
+/** Remove staging/backup entries left by a process that crashed mid-publish. */
+export async function cleanupDependencySeedCrashLeftovers(seedRoot: string): Promise<void> {
+  const entries = await readdir(seedRoot, { withFileTypes: true }).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null
+    }
+    throw error
+  })
+  if (!entries) {
+    return
+  }
+  for (const entry of entries) {
+    // The current publisher prefixes backups with `.stale-`; accept the old
+    // `<digest>.stale-...` form too so upgrades do not retain crash debris.
+    const isStaleBackup =
+      entry.name.startsWith('.stale-') || /^[0-9a-f]{64}\.stale-/u.test(entry.name)
+    if (!entry.name.startsWith('.staging-') && !isStaleBackup) {
+      continue
+    }
+    await removeDependencySeedEntry(join(seedRoot, entry.name)).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+    })
+  }
+}
+
+/** Remove only old, valid generated entries; unknown files remain untouched. */
+async function pruneDependencySeedEntries(context: SeedContext): Promise<void> {
+  const entries = await readdir(context.seedRoot, { withFileTypes: true })
+  const candidates: { path: string; createdAt: number }[] = []
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name.startsWith('.')) {
+      continue
+    }
+    const entryPath = join(context.seedRoot, entry.name)
+    const marker = await readDependencySeedMarker(entryPath)
+    if (
+      !marker ||
+      entry.name !== marker.fingerprint.digest ||
+      !dependencySeedMarkerMatchesFingerprint(marker, marker.fingerprint)
+    ) {
+      continue
+    }
+    const createdAt = Date.parse(marker.createdAt)
+    candidates.push({ path: entryPath, createdAt: Number.isFinite(createdAt) ? createdAt : 0 })
+  }
+  const retained = candidates
+    .sort((left, right) => right.createdAt - left.createdAt)
+    .slice(0, MAX_RETAINED_DEPENDENCY_SEEDS)
+  const retainedPaths = new Set(retained.map((entry) => entry.path))
+  for (const candidate of candidates) {
+    if (candidate.path === context.seedEntryPath || retainedPaths.has(candidate.path)) {
+      continue
+    }
+    await removeDependencySeedEntry(candidate.path).catch(() => {})
+  }
+}
+
+/** Promote a successfully-installed worktree into the local seed store. */
+export async function promoteWorktreeDependencySeed(
+  args: WorktreeDependencySeedArgs
+): Promise<WorktreeDependencySeedResult> {
+  try {
+    const context = await createDependencySeedContext(args)
+    if (!context) {
+      return { status: 'skipped', paths: [], reason: 'unsupported-platform-or-repository' }
+    }
+    return await withWorktreeDependencySeedLock(
+      context.seedEntryPath,
+      () => promoteContext(context, args.replaceExisting === true),
+      context.seedRoot
+    )
+  } catch (error) {
+    console.warn('[worktree-dependency-seed] promotion skipped:', error)
+    return {
+      status: 'failed',
+      paths: [],
+      reason: error instanceof Error ? error.message : 'promotion-failed'
+    }
+  }
+}

--- a/src/main/worktree-dependency-seed.test.ts
+++ b/src/main/worktree-dependency-seed.test.ts
@@ -1,0 +1,539 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { access, cp, mkdtemp, readFile, rm, writeFile, mkdir, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  computeWorktreeDependencySeedFingerprint,
+  cloneDependencySeedPath,
+  defaultWorktreeDependencySeedDependencies,
+  createWorktreeDependencySeedFingerprint,
+  createDependencySeedContext,
+  ensureDependencySeedRoot,
+  ensureDependencySeedDirectory,
+  getWorktreeDependencySeedRoot,
+  hydrateWorktreeDependencies,
+  normalizeDependencySeedPath,
+  normalizeWorktreeDependencySeedPaths,
+  promoteWorktreeDependencySeed,
+  readWorktreeDependencySeedInputs,
+  type WorktreeDependencySeedArgs
+} from './worktree-dependency-seed'
+import { withWorktreeDependencySeedLock } from './worktree-dependency-seed-lock'
+
+describe('worktree dependency seed fingerprint', () => {
+  const base = {
+    setupScript: 'pnpm install\n',
+    lockfiles: [{ path: 'pnpm-lock.yaml', bytes: Buffer.from('lock-v1') }],
+    platform: 'darwin' as const,
+    architecture: 'arm64',
+    nodeMajor: 22,
+    seedPaths: ['node_modules']
+  }
+
+  it('normalizes paths and is independent of input ordering', () => {
+    expect(
+      normalizeWorktreeDependencySeedPaths([
+        './node_modules/',
+        'node_modules/.cache',
+        'node_modules',
+        '../escape',
+        'C:\\outside'
+      ])
+    ).toEqual(['node_modules'])
+    const reversed = createWorktreeDependencySeedFingerprint({
+      ...base,
+      lockfiles: base.lockfiles.toReversed()
+    })
+    expect(reversed.digest).toBe(computeWorktreeDependencySeedFingerprint(base))
+  })
+
+  it('changes when any setup input or runtime dimension changes', () => {
+    const original = computeWorktreeDependencySeedFingerprint(base)
+    expect(
+      computeWorktreeDependencySeedFingerprint({ ...base, setupScript: 'npm install' })
+    ).not.toBe(original)
+    expect(
+      computeWorktreeDependencySeedFingerprint({
+        ...base,
+        lockfiles: [{ path: 'pnpm-lock.yaml', bytes: Buffer.from('lock-v2') }]
+      })
+    ).not.toBe(original)
+    expect(computeWorktreeDependencySeedFingerprint({ ...base, platform: 'linux' })).not.toBe(
+      original
+    )
+    expect(computeWorktreeDependencySeedFingerprint({ ...base, architecture: 'x64' })).not.toBe(
+      original
+    )
+    expect(computeWorktreeDependencySeedFingerprint({ ...base, nodeMajor: 23 })).not.toBe(original)
+  })
+
+  it('canonicalizes leading dot prefixes and preserves relative separators', () => {
+    expect(normalizeDependencySeedPath('./foo')).toBe('foo')
+    expect(normalizeDependencySeedPath('././foo')).toBe('foo')
+    expect(normalizeDependencySeedPath('foo\\bar')).toBe('foo/bar')
+    expect(normalizeDependencySeedPath('foo/./bar')).toBeNull()
+    expect(normalizeDependencySeedPath('../foo')).toBeNull()
+    expect(normalizeDependencySeedPath('C:\\outside')).toBeNull()
+  })
+})
+
+describe('worktree dependency seed fingerprint inputs', () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  })
+
+  it('reads nested files while refusing symlinked ancestors', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-dependency-seed-inputs-'))
+    roots.push(root)
+    const nested = join(root, 'nested')
+    const outside = join(root, 'outside')
+    await mkdir(nested)
+    await mkdir(outside)
+    await writeFile(join(nested, 'package-lock.json'), 'inside')
+    await writeFile(join(outside, 'package-lock.json'), 'outside')
+    await symlink(outside, join(root, 'redirect'), 'dir')
+
+    await expect(
+      readWorktreeDependencySeedInputs(root, ['./nested/package-lock.json'])
+    ).resolves.toEqual([{ path: 'nested/package-lock.json', bytes: expect.any(Uint8Array) }])
+    await expect(
+      readWorktreeDependencySeedInputs(root, ['redirect/package-lock.json'])
+    ).rejects.toThrow(/symlink/u)
+  })
+
+  it('ignores missing fingerprint inputs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-dependency-seed-inputs-'))
+    roots.push(root)
+    await expect(
+      readWorktreeDependencySeedInputs(root, ['./missing/package-lock.json'])
+    ).resolves.toEqual([])
+  })
+})
+
+describe('worktree dependency seed hydration and promotion', () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  })
+
+  async function fixture(): Promise<{
+    root: string
+    repo: string
+    worktree: string
+    seedRoot: string
+    cloneDarwinPath: NonNullable<WorktreeDependencySeedArgs['dependencies']>['cloneDarwinPath']
+  }> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-dependency-seed-'))
+    roots.push(root)
+    const repo = join(root, 'repo')
+    const worktree = join(root, 'first')
+    const seedRoot = join(root, 'seeds')
+    await mkdir(repo, { recursive: true })
+    await mkdir(join(worktree, 'node_modules'), { recursive: true })
+    await writeFile(join(repo, 'pnpm-lock.yaml'), 'lock-v1')
+    await writeFile(join(worktree, 'pnpm-lock.yaml'), 'lock-v1')
+    await writeFile(join(worktree, 'node_modules', 'package.js'), 'module.exports = 1\n')
+    const cloneDarwinPath = async (source: string, target: string, sourceIsDirectory: boolean) => {
+      await cp(source, target, { recursive: sourceIsDirectory })
+    }
+    return { root, repo, worktree, seedRoot, cloneDarwinPath }
+  }
+
+  function args(
+    fixtureData: Awaited<ReturnType<typeof fixture>>,
+    worktreePath = fixtureData.worktree
+  ) {
+    return {
+      repo: fixtureData.repo,
+      worktreePath,
+      setupScript: 'pnpm install\n',
+      declaredSeedPaths: ['node_modules'],
+      platform: 'darwin' as const,
+      architecture: 'arm64',
+      nodeMajor: 22,
+      seedRoot: fixtureData.seedRoot,
+      dependencies: { cloneDarwinPath: fixtureData.cloneDarwinPath }
+    }
+  }
+
+  it('promotes a private tree, hydrates a fresh worktree, and preserves copy isolation', async () => {
+    const data = await fixture()
+    await expect(promoteWorktreeDependencySeed(args(data))).resolves.toMatchObject({
+      status: 'promoted',
+      paths: ['node_modules']
+    })
+    const second = join(data.root, 'second')
+    await mkdir(second)
+    await writeFile(join(second, 'pnpm-lock.yaml'), 'lock-v1')
+    await expect(hydrateWorktreeDependencies(args(data, second))).resolves.toMatchObject({
+      status: 'hydrated',
+      paths: ['node_modules']
+    })
+    await writeFile(join(second, 'node_modules', 'package.js'), 'changed\n')
+    await expect(readFile(join(data.worktree, 'node_modules', 'package.js'), 'utf8')).resolves.toBe(
+      'module.exports = 1\n'
+    )
+  })
+
+  it('misses changed fingerprints and never overwrites an existing target', async () => {
+    const data = await fixture()
+    await promoteWorktreeDependencySeed(args(data))
+    const changed = join(data.root, 'changed')
+    await mkdir(join(changed, 'node_modules'), { recursive: true })
+    await writeFile(join(changed, 'pnpm-lock.yaml'), 'lock-v2')
+    await expect(hydrateWorktreeDependencies(args(data, changed))).resolves.toMatchObject({
+      status: 'miss'
+    })
+
+    const existing = join(data.root, 'existing')
+    await mkdir(join(existing, 'node_modules'), { recursive: true })
+    await writeFile(join(existing, 'pnpm-lock.yaml'), 'lock-v1')
+    await writeFile(join(existing, 'node_modules', 'package.js'), 'local\n')
+    await expect(hydrateWorktreeDependencies(args(data, existing))).resolves.toMatchObject({
+      status: 'existing',
+      paths: []
+    })
+    await expect(readFile(join(existing, 'node_modules', 'package.js'), 'utf8')).resolves.toBe(
+      'local\n'
+    )
+  })
+
+  it('rejects a marker whose fingerprint seed paths were tampered with', async () => {
+    const data = await fixture()
+    await promoteWorktreeDependencySeed(args(data))
+    const digest = computeWorktreeDependencySeedFingerprint({
+      setupScript: 'pnpm install\n',
+      lockfiles: [{ path: 'pnpm-lock.yaml', bytes: Buffer.from('lock-v1') }],
+      platform: 'darwin',
+      architecture: 'arm64',
+      nodeMajor: 22,
+      seedPaths: ['node_modules']
+    })
+    const markerPath = join(data.seedRoot, digest, 'seed.json')
+    const marker = JSON.parse(await readFile(markerPath, 'utf8'))
+    marker.fingerprint.seedPaths = []
+    await writeFile(markerPath, JSON.stringify(marker))
+    const target = join(data.root, 'tampered')
+    await mkdir(target)
+    await writeFile(join(target, 'pnpm-lock.yaml'), 'lock-v1')
+    await expect(hydrateWorktreeDependencies(args(data, target))).resolves.toMatchObject({
+      status: 'miss'
+    })
+  })
+
+  it('treats malformed marker paths as a cache miss', async () => {
+    const data = await fixture()
+    await promoteWorktreeDependencySeed(args(data))
+    const entries = await (await import('node:fs/promises')).readdir(data.seedRoot)
+    const markerPath = join(data.seedRoot, entries[0], 'seed.json')
+    const marker = JSON.parse(await readFile(markerPath, 'utf8'))
+    marker.paths = [null]
+    await writeFile(markerPath, JSON.stringify(marker))
+
+    const target = join(data.root, 'malformed-marker-target')
+    await mkdir(target)
+    await writeFile(join(target, 'pnpm-lock.yaml'), 'lock-v1')
+    await expect(hydrateWorktreeDependencies(args(data, target))).resolves.toMatchObject({
+      status: 'miss'
+    })
+  })
+
+  it('refuses a target parent symlink instead of writing outside the target root', async () => {
+    const data = await fixture()
+    const outside = join(data.root, 'outside')
+    const targetRoot = join(data.root, 'target-root')
+    await mkdir(outside)
+    await mkdir(targetRoot)
+    await symlink(outside, join(targetRoot, 'redirect'))
+
+    const source = join(data.worktree, 'node_modules', 'package.js')
+    const target = join(targetRoot, 'redirect', 'copied.js')
+    await expect(
+      cloneDependencySeedPath(
+        source,
+        target,
+        'darwin',
+        { ...defaultWorktreeDependencySeedDependencies, cloneDarwinPath: async () => undefined },
+        targetRoot,
+        data.worktree
+      )
+    ).rejects.toThrow(/symlink/u)
+    await expect(readFile(join(outside, 'copied.js'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
+  it('refuses a source parent symlink instead of importing outside the source root', async () => {
+    const data = await fixture()
+    const sourceRoot = join(data.root, 'source-root')
+    const outside = join(data.root, 'outside-source')
+    const targetRoot = join(data.root, 'target-root')
+    await mkdir(sourceRoot)
+    await mkdir(outside)
+    await mkdir(targetRoot)
+    await writeFile(join(outside, 'secret.js'), 'secret\n')
+    await symlink(outside, join(sourceRoot, 'redirect'))
+
+    await expect(
+      cloneDependencySeedPath(
+        join(sourceRoot, 'redirect', 'secret.js'),
+        join(targetRoot, 'copied.js'),
+        'darwin',
+        { ...defaultWorktreeDependencySeedDependencies, cloneDarwinPath: async () => undefined },
+        targetRoot,
+        sourceRoot
+      )
+    ).rejects.toThrow(/symlink/u)
+  })
+
+  it('refuses a nested dependency symlink that escapes the worktree', async () => {
+    const data = await fixture()
+    const outside = join(data.root, 'nested-outside')
+    await mkdir(outside)
+    await writeFile(join(outside, 'secret.js'), 'secret\n')
+    await symlink(outside, join(data.worktree, 'node_modules', 'redirect'), 'dir')
+
+    await expect(promoteWorktreeDependencySeed(args(data))).resolves.toMatchObject({
+      status: 'failed'
+    })
+    const seedEntries = await (
+      await import('node:fs/promises')
+    )
+      .readdir(data.seedRoot)
+      .catch(() => [])
+    expect(seedEntries.some((entry) => entry === 'seed.json')).toBe(false)
+  })
+
+  it('keeps default clone roots from trusting symlink ancestors', async () => {
+    const data = await fixture()
+    const sourceAlias = join(data.root, 'source-alias')
+    const targetRoot = join(data.root, 'default-target')
+    const targetAlias = join(data.root, 'target-alias')
+    await symlink(data.worktree, sourceAlias, 'dir')
+    await mkdir(targetRoot)
+    await symlink(targetRoot, targetAlias, 'dir')
+    const dependencies = {
+      ...defaultWorktreeDependencySeedDependencies,
+      cloneDarwinPath: async () => undefined
+    }
+
+    await expect(
+      cloneDependencySeedPath(
+        join(sourceAlias, 'node_modules', 'package.js'),
+        join(targetRoot, 'copied.js'),
+        'darwin',
+        dependencies
+      )
+    ).rejects.toThrow(/symlink/u)
+    await expect(
+      cloneDependencySeedPath(
+        join(data.worktree, 'node_modules', 'package.js'),
+        join(targetAlias, 'copied.js'),
+        'darwin',
+        dependencies
+      )
+    ).rejects.toThrow(/symlink/u)
+  })
+
+  it('fails open when copy-on-write is unavailable and does not publish a marker', async () => {
+    const data = await fixture()
+    const cloneDarwinPath = vi.fn(async () => {
+      throw new Error('not APFS')
+    })
+    await expect(
+      promoteWorktreeDependencySeed(args({ ...data, cloneDarwinPath }))
+    ).resolves.toMatchObject({ status: 'failed' })
+    const seedRootEntries = await (
+      await import('node:fs/promises')
+    )
+      .readdir(data.seedRoot)
+      .catch(() => [])
+    expect(seedRootEntries.some((entry) => entry === 'seed.json')).toBe(false)
+  })
+
+  it('serializes concurrent promotions for one seed entry', async () => {
+    const data = await fixture()
+    let active = 0
+    let maximum = 0
+    const cloneDarwinPath = async (source: string, target: string, sourceIsDirectory: boolean) => {
+      active += 1
+      maximum = Math.max(maximum, active)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      await cp(source, target, { recursive: sourceIsDirectory })
+      active -= 1
+    }
+    const [first, second] = await Promise.all([
+      promoteWorktreeDependencySeed(args({ ...data, cloneDarwinPath })),
+      promoteWorktreeDependencySeed(args({ ...data, cloneDarwinPath }))
+    ])
+    expect(maximum).toBe(1)
+    expect([first.status, second.status].sort()).toEqual(['existing', 'promoted'])
+  })
+
+  it('keeps the default store beside the worktree and allows an explicit root', () => {
+    const defaultRoot = getWorktreeDependencySeedRoot('/repo', '/workspace/feature')
+    expect(defaultRoot).toContain(join('workspace', '.orca-dependency-seeds'))
+    expect(getWorktreeDependencySeedRoot('/repo', '/workspace/feature', '/tmp/seeds')).toBe(
+      '/tmp/seeds'
+    )
+  })
+
+  it('fails closed when the explicit seed root is a symlink', async () => {
+    const data = await fixture()
+    const realRoot = join(data.root, 'real-seeds')
+    const aliasRoot = join(data.root, 'seed-alias')
+    await mkdir(realRoot)
+    await symlink(realRoot, aliasRoot, 'dir')
+
+    const context = await createDependencySeedContext({
+      ...args(data),
+      seedRoot: aliasRoot
+    })
+    expect(context).not.toBeNull()
+    await expect(ensureDependencySeedRoot(context!)).rejects.toThrow(/symlink/u)
+    await expect(
+      promoteWorktreeDependencySeed({ ...args(data), seedRoot: aliasRoot })
+    ).resolves.toMatchObject({
+      status: 'failed'
+    })
+    await expect((await import('node:fs/promises')).readdir(realRoot)).resolves.toEqual([])
+  })
+
+  it('fails closed when the generated store parent is a symlink', async () => {
+    const data = await fixture()
+    const redirectedParent = join(data.root, 'redirected-seeds')
+    const generatedParent = join(data.root, '.orca-dependency-seeds')
+    await mkdir(redirectedParent)
+    await symlink(redirectedParent, generatedParent, 'dir')
+
+    const result = await promoteWorktreeDependencySeed({
+      ...args(data),
+      seedRoot: join(generatedParent, 'repo-hash')
+    })
+    expect(result.status).toBe('failed')
+    await expect((await import('node:fs/promises')).readdir(redirectedParent)).resolves.toEqual([])
+  })
+
+  it('creates missing seed components but rejects a nested symlink redirect', async () => {
+    const data = await fixture()
+    const nested = join(data.root, 'new', 'nested', 'seed-root')
+    await expect(ensureDependencySeedDirectory(nested)).resolves.toBe(nested)
+
+    // macOS presents /tmp as /private/tmp; the system alias must not make a
+    // normal seed path unusable while caller-controlled links remain blocked.
+    const tempAliasRoot = await mkdtemp('/tmp/orca-dependency-seed-alias-')
+    roots.push(tempAliasRoot)
+    await expect(ensureDependencySeedDirectory(join(tempAliasRoot, 'nested'))).resolves.toBe(
+      join(tempAliasRoot, 'nested')
+    )
+
+    const real = join(data.root, 'real-parent')
+    const alias = join(data.root, 'alias-parent')
+    await mkdir(real)
+    await symlink(real, alias, 'dir')
+    const redirected = join(alias, 'child', 'seed-root')
+    await expect(ensureDependencySeedDirectory(redirected)).rejects.toThrow(/symlink/u)
+    await expect(access(join(real, 'child'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})
+
+describe('worktree dependency seed lock', () => {
+  it('queues operations by key while allowing different keys to proceed', async () => {
+    const events: string[] = []
+    let release!: () => void
+    const blocker = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const first = withWorktreeDependencySeedLock('same', async () => {
+      events.push('first:start')
+      await blocker
+      events.push('first:end')
+    })
+    const second = withWorktreeDependencySeedLock('same', async () => {
+      events.push('second:start')
+    })
+    const other = withWorktreeDependencySeedLock('other', async () => {
+      events.push('other:start')
+    })
+    await other
+    expect(events).toEqual(['first:start', 'other:start'])
+    release()
+    await Promise.all([first, second])
+    expect(events).toEqual(['first:start', 'other:start', 'first:end', 'second:start'])
+  })
+
+  it('creates a filesystem lock for absolute seed keys', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-dependency-seed-lock-'))
+    const lockKey = join(root, 'entry')
+    let releaseOperation!: () => void
+    const operationBlocked = new Promise<void>((resolve) => {
+      releaseOperation = resolve
+    })
+    try {
+      const running = withWorktreeDependencySeedLock(lockKey, async () => {
+        await vi.waitFor(async () => {
+          await access(`${lockKey}.lock`)
+        })
+        await operationBlocked
+      })
+      await vi.waitFor(async () => {
+        await access(`${lockKey}.lock`)
+      })
+      expect(await access(`${lockKey}.lock`)).toBeUndefined()
+      releaseOperation()
+      await running
+      await expect(access(`${lockKey}.lock`)).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      releaseOperation()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('locks a stable root before an entry exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-dependency-seed-lock-root-'))
+    const entry = join(root, 'missing-entry')
+    let releaseOperation!: () => void
+    const operationBlocked = new Promise<void>((resolve) => {
+      releaseOperation = resolve
+    })
+    try {
+      const running = withWorktreeDependencySeedLock(
+        entry,
+        async () => {
+          await operationBlocked
+        },
+        root
+      )
+      await vi.waitFor(async () => {
+        await access(`${root}.lock`)
+      })
+      await expect(access(entry)).rejects.toMatchObject({ code: 'ENOENT' })
+      releaseOperation()
+      await running
+      await expect(access(`${root}.lock`)).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      releaseOperation()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a symlinked lock path instead of following it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-dependency-seed-lock-link-'))
+    const entry = join(root, 'entry')
+    const outside = join(root, 'outside')
+    await mkdir(entry)
+    await mkdir(outside)
+    await symlink(outside, `${entry}.lock`, 'dir')
+    try {
+      await expect(withWorktreeDependencySeedLock(entry, async () => undefined)).rejects.toThrow(
+        /symlink/u
+      )
+      await expect((await import('node:fs/promises')).readdir(outside)).resolves.toEqual([])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/worktree-dependency-seed.test.ts
+++ b/src/main/worktree-dependency-seed.test.ts
@@ -178,6 +178,55 @@ describe('worktree dependency seed hydration and promotion', () => {
     )
   })
 
+  it('rolls back newly hydrated paths when a later clone fails', async () => {
+    const data = await fixture()
+    for (const path of ['other-deps', 'preexisting-deps']) {
+      await mkdir(join(data.worktree, path))
+      await writeFile(join(data.worktree, path, 'package.js'), `${path}\n`)
+    }
+    const seedArgs = {
+      ...args(data),
+      declaredSeedPaths: ['node_modules', 'other-deps', 'preexisting-deps']
+    }
+    await expect(promoteWorktreeDependencySeed(seedArgs)).resolves.toMatchObject({
+      status: 'promoted',
+      paths: ['node_modules', 'other-deps', 'preexisting-deps']
+    })
+
+    const target = join(data.root, 'rollback-target')
+    await mkdir(target)
+    await writeFile(join(target, 'pnpm-lock.yaml'), 'lock-v1')
+    await mkdir(join(target, 'preexisting-deps'))
+    await writeFile(join(target, 'preexisting-deps', 'keep.js'), 'keep\n')
+    let cloneCalls = 0
+    const cloneDarwinPath = async (
+      source: string,
+      destination: string,
+      sourceIsDirectory: boolean
+    ): Promise<void> => {
+      cloneCalls += 1
+      if (cloneCalls === 2) {
+        await mkdir(destination)
+        await writeFile(join(destination, 'partial.js'), 'partial\n')
+        throw new Error('injected clone failure')
+      }
+      await cp(source, destination, { recursive: sourceIsDirectory })
+    }
+
+    await expect(
+      hydrateWorktreeDependencies({
+        ...seedArgs,
+        worktreePath: target,
+        dependencies: { cloneDarwinPath }
+      })
+    ).resolves.toMatchObject({ status: 'failed', paths: [] })
+    await expect(access(join(target, 'node_modules'))).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(access(join(target, 'other-deps'))).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(join(target, 'preexisting-deps', 'keep.js'), 'utf8')).resolves.toBe(
+      'keep\n'
+    )
+  })
+
   it('misses changed fingerprints and never overwrites an existing target', async () => {
     const data = await fixture()
     await promoteWorktreeDependencySeed(args(data))

--- a/src/main/worktree-dependency-seed.ts
+++ b/src/main/worktree-dependency-seed.ts
@@ -1,0 +1,157 @@
+import {
+  dependencySeedMarkerMatchesFingerprint,
+  dependencySeedMarkerEntriesUsable,
+  dependencySeedMarkerPaths,
+  readDependencySeedMarker
+} from './worktree-dependency-seed-marker'
+import { cloneDependencySeedPath, dependencySeedPathExists } from './worktree-dependency-seed-clone'
+import {
+  createDependencySeedContext,
+  ensureDependencySeedRoot,
+  type SeedContext,
+  type WorktreeDependencySeedArgs,
+  type WorktreeDependencySeedResult
+} from './worktree-dependency-seed-context'
+import { withWorktreeDependencySeedLock } from './worktree-dependency-seed-lock'
+import { cleanupDependencySeedCrashLeftovers } from './worktree-dependency-seed-promotion'
+import { join } from 'node:path'
+
+export {
+  WORKTREE_DEPENDENCY_SEED_DIRECTORY,
+  WORKTREE_DEPENDENCY_SEED_MARKER,
+  WORKTREE_DEPENDENCY_SEED_LOCKFILE_PATHS,
+  WORKTREE_DEPENDENCY_SEED_VERSION,
+  createDependencySeedFingerprint,
+  createWorktreeDependencySeedFingerprint,
+  computeDependencySeedFingerprint,
+  computeWorktreeDependencySeedFingerprint,
+  getWorktreeDependencySeedRoot,
+  isValidDependencySeedInput,
+  normalizeDependencySeedPath,
+  normalizeWorktreeDependencySeedInputPaths,
+  normalizeWorktreeDependencySeedPaths,
+  readWorktreeDependencySeedInputs
+} from './worktree-dependency-seed-fingerprint'
+export {
+  cloneDependencySeedPath,
+  defaultWorktreeDependencySeedDependencies,
+  dependencySeedPathExists,
+  dependencySeedSameDevice,
+  removeDependencySeedEntry
+} from './worktree-dependency-seed-clone'
+export {
+  dependencySeedMarkerMatchesFingerprint,
+  dependencySeedMarkerPaths,
+  readDependencySeedMarker
+} from './worktree-dependency-seed-marker'
+export { withWorktreeDependencySeedLock } from './worktree-dependency-seed-lock'
+export {
+  createDependencySeedContext,
+  ensureDependencySeedRoot
+} from './worktree-dependency-seed-context'
+export {
+  assertDependencySeedPathNoSymlink,
+  ensureDependencySeedDirectory
+} from './worktree-dependency-seed-path'
+export { promoteWorktreeDependencySeed } from './worktree-dependency-seed-promotion'
+export { cleanupDependencySeedCrashLeftovers } from './worktree-dependency-seed-promotion'
+export {
+  resolveWorktreeDependencySeedPlan,
+  type WorktreeDependencySeedPlan
+} from './worktree-dependency-seed-plan'
+export type {
+  DependencySeedInputDigest,
+  DependencySeedInputFile,
+  WorktreeDependencySeedFingerprint,
+  WorktreeDependencySeedFingerprintInput,
+  WorktreeDependencySeedRepo
+} from './worktree-dependency-seed-fingerprint'
+export type {
+  DependencySeedProcessRunner,
+  WorktreeDependencySeedDependencies
+} from './worktree-dependency-seed-clone'
+export type {
+  SeedContext,
+  WorktreeDependencySeedArgs,
+  WorktreeDependencySeedOptions,
+  WorktreeDependencySeedResult
+} from './worktree-dependency-seed-context'
+
+async function hydrateContext(context: SeedContext): Promise<WorktreeDependencySeedResult> {
+  await ensureDependencySeedRoot(context)
+  await cleanupDependencySeedCrashLeftovers(context.seedRoot)
+  const marker = await readDependencySeedMarker(context.seedEntryPath)
+  if (!marker || !dependencySeedMarkerMatchesFingerprint(marker, context.fingerprint)) {
+    return { status: 'miss', fingerprint: context.fingerprint.digest, paths: [] }
+  }
+  if (!(await dependencySeedMarkerEntriesUsable(context.seedEntryPath, marker))) {
+    return { status: 'miss', fingerprint: context.fingerprint.digest, paths: [] }
+  }
+  const markerPaths = dependencySeedMarkerPaths(marker, context.paths)
+  if (markerPaths.length === 0) {
+    return { status: 'miss', fingerprint: context.fingerprint.digest, paths: [] }
+  }
+  const hydrated: string[] = []
+  for (const path of markerPaths) {
+    const source = join(context.seedEntryPath, path)
+    const target = join(context.worktreePath, path)
+    try {
+      // A marker is published only after every listed path is cloned. Treat a
+      // later missing source as a cache miss instead of reporting `existing`
+      // and silently accepting a partial/tampered seed.
+      if (!(await dependencySeedPathExists(source))) {
+        return { status: 'miss', fingerprint: context.fingerprint.digest, paths: [] }
+      }
+      if (await dependencySeedPathExists(target)) {
+        continue
+      }
+      const result = await cloneDependencySeedPath(
+        source,
+        target,
+        context.platform,
+        context.dependencies,
+        context.worktreePath,
+        context.seedEntryPath
+      )
+      if (result === 'cloned') {
+        hydrated.push(path)
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        continue
+      }
+      throw error
+    }
+  }
+  return {
+    status: hydrated.length > 0 ? 'hydrated' : 'existing',
+    fingerprint: context.fingerprint.digest,
+    paths: hydrated
+  }
+}
+
+/** Hydrate a newly-created worktree from a matching private CoW seed, fail-open. */
+export async function hydrateWorktreeDependencies(
+  args: WorktreeDependencySeedArgs
+): Promise<WorktreeDependencySeedResult> {
+  try {
+    const context = await createDependencySeedContext(args)
+    if (!context) {
+      return { status: 'skipped', paths: [], reason: 'unsupported-platform-or-repository' }
+    }
+    return await withWorktreeDependencySeedLock(
+      context.seedEntryPath,
+      () => hydrateContext(context),
+      context.seedRoot
+    )
+  } catch (error) {
+    console.warn('[worktree-dependency-seed] hydration skipped:', error)
+    return {
+      status: 'failed',
+      paths: [],
+      reason: error instanceof Error ? error.message : 'hydration-failed'
+    }
+  }
+}
+
+export type { DependencySeedMarker } from './worktree-dependency-seed-marker'

--- a/src/main/worktree-dependency-seed.ts
+++ b/src/main/worktree-dependency-seed.ts
@@ -4,7 +4,12 @@ import {
   dependencySeedMarkerPaths,
   readDependencySeedMarker
 } from './worktree-dependency-seed-marker'
-import { cloneDependencySeedPath, dependencySeedPathExists } from './worktree-dependency-seed-clone'
+import {
+  cloneDependencySeedPath,
+  dependencySeedPathExists,
+  isDependencySeedTargetExistsError,
+  removeDependencySeedEntry
+} from './worktree-dependency-seed-clone'
 import {
   createDependencySeedContext,
   ensureDependencySeedRoot,
@@ -92,19 +97,29 @@ async function hydrateContext(context: SeedContext): Promise<WorktreeDependencyS
     return { status: 'miss', fingerprint: context.fingerprint.digest, paths: [] }
   }
   const hydrated: string[] = []
+  const hydratedTargets: string[] = []
+  const rollbackHydratedTargets = async (additionalTarget?: string): Promise<void> => {
+    const targets = [
+      ...new Set([...hydratedTargets, ...(additionalTarget ? [additionalTarget] : [])])
+    ]
+    await Promise.all(targets.map((target) => removeDependencySeedEntry(target)))
+  }
   for (const path of markerPaths) {
     const source = join(context.seedEntryPath, path)
     const target = join(context.worktreePath, path)
+    let targetExistedBeforeClone = true
     try {
       // A marker is published only after every listed path is cloned. Treat a
       // later missing source as a cache miss instead of reporting `existing`
       // and silently accepting a partial/tampered seed.
       if (!(await dependencySeedPathExists(source))) {
+        await rollbackHydratedTargets()
         return { status: 'miss', fingerprint: context.fingerprint.digest, paths: [] }
       }
       if (await dependencySeedPathExists(target)) {
         continue
       }
+      targetExistedBeforeClone = false
       const result = await cloneDependencySeedPath(
         source,
         target,
@@ -115,11 +130,20 @@ async function hydrateContext(context: SeedContext): Promise<WorktreeDependencyS
       )
       if (result === 'cloned') {
         hydrated.push(path)
+        hydratedTargets.push(target)
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        continue
+        await rollbackHydratedTargets(
+          !targetExistedBeforeClone && !isDependencySeedTargetExistsError(error)
+            ? target
+            : undefined
+        )
+        return { status: 'miss', fingerprint: context.fingerprint.digest, paths: [] }
       }
+      await rollbackHydratedTargets(
+        !targetExistedBeforeClone && !isDependencySeedTargetExistsError(error) ? target : undefined
+      )
       throw error
     }
   }

--- a/src/shared/orca-yaml-hook-types.ts
+++ b/src/shared/orca-yaml-hook-types.ts
@@ -20,6 +20,10 @@ export type OrcaWorktreeDefaults = {
   // Why: shared (symlinked) rather than copied — large rebuildable dirs like
   // node_modules should be one install serving every worktree.
   sharedDirectories?: string[]
+  /** Repo-relative paths to seed into newly-created worktrees after setup. */
+  dependencySeedPaths?: string[]
+  /** Repo-relative files that identify the dependency/setup input for a seed. */
+  dependencySeedInputs?: string[]
 }
 
 export type OrcaDefaultTabTemplate = {

--- a/src/shared/orca-yaml.ts
+++ b/src/shared/orca-yaml.ts
@@ -32,28 +32,30 @@ export const ORCA_VM_RECIPE_ID_RULE =
   'Use 1-64 lowercase letters, numbers, dots, underscores, or hyphens, starting with a letter or number.'
 
 // Why: bound the work one repo file can request; entries beyond this are ignored.
-const MAX_SHARED_DIRECTORIES = 100
+const MAX_WORKTREE_PATHS = 100
 
-/** Normalize `worktree.sharedDirectories` into deduped repo-root-relative paths.
+/** Normalize a worktree path list into deduped repo-root-relative paths.
  *  `\` becomes `/`, a `./` prefix and trailing `/` are stripped. Absolute paths,
  *  `..` traversal and `.git` are dropped here so callers get only safe entries.
  *
  *  Entries that would still need collapsing (`apps/./web`) are dropped rather
- *  than rewritten: `resolve()` collapses them when the symlink is created, but
- *  Git reports the collapsed path, so every later comparison against the stored
- *  entry would miss and the link would look like permanent untracked work. */
-function normalizeSharedDirectories(value: unknown): string[] {
+ *  than rewritten: callers compare these paths textually, so collapsing them
+ *  later would make the stored identity differ from the materialized path. */
+function normalizeWorktreePaths(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return []
   }
 
   const seen = new Set<string>()
-  for (const entry of value.slice(0, MAX_SHARED_DIRECTORIES)) {
+  for (const entry of value.slice(0, MAX_WORKTREE_PATHS)) {
     const raw = asTrimmedString(entry)
     if (!raw) {
       continue
     }
-    const normalized = raw.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '')
+    const normalized = raw
+      .replace(/\\/g, '/')
+      .replace(/^(?:\.\/)+/u, '')
+      .replace(/\/+$/, '')
     const segments = normalized.split('/')
     if (
       !normalized ||
@@ -70,6 +72,8 @@ function normalizeSharedDirectories(value: unknown): string[] {
   }
   return Array.from(seen)
 }
+
+const normalizeSharedDirectories = normalizeWorktreePaths
 
 function normalizeDefaultTabs(value: unknown): OrcaDefaultTabTemplate[] {
   if (!Array.isArray(value) || value.length > MAX_ORCA_YAML_COLLECTION_ENTRIES) {
@@ -236,9 +240,27 @@ export function parseOrcaYaml(content: string): OrcaHooks | null {
   const environmentRecipes = environmentRecipeParse.recipes
   const environmentRecipeDiagnostics = environmentRecipeParse.diagnostics
   const worktreeRecord = asRecord(record.worktree)
+  // Keep an explicitly-declared dependency array, including `[]`, so callers
+  // can distinguish "disable this input/path set" from an omitted setting.
+  const dependencySeedPathsConfigured = Array.isArray(worktreeRecord?.dependencySeedPaths)
+  const dependencySeedInputsConfigured = Array.isArray(worktreeRecord?.dependencySeedInputs)
   const sharedDirectories = worktreeRecord
     ? normalizeSharedDirectories(worktreeRecord.sharedDirectories)
     : []
+  const dependencySeedPaths = worktreeRecord
+    ? normalizeWorktreePaths(worktreeRecord.dependencySeedPaths)
+    : []
+  const dependencySeedInputs = worktreeRecord
+    ? normalizeWorktreePaths(worktreeRecord.dependencySeedInputs)
+    : []
+  const worktree =
+    sharedDirectories.length > 0 || dependencySeedPathsConfigured || dependencySeedInputsConfigured
+      ? {
+          ...(sharedDirectories.length > 0 ? { sharedDirectories } : {}),
+          ...(dependencySeedPathsConfigured ? { dependencySeedPaths } : {}),
+          ...(dependencySeedInputsConfigured ? { dependencySeedInputs } : {})
+        }
+      : undefined
 
   if (
     !setup &&
@@ -248,7 +270,7 @@ export function parseOrcaYaml(content: string): OrcaHooks | null {
     defaultTabs.length === 0 &&
     environmentRecipes.length === 0 &&
     environmentRecipeDiagnostics.length === 0 &&
-    sharedDirectories.length === 0
+    worktree === undefined
   ) {
     return null
   }
@@ -263,6 +285,6 @@ export function parseOrcaYaml(content: string): OrcaHooks | null {
     ...(defaultTabs.length > 0 ? { defaultTabs } : {}),
     ...(environmentRecipes.length > 0 ? { environmentRecipes } : {}),
     ...(environmentRecipeDiagnostics.length > 0 ? { environmentRecipeDiagnostics } : {}),
-    ...(sharedDirectories.length > 0 ? { worktree: { sharedDirectories } } : {})
+    ...(worktree ? { worktree } : {})
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1294 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1294 |
| Prod | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2322 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​96 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2226 |

<!-- /orca-pr-loc -->

## ELI5

When Orca creates several worktrees for the same project, each one normally rebuilds the same dependency tree from scratch. This change keeps a private, content-addressed copy of a successful dependency install and uses filesystem copy-on-write cloning for later worktrees. Each worktree still gets an independent writable tree and still runs the normal setup hook, so the cache is only an optimization and never the source of truth.

## What Changed

- Added a reusable dependency-seed service:
  - Fingerprints the effective setup script, present lockfile bytes (or configured input files), platform, architecture, Node major, and declared seed paths.
  - Stores one seed per fingerprint in a sibling, same-volume store outside both the primary checkout and the new worktree.
  - Hydrates matching paths before setup and promotes a successful result only after the setup runner exits with code 0.
  - Uses APFS clone semantics on macOS and `cp --reflink=always` on Linux; never silently falls back to a full dependency-tree copy.
  - Serializes promotion/hydration with in-process and cross-process locks, stages and publishes atomically, validates markers, bounds retained entries, and cleans crash leftovers.
  - Rejects traversal, symlink-redirected ancestors/trees, malformed markers/inputs, and special files.
- Integrated seeding into local and runtime-managed worktree creation while preserving folder-workspace, SSH, WSL, and Windows boundaries. Unsupported hosts/filesystems fail open to the existing setup path.
- Added setup completion observation that records the runner’s actual exit code even though the interactive PTY shell remains alive, including the wrapped wait-for-agent-startup path.
- Materialized host-owned default tabs where renderer authority could otherwise suppress them, and preserved setup retry behavior when host provisioning fails.
- Added `worktree.dependencySeedPaths` and `worktree.dependencySeedInputs` to `orca.yaml`; explicit empty arrays disable the corresponding behavior.
- Added a macOS Electron bundle copier that attempts APFS cloning and falls back to the previous regular copy behavior.
- Added/expanded focused tests for fingerprints, normalization, security checks, locking, promotion/hydration, setup completion, YAML parsing, local provisioning, and Electron bundle fallback.
- Moved the new local provisioning tests into a dedicated file to satisfy the repository max-lines ratchet.

## Why

The setup hook remains authoritative. A cache hit only changes the starting filesystem state; setup still runs and can repair or reject the cloned tree. A miss behaves exactly as before and becomes a seed only after a successful run. Seeds are local, private, evictable, and never used for SSH/remote execution or unsupported filesystems.

## Expected Savings

The measurements recorded in #13709 on Apple silicon/APFS provide the expected order of magnitude (not a benchmark rerun in this branch):

| Path | Wall time | CPU time | New disk |
| --- | ---: | ---: | ---: |
| Fresh setup hook | 32.96 s | 24.8 s | 677 MB |
| CoW clone only | 12.78 s | 0.14 s | 29 MB |
| CoW clone + setup confirmation | 17.96 s (13.31 + 4.65) | 12.4 s | 44 MB |

That is approximately 15 seconds less wall time, 12.4 seconds less CPU, and 633 MB less new disk per subsequent worktree in that workload (about 45%, 50%, and 94% reductions). The first miss still pays the normal install plus promotion; if cloning is unavailable, Orca intentionally takes the old path with no full-copy penalty.

## Linked Issue

Fixes #13709

## Visual Proof

N/A — this is main-process/filesystem and build-runner behavior; there is no renderer layout or visual design change. The Electron bundle change is covered by unit tests for clone/fallback behavior.

## Testing

- [x] Automated tests added/updated.
- [ ] Manual end-to-end testing (not completed before handoff).

Final local validation after the follow-up commits:

- Focused seed/provisioning/setup suite: 4 files, 41/41 tests passed.
- `pnpm tc:node` passed.
- `pnpm tc:web` and `pnpm tc:cli` passed on the feature commit.
- Changed-code quality (code quality, type-aware, React Doctor): 0 new findings.
- `lint-staged` (oxlint, React Doctor, oxfmt), `oxfmt --check`, `git diff --check`, and max-lines ratchet passed.
- Regression coverage now includes failed-later-path hydration rollback, partial Linux/Darwin clone cleanup, host-owned default-tab suppression, and all-failed default-tab retry fallback.

No live Linux, Windows/WSL, SSH, or Electron CDP smoke run was available in this window; CI packaging/typecheck and the focused seams cover those boundaries, but they are not a substitute for a live matrix run.

### GitHub Actions snapshot

The first workflow run [33354426571](https://github.com/stablyai/orca/actions/runs/33354426571) completed with typecheck, Linux/Windows packaging, changed E2E detection, 7/8 Node 24 shards, and review/community checks passing. Its aggregate `verify` was red only because of two unchanged-baseline failures: static analysis at `src/main/runtime/rpc/dispatcher.ts:323` (max-lines) and Node 24 shard 6/8 at `src/main/updater.startup-scheduling.test.ts:243` (duplicate `checkForUpdates`). Neither file is in this PR's diff. The post-fix workflow run 33357028929 is now green after rerunning the failed jobs; the updater shard and aggregate verify both pass. Pullfrog also completed successfully.

## AI Disclosure

Internal StablyAI contributor; disclosure intentionally omitted per the template.

## Review

Readiness: shippable merge candidate. All required CI checks are green and GitHub reports the PR mergeable/clean. Release sign-off remains conditional on the documented platform-smoke and hardening follow-ups below.

What is now closed in this PR:

- Hydration rolls back every path it can remove when a later configured path or a reflink/APFS clone fails; cleanup failures are surfaced as a failed hydration result rather than silently accepted.
- Host default-tab ownership is only claimed when at least one host tab was created. Partial success stays host-owned (no duplicate renderer tabs); zero successes leaves the descriptor for renderer retry.
- Setup promotion remains gated on the observed runner exit code `0`; failed or unobservable setup never publishes a seed.

Residual non-blocking follow-ups (not merge blockers):

- Workspace-monorepo symlinks such as `node_modules/pkg -> ../packages/pkg` are intentionally rejected by the seed-tree boundary. Those projects continue through the normal setup path, but the optimization is a no-op and logs a promotion failure; supporting repo-relative links should be a follow-up.
- Rollback cleanup is best effort under permission or race failures. If removal itself fails, hydration returns failed and the integration fails open to ordinary setup; a partial path could therefore still be visible to the hook in that rare case. This is a candidate release blocker only if those local failure races are in scope; otherwise track it as hardening.
- The filesystem checks are path-based. A hostile process that concurrently swaps a source path or an ancestor during clone/rollback can still create a TOCTOU window; closing that requires descriptor/no-follow primitives and is outside this optimization-sized change. This does not add a remote wire or privilege surface, but should be tracked as hardening if local hostile-process races are in scope.
- No live Linux, Windows/WSL, SSH, or Electron CDP run was available here.
- A runtime without a PTY controller cannot observe setup completion, so it preserves ordinary setup behavior and does not promote a seed.

No mobile-facing surface was changed; no new RPC/stream opcode was introduced; Git command behavior is unchanged.

## Suggested split if maintainers prefer smaller reviews

1. **Core seed service:** fingerprint/input normalization, path/security validation, clone backends, lock/marker/promotion, and unit tests.
2. **Lifecycle integration:** local/runtime hydration, setup completion callbacks, default-tab ownership, and create-flow tests.
3. **Electron packaging:** macOS bundle clone/fallback helper and tests.
4. **Follow-up:** benchmark matrix, repo-relative workspace-link support, and descriptor-level no-follow hardening for adversarial filesystem races.
## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- macOS APFS and Linux reflink paths are explicit; Windows, WSL, SSH, unsupported filesystems, missing lockfiles, and clone failures preserve the existing setup behavior.
- Folder workspaces are unaffected.
- No new RPC/stream opcode or remote wire payload was introduced.
- Git command behavior is unchanged; Git 2.25 compatibility is preserved.

## Checklist

- [x] I explained what changed and why (including ELI5).
- [x] Before/after visual proof is N/A because there is no UI change.
- [x] Self-reviewed for correctness, security, concurrency, cleanup, and performance.
- [x] Cross-platform, SSH/remote, folder-workspace, and fallback behavior considered.
- [ ] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` were not all run locally; CI should cover the remaining broad gates.









