### PR TITLE
fix(cli): refuse an ambiguous project host setup instead of silently picking one

### DIFF
--- a/src/cli/worktree-project-target.test.ts
+++ b/src/cli/worktree-project-target.test.ts
@@ -44,6 +44,40 @@ const flagsFor = (host: string): Map<string, string | boolean> =>
   ])
 
 describe('resolveProjectCreateTarget host selection', () => {
+  it.each([
+    ['C0', 'setup\n', 'setup\\u000a'],
+    ['C1', 'setup\u009b', 'setup\\u009b'],
+    ['zero-width', 'setup\u200b', 'setup\\u200b'],
+    ['line separator', 'setup\u2028', 'setup\\u2028'],
+    ['bidi override', 'setup\u202e', 'setup\\u202e'],
+    ['word joiner', 'setup\u2060', 'setup\\u2060'],
+    ['BOM', 'setup\ufeff', 'setup\\ufeff'],
+    ['backslash', 'setup\\value', 'setup\\\\value']
+  ])('resolves an %s id copied from the ambiguity diagnostic', async (_name, id, escapedId) => {
+    const client = clientReturning([readySetup({ id, repoId: 'repo-selected' })])
+    const flags = new Map<string, string | boolean>([['project-host-setup', escapedId]])
+
+    await expect(resolveProjectCreateTarget(flags, client)).resolves.toEqual(
+      expect.objectContaining({
+        repoSelector: 'id:repo-selected',
+        setup: expect.objectContaining({ id })
+      })
+    )
+  })
+
+  it('preserves raw id matching when it collides with another id display', async () => {
+    const rawId = 'setup\\u000a'
+    const client = clientReturning([
+      readySetup({ id: rawId, repoId: 'repo-raw' }),
+      readySetup({ id: 'setup\n', repoId: 'repo-escaped' })
+    ])
+    const flags = new Map<string, string | boolean>([['project-host-setup', rawId]])
+
+    await expect(resolveProjectCreateTarget(flags, client)).resolves.toEqual(
+      expect.objectContaining({ repoSelector: 'id:repo-raw' })
+    )
+  })
+
   it('refuses, and names the candidates, when several setups could match', async () => {
     const client = clientReturning([
       readySetup({ id: 'a', repoId: 'repo-a', path: 'C:\\Users\\neil\\orca\\orca' }),

--- a/src/cli/worktree-project-target.test.ts
+++ b/src/cli/worktree-project-target.test.ts
@@ -113,6 +113,20 @@ describe('resolveProjectCreateTarget host selection', () => {
     ])
     const flags = new Map<string, string | boolean>([['project', 'github:stablyai/orca']])
 
-    await expect(resolveProjectCreateTarget(flags, client)).rejects.toThrow(/\/repo\?  forged/)
+    await expect(resolveProjectCreateTarget(flags, client)).rejects.toThrow(/\/repo\\u000a  forged/)
+  })
+
+  it('escapes C1, bidi and line-separator forgeries, keeping distinct ids distinct', async () => {
+    const client = clientReturning([
+      readySetup({ id: 'a\u009b31m', repoId: 'repo-a', path: '/one\u2028forged' }),
+      readySetup({ id: 'a\u202e31m', repoId: 'repo-b', path: '/two' })
+    ])
+    const flags = new Map<string, string | boolean>([['project', 'github:stablyai/orca']])
+    const failure = resolveProjectCreateTarget(flags, client)
+
+    await expect(failure).rejects.toThrow(/a\\u009b31m/)
+    await expect(failure).rejects.toThrow(/one\\u2028forged/)
+    // Distinct ids must not collapse onto the same rendering.
+    await expect(failure).rejects.toThrow(/a\\u202e31m/)
   })
 })

--- a/src/cli/worktree-project-target.test.ts
+++ b/src/cli/worktree-project-target.test.ts
@@ -78,4 +78,29 @@ describe('resolveProjectCreateTarget host selection', () => {
       expect.objectContaining({ repoSelector: 'id:repo-exact' })
     )
   })
+
+  it('refuses an ambiguous project even with no --host, and names the setup ids', async () => {
+    // Without --host the old code returned candidates[0]; ordering is persistence order, not a
+    // user choice. On the affected host this project has six ready setups.
+    const client = clientReturning([
+      readySetup({ id: 'setup-a', repoId: 'repo-a', path: 'C:\\Users\\neil\\orca\\orca' }),
+      readySetup({ id: 'setup-b', repoId: 'repo-b', path: 'C:\\orca\\orca' })
+    ])
+    const flags = new Map<string, string | boolean>([['project', 'github:stablyai/orca']])
+
+    const failure = resolveProjectCreateTarget(flags, client)
+
+    await expect(failure).rejects.toThrow(/2 ready setups/)
+    // The remedy names --project-host-setup <id>, so the id has to be shown.
+    await expect(failure).rejects.toThrow(/setup-a/)
+  })
+
+  it('still resolves a single setup when no --host is given', async () => {
+    const client = clientReturning([readySetup({ id: 'only', repoId: 'repo-only' })])
+    const flags = new Map<string, string | boolean>([['project', 'github:stablyai/orca']])
+
+    await expect(resolveProjectCreateTarget(flags, client)).resolves.toEqual(
+      expect.objectContaining({ repoSelector: 'id:repo-only' })
+    )
+  })
 })

--- a/src/cli/worktree-project-target.test.ts
+++ b/src/cli/worktree-project-target.test.ts
@@ -103,4 +103,16 @@ describe('resolveProjectCreateTarget host selection', () => {
       expect.objectContaining({ repoSelector: 'id:repo-only' })
     )
   })
+
+  it('neutralises control characters in setup metadata before printing', async () => {
+    // Paths are persisted metadata and may contain newlines or ANSI; this message goes straight
+    // to a terminal, so an unescaped value could forge a line.
+    const client = clientReturning([
+      readySetup({ id: 'setup-a', repoId: 'repo-a', path: '/repo\n  forged  (fake setup)' }),
+      readySetup({ id: 'setup-b', repoId: 'repo-b', path: '/other' })
+    ])
+    const flags = new Map<string, string | boolean>([['project', 'github:stablyai/orca']])
+
+    await expect(resolveProjectCreateTarget(flags, client)).rejects.toThrow(/\/repo\?  forged/)
+  })
 })

