### PR TITLE
fix(clipboard): route runtime-owned image paste through the runtime for server-owned SSH targets

### DIFF
--- a/src/main/runtime/rpc/methods/clipboard.ts
+++ b/src/main/runtime/rpc/methods/clipboard.ts
@@ -7,8 +7,10 @@ import {
   CLIPBOARD_IMAGE_TOO_LARGE_ERROR
 } from '../../../../shared/clipboard-image'
 
+import { CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS } from '../../../../shared/clipboard-image-upload-protocol'
+
 const MAX_CLIPBOARD_IMAGE_BASE64_CHARS = CLIPBOARD_IMAGE_MAX_BASE64_CHARS
-export const CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
+export { CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS }
 export const CLIPBOARD_IMAGE_UPLOAD_MAX_CONCURRENT = 8
 const CLIPBOARD_IMAGE_UPLOAD_TTL_MS = 5 * 60 * 1000
 const BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -648,6 +648,10 @@ describe('registerClipboardHandlers', () => {
     }
   })
 
+  // Routing decisions only in this file — chunk/abort/fallback protocol
+  // mechanics are pinned by clipboard-runtime-image-upload.test.ts and the
+  // web preload clipboard tests, both driving the shared protocol module.
+
   it('saves clipboard images through the selected remote runtime host', async () => {
     const png = Buffer.alloc(512 * 1024)
     const contentBase64 = png.toString('base64')
@@ -656,26 +660,16 @@ describe('registerClipboardHandlers', () => {
       isEmpty: () => false,
       toPNG: () => png
     })
-    callRuntimeEnvironmentMock.mockImplementation(async (_userDataPath, _runtimeId, method) => {
-      if (method === 'clipboard.startImageUpload') {
-        return { ok: true, result: { uploadId: 'upload-1' }, _meta: { runtimeId: 'runtime-1' } }
-      }
-      if (method === 'clipboard.appendImageUploadChunk') {
-        return {
-          ok: true,
-          result: { receivedBase64Length: contentBase64.length },
-          _meta: { runtimeId: 'runtime-1' }
-        }
-      }
-      if (method === 'clipboard.commitImageUpload') {
-        return {
-          ok: true,
-          result: '/tmp/orca-paste-remote.png',
-          _meta: { runtimeId: 'runtime-1' }
-        }
-      }
-      throw new Error(`unexpected method: ${method}`)
-    })
+    callRuntimeEnvironmentMock.mockImplementation(async (_userDataPath, _runtimeId, method) => ({
+      ok: true,
+      result:
+        method === 'clipboard.startImageUpload'
+          ? { uploadId: 'upload-1' }
+          : method === 'clipboard.commitImageUpload'
+            ? '/tmp/orca-paste-remote.png'
+            : { receivedBase64Length: contentBase64.length },
+      _meta: { runtimeId: 'runtime-1' }
+    }))
 
     registerClipboardHandlers({} as never)
 
@@ -693,38 +687,32 @@ describe('registerClipboardHandlers', () => {
       { expectedBase64Length: contentBase64.length, connectionId: null },
       30_000
     )
-    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
-      2,
-      '/tmp',
-      'remote-host-1',
-      'clipboard.appendImageUploadChunk',
-      {
-        uploadId: 'upload-1',
-        offset: 0,
-        contentBase64: contentBase64.slice(0, 512 * 1024)
-      },
-      30_000
-    )
-    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
-      3,
-      '/tmp',
-      'remote-host-1',
-      'clipboard.appendImageUploadChunk',
-      {
-        uploadId: 'upload-1',
-        offset: 512 * 1024,
-        contentBase64: contentBase64.slice(512 * 1024, 1024 * 1024)
-      },
-      30_000
-    )
-    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
-      4,
-      '/tmp',
-      'remote-host-1',
-      'clipboard.commitImageUpload',
-      { uploadId: 'upload-1' },
-      30_000
-    )
+    expect(fsWriteFileMock).not.toHaveBeenCalled()
+    expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a failed runtime upload instead of saving on a client-reachable host', async () => {
+    clipboardReadImageMock.mockReturnValue({
+      getSize: () => ({ height: 1, width: 1 }),
+      isEmpty: () => false,
+      toPNG: () => Buffer.from([0, 1, 2, 3])
+    })
+    callRuntimeEnvironmentMock.mockResolvedValue({
+      ok: false,
+      error: { code: 'runtime_error', message: 'runtime unreachable' },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+
+    registerClipboardHandlers({} as never)
+
+    const handlers = getRegisteredHandlers()
+    await expect(
+      handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), {
+        runtimeEnvironmentId: 'remote-host-1',
+        connectionId: 'ssh-jetson'
+      })
+    ).rejects.toThrow('runtime unreachable')
+    // A wrong-host fallback here is exactly the bug #17679 fixes.
     expect(fsWriteFileMock).not.toHaveBeenCalled()
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
   })
