### PR TITLE
feat(native-chat): local attachments in the composer on Remote Orca Server panes

### DIFF
--- a/src/main/runtime/rpc/methods/clipboard.ts
+++ b/src/main/runtime/rpc/methods/clipboard.ts
@@ -7,8 +7,10 @@ import {
   CLIPBOARD_IMAGE_TOO_LARGE_ERROR
 } from '../../../../shared/clipboard-image'
 
+import { CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS } from '../../../../shared/clipboard-image-upload-protocol'
+
 const MAX_CLIPBOARD_IMAGE_BASE64_CHARS = CLIPBOARD_IMAGE_MAX_BASE64_CHARS
-export const CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
+export { CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS }
 export const CLIPBOARD_IMAGE_UPLOAD_MAX_CONCURRENT = 8
 const CLIPBOARD_IMAGE_UPLOAD_TTL_MS = 5 * 60 * 1000
 const BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -648,6 +648,10 @@ describe('registerClipboardHandlers', () => {
     }
   })
 
+  // Routing decisions only in this file — chunk/abort/fallback protocol
+  // mechanics are pinned by clipboard-runtime-image-upload.test.ts and the
+  // web preload clipboard tests, both driving the shared protocol module.
+
   it('saves clipboard images through the selected remote runtime host', async () => {
     const png = Buffer.alloc(512 * 1024)
     const contentBase64 = png.toString('base64')
@@ -656,26 +660,16 @@ describe('registerClipboardHandlers', () => {
       isEmpty: () => false,
       toPNG: () => png
     })
-    callRuntimeEnvironmentMock.mockImplementation(async (_userDataPath, _runtimeId, method) => {
-      if (method === 'clipboard.startImageUpload') {
-        return { ok: true, result: { uploadId: 'upload-1' }, _meta: { runtimeId: 'runtime-1' } }
-      }
-      if (method === 'clipboard.appendImageUploadChunk') {
-        return {
-          ok: true,
-          result: { receivedBase64Length: contentBase64.length },
-          _meta: { runtimeId: 'runtime-1' }
-        }
-      }
-      if (method === 'clipboard.commitImageUpload') {
-        return {
-          ok: true,
-          result: '/tmp/orca-paste-remote.png',
-          _meta: { runtimeId: 'runtime-1' }
-        }
-      }
-      throw new Error(`unexpected method: ${method}`)
-    })
+    callRuntimeEnvironmentMock.mockImplementation(async (_userDataPath, _runtimeId, method) => ({
+      ok: true,
+      result:
+        method === 'clipboard.startImageUpload'
+          ? { uploadId: 'upload-1' }
+          : method === 'clipboard.commitImageUpload'
+            ? '/tmp/orca-paste-remote.png'
+            : { receivedBase64Length: contentBase64.length },
+      _meta: { runtimeId: 'runtime-1' }
+    }))
 
     registerClipboardHandlers({} as never)
 
@@ -693,38 +687,32 @@ describe('registerClipboardHandlers', () => {
       { expectedBase64Length: contentBase64.length, connectionId: null },
       30_000
     )
-    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
-      2,
-      '/tmp',
-      'remote-host-1',
-      'clipboard.appendImageUploadChunk',
-      {
-        uploadId: 'upload-1',
-        offset: 0,
-        contentBase64: contentBase64.slice(0, 512 * 1024)
-      },
-      30_000
-    )
-    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
-      3,
-      '/tmp',
-      'remote-host-1',
-      'clipboard.appendImageUploadChunk',
-      {
-        uploadId: 'upload-1',
-        offset: 512 * 1024,
-        contentBase64: contentBase64.slice(512 * 1024, 1024 * 1024)
-      },
-      30_000
-    )
-    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
-      4,
-      '/tmp',
-      'remote-host-1',
-      'clipboard.commitImageUpload',
-      { uploadId: 'upload-1' },
-      30_000
-    )
+    expect(fsWriteFileMock).not.toHaveBeenCalled()
+    expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a failed runtime upload instead of saving on a client-reachable host', async () => {
+    clipboardReadImageMock.mockReturnValue({
+      getSize: () => ({ height: 1, width: 1 }),
+      isEmpty: () => false,
+      toPNG: () => Buffer.from([0, 1, 2, 3])
+    })
+    callRuntimeEnvironmentMock.mockResolvedValue({
+      ok: false,
+      error: { code: 'runtime_error', message: 'runtime unreachable' },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+
+    registerClipboardHandlers({} as never)
+
+    const handlers = getRegisteredHandlers()
+    await expect(
+      handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), {
+        runtimeEnvironmentId: 'remote-host-1',
+        connectionId: 'ssh-jetson'
+      })
+    ).rejects.toThrow('runtime unreachable')
+    // A wrong-host fallback here is exactly the bug #17679 fixes.
     expect(fsWriteFileMock).not.toHaveBeenCalled()
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
   })
@@ -769,9 +757,6 @@ describe('registerClipboardHandlers', () => {
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
     expect(fsWriteFileMock).not.toHaveBeenCalled()
   })
-
-  // Chunk/abort/fallback mechanics live in clipboard-runtime-image-upload.test.ts;
-  // this file owns the routing decision only.
 
   it('uploads clipboard images to the SSH host when a connection is provided', async () => {
     const png = Buffer.from([0, 1, 2, 3])

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -729,47 +729,49 @@ describe('registerClipboardHandlers', () => {
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
   })
 
-  it('aborts remote runtime clipboard image uploads when a chunk fails', async () => {
-    const png = Buffer.alloc(512 * 1024)
+  it('routes runtime-owned pastes with a server-owned SSH connection through the runtime', async () => {
+    const png = Buffer.from([0, 1, 2, 3])
+    const contentBase64 = png.toString('base64')
     clipboardReadImageMock.mockReturnValue({
       getSize: () => ({ height: 1, width: 1 }),
       isEmpty: () => false,
       toPNG: () => png
     })
-    callRuntimeEnvironmentMock.mockImplementation(async (_userDataPath, _runtimeId, method) => {
-      if (method === 'clipboard.startImageUpload') {
-        return { ok: true, result: { uploadId: 'upload-1' }, _meta: { runtimeId: 'runtime-1' } }
-      }
-      if (method === 'clipboard.appendImageUploadChunk') {
-        return {
-          ok: false,
-          error: { code: 'runtime_error', message: 'append failed' },
-          _meta: { runtimeId: 'runtime-1' }
-        }
-      }
-      if (method === 'clipboard.abortImageUpload') {
-        return { ok: true, result: { aborted: true }, _meta: { runtimeId: 'runtime-1' } }
-      }
-      throw new Error(`unexpected method: ${method}`)
-    })
+    callRuntimeEnvironmentMock.mockImplementation(async (_userDataPath, _runtimeId, method) => ({
+      ok: true,
+      result:
+        method === 'clipboard.startImageUpload'
+          ? { uploadId: 'upload-1' }
+          : method === 'clipboard.commitImageUpload'
+            ? '/tmp/orca-paste-jetson.png'
+            : { receivedBase64Length: contentBase64.length },
+      _meta: { runtimeId: 'runtime-1' }
+    }))
 
     registerClipboardHandlers({} as never)
 
     const handlers = getRegisteredHandlers()
     await expect(
       handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), {
-        runtimeEnvironmentId: 'remote-host-1'
+        runtimeEnvironmentId: 'remote-host-1',
+        connectionId: 'ssh-jetson'
       })
-    ).rejects.toThrow('append failed')
-    expect(callRuntimeEnvironmentMock).toHaveBeenLastCalledWith(
+    ).resolves.toBe('/tmp/orca-paste-jetson.png')
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      1,
       '/tmp',
       'remote-host-1',
-      'clipboard.abortImageUpload',
-      { uploadId: 'upload-1' },
+      'clipboard.startImageUpload',
+      { expectedBase64Length: contentBase64.length, connectionId: 'ssh-jetson' },
       30_000
     )
+    // The connection is server-owned: the client's SSH stack must never see it.
+    expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
     expect(fsWriteFileMock).not.toHaveBeenCalled()
   })
+
+  // Chunk/abort/fallback mechanics live in clipboard-runtime-image-upload.test.ts;
+  // this file owns the routing decision only.
 
   it('uploads clipboard images to the SSH host when a connection is provided', async () => {
     const png = Buffer.from([0, 1, 2, 3])

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -61,7 +61,7 @@ async function saveClipboardImageBufferForTarget(
       app.getPath('userData'),
       runtimeEnvironmentId,
       buffer,
-      args?.connectionId ?? null
+      args?.connectionId?.trim() || null
     )
   }
   return saveClipboardImageBufferAsTempFile(buffer, args)

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -53,8 +53,16 @@ async function saveClipboardImageBufferForTarget(
 ): Promise<string> {
   assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
   const runtimeEnvironmentId = args?.runtimeEnvironmentId?.trim()
-  if (runtimeEnvironmentId && !args?.connectionId) {
-    return saveClipboardImageBufferInRuntime(app.getPath('userData'), runtimeEnvironmentId, buffer)
+  if (runtimeEnvironmentId) {
+    // A connectionId alongside a runtime owner names a SERVER-owned SSH
+    // connection (nested topology) — the runtime forwards over its own SFTP;
+    // the client's SSH stack has no such connection (#17679).
+    return saveClipboardImageBufferInRuntime(
+      app.getPath('userData'),
+      runtimeEnvironmentId,
+      buffer,
+      args?.connectionId ?? null
+    )
   }
   return saveClipboardImageBufferAsTempFile(buffer, args)
 }

--- a/src/main/window/clipboard-runtime-image-upload.test.ts
+++ b/src/main/window/clipboard-runtime-image-upload.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { callRuntimeEnvironmentMock } = vi.hoisted(() => ({
+  callRuntimeEnvironmentMock: vi.fn()
+}))
+
+vi.mock('../ipc/runtime-environment-transport-routing', () => ({
+  callRuntimeEnvironment: callRuntimeEnvironmentMock
+}))
+
+import { saveClipboardImageBufferInRuntime } from './clipboard-runtime-image-upload'
+
+function mockRuntimeUploadMethods(
+  overrides: Record<string, { ok: boolean; result?: unknown; error?: unknown }> = {}
+): void {
+  callRuntimeEnvironmentMock.mockImplementation(
+    async (_userDataPath, _runtimeId, method, params) => {
+      if (method in overrides) {
+        return { ...overrides[method], _meta: { runtimeId: 'runtime-1' } }
+      }
+      switch (method) {
+        case 'clipboard.startImageUpload':
+          return { ok: true, result: { uploadId: 'upload-1' }, _meta: { runtimeId: 'runtime-1' } }
+        case 'clipboard.appendImageUploadChunk':
+          return {
+            ok: true,
+            result: {
+              receivedBase64Length:
+                (params as { offset: number; contentBase64: string }).offset +
+                (params as { contentBase64: string }).contentBase64.length
+            },
+            _meta: { runtimeId: 'runtime-1' }
+          }
+        case 'clipboard.commitImageUpload':
+          return { ok: true, result: '/tmp/orca-paste-remote.png', _meta: { runtimeId: 'r-1' } }
+        case 'clipboard.abortImageUpload':
+          return { ok: true, result: { aborted: true }, _meta: { runtimeId: 'runtime-1' } }
+        default:
+          throw new Error(`unexpected method: ${method}`)
+      }
+    }
+  )
+}
+
+describe('saveClipboardImageBufferInRuntime', () => {
+  beforeEach(() => {
+    callRuntimeEnvironmentMock.mockReset()
+  })
+
+  it('starts the chunked upload with a null connection by default', async () => {
+    mockRuntimeUploadMethods()
+    const buffer = Buffer.from([0, 1, 2, 3])
+
+    await expect(saveClipboardImageBufferInRuntime('/data', 'env-1', buffer)).resolves.toBe(
+      '/tmp/orca-paste-remote.png'
+    )
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      1,
+      '/data',
+      'env-1',
+      'clipboard.startImageUpload',
+      { expectedBase64Length: buffer.toString('base64').length, connectionId: null },
+      30_000
+    )
+  })
+
+  it('threads a server-owned SSH connection into the chunked upload start', async () => {
+    mockRuntimeUploadMethods()
+    const buffer = Buffer.from([0, 1, 2, 3])
+
+    await expect(
+      saveClipboardImageBufferInRuntime('/data', 'env-1', buffer, 'ssh-jetson')
+    ).resolves.toBe('/tmp/orca-paste-remote.png')
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      1,
+      '/data',
+      'env-1',
+      'clipboard.startImageUpload',
+      { expectedBase64Length: buffer.toString('base64').length, connectionId: 'ssh-jetson' },
+      30_000
+    )
+  })
+
+  it('threads the connection into the single-frame fallback on older runtimes', async () => {
+    const buffer = Buffer.from([0, 1, 2, 3])
+    mockRuntimeUploadMethods({
+      'clipboard.startImageUpload': {
+        ok: false,
+        error: { code: 'method_not_found', message: 'unknown method' }
+      },
+      'clipboard.saveImageAsTempFile': { ok: true, result: '/tmp/orca-paste-remote.png' }
+    })
+
+    await expect(
+      saveClipboardImageBufferInRuntime('/data', 'env-1', buffer, 'ssh-jetson')
+    ).resolves.toBe('/tmp/orca-paste-remote.png')
+    expect(callRuntimeEnvironmentMock).toHaveBeenLastCalledWith(
+      '/data',
+      'env-1',
+      'clipboard.saveImageAsTempFile',
+      { contentBase64: buffer.toString('base64'), connectionId: 'ssh-jetson' },
+      30_000
+    )
+  })
+
+  it('aborts the upload when a chunk fails', async () => {
+    const buffer = Buffer.alloc(512 * 1024)
+    mockRuntimeUploadMethods({
+      'clipboard.appendImageUploadChunk': {
+        ok: false,
+        error: { code: 'runtime_error', message: 'append failed' }
+      }
+    })
+
+    await expect(saveClipboardImageBufferInRuntime('/data', 'env-1', buffer)).rejects.toThrow(
+      'append failed'
+    )
+    expect(callRuntimeEnvironmentMock).toHaveBeenLastCalledWith(
+      '/data',
+      'env-1',
+      'clipboard.abortImageUpload',
+      { uploadId: 'upload-1' },
+      30_000
+    )
+  })
+})

--- a/src/main/window/clipboard-runtime-image-upload.test.ts
+++ b/src/main/window/clipboard-runtime-image-upload.test.ts
@@ -81,6 +81,25 @@ describe('saveClipboardImageBufferInRuntime', () => {
     )
   })
 
