### PR TITLE
fix(ssh): discover the 1Password agent socket, scoped to the host that owns it

### DIFF
--- a/src/main/ssh/ssh-agent-socket-discovery.test.ts
+++ b/src/main/ssh/ssh-agent-socket-discovery.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { join } from 'node:path'
+
+const mockExistsSync = vi.fn<(path: string) => boolean>()
+
+vi.mock('node:fs', () => ({
+  existsSync: (path: string) => mockExistsSync(path)
+}))
+
+const TEST_HOME = '/home/testuser'
+vi.mock('node:os', () => ({
+  homedir: () => TEST_HOME
+}))
+
+import {
+  discoverNativeAgentSocket,
+  listAgentSocketCandidates,
+  WINDOWS_OPENSSH_AGENT_PIPE
+} from './ssh-agent-socket-discovery'
+import { getRemoteHostPlatform } from './ssh-remote-platform'
+
+const MACOS_ONEPASSWORD_SOCKET = join(
+  TEST_HOME,
+  'Library',
+  'Group Containers',
+  '2BUA8C4S2C.com.1password',
+  't',
+  'agent.sock'
+)
+const LINUX_ONEPASSWORD_SOCKET = join(TEST_HOME, '.1password', 'agent.sock')
+
+const originalSshAuthSock = process.env.SSH_AUTH_SOCK
+
+function usePlatform(platform: NodeJS.Platform): void {
+  vi.spyOn(process, 'platform', 'get').mockReturnValue(platform)
+}
+
+beforeEach(() => {
+  mockExistsSync.mockReset()
+  mockExistsSync.mockReturnValue(false)
+  delete process.env.SSH_AUTH_SOCK
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  if (originalSshAuthSock === undefined) {
+    delete process.env.SSH_AUTH_SOCK
+  } else {
+    process.env.SSH_AUTH_SOCK = originalSshAuthSock
+  }
+})
+
+describe('discoverNativeAgentSocket', () => {
+  it('keeps SSH_AUTH_SOCK as the primary signal even when 1Password is installed', () => {
+    usePlatform('darwin')
+    mockExistsSync.mockReturnValue(true)
+    process.env.SSH_AUTH_SOCK = '/tmp/env-agent.sock'
+
+    expect(discoverNativeAgentSocket()).toBe('/tmp/env-agent.sock')
+  })
+
+  it('falls back to the macOS 1Password group-container socket when SSH_AUTH_SOCK is unset', () => {
+    usePlatform('darwin')
+    mockExistsSync.mockImplementation((path) => path === MACOS_ONEPASSWORD_SOCKET)
+
+    expect(discoverNativeAgentSocket()).toBe(MACOS_ONEPASSWORD_SOCKET)
+  })
+
+  it('falls back to the Linux 1Password socket when SSH_AUTH_SOCK is unset', () => {
+    usePlatform('linux')
+    mockExistsSync.mockImplementation((path) => path === LINUX_ONEPASSWORD_SOCKET)
+
+    expect(discoverNativeAgentSocket()).toBe(LINUX_ONEPASSWORD_SOCKET)
+  })
+
+  it('returns nothing rather than a socket path that is not there', () => {
+    usePlatform('darwin')
+
+    expect(discoverNativeAgentSocket()).toBeUndefined()
+    expect(mockExistsSync).toHaveBeenCalledWith(MACOS_ONEPASSWORD_SOCKET)
+  })
+
+  it('uses the Windows OpenSSH pipe, which 1Password serves too', () => {
+    usePlatform('win32')
+
+    expect(discoverNativeAgentSocket()).toBe(WINDOWS_OPENSSH_AGENT_PIPE)
+    expect(mockExistsSync).not.toHaveBeenCalled()
+  })
+
+  it('lists the environment socket ahead of the 1Password one', () => {
+    usePlatform('linux')
+    process.env.SSH_AUTH_SOCK = '/tmp/env-agent.sock'
+
+    expect(listAgentSocketCandidates({ kind: 'native' })).toEqual([
+      '/tmp/env-agent.sock',
+      LINUX_ONEPASSWORD_SOCKET
+    ])
+  })
+})
+
+describe('listAgentSocketCandidates host boundary', () => {
+  it('never answers for a WSL distro with the Windows host machine sockets', () => {
+    usePlatform('win32')
+    process.env.SSH_AUTH_SOCK = '/tmp/windows-agent.sock'
+
+    const candidates = listAgentSocketCandidates({
+      kind: 'wsl',
+      distro: 'Ubuntu',
+      guestHome: '/home/dev',
+      guestEnv: {}
+    })
+
+    expect(candidates).toEqual(['/home/dev/.1password/agent.sock'])
+    expect(candidates).not.toContain(WINDOWS_OPENSSH_AGENT_PIPE)
+    expect(candidates).not.toContain('/tmp/windows-agent.sock')
+  })
+
+  it("prefers the distro's own SSH_AUTH_SOCK, where an npiperelay bridge lands", () => {
+    usePlatform('win32')
+
+    expect(
+      listAgentSocketCandidates({
+        kind: 'wsl',
+        distro: 'Ubuntu',
+        guestHome: '/home/dev',
+        guestEnv: { SSH_AUTH_SOCK: '/home/dev/.ssh/agent.sock' }
+      })
+    ).toEqual(['/home/dev/.ssh/agent.sock', '/home/dev/.1password/agent.sock'])
+  })
+
+  it('never answers for a relay host with the client machine socket', () => {
+    usePlatform('darwin')
+    process.env.SSH_AUTH_SOCK = '/tmp/client-agent.sock'
+
+    const candidates = listAgentSocketCandidates({
+      kind: 'ssh-relay',
+      connectionId: 'target-1',
+      platform: getRemoteHostPlatform('linux-x64'),
+      remoteHome: '/home/deploy',
+      remoteEnv: {}
+    })
+
+    expect(candidates).toEqual(['/home/deploy/.1password/agent.sock'])
+    expect(candidates).not.toContain('/tmp/client-agent.sock')
+    expect(candidates).not.toContain(MACOS_ONEPASSWORD_SOCKET)
+  })
+
+  it('uses the remote group-container path for a macOS relay host, with remote separators', () => {
+    usePlatform('win32')
+
+    expect(
+      listAgentSocketCandidates({
+        kind: 'ssh-relay',
+        connectionId: 'target-1',
+        platform: getRemoteHostPlatform('darwin-arm64'),
+        remoteHome: '/Users/deploy',
+        remoteEnv: {}
+      })
+    ).toEqual(['/Users/deploy/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock'])
+  })
+
+  it('offers no 1Password candidate for a Windows relay host the relay cannot pipe to', () => {
+    usePlatform('darwin')
+
+    expect(
+      listAgentSocketCandidates({
+        kind: 'ssh-relay',
+        connectionId: 'target-1',
+        platform: getRemoteHostPlatform('win32-x64'),
+        remoteHome: 'C:/Users/deploy',
+        remoteEnv: {}
+      })
+    ).toEqual([])
+  })
+})

