### PR TITLE
refactor(git): accept a caller-named WSL distro on the metadata path resolver

### DIFF
--- a/src/main/git/repo-git-marker-scan.ts
+++ b/src/main/git/repo-git-marker-scan.ts
@@ -2,6 +2,7 @@ import { readFileSync, realpathSync, statSync } from 'node:fs'
 import { dirname, isAbsolute, join, relative } from 'node:path'
 import { normalizeRuntimePathSeparators } from '../../shared/cross-platform-path'
 import { resolveGitMetadataPath } from '../../shared/git-metadata-path'
+import { parseGitdirMarkerPayload } from '../../shared/gitdir-marker-payload'
 
 export type GitMarkerScanResult =
   | { status: 'valid'; rootPath: string }
@@ -127,12 +128,8 @@ function scanWorktreeMarkerSync(worktreePath: string): GitMarkerScanResult {
 }
 
 function parseGitdirFile(basePath: string, content: string): string | null {
-  const firstLine = content.split(/\r?\n/, 1)[0] ?? ''
-  const match = firstLine.match(/^gitdir:\s*(.+?)\s*$/i)
-  if (!match) {
-    return null
-  }
-  return resolveGitMetadataPath(basePath, match[1])
+  const payload = parseGitdirMarkerPayload(content)
+  return payload === null ? null : resolveGitMetadataPath(basePath, payload)
 }
 
 function hasValidGitDirectorySync(gitDir: string): boolean {

--- a/src/main/git/source-control/resolve-git-dir.test.ts
+++ b/src/main/git/source-control/resolve-git-dir.test.ts
@@ -1,0 +1,48 @@
+import * as path from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { readFileMock } = vi.hoisted(() => ({ readFileMock: vi.fn() }))
+
+vi.mock('node:fs/promises', () => ({ readFile: readFileMock }))
+
+import { resolveGitDir } from './resolve-git-dir'
+
+// Expectations go through `path` so they hold on whichever host runs the suite.
+const linkedGitDir = path.resolve('/repo/feature', '../main/.git/worktrees/feature')
+const ownDotGit = path.join('/repo/feature', '.git')
+
+describe('resolveGitDir', () => {
+  beforeEach(() => {
+    readFileMock.mockReset()
+  })
+
+  it('resolves a relative linked-worktree marker', async () => {
+    readFileMock.mockResolvedValue('gitdir: ../main/.git/worktrees/feature\n')
+
+    await expect(resolveGitDir('/repo/feature')).resolves.toBe(linkedGitDir)
+  })
+
+  it('drops padding around the marker payload', async () => {
+    readFileMock.mockResolvedValue('gitdir: ../main/.git/worktrees/feature  \r\n')
+
+    await expect(resolveGitDir('/repo/feature')).resolves.toBe(linkedGitDir)
+  })
+
+  it('does not treat a whitespace-only gitdir payload as a metadata directory', async () => {
+    readFileMock.mockResolvedValue('gitdir:   \n')
+
+    await expect(resolveGitDir('/repo/feature')).resolves.toBe(ownDotGit)
+  })
+
+  it('ignores a gitdir line that is not the first line of the marker file', async () => {
+    readFileMock.mockResolvedValue('[core]\ngitdir: ../main/.git/worktrees/feature\n')
+
+    await expect(resolveGitDir('/repo/feature')).resolves.toBe(ownDotGit)
+  })
+
+  it('uses the .git directory when the marker cannot be read', async () => {
+    readFileMock.mockRejectedValue(Object.assign(new Error('EISDIR'), { code: 'EISDIR' }))
+
+    await expect(resolveGitDir('/repo/feature')).resolves.toBe(ownDotGit)
+  })
+})

--- a/src/main/git/source-control/resolve-git-dir.ts
+++ b/src/main/git/source-control/resolve-git-dir.ts
@@ -1,14 +1,14 @@
 import { readFile } from 'node:fs/promises'
 import * as path from 'node:path'
+import { parseGitdirMarkerPayload } from '../../../shared/gitdir-marker-payload'
 
 export async function resolveGitDir(worktreePath: string): Promise<string> {
   const dotGitPath = path.join(worktreePath, '.git')
 
   try {
-    const dotGitContents = await readFile(dotGitPath, 'utf-8')
-    const match = dotGitContents.match(/^gitdir:\s*(.+)\s*$/m)
-    if (match) {
-      return path.resolve(worktreePath, match[1])
+    const gitDir = parseGitdirMarkerPayload(await readFile(dotGitPath, 'utf-8'))
+    if (gitDir) {
+      return path.resolve(worktreePath, gitDir)
     }
   } catch {
     // `.git` is likely a directory in a non-worktree checkout.

--- a/src/shared/git-metadata-path.test.ts
+++ b/src/shared/git-metadata-path.test.ts
@@ -1,5 +1,8 @@
+import { posix, win32 } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { resolveGitMetadataPath } from './git-metadata-path'
+
+const hostIsWindows = process.platform === 'win32'
 
 describe('resolveGitMetadataPath', () => {
   it('maps a drvfs pointer to its drive spelling on a Windows host with no distro context', () => {
@@ -7,20 +10,22 @@ describe('resolveGitMetadataPath', () => {
       resolveGitMetadataPath(
         String.raw`C:\Users\me\repo`,
         '/mnt/c/Users/me/repo/.git/worktrees/feature',
-        'win32'
+        { platform: 'win32' }
       )
     ).toBe(String.raw`C:\Users\me\repo\.git\worktrees\feature`)
   })
 
   it('maps a drvfs drive root to its drive spelling', () => {
-    expect(resolveGitMetadataPath(String.raw`D:\repo`, '/mnt/d', 'win32')).toBe('D:\\')
+    expect(resolveGitMetadataPath(String.raw`D:\repo`, '/mnt/d', { platform: 'win32' })).toBe(
+      'D:\\'
+    )
   })
 
   it('keeps a non-drvfs guest pointer verbatim when no distro names it', () => {
     // Windows already reads this as drive-relative; guessing a distro would probe the wrong disk.
-    expect(resolveGitMetadataPath(String.raw`C:\repo`, '/home/me/repo/.git', 'win32')).toBe(
-      '/home/me/repo/.git'
-    )
+    expect(
+      resolveGitMetadataPath(String.raw`C:\repo`, '/home/me/repo/.git', { platform: 'win32' })
+    ).toBe('/home/me/repo/.git')
   })
 
   it('maps a guest pointer through the distro encoded by a WSL UNC base', () => {
@@ -28,9 +33,53 @@ describe('resolveGitMetadataPath', () => {
       resolveGitMetadataPath(
         String.raw`\\wsl.localhost\Debian\home\me\repo`,
         '/home/me/repo/.git',
-        'win32'
+        { platform: 'win32' }
       )
     ).toBe(String.raw`\\wsl.localhost\Debian\home\me\repo\.git`)
+  })
+
+  it('maps a guest pointer through a caller-named distro when the base encodes none', () => {
+    expect(
+      resolveGitMetadataPath(String.raw`C:\Users\me\repo`, '/home/me/repo/.git', {
+        platform: 'win32',
+        wslDistro: 'Ubuntu'
+      })
+    ).toBe(String.raw`\\wsl.localhost\Ubuntu\home\me\repo\.git`)
+  })
+
+  it('lets the distro encoded by a WSL UNC base outrank the caller-named one', () => {
+    expect(
+      resolveGitMetadataPath(
+        String.raw`\\wsl.localhost\Debian\home\me\repo`,
+        '/home/me/repo/.git',
+        { platform: 'win32', wslDistro: 'Ubuntu' }
+      )
+    ).toBe(String.raw`\\wsl.localhost\Debian\home\me\repo\.git`)
+  })
+
+  it('ignores a caller-named distro on a POSIX host', () => {
+    // A POSIX reader is already in the pointer's namespace; a UNC path there would be a filename.
+    expect(
+      resolveGitMetadataPath('/repo', '/home/me/repo/.git', {
+        platform: 'linux',
+        wslDistro: 'Ubuntu'
+      })
+    ).toBe('/home/me/repo/.git')
+    expect(
+      resolveGitMetadataPath('/repo', '/mnt/c/repo/.git', {
+        platform: 'darwin',
+        wslDistro: 'Ubuntu'
+      })
+    ).toBe('/mnt/c/repo/.git')
+  })
+
+  it('keeps a drvfs pointer on its drive spelling even when a distro is named', () => {
+    expect(
+      resolveGitMetadataPath(String.raw`C:\repo`, '/mnt/c/repo/.git', {
+        platform: 'win32',
+        wslDistro: 'Ubuntu'
+      })
+    ).toBe(String.raw`C:\repo\.git`)
   })
 
   it('resolves a relative pointer against a WSL UNC base', () => {
@@ -38,38 +87,62 @@ describe('resolveGitMetadataPath', () => {
       resolveGitMetadataPath(
         String.raw`\\wsl.localhost\Debian\home\me\repo\.git\worktrees\feature`,
         '../..',
-        'win32'
+        { platform: 'win32' }
       )
     ).toBe(String.raw`\\wsl.localhost\Debian\home\me\repo\.git`)
   })
 
   it('resolves relative pointers with the reading host path flavor', () => {
-    expect(resolveGitMetadataPath('/repo/worktree', '../.git/worktrees/feature', 'linux')).toBe(
-      '/repo/.git/worktrees/feature'
-    )
     expect(
-      resolveGitMetadataPath(
-        String.raw`C:\repo\worktree`,
-        String.raw`..\.git\worktrees\feature`,
-        'win32'
-      )
+      resolveGitMetadataPath('/repo/worktree', '../.git/worktrees/feature', { platform: 'linux' })
+    ).toBe('/repo/.git/worktrees/feature')
+    expect(
+      resolveGitMetadataPath(String.raw`C:\repo\worktree`, String.raw`..\.git\worktrees\feature`, {
+        platform: 'win32'
+      })
     ).toBe(String.raw`C:\repo\.git\worktrees\feature`)
   })
 
   it('leaves absolute pointers alone on a POSIX host, drvfs spelling included', () => {
     expect(
-      resolveGitMetadataPath('/repo/worktree', '/var/lib/git/worktrees/feature', 'linux')
+      resolveGitMetadataPath('/repo/worktree', '/var/lib/git/worktrees/feature', {
+        platform: 'linux'
+      })
     ).toBe('/var/lib/git/worktrees/feature')
-    expect(resolveGitMetadataPath('/repo/worktree', '/mnt/c/repo/.git', 'darwin')).toBe(
-      '/mnt/c/repo/.git'
-    )
+    expect(
+      resolveGitMetadataPath('/repo/worktree', '/mnt/c/repo/.git', { platform: 'darwin' })
+    ).toBe('/mnt/c/repo/.git')
   })
 
   it.each(['', '   ', '\t'])('rejects an empty metadata pointer %j', (rawPath) => {
-    expect(resolveGitMetadataPath('/repo', rawPath, 'linux')).toBeNull()
+    expect(resolveGitMetadataPath('/repo', rawPath, { platform: 'linux' })).toBeNull()
   })
 
   it('trims a padded pointer before resolving it', () => {
-    expect(resolveGitMetadataPath('/repo/worktree', '  ../.git  ', 'linux')).toBe('/repo/.git')
+    expect(resolveGitMetadataPath('/repo/worktree', '  ../.git  ', { platform: 'linux' })).toBe(
+      '/repo/.git'
+    )
+  })
+
+  // Both production callers omit options entirely, so the defaults must stay the old behavior:
+  // the reading host's own path flavor, and no distro.
+  it.each([
+    [
+      String.raw`\\wsl.localhost\Debian\home\me\repo`,
+      '/home/me/repo/.git',
+      String.raw`\\wsl.localhost\Debian\home\me\repo\.git`
+    ],
+    ['/repo', '/mnt/c/repo/.git', hostIsWindows ? String.raw`C:\repo\.git` : '/mnt/c/repo/.git'],
+    ['/repo', '/var/lib/git/worktrees/feature', '/var/lib/git/worktrees/feature'],
+    ['/repo', '   ', null]
+  ])('defaults to the current host with no distro for %j -> %j', (basePath, rawPath, expected) => {
+    expect(resolveGitMetadataPath(basePath, rawPath)).toBe(expected)
+  })
+
+  it('resolves a relative pointer with no options in the reading host flavor', () => {
+    // Expectation comes from node's own path module, not from a second call under test.
+    expect(resolveGitMetadataPath('/repo/worktree', '../.git/worktrees/feature')).toBe(
+      (hostIsWindows ? win32 : posix).resolve('/repo/worktree', '../.git/worktrees/feature')
+    )
   })
 })

--- a/src/shared/git-metadata-path.ts
+++ b/src/shared/git-metadata-path.ts
@@ -1,6 +1,13 @@
 import { posix, win32 } from 'node:path'
 import { parseWslUncPath, toWindowsWslDrivePath, toWindowsWslPath } from './wsl-paths'
 
+export type GitMetadataPathOptions = {
+  /** Host that reads the pointer back. Defaults to the current process platform. */
+  platform?: NodeJS.Platform
+  /** Distro that wrote the pointer, for callers whose base path does not encode one. Windows-only. */
+  wslDistro?: string
+}
+
 /**
  * Resolve a Git metadata pointer (a `.git` gitfile payload or a `commondir`) in the path namespace
  * of the host that reads it.
@@ -12,14 +19,15 @@ import { parseWslUncPath, toWindowsWslDrivePath, toWindowsWslPath } from './wsl-
 export function resolveGitMetadataPath(
   basePath: string,
   rawPath: string,
-  platform: NodeJS.Platform = process.platform
+  options: GitMetadataPathOptions = {}
 ): string | null {
+  const platform = options.platform ?? process.platform
   const value = rawPath.trim()
   if (!value) {
     return null
   }
   if (value.startsWith('/')) {
-    const translated = translateGuestPointer(value, basePath, platform)
+    const translated = translateGuestPointer(value, basePath, platform, options.wslDistro)
     if (translated) {
       return translated
     }
@@ -30,17 +38,24 @@ export function resolveGitMetadataPath(
 
 /**
  * The Win32 spelling of a POSIX-rooted pointer, or null to leave it alone. A WSL UNC base names the
- * distro that wrote the pointer; failing that, only a drvfs mount has a spelling we can derive, and
- * only a Windows host needs one.
+ * distro that wrote the pointer and outranks the caller's guess; failing both, only a drvfs mount
+ * has a spelling we can derive.
+ *
+ * Only a Windows host is translated at all, so a caller-named distro cannot make a POSIX host
+ * fabricate a Win32 path. A WSL UNC base is exempt because that spelling only exists on Windows.
  */
 function translateGuestPointer(
   value: string,
   basePath: string,
-  platform: NodeJS.Platform
+  platform: NodeJS.Platform,
+  wslDistro: string | undefined
 ): string | null {
-  const distro = parseWslUncPath(basePath)?.distro
-  if (distro) {
-    return toWindowsWslPath(value, distro)
+  const baseDistro = parseWslUncPath(basePath)?.distro
+  if (baseDistro) {
+    return toWindowsWslPath(value, baseDistro)
   }
-  return platform === 'win32' ? toWindowsWslDrivePath(value) : null
+  if (platform !== 'win32') {
+    return null
+  }
+  return wslDistro ? toWindowsWslPath(value, wslDistro) : toWindowsWslDrivePath(value)
 }

--- a/src/shared/gitdir-marker-payload.ts
+++ b/src/shared/gitdir-marker-payload.ts
@@ -1,0 +1,11 @@
+/**
+ * The path payload of a Git `.git` gitfile marker, or null when the file carries none.
+ *
+ * Why the shape: git's own read_gitfile_gently only accepts the `gitdir:` marker at the start of the
+ * file and strips whitespace around the payload, so a `gitdir:` line further down is not a marker
+ * and padding is not part of the path. `.` never matches a newline, which is what keeps the match on
+ * the first line.
+ */
+export function parseGitdirMarkerPayload(content: string): string | null {
+  return content.match(/^gitdir:(.*)/i)?.[1].trim() || null
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​142 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​121 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## Problem

`resolveGitMetadataPath` can only learn a WSL distro from a UNC base path, so a caller that already knows which distro wrote a `.git` gitfile or `commondir` pointer has no way to say so. Separately, `resolveGitDir`'s marker parse (`/^gitdir:\s*(.+)\s*$/m`) captures trailing padding into the path — `\s*$` matches empty, so the greedy `(.+)` swallows it — and `/m` honors a `gitdir:` line anywhere in the file rather than only at the start.

## Change

**1. `resolveGitMetadataPath`'s third parameter** widens from `platform: NodeJS.Platform` to `options: GitMetadataPathOptions = {}` (`{ platform?, wslDistro? }`). Guest-pointer translation now uses the distro from the UNC base path first, then the caller's, and translates only when the reading host is `win32`. The UNC-base branch is exempt from that gate because a `\\wsl.localhost\...` base path only exists on Windows.

Main's two contracts are kept verbatim: never null for a non-empty pointer (an untranslatable POSIX pointer is still returned as-is, which is what keeps `resolveGitDir`/`resolveGitCommonDir` at `Promise<string>`), and a drvfs pointer keeps its drive spelling even when a distro is named, because translation still goes through `toWindowsWslPath`.

**2. One gitfile-marker parser.** `src/shared/gitdir-marker-payload.ts` holds `parseGitdirMarkerPayload`: `gitdir:` at the start of the file, payload trimmed, empty payload rejected. `resolve-git-dir.ts` and `repo-git-marker-scan.ts` (which had a near-identical private copy) both call it; `repo-git-marker-scan.ts` loses six lines and gains no new behavior. This matches git's own `read_gitfile_gently`, which requires the marker at byte 0 and strips whitespace around the payload.

## What changes for users

| Platform | Change |
|---|---|
| macOS | None. |
| Linux | None. |
| Native Windows | None. |
| WSL-on-Windows | None. `wslDistro` has no caller in this PR. |
| SSH remote | None. The relay's own `resolveGitDir` copy (`src/relay/git-handler-status-ops.ts:38`) is untouched. |
| Relay wire | None. No RPC parameter, stream frame, or published content is touched; both functions are local path arithmetic. |
| Folder workspace | None. A folder workspace reaches `resolveGitDir` only through the unchanged `EISDIR`/`ENOENT` fallback. |
| Git binary | None. No subcommand or option added, removed, or reordered, so the 2.25 baseline is untouched. |

The one behavior change on every platform is a **malformed `.git` gitfile**, which git itself does not write:

- Payload with trailing padding (`gitdir: ../main/.git/worktrees/x  `): was a path with the padding attached (guaranteed `ENOENT`), now the correct path. Strict improvement.
- Whitespace-only payload (`gitdir:   `): was a path ending in a space, now the `<worktree>/.git` fallback. Both fail; the new one fails as the intended fallback.
- `gitdir:` on a line other than the first (`[core]\ngitdir: ../main/.git/worktrees/x`): **this is a narrowing, not a wash.** Main returned that gitdir and it could well exist and work; the new code returns `<worktree>/.git`, which in that scenario is the gitfile itself. All four `resolveGitDir` consumers (`worktree-sparse-state.ts:9`, `worktree-diff-stamp.ts:75`, `git-conflict-operation.ts:13`, `worktree-listing.ts:141`) already degrade through a catch or an existence check, so there is no crash — the affected worktree simply reports no sparse state / no conflict operation / no diff stamp. Git would not read such a file as a worktree either.

`repo-git-marker-scan.ts` is behaviorally identical, not just "close". I diffed its old regex against the shared parser over twelve marker spellings; the only divergence is a whitespace-only payload, which the old code turned into `" "` and then fed to `resolveGitMetadataPath`, which trimmed it to empty and returned null — the same `{ status: 'invalid' }` the new code reaches directly.

## What this does NOT do

- **No drvfs-before-UNC reorder.** That is the actual perf win of the source branch — turning `\\wsl.localhost\Ubuntu\mnt\c\repo\.git\...` (a 9p round trip per metadata read) into `C:\repo\.git\...` (direct NTFS). Excluded because it changes the *identity* of the returned string, and that string flows into settled-diff cache keys, the line-stats cache key, and `areWorktreePathsEqual` comparisons against git's own `/mnt/c/...` output. It needs a real Windows+WSL box, not a vitest mock.
- **No consumer of `wslDistro`.** Threading a distro through `resolveGitDir`, `detectConflictOperation`, the diff stamp, `file-diff`, the conflict-compat `existsSync`, the shared-symlink `lstat`, the untracked line-stat reads, and submodule path resolution are all follow-ups. The option is inert here.
- **No widened null semantics.** The source branch redefined the resolver to return null for an untranslatable POSIX pointer, cascading into six nullable signature changes and one fail-closed degradation in `attachLineStats`. Keeping main's contract makes that cascade unnecessary.
- **No unification of the nine remaining `gitdir:` parsers** — `src/relay/git-handler-status-ops.ts:38`, `src/main/runtime/repo-worktree-admin-fingerprint.ts:148`, `src/main/worktree-orphan-gitdir-proof.ts:210`, `src/main/github/local-git-config-signature.ts:243`, `src/shared/git-fetch-head-lock.ts:98`, `src/main/agent-trust-presets.ts:133`, `src/main/ipc/workspace-cleanup-activity.ts:170`, `src/main/ipc/worktree-common-git-directory.ts:54`, `src/main/git/wsl-linked-worktree-git-route-probe.ts:20`. Eleven sites parsed this marker; this PR collapses two into one and leaves nine. The relay one is the SSH path and each has its own leniency; converging them is its own change with its own blast radius.
- **No test deletion.** The source branch deleted `src/shared/git-metadata-path.test.ts`; all 11 of its cases are kept and mechanically migrated to the options object.

## Costs and residual risk

- **The non-first-line narrowing above is a real capability loss**, small as it is. I have no evidence anyone hits it — git never writes such a file — so this is hardening, not a fix for a reported failure. Please review it on that basis.
- **The shared parser is case-insensitive (`/i`)**, inherited from `repo-git-marker-scan.ts`'s copy so that file stays byte-for-byte equivalent. That *widens* `resolveGitDir`, which was case-sensitive on main: a `.git` file spelled `GITDIR: ../x` is now honored where main fell back to `<worktree>/.git`. Git is case-sensitive here, so the lenient side is the wrong side of git — I chose it because the alternative silently narrows repo detection. No test pins the case rule; a follow-up that tightens it should add one.
- **This PR widens the local-vs-SSH parsing gap for one specific pair.** On main, `resolve-git-dir.ts` and the relay's copy at `src/relay/git-handler-status-ops.ts:38` used byte-identical regexes. After this change they differ for five malformed shapes: trailing padding, `gitdir:` on a non-first line, uppercase `GITDIR:`, a whitespace-only payload, and a leading blank line. (CRLF is *not* a divergence — JS `.` excludes `\r`, so `.+` stops at the CR in both.) Only files git itself never writes are affected — git's `read_gitfile_gently` requires the marker at byte 0 — and the relay side is unchanged, so no SSH behavior regresses. Converging the relay parser would be a real SSH-path behavior change and is deliberately out of scope; it is one import away, since `src/relay` already imports from `src/shared`.
- **`wslDistro` is dead weight until a caller exists.** If slices 3+ are abandoned, this is an unused option on a shared primitive.
- **Mutation `options.platform ?? 'linux'` survives** on this darwin host. It is an equivalent mutant there — `'linux'` and `'darwin'` take the same posix branch — and a win32 runner would kill it. Every other mutation I tried was killed.
- **Typecheck coverage is scoped.** Per the environment constraint I did not run `pnpm tc`. I ran `tsc --noEmit --strict` over the four production files and both test files (exit 0), which covers the signature change and both call sites, but that is not the repo's project config, so `pnpm tc` in CI is still load-bearing.
- **The full sweep is flaky under load.** Two suites (`export-let-function-initializer-ban`, `setup-agent-sequencing`) hit the 5s test timeout in the parallel sweep and pass in isolation; neither imports anything this PR touches.

## Verification

**Existing call sites are unchanged.** `grep -rn 'resolveGitMetadataPath('` finds exactly two production call sites, both in `src/main/git/repo-git-marker-scan.ts` (132, 156), and both pass two arguments. With `options = {}` they take `platform = process.platform`, `wslDistro = undefined` — the pre-change path.

**Tests.**

- `npx vitest run src/main/git/repo-detection.test.ts src/main/git/status.test.ts src/main/git/status-conflict-operations.test.ts src/main/git/source-control/resolve-git-dir.test.ts src/shared/git-metadata-path.test.ts src/main/ipc/repos-add-linked-worktree.test.ts` → **6 files, 99 tests, all pass.**
- `npx vitest run src/main/git src/shared` → **805 files, 8681 passed / 6 failed / 73 skipped.** All 6 failures are pre-existing or environmental: 5 are the two load-timeout suites above (pass in isolation), and `git-admission-storm-measurement` fails identically on a stashed clean tree (`ENOENT: scandir .../orca-git-storm-disabled-*/state`).
- `npx tsc --noEmit --strict` (scoped, 6 files) → exit 0. `npx oxfmt --write` + `npx oxlint` on all 6 touched files → clean.

**Mutation-verified.** Each production hunk was reverted, the suite re-run, and the file restored. All eight mutations were killed by exactly the intended test:

| Mutation | Killed by |
|---|---|
| `resolveGitDir` back to main's `/^gitdir:\s*(.+)\s*$/m` | `drops padding around the marker payload`, `does not treat a whitespace-only gitdir payload as a metadata directory`, `ignores a gitdir line that is not the first line of the marker file` |
| Shared parser: drop `.trim()` | `drops padding around the marker payload`, `does not treat a whitespace-only gitdir payload…` |
| Shared parser: add `/m` (match any line) | `ignores a gitdir line that is not the first line of the marker file` |
| Drop the POSIX-host gate on a caller-named distro | `ignores a caller-named distro on a POSIX host` |
| Ignore the caller-named distro entirely | `maps a guest pointer through a caller-named distro when the base encodes none` |
| Let the caller-named distro outrank the UNC base | `lets the distro encoded by a WSL UNC base outrank the caller-named one` |
| `options.platform ?? 'win32'` | `defaults to the current host with no distro for "/repo" -> "/mnt/c/repo/.git"`, `resolves a relative pointer with no options in the reading host flavor` |
| `toWindowsWslPath` → `toWindowsWslUncPath` | `keeps a drvfs pointer on its drive spelling even when a distro is named` |

The default-behavior table asserts fixed expected values rather than comparing the function to itself, and `resolve-git-dir.test.ts` computes expectations through `path.resolve`/`path.join`, so both suites run on any host without a `process.platform` gate.

---

### Native-Windows verification (awin)

Real Windows host, Node 24, WSL distros `Ubuntu-24.04` + `Sta4593-Federated`. These slices are Windows/WSL path semantics, so macOS-green alone was not treated as sufficient.

`src/shared/git-metadata-path.test.ts src/main/git/source-control/resolve-git-dir.test.ts` → **2 files, 25 tests passed**

