### PR TITLE
Add show-more button for recent tabs in empty-query palette

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
@@ -1,5 +1,4 @@
 // @vitest-environment happy-dom
-
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -21,7 +20,6 @@ import {
   makeUnifiedTab,
   makeWorktree
 } from './worktree-jump-palette-test-fixtures'
-
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof ReactI18Next>()
   return {
@@ -31,7 +29,6 @@ vi.mock('react-i18next', async (importOriginal) => {
     })
   }
 })
-
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),
@@ -41,39 +38,29 @@ vi.mock('sonner', () => ({
     message: vi.fn()
   }
 }))
-
 vi.mock('@/hooks/useSettingsNavigationMetadata', () => ({
   useSettingsNavigationMetadata: () => []
 }))
-
 vi.mock('@/components/sidebar/StatusIndicator', () => ({
   default: () => <span data-status-indicator="true" />
 }))
-
 vi.mock('@/components/repo/RepoBadgeLabel', () => ({
   RepoBadgeMark: () => <span data-repo-badge-mark="true" />
 }))
-
 vi.mock('@/components/cmd-j/palette-host-badge', () => ({
   getPaletteHostBadge: () => null
 }))
-
-// Why: activation reaches into window.api and the whole worktree-reveal path; the palette's own
-// contract is which result it hands over, so stub the boundary and assert on that.
 const { activateWorkspaceTabPaletteResult } = vi.hoisted(() => ({
   activateWorkspaceTabPaletteResult: vi.fn((_result: unknown) => ({ status: 'activated' }) as const)
 }))
 vi.mock('@/lib/workspace-tab-palette-activation', () => ({
   activateWorkspaceTabPaletteResult: (result: unknown) => activateWorkspaceTabPaletteResult(result)
 }))