@@ -769,9 +757,6 @@ describe('registerClipboardHandlers', () => {
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
     expect(fsWriteFileMock).not.toHaveBeenCalled()
   })
-
-  // Chunk/abort/fallback mechanics live in clipboard-runtime-image-upload.test.ts;
-  // this file owns the routing decision only.
 
   it('uploads clipboard images to the SSH host when a connection is provided', async () => {
     const png = Buffer.from([0, 1, 2, 3])

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -729,47 +729,49 @@ describe('registerClipboardHandlers', () => {
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
   })
 
-  it('aborts remote runtime clipboard image uploads when a chunk fails', async () => {
-    const png = Buffer.alloc(512 * 1024)
+  it('routes runtime-owned pastes with a server-owned SSH connection through the runtime', async () => {
+    const png = Buffer.from([0, 1, 2, 3])
+    const contentBase64 = png.toString('base64')
     clipboardReadImageMock.mockReturnValue({
       getSize: () => ({ height: 1, width: 1 }),
       isEmpty: () => false,
       toPNG: () => png
     })
-    callRuntimeEnvironmentMock.mockImplementation(async (_userDataPath, _runtimeId, method) => {
-      if (method === 'clipboard.startImageUpload') {
-        return { ok: true, result: { uploadId: 'upload-1' }, _meta: { runtimeId: 'runtime-1' } }
-      }
-      if (method === 'clipboard.appendImageUploadChunk') {
-        return {
-          ok: false,
-          error: { code: 'runtime_error', message: 'append failed' },
-          _meta: { runtimeId: 'runtime-1' }
-        }
-      }
-      if (method === 'clipboard.abortImageUpload') {
-        return { ok: true, result: { aborted: true }, _meta: { runtimeId: 'runtime-1' } }
-      }
-      throw new Error(`unexpected method: ${method}`)
-    })
+    callRuntimeEnvironmentMock.mockImplementation(async (_userDataPath, _runtimeId, method) => ({
+      ok: true,
+      result:
+        method === 'clipboard.startImageUpload'
+          ? { uploadId: 'upload-1' }
+          : method === 'clipboard.commitImageUpload'
+            ? '/tmp/orca-paste-jetson.png'
+            : { receivedBase64Length: contentBase64.length },
+      _meta: { runtimeId: 'runtime-1' }
+    }))
 
     registerClipboardHandlers({} as never)
 
     const handlers = getRegisteredHandlers()
     await expect(
       handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), {
-        runtimeEnvironmentId: 'remote-host-1'
+        runtimeEnvironmentId: 'remote-host-1',
+        connectionId: 'ssh-jetson'
       })
-    ).rejects.toThrow('append failed')
-    expect(callRuntimeEnvironmentMock).toHaveBeenLastCalledWith(
+    ).resolves.toBe('/tmp/orca-paste-jetson.png')
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      1,
       '/tmp',
       'remote-host-1',
-      'clipboard.abortImageUpload',
-      { uploadId: 'upload-1' },
+      'clipboard.startImageUpload',
+      { expectedBase64Length: contentBase64.length, connectionId: 'ssh-jetson' },
       30_000
     )
+    // The connection is server-owned: the client's SSH stack must never see it.
+    expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
     expect(fsWriteFileMock).not.toHaveBeenCalled()
   })
+
+  // Chunk/abort/fallback mechanics live in clipboard-runtime-image-upload.test.ts;
+  // this file owns the routing decision only.
 
   it('uploads clipboard images to the SSH host when a connection is provided', async () => {
     const png = Buffer.from([0, 1, 2, 3])

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -61,7 +61,7 @@ async function saveClipboardImageBufferForTarget(
       app.getPath('userData'),
       runtimeEnvironmentId,
       buffer,
-      args?.connectionId ?? null
+      args?.connectionId?.trim() || null
     )
   }
   return saveClipboardImageBufferAsTempFile(buffer, args)

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -53,8 +53,16 @@ async function saveClipboardImageBufferForTarget(
 ): Promise<string> {
   assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
   const runtimeEnvironmentId = args?.runtimeEnvironmentId?.trim()
-  if (runtimeEnvironmentId && !args?.connectionId) {
-    return saveClipboardImageBufferInRuntime(app.getPath('userData'), runtimeEnvironmentId, buffer)
+  if (runtimeEnvironmentId) {
+    // A connectionId alongside a runtime owner names a SERVER-owned SSH
+    // connection (nested topology) — the runtime forwards over its own SFTP;
+    // the client's SSH stack has no such connection (#17679).
+    return saveClipboardImageBufferInRuntime(
+      app.getPath('userData'),
+      runtimeEnvironmentId,
+      buffer,
+      args?.connectionId ?? null
+    )
   }
   return saveClipboardImageBufferAsTempFile(buffer, args)
 }

--- a/src/main/window/clipboard-runtime-image-upload.test.ts
+++ b/src/main/window/clipboard-runtime-image-upload.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { callRuntimeEnvironmentMock } = vi.hoisted(() => ({
+  callRuntimeEnvironmentMock: vi.fn()
+}))
+
+vi.mock('../ipc/runtime-environment-transport-routing', () => ({
+  callRuntimeEnvironment: callRuntimeEnvironmentMock
+}))
+
+import { saveClipboardImageBufferInRuntime } from './clipboard-runtime-image-upload'
+
+function mockRuntimeUploadMethods(
+  overrides: Record<string, { ok: boolean; result?: unknown; error?: unknown }> = {}
+): void {
+  callRuntimeEnvironmentMock.mockImplementation(
+    async (_userDataPath, _runtimeId, method, params) => {
+      if (method in overrides) {
+        return { ...overrides[method], _meta: { runtimeId: 'runtime-1' } }
+      }
+      switch (method) {
+        case 'clipboard.startImageUpload':
+          return { ok: true, result: { uploadId: 'upload-1' }, _meta: { runtimeId: 'runtime-1' } }
+        case 'clipboard.appendImageUploadChunk':
+          return {
+            ok: true,
+            result: {
+              receivedBase64Length:
+                (params as { offset: number; contentBase64: string }).offset +
+                (params as { contentBase64: string }).contentBase64.length
+            },
+            _meta: { runtimeId: 'runtime-1' }
+          }
+        case 'clipboard.commitImageUpload':
+          return { ok: true, result: '/tmp/orca-paste-remote.png', _meta: { runtimeId: 'r-1' } }
+        case 'clipboard.abortImageUpload':
+          return { ok: true, result: { aborted: true }, _meta: { runtimeId: 'runtime-1' } }
+        default:
+          throw new Error(`unexpected method: ${method}`)
+      }
+    }
+  )
+}
+
+describe('saveClipboardImageBufferInRuntime', () => {
+  beforeEach(() => {
+    callRuntimeEnvironmentMock.mockReset()
+  })
+
+  it('starts the chunked upload with a null connection by default', async () => {
+    mockRuntimeUploadMethods()
+    const buffer = Buffer.from([0, 1, 2, 3])
+
+    await expect(saveClipboardImageBufferInRuntime('/data', 'env-1', buffer)).resolves.toBe(
+      '/tmp/orca-paste-remote.png'
+    )
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      1,
+      '/data',
+      'env-1',
+      'clipboard.startImageUpload',
+      { expectedBase64Length: buffer.toString('base64').length, connectionId: null },
+      30_000
+    )
+  })
+
+  it('threads a server-owned SSH connection into the chunked upload start', async () => {
+    mockRuntimeUploadMethods()
+    const buffer = Buffer.from([0, 1, 2, 3])
+
+    await expect(
+      saveClipboardImageBufferInRuntime('/data', 'env-1', buffer, 'ssh-jetson')
+    ).resolves.toBe('/tmp/orca-paste-remote.png')
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      1,
+      '/data',
+      'env-1',
+      'clipboard.startImageUpload',
+      { expectedBase64Length: buffer.toString('base64').length, connectionId: 'ssh-jetson' },
+      30_000
+    )
+  })
+
+  it('threads the connection into the single-frame fallback on older runtimes', async () => {
+    const buffer = Buffer.from([0, 1, 2, 3])
+    mockRuntimeUploadMethods({
+      'clipboard.startImageUpload': {
+        ok: false,
+        error: { code: 'method_not_found', message: 'unknown method' }
+      },
+      'clipboard.saveImageAsTempFile': { ok: true, result: '/tmp/orca-paste-remote.png' }
+    })
+
+    await expect(
+      saveClipboardImageBufferInRuntime('/data', 'env-1', buffer, 'ssh-jetson')
+    ).resolves.toBe('/tmp/orca-paste-remote.png')
+    expect(callRuntimeEnvironmentMock).toHaveBeenLastCalledWith(
+      '/data',
+      'env-1',
+      'clipboard.saveImageAsTempFile',
+      { contentBase64: buffer.toString('base64'), connectionId: 'ssh-jetson' },
+      30_000
+    )
+  })
+
+  it('aborts the upload when a chunk fails', async () => {
+    const buffer = Buffer.alloc(512 * 1024)
+    mockRuntimeUploadMethods({
+      'clipboard.appendImageUploadChunk': {
+        ok: false,
+        error: { code: 'runtime_error', message: 'append failed' }
+      }
+    })
+
+    await expect(saveClipboardImageBufferInRuntime('/data', 'env-1', buffer)).rejects.toThrow(
+      'append failed'
+    )
+    expect(callRuntimeEnvironmentMock).toHaveBeenLastCalledWith(
+      '/data',
+      'env-1',
+      'clipboard.abortImageUpload',
+      { uploadId: 'upload-1' },
+      30_000
+    )
+  })
+})

--- a/src/main/window/clipboard-runtime-image-upload.test.ts
+++ b/src/main/window/clipboard-runtime-image-upload.test.ts
@@ -81,6 +81,25 @@ describe('saveClipboardImageBufferInRuntime', () => {
     )
   })
 
