### PR TITLE
test(native-chat): fix flaky transcript watch-error initial-snapshot recovery test

### DIFF
--- a/src/main/native-chat/transcript-watch-error.test.ts
+++ b/src/main/native-chat/transcript-watch-error.test.ts
@@ -164,14 +164,16 @@ describe('native chat transcript watcher errors', () => {
 
     // initialDrain stays true after the error, so a recovered read delivers the
     // real snapshot instead of stranding the client on the error frame.
-    tailReaderState.failure = null
+    // The content must land before reads recover: the capped rotation retry is
+    // still firing, and any drain that succeeds against a still-empty file
+    // legitimately consumes the pending initial drain with an empty snapshot.
     await writeFile(filePath, claudeLine('u-recovered', 'user', 'back'))
+    tailReaderState.failure = null
     watchCallbacks[0]!('change', 'transcript.jsonl')
-    await vi.waitFor(() =>
-      expect(onInitialSnapshot.mock.calls.flat(2)).toEqual(
-        expect.arrayContaining([expect.objectContaining({ id: 'u-recovered' })])
-      )
-    )
+    await vi.waitFor(() => expect(onInitialSnapshot).toHaveBeenCalledTimes(2))
+    expect(onInitialSnapshot.mock.calls[1]![0]).toEqual([
+      expect.objectContaining({ id: 'u-recovered' })
+    ])
 
     subscription.unsubscribe()
   })


### PR DESCRIPTION
## Root cause

`transcript-watch-error.test.ts` > `still wins with a real initial snapshot once the transcript becomes readable` had a real ordering race with the watcher's own retry loop.

The test injects a tail-reader failure, waits for the `Transcript unavailable` frame, then did:

```ts
tailReaderState.failure = null                 // reads recover
await writeFile(filePath, claudeLine('u-recovered', ...))  // content lands
watchCallbacks[0]!('change', 'transcript.jsonl')           // poke the watcher
```

After the failed initial drain, `installTranscriptWatcher` keeps a capped rotation retry alive (`scheduleRotationRetry`, 25ms → 2s backoff), plus a 1s reconciliation tick. Any of those drains that lands in the window between "reads recover" and "content is on disk" succeeds against a **still-empty** file (`writeFile` also truncates first). Because `initialDrain` is still true, that drain legitimately emits the initial snapshot — an empty one — and flips `initialDrain` to false. The subsequent manual `change` callback then takes the append path, so `u-recovered` was delivered to `onAppend` and never reached `onInitialSnapshot`, and the `vi.waitFor` timed out.

The CI diff confirms this exactly. `onInitialSnapshot.mock.calls.flat(2)` was:

```
[false, 0, "Transcript unavailable", false, 0, undefined, undefined]
```

3 elements from the error frame (`([], false, 0, msg)`) + 4 from a **second, empty** snapshot (`([], hasMore, beforeOffset, undefined, lifecycle)`) = the 7-element `[ false, +0, …(5) ]` from the CI log.

## Verdict: test bug, not a product bug

Emitting an empty initial snapshot the moment the transcript becomes readable, then streaming `u-recovered` through `onAppend`, is correct: the client ends up with the identical transcript and is never stranded on the error frame. The watcher is not emitting a spurious or duplicate snapshot — coalescing is fine. The test was asserting on which callback happened to win a race that production does not order.

## Fix

Write the recovered line **before** clearing the failure, so no drain can ever observe a readable-but-empty transcript in any interleaving (while the failure is set, every read rejects; once cleared, every read sees the content). No timeout bumps, no retries, no skips.

The assertion is also strengthened rather than weakened: instead of flattening every call's args into one array and doing an `arrayContaining` membership check, it now asserts exactly two `onInitialSnapshot` calls and that the second one's message array is exactly `[{ id: 'u-recovered' }]`. That fails loudly on the empty-snapshot regression this flake was silently tolerating.

## Reproduction

Reproduced deterministically. In a scratch copy of the test I widened the race window by inserting `await new Promise(r => setTimeout(r, 60))` between `tailReaderState.failure = null` and the `writeFile`, letting a rotation retry land in the gap. It fails 100% of the time with the byte-identical CI assertion:

```
AssertionError: expected [ false, +0, …(5) ] to deeply equal ArrayContaining{…}
+   false,
+   0,
+   "Transcript unavailable",
+   false,
+   0,
+   undefined,
+   undefined,
```

With the fix applied, the same scratch copy — 60ms delay after the `writeFile` *and* another 60ms after clearing the failure, so a retry drain deliberately wins the race ahead of the manual callback — passes 5/5.

## Loop evidence

- Fixed test file, 65 consecutive runs under 8 concurrent CPU hogs: **65 passed, 0 failed**.
- `pnpm test src/main/native-chat`: 83 files, 679 tests passed.
- `oxlint` clean, `pnpm tc` clean.
