### PR TITLE
fix(orcad): publish the headless graph and start the agent hook server

### DIFF
--- a/src/main/orcad/orcad-entry.ts
+++ b/src/main/orcad/orcad-entry.ts
@@ -13,6 +13,7 @@
  */
 import process from 'node:process'
 import { setAppEnvironment, type AppEnvironment } from '../../shared/app-environment'
+import { HEADLESS_RUNTIME_WINDOW_ID } from '../../shared/runtime-session-contracts'
 import { setSecretStore, type SecretStore } from '../../shared/secret-store'
 import type { ServeReadiness } from '../server/serve-readiness'
 import { setRuntimeBrowserCommandsFactory } from '../runtime/runtime-browser-commands-factory'
@@ -199,6 +200,16 @@ async function startOrcadRuntime(
 
   await runtime.refreshRestoredOrchestrationAuthority()
   await runtime.reconcileLegacyWorkerTerminals()
+
+  // Why: nothing publishes a renderer graph here, so `graphStatus` would stay 'unavailable'
+  // forever and every RPC gated on a ready graph would fail — `captureReadyGraphEpoch()` is
+  // the FIRST statement of runCreateMobileSessionTerminal, so terminal creation returns
+  // `runtime_unavailable` before it reaches any PTY code, and the tab inventory's
+  // `while (true)` waits on an epoch that can never be established and never returns at all.
+  // `--serve` publishes the same empty graph for the same reason (index.ts). Both gates open
+  // from this one call: it adopts the headless id as authoritative, marks the graph ready,
+  // and publishes the tab inventory.
+  runtime.syncWindowGraph(HEADLESS_RUNTIME_WINDOW_ID, { tabs: [], leaves: [] })
 
   const bindHost = resolveOrcadBindHost(options.bind)
   const rpc = new OrcaRuntimeRpcServer({

--- a/src/main/orcad/orcad-entry.ts
+++ b/src/main/orcad/orcad-entry.ts
@@ -126,7 +126,19 @@ export async function startOrcad(options: OrcadOptions = {}): Promise<OrcadHandl
     return await startOrcadRuntime(options, browserProvider, instanceLock)
   } catch (error) {
     stopOrcadAgentHookServer()
-    await browserProvider?.stop()
+    try {
+      await browserProvider?.stop()
+    } catch (stopError) {
+      // Why swallowed rather than rethrown: `error` is why the host failed to come up and is
+      // the one an operator can act on. Letting a teardown rejection replace it reports the
+      // symptom and discards the cause — and would skip the lock release below, so a launch
+      // that failed once would then refuse to be retried.
+      console.error(
+        `[orcad] browser provider teardown failed during launch cleanup: ${
+          stopError instanceof Error ? stopError.message : String(stopError)
+        }`
+      )
+    }
     setRuntimeBrowserCommandsFactory(null)
     runOrcadQuitHandlers()
     instanceLock.release()
@@ -346,17 +358,30 @@ async function startOrcadRuntime(
       try {
         await rpc.stop()
       } finally {
-        // Why disconnect and not shut down: the daemon must outlive this process, or an
-        // orcad restart goes back to killing every running terminal. See
-        // orcad-daemon-supervision.ts.
-        await stopOrcadDaemon()
-        // Why no unlink of the endpoint file: stop() leaves it deliberately — a stale file
-        // matches the hook's fail-open behaviour and avoids a TOCTOU race with a concurrent Orca.
-        agentHookServer.stop()
-        await browserProvider?.stop()
-        setRuntimeBrowserCommandsFactory(null)
-        runOrcadQuitHandlers()
-        instanceLock.release()
+        // Why nested and not one flat sequence: every step here is independent teardown, and
+        // both awaits genuinely reject — `disconnectDaemon()` fans out over adapters with
+        // `Promise.all` and awaits a checkpoint write, and the browser provider's stop() ends
+        // in `rm()`, whose `force` forgives only ENOENT. Flat, the first rejection skips every
+        // later step, and the step furthest down is `instanceLock.release()`: a leaked lock
+        // file makes the NEXT launch refuse to start, so one bad shutdown costs the host until
+        // someone deletes it by hand. Nesting keeps the first failure as the reported one.
+        try {
+          // Why disconnect and not shut down: the daemon must outlive this process, or an
+          // orcad restart goes back to killing every running terminal. See
+          // orcad-daemon-supervision.ts.
+          await stopOrcadDaemon()
+        } finally {
+          // Why no unlink of the endpoint file: stop() leaves it deliberately — a stale file
+          // matches the hook's fail-open behaviour and avoids a TOCTOU race with a concurrent Orca.
+          agentHookServer.stop()
+          try {
+            await browserProvider?.stop()
+          } finally {
+            setRuntimeBrowserCommandsFactory(null)
+            runOrcadQuitHandlers()
+            instanceLock.release()
+          }
+        }
       }
     }
   }

--- a/src/main/orcad/orcad-entry.ts
+++ b/src/main/orcad/orcad-entry.ts
@@ -145,6 +145,8 @@ async function startOrcadRuntime(
     await import('../orca-profiles/profile-index-store')
   const { initSshHostKeyStoreFile } = await import('../ssh/ssh-host-key-store')
   const { startOrcadDaemon, stopOrcadDaemon } = await import('./orcad-daemon-supervision')
+  const { agentHookServer } = await import('../agent-hooks/server')
+  const { isAgentStatusHooksEnabled } = await import('../agent-hooks/managed-agent-hook-controls')
   const { daemonOwnsFreshPersistentPtys } = await import('../daemon/daemon-init')
   const { collectOrcadHealth } = await import('./orcad-health')
 
@@ -160,6 +162,38 @@ async function startOrcadRuntime(
   // Why: every SSH connect consults this sidecar. Left unbound it reports nothing trusted,
   // which is safe but silently discards accept records on every launch.
   initSshHostKeyStoreFile(profile.dataFile)
+
+  // Why before the daemon: `host-env/assembly.ts` folds `agentHookServer.buildPtyEnv()` into
+  // every PTY's environment from LIVE server state, and `buildPtyEnv()` returns {} while the
+  // port is 0. A terminal spawned before this — including one the daemon hands back on
+  // adoption — is frozen with no hook coordinates, so its agent never reports a session and
+  // the chat view has no transcript to render. The spawn path itself needs no change; it was
+  // already reading these.
+  //
+  // Why `userDataPath` is not optional: ORCA_AGENT_HOOK_ENDPOINT is set only when the endpoint
+  // file was written, and it is written only when start() received this path. The hook script
+  // returns at its first line on that exact variable, so omitting it yields four of the five
+  // vars and a hook that still does nothing — the same symptom, harder to find twice. The file
+  // matters more here than on the desktop: start() regenerates token and port every launch,
+  // while orcad's daemon deliberately outlives the runtime, so a surviving PTY carries stale
+  // coordinates that the hook repairs only by sourcing this file at invocation time.
+  //
+  // No endpointNamespace: that is for parallel dev worktrees, and namespacing would break the
+  // endpoint file's stability across exactly the restarts this host is built to survive.
+  //
+  // Fail open, matching `--serve`: hook callbacks are enrichment, so a loopback bind failure
+  // must not refuse a host whose terminals otherwise work.
+  if (isAgentStatusHooksEnabled(store.getSettings())) {
+    try {
+      await agentHookServer.start({ env: 'production', userDataPath: runtimeUserDataPath })
+    } catch (error) {
+      console.error(
+        `[orcad] agent hook server failed to start; agent chat will not render: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    }
+  }
 
   // Why before the runtime and the PTY handlers: `setLocalPtyProvider` installs the daemon
   // adapter as THE local provider, and the registry's contract is that it lands before
@@ -280,6 +314,9 @@ async function startOrcadRuntime(
         // orcad restart goes back to killing every running terminal. See
         // orcad-daemon-supervision.ts.
         await stopOrcadDaemon()
+        // Why no unlink of the endpoint file: stop() leaves it deliberately — a stale file
+        // matches the hook's fail-open behaviour and avoids a TOCTOU race with a concurrent Orca.
+        await agentHookServer.stop()
         await browserProvider?.stop()
         setRuntimeBrowserCommandsFactory(null)
         runOrcadQuitHandlers()

--- a/src/main/orcad/orcad-entry.ts
+++ b/src/main/orcad/orcad-entry.ts
@@ -32,6 +32,11 @@ import {
 
 let runOrcadQuitHandlers = (): void => {}
 
+// Why module scope, like the quit handlers above: the server is started deep inside
+// `startOrcadRuntime`, and the launch failure path that must undo it runs in `startOrcad`,
+// which never imports it.
+let stopOrcadAgentHookServer = (): void => {}
+
 function createNodeAppEnvironment(): AppEnvironment {
   const quitHandlers: (() => void)[] = []
   // The main signal handler awaits runtime and browser teardown before process.exit.
@@ -120,6 +125,7 @@ export async function startOrcad(options: OrcadOptions = {}): Promise<OrcadHandl
   try {
     return await startOrcadRuntime(options, browserProvider, instanceLock)
   } catch (error) {
+    stopOrcadAgentHookServer()
     await browserProvider?.stop()
     setRuntimeBrowserCommandsFactory(null)
     runOrcadQuitHandlers()
@@ -186,6 +192,10 @@ async function startOrcadRuntime(
   if (isAgentStatusHooksEnabled(store.getSettings())) {
     try {
       await agentHookServer.start({ env: 'production', userDataPath: runtimeUserDataPath })
+      // Why arm it here and not on the way out: a later startup step throwing leaves the
+      // listener bound, and start() returns early while `this.server` is set — so the next
+      // attempt in the same process would silently reuse this one's token and endpoint file.
+      stopOrcadAgentHookServer = () => agentHookServer.stop()
     } catch (error) {
       console.error(
         `[orcad] agent hook server failed to start; agent chat will not render: ${
@@ -215,7 +225,33 @@ async function startOrcadRuntime(
     // Why 'blocked': `'openable'` means a desktop window can be opened here, which is
     // what powers serve→desktop promotion. A Node host can never do that, and the
     // constructor's default would advertise it.
-    getDesktopWindowStatus: () => 'blocked'
+    getDesktopWindowStatus: () => 'blocked',
+    // Why these seven as well as start(): the server above is only the write path. Unwired,
+    // the rows it collects reach nothing — `getHookRowsForPane` answers [] for every pane so
+    // published tabs carry no `providerSession.transcriptPath` (the address native chat
+    // resolves a transcript by), and `hasProviderSessionObservationSource()` answers false so
+    // structured Claude resume refuses with "could not prove its fresh provider session".
+    // Same delegations the desktop host makes; ungated for the same reason it is — a server
+    // that never started answers empty, which is the same answer a second gate would give.
+    onTerminalAgentStatus: (event) => agentHookServer.ingestTerminalStatus(event),
+    // Why filtered: resume-identity rows are not running agents and must not read as live.
+    getAgentStatusSnapshot: () =>
+      agentHookServer.getStatusSnapshot().filter((entry) => entry.providerSessionOnly !== true),
+    // Why unfiltered here: those same rows are what carries the provider session.
+    getAgentProviderSessionSnapshot: () => agentHookServer.getStatusSnapshot(),
+    getAgentProviderSessionRowsForPane: (paneKey) =>
+      agentHookServer.getStatusSnapshotForPane(paneKey),
+    attestAgentHookCompatibilityAuthority: (candidate) =>
+      agentHookServer.attestCompatibilityAuthority(candidate),
+    // Why paired with attest: a pane whose launch identity is torn down must stop attesting,
+    // or its evidence survives to vouch for a later claim on the same key.
+    retireAgentHookCompatibilityAuthority: (paneKey) =>
+      agentHookServer.retirePaneAuthority(paneKey),
+    reconcileAgentStatusForEndedProcess: (paneKeys) => {
+      agentHookServer.reconcileEndedProcessForPaneKeys(paneKeys)
+    }
+    // No buildAgentHookPtyEnv: `host-env/assembly.ts` reads the same singleton directly, so
+    // wiring it here would add a second source for the env this host already gets.
   })
 
   // Why the headless entry point rather than registerPtyHandlers directly: this is the
@@ -316,7 +352,7 @@ async function startOrcadRuntime(
         await stopOrcadDaemon()
         // Why no unlink of the endpoint file: stop() leaves it deliberately — a stale file
         // matches the hook's fail-open behaviour and avoids a TOCTOU race with a concurrent Orca.
-        await agentHookServer.stop()
+        agentHookServer.stop()
         await browserProvider?.stop()
         setRuntimeBrowserCommandsFactory(null)
         runOrcadQuitHandlers()

--- a/src/main/orcad/orcad-entry.ts
+++ b/src/main/orcad/orcad-entry.ts
@@ -364,7 +364,13 @@ async function startOrcadRuntime(
         // in `rm()`, whose `force` forgives only ENOENT. Flat, the first rejection skips every
         // later step, and the step furthest down is `instanceLock.release()`: a leaked lock
         // file makes the NEXT launch refuse to start, so one bad shutdown costs the host until
-        // someone deletes it by hand. Nesting keeps the first failure as the reported one.
+        // someone deletes it by hand.
+        //
+        // What nesting buys is that every step RUNS — not that the first failure is the one
+        // reported. A throw from a `finally` replaces the in-flight exception, so if the daemon
+        // and the browser provider both reject the caller sees the browser's. That is the right
+        // trade here: the lock is released either way, and a lost second error costs a log line
+        // where a skipped release costs the next launch.
         try {
           // Why disconnect and not shut down: the daemon must outlive this process, or an
           // orcad restart goes back to killing every running terminal. See

--- a/src/main/orcad/orcad-headless-startup-wiring.test.ts
+++ b/src/main/orcad/orcad-headless-startup-wiring.test.ts
@@ -67,4 +67,35 @@ describe('orcad headless startup wiring', () => {
     expect(source.indexOf('stopOrcadAgentHookServer()', failurePath)).toBeGreaterThan(failurePath)
     expect(source.indexOf('agentHookServer.stop()', failurePath)).toBeGreaterThan(failurePath)
   })
+
+  it('finishes teardown when a step rejects instead of skipping the rest', () => {
+    const teardownStart = source.indexOf('stop: async () => {')
+    const failurePath = source.slice(
+      source.indexOf('return await startOrcadRuntime('),
+      teardownStart
+    )
+    const teardown = source.slice(teardownStart)
+
+    // Both awaits genuinely reject: `disconnectDaemon()` fans out over adapters with
+    // `Promise.all` and awaits a checkpoint write, and the browser provider's stop() ends in
+    // `rm()`, whose `force` forgives only ENOENT. In a flat sequence the first rejection skips
+    // every later step, and the last one is `instanceLock.release()` — leak that lock file and
+    // the next orcad launch refuses to start.
+    const daemon = teardown.indexOf('await stopOrcadDaemon()')
+    const hookStop = teardown.indexOf('agentHookServer.stop()', daemon)
+    expect(daemon).toBeGreaterThanOrEqual(0)
+    expect(teardown.slice(daemon, hookStop)).toContain('} finally {')
+
+    const browserStop = teardown.indexOf('await browserProvider?.stop()', hookStop)
+    const release = teardown.indexOf('instanceLock.release()', browserStop)
+    expect(browserStop).toBeGreaterThanOrEqual(0)
+    expect(teardown.slice(browserStop, release)).toContain('} finally {')
+
+    // On the launch-failure path the original error is what the operator needs, so a teardown
+    // rejection is caught there rather than allowed to replace it.
+    const failureBrowserStop = failurePath.indexOf('await browserProvider?.stop()')
+    const failureRelease = failurePath.indexOf('instanceLock.release()', failureBrowserStop)
+    expect(failureBrowserStop).toBeGreaterThanOrEqual(0)
+    expect(failurePath.slice(failureBrowserStop, failureRelease)).toContain('} catch (')
+  })
 })

--- a/src/main/orcad/orcad-headless-startup-wiring.test.ts
+++ b/src/main/orcad/orcad-headless-startup-wiring.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * orcad has no renderer and no Electron startup services, so what makes its terminals and its
+ * agent chat work is a handful of single calls in one function. Each was missing once and none
+ * failed loudly — a missing graph sentinel answers `runtime_unavailable`, unwired hook seams
+ * answer empty. Pin them in source, the way the serve host's are pinned.
+ */
+const source = readFileSync(join(process.cwd(), 'src/main/orcad/orcad-entry.ts'), 'utf8')
+
+describe('orcad headless startup wiring', () => {
+  it('publishes the headless graph sentinel after PTY registration and before RPC', () => {
+    const registration = source.indexOf('await registerHeadlessPtyRuntime(')
+    const sentinel = source.indexOf(
+      'runtime.syncWindowGraph(HEADLESS_RUNTIME_WINDOW_ID',
+      registration
+    )
+    const rpc = source.indexOf('new OrcaRuntimeRpcServer(', sentinel)
+
+    expect(registration).toBeGreaterThanOrEqual(0)
+    expect(sentinel).toBeGreaterThan(registration)
+    expect(rpc).toBeGreaterThan(sentinel)
+    // The named constant, never the literal it happens to equal.
+    expect(source).not.toContain('runtime.syncWindowGraph(0,')
+  })
+
+  it('starts the agent hook server before anything can spawn a PTY with a frozen env', () => {
+    const hookServer = source.indexOf('await agentHookServer.start(')
+    const daemon = source.indexOf('await startOrcadDaemon()', hookServer)
+    const registration = source.indexOf('await registerHeadlessPtyRuntime(', daemon)
+
+    expect(hookServer).toBeGreaterThanOrEqual(0)
+    expect(daemon).toBeGreaterThan(hookServer)
+    expect(registration).toBeGreaterThan(daemon)
+  })
+
+  it('reads hook status back into the runtime instead of only writing it', () => {
+    const runtime = source.indexOf('new OrcaRuntimeService(')
+    const deps = source.slice(runtime, source.indexOf('\n  })', runtime))
+
+    expect(runtime).toBeGreaterThanOrEqual(0)
+    // Without these the started server collects rows nothing reads: no transcript address
+    // for native chat, and Claude resume refuses for want of a provider-session observation.
+    for (const seam of [
+      'onTerminalAgentStatus:',
+      'getAgentStatusSnapshot:',
+      'getAgentProviderSessionSnapshot:',
+      'getAgentProviderSessionRowsForPane:',
+      'attestAgentHookCompatibilityAuthority:',
+      'retireAgentHookCompatibilityAuthority:',
+      'reconcileAgentStatusForEndedProcess:'
+    ]) {
+      expect(deps).toContain(seam)
+    }
+  })
+
+  it('stops the hook server on teardown and on a failed launch', () => {
+    const hookServer = source.indexOf('await agentHookServer.start(')
+    const armed = source.indexOf('stopOrcadAgentHookServer = () => agentHookServer.stop()')
+    // Why the arming matters: startOrcad's failure path never imports the server, and a
+    // listener left bound makes start()'s early return hand the next attempt a stale token.
+    const failurePath = source.indexOf('return await startOrcadRuntime(')
+
+    expect(armed).toBeGreaterThan(hookServer)
+    expect(source.indexOf('stopOrcadAgentHookServer()', failurePath)).toBeGreaterThan(failurePath)
+    expect(source.indexOf('agentHookServer.stop()', failurePath)).toBeGreaterThan(failurePath)
+  })
+})


### PR DESCRIPTION
## ELI5

`orcad` skips three startup steps that `orca serve` performs. Because of that it
cannot create a terminal **at all**, and its agent chat view renders nothing. Each
fix is one small piece of wiring that `--serve` already had.

## What Changed

Five commits in `src/main/orcad/orcad-entry.ts`, plus a test that pins the wiring.

### 1. Publish the headless graph

orcad never called `runtime.syncWindowGraph(HEADLESS_RUNTIME_WINDOW_ID, …)`.
`--serve` does, with a comment naming this exact hazard — *"headless servers have
no renderer graph publisher; publish an explicit empty graph so status clients see
a ready server."* orcad copies the surrounding sequence
(`rehydrateClientHostedBrowserPages`, `refreshRestoredOrchestrationAuthority`,
`reconcileLegacyWorkerTerminals`) and omits that one line, so `graphStatus` never
leaves `'unavailable'`.

Two failures, one cause, and neither names the graph:

- **`session.tabs.createTerminal` returns `runtime_unavailable`.** The throw is
  `assertGraphReady()` via `captureReadyGraphEpoch()`, the **first** statement of
  `runCreateMobileSessionTerminal` — above the authoritative-window check and far
  above any PTY code. A live daemon and an installed `ptyController.spawn` make no
  difference because neither is reached.
- **`session.tabs.listAll` hangs.** `getAuthoritativeSessionTabsInventoryEpoch()`
  returns non-null only when `graphStatus === 'ready'`, so the `while (true)` in
  `listAllMobileSessionTabsInventory` waits on a publication that
  `markSessionTabsInventoryPublished` early-returns out of once the epochs match.
  No timeout, no error, no log — an RPC that never answers.

One call opens both gates: it adopts `HEADLESS_RUNTIME_WINDOW_ID` as
authoritative, marks the graph ready, and publishes the tab inventory.

### 2. Start the agent hook server

Native chat reads the agent's transcript file, and `session-file-resolver.ts` names
the source: *"Authoritative transcript path reported by the agent hook
(`providerSession.transcriptPath`)"*.

The spawn path was already correct — `host-env/assembly.ts` folds
`agentHookServer.buildPtyEnv()` into every PTY's environment — but `buildPtyEnv()`
opens with `if (this.port <= 0 || !this.token) return {}`, and with no server the
port is 0. Measured on the live agent process before the change: eight `ORCA_*`
vars present, and **zero** `ORCA_AGENT_HOOK_*`. So `claude-hook.sh` returned at its
first line on every invocation.

`userDataPath` is load-bearing, not incidental: `ORCA_AGENT_HOOK_ENDPOINT` is set
only when the endpoint file was written, and it is written only when `start()`
received that path. It matters more here than on the desktop, because `start()`
regenerates token and port every launch while orcad's terminal daemon deliberately
outlives the runtime — so a surviving PTY carries stale coordinates that the hook
repairs only by sourcing the endpoint file at invocation time.

### 3. Wire the hook read seams

Starting the server only opened the **write** path. The runtime was constructed
with none of the agent-hook getters the desktop host passes, so every row the
server collected reached nothing: `getHookRowsForPane` answered `[]` for each pane,
published tabs carried no `providerSession.transcriptPath`, and
`hasProviderSessionObservationSource()` answered false — which makes structured
Claude resume refuse for want of a fresh provider session.

The filter asymmetry is deliberate, not cosmetic: `getAgentStatusSnapshot` hides
resume-identity rows from live-agent views while `getAgentProviderSessionSnapshot`
keeps them, because those rows carry the provider session native chat addresses
transcripts by. Taking one without the other fixes chat and breaks the live-agent
rows.

`buildAgentHookPtyEnv` stays unwired on purpose — `host-env/assembly.ts` reads the
same singleton directly, so passing it here would add a second source for env this
host already gets.

Also stops the server when a launch fails: `startOrcad`'s failure path undoes the
browser provider and the instance lock but never imported the hook server, so a
step throwing after `start()` left the listener bound — and `start()` returns early
while `this.server` is set, handing the next attempt in the same process a stale
token and endpoint file.

### 4. Pin the wiring in a test

So a future refactor cannot drop these steps silently, which is how all three went
missing in the first place.

### 5. Finish teardown when a step rejects

Added in review. The shutdown closure ran its teardown steps as a flat sequence, so
the first rejection skipped every later one — and both awaits in it genuinely
reject. `stopOrcadDaemon()` reaches `disconnectOnly()`, which fans out with
`Promise.all` over every adapter and awaits an unguarded checkpoint write;
`browserProvider.stop()` ends in `rm(..., { force: true })`, and `force` forgives
only ENOENT.

The step furthest down that sequence is `instanceLock.release()`. Leaking the lock
file makes the **next** orcad launch refuse to start until someone deletes it by
hand, so a transient teardown fault became a dead host. `agentHookServer.stop()`
was dropped the same way, which is what review caught; the leaked lock is the same
bug with a worse blast radius, so both are fixed at the source.

`startOrcad`'s launch-failure path had a third form: a rejecting
`browserProvider.stop()` there replaced the error explaining why startup failed and
skipped the lock release, so a launch that failed once could not be retried. It now
catches and logs that, and rethrows the original.

## ⚠️ Commit 3 is necessary but not sufficient — please read before merging

This is stated deliberately rather than left for the next person to rediscover.

With this deployed on a Synology NAS, the hook server holds rows for **both** live
panes with `transcriptPath` populated — one received 22:25:03, one 22:35:53, both
after the restart — and `session.tabs.listAll` **still reports no
`providerSession` on any tab.** So the input is wired and something downstream of
it still declines.

The prime suspect is the merge's own recency gate:

```ts
(hookAgentStatus.providerSessionReceivedAt ?? -1) >= tab.agentStatus.updatedAt
```

While the accessors were missing, this was unreachable — the `&&` short-circuited
on an undefined `hookAgentStatus`. Wiring them makes it live **for the first
time**, and agent status updates arrive from terminal parsing independently of hook
delivery, so a status update landing after the hook inverts that comparison
permanently.

That is a hypothesis from reading the condition, **not a measured result**, and it
wants an instrumented build to settle. I'd rather land the wiring — which is
correct and required either way — and flag this honestly than imply chat is fixed.

There is also a diagnosis worth recording: this third one is not a missing startup
*step* but a missing *constructor dependency*, so a shared startup sequence would
not have caught it. A shared factory that builds the runtime with its full deps
would.

## Known limitations

**A PTY retained across the upgrade that introduces this commit stays hookless.**
`ORCA_AGENT_HOOK_*` reaches a terminal only through its spawn-time environment, and
a running process's environment is frozen. So a PTY the daemon carries across this
upgrade has no vars at all — `claude-hook.sh` returns at its first line, with no
endpoint path to source. It self-heals when that terminal is recreated.

This is distinct from the *stale coordinates* case the endpoint file does solve: a
PTY spawned by a previous orcad that already had the hook server has wrong port and
token in its frozen env, and recovers because the hook re-reads the endpoint file at
invocation. That is why `userDataPath` is load-bearing here.

Closing the first case would need the hook to locate the endpoint without an env
pointer — a fixed well-known path — which is a different trust model and wants its
own design rather than a rider on this commit. Raised by Greptile in review.

## Linked Issue

Fixes #17846

## Visual Proof

`N/A` — headless runtime, no UI in this process. The client-visible effect is an
RPC that answers instead of hanging; before/after RPC output is in Testing below.

## Testing

Rebased onto `main` and rebuilt before submitting, rather than assuming the branch
it was developed on still applied. On a scratch data root:

```
session.tabs.listAll         returns {"snapshots":[]}   (was: no response, 60s)
session.tabs.createTerminal  ok, tab.status "ready"
daemon log                   session-created            (was: no create request, ever)
new PTY env                  6/6 ORCA_AGENT_HOOK_*      (was: 0)
agent-hooks/                 dir 0700, endpoint.env 0600
build                        3187 modules, zero electron and node:sqlite imports
```

The daemon line is the one that matters for the first commit: before it, the
terminal daemon never received a create request at all, from any client, on any
attempt. It was healthy throughout and simply never asked.

Platforms: Linux (Synology DSM), as a real system-scope systemd service with a
paired iOS client. orcad is a headless Linux/Unix target; no macOS or Windows
surface.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Not run in this environment:** `tsc` and `oxlint` — neither is installable on the
host this was developed and verified on. CI is the authority for those.

## AI Disclosure

Claude Opus 5 wrote the commits and this description. I reviewed them and ran all
the NAS verification above.

## Review

- **Cross-platform:** orcad is a headless Node host; these are startup-sequence
  additions with no platform branch. File modes on the agent-hooks directory (0700
  / 0600) follow the existing serve-path behaviour.
- **SSH/remote/local:** this is the remote-host case — the whole point is a runtime
  reached over an SSH port-forward by a paired client. Verified in exactly that
  configuration.
- **Agents/integrations:** the hook server is provider-neutral; the resume-identity
  filter asymmetry is preserved exactly as the desktop host has it, so no provider
  is treated specially here.
- **Performance:** one graph publication and one listener bind at startup. The
  accessors are pass-through reads over an in-memory snapshot.
- **UI:** none in-process; unblocks the client's chat view.
- **Security:** the hook server binds loopback and writes an endpoint file at 0600
  in a 0700 directory, matching `--serve`. `endpointNamespace` is deliberately not
  set — it is dev-worktree only, and namespacing would break endpoint-file
  stability across the restarts this host exists to survive. Fail-open on start,
  matching `--serve`.
- **Backwards compatibility:** additive startup steps on a path that currently
  cannot create a terminal, so there is no working behaviour to regress.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The caveat above is the next person's starting point; please don't let it get lost
in the merge.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