+  it('normalizes a blank connection to null before forwarding', async () => {
+    // The runtime schema rejects '' (z.string().min(1)); a blank id means
+    // "no connection", exactly like the desktop IPC handler treats it.
+    mockRuntimeUploadMethods()
+    const buffer = Buffer.from([0, 1, 2, 3])
+
+    await expect(saveClipboardImageBufferInRuntime('/data', 'env-1', buffer, '  ')).resolves.toBe(
+      '/tmp/orca-paste-remote.png'
+    )
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      1,
+      '/data',
+      'env-1',
+      'clipboard.startImageUpload',
+      { expectedBase64Length: buffer.toString('base64').length, connectionId: null },
+      30_000
+    )
+  })
+
   it('threads the connection into the single-frame fallback on older runtimes', async () => {
     const buffer = Buffer.from([0, 1, 2, 3])
     mockRuntimeUploadMethods({

--- a/src/main/window/clipboard-runtime-image-upload.ts
+++ b/src/main/window/clipboard-runtime-image-upload.ts
@@ -27,13 +27,14 @@ async function callRuntimeClipboardMethod<TResult>(
 async function saveClipboardImageBase64InRuntime(
   userDataPath: string,
   runtimeEnvironmentId: string,
-  contentBase64: string
+  contentBase64: string,
+  connectionId: string | null
 ): Promise<string> {
   const startResponse = await callRuntimeEnvironment(
     userDataPath,
     runtimeEnvironmentId,
     'clipboard.startImageUpload',
-    { expectedBase64Length: contentBase64.length, connectionId: null },
+    { expectedBase64Length: contentBase64.length, connectionId },
     CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
   )
   if (!startResponse.ok) {
@@ -45,7 +46,7 @@ async function saveClipboardImageBase64InRuntime(
         userDataPath,
         runtimeEnvironmentId,
         'clipboard.saveImageAsTempFile',
-        { contentBase64, connectionId: null }
+        { contentBase64, connectionId }
       )
     }
     throw new Error(startResponse.error.message)
@@ -107,12 +108,14 @@ async function saveClipboardImageBase64InRuntime(
 export function saveClipboardImageBufferInRuntime(
   userDataPath: string,
   runtimeEnvironmentId: string,
-  buffer: Buffer
+  buffer: Buffer,
+  connectionId: string | null = null
 ): Promise<string> {
   assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
   return saveClipboardImageBase64InRuntime(
     userDataPath,
     runtimeEnvironmentId,
-    buffer.toString('base64')
+    buffer.toString('base64'),
+    connectionId
   )
 }

--- a/src/main/window/clipboard-runtime-image-upload.ts
+++ b/src/main/window/clipboard-runtime-image-upload.ts
@@ -1,109 +1,6 @@
 import { assertClipboardImageByteLengthWithinLimit } from '../../shared/clipboard-image'
+import { saveClipboardImageBase64ThroughRuntime } from '../../shared/clipboard-image-upload-protocol'
 import { callRuntimeEnvironment } from '../ipc/runtime-environment-transport-routing'
-
-const CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
-const CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS = 256 * 1024
-const CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS = 30_000
-
-async function callRuntimeClipboardMethod<TResult>(
-  userDataPath: string,
-  runtimeEnvironmentId: string,
-  method: string,
-  params: unknown
-): Promise<TResult> {
-  const response = await callRuntimeEnvironment(
-    userDataPath,
-    runtimeEnvironmentId,
-    method,
-    params,
-    CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-  )
-  if (!response.ok) {
-    throw new Error(response.error.message)
-  }
-  return response.result as TResult
-}
-
-async function saveClipboardImageBase64InRuntime(
-  userDataPath: string,
-  runtimeEnvironmentId: string,
-  contentBase64: string,
-  connectionId: string | null
-): Promise<string> {
-  const startResponse = await callRuntimeEnvironment(
-    userDataPath,
-    runtimeEnvironmentId,
-    'clipboard.startImageUpload',
-    { expectedBase64Length: contentBase64.length, connectionId },
-    CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-  )
-  if (!startResponse.ok) {
-    if (
-      startResponse.error.code === 'method_not_found' &&
-      contentBase64.length <= CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS
-    ) {
-      return callRuntimeClipboardMethod<string>(
-        userDataPath,
-        runtimeEnvironmentId,
-        'clipboard.saveImageAsTempFile',
-        { contentBase64, connectionId }
-      )
-    }
-    throw new Error(startResponse.error.message)
-  }
-  const result = startResponse.result
-  if (
-    !result ||
-    typeof result !== 'object' ||
-    typeof (result as { uploadId?: unknown }).uploadId !== 'string'
-  ) {
-    throw new Error('Remote clipboard image upload returned an invalid id')
-  }
-  const { uploadId } = result as { uploadId: string }
-  try {
-    for (
-      let offset = 0;
-      offset < contentBase64.length;
-      offset += CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
-    ) {
-      await callRuntimeClipboardMethod(
-        userDataPath,
-        runtimeEnvironmentId,
-        'clipboard.appendImageUploadChunk',
-        {
-          uploadId,
-          offset,
-          contentBase64: contentBase64.slice(
-            offset,
-            offset + CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
-          )
-        }
-      )
-    }
-    const remotePath = await callRuntimeClipboardMethod<string>(
-      userDataPath,
-      runtimeEnvironmentId,
-      'clipboard.commitImageUpload',
-      { uploadId }
-    )
-    if (typeof remotePath !== 'string') {
-      throw new Error('Remote clipboard image save returned an invalid path')
-    }
-    return remotePath
-  } catch (error) {
-    // Why: failed chunked pastes should release the remote upload slot
-    // immediately instead of waiting for TTL cleanup.
-    await callRuntimeClipboardMethod(
-      userDataPath,
-      runtimeEnvironmentId,
-      'clipboard.abortImageUpload',
-      {
-        uploadId
-      }
-    ).catch(() => {})
-    throw error
-  }
-}
 
 export function saveClipboardImageBufferInRuntime(
   userDataPath: string,
@@ -112,9 +9,9 @@ export function saveClipboardImageBufferInRuntime(
   connectionId: string | null = null
 ): Promise<string> {
   assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
-  return saveClipboardImageBase64InRuntime(
-    userDataPath,
-    runtimeEnvironmentId,
+  return saveClipboardImageBase64ThroughRuntime(
+    (method, params, timeoutMs) =>
+      callRuntimeEnvironment(userDataPath, runtimeEnvironmentId, method, params, timeoutMs),
     buffer.toString('base64'),
     connectionId
   )

--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -57,6 +57,9 @@ export type NativeChatComposerImageAttachment = {
   id: string
   path: string
   connectionId?: string
+  /** Set for runtime-owned attachments so the preview reads from the runtime,
+   *  not the client filesystem. */
+  runtime?: { runtimeEnvironmentId: string; worktreeId: string; worktreePath: string }
 }
 
 /**

--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -4,6 +4,7 @@ import { ImageOff } from 'lucide-react'
 import type { useImeEnterGestureOwnership } from '@/lib/ime-composition-keyboard-event'
 import { cn } from '@/lib/utils'
 import { NATIVE_FILE_DROP_TARGET } from '../../../../shared/native-file-drop'
+import type { NativeChatAttachedHost } from './native-chat-attachment-upload'
 import type { ComposerAutocomplete, NativeChatPickerItem } from './native-chat-composer-state'
 import { NativeChatMentionHint, NativeChatPickerMenu } from './NativeChatAutocompleteMenus'
 import { NativeChatComposerActions } from './NativeChatComposerActions'
@@ -59,7 +60,7 @@ export type NativeChatComposerImageAttachment = {
   connectionId?: string
   /** Set for runtime-owned attachments so the preview reads from the runtime,
    *  not the client filesystem. */
-  runtime?: { runtimeEnvironmentId: string; worktreeId: string; worktreePath: string }
+  runtime?: NonNullable<NativeChatAttachedHost['runtime']>
 }
 
 /**

--- a/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Image as ImageIcon, X } from 'lucide-react'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { translate } from '@/i18n/i18n'
 import { basename } from '@/lib/path'
 import { useLocalImageSrc } from '@/components/editor/useLocalImageSrc'
+import { settingsForRuntimeOwner } from '@/runtime/runtime-client-target'
+import { useAppStore } from '@/store'
 import { isNativeChatPastedImagePath } from './native-chat-image-paste'
 import type { NativeChatComposerImageAttachment } from './NativeChatComposerField'
 
@@ -41,10 +43,23 @@ export function NativeChatImageAttachmentPreview({
     observer.observe(element)
     return () => observer.disconnect()
   }, [])
+  const settings = useAppStore((s) => s.settings)
+  const runtimeContext = useMemo(
+    () =>
+      attachment.runtime
+        ? {
+            settings: settingsForRuntimeOwner(settings, attachment.runtime.runtimeEnvironmentId),
+            worktreeId: attachment.runtime.worktreeId,
+            worktreePath: attachment.runtime.worktreePath
+          }
+        : undefined,
+    [attachment.runtime, settings]
+  )
   const previewSrc = useLocalImageSrc(
     isNearViewport || isOpen ? attachment.path : undefined,
     attachment.path,
-    attachment.connectionId
+    attachment.connectionId,
+    runtimeContext
   )
   const filename = isNativeChatPastedImagePath(attachment.path)
     ? translate('components.native-chat.composer.pastedImageLabel', 'Pasted image')

--- a/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
@@ -4,8 +4,6 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/compone
 import { translate } from '@/i18n/i18n'
 import { basename } from '@/lib/path'
 import { useLocalImageSrc } from '@/components/editor/useLocalImageSrc'
-import { settingsForRuntimeOwner } from '@/runtime/runtime-client-target'
-import { useAppStore } from '@/store'
 import { isNativeChatPastedImagePath } from './native-chat-image-paste'
 import type { NativeChatComposerImageAttachment } from './NativeChatComposerField'
 
@@ -43,17 +41,19 @@ export function NativeChatImageAttachmentPreview({
     observer.observe(element)
     return () => observer.disconnect()
   }, [])
-  const settings = useAppStore((s) => s.settings)
+  // No store subscription: the owning environment id is pinned on the
+  // attachment, and rebuilding the context identity on unrelated settings
+  // writes would re-run the image-cache effects for every chip.
   const runtimeContext = useMemo(
     () =>
       attachment.runtime
         ? {
-            settings: settingsForRuntimeOwner(settings, attachment.runtime.runtimeEnvironmentId),
+            settings: { activeRuntimeEnvironmentId: attachment.runtime.runtimeEnvironmentId },
             worktreeId: attachment.runtime.worktreeId,
             worktreePath: attachment.runtime.worktreePath
           }
         : undefined,
-    [attachment.runtime, settings]
+    [attachment.runtime]
   )
   const previewSrc = useLocalImageSrc(
     isNearViewport || isOpen ? attachment.path : undefined,

--- a/src/renderer/src/components/native-chat/native-chat-attachment-upload.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-attachment-upload.test.ts
@@ -38,6 +38,7 @@ import {
   resolveNativeChatAttachmentOwnerForWorktree,
   uploadNativeChatAttachmentPaths,
   uploadNativeChatRuntimeAttachmentPaths,
+  nativeChatAttachmentOwnersMatch,
   type NativeChatRuntimeAttachmentOwner
 } from './native-chat-attachment-upload'
 
@@ -286,6 +287,55 @@ describe('uploadNativeChatAttachmentPaths', () => {
     await expect(uploadNativeChatAttachmentPaths(['/local/a.txt'], owner)).resolves.toBeNull()
     expect(mocks.toastError).toHaveBeenCalledTimes(1)
     expect(mocks.toastDismiss).toHaveBeenCalledWith('toast-1')
+  })
+})
+
+describe('nativeChatAttachmentOwnersMatch', () => {
+  const runtimeOwner: NativeChatRuntimeAttachmentOwner = {
+    kind: 'runtime',
+    runtimeEnvironmentId: 'env-1',
+    worktreeId: 'wt-1',
+    worktreePath: '/srv/wt',
+    connectionId: null,
+    expectedExecutionHostId: 'local'
+  }
+  const sshOwner = {
+    kind: 'ssh' as const,
+    connectionId: 'conn-1',
+    worktreePath: '/remote/wt',
+    expectedExecutionHostId: 'ssh:conn-1' as const,
+    expectedSshTargetId: 'conn-1',
+    expectedSshConnectionGeneration: 4
+  }
+
+  it('matches owners with identical host identity', () => {
+    expect(nativeChatAttachmentOwnersMatch({ kind: 'local' }, { kind: 'local' })).toBe(true)
+    expect(nativeChatAttachmentOwnersMatch(runtimeOwner, { ...runtimeOwner })).toBe(true)
+    expect(nativeChatAttachmentOwnersMatch(sshOwner, { ...sshOwner })).toBe(true)
+  })
+
+  it('rejects any host identity drift', () => {
+    expect(nativeChatAttachmentOwnersMatch(runtimeOwner, { kind: 'local' })).toBe(false)
+    expect(
+      nativeChatAttachmentOwnersMatch(runtimeOwner, {
+        ...runtimeOwner,
+        runtimeEnvironmentId: 'env-2'
+      })
+    ).toBe(false)
+    expect(
+      nativeChatAttachmentOwnersMatch(runtimeOwner, { ...runtimeOwner, connectionId: 'conn-1' })
+    ).toBe(false)
+    expect(
+      nativeChatAttachmentOwnersMatch(sshOwner, {
+        ...sshOwner,
+        expectedSshConnectionGeneration: 5
+      })
+    ).toBe(false)
+    // not-ready can never be verified as the same host.
+    expect(nativeChatAttachmentOwnersMatch(runtimeOwner, { kind: 'not-ready' })).toBe(false)
+    expect(nativeChatAttachmentOwnersMatch({ kind: 'not-ready' }, { kind: 'not-ready' })).toBe(
+      false
+    )
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-attachment-upload.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-attachment-upload.test.ts
@@ -7,7 +7,9 @@ const mocks = vi.hoisted(() => ({
   toastDismiss: vi.fn(),
   toastError: vi.fn(),
   toastMessage: vi.fn(),
-  resolveDroppedPathsForAgent: vi.fn()
+  resolveDroppedPathsForAgent: vi.fn(),
+  importExternalPathsToRuntime: vi.fn(),
+  getState: vi.fn(() => ({}))
 }))
 
 vi.mock('sonner', () => ({
@@ -23,10 +25,20 @@ vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
 }))
 
+vi.mock('@/runtime/runtime-file-client', () => ({
+  importExternalPathsToRuntime: mocks.importExternalPathsToRuntime
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState: mocks.getState }
+}))
+
 import {
   resolveNativeChatAttachmentOwner,
   resolveNativeChatAttachmentOwnerForWorktree,
-  uploadNativeChatAttachmentPaths
+  uploadNativeChatAttachmentPaths,
+  uploadNativeChatRuntimeAttachmentPaths,
+  type NativeChatRuntimeAttachmentOwner
 } from './native-chat-attachment-upload'
 
 function terminalTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
@@ -108,7 +120,7 @@ describe('resolveNativeChatAttachmentOwner', () => {
     })
   })
 
-  it('resolves a runtime-owned repo to runtime', () => {
+  it('resolves a runtime-owned repo to a full runtime owner', () => {
     expect(
       resolveNativeChatAttachmentOwner(
         state({
@@ -116,7 +128,29 @@ describe('resolveNativeChatAttachmentOwner', () => {
         }),
         'tab-1'
       )
-    ).toEqual({ kind: 'runtime' })
+    ).toEqual({
+      kind: 'runtime',
+      runtimeEnvironmentId: 'env-1',
+      worktreeId: 'wt-1',
+      worktreePath: '/repo/worktree',
+      connectionId: null,
+      expectedExecutionHostId: 'local'
+    })
+  })
+
+  it('carries the server-owned SSH connection on nested runtime worktrees', () => {
+    expect(
+      resolveNativeChatAttachmentOwner(
+        state({
+          repos: [{ id: 'repo', connectionId: 'conn-1', executionHostId: 'runtime:env-1' }] as never
+        }),
+        'tab-1'
+      )
+    ).toMatchObject({
+      kind: 'runtime',
+      runtimeEnvironmentId: 'env-1',
+      connectionId: 'conn-1'
+    })
   })
 
   it('routes unowned repos to the focused runtime host, matching terminal drops', () => {
@@ -125,7 +159,24 @@ describe('resolveNativeChatAttachmentOwner', () => {
         state({ settings: { activeRuntimeEnvironmentId: 'env-9' } as AppState['settings'] }),
         'tab-1'
       )
-    ).toEqual({ kind: 'runtime' })
+    ).toMatchObject({
+      kind: 'runtime',
+      runtimeEnvironmentId: 'env-9',
+      worktreePath: '/repo/worktree'
+    })
+  })
+
+  it('reports not-ready when a runtime worktree has no known path yet', () => {
+    expect(
+      resolveNativeChatAttachmentOwner(
+        state({
+          repos: [{ id: 'repo', connectionId: null, executionHostId: 'runtime:env-1' }] as never,
+          getKnownWorktreeById: () => undefined,
+          worktreesByRepo: { repo: [{ id: 'wt-1', repoId: 'repo' } as never] }
+        }),
+        'tab-1'
+      )
+    ).toEqual({ kind: 'not-ready' })
   })
 
   it('reports not-ready when the tab has no worktree owner', () => {
@@ -209,6 +260,84 @@ describe('uploadNativeChatAttachmentPaths', () => {
   it('returns null and reports when the upload IPC fails', async () => {
     mocks.resolveDroppedPathsForAgent.mockRejectedValue(new Error('sftp down'))
     await expect(uploadNativeChatAttachmentPaths(['/local/a.txt'], owner)).resolves.toBeNull()
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+    expect(mocks.toastDismiss).toHaveBeenCalledWith('toast-1')
+  })
+})
+
+describe('uploadNativeChatRuntimeAttachmentPaths', () => {
+  const owner: NativeChatRuntimeAttachmentOwner = {
+    kind: 'runtime',
+    runtimeEnvironmentId: 'env-1',
+    worktreeId: 'wt-1',
+    worktreePath: '/srv/wt',
+    connectionId: null,
+    expectedExecutionHostId: 'local'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('imports into the worktree drops dir on the owning runtime and returns dest paths', async () => {
+    mocks.importExternalPathsToRuntime.mockResolvedValue({
+      results: [
+        { sourcePath: '/local/a.png', status: 'imported', destPath: '/srv/wt/.orca/drops/a.png' },
+        { sourcePath: '/local/link', status: 'skipped', reason: 'symlink' },
+        { sourcePath: '/local/b.txt', status: 'failed', reason: 'boom' }
+      ]
+    })
+    await expect(
+      uploadNativeChatRuntimeAttachmentPaths(['/local/a.png', '/local/link', '/local/b.txt'], owner)
+    ).resolves.toEqual(['/srv/wt/.orca/drops/a.png'])
+    expect(mocks.importExternalPathsToRuntime).toHaveBeenCalledWith(
+      {
+        settings: { activeRuntimeEnvironmentId: 'env-1' },
+        worktreeId: 'wt-1',
+        worktreePath: '/srv/wt',
+        expectedExecutionHostId: 'local',
+        expectedSshTargetId: undefined,
+        expectedSshConnectionGeneration: undefined
+      },
+      ['/local/a.png', '/local/link', '/local/b.txt'],
+      '/srv/wt/.orca/drops',
+      { assertCurrent: expect.any(Function) }
+    )
+    // Skips and failures surface through the shared drop toasts.
+    expect(mocks.toastMessage).toHaveBeenCalledTimes(1)
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+    expect(mocks.toastDismiss).toHaveBeenCalledWith('toast-1')
+  })
+
+  it('fails the in-flight upload when the owner changed underneath it', async () => {
+    // Live store now says wt-1 belongs to a different environment.
+    mocks.getState.mockReturnValue({
+      folderWorkspaces: [],
+      getKnownWorktreeById: () => ({ id: 'wt-1', path: '/srv/wt' }),
+      projectGroups: [],
+      repos: [{ id: 'repo', connectionId: null, executionHostId: 'runtime:env-2' }],
+      settings: { activeRuntimeEnvironmentId: null },
+      sshConnectionStates: new Map(),
+      tabsByWorktree: {},
+      worktreesByRepo: { repo: [{ id: 'wt-1', repoId: 'repo', path: '/srv/wt' }] }
+    })
+    mocks.importExternalPathsToRuntime.mockImplementation(
+      async (_context, _paths, _dest, options) => {
+        options?.assertCurrent?.()
+        return { results: [] }
+      }
+    )
+    await expect(
+      uploadNativeChatRuntimeAttachmentPaths(['/local/a.png'], owner)
+    ).resolves.toBeNull()
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null and reports when the runtime import fails', async () => {
+    mocks.importExternalPathsToRuntime.mockRejectedValue(new Error('pairing dropped'))
+    await expect(
+      uploadNativeChatRuntimeAttachmentPaths(['/local/a.png'], owner)
+    ).resolves.toBeNull()
     expect(mocks.toastError).toHaveBeenCalledTimes(1)
     expect(mocks.toastDismiss).toHaveBeenCalledWith('toast-1')
   })

--- a/src/renderer/src/components/native-chat/native-chat-attachment-upload.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-attachment-upload.test.ts
@@ -167,6 +167,23 @@ describe('resolveNativeChatAttachmentOwner', () => {
     })
   })
 
+  it('resolves the worktree path from the catalog fallback while the index hydrates', () => {
+    // The tab entry path resolves via resolveNativeChatFileLinkContext, which
+    // falls back to worktreesByRepo when the known-worktree index is empty.
+    // The structured path (also used by the stale-owner assert's
+    // re-resolution) must use the same fallback, or a mid-upload assert would
+    // spuriously fail a legitimate attach as "host changed".
+    expect(
+      resolveNativeChatAttachmentOwnerForWorktree(
+        state({
+          repos: [{ id: 'repo', connectionId: null, executionHostId: 'runtime:env-1' }] as never,
+          getKnownWorktreeById: () => undefined
+        }),
+        'wt-1'
+      )
+    ).toMatchObject({ kind: 'runtime', worktreePath: '/repo/worktree' })
+  })
+
   it('reports not-ready when a runtime worktree connection has not hydrated', () => {
     // The worktree row (with its runtime owner) can land before the repos
     // array that carries the server-owned connectionId — attaching then could

--- a/src/renderer/src/components/native-chat/native-chat-attachment-upload.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-attachment-upload.test.ts
@@ -166,6 +166,30 @@ describe('resolveNativeChatAttachmentOwner', () => {
     })
   })
 
+  it('reports not-ready when a runtime worktree connection has not hydrated', () => {
+    // The worktree row (with its runtime owner) can land before the repos
+    // array that carries the server-owned connectionId — attaching then could
+    // save on the wrong nested host (#17679).
+    expect(
+      resolveNativeChatAttachmentOwnerForWorktree(
+        state({
+          repos: [],
+          worktreesByRepo: {
+            repo: [
+              {
+                id: 'wt-1',
+                repoId: 'repo',
+                path: '/repo/worktree',
+                runtimeOwnerEnvironmentId: 'env-1'
+              } as never
+            ]
+          }
+        }),
+        'wt-1'
+      )
+    ).toEqual({ kind: 'not-ready' })
+  })
+
   it('reports not-ready when a runtime worktree has no known path yet', () => {
     expect(
       resolveNativeChatAttachmentOwner(

--- a/src/renderer/src/components/native-chat/native-chat-attachment-upload.ts
+++ b/src/renderer/src/components/native-chat/native-chat-attachment-upload.ts
@@ -185,21 +185,53 @@ export async function uploadNativeChatAttachmentPaths(
   }
 }
 
+export const nativeChatAttachmentHostChangedMessage =
+  'Attachment upload host changed; retry the attach.'
+
+/**
+ * True when two owner snapshots name the same execution host. Used to fence
+ * async attach flows (uploads, clipboard saves) against the pane's ownership
+ * changing mid-flight — a path minted on the old host must never be attached
+ * for the new one. `not-ready` never matches: an unverifiable host is a
+ * changed host.
+ */
+export function nativeChatAttachmentOwnersMatch(
+  before: NativeChatAttachmentOwner,
+  after: NativeChatAttachmentOwner
+): boolean {
+  if (before.kind === 'local' && after.kind === 'local') {
+    return true
+  }
+  if (before.kind === 'ssh' && after.kind === 'ssh') {
+    return (
+      before.connectionId === after.connectionId &&
+      before.worktreePath === after.worktreePath &&
+      before.expectedExecutionHostId === after.expectedExecutionHostId &&
+      before.expectedSshTargetId === after.expectedSshTargetId &&
+      before.expectedSshConnectionGeneration === after.expectedSshConnectionGeneration
+    )
+  }
+  if (before.kind === 'runtime' && after.kind === 'runtime') {
+    return (
+      before.runtimeEnvironmentId === after.runtimeEnvironmentId &&
+      before.worktreeId === after.worktreeId &&
+      before.connectionId === after.connectionId &&
+      before.worktreePath === after.worktreePath &&
+      before.expectedExecutionHostId === after.expectedExecutionHostId &&
+      before.expectedSshTargetId === after.expectedSshTargetId &&
+      before.expectedSshConnectionGeneration === after.expectedSshConnectionGeneration
+    )
+  }
+  return false
+}
+
 function assertNativeChatRuntimeOwnerCurrent(owner: NativeChatRuntimeAttachmentOwner): void {
   const current = resolveNativeChatAttachmentOwnerForWorktree(
     useAppStore.getState(),
     owner.worktreeId
   )
-  if (
-    current.kind !== 'runtime' ||
-    current.runtimeEnvironmentId !== owner.runtimeEnvironmentId ||
-    current.connectionId !== owner.connectionId ||
-    current.worktreePath !== owner.worktreePath ||
-    current.expectedExecutionHostId !== owner.expectedExecutionHostId ||
-    current.expectedSshTargetId !== owner.expectedSshTargetId ||
-    current.expectedSshConnectionGeneration !== owner.expectedSshConnectionGeneration
-  ) {
-    throw new Error('Attachment upload host changed; retry the attach.')
+  if (!nativeChatAttachmentOwnersMatch(owner, current)) {
+    throw new Error(nativeChatAttachmentHostChangedMessage)
   }
 }
 

--- a/src/renderer/src/components/native-chat/native-chat-attachment-upload.ts
+++ b/src/renderer/src/components/native-chat/native-chat-attachment-upload.ts
@@ -8,14 +8,19 @@ import { translate } from '@/i18n/i18n'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { getConnectionIdFromState } from '@/lib/connection-context'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
+import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import { reportTerminalDropUploadSkipsAndFailures } from '../terminal-pane/terminal-drop-upload-report'
+import { isTerminalDropWindowsPathLike } from '../terminal-pane/terminal-drop-shell'
+import { joinRuntimeTerminalDropDir } from '../terminal-pane/terminal-drop-worktree-path'
 import {
   findTerminalTabWorktreeId,
   resolveNativeChatFileLinkContext
 } from './native-chat-file-link'
 import {
   captureDirectSshMutationExpectation,
+  captureWorktreeSshMutationExpectation,
   type DirectSshMutationExpectation
 } from '@/lib/ssh-mutation-expectation'
 
@@ -25,12 +30,22 @@ export type NativeChatSshAttachmentOwner = DirectSshMutationExpectation & {
   worktreePath: string
 }
 
+export type NativeChatRuntimeAttachmentOwner = ReturnType<
+  typeof captureWorktreeSshMutationExpectation
+> & {
+  kind: 'runtime'
+  runtimeEnvironmentId: string
+  worktreeId: string
+  worktreePath: string
+  /** Server-owned SSH connection when the worktree lives behind the
+   *  runtime's own SSH target (nested topology, #17679). */
+  connectionId: string | null
+}
+
 export type NativeChatAttachmentOwner =
   | { kind: 'local' }
   | NativeChatSshAttachmentOwner
-  /** Runtime-owned (`remote:`) panes keep the composer's existing
-   *  local-attachment block; runtime upload support is a separate seam. */
-  | { kind: 'runtime' }
+  | NativeChatRuntimeAttachmentOwner
   /** Store not hydrated / worktree unknown. Callers must not attach local
    *  paths in this window — the worktree may turn out to be remote, and the
    *  agent would silently receive paths it cannot read (see #6648). */
@@ -46,7 +61,8 @@ type NativeChatAttachmentOwnerState = Pick<
   | 'sshConnectionStates'
   | 'tabsByWorktree'
   | 'worktreesByRepo'
->
+> &
+  Partial<Pick<AppState, 'sshStateByEnvironment'>>
 
 /** Resolve who owns the composer's backing worktree at attach time. Mirrors the
  *  terminal drop resolver's order: runtime owner first, then SSH vs local. */
@@ -66,8 +82,29 @@ export function resolveNativeChatAttachmentOwnerForWorktree(
   worktreeId: string,
   terminalTabId?: string
 ): NativeChatAttachmentOwner {
-  if (getRuntimeEnvironmentIdForWorktree(state, worktreeId)) {
-    return { kind: 'runtime' }
+  const resolveWorktreePath = (): string | undefined =>
+    terminalTabId
+      ? resolveNativeChatFileLinkContext(state, terminalTabId)?.worktreePath
+      : state.getKnownWorktreeById(worktreeId)?.path
+  const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+  if (runtimeEnvironmentId) {
+    const worktreePath = resolveWorktreePath()
+    if (!worktreePath) {
+      return { kind: 'not-ready' }
+    }
+    try {
+      return {
+        kind: 'runtime',
+        runtimeEnvironmentId,
+        worktreeId,
+        worktreePath,
+        connectionId: getConnectionIdFromState(state, worktreeId) ?? null,
+        ...captureWorktreeSshMutationExpectation(state, worktreeId)
+      }
+    } catch {
+      // Owner is mid-flip (SSH generation unknown) — fail closed like #6648.
+      return { kind: 'not-ready' }
+    }
   }
   const connectionId = getConnectionIdFromState(state, worktreeId)
   if (connectionId === undefined) {
@@ -76,9 +113,7 @@ export function resolveNativeChatAttachmentOwnerForWorktree(
   if (connectionId === null) {
     return { kind: 'local' }
   }
-  const worktreePath = terminalTabId
-    ? resolveNativeChatFileLinkContext(state, terminalTabId)?.worktreePath
-    : state.getKnownWorktreeById(worktreeId)?.path
+  const worktreePath = resolveWorktreePath()
   if (!worktreePath) {
     return { kind: 'not-ready' }
   }
@@ -90,17 +125,37 @@ export function resolveNativeChatAttachmentOwnerForWorktree(
   }
 }
 
+/** Where an attached path is readable — threaded onto attachment chips so
+ *  previews read from the owning host instead of the client filesystem. */
+export type NativeChatAttachedHost = {
+  connectionId?: string | null
+  runtime?: { runtimeEnvironmentId: string; worktreeId: string; worktreePath: string }
+}
+
+export function nativeChatAttachedHostForOwner(
+  owner: NativeChatAttachmentOwner
+): NativeChatAttachedHost | undefined {
+  if (owner.kind === 'ssh') {
+    return { connectionId: owner.connectionId }
+  }
+  if (owner.kind === 'runtime') {
+    // No connectionId: a runtime owner's connection is server-owned and must
+    // never be dialed from this client (#17679).
+    return {
+      runtime: {
+        runtimeEnvironmentId: owner.runtimeEnvironmentId,
+        worktreeId: owner.worktreeId,
+        worktreePath: owner.worktreePath
+      }
+    }
+  }
+  return undefined
+}
+
 export function nativeChatWorktreeNotReadyNotice(): string {
   return translate(
     'components.native-chat.composer.worktreeNotReady',
     'Worktree not ready — try again in a moment.'
-  )
-}
-
-export function nativeChatLocalAttachmentUnsupportedNotice(): string {
-  return translate(
-    'components.native-chat.composer.localAttachmentUnsupported',
-    'Local attachments are not available for remote sessions.'
   )
 }
 
@@ -110,17 +165,21 @@ export function nativeChatLocalAttachmentUnsupportedNotice(): string {
  * preserved). Returns null when the upload IPC itself failed; per-file
  * skips/failures surface through the shared drop toasts.
  */
+function uploadingAttachmentsToast(pathCount: number): string | number {
+  return toast.loading(
+    translate(
+      'components.native-chat.composer.uploadingAttachments',
+      'Uploading {{value0}} file(s) to remote…',
+      { value0: pathCount }
+    )
+  )
+}
+
 export async function uploadNativeChatAttachmentPaths(
   paths: string[],
   owner: NativeChatSshAttachmentOwner
 ): Promise<string[] | null> {
-  const pending = toast.loading(
-    translate(
-      'components.native-chat.composer.uploadingAttachments',
-      'Uploading {{value0}} file(s) to remote…',
-      { value0: paths.length }
-    )
-  )
+  const pending = uploadingAttachmentsToast(paths.length)
   try {
     const { resolvedPaths, skipped, failed } = await window.api.fs.resolveDroppedPathsForAgent({
       paths,
@@ -132,6 +191,69 @@ export async function uploadNativeChatAttachmentPaths(
     })
     reportTerminalDropUploadSkipsAndFailures(skipped, failed)
     return resolvedPaths
+  } catch (err) {
+    toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
+    return null
+  } finally {
+    toast.dismiss(pending)
+  }
+}
+
+function assertNativeChatRuntimeOwnerCurrent(owner: NativeChatRuntimeAttachmentOwner): void {
+  const current = resolveNativeChatAttachmentOwnerForWorktree(
+    useAppStore.getState(),
+    owner.worktreeId
+  )
+  if (
+    current.kind !== 'runtime' ||
+    current.runtimeEnvironmentId !== owner.runtimeEnvironmentId ||
+    current.connectionId !== owner.connectionId ||
+    current.worktreePath !== owner.worktreePath ||
+    current.expectedExecutionHostId !== owner.expectedExecutionHostId ||
+    current.expectedSshTargetId !== owner.expectedSshTargetId ||
+    current.expectedSshConnectionGeneration !== owner.expectedSshConnectionGeneration
+  ) {
+    throw new Error('Attachment upload host changed; retry the attach.')
+  }
+}
+
+/**
+ * Upload client-local paths into `${worktreePath}/.orca/drops` on the runtime
+ * host (over the pairing channel — the runtime forwards to its own SSH target
+ * for nested worktrees) and return the destination-side paths. Mirrors the
+ * terminal drop flow; returns null when the upload itself failed.
+ */
+export async function uploadNativeChatRuntimeAttachmentPaths(
+  paths: string[],
+  owner: NativeChatRuntimeAttachmentOwner
+): Promise<string[] | null> {
+  const pending = uploadingAttachmentsToast(paths.length)
+  try {
+    const { results } = await importExternalPathsToRuntime(
+      {
+        settings: { activeRuntimeEnvironmentId: owner.runtimeEnvironmentId },
+        worktreeId: owner.worktreeId,
+        worktreePath: owner.worktreePath,
+        expectedExecutionHostId: owner.expectedExecutionHostId,
+        expectedSshTargetId: owner.expectedSshTargetId,
+        expectedSshConnectionGeneration: owner.expectedSshConnectionGeneration
+      },
+      paths,
+      joinRuntimeTerminalDropDir(owner.worktreePath),
+      { assertCurrent: () => assertNativeChatRuntimeOwnerCurrent(owner) }
+    )
+    const importedPaths = results
+      .filter((result) => result.status === 'imported')
+      .map((result) =>
+        isTerminalDropWindowsPathLike(owner.worktreePath)
+          ? result.destPath.replace(/\//g, '\\')
+          : result.destPath
+      )
+    reportTerminalDropUploadSkipsAndFailures(
+      results.filter((result) => result.status === 'skipped'),
+      results.filter((result) => result.status === 'failed')
+    )
+    return importedPaths
   } catch (err) {
     toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
     return null

--- a/src/renderer/src/components/native-chat/native-chat-attachment-upload.ts
+++ b/src/renderer/src/components/native-chat/native-chat-attachment-upload.ts
@@ -14,6 +14,7 @@ import { reportTerminalDropUploadSkipsAndFailures } from '../terminal-pane/termi
 import { uploadPathsToRuntimeDropDir } from '../terminal-pane/runtime-drop-dir-upload'
 import {
   findTerminalTabWorktreeId,
+  findWorktreeFallback,
   resolveNativeChatFileLinkContext
 } from './native-chat-file-link'
 import {
@@ -80,10 +81,14 @@ export function resolveNativeChatAttachmentOwnerForWorktree(
   worktreeId: string,
   terminalTabId?: string
 ): NativeChatAttachmentOwner {
+  // Both branches share the worktreesByRepo fallback so a capture through the
+  // tab path and a later tab-less re-resolution (the stale-owner assert)
+  // resolve the same path during index hydration.
   const resolveWorktreePath = (): string | undefined =>
     terminalTabId
       ? resolveNativeChatFileLinkContext(state, terminalTabId)?.worktreePath
-      : state.getKnownWorktreeById(worktreeId)?.path
+      : (state.getKnownWorktreeById(worktreeId)?.path ??
+        findWorktreeFallback(state.worktreesByRepo, worktreeId)?.path)
   const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
   if (runtimeEnvironmentId) {
     const worktreePath = resolveWorktreePath()

--- a/src/renderer/src/components/native-chat/native-chat-attachment-upload.ts
+++ b/src/renderer/src/components/native-chat/native-chat-attachment-upload.ts
@@ -8,12 +8,10 @@ import { translate } from '@/i18n/i18n'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { getConnectionIdFromState } from '@/lib/connection-context'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
-import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import { reportTerminalDropUploadSkipsAndFailures } from '../terminal-pane/terminal-drop-upload-report'
-import { isTerminalDropWindowsPathLike } from '../terminal-pane/terminal-drop-shell'
-import { joinRuntimeTerminalDropDir } from '../terminal-pane/terminal-drop-worktree-path'
+import { uploadPathsToRuntimeDropDir } from '../terminal-pane/runtime-drop-dir-upload'
 import {
   findTerminalTabWorktreeId,
   resolveNativeChatFileLinkContext
@@ -92,13 +90,21 @@ export function resolveNativeChatAttachmentOwnerForWorktree(
     if (!worktreePath) {
       return { kind: 'not-ready' }
     }
+    // An unresolved connection fails closed rather than coercing to "no
+    // connection": in the hydration window a nested worktree (#17679) would
+    // otherwise save attachments on the runtime server instead of its SSH
+    // target. Mirrors the SSH branch below.
+    const runtimeConnectionId = getConnectionIdFromState(state, worktreeId)
+    if (runtimeConnectionId === undefined) {
+      return { kind: 'not-ready' }
+    }
     try {
       return {
         kind: 'runtime',
         runtimeEnvironmentId,
         worktreeId,
         worktreePath,
-        connectionId: getConnectionIdFromState(state, worktreeId) ?? null,
+        connectionId: runtimeConnectionId,
         ...captureWorktreeSshMutationExpectation(state, worktreeId)
       }
     } catch {
@@ -132,26 +138,6 @@ export type NativeChatAttachedHost = {
   runtime?: { runtimeEnvironmentId: string; worktreeId: string; worktreePath: string }
 }
 
-export function nativeChatAttachedHostForOwner(
-  owner: NativeChatAttachmentOwner
-): NativeChatAttachedHost | undefined {
-  if (owner.kind === 'ssh') {
-    return { connectionId: owner.connectionId }
-  }
-  if (owner.kind === 'runtime') {
-    // No connectionId: a runtime owner's connection is server-owned and must
-    // never be dialed from this client (#17679).
-    return {
-      runtime: {
-        runtimeEnvironmentId: owner.runtimeEnvironmentId,
-        worktreeId: owner.worktreeId,
-        worktreePath: owner.worktreePath
-      }
-    }
-  }
-  return undefined
-}
-
 export function nativeChatWorktreeNotReadyNotice(): string {
   return translate(
     'components.native-chat.composer.worktreeNotReady',
@@ -159,12 +145,6 @@ export function nativeChatWorktreeNotReadyNotice(): string {
   )
 }
 
-/**
- * Upload client-local paths into `${worktreePath}/.orca/drops` on the SSH
- * remote and return the remote paths the agent can read (input order
- * preserved). Returns null when the upload IPC itself failed; per-file
- * skips/failures surface through the shared drop toasts.
- */
 function uploadingAttachmentsToast(pathCount: number): string | number {
   return toast.loading(
     translate(
@@ -175,6 +155,12 @@ function uploadingAttachmentsToast(pathCount: number): string | number {
   )
 }
 
+/**
+ * Upload client-local paths into `${worktreePath}/.orca/drops` on the SSH
+ * remote and return the remote paths the agent can read (input order
+ * preserved). Returns null when the upload IPC itself failed; per-file
+ * skips/failures surface through the shared drop toasts.
+ */
 export async function uploadNativeChatAttachmentPaths(
   paths: string[],
   owner: NativeChatSshAttachmentOwner
@@ -223,41 +209,16 @@ function assertNativeChatRuntimeOwnerCurrent(owner: NativeChatRuntimeAttachmentO
  * for nested worktrees) and return the destination-side paths. Mirrors the
  * terminal drop flow; returns null when the upload itself failed.
  */
-export async function uploadNativeChatRuntimeAttachmentPaths(
+export function uploadNativeChatRuntimeAttachmentPaths(
   paths: string[],
   owner: NativeChatRuntimeAttachmentOwner
 ): Promise<string[] | null> {
-  const pending = uploadingAttachmentsToast(paths.length)
-  try {
-    const { results } = await importExternalPathsToRuntime(
-      {
-        settings: { activeRuntimeEnvironmentId: owner.runtimeEnvironmentId },
-        worktreeId: owner.worktreeId,
-        worktreePath: owner.worktreePath,
-        expectedExecutionHostId: owner.expectedExecutionHostId,
-        expectedSshTargetId: owner.expectedSshTargetId,
-        expectedSshConnectionGeneration: owner.expectedSshConnectionGeneration
-      },
-      paths,
-      joinRuntimeTerminalDropDir(owner.worktreePath),
-      { assertCurrent: () => assertNativeChatRuntimeOwnerCurrent(owner) }
-    )
-    const importedPaths = results
-      .filter((result) => result.status === 'imported')
-      .map((result) =>
-        isTerminalDropWindowsPathLike(owner.worktreePath)
-          ? result.destPath.replace(/\//g, '\\')
-          : result.destPath
-      )
-    reportTerminalDropUploadSkipsAndFailures(
-      results.filter((result) => result.status === 'skipped'),
-      results.filter((result) => result.status === 'failed')
-    )
-    return importedPaths
-  } catch (err) {
-    toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
-    return null
-  } finally {
-    toast.dismiss(pending)
-  }
+  return uploadPathsToRuntimeDropDir(paths, owner, {
+    loadingMessage: translate(
+      'components.native-chat.composer.uploadingAttachments',
+      'Uploading {{value0}} file(s) to remote…',
+      { value0: paths.length }
+    ),
+    assertCurrent: () => assertNativeChatRuntimeOwnerCurrent(owner)
+  })
 }

--- a/src/renderer/src/components/native-chat/native-chat-file-link.ts
+++ b/src/renderer/src/components/native-chat/native-chat-file-link.ts
@@ -58,7 +58,7 @@ function findStructuredTabWorktreeId(
   return null
 }
 
-function findWorktreeFallback(
+export function findWorktreeFallback(
   worktreesByRepo: NativeChatFileLinkState['worktreesByRepo'],
   worktreeId: string
 ): Pick<Worktree, 'id' | 'path'> | null {

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
@@ -4,9 +4,9 @@ import { NATIVE_FILE_DROP_MAX_PATHS } from '../../../../shared/native-file-drop'
 import { isNativeChatImageAttachmentPath } from './native-chat-image-paste'
 import {
   formatNativeChatFileReference,
-  nativeChatComposerTargetIsRemote,
   type NativeChatResolvedTarget
 } from './native-chat-composer-target'
+import type { NativeChatAttachedHost } from './native-chat-attachment-upload'
 import type { NativeChatComposerImageAttachment } from './NativeChatComposerField'
 import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
 
@@ -36,7 +36,7 @@ export function useNativeChatComposerAttachments({
   setNotice
 }: UseNativeChatComposerAttachmentsArgs): {
   imageAttachments: NativeChatComposerImageAttachment[]
-  attachResolvedPaths: (paths: string[], connectionId?: string | null) => void
+  attachResolvedPaths: (paths: string[], host?: NativeChatAttachedHost) => void
   clearImageAttachments: () => void
   flushPendingAttachments: () => void
   removeImageAttachment: (id: string) => void
@@ -45,7 +45,7 @@ export function useNativeChatComposerAttachments({
     () => readNativeChatAttachmentCache(attachmentScopeKey)
   )
   const imageAttachmentCounter = useRef(0)
-  const pendingResolvedPathsRef = useRef<{ path: string; connectionId?: string | null }[]>([])
+  const pendingResolvedPathsRef = useRef<{ path: string; host?: NativeChatAttachedHost }[]>([])
   const pendingPathLimitRejectedRef = useRef(false)
   const disabledRef = useRef(disabled)
 
@@ -73,18 +73,19 @@ export function useNativeChatComposerAttachments({
   )
 
   const appendImageAttachments = useCallback(
-    (paths: { path: string; connectionId?: string | null }[]) => {
+    (paths: { path: string; host?: NativeChatAttachedHost }[]) => {
       if (paths.length === 0) {
         return
       }
       updateImageAttachments((prev) => [
         ...prev,
-        ...paths.map(({ path, connectionId }) => {
+        ...paths.map(({ path, host }) => {
           imageAttachmentCounter.current += 1
           return {
             id: `${Date.now()}-${imageAttachmentCounter.current}`,
             path,
-            connectionId: connectionId ?? undefined
+            connectionId: host?.connectionId ?? undefined,
+            runtime: host?.runtime
           }
         })
       ])
@@ -111,24 +112,22 @@ export function useNativeChatComposerAttachments({
     [caret, setCaret, setDraft, textareaRef]
   )
 
-  // Attach paths the TARGET AGENT can read: local paths for local worktrees,
-  // already-uploaded remote paths for SSH worktrees (the composer uploads
-  // before calling this — see native-chat-attachment-upload.ts).
+  // Attach paths the TARGET AGENT can read. Every entry point resolves the
+  // owning host and uploads FIRST (see native-chat-attachment-upload.ts), so
+  // this funnel only ever receives owner-resolved paths — local paths for
+  // local worktrees, uploaded remote paths for SSH and runtime worktrees.
   const applyResolvedPaths = useCallback(
     (
-      resolvedPaths: { path: string; connectionId?: string | null }[],
+      resolvedPaths: { path: string; host?: NativeChatAttachedHost }[],
       focus: boolean,
       preserveNotice = false
     ) => {
       const target = resolveTarget()
-      if (
-        (!target && !allowWithoutTarget) ||
-        (target && nativeChatComposerTargetIsRemote(target.ptyId))
-      ) {
+      if (!target && !allowWithoutTarget) {
         setNotice(
           translate(
-            'components.native-chat.composer.localAttachmentUnsupported',
-            'Local attachments are not available for remote sessions.'
+            'components.native-chat.composer.worktreeNotReady',
+            'Worktree not ready — try again in a moment.'
           )
         )
         return
@@ -140,7 +139,7 @@ export function useNativeChatComposerAttachments({
       // Images are NOT sent to the TUI here — they ride along on submit (see
       // NativeChatComposer.send) so the GUI chips and the TUI input never
       // diverge and removing a chip needs no TUI un-paste.
-      appendImageAttachments(imagePaths.map(({ path, connectionId }) => ({ path, connectionId })))
+      appendImageAttachments(imagePaths.map(({ path, host }) => ({ path, host })))
       insertFileReferences(filePaths)
       if (!preserveNotice) {
         setNotice(null)
@@ -160,7 +159,7 @@ export function useNativeChatComposerAttachments({
   )
 
   const attachResolvedPaths = useCallback(
-    (paths: string[], connectionId?: string | null) => {
+    (paths: string[], host?: NativeChatAttachedHost) => {
       if (paths.length === 0 || disabledRef.current) {
         return
       }
@@ -176,11 +175,11 @@ export function useNativeChatComposerAttachments({
           )
           return
         }
-        pendingResolvedPathsRef.current.push(...paths.map((path) => ({ path, connectionId })))
+        pendingResolvedPathsRef.current.push(...paths.map((path) => ({ path, host })))
         return
       }
       applyResolvedPaths(
-        paths.map((path) => ({ path, connectionId })),
+        paths.map((path) => ({ path, host })),
         true
       )
     },

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-paste.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-paste.test.tsx
@@ -18,6 +18,8 @@ vi.mock('./native-chat-composer-target', () => ({
 }))
 
 vi.mock('./native-chat-attachment-upload', () => ({
+  nativeChatAttachmentHostChangedMessage: 'Attachment upload host changed; retry the attach.',
+  nativeChatAttachmentOwnersMatch: (a: unknown, b: unknown) => a === b,
   nativeChatWorktreeNotReadyNotice: () => 'Worktree not ready — try again in a moment.'
 }))
 
@@ -159,11 +161,34 @@ describe('useNativeChatComposerPaste', () => {
     expect(attachResolvedPaths).toHaveBeenCalledWith(['/tmp/orca-paste-remote.png'])
   })
 
+  it('drops a paste whose pane moved to a different host mid-save', async () => {
+    mocks.saveClipboardImageAsTempFile.mockResolvedValue('/tmp/orca-paste-remote.png')
+    const attachResolvedPaths = vi.fn()
+    const setNotice = vi.fn()
+    // First resolution captures the owner; the post-save re-resolution returns
+    // a different owner object (reference inequality = host changed).
+    const resolveAttachmentOwner = vi
+      .fn<() => NativeChatAttachmentOwner>()
+      .mockReturnValueOnce(runtimeOwner)
+      .mockReturnValue({ ...runtimeOwner, runtimeEnvironmentId: 'env-2' })
+    const probe = await renderProbe({
+      resolveAttachmentOwner,
+      attachResolvedPaths,
+      setNotice
+    })
+    await act(async () => {
+      probe.latest().handlePaste(imagePasteEvent())
+    })
+    expect(attachResolvedPaths).not.toHaveBeenCalled()
+    expect(setNotice).toHaveBeenCalledWith('Attachment upload host changed; retry the attach.')
+  })
+
   it('passes the server-owned connection for nested runtime worktrees', async () => {
     mocks.saveClipboardImageAsTempFile.mockResolvedValue('/tmp/orca-paste-jetson.png')
     const attachResolvedPaths = vi.fn()
+    const nestedOwner: NativeChatAttachmentOwner = { ...runtimeOwner, connectionId: 'conn-1' }
     const probe = await renderProbe({
-      resolveAttachmentOwner: () => ({ ...runtimeOwner, connectionId: 'conn-1' }),
+      resolveAttachmentOwner: () => nestedOwner,
       attachResolvedPaths
     })
     await act(async () => {

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-paste.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-paste.test.tsx
@@ -18,8 +18,6 @@ vi.mock('./native-chat-composer-target', () => ({
 }))
 
 vi.mock('./native-chat-attachment-upload', () => ({
-  nativeChatLocalAttachmentUnsupportedNotice: () =>
-    'Local attachments are not available for remote sessions.',
   nativeChatWorktreeNotReadyNotice: () => 'Worktree not ready — try again in a moment.'
 }))
 
@@ -128,6 +126,15 @@ const sshOwner: NativeChatAttachmentOwner = {
   expectedSshConnectionGeneration: 4
 }
 
+const runtimeOwner: NativeChatAttachmentOwner = {
+  kind: 'runtime',
+  runtimeEnvironmentId: 'env-1',
+  worktreeId: 'wt-1',
+  worktreePath: '/srv/wt',
+  connectionId: null,
+  expectedExecutionHostId: 'local'
+}
+
 afterEach(() => {
   root?.unmount()
   root = null
@@ -135,22 +142,38 @@ afterEach(() => {
 })
 
 describe('useNativeChatComposerPaste', () => {
-  it('does not save a clipboard image locally for a remote runtime', async () => {
-    const setNotice = vi.fn()
+  it('saves runtime-owned pastes on the runtime host and attaches the returned path', async () => {
+    mocks.saveClipboardImageAsTempFile.mockResolvedValue('/tmp/orca-paste-remote.png')
     const attachResolvedPaths = vi.fn()
     const probe = await renderProbe({
-      resolveAttachmentOwner: () => ({ kind: 'runtime' }),
-      attachResolvedPaths,
-      setNotice
+      resolveAttachmentOwner: () => runtimeOwner,
+      attachResolvedPaths
     })
+    await act(async () => {
+      probe.latest().handlePaste(imagePasteEvent())
+    })
+    expect(mocks.saveClipboardImageAsTempFile).toHaveBeenCalledWith({
+      connectionId: null,
+      runtimeEnvironmentId: 'env-1'
+    })
+    expect(attachResolvedPaths).toHaveBeenCalledWith(['/tmp/orca-paste-remote.png'])
+  })
 
-    await act(async () => probe.latest().pasteFromClipboard())
-
-    expect(setNotice).toHaveBeenCalledWith(
-      'Local attachments are not available for remote sessions.'
-    )
-    expect(mocks.saveClipboardImageAsTempFile).not.toHaveBeenCalled()
-    expect(attachResolvedPaths).not.toHaveBeenCalled()
+  it('passes the server-owned connection for nested runtime worktrees', async () => {
+    mocks.saveClipboardImageAsTempFile.mockResolvedValue('/tmp/orca-paste-jetson.png')
+    const attachResolvedPaths = vi.fn()
+    const probe = await renderProbe({
+      resolveAttachmentOwner: () => ({ ...runtimeOwner, connectionId: 'conn-1' }),
+      attachResolvedPaths
+    })
+    await act(async () => {
+      probe.latest().handlePaste(imagePasteEvent())
+    })
+    expect(mocks.saveClipboardImageAsTempFile).toHaveBeenCalledWith({
+      connectionId: 'conn-1',
+      runtimeEnvironmentId: 'env-1'
+    })
+    expect(attachResolvedPaths).toHaveBeenCalledWith(['/tmp/orca-paste-jetson.png'])
   })
 
   it('surfaces a failed SSH image save through the composer notice', async () => {

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
@@ -5,7 +5,6 @@ import type { AgentType } from '../../../../shared/agent-status-types'
 import { resolveImagePaste } from './native-chat-image-paste'
 import { NATIVE_CHAT_CONTEXT_PASTE_MAX_BYTES } from './native-chat-composer-target'
 import {
-  nativeChatLocalAttachmentUnsupportedNotice,
   nativeChatWorktreeNotReadyNotice,
   type NativeChatAttachmentOwner
 } from './native-chat-attachment-upload'
@@ -74,15 +73,22 @@ export function useNativeChatComposerPaste({
     async (
       owner: NativeChatAttachmentOwner
     ): Promise<{ status: 'saved'; tempPath: string } | { status: 'empty' | 'failed' }> => {
-      if (owner.kind === 'runtime') {
-        setNotice(nativeChatLocalAttachmentUnsupportedNotice())
-        return { status: 'failed' }
-      }
       try {
-        // SSH panes save the image on the remote host (SFTP) so the attached
-        // path is readable by the remote agent, matching terminal image paste.
+        // SSH panes save the image on the remote host (SFTP) and runtime panes
+        // upload over the pairing channel — either way the attached path names
+        // a file the remote agent can read, matching terminal image paste. A
+        // runtime owner's connectionId is the SERVER-owned SSH connection for
+        // nested worktrees (#17679), forwarded by the runtime, never dialed
+        // from this client.
         const tempPath = await window.api.ui.saveClipboardImageAsTempFile(
-          owner.kind === 'ssh' ? { connectionId: owner.connectionId } : undefined
+          owner.kind === 'ssh'
+            ? { connectionId: owner.connectionId }
+            : owner.kind === 'runtime'
+              ? {
+                  connectionId: owner.connectionId,
+                  runtimeEnvironmentId: owner.runtimeEnvironmentId
+                }
+              : undefined
         )
         return tempPath ? { status: 'saved', tempPath } : { status: 'empty' }
       } catch (error) {

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
@@ -108,6 +108,10 @@ export function useNativeChatComposerPaste({
     [setNotice]
   )
 
+  // Pasted chips carry no host context: the temp file lives outside the
+  // worktree on remote owners (SSH /var/tmp, runtime OS tmp), where no preview
+  // transport can read it, so the thumbnail falls back to the generic icon.
+  // The attached path itself is host-side and readable by the agent.
   const attachClipboardImageTempFile = useCallback(
     (tempPath: string) => {
       const result = resolveImagePaste(agent, tempPath)

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
@@ -5,6 +5,8 @@ import type { AgentType } from '../../../../shared/agent-status-types'
 import { resolveImagePaste } from './native-chat-image-paste'
 import { NATIVE_CHAT_CONTEXT_PASTE_MAX_BYTES } from './native-chat-composer-target'
 import {
+  nativeChatAttachmentHostChangedMessage,
+  nativeChatAttachmentOwnersMatch,
   nativeChatWorktreeNotReadyNotice,
   type NativeChatAttachmentOwner
 } from './native-chat-attachment-upload'
@@ -158,6 +160,13 @@ export function useNativeChatComposerPaste({
         if (saved.status !== 'saved' || disabledRef.current) {
           return
         }
+        // The temp path was minted on the owner captured at paste time; if the
+        // pane's host changed during the save, attaching it would hand the new
+        // agent a path from the old host.
+        if (!nativeChatAttachmentOwnersMatch(owner, resolveAttachmentOwner())) {
+          setNotice(nativeChatAttachmentHostChangedMessage)
+          return
+        }
         attachClipboardImageTempFile(saved.tempPath)
         setCaret(caretAtPaste)
       })()
@@ -186,6 +195,10 @@ export function useNativeChatComposerPaste({
       if (saved.status === 'saved') {
         if (owner.kind === 'not-ready') {
           setNotice(nativeChatWorktreeNotReadyNotice())
+          return
+        }
+        if (!nativeChatAttachmentOwnersMatch(owner, resolveAttachmentOwner())) {
+          setNotice(nativeChatAttachmentHostChangedMessage)
           return
         }
         attachClipboardImageTempFile(saved.tempPath)

--- a/src/renderer/src/components/native-chat/use-native-chat-external-attachments.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-external-attachments.test.tsx
@@ -5,7 +5,8 @@ import { createRoot, type Root } from 'react-dom/client'
 
 const mocks = vi.hoisted(() => ({
   resolveNativeChatAttachmentOwner: vi.fn(),
-  uploadNativeChatAttachmentPaths: vi.fn()
+  uploadNativeChatAttachmentPaths: vi.fn(),
+  uploadNativeChatRuntimeAttachmentPaths: vi.fn()
 }))
 
 vi.mock('@/store', () => ({
@@ -13,10 +14,9 @@ vi.mock('@/store', () => ({
 }))
 
 vi.mock('./native-chat-attachment-upload', () => ({
-  nativeChatLocalAttachmentUnsupportedNotice: () =>
-    'Local attachments are not available for remote sessions.',
   resolveNativeChatAttachmentOwner: mocks.resolveNativeChatAttachmentOwner,
   uploadNativeChatAttachmentPaths: mocks.uploadNativeChatAttachmentPaths,
+  uploadNativeChatRuntimeAttachmentPaths: mocks.uploadNativeChatRuntimeAttachmentPaths,
   nativeChatWorktreeNotReadyNotice: () => 'Worktree not ready — try again in a moment.'
 }))
 
@@ -132,7 +132,9 @@ describe('useNativeChatExternalAttachments', () => {
       expectedSshTargetId: 'conn-1',
       expectedSshConnectionGeneration: 4
     })
-    expect(attachResolvedPaths).toHaveBeenCalledWith(['/remote/wt/.orca/drops/a.txt'], 'conn-1')
+    expect(attachResolvedPaths).toHaveBeenCalledWith(['/remote/wt/.orca/drops/a.txt'], {
+      connectionId: 'conn-1'
+    })
   })
 
   it('delivers concurrent SSH resolutions in order without deduplicating paths', async () => {
@@ -164,8 +166,11 @@ describe('useNativeChatExternalAttachments', () => {
     })
 
     expect(attachResolvedPaths.mock.calls).toEqual([
-      [['/remote/wt/.orca/drops/b.txt', '/remote/wt/.orca/drops/b.txt'], 'conn-1'],
-      [['/remote/wt/.orca/drops/a.txt'], 'conn-1']
+      [
+        ['/remote/wt/.orca/drops/b.txt', '/remote/wt/.orca/drops/b.txt'],
+        { connectionId: 'conn-1' }
+      ],
+      [['/remote/wt/.orca/drops/a.txt'], { connectionId: 'conn-1' }]
     ])
   })
 
@@ -181,17 +186,46 @@ describe('useNativeChatExternalAttachments', () => {
     expect(attachResolvedPaths).not.toHaveBeenCalled()
   })
 
-  it('does not attach client-local paths to a remote runtime', async () => {
-    mocks.resolveNativeChatAttachmentOwner.mockReturnValue({ kind: 'runtime' })
+  it('uploads runtime worktree paths and attaches the destination-side results', async () => {
+    const runtimeOwner = {
+      kind: 'runtime',
+      runtimeEnvironmentId: 'env-1',
+      worktreeId: 'wt-1',
+      worktreePath: '/srv/wt',
+      connectionId: null,
+      expectedExecutionHostId: 'local'
+    }
+    mocks.resolveNativeChatAttachmentOwner.mockReturnValue(runtimeOwner)
+    mocks.uploadNativeChatRuntimeAttachmentPaths.mockResolvedValue(['/srv/wt/.orca/drops/a.txt'])
     const attachResolvedPaths = vi.fn()
-    const setNotice = vi.fn()
-    const probe = await renderProbe({ attachResolvedPaths, setNotice })
+    const probe = await renderProbe({ attachResolvedPaths })
     await act(async () => {
       probe.latest().attachExternalPaths(['/local/a.txt'])
     })
-    expect(setNotice).toHaveBeenCalledWith(
-      'Local attachments are not available for remote sessions.'
+    expect(mocks.uploadNativeChatRuntimeAttachmentPaths).toHaveBeenCalledWith(
+      ['/local/a.txt'],
+      runtimeOwner
     )
+    expect(attachResolvedPaths).toHaveBeenCalledWith(['/srv/wt/.orca/drops/a.txt'], {
+      runtime: { runtimeEnvironmentId: 'env-1', worktreeId: 'wt-1', worktreePath: '/srv/wt' }
+    })
+  })
+
+  it('attaches nothing when the runtime upload fails', async () => {
+    mocks.resolveNativeChatAttachmentOwner.mockReturnValue({
+      kind: 'runtime',
+      runtimeEnvironmentId: 'env-1',
+      worktreeId: 'wt-1',
+      worktreePath: '/srv/wt',
+      connectionId: null,
+      expectedExecutionHostId: 'local'
+    })
+    mocks.uploadNativeChatRuntimeAttachmentPaths.mockResolvedValue(null)
+    const attachResolvedPaths = vi.fn()
+    const probe = await renderProbe({ attachResolvedPaths })
+    await act(async () => {
+      probe.latest().attachExternalPaths(['/local/a.txt'])
+    })
     expect(attachResolvedPaths).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/native-chat/use-native-chat-external-attachments.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-external-attachments.ts
@@ -1,11 +1,12 @@
 import { useCallback, useLayoutEffect, useRef } from 'react'
 import { useAppStore } from '@/store'
 import {
-  nativeChatLocalAttachmentUnsupportedNotice,
   nativeChatWorktreeNotReadyNotice,
   resolveNativeChatAttachmentOwner,
   resolveNativeChatAttachmentOwnerForWorktree,
   uploadNativeChatAttachmentPaths,
+  uploadNativeChatRuntimeAttachmentPaths,
+  type NativeChatAttachedHost,
   type NativeChatAttachmentOwner
 } from './native-chat-attachment-upload'
 
@@ -15,7 +16,7 @@ export type UseNativeChatExternalAttachmentsArgs = {
   /** Live composer-disabled state; read at await-resume via a ref so a flip
    *  mid-upload doesn't attach into a guarded composer. */
   disabled: boolean
-  attachResolvedPaths: (paths: string[], connectionId?: string | null) => void
+  attachResolvedPaths: (paths: string[], host?: NativeChatAttachedHost) => void
   setNotice: (notice: string | null) => void
 }
 
@@ -58,7 +59,19 @@ export function useNativeChatExternalAttachments({
         return
       }
       if (owner.kind === 'runtime') {
-        setNotice(nativeChatLocalAttachmentUnsupportedNotice())
+        void (async () => {
+          const remotePaths = await uploadNativeChatRuntimeAttachmentPaths(paths, owner)
+          if (!remotePaths || remotePaths.length === 0 || disabledRef.current) {
+            return
+          }
+          attachResolvedPaths(remotePaths, {
+            runtime: {
+              runtimeEnvironmentId: owner.runtimeEnvironmentId,
+              worktreeId: owner.worktreeId,
+              worktreePath: owner.worktreePath
+            }
+          })
+        })()
         return
       }
       if (owner.kind !== 'ssh') {
@@ -70,7 +83,7 @@ export function useNativeChatExternalAttachments({
         if (!remotePaths || remotePaths.length === 0 || disabledRef.current) {
           return
         }
-        attachResolvedPaths(remotePaths, owner.connectionId)
+        attachResolvedPaths(remotePaths, { connectionId: owner.connectionId })
       })()
     },
     [attachResolvedPaths, resolveAttachmentOwner, setNotice]

--- a/src/renderer/src/components/terminal-pane/runtime-drop-dir-upload.ts
+++ b/src/renderer/src/components/terminal-pane/runtime-drop-dir-upload.ts
@@ -1,0 +1,65 @@
+// Shared core for uploading client-local paths into a runtime worktree's
+// `.orca/drops` — used by terminal drops and the native chat composer so the
+// two surfaces cannot diverge on the same operation.
+
+import { toast } from 'sonner'
+import { extractIpcErrorMessage } from '@/lib/ipc-error'
+import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
+import { reportTerminalDropUploadSkipsAndFailures } from './terminal-drop-upload-report'
+import { isTerminalDropWindowsPathLike } from './terminal-drop-shell'
+import { joinRuntimeTerminalDropDir } from './terminal-drop-worktree-path'
+
+export type RuntimeDropDirUploadOwner = {
+  runtimeEnvironmentId: string
+  worktreeId: string
+  worktreePath: string
+  expectedExecutionHostId?: 'local' | `ssh:${string}`
+  expectedSshTargetId?: string
+  expectedSshConnectionGeneration?: number
+}
+
+/**
+ * Upload paths into `${worktreePath}/.orca/drops` on the owning runtime (which
+ * forwards to its own SSH target for nested worktrees) and return the
+ * destination-side paths. Per-file skips/failures surface through the shared
+ * drop toasts; returns null when the upload itself failed.
+ */
+export async function uploadPathsToRuntimeDropDir(
+  paths: string[],
+  owner: RuntimeDropDirUploadOwner,
+  options: { loadingMessage: string; assertCurrent?: () => void }
+): Promise<string[] | null> {
+  const pending = toast.loading(options.loadingMessage)
+  try {
+    const { results } = await importExternalPathsToRuntime(
+      {
+        settings: { activeRuntimeEnvironmentId: owner.runtimeEnvironmentId },
+        worktreeId: owner.worktreeId,
+        worktreePath: owner.worktreePath,
+        expectedExecutionHostId: owner.expectedExecutionHostId,
+        expectedSshTargetId: owner.expectedSshTargetId,
+        expectedSshConnectionGeneration: owner.expectedSshConnectionGeneration
+      },
+      paths,
+      joinRuntimeTerminalDropDir(owner.worktreePath),
+      { assertCurrent: options.assertCurrent }
+    )
+    const importedPaths = results
+      .filter((result) => result.status === 'imported')
+      .map((result) =>
+        isTerminalDropWindowsPathLike(owner.worktreePath)
+          ? result.destPath.replace(/\//g, '\\')
+          : result.destPath
+      )
+    reportTerminalDropUploadSkipsAndFailures(
+      results.filter((result) => result.status === 'skipped'),
+      results.filter((result) => result.status === 'failed')
+    )
+    return importedPaths
+  } catch (err) {
+    toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
+    return null
+  } finally {
+    toast.dismiss(pending)
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
@@ -1,10 +1,10 @@
 import { toast } from 'sonner'
+import { uploadPathsToRuntimeDropDir } from './runtime-drop-dir-upload'
 import { getConnectionId } from '@/lib/connection-context'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
-import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
@@ -15,7 +15,6 @@ import { reportTerminalDropUploadSkipsAndFailures } from './terminal-drop-upload
 import { captureTerminalDropTarget, getCurrentTerminalDropTransport } from './terminal-drop-target'
 import {
   getTerminalTargetShellForWorktreePath,
-  isTerminalDropWindowsPathLike,
   resolveTerminalDropTargetShell
 } from './terminal-drop-shell'
 import { writeTerminalDropPathsToCapturedTarget } from './terminal-drop-path-writer'
@@ -23,10 +22,7 @@ import { resolveNativeTerminalDropPane } from './terminal-drop-pane-resolution'
 import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform'
 import { showTerminalDropWriteFailure } from './terminal-drop-write-failure'
 import { captureDirectSshMutationExpectation } from '@/lib/ssh-mutation-expectation'
-import {
-  joinRuntimeTerminalDropDir,
-  resolveTerminalDropWorktreePath
-} from './terminal-drop-worktree-path'
+import { resolveTerminalDropWorktreePath } from './terminal-drop-worktree-path'
 import { captureRuntimeTerminalDropOwner } from './terminal-drop-runtime-owner'
 
 export type NativeTerminalFileDropArgs = {
@@ -177,46 +173,32 @@ async function uploadRuntimeDropPaths(
   }
 ): Promise<void> {
   const targetShell = getTerminalTargetShellForWorktreePath(args.worktreePath)
-  const destinationDir = joinRuntimeTerminalDropDir(args.worktreePath)
-  const pending = toast.loading(
-    translate(
-      'auto.components.terminal.pane.terminal.drop.handler.29c031b49a',
-      'Uploading {{value0}} file{{value1}} to runtime…',
-      { value0: args.dataPaths.length, value1: args.dataPaths.length === 1 ? '' : 's' }
-    )
+  // Why: uploads into existing worktrees must follow the worktree owner, not
+  // the currently focused host in the sidebar — the shared core scopes its
+  // import context to the owner's environment id.
+  const importedPaths = await uploadPathsToRuntimeDropDir(
+    args.dataPaths,
+    {
+      runtimeEnvironmentId: args.runtimeEnvironmentId,
+      worktreeId: args.worktreeId,
+      worktreePath: args.worktreePath,
+      expectedExecutionHostId: args.expectedExecutionHostId,
+      expectedSshTargetId: args.expectedSshTargetId,
+      expectedSshConnectionGeneration: args.expectedSshConnectionGeneration
+    },
+    {
+      loadingMessage: translate(
+        'auto.components.terminal.pane.terminal.drop.handler.29c031b49a',
+        'Uploading {{value0}} file{{value1}} to runtime…',
+        { value0: args.dataPaths.length, value1: args.dataPaths.length === 1 ? '' : 's' }
+      ),
+      assertCurrent: args.assertCurrent
+    }
   )
-  try {
-    const { results } = await importExternalPathsToRuntime(
-      {
-        // Why: drops into existing worktrees must follow the worktree owner,
-        // not the currently focused host in the sidebar.
-        settings: { ...args.settings, activeRuntimeEnvironmentId: args.runtimeEnvironmentId },
-        worktreeId: args.worktreeId,
-        worktreePath: args.worktreePath,
-        expectedExecutionHostId: args.expectedExecutionHostId,
-        expectedSshTargetId: args.expectedSshTargetId,
-        expectedSshConnectionGeneration: args.expectedSshConnectionGeneration
-      },
-      args.dataPaths,
-      destinationDir,
-      { assertCurrent: args.assertCurrent }
-    )
-    const imported = results.filter((result) => result.status === 'imported')
-    const importedPaths = imported.map((result) =>
-      isTerminalDropWindowsPathLike(args.worktreePath)
-        ? result.destPath.replace(/\//g, '\\')
-        : result.destPath
-    )
-    await pasteResolvedDropPaths({ ...args, paths: importedPaths, targetShell })
-    reportTerminalDropUploadSkipsAndFailures(
-      results.filter((result) => result.status === 'skipped'),
-      results.filter((result) => result.status === 'failed')
-    )
-  } catch (err) {
-    toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
-  } finally {
-    toast.dismiss(pending)
+  if (importedPaths === null) {
+    return
   }
+  await pasteResolvedDropPaths({ ...args, paths: importedPaths, targetShell })
 }
 
 async function pasteLocalDropPaths(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16586,7 +16586,6 @@
         "skillScopePersonal": "Personal",
         "skillScopeBuiltIn": "Built-in",
         "skillScopePlugin": "Plugin",
-        "localAttachmentUnsupported": "Local attachments are not available for remote sessions.",
         "removeAttachment": "Remove attachment",
         "pastedImageLabel": "Pasted image",
         "imagePasteFailed": "Image paste failed.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14537,7 +14537,6 @@
         "startDictation": "Iniciar dictado",
         "stopDictation": "Detener dictado",
         "noSkills": "Sin habilidades coincidentes",
-        "localAttachmentUnsupported": "Los archivos adjuntos locales no están disponibles para sesiones remotas.",
         "removeAttachment": "Quitar archivo adjunto",
         "pastedImageLabel": "Imagen pegada",
         "imagePasteFailed": "Error al pegar imagen.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14537,7 +14537,6 @@
         "startDictation": "ディクテーションを開始する",
         "stopDictation": "ディクテーションを停止する",
         "noSkills": "一致するスキルがありません",
-        "localAttachmentUnsupported": "ローカル添付ファイルはリモートセッションでは使用できません。",
         "removeAttachment": "添付ファイルを削除する",
         "pastedImageLabel": "貼り付けた画像",
         "imagePasteFailed": "画像の貼り付けに失敗しました。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14580,7 +14580,6 @@
         "startDictation": "받아쓰기 시작",
         "stopDictation": "받아쓰기 중지",
         "noSkills": "어울리는 스킬 없음",
-        "localAttachmentUnsupported": "원격 세션에는 로컬 첨부 파일을 사용할 수 없습니다.",
         "removeAttachment": "첨부파일 삭제",
         "pastedImageLabel": "붙여넣은 이미지",
         "imagePasteFailed": "이미지 붙여넣기 실패.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14580,7 +14580,6 @@
         "startDictation": "开始听写",
         "stopDictation": "停止听写",
         "noSkills": "没有匹配的技能",
-        "localAttachmentUnsupported": "远程会话不支持本地附件。",
         "removeAttachment": "移除附件",
         "pastedImageLabel": "粘贴的图片",
         "imagePasteFailed": "图片粘贴失败。",

--- a/src/renderer/src/lib/ssh-mutation-expectation.ts
+++ b/src/renderer/src/lib/ssh-mutation-expectation.ts
@@ -1,7 +1,10 @@
 import type { SshMutationExpectation } from '../../../shared/ssh-types'
 import type { AppState } from '@/store/types'
 import { parseExecutionHostId, toSshExecutionHostId } from '../../../shared/execution-host'
-import { resolveWorktreeOperationRoute } from './worktree-operation-route'
+import {
+  resolveWorktreeOperationRoute,
+  type WorktreeOperationRouteState
+} from './worktree-operation-route'
 
 const SSH_OWNER_CHANGED_MESSAGE =
   "Couldn't verify the SSH connection. Reconnect the host and try again."
@@ -35,7 +38,7 @@ export function captureDirectSshMutationExpectation(
 }
 
 export function captureWorktreeSshMutationExpectation(
-  state: AppState,
+  state: DirectSshMutationState & WorktreeOperationRouteState,
   worktreeId: string
 ): SshMutationExpectation & { expectedExecutionHostId: 'local' | `ssh:${string}` } {
   const route = resolveWorktreeOperationRoute(state, worktreeId)
@@ -48,7 +51,7 @@ export function captureWorktreeSshMutationExpectation(
   }
   const generation = route?.runtimeEnvironmentId
     ? state.sshStateByEnvironment
-        .get(route.runtimeEnvironmentId)
+        ?.get(route.runtimeEnvironmentId)
         ?.connectionStates.get(host.targetId)?.connectionGeneration
     : state.sshConnectionStates.get(host.targetId)?.connectionGeneration
   if (generation === undefined) {

--- a/src/renderer/src/web/preload-api/web-clipboard-api.ts
+++ b/src/renderer/src/web/preload-api/web-clipboard-api.ts
@@ -7,20 +7,15 @@ import {
   assertClipboardImageDimensionsWithinLimit
 } from '../../../../shared/clipboard-image'
 import { assertClipboardTextWriteWithinLimitWithYield } from '../../../../shared/clipboard-text'
+import { saveClipboardImageBase64ThroughRuntime } from '../../../../shared/clipboard-image-upload-protocol'
 import { copyClipboardTextViaExecCommand } from '../web-clipboard-copy-fallback'
-import { callRuntimeEnvelope, callRuntimeResult } from './web-runtime-calls'
+import { callRuntimeEnvelope } from './web-runtime-calls'
 
 export const MAX_CLIPBOARD_IMAGE_BASE64_CHARS = CLIPBOARD_IMAGE_MAX_BASE64_CHARS
 
 export const MAX_CLIPBOARD_IMAGE_SOURCE_BYTES = CLIPBOARD_IMAGE_MAX_SOURCE_BYTES
 
 export const MAX_CLIPBOARD_IMAGE_PIXELS = CLIPBOARD_IMAGE_MAX_PIXELS
-
-export const CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
-
-export const CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS = 256 * 1024
-
-export const CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS = 30_000
 
 export function blobToBase64(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -120,58 +115,9 @@ export async function saveClipboardImageAsTempFileInRuntime(
   if (contentBase64.length > MAX_CLIPBOARD_IMAGE_BASE64_CHARS) {
     throw new Error(CLIPBOARD_IMAGE_TOO_LARGE_ERROR)
   }
-  const connectionId = args?.connectionId ?? null
-  const startResponse = await callRuntimeEnvelope<{ uploadId: string }>(
-    'clipboard.startImageUpload',
-    { expectedBase64Length: contentBase64.length, connectionId },
-    CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
+  return saveClipboardImageBase64ThroughRuntime(
+    (method, params, timeoutMs) => callRuntimeEnvelope(method, params, timeoutMs),
+    contentBase64,
+    args?.connectionId ?? null
   )
-  if (!startResponse.ok) {
-    if (
-      startResponse.error.code === 'method_not_found' &&
-      contentBase64.length <= CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS
-    ) {
-      return callRuntimeResult<string>(
-        'clipboard.saveImageAsTempFile',
-        { contentBase64, connectionId },
-        CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-      )
-    }
-    throw new Error(startResponse.error.message)
-  }
-
-  const { uploadId } = startResponse.result
-  try {
-    for (
-      let offset = 0;
-      offset < contentBase64.length;
-      offset += CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
-    ) {
-      await callRuntimeResult(
-        'clipboard.appendImageUploadChunk',
-        {
-          uploadId,
-          offset,
-          contentBase64: contentBase64.slice(
-            offset,
-            offset + CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
-          )
-        },
-        CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-      )
-    }
-    return await callRuntimeResult<string>(
-      'clipboard.commitImageUpload',
-      { uploadId },
-      CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-    )
-  } catch (error) {
-    // Why: after chunked paste holds server-side state, release the bounded slot on failure rather than wait for TTL cleanup.
-    await callRuntimeResult(
-      'clipboard.abortImageUpload',
-      { uploadId },
-      CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
-    ).catch(() => {})
-    throw error
-  }
 }

--- a/src/renderer/src/web/web-preload-api-clipboard.test.ts
+++ b/src/renderer/src/web/web-preload-api-clipboard.test.ts
@@ -303,7 +303,7 @@ describe('web UI preload API', () => {
     writeStoredRuntimeEnvironment(globals.storage)
     const { installWebPreloadApi } = await import('./web-preload-api')
     const { CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS } =
-      await import('./preload-api/web-clipboard-api')
+      await import('../../../shared/clipboard-image-upload-protocol')
     const contentBase64 = `${'A'.repeat(CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS)}AAAA`
     installClipboardImageBase64(contentBase64)
     installWebPreloadApi()
@@ -417,7 +417,7 @@ describe('web UI preload API', () => {
     writeStoredRuntimeEnvironment(globals.storage)
     const { installWebPreloadApi } = await import('./web-preload-api')
     const { CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS } =
-      await import('./preload-api/web-clipboard-api')
+      await import('../../../shared/clipboard-image-upload-protocol')
     installClipboardImageBase64('A'.repeat(CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS + 4))
     installWebPreloadApi()
 

--- a/src/shared/clipboard-image-upload-protocol.ts
+++ b/src/shared/clipboard-image-upload-protocol.ts
@@ -1,0 +1,93 @@
+// Chunked clipboard-image upload protocol shared by the desktop main process
+// and the web preload. Keeping one driver prevents the transports from
+// diverging on protocol details (chunking, fallback gate, abort policy,
+// connection forwarding — see #17679).
+
+export const CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
+export const CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS = 256 * 1024
+export const CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS = 30_000
+
+export type ClipboardImageUploadRpcResponse =
+  | { ok: true; result: unknown }
+  | { ok: false; error: { code?: string; message: string } }
+
+export type ClipboardImageUploadRpcCall = (
+  method: string,
+  params: unknown,
+  timeoutMs: number
+) => Promise<ClipboardImageUploadRpcResponse>
+
+async function callOk(
+  call: ClipboardImageUploadRpcCall,
+  method: string,
+  params: unknown
+): Promise<unknown> {
+  const response = await call(method, params, CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS)
+  if (!response.ok) {
+    throw new Error(response.error.message)
+  }
+  return response.result
+}
+
+function assertRemotePath(result: unknown): string {
+  if (typeof result !== 'string') {
+    throw new Error('Remote clipboard image save returned an invalid path')
+  }
+  return result
+}
+
+/**
+ * Upload a clipboard image to the paired runtime and return the path of the
+ * temp file it saved. `connectionId` names a connection owned by the RUNTIME
+ * (its own SSH target for nested worktrees), never one owned by this client.
+ * Falls back to the pre-chunking single-frame RPC for small images against
+ * older runtimes.
+ */
+export async function saveClipboardImageBase64ThroughRuntime(
+  call: ClipboardImageUploadRpcCall,
+  contentBase64: string,
+  connectionId: string | null
+): Promise<string> {
+  const startResponse = await call(
+    'clipboard.startImageUpload',
+    { expectedBase64Length: contentBase64.length, connectionId },
+    CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
+  )
+  if (!startResponse.ok) {
+    if (
+      startResponse.error.code === 'method_not_found' &&
+      contentBase64.length <= CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS
+    ) {
+      return assertRemotePath(
+        await callOk(call, 'clipboard.saveImageAsTempFile', { contentBase64, connectionId })
+      )
+    }
+    throw new Error(startResponse.error.message)
+  }
+  const uploadId = (startResponse.result as { uploadId?: unknown } | null)?.uploadId
+  if (typeof uploadId !== 'string') {
+    throw new Error('Remote clipboard image upload returned an invalid id')
+  }
+  try {
+    for (
+      let offset = 0;
+      offset < contentBase64.length;
+      offset += CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
+    ) {
+      await callOk(call, 'clipboard.appendImageUploadChunk', {
+        uploadId,
+        offset,
+        contentBase64: contentBase64.slice(
+          offset,
+          offset + CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
+        )
+      })
+    }
+    return assertRemotePath(await callOk(call, 'clipboard.commitImageUpload', { uploadId }))
+  } catch (error) {
+    // Why: failed chunked pastes should release the bounded remote upload slot
+    // immediately instead of waiting for TTL cleanup.
+    await callOk(call, 'clipboard.abortImageUpload', { uploadId }).catch(() => {})
+    throw error
+  }
+}

--- a/src/shared/clipboard-image-upload-protocol.ts
+++ b/src/shared/clipboard-image-upload-protocol.ts
@@ -46,8 +46,10 @@ function assertRemotePath(result: unknown): string {
 export async function saveClipboardImageBase64ThroughRuntime(
   call: ClipboardImageUploadRpcCall,
   contentBase64: string,
-  connectionId: string | null
+  rawConnectionId: string | null
 ): Promise<string> {
+  // A blank id means "no connection" — the runtime schema rejects ''.
+  const connectionId = rawConnectionId?.trim() || null
   const startResponse = await call(
     'clipboard.startImageUpload',
     { expectedBase64Length: contentBase64.length, connectionId },


### PR DESCRIPTION
Fixes #12572
Fixes #17410
Fixes #6889

> **Stacked on #17787** — the first two commits here belong to that PR (the nested clipboard routing fix this feature builds on). Review the last commit; this PR will shrink to it once #17787 merges.

## Problem

On a runtime-owned (`remote:`) native chat pane, none of the composer's attach surfaces work: drag-and-drop and the file picker show *"Local attachments are not available for remote sessions"*, and clipboard image paste is refused. Meanwhile the same pane's **terminal** view happily uploads a pasted image to the server, and mobile clients attach images to the very same sessions — the gap was specific to the desktop/web composer. Users fall back to scp/synced folders or pasting screenshots into GitHub comment boxes for the URL (#12572, #6889 comments).

## What this does

All three composer attach surfaces now work on runtime-owned panes, producing the same end state the SSH composer path already produces — and it's wiring, not new transport:

- **Clipboard image paste** calls the same `saveClipboardImageAsTempFile({ runtimeEnvironmentId, connectionId })` terminal paste uses (chunked upload over the pairing channel, single-frame fallback for old servers). Nested worktrees on a server-owned SSH target work from day one (#17787).
- **Drag-and-drop and the file picker** upload through the existing `importExternalPathsToRuntime` into the worktree's `.orca/drops` (no-clobber), mirroring terminal drops — including the per-file skip/failure toasts and the capability assertion that surfaces *"Remote file changes require a newer Orca server"* against old servers.
- **The attachment owner resolver** now returns a full runtime owner (environment id, worktree, server-owned connection id, host expectation), failing closed to `not-ready` while ownership is mid-flip. A stale-owner guard fails an in-flight upload if the pane's host changes underneath it.
- **The attach funnel's invariant changed, not disappeared**: instead of blocking every remote pane, `attachResolvedPaths` receives owner-resolved host contexts. Client-local paths still can't reach a remote agent because every entry point resolves the owner and uploads first (the #6648 property, now enforced at the entries and pinned by tests).
- **Attachment chips carry their owning host**: image previews read via the runtime for in-worktree files (dropped images get real thumbnails); pasted server-`/tmp` images fall back to the generic thumbnail, matching current SSH-paste behavior. A runtime chip never carries a connection id — that connection is server-owned and must not be dialed from the client.

No new wire methods, no capability negotiation needed. The send path is untouched (runtime image sends already existed for mobile). The paired web client shares the renderer, so it gets all three surfaces too; mobile already worked and is unchanged.

## Testing

At the pre-agreed seams:

- `native-chat-attachment-upload.test.ts` — resolver returns the enriched runtime owner (plain, nested-SSH, focused-host, not-ready), and the runtime upload flow: import args, `.orca/drops` destination, skip/failure toasts, stale-owner failure, error → null.
- `use-native-chat-composer-paste.test.tsx` — runtime paste routes to the runtime save (plain + nested) and attaches the returned path; existing SSH/local/failure cases unchanged.
- `use-native-chat-external-attachments.test.tsx` — runtime drop/picker uploads and attaches destination-side paths with the runtime host context; failed uploads attach nothing; SSH/local/not-ready/disabled cases unchanged.

Full `pnpm test`, `pnpm tc`, oxlint, and the localization verifies pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019G22teMcYiNe9RmGQ4dKuK
