### PR TITLE
fix(native-chat): keep the attachments on a Claude turn that pasted images

### DIFF
--- a/src/main/native-chat/transcript-line-decoders-claude-image-companion.test.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude-image-companion.test.ts
@@ -77,4 +77,42 @@ describe('Claude pasted-image companion row', () => {
     })
     expect(decodeClaudeTranscriptLine(injected, 'fallback')).toBeNull()
   })
+
+  it('does not turn a mixed marker-and-prose meta row into an image source turn', () => {
+    const mixed = JSON.stringify({
+      type: 'user',
+      uuid: 'mixed',
+      isMeta: true,
+      message: {
+        role: 'user',
+        content: [
+          { type: 'text', text: '[Image: source: /tmp/a.png]' },
+          { type: 'text', text: 'metadata prose' }
+        ]
+      }
+    })
+
+    expect(decodeClaudeTranscriptLine(mixed, 'fallback')).toBeNull()
+  })
+
+  it('retains tool results from a mixed meta row while dropping its marker text', () => {
+    const mixed = JSON.stringify({
+      type: 'user',
+      uuid: 'mixed-tool',
+      isMeta: true,
+      message: {
+        role: 'user',
+        content: [
+          { type: 'text', text: '[Image: source: /tmp/a.png]' },
+          { type: 'tool_result', content: 'tool output' }
+        ]
+      }
+    })
+
+    expect(decodeClaudeTranscriptLine(mixed, 'fallback')).toMatchObject({
+      id: 'mixed-tool',
+      role: 'tool',
+      blocks: [{ type: 'tool-result', output: 'tool output' }]
+    })
+  })
 })

--- a/src/main/native-chat/transcript-line-decoders-claude-image-companion.test.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude-image-companion.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeImageTranscriptMessages } from '../../shared/native-chat-image-transcript-markers'
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+import { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
+
+// Verbatim shape of a pasted-image turn, Claude Code 2.1.237: the prompt row carries
+// `[Image #N]` markers plus base64 blocks (no url/path, so they decode to nothing), and
+// a SEPARATE companion row marked isMeta/turnCompanion carries one `[Image: source: ]`
+// text block per image. A survey of ~/.claude/projects found 238 of 241 image-source
+// rows marked isMeta, across every versioned release.
+const PROMPT_ROW = JSON.stringify({
+  type: 'user',
+  uuid: 'prompt-uuid',
+  timestamp: '2026-09-01T01:33:04.608Z',
+  message: {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'look at this\r[Image #1] [Image #2] does it repro?' },
+      { type: 'image', source: { type: 'base64', media_type: 'image/jpeg', data: 'AAAA' } },
+      { type: 'image', source: { type: 'base64', media_type: 'image/jpeg', data: 'BBBB' } }
+    ]
+  }
+})
+const COMPANION_ROW = JSON.stringify({
+  type: 'user',
+  uuid: 'companion-uuid',
+  isMeta: true,
+  turnCompanion: true,
+  timestamp: '2026-09-01T01:33:04.608Z',
+  message: {
+    role: 'user',
+    content: [
+      { type: 'text', text: '[Image: source: /tmp/orca-paste-a.png]' },
+      { type: 'text', text: '[Image: source: /tmp/orca-paste-b.png]' }
+    ]
+  }
+})
+
+function decode(): NativeChatMessage[] {
+  return [COMPANION_ROW, PROMPT_ROW]
+    .map((line, index) => decodeClaudeTranscriptLine(line, `fallback-${index}`))
+    .filter((message): message is NativeChatMessage => message !== null)
+}
+
+describe('Claude pasted-image companion row', () => {
+  it('keeps the isMeta companion row so the turn carries its attachments', () => {
+    const decoded = decode()
+    expect(decoded.map((m) => m.id)).toEqual(['companion-uuid', 'prompt-uuid'])
+  })
+
+  it('folds a multi-image companion into the prompt as image refs', () => {
+    const folded = normalizeImageTranscriptMessages(decode())
+    expect(folded).toHaveLength(1)
+    expect(folded[0]!.blocks.filter((b) => b.type === 'image-ref')).toEqual([
+      { type: 'image-ref', path: '/tmp/orca-paste-a.png' },
+      { type: 'image-ref', path: '/tmp/orca-paste-b.png' }
+    ])
+    // The caption survives with its markers stripped.
+    const text = folded[0]!.blocks
+      .filter((b) => b.type === 'text')
+      .map((b) => b.text)
+      .join('')
+    expect(text).toContain('look at this')
+    expect(text).toContain('does it repro?')
+    expect(text).not.toContain('[Image #')
+  })
+
+  it('still drops an ordinary isMeta injected turn', () => {
+    const injected = JSON.stringify({
+      type: 'user',
+      uuid: 'injected',
+      isMeta: true,
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Base directory for this skill: /x' }]
+      }
+    })
+    expect(decodeClaudeTranscriptLine(injected, 'fallback')).toBeNull()
+  })
+})

