### PR TITLE
test(e2e): do not treat a destroyed renderer as a relaunched runtime

### DIFF
--- a/tests/e2e/helpers/client-hosted-browser-fixture.ts
+++ b/tests/e2e/helpers/client-hosted-browser-fixture.ts
@@ -298,31 +298,3 @@ export async function focusClientBrowserRow(
     { browserPageId: localPageId, worktreeId }
   )
 }
-
-export async function refreshAuthorityRuntimeId(
-  client: PairedElectronClient
-): Promise<string | null> {
-  return readRestartRendererState(() =>
-    client.page.evaluate(async (environmentId) => {
-      await window.api.runtimeEnvironments.connect({ selector: environmentId })
-      await window.__store?.getState().refreshRuntimeEnvironmentStatus(environmentId)
-      return (
-        window.__store?.getState().runtimeStatusByEnvironmentId.get(environmentId)?.status
-          ?.runtimeId ?? null
-      )
-    }, client.environmentId)
-  )
-}
-
-/** Waits until the client is talking to a genuinely new runtime process, not the one it paired to. */
-export async function waitForRelaunchedRuntime(
-  client: PairedElectronClient,
-  previousRuntimeId: string
-): Promise<void> {
-  await expect
-    .poll(() => refreshAuthorityRuntimeId(client), {
-      timeout: 180_000,
-      message: 'paired client never reconnected to a relaunched runtime process'
-    })
-    .toEqual(expect.not.stringMatching(`^${previousRuntimeId}$`))
-}

--- a/tests/e2e/helpers/client-hosted-browser-fixture.unit.test.ts
+++ b/tests/e2e/helpers/client-hosted-browser-fixture.unit.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { Page } from '@stablyai/playwright-test'
+import type { PairedElectronClient } from './paired-electron-client'
 import {
   findMirroredBrowserPage,
   findPairedWorktreeId,
   readClientWebviewMarker
 } from './client-hosted-browser-fixture'
+import { readRelaunchedRuntimeId } from './client-hosted-runtime-relaunch'
 
 function pageWhoseEvaluateThrows(message: string): Page {
   return {
@@ -12,6 +14,22 @@ function pageWhoseEvaluateThrows(message: string): Page {
       throw new Error(message)
     }
   } as unknown as Page
+}
+
+function clientWhoseEvaluateThrows(message: string): PairedElectronClient {
+  return {
+    environmentId: 'env-1',
+    page: pageWhoseEvaluateThrows(message)
+  } as unknown as PairedElectronClient
+}
+
+function clientWhoseEvaluateReturns(value: string | null): PairedElectronClient {
+  return {
+    environmentId: 'env-1',
+    page: {
+      evaluate: async () => value
+    }
+  } as unknown as PairedElectronClient
 }
 
 describe('client-hosted restart evaluate polling', () => {
@@ -37,5 +55,35 @@ describe('client-hosted restart evaluate polling', () => {
     await expect(
       readClientWebviewMarker(page, { urlPrefix: 'http://127.0.0.1/', remotePageId: 'page-1' })
     ).rejects.toThrow('fetchWorktrees failed')
+  })
+})
+
+describe('client-hosted relaunch wait', () => {
+  it('treats a destroyed renderer context as a pending relaunch miss', async () => {
+    const pending = await readRelaunchedRuntimeId(
+      clientWhoseEvaluateThrows(
+        'Execution context was destroyed, most likely because of a navigation.'
+      ),
+      'runtime-old'
+    )
+    expect(pending).toBeNull()
+  })
+
+  it('does not hide unrelated evaluate failures', async () => {
+    await expect(
+      readRelaunchedRuntimeId(clientWhoseEvaluateThrows('fetchWorktrees failed'), 'runtime-old')
+    ).rejects.toThrow('fetchWorktrees failed')
+  })
+
+  it('succeeds only with a live runtime id that is not the pre-restart process', async () => {
+    await expect(
+      readRelaunchedRuntimeId(clientWhoseEvaluateReturns('runtime-old'), 'runtime-old')
+    ).resolves.toBeNull()
+    await expect(
+      readRelaunchedRuntimeId(clientWhoseEvaluateReturns(null), 'runtime-old')
+    ).resolves.toBeNull()
+    await expect(
+      readRelaunchedRuntimeId(clientWhoseEvaluateReturns('runtime-new'), 'runtime-old')
+    ).resolves.toBe('runtime-new')
   })
 })

