### PR TITLE
Fix OMP spaced-colon working title detection after owner rewrite

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -90,6 +90,26 @@ describe('buildTitleDerivedAgentRows', () => {
     ])
   })
 
+  it('rows an idle OMP session from an owner-rewritten separator title before the first turn', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'omp' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          1: 'OMP > New OMP session'
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-omp'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.terminalTitle])).toEqual([
+      ['omp', 'idle', 'OMP > New OMP session']
+    ])
+  })
+
   it('keeps Pi-compatible title-derived rows as Pi for launched Pi sessions', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { launchAgent: 'pi' })],

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -11,7 +11,10 @@ import {
   titleHasAgentName
 } from './agent-title-core'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
-import { getPiCompatibleSyntheticAgentLabel } from './pi-compatible-synthetic-title'
+import {
+  getPiCompatibleSyntheticAgentLabel,
+  getPiCompatibleTitleSeparatorBrand
+} from './pi-compatible-synthetic-title'
 import { memoizeTitleClassification } from './terminal-title-classification-memo'
 
 /**
@@ -76,9 +79,9 @@ function computeAgentLabel(title: string): string | null {
   if (piCompatibleSyntheticAgentLabel) {
     return piCompatibleSyntheticAgentLabel
   }
-  // Why: owner rewrite turns `π : <label>` into `OMP : <label>`; only the OMP form is new (#17690).
-  if (/^\s*OMP\s+:(?=\s|$)/u.test(title)) {
-    return 'OMP'
+  const piCompatibleSeparatorBrand = getPiCompatibleTitleSeparatorBrand(title)
+  if (piCompatibleSeparatorBrand) {
+    return piCompatibleSeparatorBrand
   }
   if (isPiAgentTitle(title)) {
     return 'Pi'

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -76,6 +76,10 @@ function computeAgentLabel(title: string): string | null {
   if (piCompatibleSyntheticAgentLabel) {
     return piCompatibleSyntheticAgentLabel
   }
+  // Why: owner rewrite turns `π : <label>` into `OMP : <label>`; only the OMP form is new (#17690).
+  if (/^\s*OMP\s+:(?=\s|$)/u.test(title)) {
+    return 'OMP'
+  }
   if (isPiAgentTitle(title)) {
     return 'Pi'
   }

--- a/src/shared/agent-title-owner.ts
+++ b/src/shared/agent-title-owner.ts
@@ -10,6 +10,8 @@ import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 
 /** The π brand a Pi/OMP title leads with; the owner's label replaces it in place. */
 const LEGACY_PI_BRAND = 'π'
