### PR TITLE
perf(worktree): resolve the WSL workspace root off the main thread when preparing

### DIFF
--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -99,10 +99,24 @@ export function computeWorktreePath(
   repoPath: string,
   settings: WorktreePathSettings
 ): string {
-  const workspaceRoot = computeWorkspaceRoot(repoPath, settings)
-  const pathOps = getRuntimePathOps(repoPath, workspaceRoot)
+  return computeWorktreePathFromWorkspaceRoot(
+    sanitizedName,
+    repoPath,
+    computeWorkspaceRoot(repoPath, settings),
+    settings.nestWorkspaces
+  )
+}
 
-  if (settings.nestWorkspaces) {
+/** Layout half shared by both computeWorktreePath variants, so the sync and async paths cannot
+ *  disagree on placement once the root is resolved. */
+function computeWorktreePathFromWorkspaceRoot(
+  sanitizedName: string,
+  repoPath: string,
+  workspaceRoot: string,
+  nestWorkspaces: boolean
+): string {
+  const pathOps = getRuntimePathOps(repoPath, workspaceRoot)
+  if (nestWorkspaces) {
     const repoName = pathOps.basename(repoPath).replace(/\.git$/, '')
     return pathOps.join(workspaceRoot, repoName, sanitizedName)
   }
@@ -116,46 +130,66 @@ export async function computeWorktreePathAsync(
   repoPath: string,
   settings: WorktreePathSettings
 ): Promise<string> {
-  const workspaceRoot = await computeWorkspaceRootAsync(repoPath, settings)
-  const pathOps = getRuntimePathOps(repoPath, workspaceRoot)
-
-  if (settings.nestWorkspaces) {
-    const repoName = pathOps.basename(repoPath).replace(/\.git$/, '')
-    return pathOps.join(workspaceRoot, repoName, sanitizedName)
-  }
-  return pathOps.join(workspaceRoot, sanitizedName)
+  return computeWorktreePathFromWorkspaceRoot(
+    sanitizedName,
+    repoPath,
+    await computeWorkspaceRootAsync(repoPath, settings),
+    settings.nestWorkspaces
+  )
 }
 
-async function computeWorkspaceRootAsync(
+/** Async twin of computeWorkspaceRoot. Same result; the WSL home probe spawns `wsl.exe`, so
+ *  background preparation uses this variant rather than blocking the Electron main thread for up
+ *  to the probe timeout. The sync twin below still serves callers that cannot await (allowed-roots
+ *  resolution, the create click, CLI create, watch targets, worktree trash). */
+export async function computeWorkspaceRootAsync(
   repoPath: string,
   settings: { workspaceDir: string; wslMirrorDistro?: string }
 ): Promise<string> {
-  const distro = resolveMirrorDistro(repoPath, settings)
-  if (distro && shouldMirrorWorkspaceDirInsideWsl(repoPath, settings.workspaceDir)) {
-    const wslHome = await getWslHomeAsync(distro)
-    if (wslHome) {
-      return win32.join(wslHome, 'orca', 'workspaces')
-    }
-  }
-  return resolveWorkspaceDirForRepo(repoPath, settings.workspaceDir)
+  const distro = mirrorDistroForWorkspaceRoot(repoPath, settings)
+  return workspaceRootForMirrorHome(
+    repoPath,
+    settings.workspaceDir,
+    distro ? await getWslHomeAsync(distro) : null
+  )
 }
 
 export function computeWorkspaceRoot(
   repoPath: string,
   settings: { workspaceDir: string; wslMirrorDistro?: string }
 ): string {
+  const distro = mirrorDistroForWorkspaceRoot(repoPath, settings)
+  return workspaceRootForMirrorHome(
+    repoPath,
+    settings.workspaceDir,
+    distro ? getWslHome(distro) : null
+  )
+}
+
+/** Distro to mirror the workspace root into, or undefined when the configured root is used as-is.
+ *  Shared by both resolvers so the sync and async paths can never disagree on placement. */
+function mirrorDistroForWorkspaceRoot(
+  repoPath: string,
+  settings: { workspaceDir: string; wslMirrorDistro?: string }
+): string | undefined {
   const distro = resolveMirrorDistro(repoPath, settings)
-  if (distro && shouldMirrorWorkspaceDirInsideWsl(repoPath, settings.workspaceDir)) {
-    const wslHome = getWslHome(distro)
-    if (wslHome) {
-      // Why: WSL UNC paths are still Windows paths from Node's perspective.
-      // Mirror absolute local desktop workspace roots inside the distro so
-      // terminals stay on the WSL filesystem; repo-relative roots can resolve
-      // directly against the WSL repo path.
-      return win32.join(wslHome, 'orca', 'workspaces')
-    }
-  }
-  return resolveWorkspaceDirForRepo(repoPath, settings.workspaceDir)
+  return distro && shouldMirrorWorkspaceDirInsideWsl(repoPath, settings.workspaceDir)
+    ? distro
+    : undefined
+}
+
+function workspaceRootForMirrorHome(
+  repoPath: string,
+  workspaceDir: string,
+  wslHome: string | null
+): string {
+  // Why: WSL UNC paths are still Windows paths from Node's perspective.
+  // Mirror absolute local desktop workspace roots inside the distro so
+  // terminals stay on the WSL filesystem; repo-relative roots can resolve
+  // directly against the WSL repo path.
+  return wslHome
+    ? win32.join(wslHome, 'orca', 'workspaces')
+    : resolveWorkspaceDirForRepo(repoPath, workspaceDir)
 }
 
 export function computeRemoteWorktreePath(

--- a/src/main/worktree-create-preparation-wsl-root.test.ts
+++ b/src/main/worktree-create-preparation-wsl-root.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as WslModule from './wsl'
+import type { Store } from './persistence'
+import type { Repo } from '../shared/repo-types'
+
+// Why this file exists separately from worktree-create-preparation.test.ts: that suite mocks
+// ./ipc/worktree-logic wholesale, so it can never catch the prepare (async resolver) / consume
+// (sync resolver) key disagreement that would silently discard every prepared checkout.
+const mocks = vi.hoisted(() => ({
+  mkdir: vi.fn(),
+  listWorktreeGraph: vi.fn(),
+  prepareCheckout: vi.fn(),
+  finalize: vi.fn(),
+  discard: vi.fn(),
+  unlock: vi.fn(),
+  getWorktreeOptions: vi.fn(),
+  getMirrorDistro: vi.fn(),
+  getWslHome: vi.fn(),
+  getWslHomeAsync: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({ mkdir: mocks.mkdir }))
+vi.mock('./git/worktree', () => ({ listWorktreeGraph: mocks.listWorktreeGraph }))
+vi.mock('./git/worktree-create-preparation', () => ({
+  prepareWorktreeCreateCheckout: mocks.prepareCheckout,
+  finalizePreparedWorktree: mocks.finalize,
+  discardPreparedWorktree: mocks.discard,
+  unlockPreparedWorktree: mocks.unlock
+}))
+vi.mock('./project-runtime-git-options', () => ({
+  getLocalProjectWorktreeGitOptions: mocks.getWorktreeOptions,
+  getWorktreeMirrorDistro: mocks.getMirrorDistro
+}))
+vi.mock('./wsl', async (importOriginal) => ({
+  ...(await importOriginal<typeof WslModule>()),
+  getWslHome: mocks.getWslHome,
+  getWslHomeAsync: mocks.getWslHomeAsync
+}))
+
+import {
+  computeWorkspaceRoot,
+  computeWorktreePath,
+  getWorktreePathSettings
+} from './ipc/worktree-logic'
+import { getWorktreeMirrorDistro } from './project-runtime-git-options'
+import {
+  _resetWorktreeCreatePreparationsForTests,
+  consumePreparedWorktreeCreate,
+  prepareWorktreeCreateForRepo
+} from './worktree-create-preparation'
+
+const WSL_HOME = '\\\\wsl.localhost\\Ubuntu\\home\\jin'
+const MIRRORED_ROOT = `${WSL_HOME}\\orca\\workspaces`
+const repo = { id: 'repo-1', path: `${WSL_HOME}\\src\\repo` } as Repo
+const windowsRepo = { id: 'repo-2', path: 'C:\\src\\repo' } as Repo
+const settings = { workspaceDir: 'C:\\workspaces', nestWorkspaces: false }
+const store = { getSettings: () => settings } as unknown as Store
+const originalPlatform = process.platform
+
+/** The consume side exactly as createLocalWorktree builds it (worktree-remote.ts). */
+function consumeSideRoots(target: Repo): { workspaceRoot: string; worktreePath: string } {
+  const pathSettings = getWorktreePathSettings(
+    target,
+    settings,
+    getWorktreeMirrorDistro(store as never, target)
+  )
+  return {
+    workspaceRoot: computeWorkspaceRoot(target.path, pathSettings),
+    worktreePath: computeWorktreePath('feature', target.path, pathSettings)
+  }
+}
+
+beforeEach(() => {
+  // parseWslPath only recognises UNC repo paths on win32, so pin the platform rather than
+  // skipping the case everywhere else.
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  mocks.mkdir.mockReset().mockResolvedValue(undefined)
+  mocks.listWorktreeGraph.mockReset().mockResolvedValue([])
+  mocks.prepareCheckout.mockReset().mockResolvedValue(undefined)
+  mocks.finalize.mockReset().mockResolvedValue({ path: 'created' })
+  mocks.discard.mockReset().mockResolvedValue(undefined)
+  mocks.unlock.mockReset().mockResolvedValue(undefined)
+  mocks.getWorktreeOptions.mockReset().mockReturnValue({})
+  mocks.getMirrorDistro.mockReset().mockReturnValue(undefined)
+  mocks.getWslHome.mockReset().mockImplementation(() => {
+    throw new Error('the blocking wsl.exe home probe must not run while preparing')
+  })
+  mocks.getWslHomeAsync.mockReset().mockResolvedValue(WSL_HOME)
+})
+
+afterEach(async () => {
+  Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+  await _resetWorktreeCreatePreparationsForTests()
+})
+
+describe('worktree create preparation with the real WSL workspace-root resolver', () => {
+  it('prepares under the async-resolved mirror root that the sync consume side reproduces', async () => {
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+
+    expect(mocks.getWslHome).not.toHaveBeenCalled()
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
+    expect(mocks.prepareCheckout.mock.calls[0]?.[1]).toContain(MIRRORED_ROOT)
+
+    // createLocalWorktree still resolves the root synchronously, off the cache the probe warmed.
+    mocks.getWslHome.mockReturnValue(WSL_HOME)
+    const result = await consumePreparedWorktreeCreate({
+      repoPath: repo.path,
+      ...consumeSideRoots(repo),
+      branch: 'feature',
+      baseBranch: 'origin/main'
+    })
+
+    expect(result).not.toBeNull()
+    expect(mocks.finalize).toHaveBeenCalledTimes(1)
+    expect(mocks.discard).not.toHaveBeenCalled()
+  })
+
+  it('mirrors a C: repo with a configured mirror distro on both sides', async () => {
+    mocks.getMirrorDistro.mockReturnValue('Ubuntu')
+
+    await prepareWorktreeCreateForRepo(store, windowsRepo, 'origin/main')
+
+    expect(mocks.prepareCheckout.mock.calls[0]?.[1]).toContain(MIRRORED_ROOT)
+
+    mocks.getWslHome.mockReturnValue(WSL_HOME)
+    const result = await consumePreparedWorktreeCreate({
+      repoPath: windowsRepo.path,
+      ...consumeSideRoots(windowsRepo),
+      branch: 'feature',
+      baseBranch: 'origin/main'
+    })
+
+    expect(result).not.toBeNull()
+    expect(mocks.discard).not.toHaveBeenCalled()
+  })
+
+  it('discards nothing and falls back when the probe fails during preparation', async () => {
+    mocks.getWslHomeAsync.mockResolvedValue(null)
+
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+
+    // No mirror home -> the configured desktop root, matching what the sync resolver returns
+    // for the same failed probe.
+    expect(mocks.prepareCheckout.mock.calls[0]?.[1]).toContain('C:\\workspaces')
+  })
+})

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
   finalize: vi.fn(),
   discard: vi.fn(),
   unlock: vi.fn(),
-  getWorktreeOptions: vi.fn()
+  getWorktreeOptions: vi.fn(),
+  computeWorkspaceRoot: vi.fn(),
+  computeWorkspaceRootAsync: vi.fn()
 }))
 
 vi.mock('node:fs/promises', () => ({ mkdir: mocks.mkdir }))
@@ -22,13 +24,12 @@ vi.mock('./git/worktree-create-preparation', () => ({
   unlockPreparedWorktree: mocks.unlock
 }))
 vi.mock('./project-runtime-git-options', () => ({
-  getLocalProjectWorktreeGitOptions: mocks.getWorktreeOptions
+  getLocalProjectWorktreeGitOptions: mocks.getWorktreeOptions,
+  getWorktreeMirrorDistro: () => undefined
 }))
 vi.mock('./ipc/worktree-logic', () => ({
-  computeWorkspaceRoot: (repoPath: string) =>
-    process.platform === 'win32' && /^[A-Za-z]:[\\/]/.test(repoPath)
-      ? 'C:\\workspace'
-      : '/workspace',
+  computeWorkspaceRoot: mocks.computeWorkspaceRoot,
+  computeWorkspaceRootAsync: mocks.computeWorkspaceRootAsync,
   getWorktreePathSettings: () => ({
     workspaceDir: process.platform === 'win32' ? 'C:\\workspace' : '/workspace',
     nestWorkspaces: false
@@ -52,6 +53,16 @@ beforeEach(() => {
   mocks.discard.mockReset().mockResolvedValue(undefined)
   mocks.unlock.mockReset().mockResolvedValue(undefined)
   mocks.getWorktreeOptions.mockReset().mockReturnValue({})
+  mocks.computeWorkspaceRoot.mockReset().mockImplementation(() => {
+    throw new Error('synchronous workspace-root lookup must not run on the main thread')
+  })
+  mocks.computeWorkspaceRootAsync
+    .mockReset()
+    .mockImplementation(async (repoPath: string) =>
+      process.platform === 'win32' && /^[A-Za-z]:[\\/]/.test(repoPath)
+        ? 'C:\\workspace'
+        : '/workspace'
+    )
 })
 
 afterEach(async () => {
@@ -59,6 +70,41 @@ afterEach(async () => {
 })
 
 describe('worktree create preparation registry', () => {
+  it('starts the checkout only once the async workspace root resolves', async () => {
+    let resolveRoot!: (root: string) => void
+    mocks.computeWorkspaceRootAsync.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveRoot = resolve
+      })
+    )
+
+    const preparation = prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    await Promise.resolve()
+    expect(mocks.prepareCheckout).not.toHaveBeenCalled()
+
+    resolveRoot('/workspace')
+    await preparation
+
+    expect(mocks.computeWorkspaceRoot).not.toHaveBeenCalled()
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
+  })
+
+  it('still deduplicates when both callers await the same pending root lookup', async () => {
+    let resolveRoot!: (root: string) => void
+    mocks.computeWorkspaceRootAsync.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveRoot = resolve
+      })
+    )
+
+    const first = prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    const second = prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    resolveRoot('/workspace')
+    await Promise.all([first, second])
+
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
+  })
+
   it('namespaces native Windows preparation directories for long paths', async () => {
     const originalPlatform = process.platform
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -20,8 +20,11 @@ import {
   unlockPreparedWorktree,
   prepareWorktreeCreateCheckout
 } from './git/worktree-create-preparation'
-import { getLocalProjectWorktreeGitOptions } from './project-runtime-git-options'
-import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
+import {
+  getLocalProjectWorktreeGitOptions,
+  getWorktreeMirrorDistro
+} from './project-runtime-git-options'
+import { computeWorkspaceRootAsync, getWorktreePathSettings } from './ipc/worktree-logic'
 import { toHostFilesystemPath } from './host-tree-removal'
 
 export const WORKTREE_CREATE_PREPARATION_TTL_MS = 5 * 60_000
@@ -154,18 +157,22 @@ async function cleanupStalePreparations(
   }
 }
 
-export function prepareWorktreeCreateForRepo(
+export async function prepareWorktreeCreateForRepo(
   store: Store,
   repo: Repo,
   baseBranch: string
 ): Promise<void> {
   if (repo.connectionId || isFolderRepo(repo)) {
-    return Promise.resolve()
+    return
   }
   const options = getLocalProjectWorktreeGitOptions(store, repo)
-  const workspaceRoot = computeWorkspaceRoot(
+  // Resolving a WSL repo's root spawns `wsl.exe`, and this runs while the create composer is open,
+  // so it must not block the main thread. Key lookup and insert stay in one sync run after the await.
+  // The mirror distro must be threaded exactly as createLocalWorktree threads it, or the two sides
+  // key on different roots and every prepared checkout is discarded.
+  const workspaceRoot = await computeWorkspaceRootAsync(
     repo.path,
-    getWorktreePathSettings(repo, store.getSettings())
+    getWorktreePathSettings(repo, store.getSettings(), getWorktreeMirrorDistro(store, repo))
   )
   const key = preparationKey(repo.path, workspaceRoot, baseBranch, options)
   const existing = preparations.get(key)

--- a/src/main/worktree-root-preparation.test.ts
+++ b/src/main/worktree-root-preparation.test.ts
@@ -1,10 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as WslModule from './wsl'
 import type { Repo } from '../shared/repo-types'
 
-const { mkdirMock, authorizeExternalPathMock } = vi.hoisted(() => ({
-  mkdirMock: vi.fn(),
-  authorizeExternalPathMock: vi.fn()
-}))
+const { mkdirMock, authorizeExternalPathMock, getWslHomeMock, getWslHomeAsyncMock } = vi.hoisted(
+  () => ({
+    mkdirMock: vi.fn(),
+    authorizeExternalPathMock: vi.fn(),
+    getWslHomeMock: vi.fn(),
+    getWslHomeAsyncMock: vi.fn()
+  })
+)
 
 vi.mock('fs/promises', () => ({
   mkdir: mkdirMock
@@ -12,6 +17,12 @@ vi.mock('fs/promises', () => ({
 
 vi.mock('./ipc/filesystem-auth', () => ({
   authorizeExternalPath: authorizeExternalPathMock
+}))
+
+vi.mock('./wsl', async (importOriginal) => ({
+  ...(await importOriginal<typeof WslModule>()),
+  getWslHome: getWslHomeMock,
+  getWslHomeAsync: getWslHomeAsyncMock
 }))
 
 import { prepareLocalWorktreeRootForRepo } from './worktree-root-preparation'
@@ -33,6 +44,10 @@ describe('prepareLocalWorktreeRootForRepo', () => {
   beforeEach(() => {
     mkdirMock.mockReset().mockResolvedValue(undefined)
     authorizeExternalPathMock.mockReset()
+    getWslHomeMock.mockReset().mockImplementation(() => {
+      throw new Error('synchronous wsl.exe home probe must not run on the main thread')
+    })
+    getWslHomeAsyncMock.mockReset().mockResolvedValue(null)
     store.getSettings.mockReset().mockReturnValue({
       workspaceDir: '/Users/alice/orca/workspaces',
       nestWorkspaces: false
@@ -43,6 +58,38 @@ describe('prepareLocalWorktreeRootForRepo', () => {
     await prepareLocalWorktreeRootForRepo(store as never, repo)
 
     expect(mkdirMock).toHaveBeenCalledWith('/Users/alice/orca/workspaces', { recursive: true })
+  })
+
+  it('resolves a WSL repo root through the async probe instead of blocking on wsl.exe', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    let resolveHome!: (home: string) => void
+    getWslHomeAsyncMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveHome = resolve
+      })
+    )
+    store.getSettings.mockReturnValue({ workspaceDir: 'C:\\workspaces', nestWorkspaces: false })
+
+    try {
+      const preparation = prepareLocalWorktreeRootForRepo(store as never, {
+        ...repo,
+        path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo'
+      })
+      await Promise.resolve()
+      expect(mkdirMock).not.toHaveBeenCalled()
+
+      resolveHome('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+      await preparation
+
+      expect(getWslHomeMock).not.toHaveBeenCalled()
+      expect(mkdirMock).toHaveBeenCalledWith(
+        '\\\\wsl.localhost\\Ubuntu\\home\\jin\\orca\\workspaces',
+        { recursive: true }
+      )
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
   })
 
   it('uses repo-specific worktree base paths', async () => {

--- a/src/main/worktree-root-preparation.ts
+++ b/src/main/worktree-root-preparation.ts
@@ -3,7 +3,7 @@ import type { GlobalSettings } from '../shared/global-settings-types'
 import type { Repo } from '../shared/repo-types'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
 import { isFolderRepo } from '../shared/repo-kind'
-import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
+import { computeWorkspaceRootAsync, getWorktreePathSettings } from './ipc/worktree-logic'
 import { getWorktreeMirrorDistro } from './project-runtime-git-options'
 import type { ProjectRuntimeResolutionStore } from './local-project-runtime-resolution'
 
@@ -27,7 +27,7 @@ export async function prepareLocalWorktreeRootForRepo(
   }
 
   try {
-    const root = computeWorkspaceRoot(
+    const root = await computeWorkspaceRootAsync(
       repo.path,
       getWorktreePathSettings(repo, store.getSettings(), getWorktreeMirrorDistro(store, repo))
     )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​249 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​239 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |

<!-- /orca-pr-loc -->

## Problem

On Windows with a WSL repo, registering a repo, finishing a clone, upgrading a folder to a git repo, saving settings, or just opening the worktree create composer could freeze every Orca window for up to 5 seconds. All of those paths resolve the repo's mirror workspace root through `computeWorkspaceRoot` → `getWslHome`, which is a synchronous `execFileSync('wsl.exe', ['-d', distro, '--exec', 'bash', '-c', 'echo $HOME'], { timeout: 5000 })` (`src/main/wsl.ts:279`). On a stopped or cold distro that call blocks the Electron main thread for the full timeout.

Being fire-and-forget did not help. `prepareLocalWorktreeRootForRepo` has 16 direct production call sites; only 3 are `void`-ed (`runtime/orca-runtime.ts:23369`, `ipc/repos/repo-update-handler.ts:210`, `ipc/repos/project-host-setup-handlers.ts:111`). The other 13 are `await`ed inside IPC handlers, and a synchronous probe blocks the main thread either way.

## Changes

1. `prepareLocalWorktreeRootForRepo` (`src/main/worktree-root-preparation.ts`) and `prepareWorktreeCreateForRepo` (`src/main/worktree-create-preparation.ts`) now call the already-existing `computeWorkspaceRootAsync` instead of `computeWorkspaceRoot`. `computeWorkspaceRootAsync` was module-private; it is now exported.
2. The sync and async resolvers in `src/main/ipc/worktree-logic.ts` had duplicated mirror-distro and root-layout logic. Extracted into two shared private helpers (`mirrorDistroForWorkspaceRoot`, `workspaceRootForMirrorHome`) plus `computeWorktreePathFromWorkspaceRoot`, so the two paths cannot drift. No behavior change; resolved paths are identical.
3. Bug fix on the same line: `createLocalWorktree` builds its path settings with `getWorktreePathSettings(repo, settings, getWorktreeMirrorDistro(store, repo))` (`src/main/ipc/worktree-remote.ts:2013`) and `prepareWorktreeCreateForRepo` omitted the third argument. For a `C:\` repo belonging to a project with a resolved WSL runtime, prepare keyed on `C:\workspaces` while the create click keyed on `\\wsl.localhost\<distro>\home\<user>\orca\workspaces`. The keys never matched, so **every** prepared checkout for that configuration was discarded — after paying for a full `git worktree` checkout that then sat on disk until the 5-minute TTL. This is pre-existing on `main` (the speculative-prefetch feature simply never worked for that config); it is included here because it is the same line, the same resolver, and the new test cannot claim prepare/consume agreement without it.

## What changes for users

| Platform | Change |
| --- | --- |
| macOS | No change. `resolveMirrorDistro` returns `undefined` for non-Windows repo paths, so no `wsl.exe` was ever spawned here. Root resolution now completes one microtask later; resolved paths and created directories are byte-identical. |
| Linux | No change, same reason as macOS. |
| Native Windows (no WSL project runtime, no `\\wsl.localhost` repo path) | No change. `resolveMirrorDistro` returns `settings.wslMirrorDistro`, which is `undefined` without a WSL runtime, so no probe runs. One extra microtask hop only. |
| WSL-on-Windows | The fixed case. Repo registration, clone completion, repo update, project host setup, folder→git upgrade, settings save, and speculative create preparation no longer block the main thread on the `wsl.exe` home probe. Additionally, speculative create prefetch now actually works for `C:\` repos on a WSL project runtime instead of being discarded 100% of the time. |
| SSH remote | No change. `prepareLocalWorktreeRootForRepo` returns early when `getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID`, and `prepareWorktreeCreateForRepo` returns early on `repo.connectionId`. Both early returns are before the new `await`. |
| Relay | No change. No RPC param, stream frame, opcode, or published host content is touched. |
| Folder workspace | No change. Both prepare functions return early on `isFolderRepo(repo)`, before the new `await`. |

No git command, git binary version dependency, wire format, or provider-specific (GitHub/GitLab) code is touched.

## Scope of the win, precisely

On a **reachable** distro `getWslHome` caches on success (`wslHomeCache.set`), so before this change the first repo paid one blocking probe and every subsequent repo was a cache hit. The change makes that one probe non-blocking; it does **not** remove N probes.

Failed probes are never cached (the `catch` in `getWslHome` returns `null` without writing the cache). So on a **stopped** distro, `prepareLocalWorktreeRootsForRepos` genuinely did pay N sequential 5s blocking probes, and now shares one in-flight async probe per distro via `getWslHomeAsync`'s `wslHomeProbeCache`.

## What this does NOT do

- **Does not convert the five remaining synchronous `computeWorkspaceRoot` callers**: allowed-roots resolution (`ipc/filesystem-allowed-roots.ts:102`, reached from every renderer filesystem IPC), the create click itself (`ipc/worktree-remote.ts:2162`), CLI create (`runtime/orca-runtime.ts:27350`), watch targets (`ipc/worktree-base-directory-watch-targets.ts:124`), and worktree trash (`worktree-trash.ts:167`). Those are sync APIs with sync callers; converting them is a separate, larger change.
- **Does not let a sync caller join an in-flight async probe.** `getWslHome` reads only `wslHomeCache`, never `wslHomeProbeCache`, and a sync function cannot await a pending promise. Returning the un-mirrored fallback instead would place worktrees in the wrong root, so it is not an option.
- **Does not change the 5s probe timeout, cache failed probes, or pre-warm the probe at startup.**
- **Does not touch** `computeRemoteWorktreePath`, allowed-roots memoization, or `listRunningWslHomeDirsAsync`.
- **Does not change any resolved path or created directory on any platform**, with the single exception of the `C:\`-repo-on-WSL-runtime prepare root described above, which now matches where the real worktree is created.

## Costs and residual risk

Everything below is a real, if small, regression or newly-added cost:

1. **The freeze can move to a later sync caller.** The previously *guaranteed* synchronous cache warm-up is replaced by a window in which allowed-roots resolution or the create click can still block. Concretely: on a cold distro, opening the create composer and clicking Create within a few hundred ms now pays the 5s freeze on the click instead of on the background prep. Net across a session this is still a win (the stopped-distro case is strictly better), but "nothing blocks any more" would be false.
2. **A second concurrent `wsl.exe` can be spawned.** During that window a sync caller runs its own `execFileSync` while the async probe is in flight. Both write the same `wslHomeCache` entry with the same value, so there is no correctness issue — just one extra short-lived process.
3. **New `wsl.exe` spawn where there was none.** The mirror-distro fix makes `prepareWorktreeCreateForRepo` resolve the WSL home for `C:\` repos on a WSL project runtime. That path previously spawned nothing. The spawn is async, but it is a new process on composer-open for that configuration.
4. **Speculative checkout disk usage moves distro-side.** For those same repos, the `.orca-preparing/<id>` checkout is now created inside the WSL filesystem instead of under `C:\workspaces`. Previously that Windows-side checkout was created and then always discarded, so this trades wasted `C:` writes for real WSL-side writes.
5. **Probe concurrency changed on settings save.** `prepareLocalWorktreeRootsForRepos` uses `Promise.all(repos.map(...))`. The sync probe made it effectively sequential across distinct distros; it is now parallel, so a user with repos on several stopped distros can have several `wsl.exe` processes outstanding at once instead of one at a time.
6. **`prepareWorktreeCreateForRepo` is now `async`.** Its early returns (remote repo, folder repo) resolve one microtask later than before. All callers `await` or `void` it, so nothing depends on synchronous completion, but this is a timing change for every platform.
7. **`computeWorkspaceRootAsync` is now exported.** Wider module surface; nothing stops a future caller from picking it where a sync answer was required.
8. **The prepare/consume divergence is narrowed, not eliminated.** If the async probe *fails* during prepare and the sync probe *succeeds* at consume time (distro started in between), the two sides still key on different roots and the prepared checkout is discarded. That is the same fallback behavior as before this change — not made worse, not fixed.
9. **The `worktree-logic.ts` refactor has no new test of its own.** It is defended by 7 pre-existing `worktree-logic-wsl.test.ts` cases, which fail if the `shouldMirrorWorkspaceDirInsideWsl` guard is dropped from the shared helper.

## Verification

Commands run in the worktree (`npx vitest run`, macOS):

- `npx vitest run src/main/worktree-create-preparation.test.ts src/main/worktree-create-preparation-wsl-root.test.ts src/main/worktree-root-preparation.test.ts src/main/ipc/worktree-logic.test.ts src/main/ipc/worktree-logic-wsl.test.ts src/main/memory/hydrate-local-pty-registry.test.ts src/main/ipc/workspace-cleanup-broad-scan.test.ts src/main/ipc/workspace-cleanup.test.ts src/main/workspace-space-analysis.test.ts src/main/ipc/workspace-cleanup-local-git-routing.test.ts` → **10 files / 216 passed**. (The last five mock `project-runtime-git-options`, which gained a new import in this diff.)
- `npx vitest run src/main/runtime/orca-runtime.test.ts src/main/ipc/worktrees src/main/ipc/worktree-remote src/main/ipc/settings.test.ts src/main/ipc/repos` → **46 files / 1731 passed, 1 skipped**.
- `npx vitest run src/main/wsl src/main/worktree` → **36 files: 31 passed, 4 skipped, 1 failed (8 tests)**. The failure is `src/main/worktree-removal-session-partition-fencing.test.ts` with `AppEnvironment not initialized — call setAppEnvironment()`. Reproduced identically on the base commit with the change stashed, so it is pre-existing and unrelated.
- `npx oxfmt --write` then `npx oxlint` on all six changed files: clean. `worktree-logic.ts` is 393 lines with no `max-lines` disable.

Mutation-verified (production hunk reverted, test run, hunk restored):

| Hunk reverted | Result |
| --- | --- |
| `worktree-root-preparation.ts` back to sync `computeWorkspaceRoot` | `worktree-root-preparation.test.ts`: 1 failed / 4 passed |
| `worktree-create-preparation.ts` back to sync `computeWorkspaceRoot` | both create-preparation suites: 14 failed / 0 passed |
| Drop `getWorktreeMirrorDistro(store, repo)` from the prepare-side path settings | `worktree-create-preparation-wsl-root.test.ts`: 1 failed / 2 passed, at the `C:\` case, `Received: "C:\workspaces\.orca-preparing\..."` |

`pnpm tc` is run separately by the landing pipeline; it was not run in this session.
