### PR TITLE
test(settings): cover Escape dismissal from the search field

### DIFF
--- a/src/renderer/src/components/settings/use-settings-page-effects.escape.test.tsx
+++ b/src/renderer/src/components/settings/use-settings-page-effects.escape.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import {
+  SHORTCUTS_ESCAPE_CONFIRM_TOAST_ID,
+  SHORTCUTS_ESCAPE_CONFIRM_WINDOW_MS
+} from './settings-navigation-foundations'
+import { useSettingsPageEffects } from './use-settings-page-effects'
+import type { SettingsInteractionController } from './use-settings-interaction-controller'
+import type { SettingsStoreModel } from './use-settings-store-model'
+
+vi.mock('sonner', () => ({
+  toast: {
+    dismiss: vi.fn(),
+    info: vi.fn()
+  }
+}))
+
+function createSettingsModel(overrides: Partial<SettingsStoreModel> = {}): SettingsStoreModel {
+  return {
+    activeSectionId: 'general',
+    clearSettingsTarget: vi.fn(),
+    fetchKeybindings: vi.fn(),
+    fetchSettings: vi.fn(),
+    keybindings: {},
+    refreshModelStates: vi.fn().mockResolvedValue(undefined),
+    repoIdToHostSelection: new Map(),
+    repoIdToRepresentative: new Map(),
+    setHighlightedSettingsTargetId: vi.fn(),
+    setMountedSectionIds: vi.fn(),
+    setPendingNavRequestTick: vi.fn(),
+    setQuickCommandAddIntentSignal: vi.fn(),
+    setRemoteServerAddIntentSignal: vi.fn(),
+    setSettingsProjectHostSelection: vi.fn(),
+    setSshHostAddIntentSignal: vi.fn(),
+    setVoiceModelStatesLoading: vi.fn(),
+    settings: null,
+    settingsNavigationTarget: null,
+    settingsProjectList: [],
+    showDesktopOnlySettings: false,
+    ...overrides
+  } as unknown as SettingsStoreModel
+}
+
+function createSettingsInteractions(
+  overrides: Partial<SettingsInteractionController> = {}
+): SettingsInteractionController {
+  return {
+    closeSettingsPageWithPromptGuard: vi.fn().mockResolvedValue(undefined),
+    hasUnsavedSourceControlAiPromptChangesRef: { current: false },
+    pendingNavSectionRef: { current: null },
+    pendingScrollTargetRef: { current: null },
+    promptDiscardSourceControlAiPromptChanges: vi.fn().mockResolvedValue(true),
+    searchInputRef: { current: null },
+    shortcutsEscapeConfirmUntilRef: { current: 0 },
+    ...overrides
+  } as unknown as SettingsInteractionController
+}
+
+function focusTextInput(): HTMLInputElement {
+  const input = document.createElement('input')
+  document.body.append(input)
+  input.focus()
+  return input
+}
+
+function createEscapeEvent(overrides: KeyboardEventInit = {}): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key: 'Escape',
+    ...overrides
+  })
+}
+
+function dispatchEscape(target: EventTarget, overrides: KeyboardEventInit = {}): KeyboardEvent {
+  const event = createEscapeEvent(overrides)
+  target.dispatchEvent(event)
+  return event
+}
+
+afterEach(() => {
+  cleanup()
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('useSettingsPageEffects Escape handling', () => {
+  it('closes Settings when Escape starts from the focused search field', () => {
+    const closeSettingsPageWithPromptGuard = vi.fn().mockResolvedValue(undefined)
+    const input = focusTextInput()
+
+    renderHook(() =>
+      useSettingsPageEffects(
+        createSettingsModel(),
+        createSettingsInteractions({ closeSettingsPageWithPromptGuard })
+      )
+    )
+
+    act(() => {
+      dispatchEscape(input)
+    })
+
+    expect(closeSettingsPageWithPromptGuard).toHaveBeenCalledOnce()
+  })
+
+  it('does not close Settings when IME composition owns Escape', () => {
+    const closeSettingsPageWithPromptGuard = vi.fn().mockResolvedValue(undefined)
+    const input = focusTextInput()
+
+    renderHook(() =>
+      useSettingsPageEffects(
+        createSettingsModel(),
+        createSettingsInteractions({ closeSettingsPageWithPromptGuard })
+      )
+    )
+
+    act(() => {
+      const event = createEscapeEvent()
+      Object.defineProperty(event, 'isComposing', { value: true })
+      input.dispatchEvent(event)
+    })
+
+    expect(closeSettingsPageWithPromptGuard).not.toHaveBeenCalled()
+  })
+
+  it('does not close Settings when a child control already handled Escape', () => {
+    const closeSettingsPageWithPromptGuard = vi.fn().mockResolvedValue(undefined)
+    const input = focusTextInput()
+
+    renderHook(() =>
+      useSettingsPageEffects(
+        createSettingsModel(),
+        createSettingsInteractions({ closeSettingsPageWithPromptGuard })
+      )
+    )
+
+    act(() => {
+      const event = createEscapeEvent()
+      event.preventDefault()
+      input.dispatchEvent(event)
+    })
+
+    expect(closeSettingsPageWithPromptGuard).not.toHaveBeenCalled()
+  })
+
+  it('keeps the Shortcuts page double-Escape guard when focus starts in an input', () => {
+    const closeSettingsPageWithPromptGuard = vi.fn().mockResolvedValue(undefined)
+    const shortcutsEscapeConfirmUntilRef = { current: 0 }
+    const input = focusTextInput()
+    vi.spyOn(Date, 'now').mockReturnValue(10_000)
+
+    renderHook(() =>
+      useSettingsPageEffects(
+        createSettingsModel({ activeSectionId: 'shortcuts' }),
+        createSettingsInteractions({
+          closeSettingsPageWithPromptGuard,
+          shortcutsEscapeConfirmUntilRef
+        })
+      )
+    )
+
+    const firstEscape = createEscapeEvent()
+    act(() => {
+      input.dispatchEvent(firstEscape)
+    })
+
+    expect(firstEscape.defaultPrevented).toBe(true)
+    expect(closeSettingsPageWithPromptGuard).not.toHaveBeenCalled()
+    expect(shortcutsEscapeConfirmUntilRef.current).toBe(10_000 + SHORTCUTS_ESCAPE_CONFIRM_WINDOW_MS)
+    expect(toast.info).toHaveBeenCalledWith('Press ESC again to exit settings', {
+      className: 'whitespace-nowrap',
+      duration: SHORTCUTS_ESCAPE_CONFIRM_WINDOW_MS,
+      id: SHORTCUTS_ESCAPE_CONFIRM_TOAST_ID
+    })
+
+    const secondEscape = createEscapeEvent()
+    act(() => {
+      input.dispatchEvent(secondEscape)
+    })
+
+    expect(secondEscape.defaultPrevented).toBe(true)
+    expect(shortcutsEscapeConfirmUntilRef.current).toBe(0)
+    expect(toast.dismiss).toHaveBeenCalledWith(SHORTCUTS_ESCAPE_CONFIRM_TOAST_ID)
+    expect(closeSettingsPageWithPromptGuard).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## ELI5

Settings used to ignore Escape when the search field had focus. The behavior fix has already landed in #17516; this PR adds regression tests so the first Escape from the focused search field keeps closing Settings.

## What Changed

Added focused tests for `useSettingsPageEffects` Escape handling:

- Escape from a focused text input closes Settings.
- IME composition Escape is still ignored.
- Events already handled with `preventDefault()` are still ignored.
- The Shortcuts page still requires the existing double-Escape confirmation, even when focus starts in an input.

## Why

#17338 remained open after #17516 fixed the production behavior. This keeps the PR scope tight by adding only regression coverage around the merged behavior, including the nearby safeguards that could regress if the Escape guard is changed again.

## Linked Issue

Fixes #17338

## Visual Proof

N/A — test-only regression coverage; the user-facing behavior already landed in #17516.

## Testing

Tested locally on Windows:

- `corepack pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/use-settings-page-effects.escape.test.tsx`
- `corepack pnpm exec oxlint --report-unused-disable-directives-severity warn src/renderer/src/components/settings/use-settings-page-effects.escape.test.tsx`
- `corepack pnpm exec oxlint --type-aware --config config/oxlint-code-quality-type-aware.json src/renderer/src/components/settings/use-settings-page-effects.escape.test.tsx --deny-warnings`
- `corepack pnpm run tc:web`
- `corepack pnpm exec lint-staged`

Note: `corepack pnpm run check:code-quality:changed` could not complete in this Windows shell because Node failed to spawn the local `pnpm.cmd` shim with `EINVAL`; the relevant oxlint checks and lint-staged were run directly and passed.

- [ ] I manually tested these changes locally — not applicable for test-only coverage.
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with AI assistance from OpenAI Codex (GPT-5), with contributor direction and review.

## Review

Test-only change. No production behavior, persistence, security, performance, remote, SSH, mobile, or provider behavior changed.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Cross-platform impact considered: the tested behavior is renderer-level keyboard handling and does not depend on OS path, shell, Git provider, SSH, remote host, or mobile-specific behavior. IME handling remains covered through `event.isComposing`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted test/lint/typecheck passed locally; full lint/build left to CI.