### PR TITLE
ci(release): gate signing behind release preflight

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1122,10 +1122,33 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  # Why: artifact jobs submit Windows binaries to SignPath. Keep every
+  # quota-consuming build behind all blocking release gates so a late test
+  # failure cannot create signing requests that can never be published.
+  release-preflight:
+    needs:
+      - cut
+      - terminal-rendering-golden
+      - skill-sharing-release-gate
+      - skill-sharing-linux-floor-release-gate
+    if: >-
+      always() &&
+      needs.cut.outputs.should_release == 'true' &&
+      needs.terminal-rendering-golden.result == 'success' &&
+      needs.skill-sharing-release-gate.result == 'success' &&
+      needs.skill-sharing-linux-floor-release-gate.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Confirm blocking release gates passed
+        run: echo "All blocking release gates passed; artifact builds may start."
+
   build:
     needs:
       - cut
       - create-release
+      - release-preflight
     if: needs.cut.outputs.should_release == 'true'
     strategy:
       fail-fast: false
@@ -2026,6 +2049,7 @@ jobs:
     needs:
       - cut
       - create-release
+      - release-preflight
     if: needs.cut.outputs.should_release == 'true'
     # Why: SignPath requires every job in this signing workflow to be
     # GitHub-hosted. The actual mac build runs in release-mac-build.yml so

--- a/config/scripts/release-cut-token-permissions.test.mjs
+++ b/config/scripts/release-cut-token-permissions.test.mjs
@@ -31,6 +31,7 @@ const EXPECTED_MATRIX = {
     },
   [`${RELEASE_WORKFLOW}#post-release-e2e`]: { actions: 'write' },
   [`${RELEASE_WORKFLOW}#publish-release`]: { contents: 'write' },
+  [`${RELEASE_WORKFLOW}#release-preflight`]: { contents: 'read' },
   [`${RELEASE_WORKFLOW}#skill-sharing-linux-floor-release-gate`]: { contents: 'read' },
   [`${RELEASE_WORKFLOW}#skill-sharing-release-gate`]: { contents: 'read' },
   [`${RELEASE_WORKFLOW}#terminal-rendering-golden`]: { contents: 'read' },

--- a/config/scripts/skill-sharing-release-workflow.test.mjs
+++ b/config/scripts/skill-sharing-release-workflow.test.mjs
@@ -10,6 +10,27 @@ function stepNamed(job, name) {
 }
 
 describe('skill-sharing release workflow', () => {
+  it('keeps artifact builds behind every blocking release gate', () => {
+    const preflight = workflow.jobs['release-preflight']
+    const build = workflow.jobs.build
+    const macBuild = workflow.jobs['build-mac']
+
+    expect(preflight.needs).toEqual([
+      'cut',
+      'terminal-rendering-golden',
+      'skill-sharing-release-gate',
+      'skill-sharing-linux-floor-release-gate'
+    ])
+    expect(preflight.if).toContain('always()')
+    expect(preflight.if).toContain("needs.terminal-rendering-golden.result == 'success'")
+    expect(preflight.if).toContain("needs.skill-sharing-release-gate.result == 'success'")
+    expect(preflight.if).toContain(
+      "needs.skill-sharing-linux-floor-release-gate.result == 'success'"
+    )
+    expect(build.needs).toContain('release-preflight')
+    expect(macBuild.needs).toContain('release-preflight')
+  })
+
   it('blocks publication on native Windows, macOS, and the Linux floor', () => {
     const platform = workflow.jobs['skill-sharing-release-gate']
     const linux = workflow.jobs['skill-sharing-linux-floor-release-gate']


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |

<!-- /orca-pr-loc -->

## Summary
- gate artifact builds behind all blocking release preflight lanes
- prevent SignPath requests when golden or skill-sharing gates fail
- add workflow contract coverage for the dependency barrier

## Validation
- 60 targeted release workflow contract tests
- changed-code quality: 0 new findings
- actionlint passes with shellcheck integration disabled

This prevents signing quota from being consumed by a release that is already known to be blocked.