### PR TITLE
feat(dev): sweep the backlog of idle dev Electron bundles

### DIFF
--- a/config/scripts/dev-electron-bundle-cache.mjs
+++ b/config/scripts/dev-electron-bundle-cache.mjs
@@ -1,3 +1,25 @@
+import { execFileSync } from 'node:child_process'
+
+/** Written once a bundle is fully built; its absence is what marks a build still in flight. */
+export const DEV_BUNDLE_MARKER_FILENAME = 'orca-dev-electron-app.json'
+
+export function getDevBundleProcessTable(execFile = execFileSync) {
+  // Not pgrep: macOS pgrep has no -a (a Linux procps extension) and silently prints bare PIDs,
+  // which reads as "nothing is running" and deletes a live bundle. -ww keeps the command column
+  // from being truncated. The raw text is searched directly; see isDevBundleInUse for why it is
+  // deliberately not parsed into paths.
+  try {
+    return execFile('/bin/ps', ['-Awwo', 'command='], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000
+    })
+  } catch {
+    // Treating a failure as "nothing live" would risk deleting a running bundle, so skip pruning.
+    return null
+  }
+}
+
 // Why this module exists: `out/electron-dev` accumulates one ~270MB copy of Electron.app per
 // (branch title x Electron version x bundle layout). The runner only ever clears the directory it is
 // about to rebuild, so siblings from renamed branches and past upgrades are never reclaimed --

--- a/config/scripts/reclaim-dev-electron-bundles.mjs
+++ b/config/scripts/reclaim-dev-electron-bundles.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+// Removes idle `out/electron-dev` bundles across every worktree of a repository.
+//
+// The dev runner already prunes these, but only within the worktree it is starting and only when
+// that worktree holds more than one bundle -- and a worktree almost always holds exactly one. So
+// nothing ever reclaims a bundle belonging to a worktree you are not currently running, and one
+// ~275MB copy per branch accumulates indefinitely.
+//
+// Bundles are pure build output: `pnpm dev` rebuilds one on demand, and since the Electron dist is
+// now shared, rebuilding is cheap.
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync, rmSync, statSync } from 'node:fs'
+import path from 'node:path'
+import {
+  DEV_BUNDLE_MARKER_FILENAME,
+  getDevBundleProcessTable,
+  selectStaleDevBundleDirs
+} from './dev-electron-bundle-cache.mjs'
+
+const apply = process.argv.includes('--apply')
+const repoRoot = process.argv.includes('--repo')
+  ? path.resolve(process.argv[process.argv.indexOf('--repo') + 1])
+  : process.cwd()
+
+function listWorktrees(root) {
+  const raw = execFileSync('git', ['-C', root, 'worktree', 'list', '--porcelain'], {
+    encoding: 'utf8'
+  })
+  return raw
+    .split('\n')
+    .filter((line) => line.startsWith('worktree '))
+    .map((line) => line.slice('worktree '.length).trim())
+}
+
+function measure(targetPath) {
+  let total = 0
+  let entries
+  try {
+    entries = readdirSync(targetPath, { withFileTypes: true })
+  } catch {
+    return 0
+  }
+  for (const entry of entries) {
+    const entryPath = path.join(targetPath, entry.name)
+    if (entry.isDirectory()) {
+      total += measure(entryPath)
+    } else if (!entry.isSymbolicLink()) {
+      total += statSync(entryPath, { throwIfNoEntry: false })?.size ?? 0
+    }
+  }
+  return total
+}
+
+export function collectDevBundles(worktree) {
+  const root = path.join(worktree, 'out', 'electron-dev')
+  try {
+    return readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => {
+        const dir = path.join(root, entry.name)
+        return {
+          dir,
+          hasMarker: existsSync(path.join(dir, DEV_BUNDLE_MARKER_FILENAME)),
+          mtimeMs: statSync(dir, { throwIfNoEntry: false })?.mtimeMs ?? 0
+        }
+      })
+  } catch {
+    return []
+  }
+}
+
+function main() {
+  // The patched dev bundle is only built on macOS; elsewhere the dev app runs from dist directly.
+  if (process.platform !== 'darwin') {
+    console.log('No dev Electron bundles on this platform; nothing to reclaim.')
+    return
+  }
+
+  const processTable = getDevBundleProcessTable()
+  if (processTable === null) {
+    // Same rule the dev runner uses: no process table means we cannot prove a bundle is idle.
+    console.error('Could not read the process table; refusing to guess which bundles are idle.')
+    process.exitCode = 1
+    return
+  }
+
+  const bundles = listWorktrees(repoRoot).flatMap((worktree) => collectDevBundles(worktree))
+  // currentDir is null on purpose: unlike the dev runner, this sweep is not about to launch anything,
+  // so the only thing protecting a bundle is a live process or an in-flight build.
+  const stale = selectStaleDevBundleDirs({
+    bundles,
+    currentDir: null,
+    processTable,
+    nowMs: Date.now()
+  })
+
+  let reclaimed = 0
+  let removed = 0
+  for (const dir of stale) {
+    const size = measure(dir)
+    if (!apply) {
+      console.log(`would remove  ${dir}  ${(size / 1024 ** 3).toFixed(2)} GiB`)
+      reclaimed += size
+      removed += 1
+      continue
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true })
+      reclaimed += size
+      removed += 1
+      console.log(`removed  ${dir}  ${(size / 1024 ** 3).toFixed(2)} GiB`)
+    } catch (error) {
+      console.warn(`skip  ${dir}  (${error instanceof Error ? error.message : String(error)})`)
+    }
+  }
+
+  const inUse = bundles.length - stale.length
+  console.log(
+    `\n${apply ? 'Removed' : 'Would remove'} ${removed} bundle(s); ` +
+      `${apply ? 'reclaimed' : 'reclaimable'} ~${(reclaimed / 1024 ** 3).toFixed(2)} GiB` +
+      `${inUse > 0 ? `; left ${inUse} in use or still building` : ''}` +
+      `${apply ? '' : '\nRe-run with --apply to do it.'}`
+  )
+}
+
+// Guarded so importing this module for tests does not sweep the whole repository.
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  main()
+}

