### PR TITLE
Make file download a bit more obvious

### DIFF
--- a/src/renderer/src/components/browser-pane/navigate/browser-page-download-list.tsx
+++ b/src/renderer/src/components/browser-pane/navigate/browser-page-download-list.tsx
@@ -22,7 +22,7 @@ export function BrowserPageDownloadList({
   }
 
   return (
-    <div className="border-b border-border/60 bg-background px-3 py-1.5">
+    <div className="border-b border-border/60 bg-background">
       <div className="scrollbar-sleek flex max-h-36 flex-col gap-1 overflow-y-auto">
         {visibleDownloads.map((download) => {
           const progressLabel = formatBrowserDownloadProgress(download)
@@ -47,10 +47,14 @@ export function BrowserPageDownloadList({
           return (
             <div
               key={download.downloadId}
-              className="flex min-h-8 items-center gap-2 text-xs text-foreground"
+              className={
+                download.status === 'completed'
+                  ? 'flex min-h-8 items-center gap-2 bg-status-success-background px-3 py-1.5 text-xs text-foreground'
+                  : 'flex min-h-8 items-center gap-2 px-3 py-1.5 text-xs text-foreground'
+              }
             >
               {download.status === 'completed' ? (
-                <CircleCheck className="size-3.5 shrink-0 text-muted-foreground" />
+                <CircleCheck className="size-3.5 shrink-0 text-status-success" />
               ) : download.status === 'failed' ? (
                 <OctagonX className="size-3.5 shrink-0 text-muted-foreground" />
               ) : (
@@ -58,7 +62,13 @@ export function BrowserPageDownloadList({
               )}
               <div className="min-w-0 flex-1">
                 <div className="truncate font-medium">{download.filename}</div>
-                <div className="truncate text-muted-foreground">
+                <div
+                  className={
+                    download.status === 'completed'
+                      ? 'truncate font-medium text-status-success'
+                      : 'truncate text-muted-foreground'
+                  }
+                >
                   {download.status === 'downloading'
                     ? translate(
                         'auto.components.browser.pane.BrowserPane.4300f38145',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## Problem

Completed downloads blend in with downloads still in progress, making it unclear which files are ready and available.

## Solution

Highlight completed downloads with green success styling: green background, green checkmark icon, and green status text.

## ELI5

Finished downloads now have a green highlight so you can easily spot them.

## What Changed

Modified `browser-page-download-list.tsx` to add success-themed styling to completed download items:
- `bg-status-success-background` background on completed downloads
- `text-status-success` icon color for the checkmark
- `text-status-success` text color for status info on completed downloads
- Moved horizontal padding from container to individual items

## Why

Completed downloads are a success state and should be visually celebrated. The green styling makes the difference between "still downloading" and "ready to use" immediate and obvious.

## Linked Issue

Fixes #

## Visual Proof

TODO: Before/after screenshots or video showing download list with completed items highlighted in green

## Testing

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

## AI Disclosure

Which AI model if anyone was used, please state the details

## Review

## Agent skill upstream boundary

- [ ] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)