+  it('normalizes a blank connection to null before forwarding', async () => {
+    // The runtime schema rejects '' (z.string().min(1)); a blank id means
+    // "no connection", exactly like the desktop IPC handler treats it.
+    mockRuntimeUploadMethods()
+    const buffer = Buffer.from([0, 1, 2, 3])
+
+    await expect(saveClipboardImageBufferInRuntime('/data', 'env-1', buffer, '  ')).resolves.toBe(
+      '/tmp/orca-paste-remote.png'
+    )
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      1,
+      '/data',
+      'env-1',
+      'clipboard.startImageUpload',
+      { expectedBase64Length: buffer.toString('base64').length, connectionId: null },
+      30_000
+    )
+  })
+
   it('threads the connection into the single-frame fallback on older runtimes', async () => {
     const buffer = Buffer.from([0, 1, 2, 3])
     mockRuntimeUploadMethods({

--- a/src/main/window/clipboard-runtime-image-upload.ts
+++ b/src/main/window/clipboard-runtime-image-upload.ts
@@ -27,13 +27,14 @@ async function callRuntimeClipboardMethod<TResult>(
 async function saveClipboardImageBase64InRuntime(
   userDataPath: string,
   runtimeEnvironmentId: string,
-  contentBase64: string
+  contentBase64: string,
+  connectionId: string | null
 ): Promise<string> {
   const startResponse = await callRuntimeEnvironment(
     userDataPath,
     runtimeEnvironmentId,
     'clipboard.startImageUpload',
-    { expectedBase64Length: contentBase64.length, connectionId: null },
+    { expectedBase64Length: contentBase64.length, connectionId },
     CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
   )
   if (!startResponse.ok) {
@@ -45,7 +46,7 @@ async function saveClipboardImageBase64InRuntime(
         userDataPath,
         runtimeEnvironmentId,
         'clipboard.saveImageAsTempFile',
-        { contentBase64, connectionId: null }
+        { contentBase64, connectionId }
       )
     }
     throw new Error(startResponse.error.message)
@@ -107,12 +108,14 @@ async function saveClipboardImageBase64InRuntime(
 export function saveClipboardImageBufferInRuntime(
   userDataPath: string,
   runtimeEnvironmentId: string,
-  buffer: Buffer
+  buffer: Buffer,
+  connectionId: string | null = null
 ): Promise<string> {
   assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
   return saveClipboardImageBase64InRuntime(
     userDataPath,
     runtimeEnvironmentId,
-    buffer.toString('base64')
+    buffer.toString('base64'),
+    connectionId
   )
 }

--- a/src/main/window/clipboard-runtime-image-upload.ts
+++ b/src/main/window/clipboard-runtime-image-upload.ts
@@ -1,109 +1,6 @@
 import { assertClipboardImageByteLengthWithinLimit } from '../../shared/clipboard-image'
+import { saveClipboardImageBase64ThroughRuntime } from '../../shared/clipboard-image-upload-protocol'
 import { callRuntimeEnvironment } from '../ipc/runtime-environment-transport-routing'
-
-const CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
-const CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS = 256 * 1024
-const CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS = 30_000
-
-async function callRuntimeClipboardMethod<TResult>(
-  userDataPath: string,
-  runtimeEnvironmentId: string,
-  method: string,
-  params: unknown
-): Promise<TResult> {
-  const response = await callRuntimeEnvironment(
-    userDataPath,
-    runtimeEnvironmentId,
-    method,
-    params,
-    CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-  )
-  if (!response.ok) {
-    throw new Error(response.error.message)
-  }
-  return response.result as TResult
-}
-
-async function saveClipboardImageBase64InRuntime(
-  userDataPath: string,
-  runtimeEnvironmentId: string,
-  contentBase64: string,
-  connectionId: string | null
-): Promise<string> {
-  const startResponse = await callRuntimeEnvironment(
-    userDataPath,
-    runtimeEnvironmentId,
-    'clipboard.startImageUpload',
-    { expectedBase64Length: contentBase64.length, connectionId },
-    CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-  )
-  if (!startResponse.ok) {
-    if (
-      startResponse.error.code === 'method_not_found' &&
-      contentBase64.length <= CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS
-    ) {
-      return callRuntimeClipboardMethod<string>(
-        userDataPath,
-        runtimeEnvironmentId,
-        'clipboard.saveImageAsTempFile',
-        { contentBase64, connectionId }
-      )
-    }
-    throw new Error(startResponse.error.message)
-  }
-  const result = startResponse.result
-  if (
-    !result ||
-    typeof result !== 'object' ||
-    typeof (result as { uploadId?: unknown }).uploadId !== 'string'
-  ) {
-    throw new Error('Remote clipboard image upload returned an invalid id')
-  }
-  const { uploadId } = result as { uploadId: string }
-  try {
-    for (
-      let offset = 0;
-      offset < contentBase64.length;
-      offset += CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
-    ) {
-      await callRuntimeClipboardMethod(
-        userDataPath,
-        runtimeEnvironmentId,
-        'clipboard.appendImageUploadChunk',
-        {
-          uploadId,
-          offset,
-          contentBase64: contentBase64.slice(
-            offset,
-            offset + CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
-          )
-        }
-      )
-    }
-    const remotePath = await callRuntimeClipboardMethod<string>(
-      userDataPath,
-      runtimeEnvironmentId,
-      'clipboard.commitImageUpload',
-      { uploadId }
-    )
-    if (typeof remotePath !== 'string') {
-      throw new Error('Remote clipboard image save returned an invalid path')
-    }
-    return remotePath
-  } catch (error) {
-    // Why: failed chunked pastes should release the remote upload slot
-    // immediately instead of waiting for TTL cleanup.
-    await callRuntimeClipboardMethod(
-      userDataPath,
-      runtimeEnvironmentId,
-      'clipboard.abortImageUpload',
-      {
-        uploadId
-      }
-    ).catch(() => {})
-    throw error
-  }
-}
 
 export function saveClipboardImageBufferInRuntime(
   userDataPath: string,
@@ -112,9 +9,9 @@ export function saveClipboardImageBufferInRuntime(
   connectionId: string | null = null
 ): Promise<string> {
   assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
-  return saveClipboardImageBase64InRuntime(
-    userDataPath,
-    runtimeEnvironmentId,
+  return saveClipboardImageBase64ThroughRuntime(
+    (method, params, timeoutMs) =>
+      callRuntimeEnvironment(userDataPath, runtimeEnvironmentId, method, params, timeoutMs),
     buffer.toString('base64'),
     connectionId
   )

--- a/src/renderer/src/web/preload-api/web-clipboard-api.ts
+++ b/src/renderer/src/web/preload-api/web-clipboard-api.ts
@@ -7,20 +7,15 @@ import {
   assertClipboardImageDimensionsWithinLimit
 } from '../../../../shared/clipboard-image'
 import { assertClipboardTextWriteWithinLimitWithYield } from '../../../../shared/clipboard-text'
+import { saveClipboardImageBase64ThroughRuntime } from '../../../../shared/clipboard-image-upload-protocol'
 import { copyClipboardTextViaExecCommand } from '../web-clipboard-copy-fallback'
-import { callRuntimeEnvelope, callRuntimeResult } from './web-runtime-calls'
+import { callRuntimeEnvelope } from './web-runtime-calls'
 
 export const MAX_CLIPBOARD_IMAGE_BASE64_CHARS = CLIPBOARD_IMAGE_MAX_BASE64_CHARS
 
 export const MAX_CLIPBOARD_IMAGE_SOURCE_BYTES = CLIPBOARD_IMAGE_MAX_SOURCE_BYTES
 
 export const MAX_CLIPBOARD_IMAGE_PIXELS = CLIPBOARD_IMAGE_MAX_PIXELS
-
-export const CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
-
-export const CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS = 256 * 1024
-
-export const CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS = 30_000
 
 export function blobToBase64(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -120,58 +115,9 @@ export async function saveClipboardImageAsTempFileInRuntime(
   if (contentBase64.length > MAX_CLIPBOARD_IMAGE_BASE64_CHARS) {
     throw new Error(CLIPBOARD_IMAGE_TOO_LARGE_ERROR)
   }
-  const connectionId = args?.connectionId ?? null
-  const startResponse = await callRuntimeEnvelope<{ uploadId: string }>(
-    'clipboard.startImageUpload',
-    { expectedBase64Length: contentBase64.length, connectionId },
-    CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
+  return saveClipboardImageBase64ThroughRuntime(
+    (method, params, timeoutMs) => callRuntimeEnvelope(method, params, timeoutMs),
+    contentBase64,
+    args?.connectionId ?? null
   )
-  if (!startResponse.ok) {
-    if (
-      startResponse.error.code === 'method_not_found' &&
-      contentBase64.length <= CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS
-    ) {
-      return callRuntimeResult<string>(
-        'clipboard.saveImageAsTempFile',
-        { contentBase64, connectionId },
-        CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-      )
-    }
-    throw new Error(startResponse.error.message)
-  }
-
-  const { uploadId } = startResponse.result
-  try {
-    for (
-      let offset = 0;
-      offset < contentBase64.length;
-      offset += CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
-    ) {
-      await callRuntimeResult(
-        'clipboard.appendImageUploadChunk',
-        {
-          uploadId,
-          offset,
-          contentBase64: contentBase64.slice(
-            offset,
-            offset + CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
-          )
-        },
-        CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-      )
-    }
-    return await callRuntimeResult<string>(
-      'clipboard.commitImageUpload',
-      { uploadId },
-      CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-    )
-  } catch (error) {
-    // Why: after chunked paste holds server-side state, release the bounded slot on failure rather than wait for TTL cleanup.
-    await callRuntimeResult(
-      'clipboard.abortImageUpload',
-      { uploadId },
-      CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-    ).catch(() => {})
-    throw error
-  }
 }

--- a/src/renderer/src/web/web-preload-api-clipboard.test.ts
+++ b/src/renderer/src/web/web-preload-api-clipboard.test.ts
@@ -303,7 +303,7 @@ describe('web UI preload API', () => {
     writeStoredRuntimeEnvironment(globals.storage)
     const { installWebPreloadApi } = await import('./web-preload-api')
     const { CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS } =
-      await import('./preload-api/web-clipboard-api')
+      await import('../../../shared/clipboard-image-upload-protocol')
     const contentBase64 = `${'A'.repeat(CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS)}AAAA`
     installClipboardImageBase64(contentBase64)
     installWebPreloadApi()
@@ -417,7 +417,7 @@ describe('web UI preload API', () => {
     writeStoredRuntimeEnvironment(globals.storage)
     const { installWebPreloadApi } = await import('./web-preload-api')
     const { CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS } =
-      await import('./preload-api/web-clipboard-api')
+      await import('../../../shared/clipboard-image-upload-protocol')
     installClipboardImageBase64('A'.repeat(CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS + 4))
     installWebPreloadApi()
 

--- a/src/shared/clipboard-image-upload-protocol.ts
+++ b/src/shared/clipboard-image-upload-protocol.ts
@@ -1,0 +1,93 @@
+// Chunked clipboard-image upload protocol shared by the desktop main process
+// and the web preload. Keeping one driver prevents the transports from
+// diverging on protocol details (chunking, fallback gate, abort policy,
+// connection forwarding — see #17679).
+
+export const CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
+export const CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS = 256 * 1024
+export const CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS = 30_000
+
+export type ClipboardImageUploadRpcResponse =
+  | { ok: true; result: unknown }
+  | { ok: false; error: { code?: string; message: string } }
+
+export type ClipboardImageUploadRpcCall = (
+  method: string,
+  params: unknown,
+  timeoutMs: number
+) => Promise<ClipboardImageUploadRpcResponse>
+
+async function callOk(
+  call: ClipboardImageUploadRpcCall,
+  method: string,
+  params: unknown
+): Promise<unknown> {
+  const response = await call(method, params, CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS)
+  if (!response.ok) {
+    throw new Error(response.error.message)
+  }
+  return response.result
+}
+
+function assertRemotePath(result: unknown): string {
+  if (typeof result !== 'string') {
+    throw new Error('Remote clipboard image save returned an invalid path')
+  }
+  return result
+}
+
+/**
+ * Upload a clipboard image to the paired runtime and return the path of the
+ * temp file it saved. `connectionId` names a connection owned by the RUNTIME
+ * (its own SSH target for nested worktrees), never one owned by this client.
+ * Falls back to the pre-chunking single-frame RPC for small images against
+ * older runtimes.
+ */
+export async function saveClipboardImageBase64ThroughRuntime(
+  call: ClipboardImageUploadRpcCall,
+  contentBase64: string,
+  connectionId: string | null
+): Promise<string> {
+  const startResponse = await call(
+    'clipboard.startImageUpload',
+    { expectedBase64Length: contentBase64.length, connectionId },
+    CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
+  )
+  if (!startResponse.ok) {
+    if (
+      startResponse.error.code === 'method_not_found' &&
+      contentBase64.length <= CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS
+    ) {
+      return assertRemotePath(
+        await callOk(call, 'clipboard.saveImageAsTempFile', { contentBase64, connectionId })
+      )
+    }
+    throw new Error(startResponse.error.message)
+  }
+  const uploadId = (startResponse.result as { uploadId?: unknown } | null)?.uploadId
+  if (typeof uploadId !== 'string') {
+    throw new Error('Remote clipboard image upload returned an invalid id')
+  }
+  try {
+    for (
+      let offset = 0;
+      offset < contentBase64.length;
+      offset += CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
+    ) {
+      await callOk(call, 'clipboard.appendImageUploadChunk', {
+        uploadId,
+        offset,
+        contentBase64: contentBase64.slice(
+          offset,
+          offset + CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
+        )
+      })
+    }
+    return assertRemotePath(await callOk(call, 'clipboard.commitImageUpload', { uploadId }))
+  } catch (error) {
+    // Why: failed chunked pastes should release the bounded remote upload slot
+    // immediately instead of waiting for TTL cleanup.
+    await callOk(call, 'clipboard.abortImageUpload', { uploadId }).catch(() => {})
+    throw error
+  }
+}

--- a/src/shared/clipboard-image-upload-protocol.ts
+++ b/src/shared/clipboard-image-upload-protocol.ts
@@ -46,8 +46,10 @@ function assertRemotePath(result: unknown): string {
 export async function saveClipboardImageBase64ThroughRuntime(
   call: ClipboardImageUploadRpcCall,
   contentBase64: string,
-  connectionId: string | null
+  rawConnectionId: string | null
 ): Promise<string> {
+  // A blank id means "no connection" — the runtime schema rejects ''.
+  const connectionId = rawConnectionId?.trim() || null
   const startResponse = await call(
     'clipboard.startImageUpload',
     { expectedBase64Length: contentBase64.length, connectionId },


### PR DESCRIPTION
Fixes #17679

## Problem

In a nested topology — desktop client → Remote Orca Server → **server-owned** SSH target — pasting a clipboard image fails with `Remote connection dropped. Click Reconnect on the SSH target before retrying`, and reconnecting never helps.

The routing in `saveClipboardImageBufferForTarget` only chose the runtime transport when *no* `connectionId` was present. A nested worktree carries both a `runtimeEnvironmentId` and the server's SSH `connectionId`, so the client fell into its **own** SSH SFTP path with a connection id it has no connection for — the exact error reported, on both Windows and macOS clients.

## Fix

- Route to the runtime whenever a runtime environment id is present. A `connectionId` alongside a runtime owner names a **server-owned** connection: the runtime forwards the file over its own SFTP, exactly as the paired web client already does.
- Thread the connection id through the chunked upload start **and** the small-image single-frame fallback (both previously hardcoded `null`, which would have landed the file on the server instead of the SSH target).
- No wire change: `clipboard.startImageUpload` / `clipboard.saveImageAsTempFile` have accepted the optional nullable `connectionId` since they were introduced, so older servers honor it (per `docs/reference/remote-wire-compatibility.md`, no capability negotiation needed).

## Review follow-ups included

- Extracted the chunked-upload / fallback / abort protocol into `src/shared/clipboard-image-upload-protocol.ts`, now driven by both the desktop main process and the web preload. The two hand-rolled copies are how the `connectionId` divergence happened in the first place. (The mobile client still has its own copy — possible follow-up, it's a separate package.)
- Normalize an empty-string `connectionId` to `null` before forwarding (the old guard treated `''` as absent; the RPC schema rejects it).
- Test at the IPC seam that a failed runtime upload **rejects** instead of falling back to a client-reachable host — a wrong-host fallback is precisely the bug this PR fixes.

## Known narrow edge (not addressed here)

`getConnectionId` resolution is host-blind over duplicate repo rows (one runtime-stamped, one client-SSH): in that state a client-owned connection id could be forwarded to a runtime that doesn't know it, failing the paste. The trigger requires duplicate repo ids with only the runtime row's worktree hydrated; fixing it means host-aware connection resolution in the renderer and is left as a follow-up.

## Testing

- `clipboard-ipc-handlers.test.ts`: routing matrix at the IPC seam — runtime-only, runtime+server-owned-connection (asserts the client SSH stack is never consulted), failure rejection, plus the untouched SSH-only/local cases.
- `clipboard-runtime-image-upload.test.ts` (new): protocol mechanics through the shared driver — connection threading in start and fallback, chunking, abort-on-chunk-failure.
- Web preload clipboard tests now exercise the same shared driver unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019G22teMcYiNe9RmGQ4dKuK
