### PR TITLE
ci(docs): skip releases without docs source

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -174,6 +174,23 @@ jobs:
           fi
           echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
 
+          # Stable tags cut before the docs package was merged are valid Orca
+          # releases, but cannot produce a docs deployment. Skip them before
+          # requesting the protected production environment.
+          docs_source_available=false
+          for attempt in 1 2 3; do
+            if gh api "repos/$GITHUB_REPOSITORY/contents/docs/site/package.json?ref=$commit_sha" >/dev/null 2>&1; then
+              docs_source_available=true
+              break
+            fi
+            [[ "$attempt" -eq 3 ]] || sleep "$((attempt * 5))"
+          done
+          if [[ "$docs_source_available" != "true" ]]; then
+            echo "Release $tag does not contain docs/site; skipping docs deployment."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           deploy=false
           if [[ "$authorized_ref" == "true" && "$authorized_author" == "true" && "$release_state_ok" == "true" ]]; then
             deploy=true


### PR DESCRIPTION
## Summary

Guard the release-backed docs deployment against stable tags cut before `docs/site` existed.

The release gate now checks the resolved immutable tag commit for `docs/site/package.json` (with retries) and skips deployment before requesting the protected `docs-production` environment when the source is absent. This keeps old releases such as `v1.4.193` from entering a production job that cannot build the docs app.

## Testing

- `actionlint .github/workflows/docs.yml`
- `git diff --check`
