### PR TITLE
fix(rpc): extract shared unary dispatch path to unbreak lint on main

### DIFF
--- a/src/main/runtime/rpc/dispatcher-unary-execution.ts
+++ b/src/main/runtime/rpc/dispatcher-unary-execution.ts
@@ -1,0 +1,113 @@
+import type { RpcEnvelopeMeta, RpcMethod, RpcRequest, RpcResponse } from './core'
+import { successResponse } from './errors'
+import { emulatorProbe, emulatorProbeError } from '../../emulator/emulator-probe'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type {
+  DurableMutationInvocation,
+  OrchestrationMutationExecutor
+} from './orchestration-mutation-executor'
+import { recordRuntimeFeatureInteraction } from './runtime-feature-interaction'
+import type { OrchestrationLegacyCompatibility } from './orchestration-legacy-compatibility'
+import type { RpcDispatchStreamingOptions } from './dispatcher-stream-options'
+import { mapDispatcherError } from './dispatcher-error-response'
+import { routeDispatcherClientHostedBrowserRpc } from './dispatcher-client-browser-routing'
+import { needsLocalCallerFingerprint } from './dispatcher-caller-fingerprint'
+
+export type UnaryRpcExecutionDeps = {
+  runtime: OrcaRuntimeService
+  orchestrationMutations: OrchestrationMutationExecutor
+  legacyOrchestration: OrchestrationLegacyCompatibility
+}
+
+// Why: non-streaming methods reach the dispatcher over both transports; the streaming
+// transport just serializes the response instead of returning it.
+export async function executeUnaryRpc(
+  deps: UnaryRpcExecutionDeps,
+  request: RpcRequest,
+  method: RpcMethod,
+  params: unknown,
+  meta: RpcEnvelopeMeta,
+  options: RpcDispatchStreamingOptions | undefined
+): Promise<RpcResponse> {
+  const { runtime, orchestrationMutations, legacyOrchestration } = deps
+  const isEmulatorMethod = request.method.startsWith('emulator.')
+  if (isEmulatorMethod) {
+    emulatorProbe(`rpc ${request.method}`, request.params)
+  }
+  try {
+    const clientHostedBrowser = await routeDispatcherClientHostedBrowserRpc(
+      runtime,
+      request.method,
+      params
+    )
+    if (clientHostedBrowser.handled) {
+      recordRuntimeFeatureInteraction(
+        runtime,
+        request.method,
+        clientHostedBrowser.result,
+        undefined,
+        request.params
+      )
+      return successResponse(request.id, meta, clientHostedBrowser.result)
+    }
+
+    const compatibility = await legacyOrchestration.tryHandle(request, params, options?.signal)
+    if (compatibility.handled) {
+      return successResponse(request.id, meta, compatibility.result)
+    }
+
+    const effectiveParams = compatibility.params ?? params
+    const legacyCoordinator = legacyOrchestration.createCoordinatorInvocation(
+      request,
+      compatibility.legacyCoordinatorAuthority
+    )
+    const authenticatedCallerFingerprint =
+      options?.authenticatedCallerFingerprint ??
+      (needsLocalCallerFingerprint(request, effectiveParams)
+        ? orchestrationMutations.getLocalAuthenticatedCallerFingerprint()
+        : undefined)
+    const invoke = (mutation?: DurableMutationInvocation) => {
+      const legacyCoordinatorRunId = legacyCoordinator?.revalidate()
+      return method.handler(effectiveParams, {
+        runtime,
+        signal: options?.signal,
+        requestId: request.id,
+        connectionId: options?.connectionId,
+        clientId: options?.clientId,
+        pairedDeviceId: options?.pairedDeviceId,
+        clientKind: options?.clientKind,
+        clientCapabilities: options?.clientCapabilities,
+        orchestrationCapability: request.orchestrationCapability,
+        authenticatedCallerFingerprint:
+          mutation?.identity.callerFingerprint ??
+          legacyCoordinator?.mutationCallerFingerprint ??
+          authenticatedCallerFingerprint,
+        recordMutationReceipt: mutation?.recordReceipt,
+        orchestrationMutation: mutation?.identity,
+        pairing: options?.pairing,
+        sendBinary: options?.sendBinary,
+        registerBinaryStreamHandler: options?.registerBinaryStreamHandler,
+        registerBinaryMessageHandler: options?.registerBinaryMessageHandler,
+        legacyCoordinatorRunId,
+        legacyCoordinatorAuthority: legacyCoordinator?.authority,
+        revalidateLegacyCoordinator: legacyCoordinator?.revalidate,
+        orchestrationCompatibilityCallerAuthority:
+          compatibility.orchestrationCompatibilityCallerAuthority,
+        orchestrationCompatibilityEvidence: request.orchestrationCompatibilityEvidence
+      })
+    }
+    const result = await orchestrationMutations.run(
+      request,
+      effectiveParams,
+      invoke,
+      legacyCoordinator?.mutationCallerFingerprint ?? authenticatedCallerFingerprint
+    )
+    recordRuntimeFeatureInteraction(runtime, request.method, result, undefined, request.params)
+    return successResponse(request.id, meta, result)
+  } catch (error) {
+    if (isEmulatorMethod) {
+      emulatorProbeError(`rpc ${request.method}`, error, { params: request.params })
+    }
+    return mapDispatcherError(request, meta, error)
+  }
+}