-
 vi.mock('@/components/ui/command', async () => {
   const React = await import('react')
   return {
     Command: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     CommandGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    // Why the commandProps passthrough: cmdk resolves Enter against its `value`, so the controlled
-    // value is the only honest stand-in for "what would Enter activate" without mounting real cmdk.
     CommandDialog: ({
       children,
       open,
@@ -137,20 +124,17 @@ vi.mock('@/components/ui/command', async () => {
     )
   }
 })
-
 const initialAppState = useAppStore.getInitialState()
 let testRoot: Root
 let testContainer: HTMLDivElement
 let setCommandQuery: ((next: string) => void) | null = null
 let setCommandSelection: ((next: string) => void) | null = null
-
 async function flushEffects(): Promise<void> {
   await act(async () => {
     await Promise.resolve()
     await Promise.resolve()
   })
 }
-
 async function renderPalette(overrides: Partial<AppState>): Promise<void> {
   useAppStore.setState({
     activeModal: 'worktree-palette',
@@ -162,44 +146,36 @@ async function renderPalette(overrides: Partial<AppState>): Promise<void> {
     unifiedTabsByWorktree: {},
     hideDefaultBranchWorkspace: false,
     hideAutomationGeneratedWorkspaces: false,
-    // Why explicit: the sweep exemption is what these cases probe, so it must
-    // not ride on whatever the store default happens to be.
     alwaysShowDefaultBranchWorkspace: true,
     lastVisitedAtByWorktreeId: {},
     ...overrides
   } as Partial<AppState>)
-
   await act(async () => {
     testRoot.render(<WorktreeJumpPalette />)
   })
   await flushEffects()
 }
-
 function getWorktreeRows(): string[] {
   return [...testContainer.querySelectorAll<HTMLElement>('[data-command-item^="worktree:"]')].map(
     (node) => node.textContent ?? ''
   )
 }
-
 function getRenderedRowIds(): string[] {
   return [...testContainer.querySelectorAll<HTMLElement>('[data-command-item]')].map(
     (node) => node.dataset.commandItem ?? ''
   )
 }
-
 /** The id cmdk would activate on Enter. */
 function getCommandValue(): string {
   return (
     testContainer.querySelector<HTMLElement>('[data-command-dialog]')?.dataset.commandValue ?? ''
   )
 }
-
 function getTabRowIds(): string[] {
-  return [...testContainer.querySelectorAll<HTMLElement>('[data-command-item^="workspace-tab:"]')]
-    .map((node) => node.dataset.commandItem ?? '')
-    .map((id) => id.replace('workspace-tab:', ''))
+  return [
+    ...testContainer.querySelectorAll<HTMLElement>('[data-command-item^="workspace-tab:"]')
+  ].map((node) => (node.dataset.commandItem ?? '').replace('workspace-tab:', ''))
 }
-
 describe('WorktreeJumpPalette recent chats & terminals', () => {
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
@@ -211,7 +187,6 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     document.body.appendChild(testContainer)
     testRoot = createRoot(testContainer)
   })
-
   afterEach(async () => {
     await act(async () => {
       testRoot.unmount()
@@ -219,52 +194,52 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     document.body.replaceChildren()
     useAppStore.setState(initialAppState, true)
   })
-
   it('leads the empty-query list with the recent section', async () => {
     await renderPalette(makeRecentTabState())
-
     const rows = getRenderedRowIds().filter((id) => id.length > 0)
     expect(rows[0]).toMatch(/^workspace-tab:/)
     expect(rows.some((id) => id.startsWith('worktree:'))).toBe(true)
     expect(testContainer.textContent).toContain('Recent Chats & Terminals')
     expect(testContainer.textContent).toContain('Recent Worktrees')
   })
-
   it('keeps duplicate persisted tab ids as separate recent rows and digit targets', async () => {
     await renderPalette(makeDuplicateRecentTabState())
-
     expect(
       getRenderedRowIds().filter(
         (id) => id === 'workspace-tab:tab-duplicate' || id.includes(':workspace-tab:tab-duplicate')
       )
     ).toEqual(['workspace-tab:tab-duplicate', 'palette-dup:1:workspace-tab:tab-duplicate'])
-
     await act(async () => {
       emitCmdJRowIndexJump(1)
     })
     await flushEffects()
-
     expect(activateWorkspaceTabPaletteResult).toHaveBeenCalledWith(
       expect.objectContaining({ tabId: 'tab-duplicate', worktreeId: 'wt-beta' })
     )
   })
-
   it('caps the recent section so the worktree header stays above the fold', async () => {
     await renderPalette(makeManyTabState(12))
-
     expect(getTabRowIds()).toHaveLength(6)
     expect(testContainer.textContent).toContain('Recent Worktrees')
-    // Why: the worktree section shrinks against the recent rows so the list holds at 10 total —
-    // it must never uncap, not even for the frame before the order snapshot lands.
     expect(getWorktreeRows().length).toBeLessThanOrEqual(4)
   })
-
+  it('shows more recent chats and terminals from the empty-query view', async () => {
+    await renderPalette(makeManyTabState(12))
+    const seeMoreButton = Array.from(testContainer.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('See more')
+    )
+    expect(seeMoreButton).toBeDefined()
+    expect(testContainer.textContent).toContain('6 more')
+    await act(async () => {
+      seeMoreButton?.click()
+    })
+    await flushEffects()
+    expect(getTabRowIds()).toHaveLength(12)
+    expect(testContainer.textContent).not.toContain('6 more')
+  })
   it('backfills past the cap when rows drop out of the frozen order', async () => {
     await renderPalette(makeManyTabState(12))
     const before = getTabRowIds()
-
-    // Why: closing the whole first page stands in for any mid-open narrowing (a filter chip does the
-    // same thing) — the section must fall through to the next ranked rows, not render empty.
     await act(async () => {
       useAppStore.setState({
         unifiedTabsByWorktree: {
@@ -275,12 +250,10 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       } as Partial<AppState>)
     })
     await flushEffects()
-
     const after = getTabRowIds()
     expect(after).toHaveLength(6)
     expect(after.some((id) => before.includes(id))).toBe(false)
   })
-
   /** A tab whose title starts with the query, against worktrees that only match mid-name. */
   function makeTypedRelevanceState(): Partial<AppState> {
     const weak = makeWorktree('wt-weak', 'improve-agent-dashboard-performance')
@@ -301,62 +274,47 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       activeGroupIdByWorktree: { 'wt-host': 'group-wt-host' }
     }
   }
-
   it('leads a typed query with the tab section when it holds the stronger match', async () => {
     await renderPalette(makeTypedRelevanceState())
-
     await act(async () => {
       setCommandQuery?.('perf')
     })
     await flushEffects()
-
     const rows = getRenderedRowIds().filter((id) => id.length > 0)
     expect(rows[0]).toBe('workspace-tab:tab-host')
     expect(rows).toContain('worktree:wt-weak')
     expect(getCommandValue()).toBe('workspace-tab:tab-host')
   })
-
   it('selects the new first result when cmdk reports the deferred list selection', async () => {
     await renderPalette(makeTypedRelevanceState())
-
     await act(async () => {
       setCommandQuery?.('improve')
     })
     await flushEffects()
     expect(getCommandValue()).toBe('worktree:wt-weak')
-
     await act(async () => {
       setCommandQuery?.('perf')
       setCommandSelection?.('worktree:wt-weak')
     })
     await flushEffects()
-
     expect(getRenderedRowIds().find((id) => id.length > 0)).toBe('workspace-tab:tab-host')
     expect(getCommandValue()).toBe('workspace-tab:tab-host')
   })
-
-  // Why: after typing, arrow moves must stick. Dropping onValueChange while cmdk already
-  // advanced its internal cursor made the next ArrowDown a no-op (Object.is short-circuit).
   it('keeps arrow selection after the typed query ranking has committed', async () => {
     await renderPalette(makeTypedRelevanceState())
-
     await act(async () => {
       setCommandQuery?.('perf')
     })
     await flushEffects()
     expect(getCommandValue()).toBe('workspace-tab:tab-host')
-
     const rows = getRenderedRowIds().filter((id) => id.length > 0)
     expect(rows.length).toBeGreaterThan(1)
-
     await act(async () => {
       setCommandSelection?.(rows[1])
     })
     await flushEffects()
-
     expect(getCommandValue()).toBe(rows[1])
   })
-
   it('keeps worktrees ahead of tabs when a worktree holds the stronger match', async () => {
     await renderPalette({
       ...makeTypedRelevanceState(),
@@ -367,22 +325,17 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         ]
       }
     })
-
     await act(async () => {
       setCommandQuery?.('perf-d')
     })
     await flushEffects()
-
     const firstRow = getRenderedRowIds().find((id) => id.length > 0)
     expect(firstRow).toBe('worktree:wt-strong')
   })
-
   it('ranks a typed query by match position inside the worktree section', async () => {
     await renderPalette({
       worktreesByRepo: {
         'repo-1': [
-          // Why this order: smart sort keeps the input order here, so a promoted prefix hit can only
-          // come from relevance re-ranking.
           makeWorktree('wt-word-a', 'improve-agent-dashboard-performance'),
           makeWorktree('wt-word-b', 'rc-perf-update-channels'),
           makeWorktree('wt-prefix', 'perf-diff-tighten')
@@ -390,21 +343,16 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       },
       showSleepingWorkspaces: true
     })
-
     await act(async () => {
       setCommandQuery?.('perf')
     })
     await flushEffects()
-
-    // Why word-b beats word-a despite input order: `perf` is a whole word in
-    // `rc-perf-update-channels` but only a prefix of `performance`.
     expect(getRenderedRowIds().filter((id) => id.startsWith('worktree:'))).toEqual([
       'worktree:wt-prefix',
       'worktree:wt-word-b',
       'worktree:wt-word-a'
     ])
   })
-
   it('budget-caps the worktree section when nothing fills the recent one', async () => {
     await renderPalette({
       worktreesByRepo: {
@@ -414,14 +362,10 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       },
       showSleepingWorkspaces: true
     })
-
-    // Why this shape: a filter chip that drops every open tab lands here too, and uncapping used to
-    // mount one row per workspace.
     expect(getTabRowIds()).toEqual([])
     expect(getWorktreeRows()).toHaveLength(10)
     expect(testContainer.textContent).toContain('4 more')
   })
-
   it('captures the order when tabs hydrate after the palette is already open', async () => {
     const hydrated = makeRecentTabState()
     await renderPalette({
@@ -429,16 +373,13 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       tabsByWorktree: {},
       unifiedTabsByWorktree: {}
     })
-
     expect(getTabRowIds()).toEqual([])
-    // Why: cmdk claims the first row it sees, which before hydration is a worktree.
     const firstWorktreeId = getRenderedRowIds().find((id) => id.startsWith('worktree:'))
     expect(firstWorktreeId).toBeDefined()
     await act(async () => {
       setCommandSelection?.(firstWorktreeId ?? '')
     })
     await flushEffects()
-
     await act(async () => {
       useAppStore.setState({
         tabsByWorktree: hydrated.tabsByWorktree,
@@ -446,23 +387,17 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       } as Partial<AppState>)
     })
     await flushEffects()
-
     const [topRowId] = getTabRowIds()
     expect(getTabRowIds()).toHaveLength(2)
-    // Enter has to follow the rows up: ⌘1 already points at the first recent chat.
     expect(getCommandValue()).toBe(`workspace-tab:${topRowId}`)
-
-    // Why here: an empty snapshot also left the digit chords addressing nothing until reopen.
     await act(async () => {
       emitCmdJRowIndexJump(0)
     })
     await flushEffects()
-
     expect(activateWorkspaceTabPaletteResult).toHaveBeenCalledWith(
       expect.objectContaining({ tabId: topRowId })
     )
   })
-
   it('leaves a deliberately moved selection alone when recents land late', async () => {
     const hydrated = makeRecentTabState()
     await renderPalette({
@@ -470,16 +405,13 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       tabsByWorktree: {},
       unifiedTabsByWorktree: {}
     })
-
     const worktreeIds = getRenderedRowIds().filter((id) => id.startsWith('worktree:'))
     expect(worktreeIds.length).toBeGreaterThan(1)
-    // Why the second row: only a selection that differs from the auto-picked head proves the user moved it.
     const movedTo = worktreeIds[1]
     await act(async () => {
       setCommandSelection?.(movedTo)
     })
     await flushEffects()
-
     await act(async () => {
       useAppStore.setState({
         tabsByWorktree: hydrated.tabsByWorktree,
@@ -487,14 +419,10 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       } as Partial<AppState>)
     })
     await flushEffects()
-
     expect(getTabRowIds()).toHaveLength(2)
     expect(getCommandValue()).toBe(movedTo)
   })
-
   it('re-ranks once when terminal entities hydrate after unified tabs', async () => {
-    // Why split hydration: unified tabs can land before tabsByWorktree; without a re-capture every
-    // row ranks IDLE. A deliberate second-row highlight must survive that one re-rank.
     const hydrated = makeRecentTabState({
       agentStatusByPaneKey: {
         [makePaneKey('term-alpha', LEAF_ID)]: makeAgentEntry('term-alpha', 'blocked', Date.now())
@@ -515,10 +443,7 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     expect(getTabRowIds()).toEqual(['tab-alpha', 'tab-beta'])
     expect(getCommandValue()).toBe(movedTo)
   })
-
   it('admits a high-signal current tab whose terminal entity hydrates late', async () => {
-    // Why: with no tabsByWorktree entity the current tab's badge is unknowable, so membership is
-    // too — an attention-ready capture there would freeze it out of Recent for the whole open.
     const hydrated = makeRecentTabState({
       activeWorktreeId: 'wt-alpha',
       activeTabType: 'terminal',
@@ -531,15 +456,12 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     })
     await renderPalette({ ...hydrated, tabsByWorktree: {} })
     expect(getTabRowIds()).toEqual(['tab-beta'])
-
     await act(async () => {
       useAppStore.setState({ tabsByWorktree: hydrated.tabsByWorktree } as Partial<AppState>)
     })
     await flushEffects()
-
     expect(getTabRowIds()).toEqual(['tab-alpha', 'tab-beta'])
   })
-
   it('ranks a blocked agent above a more recently visited idle tab', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -549,19 +471,15 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         lastVisitedAtByWorktreeId: { 'wt-beta': Date.now() }
       })
     )
-
     expect(getTabRowIds()).toEqual(['tab-alpha', 'tab-beta'])
   })
-
   it('freezes the order captured on open while statuses keep changing', async () => {
     await renderPalette(
       makeRecentTabState({
         lastVisitedAtByWorktreeId: { 'wt-beta': Date.now() }
       })
     )
-
     expect(getTabRowIds()).toEqual(['tab-beta', 'tab-alpha'])
-
     await act(async () => {
       useAppStore.setState({
         agentStatusByPaneKey: {
@@ -570,20 +488,14 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       } as Partial<AppState>)
     })
     await flushEffects()
-
     expect(getTabRowIds()).toEqual(['tab-beta', 'tab-alpha'])
   })
-
   it('captures the unfiltered order when reopened after a search', async () => {
     await renderPalette(makeRecentTabState())
-
     await act(async () => {
       setCommandQuery?.('Alpha')
     })
     await flushEffects()
-
-    // Why closed-then-reopened: the palette stays mounted, and the open effect clears the query one
-    // commit after the snapshot effect — so a naive capture would freeze the Alpha-only subset.
     await act(async () => {
       useAppStore.setState({ activeModal: undefined } as Partial<AppState>)
     })
@@ -594,10 +506,8 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       } as Partial<AppState>)
     })
     await flushEffects()
-
     expect(getTabRowIds()).toHaveLength(2)
   })
-
   it('excludes the idle current tab from the recent section', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -608,10 +518,8 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         activeTabTypeByWorktree: { 'wt-alpha': 'terminal' }
       })
     )
