### PR TITLE
test: add a node-only vitest config so root-guarded tests have somewhere to run

### DIFF
--- a/vitest.node-only.config.ts
+++ b/vitest.node-only.config.ts
@@ -1,11 +1,18 @@
 /**
  * Runs the node-environment test files on a host that cannot build the full suite.
  *
- * Deliberately not `config/vitest.config.ts`: that one pulls happy-dom, the renderer
- * aliases and two setup files. The tests this config is for import only node builtins,
- * vitest and local modules, so none of that applies to them — and on a constrained host
- * (a Synology NAS, in the case this was written for) the full toolchain will not install
- * at all, which used to mean those files ran nowhere.
+ * Deliberately not `config/vitest.config.ts`: that one carries the renderer aliases,
+ * three setup files — one of which installs an app environment and a secret store for
+ * every test — a much wider `include`, and the `execArgv` flags its happy-dom suites
+ * need. The tests this config is for import only node builtins, vitest and local
+ * modules, so none of that applies to them — and on a constrained host (a Synology NAS,
+ * in the case this was written for) the full toolchain will not install at all, which
+ * used to mean those files ran nowhere.
+ *
+ * Name the file you want, as below. The `include` glob is broad so that any node test
+ * can be named, but a good many of the files it matches opt into happy-dom with a
+ * `@vitest-environment` docblock — so running this config bare, with no path argument,
+ * is not the intended use and needs happy-dom installed anyway.
  *
  * Why that matters beyond convenience: several suites guard permission-refusal cases on
  * `getuid() !== 0`. CI containers run as root, so those cases are skipped there and, with

--- a/vitest.node-only.config.ts
+++ b/vitest.node-only.config.ts
@@ -13,7 +13,7 @@
  * ordinary user account is what makes them run.
  *
  *   node_modules/vitest/vitest.mjs run --config vitest.node-only.config.ts \
- *     --reporter=verbose src/main/orcad/orcad-service-command.test.ts
+ *     --reporter=verbose src/main/agent-hooks/installer-utils.test.ts
  *
  * Use `--reporter=verbose` and look for the case you care about: a skipped test still
  * counts toward "passed" in the summary line, so the count alone cannot tell you whether

--- a/vitest.node-only.config.ts
+++ b/vitest.node-only.config.ts
@@ -1,0 +1,31 @@
+/**
+ * Runs the node-environment test files on a host that cannot build the full suite.
+ *
+ * Deliberately not `config/vitest.config.ts`: that one pulls happy-dom, the renderer
+ * aliases and two setup files. The tests this config is for import only node builtins,
+ * vitest and local modules, so none of that applies to them — and on a constrained host
+ * (a Synology NAS, in the case this was written for) the full toolchain will not install
+ * at all, which used to mean those files ran nowhere.
+ *
+ * Why that matters beyond convenience: several suites guard permission-refusal cases on
+ * `getuid() !== 0`. CI containers run as root, so those cases are skipped there and, with
+ * no second lane, execute nowhere at all. Pointing this config at such a file from an
+ * ordinary user account is what makes them run.
+ *
+ *   node_modules/vitest/vitest.mjs run --config vitest.node-only.config.ts \
+ *     --reporter=verbose src/main/orcad/orcad-service-command.test.ts
+ *
+ * Use `--reporter=verbose` and look for the case you care about: a skipped test still
+ * counts toward "passed" in the summary line, so the count alone cannot tell you whether
+ * the root-guarded assertion actually ran.
+ */
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    hookTimeout: 60_000,
+    testTimeout: 30_000
+  }
+})


### PR DESCRIPTION
## ELI5

Some tests only run their real assertion when you are **not** root. CI runs as
root, so those assertions never execute anywhere — while the suite still reports
green. This adds a second vitest config so they can be run from an ordinary
account.

## What Changed

One new file, `vitest.node-only.config.ts`. Node environment, `src/**/*.test.ts`,
longer timeouts for the ones that touch real disk. Nothing else is touched and
nothing in the default test path changes.

