### PR TITLE
fix(crash-reporting): record Linux MemAvailable at process-gone

### DIFF
--- a/src/main/crash-reporting/gone-time-system-memory.ts
+++ b/src/main/crash-reporting/gone-time-system-memory.ts
@@ -6,10 +6,12 @@ import type { CrashReportDetailValue } from '../../shared/crash-reporting'
 // memory/commit", which the per-process buckets alone cannot.
 // Timing honesty: this reads AFTER the crashed process's memory returned to
 // the OS, so free/swapFree can look healthier than they were at kill time.
-// Platform honesty: swap* exist on Windows/Linux only. On macOS `free` is
-// near-meaningless (file cache and compression keep it low on healthy
-// machines); fileBacked/purgeable are the only reclaimability proxy this API
-// gives there, and none of these fields answers "was the machine under
+// Platform honesty: swap* exist on Windows/Linux only. On Linux `free` is
+// /proc/meminfo MemFree and is NOT the pressure signal — it excludes page cache
+// and other reclaimable memory; `available` (MemAvailable, Linux-only) is. On
+// macOS `free` is near-meaningless (file cache and compression keep it low on
+// healthy machines); fileBacked/purgeable are the only reclaimability proxy this
+// API gives there, and none of these fields answers "was the machine under
 // pressure" on macOS — that needs a signal Electron does not expose.
 
 type CrashReportDetails = Record<string, CrashReportDetailValue>
