### PR TITLE
fix(mobile): kick iOS session touches after a notification resume

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -148,6 +148,7 @@ import {
 import { countTerminalGestureInputSequences } from '../../../../src/terminal/terminal-gesture-input'
 import {
   recoverActiveTerminalAfterForeground,
+  shouldKickIosTouchesOnSessionMount,
   shouldRecoverTerminalOnAppStateChange
 } from '../../../../src/terminal/terminal-foreground-recovery'
 import { MobileBrowserPane } from '../../../../src/browser/MobileBrowserPane'
@@ -2090,6 +2091,10 @@ export default function SessionScreen() {
   }, [])
 
   const pendingForegroundRecoveryRef = useRef(false)
+  const [foregroundTouchEpoch, setForegroundTouchEpoch] = useState(0)
+  const kickIosForegroundTouches = useCallback(() => {
+    setForegroundTouchEpoch((epoch) => epoch + 1)
+  }, [])
   useEffect(() => {
     let previousAppState: AppStateStatus | null = AppState.currentState
     const sub = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
@@ -2102,6 +2107,7 @@ export default function SessionScreen() {
       if (!shouldRecover) {
         return
       }
+      kickIosForegroundTouches()
       for (const terminalRef of terminalRefs.current.values()) {
         terminalRef.prepareForForegroundRecovery()
       }
@@ -2120,7 +2126,15 @@ export default function SessionScreen() {
     return () => {
       sub.remove()
     }
-  }, [scheduleDelayedAction, subscribeToTerminal, unsubscribeTerminal])
+  }, [kickIosForegroundTouches, scheduleDelayedAction, subscribeToTerminal, unsubscribeTerminal])
+
+  useEffect(() => {
+    if (!shouldKickIosTouchesOnSessionMount(Platform.OS, AppState.currentState)) {
+      return
+    }
+    kickIosForegroundTouches()
+    pendingForegroundRecoveryRef.current = true
+  }, [kickIosForegroundTouches])
 
   // Why: resume lands mid-reconnect (socket dies in bg); re-run recovery once connected or a blanked WKWebView stays stale.
   useEffect(() => {
@@ -4346,6 +4360,7 @@ export default function SessionScreen() {
                     key={terminal.handle}
                     handle={terminal.handle}
                     active={terminal.handle === activeHandle}
+                    touchEpoch={foregroundTouchEpoch}
                     keyboardLift={terminal.handle === activeHandle ? activeTerminalKeyboardLift : 0}
                     terminalTheme={terminal.terminalTheme}
                     textScale={terminalTextScale}
@@ -4384,6 +4399,7 @@ export default function SessionScreen() {
                   sendSurfaceId={nativeChatScopeKey ?? ''}
                   getSendCompletionGeneration={getSendCompletionGeneration}
                   keyboardInset={keyboardLift}
+                  touchEpoch={foregroundTouchEpoch}
                 />
                 {toastMessage && (
                   <Animated.View pointerEvents="none" style={[styles.toast, toastAnimatedStyle]}>

--- a/mobile/src/session/MobileNativeChatOverlay.tsx
+++ b/mobile/src/session/MobileNativeChatOverlay.tsx
@@ -5,6 +5,7 @@ import { foldMobileNativeChatMessages } from './mobile-native-chat-render-data'
 import type { MobileNativeChatImageAttachments } from './use-mobile-native-chat-image-attachments'
 import type { MobileNativeChatController } from './use-mobile-native-chat-controller'
 import { useMobileNativeChatStreamingBubble } from './use-mobile-native-chat-streaming-bubble'
+import { useIosForegroundTouchPulse } from './ios-foreground-touch-pulse'
 
 type Props = {
   controller: MobileNativeChatController
@@ -29,6 +30,7 @@ type Props = {
   /** Reads the retained route's focus generation for accepted-send fencing. */
   getSendCompletionGeneration: () => number
   keyboardInset: number
+  touchEpoch?: number
 }
 
 /** Keeps the terminal mounted underneath chat so its PTY subscription survives
@@ -49,7 +51,8 @@ export function MobileNativeChatOverlay({
   onClearSendError,
   sendSurfaceId,
   getSendCompletionGeneration,
-  keyboardInset
+  keyboardInset,
+  touchEpoch = 0
 }: Props): React.JSX.Element | null {
   const session = controller.nativeChatSession
   const folded = useMemo(() => foldMobileNativeChatMessages(session.messages), [session.messages])
@@ -59,11 +62,12 @@ export function MobileNativeChatOverlay({
     controller.nativeChatStreamScopeKey,
     controller.nativeChatStreamLive
   )
+  const touchCommitted = useIosForegroundTouchPulse(touchEpoch, controller.showNativeChat)
   if (!controller.showNativeChat) {
     return null
   }
   return (
-    <View style={styles.overlay}>
+    <View style={styles.overlay} pointerEvents={touchCommitted ? 'auto' : 'none'}>
       <MobileNativeChatView
         messages={session.messages}
         folded={folded}

--- a/mobile/src/session/TerminalPaneView.tsx
+++ b/mobile/src/session/TerminalPaneView.tsx
@@ -66,9 +66,6 @@ export function TerminalPaneView({
     <View
       // Why: inactive terminal WebViews stay mounted to preserve xterm state,
       // while touch and visibility are disabled until the tab is active again.
-      // iOS notification resume can leave the last frame painted with a dead
-      // hit-test; one-frame pointerEvents none (same flip as a tab switch)
-      // recommits the native wrapper.
       pointerEvents={active && touchCommitted ? 'auto' : 'none'}
       style={[
         styles.terminalPane,

--- a/mobile/src/session/TerminalPaneView.tsx
+++ b/mobile/src/session/TerminalPaneView.tsx
@@ -7,10 +7,12 @@ import type {
   TerminalModes,
   TerminalWebViewHandle
 } from '../terminal/terminal-webview-contract'
+import { useIosForegroundTouchPulse } from './ios-foreground-touch-pulse'
 
 type TerminalPaneViewProps = {
   handle: string
   active: boolean
+  touchEpoch?: number
   keyboardLift: number
   terminalTheme?: MobileTerminalTheme
   textScale: number
@@ -33,6 +35,7 @@ type TerminalPaneViewProps = {
 export function TerminalPaneView({
   handle,
   active,
+  touchEpoch = 0,
   keyboardLift,
   terminalTheme,
   textScale,
@@ -57,16 +60,21 @@ export function TerminalPaneView({
     },
     [handle, onRef]
   )
+  const touchCommitted = useIosForegroundTouchPulse(touchEpoch, active)
 
   return (
     <View
       // Why: inactive terminal WebViews stay mounted to preserve xterm state,
       // while touch and visibility are disabled until the tab is active again.
-      pointerEvents={active ? 'auto' : 'none'}
+      // iOS notification resume can leave the last frame painted with a dead
+      // hit-test; one-frame pointerEvents none (same flip as a tab switch)
+      // recommits the native wrapper.
+      pointerEvents={active && touchCommitted ? 'auto' : 'none'}
       style={[
         styles.terminalPane,
         keyboardLift > 0 && { transform: [{ translateY: -keyboardLift }] },
-        !active && styles.terminalPaneHidden
+        !active && styles.terminalPaneHidden,
+        active && !touchCommitted && styles.terminalPaneKick
       ]}
     >
       <TerminalWebView
@@ -98,6 +106,9 @@ const styles = StyleSheet.create({
   },
   terminalPaneHidden: {
     opacity: 0
+  },
+  terminalPaneKick: {
+    opacity: 0.99
   },
   terminalWebView: {
     flex: 1

--- a/mobile/src/session/ios-foreground-touch-pulse.test.ts
+++ b/mobile/src/session/ios-foreground-touch-pulse.test.ts
@@ -1,0 +1,75 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useIosForegroundTouchPulse } from './ios-foreground-touch-pulse'
+
+vi.mock('react-native', () => ({
+  View: 'View'
+}))
+
+function Probe({ epoch, enabled }: { epoch: number; enabled: boolean }) {
+  const committed = useIosForegroundTouchPulse(epoch, enabled)
+  return createElement('View', { committed, pointerEvents: committed && enabled ? 'auto' : 'none' })
+}
+
+describe('useIosForegroundTouchPulse', () => {
+  let renderer: ReactTestRenderer | null = null
+  const frames: Array<FrameRequestCallback> = []
+
+  beforeEach(() => {
+    frames.length = 0
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      frames.push(cb)
+      return frames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      frames[id - 1] = () => {}
+    })
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    vi.unstubAllGlobals()
+  })
+
+  function committed(): boolean {
+    return renderer!.root.findByType('View').props.committed as boolean
+  }
+
+  function pointerEvents(): string {
+    return renderer!.root.findByType('View').props.pointerEvents as string
+  }
+
+  it('drops pointerEvents for one frame when the kick epoch advances', () => {
+    act(() => {
+      renderer = create(createElement(Probe, { epoch: 1, enabled: true }))
+    })
+    expect(committed()).toBe(false)
+    expect(pointerEvents()).toBe('none')
+
+    act(() => {
+      frames[0]?.(0)
+    })
+    expect(committed()).toBe(true)
+    expect(pointerEvents()).toBe('auto')
+  })
+
+  it('does not pulse when the pane is inactive', () => {
+    act(() => {
+      renderer = create(createElement(Probe, { epoch: 1, enabled: false }))
+    })
+    expect(committed()).toBe(true)
+    expect(pointerEvents()).toBe('none')
+    expect(frames).toHaveLength(0)
+  })
+
+  it('does not pulse when no kick has been armed', () => {
+    act(() => {
+      renderer = create(createElement(Probe, { epoch: 0, enabled: true }))
+    })
+    expect(committed()).toBe(true)
+    expect(pointerEvents()).toBe('auto')
+    expect(frames).toHaveLength(0)
+  })
+})

--- a/mobile/src/session/ios-foreground-touch-pulse.ts
+++ b/mobile/src/session/ios-foreground-touch-pulse.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+// Why: tab switch unfreezes a notification-resume pane by flipping pointerEvents
+// and opacity; stream recovery does not, so we recommit the wrapper for one frame.
+export function useIosForegroundTouchPulse(epoch: number, enabled: boolean): boolean {
+  const [committed, setCommitted] = useState(() => !(enabled && epoch > 0))
+  useEffect(() => {
+    if (!enabled || epoch <= 0) {
+      setCommitted(true)
+      return
+    }
+    setCommitted(false)
+    const id = requestAnimationFrame(() => {
+      setCommitted(true)
+    })
+    return () => cancelAnimationFrame(id)
+  }, [epoch, enabled])
+  return committed
+}

--- a/mobile/src/session/ios-foreground-touch-pulse.ts
+++ b/mobile/src/session/ios-foreground-touch-pulse.ts
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react'
 
-// Why: tab switch unfreezes a notification-resume pane by flipping pointerEvents
-// and opacity; stream recovery does not, so we recommit the wrapper for one frame.
 export function useIosForegroundTouchPulse(epoch: number, enabled: boolean): boolean {
   const [committed, setCommitted] = useState(() => !(enabled && epoch > 0))
   useEffect(() => {

--- a/mobile/src/terminal/terminal-foreground-recovery.test.ts
+++ b/mobile/src/terminal/terminal-foreground-recovery.test.ts
@@ -6,6 +6,7 @@ import type { TerminalWebViewHandle } from './TerminalWebView'
 import {
   TERMINAL_FOREGROUND_RECOVERY_DELAY_MS,
   recoverActiveTerminalAfterForeground,
+  shouldKickIosTouchesOnSessionMount,
   shouldRecoverTerminalOnAppStateChange
 } from './terminal-foreground-recovery'
 
@@ -172,5 +173,33 @@ describe('terminal foreground recovery', () => {
     )
     expect(reconnectRetry).toContain('pendingForegroundRecoveryRef.current = false')
     expect(reconnectRetry).toContain("AppState.currentState !== 'active'")
+  })
+
+  it('kicks iOS touches when a session mounts after AppState is already active', () => {
+    expect(shouldKickIosTouchesOnSessionMount('ios', 'active')).toBe(true)
+    expect(shouldKickIosTouchesOnSessionMount('ios', 'background')).toBe(false)
+    expect(shouldKickIosTouchesOnSessionMount('ios', 'inactive')).toBe(false)
+    expect(shouldKickIosTouchesOnSessionMount('android', 'active')).toBe(false)
+  })
+
+  it('arms missed foreground recovery and a native touch kick on iOS session mount', () => {
+    expect(sessionSource).toContain('shouldKickIosTouchesOnSessionMount(')
+    expect(sessionSource).toContain('kickIosForegroundTouches()')
+    const mountKick = sliceSessionSource(
+      'shouldKickIosTouchesOnSessionMount(',
+      'pendingForegroundRecoveryRef.current = true'
+    )
+    expect(mountKick).toContain('Platform.OS')
+    expect(mountKick).toContain('AppState.currentState')
+    expect(sessionSource).toContain('foregroundTouchEpoch')
+    expect(sessionSource).toContain('touchEpoch={foregroundTouchEpoch}')
+  })
+
+  it('re-commits pane pointerEvents on the same AppState edge as stream recovery', () => {
+    const appStateRecover = sliceSessionSource(
+      'const shouldRecover = shouldRecoverTerminalOnAppStateChange(',
+      'terminalRef.prepareForForegroundRecovery()'
+    )
+    expect(appStateRecover).toContain('kickIosForegroundTouches()')
   })
 })

--- a/mobile/src/terminal/terminal-foreground-recovery.ts
+++ b/mobile/src/terminal/terminal-foreground-recovery.ts
@@ -32,8 +32,6 @@ export function shouldRecoverTerminalOnAppStateChange(
   )
 }
 
-// Why: a notification tap marks the app active before SessionScreen mounts
-// (catalog load, then host-stack REPLACE), so the AppState listener never fires.
 export function shouldKickIosTouchesOnSessionMount(platform: string, appState: string): boolean {
   return platform === 'ios' && appState === 'active'
 }

--- a/mobile/src/terminal/terminal-foreground-recovery.ts
+++ b/mobile/src/terminal/terminal-foreground-recovery.ts
@@ -32,6 +32,12 @@ export function shouldRecoverTerminalOnAppStateChange(
   )
 }
 
+// Why: a notification tap marks the app active before SessionScreen mounts
+// (catalog load, then host-stack REPLACE), so the AppState listener never fires.
+export function shouldKickIosTouchesOnSessionMount(platform: string, appState: string): boolean {
+  return platform === 'ios' && appState === 'active'
+}
+
 export function recoverActiveTerminalAfterForeground({
   activeHandleRef,
   terminalRefs,


### PR DESCRIPTION
## ELI5

Tap an Orca notification on iPhone and the right tab opens, but it will not scroll until you switch tabs and come back. The tap marks the app active before the session screen exists, so the iOS resume path never runs. This change runs that path on mount and flips the same native hit-test flags a tab switch already flips.

## What Changed

- `shouldKickIosTouchesOnSessionMount` treats an iOS session that mounts while `AppState` is already `active` as a missed resume.
- `SessionScreen` then arms the existing deferred foreground recovery and bumps `foregroundTouchEpoch`.
- `useIosForegroundTouchPulse` recommits `pointerEvents` (and terminal opacity 0.99) for one frame on that epoch, for `TerminalPaneView` and `MobileNativeChatOverlay`.
- The same kick runs on the existing `background`/`inactive` → `active` edge, which used to resubscribe the stream but not recommit the wrapper.

## Why

`RootLayout` awaits `loadHostCatalog` then push/REPLACE. iOS has already set AppState to `active`. `SessionScreen` records `previousAppState = AppState.currentState` and never sees a transition. `recoverActiveTerminalAfterForeground` also does not flip `TerminalPaneView` `pointerEvents`/`opacity`. A tab switch does, which is why that workaround works.

## Scope

- `mobile/src/terminal/terminal-foreground-recovery.ts` (`shouldKickIosTouchesOnSessionMount`)
- `mobile/src/session/ios-foreground-touch-pulse.ts`
- `mobile/app/h/[hostId]/session/[worktreeId].tsx`
- `mobile/src/session/TerminalPaneView.tsx`
- `mobile/src/session/MobileNativeChatOverlay.tsx`
- Tests for the predicate, the pulse, and session wiring

Out of scope: duplicate-session Send lock (#16995, #17098). White WKWebView first paint (#17304, #17305). Browser/markdown/file panes (they remount on tab change; this PR does not pulse them).

## Tradeoffs

One-frame `pointerEvents="none"` on the active terminal or chat overlay. No visible flash (opacity 0.99). Opening any iOS session while already foregrounded also pulses once. That is cheap and matches the missed-AppState case.

## Blast Radius

iOS session screen only. Android never kicks. No RPC, lease, or host-stack navigation change. Stacked terminal WebViews still rely on per-pane `pointerEvents`; the kick is the same flip a tab switch already performs.

## Linked Issue

Fixes #17676

Related, not this bug: #16995 / #17098 (Send lock from a second session screen). #17304 (white backing store). #8198 (blank until tab switch when stream recovery is skipped).

## Visual Proof

N/A. The change is a one-frame native hit-test recommit. `xcrun simctl` timed out on this machine, so there is no device recording. The red-then-green proof is the unit tests below.

## Testing

- [x] Automated tests added
- [ ] I manually tested these changes locally (iOS simulator tooling hung; see Verification)

```bash
pnpm --dir mobile exec vitest run \
  src/terminal/terminal-foreground-recovery.test.ts \
  src/session/ios-foreground-touch-pulse.test.ts \
  src/session/MobileNativeChatOverlay.test.ts
```

Against `main` session wiring, 2 tests fail (`shouldKickIosTouchesOnSessionMount` and `kickIosForegroundTouches` missing from `SessionScreen`). After the fix, 21/21 pass.

## AI Disclosure

Grok 4.6 (pstack / poteto-mode).

## Review

Checked iOS vs Android (`shouldKickIosTouchesOnSessionMount` is iOS-only). No SSH/remote/wire change. Native chat and terminal panes both pulse; browser/file/markdown do not. One-frame hit-test drop is the same class of work as a tab switch. No new RPC.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

If Send is disabled after a same-session notification tap, that is #17098 (duplicate session + input lease), not this freeze.

## Verification

Unit tests as above. `oxlint` clean on the changed files. `tsc --noEmit` reports only missing generated webview engines from a skipped postinstall, not this diff.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Focused mobile tests pass; full CI covers the repository-wide matrix