### PR TITLE
fix(ssh): start the pty.spawn deadline when its frame reaches the wire

### DIFF
--- a/src/main/providers/ssh-agent-session-claim-validation.ts
+++ b/src/main/providers/ssh-agent-session-claim-validation.ts
@@ -6,7 +6,7 @@ import {
 } from '../../shared/agent-session-host-authority'
 import type { PtySpawnResult } from './pty-spawn-result'
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
-import { SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS } from './ssh-agent-session-create-operation'
+import { SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS } from '../../shared/ssh-relay-request-budget'
 import { isPtyIncarnationId } from '../../shared/pty-incarnation'
 
 export type ClaimedSshSpawnValidation =
@@ -20,6 +20,9 @@ export async function proveSshAgentSessionClaimCapability(
   try {
     const result = (await mux.request('pty.getCapabilities', undefined, {
       signal: options.signal,
+      // Why: gates a claimed pty.spawn, so it must survive the same saturated
+      // writer rather than expiring in the queue ahead of it.
+      budgetStartsAtWire: true,
       timeoutMs: SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS
     })) as {
       agentSessionClaimVersion?: unknown

--- a/src/main/providers/ssh-agent-session-create-operation.ts
+++ b/src/main/providers/ssh-agent-session-create-operation.ts
@@ -10,8 +10,10 @@ import {
   type PtySourceReceivingActivation
 } from '../../shared/pty-source-receiving-activation'
 import { validateClaimedSshSpawn } from './ssh-agent-session-claim-validation'
-
-export const SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS = 5_000
+import {
+  SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS,
+  SSH_PTY_SPAWN_TIMEOUT_MS
+} from '../../shared/ssh-relay-request-budget'
 
 export function assertSshAgentSessionCreateResult(
   result: unknown
@@ -39,6 +41,10 @@ export async function sshSupportsAgentSessionCreateOperations(
   try {
     const result = (await mux.request('pty.getCapabilities', undefined, {
       signal: options.signal,
+      // Why: this probe gates pty.spawn, so it has to outlast the same saturated
+      // writer the spawn does — expiring in the queue turns a capable relay into
+      // a spawn failure before the spawn's own wire-started budget can engage.
+      budgetStartsAtWire: true,
       timeoutMs: SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS
     })) as {
       agentSessionCreateOperationVersion?: unknown
@@ -60,11 +66,17 @@ export async function requestSshAgentSessionCreate(args: {
   beforeResolve?: (result: unknown) => void
 }): Promise<unknown> {
   try {
-    const options =
-      args.signal || args.beforeResolve
-        ? { signal: args.signal, beforeResolve: args.beforeResolve }
-        : undefined
-    return await args.mux.request('pty.spawn', args.params, options)
+    return await args.mux.request('pty.spawn', args.params, {
+      signal: args.signal,
+      beforeResolve: args.beforeResolve,
+      // Why: spawning runs over a link that may still be congested from relay
+      // deploy, so the frame can sit in a saturated writer for the whole budget;
+      // a spawn that never reached the wire started nothing and retries safely.
+      budgetStartsAtWire: true,
+      // Why: named rather than inherited, so the pane-connect backstops sized
+      // from SSH_PTY_CONNECT_WORST_CASE_MS cannot drift from what spawn asks for.
+      timeoutMs: SSH_PTY_SPAWN_TIMEOUT_MS
+    })
   } catch (error) {
     if (!args.operationId) {
       throw error

--- a/src/main/providers/ssh-pty-provider-agent-session-create-operation.test.ts
+++ b/src/main/providers/ssh-pty-provider-agent-session-create-operation.test.ts
@@ -6,6 +6,10 @@ import {
 import { SshChannelMultiplexer, type MultiplexerTransport } from '../ssh/ssh-channel-multiplexer'
 import { encodeFrame, HEADER_LENGTH, MessageType } from '../ssh/relay-protocol'
 import { SshPtyProvider } from './ssh-pty-provider'
+import {
+  SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS,
+  SSH_PTY_SPAWN_TIMEOUT_MS
+} from '../../shared/ssh-relay-request-budget'
 
 function createTransport(): MultiplexerTransport & {
   deliver: (data: Buffer) => void
@@ -102,7 +106,9 @@ describe('SSH fresh agent-session create operations', () => {
 
     expect(request).toHaveBeenNthCalledWith(1, 'pty.getCapabilities', undefined, {
       signal: undefined,
-      timeoutMs: 5_000
+      // The probe gates spawn, so it waits out the same saturated writer.
+      budgetStartsAtWire: true,
+      timeoutMs: SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS
     })
     expect(request).toHaveBeenNthCalledWith(
       2,
@@ -115,7 +121,11 @@ describe('SSH fresh agent-session create operations', () => {
         command: 'codex',
         agentSessionCreateOperationId: 'a'.repeat(43)
       },
-      expect.objectContaining({ beforeResolve: expect.any(Function) })
+      expect.objectContaining({
+        beforeResolve: expect.any(Function),
+        budgetStartsAtWire: true,
+        timeoutMs: SSH_PTY_SPAWN_TIMEOUT_MS
+      })
     )
   })
 
@@ -154,7 +164,11 @@ describe('SSH fresh agent-session create operations', () => {
         env: { POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD: 'true' },
         command: 'codex'
       },
-      expect.objectContaining({ beforeResolve: expect.any(Function) })
+      expect.objectContaining({
+        beforeResolve: expect.any(Function),
+        budgetStartsAtWire: true,
+        timeoutMs: SSH_PTY_SPAWN_TIMEOUT_MS
+      })
     )
   })
 

--- a/src/main/providers/ssh-pty-provider-saturated-writer-connect.test.ts
+++ b/src/main/providers/ssh-pty-provider-saturated-writer-connect.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  AGENT_SESSION_CREATE_OPERATION_PROTOCOL_VERSION,
+  AGENT_SESSION_EXECUTION_OWNER_PROTOCOL_VERSION
+} from '../../shared/agent-session-host-authority'
+import { SshChannelMultiplexer, type MultiplexerTransport } from '../ssh/ssh-channel-multiplexer'
+import { encodeFrame, HEADER_LENGTH, MessageType } from '../ssh/relay-protocol'
+import {
+  SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS,
+  SSH_PTY_CONNECT_WORST_CASE_MS,
+  SSH_PTY_SPAWN_TIMEOUT_MS,
+  SSH_RELAY_REQUEST_TIMEOUT_MS,
+  sshRelayQueueWaitMs
+} from '../../shared/ssh-relay-request-budget'
+import { SshPtyProvider } from './ssh-pty-provider'
+
+type SaturatingTransport = MultiplexerTransport & {
+  deliver: (data: Buffer) => void
+  drain: () => void
+  setAccepting: (accepting: boolean) => void
+  written: Buffer[]
+}
+
+function createTransport(): SaturatingTransport {
+  let deliver = (_data: Buffer): void => {}
+  let drain = (): void => {}
+  let accepting = true
+  const written: Buffer[] = []
+  return {
+    write: (data) => {
+      written.push(data)
+      return accepting
+    },
+    onDrain: (callback) => {
+      drain = callback
+    },
+    onData: (callback) => {
+      deliver = callback
+    },
+    onClose: () => {},
+    deliver: (data) => deliver(data),
+    drain: () => drain(),
+    setAccepting: (value) => {
+      accepting = value
+    },
+    written
+  }
+}
+
+function requestIds(transport: SaturatingTransport, method: string): number[] {
+  return transport.written.flatMap((frame) => {
+    if (frame[0] !== MessageType.Regular) {
+      return []
+    }
+    const length = frame.readUInt32BE(9)
+    const payload = JSON.parse(
+      frame.subarray(HEADER_LENGTH, HEADER_LENGTH + length).toString()
+    ) as { method?: string; id?: number }
+    return payload.method === method && typeof payload.id === 'number' ? [payload.id] : []
+  })
+}
+
+async function flush(): Promise<void> {
+  for (let turn = 0; turn < 8; turn += 1) {
+    await Promise.resolve()
+  }
+}
+
+const claim = {
+  digestVersion: 1 as const,
+  keyId: 'key',
+  identityDigest: 'a'.repeat(43),
+  worktreeScopeDigest: 'b'.repeat(43),
+  agent: 'codex' as const
+}
+const surface = {
+  worktreeId: 'worktree',
+  tabId: 'tab',
+  leafId: '11111111-1111-4111-8111-111111111111',
+  terminalHandle: 'term_claimed'
+}
+
+describe('SSH pane connect over a saturated writer', () => {
+  let transport: SaturatingTransport
+  let mux: SshChannelMultiplexer
+  let provider: SshPtyProvider
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    transport = createTransport()
+    mux = new SshChannelMultiplexer(transport)
+    provider = new SshPtyProvider('conn-1', mux)
+  })
+
+  afterEach(() => {
+    mux.dispose()
+    vi.useRealTimers()
+  })
+
+  function saturate(): void {
+    transport.setAccepting(false)
+    mux.notify('pty.data', { id: 'pty-1', data: 'x' })
+  }
+
+  async function drainOnce(): Promise<void> {
+    transport.setAccepting(true)
+    transport.drain()
+    await flush()
+    saturate()
+    await flush()
+  }
+
+  function respond(id: number, result: unknown): void {
+    transport.deliver(
+      encodeFrame(
+        MessageType.Regular,
+        id,
+        0,
+        Buffer.from(JSON.stringify({ jsonrpc: '2.0', id, result }))
+      )
+    )
+  }
+
+  // Why: the capability probe gates spawn, so on the FIRST spawn of a connection
+  // (nothing cached yet) a probe that expired in the queue meant pty.spawn was
+  // never enqueued and its wire-started budget never engaged.
+  it('reaches the wire with the first spawn of a connection whose writer is saturated', async () => {
+    saturate()
+    await flush()
+
+    const spawned = provider.spawn({
+      cols: 80,
+      rows: 24,
+      command: 'codex',
+      agentSessionCreateOperationId: 'a'.repeat(43)
+    })
+    await flush()
+
+    vi.advanceTimersByTime(SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS + 1_000)
+    await flush()
+    expect(requestIds(transport, 'pty.getCapabilities')).toHaveLength(0)
+
+    await drainOnce()
+    const [probeId] = requestIds(transport, 'pty.getCapabilities')
+    expect(probeId).toBeDefined()
+    respond(probeId, {
+      agentSessionCreateOperationVersion: AGENT_SESSION_CREATE_OPERATION_PROTOCOL_VERSION
+    })
+    await flush()
+
+    await drainOnce()
+    const [spawnId] = requestIds(transport, 'pty.spawn')
+    expect(spawnId).toBeDefined()
+    respond(spawnId, { id: 'pty-remote', incarnationId: 'incarnation-remote' })
+
+    await expect(spawned).resolves.toMatchObject({ id: 'ssh:conn-1@@pty-remote' })
+  })
+
+  // Why: the pane-connect backstops must outlast the whole sequence — BOTH
+  // capability probes (claims, then create-operations: separate cache entries, so
+  // one launch that asks for both sends both), the spawn, then the cleanup
+  // shutdown a failed claim validation issues — not the spawn alone, or they
+  // settle a live connect as timed out.
+  it('settles the whole claimed connect sequence inside the connect worst case', async () => {
+    saturate()
+    await flush()
+
+    const spawned = provider.spawn({
+      cols: 80,
+      rows: 24,
+      agentSessionEnsure: { claim, surface },
+      agentSessionCreateOperationId: 'a'.repeat(43)
+    })
+    const outcome = spawned.then(
+      () => 'resolved',
+      (error: Error) => error.message
+    )
+    await flush()
+
+    // Each phase drains one tick short of its queue bound, then goes unanswered
+    // until one tick short of its response budget: the true worst case.
+    vi.advanceTimersByTime(sshRelayQueueWaitMs(SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS) - 1)
+    await drainOnce()
+    vi.advanceTimersByTime(SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS - 1)
+    respond(requestIds(transport, 'pty.getCapabilities')[0], {
+      agentSessionClaimVersion: AGENT_SESSION_EXECUTION_OWNER_PROTOCOL_VERSION
+    })
+    await flush()
+
+    vi.advanceTimersByTime(sshRelayQueueWaitMs(SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS) - 1)
+    await drainOnce()
+    vi.advanceTimersByTime(SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS - 1)
+    const probeIds = requestIds(transport, 'pty.getCapabilities')
+    expect(probeIds).toHaveLength(2)
+    respond(probeIds[1], {
+      agentSessionCreateOperationVersion: AGENT_SESSION_CREATE_OPERATION_PROTOCOL_VERSION
+    })
+    await flush()
+
+    vi.advanceTimersByTime(sshRelayQueueWaitMs(SSH_PTY_SPAWN_TIMEOUT_MS) - 1)
+    await drainOnce()
+    vi.advanceTimersByTime(SSH_PTY_SPAWN_TIMEOUT_MS - 1)
+    respond(requestIds(transport, 'pty.spawn')[0], {
+      id: 'pty-claimed',
+      incarnationId: 'incarnation-claimed',
+      agentSessionEnsure: {
+        disposition: 'created',
+        // Mismatched owner id: validation fails with a created PTY to clean up.
+        owner: { claim, generation: 'gen-1', phase: 'live', ptyId: 'pty-other', surface }
+      }
+    })
+    await flush()
+
+    // The cleanup shutdown did not opt in, so it spends its budget from enqueue.
+    vi.advanceTimersByTime(SSH_RELAY_REQUEST_TIMEOUT_MS)
+    await flush()
+
+    await expect(outcome).resolves.toBe('execution_owner_unavailable')
+    expect(Date.now()).toBeLessThan(SSH_PTY_CONNECT_WORST_CASE_MS)
+  })
+})

--- a/src/main/ssh/ssh-channel-multiplexer-saturation-deadline.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer-saturation-deadline.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  SSH_MUX_REQUEST_TIMEOUT_CODE,
+  SshChannelMultiplexer,
+  type MultiplexerTransport
+} from './ssh-channel-multiplexer'
+import {
+  SSH_RELAY_WRITER_FLUSH_TIMEOUT_MS,
+  SSH_RELAY_REQUEST_TIMEOUT_MS,
+  sshRelayQueueWaitMs,
+  sshRelayRequestWorstCaseMs
+} from '../../shared/ssh-relay-request-budget'
+import { encodeFrame, HEADER_LENGTH, MessageType } from './relay-protocol'
+
+type SaturatingTransport = MultiplexerTransport & {
+  deliver: (data: Buffer) => void
+  drain: () => void
+  close: () => void
+  setAccepting: (accepting: boolean) => void
+  written: Buffer[]
+}
+
+function createTransport(): SaturatingTransport {
+  let deliver = (_data: Buffer): void => {}
+  let drain = (): void => {}
+  let close = (): void => {}
+  let accepting = true
+  const written: Buffer[] = []
+  return {
+    write: (data) => {
+      written.push(data)
+      return accepting
+    },
+    onDrain: (callback) => {
+      drain = callback
+    },
+    onData: (callback) => {
+      deliver = callback
+    },
+    onClose: (callback) => {
+      close = callback
+    },
+    deliver: (data) => deliver(data),
+    drain: () => drain(),
+    close: () => close(),
+    setAccepting: (value) => {
+      accepting = value
+    },
+    written
+  }
+}
+
+function writtenMethods(transport: SaturatingTransport): string[] {
+  return transport.written.flatMap((frame) => {
+    if (frame[0] !== MessageType.Regular) {
+      return []
+    }
+    const length = frame.readUInt32BE(9)
+    const payload = JSON.parse(
+      frame.subarray(HEADER_LENGTH, HEADER_LENGTH + length).toString()
+    ) as { method?: string }
+    return payload.method ? [payload.method] : []
+  })
+}
+
+function track(promise: Promise<unknown>): { settled: () => boolean; error: () => unknown } {
+  let outcome: { error: unknown } | { value: unknown } | null = null
+  promise.then(
+    (value) => {
+      outcome = { value }
+    },
+    (error) => {
+      outcome = { error }
+    }
+  )
+  return {
+    settled: () => outcome !== null,
+    error: () => (outcome && 'error' in outcome ? outcome.error : undefined)
+  }
+}
+
+// Why: shorter than TIMEOUT_MS so a running deadline fires before the dead-link
+// check the tests deliberately leave un-fed.
+const REQUEST_BUDGET_MS = 15_000
+// Why: real callers run well past the flush window (space scan, native deps).
+const LONG_BUDGET_MS = 130_000
+
+async function flush(): Promise<void> {
+  for (let turn = 0; turn < 4; turn += 1) {
+    await Promise.resolve()
+  }
+}
+
+describe('SshChannelMultiplexer request deadlines under writer saturation', () => {
+  let transport: SaturatingTransport
+  let mux: SshChannelMultiplexer
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    transport = createTransport()
+    mux = new SshChannelMultiplexer(transport)
+  })
+
+  afterEach(() => {
+    mux.dispose()
+    vi.useRealTimers()
+  })
+
+  async function saturate(): Promise<void> {
+    transport.setAccepting(false)
+    mux.notify('pty.data', { id: 'pty-1', data: 'x' })
+    await Promise.resolve()
+  }
+
+  it('does not charge the response budget to a request still parked in the writer', async () => {
+    await saturate()
+
+    const spawn = mux.request(
+      'pty.spawn',
+      { command: 'bash' },
+      { timeoutMs: REQUEST_BUDGET_MS, budgetStartsAtWire: true }
+    )
+    const state = track(spawn)
+    // The spawn frame never reached the transport, so its budget must not run.
+    expect(writtenMethods(transport)).not.toContain('pty.spawn')
+
+    vi.advanceTimersByTime(REQUEST_BUDGET_MS + 1_000)
+    await flush()
+
+    expect(mux.isDisposed()).toBe(false)
+    expect(state.settled()).toBe(false)
+
+    transport.setAccepting(true)
+    transport.drain()
+    await Promise.resolve()
+    expect(writtenMethods(transport)).toContain('pty.spawn')
+
+    transport.deliver(
+      encodeFrame(
+        MessageType.Regular,
+        1,
+        0,
+        Buffer.from(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { id: 'pty-remote' } }))
+      )
+    )
+    await expect(spawn).resolves.toEqual({ id: 'pty-remote' })
+  })
+
+  it('starts the response budget when the frame reaches the wire', async () => {
+    await saturate()
+    const spawn = mux.request(
+      'pty.spawn',
+      {},
+      { timeoutMs: REQUEST_BUDGET_MS, budgetStartsAtWire: true }
+    )
+    const state = track(spawn)
+
+    vi.advanceTimersByTime(SSH_RELAY_WRITER_FLUSH_TIMEOUT_MS - 1_000)
+    transport.setAccepting(true)
+    transport.drain()
+    await Promise.resolve()
+
+    vi.advanceTimersByTime(REQUEST_BUDGET_MS - 1)
+    await flush()
+    expect(state.settled()).toBe(false)
+
+    vi.advanceTimersByTime(1)
+    await expect(spawn).rejects.toMatchObject({ code: SSH_MUX_REQUEST_TIMEOUT_CODE })
+  })
+
+  it('charges only the post-flush budget to a request that saturated the writer itself', async () => {
+    transport.setAccepting(false)
+    const spawn = mux.request(
+      'pty.spawn',
+      {},
+      { timeoutMs: REQUEST_BUDGET_MS, budgetStartsAtWire: true }
+    )
+    const state = track(spawn)
+
+    vi.advanceTimersByTime(REQUEST_BUDGET_MS)
+    await flush()
+    expect(state.settled()).toBe(false)
+
+    transport.setAccepting(true)
+    transport.drain()
+    await Promise.resolve()
+
+    vi.advanceTimersByTime(REQUEST_BUDGET_MS)
+    await expect(spawn).rejects.toMatchObject({ code: SSH_MUX_REQUEST_TIMEOUT_CODE })
+  })
+
+  it('bounds the flush wait so a writer that never drains still times out', async () => {
+    await saturate()
+    const spawn = mux.request(
+      'pty.spawn',
+      {},
+      { timeoutMs: REQUEST_BUDGET_MS, budgetStartsAtWire: true }
+    )
+    const state = track(spawn)
+
+    vi.advanceTimersByTime(SSH_RELAY_WRITER_FLUSH_TIMEOUT_MS - 1)
+    await flush()
+    expect(state.settled()).toBe(false)
+
+    vi.advanceTimersByTime(1)
+    await expect(spawn).rejects.toMatchObject({
+      code: SSH_MUX_REQUEST_TIMEOUT_CODE,
+      message: `Request "pty.spawn" timed out after ${SSH_RELAY_WRITER_FLUSH_TIMEOUT_MS}ms without reaching the wire`
+    })
+  })
+
+  // Why: teardown threads an absolute sweep deadline through timeoutMs, so that
+  // call must settle inside it rather than buy a flush window on top — the
+  // default, so no teardown call site has to know about the writer.
+  it('charges the queue wait to a request that did not opt in', async () => {
+    await saturate()
+    const shutdown = mux.request('pty.shutdown', {}, { timeoutMs: REQUEST_BUDGET_MS })
+    const state = track(shutdown)
+
+    vi.advanceTimersByTime(REQUEST_BUDGET_MS - 1)
+    await flush()
+    expect(state.settled()).toBe(false)
+
+    vi.advanceTimersByTime(1)
+    await expect(shutdown).rejects.toMatchObject({
+      code: SSH_MUX_REQUEST_TIMEOUT_CODE,
+      message: `Request "pty.shutdown" timed out after ${REQUEST_BUDGET_MS}ms`
+    })
+  })
+
+  // Why: opting in must never shorten a call. A 130s scan or native-deps install
+  // parked past the flush window would otherwise fail at 30s during exactly the
+  // deploy congestion the wire-started budget exists for.
+  it('never bounds the queue wait below the caller budget', async () => {
+    await saturate()
+    const scan = mux.request(
+      'fs.spaceScan',
+      {},
+      { timeoutMs: LONG_BUDGET_MS, budgetStartsAtWire: true }
+    )
+    const state = track(scan)
+
+    vi.advanceTimersByTime(SSH_RELAY_WRITER_FLUSH_TIMEOUT_MS + 15_000)
+    await flush()
+    expect(state.settled()).toBe(false)
+
+    transport.setAccepting(true)
+    transport.drain()
+    await Promise.resolve()
+    expect(writtenMethods(transport)).toContain('fs.spaceScan')
+  })
+
+  // Why: the pane-connect backstops are sized from sshRelayRequestWorstCaseMs, so
+  // the wait the mux enforces has to be the one that function advertises — a
+  // fixed 60s worst case would understate this caller by 200s.
+  it('bounds the queue wait at the advertised wait for a long caller budget', async () => {
+    await saturate()
+    const scan = mux.request(
+      'fs.spaceScan',
+      {},
+      { timeoutMs: LONG_BUDGET_MS, budgetStartsAtWire: true }
+    )
+    const state = track(scan)
+    const queueWaitMs = sshRelayQueueWaitMs(LONG_BUDGET_MS)
+    expect(sshRelayRequestWorstCaseMs(LONG_BUDGET_MS)).toBe(queueWaitMs + LONG_BUDGET_MS)
+
+    vi.advanceTimersByTime(queueWaitMs - 1)
+    await flush()
+    expect(mux.isDisposed()).toBe(false)
+    expect(state.settled()).toBe(false)
+
+    vi.advanceTimersByTime(1)
+    await expect(scan).rejects.toMatchObject({
+      code: SSH_MUX_REQUEST_TIMEOUT_CODE,
+      message: `Request "fs.spaceScan" timed out after ${queueWaitMs}ms without reaching the wire`
+    })
+  })
+
+  // Why: pty.getSize picks a 1s budget so wake repair re-forwards fast; a flush
+  // window it never asked for would defer resize repair by half a minute.
+  it('keeps a short fail-fast budget for a request that did not opt in', async () => {
+    await saturate()
+    const size = mux.request('pty.getSize', {}, { timeoutMs: 1_000 })
+    const state = track(size)
+
+    vi.advanceTimersByTime(999)
+    await flush()
+    expect(state.settled()).toBe(false)
+
+    vi.advanceTimersByTime(1)
+    await expect(size).rejects.toMatchObject({
+      code: SSH_MUX_REQUEST_TIMEOUT_CODE,
+      message: 'Request "pty.getSize" timed out after 1000ms'
+    })
+  })
+
+  // Why: sustained pty.data flaps the writer between saturated and drained; a
+  // grace re-armed per episode would suspend this deadline forever (#G5).
+  it('times out a request already on the wire while saturation flaps', async () => {
+    const status = mux.request('git.status', {}, { timeoutMs: REQUEST_BUDGET_MS })
+    const state = track(status)
+    expect(writtenMethods(transport)).toContain('git.status')
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      transport.setAccepting(false)
+      mux.notify('pty.data', { id: 'pty-1', data: 'x' })
+      await Promise.resolve()
+      vi.advanceTimersByTime(REQUEST_BUDGET_MS / 3)
+      transport.setAccepting(true)
+      transport.drain()
+      await Promise.resolve()
+    }
+    await flush()
+
+    expect(state.settled()).toBe(true)
+    expect(state.error()).toMatchObject({ code: SSH_MUX_REQUEST_TIMEOUT_CODE })
+  })
+
+  it('still fails a parked request when the link is genuinely lost', async () => {
+    await saturate()
+    const spawn = mux.request(
+      'pty.spawn',
+      {},
+      { timeoutMs: REQUEST_BUDGET_MS, budgetStartsAtWire: true }
+    )
+
+    vi.advanceTimersByTime(SSH_RELAY_WRITER_FLUSH_TIMEOUT_MS / 2)
+    transport.close()
+
+    await expect(spawn).rejects.toMatchObject({ code: 'CONNECTION_LOST' })
+    expect(mux.isDisposed()).toBe(true)
+  })
+
+  it('leaves dead-link detection on an unsaturated writer unchanged', async () => {
+    const spawn = mux.request('pty.spawn', {}, { timeoutMs: SSH_RELAY_REQUEST_TIMEOUT_MS })
+    const state = track(spawn)
+
+    vi.advanceTimersByTime(25_000)
+    await flush()
+
+    expect(mux.isDisposed()).toBe(true)
+    expect(state.error()).toMatchObject({ code: 'CONNECTION_LOST' })
+  })
+})

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -20,6 +20,10 @@ import {
   type MultiplexerWriteSettlement,
   type MultiplexerWriterLane
 } from './ssh-multiplexer-transport-writer'
+import {
+  SSH_RELAY_REQUEST_TIMEOUT_MS,
+  sshRelayQueueWaitMs
+} from '../../shared/ssh-relay-request-budget'
 
 export type { MultiplexerTransport, MultiplexerWriteSettlement }
 
@@ -27,13 +31,16 @@ type PendingRequest = {
   resolve: (result: unknown) => void
   reject: (error: Error) => void
   beforeResolve?: (result: unknown) => void
-  timer: ReturnType<typeof setTimeout>
   cleanup: () => void
 }
 
 export type SshMultiplexerRequestOptions = {
   signal?: AbortSignal
   timeoutMs?: number
+  // Why: `timeoutMs` runs from enqueue, so callers that picked a short fail-fast
+  // budget keep it. Retry-safe calls that a saturated writer can park before the
+  // wire opt in here to start it at the wire, queue wait bounded separately.
+  budgetStartsAtWire?: boolean
   beforeResolve?: (result: unknown) => void
 }
 
@@ -56,7 +63,6 @@ export function createSshDisposalError(reason: MultiplexerDisposeReason): Error 
   return err
 }
 
-const REQUEST_TIMEOUT_MS = 30_000
 const MAX_ORDINARY_UNACKED_TIMESTAMPS = 4095
 const MAX_UNACKED_TIMESTAMPS = MAX_ORDINARY_UNACKED_TIMESTAMPS + 1
 // Why: a tick gap far beyond the interval means the process was paused
@@ -72,6 +78,15 @@ function sshMuxRequestTimeoutError(method: string, timeoutMs: number): Error {
   return Object.assign(new Error(`Request "${method}" timed out after ${timeoutMs}ms`), {
     code: SSH_MUX_REQUEST_TIMEOUT_CODE
   })
+}
+
+// Why: the two phases fail for different reasons (never sent vs. never answered)
+// and only the message survives into logs and scan-issue copy.
+function sshMuxWriteFlushTimeoutError(method: string, waitMs: number): Error {
+  return Object.assign(
+    new Error(`Request "${method}" timed out after ${waitMs}ms without reaching the wire`),
+    { code: SSH_MUX_REQUEST_TIMEOUT_CODE }
+  )
 }
 
 export function isSshMuxRequestTimeoutError(error: unknown): boolean {
@@ -238,53 +253,76 @@ export class SshChannelMultiplexer {
       method,
       ...(params !== undefined ? { params } : {})
     }
-    const timeoutMs = options?.timeoutMs ?? REQUEST_TIMEOUT_MS
+    const timeoutMs = options?.timeoutMs ?? SSH_RELAY_REQUEST_TIMEOUT_MS
 
     return new Promise((resolve, reject) => {
-      let timer: ReturnType<typeof setTimeout>
-      const cleanup = (): void => {
-        clearTimeout(timer)
-        if (options?.signal) {
-          options.signal.removeEventListener('abort', onAbort)
-        }
-      }
       const onAbort = (): void => {
-        const pending = this.pendingRequests.get(id)
-        if (!pending) {
+        const found = this.pendingRequests.get(id)
+        if (!found) {
           return
         }
-        pending.cleanup()
+        found.cleanup()
         this.pendingRequests.delete(id)
         // Why: Space scans can run long on SSH hosts. Let the relay stop its
         // local filesystem work instead of only dropping the client promise.
         this.notify('rpc.cancel', { id })
         const error = new Error(`Request "${method}" was cancelled`) as Error & { name: string }
         error.name = 'AbortError'
-        pending.reject(error)
+        found.reject(error)
       }
-      timer = setTimeout(() => {
-        const pending = this.pendingRequests.get(id)
-        if (pending) {
-          pending.cleanup()
+      let timer: ReturnType<typeof setTimeout>
+      const expire = (error: Error): void => {
+        const found = this.pendingRequests.get(id)
+        if (found) {
+          found.cleanup()
           // Why: request timeouts should stop relay-side long-running work,
           // not just detach the client from the eventual response.
           this.notify('rpc.cancel', { id })
         }
         this.pendingRequests.delete(id)
-        reject(sshMuxRequestTimeoutError(method, timeoutMs))
-      }, timeoutMs)
+        reject(error)
+      }
+      const pending: PendingRequest = {
+        resolve,
+        reject,
+        beforeResolve: options?.beforeResolve,
+        cleanup: () => {
+          clearTimeout(timer)
+          if (options?.signal) {
+            options.signal.removeEventListener('abort', onAbort)
+          }
+        }
+      }
 
       if (options?.signal) {
         options.signal.addEventListener('abort', onAbort, { once: true })
       }
-      this.pendingRequests.set(id, {
-        resolve,
-        reject,
-        beforeResolve: options?.beforeResolve,
-        timer,
-        cleanup
+      // Why: until the writer hands the frame to the transport it has had no
+      // wire time, and the dead-link check stands down while the writer is
+      // saturated, so an opted-in queue wait gets its own bound instead of
+      // silently spending the caller's response budget. Anything backstopping
+      // such a call must be sized with sshRelayRequestWorstCaseMs(timeoutMs).
+      const budgetStartsAtWire = options?.budgetStartsAtWire === true
+      const queueWaitMs = budgetStartsAtWire ? sshRelayQueueWaitMs(timeoutMs) : timeoutMs
+      timer = setTimeout(
+        () =>
+          expire(
+            budgetStartsAtWire
+              ? sshMuxWriteFlushTimeoutError(method, queueWaitMs)
+              : sshMuxRequestTimeoutError(method, timeoutMs)
+          ),
+        queueWaitMs
+      )
+      this.pendingRequests.set(id, pending)
+      this.sendMessage(msg, (settlement) => {
+        // Why: per-request, so a stall that parks one frame cannot suspend the
+        // deadline of a request whose frame is already out on the wire.
+        if (!budgetStartsAtWire || !settlement.ok || this.pendingRequests.get(id) !== pending) {
+          return
+        }
+        clearTimeout(timer)
+        timer = setTimeout(() => expire(sshMuxRequestTimeoutError(method, timeoutMs)), timeoutMs)
       })
-      this.sendMessage(msg)
     })
   }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-reattach-retry.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-reattach-retry.test.ts
@@ -13,6 +13,7 @@ import {
   type MockTransport
 } from './pty-connection-test-pane-fixtures'
 import { buildPaneConnectionDeps, buildDirectSshSplitRetryCommit } from './pty-connection-test-deps'
+import { DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS } from './pty-connection/pty-connect-limits'
 import { createInitialStoreState } from './pty-connection-test-store-fixtures'
 import type { StoreState } from './pty-connection-test-store-state'
 import {
@@ -206,7 +207,7 @@ describe('connectPanePty', () => {
     expect(transport.connect).toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: restoredPtyId })
     )
-    await vi.advanceTimersByTimeAsync(31_000)
+    await vi.advanceTimersByTimeAsync(DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS)
     expect(settleDirectSshPaneRetry).toHaveBeenCalledExactlyOnceWith({
       status: 'timed-out',
       tabId: 'tab-1',

--- a/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-spawn-retry.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-spawn-retry.test.ts
@@ -7,6 +7,7 @@ import { buildPaneConnectionDeps, buildDirectSshSplitRetryCommit } from './pty-c
 import { createInitialStoreState } from './pty-connection-test-store-fixtures'
 import type { StoreState } from './pty-connection-test-store-state'
 import {
+  DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS,
   pendingSpawnByPaneKey,
   pendingSpawnGenerationByPaneKey
 } from './pty-connection/pty-connect-limits'
@@ -311,7 +312,7 @@ describe('connectPanePty', () => {
 
     expect(firstTransport.connect).toHaveBeenCalledOnce()
     expect(remountTransport.connect).not.toHaveBeenCalled()
-    await vi.advanceTimersByTimeAsync(30_999)
+    await vi.advanceTimersByTimeAsync(DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS - 1)
     expect(settleDirectSshPaneRetry).not.toHaveBeenCalled()
     await vi.advanceTimersByTimeAsync(1)
     expect(settleDirectSshPaneRetry).toHaveBeenCalledExactlyOnceWith({
@@ -373,7 +374,7 @@ describe('connectPanePty', () => {
     )
     await flushAsyncTicks()
     binding.dispose()
-    await vi.advanceTimersByTimeAsync(31_000)
+    await vi.advanceTimersByTimeAsync(DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS)
 
     expect(settleDirectSshPaneRetry).not.toHaveBeenCalled()
 

--- a/src/renderer/src/components/terminal-pane/pty-connection/pty-connect-limits.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pty-connect-limits.ts
@@ -1,10 +1,13 @@
 import { e2eConfig } from '@/lib/e2e-config'
+import { SSH_PTY_CONNECT_WORST_CASE_MS } from '../../../../../shared/ssh-relay-request-budget'
 
 export const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 export const pendingSpawnGenerationByPaneKey = new Map<string, number>()
 export const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
-// Why: relay requests expire at 30s; leave one second for their fallback before re-arming locally.
-export const DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS = 31_000
+// Why: a connect expires only after every call in its sequence has spent both
+// budgets (the bounded wait to reach the wire, then the response window); leave
+// one second for the last one's fallback before re-arming locally.
+export const DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS = SSH_PTY_CONNECT_WORST_CASE_MS + 1_000
 export const REMOTE_PTY_ID_PREFIX = 'remote:'
 export const PTY_CONNECT_DIAG_LIMIT = 200
 export const MANUAL_AGENT_COMMAND_MAX_CHARS = 4096
@@ -16,7 +19,9 @@ export const STARTUP_DRAFT_PASTE_QUIET_MS = 1500
 // recover again; the transport's destroyed-check no longer kills a
 // pre-existing session when a late reattach resolves, so a remount racing
 // a slow-but-alive connect costs a wasted view rebuild, not a shell.
-export const TRANSPORT_CONNECT_SETTLE_GRACE_MS = 60_000
+// Sized to the whole connect sequence — both capability probes, spawn, cleanup
+// shutdown — not spawn alone, so a connect past it cannot still be live.
+export const TRANSPORT_CONNECT_SETTLE_GRACE_MS = SSH_PTY_CONNECT_WORST_CASE_MS
 
 export function recordPtyConnectDiagnostic(message: string): void {
   if (!e2eConfig.exposeStore) {

--- a/src/shared/ssh-relay-request-budget.ts
+++ b/src/shared/ssh-relay-request-budget.ts
@@ -1,0 +1,52 @@
+/**
+ * Budgets an SSH relay RPC spends, and the worst case anything backstopping one
+ * has to outlast. A request is written through a bounded writer: while that
+ * writer is saturated nothing reaches the wire. Calls that opt into
+ * `budgetStartsAtWire` (pty.spawn and the capability probes gating it) wait out
+ * that queue on its own bound and only then start the response budget, so a
+ * backstop armed for the response budget alone — or for one call in a connect's
+ * sequence of them — would fire while the call is still live.
+ */
+export const SSH_RELAY_REQUEST_TIMEOUT_MS = 30_000
+// Why: the dead-link check stands down while the writer is saturated, so this
+// bound is the only detector for a frame that never reaches the wire.
+export const SSH_RELAY_WRITER_FLUSH_TIMEOUT_MS = 30_000
+
+// Why: never below the caller's own budget, or opting in would shorten a call
+// that asked for longer than the flush window.
+export function sshRelayQueueWaitMs(timeoutMs: number): number {
+  return Math.max(timeoutMs, SSH_RELAY_WRITER_FLUSH_TIMEOUT_MS)
+}
+
+// Why: a frame that drains one tick short of the queue bound then goes unanswered
+// spends both budgets in full, so the worst case scales with the caller's budget —
+// any fixed constant understates every caller that asks for longer than the default.
+export function sshRelayRequestWorstCaseMs(timeoutMs: number): number {
+  return sshRelayQueueWaitMs(timeoutMs) + timeoutMs
+}
+
+// Why: the pane-connect backstops are sized from the spawn worst case, so the
+// call site and the backstops read one budget instead of each assuming a default.
+export const SSH_PTY_SPAWN_TIMEOUT_MS = SSH_RELAY_REQUEST_TIMEOUT_MS
+export const SSH_PTY_SPAWN_WORST_CASE_MS = sshRelayRequestWorstCaseMs(SSH_PTY_SPAWN_TIMEOUT_MS)
+
+// Why: spawn is gated on these probes over the same writer, so they opt into
+// the wire-started budget too — otherwise they expire in the queue first and the
+// spawn they gate is never enqueued. The window stays short so an unresponsive
+// relay still fails fast once the frame is actually out.
+export const SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS = 5_000
+
+// Why: SshPtyProvider.spawn() gates on two independently cached probes —
+// supportsClaims (agentSessionEnsure) then supportsCreateOperations
+// (agentSessionCreateOperationId) — and a launch that asks for both sends both.
+const SSH_PTY_CONNECT_CAPABILITY_PROBES = 2
+
+// Why: a pane connect is a sequence of relay calls, not one — the probes gating
+// spawn, the spawn, then the shutdown that cleans up a spawn whose claim failed
+// validation. A backstop sized from spawn alone fires while the connect is still
+// live. The shutdown does not opt in, so it costs its budget from enqueue only.
+export const SSH_PTY_CONNECT_WORST_CASE_MS =
+  SSH_PTY_CONNECT_CAPABILITY_PROBES *
+    sshRelayRequestWorstCaseMs(SSH_AGENT_SESSION_CAPABILITY_PROBE_TIMEOUT_MS) +
+  SSH_PTY_SPAWN_WORST_CASE_MS +
+  SSH_RELAY_REQUEST_TIMEOUT_MS


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​589 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​583 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​148 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 |

<!-- /orca-pr-loc -->

## What

A relay RPC's timeout was armed at **enqueue**, not when its frame actually reached the wire.

`SshChannelMultiplexer.request()` called `setTimeout(timeoutMs)` and then handed the frame to `SshMultiplexerTransportWriter`. While that writer is saturated the control lane is parked (`pump()` early-returns), and the dead-link check that would otherwise rescue a stuck request is *deliberately* suppressed in exactly that state. So a `pty.spawn` frame could burn its entire 30 s budget sitting in the queue, never having been written. The pane settled the connect as timed out and re-armed a retry for a spawn that had never started.

The change:

- New opt-in request option `budgetStartsAtWire` on `SshChannelMultiplexer.request()`. Opt-in rather than default, so callers that deliberately chose a short fail-fast `timeoutMs` keep it.
  - The queue wait gets its **own** bound, `sshRelayQueueWaitMs(timeoutMs) = max(timeoutMs, 30_000)` — never below the caller's own budget, so opting in can never *shorten* a call.
  - The response budget is armed fresh from the writer's **per-request** settlement callback, so a stall that parks one frame cannot suspend the deadline of a request already out on the wire, and a writer that never drains still surfaces a timeout.
  - The two phases produce distinguishable errors: `timed out after Nms without reaching the wire` vs. the existing `timed out after Nms`.
- `pty.spawn` opts in (a spawn that never reached the wire started nothing and retries safely), and so do **both** `pty.getCapabilities` probes that gate it — `supportsClaims` (`agentSessionEnsure`) and `supportsCreateOperations` (`agentSessionCreateOperationId`). Without that, the 5 s probe expires in the same queue *first*, `pty.spawn` is never enqueued, and the spawn's wire-started budget never engages on the first spawn of a connection.
- New `src/shared/ssh-relay-request-budget.ts` exports `sshRelayQueueWaitMs` / `sshRelayRequestWorstCaseMs` (functions of the caller's budget) rather than one fixed constant, plus `SSH_PTY_CONNECT_WORST_CASE_MS`, which sums the whole connect sequence: two probes + spawn + the `pty.shutdown` that cleans up a spawn whose claim failed validation. The renderer backstops `DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS` and `TRANSPORT_CONNECT_SETTLE_GRACE_MS` now derive from that one number.

## Fix evidence

All output below is verbatim from this worktree.

### Before — the new tests fail against pre-change `ssh-channel-multiplexer.ts`

`src/main/ssh/ssh-channel-multiplexer.ts` restored to its merge-base blob (`git show 872bd51d479:...`), everything else at the branch tip:

```
$ pnpm test src/main/ssh/ssh-channel-multiplexer-saturation-deadline.test.ts src/main/providers/ssh-pty-provider-saturated-writer-connect.test.ts

     × does not charge the response budget to a request still parked in the writer 5ms
     × starts the response budget when the frame reaches the wire 1ms
     × charges only the post-flush budget to a request that saturated the writer itself 0ms
     × bounds the flush wait so a writer that never drains still times out 1ms
     × bounds the queue wait at the advertised wait for a long caller budget 2ms
     × still fails a parked request when the link is genuinely lost 1ms
     × reaches the wire with the first spawn of a connection whose writer is saturated 4ms
     × settles the whole claimed connect sequence inside the connect worst case 2ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 8 ⎯⎯⎯⎯⎯⎯⎯
 Test Files  2 failed (2)
      Tests  8 failed | 5 passed (13)
```

The core assertion — a parked request must not be charged the response budget:

```
 FAIL  src/main/ssh/ssh-channel-multiplexer-saturation-deadline.test.ts > SshChannelMultiplexer request deadlines under writer saturation > does not charge the response budget to a request still parked in the writer
AssertionError: expected true to be false // Object.is equality

- Expected
+ Received

- false
+ true

 ❯ src/main/ssh/ssh-channel-multiplexer-saturation-deadline.test.ts:132:29
    130|
    131|     expect(mux.isDisposed()).toBe(false)
    132|     expect(state.settled()).toBe(false)
       |                             ^
```

And the whole-connect case, driving the real `SshPtyProvider` over a saturated `MultiplexerTransport`, produced an unhandled `execution_owner_unavailable` because the gating probe died in the queue and the spawn was never dispatched:

```
⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
Error: execution_owner_unavailable
 ❯ SshPtyProvider.spawn src/main/providers/ssh-pty-provider.ts:115:13
    113|     if (opts.agentSessionCreateOperationId && !supportsCreateOperation…
    114|       // Why: host routing owns legacy selection; a changed relay must…
    115|       throw new Error('execution_owner_unavailable')
       |             ^
```

### Before — the perf-audit finding, reproduced independently

The perf audit claimed `SSH_PTY_CONNECT_WORST_CASE_MS` counted only **one** capability probe while `SshPtyProvider.spawn()` issues **two** (`ssh-pty-provider.ts:84` and `:107`, independently cached in `SshAgentSessionCapabilities`, and `orca-runtime.ts:31058-31072` sets both launch flags together). I extended the worst-case test to set both flags and ran it against the branch tip **before** touching the constant:

```
 FAIL  src/main/providers/ssh-pty-provider-saturated-writer-connect.test.ts > SSH pane connect over a saturated writer > settles the whole claimed connect sequence inside the connect worst case
AssertionError: expected 159994 to be less than 125000
 ❯ src/main/providers/ssh-pty-provider-saturated-writer-connect.test.ts:220:24
    218|
    219|     await expect(outcome).resolves.toBe('execution_owner_unavailable')
    220|     expect(Date.now()).toBeLessThan(SSH_PTY_CONNECT_WORST_CASE_MS)
       |                        ^

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

Confirmed the audit's exact numbers (`159994` measured vs. `125000` claimed). Fixed by summing two probe worst cases:

```
$ node -e "const P=5000,F=30000,R=30000;const q=t=>Math.max(t,F),w=t=>q(t)+t;
           console.log('probe worst',w(P),'spawn worst',w(R),'connect worst',2*w(P)+w(R)+R)"
probe worst 35000 spawn worst 60000 connect worst 160000
```

### After — final runs at the committed tree

```
$ pnpm test src/main/ssh/ssh-channel-multiplexer-saturation-deadline.test.ts src/main/providers/ssh-pty-provider-saturated-writer-connect.test.ts src/main/providers/ssh-pty-provider-agent-session-create-operation.test.ts src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-spawn-retry.test.ts src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-reattach-retry.test.ts

 Test Files  5 passed (5)
      Tests  41 passed (41)
   Start at  15:04:02
   Duration  2.39s
```

Full surrounding suites:

```
$ pnpm test src/main/ssh src/main/providers

 Test Files  206 passed | 3 skipped (209)
      Tests  2614 passed | 21 skipped (2635)
   Start at  15:04:08
   Duration  10.55s

$ pnpm test src/renderer/src/components/terminal-pane

 Test Files  415 passed (415)
      Tests  4038 passed (4038)
   Start at  15:04:19
   Duration  21.30s
```

Gates:

```
$ pnpm run check:code-quality:changed
code quality: 0 new finding(s) across 10 changed file(s).
type-aware code quality: 0 new finding(s) across 10 changed file(s).
React Doctor: 0 new finding(s) across 10 changed file(s).
Changed-code quality gate passed since 872bd51d479e.

$ pnpm tc; echo "EXIT=$?"
$ pnpm run typecheck
$ node config/scripts/run-typecheck-projects-in-parallel.mjs
EXIT=0

$ npx oxfmt --check <changed files>
All matched files use the correct format.
```

### Evidence I do NOT have

- **No Windows repro, and no Windows exit codes.** Everything above ran on macOS (Darwin 25.3.0). The originating crash report is not reproduced here as a native crash; the defect is reproduced as a deterministic fake-timer simulation of a saturated writer.
- **No real-SSH end-to-end run.** The saturated writer is a test transport whose `write()` returns `false`; I did not congest an actual relay link.
- **No before/after UI capture** of a pane that retried a never-dispatched spawn.

## ELI5

Imagine mailing a letter that must be answered in 30 minutes. The old code started the 30-minute clock the moment you *dropped the letter in your outbox* — not when the mail carrier actually picked it up. If the outbox was jammed (the network write buffer was full), the letter sat there, the 30 minutes ran out, and you declared "no reply!" and mailed a duplicate — even though the first letter had never left the house.

Now, for the letters where a duplicate would be dangerous (starting a terminal on a remote machine), the clock starts when the carrier picks it up. The time spent jammed in the outbox has its own separate, bounded limit — so a permanently jammed outbox still fails, it just fails saying "never got picked up" instead of pretending it was ignored. Every letter is timed individually, so one jammed letter can't freeze the clock on letters already in transit.

## Trade-offs

Real, user-facing, and worth reading:

1. **Worst-case SSH pane connect goes from ~31 s to ~161 s before the renderer gives up and retries.** `DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS` moves from `31_000` to `SSH_PTY_CONNECT_WORST_CASE_MS + 1_000` = `161_000`. On a genuinely dead-but-not-closed link where the writer is saturated, a user now stares at a connecting pane for up to ~2m40s instead of ~30s. That is the direct cost of not retrying a spawn that may have actually started: the old fast failure was fast *because* it was wrong. There is no cheaper way to distinguish "never sent" from "sent, unanswered" while the writer is parked and the dead-link detector is standing down.

2. **`TRANSPORT_CONNECT_SETTLE_GRACE_MS` grows the same way (60 s → 160 s), and its slack shrank to zero.** It is now set exactly equal to the connect worst case rather than exceeding it. It is still a correct upper bound (the measured worst path is `159994 ms` against a `160000 ms` bound), but it is a 6 ms margin, not a comfortable one. Practical effect: input-triggered recovery on a wedged pane is suppressed for up to 160 s instead of 60 s.

3. **The two gating capability probes now wait out the writer queue too.** Each `pty.getCapabilities` can now take up to 35 s (30 s queue + 5 s response) instead of 5 s flat. This only bites when the writer is saturated — on a healthy link the frame is written synchronously and the response budget is still 5 s — but it does mean a relay that is reachable-but-congested delays capability detection rather than falling back to legacy behavior quickly.

4. **Two new latency knobs that can drift.** `SSH_PTY_CONNECT_CAPABILITY_PROBES = 2` is a hand-maintained count of probe call sites in `SshPtyProvider.spawn()`. If a third gating probe is ever added and that constant is not bumped, the backstops silently understate the worst case again — exactly the bug fixed in this PR. The worst-case test in `ssh-pty-provider-saturated-writer-connect.test.ts` asserts `expect(probeIds).toHaveLength(2)` and drives the real provider, so a third probe *should* fail it, but that is a test-level guard, not a structural one.

5. **`budgetStartsAtWire` is opt-in.** Every other relay caller keeps the old enqueue-started deadline and remains vulnerable to the same class of premature timeout. That is deliberate — making it the default silently gave every short fail-fast caller up to +30 s (this was caught and rejected in adversarial round 2) — but it means the fix is scoped to the spawn path, not to the multiplexer generally.

## Adversarial review

**4 rounds. This hit the round cap; it did not converge to a clean round.** Round 4 still returned two majors (both fixed), and a separate perf audit afterwards returned a further confirmed major that was also fixed here — so the last review pass over this code found real defects, and no reviewer has since signed off on the current tree.

**Round 1** — `[blocker]` `ssh-channel-multiplexer.ts`: the original design used `parkRequestDeadlines()`/`resumeRequestDeadlines()`, which suspended *every* pending request's deadline (including requests whose frame had already reached the wire), and the 120 s bound was per saturation *episode* — a writer flapping saturated/drained (the normal state under sustained `pty.data`) re-armed the grace on every cycle, so deadlines could be suspended without limit. Reproduced with a probe: a `git.status` request already on the wire, then 200 × {saturate → advance 30 s → drain} gave `settled=false, disposed=false` after 6,000,000 ms simulated. `[major]` `ssh-agent-session-create-operation.ts`: raising the `pty.spawn` budget to 120 s broke the documented coupling with the renderer's `DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS = 31_000`, which had been left untouched. → **Both confirmed.** The global park/resume design was abandoned and rewritten as a per-request wire-started budget; the renderer backstop was made to derive from the same shared budget module.

**Round 2** — `[blocker]`: the new queue-wait bound was a fixed 30 s even when the caller asked for a much larger budget, so any request with `timeoutMs > 30_000` would newly fail at 30 s if parked — a failure mode that did not exist before. `[major]`: the wire-started behavior was the *default*, with `hardDeadline` as an opt-out that only teardown ever passed, so every caller that deliberately chose a short fail-fast `timeoutMs` silently gained up to +30 s. → **Both confirmed, neither rejected.** One root cause. Inverted to opt-in (`budgetStartsAtWire`), and made the queue bound scale with the caller's budget: `sshRelayQueueWaitMs(t) = max(t, 30_000)`.

**Round 3** — `[major]` `ssh-relay-request-budget.ts`: `SSH_RELAY_REQUEST_WORST_CASE_MS` was hardcoded at `FLUSH + REQUEST = 60_000`, but for an opted-in caller with a non-default `timeoutMs` the true worst case is `max(timeoutMs, 30s) + timeoutMs` — e.g. `130_000` for `timeoutMs: 130_000` — and the change's own test blessed exactly that shape. `[major]`: the branch's HEAD commit still contained the abandoned round-1 design and described it in its message, while the real fix was uncommitted and its new module untracked. → **Both valid, both fixed.** The fixed constant became the function `sshRelayRequestWorstCaseMs(timeoutMs)`; the commit was rewritten to match the shipped design.

**Round 4** — `[major]` `ssh-pty-provider.ts`: the gating `pty.getCapabilities` probe (5 s, *not* opted into `budgetStartsAtWire`) failed first under the very saturation the fix targets, so `pty.spawn` was never enqueued and the wire-started budget never engaged on the first spawn of a connection. Reproduced verbatim by driving the real `SshPtyProvider` over a saturated `MultiplexerTransport`: `{ e: 'execution_owner_unavailable' }` with frames `['pty.data', 'pty.getCapabilities#1', 'rpc.cancel']` — no `pty.spawn`. `[major]` `pty-connect-limits.ts`: `TRANSPORT_CONNECT_SETTLE_GRACE_MS` (60 s) was strictly less than the connect worst case it claimed to cover (5 s probe + 60 s spawn = 65 s), and the new comment asserted the opposite. → **Both valid and reproduced, both fixed.** Nothing rejected. The probes opt in, and `SSH_PTY_CONNECT_WORST_CASE_MS` was introduced to size the grace from the whole sequence.

### What remains open at the cap

- **No clean review round was ever achieved.** Rounds 1–4 each surfaced at least one blocker or major, and the post-round-4 perf audit surfaced another (see below). The rate of findings was not obviously decaying; a 5th round would plausibly find more.
- **The probe count is a magic `2`** (trade-off #4). Structurally, the worst case should be derived from the provider rather than hand-counted.
- **`TRANSPORT_CONNECT_SETTLE_GRACE_MS` has ~0 ms of engineered slack** (trade-off #2). It is correct but brittle; a future call added anywhere in the connect sequence invalidates it.
- **The connect latency regression in trade-off #1 (~31 s → ~161 s) was never reviewed as a product decision**, only as a correctness one.

## Perf review

A performance audit was run over the worktree (branch `e31e7e167e5` + the then-uncommitted work), with all measurements taken in-tree and scratch files removed afterwards.

**F1 — CONFIRMED, and fixed in this PR.** `SSH_PTY_CONNECT_WORST_CASE_MS` understated the real connect by 35 s. `src/shared/ssh-relay-request-budget.ts:43` summed **one** capability probe, but `SshPtyProvider.spawn()` issues **two** independent `pty.getCapabilities` calls — `supportsAgentSessionClaims()` (`ssh-pty-provider.ts:84`, gated on `agentSessionEnsure`) and `supportsAgentSessionCreateOperations()` (`ssh-pty-provider.ts:107`, gated on `agentSessionCreateOperationId`) — and `orca-runtime.ts:31058-31072` sets both flags on the same launch. Both now opt into `budgetStartsAtWire`, so each can spend `sshRelayRequestWorstCaseMs(5_000)` = 35 s. Measured by extending the worst-case test with both flags set (two probe ids observed on the wire):

```
AUDIT_ELAPSED 159994   CONSTANT 125000   OUTCOME execution_owner_unavailable
AssertionError: expected 159994 to be less than 125000
```

At the audited state `DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS` was 126,000 ms, so it would fire ~34 s **before** the connect settled — the pane settles `timed-out`, the retry re-arms, and a second spawn is dispatched. That is precisely the defect this PR exists to remove; at the audited state it had been *moved* from 31 s to 126 s, not eliminated.

**Resolution in this PR:** I independently reproduced F1 (identical `159994` / `125000` numbers, quoted verbatim under *Fix evidence*), then fixed it by counting both probes in `SSH_PTY_CONNECT_WORST_CASE_MS` (now 160,000 ms, backstop 161,000 ms) and by permanently strengthening `ssh-pty-provider-saturated-writer-connect.test.ts` to set both launch flags and assert `probeIds` has length 2 — so the audit's exact scenario is now a standing regression test rather than a one-off probe. The suite passes.

**Net perf posture:** this change adds no per-frame CPU or allocation work on the hot path. The only per-request cost is one extra `clearTimeout` + `setTimeout` for opted-in requests when the writer settles their frame, and a closure capture on the settlement callback — both bounded by the number of in-flight `pty.spawn`/`pty.getCapabilities` calls, which is at most a handful per connection. It does not touch `pty.data`, the writer's `pump()` loop, or any streaming path. The cost is entirely in *latency budgets* under an already-degraded link, quantified in Trade-offs #1–#3.
