### PR TITLE
perf(relay): stop two unbounded growth terms behind the long-session SSH slowdown

### DIFF
--- a/src/main/ipc/ssh-pty-closed-generation-ranges.test.ts
+++ b/src/main/ipc/ssh-pty-closed-generation-ranges.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { SshPtyClosedGenerationRanges } from './ssh-pty-closed-generation-ranges'
+
+// Deterministic so a membership divergence reproduces from the failure output alone.
+function lcg(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0
+    return state / 0x1_0000_0000
+  }
+}
+
+describe('SshPtyClosedGenerationRanges', () => {
+  it('answers membership identically to a plain set under arbitrary insertion order', () => {
+    const random = lcg(0xc0ffee)
+    const ranges = new SshPtyClosedGenerationRanges()
+    const oracle = new Set<number>()
+    for (let step = 0; step < 4_000; step += 1) {
+      const generation = 1 + Math.floor(random() * 400)
+      ranges.add(generation)
+      oracle.add(generation)
+    }
+    for (let generation = 0; generation <= 402; generation += 1) {
+      expect([generation, ranges.has(generation)]).toEqual([generation, oracle.has(generation)])
+    }
+  })
+
+  it('merges an inserted generation that bridges two ranges', () => {
+    const ranges = new SshPtyClosedGenerationRanges()
+    ranges.add(1)
+    ranges.add(3)
+    expect(ranges.size).toBe(2)
+
+    ranges.add(2)
+
+    expect(ranges.size).toBe(1)
+    expect([1, 2, 3].map((generation) => ranges.has(generation))).toEqual([true, true, true])
+    expect(ranges.has(4)).toBe(false)
+  })
+
+  it('treats a repeated close as a no-op', () => {
+    const ranges = new SshPtyClosedGenerationRanges()
+    ranges.add(7)
+    ranges.add(7)
+    expect(ranges.size).toBe(1)
+    expect(ranges.activeGaps).toBe(6)
+  })
+
+  it('keeps insertion sublinear so a fragmented list cannot become quadratic', () => {
+    // The scan this replaced took ~220ms to insert 20k non-adjacent generations and ~1300ms for
+    // 100k membership probes against them; both are microseconds once the lookup is log-time.
+    const ranges = new SshPtyClosedGenerationRanges()
+    const startedAt = performance.now()
+    for (let generation = 2; generation <= 80_000; generation += 2) {
+      ranges.add(generation)
+    }
+    for (let probe = 0; probe < 100_000; probe += 1) {
+      ranges.has(80_001)
+    }
+    const elapsed = performance.now() - startedAt
+
+    expect(ranges.size).toBe(40_000)
+    expect(elapsed).toBeLessThan(1_000)
+  })
+})

