### PR TITLE
ci(release): tolerate legacy tags without source maps

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1344,6 +1344,7 @@ jobs:
       # otherwise undecodable. The main bundle is platform-independent, so one
       # leg publishes the maps for the whole release.
       - name: Bundle main-process source maps
+        id: bundle-main-sourcemaps
         if: matrix.platform == 'linux-x64'
         shell: bash
         env:
@@ -1351,9 +1352,17 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "$(find out/main -name '*.js.map' -print -quit)" ]; then
-            echo "::error::No main-process source maps in out/main. Did build.sourcemap regress in electron.vite.config.ts?"
-            exit 1
+            # Older cut tags predate the hidden-source-map build setting. They
+            # are valid legacy releases, but have no map bundle to publish.
+            if grep -Eq "sourcemap:[[:space:]]*['\"]hidden['\"]" electron.vite.config.ts; then
+              echo "::error::No main-process source maps in out/main despite build.sourcemap='hidden'."
+              exit 1
+            fi
+            echo "has_maps=false" >>"$GITHUB_OUTPUT"
+            echo "::notice::Cut ref predates hidden main-process source maps; skipping map publication."
+            exit 0
           fi
+          echo "has_maps=true" >>"$GITHUB_OUTPUT"
           # Why: every entry in electron-builder's `files` is a negation, so
           # app-builder prepends `**/*` and packs anything left in the workspace
           # root into app.asar. Stage the bundle outside the checkout instead.
@@ -1361,7 +1370,7 @@ jobs:
           ls -l "$RUNNER_TEMP/orca-sourcemaps-$TAG.zip"
 
       - name: Publish main-process source maps
-        if: matrix.platform == 'linux-x64'
+        if: matrix.platform == 'linux-x64' && steps.bundle-main-sourcemaps.outputs.has_maps == 'true'
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10

--- a/config/scripts/release-cut-sourcemap-publish.test.mjs
+++ b/config/scripts/release-cut-sourcemap-publish.test.mjs
@@ -41,12 +41,22 @@ describe('release-cut source map publication', () => {
     expect(publish.with.command).toContain('runner.temp')
   })
 
-  it('fails the release when no source maps were emitted', () => {
-    // Why: a silent regression of build.sourcemap would ship an undecodable
-    // release rather than an obviously broken one.
+  it('fails only when a map-enabled cut emits no source maps', () => {
+    // Why: legacy tags predate source-map publication, but a newer tag that
+    // enables hidden maps must still fail loudly if the build regresses.
     const bundle = buildSteps[stepIndex('Bundle main-process source maps')]
+    expect(bundle.id).toBe('bundle-main-sourcemaps')
+    expect(bundle.run).toContain('grep -Eq')
+    expect(bundle.run).toContain('sourcemap:[[:space:]]*')
+    expect(bundle.run).toContain('has_maps=false')
+    expect(bundle.run).toContain('has_maps=true')
     expect(bundle.run).toContain('::error::')
     expect(bundle.run).toContain('exit 1')
+  })
+
+  it('skips publication for legacy cut refs without hidden source maps', () => {
+    const publish = buildSteps[stepIndex('Publish main-process source maps')]
+    expect(publish.if).toContain("steps.bundle-main-sourcemaps.outputs.has_maps == 'true'")
   })
 
   it('bundles maps after the build and before packaging strips them', () => {

--- a/tests/e2e/golden-source-control-open-diff.spec.ts
+++ b/tests/e2e/golden-source-control-open-diff.spec.ts
@@ -19,10 +19,10 @@ test('@golden opens an unstaged file diff from Source Control', async ({
 }) => {
   const fixture = createGoldenWorktree(testRepoPath, 'open-diff')
   registerPostElectronShutdownCleanup(async () => cleanupGoldenWorktree(testRepoPath, fixture))
+  seedGoldenSourceEdit(fixture.worktreePath)
 
   await waitForSessionReady(orcaPage)
   await openGoldenSourceControl(orcaPage, testRepoPath, fixture)
-  seedGoldenSourceEdit(fixture.worktreePath)
 
   const changedFile = orcaPage
     .locator('[data-testid="source-control-entry"]')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

## Summary
- allow valid release tags from before hidden main-process source maps to skip the optional map upload
- keep a hard failure when map-enabled builds emit no maps
- cover the conditional publication contract

This is required to recover the existing v1.4.194 draft without changing its candidate source or tag.