### PR TITLE
fix(worktree): run the create-base warm-up on the routed git host

### DIFF
--- a/src/main/git/commit-object-ref.test.ts
+++ b/src/main/git/commit-object-ref.test.ts
@@ -1,22 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-const gitExecFileAsyncMock = vi.hoisted(() => vi.fn())
-
-vi.mock('./runner', () => ({
-  gitExecFileAsync: gitExecFileAsyncMock
-}))
-
-import {
-  hasCommitObjectViaGitExec,
-  hasLocalCommitObject,
-  isFullGitObjectId
-} from './commit-object-ref'
+import { describe, expect, it, vi } from 'vitest'
+import { hasCommitObjectViaGitExec, isFullGitObjectId } from './commit-object-ref'
 
 describe('commit object refs', () => {
-  beforeEach(() => {
-    gitExecFileAsyncMock.mockReset()
-  })
-
   it('recognizes only complete git object IDs', () => {
     expect(isFullGitObjectId('a'.repeat(40))).toBe(true)
     expect(isFullGitObjectId('A'.repeat(40))).toBe(true)
@@ -48,16 +33,5 @@ describe('commit object refs', () => {
     await expect(hasCommitObjectViaGitExec(gitExec, 'origin/main')).resolves.toBe(false)
 
     expect(gitExec).not.toHaveBeenCalled()
-  })
-
-  it('checks local commit objects in the target repo path', async () => {
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'a'.repeat(40), stderr: '' })
-
-    await expect(hasLocalCommitObject('/repo', 'a'.repeat(40))).resolves.toBe(true)
-
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      ['rev-parse', '--verify', '--quiet', `${'a'.repeat(40)}^{commit}`],
-      { cwd: '/repo' }
-    )
   })
 })

--- a/src/main/git/commit-object-ref.ts
+++ b/src/main/git/commit-object-ref.ts
@@ -1,5 +1,3 @@
-import { gitExecFileAsync } from './runner'
-
 type GitExec = (args: string[]) => Promise<unknown>
 
 const FULL_GIT_OBJECT_ID_PATTERN = /^[0-9a-f]{40}$/i
@@ -19,8 +17,4 @@ export async function hasCommitObjectViaGitExec(gitExec: GitExec, ref: string): 
   } catch {
     return false
   }
-}
-
-export function hasLocalCommitObject(repoPath: string, ref: string): Promise<boolean> {
-  return hasCommitObjectViaGitExec((args) => gitExecFileAsync(args, { cwd: repoPath }), ref)
 }

--- a/src/main/git/worktree-base-ref-probe.test.ts
+++ b/src/main/git/worktree-base-ref-probe.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it, vi } from 'vitest'
-import { probeWorktreeBaseRefPresence } from './worktree-base-ref-probe'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const gitExecFileAsync = vi.hoisted(() => vi.fn())
+
+vi.mock('./runner', () => ({ gitExecFileAsync }))
+
+import { hasLocalWorktreeBaseRef, probeWorktreeBaseRefPresence } from './worktree-base-ref-probe'
 
 describe('probeWorktreeBaseRefPresence', () => {
   it('uses an exact show-ref probe and reports a present ref', async () => {
@@ -50,5 +55,49 @@ describe('probeWorktreeBaseRefPresence', () => {
 
     await expect(probeWorktreeBaseRefPresence(runGit, 'refs/heads/*')).resolves.toBe('unknown')
     expect(runGit).not.toHaveBeenCalled()
+  })
+})
+
+describe('hasLocalWorktreeBaseRef', () => {
+  const repoPath = String.raw`C:\workspace\repo`
+
+  function resolveOnly(present: string[]): void {
+    gitExecFileAsync.mockImplementation(async (args: string[]) => ({
+      stdout: present.includes(args.at(-1)?.replace('^{commit}', '') ?? '') ? 'f'.repeat(40) : '',
+      stderr: ''
+    }))
+  }
+
+  beforeEach(() => {
+    gitExecFileAsync.mockReset()
+  })
+
+  it('prefers the remote namespace for a slashed short name', async () => {
+    resolveOnly(['refs/remotes/origin/main'])
+
+    await expect(hasLocalWorktreeBaseRef(repoPath, 'origin/main')).resolves.toBe(true)
+    expect(gitExecFileAsync).toHaveBeenCalledWith(
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
+      { cwd: repoPath }
+    )
+  })
+
+  it('probes a bare commit id as an object, not as a ref', async () => {
+    const sha = 'a'.repeat(40)
+    resolveOnly([sha])
+
+    await expect(hasLocalWorktreeBaseRef(repoPath, sha, { wslDistro: 'Ubuntu' })).resolves.toBe(
+      true
+    )
+    expect(gitExecFileAsync).toHaveBeenCalledWith(
+      ['rev-parse', '--verify', '--quiet', `${sha}^{commit}`],
+      { cwd: repoPath, wslDistro: 'Ubuntu' }
+    )
+  })
+
+  it('reports a base no namespace resolves as absent', async () => {
+    resolveOnly([])
+
+    await expect(hasLocalWorktreeBaseRef(repoPath, 'feature/topic')).resolves.toBe(false)
   })
 })

--- a/src/main/git/worktree-base-ref-probe.ts
+++ b/src/main/git/worktree-base-ref-probe.ts
@@ -1,6 +1,8 @@
 import { gitExecFileAsync } from './runner'
 import { isShowRefNoMatchError } from './exact-ref-probe'
+import { hasCommitObjectViaGitExec } from './commit-object-ref'
 import { isSafeGitRefName } from '../../shared/git-status-upstream-ref'
+import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
 
 type GitExecOptions = {
   wslDistro?: string
@@ -38,6 +40,34 @@ export async function hasWorktreeBaseCommitRef(
   options: GitExecOptions = {}
 ): Promise<boolean> {
   return (await resolveWorktreeBaseCommitOid(repoPath, qualifiedRef, options)) !== null
+}
+
+/**
+ * Whether a worktree base — a qualified ref, a short branch or remote name, or a
+ * full commit id — already resolves in this repo's own object/ref store.
+ *
+ * Single copy on purpose: the create path, the speculative create prefetch and
+ * the remote-repo create path must agree on what counts as a local base, or the
+ * warm-up prepares a checkout create then rejects.
+ */
+export async function hasLocalWorktreeBaseRef(
+  repoPath: string,
+  baseRef: string,
+  options: GitExecOptions = {}
+): Promise<boolean> {
+  const refExists = (qualifiedRef: string) =>
+    hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
+  const resolvedBaseRef = await resolveWorktreeAddBaseRef(baseRef, refExists)
+  if (resolvedBaseRef !== baseRef) {
+    return true
+  }
+  if (baseRef.startsWith('refs/')) {
+    return refExists(baseRef)
+  }
+  return hasCommitObjectViaGitExec(
+    (gitArgs) => gitExecFileAsync(gitArgs, { cwd: repoPath, ...options }),
+    baseRef
+  )
 }
 
 export type WorktreeBaseRefPresence = 'present' | 'absent' | 'unknown'

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -38,7 +38,10 @@ import {
 import { getBranchConflictKindViaExec } from '../git/repo-branch-conflict'
 import { resolveLocalGitUsername, getSshGitUsername } from '../git/git-username'
 import { hasCommitObjectViaGitExec } from '../git/commit-object-ref'
-import { probeWorktreeBaseRefPresence } from '../git/worktree-base-ref-probe'
+import {
+  hasLocalWorktreeBaseRef,
+  probeWorktreeBaseRefPresence
+} from '../git/worktree-base-ref-probe'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
 import { getHostedReviewForBranch } from '../source-control/hosted-review'
@@ -716,46 +719,6 @@ async function canCheckoutExistingLocalBranch(
 
 function hasLocalGitOptions(gitOptions: { wslDistro?: string }): boolean {
   return Object.keys(gitOptions).length > 0
-}
-
-function hasLocalCommitObjectWithOptions(
-  repoPath: string,
-  ref: string,
-  gitOptions: { wslDistro?: string }
-): Promise<boolean> {
-  return hasCommitObjectViaGitExec(
-    (gitArgs) => gitExecFileAsync(gitArgs, { cwd: repoPath, ...gitOptions }),
-    ref
-  )
-}
-
-async function hasLocalWorktreeBaseRefWithOptions(
-  repoPath: string,
-  baseRef: string,
-  gitOptions: { wslDistro?: string }
-): Promise<boolean> {
-  const refExists = async (qualifiedRef: string) => {
-    try {
-      const { stdout } = await gitExecFileAsync(
-        ['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`],
-        {
-          cwd: repoPath,
-          ...gitOptions
-        }
-      )
-      return stdout.trim().length > 0
-    } catch {
-      return false
-    }
-  }
-  const resolvedBaseRef = await resolveWorktreeAddBaseRef(baseRef, refExists)
-  if (resolvedBaseRef !== baseRef) {
-    return true
-  }
-  if (baseRef.startsWith('refs/')) {
-    return refExists(baseRef)
-  }
-  return hasLocalCommitObjectWithOptions(repoPath, baseRef, gitOptions)
 }
 
 function getLocalGitHubPrForBranch(
@@ -2066,14 +2029,10 @@ export async function createLocalWorktree(
           ) {
             return true
           }
-          return hasLocalWorktreeBaseRefWithOptions(
-            repo.path,
-            baseBranchCandidate,
-            localGitExecOptions
-          )
+          return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate, localGitExecOptions)
         }
       }
-      return hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranchCandidate, localGitExecOptions)
+      return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate, localGitExecOptions)
     }
   })
   const [username, resolvedBaseBranch] = await Promise.all([usernamePromise, baseBranchPromise])
