### PR TITLE
fix(native-chat): list Claude Code custom slash commands in the chat picker

### DIFF
--- a/src/main/skills/custom-slash-command-discovery.test.ts
+++ b/src/main/skills/custom-slash-command-discovery.test.ts
@@ -1,0 +1,107 @@
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  buildCustomSlashCommandRoots,
+  clearCustomSlashCommandScanCache,
+  discoverCustomSlashCommands
+} from './custom-slash-command-discovery'
+
+async function writeCommand(
+  root: string,
+  relativePath: string,
+  contents = '# body\n'
+): Promise<void> {
+  const filePath = join(root, ...relativePath.split('/'))
+  await mkdir(join(filePath, '..'), { recursive: true })
+  await writeFile(filePath, contents)
+}
+
+async function buildFixture(): Promise<{ home: string; cwd: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-slash-commands-'))
+  const home = join(root, 'home')
+  const cwd = join(root, 'repo')
+  await mkdir(home, { recursive: true })
+  await mkdir(cwd, { recursive: true })
+  return { home, cwd }
+}
+
+afterEach(() => {
+  clearCustomSlashCommandScanCache()
+})
+
+describe('buildCustomSlashCommandRoots', () => {
+  it('scans the workspace and the home profile', () => {
+    const roots = buildCustomSlashCommandRoots({ homeDir: '/home/u', cwd: '/repo' })
+    expect(roots).toEqual([
+      { path: join('/repo', '.claude', 'commands'), scope: 'project' },
+      { path: join('/home/u', '.claude', 'commands'), scope: 'user' }
+    ])
+  })
+
+  it('scans one root once when the workspace is the home directory', () => {
+    expect(buildCustomSlashCommandRoots({ homeDir: '/home/u', cwd: '/home/u' })).toHaveLength(1)
+  })
+})
+
+describe('discoverCustomSlashCommands', () => {
+  it('namespaces nested files and reads the frontmatter description', async () => {
+    const { home, cwd } = await buildFixture()
+    await writeCommand(
+      join(cwd, '.claude', 'commands'),
+      'opsx/apply.md',
+      '---\ndescription: Apply an OpenSpec change\n---\n\nBody\n'
+    )
+    await writeCommand(join(cwd, '.claude', 'commands'), 'standalone.md')
+    const commands = await discoverCustomSlashCommands({ homeDir: home, cwd })
+    expect(commands.map((command) => command.name)).toEqual(['opsx:apply', 'standalone'])
+    expect(commands[0]).toMatchObject({
+      description: 'Apply an OpenSpec change',
+      scope: 'project'
+    })
+  })
+
+  it('includes user-level commands and lets the project shadow them', async () => {
+    const { home, cwd } = await buildFixture()
+    await writeCommand(
+      join(home, '.claude', 'commands'),
+      'shared.md',
+      '---\ndescription: user\n---\n'
+    )
+    await writeCommand(join(home, '.claude', 'commands'), 'only-user.md')
+    await writeCommand(
+      join(cwd, '.claude', 'commands'),
+      'shared.md',
+      '---\ndescription: project\n---\n'
+    )
+    const commands = await discoverCustomSlashCommands({ homeDir: home, cwd })
+    expect(commands.map((command) => command.name)).toEqual(['only-user', 'shared'])
+    expect(commands.find((command) => command.name === 'shared')).toMatchObject({
+      description: 'project',
+      scope: 'project'
+    })
+  })
+
+  it('ignores non-markdown files and skill roots', async () => {
+    const { home, cwd } = await buildFixture()
+    await writeCommand(join(cwd, '.claude', 'commands'), 'notes.txt')
+    await writeCommand(join(cwd, '.claude', 'skills', 'thing'), 'SKILL.md')
+    expect(await discoverCustomSlashCommands({ homeDir: home, cwd })).toEqual([])
+  })
+
+  it('returns nothing when no commands root exists', async () => {
+    const { home, cwd } = await buildFixture()
+    expect(await discoverCustomSlashCommands({ homeDir: home, cwd })).toEqual([])
+  })
+
+  it('follows a symlinked commands directory', async () => {
+    const { home, cwd } = await buildFixture()
+    const shared = join(home, 'shared-commands')
+    await writeCommand(shared, 'linked.md')
+    await mkdir(join(cwd, '.claude', 'commands'), { recursive: true })
+    await symlink(shared, join(cwd, '.claude', 'commands', 'team'), 'dir')
+    const commands = await discoverCustomSlashCommands({ homeDir: home, cwd })
+    expect(commands.map((command) => command.name)).toEqual(['team:linked'])
+  })
+})

--- a/src/main/skills/custom-slash-command-discovery.ts
+++ b/src/main/skills/custom-slash-command-discovery.ts
@@ -1,0 +1,124 @@
+import { stat } from 'node:fs/promises'
+import { join, relative, type posix } from 'node:path'
+import {
+  customSlashCommandName,
+  dedupeCustomSlashCommands,
+  type CustomSlashCommandScope,
+  type DiscoveredSlashCommand
+} from '../../shared/custom-slash-commands'
+import { SKILL_FILE_MAX_DEPTH } from '../../shared/skill-discovery-depth'
+import { readMarkdownSummary } from './markdown-summary-read'
+import { runSkillCandidateTasks } from './skill-candidate-concurrency'
+import { findRootFiles } from './skill-root-file-walk'
+import { isSkillRootUnavailableError, SkillScanCoalescer } from './skill-scan-coalescer'
+
+type CommandDiscoveryPathApi = Pick<typeof posix, 'join' | 'relative'>
+
+export type CustomSlashCommandRoot = { path: string; scope: CustomSlashCommandScope }
+
+// Why the same TTL as skill roots: `~/.claude/commands` is one shared tree for
+// every open pane, so the fan-out this bounds is identical.
+const COMMAND_ROOT_SCAN_TTL_MS = 10_000
+const MAX_CACHED_COMMAND_ROOTS = 256
+
+const commandRootScans = new SkillScanCoalescer<DiscoveredSlashCommand[]>(MAX_CACHED_COMMAND_ROOTS)
+
+export function clearCustomSlashCommandScanCache(): void {
+  commandRootScans.clear()
+}
+
+/** Claude Code reads project commands from the worktree and user commands from
+ *  the home profile; both namespace by subdirectory. */
+export function buildCustomSlashCommandRoots(args: {
+  homeDir: string
+  cwd: string
+  pathApi?: CommandDiscoveryPathApi
+}): CustomSlashCommandRoot[] {
+  const pathApi = args.pathApi ?? { join, relative }
+  const roots: CustomSlashCommandRoot[] = [
+    { path: pathApi.join(args.cwd, '.claude', 'commands'), scope: 'project' },
+    { path: pathApi.join(args.homeDir, '.claude', 'commands'), scope: 'user' }
+  ]
+  // The home directory can be the workspace, and one path must not scan twice.
+  return roots.filter((root, index) => roots.findIndex((o) => o.path === root.path) === index)
+}
+
+async function scanCommandRoot(
+  root: CustomSlashCommandRoot,
+  pathApi: CommandDiscoveryPathApi,
+  signal: AbortSignal
+): Promise<DiscoveredSlashCommand[]> {
+  const files = await findRootFiles(
+    root.path,
+    SKILL_FILE_MAX_DEPTH,
+    (fileName) => fileName.toLowerCase().endsWith('.md'),
+    signal
+  )
+  const commands = await runSkillCandidateTasks(
+    files.map((commandFilePath) => async (): Promise<DiscoveredSlashCommand | null> => {
+      signal.throwIfAborted()
+      const name = customSlashCommandName(pathApi.relative(root.path, commandFilePath))
+      if (!name) {
+        return null
+      }
+      const summary = await readMarkdownSummary(commandFilePath)
+      return {
+        name,
+        description: summary?.description ?? null,
+        scope: root.scope,
+        commandFilePath
+      }
+    })
+  )
+  return commands.filter((command): command is DiscoveredSlashCommand => command !== null)
+}
+
+async function scanCommandRootShared(
+  root: CustomSlashCommandRoot,
+  pathApi: CommandDiscoveryPathApi,
+  refresh: boolean
+): Promise<DiscoveredSlashCommand[]> {
+  try {
+    const outcome = await commandRootScans.run(
+      `${root.scope}\0${root.path}`,
+      { ttlMs: COMMAND_ROOT_SCAN_TTL_MS, refresh },
+      async (signal) => {
+        try {
+          if (!(await stat(root.path)).isDirectory()) {
+            return []
+          }
+        } catch {
+          return []
+        }
+        return scanCommandRoot(root, pathApi, signal)
+      }
+    )
+    return outcome.value
+  } catch (error) {
+    if (!isSkillRootUnavailableError(error)) {
+      throw error
+    }
+    // Why degrade: a stalled commands root must not fail the whole discovery and
+    // empty a picker whose skills scanned fine.
+    return []
+  }
+}
+
+/** Custom slash commands visible to a Claude Code session rooted at `cwd`. */
+export async function discoverCustomSlashCommands(args: {
+  homeDir: string
+  cwd: string
+  refresh?: boolean
+  pathApi?: CommandDiscoveryPathApi
+}): Promise<DiscoveredSlashCommand[]> {
+  const pathApi = args.pathApi ?? { join, relative }
+  const roots = buildCustomSlashCommandRoots({
+    homeDir: args.homeDir,
+    cwd: args.cwd,
+    pathApi
+  })
+  const scans = await Promise.all(
+    roots.map((root) => scanCommandRootShared(root, pathApi, args.refresh === true))
+  )
+  return dedupeCustomSlashCommands(scans.flat())
+}

