### PR TITLE
test(e2e): remove source control golden race

### DIFF
--- a/tests/e2e/golden-source-control-open-diff.spec.ts
+++ b/tests/e2e/golden-source-control-open-diff.spec.ts
@@ -19,10 +19,10 @@ test('@golden opens an unstaged file diff from Source Control', async ({
 }) => {
   const fixture = createGoldenWorktree(testRepoPath, 'open-diff')
   registerPostElectronShutdownCleanup(async () => cleanupGoldenWorktree(testRepoPath, fixture))
+  seedGoldenSourceEdit(fixture.worktreePath)
 
   await waitForSessionReady(orcaPage)
   await openGoldenSourceControl(orcaPage, testRepoPath, fixture)
-  seedGoldenSourceEdit(fixture.worktreePath)
 
   const changedFile = orcaPage
     .locator('[data-testid="source-control-entry"]')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Summary
- seed the unstaged edit before opening Source Control
- avoid racing the clean-workspace empty state against the commit composer

## Validation
- changed-code quality: 0 new findings

This keeps the release golden deterministic without changing product behavior.