### PR TITLE
fix(git): resolve WSL drvfs Git metadata pointers on a Windows host

### DIFF
--- a/src/main/git/repo-git-marker-scan.ts
+++ b/src/main/git/repo-git-marker-scan.ts
@@ -1,8 +1,7 @@
 import { readFileSync, realpathSync, statSync } from 'node:fs'
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { dirname, isAbsolute, join, relative } from 'node:path'
 import { normalizeRuntimePathSeparators } from '../../shared/cross-platform-path'
-import { parseWslUncPath } from '../../shared/wsl-paths'
-import { toWindowsWslPath } from '../wsl'
+import { resolveGitMetadataPath } from '../../shared/git-metadata-path'
 
 export type GitMarkerScanResult =
   | { status: 'valid'; rootPath: string }
@@ -134,18 +133,6 @@ function parseGitdirFile(basePath: string, content: string): string | null {
     return null
   }
   return resolveGitMetadataPath(basePath, match[1])
-}
-
-function resolveGitMetadataPath(basePath: string, rawPath: string): string | null {
-  const value = rawPath.trim()
-  if (!value) {
-    return null
-  }
-  const baseWsl = parseWslUncPath(basePath)
-  if (baseWsl && value.startsWith('/')) {
-    return toWindowsWslPath(value, baseWsl.distro)
-  }
-  return isAbsolute(value) ? value : resolve(basePath, value)
 }
 
 function hasValidGitDirectorySync(gitDir: string): boolean {

--- a/src/shared/git-metadata-path.test.ts
+++ b/src/shared/git-metadata-path.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { resolveGitMetadataPath } from './git-metadata-path'
+
+describe('resolveGitMetadataPath', () => {
+  it('maps a drvfs pointer to its drive spelling on a Windows host with no distro context', () => {
+    expect(
+      resolveGitMetadataPath(
+        String.raw`C:\Users\me\repo`,
+        '/mnt/c/Users/me/repo/.git/worktrees/feature',
+        'win32'
+      )
+    ).toBe(String.raw`C:\Users\me\repo\.git\worktrees\feature`)
+  })
+
+  it('maps a drvfs drive root to its drive spelling', () => {
+    expect(resolveGitMetadataPath(String.raw`D:\repo`, '/mnt/d', 'win32')).toBe('D:\\')
+  })
+
+  it('keeps a non-drvfs guest pointer verbatim when no distro names it', () => {
+    // Windows already reads this as drive-relative; guessing a distro would probe the wrong disk.
+    expect(resolveGitMetadataPath(String.raw`C:\repo`, '/home/me/repo/.git', 'win32')).toBe(
+      '/home/me/repo/.git'
+    )
+  })
+
+  it('maps a guest pointer through the distro encoded by a WSL UNC base', () => {
+    expect(
+      resolveGitMetadataPath(
+        String.raw`\\wsl.localhost\Debian\home\me\repo`,
+        '/home/me/repo/.git',
+        'win32'
+      )
+    ).toBe(String.raw`\\wsl.localhost\Debian\home\me\repo\.git`)
+  })
+
+  it('resolves a relative pointer against a WSL UNC base', () => {
+    expect(
+      resolveGitMetadataPath(
+        String.raw`\\wsl.localhost\Debian\home\me\repo\.git\worktrees\feature`,
+        '../..',
+        'win32'
+      )
+    ).toBe(String.raw`\\wsl.localhost\Debian\home\me\repo\.git`)
+  })
+
+  it('resolves relative pointers with the reading host path flavor', () => {
+    expect(resolveGitMetadataPath('/repo/worktree', '../.git/worktrees/feature', 'linux')).toBe(
+      '/repo/.git/worktrees/feature'
+    )
+    expect(
+      resolveGitMetadataPath(
+        String.raw`C:\repo\worktree`,
+        String.raw`..\.git\worktrees\feature`,
+        'win32'
+      )
+    ).toBe(String.raw`C:\repo\.git\worktrees\feature`)
+  })
+
+  it('leaves absolute pointers alone on a POSIX host, drvfs spelling included', () => {
+    expect(
+      resolveGitMetadataPath('/repo/worktree', '/var/lib/git/worktrees/feature', 'linux')
+    ).toBe('/var/lib/git/worktrees/feature')
+    expect(resolveGitMetadataPath('/repo/worktree', '/mnt/c/repo/.git', 'darwin')).toBe(
+      '/mnt/c/repo/.git'
+    )
+  })
+
+  it.each(['', '   ', '\t'])('rejects an empty metadata pointer %j', (rawPath) => {
+    expect(resolveGitMetadataPath('/repo', rawPath, 'linux')).toBeNull()
+  })
+
+  it('trims a padded pointer before resolving it', () => {
+    expect(resolveGitMetadataPath('/repo/worktree', '  ../.git  ', 'linux')).toBe('/repo/.git')
+  })
+})

--- a/src/shared/git-metadata-path.ts
+++ b/src/shared/git-metadata-path.ts
@@ -1,0 +1,46 @@
+import { posix, win32 } from 'node:path'
+import { parseWslUncPath, toWindowsWslDrivePath, toWindowsWslPath } from './wsl-paths'
+
+/**
+ * Resolve a Git metadata pointer (a `.git` gitfile payload or a `commondir`) in the path namespace
+ * of the host that reads it.
+ *
+ * Why: git running inside WSL writes these pointers in the guest namespace, but Node reads them
+ * back through Win32, where a drvfs pointer like `/mnt/c/repo/.git` silently means
+ * `C:\mnt\c\repo\.git`. Returns null only for an empty pointer.
+ */
+export function resolveGitMetadataPath(
+  basePath: string,
+  rawPath: string,
+  platform: NodeJS.Platform = process.platform
+): string | null {
+  const value = rawPath.trim()
+  if (!value) {
+    return null
+  }
+  if (value.startsWith('/')) {
+    const translated = translateGuestPointer(value, basePath, platform)
+    if (translated) {
+      return translated
+    }
+  }
+  const host = platform === 'win32' ? win32 : posix
+  return host.isAbsolute(value) ? value : host.resolve(basePath, value)
+}
+
+/**
+ * The Win32 spelling of a POSIX-rooted pointer, or null to leave it alone. A WSL UNC base names the
+ * distro that wrote the pointer; failing that, only a drvfs mount has a spelling we can derive, and
+ * only a Windows host needs one.
+ */
+function translateGuestPointer(
+  value: string,
+  basePath: string,
+  platform: NodeJS.Platform
+): string | null {
+  const distro = parseWslUncPath(basePath)?.distro
+  if (distro) {
+    return toWindowsWslPath(value, distro)
+  }
+  return platform === 'win32' ? toWindowsWslDrivePath(value) : null
+}

--- a/src/shared/wsl-paths.test.ts
+++ b/src/shared/wsl-paths.test.ts
@@ -6,6 +6,7 @@ import {
   isWslUncPath,
   parseWslUncPath,
   resolveWslRepoWorktreeBasePath,
+  toWindowsWslDrivePath,
   toWindowsWslPath,
   toWindowsWslUncPath
 } from './wsl-paths'
@@ -36,6 +37,31 @@ describe('wsl path helpers', () => {
   ])('converts %s without folding case-sensitive Linux paths', (linuxPath, expected) => {
     expect(toWindowsWslPath(linuxPath, 'Ubuntu')).toBe(expected)
   })
+
+  it.each([
+    ['/mnt/c/Users/jin', 'C:\\Users\\jin'],
+    ['/mnt/d', 'D:\\'],
+    ['/mnt/d/', 'D:\\'],
+    ['/MNT/c/Users/jin', null],
+    ['/mnt/C/Repo', null],
+    ['/home/jin', null],
+    // A drvfs prefix on a line that still carries a terminator is not a drive path.
+    ['/mnt/c/Users/jin\r', null],
+    ['/mnt/c/Users/jin\n', null],
+    ['/mnt/c/Users/jin\u2028', null],
+    ['/mnt/c/Users/jin\u2029', null]
+  ] as const)('converts the DrvFs path %j without a distro lookup', (linuxPath, expected) => {
+    expect(toWindowsWslDrivePath(linuxPath)).toBe(expected)
+  })
+
+  it.each(['\r', '\n', '\u2028', '\u2029'])(
+    'leaves a DrvFs line ending in %j on the distro UNC view',
+    (terminator) => {
+      expect(toWindowsWslPath(`/mnt/c/Users/jin${terminator}`, 'Ubuntu')).toBe(
+        `\\\\wsl.localhost\\Ubuntu\\mnt\\c\\Users\\jin${terminator}`
+      )
+    }
+  )
 
   it('keeps mounted-drive paths on the distro UNC view when requested', () => {
     expect(toWindowsWslUncPath('/mnt/c/Users/jin', 'Ubuntu')).toBe(

--- a/src/shared/wsl-paths.ts
+++ b/src/shared/wsl-paths.ts
@@ -49,13 +49,7 @@ export function toLinuxPath(windowsPath: string): string {
 
 /** Convert an absolute Linux path in a known WSL distro to its Windows form. */
 export function toWindowsWslPath(linuxPath: string, distro: string): string {
-  const mntMatch = linuxPath.match(/^\/mnt\/([a-z])(\/.*)?$/)
-  if (mntMatch) {
-    const rest = (mntMatch[2] || '').replace(/\//g, '\\')
-    return `${mntMatch[1].toUpperCase()}:${rest || '\\'}`
-  }
-
-  return toWindowsWslUncPath(linuxPath, distro)
+  return toWindowsWslDrivePath(linuxPath) ?? toWindowsWslUncPath(linuxPath, distro)
 }
 
 /** Keep a Linux path addressable through its distro, including drvfs mounts. */
@@ -132,12 +126,32 @@ export function toWslExecutionSpace(path: string): string {
   return parseWslUncPath(path)?.linuxPath ?? path
 }
 
-/** The drvfs automount is literally lowercase `/mnt/<letter>`; `/MNT` is an ordinary Linux dir. */
+/**
+ * The drvfs automount is literally lowercase `/mnt/<letter>`; `/MNT` is an ordinary Linux dir.
+ * Deliberately looser than `toWindowsWslDrivePath`'s end-anchored matcher below: this one only
+ * classifies a prefix, so do not unify them — the anchoring there is what keeps a path carrying a
+ * stray line terminator off the drive spelling.
+ */
 const DRVFS_LINUX_PATH = /^\/mnt\/[a-z](?:\/|$)/
 
 /** True for a Linux path that is really a Windows drive reached through drvfs. */
 export function isDrvfsLinuxPath(linuxPath: string): boolean {
   return DRVFS_LINUX_PATH.test(linuxPath)
+}
+
+/**
+ * The Windows drive spelling of a drvfs path, or null when the path is not one. Needs no distro:
+ * the bytes sit on the drive whichever distro mounted them.
+ */
+export function toWindowsWslDrivePath(linuxPath: string): string | null {
+  // `.` excludes every line terminator, so a drvfs prefix on a stray output line (an rg hit that
+  // still carries its CR) stays off the drive spelling.
+  const match = linuxPath.match(/^\/mnt\/([a-z])(\/.*)?$/)
+  if (!match) {
+    return null
+  }
+  const tail = (match[2] ?? '').replace(/\//g, '\\')
+  return `${match[1].toUpperCase()}:${tail || '\\'}`
 }
 
 /**


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​70 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |

<!-- /orca-pr-loc -->

On Windows, when Orca's runtime is a WSL distro but the repo lives on a Windows drive, git inside the distro writes `gitdir: /mnt/c/...` into a linked worktree's `.git` file and its `commondir`. Orca reads those files back through Win32, where `/mnt/c/repo/.git` means *drive-relative* `C:\mnt\c\repo\.git`, so `scanGitMarkerSync` could not stat the Git directory and reported the worktree `invalid` — the user sees "Not a valid git repository" for a checkout that git itself is perfectly happy with.

## What this changes

`resolveGitMetadataPath` moves out of `repo-git-marker-scan.ts` into `src/shared/git-metadata-path.ts` and gains exactly one new case: on `win32`, a POSIX-rooted pointer whose base path is *not* a `\\wsl.localhost\...` UNC path is checked against the drvfs mount table spelling and, if it matches `/mnt/<letter>/...`, converted to `C:\...`. Anything else falls through to the pre-existing behavior (verbatim if absolute, `resolve(base, value)` if relative).

`toWindowsWslDrivePath` is extracted from `toWindowsWslPath` so that conversion has one implementation instead of two.

The only observable output change is `scanGitMarkerSync` returning `{ status: 'valid' }` where it returned `{ status: 'invalid' }`. `rootPath` is always the worktree directory; the resolved pointer is only ever `statSync`'d for validity, never returned.

## What changes for users

| Platform | Change |
| --- | --- |
| macOS | No change. The new branch is gated on `platform === 'win32'`; the differential matrix (14 bases x 30 pointers) shows 0 divergences from the deleted helper. |
| Linux | No change. Same gate, 0 divergences. |
| Native Windows (no WSL) | No change in practice. The branch is reachable, but it only fires on a `.git`/`commondir` payload spelled `/mnt/<lowercase letter>`, which native-Windows git does not write. A `C:\`-spelled, relative, or POSIX-rooted-but-not-drvfs pointer is byte-identical to before. |
| WSL-on-Windows (distro runtime, repo on a Windows drive) | **This is the fixed case.** A linked worktree whose pointer is `/mnt/c/...` now reports `valid` from the marker scan instead of `invalid`, so it passes the repo-registration gates. See "Costs" — being admitted is not the same as working. |
| WSL-on-Windows (repo *inside* the distro) | No change. That layout is reached through a `\\wsl.localhost\...` base path, which already named the distro and already routed through `toWindowsWslPath`. |
| SSH remote | No change. `scanGitMarkerSync` is a synchronous `node:fs` fallback on the machine running the main process; remote hosts answer through the execution host's git (e.g. `nested-repo-import-handler.ts` takes an `resolveSsh` branch that never calls `isGitRepo`). No verdict-vocabulary surface is touched. |
| Relay | No change. The relay has its own `resolveGitDir` in `src/relay/git-handler-status-ops.ts` and does not import `repo-git-marker-scan` or the new module. No RPC params, no stream opcodes, no change to what the host publishes. |
| Folder workspace | No change on macOS/Linux, and no change for a folder that is not a git checkout. On Windows a *folder* workspace sitting in the fixed layout follows the WSL-on-Windows row: `folder-repo-git-upgrade.ts` gates on `isGitRepo`, so such a folder can now be upgraded to a git repo where it previously stayed a plain folder. |

No Git subcommand or option is added, so there is no Git-version floor implication (the code never shells out to git).

## What this does NOT do

- **It does not make the newly-accepted worktree fully functional.** `src/main/git/source-control/resolve-git-dir.ts` still does `path.resolve(worktreePath, '/mnt/c/repos/x/.git')` on the same Windows host, which yields a nonexistent `C:\mnt\c\...`. Its four consumers — `git-conflict-operation.ts` (returns `'unknown'`), `worktree-sparse-state.ts` (returns `false`), `worktree-diff-stamp.ts`, `worktree-listing.ts` — then fail open. Fixing those means changing parsers shared with the relay and is a separate slice.
- **It does not fix the inverse WSL layout** (repo inside the distro, linked worktree mirrored onto a Windows drive with `gitdir: /home/...`). Without a UNC base there is no distro to name, so that pointer still comes back verbatim and still reports `invalid`. Wiring the runtime's distro into this resolver is a separate change; the earlier version of this work carried a `wslDistro` option, and it was cut because nothing production-side could populate it.
- **It does not assume a non-default automount root.** `/mnt` is hardcoded. With `[automount] root=/` in `wsl.conf`, git writes `gitdir: /c/repos/x/.git`, which is not drvfs-matched and still reports `invalid`. This is a pre-existing tree-wide assumption (`isDrvfsLinuxPath`, `toWindowsWslPath` and friends all make it), not something this PR introduces, but this PR does not lift it either.
- **It does not fix a drvfs-spelled *base* with a relative pointer.** On win32, `resolveGitMetadataPath('/mnt/c/repo/wt', '../..')` still goes through `win32.resolve` and lands on `\mnt\c` (drive-relative), not `/mnt/c/repo`. Unchanged from `main`; outside the one cell this PR fixes.
- **It does not harden any `gitdir:` parser.** The `gitdir:` regexes in `resolve-git-dir.ts`, `git-fetch-head-lock.ts`, the relay, and five other files are untouched and still accept an empty payload. That hardening was in the larger closed PR this slice was cut from, along with a lock-key change in `git-fetch-head-lock.ts`; both were reverted here because they are unrelated to the reported bug and were the source of a main/relay behavioral disagreement.
- **It does not exercise real WSL semantics.** No `wsl.exe` invocation, no 9p round trip. The Windows rows are platform-injected unit tests.

## Costs and residual risk

- **A loud failure becomes a quiet one for the fixed configuration.** Today this layout is refused at registration with a clear "Not a valid git repository". After this change it is admitted, and then `resolve-git-dir` silently computes a nonexistent Git directory: no conflict badge where there is a conflict, no sparse-checkout badge where the checkout is sparse, and a degraded diff stamp / worktree listing. This is a real trade — a user who could previously tell something was wrong may now see a worktree that looks fine and quietly under-reports. It is still a net improvement (the repo is usable; git commands run through the execution host, not through this path), but it is worse on the "fails visibly" axis and a follow-up should land.
- **`toWindowsWslDrivePath` is a new export** from `src/shared/wsl-paths.ts`, widening that module's public surface by one function. It returns `null` rather than throwing on non-drvfs input, so a careless caller gets a null, not a wrong drive.
- **`resolveGitMetadataPath` takes an explicit `platform` parameter** defaulting to `process.platform`. On the real host it selects `win32`/`posix` path functions that are identical to the ambient `node:path` the deleted helper used, so there is no production behavior delta from the flavor selection. A caller passing a `platform` that does not match the host would get paths resolved for the wrong namespace; only the tests do this.
- **The drvfs matcher is deliberately not unified with `isDrvfsLinuxPath`.** They are ten lines apart and disagree on inputs carrying a line terminator (`isDrvfsLinuxPath('/mnt/c/x\r')` is `true`, `toWindowsWslDrivePath('/mnt/c/x\r')` is `null`). That disagreement is what makes `toWindowsWslPath` byte-for-byte unchanged, so a future "clean up the duplicate regex" pass would reintroduce a bug. This PR adds a comment at `DRVFS_LINUX_PATH` saying so; a comment is weaker than a test and this remains a maintenance trap.
- **The adoption point has no behavioral test.** `repo-git-marker-scan.ts` calling the shared resolver is covered only by the fact that the resolver's own tests pass; exercising the changed cell end-to-end needs a real Windows host with a `C:` drive to `stat`, and there is no platform-injectable seam at that layer. A mutation that swapped the resolver back inside `repo-git-marker-scan.ts` would not be caught by any test in this repo.
- **Uppercase drive letters are not matched** (`/mnt/C/repo` -> no conversion). This matches `main`'s `toWindowsWslPath` and the real automount, which is lowercase, but it is a narrow matcher.

## Verification

Environment: macOS, Node/vitest 4.1.11. `pnpm tc` runs in CI.

**Test commands and counts (all from the tip commit):**

```
npx vitest run src/shared/git-metadata-path.test.ts src/shared/wsl-paths.test.ts src/main/git/repo-detection.test.ts
  -> 3 files, 79 passed, 0 failed

npx vitest run src/main/git src/shared
  -> 796 files (785 passed, 5 failed, 6 skipped), 8705 tests: 8623 passed, 9 failed, 73 skipped
```

The 9 failures are pre-existing and environmental, in 5 files: `pty-reply-echo-shapes.node-pty.test.ts` (4), `setup-agent-sequencing.test.ts` (2), `fish-query-reply-child-stdin.node-pty.test.ts` (1), `remote-runtime-shared-control-connection.test.ts` (1), and `git-admission-storm-measurement.test.ts` (1, an `ENOENT` scandir on a temp state dir; it also fails when run alone). None of the five imports `wsl-paths` or `git-metadata-path` — verified by grep — and none is in the module graph this PR touches.

**Mutation-verified** (production hunk reverted, suite confirmed red, hunk restored — all four restored, worktree clean):

| Mutation | Result |
| --- | --- |
| `platform === 'win32' ? toWindowsWslDrivePath(value) : null` -> `return null` (restores `main`'s behavior for the fixed cell) | `git-metadata-path.test.ts` 2 failed / 9 passed |
| Remove the fall-through: return `translateGuestPointer(...)` directly, so a non-drvfs guest pointer yields `null` instead of verbatim | `git-metadata-path.test.ts` 2 failed / 9 passed |
| `const host = platform === 'win32' ? win32 : posix` -> `const host = posix` | `git-metadata-path.test.ts` 2 failed / 9 passed |
| Replace the end-anchored drvfs regex with an earlier `/[\r\n]/` guard plus `(\/[\s\S]*)?$` | `wsl-paths.test.ts` 4 failed / 33 passed |

The `null`-return mutation is the one that matters most: it is the "repo flips to not-a-repo" regression class, and it is caught.

**Not covered by any test:** the `repo-git-marker-scan.ts` -> `resolveGitMetadataPath` call site itself (see Costs), and every real-WSL behavior.

**Lint/format:** `npx oxfmt --write` then `npx oxlint` on all 5 touched files — both clean.