@@ -2103,15 +2062,11 @@ export async function createLocalWorktree(
     if (remoteTrackingBase) {
       const [hasRemoteTrackingBaseRef, hasNamedLocalBaseRef] = await Promise.all([
         runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase, ...localWorktreeGitOptionArgs),
-        hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localGitExecOptions)
+        hasLocalWorktreeBaseRef(repo.path, baseBranch, localGitExecOptions)
       ])
       const hasFallbackLocalBaseRef =
         !hasNamedLocalBaseRef &&
-        (await hasLocalWorktreeBaseRefWithOptions(
-          repo.path,
-          remoteTrackingBase.branch,
-          localGitExecOptions
-        ))
+        (await hasLocalWorktreeBaseRef(repo.path, remoteTrackingBase.branch, localGitExecOptions))
       const hasLocalBaseRef =
         hasRemoteTrackingBaseRef || hasNamedLocalBaseRef || hasFallbackLocalBaseRef
       if (!hasRemoteTrackingBaseRef && hasLocalBaseRef) {
@@ -2136,9 +2091,7 @@ export async function createLocalWorktree(
           )
         }
       }
-    } else if (
-      !(await hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localWorktreeGitOptions))
-    ) {
+    } else if (!(await hasLocalWorktreeBaseRef(repo.path, baseBranch, localWorktreeGitOptions))) {
       // Why: non-remote-prefix bases (plain main/master/local) keep the legacy best-effort fetch; verified PR SHA bases already have the object.
       legacyFetchPromise = runtime
         .fetchRemoteWithCache(repo.path, 'origin', ...localWorktreeGitOptionArgs)
@@ -2147,9 +2100,7 @@ export async function createLocalWorktree(
       emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
     }
   } else {
-    if (
-      !(await hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localWorktreeGitOptions))
-    ) {
+    if (!(await hasLocalWorktreeBaseRef(repo.path, baseBranch, localWorktreeGitOptions))) {
       legacyFetchPromise = gitExecFileAsync(['fetch', 'origin'], {
         ...localGitExecOptions,
         timeout: CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS

--- a/src/main/ipc/worktrees-test-harness.ts
+++ b/src/main/ipc/worktrees-test-harness.ts
@@ -76,6 +76,15 @@ export {
   type HandlerMap
 } from './worktrees-test-ipc-surface'
 
+/** The single repo every worktree harness test resolves; exported so a test can vary one field. */
+export const harnessRepo = {
+  id: 'repo-1',
+  path: '/workspace/repo',
+  displayName: 'repo',
+  badgeColor: '#000',
+  addedAt: 0
+}
+
 /** Registers worktree IPC handlers against freshly reset shared mocks and returns the runtime stub. */
 export function setupWorktreeHandlers(): WorktreeRuntimeStub {
   delete (store as typeof store & { getAllWorktreeMetaForHost?: (...args: unknown[]) => unknown })
@@ -185,15 +194,8 @@ export function setupWorktreeHandlers(): WorktreeRuntimeStub {
     handlers[channel] = handler
   })
 
-  const repo = {
-    id: 'repo-1',
-    path: '/workspace/repo',
-    displayName: 'repo',
-    badgeColor: '#000',
-    addedAt: 0
-  }
-  store.getRepos.mockReturnValue([repo])
-  store.getRepo.mockReturnValue({ ...repo, worktreeBaseRef: null })
+  store.getRepos.mockReturnValue([harnessRepo])
+  store.getRepo.mockReturnValue({ ...harnessRepo, worktreeBaseRef: null })
   store.getProjects.mockReturnValue([])
   store.getSparsePresets.mockReturnValue([])
   const settings = {

--- a/src/main/ipc/worktrees-wsl-runtime-routing.test.ts
+++ b/src/main/ipc/worktrees-wsl-runtime-routing.test.ts
@@ -13,9 +13,11 @@ import {
   createSetupRunnerScriptMock,
   getEffectiveHooksFromConfigMock,
   shouldRunSetupForCreateMock,
+  getBaseRefDefaultMock,
   gitExecFileAsyncMock
 } from './worktrees-test-module-mocks'
-import { handlers, setupWorktreeHandlers, store } from './worktrees-test-harness'
+import { handlers, harnessRepo, setupWorktreeHandlers, store } from './worktrees-test-harness'
+import type { WorktreeRuntimeStub } from './worktrees-test-runtime-stub'
 import {
   createdWorktreeList,
   mockKnownFeatureWorktree,
@@ -104,9 +106,65 @@ vi.mock('../runtime/worktree-teardown', async () =>
 )
 vi.mock('./pty', async () => (await import('./worktrees-test-module-mocks')).ptyModuleMock())
 
+/** Every create-path git call, including the base-ref probe now shared with the
+ *  speculative prefetch, must read the distro's ref store rather than host git's. */
+function expectEveryGitCallRoutedTo(wslDistro: string): void {
+  const callDistros = new Set(
+    gitExecFileAsyncMock.mock.calls.map(
+      ([, options]) => (options as { wslDistro?: string } | undefined)?.wslDistro
+    )
+  )
+  expect(callDistros).toEqual(new Set([wslDistro]))
+}
+
 describe('registerWorktreeHandlers', () => {
+  let runtimeStub: WorktreeRuntimeStub
+
   beforeEach(() => {
-    setupWorktreeHandlers()
+    runtimeStub = setupWorktreeHandlers()
+  })
+
+  it('routes the speculative create-base prefetch through the selected WSL project runtime', async () => {
+    mockSelectedWslProjectRuntime()
+    const remoteTrackingBase = {
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    }
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteTrackingBase)
+
+    await handlers['worktrees:prefetchCreateBase'](null, { repoId: 'repo-1' })
+
+    expect(getBaseRefDefaultMock).toHaveBeenCalledWith('/workspace/repo', { wslDistro: 'Ubuntu' })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
+      { cwd: '/workspace/repo', wslDistro: 'Ubuntu' }
+    )
+    expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'origin/main',
+      { wslDistro: 'Ubuntu' }
+    )
+    expect(runtimeStub.getOrStartRemoteTrackingBaseRefresh).toHaveBeenCalledWith(
+      '/workspace/repo',
+      remoteTrackingBase,
+      { wslDistro: 'Ubuntu' }
+    )
+  })
+
+  it('routes the prefetch remote-fetch fallback through the selected WSL project runtime', async () => {
+    mockSelectedWslProjectRuntime()
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(null)
+
+    await handlers['worktrees:prefetchCreateBase'](null, {
+      repoId: 'repo-1',
+      baseBranch: 'feature/topic'
+    })
+
+    expect(runtimeStub.fetchRemoteWithCache).toHaveBeenCalledWith('/workspace/repo', 'origin', {
+      wslDistro: 'Ubuntu'
+    })
   })
 
   it('routes local worktree creation through the selected WSL project runtime', async () => {
@@ -153,6 +211,36 @@ describe('registerWorktreeHandlers', () => {
       { wslDistro: 'Ubuntu' }
     )
     expect(listWorktreesMock).toHaveBeenCalledWith('/workspace/repo', { wslDistro: 'Ubuntu' })
+    expectEveryGitCallRoutedTo('Ubuntu')
+  })
+
+  it('routes local worktree creation with a remote tracking base through the selected WSL project runtime', async () => {
+    mockSelectedWslProjectRuntime()
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue({
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    })
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'abc123\n', stderr: '' })
+    // A persisted base that differs from the detected default also drives the usability probe.
+    store.getRepo.mockReturnValue({ ...harnessRepo, worktreeBaseRef: 'custom-base' })
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/improve-dashboard',
+        head: 'abc123',
+        branch: 'refs/heads/improve-dashboard',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard'
+    })
+
+    expectEveryGitCallRoutedTo('Ubuntu')
   })
 
   it('routes fork push target setup through the selected WSL project runtime', async () => {

--- a/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.ts
+++ b/src/main/ipc/worktrees/create/register-worktree-prefetch-handler.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron'
 import { prefetchWorktreeCreateBase } from '../../../worktree-create-base-prefetch'
 import { prepareWorktreeCreateForRepo } from '../../../worktree-create-preparation'
+import { getWorktreeCreatePrefetchGitOptions } from '../../../project-runtime-git-options'
 import type { WorktreeIpcContext } from '../worktree-ipc-context'
 
 export function registerWorktreePrefetchHandler(context: WorktreeIpcContext): void {
@@ -17,7 +18,8 @@ export function registerWorktreePrefetchHandler(context: WorktreeIpcContext): vo
         const baseBranch = await prefetchWorktreeCreateBase({
           repo,
           baseBranch: args.baseBranch,
-          runtime
+          runtime,
+          gitOptions: getWorktreeCreatePrefetchGitOptions(store, repo)
         })
         if (baseBranch) {
           await prepareWorktreeCreateForRepo(store, repo, baseBranch)

--- a/src/main/project-runtime-git-options.test.ts
+++ b/src/main/project-runtime-git-options.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from './persistence'
 import type { Project } from '../shared/project-types'
 import type { Repo } from '../shared/repo-types'
 import {
   getLocalProjectGitExecOptions,
+  getWorktreeCreatePrefetchGitOptions,
   getWorktreeMirrorDistro,
   resolveLocalProjectRuntimeForRepo
 } from './project-runtime-git-options'
@@ -173,6 +174,55 @@ describe('project runtime git options', () => {
       _setWslCachesForTests({ available: true, distros: ['Ubuntu'] })
 
       expect(withPlatform('win32', () => getWorktreeMirrorDistro({}, makeRepo()))).toBeUndefined()
+    })
+  })
+
+  describe('getWorktreeCreatePrefetchGitOptions', () => {
+    it('routes the warm-up through the distro a resolved WSL project runs in', () => {
+      _setWslCachesForTests({ available: true, distros: ['Ubuntu'] })
+      const project = makeProject({
+        localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+      })
+
+      expect(
+        withPlatform('win32', () =>
+          getWorktreeCreatePrefetchGitOptions(makeStore(project), makeRepo())
+        )
+      ).toEqual({ wslDistro: 'Ubuntu' })
+    })
+
+    // A speculative warm-up must degrade to the host Git it used before routing
+    // existed, never surface the repair state git execution raises.
+    it('falls back to host git instead of throwing when the runtime needs repair', () => {
+      _setWslCachesForTests({ available: true, distros: ['Debian'] })
+      const project = makeProject({
+        localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+      })
+
+      expect(
+        withPlatform('win32', () =>
+          getWorktreeCreatePrefetchGitOptions(makeStore(project), makeRepo())
+        )
+      ).toEqual({})
+    })
+
+    it('does not resolve a project runtime for folder workspaces', () => {
+      _setWslCachesForTests({ available: true, distros: ['Ubuntu'] })
+      const project = makeProject({
+        localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+      })
+      const store = makeStore(project)
+      const getProjects = vi.fn(store.getProjects)
+
+      expect(
+        withPlatform('win32', () =>
+          getWorktreeCreatePrefetchGitOptions(
+            { ...store, getProjects } as unknown as Store,
+            makeRepo({ kind: 'folder' })
+          )
+        )
+      ).toEqual({})
+      expect(getProjects).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/project-runtime-git-options.ts
+++ b/src/main/project-runtime-git-options.ts
@@ -1,5 +1,6 @@
 import type { Store } from './persistence'
 import type { Repo } from '../shared/repo-types'
+import { isFolderRepo } from '../shared/repo-kind'
 import {
   resolveLocalProjectRuntimeForRepo,
   type ProjectRuntimeResolutionStore
@@ -56,6 +57,28 @@ export function getLocalProjectWorktreeGitOptions(
 ): LocalProjectWorktreeGitOptions {
   const { wslDistro } = getLocalProjectGitExecOptions(store, repo)
   return wslDistro ? { wslDistro } : {}
+}
+
+/**
+ * Git routing for the speculative worktree-create warm-up.
+ *
+ * Deliberately non-throwing where `getLocalProjectWorktreeGitOptions` throws: an
+ * optimistic prefetch must not report a repair-required runtime as a failure, so
+ * an unresolved runtime falls back to the host Git the warm-up used before
+ * routing existed.
+ */
+export function getWorktreeCreatePrefetchGitOptions(
+  store: Store,
+  repo: Repo
+): LocalProjectWorktreeGitOptions {
+  if (isFolderRepo(repo)) {
+    return {}
+  }
+  const projectRuntime = resolveLocalProjectRuntimeForRepo(store, repo)
+  if (!projectRuntime || projectRuntime.status !== 'resolved') {
+    return {}
+  }
+  return getLocalProjectWorktreeGitOptionsForRuntime(repo, projectRuntime)
 }
 
 export function getLocalProjectWorktreeGitOptionsForRuntime(

--- a/src/main/runtime/orca-runtime-create-base-prefetch.test.ts
+++ b/src/main/runtime/orca-runtime-create-base-prefetch.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as WorktreeCreatePreparation from '../worktree-create-preparation'
+import type { Project } from '../../shared/project-types'
+import type { Repo } from '../../shared/repo-types'
+import { _resetWslCachesForTests, _setWslCachesForTests } from '../wsl'
+
+const mocks = vi.hoisted(() => ({
+  prefetchWorktreeCreateBase: vi.fn(),
+  prepareWorktreeCreateForRepo: vi.fn()
+}))
+
+vi.mock('../worktree-create-base-prefetch', () => ({
+  prefetchWorktreeCreateBase: mocks.prefetchWorktreeCreateBase
+}))
+vi.mock('../worktree-create-preparation', async (importOriginal) => ({
+  ...(await importOriginal<typeof WorktreeCreatePreparation>()),
+  prepareWorktreeCreateForRepo: mocks.prepareWorktreeCreateForRepo
+}))
+
+import { OrcaRuntimeService } from './orca-runtime'
+
+const repo: Repo = {
+  id: 'repo-1',
+  displayName: 'Repo',
+  path: String.raw`C:\workspace\repo`,
+  badgeColor: '#000000',
+  addedAt: 0
+}
+
+const project: Project = {
+  id: 'project-1',
+  displayName: 'Project',
+  badgeColor: '#000000',
+  sourceRepoIds: ['repo-1'],
+  createdAt: 0,
+  updatedAt: 0,
+  localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+}
+
+function makeStore(overrides: Partial<Project> = {}): unknown {
+  return {
+    getRepos: () => [repo],
+    getRepo: (id: string) => (id === repo.id ? repo : undefined),
+    getProjects: () => [{ ...project, ...overrides }],
+    getSettings: () => ({ localWindowsRuntimeDefault: { kind: 'windows-host' } })
+  }
+}
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+}
+
+const hostPlatform = process.platform
+
+beforeEach(() => {
+  mocks.prefetchWorktreeCreateBase.mockReset().mockResolvedValue(undefined)
+  mocks.prepareWorktreeCreateForRepo.mockReset().mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  setPlatform(hostPlatform)
+  _resetWslCachesForTests()
+})
+
+// The RPC/relay prefetch is the only warm-up a remote client reaches, so it has
+// to resolve the same project runtime the IPC handler does. Constructed through
+// the barrel because the split chain resolves selectors in a later subclass.
+describe('prefetchManagedWorktreeCreateBase (orca-runtime-get-worktree-terminal-provisioning-host)', () => {
+  it('warms up in the distro a WSL-routed project runs in', async () => {
+    _setWslCachesForTests({ available: true, distros: ['Ubuntu'] })
+    setPlatform('win32')
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+
+    await runtime.prefetchManagedWorktreeCreateBase({ repoSelector: 'repo-1' })
+
+    expect(mocks.prefetchWorktreeCreateBase).toHaveBeenCalledWith(
+      expect.objectContaining({ gitOptions: { wslDistro: 'Ubuntu' } })
+    )
+  })
+
+  it('warms up on host git when no project runtime routes the repo', async () => {
+    setPlatform('darwin')
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+
+    await runtime.prefetchManagedWorktreeCreateBase({ repoSelector: 'repo-1' })
+
+    expect(mocks.prefetchWorktreeCreateBase).toHaveBeenCalledWith(
+      expect.objectContaining({ gitOptions: {} })
+    )
+  })
+
+  // A repair-required runtime must degrade to host git, not fail the warm-up.
+  it('does not surface a repair-required project runtime as a prefetch failure', async () => {
+    _setWslCachesForTests({ available: true, distros: ['Debian'] })
+    setPlatform('win32')
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+
+    await expect(
+      runtime.prefetchManagedWorktreeCreateBase({ repoSelector: 'repo-1' })
+    ).resolves.toBeUndefined()
+
+    expect(mocks.prefetchWorktreeCreateBase).toHaveBeenCalledWith(
+      expect.objectContaining({ gitOptions: {} })
+    )
+  })
+
+  it('prepares the checkout the prefetch resolved', async () => {
+    _setWslCachesForTests({ available: true, distros: ['Ubuntu'] })
+    setPlatform('win32')
+    mocks.prefetchWorktreeCreateBase.mockResolvedValue('origin/main')
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+
+    await runtime.prefetchManagedWorktreeCreateBase({ repoSelector: 'repo-1' })
+
+    expect(mocks.prepareWorktreeCreateForRepo).toHaveBeenCalledWith(
+      expect.anything(),
+      repo,
+      'origin/main'
+    )
+  })
+})

--- a/src/main/runtime/orca-runtime-get-worktree-terminal-provisioning-host.ts
+++ b/src/main/runtime/orca-runtime-get-worktree-terminal-provisioning-host.ts
@@ -8,6 +8,7 @@ import type { TerminalCreateOptions } from './runtime-terminal-contracts'
 import type { WorktreeStartupReadinessHost } from './runtime-worktree-startup-readiness'
 import { prefetchWorktreeCreateBase } from '../worktree-create-base-prefetch'
 import { prepareWorktreeCreateForRepo } from '../worktree-create-preparation'
+import { getWorktreeCreatePrefetchGitOptions } from '../project-runtime-git-options'
 
 export class OrcaRuntimeWithGetWorktreeTerminalProvisioningHost extends OrcaRuntimeWithActivateManagedWorktree {
   protected getWorktreeTerminalProvisioningHost(): WorktreeTerminalProvisioningHost {
@@ -48,14 +49,16 @@ export class OrcaRuntimeWithGetWorktreeTerminalProvisioningHost extends OrcaRunt
     }
 
     const repo = await this.resolveRepoSelector(args.repoSelector)
+    const store = this.requireStore()
     const baseBranch = await prefetchWorktreeCreateBase({
       repo,
       baseBranch: args.baseBranch,
-      runtime: this
+      runtime: this,
+      gitOptions: getWorktreeCreatePrefetchGitOptions(store, repo)
     })
     if (baseBranch) {
       try {
-        await prepareWorktreeCreateForRepo(this.requireStore(), repo, baseBranch)
+        await prepareWorktreeCreateForRepo(store, repo, baseBranch)
       } catch {
         // Why: speculative preparation is an optimistic warm-up; the real create path reports failures.
       }

--- a/src/main/runtime/runtime-local-git-worktree-create.ts
+++ b/src/main/runtime/runtime-local-git-worktree-create.ts
@@ -15,7 +15,7 @@ import {
 import type { RuntimeStore } from './runtime-store-contract'
 import type { RuntimeManagedWorktreeCreateArgs } from './runtime-managed-worktree-create-types'
 import type { RemoteFetchResult, RemoteTrackingBase } from './runtime-remote-fetch-controller'
-import { hasLocalWorktreeBaseRef } from './runtime-worktree-create-git'
+import { hasLocalWorktreeBaseRef } from '../git/worktree-base-ref-probe'
 import { isGeneratedWorktreeCreateName } from '../worktree-create-candidates'
 import { consumePreparedWorktreeCreate } from '../worktree-create-preparation'
 import {

--- a/src/main/runtime/runtime-local-worktree-create.ts
+++ b/src/main/runtime/runtime-local-worktree-create.ts
@@ -14,7 +14,7 @@ import type { RuntimeManagedWorktreeCreateArgs } from './runtime-managed-worktre
 import type { RemoteFetchResult, RemoteTrackingBase } from './runtime-remote-fetch-controller'
 import type { HostedReviewExecutionOptions } from '../source-control/hosted-review-git-options'
 import { hasLocalGitOptions } from './runtime-worktree-selection'
-import { hasLocalWorktreeBaseRef } from './runtime-worktree-create-git'
+import { hasLocalWorktreeBaseRef } from '../git/worktree-base-ref-probe'
 import { resolveRuntimeLocalWorktreeCreateCandidate } from './runtime-local-worktree-create-candidate'
 import { createRuntimeLocalGitWorktree } from './runtime-local-git-worktree-create'
 import { materializeRuntimeLocalWorktree } from './runtime-local-worktree-materialization'

--- a/src/main/runtime/runtime-worktree-create-git.ts
+++ b/src/main/runtime/runtime-worktree-create-git.ts
@@ -1,10 +1,7 @@
 import type { BranchPrefixStrategy } from '../../shared/ui-chrome-types'
 import type { Repo } from '../../shared/repo-types'
-import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
 import { getPRForBranch } from '../github/client'
-import { hasCommitObjectViaGitExec } from '../git/commit-object-ref'
 import { gitExecFileAsync } from '../git/runner'
-import { hasWorktreeBaseCommitRef } from '../git/worktree-base-ref-probe'
 import { listWorktrees } from '../git/worktree'
 import { computeValidatedBranchName } from '../ipc/worktree-logic'
 import { getHostedReviewForBranch } from '../source-control/hosted-review'
@@ -113,24 +110,4 @@ export async function getSelectedHostedReviewForBranch(
         number: review.number
       }
     : null
-}
-
-export async function hasLocalWorktreeBaseRef(
-  repoPath: string,
-  baseRef: string,
-  options: { wslDistro?: string } = {}
-): Promise<boolean> {
-  const refExists = (qualifiedRef: string) =>
-    hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
-  const resolvedBaseRef = await resolveWorktreeAddBaseRef(baseRef, refExists)
-  if (resolvedBaseRef !== baseRef) {
-    return true
-  }
-  if (baseRef.startsWith('refs/')) {
-    return refExists(baseRef)
-  }
-  return hasCommitObjectViaGitExec(
-    (gitArgs) => gitExecFileAsync(gitArgs, { cwd: repoPath, ...options }),
-    baseRef
-  )
 }

--- a/src/main/worktree-create-base-prefetch.test.ts
+++ b/src/main/worktree-create-base-prefetch.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getBaseRefDefault: vi.fn(),
+  gitExecFileAsync: vi.fn(),
+  getSshGitProvider: vi.fn(),
+  prefetchRemoteWorktreeCreateBase: vi.fn(),
+  resolveRemoteTrackingBase: vi.fn(),
+  hasRemoteTrackingRef: vi.fn(),
+  getOrStartRemoteTrackingBaseRefresh: vi.fn(),
+  fetchRemoteWithCache: vi.fn()
+}))
+
+vi.mock('./git/repo', () => ({ getBaseRefDefault: mocks.getBaseRefDefault }))
+vi.mock('./git/runner', () => ({ gitExecFileAsync: mocks.gitExecFileAsync }))
+vi.mock('./providers/ssh-git-dispatch', () => ({ getSshGitProvider: mocks.getSshGitProvider }))
+vi.mock('./ipc/worktree-remote', () => ({
+  prefetchRemoteWorktreeCreateBase: mocks.prefetchRemoteWorktreeCreateBase
+}))
+
+import { prefetchWorktreeCreateBase } from './worktree-create-base-prefetch'
+
+const repo = {
+  id: 'repo-1',
+  path: String.raw`C:\workspace\repo`,
+  displayName: 'repo',
+  badgeColor: '#000000',
+  addedAt: 0
+}
+
+const WSL = { wslDistro: 'Ubuntu' }
+
+function runtime() {
+  return {
+    resolveRemoteTrackingBase: mocks.resolveRemoteTrackingBase,
+    hasRemoteTrackingRef: mocks.hasRemoteTrackingRef,
+    getOrStartRemoteTrackingBaseRefresh: mocks.getOrStartRemoteTrackingBaseRefresh,
+    fetchRemoteWithCache: mocks.fetchRemoteWithCache
+  }
+}
+
+/** Resolve only the named refs/objects; every other rev-parse answers "absent". */
+function resolveOnly(present: string[]): void {
+  mocks.gitExecFileAsync.mockImplementation(async (args: string[]) => {
+    const rev = args.at(-1)?.replace('^{commit}', '') ?? ''
+    return present.includes(rev)
+      ? { stdout: `${'f'.repeat(40)}\n`, stderr: '' }
+      : { stdout: '', stderr: '' }
+  })
+}
+
+function revParse(ref: string): string[] {
+  return ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`]
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) {
+    mock.mockReset()
+  }
+  mocks.getBaseRefDefault.mockResolvedValue('origin/main')
+  resolveOnly([])
+  mocks.resolveRemoteTrackingBase.mockResolvedValue(null)
+  mocks.hasRemoteTrackingRef.mockResolvedValue(false)
+  mocks.getOrStartRemoteTrackingBaseRefresh.mockResolvedValue({ ok: true })
+  mocks.fetchRemoteWithCache.mockResolvedValue(undefined)
+})
+
+describe('prefetchWorktreeCreateBase local git routing', () => {
+  it('resolves the default base and its ref probes inside the selected WSL distro', async () => {
+    resolveOnly(['refs/remotes/origin/main'])
+
+    await expect(
+      prefetchWorktreeCreateBase({ repo, runtime: runtime(), gitOptions: WSL })
+    ).resolves.toBe('origin/main')
+
+    expect(mocks.getBaseRefDefault).toHaveBeenCalledWith(repo.path, WSL)
+    expect(mocks.resolveRemoteTrackingBase).toHaveBeenCalledWith(repo.path, 'origin/main', WSL)
+    expect(mocks.gitExecFileAsync).toHaveBeenCalledWith(revParse('refs/remotes/origin/main'), {
+      cwd: repo.path,
+      ...WSL
+    })
+    // A base that is already local needs no fetch.
+    expect(mocks.fetchRemoteWithCache).not.toHaveBeenCalled()
+  })
+
+  it('probes a full commit object inside the selected WSL distro', async () => {
+    const sha = 'a'.repeat(40)
+    resolveOnly([sha])
+
+    await expect(
+      prefetchWorktreeCreateBase({ repo, baseBranch: sha, runtime: runtime(), gitOptions: WSL })
+    ).resolves.toBe(sha)
+
+    expect(mocks.gitExecFileAsync).toHaveBeenCalledWith(revParse(sha), {
+      cwd: repo.path,
+      ...WSL
+    })
+    expect(mocks.fetchRemoteWithCache).not.toHaveBeenCalled()
+  })
+
+  it('routes the exact remote-base refresh through the selected WSL distro', async () => {
+    const remoteTrackingBase = {
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    }
+    mocks.resolveRemoteTrackingBase.mockResolvedValue(remoteTrackingBase)
+    mocks.hasRemoteTrackingRef.mockResolvedValue(true)
+
+    await expect(
+      prefetchWorktreeCreateBase({
+        repo,
+        baseBranch: 'origin/main',
+        runtime: runtime(),
+        gitOptions: WSL
+      })
+    ).resolves.toBe('origin/main')
+
+    expect(mocks.hasRemoteTrackingRef).toHaveBeenCalledWith(repo.path, remoteTrackingBase, WSL)
+    expect(mocks.getOrStartRemoteTrackingBaseRefresh).toHaveBeenCalledWith(
+      repo.path,
+      remoteTrackingBase,
+      WSL
+    )
+  })
+
+  it('routes the broad remote-fetch fallback through the selected WSL distro', async () => {
+    await expect(
+      prefetchWorktreeCreateBase({
+        repo,
+        baseBranch: 'feature/topic',
+        runtime: runtime(),
+        gitOptions: WSL
+      })
+    ).resolves.toBe('feature/topic')
+
+    expect(mocks.fetchRemoteWithCache).toHaveBeenCalledWith(repo.path, 'origin', WSL)
+  })
+
+  it('leaves host-routed probes on the git host they used before routing existed', async () => {
+    await expect(
+      prefetchWorktreeCreateBase({
+        repo,
+        baseBranch: 'feature/topic',
+        runtime: runtime(),
+        gitOptions: {}
+      })
+    ).resolves.toBe('feature/topic')
+
+    expect(mocks.gitExecFileAsync).toHaveBeenCalledWith(revParse('refs/remotes/feature/topic'), {
+      cwd: repo.path
+    })
+    for (const call of mocks.gitExecFileAsync.mock.calls) {
+      expect(call[1]).toEqual({ cwd: repo.path })
+    }
+    // Runtime calls keep their original arity so host repos stay on the runtime's own defaults.
+    expect(mocks.resolveRemoteTrackingBase).toHaveBeenCalledWith(repo.path, 'feature/topic')
+    expect(mocks.fetchRemoteWithCache).toHaveBeenCalledWith(repo.path, 'origin')
+  })
+
+  it('does not resolve a local base for SSH repos', async () => {
+    const provider = { exec: vi.fn() }
+    mocks.getSshGitProvider.mockReturnValue(provider)
+
+    await expect(
+      prefetchWorktreeCreateBase({
+        repo: { ...repo, connectionId: 'conn-1' },
+        baseBranch: 'origin/main',
+        runtime: runtime(),
+        gitOptions: WSL
+      })
+    ).resolves.toBeUndefined()
+
+    expect(mocks.prefetchRemoteWorktreeCreateBase).toHaveBeenCalledWith(
+      provider,
+      expect.objectContaining({ connectionId: 'conn-1' }),
+      { baseBranch: 'origin/main' }
+    )
+    expect(mocks.gitExecFileAsync).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/worktree-create-base-prefetch.ts
+++ b/src/main/worktree-create-base-prefetch.ts
@@ -1,12 +1,15 @@
 import { isFolderRepo } from '../shared/repo-kind'
 import type { Repo } from '../shared/repo-types'
-import { hasLocalCommitObject, isFullGitObjectId } from './git/commit-object-ref'
-import { hasWorktreeBaseCommitRef } from './git/worktree-base-ref-probe'
+import { isFullGitObjectId } from './git/commit-object-ref'
+import { hasLocalWorktreeBaseRef } from './git/worktree-base-ref-probe'
 import { getBaseRefDefault } from './git/repo'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
 import { prefetchRemoteWorktreeCreateBase } from './ipc/worktree-remote'
 import { resolveWorktreeCreateBase } from './worktree-create-base'
-import { resolveWorktreeAddBaseRef } from '../shared/worktree/base-ref'
+
+type WorktreeCreateBaseGitOptions = {
+  wslDistro?: string
+}
 
 type RemoteTrackingBaseForPrefetch = {
   remote: string
@@ -18,49 +21,51 @@ type RemoteTrackingBaseForPrefetch = {
 type WorktreeCreateBasePrefetchRuntime = {
   resolveRemoteTrackingBase: (
     repoPath: string,
-    baseBranch: string
+    baseBranch: string,
+    options?: WorktreeCreateBaseGitOptions
   ) => Promise<RemoteTrackingBaseForPrefetch | null>
-  hasRemoteTrackingRef: (repoPath: string, base: RemoteTrackingBaseForPrefetch) => Promise<boolean>
+  hasRemoteTrackingRef: (
+    repoPath: string,
+    base: RemoteTrackingBaseForPrefetch,
+    options?: WorktreeCreateBaseGitOptions
+  ) => Promise<boolean>
   getOrStartRemoteTrackingBaseRefresh: (
     repoPath: string,
-    base: RemoteTrackingBaseForPrefetch
+    base: RemoteTrackingBaseForPrefetch,
+    options?: WorktreeCreateBaseGitOptions
   ) => Promise<unknown>
-  fetchRemoteWithCache: (repoPath: string, remote: string) => Promise<void>
-}
-
-async function hasLocalWorktreeBaseRef(repoPath: string, baseRef: string): Promise<boolean> {
-  const refExists = (qualifiedRef: string) => hasWorktreeBaseCommitRef(repoPath, qualifiedRef)
-  const resolvedBaseRef = await resolveWorktreeAddBaseRef(baseRef, refExists)
-  if (resolvedBaseRef !== baseRef) {
-    return true
-  }
-  if (baseRef.startsWith('refs/')) {
-    return refExists(baseRef)
-  }
-  return hasLocalCommitObject(repoPath, baseRef)
+  fetchRemoteWithCache: (
+    repoPath: string,
+    remote: string,
+    options?: WorktreeCreateBaseGitOptions
+  ) => Promise<void>
 }
 
 async function prefetchLocalWorktreeCreateBase(
   repo: Repo,
   baseBranch: string | undefined,
-  runtime: WorktreeCreateBasePrefetchRuntime
+  runtime: WorktreeCreateBasePrefetchRuntime,
+  options: WorktreeCreateBaseGitOptions
 ): Promise<string | undefined> {
+  // Keep host-routed calls at their original arity so they stay on the runtime's default options.
+  const optionArgs: [] | [WorktreeCreateBaseGitOptions] = options.wslDistro ? [options] : []
   const resolvedBaseBranch = await resolveWorktreeCreateBase({
     requestedBaseBranch: baseBranch,
     repoWorktreeBaseRef: repo.worktreeBaseRef,
-    resolveDefaultBaseRef: () => getBaseRefDefault(repo.path),
+    resolveDefaultBaseRef: () => getBaseRefDefault(repo.path, ...optionArgs),
     isBaseUsable: async (baseBranchCandidate) => {
       const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
         repo.path,
-        baseBranchCandidate
+        baseBranchCandidate,
+        ...optionArgs
       )
       if (remoteTrackingBase) {
-        if (await runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase)) {
+        if (await runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase, ...optionArgs)) {
           return true
         }
-        return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate)
+        return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate, options)
       }
-      return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate)
+      return hasLocalWorktreeBaseRef(repo.path, baseBranchCandidate, options)
     }
   })
   if (!resolvedBaseBranch) {
@@ -68,28 +73,37 @@ async function prefetchLocalWorktreeCreateBase(
   }
   if (
     isFullGitObjectId(resolvedBaseBranch) &&
-    (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch))
+    (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch, options))
   ) {
     return resolvedBaseBranch
   }
-  const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(repo.path, resolvedBaseBranch)
+  const remoteTrackingBase = await runtime.resolveRemoteTrackingBase(
+    repo.path,
+    resolvedBaseBranch,
+    ...optionArgs
+  )
   if (remoteTrackingBase) {
     if (
-      (await runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase)) ||
-      !(await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch))
+      (await runtime.hasRemoteTrackingRef(repo.path, remoteTrackingBase, ...optionArgs)) ||
+      !(await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch, options))
     ) {
-      await runtime.getOrStartRemoteTrackingBaseRefresh(repo.path, remoteTrackingBase)
+      await runtime.getOrStartRemoteTrackingBaseRefresh(
+        repo.path,
+        remoteTrackingBase,
+        ...optionArgs
+      )
       return resolvedBaseBranch
     }
   }
-  if (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch)) {
+  if (await hasLocalWorktreeBaseRef(repo.path, resolvedBaseBranch, options)) {
     // Why: hosted-review start points and local branch bases are already local; a broad remote fetch cannot make them fresher.
     return resolvedBaseBranch
   }
 
-  // Why: keep optimistic prefetch on the same best-effort fallback path as
-  // create so the real create can reuse the runtime's remote fetch cache.
-  await runtime.fetchRemoteWithCache(repo.path, 'origin')
+  // Why: same best-effort fallback create takes, on create's own fetch key, so a
+  // create that lands here reuses this fetch instead of repeating it. A create
+  // that instead resolves an exact remote base still queues behind it.
+  await runtime.fetchRemoteWithCache(repo.path, 'origin', ...optionArgs)
   return resolvedBaseBranch
 }
 
@@ -97,6 +111,9 @@ export async function prefetchWorktreeCreateBase(args: {
   repo: Repo
   baseBranch?: string
   runtime: WorktreeCreateBasePrefetchRuntime
+  /** Routing for the project's Git host; required so a caller cannot silently
+   *  warm up the wrong ref store — pass `{}` for host Git. */
+  gitOptions: WorktreeCreateBaseGitOptions
 }): Promise<string | undefined> {
   if (isFolderRepo(args.repo)) {
     return undefined
@@ -109,5 +126,5 @@ export async function prefetchWorktreeCreateBase(args: {
     await prefetchRemoteWorktreeCreateBase(provider, args.repo, { baseBranch: args.baseBranch })
     return undefined
   }
-  return prefetchLocalWorktreeCreateBase(args.repo, args.baseBranch, args.runtime)
+  return prefetchLocalWorktreeCreateBase(args.repo, args.baseBranch, args.runtime, args.gitOptions)
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​497 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​33 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​464 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​136 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​137 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 |

<!-- /orca-pr-loc -->

Opening the "new worktree" composer starts a speculative warm-up that resolves the base ref, fetches, and prepares a checkout so that clicking Create is fast. On Windows with a WSL project runtime that warm-up resolved refs and fetched with **host** Git, while the checkout preparation it feeds (`prepareWorktreeCreateForRepo`, which resolves `{ wslDistro }` itself at `worktree-create-preparation.ts:165`) and the real create path both run **inside the distro**. Because `getCanonicalFetchKey` namespaces the runtime's remote-fetch cache `wsl:<distro>` vs `local` (`orca-runtime.ts:28503`), the warm-up's `git fetch` was recorded under `local::<repo>::origin` while create looks under `wsl:<distro>::<repo>::origin` — so create fetched again and the warm-up bought nothing. On a Windows host with no usable Windows-side Git (WSL-only Git install) every warm-up probe failed outright and the warm-up produced nothing at all.

This threads the project's worktree Git options through `prefetchWorktreeCreateBase` so every probe and fetch runs where create runs. `gitOptions` is a **required** parameter of `prefetchWorktreeCreateBase`, so a caller cannot drop the routing silently, and both call sites (the IPC handler and the `prefetchManagedWorktreeCreateBase` RPC method) pass it.

## What changes for users

- **macOS** — No change. The resolved options are `{}`, so `options.wslDistro ? [options] : []` keeps runtime calls 2-arg and `gitExecFileAsync` still receives exactly `{ cwd }`. Byte-identical argv and arity.
- **Linux** — No change, same mechanism.
- **Native Windows (project runtime is the Windows host)** — No change. Runtime resolution returns a non-WSL runtime, options are `{}`, same argv and arity as before.
- **WSL on Windows** — The only cohort that changes. The warm-up's `git fetch` now lands on create's fetch key, so a create that takes the broad-fetch fallback reuses it instead of repeating it. On a host with no usable Windows-side Git, the warm-up's probes now resolve at all, where before every one failed. For a repo under `\\wsl.localhost\<distro>\...` the probes were *already* routed by cwd (`wsl-command-resolution.ts:77-79` derives the distro from cwd first), and for a repo on a Windows drive letter `C:\code\repo` and `/mnt/c/code/repo` are the same on-disk repository — so ref answers were already correct for both; what those two cohorts gain is only the reusable fetch. Costs below.
- **SSH remote repo** — No change. `prefetchWorktreeCreateBase` returns via the SSH provider branch before any option is read, and `resolveLocalProjectRuntimeForRepo` short-circuits on `getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID`, so an SSH repo does not even scan projects.
- **Relay / remote client driving a host** — No wire change: no RPC params, stream frames, or published content changed, so mixed client/host versions are unaffected. The host-side effect is whatever its own platform line above says — a relay client attached to a Windows+WSL host gets the WSL behavior, and to any other host, nothing.
- **Folder workspace** — No change. `prefetchWorktreeCreateBase` returns `undefined` for folder repos, and `getWorktreeCreatePrefetchGitOptions` short-circuits on `isFolderRepo` without resolving a runtime at all (asserted: `getProjects` is not called).

Git argv is unchanged everywhere, so the Git 2.25 baseline is untouched — no new subcommand, flag, or capability probe.

## What this does NOT do

- **Does not unify the fetch cache namespaces.** `getCanonicalFetchKey` still keys `wsl:<distro>` vs `local`. This makes the warm-up land in the right namespace; it does not remove the namespace split, so a project that switches runtimes still starts cold.
- **Does not de-queue the speculative fetch.** `getOrStartRemoteFetch` and create's exact-base refresh still share one per-`remoteKey` FIFO (`enqueueRemoteFetch`). Removing the warm-up's fetch from that queue would make it unusable by create, which is the point of the change.
- **Does not route any other speculative path.** Only the create-base prefetch. Workspace-cleanup scans, status polling, and the other `probeWorktreeBaseRefPresence` callers are untouched.
- **Does not change `prepareWorktreeCreateForRepo`, the remote/SSH prefetch (`prefetchRemoteWorktreeCreateBase`), or `createLocalWorktree`'s own routing.** They already resolve their own options; this PR only stops the base-resolution half from disagreeing with them.
- **Does not add a real-WSL integration or e2e test.** Coverage is unit-level with `gitExecFileAsync` mocked; the assertion is on the options each call receives, not on wsl.exe behavior.
- **Does not add a host-Git fast path for drive-letter repos** even though host Git reads the same repository faster (see costs).
- **Sibling slices cut alongside this one** (WSL linked-worktree route caching, async workspace root, git metadata resolver, GitLab known-host probe, worktree symlink guard) are separate PRs and are not in this diff.

## Costs and residual risk

1. **Drive-letter WSL repos pay drvfs on every probe.** For a WSL-routed project at `C:\code\repo`, `getBaseRefDefault` and the ref probes now execute inside the distro over `/mnt/c` instead of host Git reading the same directory natively. Per-probe latency goes up; the base-ref probe has a 15s timeout and can run up to 5 sequential probes. This is a configuration made *worse* — it buys a reusable fetch and pays slower probes.
2. **A new awaited step for that same cohort.** Every warm-up git call now satisfies `isWslLinkedWorktreeGitRoutingCandidate(cwd, wslDistro)` (win32 && wslDistro && `/^[A-Za-z]:[/\\]/`), so `gitExecFileAsyncUnlocked` now `await`s `prepareWslLinkedWorktreeGitRouting` — a parent-walking filesystem probe. The warm-up could never reach it before, because it requires a `wslDistro`. Bounded at 5s, cached 30s, shared with create.
3. **UNC repos change shell for non-direct-read commands.** `useWslLoginShell: Boolean(options.wslDistro)` (`git-command-resolution.ts:117`), so commands that do not take the direct-git read route — notably `fetch` — now run through the distro's login shell instead of `bash -c`. Checked: `rev-parse`, `symbolic-ref` and `remote` all take the direct-git read route, so no stdout we parse newly picks up rc/banner output.
4. **The speculative fetch can now delay create on WSL.** Both sit on the same per-remote FIFO, so if the user changes the base between the composer opening and clicking Create, create's exact-base refresh can wait behind the speculative broad fetch — bounded by the existing 60s `REMOTE_FETCH_TIMEOUT_MS`. This is not new to Orca (macOS/Linux/native-Windows have always had it, both sides passing `{}`), but it *is* new to WSL.
5. **Mapped network drives can lose the warm-up.** `translateArgForWsl` turns `Z:\repo` into `/mnt/z/repo`, which WSL does not auto-mount. For a WSL-routed project on a mapped drive the warm-up's probes will now fail where host Git succeeded, so the warm-up produces nothing. Create itself already routed into the distro for such a project, so this narrows a warm-up that create could not have used anyway — but it is a strictly reduced capability for that configuration.
6. **A WSL-only-Git host gets speculative work it never used to do.** That cohort's probes now succeed, so `prepareWorktreeCreateForRepo` actually runs a speculative checkout preparation for it: real disk and CPU while the composer is merely open. That is the intended benefit and also a new cost.
7. **Repair-required runtimes silently keep the old, wrong-host behavior.** `getWorktreeCreatePrefetchGitOptions` returns `{}` for any runtime whose status is not `resolved`, so a project stuck in repair keeps host-Git base resolution rather than surfacing an error. Deliberate (an optimistic warm-up must not report a failure) but it means a misconfigured runtime is invisible on this path.
8. **A future runtime status would default to host Git.** The guard is `status !== 'resolved'`, matching `getWorktreeMirrorDistro`. A new status that *should* route would silently not.
9. **Coverage is honestly partial on the deduped helper.** The three byte-equivalent copies of `hasLocalWorktreeBaseRef` collapse into one in `git/worktree-base-ref-probe.ts`, which now serves three call paths. I added the first routing assertions for the create-path consumers, but only 3 of its 6 call sites in `worktree-remote.ts` are mutation-covered (see Verification); the runtime-absent and second-fallback branches still rest on reading. This gap predates the commit (it existed identically against `hasLocalWorktreeBaseRefWithOptions`), and is narrowed, not closed.
10. **`hasLocalCommitObject` is deleted.** It was the host-only helper that caused the bug and has zero remaining references, but it was an exported symbol.
11. **`pnpm tc` was not run in this workspace** (excluded by the process that produced this change); typecheck runs separately before merge. The widened contract is `gitOptions` becoming a required parameter of `prefetchWorktreeCreateBase` plus optional third params on the structural runtime type, which the runtime's own four methods already satisfy (`gitOptions: { wslDistro?: string } = {}`).

## Verification

All commands run from the slice worktree. `git status --porcelain` is empty at the final commit.

**Suites**

- `npx vitest run src/main/ipc/worktree src/main/ipc/worktrees src/main/git/worktree src/main/git/commit-object-ref src/main/project-runtime-git-options src/main/worktree-create src/main/runtime/orca-runtime-create-base-prefetch.test.ts` → **83 files (82 passed, 1 skipped), 895 tests (894 passed, 1 skipped)**.
- `npx vitest run src/main/git` → **192 files: 189 passed, 1 failed, 2 skipped; 2190 tests: 2184 passed, 1 failed, 5 skipped.** The single failure is `command-runner/git-admission-storm-measurement.test.ts` (`ENOENT scandir` on its own temp state dir). It is in untouched `command-runner/`, fails when run alone at this commit, and was confirmed on clean `origin/main` in review.
- `npx vitest run src/main/runtime src/main/ipc` → **885 files: 881 passed, 2 failed, 2 skipped; 9532 tests: 9508 passed, 4 failed, 20 skipped.** The 4 failures are `orca-runtime-skill-recovery.test.ts` (2) and `quarter-circle-title-send-authorization.test.ts` (2). I verified they are pre-existing by checking out `HEAD~1`'s `orca-runtime.ts` and `commit-object-ref.ts` in place and re-running those two files: identical 4 failures.

**Lint/format** — `npx oxfmt --write` then `npx oxlint` over all 13 changed files: no reformatting, exit 0.

**Mutation verification** (each production hunk reverted, test run, then restored; every number below measured in this workspace, not inherited from review):

| Mutation | Result |
| --- | --- |
| Drop `gitOptions` from the RPC method `prefetchManagedWorktreeCreateBase` | 3 of 4 fail in `runtime/orca-runtime-create-base-prefetch.test.ts` |
| IPC handler passes `gitOptions: {}` | 2 fail in `ipc/worktrees-wsl-runtime-routing.test.ts` |
| Shared `hasLocalWorktreeBaseRef` ignores its `options` argument | 6 fail across 4 files (`worktree-base-ref-probe`, `worktree-create-base-prefetch`, `worktrees-wsl-runtime-routing`, `orca-runtime-create-base-prefetch`) |
| Remove the `isFolderRepo` early return | 1 fails in `project-runtime-git-options.test.ts` |
| Remove the `status !== 'resolved'` guard (the finding-3 fix) | 1 fails: "falls back to host git instead of throwing when the runtime needs repair" |
| Always pass `[options]`, breaking host arity | 1 fails in `worktree-create-base-prefetch.test.ts` |
| Create-path call sites of the shared probe, one at a time: `worktree-remote.ts:2032` / `:2065` / `:2094` | each fails `worktrees-wsl-runtime-routing.test.ts` |
| Same, at `:2035` / `:2069` / `:2103` | **not detected** — the runtime-absent and second-fallback branches, disclosed in cost 9 above |

---

### Rebase note

Rebasing onto current `main` conflicted in `src/main/runtime/orca-runtime.ts`, which `main` has since split into a 58-line barrel. `prefetchManagedWorktreeCreateBase` now lives in `orca-runtime-get-worktree-terminal-provisioning-host.ts` and the hunk was re-derived there.

Worth calling out for reviewers: the split had also extracted this PR's third duplicate of `hasLocalWorktreeBaseRef` into `runtime-worktree-create-git.ts` under a new exported name. Resolving the conflict by taking the barrel verbatim would have left that copy alive, silently shipping "collapse three byte-equivalent copies into one" as two-of-three. It is deleted explicitly.

### Native-Windows verification (awin)

Node 24, WSL distros `Ubuntu-24.04` and `Sta4593-Federated`:

`npx vitest run src/main/worktree-create-base-prefetch.test.ts src/main/ipc/worktrees-wsl-runtime-routing.test.ts src/main/project-runtime-git-options.test.ts src/main/git/worktree-base-ref-probe.test.ts src/main/git/commit-object-ref.test.ts src/main/runtime/orca-runtime-create-base-prefetch.test.ts` → **6 files, 45 tests passed**.
