### PR TITLE
fix(browser): route page-targeted keyboard input through CDP

### DIFF
--- a/src/main/browser/agent-browser-bridge-text-input.test.ts
+++ b/src/main/browser/agent-browser-bridge-text-input.test.ts
@@ -565,6 +565,178 @@ describe('AgentBrowserBridge', () => {
     expect(chunks).toEqual(['y'.repeat(AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES), 'zz'])
   })
 
+  it('routes page-targeted type through the requested page debugger', async () => {
+    const wc = mockWebContents(100)
+    const activeWc = mockWebContents(101)
+    wc.debugger.sendCommand.mockResolvedValue({})
+    webContentsFromIdMock.mockImplementation((id: number) => (id === 100 ? wc : activeWc))
+    bridge = new AgentBrowserBridge(
+      mockBrowserManager(
+        new Map([
+          ['tab-target', 100],
+          ['tab-active', 101]
+        ])
+      )
+    )
+    bridge.setActiveTab(101)
+
+    await bridge.type('HELLO-SOLO', undefined, 'tab-target')
+
+    expect(execFileMock).not.toHaveBeenCalled()
+    expect(wc.focus).toHaveBeenCalledTimes(1)
+    expect(activeWc.focus).not.toHaveBeenCalled()
+    expect(activeWc.debugger.sendCommand).not.toHaveBeenCalled()
+    expect(wc.debugger.sendCommand).toHaveBeenCalledWith('Input.insertText', {
+      text: 'HELLO-SOLO'
+    })
+  })
+
+  it('routes page-targeted keypress through the requested page debugger', async () => {
+    const wc = mockWebContents(100)
+    const activeWc = mockWebContents(101)
+    wc.debugger.sendCommand.mockResolvedValue({})
+    webContentsFromIdMock.mockImplementation((id: number) => (id === 100 ? wc : activeWc))
+    bridge = new AgentBrowserBridge(
+      mockBrowserManager(
+        new Map([
+          ['tab-target', 100],
+          ['tab-active', 101]
+        ])
+      )
+    )
+    bridge.setActiveTab(101)
+
+    const result = await bridge.keypress('Escape', undefined, 'tab-target')
+
+    expect(result).toEqual({ pressed: 'Escape' })
+    expect(execFileMock).not.toHaveBeenCalled()
+    expect(wc.focus).toHaveBeenCalledTimes(1)
+    expect(activeWc.focus).not.toHaveBeenCalled()
+    expect(activeWc.debugger.sendCommand).not.toHaveBeenCalled()
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key: 'Escape',
+      code: 'Escape',
+      windowsVirtualKeyCode: 27
+    })
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      type: 'keyUp',
+      key: 'Escape',
+      code: 'Escape',
+      windowsVirtualKeyCode: 27
+    })
+  })
+
+  it('preserves modifiers for page-targeted keypresses', async () => {
+    const wc = mockWebContents(100)
+    wc.debugger.sendCommand.mockResolvedValue({})
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await bridge.keypress('Control+a', undefined, 'tab-1')
+
+    expect(wc.focus).toHaveBeenCalledTimes(1)
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key: 'Control',
+      code: 'ControlLeft',
+      modifiers: 2,
+      windowsVirtualKeyCode: 17
+    })
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key: 'a',
+      code: 'KeyA',
+      modifiers: 2,
+      windowsVirtualKeyCode: 65,
+      unmodifiedText: 'a'
+    })
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(3, 'Input.dispatchKeyEvent', {
+      type: 'keyUp',
+      key: 'a',
+      code: 'KeyA',
+      modifiers: 2,
+      windowsVirtualKeyCode: 65,
+      unmodifiedText: 'a'
+    })
+  })
+
+  it('does not synthesize text for modified page-targeted shortcuts', async () => {
+    const wc = mockWebContents(100)
+    wc.debugger.sendCommand.mockResolvedValue({})
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await bridge.keypress('Control+Enter', undefined, 'tab-1')
+
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key: 'Control',
+      code: 'ControlLeft',
+      modifiers: 2,
+      windowsVirtualKeyCode: 17
+    })
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key: 'Enter',
+      code: 'Enter',
+      modifiers: 2,
+      windowsVirtualKeyCode: 13,
+      text: undefined
+    })
+  })
+
+  it('initializes agent-browser for unscoped keypresses', async () => {
+    succeedWith({ pressed: 'Escape' })
+
+    await bridge.keypress('Escape')
+
+    expect(execFileMock).toHaveBeenCalled()
+    const commandArgs = execFileMock.mock.calls.map((call: unknown[]) => call[1] as string[])
+    expect(commandArgs.some((args) => args.includes('press') && args.includes('Escape'))).toBe(true)
+  })
+
+  it('uses the shifted symbol for page-targeted shifted digits', async () => {
+    const wc = mockWebContents(100)
+    wc.debugger.sendCommand.mockResolvedValue({})
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await bridge.keypress('Shift+1', undefined, 'tab-1')
+
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key: 'Shift',
+      code: 'ShiftLeft',
+      modifiers: 8,
+      windowsVirtualKeyCode: 16
+    })
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key: '!',
+      code: 'Digit1',
+      modifiers: 8,
+      windowsVirtualKeyCode: 49,
+      text: '!',
+      unmodifiedText: '!'
+    })
+  })
+
+  it('uses the shifted symbol for literal page-targeted punctuation', async () => {
+    const wc = mockWebContents(100)
+    wc.debugger.sendCommand.mockResolvedValue({})
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await bridge.keypress('Shift+,', undefined, 'tab-1')
+
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key: '<',
+      code: 'Comma',
+      modifiers: 8,
+      windowsVirtualKeyCode: 188,
+      text: '<',
+      unmodifiedText: '<'
+    })
+  })
+
   it('chunks large agent-browser keyboard insert text before transport', async () => {
     const text = ['z'.repeat(AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES), 'qq'].join('')
     succeedWith({ inserted: true })

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -50,7 +50,9 @@ import type {
 import { assertClipboardTextWriteWithinLimitWithYield } from '../../shared/clipboard-text'
 import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
 import { mapSettledWithConcurrency } from '../../shared/map-with-concurrency'
-import { iterateBrowserTextInsertionChunks } from './browser-text-insertion'
+import { insertTextThroughCdp, iterateBrowserTextInsertionChunks } from './browser-text-insertion'
+import { resolveKeyDefinition, type KeyDefinition } from './cdp-text-input-commands'
+import { sendDebuggerCommand } from './browser-screencast-debugger-command'
 import { createAgentBrowserProcessEnvironment } from './agent-browser-process-environment'
 import {
   ORCA_TAB_SESSION_PREFIX,
@@ -1015,16 +1017,42 @@ export class AgentBrowserBridge {
     return this.enqueueTargetedCommand(
       worktreeId,
       browserPageId,
-      async (sessionName) => {
-        for (const chunk of iterateBrowserTextInsertionChunks(
-          input,
-          AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
-        )) {
-          await this.execAgentBrowser(sessionName, ['keyboard', 'type', chunk])
+      async (sessionName, target) => {
+        if (!browserPageId) {
+          for (const chunk of iterateBrowserTextInsertionChunks(
+            input,
+            AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
+          )) {
+            await this.execAgentBrowser(sessionName, ['keyboard', 'type', chunk])
+          }
+          return { typed: true } as BrowserTypeResult
         }
-        return { typed: true } as BrowserTypeResult
+        const wc = this.requireTargetWebContents(target)
+        let releaseDebugger = (): void => {}
+        try {
+          releaseDebugger = acquireElectronDebugger(wc).release
+          wc.focus()
+          await insertTextThroughCdp(
+            (method, params) => sendDebuggerCommand(wc.debugger, method, params),
+            input,
+            { maxChunkBytes: AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES }
+          )
+          return { typed: true } as BrowserTypeResult
+        } catch (error) {
+          if (!this.getWebContents(target.webContentsId)) {
+            throw this.createPageUnavailableError(
+              `${ORCA_TAB_SESSION_PREFIX}${target.browserPageId}`
+            )
+          }
+          throw new BrowserError(
+            'browser_error',
+            `Failed to type into browser page ${target.browserPageId}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        } finally {
+          releaseDebugger()
+        }
       },
-      { requireScopedTarget: true }
+      { ensureSession: !browserPageId, requireScopedTarget: true }
     )
   }
 
@@ -1812,9 +1840,62 @@ export class AgentBrowserBridge {
     worktreeId?: string,
     browserPageId?: string
   ): Promise<BrowserKeypressResult> {
-    return this.enqueueTargetedCommand(worktreeId, browserPageId, async (sessionName) => {
-      return (await this.execAgentBrowser(sessionName, ['press', key])) as BrowserKeypressResult
-    })
+    return this.enqueueTargetedCommand(
+      worktreeId,
+      browserPageId,
+      async (sessionName, target) => {
+        if (!browserPageId) {
+          return (await this.execAgentBrowser(sessionName, ['press', key])) as BrowserKeypressResult
+        }
+        const wc = this.requireTargetWebContents(target)
+        const keyDefinition = resolveKeyDefinition(key)
+        let releaseDebugger = (): void => {}
+        try {
+          releaseDebugger = acquireElectronDebugger(wc).release
+          wc.focus()
+          const modifierDefinitions = resolveModifierKeyDefinitions(keyDefinition.modifiers ?? 0)
+          let activeModifiers = 0
+          for (const modifier of modifierDefinitions) {
+            activeModifiers |= modifier.modifier
+            await sendDebuggerCommand(wc.debugger, 'Input.dispatchKeyEvent', {
+              type: 'keyDown',
+              ...modifier.definition,
+              modifiers: activeModifiers
+            })
+          }
+          await sendDebuggerCommand(wc.debugger, 'Input.dispatchKeyEvent', {
+            type: 'keyDown',
+            ...keyDefinition
+          })
+          await sendDebuggerCommand(wc.debugger, 'Input.dispatchKeyEvent', {
+            type: 'keyUp',
+            ...keyDefinition
+          })
+          for (const modifier of modifierDefinitions.toReversed()) {
+            activeModifiers &= ~modifier.modifier
+            await sendDebuggerCommand(wc.debugger, 'Input.dispatchKeyEvent', {
+              type: 'keyUp',
+              ...modifier.definition,
+              modifiers: activeModifiers
+            })
+          }
+          return { pressed: key }
+        } catch (error) {
+          if (!this.getWebContents(target.webContentsId)) {
+            throw this.createPageUnavailableError(
+              `${ORCA_TAB_SESSION_PREFIX}${target.browserPageId}`
+            )
+          }
+          throw new BrowserError(
+            'browser_error',
+            `Failed to press key in browser page ${target.browserPageId}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        } finally {
+          releaseDebugger()
+        }
+      },
+      { ensureSession: !browserPageId }
+    )
   }
 
   async pdf(worktreeId?: string, browserPageId?: string): Promise<BrowserPdfResult> {
@@ -2881,4 +2962,15 @@ export class AgentBrowserBridge {
       return null
     }
   }
+}
+
+const MODIFIER_KEY_DEFINITIONS: { modifier: number; definition: KeyDefinition }[] = [
+  { modifier: 1, definition: { key: 'Alt', code: 'AltLeft', windowsVirtualKeyCode: 18 } },
+  { modifier: 2, definition: { key: 'Control', code: 'ControlLeft', windowsVirtualKeyCode: 17 } },
+  { modifier: 4, definition: { key: 'Meta', code: 'MetaLeft', windowsVirtualKeyCode: 91 } },
+  { modifier: 8, definition: { key: 'Shift', code: 'ShiftLeft', windowsVirtualKeyCode: 16 } }
+]
+
+function resolveModifierKeyDefinitions(modifiers: number) {
+  return MODIFIER_KEY_DEFINITIONS.filter(({ modifier }) => (modifiers & modifier) !== 0)
 }

--- a/src/main/browser/cdp-text-input-commands.ts
+++ b/src/main/browser/cdp-text-input-commands.ts
@@ -156,14 +156,27 @@ export class CdpTextInputCommands extends CdpBridgeCommandModule {
 }
 
 // Why: Input.dispatchKeyEvent needs `text` for keys with default actions (Enter/Tab), or Chrome skips the action.
-type KeyDefinition = {
+export type KeyDefinition = {
   key: string
   code: string
+  modifiers?: number
   windowsVirtualKeyCode?: number
   text?: string
+  unmodifiedText?: string
 }
 
 const KEY_DEFINITIONS: Record<string, KeyDefinition> = {
+  Backquote: { key: '`', code: 'Backquote', windowsVirtualKeyCode: 192, text: '`' },
+  Minus: { key: '-', code: 'Minus', windowsVirtualKeyCode: 189, text: '-' },
+  Equal: { key: '=', code: 'Equal', windowsVirtualKeyCode: 187, text: '=' },
+  Backslash: { key: '\\', code: 'Backslash', windowsVirtualKeyCode: 220, text: '\\' },
+  BracketLeft: { key: '[', code: 'BracketLeft', windowsVirtualKeyCode: 219, text: '[' },
+  BracketRight: { key: ']', code: 'BracketRight', windowsVirtualKeyCode: 221, text: ']' },
+  Semicolon: { key: ';', code: 'Semicolon', windowsVirtualKeyCode: 186, text: ';' },
+  Quote: { key: "'", code: 'Quote', windowsVirtualKeyCode: 222, text: "'" },
+  Comma: { key: ',', code: 'Comma', windowsVirtualKeyCode: 188, text: ',' },
+  Period: { key: '.', code: 'Period', windowsVirtualKeyCode: 190, text: '.' },
+  Slash: { key: '/', code: 'Slash', windowsVirtualKeyCode: 191, text: '/' },
   Enter: { key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13, text: '\r' },
   Tab: { key: 'Tab', code: 'Tab', windowsVirtualKeyCode: 9, text: '\t' },
   Escape: { key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 },
@@ -177,28 +190,142 @@ const KEY_DEFINITIONS: Record<string, KeyDefinition> = {
   End: { key: 'End', code: 'End', windowsVirtualKeyCode: 35 },
   PageUp: { key: 'PageUp', code: 'PageUp', windowsVirtualKeyCode: 33 },
   PageDown: { key: 'PageDown', code: 'PageDown', windowsVirtualKeyCode: 34 },
-  Space: { key: ' ', code: 'Space', windowsVirtualKeyCode: 32, text: ' ' }
+  Space: { key: ' ', code: 'Space', windowsVirtualKeyCode: 32, text: ' ' },
+  ...Object.fromEntries(
+    Array.from({ length: 12 }, (_, index) => {
+      const key = `F${index + 1}`
+      return [key, { key, code: key, windowsVirtualKeyCode: 112 + index }]
+    })
+  )
 }
 
-function resolveKeyDefinition(key: string): KeyDefinition {
+const SHIFTED_KEYS: Record<string, string> = {
+  Backquote: '~',
+  Minus: '_',
+  Equal: '+',
+  Backslash: '|',
+  BracketLeft: '{',
+  BracketRight: '}',
+  Semicolon: ':',
+  Quote: '"',
+  Comma: '<',
+  Period: '>',
+  Slash: '?'
+}
+
+const SHIFTED_DIGITS = ')!@#$%^&*('
+
+const PUNCTUATION_KEYS: Record<
+  string,
+  { code: string; windowsVirtualKeyCode: number; shifted: string }
+> = {
+  '`': { code: 'Backquote', windowsVirtualKeyCode: 192, shifted: '~' },
+  '-': { code: 'Minus', windowsVirtualKeyCode: 189, shifted: '_' },
+  '=': { code: 'Equal', windowsVirtualKeyCode: 187, shifted: '+' },
+  '\\': { code: 'Backslash', windowsVirtualKeyCode: 220, shifted: '|' },
+  '[': { code: 'BracketLeft', windowsVirtualKeyCode: 219, shifted: '{' },
+  ']': { code: 'BracketRight', windowsVirtualKeyCode: 221, shifted: '}' },
+  ';': { code: 'Semicolon', windowsVirtualKeyCode: 186, shifted: ':' },
+  "'": { code: 'Quote', windowsVirtualKeyCode: 222, shifted: '"' },
+  ',': { code: 'Comma', windowsVirtualKeyCode: 188, shifted: '<' },
+  '.': { code: 'Period', windowsVirtualKeyCode: 190, shifted: '>' },
+  '/': { code: 'Slash', windowsVirtualKeyCode: 191, shifted: '?' }
+}
+
+export function resolveKeyDefinition(input: string): KeyDefinition {
+  const parts = input.split('+')
+  let key = parts.pop() ?? input
+  if (key === '' && parts.at(-1) === '') {
+    parts.pop()
+    key = '+'
+  }
+  let modifiers = 0
+  for (const modifier of parts) {
+    if (modifier === 'Alt') {
+      modifiers |= 1
+    } else if (modifier === 'Control' || modifier === 'Ctrl') {
+      modifiers |= 2
+    } else if (
+      modifier === 'Meta' ||
+      modifier === 'Command' ||
+      modifier === 'Cmd' ||
+      (modifier === 'ControlOrMeta' && process.platform === 'darwin')
+    ) {
+      modifiers |= 4
+    } else if (modifier === 'ControlOrMeta') {
+      modifiers |= 2
+    } else if (modifier === 'Shift') {
+      modifiers |= 8
+    }
+  }
+
+  const hasNonShiftModifier = (modifiers & ~8) !== 0
+
   if (KEY_DEFINITIONS[key]) {
-    return KEY_DEFINITIONS[key]
+    if (modifiers === 0) {
+      return KEY_DEFINITIONS[key]
+    }
+    const baseDefinition = KEY_DEFINITIONS[key]
+    const shiftedKey = (modifiers & 8) !== 0 ? SHIFTED_KEYS[key] : undefined
+    return {
+      ...baseDefinition,
+      ...(shiftedKey
+        ? {
+            key: shiftedKey,
+            text: hasNonShiftModifier ? undefined : shiftedKey,
+            unmodifiedText: shiftedKey
+          }
+        : {}),
+      modifiers,
+      ...(hasNonShiftModifier ? { text: undefined } : {})
+    }
   }
   // Why: sites that check event.code drop events with invalid code values.
   if (key.length === 1) {
     const charCode = key.charCodeAt(0)
     if (charCode >= 48 && charCode <= 57) {
-      return { key, code: `Digit${key}`, windowsVirtualKeyCode: charCode, text: key }
-    }
-    if ((charCode >= 65 && charCode <= 90) || (charCode >= 97 && charCode <= 122)) {
+      const shiftedKey = (modifiers & 8) !== 0 ? SHIFTED_DIGITS[Number(key)] : key
       return {
-        key,
-        code: `Key${key.toUpperCase()}`,
-        windowsVirtualKeyCode: key.toUpperCase().charCodeAt(0),
-        text: key
+        key: shiftedKey,
+        code: `Digit${key}`,
+        windowsVirtualKeyCode: charCode,
+        ...(hasNonShiftModifier ? {} : { text: shiftedKey }),
+        modifiers,
+        ...(modifiers > 0 ? { unmodifiedText: (modifiers & 8) !== 0 ? shiftedKey : key } : {})
       }
     }
-    return { key, code: '', windowsVirtualKeyCode: charCode, text: key }
+    if ((charCode >= 65 && charCode <= 90) || (charCode >= 97 && charCode <= 122)) {
+      const text = hasNonShiftModifier ? undefined : key
+      const shiftedKey = (modifiers & 8) !== 0 ? key.toUpperCase() : key
+      return {
+        key: shiftedKey,
+        code: `Key${shiftedKey.toUpperCase()}`,
+        windowsVirtualKeyCode: shiftedKey.toUpperCase().charCodeAt(0),
+        ...(text !== undefined ? { text: (modifiers & 8) !== 0 ? shiftedKey : text } : {}),
+        ...(modifiers > 0 ? { unmodifiedText: (modifiers & 8) !== 0 ? shiftedKey : key } : {}),
+        modifiers
+      }
+    }
+    const punctuation = PUNCTUATION_KEYS[key]
+    if (punctuation) {
+      const shiftedKey = (modifiers & 8) !== 0 ? punctuation.shifted : key
+      return {
+        key: shiftedKey,
+        code: punctuation.code,
+        windowsVirtualKeyCode: punctuation.windowsVirtualKeyCode,
+        ...(hasNonShiftModifier ? {} : { text: shiftedKey }),
+        modifiers,
+        ...(modifiers > 0 ? { unmodifiedText: (modifiers & 8) !== 0 ? shiftedKey : key } : {})
+      }
+    }
+    return {
+      key,
+      code: '',
+      windowsVirtualKeyCode: charCode,
+      text: key,
+      modifiers,
+      ...(modifiers > 0 ? { unmodifiedText: key } : {})
+    }
   }
-  return { key, code: key }
+  return { key, code: key, modifiers }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​172 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​172 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​219 |

<!-- /orca-pr-loc -->

## Summary

Fixes STA-3600 / #12912. Explicit `--page` `type` and `keypress` commands now dispatch through the resolved page's Electron debugger instead of the OS-focused `agent-browser` helper.

On `origin/main`, a deterministic Orca-managed-terminal repro returned `typed: true` / `pressed` while leaving the page input untouched and appending bytes to the focused terminal prompt. The new path targets the exact `webContents`, preserves unscoped helper behavior, and leaves element-scoped `fill` / `inserttext` behavior unchanged.

## Scope decision

This is a routing correctness fix. A later STA-3600 comment reports similar `inserttext --page` leakage; that remains a separate follow-up because this PR is limited to the canonical `type`/`keypress` failure and does not change the element/input insertion contract.

## Testing

- Baseline/revert oracle: new page-targeted tests fail on untouched `origin/main`.
- Candidate bridge/CDP tests: 39 passed across focused files.
- `pnpm tc:node`
- `pnpm run check:code-quality:changed`
- `oxlint`
- `oxfmt --check`
- `git diff --check`

## Compatibility

No RPC, stream opcode, persisted format, SSH protocol, or remote-wire change. Unscoped commands retain the existing agent-browser path; explicit page commands execute on the owning runtime/webContents. Modifier key sequences and named keyboard keys retain their prior browser semantics.

## Review

Three initial fresh gpt-5.6-luna read-only reviews were run in the same worktree. A subsequent automated review identified unscoped session initialization, shifted-digit mapping, modifier event sequencing, and named-key mapping gaps; each was validated and corrected. Two additional fresh gpt-5.6-luna read-only reviews then confirmed the amended boundary and compatibility behavior; no unresolved finding remains.
