### PR TITLE
fix(lint): merge duplicate process-table-snapshot imports

### DIFF
--- a/src/main/providers/agent-foreground-process-batch.test.ts
+++ b/src/main/providers/agent-foreground-process-batch.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildProcessTableIndex,
   parseStrictProcessTableRows,
-  ProcessTableCaptureError
+  ProcessTableCaptureError,
+  type ProcessTableIndexStats
 } from '../../shared/process-table-snapshot'
 import {
   resolveAgentForegroundProcessesBatch,
   resolveAgentForegroundProcessesFromIndex
 } from './agent-foreground-process'
-import {
-  buildProcessTableIndex,
-  type ProcessTableIndexStats
-} from '../../shared/process-table-snapshot'
 
 describe('strict process-table evidence parser', () => {
   it('extracts pgid/tpgid while retaining command spacing', () => {


### PR DESCRIPTION
## `main` is currently red

`static analysis` fails on `main` and therefore on **every open PR**:

```
src/main/providers/agent-foreground-process-batch.test.ts:5:8:
  Modules should not be imported multiple times in the same file
Found 1 warning and 0 errors.
```

The code-quality pass runs `oxlint --config config/oxlint-code-quality-native-plugins.json src config tests mobile --deny-warnings`, so that single warning fails the job.

The file imports `'../../shared/process-table-snapshot'` twice — once at line 2-5 and again at line 10-13, with `./agent-foreground-process` sandwiched between them. Introduced by #17525.

## Fix

Merge the two into one import. No behavior change; `type ProcessTableIndexStats` keeps its inline `type` modifier.

## Verification

- `pnpm exec oxlint --config config/oxlint-code-quality-native-plugins.json src config tests mobile --deny-warnings` — clean (was 1 warning)
- `pnpm test src/main/providers/agent-foreground-process-batch.test.ts` — 9 passed

Found while trying to land unrelated flaky-test fixes, all of which are blocked behind this.