### PR TITLE
fix(remote): persist Web terminal custom titles

### DIFF
--- a/src/main/runtime/mobile-session-terminal-projection.ts
+++ b/src/main/runtime/mobile-session-terminal-projection.ts
@@ -36,6 +36,7 @@ export function buildHeadlessMobileSessionTerminalTabs(
             parentTabId: tab.id,
             leafId,
             title,
+            customTitle: tab.customTitle,
             ...(ptyId ? { ptyId } : {}),
             ...(tab.startupCwd ? { startupCwd: tab.startupCwd } : {}),
             ...(tab.launchAgent ? { launchAgent: tab.launchAgent } : {}),

--- a/src/main/runtime/orca-runtime-close-headless-mobile-terminal-tab.ts
+++ b/src/main/runtime/orca-runtime-close-headless-mobile-terminal-tab.ts
@@ -199,14 +199,14 @@ export class OrcaRuntimeWithCloseHeadlessMobileTerminalTab extends OrcaRuntimeWi
     return { updated: true }
   }
 
-  // Why: tab color/pin are host-authoritative for remote-server tabs but had no
-  // push path, so pinning or coloring a tab reverted on the next snapshot and
-  // was never persisted. Persist to the workspace session + live snapshot.
+  // Why: remote-server tab props are host-authoritative; persist client writes
+  // to the workspace session and live snapshot so reconnects cannot revert them.
   async setMobileSessionTabProps(
     worktreeSelector: string,
     args: {
       tabId: string
       color?: string | null
+      customTitle?: string | null
       isPinned?: boolean
       viewMode?: 'terminal' | 'chat'
     }

--- a/src/main/runtime/orca-runtime-persist-headless-session-tab-props.ts
+++ b/src/main/runtime/orca-runtime-persist-headless-session-tab-props.ts
@@ -15,7 +15,12 @@ export class OrcaRuntimeWithPersistHeadlessSessionTabProps extends OrcaRuntimeWi
   protected persistHeadlessSessionTabProps(
     worktreeId: string,
     tabId: string,
-    props: { color?: string | null; isPinned?: boolean; viewMode?: 'terminal' | 'chat' }
+    props: {
+      color?: string | null
+      customTitle?: string | null
+      isPinned?: boolean
+      viewMode?: 'terminal' | 'chat'
+    }
   ): void {
     const session = this.getWorkspaceSessionForWorktree(worktreeId)
     if (!session || !this.store?.setWorkspaceSession) {
@@ -33,6 +38,7 @@ export class OrcaRuntimeWithPersistHeadlessSessionTabProps extends OrcaRuntimeWi
             ? {
                 ...tab,
                 ...(props.color !== undefined ? { color: props.color } : {}),
+                ...(props.customTitle !== undefined ? { customTitle: props.customTitle } : {}),
                 ...(props.isPinned !== undefined ? { isPinned: props.isPinned } : {}),
                 ...(props.viewMode !== undefined ? { viewMode: props.viewMode } : {})
               }
@@ -51,6 +57,9 @@ export class OrcaRuntimeWithPersistHeadlessSessionTabProps extends OrcaRuntimeWi
             ? {
                 ...tab,
                 ...(props.color !== undefined ? { color: props.color } : {}),
+                ...(props.customTitle !== undefined && tab.contentType === 'terminal'
+                  ? { customLabel: props.customTitle }
+                  : {}),
                 ...(props.isPinned !== undefined ? { isPinned: props.isPinned } : {})
               }
             : tab
@@ -67,12 +76,21 @@ export class OrcaRuntimeWithPersistHeadlessSessionTabProps extends OrcaRuntimeWi
   protected applyHeadlessSessionTabPropsToSnapshot(
     worktreeId: string,
     tabId: string,
-    props: { color?: string | null; isPinned?: boolean; viewMode?: 'terminal' | 'chat' }
+    props: {
+      color?: string | null
+      customTitle?: string | null
+      isPinned?: boolean
+      viewMode?: 'terminal' | 'chat'
+    }
   ): void {
     const snapshot = this.mobileSessionTabsByWorktree.get(worktreeId)
     if (!snapshot) {
       return
     }
+    const persistedTitle =
+      props.customTitle !== undefined
+        ? this.resolvePersistedHeadlessTerminalTitle(worktreeId, tabId)
+        : null
     let changed = false
     const tabs = snapshot.tabs.map((tab) => {
       if (this.getMobileSessionTopLevelTabId(tab) !== tabId) {
@@ -82,6 +100,12 @@ export class OrcaRuntimeWithPersistHeadlessSessionTabProps extends OrcaRuntimeWi
       return {
         ...tab,
         ...(props.color !== undefined ? { color: props.color } : {}),
+        ...(props.customTitle !== undefined && tab.type === 'terminal'
+          ? {
+              customTitle: props.customTitle,
+              ...(persistedTitle ? { title: persistedTitle } : {})
+            }
+          : {}),
         ...(props.isPinned !== undefined ? { isPinned: props.isPinned } : {}),
         ...(props.viewMode !== undefined ? { viewMode: props.viewMode } : {})
       }
@@ -97,6 +121,25 @@ export class OrcaRuntimeWithPersistHeadlessSessionTabProps extends OrcaRuntimeWi
     }
     this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
     this.emitMobileSessionTabsSnapshot(nextSnapshot)
+  }
+
+  private resolvePersistedHeadlessTerminalTitle(worktreeId: string, tabId: string): string | null {
+    const tabs = this.getWorkspaceSessionForWorktree(worktreeId)?.tabsByWorktree[worktreeId]
+    const sortedTabs = tabs
+      ? [...tabs].sort((a, b) => a.sortOrder - b.sortOrder || a.createdAt - b.createdAt)
+      : undefined
+    const index = sortedTabs?.findIndex((tab) => tab.id === tabId) ?? -1
+    const tab = index >= 0 ? sortedTabs?.[index] : undefined
+    if (!tab) {
+      return null
+    }
+    return (
+      tab.customTitle?.trim() ||
+      tab.generatedTitle?.trim() ||
+      tab.title?.trim() ||
+      tab.defaultTitle?.trim() ||
+      `Terminal ${index + 1}`
+    )
   }
 
   protected getMobileSessionTopLevelTabId(tab: RuntimeMobileSessionSnapshotTab): string {

--- a/src/main/runtime/rpc/methods/session-tab-agent-capability-mutations.test.ts
+++ b/src/main/runtime/rpc/methods/session-tab-agent-capability-mutations.test.ts
@@ -75,6 +75,22 @@ describe('session tab structured capability mutations', () => {
       expect(fixture.calls[method.runtimeMethod]).not.toHaveBeenCalled()
     })
   }
+
+  it('forwards customTitle through the existing setTabProps mutation', async () => {
+    const fixture = createFixture([STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY])
+
+    const response = await fixture.dispatch('session.tabs.setTabProps', {
+      worktree: 'id:wt-1',
+      tabId: 'codex-session',
+      customTitle: 'Shared build'
+    })
+
+    expect(response.ok).toBe(true)
+    expect(fixture.calls.setMobileSessionTabProps).toHaveBeenCalledWith('id:wt-1', {
+      tabId: 'codex-session',
+      customTitle: 'Shared build'
+    })
+  })
 })
 
 function createFixture(capabilities: RuntimeCapability[]) {

--- a/src/main/runtime/rpc/methods/session-tab-mutation-methods.ts
+++ b/src/main/runtime/rpc/methods/session-tab-mutation-methods.ts
@@ -106,6 +106,7 @@ export const SESSION_TAB_MUTATION_METHODS: RpcAnyMethod[] = [
       return runtime.setMobileSessionTabProps(params.worktree, {
         tabId: params.tabId,
         ...(params.color !== undefined ? { color: params.color } : {}),
+        ...(params.customTitle !== undefined ? { customTitle: params.customTitle } : {}),
         ...(params.isPinned !== undefined ? { isPinned: params.isPinned } : {}),
         ...(params.viewMode !== undefined ? { viewMode: params.viewMode } : {})
       })

--- a/src/main/runtime/rpc/methods/session-tabs-schemas.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-schemas.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { ActivateTab, CloseLifecycleTab, CloseTab, UpdatePaneLayout } from './session-tabs-schemas'
+import {
+  ActivateTab,
+  CloseLifecycleTab,
+  CloseTab,
+  SetTabProps,
+  UpdatePaneLayout
+} from './session-tabs-schemas'
 
 const WT = 'id:wt'
 
@@ -70,6 +76,18 @@ describe('CloseLifecycleTab (session.tabs.closeLifecycle params)', () => {
         terminal: 'term-1'
       }).success
     ).toBe(false)
+  })
+})
+
+describe('SetTabProps.customTitle', () => {
+  it('distinguishes a title update, clear, and unchanged payload', () => {
+    expect(
+      SetTabProps.parse({ worktree: WT, tabId: 'tab', customTitle: 'Build shell' })
+    ).toMatchObject({ customTitle: 'Build shell' })
+    expect(
+      SetTabProps.parse({ worktree: WT, tabId: 'tab', customTitle: null }).customTitle
+    ).toBeNull()
+    expect(SetTabProps.parse({ worktree: WT, tabId: 'tab' }).customTitle).toBeUndefined()
   })
 })
 

