### PR TITLE
fix(linux): remove legacy AppImage orca wrapper during migration

### DIFF
--- a/src/main/cli/cli-command-installation.ts
+++ b/src/main/cli/cli-command-installation.ts
@@ -20,10 +20,8 @@ import {
 } from './cli-command-filesystem-transaction'
 import { DEV_LAUNCHER_DIR, LEGACY_LINUX_COMMAND_NAME } from './cli-install-constants'
 import { buildWindowsForwarder } from './cli-dev-launcher'
-import { isMissingError, isPermissionError } from './cli-install-errors'
+import { isPermissionError } from './cli-install-errors'
 import { isPathInsideOrEqual } from './cli-install-path-format'
-
-const STABLE_LEGACY_INSPECTION_ATTEMPTS = 3
 
 export class CliCommandInstallation extends CliCommandInspection {
   protected async installSymlink(status: CliInstallStatus): Promise<void> {
@@ -190,34 +188,25 @@ export class CliCommandInstallation extends CliCommandInspection {
       })
     | null
   > {
-    for (let attempt = 0; attempt < STABLE_LEGACY_INSPECTION_ATTEMPTS; attempt += 1) {
-      const before = await readEntrySnapshot(commandPath)
-      if (!before) {
-        return null
-      }
-      let target: string | null = null
-      try {
-        target = before.isSymbolicLink ? await readlink(commandPath) : null
-      } catch (error) {
-        if (isMissingError(error)) {
-          continue
-        }
-        throw error
-      }
-      const after = await readEntrySnapshot(commandPath)
-      if (after && hasSameSnapshot(before, after)) {
-        const resolvedTarget = target ? resolve(dirname(commandPath), target) : null
-        return {
-          fileSha256: null,
-          rawSymlinkTarget: target,
-          snapshot: after,
-          managed: Boolean(
-            resolvedTarget && this.isManagedLegacyLinuxTarget(resolvedTarget, launcherPath)
-          )
-        }
-      }
+    const inspected = await inspectStableCommand(commandPath, () =>
+      this.inspectSymlink(commandPath, launcherPath)
+    )
+    if (!inspected.snapshot) {
+      return null
     }
-    throw new Error(`The command at ${commandPath} changed while Orca inspected it.`)
+    const resolvedTarget = inspected.rawSymlinkTarget
+      ? resolve(dirname(commandPath), inspected.rawSymlinkTarget)
+      : inspected.status.currentTarget
+    return {
+      fileSha256: inspected.fileSha256,
+      rawSymlinkTarget: inspected.rawSymlinkTarget,
+      snapshot: inspected.snapshot,
+      managed: Boolean(
+        resolvedTarget &&
+        (this.isManagedLegacyLinuxTarget(resolvedTarget, launcherPath) ||
+          (this.appImagePath && resolve(resolvedTarget) === resolve(this.appImagePath)))
+      )
+    }
   }
 
   private async restoreQuarantinedCommand(

--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -370,6 +370,56 @@ describe('CliInstaller', () => {
     }
   )
 
+  it.skipIf(process.platform === 'win32')(
+    'removes a legacy AppImage wrapper only when it names the current AppImage',
+    async () => {
+      const fixture = await makeFixture()
+      const homePath = join(fixture.root, 'home')
+      const commandDir = join(homePath, '.local', 'bin')
+      const legacyCommandPath = join(commandDir, 'orca')
+      const appImagePath = join(fixture.root, 'Orca.AppImage')
+      const foreignAppImagePath = join(fixture.root, 'Other.AppImage')
+      const cacheRootPath = join(fixture.root, 'cache')
+      await mkdir(commandDir, { recursive: true })
+      await writeFile(appImagePath, '#!/usr/bin/env bash\n', {
+        encoding: 'utf8',
+        mode: 0o755
+      })
+      await writeFile(foreignAppImagePath, '#!/usr/bin/env bash\n', {
+        encoding: 'utf8',
+        mode: 0o755
+      })
+      await writeFile(legacyCommandPath, buildLegacyAppImageCliWrapper(appImagePath), {
+        encoding: 'utf8',
+        mode: 0o755
+      })
+
+      const installer = new CliInstaller({
+        platform: 'linux',
+        isPackaged: true,
+        userDataPath: fixture.userDataPath,
+        appPath: fixture.appPath,
+        appImagePath,
+        appImageCacheRootPath: cacheRootPath,
+        appImageExtractRunner: fakeAppImageExtractRunner,
+        homePath,
+        processPathEnv: commandDir
+      })
+
+      await installer.install()
+      await expect(lstat(legacyCommandPath)).rejects.toMatchObject({ code: 'ENOENT' })
+
+      await writeFile(legacyCommandPath, buildLegacyAppImageCliWrapper(foreignAppImagePath), {
+        encoding: 'utf8',
+        mode: 0o755
+      })
+      await installer.remove()
+      await expect(readFile(legacyCommandPath, 'utf8')).resolves.toBe(
+        buildLegacyAppImageCliWrapper(foreignAppImagePath)
+      )
+    }
+  )
+
   // Why: the privilegedRunner is injectable so the EACCES→osascript path can be
   // exercised in integration without spawning osascript in unit tests.
   it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​50 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​50 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 |

<!-- /orca-pr-loc -->

## Summary

- remove the pre-stack regular `~/.local/bin/orca` AppImage wrapper when it names the current packaged AppImage
- reuse the stable command inspection (including content hashing) for race-safe quarantine
- preserve foreign AppImage wrappers and other user-owned commands

This is stacked on #17683 and closes the migration gap left by the Linux command rename. It is related to the historical GNOME Orca collision issue #7904.

## Validation

- `pnpm test src/main/cli/cli-installer.test.ts src/main/cli/cli-command-installation-races.test.ts src/main/cli/legacy-appimage-cli-wrapper.test.ts src/main/cli/appimage-extracted-root.test.ts src/main/cli/appimage-extraction-pruning.test.ts src/main/cli/cli-installer-appimage-ownership.test.ts` (6 files, 51 passed)
- `pnpm tc`
- `pnpm run check:code-quality:changed`
- `pnpm exec oxfmt --check src/main/cli/cli-command-installation.ts src/main/cli/cli-installer.test.ts`
- `git diff --check`
