### PR TITLE
fix(worktree): reject Windows drive-qualified shared paths in the symlink guard

### DIFF
--- a/src/main/git/worktree-symlink-detection.test.ts
+++ b/src/main/git/worktree-symlink-detection.test.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { findExistingWorktreeSymlinkPaths, getSafeRelativePath } from './worktree-symlink-detection'
+
+describe('getSafeRelativePath', () => {
+  // The only case in this file that binds the production change: every one of
+  // these is admitted by at least one host's `path.isAbsolute` — the
+  // drive-relative spellings are admitted by *every* host's, Windows included.
+  it('rejects Windows drive-qualified entries, including drive-relative, on any host', () => {
+    expect(getSafeRelativePath('C:\\Windows\\Temp')).toEqual({ safe: false })
+    expect(getSafeRelativePath('C:/Windows/Temp')).toEqual({ safe: false })
+    expect(getSafeRelativePath('  d:\\payload  ')).toEqual({ safe: false })
+    // Drive-RELATIVE: `win32.resolve('D:\\wt', 'C:payload')` discards the
+    // worktree root and lands under C:'s current directory.
+    expect(getSafeRelativePath('C:payload')).toEqual({ safe: false })
+    expect(getSafeRelativePath('c:')).toEqual({ safe: false })
+  })
+
+  it('keeps colon-bearing paths that are not drive-qualified', () => {
+    expect(getSafeRelativePath('build:out')).toEqual({ safe: true, rel: 'build:out' })
+    expect(getSafeRelativePath('logs/2026-08-31T10:00.txt')).toEqual({
+      safe: true,
+      rel: 'logs/2026-08-31T10:00.txt'
+    })
+  })
+
+  // These pin the rest of the guard expression, which this commit rewrote:
+  // both `isAbsolute` calls were deleted as provably subsumed by the strip
+  // above plus the drive check, so their inputs must still be judged the same.
+  it('still strips leading separators of either flavour and keeps the remainder relative', () => {
+    expect(getSafeRelativePath('node_modules')).toEqual({ safe: true, rel: 'node_modules' })
+    expect(getSafeRelativePath('  .env  ')).toEqual({ safe: true, rel: '.env' })
+    expect(getSafeRelativePath('/.env')).toEqual({ safe: true, rel: '.env' })
+    expect(getSafeRelativePath('\\.env')).toEqual({ safe: true, rel: '.env' })
+    expect(getSafeRelativePath('//srv/share/x')).toEqual({ safe: true, rel: 'srv/share/x' })
+  })
+
+  it('still rejects empty, whitespace-only, and parent-directory entries', () => {
+    expect(getSafeRelativePath('')).toEqual({ safe: false })
+    expect(getSafeRelativePath('   ')).toEqual({ safe: false })
+    expect(getSafeRelativePath('../secrets')).toEqual({ safe: false })
+    expect(getSafeRelativePath('safe/../../escape')).toEqual({ safe: false })
+    expect(getSafeRelativePath('..\\escape')).toEqual({ safe: false })
+    expect(getSafeRelativePath('foo\\..\\..\\escape')).toEqual({ safe: false })
+  })
+})
+
+describe('findExistingWorktreeSymlinkPaths', () => {
+  let root: string
+  let primary: string
+  let worktree: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-symlink-detection-'))
+    primary = join(root, 'primary')
+    worktree = join(root, 'worktree')
+    mkdirSync(primary)
+    mkdirSync(worktree)
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  // Why skipped on Windows rather than made platform-independent: the fixture
+  // needs a real on-disk directory named `C:`, which only POSIX allows. The
+  // Windows half of this guard is bound by the unit tests above, which run
+  // everywhere because they never touch the filesystem.
+  const posixIt = process.platform === 'win32' ? it.skip : it
+
+  posixIt('does not report a drive-qualified entry even when the literal path exists', async () => {
+    mkdirSync(join(worktree, 'C:'))
+    writeFileSync(join(primary, 'payload'), 'X=1\n')
+    symlinkSync(join(primary, 'payload'), join(worktree, 'C:', 'payload'))
+    symlinkSync(join(primary, 'payload'), join(worktree, 'C:payload'))
+
+    await expect(
+      findExistingWorktreeSymlinkPaths(worktree, ['C:/payload', 'C:\\payload', 'C:payload'])
+    ).resolves.toEqual([])
+  })
+})

--- a/src/main/git/worktree-symlink-detection.ts
+++ b/src/main/git/worktree-symlink-detection.ts
@@ -1,5 +1,5 @@
 import { lstat } from 'node:fs/promises'
-import { isAbsolute, resolve } from 'node:path'
+import { resolve } from 'node:path'
 
 // Why this is a leaf module rather than part of ipc/worktree-symlinks: status
 // and review-creation need only the read-only "is this a symlink" question, and
@@ -8,16 +8,25 @@ import { isAbsolute, resolve } from 'node:path'
 
 export type SafeRelativePathResult = { safe: true; rel: string } | { safe: false }
 
+// Why a regex rather than `path.isAbsolute`: the strip below already removed
+// every leading `/` and `\`, so the only rooted spelling that can still reach
+// the guard is a Windows drive designator — and `win32.isAbsolute` misses the
+// drive-RELATIVE form (`C:foo`), which `win32.resolve` still resolves against
+// that drive's current directory instead of the worktree root.
+const WINDOWS_DRIVE_DESIGNATOR = /^[a-zA-Z]:/
+
 export function getSafeRelativePath(rawPath: string): SafeRelativePathResult {
   // Why: strip leading separators (both `/` and `\`) before the guard so
   // Windows-style input like `\foo` is normalized the same way POSIX `/foo`
   // is, and the traversal check below sees the already-relative form.
   const rel = rawPath.trim().replace(/^[\\/]+/, '')
   // Why: split on both separators so a Windows-authored `..\escape` is
-  // rejected the same way POSIX `../escape` is. `path.isAbsolute` catches
-  // drive-letter absolutes (`C:\...`); the split catches relative
+  // rejected the same way POSIX `../escape` is; the split catches relative
   // backslash traversal that `.split('/')` would otherwise miss.
-  if (!rel || isAbsolute(rel) || rel.split(/[\\/]/).includes('..')) {
+  // Why the drive check runs on every host: the same entry — per-user Shared
+  // Paths setting or repo `orca.yaml` — is evaluated on every host Orca runs
+  // on, so the verdict must not depend on which one is asking.
+  if (!rel || WINDOWS_DRIVE_DESIGNATOR.test(rel) || rel.split(/[\\/]/).includes('..')) {
     return { safe: false }
   }
   return { safe: true, rel }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

## The problem

`getSafeRelativePath` (`src/main/git/worktree-symlink-detection.ts`) is the single guard that decides whether a configured shared/linked path may be resolved against a worktree root. It tested absoluteness with the host `path.isAbsolute`, which does not recognize the Windows drive-**relative** form `C:payload`. On Windows that entry was admitted, and `win32.resolve(worktreeRoot, 'C:payload')` **discards the worktree root** — so Orca created a symlink outside the worktree at create time, and `unlink`ed outside the worktree at removal time.

Verified locally on this machine:

```
win32.resolve('D:\wt', 'C:payload')                              -> C:\<cwd>\payload
win32.resolve('\\wsl.localhost\Ubuntu\home\u\wt', 'C:payload')   -> C:\<cwd>\payload
```

The value reaches the guard from the **per-user Worktree Shared Paths setting on its own** — `createWorktreeLinkedPaths(repo.path, created.path, repo.symlinkPaths ?? [])` at `orca-runtime.ts:27820` and `worktree-remote.ts:2636`. No repo config is required. (The removal and detection paths additionally merge the repo's checked-in `orca.yaml` `worktree.sharedDirectories` via `getWorktreeSharedLinkPaths`.) The Settings UI accepts any string — `WorktreeSymlinksSection.tsx:85-92` only trims and strips leading `/` — so a user can type `C:payload` today.

No such configuration is known to exist. This is not a fix for a bug anyone is reported to be hitting.

## The change

`src/main/git/worktree-symlink-detection.ts`, +13 / −4, one executable line:

```diff
-  if (!rel || isAbsolute(rel) || rel.split(/[\\/]/).includes('..')) {
+  if (!rel || WINDOWS_DRIVE_DESIGNATOR.test(rel) || rel.split(/[\\/]/).includes('..')) {
```

`WINDOWS_DRIVE_DESIGNATOR` is `/^[a-zA-Z]:/`. The guard strips every leading `/` and `\` before this test, so the only rooted spelling that can still reach it is a drive designator. Removing `isAbsolute` refuses nothing less than before: over all 88,741 strings of length ≤ 4 from a 17-character alphabet (letters, digit, `:`, `\`, `/`, `.`, space, `?`, `$`, both quote characters, NUL, fullwidth `ｃ`, `~`, `*`, `#`), the regex is a strict superset of `posix.isAbsolute || win32.isAbsolute` after the strip, and no admitted input escapes either `win32.resolve('D:\wt', rel)` or `posix.resolve('/wt', rel)`.

`src/main/git/worktree-symlink-detection.test.ts` is new, +83, 5 tests. The module had no test file.

## What changes for users

- **macOS** — No filesystem escape existed and none is closed: `posix.resolve('/wt', 'C:payload')` is `/wt/C:payload`, inside the worktree. The only change is a narrowing: a shared path whose first segment matches `<letter>:` is now refused. See Costs.
- **Linux** — Identical to macOS.
- **Native Windows** — The drive-relative escape (`C:payload`, `c:`) is closed on all three paths that use the guard: create (`materializeWorktreePaths`, worktree-symlinks.ts:208), unlink (`removeWorktreeLinkedPaths`, :368), and detect (`findExistingWorktreeSymlinkPaths`, worktree-symlink-detection.ts:41). `C:/payload` and `C:\payload` were already refused by `win32.isAbsolute`; no change there.
- **WSL-on-Windows** — Same escape, same fix, and it runs in the same process: a WSL project's repo sits behind `\\wsl.localhost\<Distro>\...` and `src/main/ipc/worktree-symlinks.ts` materializes links against that UNC root from the Windows side (its own comment at :43-45 documents this). `win32.resolve` discards a UNC root for a drive-relative argument exactly as it discards a drive root, verified above. So the escape existed here too and is closed here too.
- **SSH remote** — No change; the guard is never reached for a connected repo. Status short-circuits to the SSH provider before computing `sharedLinkPaths` (`runtime-git-status-commands.ts:33-39`, `filesystem.ts:1195-1201`), hosted-review (`ipc/hosted-review.ts:161,203`) and workspace cleanup (`workspace-cleanup-git-evidence.ts:42`) pass `[]` when `repo.connectionId` is set, and `createRemoteWorktree` never calls `createWorktreeLinkedPaths`.
- **Relay** — No wire change: no RPC parameter, stream frame, opcode, or published payload is touched, so no capability negotiation is needed. A relay- or `orca`-CLI-driven worktree removal runs `OrcaRuntimeService`'s removal path (`orca-runtime.ts:30205`) on the host machine, so it behaves per that host's line above.
- **Folder workspace** — No change. Every producer of `sharedLinkPaths` requires a `Repo`; a folder workspace has none, the list is empty, and the guard never runs.

## What this does NOT do

This slice was cut down from a larger change. Deliberately left behind:

1. **The three sibling drive-letter checks are untouched.** `isWindowsAbsolutePathLike` (`shared/cross-platform-path.ts:5`), `isSafeRuntimeRelativePath` (`runtime/runtime-relative-paths.ts:24`), and `isSafeMobileRelativePath` (`runtime/orca-runtime-files.ts:2546`) all spell the test `/^[A-Za-z]:[\\/]/` and share the drive-relative blind spot. They are not exploitable the same way: all three feed `joinWorktreeRelativePath`, and `win32.join('D:\wt', 'C:payload')` is `D:\wt\C:payload` — `join` never discards its root, unlike `resolve`. Changing them would widen the diff for zero behavior change.
2. **No WSL `pathOperations` routing.** The larger change also routed symlink materialization through a WSL-aware path-operations layer. That alters how links are created inside a distro and is not needed to close this hole.
3. **No user-facing validation.** The Settings UI still accepts `C:payload` and still lists it after it stops working; the create path skips it with a `console.warn` to the main-process log and no in-app signal. Adding validation is a separate change and would not help anyone who already has such an entry stored.
4. **No migration or cleanup** for a worktree that already holds an Orca-created symlink at a now-refused path. See Costs (2).
5. **No change to the other arms of the guard.** The leading-separator strip, the `..` split, and the empty/whitespace check are byte-identical; the new tests pin them because the `isAbsolute` deletion removed a second, redundant reader of the same inputs.

## Costs and residual risk

1. **macOS/Linux narrowing — the real cost.** `:` is a legal POSIX filename character. Any shared/linked entry whose first segment matches `<letter>:` is now refused where it previously worked: a top-level directory literally named `C:`, the entry `C:payload`, bare `c:`, and also short names like `x:cache`. This is wider than a `<letter>:<sep>`-only test would be, and that extra width is exactly what costs POSIX users. (`build:out` and `logs/2026-08-31T10:00.txt` are unaffected — the colon must be the second character.)
2. **The failure is silent on create and hard on removal.** For new worktrees the entry is skipped with a `console.warn` only. For a worktree that **already** holds an Orca-created symlink at such a path, the entry drops out of `ignoredUntrackedPaths` in all four `findExistingWorktreeSymlinkPaths` callers at once: `git worktree remove` is refused as dirty without Force Delete (`remove-registered-local-worktree.ts:91` and `orca-runtime.ts:30205`, i.e. both the in-app and the CLI/relay removal paths), Source Control shows a permanent untracked row (`status-read.ts:90`), and hosted-review creation is blocked on every provider, GitHub and GitLab alike (`hosted-review-creation-git-state.ts:290`) — while `removeWorktreeLinkedPaths` also stops unlinking it, so nothing cleans up the stale link. Force Delete still works.
3. **Windows narrowing: none found, stated for completeness.** Every string the regex newly refuses on Windows has `:` in its first segment, which Windows rejects in a relative filename. If some path syntax I have not considered makes `<letter>:...` a valid Windows relative name, this change would refuse it.
4. **The per-host alternative was rejected on purpose.** Deciding per host — POSIX keeps admitting what only escapes on Windows — would leave every POSIX user's `C:`-named directory working. It was rejected because the same per-user setting and the same `orca.yaml` are evaluated on every host a user runs Orca on, so a per-host verdict reinstates the divergence this change exists to remove. A reviewer who weighs the POSIX cost above cross-host consistency should say so; it is a one-line change either way.
5. **The escape closed is theoretical.** No repo or user config with a drive-qualified shared path is known to exist — which means the cost in (1) and (2) is equally theoretical, for the same reason.

## Verification

```
npx vitest run \
  src/main/git/worktree-symlink-detection.test.ts \
  src/main/ipc/worktree-symlinks.test.ts \
  src/main/ipc/worktree-symlink-reconciliation.real.test.ts \
  src/main/git/status-shared-symlinks.test.ts \
  src/main/git/status-discard-symlink.test.ts \
  src/main/source-control/hosted-review-creation-shared-symlinks.test.ts \
  src/main/git/worktree-shared-directories.test.ts \
  src/main/ipc/worktrees-remove-preflight.test.ts \
  src/main/ipc/worktrees-remove-archive-hooks.test.ts \
  src/renderer/src/components/settings/worktree-symlink-path-filter.test.ts
```

→ **10 files, 118 tests passed**, 2.06s. New file alone: **5 passed**.

**Mutation-verified — all 5 tests in the new file**, production hunk restored after each:

| Mutant | Test that fails |
| --- | --- |
| Full revert to `isAbsolute` (HEAD~1) | `rejects Windows drive-qualified entries…` and `does not report a drive-qualified entry even when the literal path exists` (2 failed / 3 passed) |
| `win32.isAbsolute(rel)` — Windows semantics, run on macOS | Same 2, on `expected { safe: true, rel: 'C:payload' } to deeply equal { safe: false }` and `expected [ 'C:payload' ] to deeply equal []`. Confirms the headline test binds **Windows** behavior, not just the host it runs on. |
| `/^[a-zA-Z]:/` → `/:/` (over-broad) | `keeps colon-bearing paths that are not drive-qualified` |
| Leading-separator strip removed | `still strips leading separators of either flavour…` |
| `rel.split(/[\\/]/)` → `rel.split('/')` | `still rejects empty, whitespace-only, and parent-directory entries` |

Every test is killed by at least one mutant; none is a zombie.

The one filesystem test is `it.skip`ped on `win32` because its fixture needs a real on-disk directory named `C:`, which only POSIX allows. The Windows half of the guard is bound by the four pure-unit tests, which run on every platform.

`npx oxfmt --check` and `npx oxlint` both clean on the two touched files. `pnpm tc` is run separately by the merge pipeline, not here.
---

### Native-Windows verification (awin)

Run on a real Windows host (Node 24, WSL distros `Ubuntu-24.04` + `Sta4593-Federated`):

- `src/main/git/worktree-symlink-detection.test.ts` → **4 passed, 1 skipped**.
- `src/main/ipc/worktree-symlinks.test.ts` → 9 failed / 31 passed / 6 skipped. **These 9 failures are pre-existing on `main`**: the identical 9 tests fail on `origin/main` on the same host (they need Windows symlink-creation privilege / Developer Mode). This branch neither adds nor fixes any of them.
