### PR TITLE
fix(terminal): keep restored OSC-8 ranges across a no-op resize

### DIFF
--- a/src/main/daemon/headless-emulator-restored-osc-links.test.ts
+++ b/src/main/daemon/headless-emulator-restored-osc-links.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { HeadlessEmulator } from './headless-emulator'
+
+// Why this suite: restored OSC-8 ranges are row-indexed, so a reflow
+// invalidates them — but a resize to the size already applied is not a reflow.
+// Cold restore seeds the ranges and then replays records that resize, and
+// same-size resize records reach the durable log because every attach
+// re-asserts the pane's dimensions.
+let emulator: HeadlessEmulator | undefined
+
+const LINK = { row: 0, startCol: 0, endCol: 4, uri: 'https://example.com' }
+
+afterEach(() => {
+  emulator?.dispose()
+  emulator = undefined
+})
+
+describe('HeadlessEmulator restored OSC link ranges', () => {
+  it('keeps restored ranges across a resize to the size already applied', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('link target')
+    emulator.setRestoredOscLinks([LINK])
+
+    emulator.resize(80, 24)
+
+    expect(emulator.getSnapshot().oscLinks).toEqual([LINK])
+  })
+
+  it('drops restored ranges when the dimensions actually change', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('link target')
+    emulator.setRestoredOscLinks([LINK])
+
+    emulator.resize(100, 24)
+
+    expect(emulator.getSnapshot().oscLinks).toEqual([])
+  })
+
+  it('drops restored ranges on a row-count change', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('link target')
+    emulator.setRestoredOscLinks([LINK])
+
+    emulator.resize(80, 40)
+
+    expect(emulator.getSnapshot().oscLinks).toEqual([])
+  })
+
+  it('survives a replayed run of same-size resize records', async () => {
+    // Why: mirrors history-reader's replay loop, which resizes per record.
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('link target')
+    emulator.setRestoredOscLinks([LINK])
+
+    for (let i = 0; i < 5; i++) {
+      emulator.resize(80, 24)
+    }
+
+    expect(emulator.getSnapshot().oscLinks).toEqual([LINK])
+  })
+
+  it('still drops restored ranges on clearScrollback', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('link target')
+    emulator.setRestoredOscLinks([LINK])
+
+    emulator.clearScrollback()
+
+    expect(emulator.getSnapshot().oscLinks).toEqual([])
+  })
+})

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -231,6 +231,15 @@ export class HeadlessEmulator {
     if (this.disposed) {
       return
     }
+    // Why gated: restored OSC-8 ranges are row-indexed, so a reflow
+    // invalidates them — but a resize to the size already applied is not a
+    // reflow. Cold restore seeds the ranges and then replays records that
+    // resize, and same-size records reach the durable log because every
+    // attach re-asserts the pane's dimensions, so clearing unconditionally
+    // dropped the links a restore had just recovered.
+    if (this.terminal.cols === cols && this.terminal.rows === rows) {
+      return
+    }
     this.restoredOscLinks = []
     this.terminal.resize(cols, rows)
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

Fixes #17756.

## ELI5

Terminals can contain clickable links. When Orca restores a terminal's history after a restart, it recovers those links along with the text.

It was throwing them away. Restored links are remembered by **which row** they're on, so if the terminal gets resized the remembered positions are wrong and Orca clears them — correct. But it also cleared them when the terminal was "resized" to the size it already was, which isn't a resize at all. That happens routinely: every time you reattach to a terminal, Orca re-asserts its dimensions.

So the common case — restore a session, reattach to it — silently lost every clickable link in the restored scrollback. Now a resize only clears them when the size actually changed.

## The bug

`HeadlessEmulator.resize()` cleared `restoredOscLinks` unconditionally:

```ts
resize(cols, rows) {
  if (this.disposed) return
  this.restoredOscLinks = []      // fires even when dimensions are unchanged
  this.terminal.resize(cols, rows)
}
```

The cold-restore path seeds the ranges and then replays records that resize:

- `history-reader.ts:298` — `setRestoredOscLinks(checkpoint.oscLinks)` → `:313` — `replay.resize(record.cols, record.rows)`
- `daemon-durable-history-snapshot.ts:91` (set) → `:180` (resize, via `replayPendingRecords`)

And same-size resize records genuinely reach the durable log: `session-output-plane.ts:109-111` records every resize with no same-size dedupe, while every attach re-asserts the pane's dimensions.

**Net effect:** cold-restore a session whose post-checkpoint log holds any resize record — including a no-op one from an ordinary reattach — and the checkpoint's OSC-8 ranges are dropped. Restored hyperlinks lose clickability. Cosmetic fidelity loss, not corruption.

## Where it was introduced

**d46349ce82f** — `fix: improve mobile link modifier handling` (#5597), 19 Jun 2026.

That commit added `setRestoredOscLinks` and, in the same change, unconditional clearing in both `resize()` and `clearScrollback()`:

```diff
     if (this.disposed) {
       return
     }
+    this.restoredOscLinks = []
     this.terminal.resize(cols, rows)
```

The intent was right — row-indexed ranges don't survive a reflow — but the guard was missing, so it also fired on same-size resizes. `clearScrollback()`'s clearing from that commit is correct and is left alone (with a test pinning it).

## Not a regression from the recent perf work

#17667 incidentally masked this by gating no-op resizes to protect a snapshot cache; #17752 removed that cache and with it the gate, restoring the pre-existing behavior byte-for-byte. So the bug was latent from June, briefly hidden, and is now fixed on its own terms — as a correctness change with tests, rather than as a side effect of a cache.

## Fix

Return early when `cols`/`rows` already match. Chosen over deduping resize records in `session-output-plane.ts` because it fixes the root cause for **every** caller — live sessions, replay emulators, and runtime mirrors — not just the durable-log path.

## Verification

New `headless-emulator-restored-osc-links.test.ts`, 5 cases. **Confirmed the two same-size cases fail before the fix and pass after**; the three real-invalidation cases (col change, row change, `clearScrollback`) pass throughout, so the fix doesn't over-correct.

`pnpm tc` clean; 2956 tests pass across `src/main/daemon` and the runtime suites; changed-code quality gate clean.

## Risk

Daemon-only; no renderer, wire, or persisted-format change.
