### PR TITLE
perf(renderer): collapse duplicate reveal atlas rebuilds

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import {
   recoverVisibleTerminalWindowWake,
@@ -9,8 +9,11 @@ vi.mock('@/lib/pane-manager/pane-manager-registry', () => ({
   resetAndRefreshAllTerminalWebglAtlases: vi.fn()
 }))
 const presentPaneViewport = vi.fn()
+const presentPaneViewportPreservingSynchronizedOutput = vi.fn()
 vi.mock('@/lib/pane-manager/pane-webgl-renderer', () => ({
-  presentPaneViewport: (pane: unknown) => presentPaneViewport(pane)
+  presentPaneViewport: (pane: unknown) => presentPaneViewport(pane),
+  presentPaneViewportPreservingSynchronizedOutput: (pane: unknown) =>
+    presentPaneViewportPreservingSynchronizedOutput(pane)
 }))
 vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
   flushTerminalOutput: vi.fn(),
@@ -78,6 +81,10 @@ describe('resumeTerminalVisibility reveal repaint', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     repairPaneWebglCanvasDprMismatch.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('schedules an atlas-preserving present on a light tab reveal', () => {
@@ -148,7 +155,10 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     expect(flushDeferredPaneMetricOptionsIfMeasurable).not.toHaveBeenCalled()
   })
 
-  it('defers a heavy-reveal dpr present until the shared atlas recovery', async () => {
+  it('rebuilds the atlas synchronously when a heavy reveal repaired a dpr mismatch', async () => {
+    // A repaired backing store leaves the shared atlas holding glyphs rasterized
+    // at the old dpr. Waiting two frames for the settled rebuild would paint
+    // those wrong-size glyphs first, so this path stays synchronous.
     const pane = { terminal: {} }
     const manager = createManager()
     manager.getPanes.mockReturnValue([pane])
@@ -160,15 +170,28 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     resumeTerminalVisibility(resumeArgs(manager, false))
 
     expect(repairPaneWebglCanvasDprMismatch).toHaveBeenCalledWith(pane)
-    expect(presentPaneViewport).not.toHaveBeenCalled()
     expect(resetAndRefreshAllTerminalWebglAtlases).toHaveBeenCalledTimes(1)
-    const atlasResetCallOrder = resetAndRefreshAllTerminalWebglAtlases.mock.invocationCallOrder[0]
-    if (atlasResetCallOrder === undefined) {
-      throw new Error('Shared atlas recovery call order missing')
-    }
-    expect(repairPaneWebglCanvasDprMismatch.mock.invocationCallOrder[0]).toBeLessThan(
-      atlasResetCallOrder
+    expect(resetAndRefreshAllTerminalWebglAtlases).toHaveBeenCalledWith('visibility-resume-dpr')
+    expect(presentPaneViewportPreservingSynchronizedOutput).not.toHaveBeenCalled()
+    expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
+  })
+
+  it('presents immediately on a heavy reveal so no pre-hide pixels survive the settle', async () => {
+    // Without this present the canvas composites pre-hide pixels until the
+    // settled rebuild lands two frames later, which under load is not two frames.
+    const pane = { terminal: {} }
+    const manager = createManager()
+    manager.getPanes.mockReturnValue([pane])
+    const { resetAndRefreshAllTerminalWebglAtlases } = vi.mocked(
+      await import('@/lib/pane-manager/pane-manager-registry')
     )
+
+    resumeTerminalVisibility(resumeArgs(manager, false))
+
+    expect(presentPaneViewportPreservingSynchronizedOutput).toHaveBeenCalledWith(pane)
+    // The expensive registry-wide rebuild is still deferred to the settled frame.
+    expect(resetAndRefreshAllTerminalWebglAtlases).not.toHaveBeenCalled()
+    expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
   })
 
   it('does not fit on a light tab reveal', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -18,7 +18,10 @@ import { useAppStore } from '@/store'
 import { auditPaneWeightParity } from './terminal-render-desync-weight-probe'
 import { flushDeferredPaneMetricOptionsIfMeasurable } from '@/lib/pane-manager/pane-fit'
 import { repairPaneWebglCanvasDprMismatch } from '@/lib/pane-manager/terminal-canvas-dpr-repair'
-import { presentPaneViewport } from '@/lib/pane-manager/pane-webgl-renderer'
+import {
+  presentPaneViewport,
+  presentPaneViewportPreservingSynchronizedOutput
+} from '@/lib/pane-manager/pane-webgl-renderer'
 
 const VISIBLE_RESUME_FLUSH_CHARS = 256 * 1024
 const WINDOW_WAKE_FLUSH_CHARS = 64 * 1024
@@ -74,6 +77,7 @@ export function resumeTerminalVisibility({
   // restore path avoids content matching so duplicate agent log lines do
   // not jump to the wrong history entry.
   captureViewportPositions(!wasVisible)
+  let repairedDpr = false
   withSuppressedScrollTracking(() => {
     if (shouldUseLightTabResume) {
       let flushedDeferredMetrics = false
@@ -102,22 +106,31 @@ export function resumeTerminalVisibility({
     } else {
       // fitAllRevealedPanes flushes after WebGL reattaches, avoiding a redundant
       // full refresh in the suspended DOM renderer while preserving first paint.
-      resumeTerminalVisibilityHeavy(manager, isActive)
+      repairedDpr = resumeTerminalVisibilityHeavy(manager, isActive)
     }
     enforceTerminalViewportIntents(manager)
     if (!shouldUseLightTabResume) {
       auditPaneWeightParity(manager.getPanes(), useAppStore.getState().settings)
-      // Why: this clear wipes the glyph atlas shared with other same-config
-      // terminals; refresh after reset so rebuilt atlases repaint from xterm.
-      resetAndRefreshAllTerminalWebglAtlases('visibility-resume')
     }
     if (shouldUseLightTabResume) {
       // Why: preserve the last coherent frame while a TUI holds DEC 2026. The
       // settled refresh arms xterm's watchdog without clearing shared GPU data.
       manager.scheduleRevealPresent()
+    } else if (repairedDpr) {
+      // Why: the atlas still holds glyphs rasterized at the old backing-store
+      // DPR, so it cannot wait two frames — rebuild before the next paint.
+      resetAndRefreshAllTerminalWebglAtlases('visibility-resume-dpr')
+      manager.scheduleRevealRepaint()
     } else {
-      // Why: rendering was recreated, so the heavy path still needs the proven
-      // shared-atlas recovery after layout settles.
+      // Why: a hidden pane's parsed output updated the cell model without
+      // presenting, so the reveal diff reports those cells unchanged. Force one
+      // present now; the settled rebuild is two frames out and would otherwise
+      // leave pre-hide pixels composited until then.
+      for (const pane of manager.getPanes()) {
+        presentPaneViewportPreservingSynchronizedOutput(pane)
+      }
+      // Why: one settled rebuild repairs recreated rendering without paying a
+      // duplicate global atlas rebuild before the pane is attached and measured.
       manager.scheduleRevealRepaint()
     }
   })
@@ -213,7 +226,7 @@ function requestLightTabBacklogRecovery(manager: PaneManager): void {
   }
 }
 
-function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean): void {
+function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean): boolean {
   // Why: hidden panes can accumulate large PTY bursts while Chromium is
   // occluded. Drain a bounded slice before fitting; the scheduler keeps
   // ordering and continues the rest asynchronously so return-to-app does
@@ -231,8 +244,11 @@ function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean):
   // Why: unchanged grid geometry can skip the reveal fit, but a retained WebGL
   // canvas may still carry the previous display's backing-store DPR. The
   // caller's atlas recovery presents the final shared-atlas generation.
+  let repairedDpr = false
   for (const pane of manager.getPanes()) {
-    repairPaneWebglCanvasDprMismatch(pane)
+    if (repairPaneWebglCanvasDprMismatch(pane)) {
+      repairedDpr = true
+    }
   }
   // Why: resumeRendering just re-attached WebGL, whose cell metrics briefly differ
   // from the DOM renderer's; a raw fit here reflows on a transient one-column-off
@@ -241,6 +257,7 @@ function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean):
   if (isActive) {
     focusActivePane(manager)
   }
+  return repairedDpr
 }
 
 function enforceTerminalViewportIntents(manager: PaneManager): void {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects-visibility-resume.test.ts
@@ -1,6 +1,7 @@
 import type * as ReactModule from 'react'
 import type * as StoreModule from '@/store'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { schedulePaneRevealRepaint } from '@/lib/pane-manager/pane-reveal-repaint'
 import { useTerminalPaneGlobalEffects } from './use-terminal-pane-global-effects'
 import {
   cleanupGlobalEffectsTestWindow,
@@ -127,17 +128,23 @@ describe('useTerminalPaneGlobalEffects', () => {
   })
 
   it('flushes visible terminal panes before resuming rendering and fitting', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestAnimationFrame', undefined)
     const order: string[] = []
     const terminalA = { name: 'terminal-a' }
     const terminalB = { name: 'terminal-b' }
+    const getPanes = vi.fn(() => [
+      { id: 1, terminal: terminalA },
+      { id: 2, terminal: terminalB }
+    ])
     const manager = {
-      getPanes: vi.fn(() => [
-        { id: 1, terminal: terminalA },
-        { id: 2, terminal: terminalB }
-      ]),
+      getPanes,
       resumeRendering: vi.fn(() => order.push('resume')),
       resetWebglTextureAtlases: vi.fn(() => order.push('reset-atlas')),
-      scheduleRevealRepaint: vi.fn(() => order.push('reveal-repaint')),
+      scheduleRevealRepaint: vi.fn(() => {
+        order.push('reveal-repaint')
+        schedulePaneRevealRepaint(getPanes as never)
+      }),
       scheduleRevealPresent: vi.fn(() => order.push('reveal-present')),
       refreshAllPanes: vi.fn(() => order.push('refresh')),
       suspendRendering: vi.fn(),
@@ -164,9 +171,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     })
     mocks.fitAndFocusPanes.mockImplementation(() => order.push('fit-focus'))
 
-    // Why: the resume path resets atlases through the live-manager registry
-    // (shared glyph atlas), so the fake manager must be registered to observe
-    // its reset in the ordering assertion.
+    // Why: the settled reveal resets atlases through the live-manager registry.
     registerManagerForReset(manager)
     const isActiveRef = { current: false }
     const isVisibleRef = { current: false }
@@ -197,10 +202,13 @@ describe('useTerminalPaneGlobalEffects', () => {
       'fit-reveal',
       'intent:terminal-a',
       'intent:terminal-b',
-      'reset-atlas',
-      'refresh',
       'reveal-repaint'
     ])
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(0)
+    expect(order.slice(-3)).toEqual(['reveal-repaint', 'reset-atlas', 'refresh'])
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
     expect(mocks.restoreScrollStateAfterLayout).not.toHaveBeenCalled()
     expect(mocks.flushTerminalOutput).toHaveBeenNthCalledWith(1, terminalA, {
       maxChars: 256 * 1024
@@ -491,6 +499,7 @@ describe('useTerminalPaneGlobalEffects', () => {
 
     manager.resumeRendering.mockClear()
     manager.resetWebglTextureAtlases.mockClear()
+    manager.scheduleRevealRepaint.mockClear()
     manager.refreshAllPanes.mockClear()
     manager.fitAllRevealedPanes.mockClear()
     mocks.fitAndFocusPanes.mockClear()
@@ -514,8 +523,9 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(manager.fitAllPanes).not.toHaveBeenCalled()
     expect(mocks.focusActivePane).toHaveBeenCalledWith(manager)
     expect(mocks.fitAndFocusPanes).not.toHaveBeenCalled()
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    expect(manager.refreshAllPanes).not.toHaveBeenCalled()
+    expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
   })
 
   it('enforces scroll intent after hidden layout changes the viewport', () => {

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -299,15 +299,16 @@ export class PaneManager {
   }
 
   scheduleRevealRepaint(): void {
-    // Why: the settled-frame callback can fire after destroy(); repainting
-    // disposed panes could throw in attach and latch the global WebGL
-    // attach backoff, downgrading unrelated new panes to the DOM renderer.
-    schedulePaneRevealRepaint(() => (this.destroyed ? [] : this.panes.values()))
+    // Why: the settled-frame callback can fire after hide/destroy; repainting
+    // hidden or disposed panes can revive WebGL contexts and latch attach
+    // backoff, downgrading unrelated new panes to the DOM renderer.
+    schedulePaneRevealRepaint(() => (this.isVisibleForAtlasRecovery() ? this.panes.values() : []))
   }
 
   scheduleRevealPresent(): void {
-    // Why: ordinary reveal keeps the coherent canvas until DEC 2026 releases.
-    schedulePaneRevealPresent(() => (this.destroyed ? [] : this.panes.values()))
+    // Why: ordinary reveal keeps the coherent canvas until DEC 2026 releases;
+    // skip the delayed present if the surface was hidden again meanwhile.
+    schedulePaneRevealPresent(() => (this.isVisibleForAtlasRecovery() ? this.panes.values() : []))
   }
 
   suspendRendering(): void {

--- a/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
@@ -3,6 +3,7 @@ import type { ManagedPaneInternal } from './pane-manager-types'
 import { schedulePaneRevealPresent, schedulePaneRevealRepaint } from './pane-reveal-repaint'
 import { registerLivePaneManager, unregisterLivePaneManager } from './pane-manager-registry'
 import { resetTerminalWebglSuggestion, resetWebglTextureAtlas } from './pane-webgl-renderer'
+import { PaneManager } from './pane-manager'
 
 type FakeWebglAddon = { clearTextureAtlas: ReturnType<typeof vi.fn> }
 type FakePaneManager = {
@@ -47,6 +48,21 @@ function createPane(options: { webglAddon?: FakeWebglAddon | null } = {}): Manag
     pendingSplitScrollState: null,
     debugLabel: null
   }
+}
+
+function createVisibilityProbeManager(onValues: () => void): PaneManager {
+  const manager = Object.create(PaneManager.prototype) as PaneManager
+  Object.assign(manager as unknown as Record<string, unknown>, {
+    destroyed: false,
+    atlasRecoveryVisible: true,
+    panes: {
+      values: () => {
+        onValues()
+        return []
+      }
+    }
+  })
+  return manager
 }
 
 describe('schedulePaneRevealRepaint', () => {
@@ -207,6 +223,28 @@ describe('schedulePaneRevealRepaint', () => {
 
     expect(webglAddon.clearTextureAtlas).toHaveBeenCalledTimes(1)
     vi.useRealTimers()
+  })
+
+  it('skips delayed repaint and present when the manager hides before settle', () => {
+    let repaintValuesRead = 0
+    let presentValuesRead = 0
+    const repaintManager = createVisibilityProbeManager(() => {
+      repaintValuesRead += 1
+    })
+    const presentManager = createVisibilityProbeManager(() => {
+      presentValuesRead += 1
+    })
+
+    repaintManager.scheduleRevealRepaint()
+    presentManager.scheduleRevealPresent()
+    repaintManager.setAtlasRecoveryVisible(false)
+    presentManager.setAtlasRecoveryVisible(false)
+
+    flushFrame()
+    flushFrame()
+
+    expect(repaintValuesRead).toBe(0)
+    expect(presentValuesRead).toBe(0)
   })
 
   describe('schedulePaneRevealPresent', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

## ELI5

Switching to a terminal tab rebuilt the shared WebGL glyph atlas **twice** — once immediately, once again two frames later. The atlas rebuild is the expensive recovery path and it is registry-wide, so every visible terminal paid for it. This PR does it once.

The naive version of that change (just delete the early one) would make revealed terminals briefly show their pre-hide contents. So instead the synchronous work is split by what it was actually *for*, and only the expensive half is deferred.

## What Changed

- `resumeTerminalVisibility` no longer calls `resetAndRefreshAllTerminalWebglAtlases('visibility-resume')` on every heavy reveal. The settled `scheduleRevealRepaint` frame already performed the same registry-wide rebuild.
- On a heavy reveal, force one manager-local `presentPaneViewportPreservingSynchronizedOutput` per pane instead.
- Keep the atlas rebuild synchronous in the one case that needs it: when `repairPaneWebglCanvasDprMismatch` just repaired a backing store.
- `scheduleRevealRepaint` / `scheduleRevealPresent` gate on `isVisibleForAtlasRecovery()` rather than only `destroyed`.

## Why

**The duplicate.** The heavy branch of `resumeTerminalVisibility` ran a synchronous registry-wide atlas reset, and then called `manager.scheduleRevealRepaint()`, which routes to `flushPaneRevealRepaints` → `resetAndRefreshAllTerminalWebglAtlases('settled-reveal')`. Both fire on every heavy reveal. The second one is the one that is correct by design: it waits for layout to settle, because the WebGL renderer silently drops redraw requests until the pane is attached and measured.

**Why a present, not just deletion.** Per the contract documented on `schedulePaneRevealRepaint`: while a pane is hidden, parsed output updates the renderer's per-cell model without ever presenting a frame, so at reveal the model diff reports those cells unchanged and plain refreshes skip them. That is a *presentation* problem, and a forced present fixes it without touching the atlas. Dropping the synchronous reset without adding the present would leave pre-hide pixels composited until the settled frame — and under the load this is meant to help, "two frames" is not two frames.

**Why dpr stays synchronous.** After `repairPaneWebglCanvasDprMismatch` the atlas holds glyphs rasterized at the old backing-store DPR. Presenting that would paint wrong-size glyphs, so this path keeps the immediate rebuild. It is rare (display/DPI change while the tab was hidden) and it matches today's behavior exactly.

**Why the visibility gate.** The settled callback can fire after the manager is hidden, not just after destroy. Repainting a hidden manager can revive a WebGL context and latch the global attach backoff, which downgrades unrelated *new* panes to the DOM renderer. With the synchronous present above, skipping the deferred rebuild while hidden costs nothing: the next reveal presents and re-schedules.

## Trade-offs

None identified. The common reveal path does strictly less work (one registry-wide rebuild instead of two) and closes its own visual gap locally; the dpr path is unchanged from `main`.

## Testing

- [x] `pnpm tc`
- [x] `pnpm test src/renderer/src/lib/pane-manager/ src/renderer/src/components/terminal-pane/` — 486 files, 4823 passed
- [x] `pnpm run check:code-quality:changed` — 0 new findings
- [x] New coverage for both branches: synchronous rebuild on dpr repair, and immediate present with the rebuild still deferred otherwise

## Visual Proof

`N/A` — the observable change is the *absence* of a transient wrong frame. The regression it guards against is a sub-100ms stale-pixel window that a screenshot cannot capture reliably.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered

## Notes

Split out of #17732. That PR deferred the dpr rebuild as well and did not add the present, which opened the stale-frame window this version closes.
