### PR TITLE
fix(packaging): ship agent-browser skill catalog

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -72,6 +72,17 @@ const skillFreshnessResources = {
   from: 'resources/skills',
   to: 'skills'
 }
+// Why: agent-browser resolves its version-matched skill catalog beside the binary.
+const agentBrowserSkillResources = [
+  {
+    from: 'node_modules/agent-browser/skills/agent-browser',
+    to: 'skills/agent-browser'
+  },
+  {
+    from: 'node_modules/agent-browser/skill-data',
+    to: 'skill-data'
+  }
+]
 // Why: SSH relay deploy resolves bundles from process.resourcesPath in packaged
 // apps. Keeping relay assets as extraResources makes them real directories
 // instead of paths hidden inside app.asar.
@@ -89,7 +100,12 @@ const bundledPluginResources = {
 // from package directories where pnpm's symlink farm is absent. Copy the exact
 // runtime dependency closure to Resources/node_modules so bare require() calls
 // do not fall through to a developer checkout's node_modules.
-const commonExtraResources = [relayExtraResource, bundledPluginResources, skillFreshnessResources]
+const commonExtraResources = [
+  relayExtraResource,
+  bundledPluginResources,
+  skillFreshnessResources,
+  ...agentBrowserSkillResources
+]
 // Why: native speech addons must be real files outside app.asar; copy only the
 // package matching the artifact target instead of every optional variant.
 const macSpeechNativeResource = {

--- a/config/scripts/build-orcad.mjs
+++ b/config/scripts/build-orcad.mjs
@@ -13,6 +13,7 @@ import { createHash } from 'node:crypto'
 import {
   chmodSync,
   copyFileSync,
+  cpSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -44,8 +45,25 @@ const DAEMON_ENTRY = join(ROOT, 'src/main/daemon/daemon-entry.ts')
 const DAEMON_OUT_FILE = join(OUT_DIR, 'daemon-entry.js')
 const AGENT_BROWSER_NAME = `agent-browser-${platform()}-${arch()}${process.platform === 'win32' ? '.exe' : ''}`
 const OUT_FILE = join(OUT_DIR, 'orcad.js')
-const AGENT_BROWSER_SOURCE = join(ROOT, 'node_modules', 'agent-browser', 'bin', AGENT_BROWSER_NAME)
+const AGENT_BROWSER_PACKAGE = join(ROOT, 'node_modules', 'agent-browser')
+const AGENT_BROWSER_SOURCE = join(AGENT_BROWSER_PACKAGE, 'bin', AGENT_BROWSER_NAME)
 const AGENT_BROWSER_OUTPUT = join(OUT_DIR, AGENT_BROWSER_NAME)
+// Why beside the binary, and why both: agent-browser resolves its version-matched skill
+// catalog from `<binary dir>/skills`, and only reads `<binary dir>/skill-data` when that
+// sibling `skills/` directory anchors it — probed against 0.27.0, where skill-data alone
+// answers `skills get core` with "Skills directory not found". electron-builder ships this
+// exact pair as extraResources; copying the binary here without it is what left a deployed
+// orcad reporting no skills at all.
+const AGENT_BROWSER_SKILL_PAYLOADS = [
+  {
+    from: join(AGENT_BROWSER_PACKAGE, 'skills', 'agent-browser'),
+    to: join(OUT_DIR, 'skills', 'agent-browser')
+  },
+  {
+    from: join(AGENT_BROWSER_PACKAGE, 'skill-data'),
+    to: join(OUT_DIR, 'skill-data')
+  }
+]
 
 // Native addons must exist on the host; they cannot be bundled.
 // `electron` is external so a residual import fails loudly at require() time rather
@@ -82,6 +100,11 @@ mkdirSync(OUT_DIR, { recursive: true })
 copyFileSync(AGENT_BROWSER_SOURCE, AGENT_BROWSER_OUTPUT)
 if (process.platform !== 'win32') {
   chmodSync(AGENT_BROWSER_OUTPUT, 0o755)
+}
+// Why dereference: the deploy's SFTP walk skips symlinks outright, so a linked payload
+// would land on the host as an empty directory and read as no catalog at all.
+for (const payload of AGENT_BROWSER_SKILL_PAYLOADS) {
+  cpSync(payload.from, payload.to, { recursive: true, dereference: true })
 }
 
 /** Why one call per child and not one `outdir` build: esbuild mirrors each entry's source

--- a/config/scripts/build-orcad.mjs
+++ b/config/scripts/build-orcad.mjs
@@ -101,8 +101,8 @@ copyFileSync(AGENT_BROWSER_SOURCE, AGENT_BROWSER_OUTPUT)
 if (process.platform !== 'win32') {
   chmodSync(AGENT_BROWSER_OUTPUT, 0o755)
 }
-// Why dereference: the deploy's SFTP walk skips symlinks outright, so a linked payload
-// would land on the host as an empty directory and read as no catalog at all.
+// Why dereference: the payload has no symlinks today, but the deploy's SFTP walk skips
+// symlinked entries outright, so this guards against a future pnpm layout shipping empty.
 for (const payload of AGENT_BROWSER_SKILL_PAYLOADS) {
   cpSync(payload.from, payload.to, { recursive: true, dereference: true })
 }
@@ -268,6 +268,9 @@ if (graphErrors.length > 0) {
 // this string, so two different builds carrying one version would share a directory — and an
 // already-`.install-complete` dir is never re-uploaded. The deploy would silently run stale
 // bytes while reporting the new version.
+// Note: the skill payload isn't hashed in — ORCAD_ARTIFACTS entries are read individually
+// as files, so a directory can't join the list. orcad.js changes almost every release, which
+// keeps fullVersion moving and re-triggers the upload in practice.
 if (process.exitCode !== 1) {
   const hash = createHash('sha256')
   for (const filename of orcadArtifactFilenames()) {

--- a/config/scripts/build-orcad.test.mjs
+++ b/config/scripts/build-orcad.test.mjs
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..')
+const require = createRequire(import.meta.url)
+const electronBuilderConfig = require('../electron-builder.config.cjs')
+const buildOrcadSource = readFileSync(
+  join(REPO_ROOT, 'config', 'scripts', 'build-orcad.mjs'),
+  'utf8'
+)
+
+const AGENT_BROWSER_PREFIX = 'node_modules/agent-browser/'
+
+/**
+ * The package-relative skill directories the desktop bundle ships beside the binary.
+ * `bin/` is excluded because that entry is the binary, which build-orcad already copies.
+ */
+function desktopAgentBrowserSkillDirs() {
+  return electronBuilderConfig.mac.extraResources
+    .filter(
+      (resource) =>
+        typeof resource?.from === 'string' &&
+        resource.from.startsWith(AGENT_BROWSER_PREFIX) &&
+        !resource.from.startsWith(`${AGENT_BROWSER_PREFIX}bin/`)
+    )
+    .map((resource) => resource.from.slice(AGENT_BROWSER_PREFIX.length))
+}
+
+/**
+ * orcad copies the same agent-browser binary the desktop app bundles, so it inherits the
+ * same resolution rule: the catalog has to sit beside the binary or `agent-browser skills
+ * get core` answers with nothing. Asserted against build-orcad.mjs's source because the
+ * script is a side-effecting build — the same shape as the relay-bundle coverage in
+ * client-hosted-browser-package-coverage.test.mjs.
+ */
+describe('build-orcad agent-browser skill catalog', () => {
+  it('copies into out/orcad the same catalog the desktop bundle ships', () => {
+    // Derived from the desktop list rather than restated, so a rename upstream cannot fix
+    // one packaging path and silently leave the other shipping a directory that is gone.
+    const skillDirs = desktopAgentBrowserSkillDirs()
+    expect(skillDirs).toEqual(['skills/agent-browser', 'skill-data'])
+    for (const dir of skillDirs) {
+      const segments = dir
+        .split('/')
+        .map((segment) => `'${segment}'`)
+        .join(', ')
+      expect(buildOrcadSource).toContain(`join(AGENT_BROWSER_PACKAGE, ${segments})`)
+      expect(buildOrcadSource).toContain(`join(OUT_DIR, ${segments})`)
+    }
+  })
+
+  it('anchors skill-data with the sibling skills directory it needs', () => {
+    // Probed against agent-browser 0.27.0: `<binary dir>/skill-data` on its own answers
+    // "Skills directory not found", and is only read once `<binary dir>/skills` exists.
+    // Shipping skill-data alone would look like a complete catalog and resolve nothing.
+    expect(buildOrcadSource).toContain("join(OUT_DIR, 'skills', 'agent-browser')")
+    expect(buildOrcadSource).toContain("join(OUT_DIR, 'skill-data')")
+  })
+
+  it('copies the catalog as real files rather than links', () => {
+    // The orcad deploy uploads out/orcad over SFTP and that walk skips symlinks outright,
+    // so a linked tree would land on the host as an empty directory.
+    expect(buildOrcadSource).toContain('recursive: true, dereference: true')
+  })
+})

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -118,12 +118,22 @@ describe('electron-builder config', () => {
       to: 'plugins/launch'
     })
     for (const platform of ['mac', 'linux', 'win']) {
-      expect(electronBuilderConfig[platform].extraResources).toContainEqual({
-        from: 'resources/skills',
-        to: 'skills'
-      })
       expect(electronBuilderConfig[platform].extraResources).toEqual(
-        expect.arrayContaining([bundledPluginResources])
+        expect.arrayContaining([
+          {
+            from: 'resources/skills',
+            to: 'skills'
+          },
+          {
+            from: 'node_modules/agent-browser/skills/agent-browser',
+            to: 'skills/agent-browser'
+          },
+          {
+            from: 'node_modules/agent-browser/skill-data',
+            to: 'skill-data'
+          },
+          bundledPluginResources
+        ])
       )
     }
     expect(electronBuilderConfig.mac.extraResources).toEqual(


### PR DESCRIPTION
## ELI5

The browser-automation helper we ship keeps its instruction manual in a folder next to
itself. We were shipping the helper but leaving the manual behind, so it kept answering
"I have no skills". This puts the manual next to the helper — in **both** places we copy
it: the desktop app and the headless `orcad` daemon.

## What Changed

Desktop bundle (`config/electron-builder.config.cjs`):

- ship `node_modules/agent-browser/skills/agent-browser` as `Resources/skills/agent-browser`
- ship `node_modules/agent-browser/skill-data` as `Resources/skill-data`
- both land beside the already-bundled `Resources/agent-browser-<platform>-<arch>` binary

Headless daemon (`config/scripts/build-orcad.mjs`):

- copy the same two directories into `out/orcad`, beside the agent-browser binary the
  script already copies there
- copy with `dereference: true`: the payload has no symlinks today, but the orcad deploy's
  SFTP walk skips symlinked entries, so this guards against a future pnpm layout shipping
  an empty directory

## Why

agent-browser resolves its version-matched catalog in this order:

1. `AGENT_BROWSER_SKILLS_DIR`
2. `<binary dir>/../skills`
3. `<binary dir>/skills`
4. `<binary dir>/skill-data`

Both packaging paths copy the binary and nothing else, so rules 2–4 all missed and
`agent-browser skills get core` answered "No skills found". Rule 4 has a subtlety worth
recording: `skill-data` on its own reports "Skills directory not found" — it is only read
once a sibling `skills/` directory anchors it. That is why both directories are shipped
rather than `skill-data` alone.

The first commit fixed only the Electron bundle. `build-orcad.mjs` copies the same binary
into `out/orcad`, which is what gets uploaded to a VPS, so a deployed daemon was still
skill-less. The second commit closes that half, which is what makes "Closes #17705"
honest.

The binary's own location is unchanged in both paths — `Contents/Resources/agent-browser-darwin-arm64`
is load-bearing and the issue's repro depends on it.

## Linked Issue

Closes #17705

## Visual Proof

`N/A` — packaging-only change with no UI surface. The observable difference is CLI output,
included under Testing.

## Testing

Empirical, against the real `agent-browser@0.27.0` binary. Staged the exact layout each
packaging path produces in a temp directory and ran the CLI:

```
# binary alone (what shipped before this PR)
$ ./agent-browser-linux-x64 skills get core
✗ Skills directory not found. Set AGENT_BROWSER_SKILLS_DIR or reinstall via npm.

# binary + skill-data, no skills/ anchor
$ ./agent-browser-linux-x64 skills get core
✗ Skills directory not found. Set AGENT_BROWSER_SKILLS_DIR or reinstall via npm.

# the layout this PR ships (binary + skills/agent-browser + skill-data)
$ ./agent-browser-linux-x64 skills get core
---
name: core
description: Core agent-browser usage guide. ...
$ ./agent-browser-linux-x64 skills list
  agentcore  core  dogfood  electron  slack  vercel-sandbox
```

The orcad half was staged from the real `node_modules/agent-browser` using the same
`cpSync` calls `build-orcad.mjs` now makes, so pnpm's actual on-disk layout (a symlinked
package root over hardlinked file contents) is exercised rather than a hand-built fixture.
Verified independently that the skill payload itself contains zero symlinks — `dereference:
true` is defensive, not load-bearing.

Automated:

- `vitest run --config config/vitest.config.ts config/scripts/electron-builder-config.test.mjs` (37 passed)
- `vitest run --config config/vitest.config.ts config/scripts/build-orcad.test.mjs` (3 passed; all 3 fail when the `build-orcad.mjs` change is reverted)
- `oxfmt --check` and `oxlint --deny-warnings` (default + `config/oxlint-code-quality-native-plugins.json`) on the changed files
- `node config/scripts/check-reliability-gates.mjs`, `node config/scripts/check-max-lines-ratchet.mjs`

Platforms: verified on Linux. The desktop mappings are platform-neutral `extraResources`
entries asserted for mac/win/linux by the existing test; the orcad copy is
platform-neutral `cpSync`.

`build-orcad.test.mjs` derives its expected directory list from the desktop
`extraResources` rather than restating it, so an upstream rename cannot fix one packaging
path and silently leave the other shipping a directory that no longer exists.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude (Opus 5).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: only adds package-owned data directories to artifacts we already ship; no new
  execution surface.
- Cross-platform: both changes are platform-neutral.
- Remote SSH: the orcad half is specifically the SSH/VPS deploy path. The skill payload
  has no symlinks today, but `dereference: true` is kept as a defensive guard since
  `uploadDirectory` skips symlinked entries.
- Backwards compatibility: additive only. The agent-browser binary stays exactly where it
  was in both layouts.
- Performance: adds ~228 KB of markdown to each artifact.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

