### PR TITLE
fix(terminal): preserve Shift+Enter and remote OSC 52 copy

### DIFF
--- a/src/main/runtime/rpc/methods/terminal/stream-schemas.ts
+++ b/src/main/runtime/rpc/methods/terminal/stream-schemas.ts
@@ -54,7 +54,8 @@ export const TerminalMultiplexSubscribeFrame = TerminalHandle.extend({
       ackOutputSourceRanges: z.literal(1).optional(),
       desktopViewportClaims: z.literal(1).optional(),
       outputPause: z.literal(1).optional(),
-      writeUnavailable: z.literal(1).optional()
+      writeUnavailable: z.literal(1).optional(),
+      clipboardWrite: z.literal(1).optional()
     })
     .optional()
 })

--- a/src/main/runtime/rpc/methods/terminal/stream-schemas.ts
+++ b/src/main/runtime/rpc/methods/terminal/stream-schemas.ts
@@ -55,7 +55,8 @@ export const TerminalMultiplexSubscribeFrame = TerminalHandle.extend({
       desktopViewportClaims: z.literal(1).optional(),
       outputPause: z.literal(1).optional(),
       writeUnavailable: z.literal(1).optional(),
-      clipboardWrite: z.literal(1).optional()
+      clipboardWrite: z.literal(1).optional(),
+      clipboardScannerSync: z.literal(1).optional()
     })
     .optional()
 })

--- a/src/main/runtime/rpc/methods/terminal/terminal-clipboard-scanner-synchronization.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-clipboard-scanner-synchronization.ts
@@ -1,0 +1,42 @@
+import {
+  TerminalStreamOpcode,
+  encodeTerminalStreamText
+} from '../../../../../shared/terminal-stream-protocol'
+import type { TerminalOsc52ScannerSyncState } from '../../../../../shared/terminal-osc52-stream-scanner'
+import type { TerminalMultiplexStream, TerminalOutputChunk } from './terminal-stream-types'
+import { getOutputAfterSnapshotSeq } from './terminal-stream-replay'
+
+export function prepareTerminalSnapshotPendingOutput(args: {
+  stream: TerminalMultiplexStream
+  pendingOutput: TerminalOutputChunk[]
+  snapshotSeq: number | undefined
+  includeAll: boolean
+  sendFrame: (opcode: TerminalStreamOpcode, payload: Uint8Array<ArrayBufferLike>) => boolean
+}): TerminalOutputChunk[] {
+  const uncoveredOutput = args.pendingOutput.flatMap((chunk) => {
+    const uncovered = args.includeAll ? chunk : getOutputAfterSnapshotSeq(chunk, args.snapshotSeq)
+    return uncovered ? [uncovered] : []
+  })
+  sendTerminalClipboardScannerSync(
+    args.stream,
+    uncoveredOutput[0]?.osc52StartState ?? args.stream.osc52Scanner?.syncState ?? 'plain',
+    args.sendFrame,
+    true
+  )
+  return uncoveredOutput
+}
+
+export function sendTerminalClipboardScannerSync(
+  stream: TerminalMultiplexStream,
+  state: TerminalOsc52ScannerSyncState,
+  sendFrame: (opcode: TerminalStreamOpcode, payload: Uint8Array<ArrayBufferLike>) => boolean,
+  restoreDeliveryScanner: boolean
+): void {
+  if (!stream.supportsClipboardScannerSync) {
+    return
+  }
+  if (restoreDeliveryScanner) {
+    stream.osc52DeliveryScanner.restoreSyncState(state)
+  }
+  sendFrame(TerminalStreamOpcode.ClipboardScannerSync, encodeTerminalStreamText(state))
+}

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-flow-control.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-flow-control.ts
@@ -1,9 +1,4 @@
 import {
-  TerminalStreamOpcode,
-  decodeTerminalStreamJson,
-  decodeTerminalStreamText
-} from '../../../../../shared/terminal-stream-protocol'
-import {
   TERMINAL_MULTIPLEX_ACK_STREAM_MAX_WINDOW_BYTES,
   TERMINAL_MULTIPLEX_ACK_TOTAL_MAX_WINDOW_BYTES
 } from '../../../../../shared/terminal-multiplex-flow-control'
@@ -19,24 +14,7 @@ import type {
 } from './terminal-multiplex-connection'
 import type { TerminalMultiplexStream } from './terminal-stream-types'
 import type { RemoteTerminalSourceRangeReplacementReservation } from '../../../remote-terminal-source-range-consumer'
