### PR TITLE
fix(diff): close large-diff deferral review findings from #17521

### DIFF
--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
 import { combinedDiffSectionScrollbarOptions } from './diff-editor-scrollbar-options'
+import { isCombinedDiffSizeUnknown } from './combined-diff-on-demand-load'
 import type { DiffSection } from './diff-section-types'
 import { translate } from '@/i18n/i18n'
 import { LargeDiffFallback } from './LargeDiffFallback'
@@ -98,7 +99,10 @@ export function DiffSectionBody({
         />
       ) : null}
       {section.loadOnDemand ? (
-        <LargeDiffLoadPrompt onLoad={() => onLoadDeferredSection(index)} />
+        <LargeDiffLoadPrompt
+          sizeUnknown={isCombinedDiffSizeUnknown(section)}
+          onLoad={() => onLoadDeferredSection(index)}
+        />
       ) : section.loading ? (
         <div className="flex h-full items-center gap-2 bg-muted/10 px-3 text-[11px] text-muted-foreground">
           <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" />

--- a/src/renderer/src/components/editor/LargeDiffLoadPrompt.test.tsx
+++ b/src/renderer/src/components/editor/LargeDiffLoadPrompt.test.tsx
@@ -3,6 +3,9 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { LargeDiffLoadPrompt } from './LargeDiffLoadPrompt'
 
+const KNOWN_LARGE_COPY = 'Large diffs are not rendered by default.'
+const UNKNOWN_SIZE_COPY = "This diff's size isn't known yet, so it loads on request."
+
 describe('LargeDiffLoadPrompt', () => {
   afterEach(cleanup)
 
@@ -16,10 +19,26 @@ describe('LargeDiffLoadPrompt', () => {
       </div>
     )
 
-    screen.getByText('Large diffs are not rendered by default.')
+    screen.getByText(KNOWN_LARGE_COPY)
     fireEvent.click(screen.getByRole('button', { name: 'Load diff' }))
 
     expect(onLoad).toHaveBeenCalledOnce()
     expect(onParentClick).not.toHaveBeenCalled()
+  })
+
+  it('calls a row large only when its counts say so', () => {
+    render(<LargeDiffLoadPrompt onLoad={vi.fn()} sizeUnknown={false} />)
+
+    screen.getByText(KNOWN_LARGE_COPY)
+    expect(screen.queryByText(UNKNOWN_SIZE_COPY)).toBeNull()
+  })
+
+  it('does not claim an uncounted row is large', () => {
+    // A lone tracked binary (resources/build/icon.icns) is deferred with no
+    // counts at all; it may be 4 KB.
+    render(<LargeDiffLoadPrompt onLoad={vi.fn()} sizeUnknown />)
+
+    screen.getByText(UNKNOWN_SIZE_COPY)
+    expect(screen.queryByText(KNOWN_LARGE_COPY)).toBeNull()
   })
 })

--- a/src/renderer/src/components/editor/LargeDiffLoadPrompt.tsx
+++ b/src/renderer/src/components/editor/LargeDiffLoadPrompt.tsx
@@ -1,7 +1,15 @@
 import { translate } from '@/i18n/i18n'
 import { Button } from '@/components/ui/button'
 
-export function LargeDiffLoadPrompt({ onLoad }: { onLoad: () => void }): React.JSX.Element {
+export function LargeDiffLoadPrompt({
+  onLoad,
+  sizeUnknown = false
+}: {
+  onLoad: () => void
+  // Deferred rows split two ways: over the changed-line limit, or never counted
+  // at all. Claiming "large" for an uncounted 4 KB binary would be false.
+  sizeUnknown?: boolean
+}): React.JSX.Element {
   return (
     <div
       data-testid="large-diff-load-prompt"
@@ -9,10 +17,15 @@ export function LargeDiffLoadPrompt({ onLoad }: { onLoad: () => void }): React.J
     >
       <div className="space-y-3 text-center">
         <div className="text-sm font-medium text-foreground">
-          {translate(
-            'auto.components.editor.LargeDiffLoadPrompt.a0af0198aa',
-            'Large diffs are not rendered by default.'
-          )}
+          {sizeUnknown
+            ? translate(
+                'auto.components.editor.LargeDiffLoadPrompt.c3d9f4a712',
+                "This diff's size isn't known yet, so it loads on request."
+              )
+            : translate(
+                'auto.components.editor.LargeDiffLoadPrompt.a0af0198aa',
+                'Large diffs are not rendered by default.'
+              )}
         </div>
         <Button
           type="button"

--- a/src/renderer/src/components/editor/combined-diff-on-demand-load.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-on-demand-load.test.ts
@@ -30,7 +30,46 @@ describe('combined diff on-demand loading', () => {
   })
 
   it('defers untracked files whose line counts were skipped as too large', () => {
-    expect(shouldLoadCombinedDiffOnDemand({ path: 'data/dump.json' })).toBe(true)
+    // The scan counted this row's siblings and still skipped it, so it is past
+    // MAX_UNTRACKED_LINE_COUNT_BYTES — the one case where size is truly unknown.
+    expect(
+      shouldLoadCombinedDiffOnDemand({
+        path: 'data/dump.json',
+        area: 'untracked',
+        hasCountedSiblings: true
+      })
+    ).toBe(true)
+    expect(shouldLoadCombinedDiffOnDemand({ path: 'data/dump.json', area: 'untracked' })).toBe(true)
+  })
+
+  it('automatically loads tracked binaries numstat left uncounted, whatever the extension', () => {
+    // `git diff --numstat` emits '-\t-' for any tracked binary; the extension
+    // list will never cover them all (.icns, .tiff, extensionless).
+    for (const path of ['resources/build/icon.icns', 'assets/logo.tiff', 'bin/orca-helper']) {
+      expect(
+        shouldLoadCombinedDiffOnDemand({ path, area: 'unstaged', hasCountedSiblings: true })
+      ).toBe(false)
+    }
+  })
+
+  it('automatically loads submodule rows whose only change is untracked content inside', () => {
+    // Porcelain v2 reports `1 .M S..U ... sub` while numstat emits no row at
+    // all, so the section is uncounted and 'sub' has no extension to read.
+    expect(
+      shouldLoadCombinedDiffOnDemand({
+        path: 'vendor/sub',
+        area: 'unstaged',
+        submodule: { commitChanged: false, trackedChanges: false, untrackedChanges: true }
+      })
+    ).toBe(false)
+  })
+
+  it('defers uncounted rows when the whole pass skipped counting', () => {
+    // Entry cap hit or numstat failed: no sibling has counts, so nothing
+    // distinguishes a 4 KB binary from an unbounded text file.
+    expect(
+      shouldLoadCombinedDiffOnDemand({ path: 'resources/build/icon.icns', area: 'unstaged' })
+    ).toBe(true)
   })
 
   it('defers uncounted svgs, which render as text rather than a preview', () => {

--- a/src/renderer/src/components/editor/combined-diff-on-demand-load.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-on-demand-load.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   MAX_AUTOMATIC_DIFF_CHANGED_LINES,
+  collectCountedCombinedDiffPasses,
+  getCombinedDiffCountingPassKey,
   shouldLoadCombinedDiffOnDemand
 } from './combined-diff-on-demand-load'
 
@@ -96,6 +98,29 @@ describe('combined diff on-demand loading', () => {
     expect(shouldLoadCombinedDiffOnDemand({ removed: MAX_AUTOMATIC_DIFF_CHANGED_LINES + 1 })).toBe(
       true
     )
+  })
+
+  it('credits a counted row only to its own counting pass', () => {
+    // Staged/unstaged numstats and the compare diff are separate git calls that
+    // fail separately, so `all` mode must not pool their results.
+    const countedPasses = collectCountedCombinedDiffPasses([
+      { path: 'src/app.ts', status: 'modified', area: 'unstaged' },
+      { path: 'src/staged.ts', status: 'modified', area: 'staged', added: 4 },
+      { path: 'src/compare.ts', status: 'modified', added: 9 }
+    ])
+    expect(
+      countedPasses.has(getCombinedDiffCountingPassKey({ path: 'a', status: 'modified' }))
+    ).toBe(true)
+    expect(
+      countedPasses.has(
+        getCombinedDiffCountingPassKey({ path: 'a', status: 'modified', area: 'staged' })
+      )
+    ).toBe(true)
+    expect(
+      countedPasses.has(
+        getCombinedDiffCountingPassKey({ path: 'a', status: 'modified', area: 'unstaged' })
+      )
+    ).toBe(false)
   })
 
   it('keeps counted binary-extension rows on the line-count rule', () => {

--- a/src/renderer/src/components/editor/combined-diff-on-demand-load.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-on-demand-load.test.ts
@@ -3,6 +3,7 @@ import {
   MAX_AUTOMATIC_DIFF_CHANGED_LINES,
   collectCountedCombinedDiffPasses,
   getCombinedDiffCountingPassKey,
+  isCombinedDiffSizeUnknown,
   shouldLoadCombinedDiffOnDemand
 } from './combined-diff-on-demand-load'
 
@@ -121,6 +122,22 @@ describe('combined diff on-demand loading', () => {
         getCombinedDiffCountingPassKey({ path: 'a', status: 'modified', area: 'unstaged' })
       )
     ).toBe(false)
+  })
+
+  it('separates the two deferral reasons the prompt has to explain', () => {
+    // Both defer, but only one is actually large; the prompt copy splits here.
+    const overLimit = { added: MAX_AUTOMATIC_DIFF_CHANGED_LINES + 1, path: 'src/schema.ts' }
+    const uncounted = {
+      path: 'resources/build/icon.icns',
+      area: 'unstaged' as const,
+      added: undefined,
+      removed: undefined
+    }
+    expect(shouldLoadCombinedDiffOnDemand(overLimit)).toBe(true)
+    expect(shouldLoadCombinedDiffOnDemand(uncounted)).toBe(true)
+    expect(isCombinedDiffSizeUnknown(overLimit)).toBe(false)
+    expect(isCombinedDiffSizeUnknown(uncounted)).toBe(true)
+    expect(isCombinedDiffSizeUnknown({ added: 0, removed: 0 })).toBe(false)
   })
 
   it('keeps counted binary-extension rows on the line-count rule', () => {

--- a/src/renderer/src/components/editor/combined-diff-on-demand-load.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-on-demand-load.test.ts
@@ -23,25 +23,31 @@ describe('combined diff on-demand loading', () => {
     ).toBe(false)
   })
 
-  it('automatically loads tracked diffs when line counts are unavailable', () => {
-    expect(
-      shouldLoadCombinedDiffOnDemand({ added: undefined, removed: undefined, area: 'unstaged' })
-    ).toBe(false)
+  it('defers uncounted tracked text files, whose size is unknown', () => {
+    // A capped status listing or a failed numstat leaves every tracked row
+    // uncounted; auto-loading them is what froze Monaco before deferral.
+    expect(shouldLoadCombinedDiffOnDemand({ path: 'src/generated/schema.ts' })).toBe(true)
   })
 
   it('defers untracked files whose line counts were skipped as too large', () => {
-    expect(shouldLoadCombinedDiffOnDemand({ area: 'untracked', path: 'data/dump.json' })).toBe(true)
+    expect(shouldLoadCombinedDiffOnDemand({ path: 'data/dump.json' })).toBe(true)
   })
 
-  it('defers uncounted untracked svgs, which render as text rather than a preview', () => {
-    expect(shouldLoadCombinedDiffOnDemand({ area: 'untracked', path: 'assets/map.svg' })).toBe(true)
+  it('defers uncounted svgs, which render as text rather than a preview', () => {
+    expect(shouldLoadCombinedDiffOnDemand({ path: 'assets/map.svg' })).toBe(true)
   })
 
-  it('automatically loads untracked images that report no line counts', () => {
-    expect(shouldLoadCombinedDiffOnDemand({ area: 'untracked', path: 'docs/Shot.PNG' })).toBe(false)
+  it('automatically loads uncounted images, which render as a preview', () => {
+    expect(shouldLoadCombinedDiffOnDemand({ path: 'docs/Shot.PNG' })).toBe(false)
   })
 
-  it('defers untracked diffs when only additions are reported', () => {
+  it('automatically loads uncounted non-image binaries of any size', () => {
+    expect(shouldLoadCombinedDiffOnDemand({ path: 'fixtures/sample.zip' })).toBe(false)
+    expect(shouldLoadCombinedDiffOnDemand({ path: 'fonts/Inter.woff2' })).toBe(false)
+    expect(shouldLoadCombinedDiffOnDemand({ path: 'bun.lockb' })).toBe(false)
+  })
+
+  it('defers diffs when only additions are reported', () => {
     expect(shouldLoadCombinedDiffOnDemand({ added: MAX_AUTOMATIC_DIFF_CHANGED_LINES + 1 })).toBe(
       true
     )
@@ -51,5 +57,15 @@ describe('combined diff on-demand loading', () => {
     expect(shouldLoadCombinedDiffOnDemand({ removed: MAX_AUTOMATIC_DIFF_CHANGED_LINES + 1 })).toBe(
       true
     )
+  })
+
+  it('keeps counted binary-extension rows on the line-count rule', () => {
+    expect(shouldLoadCombinedDiffOnDemand({ added: 3, path: 'fixtures/sample.zip' })).toBe(false)
+    expect(
+      shouldLoadCombinedDiffOnDemand({
+        added: MAX_AUTOMATIC_DIFF_CHANGED_LINES + 1,
+        path: 'fixtures/sample.zip'
+      })
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/components/editor/combined-diff-on-demand-load.ts
+++ b/src/renderer/src/components/editor/combined-diff-on-demand-load.ts
@@ -1,7 +1,29 @@
 import { hasBinaryFileExtension } from '../../../../shared/binary-file-extensions'
+import type { GitBranchChangeEntry } from '../../../../shared/git-diff-compare-types'
 import type { GitStatusEntry } from '../../../../shared/git-status-types'
 
 export const MAX_AUTOMATIC_DIFF_CHANGED_LINES = 10_000
+
+// Line counts come from independent passes that fail independently: one numstat
+// per staging area, the untracked scan, and the compare diff.
+export function getCombinedDiffCountingPassKey(
+  entry: GitStatusEntry | GitBranchChangeEntry
+): string {
+  return 'area' in entry ? entry.area : 'compare'
+}
+
+/** Passes that counted at least one row, so counting demonstrably ran for them. */
+export function collectCountedCombinedDiffPasses(
+  entries: readonly (GitStatusEntry | GitBranchChangeEntry)[]
+): ReadonlySet<string> {
+  const countedPasses = new Set<string>()
+  for (const entry of entries) {
+    if (entry.added !== undefined || entry.removed !== undefined) {
+      countedPasses.add(getCombinedDiffCountingPassKey(entry))
+    }
+  }
+  return countedPasses
+}
 
 export function shouldLoadCombinedDiffOnDemand({
   added,
@@ -16,8 +38,9 @@ export function shouldLoadCombinedDiffOnDemand({
   path?: string
   area?: GitStatusEntry['area']
   submodule?: GitStatusEntry['submodule']
-  // True when another row in the same status pass carried line counts, so
-  // counting ran and this row is uncounted for a reason of its own.
+  // True when another row in the SAME counting pass carried line counts, so
+  // counting ran and this row is uncounted for a reason of its own. A sibling
+  // from another pass proves nothing: passes fail independently.
   hasCountedSiblings?: boolean
 }): boolean {
   if (added === undefined && removed === undefined) {
@@ -34,9 +57,11 @@ export function shouldLoadCombinedDiffOnDemand({
     if (hasCountedSiblings === true && area !== 'untracked') {
       return false
     }
-    // Otherwise the size is unknown, not zero: an oversized untracked file, or
-    // a status pass that skipped counting entirely (entry cap hit, numstat
-    // failed). Defer everything Monaco would open as unbounded text.
+    // Otherwise the size is unknown, not zero: an oversized untracked file, a
+    // pass that skipped counting entirely (entry cap hit, numstat failed), or a
+    // lone row with no sibling to prove counting ran. Numstat's binary marker
+    // would settle the last case, but it never leaves the host. Defer them all:
+    // Monaco would open unbounded text.
     return true
   }
   return (added ?? 0) + (removed ?? 0) > MAX_AUTOMATIC_DIFF_CHANGED_LINES

--- a/src/renderer/src/components/editor/combined-diff-on-demand-load.ts
+++ b/src/renderer/src/components/editor/combined-diff-on-demand-load.ts
@@ -25,6 +25,21 @@ export function collectCountedCombinedDiffPasses(
   return countedPasses
 }
 
+/**
+ * Why a deferred row was deferred. Uncounted rows are deferred because their
+ * size is unknown, not because it is over the limit — the prompt must not
+ * claim otherwise. Mirrors the uncounted branch of the predicate below.
+ */
+export function isCombinedDiffSizeUnknown({
+  added,
+  removed
+}: {
+  added?: number
+  removed?: number
+}): boolean {
+  return added === undefined && removed === undefined
+}
+
 export function shouldLoadCombinedDiffOnDemand({
   added,
   removed,

--- a/src/renderer/src/components/editor/combined-diff-on-demand-load.ts
+++ b/src/renderer/src/components/editor/combined-diff-on-demand-load.ts
@@ -1,24 +1,43 @@
 import { hasBinaryFileExtension } from '../../../../shared/binary-file-extensions'
+import type { GitStatusEntry } from '../../../../shared/git-status-types'
 
 export const MAX_AUTOMATIC_DIFF_CHANGED_LINES = 10_000
 
 export function shouldLoadCombinedDiffOnDemand({
   added,
   removed,
-  path
+  path,
+  area,
+  submodule,
+  hasCountedSiblings
 }: {
   added?: number
   removed?: number
   path?: string
+  area?: GitStatusEntry['area']
+  submodule?: GitStatusEntry['submodule']
+  // True when another row in the same status pass carried line counts, so
+  // counting ran and this row is uncounted for a reason of its own.
+  hasCountedSiblings?: boolean
 }): boolean {
   if (added === undefined && removed === undefined) {
-    // A row with no counts is one of: a binary file (git numstat reports '-',
-    // and the untracked scan skips binaries), an untracked file past the scan's
-    // size cap (MAX_UNTRACKED_LINE_COUNT_BYTES), or any file in a status pass
-    // that skipped counting entirely (entry cap hit, numstat failed). Only the
-    // binary case is cheap to render, and only the path can tell us that here,
-    // so defer everything Monaco would open as unbounded text.
-    return !hasBinaryFileExtension(path)
+    // A submodule diffs to a "Subproject commit" line or two whatever it
+    // contains, and numstat reports nothing at all for one whose only change is
+    // untracked content inside it.
+    if (submodule !== undefined || hasBinaryFileExtension(path)) {
+      return false
+    }
+    // Counting ran for this pass, so a tracked row is uncounted only because
+    // numstat called it binary ('-'). Untracked rows are also uncounted when
+    // the scan skipped them past MAX_UNTRACKED_LINE_COUNT_BYTES, so those stay
+    // deferred — their size is exactly what is unknown.
+    if (hasCountedSiblings === true && area !== 'untracked') {
+      return false
+    }
+    // Otherwise the size is unknown, not zero: an oversized untracked file, or
+    // a status pass that skipped counting entirely (entry cap hit, numstat
+    // failed). Defer everything Monaco would open as unbounded text.
+    return true
   }
   return (added ?? 0) + (removed ?? 0) > MAX_AUTOMATIC_DIFF_CHANGED_LINES
 }

--- a/src/renderer/src/components/editor/combined-diff-on-demand-load.ts
+++ b/src/renderer/src/components/editor/combined-diff-on-demand-load.ts
@@ -1,36 +1,24 @@
-import type { GitStatusEntry } from '../../../../shared/git-status-types'
-import { IMAGE_FILE_EXTENSIONS } from '../../../../shared/image-file-extensions'
+import { hasBinaryFileExtension } from '../../../../shared/binary-file-extensions'
 
 export const MAX_AUTOMATIC_DIFF_CHANGED_LINES = 10_000
-
-// SVG is excluded: it reads as text, so the diff view renders its source in Monaco
-// rather than an image preview — deferral is exactly what an oversized one needs.
-const PREVIEWED_IMAGE_EXTENSIONS = IMAGE_FILE_EXTENSIONS.filter((ext) => ext !== '.svg')
-
-function isPreviewedImagePath(path: string | undefined): boolean {
-  const lowerPath = path?.toLowerCase()
-  return (
-    lowerPath !== undefined && PREVIEWED_IMAGE_EXTENSIONS.some((ext) => lowerPath.endsWith(ext))
-  )
-}
 
 export function shouldLoadCombinedDiffOnDemand({
   added,
   removed,
-  area,
   path
 }: {
   added?: number
   removed?: number
-  area?: GitStatusEntry['area']
   path?: string
 }): boolean {
   if (added === undefined && removed === undefined) {
-    // Untracked files lose their counts once they exceed the status-scan size cap
-    // (MAX_UNTRACKED_LINE_COUNT_BYTES), so an uncounted untracked file is either
-    // oversized text or binary — both too costly to auto-load. Images stay automatic
-    // because their preview is the point of the row.
-    return area === 'untracked' && !isPreviewedImagePath(path)
+    // A row with no counts is one of: a binary file (git numstat reports '-',
+    // and the untracked scan skips binaries), an untracked file past the scan's
+    // size cap (MAX_UNTRACKED_LINE_COUNT_BYTES), or any file in a status pass
+    // that skipped counting entirely (entry cap hit, numstat failed). Only the
+    // binary case is cheap to render, and only the path can tell us that here,
+    // so defer everything Monaco would open as unbounded text.
+    return !hasBinaryFileExtension(path)
   }
   return (added ?? 0) + (removed ?? 0) > MAX_AUTOMATIC_DIFF_CHANGED_LINES
 }

--- a/src/renderer/src/components/editor/combined-diff/remember-view/use-combined-diff-view-restore.test.tsx
+++ b/src/renderer/src/components/editor/combined-diff/remember-view/use-combined-diff-view-restore.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, renderHook } from '@testing-library/react'
+import type { GitBranchChangeEntry } from '../../../../../../shared/git-diff-compare-types'
+import type { GitStatusEntry } from '../../../../../../shared/git-status-types'
+import type { DiffSection } from '../../diff-section-types'
+import { useCombinedDiffSectionLoadRegistry } from '../load-sections/combined-diff-section-load-registry'
+import type { CombinedDiffEntrySet } from '../resolve-changes/use-combined-diff-entry-set'
+import { combinedDiffViewStateCache } from './combined-diff-view-memory'
+import { useCombinedDiffViewRestore } from './use-combined-diff-view-restore'
+
+function buildAllModeEntrySet(
+  uncommittedEntries: GitStatusEntry[],
+  renderableBranchEntries: GitBranchChangeEntry[]
+): CombinedDiffEntrySet {
+  const entries = [...uncommittedEntries, ...renderableBranchEntries]
+  return {
+    allEntries: entries,
+    branchCompare: null,
+    commitCompare: null,
+    commitEntries: [],
+    entries,
+    entrySignature: JSON.stringify(entries),
+    hasUncommittedEntriesSnapshot: false,
+    isAllMode: true,
+    isBranchMode: false,
+    isCommitMode: false,
+    renderableBranchEntries,
+    shouldAutoReloadFromGitStatus: false,
+    treeMode: 'all',
+    uncommittedEntries
+  }
+}
+
+function restoreSections(entrySet: CombinedDiffEntrySet, viewStateKey: string): DiffSection[] {
+  let sections: DiffSection[] = []
+  renderHook(() => {
+    const registry = useCombinedDiffSectionLoadRegistry([])
+    return useCombinedDiffViewRestore({
+      entrySet,
+      gitStatusEntries: [],
+      registry,
+      setGeneration: () => {},
+      setSectionHeights: () => {},
+      setSections: (value) => {
+        sections = typeof value === 'function' ? value(sections) : value
+      },
+      setSideBySide: () => {},
+      viewStateKey
+    })
+  })
+  return sections
+}
+
+describe('useCombinedDiffViewRestore deferral', () => {
+  afterEach(() => {
+    cleanup()
+    combinedDiffViewStateCache.clear()
+  })
+
+  it('keeps uncommitted rows deferred when only the branch pass counted', () => {
+    // combined-all concatenates two independent passes: the uncommitted numstat
+    // can fail (or be skipped at the entry cap) while the compare diff succeeds.
+    const sections = restoreSections(
+      buildAllModeEntrySet(
+        [
+          { path: 'src/app.ts', status: 'modified', area: 'unstaged' },
+          { path: 'src/store.ts', status: 'modified', area: 'unstaged' }
+        ],
+        [{ path: 'src/branch.ts', status: 'modified', added: 12, removed: 3 }]
+      ),
+      'mixed-pass-view'
+    )
+    expect(sections.map((section) => section.loadOnDemand)).toEqual([true, true, false])
+  })
+
+  it('auto-loads an uncounted tracked row once its own pass counted something', () => {
+    const sections = restoreSections(
+      buildAllModeEntrySet(
+        [
+          { path: 'resources/build/icon.icns', status: 'modified', area: 'unstaged' },
+          { path: 'src/app.ts', status: 'modified', area: 'unstaged', added: 5 }
+        ],
+        []
+      ),
+      'counted-pass-view'
+    )
+    expect(sections.map((section) => section.loadOnDemand)).toEqual([false, false])
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff/remember-view/use-combined-diff-view-restore.ts
+++ b/src/renderer/src/components/editor/combined-diff/remember-view/use-combined-diff-view-restore.ts
@@ -134,12 +134,20 @@ export function useCombinedDiffViewRestore({
     scrollOffsetRef.current = combinedDiffScrollTopCache.get(viewStateKey) ?? 0
     scrollAnchorRef.current = combinedDiffScrollAnchorCache.get(viewStateKey) ?? null
     latestDomScrollAnchorRef.current = scrollAnchorRef.current
+    // Why: separates "this row is uncounted" from "this whole pass skipped
+    // counting", which is what decides whether an uncounted row is cheap.
+    const hasCountedSiblings = entries.some(
+      (entry) => entry.added !== undefined || entry.removed !== undefined
+    )
     setSections(
       entries.map((entry) => {
         const loadOnDemand = shouldLoadCombinedDiffOnDemand({
           added: 'added' in entry ? entry.added : undefined,
           removed: 'removed' in entry ? entry.removed : undefined,
-          path: entry.path
+          path: entry.path,
+          area: 'area' in entry ? entry.area : undefined,
+          submodule: 'submodule' in entry ? entry.submodule : undefined,
+          hasCountedSiblings
         })
         return {
           key: getCombinedDiffFileTreeSectionKey(treeMode, entry),

--- a/src/renderer/src/components/editor/combined-diff/remember-view/use-combined-diff-view-restore.ts
+++ b/src/renderer/src/components/editor/combined-diff/remember-view/use-combined-diff-view-restore.ts
@@ -7,7 +7,11 @@ import { buildCombinedGitStatusSignature } from '../resolve-changes/combined-dif
 import { combinedDiffSectionsMatchEntryMetadata } from '../resolve-changes/combined-diff-section-cache-match'
 import { getCombinedDiffFileTreeSectionKey } from '../resolve-changes/combined-diff-section-identity'
 import { isCombinedDiffSectionViewed } from '../browse-files/combined-diff-file-tree-filter'
-import { shouldLoadCombinedDiffOnDemand } from '../../combined-diff-on-demand-load'
+import {
+  collectCountedCombinedDiffPasses,
+  getCombinedDiffCountingPassKey,
+  shouldLoadCombinedDiffOnDemand
+} from '../../combined-diff-on-demand-load'
 import type { CombinedDiffEntrySet } from '../resolve-changes/use-combined-diff-entry-set'
 import type { CombinedDiffSectionLoadRegistry } from '../load-sections/combined-diff-section-load-registry'
 import { clearPendingSectionReloadTimers } from '../load-sections/combined-diff-section-load-registry'
@@ -134,11 +138,11 @@ export function useCombinedDiffViewRestore({
     scrollOffsetRef.current = combinedDiffScrollTopCache.get(viewStateKey) ?? 0
     scrollAnchorRef.current = combinedDiffScrollAnchorCache.get(viewStateKey) ?? null
     latestDomScrollAnchorRef.current = scrollAnchorRef.current
-    // Why: separates "this row is uncounted" from "this whole pass skipped
-    // counting", which is what decides whether an uncounted row is cheap.
-    const hasCountedSiblings = entries.some(
-      (entry) => entry.added !== undefined || entry.removed !== undefined
-    )
+    // Why: separates "this row is uncounted" from "this pass skipped counting",
+    // which decides whether an uncounted row is cheap. Per pass, not per view:
+    // `all` mode merges passes that fail independently, so a counted branch row
+    // must not vouch for an uncommitted pass that counted nothing.
+    const countedPasses = collectCountedCombinedDiffPasses(entries)
     setSections(
       entries.map((entry) => {
         const loadOnDemand = shouldLoadCombinedDiffOnDemand({
@@ -147,7 +151,7 @@ export function useCombinedDiffViewRestore({
           path: entry.path,
           area: 'area' in entry ? entry.area : undefined,
           submodule: 'submodule' in entry ? entry.submodule : undefined,
-          hasCountedSiblings
+          hasCountedSiblings: countedPasses.has(getCombinedDiffCountingPassKey(entry))
         })
         return {
           key: getCombinedDiffFileTreeSectionKey(treeMode, entry),

--- a/src/renderer/src/components/editor/combined-diff/remember-view/use-combined-diff-view-restore.ts
+++ b/src/renderer/src/components/editor/combined-diff/remember-view/use-combined-diff-view-restore.ts
@@ -139,7 +139,6 @@ export function useCombinedDiffViewRestore({
         const loadOnDemand = shouldLoadCombinedDiffOnDemand({
           added: 'added' in entry ? entry.added : undefined,
           removed: 'removed' in entry ? entry.removed : undefined,
-          area: 'area' in entry ? entry.area : undefined,
           path: entry.path
         })
         return {

--- a/src/renderer/src/components/editor/combined-diff/scroll-viewport/use-combined-diff-virtualizer.ts
+++ b/src/renderer/src/components/editor/combined-diff/scroll-viewport/use-combined-diff-virtualizer.ts
@@ -3,11 +3,7 @@ import type React from 'react'
 import { elementScroll, useVirtualizer, type Virtualizer } from '@tanstack/react-virtual'
 import type { ProgrammaticScrollMarks } from '@/hooks/programmatic-scroll-marks'
 import type { DiffSection } from '../../diff-section-types'
-import {
-  getDiffSectionEstimatedHeight,
-  isIntrinsicHeightImageDiff,
-  usesLargeDiffFallbackHeight
-} from '../../diff-section-layout'
+import { getDiffSectionRowEstimatedHeight } from '../../diff-section-layout'
 
 const COMBINED_DIFF_OVERSCAN = 5
 
@@ -39,19 +35,7 @@ export function useCombinedDiffVirtualizer({
         return 88
       }
 
-      return getDiffSectionEstimatedHeight({
-        collapsed: section.collapsed,
-        measuredContentHeight: sectionHeights[index],
-        originalContent: section.originalContent,
-        modifiedContent: section.modifiedContent,
-        changedLineCount:
-          section.added === undefined && section.removed === undefined
-            ? undefined
-            : (section.added ?? 0) + (section.removed ?? 0),
-        useIntrinsicImageHeight: isIntrinsicHeightImageDiff(section.diffResult),
-        isLargeDiffLimited: usesLargeDiffFallbackHeight(section),
-        lineCounts: section.largeDiffRenderLimit?.lineCounts ?? undefined
-      })
+      return getDiffSectionRowEstimatedHeight(section, sectionHeights[index])
     },
     overscan: COMBINED_DIFF_OVERSCAN,
     initialOffset: () => scrollOffsetRef.current,

--- a/src/renderer/src/components/editor/diff-section-layout.test.ts
+++ b/src/renderer/src/components/editor/diff-section-layout.test.ts
@@ -3,10 +3,27 @@ import {
   getDiffSectionBodyHeight,
   getLargeDiffFallbackBodyHeight,
   getDiffSectionEstimatedHeight,
+  getDiffSectionRowEstimatedHeight,
   isIntrinsicHeightImageDiff,
   usesLargeDiffFallbackHeight
 } from './diff-section-layout'
+import type { DiffSection } from './diff-section-types'
 import type { GitDiffResult } from '../../../../shared/git-diff-compare-types'
+
+const largeTextSection: DiffSection = {
+  key: 'section',
+  path: 'big.txt',
+  status: 'modified',
+  added: 50_000,
+  removed: 0,
+  originalContent: '',
+  modifiedContent: '',
+  collapsed: false,
+  loading: true,
+  dirty: false,
+  diffResult: null,
+  largeDiffRenderLimit: null
+}
 
 describe('diff section layout', () => {
   it('uses Monaco measured content height for text diffs', () => {
@@ -26,16 +43,28 @@ describe('diff section layout', () => {
 
   it('uses the bounded fallback height for an on-demand diff', () => {
     expect(
-      getDiffSectionEstimatedHeight({
-        collapsed: false,
-        measuredContentHeight: undefined,
-        originalContent: '',
-        modifiedContent: '',
-        changedLineCount: 60_000,
-        useIntrinsicImageHeight: false,
-        isLoadOnDemand: true
-      })
+      getDiffSectionRowEstimatedHeight(
+        { ...largeTextSection, loading: false, loadOnDemand: true },
+        undefined
+      )
     ).toBe(188)
+  })
+
+  // Why: every viewer's virtualizer must estimate the same height DiffSectionItem
+  // renders for these rows, or each large row drifts ~100px per measure pass.
+  it('estimates deferred and in-flight large rows at the rendered fallback height', () => {
+    expect(getDiffSectionRowEstimatedHeight(largeTextSection, undefined)).toBe(188)
+    expect(getDiffSectionRowEstimatedHeight(largeTextSection, 3_800_000)).toBe(188)
+    expect(
+      getDiffSectionRowEstimatedHeight(
+        { ...largeTextSection, added: undefined, removed: undefined, path: 'vendor/blob.bin' },
+        undefined
+      )
+    ).toBe(88)
+  })
+
+  it('estimates a collapsed row as a header, whatever its size', () => {
+    expect(getDiffSectionRowEstimatedHeight({ ...largeTextSection, collapsed: true }, 500)).toBe(28)
   })
 
   it('falls back to line-count height before Monaco has mounted', () => {

--- a/src/renderer/src/components/editor/diff-section-layout.ts
+++ b/src/renderer/src/components/editor/diff-section-layout.ts
@@ -39,7 +39,7 @@ export function getLargeDiffFallbackBodyHeight(): number {
 export function usesLargeDiffFallbackHeight(
   section: Pick<
     DiffSection,
-    'added' | 'area' | 'largeDiffRenderLimit' | 'loading' | 'loadOnDemand' | 'path' | 'removed'
+    'added' | 'largeDiffRenderLimit' | 'loading' | 'loadOnDemand' | 'path' | 'removed'
   >
 ): boolean {
   return (
@@ -93,18 +93,16 @@ export function getDiffSectionEstimatedHeight({
   changedLineCount,
   useIntrinsicImageHeight,
   lineCounts,
-  isLargeDiffLimited = false,
-  isLoadOnDemand = false
+  isLargeDiffLimited = false
 }: DiffSectionBodyHeightInput & {
   collapsed: boolean
   isLargeDiffLimited?: boolean
-  isLoadOnDemand?: boolean
 }): number {
   if (collapsed) {
     return DIFF_SECTION_HEADER_HEIGHT
   }
 
-  if (isLargeDiffLimited || isLoadOnDemand) {
+  if (isLargeDiffLimited) {
     return DIFF_SECTION_HEADER_HEIGHT + getLargeDiffFallbackBodyHeight()
   }
 
@@ -119,4 +117,40 @@ export function getDiffSectionEstimatedHeight({
       lineCounts
     }) ?? MIN_DIFF_SECTION_BODY_HEIGHT)
   )
+}
+
+/**
+ * Single virtualizer estimate for a diff row, shared by the worktree and
+ * PR-review viewers so no viewer estimates a row the row's own layout metrics
+ * (useDiffSectionLayoutMetrics) would size from the bounded fallback instead.
+ */
+export function getDiffSectionRowEstimatedHeight(
+  section: Pick<
+    DiffSection,
+    | 'added'
+    | 'collapsed'
+    | 'diffResult'
+    | 'largeDiffRenderLimit'
+    | 'loading'
+    | 'loadOnDemand'
+    | 'modifiedContent'
+    | 'originalContent'
+    | 'path'
+    | 'removed'
+  >,
+  measuredContentHeight: number | undefined
+): number {
+  return getDiffSectionEstimatedHeight({
+    collapsed: section.collapsed,
+    measuredContentHeight,
+    originalContent: section.originalContent,
+    modifiedContent: section.modifiedContent,
+    changedLineCount:
+      section.added === undefined && section.removed === undefined
+        ? undefined
+        : (section.added ?? 0) + (section.removed ?? 0),
+    useIntrinsicImageHeight: isIntrinsicHeightImageDiff(section.diffResult),
+    isLargeDiffLimited: usesLargeDiffFallbackHeight(section),
+    lineCounts: section.largeDiffRenderLimit?.lineCounts ?? undefined
+  })
 }

--- a/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-viewer.tsx
+++ b/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-viewer.tsx
@@ -4,10 +4,7 @@ import type { editor as monacoEditor } from 'monaco-editor'
 import type { DecoratedDiffComment } from '@/components/diff-comments/decorated-diff-comment'
 import { createCombinedDiffSectionIndexMap } from '../../editor/combined-diff/resolve-changes/combined-diff-section-identity'
 import { handleCombinedDiffFileTreeNavigation } from '../../editor/combined-diff/browse-files/combined-diff-file-tree-navigation'
-import {
-  getDiffSectionEstimatedHeight,
-  isIntrinsicHeightImageDiff
-} from '@/components/editor/diff-section-layout'
+import { getDiffSectionRowEstimatedHeight } from '@/components/editor/diff-section-layout'
 import type { DiffSection } from '@/components/editor/diff-section-types'
 import { getCombinedDiffBranchEntriesInTreeOrder } from '../../editor/combined-diff/browse-files/combined-diff-file-tree-filter'
 import type { CombinedDiffFileTreeEntry } from '../../editor/combined-diff/resolve-changes/combined-diff-section-identity'
@@ -239,19 +236,7 @@ function PRFilesCombinedDiffSections({
       if (!section) {
         return 88
       }
-      return getDiffSectionEstimatedHeight({
-        collapsed: section.collapsed,
-        measuredContentHeight: sectionHeights[index],
-        originalContent: section.originalContent,
-        modifiedContent: section.modifiedContent,
-        changedLineCount:
-          section.added === undefined && section.removed === undefined
-            ? undefined
-            : (section.added ?? 0) + (section.removed ?? 0),
-        useIntrinsicImageHeight: isIntrinsicHeightImageDiff(section.diffResult),
-        isLargeDiffLimited: section.largeDiffRenderLimit?.limited === true,
-        lineCounts: section.largeDiffRenderLimit?.lineCounts ?? undefined
-      })
+      return getDiffSectionRowEstimatedHeight(section, sectionHeights[index])
     },
     overscan: PR_DIFF_OVERSCAN,
     getItemKey: (index) => {

--- a/src/renderer/src/components/pull-request-page/files/combined-diff-viewer.tsx
+++ b/src/renderer/src/components/pull-request-page/files/combined-diff-viewer.tsx
@@ -6,10 +6,7 @@ import { DiffSectionItem } from '@/components/editor/DiffSectionItem'
 import { CombinedDiffFileTree } from '../../editor/combined-diff/browse-files/combined-diff-file-tree'
 import { createCombinedDiffSectionIndexMap } from '../../editor/combined-diff/resolve-changes/combined-diff-section-identity'
 import { handleCombinedDiffFileTreeNavigation } from '../../editor/combined-diff/browse-files/combined-diff-file-tree-navigation'
-import {
-  getDiffSectionEstimatedHeight,
-  isIntrinsicHeightImageDiff
-} from '@/components/editor/diff-section-layout'
+import { getDiffSectionRowEstimatedHeight } from '@/components/editor/diff-section-layout'
 import type { DiffSection } from '@/components/editor/diff-section-types'
 import { getCombinedDiffBranchEntriesInTreeOrder } from '../../editor/combined-diff/browse-files/combined-diff-file-tree-filter'
 import type { CombinedDiffFileTreeEntry } from '../../editor/combined-diff/resolve-changes/combined-diff-section-identity'
@@ -201,19 +198,7 @@ export function PRFilesCombinedDiffViewer({
       if (!section) {
         return 88
       }
-      return getDiffSectionEstimatedHeight({
-        collapsed: section.collapsed,
-        measuredContentHeight: sectionHeights[index],
-        originalContent: section.originalContent,
-        modifiedContent: section.modifiedContent,
-        changedLineCount:
-          section.added === undefined && section.removed === undefined
-            ? undefined
-            : (section.added ?? 0) + (section.removed ?? 0),
-        useIntrinsicImageHeight: isIntrinsicHeightImageDiff(section.diffResult),
-        isLargeDiffLimited: section.largeDiffRenderLimit?.limited === true,
-        lineCounts: section.largeDiffRenderLimit?.lineCounts ?? undefined
-      })
+      return getDiffSectionRowEstimatedHeight(section, sectionHeights[index])
     },
     overscan: PR_DIFF_OVERSCAN,
     getItemKey: (index) => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14896,6 +14896,7 @@
         },
         "LargeDiffLoadPrompt": {
           "a0af0198aa": "Large diffs are not rendered by default.",
+          "c3d9f4a712": "This diff's size isn't known yet, so it loads on request.",
           "f7fa7a40d0": "Load diff"
         }
       },

--- a/src/shared/binary-file-extensions.test.ts
+++ b/src/shared/binary-file-extensions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { hasBinaryFileExtension } from './binary-file-extensions'
+
+describe('hasBinaryFileExtension', () => {
+  it('matches known binary extensions case-insensitively', () => {
+    expect(hasBinaryFileExtension('docs/Shot.PNG')).toBe(true)
+    expect(hasBinaryFileExtension('vendor/lib.tar.gz')).toBe(true)
+    expect(hasBinaryFileExtension('C:\\assets\\theme.woff2')).toBe(true)
+  })
+
+  it('treats svg as text because the diff view renders its source', () => {
+    expect(hasBinaryFileExtension('assets/map.svg')).toBe(false)
+  })
+
+  it('rejects text files, dotfiles, and extensionless paths', () => {
+    expect(hasBinaryFileExtension('src/index.ts')).toBe(false)
+    expect(hasBinaryFileExtension('.gitignore')).toBe(false)
+    expect(hasBinaryFileExtension('scripts/.eslintrc')).toBe(false)
+    expect(hasBinaryFileExtension('Makefile')).toBe(false)
+    expect(hasBinaryFileExtension(undefined)).toBe(false)
+  })
+
+  it('does not match an extension that only appears in a directory name', () => {
+    expect(hasBinaryFileExtension('build.zip/manifest')).toBe(false)
+  })
+})

--- a/src/shared/binary-file-extensions.ts
+++ b/src/shared/binary-file-extensions.ts
@@ -1,0 +1,90 @@
+import { IMAGE_FILE_EXTENSIONS } from './image-file-extensions'
+
+// SVG is an image format that editors open as source text, so it stays out of
+// the binary set even though it lives in IMAGE_FILE_EXTENSIONS.
+const TEXT_IMAGE_EXTENSIONS = new Set(['.svg'])
+
+const NON_IMAGE_BINARY_EXTENSIONS = [
+  // Archives
+  '.7z',
+  '.bz2',
+  '.gz',
+  '.jar',
+  '.rar',
+  '.tar',
+  '.tgz',
+  '.war',
+  '.xz',
+  '.zip',
+  '.zst',
+  // Audio and video
+  '.aac',
+  '.avi',
+  '.flac',
+  '.m4a',
+  '.mkv',
+  '.mov',
+  '.mp3',
+  '.mp4',
+  '.ogg',
+  '.wav',
+  '.webm',
+  // Documents
+  '.doc',
+  '.docx',
+  '.pdf',
+  '.ppt',
+  '.pptx',
+  '.xls',
+  '.xlsx',
+  // Fonts
+  '.eot',
+  '.otf',
+  '.ttc',
+  '.ttf',
+  '.woff',
+  '.woff2',
+  // Compiled artifacts and datastores
+  '.a',
+  '.bin',
+  '.class',
+  '.dll',
+  '.dylib',
+  '.exe',
+  '.idx',
+  '.lockb',
+  '.node',
+  '.o',
+  '.pack',
+  '.pyc',
+  '.pyd',
+  '.so',
+  '.sqlite',
+  '.sqlite3',
+  '.wasm'
+]
+
+export const BINARY_FILE_EXTENSIONS: readonly string[] = Object.freeze([
+  ...IMAGE_FILE_EXTENSIONS.filter((extension) => !TEXT_IMAGE_EXTENSIONS.has(extension)),
+  ...NON_IMAGE_BINARY_EXTENSIONS
+])
+
+const BINARY_FILE_EXTENSION_SET = new Set(BINARY_FILE_EXTENSIONS)
+
+/**
+ * Extension-only guess at "this file is not text". Content-based detection
+ * lives in `isBinaryBuffer`; use this only where the bytes are unavailable.
+ */
+export function hasBinaryFileExtension(filePath: string | undefined): boolean {
+  if (filePath === undefined) {
+    return false
+  }
+  const lowerPath = filePath.toLowerCase()
+  const dotIndex = lowerPath.lastIndexOf('.')
+  const separatorIndex = Math.max(lowerPath.lastIndexOf('/'), lowerPath.lastIndexOf('\\'))
+  // A leading dot is a dotfile (.gitignore), not an extension.
+  if (dotIndex <= separatorIndex + 1) {
+    return false
+  }
+  return BINARY_FILE_EXTENSION_SET.has(lowerPath.slice(dotIndex))
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​244 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​226 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​196 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​75 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​121 |

<!-- /orca-pr-loc -->

Follow-up to #17521 ("perf(diff): defer large diffs until user loads them"). Two rounds of review fixes were pushed to that PR's branch and then dropped by a force-push before the squash-merge, so several confirmed findings shipped to `main`. This re-checks all nine against current `main` and fixes the ones still live.

## Verdicts

| # | Finding | On current `main` |
|---|---|---|
| 1 | "line counts unavailable" treated as "diff too large", so ordinary untracked files get the Load-diff prompt | **LIVE** (fixed here) |
| 2 | Deferral silently disabled whenever git status omits line stats, so the freeze returns in the largest worktrees | **LIVE** (fixed here) |
| 3 | SVG exemption re-opens the Monaco freeze | **FIXED on main** — the author's final commit (1e2c9d5) removed `.svg` from the previewed-image exemption; kept fixed here, with a regression test |
| 4 | Untracked binaries sit behind a "Large diffs" prompt regardless of size | **LIVE** (fixed here) |
| 5 | Shared body-height rule leaks into the two PR-review viewers whose `estimateSize` was not updated | **LIVE** (fixed here) |
| 6 | PR-review virtualizers estimate loading large rows at 88px while the DOM row is 188px | **LIVE** (fixed here) — reproduced exactly: `expected 88 to be 188` |
| 7 | `getDiffSectionEstimatedHeight`'s `isLoadOnDemand` parameter is dead | **LIVE** (removed here) — no production caller, only one test used it |
| 8 | `use-combined-diff-tree-navigation.ts:58` not oxfmt-formatted | **FIXED on main** by #17694 ("fix: satisfy GitLab hook and test lint gates"); `oxfmt --check` on that file is clean, nothing to do |
| 9 | duplicate of 8 | same as 8 |

## Findings 1, 2, 4 — route taken: narrower fix, no new field

Two earlier attempts added a `binary` field to `GitStatusEntry` and had to chase it through six sibling projections (store equality gate, section-cache match, status signature, snapshot retain, moved-area rebuild, line-stats reuse cache), regressing each round. **This change adds no field and touches no wire, store, or cache.**

`shouldLoadCombinedDiffOnDemand` decides uncounted rows from signals already on the entry — never from the staging area:

```ts
if (added === undefined && removed === undefined) {
  if (submodule !== undefined || hasBinaryFileExtension(path)) return false
  if (hasCountedSiblings === true && area !== 'untracked') return false
  return true
}
return (added ?? 0) + (removed ?? 0) > MAX_AUTOMATIC_DIFF_CHANGED_LINES
```

A row with no counts is one of: a binary file (numstat reports `-`, and the untracked scan skips binaries), an untracked file past `MAX_UNTRACKED_LINE_COUNT_BYTES`, or *any* file in a pass that skipped counting entirely (`didHitLimit`, or a failed numstat). Only the first is cheap to render, so binaries and submodules stay automatic and anything Monaco would open as unbounded text defers.

The path check alone was too coarse — a hardcoded extension list can never cover every tracked binary (this repo's own `resources/build/icon.icns`, plus `.tiff` / `.psd` / extensionless). `hasCountedSiblings` closes that: if another row in the **same counting pass** carried counts, counting demonstrably ran, so a tracked row that is still uncounted can only be numstat's binary marker. "Same pass" is keyed per staging area and `compare`, because `status-line-stats.ts` runs a separate `runNumstat` per area and each fails independently — a counted branch-compare row must not vouch for an uncommitted pass that counted nothing.

- **Finding 2:** when a status pass omits line stats — exactly the >1000-entry worktrees where `status-read.ts` / `git-handler-status-ops.ts` skip numstat past the cap — large tracked rows now defer instead of auto-loading into the freeze.
- **Finding 4:** an untracked `.zip` / `.woff2` / `bun.lockb` no longer sits behind a prompt; it renders its binary stub immediately.
- **Finding 1:** an uncounted row is only prompted when its path could be text. In a healthy pass every text file carries counts, so the prompt is limited to genuinely oversized untracked text plus the counting-skipped case, where deferring is the deliberate choice (see below).

New `src/shared/binary-file-extensions.ts` holds the extension set (built on `IMAGE_FILE_EXTENSIONS`, with `.svg` deliberately excluded because the diff view renders its source), complementing the content-based `isBinaryBuffer` in `src/shared/binary-buffer.ts`.

## Findings 5, 6, 7 — one shared row estimate

All three virtualizers had the same 12-line `estimateSize` body, but the two PR-review copies passed `isLargeDiffLimited: section.largeDiffRenderLimit?.limited === true` while `useDiffSectionLayoutMetrics` (used by `DiffSectionItem` in *all* viewers) sizes deferred and in-flight large rows from the bounded fallback. A loading 50k-line row therefore estimated 88px and measured 188px in the PR viewers.

`getDiffSectionRowEstimatedHeight(section, measuredContentHeight)` in `diff-section-layout.ts` is now the single estimate, calling `usesLargeDiffFallbackHeight` exactly like the row's own layout metrics, and all three viewers call it. `isLoadOnDemand` (finding 7) is deleted — `usesLargeDiffFallbackHeight` already covers that state.

## Prompt copy: two deferral reasons, two sentences

The prompt said "Large diffs are not rendered by default." for every deferred row, which is false for the uncounted half — a lone tracked `resources/build/icon.icns` with no counted sibling in its own pass may be 4 KB. `LargeDiffLoadPrompt` now splits on `isCombinedDiffSizeUnknown(section)`, which mirrors the uncounted branch of the predicate above:

- counts present and over the limit → "Large diffs are not rendered by default."
- no counts at all → "This diff's size isn't known yet, so it loads on request."

Renderer-local: the section already carries `added` / `removed`, so this crosses no wire and touches neither `attachLineStats` copy nor the line-stats reuse cache.

## Accepted trade-offs

1. **Per-pass keying is finer than the review asked for.** The fix needed to stop pooling uncommitted rows with branch-compare rows; keying `hasCountedSiblings` by staging area also splits staged from unstaged. That matches how the counts are actually produced (`status-line-stats.ts:56-60` runs one `runNumstat` per area, each able to fail independently), but it is a real user-visible delta: entries `[{path:'src/a.ts', area:'staged', added:5}, {path:'resources/build/icon.icns', area:'unstaged'}]` give `loadOnDemand` `[false, false]` before the last commit and `[false, true]` after. So a user who stages their text edits and then touches one tracked binary now sees a prompt on that binary where it previously auto-loaded. The direction is safe — the new membership test is a strict subset of the old `entries.some(...)`, so nothing that used to defer now auto-loads — the row keeps its own Load-diff button, and the copy split above means the prompt no longer misdescribes it.
2. **Unknown size still defers.** When a pass counts nothing at all (capped listing, numstat failure, or an SSH host older than #2865 that never sends counts), no row has a counted sibling, so every text row in that pass shows the prompt. Over 1000 changed entries is precisely the freeze this deferral exists for; auto-loading that many unbounded Monaco models is the bug, not the mitigation. The gap this leaves is a bulk "load all", which would reinstate the freeze on demand.
3. **Class 1 of the original charter stays open deliberately.** A lone tracked binary outside `BINARY_FILE_EXTENSIONS`, with no counted sibling, still shows the prompt. Only numstat's `-\t-` knows it is binary, and that stdout is parsed on the host, so surfacing it per row means a new field on `GitStatusEntry` and `GitBranchChangeEntry` re-applied in two `attachLineStats` copies and in a reuse cache that persists only `{added, removed}` — the six-projection chase this PR set out to avoid. Reusing `added: 0` instead changes what the host publishes to old clients and mobile and collapses the undefined-vs-zero distinction the virtualizer's height estimate reads. Not worth a wire field, and not worth another hardcoded extension.

## Tests

Every new assertion was confirmed red against pre-fix code first:
- finding 2: uncounted tracked text row → `expected false to be true`
- finding 3: uncounted `.svg` outside the untracked area → `expected false to be true`
- finding 4: untracked `.zip` / `.woff2` / `bun.lockb` → `expected true to be false`
- findings 5/6: PR-review `estimateSize` body on a loading 50k-line row → `expected 88 to be 188`
- per-pass keying: uncounted unstaged binary with only a counted *compare* sibling → `expected false to be true`
- prompt copy: `sizeUnknown` variant → `Unable to find an element with the text: This diff's size isn't known yet…`

## Verification

- `pnpm exec oxlint <changed files>` — clean
- `pnpm exec oxlint --config config/oxlint-code-quality-native-plugins.json --deny-warnings <changed files>` — clean
- `pnpm exec oxfmt --check <changed files>` — clean
- `pnpm test src/renderer/src/components/editor src/shared/binary-file-extensions.test.ts` — 190 files, 1281 tests passed
- `pnpm test src/renderer/src/components/pull-request-page src/renderer/src/components/github-item-dialog` — 6 files, 38 tests passed
- `pnpm test src/renderer/src/i18n` — 18 files, 147 tests passed
- `pnpm tc:web` — clean
