### PR TITLE
test(cursor): widen Windows hook spawn budget to fix ETIMEDOUT flake

### DIFF
--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -25,6 +25,14 @@ const CURSOR_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'cursor-hook.cmd'
 const WINDOWS_POWERSHELL_LAUNCHER =
   /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
+// Why: on Windows one hook run is cmd.exe -> powershell.exe -> cursor-hook.cmd -> curl.exe.
+// PowerShell CLR startup alone costs ~300ms warm and seconds cold on a loaded runner, so match
+// WINDOWS_PROCESS_TEST_TIMEOUT_MS (30s), this repo's budget for a real Windows process spawn.
+const HOOK_RUN_TIMEOUT_MS = 30_000
+// Why: these cases run up to 16 of those chains back to back; stay well above HOOK_RUN_TIMEOUT_MS
+// so a stuck spawn reports ETIMEDOUT (which names the process) before the case times out.
+const HOOK_CASE_TIMEOUT_MS = 120_000
+
 type InstalledCursorHooks = {
   hooks: Record<string, { command?: string }[]>
 }
@@ -65,7 +73,7 @@ function runRegisteredCursorHook(
   const result = spawnSync(executable, args, {
     encoding: 'utf8',
     input,
-    timeout: 15_000,
+    timeout: HOOK_RUN_TIMEOUT_MS,
     env: {
       ...process.env,
       ORCA_AGENT_HOOK_ENDPOINT: '',
@@ -205,64 +213,76 @@ describe('CursorHookService', () => {
 
   // Why: installer-intent assertions missed empty stdout, which Cursor treats as
   // invalid JSON and fails closed (#15462). This runs the registered command.
-  it('emits protocol-valid JSON on stdout for every managed event, including empty stdin (#15462)', () => {
-    expect(new CursorHookService().install().state).toBe('installed')
-    const config = readInstalledCursorHooks(homeDir)
-    const payloads = [
-      (eventName: string) => JSON.stringify({ hook_event_name: eventName, tool_name: 'Write' }),
-      () => ''
-    ]
+  it(
+    'emits protocol-valid JSON on stdout for every managed event, including empty stdin (#15462)',
+    () => {
+      expect(new CursorHookService().install().state).toBe('installed')
+      const config = readInstalledCursorHooks(homeDir)
+      const payloads = [
+        (eventName: string) => JSON.stringify({ hook_event_name: eventName, tool_name: 'Write' }),
+        () => ''
+      ]
 
-    for (const eventName of CURSOR_EVENTS) {
-      const command = requireRegisteredCommand(config, eventName)
-      for (const payloadFor of payloads) {
-        const result = runRegisteredCursorHook(command, payloadFor(eventName))
-        expect(result.status, `${eventName} exit`).toBe(0)
-        expect(result.stderr, `${eventName} stderr`).toBe('')
-        expect(JSON.parse(result.stdout), `${eventName} stdout`).toEqual(
+      for (const eventName of CURSOR_EVENTS) {
+        const command = requireRegisteredCommand(config, eventName)
+        for (const payloadFor of payloads) {
+          const result = runRegisteredCursorHook(command, payloadFor(eventName))
+          expect(result.status, `${eventName} exit`).toBe(0)
+          expect(result.stderr, `${eventName} stderr`).toBe('')
+          expect(JSON.parse(result.stdout), `${eventName} stdout`).toEqual(
+            EXPECTED_CURSOR_HOOK_STDOUT[eventName]
+          )
+        }
+      }
+    },
+    HOOK_CASE_TIMEOUT_MS
+  )
+
+  it(
+    'emits protocol-valid JSON when the managed Cursor script is missing (#15462)',
+    () => {
+      expect(new CursorHookService().install().state).toBe('installed')
+      const config = readInstalledCursorHooks(homeDir)
+      unlinkSync(join(homeDir, '.orca', 'agent-hooks', CURSOR_SCRIPT_FILE_NAME))
+
+      for (const eventName of CURSOR_EVENTS) {
+        const command = requireRegisteredCommand(config, eventName)
+        const result = runRegisteredCursorHook(command, '')
+        expect(result.status, `${eventName} missing-script exit`).toBe(0)
+        expect(result.stderr, `${eventName} missing-script stderr`).toBe('')
+        expect(JSON.parse(result.stdout), `${eventName} missing-script stdout`).toEqual(
           EXPECTED_CURSOR_HOOK_STDOUT[eventName]
         )
       }
-    }
-  })
+    },
+    HOOK_CASE_TIMEOUT_MS
+  )
 
-  it('emits protocol-valid JSON when the managed Cursor script is missing (#15462)', () => {
-    expect(new CursorHookService().install().state).toBe('installed')
-    const config = readInstalledCursorHooks(homeDir)
-    unlinkSync(join(homeDir, '.orca', 'agent-hooks', CURSOR_SCRIPT_FILE_NAME))
+  it(
+    'keeps curl failure off stdout when the listener is unreachable (#15462)',
+    () => {
+      expect(new CursorHookService().install().state).toBe('installed')
+      const config = readInstalledCursorHooks(homeDir)
 
-    for (const eventName of CURSOR_EVENTS) {
-      const command = requireRegisteredCommand(config, eventName)
-      const result = runRegisteredCursorHook(command, '')
-      expect(result.status, `${eventName} missing-script exit`).toBe(0)
-      expect(result.stderr, `${eventName} missing-script stderr`).toBe('')
-      expect(JSON.parse(result.stdout), `${eventName} missing-script stdout`).toEqual(
-        EXPECTED_CURSOR_HOOK_STDOUT[eventName]
-      )
-    }
-  })
-
-  it('keeps curl failure off stdout when the listener is unreachable (#15462)', () => {
-    expect(new CursorHookService().install().state).toBe('installed')
-    const config = readInstalledCursorHooks(homeDir)
-
-    for (const eventName of ['beforeSubmitPrompt', 'preToolUse', 'stop'] as const) {
-      const command = requireRegisteredCommand(config, eventName)
-      const result = runRegisteredCursorHook(
-        command,
-        JSON.stringify({ hook_event_name: eventName, tool_name: 'Write' }),
-        {
-          ORCA_AGENT_HOOK_PORT: '59999',
-          ORCA_AGENT_HOOK_TOKEN: 'token',
-          ORCA_PANE_KEY: 'tab:leaf'
-        }
-      )
-      expect(result.status, `${eventName} dead-listener exit`).toBe(0)
-      expect(JSON.parse(result.stdout), `${eventName} dead-listener stdout`).toEqual(
-        EXPECTED_CURSOR_HOOK_STDOUT[eventName]
-      )
-    }
-  })
+      for (const eventName of ['beforeSubmitPrompt', 'preToolUse', 'stop'] as const) {
+        const command = requireRegisteredCommand(config, eventName)
+        const result = runRegisteredCursorHook(
+          command,
+          JSON.stringify({ hook_event_name: eventName, tool_name: 'Write' }),
+          {
+            ORCA_AGENT_HOOK_PORT: '59999',
+            ORCA_AGENT_HOOK_TOKEN: 'token',
+            ORCA_PANE_KEY: 'tab:leaf'
+          }
+        )
+        expect(result.status, `${eventName} dead-listener exit`).toBe(0)
+        expect(JSON.parse(result.stdout), `${eventName} dead-listener stdout`).toEqual(
+          EXPECTED_CURSOR_HOOK_STDOUT[eventName]
+        )
+      }
+    },
+    HOOK_CASE_TIMEOUT_MS
+  )
 
   it.skipIf(process.platform !== 'win32')(
     'emits parseable JSON through cmd.exe and Git Bash (#14825/#15462)',
@@ -280,7 +300,7 @@ describe('CursorHookService', () => {
           const result = spawnSync(shell.executable, [...shell.args, command], {
             encoding: 'utf8',
             input: JSON.stringify({ hook_event_name: eventName, tool_name: 'Write' }),
-            timeout: 15_000,
+            timeout: HOOK_RUN_TIMEOUT_MS,
             env: {
               ...process.env,
               ORCA_AGENT_HOOK_ENDPOINT: '',
@@ -298,6 +318,7 @@ describe('CursorHookService', () => {
           )
         }
       }
-    }
+    },
+    HOOK_CASE_TIMEOUT_MS
   )
 })

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -25,13 +25,14 @@ const CURSOR_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'cursor-hook.cmd'
 const WINDOWS_POWERSHELL_LAUNCHER =
   /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
-// Why: on Windows one hook run is cmd.exe -> powershell.exe -> cursor-hook.cmd -> curl.exe.
-// PowerShell CLR startup alone costs ~300ms warm and seconds cold on a loaded runner, so match
-// WINDOWS_PROCESS_TEST_TIMEOUT_MS (30s), this repo's budget for a real Windows process spawn.
+// Why: on Windows one hook run is cmd.exe -> powershell.exe -> cmd.exe -> cursor-hook.cmd ->
+// curl.exe, and the package job runs ~25 files at maxWorkers 4 alongside real-Electron and
+// node-pty suites, so a cold CLR start competes for the runner. Deliberately above the product's
+// own MANAGED_HOOK_TIMEOUT_SECONDS (10s): this gates launcher correctness, not user latency.
 const HOOK_RUN_TIMEOUT_MS = 30_000
-// Why: these cases run up to 16 of those chains back to back; stay well above HOOK_RUN_TIMEOUT_MS
-// so a stuck spawn reports ETIMEDOUT (which names the process) before the case times out.
-const HOOK_CASE_TIMEOUT_MS = 120_000
+// Why: these cases run up to 16 of those chains back to back. Matches the same budget
+// windows-hook-payload-delivery.test.ts uses for the identical chain.
+const HOOK_CASE_TIMEOUT_MS = 60_000
 
 type InstalledCursorHooks = {
   hooks: Record<string, { command?: string }[]>


### PR DESCRIPTION
## Infrastructure-timing flake, not a logic race

`src/main/cursor/hook-service.test.ts` failed once on the `package (windows)` job of #17659 (a packaging-only PR with no connection to cursor hooks), and cleared on rerun:

```
AssertionError: expected Error: spawnSync cmd.exe ETIMEDOUT { …(5) } to be undefined
 ❯ src/main/cursor/hook-service.test.ts:78
    78|   expect(result.error, result.stderr).toBeUndefined()
```

`ETIMEDOUT` from `spawnSync` means exactly one thing: the `timeout` option elapsed. The assertion is `expect(result.error).toBeUndefined()` — there is no ordering, no shared state, no race to fix. The subprocess was simply still running when Node killed it.

## Why this suite is the one that trips

Cursor is the heaviest of the hook-service suites on Windows. Its managed command is the PowerShell **encoded launcher** (`wrapWindowsHookCommand`, required by #6078 so a profile path with a space survives `cmd.exe`), so a single hook run is:

```
cmd.exe -> powershell.exe -NoProfile -EncodedCommand -> cursor-hook.cmd -> curl.exe
```

Four process creations, one of them a CLR start. `src/main/agent-hooks/installer-utils.ts` already documents that cost in-tree: *"PowerShell per-post costs ~300ms startup"* and *"PowerShell startup makes inline per-turn Codex hooks visibly slow"*. On a `package (windows)` runner — electron-builder saturating CPU and disk, Defender real-time scanning the freshly written `.cmd` in a temp dir — that chain is not reliably under 15s.

The sibling suites are not affected and were left alone: `src/main/codex/hook-service-managed-install.test.ts`, `src/main/grok/hook-service.test.ts`, and `src/main/agent-hooks/installer-utils.test.ts` all spawn the `.cmd` **directly** (no PowerShell hop) and set **no per-spawn timeout at all**. The `15_000` here was a one-off in this file, not a systemic value.

## The change

| | old | new |
|---|---|---|
| per-spawn `spawnSync` timeout | `15_000` | `HOOK_RUN_TIMEOUT_MS = 30_000` |
| per-case vitest timeout | default `30_000` | `HOOK_CASE_TIMEOUT_MS = 120_000` (4 spawning cases) |

**Why 30s per spawn** — it matches `WINDOWS_PROCESS_TEST_TIMEOUT_MS = 30_000`, the named budget this repo already uses for a real Windows process spawn in `src/shared/setup-agent-sequencing.test.ts` and `.windows.test.ts`, and it is the floor among the real-subprocess tests in `src/main/browser/*.electron.test.ts` (30s / 60s / 90s). It is ~30x the warm cost of the four-process chain, which is the headroom a contended packaging runner needs.

**Why the case timeout had to move too** — vitest's default `testTimeout` is also `30_000` (`config/vitest.config.ts`), so raising only the spawn timeout would have just moved the failure to an opaque `test timed out in 30000ms`. The protocol case runs 16 chains back to back (8 events x 2 payloads), so 30s was already tight for the aggregate even without an outlier. `120_000` is 4x the per-spawn budget: comfortably above the realistic aggregate plus one slow outlier, still bounded, and it guarantees the diagnostic you see is `ETIMEDOUT` — which names the stuck process — rather than a case timeout that tells you nothing.

The two constants are shared across both `spawnSync` sites and all four spawning cases, so the value stays consistent within the file.

## What is not changed

- No product code. No `.cmd` launcher or PowerShell wrapper behavior is touched.
- No end-to-end coverage removed. The Windows launcher regression guards for #6078, #8430, #14825 and #15462 all still spawn real processes; mocking them out would delete coverage that exists because of real shipped bugs.

A possible follow-up (deliberately **not** in this PR): Cursor always takes the PowerShell path, while `wrapWindowsCmdHookCommand` already returns a bare `.cmd` path when the path is cmd-safe. Routing Cursor through that would drop a CLR start from every hook invocation for most users — but it is a product behavior change against the #6078 regression guard and does not belong in a flake fix.

## Verification

- `pnpm test src/main/cursor` — 5 passed, 2 skipped.
- `pnpm exec oxlint src/main/cursor/hook-service.test.ts` — clean. `pnpm tc` — clean.
- **Local runs do not exercise the changed Windows path.** The two skipped cases are gated on `process.platform === 'win32'`; on macOS/Linux the shared helper spawns `/bin/sh`, not `cmd.exe -> powershell.exe`. The `package (windows)` CI job is the only real verification of this fix.
- The flake reproduced once in many runs, so a green Windows job is consistent with the fix but does not by itself prove it. The argument rests on the timeout arithmetic above, not on the CI result.

Do not merge without a green `package (windows)` run.