-
     expect(getTabRowIds()).toEqual(['tab-beta'])
   })
-
   it('keeps the current tab in recent when its agent needs permission', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -626,13 +534,9 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         lastVisitedAtByWorktreeId: { 'wt-beta': Date.now() }
       })
     )
-
-    // Why: high-signal current tabs stay scannable (ask-question / permission badge) even though
-    // idle "where you are" rows are still dropped.
     expect(getTabRowIds()).toEqual(['tab-alpha', 'tab-beta'])
     expect(testContainer.textContent).toContain('Current Tab')
   })
-
   it('keeps the current tab in recent when its agent is working', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -646,10 +550,8 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         }
       })
     )
-
     expect(getTabRowIds()).toContain('tab-alpha')
   })
-
   it('keeps the current tab in recent when it has unread activity', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -661,10 +563,8 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         unreadTerminalTabs: { 'term-alpha': true }
       })
     )
-
     expect(getTabRowIds()).toContain('tab-alpha')
   })
-
   it.each([undefined, true])('excludes current terminal outcomes', async (interrupted) => {
     await renderPalette(
       makeRecentTabState({
@@ -680,12 +580,8 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         }
       })
     )
-
-    // Why: a completion you watched land needs no row — `done` outlives the unread auto-ack by the
-    // whole 30m staleness window, so the slot goes to a workspace off screen instead.
     expect(getTabRowIds()).toEqual(['tab-beta'])
   })
