### PR TITLE
perf(worktree): batch remote conflict probes, re-arm the prepared checkout

### DIFF
--- a/src/main/git/exact-ref-probe.ts
+++ b/src/main/git/exact-ref-probe.ts
@@ -19,6 +19,8 @@ export type ExactRefProbeSetResult = {
 type ExactRefPresence = 'present' | 'absent' | 'unknown'
 
 const EXACT_REF_PROBE_CONCURRENCY = 8
+// SHA-1 and SHA-256 repositories both report a full object id here.
+const OBJECT_ID_PATTERN = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/
 
 export function isShowRefNoMatchError(error: unknown): boolean {
   const record = error && typeof error === 'object' ? (error as Record<string, unknown>) : undefined
@@ -125,4 +127,51 @@ export async function probeAnyExactRef(
   const workerCount = Math.min(EXACT_REF_PROBE_CONCURRENCY, uniqueRefs.length)
   await Promise.all(Array.from({ length: workerCount }, () => probeNext()))
   return { found, unknown }
+}
+
+/** Runs Git with a stdin payload. Only hosts that can feed a child's stdin supply one. */
+export type ExactRefProbeStdinExec = (
+  argv: string[],
+  options: ExactRefProbeExecOptions & { stdin: string }
+) => Promise<{ stdout: string }>
+
+/** `cat-file --batch-check` reports every ref from one child, and reports a missing ref as data
+ *  rather than a failed exit — so a batch stays as decidable as a per-ref `show-ref --verify`.
+ *  A repo with many remotes otherwise pays one subprocess per remote on every conflict check. */
+export async function probeAnyExactRefBatched(
+  runGit: ExactRefProbeStdinExec,
+  refs: readonly string[],
+  options: ExactRefProbeExecOptions = {}
+): Promise<{ found: boolean; unknown: boolean }> {
+  const uniqueRefs = [...new Set(refs)]
+  const safeRefs = uniqueRefs.filter((ref) => isSafeGitRefName(ref))
+  if (safeRefs.length === 0) {
+    return { found: false, unknown: uniqueRefs.length > 0 }
+  }
+  let stdout: string
+  try {
+    ;({ stdout } = await runGit(['cat-file', '--batch-check'], {
+      ...options,
+      stdin: `${safeRefs.join('\n')}\n`
+    }))
+  } catch {
+    return { found: false, unknown: true }
+  }
+  const lines = stdout.split('\n').filter((line) => line.trim().length > 0)
+  // One line per input, in order; a short read means the batch never answered for the rest.
+  if (lines.length !== safeRefs.length) {
+    return { found: false, unknown: true }
+  }
+  let unknown = safeRefs.length !== uniqueRefs.length
+  for (const line of lines) {
+    const [head, type] = line.split(' ')
+    if (OBJECT_ID_PATTERN.test(head) && type !== undefined && type !== 'missing') {
+      return { found: true, unknown: false }
+    }
+    if (type !== 'missing') {
+      // `ambiguous`, or a spelling this Git reports differently; neither proves absence.
+      unknown = true
+    }
+  }
+  return { found: false, unknown }
 }

--- a/src/main/git/repo-branch-conflict-real-git.test.ts
+++ b/src/main/git/repo-branch-conflict-real-git.test.ts
@@ -1,0 +1,49 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { getBranchConflictKind } from './repo-branch-conflict'
+
+describe('branch conflict real Git contract', () => {
+  const tempPaths: string[] = []
+
+  afterEach(() => {
+    for (const path of tempPaths.splice(0)) {
+      rmSync(path, { recursive: true, force: true })
+    }
+  })
+
+  it('decides remote conflicts from one batched probe across many remotes', async () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'orca-branch-conflict-'))
+    tempPaths.push(repoPath)
+    const git = (...args: string[]): string =>
+      execFileSync('git', args, { cwd: repoPath, encoding: 'utf8' })
+
+    git('init', '--quiet')
+    git('config', 'user.name', 'Orca Test')
+    git('config', 'user.email', 'orca@example.test')
+    git('config', 'commit.gpgSign', 'false')
+    git('config', 'core.hooksPath', '.git/no-hooks')
+    writeFileSync(join(repoPath, 'fixture.txt'), 'base\n')
+    git('add', 'fixture.txt')
+    git('commit', '--quiet', '-m', 'base')
+    const head = git('rev-parse', 'HEAD').trim()
+
+    // Many remotes is the shape that used to cost one subprocess each.
+    for (let index = 0; index < 12; index += 1) {
+      git('remote', 'add', `remote${index}`, 'https://example.test/repo.git')
+    }
+    git('update-ref', 'refs/remotes/remote7/taken', head)
+
+    await expect(getBranchConflictKind(repoPath, 'taken')).resolves.toBe('remote')
+    await expect(getBranchConflictKind(repoPath, 'free')).resolves.toBeNull()
+    // The allowed base ref is the one remote spelling that is not a conflict.
+    await expect(
+      getBranchConflictKind(repoPath, 'taken', 'refs/remotes/remote7/taken')
+    ).resolves.toBeNull()
+
+    git('branch', 'local-only', head)
+    await expect(getBranchConflictKind(repoPath, 'local-only')).resolves.toBe('local')
+  })
+})

--- a/src/main/git/repo-branch-conflict.test.ts
+++ b/src/main/git/repo-branch-conflict.test.ts
@@ -134,3 +134,123 @@ describe('getBranchConflictKindViaExec', () => {
     expect(exec).not.toHaveBeenCalled()
   })
 })
+
+describe('getBranchConflictKindViaExec batched remote probe', () => {
+  function remoteNames(count: number): string {
+    return `${Array.from({ length: count }, (_, index) => `remote${index}`).join('\n')}\n`
+  }
+
+  function baseExec(calls: string[][]): (argv: string[]) => Promise<{ stdout: string }> {
+    return async (argv) => {
+      calls.push(argv)
+      if (argv[0] === 'rev-parse') {
+        throw new Error('local branch is absent')
+      }
+      if (argv[0] === 'remote') {
+        return { stdout: remoteNames(3) }
+      }
+      throw new Error(`unexpected git command: ${argv.join(' ')}`)
+    }
+  }
+
+  it('asks one batched child instead of one probe per remote', async () => {
+    const calls: string[][] = []
+    const stdinPayloads: (string | undefined)[] = []
+    const exec = baseExec(calls)
+    const batched = async (
+      argv: string[],
+      options: { stdin: string }
+    ): Promise<{ stdout: string }> => {
+      calls.push(argv)
+      stdinPayloads.push(options.stdin)
+      return {
+        stdout: [
+          'refs/remotes/remote0/feature missing',
+          'refs/remotes/remote1/feature missing',
+          'refs/remotes/remote2/feature missing'
+        ].join('\n')
+      }
+    }
+
+    await expect(
+      getBranchConflictKindViaExec(exec, 'feature', undefined, {}, batched)
+    ).resolves.toBeNull()
+    expect(calls).toEqual([
+      ['rev-parse', '--verify', 'refs/heads/feature'],
+      ['remote'],
+      ['cat-file', '--batch-check']
+    ])
+    expect(stdinPayloads).toEqual([
+      'refs/remotes/remote0/feature\nrefs/remotes/remote1/feature\nrefs/remotes/remote2/feature\n'
+    ])
+  })
+
+  it('reports a remote conflict from the batched answer', async () => {
+    const calls: string[][] = []
+    const exec = baseExec(calls)
+    const batched = async (): Promise<{ stdout: string }> => ({
+      stdout: [
+        'refs/remotes/remote0/feature missing',
+        `${'a'.repeat(40)} commit 214`,
+        'refs/remotes/remote2/feature missing'
+      ].join('\n')
+    })
+
+    await expect(
+      getBranchConflictKindViaExec(exec, 'feature', undefined, {}, batched)
+    ).resolves.toBe('remote')
+  })
+
+  it('falls back to per-ref probes when the batch cannot answer', async () => {
+    const calls: string[][] = []
+    const exec = async (argv: string[]): Promise<{ stdout: string }> => {
+      calls.push(argv)
+      if (argv[0] === 'rev-parse') {
+        throw new Error('local branch is absent')
+      }
+      if (argv[0] === 'remote') {
+        return { stdout: remoteNames(3) }
+      }
+      if (argv[0] === 'show-ref') {
+        if (argv[4] === 'refs/remotes/remote1/feature') {
+          return { stdout: 'abc refs/remotes/remote1/feature\n' }
+        }
+        throw Object.assign(new Error('missing'), { code: 1, stderr: '' })
+      }
+      throw new Error(`unexpected git command: ${argv.join(' ')}`)
+    }
+    const batched = async (): Promise<{ stdout: string }> => {
+      throw new Error('cat-file is unavailable')
+    }
+
+    await expect(
+      getBranchConflictKindViaExec(exec, 'feature', undefined, {}, batched)
+    ).resolves.toBe('remote')
+    expect(calls.filter((argv) => argv[0] === 'show-ref')).toHaveLength(3)
+  })
+
+  it('treats a short batch read as undecided rather than as absence', async () => {
+    const calls: string[][] = []
+    const exec = async (argv: string[]): Promise<{ stdout: string }> => {
+      calls.push(argv)
+      if (argv[0] === 'rev-parse') {
+        throw new Error('local branch is absent')
+      }
+      if (argv[0] === 'remote') {
+        return { stdout: remoteNames(3) }
+      }
+      if (argv[0] === 'show-ref') {
+        throw Object.assign(new Error('missing'), { code: 1, stderr: '' })
+      }
+      throw new Error(`unexpected git command: ${argv.join(' ')}`)
+    }
+    const batched = async (): Promise<{ stdout: string }> => ({
+      stdout: 'refs/remotes/remote0/feature missing'
+    })
+
+    await expect(
+      getBranchConflictKindViaExec(exec, 'feature', undefined, {}, batched)
+    ).resolves.toBeNull()
+    expect(calls.filter((argv) => argv[0] === 'show-ref')).toHaveLength(3)
+  })
+})