--- a/src/cli/worktree-project-target.test.ts
+++ b/src/cli/worktree-project-target.test.ts
@@ -1,0 +1,81 @@
+/**
+ * STA-6080: `--host runtime:<id>` silently bound to a `local`-stamped setup.
+ *
+ * On the affected host every setup was stamped `local` and the project had six ready ones, so the
+ * fallback matched and selection took whichever was first — aiming worktree creation at an
+ * unrelated checkout. Ambiguity must be refused, not guessed.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { ProjectHostSetup } from '../shared/project-types'
+import { resolveProjectCreateTarget } from './worktree-project-target'
+
+function readySetup(overrides: Partial<ProjectHostSetup>): ProjectHostSetup {
+  return {
+    id: 'setup-id',
+    projectId: 'github:stablyai/orca',
+    hostId: 'local',
+    repoId: 'repo-id',
+    path: '/repo',
+    displayName: 'orca',
+    kind: 'git',
+    setupState: 'ready',
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides
+  } as ProjectHostSetup
+}
+
+function clientReturning(setups: ProjectHostSetup[]): never {
+  return {
+    call: async (method: string) => {
+      if (method !== 'projectHostSetup.list') {
+        throw new Error(`unexpected method: ${method}`)
+      }
+      return { result: { setups } }
+    }
+  } as never
+}
+
+const flagsFor = (host: string): Map<string, string | boolean> =>
+  new Map<string, string | boolean>([
+    ['project', 'github:stablyai/orca'],
+    ['host', host]
+  ])
+
+describe('resolveProjectCreateTarget host selection', () => {
+  it('refuses, and names the candidates, when several setups could match', async () => {
+    const client = clientReturning([
+      readySetup({ id: 'a', repoId: 'repo-a', path: 'C:\\Users\\neil\\orca\\orca' }),
+      readySetup({ id: 'b', repoId: 'repo-b', path: 'C:\\orca\\orca' })
+    ])
+
+    const failure = resolveProjectCreateTarget(flagsFor('runtime:env-1'), client)
+
+    await expect(failure).rejects.toThrow(/2 ready setups/)
+    // The whole point: the user is shown which checkouts were in play.
+    await expect(failure).rejects.toThrow(/C:\\Users\\neil\\orca\\orca/)
+  })
+
+  it('resolves when exactly one setup could match', async () => {
+    const client = clientReturning([readySetup({ id: 'only', repoId: 'repo-only' })])
+
+    await expect(resolveProjectCreateTarget(flagsFor('runtime:env-1'), client)).resolves.toEqual(
+      expect.objectContaining({ repoSelector: 'id:repo-only' })
+    )
+  })
+
+  it('prefers an exact host match over local-stamped candidates', async () => {
+    // An exact match is unambiguous even when local-stamped rows also exist, so it must not
+    // be dragged into the ambiguity check.
+    const client = clientReturning([
+      readySetup({ id: 'local-a', repoId: 'repo-local-a' }),
+      readySetup({ id: 'local-b', repoId: 'repo-local-b' }),
+      readySetup({ id: 'exact', repoId: 'repo-exact', hostId: 'runtime:env-1' })
+    ])
+
+    await expect(resolveProjectCreateTarget(flagsFor('runtime:env-1'), client)).resolves.toEqual(
+      expect.objectContaining({ repoSelector: 'id:repo-exact' })
+    )
+  })
+})

--- a/src/cli/worktree-project-target.test.ts
+++ b/src/cli/worktree-project-target.test.ts
@@ -54,7 +54,8 @@ describe('resolveProjectCreateTarget host selection', () => {
 
     await expect(failure).rejects.toThrow(/2 ready setups/)
     // The whole point: the user is shown which checkouts were in play.
-    await expect(failure).rejects.toThrow(/C:\\Users\\neil\\orca\\orca/)
+    // Backslashes are doubled by the escaping — the cost of an injective rendering.
+    await expect(failure).rejects.toThrow(/C:\\\\Users\\\\neil\\\\orca/)
   })
 
   it('resolves when exactly one setup could match', async () => {
@@ -128,5 +129,31 @@ describe('resolveProjectCreateTarget host selection', () => {
     await expect(failure).rejects.toThrow(/one\\u2028forged/)
     // Distinct ids must not collapse onto the same rendering.
     await expect(failure).rejects.toThrow(/a\\u202e31m/)
+  })
+
+  it('escapes backslashes so the rendering is injective and ids copy back', async () => {
+    // Without escaping backslash first, a literal "\\u000a" and a real newline render the same,
+    // and the id the error tells the user to pass becomes ambiguous.
+    const client = clientReturning([
+      readySetup({ id: 'lit\\u000a', repoId: 'repo-a', path: '/one' }),
+      readySetup({ id: 'real\n', repoId: 'repo-b', path: '/two' })
+    ])
+    const flags = new Map<string, string | boolean>([['project', 'github:stablyai/orca']])
+    const failure = resolveProjectCreateTarget(flags, client)
+
+    await expect(failure).rejects.toThrow(/lit\\\\u000a/)
+    await expect(failure).rejects.toThrow(/real\\u000a/)
+  })
+
+  it('escapes zero-width and directionality characters', async () => {
+    const client = clientReturning([
+      readySetup({ id: 'a\u200b', repoId: 'repo-a', path: '/one\ufeff' }),
+      readySetup({ id: 'b', repoId: 'repo-b', path: '/two' })
+    ])
+    const flags = new Map<string, string | boolean>([['project', 'github:stablyai/orca']])
+    const failure = resolveProjectCreateTarget(flags, client)
+
+    await expect(failure).rejects.toThrow(/a\\u200b/)
+    await expect(failure).rejects.toThrow(/one\\ufeff/)
   })
 })

--- a/src/cli/worktree-project-target.ts
+++ b/src/cli/worktree-project-target.ts
@@ -127,7 +127,7 @@ export async function resolveProjectCreateTarget(
   }
   const ready = result.result.setups.filter(isReadyProjectHostSetup)
   const setup = projectHostSetupId
-    ? ready.find((candidate) => candidate.id === projectHostSetupId)
+    ? findReadySetupById(ready, projectHostSetupId)
     : findReadySetupOnHost(ready, projectId, host)
   if (!setup) {
     throw new RuntimeClientError(
@@ -141,6 +141,18 @@ export async function resolveProjectCreateTarget(
     repoSelector: `id:${setup.repoId}`,
     setup
   }
+}
+
+function findReadySetupById(
+  setups: readonly ProjectHostSetup[],
+  requestedId: string
+): ProjectHostSetup | undefined {
+  // Raw ids take precedence for backwards compatibility; the escaped form is only a fallback for
+  // ids copied from the ambiguity diagnostic.
+  return (
+    setups.find((candidate) => candidate.id === requestedId) ??
+    setups.find((candidate) => terminalSafe(candidate.id) === requestedId)
+  )
 }
 
 // Why: setup ids and paths are persisted metadata printed straight to a terminal, so anything that

--- a/src/cli/worktree-project-target.ts
+++ b/src/cli/worktree-project-target.ts
@@ -61,9 +61,34 @@ function findReadySetupOnHost(
   if (!host) {
     return candidates[0]
   }
-  return (
-    candidates.find((candidate) => normalizeExecutionHostId(candidate.hostId) === host.id) ??
-    candidates.find((candidate) => hostFilterMatchesHostId(host, candidate.hostId))
+  const exact = candidates.filter(
+    (candidate) => normalizeExecutionHostId(candidate.hostId) === host.id
+  )
+  if (exact.length > 0) {
+    return pickSingleSetup(exact, projectId, host)
+  }
+  // Why: `local` means "the box that answered", which is the same machine as `runtime:<id>` only
+  // when the command already runs there. Picking one of several silently aimed repo creation at an
+  // unrelated checkout (STA-6080), so an ambiguous fallback must be refused, not guessed.
+  const fallback = candidates.filter((candidate) => hostFilterMatchesHostId(host, candidate.hostId))
+  if (fallback.length > 0) {
+    return pickSingleSetup(fallback, projectId, host)
+  }
+  return undefined
+}
+
+function pickSingleSetup(
+  matches: readonly ProjectHostSetup[],
+  projectId: string | undefined,
+  host: ParsedExecutionHost
+): ProjectHostSetup {
+  if (matches.length === 1) {
+    return matches[0]
+  }
+  const listed = matches.map((candidate) => `  ${candidate.path}`).join('\n')
+  throw new RuntimeClientError(
+    'invalid_argument',
+    `"${projectId}" has ${matches.length} ready setups on ${host.id}; pass --project-host-setup <id> to choose one:\n${listed}`
   )
 }
 

--- a/src/cli/worktree-project-target.ts
+++ b/src/cli/worktree-project-target.ts
@@ -59,7 +59,9 @@ function findReadySetupOnHost(
 ): ProjectHostSetup | undefined {
   const candidates = setups.filter((candidate) => candidate.projectId === projectId)
   if (!host) {
-    return candidates[0]
+    // Why: ordering here is persistence order, not a user choice, so "first" is arbitrary — the
+    // same silent pick that aimed creation at an unrelated checkout, just without a --host to blame.
+    return candidates.length > 0 ? pickSingleSetup(candidates, projectId, undefined) : undefined
   }
   const exact = candidates.filter(
     (candidate) => normalizeExecutionHostId(candidate.hostId) === host.id
@@ -80,15 +82,18 @@ function findReadySetupOnHost(
 function pickSingleSetup(
   matches: readonly ProjectHostSetup[],
   projectId: string | undefined,
-  host: ParsedExecutionHost
+  host: ParsedExecutionHost | undefined
 ): ProjectHostSetup {
   if (matches.length === 1) {
     return matches[0]
   }
-  const listed = matches.map((candidate) => `  ${candidate.path}`).join('\n')
+  // Why: list the id alongside the path — the remedy we name is `--project-host-setup <id>`, so an
+  // error that prints only paths asks for something it never showed.
+  const listed = matches.map((candidate) => `  ${candidate.id}  ${candidate.path}`).join('\n')
+  const where = host ? ` on ${host.id}` : ''
   throw new RuntimeClientError(
     'invalid_argument',
-    `"${projectId}" has ${matches.length} ready setups on ${host.id}; pass --project-host-setup <id> to choose one:\n${listed}`
+    `"${projectId}" has ${matches.length} ready setups${where}; pass --project-host-setup <id> to choose one:\n${listed}`
   )
 }
 

--- a/src/cli/worktree-project-target.ts
+++ b/src/cli/worktree-project-target.ts
@@ -89,7 +89,9 @@ function pickSingleSetup(
   }
   // Why: list the id alongside the path — the remedy we name is `--project-host-setup <id>`, so an
   // error that prints only paths asks for something it never showed.
-  const listed = matches.map((candidate) => `  ${candidate.id}  ${candidate.path}`).join('\n')
+  const listed = matches
+    .map((candidate) => `  ${terminalSafe(candidate.id)}  ${terminalSafe(candidate.path)}`)
+    .join('\n')
   const where = host ? ` on ${host.id}` : ''
   throw new RuntimeClientError(
     'invalid_argument',
@@ -137,4 +139,12 @@ export async function resolveProjectCreateTarget(
     repoSelector: `id:${setup.repoId}`,
     setup
   }
+}
+
+// Why: setup paths and ids come from persisted metadata and may legally contain newlines or
+// control characters. This message is printed straight to a terminal, so an unescaped value could
+// forge a line or emit ANSI. Keep it readable rather than fully quoting.
+function terminalSafe(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[\u0000-\u001f\u007f]/g, '?')
 }

--- a/src/cli/worktree-project-target.ts
+++ b/src/cli/worktree-project-target.ts
@@ -142,13 +142,14 @@ export async function resolveProjectCreateTarget(
 }
 
 // Why: setup ids and paths are persisted metadata printed straight to a terminal, so anything that
-// can move the cursor, change colour, or reorder text could forge a setup line. Covers C0 and DEL,
-// C1 (U+009B is an 8-bit CSI, equivalent to `ESC [`), the Unicode line/paragraph separators, and
-// the bidi overrides. Escaped rather than dropped so two distinct values never render alike.
+// can move the cursor, change colour, reorder text, or hide characters could forge a setup line.
+// Backslash is escaped FIRST — otherwise an id containing the literal text "\u000a" renders
+// identically to one containing a real newline, and the printed id could not be copied back into
+// --project-host-setup unambiguously.
 function terminalSafe(value: string): string {
-  return value.replace(
+  return value.replace(/\\/g, '\\\\').replace(
     // eslint-disable-next-line no-control-regex
-    /[\u0000-\u001f\u007f-\u009f\u2028\u2029\u202a-\u202e\u2066-\u2069]/g,
+    /[\u0000-\u001f\u007f-\u009f\u200b-\u200f\u2028\u2029\u202a-\u202e\u2060-\u2069\ufeff]/g,
     (ch) => `\\u${ch.codePointAt(0)!.toString(16).padStart(4, '0')}`
   )
 }

--- a/src/cli/worktree-project-target.ts
+++ b/src/cli/worktree-project-target.ts
@@ -141,10 +141,14 @@ export async function resolveProjectCreateTarget(
   }
 }
 
-// Why: setup paths and ids come from persisted metadata and may legally contain newlines or
-// control characters. This message is printed straight to a terminal, so an unescaped value could
-// forge a line or emit ANSI. Keep it readable rather than fully quoting.
+// Why: setup ids and paths are persisted metadata printed straight to a terminal, so anything that
+// can move the cursor, change colour, or reorder text could forge a setup line. Covers C0 and DEL,
+// C1 (U+009B is an 8-bit CSI, equivalent to `ESC [`), the Unicode line/paragraph separators, and
+// the bidi overrides. Escaped rather than dropped so two distinct values never render alike.
 function terminalSafe(value: string): string {
-  // eslint-disable-next-line no-control-regex
-  return value.replace(/[\u0000-\u001f\u007f]/g, '?')
+  return value.replace(
+    // eslint-disable-next-line no-control-regex
+    /[\u0000-\u001f\u007f-\u009f\u2028\u2029\u202a-\u202e\u2066-\u2069]/g,
+    (ch) => `\\u${ch.codePointAt(0)!.toString(16).padStart(4, '0')}`
+  )
 }

--- a/src/cli/worktree-project-target.ts
+++ b/src/cli/worktree-project-target.ts
@@ -1,4 +1,8 @@
 import { normalizeExecutionHostId, type ParsedExecutionHost } from '../shared/execution-host'
+import {
+  chooseReadyProjectHostSetup,
+  isReadyProjectHostSetup
+} from '../shared/project-host-setup-choice'
 import type { ProjectHostSetup } from '../shared/project-types'
 import { hostFilterMatchesHostId, resolveHostFlagTarget } from './execution-host-flag'
 import type { RuntimeClient } from './runtime-client'
@@ -59,9 +63,7 @@ function findReadySetupOnHost(
 ): ProjectHostSetup | undefined {
   const candidates = setups.filter((candidate) => candidate.projectId === projectId)
   if (!host) {
-    // Why: ordering here is persistence order, not a user choice, so "first" is arbitrary — the
-    // same silent pick that aimed creation at an unrelated checkout, just without a --host to blame.
-    return candidates.length > 0 ? pickSingleSetup(candidates, projectId, undefined) : undefined
+    return pickSingleSetup(candidates, projectId, undefined)
   }
   const exact = candidates.filter(
     (candidate) => normalizeExecutionHostId(candidate.hostId) === host.id
@@ -70,32 +72,32 @@ function findReadySetupOnHost(
     return pickSingleSetup(exact, projectId, host)
   }
   // Why: `local` means "the box that answered", which is the same machine as `runtime:<id>` only
-  // when the command already runs there. Picking one of several silently aimed repo creation at an
-  // unrelated checkout (STA-6080), so an ambiguous fallback must be refused, not guessed.
-  const fallback = candidates.filter((candidate) => hostFilterMatchesHostId(host, candidate.hostId))
-  if (fallback.length > 0) {
-    return pickSingleSetup(fallback, projectId, host)
-  }
-  return undefined
+  // when the command already runs there, so the broader filter is a last resort, not a peer.
+  return pickSingleSetup(
+    candidates.filter((candidate) => hostFilterMatchesHostId(host, candidate.hostId)),
+    projectId,
+    host
+  )
 }
 
 function pickSingleSetup(
   matches: readonly ProjectHostSetup[],
   projectId: string | undefined,
   host: ParsedExecutionHost | undefined
-): ProjectHostSetup {
-  if (matches.length === 1) {
-    return matches[0]
+): ProjectHostSetup | undefined {
+  const choice = chooseReadyProjectHostSetup(matches)
+  if (choice.status !== 'ambiguous') {
+    return choice.status === 'single' ? choice.setup : undefined
   }
   // Why: list the id alongside the path — the remedy we name is `--project-host-setup <id>`, so an
   // error that prints only paths asks for something it never showed.
-  const listed = matches
+  const listed = choice.candidates
     .map((candidate) => `  ${terminalSafe(candidate.id)}  ${terminalSafe(candidate.path)}`)
     .join('\n')
   const where = host ? ` on ${host.id}` : ''
   throw new RuntimeClientError(
     'invalid_argument',
-    `"${projectId}" has ${matches.length} ready setups${where}; pass --project-host-setup <id> to choose one:\n${listed}`
+    `"${projectId}" has ${choice.candidates.length} ready setups${where}; pass --project-host-setup <id> to choose one:\n${listed}`
   )
 }
 
@@ -123,7 +125,7 @@ export async function resolveProjectCreateTarget(
     }
     throw error
   }
-  const ready = result.result.setups.filter((candidate) => candidate.setupState === 'ready')
+  const ready = result.result.setups.filter(isReadyProjectHostSetup)
   const setup = projectHostSetupId
     ? ready.find((candidate) => candidate.id === projectHostSetupId)
     : findReadySetupOnHost(ready, projectId, host)

--- a/src/renderer/src/components/NewWorkspaceComposerCard.run-target-choice.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.run-target-choice.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import NewWorkspaceComposerCard from './NewWorkspaceComposerCard'
+import type { ProjectHostSetupOption } from '@/lib/project-host-setup-options'
+import type { WorkspaceCreationTarget } from '@/lib/project-host-workspace-target'
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({
+        closeModal: vi.fn(),
+        openModal: vi.fn(),
+        openSettingsPage: vi.fn(),
+        openSettingsTarget: vi.fn(),
+        setRuntimeEnvironmentStatus: vi.fn(),
+        activeModal: 'none',
+        settings: { defaultTuiAgent: null, disabledTuiAgents: [] },
+        updateSettings: vi.fn(),
+        projects: [],
+        repos: []
+      }),
+    { getState: () => ({}) }
+  )
+}))
+
+vi.mock('@/components/contextual-tours/use-contextual-tour', () => ({
+  useContextualTour: vi.fn()
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/agent/AgentCombobox', () => ({
+  default: () => <button type="button">Agent picker</button>
+}))
+
+vi.mock('@/components/sidebar/AddRemoteHostDialog', () => ({ AddRemoteHostDialog: () => null }))
+
+vi.mock('@/components/new-workspace/SetProjectLocationDialog', () => ({
+  SetProjectLocationDialog: () => null
+}))
+
+vi.mock('@/components/sparse/SparseCheckoutPresetSelect', () => ({ default: () => null }))
+
+vi.mock('@/components/new-workspace/SmartWorkspaceNameField', () => ({
+  default: () => <input aria-label="workspace name" />
+}))
+
+vi.mock('@/components/new-workspace/ProjectCombobox', () => ({
+  default: () => <div data-testid="project-combobox" />
+}))
+
+const PROJECT_ID = 'github:stablyai/orca'
+
+function readyOption(id: string, path: string): ProjectHostSetupOption {
+  return {
+    kind: 'ready',
+    id,
+    projectId: PROJECT_ID,
+    hostId: 'local',
+    repoId: id,
+    label: 'Local Mac',
+    detail: 'orca',
+    path
+  }
+}
+
+const sameHostOptions = [
+  readyOption('setup-main', '/Users/alice/orca'),
+  readyOption('setup-side', '/Users/alice/worktrees/pr-1')
+]
+
+const sameHostCandidates = [
+  { projectHostSetupId: 'setup-main', repoId: 'setup-main' },
+  { projectHostSetupId: 'setup-side', repoId: 'setup-side' }
+] as unknown as readonly WorkspaceCreationTarget[]
+
+function renderCard(
+  overrides: Partial<React.ComponentProps<typeof NewWorkspaceComposerCard>> = {}
+): HTMLDivElement {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    createRoot(container).render(
+      <NewWorkspaceComposerCard
+        quickAgent={null}
+        onQuickAgentChange={() => {}}
+        eligibleRepos={[]}
+        repoId=""
+        projectOptions={[]}
+        selectedProjectId={PROJECT_ID}
+        selectedRepoIsGit
+        onRepoChange={() => {}}
+        onProjectChange={() => {}}
+        primaryActionLabel="Create workspace"
+        name=""
+        onNameValueChange={() => {}}
+        onSmartGitHubItemSelect={() => {}}
+        onSmartGitLabItemSelect={() => {}}
+        onSmartBranchSelect={() => {}}
+        onSmartLinearIssueSelect={() => {}}
+        smartNameSelection={null}
+        onClearSmartNameSelection={() => {}}
+        canReuseSelectedBranch={false}
+        reuseSelectedBranch={false}
+        onReuseSelectedBranchChange={() => {}}
+        branchNameOverride={undefined}
+        onBranchNameOverrideChange={() => {}}
+        parentWorktreeId={null}
+        onParentWorktreeIdChange={() => {}}
+        forkPushWarning={null}
+        detectedAgentIds={null}
+        onOpenAgentSettings={() => {}}
+        advancedOpen={false}
+        onToggleAdvanced={() => {}}
+        createDisabled={false}
+        projectError={null}
+        creating={false}
+        onCreate={() => {}}
+        note=""
+        onNoteChange={() => {}}
+        setupConfig={null}
+        requiresExplicitSetupChoice={false}
+        setupDecision={null}
+        onSetupDecisionChange={() => {}}
+        setupAgentStartupPolicy="start-immediately"
+        onSetupAgentStartupPolicyChange={() => {}}
+        shouldWaitForSetupCheck={false}
+        resolvedSetupDecision={null}
+        createError={null}
+        selectedRepoConnectionId={null}
+        selectedRepoSshStatus={null}
+        selectedRepoRequiresConnection={false}
+        selectedRepoConnectInProgress={false}
+        onConnectSelectedRepo={async () => {}}
+        canUseSparseCheckout={false}
+        sparsePresets={[]}
+        sparseSelectedPresetId={null}
+        onSparseSelectPreset={() => {}}
+        branchesEnabled={false}
+        setupControlsEnabled={false}
+        sparseControlsEnabled={false}
+        {...overrides}
+      />
+    )
+  })
+  return container
+}
+
+function runTargetField(container: HTMLElement): HTMLElement | null {
+  return container.querySelector<HTMLElement>('div[data-run-target-combobox-root="true"]')
+}
+
+describe('NewWorkspaceComposerCard run target choice (STA-6080)', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    container?.remove()
+    container = null
+    document.body.innerHTML = ''
+  })
+
+  it('asks which checkout to use instead of pre-selecting one', () => {
+    container = renderCard({
+      projectHostSetupOptions: sameHostOptions,
+      selectedProjectHostSetupId: null,
+      runTargetChoiceCandidates: sameHostCandidates
+    })
+
+    expect(container.textContent).toContain('This project is set up in 2 places')
+    const field = runTargetField(container)
+    expect(field?.textContent).not.toContain('/Users/alice/orca')
+    expect(field?.querySelector('input')?.placeholder).toBe('Choose target')
+  })
+
+  it('offers every same-host checkout as its own row', () => {
+    container = renderCard({
+      projectHostSetupOptions: sameHostOptions,
+      selectedProjectHostSetupId: null,
+      runTargetChoiceCandidates: sameHostCandidates
+    })
+
+    act(() => runTargetField(container as HTMLElement)?.click())
+
+    const paths = [...document.body.querySelectorAll<HTMLElement>('[role="option"]')].map(
+      (row) => row.textContent ?? ''
+    )
+    expect(paths.some((text) => text.includes('/Users/alice/orca'))).toBe(true)
+    expect(paths.some((text) => text.includes('/Users/alice/worktrees/pr-1'))).toBe(true)
+  })
+
+  it('stays silent when a single setup resolved', () => {
+    container = renderCard({
+      projectHostSetupOptions: [sameHostOptions[0]],
+      selectedProjectHostSetupId: 'setup-main',
+      runTargetChoiceCandidates: null
+    })
+
+    expect(container.textContent).not.toContain('This project is set up in')
+    expect(runTargetField(container)?.textContent).toContain('/Users/alice/orca')
+  })
+})

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -277,6 +277,7 @@ export default function NewWorkspaceComposerCard(
           {...props}
           projectOptions={projectOptions}
           projectHostSetupOptions={projectHostSetupOptions}
+          runTargetChoiceCandidates={props.runTargetChoiceCandidates ?? null}
           ephemeralVmRecipes={ephemeralVmRecipes}
           projectDescriptionId={projectDescriptionId}
           onAddProject={handleAddProject}

--- a/src/renderer/src/components/new-workspace/NewWorkspaceComposerProjectSection.tsx
+++ b/src/renderer/src/components/new-workspace/NewWorkspaceComposerProjectSection.tsx
@@ -36,6 +36,7 @@ type NewWorkspaceComposerProjectSectionProps = Pick<
   focusNameInput: () => void
   shouldShowRunTargetPicker: boolean
   projectHostSetupOptions: NewWorkspaceComposerCardProps['projectHostSetupOptions']
+  runTargetChoiceCandidates: NewWorkspaceComposerCardProps['runTargetChoiceCandidates']
   ephemeralVmRecipes: EphemeralVmRecipeOption[]
   handleProjectHostSetupChange: (setupId: string) => void
   handleAddSshHost: () => void
@@ -61,6 +62,7 @@ export function NewWorkspaceComposerProjectSection({
   focusNameInput,
   shouldShowRunTargetPicker,
   projectHostSetupOptions,
+  runTargetChoiceCandidates,
   selectedProjectHostSetupId,
   handleProjectHostSetupChange,
   ephemeralVmRecipes,
@@ -153,6 +155,15 @@ export function NewWorkspaceComposerProjectSection({
             onConnectHost={handleConnectRunTargetHost}
             onSetLocation={handleSetLocation}
           />
+          {runTargetChoiceCandidates && runTargetChoiceCandidates.length > 1 ? (
+            <p role="status" className="text-[11px] text-muted-foreground">
+              {translate(
+                'auto.components.NewWorkspaceComposerCard.runTargetChoiceRequired',
+                'This project is set up in {{value0}} places. Choose which one to create in.',
+                { value0: runTargetChoiceCandidates.length }
+              )}
+            </p>
+          ) : null}
           {ephemeralVmRecipeError ? (
             <p className="whitespace-pre-line text-[11px] text-destructive">
               {ephemeralVmRecipeError}

--- a/src/renderer/src/components/new-workspace/RunTargetCombobox.tsx
+++ b/src/renderer/src/components/new-workspace/RunTargetCombobox.tsx
@@ -83,8 +83,9 @@ export default function RunTargetCombobox({
     () => hostOptions.filter((option) => option.kind === 'ready'),
     [hostOptions]
   )
-  const selectedHost =
-    readyHostOptions.find((option) => option.id === hostValue) ?? readyHostOptions[0] ?? null
+  // Why (STA-6080): with no setup chosen, painting the first ready row named a checkout the user
+  // never picked, and it is not the one creation would land in either.
+  const selectedHost = readyHostOptions.find((option) => option.id === hostValue) ?? null
   const selectedRecipe = recipes.find((recipe) => recipe.id === recipeValue) ?? null
   const armedRow = rows.find((row) => row.key === armedKey) ?? rows[0] ?? null
   // Only a committed selection paints the field; typing replaces it.

--- a/src/renderer/src/components/new-workspace/new-workspace-composer-card-props.ts
+++ b/src/renderer/src/components/new-workspace/new-workspace-composer-card-props.ts
@@ -4,6 +4,7 @@ import type {
   NeedsSetupProjectHostOption,
   ProjectHostSetupOption
 } from '@/lib/project-host-setup-options'
+import type { WorkspaceCreationTarget } from '@/lib/project-host-workspace-target'
 import type { SetupConfig } from '@/lib/new-workspace'
 import type { WorkspaceCreateErrorDisplay } from '@/lib/workspace-create-error-format'
 import type { SmartNameMode } from '@/components/new-workspace/smart-workspace-source-results'
@@ -49,6 +50,7 @@ export type NewWorkspaceComposerCardProps = {
   selectedEphemeralVmRecipeId?: string | null
   onEphemeralVmRecipeChange?: (recipeId: string | null) => void
   ephemeralVmRecipeError?: string | null
+  runTargetChoiceCandidates?: readonly WorkspaceCreationTarget[] | null
   repoBackedSearchRepos?: readonly RepoOption[]
   repoBackedSourcesDisabled?: boolean
   allowSmartNameAddProject?: boolean

--- a/src/renderer/src/hooks/composer-state/composer-card-contract.ts
+++ b/src/renderer/src/hooks/composer-state/composer-card-contract.ts
@@ -12,6 +12,7 @@ export type ComposerCardSourceProps = Pick<
   | 'ephemeralVmRecipes'
   | 'selectedEphemeralVmRecipeId'
   | 'ephemeralVmRecipeError'
+  | 'runTargetChoiceCandidates'
   | 'name'
   | 'branchNameOverride'
   | 'parentWorktreeId'

--- a/src/renderer/src/hooks/composer-state/composer-card-props.ts
+++ b/src/renderer/src/hooks/composer-state/composer-card-props.ts
@@ -129,6 +129,7 @@ export function buildComposerCardProps(state: ComposerModel) {
     sourceIntentBlocksCreate,
     requiresExplicitSetupChoice,
     hasSetupDecision: Boolean(setupDecision),
+    hasUnresolvedRunTargetChoice: (runTargetChoiceCandidates?.length ?? 0) > 1,
     selectedRepoRequiresConnection,
     sparseError
   }

--- a/src/renderer/src/hooks/composer-state/composer-card-props.ts
+++ b/src/renderer/src/hooks/composer-state/composer-card-props.ts
@@ -21,6 +21,7 @@ export function buildComposerCardProps(state: ComposerModel) {
     detectedAgentIds,
     eligibleRepos,
     ephemeralVmRecipeError,
+    runTargetChoiceCandidates,
     ephemeralVmRecipes,
     ephemeralVmsEnabled,
     filteredLinkItems,
@@ -153,6 +154,7 @@ export function buildComposerCardProps(state: ComposerModel) {
     onEphemeralVmRecipeChange: setSelectedEphemeralVmRecipeId,
     ephemeralVmRecipeError:
       isProjectGroupTarget || !ephemeralVmsEnabled ? null : ephemeralVmRecipeError,
+    runTargetChoiceCandidates: isProjectGroupTarget ? null : runTargetChoiceCandidates,
     repoBackedSearchRepos: isProjectGroupTarget ? folderSourceRepos : undefined,
     repoBackedSourcesDisabled: isProjectGroupTarget ? folderSourceRepos.length === 0 : false,
     allowSmartNameAddProject: !isProjectGroupTarget,

--- a/src/renderer/src/hooks/composer-state/composer-source-state.ts
+++ b/src/renderer/src/hooks/composer-state/composer-source-state.ts
@@ -89,6 +89,7 @@ export function useComposerSourceState(
     setReuseSelectedBranch: target.workspaceIdentityState.setReuseSelectedBranch,
     setSelectedProjectHostSetupOverrideId:
       target.initialTargetState.setSelectedProjectHostSetupOverrideId,
+    setSelectedProjectIdOverride: target.initialTargetState.setSelectedProjectIdOverride,
     setSparseDirectories: target.asyncComposerState.setSparseDirectories,
     setSparseEnabled: target.asyncComposerState.setSparseEnabled,
     setSparseSelectedPresetId: target.asyncComposerState.setSparseSelectedPresetId,
@@ -124,6 +125,9 @@ export function useComposerSourceState(
     setReuseEligibleBranch: target.workspaceIdentityState.setReuseEligibleBranch,
     setReuseSelectedBranch: target.workspaceIdentityState.setReuseSelectedBranch,
     setSelectedProjectGroupId: target.initialTargetState.setSelectedProjectGroupId,
+    setSelectedProjectHostSetupOverrideId:
+      target.initialTargetState.setSelectedProjectHostSetupOverrideId,
+    setSelectedProjectIdOverride: target.initialTargetState.setSelectedProjectIdOverride,
     setSparseDirectories: target.asyncComposerState.setSparseDirectories,
     setSparseEnabled: target.asyncComposerState.setSparseEnabled,
     setSparseSelectedPresetId: target.asyncComposerState.setSparseSelectedPresetId,

--- a/src/renderer/src/hooks/composer-state/composer-target-input-contracts.ts
+++ b/src/renderer/src/hooks/composer-state/composer-target-input-contracts.ts
@@ -14,6 +14,7 @@ export type ComposerRuntimeTargetSelectionInput = Pick<
   | 'repos'
   | 'selectedProjectGroup'
   | 'selectedProjectHostSetupOverrideId'
+  | 'selectedProjectIdOverride'
   | 'settings'
   | 'sshConnectionStates'
   | 'workspaceHostScope'

--- a/src/renderer/src/hooks/composer-state/composer-target-state.ts
+++ b/src/renderer/src/hooks/composer-state/composer-target-state.ts
@@ -47,6 +47,7 @@ export function useComposerTargetState(
     repos: composerTargetStore.repos,
     selectedProjectGroup: initialTargetState.selectedProjectGroup,
     selectedProjectHostSetupOverrideId: initialTargetState.selectedProjectHostSetupOverrideId,
+    selectedProjectIdOverride: initialTargetState.selectedProjectIdOverride,
     settings: composerTargetStore.settings,
     sshConnectionStates: composerTargetStore.sshConnectionStates,
     workspaceHostScope: composerTargetStore.workspaceHostScope,

--- a/src/renderer/src/hooks/composer-state/initial-target-model.ts
+++ b/src/renderer/src/hooks/composer-state/initial-target-model.ts
@@ -21,6 +21,8 @@ export type ComposerInitialTargetModel = {
   resolvedInitialRepoId: string
   internalRepoId: string
   setInternalRepoId: React.Dispatch<React.SetStateAction<string>>
+  selectedProjectIdOverride: string | null
+  setSelectedProjectIdOverride: React.Dispatch<React.SetStateAction<string | null>>
   selectedProjectHostSetupOverrideId: string | null
   setSelectedProjectHostSetupOverrideId: React.Dispatch<React.SetStateAction<string | null>>
   initialFolderProjectGroupId: string | null

--- a/src/renderer/src/hooks/composer-state/initial-target-state.ts
+++ b/src/renderer/src/hooks/composer-state/initial-target-state.ts
@@ -95,6 +95,15 @@ export function useComposerInitialTargetState(input: ComposerInitialTargetStateI
 
   const [internalRepoId, setInternalRepoId] = useState<string>(resolvedInitialRepoId)
 
+  // Why (STA-6080): several ready setups can match the seeded project. Keep the project selected
+  // while no checkout is chosen so the run-target picker can ask which one, instead of creating the
+  // workspace in whichever setup was stored first.
+  const [selectedProjectIdOverride, setSelectedProjectIdOverride] = useState<string | null>(
+    resolvedInitialWorkspaceTarget.status === 'ambiguous'
+      ? resolvedInitialWorkspaceTarget.projectId
+      : null
+  )
+
   const [selectedProjectHostSetupOverrideId, setSelectedProjectHostSetupOverrideId] = useState<
     string | null
   >(
@@ -168,6 +177,8 @@ export function useComposerInitialTargetState(input: ComposerInitialTargetStateI
     resolvedInitialRepoId,
     internalRepoId,
     setInternalRepoId,
+    selectedProjectIdOverride,
+    setSelectedProjectIdOverride,
     selectedProjectHostSetupOverrideId,
     setSelectedProjectHostSetupOverrideId,
     initialFolderProjectGroupId,

--- a/src/renderer/src/hooks/composer-state/project-target-actions.test.ts
+++ b/src/renderer/src/hooks/composer-state/project-target-actions.test.ts
@@ -5,6 +5,7 @@ import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type { Project, ProjectHostSetup } from '../../../../shared/project-types'
 import type { Repo } from '../../../../shared/repo-types'
 import { useProjectTargetActions } from './project-target-actions'
+import { useTargetChangeActions } from './target-change-actions'
 
 const PROJECT_ID = 'github:stablyai/orca'
 
@@ -112,5 +113,100 @@ describe('composer project switch with several ready setups (STA-6080)', () => {
     })
     expect(spies.setSelectedProjectIdOverride).toHaveBeenCalledWith(null)
     expect(spies.setRepoId).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * The folder branch of the composer leaves `repoId` on the group's source repo, so switching back to
+ * a project whose setup uses that same repo id hits `handleRepoChange`'s same-id early return and
+ * would keep the folder's source state. `forceResetStartFrom: isProjectGroupTarget` is what forces
+ * the reset through. Exercised against the real `handleRepoChange`, not its source text.
+ */
+function renderProjectSwitchFromFolderTarget(isProjectGroupTarget: boolean) {
+  const spies = {
+    setBaseBranch: vi.fn(),
+    setLinkedIssue: vi.fn(),
+    setRepoId: vi.fn(),
+    setSparseEnabled: vi.fn(),
+    setStartFromResetHint: vi.fn()
+  }
+  const noop = vi.fn()
+  const shared = {
+    linkedWorkItem: null,
+    setBranchNameOverride: noop,
+    setBranchNameOverridePreservesNameEdits: noop,
+    setForkPushWarning: noop,
+    setLinkedGitLabIssue: noop,
+    setLinkedGitLabMR: noop,
+    setLinkedPR: noop,
+    setLinkedTaskSourceContext: noop,
+    setLinkedWorkItem: noop,
+    setProjectError: noop,
+    setPushTarget: noop,
+    setReuseEligibleBranch: noop,
+    setReuseSelectedBranch: noop,
+    setSelectedProjectHostSetupOverrideId: noop,
+    setSelectedProjectIdOverride: noop,
+    setSparseDirectories: noop,
+    setSparseSelectedPresetId: noop,
+    ...spies
+  }
+  const { result } = renderHook(() => {
+    const { handleRepoChange } = useTargetChangeActions({
+      baseBranch: undefined,
+      branchAutoNameRef: { current: null },
+      decisions: { retargetGitHubPrStartPointSelection: (selection: unknown) => selection },
+      folderSourceRepos: [],
+      hostOptions: [],
+      projectHostSetupOptions: [],
+      // Why: the folder branch already parked the composer on this repo id, so the project switch
+      // resolves to the same value and only the forced reset can clear the folder's state.
+      repoId: 'orca-main',
+      selectedRepoProjectId: PROJECT_ID,
+      setCompareBaseRef: noop,
+      smartGitHubPrStartPointSelectionRef: { current: null },
+      ...shared
+    } as unknown as Parameters<typeof useTargetChangeActions>[0])
+    return useProjectTargetActions({
+      actionableHostIds: new Set<ExecutionHostId>(['local']),
+      eligibleRepos: [makeRepo('orca-main', '/checkouts/main')],
+      handleRepoChange,
+      initialProjectGroupAppliedRef: { current: false },
+      isProjectGroupTarget,
+      projectGroups: [],
+      projectHostSetups: [makeSetup('setup-main', 'local', 'orca-main', '/checkouts/main')],
+      projects: [project],
+      repos: [],
+      selectedWorkspaceTarget: { status: 'unavailable', reason: 'project-has-no-ready-setup' },
+      workspaceHostScope: 'all',
+      setSelectedProjectGroupId: noop,
+      ...shared
+    } as unknown as Parameters<typeof useProjectTargetActions>[0])
+  })
+  return { handleProjectChange: result.current.handleProjectChange, spies }
+}
+
+describe('returning from a folder target to a repo with the same id', () => {
+  it('forces the repo-scoped source reset', () => {
+    const { handleProjectChange, spies } = renderProjectSwitchFromFolderTarget(true)
+
+    handleProjectChange(PROJECT_ID)
+
+    expect(spies.setRepoId).toHaveBeenCalledWith('orca-main')
+    expect(spies.setSparseEnabled).toHaveBeenCalledWith(false)
+    expect(spies.setLinkedIssue).toHaveBeenCalledWith('')
+    expect(spies.setBaseBranch).toHaveBeenCalledWith(undefined)
+    expect(spies.setStartFromResetHint).toHaveBeenCalledWith(null)
+  })
+
+  it('leaves the source state alone when the composer was already on that repo', () => {
+    const { handleProjectChange, spies } = renderProjectSwitchFromFolderTarget(false)
+
+    handleProjectChange(PROJECT_ID)
+
+    expect(spies.setRepoId).toHaveBeenCalledWith('orca-main')
+    expect(spies.setSparseEnabled).not.toHaveBeenCalled()
+    expect(spies.setLinkedIssue).not.toHaveBeenCalled()
+    expect(spies.setBaseBranch).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/hooks/composer-state/project-target-actions.test.ts
+++ b/src/renderer/src/hooks/composer-state/project-target-actions.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import type { Project, ProjectHostSetup } from '../../../../shared/project-types'
+import type { Repo } from '../../../../shared/repo-types'
+import { useProjectTargetActions } from './project-target-actions'
+
+const PROJECT_ID = 'github:stablyai/orca'
+
+function makeRepo(id: string, path: string, overrides: Partial<Repo> = {}): Repo {
+  return { id, path, displayName: id, badgeColor: '#000000', addedAt: 1, ...overrides }
+}
+
+function makeSetup(id: string, hostId: ExecutionHostId, repoId: string, path: string) {
+  return {
+    id,
+    projectId: PROJECT_ID,
+    hostId,
+    repoId,
+    path,
+    displayName: repoId,
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 1
+  } satisfies ProjectHostSetup
+}
+
+const project: Project = {
+  id: PROJECT_ID,
+  displayName: 'orca',
+  badgeColor: '#000000',
+  sourceRepoIds: ['orca-main', 'orca-side'],
+  createdAt: 1,
+  updatedAt: 1
+}
+
+function renderProjectTargetActions(projectHostSetups: readonly ProjectHostSetup[]) {
+  const spies = {
+    handleRepoChange: vi.fn(),
+    setProjectError: vi.fn(),
+    setRepoId: vi.fn(),
+    setSelectedProjectGroupId: vi.fn(),
+    setSelectedProjectHostSetupOverrideId: vi.fn(),
+    setSelectedProjectIdOverride: vi.fn()
+  }
+  const noop = vi.fn()
+  const { result } = renderHook(() =>
+    useProjectTargetActions({
+      actionableHostIds: new Set<ExecutionHostId>(['local']),
+      eligibleRepos: [
+        makeRepo('orca-main', '/checkouts/main'),
+        makeRepo('orca-side', '/checkouts/side')
+      ],
+      initialProjectGroupAppliedRef: { current: false },
+      isProjectGroupTarget: false,
+      linkedWorkItem: null,
+      projectGroups: [],
+      projectHostSetups,
+      projects: [project],
+      repos: [],
+      selectedWorkspaceTarget: { status: 'unavailable', reason: 'project-has-no-ready-setup' },
+      workspaceHostScope: 'all',
+      setBaseBranch: noop,
+      setBranchNameOverride: noop,
+      setBranchNameOverridePreservesNameEdits: noop,
+      setForkPushWarning: noop,
+      setLinkedGitLabIssue: noop,
+      setLinkedGitLabMR: noop,
+      setLinkedIssue: noop,
+      setLinkedPR: noop,
+      setLinkedTaskSourceContext: noop,
+      setLinkedWorkItem: noop,
+      setPushTarget: noop,
+      setReuseEligibleBranch: noop,
+      setReuseSelectedBranch: noop,
+      setSparseDirectories: noop,
+      setSparseEnabled: noop,
+      setSparseSelectedPresetId: noop,
+      setStartFromResetHint: noop,
+      ...spies
+    } as unknown as Parameters<typeof useProjectTargetActions>[0])
+  )
+  return { handleProjectChange: result.current.handleProjectChange, spies }
+}
+
+describe('composer project switch with several ready setups (STA-6080)', () => {
+  it('keeps the project selected and asks for a checkout instead of creating in the first', () => {
+    const { handleProjectChange, spies } = renderProjectTargetActions([
+      makeSetup('setup-main', 'local', 'orca-main', '/checkouts/main'),
+      makeSetup('setup-side', 'local', 'orca-side', '/checkouts/side')
+    ])
+
+    handleProjectChange(PROJECT_ID)
+
+    expect(spies.setSelectedProjectIdOverride).toHaveBeenCalledWith(PROJECT_ID)
+    expect(spies.setSelectedProjectHostSetupOverrideId).toHaveBeenCalledWith(null)
+    expect(spies.setRepoId).toHaveBeenCalledWith('')
+    expect(spies.handleRepoChange).not.toHaveBeenCalled()
+  })
+
+  it('resolves silently when the project has one ready setup', () => {
+    const { handleProjectChange, spies } = renderProjectTargetActions([
+      makeSetup('setup-main', 'local', 'orca-main', '/checkouts/main')
+    ])
+
+    handleProjectChange(PROJECT_ID)
+
+    expect(spies.handleRepoChange).toHaveBeenCalledWith('orca-main', {
+      forceResetStartFrom: false
+    })
+    expect(spies.setSelectedProjectIdOverride).toHaveBeenCalledWith(null)
+    expect(spies.setRepoId).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/composer-state/project-target-actions.ts
+++ b/src/renderer/src/hooks/composer-state/project-target-actions.ts
@@ -28,6 +28,8 @@ type ProjectTargetActionsInput = Pick<
   | 'setReuseEligibleBranch'
   | 'setReuseSelectedBranch'
   | 'setSelectedProjectGroupId'
+  | 'setSelectedProjectHostSetupOverrideId'
+  | 'setSelectedProjectIdOverride'
   | 'setSparseDirectories'
   | 'setSparseEnabled'
   | 'setSparseSelectedPresetId'
@@ -44,7 +46,7 @@ import {
 } from '@/lib/new-workspace-project-options'
 import { translate } from '@/i18n/i18n'
 import { getFolderSourceRepos } from '@/components/sidebar/folder-workspace-composer-helpers'
-import { resolveWorkspaceCreationRepoId } from '@/lib/project-host-workspace-target'
+import { resolveWorkspaceCreationTarget } from '@/lib/project-host-workspace-target'
 
 export function useProjectTargetActions(input: ProjectTargetActionsInput) {
   const {
@@ -74,6 +76,8 @@ export function useProjectTargetActions(input: ProjectTargetActionsInput) {
     setReuseEligibleBranch,
     setReuseSelectedBranch,
     setSelectedProjectGroupId,
+    setSelectedProjectHostSetupOverrideId,
+    setSelectedProjectIdOverride,
     setSparseDirectories,
     setSparseEnabled,
     setSparseSelectedPresetId,
@@ -104,6 +108,7 @@ export function useProjectTargetActions(input: ProjectTargetActionsInput) {
         }
         const nextSourceRepo = getFolderSourceRepos(repos, projectGroups, nextProjectGroup)[0]
         setSelectedProjectGroupId(nextProjectGroup.id)
+        setSelectedProjectIdOverride(null)
         setProjectError(null)
         setRepoId(nextSourceRepo?.id ?? '')
         setLinkedIssue('')
@@ -133,7 +138,7 @@ export function useProjectTargetActions(input: ProjectTargetActionsInput) {
       const preferredHostId =
         selectedWorkspaceTarget.status === 'ready' ? selectedWorkspaceTarget.target.hostId : null
       // Why: pass the current host as a preference (focusedHostScope), not a hard hostId — pinning made selecting a project set up only on another host a silent no-op.
-      const nextRepoId = resolveWorkspaceCreationRepoId({
+      const nextTarget = resolveWorkspaceCreationTarget({
         eligibleRepos,
         projects,
         projectHostSetups,
@@ -141,10 +146,20 @@ export function useProjectTargetActions(input: ProjectTargetActionsInput) {
         focusedHostScope: preferredHostId ?? workspaceHostScope,
         actionableHostIds
       })
-      if (!nextRepoId) {
+      if (nextTarget.status === 'ambiguous') {
+        // Why (STA-6080): keep the project selected with no checkout chosen, so the run-target
+        // picker asks which of its setups to create in rather than taking the stored-first one.
+        setSelectedProjectIdOverride(nextTarget.projectId ?? projectId)
+        setSelectedProjectHostSetupOverrideId(null)
+        setRepoId('')
+        setProjectError(null)
         return
       }
-      handleRepoChange(nextRepoId, { forceResetStartFrom: isProjectGroupTarget })
+      if (nextTarget.status !== 'ready') {
+        return
+      }
+      setSelectedProjectIdOverride(null)
+      handleRepoChange(nextTarget.target.repoId, { forceResetStartFrom: isProjectGroupTarget })
     },
     [
       eligibleRepos,
@@ -175,6 +190,8 @@ export function useProjectTargetActions(input: ProjectTargetActionsInput) {
       setReuseEligibleBranch,
       setReuseSelectedBranch,
       setSelectedProjectGroupId,
+      setSelectedProjectHostSetupOverrideId,
+      setSelectedProjectIdOverride,
       setSparseDirectories,
       setSparseEnabled,
       setSparseSelectedPresetId,

--- a/src/renderer/src/hooks/composer-state/runtime-target-model.ts
+++ b/src/renderer/src/hooks/composer-state/runtime-target-model.ts
@@ -8,7 +8,10 @@ import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { AgentStartupShell } from '../../../../shared/tui-agent-startup-shell'
 import type { NewWorkspaceProjectOption } from '@/lib/new-workspace-project-options'
 import type { ProjectHostSetupOption } from '@/lib/project-host-setup-options'
-import type { WorkspaceCreationTargetResolution } from '@/lib/project-host-workspace-target'
+import type {
+  WorkspaceCreationTarget,
+  WorkspaceCreationTargetResolution
+} from '@/lib/project-host-workspace-target'
 
 export type ComposerRuntimeTargetModel = {
   isProjectGroupTarget: boolean
@@ -31,6 +34,7 @@ export type ComposerRuntimeTargetModel = {
   folderDetectedIds: TuiAgent[] | null
   folderDetectedAgentIds: Set<TuiAgent> | null
   selectedWorkspaceTarget: WorkspaceCreationTargetResolution
+  runTargetChoiceCandidates: readonly WorkspaceCreationTarget[] | null
   selectedRepo: Repo | undefined
   selectedRepoIsGit: boolean
   selectedRepoExecutionHostId: ExecutionHostId | null

--- a/src/renderer/src/hooks/composer-state/runtime-target-selection.test.ts
+++ b/src/renderer/src/hooks/composer-state/runtime-target-selection.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import type { Project, ProjectHostSetup } from '../../../../shared/project-types'
+import type { Repo } from '../../../../shared/repo-types'
+
+vi.mock('@/hooks/useDetectedAgents', () => ({ useDetectedAgents: () => ({ detectedIds: null }) }))
+vi.mock('@/components/sidebar/folder-workspace-composer-path-status', () => ({
+  useFolderWorkspaceComposerPathStatus: () => ({
+    pathStatusBlocksCreate: false,
+    pathStatusProjectError: null
+  })
+}))
+vi.mock('@/hooks/useEphemeralVmRecipeOptions', () => ({
+  useEphemeralVmRecipeOptions: () => ({
+    recipes: [],
+    selectedRecipeId: null,
+    setSelectedRecipeId: vi.fn(),
+    error: null
+  })
+}))
+
+import { useComposerRuntimeTargetSelection } from './runtime-target-selection'
+
+const PROJECT_ID = 'github:stablyai/orca'
+
+function makeRepo(id: string, path: string): Repo {
+  return { id, path, displayName: id, badgeColor: '#000000', addedAt: 1 }
+}
+
+function makeSetup(id: string, repoId: string, path: string): ProjectHostSetup {
+  return {
+    id,
+    projectId: PROJECT_ID,
+    hostId: 'local' as ExecutionHostId,
+    repoId,
+    path,
+    displayName: repoId,
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+const projects: Project[] = [
+  {
+    id: PROJECT_ID,
+    displayName: 'orca',
+    badgeColor: '#000000',
+    sourceRepoIds: ['orca-main', 'orca-side'],
+    createdAt: 1,
+    updatedAt: 1
+  }
+]
+
+const eligibleRepos = [
+  makeRepo('orca-main', '/checkouts/main'),
+  makeRepo('orca-side', '/checkouts/side')
+]
+
+const projectHostSetups = [
+  makeSetup('setup-main', 'orca-main', '/checkouts/main'),
+  makeSetup('setup-side', 'orca-side', '/checkouts/side')
+]
+
+function renderSelection(overrides: Record<string, unknown>) {
+  return renderHook(() =>
+    useComposerRuntimeTargetSelection({
+      actionableHostIds: new Set<ExecutionHostId>(['local']),
+      activeRepoId: null,
+      eligibleRepos,
+      hostOptions: [{ id: 'local', kind: 'local', label: 'Local Mac', health: 'local' }],
+      initialEphemeralVmRecipeId: null,
+      projectGroups: [],
+      projectHostSetups,
+      projects,
+      repoId: '',
+      repos: eligibleRepos,
+      selectedProjectGroup: null,
+      selectedProjectHostSetupOverrideId: null,
+      selectedProjectIdOverride: null,
+      settings: null,
+      sshConnectionStates: new Map(),
+      workspaceHostScope: 'all',
+      worktreesByRepo: new Map(),
+      ...overrides
+    } as unknown as Parameters<typeof useComposerRuntimeTargetSelection>[0])
+  )
+}
+
+describe('composer run-target selection with several ready setups (STA-6080)', () => {
+  it('keeps the project on screen and offers every checkout while the choice is open', () => {
+    const { result } = renderSelection({ selectedProjectIdOverride: PROJECT_ID })
+
+    expect(result.current.selectedWorkspaceTarget.status).toBe('ambiguous')
+    expect(result.current.runTargetChoiceCandidates).toHaveLength(2)
+    expect(result.current.selectedRepoProjectId).toBe(PROJECT_ID)
+    expect(result.current.selectedProjectHostSetupId).toBeNull()
+    expect(result.current.selectedRepo).toBeUndefined()
+    expect(
+      result.current.projectHostSetupOptions
+        .filter((option) => option.kind === 'ready')
+        .map((option) => option.id)
+    ).toEqual(['setup-main', 'setup-side'])
+  })
+
+  it('resolves the chosen setup once the user picks one', () => {
+    const { result } = renderSelection({
+      selectedProjectIdOverride: PROJECT_ID,
+      selectedProjectHostSetupOverrideId: 'setup-side',
+      repoId: 'orca-side'
+    })
+
+    expect(result.current.selectedWorkspaceTarget.status).toBe('ready')
+    expect(result.current.runTargetChoiceCandidates).toBeNull()
+    expect(result.current.selectedProjectHostSetupId).toBe('setup-side')
+    expect(result.current.selectedRepo?.path).toBe('/checkouts/side')
+  })
+})

--- a/src/renderer/src/hooks/composer-state/runtime-target-selection.ts
+++ b/src/renderer/src/hooks/composer-state/runtime-target-selection.ts
@@ -33,6 +33,7 @@ export function useComposerRuntimeTargetSelection(input: ComposerRuntimeTargetSe
     repos,
     selectedProjectGroup,
     selectedProjectHostSetupOverrideId,
+    selectedProjectIdOverride,
     settings,
     sshConnectionStates,
     workspaceHostScope,
@@ -99,6 +100,9 @@ export function useComposerRuntimeTargetSelection(input: ComposerRuntimeTargetSe
         projects,
         projectHostSetups,
         draftRepoId: repoId,
+        // Why (STA-6080): the project outlives the checkout choice — without it an unanswered
+        // ambiguity would fall back to whichever repo the draft resolver reached for.
+        projectId: selectedProjectIdOverride,
         projectHostSetupId: selectedProjectHostSetupOverrideId,
         focusedHostScope: workspaceHostScope,
         actionableHostIds
@@ -110,9 +114,13 @@ export function useComposerRuntimeTargetSelection(input: ComposerRuntimeTargetSe
       projects,
       repoId,
       selectedProjectHostSetupOverrideId,
+      selectedProjectIdOverride,
       workspaceHostScope
     ]
   )
+
+  const runTargetChoiceCandidates =
+    selectedWorkspaceTarget.status === 'ambiguous' ? selectedWorkspaceTarget.candidates : null
 
   const selectedRepo =
     selectedWorkspaceTarget.status === 'ready' && selectedWorkspaceTarget.target.repoId === repoId
@@ -158,7 +166,11 @@ export function useComposerRuntimeTargetSelection(input: ComposerRuntimeTargetSe
   })
 
   const selectedRepoProjectId =
-    selectedWorkspaceTarget.status === 'ready' ? selectedWorkspaceTarget.target.projectId : null
+    selectedWorkspaceTarget.status === 'ready'
+      ? selectedWorkspaceTarget.target.projectId
+      : selectedWorkspaceTarget.status === 'ambiguous'
+        ? selectedWorkspaceTarget.projectId
+        : null
 
   const selectedProjectId = selectedProjectGroup
     ? `project-group:${selectedProjectGroup.id}`
@@ -261,6 +273,7 @@ export function useComposerRuntimeTargetSelection(input: ComposerRuntimeTargetSe
     folderDetectedIds,
     folderDetectedAgentIds,
     selectedWorkspaceTarget,
+    runTargetChoiceCandidates,
     selectedRepo,
     selectedRepoIsGit,
     selectedRepoExecutionHostId,

--- a/src/renderer/src/hooks/composer-state/target-change-actions.test.ts
+++ b/src/renderer/src/hooks/composer-state/target-change-actions.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { ProjectHostSetupOption } from '@/lib/project-host-setup-options'
+import { useTargetChangeActions } from './target-change-actions'
+
+const readyOption: ProjectHostSetupOption = {
+  kind: 'ready',
+  id: 'setup-side',
+  projectId: 'github:stablyai/orca',
+  hostId: 'local',
+  repoId: 'orca-side',
+  label: 'Local Mac',
+  detail: 'orca',
+  path: '/checkouts/side'
+}
+
+function renderTargetChangeActions() {
+  const spies = {
+    setRepoId: vi.fn(),
+    setProjectError: vi.fn(),
+    setSelectedProjectHostSetupOverrideId: vi.fn(),
+    setSelectedProjectIdOverride: vi.fn()
+  }
+  const noop = vi.fn()
+  const { result } = renderHook(() =>
+    useTargetChangeActions({
+      baseBranch: undefined,
+      branchAutoNameRef: { current: null },
+      decisions: { retargetGitHubPrStartPointSelection: (selection: unknown) => selection },
+      folderSourceRepos: [],
+      hostOptions: [],
+      linkedWorkItem: null,
+      projectHostSetupOptions: [readyOption],
+      repoId: '',
+      selectedRepoProjectId: 'github:stablyai/orca',
+      setBaseBranch: noop,
+      setBranchNameOverride: noop,
+      setBranchNameOverridePreservesNameEdits: noop,
+      setCompareBaseRef: noop,
+      setForkPushWarning: noop,
+      setLinkedGitLabIssue: noop,
+      setLinkedGitLabMR: noop,
+      setLinkedIssue: noop,
+      setLinkedPR: noop,
+      setLinkedTaskSourceContext: noop,
+      setLinkedWorkItem: noop,
+      setPushTarget: noop,
+      setReuseEligibleBranch: noop,
+      setReuseSelectedBranch: noop,
+      setSparseDirectories: noop,
+      setSparseEnabled: noop,
+      setSparseSelectedPresetId: noop,
+      setStartFromResetHint: noop,
+      smartGitHubPrStartPointSelectionRef: { current: null },
+      ...spies
+    } as unknown as Parameters<typeof useTargetChangeActions>[0])
+  )
+  return { actions: result.current, spies }
+}
+
+describe('choosing a run target closes the pending checkout question (STA-6080)', () => {
+  it('clears the pending project when a setup is picked', () => {
+    const { actions, spies } = renderTargetChangeActions()
+
+    actions.handleProjectHostSetupChange('setup-side')
+
+    expect(spies.setSelectedProjectHostSetupOverrideId).toHaveBeenCalledWith('setup-side')
+    expect(spies.setSelectedProjectIdOverride).toHaveBeenCalledWith(null)
+    expect(spies.setRepoId).toHaveBeenCalledWith('orca-side')
+  })
+
+  it('clears the pending project when a repo is chosen directly', () => {
+    const { actions, spies } = renderTargetChangeActions()
+
+    actions.handleRepoChange('orca-main')
+
+    expect(spies.setSelectedProjectIdOverride).toHaveBeenCalledWith(null)
+  })
+})

--- a/src/renderer/src/hooks/composer-state/target-change-actions.test.ts
+++ b/src/renderer/src/hooks/composer-state/target-change-actions.test.ts
@@ -15,26 +15,32 @@ const readyOption: ProjectHostSetupOption = {
   path: '/checkouts/side'
 }
 
-function renderTargetChangeActions() {
+function renderTargetChangeActions(currentRepoId = '') {
   const spies = {
     setRepoId: vi.fn(),
     setProjectError: vi.fn(),
     setSelectedProjectHostSetupOverrideId: vi.fn(),
-    setSelectedProjectIdOverride: vi.fn()
+    setSelectedProjectIdOverride: vi.fn(),
+    setSparseEnabled: vi.fn(),
+    setSparseSelectedPresetId: vi.fn(),
+    setBaseBranch: vi.fn()
   }
+  const retargetGitHubPrStartPointSelection = vi.fn(
+    (_selection: unknown, repoId: string) => `retargeted:${repoId}`
+  )
+  const smartGitHubPrStartPointSelectionRef = { current: 'pr-selection' as unknown }
   const noop = vi.fn()
   const { result } = renderHook(() =>
     useTargetChangeActions({
       baseBranch: undefined,
       branchAutoNameRef: { current: null },
-      decisions: { retargetGitHubPrStartPointSelection: (selection: unknown) => selection },
+      decisions: { retargetGitHubPrStartPointSelection },
       folderSourceRepos: [],
       hostOptions: [],
       linkedWorkItem: null,
       projectHostSetupOptions: [readyOption],
-      repoId: '',
+      repoId: currentRepoId,
       selectedRepoProjectId: 'github:stablyai/orca',
-      setBaseBranch: noop,
       setBranchNameOverride: noop,
       setBranchNameOverridePreservesNameEdits: noop,
       setCompareBaseRef: noop,
@@ -49,14 +55,12 @@ function renderTargetChangeActions() {
       setReuseEligibleBranch: noop,
       setReuseSelectedBranch: noop,
       setSparseDirectories: noop,
-      setSparseEnabled: noop,
-      setSparseSelectedPresetId: noop,
       setStartFromResetHint: noop,
-      smartGitHubPrStartPointSelectionRef: { current: null },
+      smartGitHubPrStartPointSelectionRef,
       ...spies
     } as unknown as Parameters<typeof useTargetChangeActions>[0])
   )
-  return { actions: result.current, spies }
+  return { actions: result.current, spies, smartGitHubPrStartPointSelectionRef }
 }
 
 describe('choosing a run target closes the pending checkout question (STA-6080)', () => {
@@ -76,5 +80,35 @@ describe('choosing a run target closes the pending checkout question (STA-6080)'
     actions.handleRepoChange('orca-main')
 
     expect(spies.setSelectedProjectIdOverride).toHaveBeenCalledWith(null)
+  })
+})
+
+/**
+ * Two setups of one project can carry the same repo id (the same repo registered on two hosts), so
+ * switching run target resolves to the repo the composer is already on and trips `handleRepoChange`'s
+ * same-id early return. `forceResetStartFrom: true` at that call is the only thing that still clears
+ * the repo-scoped sparse selection and retargets an in-flight PR start point onto the new host.
+ */
+describe('switching run target to a setup with the same repo id', () => {
+  it('still resets repo-scoped state past the same-id early return', () => {
+    const { actions, spies, smartGitHubPrStartPointSelectionRef } =
+      renderTargetChangeActions('orca-side')
+
+    actions.handleProjectHostSetupChange('setup-side')
+
+    expect(spies.setSparseEnabled).toHaveBeenCalledWith(false)
+    expect(spies.setSparseSelectedPresetId).toHaveBeenCalledWith(null)
+    expect(spies.setBaseBranch).toHaveBeenCalledWith(undefined)
+    expect(smartGitHubPrStartPointSelectionRef.current).toBe('retargeted:orca-side')
+  })
+
+  it('keeps the task source, which is what preserveStartFrom protects', () => {
+    const { actions, spies } = renderTargetChangeActions('orca-side')
+
+    actions.handleProjectHostSetupChange('setup-side')
+
+    // preserveStartFrom keeps the setup override and the linked source; only repo-scoped state goes.
+    expect(spies.setSelectedProjectHostSetupOverrideId).toHaveBeenCalledTimes(1)
+    expect(spies.setSelectedProjectHostSetupOverrideId).toHaveBeenCalledWith('setup-side')
   })
 })

--- a/src/renderer/src/hooks/composer-state/target-change-actions.ts
+++ b/src/renderer/src/hooks/composer-state/target-change-actions.ts
@@ -28,6 +28,7 @@ type TargetChangeActionsInput = Pick<
   | 'setReuseEligibleBranch'
   | 'setReuseSelectedBranch'
   | 'setSelectedProjectHostSetupOverrideId'
+  | 'setSelectedProjectIdOverride'
   | 'setSparseDirectories'
   | 'setSparseEnabled'
   | 'setSparseSelectedPresetId'
@@ -76,6 +77,7 @@ export function useTargetChangeActions(input: TargetChangeActionsInput) {
     setReuseEligibleBranch,
     setReuseSelectedBranch,
     setSelectedProjectHostSetupOverrideId,
+    setSelectedProjectIdOverride,
     setSparseDirectories,
     setSparseEnabled,
     setSparseSelectedPresetId,
@@ -90,6 +92,9 @@ export function useTargetChangeActions(input: TargetChangeActionsInput) {
       options: { preserveStartFrom?: boolean; forceResetStartFrom?: boolean } = {}
     ): void => {
       setProjectError(null)
+      // Why (STA-6080): a chosen checkout answers the pending "which setup?" question — leaving it
+      // pending would re-open it for the old project the next time the setup override is cleared.
+      setSelectedProjectIdOverride(null)
       if (value === repoId && !options.forceResetStartFrom) {
         if (!options.preserveStartFrom) {
           setSelectedProjectHostSetupOverrideId(null)
@@ -189,6 +194,7 @@ export function useTargetChangeActions(input: TargetChangeActionsInput) {
       setSelectedProjectHostSetupOverrideId,
       setSparseDirectories,
       setSparseEnabled,
+      setSelectedProjectIdOverride,
       setSparseSelectedPresetId,
       setStartFromResetHint,
       smartGitHubPrStartPointSelectionRef

--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -453,15 +453,14 @@ describe('useComposerState host-context boundaries', () => {
     expect(section).toContain("branchAutoNameRef.current = ''")
   })
 
-  it('forces repo-scoped source reset when returning from folder target to a repo with the same id', () => {
+  // The caller half — that a project switch passes `forceResetStartFrom: isProjectGroupTarget`, and
+  // that the reset actually runs — is covered behaviourally against the real `handleRepoChange` in
+  // composer-state/project-target-actions.test.ts ("returning from a folder target to a repo with
+  // the same id"), so it survives renaming the local that holds the resolved repo id.
+  it('keeps the same-id early return escapable', () => {
     const handleRepoChange = COMPOSER_SOURCE.targetChange
     expect(handleRepoChange).toContain('forceResetStartFrom?: boolean')
     expect(handleRepoChange).toContain('value === repoId && !options.forceResetStartFrom')
-
-    const handleProjectChange = COMPOSER_SOURCE.projectTarget
-    expect(handleProjectChange).toContain(
-      'handleRepoChange(nextRepoId, { forceResetStartFrom: isProjectGroupTarget })'
-    )
   })
 
   it('keeps a Linear branch override when its workspace-scoped issue survives a repo change', () => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1647,6 +1647,7 @@
         "ephemeralVm": "Per-Workspace Environment",
         "chooseRunTarget": "Choose target",
         "noRunTargets": "No run targets are ready for this project.",
+        "runTargetChoiceRequired": "This project is set up in {{value0}} places. Choose which one to create in.",
         "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe",
         "branchName": "Branch name",
         "branchNamePlaceholder": "feature/my-branch",

--- a/src/renderer/src/lib/new-workspace-create-gates.test.ts
+++ b/src/renderer/src/lib/new-workspace-create-gates.test.ts
@@ -34,6 +34,21 @@ describe('new workspace create gates', () => {
     ).toBe(true)
   })
 
+  it('disables create while the run target choice is unresolved', () => {
+    expect(
+      getFullComposerCreateDisabled({
+        ...readyInput,
+        hasUnresolvedRunTargetChoice: true
+      })
+    ).toBe(true)
+    expect(
+      getQuickComposerCreateDisabled({
+        ...readyInput,
+        hasUnresolvedRunTargetChoice: true
+      })
+    ).toBe(true)
+  })
+
   it('lets quick create submit while background setup and issue probes are pending', () => {
     expect(
       getQuickComposerCreateDisabled({

--- a/src/renderer/src/lib/new-workspace-create-gates.ts
+++ b/src/renderer/src/lib/new-workspace-create-gates.ts
@@ -7,6 +7,7 @@ export type ComposerCreateGateInput = {
   sourceIntentBlocksCreate?: boolean
   requiresExplicitSetupChoice: boolean
   hasSetupDecision: boolean
+  hasUnresolvedRunTargetChoice?: boolean
   selectedRepoRequiresConnection: boolean
   sparseError: string | null
 }
@@ -18,7 +19,8 @@ function hasBlockingCreateState(input: ComposerCreateGateInput): boolean {
     input.creating ||
     input.selectedRepoRequiresConnection ||
     (input.requiresExplicitSetupChoice && !input.hasSetupDecision) ||
-    input.sparseError !== null
+    input.sparseError !== null ||
+    input.hasUnresolvedRunTargetChoice === true
   )
 }
 

--- a/src/renderer/src/lib/project-host-setup-options.test.ts
+++ b/src/renderer/src/lib/project-host-setup-options.test.ts
@@ -219,9 +219,9 @@ describe('buildProjectHostSetupOptions', () => {
     )
   })
 
-  it('collapses duplicate ready setups on one host to the setup creation actually uses', () => {
-    // Why: a linked worktree added as its own project projected a second ready `local` setup for the
-    // same project, which rendered as repeated identical "Local Mac" rows separated only by path.
+  it('offers every ready setup on one host so the sibling checkouts stay reachable', () => {
+    // Why (STA-6080): a linked worktree added as its own project projects a second ready `local`
+    // setup. Collapsing them left creation aimed at whichever came first, with no way to pick another.
     const options = buildProjectHostSetupOptions({
       projectId: 'project-1',
       eligibleRepos: [repo('main-checkout'), repo('worktree-a'), repo('worktree-b')],
@@ -236,18 +236,24 @@ describe('buildProjectHostSetupOptions', () => {
     })
 
     expect(options).toEqual([
-      expect.objectContaining({ id: 'main', kind: 'ready', label: LOCAL_HOST_LABEL })
+      expect.objectContaining({
+        id: 'main',
+        kind: 'ready',
+        label: LOCAL_HOST_LABEL,
+        path: '/Users/dev/projects/orca'
+      }),
+      expect.objectContaining({ id: 'dup-a', kind: 'ready', path: '/Users/dev/worktrees/pr-1908' }),
+      expect.objectContaining({ id: 'dup-b', kind: 'ready', path: '/Users/dev/worktrees/pr-3235' })
     ])
   })
 
-  it('keeps one ready choice per host when a project is set up on several hosts', () => {
+  it('lists each host once when a project has a single ready setup per host', () => {
     const options = buildProjectHostSetupOptions({
       projectId: 'project-1',
       eligibleRepos: [repo('local-repo'), repo('local-dup'), repo('remote-repo')],
       hosts: [host('local'), host('ssh:builder', { label: 'Builder' })],
       projectHostSetups: [
         setup('local', 'project-1', 'local', 'local-repo'),
-        setup('local-dup', 'project-1', 'local', 'local-dup'),
         setup('remote', 'project-1', 'ssh:builder', 'remote-repo')
       ]
     })

--- a/src/renderer/src/lib/project-host-setup-options.ts
+++ b/src/renderer/src/lib/project-host-setup-options.ts
@@ -112,6 +112,8 @@ function getPendingSetupByHost(
   return setups
 }
 
+// Why (STA-6080): every ready setup gets its own row, keyed by path. Collapsing same-host duplicates
+// hid the sibling checkouts a legacy profile can hold, so creation landed in one of them unnamed.
 function buildReadySetupOptions({
   projectId,
   projectHostSetups,
@@ -142,23 +144,6 @@ function buildReadySetupOptions({
       detail: setup.displayName,
       path: setup.path
     }))
-    .filter(dedupeByHost())
-}
-
-// Why: a project resolves to at most one setup per host — resolveWorkspaceCreationTarget takes the
-// first project+host match and ignores the rest, so extra same-host setups are unreachable. Legacy
-// profiles can still hold them (a linked worktree added as its own project projects a second local
-// setup), which rendered as repeated identical "Local Mac" rows. Keep the first in input order so
-// the row shown is the one workspace creation actually uses.
-function dedupeByHost(): (option: ReadyProjectHostSetupOption) => boolean {
-  const seenHosts = new Set<ExecutionHostId>()
-  return (option) => {
-    if (seenHosts.has(option.hostId)) {
-      return false
-    }
-    seenHosts.add(option.hostId)
-    return true
-  }
 }
 
 function buildNeedsSetupOptions({

--- a/src/renderer/src/lib/project-host-workspace-target.test.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.test.ts
@@ -578,7 +578,7 @@ describe('STA-6080: the renderer never silently picks a checkout', () => {
       projects: [project],
       projectHostSetups: [
         makeSetup('setup-pending', 'github:stablyai/orca', 'local', 'orca-main', {
-          setupState: 'pending'
+          setupState: 'setting-up'
         }),
         sameHostSetups[0]
       ],

--- a/src/renderer/src/lib/project-host-workspace-target.test.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.test.ts
@@ -572,6 +572,26 @@ describe('STA-6080: the renderer never silently picks a checkout', () => {
     })
   })
 
+  it('ignores a pending duplicate when a ready setup exists on the explicit host', () => {
+    const resolution = resolveWorkspaceCreationTarget({
+      eligibleRepos: repos,
+      projects: [project],
+      projectHostSetups: [
+        makeSetup('setup-pending', 'github:stablyai/orca', 'local', 'orca-main', {
+          setupState: 'pending'
+        }),
+        sameHostSetups[0]
+      ],
+      projectId: 'github:stablyai/orca',
+      hostId: 'local'
+    })
+
+    expect(resolution).toMatchObject({
+      status: 'ready',
+      target: { projectHostSetupId: 'setup-main' }
+    })
+  })
+
   it('resolves to the setup the caller named even with a same-host sibling present', () => {
     const resolution = resolveWorkspaceCreationTarget({
       eligibleRepos: repos,

--- a/src/renderer/src/lib/project-host-workspace-target.test.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.test.ts
@@ -147,7 +147,7 @@ describe('project-host workspace target resolution', () => {
     })
   })
 
-  it('resolves duplicate repo ids to a ready setup when no host is focused', () => {
+  it('reports both hosts when a duplicate repo id has no focused host to break the tie', () => {
     const localRepo = makeRepo('orca', { path: '/local/orca' })
     const sshRepo = makeRepo('orca', { path: '/remote/orca', connectionId: 'builder' })
     const projects = [makeProject('github:stablyai/orca', ['orca'])]
@@ -166,13 +166,12 @@ describe('project-host workspace target resolution', () => {
         actionableHostIds: new Set(['local', 'ssh:builder'])
       })
     ).toMatchObject({
-      status: 'ready',
-      target: {
-        hostId: 'local',
-        projectHostSetupId: 'local-setup',
-        repoId: 'orca',
-        repo: { path: '/local/orca' }
-      }
+      status: 'ambiguous',
+      projectId: 'github:stablyai/orca',
+      candidates: [
+        { projectHostSetupId: 'local-setup', repo: { path: '/local/orca' } },
+        { projectHostSetupId: 'ssh-setup', repo: { path: '/remote/orca' } }
+      ]
     })
   })
 
@@ -206,10 +205,9 @@ describe('project-host workspace target resolution', () => {
     })
   })
 
-  it('canonicalizes a stale same-host setup id to the setup the picker shows', () => {
-    // Why: the run-target picker renders one row per host. A draft persisted before that collapse
-    // can still name a duplicate local setup; creation must land in the displayed path, not a
-    // transient worktree path the user never sees.
+  it('creates in the named setup rather than a same-host sibling', () => {
+    // Why: the picker offers every ready setup, so a named duplicate is a peer the user can have
+    // chosen. Redirecting to a sibling created the workspace in a path the caller never asked for.
     const repos = [makeRepo('orca-main'), makeRepo('orca-worktree')]
     const projects = [makeProject('github:stablyai/orca', ['orca-main', 'orca-worktree'])]
     const projectHostSetups = [
@@ -226,7 +224,7 @@ describe('project-host workspace target resolution', () => {
 
     expect(resolution).toMatchObject({
       status: 'ready',
-      target: { projectHostSetupId: 'orca-main', repoId: 'orca-main', hostId: 'local' }
+      target: { projectHostSetupId: 'orca-worktree', repoId: 'orca-worktree', hostId: 'local' }
     })
   })
 
@@ -472,5 +470,162 @@ describe('project-host workspace target resolution', () => {
         reason: 'project-not-set-up-on-host'
       })
     })
+  })
+})
+
+describe('STA-6080: the renderer never silently picks a checkout', () => {
+  const project = makeProject('github:stablyai/orca', ['orca-main', 'orca-side'])
+  const repos = [
+    makeRepo('orca-main', { path: '/checkouts/main' }),
+    makeRepo('orca-side', { path: '/checkouts/side' })
+  ]
+  const sameHostSetups = [
+    makeSetup('setup-main', 'github:stablyai/orca', 'local', 'orca-main', {
+      path: '/checkouts/main'
+    }),
+    makeSetup('setup-side', 'github:stablyai/orca', 'local', 'orca-side', {
+      path: '/checkouts/side'
+    })
+  ]
+
+  it('reports both candidates when one host holds two ready setups', () => {
+    const resolution = resolveWorkspaceCreationTarget({
+      eligibleRepos: repos,
+      projects: [project],
+      projectHostSetups: sameHostSetups,
+      projectId: 'github:stablyai/orca'
+    })
+
+    expect(resolution).toMatchObject({
+      status: 'ambiguous',
+      projectId: 'github:stablyai/orca',
+      candidates: [
+        { projectHostSetupId: 'setup-main', repo: { path: '/checkouts/main' } },
+        { projectHostSetupId: 'setup-side', repo: { path: '/checkouts/side' } }
+      ]
+    })
+  })
+
+  it('reports both candidates when the project is ready on two hosts', () => {
+    const resolution = resolveWorkspaceCreationTarget({
+      eligibleRepos: [repos[0], makeRepo('orca-side', { connectionId: 'builder' })],
+      projects: [project],
+      projectHostSetups: [
+        sameHostSetups[0],
+        makeSetup('setup-side', 'github:stablyai/orca', 'ssh:builder', 'orca-side', {
+          path: '/checkouts/side'
+        })
+      ],
+      projectId: 'github:stablyai/orca'
+    })
+
+    expect(resolution).toMatchObject({
+      status: 'ambiguous',
+      candidates: [{ projectHostSetupId: 'setup-main' }, { projectHostSetupId: 'setup-side' }]
+    })
+  })
+
+  it('still resolves silently when a single ready setup matches', () => {
+    const resolution = resolveWorkspaceCreationTarget({
+      eligibleRepos: repos,
+      projects: [project],
+      projectHostSetups: [sameHostSetups[0]],
+      projectId: 'github:stablyai/orca'
+    })
+
+    expect(resolution).toMatchObject({
+      status: 'ready',
+      target: { projectHostSetupId: 'setup-main', repo: { path: '/checkouts/main' } }
+    })
+  })
+
+  it('lets a focused host break the tie instead of asking', () => {
+    const resolution = resolveWorkspaceCreationTarget({
+      eligibleRepos: [repos[0], makeRepo('orca-side', { connectionId: 'builder' })],
+      projects: [project],
+      projectHostSetups: [
+        sameHostSetups[0],
+        makeSetup('setup-side', 'github:stablyai/orca', 'ssh:builder', 'orca-side')
+      ],
+      projectId: 'github:stablyai/orca',
+      focusedHostScope: 'ssh:builder'
+    })
+
+    expect(resolution).toMatchObject({
+      status: 'ready',
+      target: { projectHostSetupId: 'setup-side' }
+    })
+  })
+
+  it('reports the candidates when an explicit host still holds two ready setups', () => {
+    const resolution = resolveWorkspaceCreationTarget({
+      eligibleRepos: repos,
+      projects: [project],
+      projectHostSetups: sameHostSetups,
+      projectId: 'github:stablyai/orca',
+      hostId: 'local'
+    })
+
+    expect(resolution).toMatchObject({
+      status: 'ambiguous',
+      candidates: [{ projectHostSetupId: 'setup-main' }, { projectHostSetupId: 'setup-side' }]
+    })
+  })
+
+  it('resolves to the setup the caller named even with a same-host sibling present', () => {
+    const resolution = resolveWorkspaceCreationTarget({
+      eligibleRepos: repos,
+      projects: [project],
+      projectHostSetups: sameHostSetups,
+      projectHostSetupId: 'setup-side'
+    })
+
+    expect(resolution).toMatchObject({
+      status: 'ready',
+      target: { projectHostSetupId: 'setup-side', repo: { path: '/checkouts/side' } }
+    })
+  })
+
+  it('reports a null project when the candidates span projects', () => {
+    const resolution = resolveWorkspaceCreationTarget({
+      eligibleRepos: [
+        makeRepo('orca', { path: '/local/orca' }),
+        makeRepo('orca', { path: '/remote/orca', connectionId: 'builder' })
+      ],
+      projects: [makeProject('project-a', ['orca']), makeProject('project-b', ['orca'])],
+      projectHostSetups: [
+        makeSetup('setup-main', 'project-a', 'local', 'orca'),
+        makeSetup('setup-side', 'project-b', 'ssh:builder', 'orca')
+      ],
+      draftRepoId: 'orca',
+      focusedHostScope: 'all'
+    })
+
+    expect(resolution).toMatchObject({ status: 'ambiguous', projectId: null })
+  })
+
+  it('reports the candidates when the named host holds two ready setups', () => {
+    const resolution = resolveWorkspaceCreationTarget({
+      eligibleRepos: repos,
+      projects: [project],
+      projectHostSetups: sameHostSetups,
+      hostId: 'local'
+    })
+
+    expect(resolution).toMatchObject({
+      status: 'ambiguous',
+      candidates: [{ projectHostSetupId: 'setup-main' }, { projectHostSetupId: 'setup-side' }]
+    })
+  })
+
+  it('resolves the repo id to nothing while the choice is open', () => {
+    expect(
+      resolveWorkspaceCreationRepoId({
+        eligibleRepos: repos,
+        projects: [project],
+        projectHostSetups: sameHostSetups,
+        projectId: 'github:stablyai/orca'
+      })
+    ).toBe('')
   })
 })

--- a/src/renderer/src/lib/project-host-workspace-target.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.ts
@@ -183,12 +183,6 @@ export function resolveWorkspaceCreationTarget(
   }
 
   if (projectId && hostId) {
-    const hostSetup = setups.find(
-      (setup) => setup.projectId === projectId && setup.hostId === hostId
-    )
-    if (hostSetup && !isReadyProjectHostSetup(hostSetup)) {
-      return { status: 'unavailable', reason: 'setup-not-ready' }
-    }
     const choice = chooseReadyTarget(
       setups,
       reposById,
@@ -199,6 +193,18 @@ export function resolveWorkspaceCreationTarget(
     }
     if (choice.status === 'single') {
       return { status: 'ready', target: choice.setup }
+    }
+    // A legacy profile can retain a pending row alongside a ready duplicate. The ready row is
+    // actionable; report pending only when no ready setup exists for the requested host.
+    if (
+      setups.some(
+        (setup) =>
+          setup.projectId === projectId &&
+          setup.hostId === hostId &&
+          !isReadyProjectHostSetup(setup)
+      )
+    ) {
+      return { status: 'unavailable', reason: 'setup-not-ready' }
     }
     return { status: 'unavailable', reason: 'project-not-set-up-on-host' }
   }

--- a/src/renderer/src/lib/project-host-workspace-target.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.ts
@@ -4,6 +4,10 @@ import {
   type ExecutionHostId,
   type ExecutionHostScope
 } from '../../../shared/execution-host'
+import {
+  chooseReadyProjectHostSetup,
+  isReadyProjectHostSetup
+} from '../../../shared/project-host-setup-choice'
 import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
 import type { Project, ProjectHostSetup } from '../../../shared/project-types'
 import type { Repo } from '../../../shared/repo-types'
@@ -20,6 +24,13 @@ export type WorkspaceCreationTarget = {
 
 export type WorkspaceCreationTargetResolution =
   | { status: 'ready'; target: WorkspaceCreationTarget }
+  | {
+      // Why (STA-6080): several ready setups matched, and storage order is not a choice. Callers
+      // surface the candidates instead of creating the workspace in whichever one came first.
+      status: 'ambiguous'
+      projectId: string | null
+      candidates: readonly WorkspaceCreationTarget[]
+    }
   | {
       status: 'unavailable'
       reason:
@@ -74,10 +85,6 @@ function getProjectSetupModel({
   }
 }
 
-function isReadySetup(setup: ProjectHostSetup): boolean {
-  return setup.setupState === 'ready'
-}
-
 function createTarget(
   setup: ProjectHostSetup,
   reposById: ReadonlyMap<string, readonly Repo[]>
@@ -99,21 +106,32 @@ function createTarget(
   }
 }
 
-function findReadySetupTarget(
+function chooseReadyTarget(
   setups: readonly ProjectHostSetup[],
   reposById: ReadonlyMap<string, readonly Repo[]>,
   predicate: (setup: ProjectHostSetup) => boolean
-): WorkspaceCreationTarget | null {
+) {
+  const targets: WorkspaceCreationTarget[] = []
   for (const setup of setups) {
-    if (!isReadySetup(setup) || !predicate(setup)) {
+    if (!isReadyProjectHostSetup(setup) || !predicate(setup)) {
       continue
     }
     const target = createTarget(setup, reposById)
     if (target) {
-      return target
+      targets.push(target)
     }
   }
-  return null
+  return chooseReadyProjectHostSetup(targets)
+}
+
+function ambiguousResolution(
+  candidates: readonly WorkspaceCreationTarget[]
+): WorkspaceCreationTargetResolution {
+  const [first] = candidates
+  const sharedProjectId = candidates.every((candidate) => candidate.projectId === first.projectId)
+    ? first.projectId
+    : null
+  return { status: 'ambiguous', projectId: sharedProjectId, candidates }
 }
 
 export function resolveWorkspaceCreationTarget(
@@ -148,20 +166,14 @@ export function resolveWorkspaceCreationTarget(
       // so fail closed and let them re-pick a host.
       return { status: 'unavailable', reason: 'setup-not-found' }
     }
-    if (!isReadySetup(setup)) {
+    if (!isReadyProjectHostSetup(setup)) {
       return { status: 'unavailable', reason: 'setup-not-ready' }
     }
-    // Why: a project resolves to one setup per host, and the run-target picker shows only the first.
-    // A stale draft can still name a same-host duplicate from a legacy profile; canonicalize to the
-    // same setup the picker displays so the shown path is the path the workspace is created in.
-    const canonical =
-      findReadySetupTarget(
-        setups,
-        reposById,
-        (entry) => entry.projectId === setup.projectId && entry.hostId === setup.hostId
-      ) ?? createTarget(setup, reposById)
-    if (canonical) {
-      return { status: 'ready', target: canonical }
+    // Why: the caller named this exact setup, so it is the one to create in — a same-host duplicate
+    // from a legacy profile is a peer the picker also offers, never a reason to redirect.
+    const target = createTarget(setup, reposById)
+    if (target) {
+      return { status: 'ready', target }
     }
     return { status: 'unavailable', reason: 'setup-not-found' }
   }
@@ -174,16 +186,19 @@ export function resolveWorkspaceCreationTarget(
     const hostSetup = setups.find(
       (setup) => setup.projectId === projectId && setup.hostId === hostId
     )
-    if (hostSetup && !isReadySetup(hostSetup)) {
+    if (hostSetup && !isReadyProjectHostSetup(hostSetup)) {
       return { status: 'unavailable', reason: 'setup-not-ready' }
     }
-    const target = findReadySetupTarget(
+    const choice = chooseReadyTarget(
       setups,
       reposById,
       (setup) => setup.projectId === projectId && setup.hostId === hostId
     )
-    if (target) {
-      return { status: 'ready', target }
+    if (choice.status === 'ambiguous') {
+      return ambiguousResolution(choice.candidates)
+    }
+    if (choice.status === 'single') {
+      return { status: 'ready', target: choice.setup }
     }
     return { status: 'unavailable', reason: 'project-not-set-up-on-host' }
   }
@@ -191,27 +206,36 @@ export function resolveWorkspaceCreationTarget(
   if (projectId) {
     const focusedHostId =
       focusedHostScope && focusedHostScope !== ALL_EXECUTION_HOSTS_SCOPE ? focusedHostScope : null
-    const focusedTarget = focusedHostId
-      ? findReadySetupTarget(
+    const focusedChoice = focusedHostId
+      ? chooseReadyTarget(
           setups,
           reposById,
           (setup) => setup.projectId === projectId && setup.hostId === focusedHostId
         )
       : null
-    if (focusedTarget) {
-      return { status: 'ready', target: focusedTarget }
+    if (focusedChoice?.status === 'ambiguous') {
+      return ambiguousResolution(focusedChoice.candidates)
     }
-    const target = findReadySetupTarget(setups, reposById, (setup) => setup.projectId === projectId)
-    if (target) {
-      return { status: 'ready', target }
+    if (focusedChoice?.status === 'single') {
+      return { status: 'ready', target: focusedChoice.setup }
+    }
+    const choice = chooseReadyTarget(setups, reposById, (setup) => setup.projectId === projectId)
+    if (choice.status === 'ambiguous') {
+      return ambiguousResolution(choice.candidates)
+    }
+    if (choice.status === 'single') {
+      return { status: 'ready', target: choice.setup }
     }
     return { status: 'unavailable', reason: 'project-has-no-ready-setup' }
   }
 
   if (hostId) {
-    const target = findReadySetupTarget(setups, reposById, (setup) => setup.hostId === hostId)
-    if (target) {
-      return { status: 'ready', target }
+    const choice = chooseReadyTarget(setups, reposById, (setup) => setup.hostId === hostId)
+    if (choice.status === 'ambiguous') {
+      return ambiguousResolution(choice.candidates)
+    }
+    if (choice.status === 'single') {
+      return { status: 'ready', target: choice.setup }
     }
     // Why: the caller named this host. Falling through to the legacy repo (or any other
     // actionable host) would create the workspace somewhere the user never selected.
@@ -227,13 +251,16 @@ export function resolveWorkspaceCreationTarget(
   const legacyRepo =
     focusedLegacyRepo ?? (legacyCandidates.length === 1 ? legacyCandidates[0] : null)
   let legacyTarget: WorkspaceCreationTarget | null = null
+  let repoIdChoice: ReturnType<typeof chooseReadyTarget> | null = null
   if (legacyRepo) {
     const projectedLegacySetup = projectHostSetupProjectionFromRepos([legacyRepo]).setups[0]
     const legacyHostId = getRepoExecutionHostId(legacyRepo)
     const legacySetup =
       setups.find(
         (setup) =>
-          setup.repoId === legacyRepo.id && setup.hostId === legacyHostId && isReadySetup(setup)
+          setup.repoId === legacyRepo.id &&
+          setup.hostId === legacyHostId &&
+          isReadyProjectHostSetup(setup)
       ) ??
       (!actionableHostIds || actionableHostIds.has(projectedLegacySetup.hostId)
         ? projectedLegacySetup
@@ -242,15 +269,23 @@ export function resolveWorkspaceCreationTarget(
   } else if (repoId) {
     // Why: duplicate repo ids across hosts leave no single legacy repo. Stay on the resolved id's
     // own setup instead of failing closed and letting the composer re-pick an arbitrary repo.
-    legacyTarget = findReadySetupTarget(setups, reposById, (setup) => setup.repoId === repoId)
+    repoIdChoice = chooseReadyTarget(setups, reposById, (setup) => setup.repoId === repoId)
+    legacyTarget = repoIdChoice.status === 'single' ? repoIdChoice.setup : null
   }
   if (legacyTarget) {
     return { status: 'ready', target: legacyTarget }
   }
-  const fallbackTarget = findReadySetupTarget(setups, reposById, () => true)
-  return fallbackTarget
-    ? { status: 'ready', target: fallbackTarget }
-    : { status: 'unavailable', reason: legacyRepo ? 'setup-not-found' : 'no-eligible-repo' }
+  if (repoIdChoice?.status === 'ambiguous') {
+    return ambiguousResolution(repoIdChoice.candidates)
+  }
+  const fallbackChoice = chooseReadyTarget(setups, reposById, () => true)
+  if (fallbackChoice.status === 'ambiguous') {
+    return ambiguousResolution(fallbackChoice.candidates)
+  }
+  if (fallbackChoice.status === 'single') {
+    return { status: 'ready', target: fallbackChoice.setup }
+  }
+  return { status: 'unavailable', reason: legacyRepo ? 'setup-not-found' : 'no-eligible-repo' }
 }
 
 export function resolveWorkspaceCreationRepoId(input: ProjectHostWorkspaceTargetInput): string {

--- a/src/shared/project-host-setup-choice.ts
+++ b/src/shared/project-host-setup-choice.ts
@@ -1,0 +1,28 @@
+import type { ProjectHostSetup } from './project-types'
+
+export type ReadyProjectHostSetupChoice<T> =
+  | { status: 'single'; setup: T }
+  | { status: 'none' }
+  | { status: 'ambiguous'; candidates: readonly T[] }
+
+export function isReadyProjectHostSetup(setup: Pick<ProjectHostSetup, 'setupState'>): boolean {
+  return setup.setupState === 'ready'
+}
+
+/**
+ * Why (STA-6080): the surviving candidates are in persistence order, which is neither a user choice
+ * nor a ranking. Taking the first aimed worktree creation at an unrelated checkout of the same
+ * project, so more than one survivor is reported as ambiguous and left for the caller to surface —
+ * the CLI refuses with the candidates named, the composer asks which one to run on.
+ */
+export function chooseReadyProjectHostSetup<T>(
+  candidates: readonly T[]
+): ReadyProjectHostSetupChoice<T> {
+  if (candidates.length === 0) {
+    return { status: 'none' }
+  }
+  if (candidates.length === 1) {
+    return { status: 'single', setup: candidates[0] }
+  }
+  return { status: 'ambiguous', candidates }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1068 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1043 |
| Prod | 21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​272 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​78 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​194 |

<!-- /orca-pr-loc -->

Fixes STA-6080 (partially — see **What this does not do**).

When you create a worktree for a project, Orca could quietly aim it at the wrong checkout of that
project on your machine. Now, when the answer is ambiguous, it stops and asks you which one — in the
CLI and in the app.

## What changes

- **Before:** if a project had more than one ready setup (a "setup" is one configured checkout of
  the project on one machine) that could match your request, Orca used whichever one happened to
  come first in its stored list. That order is just the order things were saved in — not something
  you chose, not the newest, not the closest match. You were never told a choice had been made.
- **After, in the CLI:** when more than one setup could match, the command stops with an error and
  lists every candidate with its id and path, so you can re-run with `--project-host-setup <id>`.
- **After, in the app:** the new-workspace composer keeps the project selected, leaves **Run on**
  empty, and tells you how many places the project is set up in. Every ready setup is its own row in
  that picker, labelled with its path, so you pick the checkout and then create. Create stays
  disabled until you do.
- **The picker used to hide the duplicates.** It showed one row per machine, so extra checkouts on
  the *same* machine — exactly the shape that caused this bug — were invisible and unpickable.
- **A setup you name explicitly is now the one used.** The app used to quietly redirect a named
  setup to its first same-machine sibling, so the path it showed you was not the path it created in.
- **When only one setup matches, nothing changes** — it resolves exactly as before, with no extra
  click and no extra message.
- **This applies with or without `--host`.** Running without `--host` had the same silent-pick
  behaviour, and it is fixed too.
- **The CLI and the app now share one rule** for "exactly one, or ask", so they cannot drift apart
  on what counts as ambiguous.
- The ids and paths in the CLI message are escaped before printing, so a path containing invisible
  or cursor-moving characters cannot forge extra lines or scramble the output, and two different
  setups can never print as the same text — otherwise the id you were told to copy would be
  ambiguous.

This is not a theoretical risk. On the machine where this was reported, that one project had **six**
ready setups, and the one at the front of the list was the user's main Orca checkout — not the one
they were working toward.

## ELI5

You ask for "the project", and there are six folders on your computer that all answer to that name.
Orca used to grab the one nearest the top of its list and get on with it, without mentioning that
five others existed. Sometimes that folder was your real, in-use working copy. In the app it was
worse: the picker only ever showed one of the six, so there was no way to say "not that one".

Now Orca says: "there are six of these — here they are, tell me which one," and waits. If there is
only one, it just uses it, same as always.

## Why it was possible

The lookup narrowed the list to setups belonging to the project, then took the first remaining
entry. There was no check for "did more than one survive?" — so one match and six matches were
handled identically. The app had its own copy of that same lookup, which is why fixing the CLI alone
left the app doing exactly what was reported. Both now call one shared rule that returns either the
single match or the full candidate list.

## What this does not do

- **This is the routing half only.** It explains how worktree creation was aimed at an existing
  checkout. It does not explain how that checkout lost its git data; that is tracked separately.
- **A lone match is still taken on trust.** Only ambiguity is refused. If exactly one setup matches,
  Orca uses it without asking, so a single stale or mis-registered setup still routes creation
  straight to it.
- **It does not tighten which hosts a setup can answer for.** A setup stamped `local` still answers
  a `--host runtime:<id>` request — and that is correct, because `--host` has already routed the
  command to that server, where `local` is that same machine. The limit is the one above: if that
  broader match leaves exactly one candidate, it is used without a question.
- **It does not clean up the duplicate setups.** The six entries on the reported machine are all
  still there. They are now visible and selectable instead of silently collapsed, but nothing merges
  or removes them.
- **Windows paths in the CLI message show doubled backslashes.** That is deliberate: it is the price
  of guaranteeing the printed ids can be copied back unambiguously.

## Testing

18 new tests, and the CLI's 9 existing ones now run against the shared rule:

- `src/renderer/src/lib/project-host-workspace-target.test.ts` (+9) — ambiguity reported instead of
  a first match for a project, a project on one host, a named host, and duplicate repo ids; a single
  match still resolving silently; a focused host still breaking the tie; an explicitly named setup
  resolving to itself.
- `src/renderer/src/components/NewWorkspaceComposerCard.run-target-choice.test.tsx` (+3) — the
  composer shows the prompt, pre-selects nothing, lists both same-machine checkouts, and stays
  silent when a single setup resolved.
- `src/renderer/src/hooks/composer-state/*.test.ts` (+6) — picking an ambiguous project keeps it
  selected and clears the checkout, a single-setup project still resolves in one step, the picker
  is populated while the question is open, and choosing a run target (or a repo) closes it.
- `src/renderer/src/lib/project-host-setup-options.test.ts` — the same-host collapse test is
  inverted: every ready setup now gets its own row.

Eight mutations, all caught: returning the first candidate from the shared rule (kills 15 tests
across both the CLI and the app), restoring the named-setup redirect, restoring the picker's
same-host collapse, painting the first row in an unanswered picker, skipping the composer's
ambiguous branch, dropping the pending project from the resolver input or from its output, and
leaving the pending project set after a checkout is chosen.

`tsc --noEmit` is clean on the node, web, and CLI projects; oxlint and the React Doctor changed-lines
gate pass on every touched file.

Not exercised end-to-end: the refusal and the composer prompt are covered by tests, not by a live run
against the affected machine.
