### PR TITLE
test(updater): stop a slow module import from failing the next test

### DIFF
--- a/src/main/updater-linux-package-recovery-actions.test.ts
+++ b/src/main/updater-linux-package-recovery-actions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { UpdateStatus } from '../shared/update-status-types'
 import type * as UpdaterModule from './updater'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   appMock,
@@ -95,6 +96,8 @@ const ARTIFACT = {
   sha512: 'LHlL7dKoqg98gS2nfQv878dK+UoktbAkm4M20/hoJ2Qr0Kqsa3MSL4VmWy/Lll/MYjQFkpvOxduQ/vswentozA=='
 }
 
+warmUpdaterModule()
+
 describe('linux package recovery actions', () => {
   afterEach(() => {
     vi.useRealTimers()
@@ -125,7 +128,7 @@ describe('linux package recovery actions', () => {
     updater: typeof UpdaterModule
   }> => {
     const send = vi.fn()
-    const updater = await import('./updater')
+    const updater = await loadUpdaterModule()
     updater.setupAutoUpdater({ webContents: { send } } as never, {
       getLastUpdateCheckAt: () => Date.now()
     })

--- a/src/main/updater-test-harness.leaked-timers.test.ts
+++ b/src/main/updater-test-harness.leaked-timers.test.ts
@@ -1,6 +1,7 @@
 import { setTimeout as sleep } from 'node:timers/promises'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Mock } from 'vitest'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const { autoUpdaterMock, fetchNewerReleaseTagsMock, moduleFactories, resetUpdaterMocks } =
   await vi.hoisted(async () => (await import('./updater-test-harness')).createUpdaterMocks())
@@ -21,6 +22,8 @@ vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBui
 
 const SILENT_SETTLE_DELAY_MS = 1_000
 const AUTO_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+warmUpdaterModule()
 
 describe('updater test harness real-timer tracking', () => {
   beforeEach(() => {
@@ -79,7 +82,7 @@ describe('abandoned updater instance', () => {
     })
     leakedStatusSend = vi.fn()
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater({ webContents: { send: leakedStatusSend } } as never, {
       getLastUpdateCheckAt: () => Date.now() - 25 * 60 * 60 * 1000

--- a/src/main/updater-test-module-loader.test.ts
+++ b/src/main/updater-test-module-loader.test.ts
@@ -1,0 +1,32 @@
+import { setTimeout as sleep } from 'node:timers/promises'
+import { afterAll, describe, expect, it, vi } from 'vitest'
+import { loadUpdaterModule } from './updater-test-module-loader'
+
+// Why: this pair depends on running in file order — the first test starts an import it never awaits,
+// standing in for a test whose `await loadUpdaterModule()` outran `testTimeout`, and the second test
+// is the later test the continuation used to land in.
+describe('updater module loader', () => {
+  let outcome: Promise<string> = Promise.resolve('not started')
+
+  afterAll(() => {
+    vi.doUnmock('./updater')
+    vi.resetModules()
+  })
+
+  it('starts an import that outlives the test that asked for it', () => {
+    vi.resetModules()
+    vi.doMock('./updater', async () => {
+      await sleep(50)
+      return { setupAutoUpdater: () => {} }
+    })
+
+    outcome = loadUpdaterModule().then(
+      () => 'handed the module over',
+      (error: Error) => error.message
+    )
+  })
+
+  it('refuses to hand the module to a test that already ended', async () => {
+    await expect(outcome).resolves.toContain('resolved after that test ended')
+  })
+})

--- a/src/main/updater-test-module-loader.test.ts
+++ b/src/main/updater-test-module-loader.test.ts
@@ -16,7 +16,7 @@ describe('updater module loader', () => {
   it('starts an import that outlives the test that asked for it', () => {
     vi.resetModules()
     vi.doMock('./updater', async () => {
-      await sleep(50)
+      await sleep(500)
       return { setupAutoUpdater: () => {} }
     })
 

--- a/src/main/updater-test-module-loader.ts
+++ b/src/main/updater-test-module-loader.ts
@@ -1,0 +1,42 @@
+import { beforeAll, expect } from 'vitest'
+import type * as UpdaterModule from './updater'
+import { trackRealTimers } from './updater-test-timer-tracking'
+
+/**
+ * Pays `updater.ts`'s transform cost once per file, against `hookTimeout` instead of `testTimeout`.
+ *
+ * Why: the module is ~2.4k lines and pulls in a wide graph, so a worker's first import of it costs
+ * ~1.4s idle but 45s+ on an oversubscribed machine — past the 30s `testTimeout`. `vi.resetModules()`
+ * re-evaluates the module without re-transforming it, so only a file's *first* import is exposed;
+ * warming it in a hook moves that one slow import onto the 60s hook budget and leaves every in-test
+ * import at re-evaluation cost (~25ms idle).
+ */
+export function warmUpdaterModule(): void {
+  beforeAll(async () => {
+    // Why: no reset has installed the tracker yet, so a timer armed while warming would outlive it.
+    trackRealTimers()
+    await import('./updater')
+  })
+}
+
+/**
+ * Imports `./updater`, refusing to hand the module to a test that has already ended.
+ *
+ * Why: vitest cannot cancel a timed-out test body. When the import outran `testTimeout` the
+ * continuation went on to call `setupAutoUpdater` during the *next* test, failing it with
+ * "expected 1 times, but got 2 times" — the exact signature of the abandoned-instance timer flake
+ * fixed in #17649/#17663, so the timeout read as that regression returning. Throwing here strands the
+ * continuation and leaves the timeout as the only reported failure.
+ */
+export async function loadUpdaterModule(): Promise<typeof UpdaterModule> {
+  const owner = expect.getState().currentTestName
+  const module = await import('./updater')
+  const current = expect.getState().currentTestName
+  if (owner !== undefined && owner !== current) {
+    throw new Error(
+      `updater import requested by "${owner}" resolved after that test ended (now running ` +
+        `"${String(current)}"). The test timed out mid-import; fix that timeout, not the assertions.`
+    )
+  }
+  return module
+}

--- a/src/main/updater-test-module-loader.ts
+++ b/src/main/updater-test-module-loader.ts
@@ -1,6 +1,5 @@
-import { beforeAll, expect } from 'vitest'
+import { beforeAll, TestRunner } from 'vitest'
 import type * as UpdaterModule from './updater'
-import { trackRealTimers } from './updater-test-timer-tracking'
 
 /**
  * Pays `updater.ts`'s transform cost once per file, against `hookTimeout` instead of `testTimeout`.
@@ -13,8 +12,6 @@ import { trackRealTimers } from './updater-test-timer-tracking'
  */
 export function warmUpdaterModule(): void {
   beforeAll(async () => {
-    // Why: no reset has installed the tracker yet, so a timer armed while warming would outlive it.
-    trackRealTimers()
     await import('./updater')
   })
 }
@@ -29,14 +26,16 @@ export function warmUpdaterModule(): void {
  * continuation and leaves the timeout as the only reported failure.
  */
 export async function loadUpdaterModule(): Promise<typeof UpdaterModule> {
-  const owner = expect.getState().currentTestName
+  const owner = TestRunner.getCurrentTest()
   const module = await import('./updater')
-  const current = expect.getState().currentTestName
-  if (owner !== undefined && owner !== current) {
-    throw new Error(
-      `updater import requested by "${owner}" resolved after that test ended (now running ` +
-        `"${String(current)}"). The test timed out mid-import; fix that timeout, not the assertions.`
+  if (owner !== undefined && TestRunner.getCurrentTest() !== owner) {
+    // Why: vitest has already settled the timed-out test's promise, so this throw is swallowed —
+    // warn separately or the reason the continuation was stranded reaches nobody.
+    process.emitWarning(
+      `updater import requested by "${owner.name}" resolved after that test ended. The test timed ` +
+        `out mid-import; fix that timeout, not the assertions.`
     )
+    throw new Error(`updater import for "${owner.name}" resolved after that test ended`)
   }
   return module
 }

--- a/src/main/updater.build-channel-selection.test.ts
+++ b/src/main/updater.build-channel-selection.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   appMock,
@@ -27,6 +28,8 @@ vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBui
 /** Mirrors AUTO_UPDATE_CHECK_INTERVAL_MS in updater.ts. */
 const AUTO_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
 
+warmUpdaterModule()
+
 describe('updater', () => {
   beforeEach(() => {
     resetUpdaterMocks()
@@ -54,7 +57,7 @@ describe('updater', () => {
       const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
       try {
         const send = vi.fn()
-        const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+        const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
         setupAutoUpdater({ webContents: { send } } as never, {
           getLastUpdateCheckAt: () => Date.now()
         })
@@ -83,7 +86,7 @@ describe('updater', () => {
     try {
       appMock.getVersion.mockReturnValue('1.4.160')
       const send = vi.fn()
-      const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+      const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
       setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now()
       })
@@ -113,7 +116,7 @@ describe('updater', () => {
       try {
         appMock.getVersion.mockReturnValue('1.4.160-hourly.202607281400')
         const send = vi.fn()
-        const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+        const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
         setupAutoUpdater({ webContents: { send } } as never, {
           getLastUpdateCheckAt: () => Date.now()
         })
@@ -146,7 +149,7 @@ describe('updater', () => {
         return Promise.resolve(undefined)
       })
       const send = vi.fn()
-      const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+      const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
       setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now()
       })
@@ -199,7 +202,7 @@ describe('updater', () => {
       chooseLocalBuildMock.mockRejectedValue(new Error('invalid local build'))
       const send = vi.fn()
       const { setupAutoUpdater, checkForUpdates, checkForUpdatesFromMenu } =
-        await import('./updater')
+        await loadUpdaterModule()
       setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now()
       })
@@ -242,7 +245,7 @@ describe('updater', () => {
       })
       const send = vi.fn()
       const { setupAutoUpdater, checkForUpdates, checkForUpdatesFromMenu } =
-        await import('./updater')
+        await loadUpdaterModule()
       setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now()
       })
@@ -281,7 +284,7 @@ describe('updater', () => {
       autoUpdaterMock.checkForUpdates.mockRejectedValueOnce(new Error('local feed failed'))
       const send = vi.fn()
       const { setupAutoUpdater, checkForUpdates, checkForUpdatesFromMenu } =
-        await import('./updater')
+        await loadUpdaterModule()
       setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now()
       })
@@ -327,7 +330,7 @@ describe('updater', () => {
       autoUpdaterMock.downloadUpdate.mockRejectedValue(new Error('local download failed'))
       const send = vi.fn()
       const { setupAutoUpdater, checkForUpdatesFromMenu, downloadUpdate } =
-        await import('./updater')
+        await loadUpdaterModule()
       setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now()
       })
@@ -382,7 +385,7 @@ describe('updater', () => {
       })
       const send = vi.fn()
       const { setupAutoUpdater, checkForUpdates, checkForUpdatesFromMenu, dismissAvailableUpdate } =
-        await import('./updater')
+        await loadUpdaterModule()
       setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now()
       })
@@ -429,7 +432,7 @@ describe('updater', () => {
       autoUpdaterMock.downloadUpdate.mockResolvedValue(undefined)
       const send = vi.fn()
       const { setupAutoUpdater, checkForUpdatesFromMenu, dismissAvailableUpdate, downloadUpdate } =
-        await import('./updater')
+        await loadUpdaterModule()
       setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now()
       })
@@ -461,7 +464,7 @@ describe('updater', () => {
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
     const mainWindow = { webContents: { send: vi.fn() } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     // Why: recent timestamp defers the startup check so we observe updater state before any RC-mode call, without racing.
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
@@ -490,7 +493,7 @@ describe('updater', () => {
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
     const mainWindow = { webContents: { send: vi.fn() } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
 
@@ -517,7 +520,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     const setupFeedUrlCalls = autoUpdaterMock.setFeedURL.mock.calls.length
@@ -548,7 +551,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
 
@@ -582,7 +585,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu({ includePrerelease: true })
@@ -604,7 +607,7 @@ describe('updater', () => {
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
     const mainWindow = { webContents: { send: vi.fn() } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     const initialFeedUrlCalls = autoUpdaterMock.setFeedURL.mock.calls.length

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { installNetRequestFetchAdapter } from './updater-net-request.fixture'
 import { publishingIncident } from './updater-prerelease-feed-reproduction.fixture'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const { netFetchMock, netRequestMock } = vi.hoisted(() => ({
   netFetchMock: vi.fn(),
@@ -157,6 +158,8 @@ function makeBenignCheckFailure(message: string): void {
   })
 }
 
+warmUpdaterModule()
+
 describe('updater check failure handling', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -188,7 +191,7 @@ describe('updater check failure handling', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -222,7 +225,7 @@ describe('updater check failure handling', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -264,7 +267,7 @@ describe('updater check failure handling', () => {
       const warnMock = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
       const sendMock = vi.fn()
       const mainWindow = { webContents: { send: sendMock } }
-      const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+      const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
       setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
       checkForUpdatesFromMenu()
@@ -290,7 +293,7 @@ describe('updater check failure handling', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdates } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdates } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdates()
@@ -322,7 +325,7 @@ describe('updater check failure handling', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdates, getUpdateStatus } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdates, getUpdateStatus } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdates()
@@ -348,7 +351,7 @@ describe('updater check failure handling', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdates } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdates } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdates()

--- a/src/main/updater.check-preflight.test.ts
+++ b/src/main/updater.check-preflight.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   appMock,
@@ -23,6 +24,8 @@ vi.mock('./updater-prerelease-feed', () => moduleFactories.updaterPrereleaseFeed
 vi.mock('./local-builds/local-build-switch', () => moduleFactories.localBuildSwitch())
 vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBuildFeedServer())
 
+warmUpdaterModule()
+
 describe('updater', () => {
   beforeEach(() => {
     resetUpdaterMocks()
@@ -43,7 +46,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -98,7 +101,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -151,7 +154,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -208,7 +211,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -250,7 +253,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -293,7 +296,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -336,7 +339,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -368,7 +371,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -409,7 +412,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     appMock.getVersion.mockReturnValue('1.4.35')
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
@@ -466,7 +469,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
     checkForUpdatesFromMenu()
@@ -515,7 +518,7 @@ describe('updater', () => {
     autoUpdaterMock.checkForUpdates.mockImplementation(() => new Promise(() => {}))
     const mainWindow = { webContents: { send: vi.fn() } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()

--- a/src/main/updater.check-settlement.test.ts
+++ b/src/main/updater.check-settlement.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   autoUpdaterMock,
@@ -23,6 +24,8 @@ vi.mock('./updater-prerelease-feed', () => moduleFactories.updaterPrereleaseFeed
 vi.mock('./local-builds/local-build-switch', () => moduleFactories.localBuildSwitch())
 vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBuildFeedServer())
 
+warmUpdaterModule()
+
 describe('updater', () => {
   beforeEach(() => {
     resetUpdaterMocks()
@@ -36,7 +39,7 @@ describe('updater', () => {
     })
     const send = vi.fn()
     const { setupAutoUpdater, checkForUpdatesFromMenu, dismissAvailableUpdate } =
-      await import('./updater')
+      await loadUpdaterModule()
     setupAutoUpdater({ webContents: { send } } as never, {
       getLastUpdateCheckAt: () => Date.now()
     })
@@ -68,7 +71,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -99,7 +102,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -142,7 +145,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -180,7 +183,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
 
@@ -217,7 +220,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
     checkForUpdatesFromMenu()
@@ -248,7 +251,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
 
@@ -281,7 +284,7 @@ describe('updater', () => {
     const setLastUpdateCheckAt = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now(),
@@ -308,7 +311,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => null,
@@ -337,7 +340,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()

--- a/src/main/updater.headless-serve-install.test.ts
+++ b/src/main/updater.headless-serve-install.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   appMock,
@@ -104,6 +105,8 @@ vi.mock('./serve-update-handoff', () => ({
   requestServeUpdateHandoff: requestServeUpdateHandoffMock
 }))
 
+warmUpdaterModule()
+
 describe('headless serve update install handoff', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -152,7 +155,7 @@ describe('headless serve update install handoff', () => {
     })
     killAllPtyMock.mockImplementation(beginSessionCleanup)
 
-    const { checkForUpdatesFromMenu, quitAndInstall, setupAutoUpdater } = await import('./updater')
+    const { checkForUpdatesFromMenu, quitAndInstall, setupAutoUpdater } = await loadUpdaterModule()
     setupAutoUpdater(
       { webContents: { send } } as never,
       {
@@ -226,7 +229,7 @@ describe('headless serve update install handoff', () => {
       return Promise.resolve(null)
     })
 
-    const { checkForUpdatesFromMenu, downloadUpdate, setupAutoUpdater } = await import('./updater')
+    const { checkForUpdatesFromMenu, downloadUpdate, setupAutoUpdater } = await loadUpdaterModule()
     setupAutoUpdater({ webContents: { send } } as never, {
       getLastUpdateCheckAt: () => Date.now(),
       installMode: 'unsupported-headless-serve'
@@ -283,7 +286,7 @@ describe('headless serve update install handoff', () => {
     killAllPtyMock.mockImplementation(() => lifecycle.push('in-process-pty-cleanup'))
 
     const { checkForUpdatesFromMenu, downloadUpdate, quitAndInstall, setupAutoUpdater } =
-      await import('./updater')
+      await loadUpdaterModule()
     setupAutoUpdater({ webContents: { send } } as never, {
       getLastUpdateCheckAt: () => Date.now(),
       installMode: 'supervised-headless-serve',
@@ -330,7 +333,7 @@ describe('headless serve update install handoff', () => {
       return Promise.resolve(null)
     })
 
-    const { checkForUpdatesFromMenu, quitAndInstall, setupAutoUpdater } = await import('./updater')
+    const { checkForUpdatesFromMenu, quitAndInstall, setupAutoUpdater } = await loadUpdaterModule()
     setupAutoUpdater({ webContents: { send } } as never, {
       getLastUpdateCheckAt: () => Date.now(),
       installMode: 'supervised-headless-serve'
@@ -368,7 +371,7 @@ describe('headless serve update install handoff', () => {
         return Promise.resolve(null)
       })
 
-      const { checkForUpdatesFromMenu, setupAutoUpdater } = await import('./updater')
+      const { checkForUpdatesFromMenu, setupAutoUpdater } = await loadUpdaterModule()
       setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now(),
         installMode: 'unsupported-headless-serve'
@@ -416,7 +419,7 @@ describe('headless serve update install handoff', () => {
         return Promise.resolve(null)
       })
 
-      const { checkForUpdatesFromMenu, setupAutoUpdater } = await import('./updater')
+      const { checkForUpdatesFromMenu, setupAutoUpdater } = await loadUpdaterModule()
       setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now(),
         installMode: 'unsupported-headless-serve'
@@ -446,7 +449,7 @@ describe('headless serve update install handoff', () => {
       })
 
       const { checkForUpdatesFromMenu, quitAndInstall, setupAutoUpdater } =
-        await import('./updater')
+        await loadUpdaterModule()
       setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now(),
         installMode: 'unsupported-headless-serve'
@@ -481,7 +484,7 @@ describe('headless serve update install handoff', () => {
       downloadUpdate,
       getRemoteServerUpdateSupport,
       setupAutoUpdater
-    } = await import('./updater')
+    } = await loadUpdaterModule()
     setupAutoUpdater({ webContents: { send } } as never, {
       getLastUpdateCheckAt: () => Date.now(),
       installMode: 'interactive'
@@ -507,7 +510,7 @@ describe('headless serve update install handoff', () => {
 
   it('advertises remote update control only for safely restartable installs', async () => {
     const { checkForRemoteServerUpdate, getRemoteServerUpdateSupport, setupAutoUpdater } =
-      await import('./updater')
+      await loadUpdaterModule()
     setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
       getLastUpdateCheckAt: () => Date.now(),
       installMode: 'unsupported-headless-serve'

--- a/src/main/updater.install-failure-cause.test.ts
+++ b/src/main/updater.install-failure-cause.test.ts
@@ -2,6 +2,7 @@ import os from 'node:os'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as TracerModule from './observability/tracer'
 import type * as UpdaterModule from './updater'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   appMock,
@@ -145,7 +146,7 @@ async function reachDownloaded(): Promise<typeof UpdaterModule> {
   // same tracer instance updater.ts will import.
   tracer = await import('./observability/tracer')
   tracer.setActiveSink(capturingSink())
-  const updater = await import('./updater')
+  const updater = await loadUpdaterModule()
 
   updater.setupAutoUpdater(mainWindow as never)
   await vi.waitFor(() => {
@@ -165,6 +166,8 @@ async function reachDownloaded(): Promise<typeof UpdaterModule> {
  * recovers the app state, so the payload has to survive on the status and the span has to exit
  * Failure — otherwise the only record of why the install never ran is destroyed (#11906).
  */
+warmUpdaterModule()
+
 describe('quitAndInstall failure carries the updater cause', () => {
   beforeEach(() => {
     vi.resetModules()

--- a/src/main/updater.install-failure-cause.test.ts
+++ b/src/main/updater.install-failure-cause.test.ts
@@ -160,14 +160,14 @@ async function reachDownloaded(): Promise<typeof UpdaterModule> {
   return updater
 }
 
+warmUpdaterModule()
+
 /**
  * On a `.deb` Linux host electron-updater's `install()` catches the failed elevation and
  * re-dispatches it through the 'error' event *synchronously* inside `quitAndInstall()`. Orca
  * recovers the app state, so the payload has to survive on the status and the span has to exit
  * Failure — otherwise the only record of why the install never ran is destroyed (#11906).
  */
-warmUpdaterModule()
-
 describe('quitAndInstall failure carries the updater cause', () => {
   beforeEach(() => {
     vi.resetModules()

--- a/src/main/updater.linux-root-package-install.test.ts
+++ b/src/main/updater.linux-root-package-install.test.ts
@@ -7,6 +7,7 @@ import type * as UpdaterModule from './updater'
 import type * as RecoveryModule from './linux-package-update-recovery'
 import type { UpdateStatus } from '../shared/update-status-types'
 import { PRE_COMMIT_INSTALL_FAILURE } from './updater-test-harness'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   browserWindowMock,
@@ -166,6 +167,8 @@ function probeRevalidation(): RevalidationProbe {
   }
 }
 
+warmUpdaterModule()
+
 describe('updater', () => {
   beforeEach(() => {
     resetUpdaterMocks()
@@ -239,7 +242,7 @@ describe('updater', () => {
         return Promise.resolve(undefined)
       })
       const send = vi.fn()
-      const updater = await import('./updater')
+      const updater = await loadUpdaterModule()
       updater.setupAutoUpdater({ webContents: { send } } as never, {
         getLastUpdateCheckAt: () => Date.now()
       })
@@ -267,7 +270,7 @@ describe('updater', () => {
         vi.resetModules()
         autoUpdaterMock.autoInstallOnAppQuit = true
         getLinuxRootPackageTypeMock.mockReturnValue(packageType)
-        const { setupAutoUpdater } = await import('./updater')
+        const { setupAutoUpdater } = await loadUpdaterModule()
 
         setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
           getLastUpdateCheckAt: () => Date.now(),
@@ -280,7 +283,7 @@ describe('updater', () => {
 
     it('keeps interactive install-on-quit when no root-package marker is present', async () => {
       autoUpdaterMock.autoInstallOnAppQuit = false
-      const { setupAutoUpdater } = await import('./updater')
+      const { setupAutoUpdater } = await loadUpdaterModule()
 
       setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
         getLastUpdateCheckAt: () => Date.now(),
@@ -297,7 +300,7 @@ describe('updater', () => {
       ] as const) {
         vi.resetModules()
         autoUpdaterMock.autoInstallOnAppQuit = true
-        const { setupAutoUpdater } = await import('./updater')
+        const { setupAutoUpdater } = await loadUpdaterModule()
 
         setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
           getLastUpdateCheckAt: () => Date.now(),

--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   appMock,
@@ -117,6 +118,8 @@ vi.mock('./updater-nudge', () => ({
   shouldApplyNudge: vi.fn().mockReturnValue(false)
 }))
 
+warmUpdaterModule()
+
 describe('updater mac install handoff', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -142,7 +145,7 @@ describe('updater mac install handoff', () => {
       const mainWindow = { webContents: { send: sendMock } }
 
       autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
-      const { setupAutoUpdater } = await import('./updater')
+      const { setupAutoUpdater } = await loadUpdaterModule()
 
       setupAutoUpdater(mainWindow as never)
       await vi.waitFor(() => {
@@ -194,7 +197,7 @@ describe('updater mac install handoff', () => {
       const mainWindow = { webContents: { send: vi.fn() } }
 
       autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
-      const { setupAutoUpdater, quitAndInstall } = await import('./updater')
+      const { setupAutoUpdater, quitAndInstall } = await loadUpdaterModule()
 
       setupAutoUpdater(mainWindow as never, { onBeforeQuit })
       await vi.waitFor(() => {
@@ -276,7 +279,7 @@ describe('updater mac install handoff', () => {
       const mainWindow = { webContents: { send: sendMock } }
 
       autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
-      const { setupAutoUpdater } = await import('./updater')
+      const { setupAutoUpdater } = await loadUpdaterModule()
 
       setupAutoUpdater(mainWindow as never)
       await vi.waitFor(() => {

--- a/src/main/updater.nudge-campaign.test.ts
+++ b/src/main/updater.nudge-campaign.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   appMock,
@@ -24,6 +25,8 @@ vi.mock('./updater-prerelease-feed', () => moduleFactories.updaterPrereleaseFeed
 vi.mock('./local-builds/local-build-switch', () => moduleFactories.localBuildSwitch())
 vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBuildFeedServer())
 
+warmUpdaterModule()
+
 describe('updater', () => {
   beforeEach(() => {
     resetUpdaterMocks()
@@ -40,7 +43,7 @@ describe('updater', () => {
       return Promise.resolve(undefined)
     })
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     // Why: recent timestamp defers the startup check so the nudge check runs without hitting the 'checking' guard.
     setupAutoUpdater(mainWindow as never, {
@@ -93,7 +96,7 @@ describe('updater', () => {
       return Promise.resolve(undefined)
     })
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => null,
@@ -127,7 +130,7 @@ describe('updater', () => {
       return new Promise(() => {})
     })
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => null,
@@ -152,7 +155,7 @@ describe('updater', () => {
     shouldApplyNudgeMock.mockReturnValue(true)
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never)
 
@@ -188,7 +191,7 @@ describe('updater', () => {
       return Promise.resolve(undefined)
     })
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now(),
@@ -226,7 +229,7 @@ describe('updater', () => {
     fetchNewerReleaseTagsMock.mockResolvedValue({ tags: [], state: 'no-newer' })
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now(),
@@ -262,7 +265,7 @@ describe('updater', () => {
       return Promise.resolve(undefined)
     })
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now(),
@@ -300,7 +303,7 @@ describe('updater', () => {
       return Promise.reject(missingManifest)
     })
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now(),
@@ -330,7 +333,7 @@ describe('updater', () => {
       return Promise.resolve(undefined)
     })
 
-    const { setupAutoUpdater, dismissNudge } = await import('./updater')
+    const { setupAutoUpdater, dismissNudge } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now(),

--- a/src/main/updater.prerelease-fallback.test.ts
+++ b/src/main/updater.prerelease-fallback.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const { appMock, autoUpdaterMock, fetchNewerReleaseTagsMock, moduleFactories, resetUpdaterMocks } =
   await vi.hoisted(async () => (await import('./updater-test-harness')).createUpdaterMocks())
@@ -16,6 +17,8 @@ vi.mock('./update-install-exit-watchdog', () => moduleFactories.updateInstallExi
 vi.mock('./updater-prerelease-feed', () => moduleFactories.updaterPrereleaseFeed())
 vi.mock('./local-builds/local-build-switch', () => moduleFactories.localBuildSwitch())
 vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBuildFeedServer())
+
+warmUpdaterModule()
 
 describe('updater', () => {
   beforeEach(() => {
@@ -45,7 +48,7 @@ describe('updater', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -89,7 +92,7 @@ describe('updater', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -133,7 +136,7 @@ describe('updater', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
 
@@ -181,7 +184,7 @@ describe('updater', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => lastUpdateCheckAt })
     checkForUpdatesFromMenu()
@@ -237,7 +240,7 @@ describe('updater', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -283,7 +286,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const setLastUpdateCheckAt = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => null,
@@ -331,7 +334,7 @@ describe('updater', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -378,7 +381,7 @@ describe('updater', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
 
@@ -432,7 +435,7 @@ describe('updater', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -488,7 +491,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const setLastUpdateCheckAt = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => null,
@@ -542,7 +545,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const setLastUpdateCheckAt = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now(),
@@ -597,7 +600,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const setLastUpdateCheckAt = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now(),
@@ -643,7 +646,7 @@ describe('updater', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -669,7 +672,7 @@ describe('updater', () => {
     fetchNewerReleaseTagsMock.mockResolvedValue(['v1.3.18'])
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     const mainWindow = { webContents: { send: vi.fn() } }
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
@@ -694,7 +697,7 @@ describe('updater', () => {
     fetchNewerReleaseTagsMock.mockResolvedValue(['v1.3.18-rc.1'])
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     const mainWindow = { webContents: { send: vi.fn() } }
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })

--- a/src/main/updater.publishing-window-feed.test.ts
+++ b/src/main/updater.publishing-window-feed.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   appMock,
@@ -24,6 +25,8 @@ vi.mock('./updater-prerelease-feed', () => moduleFactories.updaterPrereleaseFeed
 vi.mock('./local-builds/local-build-switch', () => moduleFactories.localBuildSwitch())
 vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBuildFeedServer())
 
+warmUpdaterModule()
+
 describe('updater', () => {
   beforeEach(() => {
     resetUpdaterMocks()
@@ -35,7 +38,7 @@ describe('updater', () => {
     fetchNewerReleaseTagsMock.mockResolvedValue(['v1.3.17-rc.2'])
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     const mainWindow = { webContents: { send: vi.fn() } }
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
@@ -67,7 +70,7 @@ describe('updater', () => {
     fetchNewerReleaseTagsMock.mockResolvedValue(['v1.3.19'])
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     const mainWindow = { webContents: { send: vi.fn() } }
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
@@ -89,7 +92,7 @@ describe('updater', () => {
     fetchNewerReleaseTagsMock.mockResolvedValue([])
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     const mainWindow = { webContents: { send: vi.fn() } }
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
@@ -115,7 +118,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     const feedCallsBeforeCheck = autoUpdaterMock.setFeedURL.mock.calls.length
@@ -146,7 +149,7 @@ describe('updater', () => {
     })
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -182,7 +185,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     const feedCallsBeforeCheck = autoUpdaterMock.setFeedURL.mock.calls.length
@@ -234,7 +237,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
 
@@ -273,7 +276,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => null,
@@ -328,7 +331,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => null,
@@ -371,7 +374,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => null,
@@ -444,7 +447,7 @@ describe('updater', () => {
       const sendMock = vi.fn()
       const mainWindow = { webContents: { send: sendMock } }
 
-      const { setupAutoUpdater } = await import('./updater')
+      const { setupAutoUpdater } = await loadUpdaterModule()
 
       setupAutoUpdater(mainWindow as never, {
         getLastUpdateCheckAt: () => Date.now(),
@@ -513,7 +516,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now(),
@@ -580,7 +583,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, dismissNudge } = await import('./updater')
+    const { setupAutoUpdater, dismissNudge } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now(),

--- a/src/main/updater.quit-and-install.test.ts
+++ b/src/main/updater.quit-and-install.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PRE_COMMIT_INSTALL_FAILURE } from './updater-test-harness'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   nativeUpdaterMock,
@@ -41,6 +42,8 @@ vi.mock('./startup/hydrate-shell-path', () => ({
   }
 }))
 
+warmUpdaterModule()
+
 describe('updater', () => {
   beforeEach(() => {
     resetUpdaterMocks()
@@ -64,7 +67,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu, downloadUpdate } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu, downloadUpdate } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -102,7 +105,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu, downloadUpdate } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu, downloadUpdate } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -143,7 +146,7 @@ describe('updater', () => {
     })
 
     const mainWindow = { webContents: { send: vi.fn() } }
-    const { setupAutoUpdater, quitAndInstall } = await import('./updater')
+    const { setupAutoUpdater, quitAndInstall } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never)
     quitAndInstall()
@@ -166,7 +169,7 @@ describe('updater', () => {
 
     const onBeforeQuit = vi.fn()
     const mainWindow = { webContents: { send: vi.fn() } }
-    const { setupAutoUpdater, quitAndInstall } = await import('./updater')
+    const { setupAutoUpdater, quitAndInstall } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { onBeforeQuit })
     quitAndInstall()
@@ -184,7 +187,7 @@ describe('updater', () => {
     vi.useFakeTimers()
 
     const mainWindow = { webContents: { send: vi.fn() } }
-    const { setupAutoUpdater, quitAndInstall } = await import('./updater')
+    const { setupAutoUpdater, quitAndInstall } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never)
     quitAndInstall()
@@ -206,7 +209,7 @@ describe('updater', () => {
         })
     )
     const mainWindow = { webContents: { send: vi.fn() } }
-    const { setupAutoUpdater, quitAndInstall } = await import('./updater')
+    const { setupAutoUpdater, quitAndInstall } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { onBeforeQuit })
     quitAndInstall()
@@ -237,7 +240,7 @@ describe('updater', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, quitAndInstall, isQuittingForUpdate } = await import('./updater')
+    const { setupAutoUpdater, quitAndInstall, isQuittingForUpdate } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never)
     quitAndInstall()
@@ -273,7 +276,7 @@ describe('updater', () => {
     })
 
     const { setupAutoUpdater, checkForUpdatesFromMenu, quitAndInstall, isQuittingForUpdate } =
-      await import('./updater')
+      await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -332,7 +335,7 @@ describe('updater', () => {
       return Promise.resolve(undefined)
     })
 
-    const { setupAutoUpdater, checkForUpdatesFromMenu, quitAndInstall } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdatesFromMenu, quitAndInstall } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
@@ -377,7 +380,7 @@ describe('updater', () => {
     })
 
     const mainWindow = { webContents: { send: vi.fn() } }
-    const { setupAutoUpdater, quitAndInstall, isQuittingForUpdate } = await import('./updater')
+    const { setupAutoUpdater, quitAndInstall, isQuittingForUpdate } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never)
     quitAndInstall()
@@ -402,7 +405,7 @@ describe('updater', () => {
     )
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, quitAndInstall, isQuittingForUpdate } = await import('./updater')
+    const { setupAutoUpdater, quitAndInstall, isQuittingForUpdate } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       onBeforeQuit,

--- a/src/main/updater.startup-scheduling.test.ts
+++ b/src/main/updater.startup-scheduling.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
 
 const {
   appMock,
@@ -25,6 +26,8 @@ vi.mock('./updater-prerelease-feed', () => moduleFactories.updaterPrereleaseFeed
 vi.mock('./local-builds/local-build-switch', () => moduleFactories.localBuildSwitch())
 vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBuildFeedServer())
 
+warmUpdaterModule()
+
 describe('updater', () => {
   beforeEach(() => {
     resetUpdaterMocks()
@@ -34,7 +37,7 @@ describe('updater', () => {
     isMock.dev = true
     const mainWindow = { webContents: { send: vi.fn() } }
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never)
 
@@ -49,7 +52,7 @@ describe('updater', () => {
     const mainWindow = { webContents: { send: vi.fn() } }
     const setLastUpdateCheckAt = vi.fn()
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now() - 25 * 60 * 60 * 1000,
@@ -67,7 +70,7 @@ describe('updater', () => {
     fetchNudgeMock.mockResolvedValue({ id: 'campaign-1', minVersion: '1.0.0' })
     shouldApplyNudgeMock.mockReturnValue(true)
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never)
 
@@ -89,7 +92,7 @@ describe('updater', () => {
     const mainWindow = { webContents: { send: vi.fn() } }
     const setLastUpdateCheckAt = vi.fn()
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => Date.now() - 23 * 60 * 60 * 1000,
@@ -114,7 +117,7 @@ describe('updater', () => {
 
     autoUpdaterMock.checkForUpdates.mockImplementation(() => new Promise(() => {}))
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => lastUpdateCheckAt
@@ -143,7 +146,7 @@ describe('updater', () => {
       return Promise.reject(new Error('net::ERR_FAILED'))
     })
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => lastUpdateCheckAt,
@@ -178,7 +181,7 @@ describe('updater', () => {
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     setupAutoUpdater(mainWindow as never, {
       getLastUpdateCheckAt: () => null,
@@ -214,7 +217,7 @@ describe('updater', () => {
     const setLastUpdateCheckAt = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     // Why: a startup check also arms its own 24h timer, which would fire at the same boundary as the
     // reschedule under test; entering 23h in makes the startup timer fire the check itself, so only
@@ -255,7 +258,7 @@ describe('updater', () => {
   it('does not disable Windows Authenticode verification on win32', async () => {
     vi.stubGlobal('process', { ...process, platform: 'win32' })
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
@@ -268,7 +271,7 @@ describe('updater', () => {
   it('does not override verifyUpdateCodeSignature on non-Windows platforms', async () => {
     vi.stubGlobal('process', { ...process, platform: 'darwin' })
 
-    const { setupAutoUpdater } = await import('./updater')
+    const { setupAutoUpdater } = await loadUpdaterModule()
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }


### PR DESCRIPTION
## The trap

`src/main/updater*.test.ts` is 23 files / 269 tests. Every test that exercises `updater.ts` does `await import('./updater')` inside the test body. `updater.ts` is 2,353 lines with a wide import graph, so a worker's **first** import of it is expensive. On a loaded machine that first import outruns the 30s `testTimeout`.

Vitest cannot cancel a timed-out test body — `Promise.race` loses the race, but the underlying async function keeps running. So the abandoned continuation resumed *during the next test*, with the harness already reset by `resetUpdaterMocks()`, and called `setupAutoUpdater` into it. The next test then failed with:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
```

That is the **exact signature** of the abandoned-instance leaked-timer flake fixed in #17649/#17663. So anyone who hit this on a loaded machine or a noisy CI runner would read it as that timer fix regressing and go hunting in `updater-test-timer-tracking.ts` — the wrong place entirely. The failure was reproduced identically on both the fixed and the unfixed code, which is what proves it is contention, not logic.

## Measurements

16-core mac. First vs. subsequent `await import('./updater')` in a single file, with `resetUpdaterMocks()` (which calls `vi.resetModules()`) between each:

| load | import #1 | #2 | #3 | #4 | #5 |
|---|---|---|---|---|---|
| idle | **1439ms** | 30ms | 25ms | 23ms | 25ms |
| 40 CPU hogs | **8339ms** | 149ms | 135ms | 385ms | 177ms |
| 150 CPU hogs | **15936ms** | 428ms | 194ms | 190ms | 361ms |
| 400 CPU hogs | **45521ms** | 15182ms | 849ms | 1294ms | 1502ms |

The crux, and it narrows the problem a lot: **vitest caches the transform across `vi.resetModules()`.** Only a file's first import pays it; the rest is module re-evaluation. So the exposure is exactly one import per file — 14 files, one test each.

Suite totals: idle `pnpm test src/main/updater` is 7.3s wall / 15.8s aggregate transform. Under 400 hogs, 88.8s wall / 498s aggregate transform, and the cold import crosses 30s.

`hookTimeout` is already 60s in `config/vitest.config.ts`; `testTimeout` is 30s.

## The fix

New `src/main/updater-test-module-loader.ts`, two functions:

**`loadUpdaterModule()`** replaces every `await import('./updater')` (120 sites, 14 files). It records the test that asked for the module and throws if the import resolves after that test has ended:

```ts
const owner = expect.getState().currentTestName
const module = await import('./updater')
if (owner !== undefined && owner !== expect.getState().currentTestName) throw new Error(...)
```

The throw lands inside the already-abandoned test promise, which vitest still has a handler on, so it produces no unhandled rejection and no extra reported failure — it just strands the continuation before it can touch `setupAutoUpdater`. **This is the part that removes the trap:** a timeout stays a timeout, correctly attributed, instead of mutating into a bogus assertion in the next test.

**`warmUpdaterModule()`** imports the module once in `beforeAll`. Since the transform is cached across `resetModules`, this pays the one slow import against the 60s `hookTimeout` rather than the 30s `testTimeout`, and leaves every in-test import at re-evaluation cost. **This is the part that removes the slowness**, and it is not just "raise the timeout": transform cost is file setup, not test work, and it is now charged once per file to the budget already sized for setup.

`updater-test-module-loader.test.ts` pins the fence contract with a deterministic pair — test 1 starts an import it never awaits (standing in for a timed-out body), test 2 asserts the loader refused to hand the module over.

### Alternatives rejected

- **Raise `testTimeout` for these files.** Only widens the window; recurs under more load, and leaves the misleading symptom fully intact when it does.
- **Reduce the transform cost of `updater.ts`.** Splitting a 2.4k-line production module to make a test suite faster is a much larger change with real behavioural risk, and it would not remove the trap either.
- **Fence in the harness only.** 5 of the 14 files build their own mocks and never call `createUpdaterMocks()`, so a harness-generation fence would not cover them. Keying off vitest's own current-test identity covers all 14 uniformly. (The existing generation fence in `updater-test-harness.ts` does not help here: it stamps the generation when `loadElectronAutoUpdater` is *called*, and the leaked continuation calls it after the bump, so it reads as current.)

## Before / after under load

Identical harness both runs: 400 `while :; do :; done` shells on a 16-core box, then `pnpm test src/main/updater`.

**Before** — 15 files / 22 tests failed:

```
 Test Files  15 failed | 9 passed (24)
      Tests  22 failed | 252 passed (274)

  15 × Error: Test timed out in 30000ms
   7 × AssertionError   (3 × "to be called 1 times, but got 2 times",
                         1 × "to be called 2 times, but got 4 times", 3 × called-with)
```

Every file shows the same shape: a timeout on its first test, then a bogus assertion failure on the *next* test — the leaked continuation landing.

**After** — same load, everything passes:

```
 Test Files  23 passed (23)
      Tests  269 passed (269)
   Duration  93.98s
```

**After, pushed to 900 hogs** (2.25× the load that broke it before) — degrades loudly and correctly, zero misleading failures:

```
 Test Files  14 failed | 10 passed (24)
      Tests  119 passed | 152 skipped (271)

  14 × Error: Hook timed out in 60000ms
   0 × AssertionError
```

The warm-up hook is now the thing that blows, which names the actual problem (this file could not load its module in 60s) instead of blaming an unrelated assertion.

## Verification

- `pnpm test src/main/updater` serially: **24 files / 271 tests passing** (23/269 before this PR, +1 file / +2 tests from the new loader regression test).
- `pnpm exec oxlint` on all 17 changed files: clean.
- `pnpm tc`: clean.

DO NOT MERGE without review.
