### PR TITLE
fix(relay): stop stale relays from exhausting the host's ptys

### DIFF
--- a/src/main/daemon/pty-subprocess-foreground-identity.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-identity.test.ts
@@ -50,7 +50,7 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof LocalPtyUtils>()
   return {
     ...actual,
-    getNodePtySpawnHelperCandidates: () => [import.meta.filename],
+    getNodePtySpawnHelperCandidates: () => [process.execPath],
     resolveUnixShellPath: resolveUnixShellPathMock,
     validateWorkingDirectory: validateWorkingDirectoryMock,
     validateWorkingDirectoryAsync: validateWorkingDirectoryMock

--- a/src/main/daemon/pty-subprocess-foreground-scan-cadence.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-scan-cadence.test.ts
@@ -44,7 +44,7 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof LocalPtyUtils>()
   return {
     ...actual,
-    getNodePtySpawnHelperCandidates: () => [import.meta.filename]
+    getNodePtySpawnHelperCandidates: () => [process.execPath]
   }
 })
 

--- a/src/main/daemon/pty-subprocess-handle-lifecycle.test.ts
+++ b/src/main/daemon/pty-subprocess-handle-lifecycle.test.ts
@@ -50,7 +50,7 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof LocalPtyUtils>()
   return {
     ...actual,
-    getNodePtySpawnHelperCandidates: () => [import.meta.filename],
+    getNodePtySpawnHelperCandidates: () => [process.execPath],
     resolveUnixShellPath: resolveUnixShellPathMock,
     validateWorkingDirectory: validateWorkingDirectoryMock,
     validateWorkingDirectoryAsync: validateWorkingDirectoryMock

--- a/src/main/daemon/pty-subprocess/spawn-preflight-helper-executability.test.ts
+++ b/src/main/daemon/pty-subprocess/spawn-preflight-helper-executability.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as fs from 'node:fs'
+import type { Stats } from 'node:fs'
+
+const DAEMON_CWD = '/orca/userData'
+const RELEASE_HELPER = '/orca/node_modules/node-pty/build/Release/spawn-helper'
+const DEBUG_HELPER = '/orca/node_modules/node-pty/build/Debug/spawn-helper'
+const PREBUILD_HELPER = '/orca/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper'
+
+const { statSyncMock, candidatesMock } = vi.hoisted(() => ({
+  statSyncMock: vi.fn(),
+  candidatesMock: vi.fn()
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>()
+  return { ...actual, statSync: statSyncMock }
+})
+
+vi.mock('node-pty', () => ({ spawn: vi.fn() }))
+
+vi.mock('../../providers/local-pty-utils', () => ({
+  ensureNodePtySpawnHelperExecutable: vi.fn(),
+  getNodePtySpawnHelperCandidates: candidatesMock,
+  validateWorkingDirectoryAsync: vi.fn(),
+  WorkingDirectoryValidationAbortedError: class extends Error {}
+}))
+
+vi.mock('../../providers/pty-default-cwd', () => ({
+  resolveSafePtyDefaultCwd: () => DAEMON_CWD
+}))
+
+import { preflightPtySpawnHealth } from './spawn-preflight'
+
+function dirStats(): Stats {
+  return { isDirectory: () => true, isFile: () => false, mode: 0o040755 } as Stats
+}
+
+function helperStats(mode: number): Stats {
+  return { isDirectory: () => false, isFile: () => true, mode } as Stats
+}
+
+/** Only the paths in `helpers` exist; everything else stats as ENOENT. */
+function stubInstalledHelpers(helpers: Record<string, number>): void {
+  statSyncMock.mockImplementation((path: string) => {
+    if (path === DAEMON_CWD) {
+      return dirStats()
+    }
+    const mode = helpers[path]
+    if (mode === undefined) {
+      throw Object.assign(new Error(`ENOENT: no such file or directory, stat '${path}'`), {
+        code: 'ENOENT'
+      })
+    }
+    return helperStats(mode)
+  })
+}
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+beforeEach(() => {
+  statSyncMock.mockReset()
+  candidatesMock.mockReturnValue([RELEASE_HELPER, DEBUG_HELPER, PREBUILD_HELPER])
+  vi.spyOn(process, 'cwd').mockReturnValue(DAEMON_CWD)
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+})
+
+describe('preflightPtySpawnHealth node-pty helper checks', () => {
+  it('passes when an installed helper is executable', () => {
+    stubInstalledHelpers({ [RELEASE_HELPER]: 0o100755 })
+
+    expect(preflightPtySpawnHealth()).toBe(true)
+  })
+
+  it('rejects a helper that exists but is not executable', () => {
+    // The regression: an isFile() probe passed on the packaged 644 prebuild helper, so the
+    // preflight cleared a spawn that node-pty then failed with EACCES.
+    stubInstalledHelpers({ [PREBUILD_HELPER]: 0o100644 })
+
+    expect(() => preflightPtySpawnHealth()).toThrow(/EACCES \(errno 13/)
+    expect(() => preflightPtySpawnHealth()).toThrow(new RegExp(`helper='${PREBUILD_HELPER}'`))
+  })
+
+  it('does not blame a missing install when the helper is merely unexecutable', () => {
+    stubInstalledHelpers({ [PREBUILD_HELPER]: 0o100644 })
+
+    expect(() => preflightPtySpawnHealth()).toThrow(/not executable/)
+    expect(() => preflightPtySpawnHealth()).not.toThrow(/is gone/)
+  })
+
+  it('accepts an executable fallback helper when the preferred one is unexecutable', () => {
+    stubInstalledHelpers({ [RELEASE_HELPER]: 0o100644, [PREBUILD_HELPER]: 0o100755 })
+
+    expect(preflightPtySpawnHealth()).toBe(true)
+  })
+
+  it('still reports a missing node-pty install as ENOENT', () => {
+    stubInstalledHelpers({})
+
+    expect(() => preflightPtySpawnHealth()).toThrow(/node-pty install is gone/)
+    expect(() => preflightPtySpawnHealth()).toThrow(/ENOENT \(errno 2/)
+  })
+})

--- a/src/main/daemon/pty-subprocess/spawn-preflight.ts
+++ b/src/main/daemon/pty-subprocess/spawn-preflight.ts
@@ -30,6 +30,13 @@ function formatMissingDaemonPathError(kind: 'helper' | 'cwd', path: string): Dae
   )
 }
 
+/** EACCES, not the ENOENT "install is gone" story: the file is there, its mode is the problem. */
+function formatNonExecutableHelperError(path: string): DaemonProtocolError {
+  return new DaemonProtocolError(
+    `Daemon's node-pty spawn-helper is not executable (chmod +x failed?). node-pty: posix_spawn failed: EACCES (errno 13, Permission denied) - helper='${path}'${daemonEnvironmentDiagSuffix()}`
+  )
+}
+
 function isExistingDirectory(path: string | undefined): path is string {
   if (!path) {
     return false
@@ -88,14 +95,26 @@ function preflightMacNodePtySpawnEnvironment(): void {
   } catch {
     throw formatMissingDaemonPathError('helper', '<unresolved>')
   }
+  // Why the mode check: the packaged prebuild helper ships 644, and node-pty spawns whichever
+  // dir it loaded from — a present-but-unexecutable helper passes an isFile() probe and then
+  // dies with EACCES at the native spawn.
+  let presentButNotExecutable: string | null = null
   for (const candidate of candidates) {
     try {
-      if (statSync(candidate).isFile()) {
+      const stats = statSync(candidate)
+      if (!stats.isFile()) {
+        continue
+      }
+      if ((stats.mode & 0o111) !== 0) {
         return
       }
+      presentButNotExecutable ??= candidate
     } catch {
       // Try the next node-pty native location.
     }
+  }
+  if (presentButNotExecutable) {
+    throw formatNonExecutableHelperError(presentButNotExecutable)
   }
   throw formatMissingDaemonPathError('helper', candidates[0] ?? '<unresolved>')
 }

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -1,5 +1,5 @@
-import { basename, isAbsolute, join } from 'node:path'
-import { existsSync, accessSync, statSync, chmodSync, constants as fsConstants } from 'node:fs'
+import { isAbsolute } from 'node:path'
+import { existsSync, accessSync, constants as fsConstants } from 'node:fs'
 import type * as pty from 'node-pty'
 import {
   hostReportsChildExitStatus,
@@ -8,35 +8,18 @@ import {
 import { formatLocalPtyEnvironmentDiag } from './working-directory-validation'
 
 export {
+  ensureNodePtySpawnHelperExecutable,
+  getNodePtySpawnHelperCandidates
+} from '../pty/node-pty-spawn-helper'
+
+export {
   formatLocalPtyEnvironmentDiag,
   validateWorkingDirectory,
   validateWorkingDirectoryAsync,
   WorkingDirectoryValidationAbortedError
 } from './working-directory-validation'
 
-let didEnsureSpawnHelperExecutable = false
-
 const UNIX_SHELL_FALLBACKS = ['/bin/zsh', '/bin/bash', '/bin/sh'] as const
-
-function toUnpackedAsarPath(candidate: string): string {
-  return candidate
-    .replace(/app\.asar([/\\])/, 'app.asar.unpacked$1')
-    .replace(/node_modules\.asar([/\\])/, 'node_modules.asar.unpacked$1')
-}
-
-export function getNodePtySpawnHelperCandidates(): string[] {
-  const unixTerminalPath = require.resolve('node-pty/lib/unixTerminal.js')
-  const packageRoot =
-    basename(unixTerminalPath) === 'unixTerminal.js'
-      ? unixTerminalPath.replace(/[/\\]lib[/\\]unixTerminal\.js$/, '')
-      : unixTerminalPath
-
-  return [
-    join(packageRoot, 'build', 'Release', 'spawn-helper'),
-    join(packageRoot, 'build', 'Debug', 'spawn-helper'),
-    join(packageRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper')
-  ].map(toUnpackedAsarPath)
-}
 
 /**
  * Validate that a shell binary exists and is executable.
@@ -74,38 +57,6 @@ export function resolveUnixShellPath(shellPath: string): string {
     return resolved
   }
   throw new Error(`No executable Unix shell found (tried: ${candidates.join(', ')})`)
-}
-
-/**
- * Ensure the node-pty spawn-helper binary has the executable bit set.
- *
- * Why: when Electron packages the app via asar, the native spawn-helper
- * binary may lose its +x permission. This function detects and repairs
- * that so pty.spawn() does not fail with EACCES on first launch.
- */
-export function ensureNodePtySpawnHelperExecutable(): void {
-  if (didEnsureSpawnHelperExecutable || process.platform === 'win32') {
-    return
-  }
-  didEnsureSpawnHelperExecutable = true
-
-  try {
-    for (const candidate of getNodePtySpawnHelperCandidates()) {
-      if (!existsSync(candidate)) {
-        continue
-      }
-      const mode = statSync(candidate).mode
-      if ((mode & 0o111) !== 0) {
-        return
-      }
-      chmodSync(candidate, mode | 0o755)
-      return
-    }
-  } catch (error) {
-    console.warn(
-      `[pty] Failed to ensure node-pty spawn-helper is executable: ${error instanceof Error ? error.message : String(error)}`
-    )
-  }
 }
 
 /** A pre-resolved Windows shell attempt: an absolute executable plus the launch

--- a/src/main/pty/node-pty-spawn-helper.test.ts
+++ b/src/main/pty/node-pty-spawn-helper.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as fs from 'node:fs'
+import type { Stats } from 'node:fs'
+import type * as SpawnHelper from './node-pty-spawn-helper'
+
+const { existsSyncMock, statSyncMock, chmodSyncMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(),
+  statSyncMock: vi.fn(),
+  chmodSyncMock: vi.fn()
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>()
+  return {
+    ...actual,
+    existsSync: existsSyncMock,
+    statSync: statSyncMock,
+    chmodSync: chmodSyncMock
+  }
+})
+
+function modeStats(mode: number): Stats {
+  return { mode } as Stats
+}
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+// Why resetModules per test: the repair latches on a module-level flag after its first run.
+async function loadHelperRepair(): Promise<typeof SpawnHelper> {
+  vi.resetModules()
+  return import('./node-pty-spawn-helper')
+}
+
+beforeEach(() => {
+  existsSyncMock.mockReset()
+  statSyncMock.mockReset()
+  chmodSyncMock.mockReset()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+})
+
+describe('ensureNodePtySpawnHelperExecutable', () => {
+  it('repairs the prebuild helper even when build/Release is already executable', async () => {
+    const { ensureNodePtySpawnHelperExecutable, getNodePtySpawnHelperCandidates } =
+      await loadHelperRepair()
+    const [releaseHelper, debugHelper, prebuildHelper] = getNodePtySpawnHelperCandidates()
+    existsSyncMock.mockImplementation((path: string) => path !== debugHelper)
+    statSyncMock.mockImplementation((path: string) =>
+      modeStats(path === releaseHelper ? 0o100755 : 0o100644)
+    )
+
+    ensureNodePtySpawnHelperExecutable()
+
+    // The regression: returning at the already-+x build/Release left the packaged prebuild at
+    // 644, so node-pty's prebuild fallback spawned it and died with EACCES.
+    expect(chmodSyncMock).toHaveBeenCalledTimes(1)
+    expect(chmodSyncMock).toHaveBeenCalledWith(prebuildHelper, 0o100644 | 0o755)
+  })
+
+  it('repairs every non-executable candidate that exists', async () => {
+    const { ensureNodePtySpawnHelperExecutable, getNodePtySpawnHelperCandidates } =
+      await loadHelperRepair()
+    const candidates = getNodePtySpawnHelperCandidates()
+    existsSyncMock.mockReturnValue(true)
+    statSyncMock.mockReturnValue(modeStats(0o100644))
+
+    ensureNodePtySpawnHelperExecutable()
+
+    expect(chmodSyncMock.mock.calls.map(([path]) => path)).toEqual(candidates)
+  })
+
+  it('leaves an already-executable candidate untouched', async () => {
+    const { ensureNodePtySpawnHelperExecutable } = await loadHelperRepair()
+    existsSyncMock.mockReturnValue(true)
+    statSyncMock.mockReturnValue(modeStats(0o100755))
+
+    ensureNodePtySpawnHelperExecutable()
+
+    expect(chmodSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps repairing after one candidate fails to chmod', async () => {
+    const { ensureNodePtySpawnHelperExecutable, getNodePtySpawnHelperCandidates } =
+      await loadHelperRepair()
+    const [releaseHelper, , prebuildHelper] = getNodePtySpawnHelperCandidates()
+    existsSyncMock.mockReturnValue(true)
+    statSyncMock.mockReturnValue(modeStats(0o100644))
+    chmodSyncMock.mockImplementation((path: string) => {
+      if (path === releaseHelper) {
+        throw new Error('EPERM: operation not permitted')
+      }
+    })
+
+    ensureNodePtySpawnHelperExecutable()
+
+    expect(chmodSyncMock).toHaveBeenCalledWith(prebuildHelper, 0o100644 | 0o755)
+  })
+
+  it('skips candidates that are not installed', async () => {
+    const { ensureNodePtySpawnHelperExecutable, getNodePtySpawnHelperCandidates } =
+      await loadHelperRepair()
+    const [, , prebuildHelper] = getNodePtySpawnHelperCandidates()
+    existsSyncMock.mockImplementation((path: string) => path === prebuildHelper)
+    statSyncMock.mockReturnValue(modeStats(0o100644))
+
+    ensureNodePtySpawnHelperExecutable()
+
+    expect(chmodSyncMock).toHaveBeenCalledTimes(1)
+    expect(chmodSyncMock).toHaveBeenCalledWith(prebuildHelper, 0o100644 | 0o755)
+  })
+
+  it('does nothing on Windows, where node-pty has no spawn-helper', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const { ensureNodePtySpawnHelperExecutable } = await loadHelperRepair()
+    existsSyncMock.mockReturnValue(true)
+    statSyncMock.mockReturnValue(modeStats(0o100644))
+
+    ensureNodePtySpawnHelperExecutable()
+
+    expect(chmodSyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/pty/node-pty-spawn-helper.ts
+++ b/src/main/pty/node-pty-spawn-helper.ts
@@ -1,0 +1,118 @@
+import { chmodSync, existsSync, statSync } from 'node:fs'
+import { basename, join } from 'node:path'
+
+// Keyed by root, not a single flag: the relay can load node-pty from the bundle and later from its
+// deployed dir, and repairing one must not mark the other done.
+const repairedPackageRoots = new Set<string>()
+const REQUIRE_RESOLVED_ROOT = '<require-resolved>'
+
+function toUnpackedAsarPath(candidate: string): string {
+  return candidate
+    .replace(/app\.asar([/\\])/, 'app.asar.unpacked$1')
+    .replace(/node_modules\.asar([/\\])/, 'node_modules.asar.unpacked$1')
+}
+
+/**
+ * node-pty's loader tries build/Release -> build/Debug -> prebuilds/<platform>-<arch> and spawns the
+ * helper sitting next to whichever one it loaded, so every entry is a live candidate.
+ */
+export function getNodePtySpawnHelperCandidatesIn(packageRoot: string): string[] {
+  return [
+    join(packageRoot, 'build', 'Release', 'spawn-helper'),
+    join(packageRoot, 'build', 'Debug', 'spawn-helper'),
+    join(packageRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper')
+  ].map(toUnpackedAsarPath)
+}
+
+export function getNodePtySpawnHelperCandidates(): string[] {
+  const unixTerminalPath = require.resolve('node-pty/lib/unixTerminal.js')
+  const packageRoot =
+    basename(unixTerminalPath) === 'unixTerminal.js'
+      ? unixTerminalPath.replace(/[/\\]lib[/\\]unixTerminal\.js$/, '')
+      : unixTerminalPath
+
+  return getNodePtySpawnHelperCandidatesIn(packageRoot)
+}
+
+function resolveCandidates(packageRoot?: string): string[] {
+  return packageRoot
+    ? getNodePtySpawnHelperCandidatesIn(packageRoot)
+    : getNodePtySpawnHelperCandidates()
+}
+
+/**
+ * Ensure every installed node-pty spawn-helper has the executable bit set.
+ *
+ * Why: asar packaging and SFTP relay deploys both drop the +x bit, and the packaged
+ * prebuilds/<platform>-<arch> helper ships 0644. posix_spawn on it fails with EACCES.
+ *
+ * @param packageRoot node-pty package dir to repair; omit to resolve it through require.
+ */
+export function ensureNodePtySpawnHelperExecutable(packageRoot?: string): void {
+  if (process.platform === 'win32') {
+    return
+  }
+  const repairKey = packageRoot ?? REQUIRE_RESOLVED_ROOT
+  if (repairedPackageRoots.has(repairKey)) {
+    return
+  }
+  repairedPackageRoots.add(repairKey)
+
+  let candidates: string[]
+  try {
+    candidates = resolveCandidates(packageRoot)
+  } catch (error) {
+    console.warn(
+      `[pty] Failed to resolve node-pty spawn-helper candidates: ${error instanceof Error ? error.message : String(error)}`
+    )
+    return
+  }
+
+  // Why every candidate, not just the first: the loader pairs the helper with the dir it loaded
+  // from, so stopping at an already-+x build/Release leaves the 0644 prebuild helper to fail.
+  for (const candidate of candidates) {
+    try {
+      if (!existsSync(candidate)) {
+        continue
+      }
+      const mode = statSync(candidate).mode
+      if ((mode & 0o111) === 0) {
+        chmodSync(candidate, mode | 0o755)
+      }
+    } catch (error) {
+      // Keep going: one unwritable candidate must not strand the dir node-pty actually picked.
+      console.warn(
+        `[pty] Failed to ensure node-pty spawn-helper is executable at ${candidate}: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+}
+
+/**
+ * Per-candidate presence and mode, for spawn-failure messages.
+ *
+ * Why: upstream node-pty collapses every failing step of its spawn into one opaque
+ * "posix_spawnp failed." Hosts that never get Orca's patched binary — every SSH relay, since
+ * pnpm patches do not cross the SSH boundary — have to describe the helper themselves.
+ */
+export function describeNodePtySpawnHelperState(packageRoot?: string): string {
+  let candidates: string[]
+  try {
+    candidates = resolveCandidates(packageRoot)
+  } catch {
+    return 'spawn-helper unresolved'
+  }
+
+  const described = candidates.map((candidate) => {
+    try {
+      const mode = statSync(candidate).mode
+      const permissions = (mode & 0o777).toString(8)
+      return (mode & 0o111) === 0
+        ? `${candidate} (mode ${permissions}, NOT executable)`
+        : `${candidate} (mode ${permissions})`
+    } catch {
+      return `${candidate} (absent)`
+    }
+  })
+  return `spawn-helper: ${described.join('; ')}`
+}

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -70,6 +70,8 @@ import {
 import type { RelayPtySourceOutput } from './relay-pty-source-output'
 import { signalPosixPtyForegroundGroup } from '../main/pty/posix-pty-foreground-group'
 import { readPtsName } from '../main/pty/node-pty-pts-name'
+import { ensureNodePtySpawnHelperExecutable } from '../main/pty/node-pty-spawn-helper'
+import { formatRelayPtySpawnError } from './pty-spawn-failure-diagnostics'
 import type { RelayPtySourcePublication } from './relay-pty-source-publication'
 import type {
   PtySourceRecoveryRequest,
@@ -456,6 +458,8 @@ export class PtyHandler {
   private ptyModule: typeof NodePty | null = null
   private ptyModuleLoadPromise: Promise<typeof NodePty | null> | null = null
   private reloadPtyModuleFromDisk = false
+  /** Set only when node-pty came off the deployed bundle dir; diagnostics probe this root. */
+  private nodePtyPackageRoot: string | undefined
   // Why: single optional slot is intentional — callers compose externally; a throw is swallowed so it can't block cleanup.
   private exitListener: PtyExitListener | null = null
   private surfaceRetiredListener: PtySurfaceRetiredListener | null = null
@@ -523,6 +527,7 @@ export class PtyHandler {
     if (!this.reloadPtyModuleFromDisk) {
       try {
         this.ptyModule = await import('node-pty')
+        ensureNodePtySpawnHelperExecutable()
         return this.ptyModule
       } catch {
         this.reloadPtyModuleFromDisk = true
@@ -535,6 +540,10 @@ export class PtyHandler {
     }
     try {
       this.ptyModule = require(moduleEntry) as typeof NodePty
+      this.nodePtyPackageRoot = join(__dirname, 'node_modules', 'node-pty')
+      // Why here: SFTP drops the +x bit and the packaged prebuild helper ships 0644, so the
+      // deployed relay can hold a node-pty whose helper posix_spawn can never execute.
+      ensureNodePtySpawnHelperExecutable(this.nodePtyPackageRoot)
       return this.ptyModule
     } catch {
       return null
@@ -1707,7 +1716,7 @@ export class PtyHandler {
         this.invalidatePtyModuleAfterBindingFailure()
         throw new Error(formatNodePtyUnavailableMessage(process.platform))
       }
-      throw error
+      throw formatRelayPtySpawnError(error, shell, cwd, this.nodePtyPackageRoot)
     }
     onPhysicalSpawnCommitted?.()
 

--- a/src/relay/pty-spawn-failure-diagnostics.test.ts
+++ b/src/relay/pty-spawn-failure-diagnostics.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as fs from 'node:fs'
+import type { Stats } from 'node:fs'
+
+const PACKAGE_ROOT = '/relay/node_modules/node-pty'
+const RELEASE_HELPER = `${PACKAGE_ROOT}/build/Release/spawn-helper`
+
+const { statSyncMock } = vi.hoisted(() => ({ statSyncMock: vi.fn() }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>()
+  return { ...actual, statSync: statSyncMock }
+})
+
+import {
+  formatRelayPtySpawnError,
+  isOpaqueNodePtySpawnFailure
+} from './pty-spawn-failure-diagnostics'
+
+function stubHelperModes(modes: Record<string, number>): void {
+  statSyncMock.mockImplementation((path: string) => {
+    const mode = modes[path]
+    if (mode === undefined) {
+      throw Object.assign(new Error(`ENOENT: stat '${path}'`), { code: 'ENOENT' })
+    }
+    return { mode } as Stats
+  })
+}
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+beforeEach(() => {
+  statSyncMock.mockReset()
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+})
+
+afterEach(() => {
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+})
+
+describe('isOpaqueNodePtySpawnFailure', () => {
+  it('matches the unpatched node-pty catch-all', () => {
+    expect(isOpaqueNodePtySpawnFailure('posix_spawnp failed.')).toBe(true)
+    expect(isOpaqueNodePtySpawnFailure('posix_spawnp failed')).toBe(true)
+  })
+
+  it('leaves a message that already names its step alone', () => {
+    expect(
+      isOpaqueNodePtySpawnFailure(
+        'node-pty: posix_spawn failed: EACCES (errno 13, Permission denied)'
+      )
+    ).toBe(false)
+  })
+})
+
+describe('formatRelayPtySpawnError', () => {
+  it('names the shell, cwd and host the client cannot see', () => {
+    stubHelperModes({ [RELEASE_HELPER]: 0o100755 })
+
+    const message = formatRelayPtySpawnError(
+      new Error('posix_spawnp failed.'),
+      '/bin/zsh',
+      '/home/dev/repo',
+      PACKAGE_ROOT
+    ).message
+
+    expect(message).toContain('/bin/zsh')
+    expect(message).toContain('/home/dev/repo')
+    expect(message).toContain(`node ${process.versions.node}`)
+  })
+
+  it('reports the spawn-helper mode when node-pty gives no step', () => {
+    stubHelperModes({ [RELEASE_HELPER]: 0o100644 })
+
+    const message = formatRelayPtySpawnError(
+      new Error('posix_spawnp failed.'),
+      '/bin/zsh',
+      '/home/dev/repo',
+      PACKAGE_ROOT
+    ).message
+
+    // The regression this exists for: a bare "posix_spawnp failed." told nobody that the helper
+    // node-pty was about to exec had lost its +x bit.
+    expect(message).toContain('NOT executable')
+    expect(message).toContain(RELEASE_HELPER)
+  })
+
+  it('reports an absent helper', () => {
+    stubHelperModes({})
+
+    const message = formatRelayPtySpawnError(
+      new Error('posix_spawnp failed.'),
+      '/bin/zsh',
+      '/repo',
+      PACKAGE_ROOT
+    ).message
+
+    expect(message).toContain('absent')
+  })
+
+  it('does not probe the helper for a failure that already names its step', () => {
+    stubHelperModes({ [RELEASE_HELPER]: 0o100644 })
+
+    const message = formatRelayPtySpawnError(
+      new Error('node-pty: posix_openpt failed: EMFILE (errno 24, Too many open files)'),
+      '/bin/zsh',
+      '/repo',
+      PACKAGE_ROOT
+    ).message
+
+    expect(message).toContain('posix_openpt failed: EMFILE')
+    expect(message).not.toContain('spawn-helper')
+  })
+
+  it('never emits the daemon-restart markers the client keys on', () => {
+    stubHelperModes({ [RELEASE_HELPER]: 0o100644 })
+
+    const message = formatRelayPtySpawnError(
+      new Error('posix_spawnp failed.'),
+      '/bin/zsh',
+      '/repo',
+      PACKAGE_ROOT
+    ).message
+
+    // shouldOfferDaemonRestart() would otherwise offer to restart a *local* daemon for a remote
+    // host's failure.
+    expect(message).not.toContain("Daemon's node-pty install is gone")
+    expect(message).not.toContain('node-pty: posix_spawn failed: ENOENT')
+  })
+
+  it('keeps the original stack', () => {
+    stubHelperModes({ [RELEASE_HELPER]: 0o100755 })
+    const original = new Error('posix_spawnp failed.')
+
+    expect(formatRelayPtySpawnError(original, '/bin/sh', '/repo', PACKAGE_ROOT).stack).toBe(
+      original.stack
+    )
+  })
+})

--- a/src/relay/pty-spawn-failure-diagnostics.ts
+++ b/src/relay/pty-spawn-failure-diagnostics.ts
@@ -1,0 +1,46 @@
+import { describeNodePtySpawnHelperState } from '../main/pty/node-pty-spawn-helper'
+
+/**
+ * Upstream node-pty reports posix_openpt, grantpt, unlockpt, the slave open and the spawn itself as
+ * one indistinguishable "posix_spawnp failed." — no step, no errno. Orca patches that away locally,
+ * but pnpm patches do not cross the SSH boundary, so a relay always runs the unpatched build.
+ */
+const OPAQUE_NODE_PTY_SPAWN_FAILURE = /^\s*posix_spawnp failed\.?\s*$/
+
+export function isOpaqueNodePtySpawnFailure(message: string): boolean {
+  return OPAQUE_NODE_PTY_SPAWN_FAILURE.test(message)
+}
+
+function relayHostDiag(): string {
+  return `host: ${process.platform} ${process.arch}, node ${process.versions.node}`
+}
+
+/**
+ * Wrap a relay PTY spawn failure with the context the client cannot otherwise see.
+ *
+ * Why: the relay used to rethrow node-pty's error verbatim, so a remote spawn failure reached the
+ * terminal toast as a bare "posix_spawnp failed." — no shell, no cwd, no host, and no way to tell a
+ * missing spawn-helper from an exhausted pty table.
+ *
+ * @param nodePtyPackageRoot node-pty dir the relay loaded, when it resolved one off disk.
+ */
+export function formatRelayPtySpawnError(
+  error: unknown,
+  shell: string,
+  cwd: string,
+  nodePtyPackageRoot?: string
+): Error {
+  const message = error instanceof Error ? error.message : String(error)
+  // Only the opaque failure earns the helper probe; a message that already names its step keeps
+  // the detail node-pty gave it.
+  const detail = isOpaqueNodePtySpawnFailure(message)
+    ? `${message} node-pty did not report which step failed (unpatched build). ${describeNodePtySpawnHelperState(nodePtyPackageRoot)}.`
+    : message
+  const formatted = new Error(
+    `Remote host failed to spawn shell "${shell}" with cwd "${cwd}": ${detail} (${relayHostDiag()})`
+  )
+  if (error instanceof Error && error.stack) {
+    formatted.stack = error.stack
+  }
+  return formatted
+}

--- a/src/relay/relay-daemon.ts
+++ b/src/relay/relay-daemon.ts
@@ -1,7 +1,11 @@
 import { installRelayLogRotation } from './rotating-log-writer'
 import { readLaunchVersion } from './relay-handshake'
 import type { RelayLaunchOptions } from './relay-launch-options'
-import { RELAY_EMPTY_DETACHED_STARTUP_GRACE_MS, RELAY_IDLE_GRACE_MS } from './relay-launch-options'
+import {
+  RELAY_ABANDONED_GRACE_MS,
+  RELAY_EMPTY_DETACHED_STARTUP_GRACE_MS,
+  RELAY_IDLE_GRACE_MS
+} from './relay-launch-options'
 import { relayLogLine } from './relay-diagnostic-log'
 import { RelayPrimaryChannel } from './relay-primary-channel'
 import { RelayRuntimeServices } from './relay-runtime-services'
@@ -49,6 +53,7 @@ export async function runRelayDaemon(
     detached: options.detached,
     emptyDetachedStartupGraceMs: RELAY_EMPTY_DETACHED_STARTUP_GRACE_MS,
     idleRelayGraceMs: RELAY_IDLE_GRACE_MS,
+    abandonedRelayGraceMs: RELAY_ABANDONED_GRACE_MS,
     readSocketClientCount: () => reconnectListener?.clientCount ?? 0,
     hasAcceptedSocketClient: () => reconnectListener?.hasAcceptedClient ?? false,
     ownsSocketPath: () => socketOwnership.owned,

--- a/src/relay/relay-grace-branch.test.ts
+++ b/src/relay/relay-grace-branch.test.ts
@@ -10,6 +10,7 @@ import {
 
 const EMPTY_DETACHED_STARTUP_GRACE_MS = 30_000
 const IDLE_RELAY_GRACE_MS = 15 * 60_000
+const ABANDONED_RELAY_GRACE_MS = 7 * 24 * 60 * 60_000
 
 function decide(overrides: Partial<RelayGraceDecisionInput> = {}) {
   return decideRelayGrace({
@@ -17,10 +18,13 @@ function decide(overrides: Partial<RelayGraceDecisionInput> = {}) {
     relayIdle: false,
     detached: false,
     hasAcceptedSocketClient: true,
+    // Default: a client is attached, so existing cases keep exercising the unbounded window.
+    hasConnectedSocketClient: true,
     activePtyCount: 1,
     retryDeferredShutdown: false,
     emptyDetachedStartupGraceMs: EMPTY_DETACHED_STARTUP_GRACE_MS,
     idleRelayGraceMs: IDLE_RELAY_GRACE_MS,
+    abandonedRelayGraceMs: ABANDONED_RELAY_GRACE_MS,
     ...overrides
   })
 }
@@ -250,5 +254,47 @@ describe('applyRelayGraceTimeConfiguration', () => {
       expect(host.configuredGraceMs()).toBe(10_000)
       expect(host.startGrace).not.toHaveBeenCalled()
     }
+  })
+})
+
+describe('the abandoned-relay bound', () => {
+  it('bounds an unlimited grace once no client is left to reattach', () => {
+    // The leak this exists for: an Orca update leaves the old version's relay running, and
+    // cross-version isolation means its client never comes back — so it held its PTYs forever.
+    expect(decide({ hasConnectedSocketClient: false })).toEqual({
+      branch: 'abandoned-no-client',
+      timeoutMs: ABANDONED_RELAY_GRACE_MS
+    })
+  })
+
+  it('leaves the window unlimited while a client is still attached', () => {
+    expect(decide({ hasConnectedSocketClient: true })).toEqual({
+      branch: 'configured',
+      timeoutMs: 0
+    })
+  })
+
+  it('honors an explicitly configured grace instead of the abandoned bound', () => {
+    // A configured grace is the host's own deadline; only the unlimited default needs a ceiling.
+    expect(decide({ hasConnectedSocketClient: false, configuredGraceMs: 5_000 })).toEqual({
+      branch: 'configured',
+      timeoutMs: 5_000
+    })
+  })
+
+  it('prefers the idle bound when the relay holds no PTYs at all', () => {
+    expect(decide({ hasConnectedSocketClient: false, relayIdle: true, activePtyCount: 0 })).toEqual(
+      {
+        branch: 'idle-no-ptys',
+        timeoutMs: IDLE_RELAY_GRACE_MS
+      }
+    )
+  })
+
+  it('does not preempt a deferred shutdown retry', () => {
+    expect(decide({ hasConnectedSocketClient: false, retryDeferredShutdown: true })).toEqual({
+      branch: 'shutdown-deferred',
+      timeoutMs: IDLE_RELAY_GRACE_MS
+    })
   })
 })

--- a/src/relay/relay-grace-branch.ts
+++ b/src/relay/relay-grace-branch.ts
@@ -3,6 +3,7 @@ export type RelayGraceBranch =
   | 'shutdown-deferred'
   | 'startup-empty-detached'
   | 'idle-no-ptys'
+  | 'abandoned-no-client'
   | 'configured'
 
 export type RelayGraceDecisionInput = {
@@ -12,10 +13,14 @@ export type RelayGraceDecisionInput = {
   relayIdle: boolean
   detached: boolean
   hasAcceptedSocketClient: boolean
+  /** A client is attached right now — distinct from `hasAcceptedSocketClient`, which stays true after it leaves. */
+  hasConnectedSocketClient: boolean
   activePtyCount: number
   retryDeferredShutdown: boolean
   emptyDetachedStartupGraceMs: number
   idleRelayGraceMs: number
+  /** Upper bound on an unlimited grace once no client is left to come back for the PTYs. */
+  abandonedRelayGraceMs: number
 }
 
 export type RelayGraceDecision = {
@@ -117,6 +122,12 @@ export function decideRelayGrace(input: RelayGraceDecisionInput): RelayGraceDeci
   // Why: a spawn parked mid-creation is not in the pool yet, so capping on it would kill the live
   // shell it is about to produce.
   const idleNoPtys = input.relayIdle && input.configuredGraceMs === 0
+  // Why bound the unlimited grace: an Orca update deploys a new version dir and leaves this relay
+  // running, and cross-version isolation means its client can never reattach. Unbounded, every past
+  // version keeps its PTYs forever — on macOS that walks the host into kern.tty.ptmx_max and no new
+  // terminal can spawn anywhere. A client that does come back cancels the window.
+  const abandonedNoClient =
+    !input.relayIdle && input.configuredGraceMs === 0 && !input.hasConnectedSocketClient
 
   const branch: RelayGraceBranch = input.retryDeferredShutdown
     ? 'shutdown-deferred'
@@ -124,7 +135,9 @@ export function decideRelayGrace(input: RelayGraceDecisionInput): RelayGraceDeci
       ? 'startup-empty-detached'
       : idleNoPtys
         ? 'idle-no-ptys'
-        : 'configured'
+        : abandonedNoClient
+          ? 'abandoned-no-client'
+          : 'configured'
 
   const timeoutMs =
     branch === 'startup-empty-detached'
@@ -135,7 +148,9 @@ export function decideRelayGrace(input: RelayGraceDecisionInput): RelayGraceDeci
         // branch must supply its own bound or the shipped grace=0 default arms no retry at all.
         branch === 'idle-no-ptys' || branch === 'shutdown-deferred'
         ? input.idleRelayGraceMs
-        : input.configuredGraceMs
+        : branch === 'abandoned-no-client'
+          ? input.abandonedRelayGraceMs
+          : input.configuredGraceMs
 
   return { branch, timeoutMs }
 }

--- a/src/relay/relay-grace-lifecycle.ts
+++ b/src/relay/relay-grace-lifecycle.ts
@@ -14,6 +14,7 @@ type RelayGraceLifecycleOptions = {
   detached: boolean
   emptyDetachedStartupGraceMs: number
   idleRelayGraceMs: number
+  abandonedRelayGraceMs: number
   readSocketClientCount: () => number
   hasAcceptedSocketClient: () => boolean
   ownsSocketPath: () => boolean
@@ -65,7 +66,9 @@ export class RelayGraceLifecycle {
       activePtyCount: this.options.ptyHandler.activePtyCount,
       retryDeferredShutdown: options?.retryDeferredShutdown === true,
       emptyDetachedStartupGraceMs: this.options.emptyDetachedStartupGraceMs,
-      idleRelayGraceMs: this.options.idleRelayGraceMs
+      idleRelayGraceMs: this.options.idleRelayGraceMs,
+      abandonedRelayGraceMs: this.options.abandonedRelayGraceMs,
+      hasConnectedSocketClient: this.options.readSocketClientCount() > 0
     })
     this.graceBranch = decision.branch
     this.graceDeadlineAt = decision.timeoutMs === 0 ? null : Date.now() + decision.timeoutMs
@@ -74,6 +77,11 @@ export class RelayGraceLifecycle {
       `[relay] Grace started (${reason}): timeoutMs=${decision.timeoutMs}, branch=${this.graceBranch}, ptys=${this.options.ptyHandler.activePtyCount}, clients=${this.options.readSocketClientCount()}`
     )
     this.options.ptyHandler.startGraceTimer(() => {
+      if (this.graceBranch === 'abandoned-no-client' && this.options.readSocketClientCount() > 0) {
+        relayLogLine(`[relay] Grace expired (${reason}) but a client is attached; re-evaluating`)
+        this.start(reason)
+        return
+      }
       if (this.graceBranch === 'idle-no-ptys' && !this.isRelayIdle()) {
         relayLogLine(`[relay] Grace expired (${reason}) but relay is no longer idle; re-evaluating`)
         this.start(reason)
@@ -86,7 +94,12 @@ export class RelayGraceLifecycle {
 
   installProcessLifecycle(): void {
     this.stopPoolWatch = this.options.ptyHandler.onPtyPoolEmpty(() => {
-      if (this.graceReason !== null && this.graceDeadlineAt === null && !this.shutdownInFlight) {
+      if (this.graceReason === null || this.shutdownInFlight) {
+        return
+      }
+      // Why the branch test alongside the deadline test: the abandoned window has a deadline, but a
+      // far longer one — going idle must still collapse it to the idle grace rather than wait days.
+      if (this.graceDeadlineAt === null || this.graceBranch === 'abandoned-no-client') {
         this.start('last pty exited')
       }
     })

--- a/src/relay/relay-launch-options.ts
+++ b/src/relay/relay-launch-options.ts
@@ -12,6 +12,12 @@ export const RELAY_EMPTY_DETACHED_STARTUP_GRACE_MS = parseNonNegativeIntEnv(
 // Why: a relay holding zero PTYs preserves nothing, so an unlimited grace only accumulates idle daemons.
 // The env override is test-only — the remote relay is launched over a non-interactive SSH exec channel that carries no client env.
 export const RELAY_IDLE_GRACE_MS = parseNonNegativeIntEnv('ORCA_RELAY_IDLE_GRACE_MS', 15 * 60_000)
+// Why days, not minutes: this window must outlast a laptop closed over a long weekend, while still
+// bounding a relay whose client will never return — an Orca update strands the whole version dir.
+export const RELAY_ABANDONED_GRACE_MS = parseNonNegativeIntEnv(
+  'ORCA_RELAY_ABANDONED_GRACE_MS',
+  7 * 24 * 60 * 60_000
+)
 
 export type RelayLaunchOptions = {
   graceTimeMs: number


### PR DESCRIPTION
## ELI5

An Orca update leaves the *old* remote relay running forever. Every update adds one more. On one mac mini, 25 of them had piled up since mid-July, between them holding so many ptys that the host hit macOS's hard limit — after which **no terminal could start on that machine at all.** And the error said only `posix_spawnp failed.`, which names nothing.

## What Changed

**1. Bound the grace window for a relay no client can return to** (the leak)

Version dirs are isolated by design, so after an update the previous version's relay can never be reattached to. Nothing tells it to leave, and a relay holding PTYs under the shipped `grace=0` default gets an *unlimited* window — so it lives forever.

New `abandoned-no-client` branch in `decideRelayGrace`: an unlimited grace held open for PTYs with **no client attached** now expires after `ORCA_RELAY_ABANDONED_GRACE_MS` (7 days). Days, not minutes, so it outlasts a laptop closed over a long weekend. A returning client cancels it; an explicitly configured grace is still honored verbatim.

This also fixed a bug the change itself exposed: the pool-empty re-arm keyed on *"this window has no deadline"*, which was only ever a proxy for *"nothing will fire"*. The abandoned window **has** a deadline, so the branch is now named explicitly — otherwise a relay whose last PTY exits would wait out the seven days instead of collapsing to the 15-minute idle grace. Caught by `subprocess.test.ts`.

**2. Make remote PTY spawn failures diagnosable**

Upstream node-pty collapses `posix_openpt`, `grantpt`, `unlockpt`, the slave open and `posix_spawn` into one opaque `posix_spawnp failed.` Orca patches that away — but **pnpm patches do not cross the SSH boundary** (`ssh-relay-deploy.ts`), so a relay always runs the unpatched build, and `pty-handler.ts` rethrew the message verbatim.

The relay now wraps spawn failures with shell, cwd and host, and probes the spawn-helper **only when node-pty named no step**, so a message that already carries its errno keeps that detail. The wrapper deliberately emits neither daemon-restart marker — those would offer to restart a *local* daemon for a *remote* host's failure (test-pinned).

**3. Repair every spawn-helper, not just the first**

`ensureNodePtySpawnHelperExecutable` returned at the first existing candidate. `build/Release/spawn-helper` is always +x from the compiler, so it returned there and never repaired the packaged `prebuilds/<platform>-<arch>/spawn-helper`, which ships **0644** — the one case the function exists for. node-pty's loader falls back to that prebuild and spawns the helper next to it.

The daemon preflight also accepted any regular file as proof of a working install; it now checks executability and reports EACCES separately from the ENOENT "install is gone" story. The repair latch is keyed per package root, because the relay can load node-pty from the bundle and later from its deployed dir.

## Why

Found while diagnosing a live report. The reproduction on the affected host:

```
kern.tty.ptmx_max: 511      ← macOS limit
/dev/ttys* :       527      ← over it
node-pty spawn  →  posix_spawnp failed.
```

Killing the 23 stale relays took `live ttys` from 165 to 2 and the spawn probe from `posix_spawnp failed.` to `SPAWN OK`. Item 1 stops the pile-up; item 2 means the next occurrence names its own cause instead of needing a live remote reproduction.

Note item 3 turned out **not** to be the cause on that host — its prebuild helper was correctly 755. It is a real defect found on the way and is kept as such, not presented as the fix.

## Linked Issue

None — filed from a live incident rather than a tracked issue. Happy to open one if that is preferred.

## Visual Proof

N/A — no UI change. The only user-visible difference is the text of a terminal error toast, which goes from `posix_spawnp failed.` to a message naming the shell, cwd, host and spawn-helper state.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

**Live verification** (macOS remote over SSH, the affected host): reproduced `posix_spawnp failed.` with the relay's own node-pty, confirmed `ptmx_max` exhaustion as the cause, cleared the stale relays, and confirmed the same probe then returns `SPAWN OK exit=0`.

**Automated**: 120 tests across the 8 touched suites pass, including new coverage for the abandoned bound (5 cases), the relay diagnostics (7), the helper repair (6) and the preflight (5). Each new test was checked to **fail** against the pre-fix source — they are regression guards, not description.

- `pnpm run typecheck` — clean
- `pnpm run check:code-quality:changed` — 0 new findings across 16 files

Platforms: verified on macOS locally and against a macOS SSH host. The Linux and Windows paths are unchanged in shape; the spawn-helper work is already `process.platform !== 'win32'`-gated.

⚠️ Full-suite `vitest run src/relay/` is flaky on a loaded machine — ~10 `git-handler-*` files time out **on clean `main` too**, with the failing set changing between runs. Isolated runs of every suite this PR touches are green.

## Wire compatibility

Item 2 changes content the host publishes, which reaches old clients unchanged in shape (Rule 3 of `docs/reference/remote-wire-compatibility.md`). Every client-side matcher was checked — `shouldOfferDaemonRestart`, `isExplainedTerminalError`, the SSH prefixes — and the new message matches none of them, so this is display-only: an old client shows a longer, more useful string.

## AI Disclosure

Investigated and written with Claude Code (Opus 5).

https://claude.ai/code/session_01RmJUpcAspFXJMpGDFPPyHc
