### PR TITLE
fix(terminal): safely prune stale remote tab ghosts

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -6412,10 +6412,10 @@
         "https://github.com/stablyai/orca/issues/9138",
         "https://github.com/stablyai/orca/issues/9229"
       ],
-      "invariant": "Reconnect, replay, or lifecycle observations from a viewer that negotiated explicit close intent must never kill a live PTY. A capable reasonless close must keep and republish; a legacy paired viewer must retain current-main behavior because its intentional close and cleanup echo are wire-identical. Lifecycle close requires the exact observed publication, terminal, environment, and authoritative liveness, never signals a process, and leaves renderer-owned or partial-split retirement to its owner. Legacy daemon hello and warm reattachment remain non-destructive.",
-      "oracle": "Start isolated v25 and v26 daemon generations with one capable-viewer PTY and one legacy-viewer PTY per generation in four target worktrees plus an unaddressed control PTY in a fifth worktree. Route them through the production desktop scanner, runtime, RPC dispatcher, renderer-close relay, and daemon router. First issue sequential reasonless closes from an authenticated capable connection and require refusal, snapshot republish, zero shutdown calls, exact process survival, and post-close I/O. Then issue the byte-identical requests without the negotiated capability and require current-main behavior: two ordered immediate shutdowns, session-killed events, and exact root/descendant death, while capable and control PTYs survive. An observer lists all targets before, between, and after while issuing zero closes. Unit contracts also require in-process reasonless refusal, legacy runtime/mobile compatibility, explicit user closes, encrypted client-auth advertisement, and old-server lifecycle calls never to fall back.",
+      "invariant": "Reconnect, replay, or lifecycle observations from a viewer that negotiated explicit close intent must never kill a live PTY. A capable reasonless close must keep and republish; a legacy paired viewer must retain current-main behavior because its intentional close and cleanup echo are wire-identical. Lifecycle close requires the exact observed publication, terminal, environment, and authoritative liveness, never signals a process, and leaves renderer-owned or partial-split retirement to its owner. Explicit renderer close without a hydrated worktree catalog routes only from agreeing live remote PTY bindings; conflicting or layout-only evidence cancels before local pruning. Legacy daemon hello and warm reattachment remain non-destructive.",
+      "oracle": "Start isolated v25 and v26 daemon generations with one capable-viewer PTY and one legacy-viewer PTY per generation in four target worktrees plus an unaddressed control PTY in a fifth worktree. Route them through the production desktop scanner, runtime, RPC dispatcher, renderer-close relay, and daemon router. First issue sequential reasonless closes from an authenticated capable connection and require refusal, snapshot republish, zero shutdown calls, exact process survival, and post-close I/O. Then issue the byte-identical requests without the negotiated capability and require current-main behavior: two ordered immediate shutdowns, session-killed events, and exact root/descendant death, while capable and control PTYs survive. An observer lists all targets before, between, and after while issuing zero closes. Unit contracts also require in-process reasonless refusal, legacy runtime/mobile compatibility, explicit user closes, encrypted client-auth advertisement, old-server lifecycle calls never to fall back, catalog-gap routing from one live owner, and zero host/local close for conflicting or stale-layout ownership.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-server-kill-attribution.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/remote-runtime-request-connection.integration.test.ts src/main/runtime/rpc/runtime-close-attribution-topology.test.ts src/main/runtime/rpc/methods/session-tabs.test.ts src/main/runtime/rpc/methods/session-tabs-schemas.test.ts src/main/runtime/rpc/e2ee-channel.test.ts src/main/runtime/rpc/e2ee-channel-v2.test.ts src/main/runtime/rpc/mobile-socket-wiring.test.ts src/main/runtime/rpc/runtime-client-capabilities.test.ts src/shared/remote-runtime-client.test.ts src/shared/remote-runtime-request-connection.test.ts src/shared/remote-runtime-shared-control-connection.test.ts src/cli/runtime/websocket-transport.test.ts src/renderer/src/web/web-runtime-client.test.ts src/renderer/src/runtime/web-runtime-session.test.ts src/renderer/src/runtime/web-session-close-intent.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/components/terminal/terminal-tab-actions.test.ts src/renderer/src/components/terminal/terminal-close-incarnation.test.ts src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-server-kill-attribution.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/remote-runtime-request-connection.integration.test.ts src/main/runtime/rpc/runtime-close-attribution-topology.test.ts src/main/runtime/rpc/methods/session-tabs.test.ts src/main/runtime/rpc/methods/session-tabs-schemas.test.ts src/main/runtime/rpc/e2ee-channel.test.ts src/main/runtime/rpc/e2ee-channel-v2.test.ts src/main/runtime/rpc/mobile-socket-wiring.test.ts src/main/runtime/rpc/runtime-client-capabilities.test.ts src/shared/remote-runtime-client.test.ts src/shared/remote-runtime-request-connection.test.ts src/shared/remote-runtime-shared-control-connection.test.ts src/cli/runtime/websocket-transport.test.ts src/renderer/src/web/web-runtime-client.test.ts src/renderer/src/runtime/web-runtime-session.test.ts src/renderer/src/runtime/web-session-close-intent.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/components/terminal/terminal-tab-actions.test.ts src/renderer/src/components/terminal/terminal-tab-runtime-close-routing.test.ts src/renderer/src/components/terminal/terminal-tab-runtime-environment.test.ts src/renderer/src/components/terminal/terminal-close-incarnation.test.ts src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.test.ts",
         "pnpm exec playwright test tests/e2e/daemon-generation-reconnect-safety.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
         "pnpm exec playwright test tests/e2e/daemon-generation-legacy-close-safety.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
       ],
