### PR TITLE
test(updater): fix startup-scheduling flake from leaked timers in abandoned module instances

### DIFF
--- a/src/main/updater-test-harness.ts
+++ b/src/main/updater-test-harness.ts
@@ -123,7 +123,35 @@ export function createUpdaterMocks(): UpdaterMocks {
     }
   }
 
+  // Why: `vi.resetModules()` abandons the previous test's `updater` module instance but cannot cancel
+  // the real timers it armed (1s silent-settle, 45s stall, 24h auto-check). Those fire during a later
+  // test — re-arming on that test's fake clock — and drove these shared spies, so a stale instance
+  // could land an extra `checkForUpdates()` inside the window under assertion.
+  let currentGeneration = 0
+
+  /**
+   * Hands each `updater` module instance an autoUpdater view stamped with the generation that loaded
+   * it. Once `resetUpdaterMocks` bumps the generation, the abandoned instance's calls and property
+   * writes are dropped instead of reaching the spies the running test asserts on.
+   */
+  const loadGenerationScopedAutoUpdater = (): AutoUpdaterMock => {
+    const loadedGeneration = currentGeneration
+    return new Proxy(autoUpdaterMock, {
+      get(target, property) {
+        const value = Reflect.get(target, property)
+        if (loadedGeneration === currentGeneration || typeof value !== 'function') {
+          return value
+        }
+        return () => undefined
+      },
+      set(target, property, value) {
+        return loadedGeneration === currentGeneration ? Reflect.set(target, property, value) : true
+      }
+    }) as AutoUpdaterMock
+  }
+
   const reset = () => {
+    currentGeneration += 1
     appEventHandlers.clear()
     appOn.mockClear()
     eventHandlers.clear()
@@ -199,7 +227,7 @@ export function createUpdaterMocks(): UpdaterMocks {
       net: { fetch: vi.fn() }
     }),
     electronUpdater: () => ({ autoUpdater: autoUpdaterMock }),
-    electronUpdaterLoader: () => ({ loadElectronAutoUpdater: () => autoUpdaterMock }),
+    electronUpdaterLoader: () => ({ loadElectronAutoUpdater: loadGenerationScopedAutoUpdater }),
     electronToolkitUtils: () => ({ is: isMock }),
     ipcPty: () => ({ killAllPty: killAllPtyMock }),
     // Why: only the marker resolver is faked so the real artifact capture/redaction path stays under test.


### PR DESCRIPTION
## Root cause

`resetUpdaterMocks()` calls `vi.resetModules()`, which abandons the previous test's `updater` module instance but **cannot cancel the real timers that instance already armed**.

The earlier real-timer tests in the file (`runs a startup check immediately when the last background check is stale`, `starts nudge polling only after updater initialization is complete`) each launch a background check whose promise resolves with no terminal event, so `handleSettledUpdateCheckPromise()` arms a **real 1s `updateCheckSilentSettleTimer`**. That timer is still pending when the test ends.

It then fires a second or so later — during a *later* test that has since installed a fake clock. The abandoned instance runs `settleSilentUpdateCheck()` → `completeSilentUpdateCheck()` → `scheduleAutomaticUpdateCheck(AUTO_UPDATE_CHECK_INTERVAL_MS)`, which arms a **24h timer on the running test's fake clock, at that clock's epoch**.

