### PR TITLE
fix(wsl): drop the linked-worktree Git route cache after worktree mutations

### DIFF
--- a/src/main/git/worktree-add.ts
+++ b/src/main/git/worktree-add.ts
@@ -6,6 +6,7 @@ import type {
 import { windowsLongPathGitArgs } from '../../shared/windows-long-path-git-args'
 import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
+import { invalidateWslLinkedWorktreeGitRouting } from './wsl-linked-worktree-git-routing'
 import {
   getLocalBaseRefUpdateSuggestionForWorktreeCreate,
   refreshLocalBaseRefForWorktreeCreate
@@ -200,11 +201,17 @@ async function performAddWorktree(
       args.push(effectiveBase)
     }
   }
-  await gitExecFileAsync(args, {
-    ...gitExecOptions(repoPath, options),
-    // Why: resolve per call — hoisting this to a module const would freeze the override at import.
-    timeout: resolveWorktreeAddTimeoutMs()
-  })
+  try {
+    await gitExecFileAsync(args, {
+      ...gitExecOptions(repoPath, options),
+      // Why: resolve per call — hoisting this to a module const would freeze the override at import.
+      timeout: resolveWorktreeAddTimeoutMs()
+    })
+  } finally {
+    // Git may have written the target's `.git` marker even when it reports a late
+    // failure, so drop any pre-create route before the follow-up commands route.
+    invalidateWslLinkedWorktreeGitRouting(worktreePath)
+  }
 
   if (options.checkoutExistingBranch) {
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}

--- a/src/main/git/worktree-create-preparation.ts
+++ b/src/main/git/worktree-create-preparation.ts
@@ -12,6 +12,7 @@ import {
 import { hasWorktreeBaseCommitRef } from './worktree-base-ref-probe'
 import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
+import { invalidateWslLinkedWorktreeGitRouting } from './wsl-linked-worktree-git-routing'
 
 function gitExecOptions(
   cwd: string,
@@ -50,10 +51,14 @@ async function performDiscardPreparedWorktree(
   } catch {
     // It may be unlocked already or only partially registered.
   }
-  await gitExecFileAsync(
-    [...windowsLongPathGitArgs(repoPath), 'worktree', 'remove', '--force', worktreePath],
-    cleanupGitOptions
-  )
+  try {
+    await gitExecFileAsync(
+      [...windowsLongPathGitArgs(repoPath), 'worktree', 'remove', '--force', worktreePath],
+      cleanupGitOptions
+    )
+  } finally {
+    invalidateWslLinkedWorktreeGitRouting(worktreePath)
+  }
 }
 
 export async function prepareWorktreeCreateCheckout(
@@ -81,6 +86,8 @@ export async function prepareWorktreeCreateCheckout(
           ],
           { ...gitExecOptions(repoPath, options), timeout: resolveWorktreeAddTimeoutMs() }
         )
+        // The add just wrote the marker; drop any pre-create route before the reset routes Git.
+        invalidateWslLinkedWorktreeGitRouting(worktreePath)
         // Why: reset materializes files without running user post-checkout hooks before submit.
         await gitExecFileAsync(
           [...windowsLongPathGitArgs(worktreePath), 'reset', '--hard', effectiveBase],
@@ -213,20 +220,26 @@ export async function finalizePreparedWorktree(
 
       let moved = false
       try {
-        await gitExecFileAsync(
-          [
-            ...windowsLongPathGitArgs(repoPath),
-            'worktree',
-            'move',
-            '-f',
-            '-f',
-            preparedPath,
-            worktreePath
-          ],
-          gitExecOptions(repoPath, finalizeGitOptions)
-        )
-        moved = true
-        // Why: `-f -f` moves the locked preparation while preserving its lock reason (Git >=2.25).
+        try {
+          // Why: `-f -f` moves the locked preparation while preserving its lock reason (Git >=2.25).
+          await gitExecFileAsync(
+            [
+              ...windowsLongPathGitArgs(repoPath),
+              'worktree',
+              'move',
+              '-f',
+              '-f',
+              preparedPath,
+              worktreePath
+            ],
+            gitExecOptions(repoPath, finalizeGitOptions)
+          )
+          moved = true
+        } finally {
+          // The move rewrites both `.git` markers, and a failure can have rewritten one.
+          invalidateWslLinkedWorktreeGitRouting(preparedPath)
+          invalidateWslLinkedWorktreeGitRouting(worktreePath)
+        }
         await gitExecFileAsync(
           [
             ...windowsLongPathGitArgs(worktreePath),

--- a/src/main/git/worktree-move.ts
+++ b/src/main/git/worktree-move.ts
@@ -1,5 +1,6 @@
 import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
+import { invalidateWslLinkedWorktreeGitRouting } from './wsl-linked-worktree-git-routing'
 import { bumpWorktreeScanGeneration } from './worktree-scan-cache'
 
 /**
@@ -18,6 +19,9 @@ export async function moveWorktree(
       gitExecFileAsync(['worktree', 'move', oldPath, newPath], { cwd: repoPath })
     )
   } finally {
+    // A failed move can still have rewritten one `.git` marker, so re-probe both paths.
+    invalidateWslLinkedWorktreeGitRouting(oldPath)
+    invalidateWslLinkedWorktreeGitRouting(newPath)
     bumpWorktreeScanGeneration(repoPath)
   }
 }

--- a/src/main/git/worktree-mutation-route-invalidation.test.ts
+++ b/src/main/git/worktree-mutation-route-invalidation.test.ts
@@ -1,0 +1,177 @@
+// Worktree add/move/remove/rollback rewrite the `.git` marker the WSL Git route was derived from.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as WorktreeModule from './worktree'
+
+const {
+  gitExecFileAsyncMock,
+  gitExecFileSyncMock,
+  translateWslOutputPathsMock,
+  listWorktreesMock
+} = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  gitExecFileSyncMock: vi.fn(),
+  translateWslOutputPathsMock: vi.fn((output: string) => output),
+  listWorktreesMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitExecFileSync: gitExecFileSyncMock,
+  translateWslOutputPaths: translateWslOutputPathsMock
+}))
+
+vi.mock('./status', () => ({
+  resolveGitDir: vi.fn(),
+  runWithGitReadCacheInvalidation: <T>(run: () => Promise<T>) => run()
+}))
+
+// Default: the checkout cannot be renamed aside, so removal deletes it in place.
+vi.mock('../worktree-trash', () => ({
+  moveWorktreeDirectoryToTrash: vi.fn().mockResolvedValue(undefined),
+  restoreWorktreeDirectoryFromTrash: vi.fn().mockResolvedValue(true),
+  scheduleWorktreeTrashDeletion: vi.fn()
+}))
+
+vi.mock('./worktree', async (importOriginal) => ({
+  ...(await importOriginal<typeof WorktreeModule>()),
+  resolveWorktreeAddBaseContext: vi.fn(async () => ({ effectiveBase: 'origin/main' })),
+  persistWorktreeCreationBase: vi.fn(),
+  configurePushAutoSetupRemote: vi.fn(),
+  notifyPreparedWorktreeMutation: vi.fn()
+}))
+
+vi.mock('./worktree-scan-cache', () => ({
+  bumpWorktreeScanGeneration: vi.fn(),
+  listWorktrees: listWorktreesMock
+}))
+
+import { addWorktree } from './worktree-add'
+import {
+  discardPreparedWorktree,
+  finalizePreparedWorktree,
+  prepareWorktreeCreateCheckout
+} from './worktree-create-preparation'
+import { moveWorktree } from './worktree-move'
+import { removeWorktree } from './worktree-removal'
+import {
+  resetWslLinkedWorktreeGitRoutingForTests,
+  seedWslLinkedWorktreeGitRoutingForTests,
+  usesHostGitForWslLinkedWorktree
+} from './wsl-linked-worktree-git-routing'
+
+const REPO = String.raw`C:\repo`
+const LINKED = String.raw`C:\ws\linked`
+const MOVED = String.raw`C:\ws\moved`
+const PREPARED = String.raw`C:\ws\.orca-preparing\wt`
+
+function hasCachedHostRoute(path: string): boolean {
+  return usesHostGitForWslLinkedWorktree(path, 'Ubuntu', 'win32')
+}
+
+beforeEach(() => {
+  gitExecFileAsyncMock.mockReset()
+  gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+  listWorktreesMock.mockReset()
+  listWorktreesMock.mockResolvedValue([])
+})
+
+afterEach(() => resetWslLinkedWorktreeGitRoutingForTests())
+
+describe('worktree mutations invalidate the WSL linked-worktree Git route', () => {
+  it('drops the target route after `git worktree add`', async () => {
+    seedWslLinkedWorktreeGitRoutingForTests(LINKED)
+
+    await addWorktree(REPO, LINKED, 'feature')
+
+    expect(hasCachedHostRoute(LINKED)).toBe(false)
+  })
+
+  it('drops the target route even when `git worktree add` fails late', async () => {
+    seedWslLinkedWorktreeGitRoutingForTests(LINKED)
+    gitExecFileAsyncMock.mockRejectedValueOnce(new Error('fatal: could not create leading dirs'))
+
+    await expect(addWorktree(REPO, LINKED, 'feature')).rejects.toThrow('leading dirs')
+
+    expect(hasCachedHostRoute(LINKED)).toBe(false)
+  })
+
+  it('drops both routes after `git worktree move`', async () => {
+    seedWslLinkedWorktreeGitRoutingForTests(LINKED)
+    seedWslLinkedWorktreeGitRoutingForTests(MOVED)
+
+    await moveWorktree(REPO, LINKED, MOVED)
+
+    expect(hasCachedHostRoute(LINKED)).toBe(false)
+    expect(hasCachedHostRoute(MOVED)).toBe(false)
+  })
+
+  it('drops both routes when `git worktree move` fails', async () => {
+    seedWslLinkedWorktreeGitRoutingForTests(LINKED)
+    seedWslLinkedWorktreeGitRoutingForTests(MOVED)
+    gitExecFileAsyncMock.mockRejectedValueOnce(new Error('fatal: destination exists'))
+
+    await expect(moveWorktree(REPO, LINKED, MOVED)).rejects.toThrow('destination exists')
+
+    expect(hasCachedHostRoute(LINKED)).toBe(false)
+    expect(hasCachedHostRoute(MOVED)).toBe(false)
+  })
+
+  it('drops the route after `git worktree remove`', async () => {
+    seedWslLinkedWorktreeGitRoutingForTests(LINKED)
+
+    await removeWorktree(REPO, LINKED, true)
+
+    expect(hasCachedHostRoute(LINKED)).toBe(false)
+  })
+
+  it('drops the route after a prepared worktree is discarded', async () => {
+    seedWslLinkedWorktreeGitRoutingForTests(LINKED)
+
+    await discardPreparedWorktree(REPO, LINKED)
+
+    expect(hasCachedHostRoute(LINKED)).toBe(false)
+  })
+
+  it('drops the target route after the prepared checkout is added', async () => {
+    seedWslLinkedWorktreeGitRoutingForTests(PREPARED)
+
+    await prepareWorktreeCreateCheckout(REPO, PREPARED, 'origin/main', 'orca preparation')
+
+    expect(hasCachedHostRoute(PREPARED)).toBe(false)
+  })
+
+  it('drops both routes after the prepared checkout is moved into place', async () => {
+    seedWslLinkedWorktreeGitRoutingForTests(PREPARED)
+    seedWslLinkedWorktreeGitRoutingForTests(LINKED)
+
+    await finalizePreparedWorktree(REPO, PREPARED, LINKED, 'feature', 'origin/main')
+
+    expect(hasCachedHostRoute(PREPARED)).toBe(false)
+    expect(hasCachedHostRoute(LINKED)).toBe(false)
+  })
+
+  it('drops both routes when the finalize move fails', async () => {
+    seedWslLinkedWorktreeGitRoutingForTests(PREPARED)
+    seedWslLinkedWorktreeGitRoutingForTests(LINKED)
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) =>
+      args.includes('move')
+        ? Promise.reject(new Error('fatal: destination exists'))
+        : { stdout: '', stderr: '' }
+    )
+
+    await expect(
+      finalizePreparedWorktree(REPO, PREPARED, LINKED, 'feature', 'origin/main')
+    ).rejects.toThrow('destination exists')
+
+    expect(hasCachedHostRoute(PREPARED)).toBe(false)
+    expect(hasCachedHostRoute(LINKED)).toBe(false)
+  })
+
+  it('leaves an unrelated worktree route cached', async () => {
+    seedWslLinkedWorktreeGitRoutingForTests(MOVED)
+
+    await removeWorktree(REPO, LINKED, true)
+
+    expect(hasCachedHostRoute(MOVED)).toBe(true)
+  })
+})

--- a/src/main/git/worktree-removal.ts
+++ b/src/main/git/worktree-removal.ts
@@ -13,6 +13,7 @@ import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
 import { deleteBranchAfterWorktreeRemoval } from './worktree-branch-removal'
 import { listWorktreesStrict } from './worktree-listing'
+import { invalidateWslLinkedWorktreeGitRouting } from './wsl-linked-worktree-git-routing'
 import type { RemoveWorktreeOptions } from './worktree-operation-options'
 import {
   WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS,
@@ -38,6 +39,7 @@ export async function removeWorktree(
       performRemoveWorktree(repoPath, worktreePath, force, options)
     )
   } finally {
+    invalidateWslLinkedWorktreeGitRouting(worktreePath)
     bumpWorktreeScanGeneration(repoPath)
   }
 }

--- a/src/main/git/wsl-linked-worktree-git-route-invalidation.test.ts
+++ b/src/main/git/wsl-linked-worktree-git-route-invalidation.test.ts
@@ -1,0 +1,111 @@
+// Route state dropped when a worktree mutation rewrites the `.git` marker it was derived from.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  invalidateWslLinkedWorktreeGitRouting,
+  prepareWslLinkedWorktreeGitRouting,
+  resetWslLinkedWorktreeGitRoutingForTests,
+  type WslLinkedWorktreeRoutingFileSystem
+} from './wsl-linked-worktree-git-routing'
+
+afterEach(() => resetWslLinkedWorktreeGitRoutingForTests())
+
+const CWD = String.raw`C:\repo`
+const fileMarker = { isDirectory: () => false, isFile: () => true }
+const directoryMarker = { isDirectory: () => true, isFile: () => false }
+const hostGitdir = 'gitdir: C:/main/.git/worktrees/linked\n'
+
+function prepare(fileSystem: WslLinkedWorktreeRoutingFileSystem): Promise<boolean> {
+  return prepareWslLinkedWorktreeGitRouting(CWD, 'Ubuntu', { platform: 'win32', fileSystem })
+}
+
+describe('invalidateWslLinkedWorktreeGitRouting', () => {
+  it('re-probes a settled route after the worktree marker is rewritten', async () => {
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi
+        .fn<WslLinkedWorktreeRoutingFileSystem['stat']>()
+        .mockResolvedValueOnce(directoryMarker)
+        .mockResolvedValueOnce(fileMarker),
+      readFile: vi.fn(async () => hostGitdir)
+    }
+
+    await expect(prepare(fileSystem)).resolves.toBe(false)
+    invalidateWslLinkedWorktreeGitRouting(CWD)
+
+    await expect(prepare(fileSystem)).resolves.toBe(true)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the retry backoff so a marker that just appeared is probed immediately', async () => {
+    const currentTime = 1_000
+    let markerExists = false
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async () => {
+        if (!markerExists) {
+          throw Object.assign(new Error('device unavailable'), { code: 'EIO' })
+        }
+        return fileMarker
+      }),
+      readFile: vi.fn(async () => hostGitdir)
+    }
+    const probe = (): Promise<boolean> =>
+      prepareWslLinkedWorktreeGitRouting(CWD, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem,
+        now: () => currentTime
+      })
+
+    // The second miss enters the exponential retry window, so the third never probes.
+    await expect(probe()).resolves.toBe(false)
+    await expect(probe()).resolves.toBe(false)
+    await expect(probe()).resolves.toBe(false)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(2)
+
+    markerExists = true
+    invalidateWslLinkedWorktreeGitRouting(CWD)
+    await expect(probe()).resolves.toBe(true)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(3)
+  })
+
+  it('drops routes cached for paths inside the mutated worktree', async () => {
+    const submodule = String.raw`C:\repo\sub`
+    const sibling = String.raw`C:\repo-other`
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async () => fileMarker),
+      readFile: vi.fn(async () => hostGitdir)
+    }
+    const probe = (cwd: string): Promise<boolean> =>
+      prepareWslLinkedWorktreeGitRouting(cwd, 'Ubuntu', { platform: 'win32', fileSystem })
+
+    await expect(probe(submodule)).resolves.toBe(true)
+    await expect(probe(sibling)).resolves.toBe(true)
+    invalidateWslLinkedWorktreeGitRouting(CWD)
+
+    // Prefix match must not reach `C:\repo-other`, which shares the string prefix.
+    await expect(probe(submodule)).resolves.toBe(true)
+    await expect(probe(sibling)).resolves.toBe(true)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(3)
+  })
+
+  it('leaves a probe that is already in flight alone', async () => {
+    // Scope control: invalidation must not retire in-flight probes. Doing so leaves
+    // callers waiting on them with no cached route, which `resolveGitCommand` reads
+    // as "route through wsl.exe git" — the misroute this module exists to prevent.
+    let releaseMarker: ((marker: typeof fileMarker) => void) | undefined
+    const inFlight = new Promise<typeof fileMarker>((resolve) => {
+      releaseMarker = resolve
+    })
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn<WslLinkedWorktreeRoutingFileSystem['stat']>().mockReturnValueOnce(inFlight),
+      readFile: vi.fn(async () => hostGitdir)
+    }
+
+    const first = prepare(fileSystem)
+    invalidateWslLinkedWorktreeGitRouting(CWD)
+    const joined = prepare(fileSystem)
+    releaseMarker?.(fileMarker)
+
+    await expect(first).resolves.toBe(true)
+    await expect(joined).resolves.toBe(true)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/git/wsl-linked-worktree-git-route-probe.ts
+++ b/src/main/git/wsl-linked-worktree-git-route-probe.ts
@@ -1,0 +1,65 @@
+import * as fsPromises from 'node:fs/promises'
+import { win32 } from 'node:path'
+import type { Stats } from 'node:fs'
+
+export type WslLinkedWorktreeRoutingFileSystem = {
+  stat(path: string): Promise<Pick<Stats, 'isDirectory' | 'isFile'>>
+  readFile(path: string): Promise<string>
+}
+
+/** `known: false` means the marker exists but cannot be classified — what a half-written `.git` file looks like mid `worktree add`. */
+export type WslLinkedWorktreeGitRouteProbeResult = {
+  usesHostGit: boolean
+  known: boolean
+}
+
+const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[/\\]/
+
+function parseLinkedGitdir(content: string): string | null {
+  const firstLine = content.split(/\r?\n/, 1)[0] ?? ''
+  return firstLine.match(/^gitdir:\s*(\S.*?)\s*$/i)?.[1] ?? null
+}
+
+export function parseWindowsLinkedGitdir(content: string): string | null {
+  const gitdir = parseLinkedGitdir(content)
+  return gitdir !== null && WINDOWS_DRIVE_PATH.test(gitdir) ? gitdir : null
+}
+
+export const defaultWslLinkedWorktreeRoutingFileSystem: WslLinkedWorktreeRoutingFileSystem = {
+  stat: (path) => fsPromises.stat(path),
+  readFile: (path) => fsPromises.readFile(path, 'utf8')
+}
+
+/** Walk parent directories until Git's worktree marker identifies which Git owns this checkout. */
+export async function probeWslLinkedWorktreeGitRoute(
+  cwd: string,
+  fileSystem: WslLinkedWorktreeRoutingFileSystem
+): Promise<WslLinkedWorktreeGitRouteProbeResult> {
+  let candidate = cwd
+  const driveRoot = win32.parse(candidate).root
+  while (true) {
+    const markerPath = win32.join(candidate, '.git')
+    try {
+      const marker = await fileSystem.stat(markerPath)
+      if (!marker.isFile()) {
+        // A `.git` directory (or anything that is not a file) is a normal main checkout.
+        return { usesHostGit: false, known: true }
+      }
+      const gitdir = parseLinkedGitdir(await fileSystem.readFile(markerPath))
+      // A POSIX gitdir is a settled answer too: the distro owns this checkout.
+      return gitdir === null
+        ? { usesHostGit: false, known: false }
+        : { usesHostGit: WINDOWS_DRIVE_PATH.test(gitdir), known: true }
+    } catch (error) {
+      const code = error && typeof error === 'object' ? (error as NodeJS.ErrnoException).code : null
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        throw error
+      }
+    }
+    if (candidate === driveRoot) {
+      // No marker up to the drive root: not a worktree at all, and stable enough to cache.
+      return { usesHostGit: false, known: true }
+    }
+    candidate = win32.dirname(candidate)
+  }
+}

--- a/src/main/git/wsl-linked-worktree-git-routing.test.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.test.ts
@@ -123,6 +123,25 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
     expect(fileSystem.readFile).not.toHaveBeenCalled()
   })
 
+  it('re-probes a half-written marker rather than caching it as distro-owned', async () => {
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async () => fileMarker),
+      readFile: vi
+        .fn<WslLinkedWorktreeRoutingFileSystem['readFile']>()
+        .mockResolvedValueOnce('')
+        .mockResolvedValueOnce('gitdir: C:/main/.git/worktrees/linked\n')
+    }
+    const prepare = (): Promise<boolean> =>
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+
+    await expect(prepare()).resolves.toBe(false)
+    await expect(prepare()).resolves.toBe(true)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(2)
+  })
+
   it('fails closed without caching a marker read error', async () => {
     const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
       stat: vi.fn(async () => fileMarker),

--- a/src/main/git/wsl-linked-worktree-git-routing.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.ts
@@ -1,6 +1,14 @@
-import * as fsPromises from 'node:fs/promises'
 import { win32 } from 'node:path'
-import type { Stats } from 'node:fs'
+import {
+  defaultWslLinkedWorktreeRoutingFileSystem,
+  probeWslLinkedWorktreeGitRoute,
+  type WslLinkedWorktreeRoutingFileSystem
+} from './wsl-linked-worktree-git-route-probe'
+
+export {
+  parseWindowsLinkedGitdir,
+  type WslLinkedWorktreeRoutingFileSystem
+} from './wsl-linked-worktree-git-route-probe'
 
 type CachedRoute = { usesHostGit: boolean; expiresAt: number }
 type TransientRouteFailure = { count: number; retryAfter: number }
@@ -46,56 +54,11 @@ function cachedRoute(cwd: string, now: number): boolean | undefined {
   return exact.usesHostGit
 }
 
-export function parseWindowsLinkedGitdir(content: string): string | null {
-  const firstLine = content.split(/\r?\n/, 1)[0] ?? ''
-  return firstLine.match(/^gitdir:\s*([A-Za-z]:[/\\].*?)\s*$/i)?.[1] ?? null
-}
-
-export type WslLinkedWorktreeRoutingFileSystem = {
-  stat(path: string): Promise<Pick<Stats, 'isDirectory' | 'isFile'>>
-  readFile(path: string): Promise<string>
-}
-
 export type WslLinkedWorktreeRoutingOptions = {
   platform?: NodeJS.Platform
   fileSystem?: WslLinkedWorktreeRoutingFileSystem
   now?: () => number
   signal?: AbortSignal
-}
-
-const defaultFileSystem: WslLinkedWorktreeRoutingFileSystem = {
-  stat: (path) => fsPromises.stat(path),
-  readFile: (path) => fsPromises.readFile(path, 'utf8')
-}
-
-async function shouldUseHostGit(
-  cwd: string,
-  fileSystem: WslLinkedWorktreeRoutingFileSystem
-): Promise<boolean> {
-  let candidate = cwd
-  const driveRoot = win32.parse(candidate).root
-  while (true) {
-    const markerPath = win32.join(candidate, '.git')
-    try {
-      const marker = await fileSystem.stat(markerPath)
-      if (marker.isDirectory()) {
-        return false
-      }
-      if (marker.isFile()) {
-        return parseWindowsLinkedGitdir(await fileSystem.readFile(markerPath)) !== null
-      }
-      return false
-    } catch (error) {
-      const code = error && typeof error === 'object' ? (error as NodeJS.ErrnoException).code : null
-      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
-        throw error
-      }
-    }
-    if (candidate === driveRoot) {
-      return false
-    }
-    candidate = win32.dirname(candidate)
-  }
 }
 
 function rememberRoute(cwd: string, usesHostGit: boolean, now: number): boolean {
@@ -117,6 +80,30 @@ function rememberRoute(cwd: string, usesHostGit: boolean, now: number): boolean 
 
 function routingAbortError(): Error {
   return Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' })
+}
+
+function forgetPathAndDescendants<T>(entries: Map<string, T>, root: string): void {
+  const prefix = root.endsWith(win32.sep) ? root : root + win32.sep
+  for (const path of entries.keys()) {
+    if (path === root || path.startsWith(prefix)) {
+      entries.delete(path)
+    }
+  }
+}
+
+/**
+ * Drop the cached route and retry backoff after Git adds, moves, or removes a
+ * worktree at `cwd`, so the next command re-reads the rewritten `.git` marker.
+ * Descendants go too: a submodule under the worktree resolved its route from the
+ * same marker walk.
+ *
+ * A probe already in flight is deliberately left alone: it still answers and still
+ * caches, so a mutation that lands mid-probe is no worse off than the 30s TTL.
+ */
+export function invalidateWslLinkedWorktreeGitRouting(cwd: string): void {
+  const normalizedCwd = normalize(cwd)
+  forgetPathAndDescendants(routeByCwd, normalizedCwd)
+  forgetPathAndDescendants(transientFailuresByCwd, normalizedCwd)
 }
 
 function rememberTransientFailure(cwd: string, now: number): void {
@@ -205,7 +192,7 @@ function discoverRoute(
   return new Promise((resolve) => {
     const generation = routeProbeGeneration
     let settled = false
-    const finish = (usesHostGit: boolean, cacheable: boolean): void => {
+    const finish = (usesHostGit: boolean, known: boolean): void => {
       if (settled) {
         return
       }
@@ -215,7 +202,7 @@ function discoverRoute(
         resolve(false)
         return
       }
-      if (cacheable) {
+      if (known) {
         transientFailuresByCwd.delete(cwd)
         resolve(rememberRoute(cwd, usesHostGit, now()))
       } else {
@@ -226,10 +213,10 @@ function discoverRoute(
     const timer = setTimeout(() => finish(false, false), WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS)
     timer.unref()
     const releaseProbe = trackRouteProbe(cwd)
-    void shouldUseHostGit(cwd, fileSystem).then(
-      (usesHostGit) => {
+    void probeWslLinkedWorktreeGitRoute(cwd, fileSystem).then(
+      ({ usesHostGit, known }) => {
         releaseProbe()
-        finish(usesHostGit, true)
+        finish(usesHostGit, known)
       },
       () => {
         releaseProbe()
@@ -245,7 +232,7 @@ export async function prepareWslLinkedWorktreeGitRouting(
   options: WslLinkedWorktreeRoutingOptions = {}
 ): Promise<boolean> {
   const platform = options.platform ?? process.platform
-  const fileSystem = options.fileSystem ?? defaultFileSystem
+  const fileSystem = options.fileSystem ?? defaultWslLinkedWorktreeRoutingFileSystem
   const now = options.now ?? Date.now
   if (!isWslLinkedWorktreeGitRoutingCandidate(cwd, wslDistro, platform)) {
     return false


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​307 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​307 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​154 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​76 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 |

<!-- /orca-pr-loc -->

## The problem

On Windows with a WSL distro configured for the project, Orca has to decide per Git command whether a `C:\...` checkout must run the **Windows** Git binary — it must, when its `.git` file says `gitdir: C:\...`, because `wsl.exe git` cannot follow a Windows-absolute gitdir pointer. `prepareWslLinkedWorktreeGitRouting` answers that by walking parent directories for the `.git` marker and caching the answer for 30 seconds. `git worktree add`, `move`, and `remove` rewrite exactly that marker, and nothing dropped the cache — so for up to 30 seconds after Orca created, moved, or removed a worktree, Git commands in it could be routed by a verdict that had stopped being true, and fail.

Second, smaller case on the same code path: mid `worktree add` the `.git` file exists but has not been written yet. Reading it produced no `gitdir:` line, and that non-answer was cached as a settled "distro owns this" for the full 30 seconds.

## What changes for users

| Platform | Change |
| --- | --- |
| macOS | No change. `isWslLinkedWorktreeGitRoutingCandidate` requires `process.platform === 'win32'`, so the cache is never written and the new calls scan two empty maps. |
| Linux | No change, same gate. |
| Native Windows (no WSL distro configured) | No change. The gate also requires a configured distro. |
| **WSL-on-Windows, drive-letter checkout** | **The only configuration with a behavior change.** After Orca adds/moves/removes a worktree, the next Git command in that path re-reads the `.git` marker instead of possibly using a verdict up to 30s old. A half-written marker is re-probed under the existing backoff instead of being cached for 30s. |
| WSL-on-Windows, `\\wsl.localhost\...` checkout | No change. The gate requires a drive-letter cwd (`/^[A-Za-z]:[/\\]/`), so UNC-path worktrees were never cached and are not now. |
| SSH remote | No change. This is an in-process map on the local machine, and it is win32-gated; the mutation itself runs on the remote host. A POSIX path passed to `win32.resolve` produces a key that misses both maps and cannot throw. |
| Relay | No change. `addWorktreeOp`/`removeWorktreeOp` in `src/relay/git-handler-worktree-ops.ts` build their own `worktree add`/`remove` argv and run them through the relay's own `GitExec`; `src/relay/` does not import `worktree-add.ts`, `worktree-move.ts`, `worktree-removal.ts`, `worktree-create-preparation.ts`, or the routing module, so the cache is never populated on a relay host. |
| Folder workspace | No change. "Walked to the drive root, found no marker" stays a settled answer and keeps its 30s cache, so a non-repo Windows folder workspace does not re-walk its parent chain. |

No RPC params, stream frames, or published content change — no wire-compatibility surface. No new Git argv, subcommand, or option: the Git 2.25 baseline is untouched and there is nothing to version-gate.

## What this does NOT do

This slice was cut down from a larger closed PR (#17647). Deliberately left behind:

- **No fencing of in-flight probes.** #17647 token-fenced `pendingRoutes` so a probe that started before a mutation could not write its verdict. Two variants of that were built and both removed: the first turned a failed mutation into an actual `wsl.exe git` misroute and starved the per-cwd probe slots (`WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_PER_CWD = 2`), the second was inert because `resolveGitCommand` reads the cache, not the probe's return value. A probe already walking the chain when a mutation lands still finishes and still caches its possibly-pre-mutation verdict for 30s — same as today on `main`. The stale-route window is shortened in one direction, not closed. `wsl-linked-worktree-git-route-invalidation.test.ts > leaves a probe that is already in flight alone` pins that as intended scope, not an oversight.
- **No `known: usesHostGit` semantics from #17647.** That PR reported a POSIX `gitdir:` as "unknown", which fed a *successful* determination into the 1s→30s retry backoff instead of the route cache, and made a marker-less Windows folder re-walk its parent chain. `known` here means only "the walk reached a classifiable answer".
- **No coverage for worktrees the user creates/moves/removes directly in a terminal.** Those still rely on the 30s TTL.
- **No changes to the cache's parameters or shape:** TTL (30s), probe timeout (5s), per-cwd/global probe caps (2/32), prune threshold (512), retry backoff curve, and abort semantics are all untouched. No change to the returned route for any settled input.
- **No merge with `repo-git-marker-scan.ts`.** That is a synchronous marker-*validity* scanner answering a different question; it stays separate.

The `wsl-linked-worktree-git-route-probe.ts` split is mechanical: `wsl-linked-worktree-git-routing.ts` was at the 300-line `max-lines` ceiling. The extracted walk differs from `main` only by returning `{ usesHostGit, known }` and by testing "not a file" rather than "is a directory" for the marker stat (same set of outcomes; both non-file cases already returned `false`).

## Costs and residual risk

1. **A failed mutation drops a still-correct route, and that can misroute a command already in flight.** Five of the six call sites invalidate from a `finally`, because Git can rewrite the marker and *then* report a failure. When it fails without touching the marker, the cached-but-still-correct route is dropped anyway. That is not just an extra stat walk: `gitExecFileAsync` re-resolves after `await prepareWindowsHostGitEnvironment`, and `gitStreamStdout` resolves twice and then calls `gitSpawn`, which resolves a **third** time after `await acquireGitAdmission` — a queue that can be arbitrarily long. An invalidation landing in that window makes the already-prepared command take the empty-cache default and run a host-owned `gitdir: C:\...` worktree under `wsl.exe git`, which fails. It self-heals on the next command (which re-probes), and it is the same default `main` already takes at process start, at TTL expiry, and after a transient probe failure — but the window is new and wider. Concretely: a `removeWorktree` that fails on a dirty tree while a status poll for the same worktree is queued in Git admission.
2. **A persistently unclassifiable `.git` file now costs more filesystem walks.** `main` cached "no `gitdir:` line" as a settled `false` for 30s. It now enters the retry backoff (delays 0, 0, 1s, 2s, 4s, 8s, 16s, …), so a `.git` file that stays unparseable triggers up to 6 parent-chain walks in the first ~31 seconds instead of 1. The *route* it yields is `false` (distro) in both cases, so nothing is misrouted — this is a syscall cost only, bounded by the existing exponential backoff.
3. **Invalidation now scans instead of doing a keyed delete.** `forgetPathAndDescendants` iterates each map (bounded at 512 entries by the existing prune threshold) instead of `Map.delete`, twice per call, 8 calls per worktree mutation. Bounded and off any hot path, but it is strictly more work than before, and on non-win32 it is 8 scans of two empty maps per mutation rather than 16 hash misses.
4. **Descendant invalidation is broader than the marker that actually changed.** Invalidating `C:\ws\linked` also drops a cached route for an *independent* nested repo or submodule under it that the mutation did not touch, costing those one extra parent walk. It also clears their retry backoff, so a flapping network mount under a mutated worktree re-probes sooner than its backoff intended.
5. **Path matching is case-sensitive.** `win32.resolve` does not case-fold, so an entry cached as `C:\Repo\sub` is not dropped by an invalidation of `c:\repo`. That is the same fidelity as the existing exact-key `cachedRoute` lookup, so no regression, but the invalidation is not case-insensitive the way Windows paths are.
6. **`git worktree prune` inside the removal path is not accounted for.** `clearGitRegistrationForMissingWorktree` can prune admin entries for *other* worktrees whose directories vanished; their cached routes are not invalidated. Those directories no longer exist, so a command there fails regardless of route.
7. **The in-flight-probe window described under "What this does NOT do" is unfixed, not fixed.**

## Verification

Run from the slice worktree with `npx vitest run`:

| Suite | Result |
| --- | --- |
| `src/main/git` | 194 files, **2197 passed**, 5 skipped, 1 failed |
| `src/main/ipc/worktrees` + `src/relay/git-handler-worktree*` | 37 files, **353 passed** |
| `src/main/ipc/filesystem` + `src/main/runtime/orca-runtime` | 85 files, **2039 passed**, 3 skipped, 2 failed |

Both failures are pre-existing on `origin/main` and unrelated. I confirmed each by checking out the parent commit into a scratch worktree and running the file there:

- `src/main/git/command-runner/git-admission-storm-measurement.test.ts` — `ENOENT: scandir .../orca-git-storm-disabled-*/state`. Fails identically at `HEAD~1`.
- `src/main/runtime/orca-runtime-skill-recovery.test.ts` (2 tests) — `Error: AppEnvironment not initialized`. Fails identically at `HEAD~1`, and fails when run in isolation, so it is not test-order pollution from this change.

`npx oxfmt --write` then `npx oxlint` on all 9 touched files: clean, exit 0. `wsl-linked-worktree-git-routing.ts` is 293 raw lines against a 300 ceiling that skips blanks and comments.

**Mutation-verified this round** (each production edit applied, suite run, edit reverted):

| Mutation | Result |
| --- | --- |
| `forgetPathAndDescendants` → `main`'s exact `Map.delete` | fails `drops routes cached for paths inside the mutated worktree` |
| `path.startsWith(prefix)` → `path.startsWith(root)` (drop the separator guard) | fails the same test — its `C:\repo-other` sibling assertion |
| probe returns `known: true` for a marker with no `gitdir:` line | fails `re-probes a half-written marker rather than caching it as distro-owned` (1 of 26) |
| `invalidateWslLinkedWorktreeGitRouting` body → no-op | fails 12 of 14 across both invalidation suites |

The two tests that survive the no-op mutation are the labelled negative controls — `leaves an unrelated worktree route cached` and `leaves a probe that is already in flight alone` — which exist to pin scope, not coverage.

Diff: 6 production files (+154/−76, of which `wsl-linked-worktree-git-route-probe.ts` is 65 lines moved out of the routing module) and 3 test files.
