### PR TITLE
Discover Claude Code custom slash commands for native chat picker

### DIFF
--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -6,6 +6,7 @@ import {
   type SkillDiscoveryResult,
   type SkillDiscoveryTarget
 } from '../../shared/skills'
+import type { ClaudeSlashCommandDiscoveryResult } from '../../shared/claude-slash-command-discovery'
 import type {
   SkillFreshnessInventory,
   SkillUpdateRun,
@@ -20,10 +21,24 @@ import {
   discoverSkillsOnTarget,
   resolveSkillDiscoveryTarget
 } from '../skills/skill-discovery-target'
+import {
+  discoverClaudeSlashCommandsOnTarget,
+  resolveClaudeSlashCommandDiscoveryTarget
+} from '../skills/claude-command-discovery-target'
 import { registerSkillCloudIpcHandlers } from './skill-cloud-ipc-handlers'
 import { handleMainWindowSkillIpc } from './skill-ipc-main-window'
 
 export function registerSkillsHandlers(store: Store, runtime?: OrcaRuntimeService): void {
+  const discoverClaudeCommands = async (
+    target?: SkillDiscoveryTarget
+  ): Promise<ClaudeSlashCommandDiscoveryResult> => {
+    const parsedTarget = target ? SkillDiscoveryTargetSchema.parse(target) : undefined
+    const resolvedTarget = resolveClaudeSlashCommandDiscoveryTarget(parsedTarget)
+    return discoverClaudeSlashCommandsOnTarget(resolvedTarget, store.getRepos(), {
+      providerRootOverrides: await runtime?.resolveSkillDiscoveryProviderRoots(resolvedTarget),
+      refresh: parsedTarget?.refresh === true
+    })
+  }
   const discover = async (target?: SkillDiscoveryTarget): Promise<SkillDiscoveryResult> => {
     const parsedTarget = target ? SkillDiscoveryTargetSchema.parse(target) : undefined
     const resolvedTarget = resolveSkillDiscoveryTarget(parsedTarget)
@@ -67,6 +82,12 @@ export function registerSkillsHandlers(store: Store, runtime?: OrcaRuntimeServic
   handleMainWindowSkillIpc(
     'skills:discover',
     async (_event, target?: SkillDiscoveryTarget): Promise<SkillDiscoveryResult> => discover(target)
+  )
+
+  handleMainWindowSkillIpc(
+    'claudeCommands:discover',
+    async (_event, target?: SkillDiscoveryTarget): Promise<ClaudeSlashCommandDiscoveryResult> =>
+      discoverClaudeCommands(target)
   )
 
   if (runtime) {

--- a/src/main/runtime/rpc/methods/skills.ts
+++ b/src/main/runtime/rpc/methods/skills.ts
@@ -8,6 +8,7 @@ import {
   type SkillDeleteRequestDependencies
 } from '../../../skills/skill-delete/request-service'
 import { SkillDiscoveryTargetSchema } from '../../../../shared/skills'
+import { ClaudeSlashCommandDiscoveryTargetSchema } from '../../../../shared/claude-slash-command-discovery'
 import {
   SkillInstallPreviewRequestSchema,
   SkillInstallRequestSchema,
@@ -26,6 +27,9 @@ import {
   discoverSkillsOnTarget,
   resolveSkillDiscoveryTarget
 } from '../../../skills/skill-discovery-target'
+import {
+  discoverClaudeSlashCommandsOnTarget
+} from '../../../skills/claude-command-discovery-target'
 import { SKILL_INSTALL_RESULT_V2_CAPABILITY } from '../../../../shared/skill-install-capability'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import {
@@ -69,6 +73,17 @@ export const SKILL_METHODS: RpcMethod[] = [
       // would scan this host's native filesystem for a WSL-configured project.
       const resolvedTarget = resolveDiscoveryTarget(params, runtime)
       return discoverSkillsOnTarget(resolvedTarget, runtime.listRepos(), {
+        providerRootOverrides: await runtime.resolveSkillDiscoveryProviderRoots(resolvedTarget),
+        refresh: params.refresh === true
+      })
+    }
+  }),
+  defineMethod({
+    name: 'claudeCommands.discover',
+    params: ClaudeSlashCommandDiscoveryTargetSchema.default({}),
+    handler: async (params, { runtime }) => {
+      const resolvedTarget = resolveDiscoveryTarget(params, runtime)
+      return discoverClaudeSlashCommandsOnTarget(resolvedTarget, runtime.listRepos(), {
         providerRootOverrides: await runtime.resolveSkillDiscoveryProviderRoots(resolvedTarget),
         refresh: params.refresh === true
       })

--- a/src/main/skills/claude-command-discovery-sources.ts
+++ b/src/main/skills/claude-command-discovery-sources.ts
@@ -1,0 +1,96 @@
+import { homedir } from 'node:os'
+import { basename, dirname, join, type posix } from 'node:path'
+import type { AgentType } from '../../shared/agent-status-types'
+import type { Repo } from '../../shared/repo-types'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
+import type { SkillProvider, SkillSourceKind } from '../../shared/skills'
+import type { SkillProviderRootOverrides } from './skill-provider-destinations'
+import { resolveEnvironmentSkillProviderRoots } from './skill-provider-runtime-roots'
+import { stablePathId, type SkillScanRoot } from './skill-discovery-sources'
+
+type CommandDiscoveryPathApi = Pick<typeof posix, 'basename' | 'dirname' | 'join'>
+
+function source(
+  id: string,
+  label: string,
+  path: string,
+  sourceKind: SkillSourceKind,
+  providers: SkillProvider[],
+  owner: AgentType | null
+): SkillScanRoot {
+  return { id, label, path, sourceKind, providers, owner }
+}
+
+function claudeProfileCommandsPath(
+  home: string,
+  claudeSkillsOverride: string | undefined,
+  pathApi: CommandDiscoveryPathApi
+): string {
+  const skillsPath = claudeSkillsOverride ?? pathApi.join(home, '.claude', 'skills')
+  return pathApi.join(pathApi.dirname(skillsPath), 'commands')
+}
+
+export function claudeCommandNameFromRelativePath(relPath: string, sep: string): string | null {
+  if (!relPath || relPath === '..' || relPath.startsWith(`..${sep}`)) {
+    return null
+  }
+  const withoutExtension = relPath.endsWith('.md') ? relPath.slice(0, -3) : relPath
+  if (!withoutExtension) {
+    return null
+  }
+  return withoutExtension.split(sep).join(':')
+}
+
+export function buildClaudeCommandDiscoverySources(
+  args: {
+    homeDir?: string
+    cwd?: string
+    repos?: Repo[]
+    includeCwd?: boolean
+    pathApi?: CommandDiscoveryPathApi
+    providerRootOverrides?: SkillProviderRootOverrides
+  } = {}
+): SkillScanRoot[] {
+  const pathApi = args.pathApi ?? { basename, dirname, join }
+  const home = args.homeDir ?? homedir()
+  const cwd = args.cwd ?? process.cwd()
+  const providerRootOverrides =
+    args.providerRootOverrides ?? (args.pathApi ? {} : resolveEnvironmentSkillProviderRoots())
+  const roots: SkillScanRoot[] = [
+    source(
+      'home-claude-commands',
+      'Claude home commands',
+      claudeProfileCommandsPath(home, providerRootOverrides.claude, pathApi),
+      'home',
+      ['claude'],
+      'claude'
+    )
+  ]
+
+  const projectPaths = new Set<string>()
+  for (const repo of args.repos ?? []) {
+    if (getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID) {
+      continue
+    }
+    projectPaths.add(repo.path)
+  }
+  if (args.includeCwd !== false) {
+    projectPaths.add(cwd)
+  }
+
+  for (const repoPath of projectPaths) {
+    const label = `Repo ${pathApi.basename(repoPath)}`
+    roots.push(
+      source(
+        `repo-claude-commands-${stablePathId(repoPath)}`,
+        `${label} .claude commands`,
+        pathApi.join(repoPath, '.claude', 'commands'),
+        'repo',
+        ['claude'],
+        'claude'
+      )
+    )
+  }
+
+  return roots
+}

--- a/src/main/skills/claude-command-discovery-target.ts
+++ b/src/main/skills/claude-command-discovery-target.ts
@@ -1,0 +1,108 @@
+import type { Repo } from '../../shared/repo-types'
+import type { ClaudeSlashCommandDiscoveryResult } from '../../shared/claude-slash-command-discovery'
+import type { SkillDiscoveryTarget } from '../../shared/skills'
+import {
+  clearClaudeCommandRootScanCache,
+  discoverClaudeSlashCommands
+} from './claude-command-discovery'
+import { discoverClaudeSlashCommandsInWsl } from './claude-command-discovery-wsl'
+import type { SkillProviderRootOverrides } from './skill-provider-destinations'
+import {
+  isSkillRootUnavailableError,
+  SkillScanCoalescer
+} from './skill-scan-coalescer'
+import {
+  resolveSkillDiscoveryTarget,
+  type ResolvedSkillDiscoveryTarget
+} from './skill-discovery-target'
+import { stablePathId } from './skill-discovery-sources'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
+
+const WSL_RESULT_TTL_MS = 10_000
+const MAX_CACHED_COMMAND_TARGETS = 32
+
+const targetScans = new SkillScanCoalescer<ClaudeSlashCommandDiscoveryResult>(
+  MAX_CACHED_COMMAND_TARGETS
+)
+
+export function clearClaudeCommandDiscoveryCaches(): void {
+  targetScans.clear()
+  clearClaudeCommandRootScanCache()
+}
+
+function repoDigest(repos: readonly Repo[]): string {
+  return stablePathId(
+    repos
+      .map((repo) => `${getRepoExecutionHostId(repo)}\0${repo.path}`)
+      .sort((left, right) => left.localeCompare(right))
+      .join('\0')
+  )
+}
+
+function scanKey(
+  target: ResolvedSkillDiscoveryTarget,
+  repos: readonly Repo[],
+  providerRootOverrides: SkillProviderRootOverrides | undefined
+): string {
+  const providerRoots = stablePathId(
+    Object.entries(providerRootOverrides ?? {})
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([provider, root]) => `${provider}\0${root}`)
+      .join('\0')
+  )
+  const targetKey =
+    target.kind === 'wsl'
+      ? `wsl\0${target.distro}\0${target.homeDir}\0${target.cwd}`
+      : `native\0${target.cwd ?? ''}\0${target.cwd ? '' : repoDigest(repos)}`
+  return `commands\0${targetKey}\0${providerRoots}`
+}
+
+export async function discoverClaudeSlashCommandsOnTarget(
+  target: ResolvedSkillDiscoveryTarget,
+  repos: readonly Repo[],
+  options: { refresh?: boolean; providerRootOverrides?: SkillProviderRootOverrides } = {}
+): Promise<ClaudeSlashCommandDiscoveryResult> {
+  const refresh = options.refresh === true
+  try {
+    const outcome = await targetScans.run(
+      scanKey(target, repos, options.providerRootOverrides),
+      { ttlMs: target.kind === 'wsl' ? WSL_RESULT_TTL_MS : 0, refresh },
+      async () => {
+        if (target.kind === 'wsl') {
+          return discoverClaudeSlashCommandsInWsl({
+            distro: target.distro,
+            homeDir: target.homeDir,
+            cwd: target.cwd,
+            providerRootOverrides: options.providerRootOverrides
+          })
+        }
+        return target.cwd
+          ? discoverClaudeSlashCommands({
+              repos: [],
+              cwd: target.cwd,
+              refresh,
+              providerRootOverrides: options.providerRootOverrides
+            })
+          : discoverClaudeSlashCommands({
+              repos: [...repos],
+              refresh,
+              providerRootOverrides: options.providerRootOverrides
+            })
+      }
+    )
+    return outcome.value
+  } catch (error) {
+    if (!isSkillRootUnavailableError(error)) {
+      throw error
+    }
+    throw new Error('Claude command discovery is still reading a slow location. Try again.', {
+      cause: error
+    })
+  }
+}
+
+export function resolveClaudeSlashCommandDiscoveryTarget(
+  target: SkillDiscoveryTarget | undefined
+): ResolvedSkillDiscoveryTarget {
+  return resolveSkillDiscoveryTarget(target)
+}

--- a/src/main/skills/claude-command-discovery-wsl.test.ts
+++ b/src/main/skills/claude-command-discovery-wsl.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { SkillScanRoot } from './skill-discovery-sources'
+import {
+  buildWslClaudeCommandDiscoveryCommand,
+  parseWslClaudeCommandDiscoveryOutput
+} from './claude-command-discovery-wsl'
+
+function homeRoot(path: string): SkillScanRoot {
+  return {
+    id: 'home-claude-commands',
+    label: 'Claude home commands',
+    path,
+    sourceKind: 'home',
+    providers: ['claude'],
+    owner: 'claude'
+  }
+}
+
+describe('parseWslClaudeCommandDiscoveryOutput', () => {
+  it('parses namespaced markdown commands from WSL scan output', () => {
+    const roots = [homeRoot('/home/tester/.claude/commands')]
+    const markdown = Buffer.from('---\ndescription: Apply change\n---\n').toString('base64')
+    const output = [
+      'R',
+      '0',
+      '1',
+      'C',
+      '0',
+      '/home/tester/.claude/commands/opsx/apply.md',
+      '42',
+      markdown,
+      ''
+    ].join('\0')
+
+    const result = parseWslClaudeCommandDiscoveryOutput(output, roots, 99)
+    expect(result.scannedAt).toBe(99)
+    expect(result.commands).toEqual([
+      expect.objectContaining({
+        name: 'opsx:apply',
+        description: 'Apply change',
+        commandFilePath: '/home/tester/.claude/commands/opsx/apply.md',
+        sourceKind: 'home'
+      })
+    ])
+  })
+
+  it('builds a find command that matches markdown files', () => {
+    const script = buildWslClaudeCommandDiscoveryCommand([
+      homeRoot('/home/tester/.claude/commands')
+    ])
+    expect(script).toContain('-name \'*.md\'')
+    expect(script).toContain('/home/tester/.claude/commands')
+  })
+})

--- a/src/main/skills/claude-command-discovery-wsl.ts
+++ b/src/main/skills/claude-command-discovery-wsl.ts
@@ -1,0 +1,158 @@
+import { posix as pathPosix } from 'node:path'
+import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
+import type {
+  ClaudeSlashCommandDiscoveryResult,
+  DiscoveredClaudeSlashCommand
+} from '../../shared/claude-slash-command-discovery'
+import { quoteBashString } from '../wsl-bash-command'
+import { runWslProcess } from '../wsl/wsl-runner'
+import {
+  buildClaudeCommandDiscoverySources,
+  claudeCommandNameFromRelativePath
+} from './claude-command-discovery-sources'
+import { discoverClaudePluginCommandSourcesInWsl } from './claude-plugin-skill-sources-wsl'
+import type { SkillProviderRootOverrides } from './skill-provider-destinations'
+import { SKILL_STAGING_GLOB } from './skill-delete/staging-names'
+import { skillFileMaxDepth } from '../../shared/skill-discovery-depth'
+import { sourceLabelForSkill, type SkillScanRoot } from './skill-discovery-sources'
+
+const MAX_MARKDOWN_BYTES = 256 * 1024
+const WSL_SCAN_TIMEOUT_MS = 10_000
+const WSL_SCAN_MAX_OUTPUT_BYTES = 128 * 1024 * 1024
+
+export function buildWslClaudeCommandDiscoveryCommand(roots: readonly SkillScanRoot[]): string {
+  const lines = [
+    'set -u',
+    'set -o pipefail',
+    'scan_root() {',
+    '  root_index=$1',
+    '  root_path=$2',
+    '  max_depth=$3',
+    '  if [ ! -d "$root_path" ]; then',
+    `    printf '%s\\0%s\\0%s\\0' R "$root_index" 0`,
+    '    return',
+    '  fi',
+    `  printf '%s\\0%s\\0%s\\0' R "$root_index" 1`,
+    `  while IFS= read -r -d '' command_file; do`,
+    `    updated_at=$(stat -c '%Y' -- "$command_file" 2>/dev/null || true)`,
+    `    encoded_markdown=$(head -c ${MAX_MARKDOWN_BYTES} -- "$command_file" 2>/dev/null | base64 | tr -d '\\n') || continue`,
+    `    printf '%s\\0%s\\0%s\\0%s\\0' C "$root_index" "$command_file" "$updated_at"`,
+    `    printf '%s' "$encoded_markdown"`,
+    `    printf '\\0'`,
+    `  done < <(find -L "$root_path" -mindepth 1 -maxdepth "$max_depth" \\( -name '${SKILL_STAGING_GLOB}' -prune \\) -o \\( -type f -name '*.md' -print0 \\) 2>/dev/null)`,
+    '}'
+  ]
+  roots.forEach((root, index) => {
+    const maxDepth = skillFileMaxDepth(root.sourceKind)
+    lines.push(`scan_root ${index} ${quoteBashString(root.path)} ${maxDepth}`)
+  })
+  return lines.join('\n')
+}
+
+async function executeWslCommandDiscovery(distro: string, script: string): Promise<string> {
+  const result = await runWslProcess({
+    distro,
+    loginPath: 'none',
+    script,
+    shell: 'bash',
+    timeoutMs: WSL_SCAN_TIMEOUT_MS,
+    maxOutputBytes: WSL_SCAN_MAX_OUTPUT_BYTES
+  })
+  if (result.code !== 0 || result.timedOut) {
+    throw new Error('claude-command-discovery-wsl-scan-failed')
+  }
+  return result.stdout
+}
+
+function readProtocolField(fields: string[], index: number): string {
+  const value = fields[index]
+  if (value === undefined) {
+    throw new Error('WSL Claude command discovery returned an incomplete response.')
+  }
+  return value
+}
+
+export function parseWslClaudeCommandDiscoveryOutput(
+  output: string,
+  roots: readonly SkillScanRoot[],
+  scannedAt = Date.now()
+): ClaudeSlashCommandDiscoveryResult {
+  const fields = output.split('\0')
+  const rootExists = new Map<number, boolean>()
+  const commandsByPath = new Map<string, DiscoveredClaudeSlashCommand>()
+  let index = 0
+  while (index < fields.length && fields[index]) {
+    const recordKind = fields[index++]
+    if (recordKind === 'R') {
+      const rootIndex = Number.parseInt(readProtocolField(fields, index++), 10)
+      rootExists.set(rootIndex, readProtocolField(fields, index++) === '1')
+      continue
+    }
+    if (recordKind !== 'C') {
+      throw new Error('WSL Claude command discovery returned an invalid response.')
+    }
+    const rootIndex = Number.parseInt(readProtocolField(fields, index++), 10)
+    const root = roots[rootIndex]
+    if (!root) {
+      throw new Error('WSL Claude command discovery referenced an unknown root.')
+    }
+    const commandFilePath = readProtocolField(fields, index++)
+    readProtocolField(fields, index++) // updated_at seconds
+    const encodedMarkdown = readProtocolField(fields, index++)
+    const relPath = pathPosix.relative(root.path, commandFilePath)
+    const name = claudeCommandNameFromRelativePath(relPath, pathPosix.sep)
+    if (!name) {
+      continue
+    }
+    const markdown = Buffer.from(encodedMarkdown, 'base64').toString('utf8')
+    const summary = summarizeSkillMarkdown(markdown)
+    const command: DiscoveredClaudeSlashCommand = {
+      name,
+      description: summary.description,
+      commandFilePath,
+      sourceKind: root.sourceKind,
+      sourceLabel: sourceLabelForSkill(root, root.sourceKind)
+    }
+    if (!commandsByPath.has(commandFilePath)) {
+      commandsByPath.set(commandFilePath, command)
+    }
+  }
+  for (const [rootIndex, exists] of rootExists.entries()) {
+    if (!exists) {
+      continue
+    }
+    const root = roots[rootIndex]
+    if (!root) {
+      throw new Error('WSL Claude command discovery referenced an unknown root.')
+    }
+  }
+  const commands = [...commandsByPath.values()].sort((left, right) =>
+    left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
+  )
+  return { commands, scannedAt }
+}
+
+export async function discoverClaudeSlashCommandsInWsl(args: {
+  distro: string
+  homeDir: string
+  cwd: string
+  providerRootOverrides?: SkillProviderRootOverrides
+}): Promise<ClaudeSlashCommandDiscoveryResult> {
+  const pluginRoots = await discoverClaudePluginCommandSourcesInWsl(args)
+  const roots = [
+    ...buildClaudeCommandDiscoverySources({
+      homeDir: args.homeDir,
+      cwd: args.cwd,
+      repos: [],
+      includeCwd: true,
+      pathApi: pathPosix,
+      providerRootOverrides: args.providerRootOverrides
+    }),
+    ...pluginRoots
+  ]
+  const output = await executeWslCommandDiscovery(
+    args.distro,
+    buildWslClaudeCommandDiscoveryCommand(roots)
+  )
+  return parseWslClaudeCommandDiscoveryOutput(output, roots)
+}

--- a/src/main/skills/claude-command-discovery.test.ts
+++ b/src/main/skills/claude-command-discovery.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  mergeVerifiedAndDiscoveredSlashCommands,
+  toSlashCommandSuggestions
+} from '../../shared/claude-slash-command-discovery'
+import {
+  buildClaudeCommandDiscoverySources,
+  claudeCommandNameFromRelativePath
+} from './claude-command-discovery-sources'
+import { clearClaudeCommandRootScanCache, discoverClaudeSlashCommands } from './claude-command-discovery'
+
+beforeEach(() => {
+  clearClaudeCommandRootScanCache()
+  vi.spyOn(console, 'info').mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('claudeCommandNameFromRelativePath', () => {
+  it('maps nested markdown files to colon-separated command names', () => {
+    expect(claudeCommandNameFromRelativePath('opsx/apply.md', '/')).toBe('opsx:apply')
+    expect(claudeCommandNameFromRelativePath('deploy.md', '/')).toBe('deploy')
+  })
+})
+
+describe('buildClaudeCommandDiscoverySources', () => {
+  it('includes home and repo .claude/commands roots', () => {
+    const roots = buildClaudeCommandDiscoverySources({
+      homeDir: '/home/tester',
+      cwd: '/repo/worktree'
+    })
+    expect(roots.map((root) => root.path)).toEqual([
+      '/home/tester/.claude/commands',
+      '/repo/worktree/.claude/commands'
+    ])
+  })
+})
+
+describe('discoverClaudeSlashCommands', () => {
+  it('discovers namespaced project commands with description frontmatter', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-claude-commands-'))
+    const commandsRoot = join(root, '.claude', 'commands', 'opsx')
+    await mkdir(commandsRoot, { recursive: true })
+    await writeFile(
+      join(commandsRoot, 'apply.md'),
+      '---\ndescription: Apply the current OpenSpec change\n---\n\n# Apply\n'
+    )
+
+    const result = await discoverClaudeSlashCommands({
+      homeDir: join(root, 'home'),
+      cwd: root,
+      repos: []
+    })
+
+    expect(result.commands).toEqual([
+      expect.objectContaining({
+        name: 'opsx:apply',
+        description: 'Apply the current OpenSpec change',
+        commandFilePath: join(commandsRoot, 'apply.md'),
+        sourceKind: 'repo'
+      })
+    ])
+    expect(toSlashCommandSuggestions(result.commands)).toEqual([
+      {
+        name: 'opsx:apply',
+        description: 'Apply the current OpenSpec change'
+      }
+    ])
+  })
+
+  it('builds Windows-shaped command roots with the win32 path adapter', () => {
+    const roots = buildClaudeCommandDiscoverySources({
+      homeDir: 'C:\\Users\\tester',
+      cwd: 'C:\\repo\\worktree',
+      pathApi: {
+        basename: (value) => value.split(/[\\/]/).pop() ?? value,
+        dirname: (value) => value.replace(/[\\/][^\\/]+$/, ''),
+        join: (...parts) => parts.join('\\')
+      }
+    })
+    expect(roots.map((root) => root.path)).toEqual([
+      'C:\\Users\\tester\\.claude\\commands',
+      'C:\\repo\\worktree\\.claude\\commands'
+    ])
+  })
+})
+
+describe('mergeVerifiedAndDiscoveredSlashCommands', () => {
+  it('appends discovered commands without overriding verified names', () => {
+    const merged = mergeVerifiedAndDiscoveredSlashCommands(
+      [{ name: 'clear', description: 'Clear conversation history' }],
+      [
+        { name: 'opsx:apply', description: 'Apply' },
+        { name: 'clear', description: 'Duplicate' }
+      ]
+    )
+    expect(merged.map((command) => command.name)).toEqual(['clear', 'opsx:apply'])
+  })
+})

--- a/src/main/skills/claude-command-discovery.ts
+++ b/src/main/skills/claude-command-discovery.ts
@@ -1,0 +1,175 @@
+import { open, stat } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { relative, sep } from 'node:path'
+import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
+import type { ClaudeSlashCommandDiscoveryResult, DiscoveredClaudeSlashCommand } from '../../shared/claude-slash-command-discovery'
+import type { Repo } from '../../shared/repo-types'
+import {
+  buildClaudeCommandDiscoverySources,
+  claudeCommandNameFromRelativePath
+} from './claude-command-discovery-sources'
+import {
+  discoverClaudePluginCommandSources as discoverNativeClaudePluginCommandSources
+} from './claude-plugin-skill-sources'
+import { findCommandMarkdownFiles } from './claude-command-file-walk'
+import { runSkillCandidateTasks } from './skill-candidate-concurrency'
+import { isSkillRootUnavailableError, SkillScanCoalescer } from './skill-scan-coalescer'
+import type { SkillProviderRootOverrides } from './skill-provider-destinations'
+import { skillDirectoryMaxDepth } from '../../shared/skill-discovery-depth'
+import { sourceLabelForSkill, type SkillScanRoot } from './skill-discovery-sources'
+
+const MAX_MARKDOWN_BYTES = 256 * 1024
+const COMMAND_ROOT_SCAN_TTL_MS = 10_000
+const MAX_CACHED_COMMAND_ROOTS = 256
+
+type RootScan = { exists: boolean; commands: DiscoveredClaudeSlashCommand[]; unavailable?: boolean }
+type ScannedCommand = DiscoveredClaudeSlashCommand & { canonicalCommandFilePath: string }
+
+const rootScans = new SkillScanCoalescer<RootScan>(MAX_CACHED_COMMAND_ROOTS)
+
+export function clearClaudeCommandRootScanCache(): void {
+  rootScans.clear()
+}
+
+async function pathExists(pathValue: string): Promise<boolean> {
+  try {
+    await stat(pathValue)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readCommandSummary(commandFilePath: string): Promise<{
+  description: string | null
+} | null> {
+  try {
+    const fileStat = await stat(commandFilePath)
+    const file = await open(commandFilePath, 'r')
+    let content = ''
+    try {
+      const buffer = Buffer.alloc(Math.min(fileStat.size, MAX_MARKDOWN_BYTES))
+      const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
+      content = buffer.toString('utf8', 0, bytesRead)
+    } finally {
+      await file.close()
+    }
+    const summary = summarizeSkillMarkdown(content)
+    return { description: summary.description }
+  } catch {
+    return null
+  }
+}
+
+async function scanRoot(root: SkillScanRoot, signal: AbortSignal): Promise<ScannedCommand[]> {
+  const maxDepth = skillDirectoryMaxDepth(root.sourceKind)
+  const commandFiles = await findCommandMarkdownFiles(root.path, maxDepth, signal)
+  const commands = await runSkillCandidateTasks(
+    commandFiles.map((commandFilePath) => async (): Promise<ScannedCommand | null> => {
+      signal.throwIfAborted()
+      const relPath = relative(root.path, commandFilePath)
+      const name = claudeCommandNameFromRelativePath(relPath, sep)
+      if (!name) {
+        return null
+      }
+      const summary = await readCommandSummary(commandFilePath)
+      if (!summary) {
+        return null
+      }
+      return {
+        name,
+        description: summary.description,
+        commandFilePath,
+        sourceKind: root.sourceKind,
+        sourceLabel: sourceLabelForSkill(root, root.sourceKind),
+        canonicalCommandFilePath: commandFilePath
+      }
+    })
+  )
+  return commands.filter((command): command is ScannedCommand => command !== null)
+}
+
+function rootScanKey(root: SkillScanRoot): string {
+  return `${root.sourceKind}\0${root.path}`
+}
+
+async function scanRootShared(root: SkillScanRoot, refresh: boolean): Promise<RootScan> {
+  const key = rootScanKey(root)
+  try {
+    const outcome = await rootScans.run(
+      key,
+      { ttlMs: COMMAND_ROOT_SCAN_TTL_MS, refresh },
+      async (signal) => {
+        const exists = await pathExists(root.path)
+        if (!exists) {
+          return { exists: false, commands: [] }
+        }
+        const scanned = await scanRoot(root, signal)
+        return {
+          exists: true,
+          commands: scanned.map(({ canonicalCommandFilePath: _canonical, ...command }) => command)
+        }
+      }
+    )
+    return outcome.value
+  } catch (error) {
+    if (!isSkillRootUnavailableError(error)) {
+      throw error
+    }
+    return { exists: true, commands: [], unavailable: true }
+  }
+}
+
+function mergeScannedCommand(
+  seen: Map<string, DiscoveredClaudeSlashCommand>,
+  command: DiscoveredClaudeSlashCommand
+): void {
+  const existing = seen.get(command.commandFilePath)
+  if (!existing) {
+    seen.set(command.commandFilePath, command)
+    return
+  }
+  if (!existing.description && command.description) {
+    existing.description = command.description
+  }
+}
+
+function compareCommands(a: DiscoveredClaudeSlashCommand, b: DiscoveredClaudeSlashCommand): number {
+  return (
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) ||
+    a.sourceLabel.localeCompare(b.sourceLabel, undefined, { sensitivity: 'base' }) ||
+    a.commandFilePath.localeCompare(b.commandFilePath)
+  )
+}
+
+export async function discoverClaudeSlashCommands(args: {
+  repos?: Repo[]
+  homeDir?: string
+  cwd?: string
+  includeCwd?: boolean
+  providerRootOverrides?: SkillProviderRootOverrides
+  refresh?: boolean
+}): Promise<ClaudeSlashCommandDiscoveryResult> {
+  const homeDir = args.homeDir ?? homedir()
+  const refresh = args.refresh === true
+  const roots = [
+    ...buildClaudeCommandDiscoverySources({ ...args, homeDir }),
+    ...(args.cwd && args.includeCwd !== false
+      ? await discoverNativeClaudePluginCommandSources({ homeDir, cwd: args.cwd })
+      : [])
+  ]
+  const scans = await Promise.all(roots.map((root) => scanRootShared(root, refresh)))
+  const seen = new Map<string, DiscoveredClaudeSlashCommand>()
+  for (const scan of scans) {
+    if (scan.unavailable) {
+      continue
+    }
+    for (const command of scan.commands) {
+      mergeScannedCommand(seen, command)
+    }
+  }
+  const commands = Array.from(seen.values()).sort(compareCommands)
+  return { commands, scannedAt: Date.now() }
+}
+
+export { buildClaudeCommandDiscoverySources } from './claude-command-discovery-sources'

--- a/src/main/skills/claude-command-file-walk.ts
+++ b/src/main/skills/claude-command-file-walk.ts
@@ -1,0 +1,99 @@
+import type { Dirent } from 'node:fs'
+import { readdir, realpath, stat } from 'node:fs/promises'
+import { isAbsolute, join, relative, sep } from 'node:path'
+import { isSkillStagingEntryName } from './skill-delete/staging-names'
+
+const COMMAND_FILE_SUFFIX = '.md'
+
+function isWithinDepth(rootPath: string, childPath: string, maxDepth: number): boolean {
+  const rel = relative(rootPath, childPath)
+  if (!rel) {
+    return true
+  }
+  if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    return false
+  }
+  return rel.split(sep).length <= maxDepth
+}
+
+async function readEntries(dirPath: string): Promise<Dirent[] | null> {
+  try {
+    return await readdir(dirPath, { withFileTypes: true })
+  } catch {
+    return null
+  }
+}
+
+function isCommandMarkdownFile(name: string): boolean {
+  return name.length > COMMAND_FILE_SUFFIX.length && name.endsWith(COMMAND_FILE_SUFFIX)
+}
+
+export async function findCommandMarkdownFiles(
+  rootPath: string,
+  maxDepth: number,
+  signal?: AbortSignal
+): Promise<string[]> {
+  const out: string[] = []
+  const visitedDirectoryPaths = new Set<string>()
+  async function visit(dirPath: string): Promise<void> {
+    signal?.throwIfAborted()
+    if (!isWithinDepth(rootPath, dirPath, maxDepth)) {
+      return
+    }
+    let resolvedDirPath: string
+    try {
+      resolvedDirPath = await realpath(dirPath)
+    } catch {
+      return
+    }
+    if (visitedDirectoryPaths.has(resolvedDirPath)) {
+      return
+    }
+    visitedDirectoryPaths.add(resolvedDirPath)
+
+    const entries = await readEntries(dirPath)
+    if (!entries) {
+      return
+    }
+    for (const entry of entries) {
+      signal?.throwIfAborted()
+      if (isSkillStagingEntryName(entry.name)) {
+        continue
+      }
+      const entryPath = join(dirPath, entry.name)
+      if (isCommandMarkdownFile(entry.name)) {
+        if (entry.isFile()) {
+          out.push(entryPath)
+          continue
+        }
+        if (entry.isSymbolicLink()) {
+          try {
+            if ((await stat(entryPath)).isFile()) {
+              out.push(entryPath)
+            }
+          } catch {
+            // Broken links are not valid command files.
+          }
+        }
+        continue
+      }
+      if (entry.isDirectory()) {
+        await visit(entryPath)
+        continue
+      }
+      if (entry.isSymbolicLink()) {
+        let linksToDirectory = false
+        try {
+          linksToDirectory = (await stat(entryPath)).isDirectory()
+        } catch {
+          // Broken links are not valid command directories.
+        }
+        if (linksToDirectory) {
+          await visit(entryPath)
+        }
+      }
+    }
+  }
+  await visit(rootPath)
+  return out
+}

--- a/src/main/skills/claude-plugin-skill-sources-wsl.ts
+++ b/src/main/skills/claude-plugin-skill-sources-wsl.ts
@@ -3,6 +3,7 @@ import { quoteBashString } from '../wsl-bash-command'
 import { runWslProcess } from '../wsl/wsl-runner'
 import {
   getClaudePluginMetadataPaths,
+  resolveClaudePluginCommandSources,
   resolveClaudePluginSkillSources,
   type ClaudePluginMetadata
 } from './claude-plugin-skill-sources'
@@ -96,4 +97,23 @@ export async function discoverClaudePluginSkillSourcesInWsl(args: {
   )
   const metadata: ClaudePluginMetadata = { installedPlugins, settings }
   return resolveClaudePluginSkillSources({ metadata, cwd: args.cwd, pathApi: pathPosix })
+}
+
+export async function discoverClaudePluginCommandSourcesInWsl(args: {
+  distro: string
+  homeDir: string
+  cwd: string
+}): Promise<SkillScanRoot[]> {
+  const paths = getClaudePluginMetadataPaths(args.homeDir, args.cwd, pathPosix)
+  const orderedPaths = [paths.installedPlugins, ...paths.settings]
+  const output = await executeWslMetadataRead(
+    args.distro,
+    buildWslClaudePluginMetadataCommand(orderedPaths)
+  )
+  const [installedPlugins, ...settings] = parseWslClaudePluginMetadataOutput(
+    output,
+    orderedPaths.length
+  )
+  const metadata: ClaudePluginMetadata = { installedPlugins, settings }
+  return resolveClaudePluginCommandSources({ metadata, cwd: args.cwd, pathApi: pathPosix })
 }

--- a/src/main/skills/claude-plugin-skill-sources.ts
+++ b/src/main/skills/claude-plugin-skill-sources.ts
@@ -185,6 +185,41 @@ export function resolveClaudePluginSkillSources(args: {
   return [...roots.values()]
 }
 
+export function resolveClaudePluginCommandSources(args: {
+  metadata: ClaudePluginMetadata
+  cwd: string
+  pathApi?: SkillDiscoveryPathApi
+}): SkillScanRoot[] {
+  const pathApi = args.pathApi ?? defaultPathApi
+  const installed = parseJsonObject(args.metadata.installedPlugins)?.plugins
+  if (!installed || typeof installed !== 'object' || Array.isArray(installed)) {
+    return []
+  }
+  const enabled = readEnabledPlugins(args.metadata.settings)
+  const roots = new Map<string, SkillScanRoot>()
+  for (const [pluginId, rawInstalls] of Object.entries(installed)) {
+    if (enabled.get(pluginId) !== true || !Array.isArray(rawInstalls)) {
+      continue
+    }
+    const install = selectActiveInstall(rawInstalls, args.cwd, pathApi)
+    if (!install) {
+      continue
+    }
+    const commandsPath = pathApi.join(install.installPath, 'commands')
+    if (!roots.has(commandsPath)) {
+      roots.set(commandsPath, {
+        id: `claude-plugin-commands-${stablePathId(commandsPath)}`,
+        label: `Claude plugin ${safePluginLabel(pluginId, pathApi)} commands`,
+        path: commandsPath,
+        sourceKind: 'plugin',
+        providers: ['claude'],
+        owner: 'claude'
+      })
+    }
+  }
+  return [...roots.values()]
+}
+
 async function readMetadataFile(pathValue: string): Promise<string | null> {
   try {
     const fileStat = await stat(pathValue)
@@ -208,12 +243,28 @@ export async function discoverClaudePluginSkillSources(args: {
   homeDir: string
   cwd: string
 }): Promise<SkillScanRoot[]> {
-  const paths = getClaudePluginMetadataPaths(args.homeDir, args.cwd)
+  const metadata = await readClaudePluginMetadata(args.homeDir, args.cwd)
+  return resolveClaudePluginSkillSources({
+    metadata,
+    cwd: args.cwd
+  })
+}
+
+export async function discoverClaudePluginCommandSources(args: {
+  homeDir: string
+  cwd: string
+}): Promise<SkillScanRoot[]> {
+  const metadata = await readClaudePluginMetadata(args.homeDir, args.cwd)
+  return resolveClaudePluginCommandSources({
+    metadata,
+    cwd: args.cwd
+  })
+}
+
+async function readClaudePluginMetadata(homeDir: string, cwd: string): Promise<ClaudePluginMetadata> {
+  const paths = getClaudePluginMetadataPaths(homeDir, cwd)
   const [installedPlugins, ...settings] = await Promise.all(
     [paths.installedPlugins, ...paths.settings].map(readMetadataFile)
   )
-  return resolveClaudePluginSkillSources({
-    metadata: { installedPlugins, settings },
-    cwd: args.cwd
-  })
+  return { installedPlugins, settings }
 }

--- a/src/preload/api/agent-skill-api.ts
+++ b/src/preload/api/agent-skill-api.ts
@@ -1,4 +1,5 @@
 import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../../shared/skills'
+import type { ClaudeSlashCommandDiscoveryResult } from '../../shared/claude-slash-command-discovery'
 import type {
   SkillCloudOperation,
   SkillCloudOwnedShare,
@@ -40,6 +41,9 @@ import type {
 
 export type SkillsApi = {
   discover: (target?: SkillDiscoveryTarget) => Promise<SkillDiscoveryResult>
+  discoverClaudeCommands: (
+    target?: SkillDiscoveryTarget
+  ) => Promise<ClaudeSlashCommandDiscoveryResult>
   freshnessInventory: () => Promise<SkillFreshnessInventory>
   startUpdateRun: (names: string[]) => Promise<SkillUpdateStartResult>
   cancelUpdateRun: () => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -153,6 +153,7 @@ import type {
   ShellOpenLocalPathResult
 } from '../shared/shell-open-types'
 import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../shared/skills'
+import type { ClaudeSlashCommandDiscoveryResult } from '../shared/claude-slash-command-discovery'
 import type {
   SkillCloudOwnedShare,
   SkillCloudOperation,
@@ -2627,6 +2628,10 @@ const api = {
   skills: {
     discover: (target?: SkillDiscoveryTarget): Promise<SkillDiscoveryResult> =>
       ipcRenderer.invoke('skills:discover', target),
+    discoverClaudeCommands: (
+      target?: SkillDiscoveryTarget
+    ): Promise<ClaudeSlashCommandDiscoveryResult> =>
+      ipcRenderer.invoke('claudeCommands:discover', target),
     freshnessInventory: (): Promise<SkillFreshnessInventory> =>
       ipcRenderer.invoke('skills:freshnessInventory'),
     startUpdateRun: (names: string[]): Promise<SkillUpdateStartResult> =>

--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -4,6 +4,10 @@ import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
 import { getVerifiedNativeChatCommands } from '../../../../shared/native-chat-agent-profiles'
 import {
+  mergeVerifiedAndDiscoveredSlashCommands
+} from '../../../../shared/claude-slash-command-discovery'
+import { getNativeChatAgentProfile } from '../../../../shared/native-chat-agent-profiles'
+import {
   isStructuredAgentSessionComposerCommand,
   STRUCTURED_AGENT_SESSION_SLASH_COMMANDS
 } from '../../../../shared/structured-agent-session-composer'
@@ -28,6 +32,7 @@ import { useNativeChatFileAttachmentActions } from './use-native-chat-file-attac
 import { useNativeChatDictationActions } from './use-native-chat-dictation-actions'
 import { useNativeChatSessionOptionCommand } from './use-native-chat-session-option-command'
 import { useNativeChatPickerState } from './use-native-chat-picker-state'
+import { useNativeChatClaudeCommands } from './use-native-chat-claude-commands'
 import { useNativeChatPickerCommandDispatch } from './use-native-chat-picker-command-dispatch'
 import { useNativeChatTypedInsertion } from './use-native-chat-typed-insertion'
 import type {
@@ -114,13 +119,25 @@ const NativeChatComposerPane = forwardRef<NativeChatComposerHandle, NativeChatCo
       dictationState === 'listening' ||
       dictationState === 'stopping'
 
-    const agentCommands = useMemo(
-      () =>
-        structuredTransport
-          ? STRUCTURED_AGENT_SESSION_SLASH_COMMANDS
-          : getVerifiedNativeChatCommands(agent),
-      [agent, structuredTransport]
+    const profile = useMemo(() => getNativeChatAgentProfile(agent), [agent])
+    const beforeCaret = draft.slice(0, caret)
+    const skillPickerTriggered =
+      profile?.skillPrefix === '$'
+        ? /(?:^|\s)\$\S*$/.test(beforeCaret)
+        : profile?.skillPrefix === '/'
+          ? beforeCaret.startsWith('/') && !/\s/.test(beforeCaret)
+          : false
+    const discoveredClaudeCommands = useNativeChatClaudeCommands(
+      agent,
+      terminalTabId,
+      skillPickerTriggered
     )
+    const agentCommands = useMemo(() => {
+      const verified = structuredTransport
+        ? STRUCTURED_AGENT_SESSION_SLASH_COMMANDS
+        : getVerifiedNativeChatCommands(agent)
+      return mergeVerifiedAndDiscoveredSlashCommands(verified, discoveredClaudeCommands.commands)
+    }, [agent, discoveredClaudeCommands.commands, structuredTransport])
     const picker = useNativeChatPickerState({
       agent,
       terminalTabId,

--- a/src/renderer/src/components/native-chat/use-native-chat-claude-commands.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-claude-commands.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { useAppStore } from '../../store'
+import type { AgentType } from '../../../../shared/agent-status-types'
+import {
+  toSlashCommandSuggestions,
+  type ClaudeSlashCommandDiscoveryResult
+} from '../../../../shared/claude-slash-command-discovery'
+import type { SlashCommandSuggestion } from '../../../../shared/native-chat-slash-commands'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import {
+  resolveNativeChatSkillDiscoveryContext,
+  selectNativeChatSkillStateInputs
+} from './native-chat-skill-discovery-context'
+
+const DISCOVERY_TIMEOUT_MS = 10_000
+const DISCOVERY_BACKSTOP_TIMEOUT_MS = 18_000
+
+export type NativeChatClaudeCommandDiscovery = {
+  status: 'idle' | 'loading' | 'ready' | 'error'
+  commands: readonly SlashCommandSuggestion[]
+  retry: () => void
+}
+
+type StoredState = {
+  status: NativeChatClaudeCommandDiscovery['status']
+  commands: readonly SlashCommandSuggestion[]
+  contextKey: string | null
+}
+
+const IDLE_STATE: StoredState = { status: 'idle', commands: [], contextKey: null }
+const inFlightDiscovery = new Map<string, Promise<ClaudeSlashCommandDiscoveryResult>>()
+
+const CLAUDE_COMMAND_AGENTS = new Set<AgentType>(['claude', 'openclaude'])
+
+export function useNativeChatClaudeCommands(
+  agent: AgentType,
+  terminalTabId: string,
+  enabled = false
+): NativeChatClaudeCommandDiscovery {
+  const inputs = useAppStore(useShallow(selectNativeChatSkillStateInputs))
+  const context = useMemo(
+    () => resolveNativeChatSkillDiscoveryContext(inputs, terminalTabId),
+    [inputs, terminalTabId]
+  )
+  const [state, setState] = useState<StoredState>(IDLE_STATE)
+  const [retryGeneration, setRetryGeneration] = useState(0)
+  const paneDiscoveryCache = useRef(new Map<string, ClaudeSlashCommandDiscoveryResult>())
+  const forceNextDiscovery = useRef(false)
+  const shouldDiscover = enabled && CLAUDE_COMMAND_AGENTS.has(agent)
+
+  useEffect(() => {
+    let cancelled = false
+    if (!shouldDiscover || !context) {
+      forceNextDiscovery.current = false
+      setState(IDLE_STATE)
+      return
+    }
+    if (context.executionHostKind === 'ssh') {
+      setState({ status: 'error', commands: [], contextKey: context.key })
+      return
+    }
+
+    const paneCacheKey = context.key
+    const cached = paneDiscoveryCache.current.get(paneCacheKey)
+    if (cached) {
+      setState({
+        status: 'ready',
+        commands: toSlashCommandSuggestions(cached.commands),
+        contextKey: context.key
+      })
+      return
+    }
+    setState({ status: 'loading', commands: [], contextKey: context.key })
+    const forced = forceNextDiscovery.current
+    forceNextDiscovery.current = false
+    const request = getOrStartDiscovery(context, forced)
+    void request.then(
+      (result) => {
+        paneDiscoveryCache.current.set(paneCacheKey, result)
+        if (cancelled) {
+          return
+        }
+        setState({
+          status: 'ready',
+          commands: toSlashCommandSuggestions(result.commands),
+          contextKey: paneCacheKey
+        })
+      },
+      () => {
+        if (cancelled) {
+          return
+        }
+        setState({ status: 'error', commands: [], contextKey: paneCacheKey })
+      }
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [context, retryGeneration, shouldDiscover])
+
+  const effectiveState = useMemo(
+    () =>
+      !shouldDiscover
+        ? IDLE_STATE
+        : !context
+          ? { status: 'error' as const, commands: [], contextKey: null }
+          : state.contextKey === context.key
+            ? state
+            : { status: 'loading' as const, commands: [], contextKey: context.key },
+    [context, shouldDiscover, state]
+  )
+
+  const retry = useCallback(() => {
+    forceNextDiscovery.current = true
+    if (context) {
+      paneDiscoveryCache.current.delete(context.key)
+      setState({ status: 'loading', commands: [], contextKey: context.key })
+    }
+    setRetryGeneration((generation) => generation + 1)
+  }, [context])
+
+  return useMemo(
+    () => ({
+      status: effectiveState.status,
+      commands: effectiveState.commands,
+      retry
+    }),
+    [effectiveState, retry]
+  )
+}
+
+function getOrStartDiscovery(
+  context: NonNullable<ReturnType<typeof resolveNativeChatSkillDiscoveryContext>>,
+  refresh = false
+): Promise<ClaudeSlashCommandDiscoveryResult> {
+  const existing = inFlightDiscovery.get(context.key)
+  if (existing && !refresh) {
+    return existing
+  }
+  const request = withDiscoveryTimeout(
+    callRuntimeRpc<ClaudeSlashCommandDiscoveryResult>(
+      context.runtimeTarget,
+      'claudeCommands.discover',
+      refresh ? { ...context.discoveryTarget, refresh: true } : context.discoveryTarget,
+      { timeoutMs: DISCOVERY_TIMEOUT_MS }
+    ),
+    DISCOVERY_BACKSTOP_TIMEOUT_MS
+  ).finally(() => {
+    if (inFlightDiscovery.get(context.key) === request) {
+      inFlightDiscovery.delete(context.key)
+    }
+  })
+  inFlightDiscovery.set(context.key, request)
+  return request
+}
+
+function withDiscoveryTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Claude command discovery timed out.')), timeoutMs)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (reason) => {
+        clearTimeout(timer)
+        reject(reason)
+      }
+    )
+  })
+}
+
+export function resetNativeChatClaudeCommandDiscoveryCacheForTests(): void {
+  inFlightDiscovery.clear()
+}

--- a/src/renderer/src/web/preload-api/web-host-capability-api.ts
+++ b/src/renderer/src/web/preload-api/web-host-capability-api.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../../../shared/computer-use-permissions-types'
 import type { SkillFreshnessInventory } from '../../../../shared/skill-freshness'
 import type { SkillDiscoveryResult } from '../../../../shared/skills'
+import type { ClaudeSlashCommandDiscoveryResult } from '../../../../shared/claude-slash-command-discovery'
 import type { SkillDeletePlan, SkillDeleteResult } from '../../../../shared/skill-delete-contract'
 import { SKILL_DELETE_CAPABILITY } from '../../../../shared/skill-install-capability'
 import { callRuntimeResult, getRemoteRuntimeStatus } from './web-runtime-calls'
@@ -146,6 +147,12 @@ export function createSkillsApi(): NonNullable<Partial<PreloadApi>['skills']> {
   return {
     discover: (target) =>
       callRuntimeResult<SkillDiscoveryResult>('skills.discover', target, 15_000),
+    discoverClaudeCommands: (target) =>
+      callRuntimeResult<ClaudeSlashCommandDiscoveryResult>(
+        'claudeCommands.discover',
+        target,
+        15_000
+      ),
     // Why: browser clients have no local skill homes; remote-host freshness stays off until its update rail covers it.
     freshnessInventory: (): Promise<SkillFreshnessInventory> =>
       Promise.resolve({

--- a/src/shared/claude-slash-command-discovery.ts
+++ b/src/shared/claude-slash-command-discovery.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod'
+import type { SlashCommandSuggestion } from './native-chat-slash-commands'
+import type { SkillSourceKind } from './skills'
+import { SkillDiscoveryTargetSchema, type SkillDiscoveryTarget } from './skills'
+
+export type DiscoveredClaudeSlashCommand = {
+  name: string
+  description: string | null
+  commandFilePath: string
+  sourceKind: SkillSourceKind
+  sourceLabel: string
+}
+
+export type ClaudeSlashCommandDiscoveryResult = {
+  commands: DiscoveredClaudeSlashCommand[]
+  scannedAt: number
+}
+
+export const ClaudeSlashCommandDiscoveryTargetSchema: z.ZodType<SkillDiscoveryTarget> =
+  SkillDiscoveryTargetSchema
+
+export function toSlashCommandSuggestions(
+  commands: readonly DiscoveredClaudeSlashCommand[]
+): SlashCommandSuggestion[] {
+  return commands.map((command) => ({
+    name: command.name,
+    ...(command.description ? { description: command.description } : {})
+  }))
+}
+
+export function mergeVerifiedAndDiscoveredSlashCommands(
+  verified: readonly SlashCommandSuggestion[],
+  discovered: readonly SlashCommandSuggestion[]
+): readonly SlashCommandSuggestion[] {
+  const seen = new Set(verified.map((command) => command.name))
+  const extra = discovered.filter((command) => !seen.has(command.name))
+  if (extra.length === 0) {
+    return verified
+  }
+  return [...verified, ...extra]
+}


### PR DESCRIPTION
## ELI5

Chat UI `/` autocomplete only knew a few built-in Claude commands and skills. Custom commands from `.claude/commands` (like `/opsx:apply`) worked when typed in full but never appeared in the picker. This adds discovery for those markdown files and lists them alongside the existing catalog.

## What Changed

- Added host-side discovery for `~/.claude/commands`, project `.claude/commands`, and enabled Claude plugin `commands/` roots.
- Nested paths map to colon names (`opsx/apply.md` → `opsx:apply`); `description:` frontmatter becomes the suggestion subtitle.
- Exposed `claudeCommands.discover` over IPC/runtime RPC; native chat merges discovered commands into slash picker items for Claude/OpenClaude.
- Typed PTY execution path is unchanged.

## Why

Fixes #17697 — skill discovery only walked `skills/` roots, so custom Claude Code commands were never in the picker catalog.

## Linked Issue

Fixes #17697

## Visual Proof

N/A — discovery/autocomplete behavior; no new visible chrome beyond picker rows for discovered commands.

## Testing

- [x] I manually tested these changes locally (unit tests)
- [x] Automated tests added/updated, or explained why not below

- `pnpm test src/main/skills/claude-command-discovery.test.ts src/main/skills/claude-command-discovery-wsl.test.ts`
- `pnpm tc`
- `pnpm run check:code-quality:changed`

## AI Disclosure

<!-- Internal contributor -->

## Review

## Agent skill upstream boundary

N/A