### PR TITLE
docs(orcad): stop recommending the KillMode that loses terminals

### DIFF
--- a/docs/reference/orcad-operations.md
+++ b/docs/reference/orcad-operations.md
@@ -25,7 +25,17 @@ below exists to keep that true.
 **Consequence for supervision:** orcad's shutdown path calls `disconnectDaemon()`, never
 `shutdownDaemon()`. A supervisor that reaps orcad's whole process group — systemd's
 `KillMode=control-group` — kills the daemon too and turns every restart back into data loss.
-Use `KillMode=mixed` (the default) or `process`, and never `--send-sigkill` on the group.
+Use `KillMode=process`, and never `--send-sigkill` on the group.
+
+`mixed` is **not** safe here, though this document used to say it was. It SIGTERMs the main
+process and then SIGKILLs everything still in the control group, and the detached daemon is
+in that control group — `setsid()` escapes the process group, not the cgroup. Measured on a
+Synology NAS running systemd 219: under `mixed`, a `systemctl restart` destroyed the daemon,
+its shell, the session and its scrollback; the identical unit under `process` kept all four.
+
+The cost of `process` is real and accepted: systemd no longer reaps what the runtime leaves
+behind. orcad owns that lifecycle through the daemon pid-record it adopts on the next start,
+and a supervisor that cleans up is exactly what breaks the guarantee above.
 
 ## Bind policy
 

--- a/docs/reference/orcad-operations.md
+++ b/docs/reference/orcad-operations.md
@@ -25,14 +25,16 @@ below exists to keep that true.
 **Consequence for supervision:** orcad's shutdown path calls `disconnectDaemon()`, never
 `shutdownDaemon()`. A supervisor that reaps orcad's whole process group — systemd's
 `KillMode=control-group` — kills the daemon too and turns every restart back into data loss.
-Use `KillMode=process` on the unit that supervises orcad, and never `--send-sigkill` on the
-group.
+That mode is also systemd's default, so a unit that omits `KillMode=` entirely is already in
+the losing configuration. Set it explicitly: `KillMode=process` on the unit that supervises
+orcad, and never `--send-sigkill` on the group.
 
-`mixed` is **not** safe here, though this document used to say it was. It SIGTERMs the main
-process and then SIGKILLs everything still in the control group, and the detached daemon is
-in that control group — `setsid()` escapes the process group, not the cgroup. Measured on a
-Synology NAS running systemd 219: under `mixed`, a `systemctl restart` destroyed the daemon,
-its shell, the session and its scrollback; the identical unit under `process` kept all four.
+`mixed` is **not** safe here, though this document used to say it was — and called it the
+default, which it never was. It SIGTERMs the main process and then SIGKILLs everything still
+in the control group, and the detached daemon is in that control group — `setsid()` escapes
+the process group, not the cgroup. Measured on a Synology NAS running systemd 219: under
+`mixed`, a `systemctl restart` destroyed the daemon, its shell, the session and its
+scrollback; the identical unit under `process` kept all four.
 
 The cost of `process` is real and accepted: systemd no longer reaps what the runtime leaves
 behind. orcad owns that lifecycle through the daemon pid-record it adopts on the next start,

--- a/docs/reference/orcad-operations.md
+++ b/docs/reference/orcad-operations.md
@@ -25,7 +25,8 @@ below exists to keep that true.
 **Consequence for supervision:** orcad's shutdown path calls `disconnectDaemon()`, never
 `shutdownDaemon()`. A supervisor that reaps orcad's whole process group — systemd's
 `KillMode=control-group` — kills the daemon too and turns every restart back into data loss.
-Use `KillMode=process`, and never `--send-sigkill` on the group.
+Use `KillMode=process` on the unit that supervises orcad, and never `--send-sigkill` on the
+group.
 
 `mixed` is **not** safe here, though this document used to say it was. It SIGTERMs the main
 process and then SIGKILLs everything still in the control group, and the detached daemon is
@@ -36,6 +37,14 @@ its shell, the session and its scrollback; the identical unit under `process` ke
 The cost of `process` is real and accepted: systemd no longer reaps what the runtime leaves
 behind. orcad owns that lifecycle through the daemon pid-record it adopts on the next start,
 and a supervisor that cleans up is exactly what breaks the guarantee above.
+
+**This rule is scoped to the orcad unit.** `orca serve` is a different deployment with the
+opposite requirement: its reliability gate demands that a stop leave no listener, descendant
+or Xvfb residue behind, so `docs/reference/headless-linux-server.md` documents
+`KillMode=mixed` and `config/scripts/headless-serve-shutdown-workflow.test.mjs` asserts that
+unit keeps it. The cgroup SIGKILL that costs orcad its daemon is a wanted backstop there.
+Whether a daemon-backed session under `orca serve` is lost the same way is untested, and is
+deliberately not answered here.
 
 ## Bind policy
 


### PR DESCRIPTION
## ELI5