-
   it('still lists a non-current tab whose agent is done', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -694,11 +590,8 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         }
       })
     )
-
-    // Why: `done` only stops earning *entry* for the tab on screen — elsewhere it is still news.
     expect(getTabRowIds()).toContain('tab-alpha')
   })
-
   it('keeps the current tab in recent on a pane-only unread completion marker', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -707,15 +600,11 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         activeTabId: 'term-alpha',
         activeTabIdByWorktree: { 'wt-alpha': 'term-alpha' },
         activeTabTypeByWorktree: { 'wt-alpha': 'terminal' },
-        // Why pane-keyed only: the narrower marker (unacked completion in one pane) is its own
-        // inclusion input — unreadTerminalTabs stays empty here.
         unreadAgentCompletionPanes: { [makePaneKey('term-alpha', LEAF_ID)]: true }
       })
     )
-
     expect(getTabRowIds()).toContain('tab-alpha')
   })
-
   it('excludes the current editor tab — no agent ladder can lift it out of "you are here"', async () => {
     const fileId = '/repo/wt-alpha/notes.ts'
     const state = makeRecentTabState({
@@ -753,18 +642,14 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         'wt-alpha': [makeGroup('wt-alpha', ['tab-alpha-file', 'tab-alpha'])]
       }
     })
-
     expect(getTabRowIds()).not.toContain('tab-alpha-file')
     expect(getTabRowIds()).toContain('tab-alpha')
-
-    // Proves the exclusion is the current-tab rule, not a missing index entry: search still finds it.
     await act(async () => {
       setCommandQuery?.('notes')
     })
     await flushEffects()
     expect(getTabRowIds()).toContain('tab-alpha-file')
   })