`reschedules the next automatic check 24 hours after finding an available update` sets the clock to `t0`, advances `1h` (its own check → call #1), then advances `23h`. The stale 24h timer lands at exactly `t0 + 24h` — the last tick of that 23h window — and the abandoned instance calls `runBackgroundUpdateCheck()`, which hits the **shared** `autoUpdaterMock.checkForUpdates` spy. Hence `expected 1, got 2` at line 243.

Instrumented failing trace (fake-clock timestamps, `t0 = 1775217600000`):

```
schedule delay=3600000  now=t0       at setupAutoUpdater (test line 222)      <- this test's 1h timer
silentSettle fired      now=t0       state=idle launchPending=true            <- LEAKED instance
schedule delay=86400000 now=t0       at completeSilentUpdateCheck             <- leaked 24h timer on this clock
autoTimer fired         now=t0+1h
launch checkForUpdates  now=t0+1h                                             <- call #1 (expected)
schedule delay=86400000 now=t0+1h    at updater-events.ts:226                 <- the reschedule under test
autoTimer fired         now=t0+24h                                            <- leaked timer
launch checkForUpdates  now=t0+24h                                            <- call #2 (the failure)
```

Whether the leaked real timer fires before or after the next test installs its fake clock is real-wall-clock dependent — hence the intermittency.

## Test bug or product bug?

**Test bug (test isolation).** Not a product bug.

Production loads `updater.ts` exactly once and runs on one clock, so a second, abandoned module instance cannot exist. The 1s silent-settle grace period, and its `recordCompletedUpdateCheck()` + 24h reschedule for a check that resolved without a terminal event, are the documented intended behavior. Nothing here can double-fire an update check for a real user. I specifically checked the alternative hypotheses (an unpinned `Date.now()`-derived delay, the startup check racing the scheduled check, an unawaited promise letting two checks overlap, the 45s stall timer re-arming a retry) — none of them fire in this scenario.

## Fix

The harness already detaches abandoned module instances on the **event** side: `reset()` clears the `app` and `autoUpdater` handler maps, so a stale instance's listeners never receive anything. The gap was the **call** side — a stale instance could still drive the shared spies.

`loadElectronAutoUpdater()` now hands each module instance a generation-stamped view of `autoUpdaterMock`, and `reset()` bumps the generation. Once a new test starts, the previous instance's calls and property writes are dropped instead of reaching the spies the running test asserts on. `getAutoUpdater()` caches its result per module instance, so the generation is captured exactly once per instance, at load time.

One file changed, test-only (`src/main/updater-test-harness.ts`). No product code touched.

## Reproduction evidence

- Failed in CI on #17638, which touches only three `config/` packaging scripts that this test never imports.
- Reproduced locally on a branch without #17638: **1 failure in 12 runs**, and again **1 failure in 15 runs** on this branch before the fix (same assertion, same line).
- Running only the failing test (`-t 'reschedules the next automatic check'`) passed **30/30** — confirming the flake requires the earlier tests in the file to leak timers, and ruling out an intra-test race.

## Verification

- `pnpm test src/main/updater.startup-scheduling.test.ts` looped **40 times: 40 passed, 0 failed**.
- `pnpm test src/main/updater` — 22 files, 264 tests, all passing.
- `pnpm exec oxlint src/main/updater-test-harness.ts` — clean.
- `pnpm tc` — clean.


## Scope of this fix — read before assuming the class is closed

Reviewed independently; nothing blocking. Two clarifications from that review worth recording:

**Affected surface is narrower than the verification scope.** Only 9 files consume `createUpdaterMocks` + `moduleFactories.electronUpdaterLoader()` (~107 tests): build-channel-selection, check-preflight, check-settlement, linux-root-package-install, nudge-campaign, prerelease-fallback, publishing-window-feed, quit-and-install, startup-scheduling. The remaining `updater.*` test files define their own local `autoUpdaterMock` and are untouched.

**This fences one channel, not the whole leak.** The generation fence stops an abandoned instance from driving the `autoUpdater` spies, but the same leaked timer still reaches other shared spies further down the chain — `runBackgroundUpdateCheck()` → `pinDefaultReleaseFeed()` → `fetchNewerReleaseTagsMock` (`updater.ts:1357`), and `scheduleUpdateNudgeCheck()` → `fetchNudgeMock` / `shouldApplyNudgeMock` (`updater.ts:2122-2130`). Exact call-count assertions exist on both (`updater.check-preflight.test.ts:59,309,528`; `updater.publishing-window-feed.test.ts:382,458`; `updater.nudge-campaign.test.ts:168,175`). `completeSilentUpdateCheck` can also arm the 1h retry (`updater.ts:553`), and several files advance exactly 59min + 1min — a live boundary.

So this is a strict improvement that fixes the observed flake, not a closure of the class. The general fix is for `resetUpdaterMocks()` to track real `setTimeout` handles issued since the last reset and clear them (fake timers are already discarded by `vi.useRealTimers()`, so real timers are the only leak). Filed as follow-up.

**One invariant to preserve:** the generation is captured at the first `getAutoUpdater()` call (`updater.ts:199-204`), not at module import. The fence works because every timer-arming path currently runs after `getAutoUpdater()` at `updater.ts:2206`. A future path that arms a timer before that would capture the new generation and silently defeat the fence.