The doc that tells you how to supervise `orcad` recommended a systemd setting that
destroys every running terminal when you restart the service. This changes the
recommendation and says plainly that the doc used to say otherwise.

## What Changed

One paragraph in `docs/reference/orcad-operations.md`. It said:

> Use `KillMode=mixed` (the default) or `process`

It now says use `KillMode=process`, explains why `mixed` is not safe here, and
states the cost of `process` so the choice is not a bare instruction.

Docs only — nothing executes differently.

## Why

`mixed` SIGTERMs the main process and then SIGKILLs everything still in the
control group. The detached terminal daemon is in that control group: `setsid()`
escapes the process group, not the cgroup. So `mixed` kills the daemon.

Measured on a Synology NAS running systemd 219: under `mixed`, a `systemctl
restart` destroyed the daemon, its shell, the session and its scrollback; the
identical unit under `process` kept all four.

That is precisely the data loss the paragraph immediately above it exists to
prevent — the doc was recommending the value that defeats its own guarantee.

It says explicitly that this document used to say otherwise. An operator whose
unit carries `mixed` got it from somewhere, and quietly correcting the line would
leave them no way to tell whether their file predates the finding.

**Deliberately not changed:** `docs/reference/headless-linux-server.md` also ships
a `KillMode=mixed` unit, but for `orca serve` and with its own Xvfb-shaped
rationale. Whether the same measurement applies to that deployment is a separate
question, and answering it by editing is how a doc acquires a claim nobody tested.
I'd rather a maintainer say which way that should go — happy to follow up either
way.

## Linked Issue

Refs #15956 — that issue reports `orca serve` under `KillMode=mixed` losing every
agent session on restart, and asks (among other options) that the docs stop
implying otherwise. This addresses the orcad half only, so `Refs` rather than
`Fixes`.

## Visual Proof

`N/A` — documentation change, no UI or interaction surface.

## Testing

Prose change; there is nothing to execute. Verified the claim it rests on rather
than the diff:

- `KillMode=mixed` vs `process` measured on a real systemd 219 host (Synology DSM)
  with a live orcad + detached terminal daemon. Under `mixed` the daemon, its
  shell, the session and its scrollback were all destroyed by `systemctl restart`;
  under `process` all four survived.
- Confirmed the surrounding paragraph's `KillMode=control-group` claim is
  unchanged and still correct.

Platforms: Linux (systemd). The document is Linux-specific.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No automated test: this is prose. The behaviour it describes is asserted by tests
in the companion PR that generates the unit.

## AI Disclosure

Claude Opus 5 wrote the commit and this description. I reviewed both, and ran the
systemd measurement the change rests on myself.

## Review

- **Cross-platform:** documentation for a Linux/systemd deployment; makes no claim
  about macOS or Windows. The launchd path is untouched.
- **SSH/remote/local:** no behavioural surface.
- **Agents/integrations:** none.
- **Performance:** none.
- **UI:** none.
- **Security:** none. No credential, permission or exposure guidance changed.
- **Backwards compatibility:** an operator running `mixed` today is not broken by
  this; they are told their unit is unsafe and why.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Review follow-ups

Two automated review points were raised and both were correct; applied as separate commits.

**`9fa3ee8c1` — scope the rule to the orcad unit** (CodeRabbit). `orca serve` still
*requires* `KillMode=mixed`: `config/scripts/headless-serve-shutdown-workflow.test.mjs`
asserts the `orca-serve.service` block in `headless-linux-server.md` matches
`/^KillMode=mixed$/m`, and the `electron-headless-quit-lifecycle` gate exercises "the
documented systemd `KillMode=mixed` main-PID SIGTERM". An unqualified "use `KillMode=process`"
was reachable by an operator holding the wrong unit file. The doc now says why the two differ:
the requirements are opposite — orcad's daemon must outlive the unit, while `orca serve` owns
its Xvfb and its gate demands a stop leave no residue, so there the cgroup SIGKILL is a wanted
backstop.

This is also the strongest argument for leaving `headless-linux-server.md` alone: editing it
would have broken that test. The divergence is load-bearing and cannot be silently reconciled
when #15956 closes.

**`a2c66bcb3` — state the real `KillMode` default** (pullfrog). The parenthetical this PR
removed called `mixed` "the default". It never was — `systemd.kill(5)` defaults `KillMode=` to
`control-group`, the exact mode the paragraph above warns reaps the daemon. Removing the line
for the safety error left the factual one standing, which inverts the operator advice:
omitting `KillMode=` is not a neutral choice that lands somewhere safe, it lands on the
data-loss mode. The doc now says so, and records that it used to claim otherwise about the
default too.

Neither change reintroduces `mixed` as acceptable for orcad, and
`headless-linux-server.md` is still untouched.

**Not run:** the diff cites `headless-serve-shutdown-workflow.test.mjs`; I read its assertions
and the gate's oracle directly, I did not execute the suite. Still prose-only — no behaviour
changes.

## Notes

The one open question is `headless-linux-server.md`, flagged above — deliberately
left alone rather than overlooked.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