-
   it('excludes an archived worktree tab even with a blocked agent', async () => {
     const alpha = makeWorktree('wt-alpha', 'Alpha workspace', { isArchived: true })
     const beta = makeWorktree('wt-beta', 'Beta workspace')
@@ -776,10 +661,8 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         }
       })
     )
-
     expect(getTabRowIds()).toEqual(['tab-beta'])
   })
-
   it('does not admit the current tab mid-open when it goes unread', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -790,19 +673,13 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         activeTabTypeByWorktree: { 'wt-alpha': 'terminal' }
       })
     )
-
     expect(getTabRowIds()).toEqual(['tab-beta'])
-
     await act(async () => {
       useAppStore.setState({ unreadTerminalTabs: { 'term-alpha': true } } as Partial<AppState>)
     })
     await flushEffects()
-
-    // Why frozen: membership shares the open-time snapshot with the row order, so a late arrival
-    // can't insert a row under the cursor and renumber ⌘1–6. It joins on the next open.
     expect(getTabRowIds()).toEqual(['tab-beta'])
   })
-
   it('keeps a frozen current row listed after it quiets mid-open', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -814,9 +691,7 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         unreadTerminalTabs: { 'term-alpha': true }
       })
     )
-
     expect(getTabRowIds()).toContain('tab-alpha')