--- a/src/main/runtime/rpc/dispatcher.ts
+++ b/src/main/runtime/rpc/dispatcher.ts
@@ -8,14 +8,12 @@ import {
   type RpcResponse
 } from './core'
 
-import { errorResponse, successResponse } from './errors'
+import { errorResponse } from './errors'
 import { ALL_RPC_METHODS } from './methods'
-import { emulatorProbe, emulatorProbeError } from '../../emulator/emulator-probe'
 import type { OrcaRuntimeService } from '../orca-runtime'
 import {
   getOrchestrationMutationExecutor,
-  type OrchestrationMutationExecutor,
-  type DurableMutationInvocation
+  type OrchestrationMutationExecutor
 } from './orchestration-mutation-executor'
 import { orchestrationMigrationFence } from './orchestration-contract-fence'
 import { recordRuntimeFeatureInteraction } from './runtime-feature-interaction'
@@ -23,9 +21,8 @@ import { OrchestrationLegacyCompatibility } from './orchestration-legacy-compati
 import type { RpcDispatchStreamingOptions } from './dispatcher-stream-options'
 import { mapDispatcherError } from './dispatcher-error-response'
 import { parseRpcRequestParams } from './dispatcher-request-parsing'
-import { routeDispatcherClientHostedBrowserRpc } from './dispatcher-client-browser-routing'
-import { needsLocalCallerFingerprint } from './dispatcher-caller-fingerprint'
 import { createDispatcherStreamingFeatureEmitter } from './dispatcher-streaming-feature-emitter'
+import { executeUnaryRpc, type UnaryRpcExecutionDeps } from './dispatcher-unary-execution'
 
 export type DispatcherOptions = { runtime: OrcaRuntimeService; methods?: readonly RpcAnyMethod[] }
 
@@ -76,88 +73,7 @@ export class RpcDispatcher {
       )
     }
 
