### PR TITLE
fix(serve): keep Chromium switches out of CLI redirect

### DIFF
--- a/src/main/startup/appimage-cli-redirect.test.ts
+++ b/src/main/startup/appimage-cli-redirect.test.ts
@@ -53,7 +53,28 @@ describe('AppImage CLI redirect', () => {
     ).toBeNull()
   })
 
-  it('routes no-sandbox serve launches through the CLI', () => {
+  it('keeps direct serve launches in Electron when Chromium switches are present', () => {
+    expect(
+      getAppImageCliArgs(
+        [
+          'AppRun',
+          '--no-sandbox',
+          '--disable-features=FedCm,DirectSockets',
+          'serve',
+          '--port',
+          '6768'
+        ],
+        { APPIMAGE: '/opt/orca' },
+        {
+          platform: 'linux',
+          isPackaged: true,
+          commandNames
+        }
+      )
+    ).toBeNull()
+  })
+
+  it('keeps clean serve launches on the CLI path for validation', () => {
     expect(
       getAppImageCliArgs(
         ['AppRun', '--no-sandbox', 'serve', '--port', '6768'],
@@ -65,6 +86,34 @@ describe('AppImage CLI redirect', () => {
         }
       )
     ).toEqual(['serve', '--port', '6768'])
+  })
+
+  it('handles a space-separated Chromium switch value', () => {
+    expect(
+      getAppImageCliArgs(
+        ['AppRun', '--disable-features', 'FedCm', 'serve'],
+        { APPIMAGE: '/opt/orca' },
+        {
+          platform: 'linux',
+          isPackaged: true,
+          commandNames
+        }
+      )
+    ).toBeNull()
+  })
+
+  it('does not broaden the Electron-owned exception to switches after serve', () => {
+    expect(
+      getAppImageCliArgs(
+        ['AppRun', 'serve', '--disable-features=FedCm'],
+        { APPIMAGE: '/opt/orca' },
+        {
+          platform: 'linux',
+          isPackaged: true,
+          commandNames
+        }
+      )
+    ).toEqual(['serve', '--disable-features=FedCm'])
   })
 
   it('removes no-sandbox before forwarding CLI help', () => {
@@ -79,6 +128,20 @@ describe('AppImage CLI redirect', () => {
         }
       )
     ).toEqual(['serve', '--help'])
+  })
+
+  it('still redirects serve help even when Chromium switches are present', () => {
+    expect(
+      getAppImageCliArgs(
+        ['AppRun', '--disable-features=FedCm', 'serve', '--help'],
+        { APPIMAGE: '/opt/orca' },
+        {
+          platform: 'linux',
+          isPackaged: true,
+          commandNames
+        }
+      )
+    ).toEqual(['--disable-features=FedCm', 'serve', '--help'])
   })
 
   it('spawns the unpacked CLI entrypoint with Electron node mode', async () => {
@@ -118,14 +181,14 @@ describe('AppImage CLI redirect', () => {
     expect(spawnOptions?.env).not.toHaveProperty('NODE_REPL_EXTERNAL_MODULE')
   })
 
-  it('forwards an explicit no-sandbox choice to the serve child', async () => {
+  it('keeps a clean no-sandbox serve launch on the CLI path', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-appimage-cli-redirect-'))
     const cliEntryPath = join(root, 'app.asar.unpacked', 'out', 'cli', 'index.js')
     await mkdir(join(root, 'app.asar.unpacked', 'out', 'cli'), { recursive: true })
     await writeFile(cliEntryPath, '', 'utf8')
     const spawn = vi.fn((..._args: unknown[]) => ({ status: 0 }))
 
-    maybeRedirectAppImageCliLaunch({
+    const result = maybeRedirectAppImageCliLaunch({
       argv: ['orca-linux.AppImage', '--no-sandbox', 'serve'],
       env: { APPIMAGE: '/opt/orca/orca-linux.AppImage' },
       platform: 'linux',
@@ -136,6 +199,7 @@ describe('AppImage CLI redirect', () => {
       spawn: spawn as never
     })
 
+    expect(result).toEqual({ redirected: true, status: 0 })
     expect(spawn).toHaveBeenCalledWith(
       '/opt/orca/orca-ide',
       [cliEntryPath, 'serve'],

--- a/src/main/startup/appimage-cli-redirect.ts
+++ b/src/main/startup/appimage-cli-redirect.ts
@@ -24,7 +24,8 @@ type RedirectOptions = {
 
 const HELP_FLAGS = new Set(['--help', '-h', 'help'])
 const APPIMAGE_DESKTOP_FLAGS = new Set(['--no-sandbox'])
-const CLI_FLAGS_WITH_VALUES = new Set(['--environment', '--pairing-code'])
+const ELECTRON_LAUNCH_SWITCHES = new Set(['--disable-features'])
+const CLI_FLAGS_WITH_VALUES = new Set(['--environment', '--pairing-code', '--disable-features'])
 // Why: the main tsconfig cannot import the CLI project, but AppImage direct
 // launches need a conservative allow-list before bypassing the GUI startup.
 const APPIMAGE_CLI_COMMAND_NAMES = [
@@ -157,21 +158,44 @@ export function getAppImageCliArgs(
 
   const commandNames = new Set(options.commandNames)
   const firstPositional = findFirstCommandCandidate(cliArgs)
-  return firstPositional && commandNames.has(firstPositional) ? cliArgs : null
+  if (!firstPositional || !commandNames.has(firstPositional)) {
+    return null
+  }
+  // Keep serve in Electron only when an Electron launch switch is present.
+  // Forwarding it to the strict Node-mode CLI parser makes an otherwise valid
+  // serve launch fail, while clean serve invocations retain CLI validation.
+  if (
+    firstPositional === 'serve' &&
+    cliArgs
+      .slice(0, findFirstCommandCandidateIndex(cliArgs))
+      .some((arg) => ELECTRON_LAUNCH_SWITCHES.has(flagName(arg)))
+  ) {
+    return null
+  }
+  return cliArgs
 }
 
 function findFirstCommandCandidate(args: string[]): string | null {
+  const index = findFirstCommandCandidateIndex(args)
+  return index === -1 ? null : args[index]!
+}
+
+function findFirstCommandCandidateIndex(args: string[]): number {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]
     if (!arg.startsWith('-')) {
-      return arg
+      return index
     }
-    const flagName = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg
-    if (CLI_FLAGS_WITH_VALUES.has(flagName) && !arg.includes('=')) {
+    if (CLI_FLAGS_WITH_VALUES.has(flagName(arg)) && !arg.includes('=')) {
       index += 1
     }
   }
-  return null
+  return -1
+}
+
+function flagName(arg: string): string {
+  const equalsIndex = arg.indexOf('=')
+  return equalsIndex === -1 ? arg : arg.slice(0, equalsIndex)
 }
 
 function buildElectronRunAsNodeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {

--- a/src/main/startup/serve-mode-argv-cli-redirect-order.test.ts
+++ b/src/main/startup/serve-mode-argv-cli-redirect-order.test.ts
@@ -4,10 +4,9 @@ import { describe, expect, it } from 'vitest'
 import { getAppImageCliArgs } from './appimage-cli-redirect'
 import { argvRequestsServeMode, normalizeServeModeArgv } from './serve-mode-argv'
 
-// Why: index.ts must run both CLI redirects before rewriting argv. Rewriting
-// first replaces the `serve` positional with `--serve`, so the redirect's
-// command-name lookup finds a port number instead of a command and bails —
-// silently dropping AppImage serve launches out of the CLI path (#12677).
+// Why: index.ts runs CLI redirects before rewriting argv. Direct AppImage serve
+// stays in Electron so launch switches do not cross into the strict Node-mode
+// CLI parser; other CLI commands still depend on redirect ordering (#12677).
 
 const REDIRECT_OPTIONS = {
   platform: 'linux' as const,
@@ -24,13 +23,18 @@ function rewriteAsIndexDoes(argv: string[]): string[] {
 describe('serve argv rewrite vs AppImage CLI redirect ordering', () => {
   const launchArgv = ['/opt/orca/orca-ide', '--no-sandbox', 'serve', '--port', '7777', '--json']
 
-  it('hands the launch argv to the CLI when the redirect runs first', () => {
+  it('keeps clean serve validation on the CLI path', () => {
     expect(getAppImageCliArgs(launchArgv, MOUNTED_APPIMAGE_ENV, REDIRECT_OPTIONS)).toEqual([
       'serve',
       '--port',
       '7777',
       '--json'
     ])
+  })
+
+  it('keeps an injected Chromium switch in Electron before argv rewriting', () => {
+    const injected = [...launchArgv.slice(0, 2), '--disable-features=FedCm', ...launchArgv.slice(2)]
+    expect(getAppImageCliArgs(injected, MOUNTED_APPIMAGE_ENV, REDIRECT_OPTIONS)).toBeNull()
   })
 
   it('loses the redirect if the rewrite runs first', () => {

--- a/src/main/startup/serve-mode-argv.test.ts
+++ b/src/main/startup/serve-mode-argv.test.ts
@@ -107,6 +107,24 @@ describe('serve-mode-argv', () => {
     ])
   })
 
+  it('keeps Electron-injected Chromium switches while normalizing direct serve', () => {
+    expect(
+      normalizeServeModeArgv([
+        '/opt/orca/orca-ide',
+        '--disable-features=FedCm,DirectSockets',
+        'serve',
+        '--port',
+        '6768'
+      ])
+    ).toEqual([
+      '/opt/orca/orca-ide',
+      '--disable-features=FedCm,DirectSockets',
+      '--serve',
+      '--serve-port',
+      '6768'
+    ])
+  })
+
   it('leaves already-normalized argv unchanged', () => {
     // Why every value flag: the CLI's own `orca serve` spawns the app with exactly this shape
     // (serveOrcaApp), and the rewrite now runs over it too — a bad mapping would drop the port here.

--- a/src/main/startup/serve-mode-argv.ts
+++ b/src/main/startup/serve-mode-argv.ts
@@ -24,13 +24,14 @@ const CLI_TO_SERVE_VALUE_FLAG = new Map([
 /**
  * Flags that consume the next argv token as a value (CLI-form + Electron passthrough).
  * Residual class: a flag outside this list whose space-separated value is literally `serve` would
- * read as the subcommand. Chromium switches are `--flag=value` only, so no real launch does that.
+ * read as the subcommand. Include switches that may arrive in either argv shape.
  */
 const VALUE_TAKING_FLAGS = new Set([
   ...CLI_TO_SERVE_VALUE_FLAG.keys(),
   '--serve-port',
   '--serve-pairing-address',
   '--serve-project-root',
+  '--disable-features',
   '--user-data-dir',
   '--environment',
   '--pairing-code'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​94 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |

<!-- /orca-pr-loc -->

## Summary

Refs STA-6020 and GitHub #17412.

Linux AppImage launches receive Electron Chromium switches such as --disable-features=... before the serve subcommand. The AppImage CLI redirect was forwarding that switch into the strict Node CLI parser, so an otherwise valid serve launch failed with Unknown flag --disable-features for command: serve.

This change keeps affected direct serve launches in Electron, where the switch belongs, while preserving the existing validating CLI redirect for clean serve invocations.

## Deterministic reproduction

Baseline:
LIBGL_ALWAYS_SOFTWARE=1 stably-orca serve
or:
AppRun --disable-features=FedCm,DirectSockets serve --port 6768

The baseline redirect forwarded the Chromium switch to the CLI and exited 1 with the unknown-flag error.

Candidate:
- pre-command --disable-features makes the AppImage redirect return null;
- Electron normalizes serve --port 6768 to --serve --serve-port 6768;
- clean serve still goes through CLI validation.

## Changes

- Detect --disable-features in both equals and separate-value argv forms while locating the command.
- Keep only direct serve launches with that pre-command Chromium switch in Electron.
- Leave help handling and post-command flag validation unchanged.
- Add focused regression coverage for direct serve, help, clean CLI routing, launch ordering, and argv normalization.

## Validation

- Focused startup suites: 31 passed.
- Full src/main/startup: 304 passed, 6 skipped; two unrelated environment-sensitive timeout tests failed (secure-dns-census and the macOS-only Electron rebuild test).
- pnpm tc:node
- pnpm tc:cli
- pnpm run check:code-quality:changed
- pnpm run build:cli
- pnpm run build:electron-vite

All touched-code gates passed.

## Tradeoff

A user-supplied pre-command --disable-features is indistinguishable from Electron injection and therefore takes the Electron path, where unknown non-serve flags are permissive. Port and project-root validation remain active. This avoids globally weakening the CLI parser or changing remote/wire behavior.