### PR TITLE
fix(runtime): isolate paired terminal creates from host focus

### DIFF
--- a/src/main/runtime/multi-client-navigation-isolation.integration.test.ts
+++ b/src/main/runtime/multi-client-navigation-isolation.integration.test.ts
@@ -465,6 +465,43 @@ describe('paired runtime navigation isolation', () => {
     ).toBe('activateWorktree')
   })
 
+  it('normalizes a paired focused terminal.create before host-renderer activation', async () => {
+    const harness = await startHarness()
+    const created = { handle: 'term-b', worktreeId: CLIENT_B_WORKTREE_ID, title: null }
+    const createTerminal = vi
+      .spyOn(harness.runtime, 'createTerminal')
+      .mockImplementation(async (_worktree, options) => {
+        if (options?.presentation === 'focused') {
+          harness.hostSelections.worktreeId = CLIENT_B_WORKTREE_ID
+        }
+        return created as never
+      })
+    vi.spyOn(harness.runtime, 'dedupeTerminalCreate').mockImplementation(
+      async (_owner, worktree, _mutationId, _reconcile, run) => run(worktree, undefined)
+    )
+
+    send(harness.clientB, {
+      id: 'terminal-create-b',
+      method: 'terminal.create',
+      params: {
+        worktree: `id:${CLIENT_B_WORKTREE_ID}`,
+        presentation: 'focused'
+      }
+    })
+    await expect(harness.readerB.next('terminal-create-b')).resolves.toMatchObject({
+      ok: true,
+      result: { terminal: created }
+    })
+    expect(createTerminal).toHaveBeenCalledWith(
+      `id:${CLIENT_B_WORKTREE_ID}`,
+      expect.objectContaining({ presentation: 'background', focus: false, activate: false })
+    )
+    expect(harness.hostSelections).toEqual({
+      worktreeId: HOST_WORKTREE_ID,
+      tabId: 'host-tab'
+    })
+  })
+
   it('still reveals a host-originated create-with-activate on the host and every client', async () => {
     const harness = await startHarness()
     await subscribeBothClientEventStreams(harness)

--- a/src/main/runtime/rpc/methods/terminal-create-idempotency.test.ts
+++ b/src/main/runtime/rpc/methods/terminal-create-idempotency.test.ts
@@ -60,4 +60,76 @@ describe('terminal.create RPC idempotency', () => {
     )
     expect(result).toEqual({ terminal })
   })
+
+  it('does not let a paired focused create navigate the host by default', async () => {
+    const terminal = { handle: 'terminal-focused', worktreeId: 'worktree-1', title: null }
+    const createTerminal = vi.fn(async () => terminal)
+    const dedupeTerminalCreate = vi.fn(
+      async (
+        _clientIdentity: string,
+        _worktree: string | undefined,
+        _mutationId: string | undefined,
+        _reconcileExisting: boolean,
+        run: (worktree: string | undefined, handle: string | undefined) => Promise<typeof terminal>
+      ) => run('id:worktree-1', undefined)
+    )
+    const method = TERMINAL_METHODS.find((candidate) => candidate.name === 'terminal.create')
+    if (!method) {
+      throw new Error('terminal.create method missing')
+    }
+
+    await method.handler(
+      {
+        worktree: 'id:worktree-1',
+        presentation: 'focused',
+        focus: true,
+        activate: true
+      },
+      {
+        runtime: { createTerminal, dedupeTerminalCreate },
+        pairedDeviceId: 'device-b',
+        clientKind: 'runtime'
+      } as unknown as RpcContext,
+      vi.fn()
+    )
+
+    expect(createTerminal).toHaveBeenCalledWith(
+      'id:worktree-1',
+      expect.objectContaining({
+        presentation: 'background',
+        focus: false,
+        activate: false
+      })
+    )
+  })
+
+  it('preserves focus for an in-process caller', async () => {
+    const createTerminal = vi.fn(async () => ({ handle: 'terminal-host' }))
+    const dedupeTerminalCreate = vi.fn(
+      async (
+        _owner: string,
+        _worktree: string | undefined,
+        _mutationId: string | undefined,
+        _reconcile: boolean,
+        run: (worktree: string | undefined, handle: string | undefined) => Promise<unknown>
+      ) => run('id:worktree-1', undefined)
+    )
+    const method = TERMINAL_METHODS.find((candidate) => candidate.name === 'terminal.create')
+    if (!method) {
+      throw new Error('terminal.create method missing')
+    }
+
+    await method.handler(
+      { worktree: 'id:worktree-1', presentation: 'focused', focus: true, activate: true },
+      {
+        runtime: { createTerminal, dedupeTerminalCreate }
+      } as unknown as RpcContext,
+      vi.fn()
+    )
+
+    expect(createTerminal).toHaveBeenCalledWith(
+      'id:worktree-1',
+      expect.objectContaining({ presentation: 'focused', focus: true, activate: true })
+    )
+  })
 })

