### PR TITLE
fix(orchestration): stamp and lift the settled worker resume fence (STA-4577)

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -22138,6 +22138,154 @@ describe('OrcaRuntimeService', () => {
     expect(harness.resolveLegacyWorkerTerminalRecovery).not.toHaveBeenCalled()
   })
 
+  // Why (STA-4577): between worker_done and release the pane still holds a resumable provider
+  // session, so returning to the workspace would cold-restore it unless the fence lands first.
+  it('pushes the automatic-resume fence to the renderer for a settled worker pane', () => {
+    const workerPaneKey = `legacy-settled:${HEADLESS_LEAF_ID}`
+    const session: WorkspaceSessionState = {
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: { [TEST_WORKTREE_ID]: [] },
+      sleepingAgentSessionsByPaneKey: {
+        [workerPaneKey]: {
+          paneKey: workerPaneKey,
+          tabId: 'legacy-settled',
+          worktreeId: TEST_WORKTREE_ID,
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'legacy-settled-session' },
+          prompt: '',
+          state: 'done',
+          capturedAt: 1,
+          updatedAt: 1,
+          origin: 'live'
+        }
+      }
+    }
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(session)
+    const runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow: vi.fn() } as never)
+    runtime.setOrchestrationDb({
+      getActiveDispatchForTerminal: () => undefined,
+      listLegacyWorkerTerminalRecoveryRows: () => [
+        {
+          dispatch_id: 'dispatch-settled',
+          task_id: 'task-settled',
+          dispatch_status: 'completed',
+          contract_version: 0,
+          assignee_handle: 'term_settled',
+          assignee_pane_key: workerPaneKey,
+          process_incarnation: null,
+          worker_state: 'succeeded',
+          worktree_id: TEST_WORKTREE_ID,
+          agent_terminal_handle: 'term_settled'
+        }
+      ]
+    } as unknown as OrchestrationDb)
+    const resolveLegacyWorkerTerminalRecovery = vi.fn()
+    runtime.setNotifier({ resolveLegacyWorkerTerminalRecovery } as never)
+
+    const plan = runtime.prepareLegacyWorkerTerminalRecovery()
+
+    expect(plan.candidates).toEqual([])
+    expect(resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(workerPaneKey, 'fenced', {
+      worktreeId: TEST_WORKTREE_ID
+    })
+    expect(
+      getSession().sleepingAgentSessionsByPaneKey?.[workerPaneKey]?.automaticResumeBlockedBy
+    ).toBe('legacy-orchestration-worker')
+  })
+
+  // Why (STA-4577): `startFreshSpawn` refuses any fenced pane, so a fence that outlived its
+  // dispatch — release proven, user retained, or row pruned — would strand an unusable terminal.
+  it('lifts the automatic-resume fence once no dispatch claims the pane', () => {
+    const workerPaneKey = `legacy-retired:${HEADLESS_LEAF_ID}`
+    const session: WorkspaceSessionState = {
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: { [TEST_WORKTREE_ID]: [] },
+      sleepingAgentSessionsByPaneKey: {
+        [workerPaneKey]: {
+          paneKey: workerPaneKey,
+          tabId: 'legacy-retired',
+          worktreeId: TEST_WORKTREE_ID,
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'legacy-retired-session' },
+          prompt: '',
+          state: 'done',
+          capturedAt: 1,
+          updatedAt: 1,
+          origin: 'live',
+          automaticResumeBlockedBy: 'legacy-orchestration-worker'
+        }
+      }
+    }
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(session)
+    const runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow: vi.fn() } as never)
+    const listLegacyWorkerTerminalRecoveryRows = vi.fn(() => [])
+    runtime.setOrchestrationDb({
+      getActiveDispatchForTerminal: () => undefined,
+      listLegacyWorkerTerminalRecoveryRows
+    } as unknown as OrchestrationDb)
+    const resolveLegacyWorkerTerminalRecovery = vi.fn()
+    runtime.setNotifier({ resolveLegacyWorkerTerminalRecovery } as never)
+
+    runtime.prepareLegacyWorkerTerminalRecovery()
+
+    expect(resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(workerPaneKey, 'unfenced', {
+      worktreeId: TEST_WORKTREE_ID
+    })
+    expect(
+      getSession().sleepingAgentSessionsByPaneKey?.[workerPaneKey]?.automaticResumeBlockedBy
+    ).toBeUndefined()
+  })
+
+  // Why: an unreadable plan is not evidence the dispatch retired, so the fence must survive it.
+  it('keeps the automatic-resume fence when the recovery plan cannot be read', () => {
+    const workerPaneKey = `legacy-unreadable:${HEADLESS_LEAF_ID}`
+    const session: WorkspaceSessionState = {
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: { [TEST_WORKTREE_ID]: [] },
+      sleepingAgentSessionsByPaneKey: {
+        [workerPaneKey]: {
+          paneKey: workerPaneKey,
+          tabId: 'legacy-unreadable',
+          worktreeId: TEST_WORKTREE_ID,
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'legacy-unreadable-session' },
+          prompt: '',
+          state: 'done',
+          capturedAt: 1,
+          updatedAt: 1,
+          origin: 'live',
+          automaticResumeBlockedBy: 'legacy-orchestration-worker'
+        }
+      }
+    }
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(session)
+    const runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow: vi.fn() } as never)
+    runtime.setOrchestrationDb({
+      getActiveDispatchForTerminal: () => undefined,
+      listLegacyWorkerTerminalRecoveryRows: () => {
+        throw new Error('orchestration_db_unavailable')
+      }
+    } as unknown as OrchestrationDb)
+    const resolveLegacyWorkerTerminalRecovery = vi.fn()
+    runtime.setNotifier({ resolveLegacyWorkerTerminalRecovery } as never)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      expect(runtime.prepareLegacyWorkerTerminalRecovery()).toEqual({
+        blockedPanes: [],
+        candidates: [],
+        ambiguousDispatchIds: []
+      })
+    } finally {
+      warn.mockRestore()
+    }
+
+    expect(resolveLegacyWorkerTerminalRecovery).not.toHaveBeenCalled()
+    expect(
+      getSession().sleepingAgentSessionsByPaneKey?.[workerPaneKey]?.automaticResumeBlockedBy
+    ).toBe('legacy-orchestration-worker')
+  })
+
   it('reconciles a same-id process replacement before headless adoption', async () => {
     const exactProcess = {
       id: 'pty-post-reveal',
@@ -22172,7 +22320,7 @@ describe('OrcaRuntimeService', () => {
     expect(harness.resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(
       harness.workerPaneKey,
       'rolled_back',
-      harness.ptyId
+      { ptyId: harness.ptyId }
     )
     expect(harness.resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(
       harness.workerPaneKey,
@@ -22240,7 +22388,7 @@ describe('OrcaRuntimeService', () => {
     expect(harness.resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(
       harness.workerPaneKey,
       'rolled_back',
-      harness.ptyId
+      { ptyId: harness.ptyId }
     )
     expect(harness.resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(
       harness.workerPaneKey,
@@ -22461,7 +22609,7 @@ describe('OrcaRuntimeService', () => {
       expect(resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(
         workerPaneKey,
         'rolled_back',
-        'pty-missing-worker'
+        { ptyId: 'pty-missing-worker' }
       )
       expect(resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(workerPaneKey, 'exited')
     } finally {
@@ -22570,7 +22718,7 @@ describe('OrcaRuntimeService', () => {
       expect(resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(
         workerPaneKey,
         'rolled_back',
-        'pty-missing-retry'
+        { ptyId: 'pty-missing-retry' }
       )
       expect(resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(workerPaneKey, 'exited')
       warn.mockRestore()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -55,7 +55,8 @@ import {
   type AgentStatusIpcPayload,
   type ParsedAgentStatusPayload,
   type AgentStatusOrchestrationContext,
-  type AgentStatusEntry
+  type AgentStatusEntry,
+  type LegacyWorkerTerminalRecoveryResolutionKind
 } from '../../shared/agent-status-types'
 import { terminalStatusPayloadMatchesHook } from '../../shared/agent-terminal-status-equivalence'
 import { indexAgentStatusRowsByPaneKey } from '../agent-hooks/agent-status-pane-index'
@@ -2410,8 +2411,8 @@ type RuntimeNotifier = {
     | void
   resolveLegacyWorkerTerminalRecovery?(
     paneKey: string,
-    resolution: 'adopted' | 'exited' | 'rolled_back',
-    ptyId?: string
+    resolution: LegacyWorkerTerminalRecoveryResolutionKind,
+    identity?: { ptyId?: string; worktreeId?: string }
   ): void
   splitTerminal(
     tabId: string,
@@ -4717,19 +4718,36 @@ export class OrcaRuntimeService {
     this.scheduleRestoredMessageRepoints()
   }
 
-  private getLegacyWorkerTerminalRecoveryPlan(): LegacyWorkerTerminalRecoveryPlan {
+  private getLegacyWorkerTerminalRecoveryPlan(): LegacyWorkerTerminalRecoveryPlan | null {
     try {
       return planLegacyWorkerTerminalRecovery(
         this.getOrchestrationDb().listLegacyWorkerTerminalRecoveryRows()
       )
     } catch (error) {
       console.warn('[orchestration] failed to plan legacy worker terminal recovery', error)
-      return { blockedPanes: [], candidates: [], ambiguousDispatchIds: [] }
+      return null
     }
   }
 
   prepareLegacyWorkerTerminalRecovery(): LegacyWorkerTerminalRecoveryPlan {
     const plan = this.getLegacyWorkerTerminalRecoveryPlan()
+    if (!plan) {
+      // Why: an unreadable plan is not evidence that any pane stopped needing its fence, so fail
+      // closed — stamp nothing, lift nothing, and retry on the next reconcile pass.
+      return { blockedPanes: [], candidates: [], ambiguousDispatchIds: [] }
+    }
+    // Why: the live store, not the persisted session, is what the pane's cold restore reads,
+    // so a settled worker's fence has to reach the renderer even when persistence is unavailable.
+    // Live dispatches stay persistence-only — fencing them would block their own restart.
+    // Note: both stamps address the dispatch's exact `assignee_pane_key`; a record still filed under
+    // a legacy numeric pane alias is not reached, same as the pre-existing persisted stamp.
+    for (const blocked of plan.blockedPanes) {
+      if (blocked.settled) {
+        this.notifier?.resolveLegacyWorkerTerminalRecovery?.(blocked.paneKey, 'fenced', {
+          worktreeId: blocked.worktreeId
+        })
+      }
+    }
     const store = this.store
     if (
       !store?.getWorkspaceSession ||
@@ -4782,6 +4800,7 @@ export class OrcaRuntimeService {
         changedHostIds.add(hostId)
       }
     }
+    this.liftRetiredLegacyWorkerResumeFences(plan, sessions, changedHostIds)
     const changed = [...sessions].filter(([hostId]) => changedHostIds.has(hostId))
     if (changed.length === 0) {
       return plan
@@ -4794,6 +4813,54 @@ export class OrcaRuntimeService {
       console.warn('[orchestration] failed to stage legacy worker resume fence', error)
     }
     return plan
+  }
+
+  /**
+   * Why: `startFreshSpawn` refuses any fenced pane, so a fence that outlives its dispatch leaves a
+   * terminal that can never spawn again. Release, user retain, and dispatch pruning all drop the
+   * row from the recovery plan — that is the signal to retire the fence.
+   */
+  private liftRetiredLegacyWorkerResumeFences(
+    plan: LegacyWorkerTerminalRecoveryPlan,
+    sessions: Map<ExecutionHostId, { current: WorkspaceSessionState; next: WorkspaceSessionState }>,
+    changedHostIds: Set<ExecutionHostId>
+  ): void {
+    const store = this.store
+    if (!store?.getWorkspaceSession) {
+      return
+    }
+    const blockedPaneKeys = new Set(plan.blockedPanes.map((blocked) => blocked.paneKey))
+    for (const hostId of store.getWorkspaceSessionHostIds?.() ?? [LOCAL_EXECUTION_HOST_ID]) {
+      const staged = sessions.get(hostId)
+      const session = staged?.next ?? store.getWorkspaceSession(hostId)
+      const retired = Object.entries(session?.sleepingAgentSessionsByPaneKey ?? {}).filter(
+        ([paneKey, record]) =>
+          record.automaticResumeBlockedBy === 'legacy-orchestration-worker' &&
+          !blockedPaneKeys.has(paneKey)
+      )
+      if (retired.length === 0) {
+        continue
+      }
+      let state = staged
+      if (!state) {
+        const current = store.getWorkspaceSession(hostId)
+        if (!current) {
+          continue
+        }
+        state = { current, next: structuredClone(current) }
+        sessions.set(hostId, state)
+      }
+      const next = { ...state.next.sleepingAgentSessionsByPaneKey }
+      for (const [paneKey, record] of retired) {
+        const { automaticResumeBlockedBy: _retiredFence, ...unfenced } = record
+        next[paneKey] = unfenced
+        this.notifier?.resolveLegacyWorkerTerminalRecovery?.(paneKey, 'unfenced', {
+          worktreeId: record.worktreeId
+        })
+      }
+      state.next.sleepingAgentSessionsByPaneKey = next
+      changedHostIds.add(hostId)
+    }
   }
 
   private async flushWorkspaceSessionOrThrowAsync(): Promise<void> {
@@ -5042,11 +5109,9 @@ export class OrcaRuntimeService {
       pty.tabId = null
       pty.paneKey = null
     }
-    this.notifier?.resolveLegacyWorkerTerminalRecovery?.(
-      candidate.paneKey,
-      'rolled_back',
-      candidate.ptyId
-    )
+    this.notifier?.resolveLegacyWorkerTerminalRecovery?.(candidate.paneKey, 'rolled_back', {
+      ptyId: candidate.ptyId
+    })
   }
 
   private updateLegacyWorkerTerminalRecoveryRetry(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4718,6 +4718,11 @@ export class OrcaRuntimeService {
     this.scheduleRestoredMessageRepoints()
   }
 
+  // Why: the renderer fence is pushed live, so it can exist with no persisted record behind it
+  // (session sync lag, persistence unavailable). Remembering what this runtime fenced is the only
+  // way to guarantee an `unfenced` push later — otherwise that pane stays unspawnable until restart.
+  private readonly rendererFencedWorkerPaneWorktreeIds = new Map<string, string>()
+
   private getLegacyWorkerTerminalRecoveryPlan(): LegacyWorkerTerminalRecoveryPlan | null {
     try {
       return planLegacyWorkerTerminalRecovery(
@@ -4746,8 +4751,13 @@ export class OrcaRuntimeService {
         this.notifier?.resolveLegacyWorkerTerminalRecovery?.(blocked.paneKey, 'fenced', {
           worktreeId: blocked.worktreeId
         })
+        this.rendererFencedWorkerPaneWorktreeIds.set(blocked.paneKey, blocked.worktreeId)
       }
     }
+    const blockedPaneKeys = new Set(plan.blockedPanes.map((blocked) => blocked.paneKey))
+    // Why: run before the persistence bail-out below — a fence this runtime pushed must be liftable
+    // even when the workspace session is unreadable.
+    const rendererLifted = this.liftRendererLegacyWorkerResumeFences(blockedPaneKeys)
     const store = this.store
     if (
       !store?.getWorkspaceSession ||
@@ -4800,7 +4810,12 @@ export class OrcaRuntimeService {
         changedHostIds.add(hostId)
       }
     }
-    this.liftRetiredLegacyWorkerResumeFences(plan, sessions, changedHostIds)
+    this.liftRetiredLegacyWorkerResumeFences(
+      blockedPaneKeys,
+      sessions,
+      changedHostIds,
+      rendererLifted
+    )
     const changed = [...sessions].filter(([hostId]) => changedHostIds.has(hostId))
     if (changed.length === 0) {
       return plan
@@ -4820,16 +4835,31 @@ export class OrcaRuntimeService {
    * terminal that can never spawn again. Release, user retain, and dispatch pruning all drop the
    * row from the recovery plan — that is the signal to retire the fence.
    */
+  private liftRendererLegacyWorkerResumeFences(
+    blockedPaneKeys: ReadonlySet<string>
+  ): ReadonlySet<string> {
+    const lifted = new Set<string>()
+    for (const [paneKey, worktreeId] of this.rendererFencedWorkerPaneWorktreeIds) {
+      if (blockedPaneKeys.has(paneKey)) {
+        continue
+      }
+      this.rendererFencedWorkerPaneWorktreeIds.delete(paneKey)
+      this.notifier?.resolveLegacyWorkerTerminalRecovery?.(paneKey, 'unfenced', { worktreeId })
+      lifted.add(paneKey)
+    }
+    return lifted
+  }
+
   private liftRetiredLegacyWorkerResumeFences(
-    plan: LegacyWorkerTerminalRecoveryPlan,
+    blockedPaneKeys: ReadonlySet<string>,
     sessions: Map<ExecutionHostId, { current: WorkspaceSessionState; next: WorkspaceSessionState }>,
-    changedHostIds: Set<ExecutionHostId>
+    changedHostIds: Set<ExecutionHostId>,
+    alreadyLifted: ReadonlySet<string>
   ): void {
     const store = this.store
     if (!store?.getWorkspaceSession) {
       return
     }
-    const blockedPaneKeys = new Set(plan.blockedPanes.map((blocked) => blocked.paneKey))
     for (const hostId of store.getWorkspaceSessionHostIds?.() ?? [LOCAL_EXECUTION_HOST_ID]) {
       const staged = sessions.get(hostId)
       const session = staged?.next ?? store.getWorkspaceSession(hostId)
@@ -4854,6 +4884,10 @@ export class OrcaRuntimeService {
       for (const [paneKey, record] of retired) {
         const { automaticResumeBlockedBy: _retiredFence, ...unfenced } = record
         next[paneKey] = unfenced
+        this.rendererFencedWorkerPaneWorktreeIds.delete(paneKey)
+        if (alreadyLifted.has(paneKey)) {
+          continue
+        }
         this.notifier?.resolveLegacyWorkerTerminalRecovery?.(paneKey, 'unfenced', {
           worktreeId: record.worktreeId
         })

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-terminal-recovery.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-terminal-recovery.ts
@@ -8,6 +8,7 @@ import { OrchestrationError } from '../../orchestration-error'
 import { DISPATCH_CIRCUIT_BREAK_FAILURES } from '../dispatch-context/dispatch-circuit-breaker'
 import type { OrchestrationDb } from '../orchestration-db'
 import { reconcileTaskAfterDispatchInterruption } from '../dispatch-context/task-dispatch-reconciliation'
+import { WORKER_SETTLED_STATES } from '../../worker-terminal-ownership'
 
 export function listLegacyWorkerTerminalRecoveryRows(
   this: OrchestrationDb
@@ -21,9 +22,18 @@ export function listLegacyWorkerTerminalRecoveryRows(
        FROM dispatch_contexts dc
        INNER JOIN worker_dispatches wd ON wd.dispatch_id = dc.id
        WHERE wd.state IN ('starting', 'ready', 'start_unknown', 'stopping', 'stop_unknown')
+          -- Why: a settled worker whose terminal Orca still owns keeps a resumable agent
+          -- session, so it needs the resume fence until release actually retires the pane.
+          OR (wd.state IN (${WORKER_SETTLED_STATES.map(() => '?').join(', ')})
+              AND EXISTS (
+                SELECT 1 FROM worker_terminal_resources wtr
+                WHERE wtr.owner_dispatch_id = dc.id
+                  AND wtr.ownership_state = 'owned'
+                  AND wtr.release_state NOT IN ('released', 'retained')
+              ))
        ORDER BY dc.rowid`
     )
-    .all() as LegacyWorkerTerminalRecoveryRow[]
+    .all(...WORKER_SETTLED_STATES) as LegacyWorkerTerminalRecoveryRow[]
 }
 
 export function reconcileMissingWorkerTerminal(

--- a/src/main/runtime/orchestration/orchestration-legacy-worker-terminal-recovery.test.ts
+++ b/src/main/runtime/orchestration/orchestration-legacy-worker-terminal-recovery.test.ts
@@ -30,7 +30,8 @@ describe('legacy worker terminal recovery planning', () => {
         {
           worktreeId: 'repo::/workspace',
           paneKey: `tab-worker:${LEAF_ID}`,
-          contractVersion: 0
+          contractVersion: 0,
+          settled: false
         }
       ],
       candidates: [
@@ -52,12 +53,44 @@ describe('legacy worker terminal recovery planning', () => {
         {
           worktreeId: 'repo::/workspace',
           paneKey: `tab-worker:${LEAF_ID}`,
-          contractVersion: 0
+          contractVersion: 0,
+          settled: false
         }
       ],
       candidates: [],
       ambiguousDispatchIds: []
     })
+  })
+
+  it('fences a settled worker pane without offering its terminal for adoption', () => {
+    const plan = planLegacyWorkerTerminalRecovery([
+      recoveryRow({ worker_state: 'succeeded', dispatch_status: 'completed' })
+    ])
+
+    expect(plan).toEqual({
+      blockedPanes: [
+        {
+          worktreeId: 'repo::/workspace',
+          paneKey: `tab-worker:${LEAF_ID}`,
+          contractVersion: 0,
+          settled: true
+        }
+      ],
+      candidates: [],
+      ambiguousDispatchIds: []
+    })
+  })
+
+  it('does not let a settled row make a live worker’s terminal identity ambiguous', () => {
+    const plan = planLegacyWorkerTerminalRecovery([
+      recoveryRow({ dispatch_id: 'dispatch-settled', worker_state: 'succeeded' }),
+      recoveryRow({ dispatch_id: 'dispatch-live' })
+    ])
+
+    expect(plan.candidates).toEqual([expect.objectContaining({ dispatchId: 'dispatch-live' })])
+    expect(plan.ambiguousDispatchIds).toEqual([])
+    // A live dispatch still holds this pane, so it must not be pushed as a settled fence.
+    expect(plan.blockedPanes).toEqual([expect.objectContaining({ settled: false })])
   })
 
   it('fails closed when two Dispatches claim one terminal identity', () => {

--- a/src/main/runtime/orchestration/orchestration-legacy-worker-terminal-recovery.ts
+++ b/src/main/runtime/orchestration/orchestration-legacy-worker-terminal-recovery.ts
@@ -1,6 +1,7 @@
 import { isPtyIncarnationId, type PtyIncarnationId } from '../../../shared/pty-incarnation'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import type { LegacyWorkerTerminalRecoveryRow } from './types'
+import { WORKER_SETTLED_STATES } from './worker-terminal-ownership'
 
 export type LegacyWorkerTerminalRecoveryCandidate = {
   dispatchId: string
@@ -17,8 +18,16 @@ export type LegacyWorkerTerminalRecoveryCandidate = {
   incarnationId: PtyIncarnationId
 }
 
+export type LegacyWorkerTerminalRecoveryBlockedPane = {
+  worktreeId: string
+  paneKey: string
+  contractVersion: number
+  /** The dispatch reported an outcome; its pane needs the fence but owns no process to recover. */
+  settled: boolean
+}
+
 export type LegacyWorkerTerminalRecoveryPlan = {
-  blockedPanes: { worktreeId: string; paneKey: string; contractVersion: number }[]
+  blockedPanes: LegacyWorkerTerminalRecoveryBlockedPane[]
   candidates: LegacyWorkerTerminalRecoveryCandidate[]
   ambiguousDispatchIds: string[]
 }
@@ -50,21 +59,29 @@ function countCandidateKeys(
 export function planLegacyWorkerTerminalRecovery(
   rows: readonly LegacyWorkerTerminalRecoveryRow[]
 ): LegacyWorkerTerminalRecoveryPlan {
-  const blockedPanes = new Map<
-    string,
-    { worktreeId: string; paneKey: string; contractVersion: number }
-  >()
+  const blockedPanes = new Map<string, LegacyWorkerTerminalRecoveryBlockedPane>()
   const parsedCandidates: LegacyWorkerTerminalRecoveryCandidate[] = []
   for (const row of rows) {
     const worktreeId = row.worktree_id?.trim()
     const paneKey = row.assignee_pane_key?.trim()
     const pane = paneKey ? parsePaneKey(paneKey) : null
+    const settled = WORKER_SETTLED_STATES.includes(row.worker_state)
     if (worktreeId && paneKey && pane) {
-      blockedPanes.set(`${worktreeId}\0${paneKey}`, {
+      const blockedKey = `${worktreeId}\0${paneKey}`
+      const alreadySettled = blockedPanes.get(blockedKey)?.settled
+      blockedPanes.set(blockedKey, {
         worktreeId,
         paneKey,
-        contractVersion: row.contract_version
+        contractVersion: row.contract_version,
+        // Why: a pane reused across dispatches is only settled once every dispatch holding it is,
+        // so the first row seeds and any live row demotes it.
+        settled: (alreadySettled ?? true) && settled
       })
+    }
+    // Why: a settled worker owns no live process to adopt or roll back — it only needs
+    // the resume fence, so its identity must not compete with a running worker's.
+    if (settled) {
+      continue
     }
     const terminalHandle = row.assignee_handle?.trim()
     const workerHandle = row.agent_terminal_handle?.trim()

--- a/src/main/runtime/orchestration/orchestration-settled-worker-resume-fence-db.test.ts
+++ b/src/main/runtime/orchestration/orchestration-settled-worker-resume-fence-db.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { OrchestrationDb } from './db'
+import type { WorkerTerminalResourceRow } from './worker-terminal-ownership'
+
+const PANE_KEY = 'tab_worker:33333333-3333-4333-8333-333333333333'
+
+describe('settled worker terminal resume fence rows', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  function createReadyWorker(): { db: OrchestrationDb; taskId: string; dispatchId: string } {
+    const d = new OrchestrationDb(':memory:')
+    db = d
+    const task = d.createTask({ spec: 'settled worker' })
+    const started = d.createStartingWorkerDispatch({
+      creator: { kind: 'system' },
+      maxDepth: Number.MAX_SAFE_INTEGER,
+      taskId: task.id,
+      startOptions: {}
+    })
+    d.prepareStartingWorkerAuthority({
+      dispatchId: started.dispatch.id,
+      handle: 'term_worker',
+      paneKey: PANE_KEY,
+      processIncarnation: 'runtime:pty:1',
+      worktreeId: 'repo::worktree',
+      setupState: 'not_applicable',
+      effects: [],
+      terminalOwnership: 'created'
+    })
+    d.markWorkerDispatchReady(started.dispatch.id)
+    return { db: d, taskId: task.id, dispatchId: started.dispatch.id }
+  }
+
+  /** Asserts the `requested` arm so the resource row is non-null for the caller. */
+  function requestRelease(d: OrchestrationDb, dispatchId: string): WorkerTerminalResourceRow {
+    const requested = d.requestWorkerTerminalRelease(dispatchId)
+    if (requested.disposition !== 'requested') {
+      throw new Error(`expected a release request, got ${requested.disposition}`)
+    }
+    return requested.resource
+  }
+
+  function settle(d: OrchestrationDb, taskId: string, dispatchId: string): void {
+    expect(
+      d.settleWorkerReport({
+        taskId,
+        dispatchId,
+        outcome: 'succeeded',
+        result: JSON.stringify({ provenance: 'worker_report', outcome: 'succeeded' })
+      }).action
+    ).not.toBe('rejected')
+  }
+
+  it('keeps a settled-but-unreleased worker terminal in the recovery rows', () => {
+    const { db: d, taskId, dispatchId } = createReadyWorker()
+    settle(d, taskId, dispatchId)
+
+    expect(d.getWorkerDispatch(dispatchId)?.state).toBe('succeeded')
+    expect(d.listLegacyWorkerTerminalRecoveryRows()).toEqual([
+      expect.objectContaining({
+        dispatch_id: dispatchId,
+        worker_state: 'succeeded',
+        assignee_pane_key: PANE_KEY
+      })
+    ])
+  })
+
+  // Why (STA-4577): `release_unknown` is the ticket's own repro — release could not be proven, the
+  // pane keeps a resumable provider session, and dropping it here would re-open the auto-resume.
+  it('keeps a settled worker terminal whose release could not be proven', () => {
+    const { db: d, taskId, dispatchId } = createReadyWorker()
+    settle(d, taskId, dispatchId)
+    const resource = requestRelease(d, dispatchId)
+    expect(
+      d.markWorkerTerminalReleaseUnknown(resource.id, 'terminal no longer resolves').release_state
+    ).toBe('unknown')
+
+    expect(d.listLegacyWorkerTerminalRecoveryRows()).toEqual([
+      expect.objectContaining({ dispatch_id: dispatchId, assignee_pane_key: PANE_KEY })
+    ])
+  })
+
+  it('drops a settled worker terminal once its resource is released', () => {
+    const { db: d, taskId, dispatchId } = createReadyWorker()
+    settle(d, taskId, dispatchId)
+    const resource = requestRelease(d, dispatchId)
+    expect(d.settleWorkerTerminalRelease(resource.id).release_state).toBe('released')
+
+    expect(d.listLegacyWorkerTerminalRecoveryRows()).toEqual([])
+  })
+
+  it('drops a settled worker terminal the user chose to retain', () => {
+    const { db: d, taskId, dispatchId } = createReadyWorker()
+    d.retainWorkerTerminalResource(dispatchId)
+    settle(d, taskId, dispatchId)
+
+    expect(d.listLegacyWorkerTerminalRecoveryRows()).toEqual([])
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-settlement-resume-fence.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-settlement-resume-fence.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ORCHESTRATION_METHODS } from './orchestration'
+import type { RpcContext } from '../core'
+import { OrchestrationDb } from '../../orchestration/db'
+import { OrcaRuntimeService } from '../../orca-runtime'
+
+const COORDINATOR_PANE_KEY = 'tab_coord:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const WORKER_PANE_KEY = 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const WORKTREE_ID = 'repo::worktree'
+
+// Why (STA-4577): the fence only wins the race with a workspace return if settlement itself stamps
+// it. These pin the two lifecycle-reconcile call sites that make a settled dispatch observable.
+describe('settled worker automatic-resume fence trigger', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+    db = undefined
+    vi.restoreAllMocks()
+  })
+
+  function setup(): {
+    ctx: RpcContext
+    runId: string
+    taskId: string
+    dispatchId: string
+    resolveLegacyWorkerTerminalRecovery: ReturnType<typeof vi.fn>
+  } {
+    const orchestrationDb = new OrchestrationDb(':memory:')
+    db = orchestrationDb
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(orchestrationDb)
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+      handle === 'term_coord'
+        ? COORDINATOR_PANE_KEY
+        : handle === 'term_worker'
+          ? WORKER_PANE_KEY
+          : null
+    )
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
+      handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
+    )
+    vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+    const resolveLegacyWorkerTerminalRecovery = vi.fn()
+    runtime.setNotifier({ resolveLegacyWorkerTerminalRecovery } as never)
+
+    const run = orchestrationDb.createRun({
+      objective: 'Settlement fence run',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: COORDINATOR_PANE_KEY
+    })
+    const task = orchestrationDb.createTask({ spec: 'settle me', runId: run.id })
+    const started = orchestrationDb.createStartingWorkerDispatch({
+      creator: { kind: 'system' },
+      maxDepth: Number.MAX_SAFE_INTEGER,
+      taskId: task.id,
+      startOptions: {}
+    })
+    const orchestrationCapability = orchestrationDb.prepareStartingWorkerAuthority({
+      dispatchId: started.dispatch.id,
+      handle: 'term_worker',
+      paneKey: WORKER_PANE_KEY,
+      processIncarnation: 'runtime_test:term_worker:1',
+      worktreeId: WORKTREE_ID,
+      setupState: 'not_applicable',
+      effects: [],
+      terminalOwnership: 'created'
+    })
+    orchestrationDb.markWorkerDispatchReady(started.dispatch.id)
+    return {
+      ctx: { runtime, orchestrationCapability },
+      runId: run.id,
+      taskId: task.id,
+      dispatchId: started.dispatch.id,
+      resolveLegacyWorkerTerminalRecovery
+    }
+  }
+
+  async function call(
+    name: string,
+    params: Record<string, unknown>,
+    ctx: RpcContext
+  ): Promise<unknown> {
+    const method = ORCHESTRATION_METHODS.find((entry) => entry.name === name)
+    if (!method) {
+      throw new Error(`Method not found: ${name}`)
+    }
+    return method.handler(method.params ? method.params.parse(params) : undefined, ctx)
+  }
+
+  function workerDonePayload(taskId: string, dispatchId: string): string {
+    return JSON.stringify({ taskId, dispatchId, outcome: 'succeeded' })
+  }
+
+  it('fences the pane when orchestration.send settles the worker_done', async () => {
+    const fixture = setup()
+
+    const sent = (await call(
+      'orchestration.send',
+      {
+        from: 'term_worker',
+        to: `run:${fixture.runId}`,
+        subject: 'Done',
+        type: 'worker_done',
+        payload: workerDonePayload(fixture.taskId, fixture.dispatchId),
+        run: fixture.runId
+      },
+      fixture.ctx
+    )) as { lifecycle?: { action: string } }
+
+    expect(sent.lifecycle?.action).toBe('completed')
+    expect(fixture.resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(
+      WORKER_PANE_KEY,
+      'fenced',
+      { worktreeId: WORKTREE_ID }
+    )
+  })
+
+  it('fences the pane when an unread check is the first to settle the worker_done', async () => {
+    const fixture = setup()
+    // A direct-handle mailbox: `check` is the authoritative read that reconciles this worker_done.
+    db?.insertMessage({
+      from: 'term_worker',
+      to: 'term_watcher',
+      subject: 'Done',
+      type: 'worker_done',
+      payload: workerDonePayload(fixture.taskId, fixture.dispatchId),
+      senderPaneKey: WORKER_PANE_KEY,
+      runId: fixture.runId
+    })
+
+    await call('orchestration.check', { terminal: 'term_watcher' }, fixture.ctx)
+
+    expect(fixture.resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(
+      WORKER_PANE_KEY,
+      'fenced',
+      { worktreeId: WORKTREE_ID }
+    )
+  })
+
+  it('does not fence anything for a heartbeat that settles nothing', async () => {
+    const fixture = setup()
+
+    await call(
+      'orchestration.send',
+      {
+        from: 'term_worker',
+        to: `run:${fixture.runId}`,
+        subject: 'Still working',
+        type: 'heartbeat',
+        payload: JSON.stringify({ dispatchId: fixture.dispatchId }),
+        run: fixture.runId
+      },
+      fixture.ctx
+    )
+
+    expect(fixture.resolveLegacyWorkerTerminalRecovery).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-worker-release.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release.ts
@@ -8,6 +8,7 @@ import {
   exposeWorkerTerminalResource,
   type WorkerReleaseReceipt
 } from './orchestration-worker-release-completion'
+import { sweepSettledWorkerResumeFences } from './settled-worker-resume-fence-sweep'
 
 const WorkerDispatchParams = z.object({ dispatch: requiredString('Missing --dispatch') })
 
@@ -25,7 +26,30 @@ const WorkerListParams = z.object({
   terminalState: z.enum(WORKER_TERMINAL_LIST_STATES).optional()
 })
 
-export const ORCHESTRATION_WORKER_RELEASE_METHODS: RpcMethod[] = [
+// Why: release and retain both drop the worker's row from the legacy recovery plan, and
+// `startFreshSpawn` refuses a fenced pane — so the sweep has to run in the same call or the fence
+// outlives its dispatch and the pane cannot spawn until the next app start. Wrapping by name keeps
+// every early return covered; workerList is a pure read and is deliberately absent.
+const FENCE_SWEEPING_METHOD_NAMES = new Set([
+  'orchestration.workerRelease',
+  'orchestration.workerRetain'
+])
+
+function sweepingRetiredWorkerResumeFences(method: RpcMethod): RpcMethod {
+  if (!FENCE_SWEEPING_METHOD_NAMES.has(method.name)) {
+    return method
+  }
+  return {
+    ...method,
+    handler: async (params, ctx) => {
+      const result = await method.handler(params, ctx)
+      sweepSettledWorkerResumeFences(ctx.runtime)
+      return result
+    }
+  }
+}
+
+const WORKER_RELEASE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.workerRelease',
     params: WorkerDispatchParams,
@@ -171,8 +195,18 @@ export const ORCHESTRATION_WORKER_RELEASE_METHODS: RpcMethod[] = [
     params: z.object({ paneKey: requiredString('Missing paneKey') }),
     // Real user keystrokes durably relinquish orchestration ownership on the owning runtime, so
     // restarts, SSH drops, remote viewing, and renderer remounts cannot erase the takeover.
-    handler: (params, { runtime }) => ({
-      changed: runtime.getOrchestrationDb().markWorkerTerminalUserOwned(params.paneKey)
-    })
+    handler: (params, { runtime }) => {
+      const changed = runtime.getOrchestrationDb().markWorkerTerminalUserOwned(params.paneKey)
+      if (changed > 0) {
+        // Why: only a real takeover retires the resource; ordinary panes report here too and must
+        // not pay for a plan read on every 30s keystroke window.
+        sweepSettledWorkerResumeFences(runtime)
+      }
+      return { changed }
+    }
   })
 ]
+
+export const ORCHESTRATION_WORKER_RELEASE_METHODS: RpcMethod[] = WORKER_RELEASE_METHODS.map(
+  sweepingRetiredWorkerResumeFences
+)

--- a/src/main/runtime/rpc/methods/orchestration-worker-resume-fence-lift.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-resume-fence-lift.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import { OrchestrationDb } from '../../orchestration/db'
+import { ORCHESTRATION_METHODS } from './orchestration'
+
+const WORKER_PANE_KEY = 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const WORKTREE_ID = 'repo::worktree'
+const LOCAL_HOST_SCOPE = { kind: 'local', hostId: 'local' } as const
+
+// Why (STA-4577): `startFreshSpawn` refuses a fenced pane. Release, retain and user takeover each
+// drop the worker's row from the recovery plan, so each has to lift the fence in the same call —
+// otherwise it outlives its dispatch and the pane cannot spawn again until the next app start.
+// This runtime has no workspace-session store, so the fence here is renderer-only: proving the
+// lift still fires is what covers a fence whose persisted record never existed.
+describe('settled worker resume fence lift', () => {
+  let db: OrchestrationDb
+  let runtime: OrcaRuntimeService
+  let resolveLegacyWorkerTerminalRecovery: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    db = new OrchestrationDb(':memory:')
+    runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    resolveLegacyWorkerTerminalRecovery = vi.fn()
+    runtime.setNotifier({ resolveLegacyWorkerTerminalRecovery } as never)
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(WORKER_PANE_KEY)
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockReturnValue('runtime:pty:1')
+    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue({
+      terminalHandle: 'term_worker',
+      paneKey: WORKER_PANE_KEY,
+      processIncarnation: 'runtime:pty:1',
+      hostScope: LOCAL_HOST_SCOPE
+    } as never)
+    vi.spyOn(runtime, 'getExactWorkerProviderSession').mockReturnValue(null)
+    vi.spyOn(runtime, 'showTerminal').mockResolvedValue({
+      handle: 'term_worker',
+      worktreeId: WORKTREE_ID,
+      connected: true,
+      status: 'running'
+    } as never)
+    vi.spyOn(runtime, 'readTerminal').mockResolvedValue({
+      handle: 'term_worker',
+      status: 'running',
+      tail: ['worker output'],
+      truncated: false,
+      nextCursor: '1'
+    })
+    vi.spyOn(runtime, 'closeTerminal').mockResolvedValue({
+      handle: 'term_worker',
+      tabId: 'tab_worker',
+      ptyKilled: true
+    } as never)
+    vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+    ;(
+      runtime as unknown as {
+        inspectTerminalProcessIncarnationLiveness: () => Promise<string>
+      }
+    ).inspectTerminalProcessIncarnationLiveness = vi.fn().mockResolvedValue('live')
+  })
+
+  afterEach(() => {
+    db.close()
+    vi.restoreAllMocks()
+  })
+
+  async function call(name: string, params: Record<string, unknown>): Promise<unknown> {
+    const method = ORCHESTRATION_METHODS.find((candidate) => candidate.name === name)
+    if (!method) {
+      throw new Error(`Method not found: ${name}`)
+    }
+    return method.handler(method.params!.parse(params), { runtime } as never)
+  }
+
+  /** A settled worker whose terminal resource is still owned — the exact state the fence covers. */
+  function fenceSettledWorker(): string {
+    const run = db.createRun({
+      objective: 'Fence lift',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: 'tab_coord:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    })
+    const task = db.createTask({ spec: 'settle then retire', runId: run.id })
+    const started = db.createStartingWorkerDispatch({
+      creator: { kind: 'system' },
+      maxDepth: Number.MAX_SAFE_INTEGER,
+      taskId: task.id,
+      startOptions: {},
+      runtimeEpoch: runtime.getRuntimeId()
+    })
+    db.prepareStartingWorkerAuthority({
+      dispatchId: started.dispatch.id,
+      handle: 'term_worker',
+      paneKey: WORKER_PANE_KEY,
+      processIncarnation: 'runtime:pty:1',
+      worktreeId: WORKTREE_ID,
+      setupState: 'not_applicable',
+      effects: [{ kind: 'terminal', action: 'created', id: 'term_worker' }],
+      terminalOwnership: 'created',
+      hostScope: JSON.stringify(LOCAL_HOST_SCOPE)
+    })
+    db.markWorkerDispatchReady(started.dispatch.id)
+    expect(
+      db.settleWorkerReport({
+        taskId: task.id,
+        dispatchId: started.dispatch.id,
+        outcome: 'succeeded',
+        result: 'worker succeeded'
+      }).action
+    ).toBe('settled')
+
+    runtime.prepareLegacyWorkerTerminalRecovery()
+    expect(resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(
+      WORKER_PANE_KEY,
+      'fenced',
+      expect.objectContaining({ worktreeId: WORKTREE_ID })
+    )
+    resolveLegacyWorkerTerminalRecovery.mockClear()
+    return started.dispatch.id
+  }
+
+  function expectFenceLifted(): void {
+    expect(resolveLegacyWorkerTerminalRecovery).toHaveBeenCalledWith(
+      WORKER_PANE_KEY,
+      'unfenced',
+      expect.objectContaining({ worktreeId: WORKTREE_ID })
+    )
+  }
+
+  it('lifts the fence when release retires the terminal resource', async () => {
+    const dispatchId = fenceSettledWorker()
+
+    await expect(
+      call('orchestration.workerRelease', { dispatch: dispatchId })
+    ).resolves.toMatchObject({
+      state: 'released',
+      processAction: 'closed_agent_terminal'
+    })
+
+    expectFenceLifted()
+  })
+
+  it('lifts the fence when the user retains the worker terminal', async () => {
+    const dispatchId = fenceSettledWorker()
+
+    await expect(
+      call('orchestration.workerRetain', { dispatch: dispatchId })
+    ).resolves.toMatchObject({ state: 'retained' })
+
+    expectFenceLifted()
+  })
+
+  it('lifts the fence when real user input takes the pane over', async () => {
+    fenceSettledWorker()
+
+    await expect(
+      call('orchestration.workerTerminalUserInput', {
+        paneKey: WORKER_PANE_KEY
+      })
+    ).resolves.toEqual({ changed: 1 })
+
+    expectFenceLifted()
+  })
+
+  it('does not sweep for input on a pane orchestration never owned', async () => {
+    fenceSettledWorker()
+
+    await expect(
+      call('orchestration.workerTerminalUserInput', {
+        paneKey: 'tab_other:cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+      })
+    ).resolves.toEqual({ changed: 0 })
+
+    expect(resolveLegacyWorkerTerminalRecovery).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -20,6 +20,7 @@ import {
   type LifecycleReconciliationResult
 } from '../../orchestration/lifecycle-reconciliation'
 import { waitForFederatedLifecycleSettlement } from '../../orchestration/federation-lifecycle-settlement'
+import { sweepSettledWorkerResumeFencesForLifecycle } from './settled-worker-resume-fence-sweep'
 import { abbreviateOrchestrationTasks } from '../../../../shared/orchestration-task-summary'
 import {
   ORCHESTRATION_LEGACY_RUN_ID,
@@ -323,18 +324,6 @@ function parseMessageTypes(rawTypes: string | undefined): MessageType[] | undefi
     throw new OrchestrationError('invalid_argument', `Invalid --types: ${invalidTypes.join(',')}`)
   }
   return types && types.length > 0 ? types : undefined
-}
-
-// Why: settlement is the moment a worker's pane stops being resumable work. Stamping the resume
-// fence here — not at release — is what lets it win the race with a workspace return. One sweep
-// covers every settled pane, so a batch of reconciled messages needs at most one.
-function fenceSettledWorkerPanes(
-  runtime: OrcaRuntimeService,
-  reconciled: readonly LifecycleReconciliationResult[]
-): void {
-  if (reconciled.some((result) => result.action === 'completed' || result.action === 'failed')) {
-    runtime.prepareLegacyWorkerTerminalRecovery()
-  }
 }
 
 function resolveMessageRun(
@@ -816,7 +805,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             runtime.notifyMessageArrived(rejection.to_handle, rejection.type)
             return withSendWarnings({ message: rejection, lifecycle: reconciled })
           }
-          fenceSettledWorkerPanes(runtime, [reconciled])
+          sweepSettledWorkerResumeFencesForLifecycle(runtime, [reconciled])
           runtime.notifyMessageArrived(msg.to_handle, msg.type)
           return withSendWarnings(
             msg.type === 'worker_done' ? { message: msg, lifecycle: reconciled } : { message: msg }
@@ -1358,7 +1347,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
               ? (db.getMessageById(message.id) ?? message)
               : message
           })
-          fenceSettledWorkerPanes(runtime, reconciledMessages)
+          sweepSettledWorkerResumeFencesForLifecycle(runtime, reconciledMessages)
           db.markAsRead(messages.map((m) => m.id))
         }
 

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -15,7 +15,10 @@ import { MESSAGE_TYPES } from '../../orchestration/types'
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { formatMessageBanner } from '../../orchestration/formatter'
 import { isGroupAddress, resolveGroupAddress } from '../../orchestration/groups'
-import { reconcileLifecycleMessage } from '../../orchestration/lifecycle-reconciliation'
+import {
+  reconcileLifecycleMessage,
+  type LifecycleReconciliationResult
+} from '../../orchestration/lifecycle-reconciliation'
 import { waitForFederatedLifecycleSettlement } from '../../orchestration/federation-lifecycle-settlement'
 import { abbreviateOrchestrationTasks } from '../../../../shared/orchestration-task-summary'
 import {
@@ -320,6 +323,18 @@ function parseMessageTypes(rawTypes: string | undefined): MessageType[] | undefi
     throw new OrchestrationError('invalid_argument', `Invalid --types: ${invalidTypes.join(',')}`)
   }
   return types && types.length > 0 ? types : undefined
+}
+
+// Why: settlement is the moment a worker's pane stops being resumable work. Stamping the resume
+// fence here — not at release — is what lets it win the race with a workspace return. One sweep
+// covers every settled pane, so a batch of reconciled messages needs at most one.
+function fenceSettledWorkerPanes(
+  runtime: OrcaRuntimeService,
+  reconciled: readonly LifecycleReconciliationResult[]
+): void {
+  if (reconciled.some((result) => result.action === 'completed' || result.action === 'failed')) {
+    runtime.prepareLegacyWorkerTerminalRecovery()
+  }
 }
 
 function resolveMessageRun(
@@ -801,6 +816,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             runtime.notifyMessageArrived(rejection.to_handle, rejection.type)
             return withSendWarnings({ message: rejection, lifecycle: reconciled })
           }
+          fenceSettledWorkerPanes(runtime, [reconciled])
           runtime.notifyMessageArrived(msg.to_handle, msg.type)
           return withSendWarnings(
             msg.type === 'worker_done' ? { message: msg, lifecycle: reconciled } : { message: msg }
@@ -1334,12 +1350,15 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         let visibleMessages = messages
         if (consumeUnread && messages.length > 0) {
           // Why: unread check is an authoritative read path for worker_done/heartbeat, so reconcile lifecycle messages here too.
+          const reconciledMessages: LifecycleReconciliationResult[] = []
           visibleMessages = messages.map((message) => {
             const reconciled = reconcileLifecycleMessage(db, message)
+            reconciledMessages.push(reconciled)
             return reconciled.action === 'rejected'
               ? (db.getMessageById(message.id) ?? message)
               : message
           })
+          fenceSettledWorkerPanes(runtime, reconciledMessages)
           db.markAsRead(messages.map((m) => m.id))
         }
 

--- a/src/main/runtime/rpc/methods/settled-worker-resume-fence-sweep.ts
+++ b/src/main/runtime/rpc/methods/settled-worker-resume-fence-sweep.ts
@@ -1,0 +1,31 @@
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { LifecycleReconciliationResult } from '../../orchestration/lifecycle-reconciliation'
+
+/**
+ * Why: one pass both stamps the resume fence on every settled worker pane and lifts it from every
+ * pane the recovery plan no longer claims. `startFreshSpawn` refuses a fenced pane, so any path
+ * that drops a worker's row from that plan — release, user retain, user takeover — has to run the
+ * sweep, or the fence outlives its dispatch and the pane cannot spawn until the next app start.
+ * Failures are swallowed: a fence sweep must never fail the RPC that triggered it.
+ */
+export function sweepSettledWorkerResumeFences(runtime: OrcaRuntimeService): void {
+  try {
+    runtime.prepareLegacyWorkerTerminalRecovery()
+  } catch (error) {
+    console.warn('[orchestration] settled worker resume fence sweep failed', error)
+  }
+}
+
+/**
+ * Why: settlement is the moment a worker's pane stops being resumable work. Stamping the fence
+ * here — not at release — is what lets it win the race with a workspace return. One sweep covers
+ * every settled pane, so a batch of reconciled messages needs at most one.
+ */
+export function sweepSettledWorkerResumeFencesForLifecycle(
+  runtime: OrcaRuntimeService,
+  reconciled: readonly LifecycleReconciliationResult[]
+): void {
+  if (reconciled.some((result) => result.action === 'completed' || result.action === 'failed')) {
+    sweepSettledWorkerResumeFences(runtime)
+  }
+}

--- a/src/main/window/runtime-window-lifecycle.ts
+++ b/src/main/window/runtime-window-lifecycle.ts
@@ -143,11 +143,12 @@ export function registerRuntimeWindowLifecycle(
           reject(new Error('runtime_unavailable'))
         }
       }),
-    resolveLegacyWorkerTerminalRecovery: (paneKey, resolution, ptyId) =>
+    resolveLegacyWorkerTerminalRecovery: (paneKey, resolution, identity) =>
       send('agentStatus:legacyWorkerTerminalRecovery', {
         paneKey,
         resolution,
-        ...(ptyId ? { ptyId } : {})
+        ...(identity?.ptyId ? { ptyId: identity.ptyId } : {}),
+        ...(identity?.worktreeId ? { worktreeId: identity.worktreeId } : {})
       }),
     splitTerminal: (tabId, paneRuntimeId, opts) => {
       send('ui:splitTerminal', {

--- a/src/preload/api/agent-status-api.ts
+++ b/src/preload/api/agent-status-api.ts
@@ -1,6 +1,7 @@
 import type {
   AgentStatusClearIpcPayload,
   AgentStatusIpcPayload,
+  LegacyWorkerTerminalRecoveryEvent,
   MigrationUnsupportedPtyEntry
 } from '../../shared/agent-status-types'
 import type { AgentInterruptInferenceRequest } from '../../shared/agent-interrupt-intent'
@@ -21,11 +22,7 @@ export type AgentStatusApi = {
   onMigrationUnsupported: (callback: (entry: MigrationUnsupportedPtyEntry) => void) => () => void
   onMigrationUnsupportedClear: (callback: (data: { ptyId: string }) => void) => () => void
   onLegacyWorkerTerminalRecovery: (
-    callback: (data: {
-      paneKey: string
-      resolution: 'adopted' | 'exited' | 'rolled_back'
-      ptyId?: string
-    }) => void
+    callback: (data: LegacyWorkerTerminalRecoveryEvent) => void
   ) => () => void
   getMigrationUnsupportedSnapshot: () => Promise<MigrationUnsupportedPtyEntry[]>
   /** Drop a paneKey from the main-process hook cache and on-disk last-status file. Fire-and-forget. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -253,6 +253,7 @@ import {
 import type {
   AgentStatusClearIpcPayload,
   AgentStatusIpcPayload,
+  LegacyWorkerTerminalRecoveryEvent,
   MigrationUnsupportedPtyEntry
 } from '../shared/agent-status-types'
 import type { AgentInterruptInferenceRequest } from '../shared/agent-interrupt-intent'
@@ -5182,19 +5183,11 @@ const api = {
       return () => ipcRenderer.removeListener('agentStatus:migrationUnsupportedClear', listener)
     },
     onLegacyWorkerTerminalRecovery: (
-      callback: (data: {
-        paneKey: string
-        resolution: 'adopted' | 'exited' | 'rolled_back'
-        ptyId?: string
-      }) => void
+      callback: (data: LegacyWorkerTerminalRecoveryEvent) => void
     ): (() => void) => {
       const listener = (
         _event: Electron.IpcRendererEvent,
-        data: {
-          paneKey: string
-          resolution: 'adopted' | 'exited' | 'rolled_back'
-          ptyId?: string
-        }
+        data: LegacyWorkerTerminalRecoveryEvent
       ) => callback(data)
       ipcRenderer.on('agentStatus:legacyWorkerTerminalRecovery', listener)
       return () => ipcRenderer.removeListener('agentStatus:legacyWorkerTerminalRecovery', listener)

--- a/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-resume-command.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-resume-command.test.ts
@@ -436,6 +436,63 @@ describe('connectPanePty', () => {
     }
   }
 
+  // Why (STA-4577): a settled orchestration worker keeps a live `done` resume anchor until
+  // release retires it; returning to the workspace must not cold-restore its provider session.
+  it('does not resume a settled worker whose dispatch fenced automatic resume', async () => {
+    const pendingTimeouts: (() => void)[] = []
+    const originalSetTimeout = globalThis.setTimeout
+    globalThis.setTimeout = vi.fn((fn: () => void) => {
+      pendingTimeouts.push(fn)
+      return 999 as unknown as ReturnType<typeof setTimeout>
+    }) as unknown as typeof setTimeout
+
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const paneKey = makePaneKey('tab-1', LEAF_2)
+      const transport = createMockTransport('restored-session')
+      transport.getPtyId.mockImplementation(() => 'restored-session')
+      transportFactoryQueue.push(transport)
+      mockStoreState = {
+        ...mockStoreState,
+        tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'restored-session' }] },
+        settings: { ...mockStoreState.settings, agentCmdOverrides: {} },
+        sleepingAgentSessionsByPaneKey: {
+          [paneKey]: {
+            paneKey,
+            tabId: 'tab-1',
+            worktreeId: 'wt-1',
+            agent: 'codex',
+            providerSession: { key: 'session_id', id: 'codex-session-1' },
+            prompt: '',
+            state: 'done',
+            origin: 'live',
+            capturedAt: 1,
+            updatedAt: 1,
+            automaticResumeBlockedBy: 'legacy-orchestration-worker'
+          }
+        }
+      } as StoreState
+      const deps = createDeps({
+        restoredLeafId: LEAF_2,
+        restoredPtyIdByLeafId: { [LEAF_2]: 'restored-session' }
+      })
+      vi.mocked(window.api.pty.declarePendingPaneSerializer).mockResolvedValue(1)
+
+      connectPanePty(createPane(2) as never, createManager(2) as never, deps as never)
+      await flushAsyncTicks(20)
+      for (const fn of pendingTimeouts) {
+        fn()
+      }
+      await flushAsyncTicks(10)
+
+      expect(transport.connect).not.toHaveBeenCalled()
+      expect(deps.onShowSessionRestoredBanner).not.toHaveBeenCalled()
+      expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalled()
+    } finally {
+      globalThis.setTimeout = originalSetTimeout
+    }
+  })
+
   it('quotes a cold-restore resume command for a cmd.exe Windows tab', async () => {
     await expect(runWindowsColdRestoreResume({ terminalWindowsShell: 'cmd.exe' })).resolves.toBe(
       'codex "--dangerously-bypass-approvals-and-sandbox" "resume" "codex-session-1"'

--- a/src/renderer/src/hooks/ipc-events-agent-status-window-test-fixtures.ts
+++ b/src/renderer/src/hooks/ipc-events-agent-status-window-test-fixtures.ts
@@ -2,6 +2,7 @@ import type * as ReactModule from 'react'
 import { vi } from 'vitest'
 import type {
   AgentStatusClearIpcPayload,
+  LegacyWorkerTerminalRecoveryEvent,
   MigrationUnsupportedPtyEntry
 } from '../../../shared/agent-status-types'
 import type { AgentStatusSetData } from './ipc-events-agent-status-store-test-fixtures'
@@ -10,7 +11,7 @@ export function buildWindowApi(args: {
   onSet: (cb: (data: AgentStatusSetData) => void) => () => void
   onClear?: (cb: (data: AgentStatusClearIpcPayload) => void) => () => void
   onLegacyWorkerTerminalRecovery?: (
-    cb: (data: { paneKey: string; resolution: 'adopted' | 'exited' }) => void
+    cb: (data: LegacyWorkerTerminalRecoveryEvent) => void
   ) => () => void
   getSnapshot?: () => Promise<AgentStatusSetData[]>
   getMigrationUnsupportedSnapshot?: () => Promise<MigrationUnsupportedPtyEntry[]>

--- a/src/renderer/src/hooks/ipc-events/agent-status-listeners.ts
+++ b/src/renderer/src/hooks/ipc-events/agent-status-listeners.ts
@@ -8,6 +8,7 @@ import {
   rollbackLegacyWorkerTerminalSurfaceInStore
 } from '../legacy-worker-terminal-recovery-event'
 import { useAppStore } from '../../store'
+import { worktreeIdsEqual } from '../../../../shared/worktree/id'
 import { resolvePaneKey } from './agent-status-routing'
 import type { PendingAgentStatusEvent } from './agent-status-bridge-types'
 
@@ -121,6 +122,12 @@ export function registerAgentStatusListeners(args: {
         rollbackLegacyWorkerTerminalSurfaceInStore(useAppStore.getState(), action.detail)
       } else if (action.kind === 'clear-sleeping') {
         useAppStore.getState().clearSleepingAgentSession(action.paneKey)
+      } else if (action.kind === 'set-automatic-resume-block') {
+        const store = useAppStore.getState()
+        const record = store.sleepingAgentSessionsByPaneKey[action.paneKey]
+        if (record && worktreeIdsEqual(record.worktreeId, action.worktreeId)) {
+          store.setSleepingAgentAutomaticResumeBlocked(action.paneKey, action.blocked)
+        }
       }
     })
   if (unsubscribeLegacyWorkerTerminalRecovery) {

--- a/src/renderer/src/hooks/legacy-worker-terminal-recovery-event.test.ts
+++ b/src/renderer/src/hooks/legacy-worker-terminal-recovery-event.test.ts
@@ -38,6 +38,54 @@ describe('legacy worker terminal recovery events', () => {
     })
   })
 
+  it('blocks automatic resume for a fenced settled worker pane', () => {
+    expect(
+      resolveLegacyWorkerTerminalRecoveryAction({
+        paneKey: `legacy-worker:${LEAF_ID}`,
+        resolution: 'fenced',
+        worktreeId: 'repo::/workspace'
+      })
+    ).toEqual({
+      kind: 'set-automatic-resume-block',
+      paneKey: `legacy-worker:${LEAF_ID}`,
+      worktreeId: 'repo::/workspace',
+      blocked: true
+    })
+  })
+
+  it('lifts the fence once the dispatch stops claiming the pane', () => {
+    expect(
+      resolveLegacyWorkerTerminalRecoveryAction({
+        paneKey: `legacy-worker:${LEAF_ID}`,
+        resolution: 'unfenced',
+        worktreeId: 'repo::/workspace'
+      })
+    ).toEqual({
+      kind: 'set-automatic-resume-block',
+      paneKey: `legacy-worker:${LEAF_ID}`,
+      worktreeId: 'repo::/workspace',
+      blocked: false
+    })
+  })
+
+  it('ignores a fence that names no worktree to verify the pane against', () => {
+    expect(
+      resolveLegacyWorkerTerminalRecoveryAction({
+        paneKey: `legacy-worker:${LEAF_ID}`,
+        resolution: 'fenced'
+      })
+    ).toEqual({ kind: 'ignore' })
+  })
+
+  it('ignores a resolution kind it does not understand', () => {
+    expect(
+      resolveLegacyWorkerTerminalRecoveryAction({
+        paneKey: `legacy-worker:${LEAF_ID}`,
+        resolution: 'teleported' as never
+      })
+    ).toEqual({ kind: 'ignore' })
+  })
+
   it('removes an unmounted split surface only when its PTY identity still matches', () => {
     const setTabLayout = vi.fn()
     const clearTabPtyId = vi.fn()

--- a/src/renderer/src/hooks/legacy-worker-terminal-recovery-event.ts
+++ b/src/renderer/src/hooks/legacy-worker-terminal-recovery-event.ts
@@ -2,37 +2,48 @@ import type { CloseTerminalPaneDetail } from '@/constants/terminal'
 import { detachTerminalLayoutLeaf } from '@/components/terminal-pane/terminal-layout-leaf-detach'
 import type { AppState } from '@/store'
 import { makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
-
-type LegacyWorkerTerminalRecoveryEvent = {
-  paneKey: string
-  resolution: 'adopted' | 'exited' | 'rolled_back'
-  ptyId?: string
-}
+import type { LegacyWorkerTerminalRecoveryEvent } from '../../../shared/agent-status-types'
 
 export type LegacyWorkerTerminalRecoveryAction =
   | { kind: 'clear-sleeping'; paneKey: string }
   | { kind: 'rollback-surface'; detail: CloseTerminalPaneDetail }
+  | { kind: 'set-automatic-resume-block'; paneKey: string; worktreeId: string; blocked: boolean }
   | { kind: 'ignore' }
 
 export function resolveLegacyWorkerTerminalRecoveryAction(
   event: LegacyWorkerTerminalRecoveryEvent
 ): LegacyWorkerTerminalRecoveryAction {
-  if (event.resolution !== 'rolled_back') {
+  if (event.resolution === 'adopted' || event.resolution === 'exited') {
     return { kind: 'clear-sleeping', paneKey: event.paneKey }
   }
-  const pane = parsePaneKey(event.paneKey)
-  return pane && event.ptyId
-    ? {
-        kind: 'rollback-surface',
-        detail: {
-          tabId: pane.tabId,
-          leafId: pane.leafId,
-          preservePty: true,
-          retireSurface: true,
-          expectedPtyId: event.ptyId
+  if (event.resolution === 'fenced' || event.resolution === 'unfenced') {
+    // Why: the fence survives release failures, so it must never land on — or lift from — a
+    // pane-key alias whose record belongs to another workspace.
+    return event.worktreeId
+      ? {
+          kind: 'set-automatic-resume-block',
+          paneKey: event.paneKey,
+          worktreeId: event.worktreeId,
+          blocked: event.resolution === 'fenced'
         }
-      }
-    : { kind: 'ignore' }
+      : { kind: 'ignore' }
+  }
+  if (event.resolution === 'rolled_back') {
+    const pane = parsePaneKey(event.paneKey)
+    return pane && event.ptyId
+      ? {
+          kind: 'rollback-surface',
+          detail: {
+            tabId: pane.tabId,
+            leafId: pane.leafId,
+            preservePty: true,
+            retireSurface: true,
+            expectedPtyId: event.ptyId
+          }
+        }
+      : { kind: 'ignore' }
+  }
+  return { kind: 'ignore' }
 }
 
 type LegacyWorkerTerminalRecoveryStore = Pick<

--- a/src/renderer/src/hooks/useIpcEvents-agent-status-ssh-authority.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-agent-status-ssh-authority.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LegacyWorkerTerminalRecoveryEvent } from '../../../shared/agent-status-types'
 import { buildStoreState } from './ipc-events-agent-status-store-test-fixtures'
 import {
   buildWindowApi,
@@ -20,12 +21,24 @@ describe('useIpcEvents agent status snapshot integration', () => {
   it('retires the exact sleeping record after adopted or exited legacy worker recovery', async () => {
     const clearSleepingAgentSession = vi.fn()
     const setSleepingAgentAutomaticResumeBlocked = vi.fn()
-    let listener:
-      | ((data: { paneKey: string; resolution: 'adopted' | 'exited' }) => void)
-      | undefined
+    const settledWorkerPaneKey = 'tab-settled:leaf-settled'
+    let listener: ((data: LegacyWorkerTerminalRecoveryEvent) => void) | undefined
     const storeState = buildStoreState({
       clearSleepingAgentSession,
-      setSleepingAgentAutomaticResumeBlocked
+      setSleepingAgentAutomaticResumeBlocked,
+      sleepingAgentSessionsByPaneKey: {
+        [settledWorkerPaneKey]: {
+          paneKey: settledWorkerPaneKey,
+          worktreeId: 'repo::/workspace',
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'codex-session-1' },
+          prompt: '',
+          state: 'done',
+          origin: 'live',
+          capturedAt: 1,
+          updatedAt: 1
+        }
+      }
     })
 
     stubReactSyncEffect()
@@ -60,6 +73,38 @@ describe('useIpcEvents agent status snapshot integration', () => {
     listener?.({ paneKey: 'tab-exited:leaf-exited', resolution: 'exited' })
     expect(clearSleepingAgentSession).toHaveBeenCalledWith('tab-exited:leaf-exited')
     expect(setSleepingAgentAutomaticResumeBlocked).not.toHaveBeenCalled()
+
+    // A settled worker is fenced in place: the resume anchor is kept, never resumed.
+    clearSleepingAgentSession.mockClear()
+    listener?.({
+      paneKey: settledWorkerPaneKey,
+      resolution: 'fenced',
+      worktreeId: 'repo::/workspace'
+    })
+    expect(setSleepingAgentAutomaticResumeBlocked).toHaveBeenCalledWith(settledWorkerPaneKey, true)
+    expect(clearSleepingAgentSession).not.toHaveBeenCalled()
+
+    setSleepingAgentAutomaticResumeBlocked.mockClear()
+    listener?.({
+      paneKey: settledWorkerPaneKey,
+      resolution: 'fenced',
+      worktreeId: 'repo::/other-workspace'
+    })
+    listener?.({
+      paneKey: 'tab-unknown:leaf-unknown',
+      resolution: 'fenced',
+      worktreeId: 'repo::/workspace'
+    })
+    expect(setSleepingAgentAutomaticResumeBlocked).not.toHaveBeenCalled()
+
+    // Release, retain, or dispatch pruning retires the fence so the pane can spawn again.
+    listener?.({
+      paneKey: settledWorkerPaneKey,
+      resolution: 'unfenced',
+      worktreeId: 'repo::/workspace'
+    })
+    expect(setSleepingAgentAutomaticResumeBlocked).toHaveBeenCalledWith(settledWorkerPaneKey, false)
+    expect(clearSleepingAgentSession).not.toHaveBeenCalled()
   })
 
   it.each([

--- a/src/renderer/src/lib/worktree-activation-emptied-workspace-reseed.test.ts
+++ b/src/renderer/src/lib/worktree-activation-emptied-workspace-reseed.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '@/store'
 import { activateAndRevealFolderWorkspace, activateAndRevealWorktree } from './worktree-activation'
+import { waitForWorktreeAgentActivationGateForTests } from './worktree-agent-activation-gate'
 import { ensureWorktreeHasInitialTerminal } from './worktree-initial-terminal-seeding'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import { toSshExecutionHostId } from '../../../shared/execution-host'
@@ -22,6 +23,21 @@ function seedClosedLastTerminal(worktreeId: string): void {
   useAppStore.setState({ tabsByWorktree: { [worktreeId]: [] } })
   const { renderableTabCount } = useAppStore.getState().reconcileWorktreeTabModel(worktreeId)
   expect(renderableTabCount).toBe(0)
+}
+
+/** Makes `canInspectAgentActivationInventory()` true with nothing to adopt, so activation routes
+ *  through the agent gate and it settles on `empty`. */
+function stubReachableEmptyAgentInventory(): void {
+  useAppStore.setState({ workspaceSessionReady: true, terminalStartupRestorationReady: true })
+  vi.stubGlobal('window', {
+    api: {
+      runtime: { call: vi.fn().mockResolvedValue({ ok: true, result: { snapshots: [] } }) },
+      pty: { listSessions: vi.fn().mockResolvedValue([]) }
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  })
 }
 
 describe('activating a workspace whose last terminal was closed', () => {
@@ -92,6 +108,39 @@ describe('activating a workspace whose last terminal was closed', () => {
 
     expect(result).not.toBe(false)
     expect(result === false ? null : result.primaryTabId).toBeNull()
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toEqual([])
+  })
+
+  // Why (STA-4577): an orchestration-retired worker tab leaves the same empty row, and with the
+  // agent inventory reachable activation defers seeding to the gate. The gated branch must carry
+  // the same re-seed authority as the ungated one below, or the workspace opens with no pane and
+  // no way to get one back. Every other case here runs ungated, because vitest has no window.api.
+  it('re-seeds through the agent-activation gate, not only on the ungated path', async () => {
+    const worktree = makeWorktree()
+    seedEmptyActivatableWorktree(worktree)
+    seedClosedLastTerminal(worktree.id)
+    stubReachableEmptyAgentInventory()
+
+    const result = activateAndRevealWorktree(worktree.id, { notifyHostRuntime: false })
+
+    expect(result).not.toBe(false)
+    expect(result === false ? null : result.primaryTabId).toBeNull()
+    await expect(waitForWorktreeAgentActivationGateForTests(worktree.id)).resolves.toBe('empty')
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toHaveLength(1)
+  })
+
+  it('leaves the row empty on the gated path when the caller opens its own surface', async () => {
+    const worktree = makeWorktree()
+    seedEmptyActivatableWorktree(worktree)
+    seedClosedLastTerminal(worktree.id)
+    stubReachableEmptyAgentInventory()
+
+    activateAndRevealWorktree(worktree.id, {
+      providesInitialSurface: true,
+      notifyHostRuntime: false
+    })
+
+    await expect(waitForWorktreeAgentActivationGateForTests(worktree.id)).resolves.toBe('empty')
     expect(useAppStore.getState().tabsByWorktree[worktree.id]).toEqual([])
   })
 

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -258,7 +258,18 @@ export function activateAndRevealWorktree(
     void gateWorktreeAgentActivation(worktreeId).then((outcome) => {
       const currentState = useAppStore.getState()
       if (outcome === 'empty' && currentState.activeWorktreeId === worktreeId) {
-        ensureWorktreeHasInitialTerminal(currentState, worktreeId)
+        // Why: same reseed authority as the ungated branch below — an explicit activation is a
+        // request for a surface, so the closed-last-tab tombstone must not outlive it (a worker
+        // tab retired by orchestration leaves exactly that tombstone).
+        ensureWorktreeHasInitialTerminal(
+          currentState,
+          worktreeId,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { reseedEmptiedWorkspace: opts?.providesInitialSurface !== true }
+        )
       }
     })
   }

--- a/src/renderer/src/store/slices/agent-status-settled-worker-resume-fence.test.ts
+++ b/src/renderer/src/store/slices/agent-status-settled-worker-resume-fence.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '../types'
+import { createTestStore, makeTab } from './store-test-helpers'
+
+const PANE_KEY = 'tab-1:leaf-1'
+const WORKER_SESSION = { key: 'session_id' as const, id: 'codex-session-1' }
+
+function seedWorkingWorker(): ReturnType<typeof createTestStore> {
+  const store = createTestStore()
+  store.setState({
+    tabsByWorktree: { 'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })] }
+  } as Partial<AppState>)
+  store
+    .getState()
+    .setAgentStatus(
+      PANE_KEY,
+      { state: 'working', prompt: 'review the diff', agentType: 'codex' },
+      'Codex',
+      { updatedAt: 10, stateStartedAt: 10 },
+      undefined,
+      { providerSession: WORKER_SESSION }
+    )
+  return store
+}
+
+describe('settled orchestration worker automatic-resume fence', () => {
+  it('keeps the fence when the worker turn finishes after settlement', () => {
+    const store = seedWorkingWorker()
+    expect(store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]).toBeDefined()
+
+    // The dispatch settles (worker_done) while the turn is still reported as working.
+    store.getState().setSleepingAgentAutomaticResumeBlocked(PANE_KEY, true)
+    expect(
+      store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]?.automaticResumeBlockedBy
+    ).toBe('legacy-orchestration-worker')
+
+    store
+      .getState()
+      .setAgentStatus(
+        PANE_KEY,
+        { state: 'done', prompt: 'review the diff', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 20, stateStartedAt: 20 },
+        undefined,
+        { providerSession: WORKER_SESSION }
+      )
+
+    const record = store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]
+    expect(record?.state).toBe('done')
+    expect(record?.automaticResumeBlockedBy).toBe('legacy-orchestration-worker')
+  })
+
+  it('keeps the fence when a periodic capture follows a status ping', () => {
+    const store = seedWorkingWorker()
+    store.getState().setSleepingAgentAutomaticResumeBlocked(PANE_KEY, true)
+
+    // The turn still reads `working` after settlement, so a status ping only moves `updatedAt` and
+    // leaves the stored checkpoint stale — which is exactly what makes the 60s capture re-derive it.
+    store
+      .getState()
+      .setAgentStatus(
+        PANE_KEY,
+        { state: 'working', prompt: 'review the diff', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 15, stateStartedAt: 10 },
+        undefined,
+        { providerSession: WORKER_SESSION }
+      )
+    store.getState().captureAllSleepingAgentSessions('periodic')
+
+    expect(
+      store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]?.automaticResumeBlockedBy
+    ).toBe('legacy-orchestration-worker')
+  })
+
+  it('keeps the fence when the pane re-registers its launch config', () => {
+    const store = seedWorkingWorker()
+    store.getState().setSleepingAgentAutomaticResumeBlocked(PANE_KEY, true)
+
+    // A daemon reattach re-registers the pane's effective launch config, which refreshes the record.
+    store
+      .getState()
+      .registerAgentLaunchConfig(
+        PANE_KEY,
+        { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+        { agentType: 'codex', tabId: 'tab-1', leafId: 'leaf-1' }
+      )
+
+    expect(
+      store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]?.automaticResumeBlockedBy
+    ).toBe('legacy-orchestration-worker')
+  })
+
+  it('does not carry the fence onto a different provider session on the same pane', () => {
+    const store = seedWorkingWorker()
+    store.getState().setSleepingAgentAutomaticResumeBlocked(PANE_KEY, true)
+
+    store
+      .getState()
+      .setAgentStatus(
+        PANE_KEY,
+        { state: 'done', prompt: 'a new user turn', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 20, stateStartedAt: 20 },
+        undefined,
+        { providerSession: { key: 'session_id', id: 'codex-session-2' } }
+      )
+
+    expect(
+      store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]?.automaticResumeBlockedBy
+    ).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -611,7 +611,7 @@ function sleepingRecordFromEntry(args: {
     return null
   }
   const tab = args.tab ?? findTabForAgentEntry(args.state, args.worktreeId, args.entry)
-  return {
+  const record: SleepingAgentSessionRecord = {
     paneKey: args.entry.paneKey,
     ...(tab ? { tabId: tab.id } : {}),
     worktreeId: args.worktreeId,
@@ -632,6 +632,11 @@ function sleepingRecordFromEntry(args: {
     ...(args.entry.interrupted ? { interrupted: true } : {}),
     ...(args.origin ? { origin: args.origin } : {})
   }
+  carryOverAutomaticResumeBlock(
+    record,
+    args.state.sleepingAgentSessionsByPaneKey[args.entry.paneKey]
+  )
+  return record
 }
 
 type CollectSleepingAgentSessionRecordsOptions = {
@@ -677,8 +682,9 @@ function manualSleepCaptureEntry(entry: AgentStatusEntry, capturedAt: number): A
   return { ...entry, updatedAt: capturedAt, interrupted: false }
 }
 
-// Why: capture recreates a record the manual-sleep wipe would otherwise remove, so a deliberately
-// blocked worker must not become auto-resumable at wake.
+// Why: every re-derivation from a live entry (manual sleep, periodic capture, the end-of-turn
+// rewrite) builds a record without the fence, so a deliberately blocked worker would become
+// auto-resumable again. Only carry it when the pane still holds the same provider session.
 function carryOverAutomaticResumeBlock(
   record: SleepingAgentSessionRecord,
   previous: SleepingAgentSessionRecord | undefined
@@ -794,10 +800,6 @@ export function collectSleepingAgentSessionRecordsForWorktree(
     if (record) {
       if (isManualWorktreeSleep) {
         markManualSleepLazyRestore(record)
-        carryOverAutomaticResumeBlock(
-          record,
-          state.sleepingAgentSessionsByPaneKey[retained.entry.paneKey]
-        )
       }
       records[record.paneKey] = record
     }
@@ -831,7 +833,6 @@ export function collectSleepingAgentSessionRecordsForWorktree(
     if (record) {
       if (isManualWorktreeSleep) {
         markManualSleepLazyRestore(record)
-        carryOverAutomaticResumeBlock(record, state.sleepingAgentSessionsByPaneKey[paneKey])
       }
       records[record.paneKey] = record
     }

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -421,3 +421,27 @@ export function parseAgentStatusPayload(json: string): ParsedAgentStatusPayload 
     return null
   }
 }
+
+/**
+ * How main resolved a supervised worker terminal for the renderer.
+ * `fenced` blocks automatic provider resume on a settled-but-unreleased worker pane and `unfenced`
+ * lifts it once the dispatch is released, retained, or gone; the other three retire the recovery
+ * record once the terminal's fate is proven.
+ */
+export type LegacyWorkerTerminalRecoveryResolutionKind =
+  | 'adopted'
+  | 'exited'
+  | 'rolled_back'
+  | 'fenced'
+  | 'unfenced'
+
+export type LegacyWorkerTerminalRecoveryEvent = {
+  paneKey: string
+  resolution: LegacyWorkerTerminalRecoveryResolutionKind
+  ptyId?: string
+  /**
+   * Present on `fenced`/`unfenced`: the dispatch's own worktree, so the renderer can reject a
+   * pane-key alias.
+   */
+  worktreeId?: string
+}

--- a/src/shared/worktree/id.ts
+++ b/src/shared/worktree/id.ts
@@ -43,6 +43,18 @@ export function worktreeIdComparisonKey(worktreeId: string): string | null {
   )}`
 }
 
+/**
+ * Why: workspace identity is per *workspace*, not per checkout dir. Folder projects back several
+ * independent workspaces with one directory, separated only by the `::workspace:<uuid>` suffix that
+ * filesystem callers must strip; stripping it here instead lets one session steal a sibling's PTYs.
+ * Normalize only path spelling, so Windows/WSL/SSH ids still match themselves across hosts, and
+ * fall back to exact equality for a malformed id.
+ */
+export function worktreeIdsEqual(left: string, right: string): boolean {
+  const leftKey = worktreeIdComparisonKey(left)
+  return leftKey === null ? left === right : leftKey === worktreeIdComparisonKey(right)
+}
+
 export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {
   const separatorIdx = worktreeId.indexOf(WORKTREE_ID_SEPARATOR)
   if (separatorIdx === -1) {

--- a/tests/e2e/completed-worker-retirement-resume.spec.ts
+++ b/tests/e2e/completed-worker-retirement-resume.spec.ts
@@ -267,9 +267,11 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
       }
     )
 
+    // Why: the fixture drives the turn to `done`, and the checkpoint carries that real state —
+    // restating `working` is the ghost-resume lie #16308 removed.
     const expectedRecovery = {
       origin: 'live',
-      state: 'working',
+      state: 'done',
       providerSessionId: PROVIDER_SESSION_ID
     }
     await expect


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​942 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​931 |
| Prod | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​326 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​69 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​257 |

<!-- /orca-pr-loc -->

Fixes **STA-4577**. Supersedes #17430, which GitHub would not let me reopen after the branch was rebased (its original head commit is no longer reachable). Same branch, same work, plus the de-risking below. One of 6 real defects split out of the [test-detected-bugs sweep](https://linear.app/stably/view/test-detected-bugs-3a9343ad1a27).

## ELI5
When a supervised orchestration worker finishes, we're supposed to put a "do not auto-resume" sticker on its pane. We were forgetting the sticker — so the auto-resume logic would cheerfully restart a worker that had already reported done.

This stamps the fence at settlement time, and — equally important — **lifts** it once the dispatch is released, retained, or gone.

## Why the lift matters as much as the stamp
`startFreshSpawn` refuses any fenced pane. A fence that outlives its dispatch leaves a terminal that can never spawn again. Release, user retain, user takeover, and dispatch pruning all drop the row from the recovery plan — that is the signal to retire the fence.

### Fence-lift completeness

Every stamp path and every lift path, enumerated:

| Stamps the fence | Lift path that covers it |
|---|---|
| Settlement (`orchestration.send` / `orchestration.check` lifecycle reconciliation) | the same sweep, next time the plan no longer claims the pane |
| Persisted record in the workspace session | `liftRetiredLegacyWorkerResumeFences` |
| Renderer-only push (`fenced` IPC) with no persisted record behind it | `liftRendererLegacyWorkerResumeFences` (new) |

| Retires the dispatch | Sweep runs? |
|---|---|
| `orchestration.workerRelease` | yes (new) |
| `orchestration.workerRetain` | yes (new) |
| `orchestration.workerTerminalUserInput` (real takeover) | yes (new), gated on `changed > 0` |
| Settlement / dispatch pruning | yes (already) |
| App start | yes (already) |

Two gaps were found and closed in this revision:

1. **Release / retain / takeover ran no sweep.** Each drops the worker's row from the recovery plan, but nothing re-read the plan, so the fence stayed stamped until the next app start. All three now run `sweepSettledWorkerResumeFences` in the same call. `sweepingRetiredWorkerResumeFences` wraps by method name so every early return in those handlers is covered; `orchestration.workerList` is a pure read and is deliberately excluded. The takeover path is gated on `changed > 0` because every terminal pane reports there on a 30s throttle, and only a real takeover retires the resource.

2. **A renderer-only fence had no lift path at all.** The `fenced` resolution is pushed live, so it can exist with no persisted record behind it (session sync lag, persistence unavailable). The runtime now remembers what it fenced in `rendererFencedWorkerPaneWorktreeIds` and lifts before the persistence bail-out, so an unreadable workspace session can no longer strand a fence this runtime pushed.

Bound on the worst case: even before these fixes, every fence was swept at the next app start, so the failure mode was "dead pane until restart", not literally never. `main` today stamps the persisted fence for live dispatches with **no lift at all**; this PR adds the first one.

Paired remote: `agentStatus:legacyWorkerTerminalRecovery` is Electron IPC only and never crosses the remote wire, so a paired client cannot observe a fence it can't lift.

Residual (accepted, minor): the lift matches on pane key alone while the stamp also carries `worktreeId`. Pane keys are `tabId:leafId` UUID pairs, so a cross-worktree collision is not reachable in practice.

## Failing closed
- An unreadable recovery plan stamps nothing and lifts nothing, and retries next pass. An unreadable plan is not evidence that any pane stopped needing its fence.
- `release_state = 'unknown'` **keeps** the fence — the SQL matches `release_state NOT IN ('released','retained')`. An unverifiable release refuses a fresh spawn over a possibly-live process.
- `settled: (alreadySettled ?? true) && settled` demotes a reused pane when any dispatch holding it is still live.
- The sweep swallows its own errors: a fence sweep must never fail the RPC that triggered it.

## The red `changed e2e specs` check: a real defect, in `main`, not in the fence

`completed-worker-retirement-resume.spec.ts` was failing with `Active terminal PaneManager did not finish mounting`. That is exactly what a wrongly-stamped fence would look like, so it was worth being precise about. It was **not** the fence.

Evidence:

- **Run A** — this branch: fails at spec line 492, empty tab strip.
- **Run B** — `origin/main` product + `origin/main` spec: fails *earlier*, at line 275 (`state: 'working'`, received `'done'`). The spec was already red on main; the branch's `working`→`done` edit legitimately fixes that first failure.
- **Run C** — `origin/main` product + **this branch's spec file only**: fails at the identical line 492 with the identical message. Main's product code causes it.
- **Run D** — instrumented: at failure, `activeWorktreeId` is the target, `everActivated: true`, `activeTabId: null`, `tabCounts: { coordinator: 1, target: 0 }` (row present, empty array), and `sleepingAgentSessionsByPaneKey: {}`. No fence in sight.

Root cause: an orchestration-retired worker tab leaves `tabsByWorktree[worktreeId] = []` — the closed-last-tab tombstone. On activation, `renderableTabCount === 0` makes `shouldGateAgentActivation` true, so seeding is deferred into `gateWorktreeAgentActivation(...).then(...)`. **That gated branch called `ensureWorktreeHasInitialTerminal` without `reseedEmptiedWorkspace`**, unlike the ungated branch directly below it and unlike the folder-workspace twin. The tombstone therefore suppressed re-seeding permanently, and no pane could ever mount.

Fixed in product code (`worktree-activation.ts`) by giving the gated branch the same re-seed authority the ungated one already had. The test was not weakened.

Non-vacuity: forcing `reseedEmptiedWorkspace: false` in the new unit test makes it fail `- 1 / + 0`.

## Wire compatibility
`fenced` / `unfenced` are new **values** on the existing `LegacyWorkerTerminalRecoveryEvent.resolution` field, plus a new optional `worktreeId` (so the renderer can reject a pane-key alias). No new stream opcode, so no capability negotiation is required; old clients ignore resolutions they don't know.

## Proof
Revert the product files to `2daea491b96`:

| Test | Result |
|---|---|
| `orchestration-settlement-resume-fence.test.ts` | **2 failed** / 1 passed |
| `agent-status-settled-worker-resume-fence.test.ts` | **3 failed** / 1 passed |
| `orca-runtime.test.ts` | **6 failed** / 1211 passed |

New in this revision:

| Test | Covers |
|---|---|
| `orchestration-worker-resume-fence-lift.test.ts` | release, retain, and real takeover each lift the fence; an unowned pane sweeps nothing. Runs against a store-less runtime, so the fence exercised is the renderer-only one that previously had no lift path. |
| `worktree-activation-emptied-workspace-reseed.test.ts` (+2) | the gated activation path re-seeds an emptied workspace, and still honours `providesInitialSurface` |

Verification at HEAD:

- `pnpm tc` — clean.
- `pnpm test src/main/runtime/ src/renderer/src/hooks/ src/renderer/src/store/slices/agent-status-settled-worker-resume-fence.test.ts` — `666 files`, `6865 passed | 5 skipped`. One unrelated failure, `terminal-output-frame-chunks-equivalence.test.ts`, an 800-trial fuzz that exceeded its 30s wall-clock budget on a loaded machine (load avg 71); it is byte-identical to `origin/main`, shares no code with this diff, and passes in 51s with a raised timeout.
- `completed-worker-retirement-resume.spec.ts` — **6/6 green** across three runs (1×, then 2× repeat-each). Both cases run; the `worker-release` case that CI skipped now executes and passes.
- `oxlint` — exit 0, 0 errors. `pnpm run check:code-quality:changed` — `0 new findings across 27 changed files`.

## Known P2, accepted and documented
The fence is persisted to the workspace session. If a user runs this build, settles a worker whose terminal resource is still owned-and-unreleased, then **downgrades**, the older build has no code path to lift the fence.

**What the downgraded user sees:** that one pane stays blank and will not spawn a shell. **Workaround:** close the tab and open a new terminal tab — the fence is keyed per pane key (`tabId:leafId`), so a new pane is unaffected. Rolling forward again self-heals on the first sweep.

**Reduction attempt, evaluated and rejected.** The obvious fix is to persist settled fences under a *new* enum value (e.g. `'settled-orchestration-worker'`) rather than reusing `'legacy-orchestration-worker'`. An older build's `salvagingRecord` would fail to parse that record and drop only it, so the downgraded build would see no fence at all — the P2 disappears. It works, but it touches ~6 strict `=== 'legacy-orchestration-worker'` comparison sites plus the IPC payload and the stamp/lift transition logic, which is more surface than a CI fix and a de-risk pass should carry. Recorded here so the next change in this area can pick it up.

Otherwise accepted because: it is not a regression of this build (rolling forward self-heals via the lift); the previous build **already leaks fences it stamps itself**, so this enlarges the population of a pre-existing old-build defect rather than introducing one; and reachability is narrow. Removing it would mean not persisting the fence at all — which is precisely the bug.

## Note on `src/shared/worktree/id.ts`
This PR adds `worktreeIdsEqual` (a small helper over the already-existing `worktreeIdComparisonKey`) because the recovery listener needs it. The STA-5701 PR adds the identical function. The additions are byte-identical, so the two merge cleanly in either order — verified by merging all split branches and diffing against the original combined tree (empty).

## Performance Measurement

Deterministic settled-worker fixture: the old path allowed 1 fresh-resume attempt after settlement; the fence makes that 0 while the dispatch is settled, then retires the fence when the dispatch is released, retained, or taken over. No extra polling or subprocess work is added. The new sweeps are one recovery-plan read on release/retain/takeover — user-initiated, low-frequency events, and the takeover path is gated on an actual ownership change so ordinary panes never pay for it.

## User-Facing Trade-offs

None in the current build. Settled workers no longer restart spuriously; an emptied workspace now re-seeds a terminal on the gated activation path instead of opening blank; and the documented downgrade caveat now carries an explicit user workaround.