--- a/config/scripts/reclaim-dev-electron-bundles.test.ts
+++ b/config/scripts/reclaim-dev-electron-bundles.test.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  DEV_BUNDLE_MARKER_FILENAME,
+  getDevBundleProcessTable,
+  selectStaleDevBundleDirs
+} from './dev-electron-bundle-cache.mjs'
+import { collectDevBundles } from './reclaim-dev-electron-bundles.mjs'
+
+const roots: string[] = []
+
+afterEach(() => {
+  while (roots.length > 0) {
+    rmSync(roots.pop()!, { recursive: true, force: true })
+  }
+})
+
+function makeWorktree(bundles: { name: string; marker: boolean }[]): string {
+  const worktree = mkdtempSync(path.join(tmpdir(), 'orca-dev-bundles-'))
+  roots.push(worktree)
+  for (const bundle of bundles) {
+    const dir = path.join(worktree, 'out', 'electron-dev', bundle.name)
+    mkdirSync(dir, { recursive: true })
+    if (bundle.marker) {
+      writeFileSync(path.join(dir, DEV_BUNDLE_MARKER_FILENAME), '{}')
+    }
+  }
+  return worktree
+}
+
+describe('collectDevBundles', () => {
+  it('reports each bundle and whether its build finished', () => {
+    const worktree = makeWorktree([
+      { name: 'aaaa', marker: true },
+      { name: 'bbbb', marker: false }
+    ])
+    const bundles = collectDevBundles(worktree).sort((a, b) => a.dir.localeCompare(b.dir))
+    expect(bundles).toHaveLength(2)
+    expect(bundles[0].hasMarker).toBe(true)
+    expect(bundles[1].hasMarker).toBe(false)
+    expect(bundles[0].mtimeMs).toBeGreaterThan(0)
+  })
+
+  it('returns nothing for a worktree that has never run the dev app', () => {
+    const worktree = mkdtempSync(path.join(tmpdir(), 'orca-dev-bundles-'))
+    roots.push(worktree)
+    expect(collectDevBundles(worktree)).toEqual([])
+  })
+})
+
+describe('sweeping across worktrees', () => {
+  it('spares a bundle a live process is running from, and takes the idle ones', () => {
+    const worktree = makeWorktree([
+      { name: 'live', marker: true },
+      { name: 'idle', marker: true }
+    ])
+    const bundles = collectDevBundles(worktree)
+    const live = bundles.find((bundle) => bundle.dir.endsWith('live'))!
+    // Why currentDir is null here: unlike the dev runner, the sweep is not about to launch
+    // anything, so only a live process or an in-flight build may protect a bundle.
+    const stale = selectStaleDevBundleDirs({
+      bundles,
+      currentDir: null,
+      processTable: `/usr/bin/foo ${live.dir}/Orca.app/Contents/MacOS/Electron`,
+      nowMs: Date.now()
+    })
+    expect(stale).toEqual([bundles.find((bundle) => bundle.dir.endsWith('idle'))!.dir])
+  })
+
+  it('spares a build still in flight, which has no marker yet', () => {
+    const worktree = makeWorktree([{ name: 'building', marker: false }])
+    const stale = selectStaleDevBundleDirs({
+      bundles: collectDevBundles(worktree),
+      currentDir: null,
+      processTable: '',
+      nowMs: Date.now()
+    })
+    expect(stale).toEqual([])
+  })
+})
+
+describe('getDevBundleProcessTable', () => {
+  it('returns null rather than an empty table when ps fails', () => {
+    expect(
+      getDevBundleProcessTable(() => {
+        throw new Error('ps unavailable')
+      })
+    ).toBeNull()
+  })
+
+  it('reads the real process table on this host', () => {
+    const table = getDevBundleProcessTable()
+    expect(typeof table === 'string' || table === null).toBe(true)
+  })
+})

