### PR TITLE
fix(startup): install the app environment with the userData decision

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -759,6 +759,16 @@ if (app.isPackaged && process.platform !== 'win32') {
 }
 configureDevUserDataPath(is.dev)
 configureOrcaUserDataPathEnv()
+// Why these four lines are one step (#16761): the two above decide where userData lives, and
+// everything below may resolve a path. Installing the accessor any later leaves a window where an
+// early resolve either throws — which is what killed `orca serve` — or, worse, memoizes the
+// pre-override directory and silently writes user state to the wrong place for the whole session.
+// Safe this early: ElectronAppEnvironment holds no state and calls `app` lazily per accessor, so it
+// changes no timing, and initDataPath only joins strings.
+setAppEnvironment(new ElectronAppEnvironment())
+// Why captured now: after the dev/E2E override above, and before app.setName('Orca') (whenReady)
+// changes how userData resolves on a case-sensitive filesystem. See persistence.ts:20-28.
+initDataPath()
 
 // Why: just past createMainWindow's 10s ready-to-show fallback, so a window revealed that way still gets its tray icon.
 const TRAY_CREATE_FALLBACK_MS = 12_000
@@ -933,12 +943,11 @@ if (!hasSingleInstanceLock) {
 
 // Why: when another process holds the lock we've already exited; skip file-writing side effects so this transient process never touches userData.
 if (hasSingleInstanceLock) {
-  // Why first: both accessors throw until installed, and everything below this line
-  // may resolve a path or read a credential. Neither constructor touches `app` or
-  // `safeStorage` — they resolve lazily per call — so installing here changes no
-  // timing, in particular not the pre-ready Keychain service-name resolution and
-  // the app.setName ordering the userData captures below depend on.
-  setAppEnvironment(new ElectronAppEnvironment())
+  // Why first in this block: the accessor throws until installed and everything below may read a
+  // credential. The constructor does not touch `safeStorage` — it resolves lazily per call — so
+  // installing here changes no timing, in particular not the pre-ready Keychain service-name
+  // resolution. The app-environment port and the userData capture install earlier still, next to
+  // the path decision they depend on.
   setSecretStore(new ElectronSecretStore())
   // Why at process level, not per-window: pty.ts registers against injected surfaces so
   // it can load without electron, and an Electron main process always has ipcMain —
@@ -971,8 +980,6 @@ if (hasSingleInstanceLock) {
   installDevParentDisconnectQuit(shouldCoupleToDevParent)
   installDevParentWatchdog(shouldCoupleToDevParent)
   installDevParentSignalQuit(shouldCoupleToDevParent)
-  // Why: run after configureDevUserDataPath but before app.setName('Orca') (whenReady), which changes the resolved path on case-sensitive filesystems.
-  initDataPath()
   // Why not at module scope with the other lifetime couplings (#16761): this resolves the handoff
   // path, so it throws until setAppEnvironment() above installs the accessor — which killed every
   // `orca serve` process before it could listen. After initDataPath() specifically, so the

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -362,11 +362,14 @@ describe('startup ordering', () => {
     // leaves the serve process orphaned on its port, which is the failure this handler prevents.
     expect(installIndex).toBeLessThan(source.indexOf('void app.whenReady().then('))
     expect(installIndex).toBeGreaterThan(source.indexOf('if (hasSingleInstanceLock) {'))
-    const betweenCode = source
-      .slice(dataPathIndex, installIndex)
+    // Why only statements at block indentation: the span now covers unrelated helper functions,
+    // and an `await` inside one of those bodies is not what this guards against — the risk is this
+    // call itself being parked behind one.
+    const blockStatements = source
+      .slice(source.indexOf('if (hasSingleInstanceLock) {'), installIndex)
       .split('\n')
-      .filter((line) => !line.trim().startsWith('//'))
+      .filter((line) => /^ {2}\S/.test(line) && !line.trim().startsWith('//'))
       .join('\n')
-    expect(betweenCode).not.toContain('await')
+    expect(blockStatements).not.toContain('await')
   })
 })

--- a/src/main/startup/host-port-bootstrap-wiring.test.ts
+++ b/src/main/startup/host-port-bootstrap-wiring.test.ts
@@ -52,6 +52,33 @@ describe('host port bootstrap wiring', () => {
     }
   })
 
