### PR TITLE
fix(cleanup): follow WSL-written gitdir pointers on a Windows host

### DIFF
--- a/src/main/ipc/workspace-cleanup-activity.test.ts
+++ b/src/main/ipc/workspace-cleanup-activity.test.ts
@@ -239,6 +239,46 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     expect(worktree.lastActivityAt).toBe(70_000)
   })
 
+  it('maps a drvfs gitdir pointer to its drive spelling on a Windows host', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      const statPath = vi.fn(async (targetPath: string) => ({
+        mtimeMs: targetPath.endsWith('COMMIT_EDITMSG') ? 70_000 : 10_000
+      }))
+      // A WSL git writes the pointer in the guest namespace even for a drive-path worktree.
+      const readTextFile = vi.fn(
+        async (_targetPath: string) => 'gitdir: /mnt/c/Users/me/repo/.git/worktrees/repo-feature\n'
+      )
+
+      const worktree = await resolveWorkspaceCleanupActivityWorktree(
+        REPO,
+        makeWorktree({ path: String.raw`C:\Users\me\repo-feature` }),
+        statPath,
+        readTextFile
+      )
+
+      // Separators are normalized because the probe join uses the host separator;
+      // what this pins is the drive spelling of every resolved probe target.
+      const normalize = (target: string): string => target.replaceAll('/', '\\')
+      expect(statPath.mock.calls.map(([target]) => normalize(target)).sort()).toEqual(
+        [
+          String.raw`C:\Users\me\repo-feature`,
+          String.raw`C:\Users\me\repo-feature\.git`,
+          String.raw`C:\Users\me\repo\.git\worktrees\repo-feature\HEAD`,
+          String.raw`C:\Users\me\repo\.git\worktrees\repo-feature\COMMIT_EDITMSG`,
+          String.raw`C:\Users\me\repo\.git\worktrees\repo-feature\ORIG_HEAD`
+        ].sort()
+      )
+      expect(readTextFile.mock.calls.map(([target]) => normalize(target))).toContain(
+        String.raw`C:\Users\me\repo\.git\worktrees\repo-feature\logs\HEAD`
+      )
+      expect(worktree.lastActivityAt).toBe(70_000)
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
   it('keeps persisted activity when it is newer than local metadata', async () => {
     const statPath = vi.fn(async () => ({ mtimeMs: 10_000 }))
 

--- a/src/main/ipc/workspace-cleanup-activity.ts
+++ b/src/main/ipc/workspace-cleanup-activity.ts
@@ -2,9 +2,8 @@ import { lstat, open, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import type { Repo } from '../../shared/repo-types'
 import type { Worktree } from '../../shared/worktree/types'
+import { resolveGitMetadataPath } from '../../shared/git-metadata-path'
 import { getPersistedWorkspaceCleanupActivityAt } from '../../shared/workspace-cleanup'
-import { parseWslUncPath } from '../../shared/wsl-paths'
-import { toWindowsWslPath } from '../wsl'
 
 type StatPath = (targetPath: string) => Promise<{ mtimeMs: number }>
 type ReadTextFile = (targetPath: string, options?: { tailBytes?: number }) => Promise<string>
@@ -176,12 +175,10 @@ async function readLocalWorktreeGitDir(
       return null
     }
     // Why: linked worktrees keep mutable git state outside the worktree; the
-    // pointer file mtime alone can miss recent external commits.
-    const wslWorktree = parseWslUncPath(worktreePath)
-    if (wslWorktree && gitDir.startsWith('/')) {
-      return toWindowsWslPath(gitDir, wslWorktree.distro)
-    }
-    return path.isAbsolute(gitDir) ? gitDir : path.resolve(worktreePath, gitDir)
+    // pointer file mtime alone can miss recent external commits. The pointer is
+    // written in the namespace of the git that wrote it, which on Windows may
+    // be a WSL guest spelling that Win32 stat cannot follow.
+    return resolveGitMetadataPath(worktreePath, gitDir)
   } catch {
     return null
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 |

<!-- /orca-pr-loc -->

# Problem

`readLocalWorktreeGitDir` in `src/main/ipc/workspace-cleanup-activity.ts` resolved a linked worktree's `.git` gitfile pointer by hand, translating a POSIX-rooted pointer only when the worktree path was itself `\\wsl.localhost\...`. On a Windows host `path.isAbsolute('/mnt/c/repo/.git/worktrees/wt')` is `true`, so a drive-path worktree (`C:\Users\me\wt`) whose gitfile was written by git running *inside* WSL kept the raw guest spelling and was joined to `\mnt\c\repo\.git\worktrees\wt\HEAD` — drive-relative to the process's current drive. All four activity probes (`HEAD`, `COMMIT_EDITMSG`, `ORIG_HEAD`, tail of `logs/HEAD`) missed, so the row's `lastActivityAt` fell back to the worktree directory's own mtime and a worktree with recent commits could read as stale in the cleanup browser.

# Change

Delegate to the resolver that already exists on `main` for exactly this case (`src/shared/git-metadata-path.ts`, landed in 7f63db7d7a3, already used by `src/main/git/repo-git-marker-scan.ts`):

```ts
return resolveGitMetadataPath(worktreePath, gitDir)
```

Production diff is **+5 / −8 lines in one file**. No signature change, one call site, no new plumbing. The shared resolver itself is untouched: `git diff origin/main -- src/shared/git-metadata-path.ts src/shared/git-metadata-path.test.ts` is 0 lines, so its "null only for an empty pointer" contract and its UNC-before-drvfs ordering are preserved by construction.

I enumerated the delta rather than reasoning about it. A throwaway script (since deleted) reimplemented the removed `parseWslUncPath` + `toWindowsWslPath` + `isAbsolute`/`resolve` branch and diffed it against `resolveGitMetadataPath` over 10 base spellings × 18 pointer spellings × {win32, darwin, linux} = **540 pairs. 28 differ.** Every one is `win32` + a non-UNC base + a `/mnt/<lowercase-letter>` pointer. Zero on darwin, zero on linux, zero for any `\\wsl.localhost\...` or `\\wsl$\...` base (including `\\wsl.localhost\Ubuntu\mnt\c\...`), zero for `/mnt/C` (uppercase), `/mnt/cc`, `/mnt`, `/`, relative pointers, `C:\...` pointers, and both UNC pointer spellings.

| base | pointer | before | after |
|---|---|---|---|
| `\\wsl.localhost\<distro>\...` | any POSIX-rooted | `toWindowsWslPath(ptr, distro)` | identical |
| any | relative | `resolve(base, ptr)` | identical |
| non-UNC | absolute, not `/mnt/<a-z>` | verbatim | verbatim |
| non-UNC, POSIX host | `/mnt/c/...` | verbatim | verbatim |
| **non-UNC, win32 host** | **`/mnt/<a-z>/...`** | **verbatim → `\mnt\c\...` probe** | **`C:\...` drive spelling** |

# What changes for users

- **macOS:** no change. 0 of 180 differential pairs differ on darwin.
- **Linux:** no change. 0 of 180 differential pairs differ on linux.
- **Native Windows (no WSL in the picture):** no change. A pointer written by Windows git is a drive or UNC path and passes through verbatim, as before.
- **WSL-on-Windows:** the fix. A worktree at a drive path whose gitfile was written by WSL git now probes `C:\...\HEAD` instead of `\mnt\c\...\HEAD`, so its cleanup-browser `lastActivityAt` reflects real git activity. Worktrees under `\\wsl.localhost\...` are unchanged — the resolver's distro branch reproduces the previous result exactly (the pre-existing UNC test passes with the production hunk both reverted and applied).
- **SSH remote:** no change. `resolveWorkspaceCleanupActivityAt` returns the persisted timestamp before any filesystem probe when `repo.connectionId` is set, so this code is unreachable for remote repos.
- **Relay:** no change. No RPC param, stream frame, opcode, or published content is touched; the change is entirely inside one main-process file read.
- **Folder workspace:** no change. A folder workspace's `.git` is a directory or absent, `readTextFile` throws into the pre-existing `catch`, and the function returns `null` exactly as today.

# What this does NOT do

This is one slice of a larger local-Git/WSL routing change; the rest was dropped rather than shipped with caveats.

- **No `localGitOptions` threading.** `workspace-cleanup-worktree-listing.ts`, `workspace-cleanup-scan.ts`, `workspace-cleanup-candidate.ts`, and `workspace-cleanup-git-evidence.ts` are untouched. Where that threading was claimed to matter it is a no-op — `wslDistroForCommand` already derives the distro from a `\\wsl.localhost\...` cwd, and `readTranslatedWorktreeGraph` already hands the scan Windows-spelled worktree paths — and on the one cwd shape where it does bite (a `C:\...` worktree under a WSL-preference project) it would flip `getStatus` onto `prepareWslLinkedWorktreeGitRouting`'s 5s parent-walk probe: a routing regression plus per-row scan latency for no gain.
- **No widened resolver.** This uses `resolveGitMetadataPath(basePath, rawPath, platform?)` as-is, with the defaulted `platform`. The options-object variant that returns `null` for unresolvable pointers would be a semantics change to a shared function with an existing call site in `repo-git-marker-scan.ts` — a separate, larger review.
- **No folder-workspace distro branch.** `shouldReadWorkspaceCleanupGitEvidence` returns false for `repoIsFolder` and `folder-repo` is an unconditional removal blocker, so such a branch could not reach a git read or influence a deletion; it would only alter a displayed timestamp on structurally undeletable rows.
- **No change to the `0` activity sentinel.** A `0` from the probe already feeds `Math.max(persistedActivityAt, 0)`, so the row keeps its stored timestamp. Replacing it with a "now" sentinel would make rows silently vanish from the browse list.
- **Does not convert the other gitfile readers.** `src/shared/git-fetch-head-lock.ts`, `src/relay/git-handler-status-ops.ts`, `src/main/agent-trust-presets.ts`, `src/main/worktree-orphan-gitdir-proof.ts`, `src/main/runtime/repo-worktree-admin-fingerprint.ts`, `src/main/github/local-git-config-signature.ts`, `src/main/ipc/worktree-common-git-directory.ts`, and `src/main/git/source-control/resolve-git-dir.ts` still parse `gitdir:` themselves. Some may share this blind spot; each has a different caller, failure mode, and blast radius, and auditing them is not this slice.

# Costs and residual risk

- **This is not strictly monotone.** The gitdir probes feed `Math.max(0, ...)` and then `Math.max(persistedActivityAt, ...)`, so in practice a corrected row becomes *more* active and therefore *less* deletable. But the old probe target `\mnt\c\...\HEAD` is a real, if absurd, filesystem location — drive-relative to the process's current drive. If a user genuinely has `<drive>:\mnt\c\Users\...\.git\worktrees\<wt>\HEAD` with a newer mtime than the real gitdir, this change **lowers** that row's `lastActivityAt`. The persisted timestamp remains a floor, so it cannot drop below what the app already stored.
- **The drvfs mapping is narrow.** `toWindowsWslDrivePath` matches `^/mnt/([a-z])(/.*)?$` only. A distro with a custom `automount.root` (pointer `/c/Users/...`) or an uppercase `/mnt/C/...` pointer still gets the verbatim spelling and still misses every probe. Unchanged from today, not fixed here.
- **`/mnt/c` exactly** (drive with no path after it) now resolves to `C:\` instead of the verbatim string. Not a valid gitdir either way; the probes fail in both versions.
- **New nullable.** `resolveGitMetadataPath` returns `string | null`. Null is returned only for an empty pointer, which the caller already rejects (it trims and returns early), and the pre-existing `gitDirPath ? [...] : []` guard handles it regardless. Dead in practice, typed honestly.
- **Imports.** Adds `src/shared/git-metadata-path`; drops `src/shared/wsl-paths` and `src/main/wsl`. Dropping `src/main/wsl` is a reduction — it re-exports the same shared function — so no module gained a heavier graph. Runtime cost is one extra regex per gitfile read, and only on a Windows host with a POSIX-rooted pointer.
- **Not a Git-compatibility concern.** This slice runs no Git command and adds no subcommand or option; it only reads files. The Git 2.25 baseline is not engaged.

# Verification

- `npx vitest run src/main/ipc/workspace-cleanup src/shared/git-metadata-path.test.ts src/shared/wsl-paths.test.ts` → **8 files, 121 tests, all pass.**
- `npx vitest run src/main/ipc/workspace-cleanup-activity.test.ts` → **11 pass** (10 pre-existing + 1 new).
- **Mutation-verified.** `git checkout HEAD~1 -- src/main/ipc/workspace-cleanup-activity.ts` (production hunk only, new test kept) then re-running that file → **1 failed | 10 passed**. The single failure is the new test, and the diff shows the three stat probes moving from `C:\Users\me\repo\.git\worktrees\repo-feature\{HEAD,COMMIT_EDITMSG,ORIG_HEAD}` to `\mnt\c\Users\me\repo\...`. Restored with `git checkout HEAD -- <file>`; `git status --porcelain` empty. The 10 that pass both ways — including the pre-existing WSL-UNC and relative-pointer cases — are the evidence that no existing shape changed.
- **Differential enumeration** (the 540-pair / 28-delta run described above); script deleted, nothing left in the tree.
- **The new test is not gated on the host platform.** It stubs `process.platform` to `win32` with an *unconditional* descriptor restore in `finally` (the `withPlatform` pattern already used in `createMainWindow-test-harness.ts`), and asserts a **fixed** list of the five expected probe paths in win32 drive spelling — not a self-comparison against `path.join`. `/` is normalized to `\` in the comparison because the probe join uses the host separator; the drive-vs-drvfs spelling is what is pinned, and the mutation above confirms it fails on regression from a macOS/Linux runner.
- `npx oxfmt --write` then `npx oxlint` clean on both touched files.
- `pnpm tc` deliberately not run here (the orchestrator runs it serially). The only new call is two-arg against a three-parameter signature with a defaulted third.

---

### Native-Windows verification (awin)

Real Windows host, Node 24, WSL distros `Ubuntu-24.04` + `Sta4593-Federated`. These slices are Windows/WSL path semantics, so macOS-green alone was not treated as sufficient.

`src/main/ipc/workspace-cleanup-activity.test.ts src/main/ipc/workspace-cleanup.test.ts` → **2 files, 35 tests passed**
