### PR TITLE
Give POSIX terminals the launcher PATH, not Orca's seeded one

### DIFF
--- a/src/main/ipc/pty-daemon-spawn-wsl-runtime.test.ts
+++ b/src/main/ipc/pty-daemon-spawn-wsl-runtime.test.ts
@@ -8,6 +8,10 @@ import {
 import { delimiter, join } from 'node:path'
 import { _setWslCachesForTests } from '../wsl'
 import { registerPtyHandlers } from './pty'
+import {
+  _resetHydrateShellPathCache,
+  _setLaunchPathForTests
+} from '../startup/hydrate-shell-path'
 
 vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
 vi.mock('fs', () => import('./pty-ipc-mock-registry').then((m) => m.fsModuleMock()))
@@ -547,37 +551,44 @@ describe('registerPtyHandlers', () => {
           mockedApp.isPackaged = prev
         }
       })
-      it('preserves the inherited PATH when dev-mode daemon env omits PATH', async () => {
+      it('preserves the launcher PATH when dev-mode daemon env omits PATH', async () => {
         const { app } = await import('electron')
         const mockedApp = app as unknown as { isPackaged: boolean }
         const prev = mockedApp.isPackaged
         mockedApp.isPackaged = false
+        // Why (#17446): the sparse daemon env falls back to the PATH Orca was
+        // launched with, not the seeded process PATH the pane must never inherit.
+        _setLaunchPathForTests('/system/bin')
         try {
           const env = await daemonSpawnAndGetEnv({}, undefined, undefined, {
-            PATH: '/system/bin'
+            PATH: `/seeded/only${delimiter}/system/bin`
           })
           expect(env.ORCA_USER_DATA_PATH).toBe('/tmp/orca-user-data')
-          expect(env.PATH).toContain(
+          expect(env.PATH).toBe(
             `${join('/tmp/orca-user-data', 'cli', 'bin')}${delimiter}/system/bin`
           )
         } finally {
+          _resetHydrateShellPathCache()
           mockedApp.isPackaged = prev
         }
       })
       it('drops a legacy shim PATH entry inherited from the host process on the daemon path', async () => {
-        // Why: the daemon path passes a sparse env, so the prepends re-read PATH from
-        // process.env — the scrub must outlive that fallback (pre-upgrade host or parent pane).
+        // Why: the daemon path passes a sparse env, so the prepends re-read the launch
+        // PATH — the scrub must outlive that fallback (pre-upgrade host or parent pane).
         const { app } = await import('electron')
         const mockedApp = app as unknown as { isPackaged: boolean }
         const prev = mockedApp.isPackaged
         mockedApp.isPackaged = false
+        const legacyShimPath = `/tmp/orca-user-data/orca-terminal-attribution/posix${delimiter}/system/bin`
+        _setLaunchPathForTests(legacyShimPath)
         try {
           const env = await daemonSpawnAndGetEnv({}, undefined, undefined, {
-            PATH: `/tmp/orca-user-data/orca-terminal-attribution/posix${delimiter}/system/bin`
+            PATH: legacyShimPath
           })
           expect(env.PATH).not.toContain('orca-terminal-attribution')
           expect(env.PATH).toContain('/system/bin')
         } finally {
+          _resetHydrateShellPathCache()
           mockedApp.isPackaged = prev
         }
       })

--- a/src/main/ipc/pty-spawn-env-terminal-basics.test.ts
+++ b/src/main/ipc/pty-spawn-env-terminal-basics.test.ts
@@ -9,6 +9,10 @@ import { __setWindowsPathRegistryLoaderForTests } from '../pty/windows-path-regi
 import { hasLiveClaudePtys, markClaudePtySpawned } from '../claude-accounts/live-pty-gate'
 import { wslHookRelayManager } from '../agent-hooks/wsl-hook-relay-manager'
 import { registerPtyHandlers, buildPtyHostEnv, clearProviderPtyState } from './pty'
+import {
+  _resetHydrateShellPathCache,
+  _setLaunchPathForTests
+} from '../startup/hydrate-shell-path'
 
 vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
 vi.mock('fs', () => import('./pty-ipc-mock-registry').then((m) => m.fsModuleMock()))
@@ -322,6 +326,27 @@ describe('registerPtyHandlers', () => {
       const env = await spawnAndGetEnv()
       expect(env.FORCE_HYPERLINK).toBe('1')
     })
+    // Why (#17446): panes run a login shell, and rc files that prepend a directory
+    // only when it is absent find Orca's seeded copies already there and skip them —
+    // leaving the user's tool dirs behind /usr/bin once path_helper hoists /etc/paths.
+    it.skipIf(process.platform === 'win32')(
+      'starts a pane from the launcher PATH, not Orca\'s seeded one',
+      async () => {
+        const launchPath = ['/usr/bin', '/bin'].join(delimiter)
+        const seededOnlyDir = '/Users/me/.local/share/mise/shims'
+        _setLaunchPathForTests(launchPath)
+        try {
+          const env = await spawnAndGetEnv(undefined, {
+            PATH: `${launchPath}${delimiter}${seededOnlyDir}`
+          })
+
+          expect(env.PATH.split(delimiter)).not.toContain(seededOnlyDir)
+          expect(env.PATH.endsWith(launchPath)).toBe(true)
+        } finally {
+          _resetHydrateShellPathCache()
+        }
+      }
+    )
     it('surfaces ORCA_APP_VERSION as TERM_PROGRAM_VERSION for TUI feature gating', async () => {
       const env = await spawnAndGetEnv(undefined, { ORCA_APP_VERSION: '1.2.3-test' })
       expect(env.TERM_PROGRAM_VERSION).toBe('1.2.3-test')

--- a/src/main/ipc/pty/host-env/assembly.ts
+++ b/src/main/ipc/pty/host-env/assembly.ts
@@ -16,7 +16,7 @@ import { resolvePathEnvKey, mergePersistedWindowsPath } from '../../../pty/windo
 import { resolveCodexShellLaunchPreflightCommand } from '../../../pty/codex-shell-launch-preflight'
 import { buildConfiguredProxyEnv } from '../../../../shared/network-proxy'
 import type { BuildPtyHostEnvOptions } from './types'
-import { readInheritedPath } from './path'
+import { readInheritedPath, restoreLauncherInheritedPath } from './path'
 import { stripInheritedOrcaCodexHomeOverride } from './codex-home'
 import {
   clearPiAgentShadowEnv,
@@ -235,6 +235,10 @@ export function buildPtyHostEnv(
     }
     delete baseEnv.ORCA_CLI_COMMAND
   }
+  // Why: must precede every prepend below -- they read the inherited PATH, and
+  // the pane's login shell must rebuild from the launcher's PATH, not Orca's.
+  restoreLauncherInheritedPath(baseEnv)
+
   // Why: dev mode needs the launcher PATH override so `orca` resolves to the dev build instead of the production binary at /usr/local/bin/orca.
   if (!opts.isPackaged) {
     const devCliBin = join(opts.userDataPath, 'cli', 'bin')

--- a/src/main/ipc/pty/host-env/path.test.ts
+++ b/src/main/ipc/pty/host-env/path.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { delimiter } from 'node:path'
+import {
+  _resetHydrateShellPathCache,
+  _setLaunchPathForTests
+} from '../../../startup/hydrate-shell-path'
+import { readInheritedPath, restoreLauncherInheritedPath } from './path'
+
+const LAUNCH_PATH = ['/usr/bin', '/bin', '/usr/sbin', '/sbin'].join(delimiter)
+const SEEDED_TAIL = [
+  '/opt/homebrew/bin',
+  '/Users/me/.local/share/mise/shims',
+  '/Users/me/.volta/bin'
+].join(delimiter)
+
+describe('restoreLauncherInheritedPath', () => {
+  const inheritedProcessPath = process.env.PATH
+
+  afterEach(() => {
+    _resetHydrateShellPathCache()
+    if (inheritedProcessPath === undefined) {
+      delete process.env.PATH
+    } else {
+      process.env.PATH = inheritedProcessPath
+    }
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'hands the pane the launcher PATH instead of the seeded one',
+    () => {
+      _setLaunchPathForTests(LAUNCH_PATH)
+      process.env.PATH = `${LAUNCH_PATH}${delimiter}${SEEDED_TAIL}`
+      const env = { PATH: process.env.PATH }
+
+      restoreLauncherInheritedPath(env)
+
+      expect(env.PATH).toBe(LAUNCH_PATH)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')('fills in a pane env that carries no PATH', () => {
+    _setLaunchPathForTests(LAUNCH_PATH)
+    process.env.PATH = `${LAUNCH_PATH}${delimiter}${SEEDED_TAIL}`
+    const env: Record<string, string> = {}
+
+    restoreLauncherInheritedPath(env)
+
+    expect(readInheritedPath(env)).toBe(LAUNCH_PATH)
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps a prefix the caller prepended onto the seeded PATH',
+    () => {
+      _setLaunchPathForTests(LAUNCH_PATH)
+      process.env.PATH = `${LAUNCH_PATH}${delimiter}${SEEDED_TAIL}`
+      const env = { PATH: `/agent-teams-shim${delimiter}${process.env.PATH}` }
+
+      restoreLauncherInheritedPath(env)
+
+      expect(env.PATH).toBe(`/agent-teams-shim${delimiter}${LAUNCH_PATH}`)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')('leaves a PATH the caller composed itself alone', () => {
+    _setLaunchPathForTests(LAUNCH_PATH)
+    process.env.PATH = `${LAUNCH_PATH}${delimiter}${SEEDED_TAIL}`
+    const env = { PATH: `/tmp/hijack-scratch${delimiter}/usr/bin` }
+
+    restoreLauncherInheritedPath(env)
+
+    expect(env.PATH).toBe(`/tmp/hijack-scratch${delimiter}/usr/bin`)
+  })
+
+  it.skipIf(process.platform !== 'win32')('never rewrites PATH on Windows', () => {
+    _setLaunchPathForTests('C:\\Windows\\system32', 'Path')
+    const env: Record<string, string> = { Path: 'C:\\Orca\\bin;C:\\Windows\\system32' }
+
+    restoreLauncherInheritedPath(env)
+
+    expect(env.Path).toBe('C:\\Orca\\bin;C:\\Windows\\system32')
+    expect(env.PATH).toBeUndefined()
+  })
+})

--- a/src/main/ipc/pty/host-env/path.ts
+++ b/src/main/ipc/pty/host-env/path.ts
@@ -1,10 +1,49 @@
 import { delimiter } from 'node:path'
 import { isLegacyTerminalShimPathEntry } from '../../../pty/legacy-terminal-shim-dir'
 import { resolvePathEnvKey } from '../../../pty/windows-environment-path'
+import { getLaunchPath } from '../../../startup/hydrate-shell-path'
 
 export function readInheritedPath(baseEnv: Record<string, string>): string {
   const pathKey = resolvePathEnvKey(baseEnv, process.platform)
   return baseEnv[pathKey] ?? process.env[pathKey] ?? ''
+}
+
+/**
+ * Replace Orca's own seeded/hydrated PATH with the one Orca was launched with.
+ *
+ * Why: POSIX panes run a login shell, so the user's profile scripts rebuild
+ * PATH from what they inherit. Orca's process PATH carries the startup seed
+ * (`patchPackagedProcessPath`) plus the login-shell probe merge, so an rc file
+ * that only prepends a directory when it is absent finds its own directories
+ * already there and skips them -- leaving them behind /usr/bin once macOS
+ * path_helper hoists /etc/paths (stablyai/orca#17446). Seeding exists so the
+ * main process can find agent CLIs; a login shell needs none of it.
+ *
+ * Windows is untouched: its panes get PATH from the registry-backed merge in
+ * `windows-environment-path.ts`, and no PowerShell/cmd equivalent of a login
+ * profile rebuild is involved.
+ *
+ * Leaves a PATH the caller composed itself alone, except for the prefix that
+ * the agent-teams shim prepends onto Orca's process PATH.
+ */
+export function restoreLauncherInheritedPath(baseEnv: Record<string, string>): void {
+  if (process.platform === 'win32') {
+    return
+  }
+  const launchPath = getLaunchPath()?.value
+  if (!launchPath) {
+    return
+  }
+  const seededPath = process.env.PATH ?? ''
+  const currentPath = baseEnv.PATH
+  if (currentPath === undefined || currentPath === seededPath) {
+    baseEnv.PATH = launchPath
+    return
+  }
+  const seededSuffix = `${delimiter}${seededPath}`
+  if (seededPath && currentPath.endsWith(seededSuffix)) {
+    baseEnv.PATH = `${currentPath.slice(0, -seededPath.length)}${launchPath}`
+  }
 }
 
 export function firstPathEntry(pathValue: string | undefined): string | null {

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -148,6 +148,21 @@ function applyLaunchPath(env: NodeJS.ProcessEnv, key: string, value: string | nu
   env[key] = value
 }
 
+/**
+ * The PATH Orca inherited from its launcher, before any seeding or hydration.
+ *
+ * Why exposed: an interactive login shell derives its PATH from the value it
+ * inherits, and rc files routinely guard their prepends on "already present".
+ * Hand one Orca's seeded PATH and those prepends become no-ops, leaving the
+ * user's tool directories wherever Orca happened to put them -- behind
+ * /usr/bin once macOS path_helper reorders (stablyai/orca#17446).
+ */
+export function getLaunchPath(): { key: string; value: string } | null {
+  const key = launchPathOverride?.key ?? LAUNCH_PATH_KEY
+  const value = launchPathOverride?.value ?? LAUNCH_PATH
+  return value === null ? null : { key, value }
+}
+
 function shellProbeEnv(): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env, [PROBE_MARKER_ENV_VAR]: '1' }
   const key = launchPathOverride?.key ?? LAUNCH_PATH_KEY


### PR DESCRIPTION
## What Changed

Orca terminals run a login shell, which builds PATH by adding to whatever
it inherits. It was inheriting Orca's own PATH, which the app pads at
startup with a list of tool directories so it can find agent CLIs. Shell
config commonly only prepends a directory when it isn't already there, so
those pre-seeded copies stopped the user's own prepends from happening --
leaving their tools stranded behind /usr/bin, where macOS path_helper
had already pushed them. A mise-managed ruby lost to /usr/bin/ruby, and
volta, asdf, fnm, yarn, bun, nix, opencode and vite-plus appeared in PATH
on machines with none of them installed. Hand panes the PATH Orca was
launched with instead, so the shell builds the same PATH it would under
any other terminal.

Windows is unchanged; its panes get PATH from the registry-backed merge,
with no login profile to rebuild.

## Why

Orca terminals showed a different PATH than any other terminal on the same machine, badly enough to break tools: mise-managed ruby resolved to /usr/bin/ruby, and volta, asdf, fnm, yarn, bun, nix, opencode and vite-plus appeared in PATH on a machine with none of them installed. A cold GUI launch gives Electron a near-empty PATH, so Orca pads its own with tool directories to find agent CLIs, and panes inherited that padded value before running a login shell on top of it. Shell config almost always prepends a directory only when it isn't already there, so every seeded copy cancelled the user's own prepend, and macOS path_helper had already pushed those directories behind /usr/bin. Panes now inherit the PATH Orca itself was launched with, which is what every other terminal emulator passes down, so the login shell derives the user's ordering by construction instead of Orca trying to reproduce it. Appending the seed at the end wouldn't help, since the directories would still be present and the prepends would still no-op, and the seed has to stay on the app's own PATH so bare-name git and gh keep resolving before the login-shell probe returns.

## Linked Issue

https://github.com/stablyai/orca/issues/17446

## Visual Proof

N/A - $PATH change only

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5

## Review

## Agent skill upstream boundary

- [ ] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [xI explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
