### PR TITLE
perf(renderer): fetch host lineage once per connect, narrow sidebar ack subscriptions

### DIFF
--- a/src/renderer/src/components/settings/use-runtime-environment-connection-actions.ts
+++ b/src/renderer/src/components/settings/use-runtime-environment-connection-actions.ts
@@ -8,6 +8,7 @@ import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-e
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
 import { evaluateHostDetails, type RuntimeHostDetails } from './runtime-environment-host-details'
 import { LOCAL_RUNTIME_VALUE, NO_RUNTIME_VALUE } from './runtime-environment-selection'
+import { refreshRuntimeProjectWorktreesAndLineage } from '@/hooks/runtime-project-refresh-scheduler'
 
 type RuntimeEnvironmentConnectionActionParams = {
   allowLocalRuntime: boolean
@@ -120,8 +121,12 @@ export function useRuntimeEnvironmentConnectionActions({
       // Why: Connect is not the Active Server selector anymore, but connected
       // hosts should still contribute their projects/workspaces to the sidebar.
       const repos = await store.fetchRuntimeEnvironmentRepos(environment.id)
-      await Promise.all(repos.map((repo) => useAppStore.getState().fetchWorktrees(repo.id)))
-      await useAppStore.getState().fetchWorktreeLineage()
+      await refreshRuntimeProjectWorktreesAndLineage(
+        environment.id,
+        repos,
+        (repoId, options) => useAppStore.getState().fetchWorktrees(repoId, options),
+        (options) => useAppStore.getState().fetchWorktreeLineage(options)
+      )
       if (mountedRef.current) {
         toast.success(
           translate(

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -27,6 +27,7 @@ import { revealElementInScrollContainer } from './worktree-sidebar-reveal'
 import { useWorktreeAgentExpansionState } from './worktree-card-agents-expansion-state'
 import { translate } from '@/i18n/i18n'
 import { activateStructuredAgentSessionTab } from '@/lib/structured-agent-session-tab-activation'
+import { selectAcknowledgedAgentTimes } from './worktree-card-agent-ack-inputs'
 
 export const SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT =
   'orca-suppress-worktree-list-scroll-adjustment'
@@ -90,16 +91,19 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
   const focusedAgentPaneKey = useFocusedAgentPaneKey(worktreeId)
   const compactAgentListRootRef = useRef<HTMLDivElement | null>(null)
 
-  // Why: derive per-agent unvisited flags from the ack map so rows bold on first appearance and mute once the tab is visited.
-  const acknowledgedAgentsByPaneKey = useAppStore((s) => s.acknowledgedAgentsByPaneKey)
+  // Why: acknowledgement writes are app-global; project only this card's rows
+  // so unrelated worktree activity does not rerender every agent body.
+  const acknowledgedAgentTimes = useAppStore(
+    useShallow((s) => selectAcknowledgedAgentTimes(s, agents))
+  )
   const unvisitedByPaneKey = useMemo(() => {
     const out: Record<string, boolean> = {}
-    for (const a of agents) {
-      const ackAt = acknowledgedAgentsByPaneKey[a.paneKey] ?? 0
-      out[a.paneKey] = ackAt < a.entry.stateStartedAt
+    for (const [index, agent] of agents.entries()) {
+      const ackAt = acknowledgedAgentTimes[index] ?? 0
+      out[agent.paneKey] = ackAt < agent.entry.stateStartedAt
     }
     return out
-  }, [agents, acknowledgedAgentsByPaneKey])
+  }, [agents, acknowledgedAgentTimes])
 
   const handleDismissAgent = useCallback(
     (paneKey: string) => {

--- a/src/renderer/src/components/sidebar/worktree-card-agent-ack-inputs.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-agent-ack-inputs.test.tsx
@@ -1,0 +1,99 @@
+/** @vitest-environment happy-dom */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { create } from 'zustand'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { shallow } from 'zustand/shallow'
+import { useShallow } from 'zustand/react/shallow'
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import { selectAcknowledgedAgentTimes } from './worktree-card-agent-ack-inputs'
+
+const AGENTS = [{ paneKey: 'tab-a:leaf-a' }, { paneKey: 'tab-a:leaf-b' }] as const
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+type AckStoreState = {
+  acknowledgedAgentsByPaneKey: Record<string, number>
+}
+
+const useAckStore = create<AckStoreState>(() => ({ acknowledgedAgentsByPaneKey: {} }))
+
+let renderCount = 0
+let selectedTimes: readonly number[] | undefined
+
+function SelectionProbe({ agents }: { agents: readonly Pick<DashboardAgentRow, 'paneKey'>[] }) {
+  selectedTimes = useAckStore(useShallow((state) => selectAcknowledgedAgentTimes(state, agents)))
+  renderCount += 1
+  return null
+}
+
+describe('selectAcknowledgedAgentTimes', () => {
+  let root: Root
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    useAckStore.setState({ acknowledgedAgentsByPaneKey: {} })
+    renderCount = 0
+    selectedTimes = undefined
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => root.render(<SelectionProbe agents={AGENTS} />))
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('projects only this card rows so unrelated acknowledgements stay shallow-equal', () => {
+    const initialTimes = selectedTimes
+
+    act(() => {
+      useAckStore.setState({ acknowledgedAgentsByPaneKey: { 'tab-other:leaf': 99 } })
+    })
+
+    expect(renderCount).toBe(1)
+    expect(selectedTimes).toBe(initialTimes)
+
+    const before = selectAcknowledgedAgentTimes(
+      { acknowledgedAgentsByPaneKey: { 'tab-a:leaf-a': 10, 'tab-a:leaf-b': 20 } },
+      AGENTS
+    )
+    const after = selectAcknowledgedAgentTimes(
+      {
+        acknowledgedAgentsByPaneKey: {
+          'tab-a:leaf-a': 10,
+          'tab-a:leaf-b': 20,
+          'tab-other:leaf': 99
+        }
+      },
+      AGENTS
+    )
+
+    expect(after).toEqual(before)
+    expect(shallow(after, before)).toBe(true)
+  })
+
+  it('updates when one of this card rows is acknowledged', () => {
+    const initialTimes = selectedTimes
+    act(() => {
+      useAckStore.setState({ acknowledgedAgentsByPaneKey: { 'tab-a:leaf-a': 11 } })
+    })
+    expect(renderCount).toBe(2)
+    expect(selectedTimes).not.toBe(initialTimes)
+    expect(selectedTimes).toEqual([11, 0])
+
+    const before = selectAcknowledgedAgentTimes(
+      { acknowledgedAgentsByPaneKey: { 'tab-a:leaf-a': 10 } },
+      AGENTS
+    )
+    const after = selectAcknowledgedAgentTimes(
+      { acknowledgedAgentsByPaneKey: { 'tab-a:leaf-a': 11 } },
+      AGENTS
+    )
+
+    expect(after).toEqual([11, 0])
+    expect(shallow(after, before)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-card-agent-ack-inputs.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-agent-ack-inputs.ts
@@ -1,0 +1,12 @@
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import type { AppState } from '@/store/types'
+
+type AcknowledgedAgentTimesState = Pick<AppState, 'acknowledgedAgentsByPaneKey'>
+
+/** Projects only the acknowledgement timestamps rendered by one card. */
+export function selectAcknowledgedAgentTimes(
+  state: AcknowledgedAgentTimesState,
+  agents: readonly Pick<DashboardAgentRow, 'paneKey'>[]
+): number[] {
+  return agents.map((agent) => state.acknowledgedAgentsByPaneKey[agent.paneKey] ?? 0)
+}

--- a/src/renderer/src/components/status-bar/SshStatusSegment.test.ts
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.test.ts
@@ -20,7 +20,16 @@ describe('connectRuntimeHostForNavigation', () => {
 
     expect(fetchRepos).toHaveBeenCalledWith('windows-2')
     expect(fetchWorktrees).toHaveBeenCalledTimes(2)
+    expect(fetchWorktrees).toHaveBeenNthCalledWith(1, 'repo-a', {
+      executionHostId: 'runtime:windows-2',
+      suppressRemoteLineageRefresh: true
+    })
+    expect(fetchWorktrees).toHaveBeenNthCalledWith(2, 'repo-b', {
+      executionHostId: 'runtime:windows-2',
+      suppressRemoteLineageRefresh: true
+    })
     expect(fetchLineage).toHaveBeenCalledOnce()
+    expect(fetchLineage).toHaveBeenCalledWith({ executionHostId: 'runtime:windows-2' })
   })
 
   it('does not load a catalog when the server is unreachable', async () => {

--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -36,20 +36,29 @@ import {
   runtimeHostConnectionState,
   runtimeStatusForOverall
 } from '@/runtime/runtime-host-connection-state'
+import { refreshRuntimeProjectWorktreesAndLineage } from '@/hooks/runtime-project-refresh-scheduler'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 
 export async function connectRuntimeHostForNavigation(args: {
   environmentId: string
   refreshStatus: (environmentId: string, timeoutMs: number) => Promise<boolean>
   fetchRepos: (environmentId: string) => Promise<{ id: string }[]>
-  fetchWorktrees: (repoId: string) => Promise<unknown>
-  fetchLineage: () => Promise<unknown>
+  fetchWorktrees: (
+    repoId: string,
+    options: { executionHostId: ExecutionHostId; suppressRemoteLineageRefresh: true }
+  ) => Promise<unknown>
+  fetchLineage: (options: { executionHostId: ExecutionHostId }) => Promise<unknown>
 }): Promise<boolean> {
   if (!(await args.refreshStatus(args.environmentId, 5_000))) {
     return false
   }
   const repos = await args.fetchRepos(args.environmentId)
-  await Promise.all(repos.map((repo) => args.fetchWorktrees(repo.id)))
-  await args.fetchLineage()
+  await refreshRuntimeProjectWorktreesAndLineage(
+    args.environmentId,
+    repos,
+    args.fetchWorktrees,
+    args.fetchLineage
+  )
   return true
 }
 

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
@@ -65,6 +65,29 @@ describe('refreshRuntimeProjectWorktrees', () => {
     expect(peak).toBe(5)
   })
 
+  it('gives interactive connect a wider lane than the coalesced event lane', async () => {
+    // Connect is one-shot and the user is waiting on it, so it runs wider than
+    // the background event lane, which can repeat and coalesce many repos.
+    let active = 0
+    let peak = 0
+    const fetchWorktrees = vi.fn(async (): Promise<void> => {
+      active += 1
+      peak = Math.max(peak, active)
+      await new Promise<void>((resolve) => setTimeout(resolve, 5))
+      active -= 1
+    })
+
+    await refreshRuntimeProjectWorktreesAndLineage(
+      'env-1',
+      Array.from({ length: 40 }, (_, index) => ({ id: `repo-${index}` })),
+      fetchWorktrees,
+      vi.fn().mockResolvedValue(true)
+    )
+
+    expect(fetchWorktrees).toHaveBeenCalledTimes(40)
+    expect(peak).toBe(15)
+  })
+
   it('retains both repo and final lineage failures', async () => {
     const repoError = new Error('repo refresh failed')
     const lineageError = new Error('lineage refresh failed')

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
@@ -43,6 +43,28 @@ describe('refreshRuntimeProjectWorktrees', () => {
     })
   })
 
+  it('limits a large catalog to the bounded worktree refresh lane', async () => {
+    let active = 0
+    let peak = 0
+    const fetchWorktrees = vi.fn(
+      async (_repoId: string, _options: { executionHostId: string }): Promise<void> => {
+        active += 1
+        peak = Math.max(peak, active)
+        await new Promise<void>((resolve) => setTimeout(resolve, 5))
+        active -= 1
+      }
+    )
+
+    await refreshRuntimeProjectWorktrees(
+      'env-1',
+      Array.from({ length: 12 }, (_, index) => ({ id: `repo-${index}` })),
+      fetchWorktrees
+    )
+
+    expect(fetchWorktrees).toHaveBeenCalledTimes(12)
+    expect(peak).toBe(5)
+  })
+
   it('retains both repo and final lineage failures', async () => {
     const repoError = new Error('repo refresh failed')
     const lineageError = new Error('lineage refresh failed')

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
@@ -23,6 +23,8 @@ type RefreshEntry = {
 const DEFAULT_DEBOUNCE_MS = 250
 const DEFAULT_MIN_INTERVAL_MS = 5_000
 const DEFAULT_REFRESH_CONCURRENCY = 5
+/** Connect is one-shot and the user is waiting, so it cannot storm the way the coalesced event lane can. */
+export const INTERACTIVE_CONNECT_REFRESH_CONCURRENCY = 15
 
 export async function refreshRuntimeProjectWorktrees(
   environmentId: string,
@@ -70,16 +72,18 @@ export async function refreshRuntimeProjectWorktrees(
   }
 }
 
+/** Interactive connect: probes the catalog, then applies one host-wide lineage snapshot. */
 export async function refreshRuntimeProjectWorktreesAndLineage(
   environmentId: string,
   repos: readonly { id: string }[],
   fetchWorktrees: Parameters<typeof refreshRuntimeProjectWorktrees>[2],
-  fetchWorktreeLineage: (options: { executionHostId: ExecutionHostId }) => Promise<unknown>
+  fetchWorktreeLineage: (options: { executionHostId: ExecutionHostId }) => Promise<unknown>,
+  concurrency = INTERACTIVE_CONNECT_REFRESH_CONCURRENCY
 ): Promise<void> {
   const executionHostId = toRuntimeExecutionHostId(environmentId)
   let worktreeFailure: { error: unknown } | null = null
   try {
-    await refreshRuntimeProjectWorktrees(environmentId, repos, fetchWorktrees)
+    await refreshRuntimeProjectWorktrees(environmentId, repos, fetchWorktrees, concurrency)
   } catch (error) {
     worktreeFailure = { error }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​153 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​153 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |

<!-- /orca-pr-loc -->

## ELI5

Two small renderer changes with no behavior trade-off.

When you connect a runtime/SSH host, Orca listed each project's worktrees — and every one of those listings *also* fetched the host's entire worktree lineage. Ten projects meant eleven full round trips for the same host-wide data. Now it fetches lineage once.

Separately, each worktree card in the sidebar subscribed to the app-global agent acknowledgement map, so acknowledging an agent in *one* worktree re-rendered the agent list of *every* worktree. Each card now watches only its own rows.

## What Changed

- Route the runtime-connect catalog refresh through the existing `refreshRuntimeProjectWorktreesAndLineage` helper: pass `suppressRemoteLineageRefresh` per repo and apply one host-scoped lineage snapshot at the end.
- Pass the connecting environment's `executionHostId` to `fetchWorktrees`.
- Narrow `WorktreeCardAgents` to a `useShallow` projection of only the ack timestamps that card renders.

## Why

**Lineage fan-out.** `refreshRemoteWorktreeLineageBestEffort` is a *host-wide* RPC (`worktrees.listLineage` / the runtime equivalent), not a per-repo one. `fetchWorktrees` calls it unless `suppressRemoteLineageRefresh` is set, and the connect path never set it — so an N-repo host issued N full lineage round trips plus a final one, each returning the same whole-host map. On a high-latency SSH link that was the dominant cost of connecting. The background event path (`worktree-event-runtime.ts`) already used the suppress-then-apply-once pattern; this just brings the manual connect path onto it.

**Host pinning.** `repoHostId(state, repoId, hostId)` falls back to `getSettingsFocusedExecutionHostId(settings)` when the repo is not yet in `state.repos`. On connect the repos were *just* fetched and often are not in the store yet, so listings could resolve against whatever host happened to be focused instead of the one being connected. Passing `executionHostId` pins it, and it is what makes the adjacent `ownerSettings` owner-missing branch resolve correctly.

**Sidebar subscription.** `acknowledgedAgentsByPaneKey` is one app-global object; any write replaced the reference and re-rendered every mounted `WorktreeCardAgentsBody`. The card only needs its own agents' timestamps.

## Trade-offs

The connect refresh is bounded to 15 concurrent probes rather than unbounded `Promise.all`. This is the one place the change is not purely additive, so it is worth stating plainly why the bound exists and why 15.

**Why bound at all:** each probe is a `callRuntimeRpc` that makes the *remote* run worktree detection for that repo. Unbounded, a 40-project host issues 40 concurrent detection RPCs against a machine that is usually also running the user's agents — the same shape as the storm in #16038.

**Why 15 and not 5:** 5 is the bound on `refreshRuntimeProjectWorktrees`, which was written for the coalesced background event lane in `worktree-event-runtime.ts`, where repo events repeat and can genuinely storm. Connect is one-shot and user-initiated; it cannot storm, and the user is actively waiting on it. It gets its own `INTERACTIVE_CONNECT_REFRESH_CONCURRENCY`, so the background lane keeps 5.

**Net wall clock:** should improve, not regress — the per-repo work removed here (a full host-wide lineage RPC each) dominates the per-repo work that remains. Not measured, so stated as expectation rather than fact.

Not verified: whether the runtime server already bounds concurrent detection. If it does, this cap is belt-and-braces.

The ack selector allocates a small array per card per store update instead of re-rendering — cheaper than the re-renders it replaces, but not free.

## Testing

- [x] `pnpm tc`
- [x] `pnpm test` on the changed paths: `worktree-card-agent-ack-inputs`, `SshStatusSegment`, `runtime-project-refresh-scheduler`
- [x] `pnpm run check:code-quality:changed` — 0 new findings

## Notes

Split out of #17732, which bundled this with two riskier renderer-scheduling changes. This piece has no user-visible behavior trade-off and is independent of the other two — see that PR for the remaining scope.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason — `N/A`, no visual change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered

