### PR TITLE
Fix paste into server-streamed remote browser sessions

### DIFF
--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -299,6 +299,22 @@ describe('registerAppMenu', () => {
     expect(send).not.toHaveBeenCalled()
   })
 
+  it('pastes through a focused guest webview', () => {
+    const send = vi.fn()
+    const guestContents = { paste: vi.fn() }
+    getFocusedWindowMock.mockReturnValue({ webContents: { send } })
+    getFocusedWebContentsMock.mockReturnValue(guestContents)
+    registerAppMenu(buildMenuOptions())
+
+    const editSubmenu = getSubmenu(getTemplate(), 'Edit')
+    editSubmenu
+      .find((item) => item.label === 'Paste')
+      ?.click?.({} as never, {} as never, {} as never)
+
+    expect(guestContents.paste).toHaveBeenCalledOnce()
+    expect(send).not.toHaveBeenCalled()
+  })
+
   it.each(['darwin', 'linux', 'win32'] as const)(
     'routes Edit selection actions through the focused Orca window on %s',
     (platform) => {

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Menu, app } from 'electron'
+import { BrowserWindow, Menu, app, webContents } from 'electron'
 import {
   formatKeybindingList,
   getEffectiveKeybindingsForAction,
@@ -191,6 +191,11 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
           // control, so raw Electron paste cannot know which Orca surface owns it.
           const focusedWindow = BrowserWindow.getFocusedWindow()
           if (focusedWindow) {
+            const focusedContents = webContents.getFocusedWebContents()
+            if (focusedContents && focusedContents !== focusedWindow.webContents) {
+              focusedContents.paste()
+              return
+            }
             focusedWindow.webContents.send('ui:appMenuPaste')
             return
           }

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-pane.chrome-chords.test.tsx
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-pane.chrome-chords.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import type { BrowserPage } from '../../../../../shared/browser-workspace-types'
 import type { BrowserChromeShortcutScope } from '../describe-page/browser-page-types'
+import { APP_MENU_PASTE_EVENT } from '@/lib/app-menu-paste'
 import {
   REMOTE_BROWSER_STREAM_LIVE,
   type RemoteBrowserStreamStatus
@@ -12,16 +13,25 @@ import {
 // Everything the streamed pane wraps is inert here; this suite is about which chords the pane
 // answers itself instead of forwarding to the remote page as raw keystrokes.
 const mocks = vi.hoisted(() => ({
+  callRuntimeRpc: vi.fn(async () => ({})),
+  enqueueRemoteInput: vi.fn(),
   runRemoteNavigation: vi.fn(async () => {}),
   handleRemoteScreenshotKeyDown: vi.fn(),
   remoteError: { current: null as string | null },
   streamStatus: { current: null as RemoteBrowserStreamStatus | null },
-  viewportRenders: { current: 0 }
+  viewportRenders: { current: 0 },
+  runtimeTarget: {
+    current: { kind: 'environment' as const, environmentId: 'environment-a' }
+  },
+  getRuntimeTarget: vi.fn(),
+  createRemoteOperationToken: vi.fn(() => ({ pageId: 'page-a', generation: 1 })),
+  isCurrentRemoteOperationToken: vi.fn(() => true)
 }))
+mocks.getRuntimeTarget.mockImplementation(() => mocks.runtimeTarget.current)
 
 vi.mock('@/runtime/runtime-rpc-client', () => ({
   runtimeEnvironmentSupportsCapability: vi.fn(async () => false),
-  callRuntimeRpc: vi.fn(async () => ({}))
+  callRuntimeRpc: mocks.callRuntimeRpc
 }))
 vi.mock('@/lib/workspace-browser-tab-open', () => ({
   openWorkspaceBrowserTab: vi.fn(async () => {})
@@ -41,14 +51,14 @@ vi.mock('../annotate/useMarkupMode', () => ({
 }))
 vi.mock('./use-remote-browser-page-lifecycle', () => ({
   useRemoteBrowserPageLifecycle: () => ({
-    lifecycle: { session: {}, tokens: {} },
+    lifecycle: { session: {}, tokens: { remotePage: 'page-a' } },
     streamStatus: mocks.streamStatus.current ?? REMOTE_BROWSER_STREAM_LIVE,
     frameUrl: 'blob:frame',
     frameMetadata: null,
     runtimeWorktree: 'worktree-a',
-    runtimeTarget: () => null,
-    createRemoteOperationToken: () => null,
-    isCurrentRemoteOperationToken: () => false,
+    runtimeTarget: mocks.getRuntimeTarget,
+    createRemoteOperationToken: mocks.createRemoteOperationToken,
+    isCurrentRemoteOperationToken: mocks.isCurrentRemoteOperationToken,
     clearStreamFrame: vi.fn(),
     closeMissingRemotePage: vi.fn(),
     mountedRef: { current: true },
@@ -68,7 +78,7 @@ vi.mock('./use-remote-browser-page-stream', () => ({
 }))
 vi.mock('./use-remote-browser-page-input', () => ({
   useRemoteBrowserPageInputQueue: () => ({
-    enqueueRemoteInput: vi.fn(),
+    enqueueRemoteInput: mocks.enqueueRemoteInput,
     clearPendingRemoteWheel: vi.fn(),
     resetRemoteInputQueue: vi.fn(),
     pendingRemoteWheelRef: { current: null },
@@ -145,9 +155,16 @@ beforeEach(() => {
   mocks.remoteError.current = null
   mocks.streamStatus.current = null
   mocks.viewportRenders.current = 0
+  mocks.callRuntimeRpc.mockReset().mockResolvedValue({})
+  mocks.enqueueRemoteInput.mockReset().mockImplementation(async (operation) => operation())
   Object.defineProperty(window, 'api', {
     configurable: true,
-    value: { ui: { onFocusBrowserAddressBar: () => () => {} } }
+    value: {
+      ui: {
+        onFocusBrowserAddressBar: () => () => {},
+        readClipboardText: vi.fn(async () => 'text copied on the Mac')
+      }
+    }
   })
 })
 
@@ -176,6 +193,41 @@ afterEach(() => {
 })
 
 describe('streamed browser pane chrome chords', () => {
+  it('pastes the Mac clipboard into the focused remote page', async () => {
+    renderPane()
+    const frame = screen.getByTestId('frame')
+    frame.focus()
+
+    await act(async () => {
+      window.dispatchEvent(new Event(APP_MENU_PASTE_EVENT, { cancelable: true }))
+    })
+
+    expect(mocks.callRuntimeRpc).toHaveBeenCalledWith(
+      mocks.runtimeTarget.current,
+      'browser.keyboardInsertText',
+      { worktree: 'worktree-a', page: 'page-a', text: 'text copied on the Mac' },
+      { timeoutMs: 15_000, suppressFeatureInteraction: true }
+    )
+  })
+
+  it('pastes when Cmd+V arrives directly at the remote screenshot', async () => {
+    renderPane()
+    const frame = screen.getByTestId('frame')
+    frame.focus()
+
+    await act(async () => {
+      fireEvent.keyDown(frame, { key: 'v', code: 'KeyV', metaKey: true })
+    })
+
+    expect(mocks.callRuntimeRpc).toHaveBeenCalledWith(
+      mocks.runtimeTarget.current,
+      'browser.keyboardInsertText',
+      { worktree: 'worktree-a', page: 'page-a', text: 'text copied on the Mac' },
+      { timeoutMs: 15_000, suppressFeatureInteraction: true }
+    )
+    expect(mocks.handleRemoteScreenshotKeyDown).not.toHaveBeenCalled()
+  })
+
   it('reloads through the remote navigation action instead of forwarding the keystroke', () => {
     renderPane()
     act(() => {

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-pane.tsx
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-pane.tsx
@@ -29,6 +29,7 @@ import {
   useRemoteBrowserPageInputQueue
 } from './use-remote-browser-page-input'
 import { useRemoteBrowserPageChromeChords } from './use-remote-browser-page-chrome-chords'
+import { useRemoteBrowserPageClipboardPaste } from './use-remote-browser-page-clipboard-paste'
 import { useRemoteBrowserPageWheel } from './use-remote-browser-page-wheel'
 import {
   RemoteBrowserPageContextMenu,
@@ -217,10 +218,23 @@ export function RemoteBrowserPagePane({
     }
   }, [browserTab.id, navigateToUrl, stagedPage])
 
+  const pasteRemoteClipboard = useRemoteBrowserPageClipboardPaste({
+    busy,
+    imageRef,
+    runtimeTarget,
+    lifecycle,
+    runtimeWorktree,
+    enqueueRemoteInput,
+    createRemoteOperationToken,
+    isCurrentRemoteOperationToken,
+    setPaneNotice
+  })
+
   useRemoteBrowserPageChromeChords({
     chromeShortcutScope,
     workspaceId,
     runRemoteNavigation,
+    pasteRemoteClipboard,
     setPaneNotice
   })
 

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-chrome-chords.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-chrome-chords.ts
@@ -24,11 +24,13 @@ export function useRemoteBrowserPageChromeChords({
   chromeShortcutScope,
   workspaceId,
   runRemoteNavigation,
+  pasteRemoteClipboard,
   setPaneNotice
 }: {
   chromeShortcutScope: BrowserChromeShortcutScope
   workspaceId: string
   runRemoteNavigation: (method: 'browser.reload') => Promise<void> | void
+  pasteRemoteClipboard: (activeElementAtDispatch: Element | null) => boolean
   setPaneNotice: Dispatch<SetStateAction<RemoteBrowserPaneNotice | null>>
 }): void {
   const keybindings = useAppStore((state) => state.keybindings)
@@ -46,6 +48,19 @@ export function useRemoteBrowserPageChromeChords({
         chromeShortcutScope === 'owned-target' &&
         !browserOverlayOwnsShortcutTarget(event.target, workspaceId)
       ) {
+        return
+      }
+      const isPaste =
+        event.key.toLowerCase() === 'v' &&
+        !event.altKey &&
+        (shortcutPlatform === 'darwin'
+          ? event.metaKey && !event.ctrlKey
+          : event.ctrlKey && !event.metaKey)
+      if (isPaste && !isEditableKeyboardTarget(event.target)) {
+        if (pasteRemoteClipboard(event.target instanceof Element ? event.target : null)) {
+          event.preventDefault()
+          event.stopImmediatePropagation()
+        }
         return
       }
       // Why: Cmd+F should open find even from the address bar (Chrome/Safari do), but reload must
@@ -113,5 +128,12 @@ export function useRemoteBrowserPageChromeChords({
         findNoticeTimerRef.current = null
       }
     }
-  }, [chromeShortcutScope, keybindings, runRemoteNavigation, setPaneNotice, workspaceId])
+  }, [
+    chromeShortcutScope,
+    keybindings,
+    pasteRemoteClipboard,
+    runRemoteNavigation,
+    setPaneNotice,
+    workspaceId
+  ])
 }

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-clipboard-paste.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-clipboard-paste.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect } from 'react'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import { APP_MENU_PASTE_EVENT } from '@/lib/app-menu-paste'
+import { CLIPBOARD_TEXT_READ_MAX_BYTES } from '../../../../../shared/clipboard-text'
+import type {
+  RemoteBrowserPaneNotice,
+  RemoteBrowserRuntimeTarget
+} from './remote-browser-page-input-model'
+import type { RemoteBrowserStreamLifecycle } from './remote-browser-stream-lifecycle'
+import type { RemoteBrowserOperationToken } from './remote-browser-stream-tokens'
+
+export function useRemoteBrowserPageClipboardPaste({
+  busy,
+  imageRef,
+  runtimeTarget,
+  lifecycle,
+  runtimeWorktree,
+  enqueueRemoteInput,
+  createRemoteOperationToken,
+  isCurrentRemoteOperationToken,
+  setPaneNotice
+}: {
+  busy: boolean
+  imageRef: React.RefObject<HTMLImageElement | null>
+  runtimeTarget: () => RemoteBrowserRuntimeTarget | null
+  lifecycle: RemoteBrowserStreamLifecycle
+  runtimeWorktree: string
+  enqueueRemoteInput: (operation: () => Promise<void>) => Promise<void>
+  createRemoteOperationToken: (remotePageId?: string | null) => RemoteBrowserOperationToken | null
+  isCurrentRemoteOperationToken: (token: RemoteBrowserOperationToken) => boolean
+  setPaneNotice: React.Dispatch<React.SetStateAction<RemoteBrowserPaneNotice | null>>
+}): (activeElementAtDispatch: Element | null) => boolean {
+  const remotePageId = lifecycle.tokens.remotePage
+  const pasteRemoteClipboard = useCallback(
+    (activeElementAtDispatch: Element | null): boolean => {
+      if (
+        busy ||
+        activeElementAtDispatch === null ||
+        activeElementAtDispatch !== imageRef.current ||
+        document.activeElement !== activeElementAtDispatch
+      ) {
+        return false
+      }
+
+      const target = runtimeTarget()
+      const operationToken = remotePageId ? createRemoteOperationToken(remotePageId) : null
+      if (!target || !remotePageId || !operationToken) {
+        return false
+      }
+
+      setPaneNotice(null)
+      void enqueueRemoteInput(async () => {
+        if (!isCurrentRemoteOperationToken(operationToken)) {
+          return
+        }
+        try {
+          const text = await window.api.ui.readClipboardText({
+            maxBytes: CLIPBOARD_TEXT_READ_MAX_BYTES
+          })
+          if (!text || !isCurrentRemoteOperationToken(operationToken)) {
+            return
+          }
+          await callRuntimeRpc(
+            target,
+            'browser.keyboardInsertText',
+            { worktree: runtimeWorktree, page: remotePageId, text },
+            { timeoutMs: 15_000, suppressFeatureInteraction: true }
+          )
+        } catch (error) {
+          if (isCurrentRemoteOperationToken(operationToken)) {
+            setPaneNotice({
+              kind: 'consequence',
+              text: error instanceof Error ? error.message : 'Remote paste failed.'
+            })
+          }
+        }
+      })
+      return true
+    },
+    [
+      busy,
+      createRemoteOperationToken,
+      enqueueRemoteInput,
+      imageRef,
+      isCurrentRemoteOperationToken,
+      remotePageId,
+      runtimeTarget,
+      runtimeWorktree,
+      setPaneNotice
+    ]
+  )
+
+  useEffect(() => {
+    const handlePaste = (event: Event): void => {
+      if (!pasteRemoteClipboard(imageRef.current)) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+    }
+
+    window.addEventListener(APP_MENU_PASTE_EVENT, handlePaste)
+    return () => window.removeEventListener(APP_MENU_PASTE_EVENT, handlePaste)
+  }, [imageRef, pasteRemoteClipboard])
+
+  return pasteRemoteClipboard
+}


### PR DESCRIPTION
## Summary

- Fix Mac-to-remote paste for server-streamed browser pages, where the desktop renders a screenshot and native paste cannot reach the browser hosted on the paired remote server.
- Intercept Cmd+V on macOS and Ctrl+V on other platforms in the streamed page pane, read the local clipboard, and insert the text through the existing browser.keyboardInsertText RPC.
- Preserve native paste for This device client-hosted pages, local guest webviews, address-bar inputs, and other editable controls.

The working case is a client-hosted page rendered on this device with network traffic routed through the paired remote server. It already uses a native webview and is not the failing path. The failing case uses Server (streamed), where the browser page is hosted on the remote server and displayed as a stream. That path is covered by this change.

## Verification

- `pnpm test src/main/menu/register-app-menu.test.ts src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-pane.chrome-chords.test.tsx src/renderer/src/components/browser-pane/stream-remote/remote-browser-keyboard.test.ts src/main/browser/agent-browser-bridge-text-input.test.ts src/main/browser/browser-text-insertion.test.ts src/main/runtime/rpc/methods/browser.test.ts --run`
- `pnpm tc`
- `pnpm run check:code-quality:changed`

All checks pass. Manual validation requires the PR build. In the dev app, select Server (streamed), create a new remote browser tab, focus the streamed page, copy text on the Mac, and press Cmd+V.