@@ -22,6 +24,7 @@ export function memoryKBFieldMB(value: unknown): number | undefined {
 type SystemMemoryInfoLike = {
   total?: unknown
   free?: unknown
+  available?: unknown
   swapTotal?: unknown
   swapFree?: unknown
   fileBacked?: unknown
@@ -58,6 +61,7 @@ export function getSystemMemoryAtGoneDetails(): CrashReportDetails {
   const fields: readonly [keyof SystemMemoryInfoLike, string][] = [
     ['total', 'systemMemoryTotalMB'],
     ['free', 'systemMemoryFreeMB'],
+    ['available', 'systemMemoryAvailableMB'],
     ['swapTotal', 'systemMemorySwapTotalMB'],
     ['swapFree', 'systemMemorySwapFreeMB'],
     ['fileBacked', 'systemMemoryFileBackedMB'],

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -612,6 +612,35 @@ describe('process gone diagnostics', () => {
     expect(details.systemMemorySwapFreeMB).toBeUndefined()
   })
 
+  it('reports Linux MemAvailable as its own field alongside MemFree', () => {
+    // MemFree alone hid the pressure on the SIGKILL-at-OOM reports; MemAvailable
+    // is the kernel's reclaim-aware estimate. Electron 43 exposes it on Linux.
+    setSystemMemoryInfoReaderForTest(() => ({
+      total: 1024 * 14_551,
+      free: 1024 * 1_292,
+      available: 1024 * 340,
+      swapTotal: 1024 * 4_096,
+      swapFree: 1024 * 167
+    }))
+
+    expect(buildProcessGoneCrashDetails({}, 'renderer')).toMatchObject({
+      systemMemoryFreeMB: 1_292,
+      systemMemoryAvailableMB: 340
+    })
+  })
+
+  it('omits the available field on platforms that do not report it', () => {
+    setSystemMemoryInfoReaderForTest(() => ({ total: 1024 * 65_536, free: 1024 * 59 }))
+    expect(buildProcessGoneCrashDetails({}, 'renderer').systemMemoryAvailableMB).toBeUndefined()
+  })
+
+  it('drops a NaN available reading instead of emitting it as zero', () => {
+    setSystemMemoryInfoReaderForTest(() => ({ total: 1024 * 16_384, available: Number.NaN }))
+    const details = buildProcessGoneCrashDetails({}, 'renderer')
+    expect(details.systemMemoryAvailableMB).toBeUndefined()
+    expect(details.systemMemoryTotalMB).toBe(16_384)
+  })
+
   it('samples system memory at gone time but never into the pre-gone snapshot', () => {
     appMetricsMock.mockReturnValue([{ pid: 1, type: 'Browser', memory: { workingSetSize: 0 } }])
     samplePreGoneProcessMetrics()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## What

Linux `process-gone` crash reports recorded system memory as `systemMemoryFreeMB` only. On Linux that value is `/proc/meminfo` **MemFree**, which excludes page cache and other reclaimable memory — so a renderer that was OOM-killed can be reported next to a large "free" number and look like the machine was fine.

Electron 43 exposes `MemAvailable` as `available` on `process.getSystemMemoryInfo()`, and `getSystemMemoryAtGoneDetails()` already had that result in hand. This adds one entry to the existing field table so the reclaim-aware number is emitted as `systemMemoryAvailableMB`, plus one optional field on the local `SystemMemoryInfoLike` type and a rewritten platform-honesty comment.

Net production delta, `git diff origin/main --stat`:

```
 .../crash-reporting/gone-time-system-memory.ts     | 12 ++++++---
 .../process-gone-diagnostics.test.ts               | 29 ++++++++++++++++++++++
 2 files changed, 37 insertions(+), 4 deletions(-)
```

## Fix evidence

**The field really is the pressure signal, and it really is available.** From `node_modules/electron/electron.d.ts` in this repo (`electron@^43.4.1`), lines 23761-23774, verbatim:

```
    total: number;
    /**
     * The total amount of memory not being used by applications or disk cache.
     */
    free: number;
    /**
     * The kernel's estimate of the amount of memory available for allocation without
     * swapping, from `/proc/meminfo` `MemAvailable`. Use this as the memory pressure
     * signal on Linux; `free` there is `MemFree`, which excludes page cache and other
     * reclaimable memory.
     *
     * @platform linux
     */
    available: number;
```

**Before — production file reverted to `origin/main`, new tests kept.** `pnpm test src/main/crash-reporting/process-gone-diagnostics.test.ts`, exit code `1`:

```
 RUN  v4.1.11 /private/tmp/orca-cf-g3-linux-oom

 ❯ src/main/crash-reporting/process-gone-diagnostics.test.ts (31 tests | 1 failed) 11ms
     × reports Linux MemAvailable as its own field alongside MemFree 3ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/main/crash-reporting/process-gone-diagnostics.test.ts > process gone diagnostics > reports Linux MemAvailable as its own field alongside MemFree
AssertionError: expected { processMetricsCount: 1, …(18) } to match object { systemMemoryFreeMB: 1292, …(1) }
(18 matching properties omitted from actual)

- Expected
+ Received

  {
-   "systemMemoryAvailableMB": 340,
    "systemMemoryFreeMB": 1292,
  }

 Test Files  1 failed (1)
      Tests  1 failed | 30 passed (31)
```

That is the bug in one frame: the machine had **340 MB actually available** and the report said **1292 MB free**.

**Honest scoping of that before-run:** only 1 of the 3 new tests fails without the production change. The other two (`omits the available field on platforms that do not report it`, `drops a NaN available reading instead of emitting it as zero`) assert `undefined`, which is trivially true on `origin/main`. They are regression guards for the platform-omission and non-finite paths, not proof of the bug. Stating that rather than implying 3/3 turned red.

**After — full change in place, `--reporter=verbose`, exit code `0`:**

```
 ✓ src/main/crash-reporting/process-gone-diagnostics.test.ts > process gone diagnostics > reports macOS-shaped system memory and omits the fields macOS lacks 0ms
 ✓ src/main/crash-reporting/process-gone-diagnostics.test.ts > process gone diagnostics > reports Linux MemAvailable as its own field alongside MemFree 0ms
 ✓ src/main/crash-reporting/process-gone-diagnostics.test.ts > process gone diagnostics > omits the available field on platforms that do not report it 0ms
 ✓ src/main/crash-reporting/process-gone-diagnostics.test.ts > process gone diagnostics > drops a NaN available reading instead of emitting it as zero 0ms
 ✓ src/main/crash-reporting/process-gone-diagnostics.test.ts > process gone diagnostics > samples system memory at gone time but never into the pre-gone snapshot 0ms

 Test Files  1 passed (1)
      Tests  31 passed (31)
```

**Wider blast radius — every crash-reporting suite, main + shared.** `pnpm test src/main/crash-reporting/ src/shared/crash-reporting.test.ts`, exit code `0`:

```
 RUN  v4.1.11 /private/tmp/orca-cf-g3-linux-oom

 Test Files  26 passed (26)
      Tests  284 passed (284)
   Duration  860ms
```

**Gates.** `pnpm tc`, exit code `0` (silent on success):

```
$ pnpm run typecheck
$ node config/scripts/run-typecheck-projects-in-parallel.mjs
```

`pnpm run check:code-quality:changed`, exit code `0`:

```
code quality: 0 new finding(s) across 2 changed file(s).
type-aware code quality: 0 new finding(s) across 2 changed file(s).
React Doctor: 0 new finding(s) across 2 changed file(s).
Changed-code quality gate passed since aa658d28e3da.
```

`npx oxfmt --check` on both changed files, exit code `0`: `All matched files use the correct format.` (`pnpm format` is `oxfmt --write .`; Prettier is not this repo's formatter and its `--check` disagreement is expected and irrelevant.)

**What I did NOT obtain, stated plainly:**

- **No live Linux OOM repro.** I did not OOM-kill a real renderer on a real Linux box and read the resulting crash report. The before/after evidence above is unit-level, against the injected reader seam `setSystemMemoryInfoReaderForTest`.
- **No Windows repro and no Windows exit codes.** This change is Linux-only in effect; `available` is `@platform linux` in Electron's own typings. There was no Windows repro to quote, so I am quoting none.
- All command output above was captured on macOS (`darwin`) in the worktree `/tmp/orca-cf-g3-linux-oom`.

## ELI5

Linux has two different numbers for "how much memory is left."

- **MemFree** = RAM nobody has touched at all. On a healthy Linux machine this is *supposed* to be small, because Linux deliberately fills spare RAM with disk cache.
- **MemAvailable** = the kernel's own estimate of how much a new program could actually get, counting the cache it would happily throw away.

Our crash reports were writing down MemFree. So when Linux killed a tab for running out of memory, the report could say "1292 MB free" and we would conclude the machine was fine and go hunt a nonexistent leak. The real number was 340 MB available.

We were already calling the function that returns both numbers and only writing one of them down. This writes down the other one too.

## Trade-offs

- **One extra field in every Linux crash report.** `systemMemoryAvailableMB`, a small integer. Crash report text is capped at 64,000 chars with tail truncation (see `src/shared/crash-reporting.ts` and its truncation tests); a typical report carries ~20 detail fields, so ~35 more characters is not close to that ceiling. No realistic truncation risk, but it is a real, if tiny, increase.
- **Two "free" numbers side by side can confuse a reader.** A Linux report now shows both `systemMemoryFreeMB` and `systemMemoryAvailableMB`, and they will often differ a lot — that difference is the point, but anyone skimming needs to know which one matters. The module comment in `gone-time-system-memory.ts` now says so explicitly.
- **macOS gets nothing.** Electron does not expose MemAvailable on darwin, and this PR does not invent a substitute. macOS memory pressure remains unanswerable from these fields; the comment still says so.
- **The pre-existing timing caveat is unchanged and still applies.** This samples *after* the dead process returned its memory to the OS, so `available` at report time reads healthier than it was at kill time. It narrows the gap between the report and the truth; it does not close it.
- **No new imports, no new IPC, no wire-format change, no startup cost.** `gone-time-system-memory.ts` was already in the startup module graph, and `getSystemMemoryAtGoneDetails()` runs only after the process-gone suppression gate and dedupe claim — never on a hot path.

## Adversarial review

Number of review rounds until clean: **1**

- **Round 1:** no findings. The change adds one entry to an existing `readonly [keyof SystemMemoryInfoLike, string][]` table that is already iterated with the shared `memoryKBFieldMB` guard, so the new field inherits the existing clamp-to-zero, non-finite-drop, and omit-when-absent behavior with no new branch. The only other reachable concern — a detail-key allowlist or field cap that might silently drop an unrecognized key — was checked and does not exist: `CrashReportDetailValue` is a structural primitive union (`string | number | boolean | null`), not an enumerated key list, and `getSystemMemoryAtGoneDetails` has exactly one importer (`process-gone-diagnostics.ts:6`). `grep -rn "systemMemory" src/` returns no consumer outside the changed module and its test, so nothing downstream can be broken by an added key.

## Perf review

**Performance audit: `/tmp/orca-cf-g3-linux-oom` — no performance findings. Nothing worth fixing.**

Measurements:

- **Startup latency / TTFP: zero delta.** No new imports. `gone-time-system-memory.ts` was already in the startup module graph via `process-gone-diagnostics.ts` ← `src/main/index.ts`. Module-graph bytes added: 0.
- **Not on a startup path at all.** `getSystemMemoryAtGoneDetails()` has exactly one caller, `buildProcessGoneCrashDetails` (`process-gone-diagnostics.ts:274`), reached only from `process-gone-recorder.ts:246` — *after* the `shouldRecordProcessGoneCrash` suppression gate and *after* `dedupe.tryClaim`. A Chromium child crash-loop cannot drive this into a hot loop, because the gate and the dedupe claim absorb the storm before the memory read.
- **Cost of the change itself:** one additional iteration of an already-running 7-entry `for` loop over a statically allocated tuple array, reading a property off an object the process had already fetched. No extra syscall — `process.getSystemMemoryInfo()` was already being called once and returns `available` in the same result.

## Scope note for reviewers

`git diff origin/main` on the original worktree HEAD was misleading: it sat 3 commits *behind* `origin/main` (`aa658d28e3d`, `08d95b99796`, `a381b474375`), so a diff against `origin/main` showed 19 updater/cursor/native-chat test files and a deleted `src/main/updater-test-module-loader.ts` as the *reverse* of those upstream commits. The branch has been fast-forwarded onto `aa658d28e3d` before committing, so `git diff origin/main` now shows exactly the two intended files.
