### PR TITLE
perf(worktree): tune Windows and WSL checkout creation

### DIFF
--- a/src/main/git/add-sparse-worktree.test.ts
+++ b/src/main/git/add-sparse-worktree.test.ts
@@ -97,8 +97,8 @@ describe('addSparseWorktree', () => {
     const calls = getGitCalls()
     expect(calls).toEqual(
       expect.arrayContaining([
-        'git -c core.longpaths=true -c checkout.workers=-1 sparse-checkout set -- packages/web',
-        'git -c core.longpaths=true -c checkout.workers=-1 checkout feature/test'
+        'git -c core.longpaths=true -c core.fscache=false -c checkout.workers=-1 sparse-checkout set -- packages/web',
+        'git -c core.longpaths=true -c core.fscache=false -c checkout.workers=-1 checkout feature/test'
       ])
     )
   })

--- a/src/main/git/add-sparse-worktree.test.ts
+++ b/src/main/git/add-sparse-worktree.test.ts
@@ -97,8 +97,8 @@ describe('addSparseWorktree', () => {
     const calls = getGitCalls()
     expect(calls).toEqual(
       expect.arrayContaining([
-        'git -c core.longpaths=true sparse-checkout set -- packages/web',
-        'git -c core.longpaths=true checkout feature/test'
+        'git -c core.longpaths=true -c checkout.workers=-1 sparse-checkout set -- packages/web',
+        'git -c core.longpaths=true -c checkout.workers=-1 checkout feature/test'
       ])
     )
   })

--- a/src/main/git/add-sparse-worktree.test.ts
+++ b/src/main/git/add-sparse-worktree.test.ts
@@ -97,6 +97,7 @@ describe('addSparseWorktree', () => {
     const calls = getGitCalls()
     expect(calls).toEqual(
       expect.arrayContaining([
+        'git -c core.longpaths=true sparse-checkout init --cone',
         'git -c core.longpaths=true -c core.fscache=false -c checkout.workers=-1 sparse-checkout set -- packages/web',
         'git -c core.longpaths=true -c core.fscache=false -c checkout.workers=-1 checkout feature/test'
       ])

--- a/src/main/git/repo-branch-conflict.test.ts
+++ b/src/main/git/repo-branch-conflict.test.ts
@@ -128,8 +128,6 @@ describe('getBranchConflictKindViaExec', () => {
     })
 
     await expect(getBranchConflictKindViaExec(exec, 'feature/example')).resolves.toBe('remote')
-    await expect(
-      getBranchConflictKindViaExec(exec, 'main', 'origin/main')
-    ).resolves.toBeNull()
+    await expect(getBranchConflictKindViaExec(exec, 'main', 'origin/main')).resolves.toBeNull()
   })
 })

--- a/src/main/git/repo-branch-conflict.test.ts
+++ b/src/main/git/repo-branch-conflict.test.ts
@@ -83,6 +83,37 @@ describe('getBranchConflictKindViaExec', () => {
     expect(calls).toContainEqual(['rev-parse', '--verify', 'refs/heads/feature/example'])
   })
 