-    if (request.method.startsWith('emulator.')) {
-      emulatorProbe(`rpc ${request.method}`, request.params)
-    }
-    try {
-      const clientHostedBrowser = await routeDispatcherClientHostedBrowserRpc(
-        this.runtime,
-        request.method,
-        parsedParams.value
-      )
-      if (clientHostedBrowser.handled) {
-        recordRuntimeFeatureInteraction(
-          this.runtime,
-          request.method,
-          clientHostedBrowser.result,
-          undefined,
-          request.params
-        )
-        return successResponse(request.id, meta, clientHostedBrowser.result)
-      }
-      const compatibility = await this.legacyOrchestration.tryHandle(
-        request,
-        parsedParams.value,
-        options?.signal
-      )
-      if (compatibility.handled) {
-        return successResponse(request.id, meta, compatibility.result)
-      }
-      const effectiveParams = compatibility.params ?? parsedParams.value
-      const legacyCoordinator = this.legacyOrchestration.createCoordinatorInvocation(
-        request,
-        compatibility.legacyCoordinatorAuthority
-      )
-      const authenticatedCallerFingerprint =
-        options?.authenticatedCallerFingerprint ??
-        (needsLocalCallerFingerprint(request, effectiveParams)
-          ? this.orchestrationMutations.getLocalAuthenticatedCallerFingerprint()
-          : undefined)
-      const invoke = (mutation?: DurableMutationInvocation) => {
-        const legacyCoordinatorRunId = legacyCoordinator?.revalidate()
-        return method.handler(effectiveParams, {
-          runtime: this.runtime,
-          signal: options?.signal,
-          connectionId: options?.connectionId,
-          requestId: request.id,
-          clientId: options?.clientId,
-          clientKind: options?.clientKind,
-          clientCapabilities: options?.clientCapabilities,
-          orchestrationCapability: request.orchestrationCapability,
-          authenticatedCallerFingerprint:
-            mutation?.identity.callerFingerprint ??
-            legacyCoordinator?.mutationCallerFingerprint ??
-            authenticatedCallerFingerprint,
-          recordMutationReceipt: mutation?.recordReceipt,
-          orchestrationMutation: mutation?.identity,
-          legacyCoordinatorRunId,
-          legacyCoordinatorAuthority: legacyCoordinator?.authority,
-          revalidateLegacyCoordinator: legacyCoordinator?.revalidate,
-          orchestrationCompatibilityCallerAuthority:
-            compatibility.orchestrationCompatibilityCallerAuthority,
-          orchestrationCompatibilityEvidence: request.orchestrationCompatibilityEvidence
-        })
-      }
-      const result = await this.orchestrationMutations.run(
-        request,
-        effectiveParams,
-        invoke,
-        legacyCoordinator?.mutationCallerFingerprint ?? authenticatedCallerFingerprint
-      )
-      recordRuntimeFeatureInteraction(
-        this.runtime,
-        request.method,
-        result,
-        undefined,
-        request.params
-      )
-      return successResponse(request.id, meta, result)
-    } catch (error) {
-      if (request.method.startsWith('emulator.')) {
-        emulatorProbeError(`rpc ${request.method}`, error, { params: request.params })
-      }
-      return mapDispatcherError(request, meta, error)
-    }
+    return executeUnaryRpc(this.unaryDeps(), request, method, parsedParams.value, meta, options)
   }
 
   // Why: streaming dispatch sends multiple responses through the reply callback