--- a/tests/e2e/helpers/client-hosted-runtime-relaunch.ts
+++ b/tests/e2e/helpers/client-hosted-runtime-relaunch.ts
@@ -1,0 +1,44 @@
+import { expect } from './orca-app'
+import { readRestartRendererState } from './orca-restart'
+import type { PairedElectronClient } from './paired-electron-client'
+
+export async function refreshAuthorityRuntimeId(
+  client: PairedElectronClient
+): Promise<string | null> {
+  return readRestartRendererState(() =>
+    client.page.evaluate(async (environmentId) => {
+      await window.api.runtimeEnvironments.connect({ selector: environmentId })
+      await window.__store?.getState().refreshRuntimeEnvironmentStatus(environmentId)
+      return (
+        window.__store?.getState().runtimeStatusByEnvironmentId.get(environmentId)?.status
+          ?.runtimeId ?? null
+      )
+    }, client.environmentId)
+  )
+}
+
+/** Pending null until a live id that is not `previousRuntimeId`; a destroyed renderer is a miss. */
+export async function readRelaunchedRuntimeId(
+  client: PairedElectronClient,
+  previousRuntimeId: string
+): Promise<string | null> {
+  const current = await refreshAuthorityRuntimeId(client)
+  // Why: `expect(null).toEqual(expect.not.stringMatching(prev))` passes; null must stay pending.
+  if (current == null || current === previousRuntimeId) {
+    return null
+  }
+  return current
+}
+
+/** Waits until the client talks to a new runtime process, not the one it paired to. */
+export async function waitForRelaunchedRuntime(
+  client: PairedElectronClient,
+  previousRuntimeId: string
+): Promise<void> {
+  await expect
+    .poll(() => readRelaunchedRuntimeId(client, previousRuntimeId), {
+      timeout: 180_000,
+      message: 'paired client never reconnected to a relaunched runtime process'
+    })
+    .not.toBeNull()
+}

--- a/tests/e2e/paired-client-hosted-browser-cookie-survival.spec.ts
+++ b/tests/e2e/paired-client-hosted-browser-cookie-survival.spec.ts
@@ -8,6 +8,12 @@ import {
   type PairedElectronClient
 } from './helpers/paired-electron-client'
 import {
+  openClientHostedFixturePage,
+  selectPairedWorktreeGroup,
+  waitForPairedWorktreeId
+} from './helpers/client-hosted-browser-fixture'
+import { readRestartRendererState } from './helpers/orca-restart'
+import {
   refreshAuthorityRuntimeId,
   waitForRelaunchedRuntime
 } from './helpers/client-hosted-runtime-relaunch'
@@ -73,156 +79,31 @@ async function startCookieFixture(): Promise<CookieFixture> {
   }
 }
 