--- a/src/main/ssh/ssh-agent-socket-discovery.ts
+++ b/src/main/ssh/ssh-agent-socket-discovery.ts
@@ -1,0 +1,125 @@
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, posix } from 'node:path'
+import { joinRemotePath, type RemoteHostPlatform } from './ssh-remote-platform'
+
+/**
+ * The Win32 OpenSSH agent pipe.
+ *
+ * 1Password serves this exact pipe rather than a private one, so Windows has no
+ * separate 1Password endpoint to discover — the incumbent fallback already covers it.
+ */
+export const WINDOWS_OPENSSH_AGENT_PIPE = '\\\\.\\pipe\\openssh-ssh-agent'
+
+/** macOS publishes the agent inside 1Password's signed group container. */
+const MACOS_ONEPASSWORD_SOCKET_SEGMENTS = [
+  'Library',
+  'Group Containers',
+  '2BUA8C4S2C.com.1password',
+  't',
+  'agent.sock'
+]
+const POSIX_ONEPASSWORD_SOCKET_SEGMENTS = ['.1password', 'agent.sock']
+
+/** One host's own `$SSH_AUTH_SOCK` reading. */
+export type AgentSocketEnv = { SSH_AUTH_SOCK?: string | undefined }
+
+/**
+ * The machine whose SSH agent is being discovered.
+ *
+ * A socket found on one host is never a valid answer for another, so only `native`
+ * may read this process's env and filesystem. The other kinds must be handed their
+ * own host's `$HOME` and `$SSH_AUTH_SOCK`, and their candidates stay unprobed until
+ * something asks that host directly.
+ */
+export type AgentSocketHost =
+  | { kind: 'native' }
+  | { kind: 'wsl'; distro: string; guestHome: string; guestEnv: AgentSocketEnv }
+  | {
+      kind: 'ssh-relay'
+      connectionId: string
+      platform: RemoteHostPlatform
+      remoteHome: string
+      remoteEnv: AgentSocketEnv
+    }
+
+function onePasswordAgentEndpoint(host: AgentSocketHost): string | undefined {
+  switch (host.kind) {
+    case 'native':
+      if (process.platform === 'win32') {
+        return WINDOWS_OPENSSH_AGENT_PIPE
+      }
+      if (process.platform === 'darwin') {
+        return join(homedir(), ...MACOS_ONEPASSWORD_SOCKET_SEGMENTS)
+      }
+      return process.platform === 'linux'
+        ? join(homedir(), ...POSIX_ONEPASSWORD_SOCKET_SEGMENTS)
+        : undefined
+    case 'wsl':
+      // A distro is Linux, and 1Password's Windows pipe is unreachable from inside it
+      // without an npiperelay bridge — which the user surfaces via $SSH_AUTH_SOCK.
+      return posix.join(host.guestHome, ...POSIX_ONEPASSWORD_SOCKET_SEGMENTS)
+    case 'ssh-relay':
+      // No named pipe survives the relay, so a Windows host publishes nothing usable.
+      return host.platform.os === 'win32'
+        ? undefined
+        : joinRemotePath(
+            host.platform,
+            host.remoteHome,
+            ...(host.platform.os === 'darwin'
+              ? MACOS_ONEPASSWORD_SOCKET_SEGMENTS
+              : POSIX_ONEPASSWORD_SOCKET_SEGMENTS)
+          )
+  }
+}
+
+function hostEnv(host: AgentSocketHost): AgentSocketEnv {
+  switch (host.kind) {
+    case 'native':
+      return { SSH_AUTH_SOCK: process.env.SSH_AUTH_SOCK }
+    case 'wsl':
+      return host.guestEnv
+    case 'ssh-relay':
+      return host.remoteEnv
+  }
+}
+
+/**
+ * Agent socket candidates for `host`, most preferred first.
+ *
+ * `$SSH_AUTH_SOCK` stays the primary signal; the 1Password endpoint is only a
+ * fallback for a host that publishes none. Entries are unverified — probe them on
+ * `host` itself, never on the client.
+ */
+export function listAgentSocketCandidates(host: AgentSocketHost): string[] {
+  const candidates = [hostEnv(host).SSH_AUTH_SOCK, onePasswordAgentEndpoint(host)]
+  return [...new Set(candidates.filter((candidate) => !!candidate))] as string[]
+}
+
+function nativeAgentEndpointExists(endpoint: string): boolean {
+  // Why: named pipes are invisible to the filesystem, and this pipe name is the
+  // incumbent Windows fallback — probing it could only regress Windows.
+  if (process.platform === 'win32') {
+    return true
+  }
+  try {
+    return existsSync(endpoint)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The agent socket on the machine running this process — the only host ssh2 can reach.
+ *
+ * `$SSH_AUTH_SOCK` is returned as the user set it; the 1Password endpoint is a guess,
+ * so it is only returned once proven present rather than handed over as a dead path.
+ */
+export function discoverNativeAgentSocket(): string | undefined {
+  const envSocket = process.env.SSH_AUTH_SOCK
+  if (envSocket) {
+    return envSocket
+  }
+  const endpoint = onePasswordAgentEndpoint({ kind: 'native' })
+  return endpoint && nativeAgentEndpointExists(endpoint) ? endpoint : undefined
+}

--- a/src/main/ssh/ssh-auth-resolution.ts
+++ b/src/main/ssh/ssh-auth-resolution.ts
@@ -3,6 +3,7 @@ import { utils, type BaseAgent, type ParsedKey } from 'ssh2'
 import type { SshTarget } from '../../shared/ssh-types'
 import type { SshResolvedConfig } from './ssh-config-parser'
 import { createIdentityFilteredAgent } from './ssh-agent-identity-filter'
+import { discoverNativeAgentSocket } from './ssh-agent-socket-discovery'
 import { resolveSshConfigHomePath } from './ssh-config-path-expansion'
 import { isOpenSshConfigBackedTarget } from './system-ssh-args'
 
@@ -16,7 +17,6 @@ const DEFAULT_KEY_PATHS = DEFAULT_KEY_NAMES.map((name) => `~/.ssh/${name}`)
 const DEFAULT_IDENTITY_PATHS = [...DEFAULT_KEY_NAMES, ...DEFAULT_SECURITY_KEY_NAMES].map(
   (name) => `~/.ssh/${name}`
 )
-const WINDOWS_OPENSSH_AGENT_PIPE = '\\\\.\\pipe\\openssh-ssh-agent'
 
 // Why: resolved IdentityFile paths are expanded before auth resolution, so they
 // won't match the ~/... form in DEFAULT_KEY_PATHS.
@@ -63,13 +63,6 @@ function expandIdentityAgentEnv(value: string): string | undefined {
   return missingEnv ? undefined : expanded
 }
 
-function resolveDefaultAgentSocket(): string | undefined {
-  return (
-    process.env.SSH_AUTH_SOCK ||
-    (process.platform === 'win32' ? WINDOWS_OPENSSH_AGENT_PIPE : undefined)
-  )
-}
-
 export function resolveAgentSocket(
   target: Pick<SshTarget, 'identityAgent' | 'configHost' | 'source' | 'host'>,
   resolved: Pick<SshResolvedConfig, 'identityAgent'> | null
@@ -86,7 +79,9 @@ export function resolveAgentSocket(
     }
     return expandIdentityAgentEnv(resolveSshConfigHomePath(trimmed))
   }
-  return resolveDefaultAgentSocket()
+  // Why: the agent runs on the client that drives ssh2, never on target.host — a
+  // remote or WSL host's agent is a different machine's and must not be answered here.
+  return discoverNativeAgentSocket()
 }
 
 function resolveExplicitPrivateKeyPaths(

--- a/src/main/ssh/ssh-connection-utils.test.ts
+++ b/src/main/ssh/ssh-connection-utils.test.ts
@@ -14,6 +14,14 @@ function testHomePath(...parts: string[]): string {
   return join(TEST_HOME, ...parts)
 }
 
+const MACOS_ONEPASSWORD_SOCKET = testHomePath(
+  'Library',
+  'Group Containers',
+  '2BUA8C4S2C.com.1password',
+  't',
+  'agent.sock'
+)
+
 vi.mock('fs', () => ({
   existsSync: (...args: unknown[]) => mockExistsSync(...args),
   readFileSync: (...args: unknown[]) => mockReadFileSync(...args)
@@ -578,6 +586,40 @@ describe('buildConnectConfig', () => {
     } finally {
       platformSpy.mockRestore()
     }
+  })
+
+  it('discovers the 1Password agent socket when SSH_AUTH_SOCK is unset', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    delete process.env.SSH_AUTH_SOCK
+    mockExistsSync.mockImplementation((path: unknown) => path === MACOS_ONEPASSWORD_SOCKET)
+
+    expect(buildConnectConfig(makeTarget(), null).agent).toBe(MACOS_ONEPASSWORD_SOCKET)
+  })
+
+  it('keeps SSH_AUTH_SOCK ahead of the 1Password agent socket', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    mockExistsSync.mockReturnValue(true)
+
+    expect(buildConnectConfig(makeTarget(), null).agent).toBe('/tmp/agent.sock')
+  })
+
+  it('keeps an explicit IdentityAgent ahead of the 1Password agent socket', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    delete process.env.SSH_AUTH_SOCK
+    mockExistsSync.mockReturnValue(true)
+
+    const config = buildConnectConfig(
+      makeTarget({ identityAgent: '/tmp/explicit-agent.sock' }),
+      null
+    )
+    expect(config.agent).toBe('/tmp/explicit-agent.sock')
+  })
+
+  it('offers no agent when neither SSH_AUTH_SOCK nor a 1Password socket exists', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    delete process.env.SSH_AUTH_SOCK
+
+    expect(buildConnectConfig(makeTarget(), null).agent).toBeUndefined()
   })
 
   it('wraps agent auth with IdentityFile filtering when IdentitiesOnly is enabled', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​217 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​217 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​129 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​120 |

<!-- /orca-pr-loc -->

## What

SSH auth resolution only ever considered `SSH_AUTH_SOCK` and the Windows OpenSSH pipe, so a user whose keys live in 1Password had no agent. New `ssh-agent-socket-discovery.ts` adds the 1Password endpoint as a **fallback**, with the owning machine as an explicit parameter.

Resolution order: explicit `IdentityAgent` (including `none`) -> `$SSH_AUTH_SOCK` -> probed 1Password endpoint -> nothing. Behavior is byte-for-byte unchanged whenever `SSH_AUTH_SOCK` is set, and unchanged on Windows in every case.

## Host scoping is the point

An `AgentSocketHost` union (`native` | `wsl` | `ssh-relay`) makes the owning machine explicit. Only `native` may read this process's `process.env` / `homedir()` / filesystem; the other two must be handed their own host's `$HOME` and `$SSH_AUTH_SOCK`. That is what stops a native answer leaking into a decision about a remote host, per [`docs/reference/ssh-execution-boundary.md`](../blob/main/docs/reference/ssh-execution-boundary.md). Native uses `path.join`, WSL uses `path.posix.join`, and the relay branch reuses the existing `joinRemotePath` / `RemoteHostPlatform` rather than a parallel path model.

## Endpoints, and their sources

| Host | Endpoint |
|---|---|
| macOS | `~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock` |
| Linux | `~/.1password/agent.sock` |
| Windows | `\\.\pipe\openssh-ssh-agent` — already the incumbent fallback, so no change |
| WSL | **none exists** |

Verified against [1Password's SSH client compatibility page](https://www.1password.dev/ssh/agent/compatibility/). The WSL row is a correction, not a gap: 1Password publishes no socket inside a distro, and its Windows pipe is unreachable from WSL without an npiperelay + socat bridge that the user points `$SSH_AUTH_SOCK` at. So the WSL branch offers the distro's own `$SSH_AUTH_SOCK` first and `~/.1password/agent.sock` only as a symlink-convention fallback — never the Windows pipe.

Only the *guessed* 1Password path is probed for existence. `$SSH_AUTH_SOCK` is deliberately not probed: it is the user's own explicit statement, and probing it would change existing behavior.

## Relationship to #12765

#12765 (by @vcolombo, credited in the commit) was closed unmerged; #17540 is the \"redo this properly\" follow-up. Kept from it: the platform socket paths, and the finding that Windows needs no change. Rejected:

- **The keys-aware probe and \"first socket with keys wins\" ordering.** It let 1Password beat a *set and non-empty* `SSH_AUTH_SOCK`, which contradicts keeping `SSH_AUTH_SOCK` primary; #12765's own doc admits the mixed-agent failure. It also cost up to ~1s per connect attempt and dragged agent-protocol plumbing into a synchronous path.
- **Module-level `probedAgentSocket` state.** A single global \"the agent socket\" is exactly the host-boundary leak #17540 asks to remove — it is target-independent by construction.
- **Shell-env hydration and the `IdentitiesOnly` fail-open.** Real issues, but separate; the latter loosens auth semantics and deserves its own change.

## Known gap — do not close #17540 on this

On macOS, launchd always sets `SSH_AUTH_SOCK` for GUI apps (confirmed on a dev machine: `/private/tmp/com.apple.launchd.XXXX/Listeners`). Because this fallback only fires when `SSH_AUTH_SOCK` is **unset**, it is effectively dead code on macOS — the platform where 1Password SSH is most used. Linux benefits today; macOS does not.

The follow-up wants a narrow discriminator rather than #12765's broad ordering: if the incumbent socket is the Apple launchd agent **and** it reports zero identities **and** a 1Password socket exists, prefer 1Password. That probes only in the one genuinely ambiguous case. Filed as follow-up work; this PR is deliberately the host-scoping half.

Also left undone: nothing probes the WSL or relay hosts yet, because there is no consumer — all ssh2 connections originate on the client, and the repo has no cross-host exec interface to build on. The host kinds are modeled and tested so a future caller must supply that host's own env to get an answer.

## Verification

```
$ pnpm test src/main/ssh/ssh-agent-socket-discovery.test.ts src/main/ssh/ssh-connection-utils.test.ts
 Test Files  2 passed (2)
      Tests  96 passed (96)

$ pnpm test src/main/ssh
 Test Files  129 passed | 2 skipped (131)
      Tests  1809 passed | 16 skipped (1825)

$ pnpm tc:node    # clean
```

11 discovery cases (per-platform fallback, `SSH_AUTH_SOCK` precedence, nothing-found, Windows pipe, five host-boundary cases) plus 4 end-to-end through `buildConnectConfig`.

Refs #17540

---

## ELI5

If your SSH keys live in 1Password, Orca could not find them. It only looked at the standard environment variable and the Windows pipe.

## User-facing regression risk

- A user whose `SSH_AUTH_SOCK` is unset but who has a **stale or broken** 1Password socket file may now get an agent-auth failure where previously they got 'no agent'. Existence is probed, but liveness is not.
- Zero change whenever `SSH_AUTH_SOCK` is set, and zero change on Windows in all cases.
- **Known gap, not a regression:** on macOS launchd always sets `SSH_AUTH_SOCK`, so this fallback never fires there. Tracked in #17826.