@@ -192,89 +108,15 @@ export class RpcDispatcher {
     }
 
     if (!isStreamingMethod(method)) {
-      try {
-        const clientHostedBrowser = await routeDispatcherClientHostedBrowserRpc(
-          this.runtime,
-          request.method,
-          parsedParams.value
-        )
-        if (clientHostedBrowser.handled) {
-          recordRuntimeFeatureInteraction(
-            this.runtime,
-            request.method,
-            clientHostedBrowser.result,
-            undefined,
-            request.params
-          )
-          reply(JSON.stringify(successResponse(request.id, meta, clientHostedBrowser.result)))
-          return
-        }
-        const compatibility = await this.legacyOrchestration.tryHandle(
-          request,
-          parsedParams.value,
-          options?.signal
-        )
-        if (compatibility.handled) {
-          reply(JSON.stringify(successResponse(request.id, meta, compatibility.result)))
-          return
-        }
-        const effectiveParams = compatibility.params ?? parsedParams.value
-        const legacyCoordinator = this.legacyOrchestration.createCoordinatorInvocation(
-          request,
-          compatibility.legacyCoordinatorAuthority
-        )
-        const authenticatedCallerFingerprint =
-          options?.authenticatedCallerFingerprint ??
-          (needsLocalCallerFingerprint(request, effectiveParams)
-            ? this.orchestrationMutations.getLocalAuthenticatedCallerFingerprint()
-            : undefined)
-        const invoke = (mutation?: DurableMutationInvocation) => {
-          const legacyCoordinatorRunId = legacyCoordinator?.revalidate()
-          return method.handler(effectiveParams, {
-            runtime: this.runtime,
-            signal: options?.signal,
-            requestId: request.id,
-            connectionId: options?.connectionId,
-            clientId: options?.clientId,
-            pairedDeviceId: options?.pairedDeviceId,
-            clientKind: options?.clientKind,
-            clientCapabilities: options?.clientCapabilities,
-            orchestrationCapability: request.orchestrationCapability,
-            authenticatedCallerFingerprint:
-              mutation?.identity.callerFingerprint ??
-              legacyCoordinator?.mutationCallerFingerprint ??
-              authenticatedCallerFingerprint,
-            recordMutationReceipt: mutation?.recordReceipt,
-            orchestrationMutation: mutation?.identity,
-            pairing: options?.pairing,
-            sendBinary: options?.sendBinary,
-            registerBinaryStreamHandler: options?.registerBinaryStreamHandler,
-            registerBinaryMessageHandler: options?.registerBinaryMessageHandler,
-            legacyCoordinatorRunId,
-            legacyCoordinatorAuthority: legacyCoordinator?.authority,
-            revalidateLegacyCoordinator: legacyCoordinator?.revalidate,
-            orchestrationCompatibilityCallerAuthority:
-              compatibility.orchestrationCompatibilityCallerAuthority,
-            orchestrationCompatibilityEvidence: request.orchestrationCompatibilityEvidence
-          })
-        }
-        const result = await this.orchestrationMutations.run(
-          request,
-          effectiveParams,
-          invoke,
-          legacyCoordinator?.mutationCallerFingerprint ?? authenticatedCallerFingerprint
-        )
-        recordRuntimeFeatureInteraction(
-          this.runtime,
-          request.method,
-          result,
-          undefined,
-          request.params
-        )
-        reply(JSON.stringify(successResponse(request.id, meta, result)))
-      } catch (error) {
-        reply(JSON.stringify(mapDispatcherError(request, meta, error)))
-      }
+      const response = await executeUnaryRpc(
+        this.unaryDeps(),
+        request,
+        method,
+        parsedParams.value,
+        meta,
+        options
+      )
+      reply(JSON.stringify(response))
       return
     }
 
@@ -314,6 +156,14 @@ export class RpcDispatcher {
       )
     } catch (error) {
       reply(JSON.stringify(mapDispatcherError(request, meta, error)))
+    }
+  }
+
+  private unaryDeps(): UnaryRpcExecutionDeps {
+    return {
+      runtime: this.runtime,
+      orchestrationMutations: this.orchestrationMutations,
+      legacyOrchestration: this.legacyOrchestration
     }
   }
 


### PR DESCRIPTION
`src/main/runtime/rpc/dispatcher.ts` grew past the 300-line `max-lines` cap, so `static analysis` (and therefore `verify`) fails on **main** and on every PR branched from it — e.g. #17528, whose own diff doesn't touch the file.

## Fix
The unary code path was duplicated verbatim between `dispatch()` and the non-streaming branch of `dispatchStreaming()`. Extracted it into `dispatcher-unary-execution.ts` and call it from both, which puts `dispatcher.ts` back well under the cap. No lint suppression added.

## Behavior notes
- The two copies differed only in which optional `RpcContext` fields they forwarded. The shared version forwards all of them; on the `dispatch()` path the extra ones (`pairedDeviceId`, `pairing`, `sendBinary`, `registerBinary*`) are `undefined`, exactly as before when they were omitted.
- The `emulator.*` probe logging previously ran only on the `dispatch()` path; it now covers both. It is opt-in behind `ORCA_EMULATOR_PROBE=1` and is best-effort logging only.

## Verification
- `oxlint`: 0 errors (was 1)
- `pnpm tc`: clean
- `pnpm test src/main/runtime/rpc/`: all dispatcher/RPC suites pass (one unrelated 800-iteration fuzz test in `terminal-output-frame-chunks-equivalence.test.ts` hit the 30s local timeout under parallel load; unrelated to this change)