-
     await act(async () => {
       useAppStore.setState({
         unreadTerminalTabs: {},
@@ -826,13 +701,10 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       } as Partial<AppState>)
     })
     await flushEffects()
-
-    // Why: a frozen row must retain its live badge while staying in its original slot.
     expect(getTabRowIds()).toContain('tab-alpha')
     expect(testContainer.textContent).toContain('Alpha chat')
     expect(document.querySelector('[data-slot=tooltip-trigger]')?.textContent).toContain('Working')
   })
-
   it('keeps a frozen current row listed when its agent finishes mid-open', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -846,9 +718,7 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         }
       })
     )
-
     expect(getTabRowIds()).toContain('tab-alpha')
-
     await act(async () => {
       useAppStore.setState({
         agentStatusByPaneKey: {
@@ -857,58 +727,44 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       } as Partial<AppState>)
     })
     await flushEffects()
-
-    // Why: completion changes the frozen row's badge without removing its reserved slot.
     expect(getTabRowIds()).toContain('tab-alpha')
     expect(document.querySelector('[data-slot=tooltip-trigger]')?.textContent).toContain('Done')
   })
-
   it('activates the row a digit chord addresses while open', async () => {
     await renderPalette(
       makeRecentTabState({
         lastVisitedAtByWorktreeId: { 'wt-beta': Date.now() }
       })
     )
-
     expect(getTabRowIds()).toEqual(['tab-beta', 'tab-alpha'])
-
     await act(async () => {
       emitCmdJRowIndexJump(1)
     })
     await flushEffects()
-
     expect(activateWorkspaceTabPaletteResult).toHaveBeenCalledWith(
       expect.objectContaining({ tabId: 'tab-alpha' })
     )
   })
-
   it('ignores a digit chord beyond the rendered recent rows', async () => {
     await renderPalette(makeRecentTabState())
-
     await act(async () => {
       emitCmdJRowIndexJump(8)
     })
     await flushEffects()
-
     expect(activateWorkspaceTabPaletteResult).not.toHaveBeenCalled()
   })
-
   it('stops routing digit chords once a query is typed', async () => {
     await renderPalette(makeRecentTabState())
-
     await act(async () => {
       setCommandQuery?.('Alpha')
     })
     await flushEffects()
-
     await act(async () => {
       emitCmdJRowIndexJump(0)
     })
     await flushEffects()
-
     expect(activateWorkspaceTabPaletteResult).not.toHaveBeenCalled()
   })
-
   it('keeps the agent badge on an Open Tabs row a query surfaced', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -917,8 +773,6 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         }
       })
     )
-
-    // Why: require the setter so this cannot silently exercise the empty-query section.
     const applyQuery = setCommandQuery
     if (!applyQuery) {
       throw new Error('CommandInput never installed a query setter')
@@ -927,8 +781,6 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       applyQuery('Alpha')
     })
     await flushEffects()
