### PR TITLE
test(updater): cancel the real timers an abandoned updater instance leaks

### DIFF
--- a/src/main/updater-test-harness.leaked-timers.test.ts
+++ b/src/main/updater-test-harness.leaked-timers.test.ts
@@ -1,0 +1,120 @@
+import { setTimeout as sleep } from 'node:timers/promises'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+
+const { autoUpdaterMock, fetchNewerReleaseTagsMock, moduleFactories, resetUpdaterMocks } =
+  await vi.hoisted(async () => (await import('./updater-test-harness')).createUpdaterMocks())
+
+vi.mock('electron', () => moduleFactories.electron())
+vi.mock('electron-updater', () => moduleFactories.electronUpdater())
+vi.mock('./electron-updater-loader', () => moduleFactories.electronUpdaterLoader())
+vi.mock('@electron-toolkit/utils', () => moduleFactories.electronToolkitUtils())
+vi.mock('./ipc/pty', () => moduleFactories.ipcPty())
+vi.mock('./linux-update-package-type', () => moduleFactories.linuxUpdatePackageType())
+vi.mock('./updater-lifecycle-diagnostics', () => moduleFactories.updaterLifecycleDiagnostics())
+vi.mock('./updater-changelog', () => moduleFactories.updaterChangelog())
+vi.mock('./updater-nudge', () => moduleFactories.updaterNudge())
+vi.mock('./update-install-exit-watchdog', () => moduleFactories.updateInstallExitWatchdog())
+vi.mock('./updater-prerelease-feed', () => moduleFactories.updaterPrereleaseFeed())
+vi.mock('./local-builds/local-build-switch', () => moduleFactories.localBuildSwitch())
+vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBuildFeedServer())
+
+const SILENT_SETTLE_DELAY_MS = 1_000
+const AUTO_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+describe('updater test harness real-timer tracking', () => {
+  beforeEach(() => {
+    resetUpdaterMocks()
+  })
+
+  it('cancels a real timer armed before the reset', async () => {
+    let fired = false
+    setTimeout(() => {
+      fired = true
+    }, 20)
+
+    resetUpdaterMocks()
+
+    await sleep(150)
+    expect(fired).toBe(false)
+  })
+
+  it('still arms real timers after the reset', async () => {
+    let fired = false
+    setTimeout(() => {
+      fired = true
+    }, 10)
+
+    await sleep(150)
+    expect(fired).toBe(true)
+  })
+
+  it('hands back the untouched Node timeout handle', () => {
+    const handle = setTimeout(() => {}, 60_000)
+
+    // Why: production code calls unref() on these; the tracker must not swap in a plain id.
+    expect(typeof handle.unref).toBe('function')
+    handle.unref()
+    clearTimeout(handle)
+  })
+})
+
+// Why: this pair reproduces the cross-test leak, so it depends on running in file order — the first
+// test arms the timer and the second one is the later test it used to fire into.
+describe('abandoned updater instance', () => {
+  let leakedStatusSend: Mock = vi.fn()
+
+  beforeEach(() => {
+    resetUpdaterMocks()
+  })
+
+  it('leaves a silent-settle timer armed when its module instance is abandoned', async () => {
+    let resolveCheck: (value: unknown) => void = () => {}
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      // Why: the checking status is what makes the silent settle publish 'not-available' later.
+      autoUpdaterMock.emit('checking-for-update')
+      return new Promise((resolve) => {
+        resolveCheck = resolve
+      })
+    })
+    leakedStatusSend = vi.fn()
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater({ webContents: { send: leakedStatusSend } } as never, {
+      getLastUpdateCheckAt: () => Date.now() - 25 * 60 * 60 * 1000
+    })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    })
+
+    // Why: resolving without a terminal event is what arms the 1s silent settle; do it here so the
+    // full delay is still ahead of us and the timer is guaranteed to be pending when this test ends.
+    resolveCheck(undefined)
+    await sleep(0)
+
+    expect(leakedStatusSend).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'not-available' })
+    )
+  })
+
+  it('never reaches the shared spies once the next test owns the clock', async () => {
+    vi.useFakeTimers()
+
+    // Why: real time past the settle delay — the abandoned instance would settle here and re-arm its
+    // 24h auto check on this test's fake clock at its epoch.
+    await sleep(SILENT_SETTLE_DELAY_MS + 300)
+    await vi.advanceTimersByTimeAsync(AUTO_UPDATE_CHECK_INTERVAL_MS)
+
+    expect(leakedStatusSend).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'not-available' })
+    )
+    // Why: the generation fence stops at the autoUpdater spies; this one sits past it on the
+    // pinDefaultReleaseFeed chain that the stale instance's re-armed background check still reached.
+    expect(fetchNewerReleaseTagsMock).not.toHaveBeenCalled()
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/updater-test-harness.ts
+++ b/src/main/updater-test-harness.ts
@@ -1,5 +1,6 @@
-import { vi } from 'vitest'
+import { afterAll, vi } from 'vitest'
 import type { Mock } from 'vitest'