+  it('retries the remote-only walk when the batched refs walk fails', async () => {
+    const calls: string[][] = []
+    let refWalkCount = 0
+    const exec = vi.fn((args: string[]) => {
+      calls.push(args)
+      if (args[0] === 'remote') {
+        return Promise.resolve({ stdout: 'origin\n' })
+      }
+      if (args[0] === 'rev-parse') {
+        return Promise.resolve({ stdout: '' })
+      }
+      if (args[0] === 'for-each-ref') {
+        refWalkCount += 1
+        if (refWalkCount === 1) {
+          return Promise.reject(new Error('unsupported'))
+        }
+        return Promise.resolve({ stdout: 'refs/remotes/origin/feature/example\n' })
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    await expect(getBranchConflictKindViaExec(exec, 'feature/example')).resolves.toBe('remote')
+    expect(calls).toContainEqual([
+      'for-each-ref',
+      '--format=%(refname)',
+      'refs/heads/feature/example',
+      'refs/remotes'
+    ])
+    expect(calls).toContainEqual(['for-each-ref', '--format=%(refname)', 'refs/remotes'])
+  })
+
   it('matches a remote conflict and honors an allowed base ref', async () => {
     const exec = vi.fn((args: string[]) => {
       if (args[0] === 'remote') {

--- a/src/main/git/repo-branch-conflict.test.ts
+++ b/src/main/git/repo-branch-conflict.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getBranchConflictKindViaExec } from './repo-branch-conflict'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+describe('getBranchConflictKindViaExec', () => {
+  it('starts remote-name and remote-ref probes together after local absence', async () => {
+    const remoteNames = deferred<{ stdout: string }>()
+    const remoteRefs = deferred<{ stdout: string }>()
+    const calls: string[][] = []
+    const exec = vi.fn((args: string[]) => {
+      calls.push(args)
+      if (args[0] === 'rev-parse') {
+        return Promise.resolve({ stdout: '' })
+      }
+      if (args[0] === 'remote') {
+        return remoteNames.promise
+      }
+      if (args[0] === 'for-each-ref') {
+        return remoteRefs.promise
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    const resultPromise = getBranchConflictKindViaExec(exec, 'feature/example')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(calls).toEqual([
+      ['rev-parse', '--verify', 'refs/heads/feature/example'],
+      ['remote'],
+      ['for-each-ref', '--format=%(refname)', 'refs/remotes']
+    ])
+
+    remoteNames.resolve({ stdout: 'origin\n' })
+    remoteRefs.resolve({ stdout: 'refs/remotes/origin/other\n' })
+    await expect(resultPromise).resolves.toBeNull()
+  })
+})

--- a/src/main/git/repo-branch-conflict.test.ts
+++ b/src/main/git/repo-branch-conflict.test.ts
@@ -13,15 +13,12 @@ function deferred<T>(): {
 }
 
 describe('getBranchConflictKindViaExec', () => {
-  it('starts remote-name and remote-ref probes together after local absence', async () => {
+  it('batches local and remote refs while probing remote names concurrently', async () => {
     const remoteNames = deferred<{ stdout: string }>()
     const remoteRefs = deferred<{ stdout: string }>()
     const calls: string[][] = []
     const exec = vi.fn((args: string[]) => {
       calls.push(args)
-      if (args[0] === 'rev-parse') {
-        return Promise.resolve({ stdout: '' })
-      }
       if (args[0] === 'remote') {
         return remoteNames.promise
       }
@@ -36,13 +33,72 @@ describe('getBranchConflictKindViaExec', () => {
     await Promise.resolve()
 
     expect(calls).toEqual([
-      ['rev-parse', '--verify', 'refs/heads/feature/example'],
-      ['remote'],
-      ['for-each-ref', '--format=%(refname)', 'refs/remotes']
+      ['for-each-ref', '--format=%(refname)', 'refs/heads/feature/example', 'refs/remotes'],
+      ['remote']
     ])
 
     remoteNames.resolve({ stdout: 'origin\n' })
     remoteRefs.resolve({ stdout: 'refs/remotes/origin/other\n' })
     await expect(resultPromise).resolves.toBeNull()
+  })
+
+  it('keeps local conflict precedence without waiting for remote names', async () => {
+    const remoteNames = deferred<{ stdout: string }>()
+    const calls: string[][] = []
+    const exec = vi.fn((args: string[]) => {
+      calls.push(args)
+      if (args[0] === 'remote') {
+        return remoteNames.promise
+      }
+      if (args[0] === 'for-each-ref') {
+        return Promise.resolve({ stdout: 'refs/heads/feature/example\n' })
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    await expect(getBranchConflictKindViaExec(exec, 'feature/example')).resolves.toBe('local')
+    expect(calls).toEqual([
+      ['for-each-ref', '--format=%(refname)', 'refs/heads/feature/example', 'refs/remotes'],
+      ['remote']
+    ])
+  })
+
+  it('falls back to the local probe when the batched refs walk fails', async () => {
+    const calls: string[][] = []
+    const exec = vi.fn((args: string[]) => {
+      calls.push(args)
+      if (args[0] === 'for-each-ref') {
+        return Promise.reject(new Error('unsupported'))
+      }
+      if (args[0] === 'remote') {
+        return Promise.resolve({ stdout: 'origin\n' })
+      }
+      if (args[0] === 'rev-parse') {
+        return Promise.resolve({ stdout: 'abc123\n' })
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    await expect(getBranchConflictKindViaExec(exec, 'feature/example')).resolves.toBe('local')
+    expect(calls).toContainEqual(['rev-parse', '--verify', 'refs/heads/feature/example'])
+  })
+
+  it('matches a remote conflict and honors an allowed base ref', async () => {
+    const exec = vi.fn((args: string[]) => {
+      if (args[0] === 'remote') {
+        return Promise.resolve({ stdout: 'origin\n' })
+      }
+      if (args[0] === 'for-each-ref') {
+        return Promise.resolve({
+          stdout: 'refs/remotes/origin/feature/example\nrefs/remotes/origin/main\n'
+        })
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    await expect(getBranchConflictKindViaExec(exec, 'feature/example')).resolves.toBe('remote')
+    await expect(
+      getBranchConflictKindViaExec(exec, 'main', 'origin/main')
+    ).resolves.toBeNull()
   })
 })

--- a/src/main/git/repo-branch-conflict.ts
+++ b/src/main/git/repo-branch-conflict.ts
@@ -35,6 +35,23 @@ function parseRefLines(stdout: string): Set<string> {
   )
 }
 
+function hasRemoteBranchConflict(
+  refs: Iterable<string>,
+  remoteNames: readonly string[],
+  branchName: string,
+  allowedBaseRef: string | undefined
+): boolean {
+  return [...refs].some((ref) => {
+    if (!ref.startsWith('refs/remotes/')) {
+      return false
+    }
+    if (isAllowedRemoteBaseRef(ref, allowedBaseRef)) {
+      return false
+    }
+    return resolveConfiguredRemoteBranchName(ref, remoteNames) === branchName
+  })
+}
+
 /** Run branch-conflict policy through the host that owns Git execution. */
 export async function getBranchConflictKindViaExec(
   exec: GitExec,
@@ -61,8 +78,26 @@ export async function getBranchConflictKindViaExec(
   } catch {
     // Keep the old local-first behavior if the combined read is unavailable.
     // A broken refs walk must not turn an existing local branch into a remote
-    // conflict (or make the create path throw).
-    return (await hasGitRefAsync(exec, localRef)) ? 'local' : null
+    // conflict (or make the create path throw). If local is absent, retry the
+    // old remote-only walk so a transient/unsupported multi-pattern command
+    // does not hide a real remote conflict.
+    if (await hasGitRefAsync(exec, localRef)) {
+      return 'local'
+    }
+    try {
+      const remoteNames = await remoteNamesPromise
+      const remoteRefs = await exec(['for-each-ref', '--format=%(refname)', 'refs/remotes'])
+      return hasRemoteBranchConflict(
+        parseRefLines(remoteRefs.stdout),
+        remoteNames,
+        branchName,
+        allowedBaseRef
+      )
+        ? 'remote'
+        : null
+    } catch {
+      return null
+    }
   }
 
   const refs = parseRefLines(stdout)
@@ -71,15 +106,12 @@ export async function getBranchConflictKindViaExec(
   }
 
   const remoteNames = await remoteNamesPromise
-  const hasRemoteConflict = [...refs].some((ref) => {
-    if (!ref.startsWith('refs/remotes/')) {
-      return false
-    }
-    if (isAllowedRemoteBaseRef(ref, allowedBaseRef)) {
-      return false
-    }
-    return resolveConfiguredRemoteBranchName(ref, remoteNames) === branchName
-  })
+  const hasRemoteConflict = hasRemoteBranchConflict(
+    refs,
+    remoteNames,
+    branchName,
+    allowedBaseRef
+  )
 
   return hasRemoteConflict ? 'remote' : null
 }

--- a/src/main/git/repo-branch-conflict.ts
+++ b/src/main/git/repo-branch-conflict.ts
@@ -37,8 +37,12 @@ export async function getBranchConflictKindViaExec(
   }
 
   try {
-    const remoteNames = await listRemoteNamesViaExec(exec)
-    const { stdout } = await exec(['for-each-ref', '--format=%(refname)', 'refs/remotes'])
+    // Both probes are read-only and independent. Keeping them in flight together
+    // removes one Git/WSL process-start interval from the common no-conflict path.
+    const [remoteNames, { stdout }] = await Promise.all([
+      listRemoteNamesViaExec(exec),
+      exec(['for-each-ref', '--format=%(refname)', 'refs/remotes'])
+    ])
     const hasRemoteConflict = stdout.split(/\r?\n/).some((ref) => {
       const trimmed = ref.trim()
       if (isAllowedRemoteBaseRef(trimmed, allowedBaseRef)) {

--- a/src/main/git/repo-branch-conflict.ts
+++ b/src/main/git/repo-branch-conflict.ts
@@ -26,35 +26,62 @@ async function listRemoteNamesViaExec(exec: GitExec): Promise<string[]> {
   }
 }
 
+function parseRefLines(stdout: string): Set<string> {
+  return new Set(
+    stdout
+      .split(/\r?\n/)
+      .map((ref) => ref.trim())
+      .filter(Boolean)
+  )
+}
+
 /** Run branch-conflict policy through the host that owns Git execution. */
 export async function getBranchConflictKindViaExec(
   exec: GitExec,
   branchName: string,
   allowedBaseRef?: string
 ): Promise<BranchConflictKind | null> {
-  if (await hasGitRefAsync(exec, `refs/heads/${branchName}`)) {
+  const localRef = `refs/heads/${branchName}`
+
+  // One ref walk can answer both questions. Keeping the remote-name probe in
+  // flight removes a WSL/Git process-start interval without changing the
+  // configured-remote matching rules below.
+  const refsPromise = exec([
+    'for-each-ref',
+    '--format=%(refname)',
+    `refs/heads/${branchName}`,
+    'refs/remotes'
+  ])
+  const remoteNamesPromise = listRemoteNamesViaExec(exec)
+
+  let stdout: string
+  try {
+    const refsResult = await refsPromise
+    stdout = refsResult.stdout
+  } catch {
+    // Keep the old local-first behavior if the combined read is unavailable.
+    // A broken refs walk must not turn an existing local branch into a remote
+    // conflict (or make the create path throw).
+    return (await hasGitRefAsync(exec, localRef)) ? 'local' : null
+  }
+
+  const refs = parseRefLines(stdout)
+  if (refs.has(localRef)) {
     return 'local'
   }
 
-  try {
-    // Both probes are read-only and independent. Keeping them in flight together
-    // removes one Git/WSL process-start interval from the common no-conflict path.
-    const [remoteNames, { stdout }] = await Promise.all([
-      listRemoteNamesViaExec(exec),
-      exec(['for-each-ref', '--format=%(refname)', 'refs/remotes'])
-    ])
-    const hasRemoteConflict = stdout.split(/\r?\n/).some((ref) => {
-      const trimmed = ref.trim()
-      if (isAllowedRemoteBaseRef(trimmed, allowedBaseRef)) {
-        return false
-      }
-      return resolveConfiguredRemoteBranchName(trimmed, remoteNames) === branchName
-    })
+  const remoteNames = await remoteNamesPromise
+  const hasRemoteConflict = [...refs].some((ref) => {
+    if (!ref.startsWith('refs/remotes/')) {
+      return false
+    }
+    if (isAllowedRemoteBaseRef(ref, allowedBaseRef)) {
+      return false
+    }
+    return resolveConfiguredRemoteBranchName(ref, remoteNames) === branchName
+  })
 
-    return hasRemoteConflict ? 'remote' : null
-  } catch {
-    return null
-  }
+  return hasRemoteConflict ? 'remote' : null
 }
 
 export function getBranchConflictKind(

--- a/src/main/git/repo-branch-conflict.ts
+++ b/src/main/git/repo-branch-conflict.ts
@@ -106,12 +106,7 @@ export async function getBranchConflictKindViaExec(
   }
 
   const remoteNames = await remoteNamesPromise
-  const hasRemoteConflict = hasRemoteBranchConflict(
-    refs,
-    remoteNames,
-    branchName,
-    allowedBaseRef
-  )
+  const hasRemoteConflict = hasRemoteBranchConflict(refs, remoteNames, branchName, allowedBaseRef)
 
   return hasRemoteConflict ? 'remote' : null
 }

--- a/src/main/git/repo-default-base-ref-batch.test.ts
+++ b/src/main/git/repo-default-base-ref-batch.test.ts
@@ -144,7 +144,61 @@ describe('WSL default-base ref batching', () => {
     }
   })
 
-  it('does not batch native probes, preserving their existing execution shape', async () => {
+  it('batches native Windows probes with the same exact argv as WSL', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      gitExecFileAsyncMock.mockResolvedValue({
+        stdout: 'refs/heads/main\0\0commit\0\n'
+      })
+
+      await expect(getBaseRefDefault('C:\\repo')).resolves.toBe('main')
+      expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+      expect(gitExecFileAsyncMock).toHaveBeenCalledWith(batchArgs(), {
+        cwd: 'C:\\repo',
+        timeout: 15_000
+      })
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('falls back to serial native Windows probes when batching is unsupported', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => {
+        if (argv[0] === 'for-each-ref') {
+          throw new Error('unsupported command')
+        }
+        if (argv[0] === 'symbolic-ref') {
+          throw new Error('origin/HEAD is unset')
+        }
+        if (argv[0] === 'rev-parse' && argv.at(-1) === 'refs/remotes/origin/main') {
+          throw new Error('missing main')
+        }
+        if (argv[0] === 'rev-parse' && argv.at(-1) === 'refs/heads/main') {
+          return { stdout: 'main-sha\n' }
+        }
+        throw new Error('missing ref')
+      })
+
+      await expect(getBaseRefDefault('C:\\repo')).resolves.toBe('main')
+      expect(gitExecFileAsyncMock.mock.calls.map(([argv]) => argv)).toEqual([
+        batchArgs(),
+        ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main'],
+        ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/master'],
+        ['rev-parse', '--verify', '--quiet', 'refs/heads/main']
+      ])
+      for (const [, options] of gitExecFileAsyncMock.mock.calls) {
+        expect(options).toEqual({ cwd: 'C:\\repo', timeout: 15_000 })
+      }
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('keeps POSIX probes serial', async () => {
     gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => {
       if (argv[0] === 'symbolic-ref') {
         throw new Error('origin/HEAD is unset')

--- a/src/main/git/repo-default-base-ref-batch.test.ts
+++ b/src/main/git/repo-default-base-ref-batch.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitExecFileSync: vi.fn()
+}))
+
+import { getBaseRefDefault } from './repo'
+
+const repoPath = String.raw`\\wsl.localhost\Ubuntu\home\neil\repo`
+const gitOptions = { cwd: repoPath, timeout: 15_000, wslDistro: 'Ubuntu' }
+
+function batchArgs(): string[] {
+  return [
+    'for-each-ref',
+    '--format=%(refname)',
+    'refs/remotes/origin/main',
+    'refs/remotes/origin/master',
+    'refs/heads/main',
+    'refs/heads/master'
+  ]
+}
+
+beforeEach(() => {
+  gitExecFileAsyncMock.mockReset()
+})
+
+describe('WSL default-base ref batching', () => {
+  it('returns a valid origin/HEAD target without running the fallback batch', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === 'symbolic-ref') {
+        return { stdout: 'refs/remotes/origin/main\n' }
+      }
+      if (argv[0] === 'rev-parse') {
+        return { stdout: 'abc123\n' }
+      }
+      throw new Error(`unexpected ${argv.join(' ')}`)
+    })
+
+    await expect(getBaseRefDefault(repoPath, { wslDistro: 'Ubuntu' })).resolves.toBe('origin/main')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalledWith(batchArgs(), gitOptions)
+  })
+
+  it('uses the configured fallback priority even when Git returns refs in another order', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === 'symbolic-ref') {
+        return { stdout: 'refs/remotes/origin/missing\n' }
+      }
+      if (argv[0] === 'rev-parse') {
+        throw new Error('missing origin HEAD target')
+      }
+      if (argv[0] === 'for-each-ref') {
+        return {
+          stdout:
+            'refs/heads/master\nrefs/heads/main\nrefs/remotes/origin/master\nrefs/remotes/origin/main\n'
+        }
+      }
+      throw new Error(`unexpected ${argv.join(' ')}`)
+    })
+
+    await expect(getBaseRefDefault(repoPath, { wslDistro: 'Ubuntu' })).resolves.toBe('origin/main')
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(batchArgs(), gitOptions)
+  })
+
+  it('falls back to individual probes when the batch command fails', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === 'symbolic-ref' || argv[0] === 'for-each-ref') {
+        throw new Error('unsupported command')
+      }
+      if (argv[0] === 'rev-parse' && argv.at(-1) === 'refs/remotes/origin/main') {
+        throw new Error('missing main')
+      }
+      if (argv[0] === 'rev-parse' && argv.at(-1) === 'refs/remotes/origin/master') {
+        return { stdout: 'master-sha\n' }
+      }
+      throw new Error(`unexpected ${argv.join(' ')}`)
+    })
+
+    await expect(getBaseRefDefault(repoPath, { wslDistro: 'Ubuntu' })).resolves.toBe(
+      'origin/master'
+    )
+
+    expect(gitExecFileAsyncMock.mock.calls.map(([argv]) => argv)).toEqual([
+      ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
+      batchArgs(),
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/master']
+    ])
+    for (const [, options] of gitExecFileAsyncMock.mock.calls) {
+      expect(options).toEqual(gitOptions)
+    }
+  })
+
+  it('treats an absent origin/HEAD as a normal batch fallback', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === 'symbolic-ref') {
+        throw new Error('origin/HEAD is unset')
+      }
+      if (argv[0] === 'for-each-ref') {
+        return { stdout: 'refs/heads/master\n' }
+      }
+      throw new Error(`unexpected ${argv.join(' ')}`)
+    })
+
+    await expect(getBaseRefDefault(repoPath, { wslDistro: 'Ubuntu' })).resolves.toBe('master')
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(batchArgs(), gitOptions)
+  })
+
+  it('does not batch native probes, preserving their existing execution shape', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => {
+      if (argv[0] === 'symbolic-ref') {
+        throw new Error('origin/HEAD is unset')
+      }
+      if (argv[0] === 'rev-parse' && argv.at(-1) === 'refs/heads/main') {
+        return { stdout: 'main-sha\n' }
+      }
+      throw new Error('missing ref')
+    })
+
+    await expect(getBaseRefDefault('/repo')).resolves.toBe('main')
+    expect(gitExecFileAsyncMock.mock.calls.map(([argv]) => argv)).toEqual([
+      ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/master'],
+      ['rev-parse', '--verify', '--quiet', 'refs/heads/main']
+    ])
+  })
+})

--- a/src/main/git/repo-default-base-ref-batch.test.ts
+++ b/src/main/git/repo-default-base-ref-batch.test.ts
@@ -17,7 +17,8 @@ const gitOptions = { cwd: repoPath, timeout: 15_000, wslDistro: 'Ubuntu' }
 function batchArgs(): string[] {
   return [
     'for-each-ref',
-    '--format=%(refname)',
+    '--format=%(refname)%00%(symref)%00%(objecttype)%00%(*objecttype)',
+    'refs/remotes/origin/HEAD',
     'refs/remotes/origin/main',
     'refs/remotes/origin/master',
     'refs/heads/main',
@@ -32,33 +33,29 @@ beforeEach(() => {
 describe('WSL default-base ref batching', () => {
   it('returns a valid origin/HEAD target without running the fallback batch', async () => {
     gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => {
-      if (argv[0] === 'symbolic-ref') {
-        return { stdout: 'refs/remotes/origin/main\n' }
-      }
-      if (argv[0] === 'rev-parse') {
-        return { stdout: 'abc123\n' }
+      if (argv[0] === 'for-each-ref') {
+        return {
+          stdout: 'refs/remotes/origin/HEAD\0refs/remotes/origin/main\0commit\0\n'
+        }
       }
       throw new Error(`unexpected ${argv.join(' ')}`)
     })
 
     await expect(getBaseRefDefault(repoPath, { wslDistro: 'Ubuntu' })).resolves.toBe('origin/main')
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
-    expect(gitExecFileAsyncMock).not.toHaveBeenCalledWith(batchArgs(), gitOptions)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(batchArgs(), gitOptions)
   })
 
   it('uses the configured fallback priority even when Git returns refs in another order', async () => {
     gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => {
-      if (argv[0] === 'symbolic-ref') {
-        return { stdout: 'refs/remotes/origin/missing\n' }
-      }
-      if (argv[0] === 'rev-parse') {
-        throw new Error('missing origin HEAD target')
-      }
       if (argv[0] === 'for-each-ref') {
         return {
           stdout:
-            'refs/heads/master\nrefs/heads/main\nrefs/remotes/origin/master\nrefs/remotes/origin/main\n'
+            'refs/heads/master\0\0commit\0\n' +
+            'refs/heads/main\0\0commit\0\n' +
+            'refs/remotes/origin/master\0\0commit\0\n' +
+            'refs/remotes/origin/main\0\0commit\0\n'
         }
       }
       throw new Error(`unexpected ${argv.join(' ')}`)
@@ -70,7 +67,7 @@ describe('WSL default-base ref batching', () => {
 
   it('falls back to individual probes when the batch command fails', async () => {
     gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => {
-      if (argv[0] === 'symbolic-ref' || argv[0] === 'for-each-ref') {
+      if (argv[0] === 'for-each-ref') {
         throw new Error('unsupported command')
       }
       if (argv[0] === 'rev-parse' && argv.at(-1) === 'refs/remotes/origin/main') {
@@ -87,7 +84,6 @@ describe('WSL default-base ref batching', () => {
     )
 
     expect(gitExecFileAsyncMock.mock.calls.map(([argv]) => argv)).toEqual([
-      ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
       batchArgs(),
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main'],
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/master']
@@ -99,18 +95,53 @@ describe('WSL default-base ref batching', () => {
 
   it('treats an absent origin/HEAD as a normal batch fallback', async () => {
     gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => {
-      if (argv[0] === 'symbolic-ref') {
-        throw new Error('origin/HEAD is unset')
-      }
       if (argv[0] === 'for-each-ref') {
-        return { stdout: 'refs/heads/master\n' }
+        return { stdout: 'refs/heads/master\0\0commit\0\n' }
       }
       throw new Error(`unexpected ${argv.join(' ')}`)
     })
 
     await expect(getBaseRefDefault(repoPath, { wslDistro: 'Ubuntu' })).resolves.toBe('master')
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
-    expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(batchArgs(), gitOptions)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(batchArgs(), gitOptions)
+  })
+
+  it('accepts an origin/HEAD that points at an annotated commit tag', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'refs/remotes/origin/HEAD\0refs/tags/release\0tag\0commit\n'
+    })
+
+    await expect(getBaseRefDefault(repoPath, { wslDistro: 'Ubuntu' })).resolves.toBe(
+      'refs/tags/release'
+    )
+  })
+
+  it('ignores an origin/HEAD that does not resolve to a commit', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout:
+        'refs/remotes/origin/HEAD\0refs/tags/blob-release\0blob\0\n' +
+        'refs/remotes/origin/main\0\0commit\0\n'
+    })
+
+    await expect(getBaseRefDefault(repoPath, { wslDistro: 'Ubuntu' })).resolves.toBe('origin/main')
+  })
+
+  it('batches a WSL UNC path even when the caller omits the distro override', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      gitExecFileAsyncMock.mockResolvedValue({
+        stdout: 'refs/remotes/origin/HEAD\0refs/remotes/origin/main\0commit\0\n'
+      })
+
+      await expect(getBaseRefDefault(repoPath)).resolves.toBe('origin/main')
+      expect(gitExecFileAsyncMock).toHaveBeenCalledWith(batchArgs(), {
+        cwd: repoPath,
+        timeout: 15_000
+      })
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
   })
 
   it('does not batch native probes, preserving their existing execution shape', async () => {

--- a/src/main/git/repo-default-base-ref.ts
+++ b/src/main/git/repo-default-base-ref.ts
@@ -36,6 +36,26 @@ async function resolveDefaultBaseRefFromProbes(
   return null
 }
 
+/** Probe the conventional refs in one Git process; retain the old loop as a fallback. */
+async function resolveDefaultBaseRefFromBatchedProbes(exec: GitExec): Promise<string | null> {
+  try {
+    const { stdout } = await exec([
+      'for-each-ref',
+      '--format=%(refname)',
+      ...DEFAULT_BASE_REF_PROBES.map(({ ref }) => ref)
+    ])
+    const refs = new Set(
+      stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => DEFAULT_BASE_REF_PROBES.some(({ ref }) => ref === line))
+    )
+    return DEFAULT_BASE_REF_PROBES.find(({ ref }) => refs.has(ref))?.returnAs ?? null
+  } catch {
+    return resolveDefaultBaseRefFromProbes((ref) => hasGitRefViaExec(exec, ref))
+  }
+}
+
 function hasGitRef(path: string, ref: string): boolean {
   try {
     gitExecFileSync(['rev-parse', '--verify', ref], { cwd: path })
@@ -117,12 +137,25 @@ export async function resolveDefaultBaseRefViaExec(exec: GitExec): Promise<strin
 export function resolveDefaultBaseRefWithLocalGit(
   options: LocalDefaultBaseRefGitOptions
 ): Promise<string | null> {
-  return resolveDefaultBaseRefViaExec((argv) =>
+  const exec = (argv: string[]) =>
     gitExecFileAsync(argv, {
       ...options,
       timeout: DEFAULT_BASE_REF_PROBE_TIMEOUT_MS
     })
-  )
+  // WSL process startup makes the four fallback probes visible in create latency.
+  return options.wslDistro
+    ? resolveDefaultBaseRefViaExecWithBatchedProbes(exec)
+    : resolveDefaultBaseRefViaExec(exec)
+}
+
+async function resolveDefaultBaseRefViaExecWithBatchedProbes(
+  exec: GitExec
+): Promise<string | null> {
+  const originHeadBaseRef = await resolveVerifiedOriginHeadBaseRefViaExec(exec)
+  if (originHeadBaseRef) {
+    return originHeadBaseRef
+  }
+  return resolveDefaultBaseRefFromBatchedProbes(exec)
 }
 
 export function getDefaultBaseRefAsync(

--- a/src/main/git/repo-default-base-ref.ts
+++ b/src/main/git/repo-default-base-ref.ts
@@ -1,4 +1,5 @@
 import { gitExecFileAsync, gitExecFileSync } from './runner'
+import { parseWslUncPath } from '../../shared/wsl-paths'
 
 export type LocalGitExecOptions = {
   wslDistro?: string
@@ -25,6 +26,18 @@ export const DEFAULT_BASE_REF_PROBES: readonly { ref: string; returnAs: string }
   { ref: 'refs/heads/master', returnAs: 'master' }
 ]
 
+const ORIGIN_HEAD_REF = 'refs/remotes/origin/HEAD'
+// `%(symref)` and `%(objecttype)` are available in Git 2.25 (Orca's baseline).
+// NUL separators are safe because Git refnames cannot contain NUL or newlines.
+const DEFAULT_BASE_REF_BATCH_FORMAT = '%(refname)%00%(symref)%00%(objecttype)%00%(*objecttype)'
+
+type BatchedRefRecord = {
+  ref: string
+  symref: string
+  objectType: string
+  peeledObjectType: string
+}
+
 async function resolveDefaultBaseRefFromProbes(
   hasRef: (ref: string) => Promise<boolean>
 ): Promise<string | null> {
@@ -36,20 +49,40 @@ async function resolveDefaultBaseRefFromProbes(
   return null
 }
 
-/** Probe the conventional refs in one Git process; retain the old loop as a fallback. */
+function parseBatchedRefRecords(stdout: string): BatchedRefRecord[] {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.split('\0'))
+    .filter((fields) => fields.length >= 4 && fields[0])
+    .map(([ref, symref, objectType, peeledObjectType]) => ({
+      ref,
+      symref,
+      objectType,
+      peeledObjectType
+    }))
+}
+
+function isCommitLikeRecord(record: BatchedRefRecord): boolean {
+  // A symbolic ref can point at an annotated tag; `rev-parse <ref>^{commit}`
+  // accepts that shape, so accept both direct and peeled commit objects.
+  return record.objectType === 'commit' || record.peeledObjectType === 'commit'
+}
+
+/** Probe origin/HEAD and conventional refs in one Git process; retain the old loop as a fallback. */
 async function resolveDefaultBaseRefFromBatchedProbes(exec: GitExec): Promise<string | null> {
   try {
     const { stdout } = await exec([
       'for-each-ref',
-      '--format=%(refname)',
+      `--format=${DEFAULT_BASE_REF_BATCH_FORMAT}`,
+      ORIGIN_HEAD_REF,
       ...DEFAULT_BASE_REF_PROBES.map(({ ref }) => ref)
     ])
-    const refs = new Set(
-      stdout
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter((line) => DEFAULT_BASE_REF_PROBES.some(({ ref }) => ref === line))
-    )
+    const records = parseBatchedRefRecords(stdout)
+    const originHead = records.find((record) => record.ref === ORIGIN_HEAD_REF)
+    if (originHead?.symref && isCommitLikeRecord(originHead)) {
+      return gitRefToDefaultBaseRef(originHead.symref)
+    }
+    const refs = new Set(records.map((record) => record.ref))
     return DEFAULT_BASE_REF_PROBES.find(({ ref }) => refs.has(ref))?.returnAs ?? null
   } catch {
     return resolveDefaultBaseRefFromProbes((ref) => hasGitRefViaExec(exec, ref))
@@ -142,8 +175,13 @@ export function resolveDefaultBaseRefWithLocalGit(
       ...options,
       timeout: DEFAULT_BASE_REF_PROBE_TIMEOUT_MS
     })
-  // WSL process startup makes the four fallback probes visible in create latency.
-  return options.wslDistro
+  // WSL process startup makes the fallback probes visible in create latency. A
+  // UNC repo carries its distro in the path, so do not require callers to repeat
+  // that hint in options (the runner derives it the same way).
+  const isWslRouted =
+    Boolean(options.wslDistro?.trim()) ||
+    (process.platform === 'win32' && parseWslUncPath(options.cwd) !== null)
+  return isWslRouted
     ? resolveDefaultBaseRefViaExecWithBatchedProbes(exec)
     : resolveDefaultBaseRefViaExec(exec)
 }
@@ -151,10 +189,6 @@ export function resolveDefaultBaseRefWithLocalGit(
 async function resolveDefaultBaseRefViaExecWithBatchedProbes(
   exec: GitExec
 ): Promise<string | null> {
-  const originHeadBaseRef = await resolveVerifiedOriginHeadBaseRefViaExec(exec)
-  if (originHeadBaseRef) {
-    return originHeadBaseRef
-  }
   return resolveDefaultBaseRefFromBatchedProbes(exec)
 }
 

--- a/src/main/git/repo-default-base-ref.ts
+++ b/src/main/git/repo-default-base-ref.ts
@@ -175,13 +175,15 @@ export function resolveDefaultBaseRefWithLocalGit(
       ...options,
       timeout: DEFAULT_BASE_REF_PROBE_TIMEOUT_MS
     })
-  // WSL process startup makes the fallback probes visible in create latency. A
-  // UNC repo carries its distro in the path, so do not require callers to repeat
-  // that hint in options (the runner derives it the same way).
+  // WSL and native Windows Git process startup make the fallback probes visible
+  // in create latency. A UNC repo carries its distro in the path, so do not
+  // require callers to repeat that hint in options (the runner derives it too).
+  const isNativeWindows = process.platform === 'win32'
   const isWslRouted =
-    Boolean(options.wslDistro?.trim()) ||
-    (process.platform === 'win32' && parseWslUncPath(options.cwd) !== null)
-  return isWslRouted
+    Boolean(options.wslDistro?.trim()) || (isNativeWindows && parseWslUncPath(options.cwd) !== null)
+  // Keep the existing POSIX execution shape; native Windows and WSL benefit
+  // from replacing several Git processes with one exact-ref batch query.
+  return isNativeWindows || isWslRouted
     ? resolveDefaultBaseRefViaExecWithBatchedProbes(exec)
     : resolveDefaultBaseRefViaExec(exec)
 }

--- a/src/main/git/windows-parallel-checkout.test.ts
+++ b/src/main/git/windows-parallel-checkout.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+import { clearGitCapabilityStateForTests } from './git-capability-state'
+import { resolveLocalWindowsParallelCheckoutGitArgs } from './windows-parallel-checkout'
+import {
+  resetWslLinkedWorktreeGitRoutingForTests,
+  seedWslLinkedWorktreeGitRoutingForTests
+} from './wsl-linked-worktree-git-routing'
+
+describe('resolveLocalWindowsParallelCheckoutGitArgs', () => {
+  beforeEach(() => {
+    clearGitCapabilityStateForTests()
+    resetWslLinkedWorktreeGitRoutingForTests()
+    gitExecFileAsyncMock.mockReset()
+  })
+
+  it('probes an existing repository instead of a not-yet-created target', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'git version 2.55.0.windows.3\n',
+      stderr: ''
+    })
+
+    await expect(
+      resolveLocalWindowsParallelCheckoutGitArgs('C:\\repo-feature', {
+        platform: 'win32',
+        probeCwd: 'C:\\repo',
+        timeout: 180_000
+      })
+    ).resolves.toEqual(['-c', 'checkout.workers=-1'])
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['--version'],
+      expect.objectContaining({ cwd: 'C:\\repo', timeout: 5_000 })
+    )
+  })
+
+  it('keeps the FSCache workaround for an old native Git host', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'git version 2.54.0.windows.1\n',
+      stderr: ''
+    })
+
+    await expect(
+      resolveLocalWindowsParallelCheckoutGitArgs('C:\\repo-feature', {
+        platform: 'win32',
+        probeCwd: 'C:\\repo'
+      })
+    ).resolves.toEqual(['-c', 'core.fscache=false', '-c', 'checkout.workers=-1'])
+  })
+
+  it('treats a non-WSL UNC share as a native Windows Git host', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'git version 2.55.0.windows.3\n',
+      stderr: ''
+    })
+
+    await expect(
+      resolveLocalWindowsParallelCheckoutGitArgs('\\\\server\\share\\repo-feature', {
+        platform: 'win32',
+        probeCwd: '\\\\server\\share\\repo'
+      })
+    ).resolves.toEqual(['-c', 'checkout.workers=-1'])
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['--version'],
+      expect.objectContaining({ cwd: '\\\\server\\share\\repo' })
+    )
+  })
+
+  it('probes host Git for a Windows-linked worktree despite a WSL override', async () => {
+    seedWslLinkedWorktreeGitRoutingForTests('C:\\linked')
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'git version 2.55.0.windows.3\n',
+      stderr: ''
+    })
+
+    await expect(
+      resolveLocalWindowsParallelCheckoutGitArgs('C:\\linked', {
+        platform: 'win32',
+        wslDistro: 'Ubuntu',
+        probeCwd: 'C:\\repo'
+      })
+    ).resolves.toEqual(['-c', 'checkout.workers=-1'])
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['--version'],
+      expect.objectContaining({ cwd: 'C:\\repo' })
+    )
+    expect(gitExecFileAsyncMock.mock.calls[0]?.[1]).not.toHaveProperty('wslDistro')
+  })
+
+  it('keeps the default worker policy for a WSL ext4 worktree', async () => {
+    await expect(
+      resolveLocalWindowsParallelCheckoutGitArgs('\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo', {
+        platform: 'win32',
+        wslDistro: 'Ubuntu'
+      })
+    ).resolves.toEqual([])
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the all-worker pool for a WSL DrvFS worktree', async () => {
+    await expect(
+      resolveLocalWindowsParallelCheckoutGitArgs('\\\\wsl.localhost\\Ubuntu\\mnt\\c\\repo', {
+        platform: 'win32',
+        wslDistro: 'Ubuntu'
+      })
+    ).resolves.toEqual(['-c', 'checkout.workers=-1'])
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the default worker policy for an explicitly WSL-routed ext4 worktree', async () => {
+    await expect(
+      resolveLocalWindowsParallelCheckoutGitArgs('/home/dev/repo', {
+        platform: 'win32',
+        wslDistro: 'Ubuntu'
+      })
+    ).resolves.toEqual([])
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the all-worker pool for an explicitly WSL-routed DrvFS path', async () => {
+    await expect(
+      resolveLocalWindowsParallelCheckoutGitArgs('/mnt/c/repo', {
+        platform: 'win32',
+        wslDistro: 'Ubuntu'
+      })
+    ).resolves.toEqual(['-c', 'checkout.workers=-1'])
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/git/windows-parallel-checkout.ts
+++ b/src/main/git/windows-parallel-checkout.ts
@@ -1,0 +1,108 @@
+import { parseWslUncPath } from '../../shared/wsl-paths'
+import {
+  windowsParallelCheckoutGitArgsAsync,
+  type WindowsParallelCheckoutGitArgsOptions
+} from '../../shared/windows-parallel-checkout-git-args'
+import { getLocalGitCapabilityCache } from './git-capability-state'
+import {
+  getWslLinkedWorktreeGitRoute,
+  isWslLinkedWorktreeGitRoutingCandidate,
+  prepareWslLinkedWorktreeGitRouting
+} from './wsl-linked-worktree-git-routing'
+import { gitExecFileAsync } from './runner'
+import { gitExecOptions, type GitWorktreeExecOptions } from './worktree-operation-options'
+
+const WINDOWS_GIT_VERSION_PROBE_TIMEOUT_MS = 5_000
+
+function isNativeWindowsAbsolutePath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
+}
+
+function isWindowsDrivePath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value)
+}
+
+/**
+ * Build checkout args for a local execution host, probing native Windows Git
+ * once so Git for Windows 2.55+ can keep FSCache enabled. WSL and ambiguous
+ * routes retain the conservative workaround.
+ */
+export async function resolveLocalWindowsParallelCheckoutGitArgs(
+  cwd: string,
+  options: GitWorktreeExecOptions & { platform?: NodeJS.Platform; probeCwd?: string } = {}
+): Promise<string[]> {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'win32') {
+    return []
+  }
+
+  let nativeWindowsGit = isNativeWindowsAbsolutePath(cwd) && parseWslUncPath(cwd) === null
+  // A non-WSL UNC path cannot be classified by the linked-worktree marker
+  // walk. With an explicit distro override, keep the old conservative argv
+  // instead of probing through whichever host the override selects.
+  let routeKnown = !(Boolean(options.wslDistro?.trim()) && !isWindowsDrivePath(cwd))
+  let hostRoutedLinkedWorktree = false
+  if (
+    nativeWindowsGit &&
+    isWslLinkedWorktreeGitRoutingCandidate(cwd, options.wslDistro, platform)
+  ) {
+    try {
+      await prepareWslLinkedWorktreeGitRouting(cwd, options.wslDistro, {
+        platform,
+        signal: options.signal
+      })
+    } catch (error) {
+      if (options.signal?.aborted) {
+        throw error
+      }
+    }
+    const route = getWslLinkedWorktreeGitRoute(cwd, options.wslDistro, platform)
+    if (route === 'wsl') {
+      nativeWindowsGit = false
+    } else if (route === 'unknown') {
+      // A failed marker probe may still be a host-routed linked worktree.
+      // Keep the old safety flag and avoid poisoning either host cache.
+      routeKnown = false
+    } else if (route === 'host') {
+      hostRoutedLinkedWorktree = true
+    }
+  }
+
+  const baseOptions: WindowsParallelCheckoutGitArgsOptions = {
+    nativeWindowsGit
+  }
+  if (!nativeWindowsGit || !routeKnown) {
+    return windowsParallelCheckoutGitArgsAsync(cwd, platform, options.wslDistro, baseOptions)
+  }
+
+  // The target/preparation directory may not exist yet. Probe from the
+  // repository (or another caller-supplied existing directory), while route
+  // classification above intentionally remains tied to the actual target.
+  const probeCwd = options.probeCwd ?? cwd
+  const capabilities = getLocalGitCapabilityCache(
+    nativeWindowsGit ? { cwd: probeCwd } : { cwd: probeCwd, wslDistro: options.wslDistro }
+  )
+  // A Windows `.git` pointer is an explicit host-Git route even when the
+  // caller carries a WSL distro override. Keep the version probe on that same
+  // host; probing through WSL would cache a Linux version against the native
+  // capability and permanently retain the slower FSCache workaround.
+  const probeExecutionOptions = hostRoutedLinkedWorktree
+    ? { ...options, wslDistro: undefined }
+    : options
+  return windowsParallelCheckoutGitArgsAsync(cwd, platform, options.wslDistro, {
+    ...baseOptions,
+    capabilities,
+    probeGitVersion: async () => {
+      const result = await gitExecFileAsync(
+        ['--version'],
+        gitExecOptions(probeCwd, {
+          ...probeExecutionOptions,
+          // Keep capability detection bounded independently of the much
+          // longer worktree operation timeout.
+          timeout: WINDOWS_GIT_VERSION_PROBE_TIMEOUT_MS
+        })
+      )
+      return result.stdout
+    }
+  })
+}

--- a/src/main/git/worktree-add-creation-config.test.ts
+++ b/src/main/git/worktree-add-creation-config.test.ts
@@ -127,6 +127,8 @@ describe('addWorktree', () => {
         '-c',
         'core.longpaths=true',
         '-c',
+        'core.fscache=false',
+        '-c',
         'checkout.workers=-1',
         'worktree',
         'add',

--- a/src/main/git/worktree-add-creation-config.test.ts
+++ b/src/main/git/worktree-add-creation-config.test.ts
@@ -123,7 +123,16 @@ describe('addWorktree', () => {
     )
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      ['-c', 'core.longpaths=true', 'worktree', 'add', 'C:\\repo-feature', 'feature/test'],
+      [
+        '-c',
+        'core.longpaths=true',
+        '-c',
+        'checkout.workers=-1',
+        'worktree',
+        'add',
+        'C:\\repo-feature',
+        'feature/test'
+      ],
       { cwd: 'C:\\repo', timeout: WORKTREE_ADD_TIMEOUT_MS }
     )
   })
@@ -148,6 +157,33 @@ describe('addWorktree', () => {
       ['-c', 'core.longpaths=true', 'worktree', 'add', 'C:\\repo-feature', 'feature/test'],
       { cwd: 'C:\\repo', wslDistro: 'Ubuntu', timeout: WORKTREE_ADD_TIMEOUT_MS }
     )
+  })
+
+  it('does not enable checkout workers for a native Windows no-checkout add', async () => {
+    platformSpy.mockReturnValue('win32')
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add --no-checkout
+      .mockResolvedValueOnce({ stdout: 'true\n' }) // push.autoSetupRemote already set
+
+    await addWorktree('C:\\repo', 'C:\\repo-feature', 'feature/test', undefined, false, true)
+
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      [
+        [
+          '-c',
+          'core.longpaths=true',
+          'worktree',
+          'add',
+          '--no-checkout',
+          '--no-track',
+          '-b',
+          'feature/test',
+          'C:\\repo-feature'
+        ],
+        { cwd: 'C:\\repo', timeout: WORKTREE_ADD_TIMEOUT_MS }
+      ],
+      [['config', '--get', 'push.autoSetupRemote'], { cwd: 'C:\\repo-feature' }]
+    ])
   })
 
   it('does not pass the Windows-only long-path option for a WSL UNC repo path', async () => {

--- a/src/main/git/worktree-add-creation-config.test.ts
+++ b/src/main/git/worktree-add-creation-config.test.ts
@@ -156,7 +156,18 @@ describe('addWorktree', () => {
     )
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      ['-c', 'core.longpaths=true', 'worktree', 'add', 'C:\\repo-feature', 'feature/test'],
+      [
+        '-c',
+        'core.longpaths=true',
+        '-c',
+        'core.fscache=false',
+        '-c',
+        'checkout.workers=-1',
+        'worktree',
+        'add',
+        'C:\\repo-feature',
+        'feature/test'
+      ],
       { cwd: 'C:\\repo', wslDistro: 'Ubuntu', timeout: WORKTREE_ADD_TIMEOUT_MS }
     )
   })
@@ -188,7 +199,7 @@ describe('addWorktree', () => {
     ])
   })
 
-  it('does not pass the Windows-only long-path option for a WSL UNC repo path', async () => {
+  it('keeps the default worker policy for a WSL ext4 repo path', async () => {
     platformSpy.mockReturnValue('win32')
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
 
@@ -206,6 +217,53 @@ describe('addWorktree', () => {
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['worktree', 'add', '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo-feature', 'feature/test'],
       { cwd: repoPath, wslDistro: 'Ubuntu', timeout: WORKTREE_ADD_TIMEOUT_MS }
+    )
+  })
+
+  it('classifies checkout storage from a WSL mirror target, not the Windows repo cwd', async () => {
+    platformSpy.mockReturnValue('win32')
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+
+    await addWorktree(
+      'C:\\repo',
+      '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo-feature',
+      'feature/test',
+      'feature/test',
+      false,
+      false,
+      { checkoutExistingBranch: true, wslDistro: 'Ubuntu' }
+    )
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        '-c',
+        'core.longpaths=true',
+        'worktree',
+        'add',
+        '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo-feature',
+        'feature/test'
+      ],
+      { cwd: 'C:\\repo', wslDistro: 'Ubuntu', timeout: WORKTREE_ADD_TIMEOUT_MS }
+    )
+  })
+
+  it('keeps the default worker policy for an ext4 POSIX cwd routed through WSL', async () => {
+    platformSpy.mockReturnValue('win32')
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+
+    await addWorktree(
+      '/home/dev/repo',
+      '/home/dev/repo-feature',
+      'feature/test',
+      'feature/test',
+      false,
+      false,
+      { checkoutExistingBranch: true, wslDistro: 'Ubuntu' }
+    )
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['-c', 'core.longpaths=true', 'worktree', 'add', '/home/dev/repo-feature', 'feature/test'],
+      { cwd: '/home/dev/repo', wslDistro: 'Ubuntu', timeout: WORKTREE_ADD_TIMEOUT_MS }
     )
   })
 

--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -63,6 +63,8 @@ describe('addWorktree', () => {
       ).resolves.toMatchObject({ status: 'updated' })
       expect(gitExecFileAsyncMock.mock.calls[8]?.[0]).toEqual([
         '-c',
+        'core.fscache=false',
+        '-c',
         'checkout.workers=-1',
         'reset',
         '--hard',

--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -46,14 +46,22 @@ describe('addWorktree', () => {
   it('uses parallel checkout workers when refreshing a native Windows owner worktree', async () => {
     const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     const worktreeListOutput = 'worktree C:\\repo\nHEAD abc123\nbranch refs/heads/main\n'
+    const localOid = '0123456789abcdef0123456789abcdef01234567'
+    const remoteOid = '89abcdef0123456789abcdef0123456789abcdef'
+    const batchFormat =
+      '%(refname)%00%(objectname)%00%(objecttype)%00%(*objectname)%00%(*objecttype)%00%(symref)'
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: '0\t1\n' }) // rev-list drift
-      .mockResolvedValueOnce({ stdout: 'old-main\n' }) // local OID
-      .mockResolvedValueOnce({ stdout: 'remote-main\n' }) // remote OID
+      .mockResolvedValueOnce({
+        stdout:
+          `refs/heads/main\0${localOid}\0commit\0\0\0\n` +
+          `refs/remotes/origin/main\0${remoteOid}\0commit\0\0\0\n`
+      }) // batched local + remote OIDs
       .mockResolvedValueOnce({ stdout: '' }) // merge-base captured OIDs
       .mockResolvedValueOnce({ stdout: worktreeListOutput }) // worktree list during evaluation
       .mockResolvedValueOnce({ stdout: '' }) // status during evaluation
       .mockResolvedValueOnce({ stdout: worktreeListOutput }) // worktree list before mutation
+      .mockResolvedValueOnce({ stdout: 'git version 2.54.0.windows.1' }) // native Git capability probe
       .mockResolvedValueOnce({ stdout: '' }) // status before mutation
       .mockResolvedValueOnce({ stdout: '' }) // reset --hard
 
@@ -61,14 +69,52 @@ describe('addWorktree', () => {
       await expect(
         refreshLocalBaseRefForWorktreeCreate('C:\\repo', 'main', 'refs/remotes/origin/main')
       ).resolves.toMatchObject({ status: 'updated' })
-      expect(gitExecFileAsyncMock.mock.calls[8]?.[0]).toEqual([
+      const resetCall = gitExecFileAsyncMock.mock.calls.find(([args]) =>
+        (args as string[]).includes('reset')
+      )
+      expect(resetCall?.[0]).toEqual([
         '-c',
         'core.fscache=false',
         '-c',
         'checkout.workers=-1',
         'reset',
         '--hard',
-        'remote-main'
+        remoteOid
+      ])
+      expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+        ['for-each-ref', `--format=${batchFormat}`, 'refs/heads/main', 'refs/remotes/origin/main'],
+        expect.objectContaining({ cwd: 'C:\\repo' })
+      )
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
+
+  it('falls back to two rev-parse reads when the Windows OID batch is malformed', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const localOid = '0123456789abcdef0123456789abcdef01234567'
+    const remoteOid = '89abcdef0123456789abcdef0123456789abcdef'
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '0\t1\n' }) // rev-list drift
+      .mockResolvedValueOnce({ stdout: 'login banner\n' }) // malformed for-each-ref output
+      .mockResolvedValueOnce({ stdout: `${localOid}\n` }) // local rev-parse fallback
+      .mockResolvedValueOnce({ stdout: `${remoteOid}\n` }) // remote rev-parse fallback
+      .mockResolvedValueOnce({ stdout: '' }) // merge-base captured OIDs
+      .mockResolvedValueOnce({ stdout: 'worktree C:\\repo\nbranch refs/heads/develop\n' }) // list
+      .mockResolvedValueOnce({ stdout: '' }) // update-ref
+
+    try {
+      await expect(
+        refreshLocalBaseRefForWorktreeCreate('C:\\repo', 'main', 'refs/remotes/origin/main')
+      ).resolves.toMatchObject({ status: 'updated' })
+      expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args[0])).toEqual([
+        'rev-list',
+        'for-each-ref',
+        'rev-parse',
+        'rev-parse',
+        'merge-base',
+        'worktree',
+        'update-ref'
       ])
     } finally {
       platformSpy.mockRestore()

--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -26,6 +26,7 @@ vi.mock('../worktree-trash', () => ({
   scheduleWorktreeTrashDeletion: vi.fn()
 }))
 
+import { refreshLocalBaseRefForWorktreeCreate } from './worktree-base-refresh'
 import { addWorktree, WORKTREE_ADD_TIMEOUT_MS } from './worktree'
 import { registerWorktreeSuiteHooks } from './worktree-test-harness'
 
@@ -40,6 +41,36 @@ describe('addWorktree', () => {
     gitExecFileAsyncMock.mockReset()
     gitExecFileSyncMock.mockReset()
     translateWslOutputPathsMock.mockClear()
+  })
+
+  it('uses parallel checkout workers when refreshing a native Windows owner worktree', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const worktreeListOutput = 'worktree C:\\repo\nHEAD abc123\nbranch refs/heads/main\n'
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '0\t1\n' }) // rev-list drift
+      .mockResolvedValueOnce({ stdout: 'old-main\n' }) // local OID
+      .mockResolvedValueOnce({ stdout: 'remote-main\n' }) // remote OID
+      .mockResolvedValueOnce({ stdout: '' }) // merge-base captured OIDs
+      .mockResolvedValueOnce({ stdout: worktreeListOutput }) // worktree list during evaluation
+      .mockResolvedValueOnce({ stdout: '' }) // status during evaluation
+      .mockResolvedValueOnce({ stdout: worktreeListOutput }) // worktree list before mutation
+      .mockResolvedValueOnce({ stdout: '' }) // status before mutation
+      .mockResolvedValueOnce({ stdout: '' }) // reset --hard
+
+    try {
+      await expect(
+        refreshLocalBaseRefForWorktreeCreate('C:\\repo', 'main', 'refs/remotes/origin/main')
+      ).resolves.toMatchObject({ status: 'updated' })
+      expect(gitExecFileAsyncMock.mock.calls[8]?.[0]).toEqual([
+        '-c',
+        'checkout.workers=-1',
+        'reset',
+        '--hard',
+        'remote-main'
+      ])
+    } finally {
+      platformSpy.mockRestore()
+    }
   })
 
   it('fast-forwards with reset --hard when localBranch is checked out in primary worktree', async () => {

--- a/src/main/git/worktree-add.ts
+++ b/src/main/git/worktree-add.ts
@@ -86,25 +86,33 @@ export async function persistWorktreeCreationBase(
   }
 }
 
-export async function configurePushAutoSetupRemote(
+async function readPushAutoSetupRemote(
   worktreePath: string,
   options: GitWorktreeExecOptions
-): Promise<void> {
+): Promise<boolean> {
   try {
     // Why: `--get` (not `--local --get`) treats a value at any scope as an explicit user choice.
-    let alreadySet = false
-    try {
-      await gitExecFileAsync(['config', '--get', 'push.autoSetupRemote'], {
-        ...gitExecOptions(worktreePath, options)
-      })
-      alreadySet = true
-    } catch (readError) {
-      // Why: exit 1 means unset; other codes are real read failures and must not overwrite config.
-      const code = (readError as { code?: unknown })?.code
-      if (code !== 1) {
-        throw readError
-      }
+    await gitExecFileAsync(['config', '--get', 'push.autoSetupRemote'], {
+      ...gitExecOptions(worktreePath, options)
+    })
+    return true
+  } catch (readError) {
+    // Why: exit 1 means unset; other codes are real read failures and must not overwrite config.
+    const code = (readError as { code?: unknown })?.code
+    if (code === 1) {
+      return false
     }
+    throw readError
+  }
+}
+
+export async function configurePushAutoSetupRemote(
+  worktreePath: string,
+  options: GitWorktreeExecOptions,
+  probe: Promise<boolean> = readPushAutoSetupRemote(worktreePath, options)
+): Promise<void> {
+  try {
+    const alreadySet = await probe
     if (!alreadySet) {
       await gitExecFileAsync(['config', '--local', 'push.autoSetupRemote', 'true'], {
         ...gitExecOptions(worktreePath, options)
@@ -218,6 +226,16 @@ async function performAddWorktree(
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}
   }
 
+  // The read-only push setting probe can overlap the base metadata write. The
+  // eventual `--local` write remains after both operations, so config locks do
+  // not race.
+  const pushAutoSetupRemoteProbe = effectiveBase && process.platform === 'win32'
+    ? readPushAutoSetupRemote(worktreePath, options)
+    : undefined
+  if (pushAutoSetupRemoteProbe) {
+    // Keep a rejection observed if an unexpected persistence failure exits early.
+    void pushAutoSetupRemoteProbe.catch(() => {})
+  }
   if (effectiveBase) {
     await persistWorktreeCreationBase(worktreePath, branch, effectiveBase, options)
   }
@@ -227,7 +245,7 @@ async function performAddWorktree(
   // `git push` create+set origin/<branch> (git >=2.37; older clients ignore it). `--local` on a
   // linked worktree writes the shared common-dir config (whole repo) — intentional and idempotent,
   // so it's warn-only and not rolled back on failure.
-  await configurePushAutoSetupRemote(worktreePath, options)
+  await configurePushAutoSetupRemote(worktreePath, options, pushAutoSetupRemoteProbe)
   return {
     ...(localBaseRefRefresh ? { localBaseRefRefresh } : {}),
     ...(localBaseRefUpdateSuggestion ? { localBaseRefUpdateSuggestion } : {})

--- a/src/main/git/worktree-add.ts
+++ b/src/main/git/worktree-add.ts
@@ -7,6 +7,7 @@ import { windowsLongPathGitArgs } from '../../shared/windows-long-path-git-args'
 import { gitExecFileAsync } from './runner'
 import { resolveLocalWindowsParallelCheckoutGitArgs } from './windows-parallel-checkout'
 import { runWithGitReadCacheInvalidation } from './status'
+import { invalidateWslLinkedWorktreeGitRouting } from './wsl-linked-worktree-git-routing'
 import {
   getLocalBaseRefUpdateSuggestionForWorktreeCreate,
   refreshLocalBaseRefForWorktreeCreate
@@ -225,11 +226,17 @@ async function performAddWorktree(
   // Keep all checkout tuning before the subcommand, after the async probe has
   // had a chance to overlap base resolution.
   args.splice(windowsLongPathGitArgs(repoPath).length, 0, ...(await parallelCheckoutArgsPromise))
-  await gitExecFileAsync(args, {
-    ...gitExecOptions(repoPath, options),
-    // Why: resolve per call — hoisting this to a module const would freeze the override at import.
-    timeout: resolveWorktreeAddTimeoutMs()
-  })
+  try {
+    await gitExecFileAsync(args, {
+      ...gitExecOptions(repoPath, options),
+      // Why: resolve per call — hoisting this to a module const would freeze the override at import.
+      timeout: resolveWorktreeAddTimeoutMs()
+    })
+  } finally {
+    // Git may have materialized the target's `.git` marker even when it reports
+    // a late failure; never carry a pre-create miss/backoff into follow-ups.
+    invalidateWslLinkedWorktreeGitRouting(worktreePath)
+  }
 
   if (options.checkoutExistingBranch) {
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}

--- a/src/main/git/worktree-add.ts
+++ b/src/main/git/worktree-add.ts
@@ -4,6 +4,7 @@ import type {
   LocalBaseRefUpdateSuggestion
 } from '../../shared/worktree/base-ref-drift-types'
 import { windowsLongPathGitArgs } from '../../shared/windows-long-path-git-args'
+import { windowsParallelCheckoutGitArgs } from '../../shared/windows-parallel-checkout-git-args'
 import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
 import {
@@ -175,8 +176,15 @@ async function performAddWorktree(
 ): Promise<AddWorktreeResult> {
   let localBaseRefRefresh: LocalBaseRefRefreshResult | undefined
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
-  // Why: enable long paths for this Windows checkout without changing user Git config.
-  const args = [...windowsLongPathGitArgs(repoPath), 'worktree', 'add']
+  // Why: enable per-invocation Windows checkout tuning without changing user Git config.
+  const args = [
+    ...windowsLongPathGitArgs(repoPath),
+    ...(noCheckout
+      ? []
+      : windowsParallelCheckoutGitArgs(repoPath, process.platform, options.wslDistro)),
+    'worktree',
+    'add'
+  ]
   let effectiveBase: string | undefined
   if (noCheckout) {
     args.push('--no-checkout')

--- a/src/main/git/worktree-add.ts
+++ b/src/main/git/worktree-add.ts
@@ -4,8 +4,8 @@ import type {
   LocalBaseRefUpdateSuggestion
 } from '../../shared/worktree/base-ref-drift-types'
 import { windowsLongPathGitArgs } from '../../shared/windows-long-path-git-args'
-import { windowsParallelCheckoutGitArgs } from '../../shared/windows-parallel-checkout-git-args'
 import { gitExecFileAsync } from './runner'
+import { resolveLocalWindowsParallelCheckoutGitArgs } from './windows-parallel-checkout'
 import { runWithGitReadCacheInvalidation } from './status'
 import {
   getLocalBaseRefUpdateSuggestionForWorktreeCreate,
@@ -185,14 +185,20 @@ async function performAddWorktree(
   let localBaseRefRefresh: LocalBaseRefRefreshResult | undefined
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
   // Why: enable per-invocation Windows checkout tuning without changing user Git config.
-  const args = [
-    ...windowsLongPathGitArgs(repoPath),
-    ...(noCheckout
-      ? []
-      : windowsParallelCheckoutGitArgs(repoPath, process.platform, options.wslDistro)),
-    'worktree',
-    'add'
-  ]
+  // Start the capability probe before base-ref validation so the first create
+  // can overlap the inexpensive `git --version` call with other preflight work.
+  const parallelCheckoutArgsPromise = noCheckout
+    ? Promise.resolve([] as string[])
+    : resolveLocalWindowsParallelCheckoutGitArgs(worktreePath, {
+        ...options,
+        // The target determines checkout storage; probe Git from the existing
+        // repo because a new worktree target may not exist yet.
+        probeCwd: repoPath
+      })
+  // Base validation can fail before the speculative capability probe is read;
+  // keep cancellation/probe failures observed without masking the real error.
+  void parallelCheckoutArgsPromise.catch(() => {})
+  const args = [...windowsLongPathGitArgs(repoPath), 'worktree', 'add']
   let effectiveBase: string | undefined
   if (noCheckout) {
     args.push('--no-checkout')
@@ -216,6 +222,9 @@ async function performAddWorktree(
       args.push(effectiveBase)
     }
   }
+  // Keep all checkout tuning before the subcommand, after the async probe has
+  // had a chance to overlap base resolution.
+  args.splice(windowsLongPathGitArgs(repoPath).length, 0, ...(await parallelCheckoutArgsPromise))
   await gitExecFileAsync(args, {
     ...gitExecOptions(repoPath, options),
     // Why: resolve per call — hoisting this to a module const would freeze the override at import.
@@ -229,9 +238,10 @@ async function performAddWorktree(
   // The read-only push setting probe can overlap the base metadata write. The
   // eventual `--local` write remains after both operations, so config locks do
   // not race.
-  const pushAutoSetupRemoteProbe = effectiveBase && process.platform === 'win32'
-    ? readPushAutoSetupRemote(worktreePath, options)
-    : undefined
+  const pushAutoSetupRemoteProbe =
+    effectiveBase && process.platform === 'win32'
+      ? readPushAutoSetupRemote(worktreePath, options)
+      : undefined
   if (pushAutoSetupRemoteProbe) {
     // Keep a rejection observed if an unexpected persistence failure exits early.
     void pushAutoSetupRemoteProbe.catch(() => {})

--- a/src/main/git/worktree-base-refresh-analysis.ts
+++ b/src/main/git/worktree-base-refresh-analysis.ts
@@ -96,19 +96,23 @@ export async function evaluateLocalBaseRefRefreshability(
       // Why: a current local ref yields no update suggestion, so the advisory path skips OID resolution and owner inspection.
       return undefined
     }
-    const { stdout: localOidOutput } = await gitExecFileAsync(
-      ['rev-parse', '--verify', `${parsed.fullRef}^{commit}`],
-      gitExecOptions(repoPath, options)
-    )
+    // These probes read independent refs. Start them together so WSL-routed
+    // creates pay one process-start interval instead of two.
+    const [{ stdout: localOidOutput }, { stdout: remoteOidOutput }] = await Promise.all([
+      gitExecFileAsync(
+        ['rev-parse', '--verify', `${parsed.fullRef}^{commit}`],
+        gitExecOptions(repoPath, options)
+      ),
+      gitExecFileAsync(
+        ['rev-parse', '--verify', `${remoteTrackingRef}^{commit}`],
+        gitExecOptions(repoPath, options)
+      )
+    ])
     localOid = localOidOutput.trim()
+    remoteOid = remoteOidOutput.trim()
     if (!localOid) {
       return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }
     }
-    const { stdout: remoteOidOutput } = await gitExecFileAsync(
-      ['rev-parse', '--verify', `${remoteTrackingRef}^{commit}`],
-      gitExecOptions(repoPath, options)
-    )
-    remoteOid = remoteOidOutput.trim()
     if (!remoteOid) {
       return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }
     }

--- a/src/main/git/worktree-base-refresh-analysis.ts
+++ b/src/main/git/worktree-base-refresh-analysis.ts
@@ -64,6 +64,130 @@ function parseRevListDrift(output: string): { ahead: number; behind: number } | 
   return counts.status === 'ok' ? { ahead: counts.ahead, behind: counts.behind } : null
 }
 
+// `rev-parse --verify` is a cheap read on POSIX, but each invocation still pays
+// a wsl.exe/Windows process start. Keep the format to atoms available in Git
+// 2.25 (Orca's baseline) and read both OIDs in one process on those hosts.
+const LOCAL_BASE_OID_BATCH_FORMAT =
+  '%(refname)%00%(objectname)%00%(objecttype)%00%(*objectname)%00%(*objecttype)%00%(symref)'
+
+type BatchedRefOidRecord = {
+  ref: string
+  objectName: string
+  objectType: string
+  peeledObjectName: string
+  peeledObjectType: string
+  symref: string
+}
+
+type BatchedRefOids = { localOid: string; remoteOid: string }
+
+function isWindowsOrWslExecution(options: GitWorktreeExecOptions): boolean {
+  return process.platform === 'win32' || Boolean(options.wslDistro?.trim())
+}
+
+function isPlausibleObjectName(value: string): boolean {
+  // SHA-1 is 40 chars and SHA-256 is 64; accepting a bounded even-length hex
+  // token leaves room for future Git object formats without accepting shell text.
+  return (
+    value.length >= 4 && value.length <= 128 && value.length % 2 === 0 && /^[0-9a-f]+$/i.test(value)
+  )
+}
+
+function parseBatchedRefOidRecords(stdout: string): BatchedRefOidRecord[] | undefined {
+  const records: BatchedRefOidRecord[] = []
+  for (const line of stdout.split(/\r?\n/)) {
+    if (line.length === 0) {
+      continue
+    }
+    const fields = line.split('\0')
+    // A shell banner, truncated output, or an old Git that echoed the format
+    // must never be mistaken for an OID. Fall back to the proven rev-parse path.
+    if (fields.length !== 6) {
+      return undefined
+    }
+    const [ref, objectName, objectType, peeledObjectName, peeledObjectType, symref] = fields
+    if (!ref || !objectName || !objectType || symref.includes('\n') || symref.includes('\r')) {
+      return undefined
+    }
+    if (!isPlausibleObjectName(objectName)) {
+      return undefined
+    }
+    if (peeledObjectName && !isPlausibleObjectName(peeledObjectName)) {
+      return undefined
+    }
+    records.push({ ref, objectName, objectType, peeledObjectName, peeledObjectType, symref })
+  }
+  return records
+}
+
+function objectNameForCommitRecord(record: BatchedRefOidRecord): string | undefined {
+  if (record.objectType === 'commit') {
+    return record.objectName
+  }
+  if (record.peeledObjectType === 'commit' && record.peeledObjectName) {
+    return record.peeledObjectName
+  }
+  return undefined
+}
+
+function parseBatchedRefOids(
+  stdout: string,
+  localRef: string,
+  remoteRef: string
+): BatchedRefOids | undefined {
+  const records = parseBatchedRefOidRecords(stdout)
+  if (!records) {
+    return undefined
+  }
+  const byRef = new Map<string, BatchedRefOidRecord>()
+  for (const record of records) {
+    // `for-each-ref refs/heads/foo` also returns refs below that prefix. Ignore
+    // those valid siblings and require an exact record for each requested ref.
+    if (record.ref !== localRef && record.ref !== remoteRef) {
+      continue
+    }
+    if (byRef.has(record.ref)) {
+      return undefined
+    }
+    byRef.set(record.ref, record)
+  }
+  const localRecord = byRef.get(localRef)
+  const remoteRecord = byRef.get(remoteRef)
+  const localOid = localRecord ? objectNameForCommitRecord(localRecord) : undefined
+  const remoteOid = remoteRecord ? objectNameForCommitRecord(remoteRecord) : undefined
+  return localOid && remoteOid ? { localOid, remoteOid } : undefined
+}
+
+async function resolveLocalAndRemoteOids(
+  exec: (args: string[]) => Promise<{ stdout: string }>,
+  localRef: string,
+  remoteRef: string,
+  options: GitWorktreeExecOptions
+): Promise<{ localOid: string; remoteOid: string }> {
+  if (isWindowsOrWslExecution(options)) {
+    try {
+      const { stdout } = await exec([
+        'for-each-ref',
+        `--format=${LOCAL_BASE_OID_BATCH_FORMAT}`,
+        localRef,
+        remoteRef
+      ])
+      const batched = parseBatchedRefOids(stdout, localRef, remoteRef)
+      if (batched) {
+        return batched
+      }
+    } catch {
+      // Fall through to the compatibility path below.
+    }
+  }
+
+  const [{ stdout: localOidOutput }, { stdout: remoteOidOutput }] = await Promise.all([
+    exec(['rev-parse', '--verify', `${localRef}^{commit}`]),
+    exec(['rev-parse', '--verify', `${remoteRef}^{commit}`])
+  ])
+  return { localOid: localOidOutput.trim(), remoteOid: remoteOidOutput.trim() }
+}
+
 export async function evaluateLocalBaseRefRefreshability(
   repoPath: string,
   baseBranch: string,
@@ -96,20 +220,15 @@ export async function evaluateLocalBaseRefRefreshability(
       // Why: a current local ref yields no update suggestion, so the advisory path skips OID resolution and owner inspection.
       return undefined
     }
-    // These probes read independent refs. Start them together so WSL-routed
-    // creates pay one process-start interval instead of two.
-    const [{ stdout: localOidOutput }, { stdout: remoteOidOutput }] = await Promise.all([
-      gitExecFileAsync(
-        ['rev-parse', '--verify', `${parsed.fullRef}^{commit}`],
-        gitExecOptions(repoPath, options)
-      ),
-      gitExecFileAsync(
-        ['rev-parse', '--verify', `${remoteTrackingRef}^{commit}`],
-        gitExecOptions(repoPath, options)
+    const { localOid: resolvedLocalOid, remoteOid: resolvedRemoteOid } =
+      await resolveLocalAndRemoteOids(
+        (args) => gitExecFileAsync(args, gitExecOptions(repoPath, options)),
+        parsed.fullRef,
+        remoteTrackingRef,
+        options
       )
-    ])
-    localOid = localOidOutput.trim()
-    remoteOid = remoteOidOutput.trim()
+    localOid = resolvedLocalOid
+    remoteOid = resolvedRemoteOid
     if (!localOid) {
       return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }
     }

--- a/src/main/git/worktree-base-refresh.ts
+++ b/src/main/git/worktree-base-refresh.ts
@@ -1,4 +1,5 @@
 import type { LocalBaseRefRefreshResult } from '../../shared/worktree/base-ref-drift-types'
+import { windowsParallelCheckoutGitArgs } from '../../shared/windows-parallel-checkout-git-args'
 import { gitExecFileAsync, translateWslOutputPaths } from './runner'
 import {
   evaluateLocalBaseRefRefreshability,
@@ -57,7 +58,12 @@ export async function refreshLocalBaseRefForWorktreeCreate(
         }
       }
       await gitExecFileAsync(
-        ['reset', '--hard', evaluation.remoteOid],
+        [
+          ...windowsParallelCheckoutGitArgs(currentOwner.path, process.platform, options.wslDistro),
+          'reset',
+          '--hard',
+          evaluation.remoteOid
+        ],
         gitExecOptions(currentOwner.path, options)
       )
       return { ...resultBase, status: 'updated', ownerWorktreePath: currentOwner.path }

--- a/src/main/git/worktree-base-refresh.ts
+++ b/src/main/git/worktree-base-refresh.ts
@@ -1,6 +1,6 @@
 import type { LocalBaseRefRefreshResult } from '../../shared/worktree/base-ref-drift-types'
-import { windowsParallelCheckoutGitArgs } from '../../shared/windows-parallel-checkout-git-args'
 import { gitExecFileAsync, translateWslOutputPaths } from './runner'
+import { resolveLocalWindowsParallelCheckoutGitArgs } from './windows-parallel-checkout'
 import {
   evaluateLocalBaseRefRefreshability,
   getLocalBaseRefUpdateSuggestionForWorktreeCreate
@@ -46,6 +46,11 @@ export async function refreshLocalBaseRefForWorktreeCreate(
       if (!currentOwner || currentOwner.path !== evaluation.ownerWorktreePath) {
         return { ...resultBase, status: 'skipped_error' }
       }
+      const parallelCheckoutArgsPromise = resolveLocalWindowsParallelCheckoutGitArgs(
+        currentOwner.path,
+        { ...options, probeCwd: repoPath }
+      )
+      void parallelCheckoutArgsPromise.catch(() => {})
       const { stdout: status } = await gitExecFileAsync(
         ['status', '--porcelain', '--untracked-files=no'],
         gitExecOptions(currentOwner.path, options)
@@ -58,12 +63,7 @@ export async function refreshLocalBaseRefForWorktreeCreate(
         }
       }
       await gitExecFileAsync(
-        [
-          ...windowsParallelCheckoutGitArgs(currentOwner.path, process.platform, options.wslDistro),
-          'reset',
-          '--hard',
-          evaluation.remoteOid
-        ],
+        [...(await parallelCheckoutArgsPromise), 'reset', '--hard', evaluation.remoteOid],
         gitExecOptions(currentOwner.path, options)
       )
       return { ...resultBase, status: 'updated', ownerWorktreePath: currentOwner.path }

--- a/src/main/git/worktree-create-preparation-cleanup.ts
+++ b/src/main/git/worktree-create-preparation-cleanup.ts
@@ -1,0 +1,71 @@
+import { windowsLongPathGitArgs } from '../../shared/windows-long-path-git-args'
+import { gitExecFileAsync } from './runner'
+import { invalidateWslLinkedWorktreeGitRouting } from './wsl-linked-worktree-git-routing'
+import {
+  gitExecOptions,
+  type GitWorktreeExecOptions,
+  WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS
+} from './worktree-operation-options'
+
+export function gitCleanupOptions(
+  cwd: string,
+  options: GitWorktreeExecOptions
+): { cwd: string; wslDistro?: string; timeout?: number } {
+  // Cancellation must not strand a partially moved worktree; cleanup is bounded separately.
+  return gitExecOptions(cwd, { ...options, signal: undefined })
+}
+
+export async function performDiscardPreparedWorktree(
+  repoPath: string,
+  worktreePath: string,
+  options: GitWorktreeExecOptions
+): Promise<void> {
+  const cleanupGitOptions = {
+    ...gitCleanupOptions(repoPath, options),
+    timeout: options.timeout ?? WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS
+  }
+  try {
+    await gitExecFileAsync(
+      [...windowsLongPathGitArgs(repoPath), 'worktree', 'unlock', worktreePath],
+      cleanupGitOptions
+    )
+  } catch {
+    // It may be unlocked already or only partially registered.
+  }
+  try {
+    await gitExecFileAsync(
+      [...windowsLongPathGitArgs(repoPath), 'worktree', 'remove', '--force', worktreePath],
+      cleanupGitOptions
+    )
+  } finally {
+    invalidateWslLinkedWorktreeGitRouting(worktreePath)
+  }
+}
+
+export async function removeFailedFinalization(
+  repoPath: string,
+  cleanupPath: string,
+  branch: string,
+  moved: boolean,
+  options: GitWorktreeExecOptions
+): Promise<void> {
+  let branchAttached = false
+  if (moved) {
+    try {
+      const { stdout } = await gitExecFileAsync(
+        ['symbolic-ref', '--short', 'HEAD'],
+        gitCleanupOptions(cleanupPath, options)
+      )
+      branchAttached = stdout.trim() === branch
+    } catch {
+      // Detached or no longer readable.
+    }
+  }
+  await performDiscardPreparedWorktree(repoPath, cleanupPath, options).catch(() => {})
+  if (branchAttached) {
+    await gitExecFileAsync(
+      ['branch', '-D', '--', branch],
+      gitCleanupOptions(repoPath, options)
+    ).catch(() => {})
+  }
+}

--- a/src/main/git/worktree-create-preparation.ts
+++ b/src/main/git/worktree-create-preparation.ts
@@ -6,57 +6,25 @@ import {
   notifyPreparedWorktreeMutation,
   persistWorktreeCreationBase,
   resolveWorktreeAddBaseContext,
-  resolveWorktreeAddTimeoutMs,
-  WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS
+  resolveWorktreeAddTimeoutMs
 } from './worktree'
 import { hasWorktreeBaseCommitRef } from './worktree-base-ref-probe'
 import { gitExecFileAsync } from './runner'
 import { resolveLocalWindowsParallelCheckoutGitArgs } from './windows-parallel-checkout'
-import { isWslLinkedWorktreeGitRoutingCandidate } from './wsl-linked-worktree-git-routing'
+import {
+  gitExecOptions,
+  WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS
+} from './worktree-operation-options'
+import {
+  gitCleanupOptions,
+  performDiscardPreparedWorktree,
+  removeFailedFinalization
+} from './worktree-create-preparation-cleanup'
+import {
+  invalidateWslLinkedWorktreeGitRouting,
+  isWslLinkedWorktreeGitRoutingCandidate
+} from './wsl-linked-worktree-git-routing'
 import { runWithGitReadCacheInvalidation } from './status'
-
-function gitExecOptions(
-  cwd: string,
-  options: GitWorktreeExecOptions
-): { cwd: string; wslDistro?: string; signal?: AbortSignal; timeout?: number } {
-  return {
-    cwd,
-    ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
-    ...(options.signal ? { signal: options.signal } : {}),
-    ...(options.timeout ? { timeout: options.timeout } : {})
-  }
-}
-
-function gitCleanupOptions(
-  cwd: string,
-  options: GitWorktreeExecOptions
-): { cwd: string; wslDistro?: string; timeout?: number } {
-  // Why: cancellation must not strand a partially moved worktree; cleanup is bounded separately.
-  return gitExecOptions(cwd, { ...options, signal: undefined })
-}
-
-async function performDiscardPreparedWorktree(
-  repoPath: string,
-  worktreePath: string,
-  options: GitWorktreeExecOptions
-): Promise<void> {
-  const cleanupGitOptions = {
-    ...gitCleanupOptions(repoPath, options),
-    timeout: options.timeout ?? WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS
-  }
-  try {
-    await gitExecFileAsync(
-      [...windowsLongPathGitArgs(repoPath), 'worktree', 'unlock', worktreePath],
-      cleanupGitOptions
-    )
-  } catch {
-    // It may be unlocked already or only partially registered.
-  }
-  await gitExecFileAsync(
-    [...windowsLongPathGitArgs(repoPath), 'worktree', 'remove', '--force', worktreePath],
-    cleanupGitOptions
-  )
-}
 
 export async function prepareWorktreeCreateCheckout(
   repoPath: string,
@@ -90,6 +58,9 @@ export async function prepareWorktreeCreateCheckout(
           ],
           { ...gitExecOptions(repoPath, options), timeout: resolveWorktreeAddTimeoutMs() }
         )
+        // The add just created the marker; clear any speculative miss/backoff
+        // before routing the materializing reset.
+        invalidateWslLinkedWorktreeGitRouting(worktreePath)
         // Why: reset materializes files without running user post-checkout hooks before submit.
         const checkoutArgs = isWslLinkedWorktreeGitRoutingCandidate(worktreePath, options.wslDistro)
           ? await resolveLocalWindowsParallelCheckoutGitArgs(worktreePath, {
@@ -163,34 +134,6 @@ export async function unlockPreparedWorktree(
   }
 }
 
-async function removeFailedFinalization(
-  repoPath: string,
-  cleanupPath: string,
-  branch: string,
-  moved: boolean,
-  options: GitWorktreeExecOptions
-): Promise<void> {
-  let branchAttached = false
-  if (moved) {
-    try {
-      const { stdout } = await gitExecFileAsync(
-        ['symbolic-ref', '--short', 'HEAD'],
-        gitCleanupOptions(cleanupPath, options)
-      )
-      branchAttached = stdout.trim() === branch
-    } catch {
-      // Detached or no longer readable.
-    }
-  }
-  await performDiscardPreparedWorktree(repoPath, cleanupPath, options).catch(() => {})
-  if (branchAttached) {
-    await gitExecFileAsync(
-      ['branch', '-D', '--', branch],
-      gitCleanupOptions(repoPath, options)
-    ).catch(() => {})
-  }
-}
-
 export async function finalizePreparedWorktree(
   repoPath: string,
   preparedPath: string,
@@ -260,6 +203,8 @@ export async function finalizePreparedWorktree(
           gitExecOptions(repoPath, finalizeGitOptions)
         )
         moved = true
+        invalidateWslLinkedWorktreeGitRouting(preparedPath)
+        invalidateWslLinkedWorktreeGitRouting(worktreePath)
         // Resolve after the move so a newly-created `.git` marker can select
         // the correct WSL/host route for the final checkout.
         const targetParallelCheckoutArgs = await resolveLocalWindowsParallelCheckoutGitArgs(
@@ -294,6 +239,10 @@ export async function finalizePreparedWorktree(
           gitExecOptions(repoPath, finalizeGitOptions)
         )
       } catch (error) {
+        // A failed move may have changed one marker before returning an error;
+        // clear both route keys before best-effort rollback probes them.
+        invalidateWslLinkedWorktreeGitRouting(preparedPath)
+        invalidateWslLinkedWorktreeGitRouting(worktreePath)
         await removeFailedFinalization(
           repoPath,
           moved ? worktreePath : preparedPath,

--- a/src/main/git/worktree-create-preparation.ts
+++ b/src/main/git/worktree-create-preparation.ts
@@ -1,5 +1,4 @@
 import { windowsLongPathGitArgs } from '../../shared/windows-long-path-git-args'
-import { windowsParallelCheckoutGitArgs } from '../../shared/windows-parallel-checkout-git-args'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
 import type { AddWorktreeOptions, AddWorktreeResult, GitWorktreeExecOptions } from './worktree'
 import {
@@ -12,6 +11,8 @@ import {
 } from './worktree'
 import { hasWorktreeBaseCommitRef } from './worktree-base-ref-probe'
 import { gitExecFileAsync } from './runner'
+import { resolveLocalWindowsParallelCheckoutGitArgs } from './windows-parallel-checkout'
+import { isWslLinkedWorktreeGitRoutingCandidate } from './wsl-linked-worktree-git-routing'
 import { runWithGitReadCacheInvalidation } from './status'
 
 function gitExecOptions(
@@ -66,6 +67,13 @@ export async function prepareWorktreeCreateCheckout(
 ): Promise<void> {
   try {
     await runWithGitReadCacheInvalidation(async () => {
+      const parallelCheckoutArgsPromise = resolveLocalWindowsParallelCheckoutGitArgs(worktreePath, {
+        ...options,
+        probeCwd: repoPath
+      })
+      // Base validation can fail before reset; observe the speculative probe so
+      // cancellation/failure never becomes an unhandled rejection.
+      void parallelCheckoutArgsPromise.catch(() => {})
       const effectiveBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
         hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
       )
@@ -83,10 +91,16 @@ export async function prepareWorktreeCreateCheckout(
           { ...gitExecOptions(repoPath, options), timeout: resolveWorktreeAddTimeoutMs() }
         )
         // Why: reset materializes files without running user post-checkout hooks before submit.
+        const checkoutArgs = isWslLinkedWorktreeGitRoutingCandidate(worktreePath, options.wslDistro)
+          ? await resolveLocalWindowsParallelCheckoutGitArgs(worktreePath, {
+              ...options,
+              probeCwd: repoPath
+            })
+          : await parallelCheckoutArgsPromise
         await gitExecFileAsync(
           [
             ...windowsLongPathGitArgs(worktreePath),
-            ...windowsParallelCheckoutGitArgs(worktreePath, process.platform, options.wslDistro),
+            ...checkoutArgs,
             'reset',
             '--hard',
             effectiveBase
@@ -192,6 +206,14 @@ export async function finalizePreparedWorktree(
   }
   try {
     return await runWithGitReadCacheInvalidation(async () => {
+      const preparedParallelCheckoutArgsPromise = resolveLocalWindowsParallelCheckoutGitArgs(
+        preparedPath,
+        {
+          ...finalizeGitOptions,
+          probeCwd: repoPath
+        }
+      )
+      void preparedParallelCheckoutArgsPromise.catch(() => {})
       const baseContext = await resolveWorktreeAddBaseContext(
         repoPath,
         baseBranch,
@@ -208,18 +230,13 @@ export async function finalizePreparedWorktree(
           gitExecOptions(preparedPath, finalizeGitOptions)
         )
       ])
-      const { stdout: targetHeadOutput } = targetHeadResult
-      const targetHead = targetHeadOutput.trim()
-      const { stdout: preparedHeadOutput } = preparedHeadResult
-      if (preparedHeadOutput.trim() !== targetHead) {
+      const targetHead = targetHeadResult.stdout.trim()
+      if (preparedHeadResult.stdout.trim() !== targetHead) {
+        const preparedParallelCheckoutArgs = await preparedParallelCheckoutArgsPromise
         await gitExecFileAsync(
           [
             ...windowsLongPathGitArgs(preparedPath),
-            ...windowsParallelCheckoutGitArgs(
-              preparedPath,
-              process.platform,
-              finalizeGitOptions.wslDistro
-            ),
+            ...preparedParallelCheckoutArgs,
             'reset',
             '--hard',
             targetHead
@@ -243,15 +260,20 @@ export async function finalizePreparedWorktree(
           gitExecOptions(repoPath, finalizeGitOptions)
         )
         moved = true
+        // Resolve after the move so a newly-created `.git` marker can select
+        // the correct WSL/host route for the final checkout.
+        const targetParallelCheckoutArgs = await resolveLocalWindowsParallelCheckoutGitArgs(
+          worktreePath,
+          {
+            ...finalizeGitOptions,
+            probeCwd: repoPath
+          }
+        )
         // Why: `-f -f` moves the locked preparation while preserving its lock reason (Git >=2.25).
         await gitExecFileAsync(
           [
             ...windowsLongPathGitArgs(worktreePath),
-            ...windowsParallelCheckoutGitArgs(
-              worktreePath,
-              process.platform,
-              finalizeGitOptions.wslDistro
-            ),
+            ...targetParallelCheckoutArgs,
             'checkout',
             '--no-track',
             '-b',

--- a/src/main/git/worktree-create-preparation.ts
+++ b/src/main/git/worktree-create-preparation.ts
@@ -1,4 +1,5 @@
 import { windowsLongPathGitArgs } from '../../shared/windows-long-path-git-args'
+import { windowsParallelCheckoutGitArgs } from '../../shared/windows-parallel-checkout-git-args'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
 import type { AddWorktreeOptions, AddWorktreeResult, GitWorktreeExecOptions } from './worktree'
 import {
@@ -83,7 +84,13 @@ export async function prepareWorktreeCreateCheckout(
         )
         // Why: reset materializes files without running user post-checkout hooks before submit.
         await gitExecFileAsync(
-          [...windowsLongPathGitArgs(worktreePath), 'reset', '--hard', effectiveBase],
+          [
+            ...windowsLongPathGitArgs(worktreePath),
+            ...windowsParallelCheckoutGitArgs(worktreePath, process.platform, options.wslDistro),
+            'reset',
+            '--hard',
+            effectiveBase
+          ],
           { ...gitExecOptions(worktreePath, options), timeout: resolveWorktreeAddTimeoutMs() }
         )
         await gitExecFileAsync(
@@ -206,7 +213,17 @@ export async function finalizePreparedWorktree(
       const { stdout: preparedHeadOutput } = preparedHeadResult
       if (preparedHeadOutput.trim() !== targetHead) {
         await gitExecFileAsync(
-          [...windowsLongPathGitArgs(preparedPath), 'reset', '--hard', targetHead],
+          [
+            ...windowsLongPathGitArgs(preparedPath),
+            ...windowsParallelCheckoutGitArgs(
+              preparedPath,
+              process.platform,
+              finalizeGitOptions.wslDistro
+            ),
+            'reset',
+            '--hard',
+            targetHead
+          ],
           gitExecOptions(preparedPath, finalizeGitOptions)
         )
       }
@@ -230,6 +247,11 @@ export async function finalizePreparedWorktree(
         await gitExecFileAsync(
           [
             ...windowsLongPathGitArgs(worktreePath),
+            ...windowsParallelCheckoutGitArgs(
+              worktreePath,
+              process.platform,
+              finalizeGitOptions.wslDistro
+            ),
             'checkout',
             '--no-track',
             '-b',

--- a/src/main/git/worktree-listing.ts
+++ b/src/main/git/worktree-listing.ts
@@ -28,8 +28,9 @@ export async function listWorktreeGraph(
   repoPath: string,
   options: GitWorktreeExecOptions = {}
 ): Promise<GitWorktreeInfo[]> {
+  const { annotateSparseCheckout: _annotateSparseCheckout, ...readOptions } = options
   try {
-    const worktrees = await readTranslatedWorktreeGraph(repoPath, options)
+    const worktrees = await readTranslatedWorktreeGraph(repoPath, readOptions)
     return options.includeCreatePreparations
       ? worktrees
       : worktrees.filter((worktree) => !isWorktreeCreatePreparation(worktree))
@@ -56,12 +57,15 @@ export async function listWorktreesUnshared(
   repoPath: string,
   options: GitWorktreeExecOptions = {}
 ): Promise<GitWorktreeInfo[]> {
+  const { annotateSparseCheckout = true, ...readOptions } = options
   try {
-    const worktrees = await readTranslatedWorktreeGraph(repoPath, options)
+    const worktrees = await readTranslatedWorktreeGraph(repoPath, readOptions)
     const visibleWorktrees = options.includeCreatePreparations
       ? worktrees
       : worktrees.filter((worktree) => !isWorktreeCreatePreparation(worktree))
-    return annotateSparseCheckoutStatus(visibleWorktrees)
+    return annotateSparseCheckout
+      ? annotateSparseCheckoutStatus(visibleWorktrees)
+      : visibleWorktrees
   } catch (err) {
     if (getErrorCode(err) === 'ENOENT') {
       try {
@@ -86,14 +90,15 @@ export async function listWorktreesStrict(
   repoPath: string,
   options: GitWorktreeExecOptions = {}
 ): Promise<GitWorktreeInfo[]> {
-  const worktrees = (await readWorktreeList(repoPath, options)).map((worktree) => {
-    const translatedPath = translateWorktreePath(worktree.path, repoPath, options)
+  const { annotateSparseCheckout = true, ...readOptions } = options
+  const worktrees = (await readWorktreeList(repoPath, readOptions)).map((worktree) => {
+    const translatedPath = translateWorktreePath(worktree.path, repoPath, readOptions)
     return translatedPath === worktree.path ? worktree : { ...worktree, path: translatedPath }
   })
   const visibleWorktrees = options.includeCreatePreparations
     ? worktrees
     : worktrees.filter((worktree) => !isWorktreeCreatePreparation(worktree))
-  return annotateSparseCheckoutStatus(visibleWorktrees)
+  return annotateSparseCheckout ? annotateSparseCheckoutStatus(visibleWorktrees) : visibleWorktrees
 }
 
 async function annotateSparseCheckoutStatus(

--- a/src/main/git/worktree-move.ts
+++ b/src/main/git/worktree-move.ts
@@ -1,5 +1,6 @@
 import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
+import { invalidateWslLinkedWorktreeGitRouting } from './wsl-linked-worktree-git-routing'
 import { bumpWorktreeScanGeneration } from './worktree-scan-cache'
 
 /**
@@ -18,6 +19,10 @@ export async function moveWorktree(
       gitExecFileAsync(['worktree', 'move', oldPath, newPath], { cwd: repoPath })
     )
   } finally {
+    // A failed move can still leave Git's marker state changed; force both
+    // paths to be re-probed before a subsequent command.
+    invalidateWslLinkedWorktreeGitRouting(oldPath)
+    invalidateWslLinkedWorktreeGitRouting(newPath)
     bumpWorktreeScanGeneration(repoPath)
   }
 }

--- a/src/main/git/worktree-operation-options.ts
+++ b/src/main/git/worktree-operation-options.ts
@@ -19,6 +19,8 @@ export type GitWorktreeExecOptions = {
   signal?: AbortSignal
   timeout?: number
   includeCreatePreparations?: boolean
+  /** Skip per-worktree sparse-checkout probes when callers only need Git metadata. */
+  annotateSparseCheckout?: boolean
 }
 
 export type WorktreeRemovalPreflightOptions = GitWorktreeExecOptions & {

--- a/src/main/git/worktree-removal.ts
+++ b/src/main/git/worktree-removal.ts
@@ -13,6 +13,7 @@ import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
 import { deleteBranchAfterWorktreeRemoval } from './worktree-branch-removal'
 import { listWorktreesStrict } from './worktree-listing'
+import { invalidateWslLinkedWorktreeGitRouting } from './wsl-linked-worktree-git-routing'
 import type { RemoveWorktreeOptions } from './worktree-operation-options'
 import {
   WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS,
@@ -38,6 +39,7 @@ export async function removeWorktree(
       performRemoveWorktree(repoPath, worktreePath, force, options)
     )
   } finally {
+    invalidateWslLinkedWorktreeGitRouting(worktreePath)
     bumpWorktreeScanGeneration(repoPath)
   }
 }

--- a/src/main/git/worktree-scan-cache-sharing.test.ts
+++ b/src/main/git/worktree-scan-cache-sharing.test.ts
@@ -5,12 +5,14 @@ const {
   gitExecFileAsyncMock,
   gitExecFileSyncMock,
   translateWslOutputPathsMock,
-  moveWorktreeDirectoryToTrashMock
+  moveWorktreeDirectoryToTrashMock,
+  detectSparseCheckoutMock
 } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
   gitExecFileSyncMock: vi.fn(),
   translateWslOutputPathsMock: vi.fn((output: string) => output),
-  moveWorktreeDirectoryToTrashMock: vi.fn()
+  moveWorktreeDirectoryToTrashMock: vi.fn(),
+  detectSparseCheckoutMock: vi.fn()
 }))
 
 vi.mock('./runner', () => ({
@@ -24,6 +26,11 @@ vi.mock('../worktree-trash', () => ({
   moveWorktreeDirectoryToTrash: moveWorktreeDirectoryToTrashMock.mockResolvedValue(undefined),
   restoreWorktreeDirectoryFromTrash: vi.fn().mockResolvedValue(true),
   scheduleWorktreeTrashDeletion: vi.fn()
+}))
+
+vi.mock('./worktree-sparse-state', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  detectSparseCheckout: detectSparseCheckoutMock
 }))
 
 import {
@@ -43,6 +50,7 @@ registerWorktreeSuiteHooks()
 describe('listWorktrees in-flight sharing', () => {
   beforeEach(async () => {
     gitExecFileAsyncMock.mockReset()
+    detectSparseCheckoutMock.mockReset().mockResolvedValue(false)
     _resetWorktreeScanCacheForTests()
     // Why: capability discovery serializes same-host callers; warming it lets
     // these tests isolate the scan-generation overlap they are exercising.
@@ -142,6 +150,32 @@ describe('listWorktrees in-flight sharing', () => {
       ],
       [['worktree', 'list', '--porcelain', '-z'], { cwd: '/repo', timeout: 5_000 }]
     ])
+  })
+
+  it('can skip sparse-checkout probes for registration-only checks', async () => {
+    const scanOutput = 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n'
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: scanOutput })
+
+    await expect(listWorktreesStrict('/repo', { annotateSparseCheckout: false })).resolves.toEqual([
+      {
+        path: '/repo',
+        head: 'abc123',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+    expect(detectSparseCheckoutMock).not.toHaveBeenCalled()
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps sparse-checkout probes in the default listing contract', async () => {
+    const scanOutput = 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n'
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: scanOutput })
+
+    await listWorktreesStrict('/repo')
+
+    expect(detectSparseCheckoutMock).toHaveBeenCalledWith('/repo')
   })
 
   it('runs a fresh scan once the shared one has settled', async () => {

--- a/src/main/git/worktree-scan-cache.ts
+++ b/src/main/git/worktree-scan-cache.ts
@@ -67,7 +67,7 @@ function shareWorktreeScan(
   const timeout = options.timeout ?? WORKTREE_LIST_TIMEOUT_MS
   // Why: callers with different deadlines cannot safely share which timeout wins the scan.
   // Why `run.name`: a strict joiner must never receive a softened `[]` from a lenient scan.
-  const key = `${repoPath}\0${options.wslDistro ?? ''}\0${timeout}\0${options.includeCreatePreparations === true}\0${generation}\0${run.name}`
+  const key = `${repoPath}\0${options.wslDistro ?? ''}\0${timeout}\0${options.includeCreatePreparations === true}\0${options.annotateSparseCheckout !== false}\0${generation}\0${run.name}`
   const inFlight = inFlightWorktreeScans.get(key)
   if (inFlight) {
     return inFlight

--- a/src/main/git/worktree-sparse-add.ts
+++ b/src/main/git/worktree-sparse-add.ts
@@ -1,4 +1,5 @@
 import { windowsLongPathGitArgs } from '../../shared/windows-long-path-git-args'
+import { windowsParallelCheckoutGitArgs } from '../../shared/windows-parallel-checkout-git-args'
 import { gitExecFileAsync } from './runner'
 import { addWorktree, unsetWorktreeCreationBase } from './worktree-add'
 import type {
@@ -34,16 +35,21 @@ export async function addSparseWorktree(
     // Why: `worktree add --no-checkout` writes no files, so these are the calls that
     // actually materialize the deep path and need the long-path escape hatch.
     const longPathArgs = windowsLongPathGitArgs(worktreePath)
+    const parallelCheckoutArgs = windowsParallelCheckoutGitArgs(
+      worktreePath,
+      process.platform,
+      options.wslDistro
+    )
     await gitExecFileAsync(
       ['sparse-checkout', 'init', '--cone'],
       gitExecOptions(worktreePath, options)
     )
     await gitExecFileAsync(
-      [...longPathArgs, 'sparse-checkout', 'set', '--', ...directories],
+      [...longPathArgs, ...parallelCheckoutArgs, 'sparse-checkout', 'set', '--', ...directories],
       gitExecOptions(worktreePath, options)
     )
     await gitExecFileAsync(
-      [...longPathArgs, 'checkout', branch],
+      [...longPathArgs, ...parallelCheckoutArgs, 'checkout', branch],
       gitExecOptions(worktreePath, options)
     )
     return addResult

--- a/src/main/git/worktree-sparse-add.ts
+++ b/src/main/git/worktree-sparse-add.ts
@@ -1,6 +1,7 @@
 import { windowsLongPathGitArgs } from '../../shared/windows-long-path-git-args'
-import { windowsParallelCheckoutGitArgs } from '../../shared/windows-parallel-checkout-git-args'
 import { gitExecFileAsync } from './runner'
+import { resolveLocalWindowsParallelCheckoutGitArgs } from './windows-parallel-checkout'
+import { isWslLinkedWorktreeGitRoutingCandidate } from './wsl-linked-worktree-git-routing'
 import { addWorktree, unsetWorktreeCreationBase } from './worktree-add'
 import type {
   AddWorktreeOptions,
@@ -21,6 +22,13 @@ export async function addSparseWorktree(
 ): Promise<AddWorktreeResult> {
   let created = false
   let addResult: AddWorktreeResult = {}
+  // The no-checkout registration below does not need checkout tuning; start the
+  // capability probe now so sparse materialization can use it immediately.
+  const parallelCheckoutArgsPromise = resolveLocalWindowsParallelCheckoutGitArgs(worktreePath, {
+    ...options,
+    probeCwd: repoPath
+  })
+  void parallelCheckoutArgsPromise.catch(() => {})
   try {
     addResult = await addWorktree(
       repoPath,
@@ -35,13 +43,17 @@ export async function addSparseWorktree(
     // Why: `worktree add --no-checkout` writes no files, so these are the calls that
     // actually materialize the deep path and need the long-path escape hatch.
     const longPathArgs = windowsLongPathGitArgs(worktreePath)
-    const parallelCheckoutArgs = windowsParallelCheckoutGitArgs(
+    const parallelCheckoutArgs = isWslLinkedWorktreeGitRoutingCandidate(
       worktreePath,
-      process.platform,
       options.wslDistro
     )
+      ? await resolveLocalWindowsParallelCheckoutGitArgs(worktreePath, {
+          ...options,
+          probeCwd: repoPath
+        })
+      : await parallelCheckoutArgsPromise
     await gitExecFileAsync(
-      ['sparse-checkout', 'init', '--cone'],
+      [...longPathArgs, 'sparse-checkout', 'init', '--cone'],
       gitExecOptions(worktreePath, options)
     )
     await gitExecFileAsync(

--- a/src/main/git/wsl-linked-worktree-git-route-probe.ts
+++ b/src/main/git/wsl-linked-worktree-git-route-probe.ts
@@ -1,0 +1,55 @@
+import * as fsPromises from 'node:fs/promises'
+import { win32 } from 'node:path'
+import type { Stats } from 'node:fs'
+
+export type WslLinkedWorktreeRoutingFileSystem = {
+  stat(path: string): Promise<Pick<Stats, 'isDirectory' | 'isFile'>>
+  readFile(path: string): Promise<string>
+}
+
+export type WslLinkedWorktreeGitRouteProbeResult = {
+  usesHostGit: boolean
+  known: boolean
+}
+
+export function parseWindowsLinkedGitdir(content: string): string | null {
+  const firstLine = content.split(/\r?\n/, 1)[0] ?? ''
+  return firstLine.match(/^gitdir:\s*([A-Za-z]:[/\\].*?)\s*$/i)?.[1] ?? null
+}
+
+export const defaultWslLinkedWorktreeRoutingFileSystem: WslLinkedWorktreeRoutingFileSystem = {
+  stat: (path) => fsPromises.stat(path),
+  readFile: (path) => fsPromises.readFile(path, 'utf8')
+}
+
+/** Walk parent directories until Git's linked-worktree marker identifies the owner. */
+export async function probeWslLinkedWorktreeGitRoute(
+  cwd: string,
+  fileSystem: WslLinkedWorktreeRoutingFileSystem
+): Promise<WslLinkedWorktreeGitRouteProbeResult> {
+  let candidate = cwd
+  const driveRoot = win32.parse(candidate).root
+  while (true) {
+    const markerPath = win32.join(candidate, '.git')
+    try {
+      const marker = await fileSystem.stat(markerPath)
+      if (marker.isDirectory()) {
+        return { usesHostGit: false, known: true }
+      }
+      if (marker.isFile()) {
+        const usesHostGit = parseWindowsLinkedGitdir(await fileSystem.readFile(markerPath)) !== null
+        return { usesHostGit, known: usesHostGit }
+      }
+      return { usesHostGit: false, known: false }
+    } catch (error) {
+      const code = error && typeof error === 'object' ? (error as NodeJS.ErrnoException).code : null
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        throw error
+      }
+    }
+    if (candidate === driveRoot) {
+      return { usesHostGit: false, known: false }
+    }
+    candidate = win32.dirname(candidate)
+  }
+}

--- a/src/main/git/wsl-linked-worktree-git-routing.test.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   parseWindowsLinkedGitdir,
   getWslLinkedWorktreeGitRoute,
+  invalidateWslLinkedWorktreeGitRouting,
   prepareWslLinkedWorktreeGitRouting,
   resetWslLinkedWorktreeGitRoutingForTests,
   seedWslLinkedWorktreeGitRoutingForTests,
@@ -118,6 +119,67 @@ describe('getWslLinkedWorktreeGitRoute', () => {
       })
     ).resolves.toBe(true)
     expect(getWslLinkedWorktreeGitRoute(cwd, 'Ubuntu', 'win32')).toBe('host')
+  })
+
+  it('invalidates a repeated miss so marker appearance is not held by backoff', async () => {
+    let markerExists = false
+    const stat = vi.fn<WslLinkedWorktreeRoutingFileSystem['stat']>(async () => {
+      if (!markerExists) {
+        throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+      }
+      return fileMarker
+    })
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat,
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+    const cwd = String.raw`C:\new-target`
+    const prepare = (): Promise<boolean> =>
+      prepareWslLinkedWorktreeGitRouting(cwd, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+
+    // The second miss enters the exponential retry window.
+    await expect(prepare()).resolves.toBe(false)
+    await expect(prepare()).resolves.toBe(false)
+    const statCallsBeforeInvalidation = stat.mock.calls.length
+
+    markerExists = true
+    invalidateWslLinkedWorktreeGitRouting(cwd)
+    await expect(prepare()).resolves.toBe(true)
+
+    expect(stat.mock.calls.length).toBeGreaterThan(statCallsBeforeInvalidation)
+    expect(getWslLinkedWorktreeGitRoute(cwd, 'Ubuntu', 'win32')).toBe('host')
+  })
+
+  it('does not let an invalidated in-flight probe repopulate the route cache', async () => {
+    let releaseOldProbe: ((marker: typeof fileMarker) => void) | undefined
+    const oldProbe = new Promise<typeof fileMarker>((resolve) => {
+      releaseOldProbe = resolve
+    })
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi
+        .fn<WslLinkedWorktreeRoutingFileSystem['stat']>()
+        .mockReturnValueOnce(oldProbe)
+        .mockResolvedValueOnce(directoryMarker),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+    const cwd = String.raw`C:\new-target`
+    const oldRoute = prepareWslLinkedWorktreeGitRouting(cwd, 'Ubuntu', {
+      platform: 'win32',
+      fileSystem
+    })
+
+    invalidateWslLinkedWorktreeGitRouting(cwd)
+    const currentRoute = prepareWslLinkedWorktreeGitRouting(cwd, 'Ubuntu', {
+      platform: 'win32',
+      fileSystem
+    })
+    await expect(currentRoute).resolves.toBe(false)
+    releaseOldProbe?.(fileMarker)
+    await expect(oldRoute).resolves.toBe(false)
+    expect(getWslLinkedWorktreeGitRoute(cwd, 'Ubuntu', 'win32')).toBe('wsl')
   })
 })
 

--- a/src/main/git/wsl-linked-worktree-git-routing.test.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   parseWindowsLinkedGitdir,
+  getWslLinkedWorktreeGitRoute,
   prepareWslLinkedWorktreeGitRouting,
   resetWslLinkedWorktreeGitRoutingForTests,
   seedWslLinkedWorktreeGitRoutingForTests,
@@ -70,6 +71,53 @@ describe('usesHostGitForWslLinkedWorktree', () => {
     expect(usesHostGitForWslLinkedWorktree(String.raw`C:\repo\linked`, 'Ubuntu', 'linux')).toBe(
       false
     )
+  })
+})
+
+describe('getWslLinkedWorktreeGitRoute', () => {
+  it('distinguishes settled host, WSL, and unknown routes', async () => {
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async () => directoryMarker),
+      readFile: vi.fn(async () => '')
+    }
+    const cwd = String.raw`C:\repo`
+    expect(getWslLinkedWorktreeGitRoute(cwd, 'Ubuntu', 'win32')).toBe('unknown')
+    await prepareWslLinkedWorktreeGitRouting(cwd, 'Ubuntu', { platform: 'win32', fileSystem })
+    expect(getWslLinkedWorktreeGitRoute(cwd, 'Ubuntu', 'win32')).toBe('wsl')
+
+    seedWslLinkedWorktreeGitRoutingForTests(String.raw`C:\linked`)
+    expect(getWslLinkedWorktreeGitRoute(String.raw`C:\linked`, 'Ubuntu', 'win32')).toBe('host')
+  })
+
+  it('retries an unknown target after its worktree marker appears', async () => {
+    let markerExists = false
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async () => {
+        if (!markerExists) {
+          throw missingMarker()
+        }
+        return fileMarker
+      }),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+    const cwd = String.raw`C:\new-target`
+
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(cwd, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+    ).resolves.toBe(false)
+    expect(getWslLinkedWorktreeGitRoute(cwd, 'Ubuntu', 'win32')).toBe('unknown')
+
+    markerExists = true
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(cwd, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+    ).resolves.toBe(true)
+    expect(getWslLinkedWorktreeGitRoute(cwd, 'Ubuntu', 'win32')).toBe('host')
   })
 })
 

--- a/src/main/git/wsl-linked-worktree-git-routing.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.ts
@@ -1,9 +1,18 @@
-import * as fsPromises from 'node:fs/promises'
 import { win32 } from 'node:path'
-import type { Stats } from 'node:fs'
+import {
+  defaultWslLinkedWorktreeRoutingFileSystem,
+  probeWslLinkedWorktreeGitRoute,
+  type WslLinkedWorktreeRoutingFileSystem
+} from './wsl-linked-worktree-git-route-probe'
+
+export {
+  parseWindowsLinkedGitdir,
+  type WslLinkedWorktreeRoutingFileSystem
+} from './wsl-linked-worktree-git-route-probe'
 
 type CachedRoute = { usesHostGit: boolean; known: boolean; expiresAt: number }
 type TransientRouteFailure = { count: number; retryAfter: number }
+type PendingRoute = { promise: Promise<boolean>; token: symbol }
 
 // Bounds stale routing after delete/recreate while amortizing async parent walks on slow storage.
 export const WSL_LINKED_WORKTREE_ROUTE_TTL_MS = 30_000
@@ -15,7 +24,7 @@ export const WSL_LINKED_WORKTREE_ROUTE_RETRY_BASE_MS = 1_000
 const WSL_LINKED_WORKTREE_ROUTE_RETRY_MAX_MS = 30_000
 
 const routeByCwd = new Map<string, CachedRoute>()
-const pendingRoutes = new Map<string, Promise<boolean>>()
+const pendingRoutes = new Map<string, PendingRoute>()
 const transientFailuresByCwd = new Map<string, TransientRouteFailure>()
 const activeProbeCountByCwd = new Map<string, number>()
 let activeProbeCount = 0
@@ -46,57 +55,11 @@ function cachedRoute(cwd: string, now: number): CachedRoute | undefined {
   return exact
 }
 
-export function parseWindowsLinkedGitdir(content: string): string | null {
-  const firstLine = content.split(/\r?\n/, 1)[0] ?? ''
-  return firstLine.match(/^gitdir:\s*([A-Za-z]:[/\\].*?)\s*$/i)?.[1] ?? null
-}
-
-export type WslLinkedWorktreeRoutingFileSystem = {
-  stat(path: string): Promise<Pick<Stats, 'isDirectory' | 'isFile'>>
-  readFile(path: string): Promise<string>
-}
-
 export type WslLinkedWorktreeRoutingOptions = {
   platform?: NodeJS.Platform
   fileSystem?: WslLinkedWorktreeRoutingFileSystem
   now?: () => number
   signal?: AbortSignal
-}
-
-const defaultFileSystem: WslLinkedWorktreeRoutingFileSystem = {
-  stat: (path) => fsPromises.stat(path),
-  readFile: (path) => fsPromises.readFile(path, 'utf8')
-}
-
-async function shouldUseHostGit(
-  cwd: string,
-  fileSystem: WslLinkedWorktreeRoutingFileSystem
-): Promise<{ usesHostGit: boolean; known: boolean }> {
-  let candidate = cwd
-  const driveRoot = win32.parse(candidate).root
-  while (true) {
-    const markerPath = win32.join(candidate, '.git')
-    try {
-      const marker = await fileSystem.stat(markerPath)
-      if (marker.isDirectory()) {
-        return { usesHostGit: false, known: true }
-      }
-      if (marker.isFile()) {
-        const usesHostGit = parseWindowsLinkedGitdir(await fileSystem.readFile(markerPath)) !== null
-        return { usesHostGit, known: usesHostGit }
-      }
-      return { usesHostGit: false, known: false }
-    } catch (error) {
-      const code = error && typeof error === 'object' ? (error as NodeJS.ErrnoException).code : null
-      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
-        throw error
-      }
-    }
-    if (candidate === driveRoot) {
-      return { usesHostGit: false, known: false }
-    }
-    candidate = win32.dirname(candidate)
-  }
 }
 
 function rememberRoute(cwd: string, usesHostGit: boolean, now: number): boolean {
@@ -118,6 +81,24 @@ function rememberRoute(cwd: string, usesHostGit: boolean, now: number): boolean 
 
 function routingAbortError(): Error {
   return Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' })
+}
+
+/**
+ * Drop route state after Git materializes, moves, or removes a worktree.
+ *
+ * A missing `.git` marker is retried with backoff.  Creation can make that
+ * marker appear during the backoff window, so leave no stale route (or stale
+ * in-flight probe) for the next Git command to inherit.
+ */
+export function invalidateWslLinkedWorktreeGitRouting(cwd: string): void {
+  const normalizedCwd = normalize(cwd)
+  routeByCwd.delete(normalizedCwd)
+  transientFailuresByCwd.delete(normalizedCwd)
+  if (pendingRoutes.has(normalizedCwd)) {
+    // Let the old probe settle in the background, but don't let callers join it
+    // after the filesystem mutation.
+    pendingRoutes.delete(normalizedCwd)
+  }
 }
 
 function rememberTransientFailure(cwd: string, now: number): void {
@@ -201,7 +182,8 @@ function waitForRouteUnlessAborted(
 function discoverRoute(
   cwd: string,
   fileSystem: WslLinkedWorktreeRoutingFileSystem,
-  now: () => number
+  now: () => number,
+  isCurrent: () => boolean
 ): Promise<boolean> {
   return new Promise((resolve) => {
     const generation = routeProbeGeneration
@@ -212,7 +194,7 @@ function discoverRoute(
       }
       settled = true
       clearTimeout(timer)
-      if (generation !== routeProbeGeneration) {
+      if (generation !== routeProbeGeneration || !isCurrent()) {
         resolve(false)
         return
       }
@@ -234,7 +216,7 @@ function discoverRoute(
     )
     timer.unref()
     const releaseProbe = trackRouteProbe(cwd)
-    void shouldUseHostGit(cwd, fileSystem).then(
+    void probeWslLinkedWorktreeGitRoute(cwd, fileSystem).then(
       ({ usesHostGit, known }) => {
         releaseProbe()
         finish(usesHostGit, known, true)
@@ -253,7 +235,7 @@ export async function prepareWslLinkedWorktreeGitRouting(
   options: WslLinkedWorktreeRoutingOptions = {}
 ): Promise<boolean> {
   const platform = options.platform ?? process.platform
-  const fileSystem = options.fileSystem ?? defaultFileSystem
+  const fileSystem = options.fileSystem ?? defaultWslLinkedWorktreeRoutingFileSystem
   const now = options.now ?? Date.now
   if (!isWslLinkedWorktreeGitRoutingCandidate(cwd, wslDistro, platform)) {
     return false
@@ -268,18 +250,24 @@ export async function prepareWslLinkedWorktreeGitRouting(
   }
   const pending = pendingRoutes.get(normalizedCwd)
   if (pending) {
-    return waitForRouteUnlessAborted(pending, options.signal)
+    return waitForRouteUnlessAborted(pending.promise, options.signal)
   }
   if (!canStartRouteProbe(normalizedCwd, now())) {
     return false
   }
-  const discovery = discoverRoute(normalizedCwd, fileSystem, now)
+  const token = Symbol('wsl-linked-route-probe')
+  const discovery = discoverRoute(
+    normalizedCwd,
+    fileSystem,
+    now,
+    () => pendingRoutes.get(normalizedCwd)?.token === token
+  )
   const route = discovery.finally(() => {
-    if (pendingRoutes.get(normalizedCwd) === route) {
+    if (pendingRoutes.get(normalizedCwd)?.token === token) {
       pendingRoutes.delete(normalizedCwd)
     }
   })
-  pendingRoutes.set(normalizedCwd, route)
+  pendingRoutes.set(normalizedCwd, { promise: route, token })
   return waitForRouteUnlessAborted(route, options.signal)
 }
 

--- a/src/main/git/wsl-linked-worktree-git-routing.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.ts
@@ -2,7 +2,7 @@ import * as fsPromises from 'node:fs/promises'
 import { win32 } from 'node:path'
 import type { Stats } from 'node:fs'
 
-type CachedRoute = { usesHostGit: boolean; expiresAt: number }
+type CachedRoute = { usesHostGit: boolean; known: boolean; expiresAt: number }
 type TransientRouteFailure = { count: number; retryAfter: number }
 
 // Bounds stale routing after delete/recreate while amortizing async parent walks on slow storage.
@@ -34,7 +34,7 @@ function normalize(path: string): string {
   return win32.resolve(path)
 }
 
-function cachedRoute(cwd: string, now: number): boolean | undefined {
+function cachedRoute(cwd: string, now: number): CachedRoute | undefined {
   const exact = routeByCwd.get(cwd)
   if (!exact) {
     return undefined
@@ -43,7 +43,7 @@ function cachedRoute(cwd: string, now: number): boolean | undefined {
     routeByCwd.delete(cwd)
     return undefined
   }
-  return exact.usesHostGit
+  return exact
 }
 
 export function parseWindowsLinkedGitdir(content: string): string | null {
@@ -71,7 +71,7 @@ const defaultFileSystem: WslLinkedWorktreeRoutingFileSystem = {
 async function shouldUseHostGit(
   cwd: string,
   fileSystem: WslLinkedWorktreeRoutingFileSystem
-): Promise<boolean> {
+): Promise<{ usesHostGit: boolean; known: boolean }> {
   let candidate = cwd
   const driveRoot = win32.parse(candidate).root
   while (true) {
@@ -79,12 +79,13 @@ async function shouldUseHostGit(
     try {
       const marker = await fileSystem.stat(markerPath)
       if (marker.isDirectory()) {
-        return false
+        return { usesHostGit: false, known: true }
       }
       if (marker.isFile()) {
-        return parseWindowsLinkedGitdir(await fileSystem.readFile(markerPath)) !== null
+        const usesHostGit = parseWindowsLinkedGitdir(await fileSystem.readFile(markerPath)) !== null
+        return { usesHostGit, known: usesHostGit }
       }
-      return false
+      return { usesHostGit: false, known: false }
     } catch (error) {
       const code = error && typeof error === 'object' ? (error as NodeJS.ErrnoException).code : null
       if (code !== 'ENOENT' && code !== 'ENOTDIR') {
@@ -92,7 +93,7 @@ async function shouldUseHostGit(
       }
     }
     if (candidate === driveRoot) {
-      return false
+      return { usesHostGit: false, known: false }
     }
     candidate = win32.dirname(candidate)
   }
@@ -111,7 +112,7 @@ function rememberRoute(cwd: string, usesHostGit: boolean, now: number): boolean 
     }
     nextRoutePruneAt = now + WSL_LINKED_WORKTREE_ROUTE_TTL_MS
   }
-  routeByCwd.set(cwd, { usesHostGit, expiresAt })
+  routeByCwd.set(cwd, { usesHostGit, known: true, expiresAt })
   return usesHostGit
 }
 
@@ -205,7 +206,7 @@ function discoverRoute(
   return new Promise((resolve) => {
     const generation = routeProbeGeneration
     let settled = false
-    const finish = (usesHostGit: boolean, cacheable: boolean): void => {
+    const finish = (usesHostGit: boolean, known: boolean, cacheable: boolean): void => {
       if (settled) {
         return
       }
@@ -215,7 +216,11 @@ function discoverRoute(
         resolve(false)
         return
       }
-      if (cacheable) {
+      // Only a positively identified route is stable enough to cache. A
+      // missing/malformed marker commonly means the worktree is being created
+      // right now; retaining that `unknown` result would suppress the host
+      // route probe during finalization and needlessly keep the FSCache flag.
+      if (cacheable && known) {
         transientFailuresByCwd.delete(cwd)
         resolve(rememberRoute(cwd, usesHostGit, now()))
       } else {
@@ -223,17 +228,20 @@ function discoverRoute(
         resolve(usesHostGit)
       }
     }
-    const timer = setTimeout(() => finish(false, false), WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS)
+    const timer = setTimeout(
+      () => finish(false, false, false),
+      WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS
+    )
     timer.unref()
     const releaseProbe = trackRouteProbe(cwd)
     void shouldUseHostGit(cwd, fileSystem).then(
-      (usesHostGit) => {
+      ({ usesHostGit, known }) => {
         releaseProbe()
-        finish(usesHostGit, true)
+        finish(usesHostGit, known, true)
       },
       () => {
         releaseProbe()
-        finish(false, false)
+        finish(false, false, false)
       }
     )
   })
@@ -256,7 +264,7 @@ export async function prepareWslLinkedWorktreeGitRouting(
   const normalizedCwd = normalize(cwd)
   const cached = cachedRoute(normalizedCwd, now())
   if (cached !== undefined) {
-    return cached
+    return cached.usesHostGit
   }
   const pending = pendingRoutes.get(normalizedCwd)
   if (pending) {
@@ -283,8 +291,23 @@ export function usesHostGitForWslLinkedWorktree(
 ): boolean {
   return (
     isWslLinkedWorktreeGitRoutingCandidate(cwd, wslDistro, platform) &&
-    cachedRoute(normalize(cwd), now()) === true
+    cachedRoute(normalize(cwd), now())?.usesHostGit === true
   )
+}
+
+export type WslLinkedWorktreeGitRoute = 'host' | 'wsl' | 'unknown' | 'not-applicable'
+
+export function getWslLinkedWorktreeGitRoute(
+  cwd: string,
+  wslDistro: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+  now: () => number = Date.now
+): WslLinkedWorktreeGitRoute {
+  if (!isWslLinkedWorktreeGitRoutingCandidate(cwd, wslDistro, platform)) {
+    return 'not-applicable'
+  }
+  const route = cachedRoute(normalize(cwd), now())
+  return route?.known ? (route.usesHostGit ? 'host' : 'wsl') : 'unknown'
 }
 
 export function resetWslLinkedWorktreeGitRoutingForTests(): void {
@@ -298,9 +321,9 @@ export function resetWslLinkedWorktreeGitRoutingForTests(): void {
 }
 
 export function seedWslLinkedWorktreeGitRoutingForTests(root: string): void {
-  const normalizedRoot = normalize(root)
-  routeByCwd.set(normalizedRoot, {
+  routeByCwd.set(normalize(root), {
     usesHostGit: true,
+    known: true,
     expiresAt: Number.POSITIVE_INFINITY
   })
 }

--- a/src/main/ipc/worktree-logic-wsl.test.ts
+++ b/src/main/ipc/worktree-logic-wsl.test.ts
@@ -15,7 +15,9 @@ vi.mock('../wsl', () => ({
 
 import {
   computeWorktreePath,
+  computeWorktreePathFromWorkspaceRoot,
   computeWorktreePathAsync,
+  computeWorkspaceRootAsync,
   getWorktreePathSettings
 } from './worktree-logic'
 import {
@@ -204,6 +206,35 @@ describe('computeWorktreePath WSL layout', () => {
     await expect(computeWorktreePathAsync('feature', repo.path, pathSettings)).resolves.toBe(
       computeWorktreePath('feature', repo.path, pathSettings)
     )
+  })
+
+  it('reuses one resolved WSL root for suffix candidates without a sync home probe', async () => {
+    parseWslPathMock.mockReturnValue(null)
+    getWslHomeMock.mockImplementation(() => {
+      throw new Error('sync WSL home lookup should not run')
+    })
+    getWslHomeAsyncMock.mockResolvedValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+
+    const settings = {
+      nestWorkspaces: false,
+      workspaceDir: 'C:\\workspaces',
+      wslMirrorDistro: 'Ubuntu'
+    }
+    const workspaceRoot = await computeWorkspaceRootAsync('C:\\Users\\jin\\repo', settings)
+
+    expect(
+      computeWorktreePathFromWorkspaceRoot('feature', 'C:\\Users\\jin\\repo', workspaceRoot, false)
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\orca\\workspaces\\feature')
+    expect(
+      computeWorktreePathFromWorkspaceRoot(
+        'feature-2',
+        'C:\\Users\\jin\\repo',
+        workspaceRoot,
+        false
+      )
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\orca\\workspaces\\feature-2')
+    expect(getWslHomeAsyncMock).toHaveBeenCalledTimes(1)
+    expect(getWslHomeMock).not.toHaveBeenCalled()
   })
 
   it('honors a Linux repo base path even when the distro home lookup fails', () => {

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -135,7 +135,13 @@ export async function computeWorktreePathAsync(
   return pathOps.join(workspaceRoot, sanitizedName)
 }
 
-async function computeWorkspaceRootAsync(
+/**
+ * Resolve the workspace root without blocking the Electron main thread.
+ *
+ * WSL home discovery shells out to `wsl.exe`; callers on an interaction path
+ * should use this variant rather than the legacy synchronous resolver.
+ */
+export async function computeWorkspaceRootAsync(
   repoPath: string,
   settings: { workspaceDir: string; wslMirrorDistro?: string }
 ): Promise<string> {

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -109,9 +109,29 @@ export function computeWorktreePath(
   settings: WorktreePathSettings
 ): string {
   const workspaceRoot = computeWorkspaceRoot(repoPath, settings)
-  const pathOps = getRuntimePathOps(repoPath, workspaceRoot)
+  return computeWorktreePathFromWorkspaceRoot(
+    sanitizedName,
+    repoPath,
+    workspaceRoot,
+    settings.nestWorkspaces
+  )
+}
 
-  if (settings.nestWorkspaces) {
+/**
+ * Build a worktree path from an already resolved workspace root.
+ *
+ * Callers that may need a WSL mirror should resolve the root once and reuse it
+ * across candidate retries; this keeps path construction pure and avoids a
+ * synchronous `wsl.exe` home probe for every candidate.
+ */
+export function computeWorktreePathFromWorkspaceRoot(
+  sanitizedName: string,
+  repoPath: string,
+  workspaceRoot: string,
+  nestWorkspaces: boolean
+): string {
+  const pathOps = getRuntimePathOps(repoPath, workspaceRoot)
+  if (nestWorkspaces) {
     const repoName = pathOps.basename(repoPath).replace(/\.git$/, '')
     return pathOps.join(workspaceRoot, repoName, sanitizedName)
   }
@@ -126,13 +146,12 @@ export async function computeWorktreePathAsync(
   settings: WorktreePathSettings
 ): Promise<string> {
   const workspaceRoot = await computeWorkspaceRootAsync(repoPath, settings)
-  const pathOps = getRuntimePathOps(repoPath, workspaceRoot)
-
-  if (settings.nestWorkspaces) {
-    const repoName = pathOps.basename(repoPath).replace(/\.git$/, '')
-    return pathOps.join(workspaceRoot, repoName, sanitizedName)
-  }
-  return pathOps.join(workspaceRoot, sanitizedName)
+  return computeWorktreePathFromWorkspaceRoot(
+    sanitizedName,
+    repoPath,
+    workspaceRoot,
+    settings.nestWorkspaces
+  )
 }
 
 /**

--- a/src/main/ipc/worktree-remote-ssh-branch-conflict.test.ts
+++ b/src/main/ipc/worktree-remote-ssh-branch-conflict.test.ts
@@ -20,7 +20,15 @@ function providerAnswering(answers: {
       return { stdout: `${answers.localBranchHead}\n`, stderr: '' }
     }
     if (args[0] === 'for-each-ref') {
-      return { stdout: `${answers.remoteRefs.join('\n')}\n`, stderr: '' }
+      // The local implementation batches the exact local-head pattern with
+      // the remote scan. Model that extra pattern while retaining the
+      // remote-only response used by the fallback path.
+      const localPattern = args.find((arg) => arg.startsWith('refs/heads/'))
+      const refs =
+        localPattern && answers.localBranchHead
+          ? [localPattern, ...answers.remoteRefs]
+          : answers.remoteRefs
+      return { stdout: `${refs.join('\n')}\n`, stderr: '' }
     }
     throw new Error(`unexpected git ${args.join(' ')}`)
   })

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -2011,7 +2011,7 @@ export async function createLocalWorktree(
     settings,
     getWorktreeMirrorDistro(store, repo)
   )
-  // WSL mirror roots require a `wsl.exe` home probe. Start it before the Git
+  // WSL mirror roots require a host-home probe. Start it before the Git
   // preflight so that probe overlaps branch/base validation and never blocks
   // the Electron main thread on the submit path.
   const workspaceRootPromise = computeWorkspaceRootAsync(repo.path, worktreePathSettings)
@@ -2049,13 +2049,21 @@ export async function createLocalWorktree(
       ...localWorktreeGitOptionArgs
     )
     remoteTrackingBaseProbes.set(baseBranch, pending)
-    // A transient runtime failure should not poison a later retry in this
-    // create; preserve the existing rejection behavior while dropping it.
-    void pending.catch(() => {
-      if (remoteTrackingBaseProbes.get(baseBranch) === pending) {
-        remoteTrackingBaseProbes.delete(baseBranch)
+    // A transient runtime failure or an unresolved base should not poison a
+    // later retry in this create; preserve rejection behavior while dropping
+    // either non-success result.
+    void pending.then(
+      (result) => {
+        if (result === null && remoteTrackingBaseProbes.get(baseBranch) === pending) {
+          remoteTrackingBaseProbes.delete(baseBranch)
+        }
+      },
+      () => {
+        if (remoteTrackingBaseProbes.get(baseBranch) === pending) {
+          remoteTrackingBaseProbes.delete(baseBranch)
+        }
       }
-    })
+    )
     return pending
   }
 

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -2019,6 +2019,36 @@ export async function createLocalWorktree(
     return { ...options, ...localWorktreeGitOptions }
   }
 
+  // Base validation may already have resolved the remote that owns a persisted
+  // base ref. Reuse that answer after the base is selected; spawning another
+  // `git remote` is especially visible on Windows and WSL.
+  const remoteTrackingBaseProbes = new Map<string, Promise<RemoteTrackingBase | null>>()
+  const resolveRemoteTrackingBaseForCreate = (
+    baseBranch: string
+  ): Promise<RemoteTrackingBase | null> => {
+    if (!runtime) {
+      return Promise.resolve(null)
+    }
+    const cached = remoteTrackingBaseProbes.get(baseBranch)
+    if (cached) {
+      return cached
+    }
+    const pending = runtime.resolveRemoteTrackingBase(
+      repo.path,
+      baseBranch,
+      ...localWorktreeGitOptionArgs
+    )
+    remoteTrackingBaseProbes.set(baseBranch, pending)
+    // A transient runtime failure should not poison a later retry in this
+    // create; preserve the existing rejection behavior while dropping it.
+    void pending.catch(() => {
+      if (remoteTrackingBaseProbes.get(baseBranch) === pending) {
+        remoteTrackingBaseProbes.delete(baseBranch)
+      }
+    })
+    return pending
+  }
+
   const requestedName = args.name
   const sanitizedName = sanitizeWorktreeName(args.name)
   const requestedDisplayName = args.displayName
@@ -2037,11 +2067,7 @@ export async function createLocalWorktree(
     resolveDefaultBaseRef: () => resolveDefaultBaseRefWithLocalGit(localGitExecOptions),
     isBaseUsable: async (baseBranchCandidate) => {
       if (runtime) {
-        const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
-          repo.path,
-          baseBranchCandidate,
-          ...localWorktreeGitOptionArgs
-        )
+        const remoteTrackingBase = await resolveRemoteTrackingBaseForCreate(baseBranchCandidate)
         if (remoteTrackingBase) {
           if (
             await runtime.hasRemoteTrackingRef(
@@ -2081,11 +2107,7 @@ export async function createLocalWorktree(
   let legacyFetchPromise: Promise<void> | null = null
 
   if (runtime) {
-    remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
-      repo.path,
-      baseBranch,
-      ...localWorktreeGitOptionArgs
-    )
+    remoteTrackingBase = await resolveRemoteTrackingBaseForCreate(baseBranch)
     if (remoteTrackingBase) {
       const [hasRemoteTrackingBaseRef, hasNamedLocalBaseRef] = await Promise.all([
         runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase, ...localWorktreeGitOptionArgs),

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -80,9 +80,9 @@ import {
   sanitizeWorktreeName,
   sanitizeWorktreeDisplayName,
   computeValidatedBranchName,
-  computeWorktreePath,
+  computeWorktreePathFromWorkspaceRoot,
   computeRemoteWorktreePath,
-  computeWorkspaceRoot,
+  computeWorkspaceRootAsync,
   ensurePathWithinWorkspace,
   getWorktreeCreationLayout,
   getWorktreePathSettings,
@@ -710,7 +710,12 @@ async function canCheckoutExistingLocalBranch(
       return false
     }
   }
-  const worktrees = await listWorktrees(repoPath, gitOptions)
+  // Branch ownership only needs Git's registration rows; sparse-checkout probes
+  // for every worktree can dominate this hot path on Windows/WSL repos.
+  const worktrees = await listWorktrees(repoPath, {
+    ...gitOptions,
+    annotateSparseCheckout: false
+  })
   return !worktrees.some((worktree) => normalizeLocalBranchName(worktree.branch) === branchName)
 }
 
@@ -2006,6 +2011,11 @@ export async function createLocalWorktree(
     settings,
     getWorktreeMirrorDistro(store, repo)
   )
+  // WSL mirror roots require a `wsl.exe` home probe. Start it before the Git
+  // preflight so that probe overlaps branch/base validation and never blocks
+  // the Electron main thread on the submit path.
+  const workspaceRootPromise = computeWorkspaceRootAsync(repo.path, worktreePathSettings)
+  void workspaceRootPromise.catch(() => {})
   const localGitExecOptions = getLocalProjectGitExecOptions(store, repo)
   const localWorktreeGitOptions = getLocalProjectWorktreeGitOptions(store, repo)
   const hasLocalWorktreeGitOptions = Object.keys(localWorktreeGitOptions).length > 0
@@ -2167,7 +2177,7 @@ export async function createLocalWorktree(
       emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
     }
   }
-  const workspaceRoot = computeWorkspaceRoot(repo.path, worktreePathSettings)
+  const workspaceRoot = await workspaceRootPromise
 
   // Why: this validation doesn't depend on remote refs, so it can overlap a required remote-tracking base refresh.
   const primarySetupScript = getEffectiveHooks(repo)?.scripts.setup
@@ -2322,7 +2332,12 @@ export async function createLocalWorktree(
     }
 
     worktreePath = ensurePathWithinWorkspace(
-      computeWorktreePath(effectiveSanitizedName, repo.path, worktreePathSettings),
+      computeWorktreePathFromWorkspaceRoot(
+        effectiveSanitizedName,
+        repo.path,
+        workspaceRoot,
+        worktreePathSettings.nestWorkspaces
+      ),
       workspaceRoot
     )
     if (existsSync(worktreePath)) {

--- a/src/main/ipc/worktrees-local-create-flow.test.ts
+++ b/src/main/ipc/worktrees-local-create-flow.test.ts
@@ -15,7 +15,7 @@ import {
   getEffectiveHooksFromConfigMock,
   shouldRunSetupForCreateMock,
   loadHooksMock,
-  computeWorktreePathMock,
+  computeWorktreePathFromWorkspaceRootMock,
   gitExecFileAsyncMock
 } from './worktrees-test-module-mocks'
 import { handlers, mainWindow, setupWorktreeHandlers, store } from './worktrees-test-harness'
@@ -442,7 +442,7 @@ describe('registerWorktreeHandlers', () => {
     })
     listWorktreesMock.mockResolvedValue([
       {
-        path: '../worktrees/feature',
+        path: '/workspace/worktrees/feature',
         head: 'abc123',
         branch: 'feature',
         isBare: false,
@@ -455,19 +455,21 @@ describe('registerWorktreeHandlers', () => {
       name: 'feature'
     })
 
-    expect(computeWorktreePathMock).toHaveBeenCalledWith('feature', '/workspace/repo', {
-      nestWorkspaces: false,
-      workspaceDir: '../worktrees'
-    })
+    expect(computeWorktreePathFromWorkspaceRootMock).toHaveBeenCalledWith(
+      'feature',
+      '/workspace/repo',
+      '/workspace/worktrees',
+      false
+    )
     expect(addWorktreeMock).toHaveBeenCalledWith(
       '/workspace/repo',
-      '../worktrees/feature',
+      '/workspace/worktrees/feature',
       'feature',
       'origin/main',
       false
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::../worktrees/feature',
+      'repo-1::/workspace/worktrees/feature',
       expect.objectContaining({
         orcaCreationWorkspaceLayout: { path: '../worktrees', nestWorkspaces: false }
       })

--- a/src/main/ipc/worktrees-local-create-flow.test.ts
+++ b/src/main/ipc/worktrees-local-create-flow.test.ts
@@ -158,7 +158,7 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
-  it('reuses the remote-tracking base probe used to validate a persisted base', async () => {
+  it('retries an unresolved remote-tracking base probe before final create', async () => {
     const remoteBase = {
       remote: 'origin',
       branch: 'master',
@@ -173,8 +173,11 @@ describe('registerWorktreeHandlers', () => {
       addedAt: 0,
       worktreeBaseRef: 'origin/master'
     })
-    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
+    runtimeStub.resolveRemoteTrackingBase
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(remoteBase)
     runtimeStub.hasRemoteTrackingRef.mockResolvedValue(true)
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'base-sha\n', stderr: '' })
     listWorktreesMock.mockResolvedValue([
       {
         path: '/workspace/reused-base-probe',
@@ -192,7 +195,7 @@ describe('registerWorktreeHandlers', () => {
       })
     ).resolves.toMatchObject({ worktree: { path: '/workspace/reused-base-probe' } })
 
-    expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalledTimes(1)
+    expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalledTimes(2)
     expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalledWith(
       '/workspace/repo',
       'origin/master'

--- a/src/main/ipc/worktrees-local-create-flow.test.ts
+++ b/src/main/ipc/worktrees-local-create-flow.test.ts
@@ -158,6 +158,47 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('reuses the remote-tracking base probe used to validate a persisted base', async () => {
+    const remoteBase = {
+      remote: 'origin',
+      branch: 'master',
+      ref: 'refs/remotes/origin/master',
+      base: 'origin/master'
+    }
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      worktreeBaseRef: 'origin/master'
+    })
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
+    runtimeStub.hasRemoteTrackingRef.mockResolvedValue(true)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/reused-base-probe',
+        head: 'abc123',
+        branch: 'refs/heads/reused-base-probe',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-1',
+        name: 'reused-base-probe'
+      })
+    ).resolves.toMatchObject({ worktree: { path: '/workspace/reused-base-probe' } })
+
+    expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalledTimes(1)
+    expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'origin/master'
+    )
+  })
+
   it('prefetches the local default create base through the runtime refresh cache', async () => {
     const repo = {
       id: 'repo-1',

--- a/src/main/ipc/worktrees-test-module-mocks.ts
+++ b/src/main/ipc/worktrees-test-module-mocks.ts
@@ -85,6 +85,16 @@ export const computeWorktreePathMock: Mock<
     settings: { nestWorkspaces: boolean; workspaceDir: string }
   ) => string
 > = vi.fn()
+export const computeWorktreePathFromWorkspaceRootMock: Mock<
+  (
+    sanitizedName: string,
+    repoPath: string,
+    workspaceRoot: string,
+    nestWorkspaces: boolean
+  ) => string
+> = vi.fn((sanitizedName, repoPath, workspaceRoot, nestWorkspaces) =>
+  computeWorktreePathMock(sanitizedName, repoPath, { workspaceDir: workspaceRoot, nestWorkspaces })
+)
 export const ensurePathWithinWorkspaceMock: StringArgMock = vi.fn()
 export const gitExecFileAsyncMock: GitArgvMock = vi.fn()
 export const getSshGitProviderMock: StringArgMock = vi.fn()
@@ -231,6 +241,7 @@ export const setupHookEnvVarsModuleMock = (actual: Record<string, unknown>) => (
 export const worktreeLogicModuleMock = (actual: Record<string, unknown>) => ({
   ...actual,
   computeWorktreePath: computeWorktreePathMock,
+  computeWorktreePathFromWorkspaceRoot: computeWorktreePathFromWorkspaceRootMock,
   ensurePathWithinWorkspace: ensurePathWithinWorkspaceMock
 })
 

--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -26,6 +26,7 @@ const {
   hasHooksFileMock,
   loadHooksMock,
   computeWorktreePathMock,
+  computeWorktreePathFromWorkspaceRootMock,
   ensurePathWithinWorkspaceMock,
   killAllProcessesForWorktreeMock,
   clearProviderPtyStateMock,
@@ -56,6 +57,7 @@ const {
   hasHooksFileMock: vi.fn(),
   loadHooksMock: vi.fn(),
   computeWorktreePathMock: vi.fn(),
+  computeWorktreePathFromWorkspaceRootMock: vi.fn(),
   ensurePathWithinWorkspaceMock: vi.fn(),
   killAllProcessesForWorktreeMock: vi.fn(),
   clearProviderPtyStateMock: vi.fn(),
@@ -142,6 +144,7 @@ vi.mock('./worktree-logic', async (importOriginal) => {
   return {
     ...actual,
     computeWorktreePath: computeWorktreePathMock,
+    computeWorktreePathFromWorkspaceRoot: computeWorktreePathFromWorkspaceRootMock,
     ensurePathWithinWorkspace: ensurePathWithinWorkspaceMock
   }
 })
@@ -201,6 +204,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     hasHooksFileMock.mockReset()
     loadHooksMock.mockReset()
     computeWorktreePathMock.mockReset()
+    computeWorktreePathFromWorkspaceRootMock.mockReset()
     ensurePathWithinWorkspaceMock.mockReset()
     killAllProcessesForWorktreeMock.mockReset()
     clearProviderPtyStateMock.mockReset()
@@ -285,6 +289,13 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     getDefaultTabsLaunchMock.mockReturnValue(undefined)
     shouldRunSetupForCreateMock.mockReturnValue(false)
     computeWorktreePathMock.mockReturnValue('C:\\workspaces\\improve-dashboard')
+    computeWorktreePathFromWorkspaceRootMock.mockImplementation(
+      (sanitizedName: string, repoPath: string, workspaceRoot: string, nestWorkspaces: boolean) =>
+        computeWorktreePathMock(sanitizedName, repoPath, {
+          workspaceDir: workspaceRoot,
+          nestWorkspaces
+        })
+    )
     ensurePathWithinWorkspaceMock.mockReturnValue('C:\\workspaces\\improve-dashboard')
     listWorktreesMock.mockResolvedValue([])
     assertWorktreeCleanForRemovalMock.mockResolvedValue(undefined)

--- a/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.test.ts
+++ b/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.test.ts
@@ -59,4 +59,26 @@ describe('registerWorktreePrefetchHandler', () => {
     })
     expect(mocks.prepareWorktreeCreateForRepo).toHaveBeenCalledWith(store, repo, 'origin/main')
   })
+
+  it('does not resolve Git runtime options for folder repos', async () => {
+    let handler: PrefetchHandler | undefined
+    mocks.handle.mockImplementation((_channel: unknown, callback: unknown) => {
+      handler = callback as PrefetchHandler
+    })
+    const repo = { id: 'folder-1', path: String.raw`C:\folder`, kind: 'folder' }
+    const store = { getRepo: vi.fn().mockReturnValue(repo) }
+    const runtime = {}
+
+    registerWorktreePrefetchHandler({ store, runtime } as never)
+    await handler?.(null, { repoId: 'folder-1' })
+
+    expect(mocks.getLocalProjectWorktreeGitOptions).not.toHaveBeenCalled()
+    expect(mocks.prefetchWorktreeCreateBase).toHaveBeenCalledWith({
+      repo,
+      baseBranch: undefined,
+      runtime,
+      gitOptions: undefined
+    })
+    expect(mocks.prepareWorktreeCreateForRepo).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.test.ts
+++ b/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(),
+  prefetchWorktreeCreateBase: vi.fn(),
+  prepareWorktreeCreateForRepo: vi.fn(),
+  getLocalProjectWorktreeGitOptions: vi.fn()
+}))
+
+vi.mock('electron', () => ({ ipcMain: { handle: mocks.handle } }))
+vi.mock('../../../worktree-create-base-prefetch', () => ({
+  prefetchWorktreeCreateBase: mocks.prefetchWorktreeCreateBase
+}))
+vi.mock('../../../worktree-create-preparation', () => ({
+  prepareWorktreeCreateForRepo: mocks.prepareWorktreeCreateForRepo
+}))
+vi.mock('../../../project-runtime-git-options', () => ({
+  getLocalProjectWorktreeGitOptions: mocks.getLocalProjectWorktreeGitOptions
+}))
+
+import { registerWorktreePrefetchHandler } from './register-worktree-prefetch-handler'
+
+type PrefetchHandler = (
+  event: unknown,
+  args: { repoId: string; baseBranch?: string }
+) => Promise<void>
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) {
+    mock.mockReset()
+  }
+  mocks.getLocalProjectWorktreeGitOptions.mockReturnValue({})
+  mocks.prefetchWorktreeCreateBase.mockResolvedValue(undefined)
+  mocks.prepareWorktreeCreateForRepo.mockResolvedValue(undefined)
+})
+
+describe('registerWorktreePrefetchHandler', () => {
+  it('passes the project WSL runtime to speculative prefetch and preparation', async () => {
+    let handler: PrefetchHandler | undefined
+    mocks.handle.mockImplementation((_channel: unknown, callback: unknown) => {
+      handler = callback as PrefetchHandler
+    })
+    const repo = { id: 'repo-1', path: String.raw`C:\repo` }
+    const store = { getRepo: vi.fn().mockReturnValue(repo) }
+    const runtime = {}
+    const gitOptions = { wslDistro: 'Ubuntu' }
+    mocks.getLocalProjectWorktreeGitOptions.mockReturnValue(gitOptions)
+    mocks.prefetchWorktreeCreateBase.mockResolvedValue('origin/main')
+
+    registerWorktreePrefetchHandler({ store, runtime } as never)
+    await handler?.(null, { repoId: 'repo-1', baseBranch: 'origin/main' })
+
+    expect(mocks.getLocalProjectWorktreeGitOptions).toHaveBeenCalledWith(store, repo)
+    expect(mocks.prefetchWorktreeCreateBase).toHaveBeenCalledWith({
+      repo,
+      baseBranch: 'origin/main',
+      runtime,
+      gitOptions
+    })
+    expect(mocks.prepareWorktreeCreateForRepo).toHaveBeenCalledWith(store, repo, 'origin/main')
+  })
+})

--- a/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.ts
+++ b/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron'
 import { prefetchWorktreeCreateBase } from '../../../worktree-create-base-prefetch'
 import { prepareWorktreeCreateForRepo } from '../../../worktree-create-preparation'
+import { getLocalProjectWorktreeGitOptions } from '../../../project-runtime-git-options'
 import type { WorktreeIpcContext } from '../worktree-ipc-context'
 
 export function registerWorktreePrefetchHandler(context: WorktreeIpcContext): void {
@@ -14,10 +15,12 @@ export function registerWorktreePrefetchHandler(context: WorktreeIpcContext): vo
         return
       }
       try {
+        const gitOptions = getLocalProjectWorktreeGitOptions(store, repo)
         const baseBranch = await prefetchWorktreeCreateBase({
           repo,
           baseBranch: args.baseBranch,
-          runtime
+          runtime,
+          gitOptions
         })
         if (baseBranch) {
           await prepareWorktreeCreateForRepo(store, repo, baseBranch)

--- a/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.ts
+++ b/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron'
+import { isFolderRepo } from '../../../../shared/repo-kind'
 import { prefetchWorktreeCreateBase } from '../../../worktree-create-base-prefetch'
 import { prepareWorktreeCreateForRepo } from '../../../worktree-create-preparation'
 import { getLocalProjectWorktreeGitOptions } from '../../../project-runtime-git-options'
@@ -15,12 +16,13 @@ export function registerWorktreePrefetchHandler(context: WorktreeIpcContext): vo
         return
       }
       try {
-        const gitOptions = getLocalProjectWorktreeGitOptions(store, repo)
         const baseBranch = await prefetchWorktreeCreateBase({
           repo,
           baseBranch: args.baseBranch,
           runtime,
-          gitOptions
+          gitOptions: isFolderRepo(repo)
+            ? undefined
+            : getLocalProjectWorktreeGitOptions(store, repo)
         })
         if (baseBranch) {
           await prepareWorktreeCreateForRepo(store, repo, baseBranch)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -5604,6 +5604,69 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('retries a remote-tracking base lookup after an unresolved probe', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const createdWorktree = {
+      path: '/tmp/workspaces/retry-null-base',
+      head: 'base-sha',
+      branch: 'retry-null-base',
+      isBare: false,
+      isMainWorktree: false
+    }
+    const repo = { ...store.getRepos()[0], worktreeBaseRef: 'origin/master' }
+    const getReposSpy = vi.spyOn(store, 'getRepos').mockReturnValue([repo] as never)
+    const remoteBase = {
+      remote: 'origin',
+      branch: 'master',
+      ref: 'refs/remotes/origin/master',
+      base: 'origin/master'
+    }
+    const resolveRemoteTrackingBaseSpy = vi
+      .spyOn(runtime, 'resolveRemoteTrackingBase')
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(remoteBase)
+    computeWorktreePathMock.mockReturnValue(createdWorktree.path)
+    ensurePathWithinWorkspaceMock.mockReturnValue(createdWorktree.path)
+    vi.mocked(addWorktree).mockResolvedValueOnce({})
+    vi.mocked(listWorktrees).mockResolvedValue([createdWorktree])
+    const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/master^{commit}')) {
+        return { stdout: 'base-sha\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) {
+        return { stdout: '/tmp/repo/.git\n', stderr: '' }
+      }
+      if (args.includes('fetch')) {
+        return { stdout: '', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+    try {
+      await expect(
+        runtime.createManagedWorktree({
+          repoSelector: 'id:repo-1',
+          name: 'retry-null-base'
+        })
+      ).resolves.toMatchObject({ worktree: { path: createdWorktree.path } })
+
+      expect(resolveRemoteTrackingBaseSpy).toHaveBeenCalledTimes(2)
+      expect(resolveRemoteTrackingBaseSpy).toHaveBeenNthCalledWith(
+        1,
+        TEST_REPO_PATH,
+        'origin/master'
+      )
+      expect(resolveRemoteTrackingBaseSpy).toHaveBeenNthCalledWith(
+        2,
+        TEST_REPO_PATH,
+        'origin/master'
+      )
+    } finally {
+      getReposSpy.mockRestore()
+      resolveRemoteTrackingBaseSpy.mockRestore()
+      gitSpy.mockRestore()
+    }
+  })
+
   it('creates a runtime local worktree from a slash-named local branch matching a remote prefix', async () => {
     const runtime = new OrcaRuntimeService(store)
     const createdWorktree = {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -250,6 +250,7 @@ const {
   removeWorktreeMock,
   forceDeleteLocalBranchMock,
   computeWorktreePathMock,
+  computeWorktreePathFromWorkspaceRootMock,
   ensurePathWithinWorkspaceMock,
   sshGitProviders,
   sshProviderGenerations,
@@ -347,6 +348,7 @@ const {
     removeWorktreeMock: vi.fn(),
     forceDeleteLocalBranchMock: vi.fn(),
     computeWorktreePathMock: vi.fn(),
+    computeWorktreePathFromWorkspaceRootMock: vi.fn(),
     ensurePathWithinWorkspaceMock: vi.fn(),
     sshGitProviders,
     sshProviderGenerations,
@@ -539,6 +541,7 @@ vi.mock('../ipc/worktree-logic', async (importOriginal) => {
   return {
     ...actual,
     computeWorktreePath: computeWorktreePathMock,
+    computeWorktreePathFromWorkspaceRoot: computeWorktreePathFromWorkspaceRootMock,
     ensurePathWithinWorkspace: ensurePathWithinWorkspaceMock
   }
 })
@@ -807,7 +810,33 @@ function resetRuntimeTestMocks(): void {
   vi.mocked(hasHooksFile).mockReturnValue(false)
   vi.mocked(parseOrcaYaml).mockReturnValue(null)
   computeWorktreePathMock.mockReset()
+  computeWorktreePathFromWorkspaceRootMock.mockReset()
   ensurePathWithinWorkspaceMock.mockReset()
+  computeWorktreePathMock.mockImplementation(
+    (
+      sanitizedName: string,
+      repoPath: string,
+      settings: { nestWorkspaces: boolean; workspaceDir: string }
+    ) => {
+      if (settings.nestWorkspaces) {
+        const repoName =
+          repoPath
+            .split(/[\\/]/)
+            .at(-1)
+            ?.replace(/\.git$/, '') ?? 'repo'
+        return `${settings.workspaceDir}/${repoName}/${sanitizedName}`
+      }
+      return `${settings.workspaceDir}/${sanitizedName}`
+    }
+  )
+  computeWorktreePathFromWorkspaceRootMock.mockImplementation(
+    (sanitizedName: string, repoPath: string, workspaceRoot: string, nestWorkspaces: boolean) =>
+      computeWorktreePathMock(sanitizedName, repoPath, {
+        workspaceDir: workspaceRoot,
+        nestWorkspaces
+      })
+  )
+  ensurePathWithinWorkspaceMock.mockImplementation((targetPath: string) => targetPath)
   invalidateAuthorizedRootsCacheMock.mockReset()
   prepareLocalWorktreeRootForRepoMock.mockReset().mockResolvedValue(undefined)
   createHostedReviewMock.mockReset()
@@ -1093,6 +1122,23 @@ function isOriginMainBaseRefProbe(args: string[]): boolean {
       args.includes('refs/remotes/origin/main^{commit}'))
   )
 }
+
+function isBatchedDefaultBaseRefProbe(args: string[]): boolean {
+  return (
+    args[0] === 'for-each-ref' &&
+    args[1] === '--format=%(refname)%00%(symref)%00%(objecttype)%00%(*objecttype)'
+  )
+}
+
+const BATCHED_DEFAULT_BASE_REF_ARGS = [
+  'for-each-ref',
+  '--format=%(refname)%00%(symref)%00%(objecttype)%00%(*objecttype)',
+  'refs/remotes/origin/HEAD',
+  'refs/remotes/origin/main',
+  'refs/remotes/origin/master',
+  'refs/heads/main',
+  'refs/heads/master'
+]
 
 function antigravityReadyScreen(model = 'Gemini 3.5 Flash (High)'): string {
   return [
@@ -1750,6 +1796,13 @@ computeWorktreePathMock.mockImplementation(
   }
 )
 ensurePathWithinWorkspaceMock.mockImplementation((targetPath: string) => targetPath)
+computeWorktreePathFromWorkspaceRootMock.mockImplementation(
+  (sanitizedName: string, repoPath: string, workspaceRoot: string, nestWorkspaces: boolean) =>
+    computeWorktreePathMock(sanitizedName, repoPath, {
+      workspaceDir: workspaceRoot,
+      nestWorkspaces
+    })
+)
 
 describe('OrcaRuntimeService.dedupeWorktreeCreate', () => {
   it('coalesces concurrent creates that share a clientMutationId', async () => {
@@ -8435,6 +8488,12 @@ describe('OrcaRuntimeService', () => {
     const wslGitOptions = { cwd: TEST_REPO_PATH, wslDistro: 'Ubuntu' }
     let driftCounts = '1\t2\n'
     const asyncGitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
+      if (isBatchedDefaultBaseRefProbe(args)) {
+        return {
+          stdout: 'refs/remotes/origin/HEAD\0refs/remotes/origin/main\0commit\0\n',
+          stderr: ''
+        }
+      }
       if (args[0] === 'symbolic-ref') {
         return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
       }
@@ -8467,10 +8526,10 @@ describe('OrcaRuntimeService', () => {
         behind: 2,
         recentSubjects: ['base commit 2', 'base commit 1']
       })
-      expect(asyncGitSpy).toHaveBeenCalledWith(
-        ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
-        { ...wslGitOptions, timeout: 15_000 }
-      )
+      expect(asyncGitSpy).toHaveBeenCalledWith(BATCHED_DEFAULT_BASE_REF_ARGS, {
+        ...wslGitOptions,
+        timeout: 15_000
+      })
       expect(asyncGitSpy).toHaveBeenCalledWith(['remote'], wslGitOptions)
       expect(asyncGitSpy).toHaveBeenCalledWith(
         ['rev-parse', '--path-format=absolute', '--git-common-dir'],
@@ -48428,6 +48487,12 @@ describe('OrcaRuntimeService', () => {
     }
     const runtime = new OrcaRuntimeService(runtimeStore as never)
     const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
+      if (isBatchedDefaultBaseRefProbe(args)) {
+        return {
+          stdout: 'refs/remotes/origin/HEAD\0refs/remotes/origin/main\0commit\0\n',
+          stderr: ''
+        }
+      }
       if (args[0] === 'symbolic-ref') {
         return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
       }
@@ -49522,6 +49587,12 @@ describe('OrcaRuntimeService', () => {
     ensurePathWithinWorkspaceMock.mockReturnValue(createdWorktree.path)
     vi.mocked(listWorktrees).mockResolvedValue([createdWorktree])
     const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
+      if (isBatchedDefaultBaseRefProbe(args)) {
+        return {
+          stdout: 'refs/remotes/origin/HEAD\0refs/remotes/origin/main\0commit\0\n',
+          stderr: ''
+        }
+      }
       if (args[0] === 'symbolic-ref') {
         return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
       }
@@ -49558,7 +49629,7 @@ describe('OrcaRuntimeService', () => {
         path: createdWorktree.path,
         branch: 'refs/heads/runtime-wsl'
       })
-      expect(gitSpy).toHaveBeenCalledWith(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'], {
+      expect(gitSpy).toHaveBeenCalledWith(BATCHED_DEFAULT_BASE_REF_ARGS, {
         cwd: TEST_REPO_PATH,
         timeout: 15_000,
         wslDistro: 'Ubuntu'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -26542,14 +26542,17 @@ export class OrcaRuntimeService {
     }
 
     const repo = await this.resolveRepoSelector(args.repoSelector)
+    const store = this.requireStore()
+    const gitOptions = getLocalProjectWorktreeGitOptions(store, repo)
     const baseBranch = await prefetchWorktreeCreateBase({
       repo,
       baseBranch: args.baseBranch,
-      runtime: this
+      runtime: this,
+      gitOptions
     })
     if (baseBranch) {
       try {
-        await prepareWorktreeCreateForRepo(this.requireStore(), repo, baseBranch)
+        await prepareWorktreeCreateForRepo(store, repo, baseBranch)
       } catch {
         // Why: speculative preparation is an optimistic warm-up; the real create path reports failures.
       }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -26840,7 +26840,7 @@ export class OrcaRuntimeService {
       settings,
       getWorktreeMirrorDistro(this.requireStore(), repo)
     )
-    // WSL mirror roots require a `wsl.exe` home probe. Start it before the Git
+    // WSL mirror roots require a host-home probe. Start it before the Git
     // preflight so root discovery overlaps branch/base validation and does not
     // block the runtime event loop on the submit path.
     const workspaceRootPromise = computeWorkspaceRootAsync(repo.path, worktreePathSettings)
@@ -26870,11 +26870,18 @@ export class OrcaRuntimeService {
         ...localWorktreeGitOptionArgs
       )
       remoteTrackingBaseByBranch.set(candidate, pending)
-      void pending.catch(() => {
-        if (remoteTrackingBaseByBranch.get(candidate) === pending) {
-          remoteTrackingBaseByBranch.delete(candidate)
+      void pending.then(
+        (result) => {
+          if (result === null && remoteTrackingBaseByBranch.get(candidate) === pending) {
+            remoteTrackingBaseByBranch.delete(candidate)
+          }
+        },
+        () => {
+          if (remoteTrackingBaseByBranch.get(candidate) === pending) {
+            remoteTrackingBaseByBranch.delete(candidate)
+          }
         }
-      })
+      )
       return pending
     }
     const addProjectGitOptions = (options?: AddWorktreeOptions): AddWorktreeOptions | undefined => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -26543,12 +26543,11 @@ export class OrcaRuntimeService {
 
     const repo = await this.resolveRepoSelector(args.repoSelector)
     const store = this.requireStore()
-    const gitOptions = getLocalProjectWorktreeGitOptions(store, repo)
     const baseBranch = await prefetchWorktreeCreateBase({
       repo,
       baseBranch: args.baseBranch,
       runtime: this,
-      gitOptions
+      gitOptions: isFolderRepo(repo) ? undefined : getLocalProjectWorktreeGitOptions(store, repo)
     })
     if (baseBranch) {
       try {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1232,8 +1232,8 @@ import { collectLayoutLeafIdsInOrder } from '../persistence/restoring-sessions/t
 import type { StatsCollector } from '../stats/collector'
 import {
   computeValidatedBranchName,
-  computeWorktreePath,
-  computeWorkspaceRoot,
+  computeWorktreePathFromWorkspaceRoot,
+  computeWorkspaceRootAsync,
   ensurePathWithinWorkspace,
   formatWorktreeRemovalError,
   getWorktreeCreationLayout,
@@ -2839,7 +2839,12 @@ async function canCheckoutExistingLocalBranch(
       return false
     }
   }
-  const worktrees = await listWorktrees(repoPath, gitOptions)
+  // Branch ownership only needs Git's registration rows; sparse-checkout probes
+  // for every worktree can dominate this hot path on Windows/WSL repos.
+  const worktrees = await listWorktrees(repoPath, {
+    ...gitOptions,
+    annotateSparseCheckout: false
+  })
   return !worktrees.some((worktree) => normalizeLocalBranchName(worktree.branch) === branchName)
 }
 
@@ -26835,12 +26840,43 @@ export class OrcaRuntimeService {
       settings,
       getWorktreeMirrorDistro(this.requireStore(), repo)
     )
+    // WSL mirror roots require a `wsl.exe` home probe. Start it before the Git
+    // preflight so root discovery overlaps branch/base validation and does not
+    // block the runtime event loop on the submit path.
+    const workspaceRootPromise = computeWorkspaceRootAsync(repo.path, worktreePathSettings)
+    // The base/branch path can fail before the root is awaited; observe a
+    // rejected probe so that early validation failures never create an
+    // unhandled-rejection warning.
+    void workspaceRootPromise.catch(() => {})
     const localGitExecOptions = getLocalProjectGitExecOptions(this.requireStore(), repo)
     const localWorktreeGitOptions = getLocalProjectWorktreeGitOptions(this.requireStore(), repo)
     const hasLocalWorktreeGitOptions = hasLocalGitOptions(localWorktreeGitOptions)
     const localWorktreeGitOptionArgs: [] | [{ wslDistro?: string }] = hasLocalWorktreeGitOptions
       ? [localWorktreeGitOptions]
       : []
+    // Base validation and the final create decision ask the same remote lookup.
+    // Share it so WSL/native Windows pay for one `git remote` process.
+    const remoteTrackingBaseByBranch = new Map<string, Promise<RemoteTrackingBase | null>>()
+    const resolveRemoteTrackingBaseForCreate = (
+      candidate: string
+    ): Promise<RemoteTrackingBase | null> => {
+      const existing = remoteTrackingBaseByBranch.get(candidate)
+      if (existing) {
+        return existing
+      }
+      const pending = this.resolveRemoteTrackingBase(
+        repo.path,
+        candidate,
+        ...localWorktreeGitOptionArgs
+      )
+      remoteTrackingBaseByBranch.set(candidate, pending)
+      void pending.catch(() => {
+        if (remoteTrackingBaseByBranch.get(candidate) === pending) {
+          remoteTrackingBaseByBranch.delete(candidate)
+        }
+      })
+      return pending
+    }
     const addProjectGitOptions = (options?: AddWorktreeOptions): AddWorktreeOptions | undefined => {
       if (!hasLocalWorktreeGitOptions) {
         return options
@@ -26866,11 +26902,7 @@ export class OrcaRuntimeService {
           ? resolveDefaultBaseRefWithLocalGit(localGitExecOptions)
           : getBaseRefDefault(repo.path),
       isBaseUsable: async (baseBranchCandidate) => {
-        const remoteTrackingBase = await this.resolveRemoteTrackingBase(
-          repo.path,
-          baseBranchCandidate,
-          ...localWorktreeGitOptionArgs
-        )
+        const remoteTrackingBase = await resolveRemoteTrackingBaseForCreate(baseBranchCandidate)
         if (remoteTrackingBase) {
           if (
             await this.hasRemoteTrackingRef(
@@ -26903,7 +26935,7 @@ export class OrcaRuntimeService {
       )
     }
 
-    const workspaceRoot = computeWorkspaceRoot(repo.path, worktreePathSettings)
+    const workspaceRoot = await workspaceRootPromise
     // Why: CLI-managed WSL worktrees live under ~/orca/workspaces inside the
     // distro filesystem through computeWorkspaceRoot. If home lookup fails,
     // still validate against the effective workspace dir.
@@ -27010,6 +27042,8 @@ export class OrcaRuntimeService {
         }
       }
 
+      // Keep the PR lookup on the first candidate: local remote-tracking refs
+      // can be stale, so GitHub remains the authority for an un-fetched branch.
       if (!checkoutExistingBranch && !selectedReviewConflictMatched) {
         let existingPR: Awaited<ReturnType<typeof getPRForBranch>> | null = null
         try {
@@ -27027,7 +27061,12 @@ export class OrcaRuntimeService {
         }
       }
       worktreePath = ensurePathWithinWorkspace(
-        computeWorktreePath(effectiveSanitizedName, repo.path, worktreePathSettings),
+        computeWorktreePathFromWorkspaceRoot(
+          effectiveSanitizedName,
+          repo.path,
+          workspaceRoot,
+          worktreePathSettings.nestWorkspaces
+        ),
         workspaceRoot
       )
       if (!(await pathExists(worktreePath))) {
@@ -27045,11 +27084,7 @@ export class OrcaRuntimeService {
         `Could not find an available worktree path for "${sanitizedName}". Pick a different worktree name.`
       )
     }
-    let remoteTrackingBase = await this.resolveRemoteTrackingBase(
-      repo.path,
-      baseBranch,
-      ...localWorktreeGitOptionArgs
-    )
+    let remoteTrackingBase = await resolveRemoteTrackingBaseForCreate(baseBranch)
     if (remoteTrackingBase) {
       const [hadRemoteTrackingBaseRef, hasNamedLocalBaseRef] = await Promise.all([
         this.hasRemoteTrackingRef(repo.path, remoteTrackingBase, ...localWorktreeGitOptionArgs),

--- a/src/main/worktree-create-base-prefetch.test.ts
+++ b/src/main/worktree-create-base-prefetch.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getBaseRefDefault: vi.fn(),
+  hasWorktreeBaseCommitRef: vi.fn(),
+  gitExecFileAsync: vi.fn(),
+  getSshGitProvider: vi.fn(),
+  prefetchRemoteWorktreeCreateBase: vi.fn(),
+  resolveRemoteTrackingBase: vi.fn(),
+  hasRemoteTrackingRef: vi.fn(),
+  getOrStartRemoteTrackingBaseRefresh: vi.fn(),
+  fetchRemoteWithCache: vi.fn()
+}))
+
+vi.mock('./git/repo', () => ({ getBaseRefDefault: mocks.getBaseRefDefault }))
+vi.mock('./git/worktree-base-ref-probe', () => ({
+  hasWorktreeBaseCommitRef: mocks.hasWorktreeBaseCommitRef
+}))
+vi.mock('./git/runner', () => ({ gitExecFileAsync: mocks.gitExecFileAsync }))
+vi.mock('./providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: mocks.getSshGitProvider
+}))
+vi.mock('./ipc/worktree-remote', () => ({
+  prefetchRemoteWorktreeCreateBase: mocks.prefetchRemoteWorktreeCreateBase
+}))
+
+import { prefetchWorktreeCreateBase } from './worktree-create-base-prefetch'
+
+const repo = {
+  id: 'repo-1',
+  path: String.raw`C:\workspace\repo`,
+  displayName: 'repo',
+  badgeColor: '#000000',
+  addedAt: 0,
+  kind: 'git' as const,
+  worktreeBaseRef: undefined
+}
+
+function runtime() {
+  return {
+    resolveRemoteTrackingBase: mocks.resolveRemoteTrackingBase,
+    hasRemoteTrackingRef: mocks.hasRemoteTrackingRef,
+    getOrStartRemoteTrackingBaseRefresh: mocks.getOrStartRemoteTrackingBaseRefresh,
+    fetchRemoteWithCache: mocks.fetchRemoteWithCache
+  }
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) {
+    mock.mockReset()
+  }
+  mocks.getBaseRefDefault.mockResolvedValue('origin/main')
+  mocks.hasWorktreeBaseCommitRef.mockResolvedValue(false)
+  mocks.gitExecFileAsync.mockResolvedValue({ stdout: '', stderr: '' })
+  mocks.resolveRemoteTrackingBase.mockResolvedValue(null)
+  mocks.hasRemoteTrackingRef.mockResolvedValue(false)
+  mocks.getOrStartRemoteTrackingBaseRefresh.mockResolvedValue({ ok: true })
+  mocks.fetchRemoteWithCache.mockResolvedValue(undefined)
+})
+
+describe('prefetchWorktreeCreateBase local Git routing', () => {
+  it('routes default and named-ref probes through the selected WSL distro', async () => {
+    mocks.hasWorktreeBaseCommitRef.mockImplementation(
+      async (_repoPath: string, ref: string) => ref === 'refs/remotes/origin/main'
+    )
+
+    await expect(
+      prefetchWorktreeCreateBase({
+        repo,
+        runtime: runtime(),
+        gitOptions: { wslDistro: 'Ubuntu' }
+      })
+    ).resolves.toBe('origin/main')
+
+    expect(mocks.getBaseRefDefault).toHaveBeenCalledWith(repo.path, { wslDistro: 'Ubuntu' })
+    expect(mocks.resolveRemoteTrackingBase).toHaveBeenCalledWith(repo.path, 'origin/main', {
+      wslDistro: 'Ubuntu'
+    })
+    expect(mocks.hasWorktreeBaseCommitRef).toHaveBeenCalledWith(
+      repo.path,
+      'refs/remotes/origin/main',
+      { wslDistro: 'Ubuntu' }
+    )
+  })
+
+  it('routes full commit-object probes through the selected WSL distro', async () => {
+    const sha = 'a'.repeat(40)
+
+    await expect(
+      prefetchWorktreeCreateBase({
+        repo,
+        baseBranch: sha,
+        runtime: runtime(),
+        gitOptions: { wslDistro: 'Ubuntu' }
+      })
+    ).resolves.toBe(sha)
+
+    expect(mocks.gitExecFileAsync).toHaveBeenCalledWith(
+      ['rev-parse', '--verify', '--quiet', `${sha}^{commit}`],
+      { cwd: repo.path, wslDistro: 'Ubuntu' }
+    )
+  })
+
+  it('routes exact remote-base refreshes through the selected WSL distro', async () => {
+    const remoteBase = {
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    }
+    mocks.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
+
+    await expect(
+      prefetchWorktreeCreateBase({
+        repo,
+        baseBranch: 'origin/main',
+        runtime: runtime(),
+        gitOptions: { wslDistro: 'Ubuntu' }
+      })
+    ).resolves.toBe('origin/main')
+
+    expect(mocks.hasRemoteTrackingRef).toHaveBeenCalledWith(repo.path, remoteBase, {
+      wslDistro: 'Ubuntu'
+    })
+    expect(mocks.getOrStartRemoteTrackingBaseRefresh).toHaveBeenCalledWith(repo.path, remoteBase, {
+      wslDistro: 'Ubuntu'
+    })
+  })
+
+  it('routes broad remote-fetch fallback through the selected WSL distro', async () => {
+    await expect(
+      prefetchWorktreeCreateBase({
+        repo,
+        baseBranch: 'feature/topic',
+        runtime: runtime(),
+        gitOptions: { wslDistro: 'Ubuntu' }
+      })
+    ).resolves.toBe('feature/topic')
+
+    expect(mocks.fetchRemoteWithCache).toHaveBeenCalledWith(repo.path, 'origin', {
+      wslDistro: 'Ubuntu'
+    })
+  })
+})

--- a/src/main/worktree-create-base-prefetch.ts
+++ b/src/main/worktree-create-base-prefetch.ts
@@ -1,12 +1,17 @@
 import { isFolderRepo } from '../shared/repo-kind'
 import type { Repo } from '../shared/repo-types'
-import { hasLocalCommitObject, isFullGitObjectId } from './git/commit-object-ref'
+import { hasCommitObjectViaGitExec, isFullGitObjectId } from './git/commit-object-ref'
 import { hasWorktreeBaseCommitRef } from './git/worktree-base-ref-probe'
 import { getBaseRefDefault } from './git/repo'
+import { gitExecFileAsync } from './git/runner'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
 import { prefetchRemoteWorktreeCreateBase } from './ipc/worktree-remote'
 import { resolveWorktreeCreateBase } from './worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree/base-ref'
+
+type WorktreeCreateBaseGitOptions = {
+  wslDistro?: string
+}
 
 type RemoteTrackingBaseForPrefetch = {
   remote: string
@@ -18,18 +23,33 @@ type RemoteTrackingBaseForPrefetch = {
 type WorktreeCreateBasePrefetchRuntime = {
   resolveRemoteTrackingBase: (
     repoPath: string,
-    baseBranch: string
+    baseBranch: string,
+    options?: WorktreeCreateBaseGitOptions
   ) => Promise<RemoteTrackingBaseForPrefetch | null>
-  hasRemoteTrackingRef: (repoPath: string, base: RemoteTrackingBaseForPrefetch) => Promise<boolean>
+  hasRemoteTrackingRef: (
+    repoPath: string,
+    base: RemoteTrackingBaseForPrefetch,
+    options?: WorktreeCreateBaseGitOptions
+  ) => Promise<boolean>
   getOrStartRemoteTrackingBaseRefresh: (
     repoPath: string,
-    base: RemoteTrackingBaseForPrefetch
+    base: RemoteTrackingBaseForPrefetch,
+    options?: WorktreeCreateBaseGitOptions
   ) => Promise<unknown>
-  fetchRemoteWithCache: (repoPath: string, remote: string) => Promise<void>
+  fetchRemoteWithCache: (
+    repoPath: string,
+    remote: string,
+    options?: WorktreeCreateBaseGitOptions
+  ) => Promise<void>
 }
 
-async function hasLocalWorktreeBaseRef(repoPath: string, baseRef: string): Promise<boolean> {
-  const refExists = (qualifiedRef: string) => hasWorktreeBaseCommitRef(repoPath, qualifiedRef)
+async function hasLocalWorktreeBaseRef(
+  repoPath: string,
+  baseRef: string,
+  options: WorktreeCreateBaseGitOptions
+): Promise<boolean> {
+  const refExists = (qualifiedRef: string) =>
+    hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
   const resolvedBaseRef = await resolveWorktreeAddBaseRef(baseRef, refExists)
   if (resolvedBaseRef !== baseRef) {
     return true
@@ -37,30 +57,36 @@ async function hasLocalWorktreeBaseRef(repoPath: string, baseRef: string): Promi
   if (baseRef.startsWith('refs/')) {
     return refExists(baseRef)
   }
-  return hasLocalCommitObject(repoPath, baseRef)
+  return hasCommitObjectViaGitExec(
+    (args) => gitExecFileAsync(args, { cwd: repoPath, ...options }),
+    baseRef
+  )
 }
 
 async function prefetchLocalWorktreeCreateBase(
   repo: Repo,
   baseBranch: string | undefined,
-  runtime: WorktreeCreateBasePrefetchRuntime
+  runtime: WorktreeCreateBasePrefetchRuntime,
+  options: WorktreeCreateBaseGitOptions
 ): Promise<string | undefined> {
+  const optionArgs: [] | [WorktreeCreateBaseGitOptions] = options.wslDistro ? [options] : []
   const resolvedBaseBranch = await resolveWorktreeCreateBase({
     requestedBaseBranch: baseBranch,
     repoWorktreeBaseRef: repo.worktreeBaseRef,
-    resolveDefaultBaseRef: () => getBaseRefDefault(repo.path),
+    resolveDefaultBaseRef: () => getBaseRefDefault(repo.path, ...optionArgs),
     isBaseUsable: async (baseBranchCandidate) => {
       const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
         repo.path,
-        baseBranchCandidate
+        baseBranchCandidate,
+        ...optionArgs
       )
       if (remoteTrackingBase) {
-        if (await runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase)) {
+        if (await runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase, ...optionArgs)) {
           return true
         }
-        return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate)
+        return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate, options)
       }
-      return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate)
+      return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate, options)
     }
   })
   if (!resolvedBaseBranch) {
@@ -68,28 +94,36 @@ async function prefetchLocalWorktreeCreateBase(
   }
   if (
     isFullGitObjectId(resolvedBaseBranch) &&
-    (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch))
+    (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch, options))
   ) {
     return resolvedBaseBranch
   }
-  const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(repo.path, resolvedBaseBranch)
+  const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
+    repo.path,
+    resolvedBaseBranch,
+    ...optionArgs
+  )
   if (remoteTrackingBase) {
     if (
-      (await runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase)) ||
-      !(await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch))
+      (await runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase, ...optionArgs)) ||
+      !(await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch, options))
     ) {
-      await runtime.getOrStartRemoteTrackingBaseRefresh(repo.path, remoteTrackingBase)
+      await runtime.getOrStartRemoteTrackingBaseRefresh(
+        repo.path,
+        remoteTrackingBase,
+        ...optionArgs
+      )
       return resolvedBaseBranch
     }
   }
-  if (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch)) {
+  if (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch, options)) {
     // Why: hosted-review start points and local branch bases are already local; a broad remote fetch cannot make them fresher.
     return resolvedBaseBranch
   }
 
   // Why: keep optimistic prefetch on the same best-effort fallback path as
   // create so the real create can reuse the runtime's remote fetch cache.
-  await runtime.fetchRemoteWithCache(repo.path, 'origin')
+  await runtime.fetchRemoteWithCache(repo.path, 'origin', ...optionArgs)
   return resolvedBaseBranch
 }
 
@@ -97,6 +131,7 @@ export async function prefetchWorktreeCreateBase(args: {
   repo: Repo
   baseBranch?: string
   runtime: WorktreeCreateBasePrefetchRuntime
+  gitOptions?: WorktreeCreateBaseGitOptions
 }): Promise<string | undefined> {
   if (isFolderRepo(args.repo)) {
     return undefined
@@ -109,5 +144,10 @@ export async function prefetchWorktreeCreateBase(args: {
     await prefetchRemoteWorktreeCreateBase(provider, args.repo, { baseBranch: args.baseBranch })
     return undefined
   }
-  return prefetchLocalWorktreeCreateBase(args.repo, args.baseBranch, args.runtime)
+  return prefetchLocalWorktreeCreateBase(
+    args.repo,
+    args.baseBranch,
+    args.runtime,
+    args.gitOptions ?? {}
+  )
 }

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
   finalize: vi.fn(),
   discard: vi.fn(),
   unlock: vi.fn(),
-  getWorktreeOptions: vi.fn()
+  getWorktreeOptions: vi.fn(),
+  getWorktreeMirrorDistro: vi.fn(),
+  getWorktreePathSettings: vi.fn()
 }))
 
 vi.mock('node:fs/promises', () => ({ mkdir: mocks.mkdir }))
@@ -22,17 +24,15 @@ vi.mock('./git/worktree-create-preparation', () => ({
   unlockPreparedWorktree: mocks.unlock
 }))
 vi.mock('./project-runtime-git-options', () => ({
-  getLocalProjectWorktreeGitOptions: mocks.getWorktreeOptions
+  getLocalProjectWorktreeGitOptions: mocks.getWorktreeOptions,
+  getWorktreeMirrorDistro: mocks.getWorktreeMirrorDistro
 }))
 vi.mock('./ipc/worktree-logic', () => ({
   computeWorkspaceRoot: (repoPath: string) =>
     process.platform === 'win32' && /^[A-Za-z]:[\\/]/.test(repoPath)
       ? 'C:\\workspace'
       : '/workspace',
-  getWorktreePathSettings: () => ({
-    workspaceDir: process.platform === 'win32' ? 'C:\\workspace' : '/workspace',
-    nestWorkspaces: false
-  })
+  getWorktreePathSettings: mocks.getWorktreePathSettings
 }))
 
 import {
@@ -52,6 +52,11 @@ beforeEach(() => {
   mocks.discard.mockReset().mockResolvedValue(undefined)
   mocks.unlock.mockReset().mockResolvedValue(undefined)
   mocks.getWorktreeOptions.mockReset().mockReturnValue({})
+  mocks.getWorktreeMirrorDistro.mockReset().mockReturnValue(undefined)
+  mocks.getWorktreePathSettings.mockReset().mockImplementation(() => ({
+    workspaceDir: process.platform === 'win32' ? 'C:\\workspace' : '/workspace',
+    nestWorkspaces: false
+  }))
 })
 
 afterEach(async () => {
@@ -68,6 +73,28 @@ describe('worktree create preparation registry', () => {
       expect(mocks.mkdir).toHaveBeenCalledWith(
         expect.stringMatching(/^\\\\\?\\C:\\workspace\\\.orca-preparing/),
         { recursive: true }
+      )
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('threads the resolved WSL mirror into speculative preparation', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      mocks.getWorktreeMirrorDistro.mockReturnValue('Ubuntu')
+
+      await prepareWorktreeCreateForRepo(store, { ...repo, path: 'C:\\repo' }, 'origin/main')
+
+      expect(mocks.getWorktreeMirrorDistro).toHaveBeenCalledWith(
+        store,
+        expect.objectContaining({ path: 'C:\\repo' })
+      )
+      expect(mocks.getWorktreePathSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ path: 'C:\\repo' }),
+        expect.anything(),
+        'Ubuntu'
       )
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -46,16 +46,20 @@ const store = { getSettings: () => ({}) } as unknown as Store
 
 beforeEach(() => {
   mocks.mkdir.mockReset().mockResolvedValue(undefined)
-  mocks.computeWorkspaceRoot.mockReset().mockImplementation((repoPath: string) =>
-    process.platform === 'win32' && /^[A-Za-z]:[\\/]/.test(repoPath)
-      ? 'C:\\workspace'
-      : '/workspace'
-  )
-  mocks.computeWorkspaceRootAsync.mockReset().mockImplementation(async (repoPath: string) =>
-    process.platform === 'win32' && /^[A-Za-z]:[\\/]/.test(repoPath)
-      ? 'C:\\workspace'
-      : '/workspace'
-  )
+  mocks.computeWorkspaceRoot
+    .mockReset()
+    .mockImplementation((repoPath: string) =>
+      process.platform === 'win32' && /^[A-Za-z]:[\\/]/.test(repoPath)
+        ? 'C:\\workspace'
+        : '/workspace'
+    )
+  mocks.computeWorkspaceRootAsync
+    .mockReset()
+    .mockImplementation(async (repoPath: string) =>
+      process.platform === 'win32' && /^[A-Za-z]:[\\/]/.test(repoPath)
+        ? 'C:\\workspace'
+        : '/workspace'
+    )
   mocks.listWorktreeGraph.mockReset().mockResolvedValue([])
   mocks.prepareCheckout.mockReset().mockResolvedValue(undefined)
   mocks.finalize.mockReset().mockResolvedValue({})

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -5,6 +5,8 @@ import { WORKTREE_CREATE_PREPARATION_DIRECTORY } from '../shared/worktree/create
 
 const mocks = vi.hoisted(() => ({
   mkdir: vi.fn(),
+  computeWorkspaceRoot: vi.fn(),
+  computeWorkspaceRootAsync: vi.fn(),
   listWorktreeGraph: vi.fn(),
   prepareCheckout: vi.fn(),
   finalize: vi.fn(),
@@ -28,10 +30,8 @@ vi.mock('./project-runtime-git-options', () => ({
   getWorktreeMirrorDistro: mocks.getWorktreeMirrorDistro
 }))
 vi.mock('./ipc/worktree-logic', () => ({
-  computeWorkspaceRoot: (repoPath: string) =>
-    process.platform === 'win32' && /^[A-Za-z]:[\\/]/.test(repoPath)
-      ? 'C:\\workspace'
-      : '/workspace',
+  computeWorkspaceRoot: mocks.computeWorkspaceRoot,
+  computeWorkspaceRootAsync: mocks.computeWorkspaceRootAsync,
   getWorktreePathSettings: mocks.getWorktreePathSettings
 }))
 
@@ -46,6 +46,16 @@ const store = { getSettings: () => ({}) } as unknown as Store
 
 beforeEach(() => {
   mocks.mkdir.mockReset().mockResolvedValue(undefined)
+  mocks.computeWorkspaceRoot.mockReset().mockImplementation((repoPath: string) =>
+    process.platform === 'win32' && /^[A-Za-z]:[\\/]/.test(repoPath)
+      ? 'C:\\workspace'
+      : '/workspace'
+  )
+  mocks.computeWorkspaceRootAsync.mockReset().mockImplementation(async (repoPath: string) =>
+    process.platform === 'win32' && /^[A-Za-z]:[\\/]/.test(repoPath)
+      ? 'C:\\workspace'
+      : '/workspace'
+  )
   mocks.listWorktreeGraph.mockReset().mockResolvedValue([])
   mocks.prepareCheckout.mockReset().mockResolvedValue(undefined)
   mocks.finalize.mockReset().mockResolvedValue({})
@@ -64,6 +74,49 @@ afterEach(async () => {
 })
 
 describe('worktree create preparation registry', () => {
+  it('resolves the workspace root asynchronously before starting preparation', async () => {
+    const resolveRoot = vi.fn<(root: string) => void>()
+    mocks.computeWorkspaceRoot.mockImplementation(() => {
+      throw new Error('synchronous workspace-root lookup must not run')
+    })
+    mocks.computeWorkspaceRootAsync.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveRoot.mockImplementation(resolve)
+      })
+    )
+
+    const preparation = prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    await Promise.resolve()
+    expect(mocks.prepareCheckout).not.toHaveBeenCalled()
+
+    resolveRoot('/workspace')
+    await preparation
+
+    expect(mocks.computeWorkspaceRoot).not.toHaveBeenCalled()
+    expect(mocks.computeWorkspaceRootAsync).toHaveBeenCalledWith(
+      repo.path,
+      expect.objectContaining({ workspaceDir: '/workspace', nestWorkspaces: false })
+    )
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
+  })
+
+  it('rechecks the preparation registry after concurrent root lookups resolve', async () => {
+    let resolveRoot!: (root: string) => void
+    mocks.computeWorkspaceRootAsync.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveRoot = resolve
+      })
+    )
+
+    const first = prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    const second = prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    resolveRoot('/workspace')
+
+    await Promise.all([first, second])
+
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
+  })
+
   it('namespaces native Windows preparation directories for long paths', async () => {
     const originalPlatform = process.platform
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
@@ -120,6 +173,21 @@ describe('worktree create preparation registry', () => {
         worktreePath: '/workspace/final',
         branch: 'feature/test',
         baseBranch: 'origin/release'
+      })
+    ).resolves.toBeNull()
+    expect(mocks.finalize).not.toHaveBeenCalled()
+  })
+
+  it('does not claim a preparation when the effective workspace root changes', async () => {
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+
+    await expect(
+      consumePreparedWorktreeCreate({
+        repoPath: repo.path,
+        workspaceRoot: '/other-workspace',
+        worktreePath: '/other-workspace/final',
+        branch: 'feature/test',
+        baseBranch: 'origin/main'
       })
     ).resolves.toBeNull()
     expect(mocks.finalize).not.toHaveBeenCalled()

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -20,7 +20,10 @@ import {
   unlockPreparedWorktree,
   prepareWorktreeCreateCheckout
 } from './git/worktree-create-preparation'
-import { getLocalProjectWorktreeGitOptions } from './project-runtime-git-options'
+import {
+  getLocalProjectWorktreeGitOptions,
+  getWorktreeMirrorDistro
+} from './project-runtime-git-options'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
 import { toHostFilesystemPath } from './host-tree-removal'
 
@@ -165,7 +168,7 @@ export function prepareWorktreeCreateForRepo(
   const options = getLocalProjectWorktreeGitOptions(store, repo)
   const workspaceRoot = computeWorkspaceRoot(
     repo.path,
-    getWorktreePathSettings(repo, store.getSettings())
+    getWorktreePathSettings(repo, store.getSettings(), getWorktreeMirrorDistro(store, repo))
   )
   const key = preparationKey(repo.path, workspaceRoot, baseBranch, options)
   const existing = preparations.get(key)

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -24,7 +24,7 @@ import {
   getLocalProjectWorktreeGitOptions,
   getWorktreeMirrorDistro
 } from './project-runtime-git-options'
-import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
+import { computeWorkspaceRootAsync, getWorktreePathSettings } from './ipc/worktree-logic'
 import { toHostFilesystemPath } from './host-tree-removal'
 
 export const WORKTREE_CREATE_PREPARATION_TTL_MS = 5 * 60_000
@@ -157,19 +157,22 @@ async function cleanupStalePreparations(
   }
 }
 
-export function prepareWorktreeCreateForRepo(
+export async function prepareWorktreeCreateForRepo(
   store: Store,
   repo: Repo,
   baseBranch: string
 ): Promise<void> {
   if (repo.connectionId || isFolderRepo(repo)) {
-    return Promise.resolve()
+    return
   }
   const options = getLocalProjectWorktreeGitOptions(store, repo)
-  const workspaceRoot = computeWorkspaceRoot(
-    repo.path,
-    getWorktreePathSettings(repo, store.getSettings(), getWorktreeMirrorDistro(store, repo))
+  const workspaceRootSettings = getWorktreePathSettings(
+    repo,
+    store.getSettings(),
+    getWorktreeMirrorDistro(store, repo)
   )
+  const workspaceRoot = await computeWorkspaceRootAsync(repo.path, workspaceRootSettings)
+  // Root/runtime are part of the key, so a settings change while probing cannot claim this prep.
   const key = preparationKey(repo.path, workspaceRoot, baseBranch, options)
   const existing = preparations.get(key)
   if (existing) {

--- a/src/main/worktree-root-preparation.test.ts
+++ b/src/main/worktree-root-preparation.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../shared/repo-types'
+import * as worktreeLogic from './ipc/worktree-logic'
 
 const { mkdirMock, authorizeExternalPathMock } = vi.hoisted(() => ({
   mkdirMock: vi.fn(),
@@ -33,6 +34,7 @@ describe('prepareLocalWorktreeRootForRepo', () => {
   beforeEach(() => {
     mkdirMock.mockReset().mockResolvedValue(undefined)
     authorizeExternalPathMock.mockReset()
+    vi.restoreAllMocks()
     store.getSettings.mockReset().mockReturnValue({
       workspaceDir: '/Users/alice/orca/workspaces',
       nestWorkspaces: false
@@ -43,6 +45,30 @@ describe('prepareLocalWorktreeRootForRepo', () => {
     await prepareLocalWorktreeRootForRepo(store as never, repo)
 
     expect(mkdirMock).toHaveBeenCalledWith('/Users/alice/orca/workspaces', { recursive: true })
+  })
+
+  it('resolves the root asynchronously without invoking the synchronous WSL probe', async () => {
+    let resolveRoot!: (root: string) => void
+    const rootReady = new Promise<string>((resolve) => {
+      resolveRoot = resolve
+    })
+    const asyncRootSpy = vi
+      .spyOn(worktreeLogic, 'computeWorkspaceRootAsync')
+      .mockReturnValue(rootReady)
+    const syncRootSpy = vi.spyOn(worktreeLogic, 'computeWorkspaceRoot').mockImplementation(() => {
+      throw new Error('synchronous workspace-root lookup must not run')
+    })
+
+    const preparation = prepareLocalWorktreeRootForRepo(store as never, repo)
+    await Promise.resolve()
+    expect(mkdirMock).not.toHaveBeenCalled()
+
+    resolveRoot('/async-workspaces')
+    await preparation
+
+    expect(asyncRootSpy).toHaveBeenCalledTimes(1)
+    expect(syncRootSpy).not.toHaveBeenCalled()
+    expect(mkdirMock).toHaveBeenCalledWith('/async-workspaces', { recursive: true })
   })
 
   it('uses repo-specific worktree base paths', async () => {

--- a/src/main/worktree-root-preparation.ts
+++ b/src/main/worktree-root-preparation.ts
@@ -3,7 +3,7 @@ import type { GlobalSettings } from '../shared/global-settings-types'
 import type { Repo } from '../shared/repo-types'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
 import { isFolderRepo } from '../shared/repo-kind'
-import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
+import { computeWorkspaceRootAsync, getWorktreePathSettings } from './ipc/worktree-logic'
 import { getWorktreeMirrorDistro } from './project-runtime-git-options'
 import type { ProjectRuntimeResolutionStore } from './local-project-runtime-resolution'
 
@@ -27,7 +27,7 @@ export async function prepareLocalWorktreeRootForRepo(
   }
 
   try {
-    const root = computeWorkspaceRoot(
+    const root = await computeWorkspaceRootAsync(
       repo.path,
       getWorktreePathSettings(repo, store.getSettings(), getWorktreeMirrorDistro(store, repo))
     )

--- a/src/main/wsl-running-distros.test.ts
+++ b/src/main/wsl-running-distros.test.ts
@@ -78,7 +78,7 @@ describe('running WSL distro discovery', () => {
       ])
       expect(execFileMock.mock.calls.map(([, args]) => args)).toEqual([
         ['--list', '--running', '--quiet'],
-        ['-d', 'Ubuntu', '--exec', 'bash', '-c', 'echo $HOME']
+        ['-d', 'Ubuntu', '--exec', 'sh', '-c', 'printf "%s" "$HOME"']
       ])
     })
   })
@@ -134,7 +134,7 @@ describe('running WSL distro discovery', () => {
         ['\\\\wsl.localhost\\Ubuntu\\home\\ada']
       ])
       expect(
-        execFileMock.mock.calls.filter(([, args]) => args.includes('echo $HOME'))
+        execFileMock.mock.calls.filter(([, args]) => args.includes('printf "%s" "$HOME"'))
       ).toHaveLength(1)
     })
   })

--- a/src/main/wsl.ts
+++ b/src/main/wsl.ts
@@ -29,6 +29,12 @@ export type WslPathInfo = {
 
 const WSL_DIRECTORY_EXISTS_MARKER = '__ORCA_DIRECTORY_EXISTS__'
 const WSL_DIRECTORY_MISSING_MARKER = '__ORCA_DIRECTORY_MISSING__'
+// `sh` avoids user bash startup hooks on the workspace-root hot path.
+const WSL_HOME_PROBE_COMMAND = 'printf "%s" "$HOME"'
+
+function getWslHomeProbeArgs(distro: string): string[] {
+  return ['-d', distro, '--exec', 'sh', '-c', WSL_HOME_PROBE_COMMAND]
+}
 
 function getWslDirectoryProbeArgs(info: WslPathInfo): string[] {
   return [
@@ -281,7 +287,7 @@ export function getWslHome(distro: string): string | null {
   }
 
   try {
-    const home = execFileSync('wsl.exe', ['-d', distro, '--exec', 'bash', '-c', 'echo $HOME'], {
+    const home = execFileSync('wsl.exe', getWslHomeProbeArgs(distro), {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000
@@ -314,7 +320,7 @@ export async function getWslHomeAsync(distro: string): Promise<string | null> {
     return inflight
   }
 
-  const probe = execFileUtf8('wsl.exe', ['-d', distro, '--exec', 'bash', '-c', 'echo $HOME'])
+  const probe = execFileUtf8('wsl.exe', getWslHomeProbeArgs(distro))
     .then((output) => {
       const home = output.trim()
       if (!home || !home.startsWith('/')) {

--- a/src/relay/git-handler-local-base-ref-refresh.ts
+++ b/src/relay/git-handler-local-base-ref-refresh.ts
@@ -1,11 +1,13 @@
 import type { GitExec } from './git-handler-ops'
 import { areRelayWorktreePathsEqual, readRelayWorktreeList } from './git-handler-worktree-ops'
 import type { GitCapabilityCache } from '../shared/git-capability-cache'
+import { windowsParallelCheckoutGitArgs } from '../shared/windows-parallel-checkout-git-args'
 
 export async function refreshLocalBaseRefForWorktreeCreateOp(
   git: GitExec,
   params: Record<string, unknown>,
-  capabilities: GitCapabilityCache
+  capabilities: GitCapabilityCache,
+  platform: NodeJS.Platform = process.platform
 ): Promise<void> {
   const repoPath = params.repoPath as string
   const fullRef = params.fullRef as string
@@ -60,7 +62,15 @@ export async function refreshLocalBaseRefForWorktreeCreateOp(
     if (checkOnly) {
       return
     }
-    await git(['reset', '--hard', remoteOid], ownerWorktree.path)
+    await git(
+      [
+        ...windowsParallelCheckoutGitArgs(ownerWorktree.path, platform),
+        'reset',
+        '--hard',
+        remoteOid
+      ],
+      ownerWorktree.path
+    )
     return
   }
 

--- a/src/relay/git-handler-local-base-ref-refresh.ts
+++ b/src/relay/git-handler-local-base-ref-refresh.ts
@@ -1,7 +1,7 @@
 import type { GitExec } from './git-handler-ops'
 import { areRelayWorktreePathsEqual, readRelayWorktreeList } from './git-handler-worktree-ops'
 import type { GitCapabilityCache } from '../shared/git-capability-cache'
-import { windowsParallelCheckoutGitArgs } from '../shared/windows-parallel-checkout-git-args'
+import { windowsParallelCheckoutGitArgsAsync } from '../shared/windows-parallel-checkout-git-args'
 
 export async function refreshLocalBaseRefForWorktreeCreateOp(
   git: GitExec,
@@ -62,15 +62,18 @@ export async function refreshLocalBaseRefForWorktreeCreateOp(
     if (checkOnly) {
       return
     }
-    await git(
-      [
-        ...windowsParallelCheckoutGitArgs(ownerWorktree.path, platform),
-        'reset',
-        '--hard',
-        remoteOid
-      ],
-      ownerWorktree.path
+    const parallelCheckoutArgs = await windowsParallelCheckoutGitArgsAsync(
+      ownerWorktree.path,
+      platform,
+      undefined,
+      {
+        ...(platform === 'win32' ? { nativeWindowsGit: true } : {}),
+        capabilities,
+        probeGitVersion: async () =>
+          (await git(['--version'], ownerWorktree.path, { timeout: 5_000 })).stdout
+      }
     )
+    await git([...parallelCheckoutArgs, 'reset', '--hard', remoteOid], ownerWorktree.path)
     return
   }
 

--- a/src/relay/git-handler-worktree-operations.ts
+++ b/src/relay/git-handler-worktree-operations.ts
@@ -151,7 +151,9 @@ export class GitHandlerWorktreeOperations extends GitHandlerOperationContext {
   }
 
   async addWorktree(params: Record<string, unknown>) {
-    return this.runWithGitReadCacheClear(() => addWorktreeOp(this.git.bind(this), params))
+    return this.runWithGitReadCacheClear(() =>
+      addWorktreeOp(this.git.bind(this), params, process.platform, this.gitCapabilities)
+    )
   }
 
   async removeWorktree(params: Record<string, unknown>) {

--- a/src/relay/git-handler-worktree-operations.ts
+++ b/src/relay/git-handler-worktree-operations.ts
@@ -171,7 +171,12 @@ export class GitHandlerWorktreeOperations extends GitHandlerOperationContext {
 
   async refreshLocalBaseRefForWorktreeCreate(params: Record<string, unknown>) {
     return this.runWithGitReadCacheClear(() =>
-      refreshLocalBaseRefForWorktreeCreateOp(this.git.bind(this), params, this.gitCapabilities)
+      refreshLocalBaseRefForWorktreeCreateOp(
+        this.git.bind(this),
+        params,
+        this.gitCapabilities,
+        process.platform
+      )
     )
   }
 }

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -136,6 +136,8 @@ describe('addWorktreeOp', () => {
         '-c',
         'core.longpaths=true',
         '-c',
+        'core.fscache=false',
+        '-c',
         'checkout.workers=-1',
         'worktree',
         'add',

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -174,7 +174,7 @@ describe('addWorktreeOp', () => {
     ])
   })
 
-  it('omits the long-path option on a WSL UNC target on a Windows SSH host', async () => {
+  it('keeps native Windows tuning for a WSL UNC target on a Windows SSH host', async () => {
     const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
 
     await addWorktreeOp(
@@ -188,9 +188,15 @@ describe('addWorktreeOp', () => {
       'win32'
     )
 
-    // A WSL UNC path is executed by WSL Git, not Git for Windows. Keep the
-    // native Windows checkout tuning off this route.
+    // The relay's GitHandler always executes native Git on the SSH host. A
+    // UNC spelling in client params must not override that execution boundary.
     expect(git.mock.calls[0][0]).toEqual([
+      '-c',
+      'core.longpaths=true',
+      '-c',
+      'core.fscache=false',
+      '-c',
+      'checkout.workers=-1',
       'worktree',
       'add',
       '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo-feature',

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -188,6 +188,8 @@ describe('addWorktreeOp', () => {
       'win32'
     )
 
+    // A WSL UNC path is executed by WSL Git, not Git for Windows. Keep the
+    // native Windows checkout tuning off this route.
     expect(git.mock.calls[0][0]).toEqual([
       'worktree',
       'add',

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -132,7 +132,16 @@ describe('addWorktreeOp', () => {
     )
 
     expect(git.mock.calls.map((call) => call[0])).toEqual([
-      ['-c', 'core.longpaths=true', 'worktree', 'add', 'C:\\repo-feature', 'feature/test']
+      [
+        '-c',
+        'core.longpaths=true',
+        '-c',
+        'checkout.workers=-1',
+        'worktree',
+        'add',
+        'C:\\repo-feature',
+        'feature/test'
+      ]
     ])
   })
 

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -92,7 +92,11 @@ export async function addWorktreeOp(
       : undefined
 
   // Why: a Windows SSH host hits the same MAX_PATH ceiling as a local Windows checkout.
-  const longPathArgs = windowsLongPathGitArgs(targetDir, platform)
+  const longPathArgs = windowsLongPathGitArgs(targetDir, platform, {
+    // GitHandler executes the relay command with the host's native git.exe;
+    // do not reinterpret a client-supplied WSL UNC path as a WSL invocation.
+    nativeWindowsGit: platform === 'win32'
+  })
   const parallelCheckoutArgs = await parallelCheckoutArgsPromise
   const args = checkoutExistingBranch
     ? [...longPathArgs, ...parallelCheckoutArgs, 'worktree', 'add', targetDir, branchName]

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree/base-ref'
 import { windowsLongPathGitArgs } from '../shared/windows-long-path-git-args'
+import { windowsParallelCheckoutGitArgs } from '../shared/windows-parallel-checkout-git-args'
 import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
 export { readRelayWorktreeList } from './git-handler-worktree-list'
@@ -70,13 +71,21 @@ export async function addWorktreeOp(
 
   // Why: a Windows SSH host hits the same MAX_PATH ceiling as a local Windows checkout.
   const longPathArgs = windowsLongPathGitArgs(targetDir, platform)
+  const parallelCheckoutArgs =
+    checkoutExistingBranch || !noCheckout ? windowsParallelCheckoutGitArgs(repoPath, platform) : []
   const args = checkoutExistingBranch
-    ? [...longPathArgs, 'worktree', 'add', targetDir, branchName]
-    : [...longPathArgs, 'worktree', 'add', '--no-track', '-b', branchName, targetDir]
-  if (!checkoutExistingBranch && noCheckout) {
-    // Why: offset by the global-option prefix so --no-checkout still lands before -b.
-    args.splice(longPathArgs.length + 3, 0, '--no-checkout')
-  }
+    ? [...longPathArgs, ...parallelCheckoutArgs, 'worktree', 'add', targetDir, branchName]
+    : [
+        ...longPathArgs,
+        ...parallelCheckoutArgs,
+        'worktree',
+        'add',
+        '--no-track',
+        ...(noCheckout ? ['--no-checkout'] : []),
+        '-b',
+        branchName,
+        targetDir
+      ]
   if (effectiveBase) {
     args.push(effectiveBase)
   }

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -1,7 +1,8 @@
 import * as path from 'node:path'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree/base-ref'
 import { windowsLongPathGitArgs } from '../shared/windows-long-path-git-args'
-import { windowsParallelCheckoutGitArgs } from '../shared/windows-parallel-checkout-git-args'
+import { windowsParallelCheckoutGitArgsAsync } from '../shared/windows-parallel-checkout-git-args'
+import type { GitCapabilityCache } from '../shared/git-capability-cache'
 import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
 export { readRelayWorktreeList } from './git-handler-worktree-list'
@@ -34,7 +35,8 @@ export async function addWorktreeOp(
   git: GitExec,
   params: Record<string, unknown>,
   // Why: only the execution host's OS matters here — the client may be macOS while the SSH host is Windows.
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  capabilities?: GitCapabilityCache
 ): Promise<void> {
   const repoPath = params.repoPath as string
   const branchName = params.branchName as string
@@ -48,6 +50,26 @@ export async function addWorktreeOp(
   if (branchName.startsWith('-') || (base && base.startsWith('-'))) {
     throw new Error('Branch name and base ref must not start with "-"')
   }
+
+  const needsParallelCheckout = checkoutExistingBranch || !noCheckout
+  const parallelCheckoutArgsPromise = needsParallelCheckout
+    ? windowsParallelCheckoutGitArgsAsync(targetDir, platform, undefined, {
+        // Relay Git always executes on the host running the relay. Do not
+        // infer a WSL route from a synthetic UNC path in client-provided
+        // params; the host platform is the execution authority here.
+        ...(platform === 'win32' ? { nativeWindowsGit: true } : {}),
+        ...(capabilities
+          ? {
+              capabilities,
+              probeGitVersion: async () =>
+                (await git(['--version'], repoPath, { timeout: 5_000 })).stdout
+            }
+          : {})
+      })
+    : Promise.resolve([] as string[])
+  // Base/ref validation can fail before argv construction; keep a speculative
+  // probe observed so an early failure never creates an unhandled rejection.
+  void parallelCheckoutArgsPromise.catch(() => {})
 
   // Why: --no-track + push.autoSetupRemote=true mirrors the local
   // addWorktree path (src/main/git/worktree.ts). Keeping the SSH path in
@@ -71,8 +93,7 @@ export async function addWorktreeOp(
 
   // Why: a Windows SSH host hits the same MAX_PATH ceiling as a local Windows checkout.
   const longPathArgs = windowsLongPathGitArgs(targetDir, platform)
-  const parallelCheckoutArgs =
-    checkoutExistingBranch || !noCheckout ? windowsParallelCheckoutGitArgs(repoPath, platform) : []
+  const parallelCheckoutArgs = await parallelCheckoutArgsPromise
   const args = checkoutExistingBranch
     ? [...longPathArgs, ...parallelCheckoutArgs, 'worktree', 'add', targetDir, branchName]
     : [

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -181,6 +181,12 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
     await runGit(['branch', '-D', 'compat-prepared-final'])
   })
 
+  it('accepts the optional parallel-checkout config across Git versions', async () => {
+    // Git before 2.32 does not implement the key; command-line config still
+    // accepts unknown keys, so the baseline remains sequential without a retry.
+    await expect(runGit(['-c', 'checkout.workers=-1', 'status', '--short'])).resolves.toBeDefined()
+  })
+
   it('recognizes ref and merge-tree compatibility boundaries', async () => {
     const fetchHeadPath = join(repoPath, '.git', 'FETCH_HEAD')
     await writeFile(fetchHeadPath, 'sentinel\n')

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -184,7 +184,9 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
   it('accepts the optional parallel-checkout config across Git versions', async () => {
     // Git before 2.32 does not implement the key; command-line config still
     // accepts unknown keys, so the baseline remains sequential without a retry.
-    await expect(runGit(['-c', 'checkout.workers=-1', 'status', '--short'])).resolves.toBeDefined()
+    await expect(
+      runGit(['-c', 'core.fscache=false', '-c', 'checkout.workers=-1', 'status', '--short'])
+    ).resolves.toBeDefined()
   })
 
   it('recognizes ref and merge-tree compatibility boundaries', async () => {

--- a/src/shared/git-capability-cache.ts
+++ b/src/shared/git-capability-cache.ts
@@ -11,6 +11,8 @@ export type GitCapability =
   | 'merge-tree-write-tree'
   | 'rev-parse-path-format'
   | 'worktree-list-z'
+  /** Git for Windows 2.55 fixed stale FSCache entries during parallel checkout. */
+  | 'windows-fscache-parallel-checkout'
 
 export class GitCapabilityCache extends CapabilityProbeCache<GitCapability> {
   constructor() {

--- a/src/shared/windows-long-path-git-args.test.ts
+++ b/src/shared/windows-long-path-git-args.test.ts
@@ -53,14 +53,48 @@ describe('windowsParallelCheckoutGitArgs', () => {
   })
 
   it.each(['\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo', '\\\\wsl$\\Ubuntu\\home\\dev\\repo'])(
-    'returns nothing for the WSL UNC path %s',
+    'keeps the default worker policy for the WSL ext4 UNC path %s',
     (cwd) => {
       expect(windowsParallelCheckoutGitArgs(cwd, 'win32')).toEqual([])
     }
   )
 
-  it('returns nothing when a Windows path is explicitly routed through WSL', () => {
-    expect(windowsParallelCheckoutGitArgs('C:\\repo', 'win32', 'Ubuntu')).toEqual([])
+  it('uses the all-worker pool for a WSL UNC path backed by DrvFS', () => {
+    expect(
+      windowsParallelCheckoutGitArgs('\\\\wsl.localhost\\Ubuntu\\mnt\\c\\repo', 'win32')
+    ).toEqual(['-c', 'checkout.workers=-1'])
+  })
+
+  it('keeps the default worker policy for an ext4 POSIX cwd routed through WSL', () => {
+    expect(windowsParallelCheckoutGitArgs('/home/dev/repo', 'win32', 'Ubuntu')).toEqual([])
+  })
+
+  it('uses the all-worker pool for an explicitly WSL-routed DrvFS path', () => {
+    expect(windowsParallelCheckoutGitArgs('/mnt/c/repo', 'win32', 'Ubuntu')).toEqual([
+      '-c',
+      'checkout.workers=-1'
+    ])
+  })
+
+  it('uses the all-worker pool when a Windows drive cwd is routed through WSL', () => {
+    // The command runner keeps the Windows spelling for its cwd while it
+    // translates that cwd to /mnt/c/... inside the selected distro.
+    expect(
+      windowsParallelCheckoutGitArgs('C:\\repo', 'win32', 'Ubuntu', {
+        nativeWindowsGit: false
+      })
+    ).toEqual(['-c', 'checkout.workers=-1'])
+  })
+
+  it('keeps the FSCache workaround on an ambiguous Windows cwd with a WSL override', () => {
+    // A linked worktree can force this C:\ path back to host Git even when a
+    // WSL distro override is present, so retain the native safety setting.
+    expect(windowsParallelCheckoutGitArgs('C:\\repo', 'win32', 'Ubuntu')).toEqual([
+      '-c',
+      'core.fscache=false',
+      '-c',
+      'checkout.workers=-1'
+    ])
   })
 
   it.each(['relative\\repo', '/home/dev/repo', '\\repo'])(

--- a/src/shared/windows-long-path-git-args.test.ts
+++ b/src/shared/windows-long-path-git-args.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { windowsLongPathGitArgs } from './windows-long-path-git-args'
+import { windowsParallelCheckoutGitArgs } from './windows-parallel-checkout-git-args'
 
 describe('windowsLongPathGitArgs', () => {
   it('enables long paths for a Windows drive path', () => {
@@ -25,5 +26,52 @@ describe('windowsLongPathGitArgs', () => {
     const first = windowsLongPathGitArgs('C:\\repo', 'win32')
     first.push('--bogus')
     expect(windowsLongPathGitArgs('C:\\repo', 'win32')).toEqual(['-c', 'core.longpaths=true'])
+  })
+})
+
+describe('windowsParallelCheckoutGitArgs', () => {
+  it('enables all logical checkout workers for a native Windows drive path', () => {
+    expect(windowsParallelCheckoutGitArgs('C:\\Users\\dev\\repo', 'win32')).toEqual([
+      '-c',
+      'checkout.workers=-1'
+    ])
+  })
+
+  it('enables workers for a native Windows UNC share', () => {
+    expect(windowsParallelCheckoutGitArgs('\\\\server\\share\\repo', 'win32')).toEqual([
+      '-c',
+      'checkout.workers=-1'
+    ])
+  })
+
+  it.each(['darwin', 'linux'] as const)('returns nothing on %s', (platform) => {
+    expect(windowsParallelCheckoutGitArgs('/home/dev/repo', platform)).toEqual([])
+  })
+
+  it.each(['\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo', '\\\\wsl$\\Ubuntu\\home\\dev\\repo'])(
+    'returns nothing for the WSL UNC path %s',
+    (cwd) => {
+      expect(windowsParallelCheckoutGitArgs(cwd, 'win32')).toEqual([])
+    }
+  )
+
+  it('returns nothing when a Windows path is explicitly routed through WSL', () => {
+    expect(windowsParallelCheckoutGitArgs('C:\\repo', 'win32', 'Ubuntu')).toEqual([])
+  })
+
+  it.each(['relative\\repo', '/home/dev/repo', '\\repo'])(
+    'returns nothing for a non-absolute native path %s',
+    (cwd) => {
+      expect(windowsParallelCheckoutGitArgs(cwd, 'win32')).toEqual([])
+    }
+  )
+
+  it('never mutates the shared constant', () => {
+    const first = windowsParallelCheckoutGitArgs('C:\\repo', 'win32')
+    first.push('--bogus')
+    expect(windowsParallelCheckoutGitArgs('C:\\repo', 'win32')).toEqual([
+      '-c',
+      'checkout.workers=-1'
+    ])
   })
 })

--- a/src/shared/windows-long-path-git-args.test.ts
+++ b/src/shared/windows-long-path-git-args.test.ts
@@ -22,6 +22,14 @@ describe('windowsLongPathGitArgs', () => {
     }
   )
 
+  it('honors an explicit native Windows route for a WSL UNC spelling', () => {
+    expect(
+      windowsLongPathGitArgs('\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo', 'win32', {
+        nativeWindowsGit: true
+      })
+    ).toEqual(['-c', 'core.longpaths=true'])
+  })
+
   it('never mutates the shared constant', () => {
     const first = windowsLongPathGitArgs('C:\\repo', 'win32')
     first.push('--bogus')
@@ -95,6 +103,17 @@ describe('windowsParallelCheckoutGitArgs', () => {
       '-c',
       'checkout.workers=-1'
     ])
+  })
+
+  it('honors an explicit native Windows route for a WSL UNC path', () => {
+    expect(
+      windowsParallelCheckoutGitArgs(
+        '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo',
+        'win32',
+        'Ubuntu',
+        { nativeWindowsGit: true }
+      )
+    ).toEqual(['-c', 'core.fscache=false', '-c', 'checkout.workers=-1'])
   })
 
   it.each(['relative\\repo', '/home/dev/repo', '\\repo'])(

--- a/src/shared/windows-long-path-git-args.test.ts
+++ b/src/shared/windows-long-path-git-args.test.ts
@@ -33,12 +33,16 @@ describe('windowsParallelCheckoutGitArgs', () => {
   it('enables all logical checkout workers for a native Windows drive path', () => {
     expect(windowsParallelCheckoutGitArgs('C:\\Users\\dev\\repo', 'win32')).toEqual([
       '-c',
+      'core.fscache=false',
+      '-c',
       'checkout.workers=-1'
     ])
   })
 
   it('enables workers for a native Windows UNC share', () => {
     expect(windowsParallelCheckoutGitArgs('\\\\server\\share\\repo', 'win32')).toEqual([
+      '-c',
+      'core.fscache=false',
       '-c',
       'checkout.workers=-1'
     ])
@@ -70,6 +74,8 @@ describe('windowsParallelCheckoutGitArgs', () => {
     const first = windowsParallelCheckoutGitArgs('C:\\repo', 'win32')
     first.push('--bogus')
     expect(windowsParallelCheckoutGitArgs('C:\\repo', 'win32')).toEqual([
+      '-c',
+      'core.fscache=false',
       '-c',
       'checkout.workers=-1'
     ])

--- a/src/shared/windows-long-path-git-args.ts
+++ b/src/shared/windows-long-path-git-args.ts
@@ -2,6 +2,11 @@ import { parseWslUncPath } from './wsl-paths'
 
 const WINDOWS_LONG_PATH_GIT_ARGS = ['-c', 'core.longpaths=true'] as const
 
+export type WindowsLongPathGitArgsOptions = {
+  /** Override path inference when a Windows relay explicitly runs native Git. */
+  nativeWindowsGit?: boolean
+}
+
 /**
  * Global `git -c` options that let a Windows checkout exceed MAX_PATH.
  *
@@ -10,15 +15,15 @@ const WINDOWS_LONG_PATH_GIT_ARGS = ['-c', 'core.longpaths=true'] as const
  * only — never `--global`, `--system`, or `--local`, so no user config is
  * written. Available since Git 1.9, well under the 2.25 baseline.
  *
- * Why keyed off cwd rather than a wslDistro option: a `C:\...` cwd can still be
- * served by host git.exe even when a distro is configured, and Linux git parses
- * and ignores the key, so only a true `\\wsl.localhost\...` path opts out.
+ * Path inference keeps WSL UNC paths off native-only flags; callers with an
+ * authoritative native execution boundary can opt back in explicitly.
  */
 export function windowsLongPathGitArgs(
   cwd: string,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  options: WindowsLongPathGitArgsOptions = {}
 ): string[] {
-  if (platform !== 'win32' || parseWslUncPath(cwd)) {
+  if (platform !== 'win32' || (options.nativeWindowsGit !== true && parseWslUncPath(cwd))) {
     return []
   }
   return [...WINDOWS_LONG_PATH_GIT_ARGS]

--- a/src/shared/windows-parallel-checkout-capability.test.ts
+++ b/src/shared/windows-parallel-checkout-capability.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import { GitCapabilityCache } from './git-capability-cache'
+import {
+  parseGitForWindowsVersion,
+  resolveWindowsFscacheParallelCheckout,
+  supportsWindowsFscacheParallelCheckout,
+  WINDOWS_FSCACHE_PARALLEL_CHECKOUT_CAPABILITY
+} from './windows-parallel-checkout-capability'
+
+describe('parseGitForWindowsVersion', () => {
+  it('parses the Git for Windows version shape', () => {
+    expect(parseGitForWindowsVersion('git version 2.55.0.windows.3\r\n')).toEqual({
+      major: 2,
+      minor: 55,
+      patch: 0,
+      build: 3
+    })
+  })
+
+  it('accepts future major versions and optional patch/build components', () => {
+    expect(parseGitForWindowsVersion('git version 3.0.windows')).toEqual({
+      major: 3,
+      minor: 0,
+      patch: 0,
+      build: null
+    })
+  })
+
+  it.each([
+    'git version 2.54.0.windows.1',
+    'git version 2.55.0',
+    'git version 2.55.0 (Apple Git-155)',
+    'noise\ngit version 2.55.0.windows.1',
+    'git version 999999999999999999999.windows.1'
+  ])('rejects or marks unsafe non-native output: %s', (output) => {
+    expect(supportsWindowsFscacheParallelCheckout(output)).toBe(false)
+  })
+})
+
+describe('resolveWindowsFscacheParallelCheckout', () => {
+  it('probes once and reuses a supported value', async () => {
+    const cache = new GitCapabilityCache()
+    const probe = vi.fn(async () => 'git version 2.55.0.windows.3\n')
+
+    await expect(resolveWindowsFscacheParallelCheckout(cache, probe)).resolves.toBe(true)
+    await expect(resolveWindowsFscacheParallelCheckout(cache, probe)).resolves.toBe(true)
+    expect(probe).toHaveBeenCalledTimes(1)
+    expect(cache.isKnownSupported(WINDOWS_FSCACHE_PARALLEL_CHECKOUT_CAPABILITY)).toBe(true)
+  })
+
+  it('coalesces concurrent probes and fails closed for unknown output', async () => {
+    const cache = new GitCapabilityCache()
+    let release!: (output: string) => void
+    const pending = new Promise<string>((resolve) => {
+      release = resolve
+    })
+    const probe = vi.fn(() => pending)
+
+    const first = resolveWindowsFscacheParallelCheckout(cache, probe)
+    const second = resolveWindowsFscacheParallelCheckout(cache, probe)
+    expect(probe).toHaveBeenCalledTimes(1)
+    release('git version 2.54.0.windows.1\n')
+    await expect(Promise.all([first, second])).resolves.toEqual([false, false])
+    expect(cache.isKnownSupported(WINDOWS_FSCACHE_PARALLEL_CHECKOUT_CAPABILITY)).toBe(false)
+  })
+
+  it('retries a failed probe only after the capability interval', async () => {
+    const cache = new GitCapabilityCache()
+    const probe = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockResolvedValueOnce('git version 2.55.0.windows.3')
+
+    await expect(resolveWindowsFscacheParallelCheckout(cache, probe)).resolves.toBe(false)
+    await expect(resolveWindowsFscacheParallelCheckout(cache, probe)).resolves.toBe(false)
+    expect(probe).toHaveBeenCalledTimes(1)
+
+    cache.rememberUnsupported(
+      WINDOWS_FSCACHE_PARALLEL_CHECKOUT_CAPABILITY,
+      Date.now() - 30 * 60_000 - 1
+    )
+    await expect(resolveWindowsFscacheParallelCheckout(cache, probe)).resolves.toBe(true)
+    expect(probe).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/shared/windows-parallel-checkout-capability.ts
+++ b/src/shared/windows-parallel-checkout-capability.ts
@@ -1,0 +1,107 @@
+import type { GitCapabilityCache } from './git-capability-cache'
+
+/** Git for Windows fixed stale directory listings during parallel checkout in 2.55. */
+export const WINDOWS_FSCACHE_PARALLEL_CHECKOUT_CAPABILITY =
+  'windows-fscache-parallel-checkout' as const
+
+export type GitForWindowsVersion = {
+  major: number
+  minor: number
+  patch: number
+  build: number | null
+}
+
+// Keep this deliberately narrow: a native Windows Git version is the only
+// evidence that permits omitting the old FSCache workaround.
+const GIT_FOR_WINDOWS_VERSION_RE =
+  /^git version (\d+)\.(\d+)(?:\.(\d+))?\.windows(?:\.(\d+))?(?:\s+\([^\r\n]*\))?$/i
+
+/**
+ * Parse the one-line version emitted by Git for Windows.
+ *
+ * Non-Windows Git, malformed output, and output contaminated by a shell
+ * banner all return null so callers retain the conservative workaround.
+ */
+export function parseGitForWindowsVersion(output: string): GitForWindowsVersion | null {
+  const normalized = output.trim()
+  if (normalized.includes('\n') || normalized.includes('\r')) {
+    return null
+  }
+  const match = GIT_FOR_WINDOWS_VERSION_RE.exec(normalized)
+  if (!match) {
+    return null
+  }
+  const major = Number(match[1])
+  const minor = Number(match[2])
+  const patch = Number(match[3] ?? 0)
+  const build = match[4] === undefined ? null : Number(match[4])
+  if (
+    ![major, minor, patch].every((value) => Number.isSafeInteger(value) && value >= 0) ||
+    (build !== null && (!Number.isSafeInteger(build) || build < 0))
+  ) {
+    return null
+  }
+  return { major, minor, patch, build }
+}
+
+/** True only for Git for Windows 2.55 or newer. */
+export function supportsWindowsFscacheParallelCheckout(output: string): boolean {
+  const version = parseGitForWindowsVersion(output)
+  return version !== null && (version.major > 2 || (version.major === 2 && version.minor >= 55))
+}
+
+// `CapabilityProbeCache.runWithFallback` intentionally re-runs the preferred
+// callback after a positive probe. Version probing returns a value, so retain
+// that value separately while still using the shared support/retry semantics.
+const supportedValueByCache = new WeakMap<GitCapabilityCache, true>()
+const inFlightByCache = new WeakMap<GitCapabilityCache, Promise<boolean>>()
+
+/**
+ * Resolve whether this execution host's Git can safely use its default
+ * FSCache during parallel checkout. Failures and unknown versions fail closed.
+ * Concurrent callers share one `git --version` subprocess per capability cache.
+ */
+export async function resolveWindowsFscacheParallelCheckout(
+  capabilities: GitCapabilityCache,
+  probeGitVersion: () => Promise<string>
+): Promise<boolean> {
+  // A caller may clear and reuse a cache in tests or after host reinitializing;
+  // never let the side-map outlive the cache's support state.
+  if (supportedValueByCache.has(capabilities)) {
+    if (capabilities.isKnownSupported(WINDOWS_FSCACHE_PARALLEL_CHECKOUT_CAPABILITY)) {
+      return true
+    }
+    supportedValueByCache.delete(capabilities)
+  }
+  if (!capabilities.shouldTry(WINDOWS_FSCACHE_PARALLEL_CHECKOUT_CAPABILITY)) {
+    return false
+  }
+  const existing = inFlightByCache.get(capabilities)
+  if (existing) {
+    return existing
+  }
+
+  let probe!: Promise<boolean>
+  probe = (async (): Promise<boolean> => {
+    try {
+      const safe = supportsWindowsFscacheParallelCheckout(await probeGitVersion())
+      if (safe) {
+        supportedValueByCache.set(capabilities, true)
+        capabilities.rememberSupported(WINDOWS_FSCACHE_PARALLEL_CHECKOUT_CAPABILITY)
+      } else {
+        capabilities.rememberUnsupported(WINDOWS_FSCACHE_PARALLEL_CHECKOUT_CAPABILITY)
+      }
+      return safe
+    } catch {
+      // Unknown, timed out, or cancelled probes must not remove a safety flag.
+      capabilities.rememberUnsupported(WINDOWS_FSCACHE_PARALLEL_CHECKOUT_CAPABILITY)
+      return false
+    } finally {
+      if (inFlightByCache.get(capabilities) === probe) {
+        inFlightByCache.delete(capabilities)
+      }
+    }
+  })()
+  inFlightByCache.set(capabilities, probe)
+  return probe
+}

--- a/src/shared/windows-parallel-checkout-git-args.ts
+++ b/src/shared/windows-parallel-checkout-git-args.ts
@@ -1,39 +1,131 @@
 import { parseWslUncPath } from './wsl-paths'
+import type { GitCapabilityCache } from './git-capability-cache'
+import { resolveWindowsFscacheParallelCheckout } from './windows-parallel-checkout-capability'
 
-const WINDOWS_PARALLEL_CHECKOUT_GIT_ARGS = [
+const PARALLEL_CHECKOUT_GIT_ARGS = ['-c', 'checkout.workers=-1'] as const
+
+function isWslDrvFsPath(value: string, wslDistro?: string): boolean {
+  const parsed = parseWslUncPath(value)
+  // A drive-qualified cwd can still be executed by WSL when the caller has
+  // explicitly selected a distro (the runner translates C:\\... to
+  // /mnt/<drive>/...). Keep the conversion local to this policy helper so
+  // callers do not have to change the path passed to Git.
+  const driveMatch = value.match(/^([A-Za-z]):[\\/](.*)$/)
+  const linuxPath =
+    parsed?.linuxPath ??
+    (driveMatch && wslDistro?.trim()
+      ? `/mnt/${driveMatch[1].toLowerCase()}/${driveMatch[2].replace(/\\/g, '/')}`
+      : value)
+  // WSL's /mnt/<drive> mounts are DrvFS; unlike ext4, they benefit from the
+  // larger pool. Keep this spelling strict so ordinary /mnt-like directories
+  // are not silently classified as Windows-backed storage.
+  return /^\/mnt\/[a-z](?:\/|$)/.test(linuxPath)
+}
+
+function wslParallelCheckoutGitArgs(cwd: string, wslDistro?: string): string[] {
+  return isWslDrvFsPath(cwd, wslDistro) ? [...PARALLEL_CHECKOUT_GIT_ARGS] : []
+}
+
+// Git for Windows versions before 2.55 can return stale directory entries from
+// FSCache while parallel workers are writing. Keep the narrowly scoped workaround
+// for native Windows Git; WSL Git uses the Linux filesystem and does not need it.
+const NATIVE_WINDOWS_PARALLEL_CHECKOUT_GIT_ARGS = [
   '-c',
   'core.fscache=false',
-  '-c',
-  'checkout.workers=-1'
+  ...PARALLEL_CHECKOUT_GIT_ARGS
 ] as const
+
+export type WindowsParallelCheckoutGitArgsOptions = {
+  /** Omit the pre-2.55 FSCache workaround after a verified Git for Windows probe. */
+  fscacheSafe?: boolean
+  /** Override path inference when a C:\\ path is explicitly routed through WSL. */
+  nativeWindowsGit?: boolean
+}
 
 function isNativeWindowsAbsolutePath(value: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
 }
 
 /**
- * Enable Git's parallel checkout only for a native Windows Git invocation.
+ * Enable Git's parallel checkout for native Windows and WSL-routed Git.
  *
  * Git 2.25 (Orca's baseline) ignores the checkout.workers key, so older Git
  * remains sequential without a capability probe. Git for Windows releases
  * before the 2.55 fscache fix can fail when parallel workers observe stale
- * directory listings; disable that cache for this invocation to keep those
- * releases correct without changing the user's config. WSL paths and
- * explicit WSL routing stay untouched because their filesystem/runtime has
- * different costs.
+ * directory listings; disable that cache for native Windows invocations only,
+ * without changing the user's config. WSL Git only gets the worker setting on
+ * DrvFS paths; ext4 keeps Git's default because parallelism regresses there.
  */
 export function windowsParallelCheckoutGitArgs(
   cwd: string,
   platform: NodeJS.Platform = process.platform,
-  wslDistro?: string
+  wslDistro?: string,
+  options: WindowsParallelCheckoutGitArgsOptions = {}
 ): string[] {
-  if (
-    platform !== 'win32' ||
-    !isNativeWindowsAbsolutePath(cwd) ||
-    parseWslUncPath(cwd) ||
-    wslDistro
-  ) {
+  if (platform !== 'win32') {
     return []
   }
-  return [...WINDOWS_PARALLEL_CHECKOUT_GIT_ARGS]
+
+  // A UNC path under \wsl.localhost/\wsl$ is unambiguously executed by WSL.
+  // An explicit distro also marks a WSL route, including POSIX cwd values.
+  // Keep native drive/SMB paths on the FSCache-safe argv: linked-worktree
+  // routing may deliberately send a C:\ path back to host Git even when a
+  // distro override is present.
+  if (
+    parseWslUncPath(cwd) ||
+    options.nativeWindowsGit === false ||
+    (options.nativeWindowsGit !== true &&
+      wslDistro &&
+      wslDistro.trim().length > 0 &&
+      !isNativeWindowsAbsolutePath(cwd))
+  ) {
+    return wslParallelCheckoutGitArgs(cwd, wslDistro)
+  }
+  if (!isNativeWindowsAbsolutePath(cwd)) {
+    return []
+  }
+  return options.fscacheSafe
+    ? [...PARALLEL_CHECKOUT_GIT_ARGS]
+    : [...NATIVE_WINDOWS_PARALLEL_CHECKOUT_GIT_ARGS]
+}
+
+/**
+ * Resolve checkout arguments after probing the execution host's Git version.
+ *
+ * Callers must supply the cache and probe for native Windows Git. Omitting
+ * either keeps the pre-2.55 workaround, which is the safe behavior for old
+ * callers and for an ambiguous WSL/host route.
+ */
+export async function windowsParallelCheckoutGitArgsAsync(
+  cwd: string,
+  platform: NodeJS.Platform = process.platform,
+  wslDistro?: string,
+  options: WindowsParallelCheckoutGitArgsOptions & {
+    capabilities?: GitCapabilityCache
+    probeGitVersion?: () => Promise<string>
+  } = {}
+): Promise<string[]> {
+  const nativeWindowsGit =
+    options.nativeWindowsGit ?? (isNativeWindowsAbsolutePath(cwd) && parseWslUncPath(cwd) === null)
+  if (!nativeWindowsGit || platform !== 'win32') {
+    return windowsParallelCheckoutGitArgs(cwd, platform, wslDistro, {
+      ...options,
+      nativeWindowsGit
+    })
+  }
+  if (!options.capabilities || !options.probeGitVersion) {
+    return windowsParallelCheckoutGitArgs(cwd, platform, wslDistro, {
+      ...options,
+      nativeWindowsGit: true
+    })
+  }
+  const fscacheSafe = await resolveWindowsFscacheParallelCheckout(
+    options.capabilities,
+    options.probeGitVersion
+  )
+  return windowsParallelCheckoutGitArgs(cwd, platform, wslDistro, {
+    ...options,
+    nativeWindowsGit: true,
+    fscacheSafe
+  })
 }

--- a/src/shared/windows-parallel-checkout-git-args.ts
+++ b/src/shared/windows-parallel-checkout-git-args.ts
@@ -1,0 +1,30 @@
+import { parseWslUncPath } from './wsl-paths'
+
+const WINDOWS_PARALLEL_CHECKOUT_GIT_ARGS = ['-c', 'checkout.workers=-1'] as const
+
+function isNativeWindowsAbsolutePath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
+}
+
+/**
+ * Enable Git's parallel checkout only for a native Windows Git invocation.
+ *
+ * Git 2.25 (Orca's baseline) ignores this unknown config key, so older Git
+ * remains sequential without a capability probe. WSL paths and explicit WSL
+ * routing stay untouched because their filesystem/runtime has different costs.
+ */
+export function windowsParallelCheckoutGitArgs(
+  cwd: string,
+  platform: NodeJS.Platform = process.platform,
+  wslDistro?: string
+): string[] {
+  if (
+    platform !== 'win32' ||
+    !isNativeWindowsAbsolutePath(cwd) ||
+    parseWslUncPath(cwd) ||
+    wslDistro
+  ) {
+    return []
+  }
+  return [...WINDOWS_PARALLEL_CHECKOUT_GIT_ARGS]
+}

--- a/src/shared/windows-parallel-checkout-git-args.ts
+++ b/src/shared/windows-parallel-checkout-git-args.ts
@@ -72,7 +72,7 @@ export function windowsParallelCheckoutGitArgs(
   // routing may deliberately send a C:\ path back to host Git even when a
   // distro override is present.
   if (
-    parseWslUncPath(cwd) ||
+    (options.nativeWindowsGit !== true && parseWslUncPath(cwd)) ||
     options.nativeWindowsGit === false ||
     (options.nativeWindowsGit !== true &&
       wslDistro &&

--- a/src/shared/windows-parallel-checkout-git-args.ts
+++ b/src/shared/windows-parallel-checkout-git-args.ts
@@ -1,6 +1,11 @@
 import { parseWslUncPath } from './wsl-paths'
 
-const WINDOWS_PARALLEL_CHECKOUT_GIT_ARGS = ['-c', 'checkout.workers=-1'] as const
+const WINDOWS_PARALLEL_CHECKOUT_GIT_ARGS = [
+  '-c',
+  'core.fscache=false',
+  '-c',
+  'checkout.workers=-1'
+] as const
 
 function isNativeWindowsAbsolutePath(value: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
@@ -9,9 +14,13 @@ function isNativeWindowsAbsolutePath(value: string): boolean {
 /**
  * Enable Git's parallel checkout only for a native Windows Git invocation.
  *
- * Git 2.25 (Orca's baseline) ignores this unknown config key, so older Git
- * remains sequential without a capability probe. WSL paths and explicit WSL
- * routing stay untouched because their filesystem/runtime has different costs.
+ * Git 2.25 (Orca's baseline) ignores the checkout.workers key, so older Git
+ * remains sequential without a capability probe. Git for Windows releases
+ * before the 2.55 fscache fix can fail when parallel workers observe stale
+ * directory listings; disable that cache for this invocation to keep those
+ * releases correct without changing the user's config. WSL paths and
+ * explicit WSL routing stay untouched because their filesystem/runtime has
+ * different costs.
  */
 export function windowsParallelCheckoutGitArgs(
   cwd: string,


### PR DESCRIPTION
## ELI5

Worktree creation spends a surprising amount of time starting Git/WSL processes and checking refs before any files are materialized. This change overlaps independent checks and uses Git's parallel checkout only on storage where it helps, so creating a worktree can feel faster without changing the user's Git configuration.

## What Changed

- Enable per-invocation parallel checkout for native Windows worktree materialization, sparse checkout, and local-base refresh.
- Probe Git for Windows' FSCache behavior per execution host: Git 2.55+ keeps FSCache enabled; older or unknown versions use the existing safe `core.fscache=false` workaround.
- Apply parallel checkout to WSL DrvFS paths (`/mnt/<drive>`); keep WSL ext4 on Git's default because larger ext4 measurements regressed.
- Route Windows-linked worktrees to the Git host that owns their `.git` marker and classify checkout policy from the final materialization path (including relay/UNC paths).
- Batch or overlap default-base, branch-conflict, local/remote OID, remote-base, workspace-root, and push-config preflights; reuse remote-base results during create.
- Avoid sparse-checkout probes when callers only need worktree registration metadata.
- Invalidate route caches around add, preparation, move, remove, rollback, and failed operations; fence in-flight probes so stale results cannot repopulate a cache after mutation.
- Preserve Git 2.25-compatible fallbacks, Windows long-path arguments, SSH/execution-host semantics, and folder-workspace behavior.

## Why

The largest measured cost on Windows/WSL was process startup and serial preflight work, followed by checkout materialization on larger NTFS/DrvFS trees. The policy is intentionally adaptive: ext4 stays conservative, and unknown or failed capability probes fail closed.

## Linked Issue

Follow-up to #17290 (Windows/WSL worktree-create performance investigation). #13704 is intentionally not included.

## Visual Proof

N/A — no renderer/UI surface changed.

## Testing

- Focused routing, long-path, preparation, and create-flow suites: 21 files passed (1 skipped), 1,460 tests passed (11 skipped); isolated metadata and null-retry regressions pass.
- `pnpm tc:node` passed.
- `pnpm run check:code-quality:changed` passed with 0 findings.
- `pnpm check:max-lines-ratchet` passed.
- `git diff --check` clean.
- awin Windows 11 / Git 2.55, ~20k-file NTFS checkout: sequential 4.668/4.774/4.898s vs checkout.workers=-1 4.070/4.233/4.525s (~8–13% faster); adding core.fscache=false did not improve it. Small trees are neutral/slightly slower.
- openclaw SSH Ubuntu 24.04 / Git 2.43 raw ~6,000-file ext4 checkout: default median ~127ms; workers=4 ~75ms; workers=-1 ~74ms. Larger ext4 runs regressed, so ext4 remains on Git's default.
- Live WSL distro and m4air app-level runs were unavailable; deterministic routing/argv tests cover those paths.
- awin host smoke (Windows 11 / Git 2.55) passed the routing and worktree-add tests on a baseline checkout; its OS long-path policy is disabled (LongPathsEnabled=0, core.longpaths unset), so this PR does not mutate that policy.

- [x] Automated tests added/updated
- [ ] Manual packaged Electron testing (platform hosts unavailable for final rebased commit)
- [x] GitHub CI run 33376899593: static analysis, typecheck, Git compatibility, Linux/Windows packaging, all 8 Node 24 test shards, and guards passed.

## AI Disclosure

AI-assisted implementation and review (Codex).

## Review

Please review the commits in order; they separate routing correctness, capability safety, adaptive checkout policy, and independent preflight batching.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- The linked-worktree route cache has a bounded 30-second TTL; a path whose `.git` shape changes during that interval can briefly retain a conservative route.
- Unknown Git versions, failed probes, and unsupported older Git fall back safely.
- No mobile-facing wire/schema surface changed.
- No packaged Electron Windows E2E run was possible for the final rebased commit; CI should provide the remaining build/platform coverage.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (CI will cover full suite/build; focused checks listed above)