+  it('installs the app environment as part of the userData decision, not after it', () => {
+    // Why (#16761): the accessor throws until installed, and `getCanonicalUserDataPath()` memoizes
+    // whatever it first resolves. Any gap between deciding where userData lives and installing the
+    // port is a window where an early path resolve either kills the process — which is what took
+    // down every macOS `orca serve` — or caches the pre-override directory for the whole session.
+    // Keeping the four statements adjacent is what makes that window zero rather than merely small.
+    const decide = source.indexOf('configureDevUserDataPath(is.dev)')
+    const install = source.indexOf('setAppEnvironment(new ElectronAppEnvironment())')
+    const capture = source.indexOf('initDataPath()')
+
+    expect(decide).toBeGreaterThanOrEqual(0)
+    expect(install).toBeGreaterThan(decide)
+    expect(capture).toBeGreaterThan(install)
+
+    const statements = source
+      .slice(decide, capture)
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith('//'))
+
+    expect(statements).toEqual([
+      'configureDevUserDataPath(is.dev)',
+      'configureOrcaUserDataPathEnv()',
+      'setAppEnvironment(new ElectronAppEnvironment())'
+    ])
+  })
+
   it('installs the ports at process level, not per window', () => {
     // Why: installing per window registered the PTY surfaces against no-ops on the
     // serve path, where no window ever opens. Caught in CI by the SSH docker E2E.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## ELI5

The app decides where to keep your data, and separately switches on the thing that looks that location up. Those two steps were about 180 lines apart, and anything landing in between would either kill the app on launch or quietly answer with the wrong folder. We already shipped the first one — it was the `orca serve` crash. This puts the two steps next to each other so there is no gap left to fall into.

## What Changed

Moved `setAppEnvironment(new ElectronAppEnvironment())` and `initDataPath()` in `src/main/index.ts` from inside the `if (hasSingleInstanceLock)` block up to immediately after `configureDevUserDataPath()` / `configureOrcaUserDataPathEnv()` — the two calls that decide where `userData` lives.

`setSecretStore(new ElectronSecretStore())` deliberately stays where it is; its comment documents a pre-ready Keychain service-name timing constraint that has nothing to do with paths, and moving it is unrelated scope.

Two guards:

- `host-port-bootstrap-wiring.test.ts` — asserts the decision, the install, and the capture stay adjacent, with nothing but comments between them.
- `desktop-startup-ordering.test.ts` — the serve-supervisor `await` assertion added in #16762 assumed those statements were adjacent. Now that they are ~200 lines apart it would pass by accident and fail confusingly on unrelated edits, so it is re-scoped to statements at block indentation.

## Why

`getAppEnvironment()` throws until installed, and `getCanonicalUserDataPath()` memoizes whatever it first resolves. Between the decision and the install, any statement that transitively resolves a path had two possible outcomes:

1. **Loud** — throws `AppEnvironment not initialized` and kills the process at startup.
2. **Quiet, and worse** — with the accessor installed but the decision not yet run, `_userDataDir` caches the *pre-override* directory and keeps returning it for the entire session, writing user state to the wrong place with nothing to notice.

We shipped outcome 1 to users. #16761 / #16698 / #17509 were exactly one statement landing in that gap: `installServeSupervisorDisconnectQuit()` resolved the serve update handoff path at module scope and killed every macOS `orca serve` process across 1.4.190–1.4.192. #16762 moved that call. This removes the gap it fell into.

Nothing in the type system or the suite prevented it, and nothing would prevent the next one: `serve-update-handoff.test.ts` mocks the path resolver, which is exactly why the original never failed a test.

**The throw is kept and still does its job.** Resolving a path *before* the decision has run still throws, which is correct — the answer genuinely does not exist yet. What is gone is the window where the decision had been made but the accessor was not yet installed.

**This matches what we already do elsewhere.** `src/main/orcad/orcad-entry.ts:107-109` — the Node host — calls `installOrcadHostAdapters()` as the first statement of `startOrcad()` and `resolveUserDataPath()` immediately after. The desktop entry was the outlier. The same shape is the norm in other Electron main processes, which typically resolve the user-data path once at the top of the entry as a pure function of CLI args and environment, so there is no installed singleton and no ordering hazard to get wrong.

### Why this is safe to run earlier

- `ElectronAppEnvironment` has **no constructor** and calls `app` lazily inside each accessor, so installing it earlier changes no timing.
- `initDataPath()` only reads `app.getPath('userData')` and joins strings.
- I verified `app.getPath('userData')` does **not** create the directory:
  `{"existsBeforeGetPath":false,"resolved":"/tmp/orca-nonexistent-25680/ud","existsAfterGetPath":false}`
  That matters because both statements now run before the single-instance-lock check. The block comment there promises a lock-losing transient process "never touches userData" — still true, since neither statement writes anything.
- Ordering constraints preserved: still after `configureDevUserDataPath()` (dev/E2E override), still before `app.setName('Orca')` (which changes how `userData` resolves on a case-sensitive filesystem), still before `acquireSingleInstanceLock` (which derives lock identity from `userData`).

## Linked Issue

Fixes #17750

## Visual Proof

`N/A` — main-process startup ordering, no UI or interaction surface. The observable evidence is that both entry paths still behave identically:

**Desktop** — launched with `ORCA_DEV_USER_DATA_PATH` pointed at a temp dir, on this branch and on `main`, then diffed the resulting profile. Identical apart from a Chromium journal-mode filename and a PID-named socket:

```
16c16
< DIPS-wal
---
> DIPS-journal
22,23c22
< Network Persistent State
< o-26108-0395.sock
---
> o-42357-e685.sock
```

Zero `uncaught` / `AppEnvironment not initialized` in either. The override being honored is the load-bearing part: if the capture had moved ahead of the decision, the profile would have landed in `orca-dev` instead.

**Serve** — still reaches ready and still couples to its supervisor:

```
Orca server ready
Bound endpoint: ws://0.0.0.0:6820
IPC MSG {"type":"orca:serve-ready","version":"...","runtimeId":"..."}
[check] disconnecting parent IPC
[check] EXIT code=0 signal=null
```

## Testing

- `pnpm tc` — clean
- `pnpm vitest run src/main/startup src/main/persistence src/main/serve-update-handoff*` — 107 files / 1131 tests passed
- The adjacency guard is non-vacuous: against `main`'s `index.ts` it fails with `expected [ …(157) ] to deeply equal [ …(3) ]`. The `desktop-startup-ordering.test.ts` change is **not** a new guard and passes on both versions — it is only a re-scope so the pre-existing no-await check keeps testing the property it was written for once the statements it spans are no longer adjacent
- Manual desktop launch and manual `orca serve` launch, both on macOS (arm64), as above

Platforms: macOS tested directly. The change is a statement move with no platform branch, and the moved calls are platform-neutral, so Linux/Windows behaviour is unchanged. No SSH/remote or mobile surface is touched; `orca serve` is what remote clients pair against, and it is verified above.

Full-suite note: a broad local `src/main` sweep showed 6 failures, all in timing-sensitive files (30s+ timeouts, `.electron.` runtime tests, live-shell tests). They are environmental on this machine, not from this change — load average was 237 during the run, and I confirmed `browser-route-tcp-egress.electron.test.ts` fails identically on clean `main` with the same ~32s timeout, while `ssh-remote-commands.test.ts` passes on this branch when run without contention. Leaving the full suite to CI, which runs it sharded on clean runners.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security:** none. No credential or path is newly exposed; the secret store install is untouched, and its Keychain timing note still applies where it sits.
- **Cross-platform:** statement move, no platform branch added or removed.
- **Remote SSH / mobile:** unaffected. `orca serve` verified working.
- **Backwards compatibility:** no persisted state, schema, migration, or wire contract touched. The resolved `userData` value is byte-identical — same expression, same point relative to the override and to `app.setName`.
- **Performance:** none. Same statements, same synchronous module evaluation, different line numbers.
- **Follow-up not included here:** `installServeSupervisorDisconnectQuit()` could now return to module scope, since its prerequisite is installed before it. I left it where #16762 put it — moving it back is a behaviour question about how early the disconnect coupling should exist, not part of closing this gap.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

