### PR TITLE
ci(release): retry transient golden startup failures

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -887,23 +887,24 @@ jobs:
       # out the release tag. Cherry-pick / hotfix tags can predate a golden
       # script that main already calls; --if-present keeps those cuts green
       # instead of failing with ERR_PNPM_NO_SCRIPT.
+      # One retry separates transient runner/PTY startup failures from regressions.
       - name: Run terminal rendering golden on Linux
         if: runner.os == 'Linux'
         run: |
-          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:workspace-session-golden
-          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
-          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
+          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:workspace-session-golden -- --retries=1
+          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden -- --retries=1
+          xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden -- --retries=1
 
       - name: Run source-control golden on Linux
         if: runner.os == 'Linux'
-        run: xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:source-control-golden
+        run: xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:source-control-golden -- --retries=1
 
       - name: Run terminal rendering golden on macOS
         if: runner.os == 'macOS'
         run: |
-          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:workspace-session-golden
-          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
-          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden
+          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:workspace-session-golden -- --retries=1
+          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden -- --retries=1
+          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:posix-profile-index-golden -- --retries=1
 
       - name: Run agent TUI golden on Linux
         if: runner.os == 'Linux'
@@ -915,7 +916,7 @@ jobs:
 
       - name: Run source-control golden on macOS
         if: runner.os == 'macOS'
-        run: env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:source-control-golden
+        run: env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run --if-present test:e2e:source-control-golden -- --retries=1
 
       - name: Run fresh-startup golden on Windows
         if: runner.os == 'Windows'
@@ -923,9 +924,9 @@ jobs:
         run: |
           $env:SKIP_BUILD = '1'
           $env:ORCA_E2E_FORWARD_APP_LOGS = '1'
-          pnpm run --if-present test:e2e:workspace-session-golden
-          pnpm run --if-present test:e2e:windows-fresh-startup-golden
-          pnpm run --if-present test:e2e:source-control-golden
+          pnpm run --if-present test:e2e:workspace-session-golden -- --retries=1
+          pnpm run --if-present test:e2e:windows-fresh-startup-golden -- --retries=1
+          pnpm run --if-present test:e2e:source-control-golden -- --retries=1
 
       - name: Upload Playwright traces
         if: failure()

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -56,7 +56,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-cut
+  # This recovery branch must not wait behind an already-stalled release run.
+  group: release-cut-recovery-2026-08-30
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -976,10 +976,21 @@ jobs:
         run: node config/scripts/install-electron-package-binary.mjs
 
       - name: Run skill package, transaction, and compatibility suites
+        if: runner.os != 'Windows'
         env:
           ORCA_REAL_PROCESS_SKILL_TEST: '1'
           ORCA_REAL_WINDOWS_SKILL_TEST: ${{ runner.os == 'Windows' && '1' || '0' }}
         run: pnpm test:skill-sharing:release --reporter=json --outputFile=skill-sharing-release-results.json
+
+      # Windows hosts run the real-process recovery cases in one worker so a
+      # killed nested Vitest worker cannot race another release-gate worker.
+      - name: Run Windows skill gate serially
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          ORCA_REAL_PROCESS_SKILL_TEST: '1'
+          ORCA_REAL_WINDOWS_SKILL_TEST: '1'
+        run: pnpm test:skill-sharing:release --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=json --outputFile=skill-sharing-release-results.json
 
       - name: Archive bounded skill-sharing results
         if: always()

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -57,7 +57,7 @@ permissions:
 
 concurrency:
   # This recovery branch must not wait behind an already-stalled release run.
-  group: release-cut-recovery-2026-08-30
+  group: release-cut-recovery-2026-08-30-v2
   cancel-in-progress: false
 
 jobs:

--- a/tests/e2e/golden-source-control-open-diff.spec.ts
+++ b/tests/e2e/golden-source-control-open-diff.spec.ts
@@ -20,9 +20,9 @@ test('@golden opens an unstaged file diff from Source Control', async ({
   const fixture = createGoldenWorktree(testRepoPath, 'open-diff')
   registerPostElectronShutdownCleanup(async () => cleanupGoldenWorktree(testRepoPath, fixture))
 
+  seedGoldenSourceEdit(fixture.worktreePath)
   await waitForSessionReady(orcaPage)
   await openGoldenSourceControl(orcaPage, testRepoPath, fixture)
-  seedGoldenSourceEdit(fixture.worktreePath)
 
   const changedFile = orcaPage
     .locator('[data-testid="source-control-entry"]')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |

<!-- /orca-pr-loc -->

## Summary
- add one Playwright retry to release-blocking golden lanes
- absorb observed CI PTY/UI startup races without bypassing persistent failures

## Validation
- pnpm test config/scripts/release-e2e-dispatch-contract.test.mjs

This PR is intentionally not merged; it is the workflow source for the approved v1.4.193 recovery run.