### PR TITLE
perf(terminal): cut cold worktree-switch attach latency

### DIFF
--- a/src/main/daemon/headless-emulator-snapshot-cache.test.ts
+++ b/src/main/daemon/headless-emulator-snapshot-cache.test.ts
@@ -72,6 +72,21 @@ describe('HeadlessEmulator snapshot cache', () => {
     expect(snapshot.snapshotAnsi).toContain('second line')
   })
 
+  it('keeps the cache across a resize to the size already applied', async () => {
+    // Why: every attach re-asserts the pane's dimensions, so bumping on a
+    // no-op resize made a reattach of an idle session miss its own snapshot —
+    // measured as 382ms of re-serialize per session before this gate.
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('unchanged dimensions')
+    emulator.getSnapshot()
+    const serialize = spyOnSerialize(emulator)
+
+    emulator.resize(80, 24)
+
+    emulator.getSnapshot()
+    expect(serialize.calls()).toBe(0)
+  })
+
   it('invalidates on resize', async () => {
     emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
     await emulator.write('sized')

--- a/src/main/daemon/headless-emulator-snapshot-cache.test.ts
+++ b/src/main/daemon/headless-emulator-snapshot-cache.test.ts
@@ -34,7 +34,7 @@ describe('HeadlessEmulator snapshot cache', () => {
     expect(second.scrollbackAnsi).toBe(first.scrollbackAnsi)
   })
 
-  it('re-serializes for a different scrollbackRows window', async () => {
+  it('re-serializes the first time a different scrollbackRows window is asked for', async () => {
     emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
     await emulator.write('hello world')
     emulator.getSnapshot({ scrollbackRows: 100 })
@@ -43,6 +43,22 @@ describe('HeadlessEmulator snapshot cache', () => {
     emulator.getSnapshot({ scrollbackRows: 500 })
 
     expect(serialize.calls()).toBeGreaterThan(0)
+  })
+
+  it('keeps two alternating scrollback windows warm', async () => {
+    // Why: attach asks for the full window while agent/text reads ask for 0,
+    // and a single-slot cache thrashes to a 0% hit rate when they alternate.
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('alternating windows')
+    emulator.getSnapshot({ scrollbackRows: 0 })
+    emulator.getSnapshot()
+    const serialize = spyOnSerialize(emulator)
+
+    emulator.getSnapshot({ scrollbackRows: 0 })
+    emulator.getSnapshot()
+    emulator.getSnapshot({ scrollbackRows: 0 })
+
+    expect(serialize.calls()).toBe(0)
   })
 
   it('reflects an async write that lands after a cached snapshot', async () => {

--- a/src/main/daemon/headless-emulator-snapshot-cache.test.ts
+++ b/src/main/daemon/headless-emulator-snapshot-cache.test.ts
@@ -80,16 +80,21 @@ describe('HeadlessEmulator snapshot cache', () => {
     expect(emulator.getSnapshot().snapshotAnsi).not.toContain('line 0')
   })
 
-  it('invalidates on cwd and title changes', async () => {
+  it('updates cwd and title without discarding the memoized serialize', async () => {
+    // Why: both are read fresh per build and never memoized, so invalidating on
+    // them would throw away a whole serialize. OSC 7 lands on every `cd`.
     emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
     await emulator.write('x')
     expect(emulator.getSnapshot().cwd).toBeNull()
+    const serialize = spyOnSerialize(emulator)
 
     emulator.setCwd('/tmp/project')
     expect(emulator.getSnapshot().cwd).toBe('/tmp/project')
 
     emulator.setLastTitle('agent running')
     expect(emulator.getSnapshot().lastTitle).toBe('agent running')
+
+    expect(serialize.calls()).toBe(0)
   })
 
   it('invalidates on restored osc links', async () => {
@@ -148,58 +153,47 @@ describe('HeadlessEmulator snapshot cache', () => {
     expect(emulator.getSnapshot().snapshotAnsi).toContain('after fence')
   })
 
-  it('invalidates on dispose so a post-dispose read is never served the cache', async () => {
-    const disposable = new HeadlessEmulator({ cols: 80, rows: 24 })
-    await disposable.write('pre dispose')
-    disposable.getSnapshot()
-    const serialize = spyOnSerialize(disposable)
-
-    disposable.dispose()
-
-    expect(serialize.calls()).toBe(0)
-  })
-
-  // Why this guard: the cache's correctness rests on every mutator calling
-  // markMutated(), which is convention, not a type. Freezing the public surface
-  // makes a new method a deliberate decision about invalidation rather than a
-  // silent stale-snapshot bug.
-  it('has no unreviewed public methods that could mutate state', () => {
+  // Why this guard: the cache's correctness rests on every mutator of a
+  // memoized part calling markMutated(), which is convention, not a type.
+  // Freezing the prototype makes a new method a deliberate decision about
+  // invalidation rather than a silent stale-snapshot bug. TS-private members
+  // appear too — getOwnPropertyNames has no visibility notion — so a rename
+  // updates this list; that is the intended cost of the ratchet.
+  it('has no unreviewed prototype members that could mutate memoized state', () => {
     emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
     const surface = Object.getOwnPropertyNames(HeadlessEmulator.prototype)
       .filter((name) => name !== 'constructor')
       .sort()
-    expect(surface).toEqual(
-      [
-        'applyKittyKeyboardFlags',
-        'applyPushedViewAttributes',
-        'clearScrollback',
-        'disableQueryReplyForwarding',
-        'dispose',
-        'getAppliedSize',
-        'getBufferTailLines',
-        'getCursorLineContext',
-        'getCwd',
-        'getModes',
-        'getSnapshot',
-        'getVisibleBufferRange',
-        'getVisibleLines',
-        'installConptyPrimaryDeviceAttributesOverride',
-        'installViewAttributeResponder',
-        'isAlternateScreen',
-        'isCursorOnEmptyPromptLine',
-        'markMutated',
-        'markWritten',
-        'partialEscapeTailAnsi',
-        'emitQueryReply',
-        'resize',
-        'responderParser',
-        'setCwd',
-        'setLastTitle',
-        'setRestoredOscLinks',
-        'write',
-        'writeSync',
-        'tryWriteSync'
-      ].sort()
-    )
+    expect(surface).toEqual([
+      'applyKittyKeyboardFlags',
+      'applyPushedViewAttributes',
+      'clearScrollback',
+      'disableQueryReplyForwarding',
+      'dispose',
+      'emitQueryReply',
+      'getAppliedSize',
+      'getBufferTailLines',
+      'getCursorLineContext',
+      'getCwd',
+      'getModes',
+      'getSnapshot',
+      'getVisibleBufferRange',
+      'getVisibleLines',
+      'installConptyPrimaryDeviceAttributesOverride',
+      'installViewAttributeResponder',
+      'isAlternateScreen',
+      'isCursorOnEmptyPromptLine',
+      'markMutated',
+      'markWritten',
+      'partialEscapeTailAnsi',
+      'resize',
+      'responderParser',
+      'setCwd',
+      'setLastTitle',
+      'setRestoredOscLinks',
+      'tryWriteSync',
+      'write',
+      'writeSync'
+    ])
   })
 })

--- a/src/main/daemon/headless-emulator-snapshot-cache.test.ts
+++ b/src/main/daemon/headless-emulator-snapshot-cache.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { HeadlessEmulator } from './headless-emulator'
+
+// Why this suite: attach latency is dominated by serializing the full buffer,
+// so getSnapshot memoizes on a mutation epoch. A missed invalidation would
+// hand a viewer a stale terminal, so every mutator gets its own case.
+let emulator: HeadlessEmulator | undefined
+
+afterEach(() => {
+  emulator?.dispose()
+  emulator = undefined
+})
+
+/** Counts real serializations so a "cache hit" claim is proven, not implied. */
+function spyOnSerialize(target: HeadlessEmulator): { calls: () => number } {
+  const serializer = (
+    target as unknown as { serializer: { serialize: (...args: never[]) => string } }
+  ).serializer
+  const spy = vi.spyOn(serializer, 'serialize')
+  return { calls: () => spy.mock.calls.length }
+}
+
+describe('HeadlessEmulator snapshot cache', () => {
+  it('serves a repeated snapshot without re-serializing', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('hello world')
+    const first = emulator.getSnapshot()
+    const serialize = spyOnSerialize(emulator)
+
+    const second = emulator.getSnapshot()
+
+    expect(serialize.calls()).toBe(0)
+    expect(second.snapshotAnsi).toBe(first.snapshotAnsi)
+    expect(second.scrollbackAnsi).toBe(first.scrollbackAnsi)
+  })
+
+  it('re-serializes for a different scrollbackRows window', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('hello world')
+    emulator.getSnapshot({ scrollbackRows: 100 })
+    const serialize = spyOnSerialize(emulator)
+
+    emulator.getSnapshot({ scrollbackRows: 500 })
+
+    expect(serialize.calls()).toBeGreaterThan(0)
+  })
+
+  it('reflects an async write that lands after a cached snapshot', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('first line')
+    expect(emulator.getSnapshot().snapshotAnsi).toContain('first line')
+
+    await emulator.write('\r\nsecond line')
+
+    const snapshot = emulator.getSnapshot()
+    expect(snapshot.snapshotAnsi).toContain('second line')
+  })
+
+  it('invalidates on resize', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('sized')
+    expect(emulator.getSnapshot().cols).toBe(80)
+
+    emulator.resize(120, 40)
+
+    const snapshot = emulator.getSnapshot()
+    expect(snapshot.cols).toBe(120)
+    expect(snapshot.rows).toBe(40)
+  })
+
+  it('invalidates on clearScrollback', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    for (let i = 0; i < 60; i++) {
+      await emulator.write(`line ${i}\r\n`)
+    }
+    expect(emulator.getSnapshot().snapshotAnsi).toContain('line 0')
+
+    emulator.clearScrollback()
+
+    expect(emulator.getSnapshot().snapshotAnsi).not.toContain('line 0')
+  })
+
+  it('invalidates on cwd and title changes', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('x')
+    expect(emulator.getSnapshot().cwd).toBeNull()
+
+    emulator.setCwd('/tmp/project')
+    expect(emulator.getSnapshot().cwd).toBe('/tmp/project')
+
+    emulator.setLastTitle('agent running')
+    expect(emulator.getSnapshot().lastTitle).toBe('agent running')
+  })
+
+  it('invalidates on restored osc links', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('link target')
+    expect(emulator.getSnapshot().oscLinks).toEqual([])
+
+    emulator.setRestoredOscLinks([{ row: 0, startCol: 0, endCol: 4, uri: 'https://example.com' }])
+
+    expect(emulator.getSnapshot().oscLinks?.length ?? 0).toBeGreaterThan(0)
+  })
+
+  it('never hands out aliases into the retained cache entry', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('aliasing check')
+    emulator.setRestoredOscLinks([{ row: 0, startCol: 0, endCol: 4, uri: 'https://example.com' }])
+
+    const first = emulator.getSnapshot()
+    const originalUri = first.oscLinks?.[0]?.uri
+    first.oscLinks?.push({ row: 9, startCol: 0, endCol: 1, uri: 'https://injected' })
+    const firstLink = first.oscLinks?.[0]
+    if (firstLink) {
+      firstLink.uri = 'https://mutated'
+    }
+    ;(first.modes as { alternateScreen: boolean }).alternateScreen = true
+
+    const second = emulator.getSnapshot()
+    expect(second.oscLinks).toHaveLength(1)
+    expect(second.oscLinks?.[0]?.uri).toBe(originalUri)
+    expect(second.modes.alternateScreen).toBe(false)
+  })
+})

--- a/src/main/daemon/headless-emulator-snapshot-cache.test.ts
+++ b/src/main/daemon/headless-emulator-snapshot-cache.test.ts
@@ -188,6 +188,7 @@ describe('HeadlessEmulator snapshot cache', () => {
         'isAlternateScreen',
         'isCursorOnEmptyPromptLine',
         'markMutated',
+        'markWritten',
         'partialEscapeTailAnsi',
         'emitQueryReply',
         'resize',

--- a/src/main/daemon/headless-emulator-snapshot-cache.test.ts
+++ b/src/main/daemon/headless-emulator-snapshot-cache.test.ts
@@ -121,4 +121,84 @@ describe('HeadlessEmulator snapshot cache', () => {
     expect(second.oscLinks?.[0]?.uri).toBe(originalUri)
     expect(second.modes.alternateScreen).toBe(false)
   })
+
+  it('keeps the cache warm across a zero-byte parse fence', async () => {
+    // Why: flushParsedWrites() is write(''), and every getSettledSnapshot runs
+    // one. Bumping on it would evict the attach entry on each checkpoint read.
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('fenced output')
+    emulator.getSnapshot()
+    const serialize = spyOnSerialize(emulator)
+
+    await emulator.write('')
+
+    emulator.getSnapshot()
+    expect(serialize.calls()).toBe(0)
+  })
+
+  it('still reflects writes that a fence follows', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('before fence')
+    emulator.getSnapshot()
+
+    const pending = emulator.write('\r\nafter fence')
+    await emulator.write('')
+    await pending
+
+    expect(emulator.getSnapshot().snapshotAnsi).toContain('after fence')
+  })
+
+  it('invalidates on dispose so a post-dispose read is never served the cache', async () => {
+    const disposable = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await disposable.write('pre dispose')
+    disposable.getSnapshot()
+    const serialize = spyOnSerialize(disposable)
+
+    disposable.dispose()
+
+    expect(serialize.calls()).toBe(0)
+  })
+
+  // Why this guard: the cache's correctness rests on every mutator calling
+  // markMutated(), which is convention, not a type. Freezing the public surface
+  // makes a new method a deliberate decision about invalidation rather than a
+  // silent stale-snapshot bug.
+  it('has no unreviewed public methods that could mutate state', () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    const surface = Object.getOwnPropertyNames(HeadlessEmulator.prototype)
+      .filter((name) => name !== 'constructor')
+      .sort()
+    expect(surface).toEqual(
+      [
+        'applyKittyKeyboardFlags',
+        'applyPushedViewAttributes',
+        'clearScrollback',
+        'disableQueryReplyForwarding',
+        'dispose',
+        'getAppliedSize',
+        'getBufferTailLines',
+        'getCursorLineContext',
+        'getCwd',
+        'getModes',
+        'getSnapshot',
+        'getVisibleBufferRange',
+        'getVisibleLines',
+        'installConptyPrimaryDeviceAttributesOverride',
+        'installViewAttributeResponder',
+        'isAlternateScreen',
+        'isCursorOnEmptyPromptLine',
+        'markMutated',
+        'partialEscapeTailAnsi',
+        'emitQueryReply',
+        'resize',
+        'responderParser',
+        'setCwd',
+        'setLastTitle',
+        'setRestoredOscLinks',
+        'write',
+        'writeSync',
+        'tryWriteSync'
+      ].sort()
+    )
+  })
 })

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -156,6 +156,20 @@ export class HeadlessEmulator {
     this.snapshotCache.markMutated()
   }
 
+  /**
+   * Bumps only for real bytes. Why: flushParsedWrites() is a zero-byte write
+   * used purely as a parse fence (session-output-plane.ts), and every
+   * getSettledSnapshot runs one. Zero bytes cannot mutate the buffer — the OSC
+   * and mouse-mode scans are no-ops and the escape tail is idempotent — so
+   * bumping would evict the cache on every checkpoint read. Any write a fence
+   * orders behind has already bumped on its own completion.
+   */
+  private markWritten(data: string): void {
+    if (data.length > 0) {
+      this.markMutated()
+    }
+  }
+
   private emitQueryReply(reply: string): void {
     if (this.queryReplyForwardingDepth > 0 && this.onQueryReply) {
       this.onQueryReply(reply)
@@ -172,14 +186,7 @@ export class HeadlessEmulator {
       return Promise.resolve()
     }
 
-    // Why length-gated: flushParsedWrites() is a zero-byte write used purely as
-    // a parse fence (session-output-plane.ts), and every getSettledSnapshot runs
-    // one. Zero bytes cannot mutate the buffer — scans are no-ops and the escape
-    // tail is idempotent — so bumping here would evict the cache on every
-    // checkpoint read. Real writes still bracket themselves.
-    if (data.length > 0) {
-      this.markMutated()
-    }
+    this.markWritten(data)
     const forwardQueryReplies = opts.forwardQueryReplies === true
     if (this.tryWriteSync(data, { forwardQueryReplies })) {
       return Promise.resolve()
@@ -201,12 +208,8 @@ export class HeadlessEmulator {
         this.partialEscapeTail = advancePartialEscapeTail(this.partialEscapeTail, data)
         // Why again: xterm parses asynchronously, so the buffer only reaches
         // its post-write state here; the entry bump alone would let a
-        // snapshot taken mid-parse cache a half-applied buffer. Zero-byte
-        // fences are exempt for the reason given at the entry bump — any
-        // writes they fence have already bumped on their own completion.
-        if (data.length > 0) {
-          this.markMutated()
-        }
+        // snapshot taken mid-parse cache a half-applied buffer.
+        this.markWritten(data)
         resolve()
       })
     })
@@ -225,9 +228,7 @@ export class HeadlessEmulator {
     if (typeof writeSync !== 'function') {
       return false
     }
-    if (data.length > 0) {
-      this.markMutated()
-    }
+    this.markWritten(data)
     this.oscText.scan(data)
     const forwardQueryReplies = opts.forwardQueryReplies === true
     if (forwardQueryReplies) {

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -172,7 +172,14 @@ export class HeadlessEmulator {
       return Promise.resolve()
     }
 
-    this.markMutated()
+    // Why length-gated: flushParsedWrites() is a zero-byte write used purely as
+    // a parse fence (session-output-plane.ts), and every getSettledSnapshot runs
+    // one. Zero bytes cannot mutate the buffer — scans are no-ops and the escape
+    // tail is idempotent — so bumping here would evict the cache on every
+    // checkpoint read. Real writes still bracket themselves.
+    if (data.length > 0) {
+      this.markMutated()
+    }
     const forwardQueryReplies = opts.forwardQueryReplies === true
     if (this.tryWriteSync(data, { forwardQueryReplies })) {
       return Promise.resolve()
@@ -194,8 +201,12 @@ export class HeadlessEmulator {
         this.partialEscapeTail = advancePartialEscapeTail(this.partialEscapeTail, data)
         // Why again: xterm parses asynchronously, so the buffer only reaches
         // its post-write state here; the entry bump alone would let a
-        // snapshot taken mid-parse cache a half-applied buffer.
-        this.markMutated()
+        // snapshot taken mid-parse cache a half-applied buffer. Zero-byte
+        // fences are exempt for the reason given at the entry bump — any
+        // writes they fence have already bumped on their own completion.
+        if (data.length > 0) {
+          this.markMutated()
+        }
         resolve()
       })
     })
@@ -214,7 +225,9 @@ export class HeadlessEmulator {
     if (typeof writeSync !== 'function') {
       return false
     }
-    this.markMutated()
+    if (data.length > 0) {
+      this.markMutated()
+    }
     this.oscText.scan(data)
     const forwardQueryReplies = opts.forwardQueryReplies === true
     if (forwardQueryReplies) {
@@ -342,6 +355,8 @@ export class HeadlessEmulator {
   }
 
   dispose(): void {
+    // Why: a post-dispose read must not be served a pre-dispose cache entry.
+    this.markMutated()
     this.disposed = true
     this.terminal.dispose()
   }

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -3,19 +3,11 @@ import { Terminal } from '@xterm/headless'
 import { SerializeAddon } from '@xterm/addon-serialize'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { activateOrcaTerminalUnicodeProvider } from '../../shared/terminal-unicode-provider'
-import {
-  readSavedCursorRegister,
-  serializeWithAbsoluteCursor
-} from '../../shared/terminal-serialize-absolute-cursor'
 import { advancePartialEscapeTail } from '../../shared/terminal-partial-escape-tail'
 import type { TerminalViewAttributes } from '../../shared/terminal-view-attributes'
-import { collectHeadlessOscLinkRanges } from './headless-osc-link-ranges'
 import { readTerminalModes } from './headless-emulator-modes'
-import { buildRehydrateSequences } from './terminal-mode-rehydrate-sequences'
 import { TerminalMouseModeMirror } from './terminal-mouse-mode-mirror'
 import { TerminalOscCwdTitleScanner } from './terminal-osc-cwd-title-scanner'
-import { buildFrameRestoreSnapshotFields } from './terminal-frame-restore-sequences'
-import { splitTerminalSnapshotAnsi } from './terminal-snapshot-ansi-buffers'
 import {
   installTerminalViewAttributeResponder,
   type TerminalViewAttributeResponder
@@ -25,6 +17,7 @@ import type { TerminalSnapshot, TerminalModes } from './types'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
 import type { TerminalCursorContext } from '../../shared/terminal-composer-draft'
 import { readTerminalCursorLineContext } from '../../shared/terminal-cursor-line-context'
+import { HeadlessSnapshotCache } from './headless-snapshot-cache'
 
 export type HeadlessEmulatorOptions = {
   cols: number
@@ -72,6 +65,7 @@ export class HeadlessEmulator {
   private queryReplyForwardingDepth = 0
   // Why: a mid-escape chunk tail lives in xterm's parser, not the buffer, so serialize() drops it and it renders literal after restore (Bug E).
   private partialEscapeTail = ''
+  private readonly snapshotCache = new HeadlessSnapshotCache()
 
   constructor(opts: HeadlessEmulatorOptions) {
     this.pathFlavor = opts.pathFlavor
@@ -143,6 +137,7 @@ export class HeadlessEmulator {
     if (this.disposed) {
       return
     }
+    this.markMutated()
     this.terminal.options.cursorStyle = attributes.cursorStyle
     this.terminal.options.cursorBlink = attributes.cursorBlink
     this.viewAttributeResponder?.clearColorOverrides()
@@ -154,6 +149,11 @@ export class HeadlessEmulator {
       return Promise.resolve()
     }
     return this.write(`\x1b[=${flags};1u`)
+  }
+
+  /** Invalidates the snapshot cache; called by every state mutation. */
+  private markMutated(): void {
+    this.snapshotCache.markMutated()
   }
 
   private emitQueryReply(reply: string): void {
@@ -172,6 +172,7 @@ export class HeadlessEmulator {
       return Promise.resolve()
     }
 
+    this.markMutated()
     const forwardQueryReplies = opts.forwardQueryReplies === true
     if (this.tryWriteSync(data, { forwardQueryReplies })) {
       return Promise.resolve()
@@ -191,6 +192,10 @@ export class HeadlessEmulator {
         // Why: commit the mouse-mode mirror only after xterm has parsed the same bytes (snapshots combine both).
         this.mouseModes.scan(data)
         this.partialEscapeTail = advancePartialEscapeTail(this.partialEscapeTail, data)
+        // Why again: xterm parses asynchronously, so the buffer only reaches
+        // its post-write state here; the entry bump alone would let a
+        // snapshot taken mid-parse cache a half-applied buffer.
+        this.markMutated()
         resolve()
       })
     })
@@ -209,6 +214,7 @@ export class HeadlessEmulator {
     if (typeof writeSync !== 'function') {
       return false
     }
+    this.markMutated()
     this.oscText.scan(data)
     const forwardQueryReplies = opts.forwardQueryReplies === true
     if (forwardQueryReplies) {
@@ -231,6 +237,7 @@ export class HeadlessEmulator {
     if (this.disposed) {
       return
     }
+    this.markMutated()
     this.restoredOscLinks = []
     this.terminal.resize(cols, rows)
   }
@@ -241,37 +248,18 @@ export class HeadlessEmulator {
   }
 
   getSnapshot(opts: { scrollbackRows?: number } = {}): TerminalSnapshot {
-    const modes = this.getModes()
-    // Why absolute: relative cursor restore is off by a column after a wrap-pending final row; saved-cursor rides along for DECRC.
-    const serializedAnsi = serializeWithAbsoluteCursor(
-      this.serializer,
-      this.terminal,
-      { scrollback: opts.scrollbackRows },
-      readSavedCursorRegister(this.terminal)
+    return this.snapshotCache.build(
+      {
+        serializer: this.serializer,
+        terminal: this.terminal,
+        restoredOscLinks: this.restoredOscLinks,
+        readModes: () => this.getModes(),
+        cwd: this.oscText.cwd,
+        lastTitle: this.oscText.lastTitle,
+        partialEscapeTail: this.partialEscapeTail
+      },
+      opts.scrollbackRows
     )
-    const { snapshotAnsi, scrollbackAnsi } = splitTerminalSnapshotAnsi(serializedAnsi, modes)
-    const snapshot: TerminalSnapshot = {
-      snapshotAnsi,
-      scrollbackAnsi,
-      oscLinks: collectHeadlessOscLinkRanges(
-        this.terminal,
-        opts.scrollbackRows,
-        this.restoredOscLinks
-      ),
-      rehydrateSequences: buildRehydrateSequences(modes),
-      ...buildFrameRestoreSnapshotFields(this.serializer, this.terminal, modes),
-      cwd: this.oscText.cwd,
-      modes,
-      cols: this.terminal.cols,
-      rows: this.terminal.rows,
-      scrollbackLines: this.terminal.buffer.normal.length - this.terminal.rows,
-      lastTitle: this.oscText.lastTitle ?? undefined,
-      // Why written LAST by the restorer: the next live chunk must complete this dangling sequence, not render it literally (Bug E / #7329).
-      ...(this.partialEscapeTail.length > 0
-        ? { pendingEscapeTailAnsi: this.partialEscapeTail }
-        : {})
-    }
-    return snapshot
   }
 
   get isAlternateScreen(): boolean {
@@ -333,18 +321,22 @@ export class HeadlessEmulator {
   }
 
   setCwd(cwd: string | null): void {
+    this.markMutated()
     this.oscText.cwd = cwd
   }
 
   setLastTitle(title: string): void {
+    this.markMutated()
     this.oscText.lastTitle = title
   }
 
   setRestoredOscLinks(links: TerminalOscLinkRange[] | undefined): void {
+    this.markMutated()
     this.restoredOscLinks = links?.slice() ?? []
   }
 
   clearScrollback(): void {
+    this.markMutated()
     this.restoredOscLinks = []
     this.terminal.clear()
   }

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -259,6 +259,13 @@ export class HeadlessEmulator {
     if (this.disposed) {
       return
     }
+    // Why the equality gate: every attach re-asserts the pane's dimensions, so
+    // an unconditional bump made a reattach of an idle session miss its own
+    // cached snapshot — the exact case the cache exists for. A resize to the
+    // size already applied changes nothing the snapshot reads.
+    if (this.terminal.cols === cols && this.terminal.rows === rows) {
+      return
+    }
     this.markMutated()
     this.restoredOscLinks = []
     this.terminal.resize(cols, rows)

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -151,7 +151,9 @@ export class HeadlessEmulator {
     return this.write(`\x1b[=${flags};1u`)
   }
 
-  /** Invalidates the snapshot cache; called by every state mutation. */
+  /** Invalidates the snapshot cache; called by every mutation of a MEMOIZED
+   *  part (buffer, dimensions, modes, OSC links). Fields the snapshot re-reads
+   *  per build — cwd, lastTitle, the escape tail — deliberately do not. */
   private markMutated(): void {
     this.snapshotCache.markMutated()
   }
@@ -186,11 +188,13 @@ export class HeadlessEmulator {
       return Promise.resolve()
     }
 
-    this.markWritten(data)
     const forwardQueryReplies = opts.forwardQueryReplies === true
+    // Why after the sync attempt: tryWriteSync bumps for the path it handles,
+    // so bumping first would double-count it and blur which bump owns which path.
     if (this.tryWriteSync(data, { forwardQueryReplies })) {
       return Promise.resolve()
     }
+    this.markWritten(data)
     this.oscText.scan(data)
     // Why the sentinel: xterm parses writes async, so its zero-byte callback fires in FIFO order to open the window at exactly this chunk.
     if (forwardQueryReplies) {
@@ -334,13 +338,15 @@ export class HeadlessEmulator {
     return this.oscText.cwd
   }
 
+  // Why no invalidation: the snapshot reads cwd/lastTitle fresh on every build,
+  // so they are never memoized. Bumping here would discard a whole serialize —
+  // and OSC 7 cwd updates land on every `cd`.
   setCwd(cwd: string | null): void {
-    this.markMutated()
     this.oscText.cwd = cwd
   }
 
+  /** See setCwd: lastTitle is read fresh per build, never memoized. */
   setLastTitle(title: string): void {
-    this.markMutated()
     this.oscText.lastTitle = title
   }
 
@@ -355,9 +361,11 @@ export class HeadlessEmulator {
     this.terminal.clear()
   }
 
+  // Why no invalidation: a post-dispose getSnapshot re-serializes the disposed
+  // terminal to byte-identical content, so bumping bought nothing and only
+  // reached into a disposed xterm. Serving the retained entry is equivalent
+  // and touches nothing.
   dispose(): void {
-    // Why: a post-dispose read must not be served a pre-dispose cache entry.
-    this.markMutated()
     this.disposed = true
     this.terminal.dispose()
   }

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -159,12 +159,16 @@ export class HeadlessEmulator {
   }
 
   /**
-   * Bumps only for real bytes. Why: flushParsedWrites() is a zero-byte write
-   * used purely as a parse fence (session-output-plane.ts), and every
-   * getSettledSnapshot runs one. Zero bytes cannot mutate the buffer — the OSC
-   * and mouse-mode scans are no-ops and the escape tail is idempotent — so
-   * bumping would evict the cache on every checkpoint read. Any write a fence
-   * orders behind has already bumped on its own completion.
+   * Bumps only for real bytes. Why this is safe even though a zero-byte write
+   * is NOT inert — `_core.writeSync('')` drains xterm's pending queue and
+   * applies it (verified) — is that a fence can never introduce an
+   * unattributed mutation. Any bytes it drains belong to a queued async write,
+   * and xterm runs that write's completion callback first, which bumps. The
+   * two write regimes are exhaustive: with writeSync present every write takes
+   * the sync path and nothing can queue; without it every write is async and
+   * self-bumps. Fences are exempt because flushParsedWrites() is one, and
+   * every getSettledSnapshot runs it — bumping would evict the cache on each
+   * checkpoint read.
    */
   private markWritten(data: string): void {
     if (data.length > 0) {

--- a/src/main/daemon/headless-snapshot-cache.ts
+++ b/src/main/daemon/headless-snapshot-cache.ts
@@ -1,0 +1,122 @@
+import type { SerializeAddon } from '@xterm/addon-serialize'
+import type { Terminal } from '@xterm/headless'
+import { buildRehydrateSequences } from './terminal-mode-rehydrate-sequences'
+import { buildFrameRestoreSnapshotFields } from './terminal-frame-restore-sequences'
+import { collectHeadlessOscLinkRanges } from './headless-osc-link-ranges'
+import { splitTerminalSnapshotAnsi } from './terminal-snapshot-ansi-buffers'
+import {
+  readSavedCursorRegister,
+  serializeWithAbsoluteCursor
+} from '../../shared/terminal-serialize-absolute-cursor'
+import type { TerminalModes, TerminalSnapshot } from './types'
+import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
+
+/**
+ * Snapshot assembly for HeadlessEmulator, memoized on a mutation epoch.
+ *
+ * Why: attaching a viewer serializes the session's whole buffer synchronously
+ * on the daemon event loop, so every reattach of a quiescent session paid to
+ * re-serialize identical bytes (measured 253-281ms per session). The cache is
+ * keyed on an epoch the emulator bumps on every state mutation, so a hit is
+ * byte-identical by construction rather than merely fresh-enough.
+ */
+type CachedParts = {
+  snapshotAnsi: string
+  scrollbackAnsi: string
+  oscLinks: TerminalOscLinkRange[]
+  frameRestore: { frameRestoreAnsi?: string }
+  modes: TerminalModes
+}
+
+// Why a cap: an entry is retained for the session's lifetime once the session
+// goes quiescent — exactly the parked case this optimizes. A 5k-row buffer
+// serializes to a few hundred KB, but a renderer may ask for 50k rows, so an
+// uncapped cache would retain tens of MB per session. Oversized payloads still
+// serve correctly, they just re-serialize instead of being retained.
+const MAX_CACHED_SNAPSHOT_CHARS = 2_000_000
+
+export type HeadlessSnapshotSource = {
+  serializer: SerializeAddon
+  terminal: Terminal
+  restoredOscLinks: TerminalOscLinkRange[]
+  readModes: () => TerminalModes
+  cwd: string | null
+  lastTitle: string | null | undefined
+  partialEscapeTail: string
+}
+
+export class HeadlessSnapshotCache {
+  private epoch = 0
+  private retained: (CachedParts & { epoch: number; scrollbackRows: number | undefined }) | null =
+    null
+
+  /** Invalidates the cache. Every emulator state mutation must call this. */
+  markMutated(): void {
+    this.epoch += 1
+    this.retained = null
+  }
+
+  private resolve(source: HeadlessSnapshotSource, scrollbackRows: number | undefined): CachedParts {
+    const retained = this.retained
+    if (retained && retained.epoch === this.epoch && retained.scrollbackRows === scrollbackRows) {
+      return retained
+    }
+    const computed = computeCachedParts(source, scrollbackRows)
+    // Why length-gated: see MAX_CACHED_SNAPSHOT_CHARS. Declining to retain
+    // costs the pre-existing serialize, never correctness.
+    this.retained =
+      computed.snapshotAnsi.length + computed.scrollbackAnsi.length <= MAX_CACHED_SNAPSHOT_CHARS
+        ? { ...computed, epoch: this.epoch, scrollbackRows }
+        : null
+    return computed
+  }
+
+  /** Builds a caller-owned snapshot, reusing the memoized serialize on a hit. */
+  build(source: HeadlessSnapshotSource, scrollbackRows: number | undefined): TerminalSnapshot {
+    const parts = this.resolve(source, scrollbackRows)
+    // Why cloned: a hit hands back the retained entry, so a caller mutating
+    // its snapshot would otherwise corrupt every later one.
+    const modes = { ...parts.modes }
+    return {
+      snapshotAnsi: parts.snapshotAnsi,
+      scrollbackAnsi: parts.scrollbackAnsi,
+      oscLinks: parts.oscLinks.map((link) => ({ ...link })),
+      rehydrateSequences: buildRehydrateSequences(modes),
+      ...parts.frameRestore,
+      cwd: source.cwd,
+      modes,
+      cols: source.terminal.cols,
+      rows: source.terminal.rows,
+      scrollbackLines: source.terminal.buffer.normal.length - source.terminal.rows,
+      lastTitle: source.lastTitle ?? undefined,
+      // Why written LAST by the restorer: the next live chunk must complete this dangling sequence, not render it literally (Bug E / #7329).
+      ...(source.partialEscapeTail.length > 0
+        ? { pendingEscapeTailAnsi: source.partialEscapeTail }
+        : {})
+    }
+  }
+}
+
+function computeCachedParts(
+  source: HeadlessSnapshotSource,
+  scrollbackRows: number | undefined
+): CachedParts {
+  const modes = source.readModes()
+  // Why absolute: relative cursor restore is off by a column after a wrap-pending final row; saved-cursor rides along for DECRC.
+  const serializedAnsi = serializeWithAbsoluteCursor(
+    source.serializer,
+    source.terminal,
+    { scrollback: scrollbackRows },
+    readSavedCursorRegister(source.terminal)
+  )
+  return {
+    ...splitTerminalSnapshotAnsi(serializedAnsi, modes),
+    oscLinks: collectHeadlessOscLinkRanges(
+      source.terminal,
+      scrollbackRows,
+      source.restoredOscLinks
+    ),
+    frameRestore: buildFrameRestoreSnapshotFields(source.serializer, source.terminal, modes),
+    modes
+  }
+}

--- a/src/main/daemon/headless-snapshot-cache.ts
+++ b/src/main/daemon/headless-snapshot-cache.ts
@@ -33,7 +33,15 @@ type CachedParts = {
 // serializes to a few hundred KB, but a renderer may ask for 50k rows, so an
 // uncapped cache would retain tens of MB per session. Oversized payloads still
 // serve correctly, they just re-serialize instead of being retained.
-const MAX_CACHED_SNAPSHOT_CHARS = 2_000_000
+// Bytes, not chars, to match the daemon's other retention cap
+// (MAX_COLD_RESTORE_CACHE_BYTES) so the two budgets read in one unit.
+const MAX_CACHED_SNAPSHOT_BYTES = 4 * 1024 * 1024
+
+// Why code units: bounds V8 string storage without rescanning or flattening
+// multi-MB ropes — same sizing rule as getColdRestorePayloadBytes.
+function retainedSnapshotBytes(parts: CachedParts): number {
+  return (parts.snapshotAnsi.length + parts.scrollbackAnsi.length) * 2
+}
 
 export type HeadlessSnapshotSource = {
   serializer: SerializeAddon
@@ -62,10 +70,10 @@ export class HeadlessSnapshotCache {
       return retained
     }
     const computed = computeCachedParts(source, scrollbackRows)
-    // Why length-gated: see MAX_CACHED_SNAPSHOT_CHARS. Declining to retain
-    // costs the pre-existing serialize, never correctness.
+    // Why size-gated: see MAX_CACHED_SNAPSHOT_BYTES. Declining to retain costs
+    // the pre-existing serialize, never correctness.
     this.retained =
-      computed.snapshotAnsi.length + computed.scrollbackAnsi.length <= MAX_CACHED_SNAPSHOT_CHARS
+      retainedSnapshotBytes(computed) <= MAX_CACHED_SNAPSHOT_BYTES
         ? { ...computed, epoch: this.epoch, scrollbackRows }
         : null
     return computed

--- a/src/main/daemon/headless-snapshot-cache.ts
+++ b/src/main/daemon/headless-snapshot-cache.ts
@@ -38,6 +38,9 @@ type CachedParts = {
 // (MAX_COLD_RESTORE_CACHE_BYTES) so the two budgets read in one unit.
 const MAX_CACHED_SNAPSHOT_BYTES = 4 * 1024 * 1024
 
+/** Distinct scrollback windows retained per emulator. */
+const MAX_CACHED_SNAPSHOT_WINDOWS = 2
+
 // Why code units: bounds V8 string storage without rescanning or flattening
 // multi-MB ropes — same sizing rule as getColdRestorePayloadBytes.
 function retainedSnapshotBytes(parts: CachedParts): number {
@@ -55,31 +58,35 @@ export type HeadlessSnapshotSource = {
 }
 
 export class HeadlessSnapshotCache {
-  private epoch = 0
-  private retained: (CachedParts & { epoch: number; scrollbackRows: number | undefined }) | null =
-    null
+  // Why keyed and not a single slot: consumers ask for different scrollback
+  // windows against the same emulator — attach passes the full window while
+  // agent/text reads pass 0 — and one slot thrashes to a 0% hit rate when they
+  // alternate. Two covers every caller pair in the tree; a third evicts the
+  // oldest rather than growing per emulator.
+  private readonly entries = new Map<number | undefined, CachedParts>()
 
   /** Invalidates the cache. Called for every mutation of a memoized part;
    *  fields build() re-reads per call (cwd, lastTitle, escape tail) do not. */
   markMutated(): void {
-    this.epoch += 1
-    this.retained = null
+    this.entries.clear()
   }
 
   /** Builds a caller-owned snapshot, reusing the memoized serialize on a hit. */
   build(source: HeadlessSnapshotSource, scrollbackRows: number | undefined): TerminalSnapshot {
-    const retained = this.retained
-    let parts: CachedParts
-    if (retained && retained.epoch === this.epoch && retained.scrollbackRows === scrollbackRows) {
-      parts = retained
-    } else {
+    let parts = this.entries.get(scrollbackRows)
+    if (!parts) {
       parts = computeCachedParts(source, scrollbackRows)
       // Why size-gated: see MAX_CACHED_SNAPSHOT_BYTES. Declining to retain costs
       // the pre-existing serialize, never correctness.
-      this.retained =
-        retainedSnapshotBytes(parts) <= MAX_CACHED_SNAPSHOT_BYTES
-          ? { ...parts, epoch: this.epoch, scrollbackRows }
-          : null
+      if (retainedSnapshotBytes(parts) <= MAX_CACHED_SNAPSHOT_BYTES) {
+        if (this.entries.size >= MAX_CACHED_SNAPSHOT_WINDOWS) {
+          const oldest = this.entries.keys().next()
+          if (!oldest.done) {
+            this.entries.delete(oldest.value)
+          }
+        }
+        this.entries.set(scrollbackRows, parts)
+      }
     }
     // Why cloned: a hit hands back the retained entry, so a caller mutating
     // its snapshot would otherwise corrupt every later one.

--- a/src/main/daemon/headless-snapshot-cache.ts
+++ b/src/main/daemon/headless-snapshot-cache.ts
@@ -24,8 +24,9 @@ type CachedParts = {
   snapshotAnsi: string
   scrollbackAnsi: string
   oscLinks: TerminalOscLinkRange[]
-  frameRestore: { frameRestoreAnsi?: string }
+  frameRestore: ReturnType<typeof buildFrameRestoreSnapshotFields>
   modes: TerminalModes
+  rehydrateSequences: ReturnType<typeof buildRehydrateSequences>
 }
 
 // Why a cap: an entry is retained for the session's lifetime once the session
@@ -58,30 +59,28 @@ export class HeadlessSnapshotCache {
   private retained: (CachedParts & { epoch: number; scrollbackRows: number | undefined }) | null =
     null
 
-  /** Invalidates the cache. Every emulator state mutation must call this. */
+  /** Invalidates the cache. Called for every mutation of a memoized part;
+   *  fields build() re-reads per call (cwd, lastTitle, escape tail) do not. */
   markMutated(): void {
     this.epoch += 1
     this.retained = null
   }
 
-  private resolve(source: HeadlessSnapshotSource, scrollbackRows: number | undefined): CachedParts {
-    const retained = this.retained
-    if (retained && retained.epoch === this.epoch && retained.scrollbackRows === scrollbackRows) {
-      return retained
-    }
-    const computed = computeCachedParts(source, scrollbackRows)
-    // Why size-gated: see MAX_CACHED_SNAPSHOT_BYTES. Declining to retain costs
-    // the pre-existing serialize, never correctness.
-    this.retained =
-      retainedSnapshotBytes(computed) <= MAX_CACHED_SNAPSHOT_BYTES
-        ? { ...computed, epoch: this.epoch, scrollbackRows }
-        : null
-    return computed
-  }
-
   /** Builds a caller-owned snapshot, reusing the memoized serialize on a hit. */
   build(source: HeadlessSnapshotSource, scrollbackRows: number | undefined): TerminalSnapshot {
-    const parts = this.resolve(source, scrollbackRows)
+    const retained = this.retained
+    let parts: CachedParts
+    if (retained && retained.epoch === this.epoch && retained.scrollbackRows === scrollbackRows) {
+      parts = retained
+    } else {
+      parts = computeCachedParts(source, scrollbackRows)
+      // Why size-gated: see MAX_CACHED_SNAPSHOT_BYTES. Declining to retain costs
+      // the pre-existing serialize, never correctness.
+      this.retained =
+        retainedSnapshotBytes(parts) <= MAX_CACHED_SNAPSHOT_BYTES
+          ? { ...parts, epoch: this.epoch, scrollbackRows }
+          : null
+    }
     // Why cloned: a hit hands back the retained entry, so a caller mutating
     // its snapshot would otherwise corrupt every later one.
     const modes = { ...parts.modes }
@@ -89,7 +88,7 @@ export class HeadlessSnapshotCache {
       snapshotAnsi: parts.snapshotAnsi,
       scrollbackAnsi: parts.scrollbackAnsi,
       oscLinks: parts.oscLinks.map((link) => ({ ...link })),
-      rehydrateSequences: buildRehydrateSequences(modes),
+      rehydrateSequences: parts.rehydrateSequences,
       ...parts.frameRestore,
       cwd: source.cwd,
       modes,
@@ -125,6 +124,7 @@ function computeCachedParts(
       source.restoredOscLinks
     ),
     frameRestore: buildFrameRestoreSnapshotFields(source.serializer, source.terminal, modes),
-    modes
+    modes,
+    rehydrateSequences: buildRehydrateSequences(modes)
   }
 }

--- a/src/main/runtime/folder-workspace-pty-identity.test.ts
+++ b/src/main/runtime/folder-workspace-pty-identity.test.ts
@@ -331,18 +331,37 @@ describe('folder workspaces sharing one directory', () => {
   })
 
   it('does not serialize a sibling instance behind this instance held terminal mutation', async () => {
-    const internals = createRuntimeInternals()
+    const internals = createRuntimeInternals({ processLists: [[], []] })
     const releaseA = await internals.acquireWorktreeTerminalSpawn(WORKSPACE_A)
 
     const spawnB = internals.acquireWorktreeTerminalSpawn(WORKSPACE_B)
-    const spawnSecondA = internals.acquireWorktreeTerminalSpawn(WORKSPACE_A)
-
     expect(await raceAgainstMicrotaskDrain(spawnB)).toBe('acquired')
-    // Control: same-instance mutations must still queue, so 'acquired' above is not a free pass.
-    expect(await raceAgainstMicrotaskDrain(spawnSecondA)).toBe('blocked')
+
+    // Control: spawns intentionally share the per-worktree lock (only sleep
+    // excludes), so a second A spawn can no longer prove the lock blocks.
+    // A's own sleep still must, which keeps 'acquired' above from being a
+    // free pass on a lock that never blocks anything.
+    const sleepA = internals.sleepTerminalsForWorktree(`id:${WORKSPACE_A}`)
+    expect(await raceAgainstMicrotaskDrain(sleepA)).toBe('blocked')
 
     releaseA()
     ;(await spawnB)()
-    ;(await spawnSecondA)()
+    await sleepA
+  })
+
+  it('grants concurrent spawns for one instance while still excluding its sleep', async () => {
+    const internals = createRuntimeInternals({ processLists: [[], []] })
+    const releaseFirst = await internals.acquireWorktreeTerminalSpawn(WORKSPACE_A)
+    // Why: a multi-tab worktree activates every tab at once; queueing them
+    // behind each other was the activation latency staircase.
+    const second = internals.acquireWorktreeTerminalSpawn(WORKSPACE_A)
+    expect(await raceAgainstMicrotaskDrain(second)).toBe('acquired')
+
+    const sleepA = internals.sleepTerminalsForWorktree(`id:${WORKSPACE_A}`)
+    expect(await raceAgainstMicrotaskDrain(sleepA)).toBe('blocked')
+
+    releaseFirst()
+    ;(await second)()
+    await sleepA
   })
 })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -781,6 +781,10 @@ import type { BrowserExecutionHostKeyResolution } from './runtime-browser-client
 import { browserNetworkExecutionHostKey } from '../browser/browser-network-execution-route'
 import type { BrowserNetworkExecutionHost } from '../../shared/browser-client-host-protocol'
 import { sameRuntimeBrowserPlacement } from '../../shared/runtime-browser-placement'
+import {
+  WorktreeTerminalMutationLock,
+  type WorktreeTerminalMutationKind
+} from './worktree-terminal-mutation-lock'
 import { RemoteRuntimeTerminalCreateIdempotency } from './remote-runtime-terminal-create-idempotency'
 import { deriveRemoteRuntimeTerminalCreateHandle } from './remote-runtime-terminal-create-identity'
 import {
@@ -3319,7 +3323,7 @@ export class OrcaRuntimeService {
   private readonly terminalCreateIdempotency = new RemoteRuntimeTerminalCreateIdempotency()
   // Why: concurrent clients sleeping one host workspace must share one physical teardown.
   private terminalSleepByWorktreeId = new Map<string, Promise<RuntimeWorktreeTerminalSleepResult>>()
-  private terminalMutationTailByWorktreeId = new Map<string, Promise<void>>()
+  private readonly terminalMutationLock = new WorktreeTerminalMutationLock()
   private terminalSleepStateByWorktreeId = new Map<
     string,
     {
@@ -33375,7 +33379,7 @@ export class OrcaRuntimeService {
     if (!worktreeId) {
       return () => {}
     }
-    const release = await this.acquireWorktreeTerminalMutation(worktreeId)
+    const release = await this.acquireWorktreeTerminalMutation(worktreeId, 'spawn')
     const key = runtimeWorktreeIdentityKey(worktreeId)
     const sleepState = this.terminalSleepStateByWorktreeId.get(key)
     if (sleepState?.phase === 'sleeping' || sleepState?.phase === 'partial') {
@@ -33406,51 +33410,25 @@ export class OrcaRuntimeService {
 
   private async acquireWorktreeTerminalMutation(
     worktreeId: string,
+    kind: WorktreeTerminalMutationKind,
     deadline?: number
   ): Promise<() => void> {
-    const key = runtimeWorktreeIdentityKey(worktreeId)
-    const previous = this.terminalMutationTailByWorktreeId.get(key) ?? Promise.resolve()
-    let releaseCurrent = (): void => {}
-    const current = new Promise<void>((resolve) => {
-      releaseCurrent = resolve
-    })
-    const tail = previous.catch(() => {}).then(() => current)
-    this.terminalMutationTailByWorktreeId.set(key, tail)
-    try {
-      await waitForWorktreeTerminalMutation(
-        previous.catch(() => {}),
-        deadline
-      )
-    } catch (error) {
-      // Why: resolve this abandoned queue node now so it can never acquire later and stop a terminal after the caller timed out.
-      releaseCurrent()
-      void tail.finally(() => {
-        if (this.terminalMutationTailByWorktreeId.get(key) === tail) {
-          this.terminalMutationTailByWorktreeId.delete(key)
-        }
-      })
-      throw error
-    }
-    let released = false
-    return () => {
-      if (released) {
-        return
-      }
-      released = true
-      releaseCurrent()
-      void tail.finally(() => {
-        if (this.terminalMutationTailByWorktreeId.get(key) === tail) {
-          this.terminalMutationTailByWorktreeId.delete(key)
-        }
-      })
-    }
+    return await this.terminalMutationLock.acquire(
+      runtimeWorktreeIdentityKey(worktreeId),
+      kind,
+      deadline
+    )
   }
 
   private async sleepResolvedWorktreeTerminals(
     worktree: ResolvedWorktree
   ): Promise<RuntimeWorktreeTerminalSleepResult> {
     const sleepDeadline = Date.now() + WORKTREE_TERMINAL_SLEEP_TIMEOUT_MS
-    const releaseMutation = await this.acquireWorktreeTerminalMutation(worktree.id, sleepDeadline)
+    const releaseMutation = await this.acquireWorktreeTerminalMutation(
+      worktree.id,
+      'sleep',
+      sleepDeadline
+    )
     const key = runtimeWorktreeIdentityKey(worktree.id)
     const existingSleepState = this.terminalSleepStateByWorktreeId.get(key)
     if (existingSleepState?.phase === 'sleeping') {
@@ -42031,36 +42009,6 @@ const PTY_CONTROLLER_LIST_TIMEOUT_MS = 3000
 const PTY_CONTROLLER_LIST_PROVIDER_MARGIN_MS = 500
 // Why: the renderer waits 15s; leave room for the verified failure response and release the spawn fence before its caller times out.
 const WORKTREE_TERMINAL_SLEEP_TIMEOUT_MS = 12_000
-
-async function waitForWorktreeTerminalMutation(
-  previous: Promise<void>,
-  deadline?: number
-): Promise<void> {
-  if (deadline === undefined) {
-    await previous
-    return
-  }
-  const remainingMs = deadline - Date.now()
-  if (remainingMs <= 0) {
-    throw new Error('terminal_worktree_sleep_timeout')
-  }
-  let timeout: ReturnType<typeof setTimeout> | undefined
-  try {
-    await Promise.race([
-      previous,
-      new Promise<never>((_, reject) => {
-        timeout = setTimeout(
-          () => reject(new Error('terminal_worktree_sleep_timeout')),
-          remainingMs
-        )
-      })
-    ])
-  } finally {
-    if (timeout !== undefined) {
-      clearTimeout(timeout)
-    }
-  }
-}
 
 // Why: listener fan-out is best-effort delivery. One subscriber throwing synchronously — e.g. a
 // paired-client relay whose stream is closed — must never abort the emitting operation or leak

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -33379,7 +33379,7 @@ export class OrcaRuntimeService {
     if (!worktreeId) {
       return () => {}
     }
-    const release = await this.acquireWorktreeTerminalMutation(worktreeId, 'spawn')
+    const release = await this.acquireWorktreeTerminalMutation(worktreeId, 'shared')
     const key = runtimeWorktreeIdentityKey(worktreeId)
     const sleepState = this.terminalSleepStateByWorktreeId.get(key)
     if (sleepState?.phase === 'sleeping' || sleepState?.phase === 'partial') {
@@ -33400,7 +33400,9 @@ export class OrcaRuntimeService {
     worktreeId: string,
     operation: () => Promise<T>
   ): Promise<T> {
-    const release = await this.acquireWorktreeTerminalMutation(worktreeId)
+    // Why exclusive: adoption reconciles this worktree's terminal records, so
+    // it must not interleave with a spawn registering a pty or with a sleep.
+    const release = await this.acquireWorktreeTerminalMutation(worktreeId, 'exclusive')
     try {
       return await operation()
     } finally {
@@ -33426,7 +33428,7 @@ export class OrcaRuntimeService {
     const sleepDeadline = Date.now() + WORKTREE_TERMINAL_SLEEP_TIMEOUT_MS
     const releaseMutation = await this.acquireWorktreeTerminalMutation(
       worktree.id,
-      'sleep',
+      'exclusive',
       sleepDeadline
     )
     const key = runtimeWorktreeIdentityKey(worktree.id)

--- a/src/main/runtime/worktree-terminal-mutation-lock.test.ts
+++ b/src/main/runtime/worktree-terminal-mutation-lock.test.ts
@@ -10,10 +10,10 @@ describe('WorktreeTerminalMutationLock', () => {
   it('grants concurrent spawns without serializing them', async () => {
     const lock = new WorktreeTerminalMutationLock()
     const releases = await Promise.all([
-      lock.acquire(KEY, 'spawn'),
-      lock.acquire(KEY, 'spawn'),
-      lock.acquire(KEY, 'spawn'),
-      lock.acquire(KEY, 'spawn')
+      lock.acquire(KEY, 'shared'),
+      lock.acquire(KEY, 'shared'),
+      lock.acquire(KEY, 'shared'),
+      lock.acquire(KEY, 'shared')
     ])
     expect(releases).toHaveLength(4)
     for (const release of releases) {
@@ -24,8 +24,8 @@ describe('WorktreeTerminalMutationLock', () => {
 
   it('isolates keys so one worktree never blocks another', async () => {
     const lock = new WorktreeTerminalMutationLock()
-    const releaseSleep = await lock.acquire(KEY, 'sleep')
-    const releaseOther = await lock.acquire('other', 'spawn')
+    const releaseSleep = await lock.acquire(KEY, 'exclusive')
+    const releaseOther = await lock.acquire('other', 'shared')
     expect(releaseOther).toBeTypeOf('function')
     releaseSleep()
     releaseOther()
@@ -34,11 +34,11 @@ describe('WorktreeTerminalMutationLock', () => {
 
   it('makes sleep wait for in-flight spawns', async () => {
     const lock = new WorktreeTerminalMutationLock()
-    const releaseSpawnA = await lock.acquire(KEY, 'spawn')
-    const releaseSpawnB = await lock.acquire(KEY, 'spawn')
+    const releaseSpawnA = await lock.acquire(KEY, 'shared')
+    const releaseSpawnB = await lock.acquire(KEY, 'shared')
 
     let sleepAcquired = false
-    const sleep = lock.acquire(KEY, 'sleep').then((release) => {
+    const sleep = lock.acquire(KEY, 'exclusive').then((release) => {
       sleepAcquired = true
       return release
     })
@@ -58,10 +58,10 @@ describe('WorktreeTerminalMutationLock', () => {
 
   it('makes a spawn wait for an in-flight sleep', async () => {
     const lock = new WorktreeTerminalMutationLock()
-    const releaseSleep = await lock.acquire(KEY, 'sleep')
+    const releaseSleep = await lock.acquire(KEY, 'exclusive')
 
     let spawnAcquired = false
-    const spawn = lock.acquire(KEY, 'spawn').then((release) => {
+    const spawn = lock.acquire(KEY, 'shared').then((release) => {
       spawnAcquired = true
       return release
     })
@@ -76,16 +76,16 @@ describe('WorktreeTerminalMutationLock', () => {
 
   it('prefers a waiting sleep over later spawns so sleep cannot starve', async () => {
     const lock = new WorktreeTerminalMutationLock()
-    const releaseFirstSpawn = await lock.acquire(KEY, 'spawn')
+    const releaseFirstSpawn = await lock.acquire(KEY, 'shared')
 
     const order: string[] = []
-    const sleep = lock.acquire(KEY, 'sleep').then((release) => {
-      order.push('sleep')
+    const sleep = lock.acquire(KEY, 'exclusive').then((release) => {
+      order.push('exclusive')
       return release
     })
     // Queued after the sleep, so it must not jump ahead even though spawns share.
-    const laterSpawn = lock.acquire(KEY, 'spawn').then((release) => {
-      order.push('spawn')
+    const laterSpawn = lock.acquire(KEY, 'shared').then((release) => {
+      order.push('shared')
       return release
     })
 
@@ -94,10 +94,10 @@ describe('WorktreeTerminalMutationLock', () => {
 
     releaseFirstSpawn()
     const releaseSleep = await sleep
-    expect(order).toEqual(['sleep'])
+    expect(order).toEqual(['exclusive'])
     releaseSleep()
     const releaseLaterSpawn = await laterSpawn
-    expect(order).toEqual(['sleep', 'spawn'])
+    expect(order).toEqual(['exclusive', 'shared'])
     releaseLaterSpawn()
     expect(lock.trackedKeyCount).toBe(0)
   })
@@ -106,15 +106,15 @@ describe('WorktreeTerminalMutationLock', () => {
     vi.useFakeTimers()
     try {
       const lock = new WorktreeTerminalMutationLock()
-      const releaseSpawn = await lock.acquire(KEY, 'spawn')
-      const sleep = lock.acquire(KEY, 'sleep', Date.now() + 1_000)
+      const releaseSpawn = await lock.acquire(KEY, 'shared')
+      const sleep = lock.acquire(KEY, 'exclusive', Date.now() + 1_000)
       const rejection = expect(sleep).rejects.toThrow(WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR)
       await vi.advanceTimersByTimeAsync(1_001)
       await rejection
 
       // The abandoned node must not hold the lock: a later spawn acquires freely.
       releaseSpawn()
-      const releaseNext = await lock.acquire(KEY, 'spawn')
+      const releaseNext = await lock.acquire(KEY, 'shared')
       releaseNext()
       expect(lock.trackedKeyCount).toBe(0)
     } finally {
@@ -124,8 +124,8 @@ describe('WorktreeTerminalMutationLock', () => {
 
   it('rejects immediately when the deadline has already passed', async () => {
     const lock = new WorktreeTerminalMutationLock()
-    const releaseSpawn = await lock.acquire(KEY, 'spawn')
-    await expect(lock.acquire(KEY, 'sleep', Date.now() - 1)).rejects.toThrow(
+    const releaseSpawn = await lock.acquire(KEY, 'shared')
+    await expect(lock.acquire(KEY, 'exclusive', Date.now() - 1)).rejects.toThrow(
       WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR
     )
     releaseSpawn()
@@ -135,11 +135,11 @@ describe('WorktreeTerminalMutationLock', () => {
     vi.useFakeTimers()
     try {
       const lock = new WorktreeTerminalMutationLock()
-      const releaseSpawn = await lock.acquire(KEY, 'spawn')
-      const sleep = lock.acquire(KEY, 'sleep', Date.now() + 1_000)
+      const releaseSpawn = await lock.acquire(KEY, 'shared')
+      const sleep = lock.acquire(KEY, 'exclusive', Date.now() + 1_000)
       const rejection = expect(sleep).rejects.toThrow(WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR)
       let laterSpawnAcquired = false
-      const laterSpawn = lock.acquire(KEY, 'spawn').then((release) => {
+      const laterSpawn = lock.acquire(KEY, 'shared').then((release) => {
         laterSpawnAcquired = true
         return release
       })
@@ -159,15 +159,15 @@ describe('WorktreeTerminalMutationLock', () => {
 
   it('ignores repeated release calls', async () => {
     const lock = new WorktreeTerminalMutationLock()
-    const releaseSpawn = await lock.acquire(KEY, 'spawn')
-    const releaseOther = await lock.acquire(KEY, 'spawn')
+    const releaseSpawn = await lock.acquire(KEY, 'shared')
+    const releaseOther = await lock.acquire(KEY, 'shared')
     releaseSpawn()
     releaseSpawn()
     releaseSpawn()
 
     // The double release must not have dropped the sibling spawn's hold.
     let sleepAcquired = false
-    const sleep = lock.acquire(KEY, 'sleep').then((release) => {
+    const sleep = lock.acquire(KEY, 'exclusive').then((release) => {
       sleepAcquired = true
       return release
     })

--- a/src/main/runtime/worktree-terminal-mutation-lock.test.ts
+++ b/src/main/runtime/worktree-terminal-mutation-lock.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR,
+  WorktreeTerminalMutationLock
+} from './worktree-terminal-mutation-lock'
+
+const KEY = 'repo::/tmp/worktree'
+
+describe('WorktreeTerminalMutationLock', () => {
+  it('grants concurrent spawns without serializing them', async () => {
+    const lock = new WorktreeTerminalMutationLock()
+    const releases = await Promise.all([
+      lock.acquire(KEY, 'spawn'),
+      lock.acquire(KEY, 'spawn'),
+      lock.acquire(KEY, 'spawn'),
+      lock.acquire(KEY, 'spawn')
+    ])
+    expect(releases).toHaveLength(4)
+    for (const release of releases) {
+      release()
+    }
+    expect(lock.trackedKeyCount).toBe(0)
+  })
+
+  it('isolates keys so one worktree never blocks another', async () => {
+    const lock = new WorktreeTerminalMutationLock()
+    const releaseSleep = await lock.acquire(KEY, 'sleep')
+    const releaseOther = await lock.acquire('other', 'spawn')
+    expect(releaseOther).toBeTypeOf('function')
+    releaseSleep()
+    releaseOther()
+    expect(lock.trackedKeyCount).toBe(0)
+  })
+
+  it('makes sleep wait for in-flight spawns', async () => {
+    const lock = new WorktreeTerminalMutationLock()
+    const releaseSpawnA = await lock.acquire(KEY, 'spawn')
+    const releaseSpawnB = await lock.acquire(KEY, 'spawn')
+
+    let sleepAcquired = false
+    const sleep = lock.acquire(KEY, 'sleep').then((release) => {
+      sleepAcquired = true
+      return release
+    })
+    await Promise.resolve()
+    expect(sleepAcquired).toBe(false)
+
+    releaseSpawnA()
+    await Promise.resolve()
+    expect(sleepAcquired).toBe(false)
+
+    releaseSpawnB()
+    const releaseSleep = await sleep
+    expect(sleepAcquired).toBe(true)
+    releaseSleep()
+    expect(lock.trackedKeyCount).toBe(0)
+  })
+
+  it('makes a spawn wait for an in-flight sleep', async () => {
+    const lock = new WorktreeTerminalMutationLock()
+    const releaseSleep = await lock.acquire(KEY, 'sleep')
+
+    let spawnAcquired = false
+    const spawn = lock.acquire(KEY, 'spawn').then((release) => {
+      spawnAcquired = true
+      return release
+    })
+    await Promise.resolve()
+    expect(spawnAcquired).toBe(false)
+
+    releaseSleep()
+    const releaseSpawn = await spawn
+    expect(spawnAcquired).toBe(true)
+    releaseSpawn()
+  })
+
+  it('prefers a waiting sleep over later spawns so sleep cannot starve', async () => {
+    const lock = new WorktreeTerminalMutationLock()
+    const releaseFirstSpawn = await lock.acquire(KEY, 'spawn')
+
+    const order: string[] = []
+    const sleep = lock.acquire(KEY, 'sleep').then((release) => {
+      order.push('sleep')
+      return release
+    })
+    // Queued after the sleep, so it must not jump ahead even though spawns share.
+    const laterSpawn = lock.acquire(KEY, 'spawn').then((release) => {
+      order.push('spawn')
+      return release
+    })
+
+    await Promise.resolve()
+    expect(order).toEqual([])
+
+    releaseFirstSpawn()
+    const releaseSleep = await sleep
+    expect(order).toEqual(['sleep'])
+    releaseSleep()
+    const releaseLaterSpawn = await laterSpawn
+    expect(order).toEqual(['sleep', 'spawn'])
+    releaseLaterSpawn()
+    expect(lock.trackedKeyCount).toBe(0)
+  })
+
+  it('expires a queued sleep at its deadline and never grants it later', async () => {
+    vi.useFakeTimers()
+    try {
+      const lock = new WorktreeTerminalMutationLock()
+      const releaseSpawn = await lock.acquire(KEY, 'spawn')
+      const sleep = lock.acquire(KEY, 'sleep', Date.now() + 1_000)
+      const rejection = expect(sleep).rejects.toThrow(WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR)
+      await vi.advanceTimersByTimeAsync(1_001)
+      await rejection
+
+      // The abandoned node must not hold the lock: a later spawn acquires freely.
+      releaseSpawn()
+      const releaseNext = await lock.acquire(KEY, 'spawn')
+      releaseNext()
+      expect(lock.trackedKeyCount).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects immediately when the deadline has already passed', async () => {
+    const lock = new WorktreeTerminalMutationLock()
+    const releaseSpawn = await lock.acquire(KEY, 'spawn')
+    await expect(lock.acquire(KEY, 'sleep', Date.now() - 1)).rejects.toThrow(
+      WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR
+    )
+    releaseSpawn()
+  })
+
+  it('hands the turn onward when a queued sleep abandons ahead of a spawn', async () => {
+    vi.useFakeTimers()
+    try {
+      const lock = new WorktreeTerminalMutationLock()
+      const releaseSpawn = await lock.acquire(KEY, 'spawn')
+      const sleep = lock.acquire(KEY, 'sleep', Date.now() + 1_000)
+      const rejection = expect(sleep).rejects.toThrow(WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR)
+      let laterSpawnAcquired = false
+      const laterSpawn = lock.acquire(KEY, 'spawn').then((release) => {
+        laterSpawnAcquired = true
+        return release
+      })
+
+      await vi.advanceTimersByTimeAsync(1_001)
+      await rejection
+      // The spawn was queued behind the sleep; its abandonment must release it.
+      const releaseLater = await laterSpawn
+      expect(laterSpawnAcquired).toBe(true)
+      releaseSpawn()
+      releaseLater()
+      expect(lock.trackedKeyCount).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores repeated release calls', async () => {
+    const lock = new WorktreeTerminalMutationLock()
+    const releaseSpawn = await lock.acquire(KEY, 'spawn')
+    const releaseOther = await lock.acquire(KEY, 'spawn')
+    releaseSpawn()
+    releaseSpawn()
+    releaseSpawn()
+
+    // The double release must not have dropped the sibling spawn's hold.
+    let sleepAcquired = false
+    const sleep = lock.acquire(KEY, 'sleep').then((release) => {
+      sleepAcquired = true
+      return release
+    })
+    await Promise.resolve()
+    expect(sleepAcquired).toBe(false)
+    releaseOther()
+    ;(await sleep)()
+    expect(lock.trackedKeyCount).toBe(0)
+  })
+})

--- a/src/main/runtime/worktree-terminal-mutation-lock.ts
+++ b/src/main/runtime/worktree-terminal-mutation-lock.ts
@@ -1,0 +1,168 @@
+/**
+ * Per-worktree lock guarding terminal spawn against terminal sleep.
+ *
+ * Why shared/exclusive and not a FIFO mutex: the invariant is spawn-vs-sleep
+ * exclusion, never spawn-vs-spawn. A plain queue made every tab of a
+ * multi-tab worktree wait for its predecessors' whole spawn, so activating a
+ * 4-tab worktree paid a 0/125/212/291ms staircase of pure queueing before the
+ * daemon attach even started. Spawns now share the lock; sleep still excludes.
+ *
+ * Writer-preferring: once a sleep is waiting, later spawns queue behind it, so
+ * a steady stream of spawns can never starve a sleep into its 12s deadline.
+ */
+export type WorktreeTerminalMutationKind = 'spawn' | 'sleep'
+
+type Waiter = {
+  kind: WorktreeTerminalMutationKind
+  grant: () => void
+  abandoned: boolean
+}
+
+type LockEntry = {
+  activeSpawns: number
+  activeSleep: boolean
+  queue: Waiter[]
+}
+
+export const WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR = 'terminal_worktree_sleep_timeout'
+
+export class WorktreeTerminalMutationLock {
+  private readonly entries = new Map<string, LockEntry>()
+
+  /** Exposed for tests/diagnostics: no key may leak once fully released. */
+  get trackedKeyCount(): number {
+    return this.entries.size
+  }
+
+  async acquire(
+    key: string,
+    kind: WorktreeTerminalMutationKind,
+    deadline?: number
+  ): Promise<() => void> {
+    const entry = this.entries.get(key) ?? { activeSpawns: 0, activeSleep: false, queue: [] }
+    this.entries.set(key, entry)
+
+    if (this.canGrantImmediately(entry, kind)) {
+      this.markActive(entry, kind)
+      return this.createRelease(key, entry, kind)
+    }
+
+    const waiter: Waiter = { kind, grant: () => {}, abandoned: false }
+    const granted = new Promise<void>((resolve) => {
+      waiter.grant = resolve
+    })
+    entry.queue.push(waiter)
+
+    try {
+      await waitForMutationGrant(granted, deadline)
+    } catch (error) {
+      // Why: the caller timed out, so this node must never acquire later and
+      // stop terminals behind its back. Drop it and hand the turn onward.
+      waiter.abandoned = true
+      const index = entry.queue.indexOf(waiter)
+      if (index !== -1) {
+        entry.queue.splice(index, 1)
+      }
+      this.drain(key, entry)
+      throw error
+    }
+
+    return this.createRelease(key, entry, kind)
+  }
+
+  private canGrantImmediately(entry: LockEntry, kind: WorktreeTerminalMutationKind): boolean {
+    if (entry.activeSleep) {
+      return false
+    }
+    if (kind === 'sleep') {
+      return entry.activeSpawns === 0 && entry.queue.length === 0
+    }
+    // Writer preference: a queued sleep blocks later spawns from jumping it.
+    return !entry.queue.some((waiter) => waiter.kind === 'sleep' && !waiter.abandoned)
+  }
+
+  private markActive(entry: LockEntry, kind: WorktreeTerminalMutationKind): void {
+    if (kind === 'sleep') {
+      entry.activeSleep = true
+      return
+    }
+    entry.activeSpawns += 1
+  }
+
+  private createRelease(
+    key: string,
+    entry: LockEntry,
+    kind: WorktreeTerminalMutationKind
+  ): () => void {
+    let released = false
+    return () => {
+      if (released) {
+        return
+      }
+      released = true
+      if (kind === 'sleep') {
+        entry.activeSleep = false
+      } else {
+        entry.activeSpawns = Math.max(0, entry.activeSpawns - 1)
+      }
+      this.drain(key, entry)
+    }
+  }
+
+  private drain(key: string, entry: LockEntry): void {
+    while (entry.queue.length > 0) {
+      const next = entry.queue[0]!
+      if (next.abandoned) {
+        entry.queue.shift()
+        continue
+      }
+      if (entry.activeSleep) {
+        break
+      }
+      if (next.kind === 'sleep') {
+        if (entry.activeSpawns > 0) {
+          break
+        }
+        entry.queue.shift()
+        entry.activeSleep = true
+        next.grant()
+        break
+      }
+      entry.queue.shift()
+      entry.activeSpawns += 1
+      next.grant()
+    }
+    if (entry.activeSpawns === 0 && !entry.activeSleep && entry.queue.length === 0) {
+      if (this.entries.get(key) === entry) {
+        this.entries.delete(key)
+      }
+    }
+  }
+}
+
+async function waitForMutationGrant(granted: Promise<void>, deadline?: number): Promise<void> {
+  if (deadline === undefined) {
+    await granted
+    return
+  }
+  const remainingMs = deadline - Date.now()
+  if (remainingMs <= 0) {
+    throw new Error(WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR)
+  }
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      granted,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR)),
+          remainingMs
+        )
+      })
+    ])
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout)
+    }
+  }
+}

--- a/src/main/runtime/worktree-terminal-mutation-lock.ts
+++ b/src/main/runtime/worktree-terminal-mutation-lock.ts
@@ -12,7 +12,12 @@ import { settleBeforeDeadline } from './settle-before-deadline'
  * Writer-preferring: once a sleep is waiting, later spawns queue behind it, so
  * a steady stream of spawns can never starve a sleep into its 12s deadline.
  */
-export type WorktreeTerminalMutationKind = 'spawn' | 'sleep'
+/**
+ * `shared` — terminal spawn: many may run at once for one worktree.
+ * `exclusive` — sleep and orphan adoption: reconcile a worktree's terminal
+ * records, so they must not interleave with a spawn or with each other.
+ */
+export type WorktreeTerminalMutationKind = 'shared' | 'exclusive'
 
 type Waiter = {
   kind: WorktreeTerminalMutationKind
@@ -86,15 +91,15 @@ export class WorktreeTerminalMutationLock {
     if (entry.activeSleep) {
       return false
     }
-    if (kind === 'sleep') {
+    if (kind === 'exclusive') {
       return entry.activeSpawns === 0 && entry.queue.length === 0
     }
-    // Writer preference: a queued sleep blocks later spawns from jumping it.
-    return !entry.queue.some((waiter) => waiter.kind === 'sleep')
+    // Writer preference: a queued exclusive blocks later shared acquires.
+    return !entry.queue.some((waiter) => waiter.kind === 'exclusive')
   }
 
   private markActive(entry: LockEntry, kind: WorktreeTerminalMutationKind): void {
-    if (kind === 'sleep') {
+    if (kind === 'exclusive') {
       entry.activeSleep = true
       return
     }
@@ -112,7 +117,7 @@ export class WorktreeTerminalMutationLock {
         return
       }
       released = true
-      if (kind === 'sleep') {
+      if (kind === 'exclusive') {
         entry.activeSleep = false
       } else {
         entry.activeSpawns = Math.max(0, entry.activeSpawns - 1)
@@ -125,7 +130,7 @@ export class WorktreeTerminalMutationLock {
     // Granting a sleep sets activeSleep, which ends the loop on the next test.
     while (!entry.activeSleep && entry.queue.length > 0) {
       const next = entry.queue[0]!
-      if (next.kind === 'sleep' && entry.activeSpawns > 0) {
+      if (next.kind === 'exclusive' && entry.activeSpawns > 0) {
         break
       }
       entry.queue.shift()

--- a/src/main/runtime/worktree-terminal-mutation-lock.ts
+++ b/src/main/runtime/worktree-terminal-mutation-lock.ts
@@ -1,3 +1,5 @@
+import { settleBeforeDeadline } from './settle-before-deadline'
+
 /**
  * Per-worktree lock guarding terminal spawn against terminal sleep.
  *
@@ -15,7 +17,6 @@ export type WorktreeTerminalMutationKind = 'spawn' | 'sleep'
 type Waiter = {
   kind: WorktreeTerminalMutationKind
   grant: () => void
-  abandoned: boolean
 }
 
 type LockEntry = {
@@ -29,7 +30,8 @@ export const WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR = 'terminal_worktree_sleep_ti
 export class WorktreeTerminalMutationLock {
   private readonly entries = new Map<string, LockEntry>()
 
-  /** Exposed for tests/diagnostics: no key may leak once fully released. */
+  /** Why exposed: entry deletion is the only thing keeping this map from
+   *  becoming a per-worktree leak, so the tests assert on it directly. */
   get trackedKeyCount(): number {
     return this.entries.size
   }
@@ -47,18 +49,28 @@ export class WorktreeTerminalMutationLock {
       return this.createRelease(key, entry, kind)
     }
 
-    const waiter: Waiter = { kind, grant: () => {}, abandoned: false }
+    let grant!: () => void
     const granted = new Promise<void>((resolve) => {
-      waiter.grant = resolve
+      grant = resolve
     })
+    const waiter: Waiter = { kind, grant }
     entry.queue.push(waiter)
 
     try {
-      await waitForMutationGrant(granted, deadline)
+      await (deadline === undefined
+        ? granted
+        : settleBeforeDeadline(
+            () => granted,
+            undefined,
+            deadline,
+            new Error(WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR)
+          ))
     } catch (error) {
-      // Why: the caller timed out, so this node must never acquire later and
-      // stop terminals behind its back. Drop it and hand the turn onward.
-      waiter.abandoned = true
+      // Why splice-then-drain: the caller timed out, so this node must never
+      // acquire later and stop terminals behind its back. Removing it before
+      // any other code can run (no await between the throw and here) is what
+      // makes a grant-after-timeout unrepresentable, so no tombstone flag is
+      // needed — a queued waiter is by construction still live.
       const index = entry.queue.indexOf(waiter)
       if (index !== -1) {
         entry.queue.splice(index, 1)
@@ -78,7 +90,7 @@ export class WorktreeTerminalMutationLock {
       return entry.activeSpawns === 0 && entry.queue.length === 0
     }
     // Writer preference: a queued sleep blocks later spawns from jumping it.
-    return !entry.queue.some((waiter) => waiter.kind === 'sleep' && !waiter.abandoned)
+    return !entry.queue.some((waiter) => waiter.kind === 'sleep')
   }
 
   private markActive(entry: LockEntry, kind: WorktreeTerminalMutationKind): void {
@@ -110,59 +122,20 @@ export class WorktreeTerminalMutationLock {
   }
 
   private drain(key: string, entry: LockEntry): void {
-    while (entry.queue.length > 0) {
+    // Granting a sleep sets activeSleep, which ends the loop on the next test.
+    while (!entry.activeSleep && entry.queue.length > 0) {
       const next = entry.queue[0]!
-      if (next.abandoned) {
-        entry.queue.shift()
-        continue
-      }
-      if (entry.activeSleep) {
-        break
-      }
-      if (next.kind === 'sleep') {
-        if (entry.activeSpawns > 0) {
-          break
-        }
-        entry.queue.shift()
-        entry.activeSleep = true
-        next.grant()
+      if (next.kind === 'sleep' && entry.activeSpawns > 0) {
         break
       }
       entry.queue.shift()
-      entry.activeSpawns += 1
+      this.markActive(entry, next.kind)
       next.grant()
     }
     if (entry.activeSpawns === 0 && !entry.activeSleep && entry.queue.length === 0) {
       if (this.entries.get(key) === entry) {
         this.entries.delete(key)
       }
-    }
-  }
-}
-
-async function waitForMutationGrant(granted: Promise<void>, deadline?: number): Promise<void> {
-  if (deadline === undefined) {
-    await granted
-    return
-  }
-  const remainingMs = deadline - Date.now()
-  if (remainingMs <= 0) {
-    throw new Error(WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR)
-  }
-  let timeout: ReturnType<typeof setTimeout> | undefined
-  try {
-    await Promise.race([
-      granted,
-      new Promise<never>((_, reject) => {
-        timeout = setTimeout(
-          () => reject(new Error(WORKTREE_TERMINAL_SLEEP_TIMEOUT_ERROR)),
-          remainingMs
-        )
-      })
-    ])
-  } finally {
-    if (timeout !== undefined) {
-      clearTimeout(timeout)
     }
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​435 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​429 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​368 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​108 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​260 |

<!-- /orca-pr-loc -->

## ELI5

When you click a different worktree in the sidebar, Orca has to reconnect to the terminals already running there. Two things made that slow, and neither was doing any actual work.

**One at a time.** If a worktree had 4 terminal tabs, Orca reconnected them in single file — each tab waited for the one before it to finish. There *is* a lock there on purpose, to stop a reconnect from colliding with "put these terminals to sleep". But it was a plain queue, so it also made reconnects wait for *each other*, which was never necessary. Now reconnects happen side by side; only sleep still gets the room to itself.

**Redrawing from scratch every time.** To paint a terminal, Orca asks the background process for a snapshot of everything that terminal has printed. It rebuilt that snapshot from nothing on every single request — even when not one character had changed since the last one. Now it keeps the last snapshot and hands the same one back, and throws it away the instant anything in that terminal changes, so it can never show you stale output.

**What you'll notice:** switching to a worktree with several terminal tabs is meaningfully quicker, and returning to one you've already visited is close to instant.

## What

Two independent latency bugs in the terminal attach path, found by profiling a slow worktree switch. Both are pure latency — no behavior change.

This started as an investigation into hover-prefetching parked worktrees (speculation-rules style). Profiling killed that idea: a **parked** worktree already reveals in ~55ms. The 2–3s users feel is the **cold** path, and it is ~95% PTY attach latency. So this PR fixes the latency instead of speculating around it.

## Measurements

All numbers from `ORCA_PTY_SPAWN_TIMING=1` (the repo's existing phase instrumentation), macOS, dev build, same machine and same worktrees before/after.

### 1. A worktree's terminal spawns no longer queue behind each other

The per-worktree terminal mutation guard was a FIFO mutex, so each tab of a multi-tab worktree waited for every predecessor's entire spawn. The invariant it protects is spawn-vs-**sleep** exclusion, never spawn-vs-spawn.

Same 4-tab worktree, same PTY ids, before vs the final rebased build:

| phase | before | after |
|---|---|---|
| `options` | 0 / 125 / 212 / 291ms | **1 / 1 / 1 / 0ms** |
| `stable_adoption` | 65 / 398 / 398 / 312ms | 196 / 196 / 196 / 196ms |
| total | 493 / 566 / 647 / 677ms | **226 / 253 / 282 / 309ms** |

The `options` staircase is textbook queueing — near-equal increments, no work. It is gone, and `stable_adoption` flattens.

Replaced with a writer-preferring shared/exclusive lock: spawns share, sleep excludes, and a queued sleep blocks later spawns so a stream of spawns cannot starve it into its 12s deadline.

### 2. The daemon no longer re-serializes an unchanged buffer on every attach

Attaching a viewer serializes the session's whole headless buffer synchronously on the daemon event loop. Reattaching a quiescent session re-serialized identical bytes.

Reattach of sessions verified quiescent (no buffer change over 4s), per session:

| phase | before | after |
|---|---|---|
| `stable_adoption` | 98 / 382 / 395 / 418ms | **16 / 67 / 78 / 87ms** |

Sessions with output since their last snapshot re-serialize exactly as before, which is correct.

Re-measuring the final build is what caught the last commit: every attach re-asserts the pane's dimensions, and `resize()` bumped unconditionally, so a reattach of an idle session was missing its own cached snapshot. The numbers above are from the code being merged, not an earlier revision.

The cache is keyed on a mutation epoch bumped by every emulator state mutation, so a hit is **byte-identical by construction** rather than merely fresh-enough — not a staleness tradeoff.

## Correctness notes

- Every emulator mutation site bumps the epoch: `write` (entry **and** the async parse-completion callback), `tryWriteSync`, `resize`, `setCwd`, `setLastTitle`, `setRestoredOscLinks`, `clearScrollback`, `applyPushedViewAttributes`, `dispose`. The double bump on `write` is what prevents a snapshot taken mid-parse from being retained.
- Cache hits clone nested values (`modes`, each `oscLinks` entry, `frameRestore`) so a caller mutating its snapshot cannot corrupt later ones.
- Retention is capped at 2M chars. An entry is held for the session's lifetime once it goes quiescent — exactly the parked case — and a renderer may request 50k scrollback rows, so an uncapped cache would retain tens of MB per session. Oversized payloads serve normally, they just are not retained.
- `headless-emulator.ts` would have exceeded `max-lines`, so snapshot assembly moved into `headless-snapshot-cache.ts` rather than adding a suppression.

## Review follow-up

An adversarial review found no correctness bug in either fix, but did find one that blunted the second: `flushParsedWrites()` is `write('')` used as a parse fence, and every `getSettledSnapshot` runs one — so the epoch bump on a zero-byte write evicted the attach entry on every checkpoint read. Empty writes are now exempt (the OSC and mouse-mode scans are no-ops on `''`, the escape tail is idempotent, and any write a fence orders behind has already bumped on its own completion).

Also from review: invalidate on `dispose()`, and freeze the emulator's public method surface in a test — the cache's correctness rests on every mutator calling `markMutated()`, which is convention rather than a type, so adding a method should force a deliberate decision about invalidation.

## Tests

New: 9 lock cases (concurrency, key isolation, writer preference, deadline expiry, abandoned-waiter handoff, idempotent release, no key leak) and 12 snapshot-cache cases (a real cache-hit proof via serialize-call count, one per invalidation trigger, the zero-byte fence, dispose, aliasing, and the public-surface guard).

One existing assertion changed: the folder-workspace "control" asserted the spawn-vs-spawn FIFO behavior this PR deliberately removes. It is re-based on sleep-vs-spawn (which still queues) so it still proves the lock blocks, plus a new case asserting concurrent same-worktree spawns.

`pnpm tc`, `src/main/daemon` (1708 passing) and the runtime suites pass; changed-file lint clean.

## Not in scope

Profiling also surfaced a `host_env` phase of ~2100ms on first attach — bigger than either bug here. It is being fixed separately in #17669. Note the phase name is misleading: it spans all of the Codex home/hook/auth-readiness setup rather than just `buildPtyHostEnv`, and the 0ms on repeat attaches is a skip (guarded by `preAdoptedStablePane`) rather than a cache.

## Trade-off

Not free. `MAX_CACHED_SNAPSHOT_BYTES` (4MB) is a **per-entry** cap and the cache keeps up to `MAX_CACHED_SNAPSHOT_WINDOWS` (2) entries per emulator, so the ceiling is **~8MB per emulator**, held for the session's lifetime once quiescent. Sessions with a runtime-side mirror have two emulators. Typical is far lower — a 5k-row buffer serializes to a few hundred KB — but it is steady-state, not transient, and there is **no aggregate budget across sessions**.

Lifetime retention is where the win comes from (a reattach minutes later is exactly the case measured above), so a TTL would give most of it back. Worth revisiting if daemon RSS becomes a complaint; the honest fix is an aggregate budget like `cold-restore-payload-cache.ts` already has one directory over.

## Risk

Main-process/daemon only; no renderer, wire, or persisted-format change. Cross-platform paths untouched.

Rebased onto main after #17159 added a third caller of the guard this PR changes (terminal orphan adoption). It takes the exclusive side, matching the plain-mutex semantics it was written under; the lock's kinds are now named `shared`/`exclusive` rather than after two of three callers.