--- a/src/main/runtime/rpc/methods/session-tabs-schemas.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-schemas.test.ts
@@ -6,6 +6,7 @@ import {
   SetTabProps,
   UpdatePaneLayout
 } from './session-tabs-schemas'
+import { CUSTOM_TAB_TITLE_MAX_LENGTH } from '../../../../shared/custom-tab-title'
 
 const WT = 'id:wt'
 
@@ -88,6 +89,23 @@ describe('SetTabProps.customTitle', () => {
       SetTabProps.parse({ worktree: WT, tabId: 'tab', customTitle: null }).customTitle
     ).toBeNull()
     expect(SetTabProps.parse({ worktree: WT, tabId: 'tab' }).customTitle).toBeUndefined()
+  })
+
+  it('bounds untrusted titles before they reach persisted session state', () => {
+    expect(
+      SetTabProps.safeParse({
+        worktree: WT,
+        tabId: 'tab',
+        customTitle: 'x'.repeat(CUSTOM_TAB_TITLE_MAX_LENGTH)
+      }).success
+    ).toBe(true)
+    expect(
+      SetTabProps.safeParse({
+        worktree: WT,
+        tabId: 'tab',
+        customTitle: 'x'.repeat(CUSTOM_TAB_TITLE_MAX_LENGTH + 1)
+      }).success
+    ).toBe(false)
   })
 })
 

