### PR TITLE
test(git): pin FETCH_HEAD lock order in the admission lifetime test

### DIFF
--- a/src/main/git/command-runner/git-exec-admission-lifetime.test.ts
+++ b/src/main/git/command-runner/git-exec-admission-lifetime.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events'
 import type { ChildProcess } from 'node:child_process'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as GitFetchHeadLockModule from '../../../shared/git-fetch-head-lock'
 
 const {
   execFileMock,
@@ -28,6 +29,22 @@ vi.mock('../../../shared/child-process/process-tree-termination', () => ({
   signalProcessTree: signalProcessTreeMock,
   forceTerminateProcessTree: forceTerminateProcessTreeMock
 }))
+// Why: the real FETCH_HEAD key derivation walks the filesystem (realpath/stat/readFile), so
+// concurrent same-repo callers join the lock lane in libuv threadpool completion order rather
+// than call order. Keep the real FIFO lock and drop only the key walk, which owns its coverage
+// in `src/shared/git-fetch-head-lock.test.ts`.
+vi.mock('../../../shared/git-fetch-head-lock', async (importOriginal) => {
+  const actual = await importOriginal<typeof GitFetchHeadLockModule>()
+  const { runWithGitOperationLock } = await import('../../../shared/git-operation-lock')
+  return {
+    ...actual,
+    runWithGitFetchHeadLock: <T>(
+      worktreePath: string,
+      signal: AbortSignal | undefined,
+      run: () => Promise<T>
+    ): Promise<T> => runWithGitOperationLock(worktreePath, signal, run)
+  }
+})
 
 import { gitExecFileAsync, gitExecFileAsyncBuffer } from './git-exec-file'
 import { execFileCapture } from './exec-file-capture'


### PR DESCRIPTION
## Root cause

`git-exec-admission-lifetime.test.ts` > `serializes FETCH_HEAD callers before they enter admission` assumed that two same-repo fetches issued back to back join the FETCH_HEAD lock lane in call order. They do not.

`runWithGitFetchHeadLock` first `await`s `fetchLockPath`, which walks the filesystem — `realpath(worktree)`, a `stat` per parent directory up to `/`, `readFile` of `commondir`, then `realpath` again — and only calls `runWithGitOperationLock` (which registers the lane synchronously) after that walk resolves. For the test's non-existent `/repo` that is five libuv threadpool round-trips per caller. The two callers run their chains concurrently, so lane order is **threadpool completion order, not call order**.

When the `interactive` fetch won that race, it entered the lock lane ahead of the `background` fetch. As soon as the first fetch released the lock, `interactive` reached admission, and because its tier is interactive it took the free network **headroom** slot immediately instead of queueing — while the `background` fetch stayed parked on the lock and never entered admission at all. So `queued` settled at `0` and never reached the asserted `1`, and `vi.waitFor` timed out.

Instrumented failure state confirms it exactly:

```
DEBUG callbacks [ 'first', 'interactive' ]
{"queued":0,"budgets":{"network":{"baseUsed":1,"headroomUsed":1}}}
```

This is a test-premise defect, not a scheduler bug. The scheduler behaved correctly in both orderings; only one of the two orderings matches what the test asserts.

## Evidence it was a flake, not a regression

- Failed on **#17530** (pruned `node_modules` source maps) and **#17630** (YAML workflow only) — two changes that cannot touch git admission.
- Both failures at the **same place**: `git-exec-admission-lifetime.test.ts:221:75`, `AssertionError: expected +0 to be 1`, with 1 failed / ~899 passed.
- Reproduced locally on `main`: **5/20** failures, always at 221:75 with the same message.
- A standalone probe of just the lock-path walk inverted the completion order of two concurrent same-repo callers **54/500 times on an idle machine**.

## Fix

Fix the premise rather than the symptom — no timeout bump, no retry, no weakened assertion. The test file now stubs *only* the FETCH_HEAD **key derivation**, delegating to the real `runWithGitOperationLock`. The FIFO lock that the test actually exercises stays real, and the lane is now registered synchronously with the call, so lock order is call order.

Key derivation keeps its own coverage in `src/shared/git-fetch-head-lock.test.ts`; this file has never been the place that verifies it. Two incidental improvements fall out: the fetch tests in this file no longer share one global `/.git/FETCH_HEAD` lane with each other, and they no longer issue real filesystem syscalls against `/` from a unit test.

## Determinism proof

| Scenario | Result |
| --- | --- |
| `git-exec-admission-lifetime.test.ts` alone | **40/40 pass** |
| Same, after the final refactor | **30/30 pass** |
| Same, under load — 12 CPU hogs + a concurrent `src/main/git/command-runner/` vitest run | **25/25 pass** |
| Full `src/main/git/command-runner/` directory | 9 files, 57 passed / 1 skipped |
| `src/shared/git-fetch-head-lock.test.ts` (unaffected) | 12 passed |

`pnpm exec oxlint` on the changed file and `pnpm tc` both clean.

## Follow-up worth considering (not in this PR)

The same fs-walk race exists in production: two same-repo fetches acquire the FETCH_HEAD lock in threadpool completion order rather than call order. It is not a correctness bug — mutual exclusion still holds — and the exposure is narrow: it only shuffles arrivals issued within the same sub-millisecond window, since outside that window the walk completes in call order anyway.

Worth being precise about what a fix would and would not buy, so nobody over-values it: `runWithGitOperationLock` is **pure FIFO with no tier awareness at all**, so the FETCH_HEAD lock already sits as a priority inversion in front of the tiered, aging-aware admission scheduler by design — an interactive fetch issued after a background fetch on the same repo waits behind it regardless. Memoizing the in-flight lock-path resolution per worktree would make lane order *deterministic* and skip a repeated 5-syscall walk per fetch; it would **not** restore tiered priority. That would take a tier-aware FETCH_HEAD lock, which is a much larger design. Left out here because sharing an in-flight resolution across callers with different `AbortSignal`s needs its own design too.

