### PR TITLE
fix(ssh): declare a wedged relay link lost, and stop reading silence as a verdict

### DIFF
--- a/src/main/ai-vault/ssh-session-list.test.ts
+++ b/src/main/ai-vault/ssh-session-list.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AiVaultListResult, AiVaultSession } from '../../shared/ai-vault-types'
-import { SSH_MUX_REQUEST_TIMEOUT_CODE } from '../ssh/ssh-channel-multiplexer'
+import {
+  createSshDisposalError,
+  SSH_MUX_REQUEST_TIMEOUT_CODE
+} from '../ssh/ssh-channel-multiplexer'
 
 const requestActiveSshAiVaultSessionList = vi.fn()
 const getActiveSshAiVaultHostInfo = vi.fn()
@@ -132,6 +135,24 @@ describe('scanSshAiVaultSessions', () => {
     // A relay that had a fair scan window will not answer faster over the far
     // slower filesystem crawl, so retrying it only stalls the merge.
     requestActiveSshAiVaultSessionList.mockRejectedValue(relayTimeoutError())
+
+    const result = await scanSshAiVaultSessions('dev-box', undefined, {
+      timeoutMs: 20_000,
+      relayTimeoutMs: 15_000
+    })
+
+    expect(scanRemoteAiVaultSessions).not.toHaveBeenCalled()
+    expect(result.issues).toEqual([
+      expect.objectContaining({ executionHostId: 'ssh:dev-box', kind: 'host' })
+    ])
+  })
+
+  it('reports a host issue when the relay link was declared lost on a real scan budget', async () => {
+    // Declaring a wedged link lost trades SSH_MUX_REQUEST_TIMEOUT for CONNECTION_LOST on this leg.
+    // Both are unverifiable, so both must surface as a host issue rather than falling through to a
+    // crawl that would publish an authoritative-looking empty list
+    // (docs/reference/ssh-execution-boundary.md).
+    requestActiveSshAiVaultSessionList.mockRejectedValue(createSshDisposalError('connection_lost'))
 
     const result = await scanSshAiVaultSessions('dev-box', undefined, {
       timeoutMs: 20_000,

--- a/src/main/ai-vault/ssh-session-list.ts
+++ b/src/main/ai-vault/ssh-session-list.ts
@@ -10,7 +10,7 @@ import {
   SSH_FILESYSTEM_PROVIDER_UNAVAILABLE_MESSAGE
 } from '../providers/ssh-filesystem-dispatch'
 import { getActiveSshAiVaultHostInfo, requestActiveSshAiVaultSessionList } from '../ipc/ssh'
-import { isSshMuxRequestTimeoutError } from '../ssh/ssh-channel-multiplexer'
+import { isSshRequestOutcomeUnverifiable } from '../ssh/ssh-channel-multiplexer'
 import { createAiVaultScanCancelledError } from './ai-vault-scan-cancellation'
 import { scanRemoteAiVaultSessions } from './remote-session-scanner'
 import { parseAiVaultListResult } from './session-list-result-validation'
@@ -84,7 +84,7 @@ async function scanOneSshHost(
       throw error
     }
     if (
-      isSshMuxRequestTimeoutError(error) &&
+      isSshRequestOutcomeUnverifiable(error) &&
       (relayTimeoutMs === undefined || relayTimeoutMs >= MEANINGFUL_RELAY_SCAN_ATTEMPT_MS)
     ) {
       return sshScanIssueResult(executionHostId, targetId, errorMessage(error))

--- a/src/main/ssh/ssh-channel-multiplexer-saturation-wedge.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer-saturation-wedge.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { encodeKeepAliveFrame, KEEPALIVE_SEND_MS, TIMEOUT_MS } from './relay-protocol'
+import { SshChannelMultiplexer, type MultiplexerTransport } from './ssh-channel-multiplexer'
+
+type WedgedTransport = MultiplexerTransport & { writes: Buffer[]; feed: (chunk: Buffer) => void }
+
+/**
+ * A transport that accepts the first write, then reports backpressure forever: no drain, and no
+ * write settlement. This is a half-open TCP link — the socket buffer filled and the peer's FIN
+ * never arrived — which is what sleep/resume and a dropped NAT mapping produce in the field.
+ */
+function createWedgedTransport(): WedgedTransport {
+  const writes: Buffer[] = []
+  let onData: (chunk: Buffer) => void = () => {}
+  return {
+    write: (data) => {
+      writes.push(data)
+      return false
+    },
+    onData: (callback) => {
+      onData = callback
+    },
+    onClose: () => {},
+    onDrain: () => () => {},
+    supportsWriteSettlement: true,
+    writes,
+    feed: (chunk) => onData(chunk)
+  }
+}
+
+describe('SshChannelMultiplexer on a transport that saturates and never drains', () => {
+  let transport: WedgedTransport
+  let mux: SshChannelMultiplexer
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    transport = createWedgedTransport()
+    mux = new SshChannelMultiplexer(transport)
+  })
+
+  afterEach(() => {
+    mux.dispose()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('declares the link lost instead of suppressing the dead-link check forever', async () => {
+    // Drive well past every health window: keepalive interval, dead-link timeout, and the
+    // wake-gap grace that resets staleness after a suspend.
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS * 10 + KEEPALIVE_SEND_MS)
+
+    expect(mux.isDisposed()).toBe(true)
+  })
+
+  it('fails a request parked behind saturation rather than leaving it pending forever', async () => {
+    const settled = vi.fn()
+    mux.request('pty.spawn', {}).then(
+      () => settled('resolved'),
+      () => settled('rejected')
+    )
+
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS * 10 + KEEPALIVE_SEND_MS)
+
+    expect(settled).toHaveBeenCalledWith('rejected')
+  })
+
+  it('keeps a slow-but-alive peer connected while its own keepalives arrive', async () => {
+    // The regression guard for the fix above: backpressure on our uplink is not evidence of
+    // death, and the relay's own keepalive is what proves it.
+    let seq = 1
+    const inbound = setInterval(() => {
+      transport.feed(encodeKeepAliveFrame(seq++, 0))
+    }, KEEPALIVE_SEND_MS)
+    try {
+      await vi.advanceTimersByTimeAsync(TIMEOUT_MS * 10 + KEEPALIVE_SEND_MS)
+      expect(mux.isDisposed()).toBe(false)
+    } finally {
+      clearInterval(inbound)
+    }
+  })
+})

--- a/src/main/ssh/ssh-channel-multiplexer.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.test.ts
@@ -71,7 +71,6 @@ type MuxInternals = {
   disposeHandlers: unknown[]
   lastReceivedAt: number
   unackedTimestamps: Map<number, number>
-  writerSaturated: boolean
 }
 
 function getMuxInternals(instance: SshChannelMultiplexer): MuxInternals {
@@ -354,9 +353,10 @@ describe('SshChannelMultiplexer', () => {
       expect(mux.isDisposed()).toBe(true)
     })
 
-    it('suppresses false death while locally saturated and rebases both clocks on drain', () => {
+    it('survives local saturation while the peer keeps talking, and rebases both clocks on drain', () => {
       mux.dispose()
       let drain = (): void => {}
+      let feed: (chunk: Buffer) => void = () => {}
       const written: Buffer[] = []
       const saturatedTransport: MultiplexerTransport = {
         write: (data) => {
@@ -367,21 +367,29 @@ describe('SshChannelMultiplexer', () => {
         onDrain: (callback) => {
           drain = callback
         },
-        onData: vi.fn(),
+        onData: (callback) => {
+          feed = callback
+        },
         onClose: vi.fn()
       }
       mux = new SshChannelMultiplexer(saturatedTransport)
 
       vi.advanceTimersByTime(5_000)
-      expect(getMuxInternals(mux).writerSaturated).toBe(true)
-      vi.advanceTimersByTime(25_000)
+      // The writer parked after its first frame: that is the saturation this test is about.
+      expect(written).toHaveLength(1)
+      // Why: backpressure on our uplink is not evidence of death. The relay's own keepalive is,
+      // and only that inbound traffic may keep the link alive — suppressing the check on
+      // saturation alone wedged a half-open link forever (see the saturation-wedge suite).
+      for (let tick = 0; tick < 5; tick++) {
+        feed(encodeKeepAliveFrame(0, 0))
+        vi.advanceTimersByTime(5_000)
+      }
       expect(mux.isDisposed()).toBe(false)
       expect(written).toHaveLength(1)
 
       drain()
       const resumedAt = Date.now()
       const internals = getMuxInternals(mux)
-      expect(internals.writerSaturated).toBe(false)
       expect(internals.lastReceivedAt).toBe(resumedAt)
       expect(new Set(internals.unackedTimestamps.values())).toEqual(new Set([resumedAt]))
 

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -102,7 +102,6 @@ export class SshChannelMultiplexer {
   private disposed = false
   private disposeReason: 'shutdown' | 'connection_lost' | null = null
   private decoderReadPaused = false
-  private writerSaturated = false
 
   // Track the oldest unacked outgoing message timestamp
   private unackedTimestamps = new Map<number, number>()
@@ -587,7 +586,12 @@ export class SshChannelMultiplexer {
 
       this.sendKeepAlive()
 
-      if (this.disposed || resumedAfterWake || this.decoderReadPaused || this.writerSaturated) {
+      // Why: a saturated writer used to suppress this check outright, which wedged a half-open
+      // link forever — no drain, so no frame ever left, and the writer's single-outstanding
+      // liveness guard silenced the one probe that could have noticed. The relay sends its own
+      // keepalive every KEEPALIVE_SEND_MS, so a slow-but-alive peer still refreshes
+      // lastReceivedAt; only a link that delivers nothing inbound is declared lost.
+      if (this.disposed || resumedAfterWake || this.decoderReadPaused) {
         return
       }
 
@@ -650,7 +654,6 @@ export class SshChannelMultiplexer {
   }
 
   private handleWriterSaturationChange(saturated: boolean): void {
-    this.writerSaturated = saturated
     if (!saturated && !this.disposed) {
       this.rebaseHealthClocks(Date.now())
     }

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -74,11 +74,19 @@ function sshMuxRequestTimeoutError(method: string, timeoutMs: number): Error {
   })
 }
 
-export function isSshMuxRequestTimeoutError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error as Error & { code?: unknown }).code === SSH_MUX_REQUEST_TIMEOUT_CODE
-  )
+/**
+ * True when a request may have run on the host despite failing here.
+ *
+ * A response deadline and a link declared lost are the same verdict: the frame reached the wire and
+ * the peer's answer did not come back, so the work is `unverifiable`, never absent. Declaring a
+ * wedged link lost at TIMEOUT_MS turned what used to surface as SSH_MUX_REQUEST_TIMEOUT into
+ * CONNECTION_LOST, so callers that phrase the verdict to a user must branch on this rather than on
+ * the timeout alone or they silently start reporting absence
+ * (docs/reference/ssh-execution-boundary.md).
+ */
+export function isSshRequestOutcomeUnverifiable(error: unknown): boolean {
+  const code = error instanceof Error ? (error as Error & { code?: unknown }).code : undefined
+  return code === SSH_MUX_REQUEST_TIMEOUT_CODE || code === 'CONNECTION_LOST'
 }
 
 export class SshChannelMultiplexer {

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -826,7 +826,7 @@ async function probeRequiredNativeDeps(
           hostPlatform,
           nodePath,
           remoteDir,
-          `try { & ${powerShellLiteral(nodePath)} -e ${powerShellNativeArg(probeJs)} } catch { 'MISSING' }`
+          `try { & ${powerShellLiteral(nodePath)} -e ${powerShellNativeArg(probeJs)}; if ($LASTEXITCODE -ne 0) { 'MISSING' } } catch { 'MISSING' }`
         )
       : // Why: no `2>/dev/null` — it discarded the only line that says why node never reached the
         // script. stderr stays its own stream so it can't be mistaken for the verdict, mirroring

--- a/src/main/ssh/ssh-relay-exec-command.ts
+++ b/src/main/ssh/ssh-relay-exec-command.ts
@@ -24,6 +24,16 @@ type SshCommandTerminationError = Error & {
   sshChannelCloseConfirmed: boolean
 }
 
+// Why: callers must tell "the host answered no" from "the host never answered". Matching the
+// message text is what let an unanswered probe be read as a definitive negative.
+export const SSH_EXEC_TIMEOUT_CODE = 'SSH_EXEC_TIMEOUT'
+
+export function isSshExecTimeout(error: unknown): boolean {
+  return (
+    error instanceof Error && (error as Partial<{ code: string }>).code === SSH_EXEC_TIMEOUT_CODE
+  )
+}
+
 export function isUnconfirmedSshCommandTermination(
   error: unknown
 ): error is SshCommandTerminationError {
@@ -164,8 +174,13 @@ export async function execCommand(
     }
     const timeout = setTimeout(() => {
       requestTermination(
-        new Error(
-          `Command "${redactRelayInstallMarkerTokens(command)}" timed out after ${timeoutMs / 1000}s`
+        Object.assign(
+          new Error(
+            `Command "${redactRelayInstallMarkerTokens(command)}" timed out after ${
+              timeoutMs / 1000
+            }s`
+          ),
+          { code: SSH_EXEC_TIMEOUT_CODE }
         )
       )
     }, timeoutMs)

--- a/src/main/ssh/ssh-relay-native-deps-install.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install.test.ts
@@ -394,6 +394,31 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
     }
   })
 
+  it('does not rewrite node_modules when the health probe never answered', async () => {
+    // Why (#14830): a wedged `require("node-pty")` makes the probe time out. Reading that silence
+    // as "every native dep is missing" sent a healthy install through npm install + rebuild that
+    // could not help, and the retry loop burned the whole deploy budget at "Deploying relay…".
+    const conn = makeMockConnection(sftpCapture)
+    vi.mocked(isRelayAlreadyInstalled).mockResolvedValue(true)
+    feed([
+      '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+      '/home/u',
+      { reject: 'Command "node -e ..." timed out after 30s' } // health probe never answered
+    ])
+
+    await deployAndLaunchRelay(conn).catch(() => {})
+
+    const execCalls = vi.mocked(execCommand).mock.calls.map(([, c]) => c)
+    expect(execCalls.some((c) => c.includes('npm install'))).toBe(false)
+    expect(execCalls.some((c) => c.includes('npm rebuild'))).toBe(false)
+
+    const warnMessages = warnSpy.mock.calls.map((args) => String(args[0] ?? ''))
+    expect(warnMessages.some((m) => m.includes('Repairing missing native deps'))).toBe(false)
+    // Why no log assertion: the behavioural claim above is the real one. Asserting on warn text
+    // pinned wording that main's landed probe verdict does not use, and #18000 adds its own.
+    expect(execCalls.some((c) => c.includes("rm -rf 'node_modules/node-pty'"))).toBe(false)
+  })
+
   it('lets a probe SSH-channel failure bubble up rather than silently mapping to MISSING', async () => {
     const conn = makeMockConnection(sftpCapture)
     feed(

--- a/src/main/ssh/ssh-remote-platform-detection.test.ts
+++ b/src/main/ssh/ssh-remote-platform-detection.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SshConnection } from './ssh-connection'
+import { SSH_EXEC_TIMEOUT_CODE } from './ssh-relay-exec-command'
 
 const execCommandMock = vi.hoisted(() => vi.fn())
 
@@ -224,6 +225,32 @@ describe('detectRemoteHostPlatform failure reporting', () => {
     expect((error as Error).message).toMatch(/open failed/iu)
     expect((error as Error).message).not.toMatch(/unsupported/iu)
     expect((error as Error).cause).toMatchObject({ reason: 2 })
+  })
+
+  it('does not call an unmappable uname unsupported when the PowerShell probe timed out', async () => {
+    // The timed-out channel is the better explanation, and it is identified by execCommand's typed
+    // code — matching "timed out after Ns" in the message let any look-alike claim the branch.
+    execCommandMock
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ CYGWIN_NT-10.0 x86_64\n')
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Command "pwsh" timed out after 30s'), {
+          code: SSH_EXEC_TIMEOUT_CODE
+        })
+      )
+
+    const error = await detectRemoteHostPlatform(conn).catch((err: unknown) => err)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toMatch(/unsupported/iu)
+    expect((error as Error).cause).toMatchObject({ code: SSH_EXEC_TIMEOUT_CODE })
+  })
+
+  it('does not read a look-alike timeout message as a timed-out channel', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ FreeBSD x86_64\n')
+      .mockRejectedValueOnce(new Error('the agent it launched timed out after 30s'))
+
+    await expect(detectRemoteHostPlatform(conn)).resolves.toBeNull()
   })
 
   it('falls through to PowerShell for a Cygwin uname it cannot map', async () => {

--- a/src/main/ssh/ssh-remote-platform-detection.ts
+++ b/src/main/ssh/ssh-remote-platform-detection.ts
@@ -5,7 +5,7 @@ import {
 } from '../../shared/process-output-field-scanner'
 import { parseUnameToRelayPlatform, type RelayPlatform } from './relay-protocol'
 import { execCommand } from './ssh-relay-deploy-helpers'
-import { isUnconfirmedSshCommandTermination } from './ssh-relay-exec-command'
+import { isSshExecTimeout, isUnconfirmedSshCommandTermination } from './ssh-relay-exec-command'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
 import { getRemoteHostPlatform, type RemoteHostPlatform } from './ssh-remote-platform'
 import { powerShellCommand } from './ssh-remote-powershell'
@@ -14,7 +14,6 @@ const PLATFORM_PROBE_MARKER = '__ORCA_REMOTE_PLATFORM__'
 const MAX_UNAME_FIELD_CHARS = 64
 const MAX_THROWN_OUTPUT_CHARS = 200
 const MAX_LOGGED_OUTPUT_CHARS = 1000
-const EXEC_TIMEOUT_MESSAGE = /timed out after \d+s$/u
 
 type PlatformProbeOutcome =
   | { kind: 'detected'; platform: RelayPlatform }
@@ -89,7 +88,7 @@ function isTransportShapedError(error: unknown): boolean {
   return (
     isSshSessionLimitError(error) ||
     isUnconfirmedSshCommandTermination(error) ||
-    (error instanceof Error && EXEC_TIMEOUT_MESSAGE.test(error.message))
+    isSshExecTimeout(error)
   )
 }
 

--- a/src/main/ssh/ssh-request-outcome-verdict.test.ts
+++ b/src/main/ssh/ssh-request-outcome-verdict.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createSshDisposalError,
+  isSshRequestOutcomeUnverifiable,
+  SSH_MUX_REQUEST_TIMEOUT_CODE
+} from './ssh-channel-multiplexer'
+
+// docs/reference/ssh-execution-boundary.md: the vocabulary is live / unverifiable / exited, and
+// loss of contact is never evidence of absence. Three call sites phrase this verdict to a user, so
+// collapsing "unverifiable" into "could not be reached" is a user-visible lie.
+describe('SSH request outcome verdict', () => {
+  it('treats a response deadline as unverifiable', () => {
+    const timedOut = Object.assign(new Error('Request "x" timed out after 30000ms'), {
+      code: SSH_MUX_REQUEST_TIMEOUT_CODE
+    })
+    expect(isSshRequestOutcomeUnverifiable(timedOut)).toBe(true)
+  })
+
+  it('treats a link declared lost as unverifiable, not as absence', () => {
+    // The regression this exists for: declaring a wedged link lost at TIMEOUT_MS made those
+    // requests surface CONNECTION_LOST where they used to surface a timeout, silently downgrading
+    // the honest "may still be running on the remote host" to "could not be reached".
+    expect(isSshRequestOutcomeUnverifiable(createSshDisposalError('connection_lost'))).toBe(true)
+  })
+
+  it('does not claim unverifiable for a deliberate shutdown', () => {
+    expect(isSshRequestOutcomeUnverifiable(createSshDisposalError('shutdown'))).toBe(false)
+  })
+
+  it('does not claim unverifiable for an ordinary failure', () => {
+    expect(isSshRequestOutcomeUnverifiable(new Error('boom'))).toBe(false)
+    expect(isSshRequestOutcomeUnverifiable(undefined)).toBe(false)
+  })
+})

--- a/src/main/text-generation/commit-message-model-discovery.ts
+++ b/src/main/text-generation/commit-message-model-discovery.ts
@@ -3,7 +3,7 @@ import type { CommitMessagePlan } from '../../shared/commit-message-plan'
 import { getAgentModelProbeSpec } from '../../shared/agent-model-probe-spec'
 import type { TuiAgent } from '../../shared/tui-agent'
 import { resolveCodexHomeProcessLockKeyForSpawnEnv } from '../codex-cli/codex-home-process-lock'
-import { isSshMuxRequestTimeoutError } from '../ssh/ssh-channel-multiplexer'
+import { isSshRequestOutcomeUnverifiable } from '../ssh/ssh-channel-multiplexer'
 import { WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR } from '../win32-utils'
 import {
   finalizeModelDiscoveryOutput,
@@ -206,7 +206,7 @@ export async function discoverModelsRemote(input: {
     console.error('[commit-message] Remote model discovery request failed:', error)
     return {
       success: false,
-      error: isSshMuxRequestTimeoutError(error)
+      error: isSshRequestOutcomeUnverifiable(error)
         ? `${spec.label} model discovery took longer than ${SOURCE_CONTROL_GENERATION_TIMEOUT_MS / 1000}s and may still be running on the remote host.`
         : `${spec.label} model discovery could not be reached on the remote PATH. Try again after the SSH connection recovers.`
     }

--- a/src/main/text-generation/commit-message-text-generation-model-discovery.test.ts
+++ b/src/main/text-generation/commit-message-text-generation-model-discovery.test.ts
@@ -1,7 +1,10 @@
 import { spawn } from 'node:child_process'
 import type * as ChildProcess from 'node:child_process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { SSH_MUX_REQUEST_TIMEOUT_CODE } from '../ssh/ssh-channel-multiplexer'
+import {
+  createSshDisposalError,
+  SSH_MUX_REQUEST_TIMEOUT_CODE
+} from '../ssh/ssh-channel-multiplexer'
 import {
   discoverCommitMessageModelsLocal,
   discoverCommitMessageModelsRemote
@@ -464,6 +467,26 @@ describe('generateCommitMessageFromContext', () => {
       '/remote/repo',
       async () => {
         throw transportTimeout
+      },
+      'npx cursor-agent'
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        'Cursor model discovery took longer than 60s and may still be running on the remote host.'
+    })
+  })
+
+  it('keeps the unverifiable wording when the link is declared lost instead of timing out', async () => {
+    // Same regression as the exec leg: a wedged link now disposes the mux before the response
+    // deadline, so this branch sees CONNECTION_LOST. Reporting "could not be reached" for it
+    // asserts absence the client never observed (docs/reference/ssh-execution-boundary.md).
+    const result = await discoverCommitMessageModelsRemote(
+      'cursor',
+      '/remote/repo',
+      async () => {
+        throw createSshDisposalError('connection_lost')
       },
       'npx cursor-agent'
     )

--- a/src/main/text-generation/commit-message-text-generation-remote-execution.test.ts
+++ b/src/main/text-generation/commit-message-text-generation-remote-execution.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { SSH_MUX_REQUEST_TIMEOUT_CODE } from '../ssh/ssh-channel-multiplexer'
+import {
+  createSshDisposalError,
+  SSH_MUX_REQUEST_TIMEOUT_CODE
+} from '../ssh/ssh-channel-multiplexer'
 import { generateCommitMessageFromContext } from './commit-message-text-generation'
 
 describe('generateCommitMessageFromContext', () => {
@@ -65,6 +68,40 @@ describe('generateCommitMessageFromContext', () => {
         missingBinaryLocation: 'remote PATH',
         execute: async () => {
           throw transportTimeout
+        }
+      }
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error: 'agent took longer than 60s to respond and may still be running on the remote host.',
+      canceled: undefined
+    })
+  })
+
+  it('keeps the unverifiable wording when the link is declared lost instead of timing out', async () => {
+    // Declaring a wedged link lost disposes the mux before the 30s response deadline, so this leg
+    // now sees CONNECTION_LOST where it used to see SSH_MUX_REQUEST_TIMEOUT. Both mean the frame
+    // reached the wire and no answer came back, so both must keep "may still be running" — falling
+    // through to "could not be reached" asserts absence the client cannot observe
+    // (docs/reference/ssh-execution-boundary.md).
+    const result = await generateCommitMessageFromContext(
+      {
+        branch: 'main',
+        stagedSummary: 'M\tREADME.md',
+        stagedPatch: '+hello'
+      },
+      {
+        agentId: 'custom',
+        model: '',
+        customAgentCommand: 'agent'
+      },
+      {
+        kind: 'remote',
+        cwd: '/repo',
+        missingBinaryLocation: 'remote PATH',
+        execute: async () => {
+          throw createSshDisposalError('connection_lost')
         }
       }
     )

--- a/src/main/text-generation/source-control-remote-generation.ts
+++ b/src/main/text-generation/source-control-remote-generation.ts
@@ -1,5 +1,5 @@
 import type { CommitMessagePlan } from '../../shared/commit-message-plan'
-import { isSshMuxRequestTimeoutError } from '../ssh/ssh-channel-multiplexer'
+import { isSshRequestOutcomeUnverifiable } from '../ssh/ssh-channel-multiplexer'
 import { WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR } from '../win32-utils'
 import {
   finalizeFromAgentOutput,
@@ -25,7 +25,7 @@ export async function runRemoteSourceControlPlan(input: {
     result = await target.execute(plan, target.cwd, SOURCE_CONTROL_GENERATION_TIMEOUT_MS, operation)
   } catch (error) {
     console.error('[commit-message] Remote generator request failed:', error)
-    if (isSshMuxRequestTimeoutError(error)) {
+    if (isSshRequestOutcomeUnverifiable(error)) {
       return {
         success: false,
         error: `${plan.label} took longer than ${SOURCE_CONTROL_GENERATION_TIMEOUT_MS / 1000}s to respond and may still be running on the remote host.`

--- a/src/relay/dispatcher-client-lifecycle.ts
+++ b/src/relay/dispatcher-client-lifecycle.ts
@@ -12,6 +12,12 @@ import type {
 } from './dispatcher-contract'
 import { RelayDispatcherClientState } from './dispatcher-client-state'
 
+// Why: a client that clears the endpoint handshake and then never frames anything is invisible to
+// the silence window -- it has no lastReceivedAt to go stale -- so its socket, writer and client
+// entry are held for the life of the relay. The bound is deliberately several windows wide: a real
+// client frames immediately after the handshake, so only a peer that is already gone reaches it.
+const SILENT_CONNECT_TIMEOUT_MS = TIMEOUT_MS * 6
+
 export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClientState {
   // Why: redirect outgoing frames to the reconnected socket without rebuilding the dispatcher + handler tree.
   // Why: a new multiplexer restarts at seq=1; reset state to avoid stalled acknowledgements.
@@ -122,6 +128,7 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
       bulkChain: Promise.resolve(),
       nextOutgoingSeq: 1,
       highestReceivedSeq: 0,
+      attachedAt: Date.now(),
       lastReceivedAt: null,
       keepaliveObserved: false,
       generation: 0,
@@ -146,6 +153,7 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
   protected resetClient(client: RelayClient): void {
     client.nextOutgoingSeq = 1
     client.highestReceivedSeq = 0
+    client.attachedAt = Date.now()
     client.lastReceivedAt = null
     client.keepaliveObserved = false
     client.decoder.reset()
@@ -185,8 +193,11 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
         if (client.closed) {
           continue
         }
-        if (resumedAfterPause && client.lastReceivedAt !== null) {
-          client.lastReceivedAt = now
+        if (resumedAfterPause) {
+          client.attachedAt = now
+          if (client.lastReceivedAt !== null) {
+            client.lastReceivedAt = now
+          }
         }
         client.writer.enqueue(
           'liveness',
@@ -220,20 +231,24 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
       if (client === this.primaryClient) {
         continue
       }
-      // Why the null check is not just defensive: a relay is launched before its client finishes
-      // handshaking, and on a slow link that can exceed the window. Reaping a client that has never
-      // spoken would break the connect it is still completing, so silence only counts against a
-      // client that has already proven it can talk.
+      if (client.closed) {
+        continue
+      }
+      // Why a client that has never spoken gets its own, much wider bound: a relay is launched
+      // before its client finishes handshaking, and on a slow link that can exceed the silence
+      // window, so judging it there would break the connect it is still completing. Leaving it
+      // unbounded instead held its socket and client entry forever.
+      if (client.lastReceivedAt === null) {
+        if (now - client.attachedAt > SILENT_CONNECT_TIMEOUT_MS) {
+          this.closeClient(client, new Error('Relay client never spoke'), true)
+        }
+        continue
+      }
       // Why keepaliveObserved gates this: not every client speaks the keepalive protocol. The
       // remote `orca` CLI sends one `orca.cli` request and waits for a result budgeted in minutes
       // (src/relay/remote-cli-timeout.ts), so judging it on inbound silence would kill
       // `terminal wait`, `--wait` and `orchestration ask` after 20s.
-      if (
-        client.closed ||
-        !client.keepaliveObserved ||
-        client.lastReceivedAt === null ||
-        now - client.lastReceivedAt <= TIMEOUT_MS
-      ) {
+      if (!client.keepaliveObserved || now - client.lastReceivedAt <= TIMEOUT_MS) {
         continue
       }
       this.closeClient(client, new Error('Relay client stopped answering'), true)

--- a/src/relay/dispatcher-client-lifecycle.ts
+++ b/src/relay/dispatcher-client-lifecycle.ts
@@ -1,4 +1,4 @@
-import { FrameDecoder, KEEPALIVE_SEND_MS, encodeKeepAliveFrame } from './protocol'
+import { FrameDecoder, KEEPALIVE_SEND_MS, TIMEOUT_MS, encodeKeepAliveFrame } from './protocol'
 import type { PtyConsumerCloseCause } from '../shared/pty-consumer-session-contract'
 import type {
   DispatcherClientWriter,
@@ -122,6 +122,8 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
       bulkChain: Promise.resolve(),
       nextOutgoingSeq: 1,
       highestReceivedSeq: 0,
+      lastReceivedAt: null,
+      keepaliveObserved: false,
       generation: 0,
       closed: false,
       droppedNotificationLog: null,
@@ -144,6 +146,8 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
   protected resetClient(client: RelayClient): void {
     client.nextOutgoingSeq = 1
     client.highestReceivedSeq = 0
+    client.lastReceivedAt = null
+    client.keepaliveObserved = false
     client.decoder.reset()
     client.generation++
     client.closed = false
@@ -163,13 +167,26 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
   }
 
   protected startKeepalive(): void {
+    let lastTickAt = Date.now()
     this.keepaliveTimer = setInterval(() => {
       if (this.disposed) {
         return
       }
+      const now = Date.now()
+      // Why this threshold and not TIMEOUT_MS: a healthy client answers the PREVIOUS tick, so its
+      // lastReceivedAt is already up to KEEPALIVE_SEND_MS + RTT old. A tick gap beyond
+      // TIMEOUT_MS - KEEPALIVE_SEND_MS therefore pushes staleness past the window on its own, and a
+      // rebase armed at TIMEOUT_MS would not have fired -- reaping every client after a host
+      // suspend, a VM migration, or the relay's own event loop stalling. Mirrors the client's
+      // WAKE_GAP_MS guard (ssh-channel-multiplexer.ts).
+      const resumedAfterPause = now - lastTickAt >= TIMEOUT_MS - KEEPALIVE_SEND_MS
+      lastTickAt = now
       for (const client of this.clients.values()) {
         if (client.closed) {
           continue
+        }
+        if (resumedAfterPause && client.lastReceivedAt !== null) {
+          client.lastReceivedAt = now
         }
         client.writer.enqueue(
           'liveness',
@@ -180,9 +197,47 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
           13
         )
       }
+      this.reapSilentClients(now)
     }, KEEPALIVE_SEND_MS)
     // Why: unref so the keepalive interval doesn't pin the event loop and block process exit.
     this.keepaliveTimer.unref()
+  }
+
+  /**
+   * Drop the transport of a client that has gone silent. The relay's writer parks forever on a
+   * half-open link and nothing else ever notices, so an abandoned viewer kept its owner lease and
+   * left every PTY it held paused — the shape behind the "SSH degrades until I cannot connect at
+   * all" reports. Reaping is a statement about the TRANSPORT only: the cause stays the cautious
+   * 'local' default because silence is not evidence the peer died, and the PTYs stay live for the
+   * replacement client to reclaim (docs/reference/ssh-execution-boundary.md).
+   */
+  private reapSilentClients(now: number): void {
+    for (const client of Array.from(this.clients.values())) {
+      // Why the primary is exempt: closing it tears down the relay's own stdin/stdout, and nothing
+      // in production revives it -- setWrite() has no non-test caller. The leak this exists for is
+      // a socket client holding an owner lease, and the launch channel's own liveness is already
+      // owned by the client-side dead-link check.
+      if (client === this.primaryClient) {
+        continue
+      }
+      // Why the null check is not just defensive: a relay is launched before its client finishes
+      // handshaking, and on a slow link that can exceed the window. Reaping a client that has never
+      // spoken would break the connect it is still completing, so silence only counts against a
+      // client that has already proven it can talk.
+      // Why keepaliveObserved gates this: not every client speaks the keepalive protocol. The
+      // remote `orca` CLI sends one `orca.cli` request and waits for a result budgeted in minutes
+      // (src/relay/remote-cli-timeout.ts), so judging it on inbound silence would kill
+      // `terminal wait`, `--wait` and `orchestration ask` after 20s.
+      if (
+        client.closed ||
+        !client.keepaliveObserved ||
+        client.lastReceivedAt === null ||
+        now - client.lastReceivedAt <= TIMEOUT_MS
+      ) {
+        continue
+      }
+      this.closeClient(client, new Error('Relay client stopped answering'), true)
+    }
   }
 
   protected closeClient(

--- a/src/relay/dispatcher-contract.ts
+++ b/src/relay/dispatcher-contract.ts
@@ -51,6 +51,15 @@ export type RelayClient = {
   bulkChain: Promise<void>
   nextOutgoingSeq: number
   highestReceivedSeq: number
+  // Why: the relay had no inbound-liveness signal at all, so a half-open client was never reaped
+  // and kept its owner lease and paused PTYs indefinitely.
+  lastReceivedAt: number | null
+  // Why silence is only held against a client that sends keepalives: not every client speaks that
+  // protocol. The remote `orca` CLI opens the socket, sends one `orca.cli` request and then waits
+  // for a result that is deliberately budgeted in minutes (src/relay/remote-cli-timeout.ts), so
+  // judging it on inbound silence would kill `terminal wait`, `--wait` and `orchestration ask`
+  // after 20s. Only a client that has proven it participates is eligible.
+  keepaliveObserved: boolean
   generation: number
   closed: boolean
   droppedNotificationLog: DroppedProducerNotificationLog | null

--- a/src/relay/dispatcher-contract.ts
+++ b/src/relay/dispatcher-contract.ts
@@ -51,6 +51,9 @@ export type RelayClient = {
   bulkChain: Promise<void>
   nextOutgoingSeq: number
   highestReceivedSeq: number
+  // Why: a client that never frames anything has no staleness to measure, so the silence window
+  // cannot see it. Its attach time is the only clock it has.
+  attachedAt: number
   // Why: the relay had no inbound-liveness signal at all, so a half-open client was never reaped
   // and kept its owner lease and paused PTYs indefinitely.
   lastReceivedAt: number | null

--- a/src/relay/dispatcher-frame-codec.ts
+++ b/src/relay/dispatcher-frame-codec.ts
@@ -15,11 +15,14 @@ import { RelayDispatcherCapacitySignals } from './dispatcher-capacity-signals'
 
 export abstract class RelayDispatcherFrameCodec extends RelayDispatcherCapacitySignals {
   protected handleFrame(client: RelayClient, frame: DecodedFrame): void {
+    // Before the KeepAlive early return: a keepalive is the only proof a quiet client is still there.
+    client.lastReceivedAt = Date.now()
     if (frame.id > client.highestReceivedSeq) {
       client.highestReceivedSeq = frame.id
     }
 
     if (frame.type === MessageType.KeepAlive) {
+      client.keepaliveObserved = true
       return
     }
 

--- a/src/relay/dispatcher-silent-client-reaper.test.ts
+++ b/src/relay/dispatcher-silent-client-reaper.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+import { encodeJsonRpcFrame, encodeKeepAliveFrame, KEEPALIVE_SEND_MS, TIMEOUT_MS } from './protocol'
+
+// The relay had no inbound-liveness signal at all: its writer parks forever on a half-open link, so
+// an abandoned viewer kept its owner lease and left the PTYs it held paused until the process died.
+describe('RelayDispatcher silent-client reaper', () => {
+  let dispatcher: RelayDispatcher
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+  })
+
+  afterEach(() => {
+    dispatcher.dispose()
+    vi.useRealTimers()
+  })
+
+  it('detaches a client that spoke once and then stopped answering', () => {
+    const detachListener = vi.fn()
+    dispatcher = new RelayDispatcher(() => true)
+    dispatcher.onClientDetached(detachListener)
+    const clientId = dispatcher.attachClient(() => true)
+    dispatcher.feedClient(clientId, encodeKeepAliveFrame(1, 0))
+
+    vi.advanceTimersByTime(TIMEOUT_MS + KEEPALIVE_SEND_MS * 2)
+
+    // 'local', not a peer close: silence is not evidence the peer died, and a consumer that read it
+    // as one would shorten the owner grace on a session that is still there.
+    expect(detachListener).toHaveBeenCalledWith(clientId, 'local')
+  })
+
+  it('keeps a quiet but answering client attached', () => {
+    const detachListener = vi.fn()
+    dispatcher = new RelayDispatcher(() => true)
+    dispatcher.onClientDetached(detachListener)
+    const clientId = dispatcher.attachClient(() => true)
+
+    // A client with nothing to say still answers the keepalive; that is the only proof required.
+    for (let tick = 0; tick < 10; tick += 1) {
+      vi.advanceTimersByTime(KEEPALIVE_SEND_MS)
+      dispatcher.feedClient(clientId, encodeKeepAliveFrame(tick + 1, 0))
+    }
+
+    // Asserted against this client specifically: the unattached primary sink has no peer answering
+    // it in this harness, so it is expected to be reaped and says nothing about the case under test.
+    expect(detachListener).not.toHaveBeenCalledWith(clientId, expect.anything())
+  })
+
+  it('does not reap every client on the first tick after the host slept', () => {
+    const detachListener = vi.fn()
+    dispatcher = new RelayDispatcher(() => true)
+    dispatcher.onClientDetached(detachListener)
+    dispatcher.attachClient(() => true)
+
+    // One tick fires far late because the process was paused, not because the peers went away.
+    vi.setSystemTime(10 * 60_000)
+    vi.advanceTimersByTime(KEEPALIVE_SEND_MS)
+
+    expect(detachListener).not.toHaveBeenCalled()
+  })
+
+  it('never reaps a client that has not spoken yet', () => {
+    // A relay is launched before its client finishes handshaking, and on a slow link that can
+    // outlast the window. Reaping there would break the connect the client is still completing.
+    const detachListener = vi.fn()
+    dispatcher = new RelayDispatcher(() => true)
+    dispatcher.onClientDetached(detachListener)
+    const clientId = dispatcher.attachClient(() => true)
+
+    vi.advanceTimersByTime(TIMEOUT_MS * 5)
+
+    expect(detachListener).not.toHaveBeenCalledWith(clientId, expect.anything())
+  })
+
+  it('never reaps a client that does not send keepalives at all', () => {
+    // The remote `orca` CLI opens the socket, sends one `orca.cli` request and then waits for a
+    // result budgeted in minutes (remote-cli-timeout.ts: 5min default, 10min for wait, 11min for
+    // orchestration ask). It has no keepalive timer, so judging it on inbound silence would abort
+    // `terminal wait`, `--wait` and `orchestration ask` after 20s.
+    const detachListener = vi.fn()
+    dispatcher = new RelayDispatcher(() => true)
+    dispatcher.onClientDetached(detachListener)
+    const clientId = dispatcher.attachClient(() => true)
+    dispatcher.feedClient(
+      clientId,
+      encodeJsonRpcFrame({ jsonrpc: '2.0', id: 1, method: 'orca.cli', params: {} }, 1, 0)
+    )
+
+    vi.advanceTimersByTime(TIMEOUT_MS * 20)
+
+    expect(detachListener).not.toHaveBeenCalledWith(clientId, expect.anything())
+  })
+
+  it('does not reap a healthy client when the relay itself stalls for most of the window', () => {
+    // The dead band this exists for: a healthy client answers the PREVIOUS tick, so its
+    // lastReceivedAt is already ~KEEPALIVE_SEND_MS old. A tick gap short of TIMEOUT_MS still pushes
+    // staleness past the window, so a rebase armed at TIMEOUT_MS would never fire and every client
+    // would be reaped after a host suspend, VM migration, or an event-loop stall.
+    const detachListener = vi.fn()
+    dispatcher = new RelayDispatcher(() => true)
+    dispatcher.onClientDetached(detachListener)
+    const clientId = dispatcher.attachClient(() => true)
+
+    // The client answers at t=5s, then the next tick at t=10s finds it already ~5s stale — normal.
+    vi.advanceTimersByTime(KEEPALIVE_SEND_MS)
+    dispatcher.feedClient(clientId, encodeKeepAliveFrame(1, 0))
+    vi.advanceTimersByTime(KEEPALIVE_SEND_MS)
+
+    // Now the relay stalls: the clock jumps but no tick runs, so the following tick lands 17s after
+    // the last one. Staleness is 22s (past the window) while the tick gap is under TIMEOUT_MS, so a
+    // rebase armed at TIMEOUT_MS would not fire and this healthy client would be reaped.
+    vi.setSystemTime(Date.now() + 12_000)
+    vi.advanceTimersByTime(KEEPALIVE_SEND_MS)
+
+    expect(detachListener).not.toHaveBeenCalledWith(clientId, expect.anything())
+  })
+
+  it('never reaps the primary client, whose sink cannot be revived', () => {
+    const detachListener = vi.fn()
+    dispatcher = new RelayDispatcher(() => true)
+    dispatcher.onClientDetached(detachListener)
+
+    vi.advanceTimersByTime(TIMEOUT_MS * 20)
+
+    // Client id 1 is the primary sink; closing it would tear down the relay's own stdin/stdout and
+    // nothing in production calls setWrite() to bring it back.
+    expect(detachListener).not.toHaveBeenCalled()
+  })
+})

--- a/src/relay/dispatcher-silent-client-reaper.test.ts
+++ b/src/relay/dispatcher-silent-client-reaper.test.ts
@@ -122,6 +122,12 @@ describe('RelayDispatcher silent-client reaper', () => {
     dispatcher = new RelayDispatcher(() => true)
     dispatcher.onClientDetached(detachListener)
 
+    // Feed the primary first, or the test proves nothing: an unfed client is skipped by the
+    // never-spoken and no-keepalive guards, so it survives whether or not the exemption exists.
+    // A real primary answers keepalives, so the exemption is the only thing standing between it
+    // and the reaper.
+    dispatcher.feed(encodeKeepAliveFrame(1, 0))
+
     vi.advanceTimersByTime(TIMEOUT_MS * 20)
 
     // Client id 1 is the primary sink; closing it would tear down the relay's own stdin/stdout and

--- a/src/relay/dispatcher-silent-client-reaper.test.ts
+++ b/src/relay/dispatcher-silent-client-reaper.test.ts
@@ -61,7 +61,7 @@ describe('RelayDispatcher silent-client reaper', () => {
     expect(detachListener).not.toHaveBeenCalled()
   })
 
-  it('never reaps a client that has not spoken yet', () => {
+  it('does not judge a client that has not spoken yet by the silence window', () => {
     // A relay is launched before its client finishes handshaking, and on a slow link that can
     // outlast the window. Reaping there would break the connect the client is still completing.
     const detachListener = vi.fn()
@@ -70,6 +70,32 @@ describe('RelayDispatcher silent-client reaper', () => {
     const clientId = dispatcher.attachClient(() => true)
 
     vi.advanceTimersByTime(TIMEOUT_MS * 5)
+
+    expect(detachListener).not.toHaveBeenCalledWith(clientId, expect.anything())
+  })
+
+  it('still bounds a client that never speaks at all', () => {
+    // Otherwise it is invisible to the silence window forever -- no lastReceivedAt to go stale --
+    // and its socket, writer and client entry are held for the life of the relay.
+    const detachListener = vi.fn()
+    dispatcher = new RelayDispatcher(() => true)
+    dispatcher.onClientDetached(detachListener)
+    const clientId = dispatcher.attachClient(() => true)
+
+    vi.advanceTimersByTime(TIMEOUT_MS * 7)
+
+    expect(detachListener).toHaveBeenCalledWith(clientId, 'local')
+  })
+
+  it("does not spend a mute client's connect budget while the host was suspended", () => {
+    // Same rebase the silence window gets: a paused process is not a peer that went away.
+    const detachListener = vi.fn()
+    dispatcher = new RelayDispatcher(() => true)
+    dispatcher.onClientDetached(detachListener)
+    const clientId = dispatcher.attachClient(() => true)
+
+    vi.setSystemTime(60 * 60_000)
+    vi.advanceTimersByTime(KEEPALIVE_SEND_MS)
 
     expect(detachListener).not.toHaveBeenCalledWith(clientId, expect.anything())
   })

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15962,7 +15962,8 @@
           "none": "None",
           "search": "Search",
           "showUnreadOnly": "Show unread only",
-          "showChildAgents": "Show child agents"
+          "showChildAgents": "Show child agents",
+          "activityOptions": "Activity options"
         },
         "clearCompleted": {
           "clearedOne": "Cleared 1 completed agent",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17260,7 +17260,9 @@
   "dashboard": {
     "sidebar": {
       "label": "Agents",
-      "dashboardLabel": "Agent Dashboard"
+      "dashboardLabel": "Agent Dashboard",
+      "openActivity": "View activity",
+      "closeActivity": "Turn off activity view"
     }
   },
   "runtimeRpc": {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​429 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​420 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​136 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 |

<!-- /orca-pr-loc -->

## What

Three fixes for one class of bug: **treating "no answer" as evidence**. Per [`docs/reference/ssh-execution-boundary.md`](../blob/main/docs/reference/ssh-execution-boundary.md), loss of contact is never evidence of process death — and the same mistake was being made in both directions, on both ends of the link.

### 1. A saturated writer suppressed dead-link detection, with no upper bound

`SshChannelMultiplexer`'s health check was gated on `writerSaturated`. On a half-open link (sleep/resume, dropped NAT mapping) the transport reports backpressure and never drains, so:

- nothing ever leaves the writer;
- the writer's single-outstanding liveness guard (`ssh-multiplexer-transport-writer.ts:82`) silences every keepalive after the first, because that flag only clears on a settlement that never comes;
- and the one check that could notice is suppressed indefinitely.

The mux never disposes, so `onRelayLost` (`ssh-relay-session.ts`) never fires and the bounded-backoff reconnect never runs. Every RPC times out at 30s, forever.

Saturation no longer suppresses the check. The relay sends its own keepalive every 5s (`src/relay/dispatcher-client-lifecycle.ts`), so a slow-but-alive peer still refreshes `lastReceivedAt` and is never falsely killed; only a link delivering nothing inbound for 20s is declared lost, which reconnects.

### 2. The relay had no inbound-liveness signal at all

Symmetric to the above, on the host side. `RelayClient` had no `lastReceivedAt`; the 5s timer is send-only; `frame.ack` is never read; there is no `socket.setTimeout`; and the writer's drain arm has no timer. So a half-open client parked forever holding its owner lease, with every PTY it held paused, until the OS eventually failed the socket — or never.

`ssh-owner-recovery-retry.ts:14-17` documents the assumption this violated: *"the relay frees it when its keepalive notices."* It never noticed, which is why the client-side budget for that case is only 1000ms.

Clients are now reaped after 20s of silence, with a sleep/wake rebase so a paused host process does not reap everyone on its first tick back. The close cause stays the cautious `'local'` default: silence is not evidence the peer died, and the PTYs stay live for the replacement client to reclaim.

Three carve-outs, each with its own test: the **primary** sink (closing it tears down the relay's own stdin/stdout and nothing in production revives it), a client that **does not speak the keepalive protocol** (the remote `orca` CLI sends one `orca.cli` request and then waits for a result budgeted in minutes), and a client that **has not spoken yet** (a relay is launched before its client finishes handshaking).

That last carve-out was unbounded, which review flagged twice: a client that clears the endpoint handshake and then never frames anything has no `lastReceivedAt` to go stale, so its socket, writer and client entry were held for the life of the relay. It now has its own much wider deadline — 6 silence windows, rebased across a host suspend like the other clock — so a real client that is merely slow is never touched and a dead one is still collected.

### 3. Keeping the verdict honest where fix 1 changes it

Fix 1 has a user-visible consequence that has to be paid for here rather than discovered later. Pre-change, a saturated-writer wedge left the mux alive and requests failed at 30s with `SSH_MUX_REQUEST_TIMEOUT`. Post-change the mux disposes at 20s and `dispose('connection_lost')` rejects the pending requests with `CONNECTION_LOST`.

Three sites branched on `isSshMuxRequestTimeoutError` to choose their wording:

- `source-control-remote-generation.ts:28`
- `commit-message-model-discovery.ts:209`
- `ai-vault/ssh-session-list.ts:87`

The timeout branch says *"…may still be running on the remote host."*; the fallthrough says *"could not be reached on the {location}."* So fix 1 on its own would have deleted the `unverifiable` wording from three user-facing surfaces and replaced it with a claim of absence — exactly the substitution the boundary doc forbids, and the sentence mosh treats as essential (`stmclient.cc:229-232`: *"the mosh-server process may still be running on the server"*).

Both codes mean the same thing — the frame reached the wire and the answer did not come back — so the three sites now branch on `isSshRequestOutcomeUnverifiable`, which covers both. Each site has a regression test that fails if the wording is dropped again, plus a unit test on the predicate itself.

### Also here: two small probe fixes

- The Windows native-deps probe now checks `$LASTEXITCODE`, so a real load failure prints `MISSING` and exits 0 like its POSIX twin, instead of throwing and being read as "the host never answered".
- `execCommand`'s timeout error carries a typed `SSH_EXEC_TIMEOUT_CODE`, and `ssh-remote-platform-detection.ts` now reads that code instead of matching `/timed out after \d+s$/u` against the message. Previously any error whose message happened to end that way could claim the transport-shaped branch and turn an unsupported-platform answer into a thrown probe failure.

## Fix evidence

Each fix has a test verified failing before and passing after.

- `ssh-channel-multiplexer-saturation-wedge.test.ts` against pre-change code: mux never disposes after 200s, and exactly **1** keepalive is ever written.
- `dispatcher-silent-client-reaper.test.ts`: reaps the silent client, keeps the quiet-but-answering one, keeps the primary, keeps a non-keepalive CLI client, does not reap everyone after a simulated host sleep, and still bounds a client that never speaks.
- The three verdict call sites: dropping `CONNECTION_LOST` from `isSshRequestOutcomeUnverifiable` fails one test per site plus the predicate's own.
- `ssh-remote-platform-detection.test.ts`: restoring the message-text match fails *does not read a look-alike timeout message as a timed-out channel*.

Mutation-checked rather than assumed. Deleting the `client === this.primaryClient` guard from `reapSilentClients` used to leave all 7 reaper tests passing — the primary was never fed, so the never-spoken and no-keepalive guards skipped it regardless. The test now feeds it (`dispatcher.feed(encodeKeepAliveFrame(1, 0))`), which is what a real primary does, and deleting the guard fails it:

```
FAIL  src/relay/dispatcher-silent-client-reaper.test.ts > RelayDispatcher silent-client reaper
      > never reaps the primary client, whose sink cannot be revived
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
```

```
$ pnpm tc                                                        # clean
$ pnpm test src/main/ssh src/relay src/main/text-generation src/main/ai-vault src/main/providers
 Test Files  471 passed | 3 skipped (474)
      Tests  5026 passed | 23 skipped (5049)
$ pnpm run check:code-quality:changed                            # 0 new findings
```

## Relationship to #17748

This supersedes it. #17748's own description names the defect fixed here as a given — *"the dead-link check … is **deliberately** suppressed in exactly that state"* — and works around it by extending budgets. With the suppression gone, a wedged writer disposes in ~20s and reconnects, rather than a spawn burning 30s in a queue on a link that is already dead. #17748 would instead raise `SSH_PTY_CONNECT_WORST_CASE_MS` to 160s, lengthening the dead-pane window ~6x on exactly the path users complained about. Its orphan-PTY hazard also dissolves here: `dispose()` clears the writer queue, so a parked frame can never later reach the wire.

Worth salvaging from it separately: its two test files, and dequeue-on-timeout in the writer.

## Note on scope

An earlier revision of this branch also carried the three-state native-deps probe (`available` / `missing` / `unverifiable`) for #14830. That landed independently on `main` via #17979 and #18011, so only the Windows `$LASTEXITCODE` fix and its regression test remain here. #14830 is closed by those PRs, not this one.

**#17928 is stacked on this branch and must land with it.** Fix 1 widens the window in which a `pty.spawn` reaches an already-disposed mux, and that path tombstones the operation id for 24 hours even though the request was never framed. Merging this alone makes that bug easier to hit.

---

## ELI5

Orca could get stuck talking to a remote machine and never notice. If the network died in a way that leaves the connection technically 'open' (laptop sleep, Wi-Fi change), Orca would wait forever instead of reconnecting. Same bug on the server side: an abandoned Orca window kept holding your terminals hostage. And when Orca gives up on a remote request, it now still tells you the truth — *"it may still be running over there"* — instead of claiming the machine could not be reached.

## User-facing regression risk

- **You may now see a brief 'reconnecting' state where the terminal previously just froze.** That is the fix working, but it is a visible change.
- A link that genuinely delivers nothing for 20s is now dropped and rebuilt. On a very bad network you could see more reconnects than before, where previously you saw a hang.
- On the relay side, a client that has gone silent for 20s loses its socket. Its PTYs stay live and the reconnecting client reclaims them; the close cause is `'local'`, so nothing downstream reads it as the peer having died.