--- a/src/main/native-chat/transcript-line-decoders-claude.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.ts
@@ -11,6 +11,7 @@ import {
   parseJsonObject,
   timestampMs
 } from '../ai-vault/session-scanner-values'
+import { imageSourcePathFromText } from '../../shared/native-chat-image-transcript-markers'
 import { claudeContentBlocks } from './transcript-record-blocks'
 import { claudeInterruptedMessageId } from './transcript-turn-markers'
 
@@ -49,8 +50,17 @@ export function decodeClaudeTranscriptLine(
   const isInjectedUserTurn =
     role === 'user' &&
     (record.isMeta === true || record.isSynthetic === true || record.isCompactSummary === true)
+  // Why image-source text survives the filter: Claude records a pasted image as a
+  // companion turn marked `isMeta`, holding one `[Image: source: <path>]` block per
+  // image. Dropping it left the prompt turn with no trace of its attachments — the
+  // base64 blocks on the prompt itself carry no url/path and are dropped too — so a
+  // turn with images rendered with no images at all.
   const blocks = isInjectedUserTurn
-    ? decodedBlocks.filter((block) => block.type === 'tool-result')
+    ? decodedBlocks.filter(
+        (block) =>
+          block.type === 'tool-result' ||
+          (block.type === 'text' && imageSourcePathFromText(block.text) !== null)
+      )
     : decodedBlocks
   if (blocks.length === 0) {
     return null

--- a/src/main/native-chat/transcript-line-decoders-claude.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.ts
@@ -56,11 +56,9 @@ export function decodeClaudeTranscriptLine(
   // base64 blocks on the prompt itself carry no url/path and are dropped too — so a
   // turn with images rendered with no images at all.
   const blocks = isInjectedUserTurn
-    ? decodedBlocks.filter(
-        (block) =>
-          block.type === 'tool-result' ||
-          (block.type === 'text' && imageSourcePathFromText(block.text) !== null)
-      )
+    ? isImageSourceRecord(decodedBlocks)
+      ? decodedBlocks
+      : decodedBlocks.filter((block) => block.type === 'tool-result')
     : decodedBlocks
   if (blocks.length === 0) {
     return null
@@ -73,6 +71,15 @@ export function decodeClaudeTranscriptLine(
     timestamp,
     source: 'transcript'
   }
+}
+
+// Keep only genuine image companion records; a marker mixed with prose must
+// remain an injected turn (or be dropped), never become an image-source turn.
+function isImageSourceRecord(blocks: NativeChatBlock[]): boolean {
+  return (
+    blocks.length > 0 &&
+    blocks.every((block) => block.type === 'text' && imageSourcePathFromText(block.text) !== null)
+  )
 }
 
 // Claude marks reasoning via `thinking` content blocks; when a message is made

--- a/src/renderer/src/components/native-chat/native-chat-incremental-assembler.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-incremental-assembler.test.ts
@@ -150,4 +150,51 @@ describe('incremental assembler — oracle differential', () => {
       }
     ])
   })
+
+  it('does not cross-fold distinct equal-timestamp image turns', () => {
+    const assembler = createIncrementalAssembler()
+    const firstPrompt = msg({
+      id: 'a-first-prompt',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image #1] inspect the first' }]
+    })
+    const firstCompanion = msg({
+      id: 'z-first-companion',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image: source: /tmp/first.png]' }]
+    })
+    const secondPrompt = msg({
+      id: 'b-second-prompt',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image #1] inspect the second' }]
+    })
+    const secondCompanion = msg({
+      id: 'y-second-companion',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image: source: /tmp/second.png]' }]
+    })
+
+    const assembled = reset(assembler, [firstPrompt, firstCompanion, secondPrompt, secondCompanion])
+
+    expect(normalizeImageTranscriptMessages(assembled)).toEqual([
+      {
+        ...firstPrompt,
+        blocks: [
+          { type: 'image-ref', path: '/tmp/first.png' },
+          { type: 'text', text: 'inspect the first' }
+        ]
+      },
+      {
+        ...secondPrompt,
+        blocks: [
+          { type: 'image-ref', path: '/tmp/second.png' },
+          { type: 'text', text: 'inspect the second' }
+        ]
+      }
+    ])
+  })
 })

