### PR TITLE
perf(relay): cache process-table descendant indexes

### DIFF
--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -472,6 +472,24 @@ describe('getForegroundProcessName', () => {
     })
   })
 
+  it('resolves a duplicated root pid to the LAST capture row', async () => {
+    // Why: the shared index is last-wins, replacing a first-wins `rows.find()`.
+    // One tie-break for every consumer of a malformed capture; here the later
+    // row owns the terminal foreground, so no background child can claim it.
+    await withProcessPlatform('linux', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return {
+            stdout: ['100 1 Ss bash', '100 1 Ss+ bash', '101 100 S node /opt/codex'].join('\n')
+          }
+        }
+        return new Error('unexpected command')
+      })
+
+      await expect(getForegroundProcessName(100, 'bash')).resolves.toBe('bash')
+    })
+  })
+
   it('falls back to the root process command when descendant inspection fails', async () => {
     mockExecFile((_command, args) => {
       if (args[0] === '-axo') {

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -472,10 +472,10 @@ describe('getForegroundProcessName', () => {
     })
   })
 
-  it('resolves a duplicated root pid to the LAST capture row', async () => {
-    // Why: the shared index is last-wins, replacing a first-wins `rows.find()`.
-    // One tie-break for every consumer of a malformed capture; here the later
-    // row owns the terminal foreground, so no background child can claim it.
+  it('resolves a duplicated root pid to the FIRST capture row', async () => {
+    // Preserve rows.find() semantics if a malformed table repeats a pid: an argv
+    // newline makes `ps` print a continuation line that can parse as a spurious
+    // row, so the real root (row one) must keep owning the pane's foreground.
     await withProcessPlatform('linux', async () => {
       mockExecFile((_command, args) => {
         if (args[0] === '-axo') {
@@ -486,7 +486,7 @@ describe('getForegroundProcessName', () => {
         return new Error('unexpected command')
       })
 
-      await expect(getForegroundProcessName(100, 'bash')).resolves.toBe('bash')
+      await expect(getForegroundProcessName(100, 'bash')).resolves.toBe('codex')
     })
   })
 

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -11,8 +11,10 @@ import {
 } from '../shared/agent-process-recognition'
 import { getFirstCommandToken } from '../shared/command-token-scanner'
 import {
+  getProcessTableIndex,
   getProcessTableSnapshot,
   scoreForegroundCandidateRow,
+  type ProcessTableIndex,
   type ProcessTableRow
 } from '../shared/process-table-snapshot'
 import {
@@ -198,22 +200,15 @@ export function isProcessAlive(pid: number): boolean {
 }
 
 function collectDescendants(
-  rows: ProcessTableRow[],
+  index: ProcessTableIndex,
   rootPid: number
 ): (ProcessTableRow & { depth: number })[] {
-  const childrenByParent = new Map<number, ProcessTableRow[]>()
-  for (const row of rows) {
-    const children = childrenByParent.get(row.ppid) ?? []
-    children.push(row)
-    childrenByParent.set(row.ppid, children)
-  }
-
   const descendants: (ProcessTableRow & { depth: number })[] = []
-  const stack = (childrenByParent.get(rootPid) ?? []).map((row) => ({ row, depth: 1 }))
+  const stack = (index.childrenByPpid.get(rootPid) ?? []).map((row) => ({ row, depth: 1 }))
   while (stack.length > 0) {
     const { row, depth } = stack.pop()!
     descendants.push({ ...row, depth })
-    for (const child of childrenByParent.get(row.pid) ?? []) {
+    for (const child of index.childrenByPpid.get(row.pid) ?? []) {
       stack.push({ row: child, depth: depth + 1 })
     }
   }
@@ -241,8 +236,11 @@ function getForegroundProcessNameFromProcessTable(
   pid: number,
   fallbackProcess?: string | null
 ): string | null {
-  const root = rows.find((row) => row.pid === pid)
-  const candidates = collectDescendants(rows, pid).sort(
+  // Why: one memoized index per capture, so N panes sharing the TTL-cached
+  // snapshot no longer each rebuild the parent/child map over every row.
+  const index = getProcessTableIndex(rows)
+  const root = index.byPid.get(pid)
+  const candidates = collectDescendants(index, pid).sort(
     (a, b) => scoreForegroundCandidateRow(b) - scoreForegroundCandidateRow(a)
   )
   // Why: SSH relays do not have the daemon's async wrapper cache. Inspect the

--- a/src/shared/process-table-snapshot.test.ts
+++ b/src/shared/process-table-snapshot.test.ts
@@ -396,12 +396,22 @@ describe('getProcessTableIndex', () => {
     expect(getProcessTableIndex(secondRows)).not.toBe(getProcessTableIndex(firstRows))
   })
 
-  it('resolves a duplicated pid to the LAST row, matching the evidence resolver', () => {
-    // Why: the memo replaces a first-wins `rows.find()`, so pin the deliberate
-    // tie-break — one rule for every index consumer on a malformed capture.
+  it('resolves a duplicated pid to the FIRST row, as `rows.find()` did', () => {
+    // Preserve rows.find() semantics if a malformed table repeats a pid: an argv
+    // newline makes `ps` print a continuation line that can parse as a spurious
+    // row, and that row always follows the real one it was split from.
     const rows = parseProcessTableRows(['100 1 Ss bash', '100 1 Ss+ zsh'].join('\n'))
 
-    expect(getProcessTableIndex(rows).byPid.get(100)).toBe(rows[1])
+    expect(getProcessTableIndex(rows).byPid.get(100)).toBe(rows[0])
+    expect(buildProcessTableIndex(rows).byPid.get(100)).toBe(rows[0])
+  })
+
+  it('materializes only the maps the descendant walk reads', () => {
+    // Why: this memo exists to cut relay CPU; four indexes for two readers would
+    // make a single-pane relay pay more per capture than the code it replaced.
+    const index = getProcessTableIndex(parseProcessTableRows('100 1 Ss bash'))
+
+    expect(Object.keys(index).sort()).toEqual(['byPid', 'childrenByPpid', 'rows', 'stats'])
   })
 
   it('keeps the memo out of measured builds so a cache hit cannot satisfy a perf gate', () => {

--- a/src/shared/process-table-snapshot.test.ts
+++ b/src/shared/process-table-snapshot.test.ts
@@ -9,12 +9,14 @@ vi.mock('node:child_process', () => ({ execFile: execFileMock }))
 import {
   buildProcessTableIndex,
   createProcessTableSnapshotReader,
+  getProcessTableIndex,
   getProcessTableSnapshot,
   getStrictProcessTableSnapshot,
   parseProcessTableRows,
   parseStrictProcessTableRows,
   ProcessTableCaptureError,
-  resetProcessTableSnapshotForTests
+  resetProcessTableSnapshotForTests,
+  type ProcessTableIndexStats
 } from './process-table-snapshot'
 
 function deferred<T>(): {
@@ -370,5 +372,49 @@ describe('parseStrictProcessTableRows', () => {
     expect(() => parseStrictProcessTableRows('PID PPID PGID TPGID STAT COMMAND')).toThrow(
       ProcessTableCaptureError
     )
+  })
+})
+
+describe('getProcessTableIndex', () => {
+  it('reuses one index for the same snapshot identity', () => {
+    const rows = parseProcessTableRows(
+      ['100 1 Ss bash', '101 100 S node codex', '102 100 S vim'].join('\n')
+    )
+
+    const first = getProcessTableIndex(rows)
+    const second = getProcessTableIndex(rows)
+
+    expect(second).toBe(first)
+    expect(first.byPid.get(100)).toBe(rows[0])
+    expect(first.childrenByPpid.get(100)).toEqual([rows[1], rows[2]])
+  })
+
+  it('does not reuse an index across distinct snapshot arrays', () => {
+    const firstRows = parseProcessTableRows('100 1 Ss bash')
+    const secondRows = parseProcessTableRows('100 1 Ss bash')
+
+    expect(getProcessTableIndex(secondRows)).not.toBe(getProcessTableIndex(firstRows))
+  })
+
+  it('resolves a duplicated pid to the LAST row, matching the evidence resolver', () => {
+    // Why: the memo replaces a first-wins `rows.find()`, so pin the deliberate
+    // tie-break — one rule for every index consumer on a malformed capture.
+    const rows = parseProcessTableRows(['100 1 Ss bash', '100 1 Ss+ zsh'].join('\n'))
+
+    expect(getProcessTableIndex(rows).byPid.get(100)).toBe(rows[1])
+  })
+
+  it('keeps the memo out of measured builds so a cache hit cannot satisfy a perf gate', () => {
+    const rows = parseProcessTableRows('100 1 Ss bash')
+    const stats: ProcessTableIndexStats = { indexBuilds: 0, rowVisits: 0, indexLookups: 0 }
+
+    const memoized = getProcessTableIndex(rows)
+    const measured = buildProcessTableIndex(rows, stats)
+
+    expect(memoized.stats).toBeUndefined()
+    expect(measured).not.toBe(memoized)
+    expect(stats).toEqual({ indexBuilds: 1, rowVisits: 1, indexLookups: 0 })
+    // The measured build must not evict or replace the shared memo.
+    expect(getProcessTableIndex(rows)).toBe(memoized)
   })
 })

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -150,7 +150,10 @@ export function buildProcessTableIndex(
     if (stats) {
       stats.rowVisits += 1
     }
-    byPid.set(row.pid, row)
+    // Preserve rows.find() semantics if a malformed table repeats a pid
+    if (!byPid.has(row.pid)) {
+      byPid.set(row.pid, row)
+    }
     const children = childrenByPpid.get(row.ppid) ?? []
     children.push(row)
     childrenByPpid.set(row.ppid, children)
@@ -166,12 +169,25 @@ export function scoreForegroundCandidateRow(row: ProcessTableRow & { depth: numb
   return (row.stat.includes('+') ? 10_000 : 0) + row.depth
 }
 
+export function lookupProcessTableIndex<T>(
+  index: ProcessTableIndex,
+  lookup: (index: ProcessTableIndex) => T,
+  stats = index.stats
+): T {
+  if (stats) {
+    stats.indexLookups += 1
+  }
+  return lookup(index)
+}
+
 const processTableIndexes = new WeakMap<readonly ProcessTableRow[], ProcessTableIndex>()
 
 /**
  * Memoize one index per snapshot identity, so the panes that share a TTL-cached
  * capture walk its rows once instead of once each. Keyed weakly by the rows
- * array, so an index dies with the snapshot that produced it.
+ * array, so an index dies with the snapshot that produced it. The shared build
+ * materializes only `byPid` and `childrenByPpid`, so a one-pane relay pays for
+ * two maps per capture rather than four indexes no resolver queries.
  *
  * Deliberately stats-free: `buildProcessTableIndex` mutates the caller's counter
  * bag and stores it on the index, so a shared index would hand one caller's bag
@@ -187,17 +203,6 @@ export function getProcessTableIndex(rows: readonly ProcessTableRow[]): ProcessT
   const index = buildProcessTableIndex(rows)
   processTableIndexes.set(rows, index)
   return index
-}
-
-export function lookupProcessTableIndex<T>(
-  index: ProcessTableIndex,
-  lookup: (index: ProcessTableIndex) => T,
-  stats = index.stats
-): T {
-  if (stats) {
-    stats.indexLookups += 1
-  }
-  return lookup(index)
 }
 
 type Snapshot<T> = { value: T; capturedAtMs: number }

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -166,6 +166,29 @@ export function scoreForegroundCandidateRow(row: ProcessTableRow & { depth: numb
   return (row.stat.includes('+') ? 10_000 : 0) + row.depth
 }
 
+const processTableIndexes = new WeakMap<readonly ProcessTableRow[], ProcessTableIndex>()
+
+/**
+ * Memoize one index per snapshot identity, so the panes that share a TTL-cached
+ * capture walk its rows once instead of once each. Keyed weakly by the rows
+ * array, so an index dies with the snapshot that produced it.
+ *
+ * Deliberately stats-free: `buildProcessTableIndex` mutates the caller's counter
+ * bag and stores it on the index, so a shared index would hand one caller's bag
+ * to an unrelated later caller and let a cache hit satisfy an `indexBuilds`
+ * measurement without building anything. Measured callers keep calling
+ * `buildProcessTableIndex(rows, stats)` directly.
+ */
+export function getProcessTableIndex(rows: readonly ProcessTableRow[]): ProcessTableIndex {
+  const cached = processTableIndexes.get(rows)
+  if (cached) {
+    return cached
+  }
+  const index = buildProcessTableIndex(rows)
+  processTableIndexes.set(rows, index)
+  return index
+}
+
 export function lookupProcessTableIndex<T>(
   index: ProcessTableIndex,
   lookup: (index: ProcessTableIndex) => T,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |

<!-- /orca-pr-loc -->

## ELI5

`ps` output is cached for 500ms, so a burst of terminal panes all inspect the *same* rows array. Each pane still walked every row to rebuild its own parent→child map before looking for the agent process. This memoizes one index per snapshot, keyed by the array itself, so the first pane in a window pays for the walk and the rest get it free. The `WeakMap` key means the index is released along with the snapshot.

## What Changed

Rebased onto current `main` and re-expressed on top of #17525, which has since merged.

- `src/shared/process-table-snapshot.ts` — add `getProcessTableIndex(rows)`: a `WeakMap<readonly ProcessTableRow[], ProcessTableIndex>` memo sitting directly on top of #17525's `buildProcessTableIndex`. No new index type and no second builder; `main`'s `ProcessTableIndex` remains the only one.
- `src/relay/pty-shell-utils.ts` — `collectDescendants` takes the shared index instead of rebuilding a private `childrenByParent` map per call, and `getForegroundProcessNameFromProcessTable` resolves the PTY root through `index.byPid` instead of `rows.find()`.
- Tests for cache identity, cross-snapshot isolation, the duplicate-pid tie-break, and the stats hazard below.

## Why

`getForegroundProcessName` runs per pane on the 750ms/2000ms inspection cadence and reads the TTL-cached snapshot, so N panes in one window each did an O(rows) map build over an identical array. Now that is one build per capture. #17525 batched the *inventory* path but left this per-pane relay path rebuilding.

## Two Deliberate Decisions

**Duplicate-pid tie-break — kept first-wins, and moved the rule into the shared builder.** `rows.find()` was first-wins; `buildProcessTableIndex` was last-wins (`byPid.set`), so routing the relay through the shared index silently flipped root resolution on a malformed capture. First-wins is restored, and the rule now lives in `buildProcessTableIndex` so `resolveAgentForegroundProcessesFromIndex`'s `byPid.get(rootPid)` root lookup gets the same semantics the subsystem had before indexing.

The tie-break is reachable and *not* symmetric. A process's argv may legally contain a newline, and `ps -axo ... command=` prints it raw, so the lenient parser can accept a continuation line as a spurious row duplicating a real pid — and that spurious row always **follows** the real one it was split from. Last-wins therefore hands the pane's foreground identity to a row assembled from process-controlled argv bytes. First-wins keeps the real root. Pinned by `resolves a duplicated root pid to the FIRST capture row` (relay: `'bash'` → `'codex'`) and `resolves a duplicated pid to the FIRST row, as \`rows.find()\` did` (shared, asserted against both `getProcessTableIndex` and `buildProcessTableIndex`); both confirmed red against the previous commit.

**The memo builds only the two indexes a resolver reads.** Delegating to a four-map `buildProcessTableIndex` (`byPid`, `childrenByPpid`, `byPgid`, `byTpgid`) made this PR *slower* in the topology it is meant to help: the relay path reads only `byPid` and `childrenByPpid`, and the code it replaced built exactly one map. A single-pane relay would have gone from ~3 map/array ops per row per 500ms window to ~10. `byPgid`/`byTpgid` have no readers anywhere in the repo, so they are dropped — the same deletion #17763 makes, written line for line to match it. Pinned by `materializes only the maps the descendant walk reads`.

Per 500ms TTL window, over `N` rows and `P` panes polling in that window:

| | map builds | row visits | map/array ops |
| :--- | ---: | ---: | ---: |
| before this PR, P=1 | 1 | ~1.5N (`find` + walk) | ~3N |
| PR head 55b1028 (4 maps), P=1 | 4 | N | ~10N |
| this branch (2 maps), P=1 | 2 | N | ~5N |
| before this PR, P=20 | 20 | ~30N | ~60N |
| PR head 55b1028 (4 maps), P=20 | 4 | N | ~10N |
| this branch (2 maps), P=20 | 2 | N | ~5N |

Those are op counts, not timings. Measured wall clock (Node 24.18, macOS arm64, one process per variant, real bundled `getForegroundProcessNameFromProcessTable` from each revision; 20 000 warmed windows per config; a fresh rows-array copy per window so the `WeakMap` key turns over exactly as it does in production, with the copy outside the timed region; root pid placed mid-table so `main`'s `rows.find` pays its average scan). Median µs per 500 ms window:

**400-row table**

| panes | `main` | 55b1028 (4 maps) | this branch (2 maps) |
| ---: | ---: | ---: | ---: |
| 1 | 5.0 | 24.9 | 11.9 |
| 2 | 9.8 | | 13.8 |
| 3 | 18.9 | | 15.4 |
| 4 | 19.8 | | 17.0 |
| 8 | 39.0 | | 24.0 |
| 20 | 99.3 | 58.5 | 44.0 |

**2000-row table**

| panes | `main` | 55b1028 (4 maps) | this branch (2 maps) |
| ---: | ---: | ---: | ---: |
| 1 | 17.4 | 117.8 | 50.6 |
| 20 | 349.6 | 152.4 | 83.5 |

Stated plainly: **at 1 pane this is a real regression, not a wash.** It costs ~1.5–2.4x at 400 rows (`main` ranged 4.9–7.8 µs across repeated runs, this branch a stable 11.9 µs) and ~2.9x at 2000 rows. In absolute terms that is **+5 µs per 500 ms window at 400 rows and +33 µs at 2000 rows** — single-digit to low-tens of microseconds against a 500 000 µs window, so it is a regression worth stating plainly but not one a user can perceive. Break-even is **between 2 and 3 panes**. Past that the win grows with `P`: 1.6x at 8 panes and 2.2x at 20 panes on a 400-row table, and 4.2x at 20 panes on a 2000-row table.

The wall-clock win is smaller than the op-count table above suggests (~12x fewer map/array ops at 20 panes) because the memo removes only the *index build*. The descendant walk, the candidate sort and `recognizeAgentProcessFromCommandLine` still run once per pane and set the floor: at 20 panes over 400 rows this branch spends ~12 µs building the one index and ~1.7 µs per pane after it. Any claim of a ~10x end-to-end speedup would be reading the op-count ratio as if it were wall clock.

The four-map version was a worse 1-pane regression than "~3x" — 24.9 µs vs 5.0 µs (~5x) at 400 rows, 117.8 µs vs 17.4 µs (~6.8x) at 2000 rows — which is what motivated narrowing the build to the two maps a resolver reads.

**The memo is deliberately stats-free.** `buildProcessTableIndex(rows, stats)` mutates the caller's counter bag and stores it on the returned index, and `lookupProcessTableIndex` increments it afterwards. Memoizing such an index would hand one caller's bag to an unrelated later caller and let a cache hit satisfy an `indexBuilds` assertion without building anything. `getProcessTableIndex` therefore takes no `stats` and never memoizes a measured build; the perf gate in `agent-foreground-process-batch.test.ts` still calls `buildProcessTableIndex(rows, stats)` directly and still measures a real build. Pinned by `keeps the memo out of measured builds so a cache hit cannot satisfy a perf gate`.

## Notes On The Rebase

- `src/shared/process-table-snapshot.ts` **auto-merged with no conflict markers** into a file declaring `export type ProcessTableIndex` twice — `git status` reported it clean and every test still passed; only `tsc` catches it (TS2300). Resolved by taking `main`'s file wholesale and re-adding only the memo.
- Real conflicts in `src/relay/pty-shell-utils.ts` and `src/shared/process-table-snapshot.test.ts` were resolved to `main`'s #17525 structure, then the memo was reapplied on top.
- The `[...evidenceRows]` spread this PR originally needed to remove **no longer exists**: #17525 rewrote `listProcesses` to publish titles from `evidenceResults[entryIndex]`, so nothing copies the rows array and the identity key is intact. For the same reason the "hoist one index across both the batch resolver and the title path" idea is already satisfied on `main` — a listing walks the table once. No change needed there.

## Interaction With #17763

#17763 (`brennanb2025/r1-build-review-fixes`) edits the same files: it collapses the two `ps` readers into one `ProcessTableCapture` with lazy `lenient()`/`strict()` parsers and drops `byPgid`/`byTpgid`. **There is no merge-ordering constraint** — the `byPgid`/`byTpgid` deletion is duplicated here rather than deferred, so this branch stands on its own at the cost measured above (a small 1-pane regression, break-even by ~3 panes, a growing win beyond) instead of needing #17763 to land first to narrow the build.

- The deletion is written to match #17763's byte for byte, so the type hunk, the loop-body hunk and the first-wins line all auto-merge.
- `ProcessTableCapture.lenient()` memoizes its parse per capture, so snapshot array identity — the thing this cache keys on — survives.
- The memo block was moved below `lookupProcessTableIndex` so #17763's insertion of `scoreForegroundCandidateRow` lands on unchanged context.
- Verified by test-merging `add1f1c8a48`: `process-table-snapshot.ts` now has exactly **one** 1-line conflict (both sides rewrite the `return { ... }` line; #17763's side is correct as-is). The other three conflicts — two import lists and the `getForegroundProcessNameFromProcessTable` body — are unchanged from before this commit and are inherent to both PRs rewriting that function.

## Linked Issue

N/A — proactive performance audit.

## Visual Proof

`N/A` — relay/shared process bookkeeping only; no UI or interaction change.

## Testing

- `pnpm tc:node` — clean (run first; the only check that catches the silent duplicate-type auto-merge).
- `pnpm test src/shared/process-table-snapshot.test.ts src/relay/pty-shell-utils.test.ts src/main/providers/` — 858 passed, 5 skipped.
- `pnpm exec oxlint` / `pnpm exec oxfmt --check` on all four changed files — clean.
- Every new test confirmed red against pre-fix source, then restored (3 failures: both first-wins tests and the narrow-index test).
- Local macOS only; no live SSH/network-failure or native Windows/WSL run was available.

## Review

Ready for review. The earlier "#17525 may supersede this; do not merge both implementations" note is obsolete — #17525 has merged as `9477b5fcbb9`, this branch now builds on it rather than duplicating it, and the overlap it warned about is gone.

No RPC, wire, persistence, mobile schema, provider, or path contract changes are included.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (CI will cover; focused local checks listed above)


