### PR TITLE
perf(renderer): cooperative terminal output scheduling lanes

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection/foreground-output-refresh.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/foreground-output-refresh.ts
@@ -210,8 +210,11 @@ export function bindForegroundOutputRefresh(session: ConnectPanePtySession): voi
     return activePane ? activePane.id === session.pane.id : true
   }
 
-  session.isLatencySensitiveForegroundOutput = function (data: string): boolean {
-    if (!session.isActiveSplitPane()) {
+  session.isLatencySensitiveForegroundOutput = function (
+    data: string,
+    activeSplitPane: boolean = session.isActiveSplitPane()
+  ): boolean {
+    if (!activeSplitPane) {
       // Why: many visible split panes each emit tiny TUI frames; a shared budget keeps them live without letting aggregate xterm work starve typing in the active pane.
       if (data.includes('\x1b[')) {
         return false

--- a/src/renderer/src/components/terminal-pane/pty-connection/write-pty-output-to-xterm.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/write-pty-output-to-xterm.ts
@@ -75,6 +75,17 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
     // Why: ConPTY can split a submit repaint's closing chunk past the 150ms window, so treat a keystroke-opened frame as latency-sensitive to drain it fast (~16-32ms) not the 1s coalesce fallback.
     const synchronizedFrameLatencySensitive =
       synchronizedForegroundOutput && session.synchronizedForegroundFrameInteractive
+    // Read pane activity once per chunk; the classifier and scheduler lane
+    // must agree even if focus changes while this callback is running.
+    const activeSplitPane =
+      foreground && !parseHiddenStartupOutput ? session.isActiveSplitPane() : false
+    const latencySensitive =
+      !foreground || parseHiddenStartupOutput
+        ? true
+        : synchronizedFrameLatencySensitive ||
+          session.isLatencySensitiveForegroundOutput(data, activeSplitPane)
+    const foregroundPriority =
+      foregroundOutput && foreground && !activeSplitPane ? 'visible-background' : 'active'
     session.synchronizedForegroundOutputActive = nextSynchronizedForegroundOutputActive
     session.synchronizedForegroundMarkerTail = synchronizedForegroundScan?.markerTail ?? ''
     writeTerminalOutput(session.pane.terminal, data, {
@@ -83,10 +94,8 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
       // Why: every scheduler write claims one child so a split delivery is credited only after all children parse or discard.
       ackCredit: takeCurrentTerminalDeliveryCredit() ?? undefined,
       onBackgroundBacklogDropped: session.markHiddenOutputRestoreNeeded,
-      latencySensitive:
-        !foreground || parseHiddenStartupOutput
-          ? true
-          : synchronizedFrameLatencySensitive || session.isLatencySensitiveForegroundOutput(data),
+      latencySensitive,
+      foregroundPriority,
       forceForegroundRefresh:
         foregroundOutput &&
         (synchronizedForegroundOutput ||

--- a/src/renderer/src/lib/pane-manager/pane-terminal-foreground-queue-state.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-foreground-queue-state.ts
@@ -22,7 +22,12 @@ export function createQueueEntry(
     queuedChars: 0,
     onBackgroundBacklogDropped: options.onBackgroundBacklogDropped,
     backgroundBacklogDropped: false,
-    highPriority: true,
+    priority:
+      options.foreground && options.foregroundPriority === 'visible-background'
+        ? 'visible-background'
+        : options.foreground
+          ? 'high'
+          : 'background',
     foregroundHold: false,
     foregroundHoldSafetyDelayMs: FOREGROUND_HOLD_SAFETY_DELAY_MS,
     foregroundCoalesce: false,

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-drain.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-drain.ts
@@ -4,7 +4,7 @@ import {
   terminalOutputSchedulerDebugState as debugState
 } from './pane-terminal-output-scheduler-debug'
 import { clearForegroundRelease, isEntryDrainable } from './pane-terminal-foreground-queue-state'
-import { hasHighPriorityBacklog, hasQueuedChunks } from './pane-terminal-output-queue-backlog'
+import { hasQueuedChunks } from './pane-terminal-output-queue-backlog'
 import {
   BACKGROUND_DRAIN_INTERVAL_MS,
   DRAIN_TIME_BUDGET_MS,
@@ -12,54 +12,104 @@ import {
   HIGH_PRIORITY_MAX_WRITES_PER_DRAIN,
   LARGE_BACKLOG_CHARS,
   MAX_WRITES_PER_DRAIN,
+  isCooperativeQueueEntry,
+  isCooperativeTurnPending,
+  isHighPriorityQueueEntry,
   isMessageChannelDrainEnabled,
   markTerminalOutputDrainStarted,
   queuedByTerminal,
+  resetCooperativeTurnPending,
   scheduleDrain,
+  setCooperativeTurnPending,
   setTerminalOutputDrainRunner,
   type QueueEntry
 } from './pane-terminal-output-queue-registry'
 
 import { writeQueuedChunk } from './pane-terminal-output-pipeline'
 
-function hasDrainableBacklog(): boolean {
-  for (const entry of queuedByTerminal.values()) {
-    if (isEntryDrainable(entry)) {
-      return true
-    }
-  }
-  return false
-}
-
 // Why no per-write scroll enforcement: xterm's BufferService.isUserScrolling owns live follow/pin; app-side enforcement is limited to structural ops xterm can't identify, like replay.
 
-function takeNextDrainableEntry(): QueueEntry | null {
+function takeNextDrainableEntry(options?: { preferCooperative?: boolean }): QueueEntry | null {
+  const preferCooperative = options?.preferCooperative === true
   let largeBacklogEntry: QueueEntry | null = null
+  let visibleBackgroundEntry: QueueEntry | null = null
+  let firstCooperativeEntry: QueueEntry | null = null
+  let firstDrainableEntry: QueueEntry | null = null
   for (const entry of queuedByTerminal.values()) {
     if (!isEntryDrainable(entry)) {
       continue
     }
+    firstDrainableEntry ??= entry
+    if (isCooperativeQueueEntry(entry)) {
+      firstCooperativeEntry ??= entry
+    }
     // Why: active/foreground output should be chosen first, not left in insertion order behind older background terminals.
-    if (entry.highPriority) {
-      queuedByTerminal.delete(entry.terminal)
-      return entry
+    if (entry.priority === 'high') {
+      if (!preferCooperative) {
+        queuedByTerminal.delete(entry.terminal)
+        return entry
+      }
+      continue
     }
     if (!largeBacklogEntry && entry.queuedChars > LARGE_BACKLOG_CHARS) {
       largeBacklogEntry = entry
     }
+    if (!visibleBackgroundEntry && entry.priority === 'visible-background') {
+      visibleBackgroundEntry = entry
+    }
   }
-  if (largeBacklogEntry) {
-    queuedByTerminal.delete(largeBacklogEntry.terminal)
-    return largeBacklogEntry
+  const selected = preferCooperative
+    ? visibleBackgroundEntry && isCooperativeQueueEntry(visibleBackgroundEntry)
+      ? visibleBackgroundEntry
+      : (firstCooperativeEntry ?? largeBacklogEntry ?? firstDrainableEntry)
+    : (largeBacklogEntry ?? visibleBackgroundEntry ?? firstDrainableEntry)
+  if (selected) {
+    queuedByTerminal.delete(selected.terminal)
   }
+  return selected
+}
+
+type QueueBacklogState = {
+  hasDrainable: boolean
+  hasHighPriority: boolean
+  hasCooperative: boolean
+  hasCompetingPriorities: boolean
+}
+
+function getQueueBacklogState(): QueueBacklogState {
+  let hasDrainable = false
+  let hasHighPriority = false
+  let hasCooperative = false
+  let highPriorityEntry: QueueEntry | null = null
+  let cooperativeEntry: QueueEntry | null = null
+  let hasCompetingPriorities = false
   for (const entry of queuedByTerminal.values()) {
     if (!isEntryDrainable(entry)) {
       continue
     }
-    queuedByTerminal.delete(entry.terminal)
-    return entry
+    hasDrainable = true
+    const cooperative = isCooperativeQueueEntry(entry)
+    const highPriority = isHighPriorityQueueEntry(entry)
+    if (cooperative) {
+      hasCooperative = true
+      cooperativeEntry ??= entry
+      hasCompetingPriorities ||= highPriorityEntry !== null && highPriorityEntry !== entry
+    }
+    if (highPriority) {
+      hasHighPriority = true
+      highPriorityEntry ??= entry
+      hasCompetingPriorities ||= cooperativeEntry !== null && cooperativeEntry !== entry
+    }
+    if (hasCompetingPriorities) {
+      break
+    }
   }
-  return null
+  return {
+    hasDrainable,
+    hasHighPriority,
+    hasCooperative,
+    hasCompetingPriorities
+  }
 }
 
 // Why: re-arm a zero-delay drain once xterm confirms the previous high-priority batch parsed; the fixed 4/16ms cadence otherwise drips far below xterm's ~100 MB/s parse. Only visible panes are pacer-clocked; background keeps the fixed cadence to protect the focused terminal.
@@ -75,15 +125,20 @@ export function drainQueuedOutputImpl(): void {
   markTerminalOutputDrainStarted()
   let writes = 0
   const startedAt = getDrainNow()
-  const highPriority = hasHighPriorityBacklog()
-  const maxWrites = highPriority ? HIGH_PRIORITY_MAX_WRITES_PER_DRAIN : MAX_WRITES_PER_DRAIN
+  const requestedCooperativeTurn = isCooperativeTurnPending()
+  let entry = takeNextDrainableEntry({ preferCooperative: requestedCooperativeTurn })
+  const cooperativeTurn =
+    requestedCooperativeTurn && entry !== null && isCooperativeQueueEntry(entry)
+  const highPriority = !cooperativeTurn && entry !== null && isHighPriorityQueueEntry(entry)
+  // A fairness turn is intentionally one write: keep active output's first
+  // paint budget intact while giving another pane a bounded chance to parse.
+  const maxWrites = cooperativeTurn
+    ? 1
+    : highPriority
+      ? HIGH_PRIORITY_MAX_WRITES_PER_DRAIN
+      : MAX_WRITES_PER_DRAIN
 
-  while (queuedByTerminal.size > 0 && writes < maxWrites) {
-    const entry = takeNextDrainableEntry()
-    if (!entry) {
-      break
-    }
-
+  while (entry !== null && writes < maxWrites) {
     const writeKind = writeQueuedChunk(entry)
     if (writeKind) {
       writes++
@@ -98,13 +153,29 @@ export function drainQueuedOutputImpl(): void {
     if (hasQueuedChunks(entry)) {
       queuedByTerminal.set(entry.terminal, entry)
     } else {
-      entry.highPriority = false
+      entry.priority = 'background'
       clearForegroundRelease(entry)
     }
     // Why: xterm parsing and DOM work share the renderer thread with input; keep draining cooperative so WSL/agent output can't pin the UI.
     if (writes > 0 && getDrainNow() - startedAt >= DRAIN_TIME_BUDGET_MS) {
       break
     }
+    if (writes >= maxWrites) {
+      break
+    }
+    const nextEntry = takeNextDrainableEntry()
+    if (
+      highPriority &&
+      nextEntry?.priority === 'visible-background' &&
+      !isHighPriorityQueueEntry(nextEntry) &&
+      nextEntry !== entry
+    ) {
+      // A high-priority tick must not pull cooperative visible redraws into
+      // the same batch; leave them for the next frame-sized drain.
+      queuedByTerminal.set(nextEntry.terminal, nextEntry)
+      break
+    }
+    entry = nextEntry
   }
 
   if (debugEnabled && writes > 0) {
@@ -112,10 +183,24 @@ export function drainQueuedOutputImpl(): void {
     debugState.drainHighPriority.push(highPriority)
   }
   recordQueueDebugPressure()
-  if (queuedByTerminal.size > 0 && hasDrainableBacklog()) {
+  if (queuedByTerminal.size === 0) {
+    resetCooperativeTurnPending()
+    return
+  }
+  const backlogState = getQueueBacklogState()
+  if (cooperativeTurn) {
+    resetCooperativeTurnPending()
+  } else if (highPriority && backlogState.hasCompetingPriorities) {
+    // Alternate one high-priority burst with one cooperative write. This is
+    // only armed when a lower-priority queue is actually waiting.
+    setCooperativeTurnPending(true)
+  } else if (!backlogState.hasHighPriority || !backlogState.hasCooperative) {
+    resetCooperativeTurnPending()
+  }
+  if (backlogState.hasDrainable) {
     // Why 0 on the channel path: a posted message already yields (input/paint serviced between macrotasks), so the 4ms interval only deepened the queue; timer path keeps it for fake-timer tests.
     scheduleDrain(
-      hasHighPriorityBacklog()
+      backlogState.hasHighPriority
         ? isMessageChannelDrainEnabled()
           ? 0
           : HIGH_PRIORITY_DRAIN_INTERVAL_MS

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-flusher.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-flusher.ts
@@ -27,6 +27,7 @@ import {
   queuedByTerminal,
   requestRegisteredTerminalBacklogRecovery,
   scheduleDrain,
+  resetCooperativeTurnPending,
   type TerminalOutputTarget
 } from './pane-terminal-output-queue-registry'
 
@@ -40,6 +41,9 @@ export function flushTerminalOutputImpl(
     return
   }
   queuedByTerminal.delete(terminal)
+  if (queuedByTerminal.size === 0) {
+    resetCooperativeTurnPending()
+  }
   if (isTerminalWritePipelineCertifiedDead(terminal)) {
     discardDetachedQueueEntry(entry)
     discardTerminalOutput(terminal)
@@ -54,7 +58,7 @@ export function flushTerminalOutputImpl(
     entry.chunks.length = 0
     entry.chunkIndex = 0
     entry.queuedChars = 0
-    entry.highPriority = false
+    entry.priority = 'background'
     clearForegroundRelease(entry)
     recordQueueDebugPressure()
     return
@@ -119,11 +123,11 @@ export function flushTerminalOutputImpl(
     queuedWrite = takeQueuedChunk(entry, BACKGROUND_CHUNK_CHARS)
   }
   if (hasQueuedChunks(entry)) {
-    entry.highPriority = true
+    entry.priority = 'high'
     queuedByTerminal.set(terminal, entry)
     scheduleDrain(0)
   } else {
-    entry.highPriority = false
+    entry.priority = 'background'
     clearForegroundRelease(entry)
   }
   recordQueueDebugPressure()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-pipeline.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-pipeline.ts
@@ -112,7 +112,7 @@ export function writeQueuedChunk(entry: QueueEntry): 'foreground' | 'background'
   if (!queuedWrite) {
     return null
   }
-  const pacer = entry.highPriority ? makeParseClockPacer() : undefined
+  const pacer = entry.priority === 'high' ? makeParseClockPacer() : undefined
   const ackCreditsParsed = registerTerminalOutputAckCredits(entry.terminal, queuedWrite.ackCredits)
   // Why armed BEFORE the write: a wedged WriteBuffer (issue #2836) or disposed xterm (6.1.0-beta.287) never runs the parsed callback, so the watch must be live first to catch it.
   armTerminalWriteStallWatch(entry.terminal, {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-backlog.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-backlog.ts
@@ -13,10 +13,10 @@ import {
   ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY,
   BACKGROUND_BACKLOG_WARNING,
   FOREGROUND_BACKLOG_WARNING,
-  LARGE_BACKLOG_CHARS,
   MAX_BACKGROUND_QUEUE_CHUNKS,
   fireQueuedAckCredits,
   getTerminalOutputMaxQueueChars,
+  isHighPriorityQueueEntry,
   queuedByTerminal,
   type QueueEntry,
   type TerminalOutputBeforeWrite
@@ -27,7 +27,7 @@ export function discardDetachedQueueEntry(entry: QueueEntry): void {
   entry.chunks.length = 0
   entry.chunkIndex = 0
   entry.queuedChars = 0
-  entry.highPriority = false
+  entry.priority = 'background'
   clearForegroundRelease(entry)
 }
 
@@ -75,7 +75,7 @@ export function replaceBacklogWithWarning(
   entry.chunkIndex = 0
   entry.queuedChars = warning.length
   entry.backgroundBacklogDropped = true
-  entry.highPriority = true
+  entry.priority = 'high'
   entry.foregroundHold = false
   if (debugEnabled && shouldNotify) {
     debugState.droppedBacklogCount++
@@ -93,10 +93,7 @@ export function hasQueuedChunks(entry: QueueEntry): boolean {
 
 export function hasHighPriorityBacklog(): boolean {
   for (const entry of queuedByTerminal.values()) {
-    if (
-      isEntryDrainable(entry) &&
-      (entry.highPriority || entry.queuedChars > LARGE_BACKLOG_CHARS)
-    ) {
+    if (isEntryDrainable(entry) && isHighPriorityQueueEntry(entry)) {
       return true
     }
   }

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-chunks.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-chunks.test.ts
@@ -10,7 +10,7 @@ function createEntry(): QueueEntry {
     chunkIndex: 0,
     queuedChars: 0,
     backgroundBacklogDropped: false,
-    highPriority: false,
+    priority: 'background',
     foregroundHold: false,
     foregroundHoldSafetyDelayMs: 0,
     foregroundCoalesce: false,

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-queue-registry.ts
@@ -22,9 +22,13 @@ export type TerminalOutputBeforeWrite = (data: string) => void
 type TerminalBacklogRecoveryRequest = () => boolean
 export type TerminalOutputParsedCallback = () => void
 type ForegroundRefreshSyncResolver = () => boolean
+export type ForegroundTerminalOutputPriority = 'active' | 'visible-background'
+export type TerminalOutputQueuePriority = 'high' | 'visible-background' | 'background'
 
 export type WriteTerminalOutputOptions = {
   foreground: boolean
+  /** Keep inactive visible redraws cooperative while preserving foreground writes. */
+  foregroundPriority?: ForegroundTerminalOutputPriority
   beforeWrite?: TerminalOutputBeforeWrite
   onParsed?: TerminalOutputParsedCallback
   /** Parse-deferred delivery ACK (terminal-pty-ack-gate). MUST be invoked when the chunk is parsed OR discarded by any drop path; fire-once, so double invocation is safe but omission permanently shrinks main's in-flight window. */
@@ -72,7 +76,7 @@ export type QueueEntry = {
   queuedChars: number
   onBackgroundBacklogDropped?: () => void
   backgroundBacklogDropped: boolean
-  highPriority: boolean
+  priority: TerminalOutputQueuePriority
   foregroundHold: boolean
   foregroundHoldSafetyDelayMs: number
   foregroundCoalesce: boolean
@@ -113,8 +117,65 @@ export const FOREGROUND_BACKLOG_WARNING =
   '\x18\x1b[0m\r\n[Orca skipped a burst of terminal output because the backlog grew too large.]\r\n'
 export const ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY = (): boolean => true
 
+export function isHighPriorityQueueEntry(
+  entry: Pick<QueueEntry, 'priority' | 'queuedChars'>
+): boolean {
+  return entry.priority === 'high' || entry.queuedChars > LARGE_BACKLOG_CHARS
+}
+
+export function isCooperativeQueueEntry(entry: Pick<QueueEntry, 'priority'>): boolean {
+  // Size promotion selects a larger throughput budget but does not make a
+  // visible/background queue eligible to monopolize the renderer.
+  return entry.priority !== 'high'
+}
+
+export function queuedEntryDrainDelay(
+  entry: Pick<QueueEntry, 'priority' | 'queuedChars'>,
+  wasEmpty = false
+): number {
+  if (isHighPriorityQueueEntry(entry)) {
+    return 0
+  }
+  // Give the first visible redraw a prompt paint, then pace the remaining
+  // flood at one frame-sized cadence.
+  if (wasEmpty && entry.priority === 'visible-background') {
+    return 0
+  }
+  return entry.priority === 'visible-background'
+    ? BACKGROUND_DRAIN_INTERVAL_MS
+    : BACKGROUND_FLUSH_DELAY_MS
+}
+
+export function promoteForegroundQueuePriority(
+  entry: QueueEntry,
+  requested: ForegroundTerminalOutputPriority,
+  forceHighPriority: boolean
+): void {
+  if (forceHighPriority || requested === 'active' || entry.priority === 'high') {
+    entry.priority = 'high'
+    return
+  }
+  entry.priority = 'visible-background'
+}
+
 export const queuedByTerminal = new Map<TerminalOutputTarget, QueueEntry>()
 setTerminalOutputDebugQueueReader(() => queuedByTerminal.values())
+// A continuously active pane must stay responsive, but it cannot monopolize
+// the shared renderer forever when other panes have pending output.
+let cooperativeTurnPending = false
+
+export function isCooperativeTurnPending(): boolean {
+  return cooperativeTurnPending
+}
+
+export function setCooperativeTurnPending(value: boolean): void {
+  cooperativeTurnPending = value
+}
+
+export function resetCooperativeTurnPending(): void {
+  cooperativeTurnPending = false
+}
+
 const backlogRecoveryByTerminal = new WeakMap<
   TerminalOutputTarget,
   TerminalBacklogRecoveryRequest
@@ -239,6 +300,9 @@ export function discardTerminalOutput(terminal: TerminalOutputTarget): void {
   }
   discardInFlightTerminalOutputAckCredits(terminal)
   queuedByTerminal.delete(terminal)
+  if (queuedByTerminal.size === 0) {
+    resetCooperativeTurnPending()
+  }
   discardForegroundRenderSettle(terminal)
   // Why: cancel the watch without masquerading as parse progress; replay guards use real completions to tell slow from wedged.
   cancelTerminalWriteStallWatch(terminal)

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -137,6 +137,225 @@ describe('pane terminal output scheduler', () => {
     )
   })
 
+  it('keeps inactive visible redraws foreground while using the cooperative lane', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createForegroundTerminal()
+    const redraw = '\x1b[2J\x1b[Hinactive redraw'
+
+    writeTerminalOutput(terminal, redraw, {
+      foreground: true,
+      foregroundPriority: 'visible-background',
+      latencySensitive: false,
+      forceForegroundRefresh: true
+    })
+
+    expect(terminal.write).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(0)
+
+    expect(terminal.write).toHaveBeenCalledWith(redraw, expect.any(Function))
+    expect(terminal._core.refresh).toHaveBeenCalledWith(0, terminal.rows - 1, true)
+  })
+
+  it('paces subsequent inactive visible redraws after the first prompt frame', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createForegroundTerminal()
+    const chunk = 'x'.repeat(16 * 1024)
+
+    for (let index = 0; index < 3; index += 1) {
+      writeTerminalOutput(terminal, chunk, {
+        foreground: true,
+        foregroundPriority: 'visible-background',
+        latencySensitive: false
+      })
+    }
+    vi.advanceTimersByTime(0)
+    expect(terminal.write).toHaveBeenCalledTimes(2)
+
+    vi.advanceTimersByTime(15)
+    expect(terminal.write).toHaveBeenCalledTimes(2)
+    vi.advanceTimersByTime(1)
+    expect(terminal.write).toHaveBeenCalledTimes(3)
+  })
+
+  it('drains active foreground output before an inactive visible redraw', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const inactive = createForegroundTerminal()
+    const active = createForegroundTerminal()
+
+    writeTerminalOutput(inactive, 'inactive', {
+      foreground: true,
+      foregroundPriority: 'visible-background',
+      latencySensitive: false
+    })
+    writeTerminalOutput(active, 'active', {
+      foreground: true,
+      foregroundPriority: 'active',
+      latencySensitive: false
+    })
+
+    vi.advanceTimersByTime(0)
+
+    expect(active.write).toHaveBeenCalledWith('active', expect.any(Function))
+    expect(inactive.write).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(16)
+    expect(inactive.write).toHaveBeenCalledWith('inactive', expect.any(Function))
+  })
+
+  it('does not let a sustained active flood starve a queued background pane', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const active = createTerminal()
+    const background = createTerminal()
+    const chunk = 'a'.repeat(16 * 1024)
+
+    writeTerminalOutput(background, 'background', { foreground: false })
+    for (let index = 0; index < 32; index += 1) {
+      writeTerminalOutput(active, chunk, {
+        foreground: true,
+        latencySensitive: false
+      })
+    }
+
+    vi.advanceTimersByTime(0)
+    expect(active.write).toHaveBeenCalledTimes(8)
+    expect(background.write).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(4)
+    expect(active.write).toHaveBeenCalledTimes(8)
+    expect(background.write).toHaveBeenCalledWith('background', expect.any(Function))
+  })
+
+  it('gives a large visible redraw a cooperative turn during sustained active output', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const active = createForegroundTerminal()
+    const visible = createForegroundTerminal()
+    const activeChunk = 'a'.repeat(16 * 1024)
+    const visibleChunk = 'v'.repeat(16 * 1024)
+
+    for (let index = 0; index < 33; index += 1) {
+      writeTerminalOutput(visible, visibleChunk, {
+        foreground: true,
+        foregroundPriority: 'visible-background',
+        latencySensitive: false
+      })
+    }
+    for (let index = 0; index < 64; index += 1) {
+      writeTerminalOutput(active, activeChunk, {
+        foreground: true,
+        latencySensitive: false
+      })
+    }
+
+    vi.advanceTimersByTime(0)
+    expect(active.write).toHaveBeenCalledTimes(8)
+    expect(visible.write).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(4)
+    expect(active.write).toHaveBeenCalledTimes(8)
+    expect(visible.write).toHaveBeenCalledTimes(1)
+    expect(visible.write).toHaveBeenCalledWith(visibleChunk, expect.any(Function))
+  })
+
+  it('chooses a small visible turn before a size-promoted hidden backlog', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const active = createTerminal()
+    const hidden = createTerminal()
+    const visible = createForegroundTerminal()
+    const chunk = 'h'.repeat(16 * 1024)
+
+    for (let index = 0; index < 40; index += 1) {
+      writeTerminalOutput(hidden, chunk, { foreground: false })
+    }
+    writeTerminalOutput(visible, 'visible redraw', {
+      foreground: true,
+      foregroundPriority: 'visible-background',
+      latencySensitive: false
+    })
+    for (let index = 0; index < 32; index += 1) {
+      writeTerminalOutput(active, chunk, {
+        foreground: true,
+        latencySensitive: false
+      })
+    }
+
+    vi.advanceTimersByTime(0)
+    vi.advanceTimersByTime(4)
+
+    expect(visible.write).toHaveBeenCalledWith('visible redraw', expect.any(Function))
+    expect(hidden.write).not.toHaveBeenCalled()
+  })
+
+  it('promotes an inactive visible queue when active output follows it without reordering', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createForegroundTerminal()
+
+    writeTerminalOutput(terminal, 'inactive-before', {
+      foreground: true,
+      foregroundPriority: 'visible-background',
+      latencySensitive: false
+    })
+    writeTerminalOutput(terminal, 'active-after', {
+      foreground: true,
+      foregroundPriority: 'active',
+      latencySensitive: true,
+      forceForegroundRefresh: true
+    })
+
+    vi.advanceTimersByTime(0)
+
+    expect(terminal.write).toHaveBeenCalledWith('inactive-beforeactive-after', expect.any(Function))
+    expect(terminal._core.refresh).toHaveBeenCalledWith(0, terminal.rows - 1, true)
+  })
+
+  it('keeps later latency-sensitive inactive output on the visible cooperative lane', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createForegroundTerminal()
+
+    writeTerminalOutput(terminal, '\x1b[2Jinactive-redraw', {
+      foreground: true,
+      foregroundPriority: 'visible-background',
+      latencySensitive: false
+    })
+    writeTerminalOutput(terminal, 'tiny-followup', {
+      foreground: true,
+      foregroundPriority: 'visible-background',
+      latencySensitive: true
+    })
+
+    vi.advanceTimersByTime(0)
+    expect(terminal.write).toHaveBeenCalledWith(
+      '\x1b[2Jinactive-redrawtiny-followup',
+      expect.any(Function)
+    )
+  })
+
+  it('keeps a large visible-background backlog on the throughput budget', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+    const chunk = 'x'.repeat(16 * 1024)
+
+    for (let index = 0; index < 33; index += 1) {
+      writeTerminalOutput(terminal, chunk, {
+        foreground: true,
+        foregroundPriority: 'visible-background',
+        latencySensitive: false
+      })
+    }
+
+    vi.advanceTimersByTime(0)
+
+    expect(terminal.write).toHaveBeenCalledTimes(8)
+  })
+
   it('defers background write preparation until coalesced output drains', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-writer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-writer.ts
@@ -19,7 +19,11 @@ import {
 } from './pane-terminal-output-scheduler-debug'
 import { flushTerminalOutputImpl } from './pane-terminal-output-flusher'
 import { composeParsedCallback, composeWriteFailureCallback } from './pane-terminal-output-pipeline'
-import { queueCapExceeded, replaceBacklogWithWarning } from './pane-terminal-output-queue-backlog'
+import {
+  hasQueuedChunks,
+  queueCapExceeded,
+  replaceBacklogWithWarning
+} from './pane-terminal-output-queue-backlog'
 import {
   FOREGROUND_HOLD_SAFETY_DELAY_MS,
   LATENCY_SENSITIVE_FOREGROUND_COALESCE_DELAY_MS,
@@ -33,10 +37,10 @@ import {
 } from './pane-terminal-foreground-queue-state'
 import {
   ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY,
-  BACKGROUND_FLUSH_DELAY_MS,
   FOREGROUND_BACKLOG_WARNING,
-  LARGE_BACKLOG_CHARS,
   discardTerminalOutput,
+  promoteForegroundQueuePriority,
+  queuedEntryDrainDelay,
   queuedByTerminal,
   scheduleDrain,
   type TerminalOutputTarget,
@@ -62,11 +66,23 @@ export function writeTerminalOutputImpl(
 
   if (options.foreground) {
     const entry = queuedByTerminal.get(terminal)
-    if (entry?.highPriority || options.coalesceForeground || options.holdForeground) {
+    const foregroundPriority = options.foregroundPriority ?? 'active'
+    if (
+      entry?.priority === 'high' ||
+      entry?.priority === 'visible-background' ||
+      (foregroundPriority === 'visible-background' && options.latencySensitive === false) ||
+      options.coalesceForeground ||
+      options.holdForeground
+    ) {
       const queued = entry ?? createQueueEntry(terminal, options)
       queued.onBackgroundBacklogDropped = options.onBackgroundBacklogDropped
-      queued.highPriority = true
+      promoteForegroundQueuePriority(
+        queued,
+        foregroundPriority,
+        options.coalesceForeground === true || options.holdForeground === true
+      )
       queuedByTerminal.set(terminal, queued)
+      const wasEmpty = !hasQueuedChunks(queued)
       enqueueChunk(queued, data, {
         foreground: true,
         forceForegroundRefresh: options.forceForegroundRefresh,
@@ -130,11 +146,11 @@ export function writeTerminalOutputImpl(
       }
       queued.foregroundHold = false
       clearForegroundRelease(queued)
-      scheduleDrain(0)
+      scheduleDrain(queuedEntryDrainDelay(queued, wasEmpty))
       return
     }
     if (entry && entry.queuedChars > SYNC_FOREGROUND_FLUSH_CHARS) {
-      entry.highPriority = true
+      entry.priority = 'high'
       enqueueChunk(entry, data, {
         foreground: true,
         forceForegroundRefresh: options.forceForegroundRefresh,
@@ -163,8 +179,9 @@ export function writeTerminalOutputImpl(
         queuedByTerminal.set(terminal, queued)
       } else {
         queued.onBackgroundBacklogDropped = options.onBackgroundBacklogDropped
-        queued.highPriority = true
       }
+      promoteForegroundQueuePriority(queued, foregroundPriority, false)
+      const wasEmpty = !hasQueuedChunks(queued)
       enqueueChunk(queued, data, {
         foreground: true,
         forceForegroundRefresh: options.forceForegroundRefresh,
@@ -183,7 +200,7 @@ export function writeTerminalOutputImpl(
         replaceBacklogWithWarning(queued, FOREGROUND_BACKLOG_WARNING)
       }
       // Why: visible command floods are throughput work, not keystroke echo — queue behind a zero-delay drain so one IPC callback can't pin the renderer while input/paint wait.
-      scheduleDrain(0)
+      scheduleDrain(queuedEntryDrainDelay(queued, wasEmpty))
       return
     }
     flushTerminalOutputImpl(terminal)
@@ -223,7 +240,6 @@ export function writeTerminalOutputImpl(
   let entry = queuedByTerminal.get(terminal)
   if (!entry) {
     entry = createQueueEntry(terminal, options)
-    entry.highPriority = false
     queuedByTerminal.set(terminal, entry)
   } else {
     entry.onBackgroundBacklogDropped = options.onBackgroundBacklogDropped
@@ -240,7 +256,5 @@ export function writeTerminalOutputImpl(
     debugState.backgroundEnqueueCount++
   }
   // Why: letting every non-focused pane call xterm.write immediately spawns a WriteBuffer timer per pane, starving the focused terminal on the shared renderer thread.
-  scheduleDrain(
-    entry.highPriority || entry.queuedChars > LARGE_BACKLOG_CHARS ? 0 : BACKGROUND_FLUSH_DELAY_MS
-  )
+  scheduleDrain(queuedEntryDrainDelay(entry))
 }


### PR DESCRIPTION
> **Status: not ready to merge. Blocked on a measurement, and carries two known user-facing regressions (below).** Kept open because the underlying question — whether sibling terminal panes can starve the focused one — is still unanswered, not because this diff is ready.

## Scope change

This PR originally bundled three unrelated renderer changes. The two that had no user-facing trade-off were split out and have merged:

- #17761 — fetch host lineage once per connect, narrow sidebar ack subscriptions
- #17762 — collapse duplicate reveal atlas rebuilds

What remains here is only the terminal output **scheduling** work, rebased onto current `main`.

## What This Does

Splits terminal output into three lanes instead of one foreground flag:

- `high` — the active pane
- `visible-background` — visible but not focused (split panes)
- `background` — hidden panes

The active pane keeps the prompt path. Inactive visible panes are paced, and a sustained active flood is forced to yield one cooperative write when another queue is waiting, so it cannot monopolize the renderer indefinitely.

## Known regressions

Both are real and neither is fixed in this diff.

**1. Non-focused visible split panes render noticeably slower.** This is the mechanism, not a bug. A `visible-background` entry simultaneously loses three things versus today, where every foreground write is `highPriority`:

- the parse-clock pacer (`pane-terminal-output-pipeline.ts` only builds one for `priority === 'high'`), whose own comment notes the fixed cadence "drips far below xterm's ~100 MB/s parse"
- 8 writes/drain → 2, or exactly **1** while an active pane is flooding
- 0/4 ms cadence → 16 ms

A TUI or streaming agent in a split you are *watching* rather than typing in will stutter. Severity is tunable (the cooperative turn is hard-capped at one write; the pacer is withheld from the whole lane) but it cannot be removed without removing the point.

**2. Focus does not re-prioritize already-queued output.** Priority is assigned at write time and never re-evaluated — every assignment in this diff is on a write, flush, or drain path, none on a focus handler. Click into a pane that is mid-flood, and if the producer then goes quiet its existing backlog keeps draining on the slow lane. Unlike #1 this is a plain bug; the fix is to re-tag the queue on active-pane change.

## Why this is blocked

The investigation behind it was macOS-only, on a host with ~1,650 processes and load well above available CPU, and the PR's own framing was that host-wide oversubscription was the *leading hypothesis* rather than a proven Orca-only cause. No packaged-build A/B was run, so there is no evidence this helps the reported stalls.

The existing scheduler already has a fairness mechanism: priority ordering plus the 8 ms `DRAIN_TIME_BUDGET_MS` yield. This adds a second, finer-grained one on top, with new module-global mutable state, and no measurement showing the first one was insufficient.

`main` has also moved since the trace. #17762 removed a registry-wide WebGL atlas rebuild from *every* heavy reveal and #17761 removed N redundant host-wide lineage RPCs per connect — both real work during exactly the visibility and worktree churn in the original report. Some of the observed stalls may already be gone.

## What would unblock it

1. Reproduce the stall on a packaged build off current `main`.
2. Confirm the focused pane is actually starved by *sibling panes*, rather than by main-process or host contention.
3. If confirmed, fix regression #2 on the way in and land with #1 stated as an accepted trade.

If step 2 does not confirm, close this.

## Testing

- [x] `pnpm tc`
- [x] `pnpm test src/renderer/src/lib/pane-manager/ src/renderer/src/components/terminal-pane/` — 489 files, 4899 passed
- [x] `pnpm run check:code-quality:changed` — 0 new findings
- [ ] Windows/ConPTY — **not validated.** `write-pty-output-to-xterm.ts` carries a hand-tuned ConPTY chunking heuristic that feeds the new lane classification. This is the riskiest unvalidated surface.
- [ ] WSL, SSH, folder-workspace — not validated
- [ ] Packaged-build A/B — not run; this is the blocker above