--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -631,4 +631,28 @@ describe('skill discovery', () => {
 
     expect(result.skills.map((skill) => skill.name)).not.toContain('Too Deep')
   })
+  it('returns Claude Code custom slash commands for a targeted workspace scan', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const cwd = join(root, 'repo')
+    const projectCommands = join(cwd, '.claude', 'commands', 'opsx')
+    await mkdir(projectCommands, { recursive: true })
+    await writeFile(
+      join(projectCommands, 'apply.md'),
+      '---\ndescription: Apply an OpenSpec change\n---\n'
+    )
+
+    const result = await discoverSkills({ homeDir: home, cwd })
+
+    expect(result.commands?.map((command) => command.name)).toEqual(['opsx:apply'])
+  })
+
+  it('leaves commands empty for an untargeted inventory scan', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+
+    const result = await discoverSkills({ homeDir: home, repos: [], includeCwd: false })
+
+    expect(result.commands).toEqual([])
+  })
 })

--- a/src/main/skills/discovery.ts
+++ b/src/main/skills/discovery.ts
@@ -1,7 +1,6 @@
-import { open, realpath, stat } from 'node:fs/promises'
+import { realpath, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, dirname, relative, sep } from 'node:path'
-import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
 import type { Repo } from '../../shared/repo-types'
 import type {
   DiscoveredSkill,
@@ -26,10 +25,14 @@ import {
 } from './skill-scan-coalescer'
 import type { SkillProviderRootOverrides } from './skill-provider-destinations'
 import { skillDirectoryMaxDepth } from '../../shared/skill-discovery-depth'
+import { readMarkdownSummary } from './markdown-summary-read'
+import {
+  clearCustomSlashCommandScanCache,
+  discoverCustomSlashCommands
+} from './custom-slash-command-discovery'
 
 export { buildSkillDiscoverySources } from './skill-discovery-sources'
 
-const MAX_MARKDOWN_BYTES = 256 * 1024
 // Why: the fixed home roots are identical for every target, so one worktree pane
 // per open workspace used to re-walk the same directories once per pane. Sharing
 // them for a few seconds is what bounds that fan-out.
@@ -65,6 +68,7 @@ const lastKnownRootScans = new Map<string, { skills: ScannedSkill[]; recordedAt:
 /** Drop every shared root scan, e.g. after a skill install/update mutates disk. */
 export function clearSkillRootScanCache(): void {
   rootScans.clear()
+  clearCustomSlashCommandScanCache()
   // A mutation invalidates the retained copy too — it is a pre-mutation answer.
   lastKnownRootScans.clear()
 }
@@ -109,31 +113,6 @@ async function pathExists(pathValue: string): Promise<boolean> {
   }
 }
 
-async function readSkillSummary(skillFilePath: string): Promise<{
-  name: string | null
-  description: string | null
-  updatedAt: number | null
-} | null> {
-  try {
-    const fileStat = await stat(skillFilePath)
-    const file = await open(skillFilePath, 'r')
-    let content = ''
-    try {
-      const buffer = Buffer.alloc(Math.min(fileStat.size, MAX_MARKDOWN_BYTES))
-      const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
-      content = buffer.toString('utf8', 0, bytesRead)
-    } finally {
-      await file.close()
-    }
-    return {
-      ...summarizeSkillMarkdown(content),
-      updatedAt: fileStat.mtimeMs
-    }
-  } catch {
-    return null
-  }
-}
-
 type ScannedSkill = DiscoveredSkill & { canonicalSkillFilePath: string }
 
 async function scanRoot(root: SkillScanRoot, signal: AbortSignal): Promise<ScannedSkill[]> {
@@ -151,7 +130,7 @@ async function scanRoot(root: SkillScanRoot, signal: AbortSignal): Promise<Scann
       // returning prevents symlinked roots from becoming duplicate picker rows.
       const canonicalSkillFilePath = await realpath(skillFilePath).catch(() => skillFilePath)
       const directoryPath = dirname(skillFilePath)
-      const summary = await readSkillSummary(skillFilePath)
+      const summary = await readMarkdownSummary(skillFilePath)
       if (!summary) {
         return null
       }
@@ -275,7 +254,14 @@ export async function discoverSkills(args: {
       ? await discoverClaudePluginSkillSources({ homeDir, cwd: args.cwd })
       : [])
   ]
-  const scans = await Promise.all(roots.map((root) => scanRootShared(root, refresh)))
+  // Why here: `.claude/commands` is workspace-scoped picker data, exactly like
+  // plugin roots above, and the same one call feeds both halves of the picker.
+  const [scans, commands] = await Promise.all([
+    Promise.all(roots.map((root) => scanRootShared(root, refresh))),
+    args.cwd && args.includeCwd !== false
+      ? discoverCustomSlashCommands({ homeDir, cwd: args.cwd, refresh })
+      : Promise.resolve([])
+  ])
   const sources: SkillDiscoverySource[] = roots.map((root, index) => ({
     ...root,
     providers: [...root.providers],
@@ -312,6 +298,7 @@ export async function discoverSkills(args: {
     sources: sources.sort((a, b) =>
       a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
     ),
-    scannedAt: Date.now()
+    scannedAt: Date.now(),
+    commands
   }
 }

--- a/src/main/skills/markdown-summary-read.ts
+++ b/src/main/skills/markdown-summary-read.ts
@@ -1,0 +1,33 @@
+import { open, stat } from 'node:fs/promises'
+import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
+
+const MAX_MARKDOWN_BYTES = 256 * 1024
+
+export type MarkdownSummary = {
+  name: string | null
+  description: string | null
+  updatedAt: number | null
+}
+
+/** Frontmatter summary of a markdown file, bounded to the head of the file so a
+ *  huge document costs one page read. Shared by skill and slash-command scans. */
+export async function readMarkdownSummary(filePath: string): Promise<MarkdownSummary | null> {
+  try {
+    const fileStat = await stat(filePath)
+    const file = await open(filePath, 'r')
+    let content = ''
+    try {
+      const buffer = Buffer.alloc(Math.min(fileStat.size, MAX_MARKDOWN_BYTES))
+      const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
+      content = buffer.toString('utf8', 0, bytesRead)
+    } finally {
+      await file.close()
+    }
+    return {
+      ...summarizeSkillMarkdown(content),
+      updatedAt: fileStat.mtimeMs
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/main/skills/skill-discovery-wsl-script-roundtrip.test.ts
+++ b/src/main/skills/skill-discovery-wsl-script-roundtrip.test.ts
@@ -60,4 +60,30 @@ describe.skipIf(process.platform === 'win32')('WSL skill discovery script round-
     }
     expect(result.scannedAt).toBe(42)
   })
+
+  it('parses back the custom slash commands the generated script emits', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'orca-wsl-roundtrip-'))
+    const projectCommands = join(base, 'repo', '.claude', 'commands')
+    await mkdir(join(projectCommands, 'opsx'), { recursive: true })
+    await writeFile(
+      join(projectCommands, 'opsx', 'apply.md'),
+      '---\ndescription: Apply an OpenSpec change\n---\n'
+    )
+    await writeFile(join(projectCommands, 'standalone.md'), '# Standalone\n\nRun it.\n')
+    await writeFile(join(projectCommands, 'notes.txt'), 'not a command')
+    const commandRoots = [
+      { path: projectCommands, scope: 'project' as const },
+      { path: join(base, 'absent-commands'), scope: 'user' as const }
+    ]
+
+    const { stdout } = await run('bash', ['-c', buildWslSkillDiscoveryCommand([], commandRoots)], {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024
+    })
+    const result = parseWslSkillDiscoveryOutput(stdout, [], 42, commandRoots)
+
+    expect(result.commands?.map((command) => command.name)).toEqual(['opsx:apply', 'standalone'])
+    expect(result.commands?.[0].description).toBe('Apply an OpenSpec change')
+    expect(result.commands?.[0].scope).toBe('project')
+  })
 })

--- a/src/main/skills/skill-discovery-wsl.ts
+++ b/src/main/skills/skill-discovery-wsl.ts
@@ -1,5 +1,10 @@
 import { posix as pathPosix } from 'node:path'
 import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
+import {
+  customSlashCommandName,
+  dedupeCustomSlashCommands,
+  type DiscoveredSlashCommand
+} from '../../shared/custom-slash-commands'
 import type {
   DiscoveredSkill,
   SkillDiscoveryResult,
@@ -18,13 +23,20 @@ import {
 import { discoverClaudePluginSkillSourcesInWsl } from './claude-plugin-skill-sources-wsl'
 import type { SkillProviderRootOverrides } from './skill-provider-destinations'
 import { SKILL_STAGING_GLOB } from './skill-delete/staging-names'
-import { skillFileMaxDepth } from '../../shared/skill-discovery-depth'
+import { SKILL_FILE_MAX_DEPTH, skillFileMaxDepth } from '../../shared/skill-discovery-depth'
+import {
+  buildCustomSlashCommandRoots,
+  type CustomSlashCommandRoot
+} from './custom-slash-command-discovery'
 
 const MAX_MARKDOWN_BYTES = 256 * 1024
 const WSL_SCAN_TIMEOUT_MS = 10_000
 const WSL_SCAN_MAX_OUTPUT_BYTES = 128 * 1024 * 1024
 
-export function buildWslSkillDiscoveryCommand(roots: readonly SkillScanRoot[]): string {
+export function buildWslSkillDiscoveryCommand(
+  roots: readonly SkillScanRoot[],
+  commandRoots: readonly CustomSlashCommandRoot[] = []
+): string {
   const lines = [
     'set -u',
     'set -o pipefail',
@@ -47,9 +59,29 @@ export function buildWslSkillDiscoveryCommand(roots: readonly SkillScanRoot[]): 
     `  done < <(find -L "$root_path" -mindepth 1 -maxdepth "$max_depth" \\( -name '${SKILL_STAGING_GLOB}' -prune \\) -o \\( -type f -name 'SKILL.md' -print0 \\) 2>/dev/null)`,
     '}'
   ]
+  if (commandRoots.length > 0) {
+    lines.push(
+      'scan_command_root() {',
+      '  root_index=$1',
+      '  root_path=$2',
+      '  if [ ! -d "$root_path" ]; then',
+      '    return',
+      '  fi',
+      `  while IFS= read -r -d '' command_file; do`,
+      `    encoded_markdown=$(head -c ${MAX_MARKDOWN_BYTES} -- "$command_file" 2>/dev/null | base64 | tr -d '\\n') || continue`,
+      `    printf '%s\\0%s\\0%s\\0' C "$root_index" "$command_file"`,
+      `    printf '%s' "$encoded_markdown"`,
+      `    printf '\\0'`,
+      `  done < <(find -L "$root_path" -mindepth 1 -maxdepth ${SKILL_FILE_MAX_DEPTH} -type f -name '*.md' -print0 2>/dev/null)`,
+      '}'
+    )
+  }
   roots.forEach((root, index) => {
     const maxDepth = skillFileMaxDepth(root.sourceKind)
     lines.push(`scan_root ${index} ${quoteBashString(root.path)} ${maxDepth}`)
+  })
+  commandRoots.forEach((root, index) => {
+    lines.push(`scan_command_root ${index} ${quoteBashString(root.path)}`)
   })
   return lines.join('\n')
 }
@@ -87,15 +119,35 @@ function readProtocolField(fields: string[], index: number): string {
 export function parseWslSkillDiscoveryOutput(
   output: string,
   roots: readonly SkillScanRoot[],
-  scannedAt = Date.now()
+  scannedAt = Date.now(),
+  commandRoots: readonly CustomSlashCommandRoot[] = []
 ): SkillDiscoveryResult {
   const fields = output.split('\0')
   const rootExists = new Map<number, boolean>()
   const skillsByCanonicalPath = new Map<string, DiscoveredSkill>()
+  const commands: DiscoveredSlashCommand[] = []
   let index = 0
   while (index < fields.length && fields[index]) {
     const recordKind = fields[index++]
     const rootIndex = Number.parseInt(readProtocolField(fields, index++), 10)
+    if (recordKind === 'C') {
+      const commandRoot = commandRoots[rootIndex]
+      if (!commandRoot) {
+        throw new Error('WSL skill discovery returned an unknown source.')
+      }
+      const commandFilePath = readProtocolField(fields, index++)
+      const markdown = Buffer.from(readProtocolField(fields, index++), 'base64').toString('utf8')
+      const name = customSlashCommandName(pathPosix.relative(commandRoot.path, commandFilePath))
+      if (name) {
+        commands.push({
+          name,
+          description: summarizeSkillMarkdown(markdown).description,
+          scope: commandRoot.scope,
+          commandFilePath
+        })
+      }
+      continue
+    }
     const root = roots[rootIndex]
     if (!root) {
       throw new Error('WSL skill discovery returned an unknown source.')
@@ -166,7 +218,8 @@ export function parseWslSkillDiscoveryOutput(
     sources: sources.sort((a, b) =>
       a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
     ),
-    scannedAt
+    scannedAt,
+    commands: dedupeCustomSlashCommands(commands)
   }
 }
 
@@ -201,8 +254,16 @@ export async function discoverSkillsInWsl(args: {
     }),
     ...pluginRoots
   ]
+  const commandRoots = buildCustomSlashCommandRoots({
+    homeDir: args.homeDir,
+    cwd: args.cwd,
+    pathApi: pathPosix
+  })
   // Why: UNC traversal applies Windows casing and symlink rules. The distro
   // must own enumeration, metadata reads, and canonical path identity.
-  const output = await executeWslSkillDiscovery(args.distro, buildWslSkillDiscoveryCommand(roots))
-  return parseWslSkillDiscoveryOutput(output, roots)
+  const output = await executeWslSkillDiscovery(
+    args.distro,
+    buildWslSkillDiscoveryCommand(roots, commandRoots)
+  )
+  return parseWslSkillDiscoveryOutput(output, roots, undefined, commandRoots)
 }

--- a/src/main/skills/skill-root-file-walk.ts
+++ b/src/main/skills/skill-root-file-walk.ts
@@ -36,6 +36,17 @@ export async function findSkillFiles(
   maxDepth: number,
   signal?: AbortSignal
 ): Promise<string[]> {
+  return findRootFiles(rootPath, maxDepth, (name) => name === SKILL_FILE_NAME, signal)
+}
+
+/** The same bounded, symlink-guarded walk with a caller-chosen file predicate,
+ *  so slash-command roots do not need a second walker. */
+export async function findRootFiles(
+  rootPath: string,
+  maxDepth: number,
+  isMatch: (fileName: string) => boolean,
+  signal?: AbortSignal
+): Promise<string[]> {
   const out: string[] = []
   const visitedDirectoryPaths = new Set<string>()
   async function visit(dirPath: string): Promise<void> {
@@ -69,7 +80,7 @@ export async function findSkillFiles(
         continue
       }
       const entryPath = join(dirPath, entry.name)
-      if (entry.name === SKILL_FILE_NAME) {
+      if (isMatch(entry.name)) {
         if (entry.isFile()) {
           out.push(entryPath)
           continue

--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -113,7 +113,13 @@ vi.mock('./NativeChatComposerField', () => ({
   }
 }))
 vi.mock('./use-native-chat-skills', () => ({
-  useNativeChatSkills: () => ({ status: 'ready', skills: [], error: null, retry: () => {} })
+  useNativeChatSkills: () => ({
+    status: 'ready',
+    skills: [],
+    commands: [],
+    error: null,
+    retry: () => {}
+  })
 }))
 vi.mock('./use-native-chat-composer-attachments', () => ({
   useNativeChatComposerAttachments: (args: { isComposing: () => boolean }) => {

--- a/src/renderer/src/components/native-chat/native-chat-picker-items.ts
+++ b/src/renderer/src/components/native-chat/native-chat-picker-items.ts
@@ -1,7 +1,7 @@
 import type { DiscoveredSkill, SkillSourceKind } from '../../../../shared/skills'
 import type { SlashCommandSuggestion } from '../../../../shared/native-chat-slash-commands'
 import {
-  isSafeDisplayCharacter,
+  isTokenSafeName,
   stripUnsafeDisplayCharacters
 } from '../../../../shared/skill-display-text'
 import { compareBaseSensitivityLocaleText } from '@/lib/locale-text-collators'
@@ -56,8 +56,9 @@ export function buildNativeChatPickerItems(
     commands.map((command, index) => ({
       item: {
         kind: 'command' as const,
-        // Why: the name is the dispatch token and the catalog is curated, so
-        // it is inserted verbatim; only untrusted skill text gets sanitized.
+        // Why: the name is the dispatch token, and discovered `.claude/commands`
+        // names are already validated/sanitized where they join the catalog
+        // (mergeDiscoveredSlashCommands), so it is inserted verbatim here.
         id: `command:${command.name}`,
         name: command.name,
         description: command.description ? sanitizePickerText(command.description, 240) : undefined,
@@ -164,25 +165,12 @@ function isSubsequence(query: string, value: string): boolean {
   return false
 }
 
-// Why: the row's visual truncation is CSS; the name IS the inserted PTY token,
-// so it must never be sliced. Token safety instead rejects absurd lengths.
-const MAX_TOKEN_SAFE_NAME_LENGTH = 200
-
 function getSafeSkillName(skill: DiscoveredSkill): string | null {
-  if (isTokenSafe(skill.name)) {
+  if (isTokenSafeName(skill.name)) {
     return skill.name
   }
   const directoryName = skill.directoryPath.split(/[\\/]/).findLast(Boolean) ?? ''
-  return isTokenSafe(directoryName) ? directoryName : null
-}
-
-function isTokenSafe(value: string): boolean {
-  return (
-    value.length > 0 &&
-    value.length <= MAX_TOKEN_SAFE_NAME_LENGTH &&
-    !/\s/u.test(value) &&
-    [...value].every(isSafeDisplayCharacter)
-  )
+  return isTokenSafeName(directoryName) ? directoryName : null
 }
 
 function sanitizePickerText(value: string, maxLength: number): string {

--- a/src/renderer/src/components/native-chat/native-chat-structured-send-composition-clear.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-structured-send-composition-clear.test.tsx
@@ -58,7 +58,13 @@ vi.mock('@/lib/native-chat-telemetry', () => ({
   emitNativeChatSendClassified: vi.fn()
 }))
 vi.mock('./use-native-chat-skills', () => ({
-  useNativeChatSkills: () => ({ status: 'ready', skills: [], error: null, retry: () => {} })
+  useNativeChatSkills: () => ({
+    status: 'ready',
+    skills: [],
+    commands: [],
+    error: null,
+    retry: () => {}
+  })
 }))
 vi.mock('../dictation/dictation-control-events', () => ({
   dispatchDictationControl: vi.fn()

--- a/src/renderer/src/components/native-chat/use-native-chat-picker-state.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-picker-state.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import { renderHook } from '@testing-library/react'
+import { createRef } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DiscoveredSlashCommand } from '../../../../shared/custom-slash-commands'
+import { getVerifiedNativeChatCommands } from '../../../../shared/native-chat-agent-profiles'
+
+const discovery = vi.hoisted(() => ({ commands: [] as DiscoveredSlashCommand[] }))
+
+vi.mock('./use-native-chat-skills', () => ({
+  useNativeChatSkills: (_agent: string, _tabId: string, enabled: boolean) => ({
+    status: 'ready' as const,
+    skills: [],
+    commands: enabled ? discovery.commands : [],
+    error: null,
+    retry: () => {}
+  })
+}))
+vi.mock('@/lib/native-chat-telemetry', () => ({
+  emitNativeChatPickerItemAccepted: vi.fn(),
+  emitNativeChatPickerOpened: vi.fn(),
+  emitNativeChatSendClassified: vi.fn()
+}))
+
+import { useNativeChatPickerState } from './use-native-chat-picker-state'
+
+const CUSTOM_COMMAND: DiscoveredSlashCommand = {
+  name: 'opsx:apply',
+  description: 'Apply an OpenSpec change',
+  scope: 'project',
+  commandFilePath: '/repo/.claude/commands/opsx/apply.md'
+}
+
+function renderPicker(draft: string) {
+  return renderHook(
+    (props: { draft: string }) =>
+      useNativeChatPickerState({
+        agent: 'claude',
+        terminalTabId: 'tab-1',
+        draftScopeKey: 'pane-1',
+        draft: props.draft,
+        caret: props.draft.length,
+        agentCommands: getVerifiedNativeChatCommands('claude'),
+        textareaRef: createRef<HTMLTextAreaElement>(),
+        setDraft: vi.fn(),
+        setCaret: vi.fn(),
+        setActiveSuggestion: vi.fn()
+      }),
+    { initialProps: { draft } }
+  )
+}
+
+describe('useNativeChatPickerState custom slash commands', () => {
+  beforeEach(() => {
+    discovery.commands = [CUSTOM_COMMAND]
+  })
+
+  it('lists .claude/commands entries beside the curated built-ins', () => {
+    const { result } = renderPicker('/opsx')
+    const autocomplete = result.current.autocomplete
+    if (autocomplete.mode !== 'slash') {
+      throw new Error('expected the slash picker to open')
+    }
+    expect(
+      autocomplete.items.filter((item) => item.kind === 'command').map((item) => item.name)
+    ).toContain('opsx:apply')
+    expect(autocomplete.items.find((item) => item.name === 'opsx:apply')?.description).toBe(
+      'Apply an OpenSpec change'
+    )
+  })
+
+  it('keeps the built-in catalog when nothing was discovered', () => {
+    discovery.commands = []
+    const { result } = renderPicker('/cl')
+    const autocomplete = result.current.autocomplete
+    if (autocomplete.mode !== 'slash') {
+      throw new Error('expected the slash picker to open')
+    }
+    expect(autocomplete.items.map((item) => item.name)).toContain('clear')
+    expect(autocomplete.items.every((item) => item.kind === 'command')).toBe(true)
+    expect(autocomplete.items.map((item) => item.name)).not.toContain('opsx:apply')
+  })
+
+  it('classifies a discovered command as a command, not an unknown token', () => {
+    const { result } = renderPicker('/opsx:apply')
+    expect(result.current.classifySend('/opsx:apply')).toBe('command')
+  })
+
+  it('still classifies the command once arguments close the picker', () => {
+    const view = renderPicker('/opsx:apply')
+    expect(view.result.current.classifySend('/opsx:apply')).toBe('command')
+    // Typing a space ends the trigger token, so discovery goes idle — the
+    // retained catalog is what keeps the send from reading as prose.
+    view.rerender({ draft: '/opsx:apply now' })
+    expect(view.result.current.classifySend('/opsx:apply now')).toBe('command')
+  })
+
+  it('leaves an unrelated slash token unknown', () => {
+    const { result } = renderPicker('/nope')
+    expect(result.current.classifySend('/nope')).toBe('unknown-token')
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-picker-state.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-picker-state.ts
@@ -11,7 +11,11 @@ import {
 } from 'react'
 import type { AgentType } from '../../../../shared/agent-status-types'
 import { getNativeChatAgentProfile } from '../../../../shared/native-chat-agent-profiles'
-import type { SlashCommandSuggestion } from '../../../../shared/native-chat-slash-commands'
+import {
+  mergeDiscoveredSlashCommands,
+  type SlashCommandSuggestion
+} from '../../../../shared/native-chat-slash-commands'
+import type { DiscoveredSlashCommand } from '../../../../shared/custom-slash-commands'
 import {
   applyPickerSuggestion,
   classifyNativeChatSend,
@@ -72,6 +76,16 @@ export function useNativeChatPickerState(args: {
         ? beforeCaret.startsWith('/') && !/\s/.test(beforeCaret)
         : false
   const discovery = useNativeChatSkills(agent, terminalTabId, skillPickerTriggered)
+  // The one place curated built-ins and discovered `.claude/commands` become a
+  // single catalog, so the picker, send classification, and dispatch agree.
+  const commands = useMemo(
+    () => mergeDiscoveredSlashCommands(agentCommands, discovery.commands),
+    [agentCommands, discovery.commands]
+  )
+  // Why retained: discovery only runs while a `/` token is being typed, so the
+  // live list is empty by the time a completed command with arguments is sent —
+  // without this the send would be classified as an unknown token.
+  const discoveredCommandsRef = useRef<readonly DiscoveredSlashCommand[]>([])
   const listboxId = `native-chat-picker-${useId().replaceAll(':', '')}`
   const dismissalContext = `${draftScopeKey}:${agent}`
   const [dismissed, setDismissed] = useState<{ context: string; triggerKey: string } | null>(null)
@@ -82,13 +96,13 @@ export function useNativeChatPickerState(args: {
       deriveComposerAutocomplete(
         draft,
         caret,
-        agentCommands,
+        commands,
         discovery.skills,
         profile,
         discovery,
         dismissed?.context === dismissalContext ? dismissed.triggerKey : null
       ),
-    [agentCommands, caret, dismissalContext, dismissed, discovery, draft, profile]
+    [caret, commands, dismissalContext, dismissed, discovery, draft, profile]
   )
 
   useEffect(() => {
@@ -96,8 +110,15 @@ export function useNativeChatPickerState(args: {
     // is reused across pane/agent switches, so a stale dismissal must clear or
     // the picker stays closed for an in-progress token when that context returns.
     skillOriginRef.current = null
+    discoveredCommandsRef.current = []
     setDismissed(null)
   }, [dismissalContext])
+
+  useEffect(() => {
+    if (discovery.commands.length > 0) {
+      discoveredCommandsRef.current = discovery.commands
+    }
+  }, [discovery.commands])
 
   useEffect(() => {
     if (autocomplete.mode !== 'slash' && autocomplete.mode !== 'skill') {
@@ -149,7 +170,7 @@ export function useNativeChatPickerState(args: {
       const next = deriveComposerAutocomplete(
         value,
         nextCaret,
-        agentCommands,
+        commands,
         discovery.skills,
         profile,
         discovery
@@ -161,14 +182,14 @@ export function useNativeChatPickerState(args: {
         setDismissed(null)
       }
     },
-    [agentCommands, dismissalContext, dismissed, discovery, draft, profile]
+    [commands, dismissalContext, dismissed, discovery, draft, profile]
   )
 
   const classifySend = useCallback(
     (value: string) => {
       const outcome = classifyNativeChatSend(
         value,
-        agentCommands,
+        mergeDiscoveredSlashCommands(agentCommands, discoveredCommandsRef.current),
         skillOriginRef.current,
         profile?.skillPrefix ?? null
       )

--- a/src/renderer/src/components/native-chat/use-native-chat-skills.react.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-skills.react.test.tsx
@@ -51,8 +51,14 @@ function stateForHost(hostId: string) {
   }
 }
 
-function Probe({ enabled }: { enabled: boolean }): null {
-  mocks.snapshots.push(useNativeChatSkills('codex', 'tab-1', enabled))
+function Probe({
+  enabled,
+  agent = 'codex'
+}: {
+  enabled: boolean
+  agent?: 'codex' | 'claude'
+}): null {
+  mocks.snapshots.push(useNativeChatSkills(agent, 'tab-1', enabled))
   return null
 }
 
@@ -130,6 +136,53 @@ describe('useNativeChatSkills', () => {
       { cwd: '/repo/worktree', worktreeId: 'worktree-1' },
       { timeoutMs: 10_000 }
     )
+  })
+
+  it('exposes discovered .claude/commands to Claude-owned panes', async () => {
+    mocks.callRuntimeRpc.mockResolvedValue({
+      skills: [],
+      sources: [],
+      scannedAt: 1,
+      commands: [
+        {
+          name: 'opsx:apply',
+          description: 'Apply an OpenSpec change',
+          scope: 'project',
+          commandFilePath: '/repo/.claude/commands/opsx/apply.md'
+        }
+      ]
+    })
+    render(<Probe enabled agent="claude" />)
+
+    await waitFor(() => expect(mocks.snapshots.at(-1)?.status).toBe('ready'))
+    expect(mocks.snapshots.at(-1)?.commands.map((command) => command.name)).toEqual(['opsx:apply'])
+  })
+
+  it('withholds Claude command grammar from a Codex pane', async () => {
+    mocks.callRuntimeRpc.mockResolvedValue({
+      skills: [],
+      sources: [],
+      scannedAt: 1,
+      commands: [
+        {
+          name: 'opsx:apply',
+          description: null,
+          scope: 'project',
+          commandFilePath: '/repo/.claude/commands/opsx/apply.md'
+        }
+      ]
+    })
+    render(<Probe enabled />)
+
+    await waitFor(() => expect(mocks.snapshots.at(-1)?.status).toBe('ready'))
+    expect(mocks.snapshots.at(-1)?.commands).toEqual([])
+  })
+
+  it('tolerates a host that never scanned commands', async () => {
+    render(<Probe enabled agent="claude" />)
+
+    await waitFor(() => expect(mocks.snapshots.at(-1)?.status).toBe('ready'))
+    expect(mocks.snapshots.at(-1)?.commands).toEqual([])
   })
 
   it('surfaces discovery failure instead of remaining loading', async () => {

--- a/src/renderer/src/components/native-chat/use-native-chat-skills.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-skills.ts
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../store'
 import type { AgentType } from '../../../../shared/agent-status-types'
 import type { DiscoveredSkill, SkillDiscoveryResult } from '../../../../shared/skills'
+import type { DiscoveredSlashCommand } from '../../../../shared/custom-slash-commands'
 import { getNativeChatAgentProfile } from '../../../../shared/native-chat-agent-profiles'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import { emitNativeChatSkillDiscovery } from '@/lib/native-chat-telemetry'
@@ -28,14 +29,19 @@ const DISCOVERY_BACKSTOP_TIMEOUT_MS = 18_000
 export type NativeChatSkillDiscovery = {
   status: 'idle' | 'loading' | 'ready' | 'error'
   skills: DiscoveredSkill[]
+  /** Claude Code `.claude/commands` entries from the same scan; empty for agents
+   *  that do not read Claude-owned roots. */
+  commands: readonly DiscoveredSlashCommand[]
   error: Error | null
   errorKind?: 'unavailable' | 'timeout' | 'host' | 'unknown'
   retry: () => void
 }
 
-type StoredDiscoveryState = Omit<NativeChatSkillDiscovery, 'retry'> & {
+type StoredDiscoveryState = Omit<NativeChatSkillDiscovery, 'retry' | 'commands'> & {
   contextKey: string | null
 }
+
+const NO_COMMANDS: readonly DiscoveredSlashCommand[] = []
 
 const IDLE_STATE: StoredDiscoveryState = {
   status: 'idle',
@@ -201,6 +207,16 @@ export function useNativeChatSkills(
       : []
   }, [agent, context, effectiveState, profile])
 
+  // Why gated on the Claude-owned root set: `.claude/commands` is Claude Code
+  // grammar, so offering it under Codex would insert a token its TUI rejects.
+  const visibleCommands = useMemo(() => {
+    if (profile?.skillSourceOwner !== 'claude' || effectiveState.status !== 'ready') {
+      return NO_COMMANDS
+    }
+    const result = context ? paneDiscoveryCache.current.get(context.key) : undefined
+    return result?.commands ?? NO_COMMANDS
+  }, [context, effectiveState, profile])
+
   const retry = useCallback(() => {
     forceNextDiscovery.current = true
     if (context) {
@@ -213,11 +229,12 @@ export function useNativeChatSkills(
     () => ({
       status: effectiveState.status,
       skills: visibleSkills,
+      commands: visibleCommands,
       error: effectiveState.error,
       ...(effectiveState.errorKind ? { errorKind: effectiveState.errorKind } : {}),
       retry
     }),
-    [effectiveState, retry, visibleSkills]
+    [effectiveState, retry, visibleCommands, visibleSkills]
   )
 }
 

--- a/src/shared/custom-slash-commands.test.ts
+++ b/src/shared/custom-slash-commands.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  customSlashCommandName,
+  dedupeCustomSlashCommands,
+  sanitizeCustomSlashCommandDescription,
+  type DiscoveredSlashCommand
+} from './custom-slash-commands'
+
+function command(
+  name: string,
+  scope: DiscoveredSlashCommand['scope'],
+  commandFilePath = `/${name}.md`
+): DiscoveredSlashCommand {
+  return { name, description: null, scope, commandFilePath }
+}
+
+describe('customSlashCommandName', () => {
+  it('drops the .md extension for a top-level command', () => {
+    expect(customSlashCommandName('review.md')).toBe('review')
+  })
+
+  it('namespaces subdirectories with colons like Claude Code', () => {
+    expect(customSlashCommandName('opsx/apply.md')).toBe('opsx:apply')
+    expect(customSlashCommandName('git/pr/open.md')).toBe('git:pr:open')
+  })
+
+  it('accepts Windows separators', () => {
+    expect(customSlashCommandName('opsx\\apply.md')).toBe('opsx:apply')
+  })
+
+  it('ignores files that are not markdown', () => {
+    expect(customSlashCommandName('notes.txt')).toBeNull()
+    expect(customSlashCommandName('README')).toBeNull()
+  })
+
+  it('rejects names that cannot be typed back as one slash token', () => {
+    expect(customSlashCommandName('my command.md')).toBeNull()
+    expect(customSlashCommandName('bad‮name.md')).toBeNull()
+    expect(customSlashCommandName(`${'a'.repeat(201)}.md`)).toBeNull()
+  })
+})
+
+describe('sanitizeCustomSlashCommandDescription', () => {
+  it('strips control and bidi characters from author-controlled text', () => {
+    expect(sanitizeCustomSlashCommandDescription('safe‮desc')).toBe('safedesc')
+  })
+
+  it('bounds the description length', () => {
+    expect(sanitizeCustomSlashCommandDescription('x'.repeat(400))).toHaveLength(240)
+  })
+
+  it('returns undefined for empty or missing text', () => {
+    expect(sanitizeCustomSlashCommandDescription(null)).toBeUndefined()
+    expect(sanitizeCustomSlashCommandDescription('   ')).toBeUndefined()
+  })
+})
+
+describe('dedupeCustomSlashCommands', () => {
+  it('lets project scope shadow the user-level command of the same name', () => {
+    const merged = dedupeCustomSlashCommands([
+      command('apply', 'user', '/home/.claude/commands/apply.md'),
+      command('apply', 'project', '/repo/.claude/commands/apply.md')
+    ])
+    expect(merged).toHaveLength(1)
+    expect(merged[0].commandFilePath).toBe('/repo/.claude/commands/apply.md')
+  })
+
+  it('keeps user commands that the project does not define, sorted by name', () => {
+    const merged = dedupeCustomSlashCommands([command('zeta', 'user'), command('alpha', 'project')])
+    expect(merged.map((entry) => entry.name)).toEqual(['alpha', 'zeta'])
+  })
+})

--- a/src/shared/custom-slash-commands.ts
+++ b/src/shared/custom-slash-commands.ts
@@ -1,0 +1,58 @@
+// Claude Code custom slash commands: markdown files under `<repo>/.claude/commands`
+// and `~/.claude/commands`. The TUI lists them next to its built-ins, so Orca's
+// chat picker has to discover them rather than curate them.
+
+import { isTokenSafeName, stripUnsafeDisplayCharacters } from './skill-display-text'
+
+export type CustomSlashCommandScope = 'project' | 'user'
+
+export type DiscoveredSlashCommand = {
+  /** Invocation token without the leading slash, e.g. `opsx:apply`. */
+  name: string
+  description: string | null
+  scope: CustomSlashCommandScope
+  /** Absolute path of the markdown file that defines the command. */
+  commandFilePath: string
+}
+
+export const CUSTOM_SLASH_COMMAND_DESCRIPTION_MAX_LENGTH = 240
+
+/** `git/pr.md` -> `git:pr`. Subdirectories are the namespace, exactly as Claude
+ *  Code spells them. Null when the path cannot be typed back as a slash token. */
+export function customSlashCommandName(relativePath: string): string | null {
+  const segments = relativePath.split(/[\\/]+/).filter(Boolean)
+  const fileName = segments.pop()
+  if (!fileName || !/\.md$/i.test(fileName)) {
+    return null
+  }
+  const name = [...segments, fileName.slice(0, -'.md'.length)].join(':')
+  return isTokenSafeName(name) ? name : null
+}
+
+/** Frontmatter is author-controlled text rendered in the picker, so it is
+ *  stripped and bounded before it reaches a row. */
+export function sanitizeCustomSlashCommandDescription(
+  description: string | null | undefined
+): string | undefined {
+  if (!description) {
+    return undefined
+  }
+  const safe = stripUnsafeDisplayCharacters(description)
+    .slice(0, CUSTOM_SLASH_COMMAND_DESCRIPTION_MAX_LENGTH)
+    .trim()
+  return safe || undefined
+}
+
+/** Project scope shadows user scope on a name collision, matching Claude Code. */
+export function dedupeCustomSlashCommands(
+  commands: readonly DiscoveredSlashCommand[]
+): DiscoveredSlashCommand[] {
+  const byName = new Map<string, DiscoveredSlashCommand>()
+  for (const command of commands) {
+    const existing = byName.get(command.name)
+    if (!existing || (existing.scope === 'user' && command.scope === 'project')) {
+      byName.set(command.name, command)
+    }
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/src/shared/native-chat-slash-commands.test.ts
+++ b/src/shared/native-chat-slash-commands.test.ts
@@ -4,6 +4,7 @@ import {
   filterSlashCommands,
   getAgentSlashCommands,
   isSlashCommandDraft,
+  mergeDiscoveredSlashCommands,
   slashCommandDispatchText
 } from './native-chat-slash-commands'
 
@@ -62,5 +63,48 @@ describe('dispatch vs completion text', () => {
 
   it('completion text has a trailing space (Tab completes for arguments)', () => {
     expect(applySlashSuggestion({ name: 'model' })).toBe('/model ')
+  })
+})
+
+describe('mergeDiscoveredSlashCommands', () => {
+  const discovered = (name: string, description: string | null = null) => ({
+    name,
+    description,
+    scope: 'project' as const,
+    commandFilePath: `/repo/.claude/commands/${name}.md`
+  })
+
+  it('appends discovered commands to the curated catalog', () => {
+    const merged = mergeDiscoveredSlashCommands(getAgentSlashCommands('claude'), [
+      discovered('opsx:apply', 'Apply a change')
+    ])
+    expect(merged.map((command) => command.name)).toContain('opsx:apply')
+    expect(merged.find((command) => command.name === 'opsx:apply')?.description).toBe(
+      'Apply a change'
+    )
+  })
+
+  it('keeps the built-in when a custom command shadows its name', () => {
+    const merged = mergeDiscoveredSlashCommands(
+      [{ name: 'review', description: 'Review the current changes' }],
+      [discovered('review', 'Custom review')]
+    )
+    expect(merged).toHaveLength(1)
+    expect(merged[0].description).toBe('Review the current changes')
+  })
+
+  it('drops filesystem names that are not typeable as one slash token', () => {
+    const merged = mergeDiscoveredSlashCommands([], [discovered('two words')])
+    expect(merged).toHaveLength(0)
+  })
+
+  it('sanitizes author-controlled descriptions', () => {
+    const merged = mergeDiscoveredSlashCommands([], [discovered('opsx:apply', 'a‮b')])
+    expect(merged[0].description).toBe('ab')
+  })
+
+  it('returns the curated catalog untouched when nothing was discovered', () => {
+    const builtins = getAgentSlashCommands('claude')
+    expect(mergeDiscoveredSlashCommands(builtins, [])).toBe(builtins)
   })
 })

--- a/src/shared/native-chat-slash-commands.ts
+++ b/src/shared/native-chat-slash-commands.ts
@@ -5,6 +5,11 @@
 // Metro forces us to duplicate.
 
 import type { AgentType } from './agent-status-types'
+import {
+  sanitizeCustomSlashCommandDescription,
+  type DiscoveredSlashCommand
+} from './custom-slash-commands'
+import { isTokenSafeName } from './skill-display-text'
 
 export type SlashCommandSuggestion = {
   /** The command token without its leading slash, e.g. `clear`. */
@@ -88,6 +93,31 @@ const COMMANDS_BY_AGENT: Partial<Record<AgentType, readonly SlashCommandSuggesti
  *  `/` menu is never empty for a recognized agent. */
 export function getAgentSlashCommands(agent: AgentType): readonly SlashCommandSuggestion[] {
   return COMMANDS_BY_AGENT[agent] ?? COMMON_COMMANDS
+}
+
+/** Fold discovered `.claude/commands` entries into the curated catalog so the
+ *  picker, send classification, and dispatch all read one list. Built-ins win a
+ *  name collision because the TUI resolves them first, and discovered names are
+ *  filesystem-controlled, so they are validated here — the one merge point —
+ *  before any of them becomes an inserted token. */
+export function mergeDiscoveredSlashCommands(
+  builtins: readonly SlashCommandSuggestion[],
+  discovered: readonly DiscoveredSlashCommand[]
+): readonly SlashCommandSuggestion[] {
+  if (discovered.length === 0) {
+    return builtins
+  }
+  const seen = new Set(builtins.map((command) => command.name))
+  const merged = [...builtins]
+  for (const command of discovered) {
+    if (seen.has(command.name) || !isTokenSafeName(command.name)) {
+      continue
+    }
+    seen.add(command.name)
+    const description = sanitizeCustomSlashCommandDescription(command.description)
+    merged.push({ name: command.name, ...(description ? { description } : {}) })
+  }
+  return merged
 }
 
 /** Whether the draft is a slash command (leading `/`, ignoring leading space).

--- a/src/shared/skill-display-text.ts
+++ b/src/shared/skill-display-text.ts
@@ -24,3 +24,17 @@ export function isSafeDisplayCharacter(character: string): boolean {
 export function stripUnsafeDisplayCharacters(value: string): string {
   return [...value].filter(isSafeDisplayCharacter).join('')
 }
+
+// Why: the row's visual truncation is CSS; a picker name IS the token inserted
+// into the PTY, so it must never be sliced. Token safety instead rejects absurd
+// lengths and anything unspellable as a single argument-free token.
+export const MAX_TOKEN_SAFE_NAME_LENGTH = 200
+
+export function isTokenSafeName(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= MAX_TOKEN_SAFE_NAME_LENGTH &&
+    !/\s/u.test(value) &&
+    [...value].every(isSafeDisplayCharacter)
+  )
+}

--- a/src/shared/skills.ts
+++ b/src/shared/skills.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import type { AgentType } from './agent-status-types'
+import type { DiscoveredSlashCommand } from './custom-slash-commands'
 import type { ProjectExecutionRuntimeResolution } from './project-execution-runtime'
 
 export type SkillProvider = 'codex' | 'claude' | 'agent-skills'
@@ -40,6 +41,9 @@ export type SkillDiscoveryResult = {
   skills: DiscoveredSkill[]
   sources: SkillDiscoverySource[]
   scannedAt: number
+  /** Claude Code custom slash commands under the scanned workspace/home roots.
+   *  Optional so an older host that never scanned them stays wire compatible. */
+  commands?: DiscoveredSlashCommand[]
 }
 
 export type SkillDiscoveryTarget = {


### PR DESCRIPTION
## ELI5

Typing `/` in Chat UI showed the five built-in Claude commands and your skills, but not the commands you wrote yourself in `.claude/commands/`. Orca never looked in that folder. Now it does, and those commands show up in the same list and run when you pick them.

## What Changed

- **New discovery source (main):** `src/main/skills/custom-slash-command-discovery.ts` scans `<workspace>/.claude/commands/**/*.md` (project scope) and `~/.claude/commands/**/*.md` (user scope). Subdirectories are the namespace, exactly as Claude Code spells them: `commands/opsx/apply.md` → `/opsx:apply`. `description:` frontmatter becomes the row subtitle; project scope shadows user scope on a name collision.
- **Rides the existing scan:** `discoverSkills` already does a targeted, workspace-scoped pass for Claude plugin roots. Commands are collected on that same pass and returned on the existing `skills.discover` result as a **new optional** `commands` field — no new RPC, no new IPC channel, no second cache. Optional keeps it wire compatible with an older host that never scanned them (`docs/reference/remote-wire-compatibility.md`).
- **One merge point (renderer):** `mergeDiscoveredSlashCommands` in `src/shared/native-chat-slash-commands.ts` folds discovered commands into the curated catalog. `useNativeChatPickerState` calls it once, so the picker rows, `classifyNativeChatSend`, and Enter-to-dispatch all read a single list. Discovered entries are ordinary `kind: 'command'` picker items, so `useNativeChatPickerCommandDispatch` sends `/opsx:apply` to the PTY with no UI change at all.
- **WSL parity:** the distro-side scan emits command records next to its skill records, so path identity and symlink rules stay on the host that owns them.
- **Reuse, not a second implementation:** the directory walk is the existing `skill-root-file-walk` walker generalized with a file predicate; frontmatter parsing is the existing `summarizeSkillMarkdown`; the markdown head-read was lifted out of `discovery.ts` into `markdown-summary-read.ts` and shared; the picker's private `isTokenSafe` moved to `skill-display-text.ts` and is now used by both. No new dependency.

## Why

Two independent sources fed the picker and neither covered `.claude/commands`: `CLAUDE_COMMANDS` in `src/shared/native-chat-slash-commands.ts` is a curated list of five, and every root in `skill-discovery-sources.ts` is a `skills/` root. A search for `.claude/commands` returned zero results repo-wide — the commands were never in the catalog, so this was a discovery gap, not a ranking or truncation one (distinct from #14690).

Merging into the existing command catalog rather than adding a second list to the UI is what makes selection actually work: the picker's Enter path dispatches `kind: 'command'` items, and `classifyNativeChatSend` uses the same list to decide a slash draft is a control action rather than a chat turn that deserves an optimistic bubble.

**Security:** command names come from disk and become the token inserted into the PTY, so they are validated as typeable single tokens (no whitespace, no control/bidi/zero-width codepoints, bounded length) and descriptions are stripped and length-bounded — at the merge point, which is the one place discovered data enters the catalog.

**Performance:** the scan only runs on the workspace-targeted discovery the picker already triggers, is coalesced/TTL-cached per root like skill roots, and is skipped entirely for untargeted Settings inventory scans.

## Linked Issue

Fixes #17697

## Visual Proof

I do not have a signed Orca build or the reporter's Windows environment available, so I could not capture a before/after recording. The change is covered end to end by tests instead, including one that asserts the discovered command appears as a picker row with its frontmatter description:

- Before: `/opsx` in Chat UI renders only the Skills section (see the screenshots in #17697).
- After: `buildNativeChatPickerItems` receives `opsx:apply` in the command list, so it renders under the existing **Commands** heading with `Apply an OpenSpec change` as the subtitle — the same row component and styling as the built-ins, no new UI. Asserted in `use-native-chat-picker-state.test.tsx`.

Happy to add a recording if a maintainer can run it on a build.

## Testing

Reproduce manually: create `.claude/commands/opsx/apply.md` with a `description:` frontmatter line in any repo, open a Claude Code session with Chat UI enabled, type `/opsx` — the command now appears under Commands and Enter dispatches `/opsx:apply`.

Automated (new/updated):

- `src/shared/custom-slash-commands.test.ts` — namespacing (`opsx/apply.md`, `git/pr/open.md`, Windows separators), non-markdown rejection, unsafe/untypeable name rejection, description sanitization, project-shadows-user precedence.
- `src/shared/native-chat-slash-commands.test.ts` — merge semantics: built-ins win a name collision, unsafe names dropped, descriptions sanitized, curated catalog returned untouched when nothing was discovered.
- `src/main/skills/custom-slash-command-discovery.test.ts` — real tmpdir fixtures: roots, nested namespacing, frontmatter description, user + project merge, non-markdown and skill roots ignored, missing root, symlinked commands directory.
- `src/main/skills/discovery.test.ts` — commands present on a targeted workspace scan, empty on an untargeted inventory scan.
- `src/main/skills/skill-discovery-wsl-script-roundtrip.test.ts` — the real generated bash script's stdout parsed by the real parser, so the NUL protocol cannot drift.
- `src/renderer/src/components/native-chat/use-native-chat-skills.react.test.tsx` — commands surface for Claude-owned panes, are withheld from Codex panes, and a host that never scanned them degrades to empty.
- `src/renderer/src/components/native-chat/use-native-chat-picker-state.test.tsx` — discovered command renders as a picker row with its description, and is classified as `command` (not `unknown-token`) both bare and with arguments.

Verified locally on Linux: `typecheck:node`, `typecheck:web`, `typecheck:cli`, `oxlint`, `oxfmt`, and `vitest run src/main/skills src/shared src/renderer/src/components/native-chat src/main/runtime/rpc/methods/skills.test.ts src/relay src/cli/handlers` (only pre-existing `node-pty` native-module failures, unrelated to this change — my sandbox cannot compile it). Windows/WSL paths are built through `buildCustomSlashCommandRoots` with the injected path API (`node:path` natively, `path.posix` for WSL), never raw string joins.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

This PR was written by Claude (Opus 5) running as an autonomous agent, and reviewed before submission. The analysis, design (single merge point, wire-compatible optional field), implementation, and tests are all AI-authored.

## Review

Known scope limits, called out deliberately rather than guessed at:

- **Plugin-contributed commands are not included.** The issue lists them under expected behavior, but a plugin command's invocation token is `/<plugin>:<command>`, and emitting a name I could not verify against a real plugin install would insert a token the TUI rejects — worse than omitting it. Easy follow-up once the exact namespacing is confirmed; the roots list is the only place it needs to be added.
- **`argument-hint:` frontmatter is parsed but not surfaced**, since the picker row has no slot for it today.
- **SSH hosts get no commands**, matching how skill discovery already reports SSH as unavailable.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security:** covered above — filesystem-controlled names/descriptions are validated and sanitized at the single merge point before becoming a row or a PTY token.
- **Cross-platform:** path building goes through an injected path API; WSL uses `path.posix` and the distro-side scan. No raw separators.
- **Remote SSH:** unchanged (already reported unavailable for discovery).
- **Mobile:** unchanged. The shared catalog module stays pure data + string helpers with no Node imports, so Metro still resolves it; mobile simply passes no discovered commands.
- **Backwards compatibility:** `commands` is a new optional field on an existing RPC result. An old host omits it and the renderer degrades to the curated catalog; a new host sending it to an old client is ignored.
- **Performance:** workspace-targeted scans only, coalesced and TTL-cached per root, skipped for Settings inventory scans.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