--- a/src/main/git/repo-branch-conflict.ts
+++ b/src/main/git/repo-branch-conflict.ts
@@ -90,12 +90,10 @@ async function probeAnyRemoteConflictRef(
   probeOptions: ExactRefProbeExecOptions
 ): Promise<{ found: boolean }> {
   if (batchedExec) {
+    // A present ref is always decisive, so `found` never survives with `unknown` set.
     const batched = await probeAnyExactRefBatched(batchedExec, candidateRefs, probeOptions)
     if (!batched.unknown) {
       return { found: batched.found }
-    }
-    if (batched.found) {
-      return { found: true }
     }
   }
   return probeAnyExactRef(exec, candidateRefs, probeOptions)

--- a/src/main/git/repo-branch-conflict.ts
+++ b/src/main/git/repo-branch-conflict.ts
@@ -4,8 +4,10 @@ import { gitExecFileAsync } from './runner'
 import { isSafeGitRefName } from '../../shared/git-status-upstream-ref'
 import {
   probeAnyExactRef,
+  probeAnyExactRefBatched,
   type ExactRefProbeExec,
-  type ExactRefProbeExecOptions
+  type ExactRefProbeExecOptions,
+  type ExactRefProbeStdinExec
 } from './exact-ref-probe'
 
 export type BranchConflictKind = 'local' | 'remote'
@@ -79,12 +81,33 @@ function buildRemoteBranchConflictRefs(
   return [...refs]
 }
 
+/** One batched child answers for every remote; the per-ref probes only run when the host cannot
+ *  feed stdin, or when the batch came back undecided. */
+async function probeAnyRemoteConflictRef(
+  exec: ExactRefProbeExec,
+  batchedExec: ExactRefProbeStdinExec | undefined,
+  candidateRefs: readonly string[],
+  probeOptions: ExactRefProbeExecOptions
+): Promise<{ found: boolean }> {
+  if (batchedExec) {
+    const batched = await probeAnyExactRefBatched(batchedExec, candidateRefs, probeOptions)
+    if (!batched.unknown) {
+      return { found: batched.found }
+    }
+    if (batched.found) {
+      return { found: true }
+    }
+  }
+  return probeAnyExactRef(exec, candidateRefs, probeOptions)
+}
+
 /** Run branch-conflict policy through the host that owns Git execution. */
 export async function getBranchConflictKindViaExec(
   exec: ExactRefProbeExec,
   branchName: string,
   allowedBaseRef?: string,
-  options: ExactRefProbeExecOptions = {}
+  options: ExactRefProbeExecOptions = {},
+  batchedExec?: ExactRefProbeStdinExec
 ): Promise<BranchConflictKind | null> {
   if (!canQueryRemoteBranchName(branchName)) {
     return null
@@ -104,7 +127,12 @@ export async function getBranchConflictKindViaExec(
       return null
     }
 
-    const { found: hasRemoteConflict } = await probeAnyExactRef(exec, candidateRefs, probeOptions)
+    const { found: hasRemoteConflict } = await probeAnyRemoteConflictRef(
+      exec,
+      batchedExec,
+      candidateRefs,
+      probeOptions
+    )
 
     return hasRemoteConflict ? 'remote' : null
   } catch {
@@ -119,15 +147,22 @@ export function getBranchConflictKind(
   options: LocalGitExecOptions = {}
 ): Promise<BranchConflictKind | null> {
   const execOptions = gitExecOptions(path, options)
+  const runLocalGit = (
+    argv: string[],
+    commandOptions?: ExactRefProbeExecOptions & { stdin?: string }
+  ): Promise<{ stdout: string }> =>
+    gitExecFileAsync(argv, {
+      ...execOptions,
+      ...(commandOptions?.maxBuffer === undefined ? {} : { maxBuffer: commandOptions.maxBuffer }),
+      ...(commandOptions?.timeoutMs === undefined ? {} : { timeout: commandOptions.timeoutMs }),
+      ...(commandOptions?.stdin === undefined ? {} : { stdin: commandOptions.stdin })
+    })
   return getBranchConflictKindViaExec(
-    (argv, commandOptions) =>
-      gitExecFileAsync(argv, {
-        ...execOptions,
-        ...(commandOptions?.maxBuffer === undefined ? {} : { maxBuffer: commandOptions.maxBuffer }),
-        ...(commandOptions?.timeoutMs === undefined ? {} : { timeout: commandOptions.timeoutMs })
-      }),
+    runLocalGit,
     branchName,
-    allowedBaseRef
+    allowedBaseRef,
+    {},
+    (argv, commandOptions) => runLocalGit(argv, commandOptions)
   )
 }
 

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -2189,124 +2189,130 @@ export async function createLocalWorktree(
   let lastExistingReviewNumber: number | null = null
   const shouldRetireGeneratedName =
     args.nameWasGenerated === true && isGeneratedWorktreeCreateName(sanitizedName)
-  const retiredNameRegistry = shouldRetireGeneratedName
-    ? await getRetiredNameRegistryForRepo(store, repo, store.getRepos(), settings)
-    : null
-  const isRetiredName = retiredNameRegistry ? createRetiredNameLookup(retiredNameRegistry) : null
-  // Why: a create-from-review branch override may already exist locally; suffix both branch and path instead of blocking the user.
-  for (let suffix = 1, attempts = 0; attempts < WORKTREE_CREATE_MAX_SUFFIX_ATTEMPTS; suffix += 1) {
-    effectiveSanitizedName = shouldRetireGeneratedName
-      ? getGeneratedWorktreeCreateCandidate(
-          sanitizedName,
-          suffix,
-          retiredNameRegistry?.exhaustedTiers
-        )
-      : getWorktreeCreateCandidate(sanitizedName, suffix)
-    effectiveRequestedName = shouldRetireGeneratedName
-      ? effectiveSanitizedName
-      : requestedName.trim()
-        ? getWorktreeCreateCandidate(requestedName, suffix)
-        : effectiveSanitizedName
-    if (isRetiredName?.(effectiveSanitizedName)) {
-      continue
-    }
-    attempts += 1
-    lastExistingReviewNumber = null
+  await timing.time('resolve_name', async () => {
+    const retiredNameRegistry = shouldRetireGeneratedName
+      ? await getRetiredNameRegistryForRepo(store, repo, store.getRepos(), settings)
+      : null
+    const isRetiredName = retiredNameRegistry ? createRetiredNameLookup(retiredNameRegistry) : null
+    // Why: a create-from-review branch override may already exist locally; suffix both branch and path instead of blocking the user.
+    for (
+      let suffix = 1, attempts = 0;
+      attempts < WORKTREE_CREATE_MAX_SUFFIX_ATTEMPTS;
+      suffix += 1
+    ) {
+      effectiveSanitizedName = shouldRetireGeneratedName
+        ? getGeneratedWorktreeCreateCandidate(
+            sanitizedName,
+            suffix,
+            retiredNameRegistry?.exhaustedTiers
+          )
+        : getWorktreeCreateCandidate(sanitizedName, suffix)
+      effectiveRequestedName = shouldRetireGeneratedName
+        ? effectiveSanitizedName
+        : requestedName.trim()
+          ? getWorktreeCreateCandidate(requestedName, suffix)
+          : effectiveSanitizedName
+      if (isRetiredName?.(effectiveSanitizedName)) {
+        continue
+      }
+      attempts += 1
+      lastExistingReviewNumber = null
 
-    branchName = await resolveCreateBranchName(
-      repo.path,
-      selectedExistingLocalBranchName
-        ? selectedExistingLocalBranchName
-        : getBranchNameOverrideCandidate(args.branchNameOverride, suffix),
-      effectiveSanitizedName,
-      settings,
-      username,
-      localWorktreeGitOptions
-    )
-    checkoutExistingBranch = await canCheckoutExistingLocalBranch(
-      repo.path,
-      branchName,
-      baseBranch,
-      localWorktreeGitOptions
-    )
-    if (checkoutExistingBranch && !selectedExistingLocalBranchName) {
-      // Why: suffix retries may need a new path, but an existing-branch checkout must keep the user-selected branch, not a sibling.
-      selectedExistingLocalBranchName = branchName
-    }
-    lastBranchConflictKind = checkoutExistingBranch
-      ? null
-      : await getBranchConflictKind(repo.path, branchName, baseBranch, localWorktreeGitOptions)
-    const allowedPushTargetRemoteConflict =
-      lastBranchConflictKind &&
-      isAllowedPushTargetRemoteConflict(lastBranchConflictKind, branchName, args)
-    if (lastBranchConflictKind) {
-      if (allowedPushTargetRemoteConflict) {
-        lastExistingPR = null
-        let lookupFailed = false
-        const selectedReview = getSelectedReviewBranch(args)
-        if (selectedReview?.provider === 'github') {
-          try {
-            lastExistingPR = await getLocalGitHubPrForBranch(
-              repo.path,
-              branchName,
-              localWorktreeGitOptions
-            )
-          } catch {
-            lookupFailed = true
-          }
-          if (!lookupFailed && isMatchingSelectedGitHubPr(lastExistingPR, args, branchName)) {
-            lastBranchConflictKind = null
-          } else if (lastExistingPR) {
-            lastExistingReviewNumber = lastExistingPR.number
-          }
-        } else if (selectedReview) {
-          let hostedReview: Awaited<ReturnType<typeof getSelectedHostedReviewForBranch>> = null
-          try {
-            hostedReview = await getSelectedHostedReviewForBranch(repo, branchName, args)
-          } catch {
-            lookupFailed = true
-          }
-          if (!lookupFailed && hostedReview?.matchesSelected) {
-            lastBranchConflictKind = null
-          } else if (hostedReview) {
-            lastExistingReviewNumber = hostedReview.number
+      branchName = await resolveCreateBranchName(
+        repo.path,
+        selectedExistingLocalBranchName
+          ? selectedExistingLocalBranchName
+          : getBranchNameOverrideCandidate(args.branchNameOverride, suffix),
+        effectiveSanitizedName,
+        settings,
+        username,
+        localWorktreeGitOptions
+      )
+      checkoutExistingBranch = await canCheckoutExistingLocalBranch(
+        repo.path,
+        branchName,
+        baseBranch,
+        localWorktreeGitOptions
+      )
+      if (checkoutExistingBranch && !selectedExistingLocalBranchName) {
+        // Why: suffix retries may need a new path, but an existing-branch checkout must keep the user-selected branch, not a sibling.
+        selectedExistingLocalBranchName = branchName
+      }
+      lastBranchConflictKind = checkoutExistingBranch
+        ? null
+        : await getBranchConflictKind(repo.path, branchName, baseBranch, localWorktreeGitOptions)
+      const allowedPushTargetRemoteConflict =
+        lastBranchConflictKind &&
+        isAllowedPushTargetRemoteConflict(lastBranchConflictKind, branchName, args)
+      if (lastBranchConflictKind) {
+        if (allowedPushTargetRemoteConflict) {
+          lastExistingPR = null
+          let lookupFailed = false
+          const selectedReview = getSelectedReviewBranch(args)
+          if (selectedReview?.provider === 'github') {
+            try {
+              lastExistingPR = await getLocalGitHubPrForBranch(
+                repo.path,
+                branchName,
+                localWorktreeGitOptions
+              )
+            } catch {
+              lookupFailed = true
+            }
+            if (!lookupFailed && isMatchingSelectedGitHubPr(lastExistingPR, args, branchName)) {
+              lastBranchConflictKind = null
+            } else if (lastExistingPR) {
+              lastExistingReviewNumber = lastExistingPR.number
+            }
+          } else if (selectedReview) {
+            let hostedReview: Awaited<ReturnType<typeof getSelectedHostedReviewForBranch>> = null
+            try {
+              hostedReview = await getSelectedHostedReviewForBranch(repo, branchName, args)
+            } catch {
+              lookupFailed = true
+            }
+            if (!lookupFailed && hostedReview?.matchesSelected) {
+              lastBranchConflictKind = null
+            } else if (hostedReview) {
+              lastExistingReviewNumber = hostedReview.number
+            }
           }
         }
       }
-    }
-    if (lastBranchConflictKind) {
-      continue
-    }
-
-    // Why: gh pr list is a ~1–3s network call; only probe PR conflicts after a branch collision (suffix > 1) so the common no-collision path skips it.
-    if (suffix > 1 && !checkoutExistingBranch) {
-      lastExistingPR = null
-      try {
-        lastExistingPR = await getLocalGitHubPrForBranch(
-          repo.path,
-          branchName,
-          localWorktreeGitOptions
-        )
-      } catch {
-        // GitHub API may be unreachable, rate-limited, or token missing
-      }
-      if (lastExistingPR && !isMatchingSelectedGitHubPr(lastExistingPR, args, branchName)) {
-        lastExistingReviewNumber = lastExistingPR.number
+      if (lastBranchConflictKind) {
         continue
       }
-    }
 
-    worktreePath = ensurePathWithinWorkspace(
-      computeWorktreePath(effectiveSanitizedName, repo.path, worktreePathSettings),
-      workspaceRoot
-    )
-    if (existsSync(worktreePath)) {
-      continue
-    }
+      // Why: gh pr list is a ~1–3s network call; only probe PR conflicts after a branch collision (suffix > 1) so the common no-collision path skips it.
+      if (suffix > 1 && !checkoutExistingBranch) {
+        lastExistingPR = null
+        try {
+          lastExistingPR = await getLocalGitHubPrForBranch(
+            repo.path,
+            branchName,
+            localWorktreeGitOptions
+          )
+        } catch {
+          // GitHub API may be unreachable, rate-limited, or token missing
+        }
+        if (lastExistingPR && !isMatchingSelectedGitHubPr(lastExistingPR, args, branchName)) {
+          lastExistingReviewNumber = lastExistingPR.number
+          continue
+        }
+      }
 
-    resolved = true
-    break
-  }
+      worktreePath = ensurePathWithinWorkspace(
+        computeWorktreePath(effectiveSanitizedName, repo.path, worktreePathSettings),
+        workspaceRoot
+      )
+      if (existsSync(worktreePath)) {
+        continue
+      }
+
+      resolved = true
+      break
+    }
+  })
 
   if (!resolved) {
     // Why: every suffix collided; reject with a specific reason so the user sees why create failed instead of a generic error or hung spinner.
@@ -2361,14 +2367,17 @@ export async function createLocalWorktree(
   emitCreateWorktreeProgress(mainWindow, 'creating', args.creationId)
 
   let preparedPushTarget: GitPushTarget | undefined
-  if (args.pushTarget) {
+  const requestedPushTarget = args.pushTarget
+  if (requestedPushTarget) {
     // Why: validate/fetch the contributor remote before create so a failure doesn't leave a half-created worktree with conflicts on retry.
-    preparedPushTarget = await prepareWorktreePushTarget(
-      repo.path,
-      args.pushTarget,
-      store,
-      repo.id,
-      localWorktreeGitOptions
+    preparedPushTarget = await timing.time('prepare_push_target', () =>
+      prepareWorktreePushTarget(
+        repo.path,
+        requestedPushTarget,
+        store,
+        repo.id,
+        localWorktreeGitOptions
+      )
     )
   }
 

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -2316,9 +2316,12 @@ export async function createLocalWorktree(
 
   if (!resolved) {
     // Why: every suffix collided; reject with a specific reason so the user sees why create failed instead of a generic error or hung spinner.
-    if (lastExistingReviewNumber !== null) {
+    // Read once and format eagerly: the suffix loop assigns this from a callback, so the `let`'s
+    // narrowing does not reach the message.
+    const existingReviewNumber = lastExistingReviewNumber
+    if (existingReviewNumber !== null) {
       throw new Error(
-        `Branch "${branchName}" already has PR #${lastExistingReviewNumber}. Pick a different ${branchConflictSubject}.`
+        `Branch "${branchName}" already has PR #${String(existingReviewNumber)}. Pick a different ${branchConflictSubject}.`
       )
     }
     if (lastBranchConflictKind) {

--- a/src/main/ipc/worktrees/create/register-worktree-create-handlers.ts
+++ b/src/main/ipc/worktrees/create/register-worktree-create-handlers.ts
@@ -4,7 +4,10 @@ import type {
   CreateWorktreeResult,
   AdoptProvisionedRootArgs
 } from '../../../../shared/worktree/create-types'
-import { withWorktreeSpan } from '../../../observability/instrumentation'
+import {
+  addWorktreeCreatePhaseAttributes,
+  withWorktreeSpan
+} from '../../../observability/instrumentation'
 import { workspaceSourceSchema } from '../../../../shared/telemetry-events'
 import type { WorkspaceSource } from '../../../../shared/telemetry-events'
 import {
@@ -36,7 +39,7 @@ export function registerWorktreeCreateHandlers(context: WorktreeIpcContext): voi
     async (_event, rawArgs: CreateWorktreeArgs): Promise<CreateWorktreeResult> => {
       const args = normalizeLinkedWorkItemFields(rawArgs)
       // Why span here: parent the child git spans for the trace tree; don't attach branch name/remote URL (user content) — repo ID is the safer correlator.
-      return withWorktreeSpan({ stage: 'create' }, async () => {
+      return withWorktreeSpan({ stage: 'create' }, async (span) => {
         const repo = store.getRepo(args.repoId)
         if (!repo) {
           throw new Error(`Repo not found: ${args.repoId}`)
@@ -74,6 +77,9 @@ export function registerWorktreeCreateHandlers(context: WorktreeIpcContext): voi
           throw error
         }
         finishAutomationWorkspaceProvenanceRequest(args.automationProvenanceRequest)
+        if (result.timing) {
+          addWorktreeCreatePhaseAttributes(span, result.timing)
+        }
 
         // Why: reaching here means create succeeded (helpers throw); skip a separate workspace_initialized (telemetry-plan.md§Deferred); never send the branch name.
         track('workspace_created', {

--- a/src/main/observability/instrumentation.test.ts
+++ b/src/main/observability/instrumentation.test.ts
@@ -3,6 +3,7 @@ import { _resetTracerForTests, setActiveSink, type TracerSink } from './tracer'
 import {
   _gitSpanSamplingBucketCountForTests,
   _resetGitSpanSamplingForTests,
+  addWorktreeCreatePhaseAttributes,
   withGitSpan
 } from './instrumentation'
 
@@ -165,5 +166,52 @@ describe('withGitSpan sampling', () => {
     await runGitSpan({ args: ['status'], cwd: '/fresh-repo' }, 5)
 
     expect(_gitSpanSamplingBucketCountForTests()).toBe(1)
+  })
+})
+
+describe('addWorktreeCreatePhaseAttributes', () => {
+  function capture(): {
+    attributes: Record<string, unknown>
+    span: Parameters<typeof addWorktreeCreatePhaseAttributes>[0]
+  } {
+    const attributes: Record<string, unknown> = {}
+    const span = {
+      setAttribute: (key: string, value: unknown) => {
+        attributes[key] = value
+      }
+    } as unknown as Parameters<typeof addWorktreeCreatePhaseAttributes>[0]
+    return { attributes, span }
+  }
+
+  it('counts concurrent phases once when measuring unattributed time', () => {
+    const { attributes, span } = capture()
+    // Create resolves shared directories and .worktreeinclude concurrently; summing their
+    // durations would claim 400ms of coverage for a 200ms window.
+    addWorktreeCreatePhaseAttributes(span, {
+      totalDurationMs: 1000,
+      phases: [
+        { phase: 'resolve_shared_directories', startedAtMs: 100, durationMs: 200 },
+        { phase: 'resolve_worktreeinclude', startedAtMs: 150, durationMs: 150 }
+      ]
+    })
+
+    expect(attributes['worktree.create.phase.resolve_shared_directories_ms']).toBe(200)
+    expect(attributes['worktree.create.phase.resolve_worktreeinclude_ms']).toBe(150)
+    // Covered wall clock is 100..300, so 800ms is genuinely unaccounted for.
+    expect(attributes['worktree.create.unattributed_ms']).toBe(800)
+  })
+
+  it('sums disjoint phases and never reports negative unattributed time', () => {
+    const { attributes, span } = capture()
+    addWorktreeCreatePhaseAttributes(span, {
+      totalDurationMs: 500,
+      phases: [
+        { phase: 'resolve_name', startedAtMs: 0, durationMs: 100 },
+        { phase: 'git_worktree_add', startedAtMs: 300, durationMs: 200 }
+      ]
+    })
+
+    expect(attributes['worktree.create.total_ms']).toBe(500)
+    expect(attributes['worktree.create.unattributed_ms']).toBe(200)
   })
 })

--- a/src/main/observability/instrumentation.ts
+++ b/src/main/observability/instrumentation.ts
@@ -202,10 +202,11 @@ export type WorktreeSpanArgs = {
   readonly path?: string
 }
 
-/** Wrap a worktree-setup phase in a `worktree.<stage>` span. */
+/** Wrap a worktree-setup phase in a `worktree.<stage>` span. The callback receives the span so a
+ *  create can attach its own phase breakdown; the git children alone leave the waits invisible. */
 export async function withWorktreeSpan<T>(
   meta: WorktreeSpanArgs,
-  fn: () => Promise<T>
+  fn: (span: ActiveSpan) => Promise<T>
 ): Promise<T> {
   return withSpan(
     `worktree.${meta.stage}`,
@@ -214,9 +215,29 @@ export async function withWorktreeSpan<T>(
       if (meta.path) {
         span.setAttribute('worktree.path', meta.path)
       }
-      return await fn()
+      return await fn(span)
     },
     { attributes: { kind: 'worktree' } }
+  )
+}
+
+/** Records a create's phase breakdown on its span. Phase names are already a closed vocabulary in
+ *  the recorder, so they are safe to key on; nothing here carries a branch name or a path. */
+export function addWorktreeCreatePhaseAttributes(
+  span: ActiveSpan,
+  timing: { totalDurationMs: number; phases: readonly { phase: string; durationMs: number }[] }
+): void {
+  span.setAttribute('worktree.create.total_ms', Math.round(timing.totalDurationMs))
+  let measured = 0
+  for (const phase of timing.phases) {
+    measured += phase.durationMs
+    span.setAttribute(`worktree.create.phase.${phase.phase}_ms`, Math.round(phase.durationMs))
+  }
+  // What the phases do not cover is the number that matters when create feels slow for no visible
+  // reason, so name it rather than leaving it to subtraction.
+  span.setAttribute(
+    'worktree.create.unattributed_ms',
+    Math.max(0, Math.round(timing.totalDurationMs - measured))
   )
 }
 

--- a/src/main/observability/instrumentation.ts
+++ b/src/main/observability/instrumentation.ts
@@ -221,23 +221,55 @@ export async function withWorktreeSpan<T>(
   )
 }
 
+type WorktreeCreatePhaseTiming = {
+  readonly phase: string
+  readonly startedAtMs: number
+  readonly durationMs: number
+}
+
+/** Wall-clock span covered by at least one phase. Create runs some phases concurrently, so summing
+ *  durations double-counts and would report overlap as coverage the phases never had. */
+function measuredWallClockMs(phases: readonly WorktreePhaseInterval[]): number {
+  const intervals = [...phases]
+    .map((phase) => [phase.startedAtMs, phase.startedAtMs + phase.durationMs] as const)
+    .sort((left, right) => left[0] - right[0])
+  let covered = 0
+  let openedAt: number | null = null
+  let closesAt = 0
+  for (const [start, end] of intervals) {
+    if (openedAt === null) {
+      openedAt = start
+      closesAt = end
+      continue
+    }
+    if (start <= closesAt) {
+      closesAt = Math.max(closesAt, end)
+      continue
+    }
+    covered += closesAt - openedAt
+    openedAt = start
+    closesAt = end
+  }
+  return openedAt === null ? 0 : covered + (closesAt - openedAt)
+}
+
+type WorktreePhaseInterval = Pick<WorktreeCreatePhaseTiming, 'startedAtMs' | 'durationMs'>
+
 /** Records a create's phase breakdown on its span. Phase names are already a closed vocabulary in
  *  the recorder, so they are safe to key on; nothing here carries a branch name or a path. */
 export function addWorktreeCreatePhaseAttributes(
   span: ActiveSpan,
-  timing: { totalDurationMs: number; phases: readonly { phase: string; durationMs: number }[] }
+  timing: { totalDurationMs: number; phases: readonly WorktreeCreatePhaseTiming[] }
 ): void {
   span.setAttribute('worktree.create.total_ms', Math.round(timing.totalDurationMs))
-  let measured = 0
   for (const phase of timing.phases) {
-    measured += phase.durationMs
     span.setAttribute(`worktree.create.phase.${phase.phase}_ms`, Math.round(phase.durationMs))
   }
   // What the phases do not cover is the number that matters when create feels slow for no visible
   // reason, so name it rather than leaving it to subtraction.
   span.setAttribute(
     'worktree.create.unattributed_ms',
-    Math.max(0, Math.round(timing.totalDurationMs - measured))
+    Math.max(0, Math.round(timing.totalDurationMs - measuredWallClockMs(timing.phases)))
   )
 }
 

--- a/src/main/worktree-create-preparation-burst.ts
+++ b/src/main/worktree-create-preparation-burst.ts
@@ -1,0 +1,21 @@
+import { setBoundedMapEntry } from './runtime/runtime-async-boundaries'
+
+/** Two creates this close together mean more are likely; an isolated create earns no replacement. */
+export const WORKTREE_CREATE_BURST_MS = 5 * 60_000
+const WORKTREE_CREATE_PREPARATION_CONSUME_MAX = 64
+
+/** When each preparation key was last consumed, so a burst can be told from an isolated create. */
+const lastConsumedAt = new Map<string, number>()
+
+/** Records this consume and reports whether it continues a burst. A replacement checkout costs a
+ *  full tree and holds disk until its TTL, so only a user who is already creating repeatedly earns
+ *  one; the first create of a session pays nothing for a spare nobody claims. */
+export function recordPreparationConsume(key: string, now = Date.now()): boolean {
+  const previous = lastConsumedAt.get(key)
+  setBoundedMapEntry(lastConsumedAt, key, now, WORKTREE_CREATE_PREPARATION_CONSUME_MAX)
+  return previous !== undefined && now - previous <= WORKTREE_CREATE_BURST_MS
+}
+
+export function resetPreparationConsumeHistoryForTests(): void {
+  lastConsumedAt.clear()
+}

--- a/src/main/worktree-create-preparation-stale-cleanup.ts
+++ b/src/main/worktree-create-preparation-stale-cleanup.ts
@@ -1,0 +1,79 @@
+import {
+  isWorktreeCreatePreparation,
+  parseWorktreePreparationOwnerPid,
+  parseWorktreePreparationPathOwnerPid
+} from '../shared/worktree/create-preparation'
+import type { AddWorktreeOptions } from './git/worktree'
+import { listWorktreeGraph } from './git/worktree'
+import { discardPreparedWorktree, unlockPreparedWorktree } from './git/worktree-create-preparation'
+import { retryPendingPreparationDiscards } from './worktree-preparation-discard-retry'
+
+const STALE_PREPARATION_CLEANUP_CONCURRENCY = 4
+
+const staleCleanupInFlight = new Map<string, Promise<void>>()
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+/** Reclaims preparations a crashed process left registered. Single-flighted per host key so a burst
+ *  of arming calls shares one worktree listing. */
+export async function cleanupStalePreparations(
+  cleanupKey: string,
+  repoPath: string,
+  options: AddWorktreeOptions
+): Promise<void> {
+  const existing = staleCleanupInFlight.get(cleanupKey)
+  if (existing) {
+    await existing.catch(() => {})
+    return
+  }
+  const cleanup = (async () => {
+    // Not awaited: the create path awaits this cleanup, and one stranded discard costs an unlock plus
+    // a `worktree remove --force` bounded at 30s each. Reclaiming leaked scratch must not delay create.
+    void retryPendingPreparationDiscards(cleanupKey)
+    const worktrees = await listWorktreeGraph(repoPath, {
+      ...options,
+      includeCreatePreparations: true
+    })
+    const staleWorktrees = worktrees.filter(isWorktreeCreatePreparation)
+    let nextIndex = 0
+    async function discardNextStalePreparation(): Promise<void> {
+      while (nextIndex < staleWorktrees.length) {
+        const worktree = staleWorktrees[nextIndex]
+        nextIndex += 1
+        const lockOwnerPid = parseWorktreePreparationOwnerPid(worktree.lockReason)
+        const pathOwnerPid = parseWorktreePreparationPathOwnerPid(worktree.path)
+        if (!lockOwnerPid || isProcessAlive(lockOwnerPid)) {
+          continue
+        }
+        // Preserve a branch-attached final path after a crash; only detached or
+        // still-hidden preparations are safe to discard automatically.
+        if (worktree.branch && pathOwnerPid === null) {
+          await unlockPreparedWorktree(repoPath, worktree.path, options).catch(() => {})
+        } else if (pathOwnerPid === lockOwnerPid) {
+          await discardPreparedWorktree(repoPath, worktree.path, options).catch(() => {})
+        }
+      }
+    }
+    const workerCount = Math.min(STALE_PREPARATION_CLEANUP_CONCURRENCY, staleWorktrees.length)
+    await Promise.all(Array.from({ length: workerCount }, () => discardNextStalePreparation()))
+  })()
+  staleCleanupInFlight.set(cleanupKey, cleanup)
+  try {
+    await cleanup.catch(() => {})
+  } finally {
+    if (staleCleanupInFlight.get(cleanupKey) === cleanup) {
+      staleCleanupInFlight.delete(cleanupKey)
+    }
+  }
+}
+
+export function resetStalePreparationCleanupForTests(): void {
+  staleCleanupInFlight.clear()
+}

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -467,45 +467,56 @@ describe('worktree create preparation registry', () => {
     expect(mocks.discard).toHaveBeenCalledTimes(1)
   })
 
-  it('re-arms a preparation after one is consumed so the next create stays warm', async () => {
-    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
-    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
-
+  async function consumeOnce(name: string): Promise<void> {
     await consumePreparedWorktreeCreate({
       repoPath: repo.path,
       workspaceRoot: '/workspace',
-      worktreePath: '/workspace/first',
-      branch: 'feature/first',
+      worktreePath: `/workspace/${name}`,
+      branch: `feature/${name}`,
       baseBranch: 'origin/main'
     })
+  }
+
+  it('does not re-arm after an isolated create', async () => {
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    await consumeOnce('only')
+
+    // Why: a lone create would otherwise leave a full spare checkout on disk for the whole TTL.
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms a preparation once creates arrive in a burst', async () => {
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    await consumeOnce('first')
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
+
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    await consumeOnce('second')
     await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
 
-    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(2)
-    // The replacement is claimable, so a second create still skips the cold add.
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(3)
+    // The replacement is claimable, so a third create still skips the cold add.
     await expect(
       consumePreparedWorktreeCreate({
         repoPath: repo.path,
         workspaceRoot: '/workspace',
-        worktreePath: '/workspace/second',
-        branch: 'feature/second',
+        worktreePath: '/workspace/third',
+        branch: 'feature/third',
         baseBranch: 'origin/main'
       })
     ).resolves.toEqual({})
-    expect(mocks.finalize).toHaveBeenCalledTimes(2)
+    expect(mocks.finalize).toHaveBeenCalledTimes(3)
   })
 
   it('does not re-arm when finalization failed', async () => {
     await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    await consumeOnce('first')
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    mocks.prepareCheckout.mockClear()
     mocks.finalize.mockRejectedValueOnce(new Error('submodules prevent worktree move'))
 
-    await consumePreparedWorktreeCreate({
-      repoPath: repo.path,
-      workspaceRoot: '/workspace',
-      worktreePath: '/workspace/final',
-      branch: 'feature/test',
-      baseBranch: 'origin/main'
-    })
+    await consumeOnce('second')
 
-    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
+    expect(mocks.prepareCheckout).not.toHaveBeenCalled()
   })
 })

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -467,8 +467,8 @@ describe('worktree create preparation registry', () => {
     expect(mocks.discard).toHaveBeenCalledTimes(1)
   })
 
-  async function consumeOnce(name: string): Promise<void> {
-    await consumePreparedWorktreeCreate({
+  function consumeOnce(name: string): ReturnType<typeof consumePreparedWorktreeCreate> {
+    return consumePreparedWorktreeCreate({
       repoPath: repo.path,
       workspaceRoot: '/workspace',
       worktreePath: `/workspace/${name}`,
@@ -479,7 +479,7 @@ describe('worktree create preparation registry', () => {
 
   it('does not re-arm after an isolated create', async () => {
     await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
-    await consumeOnce('only')
+    await expect(consumeOnce('only')).resolves.toEqual({})
 
     // Why: a lone create would otherwise leave a full spare checkout on disk for the whole TTL.
     expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
@@ -487,35 +487,29 @@ describe('worktree create preparation registry', () => {
 
   it('re-arms a preparation once creates arrive in a burst', async () => {
     await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
-    await consumeOnce('first')
+    await expect(consumeOnce('first')).resolves.toEqual({})
     expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
 
     await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
-    await consumeOnce('second')
-    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(2)
 
+    // No arming call follows this consume: the third checkout can only come from the re-arm.
+    await expect(consumeOnce('second')).resolves.toEqual({})
     expect(mocks.prepareCheckout).toHaveBeenCalledTimes(3)
+
     // The replacement is claimable, so a third create still skips the cold add.
-    await expect(
-      consumePreparedWorktreeCreate({
-        repoPath: repo.path,
-        workspaceRoot: '/workspace',
-        worktreePath: '/workspace/third',
-        branch: 'feature/third',
-        baseBranch: 'origin/main'
-      })
-    ).resolves.toEqual({})
+    await expect(consumeOnce('third')).resolves.toEqual({})
     expect(mocks.finalize).toHaveBeenCalledTimes(3)
   })
 
   it('does not re-arm when finalization failed', async () => {
     await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
-    await consumeOnce('first')
+    await expect(consumeOnce('first')).resolves.toEqual({})
     await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
     mocks.prepareCheckout.mockClear()
     mocks.finalize.mockRejectedValueOnce(new Error('submodules prevent worktree move'))
 
-    await consumeOnce('second')
+    await expect(consumeOnce('second')).resolves.toBeNull()
 
     expect(mocks.prepareCheckout).not.toHaveBeenCalled()
   })

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -466,4 +466,46 @@ describe('worktree create preparation registry', () => {
     expect(mocks.mkdir).toHaveBeenCalledWith('/workspace', { recursive: true })
     expect(mocks.discard).toHaveBeenCalledTimes(1)
   })
+
+  it('re-arms a preparation after one is consumed so the next create stays warm', async () => {
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
+
+    await consumePreparedWorktreeCreate({
+      repoPath: repo.path,
+      workspaceRoot: '/workspace',
+      worktreePath: '/workspace/first',
+      branch: 'feature/first',
+      baseBranch: 'origin/main'
+    })
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(2)
+    // The replacement is claimable, so a second create still skips the cold add.
+    await expect(
+      consumePreparedWorktreeCreate({
+        repoPath: repo.path,
+        workspaceRoot: '/workspace',
+        worktreePath: '/workspace/second',
+        branch: 'feature/second',
+        baseBranch: 'origin/main'
+      })
+    ).resolves.toEqual({})
+    expect(mocks.finalize).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not re-arm when finalization failed', async () => {
+    await prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    mocks.finalize.mockRejectedValueOnce(new Error('submodules prevent worktree move'))
+
+    await consumePreparedWorktreeCreate({
+      repoPath: repo.path,
+      workspaceRoot: '/workspace',
+      worktreePath: '/workspace/final',
+      branch: 'feature/test',
+      baseBranch: 'origin/main'
+    })
+
+    expect(mocks.prepareCheckout).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -25,6 +25,10 @@ import {
   getWorktreeMirrorDistro
 } from './project-runtime-git-options'
 import { computeWorkspaceRootAsync, getWorktreePathSettings } from './ipc/worktree-logic'
+import {
+  recordPreparationConsume,
+  resetPreparationConsumeHistoryForTests
+} from './worktree-create-preparation-burst'
 import { toHostFilesystemPath } from './host-tree-removal'
 import {
   discardPreparationWithRetry,
@@ -276,10 +280,15 @@ async function claimPreparedWorktree(
   }
 }
 
-/** Replaces a just-consumed preparation. Never awaited: create has already returned by the time
- *  the replacement checkout finishes. */
+/** Replaces a just-consumed preparation, but only once the user has shown they are creating in a
+ *  burst. A replacement costs a full checkout and ~5 minutes of disk until its TTL, so arming one
+ *  after an isolated create spends that on nobody. Never awaited: create has already returned by
+ *  the time the replacement checkout finishes. */
 function rearmPreparation(entry: PreparationEntry, baseBranch: string): void {
   if (preparations.has(entry.key)) {
+    return
+  }
+  if (!recordPreparationConsume(entry.key)) {
     return
   }
   void startPreparation(
@@ -319,9 +328,8 @@ export async function consumePreparedWorktreeCreate(
       args.refreshLocalBaseRef,
       options
     )
-    // Consuming the only prepared checkout leaves the next create cold, and back-to-back creates
-    // from the same composer are the common case. Re-arm in the background; the TTL and the
-    // preparation limit still bound how long an unused one survives.
+    // Consuming the only prepared checkout leaves the next create cold. Re-arm for a user who is
+    // creating in a burst; the TTL and the preparation limit still bound an unused replacement.
     rearmPreparation(entry, args.baseBranch)
     return result
   } catch (error) {
@@ -337,6 +345,7 @@ export async function consumePreparedWorktreeCreate(
 export async function _resetWorktreeCreatePreparationsForTests(): Promise<void> {
   const entries = [...preparations.values()]
   preparations.clear()
+  resetPreparationConsumeHistoryForTests()
   staleCleanupInFlight.clear()
   await Promise.all(
     entries.map(async (entry) => {

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -7,17 +7,12 @@ import { isFolderRepo } from '../shared/repo-kind'
 import { isWindowsAbsolutePathLike } from '../shared/cross-platform-path'
 import {
   WORKTREE_CREATE_PREPARATION_DIRECTORY,
-  createWorktreePreparationLockReason,
-  isWorktreeCreatePreparation,
-  parseWorktreePreparationOwnerPid,
-  parseWorktreePreparationPathOwnerPid
+  createWorktreePreparationLockReason
 } from '../shared/worktree/create-preparation'
 import type { AddWorktreeOptions, AddWorktreeResult } from './git/worktree'
-import { listWorktreeGraph } from './git/worktree'
 import {
   discardPreparedWorktree,
   finalizePreparedWorktree,
-  unlockPreparedWorktree,
   prepareWorktreeCreateCheckout
 } from './git/worktree-create-preparation'
 import {
@@ -29,17 +24,19 @@ import {
   recordPreparationConsume,
   resetPreparationConsumeHistoryForTests
 } from './worktree-create-preparation-burst'
+import {
+  cleanupStalePreparations,
+  resetStalePreparationCleanupForTests
+} from './worktree-create-preparation-stale-cleanup'
 import { toHostFilesystemPath } from './host-tree-removal'
 import {
   discardPreparationWithRetry,
   resetPendingPreparationDiscardsForTests,
-  retryPendingPreparationDiscards,
   trackPreparationDiscard
 } from './worktree-preparation-discard-retry'
 
 export const WORKTREE_CREATE_PREPARATION_TTL_MS = 5 * 60_000
 export const WORKTREE_CREATE_PREPARATION_LIMIT = 3
-const STALE_PREPARATION_CLEANUP_CONCURRENCY = 4
 
 type PreparationEntry = {
   key: string
@@ -63,7 +60,6 @@ type ConsumePreparedWorktreeArgs = {
 }
 
 const preparations = new Map<string, PreparationEntry>()
-const staleCleanupInFlight = new Map<string, Promise<void>>()
 
 function pathOps(path: string): Pick<typeof posix, 'dirname' | 'join' | 'normalize'> {
   return isWindowsAbsolutePathLike(path) ? win32 : posix
@@ -81,15 +77,6 @@ function preparationKey(
   options: AddWorktreeOptions
 ): string {
   return `${pathKey(repoPath)}\0${pathKey(workspaceRoot)}\0${baseBranch}\0${options.wslDistro ?? ''}`
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
-  }
 }
 
 function preparationHostKey(repoPath: string, options: AddWorktreeOptions): string {
@@ -132,57 +119,6 @@ function enforcePreparationLimit(): void {
     preparations.delete(oldest.key)
     clearTimeout(oldest.expiration)
     discardEntryInBackground(oldest)
-  }
-}
-
-async function cleanupStalePreparations(
-  repoPath: string,
-  options: AddWorktreeOptions
-): Promise<void> {
-  const cleanupKey = preparationHostKey(repoPath, options)
-  const existing = staleCleanupInFlight.get(cleanupKey)
-  if (existing) {
-    await existing.catch(() => {})
-    return
-  }
-  const cleanup = (async () => {
-    // Not awaited: the create path awaits this cleanup, and one stranded discard costs an unlock plus
-    // a `worktree remove --force` bounded at 30s each. Reclaiming leaked scratch must not delay create.
-    void retryPendingPreparationDiscards(cleanupKey)
-    const worktrees = await listWorktreeGraph(repoPath, {
-      ...options,
-      includeCreatePreparations: true
-    })
-    const staleWorktrees = worktrees.filter(isWorktreeCreatePreparation)
-    let nextIndex = 0
-    async function discardNextStalePreparation(): Promise<void> {
-      while (nextIndex < staleWorktrees.length) {
-        const worktree = staleWorktrees[nextIndex]
-        nextIndex += 1
-        const lockOwnerPid = parseWorktreePreparationOwnerPid(worktree.lockReason)
-        const pathOwnerPid = parseWorktreePreparationPathOwnerPid(worktree.path)
-        if (!lockOwnerPid || isProcessAlive(lockOwnerPid)) {
-          continue
-        }
-        // Preserve a branch-attached final path after a crash; only detached or
-        // still-hidden preparations are safe to discard automatically.
-        if (worktree.branch && pathOwnerPid === null) {
-          await unlockPreparedWorktree(repoPath, worktree.path, options).catch(() => {})
-        } else if (pathOwnerPid === lockOwnerPid) {
-          await discardPreparedWorktree(repoPath, worktree.path, options).catch(() => {})
-        }
-      }
-    }
-    const workerCount = Math.min(STALE_PREPARATION_CLEANUP_CONCURRENCY, staleWorktrees.length)
-    await Promise.all(Array.from({ length: workerCount }, () => discardNextStalePreparation()))
-  })()
-  staleCleanupInFlight.set(cleanupKey, cleanup)
-  try {
-    await cleanup.catch(() => {})
-  } finally {
-    if (staleCleanupInFlight.get(cleanupKey) === cleanup) {
-      staleCleanupInFlight.delete(cleanupKey)
-    }
   }
 }
 
@@ -239,7 +175,7 @@ function startPreparation(
     createdAt: Date.now(),
     expiration,
     ready: (async () => {
-      await cleanupStalePreparations(repoPath, options)
+      await cleanupStalePreparations(preparationHostKey(repoPath, options), repoPath, options)
       await mkdir(
         toHostFilesystemPath(
           pathOps(workspaceRoot).join(workspaceRoot, WORKTREE_CREATE_PREPARATION_DIRECTORY)
@@ -346,7 +282,7 @@ export async function _resetWorktreeCreatePreparationsForTests(): Promise<void> 
   const entries = [...preparations.values()]
   preparations.clear()
   resetPreparationConsumeHistoryForTests()
-  staleCleanupInFlight.clear()
+  resetStalePreparationCleanupForTests()
   await Promise.all(
     entries.map(async (entry) => {
       clearTimeout(entry.expiration)

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -205,6 +205,16 @@ export async function prepareWorktreeCreateForRepo(
     return existing.ready
   }
 
+  return startPreparation(key, repo.path, workspaceRoot, baseBranch, options)
+}
+
+function startPreparation(
+  key: string,
+  repoPath: string,
+  workspaceRoot: string,
+  baseBranch: string,
+  options: AddWorktreeOptions
+): Promise<void> {
   enforcePreparationLimit()
   const preparationId = `${process.pid}-${randomUUID()}`
   const lockReason = createWorktreePreparationLockReason(preparationId)
@@ -218,21 +228,21 @@ export async function prepareWorktreeCreateForRepo(
   expiration.unref()
   Object.assign(entry, {
     key,
-    repoPath: repo.path,
+    repoPath,
     workspaceRoot,
     preparedPath,
     options,
     createdAt: Date.now(),
     expiration,
     ready: (async () => {
-      await cleanupStalePreparations(repo.path, options)
+      await cleanupStalePreparations(repoPath, options)
       await mkdir(
         toHostFilesystemPath(
           pathOps(workspaceRoot).join(workspaceRoot, WORKTREE_CREATE_PREPARATION_DIRECTORY)
         ),
         { recursive: true }
       )
-      await prepareWorktreeCreateCheckout(repo.path, preparedPath, baseBranch, lockReason, options)
+      await prepareWorktreeCreateCheckout(repoPath, preparedPath, baseBranch, lockReason, options)
     })()
   } satisfies PreparationEntry)
   preparations.set(key, entry)
@@ -266,6 +276,23 @@ async function claimPreparedWorktree(
   }
 }
 
+/** Replaces a just-consumed preparation. Never awaited: create has already returned by the time
+ *  the replacement checkout finishes. */
+function rearmPreparation(entry: PreparationEntry, baseBranch: string): void {
+  if (preparations.has(entry.key)) {
+    return
+  }
+  void startPreparation(
+    entry.key,
+    entry.repoPath,
+    entry.workspaceRoot,
+    baseBranch,
+    entry.options
+  ).catch(() => {
+    // Why: a warm-up failure is recovered by the normal add on the next create.
+  })
+}
+
 export async function consumePreparedWorktreeCreate(
   args: ConsumePreparedWorktreeArgs
 ): Promise<AddWorktreeResult | null> {
@@ -283,7 +310,7 @@ export async function consumePreparedWorktreeCreate(
     await mkdir(toHostFilesystemPath(pathOps(args.worktreePath).dirname(args.worktreePath)), {
       recursive: true
     })
-    return await finalizePreparedWorktree(
+    const result = await finalizePreparedWorktree(
       args.repoPath,
       entry.preparedPath,
       args.worktreePath,
@@ -292,6 +319,11 @@ export async function consumePreparedWorktreeCreate(
       args.refreshLocalBaseRef,
       options
     )
+    // Consuming the only prepared checkout leaves the next create cold, and back-to-back creates
+    // from the same composer are the common case. Re-arm in the background; the TTL and the
+    // preparation limit still bound how long an unused one survives.
+    rearmPreparation(entry, args.baseBranch)
+    return result
   } catch (error) {
     await discardPreparedWorktree(args.repoPath, entry.preparedPath, options).catch(() => {})
     console.warn(

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -285,10 +285,10 @@ async function claimPreparedWorktree(
  *  after an isolated create spends that on nobody. Never awaited: create has already returned by
  *  the time the replacement checkout finishes. */
 function rearmPreparation(entry: PreparationEntry, baseBranch: string): void {
-  if (preparations.has(entry.key)) {
-    return
-  }
-  if (!recordPreparationConsume(entry.key)) {
+  // Record first: a prefetch that re-armed this key while we finalized would otherwise swallow the
+  // consume, and the next create would look isolated when it is really the middle of a burst.
+  const continuesBurst = recordPreparationConsume(entry.key)
+  if (preparations.has(entry.key) || !continuesBurst) {
     return
   }
   void startPreparation(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​264 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​264 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​436 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​206 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​230 |

<!-- /orca-pr-loc -->

## ELI5

Creating a workspace asked git the same question once per git remote — 55 separate processes on a big repo. Now it asks once. Also, the pre-warmed checkout that makes creation fast was single-use, so the *second* workspace you made was always slow; now it refills itself.

## What Changed

**1. One batched ref probe instead of one subprocess per remote.**
`getBranchConflictKindViaExec` spawned a `git show-ref --verify` per configured remote to answer "does this branch already exist on any remote?". On a repo with 55 remotes that is 55 subprocesses on every create. It now asks one `git cat-file --batch-check` over stdin.

`cat-file --batch-check` is the right primitive here because it reports a missing ref as *data* (`<input> missing`) rather than as a failed exit, so a batch stays exactly as decidable as the per-ref `show-ref --verify` it replaces. The alternatives do not work: `show-ref --verify` with multiple refs dies at the first missing ref, and `for-each-ref` with exact patterns still walks the whole `refs/remotes/` namespace.

Hosts that cannot feed a child's stdin (the SSH provider) do not pass a batched exec and keep the per-ref path unchanged. An undecided batch — short read, `ambiguous`, or a spelling this git reports differently — also falls back rather than guessing absence.

**2. The prepared checkout re-arms itself.**
`consumePreparedWorktreeCreate` claimed and removed the single prepared checkout, so back-to-back creates paid the full cold `git worktree add` on the second one. It now starts a replacement in the background after a successful finalize. The existing 5-minute TTL and preparation limit of 3 still bound how long an unused one survives, and a re-arm is only attempted when a preparation was actually consumed — so this cannot switch the feature on for a repo that was not already using it.

**3. Create phase timings reach the trace.**
`createWorktreeCreateTimingRecorder` already existed and its result was already carried on `CreateWorktreeResult.timing`, but nothing ever read it, and preflight was uncovered. Added `resolve_name` and `prepare_push_target` phases and recorded the breakdown on the `worktree.create` span, including an explicit `unattributed_ms` — because the thing that needed naming was a 1.0–1.75s window per create with no git subprocess running at all.

## Why

Measured on a real user's machine (macOS, latest hourly): a `~/projects/orca` checkout with 973 live worktrees, 80,068 refs, 55 remotes, 12 GB `.git`, 21,080 tracked files. Worktree creation there has a **median of 7.7s** across 91 recorded creates.

Measured effect of change 1 in that repo:

```
55 sequential `git show-ref --verify --quiet -- <ref>`   0.651s
1  `git cat-file --batch-check` over the same 55 refs    0.011s   (59x)
```

For reference, the two obvious batched alternatives were measured and rejected:

```
1  `git for-each-ref` with the same 55 exact patterns    0.492s   (walks 59,716 remote refs)
1  `git show-ref --verify -- <all 55>`                   fatals at the first missing ref
```

Change 2 targets the 11.7s outlier in the newest traces, which was a create that missed the prepared checkout and paid an 8.4s `git worktree add`.

Refs #17828

## Visual Proof

N/A — no UI or interaction change. All three changes are main-process git/tracing behavior; creation produces the same workspace with the same metadata, only faster.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Added:
- `src/main/git/repo-branch-conflict.test.ts` — batched probe issues one `cat-file` with the right stdin payload; reports a conflict from the batched answer; falls back to per-ref probes when the batch throws; treats a short batch read as undecided rather than as absence.
- `src/main/git/repo-branch-conflict-real-git.test.ts` — real-git contract over a 12-remote fixture: remote conflict found, absent branch clean, allowed-base-ref exemption honoured, local conflict still detected. This one matters because the change depends on `cat-file --batch-check`'s exact output shape.
- `src/main/worktree-create-preparation.test.ts` — a consumed preparation is replaced and the replacement is claimable; no re-arm when finalization failed.

Verified: `pnpm tc` clean, `pnpm run check:code-quality:changed` clean, and 1,173 tests across `src/main/ipc/worktree*`, `src/main/git/worktree*`, `src/main/git/repo*`, `src/main/observability`, `src/main/worktree-create*` pass.

Platforms: developed and tested on **macOS**. The batched path is gated on the caller supplying a stdin-capable exec, which today is only the local host runner, so **SSH** keeps its existing per-ref behavior byte for byte; **WSL** routes through the same local runner and inherits the batch (`stdin` is already plumbed through `git-exec-options.ts`). Not manually exercised on Linux or Windows — no platform-specific code paths were touched.

## AI Disclosure

Claude Opus 5 (Claude Code) — investigation, implementation, and tests, from trace analysis of a real user's `main.trace.ndjson` logs.

## Review

Reviewers may want to look hardest at the `probeAnyExactRefBatched` parse: the present/absent/undecided trichotomy is deliberate, and treating an undecided batch as "absent" would silently let a create clobber a branch that exists on a remote.

## Agent skill upstream boundary

N/A

## User-Facing Regressions

Not none. All are performance/IO trade-offs; none change what data the user is shown.

- During a **burst** of creates, a replacement prepared checkout (a full `worktree add` + `reset --hard`) runs in the background while you are already working in the worktree you just created, competing for disk and CPU in its first seconds. An isolated create no longer re-arms at all, so this is scoped to users creating repeatedly.
- An unused replacement is discarded when its 5-minute TTL expires, so a repo can see an unexplained `worktree remove --force` of a full tree several minutes after you stopped creating.
- Eviction in this PR is still **global oldest-first**, so a re-arm caused by activity in one project can evict another project's warm checkout, making the next create there cold. Repo-scoped eviction lands in #17863.
- A create submitted while a replacement is still being prepared can wait on it rather than doing a cold add. Roughly a wash normally; if that preparation fails, the wait is paid *on top of* the cold add.
- Pathological naming: a local branch named literally `refs/remotes/<remote>/<branch>` resolves in the batched `cat-file` probe where the per-ref `show-ref --verify` reported absent, so a new worktree branch is silently suffixed (`-2`). Fails safe — it can never clobber an existing branch.

**No change:** SSH hosts do not supply a stdin-capable exec, so they keep the per-ref probe path byte-for-byte.
