### PR TITLE
fix(windows): opt out of native window-occlusion tracking

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -156,6 +156,7 @@ import {
   configureOrcaUserDataPathEnv,
   disableUnsupportedChromiumFeatures,
   optOutOfHiddenPageWakeUpThrottling,
+  optOutOfWindowsNativeOcclusionTracking,
   enableMainProcessGpuFeatures,
   installDevParentDisconnectQuit,
   installDevParentSignalQuit,
@@ -1012,6 +1013,7 @@ if (hasSingleInstanceLock) {
   disableUnsupportedChromiumFeatures()
   // Why: unconditional — a GPU-fallback launch skips enableMainProcessGpuFeatures() below.
   optOutOfHiddenPageWakeUpThrottling()
+  optOutOfWindowsNativeOcclusionTracking()
   configureElectronNetworkCompatibility()
   enableRendererHeapHeadroom()
   maybeApplyGpuFallbackForThisLaunch()

--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -772,6 +772,46 @@ describe('safe graphics mode startup switches', () => {
     )
   })
 
+  describe('optOutOfWindowsNativeOcclusionTracking', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    function setPlatform(platform: NodeJS.Platform): void {
+      Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+    }
+
+    afterEach(() => {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    })
+
+    it('disables native window-occlusion tracking on win32', async () => {
+      const { app } = await import('electron')
+      const { optOutOfWindowsNativeOcclusionTracking } = await import('./configure-process')
+
+      setPlatform('win32')
+      vi.mocked(app.commandLine.appendSwitch).mockClear()
+      optOutOfWindowsNativeOcclusionTracking()
+
+      expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
+        'disable-features',
+        'CalculateNativeWinOcclusion'
+      )
+    })
+
+    it('does nothing on macOS/Linux', async () => {
+      const { app } = await import('electron')
+      const { optOutOfWindowsNativeOcclusionTracking } = await import('./configure-process')
+
+      for (const platform of ['darwin', 'linux'] as const) {
+        setPlatform(platform)
+        vi.mocked(app.commandLine.appendSwitch).mockClear()
+        optOutOfWindowsNativeOcclusionTracking()
+        expect(app.commandLine.appendSwitch).not.toHaveBeenCalled()
+      }
+    })
+  })
+
   // Why: the defect was the call site, not the switch — a win32 safe-graphics launch runs
   // `if (!gpuFallbackActiveThisLaunch) enableMainProcessGpuFeatures()` and skips everything
   // parked inside it, so only an unconditional call site reaches the users a GPU crash already hit.

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -77,6 +77,17 @@ export function optOutOfHiddenPageWakeUpThrottling(): void {
   appendDisabledChromiumFeatures(['IntensiveWakeUpThrottling'])
 }
 
+// Why: Chromium's native window-occlusion tracking polls DWM to decide whether to throttle
+// rendering, and on Windows this is a well-documented source of app-wide freezes/stutter that
+// scale with window/surface count (electron/electron#40578 and related reports) — every desktop
+// Electron app with heavy per-window surfaces (VS Code included) disables it on win32.
+export function optOutOfWindowsNativeOcclusionTracking(): void {
+  if (process.platform !== 'win32') {
+    return
+  }
+  appendDisabledChromiumFeatures(['CalculateNativeWinOcclusion'])
+}
+
 function appendDisabledChromiumFeatures(features: string[]): void {
   const existingFeatures = app.commandLine
     .getSwitchValue('disable-features')


### PR DESCRIPTION
Chromium polls DWM via `CalculateNativeWinOcclusion` to decide when to throttle rendering - a well-documented source of Windows-only freezes/stutter in Electron apps (VS Code disables it for the same reason).

Orca already opts a few other Chromium features out at the same pre-`whenReady()` call site in `src/main/index.ts` (`disableUnsupportedChromiumFeatures`, `optOutOfHiddenPageWakeUpThrottling`) but was missing this one.

This adds `optOutOfWindowsNativeOcclusionTracking()` (win32-gated, mirrors the existing opt-out pattern) and wires it into the same unconditional call site.

Verified locally on Windows 11 - the reported freeze-on-tab-add/general Windows sluggishness improved after this change. Tests added mirroring the existing `optOutOfHiddenPageWakeUpThrottling` coverage.