@@ -6439,6 +6439,8 @@
         "src/renderer/src/runtime/web-session-close-intent.test.ts",
         "src/renderer/src/runtime/web-session-tabs-sync.test.ts",
         "src/renderer/src/components/terminal/terminal-tab-actions.test.ts",
+        "src/renderer/src/components/terminal/terminal-tab-runtime-close-routing.test.ts",
+        "src/renderer/src/components/terminal/terminal-tab-runtime-environment.test.ts",
         "src/renderer/src/components/terminal/terminal-close-incarnation.test.ts",
         "src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.test.ts",
         "tests/e2e/daemon-generation-reconnect-safety.spec.ts",
@@ -6558,6 +6560,18 @@
           "file": "src/renderer/src/runtime/web-session-close-intent.test.ts",
           "assertions": [
             "identical worktree and tab ids in another runtime cannot suppress, reconcile, or clear this profile's intent"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/terminal/terminal-tab-runtime-close-routing.test.ts",
+          "assertions": [
+            "catalog-gap close routes to the one live remote PTY owner, while conflicting owners and persisted layout-only evidence issue zero host closes and zero local pruning"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/terminal/terminal-tab-runtime-environment.test.ts",
+          "assertions": [
+            "live PTY owner resolution distinguishes no evidence, one agreeing runtime owner, and conflicting runtime owners"
           ]
         },
         {

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -38,6 +38,7 @@ import {
   validatePrecomputedTerminalCloseState,
   type PrecomputedTerminalCloseState
 } from './terminal-close-target'
+import { resolveTerminalTabRuntimeEnvironment } from './terminal-tab-runtime-environment'
 export type { PrecomputedTerminalCloseState } from './terminal-close-target'
 export { closeOtherTerminalTabs, closeTerminalTabsToRight } from './terminal-tab-bulk-actions'
 
@@ -91,8 +92,16 @@ export function closeTerminalTab(
     return
   }
   const { worktreeId: owningWorktreeId, terminalTabId } = target
+  const terminalRuntimeEnvironment = resolveTerminalTabRuntimeEnvironment(
+    state,
+    owningWorktreeId,
+    terminalTabId
+  )
   const worktreeRoute = resolveTerminalWorktreeRoute(state, owningWorktreeId)
-  if (!worktreeRoute) {
+  if (
+    terminalRuntimeEnvironment.kind === 'conflict' ||
+    (!worktreeRoute && terminalRuntimeEnvironment.kind === 'none')
+  ) {
     options?.onCancel?.()
     return
   }
@@ -139,7 +148,10 @@ export function closeTerminalTab(
     return
   }
 
-  const runtimeEnvironmentId = worktreeRoute.runtimeEnvironmentId
+  const runtimeEnvironmentId =
+    terminalRuntimeEnvironment.kind === 'runtime'
+      ? terminalRuntimeEnvironment.environmentId
+      : (worktreeRoute?.runtimeEnvironmentId ?? null)
   const structuredSessionId = structuredTerminalSessionId(
     state.unifiedTabsByWorktree?.[owningWorktreeId],
     terminalTabId

--- a/src/renderer/src/components/terminal/terminal-tab-runtime-close-routing.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-runtime-close-routing.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  closeWebRuntimeSessionTabMock,
+  getStateMock,
+  isWebRuntimeSessionActiveMock,
+  resolveHostSessionTabIdForWebSessionTabMock
+} = vi.hoisted(() => ({
+  closeWebRuntimeSessionTabMock: vi.fn(),
+  getStateMock: vi.fn(),
+  isWebRuntimeSessionActiveMock: vi.fn(),
+  resolveHostSessionTabIdForWebSessionTabMock: vi.fn<() => string | null>(() => null)
+}))
+
+vi.mock('@/store', () => ({ useAppStore: { getState: getStateMock } }))
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  activateWebRuntimeSessionTab: vi.fn(),
+  closeWebRuntimeSessionTab: closeWebRuntimeSessionTabMock,
+  createWebRuntimeSessionTerminal: vi.fn(),
+  isWebRuntimeSessionActive: isWebRuntimeSessionActiveMock,
+  isWebTerminalSurfaceTabId: vi.fn(() => false),
+  toHostSessionTabId: vi.fn((tabId: string) => tabId)
+}))
+
+vi.mock('@/runtime/web-session-tabs-sync', () => ({
+  getLatestWebSessionTabsPublicationEpoch: vi.fn(() => 'epoch-1'),
+  resolveHostSessionTabIdForWebSessionTab: resolveHostSessionTabIdForWebSessionTabMock
+}))
+
+import { closeTerminalTab } from './terminal-tab-actions'
+
+describe('closeTerminalTab runtime evidence routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveHostSessionTabIdForWebSessionTabMock.mockReturnValue(null)
+  })
+
+  it('routes a remote PTY close while the worktree catalog is absent', () => {
+    const closeTab = vi.fn()
+    isWebRuntimeSessionActiveMock.mockImplementation(
+      (environmentId: string) => environmentId === 'owner-runtime'
+    )
+    getStateMock.mockReturnValue({
+      settings: {
+        activeRuntimeEnvironmentId: 'focused-runtime',
+        skipCloseTerminalWithRunningProcessConfirm: true
+      },
+      repos: [],
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'host-tab-1',
+            ptyId: 'remote:owner-runtime@@terminal-1',
+            worktreeId: 'wt-1'
+          }
+        ]
+      },
+      unifiedTabsByWorktree: {},
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'host-tab-1',
+      openFiles: [],
+      closeTab,
+      setActiveTab: vi.fn()
+    })
+
+    closeTerminalTab('host-tab-1')
+
+    expect(closeTab).toHaveBeenCalledWith('host-tab-1', {
+      reason: undefined,
+      remoteCloseOwnedByHost: true
+    })
+    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      tabId: 'host-tab-1',
+      environmentId: 'owner-runtime',
+      reason: 'user'
+    })
+  })
+
+  it('fails closed when live PTY bindings name conflicting runtime owners', () => {
+    const closeTab = vi.fn()
+    const onCancel = vi.fn()
+    isWebRuntimeSessionActiveMock.mockReturnValue(true)
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: 'runtime-a' },
+      repos: [{ id: 'repo-1', executionHostId: 'runtime:runtime-a', connectionId: null }],
+      worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }] },
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'host-tab-1',
+            ptyId: 'remote:runtime-a@@terminal-1',
+            worktreeId: 'wt-1'
+          }
+        ]
+      },
+      ptyIdsByTabId: { 'host-tab-1': ['remote:runtime-b@@terminal-2'] },
+      unifiedTabsByWorktree: {},
+      closeTab
+    })
+
+    closeTerminalTab('host-tab-1', { onCancel })
+
+    expect(onCancel).toHaveBeenCalledOnce()
+    expect(closeTab).not.toHaveBeenCalled()
+    expect(closeWebRuntimeSessionTabMock).not.toHaveBeenCalled()
+  })
+
+  it('does not route a close from a persisted layout binding alone', () => {
+    const closeTab = vi.fn()
+    const onCancel = vi.fn()
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: 'focused-runtime' },
+      repos: [],
+      tabsByWorktree: {
+        'wt-1': [{ id: 'host-tab-1', ptyId: null, worktreeId: 'wt-1' }]
+      },
+      ptyIdsByTabId: {},
+      terminalLayoutsByTabId: {
+        'host-tab-1': {
+          activeLeafId: 'leaf-1',
+          ptyIdsByLeafId: { 'leaf-1': 'remote:stale-runtime@@terminal-1' }
+        }
+      },
+      unifiedTabsByWorktree: {},
+      closeTab
+    })
+
+    closeTerminalTab('host-tab-1', { onCancel })
+
+    expect(onCancel).toHaveBeenCalledOnce()
+    expect(closeTab).not.toHaveBeenCalled()
+    expect(closeWebRuntimeSessionTabMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-tab-runtime-environment.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-runtime-environment.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '@/store/types'
+import { resolveTerminalTabRuntimeEnvironment } from './terminal-tab-runtime-environment'
+
+function makeState(ptyIds: string[]): Pick<AppState, 'tabsByWorktree' | 'ptyIdsByTabId'> {
+  return {
+    tabsByWorktree: {
+      'wt-1': [
+        {
+          id: 'tab-1',
+          ptyId: ptyIds[0] ?? null,
+          worktreeId: 'wt-1',
+          title: 'Terminal',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 0
+        }
+      ]
+    },
+    ptyIdsByTabId: { 'tab-1': ptyIds.slice(1) }
+  }
+}
+
+describe('resolveTerminalTabRuntimeEnvironment', () => {
+  it('returns the unique environment from terminal PTY evidence', () => {
+    const state = makeState(['remote:runtime-a@@terminal-1', 'remote:runtime-a@@terminal-2'])
+
+    expect(resolveTerminalTabRuntimeEnvironment(state, 'wt-1', 'tab-1')).toEqual({
+      kind: 'runtime',
+      environmentId: 'runtime-a'
+    })
+  })
+
+  it('rejects conflicting remote PTY owners', () => {
+    const state = makeState(['remote:runtime-a@@terminal-1', 'remote:runtime-b@@terminal-2'])
+
+    expect(resolveTerminalTabRuntimeEnvironment(state, 'wt-1', 'tab-1')).toEqual({
+      kind: 'conflict'
+    })
+  })
+
+  it('returns no owner without live PTY evidence', () => {
+    expect(resolveTerminalTabRuntimeEnvironment(makeState([]), 'wt-1', 'tab-1')).toEqual({
+      kind: 'none'
+    })
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-tab-runtime-environment.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-runtime-environment.ts
@@ -1,0 +1,33 @@
+import type { AppState } from '@/store/types'
+import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
+
+type TerminalTabRuntimeEnvironmentState = Pick<AppState, 'tabsByWorktree' | 'ptyIdsByTabId'>
+
+export type TerminalTabRuntimeEnvironment =
+  | { kind: 'none' }
+  | { kind: 'runtime'; environmentId: string }
+  | { kind: 'conflict' }
+
+/** Resolves a terminal tab's remote owner only when all live PTY bindings agree. */
+export function resolveTerminalTabRuntimeEnvironment(
+  state: TerminalTabRuntimeEnvironmentState,
+  worktreeId: string,
+  terminalTabId: string
+): TerminalTabRuntimeEnvironment {
+  const tab = state.tabsByWorktree[worktreeId]?.find((entry) => entry.id === terminalTabId)
+  const ptyIds = [tab?.ptyId, ...(state.ptyIdsByTabId?.[terminalTabId] ?? [])]
+  let ownerEnvironmentId: string | null = null
+  for (const ptyId of ptyIds) {
+    const environmentId = ptyId ? getRemoteRuntimePtyEnvironmentId(ptyId) : null
+    if (!environmentId) {
+      continue
+    }
+    if (ownerEnvironmentId && ownerEnvironmentId !== environmentId) {
+      return { kind: 'conflict' }
+    }
+    ownerEnvironmentId = environmentId
+  }
+  return ownerEnvironmentId
+    ? { kind: 'runtime', environmentId: ownerEnvironmentId }
+    : { kind: 'none' }
+}

--- a/src/renderer/src/runtime/web-session-tabs-sync-terminal-mirroring.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-terminal-mirroring.test.ts
@@ -477,8 +477,6 @@ describe('applyWebSessionTabsSnapshot', () => {
 
     const patch = applyWebSessionTabsSnapshot(
       makeState({
-        repos: [{ id: 'repo', connectionId: null, executionHostId: `runtime:${ENV}` }],
-        worktreesByRepo: { repo: [{ id: WT, repoId: 'repo' }] },
         tabsByWorktree: { [WT]: [pendingTab] },
         activeTabId: pendingTab.id,
         activeTabIdByWorktree: { [WT]: pendingTab.id }

--- a/src/renderer/src/runtime/web-session-tabs-sync-terminal-mirroring.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-terminal-mirroring.test.ts
@@ -477,6 +477,8 @@ describe('applyWebSessionTabsSnapshot', () => {
 
     const patch = applyWebSessionTabsSnapshot(
       makeState({
+        repos: [{ id: 'repo', connectionId: null, executionHostId: `runtime:${ENV}` }],
+        worktreesByRepo: { repo: [{ id: WT, repoId: 'repo' }] },
         tabsByWorktree: { [WT]: [pendingTab] },
         activeTabId: pendingTab.id,
         activeTabIdByWorktree: { [WT]: pendingTab.id }

--- a/src/renderer/src/runtime/web-session-tabs-sync-test-harness.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-test-harness.ts
@@ -6,7 +6,7 @@ import { resetWebSessionReorderIntentForTests } from './web-session-reorder-inte
 import { resetWebAgentSessionHandoffsForTests } from './web-agent-session-handoff'
 import {
   resetWebSessionTabsSnapshotFreshnessForTests,
-  type WebSessionTabsSyncState
+  type WebSessionTabsSyncInputState
 } from './web-session-tabs-sync'
 
 export const WT = 'repo::/worktree'
@@ -37,8 +37,8 @@ export function layoutHasGroup(layout: TabGroupLayoutNode | undefined, groupId: 
 }
 
 export function makeState(
-  overrides: Partial<WebSessionTabsSyncState> = {}
-): WebSessionTabsSyncState {
+  overrides: Partial<WebSessionTabsSyncInputState> = {}
+): WebSessionTabsSyncInputState {
   return {
     activeBrowserTabId: null,
     activeBrowserTabIdByWorktree: {},

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -367,6 +367,52 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect({ ...state, ...patch }.tabsByWorktree[WT]).toContainEqual(tab)
   })
 
+  it('keeps a pending activation tab when worktree ownership is ambiguous', () => {
+    const tab: TerminalTab = {
+      id: 'ambiguous-owner-pending-tab',
+      ptyId: null,
+      worktreeId: WT,
+      title: 'Terminal',
+      defaultTitle: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW - 1,
+      pendingActivationSpawn: true
+    }
+    const state = makeState({
+      tabsByWorktree: { [WT]: [tab] },
+      detectedWorktreesByRepo: {
+        'repo-a': {
+          worktrees: [{ id: WT, repoId: 'repo-a', hostId: 'runtime:runtime-a' }]
+        },
+        'repo-b': {
+          worktrees: [{ id: WT, repoId: 'repo-b', hostId: 'runtime:runtime-b' }]
+        }
+      }
+    })
+
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'Terminal',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-1'
+        }
+      ]),
+      'runtime-a',
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect({ ...state, ...patch }.tabsByWorktree[WT]).toContainEqual(tab)
+  })
+
   it('ignores stale or duplicate same-epoch snapshots after a newer version was applied', () => {
     const state = makeState()
     const newer = makeSnapshot([], { snapshotVersion: 3, activeTabType: null })

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import {
+  UNPUBLISHED_WORKTREE_PUBLICATION_EPOCH,
+  type RuntimeMobileSessionTabsResult
+} from '../../../shared/runtime-types'
 import { toWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import {
@@ -126,6 +129,242 @@ describe('applyWebSessionTabsSnapshot', () => {
 
     expect(patch.unifiedTabsByWorktree?.[WT]).toBeUndefined()
     expect(patch.activeTabTypeByWorktree?.[WT]).toBe('terminal')
+  })
+
+  it('prunes an aged null-PTY tab after an authoritative host snapshot omits it', () => {
+    const staleTab: TerminalTab = {
+      id: 'stale-local-tab',
+      ptyId: null,
+      worktreeId: WT,
+      title: 'Claude',
+      defaultTitle: 'Claude',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW - 31_000,
+      launchAgent: 'claude'
+    }
+
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        repos: [{ id: 'repo', connectionId: null, executionHostId: `runtime:${ENV}` }],
+        worktreesByRepo: { repo: [{ id: WT, repoId: 'repo' }] },
+        tabsByWorktree: { [WT]: [staleTab] },
+        unifiedTabsByWorktree: {
+          [WT]: [
+            {
+              id: staleTab.id,
+              entityId: staleTab.id,
+              groupId: 'group-1',
+              worktreeId: WT,
+              contentType: 'terminal',
+              label: staleTab.title,
+              customLabel: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: staleTab.createdAt,
+              isPreview: false,
+              isPinned: false
+            }
+          ]
+        }
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'Codex',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          launchAgent: 'codex',
+          status: 'ready',
+          terminal: 'terminal-1'
+        }
+      ]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.tabsByWorktree?.[WT]?.map((tab) => tab.id)).toEqual([
+      toWebTerminalSurfaceTabId('host-tab-1')
+    ])
+    expect(patch.unifiedTabsByWorktree?.[WT]?.map((tab) => tab.entityId)).toEqual([
+      toWebTerminalSurfaceTabId('host-tab-1')
+    ])
+    expect(patch.ptyIdsByTabId?.[toWebTerminalSurfaceTabId('host-tab-1')]).toEqual([
+      `remote:${ENV}@@terminal-1`
+    ])
+  })
+
+  it('keeps a fresh null-PTY placeholder during its create grace period', () => {
+    const freshTab: TerminalTab = {
+      id: 'fresh-local-tab',
+      ptyId: null,
+      worktreeId: WT,
+      title: 'Codex',
+      defaultTitle: 'Codex',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW - 29_000,
+      launchAgent: 'codex'
+    }
+
+    const state = makeState({ tabsByWorktree: { [WT]: [freshTab] } })
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      makeSnapshot([], { activeTabType: null }),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect({ ...state, ...patch }.tabsByWorktree[WT]).toEqual([freshTab])
+  })
+
+  it('keeps an aged null-PTY tab while a live PTY binding remains', () => {
+    const livePtyId = `remote:${ENV}@@terminal-live`
+    const reconnectingTab: TerminalTab = {
+      id: 'reconnecting-tab',
+      ptyId: null,
+      worktreeId: WT,
+      title: 'Terminal',
+      defaultTitle: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW - 60_000,
+      pendingActivationSpawn: true
+    }
+    const state = makeState({
+      repos: [{ id: 'repo', connectionId: null, executionHostId: `runtime:${ENV}` }],
+      worktreesByRepo: { repo: [{ id: WT, repoId: 'repo' }] },
+      tabsByWorktree: { [WT]: [reconnectingTab] },
+      ptyIdsByTabId: { [reconnectingTab.id]: [livePtyId] }
+    })
+
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'Other terminal',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-other'
+        }
+      ]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+    const applied = { ...state, ...patch }
+
+    expect(applied.tabsByWorktree[WT]).toContainEqual(reconnectingTab)
+    expect(applied.ptyIdsByTabId[reconnectingTab.id]).toEqual([livePtyId])
+  })
+
+  it('keeps an aged null-PTY tab while PTY loss is unverifiable', () => {
+    const tab: TerminalTab = {
+      id: 'unverified-tab',
+      ptyId: null,
+      worktreeId: WT,
+      title: 'Terminal',
+      defaultTitle: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW - 60_000
+    }
+    const state = makeState({
+      repos: [{ id: 'repo', connectionId: null, executionHostId: `runtime:${ENV}` }],
+      worktreesByRepo: { repo: [{ id: WT, repoId: 'repo' }] },
+      tabsByWorktree: { [WT]: [tab] },
+      unverifiedPtyLossTabIds: { [tab.id]: true }
+    })
+
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      makeSnapshot([], { activeTabType: null }),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect({ ...state, ...patch }.tabsByWorktree[WT]).toEqual([tab])
+  })
+
+  it('keeps an aged null-PTY tab when the host inventory is not published yet', () => {
+    const tab: TerminalTab = {
+      id: 'restart-placeholder',
+      ptyId: null,
+      worktreeId: WT,
+      title: 'Terminal',
+      defaultTitle: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW - 60_000
+    }
+    const state = makeState({
+      repos: [{ id: 'repo', connectionId: null, executionHostId: `runtime:${ENV}` }],
+      worktreesByRepo: { repo: [{ id: WT, repoId: 'repo' }] },
+      tabsByWorktree: { [WT]: [tab] }
+    })
+
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      makeSnapshot([], {
+        publicationEpoch: UNPUBLISHED_WORKTREE_PUBLICATION_EPOCH,
+        snapshotVersion: 0,
+        activeTabType: null
+      }),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect({ ...state, ...patch }.tabsByWorktree[WT]).toEqual([tab])
+  })
+
+  it('keeps an aged null-PTY tab when another runtime publishes the same worktree id', () => {
+    const tab: TerminalTab = {
+      id: 'other-runtime-placeholder',
+      ptyId: null,
+      worktreeId: WT,
+      title: 'Terminal',
+      defaultTitle: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW - 60_000,
+      pendingActivationSpawn: true
+    }
+    const state = makeState({
+      repos: [{ id: 'repo', connectionId: null, executionHostId: `runtime:${ENV}` }],
+      worktreesByRepo: { repo: [{ id: WT, repoId: 'repo' }] },
+      tabsByWorktree: { [WT]: [tab] }
+    })
+
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'Other runtime terminal',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-other'
+        }
+      ]),
+      'other-runtime',
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect({ ...state, ...patch }.tabsByWorktree[WT]).toContainEqual(tab)
   })
 
   it('ignores stale or duplicate same-epoch snapshots after a newer version was applied', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -56,6 +56,7 @@ import {
   getExplicitRuntimeEnvironmentIdForWorktree,
   type WorktreeRuntimeOwnerState
 } from '@/lib/worktree-runtime-owner'
+import { resolveWorktreeOperationRouteResult } from '@/lib/worktree-operation-route'
 import {
   clearHostSessionMirrorHydration,
   markHostSessionMirrorHydrated,
@@ -1396,7 +1397,8 @@ function shouldReplaceTerminalTab(
   now: number,
   hasReconnectEvidence: boolean,
   hostAffirmsWorktreeContents: boolean,
-  tabBelongsToEnvironment: boolean
+  tabBelongsToEnvironment: boolean,
+  worktreeOwnerIsMissing: boolean
 ): boolean {
   if (exactProvisionalHandoffs.has(tab.id)) {
     // Why: agent kind is not session identity; retire only the provisional tab
@@ -1411,7 +1413,11 @@ function shouldReplaceTerminalTab(
     if (hasReconnectEvidence) {
       return false
     }
-    if (tab.pendingActivationSpawn && tabBelongsToEnvironment && nextRemotePtyIds.size > 0) {
+    if (
+      tab.pendingActivationSpawn &&
+      nextRemotePtyIds.size > 0 &&
+      (tabBelongsToEnvironment || worktreeOwnerIsMissing)
+    ) {
       return true
     }
     // Why: a worktree has one execution host, so null-PTY placeholders inherit this
@@ -3188,6 +3194,8 @@ function applyWebSessionTabsSnapshotWithContext(
   const snapshotAffirmsWorktreeContents = hostSnapshotAffirmsWorktreeContents(snapshot)
   const nullPtyTabsBelongToEnvironment =
     getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId) === environmentId
+  const worktreeOwnerIsMissing =
+    resolveWorktreeOperationRouteResult(state, worktreeId).kind === 'missing'
   const retainedTerminalTabs = reconcilesNonAgentTabs
     ? currentTerminalTabs.filter(
         (tab) =>
@@ -3200,7 +3208,8 @@ function applyWebSessionTabsSnapshotWithContext(
             now,
             nullPtyTabHasRetentionEvidence(state, tab),
             snapshotAffirmsWorktreeContents,
-            nullPtyTabsBelongToEnvironment
+            nullPtyTabsBelongToEnvironment,
+            worktreeOwnerIsMissing
           )
       )
     : currentTerminalTabs

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -23,7 +23,10 @@ import type {
   RuntimeMobileSessionTabGroup,
   RuntimeMobileSessionTerminalClientTab
 } from '../../../shared/runtime-types'
-import { hostSnapshotAffirmsClientHostedPages } from './host-session-snapshot-authority'
+import {
+  hostSnapshotAffirmsClientHostedPages,
+  hostSnapshotAffirmsWorktreeContents
+} from './host-session-snapshot-authority'
 import type {
   BrowserCertificateFailure,
   BrowserPage,
@@ -43,12 +46,16 @@ import {
   buildRetiredTerminalTabStateSweepPatch,
   type RetiredTerminalTabSweepState
 } from '../store/slices/retired-terminal-tab-state-sweep'
+import { terminalTabHasReconnectablePty } from '../store/slices/terminal-orphan-helpers'
 import { getRemoteRuntimePtyEnvironmentId, toRemoteRuntimePtyId } from './runtime-terminal-stream'
 import { sanitizeTerminalLayoutPaneTitlesForLabels } from '@/lib/terminal-pane-title-sanitization'
 import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
 import { normalizeTerminalLayoutPtyOwnership } from '@/components/terminal-pane/terminal-layout-pty-ownership'
 import { isClientAuthoritativeAgentStatusPane } from '@/components/terminal-pane/renderer-owned-agent-status-registry'
-import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  getExplicitRuntimeEnvironmentIdForWorktree,
+  type WorktreeRuntimeOwnerState
+} from '@/lib/worktree-runtime-owner'
 import {
   clearHostSessionMirrorHydration,
   markHostSessionMirrorHydrated,
@@ -133,6 +140,7 @@ import {
 } from '../../../shared/runtime-browser-placement'
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
+const REMOTE_NULL_PTY_TAB_GRACE_MS = 30_000
 export const WEB_SESSION_TABS_VISIBILITY_RESUME_STAGGER_MS = 100
 
 type SessionTabsStreamEvent =
@@ -339,13 +347,19 @@ export type WebSessionTabsSyncState = Pick<
       | 'automaticAgentResumeClaimsByTabId'
       | 'migrationUnsupportedByPtyId'
       | 'paneForegroundAgentByPaneKey'
+      | 'lastKnownRelayPtyIdByTabId'
+      | 'deferredSshSessionIdsByTabId'
+      | 'pendingReconnectPtyIdByTabId'
       | 'pendingStartupByTabId'
       | 'recentlyClosedAgentStatusTabIds'
       | 'recentlyRetiredAgentStatusPaneKeys'
       | 'retainedAgentsByPaneKey'
       | 'retentionSuppressedPaneKeys'
+      | 'unverifiedPtyLossTabIds'
     >
   >
+
+export type WebSessionTabsSyncInputState = WebSessionTabsSyncState & WorktreeRuntimeOwnerState
 
 type WebSessionTabsBatchRecordKey =
   | 'activeBrowserTabIdByWorktree'
@@ -1378,7 +1392,11 @@ function shouldReplaceTerminalTab(
   environmentId: string,
   nextRemotePtyIds: ReadonlySet<string>,
   nextMirroredTerminalIds: ReadonlySet<string>,
-  exactProvisionalHandoffs: ReadonlySet<string>
+  exactProvisionalHandoffs: ReadonlySet<string>,
+  now: number,
+  hasReconnectEvidence: boolean,
+  hostAffirmsWorktreeContents: boolean,
+  tabBelongsToEnvironment: boolean
 ): boolean {
   if (exactProvisionalHandoffs.has(tab.id)) {
     // Why: agent kind is not session identity; retire only the provisional tab
@@ -1389,8 +1407,22 @@ function shouldReplaceTerminalTab(
     // Why: host snapshots are authoritative for mirrored tabs; replace old mirrors even when the next surface still awaits a stream handle, else parity drifts.
     return true
   }
-  if (tab.pendingActivationSpawn && tab.ptyId === null && nextRemotePtyIds.size > 0) {
-    return true
+  if (tab.ptyId === null) {
+    if (hasReconnectEvidence) {
+      return false
+    }
+    if (tab.pendingActivationSpawn && tabBelongsToEnvironment && nextRemotePtyIds.size > 0) {
+      return true
+    }
+    // Why: a worktree has one execution host, so null-PTY placeholders inherit this
+    // snapshot's owner; after the bounded create window, omission proves they are ghosts.
+    if (
+      hostAffirmsWorktreeContents &&
+      tabBelongsToEnvironment &&
+      now - tab.createdAt >= REMOTE_NULL_PTY_TAB_GRACE_MS
+    ) {
+      return true
+    }
   }
   if (!isRuntimeTerminalTabForEnvironment(tab, environmentId)) {
     return false
@@ -1400,6 +1432,23 @@ function shouldReplaceTerminalTab(
     tab.ptyId !== null &&
     (nextRemotePtyIds.has(tab.ptyId) ||
       nextMirroredTerminalIds.has(toWebTerminalSurfaceTabId(tab.id)))
+  )
+}
+
+function nullPtyTabHasRetentionEvidence(state: WebSessionTabsSyncState, tab: TerminalTab): boolean {
+  if (state.unverifiedPtyLossTabIds?.[tab.id]) {
+    return true
+  }
+  return terminalTabHasReconnectablePty(
+    {
+      ptyIdsByTabId: state.ptyIdsByTabId,
+      lastKnownRelayPtyIdByTabId: state.lastKnownRelayPtyIdByTabId ?? {},
+      deferredSshSessionIdsByTabId: state.deferredSshSessionIdsByTabId ?? {},
+      pendingReconnectPtyIdByTabId: state.pendingReconnectPtyIdByTabId ?? {},
+      unverifiedPtyLossTabIds: state.unverifiedPtyLossTabIds ?? {}
+    },
+    tab.id,
+    tab.ptyId
   )
 }
 
@@ -3023,7 +3072,7 @@ function toVisibleTabType(tab: Tab): WebSessionTabsSyncState['activeTabType'] {
 }
 
 function applyWebSessionTabsSnapshotWithContext(
-  state: WebSessionTabsSyncState,
+  state: WebSessionTabsSyncInputState,
   rawSnapshot: RuntimeMobileSessionTabsResult,
   environmentId: string,
   now = Date.now(),
@@ -3136,6 +3185,9 @@ function applyWebSessionTabsSnapshotWithContext(
     }
   }
   const exactProvisionalHandoffs = new Set(provisionalHandoffHostTabIds.keys())
+  const snapshotAffirmsWorktreeContents = hostSnapshotAffirmsWorktreeContents(snapshot)
+  const nullPtyTabsBelongToEnvironment =
+    getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId) === environmentId
   const retainedTerminalTabs = reconcilesNonAgentTabs
     ? currentTerminalTabs.filter(
         (tab) =>
@@ -3144,7 +3196,11 @@ function applyWebSessionTabsSnapshotWithContext(
             environmentId,
             nextRemotePtyIds,
             nextMirroredTerminalIds,
-            exactProvisionalHandoffs
+            exactProvisionalHandoffs,
+            now,
+            nullPtyTabHasRetentionEvidence(state, tab),
+            snapshotAffirmsWorktreeContents,
+            nullPtyTabsBelongToEnvironment
           )
       )
     : currentTerminalTabs
@@ -4308,7 +4364,7 @@ function applyWebSessionTabsSnapshotWithContext(
 }
 
 export function applyWebSessionTabsSnapshot(
-  state: WebSessionTabsSyncState,
+  state: WebSessionTabsSyncInputState,
   rawSnapshot: RuntimeMobileSessionTabsResult,
   environmentId: string,
   now = Date.now(),
@@ -4325,7 +4381,7 @@ export function applyWebSessionTabsSnapshot(
 }
 
 export function applyWebSessionTabsSnapshots(
-  state: WebSessionTabsSyncState,
+  state: WebSessionTabsSyncInputState,
   snapshots: readonly RuntimeMobileSessionTabsResult[],
   environmentId: string,
   now = Date.now()
@@ -4360,7 +4416,7 @@ export function applyWebSessionTabsSnapshots(
 }
 
 export function applyFreshWebSessionTabsSnapshot(
-  state: WebSessionTabsSyncState,
+  state: WebSessionTabsSyncInputState,
   snapshot: RuntimeMobileSessionTabsResult,
   environmentId: string,
   now = Date.now()
@@ -4372,7 +4428,7 @@ export function applyFreshWebSessionTabsSnapshot(
 }
 
 export function applyFreshWebSessionTabsSnapshots(
-  state: WebSessionTabsSyncState,
+  state: WebSessionTabsSyncInputState,
   snapshots: readonly RuntimeMobileSessionTabsResult[],
   environmentId: string,
   now = Date.now()
@@ -4411,7 +4467,7 @@ function decideWebSessionTabsSnapshotOperations(
 }
 
 function applyWebSessionTabsSnapshotOperations(
-  state: WebSessionTabsSyncState,
+  state: WebSessionTabsSyncInputState,
   operations: readonly DecidedWebSessionTabsSnapshotOperation[]
 ): WebSessionTabsSyncState | Partial<WebSessionTabsSyncState> {
   let nextState = state


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​470 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​469 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​144 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​124 |

<!-- /orca-pr-loc -->

## ELI5

A paired viewer could keep blank terminal tabs after the owning host had stopped publishing them. This waits through a short create window, then removes only viewer-side ghosts when a published host inventory and explicit worktree owner agree. Closing a real remote tab can also reach its host during a catalog hydration gap, but ambiguous ownership fails closed.

## What Changed

- prune null-PTY placeholders after 30 seconds only when the authoritative host inventory is published, the worktree owner matches that environment, and no PTY/reconnect evidence remains
- preserve exact structured-create handoffs, fresh placeholders, unpublished restart frames, cross-environment collisions, and unverifiable PTY loss
- resolve catalog-gap explicit closes from one agreeing live remote PTY owner; reject conflicting, persisted-layout-only, and unresolved SSH ownership
- register the lifecycle contracts and focused regressions in the reliability gate

## Why

Current `origin/main` reproduced both failures deterministically: an aged null-PTY viewer placeholder survived an authoritative omission, and a catalog-gap close dispatched no host call. Pruning belongs in renderer mirror reconciliation and must never infer PTY death; explicit close routing belongs at the live PTY ownership boundary.

## Linked Issue

Fixes #11800

Related: #17767. Supersedes #11801; the implementations should not be combined.

## Visual Proof

N/A — this changes renderer state reconciliation and close routing without adding or changing UI.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Deterministic oracle:

- baseline `origin/main` (`f8a3f2c7c0` when reproduced): stale ghost remained; catalog-gap close issued zero host calls
- candidate: 5 focused files, 72 tests passed
- causal reverts: removing only age pruning made the stale-ghost regression red; disabling only live-owner resolution made the catalog-gap close regression red
- restored candidate: both regressions green and `git diff HEAD` empty

Validation:

- related reliability suite: 23 files, 1500 passed, 1 skipped
- `pnpm tc`
- `pnpm tc:web`
- focused `oxlint --deny-warnings`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:reliability-gates`
- `pnpm run build:electron-vite`
- `git diff --check`

## AI Disclosure

## Review

Three fresh `gpt-5.6-luna` Codex reviewers independently assessed the ownership boundary, product/compatibility decisions, and regression risk. Valid initial findings were reproduced and fixed; all three final bounded reviews returned `CLEAN`.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Null-PTY pruning mutates only the viewer mirror and never invokes a host close or PTY kill.
- No RPC fields, stream opcodes, or other remote-wire contracts changed.
- SSH-shaped PTYs remain fail-closed without catalog ownership because their IDs do not identify a paired runtime.
- Folder-workspace ownership is explicit; no git-worktree assumption or platform-specific path/process behavior was added.
- The older #11801 trusts persisted layout PTY evidence and lacks the published-inventory, owner-match, reconnect, and conflict guards; this PR is the safer replacement.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

