### PR TITLE
refactor(packaging): prune declaration and source-map artifacts in one walk

### DIFF
--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -442,19 +442,19 @@ function prunePackagedParcelWatcher(resourcesDir, electronPlatformName, electron
 // Why type declarations: they are compile-time only; the packaged app never resolves them.
 // Why source maps: they embed the original sources (megabytes for @linear/sdk alone) and
 // nothing in the packaged app turns on Node's source-map support, so they are never read.
-// Orca's own main-process maps live outside node_modules and ship as a separate artifact.
-function isPrunablePackagedRuntimeArtifact(filename) {
+// Orca's own main-process maps live outside node_modules and ship as a separate release artifact.
+function isPrunableTypeOrSourceMapArtifact(filename) {
   return TYPE_DECLARATION_ARTIFACT_RE.test(filename) || JS_SOURCE_MAP_ARTIFACT_RE.test(filename)
 }
 
-// Why one walk: both predicates are disjoint filename tests over the same tree, and a
-// second recursive traversal of packaged node_modules costs seconds for no extra deletions.
+// Why one walk: pruneMatchingFiles only ever deletes files, so passes over the same tree
+// commute — a second recursive traversal costs seconds for no extra deletions.
 function prunePackagedRuntimeTypeAndSourceMapArtifacts(resourcesDir) {
   const nodeModulesDir = join(resourcesDir, 'node_modules')
   if (!existsSync(nodeModulesDir)) {
     return
   }
-  pruneMatchingFiles(nodeModulesDir, isPrunablePackagedRuntimeArtifact)
+  pruneMatchingFiles(nodeModulesDir, isPrunableTypeOrSourceMapArtifact)
 }
 
 function prunePackagedSherpaOnnx(resourcesDir, electronPlatformName) {

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -439,24 +439,22 @@ function prunePackagedParcelWatcher(resourcesDir, electronPlatformName, electron
   }
 }
 
-function prunePackagedRuntimeTypeDeclarations(resourcesDir) {
-  const nodeModulesDir = join(resourcesDir, 'node_modules')
-  if (!existsSync(nodeModulesDir)) {
-    return
-  }
-  pruneMatchingFiles(nodeModulesDir, (filename) => TYPE_DECLARATION_ARTIFACT_RE.test(filename))
+// Why type declarations: they are compile-time only; the packaged app never resolves them.
+// Why source maps: they embed the original sources (megabytes for @linear/sdk alone) and
+// nothing in the packaged app turns on Node's source-map support, so they are never read.
+// Orca's own main-process maps live outside node_modules and ship as a separate artifact.
+function isPrunablePackagedRuntimeArtifact(filename) {
+  return TYPE_DECLARATION_ARTIFACT_RE.test(filename) || JS_SOURCE_MAP_ARTIFACT_RE.test(filename)
 }
 
-function prunePackagedRuntimeSourceMaps(resourcesDir) {
-  // Why: dependency source maps embed the original sources (megabytes for
-  // @linear/sdk alone), and nothing in the packaged app turns on Node's
-  // source-map support, so they are never read. Orca's own main-process maps
-  // live outside node_modules and ship as a separate release artifact.
+// Why one walk: both predicates are disjoint filename tests over the same tree, and a
+// second recursive traversal of packaged node_modules costs seconds for no extra deletions.
+function prunePackagedRuntimeTypeAndSourceMapArtifacts(resourcesDir) {
   const nodeModulesDir = join(resourcesDir, 'node_modules')
   if (!existsSync(nodeModulesDir)) {
     return
   }
-  pruneMatchingFiles(nodeModulesDir, (filename) => JS_SOURCE_MAP_ARTIFACT_RE.test(filename))
+  pruneMatchingFiles(nodeModulesDir, isPrunablePackagedRuntimeArtifact)
 }
 
 function prunePackagedSherpaOnnx(resourcesDir, electronPlatformName) {
@@ -494,10 +492,10 @@ function prunePackagedRuntimeNodeModules(resourcesDir, electronPlatformName, ele
   const architecture = normalizeElectronArchitecture(electronArch)
   prunePackagedNodePty(resourcesDir, electronPlatformName, architecture)
   prunePackagedParcelWatcher(resourcesDir, electronPlatformName, architecture)
-  prunePackagedRuntimeTypeDeclarations(resourcesDir)
-  prunePackagedRuntimeSourceMaps(resourcesDir)
-  prunePackagedSherpaOnnx(resourcesDir, electronPlatformName)
+  // Why before the filename walk: zod/src is deleted wholesale, so walking it first is wasted work.
   prunePackagedZodSources(resourcesDir)
+  prunePackagedRuntimeTypeAndSourceMapArtifacts(resourcesDir)
+  prunePackagedSherpaOnnx(resourcesDir, electronPlatformName)
 }
 
 function pruneMatchingFiles(directory, shouldPrune) {
@@ -520,9 +518,8 @@ module.exports = {
   prunePackagedNodePty,
   prunePackagedParcelWatcher,
   prunePackagedRuntimeNodeModules,
-  prunePackagedRuntimeSourceMaps,
+  prunePackagedRuntimeTypeAndSourceMapArtifacts,
   prunePackagedSherpaOnnx,
-  prunePackagedRuntimeTypeDeclarations,
   prunePackagedZodSources,
   verifyPackagedMainRuntimeDeps
 }

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -534,6 +534,7 @@ describe('electron-builder config', () => {
       await writeFile(join(packageDir, 'dist', 'index.cjs'), 'module.exports = {}', 'utf8')
       await writeFile(join(packageDir, 'dist', 'index.d.ts'), 'export type Value = string', 'utf8')
       await writeFile(join(packageDir, 'dist', 'index.d.cts'), 'export type Value = string', 'utf8')
+      await writeFile(join(packageDir, 'dist', 'index.d.mts'), 'export type Value = string', 'utf8')
       await writeFile(join(packageDir, 'dist', 'index.d.cts.map'), '{}', 'utf8')
       await writeFile(join(packageDir, 'dist', 'index.d.mts.map'), '{}', 'utf8')
 

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -17,7 +17,7 @@ const {
   prunePackagedNodePty,
   prunePackagedParcelWatcher,
   prunePackagedSherpaOnnx,
-  prunePackagedRuntimeTypeDeclarations,
+  prunePackagedRuntimeTypeAndSourceMapArtifacts,
   prunePackagedZodSources,
   verifyPackagedMainRuntimeDeps
 } = require('../packaged-runtime-node-modules.cjs')
@@ -534,9 +534,10 @@ describe('electron-builder config', () => {
       await writeFile(join(packageDir, 'dist', 'index.cjs'), 'module.exports = {}', 'utf8')
       await writeFile(join(packageDir, 'dist', 'index.d.ts'), 'export type Value = string', 'utf8')
       await writeFile(join(packageDir, 'dist', 'index.d.cts'), 'export type Value = string', 'utf8')
+      await writeFile(join(packageDir, 'dist', 'index.d.cts.map'), '{}', 'utf8')
       await writeFile(join(packageDir, 'dist', 'index.d.mts.map'), '{}', 'utf8')
 
-      prunePackagedRuntimeTypeDeclarations(resourcesDir)
+      prunePackagedRuntimeTypeAndSourceMapArtifacts(resourcesDir)
 
       await expect(readdir(join(packageDir, 'dist'))).resolves.toEqual(['index.cjs'])
     } finally {

--- a/config/scripts/packaged-source-map-prune.test.mjs
+++ b/config/scripts/packaged-source-map-prune.test.mjs
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest'
 
 const require = createRequire(import.meta.url)
 const {
-  prunePackagedRuntimeSourceMaps,
+  prunePackagedRuntimeTypeAndSourceMapArtifacts,
   prunePackagedRuntimeNodeModules
 } = require('../packaged-runtime-node-modules.cjs')
 
@@ -54,14 +54,14 @@ async function createPackagedNodeModulesFixture(resourcesDir) {
   return { packageDir, distDir, webhooksDir, updaterDir, jsYamlDir, nodePtyDir }
 }
 
-describe('packaged runtime source-map pruning', () => {
+describe('packaged runtime type-declaration and source-map pruning', () => {
   it('removes @linear/sdk source maps while preserving runtime files and non-JS maps', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-source-map-prune-'))
     try {
       const { packageDir, distDir, webhooksDir } =
         await createPackagedNodeModulesFixture(resourcesDir)
 
-      prunePackagedRuntimeSourceMaps(resourcesDir)
+      prunePackagedRuntimeTypeAndSourceMapArtifacts(resourcesDir)
 
       await expect(readdir(distDir).then((entries) => entries.sort())).resolves.toEqual([
         'index.cjs',
@@ -91,7 +91,7 @@ describe('packaged runtime source-map pruning', () => {
     try {
       const { jsYamlDir, nodePtyDir } = await createPackagedNodeModulesFixture(resourcesDir)
 
-      prunePackagedRuntimeSourceMaps(resourcesDir)
+      prunePackagedRuntimeTypeAndSourceMapArtifacts(resourcesDir)
 
       await expect(readdir(jsYamlDir)).resolves.toEqual(['js-yaml.min.js'])
       await expect(readdir(nodePtyDir)).resolves.toEqual(['index.js'])
@@ -100,25 +100,20 @@ describe('packaged runtime source-map pruning', () => {
     }
   })
 
-  it('leaves declaration-map cleanup to the type-declaration prune', async () => {
+  it('removes type declarations and declaration maps in the same walk', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-source-map-prune-dts-'))
     try {
       const { updaterDir } = await createPackagedNodeModulesFixture(resourcesDir)
 
-      prunePackagedRuntimeSourceMaps(resourcesDir)
+      prunePackagedRuntimeTypeAndSourceMapArtifacts(resourcesDir)
 
-      // Why: the two predicates are disjoint -- `.d.ts.map` never ends in `.js.map`.
-      await expect(readdir(updaterDir).then((entries) => entries.sort())).resolves.toEqual([
-        'main.d.ts',
-        'main.d.ts.map',
-        'main.js'
-      ])
+      await expect(readdir(updaterDir)).resolves.toEqual(['main.js'])
     } finally {
       await rm(resourcesDir, { recursive: true, force: true })
     }
   })
 
-  it('runs the source-map prune through aggregate runtime cleanup', async () => {
+  it('runs the artifact prune through aggregate runtime cleanup', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-source-map-aggregate-prune-'))
     try {
       const { distDir, updaterDir, packageDir } =


### PR DESCRIPTION
## What

`config/packaged-runtime-node-modules.cjs` had two functions that were byte-identical apart from their regex, and each did its own **full recursive walk** of packaged `Resources/node_modules` (~1.7s per walk locally):

- `prunePackagedRuntimeTypeDeclarations` — `/\.d\.(?:c|m)?ts(?:\.map)?$/`
- `prunePackagedRuntimeSourceMaps` — `/\.(?:c|m)?js\.map$/` (added in #17638)

They are now one walk with the OR of both predicates:

```js
function isPrunablePackagedRuntimeArtifact(filename) {
  return TYPE_DECLARATION_ARTIFACT_RE.test(filename) || JS_SOURCE_MAP_ARTIFACT_RE.test(filename)
}
```

## Behavior is unchanged

The same set of files is deleted, no more and no less. The two regexes are **disjoint** — a `.d.ts.map` never ends in `.js.map` — so a single pass over the tree deletes exactly the union the two passes deleted. The predicate stays filename-based, so `metadata.json.map` still survives.

### Exported surface

Neither old function had a production caller outside `prunePackagedRuntimeNodeModules` (only tests imported them directly). Keeping them as thin wrappers would have required keeping their separate predicates — and therefore the second walk — so both exports are replaced by the single `prunePackagedRuntimeTypeAndSourceMapArtifacts`, with the two call sites in the tests updated. `prunePackagedRuntimeNodeModules` is untouched from the caller's perspective.

### Bonus reorder

`prunePackagedZodSources` now runs *before* the filename walk instead of last. `zod/src` is deleted wholesale, so the walk was traversing it immediately before it was removed — pure wasted work. The prunes are independent of each other, so the order change does not affect the result (verified by the aggregate equivalence run below).

## Equivalence evidence

Throwaway script (not committed) built identical fixture trees and ran `git show origin/main:config/packaged-runtime-node-modules.cjs` against the new file. Fixture covered `.d.ts`, `.d.cts`, `.d.mts`, `.d.ts.map`, `.d.cts.map`, `.d.mts.map`, `.js.map`, `.cjs.map`, `.mjs.map`, a nested `bundle.min.js.map`, plus survivors: `.js`/`.cjs`/`.mjs`, `metadata.json.map`, `data.map`, `weird.js.map.bak`, `notes.d.txt`, `index.ts`, `binding.node`, `package.json`, `README.md`, `zod/src/*`, and the sherpa-onnx dylibs.

```
aggregate old==new: true (14 survivors)
filename prunes old(2 walks)==new(1 walk): true
deleted:
  node_modules/deep/a/b/c/bundle.min.js.map
  node_modules/pkg/dist/index.cjs.map
  node_modules/pkg/dist/index.d.cts
  node_modules/pkg/dist/index.d.cts.map
  node_modules/pkg/dist/index.d.mts
  node_modules/pkg/dist/index.d.mts.map
  node_modules/pkg/dist/index.d.ts
  node_modules/pkg/dist/index.d.ts.map
  node_modules/pkg/dist/index.js.map
  node_modules/pkg/dist/index.mjs.map
  node_modules/zod/src/nested.d.ts
  node_modules/zod/src/nested.js.map
survivors:
  node_modules/pkg/README.md
  node_modules/pkg/dist/data.map
  node_modules/pkg/dist/index.cjs
  node_modules/pkg/dist/index.js
  node_modules/pkg/dist/index.mjs
  node_modules/pkg/dist/index.ts
  node_modules/pkg/dist/notes.d.txt
  node_modules/pkg/dist/weird.js.map.bak
  node_modules/pkg/metadata.json.map
  node_modules/pkg/native/binding.node
  node_modules/pkg/package.json
  node_modules/sherpa-onnx-darwin-arm64/libonnxruntime.1.23.2.dylib
  node_modules/sherpa-onnx-darwin-arm64/libonnxruntime.dylib
  node_modules/sherpa-onnx-darwin-arm64/sherpa-onnx.node
  node_modules/zod/index.cjs
  node_modules/zod/src/index.ts
names matching BOTH regexes (must be empty): []
EQUIVALENT
```

Both comparisons matched exactly: the full `prunePackagedRuntimeNodeModules('darwin','arm64')` old-vs-new run, and old's two separate walks vs new's single walk. Regex disjointness was checked over every fixture basename plus generated `stem x extension` combinations (including adversarial stems like `x.d`, `y.js`, `z.d.ts`) — no filename matches both.

## Coverage

Both behaviors stay pinned:
- `.js.map` / `.cjs.map` / `.mjs.map` pruned across every packaged dep, `metadata.json.map` survives (`packaged-source-map-prune.test.mjs`)
- `.d.ts` / `.d.cts` / `.d.cts.map` / `.d.mts.map` pruned (`electron-builder-config.test.mjs`, now also covering `.d.cts.map`)
- the "leaves declaration maps to the other prune" test became "removes type declarations and declaration maps in the same walk" — it now asserts `electron-updater/out` is reduced to `main.js` alone
- the aggregate test through `prunePackagedRuntimeNodeModules` is unchanged and still passes

## Verification

- `pnpm test config/scripts/packaged-source-map-prune.test.mjs config/scripts/electron-builder-config.test.mjs` — 41 passed
- `pnpm exec oxlint <changed files>` — clean
- `oxfmt --check` — clean
- `pnpm tc` — clean
