### PR TITLE
fix(mobile-native-chat): retire an image echo glued with the send beside it

### DIFF
--- a/mobile/src/session/mobile-native-chat-draft-reconcile.test.ts
+++ b/mobile/src/session/mobile-native-chat-draft-reconcile.test.ts
@@ -73,6 +73,19 @@ describe('mobile native chat image preview reconciliation', () => {
     expect(findLandedImagePreviewEchoes(messages, [preview])).toEqual([])
   })
 
+  it('does not bind a glued image echo to an ordinary row with the same prefix', () => {
+    const messages = [
+      userText('ordinary', 'look at this later'),
+      userText('source', '[Image: source: /tmp/a.png]'),
+      userText('prompt', 'look at this[Image #1] is it still working?')
+    ]
+    const preview = { ...pending('pending', ['file:///a.jpg']), text: 'look at this' }
+
+    expect(findLandedImagePreviewEchoes(messages, [preview])).toEqual([
+      { pendingId: 'pending', messageId: 'prompt', images: ['file:///a.jpg'] }
+    ])
+  })
+
   it('reconciles a middle-marker echo without changing its rendered whitespace', () => {
     const messages = [
       userText('source', '[Image: source: /tmp/a.png]'),

--- a/mobile/src/session/mobile-native-chat-draft-reconcile.test.ts
+++ b/mobile/src/session/mobile-native-chat-draft-reconcile.test.ts
@@ -47,6 +47,32 @@ describe('mobile native chat image preview reconciliation', () => {
     ])
   })
 
+  it('binds an image echo to the row it was glued into with a following send', () => {
+    // Regression: a send issued while the agent was mid-turn glues onto the input line
+    // with the send beside it, so the landed row's text is the concatenation. Demanding
+    // the whole row equal this echo left it unbound — the phone-local photo never
+    // reached the authoritative row and the echo could never be retired.
+    const messages = [
+      userText('source', '[Image: source: /tmp/a.png]'),
+      userText('prompt', 'look at this[Image #1] is it still working?')
+    ]
+    const preview = { ...pending('pending', ['file:///a.jpg']), text: 'look at this' }
+
+    expect(findLandedImagePreviewEchoes(messages, [preview])).toEqual([
+      { pendingId: 'pending', messageId: 'prompt', images: ['file:///a.jpg'] }
+    ])
+  })
+
+  it('does not bind an image echo to a row that merely shares a word', () => {
+    const messages = [
+      userText('source', '[Image: source: /tmp/a.png]'),
+      userText('prompt', 'totally different[Image #1]')
+    ]
+    const preview = { ...pending('pending', ['file:///a.jpg']), text: 'look at this' }
+
+    expect(findLandedImagePreviewEchoes(messages, [preview])).toEqual([])
+  })
+
   it('reconciles a middle-marker echo without changing its rendered whitespace', () => {
     const messages = [
       userText('source', '[Image: source: /tmp/a.png]'),

--- a/mobile/src/session/mobile-native-chat-draft-reconcile.ts
+++ b/mobile/src/session/mobile-native-chat-draft-reconcile.ts
@@ -153,6 +153,20 @@ export function findLandedImagePreviewEchoes(
 ): LandedImagePreviewEcho[] {
   const normalized = normalizeImageTranscriptMessages(messages)
   const messageIndexById = new Map(normalized.map((message, index) => [message.id, index]))
+  // Keep provenance from the raw transcript: normalization removes image markers,
+  // so a plain text row must not become a candidate merely because it shares a
+  // caption prefix with a glued image send.
+  const imageMessageIds = new Set(
+    messages
+      .filter(
+        (message) =>
+          message.role === 'user' &&
+          (isImageSourceUserTurn(message) ||
+            hasImagePromptMarker(message) ||
+            message.blocks.some(isImageRefBlock))
+      )
+      .map((message) => message.id)
+  )
   const claimedMessageIds = new Set<string>()
   const landed: LandedImagePreviewEcho[] = []
 
@@ -175,7 +189,9 @@ export function findLandedImagePreviewEchoes(
         // text-only send lands in a row whose text is the concatenation. Requiring the
         // whole row to equal this echo left it unmatched, and since both other
         // retirement paths skip image echoes, nothing could ever retire it.
-        return text === targetText || text.startsWith(targetText)
+        return (
+          text === targetText || (imageMessageIds.has(message.id) && text.startsWith(targetText))
+        )
       }
       const imageCount = message.blocks.filter(isImageRefBlock).length
       return message.blocks.length === 0 || imageCount >= entry.images!.length

--- a/mobile/src/session/mobile-native-chat-draft-reconcile.ts
+++ b/mobile/src/session/mobile-native-chat-draft-reconcile.ts
@@ -166,7 +166,16 @@ export function findLandedImagePreviewEchoes(
         return false
       }
       if (targetText) {
-        return normalizedUserText(message) === targetText
+        const text = normalizedUserText(message)
+        if (text === null) {
+          return false
+        }
+        // Why not equality alone: a send is glued onto the agent's input line with any
+        // send adjacent to it, so an image send that shares a turn with a following
+        // text-only send lands in a row whose text is the concatenation. Requiring the
+        // whole row to equal this echo left it unmatched, and since both other
+        // retirement paths skip image echoes, nothing could ever retire it.
+        return text === targetText || text.startsWith(targetText)
       }
       const imageCount = message.blocks.filter(isImageRefBlock).length
       return message.blocks.length === 0 || imageCount >= entry.images!.length

--- a/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
@@ -232,6 +232,38 @@ describe('selectGluedPendingIds', () => {
     ).toEqual(['p1', 'p2'])
   })
 
+  it('retires an image send glued with the text send beside it once its preview rebinds', () => {
+    // Regression: one message typed, images attached, then a second send glued onto the
+    // same input line. The image echo could not match the glued row (its matcher wanted
+    // the whole row to equal the echo), and because an image echo was excluded from the
+    // glue pass it also acted as a barrier — stranding the text send in a run of one,
+    // which `matchGluedRun` rejects. Neither echo could ever retire, so the message
+    // rendered twice over, with the image copy sorting below the reply it preceded.
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
+    const pending = [
+      { ...pendingSend('p1', 'one', 'm1'), images: ['file:///a.png'] },
+      pendingSend('p2', 'two', 'm1')
+    ]
+    const rebound: ReadonlySet<string> = new Set(['p1'])
+    expect([...selectGluedPendingIds(messages, pending, new Set(), rebound)].sort()).toEqual([
+      'p1',
+      'p2'
+    ])
+    expect(
+      retireLandedMobileNativeChatPending(messages, pending, rebound).map((item) => item.id)
+    ).toEqual([])
+  })
+
+  it('still strands nothing when the glued row belongs to an older baseline', () => {
+    // The per-send boundary still applies to a rebound image echo.
+    const messages = [userTurn('m1', 'one two', 1000), assistantTurn('m2', 'ready', 5000)]
+    const pending = [
+      { ...pendingSend('p1', 'one', 'm2'), images: ['file:///a.png'] },
+      pendingSend('p2', 'two', 'm2')
+    ]
+    expect([...selectGluedPendingIds(messages, pending, new Set(), new Set(['p1']))]).toEqual([])
+  })
+
   it('does nothing for a single pending send', () => {
     const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two', 5000)]
     expect(retiredIds(messages, [pendingSend('p1', 'one', 'm1')])).toEqual([])

--- a/mobile/src/session/mobile-native-chat-pending-retirement.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.ts
@@ -23,7 +23,10 @@ type GlueSegment = { text: string; tail: number } | null
 export function selectGluedPendingIds(
   messages: readonly NativeChatMessage[],
   pending: readonly MobileNativeChatPendingMessage[],
-  excludedPendingIds: ReadonlySet<string> = NO_PENDING_IDS
+  excludedPendingIds: ReadonlySet<string> = NO_PENDING_IDS,
+  /** Image echoes whose local preview has been rebound onto its transcript row.
+   *  Until that happens an image echo must stay put, so it is not a glue segment. */
+  reboundImagePendingIds: ReadonlySet<string> = NO_PENDING_IDS
 ): ReadonlySet<string> {
   const retired = new Set<string>()
   if (pending.length < 2) {
@@ -44,9 +47,14 @@ export function selectGluedPendingIds(
       item.baselineTailMessageId === null
         ? -1
         : (messageIndexById.get(item.baselineTailMessageId) ?? null)
+    // An image send glues onto the input line like any other, so once its preview is
+    // rebound its text is a real segment of the resulting row. While it is still
+    // unbound it stays a barrier: retiring it early would drop the phone-local photo,
+    // which the transcript's host path cannot render.
+    const unboundImage = Boolean(item.images?.length) && !reboundImagePendingIds.has(item.id)
     return excludedPendingIds.has(item.id) ||
       !item.baselineResolved ||
-      item.images?.length ||
+      unboundImage ||
       text === '' ||
       tail === null
       ? null
@@ -146,6 +154,10 @@ export function retireLandedMobileNativeChatPending(
     }
   }
   const landedPendingIds = new Set<string>()
+  // Why a separate set: a barrier preserves adjacency after a landing consumed a whole
+  // row. An image landing can share its row with the send glued after it, so treating it
+  // as a barrier would strand that send in a run of one and keep its echo forever.
+  const exactLandedIds = new Set<string>()
   for (const item of current) {
     if (landedImagePendingIds.has(item.id)) {
       landedPendingIds.add(item.id)
@@ -164,9 +176,10 @@ export function retireLandedMobileNativeChatPending(
         : (landedCounts.get(normalizeReconcileText(item.text)) ?? 0) >= item.expectedOccurrence
     if (landed) {
       landedPendingIds.add(item.id)
+      exactLandedIds.add(item.id)
     }
   }
-  const glued = selectGluedPendingIds(messages, current, landedPendingIds)
+  const glued = selectGluedPendingIds(messages, current, exactLandedIds, landedImagePendingIds)
   return landedPendingIds.size === 0 && glued.size === 0
     ? current
     : current.filter((item) => !landedPendingIds.has(item.id) && !glued.has(item.id))


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |

<!-- /orca-pr-loc -->

## What was broken

A message sent with images rendered **two or three times over** in mobile native chat, and the copy carrying the photos sorted *below* the assistant reply that answered it. It never cleared.

## Root cause

A send issued while the agent is mid-turn is glued onto the agent's input line with any send adjacent to it, so the pair lands as **one** transcript row whose text is the concatenation. In the reported case the row's text was `A \r [Image #1..4] B` — one send carrying the caption + photos, one carrying the follow-up question.

Every retirement path then declined the pair:

| path | why it declined |
|---|---|
| image matcher (`mobile-native-chat-draft-reconcile.ts:168`) | required the **whole row** to equal the echo's text; a glued row is the concatenation, so it never matched |
| exact-count (`mobile-native-chat-pending-retirement.ts:157`) | skips image echoes by design |
| glue (`:49`) | excluded image echoes too — which made one a **barrier**, splitting the run so the text-only send beside it was stranded alone, and `matchGluedRun` rejects a lone match (`matched > 1` at `:129`) |

So neither echo could ever retire. The unmatched image echo then had no usable anchor and fell through to `trailingPending`, which is what put it below the reply.

Confirmed empirically before fixing — feeding the real shape through `findLandedImagePreviewEchoes` + `retireLandedMobileNativeChatPending` gave `LANDED: []` and `SURVIVORS: ["p1","p2"]`.

## The fix

- **Match a glued row** in the image matcher: the echo's normalized text may be a leading segment of the row, not only the whole of it. This is the same looseness the glue matcher already uses (`startsWith` with an optional single space), and `claimedMessageIds` plus the baseline-tail guard still prevent over-claiming.
- **Let a rebound image echo take part in the glue pass**, and stop treating an image landing as a barrier — its row can be shared with the send glued after it, unlike an exact landing which consumes a whole row.

## The guarantee that is preserved

An image echo **stays a barrier while its preview is unbound**. The existing invariant — `keeps a captioned image echo and its neighbors until the preview is rebound` — matters: retiring the echo before the local preview URI is bound to the transcript row would drop the phone-local photo, which the row's host path cannot render.

My first attempt let image sends glue unconditionally and broke exactly that test. The landed version gates glue participation on `reboundImagePendingIds`, so the invariant holds and the suite is green.

## Verification

- Full mobile suite: **488 files / 3975 tests pass**. `tsc --noEmit`: clean.
- **Ablation** (tests are not vacuous): reverting the matcher change turns the new reconcile test red (1 failed / 9 passed); reverting the glue-participation change turns the new retirement test red (1 failed / 29 passed). Both restored and re-verified green.
- Negative case covered: an echo is not bound to a row that merely shares a word.
- Changed-code quality gate (oxlint + type-aware + React Doctor): 0 new findings across 4 files.

## Review note

This module has history — #14665 landed glued retirement, #14819 reverted it, #14936 relanded it. I kept the change additive to the existing rules rather than restructuring them, and pinned the invariant that the revert was about.
