### PR TITLE
fix(terminal): send a composing cursor chord once, not twice

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.test.ts
@@ -22,7 +22,7 @@ describe('createTerminalImeDeferredChordSender', () => {
     const send = vi.fn()
     const sender = createTerminalImeDeferredChordSender()
 
-    sender.defer(el, send)
+    sender.defer({ code: 'ArrowLeft', timeStamp: 101 }, el, send)
     expect(send).not.toHaveBeenCalled()
 
     el.dispatchEvent(new Event('compositionend'))
@@ -37,8 +37,8 @@ describe('createTerminalImeDeferredChordSender', () => {
     const second = vi.fn()
     const sender = createTerminalImeDeferredChordSender()
 
-    sender.defer(el, first)
-    sender.defer(el, second)
+    sender.defer({ code: 'ArrowLeft', timeStamp: 102 }, el, first)
+    sender.defer({ code: 'ArrowLeft', timeStamp: 103 }, el, second)
     sender.cancelPending()
 
     expect(removeEventListener).toHaveBeenCalledTimes(4)
@@ -55,7 +55,7 @@ describe('createTerminalImeDeferredChordSender', () => {
     const send = vi.fn()
     const sender = createTerminalImeDeferredChordSender()
 
-    sender.defer(el, send)
+    sender.defer({ code: 'ArrowLeft', timeStamp: 104 }, el, send)
     vi.advanceTimersByTime(TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS - 1)
     expect(send).not.toHaveBeenCalled()
 
@@ -70,12 +70,65 @@ describe('createTerminalImeDeferredChordSender', () => {
     const send = vi.fn()
     const sender = createTerminalImeDeferredChordSender()
 
-    sender.defer(el, send)
+    sender.defer({ code: 'ArrowLeft', timeStamp: 105 }, el, send)
     el.dispatchEvent(new Event('compositionend'))
     vi.advanceTimersByTime(0)
     sender.cancelPending()
     vi.runAllTimers()
 
     expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('absorbs the replay of a held chord exactly once (#17616)', () => {
+    // 2-Set Korean ends the composition on the chord and the platform replays that press
+    // unmarked. Chromium keeps the original timeStamp on a re-dispatch, so the replay is
+    // recognisable as the press it repeats — measured on stock macOS, both ArrowLeft keydowns
+    // of one Option+← over a preedit report the same timeStamp.
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const sender = createTerminalImeDeferredChordSender()
+    const chord = { code: 'ArrowLeft', timeStamp: 23884 }
+
+    sender.defer(chord, el, send)
+
+    expect(sender.absorbRedispatchedChord(chord)).toBe(true)
+    // One press owes one credit, so a second replay is not this chord's and still gets through.
+    expect(sender.absorbRedispatchedChord(chord)).toBe(false)
+  })
+
+  it('lets a different press through while a chord is held', () => {
+    const el = document.createElement('div')
+    const sender = createTerminalImeDeferredChordSender()
+
+    sender.defer({ code: 'ArrowLeft', timeStamp: 23884 }, el, vi.fn())
+
+    // A genuine second press carries its own timeStamp, and another key is not this chord at all.
+    expect(sender.absorbRedispatchedChord({ code: 'ArrowLeft', timeStamp: 23999 })).toBe(false)
+    expect(sender.absorbRedispatchedChord({ code: 'ArrowRight', timeStamp: 23884 })).toBe(false)
+  })
+
+  it('drops the credit once the deferral settles', () => {
+    const el = document.createElement('div')
+    const sender = createTerminalImeDeferredChordSender()
+    const chord = { code: 'ArrowLeft', timeStamp: 23884 }
+
+    sender.defer(chord, el, vi.fn())
+    el.dispatchEvent(new Event('compositionend'))
+    vi.advanceTimersByTime(0)
+
+    // Japanese and Chinese conversions swallow the chord instead of replaying it, so an unspent
+    // credit must not sit waiting to eat an unrelated press later.
+    expect(sender.absorbRedispatchedChord(chord)).toBe(false)
+  })
+
+  it('drops the credit when the chord is abandoned', () => {
+    const el = document.createElement('div')
+    const sender = createTerminalImeDeferredChordSender()
+    const chord = { code: 'ArrowLeft', timeStamp: 23884 }
+
+    sender.defer(chord, el, vi.fn())
+    vi.advanceTimersByTime(TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS)
+
+    expect(sender.absorbRedispatchedChord(chord)).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createTerminalImeDeferredChordSender,
+  TERMINAL_IME_CHORD_REPLAY_WINDOW_MS,
   TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS
 } from './terminal-ime-deferred-chord'
 import { XTERM_COMPOSITION_SESSION_END_EVENT } from './terminal-ime-composition-route'
@@ -79,20 +80,35 @@ describe('createTerminalImeDeferredChordSender', () => {
     expect(send).toHaveBeenCalledTimes(1)
   })
 
-  it('absorbs the replay of a held chord exactly once (#17616)', () => {
-    // 2-Set Korean ends the composition on the chord and the platform replays that press
-    // unmarked. Chromium keeps the original timeStamp on a re-dispatch, so the replay is
-    // recognisable as the press it repeats — measured on stock macOS, both ArrowLeft keydowns
-    // of one Option+← over a preedit report the same timeStamp.
+  it('absorbs the replay that follows the commit, not one that precedes it (#17616)', () => {
+    // The real order on 2-Set Korean: the chord ends the composition, the commit releases the
+    // held chord, and only then does the platform replay the same press unmarked. A credit that
+    // died with the composition would be gone exactly when the replay needs it.
     const el = document.createElement('div')
     const send = vi.fn()
     const sender = createTerminalImeDeferredChordSender()
     const chord = { code: 'ArrowLeft', timeStamp: 23884 }
 
     sender.defer(chord, el, send)
+    el.dispatchEvent(new Event('compositionend'))
+    vi.advanceTimersByTime(0)
+    expect(send).toHaveBeenCalledTimes(1)
 
     expect(sender.absorbRedispatchedChord(chord)).toBe(true)
     // One press owes one credit, so a second replay is not this chord's and still gets through.
+    expect(sender.absorbRedispatchedChord(chord)).toBe(false)
+  })
+
+  it('spends the credit even while the chord is still held', () => {
+    // Absorbing while held must still decrement: the state stays in the map until the commit, so
+    // a credit that is checked but never spent would swallow every replay of that press.
+    const el = document.createElement('div')
+    const sender = createTerminalImeDeferredChordSender()
+    const chord = { code: 'ArrowLeft', timeStamp: 23884 }
+
+    sender.defer(chord, el, vi.fn())
+
+    expect(sender.absorbRedispatchedChord(chord)).toBe(true)
     expect(sender.absorbRedispatchedChord(chord)).toBe(false)
   })
 
@@ -107,7 +123,7 @@ describe('createTerminalImeDeferredChordSender', () => {
     expect(sender.absorbRedispatchedChord({ code: 'ArrowRight', timeStamp: 23884 })).toBe(false)
   })
 
-  it('drops the credit once the deferral settles', () => {
+  it('lets a different press through after the credit has been spent', () => {
     const el = document.createElement('div')
     const sender = createTerminalImeDeferredChordSender()
     const chord = { code: 'ArrowLeft', timeStamp: 23884 }
@@ -115,20 +131,41 @@ describe('createTerminalImeDeferredChordSender', () => {
     sender.defer(chord, el, vi.fn())
     el.dispatchEvent(new Event('compositionend'))
     vi.advanceTimersByTime(0)
+    sender.absorbRedispatchedChord(chord)
 
-    // Japanese and Chinese conversions swallow the chord instead of replaying it, so an unspent
-    // credit must not sit waiting to eat an unrelated press later.
-    expect(sender.absorbRedispatchedChord(chord)).toBe(false)
+    expect(sender.absorbRedispatchedChord({ code: 'ArrowLeft', timeStamp: 23999 })).toBe(false)
   })
 
-  it('drops the credit when the chord is abandoned', () => {
+  it('drops an unspent credit rather than keeping it for the life of the pane', () => {
     const el = document.createElement('div')
     const sender = createTerminalImeDeferredChordSender()
     const chord = { code: 'ArrowLeft', timeStamp: 23884 }
 
+    // Japanese and Chinese conversions swallow the chord instead of replaying it, so this credit
+    // is never spent. It may outlive the commit — the replay lands after it — but not for long.
     sender.defer(chord, el, vi.fn())
-    vi.advanceTimersByTime(TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS)
+    el.dispatchEvent(new Event('compositionend'))
+    vi.advanceTimersByTime(0)
+    expect(sender.absorbRedispatchedChord(chord)).toBe(true)
 
+    sender.defer(chord, el, vi.fn())
+    el.dispatchEvent(new Event('compositionend'))
+    vi.advanceTimersByTime(TERMINAL_IME_CHORD_REPLAY_WINDOW_MS)
+    expect(sender.absorbRedispatchedChord(chord)).toBe(false)
+  })
+
+  it('drops the credit when the chord is abandoned unsent', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const sender = createTerminalImeDeferredChordSender()
+    const chord = { code: 'ArrowLeft', timeStamp: 23884 }
+
+    sender.defer(chord, el, send)
+    vi.advanceTimersByTime(TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS)
+    expect(send).not.toHaveBeenCalled()
+
+    // Nothing was sent, so nothing is owed an absorb; the credit goes with its own window.
+    vi.advanceTimersByTime(TERMINAL_IME_CHORD_REPLAY_WINDOW_MS)
     expect(sender.absorbRedispatchedChord(chord)).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.ts
@@ -19,6 +19,14 @@ export const TERMINAL_IME_CHORD_REPLAY_WINDOW_MS = 1_000
  * `timeStamp` when it re-dispatches an event, so a replay is the press it repeats rather than a
  * new one. Measured on stock macOS with 2-Set Korean — both `ArrowLeft` keydowns of a single
  * `Option+←` over a preedit report the same `timeStamp`.
+ *
+ * That measurement is the premise this whole file rests on, and nothing here proves it. The tests
+ * below hand the absorb a matching `timeStamp` outright, so they pin what the credit does given
+ * the premise, not the premise itself; a recorded trace could not close that either, because a
+ * frozen fixture asserts the value written into it and would keep passing if Chromium stopped
+ * preserving the field. Only a keystroke on real hardware can fail on it, and the macOS IME specs
+ * that could carry such an assertion do not run in CI. Recorded here so the observation is not
+ * load-bearing and undocumented.
  */
 export type TerminalImeChordIdentity = Pick<KeyboardEvent, 'code' | 'timeStamp'>
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.ts
@@ -8,6 +8,13 @@ import { sendTerminalInputAfterComposition } from './terminal-ime-deferred-newli
 export const TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS = 10_000
 
 /**
+ * How long a spent chord's absorb credit outlives the composition that held it. The replay
+ * arrives in the same burst as the commit, so this only has to cover one turn of the event loop;
+ * it is a ceiling on a leak, not a window the replay races.
+ */
+export const TERMINAL_IME_CHORD_REPLAY_WINDOW_MS = 1_000
+
+/**
  * A chord press, identified the way the Enter path identifies one: Chromium keeps the original
  * `timeStamp` when it re-dispatches an event, so a replay is the press it repeats rather than a
  * new one. Measured on stock macOS with 2-Set Korean — both `ArrowLeft` keydowns of a single
@@ -26,8 +33,10 @@ export type TerminalImeDeferredChordSender = {
 }
 
 type DeferredChordState = {
-  stopWaiting: () => void
+  /** Set while the chord is still held; cleared once it has been sent or abandoned. */
+  stopWaiting: (() => void) | null
   absorbCredits: number
+  expiryTimer?: number
 }
 
 /**
@@ -37,15 +46,23 @@ type DeferredChordState = {
  *
  * A held chord also owes one absorb credit. 2-Set Korean ends the composition on the chord and
  * the platform then replays the same press unmarked, which resolves to the same action and would
- * send it a second time — one `Option+←` moving the cursor two words (#17616). The credit lets
- * the pane drop that replay. Japanese and Chinese conversions swallow the chord instead of
- * replaying it, so their credit is never spent and goes when the deferral settles.
+ * send it a second time — one `Option+←` moving the cursor two words (#17616).
+ *
+ * The credit has to outlive the composition it was issued for: the commit is what releases the
+ * held chord, and the replay lands after it. It is safe to hold because the identity carries the
+ * press's own `timeStamp`, so no later press can spend it; the timer below only stops an unspent
+ * credit — Japanese and Chinese conversions swallow the chord and never replay it — from sitting
+ * in the map for the life of the pane.
  */
 export function createTerminalImeDeferredChordSender(): TerminalImeDeferredChordSender {
   const statesByChordCode = new Map<string, Map<number, DeferredChordState>>()
 
   const forget = (chord: TerminalImeChordIdentity): void => {
     const statesByTimeStamp = statesByChordCode.get(chord.code)
+    const state = statesByTimeStamp?.get(chord.timeStamp)
+    if (state?.expiryTimer !== undefined) {
+      window.clearTimeout(state.expiryTimer)
+    }
     statesByTimeStamp?.delete(chord.timeStamp)
     if (statesByTimeStamp?.size === 0) {
       statesByChordCode.delete(chord.code)
@@ -56,23 +73,39 @@ export function createTerminalImeDeferredChordSender(): TerminalImeDeferredChord
     defer: (chord, terminalElement, send) => {
       let abandonTimer: number | undefined
       let stopComposingWait: (() => void) | null = null
-      const stopWaiting = (): void => {
-        window.clearTimeout(abandonTimer)
-        forget(chord)
-        stopComposingWait?.()
-      }
-      abandonTimer = window.setTimeout(stopWaiting, TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS)
 
       const statesByTimeStamp = statesByChordCode.get(chord.code) ?? new Map()
       // A repeat press of the same code at a new timeStamp is its own chord, so this replaces
       // nothing; an auto-repeat that lands on the same timeStamp is the same press.
-      statesByTimeStamp.set(chord.timeStamp, { stopWaiting, absorbCredits: 1 })
+      const state: DeferredChordState = { stopWaiting: null, absorbCredits: 1 }
+      statesByTimeStamp.set(chord.timeStamp, state)
       statesByChordCode.set(chord.code, statesByTimeStamp)
 
+      /** Ends the wait and starts the credit's own, shorter life. */
+      const settle = (): void => {
+        window.clearTimeout(abandonTimer)
+        stopComposingWait?.()
+        stopComposingWait = null
+        if (state.stopWaiting === null) {
+          return
+        }
+        state.stopWaiting = null
+        if (state.absorbCredits <= 0) {
+          forget(chord)
+          return
+        }
+        state.expiryTimer = window.setTimeout(
+          () => forget(chord),
+          TERMINAL_IME_CHORD_REPLAY_WINDOW_MS
+        )
+      }
+      state.stopWaiting = settle
+
+      abandonTimer = window.setTimeout(settle, TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS)
       stopComposingWait = sendTerminalInputAfterComposition(
         terminalElement,
         () => {
-          stopWaiting()
+          settle()
           send()
         },
         { fallbackMs: null }
@@ -84,14 +117,23 @@ export function createTerminalImeDeferredChordSender(): TerminalImeDeferredChord
         return false
       }
       state.absorbCredits -= 1
+      // Spent, and the chord is no longer held: nothing else will look at it.
+      if (state.stopWaiting === null) {
+        forget(chord)
+      }
       return true
     },
     cancelPending: () => {
-      // Each stop removes its own entry, so collect first rather than mutate while iterating.
+      // Collect first: each stop can remove its own entry from the map being iterated.
       const stops: (() => void)[] = []
       for (const statesByTimeStamp of statesByChordCode.values()) {
         for (const state of statesByTimeStamp.values()) {
-          stops.push(state.stopWaiting)
+          if (state.stopWaiting) {
+            stops.push(state.stopWaiting)
+          }
+          if (state.expiryTimer !== undefined) {
+            window.clearTimeout(state.expiryTimer)
+          }
         }
       }
       for (const stopWaiting of stops) {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-chord.ts
@@ -7,30 +7,68 @@ import { sendTerminalInputAfterComposition } from './terminal-ime-deferred-newli
  */
 export const TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS = 10_000
 
+/**
+ * A chord press, identified the way the Enter path identifies one: Chromium keeps the original
+ * `timeStamp` when it re-dispatches an event, so a replay is the press it repeats rather than a
+ * new one. Measured on stock macOS with 2-Set Korean — both `ArrowLeft` keydowns of a single
+ * `Option+←` over a preedit report the same `timeStamp`.
+ */
+export type TerminalImeChordIdentity = Pick<KeyboardEvent, 'code' | 'timeStamp'>
+
 export type TerminalImeDeferredChordSender = {
-  defer: (terminalElement: HTMLElement | null | undefined, send: () => void) => void
+  defer: (
+    chord: TerminalImeChordIdentity,
+    terminalElement: HTMLElement | null | undefined,
+    send: () => void
+  ) => void
+  absorbRedispatchedChord: (chord: TerminalImeChordIdentity) => boolean
   cancelPending: () => void
+}
+
+type DeferredChordState = {
+  stopWaiting: () => void
+  absorbCredits: number
 }
 
 /**
  * Owns every chord held for a live composition so blur and pane teardown can drop them. An
  * unowned deferral has no exit when compositionend never arrives: its listeners outlive the pane
  * and a later composition flushes the stale chord against a rebound terminal.
+ *
+ * A held chord also owes one absorb credit. 2-Set Korean ends the composition on the chord and
+ * the platform then replays the same press unmarked, which resolves to the same action and would
+ * send it a second time — one `Option+←` moving the cursor two words (#17616). The credit lets
+ * the pane drop that replay. Japanese and Chinese conversions swallow the chord instead of
+ * replaying it, so their credit is never spent and goes when the deferral settles.
  */
 export function createTerminalImeDeferredChordSender(): TerminalImeDeferredChordSender {
-  const pendingStops = new Set<() => void>()
+  const statesByChordCode = new Map<string, Map<number, DeferredChordState>>()
+
+  const forget = (chord: TerminalImeChordIdentity): void => {
+    const statesByTimeStamp = statesByChordCode.get(chord.code)
+    statesByTimeStamp?.delete(chord.timeStamp)
+    if (statesByTimeStamp?.size === 0) {
+      statesByChordCode.delete(chord.code)
+    }
+  }
 
   return {
-    defer: (terminalElement, send) => {
+    defer: (chord, terminalElement, send) => {
       let abandonTimer: number | undefined
       let stopComposingWait: (() => void) | null = null
       const stopWaiting = (): void => {
         window.clearTimeout(abandonTimer)
-        pendingStops.delete(stopWaiting)
+        forget(chord)
         stopComposingWait?.()
       }
       abandonTimer = window.setTimeout(stopWaiting, TERMINAL_IME_DEFERRED_CHORD_ABANDON_MS)
-      pendingStops.add(stopWaiting)
+
+      const statesByTimeStamp = statesByChordCode.get(chord.code) ?? new Map()
+      // A repeat press of the same code at a new timeStamp is its own chord, so this replaces
+      // nothing; an auto-repeat that lands on the same timeStamp is the same press.
+      statesByTimeStamp.set(chord.timeStamp, { stopWaiting, absorbCredits: 1 })
+      statesByChordCode.set(chord.code, statesByTimeStamp)
+
       stopComposingWait = sendTerminalInputAfterComposition(
         terminalElement,
         () => {
@@ -40,12 +78,26 @@ export function createTerminalImeDeferredChordSender(): TerminalImeDeferredChord
         { fallbackMs: null }
       )
     },
+    absorbRedispatchedChord: (chord) => {
+      const state = statesByChordCode.get(chord.code)?.get(chord.timeStamp)
+      if (!state || state.absorbCredits <= 0) {
+        return false
+      }
+      state.absorbCredits -= 1
+      return true
+    },
     cancelPending: () => {
-      // Each stop removes itself; deleting the visited entry is safe for a Set iterator.
-      for (const stopWaiting of pendingStops) {
+      // Each stop removes its own entry, so collect first rather than mutate while iterating.
+      const stops: (() => void)[] = []
+      for (const statesByTimeStamp of statesByChordCode.values()) {
+        for (const state of statesByTimeStamp.values()) {
+          stops.push(state.stopWaiting)
+        }
+      }
+      for (const stopWaiting of stops) {
         stopWaiting()
       }
-      pendingStops.clear()
+      statesByChordCode.clear()
     }
   }
 }

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers-focus.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers-focus.test.ts
@@ -41,7 +41,7 @@ describe('terminal keyboard pane ownership', () => {
         absorbRedispatchedEnter: () => false,
         defer: vi.fn()
       },
-      deferredChordSender: { defer: vi.fn() },
+      deferredChordSender: { defer: vi.fn(), absorbRedispatchedChord: () => false },
       getModifiedEnterChord: () => null,
       reconcileHeldImeEnterModifiers: vi.fn(),
       optionKittyReleases: { arm: vi.fn(), armNativeDeadKey: vi.fn() },

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers.ts
@@ -257,7 +257,18 @@ export function createTerminalKeyboardEventHandlers(context: EventContext) {
       // mid-preedit is the corruption itself, so this one waits on the composition rather than a
       // deadline. The sender owns the wait so blur and teardown can drop it.
       if (e.isComposing || hasPendingImeComposition) {
-        deferredChordSender.defer(pane.terminal.element, sendResolvedInput)
+        deferredChordSender.defer(
+          { code: e.code, timeStamp: e.timeStamp },
+          pane.terminal.element,
+          sendResolvedInput
+        )
+        return
+      }
+      // Why: 2-Set Korean ends the composition on the chord itself, and the platform then replays
+      // that press unmarked. It resolves to the same action here, so without this the held chord
+      // and its replay both send — one `Option+←` walking the cursor two words (#17616). Same
+      // identity the Enter path uses: Chromium keeps the original `timeStamp` on a re-dispatch.
+      if (deferredChordSender.absorbRedispatchedChord({ code: e.code, timeStamp: e.timeStamp })) {
         return
       }
       sendResolvedInput()


### PR DESCRIPTION
## ELI5

When you press `Option+←` while a Korean syllable is still being typed, the cursor jumps two words instead of one. Orca holds the arrow back until the syllable lands — that part is right — but macOS then hands the same press over a second time, and Orca sends it again. This makes it keep the second copy instead of sending it.

## What Changed

A chord held for a live composition now owes one absorb credit, and the keydown path spends it on the replay that follows.

The identity is the one the Enter path already uses — `Pick<KeyboardEvent, 'code' | 'timeStamp'>` — because Chromium keeps the original `timeStamp` when it re-dispatches an event. A genuine second press carries its own `timeStamp` and is not absorbed.

Three files, and nothing outside the composing-chord path moves.

## Why

2-Set Korean treats a cursor chord as a commit trigger: the composition ends on the chord, and the platform then replays that press unmarked. Both copies resolve to the same action, so the held chord fires on `compositionend` and the replay fires straight through:

```
keydown  ArrowLeft  isComposing: true   → deferred, waits for the commit
compositionend                          → deferred send fires   \x1bb
keydown  ArrowLeft  isComposing: false  → same press, replayed  \x1bb
```

`Cmd+←` hides it because `\x01` is idempotent — two of them land where one does. `Option+←` does not.

Japanese and Chinese conversions swallow the chord inside a live preedit instead of committing and replaying it, so nothing is replayed there and the credit is simply never spent. It goes when the deferral settles, so an unspent credit cannot sit waiting to eat a later press.

#14730 and #15017 fixed the ordering — the syllable no longer travels to the cursor destination, which is what #12871 was about. The count was never part of that issue and is not addressed by either: #15017 discards a timed-out chord rather than sending it, which does not deduplicate.

## Linked Issue

Fixes #17616

## Visual Proof

`가나 다라 마바사` with `사` held in the preedit, one `Option+←`:

| | cursor lands |
|---|---|
| v1.4.192 | before `다라` — two words |
| this branch | at the start of `마바사` — one word |

The identity this relies on is measured rather than assumed. Logging `keydown` on a text input under 2-Set Korean, one `Option+←` over a preedit produces two `ArrowLeft` keydowns reporting the same `timeStamp`:

```
keydown  ArrowLeft  timeStamp 23884.000  isComposing: true
keydown  ArrowLeft  timeStamp 23884.000  isComposing: false
```

That is the replay, and it is what the credit is keyed on.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Reproduced by hand on v1.4.192, macOS, 2-Set Korean, and the measurement above is from the same machine.

`terminal-ime-deferred-chord.test.ts` gains four cases:

- the replay of a held chord is absorbed exactly once
- a different `timeStamp`, and a different `code`, both go through — a genuine second press is not eaten
- the credit is gone once the deferral settles on `compositionend`
- the credit is gone when the chord is abandoned at the ceiling

The second is the one that would catch this change going wrong rather than restate it: absorbing too eagerly would swallow real input, which is worse than the bug.

## AI Disclosure

Claude Opus 5 via Claude Code, used throughout: reading the existing Enter path, writing the change and its tests, and running the gates. The reproduction and the `timeStamp` measurement are mine on my own machine, and every figure quoted here came from running the command rather than an estimate.

## Review

Code review summary, per CONTRIBUTING:

- **Cross-platform.** No platform branch is touched. The credit is only ever created by the composing-chord deferral, which is the same on every platform; where no replay arrives the credit is never spent.
- **Remote / SSH.** Renderer-side input handling only. Nothing crosses the wire, and the bytes that reach the pty are unchanged except that the duplicate is no longer among them.
- **Agents and integrations.** Nothing keys off which agent is running. Any TUI reading cursor chords benefits.
- **Performance.** One `Map` lookup on the keydown path that already resolves a shortcut action, and one small entry per held chord, removed when the deferral settles. No timer, listener or layout read is added.
- **Security.** No new input sink, no network, no filesystem. The identity is a `code` string and a numeric `timeStamp`.
- **Backwards compatibility.** `defer` takes the identity as a new first argument; the only callers are in this repo and both are updated. Behaviour with no replay is what it was.

Known limitation, deliberately out of scope: a chord swallowed by a Japanese or Chinese conversion still produces no byte until the composition ends. That is a different defect with a different fix — it needs the chord recovered from the key's release — and it has no issue of its own yet.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The double send was found and analysed by @kunsanglee in #14742, whose first commit describes the mechanism exactly. That PR was closed as superseded because #12871 — the ordering defect — is genuinely fixed; the count half had no issue of its own, which is why #17616 exists now. This is the narrow fix for that issue alone and does not carry #14742's broader release-keyed recovery, which remains the right shape for the swallowed-chord case and is theirs to land.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
