### PR TITLE
fix(dev): make reclaim report real sizes on Windows and keep setuid intact

### DIFF
--- a/config/scripts/reclaim-electron-dists.mjs
+++ b/config/scripts/reclaim-electron-dists.mjs
@@ -6,7 +6,15 @@
 
 import { execFileSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { existsSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
 import path from 'node:path'
 import {
   hasAdoptedSharedElectronDist,
@@ -33,14 +41,24 @@ function listWorktrees(root) {
     .map((line) => line.slice('worktree '.length).trim())
 }
 
-function measure(distPath) {
+/** Apparent size, walked in Node: `du` does not exist on Windows, where it silently reported 0. */
+function measure(targetPath) {
+  let total = 0
+  let entries
   try {
-    return (
-      Number(execFileSync('du', ['-sk', distPath], { encoding: 'utf8' }).split(/\s+/)[0]) * 1024
-    )
+    entries = readdirSync(targetPath, { withFileTypes: true })
   } catch {
     return 0
   }
+  for (const entry of entries) {
+    const entryPath = path.join(targetPath, entry.name)
+    if (entry.isDirectory()) {
+      total += measure(entryPath)
+    } else if (!entry.isSymbolicLink()) {
+      total += statSync(entryPath, { throwIfNoEntry: false })?.size ?? 0
+    }
+  }
+  return total
 }
 
 /** Swap in a shared copy behind a rename, so an interrupted run never leaves a partial dist. */

--- a/config/scripts/space-sharing-copy.mjs
+++ b/config/scripts/space-sharing-copy.mjs
@@ -7,6 +7,7 @@ import {
   readdirSync,
   readlinkSync,
   rmSync,
+  statSync,
   symlinkSync
 } from 'node:fs'
 import { join } from 'node:path'
@@ -100,7 +101,10 @@ export function makeTreeReadOnly(targetPath, chmod = chmodSync) {
     if (entry.isDirectory()) {
       makeTreeReadOnly(entryPath, chmod)
     } else if (!entry.isSymbolicLink()) {
-      chmod(entryPath, 0o555)
+      // Clear the write bits and nothing else. A flat 0o555 would strip setuid from
+      // chrome-sandbox, and under hardlink sharing it would strip it in every worktree at once.
+      const mode = statSync(entryPath, { throwIfNoEntry: false })?.mode
+      chmod(entryPath, mode === undefined ? 0o555 : mode & ~0o222)
     }
   }
   chmod(targetPath, 0o755)

--- a/config/scripts/space-sharing-copy.test.ts
+++ b/config/scripts/space-sharing-copy.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -143,6 +144,16 @@ describe('makeTreeReadOnly', () => {
     makeTreeReadOnly(destination)
     expect(() => writeFileSync(path.join(destination, 'nested', 'file'), 'mutated')).toThrow()
     expect(readFileSync(path.join(source, 'nested', 'file'), 'utf8')).toBe('contents')
+  })
+
+  it.runIf(process.platform !== 'win32')('preserves setuid, which chrome-sandbox needs', () => {
+    const { source } = makeTree()
+    const sandbox = path.join(source, 'chrome-sandbox')
+    writeFileSync(sandbox, 'binary')
+    chmodSync(sandbox, 0o4755)
+    makeTreeReadOnly(source)
+    expect(statSync(sandbox).mode & 0o4000).toBe(0o4000)
+    expect(statSync(sandbox).mode & 0o222).toBe(0)
   })
 
   it.runIf(process.platform !== 'win32')(


### PR DESCRIPTION
Follow-up to #17664, from actually running `pnpm reclaim:electron-dists` on real Linux and Windows hosts.

## Two bugs

**Sizes read as zero on Windows.** The report shelled out to `du`, which does not exist there, and the failure was swallowed — so every worktree measured 0 bytes and the script claimed nothing was reclaimable on the platform with the *largest* dist (374 MB). Now walked in Node.

**`makeTreeReadOnly` cleared setuid.** It chmod'd files to a flat `0o555`. On Linux that silently strips the bit from `chrome-sandbox` if a developer has run the usual `sudo chown root:root && chmod 4755` workaround — and under hardlink sharing it would strip it from every worktree and the shared cache at once. Now it clears the write bits and nothing else.

## Verified by running it

| host | worktrees | freed |
| --- | ---: | ---: |
| macOS (APFS) | 400 | 114.4 GiB |
| Ubuntu 24.04 / ext4 | 19 | 5.17 GiB |
| Windows / NTFS (awin) | 23 | 7.30 GiB |
| Windows / NTFS (win) | 56 | 18.31 GiB |

Every figure is a real free-space delta, not the script's own accounting. Both Windows hosts reported `0.00 GiB` before this fix.

Also confirmed the Windows file-lock case behaves as designed: worktrees with a running Electron failed the rename with `EPERM`, were skipped with a message, and were left completely untouched.

## Tests

New: setuid survives `makeTreeReadOnly` (POSIX-only, since Windows has no setuid).

`pnpm tc:node`, `oxlint`, changed-code quality gate, and the full `config/scripts` suite all pass.

---

*Note: an earlier revision of this description also covered a cross-worktree `out/electron-dev` sweep. That work is not in this PR — it is in the follow-up.*

## Visual proof

N/A — no renderer or visual behavior changed.