### PR TITLE
perf(wsl): warn at project-add when the tree sits on a Windows drive

### DIFF
--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -477,7 +477,9 @@
           "15cf5319ec": "{{path}} was checked on {{hostName}}, but that host did not report a usable folder.",
           "2dcd706774": "Project also exists in another profile",
           "presenceProfileOverflow": "{{names}} +{{count}} more",
-          "removeProjectFailed": "Failed to remove project"
+          "removeProjectFailed": "Failed to remove project",
+          "wslFilesystemBoundaryTitle": "This project is stored on a Windows drive",
+          "wslFilesystemBoundaryDescription": "Git for this project runs in {{distro}}, which reaches Windows drives over the WSL filesystem bridge. Expect git to be roughly 20x slower than it would be on a copy stored inside {{distro}}."
         },
         "settings": {
           "e12dab333b": "Failed to switch servers",

--- a/src/renderer/src/store/projects/project-wsl-filesystem-boundary-advisory.test.ts
+++ b/src/renderer/src/store/projects/project-wsl-filesystem-boundary-advisory.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { Project } from '../../../../shared/project-types'
+import type { Repo } from '../../../../shared/repo-types'
+
+const { warningMock } = vi.hoisted(() => ({ warningMock: vi.fn() }))
+
+vi.mock('sonner', () => ({ toast: { warning: warningMock } }))
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, vars?: Record<string, string>) =>
+    fallback.replace(/\{\{(\w+)\}\}/g, (_match, name: string) => vars?.[name] ?? '')
+}))
+
+import { warnIfProjectCrossesWslFilesystemBoundary } from './project-wsl-filesystem-boundary-advisory'
+
+const WSL_DEFAULT = {
+  localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu-24.04' }
+} as unknown as GlobalSettings
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return { id: 'repo-1', path: 'C:\\Users\\alice\\orca', ...overrides } as Repo
+}
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return { id: 'project-1', sourceRepoIds: ['repo-1'], ...overrides } as Project
+}
+
+describe('warnIfProjectCrossesWslFilesystemBoundary', () => {
+  beforeEach(() => {
+    warningMock.mockReset()
+  })
+
+  it('warns and names the distro when a Windows-drive project runs WSL git', () => {
+    warnIfProjectCrossesWslFilesystemBoundary(makeRepo(), [makeProject()], WSL_DEFAULT)
+
+    expect(warningMock).toHaveBeenCalledTimes(1)
+    expect(warningMock.mock.calls[0]?.[1]?.description).toContain('Ubuntu-24.04')
+  })
+
+  // The project override is what actually routes git, so it must beat the global default here too.
+  it('respects a project override that pins the project back to the Windows host', () => {
+    warnIfProjectCrossesWslFilesystemBoundary(
+      makeRepo(),
+      [makeProject({ localWindowsRuntimePreference: { kind: 'windows-host' } })],
+      WSL_DEFAULT
+    )
+
+    expect(warningMock).not.toHaveBeenCalled()
+  })
+
+  it('warns from a project override even when the global default is the Windows host', () => {
+    warnIfProjectCrossesWslFilesystemBoundary(
+      makeRepo(),
+      [makeProject({ localWindowsRuntimePreference: { kind: 'wsl', distro: 'Debian' } })],
+      { localWindowsRuntimeDefault: { kind: 'windows-host' } } as unknown as GlobalSettings
+    )
+
+    expect(warningMock.mock.calls[0]?.[1]?.description).toContain('Debian')
+  })
+
+  it('stays silent for a project already inside the distro', () => {
+    warnIfProjectCrossesWslFilesystemBoundary(
+      makeRepo({ path: '\\\\wsl.localhost\\Ubuntu-24.04\\home\\alice\\orca' }),
+      [makeProject()],
+      WSL_DEFAULT
+    )
+
+    expect(warningMock).not.toHaveBeenCalled()
+  })
+
+  // Why: the Windows runtime preference governs local projects only; an SSH path that happens to
+  // look Windows-shaped is a different host's filesystem.
+  it('stays silent for a repo on a remote execution host', () => {
+    warnIfProjectCrossesWslFilesystemBoundary(
+      makeRepo({ connectionId: 'ssh-1' }),
+      [makeProject()],
+      WSL_DEFAULT
+    )
+
+    expect(warningMock).not.toHaveBeenCalled()
+  })
+
+  it('stays silent when the WSL default has no distro to repair to', () => {
+    warnIfProjectCrossesWslFilesystemBoundary(makeRepo(), [makeProject()], {
+      localWindowsRuntimeDefault: { kind: 'wsl', distro: null }
+    } as unknown as GlobalSettings)
+
+    expect(warningMock).not.toHaveBeenCalled()
+  })
+
+  it('never throws when the advisory itself fails', () => {
+    const repo = makeRepo()
+    Object.defineProperty(repo, 'path', {
+      get: () => {
+        throw new Error('unreadable path')
+      }
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(() =>
+      warnIfProjectCrossesWslFilesystemBoundary(repo, [makeProject()], WSL_DEFAULT)
+    ).not.toThrow()
+    expect(warningMock).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+})

--- a/src/renderer/src/store/projects/project-wsl-filesystem-boundary-advisory.ts
+++ b/src/renderer/src/store/projects/project-wsl-filesystem-boundary-advisory.ts
@@ -1,0 +1,74 @@
+import { toast } from 'sonner'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { Project } from '../../../../shared/project-types'
+import type { Repo } from '../../../../shared/repo-types'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+import { getWslFilesystemBoundaryDistro } from '../../../../shared/wsl-paths'
+import { resolveProjectExecutionRuntime } from '../../../../shared/project-execution-runtime'
+import { translate } from '@/i18n/i18n'
+
+type BoundaryAdvisorySettings = Pick<GlobalSettings, 'localWindowsRuntimeDefault'>
+
+/** The distro this project's git runs in, or null when it runs on the Windows host or elsewhere. */
+function getProjectWslRuntimeDistro(
+  repo: Repo,
+  projects: readonly Project[],
+  settings: BoundaryAdvisorySettings
+): string | null {
+  const project = projects.find((candidate) => candidate.sourceRepoIds.includes(repo.id))
+  const resolution = resolveProjectExecutionRuntime({
+    // Why win32 unconditionally: a non-Windows host cannot produce a drive or WSL UNC repo path, so
+    // the boundary check below rejects it regardless of what platform we claim here.
+    appPlatform: 'win32',
+    projectId: project?.id ?? repo.id,
+    projectRuntimePreference: project?.localWindowsRuntimePreference,
+    globalWindowsRuntimeDefault: settings.localWindowsRuntimeDefault
+  })
+  // Why not warn on repair-required: the runtime is unusable, and a perf advisory on top of the
+  // repair prompt is noise.
+  return resolution.status === 'resolved' && resolution.runtime.kind === 'wsl'
+    ? resolution.runtime.distro
+    : null
+}
+
+/**
+ * Advises that a just-added project's working tree sits on the Windows drive while its git runs in
+ * WSL, so every command pays the 9p/drvfs crossing.
+ *
+ * Worktree placement already moves NEW workspaces inside the distro, but the project's own tree
+ * stays where the user put it and that cost is otherwise invisible — the project simply feels slow.
+ */
+export function warnIfProjectCrossesWslFilesystemBoundary(
+  repo: Repo,
+  projects: readonly Project[],
+  settings: BoundaryAdvisorySettings | null
+): void {
+  try {
+    if (!settings || getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID) {
+      return
+    }
+    const distro = getWslFilesystemBoundaryDistro({
+      projectPath: repo.path,
+      wslRuntimeDistro: getProjectWslRuntimeDistro(repo, projects, settings)
+    })
+    if (!distro) {
+      return
+    }
+    toast.warning(
+      translate(
+        'auto.store.slices.repos.wslFilesystemBoundaryTitle',
+        'This project is stored on a Windows drive'
+      ),
+      {
+        description: translate(
+          'auto.store.slices.repos.wslFilesystemBoundaryDescription',
+          'Git for this project runs in {{distro}}, which reaches Windows drives over the WSL filesystem bridge. Expect git to be roughly 20x slower than it would be on a copy stored inside {{distro}}.',
+          { distro }
+        )
+      }
+    )
+  } catch (err) {
+    // Why: adding a project should not fail because a performance advisory could not be computed.
+    console.warn('Failed to check WSL filesystem boundary for added project:', err)
+  }
+}

--- a/src/renderer/src/store/repos/repo-add-actions.ts
+++ b/src/renderer/src/store/repos/repo-add-actions.ts
@@ -24,6 +24,7 @@ import {
 } from './owner-routing'
 import { mergeProjectCompatibilityForHostRepoChange } from './repo-catalog-identity'
 import { warnIfProjectKnownInAnotherProfile } from '../projects/project-profile-presence'
+import { warnIfProjectCrossesWslFilesystemBoundary } from '../projects/project-wsl-filesystem-boundary-advisory'
 
 export function createRepoAddActions(
   set: Parameters<StateCreator<AppState>>[0],
@@ -128,6 +129,8 @@ export function createRepoAddActions(
           )
           // Why: the cross-profile advisory applies to SSH-added projects too; the presence lookup already keys on connection/host.
           await warnIfProjectKnownInAnotherProfile(repo, get().activeOrcaProfileId)
+          // Why after the set(): the project row carrying the runtime override only exists once the repo is in state.
+          warnIfProjectCrossesWslFilesystemBoundary(repo, get().projects, get().settings)
         }
         return repo
       } catch (err) {

--- a/src/shared/wsl-paths.test.ts
+++ b/src/shared/wsl-paths.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   foldWslUncPathCaseInsensitiveParts,
+  getWslFilesystemBoundaryDistro,
+  isDrvfsLinuxPath,
   isWslUncPath,
   parseWslUncPath,
   resolveWslRepoWorktreeBasePath,
@@ -114,5 +116,60 @@ describe('foldWslUncPathCaseInsensitiveParts', () => {
     expect(foldWslUncPathCaseInsensitiveParts('C:\\Users\\jin')).toBeNull()
     expect(foldWslUncPathCaseInsensitiveParts('//server/share/x')).toBeNull()
     expect(foldWslUncPathCaseInsensitiveParts('/home/jin')).toBeNull()
+  })
+})
+
+describe('getWslFilesystemBoundaryDistro', () => {
+  it('names the runtime distro for a Windows drive project running WSL git', () => {
+    expect(
+      getWslFilesystemBoundaryDistro({
+        projectPath: 'C:\\Users\\alice\\orca',
+        wslRuntimeDistro: 'Ubuntu-24.04'
+      })
+    ).toBe('Ubuntu-24.04')
+  })
+
+  it('stays silent for a Windows drive project running host git', () => {
+    for (const wslRuntimeDistro of [undefined, null, '']) {
+      expect(
+        getWslFilesystemBoundaryDistro({ projectPath: 'C:/Users/alice/orca', wslRuntimeDistro })
+      ).toBeNull()
+    }
+  })
+
+  it('stays silent for a project already inside the distro', () => {
+    expect(
+      getWslFilesystemBoundaryDistro({
+        projectPath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\orca',
+        wslRuntimeDistro: 'Ubuntu'
+      })
+    ).toBeNull()
+  })
+
+  // The UNC spelling of drvfs is still the Windows drive, so it crosses the boundary even though
+  // the path names no runtime preference at all.
+  it('names the path distro for the UNC spelling of a drvfs mount', () => {
+    expect(
+      getWslFilesystemBoundaryDistro({
+        projectPath: '\\\\wsl.localhost\\Ubuntu\\mnt\\c\\Users\\alice\\orca'
+      })
+    ).toBe('Ubuntu')
+  })
+
+  it('stays silent for POSIX, relative, and plain UNC share paths', () => {
+    for (const projectPath of ['/home/alice/orca', 'orca', '\\\\fileserver\\share\\orca']) {
+      expect(getWslFilesystemBoundaryDistro({ projectPath, wslRuntimeDistro: 'Ubuntu' })).toBeNull()
+    }
+  })
+})
+
+describe('isDrvfsLinuxPath', () => {
+  it('accepts the automount root and its descendants only', () => {
+    expect(isDrvfsLinuxPath('/mnt/c')).toBe(true)
+    expect(isDrvfsLinuxPath('/mnt/c/Users')).toBe(true)
+    expect(isDrvfsLinuxPath('/mnt/cdrom')).toBe(false)
+    // Why: /MNT and /mnt/C are ordinary case-sensitive Linux directories, not the drvfs automount.
+    expect(isDrvfsLinuxPath('/MNT/c')).toBe(false)
+    expect(isDrvfsLinuxPath('/mnt/C/Users')).toBe(false)
   })
 })

--- a/src/shared/wsl-paths.ts
+++ b/src/shared/wsl-paths.ts
@@ -126,3 +126,36 @@ export function foldWslUncPathCaseInsensitiveParts(path: string): string | null 
 export function toWslExecutionSpace(path: string): string {
   return parseWslUncPath(path)?.linuxPath ?? path
 }
+
+/** The drvfs automount is literally lowercase `/mnt/<letter>`; `/MNT` is an ordinary Linux dir. */
+const DRVFS_LINUX_PATH = /^\/mnt\/[a-z](?:\/|$)/
+
+/** True for a Linux path that is really a Windows drive reached through drvfs. */
+export function isDrvfsLinuxPath(linuxPath: string): boolean {
+  return DRVFS_LINUX_PATH.test(linuxPath)
+}
+
+/**
+ * The distro whose git would reach `projectPath` across the 9p/drvfs boundary, or null when it
+ * would not.
+ *
+ * Two shapes cross it. A Windows drive path (`C:\...`) crosses it whenever the project's runtime is
+ * WSL. The UNC spelling of a distro's own drvfs mount (`\\wsl.localhost\Ubuntu\mnt\c\...`) crosses
+ * it however the runtime is set, because the bytes sit on the Windows drive either way.
+ *
+ * Everything else returns null: a real Linux path inside the distro, a drive path under Windows-host
+ * git, a plain UNC share (not mounted in the distro at all), and any POSIX or SSH path.
+ */
+export function getWslFilesystemBoundaryDistro(args: {
+  projectPath: string
+  wslRuntimeDistro?: string | null
+}): string | null {
+  const wsl = parseWslUncPath(args.projectPath)
+  if (wsl) {
+    return isDrvfsLinuxPath(wsl.linuxPath) ? wsl.distro : null
+  }
+  if (!/^[A-Za-z]:[\\/]/.test(args.projectPath)) {
+    return null
+  }
+  return args.wslRuntimeDistro || null
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​163 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​163 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​112 |

<!-- /orca-pr-loc -->

## Why

#17387 moved **new worktrees** inside the distro when a project's git runs in WSL. It cannot move the project's own tree — that lives wherever the user put it. A repo sitting on `C:\` under a WSL runtime keeps paying the 9p/drvfs crossing on every command, and nothing in the UI says so. The project just feels slow.

Measured clean-vs-clean on a real Windows machine (`/mnt/c` vs ext4, same tree, same distro):

| operation | slowdown |
| --- | --- |
| `git status` | ~20x |
| `git add -A` | ~31x |
| `git worktree add` | ~26x |

## What

One advisory toast right after the add succeeds, naming the distro the project's git actually resolves to. It hangs off `addRepoPath` — the single choke point every local add path converges on — next to the existing cross-profile advisory, and is wrapped so it can never fail the add.

**Two shapes cross the boundary, and both warn:**
- a Windows drive path (`C:\...`) when the project's resolved runtime is WSL
- the UNC spelling of a distro's own drvfs mount (`\\wsl.localhost\Ubuntu\mnt\c\...`), which crosses it *however* the runtime is set — the bytes are on the Windows drive either way

**Stays silent for:** a tree already inside the distro, a drive path under Windows-host git, a project override that pins the project back to the Windows host, a WSL default with no distro to repair to (that's a repair prompt's job, not a perf nag), a plain UNC share (`\\fileserver\...` — not mounted in the distro at all), and every POSIX/SSH path.

The runtime comes from `resolveProjectExecutionRuntime`, so a **project override beats the global default in both directions**: an override to `windows-host` silences the warning even when the global default is WSL, and an override to WSL fires it even when the global default is the Windows host.

## Scope notes

- **SSH / remote hosts:** gated on `LOCAL_EXECUTION_HOST_ID`. The Windows runtime preference governs local projects only; a remote path that happens to look Windows-shaped is a different host's filesystem.
- **Folder workspaces:** the advisory is path-shape-based, not git-based, so a non-git folder on `C:\` under a WSL runtime warns too. That is correct — the 9p cost is a filesystem property.
- **Platform:** `appPlatform: 'win32'` is passed unconditionally, which is safe because a non-Windows host cannot produce a drive-letter or WSL UNC repo path — the boundary check rejects it regardless. This deliberately avoids depending on `navigator.userAgent`, which reports the *browser's* platform in the web client, not the execution host's.

## Tests

- `src/shared/wsl-paths.test.ts` — 2 new suites over `getWslFilesystemBoundaryDistro` / `isDrvfsLinuxPath`, including the case-sensitivity corners (`/MNT/c` and `/mnt/C` are ordinary Linux dirs, not the automount; `/mnt/cdrom` is not `/mnt/c`).
- `src/renderer/src/store/projects/project-wsl-filesystem-boundary-advisory.test.ts` — 7 cases: fires and names the distro, both override directions, inside-the-distro, remote host, distro-less WSL default, and never-throws.

Verified locally: `vitest` (new + `store/repos`, `store/projects`, `repos-add-races`, `repos-paired-runtime-add`, i18n regression) all pass; `tsc -p config/tsconfig.node.json` and `config/tsconfig.tc.web.json` clean; `oxlint` and `oxfmt --check` clean.

Visual proof to follow in a comment.