-
-    // Why: searching for a tab is exactly when its status matters — the pip must survive the query.
     expect(getTabRowIds()).toContain('tab-alpha')
     expect(getTabRowIds()).not.toContain('tab-beta')
     const alphaRow = testContainer.querySelector<HTMLElement>(
@@ -936,20 +788,16 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     )
     expect(alphaRow?.querySelector('[data-slot=tooltip-trigger]')?.textContent).toContain('Working')
   })
-
   it('keeps create-worktree below the matches it would otherwise outrank', async () => {
     await renderPalette(makeRecentTabState())
-
     await act(async () => {
       setCommandQuery?.('Alpha')
     })
     await flushEffects()
-
     const rows = getRenderedRowIds().filter((id) => id.length > 0)
     expect(rows.at(-1)).toBe('__create_worktree__')
     expect(rows.length).toBeGreaterThan(1)
   })
-
   it('labels a folder workspace row with its display name, not a branch', async () => {
     await renderPalette(
       makeRecentTabState({
@@ -964,7 +812,6 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         }
       })
     )
-
     expect(testContainer.textContent).toContain('Alpha workspace')
   })
 })

--- a/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
@@ -176,6 +176,20 @@ function getTabRowIds(): string[] {
     ...testContainer.querySelectorAll<HTMLElement>('[data-command-item^="workspace-tab:"]')
   ].map((node) => (node.dataset.commandItem ?? '').replace('workspace-tab:', ''))
 }