+import { clearTrackedRealTimers, trackRealTimers } from './updater-test-timer-tracking'
 
 /** Loose spy signature for the electron/electron-updater calls the suites only assert on. */
 type UpdaterSpy = Mock<(...args: unknown[]) => unknown>
@@ -257,6 +258,9 @@ export function createUpdaterMocks(): UpdaterMocks {
   const resetUpdaterMocks = () => {
     vi.clearAllTimers()
     vi.useRealTimers()
+    // Why: the generation fence only ignores a stale instance's spy calls; this cancels the real
+    // timers it left armed so it never runs at all.
+    clearTrackedRealTimers()
     vi.resetModules()
     autoUpdaterMock.reset()
     nativeUpdaterMock.on.mockReset()
@@ -284,7 +288,11 @@ export function createUpdaterMocks(): UpdaterMocks {
       close: closeLocalBuildFeedMock
     })
     vi.unstubAllGlobals()
+    trackRealTimers()
   }
+
+  // Why: keeps the timer patch scoped to files that use the harness instead of the whole worker.
+  afterAll(clearTrackedRealTimers)
 
   return {
     appMock,

--- a/src/main/updater-test-harness.ts
+++ b/src/main/updater-test-harness.ts
@@ -291,8 +291,12 @@ export function createUpdaterMocks(): UpdaterMocks {
     trackRealTimers()
   }
 
-  // Why: keeps the timer patch scoped to files that use the harness instead of the whole worker.
-  afterAll(clearTrackedRealTimers)
+  // Why: keeps the timer patch scoped to files that use the harness. Fakes are dropped first
+  // because a file ending on a fake clock fails the wrapper's identity guard, stranding it.
+  afterAll(() => {
+    vi.useRealTimers()
+    clearTrackedRealTimers()
+  })
 
   return {
     appMock,

--- a/src/main/updater-test-timer-tracking.ts
+++ b/src/main/updater-test-timer-tracking.ts
@@ -9,6 +9,10 @@ import { vi } from 'vitest'
  *
  * Vitest arms its own test timeouts through `getSafeTimers()`, snapshotted at worker setup, so
  * nothing here can capture or cancel them.
+ *
+ * Scope: the `globalThis` timer functions only. `node:timers/promises` and `util.promisify`
+ * bypass this entirely, so an `await setTimeout(...)` added to `updater.ts` would reopen the
+ * leak without failing a test here.
  */
 
 /** Node hands back a `Timeout` object; other environments hand back an id. */

--- a/src/main/updater-test-timer-tracking.ts
+++ b/src/main/updater-test-timer-tracking.ts
@@ -1,0 +1,100 @@
+import { vi } from 'vitest'
+
+/**
+ * Cancels the real timers an abandoned `updater` module instance left armed.
+ *
+ * Why: `vi.resetModules()` drops the previous test's instance but cannot cancel the timers it already
+ * scheduled, so they fire into a later test and drive shared spies. Fake handles die with
+ * `vi.useRealTimers()`, which leaves real handles as the only leak channel.
+ *
+ * Vitest arms its own test timeouts through `getSafeTimers()`, snapshotted at worker setup, so
+ * nothing here can capture or cancel them.
+ */
+
+/** Node hands back a `Timeout` object; other environments hand back an id. */
+type RealTimerHandle = ReturnType<typeof setTimeout> | number
+type ArmTimer = (...args: never[]) => RealTimerHandle
+type ClearTimer = (handle?: RealTimerHandle) => void
+
+type TimerGlobals = {
+  setTimeout: ArmTimer
+  setInterval: ArmTimer
+  clearTimeout: ClearTimer
+  clearInterval: ClearTimer
+}
+
+// Why: the ambient `setTimeout` overloads disagree on the handle type across lib.dom/@types/node;
+// this view keeps the wrapper honest about what it actually does — pass through and remember.
+const timerGlobals = globalThis as unknown as TimerGlobals
+
+const armedTimeouts = new Set<RealTimerHandle>()
+const armedIntervals = new Set<RealTimerHandle>()
+let originalTimers: TimerGlobals | null = null
+let trackingTimers: TimerGlobals | null = null
+
+/** Returns the handle untouched so callers keep `unref()` and friends. */
+const trackArmed = (arm: ArmTimer, armed: Set<RealTimerHandle>): ArmTimer =>
+  Object.assign((...args: never[]) => {
+    const handle = arm(...args)
+    armed.add(handle)
+    return handle
+  }, arm)
+
+/** Untracking on cancel bounds the set and keeps a recycled numeric id from cancelling a live timer. */
+const trackCleared = (clear: ClearTimer, armed: Set<RealTimerHandle>): ClearTimer =>
+  Object.assign((handle?: RealTimerHandle) => {
+    if (handle !== undefined) {
+      armed.delete(handle)
+    }
+    clear(handle)
+  }, clear)
+
+/** Wraps the real timer globals so anything armed from here on can be cancelled. Idempotent. */
+export function trackRealTimers(): void {
+  // Why: wrapping a fake clock would capture handles vitest already discards, and its restore would
+  // throw the wrapper away anyway.
+  if (trackingTimers || vi.isFakeTimers()) {
+    return
+  }
+  const original: TimerGlobals = {
+    setTimeout: timerGlobals.setTimeout,
+    setInterval: timerGlobals.setInterval,
+    clearTimeout: timerGlobals.clearTimeout,
+    clearInterval: timerGlobals.clearInterval
+  }
+  originalTimers = original
+  trackingTimers = {
+    setTimeout: trackArmed(original.setTimeout, armedTimeouts),
+    setInterval: trackArmed(original.setInterval, armedIntervals),
+    clearTimeout: trackCleared(original.clearTimeout, armedTimeouts),
+    clearInterval: trackCleared(original.clearInterval, armedIntervals)
+  }
+  Object.assign(timerGlobals, trackingTimers)
+}
+
+/** Cancels every real timer armed since tracking started, then hands the globals back untouched. */
+export function clearTrackedRealTimers(): void {
+  const original = originalTimers
+  const tracking = trackingTimers
+  if (!original || !tracking) {
+    return
+  }
+  try {
+    for (const handle of armedTimeouts) {
+      original.clearTimeout(handle)
+    }
+    for (const handle of armedIntervals) {
+      original.clearInterval(handle)
+    }
+  } finally {
+    armedTimeouts.clear()
+    armedIntervals.clear()
+    // Why: a fake clock installed over the wrapper owns the globals until vitest restores it, so only
+    // take back what is still ours; tracking stays on until then rather than clobbering the fakes.
+    if (timerGlobals.setTimeout === tracking.setTimeout) {
+      Object.assign(timerGlobals, original)
+      originalTimers = null
+      trackingTimers = null
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #17649, which was a partial fix.

## What #17649 fixed, and what it left open

#17649 diagnosed the `updater.startup-scheduling` flake correctly: `resetUpdaterMocks()` calls `vi.resetModules()`, which abandons the previous test's `updater` module instance but **cannot cancel the real timers that instance already armed**. The abandoned instance's 1s `updateCheckSilentSettleTimer` (`UPDATE_CHECK_SILENT_SETTLE_DELAY_MS`, `src/main/updater.ts:118`, armed at `:601`) fires during a *later* test that has since installed a fake clock, runs `completeSilentUpdateCheck()` -> `scheduleAutomaticUpdateCheck(24h)` on **that test's fake clock at its epoch**, and then double-drives shared spies.

Its fix was a generation fence: `loadElectronAutoUpdater()` hands each module instance a generation-stamped proxy of `autoUpdaterMock`, and `reset()` bumps the generation so a stale instance's calls and property writes are dropped.

That fences the `autoUpdater` spies only. The leaked timer still runs, and everything downstream of it is un-fenced:

| Leaked timer | Chain | Un-fenced shared spy | Exact-count assertions |
| --- | --- | --- | --- |
| 1s silent settle -> re-armed 24h auto check | `runBackgroundUpdateCheck()` -> `pinDefaultReleaseFeed()` (`updater.ts:1357`) -> `fetchNewerReleaseTagsWithReadiness` | `fetchNewerReleaseTagsMock` | `updater.check-preflight.test.ts:59,309,528`; `updater.publishing-window-feed.test.ts:382,458` |
| `scheduleUpdateNudgeCheck()` (`updater.ts:2122-2130`) | `checkForUpdateNudge()` | `fetchNudgeMock` / `shouldApplyNudgeMock` | `updater.nudge-campaign.test.ts:168,175` |
| 1s silent settle | `settleSilentUpdateCheck()` -> `sendStatus()` | the previous test's `webContents.send` mock | — |
| `completeSilentUpdateCheck()` 1h retry (`updater.ts:553`) | re-armed auto check | `autoUpdaterMock.checkForUpdates` | `updater.startup-scheduling.test.ts:76`, plus files that advance exactly 59min + 1min |

## The fix

Close the leak channel instead of ignoring its downstream effects.

`src/main/updater-test-timer-tracking.ts` (new) wraps the real `setTimeout` / `setInterval` / `clearTimeout` / `clearInterval` globals and remembers every handle armed since the last reset. `resetUpdaterMocks()` now cancels them right after `vi.useRealTimers()`, so the abandoned instance never runs at all. Fake handles are already discarded by `vi.useRealTimers()`, which made real handles the only remaining leak channel.

Safety properties, all deliberate:

- **Never fights vitest's clock.** The wrapper installs only when `vi.isFakeTimers()` is false (end of `resetUpdaterMocks()`, after `vi.useRealTimers()`), so it can never capture fake handles. If a test installs a fake clock over it, `vi.useRealTimers()` restores the wrapper on the way out.
- **Restores only what is still its own.** Uninstall is guarded on `globalThis.setTimeout` still holding the wrapper, so it can't clobber a fake clock or a `vi.stubGlobal` that sits on top; tracking simply stays live until it can hand the globals back cleanly. Clearing is `try`/`finally` so an exception can't strand the patch.
- **Scoped to files that use the harness.** `createUpdaterMocks()` registers `afterAll(clearTrackedRealTimers)`, so no unrelated test file in the same worker ever sees the patch.
- **Handles pass through untouched.** The wrapper returns the original Node `Timeout` object, so `unref()` and friends keep working; numeric handles are supported too, and `clearTimeout`/`clearInterval` untrack so a recycled id can never cancel a live timer.
- **Cannot touch vitest's own timers.** Vitest arms test timeouts, `waitFor`, RPC and console through `getSafeTimers()`, snapshotted at worker setup, so nothing here can capture or cancel them.

**The #17649 generation fence is untouched.** This is additive defense in depth, not a replacement.

## Proof it works

`src/main/updater-test-harness.leaked-timers.test.ts` (new, 5 tests). Two of them fail on `main` and pass here:

1. `cancels a real timer armed before the reset` — arms a 20ms real timer, calls `resetUpdaterMocks()`, waits 150ms. Without the fix: `expected true to be false`.
2. `never reaches the shared spies once the next test owns the clock` — the paired test before it drives a real (non-fake-clock) background startup check whose promise resolves with no terminal event, arming the 1s silent settle, then ends without draining it. This test installs a fake clock, sleeps past the settle delay in **real** time, and advances the fake clock 24h. Without the fix the abandoned instance settles, re-arms its 24h check on this test's fake clock, and reaches the un-fenced spy:

```
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
  1st vi.fn() call: [ "1.0.51", 1, { "includePrerelease": false } ]
  ❯ expect(fetchNewerReleaseTagsMock).not.toHaveBeenCalled()
```

It also catches the stale `'not-available'` status published into the previous test's window mock.

The other three tests guard the wrapper itself: timers armed after a reset still fire, and the returned handle is still a Node `Timeout` with a working `unref()`.

## Verification

All runs on this branch, macOS, one job at a time (concurrent heavy jobs push the `updater.ts` transform past the 30s `testTimeout` and produce unrelated failures):

| Suite | Runs | Failures |
| --- | --- | --- |
| `pnpm test src/main/updater.startup-scheduling.test.ts` | 42 | 0 |
| `pnpm test src/main/updater.check-preflight.test.ts` | 15 | 0 |
| `pnpm test src/main/updater.publishing-window-feed.test.ts` | 15 | 0 |
| `pnpm test src/main/updater.nudge-campaign.test.ts` | 15 | 0 |
| `pnpm test src/main/updater-test-harness.leaked-timers.test.ts` | 15 | 0 |

Full updater suite: `pnpm test src/main/updater` -> **23 files, 269 tests, all passing** (22 files / 264 tests before, plus the 5 new ones).

`pnpm exec oxlint` clean on all three changed files, `oxfmt --check` clean, `pnpm run check:max-lines-ratchet` clean, `pnpm tc` clean. `updater-test-harness.ts` sits at ~276 countable lines against the 300 cap; the timer tracking lives in its own module rather than eating that headroom.


---

## Correction after review

An earlier revision of this PR claimed `afterAll(clearTrackedRealTimers)` kept the patch scoped so "no unrelated test file in the same worker ever sees it." **That was false**, and review caught it.

The uninstall is guarded on identity (`globalThis.setTimeout === wrapper`) so it can't clobber a fake clock layered above. But no updater test ever calls `vi.useRealTimers()` — the only restore is the *next* `beforeEach`, which never runs after a file's last test. So any file ending on a fake clock stranded the wrapper permanently. Four files did exactly that:

- `updater.check-settlement.test.ts:334`
- `updater.publishing-window-feed.test.ts:553`
- `updater.quit-and-install.test.ts:394`
- `updater-test-harness.leaked-timers.test.ts` — this PR's own test

Fixed by dropping fakes before reclaiming the globals:

```js
afterAll(() => {
  vi.useRealTimers()
  clearTrackedRealTimers()
})
```

Verified both directions with a scratch test reproducing the case (file ends on a fake clock): it fails `expected [Function setTimeout] to be [Function setTimeout]` without the `vi.useRealTimers()` line and passes with it.

## The real safety boundary: `isolate: true`

Worth stating plainly rather than leaving implicit. `config/vitest.config.ts` never sets `isolate`, and vitest 4.1.11 defaults it to `true` — each test file gets its own forked process, so even a stranded wrapper dies with the worker. That, not `afterAll`, is what made the original bug harmless.

**If anyone sets `--no-isolate` for CI speed, re-audit this module.** With the fix above the wrapper is removed properly, but the blast radius under a shared worker is: patch stays installed for every later file, `armedTimeouts`/`armedIntervals` retain every `Timeout` object forever, and a later updater file's `resetUpdaterMocks()` cancels live timers belonging to unrelated suites.

## Scope limit

`node:timers/promises` and `util.promisify` bypass the globals entirely (`Object.assign` copies Node's `promisify.custom` value, so `util.promisify(globalThis.setTimeout)` resolves to `timers/promises.setTimeout`). Harmless today — `updater.ts` uses neither — but an `await setTimeout(...)` added there later would reopen this leak with **no failing test**. Noted in the module docstring.