--- a/src/main/runtime/rpc/methods/terminal/terminal-lifecycle-methods.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-lifecycle-methods.ts
@@ -33,38 +33,49 @@ export const TERMINAL_LIFECYCLE_METHODS: RpcAnyMethod[] = [
   defineMethod({
     name: 'terminal.create',
     params: TerminalCreateParams,
-    handler: async (params, { runtime, pairedDeviceId, clientId }) => ({
-      terminal: await runtime.dedupeTerminalCreate(
-        pairedDeviceId ?? clientId ?? 'local',
-        params.worktree,
-        params.clientMutationId,
-        params.reconcileExisting === true,
-        (canonicalWorktreeSelector, preAllocatedHandle) =>
-          runtime.createTerminal(canonicalWorktreeSelector, {
-            command: params.command,
-            startupCommandDelivery: params.startupCommandDelivery,
-            env: params.env,
-            envToDelete: params.envToDelete,
-            ...(params.launchConfig ? { launchConfig: params.launchConfig } : {}),
-            ...(params.resumeProviderSession
-              ? { resumeProviderSession: params.resumeProviderSession }
-              : {}),
-            ...(params.launchToken ? { launchToken: params.launchToken } : {}),
-            ...(params.launchAgent ? { launchAgent: params.launchAgent } : {}),
-            ...(params.terminalColorQueryReplies
-              ? { terminalColorQueryReplies: params.terminalColorQueryReplies }
-              : {}),
-            title: params.title,
-            focus: params.focus === true,
-            rendererBacked: params.rendererBacked === true,
-            activate: params.activate === true,
-            presentation: params.presentation,
-            tabId: params.tabId,
-            leafId: params.leafId,
-            ...(preAllocatedHandle ? { preAllocatedHandle } : {})
-          })
-      )
-    })
+    handler: async (params, { runtime, pairedDeviceId, clientId, clientKind }) => {
+      // A focused terminal create predates paired-client navigation. Keep the
+      // authority boundary here so a remote caller cannot activate the host
+      // renderer. This legacy RPC remains a background create for paired viewers;
+      // caller-local selection belongs to the session-tab RPC flow.
+      const pairedViewer = clientKind !== undefined
+      const focus = pairedViewer ? false : params.focus === true
+      const activate = pairedViewer ? false : params.activate === true
+      const presentation =
+        pairedViewer && params.presentation === 'focused' ? 'background' : params.presentation
+      return {
+        terminal: await runtime.dedupeTerminalCreate(
+          pairedDeviceId ?? clientId ?? 'local',
+          params.worktree,
+          params.clientMutationId,
+          params.reconcileExisting === true,
+          (canonicalWorktreeSelector, preAllocatedHandle) =>
+            runtime.createTerminal(canonicalWorktreeSelector, {
+              command: params.command,
+              startupCommandDelivery: params.startupCommandDelivery,
+              env: params.env,
+              envToDelete: params.envToDelete,
+              ...(params.launchConfig ? { launchConfig: params.launchConfig } : {}),
+              ...(params.resumeProviderSession
+                ? { resumeProviderSession: params.resumeProviderSession }
+                : {}),
+              ...(params.launchToken ? { launchToken: params.launchToken } : {}),
+              ...(params.launchAgent ? { launchAgent: params.launchAgent } : {}),
+              ...(params.terminalColorQueryReplies
+                ? { terminalColorQueryReplies: params.terminalColorQueryReplies }
+                : {}),
+              title: params.title,
+              focus,
+              rendererBacked: params.rendererBacked === true,
+              activate,
+              presentation,
+              tabId: params.tabId,
+              leafId: params.leafId,
+              ...(preAllocatedHandle ? { preAllocatedHandle } : {})
+            })
+        )
+      }
+    }
   }),
   defineMethod({
     name: 'terminal.split',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​32 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## Summary

A paired client could send a focused `terminal.create` request and activate the host renderer, causing another connected client to jump workspaces/tabs and observe the wrong live terminal. This change enforces the isolation invariant at the runtime RPC authority boundary:

> Actions from client B must not change client A active workspace, tab, or focus unless A explicitly requested or accepted shared-control/navigation.

## Concrete reproduction

On a second client connected to the same remote host, run:

~~~sh
orca terminal create \
  --pairing-code <remote-pairing-code> \
  --worktree id:<repo>::<workspace> \
  --command codex \
  --focus
~~~

The CLI maps `--focus` to `focus: true` and `presentation: "focused"`. Before this change, the paired `terminal.create` handler forwarded those values to `runtime.createTerminal`; a host renderer could then reveal and activate the remote workspace globally.

## Root cause

The legacy `terminal.create` RPC had no caller-local selection or fan-out target. It accepted activation flags from paired clients as if they were host-originated, so renderer activation escaped the requesting client.

## Fix

For `runtime` and `mobile` callers, the handler now forces `focus: false`, `activate: false`, and converts `presentation: "focused"` to `"background"`. In-process host calls preserve existing focus behavior. Explicit caller-local navigation remains in the session-tab RPC flow, which carries the appropriate selection authority.

This keeps the guard at the source where activation is authorized rather than scattering client-side checks across event handlers.

## Verification

- Deterministic two-viewer isolation integration test: 12/12
- Focused terminal RPC and manifest tests: 8/8
- `pnpm tc`
- `pnpm run check:code-quality:changed`
- pre-commit oxlint, React doctor lint, and oxfmt
- `git diff --check`
- Independent boundary, race-safety, and test-quality reviews by three gpt-5.6-sol agents

The regression oracle simulates host renderer activation if focused options reach the runtime and asserts that client B request normalization leaves host selection unchanged.

## Scope and remaining gaps

- This intentionally makes legacy paired `terminal.create --focus` background-only; that RPC has no safe caller-local selection ID.
- No live headed renderer/PTY paired E2E was added; the deterministic runtime oracle covers the authority boundary.
- Nested agent CLI provenance is still not persisted as terminal-handle to paired-device identity, so this does not solve every possible agent-origin attribution path.
- Browser `browser.tabCreate` and `browser.tabSwitch` focus paths remain separate follow-up areas.
- An older host cannot enforce this behavior against a newer client until the host is upgraded.