--- a/src/main/ipc/ssh-pty-closed-generation-ranges.ts
+++ b/src/main/ipc/ssh-pty-closed-generation-ranges.ts
@@ -7,10 +7,7 @@ export class SshPtyClosedGenerationRanges {
   private readonly ranges: ClosedGenerationRange[] = []
 
   add(generation: number): void {
-    let index = 0
-    while (index < this.ranges.length && this.ranges[index]!.end + 1 < generation) {
-      index++
-    }
+    const index = this.firstRangeReachableFrom(generation)
     const current = this.ranges[index]
     if (!current || generation + 1 < current.start) {
       this.ranges.splice(index, 0, { start: generation, end: generation })
@@ -26,15 +23,27 @@ export class SshPtyClosedGenerationRanges {
   }
 
   has(generation: number): boolean {
-    for (const range of this.ranges) {
-      if (generation < range.start) {
-        return false
-      }
-      if (generation <= range.end) {
-        return true
+    const range = this.ranges[this.firstRangeReachableFrom(generation)]
+    return range !== undefined && generation >= range.start && generation <= range.end
+  }
+
+  // Why binary search rather than a scan: ranges only collapse to one while every allocated
+  // generation is eventually closed. A generation that is allocated and never closed leaves a
+  // permanent gap, and `has` is on the per-output-chunk admission path, so a linear scan turns
+  // fragmentation into a hot-path cost (measured ~1800x a plain Set at 20k ranges) and makes `add`
+  // quadratic. Log-time keeps the degraded shape no worse than the Set this replaced.
+  private firstRangeReachableFrom(generation: number): number {
+    let low = 0
+    let high = this.ranges.length
+    while (low < high) {
+      const mid = (low + high) >> 1
+      if (this.ranges[mid]!.end + 1 < generation) {
+        low = mid + 1
+      } else {
+        high = mid
       }
     }
-    return false
+    return low
   }
 
   get size(): number {

--- a/src/main/ipc/ssh-pty-model-admission-entry.ts
+++ b/src/main/ipc/ssh-pty-model-admission-entry.ts
@@ -37,7 +37,7 @@ export function canReserveAdmission(args: {
   charge: AdmissionCharge
   limits: SshPtyModelAdmissionLimits
   usageByPty: ReadonlyMap<string, PtyUsage>
-  closingGenerations: ReadonlySet<number>
+  closingGenerations: { has: (generation: number) => boolean }
   globalSourceUnits: number
   globalBytes: number
 }): boolean {

--- a/src/main/ipc/ssh-pty-model-admission-generation-scope.test.ts
+++ b/src/main/ipc/ssh-pty-model-admission-generation-scope.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { SshPtyClosedGenerationRanges } from './ssh-pty-closed-generation-ranges'
+
+const HOSTS = 8
+const RECONNECTS = 20_000
+
+function lcg(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0
+    return state / 0x1_0000_0000
+  }
+}
+
+// Provider generations come from one process-global counter shared by every SSH target
+// (ssh-pty-output-intake-registry.ts), so lower-numbered generations are routinely still live on a
+// different host. The closed set must answer exactly; a high-water approximation would reject a
+// healthy target's output the moment any other target disconnected.
+describe('closed provider generations across concurrent SSH targets', () => {
+  it('keeps a lower live generation admissible after a higher one closes', () => {
+    const closed = new SshPtyClosedGenerationRanges()
+
+    // Host A holds generation 1 and stays connected; host B holds 2 and disconnects.
+    closed.add(2)
+
+    expect(closed.has(2)).toBe(true)
+    expect(closed.has(1)).toBe(false)
+  })
+
+  it('collapses to one range when two targets take turns reconnecting', () => {
+    // Each reconnect closes the generation it is replacing, so alternating hosts still produce a
+    // contiguous closed run -- interleaving alone does not fragment the list.
+    const closed = new SshPtyClosedGenerationRanges()
+    let nextGeneration = 1
+    const live = [nextGeneration++, nextGeneration++]
+    for (let reconnect = 0; reconnect < RECONNECTS; reconnect += 1) {
+      const host = reconnect % live.length
+      closed.add(live[host]!)
+      live[host] = nextGeneration++
+    }
+
+    expect(closed.size).toBe(1)
+    expect(closed.has(live[0]!)).toBe(false)
+    expect(closed.has(live[1]!)).toBe(false)
+  })
+
+  it('bounds ranges by the live generation count, not the reconnect count', () => {
+    // Eight hosts reconnecting in scrambled order, with closes landing out of order the way a
+    // deferred model migration settles them. Every gap is a generation that is still live, so the
+    // list can never hold more than one range per live generation plus one.
+    const random = lcg(0x5eed)
+    const closed = new SshPtyClosedGenerationRanges()
+    let nextGeneration = 1
+    const live = Array.from({ length: HOSTS }, () => nextGeneration++)
+    const settling: number[] = []
+    let peakRanges = 0
+    for (let reconnect = 0; reconnect < RECONNECTS; reconnect += 1) {
+      const host = Math.floor(random() * HOSTS)
+      settling.push(live[host]!)
+      live[host] = nextGeneration++
+      if (settling.length > 4) {
+        closed.add(settling.splice(Math.floor(random() * settling.length), 1)[0]!)
+      }
+      peakRanges = Math.max(peakRanges, closed.size)
+    }
+    for (const generation of settling) {
+      closed.add(generation)
+    }
+
+    expect(peakRanges).toBeLessThanOrEqual(HOSTS + 4 + 1)
+    expect(closed.size).toBeLessThanOrEqual(HOSTS + 1)
+    for (const generation of live) {
+      expect(closed.has(generation)).toBe(false)
+    }
+  })
+
+  it('retains one range for every generation that is allocated and never closed', () => {
+    // The honest limitation, pinned rather than assumed away: ranges compact only against closes.
+    // A generation that is allocated and abandoned without a close leaves a permanent gap, so this
+    // structure is bounded by unclosed generations -- not by anything the reconnect loop does.
+    const closed = new SshPtyClosedGenerationRanges()
+    let nextGeneration = 1
+    for (let reconnect = 0; reconnect < 5_000; reconnect += 1) {
+      nextGeneration += 1
+      closed.add(nextGeneration++)
+    }
+
+    expect(closed.size).toBe(5_000)
+  })
+})

--- a/src/main/ipc/ssh-pty-model-admission-migration.ts
+++ b/src/main/ipc/ssh-pty-model-admission-migration.ts
@@ -48,7 +48,7 @@ export function settleSshPtyModelAdmissionFailure(args: {
   entry: AdmissionEntry
   error: Error
   migratingPtys: ReadonlySet<string>
-  closingGenerations: Set<number>
+  closingGenerations: { add: (generation: number) => void }
   release: (key: SshPtyModelAdmissionKey, charge: AdmissionCharge) => void
   closeGeneration: (providerGeneration: number) => void
   cleanup: (id: string, usage: PtyUsage) => void

--- a/src/main/ipc/ssh-pty-model-admission.ts
+++ b/src/main/ipc/ssh-pty-model-admission.ts
@@ -1,3 +1,4 @@
+import { SshPtyClosedGenerationRanges } from './ssh-pty-closed-generation-ranges'
 import type {
   SshPtyModelAdmissionKey,
   SshPtyModelAdmissionOptions,
@@ -27,7 +28,15 @@ export class SshPtyModelAdmission {
   private readonly usageByPty = new Map<string, PtyUsage>()
   private readonly pressure: SshPtyModelAdmissionPressure
   private readonly idleWaiters = new Map<string, Set<() => void>>()
-  private readonly closingGenerations = new Set<number>()
+  // Why ranges rather than a Set: provider generations are a process-global monotonic counter
+  // shared by every SSH target, so this grew one entry per relay reconnect for the life of the
+  // process. Because a reconnect closes the generation it replaces, the closed run stays
+  // contiguous apart from the generations that are still live, which bounds the list at roughly
+  // one range per concurrently connected target however hosts interleave. Membership stays exact:
+  // generations below the high-water mark can still be live on another host, so a high-water
+  // approximation would reject a healthy target's output. Do not scope this per target -- with a
+  // global counter each target's own closes are non-adjacent, which is the growth this avoids.
+  private readonly closingGenerations = new SshPtyClosedGenerationRanges()
   private readonly migratingPtys = new Set<string>()
   private globalSourceUnits = 0
   private globalBytes = 0

--- a/src/relay/port-scan-handler.test.ts
+++ b/src/relay/port-scan-handler.test.ts
@@ -70,28 +70,48 @@ function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void
   return { promise, resolve }
 }
 
+type FixtureListener = { port: number; inode: number }
+
+const DEFAULT_LISTENER: FixtureListener = { port: 3000, inode: 11_111 }
+
+function tcpRow(index: number, { port, inode }: FixtureListener): string {
+  const hexPort = port.toString(16).toUpperCase().padStart(4, '0')
+  return `${index}: 0100007F:${hexPort} 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 ${inode}`
+}
+
 function mockLinuxProcScan({
   pidCount,
   fdCount,
-  firstReadlink
+  firstReadlink,
+  listeners = [DEFAULT_LISTENER],
+  inodesByPidOffset,
+  cmdlineByPidOffset
 }: {
   pidCount: number
   fdCount: number
   firstReadlink?: Promise<string>
+  // Listening rows in /proc/net/tcp. Several rows are what makes an early exit keyed on
+  // `result.size === inodes.size` distinguishable from one keyed on `result.size > 0`.
+  listeners?: readonly FixtureListener[]
+  // Socket inode per fd index, keyed by the pid's offset from PID_BASE. Offsets left out hold no
+  // listening socket at all; fd indexes past the end of a list link to a non-socket path.
+  inodesByPidOffset?: ReadonlyMap<number, readonly number[]>
+  cmdlineByPidOffset?: ReadonlyMap<number, string>
 }): void {
   const tcpHeader =
     'sl local_address rem_address st tx_queue rx_queue tr tm->when retrnsmt uid timeout inode'
-  const tcpRow =
-    '0: 0100007F:0BB8 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 11111'
   readFileMock.mockImplementation(async (path: string) => {
     if (path === '/proc/net/tcp') {
-      return `${tcpHeader}\n${tcpRow}\n`
+      return `${tcpHeader}\n${listeners.map((listener, index) => tcpRow(index, listener)).join('\n')}\n`
     }
     if (path === '/proc/net/tcp6') {
       return `${tcpHeader}\n`
     }
-    if (path.endsWith('/cmdline')) {
-      return '/usr/bin/node\0server.js'
+    const cmdlineMatch = path.match(/^\/proc\/(\d+)\/cmdline$/)
+    if (cmdlineMatch) {
+      return (
+        cmdlineByPidOffset?.get(Number(cmdlineMatch[1]) - PID_BASE) ?? '/usr/bin/node\0server.js'
+      )
     }
     throw new Error(`unexpected readFile: ${path}`)
   })
@@ -109,15 +129,135 @@ function mockLinuxProcScan({
   })
 
   let first = true
-  readlinkMock.mockImplementation(() => {
+  readlinkMock.mockImplementation((path: string) => {
     if (first && firstReadlink) {
       first = false
       return firstReadlink
     }
     first = false
-    return Promise.resolve('socket:[11111]')
+    if (!inodesByPidOffset) {
+      return Promise.resolve(`socket:[${DEFAULT_LISTENER.inode}]`)
+    }
+    const match = path.match(/^\/proc\/(\d+)\/fd\/(\d+)$/)
+    if (!match) {
+      throw new Error(`unexpected readlink: ${path}`)
+    }
+    const inode = inodesByPidOffset.get(Number(match[1]) - PID_BASE)?.[Number(match[2])]
+    return Promise.resolve(inode === undefined ? '/dev/null' : `socket:[${inode}]`)
   })
 }
+
+describe('PortScanHandler Linux walk bounds', () => {
+  it('stops walking procfs once every listening socket has an owner', async () => {
+    // Why: this scan repeats for the life of the session, and its unit cost was O(all host
+    // processes x all fds) regardless of how few sockets it was resolving. On a busy remote the
+    // process count only climbs, so the scan got permanently more expensive -- the shape behind
+    // "SSH degrades the longer Orca stays open". One listener means one readlink, not 100,000.
+    mockLinuxProcScan({ pidCount: 1_000, fdCount: 100 })
+
+    await capturePortDetectHandler()({}, requestContext())
+
+    expect(readlinkMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('still walks the whole table when a socket has no reachable owner', async () => {
+    // The inverse: an unattributable inode (another user's process) must not make the scan give up
+    // early on sockets it could still attribute.
+    mockLinuxProcScan({ pidCount: 3, fdCount: 2 })
+    readlinkMock.mockImplementation(() => Promise.resolve('socket:[99999]'))
+
+    await capturePortDetectHandler()({}, requestContext())
+
+    expect(readlinkMock).toHaveBeenCalledTimes(6)
+  })
+
+  it('resolves an owner for every listening socket before it exits', async () => {
+    // The exit condition has to be "every inode is attributed", not "some inode is". With one
+    // fixture row those are the same assertion, which is how an exit-after-the-first-listener bug
+    // would slip through: ports 3001 and 3002 would come back ownerless.
+    mockLinuxProcScan({
+      pidCount: 500,
+      fdCount: 1,
+      listeners: [
+        { port: 3000, inode: 11_111 },
+        { port: 3001, inode: 22_222 },
+        { port: 3002, inode: 33_333 }
+      ],
+      inodesByPidOffset: new Map([
+        [0, [11_111]],
+        [1, [22_222]],
+        [2, [33_333]]
+      ])
+    })
+
+    await expect(capturePortDetectHandler()({}, requestContext())).resolves.toEqual({
+      platform: 'linux',
+      ports: [
+        { host: '127.0.0.1', port: 3000, pid: PID_BASE, processName: 'node' },
+        { host: '127.0.0.1', port: 3001, pid: PID_BASE + 1, processName: 'node' },
+        { host: '127.0.0.1', port: 3002, pid: PID_BASE + 2, processName: 'node' }
+      ]
+    })
+    // Three owners found means three readlinks: it stops at the third pid, not the five hundredth.
+    expect(readlinkMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('keeps walking past an attributed socket to reach a later owner', async () => {
+    // A partially attributed table is the sharpest case: the first pid resolves one inode, and the
+    // second inode is only reachable at the end of the walk.
+    mockLinuxProcScan({
+      pidCount: 4,
+      fdCount: 1,
+      listeners: [
+        { port: 3000, inode: 11_111 },
+        { port: 3001, inode: 22_222 }
+      ],
+      inodesByPidOffset: new Map([
+        [0, [11_111]],
+        [3, [22_222]]
+      ])
+    })
+
+    await expect(capturePortDetectHandler()({}, requestContext())).resolves.toEqual({
+      platform: 'linux',
+      ports: [
+        { host: '127.0.0.1', port: 3000, pid: PID_BASE, processName: 'node' },
+        { host: '127.0.0.1', port: 3001, pid: PID_BASE + 3, processName: 'node' }
+      ]
+    })
+    expect(readlinkMock).toHaveBeenCalledTimes(4)
+  })
+})
+
+describe('PortScanHandler shared listening inode attribution', () => {
+  it('attributes a shared inode to the first holder the walk reaches', async () => {
+    // An nginx master and its workers (or a Node cluster) share one listening inode. The walk used
+    // to overwrite the entry for every later holder, so the last pid in readdir order won; exiting
+    // as soon as the inode is attributed makes the first one win instead. That is the better
+    // answer -- the master owns the socket -- but it is a visible change to the name in the ports
+    // UI, so pin it here rather than let it drift.
+    mockLinuxProcScan({
+      pidCount: 3,
+      fdCount: 1,
+      inodesByPidOffset: new Map([
+        [0, [DEFAULT_LISTENER.inode]],
+        [1, [DEFAULT_LISTENER.inode]],
+        [2, [DEFAULT_LISTENER.inode]]
+      ]),
+      cmdlineByPidOffset: new Map([
+        [0, '/usr/sbin/nginx\0master process'],
+        [1, '/usr/sbin/nginx-worker\0worker process'],
+        [2, '/usr/sbin/nginx-worker\0worker process']
+      ])
+    })
+
+    await expect(capturePortDetectHandler()({}, requestContext())).resolves.toEqual({
+      platform: 'linux',
+      ports: [{ host: '127.0.0.1', port: 3000, pid: PID_BASE, processName: 'nginx' }]
+    })
+    expect(readlinkMock).toHaveBeenCalledTimes(1)
+  })
+})
 
 describe('PortScanHandler Linux cancellation', () => {
   it('does not touch procfs for an already-cancelled request', async () => {

--- a/src/relay/port-scan-handler.ts
+++ b/src/relay/port-scan-handler.ts
@@ -161,6 +161,13 @@ export class PortScanHandler {
 
     for (const pidStr of pids) {
       signal?.throwIfAborted()
+      // Why: every remaining pid costs a readdir plus one readlink per fd, and this scan repeats for
+      // the life of the session. Without this the walk was O(all host processes x all fds) even once
+      // every listener was already attributed, so its cost grew with the remote's process count and
+      // never came back down — the shape behind "SSH gets slower the longer Orca stays open".
+      if (result.size === inodes.size) {
+        return result
+      }
       const fdDir = `/proc/${pidStr}/fd`
       let fds: string[]
       try {
@@ -192,6 +199,9 @@ export class PortScanHandler {
         const inode = Number.parseInt(match[1], 10)
         if (inodes.has(inode)) {
           result.set(inode, pid)
+          if (result.size === inodes.size) {
+            return result
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​303 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​295 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 |

<!-- /orca-pr-loc -->

## What

Two independent growth terms found while root-causing the report that *"SSH performance degrades over time, until I can no longer SSH into the remote machine at all; quitting Orca fixes it."*

**This PR now contains the work previously split across #17818 and #17937, squashed into a single commit.** #17818 alone swapped an `O(1)` `Set.has` on the per-output-chunk admission path for a linear scan; that intermediate state must never be bisectable. See the benchmark below.

### 1. The port scan walked all of procfs on every pass

`PortScanHandler.mapInodesToPids` iterated **every pid on the host** and **every fd of each**, doing a `readlink` syscall per fd, and never stopped once every listening socket already had an owner. Unit cost was O(host processes x fds) per scan, and the scan repeats for the life of the session — so on a busy remote it got permanently more expensive as the process count climbed and never came back down.

Measured on the existing test fixture (1,000 pids x 100 fds, one listening socket):

```
before: expected "vi.fn()" to be called 1 times, but got 100000 times
after:  1
```

Two tests guard both directions: the walk stops once every socket is attributed, and it still traverses the whole table when a socket's owner is unreachable (another user's process), so the early exit cannot silently under-scan.

### 2. `closingGenerations` grew for the life of the process

`SshPtyModelAdmission` kept a `Set<number>` of every closed provider generation. Provider generations are a **process-global monotonic counter shared by every SSH target**, so the set gained one entry per relay reconnect and nothing ever pruned it.

Retention after 500k reconnects:

| | retained | entries |
| :--- | ---: | ---: |
| `main` | ~10,234 KB | 500,000 |
| this PR | 18 KB | 1 range |

Closed generations now live in `SshPtyClosedGenerationRanges`, which collapses contiguous closed runs into a single range. Because a reconnect closes the generation it replaces, the closed run stays contiguous apart from the generations that are still live, which bounds the list at roughly one range per concurrently connected target however hosts interleave.

Membership stays **exact**, not a high-water approximation: a generation below the high-water mark can still be live on another host, so approximating would reject a healthy target's output. The container is deliberately not scoped per target — with a global counter, each target's own closes are non-adjacent, which is the growth this avoids.

### Why a dead-id registry at all

Worth stating because the obvious comparison argues the other way. tmux uses a monotonic counter plus a live-only container and keeps **no** dead-id registry. It can: its ids never leave the process. Ours cross a network boundary, and a relay restart remints them, so we must be able to distinguish "id from a dead generation" from "id I never knew" — which a live-only container cannot do.

### Sublinear lookup

`has()` and `add()` on the range container were a linear scan; both are now binary search.

`has()` is on the per-output-chunk admission path, so a scan trades a bounded `Set` lookup for one that degrades with fragmentation, and makes `add` quadratic. Measured, 200k probes:

| ranges | `Set` | linear scan | binary search |
| ---: | ---: | ---: | ---: |
| 20 | 1.6 ms | 8.3 ms (5.2x) | 2.4 ms (1.5x) |
| 1,000 | 2.2 ms | 178.3 ms (82x) | 4.6 ms (2.1x) |
| 20,000 | 4.3 ms | 11,984.9 ms (2,758x) | 28.9 ms (6.7x) |

A differential probe over randomized insertion orders found **0 mismatches** against both a plain `Set` and the linear implementation, including identical resulting range arrays.

This also speeds up `ssh-pty-output-generation-guard.ts`, which already uses this container on `main`.

## Known limitation — stated, not fixed here

The closed-generation set is bounded in the healthy case (one range) but **unbounded when generations leak**: a generation that is allocated and never closed leaves a permanent gap, and each gap is a range. **Sublinear is not bounded.**

A *live*-generation set would be bounded by construction and is the better long-term design. That is a follow-up, not this PR. `retains one range for every generation that is allocated and never closed` pins the current shape so the limitation is visible rather than assumed away.

## What this does *not* change

`src/shared/process-table-snapshot.ts` was also flagged to me as a monotonic term. It is not, and I left it alone: it is already memoized to one `ps` per 500ms window regardless of pane count (the #6288 fix), so its cost is linear in host process count and bounded, not growing.

## Scope note

This is the resource half of the long-session report. The other half — accumulating wedged relay clients that hold their owner leases and SSH channels, which is what produces the "cannot SSH in at all" symptom against the host's `MaxSessions` — is fixed in #17817.
