### PR TITLE
perf(codex): share one launch-prep hook install across a spawn burst

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -117,6 +117,7 @@
     "../src/main/hermes/hermes-home-filesystem.ts",
     "../src/main/hermes/hermes-managed-plugin-source.ts",
     "../src/main/hermes/hook-service.ts",
+    "../src/main/in-flight-run-dedupe.ts",
     "../src/main/kimi/hook-service.ts",
     "../src/main/kimi/kimi-hook-config-toml.ts",
     "../src/main/openclaude/hook-service.ts",

--- a/src/main/codex/codex-hook-service-implementation.ts
+++ b/src/main/codex/codex-hook-service-implementation.ts
@@ -28,6 +28,11 @@ import {
 } from './codex-wsl-hook-install-plan'
 import type { CodexTrustEntry } from './config-toml-trust'
 
+/** Lane-scoped so the hooks-on install never joins the hooks-off refresh. */
+function launchPrepKey(lane: 'install' | 'refresh', runtimeHomePath: string): string {
+  return `${lane}\0${normalizeRuntimePathForComparison(runtimeHomePath)}`
+}
+
 export class CodexHookService {
   async refreshManagedScripts(): Promise<void> {
     await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
@@ -140,20 +145,11 @@ export class CodexHookService {
       return Promise.resolve(null)
     }
     const targetKey = target?.runtime === 'wsl' ? target.wslDistro?.trim().toLowerCase() : ''
-    const key = `${getWslReconciliationKey(runtimeHomePath)}\0${targetKey ?? ''}`
-    const active = this.wslInstallsInFlight.get(key)
-    if (active) {
-      return active
-    }
-    const install = this.installForRuntimeHome(runtimeHomePath, target)
-    this.wslInstallsInFlight.set(key, install)
-    const clear = (): void => {
-      if (this.wslInstallsInFlight.get(key) === install) {
-        this.wslInstallsInFlight.delete(key)
-      }
-    }
-    void install.then(clear, clear)
-    return install
+    return this.shareInFlight(
+      this.wslInstallsInFlight,
+      `${getWslReconciliationKey(runtimeHomePath)}\0${targetKey ?? ''}`,
+      () => this.installForRuntimeHome(runtimeHomePath, target)
+    )
   }
 
   async prepareRuntimeHomeForLaunch(
@@ -212,39 +208,49 @@ export class CodexHookService {
    * globally per Codex home, so activating a multi-pane worktree used to pay one
    * full hook install per pane back to back (measured ~790ms for 7 panes, and a
    * resumed Codex pane prepares twice). Spawns racing for the same home all want
-   * the same on-disk outcome, so they share one run.
+   * the same on-disk outcome, so they share one run — the same reason the WSL
+   * lane above shares `installForRuntimeHome`.
    *
-   * Invalidation: the shared promise is dropped the moment it settles, so the
+   * Invalidation: `shareInFlight` drops the run the moment it settles, so the
    * next launch re-reads hooks.json and the user's trust state. Never widen this
    * into a time-based cache — the hooks setting, ~/.codex approvals and the
    * managed script can all change between spawns, and only a fresh run sees them.
-   * The key is the runtime home, so per-account homes never share a run.
    */
   installForLaunchPrep(runtimeHomePath?: string): Promise<AgentHookInstallStatus> {
     const homePath = runtimeHomePath ?? getOrcaManagedCodexHomePath()
-    return this.shareLaunchPrep('install', homePath, () => this.install(homePath))
+    return this.shareInFlight(this.launchPrepInFlight, launchPrepKey('install', homePath), () =>
+      this.install(homePath)
+    )
   }
 
   refreshRuntimeUserHooksForLaunchPrep(runtimeHomePath?: string): Promise<AgentHookInstallStatus> {
     const homePath = runtimeHomePath ?? getOrcaManagedCodexHomePath()
-    return this.shareLaunchPrep('refresh', homePath, () => this.refreshRuntimeUserHooks(homePath))
+    return this.shareInFlight(this.launchPrepInFlight, launchPrepKey('refresh', homePath), () =>
+      this.refreshRuntimeUserHooks(homePath)
+    )
   }
 
-  private shareLaunchPrep(
-    lane: 'install' | 'refresh',
-    runtimeHomePath: string,
-    start: () => Promise<AgentHookInstallStatus>
-  ): Promise<AgentHookInstallStatus> {
-    const key = `${lane}\0${normalizeRuntimePathForComparison(runtimeHomePath)}`
-    const active = this.launchPrepInFlight.get(key)
+  /**
+   * Shares one in-flight run per key. Generic over the run's result so the WSL
+   * lane (nullable) and the launch-prep lane keep their own maps and exact
+   * types; a single map would need a cast at every read.
+   */
+  private shareInFlight<T>(
+    runs: Map<string, Promise<T>>,
+    key: string,
+    start: () => Promise<T>
+  ): Promise<T> {
+    const active = runs.get(key)
     if (active) {
       return active
     }
     const run = start()
-    this.launchPrepInFlight.set(key, run)
+    runs.set(key, run)
+    // Why: clear on rejection too, or one failed install would wedge every
+    // later launch onto the same rejected promise.
     const clear = (): void => {
-      if (this.launchPrepInFlight.get(key) === run) {
-        this.launchPrepInFlight.delete(key)
+      if (runs.get(key) === run) {
+        runs.delete(key)
       }
     }
     void run.then(clear, clear)

--- a/src/main/codex/codex-hook-service-implementation.ts
+++ b/src/main/codex/codex-hook-service-implementation.ts
@@ -1,6 +1,7 @@
 import { win32 as pathWin32 } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import { getOrcaManagedCodexHomePath } from './codex-home-paths'
 import { getManagedScriptPath } from './codex-hook-definition'
@@ -34,6 +35,7 @@ export class CodexHookService {
 
   private readonly wslReconciliationGeneration = new Map<string, number>()
   private readonly wslInstallsInFlight = new Map<string, Promise<AgentHookInstallStatus | null>>()
+  private readonly launchPrepInFlight = new Map<string, Promise<AgentHookInstallStatus>>()
 
   private supersedeWslReconciliation(runtimeHomePath: string | null | undefined): number {
     if (!runtimeHomePath) {
@@ -164,12 +166,12 @@ export class CodexHookService {
       // so hooks/trust must install there rather than the shared mirror.
       return (
         (await this.installForRuntimeHomeSerialized(runtimeHomePath, target)) ??
-        (await this.install(runtimeHomePath ?? undefined))
+        (await this.installForLaunchPrep(runtimeHomePath ?? undefined))
       )
     }
     return (
       this.refreshRuntimeUserHooksForRuntimeHome(runtimeHomePath, target) ??
-      (await this.refreshRuntimeUserHooks(runtimeHomePath ?? undefined))
+      (await this.refreshRuntimeUserHooksForLaunchPrep(runtimeHomePath ?? undefined))
     )
   }
 
@@ -203,6 +205,50 @@ export class CodexHookService {
     return runExclusivelyForRuntimeAndSystemTrustConfig(runtimeHomePath, () =>
       this.installExclusively(runtimeHomePath)
     )
+  }
+
+  /**
+   * Launch prep runs on every local PTY spawn, and both lanes below serialize
+   * globally per Codex home, so activating a multi-pane worktree used to pay one
+   * full hook install per pane back to back (measured ~790ms for 7 panes, and a
+   * resumed Codex pane prepares twice). Spawns racing for the same home all want
+   * the same on-disk outcome, so they share one run.
+   *
+   * Invalidation: the shared promise is dropped the moment it settles, so the
+   * next launch re-reads hooks.json and the user's trust state. Never widen this
+   * into a time-based cache — the hooks setting, ~/.codex approvals and the
+   * managed script can all change between spawns, and only a fresh run sees them.
+   * The key is the runtime home, so per-account homes never share a run.
+   */
+  installForLaunchPrep(runtimeHomePath?: string): Promise<AgentHookInstallStatus> {
+    const homePath = runtimeHomePath ?? getOrcaManagedCodexHomePath()
+    return this.shareLaunchPrep('install', homePath, () => this.install(homePath))
+  }
+
+  refreshRuntimeUserHooksForLaunchPrep(runtimeHomePath?: string): Promise<AgentHookInstallStatus> {
+    const homePath = runtimeHomePath ?? getOrcaManagedCodexHomePath()
+    return this.shareLaunchPrep('refresh', homePath, () => this.refreshRuntimeUserHooks(homePath))
+  }
+
+  private shareLaunchPrep(
+    lane: 'install' | 'refresh',
+    runtimeHomePath: string,
+    start: () => Promise<AgentHookInstallStatus>
+  ): Promise<AgentHookInstallStatus> {
+    const key = `${lane}\0${normalizeRuntimePathForComparison(runtimeHomePath)}`
+    const active = this.launchPrepInFlight.get(key)
+    if (active) {
+      return active
+    }
+    const run = start()
+    this.launchPrepInFlight.set(key, run)
+    const clear = (): void => {
+      if (this.launchPrepInFlight.get(key) === run) {
+        this.launchPrepInFlight.delete(key)
+      }
+    }
+    void run.then(clear, clear)
+    return run
   }
 
   private installExclusively(runtimeHomePath: string): Promise<AgentHookInstallStatus> {

--- a/src/main/codex/codex-hook-service-implementation.ts
+++ b/src/main/codex/codex-hook-service-implementation.ts
@@ -2,6 +2,7 @@ import { win32 as pathWin32 } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import { dedupeInFlightRun } from '../in-flight-run-dedupe'
 import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import { getOrcaManagedCodexHomePath } from './codex-home-paths'
 import { getManagedScriptPath } from './codex-hook-definition'
@@ -145,7 +146,7 @@ export class CodexHookService {
       return Promise.resolve(null)
     }
     const targetKey = target?.runtime === 'wsl' ? target.wslDistro?.trim().toLowerCase() : ''
-    return this.shareInFlight(
+    return dedupeInFlightRun(
       this.wslInstallsInFlight,
       `${getWslReconciliationKey(runtimeHomePath)}\0${targetKey ?? ''}`,
       () => this.installForRuntimeHome(runtimeHomePath, target)
@@ -211,50 +212,23 @@ export class CodexHookService {
    * the same on-disk outcome, so they share one run — the same reason the WSL
    * lane above shares `installForRuntimeHome`.
    *
-   * Invalidation: `shareInFlight` drops the run the moment it settles, so the
+   * Invalidation: `dedupeInFlightRun` drops the run the moment it settles, so the
    * next launch re-reads hooks.json and the user's trust state. Never widen this
    * into a time-based cache — the hooks setting, ~/.codex approvals and the
    * managed script can all change between spawns, and only a fresh run sees them.
    */
   installForLaunchPrep(runtimeHomePath?: string): Promise<AgentHookInstallStatus> {
     const homePath = runtimeHomePath ?? getOrcaManagedCodexHomePath()
-    return this.shareInFlight(this.launchPrepInFlight, launchPrepKey('install', homePath), () =>
+    return dedupeInFlightRun(this.launchPrepInFlight, launchPrepKey('install', homePath), () =>
       this.install(homePath)
     )
   }
 
   refreshRuntimeUserHooksForLaunchPrep(runtimeHomePath?: string): Promise<AgentHookInstallStatus> {
     const homePath = runtimeHomePath ?? getOrcaManagedCodexHomePath()
-    return this.shareInFlight(this.launchPrepInFlight, launchPrepKey('refresh', homePath), () =>
+    return dedupeInFlightRun(this.launchPrepInFlight, launchPrepKey('refresh', homePath), () =>
       this.refreshRuntimeUserHooks(homePath)
     )
-  }
-
-  /**
-   * Shares one in-flight run per key. Generic over the run's result so the WSL
-   * lane (nullable) and the launch-prep lane keep their own maps and exact
-   * types; a single map would need a cast at every read.
-   */
-  private shareInFlight<T>(
-    runs: Map<string, Promise<T>>,
-    key: string,
-    start: () => Promise<T>
-  ): Promise<T> {
-    const active = runs.get(key)
-    if (active) {
-      return active
-    }
-    const run = start()
-    runs.set(key, run)
-    // Why: clear on rejection too, or one failed install would wedge every
-    // later launch onto the same rejected promise.
-    const clear = (): void => {
-      if (runs.get(key) === run) {
-        runs.delete(key)
-      }
-    }
-    void run.then(clear, clear)
-    return run
   }
 
   private installExclusively(runtimeHomePath: string): Promise<AgentHookInstallStatus> {

--- a/src/main/codex/hook-service-concurrent-launch-install.test.ts
+++ b/src/main/codex/hook-service-concurrent-launch-install.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import type * as Os from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
+
+const { getPathMock, homedirMock, installExclusivelyMock, refreshExclusivelyMock } = vi.hoisted(
+  () => ({
+    getPathMock: vi.fn<(name: string) => string>(),
+    homedirMock: vi.fn<() => string>(),
+    installExclusivelyMock: vi.fn<(runtimeHomePath: string) => Promise<AgentHookInstallStatus>>(),
+    refreshExclusivelyMock: vi.fn<(runtimeHomePath: string) => Promise<AgentHookInstallStatus>>()
+  })
+)
+
+vi.mock('electron', () => ({ app: { getPath: getPathMock } }))
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof Os>()
+  return { ...actual, homedir: homedirMock }
+})
+vi.mock('./codex-hook-local-install', () => ({
+  installCodexHooksExclusively: installExclusivelyMock
+}))
+vi.mock('./codex-hook-local-maintenance', () => ({
+  refreshCodexRuntimeUserHooksExclusively: refreshExclusivelyMock,
+  removeCodexHooksExclusively: vi.fn()
+}))
+
+import { CodexHookService } from './codex-hook-service-implementation'
+
+let tmpHome: string
+let userDataDir: string
+let previousUserDataPath: string | undefined
+
+/** Stands in for a real `codex app-server` grant session, measured at ~380ms locally. */
+const INSTALL_MS = 60
+
+function installedStatus(configPath: string): AgentHookInstallStatus {
+  return {
+    agent: 'codex',
+    state: 'installed',
+    configPath,
+    managedHooksPresent: true,
+    detail: null
+  }
+}
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'orca-codex-home-'))
+  userDataDir = mkdtempSync(join(tmpdir(), 'orca-codex-user-data-'))
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  process.env.ORCA_USER_DATA_PATH = userDataDir
+  homedirMock.mockReturnValue(tmpHome)
+  getPathMock.mockImplementation((name: string) => {
+    if (name === 'userData') {
+      return userDataDir
+    }
+    throw new Error(`unexpected app.getPath(${name})`)
+  })
+  installExclusivelyMock.mockImplementation(async (runtimeHomePath: string) => {
+    await delay(INSTALL_MS)
+    return installedStatus(join(runtimeHomePath, 'hooks.json'))
+  })
+  refreshExclusivelyMock.mockImplementation(async (runtimeHomePath: string) => {
+    await delay(INSTALL_MS)
+    return installedStatus(join(runtimeHomePath, 'hooks.json'))
+  })
+})
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true })
+  rmSync(userDataDir, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  vi.clearAllMocks()
+})
+
+describe('launch-prep Codex hook install sharing', () => {
+  it('collapses a burst of concurrent launches into one install', async () => {
+    const service = new CodexHookService()
+    const home = join(userDataDir, 'managed')
+
+    const statuses = await Promise.all(
+      Array.from({ length: 7 }, () => service.installForLaunchPrep(home))
+    )
+
+    expect(statuses.every((status) => status.state === 'installed')).toBe(true)
+    expect(installExclusivelyMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-installs for a launch that starts after the shared run settled', async () => {
+    const service = new CodexHookService()
+    const home = join(userDataDir, 'managed')
+
+    await Promise.all(Array.from({ length: 3 }, () => service.installForLaunchPrep(home)))
+    await service.installForLaunchPrep(home)
+
+    expect(installExclusivelyMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-installs after a failed shared run instead of caching the failure', async () => {
+    const service = new CodexHookService()
+    const home = join(userDataDir, 'managed')
+    installExclusivelyMock.mockRejectedValueOnce(new Error('hooks.json unreadable'))
+
+    await expect(service.installForLaunchPrep(home)).rejects.toThrow('hooks.json unreadable')
+    await expect(service.installForLaunchPrep(home)).resolves.toMatchObject({
+      state: 'installed'
+    })
+    expect(installExclusivelyMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('never shares a run across different runtime homes', async () => {
+    const service = new CodexHookService()
+
+    await Promise.all([
+      service.installForLaunchPrep(join(userDataDir, 'managed')),
+      service.installForLaunchPrep(join(userDataDir, 'per-account'))
+    ])
+
+    expect(installExclusivelyMock).toHaveBeenCalledTimes(2)
+    expect(installExclusivelyMock.mock.calls.map(([home]) => home)).toEqual([
+      join(userDataDir, 'managed'),
+      join(userDataDir, 'per-account')
+    ])
+  })
+
+  it('never shares the install lane with the hooks-disabled refresh lane', async () => {
+    const service = new CodexHookService()
+    const home = join(userDataDir, 'managed')
+
+    await Promise.all([
+      service.installForLaunchPrep(home),
+      service.refreshRuntimeUserHooksForLaunchPrep(home)
+    ])
+
+    expect(installExclusivelyMock).toHaveBeenCalledTimes(1)
+    expect(refreshExclusivelyMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the direct install path unshared for settings-driven reinstalls', async () => {
+    const service = new CodexHookService()
+    const home = join(userDataDir, 'managed')
+
+    await Promise.all([service.install(home), service.install(home)])
+
+    expect(installExclusivelyMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/github/conflict-summary-cache.ts
+++ b/src/main/github/conflict-summary-cache.ts
@@ -1,4 +1,5 @@
 import type { PRConflictSummary } from '../../shared/github/pull-request-types'
+import { dedupeInFlightRun } from '../in-flight-run-dedupe'
 
 // Why 60s: the hottest coordinator cadences that re-derive a CONFLICTING PR
 // (10s mergeability-pending, 2.5s manual-pending) previously each ran a
@@ -102,30 +103,14 @@ export function dedupeBaseOidResolve(
   key: string,
   factory: () => Promise<FreshBaseTipResolution>
 ): Promise<FreshBaseTipResolution> {
-  return dedupeInFlight(inFlightBaseOidResolves, key, factory)
+  return dedupeInFlightRun(inFlightBaseOidResolves, key, factory)
 }
 
 export function dedupeSummaryDerivation(
   key: string,
   factory: () => Promise<PRConflictSummary | undefined>
 ): Promise<PRConflictSummary | undefined> {
-  return dedupeInFlight(inFlightSummaryDerivations, key, factory)
-}
-
-function dedupeInFlight<T>(
-  map: Map<string, Promise<T>>,
-  key: string,
-  factory: () => Promise<T>
-): Promise<T> {
-  const existing = map.get(key)
-  if (existing) {
-    return existing
-  }
-  const promise = factory().finally(() => {
-    map.delete(key)
-  })
-  map.set(key, promise)
-  return promise
+  return dedupeInFlightRun(inFlightSummaryDerivations, key, factory)
 }
 
 function setBoundedMapEntry<K, V>(map: Map<K, V>, key: K, value: V, maxEntries: number): void {

--- a/src/main/in-flight-run-dedupe.ts
+++ b/src/main/in-flight-run-dedupe.ts
@@ -1,0 +1,31 @@
+/**
+ * Shares one in-flight promise per key so concurrent callers that want the same
+ * result run the work once. Purely a concurrency collapse, never a cache: the
+ * entry is dropped the moment the run settles, so the next caller starts fresh
+ * and re-reads whatever state the run depends on.
+ *
+ * Callers own the map, which keeps each lane's exact result type (including
+ * nullable ones) without a cast at every read.
+ */
+export function dedupeInFlightRun<T>(
+  runs: Map<string, Promise<T>>,
+  key: string,
+  start: () => Promise<T>
+): Promise<T> {
+  const active = runs.get(key)
+  if (active) {
+    return active
+  }
+  const run = start()
+  runs.set(key, run)
+  // Why: clear on rejection too, or one failure would wedge every later caller
+  // onto the same rejected promise. The identity check keeps a late settle from
+  // evicting a newer entry for the same key.
+  const clear = (): void => {
+    if (runs.get(key) === run) {
+      runs.delete(key)
+    }
+  }
+  void run.then(clear, clear)
+  return run
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1377,9 +1377,9 @@ async function prepareCodexSessionResumeForLaunch(args: {
             userDataPath: app.getPath('userData')
           })
         } else if (hooksEnabled) {
-          await codexHookService.install(resumeHome)
+          await codexHookService.installForLaunchPrep(resumeHome)
         } else {
-          await codexHookService.refreshRuntimeUserHooks(resumeHome)
+          await codexHookService.refreshRuntimeUserHooksForLaunchPrep(resumeHome)
         }
       } catch (error) {
         // Why: hook repair is best-effort; session provenance must still win over the currently selected home.

--- a/src/main/ipc/pty-spawn-timing.ts
+++ b/src/main/ipc/pty-spawn-timing.ts
@@ -1,7 +1,10 @@
-// Why: pty:spawn latency has four very different suspects (startup barrier,
-// Claude auth prep, buildPtyHostEnv filesystem work, provider/daemon spawn).
-// A single opt-in log line per spawn lets benchmarks attribute the cost
-// without a tracing dependency. Enabled via ORCA_PTY_SPAWN_TIMING=1.
+// Why: pty:spawn latency has several very different suspects (startup barrier,
+// Claude auth prep, Codex resume/hook prep, account resolution, buildPtyHostEnv
+// filesystem work, provider/daemon spawn). A single opt-in log line per spawn
+// lets benchmarks attribute the cost without a tracing dependency. Each phase
+// must name what it actually spans — `host_env` once covered the whole Codex
+// preamble and pinned 2s of hook-install cost on the env builder that ran last.
+// Enabled via ORCA_PTY_SPAWN_TIMING=1.
 
 export type PtySpawnTiming = {
   mark(phase: string): void

--- a/src/main/ipc/pty/ipc/spawn-env-codex.ts
+++ b/src/main/ipc/pty/ipc/spawn-env-codex.ts
@@ -45,6 +45,10 @@ export async function assemblePtyIpcSpawnCodexEnv(ctx: PtyIpcSpawnState): Promis
   ctx.codexResumeLaunch = codexResumePreparation
     ? await ctx.deps.resolveCodexResumeLaunch(args.command, codexResumePreparation)
     : ctx.deps.noCodexResumeLaunch(ctx.preAdoptedStablePane ? undefined : args.command)
+  // Why: these three phases have unrelated costs (session provenance + hook
+  // repair, account/auth resolution, then the synchronous env build). One
+  // `host_env` label hid all of them behind the name of the cheapest.
+  ctx.spawnTiming.mark('codex_resume')
   const codexResumeHome = ctx.codexResumeLaunch.codexResumeHome
   ctx.launchCommand = ctx.codexResumeLaunch.command
   ctx.baseEnv = ctx.deps.stripSequencedStartupResumeArgv(ctx.baseEnv, ctx.codexResumeLaunch)
@@ -99,6 +103,7 @@ export async function assemblePtyIpcSpawnCodexEnv(ctx: PtyIpcSpawnState): Promis
   if (args.launchAgent === 'codex' && ctx.selectedCodexHomePath) {
     await ensureCodexStateDbBackfillRecoveryStarted(ctx.selectedCodexHomePath)
   }
+  ctx.spawnTiming.mark('codex_home')
   ctx.codexResumeHomeSelected = Boolean(
     codexResumeHome && codexHomePathsEqual(ctx.selectedCodexHomePath, codexResumeHome.codexHomePath)
   )

--- a/src/main/ipc/pty/ipc/spawn-env.ts
+++ b/src/main/ipc/pty/ipc/spawn-env.ts
@@ -139,5 +139,6 @@ export async function assemblePtyIpcSpawnEnv(ctx: PtyIpcSpawnState): Promise<voi
   // Why: SSH can strip ORCA_PANE_KEY when remote hooks are off; IPC tab/leaf metadata still names the pane.
   ctx.reservationPaneKey = ctx.metadataPaneKey ?? ctx.validatedPaneKey
   ctx.validatedLeafId = ctx.verifiedLeafId ?? ctx.metadataLeafId
+  ctx.spawnTiming.mark('pane_env')
   await assemblePtyIpcSpawnCodexEnv(ctx)
 }


### PR DESCRIPTION
## ELI5

Every time Orca opens a terminal, it first does a bit of setup so the coding agent in that terminal can report its status back to the app. That setup involves rewriting a couple of config files, and Orca is careful to only ever do one of them at a time so two terminals can't scribble over each other.

The problem: when you switch to a worktree that has seven terminals, all seven open at once — and each one insisted on doing that whole setup for itself. Because they have to take turns, they formed a queue, and the last terminal sat waiting for the six ahead of it. That queue was a big chunk of the delay before your terminals appeared.

The fix: terminals opening at the same moment now wait on a single shared setup instead of each running their own. It's the same work, done once, and everyone gets the result. Measured on a real config, seven terminals went from **698 ms to 175 ms** of setup. Nothing is cached between openings — the next terminal you open still re-reads your settings, so toggling status hooks or changing your Codex config takes effect immediately.

Two smaller things came along with it. The same fix now also applies on WSL, which had the identical queue. And the timing label that pointed at this problem was misleading — it was named after the last step in a long stretch of work rather than the stretch itself, which is why the slowdown looked like it lived somewhere it didn't. That label is now split into four honest ones.

**What you'll notice:** switching to a worktree with several terminals feels quicker, and the terminals appear together instead of trickling in one by one. Nothing else changes.

---

<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​154 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​154 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​40 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |

<!-- /orca-pr-loc -->

## What

Codex launch prep (`prepareCodexRuntimeHomeForLaunch`, `src/main/index.ts:1195`) runs a **full managed-hook install on every local PTY spawn** — bare shells included — and both install lanes serialize globally per Codex home via `runExclusivelyForRuntimeAndSystemTrustConfig`. Opening a multi-pane worktree therefore paid N full installs strictly back to back, and a resumed Codex pane prepares twice (once from `resolveVerifiedResumeHome`, once from launch prep).

Concurrent launch-prep runs for the same runtime home now share one install.

## Root cause, with measurements

All numbers measured on macOS against a fixture copied from this machine's real `~/.codex` and managed Codex home (62–64 KB `config.toml` on both sides), driving `CodexHookService` directly.

| Measurement | Value |
| --- | --- |
| One real `codex app-server` trust-grant session (`initialize` → `hooks/list` → `hooks/list`, codex-cli 0.151.0, real managed home) | **378 ms** |
| One full `install()` with a warm trust-grant ledger (no session) | ~50–110 ms |
| 7 concurrent launch-prep installs, warm ledger — **before** | **698 ms**, staggered `352, 549, 582, 608, 650, 676, 696` |
| 7 concurrent launch-prep installs, warm ledger — **after** | **175 ms**, all panes `175` |
| 7 concurrent launch-prep installs, cold ledger (one 380 ms session) — **before** | 729 ms, staggered `521 … 729` |
| 7 concurrent launch-prep installs, cold ledger — **after** | 658 ms, all panes `658` |

The steady-state (warm-ledger) case — which is what a normal worktree activation hits — improves **4×**, and every pane finishes together instead of the last one absorbing the whole serialized chain. A resumed Codex pane pays this twice, so the saving roughly doubles for restored agent panes.

The ledger (`codex-trust-grant-ledger.json`) already suppresses repeat app-server sessions, and it works correctly under concurrency because the ledger lookup happens *inside* the serialized region — the burst only ever spends one session. What it does **not** suppress is the rest of the install: `promoteCodexRuntimeHookApprovalsToSystem`, `readHooksJson`, `getRuntimeHooksWithSystemUserHooks`, `writeCodexHooksJson`, `syncSystemConfigIntoManagedCodexHome`, the trust upsert/stale sweep over a 64 KB `config.toml`, the provenance snapshot, and `cleanupLegacyManagedHookRepresentations`. That's the ~50–110 ms per pane that the mutex turns into a serial chain.

## Honest scoping of the reported 2.1 s

The report was `host_env=2100ms` on a 7-tab activation of a large worktree. Two corrections to how that reads:

1. **The phase name was wrong.** `host_env` spans `mark('auth')` (`ipc/spawn-preflight.ts:228`) → `mark('host_env')` (`ipc/spawn-env-codex.ts`), i.e. *all* of `assemblePtyIpcSpawnEnv` + `assemblePtyIpcSpawnCodexEnv`. `buildPtyHostEnv` is one synchronous call near the end of that span; optimizing it would have bought ~0 ms. This PR splits the span into `pane_env`, `codex_resume`, `codex_home` and `host_env` so a re-measure attributes cost to the right stage.
2. **This fix accounts for a large share of that window, not provably all of it.** I could not reproduce the exact 7-tab activation in isolation (it needs the user's live session state), so I measured the launch-prep install path directly rather than guessing. On the fixture above it is worth ~0.5 s for 7 plain panes and ~1.0–1.4 s for 7 resumed Codex panes. The remaining time lives in the newly-split `codex_resume` / `codex_home` phases (`resolveCodexHomeAfterManagedAuthReadiness`'s polling wait, `markCodexProjectTrusted`'s double `config.toml` mutation, `ensureCodexStateDbBackfillRecoveryStarted`'s lock arbitration) — those now have their own labels, so the next `ORCA_PTY_SPAWN_TIMING=1` capture will say which.

## Invalidation rule

Documented in the code: the shared promise is dropped the instant it settles, including on rejection. Nothing is cached across spawns — the next launch re-reads `hooks.json`, `~/.codex` approvals, the hooks on/off setting and the managed script. The key is `lane + normalized runtime home`, so the install and hooks-disabled refresh lanes never share, and per-account Codex homes never share with the shared managed mirror. Direct `install()` (settings toggles, hook repair) is deliberately left unshared.

## Cross-platform

No platform branches added. The WSL lane (`installForRuntimeHomeSerialized`) already had its own single-flight and keeps it; this adds the equivalent for the native fallback that runs when there is no WSL plan. Keys are normalized with `normalizeRuntimePathForComparison`, so Windows case/separator variants of the same home share correctly. SSH spawns never reach this path.

## Tests

New `src/main/codex/hook-service-concurrent-launch-install.test.ts` covers the fast path and each invalidation trigger:
- a 7-launch burst collapses to one underlying install (fails with 7 without the fix)
- a launch starting after the burst settles installs again
- a rejected shared run is not cached — the next launch retries
- different runtime homes never share
- the install lane never shares with the hooks-disabled refresh lane
- direct `install()` stays unshared

## Verification

- `pnpm tc` clean
- `pnpm test src/main/codex src/main/ipc/pty` — 2068 passed, 16 skipped
- `pnpm run check:code-quality:changed` — 0 new findings
- `check:max-lines-ratchet`, `check:reliability-gates` pass
- Temporary instrumentation removed before commit


## Readiness review (self, adversarial)

Ran the repo readiness checklist over this diff. Confirmed findings fixed; everything else recorded below with reasoning rather than left implicit.

**Superseded by main — WSL launch prep.** My earlier revision also switched the WSL lane at this call site onto `installForRuntimeHomeSerialized`, because launch prep was the one caller still using the raw `installForRuntimeHome`. #16854 landed that independently while this PR was open, extracting the whole block into `CodexHookService.prepareRuntimeHomeForLaunch`. On rebase I dropped my version and kept main's. The native fallback inside that new method was still un-deduped, which is what this PR now changes.

**Fixed — §08 duplicated mechanism, three copies.** The new dedupe duplicated the map bookkeeping `installForRuntimeHomeSerialized` already had, and a third near-identical private copy already existed in `src/main/github/conflict-summary-cache.ts`. All three now use one `dedupeInFlightRun` module. Callers keep their own maps so each lane retains its exact result type (including the WSL lane's nullable one) without an `as` cast at every read. The shared copy keeps the identity check on clear, which the GitHub copy lacked.

**Not real — rejection wedging later callers.** `clear` is passed as both handlers of `run.then`, so a rejected run is evicted immediately. Covered by a test that asserts the next launch retries rather than re-receiving the failure.

**Not real — unbounded map growth.** Entries are keyed by lane + normalized runtime home and deleted on settle; the map is bounded by the number of homes concurrently spawning. The identity check in `clear` makes the settle-vs-replace race safe.

**Not real — new permanent-stuck risk from a hung install.** These calls were already serialized on the same per-`config.toml` mutex, so a hung install blocked every concurrent spawn before this change too. Sharing strictly reduces the number of pending awaits rather than adding a new stall. The underlying app-server session is separately deadline-bounded (10 s native / 30 s WSL).

**Not real — sharing clobbers a concurrent project-trust write.** `markCodexProjectTrusted` (`src/main/agent-trust-presets.ts:112`) takes the same runtime-before-system `runExclusivelyForCodexTrustConfig` lanes and writes `[projects.*]`, which is disjoint from the `[hooks.state.*]` the install manages. A joined install can neither lose that write nor need to observe it.

**Not real — sharing skips work a resumed pane needed.** The only thing that runs between a pane's own preconditions and its install is `prepareLegacySharedCodexSessionResume`, which touches session rollout files and never `hooks.json` or `config.toml`, so a joined install's inputs are unchanged.

**Not real — settings toggles get a stale shared result.** Direct `install()` is deliberately left unshared, so a toggle always forces a real reinstall. The install and hooks-disabled refresh lanes are keyed separately, so a spawn that reads `hooksEnabled=false` can never join an in-flight install started when it was true.

**§06 backward compatibility: nothing persisted changed.** The trust-grant ledger, `hooks.json` and `config.toml` formats are untouched; the sharing is in-memory and process-local. No mobile-facing surface touched.

**§03 security: no new network sinks, no shell/eval, no dependency change.** The diff adds no new process spawns — it removes redundant runs of an existing one.

**Residual risk.** The Windows and WSL lanes are reasoned about but not measured; I only had a macOS host. The WSL change is a call-site swap onto an already-tested method (`hook-service-wsl-runtime.test.ts` covers its dedupe, alias-normalization and per-distro keying), so the risk is that WSL launch prep wanted a fresh install per spawn for some reason not visible in the code — nothing in the reconciliation-generation logic suggests it does, and two other callers already share that lane.



## Rebase note (onto 02a7742406a)

Two conflicts in `src/main/index.ts`, both from #16854 landing the WSL direct-home cutover. That PR extracted the launch-prep hook block out of `index.ts` into `CodexHookService.prepareRuntimeHomeForLaunch` and routed the WSL lane through `installForRuntimeHomeSerialized` — overlapping work with my earlier revision. I resolved both to main's side and re-targeted the dedupe into the new method, so `index.ts` now carries only the two-line resume-path change and the service owns the whole launch-prep decision. That is a better shape than what I had.

Re-verified after rebasing rather than assuming the rebase was clean: `pnpm tc`, 3654 tests across `src/main/codex`, `src/main/ipc/pty`, `src/main/agent-hooks` and `src/main/github`, and `check:code-quality:changed`. I also re-confirmed the regression test still fails without the fix (7 installs instead of 1) on the rebased tree, since a silently-neutered test would be the easy way for this rebase to go wrong.

One run of the combined suite showed a single failure that did not reproduce across three subsequent full runs and named no test in the reporter output; the GitHub suite alone is green. Recording it as an observed flake rather than claiming it away.