+// Why: owner rewrite already swapped π; re-running must swap Pi/OMP in place, not collapse (#17690).
+const PI_COMPATIBLE_SPACED_COLON_TITLE_RE = /^\s*(?:Pi|OMP)\s+:(?=\s|$)/u
 
 type TitleProfileMatch = {
   profile: SyntheticAgentTitleProfile
@@ -167,6 +169,11 @@ export function normalizeCompatibleAgentTitleForOwner(
     // scoping is only as good as the segment match — a prefix that itself parses as a π title
     // makes the whole string the match, and then the prefix's brand is what gets swapped.
     const ownedSegment = source.sourceTitle.replace(LEGACY_PI_BRAND, ownerProfile.workingLabel)
+    const segmentAt = title.lastIndexOf(source.sourceTitle)
+    return segmentAt === -1 ? ownedSegment : title.slice(0, segmentAt) + ownedSegment
+  }
+  if (PI_COMPATIBLE_SPACED_COLON_TITLE_RE.test(source.sourceTitle)) {
+    const ownedSegment = source.sourceTitle.replace(/^\s*(?:Pi|OMP)/u, ownerProfile.workingLabel)
     const segmentAt = title.lastIndexOf(source.sourceTitle)
     return segmentAt === -1 ? ownedSegment : title.slice(0, segmentAt) + ownedSegment
   }

--- a/src/shared/agent-title-owner.ts
+++ b/src/shared/agent-title-owner.ts
@@ -5,13 +5,11 @@ import {
   SYNTHETIC_AGENT_TITLE_PROFILES,
   type SyntheticAgentTitleProfile
 } from './synthetic-agent-title'
-import { isLegacyPiCompatibleTitle } from './pi-compatible-synthetic-title'
+import { isLegacyPiCompatibleTitle, isPiCompatibleAsciiSeparatorTitle } from './pi-compatible-synthetic-title'
 import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 
 /** The π brand a Pi/OMP title leads with; the owner's label replaces it in place. */
 const LEGACY_PI_BRAND = 'π'
-// Why: owner rewrite already swapped π; re-running must swap Pi/OMP in place, not collapse (#17690).
-const PI_COMPATIBLE_SPACED_COLON_TITLE_RE = /^\s*(?:Pi|OMP)\s+:(?=\s|$)/u
 
 type TitleProfileMatch = {
   profile: SyntheticAgentTitleProfile
@@ -172,7 +170,7 @@ export function normalizeCompatibleAgentTitleForOwner(
     const segmentAt = title.lastIndexOf(source.sourceTitle)
     return segmentAt === -1 ? ownedSegment : title.slice(0, segmentAt) + ownedSegment
   }
-  if (PI_COMPATIBLE_SPACED_COLON_TITLE_RE.test(source.sourceTitle)) {
+  if (isPiCompatibleAsciiSeparatorTitle(source.sourceTitle)) {
     const ownedSegment = source.sourceTitle.replace(/^\s*(?:Pi|OMP)/u, ownerProfile.workingLabel)
     const segmentAt = title.lastIndexOf(source.sourceTitle)
     return segmentAt === -1 ? ownedSegment : title.slice(0, segmentAt) + ownedSegment

--- a/src/shared/omp-pi-semantic-title-preservation.test.ts
+++ b/src/shared/omp-pi-semantic-title-preservation.test.ts
@@ -270,5 +270,8 @@ describe('latent hazards the reviewers flagged', () => {
     const once = normalizeCompatibleAgentTitleForOwner(title, 'omp')
     expect(normalizeCompatibleAgentTitleForOwner(once, 'omp')).toBe(once)
     expect(once).toContain('OMP')
+    if (title.includes('Run a long task')) {
+      expect(once).toContain('Run a long task')
+    }
   })
 })

--- a/src/shared/omp-pi-semantic-title-preservation.test.ts
+++ b/src/shared/omp-pi-semantic-title-preservation.test.ts
@@ -109,6 +109,17 @@ describe('OMP owner rewrite preserves spaced-colon working titles (#17690)', () 
   })
 })
 
