### PR TITLE
fix(browser): show immediate feedback during reload

### DIFF
--- a/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-pane.tsx
+++ b/src/renderer/src/components/browser-pane/assemble-chrome/browser-page-pane.tsx
@@ -171,6 +171,7 @@ export function BrowserPagePane({
   useBrowserPageWebviewLifecycle({
     browserTabId: browserTab.id,
     browserTabUrl: browserTab.url,
+    browserTabLoading: browserTab.loading,
     browserTabLoadError: browserTab.loadError,
     workspaceId,
     worktreeId,
@@ -231,6 +232,7 @@ export function BrowserPagePane({
   const reload = useBrowserPageReloadActions({
     browserTab,
     webviewRef,
+    trackNextLoadingEventRef,
     retryGuestRecoveryRef,
     onUpdatePageStateRef
   })

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-webview-lifecycle.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-webview-lifecycle.ts
@@ -34,6 +34,7 @@ import type {
 export function useBrowserPageWebviewLifecycle({
   browserTabId,
   browserTabUrl,
+  browserTabLoading,
   browserTabLoadError,
   workspaceId,
   worktreeId,
@@ -75,6 +76,7 @@ export function useBrowserPageWebviewLifecycle({
 }: {
   browserTabId: string
   browserTabUrl: string
+  browserTabLoading: boolean
   browserTabLoadError: BrowserLoadError | null
   workspaceId: string
   worktreeId: string
@@ -120,6 +122,7 @@ export function useBrowserPageWebviewLifecycle({
   const guestRecoveryPendingRef = useRef(false)
   const validateVisibleGuestRegistrationRef = useRef<() => void>(() => {})
   const wasPaintableForGuestValidationRef = useRef(isPaintable)
+  const browserTabLoadingRef = useRef(browserTabLoading)
   const inputLockedRef = useRef(inputLocked)
   const faviconUrlRef = useRef<string | null>(faviconUrl)
   const initialBrowserUrlRef = useRef(browserTabUrl)
@@ -140,6 +143,7 @@ export function useBrowserPageWebviewLifecycle({
   const clearBrowserPageAnnotationsRef = useRef(clearBrowserPageAnnotations)
 
   useLayoutEffect(() => {
+    browserTabLoadingRef.current = browserTabLoading
     inputLockedRef.current = inputLocked
     viewportPresetIdRef.current = viewportPresetId
     isActiveRef.current = isActive
@@ -149,6 +153,7 @@ export function useBrowserPageWebviewLifecycle({
     isPaintableRef.current = isPaintable
   }, [
     browserAnnotations,
+    browserTabLoading,
     clearBrowserPageAnnotations,
     inputLocked,
     isActive,
@@ -185,12 +190,15 @@ export function useBrowserPageWebviewLifecycle({
   const syncNavigationState = useCallback(
     (webview: Electron.WebviewTag): void => {
       try {
+        // Parked panes miss guest events; only reconcile isLoading when the store already knows
+        // a navigation is active so an attach-time transient cannot flash a loading indicator.
+        const loading = browserTabLoadingRef.current ? webview.isLoading() : undefined
         onUpdatePageStateRef.current(browserTabId, {
           title: getBrowserDisplayTitle(
             webview.getTitle(),
             webview.getURL() || browserTabUrlRef.current
           ),
-          // Why: attach can transiently report isLoading() with no real navigation; syncing it would flash the loading dot on tab switches.
+          ...(loading === undefined ? {} : { loading }),
           canGoBack: webview.canGoBack(),
           canGoForward: webview.canGoForward()
         })

--- a/src/renderer/src/components/browser-pane/navigate/use-browser-page-reload-actions.test.tsx
+++ b/src/renderer/src/components/browser-pane/navigate/use-browser-page-reload-actions.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { BrowserPage } from '../../../../../shared/browser-workspace-types'
+import { useBrowserPageReloadActions } from './use-browser-page-reload-actions'
+
+vi.mock('@/hooks/useShortcutLabel', () => ({ useShortcutLabel: () => '' }))
+
+function createBrowserTab(overrides: Partial<BrowserPage> = {}): BrowserPage {
+  return {
+    id: 'page-a',
+    browserTabId: 'tab-a',
+    url: 'https://example.test/',
+    title: 'Example',
+    loading: false,
+    loadError: null,
+    faviconUrl: null,
+    canGoBack: false,
+    canGoForward: false,
+    ...overrides
+  } as BrowserPage
+}
+
+function createWebview(overrides: Partial<Electron.WebviewTag> = {}): Electron.WebviewTag {
+  return {
+    getWebContentsId: vi.fn(() => 42),
+    reload: vi.fn(),
+    reloadIgnoringCache: vi.fn(),
+    stop: vi.fn(),
+    ...overrides
+  } as unknown as Electron.WebviewTag
+}
+
+describe('useBrowserPageReloadActions', () => {
+  it('arms the lifecycle gate and exposes loading after an accepted reload', () => {
+    const webview = createWebview()
+    const trackNextLoadingEventRef = { current: false }
+    const onUpdatePageStateRef = { current: vi.fn() }
+    const view = renderHook(() =>
+      useBrowserPageReloadActions({
+        browserTab: createBrowserTab(),
+        webviewRef: { current: webview },
+        trackNextLoadingEventRef,
+        retryGuestRecoveryRef: { current: vi.fn() },
+        onUpdatePageStateRef
+      })
+    )
+
+    act(() => view.result.current.runReloadTrigger('button'))
+
+    expect(webview.reload).toHaveBeenCalledTimes(1)
+    expect(trackNextLoadingEventRef.current).toBe(true)
+    expect(onUpdatePageStateRef.current).toHaveBeenCalledWith('page-a', { loading: true })
+  })
+
+  it('does not strand loading when a live guest rejects reload before it is ready', () => {
+    const webview = createWebview({
+      reload: vi.fn(() => {
+        throw new Error('The WebView must be attached to the DOM')
+      })
+    })
+    const trackNextLoadingEventRef = { current: false }
+    const onUpdatePageStateRef = { current: vi.fn() }
+    const view = renderHook(() =>
+      useBrowserPageReloadActions({
+        browserTab: createBrowserTab(),
+        webviewRef: { current: webview },
+        trackNextLoadingEventRef,
+        retryGuestRecoveryRef: { current: vi.fn() },
+        onUpdatePageStateRef
+      })
+    )
+
+    act(() => view.result.current.runReloadTrigger('button'))
+
+    expect(trackNextLoadingEventRef.current).toBe(false)
+    expect(onUpdatePageStateRef.current).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/browser-pane/navigate/use-browser-page-reload-actions.ts
+++ b/src/renderer/src/components/browser-pane/navigate/use-browser-page-reload-actions.ts
@@ -14,11 +14,13 @@ import type { BrowserTabPageState } from '../describe-page/browser-page-types'
 export function useBrowserPageReloadActions({
   browserTab,
   webviewRef,
+  trackNextLoadingEventRef,
   retryGuestRecoveryRef,
   onUpdatePageStateRef
 }: {
   browserTab: BrowserPageState
   webviewRef: MutableRefObject<Electron.WebviewTag | null>
+  trackNextLoadingEventRef?: MutableRefObject<boolean>
   retryGuestRecoveryRef: MutableRefObject<() => void>
   onUpdatePageStateRef: MutableRefObject<(tabId: string, updates: BrowserTabPageState) => void>
 }): {
@@ -44,13 +46,30 @@ export function useBrowserPageReloadActions({
       if (!webview) {
         return
       }
-      if (reloadBrowserPageWebview(webview, { ignoreCache }) === 'guest-missing') {
+      if (trackNextLoadingEventRef) {
+        trackNextLoadingEventRef.current = true
+      }
+      const result = reloadBrowserPageWebview(webview, { ignoreCache })
+      if (result === 'reloaded') {
+        onUpdatePageStateRef.current(browserTab.id, { loading: true })
+      } else if (result === 'guest-missing') {
+        if (trackNextLoadingEventRef) {
+          trackNextLoadingEventRef.current = false
+        }
         // Why: reload cannot revive a destroyed guest (STA-3448) — recreate it instead.
         onUpdatePageStateRef.current(browserTab.id, { loading: true })
         retryGuestRecoveryRef.current()
+      } else if (trackNextLoadingEventRef) {
+        trackNextLoadingEventRef.current = false
       }
     },
-    [browserTab.id, onUpdatePageStateRef, retryGuestRecoveryRef, webviewRef]
+    [
+      browserTab.id,
+      onUpdatePageStateRef,
+      retryGuestRecoveryRef,
+      trackNextLoadingEventRef,
+      webviewRef
+    ]
   )
   const runReloadTrigger = useCallback(
     (trigger: BrowserReloadTrigger) => {

--- a/tests/e2e/browser-reload-feedback.spec.ts
+++ b/tests/e2e/browser-reload-feedback.spec.ts
@@ -1,0 +1,108 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { expect, test } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  getBrowserTabs,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  )
+}
+
+test('shows Stop and a spinner during a held reload, then returns to Reload', async ({
+  orcaPage
+}, testInfo) => {
+  let requestCount = 0
+  const reloadResolvers: (() => void)[] = []
+  let reloadReleased = false
+  let reloadRequestSeen: (() => void) | undefined
+  const secondRequest = new Promise<void>((resolve) => {
+    reloadRequestSeen = resolve
+  })
+  const server = createServer((request, response) => {
+    const pathname = new URL(request.url ?? '/', 'http://127.0.0.1').pathname
+    if (pathname !== '/held') {
+      response.writeHead(204).end()
+      return
+    }
+    requestCount += 1
+    response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    if (requestCount === 1) {
+      response.end('<!doctype html><title>Held reload</title><body>initial</body>')
+      return
+    }
+    reloadRequestSeen?.()
+    const release = (): void => {
+      response.end(`<!doctype html><title>Held reload</title><body>reloaded-${requestCount}</body>`)
+    }
+    if (reloadReleased) {
+      release()
+    } else {
+      new Promise<void>((resolve) => reloadResolvers.push(resolve)).then(release)
+    }
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/held`
+  try {
+    await waitForSessionReady(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    const worktreeId = await waitForActiveWorktree(orcaPage)
+    const tab = await orcaPage.evaluate(
+      ({ worktreeId, url }) => {
+        const created = window.__store?.getState().createBrowserTab(worktreeId, url, {
+          title: 'Held reload',
+          activate: true
+        })
+        return created ? { id: created.id, url: created.url } : null
+      },
+      { worktreeId, url }
+    )
+    if (!tab) {
+      throw new Error('browser tab was not created')
+    }
+    const pane = orcaPage.locator(`[data-browser-overlay-tab-id="${tab.id}"]`)
+    const reload = pane.getByRole('button', { name: 'Reload' })
+    await expect(reload).toBeVisible({ timeout: 20_000 })
+    await reload.click()
+    await secondRequest
+    await expect
+      .poll(async () => (await getBrowserTabs(orcaPage, worktreeId)).at(-1)?.url, {
+        timeout: 20_000
+      })
+      .toBe(url)
+    const getLoading = (): Promise<boolean | null> =>
+      orcaPage.evaluate(
+        ({ worktreeId, tabId }) => {
+          const tab = window.__store
+            ?.getState()
+            .browserTabsByWorktree[worktreeId]?.find((entry) => entry.id === tabId)
+          return tab?.loading ?? null
+        },
+        { worktreeId, tabId: tab.id }
+      )
+    await expect.poll(getLoading, { timeout: 10_000 }).toBe(true)
+    const stop = pane.getByRole('button', { name: 'Stop' })
+    await expect(stop).toBeVisible({ timeout: 10_000 })
+    await expect(stop.locator('svg')).toHaveAttribute('class', /animate-spin/)
+    await orcaPage.screenshot({ path: testInfo.outputPath('reload-held.png') })
+    reloadReleased = true
+    reloadResolvers.splice(0).forEach((resolve) => resolve())
+    await expect(pane.getByRole('button', { name: 'Reload' })).toBeVisible({ timeout: 20_000 })
+    await expect.poll(getLoading, { timeout: 10_000 }).toBe(false)
+    const body = await pane
+      .locator('webview')
+      .evaluate((webview) =>
+        (webview as Electron.WebviewTag).executeJavaScript('document.body.textContent')
+      )
+    expect(body).toContain('reloaded')
+  } finally {
+    reloadReleased = true
+    reloadResolvers.splice(0).forEach((resolve) => resolve())
+    await closeServer(server)
+  }
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​187 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​187 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |

<!-- /orca-pr-loc -->

## Summary

- Fixes local embedded-browser reloads that remained visually idle while Chromium was still loading.
- Keeps the existing browser navigation lifecycle as the source of truth and preserves Stop/Reload semantics.

## What was broken

The local webview `did-start-loading` handler is intentionally gated by `trackNextLoadingEventRef`. URL navigations arm that gate, but accepted reloads did not. A delayed reload therefore left the persisted tab state at `loading: false`, so the toolbar continued to show Reload.

## Fix

- Arm the existing local loading-event gate before calling `webview.reload()` / `reloadIgnoringCache()`.
- Set `BrowserPage.loading` to true immediately after an accepted reload.
- Clear the temporary gate for guest-missing and not-ready outcomes.
- On parked-pane reattach, reconcile `webview.isLoading()` only when the store already says a navigation is active, using a stable ref to avoid listener teardown/rebind races.
- Client-hosted and remote/server-hosted paths remain unchanged.

## Reproduction and proof

Added a deterministic local HTTP fixture whose second `/held` response waits on an explicit resolver barrier (no arbitrary sleeps). Baseline/reverted source stayed at Reload/non-spinning/loading=false after the reload request began. The candidate showed Stop, an animated Loader2, and loading=true until the barrier was released, then returned to Reload/loading=false with the reloaded body.

![reload-held.png](https://github.com/user-attachments/assets/92c14031-14c7-471e-a2af-bec6fbcdc79d)

## Tests

- `pnpm test src/renderer/src/components/browser-pane/navigate/browser-reload-action.test.ts src/renderer/src/components/browser-pane/navigate/use-browser-page-reload-actions.test.tsx src/renderer/src/components/browser-pane/assemble-chrome/browser-navigation-control-row.test.tsx src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.chrome-parity.test.tsx` (33 passed)
- `pnpm exec playwright test tests/e2e/browser-reload-feedback.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1` (passed)
- Existing browser reload/zoom E2E in `tests/e2e/browser-tab.spec.ts` (2 passed)
- `pnpm tc` and `pnpm tc:web` (passed)
- `pnpm run check:code-quality:changed` (passed)
- `pnpm typecheck:e2e` still reports unrelated pre-existing repository-wide typing errors.

## Tradeoffs

This is intentionally scoped to local embedded guests. It adds no timer, polling, duplicate navigation state, wire field, or remote protocol change. The only behavioral risk is the small accepted-reload window before Chromium emits lifecycle events; the gate and did-stop/did-fail cleanup keep the icon tied to actual navigation, while parked-pane reconciliation covers missed events.