-import type { TerminalOutputFrameChunk } from '../../terminal-output-frame-chunks'
-
-function scanPendingOsc52Output(
-  stream: TerminalMultiplexStream,
-  chunk: TerminalOutputFrameChunk
-): void {
-  if (!stream.supportsClipboardWrite) {
-    return
-  }
-  if (chunk.opcode === TerminalStreamOpcode.OutputSpan) {
-    const span = decodeTerminalStreamJson<{ data?: unknown }>(chunk.bytes)
-    if (typeof span?.data === 'string') {
-      stream.osc52Scanner.scan(span.data)
-    }
-    return
-  }
-  stream.osc52Scanner.scan(decodeTerminalStreamText(chunk.bytes))
-}
+import { sendTerminalClipboardScannerSync } from './terminal-clipboard-scanner-synchronization'
 
 export function installMultiplexFlowControl(
   build: TerminalMultiplexFrameDeliveryStage
@@ -86,7 +64,6 @@ export function installMultiplexFlowControl(
         stream.sourceRangeReplacement = replacement
       }
       const displayMode = runtime.getMobileDisplayMode(stream.ptyId)
-      stream.osc52Scanner.reset()
       const publication = sendSnapshotFrames(
         (opcode, payload) =>
           !state.closed &&
@@ -146,9 +123,12 @@ export function installMultiplexFlowControl(
           0
         )
       }
-      for (const chunk of stream.ackPendingOutput) {
-        scanPendingOsc52Output(stream, chunk)
-      }
+      sendTerminalClipboardScannerSync(
+        stream,
+        stream.ackPendingOutput[0]?.osc52StartState ?? stream.osc52Scanner?.syncState ?? 'plain',
+        (opcode, payload) => state.sendFrame(stream.streamId, opcode, payload),
+        false
+      )
       stream.ackPendingOutputOverflowed = false
     } catch (error) {
       if (replacement) {

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-flow-control.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-flow-control.ts
@@ -1,4 +1,9 @@
 import {
+  TerminalStreamOpcode,
+  decodeTerminalStreamJson,
+  decodeTerminalStreamText
+} from '../../../../../shared/terminal-stream-protocol'
+import {
   TERMINAL_MULTIPLEX_ACK_STREAM_MAX_WINDOW_BYTES,
   TERMINAL_MULTIPLEX_ACK_TOTAL_MAX_WINDOW_BYTES
 } from '../../../../../shared/terminal-multiplex-flow-control'
@@ -14,6 +19,24 @@ import type {
 } from './terminal-multiplex-connection'
 import type { TerminalMultiplexStream } from './terminal-stream-types'
 import type { RemoteTerminalSourceRangeReplacementReservation } from '../../../remote-terminal-source-range-consumer'
+import type { TerminalOutputFrameChunk } from '../../terminal-output-frame-chunks'
+
+function scanPendingOsc52Output(
+  stream: TerminalMultiplexStream,
+  chunk: TerminalOutputFrameChunk
+): void {
+  if (!stream.supportsClipboardWrite) {
+    return
+  }
+  if (chunk.opcode === TerminalStreamOpcode.OutputSpan) {
+    const span = decodeTerminalStreamJson<{ data?: unknown }>(chunk.bytes)
+    if (typeof span?.data === 'string') {
+      stream.osc52Scanner.scan(span.data)
+    }
+    return
+  }
+  stream.osc52Scanner.scan(decodeTerminalStreamText(chunk.bytes))
+}
 
 export function installMultiplexFlowControl(
   build: TerminalMultiplexFrameDeliveryStage
@@ -30,6 +53,7 @@ export function installMultiplexFlowControl(
       return
     }
     stream.ackRecoverySnapshotInFlight = true
+    stream.outputBatcher.flush()
     let replacement: RemoteTerminalSourceRangeReplacementReservation | null = null
     try {
       const serialized = await serializeBudgetedRequestedSnapshot(runtime, stream.ptyId, 0)
@@ -62,6 +86,7 @@ export function installMultiplexFlowControl(
         stream.sourceRangeReplacement = replacement
       }
       const displayMode = runtime.getMobileDisplayMode(stream.ptyId)
+      stream.osc52Scanner.reset()
       const publication = sendSnapshotFrames(
         (opcode, payload) =>
           !state.closed &&
@@ -120,6 +145,9 @@ export function installMultiplexFlowControl(
           (total, chunk) => total + chunk.bytes.byteLength,
           0
         )
+      }
+      for (const chunk of stream.ackPendingOutput) {
+        scanPendingOsc52Output(stream, chunk)
       }
       stream.ackPendingOutputOverflowed = false
     } catch (error) {

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-frame-delivery.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-frame-delivery.ts
@@ -1,5 +1,7 @@
 import {
   TerminalStreamOpcode,
+  decodeTerminalStreamJson,
+  decodeTerminalStreamText,
   encodeTerminalStreamFrame,
   encodeTerminalStreamJson,
   encodeTerminalStreamText
@@ -13,6 +15,24 @@ import type {
 import type { TerminalOutputFrameChunk } from '../../terminal-output-frame-chunks'
 import type { TerminalStreamInputOutcome } from './terminal-input-delivery'
 import type { TerminalMultiplexStream } from './terminal-stream-types'
+
+function scanDeliveredOsc52Output(
+  stream: TerminalMultiplexStream,
+  chunk: TerminalOutputFrameChunk
+): void {
+  if (!stream.supportsClipboardScannerSync) {
+    return
+  }
+  chunk.osc52StartState = stream.osc52DeliveryScanner.syncState
+  if (chunk.opcode === TerminalStreamOpcode.OutputSpan) {
+    const span = decodeTerminalStreamJson<{ data?: unknown }>(chunk.bytes)
+    if (typeof span?.data === 'string') {
+      stream.osc52DeliveryScanner.scan(span.data)
+    }
+    return
+  }
+  stream.osc52DeliveryScanner.scan(decodeTerminalStreamText(chunk.bytes))
+}
 
 export function installMultiplexFrameDelivery(
   build: TerminalMultiplexConnectionBase
@@ -140,6 +160,7 @@ export function installMultiplexFrameDelivery(
     if (state.closed || streams.get(stream.streamId) !== stream || stream.outputPaused) {
       return
     }
+    scanDeliveredOsc52Output(stream, chunk)
     if (
       stream.ackPendingOutputOverflowed ||
       stream.ackPendingOutput.length > 0 ||

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-initial-snapshot.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-initial-snapshot.ts
@@ -89,6 +89,7 @@ export async function publishMultiplexInitialSnapshot(
           'initial-snapshot'
         )
       : null
+  stream.osc52Scanner.reset()
   const snapshotPublication = sendSnapshotFrames(
     (opcode, payload) => state.sendFrame(request.streamId, opcode, payload),
     {
@@ -135,6 +136,9 @@ export async function publishMultiplexInitialSnapshot(
     for (const chunk of pendingOutput) {
       const uncovered = getOutputAfterSnapshotSeq(chunk, snapshotOutputSeq)
       if (uncovered) {
+        if (stream.supportsClipboardWrite) {
+          stream.osc52Scanner.scan(uncovered.data)
+        }
         stream.outputBatcher.push(uncovered.data, uncovered.meta)
       }
     }

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-initial-snapshot.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-initial-snapshot.ts
@@ -60,10 +60,13 @@ export async function publishMultiplexInitialSnapshot(
     rows: serialized?.rows ?? size?.rows,
     displayMode,
     seq: layoutSeq,
-    ...((stream.ackOutputSourceRanges || stream.supportsOutputPause) && {
+    ...((stream.ackOutputSourceRanges ||
+      stream.supportsOutputPause ||
+      stream.supportsClipboardWrite) && {
       capabilities: {
         ...(stream.ackOutputSourceRanges ? { ackOutputSourceRanges: 1 as const } : {}),
-        ...(stream.supportsOutputPause ? { outputPause: 1 as const } : {})
+        ...(stream.supportsOutputPause ? { outputPause: 1 as const } : {}),
+        ...(stream.supportsClipboardWrite ? { clipboardWrite: 1 as const } : {})
       }
     }),
     ...(stream.ackOutputSourceRanges ? { streamGeneration: stream.streamGeneration } : {}),

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-initial-snapshot.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-initial-snapshot.ts
@@ -3,6 +3,7 @@ import {
   serializeBudgetedMobileSnapshot
 } from './terminal-snapshot-publication'
 import { getOutputAfterSnapshotSeq } from './terminal-stream-replay'
+import { sendTerminalClipboardScannerSync } from './terminal-clipboard-scanner-synchronization'
 import type {
   MultiplexSubscribeRequest,
   TerminalMultiplexConnection
@@ -89,7 +90,6 @@ export async function publishMultiplexInitialSnapshot(
           'initial-snapshot'
         )
       : null
-  stream.osc52Scanner.reset()
   const snapshotPublication = sendSnapshotFrames(
     (opcode, payload) => state.sendFrame(request.streamId, opcode, payload),
     {
@@ -132,16 +132,20 @@ export async function publishMultiplexInitialSnapshot(
   stream.lastResizeCols = serialized?.cols ?? size?.cols
   stream.buffering = false
   const pendingOutput = stream.pendingOutput.splice(0)
-  if (!initialOutputOverflowed) {
-    for (const chunk of pendingOutput) {
-      const uncovered = getOutputAfterSnapshotSeq(chunk, snapshotOutputSeq)
-      if (uncovered) {
-        if (stream.supportsClipboardWrite) {
-          stream.osc52Scanner.scan(uncovered.data)
-        }
-        stream.outputBatcher.push(uncovered.data, uncovered.meta)
-      }
-    }
+  const uncoveredOutput = initialOutputOverflowed
+    ? []
+    : pendingOutput.flatMap((chunk) => {
+        const uncovered = getOutputAfterSnapshotSeq(chunk, snapshotOutputSeq)
+        return uncovered ? [uncovered] : []
+      })
+  sendTerminalClipboardScannerSync(
+    stream,
+    uncoveredOutput[0]?.osc52StartState ?? stream.osc52Scanner?.syncState ?? 'plain',
+    (opcode, payload) => state.sendFrame(request.streamId, opcode, payload),
+    true
+  )
+  for (const chunk of uncoveredOutput) {
+    stream.outputBatcher.push(chunk.data, chunk.meta)
   }
   stream.pendingOutputBytes = 0
   stream.pendingOutputOverflowed = false

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-initial-snapshot.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-initial-snapshot.ts
@@ -62,11 +62,13 @@ export async function publishMultiplexInitialSnapshot(
     seq: layoutSeq,
     ...((stream.ackOutputSourceRanges ||
       stream.supportsOutputPause ||
-      stream.supportsClipboardWrite) && {
+      stream.supportsClipboardWrite ||
+      stream.supportsClipboardScannerSync) && {
       capabilities: {
         ...(stream.ackOutputSourceRanges ? { ackOutputSourceRanges: 1 as const } : {}),
         ...(stream.supportsOutputPause ? { outputPause: 1 as const } : {}),
-        ...(stream.supportsClipboardWrite ? { clipboardWrite: 1 as const } : {})
+        ...(stream.supportsClipboardWrite ? { clipboardWrite: 1 as const } : {}),
+        ...(stream.supportsClipboardScannerSync ? { clipboardScannerSync: 1 as const } : {})
       }
     }),
     ...(stream.ackOutputSourceRanges ? { streamGeneration: stream.streamGeneration } : {}),

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-slot-frames.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-slot-frames.ts
@@ -2,7 +2,6 @@ import {
   TerminalStreamOpcode,
   decodeTerminalStreamJson,
   decodeTerminalStreamText,
-  encodeTerminalStreamText,
   type TerminalStreamFrame
 } from '../../../../../shared/terminal-stream-protocol'
 import {
@@ -11,15 +10,16 @@ import {
   TerminalMultiplexSourceRangeAckFrame
 } from './stream-schemas'
 import { isTerminalInputLockedForClient, sendTerminalStreamInput } from './terminal-input-delivery'
-import {
-  getOutputAfterSnapshotSeq,
-  normalizeMultiplexSnapshotScrollbackRows
-} from './terminal-stream-replay'
+import { normalizeMultiplexSnapshotScrollbackRows } from './terminal-stream-replay'
 import {
   sendSnapshotFrames,
   serializeBudgetedRequestedSnapshot
 } from './terminal-snapshot-publication'
 import { updateViewportForClient } from './terminal-viewport-update'
+import {
+  prepareTerminalSnapshotPendingOutput,
+  sendTerminalClipboardScannerSync
+} from './terminal-clipboard-scanner-synchronization'
 import type {
   MultiplexSnapshotRequest,
   TerminalMultiplexCleanupStage,
@@ -90,11 +90,12 @@ export function installMultiplexSlotFrames(
       if (typeof payload?.paused !== 'boolean' || stream.outputPaused === payload.paused) {
         return
       }
-      if (!payload.paused && stream.supportsClipboardScannerSync) {
-        state.sendFrame(
-          stream.streamId,
-          TerminalStreamOpcode.ClipboardScannerSync,
-          encodeTerminalStreamText(stream.osc52Scanner.syncState)
+      if (!payload.paused) {
+        sendTerminalClipboardScannerSync(
+          stream,
+          stream.osc52Scanner.syncState,
+          (opcode, encoded) => state.sendFrame(stream.streamId, opcode, encoded),
+          true
         )
       }
       stream.outputPaused = payload.paused
@@ -215,7 +216,6 @@ export function installMultiplexSlotFrames(
         size = runtime.getTerminalSize(stream.ptyId)
         displayMode = runtime.getMobileDisplayMode(stream.ptyId)
         if (stream.pendingOutputOverflowed) {
-          stream.osc52Scanner.reset()
           sendSnapshotFrames(
             (opcode, payload) => state.sendFrame(stream.streamId, opcode, payload),
             {
@@ -234,7 +234,6 @@ export function installMultiplexSlotFrames(
         }
       }
       sentSnapshotOutputSeq = serialized?.seq
-      stream.osc52Scanner.reset()
       sendSnapshotFrames((opcode, payload) => state.sendFrame(stream.streamId, opcode, payload), {
         kind: 'scrollback',
         cols: serialized?.cols ?? size?.cols ?? 80,
@@ -265,21 +264,16 @@ export function installMultiplexSlotFrames(
         const shouldFlushPendingOutput = !stream.pendingOutputOverflowed
         stream.buffering = false
         const pendingOutput = stream.pendingOutput.splice(0)
-        if (shouldFlushPendingOutput) {
-          for (const chunk of pendingOutput) {
-            // Why: an untagged reply resets the client to the snapshot's
-            // high-water, so covered bytes would render twice; tagged
-            // snapshots feed a side consumer and the live view still
-            // needs every buffered chunk.
-            const uncovered =
-              typeof requestId === 'number'
-                ? chunk
-                : getOutputAfterSnapshotSeq(chunk, sentSnapshotOutputSeq)
-            if (uncovered) {
-              stream.osc52Scanner.scan(uncovered.data)
-              stream.outputBatcher.push(uncovered.data, uncovered.meta)
-            }
-          }
+        const uncoveredOutput = prepareTerminalSnapshotPendingOutput({
+          stream,
+          pendingOutput: shouldFlushPendingOutput ? pendingOutput : [],
+          snapshotSeq: sentSnapshotOutputSeq,
+          // Why: tagged snapshots feed a side consumer and still need every live chunk.
+          includeAll: typeof requestId === 'number',
+          sendFrame: (opcode, payload) => state.sendFrame(stream.streamId, opcode, payload)
+        })
+        for (const chunk of uncoveredOutput) {
+          stream.outputBatcher.push(chunk.data, chunk.meta)
         }
         stream.pendingOutputBytes = 0
         stream.pendingOutputOverflowed = false

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-slot-frames.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-slot-frames.ts
@@ -2,6 +2,7 @@ import {
   TerminalStreamOpcode,
   decodeTerminalStreamJson,
   decodeTerminalStreamText,
+  encodeTerminalStreamText,
   type TerminalStreamFrame
 } from '../../../../../shared/terminal-stream-protocol'
 import {
@@ -88,6 +89,13 @@ export function installMultiplexSlotFrames(
       const payload = decodeTerminalStreamJson<{ paused?: unknown }>(frame.payload)
       if (typeof payload?.paused !== 'boolean' || stream.outputPaused === payload.paused) {
         return
+      }
+      if (!payload.paused && stream.supportsClipboardScannerSync) {
+        state.sendFrame(
+          stream.streamId,
+          TerminalStreamOpcode.ClipboardScannerSync,
+          encodeTerminalStreamText(stream.osc52Scanner.syncState)
+        )
       }
       stream.outputPaused = payload.paused
       if (stream.outputPaused) {

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-slot-frames.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-slot-frames.ts
@@ -215,6 +215,7 @@ export function installMultiplexSlotFrames(
         size = runtime.getTerminalSize(stream.ptyId)
         displayMode = runtime.getMobileDisplayMode(stream.ptyId)
         if (stream.pendingOutputOverflowed) {
+          stream.osc52Scanner.reset()
           sendSnapshotFrames(
             (opcode, payload) => state.sendFrame(stream.streamId, opcode, payload),
             {
@@ -233,6 +234,7 @@ export function installMultiplexSlotFrames(
         }
       }
       sentSnapshotOutputSeq = serialized?.seq
+      stream.osc52Scanner.reset()
       sendSnapshotFrames((opcode, payload) => state.sendFrame(stream.streamId, opcode, payload), {
         kind: 'scrollback',
         cols: serialized?.cols ?? size?.cols ?? 80,
@@ -274,6 +276,7 @@ export function installMultiplexSlotFrames(
                 ? chunk
                 : getOutputAfterSnapshotSeq(chunk, sentSnapshotOutputSeq)
             if (uncovered) {
+              stream.osc52Scanner.scan(uncovered.data)
               stream.outputBatcher.push(uncovered.data, uncovered.meta)
             }
           }

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-stream-initialization.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-stream-initialization.ts
@@ -65,6 +65,7 @@ export async function initializeMultiplexStream(
       request.capabilities?.clipboardWrite === 1 &&
       request.capabilities?.clipboardScannerSync === 1,
     osc52Scanner: new TerminalOsc52StreamScanner(),
+    osc52DeliveryScanner: new TerminalOsc52StreamScanner(),
     outputPaused: false,
     supportsDesktopViewportClaims: request.capabilities?.desktopViewportClaims === 1,
     desktopClaimTail: Promise.resolve(true),
@@ -112,6 +113,9 @@ export async function initializeMultiplexStream(
     if (state.closed || streams.get(request.streamId) !== stream) {
       return
     }
+    const osc52StartState = stream.supportsClipboardWrite
+      ? stream.osc52Scanner.syncState
+      : undefined
     if (stream.supportsClipboardWrite) {
       const payload = stream.osc52Scanner
         .scan(data)
@@ -129,7 +133,7 @@ export async function initializeMultiplexStream(
       return
     }
     if (stream.buffering) {
-      appendPendingMultiplexOutput(stream, data, meta)
+      appendPendingMultiplexOutput(stream, data, meta, osc52StartState)
       return
     }
     stream.outputBatcher.push(data, meta)

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-stream-initialization.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-stream-initialization.ts
@@ -1,12 +1,17 @@
 import { randomUUID } from 'node:crypto'
 import {
   TerminalStreamOpcode,
-  encodeTerminalStreamJson
+  encodeTerminalStreamJson,
+  encodeTerminalStreamText
 } from '../../../../../shared/terminal-stream-protocol'
 import { iterateTerminalOutputFrameChunks } from '../../terminal-output-frame-chunks'
 import { TERMINAL_MULTIPLEX_ACK_STREAM_INITIAL_WINDOW_BYTES } from '../../../../../shared/terminal-multiplex-flow-control'
 import { createTerminalOutputBatcher } from './terminal-output-batcher'
 import { appendPendingMultiplexOutput } from './terminal-stream-replay'
+import {
+  TerminalOsc52StreamScanner,
+  isTerminalOsc52ClipboardQuery
+} from '../../../../../shared/terminal-osc52-stream-scanner'
 import { updateViewportForClient } from './terminal-viewport-update'
 import type {
   MultiplexSubscribeRequest,
@@ -55,6 +60,8 @@ export async function initializeMultiplexStream(
     ackWindowBytes: TERMINAL_MULTIPLEX_ACK_STREAM_INITIAL_WINDOW_BYTES,
     supportsOutputPause: request.capabilities?.outputPause === 1,
     supportsWriteUnavailable: request.capabilities?.writeUnavailable === 1,
+    supportsClipboardWrite: request.capabilities?.clipboardWrite === 1,
+    osc52Scanner: new TerminalOsc52StreamScanner(),
     outputPaused: false,
     supportsDesktopViewportClaims: request.capabilities?.desktopViewportClaims === 1,
     desktopClaimTail: Promise.resolve(true),
@@ -101,6 +108,19 @@ export async function initializeMultiplexStream(
   const unsubscribeStreamData = runtime.subscribeToTerminalData(ptyId, (data, meta) => {
     if (state.closed || streams.get(request.streamId) !== stream) {
       return
+    }
+    if (stream.supportsClipboardWrite) {
+      const payload = stream.osc52Scanner
+        .scan(data)
+        .payloads.findLast((candidate) => !isTerminalOsc52ClipboardQuery(candidate))
+      if (payload !== undefined) {
+        state.sendFrame(
+          request.streamId,
+          TerminalStreamOpcode.ClipboardWrite,
+          encodeTerminalStreamText(payload),
+          meta?.seq
+        )
+      }
     }
     if (stream.outputPaused) {
       return

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-stream-initialization.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-stream-initialization.ts
@@ -61,6 +61,9 @@ export async function initializeMultiplexStream(
     supportsOutputPause: request.capabilities?.outputPause === 1,
     supportsWriteUnavailable: request.capabilities?.writeUnavailable === 1,
     supportsClipboardWrite: request.capabilities?.clipboardWrite === 1,
+    supportsClipboardScannerSync:
+      request.capabilities?.clipboardWrite === 1 &&
+      request.capabilities?.clipboardScannerSync === 1,
     osc52Scanner: new TerminalOsc52StreamScanner(),
     outputPaused: false,
     supportsDesktopViewportClaims: request.capabilities?.desktopViewportClaims === 1,

--- a/src/main/runtime/rpc/methods/terminal/terminal-stream-replay.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-stream-replay.ts
@@ -1,5 +1,9 @@
 import type { TerminalReplyQuerySequence } from '../../../../../shared/terminal-reply-query-scan'
 import {
+  TerminalOsc52StreamScanner,
+  type TerminalOsc52ScannerSyncState
+} from '../../../../../shared/terminal-osc52-stream-scanner'
+import {
   iterateTerminalOutputFrameChunks,
   sliceTerminalOutputSourceRanges,
   type TerminalOutputFrameChunk,
@@ -15,7 +19,8 @@ import type { TerminalMultiplexStream, TerminalOutputChunk } from './terminal-st
 export function appendPendingMultiplexOutput(
   stream: TerminalMultiplexStream,
   data: string,
-  meta?: TerminalOutputMeta
+  meta?: TerminalOutputMeta,
+  osc52StartState?: TerminalOsc52ScannerSyncState
 ): void {
   const remainingBudget = Math.max(
     1,
@@ -24,7 +29,7 @@ export function appendPendingMultiplexOutput(
   const measurement = measureTerminalStreamByteLength(data, {
     stopAfterBytes: remainingBudget
   })
-  stream.pendingOutput.push({ data, bytes: measurement.byteLength, meta })
+  stream.pendingOutput.push({ data, bytes: measurement.byteLength, meta, osc52StartState })
   stream.pendingOutputBytes += measurement.byteLength
   const trimmed = trimPendingOutputToBudget(stream.pendingOutput, stream.pendingOutputBytes)
   stream.pendingOutputBytes = trimmed.bytes
@@ -53,6 +58,13 @@ export function getOutputAfterSnapshotSeq(
     return null
   }
   const offset = snapshotSeq - chunkStartSeq
+  let osc52StartState = chunk.osc52StartState
+  if (osc52StartState) {
+    const scanner = new TerminalOsc52StreamScanner()
+    scanner.restoreSyncState(osc52StartState)
+    scanner.scan(chunk.data.slice(0, offset))
+    osc52StartState = scanner.syncState
+  }
   return {
     data: chunk.data.slice(offset),
     bytes: chunk.bytes,
@@ -64,7 +76,8 @@ export function getOutputAfterSnapshotSeq(
         offset,
         chunk.data.length
       )
-    }
+    },
+    osc52StartState
   }
 }
 

--- a/src/main/runtime/rpc/methods/terminal/terminal-stream-types.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-stream-types.ts
@@ -71,6 +71,7 @@ export type TerminalMultiplexStream = {
   supportsOutputPause: boolean
   supportsWriteUnavailable: boolean
   supportsClipboardWrite: boolean
+  supportsClipboardScannerSync: boolean
   osc52Scanner: TerminalOsc52StreamScanner
   outputPaused: boolean
   supportsDesktopViewportClaims: boolean

--- a/src/main/runtime/rpc/methods/terminal/terminal-stream-types.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-stream-types.ts
@@ -1,5 +1,8 @@
 import type { TerminalOscLinkRange } from '../../../../../shared/terminal-osc-link-ranges'
-import type { TerminalOsc52StreamScanner } from '../../../../../shared/terminal-osc52-stream-scanner'
+import type {
+  TerminalOsc52ScannerSyncState,
+  TerminalOsc52StreamScanner
+} from '../../../../../shared/terminal-osc52-stream-scanner'
 import type { TerminalSnapshotUnavailableReason } from '../../../../../shared/terminal-snapshot-unavailability'
 import type { TerminalSourceRangeLedger } from '../../terminal-source-range-ledger'
 import type { RemoteTerminalSourceRangeReplacementReservation } from '../../../remote-terminal-source-range-consumer'
@@ -73,6 +76,7 @@ export type TerminalMultiplexStream = {
   supportsClipboardWrite: boolean
   supportsClipboardScannerSync: boolean
   osc52Scanner: TerminalOsc52StreamScanner
+  osc52DeliveryScanner: TerminalOsc52StreamScanner
   outputPaused: boolean
   supportsDesktopViewportClaims: boolean
   desktopClaimTail: Promise<boolean>
@@ -105,4 +109,5 @@ export type TerminalOutputChunk = {
   data: string
   bytes: number
   meta?: TerminalOutputMeta
+  osc52StartState?: TerminalOsc52ScannerSyncState
 }

--- a/src/main/runtime/rpc/methods/terminal/terminal-stream-types.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-stream-types.ts
@@ -1,4 +1,5 @@
 import type { TerminalOscLinkRange } from '../../../../../shared/terminal-osc-link-ranges'
+import type { TerminalOsc52StreamScanner } from '../../../../../shared/terminal-osc52-stream-scanner'
 import type { TerminalSnapshotUnavailableReason } from '../../../../../shared/terminal-snapshot-unavailability'
 import type { TerminalSourceRangeLedger } from '../../terminal-source-range-ledger'
 import type { RemoteTerminalSourceRangeReplacementReservation } from '../../../remote-terminal-source-range-consumer'
@@ -69,6 +70,8 @@ export type TerminalMultiplexStream = {
   ackWindowBytes: number
   supportsOutputPause: boolean
   supportsWriteUnavailable: boolean
+  supportsClipboardWrite: boolean
+  osc52Scanner: TerminalOsc52StreamScanner
   outputPaused: boolean
   supportsDesktopViewportClaims: boolean
   desktopClaimTail: Promise<boolean>

--- a/src/main/runtime/rpc/terminal-output-frame-chunks.ts
+++ b/src/main/runtime/rpc/terminal-output-frame-chunks.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../shared/terminal-stream-protocol'
 import { TERMINAL_STREAM_CHUNK_BYTES } from '../../../shared/terminal-multiplex-flow-control'
 import type { TerminalOutputSourceRange } from '../../../shared/terminal-output-source-range'
+import type { TerminalOsc52ScannerSyncState } from '../../../shared/terminal-osc52-stream-scanner'
 import { terminalStreamByteLength } from './terminal-stream-byte-length'
 
 export type TerminalOutputMeta = {
@@ -21,6 +22,7 @@ export type TerminalOutputFrameChunk = {
   seq?: number
   opcode?: TerminalStreamOpcode
   sourceRanges?: readonly TerminalOutputSourceRange[]
+  osc52StartState?: TerminalOsc52ScannerSyncState
 }
 
 export const TERMINAL_STREAM_BYTE_PROBE_CODE_UNITS = 8 * 1024

--- a/src/main/runtime/runtime-rpc-mobile-terminal-streaming.test.ts
+++ b/src/main/runtime/runtime-rpc-mobile-terminal-streaming.test.ts
@@ -673,12 +673,16 @@ describe('OrcaRuntimeRpcServer', () => {
         })
       )
       await vi.waitFor(() => {
-        const snapshotStarted = binaryFrames
+        const frames = binaryFrames
           .map((frame) => decodeTerminalStreamFrame(frame))
-          .some(
-            (frame) => frame?.opcode === TerminalStreamOpcode.SnapshotStart && frame.streamId === 22
-          )
-        expect(snapshotStarted).toBe(true)
+          .filter((frame) => frame?.streamId === 22)
+        expect(frames.some((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotEnd)).toBe(
+          true
+        )
+        const scannerSync = frames.find(
+          (frame) => frame?.opcode === TerminalStreamOpcode.ClipboardScannerSync
+        )
+        expect(scannerSync && decodeTerminalStreamText(scannerSync.payload)).toBe('payload')
       })
       binaryFrames.splice(0)
       runtime.onPtyData('multiplex-active-pty', 'dGlhbA==\x07after-snapshot', 7)
@@ -687,9 +691,10 @@ describe('OrcaRuntimeRpcServer', () => {
           .map((frame) => decodeTerminalStreamFrame(frame))
           .filter((frame) => frame?.streamId === 22)
         expect(frames.some((frame) => frame?.opcode === TerminalStreamOpcode.Output)).toBe(true)
-        expect(frames.some((frame) => frame?.opcode === TerminalStreamOpcode.ClipboardWrite)).toBe(
-          false
-        )
+        const clipboardWrites = frames
+          .filter((frame) => frame?.opcode === TerminalStreamOpcode.ClipboardWrite)
+          .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+        expect(clipboardWrites).toEqual(['c;cGFydGlhbA=='])
       })
       binaryFrames.splice(0)
 

--- a/src/main/runtime/runtime-rpc-mobile-terminal-streaming.test.ts
+++ b/src/main/runtime/runtime-rpc-mobile-terminal-streaming.test.ts
@@ -570,7 +570,7 @@ describe('OrcaRuntimeRpcServer', () => {
             streamId: 22,
             terminal: activeTerminal.handle,
             client: { id: 'desktop-active', type: 'desktop' },
-            capabilities: { ackOutput: 1 }
+            capabilities: { ackOutput: 1, clipboardWrite: 1, outputPause: 1 }
           })
         })
       )
@@ -581,6 +581,58 @@ describe('OrcaRuntimeRpcServer', () => {
           .map((result) => result?.streamId)
         expect(subscribedStreamIds).toEqual(expect.arrayContaining([21, 22]))
       })
+      binaryFrames.splice(0)
+
+      runtime.onPtyData('multiplex-active-pty', '\x1b]52;c;Y29weQ==\x07', 1)
+      await vi.waitFor(() => {
+        const clipboardWrites = binaryFrames
+          .map((frame) => decodeTerminalStreamFrame(frame))
+          .filter(
+            (frame) =>
+              frame?.opcode === TerminalStreamOpcode.ClipboardWrite && frame.streamId === 22
+          )
+          .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+        expect(clipboardWrites).toEqual(['c;Y29weQ=='])
+      })
+      binaryFrames.splice(0)
+
+      subscription.sendBinary(
+        encodeTerminalStreamFrame({
+          seq: 3,
+          opcode: TerminalStreamOpcode.SetOutputPaused,
+          streamId: 22,
+          payload: encodeTerminalStreamJson({ paused: true })
+        })
+      )
+      runtime.onPtyData('multiplex-active-pty', '\x1b]52;c;aGlkZGVu\x07', 2)
+      await vi.waitFor(() => {
+        const frames = binaryFrames
+          .map((frame) => decodeTerminalStreamFrame(frame))
+          .filter((frame) => frame?.streamId === 22)
+        expect(
+          frames
+            .filter((frame) => frame?.opcode === TerminalStreamOpcode.ClipboardWrite)
+            .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+        ).toEqual(['c;aGlkZGVu'])
+        expect(frames.some((frame) => frame?.opcode === TerminalStreamOpcode.Output)).toBe(false)
+      })
+      binaryFrames.splice(0)
+      runtime.onPtyData('multiplex-active-pty', '\x1b]52;c;?\x07', 3)
+      await Promise.resolve()
+      expect(
+        binaryFrames
+          .map((frame) => decodeTerminalStreamFrame(frame))
+          .some((frame) => frame?.opcode === TerminalStreamOpcode.ClipboardWrite)
+      ).toBe(false)
+
+      subscription.sendBinary(
+        encodeTerminalStreamFrame({
+          seq: 4,
+          opcode: TerminalStreamOpcode.SetOutputPaused,
+          streamId: 22,
+          payload: encodeTerminalStreamJson({ paused: false })
+        })
+      )
       binaryFrames.splice(0)
 
       const backgroundOutput = 'B'.repeat(700 * 1024)
@@ -598,7 +650,7 @@ describe('OrcaRuntimeRpcServer', () => {
       })
 
       const frameCountBeforeActive = binaryFrames.length
-      runtime.onPtyData('multiplex-active-pty', 'ACTIVE_MULTIPLEX_READY\r\n', 2)
+      runtime.onPtyData('multiplex-active-pty', 'ACTIVE_MULTIPLEX_READY\r\n', 3)
       await vi.waitFor(() => {
         const activeOutput = binaryFrames
           .slice(frameCountBeforeActive)
@@ -611,7 +663,7 @@ describe('OrcaRuntimeRpcServer', () => {
 
       subscription.sendBinary(
         encodeTerminalStreamFrame({
-          seq: 3,
+          seq: 5,
           opcode: TerminalStreamOpcode.Input,
           streamId: 22,
           payload: encodeTerminalStreamText('still interactive\r')
@@ -630,7 +682,7 @@ describe('OrcaRuntimeRpcServer', () => {
         .reduce((total, frame) => total + (frame?.payload.byteLength ?? 0), 0)
       subscription.sendBinary(
         encodeTerminalStreamFrame({
-          seq: 4,
+          seq: 6,
           opcode: TerminalStreamOpcode.Ack,
           streamId: 21,
           payload: encodeTerminalStreamJson({ bytes: backgroundBytesBeforeAck })

--- a/src/main/runtime/runtime-rpc-mobile-terminal-streaming.test.ts
+++ b/src/main/runtime/runtime-rpc-mobile-terminal-streaming.test.ts
@@ -663,6 +663,36 @@ describe('OrcaRuntimeRpcServer', () => {
       })
       binaryFrames.splice(0)
 
+      runtime.onPtyData('multiplex-active-pty', '\x1b]52;c;cGFy', 6)
+      subscription.sendBinary(
+        encodeTerminalStreamFrame({
+          seq: 5,
+          opcode: TerminalStreamOpcode.SnapshotRequest,
+          streamId: 22,
+          payload: encodeTerminalStreamJson({ requestId: 77 })
+        })
+      )
+      await vi.waitFor(() => {
+        const snapshotStarted = binaryFrames
+          .map((frame) => decodeTerminalStreamFrame(frame))
+          .some(
+            (frame) => frame?.opcode === TerminalStreamOpcode.SnapshotStart && frame.streamId === 22
+          )
+        expect(snapshotStarted).toBe(true)
+      })
+      binaryFrames.splice(0)
+      runtime.onPtyData('multiplex-active-pty', 'dGlhbA==\x07after-snapshot', 7)
+      await vi.waitFor(() => {
+        const frames = binaryFrames
+          .map((frame) => decodeTerminalStreamFrame(frame))
+          .filter((frame) => frame?.streamId === 22)
+        expect(frames.some((frame) => frame?.opcode === TerminalStreamOpcode.Output)).toBe(true)
+        expect(frames.some((frame) => frame?.opcode === TerminalStreamOpcode.ClipboardWrite)).toBe(
+          false
+        )
+      })
+      binaryFrames.splice(0)
+
       const backgroundOutput = 'B'.repeat(700 * 1024)
       runtime.onPtyData('multiplex-background-pty', backgroundOutput, 1)
       await vi.waitFor(() => {
@@ -691,7 +721,7 @@ describe('OrcaRuntimeRpcServer', () => {
 
       subscription.sendBinary(
         encodeTerminalStreamFrame({
-          seq: 5,
+          seq: 6,
           opcode: TerminalStreamOpcode.Input,
           streamId: 22,
           payload: encodeTerminalStreamText('still interactive\r')
@@ -710,7 +740,7 @@ describe('OrcaRuntimeRpcServer', () => {
         .reduce((total, frame) => total + (frame?.payload.byteLength ?? 0), 0)
       subscription.sendBinary(
         encodeTerminalStreamFrame({
-          seq: 6,
+          seq: 7,
           opcode: TerminalStreamOpcode.Ack,
           streamId: 21,
           payload: encodeTerminalStreamJson({ bytes: backgroundBytesBeforeAck })

--- a/src/main/runtime/runtime-rpc-mobile-terminal-streaming.test.ts
+++ b/src/main/runtime/runtime-rpc-mobile-terminal-streaming.test.ts
@@ -570,7 +570,12 @@ describe('OrcaRuntimeRpcServer', () => {
             streamId: 22,
             terminal: activeTerminal.handle,
             client: { id: 'desktop-active', type: 'desktop' },
-            capabilities: { ackOutput: 1, clipboardWrite: 1, outputPause: 1 }
+            capabilities: {
+              ackOutput: 1,
+              clipboardWrite: 1,
+              clipboardScannerSync: 1,
+              outputPause: 1
+            }
           })
         })
       )
@@ -625,6 +630,8 @@ describe('OrcaRuntimeRpcServer', () => {
           .some((frame) => frame?.opcode === TerminalStreamOpcode.ClipboardWrite)
       ).toBe(false)
 
+      runtime.onPtyData('multiplex-active-pty', '\x1b]52;c;c3Bs', 4)
+      binaryFrames.splice(0)
       subscription.sendBinary(
         encodeTerminalStreamFrame({
           seq: 4,
@@ -633,6 +640,27 @@ describe('OrcaRuntimeRpcServer', () => {
           payload: encodeTerminalStreamJson({ paused: false })
         })
       )
+      await vi.waitFor(() => {
+        const scannerSync = binaryFrames
+          .map((frame) => decodeTerminalStreamFrame(frame))
+          .find(
+            (frame) =>
+              frame?.opcode === TerminalStreamOpcode.ClipboardScannerSync && frame.streamId === 22
+          )
+        expect(scannerSync && decodeTerminalStreamText(scannerSync.payload)).toBe('payload')
+      })
+      binaryFrames.splice(0)
+      runtime.onPtyData('multiplex-active-pty', 'aXQ=\x07visible', 5)
+      await vi.waitFor(() => {
+        const clipboardWrites = binaryFrames
+          .map((frame) => decodeTerminalStreamFrame(frame))
+          .filter(
+            (frame) =>
+              frame?.opcode === TerminalStreamOpcode.ClipboardWrite && frame.streamId === 22
+          )
+          .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+        expect(clipboardWrites).toEqual(['c;c3BsaXQ='])
+      })
       binaryFrames.splice(0)
 
       const backgroundOutput = 'B'.repeat(700 * 1024)

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-shortcuts.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-shortcuts.test.ts
@@ -128,10 +128,18 @@ describe('resolvePreviewShortcutAction', () => {
     })
     expect(
       resolvePreviewShortcutAction(keydown({ key: 'Enter', shiftKey: true }), windowsHost)
-    ).toEqual({ type: 'sendInput', data: '\x1b[13;2u' })
+    ).toEqual({
+      type: 'sendInput',
+      data: '\x1b[13;2u',
+      kittyKeyboardInput: { kitty: '\x1b[13;2u', legacy: '\x1b[13;2u' }
+    })
     expect(
       resolvePreviewShortcutAction(keydown({ key: 'Enter', shiftKey: true }), contextFor())
-    ).toEqual({ type: 'sendInput', data: '\x1b\r' })
+    ).toEqual({
+      type: 'sendInput',
+      data: '\x1b\r',
+      kittyKeyboardInput: { kitty: '\x1b[13;2u', legacy: '\x1b\r' }
+    })
   })
 
   it('protects local ConPTY shells while preserving trusted Ctrl+Enter consumers', () => {

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1713,6 +1713,7 @@ function TerminalPane(
         clearWorktreeUnread,
         clearTerminalTabUnread,
         clearTerminalPaneUnread,
+        dispatchLiveOsc52Clipboard: (data) => pane.terminal.write(`\x1b]52;${data}\x07`),
         onShowSessionRestoredBanner: showRestoredSessionBanner,
         dispatchNotification,
         setCacheTimerStartedAt,

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -103,6 +103,7 @@ import type { AgentSessionContinuationRequest } from '@/lib/agent-session-contin
 import { useNotificationDispatch } from './use-notification-dispatch'
 import { connectPanePty } from './pty-connection'
 import type { PaneProcessExit, PtyConnectionDeps } from './pty-connection-types'
+import { createTerminalLiveOsc52ClipboardHandler } from './terminal-live-osc52-clipboard'
 import { resolveTerminalProcessExitRestartStartup } from './terminal-process-exit-restart'
 import { resolveTerminalLayoutActiveLeafId } from './terminal-layout-leaf-ids'
 import { shouldIgnoreStalePanePtyLayoutBinding } from './pty-connection/pane-pty-layout-binding'
@@ -888,6 +889,13 @@ function TerminalPane(
 
   const settingsRef = useRef(settings)
   settingsRef.current = settings
+  const dispatchLiveOsc52Clipboard = useMemo(
+    () =>
+      createTerminalLiveOsc52ClipboardHandler(
+        () => settingsRef.current?.terminalAllowOsc52Clipboard
+      ),
+    []
+  )
   const openLinksInAppPreferencePromiseRef = useRef<Promise<boolean> | null>(null)
 
   const requestOpenLinksInAppPreference = useCallback(
@@ -1495,6 +1503,7 @@ function TerminalPane(
     clearWorktreeUnread,
     clearTerminalTabUnread,
     clearTerminalPaneUnread,
+    dispatchLiveOsc52Clipboard,
     onShowSessionRestoredBanner: showRestoredSessionBanner,
     dispatchNotification,
     setCacheTimerStartedAt,
@@ -1713,7 +1722,7 @@ function TerminalPane(
         clearWorktreeUnread,
         clearTerminalTabUnread,
         clearTerminalPaneUnread,
-        dispatchLiveOsc52Clipboard: (data) => pane.terminal.write(`\x1b]52;${data}\x07`),
+        dispatchLiveOsc52Clipboard,
         onShowSessionRestoredBanner: showRestoredSessionBanner,
         dispatchNotification,
         setCacheTimerStartedAt,
@@ -1730,6 +1739,7 @@ function TerminalPane(
       clearTabPtyId,
       cwd,
       dispatchNotification,
+      dispatchLiveOsc52Clipboard,
       handlePaneProcessDied,
       markWorktreeUnread,
       markTerminalTabUnread,

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -126,7 +126,11 @@ describe('resolveTerminalKeyboardShortcutAction', () => {
         () => 'alt-enter',
         () => true
       )
-    ).toEqual({ type: 'sendInput', data: '\x1b\r' })
+    ).toEqual({
+      type: 'sendInput',
+      data: '\x1b\r',
+      kittyKeyboardInput: { kitty: '\x1b[13;2u', legacy: '\x1b\r' }
+    })
   })
 
   it('forwards trusted Ctrl+Enter authority to the shared policy', () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection-agent-session-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-agent-session-resume.test.ts
@@ -513,7 +513,16 @@ describe('connectPanePty', () => {
       restoredPtyIdByLeafId: { [LEAF_1]: retainedPtyId }
     })
 
-    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    const binding = connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      deps as never
+    ) as unknown as {
+      dispatchKittyShortcutInput: (
+        input: { kitty: string; legacy: string },
+        send: (data: string) => void
+      ) => boolean
+    }
     await flushAsyncTicks(20)
     await new Promise((resolve) => setTimeout(resolve, 70))
 
@@ -523,6 +532,12 @@ describe('connectPanePty', () => {
     expect(transport.connect).not.toHaveBeenCalled()
     expect(deps.clearTabPtyId).not.toHaveBeenCalled()
     expect(mockStoreState.registerAgentLaunchConfig).not.toHaveBeenCalled()
+
+    const send = vi.fn()
+    expect(
+      binding.dispatchKittyShortcutInput({ kitty: '\x1b[13;2u', legacy: '\x1b\r' }, send)
+    ).toBe(true)
+    expect(send).toHaveBeenCalledExactlyOnceWith('\x1b\r')
   })
 
   it('preserves a missing retained legacy worker through direct SSH reconnect', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection-agent-session-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-agent-session-resume.test.ts
@@ -2,6 +2,7 @@ import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { toAppSshPtyId } from '../../../../shared/ssh-pty-id'
+import { toRemoteRuntimePtyId } from '../../../../shared/remote-runtime-pty-id'
 import { flushAsyncTicks } from './pty-connection-test-async'
 import { UUID_RE } from './pty-connection-test-constants'
 import {
@@ -537,6 +538,63 @@ describe('connectPanePty', () => {
     expect(
       binding.dispatchKittyShortcutInput({ kitty: '\x1b[13;2u', legacy: '\x1b\r' }, send)
     ).toBe(true)
+    expect(send).toHaveBeenCalledExactlyOnceWith('\x1b\r')
+  })
+
+  it('discards deferred shortcuts when a retained remote attach fails asynchronously', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const retainedPtyId = toRemoteRuntimePtyId('missing-legacy-worker', 'env-a')
+    const transport = createMockTransport()
+    let onError: ((message: string) => void) | undefined
+    transport.attach.mockImplementation(({ callbacks }) => {
+      onError = callbacks.onError
+    })
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: retainedPtyId }]
+      },
+      sleepingAgentSessionsByPaneKey: {
+        [paneKey]: {
+          paneKey,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'codex-session-1' },
+          prompt: 'finish the task',
+          state: 'working',
+          capturedAt: 1,
+          updatedAt: 1,
+          automaticResumeBlockedBy: 'legacy-orchestration-worker'
+        }
+      }
+    } as StoreState
+    const binding = connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: retainedPtyId }
+      }) as never
+    ) as unknown as {
+      dispatchKittyShortcutInput: (
+        input: { kitty: string; legacy: string },
+        send: (data: string) => void
+      ) => boolean
+    }
+    await flushAsyncTicks(20)
+
+    const send = vi.fn()
+    binding.dispatchKittyShortcutInput({ kitty: '\x1b[13;2u', legacy: '\x1b\r' }, send)
+    expect(send).not.toHaveBeenCalled()
+
+    expect(onError).toBeTypeOf('function')
+    onError?.('remote attach failed')
+    expect(send).not.toHaveBeenCalled()
+
+    binding.dispatchKittyShortcutInput({ kitty: '\x1b[13;2u', legacy: '\x1b\r' }, send)
     expect(send).toHaveBeenCalledExactlyOnceWith('\x1b\r')
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
@@ -199,6 +199,26 @@ describe('connectPanePty', () => {
     expect(staleTracker.flags).toBe(0)
   })
 
+  it('preserves kitty state when a fresh-spawn request adopts an existing PTY', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { TerminalKittyKeyboardModeTracker } =
+      await import('../../../../shared/terminal-kitty-keyboard-mode-tracker')
+    const transport = createMockTransport()
+    transport.connect.mockResolvedValue({ id: 'reattached-pty', isReattach: true })
+    transportFactoryQueue.push(transport)
+    const retainedTracker = new TerminalKittyKeyboardModeTracker()
+    retainedTracker.scan('\x1b[>1u')
+    const deps = createDeps({
+      tabId: 'tab-kitty-adopted-spawn',
+      paneKittyKeyboardModesRef: { current: new Map([[92, retainedTracker]]) }
+    })
+
+    connectPanePty(createPane(92) as never, createManager(92) as never, deps as never)
+    await flushAsyncTicks()
+
+    expect(retainedTracker.flags).toBe(1)
+  })
+
   // Why: deleting a worktree kills its PTYs for the filesystem teardown; the
   // renderer must not race a doomed respawn into a directory main is deleting
   // (main fences it with TerminalRemovalInProgressError and the pane is about to

--- a/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
@@ -208,14 +208,16 @@ describe('connectPanePty', () => {
     transportFactoryQueue.push(transport)
     const retainedTracker = new TerminalKittyKeyboardModeTracker()
     retainedTracker.scan('\x1b[>1u')
+    const paneKittyKeyboardModesRef = { current: new Map([[92, retainedTracker]]) }
     const deps = createDeps({
       tabId: 'tab-kitty-adopted-spawn',
-      paneKittyKeyboardModesRef: { current: new Map([[92, retainedTracker]]) }
+      paneKittyKeyboardModesRef
     })
 
     connectPanePty(createPane(92) as never, createManager(92) as never, deps as never)
     await flushAsyncTicks()
 
+    expect(paneKittyKeyboardModesRef.current.get(92)).toBe(retainedTracker)
     expect(retainedTracker.flags).toBe(1)
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection-test-deps.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-test-deps.ts
@@ -37,6 +37,7 @@ export type PaneConnectionDeps = {
   clearWorktreeUnread: Mock
   clearTerminalTabUnread: Mock
   clearTerminalPaneUnread: Mock
+  dispatchLiveOsc52Clipboard: Mock
   dispatchNotification: Mock
   onShowSessionRestoredBanner: Mock
   setCacheTimerStartedAt: Mock
@@ -89,6 +90,7 @@ export function buildPaneConnectionDeps(
     clearWorktreeUnread: vi.fn(),
     clearTerminalTabUnread: vi.fn(),
     clearTerminalPaneUnread: vi.fn(),
+    dispatchLiveOsc52Clipboard: vi.fn(),
     dispatchNotification: vi.fn(),
     onShowSessionRestoredBanner: vi.fn(),
     setCacheTimerStartedAt: vi.fn(),

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -103,6 +103,7 @@ export type PtyConnectionDeps = {
   clearWorktreeUnread: (worktreeId: string) => void
   clearTerminalTabUnread: (tabId: string) => void
   clearTerminalPaneUnread: (paneKey: string) => void
+  dispatchLiveOsc52Clipboard: (data: string) => void
   onShowSessionRestoredBanner: (paneId: number, reason?: SessionRestoredBannerReason) => void
   // Why: the renderer dispatches two notification sources — BEL from the PTY
   // byte stream and agent-task-complete on the working→idle title transition.

--- a/src/renderer/src/components/terminal-pane/pty-connection/apply-reattach-payload.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/apply-reattach-payload.ts
@@ -19,6 +19,7 @@ import { resolveSshReconnectModelPaint } from './resolve-ssh-reconnect-model-pai
 
 import type { ReattachPayloadContext } from './reattach-payload-context'
 import type { ReattachPayloadSession } from './reattach-payload-session'
+import { retainTerminalKittyState } from '../terminal-kitty-state-retention'
 
 export function createReattachPayloadHandlers(
   session: ReattachPayloadSession,
@@ -168,6 +169,7 @@ export function createReattachPayloadHandlers(
           // baseline, then the replay layers the outage on top — otherwise Option/Alt chords
           // encode against a stale flag stack.
           session.kittyKeyboardModes.scanReplay(ctx.connectResult.replay)
+          retainTerminalKittyState(ctx.ptyId, session.kittyKeyboardModes)
         }
         // Why shared: park+reveal of an alt-screen TUI needs the same
         // ?1049l/?1049h rebuild as applyMainBufferSnapshot (main strips
@@ -217,6 +219,7 @@ export function createReattachPayloadHandlers(
           session.kittyKeyboardModes.resetForSnapshot()
         }
         session.kittyKeyboardModes.scanReplay(ctx.connectResult.replay)
+        retainTerminalKittyState(ctx.ptyId, session.kittyKeyboardModes)
         session.writeReplayData(
           `${ctx.connectResult.coldRestore ? RESET_GRAPHIC_RENDITION : ''}${ctx.connectResult.replay}`
         )

--- a/src/renderer/src/components/terminal-pane/pty-connection/connect-pane-pty.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/connect-pane-pty.ts
@@ -1,6 +1,7 @@
 import type { PaneManager, ManagedPane } from '@/lib/pane-manager/pane-manager'
 import { useAppStore } from '@/store'
 import { TerminalKittyKeyboardModeTracker } from '../../../../../shared/terminal-kitty-keyboard-mode-tracker'
+import { TerminalKittyShortcutInputSettlement } from '../terminal-kitty-shortcut-input'
 import type { PtyConnectionDeps } from '../pty-connection-types'
 import {
   captureTerminalPaneRecoveryGeneration,
@@ -191,6 +192,7 @@ export function connectPanePty(
   // Fed only from application output (live PTY bytes + daemon replay
   // payloads), never from renderer-generated resets, so it reflects what the
   // application expects even after defensive renderer-side kitty wipes.
+  session.kittyShortcutInputSettlement = new TerminalKittyShortcutInputSettlement()
   session.kittyKeyboardModes = (() => {
     const existing = session.deps.paneKittyKeyboardModesRef.current.get(session.pane.id)
     if (existing) {

--- a/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
@@ -15,6 +15,7 @@ import type {
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
 import { resolveTerminalTabId } from './terminal-tab-id'
+import { forgetRetainedTerminalKittyState } from '../terminal-kitty-state-retention'
 
 export function bindStartFreshSpawn(session: ConnectPanePtySession): void {
   session.startFreshSpawn = (
@@ -41,6 +42,7 @@ export function bindStartFreshSpawn(session: ConnectPanePtySession): void {
     // zero. The exit-handler reset alone is not enough: a late exit from a
     // replaced PTY takes the stale-transport early return and skips it, so
     // a restart-in-place would leak the old TUI's flags into a fresh shell.
+    forgetRetainedTerminalKittyState(session.transport.getPtyId())
     session.kittyKeyboardModes.reset()
     session.prepareFreshShellViewportForSpawn(options)
     const coldRestoreOverride =
@@ -190,6 +192,7 @@ export function bindStartFreshSpawn(session: ConnectPanePtySession): void {
           }
           return accepted ? resolvedPtyId : null
         }
+        session.kittyShortcutInputSettlement.settle(session.kittyKeyboardModes.flags)
         if (spawnedPtyId && typeof spawnedPtyId === 'object' && 'id' in spawnedPtyId) {
           session.registerEffectiveLaunchConfig(spawnedPtyId.launchConfig, {
             ...(coldRestoreOverride ? { launchToken: coldRestoreOverride.launchToken } : {}),

--- a/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
@@ -38,12 +38,7 @@ export function bindStartFreshSpawn(session: ConnectPanePtySession): void {
     // Why: a canceled old replay clear can preserve xterm's native
     // isUserScrolling flag. A replacement shell must start in follow mode.
     session.resetFreshSpawnFollowOutput()
-    // Why: a fresh spawn is a new process with kitty keyboard flags at
-    // zero. The exit-handler reset alone is not enough: a late exit from a
-    // replaced PTY takes the stale-transport early return and skips it, so
-    // a restart-in-place would leak the old TUI's flags into a fresh shell.
-    forgetRetainedTerminalKittyState(session.transport.getPtyId())
-    session.kittyKeyboardModes.reset()
+    const replacedPtyId = session.transport.getPtyId()
     session.prepareFreshShellViewportForSpawn(options)
     const coldRestoreOverride =
       startupOverride && 'launchConfig' in startupOverride
@@ -192,6 +187,10 @@ export function bindStartFreshSpawn(session: ConnectPanePtySession): void {
           }
           return accepted ? resolvedPtyId : null
         }
+        // connect() can adopt an existing daemon PTY; clear prior protocol state only
+        // after its result proves this is a new process.
+        forgetRetainedTerminalKittyState(replacedPtyId)
+        session.kittyKeyboardModes.reset()
         session.kittyShortcutInputSettlement.settle(session.kittyKeyboardModes.flags)
         if (spawnedPtyId && typeof spawnedPtyId === 'object' && 'id' in spawnedPtyId) {
           session.registerEffectiveLaunchConfig(spawnedPtyId.launchConfig, {

--- a/src/renderer/src/components/terminal-pane/pty-connection/hidden-output-seq-and-skip.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/hidden-output-seq-and-skip.ts
@@ -17,6 +17,7 @@ import { shouldWritePtyOutputForeground } from './foreground-output-scan'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
 import { bindWritePtyOutputToXterm } from './write-pty-output-to-xterm'
+import { retainTerminalKittyState } from '../terminal-kitty-state-retention'
 
 import { bindAbandonHiddenOutputRestore } from './hidden-output-restore-abandon'
 import { bindHiddenOutputRestoreChunk } from './hidden-output-restore-chunk'
@@ -155,11 +156,13 @@ export function bindHiddenOutputSeqAndSkip(session: ConnectPanePtySession): void
         session.kittyKeyboardModes.resetForSnapshot()
       }
       session.kittyKeyboardModes.scanReplay(snapshotData)
+      retainTerminalKittyState(session.transport.getPtyId(), session.kittyKeyboardModes)
       return
     }
     session.kittyKeyboardModes.resetForSnapshot()
     session.kittyKeyboardModes.scanReplay(snapshotData)
     session.kittyKeyboardModes.restoreSnapshotFlags(proven)
+    retainTerminalKittyState(session.transport.getPtyId(), session.kittyKeyboardModes)
     // Why in the same critical section: without the baseline a quiet pane
     // could not publish a coherent snapshot until unrelated output arrived.
     session.recordRendererOrderedSeq({ seq: snapshot.snapshotSeq })

--- a/src/renderer/src/components/terminal-pane/pty-connection/pane-pty-binding.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pane-pty-binding.ts
@@ -20,6 +20,11 @@ export type PanePtyBinding = IDisposable & {
   requestWindowsShiftEnterReconfirmation: () => void
   /** Refresh interactive redraw scheduling after captured shortcut input. */
   markShortcutTerminalInputSent: () => void
+  /** Hold protocol-dependent shortcuts until a connect/reattach restores Kitty state. */
+  dispatchKittyShortcutInput: (
+    input: { kitty: string; legacy: string },
+    send: (data: string) => void
+  ) => boolean
   reconcileIfSessionDead: (liveSessionIds: Set<string>, snapshotRequestedAt?: number) => void
   reconcileIfSessionMissing: (hasPty: HasPty, livenessRequestedAt?: number) => void
   /** This session fresh-spawned the PTY (onPtySpawn fired for it) and never

--- a/src/renderer/src/components/terminal-pane/pty-connection/pty-exit-hibernate.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pty-exit-hibernate.ts
@@ -20,6 +20,7 @@ import {
 import type { PtyPaneStartup } from '../pty-connection-types'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
+import { forgetRetainedTerminalKittyState } from '../terminal-kitty-state-retention'
 
 /** PTY exit handling, hibernated-pane wake targets, and post-exit focus transfer. */
 export function installPtyExitHibernate(session: ConnectPanePtySession): void {
@@ -189,6 +190,7 @@ export function installPtyExitHibernate(session: ConnectPanePtySession): void {
       opts.preserveRendererBinding === true ||
       consumeCommittedPtyShutdownExit(ptyId, session.runtimeEnvironmentId)
     session.resetRendererOrderedSeqForPtyExit(ptyId)
+    forgetRetainedTerminalKittyState(ptyId)
     const currentPaneTransport = session.deps.paneTransportsRef.current.get(session.pane.id)
     if (currentPaneTransport && currentPaneTransport !== session.transport) {
       // Why: an old transport can deliver a late exit after this pane has

--- a/src/renderer/src/components/terminal-pane/pty-connection/reattach-result-handler.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/reattach-result-handler.ts
@@ -19,6 +19,7 @@ import type { ReattachPayloadContext } from './reattach-payload-context'
 import { createReattachPayloadHandlers } from './apply-reattach-payload'
 import type { ReattachPayloadSession } from './reattach-payload-session'
 import { recoverUnverifiableDirectSshReattach } from './direct-ssh-reattach-recovery'
+import { restoreRetainedTerminalKittyState } from '../terminal-kitty-state-retention'
 
 type ReattachResultSession = ReattachPayloadSession &
   Pick<
@@ -35,6 +36,7 @@ type ReattachResultSession = ReattachPayloadSession &
     | 'disposed'
     | 'getSshMainModelSnapshotProbe'
     | 'handleReattachResult'
+    | 'kittyShortcutInputSettlement'
     | 'followsDirectSshReconnect'
     | 'mountFollowsTerminalPark'
     | 'registerEffectiveLaunchConfig'
@@ -82,8 +84,11 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
     session.authoritativeReattachGeneration += 1
     const connectResult =
       result && typeof result === 'object' && 'id' in result ? (result as PtyConnectResult) : null
+    const settleShortcutInput = (): void =>
+      session.kittyShortcutInputSettlement.settle(session.kittyKeyboardModes.flags)
 
     if (connectResult?.exitedBeforeAttach) {
+      settleShortcutInput()
       // Why: the transport already delivered the dead session's final frame + exit; treat as terminal state, not a failed reattach.
       return true
     }
@@ -93,6 +98,7 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
       (typeof result === 'string' ? result : (staleSessionId ?? session.transport.getPtyId()))
     if (session.rejectObsoleteDirectSshReattach(retryPtyId)) {
       // Why: an obsolete reattach must stop consuming frames without killing the durable PTY a newer lease may adopt.
+      settleShortcutInput()
       return false
     }
     const ptyId =
@@ -107,6 +113,7 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
         ptyId: staleSessionId ?? null
       })
       if (session.connectionId) {
+        settleShortcutInput()
         recoverUnverifiableDirectSshReattach(sessionBag, staleSessionId)
         return false
       }
@@ -119,6 +126,7 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
       if (staleSessionId) {
         session.deps.clearTabPtyId(session.deps.tabId, staleSessionId)
       }
+      settleShortcutInput()
       session.startFreshColdRestoreAgentResume(coldRestoreStartup, {
         forceBlankRestoredViewport: true
       })
@@ -142,6 +150,7 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
         session.deps.clearTabPtyId(session.deps.tabId, staleSessionId)
       }
       // Why: SSH sleep/reconnect can invalidate the relay PTY while the tab stays mounted; replace the dead lease in-place, not a stale overlay.
+      settleShortcutInput()
       session.startFreshColdRestoreAgentResume(coldRestoreStartup, {
         forceBlankRestoredViewport: true
       })
@@ -156,6 +165,7 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
     if (!isCurrentReattachPayload()) {
       return false
     }
+    restoreRetainedTerminalKittyState(ptyId, session.kittyKeyboardModes)
     // Strict precedence snapshot > replay > coldRestore: paint exactly one, else overlapping tails duplicate TUI output on worktree switch.
     const hasStructuralReplay = Boolean(
       connectResult?.snapshot || connectResult?.replay || connectResult?.coldRestore
@@ -175,6 +185,7 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
       } else {
         session.syncPanePtyLayoutBinding(null)
       }
+      settleShortcutInput()
       session.startFreshColdRestoreAgentResume(coldRestoreStartup, {
         forceBlankRestoredViewport: true
       })
@@ -314,8 +325,12 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
       await fitAfterReattachRestore()
     }
     if (!isCurrentReattachPayload() || !reattachPayload.reattachPayloadApplied) {
+      if (isCurrentReattachPayload()) {
+        settleShortcutInput()
+      }
       return false
     }
+    settleShortcutInput()
     session.scheduleReattachIdleAgentCursorReset()
 
     scheduleRuntimeGraphSync()

--- a/src/renderer/src/components/terminal-pane/pty-connection/retained-legacy-pty-attach.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/retained-legacy-pty-attach.ts
@@ -24,7 +24,7 @@ export function bindAttachRetainedLegacyPty(session: ConnectPanePtySession): voi
       session.kittyShortcutInputSettlement.settle(session.kittyKeyboardModes.flags)
       return true
     } catch (err) {
-      session.kittyShortcutInputSettlement.settle(session.kittyKeyboardModes.flags)
+      session.kittyShortcutInputSettlement.settleDiscardingPending(session.kittyKeyboardModes.flags)
       session.reportError(err instanceof Error ? err.message : String(err))
       return false
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection/retained-legacy-pty-attach.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/retained-legacy-pty-attach.ts
@@ -21,8 +21,10 @@ export function bindAttachRetainedLegacyPty(session: ConnectPanePtySession): voi
       if (isRemoteRuntimePtyId(attachedPtyId)) {
         session.registerPaneSerializerFor(attachedPtyId)
       }
+      session.kittyShortcutInputSettlement.settle(session.kittyKeyboardModes.flags)
       return true
     } catch (err) {
+      session.kittyShortcutInputSettlement.settle(session.kittyKeyboardModes.flags)
       session.reportError(err instanceof Error ? err.message : String(err))
       return false
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection/retained-legacy-pty-attach.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/retained-legacy-pty-attach.ts
@@ -9,9 +9,46 @@ export function bindAttachRetainedLegacyPty(session: ConnectPanePtySession): voi
       session.clearPaneMode2031State()
       session.clearHiddenOutputRestoreState()
       const outputCallbacks = session.captureTransportOutputCallbacks(session.reportError, null)
+      const remoteAttach = isRemoteRuntimePtyId(ptyId)
+      let remoteAttachPending = remoteAttach
+      const settleRemoteAttach = (discardPending: boolean): void => {
+        if (
+          !remoteAttachPending ||
+          session.disposed ||
+          outputCallbacks.generation !== session.transportStreamGeneration ||
+          session.deps.paneTransportsRef.current.get(session.pane.id) !== session.transport
+        ) {
+          return
+        }
+        remoteAttachPending = false
+        if (discardPending) {
+          session.kittyShortcutInputSettlement.settleDiscardingPending(
+            session.kittyKeyboardModes.flags
+          )
+        } else {
+          session.kittyShortcutInputSettlement.settle(session.kittyKeyboardModes.flags)
+        }
+      }
+      const baseCallbacks = outputCallbacks.callbacks
       session.transport.attach({
         existingPtyId: ptyId,
-        callbacks: outputCallbacks.callbacks
+        callbacks: remoteAttach
+          ? {
+              ...baseCallbacks,
+              onConnect: () => {
+                baseCallbacks.onConnect?.()
+                settleRemoteAttach(false)
+              },
+              onError: (message: string, errors?: string[]) => {
+                settleRemoteAttach(true)
+                baseCallbacks.onError?.(message, errors)
+              },
+              onDisconnect: () => {
+                settleRemoteAttach(true)
+                baseCallbacks.onDisconnect?.()
+              }
+            }
+          : baseCallbacks
       })
       const attachedPtyId = session.transport.getPtyId() ?? ptyId
       session.bindActivePanePty(attachedPtyId, {
@@ -21,7 +58,9 @@ export function bindAttachRetainedLegacyPty(session: ConnectPanePtySession): voi
       if (isRemoteRuntimePtyId(attachedPtyId)) {
         session.registerPaneSerializerFor(attachedPtyId)
       }
-      session.kittyShortcutInputSettlement.settle(session.kittyKeyboardModes.flags)
+      if (!remoteAttach) {
+        session.kittyShortcutInputSettlement.settle(session.kittyKeyboardModes.flags)
+      }
       return true
     } catch (err) {
       session.kittyShortcutInputSettlement.settleDiscardingPending(session.kittyKeyboardModes.flags)

--- a/src/renderer/src/components/terminal-pane/pty-connection/session-reconcile-dispose.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/session-reconcile-dispose.ts
@@ -170,12 +170,16 @@ export function installSessionReconcileDispose(session: ConnectPanePtySession): 
     markShortcutTerminalInputSent() {
       session.markInteractiveRedrawInput()
     },
+    dispatchKittyShortcutInput(input, send) {
+      return session.kittyShortcutInputSettlement.dispatch(input, send)
+    },
     reconcileIfSessionDead: session.reconcileIfSessionDead,
     reconcileIfSessionMissing: session.reconcileIfSessionMissing,
     isUntouchedFreshSpawnPty: (ptyId) =>
       session.spawnedFreshPtyId === ptyId && !Number.isFinite(session.lastTerminalInputAt),
     dispose() {
       session.disposed = true
+      session.kittyShortcutInputSettlement.dispose()
       // A successor can claim the numeric pane slot before this retired
       // binding's disposal callback runs; do not clear its pane-scoped error.
       const currentPaneTransport = session.deps.paneTransportsRef.current.get(session.pane.id)

--- a/src/renderer/src/components/terminal-pane/pty-connection/transport-output-callbacks.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/transport-output-callbacks.ts
@@ -11,6 +11,7 @@ export function bindCaptureTransportOutputCallbacks(session: ConnectPanePtySessi
     onError: (message: string) => void,
     startup: PtyPaneStartup
   ) => {
+    session.kittyShortcutInputSettlement.begin()
     // Why: a new stream generation cannot inherit an old replay's pending
     // destination-grid fit or keep its live-data waiter open.
     session.pendingHiddenSnapshotFit?.cancel()
@@ -51,6 +52,11 @@ export function bindCaptureTransportOutputCallbacks(session: ConnectPanePtySessi
           if (isCurrent()) {
             processExitState.detector.observe(data)
             session.dataCallback(data, meta, generation)
+          }
+        },
+        onOsc52Clipboard: (data: string): void => {
+          if (isCurrent()) {
+            session.deps.dispatchLiveOsc52Clipboard(data)
           }
         },
         onReplayData: (data: string, meta?: PtyReplayDataMeta): void => {

--- a/src/renderer/src/components/terminal-pane/pty-connection/write-pty-output-to-xterm.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/write-pty-output-to-xterm.ts
@@ -11,6 +11,7 @@ import {
 import { containsHiddenStartupRendererQuery } from './hidden-startup-renderer-query'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
+import { retainTerminalKittyState } from '../terminal-kitty-state-retention'
 
 /** The xterm write path for PTY output, including the queued agent-idle mode reset. */
 export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void {
@@ -21,6 +22,7 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
   ): void {
     // Why: every application byte funnels through here, so it's the one place the kitty keyboard mirror observes the pane's protocol negotiation.
     session.kittyKeyboardModes.scan(data)
+    retainTerminalKittyState(session.transport.getPtyId(), session.kittyKeyboardModes)
     if (foreground) {
       session.resetHiddenOutputRestoreIfPtyChanged()
     }

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -113,6 +113,8 @@ type PtyCallbacks = {
   onStreamRecovered?: () => void
   onDisconnect?: () => void
   onData?: (data: string, meta?: PtyDataMeta) => void
+  /** Live OSC 52 intent carried outside snapshot-recoverable terminal output. */
+  onOsc52Clipboard?: (data: string) => void
   onReplayData?: (data: string, meta?: PtyReplayDataMeta) => void
   onStatus?: (shell: string) => void
   onError?: (message: string, errors?: string[]) => void

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-attach-subscription.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-attach-subscription.test.ts
@@ -62,6 +62,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       expect(latestSubscribePayload().capabilities).toEqual({
         ackOutput: 1,
         ackOutputSourceRanges: 1,
+        clipboardWrite: 1,
         desktopViewportClaims: 1,
         outputPause: 1,
         writeUnavailable: 1

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-attach-subscription.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-attach-subscription.test.ts
@@ -63,6 +63,7 @@ describe('createRemoteRuntimePtyTransport', () => {
         ackOutput: 1,
         ackOutputSourceRanges: 1,
         clipboardWrite: 1,
+        clipboardScannerSync: 1,
         desktopViewportClaims: 1,
         outputPause: 1,
         writeUnavailable: 1

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -1889,6 +1889,11 @@ export function createRemoteRuntimePtyTransport(
             shutdownDataHandler(data, meta)
           }
         },
+        onOsc52Clipboard: (data) => {
+          if (isCurrentSubscription()) {
+            storedCallbacks.onOsc52Clipboard?.(data)
+          }
+        },
         onSnapshot: (data, meta) => {
           // Why: an empty snapshot can still carry a pending mid-escape tail that must replay so the next live chunk completes it.
           if ((data || meta?.pendingEscapeTailAnsi) && isCurrentSubscription()) {

--- a/src/renderer/src/components/terminal-pane/terminal-captured-input-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-captured-input-dispatch.ts
@@ -1,4 +1,5 @@
 import type { PtyTransport } from './pty-transport'
+import type { TerminalKittyShortcutInput } from './terminal-kitty-shortcut-input'
 
 type CapturedTerminalInputDispatch = {
   targetPaneMounted: boolean
@@ -12,6 +13,10 @@ type CapturedTerminalInputDispatch = {
 export type TerminalCapturedInputBinding = {
   requestWindowsShiftEnterReconfirmation?: () => void
   markShortcutTerminalInputSent?: () => void
+  dispatchKittyShortcutInput?: (
+    input: TerminalKittyShortcutInput,
+    send: (data: string) => void
+  ) => boolean
 }
 
 export function sendCapturedTerminalInput({

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers.ts
@@ -19,6 +19,7 @@ import { dispatchTerminalShortcutAction } from './terminal-keyboard-action-dispa
 import { getLayoutCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 import { createTerminalKeyboardReleaseHandlers } from './terminal-keyboard-release-handlers'
 import { synchronizeTerminalKeyboardPane } from './terminal-keyboard-pane-resolution'
+import type { TerminalCapturedInputBinding } from './terminal-captured-input-dispatch'
 
 const MAX_OBSERVED_ENTER_KEYDOWNS_PER_CODE = 8
 
@@ -54,6 +55,7 @@ export function createTerminalKeyboardEventHandlers(context: EventContext) {
     keyboardScopeRef,
     managerRef,
     paneTransportsRef,
+    panePtyBindingsRef,
     paneCwdRef,
     fallbackCwd,
     expandedPaneIdRef,
@@ -223,13 +225,28 @@ export function createTerminalKeyboardEventHandlers(context: EventContext) {
         return
       }
       const sendResolvedInput = createCapturedInputSender(pane, action.data)
+      const capturedBinding = panePtyBindingsRef.current.get(pane.id) as
+        | TerminalCapturedInputBinding
+        | undefined
+      const sendShortcutInput = (): void => {
+        if (
+          action.kittyKeyboardInput &&
+          capturedBinding?.dispatchKittyShortcutInput?.(
+            action.kittyKeyboardInput,
+            sendResolvedInput
+          ) === true
+        ) {
+          return
+        }
+        sendResolvedInput()
+      }
       if (action.consumeOptionKeyUp) {
         optionKittyReleases.armNativeDeadKey(e)
       } else if (action.optionKittyRelease) {
         optionKittyReleases.arm(
           e,
           action.optionKittyRelease,
-          sendResolvedInput,
+          sendShortcutInput,
           () => paneKittyKeyboardModesRef?.current.get(pane.id)?.flags ?? 0,
           getLayoutCharacterForCode
         )
@@ -247,7 +264,7 @@ export function createTerminalKeyboardEventHandlers(context: EventContext) {
             return
           }
         }
-        deferredNewlineSender.defer(e, pane.terminal.element, sendResolvedInput)
+        deferredNewlineSender.defer(e, pane.terminal.element, sendShortcutInput)
         return
       }
       // Why: the composed glyph reaches the pty from the composition session-end handler, which
@@ -257,10 +274,10 @@ export function createTerminalKeyboardEventHandlers(context: EventContext) {
       // mid-preedit is the corruption itself, so this one waits on the composition rather than a
       // deadline. The sender owns the wait so blur and teardown can drop it.
       if (e.isComposing || hasPendingImeComposition) {
-        deferredChordSender.defer(pane.terminal.element, sendResolvedInput)
+        deferredChordSender.defer(pane.terminal.element, sendShortcutInput)
         return
       }
-      sendResolvedInput()
+      sendShortcutInput()
       return
     }
 

--- a/src/renderer/src/components/terminal-pane/terminal-kitty-shortcut-input.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-kitty-shortcut-input.test.ts
@@ -46,6 +46,18 @@ describe('TerminalKittyShortcutInputSettlement', () => {
     expect(send).toHaveBeenNthCalledWith(2, '\x1b\r')
   })
 
+  it('drops queued input after a failed attach but settles later shortcuts', () => {
+    const settlement = new TerminalKittyShortcutInputSettlement()
+    const send = vi.fn()
+
+    settlement.dispatch(SHIFT_ENTER, send)
+    settlement.settleDiscardingPending(0)
+
+    expect(send).not.toHaveBeenCalled()
+    expect(settlement.dispatch(SHIFT_ENTER, send)).toBe(true)
+    expect(send).toHaveBeenCalledExactlyOnceWith('\x1b\r')
+  })
+
   it('drops deferred input when the pane is disposed', () => {
     const settlement = new TerminalKittyShortcutInputSettlement()
     const send = vi.fn()

--- a/src/renderer/src/components/terminal-pane/terminal-kitty-shortcut-input.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-kitty-shortcut-input.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TerminalKittyShortcutInputSettlement } from './terminal-kitty-shortcut-input'
+
+const SHIFT_ENTER = {
+  kitty: '\x1b[13;2u',
+  legacy: '\x1b\r'
+}
+
+describe('TerminalKittyShortcutInputSettlement', () => {
+  it('holds Shift+Enter through park reattach until the restored Kitty state is known', () => {
+    const settlement = new TerminalKittyShortcutInputSettlement()
+    const send = vi.fn()
+
+    expect(settlement.dispatch(SHIFT_ENTER, send)).toBe(true)
+    expect(send).not.toHaveBeenCalled()
+
+    settlement.settle(1)
+
+    expect(send).toHaveBeenCalledExactlyOnceWith('\x1b[13;2u')
+  })
+
+  it('preserves the legacy encoding after a non-Kitty reattach settles', () => {
+    const settlement = new TerminalKittyShortcutInputSettlement()
+    const send = vi.fn()
+
+    settlement.dispatch(SHIFT_ENTER, send)
+    settlement.settle(0)
+
+    expect(send).toHaveBeenCalledExactlyOnceWith('\x1b\r')
+  })
+
+  it('re-enters settlement when an already-bound pane starts another reattach', () => {
+    const settlement = new TerminalKittyShortcutInputSettlement()
+    const send = vi.fn()
+    settlement.settle(1)
+
+    settlement.dispatch(SHIFT_ENTER, send)
+    settlement.begin()
+    settlement.dispatch(SHIFT_ENTER, send)
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenLastCalledWith('\x1b[13;2u')
+
+    settlement.settle(0)
+
+    expect(send).toHaveBeenNthCalledWith(2, '\x1b\r')
+  })
+
+  it('drops deferred input when the pane is disposed', () => {
+    const settlement = new TerminalKittyShortcutInputSettlement()
+    const send = vi.fn()
+
+    settlement.dispatch(SHIFT_ENTER, send)
+    settlement.dispose()
+    settlement.settle(1)
+
+    expect(send).not.toHaveBeenCalled()
+    expect(settlement.dispatch(SHIFT_ENTER, send)).toBe(false)
+  })
+
+  it('bounds deferred input while a reattach is stalled', () => {
+    const settlement = new TerminalKittyShortcutInputSettlement()
+    const send = vi.fn()
+
+    for (let index = 0; index < 64; index += 1) {
+      expect(settlement.dispatch(SHIFT_ENTER, send)).toBe(true)
+    }
+    settlement.settle(1)
+
+    expect(send).toHaveBeenCalledTimes(32)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-kitty-shortcut-input.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-kitty-shortcut-input.ts
@@ -1,0 +1,60 @@
+export type TerminalKittyShortcutInput = {
+  kitty: string
+  legacy: string
+}
+
+const MAX_PENDING_KITTY_SHORTCUT_INPUTS = 32
+
+type PendingKittyShortcutInput = {
+  input: TerminalKittyShortcutInput
+  send: (data: string) => void
+}
+
+export class TerminalKittyShortcutInputSettlement {
+  private flags = 0
+  private settled = false
+  private disposed = false
+  private pending: PendingKittyShortcutInput[] = []
+
+  begin(): void {
+    if (!this.disposed) {
+      this.settled = false
+    }
+  }
+
+  dispatch(input: TerminalKittyShortcutInput, send: (data: string) => void): boolean {
+    if (this.disposed) {
+      return false
+    }
+    if (this.settled) {
+      send(this.resolve(input, this.flags))
+      return true
+    }
+    if (this.pending.length < MAX_PENDING_KITTY_SHORTCUT_INPUTS) {
+      this.pending.push({ input, send })
+    }
+    return true
+  }
+
+  settle(flags: number): void {
+    if (this.disposed) {
+      return
+    }
+    this.flags = flags
+    this.settled = true
+    const pending = this.pending
+    this.pending = []
+    for (const item of pending) {
+      item.send(this.resolve(item.input, flags))
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true
+    this.pending = []
+  }
+
+  private resolve(input: TerminalKittyShortcutInput, flags: number): string {
+    return flags > 0 ? input.kitty : input.legacy
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-kitty-shortcut-input.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-kitty-shortcut-input.ts
@@ -49,6 +49,15 @@ export class TerminalKittyShortcutInputSettlement {
     }
   }
 
+  settleDiscardingPending(flags: number): void {
+    if (this.disposed) {
+      return
+    }
+    this.pending = []
+    this.flags = flags
+    this.settled = true
+  }
+
   dispose(): void {
     this.disposed = true
     this.pending = []

--- a/src/renderer/src/components/terminal-pane/terminal-kitty-state-retention.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-kitty-state-retention.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
+import { TerminalKittyShortcutInputSettlement } from './terminal-kitty-shortcut-input'
+import {
+  forgetRetainedTerminalKittyState,
+  resetRetainedTerminalKittyStatesForTests,
+  restoreRetainedTerminalKittyState,
+  retainTerminalKittyState
+} from './terminal-kitty-state-retention'
+
+afterEach(() => resetRetainedTerminalKittyStatesForTests())
+
+describe('terminal kitty state retention', () => {
+  it('restores proven flags when the same live PTY remounts', () => {
+    const mounted = new TerminalKittyKeyboardModeTracker()
+    mounted.reset()
+    mounted.scan('\x1b[>1u')
+    retainTerminalKittyState('pty-1', mounted)
+
+    const remounted = new TerminalKittyKeyboardModeTracker()
+    remounted.resetForSnapshot()
+    restoreRetainedTerminalKittyState('pty-1', remounted)
+
+    expect(remounted.snapshotFlags).toBe(1)
+  })
+
+  it('settles deferred Shift+Enter from a retained park baseline', () => {
+    const mounted = new TerminalKittyKeyboardModeTracker()
+    mounted.reset()
+    mounted.scan('\x1b[>1u')
+    retainTerminalKittyState('pty-1', mounted)
+
+    const remounted = new TerminalKittyKeyboardModeTracker()
+    remounted.resetForSnapshot()
+    const settlement = new TerminalKittyShortcutInputSettlement()
+    const sent: string[] = []
+    settlement.dispatch({ kitty: '\x1b[13;2u', legacy: '\x1b\r' }, (data) => sent.push(data))
+
+    restoreRetainedTerminalKittyState('pty-1', remounted)
+    settlement.settle(remounted.flags)
+
+    expect(sent).toEqual(['\x1b[13;2u'])
+  })
+
+  it('does not carry state into a fresh or exited PTY', () => {
+    const mounted = new TerminalKittyKeyboardModeTracker()
+    mounted.reset()
+    mounted.scan('\x1b[>1u')
+    retainTerminalKittyState('pty-1', mounted)
+    forgetRetainedTerminalKittyState('pty-1')
+
+    const fresh = new TerminalKittyKeyboardModeTracker()
+    fresh.resetForSnapshot()
+    restoreRetainedTerminalKittyState('pty-1', fresh)
+
+    expect(fresh.snapshotFlags).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-kitty-state-retention.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-kitty-state-retention.ts
@@ -1,0 +1,49 @@
+import type { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
+
+const MAX_RETAINED_KITTY_STATES = 256
+const retainedFlagsByPtyId = new Map<string, number>()
+
+/** Retains proven protocol state while a live PTY has no mounted pane tracker. */
+export function retainTerminalKittyState(
+  ptyId: string | null | undefined,
+  tracker: TerminalKittyKeyboardModeTracker
+): void {
+  const flags = tracker.snapshotFlags
+  if (!ptyId || flags === undefined) {
+    return
+  }
+  retainedFlagsByPtyId.delete(ptyId)
+  retainedFlagsByPtyId.set(ptyId, flags)
+  while (retainedFlagsByPtyId.size > MAX_RETAINED_KITTY_STATES) {
+    const oldest = retainedFlagsByPtyId.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    retainedFlagsByPtyId.delete(oldest)
+  }
+}
+
+export function restoreRetainedTerminalKittyState(
+  ptyId: string | null | undefined,
+  tracker: TerminalKittyKeyboardModeTracker
+): void {
+  if (!ptyId || tracker.hasProvenBaseline) {
+    return
+  }
+  const flags = retainedFlagsByPtyId.get(ptyId)
+  if (flags === undefined) {
+    return
+  }
+  tracker.resetForSnapshot()
+  tracker.restoreSnapshotFlags(flags)
+}
+
+export function forgetRetainedTerminalKittyState(ptyId: string | null | undefined): void {
+  if (ptyId) {
+    retainedFlagsByPtyId.delete(ptyId)
+  }
+}
+
+export function resetRetainedTerminalKittyStatesForTests(): void {
+  retainedFlagsByPtyId.clear()
+}

--- a/src/renderer/src/components/terminal-pane/terminal-live-osc52-clipboard.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-osc52-clipboard.ts
@@ -1,0 +1,18 @@
+import { createOsc52OscHandler } from './osc52-clipboard'
+import {
+  showOsc52ClipboardBlockedToast,
+  showOsc52ClipboardFailedToast
+} from './osc52-clipboard-toast'
+
+/** Routes live sidechannel writes through the same verified clipboard policy as parsed OSC 52. */
+export function createTerminalLiveOsc52ClipboardHandler(
+  getSettingEnabled: () => boolean | undefined
+): (data: string) => boolean {
+  return createOsc52OscHandler({
+    getSettingEnabled,
+    getReplaying: () => false,
+    writeClipboardText: (text) => window.api.ui.writeTerminalClipboardText(text),
+    showBlockedWriteToast: showOsc52ClipboardBlockedToast,
+    showWriteFailedToast: showOsc52ClipboardFailedToast
+  })
+}

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -18,6 +18,14 @@ function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent
   }
 }
 
+function shiftEnterAction(data: string, legacy = '\x1b\r') {
+  return {
+    type: 'sendInput',
+    data,
+    kittyKeyboardInput: { kitty: '\x1b[13;2u', legacy }
+  }
+}
+
 describe('resolveTerminalShortcutAction', () => {
   it('preserves macOS readline ctrl chords for the shell', () => {
     const passthroughCases = [
@@ -70,10 +78,7 @@ describe('resolveTerminalShortcutAction', () => {
   it('keeps inactive shift-enter and delete helpers explicit', () => {
     expect(
       resolveTerminalShortcutAction(event({ key: 'Enter', code: 'Enter', shiftKey: true }), true)
-    ).toEqual({
-      type: 'sendInput',
-      data: '\x1b\r'
-    })
+    ).toEqual(shiftEnterAction('\x1b\r'))
     expect(resolveTerminalShortcutAction(event({ key: 'Backspace', ctrlKey: true }), true)).toEqual(
       { type: 'sendInput', data: '\x17' }
     )
@@ -101,10 +106,7 @@ describe('resolveTerminalShortcutAction', () => {
         0,
         true
       )
-    ).toEqual({
-      type: 'sendInput',
-      data: '\x1b\r'
-    })
+    ).toEqual(shiftEnterAction('\x1b\r'))
     expect(
       resolveTerminalShortcutAction(
         event({ key: 'Enter', code: 'Enter', shiftKey: true }),
@@ -118,7 +120,7 @@ describe('resolveTerminalShortcutAction', () => {
         undefined,
         () => 'alt-enter'
       )
-    ).toEqual({ type: 'sendInput', data: '\x1b\r' })
+    ).toEqual(shiftEnterAction('\x1b\r'))
   })
 
   it('sends CSI-u Shift+Enter to Windows panes whose active agent requires it (#7620)', () => {
@@ -137,7 +139,7 @@ describe('resolveTerminalShortcutAction', () => {
         undefined,
         () => 'csi-u'
       )
-    ).toEqual({ type: 'sendInput', data: '\x1b[13;2u' })
+    ).toEqual(shiftEnterAction('\x1b[13;2u', '\x1b[13;2u'))
   })
 
   it('uses CSI-u for a non-Windows PTY reached from Windows only while Kitty is active', () => {
@@ -156,8 +158,8 @@ describe('resolveTerminalShortcutAction', () => {
         getWindowsShiftEnterEncoding,
         () => false
       )
-    expect(resolve(true)).toEqual({ type: 'sendInput', data: '\x1b[13;2u' })
-    expect(resolve(false)).toEqual({ type: 'sendInput', data: '\x1b\r' })
+    expect(resolve(true)).toEqual(shiftEnterAction('\x1b[13;2u'))
+    expect(resolve(false)).toEqual(shiftEnterAction('\x1b\r'))
     expect(getWindowsShiftEnterEncoding).not.toHaveBeenCalled()
   })
 
@@ -176,8 +178,8 @@ describe('resolveTerminalShortcutAction', () => {
           undefined,
           encoding
         )
-      expect(resolve(true)).toEqual({ type: 'sendInput', data: '\x1b[13;2u' })
-      expect(resolve(false)).toEqual({ type: 'sendInput', data: '\x1b\r' })
+      expect(resolve(true)).toEqual(shiftEnterAction('\x1b[13;2u'))
+      expect(resolve(false)).toEqual(shiftEnterAction('\x1b\r'))
     }
   })
 
@@ -221,7 +223,7 @@ describe('resolveTerminalShortcutAction', () => {
         getWindowsShiftEnterEncoding,
         isWindowsTerminalHost
       )
-    ).toEqual({ type: 'sendInput', data: '\x1b[13;2u' })
+    ).toEqual(shiftEnterAction('\x1b[13;2u', '\x1b[13;2u'))
     expect(isLocalWindowsConptyPane).not.toHaveBeenCalled()
     expect(getWindowsShiftEnterEncoding).toHaveBeenCalledTimes(1)
     expect(isWindowsTerminalHost).toHaveBeenCalledTimes(1)
@@ -242,7 +244,7 @@ describe('resolveTerminalShortcutAction', () => {
         getWindowsShiftEnterEncoding,
         isWindowsTerminalHost
       )
-    ).toEqual({ type: 'sendInput', data: '\x1b[13;2u' })
+    ).toEqual(shiftEnterAction('\x1b[13;2u'))
     expect(isLocalWindowsConptyPane).not.toHaveBeenCalled()
     expect(getWindowsShiftEnterEncoding).toHaveBeenCalledTimes(1)
     expect(isWindowsTerminalHost).toHaveBeenCalledTimes(2)
@@ -265,8 +267,8 @@ describe('resolveTerminalShortcutAction', () => {
         getWindowsShiftEnterEncoding,
         () => true
       )
-    expect(resolve(true)).toEqual({ type: 'sendInput', data: '\x1b[13;2u' })
-    expect(resolve(false)).toEqual({ type: 'sendInput', data: '\x1b\r' })
+    expect(resolve(true)).toEqual(shiftEnterAction('\x1b[13;2u'))
+    expect(resolve(false)).toEqual(shiftEnterAction('\x1b\r'))
     expect(getWindowsShiftEnterEncoding).toHaveBeenCalledTimes(2)
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -61,6 +61,7 @@ export type TerminalShortcutAction =
   | {
       type: 'sendInput'
       data: string
+      kittyKeyboardInput?: { kitty: string; legacy: string }
       optionKittyRelease?: TerminalOptionKittyRelease
       consumeOptionKeyUp?: boolean
     }
@@ -175,7 +176,14 @@ export function resolveTerminalShortcutAction(
     const hasTrustedWindowsCsiU = windowsHost && getWindowsShiftEnterEncoding?.() === 'csi-u'
     // Why: CSI-u is application input, not universal; without trusted Windows evidence, require active KKP negotiation.
     const canSendCsiU = hasTrustedWindowsCsiU || (getKittyKeyboardFlagsActivePane?.() ?? 0) > 0
-    return { type: 'sendInput', data: canSendCsiU ? '\x1b[13;2u' : '\x1b\r' }
+    return {
+      type: 'sendInput',
+      data: canSendCsiU ? '\x1b[13;2u' : '\x1b\r',
+      kittyKeyboardInput: {
+        kitty: '\x1b[13;2u',
+        legacy: hasTrustedWindowsCsiU ? '\x1b[13;2u' : '\x1b\r'
+      }
+    }
   }
 
   if (

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -326,6 +326,7 @@ type UseTerminalPaneLifecycleDeps = {
   clearWorktreeUnread: (worktreeId: string) => void
   clearTerminalTabUnread: (tabId: string) => void
   clearTerminalPaneUnread: (paneKey: string) => void
+  dispatchLiveOsc52Clipboard: (data: string) => void
   onShowSessionRestoredBanner: (paneId: number, reason?: SessionRestoredBannerReason) => void
   dispatchNotification: (event: {
     source: 'terminal-bell' | 'agent-task-complete'
@@ -748,6 +749,7 @@ export function useTerminalPaneLifecycle({
   clearWorktreeUnread,
   clearTerminalTabUnread,
   clearTerminalPaneUnread,
+  dispatchLiveOsc52Clipboard,
   onShowSessionRestoredBanner,
   dispatchNotification,
   setCacheTimerStartedAt,
@@ -969,13 +971,6 @@ export function useTerminalPaneLifecycle({
       startup && setupSplit
         ? { ...startup, waitForSetupSplitDirection: setupSplit.direction }
         : startup
-    const dispatchLiveOsc52Clipboard = createOsc52OscHandler({
-      getSettingEnabled: () => settingsRef.current?.terminalAllowOsc52Clipboard,
-      getReplaying: () => false,
-      writeClipboardText: (text) => window.api.ui.writeTerminalClipboardText(text),
-      showBlockedWriteToast: showOsc52ClipboardBlockedToast,
-      showWriteFailedToast: showOsc52ClipboardFailedToast
-    })
     const ptyDeps = {
       tabId,
       worktreeId,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -969,6 +969,13 @@ export function useTerminalPaneLifecycle({
       startup && setupSplit
         ? { ...startup, waitForSetupSplitDirection: setupSplit.direction }
         : startup
+    const dispatchLiveOsc52Clipboard = createOsc52OscHandler({
+      getSettingEnabled: () => settingsRef.current?.terminalAllowOsc52Clipboard,
+      getReplaying: () => false,
+      writeClipboardText: (text) => window.api.ui.writeTerminalClipboardText(text),
+      showBlockedWriteToast: showOsc52ClipboardBlockedToast,
+      showWriteFailedToast: showOsc52ClipboardFailedToast
+    })
     const ptyDeps = {
       tabId,
       worktreeId,
@@ -1002,6 +1009,7 @@ export function useTerminalPaneLifecycle({
       clearWorktreeUnread,
       clearTerminalTabUnread,
       clearTerminalPaneUnread,
+      dispatchLiveOsc52Clipboard,
       onShowSessionRestoredBanner,
       dispatchNotification,
       setCacheTimerStartedAt,

--- a/src/renderer/src/runtime/remote-runtime-terminal-binary-controller.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-binary-controller.ts
@@ -49,6 +49,11 @@ export abstract class RemoteRuntimeTerminalBinaryController extends RemoteRuntim
       stream.callbacks.onWriteUnavailable?.()
       return
     }
+    if (frame.opcode === TerminalStreamOpcode.ClipboardWrite) {
+      stream.supportsClipboardWrite = true
+      stream.callbacks.onOsc52Clipboard?.(decodeTerminalStreamText(frame.payload))
+      return
+    }
     if (
       frame.opcode === TerminalStreamOpcode.Output ||
       frame.opcode === TerminalStreamOpcode.OutputSpan
@@ -78,12 +83,15 @@ export abstract class RemoteRuntimeTerminalBinaryController extends RemoteRuntim
         Number.isSafeInteger(span.rawLength) &&
         span.rawLength >= 0 &&
         span.transformed === true)
-    const data =
+    const rawData =
       frame.opcode === TerminalStreamOpcode.OutputSpan
         ? validSpan
           ? (span!.data as string)
           : ''
         : decodeTerminalStreamText(frame.payload)
+    const data = stream.supportsClipboardWrite
+      ? stream.osc52Scanner.scan(rawData).passthrough
+      : rawData
     const deliverOutput = (): void => {
       if (!validSpan) {
         // Why: rendering malformed span JSON would expose protocol framing
@@ -94,7 +102,7 @@ export abstract class RemoteRuntimeTerminalBinaryController extends RemoteRuntim
       const rawLength =
         frame.opcode === TerminalStreamOpcode.OutputSpan && typeof span?.rawLength === 'number'
           ? span.rawLength
-          : data.length
+          : rawData.length
       // Why: a resync snapshot is authoritative; discard live output while
       // it is in flight, but still return transport credit in finally.
       if (stream.resyncInFlight) {
@@ -121,7 +129,9 @@ export abstract class RemoteRuntimeTerminalBinaryController extends RemoteRuntim
       stream.callbacks.onData(data, {
         seq,
         rawLength,
-        ...(frame.opcode === TerminalStreamOpcode.OutputSpan ? { transformed: true } : {})
+        ...(frame.opcode === TerminalStreamOpcode.OutputSpan || data !== rawData
+          ? { transformed: true }
+          : {})
       })
     }
     if (!stream.acknowledgeOutput) {

--- a/src/renderer/src/runtime/remote-runtime-terminal-binary-controller.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-binary-controller.ts
@@ -6,6 +6,7 @@ import {
   type TerminalStreamFrame
 } from '../../../shared/terminal-stream-protocol'
 import { deliverTerminalDataWithDeferredCredit } from '@/lib/pane-manager/terminal-delivery-credit'
+import { isTerminalOsc52ScannerSyncState } from '../../../shared/terminal-osc52-stream-scanner'
 import {
   shouldDropE2eRemoteTerminalOutput,
   shouldHoldE2eRemoteTerminalAck
@@ -52,6 +53,13 @@ export abstract class RemoteRuntimeTerminalBinaryController extends RemoteRuntim
     if (frame.opcode === TerminalStreamOpcode.ClipboardWrite) {
       stream.supportsClipboardWrite = true
       stream.callbacks.onOsc52Clipboard?.(decodeTerminalStreamText(frame.payload))
+      return
+    }
+    if (frame.opcode === TerminalStreamOpcode.ClipboardScannerSync) {
+      const syncState = decodeTerminalStreamText(frame.payload)
+      if (stream.supportsClipboardScannerSync && isTerminalOsc52ScannerSyncState(syncState)) {
+        stream.osc52Scanner.restoreSyncState(syncState)
+      }
       return
     }
     if (

--- a/src/renderer/src/runtime/remote-runtime-terminal-binary-snapshots.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-binary-snapshots.ts
@@ -25,6 +25,7 @@ export abstract class RemoteRuntimeTerminalBinarySnapshots extends RemoteRuntime
   ): void {
     if (frame.opcode === TerminalStreamOpcode.SnapshotStart) {
       clearSnapshot(stream)
+      stream.osc52Scanner.reset()
       stream.snapshotInfo = decodeSnapshotInfo(frame.payload)
       const requestId = stream.snapshotInfo?.requestId
       stream.snapshotTarget =

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -158,6 +158,14 @@ class FakeMultiplexServer {
     this.send(TerminalStreamOpcode.Output, encodeTerminalStreamText(text), this.cursorUnits)
   }
 
+  clipboardWrite(payload: string): void {
+    this.send(
+      TerminalStreamOpcode.ClipboardWrite,
+      encodeTerminalStreamText(payload),
+      this.cursorUnits
+    )
+  }
+
   flushHeldManualSnapshot(): void {
     if (this.heldManualRequestId === null) {
       throw new Error('No manual snapshot is held')
@@ -203,11 +211,13 @@ describe('remote terminal frame-drop resync', () => {
     data: string[]
     metas: { seq?: number; rawLength?: number; transformed?: boolean }[]
     snapshots: string[]
+    clipboardWrites: string[]
     stream: RemoteRuntimeMultiplexedTerminal
   }> {
     const data: string[] = []
     const metas: { seq?: number; rawLength?: number; transformed?: boolean }[] = []
     const snapshots: string[] = []
+    const clipboardWrites: string[] = []
     const multiplexer = getRemoteRuntimeTerminalMultiplexer('env-1')
     const stream = await multiplexer.subscribeTerminal({
       terminal: 'terminal-1',
@@ -217,14 +227,32 @@ describe('remote terminal frame-drop resync', () => {
           data.push(chunk)
           metas.push(meta ?? {})
         },
-        onSnapshot: (chunk) => snapshots.push(chunk)
+        onSnapshot: (chunk) => snapshots.push(chunk),
+        onOsc52Clipboard: (payload) => clipboardWrites.push(payload)
       }
     })
     // Let the initial snapshot round-trip settle.
     await Promise.resolve()
     await Promise.resolve()
-    return { data, metas, snapshots, stream }
+    return { data, metas, snapshots, clipboardWrites, stream }
   }
+
+  it('delivers negotiated OSC 52 outside dropped output and strips the in-band duplicate', async () => {
+    const { clipboardWrites, data } = await subscribeClient()
+    const sequence = '\x1b]52;c;Y29weQ==\x07'
+
+    server.clipboardWrite('c;Y29weQ==')
+    server.output(sequence)
+
+    expect(clipboardWrites).toEqual(['c;Y29weQ=='])
+    expect(data).toEqual([''])
+
+    server.clipboardWrite('c;bmV4dA==')
+    server.dropNextOutput = true
+    server.output('\x1b]52;c;bmV4dA==\x07')
+
+    expect(clipboardWrites).toEqual(['c;Y29weQ==', 'c;bmV4dA=='])
+  })
 
   it('detects a dropped Output frame via the seq gap and resyncs', async () => {
     const { data, snapshots } = await subscribeClient()

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -187,6 +187,12 @@ class FakeMultiplexServer {
     this.send(TerminalStreamOpcode.Output, encodeTerminalStreamText(text), 0)
   }
 
+  snapshotWithClipboardScannerSync(state: string): void {
+    this.snapshotData = 'RECOVERED'
+    this.sendSnapshot()
+    this.clipboardScannerSync(state)
+  }
+
   flushHeldManualSnapshot(): void {
     if (this.heldManualRequestId === null) {
       throw new Error('No manual snapshot is held')
@@ -288,6 +294,20 @@ describe('remote terminal frame-drop resync', () => {
 
     expect(clipboardWrites).toEqual(['c;aW5pdGlhbA==', 'c;c3BsaXQ='])
     expect(data).toEqual(['visible'])
+  })
+
+  it('preserves OSC 52 stripping across a snapshot boundary', async () => {
+    const { clipboardWrites, data, snapshots } = await subscribeClient()
+
+    server.clipboardWrite('c;aW5pdGlhbA==')
+    server.unsequencedOutput('\x1b]52;c;cGFy')
+    server.snapshotWithClipboardScannerSync('payload')
+    server.clipboardWrite('c;cGFydGlhbA==')
+    server.unsequencedOutput('dGlhbA==\x07visible')
+
+    expect(clipboardWrites).toEqual(['c;aW5pdGlhbA==', 'c;cGFydGlhbA=='])
+    expect(data).toEqual(['', 'visible'])
+    expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
   })
 
   it('detects a dropped Output frame via the seq gap and resyncs', async () => {

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -48,6 +48,7 @@ class FakeMultiplexServer {
 
   constructor(
     private readonly toClient: (bytes: Uint8Array<ArrayBufferLike>) => void,
+    private readonly toClientResponse: (response: unknown) => void,
     private readonly onServerSideDrop?: () => void
   ) {}
 
@@ -60,6 +61,14 @@ class FakeMultiplexServer {
     if (frame.opcode === TerminalStreamOpcode.Subscribe) {
       const payload = decodeTerminalStreamJson<{ streamId: number }>(frame.payload)
       this.streamId = payload?.streamId ?? 0
+      this.toClientResponse({
+        ok: true,
+        result: {
+          type: 'subscribed',
+          streamId: this.streamId,
+          capabilities: { clipboardWrite: 1, clipboardScannerSync: 1 }
+        }
+      })
       this.sendSnapshot()
       return
     }
@@ -166,6 +175,18 @@ class FakeMultiplexServer {
     )
   }
 
+  clipboardScannerSync(state: string): void {
+    this.send(
+      TerminalStreamOpcode.ClipboardScannerSync,
+      encodeTerminalStreamText(state),
+      this.cursorUnits
+    )
+  }
+
+  unsequencedOutput(text: string): void {
+    this.send(TerminalStreamOpcode.Output, encodeTerminalStreamText(text), 0)
+  }
+
   flushHeldManualSnapshot(): void {
     if (this.heldManualRequestId === null) {
       throw new Error('No manual snapshot is held')
@@ -190,7 +211,10 @@ describe('remote terminal frame-drop resync', () => {
 
     subscribe = vi.fn(async (_args: unknown, callbacks: SubscribeCallbacks) => {
       subscriptionCallbacks = callbacks
-      server = new FakeMultiplexServer((bytes) => callbacks.onBinary?.(bytes))
+      server = new FakeMultiplexServer(
+        (bytes) => callbacks.onBinary?.(bytes),
+        (response) => callbacks.onResponse(response)
+      )
       queueMicrotask(() => callbacks.onResponse({ ok: true, result: { type: 'ready' } }))
       return {
         unsubscribe,
@@ -252,6 +276,18 @@ describe('remote terminal frame-drop resync', () => {
     server.output('\x1b]52;c;bmV4dA==\x07')
 
     expect(clipboardWrites).toEqual(['c;Y29weQ==', 'c;bmV4dA=='])
+  })
+
+  it('aligns OSC 52 stripping after paused output is omitted', async () => {
+    const { clipboardWrites, data } = await subscribeClient()
+
+    server.clipboardWrite('c;aW5pdGlhbA==')
+    server.clipboardScannerSync('payload')
+    server.clipboardWrite('c;c3BsaXQ=')
+    server.unsequencedOutput('aXQ=\x07visible')
+
+    expect(clipboardWrites).toEqual(['c;aW5pdGlhbA==', 'c;c3BsaXQ='])
+    expect(data).toEqual(['visible'])
   })
 
   it('detects a dropped Output frame via the seq gap and resyncs', async () => {

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer-implementation.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer-implementation.ts
@@ -36,6 +36,7 @@ export class RemoteRuntimeTerminalMultiplexer extends RemoteRuntimeTerminalBinar
       acknowledgeOutputSourceRanges: false,
       supportsOutputPause: false,
       supportsClipboardWrite: false,
+      supportsClipboardScannerSync: false,
       outputPaused: false,
       osc52Scanner: new TerminalOsc52StreamScanner(),
       streamGeneration: null,
@@ -147,7 +148,9 @@ export class RemoteRuntimeTerminalMultiplexer extends RemoteRuntimeTerminalBinar
             ackOutputSourceRanges: 1,
             outputPause: 1,
             writeUnavailable: 1,
-            ...(args.callbacks.onOsc52Clipboard ? { clipboardWrite: 1 } : {}),
+            ...(args.callbacks.onOsc52Clipboard
+              ? { clipboardWrite: 1, clipboardScannerSync: 1 }
+              : {}),
             ...(args.client.type === 'desktop' ? { desktopViewportClaims: 1 } : {})
           }
         })

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer-implementation.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer-implementation.ts
@@ -17,6 +17,7 @@ import type {
   RemoteRuntimeMultiplexedTerminalState
 } from './remote-runtime-terminal-multiplexer-types'
 import { createRemoteTerminalStreamWatchdog } from './remote-terminal-stream-watchdog'
+import { TerminalOsc52StreamScanner } from '../../../shared/terminal-osc52-stream-scanner'
 
 export class RemoteRuntimeTerminalMultiplexer extends RemoteRuntimeTerminalBinaryController {
   async subscribeTerminal(args: {
@@ -34,7 +35,9 @@ export class RemoteRuntimeTerminalMultiplexer extends RemoteRuntimeTerminalBinar
       acknowledgeOutput: true,
       acknowledgeOutputSourceRanges: false,
       supportsOutputPause: false,
+      supportsClipboardWrite: false,
       outputPaused: false,
+      osc52Scanner: new TerminalOsc52StreamScanner(),
       streamGeneration: null,
       sourceAckedEndByte: 0,
       heldAckBytes: 0,
@@ -144,6 +147,7 @@ export class RemoteRuntimeTerminalMultiplexer extends RemoteRuntimeTerminalBinar
             ackOutputSourceRanges: 1,
             outputPause: 1,
             writeUnavailable: 1,
+            ...(args.callbacks.onOsc52Clipboard ? { clipboardWrite: 1 } : {}),
             ...(args.client.type === 'desktop' ? { desktopViewportClaims: 1 } : {})
           }
         })

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer-types.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer-types.ts
@@ -1,6 +1,7 @@
 import type { TerminalSnapshotUnavailableReason } from '../../../shared/terminal-snapshot-unavailability'
 import type { TerminalStreamEndVerdict } from '../../../shared/terminal-stream-end-verdict'
 import type { RemoteTerminalStreamWatchdog } from './remote-terminal-stream-watchdog'
+import type { TerminalOsc52StreamScanner } from '../../../shared/terminal-osc52-stream-scanner'
 
 export type RuntimeEnvironmentSubscriptionHandle = {
   unsubscribe: () => void
@@ -13,7 +14,7 @@ export type TerminalMultiplexEvent =
       type: 'subscribed'
       streamId: number
       streamGeneration?: string
-      capabilities?: { ackOutputSourceRanges?: 1; outputPause?: 1 }
+      capabilities?: { ackOutputSourceRanges?: 1; outputPause?: 1; clipboardWrite?: 1 }
     }
   | { type: 'end'; streamId: number; verdict?: TerminalStreamEndVerdict }
   | { type: 'error'; streamId: number; message?: string }
@@ -45,6 +46,7 @@ export type RemoteRuntimeMultiplexedTerminalCallbacks = {
   ) => void
   onSubscribed?: () => void
   onOutputPauseCapability?: () => void
+  onOsc52Clipboard?: (data: string) => void
   onEnd?: (verdict: TerminalStreamEndVerdict) => void
   onError?: (message: string) => void
   onFitOverrideChanged?: (event: {
@@ -151,7 +153,9 @@ export type RemoteRuntimeMultiplexedTerminalState = {
   acknowledgeOutput: boolean
   acknowledgeOutputSourceRanges: boolean
   supportsOutputPause: boolean
+  supportsClipboardWrite: boolean
   outputPaused: boolean
+  osc52Scanner: TerminalOsc52StreamScanner
   streamGeneration: string | null
   sourceAckedEndByte: number
   heldAckBytes: number

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer-types.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer-types.ts
@@ -14,7 +14,12 @@ export type TerminalMultiplexEvent =
       type: 'subscribed'
       streamId: number
       streamGeneration?: string
-      capabilities?: { ackOutputSourceRanges?: 1; outputPause?: 1; clipboardWrite?: 1 }
+      capabilities?: {
+        ackOutputSourceRanges?: 1
+        outputPause?: 1
+        clipboardWrite?: 1
+        clipboardScannerSync?: 1
+      }
     }
   | { type: 'end'; streamId: number; verdict?: TerminalStreamEndVerdict }
   | { type: 'error'; streamId: number; message?: string }
@@ -154,6 +159,7 @@ export type RemoteRuntimeMultiplexedTerminalState = {
   acknowledgeOutputSourceRanges: boolean
   supportsOutputPause: boolean
   supportsClipboardWrite: boolean
+  supportsClipboardScannerSync: boolean
   outputPaused: boolean
   osc52Scanner: TerminalOsc52StreamScanner
   streamGeneration: string | null

--- a/src/renderer/src/runtime/remote-runtime-terminal-response-controller.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-response-controller.ts
@@ -51,6 +51,7 @@ export abstract class RemoteRuntimeTerminalResponseController extends RemoteRunt
               ackOutputSourceRanges?: unknown
               outputPause?: unknown
               clipboardWrite?: unknown
+              clipboardScannerSync?: unknown
             })
           : null
       if (
@@ -63,6 +64,7 @@ export abstract class RemoteRuntimeTerminalResponseController extends RemoteRunt
       }
       stream.supportsOutputPause = capabilities?.outputPause === 1
       stream.supportsClipboardWrite = capabilities?.clipboardWrite === 1
+      stream.supportsClipboardScannerSync = capabilities?.clipboardScannerSync === 1
       if (stream.supportsOutputPause) {
         stream.callbacks.onOutputPauseCapability?.()
       }

--- a/src/renderer/src/runtime/remote-runtime-terminal-response-controller.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-response-controller.ts
@@ -47,7 +47,11 @@ export abstract class RemoteRuntimeTerminalResponseController extends RemoteRunt
     if (event.type === 'subscribed') {
       const capabilities =
         typeof event.capabilities === 'object' && event.capabilities !== null
-          ? (event.capabilities as { ackOutputSourceRanges?: unknown; outputPause?: unknown })
+          ? (event.capabilities as {
+              ackOutputSourceRanges?: unknown
+              outputPause?: unknown
+              clipboardWrite?: unknown
+            })
           : null
       if (
         capabilities?.ackOutputSourceRanges === 1 &&
@@ -58,6 +62,7 @@ export abstract class RemoteRuntimeTerminalResponseController extends RemoteRunt
         stream.streamGeneration = event.streamGeneration
       }
       stream.supportsOutputPause = capabilities?.outputPause === 1
+      stream.supportsClipboardWrite = capabilities?.clipboardWrite === 1
       if (stream.supportsOutputPause) {
         stream.callbacks.onOutputPauseCapability?.()
       }

--- a/src/shared/terminal-osc52-stream-scanner.test.ts
+++ b/src/shared/terminal-osc52-stream-scanner.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TerminalOsc52StreamScanner,
+  isTerminalOsc52ClipboardQuery
+} from './terminal-osc52-stream-scanner'
+
+describe('TerminalOsc52StreamScanner', () => {
+  it('identifies clipboard queries without accepting lookalikes', () => {
+    expect(isTerminalOsc52ClipboardQuery('c;?')).toBe(true)
+    expect(isTerminalOsc52ClipboardQuery('c;YQ==')).toBe(false)
+  })
+
+  it('extracts and strips OSC 52 while preserving surrounding output', () => {
+    const scanner = new TerminalOsc52StreamScanner()
+
+    expect(scanner.scan('before\x1b]52;c;Y29weQ==\x07after')).toEqual({
+      passthrough: 'beforeafter',
+      payloads: ['c;Y29weQ==']
+    })
+  })
+
+  it('tracks split ST-terminated controls across chunks', () => {
+    const scanner = new TerminalOsc52StreamScanner()
+
+    expect(scanner.scan('a\x1b]52;c;Y2')).toEqual({ passthrough: 'a', payloads: [] })
+    expect(scanner.scan('9weQ==\x1b')).toEqual({ passthrough: '', payloads: [] })
+    expect(scanner.scan('\\b')).toEqual({ passthrough: 'b', payloads: ['c;Y29weQ=='] })
+  })
+
+  it('supports C1 OSC and ST controls', () => {
+    const scanner = new TerminalOsc52StreamScanner()
+
+    expect(scanner.scan('\x9d52;;YQ==\x9c')).toEqual({
+      passthrough: '',
+      payloads: [';YQ==']
+    })
+  })
+
+  it('releases non-OSC-52 controls unchanged', () => {
+    const scanner = new TerminalOsc52StreamScanner()
+
+    expect(scanner.scan('\x1b]0;title\x07text')).toEqual({
+      passthrough: '\x1b]0;title\x07text',
+      payloads: []
+    })
+  })
+})

--- a/src/shared/terminal-osc52-stream-scanner.test.ts
+++ b/src/shared/terminal-osc52-stream-scanner.test.ts
@@ -27,6 +27,27 @@ describe('TerminalOsc52StreamScanner', () => {
     expect(scanner.scan('\\b')).toEqual({ passthrough: 'b', payloads: ['c;Y29weQ=='] })
   })
 
+  it('restores strip state after a peer intentionally omits output', () => {
+    const host = new TerminalOsc52StreamScanner()
+    const client = new TerminalOsc52StreamScanner()
+
+    host.scan('\x1b]52;c;Y2')
+    client.restoreSyncState(host.syncState)
+
+    expect(host.scan('9weQ==\x07visible').payloads).toEqual(['c;Y29weQ=='])
+    expect(client.scan('9weQ==\x07visible').passthrough).toBe('visible')
+  })
+
+  it('does not release a synthetic prefix when synchronized output is not OSC 52', () => {
+    const host = new TerminalOsc52StreamScanner()
+    const client = new TerminalOsc52StreamScanner()
+
+    host.scan('\x1b]5')
+    client.restoreSyncState(host.syncState)
+
+    expect(client.scan('xvisible').passthrough).toBe('xvisible')
+  })
+
   it('supports C1 OSC and ST controls', () => {
     const scanner = new TerminalOsc52StreamScanner()
 

--- a/src/shared/terminal-osc52-stream-scanner.ts
+++ b/src/shared/terminal-osc52-stream-scanner.ts
@@ -1,0 +1,127 @@
+const OSC52_PREFIX = '52;'
+const MAX_OSC52_SEQUENCE_CHARS = 128 * 1024 + 64
+
+type ScanMode = 'plain' | 'escape' | 'prefix' | 'payload' | 'payload-escape'
+
+export type TerminalOsc52ScanResult = {
+  passthrough: string
+  payloads: string[]
+}
+
+export function isTerminalOsc52ClipboardQuery(payload: string): boolean {
+  const separator = payload.indexOf(';')
+  return separator !== -1 && payload.slice(separator + 1) === '?'
+}
+
+/** Finds complete OSC 52 controls across PTY chunk boundaries. */
+export class TerminalOsc52StreamScanner {
+  private mode: ScanMode = 'plain'
+  private candidate = ''
+  private prefixOffset = 0
+  private payloadOffset = 0
+
+  scan(data: string): TerminalOsc52ScanResult {
+    let passthrough = ''
+    const payloads: string[] = []
+
+    const reset = (): void => {
+      this.mode = 'plain'
+      this.candidate = ''
+      this.prefixOffset = 0
+      this.payloadOffset = 0
+    }
+    const restartOrRelease = (last: string): void => {
+      const failed = this.candidate
+      reset()
+      if (last === '\x1b') {
+        passthrough += failed.slice(0, -1)
+        this.candidate = last
+        this.mode = 'escape'
+      } else if (last === '\x9d') {
+        passthrough += failed.slice(0, -1)
+        this.candidate = last
+        this.mode = 'prefix'
+      } else {
+        passthrough += failed
+      }
+    }
+    const enforceLimit = (): void => {
+      if (this.candidate.length <= MAX_OSC52_SEQUENCE_CHARS) {
+        return
+      }
+      passthrough += this.candidate
+      reset()
+    }
+
+    for (const char of data) {
+      if (this.mode === 'plain') {
+        if (char === '\x1b') {
+          this.candidate = char
+          this.mode = 'escape'
+        } else if (char === '\x9d') {
+          this.candidate = char
+          this.mode = 'prefix'
+        } else {
+          passthrough += char
+        }
+        continue
+      }
+
+      if (this.mode === 'escape') {
+        this.candidate += char
+        if (char === ']') {
+          this.mode = 'prefix'
+        } else {
+          restartOrRelease(char)
+        }
+        continue
+      }
+
+      if (this.mode === 'prefix') {
+        this.candidate += char
+        if (char !== OSC52_PREFIX[this.prefixOffset]) {
+          restartOrRelease(char)
+          continue
+        }
+        this.prefixOffset += 1
+        if (this.prefixOffset === OSC52_PREFIX.length) {
+          this.payloadOffset = this.candidate.length
+          this.mode = 'payload'
+        }
+        continue
+      }
+
+      if (this.mode === 'payload') {
+        if (char === '\x07' || char === '\x9c') {
+          payloads.push(this.candidate.slice(this.payloadOffset))
+          reset()
+          continue
+        }
+        this.candidate += char
+        if (char === '\x1b') {
+          this.mode = 'payload-escape'
+        }
+        enforceLimit()
+        continue
+      }
+
+      if (char === '\\') {
+        payloads.push(this.candidate.slice(this.payloadOffset, -1))
+        reset()
+        continue
+      }
+      this.candidate += char
+      this.mode = char === '\x1b' ? 'payload-escape' : 'payload'
+      enforceLimit()
+    }
+
+    return { passthrough, payloads }
+  }
+
+  reset(): void {
+    this.mode = 'plain'
+    this.candidate = ''
+    this.prefixOffset = 0
+    this.payloadOffset = 0
+  }
+}

--- a/src/shared/terminal-osc52-stream-scanner.ts
+++ b/src/shared/terminal-osc52-stream-scanner.ts
@@ -3,6 +3,25 @@ const MAX_OSC52_SEQUENCE_CHARS = 128 * 1024 + 64
 
 type ScanMode = 'plain' | 'escape' | 'prefix' | 'payload' | 'payload-escape'
 
+export type TerminalOsc52ScannerSyncState =
+  | 'plain'
+  | 'escape'
+  | 'prefix-0'
+  | 'prefix-1'
+  | 'prefix-2'
+  | 'payload'
+  | 'payload-escape'
+
+const TERMINAL_OSC52_SCANNER_SYNC_STATES = new Set<TerminalOsc52ScannerSyncState>([
+  'plain',
+  'escape',
+  'prefix-0',
+  'prefix-1',
+  'prefix-2',
+  'payload',
+  'payload-escape'
+])
+
 export type TerminalOsc52ScanResult = {
   passthrough: string
   payloads: string[]
@@ -13,12 +32,53 @@ export function isTerminalOsc52ClipboardQuery(payload: string): boolean {
   return separator !== -1 && payload.slice(separator + 1) === '?'
 }
 
+export function isTerminalOsc52ScannerSyncState(
+  value: string
+): value is TerminalOsc52ScannerSyncState {
+  return TERMINAL_OSC52_SCANNER_SYNC_STATES.has(value as TerminalOsc52ScannerSyncState)
+}
+
 /** Finds complete OSC 52 controls across PTY chunk boundaries. */
 export class TerminalOsc52StreamScanner {
   private mode: ScanMode = 'plain'
   private candidate = ''
   private prefixOffset = 0
   private payloadOffset = 0
+  private suppressedCandidateChars = 0
+
+  get syncState(): TerminalOsc52ScannerSyncState {
+    if (this.mode !== 'prefix') {
+      return this.mode
+    }
+    if (this.prefixOffset === 0) {
+      return 'prefix-0'
+    }
+    return this.prefixOffset === 1 ? 'prefix-1' : 'prefix-2'
+  }
+
+  /** Aligns a strip-only peer after output was intentionally omitted. */
+  restoreSyncState(state: TerminalOsc52ScannerSyncState): void {
+    this.reset()
+    if (state === 'plain') {
+      return
+    }
+    if (state === 'escape') {
+      this.candidate = '\x1b'
+      this.mode = 'escape'
+    } else if (state === 'prefix-0' || state === 'prefix-1' || state === 'prefix-2') {
+      this.prefixOffset = Number(state.slice(-1))
+      this.candidate = `\x1b]${OSC52_PREFIX.slice(0, this.prefixOffset)}`
+      this.mode = 'prefix'
+    } else {
+      this.candidate = `\x1b]${OSC52_PREFIX}`
+      this.payloadOffset = this.candidate.length
+      this.mode = state
+      if (state === 'payload-escape') {
+        this.candidate += '\x1b'
+      }
+    }
+    this.suppressedCandidateChars = this.candidate.length
+  }
 
   scan(data: string): TerminalOsc52ScanResult {
     let passthrough = ''
@@ -29,9 +89,10 @@ export class TerminalOsc52StreamScanner {
       this.candidate = ''
       this.prefixOffset = 0
       this.payloadOffset = 0
+      this.suppressedCandidateChars = 0
     }
     const restartOrRelease = (last: string): void => {
-      const failed = this.candidate
+      const failed = this.candidate.slice(this.suppressedCandidateChars)
       reset()
       if (last === '\x1b') {
         passthrough += failed.slice(0, -1)
@@ -49,7 +110,7 @@ export class TerminalOsc52StreamScanner {
       if (this.candidate.length <= MAX_OSC52_SEQUENCE_CHARS) {
         return
       }
-      passthrough += this.candidate
+      passthrough += this.candidate.slice(this.suppressedCandidateChars)
       reset()
     }
 
@@ -123,5 +184,6 @@ export class TerminalOsc52StreamScanner {
     this.candidate = ''
     this.prefixOffset = 0
     this.payloadOffset = 0
+    this.suppressedCandidateChars = 0
   }
 }

--- a/src/shared/terminal-stream-protocol.ts
+++ b/src/shared/terminal-stream-protocol.ts
@@ -34,7 +34,9 @@ export enum TerminalStreamOpcode {
   // Negotiated per stream because older clients reject unknown opcodes.
   WriteUnavailable = 17,
   // Carries live OSC 52 intent outside the lossy terminal snapshot/ack path.
-  ClipboardWrite = 18
+  ClipboardWrite = 18,
+  // Negotiated with ClipboardWrite; aligns duplicate stripping after omitted output.
+  ClipboardScannerSync = 19
 }
 
 export type TerminalStreamFrame = {
@@ -125,6 +127,7 @@ function isTerminalStreamOpcode(value: number): value is TerminalStreamOpcode {
     value === TerminalStreamOpcode.OutputSpan ||
     value === TerminalStreamOpcode.SetOutputPaused ||
     value === TerminalStreamOpcode.WriteUnavailable ||
-    value === TerminalStreamOpcode.ClipboardWrite
+    value === TerminalStreamOpcode.ClipboardWrite ||
+    value === TerminalStreamOpcode.ClipboardScannerSync
   )
 }

--- a/src/shared/terminal-stream-protocol.ts
+++ b/src/shared/terminal-stream-protocol.ts
@@ -32,7 +32,9 @@ export enum TerminalStreamOpcode {
   // Negotiated per stream; older hosts reject unknown opcodes, so clients send only after capability confirmation.
   SetOutputPaused = 16,
   // Negotiated per stream because older clients reject unknown opcodes.
-  WriteUnavailable = 17
+  WriteUnavailable = 17,
+  // Carries live OSC 52 intent outside the lossy terminal snapshot/ack path.
+  ClipboardWrite = 18
 }
 
 export type TerminalStreamFrame = {
@@ -122,6 +124,7 @@ function isTerminalStreamOpcode(value: number): value is TerminalStreamOpcode {
     value === TerminalStreamOpcode.ClaimViewport ||
     value === TerminalStreamOpcode.OutputSpan ||
     value === TerminalStreamOpcode.SetOutputPaused ||
-    value === TerminalStreamOpcode.WriteUnavailable
+    value === TerminalStreamOpcode.WriteUnavailable ||
+    value === TerminalStreamOpcode.ClipboardWrite
   )
 }

--- a/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
@@ -116,10 +116,9 @@ function expectWireCompatible(record: JourneyRecord): void {
   expect(record.rejected).toEqual([])
   expect(record.clientErrors).toEqual([])
 
-  // The subscribe handshake still negotiates the optional output-pause opcode,
-  // which is what keeps opcode 16 legal to send on this pairing.
+  // The subscribe handshake still negotiates output pause across both skew directions.
   for (const event of record.subscribedEvents) {
-    expect(event.capabilities).toEqual({ outputPause: 1 })
+    expect(event.capabilities).toMatchObject({ outputPause: 1 })
   }
 
   // Input reached the process, before and after the reconnect.
@@ -163,6 +162,9 @@ describe('cross-version remote terminal wire', () => {
   it('current client against current server completes the journey, and is the reference for a current host', () => {
     expectJourneyActuallyRan(currentReference)
     expectWireCompatible(currentReference)
+    for (const event of currentReference.subscribedEvents) {
+      expect(event.capabilities).toMatchObject({ clipboardWrite: 1 })
+    }
     // Current code's own contract in both roles, so it is safe to state literally.
     expect(currentReference.snapshotStarts).toEqual([
       expect.objectContaining({ alternateScreen: false, terminalOwner: 'shell' }),

--- a/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
@@ -163,7 +163,10 @@ describe('cross-version remote terminal wire', () => {
     expectJourneyActuallyRan(currentReference)
     expectWireCompatible(currentReference)
     for (const event of currentReference.subscribedEvents) {
-      expect(event.capabilities).toMatchObject({ clipboardWrite: 1 })
+      expect(event.capabilities).toMatchObject({
+        clipboardWrite: 1,
+        clipboardScannerSync: 1
+      })
     }
     // Current code's own contract in both roles, so it is safe to state literally.
     expect(currentReference.snapshotStarts).toEqual([

--- a/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
@@ -87,7 +87,9 @@ function expectJourneyActuallyRan(record: JourneyRecord): void {
   // The anti-vacuous-pass oracle. A harness that connects and then does nothing
   // fails here, because "nothing threw" is never enough to call a pairing green.
   expect(record.completed).toEqual([...JOURNEY_STEPS])
-  expect(record.frameSequence).toEqual(EXPECTED_JOURNEY_FRAMES)
+  expect(record.frameSequence.filter((frame) => frame !== 'H>C ClipboardScannerSync')).toEqual(
+    EXPECTED_JOURNEY_FRAMES
+  )
   expect(record.subscribedEvents).toHaveLength(2)
   expect(record.snapshotStarts).toHaveLength(3)
   expect(record.missingRuntimeMethods).toEqual([])
@@ -162,6 +164,9 @@ describe('cross-version remote terminal wire', () => {
   it('current client against current server completes the journey, and is the reference for a current host', () => {
     expectJourneyActuallyRan(currentReference)
     expectWireCompatible(currentReference)
+    expect(
+      currentReference.frameSequence.filter((frame) => frame === 'H>C ClipboardScannerSync')
+    ).toHaveLength(3)
     for (const event of currentReference.subscribedEvents) {
       expect(event.capabilities).toMatchObject({
         clipboardWrite: 1,

--- a/tests/e2e/cross-version-wire/terminal-skew-journey.ts
+++ b/tests/e2e/cross-version-wire/terminal-skew-journey.ts
@@ -169,6 +169,7 @@ export async function runTerminalSkewJourney(args: {
     onSnapshot: (data: string) => {
       record.snapshotsRendered.push(data)
     },
+    onOsc52Clipboard: () => {},
     onSubscribed: () => {
       subscribedCount++
     },


### PR DESCRIPTION
## ELI5

Shift+Enter and clipboard copy both depended on terminal state that could disappear while a pane was reconnecting. This keeps the proven keyboard protocol state through park/reattach, waits to encode Shift+Enter until that state settles, and carries live remote clipboard intent separately from lossy screen snapshots.

## What Changed

- retain proven Kitty keyboard flags by live PTY across pane park/remount
- defer protocol-dependent Shift+Enter bytes during connect/reattach, then emit CSI-u or legacy bytes from settled state
- preserve existing trusted Windows encoding and real Alt+Enter behavior
- add a capability-negotiated `ClipboardWrite` terminal frame for live OSC 52 writes
- extract OSC 52 on the execution host before output pause/ACK overflow can replace bytes with a grid snapshot
- strip the negotiated in-band duplicate on the client and route the live intent through the existing setting gate, coalescing, verified Electron clipboard write, and failure toast
- refuse OSC 52 clipboard queries on the host and preserve old-client/old-host in-band fallback

## Why

Orca owns Shift+Enter encoding. A parked pane could lose its renderer Kitty tracker while the still-live TUI remained in Kitty mode, causing Orca to send legacy `ESC CR`, which Pi can interpret as Alt+Enter/follow-up submission.

For paired runtimes, OSC 52 was carried only in display output. Hidden-output pause, ACK backlog recovery, and gap resync can intentionally replace display bytes with a serialized grid snapshot. Clipboard controls have no grid representation, so Pi could report a copy while the control never reached the Mac clipboard handler.

## Linked Issue

N/A — direct regression report; no public issue was provided.

## Visual Proof

N/A — No visual change; this changes terminal byte routing and clipboard delivery.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated on Linux:

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- focused Vitest coverage for Kitty settlement/retention, IME routing, OSC 52 extraction, paused output, dropped-frame recovery, query refusal, and transport subscription
- cross-version terminal wire journey in both skew directions
- full `pnpm test`: 57,026 tests passed; one unrelated updater scheduling timer test flaked once, then passed 10/10 in isolation

No Mac desktop was available for manual clipboard verification. The final Mac write still uses the existing Electron clipboard read-back verification path, covered by its existing tests.

## Review

- **Cross-platform:** no platform-specific key assumptions added; legacy and trusted Windows encodings remain intact.
- **SSH/remote/local:** PTY protocol state is keyed to the execution-owned PTY; no client-side remote process inference was added. Local OSC 52 remains unchanged.
- **Agents/integrations:** fixes are protocol-based and not Pi-specific; any Kitty keyboard TUI or OSC 52 producer benefits.
- **Compatibility:** the new frame is capability-negotiated. New client/old host and old client/new host retain the existing in-band path; skew tests cover both.
- **Performance:** OSC scanning is limited to negotiated remote terminal streams, state is bounded, and clipboard writes remain coalesced.
- **Security:** clipboard queries are dropped on the host; writes still pass the client setting, payload validation/size cap, replay boundary, and verified local clipboard write. No remote process can read the client clipboard.
- **UI quality:** No visual change.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The remote clipboard frame represents only live output observed after subscription. Historical snapshots never replay clipboard intent.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