## Why

A number of suites guard permission-refusal cases on `getuid() !== 0` —
`agent-hooks/installer-utils`, `agent-hooks/managed-hook-owner-identity`,
`cli/cli-installer`, `codex-accounts/codex-credential-absence-grace`,
`main/orcad/orcad-instance-lock` and `main/daemon/history-manager` among them. CI
containers run as root, so those cases skip there, and with no second lane they
execute nowhere at all.

**The count does not reveal it either:** a skipped test still counts toward
"passed", so a suite reports green while the assertion it exists for has never run.

At least one case is worse than skipped. `src/main/ssh/ssh-g-config-resolution.test.ts`
has **no guard** — it `chmod`s a file to `0o000` and expects the read to fail,
which under uid 0 cannot happen. It does not skip on a root runner, it **fails**,
every run, and reads as flake.

### Why not `config/vitest.config.ts`

That one carries the renderer aliases, three setup files (one of which installs an
app environment and a secret store for every test), a much wider `include`, and the
`execArgv` flags its happy-dom suites need. The tests this serves import only node
builtins, `vitest` and local modules, so none of it applies — and on a constrained
host the full toolchain will not install at all, which is what makes those files
unrunnable rather than merely inconvenient.

The `include` glob is broad so any node test can be named, but a good many of the
files it matches opt into happy-dom via a `@vitest-environment` docblock, so the
config is meant to be pointed at a file rather than run bare. That is documented in
the docstring.

```
node_modules/vitest/vitest.mjs run --config vitest.node-only.config.ts \
  --reporter=verbose src/main/ssh/ssh-g-config-resolution.test.ts
```

`--reporter=verbose` is in the docstring deliberately: without it you cannot tell
whether the root-guarded case ran or was skipped, which is the whole failure mode
this addresses.

## Linked Issue

Fixes #17847

## Visual Proof

`N/A` — test configuration. No runtime or UI surface.

## Testing

Run as a non-root user (uid 1026) on a real filesystem, against `main`:

```
src/main/daemon/history-manager.test.ts        }  66 passed, 0 skipped
src/main/ssh/ssh-g-config-resolution.test.ts   }

✓ siteConfigMayRestrictHostKeys > treats an unreadable config as doubt rather than permission
✓ HistoryManager > error handling > disables writes after fs error and does not throw
✓ HistoryManager > error handling > disables writes after fs error on openSession
```

Those are `✓`, not `↓`. On a root runner the first of them fails and the others
skip — which is the point of the change.

Platforms: Linux. The config is platform-neutral; the root/non-root distinction it
exists for is Unix-shaped.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No new tests: this **is** test infrastructure. Its correctness is demonstrated by
existing suites producing `✓` where they previously produced `↓` or a failure.

## AI Disclosure

Claude Opus 5 wrote the commit and this description. I reviewed both and ran the
non-root verification.

## Review

- **Cross-platform:** platform-neutral vitest config. It does not change the
  default lane, so no existing platform's CI behaviour moves.
- **SSH/remote/local:** none, beyond letting `ssh-g-config-resolution` actually
  assert what it claims.
- **Agents/integrations:** none.
- **Performance:** none — additive, opt-in via `--config`.
- **UI:** none.
- **Security:** it makes permission-refusal assertions executable, which is a
  security *improvement*: several of these guard credential-file and
  hook-ownership permission checks that currently prove nothing on CI.
- **Backwards compatibility:** one new file, no existing file touched, nothing in
  the default test path changes.

## Notes

Loading this emits the same Vite "ESM syntax in a file loaded as CommonJS" advisory
that `config/vitest.config.ts` does — the package has no `"type": "module"`, so it
applies to both equally. Left consistent with the existing config rather than
diverging in a file whose only job is to be minimal.

Worth a maintainer's view on whether CI should gain a non-root job using this
config. That is the step that would turn these assertions from "runnable" into
"actually run", and it is deliberately not in this PR.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

