### PR TITLE
fix(agent-status): reconcile stale pane status

### DIFF
--- a/src/main/agent-hooks/server-interrupt-inference-resurrection.test.ts
+++ b/src/main/agent-hooks/server-interrupt-inference-resurrection.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AgentHookServer, _internals } from './server'
-import { PANE } from './server.test-fixtures'
+import { buildBody, PANE } from './server.test-fixtures'
 
 const { getCohortAtEmitMock, trackMock } = vi.hoisted(() => ({
   getCohortAtEmitMock: vi.fn(),
@@ -389,7 +389,7 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
-  it('suppresses same-turn Claude tool progress after the stale suppression window', () => {
+  it('allows same-turn Claude tool progress after the stale suppression window', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)
     try {
@@ -440,12 +440,12 @@ describe('AgentHookServer listener replay', () => {
 
       expect(server.getStatusSnapshot()).toEqual([
         expect.objectContaining({
-          state: 'done',
+          state: 'working',
           prompt: 'repeat task',
           agentType: 'claude',
-          interrupted: true,
-          receivedAt: 1_500,
-          stateStartedAt: 1_500
+          interrupted: undefined,
+          receivedAt: 16_501,
+          stateStartedAt: 16_501
         })
       ])
     } finally {
@@ -565,6 +565,89 @@ describe('AgentHookServer listener replay', () => {
         })
       ])
     } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('allows Codex tool progress after a request_user_input wait and interrupted turn', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const server = new AgentHookServer()
+    try {
+      await server.start({ env: 'production' })
+      const postCodexHook = async (payload: Record<string, unknown>): Promise<void> => {
+        const env = server.buildPtyEnv()
+        const response = await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/codex`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+        expect(response.status).toBe(204)
+      }
+
+      await postCodexHook({
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'same turn'
+      })
+      vi.setSystemTime(1_100)
+      await postCodexHook({
+        hook_event_name: 'PreToolUse',
+        prompt: 'same turn',
+        tool_name: 'request_user_input',
+        tool_input: {
+          questions: [{ id: 'choice', question: 'Which color?', options: [{ label: 'Blue' }] }]
+        }
+      })
+      // Mirrors the captured Codex shape: this auto-allowed tool parks the row while awaiting an answer.
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'waiting',
+        prompt: 'same turn',
+        toolName: 'request_user_input'
+      })
+      vi.setSystemTime(2_000)
+      await postCodexHook({
+        hook_event_name: 'PostToolUse',
+        prompt: 'same turn',
+        tool_name: 'request_user_input',
+        tool_input: {
+          questions: [{ id: 'choice', question: 'Which color?', options: [{ label: 'Blue' }] }]
+        },
+        tool_response: '{"answers":{"choice":{"answers":["Blue"]}}}'
+      })
+      const baseline = server.getStatusSnapshot()[0]
+      expect(baseline).toMatchObject({ state: 'working', prompt: 'same turn' })
+      vi.setSystemTime(2_500)
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'same turn',
+          baselineAgentType: 'codex',
+          intent: 'plain-escape'
+        })
+      ).toBe(true)
+
+      vi.setSystemTime(18_501)
+      await postCodexHook({
+        hook_event_name: 'PreToolUse',
+        prompt: 'same turn',
+        tool_name: 'exec_command',
+        tool_input: { cmd: 'pnpm test' }
+      })
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'working',
+        prompt: 'same turn',
+        toolName: 'exec_command',
+        interrupted: undefined,
+        receivedAt: 18_501,
+        stateStartedAt: 18_501
+      })
+    } finally {
+      server.stop()
       vi.useRealTimers()
     }
   })

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1599,7 +1599,8 @@ export class AgentHookServer {
       previous.payload.agentType === effectivePayload.payload.agentType &&
       previous.payload.prompt === effectivePayload.payload.prompt &&
       (effectivePayload.isReplay === true ||
-        isToolProgressWorkingAfterInterrupt(effectivePayload) ||
+        (isToolProgressWorkingAfterInterrupt(effectivePayload) &&
+          Date.now() - previous.receivedAt <= INTERRUPTED_DONE_LATE_WORKING_SUPPRESSION_MS) ||
         (effectivePayload.hasExplicitPrompt !== true &&
           Date.now() - previous.receivedAt <= INTERRUPTED_DONE_LATE_WORKING_SUPPRESSION_MS))
     ) {

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -5,7 +5,7 @@ import { resolveWorktreeStatus, type WorktreeStatus } from '@/lib/worktree-statu
 import { EMPTY_BROWSER_TABS, EMPTY_TABS } from './WorktreeCardHelpers'
 import {
   selectLivePtyIdsForWorktree,
-  selectTerminalLayoutRootsForWorktree,
+  selectTerminalLayoutsForWorktree,
   selectRuntimePaneTitlesForWorktree
 } from './worktree-card-status-inputs'
 import { selectWorktreeAgentActivitySummary } from './worktree-agent-activity-summary'
@@ -19,8 +19,8 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
   const ptyIdsForWorktree = useAppStore(
     useShallow((s) => selectLivePtyIdsForWorktree(s, worktreeId))
   )
-  const terminalLayoutRootsByTabId = useAppStore(
-    useShallow((s) => selectTerminalLayoutRootsForWorktree(s, worktreeId))
+  const terminalLayoutsByTabId = useAppStore(
+    useShallow((s) => selectTerminalLayoutsForWorktree(s, worktreeId))
   )
   const {
     hasPermission,
@@ -44,7 +44,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         ptyIdsByTabId: ptyIdsForWorktree,
         runtimePaneTitlesByTabId: runtimePaneTitlesForWorktree,
         agentStatusPaneIdsByTabId,
-        terminalLayoutRootsByTabId,
+        terminalLayoutsByTabId,
         paneForegroundAgentByPaneKey,
         hasPermission,
         hasLiveWorking,
@@ -59,7 +59,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       ptyIdsForWorktree,
       runtimePaneTitlesForWorktree,
       agentStatusPaneIdsByTabId,
-      terminalLayoutRootsByTabId,
+      terminalLayoutsByTabId,
       paneForegroundAgentByPaneKey,
       hasPermission,
       hasLiveWorking,

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -29,7 +29,8 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
     hasInterrupted,
     hasLiveDone,
     hasRetainedDone,
-    agentStatusPaneIdsByTabId
+    agentStatusPaneIdsByTabId,
+    paneForegroundAgentByPaneKey
   } = useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
 
   // Why: compact and detailed cards need the same status-dot semantics:
@@ -44,6 +45,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         runtimePaneTitlesByTabId: runtimePaneTitlesForWorktree,
         agentStatusPaneIdsByTabId,
         terminalLayoutRootsByTabId,
+        paneForegroundAgentByPaneKey,
         hasPermission,
         hasLiveWorking,
         hasLiveMonitoring,
@@ -58,6 +60,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       runtimePaneTitlesForWorktree,
       agentStatusPaneIdsByTabId,
       terminalLayoutRootsByTabId,
+      paneForegroundAgentByPaneKey,
       hasPermission,
       hasLiveWorking,
       hasLiveMonitoring,

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -30,7 +30,8 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
     hasLiveDone,
     hasRetainedDone,
     agentStatusPaneIdsByTabId,
-    paneForegroundAgentByPaneKey
+    paneForegroundAgentByPaneKey,
+    paneForegroundAgentObservationByPaneKey
   } = useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
 
   // Why: compact and detailed cards need the same status-dot semantics:
@@ -46,6 +47,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         agentStatusPaneIdsByTabId,
         terminalLayoutsByTabId,
         paneForegroundAgentByPaneKey,
+        paneForegroundAgentObservationByPaneKey,
         hasPermission,
         hasLiveWorking,
         hasLiveMonitoring,
@@ -61,6 +63,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       agentStatusPaneIdsByTabId,
       terminalLayoutsByTabId,
       paneForegroundAgentByPaneKey,
+      paneForegroundAgentObservationByPaneKey,
       hasPermission,
       hasLiveWorking,
       hasLiveMonitoring,

--- a/src/renderer/src/components/sidebar/use-worktree-activity-statuses.test.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-statuses.test.ts
@@ -15,7 +15,8 @@ function makeStatusState(): StatusState {
     agentStatusByPaneKey: {},
     migrationUnsupportedByPtyId: {},
     retainedAgentsByPaneKey: {},
-    runtimeAgentOrchestrationByPaneKey: {}
+    runtimeAgentOrchestrationByPaneKey: {},
+    paneForegroundAgentByPaneKey: {}
   }
 }
 

--- a/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
@@ -23,7 +23,9 @@ type WorktreeActivityStatusState = Pick<
   | 'retainedAgentsByPaneKey'
   | 'runtimeAgentOrchestrationByPaneKey'
   | 'paneForegroundAgentByPaneKey'
->
+> & {
+  paneForegroundAgentObservationByPaneKey?: AppState['paneForegroundAgentObservationByPaneKey']
+}
 
 export function selectWorktreeActivityStatuses(
   statusInputs: WorktreeActivityStatusState,
@@ -39,7 +41,8 @@ export function selectWorktreeActivityStatuses(
       hasLiveDone,
       hasRetainedDone,
       agentStatusPaneIdsByTabId,
-      paneForegroundAgentByPaneKey
+      paneForegroundAgentByPaneKey,
+      paneForegroundAgentObservationByPaneKey
     } = selectWorktreeAgentActivitySummary(statusInputs, worktreeId)
     statuses.set(
       worktreeId,
@@ -51,6 +54,7 @@ export function selectWorktreeActivityStatuses(
         agentStatusPaneIdsByTabId,
         terminalLayoutsByTabId: selectTerminalLayoutsForWorktree(statusInputs, worktreeId),
         paneForegroundAgentByPaneKey,
+        paneForegroundAgentObservationByPaneKey,
         hasPermission,
         hasLiveWorking,
         hasLiveMonitoring,

--- a/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
@@ -5,7 +5,7 @@ import { resolveWorktreeStatus, type WorktreeStatus } from '@/lib/worktree-statu
 import { EMPTY_BROWSER_TABS, EMPTY_TABS } from './WorktreeCardHelpers'
 import {
   selectLivePtyIdsForWorktree,
-  selectTerminalLayoutRootsForWorktree,
+  selectTerminalLayoutsForWorktree,
   selectRuntimePaneTitlesForWorktree
 } from './worktree-card-status-inputs'
 import { selectWorktreeAgentActivitySummary } from './worktree-agent-activity-summary'
@@ -48,7 +48,7 @@ export function selectWorktreeActivityStatuses(
         ptyIdsByTabId: selectLivePtyIdsForWorktree(statusInputs, worktreeId),
         runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(statusInputs, worktreeId),
         agentStatusPaneIdsByTabId,
-        terminalLayoutRootsByTabId: selectTerminalLayoutRootsForWorktree(statusInputs, worktreeId),
+        terminalLayoutsByTabId: selectTerminalLayoutsForWorktree(statusInputs, worktreeId),
         paneForegroundAgentByPaneKey,
         hasPermission,
         hasLiveWorking,

--- a/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
@@ -37,7 +37,8 @@ export function selectWorktreeActivityStatuses(
       hasInterrupted,
       hasLiveDone,
       hasRetainedDone,
-      agentStatusPaneIdsByTabId
+      agentStatusPaneIdsByTabId,
+      paneForegroundAgentByPaneKey
     } = selectWorktreeAgentActivitySummary(statusInputs, worktreeId)
     statuses.set(
       worktreeId,
@@ -48,6 +49,7 @@ export function selectWorktreeActivityStatuses(
         runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(statusInputs, worktreeId),
         agentStatusPaneIdsByTabId,
         terminalLayoutRootsByTabId: selectTerminalLayoutRootsForWorktree(statusInputs, worktreeId),
+        paneForegroundAgentByPaneKey,
         hasPermission,
         hasLiveWorking,
         hasLiveMonitoring,

--- a/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
@@ -22,6 +22,7 @@ type WorktreeActivityStatusState = Pick<
   | 'migrationUnsupportedByPtyId'
   | 'retainedAgentsByPaneKey'
   | 'runtimeAgentOrchestrationByPaneKey'
+  | 'paneForegroundAgentByPaneKey'
 >
 
 export function selectWorktreeActivityStatuses(

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
@@ -267,6 +267,24 @@ describe('buildWorktreeAgentRows', () => {
     expect(done?.state).toBe('done')
   })
 
+  it('lets fresh pane activity replace a stale done row for the same pane', () => {
+    const staleAt = 1_000
+    const now = staleAt + AGENT_STATUS_STALE_AFTER_MS + 1
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'zsh' })],
+      entries: [makeEntry(PANE_KEY_1, staleAt, { state: 'done', updatedAt: staleAt })],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: '⠋ Claude Code' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSinglePaneLayout(LEAF_ID_1) },
+      now
+    })
+
+    expect(rows.map((row) => [row.paneKey, row.state, row.agentType])).toEqual([
+      [PANE_KEY_1, 'working', 'claude']
+    ])
+  })
+
   it('decays a restored-unconfirmed working entry to idle even while recent', () => {
     // Why: a hydrated nonterminal row may describe a turn that ended while no
     // receiver was up; it must never render as confirmed working, however new.

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -22,6 +22,7 @@ import {
 } from './worktree-agent-freshness-selector'
 import {
   EMPTY_PANE_FOREGROUND_AGENTS,
+  EMPTY_PANE_FOREGROUND_OBSERVATIONS,
   selectWorktreeAgentActivitySummary
 } from './worktree-agent-activity-summary'
 
@@ -85,6 +86,11 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
       ? selectWorktreeAgentActivitySummary(s, worktreeId).paneForegroundAgentByPaneKey
       : EMPTY_PANE_FOREGROUND_AGENTS
   )
+  const paneForegroundAgentObservationByPaneKey = useAppStore((s) =>
+    active
+      ? selectWorktreeAgentActivitySummary(s, worktreeId).paneForegroundAgentObservationByPaneKey
+      : EMPTY_PANE_FOREGROUND_OBSERVATIONS
+  )
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
   )
@@ -116,6 +122,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
         terminalLayoutsByTabId,
         runtimeAgentOrchestrationByPaneKey,
         paneForegroundAgentByPaneKey,
+        paneForegroundAgentObservationByPaneKey,
         now
       })
     )
@@ -131,6 +138,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     terminalLayoutsByTabId,
     runtimeAgentOrchestrationByPaneKey,
     paneForegroundAgentByPaneKey,
+    paneForegroundAgentObservationByPaneKey,
     agentFreshnessSignature
   ])
 }

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -20,6 +20,10 @@ import {
   createWorktreeAgentFreshnessSelector,
   EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
 } from './worktree-agent-freshness-selector'
+import {
+  EMPTY_PANE_FOREGROUND_AGENTS,
+  selectWorktreeAgentActivitySummary
+} from './worktree-agent-activity-summary'
 
 export { buildWorktreeAgentRows } from './worktree-agent-rows'
 export {
@@ -74,6 +78,13 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const runtimeAgentOrchestrationByPaneKey = useAppStore(
     useShallow((s) => (active ? selectRuntimeAgentOrchestrationForWorktree(s, worktreeId) : {}))
   )
+  // Reuse the worktree-narrowed process identity projection so hookless live
+  // panes can still appear without subscribing every card to the global map.
+  const paneForegroundAgentByPaneKey = useAppStore((s) =>
+    active
+      ? selectWorktreeAgentActivitySummary(s, worktreeId).paneForegroundAgentByPaneKey
+      : EMPTY_PANE_FOREGROUND_AGENTS
+  )
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
   )
@@ -104,6 +115,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
         ptyIdsByTabId,
         terminalLayoutsByTabId,
         runtimeAgentOrchestrationByPaneKey,
+        paneForegroundAgentByPaneKey,
         now
       })
     )
@@ -118,6 +130,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     ptyIdsByTabId,
     terminalLayoutsByTabId,
     runtimeAgentOrchestrationByPaneKey,
+    paneForegroundAgentByPaneKey,
     agentFreshnessSignature
   ])
 }

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary-equality.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary-equality.ts
@@ -1,0 +1,39 @@
+export function paneForegroundAgentsEqual<T>(
+  previous: Record<string, T>,
+  next: Record<string, T>
+): boolean {
+  if (previous === next) {
+    return true
+  }
+  const previousKeys = Object.keys(previous)
+  if (previousKeys.length !== Object.keys(next).length) {
+    return false
+  }
+  return previousKeys.every((paneKey) => previous[paneKey] === next[paneKey])
+}
+
+export function agentStatusPaneIdsByTabIdEqual(
+  previous: Record<string, ReadonlySet<string>>,
+  next: Record<string, ReadonlySet<string>>
+): boolean {
+  if (previous === next) {
+    return true
+  }
+  const previousKeys = Object.keys(previous)
+  if (previousKeys.length !== Object.keys(next).length) {
+    return false
+  }
+  for (const tabId of previousKeys) {
+    const previousPaneIds = previous[tabId]
+    const nextPaneIds = next[tabId]
+    if (!nextPaneIds || previousPaneIds.size !== nextPaneIds.size) {
+      return false
+    }
+    for (const paneId of previousPaneIds) {
+      if (!nextPaneIds.has(paneId)) {
+        return false
+      }
+    }
+  }
+  return true
+}

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -11,6 +11,7 @@ import {
   type AgentStatusEntry,
   type AgentStatusOrchestrationContext
 } from '../../../../shared/agent-status-types'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 export type WorktreeAgentActivitySummary = {
   hasPermission: boolean
@@ -21,9 +22,12 @@ export type WorktreeAgentActivitySummary = {
   hasLiveDone: boolean
   hasRetainedDone: boolean
   agentStatusPaneIdsByTabId: Record<string, ReadonlySet<string>>
+  /** Process identity narrowed to this worktree's panes. */
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
 }
 
 const EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID: Record<string, ReadonlySet<string>> = {}
+export const EMPTY_PANE_FOREGROUND_AGENTS: Record<string, PaneForegroundAgentEntry> = {}
 
 const EMPTY_SUMMARY: WorktreeAgentActivitySummary = {
   hasPermission: false,
@@ -32,7 +36,8 @@ const EMPTY_SUMMARY: WorktreeAgentActivitySummary = {
   hasInterrupted: false,
   hasLiveDone: false,
   hasRetainedDone: false,
-  agentStatusPaneIdsByTabId: EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID
+  agentStatusPaneIdsByTabId: EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID,
+  paneForegroundAgentByPaneKey: EMPTY_PANE_FOREGROUND_AGENTS
 }
 
 type AgentActivityTabsByWorktree = Record<string, readonly { id: string }[]>
@@ -46,6 +51,7 @@ export type AgentActivityInput = Pick<
 > & {
   tabsByWorktree: AgentActivityTabsByWorktree
   runtimeAgentOrchestrationByPaneKey?: AppState['runtimeAgentOrchestrationByPaneKey']
+  paneForegroundAgentByPaneKey?: AppState['paneForegroundAgentByPaneKey']
 }
 
 type AgentActivityCache = {
@@ -54,6 +60,7 @@ type AgentActivityCache = {
   migrationUnsupportedByPtyId: AppState['migrationUnsupportedByPtyId']
   retainedAgentsByPaneKey: AppState['retainedAgentsByPaneKey']
   runtimeAgentOrchestrationByPaneKey: AppState['runtimeAgentOrchestrationByPaneKey'] | undefined
+  paneForegroundAgentByPaneKey: AppState['paneForegroundAgentByPaneKey'] | undefined
   summaries: Map<string, WorktreeAgentActivitySummary>
 }
 
@@ -70,13 +77,15 @@ function getWorktreeAgentActivitySummaries(
   state: AgentActivityInput
 ): Map<string, WorktreeAgentActivitySummary> {
   const runtimeAgentOrchestrationByPaneKey = state.runtimeAgentOrchestrationByPaneKey
+  const paneForegroundAgentByPaneKey = state.paneForegroundAgentByPaneKey
   if (
     agentActivityCache &&
     agentActivityCache.tabsByWorktree === state.tabsByWorktree &&
     agentActivityCache.agentStatusEpoch === state.agentStatusEpoch &&
     agentActivityCache.migrationUnsupportedByPtyId === state.migrationUnsupportedByPtyId &&
     agentActivityCache.retainedAgentsByPaneKey === state.retainedAgentsByPaneKey &&
-    agentActivityCache.runtimeAgentOrchestrationByPaneKey === runtimeAgentOrchestrationByPaneKey
+    agentActivityCache.runtimeAgentOrchestrationByPaneKey === runtimeAgentOrchestrationByPaneKey &&
+    agentActivityCache.paneForegroundAgentByPaneKey === paneForegroundAgentByPaneKey
   ) {
     return agentActivityCache.summaries
   }
@@ -138,6 +147,23 @@ function getWorktreeAgentActivitySummaries(
     }
   }
 
+  // Narrow process identity to each worktree so sidebar rows can attribute
+  // title-derived activity without subscribing to every pane globally.
+  for (const [paneKey, entry] of Object.entries(paneForegroundAgentByPaneKey ?? {})) {
+    if (!entry.agent) {
+      continue
+    }
+    const worktreeId = worktreeIdForPaneKey(paneKey, tabIdToWorktreeId)
+    if (!worktreeId) {
+      continue
+    }
+    const summary = summaryForWorktree(worktreeId)
+    if (summary.paneForegroundAgentByPaneKey === EMPTY_PANE_FOREGROUND_AGENTS) {
+      summary.paneForegroundAgentByPaneKey = {}
+    }
+    summary.paneForegroundAgentByPaneKey[paneKey] = entry
+  }
+
   for (const retained of Object.values(state.retainedAgentsByPaneKey ?? {})) {
     const summary = summaryForWorktree(retained.worktreeId)
     summary.hasRetainedDone = true
@@ -170,6 +196,7 @@ function getWorktreeAgentActivitySummaries(
     migrationUnsupportedByPtyId: state.migrationUnsupportedByPtyId,
     retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
     runtimeAgentOrchestrationByPaneKey,
+    paneForegroundAgentByPaneKey,
     summaries
   }
   return summaries
@@ -189,8 +216,26 @@ function summariesEqual(
     agentStatusPaneIdsByTabIdEqual(
       previous.agentStatusPaneIdsByTabId,
       next.agentStatusPaneIdsByTabId
+    ) &&
+    paneForegroundAgentsEqual(
+      previous.paneForegroundAgentByPaneKey,
+      next.paneForegroundAgentByPaneKey
     )
   )
+}
+
+function paneForegroundAgentsEqual(
+  previous: Record<string, PaneForegroundAgentEntry>,
+  next: Record<string, PaneForegroundAgentEntry>
+): boolean {
+  if (previous === next) {
+    return true
+  }
+  const previousKeys = Object.keys(previous)
+  if (previousKeys.length !== Object.keys(next).length) {
+    return false
+  }
+  return previousKeys.every((paneKey) => previous[paneKey] === next[paneKey])
 }
 
 function agentStatusPaneIdsByTabIdEqual(

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -8,10 +8,17 @@ import {
 } from '@/lib/agent-status-worktree-attribution'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
-  type AgentStatusEntry,
   type AgentStatusOrchestrationContext
 } from '../../../../shared/agent-status-types'
-import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import type {
+  PaneForegroundAgentEntry,
+  PaneForegroundAgentObservation
+} from '@/store/slices/pane-foreground-agent'
+import {
+  agentStatusPaneIdsByTabIdEqual,
+  paneForegroundAgentsEqual
+} from './worktree-agent-activity-summary-equality'
+import { applyLiveAgentState } from './worktree-agent-state-flags'
 
 export type WorktreeAgentActivitySummary = {
   hasPermission: boolean
@@ -24,10 +31,12 @@ export type WorktreeAgentActivitySummary = {
   agentStatusPaneIdsByTabId: Record<string, ReadonlySet<string>>
   /** Process identity narrowed to this worktree's panes. */
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
+  paneForegroundAgentObservationByPaneKey: Record<string, PaneForegroundAgentObservation>
 }
 
 const EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID: Record<string, ReadonlySet<string>> = {}
 export const EMPTY_PANE_FOREGROUND_AGENTS: Record<string, PaneForegroundAgentEntry> = {}
+export const EMPTY_PANE_FOREGROUND_OBSERVATIONS: Record<string, PaneForegroundAgentObservation> = {}
 
 const EMPTY_SUMMARY: WorktreeAgentActivitySummary = {
   hasPermission: false,
@@ -37,7 +46,8 @@ const EMPTY_SUMMARY: WorktreeAgentActivitySummary = {
   hasLiveDone: false,
   hasRetainedDone: false,
   agentStatusPaneIdsByTabId: EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID,
-  paneForegroundAgentByPaneKey: EMPTY_PANE_FOREGROUND_AGENTS
+  paneForegroundAgentByPaneKey: EMPTY_PANE_FOREGROUND_AGENTS,
+  paneForegroundAgentObservationByPaneKey: EMPTY_PANE_FOREGROUND_OBSERVATIONS
 }
 
 type AgentActivityTabsByWorktree = Record<string, readonly { id: string }[]>
@@ -52,6 +62,7 @@ export type AgentActivityInput = Pick<
   tabsByWorktree: AgentActivityTabsByWorktree
   runtimeAgentOrchestrationByPaneKey?: AppState['runtimeAgentOrchestrationByPaneKey']
   paneForegroundAgentByPaneKey?: AppState['paneForegroundAgentByPaneKey']
+  paneForegroundAgentObservationByPaneKey?: AppState['paneForegroundAgentObservationByPaneKey']
 }
 
 type AgentActivityCache = {
@@ -61,6 +72,9 @@ type AgentActivityCache = {
   retainedAgentsByPaneKey: AppState['retainedAgentsByPaneKey']
   runtimeAgentOrchestrationByPaneKey: AppState['runtimeAgentOrchestrationByPaneKey'] | undefined
   paneForegroundAgentByPaneKey: AppState['paneForegroundAgentByPaneKey'] | undefined
+  paneForegroundAgentObservationByPaneKey:
+    | AppState['paneForegroundAgentObservationByPaneKey']
+    | undefined
   summaries: Map<string, WorktreeAgentActivitySummary>
 }
 
@@ -78,6 +92,7 @@ function getWorktreeAgentActivitySummaries(
 ): Map<string, WorktreeAgentActivitySummary> {
   const runtimeAgentOrchestrationByPaneKey = state.runtimeAgentOrchestrationByPaneKey
   const paneForegroundAgentByPaneKey = state.paneForegroundAgentByPaneKey
+  const paneForegroundAgentObservationByPaneKey = state.paneForegroundAgentObservationByPaneKey
   if (
     agentActivityCache &&
     agentActivityCache.tabsByWorktree === state.tabsByWorktree &&
@@ -85,7 +100,9 @@ function getWorktreeAgentActivitySummaries(
     agentActivityCache.migrationUnsupportedByPtyId === state.migrationUnsupportedByPtyId &&
     agentActivityCache.retainedAgentsByPaneKey === state.retainedAgentsByPaneKey &&
     agentActivityCache.runtimeAgentOrchestrationByPaneKey === runtimeAgentOrchestrationByPaneKey &&
-    agentActivityCache.paneForegroundAgentByPaneKey === paneForegroundAgentByPaneKey
+    agentActivityCache.paneForegroundAgentByPaneKey === paneForegroundAgentByPaneKey &&
+    agentActivityCache.paneForegroundAgentObservationByPaneKey ===
+      paneForegroundAgentObservationByPaneKey
   ) {
     return agentActivityCache.summaries
   }
@@ -111,7 +128,7 @@ function getWorktreeAgentActivitySummaries(
   }
 
   const now = Date.now()
-  for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey)) {
+  for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey ?? {})) {
     const paneIdentity = parseAgentStatusPaneIdentity(paneKey)
     if (!paneIdentity) {
       continue
@@ -160,8 +177,13 @@ function getWorktreeAgentActivitySummaries(
     const summary = summaryForWorktree(worktreeId)
     if (summary.paneForegroundAgentByPaneKey === EMPTY_PANE_FOREGROUND_AGENTS) {
       summary.paneForegroundAgentByPaneKey = {}
+      summary.paneForegroundAgentObservationByPaneKey = {}
     }
     summary.paneForegroundAgentByPaneKey[paneKey] = entry
+    const observation = paneForegroundAgentObservationByPaneKey?.[paneKey]
+    if (observation) {
+      summary.paneForegroundAgentObservationByPaneKey[paneKey] = observation
+    }
   }
 
   for (const retained of Object.values(state.retainedAgentsByPaneKey ?? {})) {
@@ -197,6 +219,7 @@ function getWorktreeAgentActivitySummaries(
     retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
     runtimeAgentOrchestrationByPaneKey,
     paneForegroundAgentByPaneKey,
+    paneForegroundAgentObservationByPaneKey,
     summaries
   }
   return summaries
@@ -220,68 +243,12 @@ function summariesEqual(
     paneForegroundAgentsEqual(
       previous.paneForegroundAgentByPaneKey,
       next.paneForegroundAgentByPaneKey
+    ) &&
+    paneForegroundAgentsEqual(
+      previous.paneForegroundAgentObservationByPaneKey,
+      next.paneForegroundAgentObservationByPaneKey
     )
   )
-}
-
-function paneForegroundAgentsEqual(
-  previous: Record<string, PaneForegroundAgentEntry>,
-  next: Record<string, PaneForegroundAgentEntry>
-): boolean {
-  if (previous === next) {
-    return true
-  }
-  const previousKeys = Object.keys(previous)
-  if (previousKeys.length !== Object.keys(next).length) {
-    return false
-  }
-  return previousKeys.every((paneKey) => previous[paneKey] === next[paneKey])
-}
-
-function agentStatusPaneIdsByTabIdEqual(
-  previous: Record<string, ReadonlySet<string>>,
-  next: Record<string, ReadonlySet<string>>
-): boolean {
-  if (previous === next) {
-    return true
-  }
-  const previousKeys = Object.keys(previous)
-  if (previousKeys.length !== Object.keys(next).length) {
-    return false
-  }
-  for (const tabId of previousKeys) {
-    const previousPaneIds = previous[tabId]
-    const nextPaneIds = next[tabId]
-    if (!nextPaneIds || previousPaneIds.size !== nextPaneIds.size) {
-      return false
-    }
-    for (const paneId of previousPaneIds) {
-      if (!nextPaneIds.has(paneId)) {
-        return false
-      }
-    }
-  }
-  return true
-}
-
-function applyLiveAgentState(
-  summary: WorktreeAgentActivitySummary,
-  entry: Pick<AgentStatusEntry, 'state' | 'workingMode' | 'interrupted'>
-): void {
-  if (entry.state === 'blocked' || entry.state === 'waiting') {
-    summary.hasPermission = true
-  } else if (entry.interrupted === true) {
-    // Interrupted is encoded as done, so it must be checked first.
-    summary.hasInterrupted = true
-  } else if (entry.state === 'working') {
-    if (entry.workingMode === 'monitoring') {
-      summary.hasLiveMonitoring = true
-    } else {
-      summary.hasLiveWorking = true
-    }
-  } else if (entry.state === 'done') {
-    summary.hasLiveDone = true
-  }
 }
 
 function addAgentStatusPaneId(

--- a/src/renderer/src/components/sidebar/worktree-agent-process-evidence.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-process-evidence.ts
@@ -1,0 +1,118 @@
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import { formatAgentTypeLabel } from '@/lib/agent-status'
+import {
+  resolveFreshPaneForegroundAgent,
+  type PaneForegroundAgentEntry
+} from '@/store/slices/pane-foreground-agent'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import { tabHasLivePty } from '@/lib/tab-has-live-pty'
+
+/** Identity-only observations need a distinct authority from title snapshots. */
+export const PROCESS_DERIVED_AGENT_ROW_AUTHORITY_ID = 'renderer-process-projection'
+
+export function freshProcessAgentForLeaf(args: {
+  tabId: string
+  leafId: string
+  layout: TerminalLayoutSnapshot | undefined
+  livePtyIds: readonly string[] | undefined
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry> | undefined
+  now: number
+}): TuiAgent | null {
+  if (!args.paneForegroundAgentByPaneKey || !isTerminalLeafId(args.leafId)) {
+    return null
+  }
+  return resolveFreshPaneForegroundAgent(
+    args.paneForegroundAgentByPaneKey[makePaneKey(args.tabId, args.leafId)],
+    {
+      now: args.now,
+      paneBoundPtyId: args.layout?.ptyIdsByLeafId?.[args.leafId],
+      liveTabPtyIds: args.livePtyIds
+    }
+  )
+}
+
+/** Append identity-only rows for fresh process observations that have no hook/title row. */
+export function appendProcessDerivedAgentRows(args: {
+  tabs: TerminalTab[]
+  ptyIdsByTabId: Record<string, string[]>
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry> | undefined
+  seenPaneKeys: Set<string>
+  rows: DashboardAgentRow[]
+  now: number
+}): void {
+  for (const [paneKey] of Object.entries(args.paneForegroundAgentByPaneKey ?? {})) {
+    if (args.seenPaneKeys.has(paneKey)) {
+      continue
+    }
+    const parsed = parsePaneKey(paneKey)
+    if (!parsed) {
+      continue
+    }
+    const tab = args.tabs.find((candidate) => candidate.id === parsed.tabId)
+    if (!tab || !tabHasLivePty(args.ptyIdsByTabId, tab.id)) {
+      continue
+    }
+    const processAgent = freshProcessAgentForLeaf({
+      tabId: tab.id,
+      leafId: parsed.leafId,
+      layout: args.terminalLayoutsByTabId[tab.id],
+      livePtyIds: args.ptyIdsByTabId[tab.id],
+      paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+      now: args.now
+    })
+    if (!processAgent) {
+      continue
+    }
+    args.rows.push(
+      buildProcessDerivedAgentRow({
+        tab,
+        leafId: parsed.leafId,
+        agent: processAgent,
+        now: args.now
+      })
+    )
+    args.seenPaneKeys.add(paneKey)
+  }
+}
+
+function buildProcessDerivedAgentRow(args: {
+  tab: TerminalTab
+  leafId: string
+  agent: TuiAgent
+  now: number
+}): DashboardAgentRow {
+  const paneKey = makePaneKey(args.tab.id, args.leafId)
+  const label = formatAgentTypeLabel(args.agent)
+  const entry: AgentStatusEntry = {
+    paneKey,
+    state: 'working',
+    prompt: label,
+    updatedAt: args.now,
+    stateStartedAt: args.now,
+    stateHistory: [],
+    agentType: args.agent,
+    terminalTitle: args.tab.title,
+    lastAssistantMessage: 'Idle',
+    observation: {
+      origin: 'process',
+      authorityId: PROCESS_DERIVED_AGENT_ROW_AUTHORITY_ID,
+      incarnation: 0,
+      revision: args.now,
+      observedAt: args.now,
+      kind: 'snapshot'
+    }
+  }
+  return {
+    paneKey,
+    entry,
+    tab: args.tab,
+    agentType: args.agent,
+    rowSource: 'live',
+    state: 'idle',
+    startedAt: args.now
+  }
+}

--- a/src/renderer/src/components/sidebar/worktree-agent-process-evidence.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-process-evidence.ts
@@ -2,7 +2,8 @@ import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { formatAgentTypeLabel } from '@/lib/agent-status'
 import {
   resolveFreshPaneForegroundAgent,
-  type PaneForegroundAgentEntry
+  type PaneForegroundAgentEntry,
+  type PaneForegroundAgentObservation
 } from '@/store/slices/pane-foreground-agent'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
@@ -19,6 +20,9 @@ export function freshProcessAgentForLeaf(args: {
   layout: TerminalLayoutSnapshot | undefined
   livePtyIds: readonly string[] | undefined
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry> | undefined
+  paneForegroundAgentObservationByPaneKey:
+    | Record<string, PaneForegroundAgentObservation>
+    | undefined
   now: number
 }): TuiAgent | null {
   if (!args.paneForegroundAgentByPaneKey || !isTerminalLeafId(args.leafId)) {
@@ -26,6 +30,7 @@ export function freshProcessAgentForLeaf(args: {
   }
   return resolveFreshPaneForegroundAgent(
     args.paneForegroundAgentByPaneKey[makePaneKey(args.tabId, args.leafId)],
+    args.paneForegroundAgentObservationByPaneKey?.[makePaneKey(args.tabId, args.leafId)],
     {
       now: args.now,
       paneBoundPtyId: args.layout?.ptyIdsByLeafId?.[args.leafId],
@@ -40,6 +45,9 @@ export function appendProcessDerivedAgentRows(args: {
   ptyIdsByTabId: Record<string, string[]>
   terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry> | undefined
+  paneForegroundAgentObservationByPaneKey:
+    | Record<string, PaneForegroundAgentObservation>
+    | undefined
   seenPaneKeys: Set<string>
   rows: DashboardAgentRow[]
   now: number
@@ -62,6 +70,7 @@ export function appendProcessDerivedAgentRows(args: {
       layout: args.terminalLayoutsByTabId[tab.id],
       livePtyIds: args.ptyIdsByTabId[tab.id],
       paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+      paneForegroundAgentObservationByPaneKey: args.paneForegroundAgentObservationByPaneKey,
       now: args.now
     })
     if (!processAgent) {

--- a/src/renderer/src/components/sidebar/worktree-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-rows.ts
@@ -26,7 +26,10 @@ import {
 } from './worktree-agent-row-fallback-tab'
 import { resolveRowAgentType } from './worktree-agent-row-type'
 import { entryWithRuntimeOrchestration } from './worktree-agent-row-orchestration'
-import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import type {
+  PaneForegroundAgentEntry,
+  PaneForegroundAgentObservation
+} from '@/store/slices/pane-foreground-agent'
 
 function countTerminalLayoutLeaves(node: TerminalPaneLayoutNode | null | undefined): number {
   if (!node) {
@@ -146,6 +149,7 @@ export function buildWorktreeAgentRows(args: {
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
   paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
+  paneForegroundAgentObservationByPaneKey?: Record<string, PaneForegroundAgentObservation>
   now: number
 }): DashboardAgentRow[] {
   const rows: DashboardAgentRow[] = []

--- a/src/renderer/src/components/sidebar/worktree-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-rows.ts
@@ -26,6 +26,7 @@ import {
 } from './worktree-agent-row-fallback-tab'
 import { resolveRowAgentType } from './worktree-agent-row-type'
 import { entryWithRuntimeOrchestration } from './worktree-agent-row-orchestration'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 function countTerminalLayoutLeaves(node: TerminalPaneLayoutNode | null | undefined): number {
   if (!node) {
@@ -144,10 +145,12 @@ export function buildWorktreeAgentRows(args: {
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
   now: number
 }): DashboardAgentRow[] {
   const rows: DashboardAgentRow[] = []
   const seenPaneKeys = new Set<string>()
+  const staleTerminalPaneKeys = new Set<string>()
   const currentTabIds = new Set(args.tabs.map((tab) => tab.id))
 
   const entriesByTabId = new Map<string, AgentStatusEntry[]>()
@@ -186,6 +189,9 @@ export function buildWorktreeAgentRows(args: {
       })
       rows.push(...buildSubagentChildRows({ parentEntry: rowEntry, tab, parentIsFresh: isFresh }))
       seenPaneKeys.add(rowEntry.paneKey)
+      if (!isFresh && rowEntry.state === 'done') {
+        staleTerminalPaneKeys.add(rowEntry.paneKey)
+      }
     }
   }
 
@@ -198,7 +204,30 @@ export function buildWorktreeAgentRows(args: {
     seenPaneKeys
   })
 
-  rows.push(...buildTitleDerivedAgentRows({ ...args, seenPaneKeys }))
+  // Terminal outcomes are retained as history, but must yield to a fresh
+  // title/process observation for the same pane (e.g. a stale `done` row while
+  // the agent is visibly working again). Keep the history row when no newer
+  // evidence exists.
+  const titleSeenPaneKeys = new Set(seenPaneKeys)
+  for (const paneKey of staleTerminalPaneKeys) {
+    titleSeenPaneKeys.delete(paneKey)
+  }
+  const titleRows = buildTitleDerivedAgentRows({ ...args, seenPaneKeys: titleSeenPaneKeys })
+  if (staleTerminalPaneKeys.size > 0 && titleRows.length > 0) {
+    const replacedPaneKeys = new Set(titleRows.map((row) => row.paneKey))
+    for (let index = rows.length - 1; index >= 0; index -= 1) {
+      if (
+        staleTerminalPaneKeys.has(rows[index].paneKey) &&
+        replacedPaneKeys.has(rows[index].paneKey)
+      ) {
+        rows.splice(index, 1)
+      }
+    }
+  }
+  rows.push(...titleRows)
+  for (const paneKey of titleSeenPaneKeys) {
+    seenPaneKeys.add(paneKey)
+  }
 
   // Why: orchestration workers can be attributed to a worktree by main before
   // their tab is present in this renderer. Keep those live rows visible in the

--- a/src/renderer/src/components/sidebar/worktree-agent-state-flags.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-state-flags.ts
@@ -1,0 +1,22 @@
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { WorktreeAgentActivitySummary } from './worktree-agent-activity-summary'
+
+export function applyLiveAgentState(
+  summary: WorktreeAgentActivitySummary,
+  entry: Pick<AgentStatusEntry, 'state' | 'workingMode' | 'interrupted'>
+): void {
+  if (entry.state === 'blocked' || entry.state === 'waiting') {
+    summary.hasPermission = true
+  } else if (entry.interrupted === true) {
+    // Interrupted is encoded as done, so it must be checked first.
+    summary.hasInterrupted = true
+  } else if (entry.state === 'working') {
+    if (entry.workingMode === 'monitoring') {
+      summary.hasLiveMonitoring = true
+    } else {
+      summary.hasLiveWorking = true
+    }
+  } else if (entry.state === 'done') {
+    summary.hasLiveDone = true
+  }
+}

--- a/src/renderer/src/components/sidebar/worktree-card-status-inputs.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-status-inputs.ts
@@ -1,5 +1,8 @@
 import type { AppState } from '@/store/types'
-import type { TerminalPaneLayoutNode } from '../../../../shared/terminal-tab-types'
+import type {
+  TerminalLayoutSnapshot,
+  TerminalPaneLayoutNode
+} from '../../../../shared/terminal-tab-types'
 
 // Why: these selectors return fresh maps whose top-level values preserve
 // underlying per-tab references, so callers must compare them shallowly.
@@ -47,6 +50,17 @@ export function selectTerminalLayoutRootsForWorktree(
   const out: Record<string, TerminalPaneLayoutNode | null | undefined> = {}
   for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
     out[tab.id] = state.terminalLayoutsByTabId[tab.id]?.root
+  }
+  return out
+}
+
+export function selectTerminalLayoutsForWorktree(
+  state: WorktreeCardLayoutRootInputState,
+  worktreeId: string
+): Record<string, TerminalLayoutSnapshot | undefined> {
+  const out: Record<string, TerminalLayoutSnapshot | undefined> = {}
+  for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
+    out[tab.id] = state.terminalLayoutsByTabId[tab.id]
   }
   return out
 }

--- a/src/renderer/src/components/sidebar/worktree-title-agent-type.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-agent-type.ts
@@ -1,11 +1,11 @@
 import {
   resolveCompatibleAgentTypeForOwner,
+  normalizeCompatibleAgentTitleForOwner,
   type CompatibleAgentOwnerOptions
 } from '../../../../shared/agent-title-owner'
 import type { AgentType } from '../../../../shared/agent-status-types'
 import { isClaudeIdentityFrameTitle } from '../../../../shared/terminal-title-agent-type'
 import { resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
-import { normalizeCompatibleAgentTitleForOwner } from '../../../../shared/agent-title-owner'
 
 const TITLE_AGENT_LABEL_TO_TYPE: Record<string, AgentType> = {
   'Claude Code': 'claude',

--- a/src/renderer/src/components/sidebar/worktree-title-agent-type.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-agent-type.ts
@@ -1,0 +1,70 @@
+import {
+  resolveCompatibleAgentTypeForOwner,
+  type CompatibleAgentOwnerOptions
+} from '../../../../shared/agent-title-owner'
+import type { AgentType } from '../../../../shared/agent-status-types'
+import { isClaudeIdentityFrameTitle } from '../../../../shared/terminal-title-agent-type'
+import { resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
+import { normalizeCompatibleAgentTitleForOwner } from '../../../../shared/agent-title-owner'
+
+const TITLE_AGENT_LABEL_TO_TYPE: Record<string, AgentType> = {
+  'Claude Code': 'claude',
+  OpenClaude: 'openclaude',
+  Codex: 'codex',
+  'Gemini CLI': 'gemini',
+  'GitHub Copilot': 'copilot',
+  Grok: 'grok',
+  Devin: 'devin',
+  Antigravity: 'antigravity',
+  OpenCode: 'opencode',
+  Aider: 'aider',
+  Cursor: 'cursor',
+  Droid: 'droid',
+  Hermes: 'hermes',
+  Pi: 'pi',
+  OMP: 'omp'
+}
+
+const CLAUDE_AGENT_TOKEN_RE = /(?<![\w./\\-])claude(?![\w./\\-])/i
+
+export function resolveTitleDerivedAgentType(
+  title: string,
+  label: string,
+  ownerAgentType?: AgentType | null,
+  processAgent?: AgentType | null
+): AgentType | null {
+  const agentType = TITLE_AGENT_LABEL_TO_TYPE[label] ?? 'unknown'
+  if (agentType !== 'claude') {
+    return agentType
+  }
+  // Claude's spinner has no provider identity; a process observation may
+  // supply it when the title itself is neutral.
+  if (!CLAUDE_AGENT_TOKEN_RE.test(title) && processAgent !== 'claude') {
+    return null
+  }
+  const owner = ownerAgentType && ownerAgentType !== 'unknown' ? ownerAgentType : null
+  if (owner && owner !== 'claude' && !isClaudeIdentityFrameTitle(title)) {
+    return null
+  }
+  return agentType
+}
+
+export function resolveAgentTypeFromTerminalTitle(
+  title: string | null | undefined,
+  ownerAgentType?: AgentType | null,
+  options?: CompatibleAgentOwnerOptions,
+  processAgent?: AgentType | null
+): AgentType | null {
+  if (!title) {
+    return null
+  }
+  const normalizedTitle = normalizeCompatibleAgentTitleForOwner(title, ownerAgentType, options)
+  const label = resolveTitleActivityLabel(normalizedTitle)
+  return label
+    ? (resolveCompatibleAgentTypeForOwner(
+        resolveTitleDerivedAgentType(normalizedTitle, label, ownerAgentType, processAgent),
+        ownerAgentType,
+        options
+      ) ?? null)
+    : null
+}

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -3,7 +3,10 @@ import { applyAgentRowLineage } from '@/components/dashboard/agent-row-lineage'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
-import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import type {
+  PaneForegroundAgentEntry,
+  PaneForegroundAgentObservation
+} from '@/store/slices/pane-foreground-agent'
 import { buildWorktreeAgentRows } from './worktree-agent-rows'
 
 const LEAF_ID_1 = '77777777-7777-4777-8777-777777777777'
@@ -49,10 +52,9 @@ describe('buildTitleDerivedAgentRows', () => {
     const paneKey = makePaneKey('tab-1', LEAF_ID_1)
     const foreground: PaneForegroundAgentEntry = {
       agent: 'claude',
-      shellForeground: false,
-      observedAt: 1_000,
-      ptyId: 'pty-claude'
+      shellForeground: false
     }
+    const observation: PaneForegroundAgentObservation = { observedAt: 1_000, ptyId: 'pty-claude' }
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { title: 'zsh' })],
       entries: [],
@@ -60,6 +62,7 @@ describe('buildTitleDerivedAgentRows', () => {
       ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
       terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
       paneForegroundAgentByPaneKey: { [paneKey]: foreground },
+      paneForegroundAgentObservationByPaneKey: { [paneKey]: observation },
       now: 1_000 + 1_000
     })
 
@@ -79,10 +82,11 @@ describe('buildTitleDerivedAgentRows', () => {
       paneForegroundAgentByPaneKey: {
         [paneKey]: {
           agent: 'claude',
-          shellForeground: false,
-          observedAt: 1_000,
-          ptyId: 'pty-old'
+          shellForeground: false
         }
+      },
+      paneForegroundAgentObservationByPaneKey: {
+        [paneKey]: { observedAt: 1_000, ptyId: 'pty-old' }
       },
       now: 2_000
     })
@@ -101,10 +105,11 @@ describe('buildTitleDerivedAgentRows', () => {
       paneForegroundAgentByPaneKey: {
         [paneKey]: {
           agent: 'claude',
-          shellForeground: false,
-          observedAt: 1_000,
-          ptyId: 'pty-claude'
+          shellForeground: false
         }
+      },
+      paneForegroundAgentObservationByPaneKey: {
+        [paneKey]: { observedAt: 1_000, ptyId: 'pty-claude' }
       },
       now: 31_001
     })

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -3,6 +3,7 @@ import { applyAgentRowLineage } from '@/components/dashboard/agent-row-lineage'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 import { buildWorktreeAgentRows } from './worktree-agent-rows'
 
 const LEAF_ID_1 = '77777777-7777-4777-8777-777777777777'
@@ -44,6 +45,73 @@ function makeSingleLayout(leafId: string): TerminalLayoutSnapshot {
 }
 
 describe('buildTitleDerivedAgentRows', () => {
+  it('adds an idle identity row for a fresh live process with no hook or title', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const foreground: PaneForegroundAgentEntry = {
+      agent: 'claude',
+      shellForeground: false,
+      observedAt: 1_000,
+      ptyId: 'pty-claude'
+    }
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'zsh' })],
+      entries: [],
+      retained: [],
+      ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      paneForegroundAgentByPaneKey: { [paneKey]: foreground },
+      now: 1_000 + 1_000
+    })
+
+    expect(rows.map((row) => [row.paneKey, row.agentType, row.state])).toEqual([
+      [paneKey, 'claude', 'idle']
+    ])
+  })
+
+  it('does not attribute process identity to a pane after its PTY is rebound', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'zsh' })],
+      entries: [],
+      retained: [],
+      ptyIdsByTabId: { 'tab-1': ['pty-new'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: {
+          agent: 'claude',
+          shellForeground: false,
+          observedAt: 1_000,
+          ptyId: 'pty-old'
+        }
+      },
+      now: 2_000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('expires process identity after the observation TTL', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'zsh' })],
+      entries: [],
+      retained: [],
+      ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: {
+          agent: 'claude',
+          shellForeground: false,
+          observedAt: 1_000,
+          ptyId: 'pty-claude'
+        }
+      },
+      now: 31_001
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
   it('adds title-derived rows for live agent panes that have no hook status yet', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1')],

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -3,6 +3,7 @@ import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-statu
 import { isCursorAgentTitle } from '../../../../shared/agent-title-core'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 import type {
   AgentStatusEntry,
   AgentStatusOrchestrationContext,
@@ -15,13 +16,19 @@ import type {
   TerminalPaneLayoutNode,
   TerminalTab
 } from '../../../../shared/terminal-tab-types'
-import {
-  normalizeCompatibleAgentTitleForOwner,
-  resolveCompatibleAgentTypeForOwner,
-  type CompatibleAgentOwnerOptions
-} from '../../../../shared/agent-title-owner'
+import { normalizeCompatibleAgentTitleForOwner } from '../../../../shared/agent-title-owner'
 import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
-import { isClaudeIdentityFrameTitle } from '../../../../shared/terminal-title-agent-type'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import {
+  appendProcessDerivedAgentRows,
+  freshProcessAgentForLeaf
+} from './worktree-agent-process-evidence'
+export { freshProcessAgentForLeaf } from './worktree-agent-process-evidence'
+export {
+  resolveAgentTypeFromTerminalTitle,
+  resolveTitleDerivedAgentType
+} from './worktree-title-agent-type'
+import { resolveTitleDerivedAgentType } from './worktree-title-agent-type'
 
 /** Fixed, not per-process: title rows are a pure projection of the current title, so they are
  *  comparable across restarts in a way a sequenced authority's rows are not. Ordering against
@@ -32,32 +39,13 @@ const EMPTY_RUNTIME_TITLES: Record<string, Record<number, string>> = {}
 const EMPTY_LIVE_PTY_IDS: Record<string, string[]> = {}
 const EMPTY_TERMINAL_LAYOUTS: Record<string, TerminalLayoutSnapshot | undefined> = {}
 
-const TITLE_AGENT_LABEL_TO_TYPE: Record<string, AgentType> = {
-  'Claude Code': 'claude',
-  OpenClaude: 'openclaude',
-  Codex: 'codex',
-  'Gemini CLI': 'gemini',
-  'GitHub Copilot': 'copilot',
-  Grok: 'grok',
-  Devin: 'devin',
-  Antigravity: 'antigravity',
-  OpenCode: 'opencode',
-  Aider: 'aider',
-  Cursor: 'cursor',
-  Droid: 'droid',
-  Hermes: 'hermes',
-  Pi: 'pi',
-  OMP: 'omp'
-}
-
-const CLAUDE_AGENT_TOKEN_RE = /(?<![\w./\\-])claude(?![\w./\\-])/i
-
 export function buildTitleDerivedAgentRows(args: {
   tabs: TerminalTab[]
   runtimePaneTitlesByTabId?: Record<string, Record<number, string>>
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
   seenPaneKeys: Set<string>
   now: number
 }): DashboardAgentRow[] {
@@ -94,7 +82,15 @@ export function buildTitleDerivedAgentRows(args: {
           title,
           ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
           now: args.now,
-          runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
+          runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey,
+          processAgent: freshProcessAgentForLeaf({
+            tabId: tab.id,
+            leafId,
+            layout,
+            livePtyIds: ptyIdsByTabId[tab.id],
+            paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+            now: args.now
+          })
         })
         if (!row || args.seenPaneKeys.has(row.paneKey)) {
           continue
@@ -115,7 +111,15 @@ export function buildTitleDerivedAgentRows(args: {
       title: tab.title,
       ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
       now: args.now,
-      runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
+      runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey,
+      processAgent: freshProcessAgentForLeaf({
+        tabId: tab.id,
+        leafId,
+        layout,
+        livePtyIds: ptyIdsByTabId[tab.id],
+        paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+        now: args.now
+      })
     })
     if (!row || args.seenPaneKeys.has(row.paneKey)) {
       continue
@@ -123,6 +127,16 @@ export function buildTitleDerivedAgentRows(args: {
     rows.push(row)
     args.seenPaneKeys.add(row.paneKey)
   }
+
+  appendProcessDerivedAgentRows({
+    tabs: args.tabs,
+    ptyIdsByTabId,
+    terminalLayoutsByTabId,
+    paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+    seenPaneKeys: args.seenPaneKeys,
+    rows,
+    now: args.now
+  })
 
   return rows
 }
@@ -138,6 +152,7 @@ function buildTitleDerivedAgentRow(args: {
   ownerAgentType: AgentType | null
   now: number
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  processAgent?: TuiAgent | null
 }): DashboardAgentRow | null {
   // Why launchAgent, not ownerAgentType: this only rewrites a title within its own identity
   // group (OMP wraps Pi and emits Pi frames), which stays correct in a split. Pane ownership
@@ -166,7 +181,7 @@ function buildTitleDerivedAgentRow(args: {
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
   const titleAgentType = isClaudeAgentsTitle
     ? 'claude'
-    : resolveTitleDerivedAgentType(title, label, args.ownerAgentType)
+    : resolveTitleDerivedAgentType(title, label, args.ownerAgentType, args.processAgent)
   // Why: a status frame proves activity, not identity, so the resolver drops it.
   // Hook-less agents over SSH (Codex, #8711; OpenCode's '. '/'* ' frames, #8940)
   // surface only decorated task titles; fall back to the pane's known owner instead
@@ -219,30 +234,6 @@ function buildTitleDerivedAgentRow(args: {
   }
 }
 
-export function resolveTitleDerivedAgentType(
-  title: string,
-  label: string,
-  ownerAgentType?: AgentType | null
-): AgentType | null {
-  const agentType = TITLE_AGENT_LABEL_TO_TYPE[label] ?? 'unknown'
-  if (agentType !== 'claude') {
-    return agentType
-  }
-  // Why: Claude's task-title spinner heuristic has no provider identity. In
-  // split panes it can match arbitrary terminal spinners, so sidebar rows only
-  // accept Claude when the title itself names Claude.
-  if (!CLAUDE_AGENT_TOKEN_RE.test(title)) {
-    return null
-  }
-  // Why: a "claude" word inside another agent's task text is a mention, not identity.
-  // Only a title that PRESENTS Claude may take a pane away from its known owner (#8940).
-  const owner = ownerAgentType && ownerAgentType !== 'unknown' ? ownerAgentType : null
-  if (owner && owner !== 'claude' && !isClaudeIdentityFrameTitle(title)) {
-    return null
-  }
-  return agentType
-}
-
 function resolveTitleDerivedPaneOwner(
   tab: TerminalTab,
   layout: TerminalLayoutSnapshot | undefined,
@@ -260,24 +251,6 @@ function resolveTitleDerivedPaneOwner(
  * Determines the agent type from a terminal title, normalising Pi-compatible
  * agents to their authoritative owner if specified.
  */
-export function resolveAgentTypeFromTerminalTitle(
-  title: string | null | undefined,
-  ownerAgentType?: AgentType | null,
-  options?: CompatibleAgentOwnerOptions
-): AgentType | null {
-  if (!title) {
-    return null
-  }
-  const normalizedTitle = normalizeCompatibleAgentTitleForOwner(title, ownerAgentType, options)
-  const label = resolveTitleActivityLabel(normalizedTitle)
-  return label
-    ? (resolveCompatibleAgentTypeForOwner(
-        resolveTitleDerivedAgentType(normalizedTitle, label, ownerAgentType),
-        ownerAgentType,
-        options
-      ) ?? null)
-    : null
-}
 
 function titleStatusToRowState(
   status: 'working' | 'permission' | 'idle'

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -3,7 +3,10 @@ import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-statu
 import { isCursorAgentTitle } from '../../../../shared/agent-title-core'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
-import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import type {
+  PaneForegroundAgentEntry,
+  PaneForegroundAgentObservation
+} from '@/store/slices/pane-foreground-agent'
 import type {
   AgentStatusEntry,
   AgentStatusOrchestrationContext,
@@ -46,6 +49,7 @@ export function buildTitleDerivedAgentRows(args: {
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
   paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
+  paneForegroundAgentObservationByPaneKey?: Record<string, PaneForegroundAgentObservation>
   seenPaneKeys: Set<string>
   now: number
 }): DashboardAgentRow[] {
@@ -89,6 +93,7 @@ export function buildTitleDerivedAgentRows(args: {
             layout,
             livePtyIds: ptyIdsByTabId[tab.id],
             paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+            paneForegroundAgentObservationByPaneKey: args.paneForegroundAgentObservationByPaneKey,
             now: args.now
           })
         })
@@ -118,6 +123,7 @@ export function buildTitleDerivedAgentRows(args: {
         layout,
         livePtyIds: ptyIdsByTabId[tab.id],
         paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+        paneForegroundAgentObservationByPaneKey: args.paneForegroundAgentObservationByPaneKey,
         now: args.now
       })
     })
@@ -133,6 +139,7 @@ export function buildTitleDerivedAgentRows(args: {
     ptyIdsByTabId,
     terminalLayoutsByTabId,
     paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+    paneForegroundAgentObservationByPaneKey: args.paneForegroundAgentObservationByPaneKey,
     seenPaneKeys: args.seenPaneKeys,
     rows,
     now: args.now

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -38,6 +38,8 @@ export type AgentCompletionCoordinatorOptions = {
     replacement: RecognizedAgentProcess
   ) => boolean
   shouldSuppressConfirmedProcessExitCompletion?: (exited: RecognizedAgentProcess) => boolean
+  /** Re-arm renderer process identity freshness when a cadence inspection sees an agent. */
+  onForegroundAgentInspected?: (process: RecognizedAgentProcess) => void
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean
   // Why: on hosts where one inspection forks a whole-process-table scan (local

--- a/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
@@ -77,6 +77,7 @@ export function createAgentCompletionProcessMonitor({
     state.consecutiveInspectionErrors = 0
     const recognized = recognizeAgentProcess(result.foregroundProcess)
     if (recognized) {
+      options.onForegroundAgentInspected?.(recognized)
       handleRecognizedProcess(recognized)
       return true
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-sampling.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-sampling.test.ts
@@ -272,10 +272,17 @@ describe('connectPanePty', () => {
       await advanceVisibleForegroundRead()
 
       expect(foregroundReadCallsFor(ptyId)).toEqual([[ptyId]])
-      expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(cacheKey, {
-        agent: 'codex',
-        shellForeground: false
-      })
+      expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(
+        cacheKey,
+        {
+          agent: 'codex',
+          shellForeground: false
+        },
+        {
+          observedAt: expect.any(Number),
+          ptyId
+        }
+      )
     })
 
     it('does not sample hidden restored PTYs', async () => {
@@ -758,10 +765,17 @@ describe('connectPanePty', () => {
 
       await advanceVisibleForegroundRead()
 
-      expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(cacheKey, {
-        agent: null,
-        shellForeground: true
-      })
+      expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(
+        cacheKey,
+        {
+          agent: null,
+          shellForeground: true
+        },
+        {
+          observedAt: expect.any(Number),
+          ptyId
+        }
+      )
       expect(foregroundReadCallsFor(ptyId)).toHaveLength(0)
     })
 
@@ -807,11 +821,18 @@ describe('connectPanePty', () => {
         agent: null,
         shellForeground: true
       })
-      expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(cacheKey, {
-        agent: 'droid',
-        routingTrusted: true,
-        shellForeground: false
-      })
+      expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(
+        cacheKey,
+        {
+          agent: 'droid',
+          routingTrusted: true,
+          shellForeground: false
+        },
+        {
+          observedAt: expect.any(Number),
+          ptyId
+        }
+      )
     })
 
     it('never probes the foreground for a visible remote/SSH restored pane', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection/pane-agent-identity.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pane-agent-identity.ts
@@ -15,7 +15,6 @@ import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { resolveCommittedTitleAgentType } from '@/lib/pane-agent-evidence'
 import type { TuiAgent } from '../../../../../shared/tui-agent'
 import { isTuiAgent, TUI_AGENT_CONFIG } from '../../../../../shared/tui-agent-config'
-import { createPaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
 
@@ -159,13 +158,10 @@ export function installPaneAgentIdentity(session: ConnectPanePtySession): void {
     // Bind observations to the PTY that was inspected; a pane key may survive
     // a rebind while the old process identity is still in the store.
     publish: (entry) =>
-      useAppStore.getState().setPaneForegroundAgent(
-        session.cacheKey,
-        createPaneForegroundAgentEntry(entry, {
-          observedAt: Date.now(),
-          ptyId: session.transport.getPtyId() ?? undefined
-        })
-      ),
+      useAppStore.getState().setPaneForegroundAgent(session.cacheKey, entry, {
+        observedAt: Date.now(),
+        ptyId: session.transport.getPtyId() ?? undefined
+      }),
     hasKnownAgentIdentity: session.paneHasKnownAgentIdentity,
     onConfirmedShellForeground: (reason) => {
       session.clearStaleAgentTabTitleOnConfirmedShell()
@@ -199,17 +195,11 @@ export function installPaneAgentIdentity(session: ConnectPanePtySession): void {
       if (foreground?.routingConfirmationPending !== true) {
         return
       }
-      useAppStore.getState().setPaneForegroundAgent(
-        session.cacheKey,
-        createPaneForegroundAgentEntry(
-          {
-            agent: foreground.agent,
-            routingRevoked: true,
-            shellForeground: foreground.shellForeground
-          },
-          { ptyId: session.transport.getPtyId() ?? undefined }
-        )
-      )
+      useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
+        agent: foreground.agent,
+        routingRevoked: true,
+        shellForeground: foreground.shellForeground
+      })
     }
   })
   // Why: one command-finished policy whether the signal arrives as bytes
@@ -303,33 +293,23 @@ export function installPaneAgentIdentity(session: ConnectPanePtySession): void {
     }
     // Why: cmd.exe and Git Bash have no OSC command boundaries. Keep the icon
     // as a hint, but revoke bytes until one current provider confirmation lands.
-    useAppStore
-      .getState()
-      .setPaneForegroundAgent(
-        session.cacheKey,
-        createPaneForegroundAgentEntry(
-          { agent: foreground.agent, routingRevoked: true, shellForeground: false },
-          { ptyId: session.transport.getPtyId() ?? undefined }
-        )
-      )
+    useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
+      agent: foreground.agent,
+      routingRevoked: true,
+      shellForeground: false
+    })
     session.visibleForegroundSamplePending = false
     session.visibleForegroundSampleSettled = false
     // Why: hook rows can suppress display-only sampling, but cannot restore
     // byte authority after this function explicitly revoked routing trust.
     session.sampleVisiblePaneForegroundAgent(true)
     if (session.paneForegroundAgentTracker.hasReadInFlight()) {
-      useAppStore.getState().setPaneForegroundAgent(
-        session.cacheKey,
-        createPaneForegroundAgentEntry(
-          {
-            agent: foreground.agent,
-            routingRevoked: true,
-            shellForeground: false,
-            routingConfirmationPending: true
-          },
-          { ptyId: session.transport.getPtyId() ?? undefined }
-        )
-      )
+      useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
+        agent: foreground.agent,
+        routingRevoked: true,
+        shellForeground: false,
+        routingConfirmationPending: true
+      })
     }
   }
   session.commandLifecycle = createTerminalCommandLifecycle({

--- a/src/renderer/src/components/terminal-pane/pty-connection/pane-agent-identity.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pane-agent-identity.ts
@@ -155,7 +155,14 @@ export function installPaneAgentIdentity(session: ConnectPanePtySession): void {
     isTrackablePtyId: session.isForegroundTrackingAllowed,
     readForegroundProcess: (id) => window.api.pty.getForegroundProcess(id),
     confirmForegroundProcess: (id) => window.api.pty.confirmForegroundProcess(id),
-    publish: (entry) => useAppStore.getState().setPaneForegroundAgent(session.cacheKey, entry),
+    // Bind observations to the PTY that was inspected; a pane key may survive
+    // a rebind while the old process identity is still in the store.
+    publish: (entry) =>
+      useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
+        ...entry,
+        observedAt: Date.now(),
+        ptyId: session.transport.getPtyId() ?? undefined
+      }),
     hasKnownAgentIdentity: session.paneHasKnownAgentIdentity,
     onConfirmedShellForeground: (reason) => {
       session.clearStaleAgentTabTitleOnConfirmedShell()
@@ -192,7 +199,8 @@ export function installPaneAgentIdentity(session: ConnectPanePtySession): void {
       useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
         agent: foreground.agent,
         routingRevoked: true,
-        shellForeground: foreground.shellForeground
+        shellForeground: foreground.shellForeground,
+        ptyId: session.transport.getPtyId() ?? undefined
       })
     }
   })
@@ -290,7 +298,8 @@ export function installPaneAgentIdentity(session: ConnectPanePtySession): void {
     useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
       agent: foreground.agent,
       routingRevoked: true,
-      shellForeground: false
+      shellForeground: false,
+      ptyId: session.transport.getPtyId() ?? undefined
     })
     session.visibleForegroundSamplePending = false
     session.visibleForegroundSampleSettled = false
@@ -302,7 +311,8 @@ export function installPaneAgentIdentity(session: ConnectPanePtySession): void {
         agent: foreground.agent,
         routingRevoked: true,
         shellForeground: false,
-        routingConfirmationPending: true
+        routingConfirmationPending: true,
+        ptyId: session.transport.getPtyId() ?? undefined
       })
     }
   }

--- a/src/renderer/src/components/terminal-pane/pty-connection/pane-agent-identity.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pane-agent-identity.ts
@@ -15,6 +15,7 @@ import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { resolveCommittedTitleAgentType } from '@/lib/pane-agent-evidence'
 import type { TuiAgent } from '../../../../../shared/tui-agent'
 import { isTuiAgent, TUI_AGENT_CONFIG } from '../../../../../shared/tui-agent-config'
+import { createPaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
 
@@ -158,11 +159,13 @@ export function installPaneAgentIdentity(session: ConnectPanePtySession): void {
     // Bind observations to the PTY that was inspected; a pane key may survive
     // a rebind while the old process identity is still in the store.
     publish: (entry) =>
-      useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
-        ...entry,
-        observedAt: Date.now(),
-        ptyId: session.transport.getPtyId() ?? undefined
-      }),
+      useAppStore.getState().setPaneForegroundAgent(
+        session.cacheKey,
+        createPaneForegroundAgentEntry(entry, {
+          observedAt: Date.now(),
+          ptyId: session.transport.getPtyId() ?? undefined
+        })
+      ),
     hasKnownAgentIdentity: session.paneHasKnownAgentIdentity,
     onConfirmedShellForeground: (reason) => {
       session.clearStaleAgentTabTitleOnConfirmedShell()
@@ -196,12 +199,17 @@ export function installPaneAgentIdentity(session: ConnectPanePtySession): void {
       if (foreground?.routingConfirmationPending !== true) {
         return
       }
-      useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
-        agent: foreground.agent,
-        routingRevoked: true,
-        shellForeground: foreground.shellForeground,
-        ptyId: session.transport.getPtyId() ?? undefined
-      })
+      useAppStore.getState().setPaneForegroundAgent(
+        session.cacheKey,
+        createPaneForegroundAgentEntry(
+          {
+            agent: foreground.agent,
+            routingRevoked: true,
+            shellForeground: foreground.shellForeground
+          },
+          { ptyId: session.transport.getPtyId() ?? undefined }
+        )
+      )
     }
   })
   // Why: one command-finished policy whether the signal arrives as bytes
@@ -295,25 +303,33 @@ export function installPaneAgentIdentity(session: ConnectPanePtySession): void {
     }
     // Why: cmd.exe and Git Bash have no OSC command boundaries. Keep the icon
     // as a hint, but revoke bytes until one current provider confirmation lands.
-    useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
-      agent: foreground.agent,
-      routingRevoked: true,
-      shellForeground: false,
-      ptyId: session.transport.getPtyId() ?? undefined
-    })
+    useAppStore
+      .getState()
+      .setPaneForegroundAgent(
+        session.cacheKey,
+        createPaneForegroundAgentEntry(
+          { agent: foreground.agent, routingRevoked: true, shellForeground: false },
+          { ptyId: session.transport.getPtyId() ?? undefined }
+        )
+      )
     session.visibleForegroundSamplePending = false
     session.visibleForegroundSampleSettled = false
     // Why: hook rows can suppress display-only sampling, but cannot restore
     // byte authority after this function explicitly revoked routing trust.
     session.sampleVisiblePaneForegroundAgent(true)
     if (session.paneForegroundAgentTracker.hasReadInFlight()) {
-      useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
-        agent: foreground.agent,
-        routingRevoked: true,
-        shellForeground: false,
-        routingConfirmationPending: true,
-        ptyId: session.transport.getPtyId() ?? undefined
-      })
+      useAppStore.getState().setPaneForegroundAgent(
+        session.cacheKey,
+        createPaneForegroundAgentEntry(
+          {
+            agent: foreground.agent,
+            routingRevoked: true,
+            shellForeground: false,
+            routingConfirmationPending: true
+          },
+          { ptyId: session.transport.getPtyId() ?? undefined }
+        )
+      )
     }
   }
   session.commandLifecycle = createTerminalCommandLifecycle({

--- a/src/renderer/src/components/terminal-pane/pty-connection/sleeping-record-access.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/sleeping-record-access.ts
@@ -18,7 +18,6 @@ import {
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
 
 import { installCommandInferredPaneAgent } from './command-inferred-pane-agent'
-import { createPaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 export function installSleepingRecordAccess(session: ConnectPanePtySession): void {
   session.getSleepingRecordForPane = (
@@ -160,15 +159,10 @@ export function installSleepingRecordAccess(session: ConnectPanePtySession): voi
       if (metadata?.launchAgent) {
         // Why: daemon launch identity can outlive the process while Orca is
         // closed. Use it to request confirmation, never as current byte authority.
-        useAppStore
-          .getState()
-          .setPaneForegroundAgent(
-            session.cacheKey,
-            createPaneForegroundAgentEntry(
-              { agent: metadata.launchAgent, shellForeground: false },
-              { ptyId: session.transport.getPtyId() ?? undefined }
-            )
-          )
+        useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
+          agent: metadata.launchAgent,
+          shellForeground: false
+        })
       }
       return
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection/sleeping-record-access.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/sleeping-record-access.ts
@@ -161,7 +161,8 @@ export function installSleepingRecordAccess(session: ConnectPanePtySession): voi
         // closed. Use it to request confirmation, never as current byte authority.
         useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
           agent: metadata.launchAgent,
-          shellForeground: false
+          shellForeground: false,
+          ptyId: session.transport.getPtyId() ?? undefined
         })
       }
       return

--- a/src/renderer/src/components/terminal-pane/pty-connection/sleeping-record-access.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/sleeping-record-access.ts
@@ -18,6 +18,7 @@ import {
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
 
 import { installCommandInferredPaneAgent } from './command-inferred-pane-agent'
+import { createPaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 export function installSleepingRecordAccess(session: ConnectPanePtySession): void {
   session.getSleepingRecordForPane = (
@@ -159,11 +160,15 @@ export function installSleepingRecordAccess(session: ConnectPanePtySession): voi
       if (metadata?.launchAgent) {
         // Why: daemon launch identity can outlive the process while Orca is
         // closed. Use it to request confirmation, never as current byte authority.
-        useAppStore.getState().setPaneForegroundAgent(session.cacheKey, {
-          agent: metadata.launchAgent,
-          shellForeground: false,
-          ptyId: session.transport.getPtyId() ?? undefined
-        })
+        useAppStore
+          .getState()
+          .setPaneForegroundAgent(
+            session.cacheKey,
+            createPaneForegroundAgentEntry(
+              { agent: metadata.launchAgent, shellForeground: false },
+              { ptyId: session.transport.getPtyId() ?? undefined }
+            )
+          )
       }
       return
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
@@ -213,7 +213,7 @@ export function installTerminalKeydownFit(session: ConnectPanePtySession): void 
       }
       useAppStore
         .getState()
-        .refreshPaneForegroundAgentObservation(session.cacheKey, process.agent, inspectedPtyId)
+        .refreshPaneForegroundAgentObservation?.(session.cacheKey, process.agent, inspectedPtyId)
     },
     dispatchCompletion: (title, meta) => {
       if (meta?.source === 'process-exit') {

--- a/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
@@ -204,6 +204,17 @@ export function installTerminalKeydownFit(session: ConnectPanePtySession): void 
         currentAgentForExited !== exited.agent
       )
     },
+    onForegroundAgentInspected: (process) => {
+      const inspectedPtyId = session.transport.getPtyId()
+      // Process identity is local-only evidence; never publish an SSH/WSL
+      // inspection into the renderer's pane identity cache.
+      if (!inspectedPtyId || !session.isForegroundTrackingAllowed(inspectedPtyId)) {
+        return
+      }
+      useAppStore
+        .getState()
+        .refreshPaneForegroundAgentObservation(session.cacheKey, process.agent, inspectedPtyId)
+    },
     dispatchCompletion: (title, meta) => {
       if (meta?.source === 'process-exit') {
         session.clearSuppressedTitleSideEffects()

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -158,10 +158,11 @@ describe('getWorktreeStatus', () => {
         paneForegroundAgentByPaneKey: {
           [makePaneKey('tab-1', LEAF_ID_1)]: {
             agent: 'claude',
-            shellForeground: false,
-            observedAt: 1_000,
-            ptyId: 'pty-old'
+            shellForeground: false
           }
+        },
+        paneForegroundAgentObservationByPaneKey: {
+          [makePaneKey('tab-1', LEAF_ID_1)]: { observedAt: 1_000, ptyId: 'pty-old' }
         },
         now: 2_000
       }

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { TerminalLayoutSnapshot } from '../../../shared/terminal-tab-types'
+import { makePaneKey } from '../../../shared/stable-pane-id'
 import { getWorktreeStatus, getWorktreeStatusLabel, resolveWorktreeStatus } from './worktree-status'
 
 const LEAF_ID_1 = '11111111-1111-4111-8111-111111111111'
@@ -137,6 +138,36 @@ describe('getWorktreeStatus', () => {
     )
 
     expect(status).toBe('working')
+  })
+
+  it('rejects a neutral spinner when process evidence belongs to a rebound PTY', () => {
+    const status = getWorktreeStatus(
+      [{ id: 'tab-1', title: '⠋ Review branch' }],
+      [],
+      { 'tab-1': ['pty-old', 'pty-new'] },
+      {},
+      {
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            root: { type: 'leaf', leafId: LEAF_ID_1 },
+            activeLeafId: LEAF_ID_1,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [LEAF_ID_1]: 'pty-new' }
+          }
+        },
+        paneForegroundAgentByPaneKey: {
+          [makePaneKey('tab-1', LEAF_ID_1)]: {
+            agent: 'claude',
+            shellForeground: false,
+            observedAt: 1_000,
+            ptyId: 'pty-old'
+          }
+        },
+        now: 2_000
+      }
+    )
+
+    expect(status).toBe('active')
   })
 })
 

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -1,8 +1,12 @@
-import { resolveAgentTypeFromTerminalTitle } from '@/components/sidebar/worktree-title-derived-agent-rows'
+import {
+  freshProcessAgentForLeaf,
+  resolveAgentTypeFromTerminalTitle
+} from '@/components/sidebar/worktree-title-derived-agent-rows'
 import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { resolveRuntimePaneTitleLeafIdFromRoot } from '@/lib/runtime-pane-title-leaf-id'
 import { containsAgentSpinnerGlyph } from '../../../shared/agent-title-core'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
@@ -25,6 +29,8 @@ type WorktreeStatusHeuristicOptions = {
   agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   terminalLayoutRootsByTabId?: Record<string, TerminalPaneLayoutNode | null | undefined>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
+  now?: number
 }
 
 const STATUS_LABELS: Record<WorktreeStatus, string> = {
@@ -49,7 +55,9 @@ export function getWorktreeStatus(
 
   // Why: tab.title tracks only the most-recently-focused pane (onActivePaneChange in use-terminal-pane-lifecycle.ts); consult per-pane titles so the spinner reflects aggregate tab state.
   const hasStatus = (status: 'permission' | 'working'): boolean =>
-    liveTabs.some((tab) => tabHasStatus(tab, runtimePaneTitlesByTabId, status, options))
+    liveTabs.some((tab) =>
+      tabHasStatus(tab, runtimePaneTitlesByTabId, status, options, ptyIdsByTabId)
+    )
 
   if (options.liveAgentStatus === 'permission' || hasStatus('permission')) {
     return 'permission'
@@ -71,9 +79,21 @@ function tabHasStatus(
   tab: Pick<TerminalTab, 'id' | 'title' | 'launchAgent'>,
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>,
   status: 'permission' | 'working',
-  options: WorktreeStatusHeuristicOptions
+  options: WorktreeStatusHeuristicOptions,
+  ptyIdsByTabId: Record<string, string[]>
 ): boolean {
   const agentStatusPaneIds = options.agentStatusPaneIdsByTabId?.[tab.id]
+  const processAgentForLeaf = (leafId: string | null): TuiAgent | null =>
+    leafId === null
+      ? null
+      : freshProcessAgentForLeaf({
+          tabId: tab.id,
+          leafId,
+          layout: options.terminalLayoutsByTabId?.[tab.id],
+          livePtyIds: ptyIdsByTabId[tab.id],
+          paneForegroundAgentByPaneKey: options.paneForegroundAgentByPaneKey,
+          now: options.now ?? Date.now()
+        })
   const paneTitles = runtimePaneTitlesByTabId[tab.id]
   if (paneTitles && Object.keys(paneTitles).length > 0) {
     const tabLayoutRoot =
@@ -93,7 +113,7 @@ function tabHasStatus(
       }
       if (
         classifyTitleActivity(title) === status &&
-        titleStatusIsAgentAttributable(title, tab.launchAgent)
+        titleStatusIsAgentAttributable(title, processAgentForLeaf(leafId), tab.launchAgent)
       ) {
         return true
       }
@@ -106,13 +126,29 @@ function tabHasStatus(
   }
   return (
     classifyTitleActivity(tab.title) === status &&
-    titleStatusIsAgentAttributable(tab.title, tab.launchAgent)
+    // A tab title can borrow process identity only when the layout proves it
+    // contains one pane; split tabs must not brand a sibling.
+    titleStatusIsAgentAttributable(
+      tab.title,
+      processAgentForLeaf(resolveSoleLeafId(tab.id, options)),
+      tab.launchAgent
+    )
   )
 }
 
+function resolveSoleLeafId(tabId: string, options: WorktreeStatusHeuristicOptions): string | null {
+  const root =
+    options.terminalLayoutRootsByTabId?.[tabId] ?? options.terminalLayoutsByTabId?.[tabId]?.root
+  return root?.type === 'leaf' ? root.leafId : null
+}
+
 // Why: require agent attribution so a bare never-cleared spinner title can't spin the dot "0 agents" forever with no matching sidebar row.
-function titleStatusIsAgentAttributable(title: string, launchAgent?: TuiAgent | null): boolean {
-  if (resolveAgentTypeFromTerminalTitle(title) !== null) {
+function titleStatusIsAgentAttributable(
+  title: string,
+  processAgent?: TuiAgent | null,
+  launchAgent?: TuiAgent | null
+): boolean {
+  if (resolveAgentTypeFromTerminalTitle(title, undefined, undefined, processAgent) !== null) {
     return true
   }
   // Why: a spinner proves activity but not identity (Claude's thinking title has no provider
@@ -141,6 +177,8 @@ export function resolveWorktreeStatus(args: {
   agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   terminalLayoutRootsByTabId?: Record<string, TerminalPaneLayoutNode | null | undefined>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
+  now?: number
   hasPermission: boolean
   hasLiveWorking: boolean
   hasLiveMonitoring?: boolean
@@ -156,7 +194,9 @@ export function resolveWorktreeStatus(args: {
     {
       agentStatusPaneIdsByTabId: args.agentStatusPaneIdsByTabId,
       terminalLayoutsByTabId: args.terminalLayoutsByTabId,
-      terminalLayoutRootsByTabId: args.terminalLayoutRootsByTabId
+      terminalLayoutRootsByTabId: args.terminalLayoutRootsByTabId,
+      paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+      now: args.now
     }
   )
   if (args.hasPermission) {

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -6,7 +6,10 @@ import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { resolveRuntimePaneTitleLeafIdFromRoot } from '@/lib/runtime-pane-title-leaf-id'
 import { containsAgentSpinnerGlyph } from '../../../shared/agent-title-core'
-import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import type {
+  PaneForegroundAgentEntry,
+  PaneForegroundAgentObservation
+} from '@/store/slices/pane-foreground-agent'
 import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
@@ -30,6 +33,7 @@ type WorktreeStatusHeuristicOptions = {
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   terminalLayoutRootsByTabId?: Record<string, TerminalPaneLayoutNode | null | undefined>
   paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
+  paneForegroundAgentObservationByPaneKey?: Record<string, PaneForegroundAgentObservation>
   now?: number
 }
 
@@ -92,6 +96,7 @@ function tabHasStatus(
           layout: options.terminalLayoutsByTabId?.[tab.id],
           livePtyIds: ptyIdsByTabId[tab.id],
           paneForegroundAgentByPaneKey: options.paneForegroundAgentByPaneKey,
+          paneForegroundAgentObservationByPaneKey: options.paneForegroundAgentObservationByPaneKey,
           now: options.now ?? Date.now()
         })
   const paneTitles = runtimePaneTitlesByTabId[tab.id]
@@ -178,6 +183,7 @@ export function resolveWorktreeStatus(args: {
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   terminalLayoutRootsByTabId?: Record<string, TerminalPaneLayoutNode | null | undefined>
   paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
+  paneForegroundAgentObservationByPaneKey?: Record<string, PaneForegroundAgentObservation>
   now?: number
   hasPermission: boolean
   hasLiveWorking: boolean
@@ -196,6 +202,7 @@ export function resolveWorktreeStatus(args: {
       terminalLayoutsByTabId: args.terminalLayoutsByTabId,
       terminalLayoutRootsByTabId: args.terminalLayoutRootsByTabId,
       paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+      paneForegroundAgentObservationByPaneKey: args.paneForegroundAgentObservationByPaneKey,
       now: args.now
     }
   )

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -286,6 +286,7 @@ export type WebSessionTabsSyncState = Pick<
       | 'automaticAgentResumeClaimsByTabId'
       | 'migrationUnsupportedByPtyId'
       | 'paneForegroundAgentByPaneKey'
+      | 'paneForegroundAgentObservationByPaneKey'
       | 'pendingStartupByTabId'
       | 'recentlyClosedAgentStatusTabIds'
       | 'recentlyRetiredAgentStatusPaneKeys'
@@ -1400,6 +1401,7 @@ function buildRetractedMirroredTabSweepPatch(
     agentStatusEpoch: agentStatusPatch?.agentStatusEpoch ?? state.agentStatusEpoch,
     migrationUnsupportedByPtyId: state.migrationUnsupportedByPtyId ?? {},
     paneForegroundAgentByPaneKey: state.paneForegroundAgentByPaneKey ?? {},
+    paneForegroundAgentObservationByPaneKey: state.paneForegroundAgentObservationByPaneKey ?? {},
     recentlyClosedAgentStatusTabIds: state.recentlyClosedAgentStatusTabIds ?? {},
     recentlyRetiredAgentStatusPaneKeys: state.recentlyRetiredAgentStatusPaneKeys ?? {},
     retainedAgentsByPaneKey: state.retainedAgentsByPaneKey ?? {},

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1675,6 +1675,10 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             s.paneForegroundAgentByPaneKey,
             retiredPaneKeySet
           ),
+          paneForegroundAgentObservationByPaneKey: removePaneKeys(
+            s.paneForegroundAgentObservationByPaneKey,
+            retiredPaneKeySet
+          ),
           unreadTerminalPanes: removePaneKeys(s.unreadTerminalPanes, retiredPaneKeySet),
           unreadAgentCompletionPanes: removePaneKeys(
             s.unreadAgentCompletionPanes,
@@ -1800,6 +1804,11 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         ),
         acknowledgedAgentsByPaneKey: movePaneKeyedRecord(s.acknowledgedAgentsByPaneKey, from, to),
         paneForegroundAgentByPaneKey: movePaneKeyedRecord(s.paneForegroundAgentByPaneKey, from, to),
+        paneForegroundAgentObservationByPaneKey: movePaneKeyedRecord(
+          s.paneForegroundAgentObservationByPaneKey,
+          from,
+          to
+        ),
         unreadTerminalPanes: movePaneKeyedRecord(s.unreadTerminalPanes, from, to),
         unreadAgentCompletionPanes: movePaneKeyedRecord(s.unreadAgentCompletionPanes, from, to),
         lastTerminalInputAtByPaneKey: movePaneKeyedRecord(s.lastTerminalInputAtByPaneKey, from, to),

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -16,6 +16,22 @@ function terminalTab(id: string, worktreeId: string): TerminalTab {
 }
 
 describe('pane foreground agent slice', () => {
+  it('keeps process freshness metadata out of the public identity shape', () => {
+    const store = createTestStore()
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'codex',
+      shellForeground: false,
+      observedAt: 1_000,
+      ptyId: 'pty-1'
+    })
+
+    const entry = store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']
+    expect(entry).toMatchObject({ agent: 'codex', shellForeground: false })
+    expect(entry?.observedAt).toBe(1_000)
+    expect(entry?.ptyId).toBe('pty-1')
+    expect(Object.keys(entry ?? {})).toEqual(['agent', 'shellForeground'])
+  })
+
   it('sets, value-bails, and clears entries per pane key', () => {
     const store = createTestStore()
     store

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -16,20 +16,27 @@ function terminalTab(id: string, worktreeId: string): TerminalTab {
 }
 
 describe('pane foreground agent slice', () => {
-  it('keeps process freshness metadata out of the public identity shape', () => {
+  it('keeps process freshness metadata in an explicit observation map', () => {
     const store = createTestStore()
-    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
-      agent: 'codex',
-      shellForeground: false,
-      observedAt: 1_000,
-      ptyId: 'pty-1'
-    })
+    store.getState().setPaneForegroundAgent(
+      'tab-1:leaf-1',
+      {
+        agent: 'codex',
+        shellForeground: false
+      },
+      {
+        observedAt: 1_000,
+        ptyId: 'pty-1'
+      }
+    )
 
     const entry = store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']
     expect(entry).toMatchObject({ agent: 'codex', shellForeground: false })
-    expect(entry?.observedAt).toBe(1_000)
-    expect(entry?.ptyId).toBe('pty-1')
     expect(Object.keys(entry ?? {})).toEqual(['agent', 'shellForeground'])
+    expect(store.getState().paneForegroundAgentObservationByPaneKey['tab-1:leaf-1']).toEqual({
+      observedAt: 1_000,
+      ptyId: 'pty-1'
+    })
   })
 
   it('sets, value-bails, and clears entries per pane key', () => {

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -2,6 +2,11 @@ import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 
+// Process identity is attribution evidence, not a permanent status row. Keep
+// it fresh enough for sidebar projections while bounded when observations stop.
+export const PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS = 30_000
+const OBSERVATION_REFRESH_QUANTUM_MS = 5_000
+
 export type PaneForegroundAgentEntry = {
   /** Recognized agent process in the pane's foreground; null when unknown. */
   agent: TuiAgent | null
@@ -16,6 +21,10 @@ export type PaneForegroundAgentEntry = {
   /** True once the foreground is proven back at the shell (OSC 133;D) —
    *  process-grade launched-agent exit evidence, independent of titles. */
   shellForeground: boolean
+  /** Main-clock timestamp for the process observation. */
+  observedAt?: number
+  /** PTY from which the process observation was read. */
+  ptyId?: string
 }
 
 /**
@@ -26,6 +35,7 @@ export type PaneForegroundAgentEntry = {
 export type PaneForegroundAgentSlice = {
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
   setPaneForegroundAgent: (paneKey: string, entry: PaneForegroundAgentEntry) => void
+  refreshPaneForegroundAgentObservation: (paneKey: string, agent: TuiAgent, ptyId?: string) => void
   clearPaneForegroundAgent: (paneKey: string) => void
   /** Wholesale teardown sweeps (tab close, worktree sleep/remove) retire pane
    *  keys without per-pane close events — clear their entries too. */
@@ -49,12 +59,74 @@ export const createPaneForegroundAgentSlice: StateCreator<
         current.routingTrusted === entry.routingTrusted &&
         current.routingRevoked === entry.routingRevoked &&
         current.routingConfirmationPending === entry.routingConfirmationPending &&
-        current.shellForeground === entry.shellForeground
+        current.shellForeground === entry.shellForeground &&
+        current.ptyId === entry.ptyId
       ) {
-        return s
+        // Test/legacy callers may provide identity-only entries. Preserve the
+        // value-bail semantics for those records; only observed process
+        // evidence opts into the bounded freshness clock.
+        if (current.observedAt === undefined && entry.observedAt === undefined) {
+          return s
+        }
+        const now = Date.now()
+        if (
+          current.observedAt !== undefined &&
+          now - current.observedAt < OBSERVATION_REFRESH_QUANTUM_MS
+        ) {
+          return s
+        }
+        return {
+          paneForegroundAgentByPaneKey: {
+            ...s.paneForegroundAgentByPaneKey,
+            [paneKey]: { ...current, observedAt: now }
+          }
+        }
       }
       return {
-        paneForegroundAgentByPaneKey: { ...s.paneForegroundAgentByPaneKey, [paneKey]: entry }
+        paneForegroundAgentByPaneKey: {
+          ...s.paneForegroundAgentByPaneKey,
+          [paneKey]: entry
+        }
+      }
+    })
+  },
+  refreshPaneForegroundAgentObservation: (paneKey, agent, ptyId) => {
+    set((s) => {
+      const now = Date.now()
+      const current = s.paneForegroundAgentByPaneKey[paneKey]
+      if (current) {
+        if (current.agent !== agent) {
+          return {
+            paneForegroundAgentByPaneKey: {
+              ...s.paneForegroundAgentByPaneKey,
+              [paneKey]: {
+                agent,
+                shellForeground: false,
+                observedAt: now,
+                ptyId: ptyId ?? current.ptyId
+              }
+            }
+          }
+        }
+        if (
+          current.observedAt !== undefined &&
+          now - current.observedAt < OBSERVATION_REFRESH_QUANTUM_MS
+        ) {
+          return s
+        }
+        return {
+          paneForegroundAgentByPaneKey: {
+            ...s.paneForegroundAgentByPaneKey,
+            [paneKey]: { ...current, observedAt: now }
+          }
+        }
+      }
+      // Coordinator inspection proves identity but not input-routing authority.
+      return {
+        paneForegroundAgentByPaneKey: {
+          ...s.paneForegroundAgentByPaneKey,
+          [paneKey]: { agent, shellForeground: false, observedAt: now }
+        }
       }
     })
   },
@@ -88,6 +160,26 @@ export const createPaneForegroundAgentSlice: StateCreator<
     })
   }
 })
+
+/** Return process identity only while the evidence and its PTY are current. */
+export function resolveFreshPaneForegroundAgent(
+  entry: PaneForegroundAgentEntry | undefined,
+  args: { now: number; paneBoundPtyId?: string; liveTabPtyIds?: readonly string[] }
+): TuiAgent | null {
+  if (!entry?.agent || entry.shellForeground || entry.observedAt === undefined) {
+    return null
+  }
+  if (args.now - entry.observedAt > PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS) {
+    return null
+  }
+  if (args.paneBoundPtyId !== undefined) {
+    return entry.ptyId === undefined || entry.ptyId === args.paneBoundPtyId ? entry.agent : null
+  }
+  if (entry.ptyId !== undefined) {
+    return args.liveTabPtyIds?.includes(entry.ptyId) === true ? entry.agent : null
+  }
+  return (args.liveTabPtyIds?.length ?? 0) > 0 ? entry.agent : null
+}
 
 export function buildPaneForegroundAgentTabPrefixClearPatch(
   entries: Record<string, PaneForegroundAgentEntry>,

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -27,6 +27,29 @@ export type PaneForegroundAgentEntry = {
   ptyId?: string
 }
 
+/** Keep freshness metadata out of the long-standing identity record shape. */
+export function createPaneForegroundAgentEntry(
+  entry: PaneForegroundAgentEntry,
+  metadata: Pick<PaneForegroundAgentEntry, 'observedAt' | 'ptyId'> = entry
+): PaneForegroundAgentEntry {
+  const { observedAt: _ignoredObservedAt, ptyId: _ignoredPtyId, ...publicEntry } = entry
+  Object.defineProperties(publicEntry, {
+    observedAt: {
+      configurable: true,
+      enumerable: false,
+      value: metadata.observedAt,
+      writable: true
+    },
+    ptyId: {
+      configurable: true,
+      enumerable: false,
+      value: metadata.ptyId,
+      writable: true
+    }
+  })
+  return publicEntry
+}
+
 /**
  * Process-table identity for local panes, read at OSC 133 command boundaries
  * (see pane-foreground-agent-tracker). Sits below hook rows in the tab-icon
@@ -52,20 +75,21 @@ export const createPaneForegroundAgentSlice: StateCreator<
   paneForegroundAgentByPaneKey: {},
   setPaneForegroundAgent: (paneKey, entry) => {
     set((s) => {
+      const normalizedEntry = createPaneForegroundAgentEntry(entry)
       const current = s.paneForegroundAgentByPaneKey[paneKey]
       if (
         current &&
-        current.agent === entry.agent &&
-        current.routingTrusted === entry.routingTrusted &&
-        current.routingRevoked === entry.routingRevoked &&
-        current.routingConfirmationPending === entry.routingConfirmationPending &&
-        current.shellForeground === entry.shellForeground &&
-        current.ptyId === entry.ptyId
+        current.agent === normalizedEntry.agent &&
+        current.routingTrusted === normalizedEntry.routingTrusted &&
+        current.routingRevoked === normalizedEntry.routingRevoked &&
+        current.routingConfirmationPending === normalizedEntry.routingConfirmationPending &&
+        current.shellForeground === normalizedEntry.shellForeground &&
+        current.ptyId === normalizedEntry.ptyId
       ) {
         // Test/legacy callers may provide identity-only entries. Preserve the
         // value-bail semantics for those records; only observed process
         // evidence opts into the bounded freshness clock.
-        if (current.observedAt === undefined && entry.observedAt === undefined) {
+        if (normalizedEntry.observedAt === undefined) {
           return s
         }
         const now = Date.now()
@@ -78,14 +102,17 @@ export const createPaneForegroundAgentSlice: StateCreator<
         return {
           paneForegroundAgentByPaneKey: {
             ...s.paneForegroundAgentByPaneKey,
-            [paneKey]: { ...current, observedAt: now }
+            [paneKey]: createPaneForegroundAgentEntry(current, {
+              observedAt: now,
+              ptyId: current.ptyId
+            })
           }
         }
       }
       return {
         paneForegroundAgentByPaneKey: {
           ...s.paneForegroundAgentByPaneKey,
-          [paneKey]: entry
+          [paneKey]: normalizedEntry
         }
       }
     })
@@ -99,12 +126,10 @@ export const createPaneForegroundAgentSlice: StateCreator<
           return {
             paneForegroundAgentByPaneKey: {
               ...s.paneForegroundAgentByPaneKey,
-              [paneKey]: {
-                agent,
-                shellForeground: false,
-                observedAt: now,
-                ptyId: ptyId ?? current.ptyId
-              }
+              [paneKey]: createPaneForegroundAgentEntry(
+                { agent, shellForeground: false },
+                { observedAt: now, ptyId: ptyId ?? current.ptyId }
+              )
             }
           }
         }
@@ -117,7 +142,10 @@ export const createPaneForegroundAgentSlice: StateCreator<
         return {
           paneForegroundAgentByPaneKey: {
             ...s.paneForegroundAgentByPaneKey,
-            [paneKey]: { ...current, observedAt: now }
+            [paneKey]: createPaneForegroundAgentEntry(current, {
+              observedAt: now,
+              ptyId: ptyId ?? current.ptyId
+            })
           }
         }
       }
@@ -125,7 +153,10 @@ export const createPaneForegroundAgentSlice: StateCreator<
       return {
         paneForegroundAgentByPaneKey: {
           ...s.paneForegroundAgentByPaneKey,
-          [paneKey]: { agent, shellForeground: false, observedAt: now }
+          [paneKey]: createPaneForegroundAgentEntry(
+            { agent, shellForeground: false },
+            { observedAt: now, ptyId }
+          )
         }
       }
     })

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -21,33 +21,12 @@ export type PaneForegroundAgentEntry = {
   /** True once the foreground is proven back at the shell (OSC 133;D) —
    *  process-grade launched-agent exit evidence, independent of titles. */
   shellForeground: boolean
-  /** Main-clock timestamp for the process observation. */
-  observedAt?: number
-  /** PTY from which the process observation was read. */
-  ptyId?: string
 }
 
-/** Keep freshness metadata out of the long-standing identity record shape. */
-export function createPaneForegroundAgentEntry(
-  entry: PaneForegroundAgentEntry,
-  metadata: Pick<PaneForegroundAgentEntry, 'observedAt' | 'ptyId'> = entry
-): PaneForegroundAgentEntry {
-  const { observedAt: _ignoredObservedAt, ptyId: _ignoredPtyId, ...publicEntry } = entry
-  Object.defineProperties(publicEntry, {
-    observedAt: {
-      configurable: true,
-      enumerable: false,
-      value: metadata.observedAt,
-      writable: true
-    },
-    ptyId: {
-      configurable: true,
-      enumerable: false,
-      value: metadata.ptyId,
-      writable: true
-    }
-  })
-  return publicEntry
+/** PTY-bound, time-bounded process evidence kept separate from the public identity record. */
+export type PaneForegroundAgentObservation = {
+  observedAt: number
+  ptyId?: string
 }
 
 /**
@@ -57,7 +36,12 @@ export function createPaneForegroundAgentEntry(
  */
 export type PaneForegroundAgentSlice = {
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
-  setPaneForegroundAgent: (paneKey: string, entry: PaneForegroundAgentEntry) => void
+  paneForegroundAgentObservationByPaneKey: Record<string, PaneForegroundAgentObservation>
+  setPaneForegroundAgent: (
+    paneKey: string,
+    entry: PaneForegroundAgentEntry,
+    observation?: PaneForegroundAgentObservation
+  ) => void
   refreshPaneForegroundAgentObservation: (paneKey: string, agent: TuiAgent, ptyId?: string) => void
   clearPaneForegroundAgent: (paneKey: string) => void
   /** Wholesale teardown sweeps (tab close, worktree sleep/remove) retire pane
@@ -73,47 +57,54 @@ export const createPaneForegroundAgentSlice: StateCreator<
   PaneForegroundAgentSlice
 > = (set) => ({
   paneForegroundAgentByPaneKey: {},
-  setPaneForegroundAgent: (paneKey, entry) => {
+  paneForegroundAgentObservationByPaneKey: {},
+  setPaneForegroundAgent: (paneKey, entry, observation) => {
     set((s) => {
-      const normalizedEntry = createPaneForegroundAgentEntry(entry)
       const current = s.paneForegroundAgentByPaneKey[paneKey]
       if (
         current &&
-        current.agent === normalizedEntry.agent &&
-        current.routingTrusted === normalizedEntry.routingTrusted &&
-        current.routingRevoked === normalizedEntry.routingRevoked &&
-        current.routingConfirmationPending === normalizedEntry.routingConfirmationPending &&
-        current.shellForeground === normalizedEntry.shellForeground &&
-        current.ptyId === normalizedEntry.ptyId
+        current.agent === entry.agent &&
+        current.routingTrusted === entry.routingTrusted &&
+        current.routingRevoked === entry.routingRevoked &&
+        current.routingConfirmationPending === entry.routingConfirmationPending &&
+        current.shellForeground === entry.shellForeground
       ) {
-        // Test/legacy callers may provide identity-only entries. Preserve the
-        // value-bail semantics for those records; only observed process
-        // evidence opts into the bounded freshness clock.
-        if (normalizedEntry.observedAt === undefined) {
+        if (!observation) {
           return s
         }
         const now = Date.now()
+        const currentObservation = s.paneForegroundAgentObservationByPaneKey[paneKey]
         if (
-          current.observedAt !== undefined &&
-          now - current.observedAt < OBSERVATION_REFRESH_QUANTUM_MS
+          currentObservation &&
+          currentObservation.ptyId === observation.ptyId &&
+          now - currentObservation.observedAt < OBSERVATION_REFRESH_QUANTUM_MS
         ) {
           return s
         }
         return {
-          paneForegroundAgentByPaneKey: {
-            ...s.paneForegroundAgentByPaneKey,
-            [paneKey]: createPaneForegroundAgentEntry(current, {
-              observedAt: now,
-              ptyId: current.ptyId
-            })
+          paneForegroundAgentObservationByPaneKey: {
+            ...s.paneForegroundAgentObservationByPaneKey,
+            [paneKey]: { ...observation, observedAt: now }
           }
         }
+      }
+      const nextObservation = observation
+        ? { ...observation }
+        : entry.agent !== current?.agent || entry.shellForeground
+          ? undefined
+          : s.paneForegroundAgentObservationByPaneKey[paneKey]
+      const nextObservations = { ...s.paneForegroundAgentObservationByPaneKey }
+      if (nextObservation) {
+        nextObservations[paneKey] = nextObservation
+      } else {
+        delete nextObservations[paneKey]
       }
       return {
         paneForegroundAgentByPaneKey: {
           ...s.paneForegroundAgentByPaneKey,
-          [paneKey]: normalizedEntry
-        }
+          [paneKey]: entry
+        },
+        paneForegroundAgentObservationByPaneKey: nextObservations
       }
     })
   },
@@ -126,26 +117,25 @@ export const createPaneForegroundAgentSlice: StateCreator<
           return {
             paneForegroundAgentByPaneKey: {
               ...s.paneForegroundAgentByPaneKey,
-              [paneKey]: createPaneForegroundAgentEntry(
-                { agent, shellForeground: false },
-                { observedAt: now, ptyId: ptyId ?? current.ptyId }
-              )
+              [paneKey]: { agent, shellForeground: false }
+            },
+            paneForegroundAgentObservationByPaneKey: {
+              ...s.paneForegroundAgentObservationByPaneKey,
+              [paneKey]: { observedAt: now, ptyId }
             }
           }
         }
+        const currentObservation = s.paneForegroundAgentObservationByPaneKey[paneKey]
         if (
-          current.observedAt !== undefined &&
-          now - current.observedAt < OBSERVATION_REFRESH_QUANTUM_MS
+          currentObservation &&
+          now - currentObservation.observedAt < OBSERVATION_REFRESH_QUANTUM_MS
         ) {
           return s
         }
         return {
-          paneForegroundAgentByPaneKey: {
-            ...s.paneForegroundAgentByPaneKey,
-            [paneKey]: createPaneForegroundAgentEntry(current, {
-              observedAt: now,
-              ptyId: ptyId ?? current.ptyId
-            })
+          paneForegroundAgentObservationByPaneKey: {
+            ...s.paneForegroundAgentObservationByPaneKey,
+            [paneKey]: { observedAt: now, ptyId: ptyId ?? currentObservation?.ptyId }
           }
         }
       }
@@ -153,30 +143,41 @@ export const createPaneForegroundAgentSlice: StateCreator<
       return {
         paneForegroundAgentByPaneKey: {
           ...s.paneForegroundAgentByPaneKey,
-          [paneKey]: createPaneForegroundAgentEntry(
-            { agent, shellForeground: false },
-            { observedAt: now, ptyId }
-          )
+          [paneKey]: { agent, shellForeground: false }
+        },
+        paneForegroundAgentObservationByPaneKey: {
+          ...s.paneForegroundAgentObservationByPaneKey,
+          [paneKey]: { observedAt: now, ptyId }
         }
       }
     })
   },
   clearPaneForegroundAgent: (paneKey) => {
     set((s) => {
-      if (!(paneKey in s.paneForegroundAgentByPaneKey)) {
+      if (
+        !(paneKey in s.paneForegroundAgentByPaneKey) &&
+        !(paneKey in s.paneForegroundAgentObservationByPaneKey)
+      ) {
         return s
       }
       const next = { ...s.paneForegroundAgentByPaneKey }
       delete next[paneKey]
-      return { paneForegroundAgentByPaneKey: next }
+      const nextObservations = { ...s.paneForegroundAgentObservationByPaneKey }
+      delete nextObservations[paneKey]
+      return {
+        paneForegroundAgentByPaneKey: next,
+        paneForegroundAgentObservationByPaneKey: nextObservations
+      }
     })
   },
   clearPaneForegroundAgentByTabPrefix: (tabIdPrefix) => {
     set(
       (s) =>
-        buildPaneForegroundAgentTabPrefixClearPatch(s.paneForegroundAgentByPaneKey, [
-          `${tabIdPrefix}:`
-        ]) ?? s
+        buildPaneForegroundAgentTabPrefixClearPatch(
+          s.paneForegroundAgentByPaneKey,
+          s.paneForegroundAgentObservationByPaneKey,
+          [`${tabIdPrefix}:`]
+        ) ?? s
     )
   },
   clearPaneForegroundAgentByWorktree: (worktreeId) => {
@@ -186,7 +187,11 @@ export const createPaneForegroundAgentSlice: StateCreator<
     set((s) => {
       const prefixes = (s.tabsByWorktree[worktreeId] ?? []).map((tab) => `${tab.id}:`)
       return (
-        buildPaneForegroundAgentTabPrefixClearPatch(s.paneForegroundAgentByPaneKey, prefixes) ?? s
+        buildPaneForegroundAgentTabPrefixClearPatch(
+          s.paneForegroundAgentByPaneKey,
+          s.paneForegroundAgentObservationByPaneKey,
+          prefixes
+        ) ?? s
       )
     })
   }
@@ -195,39 +200,55 @@ export const createPaneForegroundAgentSlice: StateCreator<
 /** Return process identity only while the evidence and its PTY are current. */
 export function resolveFreshPaneForegroundAgent(
   entry: PaneForegroundAgentEntry | undefined,
+  observation: PaneForegroundAgentObservation | undefined,
   args: { now: number; paneBoundPtyId?: string; liveTabPtyIds?: readonly string[] }
 ): TuiAgent | null {
-  if (!entry?.agent || entry.shellForeground || entry.observedAt === undefined) {
+  if (!entry?.agent || entry.shellForeground || !observation) {
     return null
   }
-  if (args.now - entry.observedAt > PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS) {
+  if (args.now - observation.observedAt > PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS) {
     return null
   }
   if (args.paneBoundPtyId !== undefined) {
-    return entry.ptyId === undefined || entry.ptyId === args.paneBoundPtyId ? entry.agent : null
+    return observation.ptyId === undefined || observation.ptyId === args.paneBoundPtyId
+      ? entry.agent
+      : null
   }
-  if (entry.ptyId !== undefined) {
-    return args.liveTabPtyIds?.includes(entry.ptyId) === true ? entry.agent : null
+  if (observation.ptyId !== undefined) {
+    return args.liveTabPtyIds?.includes(observation.ptyId) === true ? entry.agent : null
   }
   return (args.liveTabPtyIds?.length ?? 0) > 0 ? entry.agent : null
 }
 
 export function buildPaneForegroundAgentTabPrefixClearPatch(
   entries: Record<string, PaneForegroundAgentEntry>,
+  observations: Record<string, PaneForegroundAgentObservation>,
   tabPrefixes: readonly string[]
-): Pick<PaneForegroundAgentSlice, 'paneForegroundAgentByPaneKey'> | null {
+): Pick<
+  PaneForegroundAgentSlice,
+  'paneForegroundAgentByPaneKey' | 'paneForegroundAgentObservationByPaneKey'
+> | null {
   if (tabPrefixes.length === 0) {
     return null
   }
-  const staleKeys = Object.keys(entries).filter((paneKey) =>
-    tabPrefixes.some((prefix) => paneKey.startsWith(prefix))
-  )
+  const staleKeys = [
+    ...new Set(
+      [...Object.keys(entries), ...Object.keys(observations)].filter((paneKey) =>
+        tabPrefixes.some((prefix) => paneKey.startsWith(prefix))
+      )
+    )
+  ]
   if (staleKeys.length === 0) {
     return null
   }
   const next = { ...entries }
+  const nextObservations = { ...observations }
   for (const paneKey of staleKeys) {
     delete next[paneKey]
+    delete nextObservations[paneKey]
   }
-  return { paneForegroundAgentByPaneKey: next }
+  return {
+    paneForegroundAgentByPaneKey: next,
+    paneForegroundAgentObservationByPaneKey: nextObservations
+  }
 }

--- a/src/renderer/src/store/slices/retired-terminal-tab-state-sweep.ts
+++ b/src/renderer/src/store/slices/retired-terminal-tab-state-sweep.ts
@@ -19,7 +19,7 @@ export type RetiredTerminalTabSweepActions = Pick<
 /** The state the sweep reduces over: the two store maps plus everything the
  *  agent-status drop reads. Narrow so a non-store caller can pass its own view. */
 export type RetiredTerminalTabSweepState = AgentStatusTabPrefixDropState &
-  Pick<AppState, 'paneForegroundAgentByPaneKey'>
+  Pick<AppState, 'paneForegroundAgentByPaneKey' | 'paneForegroundAgentObservationByPaneKey'>
 
 /**
  * The suppressor-aware store maps plus three module registries a retired terminal tab strands.
@@ -77,6 +77,7 @@ export function buildRetiredTerminalTabStateSweepPatch(
     )
     const foreground = buildPaneForegroundAgentTabPrefixClearPatch(
       swept.paneForegroundAgentByPaneKey,
+      swept.paneForegroundAgentObservationByPaneKey,
       [`${tabId}:`]
     )
     swept = { ...swept, ...patch, ...foreground }

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
@@ -104,6 +104,9 @@ export function buildWorktreePurgeState(
     agentLaunchConfigByPaneKey: omitByPaneKeyTabPrefix(s.agentLaunchConfigByPaneKey),
     acknowledgedAgentsByPaneKey: omitByPaneKeyTabPrefix(s.acknowledgedAgentsByPaneKey),
     paneForegroundAgentByPaneKey: omitByPaneKeyTabPrefix(s.paneForegroundAgentByPaneKey),
+    paneForegroundAgentObservationByPaneKey: omitByPaneKeyTabPrefix(
+      s.paneForegroundAgentObservationByPaneKey
+    ),
     sleepingAgentSessionsByPaneKey: omitByPaneKeyTabPrefix(s.sleepingAgentSessionsByPaneKey),
     unreadTerminalTabs: omitByTabId(s.unreadTerminalTabs),
     unreadTerminalPanes: omitByPaneKeyTabPrefix(s.unreadTerminalPanes),

--- a/src/shared/pane-agent-identity-inventory.test.ts
+++ b/src/shared/pane-agent-identity-inventory.test.ts
@@ -218,7 +218,7 @@ const INVENTORY: readonly InventoryGroup[] = [
     paths: [
       ['src/main/runtime/orca-runtime.ts', 3],
       ['src/renderer/src/components/sidebar/worktree-agent-row-type.ts', 2],
-      ['src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts', 2],
+      ['src/renderer/src/components/sidebar/worktree-title-agent-type.ts', 2],
       ['src/renderer/src/lib/tab-agent-from-signals.ts', 2],
       ['src/renderer/src/lib/use-tab-agent.ts', 2]
     ]


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​272 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​251 |
| Prod | 22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​717 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​159 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​558 |

<!-- /orca-pr-loc -->

## What this fixes, in plain English

Orca's sidebar tells you what each agent is doing. It learns that from "hooks" — little messages the
agent fires as it works ("I started", "I'm running a tool", "I'm done").

The problem: the sidebar was showing **the last message it accepted**, not what the agent is
*actually* doing right now. If the right message never arrived, the dot just froze — and it kept
looking confident while being wrong. Three ways that went wrong in the wild:

- You answered an agent's question, it went back to work, and the sidebar still said it was
  **waiting on you** — for 18 minutes, while the agent had been working for over an hour.
- An agent finished and sat idle, and the sidebar said it was still **working** — for 73 minutes.
- An agent was visibly working, and the sidebar said it was **done**.

The fix does two things. First, once an agent resumes after a question or an interruption, its
progress is allowed through again instead of being suppressed forever. Second, the sidebar now
double-checks against the actual running process: if a row says `done` but the process is plainly
working, the live evidence wins. Completion history is still kept when there's nothing newer to
replace it with.

Net effect: the dot follows the agent instead of getting stuck on the last thing it heard.

## Before / after

| You do this | Before | After |
| --- | --- | --- |
| Agent asks a question, you answer, it keeps working | Sidebar stays **"waiting"** indefinitely — until you start a brand-new turn | Returns to **"working"** once progress resumes |
| Agent finishes and goes idle | Can stay stuck on **"working"** (seen: 73 min) | Settles to the correct state |
| Agent is working, but an earlier turn ended | Can show **"done"** while it's visibly working | Live process evidence replaces the stale row |
| Agent genuinely finished | Shows **"done"** | Unchanged — completion history is kept |

**Still not fixed by this PR:** an agent the process monitor never samples (hidden or remote panes)
can still show no row at all. That needs a cross-host process inventory and is deliberately out of
scope — see "Evidence directions", direction 4.

## Mechanism

Agent status remains a hook-derived record. This change adds a bounded, PTY-bound process observation path in the renderer: process identity and observation freshness are stored in separate keyed maps, so the long-standing pane identity record remains enumerable and serializable while observations expire after 30 seconds or a PTY rebind. Fresh title/process evidence supersedes stale terminal outcomes, while terminal history remains when no newer evidence exists. The inherited same-prompt interrupted/done suppression remains bounded to the existing 15-second late-work window so resumed tool progress can publish `working`.

## Evidence directions

- **1 (waiting while working): fixed.** Same-prompt tool progress after `request_user_input`/interrupt is admitted after the bounded late-work window.
- **2 (working while idle): fixed in the renderer.** Existing freshness decay remains in place; process-only rows are identity-only `idle`, and stale process evidence expires after 30 seconds.
- **3 (done while working): fixed when fresh pane evidence is available.** A fresh title or PTY process observation replaces a stale `done`/`interrupted` row for that pane; terminal completion history is retained otherwise.
- **4 (live process with no row): partial only.** A row is synthesized when a pane has a fresh local PTY process observation, even with no hook/title. Agents never sampled by the existing process monitor (including unsampled hidden/remote panes) can still be rowless; a complete fix needs a separate cross-host process inventory and cadence design, intentionally out of scope.

## Renderer decay decision

The exclusions at `worktree-agent-rows.ts:237` and `worktree-agent-freshness-selector.ts:24` remain intentional. They apply to retained completion history and the live-state freshness clock; completion rows are replaced only by fresh same-pane title/process evidence, while adding terminal outcomes to the live freshness signature would create rerenders without changing retained-history semantics.

The status-dot path receives full per-tab layout snapshots and live PTY IDs, applying the same pane-bound PTY rebind fence as sidebar rows. Observations are moved and cleared with pane identity, including tab/worktree teardown, and are carried in an explicit store map rather than hidden properties that object spread or JSON serialization would discard.

## Verification

- Failing-first: reversing the inherited suppression bound made the Claude and Codex resurrection tests fail; restoring it made them pass. Disabling the process-row, stale-terminal-precedence, and status-dot PTY-fence paths made their focused tests fail, then pass with the change.
- Regression follow-up: the CI foreground-agent failures were coupled to this PR. The widened identity shape was removed in favor of the separate observation map, and the affiliate-list sidebar fixture now passes with the selector's missing optional maps handled safely.
- Focused status/process suites pass, including pane-foreground-agent routing, command cleanup, sampling, completion side effects, inventory, pane identity, sidebar/title rows, affiliate-list mode, and worktree status.
- `pnpm tc:node`, `pnpm tc:web`, changed-file `npx oxlint`, and changed-file `npx oxfmt --check` pass locally.
- The prior CI run had a pre-existing static-analysis max-lines failure and environment failures in unrelated Windows Cursor and SSH watcher tests; the new HEAD check is the source of truth and must complete before merge.

