### PR TITLE
fix(runtime): recover stale session owners and await terminal retirement

### DIFF
--- a/src/main/runtime/orca-runtime-stop-terminals-for-worktree.ts
+++ b/src/main/runtime/orca-runtime-stop-terminals-for-worktree.ts
@@ -15,7 +15,7 @@ export class OrcaRuntimeWithStopTerminalsForWorktree extends OrcaRuntimeWithReso
       deadline?: number
       stopPty?: (
         ptyId: string,
-        stop: () => boolean | Promise<boolean>
+        stop: () => Promise<boolean>
       ) => Promise<{ stopped: boolean; owner: boolean }>
       /** Authoritative id for an orphan whose selector no longer resolves. */
       resolvedWorktreeId?: string
@@ -68,30 +68,32 @@ export class OrcaRuntimeWithStopTerminalsForWorktree extends OrcaRuntimeWithReso
       if (options.deadline !== undefined && Date.now() >= options.deadline) {
         break
       }
-      const stop = (): boolean | Promise<boolean> => {
+      const stop = async (): Promise<boolean> => {
         if (options.deadline !== undefined && Date.now() >= options.deadline) {
           return false
         }
-        if (options.stopPty) {
-          // Why: destructive worktree cleanup must not let its cross-surface
-          // dedupe treat fire-and-forget controller.kill as physical exit.
-          // Why: the RPC deadline makes shutdown/list RPCs settle before the sweep
-          // deadline so a wedged daemon yields the accurate stop failure; no deadline
-          // (non-destructive) keeps the provider default RPC timeout.
-          if (options.deadline !== undefined) {
-            return (
-              this.ptyController?.stopAndWait?.(ptyId, {
+        try {
+          // Why: terminal.stop is a durable receipt; wait for provider exit so
+          // onPtyExit de-persists the tab before returning.
+          if (this.ptyController?.stopAndWait) {
+            // Why: the RPC deadline makes shutdown/list RPCs settle before the sweep deadline.
+            if (options.deadline !== undefined) {
+              return await this.ptyController.stopAndWait(ptyId, {
                 deadlineMs: teardownRpcDeadline(options.deadline)
-              }) ?? false
-            )
+              })
+            }
+            return await this.ptyController.stopAndWait(ptyId)
           }
-          return this.ptyController?.stopAndWait?.(ptyId) ?? false
+          return Boolean(this.ptyController?.kill(ptyId))
+        } catch (error) {
+          // A worktree sweep is best-effort per PTY; continue after provider errors.
+          console.warn(`[runtime] failed to stop terminal ${ptyId}`, error)
+          return false
         }
-        return Boolean(this.ptyController?.kill(ptyId))
       }
       const stopResult = options.stopPty
         ? await options.stopPty(ptyId, stop)
-        : { stopped: stop(), owner: true }
+        : { stopped: await stop(), owner: true }
       if (stopResult.owner && stopResult.stopped) {
         stopped += 1
       }

--- a/src/main/runtime/orca-runtime-terminal-retirement-host-partition.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-retirement-host-partition.test.ts
@@ -12,6 +12,14 @@ const SSH_WORKTREE_ID = `${SSH_REPO_ID}::/remote/worktree`
 const SSH_PTY_LEFT = `ssh:${CONNECTION_ID}@@pty-left`
 const SSH_PTY_RIGHT = `ssh:${CONNECTION_ID}@@pty-right`
 
+function makeDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
 const SSH_REPO = {
   id: SSH_REPO_ID,
   path: '/remote/worktree',
@@ -166,6 +174,137 @@ function syncSshSplit(runtime: OrcaRuntimeService, snapshot: RuntimeMobileSessio
 }
 
 describe('OrcaRuntimeService terminal retirement host partitioning (STA-3463)', () => {
+  it('routes a stale catalog owner to the unique persisted session owner', async () => {
+    const staleHostId: ExecutionHostId = 'runtime:stale-host'
+    const persistedTab = {
+      id: 'tab',
+      ptyId: 'persisted-pty',
+      worktreeId: SSH_WORKTREE_ID,
+      title: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 1
+    }
+    const localSession: WorkspaceSessionState = {
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: { [SSH_WORKTREE_ID]: [persistedTab] },
+      terminalLayoutsByTabId: {
+        tab: {
+          root: { type: 'leaf', leafId: 'leaf' },
+          activeLeafId: 'leaf',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf: 'persisted-pty' }
+        }
+      }
+    }
+    const sessions = new Map<ExecutionHostId, WorkspaceSessionState>([
+      [LOCAL_EXECUTION_HOST_ID, localSession],
+      [staleHostId, getDefaultWorkspaceSession()]
+    ])
+    const store = {
+      getRepos: () => [{ ...SSH_REPO, executionHostId: staleHostId }],
+      getRepo: () => ({ ...SSH_REPO, executionHostId: staleHostId }),
+      getWorktreeMeta: () => undefined,
+      getAllWorktreeMeta: () => ({}),
+      getWorkspaceSessionHostIds: () => [...sessions.keys()],
+      getWorkspaceSession: (hostId?: ExecutionHostId) =>
+        sessions.get(hostId ?? LOCAL_EXECUTION_HOST_ID) ?? getDefaultWorkspaceSession(),
+      setWorkspaceSession: (session: WorkspaceSessionState, hostId?: ExecutionHostId) =>
+        sessions.set(hostId ?? LOCAL_EXECUTION_HOST_ID, session),
+      flushOrThrow: vi.fn()
+    } as never
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: vi.fn(() => true),
+      getForegroundProcess: async () => null
+    })
+    runtime.registerPty('persisted-pty', SSH_WORKTREE_ID, null, {
+      tabId: 'tab',
+      leafId: 'leaf'
+    })
+
+    await expect(
+      runtime.closeMobileSessionTab(`id:${SSH_WORKTREE_ID}`, 'tab')
+    ).resolves.toMatchObject({
+      closed: true
+    })
+    expect(sessions.get(LOCAL_EXECUTION_HOST_ID)?.tabsByWorktree[SSH_WORKTREE_ID]).toEqual([])
+    expect(sessions.get(staleHostId)?.tabsByWorktree[SSH_WORKTREE_ID]).toBeUndefined()
+  })
+
+  it('waits for provider retirement on a direct worktree stop', async () => {
+    const harness = partitionedStore()
+    const runtime = new OrcaRuntimeService(harness.store)
+    const physicalStop = makeDeferred()
+    const kill = vi.fn(() => true)
+    const stopAndWait = vi.fn(async () => {
+      await physicalStop.promise
+      return true
+    })
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      stopAndWait,
+      getForegroundProcess: async () => null
+    })
+    syncSshSplit(runtime, makeSshSnapshot())
+    runtime.registerPty(SSH_PTY_LEFT, SSH_WORKTREE_ID, CONNECTION_ID, {
+      tabId: 'tab',
+      leafId: 'left'
+    })
+
+    const stopping = runtime.stopTerminalsForWorktree(`id:${SSH_WORKTREE_ID}`, {
+      resolvedWorktreeId: SSH_WORKTREE_ID
+    })
+    await vi.waitFor(() => expect(stopAndWait).toHaveBeenCalledWith(SSH_PTY_LEFT))
+    let settled = false
+    void stopping.then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    expect(kill).not.toHaveBeenCalled()
+
+    physicalStop.resolve()
+    await expect(stopping).resolves.toEqual({ stopped: 2 })
+  })
+
+  it('continues stopping later PTYs when one provider retirement rejects', async () => {
+    const harness = partitionedStore()
+    const runtime = new OrcaRuntimeService(harness.store)
+    const stopAndWait = vi.fn(async (ptyId: string) => {
+      if (ptyId === SSH_PTY_LEFT) {
+        throw new Error('relay_unavailable')
+      }
+      return true
+    })
+    runtime.setPtyController({
+      write: () => true,
+      kill: vi.fn(() => true),
+      stopAndWait,
+      getForegroundProcess: async () => null
+    })
+    syncSshSplit(runtime, makeSshSnapshot())
+    runtime.registerPty(SSH_PTY_LEFT, SSH_WORKTREE_ID, CONNECTION_ID, {
+      tabId: 'tab',
+      leafId: 'left'
+    })
+    runtime.registerPty(SSH_PTY_RIGHT, SSH_WORKTREE_ID, CONNECTION_ID, {
+      tabId: 'tab',
+      leafId: 'right'
+    })
+
+    await expect(
+      runtime.stopTerminalsForWorktree(`id:${SSH_WORKTREE_ID}`, {
+        resolvedWorktreeId: SSH_WORKTREE_ID
+      })
+    ).resolves.toEqual({ stopped: 1 })
+    expect(stopAndWait).toHaveBeenNthCalledWith(1, SSH_PTY_LEFT)
+    expect(stopAndWait).toHaveBeenNthCalledWith(2, SSH_PTY_RIGHT)
+  })
+
   it('retires an exited SSH pane from the SSH partition and leaves the local partition untouched', async () => {
     const harness = partitionedStore()
     const localBefore = harness.sessions.get(LOCAL_EXECUTION_HOST_ID)!

--- a/src/main/runtime/orca-runtime-tests/terminal-sleep-and-teardown.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-sleep-and-teardown.spec.ts
@@ -76,10 +76,11 @@ describe('OrcaRuntimeService', () => {
   it('stops by exact id when the selector no longer resolves', async () => {
     const runtime = new OrcaRuntimeService(store)
     const kill = vi.fn(() => true)
+    const stopAndWait = vi.fn(async () => true)
     runtime.setPtyController({
       write: () => true,
       kill,
-      stopAndWait: vi.fn(async () => true),
+      stopAndWait,
       getForegroundProcess: async () => null
     })
     syncSinglePty(runtime)
@@ -90,7 +91,7 @@ describe('OrcaRuntimeService', () => {
         resolvedWorktreeId: TEST_WORKTREE_ID
       })
     ).resolves.toEqual({ stopped: 1 })
-    expect(kill).toHaveBeenCalledWith('pty-1')
+    expect(stopAndWait).toHaveBeenCalledWith('pty-1')
   })
 
   it('does not sweep a sibling workspace sharing the checkout dir of an exact id', async () => {
@@ -138,10 +139,11 @@ describe('OrcaRuntimeService', () => {
   it('stops only the owning connection when one worktree id lives on two hosts', async () => {
     const runtime = new OrcaRuntimeService(store)
     const kill = vi.fn(() => true)
+    const stopAndWait = vi.fn(async () => true)
     runtime.setPtyController({
       write: () => true,
       kill,
-      stopAndWait: vi.fn(async () => true),
+      stopAndWait,
       getForegroundProcess: async () => null
     })
     syncSinglePty(runtime, null)
@@ -156,8 +158,8 @@ describe('OrcaRuntimeService', () => {
         resolvedConnectionId: 'ssh-1'
       })
     ).resolves.toEqual({ stopped: 1 })
-    expect(kill).toHaveBeenCalledWith('pty-ssh')
-    expect(kill).not.toHaveBeenCalledWith('pty-local')
+    expect(stopAndWait).toHaveBeenCalledWith('pty-ssh')
+    expect(stopAndWait).not.toHaveBeenCalledWith('pty-local')
   })
 
   it('awaits physical PTY stop when destructive teardown supplies shared dedupe', async () => {
@@ -175,7 +177,7 @@ describe('OrcaRuntimeService', () => {
       getForegroundProcess: async () => null
     })
     syncSinglePty(runtime)
-    const stopPty = vi.fn(async (_ptyId: string, stop: () => boolean | Promise<boolean>) => ({
+    const stopPty = vi.fn(async (_ptyId: string, stop: () => Promise<boolean>) => ({
       stopped: await stop(),
       owner: true
     }))
@@ -204,7 +206,7 @@ describe('OrcaRuntimeService', () => {
       getForegroundProcess: async () => null
     })
     syncSinglePty(runtime)
-    const stopPty = vi.fn(async (_ptyId: string, stop: () => boolean | Promise<boolean>) => ({
+    const stopPty = vi.fn(async (_ptyId: string, stop: () => Promise<boolean>) => ({
       stopped: await stop(),
       owner: true
     }))

--- a/src/main/runtime/runtime-workspace-session-controller.ts
+++ b/src/main/runtime/runtime-workspace-session-controller.ts
@@ -27,6 +27,7 @@ export class RuntimeWorkspaceSessionController {
   tryGetHostId(worktreeId: string): ExecutionHostId | null {
     const store = this.deps.getStore()
     const scope = parseWorkspaceKey(worktreeId)
+    let preferredHostId: ExecutionHostId
     if (scope?.type === 'folder') {
       const workspace = store
         ?.getFolderWorkspaces?.()
@@ -37,14 +38,39 @@ export class RuntimeWorkspaceSessionController {
       // An explicit host is authoritative for folder workspaces. The connection
       // id is only a legacy fallback for records written before host ids existed.
       if (workspace.executionHostId != null) {
-        return parseExecutionHostId(workspace.executionHostId)?.id ?? null
+        const parsedHostId = parseExecutionHostId(workspace.executionHostId)?.id
+        if (!parsedHostId) {
+          return null
+        }
+        preferredHostId = parsedHostId
+      } else {
+        const connectionId = this.deps.resolveFolderConnectionId(workspace)
+        preferredHostId = connectionId
+          ? toSshExecutionHostId(connectionId)
+          : LOCAL_EXECUTION_HOST_ID
       }
-      const connectionId = this.deps.resolveFolderConnectionId(workspace)
-      return connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID
+    } else {
+      const resolvedWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
+      const repo = store?.getRepo?.(getRepoIdFromWorktreeId(resolvedWorktreeId))
+      preferredHostId = repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
     }
-    const resolvedWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
-    const repo = store?.getRepo?.(getRepoIdFromWorktreeId(resolvedWorktreeId))
-    return repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
+    const getWorkspaceSession = store?.getWorkspaceSession
+    const persistedHostIds = store?.getWorkspaceSessionHostIds?.()
+    if (
+      !getWorkspaceSession ||
+      !persistedHostIds ||
+      Object.hasOwn(getWorkspaceSession(preferredHostId).tabsByWorktree, worktreeId)
+    ) {
+      return preferredHostId
+    }
+    const persistedOwners = persistedHostIds.filter(
+      (hostId) =>
+        hostId !== preferredHostId &&
+        Object.hasOwn(getWorkspaceSession(hostId).tabsByWorktree, worktreeId)
+    )
+    // Relay restarts can leave catalog metadata on an obsolete partition while
+    // the durable tab owner remains unique.
+    return persistedOwners.length === 1 ? persistedOwners[0]! : preferredHostId
   }
 
   getHostId(worktreeId: string): ExecutionHostId {
@@ -120,12 +146,13 @@ export class RuntimeWorkspaceSessionController {
       }
       for (const [worktreeId, tabs] of Object.entries(session.tabsByWorktree ?? {})) {
         const scope = parseWorkspaceKey(worktreeId)
-        const ownerHostId =
+        const catalogOwnerHostId =
           scope?.type === 'folder'
             ? (folderHostIdByWorkspaceId.get(scope.folderWorkspaceId) ?? null)
             : (repoHostIdByRepoId.get(
                 getRepoIdFromWorktreeId(scope?.type === 'worktree' ? scope.worktreeId : worktreeId)
               ) ?? LOCAL_EXECUTION_HOST_ID)
+        const ownerHostId = this.tryGetHostId(worktreeId) ?? catalogOwnerHostId
         if (
           ownerHostId === hostId &&
           (includeAllPersistedWorktrees ||

--- a/src/main/runtime/runtime-workspace-session-controller.ts
+++ b/src/main/runtime/runtime-workspace-session-controller.ts
@@ -24,10 +24,8 @@ type RuntimeWorkspaceSessionDependencies = {
 export class RuntimeWorkspaceSessionController {
   constructor(private readonly deps: RuntimeWorkspaceSessionDependencies) {}
 
-  tryGetHostId(worktreeId: string): ExecutionHostId | null {
-    const store = this.deps.getStore()
+  private getPreferredHostId(worktreeId: string, store: RuntimeStore): ExecutionHostId | null {
     const scope = parseWorkspaceKey(worktreeId)
-    let preferredHostId: ExecutionHostId
     if (scope?.type === 'folder') {
       const workspace = store
         ?.getFolderWorkspaces?.()
@@ -42,25 +40,23 @@ export class RuntimeWorkspaceSessionController {
         if (!parsedHostId) {
           return null
         }
-        preferredHostId = parsedHostId
-      } else {
-        const connectionId = this.deps.resolveFolderConnectionId(workspace)
-        preferredHostId = connectionId
-          ? toSshExecutionHostId(connectionId)
-          : LOCAL_EXECUTION_HOST_ID
+        return parsedHostId
       }
-    } else {
-      const resolvedWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
-      const repo = store?.getRepo?.(getRepoIdFromWorktreeId(resolvedWorktreeId))
-      preferredHostId = repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
+      const connectionId = this.deps.resolveFolderConnectionId(workspace)
+      return connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID
     }
-    const getWorkspaceSession = store?.getWorkspaceSession
-    const persistedHostIds = store?.getWorkspaceSessionHostIds?.()
-    if (
-      !getWorkspaceSession ||
-      !persistedHostIds ||
-      Object.hasOwn(getWorkspaceSession(preferredHostId).tabsByWorktree, worktreeId)
-    ) {
+    const resolvedWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
+    const repo = store?.getRepo?.(getRepoIdFromWorktreeId(resolvedWorktreeId))
+    return repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
+  }
+
+  private resolveHostId(
+    worktreeId: string,
+    preferredHostId: ExecutionHostId,
+    persistedHostIds: readonly ExecutionHostId[],
+    getWorkspaceSession: (hostId: ExecutionHostId) => WorkspaceSessionState
+  ): ExecutionHostId {
+    if (Object.hasOwn(getWorkspaceSession(preferredHostId).tabsByWorktree, worktreeId)) {
       return preferredHostId
     }
     const persistedOwners = persistedHostIds.filter(
@@ -71,6 +67,24 @@ export class RuntimeWorkspaceSessionController {
     // Relay restarts can leave catalog metadata on an obsolete partition while
     // the durable tab owner remains unique.
     return persistedOwners.length === 1 ? persistedOwners[0]! : preferredHostId
+  }
+
+  tryGetHostId(worktreeId: string): ExecutionHostId | null {
+    const store = this.deps.getStore()
+    if (!store) {
+      return null
+    }
+    const preferredHostId = this.getPreferredHostId(worktreeId, store)
+    if (!preferredHostId) {
+      return null
+    }
+    const persistedHostIds = store?.getWorkspaceSessionHostIds?.()
+    if (!store.getWorkspaceSession || !persistedHostIds) {
+      return preferredHostId
+    }
+    return this.resolveHostId(worktreeId, preferredHostId, persistedHostIds, (hostId) =>
+      store.getWorkspaceSession!(hostId)
+    )
   }
 
   getHostId(worktreeId: string): ExecutionHostId {
@@ -139,11 +153,15 @@ export class RuntimeWorkspaceSessionController {
     }
 
     const targets = new Map<string, WorkspaceSessionState>()
+    const sessionsByHostId = new Map<ExecutionHostId, WorkspaceSessionState>()
     for (const hostId of hostIds) {
       const session = store?.getWorkspaceSession?.(hostId)
       if (!session) {
         continue
       }
+      sessionsByHostId.set(hostId, session)
+    }
+    for (const [hostId, session] of sessionsByHostId) {
       for (const [worktreeId, tabs] of Object.entries(session.tabsByWorktree ?? {})) {
         const scope = parseWorkspaceKey(worktreeId)
         const catalogOwnerHostId =
@@ -152,7 +170,12 @@ export class RuntimeWorkspaceSessionController {
             : (repoHostIdByRepoId.get(
                 getRepoIdFromWorktreeId(scope?.type === 'worktree' ? scope.worktreeId : worktreeId)
               ) ?? LOCAL_EXECUTION_HOST_ID)
-        const ownerHostId = this.tryGetHostId(worktreeId) ?? catalogOwnerHostId
+        const ownerHostId = this.resolveHostId(
+          worktreeId,
+          catalogOwnerHostId ?? LOCAL_EXECUTION_HOST_ID,
+          [...sessionsByHostId.keys()],
+          (candidateHostId) => sessionsByHostId.get(candidateHostId)!
+        )
         if (
           ownerHostId === hostId &&
           (includeAllPersistedWorktrees ||

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -99,7 +99,7 @@ export async function killAllProcessesForWorktree(
   const stopAttempts = new Map<string, Promise<boolean>>()
   const stopPty = (
     ptyId: string,
-    stop: () => boolean | Promise<boolean>
+    stop: () => Promise<boolean>
   ): Promise<{ stopped: boolean; owner: boolean }> => {
     const previous = stopAttempts.get(ptyId) ?? Promise.resolve(false)
     const current = previous


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​148 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |

<!-- /orca-pr-loc -->

## Summary
- recover a worktree session when the catalog executionHostId is stale but exactly one persisted host partition owns the tabs
- make worktree terminal retirement await provider stopAndWait, preserve the kill fallback for older controllers, and continue after per-PTY provider failures
- add regression coverage for stale-owner routing, durable direct stop, and partial provider failure

## Why
On current origin/main, a paired/headless remote topology can retain tabs under a persisted SSH host partition while the catalog points at an old runtime host. Close then routes to the empty stale partition and returns `tab_not_found`. Direct worktree stop also previously fired a non-durable kill path, allowing the process/tab state to outlive the sweep and reappear after restart.

## Validation
- deterministic red oracle reproduced both failures against origin/main
- focused runtime regression suite: 34 tests passed
- `pnpm tc`
- `pnpm run check:code-quality:changed`
- `git diff --check`
- three fresh gpt-5.6-luna reviewers checked boundary, compatibility/product behavior, and regressions; no actionable code changes remained

## Compatibility and risks
- no wire/API changes
- preserves SSH, folder workspaces, mixed-version controllers, and cross-platform behavior
- alternate persisted ownership is used only when unique; ambiguous partitions retain catalog preference
- stop remains best-effort per PTY and may wait for provider retirement up to the existing teardown deadline