### PR TITLE
fix(daemon): keep attach cancellation behind client timeout

### DIFF
--- a/src/main/daemon/daemon-client-rpc-request.test.ts
+++ b/src/main/daemon/daemon-client-rpc-request.test.ts
@@ -21,7 +21,64 @@ function addSiblingRequest(pendingRequests: DaemonPendingRequests, reject: () =>
 
 describe('requestDaemonRpc', () => {
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.useRealTimers()
+  })
+
+  it('keeps the daemon attach guard behind the client timeout window', async () => {
+    const pendingRequests = new DaemonPendingRequests()
+    const abort = new AbortController()
+    const write = vi.fn()
+    const request = requestDaemonRpc({
+      socket: { write } as unknown as Socket,
+      pendingRequests,
+      id: 'req-1',
+      type: 'createOrAttach',
+      payload: { sessionId: 'guarded-spawn' },
+      timeoutMs: 30_000,
+      signal: abort.signal,
+      unmatchedCancelGraceMs: 5_000,
+      onCreateCancellationFailure: vi.fn(),
+      settleCreateCancellation: vi.fn(async () => ({ canceled: true }))
+    })
+
+    expect(JSON.parse(String(write.mock.calls[0]?.[0]))).toMatchObject({
+      payload: { sessionId: 'guarded-spawn', cancelAfterMs: 35_000 }
+    })
+    abort.abort()
+    await expect(request).rejects.toThrow('client_disconnected')
+  })
+
+  it('classifies a cancellation delivered after an overdue timeout as a timeout', async () => {
+    vi.useFakeTimers()
+    const monotonicNow = vi.spyOn(performance, 'now').mockReturnValue(0)
+    const pendingRequests = new DaemonPendingRequests()
+    const settleCreateCancellation = vi.fn(() => new Promise<{ canceled: boolean }>(() => {}))
+    const request = requestDaemonRpc({
+      socket: { write: vi.fn() } as unknown as Socket,
+      pendingRequests,
+      id: 'req-1',
+      type: 'createOrAttach',
+      payload: { sessionId: 'deadline-spawn' },
+      timeoutMs: 10,
+      unmatchedCancelGraceMs: 5,
+      onCreateCancellationFailure: vi.fn(),
+      settleCreateCancellation
+    })
+    const rejected = expect(request).rejects.toMatchObject({
+      name: 'DaemonRequestTimeoutError',
+      message: 'Request createOrAttach timed out after 10ms'
+    })
+
+    monotonicNow.mockReturnValue(16)
+    pendingRequests.settle({
+      id: 'req-1',
+      ok: false,
+      error: 'Attach canceled for session deadline-spawn'
+    })
+
+    await rejected
+    expect(settleCreateCancellation).not.toHaveBeenCalled()
   })
 
   it('keeps a completed spawn result when cancellation arrives too late', async () => {

--- a/src/main/daemon/daemon-client-rpc-request.ts
+++ b/src/main/daemon/daemon-client-rpc-request.ts
@@ -54,20 +54,27 @@ function wedgedDaemonError(requestError: Error, cancelError: unknown): Error | n
 }
 
 export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
+  // A stalled event loop can deliver a daemon cancellation before its overdue timer runs.
   const { payload, type } = opts
+  const createTimeoutError = (): DaemonRequestTimeoutError =>
+    new DaemonRequestTimeoutError(`Request ${type} timed out after ${opts.timeoutMs}ms`)
   const createSessionId =
     type === 'createOrAttach' && payload !== null && typeof payload === 'object'
       ? Reflect.get(payload, 'sessionId')
       : null
   const requestPayload =
     type === 'createOrAttach' && payload !== null && typeof payload === 'object'
-      ? { ...payload, cancelAfterMs: Math.max(1, opts.timeoutMs - 100) }
+      ? {
+          ...payload,
+          cancelAfterMs: Math.max(1, opts.timeoutMs + opts.unmatchedCancelGraceMs)
+        }
       : payload
   const encoded = encodeNdjson({
     id: opts.id,
     type,
     ...(requestPayload !== undefined ? { payload: requestPayload } : {})
   })
+  const clientDeadlineMs = performance.now() + opts.timeoutMs
 
   return new Promise<T>((resolve, reject) => {
     let sent = false
@@ -146,9 +153,7 @@ export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
         })
     }
     const timer = setTimeout(() => {
-      const error = new DaemonRequestTimeoutError(
-        `Request ${type} timed out after ${opts.timeoutMs}ms`
-      )
+      const error = createTimeoutError()
       if (typeof createSessionId === 'string') {
         cancelCreate(error)
       } else {
@@ -172,8 +177,11 @@ export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
         removeAbortListener()
         clearTimers()
         reject(
-          cancellationError !== null && isTerminalAttachCanceledMessage(error.message)
-            ? cancellationError
+          isTerminalAttachCanceledMessage(error.message)
+            ? (cancellationError ??
+                (type === 'createOrAttach' && performance.now() >= clientDeadlineMs
+                  ? createTimeoutError()
+                  : error))
             : error
         )
       },


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 |

<!-- /orca-pr-loc -->

## Summary

Fixes #17675 (Linear STA-6168). On a slow/stalled macOS main process, the daemon could cancel a `createOrAttach` request just before the client timeout callback ran. The client then surfaced `DaemonProtocolError: Attach canceled...` and left the new terminal stuck.

## ELI5

The app and daemon each had a stopwatch. The daemon's stopwatch was set to ring 100ms *before* the app's stopwatch. If the app was busy and did not notice its own timeout yet, it received the daemon's cancellation message first and treated it like a protocol failure.

The client now gives the daemon a cancellation deadline after the client timeout plus the existing grace window, and recognizes a late attach-cancellation response as the client timeout when the deadline has passed. Explicit user/client aborts still report `client_disconnected`.

## Reproduction / oracle

A deterministic unit oracle was run against today's `origin/main` before the fix:

- Expected daemon guard for a 30s client timeout + 5s grace: `cancelAfterMs: 35000`
- `origin/main` sent `cancelAfterMs: 29900`
- A cancellation delivered after the overdue client deadline rejected as `DaemonProtocolError`, not `DaemonRequestTimeoutError`

The oracle fails on the baseline and passes with this change.

## Why this boundary

This is a daemon RPC request lifecycle race. The authoritative ownership boundary is `requestDaemonRpc`, where the client timeout, daemon cancellation payload, and pending response classification meet. No renderer, PTY, parking, session/worktree, SSH, folder-workspace, or runtime changes are needed.

## Validation

- Focused regression: 11/11 passed
- Typecheck: `pnpm tc` passed
- Changed-code quality: passed with 0 findings
- Build: `pnpm build` passed (existing CSS/chunk warnings only)
- Baseline oracle: failed deterministically on `origin/main` as described above
- `git diff --check`: passed
- Three fresh gpt-5.6-luna reviews (boundary, compatibility/product, regressions): approved; one test-isolation finding was fixed with `vi.restoreAllMocks()`

The full `src/main/daemon` sweep reached 1,736 passing tests but also hit two unrelated pre-existing zsh PTY timing failures in `repro-13767-shell-ready-marker-lost-to-exec.test.ts`.

## Compatibility / product notes

This is primarily a bug fix. It changes only timeout/error classification for this race. The existing optional `cancelAfterMs` payload remains wire-compatible with mixed-version daemons; no opcode or required field was added. SSH, remote runtimes, folder workspaces, and other platforms are unchanged.

A bounded cleanup-window classification nuance remains possible for very late daemon replies, but no current caller branches on `DaemonRequestTimeoutError`; explicit abort behavior is preserved.

Downside: some late daemon cancellation errors may now appear as timeout-shaped errors, which is the intended user-visible outcome for an operation that exceeded its client deadline.