-type MirroredBrowserPage = {
-  localPageId: string
-  placementKind: 'client' | 'server' | null
-  remotePageId: string
-}
-
-async function findPairedWorktreeId(page: Page, repoPath: string): Promise<string | null> {
-  return page.evaluate(
-    (path) =>
-      window.__store
-        ?.getState()
-        .allWorktrees()
-        .find((worktree) => worktree.path === path)?.id ?? null,
-    repoPath
-  )
-}
-
-async function waitForPairedWorktreeId(page: Page, repoPath: string): Promise<string> {
-  await expect
-    .poll(() => findPairedWorktreeId(page, repoPath), {
-      timeout: 120_000,
-      message: 'paired client never received the host worktree'
-    })
-    .not.toBeNull()
-  const worktreeId = await findPairedWorktreeId(page, repoPath)
-  if (!worktreeId) {
-    throw new Error('Paired worktree disappeared after discovery')
-  }
-  return worktreeId
-}
-
-async function selectPairedWorktreeGroup(
-  page: Page,
-  environmentId: string,
-  worktreeId: string
-): Promise<void> {
-  await expect
-    .poll(
-      () =>
-        page.evaluate(
-          ({ environmentId, worktreeId }) => {
-            const state = window.__store?.getState()
-            state?.setActiveWorktree(worktreeId, `runtime:${environmentId}`)
-            return state?.activeGroupIdByWorktree[worktreeId] ?? null
-          },
-          { environmentId, worktreeId }
-        ),
-      {
-        timeout: 120_000,
-        message: 'paired client never activated a tab group for the worktree'
-      }
-    )
-    .not.toBeNull()
-}
-
-async function createProductBrowserPage(page: Page, url: string): Promise<void> {
-  await page.evaluate(async (url) => {
-    const state = window.__store?.getState()
-    if (!state?.activeWorktreeId) {
-      throw new Error('Paired client has no active worktree')
-    }
-    const groupId = state.activeGroupIdByWorktree[state.activeWorktreeId]
-    if (!groupId) {
-      throw new Error('Paired client has no active tab group')
-    }
-    state.setBrowserDefaultUrl(url)
-    await state.openNewBrowserTabInActiveWorkspace(groupId)
-  }, url)
-}
-
-async function findMirroredBrowserPage(
-  page: Page,
-  worktreeId: string,
-  url: string
-): Promise<MirroredBrowserPage | null> {
-  return page.evaluate(
-    ({ url, worktreeId }) => {
-      const state = window.__store?.getState()
-      for (const workspace of state?.browserTabsByWorktree[worktreeId] ?? []) {
-        for (const browserPage of state?.browserPagesByWorkspace[workspace.id] ?? []) {
-          if (!browserPage.url.startsWith(url)) {
-            continue
-          }
-          const handle = state?.remoteBrowserPageHandlesByPageId[browserPage.id]
-          return {
-            localPageId: browserPage.id,
-            placementKind: handle?.placement?.kind ?? null,
-            remotePageId: handle?.remotePageId ?? browserPage.id
-          }
-        }
-      }
-      return null
-    },
-    { url, worktreeId }
-  )
-}
-
-async function openClientHostedFixturePage(
-  client: PairedElectronClient,
-  worktreeId: string,
-  url: string
-): Promise<MirroredBrowserPage> {
-  await createProductBrowserPage(client.page, url)
-  await expect
-    .poll(() => findMirroredBrowserPage(client.page, worktreeId, url), {
-      timeout: 60_000,
-      message: `paired client never materialized ${url}`
-    })
-    .not.toBeNull()
-  const mirrored = await findMirroredBrowserPage(client.page, worktreeId, url)
-  if (!mirrored) {
-    throw new Error(`Mirrored browser page disappeared for ${url}`)
-  }
-  expect(mirrored.placementKind, 'fixture page must be hosted on the viewing desktop').toBe(
-    'client'
-  )
-  await client.page.evaluate(
-    ({ browserPageId, worktreeId }) => {
-      window.__store?.getState().focusBrowserTabInWorktree(worktreeId, browserPageId, {
-        surfacePane: true
-      })
-    },
-    { browserPageId: mirrored.localPageId, worktreeId }
-  )
-  return mirrored
-}
-
 async function readClientWebview(
   page: Page,
   url: string
 ): Promise<{ marker: string | null; partition: string | null } | null> {
-  return page.evaluate(async (prefix) => {
-    for (const candidate of document.querySelectorAll('webview')) {
-      const webview = candidate as Electron.WebviewTag
-      try {
-        if (!webview.getURL().startsWith(prefix)) {
-          continue
+  return readRestartRendererState(() =>
+    page.evaluate(async (prefix) => {
+      for (const candidate of document.querySelectorAll('webview')) {
+        const webview = candidate as Electron.WebviewTag
+        try {
+          if (!webview.getURL().startsWith(prefix)) {
+            continue
+          }
+          return {
+            marker: (await webview.executeJavaScript(
+              'document.querySelector("#marker")?.textContent ?? null'
+            )) as string | null,
+            partition: webview.getAttribute('partition')
+          }
+        } catch {
+          // The guest may still be attaching.
         }
-        return {
-          marker: (await webview.executeJavaScript(
-            'document.querySelector("#marker")?.textContent ?? null'
-          )) as string | null,
-          partition: webview.getAttribute('partition')
-        }
-      } catch {
-        // The guest may still be attaching.
       }
-    }
-    return null
-  }, url)
+      return null
+    }, url)
+  )
 }
 
 async function waitForRenderedClientWebview(

--- a/tests/e2e/paired-client-hosted-browser-cookie-survival.spec.ts
+++ b/tests/e2e/paired-client-hosted-browser-cookie-survival.spec.ts
@@ -7,16 +7,6 @@ import {
   launchPairedElectronClient,
   type PairedElectronClient
 } from './helpers/paired-electron-client'
-import {
-  openClientHostedFixturePage,
-  selectPairedWorktreeGroup,
-  waitForPairedWorktreeId
-} from './helpers/client-hosted-browser-fixture'
-import { readRestartRendererState } from './helpers/orca-restart'
-import {
-  refreshAuthorityRuntimeId,
-  waitForRelaunchedRuntime
-} from './helpers/client-hosted-runtime-relaunch'
 
 const COOKIE_NAME = 'sta4150'
 const COOKIE_VALUE = 'survivor'
@@ -79,31 +69,156 @@ async function startCookieFixture(): Promise<CookieFixture> {
   }
 }
 
+type MirroredBrowserPage = {
+  localPageId: string
+  placementKind: 'client' | 'server' | null
+  remotePageId: string
+}
+
+async function findPairedWorktreeId(page: Page, repoPath: string): Promise<string | null> {
+  return page.evaluate(
+    (path) =>
+      window.__store
+        ?.getState()
+        .allWorktrees()
+        .find((worktree) => worktree.path === path)?.id ?? null,
+    repoPath
+  )
+}
+
+async function waitForPairedWorktreeId(page: Page, repoPath: string): Promise<string> {
+  await expect
+    .poll(() => findPairedWorktreeId(page, repoPath), {
+      timeout: 120_000,
+      message: 'paired client never received the host worktree'
+    })
+    .not.toBeNull()
+  const worktreeId = await findPairedWorktreeId(page, repoPath)
+  if (!worktreeId) {
+    throw new Error('Paired worktree disappeared after discovery')
+  }
+  return worktreeId
+}
+
+async function selectPairedWorktreeGroup(
+  page: Page,
+  environmentId: string,
+  worktreeId: string
+): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          ({ environmentId, worktreeId }) => {
+            const state = window.__store?.getState()
+            state?.setActiveWorktree(worktreeId, `runtime:${environmentId}`)
+            return state?.activeGroupIdByWorktree[worktreeId] ?? null
+          },
+          { environmentId, worktreeId }
+        ),
+      {
+        timeout: 120_000,
+        message: 'paired client never activated a tab group for the worktree'
+      }
+    )
+    .not.toBeNull()
+}
+
+async function createProductBrowserPage(page: Page, url: string): Promise<void> {
+  await page.evaluate(async (url) => {
+    const state = window.__store?.getState()
+    if (!state?.activeWorktreeId) {
+      throw new Error('Paired client has no active worktree')
+    }
+    const groupId = state.activeGroupIdByWorktree[state.activeWorktreeId]
+    if (!groupId) {
+      throw new Error('Paired client has no active tab group')
+    }
+    state.setBrowserDefaultUrl(url)
+    await state.openNewBrowserTabInActiveWorkspace(groupId)
+  }, url)
+}
+
+async function findMirroredBrowserPage(
+  page: Page,
+  worktreeId: string,
+  url: string
+): Promise<MirroredBrowserPage | null> {
+  return page.evaluate(
+    ({ url, worktreeId }) => {
+      const state = window.__store?.getState()
+      for (const workspace of state?.browserTabsByWorktree[worktreeId] ?? []) {
+        for (const browserPage of state?.browserPagesByWorkspace[workspace.id] ?? []) {
+          if (!browserPage.url.startsWith(url)) {
+            continue
+          }
+          const handle = state?.remoteBrowserPageHandlesByPageId[browserPage.id]
+          return {
+            localPageId: browserPage.id,
+            placementKind: handle?.placement?.kind ?? null,
+            remotePageId: handle?.remotePageId ?? browserPage.id
+          }
+        }
+      }
+      return null
+    },
+    { url, worktreeId }
+  )
+}
+
+async function openClientHostedFixturePage(
+  client: PairedElectronClient,
+  worktreeId: string,
+  url: string
+): Promise<MirroredBrowserPage> {
+  await createProductBrowserPage(client.page, url)
+  await expect
+    .poll(() => findMirroredBrowserPage(client.page, worktreeId, url), {
+      timeout: 60_000,
+      message: `paired client never materialized ${url}`
+    })
+    .not.toBeNull()
+  const mirrored = await findMirroredBrowserPage(client.page, worktreeId, url)
+  if (!mirrored) {
+    throw new Error(`Mirrored browser page disappeared for ${url}`)
+  }
+  expect(mirrored.placementKind, 'fixture page must be hosted on the viewing desktop').toBe(
+    'client'
+  )
+  await client.page.evaluate(
+    ({ browserPageId, worktreeId }) => {
+      window.__store?.getState().focusBrowserTabInWorktree(worktreeId, browserPageId, {
+        surfacePane: true
+      })
+    },
+    { browserPageId: mirrored.localPageId, worktreeId }
+  )
+  return mirrored
+}
+
 async function readClientWebview(
   page: Page,
   url: string
 ): Promise<{ marker: string | null; partition: string | null } | null> {
-  return readRestartRendererState(() =>
-    page.evaluate(async (prefix) => {
-      for (const candidate of document.querySelectorAll('webview')) {
-        const webview = candidate as Electron.WebviewTag
-        try {
-          if (!webview.getURL().startsWith(prefix)) {
-            continue
-          }
-          return {
-            marker: (await webview.executeJavaScript(
-              'document.querySelector("#marker")?.textContent ?? null'
-            )) as string | null,
-            partition: webview.getAttribute('partition')
-          }
-        } catch {
-          // The guest may still be attaching.
+  return page.evaluate(async (prefix) => {
+    for (const candidate of document.querySelectorAll('webview')) {
+      const webview = candidate as Electron.WebviewTag
+      try {
+        if (!webview.getURL().startsWith(prefix)) {
+          continue
         }
+        return {
+          marker: (await webview.executeJavaScript(
+            'document.querySelector("#marker")?.textContent ?? null'
+          )) as string | null,
+          partition: webview.getAttribute('partition')
+        }
+      } catch {
+        // The guest may still be attaching.
       }
-      return null
-    }, url)
-  )
+    }
+    return null
+  }, url)
 }
 
 async function waitForRenderedClientWebview(
@@ -138,6 +253,42 @@ async function readClientSessionCookie(
     },
     { name: COOKIE_NAME, partition, url }
   )
+}
+
+/** Re-reads the runtime's per-process id from the live connection, not the cached status. */
+async function refreshAuthorityRuntimeId(client: PairedElectronClient): Promise<string | null> {
+  return client.page
+    .evaluate(async (environmentId) => {
+      await window.api.runtimeEnvironments.connect({ selector: environmentId })
+      await window.__store?.getState().refreshRuntimeEnvironmentStatus(environmentId)
+      return (
+        window.__store?.getState().runtimeStatusByEnvironmentId.get(environmentId)?.status
+          ?.runtimeId ?? null
+      )
+    }, client.environmentId)
+    .catch(() => null)
+}
+
+/**
+ * Waits until the client is talking to a genuinely new runtime process. A changed
+ * `runtimeId` is the point of the test: it is the per-process value the partition scheme
+ * deliberately stopped hashing, so the cookie must survive precisely while it changes.
+ */
+async function waitForRelaunchedRuntime(
+  client: PairedElectronClient,
+  previousRuntimeId: string
+): Promise<string> {
+  await expect
+    .poll(() => refreshAuthorityRuntimeId(client), {
+      timeout: 180_000,
+      message: 'paired client never reconnected to a relaunched runtime process'
+    })
+    .toEqual(expect.not.stringMatching(`^${previousRuntimeId}$`))
+  const runtimeId = await refreshAuthorityRuntimeId(client)
+  if (!runtimeId) {
+    throw new Error('Paired client lost the runtime id after reconnecting')
+  }
+  return runtimeId
 }
 
 test('keeps client-hosted browser cookies across a paired runtime restart', async ({

--- a/tests/e2e/paired-client-hosted-browser-cookie-survival.spec.ts
+++ b/tests/e2e/paired-client-hosted-browser-cookie-survival.spec.ts
@@ -7,6 +7,10 @@ import {
   launchPairedElectronClient,
   type PairedElectronClient
 } from './helpers/paired-electron-client'
+import {
+  refreshAuthorityRuntimeId,
+  waitForRelaunchedRuntime
+} from './helpers/client-hosted-runtime-relaunch'
 
 const COOKIE_NAME = 'sta4150'
 const COOKIE_VALUE = 'survivor'
@@ -253,42 +257,6 @@ async function readClientSessionCookie(
     },
     { name: COOKIE_NAME, partition, url }
   )
-}
-
-/** Re-reads the runtime's per-process id from the live connection, not the cached status. */
-async function refreshAuthorityRuntimeId(client: PairedElectronClient): Promise<string | null> {
-  return client.page
-    .evaluate(async (environmentId) => {
-      await window.api.runtimeEnvironments.connect({ selector: environmentId })
-      await window.__store?.getState().refreshRuntimeEnvironmentStatus(environmentId)
-      return (
-        window.__store?.getState().runtimeStatusByEnvironmentId.get(environmentId)?.status
-          ?.runtimeId ?? null
-      )
-    }, client.environmentId)
-    .catch(() => null)
-}
-
-/**
- * Waits until the client is talking to a genuinely new runtime process. A changed
- * `runtimeId` is the point of the test: it is the per-process value the partition scheme
- * deliberately stopped hashing, so the cookie must survive precisely while it changes.
- */
-async function waitForRelaunchedRuntime(
-  client: PairedElectronClient,
-  previousRuntimeId: string
-): Promise<string> {
-  await expect
-    .poll(() => refreshAuthorityRuntimeId(client), {
-      timeout: 180_000,
-      message: 'paired client never reconnected to a relaunched runtime process'
-    })
-    .toEqual(expect.not.stringMatching(`^${previousRuntimeId}$`))
-  const runtimeId = await refreshAuthorityRuntimeId(client)
-  if (!runtimeId) {
-    throw new Error('Paired client lost the runtime id after reconnecting')
-  }
-  return runtimeId
 }
 
 test('keeps client-hosted browser cookies across a paired runtime restart', async ({

--- a/tests/e2e/paired-client-hosted-browser-double-restart.spec.ts
+++ b/tests/e2e/paired-client-hosted-browser-double-restart.spec.ts
@@ -12,13 +12,15 @@ import {
   navigateGuest,
   openClientHostedFixturePage,
   readClientBrowserRows,
-  refreshAuthorityRuntimeId,
   selectPairedWorktreeGroup,
   startClientHostedMarkerFixture,
   waitForPairedWorktreeId,
-  waitForRelaunchedRuntime,
   waitForRenderedClientWebview
 } from './helpers/client-hosted-browser-fixture'
+import {
+  refreshAuthorityRuntimeId,
+  waitForRelaunchedRuntime
+} from './helpers/client-hosted-runtime-relaunch'
 
 const CLIENT_NAME = 'STA-4150 client-hosted double restart'
 

--- a/tests/e2e/paired-client-hosted-browser-ghost-close.spec.ts
+++ b/tests/e2e/paired-client-hosted-browser-ghost-close.spec.ts
@@ -12,13 +12,15 @@ import {
   findMirroredBrowserPage,
   openClientHostedFixturePage,
   readClientBrowserRows,
-  refreshAuthorityRuntimeId,
   selectPairedWorktreeGroup,
   startClientHostedMarkerFixture,
   waitForPairedWorktreeId,
-  waitForRelaunchedRuntime,
   waitForRenderedClientWebview
 } from './helpers/client-hosted-browser-fixture'
+import {
+  refreshAuthorityRuntimeId,
+  waitForRelaunchedRuntime
+} from './helpers/client-hosted-runtime-relaunch'
 
 const CLIENT_NAME = 'STA-4150 client-hosted ghost close'
 

--- a/tests/e2e/paired-client-hosted-browser-restart-survival.spec.ts
+++ b/tests/e2e/paired-client-hosted-browser-restart-survival.spec.ts
@@ -12,13 +12,15 @@ import {
   navigateGuest,
   openClientHostedFixturePage,
   readClientBrowserRows,
-  refreshAuthorityRuntimeId,
   selectPairedWorktreeGroup,
   startClientHostedMarkerFixture,
   waitForPairedWorktreeId,
-  waitForRelaunchedRuntime,
   waitForRenderedClientWebview
 } from './helpers/client-hosted-browser-fixture'
+import {
+  refreshAuthorityRuntimeId,
+  waitForRelaunchedRuntime
+} from './helpers/client-hosted-runtime-relaunch'
 
 const CLIENT_NAME = 'STA-4150 client-hosted restart survival'
 


### PR DESCRIPTION
## ELI5

After #17780, a recycled renderer during a paired runtime restart returned `null` from the evaluate helper. The relaunch wait then asked Playwright whether that `null` was \"not the old runtime id\". Playwright says yes — `expect(null).toEqual(expect.not.stringMatching(oldId))` passes — so the wait ended as if the client had already reconnected to a new process.

The wait now polls until it sees a **non-null** runtime id that is not the pre-restart one. A destroyed-context miss stays pending.

## Proof

Unit test drives the shipped `readRelaunchedRuntimeId` helper the wait actually polls:

- `Execution context was destroyed` → `null` (pending miss)
- unrelated evaluate error still rejects
- same id / missing id stay pending; a different live id succeeds