--- a/src/main/runtime/rpc/methods/session-tabs-schemas.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-schemas.ts
@@ -126,6 +126,8 @@ export const SetTabProps = WorktreeTabSelector.extend({
     .pipe(z.string().min(1, 'Missing tab id')),
   // undefined = leave unchanged; null = clear color / unset.
   color: z.string().max(64).nullable().optional(),
+  // undefined = leave unchanged; null = clear the user-authored title.
+  customTitle: z.string().nullable().optional(),
   isPinned: z.boolean().optional(),
   // undefined = leave unchanged; no "clear" semantic (absence means default 'terminal').
   viewMode: z.enum(['terminal', 'chat']).optional()

--- a/src/main/runtime/rpc/methods/session-tabs-schemas.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-schemas.ts
@@ -5,6 +5,7 @@ import type { TuiAgent } from '../../../../shared/tui-agent'
 import { sleepingAgentLaunchConfigSchema } from '../../../../shared/workspace-session-sleeping-agents'
 import { RUNTIME_NAVIGATION_TARGETS } from '../../../../shared/runtime-navigation'
 import { TAB_ACTIVATION_INTENTS } from '../../../../shared/tab-activation-intent'
+import { CUSTOM_TAB_TITLE_MAX_LENGTH } from '../../../../shared/custom-tab-title'
 import { OptionalBoolean } from '../schemas'
 
 export const WorktreeTabSelector = z.object({
@@ -127,7 +128,7 @@ export const SetTabProps = WorktreeTabSelector.extend({
   // undefined = leave unchanged; null = clear color / unset.
   color: z.string().max(64).nullable().optional(),
   // undefined = leave unchanged; null = clear the user-authored title.
-  customTitle: z.string().nullable().optional(),
+  customTitle: z.string().max(CUSTOM_TAB_TITLE_MAX_LENGTH).nullable().optional(),
   isPinned: z.boolean().optional(),
   // undefined = leave unchanged; no "clear" semantic (absence means default 'terminal').
   viewMode: z.enum(['terminal', 'chat']).optional()

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -23,6 +23,7 @@ import { TAB_CONTAINER_WIDTH_CLASSES, TAB_LABEL_WIDTH_CLASSES } from './tab-widt
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { useTabStripPointerActivation } from './tab-strip-pointer-activation'
 import { TerminalTabLeadingIcon } from './TerminalTabLeadingIcon'
+import { CUSTOM_TAB_TITLE_MAX_LENGTH } from '../../../../shared/custom-tab-title'
 import {
   isTerminalTabActivityLive,
   resolveTerminalTabActivityStatus,
@@ -272,6 +273,7 @@ export default function SortableTab({
           ref={setRenameInputElement}
           data-tab-rename-input="true"
           value={renameValue}
+          maxLength={CUSTOM_TAB_TITLE_MAX_LENGTH}
           aria-label={translate(
             'auto.components.tab.bar.SortableTab.ab19f603eb',
             'Rename tab {{value0}}',

--- a/src/renderer/src/runtime/web-runtime-session-tab-props.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-tab-props.test.ts
@@ -99,6 +99,32 @@ describe('setWebRuntimeTabProps', () => {
     })
   })
 
+  it('pushes a custom title and clear signal to the host', async () => {
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', false)
+    mocks.getRuntimeEnvironmentIdForWorktree.mockReturnValue(ENVIRONMENT_ID)
+    mocks.getState.mockReturnValue({})
+    const runtimeCall = vi.fn().mockResolvedValue({ id: 'p', ok: true, result: { updated: true } })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    setWebRuntimeTabProps({
+      worktreeId: WORKTREE_ID,
+      tabId: 'web-terminal-host-tab-1',
+      customTitle: 'Shared build'
+    })
+    await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(1))
+    setWebRuntimeTabProps({
+      worktreeId: WORKTREE_ID,
+      tabId: 'web-terminal-host-tab-1',
+      customTitle: null
+    })
+
+    await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(2))
+    expect(runtimeCall.mock.calls.map(([call]) => call.params.customTitle)).toEqual([
+      'Shared build',
+      null
+    ])
+  })
+
   it('maps mirrored browser/editor unified ids before setting host tab props', async () => {
     vi.stubGlobal('__ORCA_WEB_CLIENT__', false)
     mocks.getRuntimeEnvironmentIdForWorktree.mockReturnValue(ENVIRONMENT_ID)

--- a/src/renderer/src/runtime/web-runtime-tab-props-mutation.ts
+++ b/src/renderer/src/runtime/web-runtime-tab-props-mutation.ts
@@ -1,0 +1,9 @@
+export type WebRuntimeTabPropsMutation = {
+  worktreeId: string
+  tabId: string
+  color?: string | null
+  customTitle?: string | null
+  previousCustomTitle?: string | null
+  isPinned?: boolean
+  viewMode?: 'terminal' | 'chat'
+}

--- a/src/renderer/src/runtime/web-runtime-terminal-actions.ts
+++ b/src/renderer/src/runtime/web-runtime-terminal-actions.ts
@@ -231,11 +231,12 @@ export async function updateWebRuntimePaneLayout(args: {
   }
 }
 
-// Why: tab color/pin are host-authoritative; mirror the change so it persists (undefined field = leave as-is on host).
+// Why: tab props are host-authoritative; mirror changes so they persist (undefined = unchanged).
 export function setWebRuntimeTabProps(args: {
   worktreeId: string
   tabId: string
   color?: string | null
+  customTitle?: string | null
   isPinned?: boolean
   viewMode?: 'terminal' | 'chat'
 }): boolean {
@@ -260,6 +261,7 @@ export function setWebRuntimeTabProps(args: {
           worktree: toRuntimeWorktreeSelector(args.worktreeId),
           tabId: hostTabId,
           ...(args.color !== undefined ? { color: args.color } : {}),
+          ...(args.customTitle !== undefined ? { customTitle: args.customTitle } : {}),
           ...(args.isPinned !== undefined ? { isPinned: args.isPinned } : {}),
           ...(args.viewMode !== undefined ? { viewMode: args.viewMode } : {})
         },

--- a/src/renderer/src/runtime/web-runtime-terminal-actions.ts
+++ b/src/renderer/src/runtime/web-runtime-terminal-actions.ts
@@ -21,6 +21,8 @@ import {
   focusSplitWebRuntimeTerminalPane,
   type WebRuntimeSplitSource
 } from './web-runtime-split-focus'
+import { beginWebSessionCustomTitleIntent } from './web-session-custom-title-intent'
+import type { WebRuntimeTabPropsMutation } from './web-runtime-tab-props-mutation'
 
 const pendingWebRuntimeSplitMirrorTelemetry = new Map<string, Set<string>>()
 const WEB_RUNTIME_SPLIT_MIRROR_SUPPRESSION_TTL_MS = 30_000
@@ -191,7 +193,6 @@ export function closeWebRuntimeTerminal(ptyId: string | null | undefined): boole
   return true
 }
 
-// Why: pane geometry is host-authoritative for remote tabs; local-only changes revert on next snapshot, so push to host.
 export async function updateWebRuntimePaneLayout(args: {
   worktreeId: string
   tabId: string
@@ -231,22 +232,22 @@ export async function updateWebRuntimePaneLayout(args: {
   }
 }
 
-// Why: tab props are host-authoritative; mirror changes so they persist (undefined = unchanged).
-export function setWebRuntimeTabProps(args: {
-  worktreeId: string
-  tabId: string
-  color?: string | null
-  customTitle?: string | null
-  isPinned?: boolean
-  viewMode?: 'terminal' | 'chat'
-}): boolean {
+export function setWebRuntimeTabProps(args: WebRuntimeTabPropsMutation): boolean {
   const environmentId =
     getRuntimeEnvironmentIdForWorktree(useAppStore.getState(), args.worktreeId) ?? null
   if (!environmentId || !isWebRuntimeSessionActive(environmentId)) {
     return false
   }
   const callEnvironment = captureRuntimeEnvironmentCall(environmentId)
+  const intentOwner = captureWebSessionIntentOwner(environmentId)
   const state = useAppStore.getState()
+  const customTitleIntent = beginWebSessionCustomTitleIntent({
+    owner: intentOwner,
+    worktreeId: args.worktreeId,
+    tabId: args.tabId,
+    previousTitle: args.previousCustomTitle ?? null,
+    intendedTitle: args.customTitle
+  })
   void import('./web-session-tabs-sync')
     .then(({ resolveHostSessionTabIdForWebSessionTab }) => {
       const hostTabId =
@@ -255,6 +256,7 @@ export function setWebRuntimeTabProps(args: {
           worktreeId: args.worktreeId,
           tabId: args.tabId
         }) ?? (isWebTerminalSurfaceTabId(args.tabId) ? toHostSessionTabId(args.tabId) : args.tabId)
+      customTitleIntent?.retarget(hostTabId)
       return callEnvironment({
         method: 'session.tabs.setTabProps',
         params: {
@@ -272,6 +274,7 @@ export function setWebRuntimeTabProps(args: {
       unwrapRuntimeRpcResult(response as RuntimeRpcResponse<{ updated: true }>)
     })
     .catch((error) => {
+      customTitleIntent?.cancel()
       console.warn(
         '[web-runtime-session] failed to set tab props:',
         error instanceof Error ? error.message : String(error)

--- a/src/renderer/src/runtime/web-session-custom-title-intent.test.ts
+++ b/src/renderer/src/runtime/web-session-custom-title-intent.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  cancelWebSessionCustomTitleIntent,
+  reconcileWebSessionCustomTitleIntent,
+  recordWebSessionCustomTitleIntent,
+  resetWebSessionCustomTitleIntentsForTests
+} from './web-session-custom-title-intent'
+
+const OWNER = { environmentId: 'remote-1', pairingRevision: 1 }
+const BASE = { owner: OWNER, worktreeId: 'repo::/worktree', hostTabId: 'host-tab' }
+
+afterEach(() => resetWebSessionCustomTitleIntentsForTests())
+
+describe('web session custom-title intent', () => {
+  it('keeps an optimistic rename while the host still echoes the previous title', () => {
+    recordWebSessionCustomTitleIntent({
+      ...BASE,
+      previousTitle: null,
+      intendedTitle: 'Shared build',
+      now: 1
+    })
+
+    expect(reconcileWebSessionCustomTitleIntent({ ...BASE, hostTitle: null, now: 2 })).toBe(
+      'Shared build'
+    )
+    expect(
+      reconcileWebSessionCustomTitleIntent({ ...BASE, hostTitle: 'Shared build', now: 3 })
+    ).toBe('Shared build')
+    expect(
+      reconcileWebSessionCustomTitleIntent({ ...BASE, hostTitle: 'Other client', now: 4 })
+    ).toBe('Other client')
+  })
+
+  it('protects the newest rapid rename from the prior request acknowledgement', () => {
+    recordWebSessionCustomTitleIntent({
+      ...BASE,
+      previousTitle: 'First',
+      intendedTitle: 'Second',
+      now: 1
+    })
+    recordWebSessionCustomTitleIntent({
+      ...BASE,
+      previousTitle: 'Second',
+      intendedTitle: 'Third',
+      now: 2
+    })
+
+    expect(reconcileWebSessionCustomTitleIntent({ ...BASE, hostTitle: 'Second', now: 3 })).toBe(
+      'Third'
+    )
+    expect(reconcileWebSessionCustomTitleIntent({ ...BASE, hostTitle: 'Third', now: 4 })).toBe(
+      'Third'
+    )
+  })
+
+  it('accepts a concurrent third-party title and ignores cancellation from an older request', () => {
+    const oldToken = recordWebSessionCustomTitleIntent({
+      ...BASE,
+      previousTitle: null,
+      intendedTitle: 'First',
+      now: 1
+    })
+    recordWebSessionCustomTitleIntent({
+      ...BASE,
+      previousTitle: 'First',
+      intendedTitle: 'Second',
+      now: 2
+    })
+    cancelWebSessionCustomTitleIntent(oldToken)
+
+    expect(
+      reconcileWebSessionCustomTitleIntent({ ...BASE, hostTitle: 'Peer rename', now: 3 })
+    ).toBe('Peer rename')
+  })
+
+  it('expires instead of masking a host value indefinitely', () => {
+    recordWebSessionCustomTitleIntent({
+      ...BASE,
+      previousTitle: null,
+      intendedTitle: 'Stale local',
+      now: 1
+    })
+
+    expect(
+      reconcileWebSessionCustomTitleIntent({ ...BASE, hostTitle: null, now: 30_002 })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/runtime/web-session-custom-title-intent.ts
+++ b/src/renderer/src/runtime/web-session-custom-title-intent.ts
@@ -1,0 +1,148 @@
+import { webSessionIntentOwnerKey, type WebSessionIntentOwner } from './web-session-intent-owner'
+import { isWebTerminalSurfaceTabId, toHostSessionTabId } from './web-terminal-surface-id'
+
+const CUSTOM_TITLE_INTENT_TTL_MS = 30_000
+
+type CustomTitle = string | null
+
+type CustomTitleIntent = {
+  id: number
+  previousTitle: CustomTitle
+  intendedTitle: CustomTitle
+  recordedAt: number
+}
+
+export type WebSessionCustomTitleIntentToken = {
+  key: string
+  id: number
+}
+
+export type WebSessionCustomTitleIntentHandle = {
+  retarget: (hostTabId: string) => void
+  cancel: () => void
+}
+
+const pendingCustomTitleByKey = new Map<string, CustomTitleIntent>()
+let nextCustomTitleIntentId = 0
+
+function customTitleIntentKey(
+  owner: WebSessionIntentOwner,
+  worktreeId: string,
+  hostTabId: string
+): string {
+  return `${webSessionIntentOwnerKey(owner)}\0${worktreeId}\0${hostTabId}`
+}
+
+export function beginWebSessionCustomTitleIntent(args: {
+  owner: WebSessionIntentOwner
+  worktreeId: string
+  tabId: string
+  previousTitle: CustomTitle
+  intendedTitle: CustomTitle | undefined
+}): WebSessionCustomTitleIntentHandle | null {
+  if (args.intendedTitle === undefined) {
+    return null
+  }
+  let token = recordWebSessionCustomTitleIntent({
+    owner: args.owner,
+    worktreeId: args.worktreeId,
+    hostTabId: isWebTerminalSurfaceTabId(args.tabId) ? toHostSessionTabId(args.tabId) : args.tabId,
+    previousTitle: args.previousTitle,
+    intendedTitle: args.intendedTitle
+  })
+  return {
+    retarget: (hostTabId) => {
+      token = rekeyWebSessionCustomTitleIntent(token, { ...args, hostTabId })
+    },
+    cancel: () => cancelWebSessionCustomTitleIntent(token)
+  }
+}
+
+export function recordWebSessionCustomTitleIntent(args: {
+  owner: WebSessionIntentOwner
+  worktreeId: string
+  hostTabId: string
+  previousTitle: CustomTitle
+  intendedTitle: CustomTitle
+  now?: number
+}): WebSessionCustomTitleIntentToken {
+  const key = customTitleIntentKey(args.owner, args.worktreeId, args.hostTabId)
+  const id = ++nextCustomTitleIntentId
+  pendingCustomTitleByKey.set(key, {
+    id,
+    previousTitle: args.previousTitle,
+    intendedTitle: args.intendedTitle,
+    recordedAt: args.now ?? Date.now()
+  })
+  return { key, id }
+}
+
+export function rekeyWebSessionCustomTitleIntent(
+  token: WebSessionCustomTitleIntentToken,
+  args: { owner: WebSessionIntentOwner; worktreeId: string; hostTabId: string }
+): WebSessionCustomTitleIntentToken {
+  const nextKey = customTitleIntentKey(args.owner, args.worktreeId, args.hostTabId)
+  if (nextKey === token.key) {
+    return token
+  }
+  const intent = pendingCustomTitleByKey.get(token.key)
+  if (intent?.id === token.id) {
+    pendingCustomTitleByKey.delete(token.key)
+    pendingCustomTitleByKey.set(nextKey, intent)
+  }
+  return { key: nextKey, id: token.id }
+}
+
+export function cancelWebSessionCustomTitleIntent(
+  token: WebSessionCustomTitleIntentToken | null
+): void {
+  if (!token) {
+    return
+  }
+  if (pendingCustomTitleByKey.get(token.key)?.id === token.id) {
+    pendingCustomTitleByKey.delete(token.key)
+  }
+}
+
+export function reconcileWebSessionCustomTitleIntent(args: {
+  owner: WebSessionIntentOwner
+  worktreeId: string
+  hostTabId: string
+  hostTitle: CustomTitle
+  now: number
+}): CustomTitle {
+  const key = customTitleIntentKey(args.owner, args.worktreeId, args.hostTabId)
+  const intent = pendingCustomTitleByKey.get(key)
+  if (!intent) {
+    return args.hostTitle
+  }
+  if (args.now - intent.recordedAt > CUSTOM_TITLE_INTENT_TTL_MS) {
+    pendingCustomTitleByKey.delete(key)
+    return args.hostTitle
+  }
+  if (args.hostTitle === intent.intendedTitle) {
+    pendingCustomTitleByKey.delete(key)
+    return args.hostTitle
+  }
+  if (args.hostTitle === intent.previousTitle) {
+    return intent.intendedTitle
+  }
+  pendingCustomTitleByKey.delete(key)
+  return args.hostTitle
+}
+
+export function clearWebSessionCustomTitleIntentsForWorktree(
+  environmentId: string,
+  worktreeId: string
+): void {
+  const ownerPrefix = `${webSessionIntentOwnerKey({ environmentId })}\0${worktreeId}\0`
+  for (const key of pendingCustomTitleByKey.keys()) {
+    if (key.startsWith(ownerPrefix)) {
+      pendingCustomTitleByKey.delete(key)
+    }
+  }
+}
+
+export function resetWebSessionCustomTitleIntentsForTests(): void {
+  pendingCustomTitleByKey.clear()
+}

--- a/src/renderer/src/runtime/web-session-tabs-sync/terminal-build.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/terminal-build.ts
@@ -5,6 +5,7 @@ import { resolvePaneAgentOwnerRecord } from '../../../../shared/pane-agent-owner
 import { normalizeCompatibleAgentTitleForOwner } from '../../../../shared/agent-title-owner'
 import { getRemoteRuntimePtyEnvironmentId, toRemoteRuntimePtyId } from '../runtime-terminal-stream'
 import { toWebTerminalSurfaceTabId } from '../web-runtime-session'
+import { reconcileWebSessionCustomTitleIntent } from '../web-session-custom-title-intent'
 import type { MirroredTerminalTab, TerminalSurface, ReadyTerminalSurface } from './state'
 import { chooseRemoteTerminalLayout, isTerminalSurfaceTab } from './terminal-surfaces'
 
@@ -163,7 +164,13 @@ export function buildMirroredTerminalTabs(
     // Missing means an older host; present null/string is the new host's authoritative value.
     const hostCustomTitleSurface = surfaces.find((surface) => surface.customTitle !== undefined)
     const customTitle = hostCustomTitleSurface
-      ? (hostCustomTitleSurface.customTitle ?? null)
+      ? reconcileWebSessionCustomTitleIntent({
+          owner: { environmentId },
+          worktreeId: snapshot.worktree,
+          hostTabId: parentTabId,
+          hostTitle: hostCustomTitleSurface.customTitle ?? null,
+          now
+        })
       : (existing?.customTitle ?? null)
     return {
       tab: {

--- a/src/renderer/src/runtime/web-session-tabs-sync/terminal-build.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/terminal-build.ts
@@ -160,6 +160,11 @@ export function buildMirroredTerminalTabs(
     // Why: viewMode echoes back through host snapshots, so prefer the client's record during the echo window and adopt the host value only without a prior tab.
     const hostViewModeSurface = surfaces.find((surface) => surface.viewMode)
     const viewMode = existing ? existing.viewMode : hostViewModeSurface?.viewMode
+    // Missing means an older host; present null/string is the new host's authoritative value.
+    const hostCustomTitleSurface = surfaces.find((surface) => surface.customTitle !== undefined)
+    const customTitle = hostCustomTitleSurface
+      ? (hostCustomTitleSurface.customTitle ?? null)
+      : (existing?.customTitle ?? null)
     return {
       tab: {
         id: localTabId,
@@ -173,7 +178,7 @@ export function buildMirroredTerminalTabs(
         ...(existing?.aiVaultTitle ? { aiVaultTitle: existing.aiVaultTitle } : {}),
         ...(quickCommandLabel ? { quickCommandLabel } : {}),
         ...(startupCwd ? { startupCwd } : {}),
-        customTitle: existing?.customTitle ?? null,
+        customTitle,
         color,
         isPinned,
         ...(viewMode ? { viewMode } : {}),

--- a/src/renderer/src/runtime/web-session-tabs-sync/tracking-lifecycle.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/tracking-lifecycle.ts
@@ -24,6 +24,7 @@ import {
 } from '../web-runtime-wake-terminal-respawn'
 import { clearWebSessionReorderIntentsForWorktree } from '../web-session-reorder-intent'
 import { clearWebSessionCloseIntentsForWorktree } from '../web-session-close-intent'
+import { clearWebSessionCustomTitleIntentsForWorktree } from '../web-session-custom-title-intent'
 import {
   clearWebAgentSessionHandoffsForWorktree,
   clearWebAgentSessionHandoffsForEnvironment
@@ -141,6 +142,7 @@ export function clearWebSessionTabsTrackingForWorktree(
   clearWebRuntimeWakeTerminalRespawnForWorktree(worktreeId)
   clearWebSessionReorderIntentsForWorktree({ environmentId }, worktreeId)
   clearWebSessionCloseIntentsForWorktree({ environmentId }, worktreeId)
+  clearWebSessionCustomTitleIntentsForWorktree(environmentId, worktreeId)
   clearWebAgentSessionHandoffsForWorktree(environmentId, worktreeId)
   clearHostSessionTabIdMappings(environmentId, worktreeId)
   clearWebSessionBrowserPlacementsForWorktree(environmentId, worktreeId)

--- a/src/renderer/src/store/terminals/terminal-tab-attention.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-attention.ts
@@ -5,6 +5,7 @@ import type { TerminalSlice, TerminalStoreGet, TerminalStoreSet } from './termin
 type MirroredTerminalTabProps = {
   color?: string | null
   customTitle?: string | null
+  previousCustomTitle?: string | null
 }
 
 function mirrorTerminalTabPropsToRuntime(
@@ -104,6 +105,9 @@ export function createTerminalTabAttentionActions(
       })
     },
     setTabCustomTitle: (tabId, title, opts) => {
+      const previousCustomTitle = Object.values(get().tabsByWorktree)
+        .flat()
+        .find((tab) => tab.id === tabId)?.customTitle
       set((s) => {
         const next = { ...s.tabsByWorktree }
         for (const wId of Object.keys(next)) {
@@ -117,7 +121,10 @@ export function createTerminalTabAttentionActions(
         .find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId)
       if (item) {
         get().setTabCustomLabel(item.id, title, opts)
-        mirrorTerminalTabPropsToRuntime(get, item.id, { customTitle: title })
+        mirrorTerminalTabPropsToRuntime(get, item.id, {
+          customTitle: title,
+          previousCustomTitle: previousCustomTitle ?? null
+        })
       }
     },
     setTabColor: (tabId, color) => {

--- a/src/renderer/src/store/terminals/terminal-tab-attention.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-attention.ts
@@ -2,6 +2,31 @@ import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
 import type { TerminalSlice, TerminalStoreGet, TerminalStoreSet } from './terminal-state'
 
+type MirroredTerminalTabProps = {
+  color?: string | null
+  customTitle?: string | null
+}
+
+function mirrorTerminalTabPropsToRuntime(
+  get: TerminalStoreGet,
+  tabId: string,
+  props: MirroredTerminalTabProps
+): void {
+  const state = get()
+  const owningWorktreeId = Object.keys(state.unifiedTabsByWorktree).find((worktreeId) =>
+    (state.unifiedTabsByWorktree[worktreeId] ?? []).some((entry) => entry.id === tabId)
+  )
+  if (
+    !owningWorktreeId ||
+    !resolveTerminalWorktreeRoute(state, owningWorktreeId)?.runtimeEnvironmentId
+  ) {
+    return
+  }
+  void import('@/runtime/web-runtime-session').then(({ setWebRuntimeTabProps }) =>
+    setWebRuntimeTabProps({ worktreeId: owningWorktreeId, tabId, ...props })
+  )
+}
+
 export function createTerminalTabAttentionActions(
   set: TerminalStoreSet,
   get: TerminalStoreGet
@@ -92,6 +117,7 @@ export function createTerminalTabAttentionActions(
         .find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId)
       if (item) {
         get().setTabCustomLabel(item.id, title, opts)
+        mirrorTerminalTabPropsToRuntime(get, item.id, { customTitle: title })
       }
     },
     setTabColor: (tabId, color) => {
@@ -107,19 +133,7 @@ export function createTerminalTabAttentionActions(
         .find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId)
       if (item) {
         get().setUnifiedTabColor(item.id, color)
-        // Why: tab color is host-authoritative for remote-server tabs; mirror it so it persists instead of reverting on the next snapshot.
-        const state = get()
-        const owningWorktreeId = Object.keys(state.unifiedTabsByWorktree).find((wId) =>
-          (state.unifiedTabsByWorktree[wId] ?? []).some((entry) => entry.id === item.id)
-        )
-        if (
-          owningWorktreeId &&
-          resolveTerminalWorktreeRoute(state, owningWorktreeId)?.runtimeEnvironmentId
-        ) {
-          void import('@/runtime/web-runtime-session').then(({ setWebRuntimeTabProps }) =>
-            setWebRuntimeTabProps({ worktreeId: owningWorktreeId, tabId: item.id, color })
-          )
-        }
+        mirrorTerminalTabPropsToRuntime(get, item.id, { color })
       }
     }
   }

--- a/src/renderer/src/store/terminals/terminal-tab-title-runtime-mirror.test.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-title-runtime-mirror.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  scheduleRuntimeGraphSync: vi.fn(),
+  setWebRuntimeTabProps: vi.fn()
+}))
+
+vi.mock('@/runtime/sync-runtime-graph', () => ({
+  scheduleRuntimeGraphSync: mocks.scheduleRuntimeGraphSync
+}))
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  setWebRuntimeTabProps: mocks.setWebRuntimeTabProps
+}))
+
+vi.mock('@/lib/terminal-worktree-route', () => ({
+  resolveTerminalWorktreeRoute: () => ({ runtimeEnvironmentId: 'remote-1' })
+}))
+
+import { createTerminalTabAttentionActions } from './terminal-tab-attention'
+
+describe('terminal custom title runtime mirror', () => {
+  it('mirrors rename and clear mutations to the owning host tab', async () => {
+    const setTabCustomLabel = vi.fn()
+    let state = {
+      tabsByWorktree: {
+        'repo::/worktree': [{ id: 'terminal-1', customTitle: null }]
+      },
+      unifiedTabsByWorktree: {
+        'repo::/worktree': [{ id: 'unified-1', entityId: 'terminal-1', contentType: 'terminal' }]
+      },
+      setTabCustomLabel
+    }
+    const set = (update: (current: typeof state) => Partial<typeof state>): void => {
+      state = { ...state, ...update(state) }
+    }
+    const actions = createTerminalTabAttentionActions(set as never, (() => state) as never)
+
+    actions.setTabCustomTitle('terminal-1', 'Shared build')
+    await vi.waitFor(() => expect(mocks.setWebRuntimeTabProps).toHaveBeenCalledTimes(1))
+    actions.setTabCustomTitle('terminal-1', null)
+
+    await vi.waitFor(() => expect(mocks.setWebRuntimeTabProps).toHaveBeenCalledTimes(2))
+    expect(mocks.setWebRuntimeTabProps.mock.calls).toEqual([
+      [
+        {
+          worktreeId: 'repo::/worktree',
+          tabId: 'unified-1',
+          customTitle: 'Shared build'
+        }
+      ],
+      [
+        {
+          worktreeId: 'repo::/worktree',
+          tabId: 'unified-1',
+          customTitle: null
+        }
+      ]
+    ])
+    expect(setTabCustomLabel).toHaveBeenLastCalledWith('unified-1', null, undefined)
+  })
+})

--- a/src/renderer/src/store/terminals/terminal-tab-title-runtime-mirror.test.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-title-runtime-mirror.test.ts
@@ -46,14 +46,16 @@ describe('terminal custom title runtime mirror', () => {
         {
           worktreeId: 'repo::/worktree',
           tabId: 'unified-1',
-          customTitle: 'Shared build'
+          customTitle: 'Shared build',
+          previousCustomTitle: null
         }
       ],
       [
         {
           worktreeId: 'repo::/worktree',
           tabId: 'unified-1',
-          customTitle: null
+          customTitle: null,
+          previousCustomTitle: 'Shared build'
         }
       ]
     ])

--- a/src/shared/custom-tab-title.ts
+++ b/src/shared/custom-tab-title.ts
@@ -1,0 +1,1 @@
+export const CUSTOM_TAB_TITLE_MAX_LENGTH = 256

--- a/src/shared/runtime-mobile-session-tab-contracts.ts
+++ b/src/shared/runtime-mobile-session-tab-contracts.ts
@@ -9,6 +9,7 @@ export type RuntimeMobileSessionTerminalTab = {
   type: 'terminal'
   id: string
   title: string
+  customTitle?: string | null
   quickCommandLabel?: string | null
   parentTabId: string
   leafId: string

--- a/tests/e2e/session-tabs-custom-title-persistence.unit.test.ts
+++ b/tests/e2e/session-tabs-custom-title-persistence.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { OrcaRuntimeService } from '../../src/main/runtime/orca-runtime'
 import {
   applyWebSessionTabsSnapshot,
@@ -7,6 +7,10 @@ import {
 import { getDefaultWorkspaceSession } from '../../src/shared/constants'
 import type { RuntimeMobileSessionTabsResult } from '../../src/shared/runtime-types'
 import type { WorkspaceSessionState } from '../../src/shared/workspace-session-state-types'
+import {
+  recordWebSessionCustomTitleIntent,
+  resetWebSessionCustomTitleIntentsForTests
+} from '../../src/renderer/src/runtime/web-session-custom-title-intent'
 
 vi.mock('../../src/renderer/src/store', () => ({
   useAppStore: { setState: vi.fn() }
@@ -139,6 +143,8 @@ function visibleTitle(state: WebSessionTabsSyncState): string | null {
 }
 
 describe('remote Web terminal custom title persistence', () => {
+  afterEach(() => resetWebSessionCustomTitleIntentsForTests())
+
   it('preserves a local rename when an older host omits customTitle', async () => {
     const host = createRuntime(makeSession())
     const legacySnapshot = structuredClone(
@@ -218,5 +224,65 @@ describe('remote Web terminal custom title persistence', () => {
       'web-client-after-restart'
     )
     expect(visibleTitle(afterClear)).toBe('Base terminal')
+  })
+
+  it('does not revert an optimistic rename when a stale snapshot wins the transport race', async () => {
+    const host = createRuntime(makeSession())
+    const staleSnapshot = await host.runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)
+    const initial = applySnapshot(makeViewerState(), staleSnapshot, 'web-client-a')
+    const localTab = initial.tabsByWorktree[WORKTREE_ID]?.[0]
+    expect(localTab).toBeDefined()
+    const renamed = {
+      ...initial,
+      tabsByWorktree: {
+        ...initial.tabsByWorktree,
+        [WORKTREE_ID]: [{ ...localTab!, customTitle: 'Optimistic rename' }]
+      }
+    }
+    recordWebSessionCustomTitleIntent({
+      owner: { environmentId: 'web-client-a' },
+      worktreeId: WORKTREE_ID,
+      hostTabId: TAB_ID,
+      previousTitle: null,
+      intendedTitle: 'Optimistic rename'
+    })
+
+    expect(visibleTitle(applySnapshot(renamed, staleSnapshot, 'web-client-a'))).toBe(
+      'Optimistic rename'
+    )
+  })
+
+  it('uses sorted tab order for the fallback title after clearing a rename', async () => {
+    const session = makeSession()
+    const target = session.tabsByWorktree[WORKTREE_ID]![0]!
+    target.title = ''
+    target.defaultTitle = ''
+    target.sortOrder = 10
+    target.createdAt = 20
+    session.tabsByWorktree[WORKTREE_ID] = [
+      target,
+      {
+        ...target,
+        id: 'earlier-terminal',
+        ptyId: null,
+        sortOrder: 0,
+        createdAt: 10
+      }
+    ]
+    const host = createRuntime(session)
+
+    await host.runtime.setMobileSessionTabProps(`id:${WORKTREE_ID}`, {
+      tabId: TAB_ID,
+      customTitle: 'Temporary title'
+    })
+    await host.runtime.setMobileSessionTabProps(`id:${WORKTREE_ID}`, {
+      tabId: TAB_ID,
+      customTitle: null
+    })
+
+    const snapshot = await host.runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)
+    expect(
+      snapshot.tabs.find((tab) => tab.type === 'terminal' && tab.parentTabId === TAB_ID)?.title
+    ).toBe('Terminal 2')
   })
 })

--- a/tests/e2e/session-tabs-custom-title-persistence.unit.test.ts
+++ b/tests/e2e/session-tabs-custom-title-persistence.unit.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../../src/main/runtime/orca-runtime'
+import {
+  applyWebSessionTabsSnapshot,
+  type WebSessionTabsSyncState
+} from '../../src/renderer/src/runtime/web-session-tabs-sync'
+import { getDefaultWorkspaceSession } from '../../src/shared/constants'
+import type { RuntimeMobileSessionTabsResult } from '../../src/shared/runtime-types'
+import type { WorkspaceSessionState } from '../../src/shared/workspace-session-state-types'
+
+vi.mock('../../src/renderer/src/store', () => ({
+  useAppStore: { setState: vi.fn() }
+}))
+
+const WORKTREE_ID = 'repo-1::/remote-worktree'
+const TAB_ID = 'host-terminal'
+const LEAF_ID = '00000000-0000-4000-8000-000000000001'
+const PTY_ID = 'remote-pty'
+
+const storeBase = {
+  getRepo: () => ({
+    id: 'repo-1',
+    path: '/remote/repo',
+    displayName: 'repo',
+    badgeColor: 'blue',
+    addedAt: 1
+  }),
+  getRepos: () => [storeBase.getRepo()],
+  addRepo: () => {},
+  updateRepo: () => undefined as never,
+  getAllWorktreeMeta: () => ({}),
+  getWorktreeMeta: () => undefined,
+  getGitHubCache: () => ({ pr: {}, issue: {} }),
+  setWorktreeMeta: () => undefined as never,
+  removeWorktreeMeta: () => {},
+  getRetiredWorktreeNameRegistry: () => ({ exhaustedTiers: 0, names: [] }),
+  addRetiredWorktreeName: () => {},
+  mergeRetiredWorktreeNames: () => false,
+  getSettings: () => ({
+    workspaceDir: '/remote/workspaces',
+    nestWorkspaces: false,
+    refreshLocalBaseRefOnWorktreeCreate: false,
+    branchPrefix: 'none',
+    branchPrefixCustom: ''
+  })
+}
+
+function makeSession(): WorkspaceSessionState {
+  return {
+    ...getDefaultWorkspaceSession(),
+    activeRepoId: 'repo-1',
+    activeWorktreeId: WORKTREE_ID,
+    activeTabId: TAB_ID,
+    activeTabIdByWorktree: { [WORKTREE_ID]: TAB_ID },
+    tabsByWorktree: {
+      [WORKTREE_ID]: [
+        {
+          id: TAB_ID,
+          ptyId: PTY_ID,
+          worktreeId: WORKTREE_ID,
+          title: 'Base terminal',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {
+      [TAB_ID]: {
+        root: { type: 'leaf', leafId: LEAF_ID },
+        activeLeafId: LEAF_ID,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_ID]: PTY_ID }
+      }
+    }
+  }
+}
+
+function createRuntime(initialSession: WorkspaceSessionState) {
+  let session = initialSession
+  const runtime = new OrcaRuntimeService({
+    ...storeBase,
+    getWorkspaceSession: () => session,
+    setWorkspaceSession: (next: WorkspaceSessionState) => {
+      session = next
+    }
+  })
+  runtime.registerPty(PTY_ID, WORKTREE_ID, null, {
+    tabId: TAB_ID,
+    leafId: LEAF_ID,
+    incarnationId: 'title-persistence-incarnation'
+  })
+  return { runtime, getSession: () => session }
+}
+
+function makeViewerState(): WebSessionTabsSyncState {
+  return {
+    activeBrowserTabId: null,
+    activeBrowserTabIdByWorktree: {},
+    activeFileId: null,
+    activeFileIdByWorktree: {},
+    activeGroupIdByWorktree: {},
+    activeTabId: null,
+    activeTabIdByWorktree: {},
+    activeTabType: 'terminal',
+    activeTabTypeByWorktree: {},
+    activeWorktreeId: WORKTREE_ID,
+    agentStatusByPaneKey: {},
+    agentStatusEpoch: 0,
+    browserCertificateFailuresByPageId: {},
+    browserPagesByWorkspace: {},
+    browserTabsByWorktree: {},
+    groupsByWorktree: {},
+    layoutByWorktree: {},
+    openFiles: [],
+    ptyIdsByTabId: {},
+    remoteBrowserPageHandlesByPageId: {},
+    tabBarOrderByWorktree: {},
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    unifiedTabsByWorktree: {},
+    unreadTerminalTabs: {},
+    sortEpoch: 0
+  }
+}
+
+function applySnapshot(
+  state: WebSessionTabsSyncState,
+  snapshot: RuntimeMobileSessionTabsResult,
+  environmentId: string
+): WebSessionTabsSyncState {
+  return { ...state, ...applyWebSessionTabsSnapshot(state, snapshot, environmentId) }
+}
+
+function visibleTitle(state: WebSessionTabsSyncState): string | null {
+  const tab = state.tabsByWorktree[WORKTREE_ID]?.[0]
+  return tab?.customTitle ?? tab?.title ?? null
+}
+
+describe('remote Web terminal custom title persistence', () => {
+  it('preserves a local rename when an older host omits customTitle', async () => {
+    const host = createRuntime(makeSession())
+    const legacySnapshot = structuredClone(
+      await host.runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)
+    )
+    for (const tab of legacySnapshot.tabs) {
+      if (tab.type === 'terminal') {
+        delete tab.customTitle
+      }
+    }
+    const renamed = makeViewerState()
+    renamed.tabsByWorktree[WORKTREE_ID] = [
+      {
+        id: TAB_ID,
+        ptyId: null,
+        worktreeId: WORKTREE_ID,
+        title: 'Base terminal',
+        customTitle: 'Local rename',
+        color: null,
+        sortOrder: 0,
+        createdAt: 1
+      }
+    ]
+
+    expect(visibleTitle(applySnapshot(renamed, legacySnapshot, 'new-client-old-host'))).toBe(
+      'Local rename'
+    )
+  })
+
+  it('fans out to two clients and survives refresh plus host restart', async () => {
+    const firstHost = createRuntime(makeSession())
+    const initial = await firstHost.runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)
+    let clientA = applySnapshot(makeViewerState(), initial, 'web-client-a')
+    let clientB = applySnapshot(makeViewerState(), initial, 'web-client-b')
+    const unsubscribeA = firstHost.runtime.onMobileSessionTabsChanged((snapshot) => {
+      clientA = applySnapshot(clientA, snapshot, 'web-client-a')
+    }, 'web-client-a')
+    const unsubscribeB = firstHost.runtime.onMobileSessionTabsChanged((snapshot) => {
+      clientB = applySnapshot(clientB, snapshot, 'web-client-b')
+    }, 'web-client-b')
+
+    await firstHost.runtime.setMobileSessionTabProps(`id:${WORKTREE_ID}`, {
+      tabId: TAB_ID,
+      customTitle: 'Shared build'
+    })
+
+    expect(visibleTitle(clientA)).toBe('Shared build')
+    expect(visibleTitle(clientB)).toBe('Shared build')
+    expect(firstHost.getSession().tabsByWorktree[WORKTREE_ID]?.[0]?.customTitle).toBe(
+      'Shared build'
+    )
+
+    const refreshed = applySnapshot(
+      makeViewerState(),
+      await firstHost.runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`),
+      'web-client-a-refreshed'
+    )
+    expect(visibleTitle(refreshed)).toBe('Shared build')
+
+    unsubscribeA()
+    unsubscribeB()
+    const restartedHost = createRuntime(structuredClone(firstHost.getSession()))
+    const afterRestart = applySnapshot(
+      makeViewerState(),
+      await restartedHost.runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`),
+      'web-client-after-restart'
+    )
+    expect(visibleTitle(afterRestart)).toBe('Shared build')
+
+    await restartedHost.runtime.setMobileSessionTabProps(`id:${WORKTREE_ID}`, {
+      tabId: TAB_ID,
+      customTitle: null
+    })
+    const afterClear = applySnapshot(
+      afterRestart,
+      await restartedHost.runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`),
+      'web-client-after-restart'
+    )
+    expect(visibleTitle(afterClear)).toBe('Base terminal')
+  })
+})


### PR DESCRIPTION
## ELI5

Renaming a terminal tab in Remote Web UI now saves the name on the Orca host, so every connected Web client sees the same title and it remains after refresh or host restart.

## What Changed

- Extended the existing session.tabs.setTabProps RPC with optional nullable customTitle set, clear, and unchanged semantics.
- Persisted custom titles in host-owned workspace-session tab state and included the authoritative value in subscription snapshots.
- Added a short-lived client intent guard so stale echo snapshots cannot undo an optimistic rename, while third-party client renames still propagate.
- Applied a shared 256-character maximum at both the rename input and untrusted RPC boundary.
- Kept fallback title numbering consistent with persisted tab ordering when a custom title is cleared.
- Added regression coverage for two Web clients, refresh, host restart, clear, reordered tabs, rapid renames, intent expiry, and older-host compatibility.

## Why

Remote Web terminal renames previously lived only in one renderer, so the next host snapshot, browser refresh, or host restart restored the old title. Extending the existing tab-props mutation and snapshot flow keeps the host authoritative without introducing a parallel RPC or stream opcode.

## Linked Issue

Fixes #17640

## Visual Proof

N/A

No layout or visual styling changed; this fixes persistence and synchronization of the existing inline rename behavior, which is covered by the rendered Playwright check below.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Current head bf895ebd916ccc0d6f891bf3878434bcf6f558e6 after rebase onto current main:

- Targeted Vitest: 6 files, 43 tests passed.
- pnpm tc passed.
- pnpm run check:code-quality:changed passed with zero findings across 17 changed files.

On the pre-rebase implementation head, pnpm exec electron-vite build --mode e2e passed with only existing warnings, and the Playwright CDP rendered smoke passed 1/1. These heavier checks were not repeated after the conflict resolution; the current-head focused tests, typecheck, and changed-code quality passed.
- Manual/rendered validation was performed on macOS. Linux, Windows, and a live SSH host were not manually exercised.

## AI Disclosure

OpenAI Codex from the GPT-5 family was used for implementation, test creation, review follow-up, and PR description updates. The resulting changes and reviewer findings were inspected and validated with the checks listed above.

## Review

- Addressed the fallback ordering finding by using the same sortOrder and createdAt comparator as snapshot construction.
- Addressed overlapping title-length findings with one shared UI and RPC limit plus boundary tests.
- Addressed the echo-window finding with per-environment, per-worktree, per-tab intent reconciliation and rapid-rename coverage.

## Agent skill upstream boundary

- [x] Not applicable; this change modifies no agent skill installer source, tests, fixtures, registries, path tables, comments, or documentation.

## Notes

- Remote wire compatibility: customTitle is an optional field. Updated hosts publish string or null; updated clients retain the local value when an older host omits it. No new stream opcode or required RPC field was added.
- SSH: execution remains host-owned through the existing runtime RPC and workspace-session persistence path. No local-process inference, SSH command, or disconnect verdict behavior changed.
- Folder workspaces: no Git-worktree-only lookup, Git command, or path assumption was introduced; the existing session/workspace identifiers and routing are reused.
- Cross-platform: production changes are platform-neutral TypeScript and add no filesystem separators, child processes, shortcuts, or OS-specific APIs. Only macOS was manually exercised; automated type and unit coverage is platform-neutral.
- Security: customTitle is validated as nullable text and capped at 256 characters before persistence and fan-out. The change adds no HTML execution, privilege, capability, filesystem, or process surface.
- Performance: title payloads are bounded; intent entries are cleared on acknowledgement, third-party divergence, expiry, and worktree cleanup. Fallback ordering sorts only the small persisted tab list during a title mutation, not on the terminal render hot path.
- Mobile and backwards compatibility: older clients ignore the optional snapshot member and continue receiving the resolved title; no mobile-only interaction or required contract field changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] Full pnpm lint, full pnpm test, and default pnpm build were not run locally; the scope-focused quality, typecheck, targeted tests, E2E build, and rendered smoke above passed.