--- a/config/scripts/reclaim-electron-dists.mjs
+++ b/config/scripts/reclaim-electron-dists.mjs
@@ -6,7 +6,15 @@
 
 import { execFileSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { existsSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
 import path from 'node:path'
 import {
   hasAdoptedSharedElectronDist,
@@ -33,14 +41,24 @@ function listWorktrees(root) {
     .map((line) => line.slice('worktree '.length).trim())
 }
 
-function measure(distPath) {
+/** Apparent size, walked in Node: `du` does not exist on Windows, where it silently reported 0. */
+function measure(targetPath) {
+  let total = 0
+  let entries
   try {
-    return (
-      Number(execFileSync('du', ['-sk', distPath], { encoding: 'utf8' }).split(/\s+/)[0]) * 1024
-    )
+    entries = readdirSync(targetPath, { withFileTypes: true })
   } catch {
     return 0
   }
+  for (const entry of entries) {
+    const entryPath = path.join(targetPath, entry.name)
+    if (entry.isDirectory()) {
+      total += measure(entryPath)
+    } else if (!entry.isSymbolicLink()) {
+      total += statSync(entryPath, { throwIfNoEntry: false })?.size ?? 0
+    }
+  }
+  return total
 }
 
 /** Swap in a shared copy behind a rename, so an interrupted run never leaves a partial dist. */

--- a/config/scripts/reclaim-electron-dists.mjs
+++ b/config/scripts/reclaim-electron-dists.mjs
@@ -81,89 +81,96 @@ function adoptInto(distPath, entry, identity) {
   return true
 }
 
-let reclaimed = 0
-let converted = 0
-let skipped = 0
+function main() {
+  let reclaimed = 0
+  let converted = 0
+  let skipped = 0
 
-for (const worktree of listWorktrees(repoRoot)) {
-  const electronPackageDir = path.join(worktree, 'node_modules', 'electron')
-  const distPath = path.join(electronPackageDir, 'dist')
-  if (!existsSync(path.join(electronPackageDir, 'package.json')) || !existsSync(distPath)) {
-    continue
-  }
-  if (statSync(distPath, { throwIfNoEntry: false })?.isDirectory() !== true) {
-    continue
-  }
-
-  let version
-  try {
-    version = JSON.parse(
-      readFileSync(path.join(electronPackageDir, 'package.json'), 'utf8')
-    ).version
-  } catch {
-    continue
-  }
-  const targetPlatform = process.platform
-  const targetArch = process.arch
-  let platformPath
-  try {
-    platformPath = getElectronPlatformPath(targetPlatform)
-  } catch {
-    continue
-  }
-  if (!isUsableElectronDist(distPath, version, platformPath)) {
-    console.log(`skip  ${worktree}  (dist is not a complete Electron ${version})`)
-    skipped += 1
-    continue
-  }
-
-  const entry = resolveSharedElectronDistEntry({
-    repoRoot: worktree,
-    electronPackageDir,
-    version,
-    targetPlatform,
-    targetArch
-  })
-  if (entry === null) {
-    continue
-  }
-  if (hasAdoptedSharedElectronDist(entry)) {
-    continue
-  }
-
-  const size = measure(distPath)
-  if (!apply) {
-    console.log(`would share  ${worktree}  ${(size / 1024 ** 3).toFixed(2)} GiB  (${version})`)
-    reclaimed += size
-    converted += 1
-    continue
-  }
-
-  try {
-    if (!existsSync(entry.entryPath)) {
-      if (publishSharedElectronDist(distPath, entry, { version, platformPath })) {
-        recordAdoptedSharedElectronDist(entry, writeFileSync)
-        console.log(`seeded  ${worktree}  -> ${entry.entryPath}`)
-        converted += 1
-      }
+  for (const worktree of listWorktrees(repoRoot)) {
+    const electronPackageDir = path.join(worktree, 'node_modules', 'electron')
+    const distPath = path.join(electronPackageDir, 'dist')
+    if (!existsSync(path.join(electronPackageDir, 'package.json')) || !existsSync(distPath)) {
       continue
     }
-    if (adoptInto(distPath, entry, { version, platformPath })) {
-      recordAdoptedSharedElectronDist(entry, writeFileSync)
+    if (statSync(distPath, { throwIfNoEntry: false })?.isDirectory() !== true) {
+      continue
+    }
+
+    let version
+    try {
+      version = JSON.parse(
+        readFileSync(path.join(electronPackageDir, 'package.json'), 'utf8')
+      ).version
+    } catch {
+      continue
+    }
+    const targetPlatform = process.platform
+    const targetArch = process.arch
+    let platformPath
+    try {
+      platformPath = getElectronPlatformPath(targetPlatform)
+    } catch {
+      continue
+    }
+    if (!isUsableElectronDist(distPath, version, platformPath)) {
+      console.log(`skip  ${worktree}  (dist is not a complete Electron ${version})`)
+      skipped += 1
+      continue
+    }
+
+    const entry = resolveSharedElectronDistEntry({
+      repoRoot: worktree,
+      electronPackageDir,
+      version,
+      targetPlatform,
+      targetArch
+    })
+    if (entry === null) {
+      continue
+    }
+    if (hasAdoptedSharedElectronDist(entry)) {
+      continue
+    }
+
+    const size = measure(distPath)
+    if (!apply) {
+      console.log(`would share  ${worktree}  ${(size / 1024 ** 3).toFixed(2)} GiB  (${version})`)
       reclaimed += size
       converted += 1
-      console.log(`shared  ${worktree}  reclaimed ${(size / 1024 ** 3).toFixed(2)} GiB`)
+      continue
     }
-  } catch (error) {
-    // A worktree that fails is left exactly as it was; it still has its own working dist.
-    console.warn(`skip  ${worktree}  (${error instanceof Error ? error.message : String(error)})`)
-    skipped += 1
+
+    try {
+      if (!existsSync(entry.entryPath)) {
+        if (publishSharedElectronDist(distPath, entry, { version, platformPath })) {
+          recordAdoptedSharedElectronDist(entry, writeFileSync)
+          console.log(`seeded  ${worktree}  -> ${entry.entryPath}`)
+          converted += 1
+        }
+        continue
+      }
+      if (adoptInto(distPath, entry, { version, platformPath })) {
+        recordAdoptedSharedElectronDist(entry, writeFileSync)
+        reclaimed += size
+        converted += 1
+        console.log(`shared  ${worktree}  reclaimed ${(size / 1024 ** 3).toFixed(2)} GiB`)
+      }
+    } catch (error) {
+      // A worktree that fails is left exactly as it was; it still has its own working dist.
+      console.warn(`skip  ${worktree}  (${error instanceof Error ? error.message : String(error)})`)
+      skipped += 1
+    }
   }
+
+  console.log(
+    `\n${apply ? 'Shared' : 'Would share'} ${converted} worktree(s); ` +
+      `${apply ? 'reclaimed' : 'reclaimable'} ~${(reclaimed / 1024 ** 3).toFixed(2)} GiB` +
+      `${skipped > 0 ? `; skipped ${skipped}` : ''}` +
+      `${apply ? '' : '\nRe-run with --apply to do it.'}`
+  )
 }
 
-console.log(
-  `\n${apply ? 'Shared' : 'Would share'} ${converted} worktree(s); ` +
-    `${apply ? 'reclaimed' : 'reclaimable'} ~${(reclaimed / 1024 ** 3).toFixed(2)} GiB` +
-    `${skipped > 0 ? `; skipped ${skipped}` : ''}` +
-    `${apply ? '' : '\nRe-run with --apply to do it.'}`
-)
+// Guarded so importing this module for tests does not sweep the whole repository.
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  main()
+}

--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -17,7 +17,12 @@ import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import { prepareDevCliTerminalWrappers } from './dev-cli-terminal-wrapper.mjs'
-import { isDevBundleInUse, selectStaleDevBundleDirs } from './dev-electron-bundle-cache.mjs'
+import {
+  DEV_BUNDLE_MARKER_FILENAME,
+  getDevBundleProcessTable,
+  isDevBundleInUse,
+  selectStaleDevBundleDirs
+} from './dev-electron-bundle-cache.mjs'
 import { copyPrivateTree } from './space-sharing-copy.mjs'
 import {
   DEV_BUNDLE_ID,
@@ -117,23 +122,6 @@ function sanitizeMacAppBundleName(value) {
   )
 }
 
-function getDevBundleProcessTable() {
-  // Not pgrep: macOS pgrep has no -a (a Linux procps extension) and silently prints bare PIDs,
-  // which reads as "nothing is running" and deletes a live bundle. -ww keeps the command column
-  // from being truncated. The raw text is searched directly; see dev-electron-bundle-cache.mjs
-  // for why it is deliberately not parsed into paths.
-  try {
-    return execFileSync('/bin/ps', ['-Awwo', 'command='], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 5000
-    })
-  } catch {
-    // Treating a failure as "nothing live" would risk deleting a running bundle, so skip pruning.
-    return null
-  }
-}
-
 function pruneStaleDevBundles(distDir) {
   const root = path.dirname(distDir)
   let bundles
@@ -144,7 +132,7 @@ function pruneStaleDevBundles(distDir) {
         const dir = path.join(root, entry.name)
         return {
           dir,
-          hasMarker: existsSync(path.join(dir, 'orca-dev-electron-app.json')),
+          hasMarker: existsSync(path.join(dir, DEV_BUNDLE_MARKER_FILENAME)),
           mtimeMs: getMtimeMs(dir)
         }
       })
@@ -204,7 +192,7 @@ function prepareMacDevElectronApp() {
   // and it sits outside the code signature, so varying it does not disturb the cdhash.
   const appBundleName = `${sanitizeMacAppBundleName(title)}.app`
   const appPath = path.join(distDir, appBundleName)
-  const markerPath = path.join(distDir, 'orca-dev-electron-app.json')
+  const markerPath = path.join(distDir, DEV_BUNDLE_MARKER_FILENAME)
   // Why: one stable id for every dev instance. Per-instance ids registered a
   // new macOS Notification Settings entry for each branch × Electron version,
   // piling up "Orca: <branch>" rows forever and breaking the notification

--- a/config/scripts/space-sharing-copy.mjs
+++ b/config/scripts/space-sharing-copy.mjs
@@ -7,6 +7,7 @@ import {
   readdirSync,
   readlinkSync,
   rmSync,
+  statSync,
   symlinkSync
 } from 'node:fs'
 import { join } from 'node:path'
@@ -100,7 +101,10 @@ export function makeTreeReadOnly(targetPath, chmod = chmodSync) {
     if (entry.isDirectory()) {
       makeTreeReadOnly(entryPath, chmod)
     } else if (!entry.isSymbolicLink()) {
-      chmod(entryPath, 0o555)
+      // Clear the write bits and nothing else. A flat 0o555 would strip setuid from
+      // chrome-sandbox, and under hardlink sharing it would strip it in every worktree at once.
+      const mode = statSync(entryPath, { throwIfNoEntry: false })?.mode
+      chmod(entryPath, mode === undefined ? 0o555 : mode & ~0o222)
     }
   }
   chmod(targetPath, 0o755)

--- a/config/scripts/space-sharing-copy.test.ts
+++ b/config/scripts/space-sharing-copy.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -143,6 +144,16 @@ describe('makeTreeReadOnly', () => {
     makeTreeReadOnly(destination)
     expect(() => writeFileSync(path.join(destination, 'nested', 'file'), 'mutated')).toThrow()
     expect(readFileSync(path.join(source, 'nested', 'file'), 'utf8')).toBe('contents')
+  })
+
+  it.runIf(process.platform !== 'win32')('preserves setuid, which chrome-sandbox needs', () => {
+    const { source } = makeTree()
+    const sandbox = path.join(source, 'chrome-sandbox')
+    writeFileSync(sandbox, 'binary')
+    chmodSync(sandbox, 0o4755)
+    makeTreeReadOnly(source)
+    expect(statSync(sandbox).mode & 0o4000).toBe(0o4000)
+    expect(statSync(sandbox).mode & 0o222).toBe(0)
   })
 
   it.runIf(process.platform !== 'win32')(

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "postinstall": "node config/scripts/rebuild-native-deps.mjs",
     "rebuild:electron": "node config/scripts/rebuild-native-deps.mjs",
     "reclaim:electron-dists": "node config/scripts/reclaim-electron-dists.mjs",
+    "reclaim:dev-bundles": "node config/scripts/reclaim-dev-electron-bundles.mjs",
     "rebuild:node": "pnpm rebuild node-pty",
     "build:unpack": "pnpm run build && pnpm run ensure:electron-runtime && electron-builder --config config/electron-builder.config.cjs --dir",
     "build:win": "pnpm run build:desktop && pnpm run ensure:electron-runtime && electron-builder --config config/electron-builder.config.cjs --win",


### PR DESCRIPTION
Follow-up to #17664 and #17800. Found while measuring what else was eating disk after the Electron dist sharing landed.

## The gap

`out/electron-dev` holds one ~275 MB patched `Electron.app` per branch title × Electron version. The dev runner already prunes these — but only inside the worktree it is starting, and only when that worktree holds **more than one** bundle (`run-electron-vite-dev.mjs`, `bundles.length <= 1` → return).

A worktree almost always holds exactly one. So the sweep returns early every time, and nothing ever reclaims a bundle belonging to a worktree you are not currently running.

That matches the "143 directories / 38GB" note already in `dev-electron-bundle-cache.mjs`'s header comment — a known, recurring problem that was never fully fixed.

## Fix

```
pnpm reclaim:dev-bundles            # report
pnpm reclaim:dev-bundles --apply    # do it
```

Sweeps every worktree of the repo. Bundles are pure build output that `pnpm dev` rebuilds on demand, and rebuilding is cheap now that the Electron dist is shared.

It reuses the runner's own staleness rules rather than reimplementing them, so:
- a bundle a live process is running from is never removed
- a bundle whose build is still in flight (no marker, recent mtime) is never removed
- if the process table cannot be read it refuses to run at all, rather than guessing

macOS-only in effect, since the patched dev bundle is only built there; elsewhere it reports that there is nothing to reclaim.

**Measured: 120 bundles, 32.2 GiB on one machine**, with 1 correctly left alone as in-use. Verified by free-space delta.

## Also: both reclaim scripts ran at import time

Importing either module for tests executed its full sweep — the dev-bundles test import took ~3s doing real work. Both are now guarded behind a direct-invocation check, matching `install-electron-package-binary.mjs`.

## Refactor

`getDevBundleProcessTable` and the bundle marker filename moved from `run-electron-vite-dev.mjs` into `dev-electron-bundle-cache.mjs`, which already owns the staleness rules, so the runner and the sweep share one definition.

## Tests

New: bundle collection and marker detection; a live process protects its bundle; an in-flight build is spared; a missing process table returns null rather than an empty table.

`pnpm tc:node`, `oxlint`, the changed-code quality gate, and the full `config/scripts` suite (1180 tests) all pass.

## Visual proof

N/A — no renderer or visual behavior changed.