--- a/src/renderer/src/components/native-chat/native-chat-incremental-assembler.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-incremental-assembler.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import { normalizeImageTranscriptMessages } from '../../../../shared/native-chat-image-transcript-markers'
 import { assembleNativeChatSession } from './native-chat-session-assembler'
 import {
   applyAppends,
@@ -120,5 +121,33 @@ describe('incremental assembler — oracle differential', () => {
     reset(assembler, base)
     const out = assembler.messages
     expect(applyAppends(assembler, [])).toBe(out)
+  })
+
+  it('keeps equal-timestamp image companions ahead of prompts for normalization', () => {
+    const assembler = createIncrementalAssembler()
+    const prompt = msg({
+      id: 'a-prompt',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image #1] inspect this' }]
+    })
+    const companion = msg({
+      id: 'z-companion',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image: source: /tmp/image.png]' }]
+    })
+
+    const assembled = reset(assembler, [prompt, companion])
+    expect(assembled.map((message) => message.id)).toEqual(['z-companion', 'a-prompt'])
+    expect(normalizeImageTranscriptMessages(assembled)).toEqual([
+      {
+        ...prompt,
+        blocks: [
+          { type: 'image-ref', path: '/tmp/image.png' },
+          { type: 'text', text: 'inspect this' }
+        ]
+      }
+    ])
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-incremental-assembler.ts
+++ b/src/renderer/src/components/native-chat/native-chat-incremental-assembler.ts
@@ -12,8 +12,16 @@
 // Correctness invariant: applyAppends output deep-equals a full rebuild over
 // base ++ all-appends for every prefix (locked by the oracle differential test).
 
+import {
+  hasImagePromptMarker,
+  isImageSourceUserTurn
+} from '../../../../shared/native-chat-image-transcript-markers'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
-import { compareMessages, mergeOne } from './native-chat-session-assembler'
+import {
+  compareMessages,
+  mergeOne,
+  sortForImageNormalization
+} from './native-chat-session-assembler'
 
 export type IncrementalChatAssembler = {
   byId: Map<string, NativeChatMessage>
@@ -37,7 +45,7 @@ export function reset(
   for (const message of base) {
     mergeOne(assembler.byId, assembler.byTurn, message)
   }
-  assembler.messages = Array.from(assembler.byId.values()).sort(compareMessages)
+  assembler.messages = [...sortForImageNormalization(Array.from(assembler.byId.values()))]
   return assembler.messages
 }
 
@@ -66,12 +74,12 @@ export function applyAppends(
   if (grewByBatch && isTailAppend(assembler.messages, incoming)) {
     // Every incoming message is new and sorts at/after the tail: splice the
     // batch in its own sorted order without touching the existing prefix.
-    const tail = [...incoming].sort(compareMessages)
+    const tail = [...sortForImageNormalization(incoming)]
     assembler.messages = [...assembler.messages, ...tail]
     return assembler.messages
   }
 
-  assembler.messages = Array.from(assembler.byId.values()).sort(compareMessages)
+  assembler.messages = [...sortForImageNormalization(Array.from(assembler.byId.values()))]
   return assembler.messages
 }
 
@@ -86,6 +94,14 @@ function isTailAppend(
   const last = current.at(-1)
   if (!last) {
     return true
+  }
+  if (
+    hasImagePromptMarker(last) &&
+    incoming[0]?.source === last.source &&
+    incoming[0]?.timestamp === last.timestamp &&
+    isImageSourceUserTurn(incoming[0]!)
+  ) {
+    return false
   }
   for (const message of incoming) {
     // Null timestamp (sorts to the front) can never be a tail append.

--- a/src/renderer/src/components/native-chat/native-chat-session-assembler.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-assembler.test.ts
@@ -112,6 +112,35 @@ describe('assembleNativeChatSession', () => {
     ])
   })
 
+  it('folds equal-timestamp image companions before UUID ordering can split them', () => {
+    const prompt = msg({
+      id: 'a-prompt',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image #1] what do you see' }]
+    })
+    const companion = msg({
+      id: 'z-companion',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image: source: /tmp/3d.png]' }]
+    })
+
+    const session = assembleNativeChatSession({
+      // Arrival order is intentionally reversed; UUID order would be wrong too.
+      sources: { transcript: [prompt, companion] },
+      sessionId: 's1',
+      agent: 'claude'
+    })
+
+    expect(session.messages).toHaveLength(1)
+    expect(session.messages[0]).toMatchObject({ id: 'a-prompt', role: 'user' })
+    expect(session.messages[0]?.blocks).toEqual([
+      { type: 'image-ref', path: '/tmp/3d.png' },
+      { type: 'text', text: 'what do you see' }
+    ])
+  })
+
   it('merges Claude image source markers into a trailing-marker prompt', () => {
     const imageSource = msg({
       id: 'u-image-source',

--- a/src/renderer/src/components/native-chat/native-chat-session-assembler.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-assembler.test.ts
@@ -141,6 +141,92 @@ describe('assembleNativeChatSession', () => {
     ])
   })
 
+  it('keeps distinct equal-timestamp image companions with their adjacent prompts', () => {
+    const firstPrompt = msg({
+      id: 'a-first-prompt',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image #1] inspect the first' }]
+    })
+    const firstCompanion = msg({
+      id: 'z-first-companion',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image: source: /tmp/first.png]' }]
+    })
+    const secondPrompt = msg({
+      id: 'b-second-prompt',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image #1] inspect the second' }]
+    })
+    const secondCompanion = msg({
+      id: 'y-second-companion',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image: source: /tmp/second.png]' }]
+    })
+
+    const session = assembleNativeChatSession({
+      sources: {
+        transcript: [firstPrompt, firstCompanion, secondPrompt, secondCompanion]
+      },
+      sessionId: 's1',
+      agent: 'claude'
+    })
+
+    expect(session.messages).toEqual([
+      {
+        ...firstPrompt,
+        blocks: [
+          { type: 'image-ref', path: '/tmp/first.png' },
+          { type: 'text', text: 'inspect the first' }
+        ]
+      },
+      {
+        ...secondPrompt,
+        blocks: [
+          { type: 'image-ref', path: '/tmp/second.png' },
+          { type: 'text', text: 'inspect the second' }
+        ]
+      }
+    ])
+  })
+
+  it('does not move an equal-timestamp companion across an unrelated row', () => {
+    const prompt = msg({
+      id: 'a-prompt',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image #1] inspect this' }]
+    })
+    const unrelated = msg({
+      id: 'm-answer',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: 'unrelated' }]
+    })
+    const companion = msg({
+      id: 'z-companion',
+      role: 'user',
+      timestamp: 100,
+      blocks: [{ type: 'text', text: '[Image: source: /tmp/image.png]' }]
+    })
+
+    const session = assembleNativeChatSession({
+      sources: { transcript: [prompt, unrelated, companion] },
+      sessionId: 's1',
+      agent: 'claude'
+    })
+
+    expect(session.messages.map((message) => message.id)).toEqual([
+      'a-prompt',
+      'm-answer',
+      'z-companion'
+    ])
+    expect(session.messages[0]?.blocks).toEqual([{ type: 'text', text: 'inspect this' }])
+    expect(session.messages[2]?.blocks).toEqual([{ type: 'image-ref', path: '/tmp/image.png' }])
+  })
+
   it('merges Claude image source markers into a trailing-marker prompt', () => {
     const imageSource = msg({
       id: 'u-image-source',

--- a/src/renderer/src/components/native-chat/native-chat-session-assembler.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-assembler.ts
@@ -9,7 +9,7 @@ import {
 import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
 import {
   hasImagePromptMarker,
-  imageSourcePathFromText,
+  isImageSourceUserTurn,
   normalizeImageTranscriptMessages
 } from '../../../../shared/native-chat-image-transcript-markers'
 import { isLaunchPromptMessageId, isPendingMessageId } from './native-chat-pending'
@@ -118,13 +118,6 @@ export function compareMessages(a: NativeChatMessage, b: NativeChatMessage): num
   if (at !== bt) {
     return at - bt
   }
-  // Claude emits an image-source companion and its prompt at the same instant.
-  // Keep the companion adjacent and first so the normalization pass can fold it
-  // into the prompt, regardless of opaque UUID ordering.
-  const imageOrder = imageTranscriptOrder(a, b)
-  if (imageOrder !== 0) {
-    return imageOrder
-  }
   if (a.id < b.id) {
     return -1
   }
@@ -132,30 +125,6 @@ export function compareMessages(a: NativeChatMessage, b: NativeChatMessage): num
     return 1
   }
   return 0
-}
-
-function imageTranscriptOrder(a: NativeChatMessage, b: NativeChatMessage): number {
-  return imageTranscriptRank(a) - imageTranscriptRank(b)
-}
-
-function imageTranscriptRank(message: NativeChatMessage): number {
-  if (isImageSourceCompanion(message)) {
-    return 0
-  }
-  if (message.role === 'user' && hasImagePromptMarker(message)) {
-    return 2
-  }
-  return 1
-}
-
-function isImageSourceCompanion(message: NativeChatMessage): boolean {
-  return (
-    message.role === 'user' &&
-    message.blocks.length > 0 &&
-    message.blocks.every(
-      (block) => isTextBlock(block) && imageSourcePathFromText(block.text) !== null
-    )
-  )
 }
 
 /**
@@ -200,15 +169,74 @@ export function assembleNativeChatSession(
   }
 }
 
-function sortForImageNormalization(
+type ImageNormalizationUnit = {
+  messages: NativeChatMessage[]
+  sortKey: NativeChatMessage
+}
+
+// Keep only adjacent companion/prompt rows atomic; ranking every companion first
+// can cross-fold distinct turns that share a timestamp.
+export function sortForImageNormalization(
   messages: readonly NativeChatMessage[]
 ): readonly NativeChatMessage[] {
-  for (let index = 1; index < messages.length; index += 1) {
-    if (compareMessages(messages[index - 1]!, messages[index]!) > 0) {
-      return [...messages].sort(compareMessages)
+  const units: ImageNormalizationUnit[] = []
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index]!
+    const companions: NativeChatMessage[] = []
+    let prompt: NativeChatMessage | undefined
+
+    if (isImageSourceUserTurn(message)) {
+      let nextIndex = index
+      while (
+        nextIndex < messages.length &&
+        messages[nextIndex]?.source === message.source &&
+        isImageSourceUserTurn(messages[nextIndex]!)
+      ) {
+        companions.push(messages[nextIndex]!)
+        nextIndex += 1
+      }
+      const candidate = messages[nextIndex]
+      if (
+        candidate?.role === 'user' &&
+        candidate.source === message.source &&
+        hasImagePromptMarker(candidate)
+      ) {
+        prompt = candidate
+        index = nextIndex
+      } else {
+        companions.length = 0
+      }
+    } else {
+      const candidate = messages[index + 1]
+      if (
+        message.role === 'user' &&
+        hasImagePromptMarker(message) &&
+        candidate?.source === message.source &&
+        candidate.timestamp === message.timestamp &&
+        isImageSourceUserTurn(candidate)
+      ) {
+        let nextIndex = index + 1
+        while (
+          nextIndex < messages.length &&
+          messages[nextIndex]?.source === message.source &&
+          messages[nextIndex]?.timestamp === message.timestamp &&
+          isImageSourceUserTurn(messages[nextIndex]!)
+        ) {
+          companions.push(messages[nextIndex]!)
+          nextIndex += 1
+        }
+        prompt = message
+        index = nextIndex - 1
+      }
     }
+
+    const unitMessages = prompt ? [...companions, prompt] : [message]
+    units.push({ messages: unitMessages, sortKey: prompt ?? message })
   }
-  return messages
+
+  units.sort((a, b) => compareMessages(a.sortKey, b.sortKey))
+  const sorted = units.flatMap((unit) => unit.messages)
+  return sorted.every((message, index) => message === messages[index]) ? messages : sorted
 }
 
 /**

--- a/src/renderer/src/components/native-chat/native-chat-session-assembler.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-assembler.ts
@@ -7,7 +7,11 @@ import {
   type NativeChatSessionStatus
 } from '../../../../shared/native-chat-types'
 import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
-import { normalizeImageTranscriptMessages } from '../../../../shared/native-chat-image-transcript-markers'
+import {
+  hasImagePromptMarker,
+  imageSourcePathFromText,
+  normalizeImageTranscriptMessages
+} from '../../../../shared/native-chat-image-transcript-markers'
 import { isLaunchPromptMessageId, isPendingMessageId } from './native-chat-pending'
 
 /** Messages grouped by source. Higher-priority sources (transcript > hook >
@@ -114,6 +118,13 @@ export function compareMessages(a: NativeChatMessage, b: NativeChatMessage): num
   if (at !== bt) {
     return at - bt
   }
+  // Claude emits an image-source companion and its prompt at the same instant.
+  // Keep the companion adjacent and first so the normalization pass can fold it
+  // into the prompt, regardless of opaque UUID ordering.
+  const imageOrder = imageTranscriptOrder(a, b)
+  if (imageOrder !== 0) {
+    return imageOrder
+  }
   if (a.id < b.id) {
     return -1
   }
@@ -121,6 +132,30 @@ export function compareMessages(a: NativeChatMessage, b: NativeChatMessage): num
     return 1
   }
   return 0
+}
+
+function imageTranscriptOrder(a: NativeChatMessage, b: NativeChatMessage): number {
+  return imageTranscriptRank(a) - imageTranscriptRank(b)
+}
+
+function imageTranscriptRank(message: NativeChatMessage): number {
+  if (isImageSourceCompanion(message)) {
+    return 0
+  }
+  if (message.role === 'user' && hasImagePromptMarker(message)) {
+    return 2
+  }
+  return 1
+}
+
+function isImageSourceCompanion(message: NativeChatMessage): boolean {
+  return (
+    message.role === 'user' &&
+    message.blocks.length > 0 &&
+    message.blocks.every(
+      (block) => isTextBlock(block) && imageSourcePathFromText(block.text) !== null
+    )
+  )
 }
 
 /**
@@ -135,13 +170,14 @@ export function assembleNativeChatSession(
   const { sources, sessionId, agent, status, error } = input
 
   // Process highest priority first so a later, lower-priority duplicate is
-  // dropped rather than overwriting. Within a source, order is preserved.
+  // dropped rather than overwriting. Sort each source before image folding so
+  // equal-timestamp companion/prompt rows retain semantic order.
   const ordered: NativeChatMessage[] = [
-    ...normalizeImageTranscriptMessages(sources.transcript ?? []),
+    ...normalizeImageTranscriptMessages(sortForImageNormalization(sources.transcript ?? [])),
     ...(sources.hook ?? []),
     // Scrape segments carry the same raw `[Image: source: …]` markers (e.g. from
     // scrollback before the transcript loads), so normalize them too.
-    ...normalizeImageTranscriptMessages(sources.scrape ?? [])
+    ...normalizeImageTranscriptMessages(sortForImageNormalization(sources.scrape ?? []))
   ]
 
   const byId = new Map<string, NativeChatMessage>()
@@ -162,6 +198,17 @@ export function assembleNativeChatSession(
     agent,
     ...(error ? { error } : {})
   }
+}
+
+function sortForImageNormalization(
+  messages: readonly NativeChatMessage[]
+): readonly NativeChatMessage[] {
+  for (let index = 1; index < messages.length; index += 1) {
+    if (compareMessages(messages[index - 1]!, messages[index]!) > 0) {
+      return [...messages].sort(compareMessages)
+    }
+  }
+  return messages
 }
 
 /**

--- a/src/shared/native-chat-image-transcript-markers.test.ts
+++ b/src/shared/native-chat-image-transcript-markers.test.ts
@@ -172,6 +172,47 @@ describe('normalizeImageTranscriptMessages', () => {
     ])
   })
 
+  it('folds a multi-block companion turn into one turn carrying every ref', () => {
+    // Claude records a multi-image paste as ONE companion message with a marker block
+    // per image, so a single-block-only rule missed every multi-image turn.
+    const out = normalizeImageTranscriptMessages([
+      {
+        id: 'companion',
+        role: 'user',
+        blocks: [
+          { type: 'text', text: '[Image: source: /tmp/a.png]' },
+          { type: 'text', text: '[Image: source: /tmp/b.png]' }
+        ],
+        timestamp: 1,
+        source: 'transcript'
+      }
+    ])
+
+    expect(out).toHaveLength(1)
+    expect(out[0]!.blocks).toEqual([
+      { type: 'image-ref', path: '/tmp/a.png' },
+      { type: 'image-ref', path: '/tmp/b.png' }
+    ])
+  })
+
+  it('does not treat a turn mixing prose with a marker as an image-source turn', () => {
+    const messages = [
+      {
+        id: 'mixed',
+        role: 'user' as const,
+        blocks: [
+          { type: 'text' as const, text: '[Image: source: /tmp/a.png]' },
+          { type: 'text' as const, text: 'and here is what I think' }
+        ],
+        timestamp: 1,
+        source: 'transcript' as const
+      }
+    ]
+    const out = normalizeImageTranscriptMessages(messages)
+
+    expect(out[0]!.blocks.some((block) => block.type === 'image-ref')).toBe(false)
+  })
+
   it('leaves ordinary user text untouched', () => {
     const message = userText('a', 'how about this')
     const messages = [message]

--- a/src/shared/native-chat-image-transcript-markers.ts
+++ b/src/shared/native-chat-image-transcript-markers.ts
@@ -12,18 +12,37 @@ const IMAGE_PROMPT_MARKER_AT_END = /\[Image #\d+\][^\S\r\n]*$/
 const HORIZONTAL_WHITESPACE_START = /^[^\S\r\n]+/
 const HORIZONTAL_WHITESPACE_END = /[^\S\r\n]+$/
 
-function soleText(message: NativeChatMessage): string | null {
-  return message.blocks.length === 1 && isTextBlock(message.blocks[0])
-    ? message.blocks[0].text
-    : null
-}
-
 export function imageSourcePathFromText(text: string): string | null {
   return text.match(IMAGE_SOURCE_MARKER)?.[1]?.trim() ?? null
 }
 
+/** Every image-source path a user turn carries, or [] when it is not a pure
+ *  image-source turn.
+ *
+ *  Why not `soleText`: Claude records a multi-image paste as ONE companion message
+ *  holding one `[Image: source: ...]` text block per image, so requiring a single
+ *  block missed every multi-image turn. A turn qualifies only when it is all text
+ *  and every block is a marker, so a real prompt is never mistaken for one. */
+export function imageSourcePathsFromMessage(message: NativeChatMessage): string[] {
+  if (message.role !== 'user' || message.blocks.length === 0) {
+    return []
+  }
+  const paths: string[] = []
+  for (const block of message.blocks) {
+    if (!isTextBlock(block)) {
+      return []
+    }
+    const path = imageSourcePathFromText(block.text)
+    if (path === null) {
+      return []
+    }
+    paths.push(path)
+  }
+  return paths
+}
+
 export function isImageSourceUserTurn(message: NativeChatMessage): boolean {
-  return message.role === 'user' && imageSourcePathFromText(soleText(message) ?? '') !== null
+  return imageSourcePathsFromMessage(message).length > 0
 }
 
 export function stripImagePromptMarker(text: string): string {
@@ -107,18 +126,22 @@ export function normalizeImageTranscriptMessages(
       normalized?.push(message)
       continue
     }
-    const imagePath = imageSourcePathFromText(soleText(message) ?? '')
-    if (imagePath) {
+    const messageImagePaths = imageSourcePathsFromMessage(message)
+    if (messageImagePaths.length > 0) {
       normalized ??= messages.slice(0, index)
-      const imagePaths = [imagePath]
+      const imagePaths = [...messageImagePaths]
       let nextIndex = index + 1
       while (nextIndex < messages.length) {
         const candidate = messages[nextIndex]!
-        const candidatePath = imageSourcePathFromText(soleText(candidate) ?? '')
-        if (candidate.role !== 'user' || candidate.source !== message.source || !candidatePath) {
+        const candidatePaths = imageSourcePathsFromMessage(candidate)
+        if (
+          candidate.role !== 'user' ||
+          candidate.source !== message.source ||
+          candidatePaths.length === 0
+        ) {
           break
         }
-        imagePaths.push(candidatePath)
+        imagePaths.push(...candidatePaths)
         nextIndex += 1
       }
       const prompt = messages[nextIndex]
@@ -137,9 +160,11 @@ export function normalizeImageTranscriptMessages(
         index = nextIndex
         continue
       }
+      // Only THIS turn's paths: `imagePaths` also holds the following source turns the
+      // fold scan looked at, and without a prompt to fold into they stay separate turns.
       normalized.push({
         ...message,
-        blocks: [{ type: 'image-ref', path: imagePath }]
+        blocks: messageImagePaths.map((path) => ({ type: 'image-ref' as const, path }))
       })
       continue
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​350 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​350 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​156 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​133 |

<!-- /orca-pr-loc -->

## What was broken

A Claude turn carrying pasted images reached native chat with **no images at all** — no thumbnails on mobile, and not even an attachment chip on desktop. Nothing indicated the message had any.

## Root cause

Both carriers of the attachment were dropped.

**1. The companion row is `isMeta`.** Claude records the paths in a separate turn holding one `[Image: source: <path>]` text block per image, marked `isMeta: true` (and `turnCompanion: true` since 2.1.237). `transcript-line-decoders-claude.ts` treats an `isMeta` user row as injected, filters its blocks down to `tool-result`, and returns `null` when none remain:

```ts
const blocks = isInjectedUserTurn
  ? decodedBlocks.filter((block) => block.type === 'tool-result')
  : decodedBlocks
if (blocks.length === 0) { return null }
```

**2. The prompt row's own image blocks have no address.** They are `{type: 'image', source: {type: 'base64', media_type, data}}`; `imageRefBlock` (`transcript-record-blocks.ts:103`) requires `source.url`, `record.url`, or `record.path`, so they drop too.

With the companion gone, `isImageSourceUserTurn` could never fire, which made the fold in `normalizeImageTranscriptMessages` unreachable on the Claude path.

### Survey

Every transcript under `~/.claude/projects` — **238 of 241** image-source rows are `isMeta`:

| version | isMeta |
|---|---|
| 2.1.220 | 48 |
| 2.1.227 | 13 |
| 2.1.228 | 9 |
| 2.1.229 | 5 |
| 2.1.232 | 18 |
| 2.1.233 | 63 |
| 2.1.234 | 8 |
| 2.1.237 | 74 |
| *(no version field)* | **0** — the only 3 non-meta rows |

Every row from every versioned release is meta. Separately, **38** of those rows hold more than one content block, which also defeated the single-block (`soleText`) rule in `isImageSourceUserTurn` — so a multi-image paste would have been missed even with the meta filter lifted.

## The fix

- Let image-source text survive the injected-turn filter, narrowly: a text block only passes when it parses as an `[Image: source: ...]` marker.
- Recognize a turn whose blocks are **all** markers, instead of only a lone one, so a multi-image paste folds.

Preserved: an ordinary injected turn (skill preamble, compact summary) is still dropped, and a turn mixing prose with a marker is still not an image-source turn. Both are pinned by tests.

Carrying the **paths** keeps the payload small — decoding the base64 instead would put hundreds of KB per image on the wire to mobile (the reported turn had four blocks totalling ~1.2 MB).

## Verification

- New test decodes the verbatim two-row shape (prompt row with `\r` + `[Image #N]` markers + base64 blocks, plus the `isMeta` companion) and asserts the folded turn carries both image refs, the caption survives marker-stripped, and an ordinary `isMeta` turn still returns `null`.
- **Ablation**: reverting the decoder filter turns 2 of the 3 new tests red; reverting multi-block support turns 1 red. Both restored and re-verified green.
- `src/main/native-chat` + `src/shared` + `src/renderer/.../native-chat`: 183 files / 1727 tests pass. Full mobile suite: 488 files / 3971 tests pass. `pnpm tc` and mobile `tsc --noEmit` clean.
- Changed-code quality gate: 0 new findings across 4 files.

### Caught in review of my own first attempt

My initial version made a standalone image turn swallow its neighbour's path — the fallback branch used the paths accumulated by the fold scan rather than the turn's own. `preserves adjacent standalone image turns without a prompt marker` caught it; the landed version scopes the fallback to the turn itself.

### Unrelated pre-existing failure

`structured-tui-transcript-catchup.test.ts > tails only TUI-era appends from the durable account home` fails on this branch **and on a pristine checkout without these changes**. Not introduced here.

## Follow-on

This restores the attachment chip on desktop and lets mobile's local-preview binding attach real thumbnails on the sending device. Rendering a host path as an actual image on a *remote* mobile client still needs a transport for the file and is out of scope.