+function getTabRowShortcutDigits(): string[] {
+  return [
+    ...testContainer.querySelectorAll<HTMLElement>('[data-command-item^="workspace-tab:"]')
+  ].flatMap((row) =>
+    [...row.querySelectorAll<HTMLElement>('span')]
+      .map((node) => node.textContent ?? '')
+      .filter((text) => /^\d+$/.test(text))
+  )
+}
+function clickSeeMore(): void {
+  ;[...testContainer.querySelectorAll('button')]
+    .find((button) => button.textContent?.includes('See more'))
+    ?.click()
+}
 describe('WorktreeJumpPalette recent chats & terminals', () => {
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
@@ -236,6 +250,25 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     await flushEffects()
     expect(getTabRowIds()).toHaveLength(12)
     expect(testContainer.textContent).not.toContain('6 more')
+  })
+  it('reveals every recent row from a single expansion', async () => {
+    await renderPalette(makeManyTabState(30))
+    expect(getTabRowIds()).toHaveLength(6)
+    await act(async () => {
+      clickSeeMore()
+    })
+    await flushEffects()
+    expect(getTabRowIds()).toHaveLength(30)
+  })
+  it('stops badging expanded recent rows at the last addressable digit', async () => {
+    await renderPalette(makeManyTabState(12))
+    expect(getTabRowShortcutDigits()).toEqual(['1', '2', '3', '4', '5', '6'])
+    await act(async () => {
+      clickSeeMore()
+    })
+    await flushEffects()
+    expect(getTabRowIds()).toHaveLength(12)
+    expect(getTabRowShortcutDigits()).toEqual(['1', '2', '3', '4', '5', '6', '7', '8', '9'])
   })
   it('backfills past the cap when rows drop out of the frozen order', async () => {
     await renderPalette(makeManyTabState(12))
@@ -803,10 +836,7 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
       makeRecentTabState({
         worktreesByRepo: {
           'repo-1': [
-            makeWorktree('wt-alpha', 'Alpha workspace', {
-              isMainWorktree: true,
-              branch: ''
-            }),
+            makeWorktree('wt-alpha', 'Alpha workspace', { isMainWorktree: true, branch: '' }),
             makeWorktree('wt-beta', 'Beta workspace')
           ]
         }

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1637,9 +1637,7 @@ function WorktreeJumpPaletteContent({
     const itemByOccurrenceId = new Map(
       openTabRecentRows.map(({ occurrenceId, item }) => [occurrenceId, item])
     )
-    return recentTabOrder
-      .flatMap((occurrenceId) => itemByOccurrenceId.get(occurrenceId) ?? [])
-      .slice(0, EMPTY_QUERY_RECENT_TAB_CAP)
+    return recentTabOrder.flatMap((occurrenceId) => itemByOccurrenceId.get(occurrenceId) ?? [])
   }, [openTabRecentRows, recentTabOrder])
 
   const settingsResults = useMemo(
@@ -1892,9 +1890,10 @@ function WorktreeJumpPaletteContent({
 
   const paletteSections = useMemo(() => {
     const openTabsCap = PALETTE_SECTION_RENDER_CAP + (expandedSectionCaps['open-tabs'] ?? 0)
+    const recentTabsCap = EMPTY_QUERY_RECENT_TAB_CAP + (expandedSectionCaps['open-tabs'] ?? 0)
     const openTabs = hasQuery
       ? capPaletteSection(openTabItems, openTabsCap)
-      : { visible: recentTabItems, overflowCount: 0 }
+      : capPaletteSection(recentTabItems, recentTabsCap)
     // Why: the worktree section shrinks against the recent rows to hold the empty-query list at its
     // pre-existing 10, so RECENT WORKTREES stays above the fold. An empty recent section hands the
     // whole budget to worktrees but never uncaps — a filter chip or a tab-less session used to drop

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -339,6 +339,8 @@ type OpenTabPaletteItem = BrowserPaletteItem | SimulatorPaletteItem | WorkspaceT
 
 // Why: while the palette is open the workspace digit chord addresses recent rows, so it labels them.
 const DIGIT_INDEX_ACTION_ID = 'workspace.selectByIndex' as const
+// Why: the chord only binds keys 1–9, so expanded rows past the ninth are unaddressable.
+const DIGIT_INDEX_ADDRESSABLE_ROWS = 9
 // Why: this is also the ⌘N ceiling — any deeper and RECENT WORKTREES falls below the first screenful.
 const EMPTY_QUERY_RECENT_TAB_CAP = 6
 // Why: hold total empty-query rows at the pre-existing 10 so the worktree header stays above the fold.
@@ -1890,7 +1892,11 @@ function WorktreeJumpPaletteContent({
 
   const paletteSections = useMemo(() => {
     const openTabsCap = PALETTE_SECTION_RENDER_CAP + (expandedSectionCaps['open-tabs'] ?? 0)
-    const recentTabsCap = EMPTY_QUERY_RECENT_TAB_CAP + (expandedSectionCaps['open-tabs'] ?? 0)
+    // Why: "See more" drops the above-the-fold trim outright instead of stepping 20 at a time, so one
+    // click reveals the whole recent history the shared render cap allows.
+    const recentTabsCap = expandedSectionCaps['open-tabs']
+      ? openTabsCap
+      : EMPTY_QUERY_RECENT_TAB_CAP
     const openTabs = hasQuery
       ? capPaletteSection(openTabItems, openTabsCap)
       : capPaletteSection(recentTabItems, recentTabsCap)
@@ -1958,11 +1964,16 @@ function WorktreeJumpPaletteContent({
     openTabsLeadSections
   ])
 
-  // Why: badges number the snapshotted recent rows only — ⌘N is meaningless on a typed query.
+  // Why: badges number the snapshotted recent rows only — ⌘N is meaningless on a typed query, and an
+  // expanded section leaves its unaddressable rows unbadged rather than advertising ⌘10.
   const recentTabShortcutIndexByItem = useMemo(
     () =>
       new Map(
-        hasQuery ? [] : paletteSections.visibleOpenTabItems.map((item, index) => [item, index])
+        hasQuery
+          ? []
+          : paletteSections.visibleOpenTabItems
+              .slice(0, DIGIT_INDEX_ADDRESSABLE_ROWS)
+              .map((item, index) => [item, index])
       ),
     [hasQuery, paletteSections]
   )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​174 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​123 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## Problem

When the palette opens with no query, recent chats and terminals are capped at a fixed limit to keep the Recent Worktrees section visible above the fold. Users can't access their full recent tab history without typing a search query.

## Solution

Add a "See more" button that expands the recent tabs section to show additional items. The button displays the count of hidden tabs (e.g., "6 more"). Clicking it reveals the full list without a query.

## Changes

- Removed hardcoded `.slice()` cap from recentTabItems computation
- Added expandable cap logic for the empty-query case using `expandedSectionCaps['open-tabs']`
- Uses existing `capPaletteSection()` to render overflow button and count
- Added test verifying the expand button appears and functionality works correctly

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated for expand button behavior