+describe('OMP owner rewrite preserves idle separator titles before the first turn', () => {
+  const raw = 'π > New OMP session'
+
+  it('detects idle and OMP identity after the owner rewrite', () => {
+    const rewritten = normalizeCompatibleAgentTitleForOwner(raw, 'omp', { ownerIsLaunch: true })
+    expect(rewritten).toBe('OMP > New OMP session')
+    expect(detectAgentStatusFromTitle(rewritten)).toBe('idle')
+    expect(getAgentLabel(rewritten)).toBe('OMP')
+  })
+})
+
 describe('the churn is gone at the suppressor', () => {
   it('treats consecutive animation frames as decoration', () => {
     for (const build of [ORCA_EXTENSION_WORKING, OMP_NATIVE_WORKING]) {
@@ -265,6 +276,7 @@ describe('latent hazards the reviewers flagged', () => {
     'π ⠙ fixing the sidebar',
     'π : Run a long task',
     'OMP : Run a long task',
+    'OMP > New OMP session',
     'zsh | ⠙ π - a - b'
   ])('is a fixed point when the owner rewrite re-runs on %s', (title) => {
     const once = normalizeCompatibleAgentTitleForOwner(title, 'omp')
@@ -272,6 +284,9 @@ describe('latent hazards the reviewers flagged', () => {
     expect(once).toContain('OMP')
     if (title.includes('Run a long task')) {
       expect(once).toContain('Run a long task')
+    }
+    if (title.includes('New OMP session')) {
+      expect(once).toContain('New OMP session')
     }
   })
 })

--- a/src/shared/omp-pi-semantic-title-preservation.test.ts
+++ b/src/shared/omp-pi-semantic-title-preservation.test.ts
@@ -20,6 +20,7 @@
  * rotating braille frame so consecutive frames dedupe while the label survives.
  */
 import { describe, expect, it } from 'vitest'
+import { getAgentLabel } from './agent-detection'
 import { detectAgentStatusFromTitle, normalizeTerminalTitle } from './agent-title-status'
 import { isDecorativeAgentTitleFrameChange } from './agent-decorative-title-signature'
 import {
@@ -85,9 +86,26 @@ describe('detectAgentStatusFromTitle reads the π state separator', () => {
     ['π > fixing the sidebar', 'idle'],
     ['π ⠋ fixing the sidebar', 'working'],
     ['⠋ π - fixing the sidebar - orca', 'working'],
-    ['π: fixing the sidebar', 'idle']
+    ['π: fixing the sidebar', 'idle'],
+    ['π : fixing the sidebar', 'working']
   ])('classifies %s as %s', (title, expected) => {
     expect(detectAgentStatusFromTitle(title)).toBe(expected)
+  })
+})
+
+describe('OMP owner rewrite preserves spaced-colon working titles (#17690)', () => {
+  const raw = 'π : Run a long task'
+
+  it('detects working on the raw π state title', () => {
+    expect(detectAgentStatusFromTitle(raw)).toBe('working')
+    expect(getAgentLabel(raw)).toBe('Pi')
+  })
+
+  it('detects working and OMP identity after the owner rewrite', () => {
+    const rewritten = normalizeCompatibleAgentTitleForOwner(raw, 'omp', { ownerIsLaunch: true })
+    expect(rewritten).toBe('OMP : Run a long task')
+    expect(detectAgentStatusFromTitle(rewritten)).toBe('working')
+    expect(getAgentLabel(rewritten)).toBe('OMP')
   })
 })
 
@@ -158,6 +176,7 @@ describe('the owner relabel keeps the label and swaps only the brand', () => {
     'π - fixing the sidebar - orca',
     'π ! fixing the sidebar',
     'π > fixing the sidebar',
+    'π : fixing the sidebar',
     '⠋ Pi',
     'Pi ready',
     'Pi - action required'

--- a/src/shared/omp-pi-semantic-title-preservation.test.ts
+++ b/src/shared/omp-pi-semantic-title-preservation.test.ts
@@ -263,6 +263,8 @@ describe('latent hazards the reviewers flagged', () => {
     'π - fixing the sidebar - orca',
     'π ! fixing the sidebar',
     'π ⠙ fixing the sidebar',
+    'π : Run a long task',
+    'OMP : Run a long task',
     'zsh | ⠙ π - a - b'
   ])('is a fixed point when the owner rewrite re-runs on %s', (title) => {
     const once = normalizeCompatibleAgentTitleForOwner(title, 'omp')

--- a/src/shared/pi-compatible-synthetic-title.ts
+++ b/src/shared/pi-compatible-synthetic-title.ts
@@ -9,7 +9,9 @@ const LEGACY_PI_COMPATIBLE_TITLE_RE = /^\s*(?:[\u2800-\u28ff]\s+)?π(?:\s*[-:]|\
 // may already have been swapped for the owner's label, so accept those too — but only in their
 // exact profile casing, since a lowercase `pi - refactor…` is ordinary prose, not a Pi title.
 // The separator must be delimited (`:` attached, or spaced) or `omp-harness` reads as a state.
-const PI_COMPATIBLE_SEPARATOR_RE = /^\s*(?:π|Pi|OMP)(?::|\s+([!>-]))(?=\s|$)/u
+// Why: OMP 17.2.12+ emits `π : <label>` on WSL/ConPTY; owner rewrite swaps the brand to
+// `OMP : <label>`, so the spaced colon must classify as working here too (#17690).
+const PI_COMPATIBLE_SEPARATOR_RE = /^\s*(?:π|Pi|OMP)(?::|\s+([!>:-]))(?=\s|$)/u
 const PI_COMPATIBLE_PERMISSION_TAIL_RE = /\baction required\b/i
 
 function containsBrailleSpinner(title: string): boolean {
@@ -86,5 +88,11 @@ export function getPiCompatibleTitleSeparatorStatus(
   if (PI_COMPATIBLE_PERMISSION_TAIL_RE.test(title)) {
     return 'permission'
   }
-  return match[1] === '!' ? 'permission' : 'idle'
+  if (match[1] === '!') {
+    return 'permission'
+  }
+  if (match[1] === ':') {
+    return 'working'
+  }
+  return 'idle'
 }

--- a/src/shared/pi-compatible-synthetic-title.ts
+++ b/src/shared/pi-compatible-synthetic-title.ts
@@ -62,6 +62,30 @@ export function isLegacyPiCompatibleTitle(title: string): boolean {
   return LEGACY_PI_COMPATIBLE_TITLE_RE.test(title)
 }
 
+/** Brand a Pi/OMP separator title carries, using the same grammar as status detection. */
+export function getPiCompatibleTitleSeparatorBrand(
+  title: string
+): PiCompatibleSyntheticAgentLabel | null {
+  if (containsBrailleSpinner(title)) {
+    return null
+  }
+  if (!PI_COMPATIBLE_SEPARATOR_RE.exec(title)) {
+    return null
+  }
+  const brandMatch = /^\s*(π|Pi|OMP)/u.exec(title)
+  if (!brandMatch) {
+    return null
+  }
+  return brandMatch[1] === 'OMP' ? 'OMP' : 'Pi'
+}
+
+/** Owner-rewritten titles that already use the ASCII Pi/OMP brand plus a state separator. */
+export function isPiCompatibleAsciiSeparatorTitle(title: string): boolean {
+  return (
+    getPiCompatibleTitleSeparatorBrand(title) !== null && /^\s*(?:Pi|OMP)/u.test(title)
+  )
+}
+
 /**
  * Reads the run state a π-branded title encodes in its separator.
  *


### PR DESCRIPTION
## ELI5

When OMP is working on WSL, its pane title looks like `π : Run a long task`. Orca rewrites that to `OMP : Run a long task` for display, but the status parser only recognized the spaced colon while the brand was still `π`. After the rewrite, Orca stopped seeing the pane as working and the sidebar fell back to a green active dot.

## What Changed

- Teach `getPiCompatibleTitleSeparatorStatus` to treat `OMP : <label>` (and the equivalent `π`/`Pi` forms) as a working state marker, matching the existing `π :` protocol.
- Teach `getAgentLabel` to recognize `OMP : <label>` as OMP identity so title-derived sidebar rows survive the owner rewrite.
- Add regression tests for both the raw `π :` title and the rewritten `OMP :` title.

## Why

OMP 17.2.12+ emits static `π : <label>` markers on WSL/ConPTY instead of braille frames. Orca's owner rewrite swaps `π` → `OMP` in place, but the compatible separator regex only matched an attached colon or spaced `!`/`>`/`-` — not spaced colon after `OMP`. Hook-less panes then lost title-derived working status and identity (#17690).

## Linked Issue

Fixes #17690

## Visual Proof

N/A — title parsing fix only; no UI layout or styling change. The sidebar spinner vs green-dot behavior is driven by this detection path.

## Testing

- `pnpm test src/shared/omp-pi-semantic-title-preservation.test.ts src/shared/pi-state-title-marker.test.ts src/shared/agent-detection.test.ts`
- `pnpm tc`
- `pnpm run check:code-quality:changed`
- Manual repro via tsx: `detectAgentStatusFromTitle('OMP : Run a long task')` now returns `working` and `getAgentLabel` returns `OMP`

Platforms: logic-only shared module change; no platform-specific code paths touched.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented by Cursor Cloud Agent.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Cross-platform: shared title parser only; OMP WSL/ConPTY is the reported environment but the fix is brand-agnostic.
- SSH/remote: title detection runs on the same shared path for local and remote panes.
- Performance: one additional character-class in an existing anchored regex; no hot-path allocation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)