### PR TITLE
fix(native-chat): stop unjournaled provider frames from killing the structured session

### DIFF
--- a/src/main/codex/codex-structured-journal-generic-frames.ts
+++ b/src/main/codex/codex-structured-journal-generic-frames.ts
@@ -64,19 +64,24 @@ export class CodexJournalGenericFrames {
     threadId = 'session'
   ): CodexJournalTranslationAdmission {
     const translated = unhandledProviderFrameJournalItem('codex', kind, payload)
+    // A frame the classifier declines is deliberately not journaled, which is success.
+    // Failing admission here force-closes the provider through the retry queue.
     if (!translated) {
-      return { accepted: false, reason: 'untranslated' }
+      return CODEX_JOURNAL_ADMITTED
     }
     const turnId = readCodexTurnId(payload) ?? this.activeTurn(threadId) ?? 'outside-turn'
     const bucket = this.bucketFor(threadId, turnId)
     const rowCount = this.genericRowsByTurn.get(bucket) ?? 0
-    if (rowCount >= MAX_CODEX_GENERIC_ROWS_PER_TURN) {
+    // The cap bounds noise, never evidence: an error frame is always journaled, and
+    // capped frames stay countable through one summary row per turn.
+    const isError = translated.classification === 'error-surface'
+    if (!isError && rowCount >= MAX_CODEX_GENERIC_ROWS_PER_TURN) {
       this.addSuppressed(bucket, 1)
       this.recordBucket(bucket)
       this.scheduleSuppressedRows()
       return CODEX_JOURNAL_ADMITTED
     }
-    if (translated.classification === 'error-surface') {
+    if (isError) {
       const suppressionAdmission = this.flush()
       if (!suppressionAdmission.accepted) {
         return suppressionAdmission

--- a/src/main/codex/codex-structured-journal-translation-streams.test.ts
+++ b/src/main/codex/codex-structured-journal-translation-streams.test.ts
@@ -299,6 +299,31 @@ describe('codex journal translation', () => {
     })
   })
 
+  // A frame the classifier declines is intentionally unjournaled. #17720 turned that
+  // into an admission failure, which the notification retry queue escalated to a
+  // provider force-close, so no structured session could survive its first chrome frame.
+  it('admits chrome and suppressed-benign frames without journaling them', () => {
+    const { translator, tap } = translatorWith()
+    translator.handle(TURN_STARTED)
+    const before = tap.rows.length
+    for (const method of [
+      'remoteControl/status/changed',
+      'thread/status/changed',
+      'thread/tokenUsage/updated',
+      'hook/started',
+      'fs/changed',
+      'rawResponse/completed',
+      // Delta-shaped unknown methods reach the same early-out via the name heuristic.
+      'future/somethingDelta'
+    ]) {
+      expect(translator.handle(notification(method, { status: 'disabled' }))).toEqual({
+        accepted: true
+      })
+    }
+    expect(tap.rows.length).toBe(before)
+    expect(tap.publishes()).toBe(0)
+  })
+
   it('bounds generic rows per turn while keeping the suppression visible and countable', () => {
     const { translator, tap, window } = translatorWith()
     translator.handle(TURN_STARTED)
@@ -399,7 +424,9 @@ describe('codex journal translation', () => {
     expect(tap.rows.filter((row) => row.key.includes('provider-frame-suppressed'))).toHaveLength(1)
   })
 
-  it('bounds error-surface provider frames under the generic-row cap', () => {
+  // The cap bounds noise, never evidence. #17720 dropped this exemption (and pinned the
+  // capped behavior in a test), so a noisy turn could silently swallow provider errors.
+  it('exempts error-surface provider frames from the generic-row cap', () => {
     const { translator, tap, window } = translatorWith()
     translator.handle(TURN_STARTED)
     for (let index = 0; index < MAX_CODEX_GENERIC_ROWS_PER_TURN + 3; index += 1) {
@@ -411,11 +438,15 @@ describe('codex journal translation', () => {
     const generic = tap.rows.filter(
       (row) => row.body.kind === 'status' && row.body.providerFrame !== undefined
     )
-    expect(generic).toHaveLength(MAX_CODEX_GENERIC_ROWS_PER_TURN)
+    expect(generic).toHaveLength(MAX_CODEX_GENERIC_ROWS_PER_TURN + 1)
+    expect(generic.at(-1)?.body).toMatchObject({
+      providerFrame: { kind: 'notification:future/failure' }
+    })
+    // Only the 3 capped noise frames reduce to a summary; the error is not counted there.
     expect(tap.rows.filter((row) => row.key.includes('provider-frame-suppressed'))).toHaveLength(1)
-    expect(tap.rows.at(-1)?.body).toEqual({
+    expect(tap.rows.find((row) => row.key.includes('provider-frame-suppressed'))?.body).toEqual({
       kind: 'status',
-      text: '4 more provider notifications not shown for this turn'
+      text: '3 more provider notifications not shown for this turn'
     })
   })
 

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
@@ -10,7 +10,7 @@ import { classifyProviderFrame } from './provider-frame-disposition'
 export type UnhandledProviderFrameJournalItem = {
   body: AgentJournalStatusItem
   blobs: { digest: string; payload: string }[]
-  /** Why the frame surfaced; all classes are subject to the translator's row cap. */
+  /** Why the frame surfaced. Error frames are exempt from generic-row caps. */
   classification: 'timeline-substantive' | 'error-surface'
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## The bug

Structured Codex native chat could not open a session. Every attempt failed with:

```
Could not open Codex chat
codex app-server connection is closed (model/list)
```

Deterministic — reported against an ad-hoc build from main, 100% reproducible, first chat after restart and every one after.

## Root cause

A frame the classifier declines — `status-chrome`, `suppressed-benign`, `stream-into-item` — is deliberately not journaled, and `unhandledProviderFrameJournalItem` returns `null` to say so.

#17720 turned that `null` into `{ accepted: false, reason: 'untranslated' }`. Before it, the same case was a void drop. `untranslated` is not `backpressure`, so the notification retry queue treats it as unreplayable and escalates: `fail()` → `forceCloseUnexpected` → `closeCodexPublishedSession` → `connection.close()`. That latches `closing` permanently, and the create path's next request — `model/list` from `readNativeSessionOptions` — rejects with the toast text above.

The provider emits `remoteControl/status/changed` immediately after `initialize` (verified against the real binary, codex-cli 0.151.0), so every session died on its first chrome frame. About 50 catalogued methods are armed identically, so dodging one only defers it to the next.

## Second regression in the same function

`appendUnhandled` also began testing the generic row cap **before** looking at classification, dropping the error exemption:

```js
// before #17720
const capped =
  rowCount >= MAX_CODEX_GENERIC_ROWS_PER_TURN && translated.classification !== 'error-surface'
```

Once a turn got noisy, real evidence — `guardianWarning`, `configWarning`, MCP startup failures, `windows/worldWritableWarning` — was silently reduced to a suppression count. Restored.

## Why CI was green

#17720 added a test, `bounds error-surface provider frames under the generic-row cap`, pinning the new capped behavior. It is inverted here to assert the exemption. No existing test fed a chrome frame through acquire, so the force-close path had no coverage at all.

## Scope

Deliberately minimal. Narrowing the retry-queue escalation and giving the read pause ownership semantics were considered and **deferred** — after this fix `untranslated` has no producer that reaches that queue, and the hardening has unresolved design questions (the sink shares one boolean pause; a `connection.closed` guard that falls through to `fail()` overwrites `requestedClose`; dropping retry state on teardown loses queued unjournaled frames). Follow-ups: that ownership model, the closed-but-indexed session at `codex-structured-session-close.ts:81`, caching the account-scoped `model/list`, and structured-session trace spans — a P0 here currently leaves no trace evidence at all.

Sibling `untranslated` producers left alone: `restoreThread` on a malformed history item (which surfaces as a misleading "history exceeds the bounded restore queue" refusal) and empty lifecycle prompt batches. Neither enters the notification retry queue.

## Testing

- `codex-structured-journal-translation-streams.test.ts` — chrome/suppressed-benign/delta-shaped frames admit without journaling or publishing; error frames still journal past the cap while noise reduces to an exact summary.
- Full `src/main/codex` + `src/main/native-chat` suites: 2300 passed. One unrelated `vi.waitFor` watcher flake in `structured-tui-transcript-catchup.test.ts` under load; passes in isolation.
- `pnpm tc` clean; changed-code quality gate clean.
