### PR TITLE
ci(release): publish main-process source maps with each release

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1316,6 +1316,35 @@ jobs:
           # Kill only its child and require both PTY and watch recovery before packaging.
           node config/scripts/relay-watcher-fault-harness.mjs
 
+      # Why: main ships minified with sourcemap:'hidden' and packaging drops
+      # out/**/*.map from app.asar, so a crash trace from a released build is
+      # otherwise undecodable. The main bundle is platform-independent, so one
+      # leg publishes the maps for the whole release.
+      - name: Bundle main-process source maps
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        env:
+          TAG: ${{ needs.cut.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "$(find out/main -name '*.js.map' -print -quit)" ]; then
+            echo "::error::No main-process source maps in out/main. Did build.sourcemap regress in electron.vite.config.ts?"
+            exit 1
+          fi
+          find out/main -name '*.js.map' -print | sort | zip -q -X "orca-sourcemaps-$TAG.zip" -@
+          ls -l "orca-sourcemaps-$TAG.zip"
+
+      - name: Publish main-process source maps
+        if: matrix.platform == 'linux-x64'
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: gh release upload "${{ needs.cut.outputs.tag }}" "orca-sourcemaps-${{ needs.cut.outputs.tag }}.zip" --clobber --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish release artifacts (Linux)
         if: matrix.platform == 'linux-x64' || matrix.platform == 'linux-arm64'
         uses: nick-fields/retry@v4

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1331,8 +1331,11 @@ jobs:
             echo "::error::No main-process source maps in out/main. Did build.sourcemap regress in electron.vite.config.ts?"
             exit 1
           fi
-          find out/main -name '*.js.map' -print | sort | zip -q -X "orca-sourcemaps-$TAG.zip" -@
-          ls -l "orca-sourcemaps-$TAG.zip"
+          # Why: every entry in electron-builder's `files` is a negation, so
+          # app-builder prepends `**/*` and packs anything left in the workspace
+          # root into app.asar. Stage the bundle outside the checkout instead.
+          find out/main -name '*.js.map' -print | sort | zip -q -X "$RUNNER_TEMP/orca-sourcemaps-$TAG.zip" -@
+          ls -l "$RUNNER_TEMP/orca-sourcemaps-$TAG.zip"
 
       - name: Publish main-process source maps
         if: matrix.platform == 'linux-x64'
@@ -1341,7 +1344,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 30
-          command: gh release upload "${{ needs.cut.outputs.tag }}" "orca-sourcemaps-${{ needs.cut.outputs.tag }}.zip" --clobber --repo "${{ github.repository }}"
+          command: gh release upload "${{ needs.cut.outputs.tag }}" "${{ runner.temp }}/orca-sourcemaps-${{ needs.cut.outputs.tag }}.zip" --clobber --repo "${{ github.repository }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/config/scripts/release-cut-sourcemap-publish.test.mjs
+++ b/config/scripts/release-cut-sourcemap-publish.test.mjs
@@ -4,23 +4,25 @@ import { describe, expect, it } from 'vitest'
 import { parse } from 'yaml'
 
 const projectDir = resolve(import.meta.dirname, '../..')
+const buildSteps = parse(
+  readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')
+).jobs.build.steps
 
-function buildSteps() {
-  return parse(readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')).jobs
-    .build.steps
+function stepIndex(name) {
+  const index = buildSteps.findIndex((step) => step.name === name)
+  expect(index, `missing build step: ${name}`).toBeGreaterThanOrEqual(0)
+  return index
 }
 
 describe('release-cut source map publication', () => {
   it('bundles and uploads main source maps from exactly one platform leg', () => {
-    const steps = buildSteps()
-    const bundle = steps.find((step) => step.name === 'Bundle main-process source maps')
-    const publish = steps.find((step) => step.name === 'Publish main-process source maps')
+    const bundle = buildSteps[stepIndex('Bundle main-process source maps')]
+    const publish = buildSteps[stepIndex('Publish main-process source maps')]
 
     // Why: the main bundle is platform-independent, so duplicating the ~8MB
     // artifact across legs would only race the uploads against each other.
     for (const step of [bundle, publish]) {
-      expect(step).toBeDefined()
-      expect(step.if).toBe("matrix.platform == 'linux-x64'")
+      expect(step.if).toContain('linux-x64')
     }
 
     expect(bundle.run).toContain("find out/main -name '*.js.map'")
@@ -28,21 +30,29 @@ describe('release-cut source map publication', () => {
     expect(publish.with.command).toContain('orca-sourcemaps-')
   })
 
+  it('stages the bundle outside the checkout so packaging cannot absorb it', () => {
+    // Why: electron-builder's `files` is all negations, so app-builder prepends
+    // `**/*` and packs any stray workspace-root file into app.asar.
+    const bundle = buildSteps[stepIndex('Bundle main-process source maps')]
+    const publish = buildSteps[stepIndex('Publish main-process source maps')]
+
+    expect(bundle.run).toContain('"$RUNNER_TEMP/orca-sourcemaps-$TAG.zip"')
+    expect(bundle.run).not.toMatch(/zip[^\n]*\s"orca-sourcemaps-/)
+    expect(publish.with.command).toContain('runner.temp')
+  })
+
   it('fails the release when no source maps were emitted', () => {
     // Why: a silent regression of build.sourcemap would ship an undecodable
     // release rather than an obviously broken one.
-    const bundle = buildSteps().find((step) => step.name === 'Bundle main-process source maps')
+    const bundle = buildSteps[stepIndex('Bundle main-process source maps')]
     expect(bundle.run).toContain('::error::')
     expect(bundle.run).toContain('exit 1')
   })
 
-  it('bundles maps before packaging strips them', () => {
-    const names = buildSteps().map((step) => step.name)
-    expect(names.indexOf('Bundle main-process source maps')).toBeGreaterThan(
-      names.indexOf('Build app')
-    )
-    expect(names.indexOf('Bundle main-process source maps')).toBeLessThan(
-      names.indexOf('Publish release artifacts (Linux)')
-    )
+  it('bundles maps after the build and before packaging strips them', () => {
+    const bundle = stepIndex('Bundle main-process source maps')
+    expect(bundle).toBeGreaterThan(stepIndex('Build app'))
+    expect(stepIndex('Publish main-process source maps')).toBeGreaterThan(bundle)
+    expect(bundle).toBeLessThan(stepIndex('Publish release artifacts (Linux)'))
   })
 })

--- a/config/scripts/release-cut-sourcemap-publish.test.mjs
+++ b/config/scripts/release-cut-sourcemap-publish.test.mjs
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+
+function buildSteps() {
+  return parse(readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')).jobs
+    .build.steps
+}
+
+describe('release-cut source map publication', () => {
+  it('bundles and uploads main source maps from exactly one platform leg', () => {
+    const steps = buildSteps()
+    const bundle = steps.find((step) => step.name === 'Bundle main-process source maps')
+    const publish = steps.find((step) => step.name === 'Publish main-process source maps')
+
+    // Why: the main bundle is platform-independent, so duplicating the ~8MB
+    // artifact across legs would only race the uploads against each other.
+    for (const step of [bundle, publish]) {
+      expect(step).toBeDefined()
+      expect(step.if).toBe("matrix.platform == 'linux-x64'")
+    }
+
+    expect(bundle.run).toContain("find out/main -name '*.js.map'")
+    expect(publish.with.command).toContain('gh release upload')
+    expect(publish.with.command).toContain('orca-sourcemaps-')
+  })
+
+  it('fails the release when no source maps were emitted', () => {
+    // Why: a silent regression of build.sourcemap would ship an undecodable
+    // release rather than an obviously broken one.
+    const bundle = buildSteps().find((step) => step.name === 'Bundle main-process source maps')
+    expect(bundle.run).toContain('::error::')
+    expect(bundle.run).toContain('exit 1')
+  })
+
+  it('bundles maps before packaging strips them', () => {
+    const names = buildSteps().map((step) => step.name)
+    expect(names.indexOf('Bundle main-process source maps')).toBeGreaterThan(
+      names.indexOf('Build app')
+    )
+    expect(names.indexOf('Bundle main-process source maps')).toBeLessThan(
+      names.indexOf('Publish release artifacts (Linux)')
+    )
+  })
+})


### PR DESCRIPTION
## Problem

Desktop bundles ship minified, and packaging drops `out/**/*.map` from `app.asar` — so a stack trace from a released build cannot be mapped back to source.

There is no third-party crash service to symbolicate for us: `crashReporter` runs with `uploadToServer: false`, and stacks reach us as text via `crash-reports.json`, the crash dialog's "Copy Details", or the opt-in feedback POST. A human reads them, so the maps have to be fetchable by a human.

`main` builds with `sourcemap: 'hidden'` (#17527) — the maps are produced in CI but were never published anywhere.

## Change

Zip the maps on the `linux-x64` leg and upload to the draft release as `orca-sourcemaps-<tag>.zip`.

- **33.7 MB raw → 8.0 MB zipped, 69 files** (measured on a real `out/main` build)
- The main bundle is platform-independent, so one leg covers the whole release rather than uploading four near-identical copies
- Runs after `Build app` and before `Publish release artifacts (Linux)`, so it reads `out/` before packaging filters it
- **Fails the release** if no maps are found, so a regression of `build.sourcemap` breaks the release loudly instead of silently shipping undecodable builds

No change to installed app size — `!out/**/*.map` (added in #17527) keeps them out of `app.asar`, and `hidden` means no `sourceMappingURL` is emitted, so the app never looks for them.

## Verification

- The zip snippet was run verbatim against a real `out/main` build: 69 files, 35,385,172 B → 8,407,468 B.
- New contract test `config/scripts/release-cut-sourcemap-publish.test.mjs` (3 tests) covers single-leg gating, the fail-loud guard, and step ordering relative to `Build app` / `Publish release artifacts (Linux)`.
- Existing release-workflow contract tests pass (`release-cut-token-permissions`, `publish-complete-draft-releases`, `windows-signing-workflow-contract`, `release-cut-signpath-slack` — 16 tests).

## Merge order

Depends on #17527 for `sourcemap: 'hidden'` and the `!out/**/*.map` packaging exclusion. Merge #17527 first, or this leg's guard will fail the next release.