### PR TITLE
fix(remote-runtime): make every advertised recovery attempt reachable, and stop two recovery latches

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalRemoteRuntimeReconnectBanner.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRemoteRuntimeReconnectBanner.test.tsx
@@ -17,7 +17,7 @@ describe('TerminalRemoteRuntimeReconnectBanner', () => {
     render(<TerminalRemoteRuntimeReconnectBanner phase="backoff" onReconnect={vi.fn()} />)
 
     expect(screen.getByText('Reconnecting to remote runtime')).toBeInTheDocument()
-    expect(screen.getByText(/retry for up to one minute/)).toBeInTheDocument()
+    expect(screen.getByText(/retrying automatically/)).toBeInTheDocument()
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 

--- a/src/renderer/src/components/terminal-pane/TerminalRemoteRuntimeReconnectBanner.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRemoteRuntimeReconnectBanner.tsx
@@ -50,7 +50,7 @@ export function TerminalRemoteRuntimeReconnectBanner({
             {retrying
               ? translate(
                   'auto.components.terminal.pane.TerminalRemoteRuntimeReconnectBanner.retryingBody',
-                  'Orca will retry for up to one minute. This terminal will resume if the connection returns.'
+                  'Orca is retrying automatically. This terminal will resume if the connection returns.'
                 )
               : translate(
                   'auto.components.terminal.pane.TerminalRemoteRuntimeReconnectBanner.disconnectedBody',

--- a/src/renderer/src/components/terminal-pane/remote-runtime-connect-failure-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-connect-failure-recovery.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createRemoteRuntimeTransportMocks,
+  type MultiplexSubscriptionCallbacks
+} from './remote-runtime-pty-transport-test-harness'
+import { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } from './remote-runtime-pty-recovery-state'
+
+let subscriptionCallbacks: MultiplexSubscriptionCallbacks = null
+let resolvedPaneHandle = 'terminal-1'
+
+const { runtimeCall, resetRemoteRuntimeTransport } = createRemoteRuntimeTransportMocks({
+  getCallbacks: () => subscriptionCallbacks,
+  setCallbacks: (callbacks) => {
+    subscriptionCallbacks = callbacks
+  },
+  getResolvedPaneHandle: () => resolvedPaneHandle,
+  setResolvedPaneHandle: (handle) => {
+    resolvedPaneHandle = handle
+  }
+})
+
+// #12684: connect() classified these failures as recoverable and then latched 'disconnected' with
+// nothing armed — no backoff timer, no parked retry, and a Reconnect button that returned false.
+describe('recoverable connect failures on a remote runtime pane', () => {
+  let resolvePaneCalls = 0
+
+  function installUnreachableRuntime(): void {
+    resolvePaneCalls = 0
+    runtimeCall.mockImplementation(async (args: { method: string }) => {
+      if (args.method === 'terminal.resolvePane') {
+        resolvePaneCalls += 1
+      }
+      throw Object.assign(new Error('Remote Orca runtime closed the connection.'), {
+        code: 'remote_runtime_unavailable'
+      })
+    })
+  }
+
+  beforeEach(() => {
+    resetRemoteRuntimeTransport()
+  })
+
+  it('keeps retrying a recoverable connect failure instead of latching immediately', async () => {
+    vi.useFakeTimers()
+    try {
+      installUnreachableRuntime()
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const onError = vi.fn()
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        leafId: 'pane:1'
+      })
+
+      await transport.connect({
+        url: '',
+        sessionId: 'remote:env-1@@',
+        callbacks: { onError }
+      })
+
+      // Loss of contact is unverifiable, not a dead terminal: automatic recovery must still be running.
+      expect(resolvePaneCalls).toBe(1)
+      expect(transport.getRecoveryState?.().phase).toBe('backoff')
+      expect(onError).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(resolvePaneCalls).toBeGreaterThan(1)
+
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('leaves both revival paths armed once the recovery window is spent', async () => {
+    vi.useFakeTimers()
+    try {
+      installUnreachableRuntime()
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      // Why dynamic: resetRemoteRuntimeTransport() re-registers the module graph, and the retry
+      // registry only sees panes from the same instance the transport was loaded from.
+      const { retryAllRemoteRuntimePtyRecoveriesNow } =
+        await import('./remote-runtime-pty-recovery-state')
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        leafId: 'pane:1'
+      })
+
+      await transport.connect({ url: '', sessionId: 'remote:env-1@@', callbacks: {} })
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 1_000)
+
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      const callsAtCutoff = resolvePaneCalls
+
+      // The cutoff stops self-initiated retries only; online/resume must still find a parked retry.
+      expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(1)
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(resolvePaneCalls).toBeGreaterThan(callsAtCutoff)
+
+      // ...and so must the Reconnect button, which returned false before #12684.
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 1_000)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      expect(transport.retryRecovery?.()).toBe(true)
+
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/renderer/src/components/terminal-pane/remote-runtime-connect-failure-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-connect-failure-recovery.test.ts
@@ -3,7 +3,10 @@ import {
   createRemoteRuntimeTransportMocks,
   type MultiplexSubscriptionCallbacks
 } from './remote-runtime-pty-transport-test-harness'
-import { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } from './remote-runtime-pty-recovery-state'
+import {
+  REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS,
+  REMOTE_RUNTIME_RECOVERY_ATTEMPT_BUDGET_MS
+} from './remote-runtime-pty-recovery-state'
 
 let subscriptionCallbacks: MultiplexSubscriptionCallbacks = null
 let resolvedPaneHandle = 'terminal-1'
@@ -30,6 +33,24 @@ describe('recoverable connect failures on a remote runtime pane', () => {
       if (args.method === 'terminal.resolvePane') {
         resolvePaneCalls += 1
       }
+      throw Object.assign(new Error('Remote Orca runtime closed the connection.'), {
+        code: 'remote_runtime_unavailable'
+      })
+    })
+  }
+
+  // Why: installUnreachableRuntime() rejects synchronously, so every failure lands during a backoff
+  // wait. A silently dropped link instead burns the whole RPC budget, so the rejection arrives while
+  // the attempt is still in flight — including after the auto-recovery deadline has already latched.
+  function installSilentlyDroppedRuntime(): void {
+    resolvePaneCalls = 0
+    runtimeCall.mockImplementation(async (args: { method: string }) => {
+      if (args.method === 'terminal.resolvePane') {
+        resolvePaneCalls += 1
+      }
+      await new Promise((resolve) => {
+        setTimeout(resolve, REMOTE_RUNTIME_RECOVERY_ATTEMPT_BUDGET_MS)
+      })
       throw Object.assign(new Error('Remote Orca runtime closed the connection.'), {
         code: 'remote_runtime_unavailable'
       })
@@ -101,6 +122,34 @@ describe('recoverable connect failures on a remote runtime pane', () => {
       // ...and so must the Reconnect button, which returned false before #12684.
       await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 1_000)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      expect(transport.retryRecovery?.()).toBe(true)
+
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+  it('keeps the window bounded when a silent drop fails after the deadline latched', async () => {
+    vi.useFakeTimers()
+    try {
+      installSilentlyDroppedRuntime()
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        leafId: 'pane:1'
+      })
+
+      void transport.connect({ url: '', sessionId: 'remote:env-1@@', callbacks: {} })
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS * 2)
+
+      // The in-flight rejection must not begin a new epoch; that re-arms a full-length window forever.
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      const callsAtCutoff = resolvePaneCalls
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS * 2)
+      expect(resolvePaneCalls).toBe(callsAtCutoff)
+
+      // A deadline that lands mid-attempt parks nothing, so the latch must still stay revivable.
       expect(transport.retryRecovery?.()).toBe(true)
 
       transport.destroy?.()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-outage-toast-flood-and-stuck-reconnect.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-outage-toast-flood-and-stuck-reconnect.test.ts
@@ -26,6 +26,7 @@ import {
 import { RuntimeRpcCallQueueOverloadError } from '../../../../shared/runtime-rpc-call-queue'
 import { withRemoteRuntimeTailscaleHint } from '../../../../shared/remote-runtime-tailscale-hint'
 import type { PtyTransportRecoveryState } from './pty-transport-types'
+import { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } from './remote-runtime-pty-recovery-state'
 
 const ELECTRON_IPC_PREFIX = "Error invoking remote method 'runtimeEnvironments:call': "
 
@@ -409,7 +410,7 @@ describe('remote runtime outage: toast flood and stuck reconnect (issue3)', () =
       await vi.advanceTimersByTimeAsync(16_000)
 
       // Auto-recovery deadline latches the pane 'disconnected'.
-      await vi.advanceTimersByTimeAsync(60_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
 
       // Connectivity restored; 'online'/system-resume trigger fires.
@@ -417,7 +418,7 @@ describe('remote runtime outage: toast flood and stuck reconnect (issue3)', () =
       await vi.advanceTimersByTimeAsync(16_000)
 
       // Latch again, then the user clicks the Reconnect banner.
-      await vi.advanceTimersByTimeAsync(60_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       transport.retryRecovery?.()
       await vi.advanceTimersByTimeAsync(16_000)
 

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
@@ -8,6 +8,7 @@ import {
   encodeTerminalStreamText
 } from '../../../../shared/terminal-stream-protocol'
 import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
+import { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } from './remote-runtime-pty-recovery-state'
 
 describe('remote runtime pty reattach after the bounded recovery window', () => {
   const runtimeCall = vi.fn()
@@ -198,7 +199,7 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
       expect(handleEvents.getWebSessionTerminalHandleSubscriberCountForTests()).toBe(1)
       expect(transport.getRecoveryState?.().phase).not.toBe('disconnected')
 
-      await vi.advanceTimersByTimeAsync(50_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
       // The cutoff must not tear down the accepted-snapshot listener; it is the only path back.
       expect(handleEvents.getWebSessionTerminalHandleSubscriberCountForTests()).toBe(1)
@@ -227,7 +228,7 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
       const { transport, onError } = await attachStalePane()
       const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
 
-      await vi.advanceTimersByTimeAsync(66_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 6_000)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
       const listCallsAtCutoff = hostListCalls
 
@@ -277,7 +278,7 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
       const { transport, onError } = await attachStalePane()
       const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
 
-      await vi.advanceTimersByTimeAsync(66_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 6_000)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
       expect(handleEvents.getWebSessionTerminalHandleSubscriberCountForTests()).toBe(1)
       const listCallsAtCutoff = hostListCalls
@@ -310,7 +311,7 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
       const { retryAllRemoteRuntimePtyRecoveriesNow } =
         await import('./remote-runtime-pty-recovery-state')
 
-      await vi.advanceTimersByTimeAsync(66_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 6_000)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
       const listCallsAtCutoff = hostListCalls
 
@@ -365,7 +366,7 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
         callbacks: { onError: vi.fn() }
       })
 
-      await vi.advanceTimersByTimeAsync(66_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 6_000)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
 
       const callsBeforeRetry = runtimeCall.mock.calls.length
@@ -373,6 +374,62 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
       expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(0)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
       expect(runtimeCall.mock.calls.length).toBe(callsBeforeRetry)
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // #12683: a fatal resubscribe latches the banner via markDisconnected(), but that latch is not
+  // evidence the auto-recovery window ran out, so it must not license reattaching a fenced handle.
+  it('does not reattach a fenced same handle when only a UI latch closed the window', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-tab-1',
+        leafId: 'pane:1',
+        onPtyExit: vi.fn(),
+        onPtyRebind: vi.fn()
+      })
+      transport.attach({
+        existingPtyId: 'remote:env-1@@terminal-stale',
+        cols: 80,
+        rows: 24,
+        callbacks: { onError: vi.fn() }
+      })
+      await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+      emitSnapshot(latestSubscribePayload().streamId, 'live before the drop')
+
+      // The host keeps publishing the same handle, so no replacement can ever arrive.
+      runtimeCall.mockImplementation(async (args: { method: string }) => {
+        if (args.method !== 'session.tabs.list') {
+          return { ok: true, result: {} }
+        }
+        hostListCalls += 1
+        return { ok: true, result: hostSnapshot('terminal-stale', hostListCalls + 1, 'epoch-1') }
+      })
+      // The stream drops and the resubscribe fails fatally with a stale handle: markDisconnected()
+      // latches the banner, then stale routing fences the handle with require-replacement.
+      // Only that one attempt fails, so a later reattach would succeed and be observable.
+      runtimeSubscribe.mockImplementationOnce(async () => {
+        throw new Error('terminal_handle_stale')
+      })
+      subscriptionCallbacks?.onClose?.()
+      await vi.advanceTimersByTimeAsync(16_000)
+      expect(transport.getRecoveryState?.().phase).not.toBe('idle')
+
+      const subscribesBeforeRepublish = subscribedTerminalHandles().length
+      handleEvents.queueAcceptedWebSessionTerminalSnapshot(
+        hostSnapshot('terminal-stale', 9, 'epoch-2'),
+        'env-1'
+      )
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      // The recovery deadline never fired, so the fenced handle stays fenced.
+      expect(subscribedTerminalHandles()).toHaveLength(subscribesBeforeRepublish)
       transport.destroy?.()
     } finally {
       vi.useRealTimers()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-latched-pane-retention.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-latched-pane-retention.test.ts
@@ -5,6 +5,7 @@ import {
   decodeTerminalStreamJson
 } from '../../../../shared/terminal-stream-protocol'
 import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
+import { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } from './remote-runtime-pty-recovery-state'
 
 // Why: the recovery cutoff no longer tears down the retry registry entry or the accepted-snapshot
 // listener, so those two module-global collections are the only places a latched pane can accumulate.
@@ -184,7 +185,7 @@ describe('remote runtime pty latched-pane retention', () => {
 
       for (let cycle = 0; cycle < 20; cycle += 1) {
         const transport = await attachStalePane(cycle)
-        await vi.advanceTimersByTimeAsync(66_000)
+        await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 6_000)
         expect(transport.getRecoveryState?.().phase).toBe('disconnected')
         latched.push(await registries())
         transport.destroy?.()
@@ -208,7 +209,7 @@ describe('remote runtime pty latched-pane retention', () => {
       const settled: { subscribers: number; scheduled: number }[] = []
       for (let cycle = 0; cycle < 20; cycle += 1) {
         const transport = await attachStalePane(cycle)
-        await vi.advanceTimersByTimeAsync(66_000)
+        await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 6_000)
         expect(transport.getRecoveryState?.().phase).toBe('disconnected')
         transport.detach?.()
         await vi.advanceTimersByTimeAsync(1_000)
@@ -227,7 +228,7 @@ describe('remote runtime pty latched-pane retention', () => {
       const transports: Awaited<ReturnType<typeof attachStalePane>>[] = []
       for (let pane = 0; pane < 8; pane += 1) {
         transports.push(await attachStalePane(pane))
-        await vi.advanceTimersByTimeAsync(66_000)
+        await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 6_000)
       }
       // Retention is per live pane, not per timeout: eight latched panes hold eight of each.
       expect(await registries()).toEqual({ subscribers: 8, scheduled: 8 })
@@ -247,7 +248,7 @@ describe('remote runtime pty latched-pane retention', () => {
     vi.useFakeTimers()
     try {
       const transport = await attachStalePane(0)
-      await vi.advanceTimersByTimeAsync(66_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 6_000)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
 
       const baseline = await registries()
@@ -277,7 +278,7 @@ describe('remote runtime pty latched-pane retention', () => {
       const { retryAllRemoteRuntimePtyRecoveriesNow } =
         await import('./remote-runtime-pty-recovery-state')
       const transport = await attachStalePane(0)
-      await vi.advanceTimersByTimeAsync(66_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 6_000)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
 
       const baseline = await registries()
@@ -295,7 +296,7 @@ describe('remote runtime pty latched-pane retention', () => {
         // A second trigger in the same window must find nothing to advance, so an online/resume
         // storm cannot stack fresh recovery epochs on one pane.
         expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(0)
-        await vi.advanceTimersByTimeAsync(66_000)
+        await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 6_000)
         expect(transport.getRecoveryState?.().phase).toBe('disconnected')
         observed.push({ ...(await registries()), timers: vi.getTimerCount(), revived })
       }
@@ -325,7 +326,7 @@ describe('remote runtime pty latched-pane retention', () => {
     try {
       const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
       const transport = await attachStalePane(0)
-      await vi.advanceTimersByTimeAsync(66_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 6_000)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
       const baseline = await registries()
 

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS,
+  REMOTE_RUNTIME_RECOVERY_ATTEMPT_BUDGET_MS,
+  REMOTE_RUNTIME_RECOVERY_DELAYS_MS,
   RemoteRuntimePtyRecoveryState,
   retryAllRemoteRuntimePtyRecoveriesNow
 } from './remote-runtime-pty-recovery-state'
@@ -63,7 +65,7 @@ describe('RemoteRuntimePtyRecoveryState', () => {
     const epoch = state.begin()
     state.schedule(epoch, retry)
 
-    await vi.advanceTimersByTimeAsync(60_000)
+    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
 
     expect(state.currentPhase).toBe('disconnected')
     expect(state.isActive).toBe(false)
@@ -112,7 +114,7 @@ describe('RemoteRuntimePtyRecoveryState', () => {
     const state = new RemoteRuntimePtyRecoveryState()
     const firstEpoch = state.begin()
 
-    await vi.advanceTimersByTimeAsync(60_000)
+    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
     const manualEpoch = state.begin()
 
     expect(manualEpoch).toBe(firstEpoch + 1)
@@ -225,6 +227,70 @@ describe('RemoteRuntimePtyRecoveryState', () => {
     state.cancel()
     expect(state.parkRetryForExternalTrigger(epoch, vi.fn())).toBe(false)
     expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(0)
+    state.dispose()
+  })
+
+  // #11305: the schedule and the deadline lived as two independent literals and drifted apart.
+  it('keeps the backoff schedule inside the auto-recovery budget it arms', () => {
+    const scheduleSumMs = REMOTE_RUNTIME_RECOVERY_DELAYS_MS.reduce(
+      (total, delayMs) => total + delayMs,
+      0
+    )
+
+    expect(scheduleSumMs).toBeLessThanOrEqual(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
+    // Every step also needs room for the attempt it leads into, or the tail is dead code
+    // whenever a half-open link makes each attempt burn its full RPC timeout.
+    expect(
+      scheduleSumMs +
+        REMOTE_RUNTIME_RECOVERY_DELAYS_MS.length * REMOTE_RUNTIME_RECOVERY_ATTEMPT_BUDGET_MS
+    ).toBeLessThanOrEqual(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
+  })
+
+  it('reaches every backoff step when each attempt burns a full RPC timeout', async () => {
+    vi.useFakeTimers()
+    const state = new RemoteRuntimePtyRecoveryState()
+    const attemptStartsMs: number[] = []
+    const epoch = state.begin()
+    const startedAt = Date.now()
+
+    const failSlowly = (currentEpoch: number): void => {
+      attemptStartsMs.push(Date.now() - startedAt)
+      // Silent-drop reconnects do not fail instantly; they time out.
+      setTimeout(() => {
+        if (state.isCurrent(currentEpoch)) {
+          state.schedule(currentEpoch, failSlowly)
+        }
+      }, REMOTE_RUNTIME_RECOVERY_ATTEMPT_BUDGET_MS)
+    }
+    state.schedule(epoch, failSlowly)
+
+    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
+
+    expect(attemptStartsMs.length).toBeGreaterThanOrEqual(REMOTE_RUNTIME_RECOVERY_DELAYS_MS.length)
+    expect(state.currentPhase).toBe('disconnected')
+    state.dispose()
+  })
+
+  // #12683: markDisconnected() is a UI latch, not proof the window ran out.
+  it('only reports the auto-recovery window spent when the deadline actually fired', async () => {
+    vi.useFakeTimers()
+    const state = new RemoteRuntimePtyRecoveryState()
+    const epoch = state.begin()
+    state.schedule(epoch, vi.fn())
+
+    state.markDisconnected()
+    expect(state.currentPhase).toBe('disconnected')
+    expect(state.autoRecoveryDeadlineExpired).toBe(false)
+
+    const secondEpoch = state.begin()
+    state.schedule(secondEpoch, vi.fn())
+    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
+
+    expect(state.currentPhase).toBe('disconnected')
+    expect(state.autoRecoveryDeadlineExpired).toBe(true)
+
+    state.markHealthy()
+    expect(state.autoRecoveryDeadlineExpired).toBe(false)
     state.dispose()
   })
 })

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
@@ -1,5 +1,17 @@
-const RECOVERY_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000] as const
-export const REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS = 60_000
+export const REMOTE_RUNTIME_RECOVERY_DELAYS_MS = [
+  250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000
+] as const
+
+// Why: mirrors DEFAULT_REMOTE_RUNTIME_TIMEOUT_MS in the main-process runtime router; a silently
+// dropped link burns the whole RPC timeout on the attempt each backoff step leads into.
+export const REMOTE_RUNTIME_RECOVERY_ATTEMPT_BUDGET_MS = 15_000
+
+// Why derived, not hand-tuned: a literal deadline drifted below the ladder it arms, making the last
+// backoff steps unreachable dead code (#11305). Loss of contact is never evidence of exit, so the
+// window must outlast the schedule it advertises rather than the schedule being trimmed to fit.
+export const REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS =
+  REMOTE_RUNTIME_RECOVERY_DELAYS_MS.reduce((total, delayMs) => total + delayMs, 0) +
+  REMOTE_RUNTIME_RECOVERY_DELAYS_MS.length * REMOTE_RUNTIME_RECOVERY_ATTEMPT_BUDGET_MS
 
 export type RemoteRuntimePtyRecoveryPhase =
   | 'idle'
@@ -34,6 +46,9 @@ export class RemoteRuntimePtyRecoveryState {
   private deadlineTimer: ReturnType<typeof setTimeout> | null = null
   private pendingRetry: ((epoch: number) => void) | null = null
   private pendingEpoch: number | null = null
+  // Why: only the wall-clock deadline proves the auto-recovery window was actually spent; a UI latch
+  // via markDisconnected() must not forge that evidence (#12683).
+  private deadlineExpired = false
 
   constructor(private readonly onChange?: () => void) {}
 
@@ -51,6 +66,10 @@ export class RemoteRuntimePtyRecoveryState {
 
   get attemptCount(): number {
     return this.attempt
+  }
+
+  get autoRecoveryDeadlineExpired(): boolean {
+    return this.deadlineExpired
   }
 
   begin(): number {
@@ -82,7 +101,10 @@ export class RemoteRuntimePtyRecoveryState {
     }
     this.clearRetryTimer()
     this.phase = 'backoff'
-    const delayMs = RECOVERY_DELAYS_MS[Math.min(this.attempt, RECOVERY_DELAYS_MS.length - 1)]
+    const delayMs =
+      REMOTE_RUNTIME_RECOVERY_DELAYS_MS[
+        Math.min(this.attempt, REMOTE_RUNTIME_RECOVERY_DELAYS_MS.length - 1)
+      ]
     this.attempt += 1
     this.pendingRetry = retry
     this.pendingEpoch = epoch
@@ -152,6 +174,7 @@ export class RemoteRuntimePtyRecoveryState {
     if (this.phase === 'disposed') {
       return
     }
+    this.deadlineExpired = false
     this.clearTimers()
     this.phase = 'idle'
     this.attempt = 0
@@ -175,6 +198,7 @@ export class RemoteRuntimePtyRecoveryState {
     if (this.phase === 'disposed') {
       return
     }
+    this.deadlineExpired = false
     this.epoch += 1
     this.clearTimers()
     this.phase = 'idle'
@@ -191,11 +215,13 @@ export class RemoteRuntimePtyRecoveryState {
 
   private armDeadline(epoch: number): void {
     this.clearDeadlineTimer()
+    this.deadlineExpired = false
     const timer = setTimeout(() => {
       if (this.deadlineTimer !== timer || !this.isCurrent(epoch)) {
         return
       }
       this.deadlineTimer = null
+      this.deadlineExpired = true
       // Why: the cutoff stops self-initiated retries but must keep the pane revivable by online/resume/reconnect.
       this.stopRetryTimer()
       this.phase = 'disconnected'

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
@@ -129,11 +129,22 @@ export class RemoteRuntimePtyRecoveryState {
 
   // Why: a wait that ends with no liveness evidence arms no timer, so park a retry or online/resume/reconnect find nothing to revive.
   parkRetryForExternalTrigger(epoch: number, retry: (epoch: number) => void): boolean {
-    if (!this.isCurrent(epoch) || this.pendingRetry !== null) {
+    return this.isCurrent(epoch) && this.parkRetry(retry)
+  }
+
+  // Why: the deadline can latch while an attempt is still in flight, before schedule() parked anything,
+  // so the late failure has no live epoch to join and must not begin a new one — that would re-arm a
+  // full-length window and the budget would never actually expire.
+  parkRetryAfterDeadline(retry: (epoch: number) => void): boolean {
+    return this.phase === 'disconnected' && this.parkRetry(retry)
+  }
+
+  private parkRetry(retry: (epoch: number) => void): boolean {
+    if (this.pendingRetry !== null) {
       return false
     }
     this.pendingRetry = retry
-    this.pendingEpoch = epoch
+    this.pendingEpoch = this.epoch
     scheduledRecoveries.add(this)
     return true
   }

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-create-outcome-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-create-outcome-recovery.test.ts
@@ -4,6 +4,7 @@ import {
   createRemoteRuntimeTransportMocks,
   type MultiplexSubscriptionCallbacks
 } from './remote-runtime-pty-transport-test-harness'
+import { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } from './remote-runtime-pty-recovery-state'
 
 let subscriptionCallbacks: MultiplexSubscriptionCallbacks = null
 let resolvedPaneHandle = 'terminal-1'
@@ -81,7 +82,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       let createCalls = 0
       runtimeCall.mockImplementation(async (args: { method: string }) => {
         if (args.method === 'status.get') {
-          vi.setSystemTime(startedAt + 59_000)
+          vi.setSystemTime(startedAt + REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS - 1_000)
           return {
             ok: true,
             result: { capabilities: [TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY] }
@@ -163,7 +164,7 @@ describe('createRemoteRuntimePtyTransport', () => {
     transport.destroy?.()
   })
 
-  it('stops unknown terminal-create recovery after one minute and remains manually retryable', async () => {
+  it('stops unknown terminal-create recovery at the cutoff and remains manually retryable', async () => {
     vi.useFakeTimers()
     try {
       let reachable = false
@@ -205,7 +206,7 @@ describe('createRemoteRuntimePtyTransport', () => {
           onRecoveryStateChange: (state) => recoveryStates.push(state.phase)
         }
       })
-      await vi.advanceTimersByTimeAsync(60_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       await connect
       const callsAtCutoff = runtimeCall.mock.calls.length
 
@@ -218,7 +219,7 @@ describe('createRemoteRuntimePtyTransport', () => {
 
       statusTimesOut = true
       expect(transport.retryRecovery?.()).toBe(true)
-      await vi.advanceTimersByTimeAsync(60_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       const callsAtManualCutoff = runtimeCall.mock.calls.length
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
       await vi.advanceTimersByTimeAsync(5 * 60_000)
@@ -278,7 +279,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       })
 
       const connect = transport.connect({ url: '', callbacks: {} })
-      await vi.advanceTimersByTimeAsync(60_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       await connect
 
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-stale-handle-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-stale-handle-recovery.test.ts
@@ -4,6 +4,7 @@ import {
   readyHostSessionInventoryResponse,
   type MultiplexSubscriptionCallbacks
 } from './remote-runtime-pty-transport-test-harness'
+import { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } from './remote-runtime-pty-recovery-state'
 
 let subscriptionCallbacks: MultiplexSubscriptionCallbacks = null
 let resolvedPaneHandle = 'terminal-1'
@@ -72,7 +73,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       expect(hostListCalls).toBe(callsAfterTwoWindows)
       expect(transport.getRecoveryState?.().phase).toBe('recovering')
 
-      await vi.advanceTimersByTimeAsync(9_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
       expect(subscribedTerminalHandles()).toEqual(['terminal-stable'])
       transport.destroy?.()
@@ -180,7 +181,7 @@ describe('createRemoteRuntimePtyTransport', () => {
         'terminal-flapping'
       ])
       expect(transport.isConnected()).toBe(false)
-      await vi.advanceTimersByTimeAsync(45_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
       transport.destroy?.()
     } finally {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-sticky-replacement-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-sticky-replacement-policy.test.ts
@@ -9,6 +9,7 @@ import {
   readyHostSessionInventoryResponse,
   type MultiplexSubscriptionCallbacks
 } from './remote-runtime-pty-transport-test-harness'
+import { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } from './remote-runtime-pty-recovery-state'
 
 let subscriptionCallbacks: MultiplexSubscriptionCallbacks = null
 let resolvedPaneHandle = 'terminal-1'
@@ -160,7 +161,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       expect(transport.isConnected()).toBe(false)
       expect(onPtyExit).not.toHaveBeenCalled()
 
-      await vi.advanceTimersByTimeAsync(44_001)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
       expect(subscribedTerminalHandles()).toHaveLength(3)
     } finally {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-stream-reconnect.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-stream-reconnect.test.ts
@@ -9,6 +9,7 @@ import {
   createRemoteRuntimeTransportMocks,
   type MultiplexSubscriptionCallbacks
 } from './remote-runtime-pty-transport-test-harness'
+import { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } from './remote-runtime-pty-recovery-state'
 
 let subscriptionCallbacks: MultiplexSubscriptionCallbacks = null
 let resolvedPaneHandle = 'terminal-1'
@@ -534,7 +535,7 @@ describe('createRemoteRuntimePtyTransport', () => {
 
       partitioned = true
       callbacksByConnection[0].onClose?.()
-      await vi.advanceTimersByTimeAsync(60_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
 
       const disconnectedState = transport.getRecoveryState?.()
       const callsAtCutoff = runtimeSubscribe.mock.calls.length

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-web-mirror-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-web-mirror-recovery.test.ts
@@ -3,6 +3,10 @@ import {
   createRemoteRuntimeTransportMocks,
   type MultiplexSubscriptionCallbacks
 } from './remote-runtime-pty-transport-test-harness'
+import {
+  REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS,
+  REMOTE_RUNTIME_RECOVERY_DELAYS_MS
+} from './remote-runtime-pty-recovery-state'
 
 let subscriptionCallbacks: MultiplexSubscriptionCallbacks = null
 let resolvedPaneHandle = 'terminal-1'
@@ -140,10 +144,11 @@ describe('createRemoteRuntimePtyTransport', () => {
         existingPtyId: 'remote:env-1@@stale-client-handle',
         callbacks: {}
       })
-      await vi.advanceTimersByTimeAsync(60_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
 
       const attemptsAtCutoff = runtimeSubscribe.mock.calls.length
-      expect(attemptsAtCutoff).toBe(8)
+      // Why: every backoff step must be reachable inside the window it arms (#11305).
+      expect(attemptsAtCutoff).toBeGreaterThanOrEqual(REMOTE_RUNTIME_RECOVERY_DELAYS_MS.length)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
 
       await vi.advanceTimersByTimeAsync(5 * 60_000)
@@ -235,7 +240,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       await vi.advanceTimersByTimeAsync(250)
       expect(activateAttempts).toBe(2)
 
-      await vi.advanceTimersByTimeAsync(60_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
 
       rejectInFlight(
@@ -292,7 +297,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       await vi.advanceTimersByTimeAsync(250)
       expect(runtimeSubscribe).toHaveBeenCalledTimes(1)
 
-      await vi.advanceTimersByTimeAsync(60_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
 
       rejectSubscription(
@@ -349,7 +354,7 @@ describe('createRemoteRuntimePtyTransport', () => {
         expect.objectContaining({ method: 'terminal.resolvePane' })
       )
 
-      await vi.advanceTimersByTimeAsync(60_000)
+      await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
 
       resolveMetadata({

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -90,6 +90,10 @@ const HOST_SESSION_POLL_MAX_MS = 1_000
 const HOST_SESSION_ATTACH_TIMEOUT_MS = 15_000
 const HOST_SESSION_INVENTORY_MAX_WINDOWS_PER_RECOVERY = 2
 const HOST_SESSION_SAME_HANDLE_END_REUSE_LIMIT = 2
+// Why its own constant: this fences how long an end-then-reattach on the same handle still counts as
+// one recovery, which is unrelated to how long auto-recovery keeps retrying. It read the recovery
+// budget before that budget became a derived value, and must not drift with it.
+const HOST_SESSION_SAME_HANDLE_END_REUSE_WINDOW_MS = 60_000
 const MAX_SURFACED_TERMINAL_ERRORS = 8
 const TERMINAL_CREATE_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000] as const
 
@@ -328,7 +332,7 @@ export function createRemoteRuntimePtyTransport(
     if (
       sameHandleEndReuseHandle !== targetHandle ||
       sameHandleEndReuseAttachedAt === null ||
-      Date.now() - sameHandleEndReuseAttachedAt >= REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS
+      Date.now() - sameHandleEndReuseAttachedAt >= HOST_SESSION_SAME_HANDLE_END_REUSE_WINDOW_MS
     ) {
       resetSameHandleEndReuse()
       return 'prefer-replacement'
@@ -897,6 +901,12 @@ export function createRemoteRuntimePtyTransport(
       recovery.markDisconnected()
       return
     }
+    // Why: the last attempt's RPC budget expires at the same instant as the deadline, so a silent drop
+    // rejects after the latch. Beginning a new epoch there re-arms the whole window, so park instead.
+    if (recovery.currentPhase === 'disconnected') {
+      recovery.parkRetryAfterDeadline(retryAfterRecoverableConnectFailure)
+      return
+    }
     const recoveryEpoch = recovery.isActive ? recovery.currentEpoch : recovery.begin()
     if (!recovery.schedule(recoveryEpoch, retryAfterRecoverableConnectFailure)) {
       recovery.markDisconnected()
@@ -1066,6 +1076,8 @@ export function createRemoteRuntimePtyTransport(
       kind === 'agent-session'
         ? agentSessionRequiresHostAuthorityReplay
         : terminalCreateNeedsReconciliation
+    // Why the same budget: this loop calls recovery.begin(), so a shorter local deadline would abandon
+    // the create while the recovery state still reports 'recovering' with nothing in flight.
     let recoveryDeadlineAt: number | null = recovery.isActive
       ? Date.now() + REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS
       : null

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -247,7 +247,9 @@ export function createRemoteRuntimePtyTransport(
       clearPublishedHandleWait()
     }
     if (recovery.currentPhase === 'disconnected') {
-      autoRecoveryWindowSpent = true
+      // Why: only the wall-clock deadline is evidence the window was spent; a UI latch from a fatal
+      // resubscribe must not license reattaching a fenced same handle (#12683).
+      autoRecoveryWindowSpent ||= recovery.autoRecoveryDeadlineExpired
       // Why: cached pixels may remain, but no stream from the exhausted epoch may keep delivering or accepting terminal traffic.
       subscriptionGeneration += 1
       closeMultiplexedStream()
@@ -868,6 +870,37 @@ export function createRemoteRuntimePtyTransport(
       return true
     }
     return false
+  }
+
+  // Why: a recoverable connect failure is unverifiable contact loss, not a dead terminal, so retry
+  // whichever path can still reach the pane instead of latching with nothing armed (#12684).
+  function retryAfterRecoverableConnectFailure(nextEpoch: number): void {
+    if (destroyed || terminalEnded) {
+      return
+    }
+    if (connected && handle) {
+      scheduleResubscribeAfterTransportClose(getRecoveryReplacementPolicy(handle), nextEpoch)
+      return
+    }
+    replayLastTransportEntryPoint()
+  }
+
+  // Why: schedule() both auto-retries inside the window and leaves the retry parked when the deadline
+  // latches, so online/resume and the Reconnect button always find something to fire.
+  function scheduleConnectRetryAfterRecoverableFailure(): void {
+    if (destroyed) {
+      return
+    }
+    // Why: an ambiguous create already owns a reconciliation-gated retry that only Reconnect may
+    // re-enter; auto-replaying here would just re-probe a runtime that cannot reconcile.
+    if (terminalCreateNeedsReconciliation || agentSessionRequiresHostAuthorityReplay) {
+      recovery.markDisconnected()
+      return
+    }
+    const recoveryEpoch = recovery.isActive ? recovery.currentEpoch : recovery.begin()
+    if (!recovery.schedule(recoveryEpoch, retryAfterRecoverableConnectFailure)) {
+      recovery.markDisconnected()
+    }
   }
 
   async function attachHostSessionMirror(
@@ -2314,7 +2347,7 @@ export function createRemoteRuntimePtyTransport(
           } else if (
             isRecoverableRemoteRuntimeConnectionError(toRemoteRuntimeClientErrorLike(error))
           ) {
-            recovery.markDisconnected()
+            scheduleConnectRetryAfterRecoverableFailure()
           } else {
             recovery.cancel()
             emitRecoveryState()
@@ -2615,6 +2648,12 @@ export function createRemoteRuntimePtyTransport(
         recovery.begin()
         void transport.connect(lastConnectOptions)
         return true
+      }
+      // Why: online/resume fires a parked retry; the button must not be weaker than an event (#12684).
+      if (!destroyed && !terminalEnded && recovery.currentPhase === 'disconnected') {
+        if (recovery.retryNow()) {
+          return true
+        }
       }
       if (
         destroyed ||

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15962,7 +15962,8 @@
           "none": "None",
           "search": "Search",
           "showUnreadOnly": "Show unread only",
-          "showChildAgents": "Show child agents"
+          "showChildAgents": "Show child agents",
+          "activityOptions": "Activity options"
         },
         "clearCompleted": {
           "clearedOne": "Cleared 1 completed agent",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3251,7 +3251,7 @@
           "TerminalRemoteRuntimeReconnectBanner": {
             "retryingTitle": "Reconnecting to remote runtime",
             "disconnectedTitle": "Remote runtime disconnected",
-            "retryingBody": "Orca will retry for up to one minute. This terminal will resume if the connection returns.",
+            "retryingBody": "Orca is retrying automatically. This terminal will resume if the connection returns.",
             "disconnectedBody": "Automatic retries stopped. Reconnect to resume this terminal session.",
             "reconnectButton": "Reconnect"
           },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3251,7 +3251,7 @@
           "TerminalRemoteRuntimeReconnectBanner": {
             "retryingTitle": "Reconnecting to remote runtime",
             "disconnectedTitle": "Remote runtime disconnected",
-            "retryingBody": "Orca is retrying automatically. This terminal will resume if the connection returns.",
+            "retryingBody": "Orca will retry for up to one minute. This terminal will resume if the connection returns.",
             "disconnectedBody": "Automatic retries stopped. Reconnect to resume this terminal session.",
             "reconnectButton": "Reconnect"
           },
@@ -17260,7 +17260,9 @@
   "dashboard": {
     "sidebar": {
       "label": "Agents",
-      "dashboardLabel": "Agent Dashboard"
+      "dashboardLabel": "Agent Dashboard",
+      "openActivity": "View activity",
+      "closeActivity": "Turn off activity view"
     }
   },
   "runtimeRpc": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2881,7 +2881,7 @@
           "TerminalRemoteRuntimeReconnectBanner": {
             "retryingTitle": "Reconnecting to remote runtime",
             "disconnectedTitle": "Remote runtime disconnected",
-            "retryingBody": "Orca will retry for up to one minute. This terminal will resume if the connection returns.",
+            "retryingBody": "Orca is retrying automatically. This terminal will resume if the connection returns.",
             "disconnectedBody": "Automatic retries stopped. Reconnect to resume this terminal session.",
             "reconnectButton": "Reconnect"
           }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2881,7 +2881,7 @@
           "TerminalRemoteRuntimeReconnectBanner": {
             "retryingTitle": "リモートランタイムに再接続中",
             "disconnectedTitle": "リモートランタイムが切断されました",
-            "retryingBody": "Orca は最大1分間再試行します。接続が復元されると、このターミナルが再開されます。",
+            "retryingBody": "Orca は自動的に再試行します。接続が復元されると、このターミナルが再開されます。",
             "disconnectedBody": "自動再試行が停止しました。このターミナルセッションを再開するには再接続してください。",
             "reconnectButton": "再接続"
           }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2886,7 +2886,7 @@
           "TerminalRemoteRuntimeReconnectBanner": {
             "retryingTitle": "원격 런타임에 다시 연결 중",
             "disconnectedTitle": "원격 런타임 연결 끊김",
-            "retryingBody": "Orca는 최대 1분간 재시도합니다. 연결이 복원되면 이 터미널이 재개됩니다.",
+            "retryingBody": "Orca가 자동으로 재시도합니다. 연결이 복원되면 이 터미널이 재개됩니다.",
             "disconnectedBody": "자동 재시도가 중지되었습니다. 이 터미널 세션을 재개하려면 다시 연결하세요.",
             "reconnectButton": "다시 연결"
           }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2896,7 +2896,7 @@
           "TerminalRemoteRuntimeReconnectBanner": {
             "retryingTitle": "正在重新连接到远程运行时",
             "disconnectedTitle": "远程运行时已断开连接",
-            "retryingBody": "Orca 将重试最多一分钟。如果连接恢复，此终端将恢复。",
+            "retryingBody": "Orca 正在自动重试。如果连接恢复，此终端将恢复。",
             "disconnectedBody": "自动重试已停止。重新连接以恢复此终端会话。",
             "reconnectButton": "重新连接"
           }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​325 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​294 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​106 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 |

<!-- /orca-pr-loc -->

Three issues in the remote-runtime PTY recovery stack, each with a red-then-green oracle.

## #11305 — the backoff schedule overran its own deadline

`RECOVERY_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000]` sums to **60,750 ms** against a 60,000 ms deadline. Both halves proven by pinning the old literal back in:

```
AssertionError: expected 60750 to be less than or equal to 60000
AssertionError: expected 4 to be greater than or equal to 8
```

The second is the one that matters: driving the ladder with each attempt costing the 15s RPC timeout — the silent-drop case the liveness monitor exists for — only **4** of 8 attempts start inside the window. `[4000, 8000, 15000, 30000]` are unreachable under exactly the condition they were written for.

**Changed the deadline, not the schedule**, and made it derived:

```ts
export const REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS =
  REMOTE_RUNTIME_RECOVERY_DELAYS_MS.reduce((total, delayMs) => total + delayMs, 0) +
  REMOTE_RUNTIME_RECOVERY_DELAYS_MS.length * REMOTE_RUNTIME_RECOVERY_ATTEMPT_BUDGET_MS
```

= 60,750 + 8x15,000 = **180,750 ms**. Trimming the ladder to fit 60s would give up *sooner* on the `unverifiable` silent drop — where [`ssh-execution-boundary.md`](../blob/main/docs/reference/ssh-execution-boundary.md) says loss of contact is not evidence of exit — hardening the "it never recovers" complaint behind #9092/#15141/#14878 rather than fixing it. The two numbers can no longer drift: an invariant test fails if anyone reintroduces a literal that is too small.

**Note the product-visible change:** auto-recovery now runs up to ~3 minutes instead of 1. The banner said *"Orca will retry for up to one minute"*, which this makes false, so it is now duration-free copy (*"Orca is retrying automatically…"*) in the TSX default and all five locales.

## #12683 (P1) — a UI latch spent the recovery window without any deadline firing

Confirmed chain: resubscribe catch (`remote-runtime-pty-transport.ts:1811`) → `markDisconnected()` → the recovery `onChange` at `:250` sets `autoRecoveryWindowSpent = true` **unconditionally** → `handleRemoteTerminalError` → `scheduleResubscribeAfterTransportClose('require-replacement')` → `recovery.begin()` (phase `recovering` does not clear the flag; only `idle` does) → the same-handle republish branch at `:1549` reattaches *because* the flag is set, and that branch does not honour `require-replacement`.

Pre-fix oracle: `expected [ 'terminal-stale', 'terminal-stale' ] to have a length of 1 but got 2` — the fenced handle is re-subscribed with no deadline ever having fired.

Fix: recovery state now tracks `deadlineExpired`, set only inside the deadline timer callback and cleared by `armDeadline`/`markHealthy`/`cancel`; the transport does `autoRecoveryWindowSpent ||= recovery.autoRecoveryDeadlineExpired`. The intentional "handle outlived a genuinely spent window" path still works.

## #12684 — recoverable connect failures latched with no retry

`connect()`'s catch routes `recoverable` to `markDisconnected()` only, which calls `clearTimers()` → `clearRetryTimer()` — nulling `pendingRetry` and removing the pane from `scheduledRecoveries`. No backoff timer, no parked retry, and `retryAllRemoteRuntimePtyRecoveriesNow()` returns 0. `retryRecovery()`'s three branches all miss a thin path (e.g. `resolvePersistedHostPane()` throwing `remote_runtime_unavailable` on a non-web pane), so the Reconnect button returned `false`. Oracles: `expected 'disconnected' to be 'backoff'` and `expected +0 to be 1`.

Fix: a `scheduleConnectRetryAfterRecoverableFailure()` path that gives bounded auto-retry and leaves the retry parked when the deadline latches (the deadline uses `stopRetryTimer`, not `clearRetryTimer`), plus a `recovery.retryNow()` branch so the button is never weaker than the online/resume event.

**Deliberate partial:** the `terminalCreateNeedsReconciliation` / `agentSessionRequiresHostAuthorityReplay` case keeps its existing latch, because `createWithUnknownOutcomeRecovery` already owns a reconciliation-gated retry that `retryRecovery()` re-enters. Auto-replaying there would re-probe a runtime that cannot reconcile, and would regress "does not retry an unknown create outcome against an older runtime".

## Post-review fix — the widened window did not actually bound anything

`scheduleConnectRetryAfterRecoverableFailure()` did `recovery.isActive ? recovery.currentEpoch : recovery.begin()`. `isActive` is only `recovering|backoff`, so once the deadline latched `phase = 'disconnected'` it is false and `begin()` incremented the epoch, reset `attempt = 0`, and armed a **fresh full-length deadline**.

The timing is not marginal. The derived budget is `sum(delays) + 8 x 15_000`, so the 8th attempt's RPC timeout lands at **exactly 180,750 ms — the same instant as the deadline**. In the silent-drop case this PR exists for, the rejection always arrives after the latch and restarts the whole window. On `main` that catch called `markDisconnected()`, which was bounded — so the headline guarantee was a regression this PR introduced.

`remote-runtime-connect-failure-recovery.test.ts` could not see it: `installUnreachableRuntime()` rejects immediately, so every failure lands during a backoff *wait*, never in flight.

Red-then-green with a runtime that burns the whole RPC budget before rejecting, driven through two full windows (361.5 s of fake time):

```
before: AssertionError: expected 'recovering' to be 'disconnected'
after:  Test Files  1 passed (1) / Tests  3 passed (3)
```

Fix: park the retry under the latched epoch instead of beginning a new one (`parkRetryAfterDeadline`, sharing `parkRetry` with `parkRetryForExternalTrigger`). Simply dropping `begin()` is not enough — the deadline can fire *mid-attempt*, before `schedule()` parked anything, so `pendingRetry` is null and the pane is left dead. The same test asserts `retryRecovery()` still returns `true` after the latch; removing only the park call turns that assertion red.

## Blast radius of the derived constant

`REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS` was not private to the auto-recovery deadline. Tripling it 60s -> 180.75s reached three call sites, not one:

1. **Same-handle end-reuse fence** (`remote-runtime-pty-transport.ts`) — how long an end-then-reattach on the same handle still counts as one recovery. Unrelated to how long auto-recovery retries, and it borders the recently merged stale-handle work (#16325, #17429). Now pinned on its own `HOST_SESSION_SAME_HANDLE_END_REUSE_WINDOW_MS = 60_000`, so this behaviour is byte-identical to `main`.
2. **Ambiguous-create reconciliation deadline** (`createWithUnknownOutcomeRecovery`, 3 uses) — **intentionally still tracks the recovery budget**, because that loop calls `recovery.begin()`; a shorter local deadline would abandon the create while the recovery state still reports `recovering` with nothing in flight. This is a second product-visible change: an ambiguous `terminal.create` now reconciles for up to ~3 minutes instead of 1. A comment at the call site records the coupling.

## Verification

```
$ pnpm test .../remote-runtime-pty-recovery-state.test.ts \
            .../remote-runtime-connect-failure-recovery.test.ts \
            .../remote-runtime-pty-deadline-reattach.test.ts
 Test Files  3 passed (3)
      Tests  27 passed (27)

$ pnpm test src/renderer/src/components/terminal-pane/ src/renderer/src/runtime/
 Test Files  577 passed (577)
      Tests  5345 passed (5345)

$ pnpm tc:node                            # EXIT=0
$ pnpm run check:code-quality:changed     # 0 new findings across 15 changed files (all three gates)
```

Baseline: all 9 files later touched were green on `main` first (9 files / 57 tests), so every failure fixed was caused by the widened budget, not pre-existing. Hardcoded 60s / 66s / 44,001ms cutoffs across 6 other test files were replaced with the exported constant so they track the budget instead of re-encoding it.

## Two remaining asymmetries, deliberately not fixed

1. **`markDisconnected()` destroys revivability.** It uses `clearTimers()` → `clearRetryTimer()`, dropping the pane from `scheduledRecoveries`; the deadline path deliberately uses `stopRetryTimer()` so the pane stays revivable. A UI latch is therefore *more* destructive than the timeout it imitates — the same shape as the SSH transport wedge in #17817, where a path suppresses its own recovery machinery and can never come back. Widening it would change #12650's established behaviour, so it wants its own change.
2. **`attachHostSessionMirror` at `:1057`** surfaces "Remote terminal was closed." when `hostHandle` is falsy — but absence from a *client-side inventory snapshot* is not host evidence of exit, and the adjacent `retireRemoteTerminalId(-1)` call sites in the same file explicitly comment that. Very close to what #15141 reports; worth its own issue.

Fixes #11305, #12683, #12684

---

## ELI5

The auto-reconnect for remote terminals promised 8 retry attempts but gave up after 60 seconds — and the attempts themselves added up to 60.75 seconds, so the last four could never run.

## User-facing regression risk

- **The auto-recovery window grew from ~1 minute to ~3 minutes.** A genuinely dead remote now shows 'retrying' for longer before giving up. Deliberate: shortening it instead would give up sooner on exactly the silent-drop case recovery exists for.
- The reconnect banner no longer says 'Orca will retry for up to one minute' — that sentence became false. Copy changed in English and all five locales.
- **An ambiguous `terminal.create` now reconciles for up to ~3 minutes instead of 1**, because that loop shares the recovery budget on purpose (see 'Blast radius' above). The same-handle end-reuse fence was explicitly *not* widened.

