### PR TITLE
fix(relay): retire PTYs the host proves are gone, and stop two per-poll scan storms

### DIFF
--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -138,8 +138,34 @@ index 8c4fca9022a6d6f015bca87f61625cde2278f428..0a01730616488119aa21ef441cf3c441
  process.exit(0);
  //# sourceMappingURL=conpty_console_list_agent.js.map
 \ No newline at end of file
+diff --git a/lib/terminal.js b/lib/terminal.js
+index e2f9bc9131077b53ebc32d207207ad82804ff185..6c63bfaaf75128d88f9a2efece13476348780cfd 100644
+--- a/lib/terminal.js
++++ b/lib/terminal.js
+@@ -172,6 +172,21 @@ var Terminal = /** @class */ (function () {
+         this.end = function () { };
+         this._writable = false;
+         this._readable = false;
++        // Orca: libuv closes the master fd on EIO/EOF, and the kernel may hand
++        // that number straight to the next open(2). Retire it in the same block
++        // that gives up the handle so no later ioctl can address a reused fd.
++        // Inert on Windows, where `_fd` is written once and never read back.
++        // Upstream named this mechanism in microsoft/node-pty#220 ("fd number got
++        // reattached to something else"), closed 2025-12-19 as completed after
++        // only improving the error message; #827 is still open. Windows guards in
++        // windowsPtyAgent.ts, Unix does not. Orca tracking: #18109.
++        this._fd = -1;
++        // Orca: the write stream holds its own copy of that number, so retiring
++        // `_fd` alone leaves the queued and in-flight writes addressing it.
++        // Undefined on Windows and on `UnixTerminal.open()` handles.
++        if (this._writeStream) {
++            this._writeStream.dispose();
++        }
+     };
+     Terminal.prototype._parseEnv = function (env) {
+         var keys = Object.keys(env || {});
 diff --git a/lib/unixTerminal.js b/lib/unixTerminal.js
-index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088bf1865877 100644
+index 1ec12f796a822c78fba9ad7f6448c3987e325c23..d838d795ecb9ea72e3bcc31113344947c006af7e 100644
 --- a/lib/unixTerminal.js
 +++ b/lib/unixTerminal.js
 @@ -28,8 +28,12 @@ var native = utils_1.loadNativeModule('pty');
@@ -157,6 +183,56 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088b
  var DEFAULT_FILE = 'sh';
  var DEFAULT_NAME = 'xterm';
  var DESTROY_SOCKET_TIMEOUT_MS = 200;
+@@ -234,6 +238,11 @@ var UnixTerminal = /** @class */ (function (_super) {
+          * Gets the name of the process.
+          */
+         get: function () {
++            // Orca: tcgetpgrp on a retired fd would name whatever process now
++            // owns that descriptor, so a closed master reports the spawn file.
++            if (this._fd < 0) {
++                return this._file;
++            }
+             if (process.platform === 'darwin') {
+                 var title = pty.process(this._fd);
+                 return (title !== 'kernel_task') ? title : this._file;
+@@ -250,6 +259,11 @@ var UnixTerminal = /** @class */ (function (_super) {
+         if (cols <= 0 || rows <= 0 || isNaN(cols) || isNaN(rows) || cols === Infinity || rows === Infinity) {
+             throw new Error('resizing must be done using positive cols and rows');
+         }
++        // Orca: a retired master is unreachable rather than EBADF-or-worse; cols
++        // and rows stay at the last size actually applied instead of a claim.
++        if (this._fd < 0) {
++            return;
++        }
+         pty.resize(this._fd, cols, rows);
+         this._cols = cols;
+         this._rows = rows;
+@@ -287,8 +301,15 @@ var CustomWriteStream = /** @class */ (function () {
+     CustomWriteStream.prototype.dispose = function () {
+         clearImmediate(this._writeImmediate);
+         this._writeImmediate = undefined;
++        // Orca: retire this stream's own copy of the master fd and drop what has
++        // not shipped, so nothing queued here reaches a reused descriptor.
++        this._fd = -1;
++        this._writeQueue.length = 0;
+     };
+     CustomWriteStream.prototype.write = function (data) {
++        if (this._fd < 0) {
++            return;
++        }
+         // Writes are put in a queue and processed asynchronously in order to handle
+         // backpressure from the kernel buffer.
+         var buffer = typeof data === 'string'
+@@ -304,7 +325,8 @@ var CustomWriteStream = /** @class */ (function () {
+     CustomWriteStream.prototype._processWriteQueue = function () {
+         var _this = this;
+         this._writeImmediate = undefined;
+-        if (this._writeQueue.length === 0) {
++        // Orca: an in-flight fs.write can re-enter here after dispose().
++        if (this._fd < 0 || this._writeQueue.length === 0) {
+             return;
+         }
+         var task = this._writeQueue[0];
 diff --git a/src/conpty_console_list_agent.ts b/src/conpty_console_list_agent.ts
 index 181ccabbbe9c4948a9725fb1db907a68e9de01fc..67f31facf85562b67adbfbd04ce28ddd8eeb4a79 100644
 --- a/src/conpty_console_list_agent.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,7 +115,7 @@ patchedDependencies:
   '@xterm/addon-webgl@0.20.0-beta.299': 94687e89a0115e6e6aa102837f986debdc029c091527ee5eb4a4e17ceaf9473e
   '@xterm/xterm@6.1.0-beta.303': 98756bcedc402bcdb7c6ab7b015d2e59cd18e97b03a2c06a27e95bb3ba429d9d
   lint-staged@16.4.0: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
-  node-pty@1.1.0: 40b6b6b814c89a8a29c995495ea86cff2cf6766f42124b5702aedf4ce0565c0e
+  node-pty@1.1.0: e262847f57a1d4d3f2287a843822f7dcf3c9d8655892b07a69eba464e1317eaa
 
 importers:
 
@@ -156,7 +156,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=40b6b6b814c89a8a29c995495ea86cff2cf6766f42124b5702aedf4ce0565c0e)
+        version: 1.1.0(patch_hash=e262847f57a1d4d3f2287a843822f7dcf3c9d8655892b07a69eba464e1317eaa)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12194,7 +12194,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=40b6b6b814c89a8a29c995495ea86cff2cf6766f42124b5702aedf4ce0565c0e):
+  node-pty@1.1.0(patch_hash=e262847f57a1d4d3f2287a843822f7dcf3c9d8655892b07a69eba464e1317eaa):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/src/main/ai-vault/remote-session-parse-cache.test.ts
+++ b/src/main/ai-vault/remote-session-parse-cache.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { FileReadResult } from '../providers/types'
+import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { resetRemoteSessionParseCacheForTests } from './remote-session-parse-cache'
+import { scanRemoteAiVaultSessions } from './remote-session-scanner'
+import { MemoryRemoteProvider, jsonLines } from './remote-session-scanner-test-fixtures'
+
+/**
+ * Counts whole-transcript reads, which is the cost #13753 is about. Codex's
+ * per-scan `session_index.jsonl` title lookup is one small file and is not part
+ * of the corpus term, so it is excluded rather than asserted on.
+ */
+class CountingRemoteProvider extends MemoryRemoteProvider {
+  readonly readFilePaths: string[] = []
+
+  override async readFile(filePath: string): Promise<FileReadResult> {
+    if (filePath.includes('/sessions/')) {
+      this.readFilePaths.push(filePath)
+    }
+    return await super.readFile(filePath)
+  }
+}
+
+function transcript(sessionId: string, title: string, timestamp: string): string {
+  return jsonLines([
+    {
+      timestamp,
+      type: 'session_meta',
+      payload: { id: sessionId, cwd: '/home/ada/repo' }
+    },
+    {
+      timestamp,
+      type: 'response_item',
+      payload: { type: 'message', role: 'user', content: [{ type: 'text', text: title }] }
+    }
+  ])
+}
+
+function scan(provider: CountingRemoteProvider): ReturnType<typeof scanRemoteAiVaultSessions> {
+  return scanRemoteAiVaultSessions({
+    provider,
+    executionHostId: 'ssh:dev-box',
+    remoteHome: '/home/ada',
+    hostPlatform: getRemoteHostPlatform('linux-x64')
+  })
+}
+
+describe('remote AI Vault transcript re-reads', () => {
+  beforeEach(() => {
+    resetRemoteSessionParseCacheForTests()
+  })
+
+  it('does not re-read an unchanged corpus on the next scan', async () => {
+    const provider = new CountingRemoteProvider()
+    for (const day of ['07/07', '07/25', '08/10']) {
+      provider.addFile(
+        `/home/ada/.codex/sessions/2026/${day}/rollout-${day.replace('/', '')}.jsonl`,
+        transcript(
+          `session-${day.replace('/', '')}`,
+          `Work from ${day}`,
+          '2026-07-07T01:00:00.000Z'
+        ),
+        1_000
+      )
+    }
+
+    const first = await scan(provider)
+    expect(first.sessions).toHaveLength(3)
+    expect(provider.readFilePaths).toHaveLength(3)
+
+    provider.readFilePaths.length = 0
+    const second = await scan(provider)
+
+    // Historical transcripts are immutable; a second pass must cost zero reads.
+    expect(provider.readFilePaths).toEqual([])
+    expect(second.sessions.map((session) => session.title)).toEqual(
+      first.sessions.map((session) => session.title)
+    )
+  })
+
+  it('re-reads a transcript that actually changed', async () => {
+    const provider = new CountingRemoteProvider()
+    const path = '/home/ada/.codex/sessions/2026/08/31/rollout-live.jsonl'
+    provider.addFile(
+      path,
+      transcript('live-session', 'First prompt', '2026-08-31T01:00:00.000Z'),
+      1_000
+    )
+
+    await scan(provider)
+    provider.readFilePaths.length = 0
+
+    provider.addFile(
+      path,
+      transcript('live-session', 'Second prompt', '2026-08-31T02:00:00.000Z'),
+      2_000
+    )
+    const result = await scan(provider)
+
+    expect(provider.readFilePaths).toEqual([path])
+    expect(result.sessions[0]?.title).toBe('Second prompt')
+  })
+
+  it('re-reads when only the size changed under an unchanged mtime', async () => {
+    const provider = new CountingRemoteProvider()
+    const path = '/home/ada/.codex/sessions/2026/08/31/rollout-grown.jsonl'
+    provider.addFile(path, transcript('grown-session', 'Short', '2026-08-31T01:00:00.000Z'), 1_000)
+
+    await scan(provider)
+    provider.readFilePaths.length = 0
+
+    provider.addFile(
+      path,
+      transcript(
+        'grown-session',
+        'A much longer first prompt than before',
+        '2026-08-31T01:00:00.000Z'
+      ),
+      1_000
+    )
+    const result = await scan(provider)
+
+    expect(provider.readFilePaths).toEqual([path])
+    expect(result.sessions[0]?.title).toBe('A much longer first prompt than before')
+  })
+
+  it('does not serve a cached parse to a different execution host', async () => {
+    const provider = new CountingRemoteProvider()
+    const path = '/home/ada/.codex/sessions/2026/08/31/rollout-host.jsonl'
+    provider.addFile(
+      path,
+      transcript('host-session', 'Host scoped', '2026-08-31T01:00:00.000Z'),
+      1_000
+    )
+
+    await scan(provider)
+    provider.readFilePaths.length = 0
+
+    const other = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:other-box',
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64')
+    })
+
+    expect(provider.readFilePaths).toEqual([path])
+    expect(other.sessions[0]?.executionHostId).toBe('ssh:other-box')
+  })
+
+  it('does not cache a read that failed', async () => {
+    const provider = new CountingRemoteProvider()
+    const path = '/home/ada/.codex/sessions/2026/08/31/rollout-flaky.jsonl'
+    provider.addFile(
+      path,
+      transcript('flaky-session', 'Recovered', '2026-08-31T01:00:00.000Z'),
+      1_000
+    )
+
+    let failNextRead = true
+    const originalReadFile = provider.readFile.bind(provider)
+    provider.readFile = async (filePath: string): Promise<FileReadResult> => {
+      if (failNextRead && filePath === path) {
+        failNextRead = false
+        provider.readFilePaths.push(filePath)
+        throw new Error('EIO: transient relay read failure')
+      }
+      return await originalReadFile(filePath)
+    }
+
+    const failed = await scan(provider)
+    expect(failed.sessions).toEqual([])
+    expect(failed.issues).toHaveLength(1)
+
+    provider.readFilePaths.length = 0
+    const recovered = await scan(provider)
+
+    expect(provider.readFilePaths).toEqual([path])
+    expect(recovered.sessions[0]?.title).toBe('Recovered')
+  })
+})

--- a/src/main/ai-vault/remote-session-parse-cache.test.ts
+++ b/src/main/ai-vault/remote-session-parse-cache.test.ts
@@ -124,6 +124,42 @@ describe('remote AI Vault transcript re-reads', () => {
     expect(result.sessions[0]?.title).toBe('A much longer first prompt than before')
   })
 
+  // Codex names threads in $CODEX_HOME/session_index.jsonl asynchronously, after
+  // the rollout's last append — so the transcript's mtime+size never changes to
+  // signal it. That file sits outside `sessions/`, hence outside the read count.
+  it('picks up a session_index title written after the transcript was cached', async () => {
+    const provider = new CountingRemoteProvider()
+    const path = '/home/ada/.codex/sessions/2026/08/31/rollout-named-later.jsonl'
+    provider.addFile(
+      path,
+      transcript('named-later-session', 'First prompt', '2026-08-31T01:00:00.000Z'),
+      1_000
+    )
+    provider.addFile(
+      '/home/ada/.codex/session_index.jsonl',
+      jsonLines([{ id: 'some-other-session', thread_name: 'Unrelated thread' }]),
+      1_000
+    )
+
+    const first = await scan(provider)
+    expect(first.sessions[0]?.title).toBe('First prompt')
+
+    provider.readFilePaths.length = 0
+    provider.addFile(
+      '/home/ada/.codex/session_index.jsonl',
+      jsonLines([
+        { id: 'some-other-session', thread_name: 'Unrelated thread' },
+        { id: 'named-later-session', thread_name: 'Named by Codex after the fact' }
+      ]),
+      2_000
+    )
+    const second = await scan(provider)
+
+    expect(second.sessions[0]?.title).toBe('Named by Codex after the fact')
+    // The #13753 win is preserved: the index is read, the transcript is not.
+    expect(provider.readFilePaths).toEqual([])
+  })
+
   it('does not serve a cached parse to a different execution host', async () => {
     const provider = new CountingRemoteProvider()
     const path = '/home/ada/.codex/sessions/2026/08/31/rollout-host.jsonl'

--- a/src/main/ai-vault/remote-session-parse-cache.ts
+++ b/src/main/ai-vault/remote-session-parse-cache.ts
@@ -1,0 +1,99 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import type { RemoteScannerContext, RemoteSessionCandidate } from './remote-session-scanner-types'
+
+// Matches the local scanner's cap. The relay sidecar is forked with
+// --max-old-space-size=384, and a retained session row is a title, a preview
+// window and counters — orders of magnitude smaller than the transcript it was
+// parsed from, which is what the cache stops us re-reading.
+const MAX_CACHE_ENTRIES = 4096
+
+type RemoteSessionParseCacheEntry = {
+  mtimeMs: number
+  sizeBytes: number | null
+  hostKey: string
+  session: AiVaultSession | null
+}
+
+// Module scope so it outlives one scan: the sidecar is retired only after 10
+// idle minutes, so it spans many passes of a 30s cadence.
+const cache = new Map<string, RemoteSessionParseCacheEntry>()
+
+export type RemoteSessionParseStats = { reused: number; parsed: number }
+
+export function createRemoteSessionParseStats(): RemoteSessionParseStats {
+  return { reused: 0, parsed: 0 }
+}
+
+export function resetRemoteSessionParseCacheForTests(): void {
+  cache.clear()
+}
+
+/** Identity of the host a parse result belongs to; a result is not portable across either field. */
+export function remoteSessionParseHostKey(context: RemoteScannerContext): string {
+  return `${context.executionHostId}\u0000${context.hostPlatform.relayPlatform}`
+}
+
+function storeEntry(path: string, entry: RemoteSessionParseCacheEntry): void {
+  cache.delete(path)
+  cache.set(path, entry)
+  if (cache.size > MAX_CACHE_ENTRIES) {
+    const oldest = cache.keys().next()
+    if (!oldest.done) {
+      cache.delete(oldest.value)
+    }
+  }
+}
+
+/**
+ * Parse a remote transcript, reusing the previous result when the file is
+ * provably unchanged.
+ *
+ * Why this exists: the remote scanner had no cache of any kind, so every pass
+ * re-read and re-parsed the whole corpus — up to 3000 whole-file reads, GBs of
+ * JSONL, including July transcripts that had not changed in a month — which is
+ * what pegged the relay host on the renderer's 30s forced-rescan cadence
+ * (#13753). The local scanner has had `parseAgentSessionFileCached` for exactly
+ * this reason; this is its remote counterpart.
+ *
+ * `(mtimeMs, sizeBytes)` is a sound validity key here because discovery already
+ * folds a source's `contentDependencyPath` stat into both fields
+ * (remote-session-scanner-discovery.ts), so a metadata-only transcript whose
+ * companion file changed still looks changed.
+ *
+ * Only a completed parse is stored. A read that threw stays uncached so a
+ * transient filesystem failure cannot pin a wrong answer for the corpus's life.
+ */
+export async function parseRemoteSessionFileCached(args: {
+  candidate: RemoteSessionCandidate
+  hostKey: string
+  parse: () => Promise<AiVaultSession | null>
+  stats?: RemoteSessionParseStats
+}): Promise<AiVaultSession | null> {
+  const { file } = args.candidate
+  const entry = cache.get(file.path)
+  const unchanged =
+    entry !== undefined &&
+    entry.hostKey === args.hostKey &&
+    entry.mtimeMs === file.mtimeMs &&
+    (entry.sizeBytes === null || file.sizeBytes === undefined || entry.sizeBytes === file.sizeBytes)
+  if (unchanged) {
+    if (args.stats) {
+      args.stats.reused++
+    }
+    // Refresh recency without re-parsing so the LRU evicts cold paths first.
+    storeEntry(file.path, entry)
+    return entry.session
+  }
+
+  const session = await args.parse()
+  if (args.stats) {
+    args.stats.parsed++
+  }
+  storeEntry(file.path, {
+    mtimeMs: file.mtimeMs,
+    sizeBytes: file.sizeBytes ?? null,
+    hostKey: args.hostKey,
+    session
+  })
+  return session
+}

--- a/src/main/ai-vault/remote-session-parse-cache.ts
+++ b/src/main/ai-vault/remote-session-parse-cache.ts
@@ -58,7 +58,10 @@ function storeEntry(path: string, entry: RemoteSessionParseCacheEntry): void {
  * `(mtimeMs, sizeBytes)` is a sound validity key here because discovery already
  * folds a source's `contentDependencyPath` stat into both fields
  * (remote-session-scanner-discovery.ts), so a metadata-only transcript whose
- * companion file changed still looks changed.
+ * companion file changed still looks changed. Sources whose parse reads a file
+ * discovery does not stat — Codex looks its title up in `session_index.jsonl` —
+ * are not covered by that key and pass `refreshReusedSession` to re-derive the
+ * uncovered part without touching the transcript.
  *
  * Only a completed parse is stored. A read that threw stays uncached so a
  * transient filesystem failure cannot pin a wrong answer for the corpus's life.
@@ -67,6 +70,8 @@ export async function parseRemoteSessionFileCached(args: {
   candidate: RemoteSessionCandidate
   hostKey: string
   parse: () => Promise<AiVaultSession | null>
+  // Applied to a reused session only; must not re-read the transcript.
+  refreshReusedSession?: (session: AiVaultSession) => Promise<AiVaultSession>
   stats?: RemoteSessionParseStats
 }): Promise<AiVaultSession | null> {
   const { file } = args.candidate
@@ -79,6 +84,9 @@ export async function parseRemoteSessionFileCached(args: {
   if (unchanged) {
     if (args.stats) {
       args.stats.reused++
+    }
+    if (entry.session && args.refreshReusedSession) {
+      entry.session = await args.refreshReusedSession(entry.session)
     }
     // Refresh recency without re-parsing so the LRU evicts cold paths first.
     storeEntry(file.path, entry)

--- a/src/main/ai-vault/remote-session-scanner-codex-index.ts
+++ b/src/main/ai-vault/remote-session-scanner-codex-index.ts
@@ -3,9 +3,30 @@ import { joinRemotePath } from '../ssh/ssh-remote-platform'
 import { extractString, normalizeTitleText, parseJsonObject } from './session-scanner-values'
 import { remoteSessionContentLines } from './remote-session-content-lines'
 import { throwIfAiVaultScanCancelled } from './ai-vault-scan-cancellation'
-import type { RemoteSessionFilesystemProvider } from './remote-session-scanner-types'
+import type {
+  RemoteScannerContext,
+  RemoteSessionFilesystemProvider
+} from './remote-session-scanner-types'
 
 const CODEX_SESSION_INDEX_FILE = 'session_index.jsonl'
+
+// One index read per CODEX_HOME per scan (`context.titleCaches` is scan-scoped);
+// used both by the transcript parse and by the parse cache's reuse path.
+export function remoteCodexIndexedTitleReader(
+  codexHome: string,
+  context: RemoteScannerContext
+): (sessionId: string) => Promise<string | null> {
+  return async (sessionId) =>
+    (
+      await remoteCodexIndexTitles({
+        provider: context.provider,
+        codexHome,
+        hostPlatform: context.hostPlatform,
+        titleCaches: context.titleCaches,
+        signal: context.signal
+      })
+    ).get(sessionId) ?? null
+}
 
 export async function remoteCodexIndexTitles(args: {
   provider: RemoteSessionFilesystemProvider

--- a/src/main/ai-vault/remote-session-scanner-sources.ts
+++ b/src/main/ai-vault/remote-session-scanner-sources.ts
@@ -16,7 +16,7 @@ import { partitionSubagentTranscriptPaths } from './session-scanner-subagent-tra
 import { partitionOmpSubagentTranscriptPaths } from './session-scanner-omp-subagent-transcripts'
 import type { FileWithMtime } from './session-scanner-types'
 import { normalizeAgentSessionsDir } from './session-scanner-values'
-import { remoteCodexIndexTitles } from './remote-session-scanner-codex-index'
+import { remoteCodexIndexedTitleReader } from './remote-session-scanner-codex-index'
 import { remoteClineSource } from './remote-session-scanner-cline-source'
 import type {
   RemoteParserOptions,
@@ -216,16 +216,7 @@ function remoteCodexSources(
         executionHostId: context.executionHostId,
         executionHostPlatform: context.hostPlatform.os,
         signal: context.signal,
-        readIndexedTitle: async (sessionId) =>
-          (
-            await remoteCodexIndexTitles({
-              provider: context.provider,
-              codexHome,
-              hostPlatform,
-              titleCaches: context.titleCaches,
-              signal: context.signal
-            })
-          ).get(sessionId) ?? null
+        readIndexedTitle: remoteCodexIndexedTitleReader(codexHome, context)
       })
   }))
 }

--- a/src/main/ai-vault/remote-session-scanner.ts
+++ b/src/main/ai-vault/remote-session-scanner.ts
@@ -12,6 +12,10 @@ import {
   dedupeCodexRolloutFileAliases,
   dedupeCodexSessionsBySessionId
 } from './codex-session-root-dedup'
+import {
+  parseRemoteSessionFileCached,
+  remoteSessionParseHostKey
+} from './remote-session-parse-cache'
 import { discoverRemoteSourceCandidates } from './remote-session-scanner-discovery'
 import { remoteSessionSources } from './remote-session-scanner-sources'
 import type {
@@ -224,12 +228,20 @@ async function parseRemoteSessionCandidate(
 ): Promise<AiVaultSession | null> {
   try {
     throwIfAiVaultScanCancelled(context.signal)
-    const read = await context.provider.readFile(candidate.file.path)
-    throwIfAiVaultScanCancelled(context.signal)
-    if (read.isBinary) {
-      return null
-    }
-    const session = await candidate.source.parse(candidate.file, read.content, context)
+    // The read is inside the cached parse: an unchanged transcript must not be
+    // pulled off the remote disk at all, which is the whole cost of #13753.
+    const session = await parseRemoteSessionFileCached({
+      candidate,
+      hostKey: remoteSessionParseHostKey(context),
+      parse: async () => {
+        const read = await context.provider.readFile(candidate.file.path)
+        throwIfAiVaultScanCancelled(context.signal)
+        if (read.isBinary) {
+          return null
+        }
+        return await candidate.source.parse(candidate.file, read.content, context)
+      }
+    })
     throwIfAiVaultScanCancelled(context.signal)
     // Mirror the local rule: every session carries its sibling subagent
     // transcript count (row badge; recoverable signal at zero turns). The

--- a/src/main/ai-vault/remote-session-scanner.ts
+++ b/src/main/ai-vault/remote-session-scanner.ts
@@ -16,6 +16,7 @@ import {
   parseRemoteSessionFileCached,
   remoteSessionParseHostKey
 } from './remote-session-parse-cache'
+import { remoteCodexIndexedTitleReader } from './remote-session-scanner-codex-index'
 import { discoverRemoteSourceCandidates } from './remote-session-scanner-discovery'
 import { remoteSessionSources } from './remote-session-scanner-sources'
 import type {
@@ -29,6 +30,7 @@ import { errorMessage } from './session-scanner-values'
 import { mapRemoteScanBatches } from './remote-session-scan-batching'
 import { throwIfAiVaultScanCancelled } from './ai-vault-scan-cancellation'
 import { recordSessionScanIssue } from './session-scan-issues'
+import { refreshCodexTitleFromIndex } from './session-scanner-codex-cached-title'
 import { limitRemoteScanFilesystemConcurrency } from './remote-session-scan-concurrency'
 import { aiVaultScanLimit } from '../../shared/ai-vault-session-depth'
 
@@ -240,7 +242,8 @@ async function parseRemoteSessionCandidate(
           return null
         }
         return await candidate.source.parse(candidate.file, read.content, context)
-      }
+      },
+      refreshReusedSession: reusedCodexTitleRefresh(candidate, context)
     })
     throwIfAiVaultScanCancelled(context.signal)
     // Mirror the local rule: every session carries its sibling subagent
@@ -261,6 +264,22 @@ async function parseRemoteSessionCandidate(
     })
     return null
   }
+}
+
+// Codex thread names live in `<CODEX_HOME>/session_index.jsonl`, not the
+// rollout, and are written after it — so a transcript-keyed cache hit would
+// pin the fallback title forever. Local counterpart:
+// session-scanner-parse-cache.ts's reuse path.
+function reusedCodexTitleRefresh(
+  candidate: RemoteSessionCandidate,
+  context: RemoteScannerContext
+): ((session: AiVaultSession) => Promise<AiVaultSession>) | undefined {
+  const codexHome = candidate.source.agent === 'codex' ? candidate.source.codexHome : undefined
+  if (!codexHome) {
+    return undefined
+  }
+  const readIndexedTitle = remoteCodexIndexedTitleReader(codexHome, context)
+  return (session) => refreshCodexTitleFromIndex(session, readIndexedTitle)
 }
 
 function mergeRemoteSessions(

--- a/src/main/ai-vault/session-scanner-codex-cached-title.ts
+++ b/src/main/ai-vault/session-scanner-codex-cached-title.ts
@@ -2,14 +2,29 @@ import type { AiVaultSession } from '../../shared/ai-vault-types'
 import type { SessionFileCandidate } from './session-scanner-types'
 import { readCodexSessionIndexTitle } from './session-scanner-codex-title-index'
 
-export async function refreshCachedCodexTitle(
+/**
+ * Codex names a thread in <CODEX_HOME>/session_index.jsonl asynchronously,
+ * after the rollout exists — often after the rollout's last append. A parse
+ * cache keyed on the transcript's own mtime/size therefore freezes the fallback
+ * title forever, so every reuse path re-derives it through here.
+ *
+ * Both caches share this: `session-scanner-parse-cache.ts` (local disk, via
+ * `refreshCachedCodexTitle`) and `remote-session-parse-cache.ts` (relay
+ * provider, whose reader lives in `remote-session-scanner-codex-index.ts`).
+ */
+export async function refreshCodexTitleFromIndex(
+  session: AiVaultSession,
+  readIndexedTitle: (sessionId: string) => Promise<string | null>
+): Promise<AiVaultSession> {
+  const title = await readIndexedTitle(session.sessionId)
+  return title && title !== session.title ? { ...session, title } : session
+}
+
+export function refreshCachedCodexTitle(
   candidate: SessionFileCandidate,
   session: AiVaultSession
 ): Promise<AiVaultSession> {
-  const title = await readCodexSessionIndexTitle(
-    candidate.file.path,
-    candidate.codexHome,
-    session.sessionId
+  return refreshCodexTitleFromIndex(session, (sessionId) =>
+    readCodexSessionIndexTitle(candidate.file.path, candidate.codexHome, sessionId)
   )
-  return title && title !== session.title ? { ...session, title } : session
 }

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -209,6 +209,8 @@ export async function parseAgentSessionFileCached(
         entry.session = { ...entry.session, subagentTranscriptCount }
       }
     }
+    // Codex titles come from session_index.jsonl, which mtime+size can't see.
+    // Remote counterpart: remote-session-scanner.ts's reusedCodexTitleRefresh.
     if (entry.session && candidate.agent === 'codex') {
       entry.session = await refreshCachedCodexTitle(candidate, entry.session)
     }

--- a/src/main/pty/node-pty-master-fd-retirement.test.ts
+++ b/src/main/pty/node-pty-master-fd-retirement.test.ts
@@ -1,0 +1,194 @@
+import * as pty from 'node-pty'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * node-pty hands the master fd to libuv, which closes it on EIO/EOF, but upstream
+ * never invalidated `_fd`, and none of the three fd-addressed surfaces consulted
+ * anything: `resize()`, the `process` getter, and `CustomWriteStream`, which holds
+ * its own plain-number copy of the fd taken at spawn. Orca's patch retires all
+ * three in the same block that gives up the handle
+ * (config/patches/node-pty@1.1.0.patch).
+ *
+ * Scope: this narrows the window, it does not close it. libuv closes the fd
+ * synchronously inside `uv_close`, before the JS `'close'` that runs `_close()`,
+ * so callers still need their own liveness verdict for that tick — and a relay
+ * host installs node-pty from npm, where this patch is not applied at all.
+ */
+
+const POSIX_SHELL = '/bin/sh'
+
+function spawnPty(command: string, cols = 80, rows = 24): pty.IPty {
+  return pty.spawn(POSIX_SHELL, ['-c', command], {
+    name: 'xterm-256color',
+    cols,
+    rows,
+    cwd: process.cwd(),
+    env: { ...process.env }
+  })
+}
+
+function masterFd(term: pty.IPty): number {
+  return (term as unknown as { fd: number }).fd
+}
+
+type CustomWriteStream = { _fd: number; _writeQueue: unknown[]; write(data: string): void }
+
+/**
+ * `Terminal._close()` already shadows `terminal.write` with a no-op, so the stream
+ * itself is the surface that still reached the fd: a residual `_writeQueue` and an
+ * in-flight `fs.write` both re-enter it after the close.
+ */
+function writeStream(term: pty.IPty): CustomWriteStream {
+  return (term as unknown as { _writeStream: CustomWriteStream })._writeStream
+}
+
+/**
+ * Run `command` to completion and let node-pty finish giving up the master.
+ *
+ * `destroy: false` exercises only the EIO/EOF read-error path, which reaches
+ * `_close()` without ever calling `destroy()` — the path the exit of a shell
+ * actually takes, and the one the write stream was previously never told about.
+ */
+async function retiredPty(
+  command = 'exit 0',
+  { destroy = true }: { destroy?: boolean } = {}
+): Promise<{ term: pty.IPty; spawnFd: number }> {
+  const term = spawnPty(command)
+  const spawnFd = masterFd(term)
+  await new Promise<void>((resolve) => {
+    term.onExit(() => resolve())
+  })
+  if (destroy) {
+    ;(term as unknown as { destroy?: () => void }).destroy?.()
+  }
+  await new Promise<void>((resolve) => setTimeout(resolve, 400))
+  return { term, spawnFd }
+}
+
+// Windows never reaches this code: WindowsTerminal.resize goes through the conpty
+// agent and reads no fd, so the sentinel is written and never consulted there.
+const describeOnPosix = process.platform === 'win32' ? describe.skip : describe
+
+describeOnPosix('node-pty master fd retirement', () => {
+  it('invalidates the descriptor once it gives up the handle', async () => {
+    const { term, spawnFd } = await retiredPty()
+
+    expect(spawnFd).toBeGreaterThanOrEqual(0)
+    expect(masterFd(term)).toBe(-1)
+  }, 15000)
+
+  it('answers a resize past retirement without issuing the ioctl', async () => {
+    const { term } = await retiredPty()
+
+    // Pre-patch this threw `ioctl(2) failed, EBADF` out of whatever called it.
+    expect(() => term.resize(200, 50)).not.toThrow()
+    // Geometry stays at the last size actually applied rather than claiming one
+    // that no descriptor ever received.
+    expect([term.cols, term.rows]).toEqual([80, 24])
+  }, 15000)
+
+  it('retires the write stream fd on _close(), not only on destroy()', async () => {
+    const { term } = await retiredPty('exit 0', { destroy: false })
+
+    // The stream copied the fd number at spawn, so `Terminal._fd = -1` alone
+    // leaves it addressing a descriptor the kernel may already have reissued.
+    expect(writeStream(term)._fd).toBe(-1)
+
+    writeStream(term).write('x')
+    expect(writeStream(term)._writeQueue).toHaveLength(0)
+  }, 15000)
+
+  it('names the spawn file rather than tcgetpgrp on a retired descriptor', async () => {
+    const { term } = await retiredPty()
+
+    expect(term.process).toBe(POSIX_SHELL)
+  }, 15000)
+})
+
+// Linux frees the master synchronously enough that the very next pty is handed the
+// same descriptor number every time, which makes the reuse hazard directly
+// observable rather than a race to reproduce.
+//
+// Which is also the constraint on writing a case here: the kernel hands out the
+// lowest free number, so a case that returns while its live pty is still open
+// leaks that descriptor into the next case's premise as an off-by-one. Await the
+// exit, never a fixed sleep.
+const describeOnLinux = process.platform === 'linux' ? describe : describe.skip
+
+describeOnLinux('node-pty master fd reuse', () => {
+  it('cannot resize a live pty handed the retired descriptor number', async () => {
+    const { term: retired, spawnFd } = await retiredPty()
+
+    const live = spawnPty('sleep 1; stty size')
+    let output = ''
+    live.onData((data) => {
+      output += data
+    })
+    try {
+      // The premise of this test: the kernel really did reissue the number. If it
+      // stops holding, the assertion below would pass for the wrong reason.
+      expect(masterFd(live)).toBe(spawnFd)
+
+      // Pre-patch this reached TIOCSWINSZ on `live`'s master and silently resized
+      // a terminal it has no relationship to — no error, nothing for a liveness
+      // probe of the retired pid to observe.
+      retired.resize(200, 50)
+
+      await new Promise<void>((resolve) => {
+        live.onExit(() => resolve())
+      })
+      expect(output.trim()).toBe('24 80')
+    } finally {
+      live.kill()
+    }
+  }, 15000)
+
+  it('cannot write into a live pty handed the retired descriptor number', async () => {
+    const { term: retired, spawnFd } = await retiredPty('exit 0', { destroy: false })
+
+    const live = spawnPty('sleep 1')
+    let output = ''
+    live.onData((data) => {
+      output += data
+    })
+    try {
+      expect(masterFd(live)).toBe(spawnFd)
+
+      // Pre-patch this fs.write reached `live`'s master, and the line discipline
+      // echoed it straight back: a retired pane's bytes landing in an unrelated
+      // terminal. Nothing has to read them for the leak to be observable.
+      writeStream(retired).write('leak\r')
+
+      // Await the exit rather than sleeping: a fixed wait leaves this descriptor
+      // open into the next case, whose `expect(masterFd(live)).toBe(spawnFd)`
+      // premise then sees the kernel hand out the lower number this pty was still
+      // holding. That is what broke `node 24 1/8` on Linux, where alone among the
+      // platforms these cases actually run.
+      await new Promise<void>((resolve) => {
+        live.onExit(() => resolve())
+      })
+      expect(output).not.toContain('leak')
+    } finally {
+      live.kill()
+    }
+  }, 15000)
+
+  it('does not name a live pty foreground process off the retired descriptor', async () => {
+    const { term: retired, spawnFd } = await retiredPty()
+
+    // `exec` replaces the shell, so the foreground pgrp's cmdline is distinct
+    // from the file this pty was spawned with.
+    const live = spawnPty('exec sleep 5')
+    try {
+      expect(masterFd(live)).toBe(spawnFd)
+      // Let the shell finish exec'ing, or its own cmdline is still the fallback.
+      await new Promise<void>((resolve) => setTimeout(resolve, 300))
+
+      // Pre-patch this read tcgetpgrp off `live`'s master and reported `sleep`,
+      // attributing an unrelated pane's process to a pty that had already exited.
+      expect(retired.process).toBe(POSIX_SHELL)
+    } finally {
+      live.kill()
+    }
+  }, 15000)
+})

--- a/src/relay/pty-handler-resize-stale-pty.test.ts
+++ b/src/relay/pty-handler-resize-stale-pty.test.ts
@@ -36,7 +36,15 @@ import type { MockDispatcher } from './pty-handler-test-harness'
 const PTY_1 = testPtyId(1)
 const STALE_PID = 424_242
 
-/** node-pty's native `pty.resize` error when the master fd is already closed. */
+/**
+ * node-pty's native `pty.resize` error when the ioctl reaches a closed master.
+ *
+ * Orca's node-pty patch retires `_fd` when it gives up the master, so a patched
+ * handle answers a late resize with a no-op. That leaves this handler two cases
+ * it still has to contain: the tick between libuv closing the fd and node-pty's
+ * own handler observing it, and a relay host, which installs node-pty from npm
+ * and has no such guard.
+ */
 function ebadfResize(): never {
   throw new Error('ioctl(2) failed, EBADF')
 }
@@ -55,7 +63,7 @@ describe('PtyHandler.resize against a stale PTY handle', () => {
     }))
     resize = vi.fn()
     // A shell that exited without node-pty producing `onExit`: the record is
-    // still in the pool and undisposed, but the master fd behind it is closed.
+    // still in the pool and undisposed, but the master behind it is gone.
     mockPtySpawn.mockReturnValue({ ...mockPtyInstance, pid: STALE_PID, resize })
     await dispatcher.callRequest('pty.spawn', {})
     expect(handler.activePtyCount).toBe(1)
@@ -80,7 +88,7 @@ describe('PtyHandler.resize against a stale PTY handle', () => {
     expect(handler.activePtyCount).toBe(0)
   })
 
-  it('contains an ioctl failure whose process is still live, and keeps the record', () => {
+  it('contains an ioctl failure without re-classifying liveness, and keeps the record', () => {
     vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(true)
     resize.mockImplementation(ebadfResize)
     const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
@@ -94,11 +102,32 @@ describe('PtyHandler.resize against a stale PTY handle', () => {
       dispatcher.callNotification('pty.resize', { id: PTY_1, cols: 90, rows: 30 })
     ).not.toThrow()
 
-    // Loss of an fd is not evidence the shell exited, so the claim is retained.
+    // Loss of an fd observed the handle, not the host that owns the pid, so it is
+    // `unverifiable` and the claim is retained. Only the probe above retires.
     expect(handler.activePtyCount).toBe(1)
     expect(stderr.mock.calls.map(([line]) => String(line)).join('')).toContain(
       'ioctl(2) failed, EBADF'
     )
+  })
+
+  it('retires the entry when the pid goes absent between the pre-probe and the ioctl', () => {
+    // The race the catch-block re-probe exists for, and the one a constant
+    // liveness mock cannot express: alive when the pre-probe asks, gone by the
+    // time the ioctl fails. libuv closes the master synchronously inside
+    // `uv_close`, so this window opens before any JS guard can be set — and on
+    // a relay host, where node-pty comes from npm, there is no JS guard at all.
+    vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValueOnce(true).mockReturnValueOnce(false)
+    resize.mockImplementation(ebadfResize)
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+
+    expect(() =>
+      dispatcher.callNotification('pty.resize', { id: PTY_1, cols: 120, rows: 40 })
+    ).not.toThrow()
+
+    expect(resize).toHaveBeenCalledTimes(1)
+    expect(handler.activePtyCount).toBe(0)
+    // Proven `exited` retires silently; only live-or-unverifiable is reported.
+    expect(stderr).not.toHaveBeenCalled()
   })
 
   it('still resizes a live PTY, with the clamped geometry', () => {

--- a/src/relay/pty-handler-resize-stale-pty.test.ts
+++ b/src/relay/pty-handler-resize-stale-pty.test.ts
@@ -147,7 +147,8 @@ describe('PtyHandler.resize against a stale PTY handle', () => {
   it('does not republish an exit node-pty already reported', async () => {
     // The listing sweep also reaps entries the natural `onExit` left behind; a
     // second `pty.exit` would hand the client a duplicate carrying -1 in place
-    // of the real status.
+    // of the real status. That sweep retires off `managed.disposed`, which is
+    // bookkeeping rather than liveness, so it never publishes a verdict at all.
     const onExit = mockPtyInstance.onExit.mock.calls.at(-1)?.[0] as (e: {
       exitCode: number
     }) => void

--- a/src/relay/pty-handler-resize-stale-pty.test.ts
+++ b/src/relay/pty-handler-resize-stale-pty.test.ts
@@ -130,6 +130,40 @@ describe('PtyHandler.resize against a stale PTY handle', () => {
     expect(stderr).not.toHaveBeenCalled()
   })
 
+  it('publishes the exit so the client stops holding a pane on a retired session', () => {
+    vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(false)
+
+    dispatcher.callNotification('pty.resize', { id: PTY_1, cols: 120, rows: 40 })
+
+    // Retiring the record without this leaves the pane mounted against a
+    // session the relay has already forgotten: the next attach answers
+    // `PTY "<id>" not found` and nothing before it explained why.
+    expect(dispatcher._notifications).toContainEqual({
+      method: 'pty.exit',
+      params: { id: PTY_1, code: -1, incarnationId: expect.any(String) }
+    })
+  })
+
+  it('does not republish an exit node-pty already reported', async () => {
+    // The listing sweep also reaps entries the natural `onExit` left behind; a
+    // second `pty.exit` would hand the client a duplicate carrying -1 in place
+    // of the real status.
+    const onExit = mockPtyInstance.onExit.mock.calls.at(-1)?.[0] as (e: {
+      exitCode: number
+    }) => void
+    onExit({ exitCode: 7 })
+    await vi.runAllTimersAsync()
+    vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(false)
+
+    await dispatcher.callRequest('pty.listProcesses', {})
+
+    const exits = dispatcher._notifications.filter(
+      (notification) => notification.method === 'pty.exit'
+    )
+    expect(exits).toHaveLength(1)
+    expect(exits[0]?.params).toMatchObject({ id: PTY_1, code: 7 })
+  })
+
   it('still resizes a live PTY, with the clamped geometry', () => {
     vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(true)
 

--- a/src/relay/pty-handler-resize-stale-pty.test.ts
+++ b/src/relay/pty-handler-resize-stale-pty.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockPtySpawn, mockPtyInstance, mockCreateShellPromptReadinessProbe } = vi.hoisted(() => ({
+  mockPtySpawn: vi.fn(),
+  mockCreateShellPromptReadinessProbe: vi.fn(),
+  mockPtyInstance: {
+    pid: process.pid,
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    clear: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn()
+  }
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: mockPtySpawn
+}))
+
+vi.mock('../main/pty/posix-pty-process-groups', () => ({
+  forceKillPosixPtyProcessGroups: vi.fn((_pid: number, fallback: () => void) => fallback())
+}))
+
+vi.mock('../main/shell-prompt-readiness-probe', () => ({
+  createShellPromptReadinessProbe: mockCreateShellPromptReadinessProbe
+}))
+
+import type { PtyHandler } from './pty-handler'
+import * as ptyShellUtils from './pty-shell-utils'
+import { beginPtyHandlerTest, endPtyHandlerTest, testPtyId } from './pty-handler-test-harness'
+import type { MockDispatcher } from './pty-handler-test-harness'
+
+const PTY_1 = testPtyId(1)
+const STALE_PID = 424_242
+
+/** node-pty's native `pty.resize` error when the master fd is already closed. */
+function ebadfResize(): never {
+  throw new Error('ioctl(2) failed, EBADF')
+}
+
+describe('PtyHandler.resize against a stale PTY handle', () => {
+  let dispatcher: MockDispatcher
+  let handler: PtyHandler
+  let originalPlatform: PropertyDescriptor | undefined
+  let resize: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    ;({ dispatcher, handler, originalPlatform } = beginPtyHandlerTest({
+      mockPtySpawn,
+      mockPtyInstance,
+      mockCreateShellPromptReadinessProbe
+    }))
+    resize = vi.fn()
+    // A shell that exited without node-pty producing `onExit`: the record is
+    // still in the pool and undisposed, but the master fd behind it is closed.
+    mockPtySpawn.mockReturnValue({ ...mockPtyInstance, pid: STALE_PID, resize })
+    await dispatcher.callRequest('pty.spawn', {})
+    expect(handler.activePtyCount).toBe(1)
+  })
+
+  afterEach(async () => {
+    await endPtyHandlerTest(handler, originalPlatform)
+  })
+
+  it('retires an entry whose pid the host proves is gone, instead of issuing the ioctl', () => {
+    vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(false)
+    resize.mockImplementation(ebadfResize)
+
+    expect(() =>
+      dispatcher.callNotification('pty.resize', { id: PTY_1, cols: 120, rows: 40 })
+    ).not.toThrow()
+
+    expect(resize).not.toHaveBeenCalled()
+    // The record must leave the pool: while it stays, the relay keeps
+    // advertising a dead shell and `activePtyCount` never reaches zero, so a
+    // relay configured with an unlimited grace never reaches its idle exit.
+    expect(handler.activePtyCount).toBe(0)
+  })
+
+  it('contains an ioctl failure whose process is still live, and keeps the record', () => {
+    vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(true)
+    resize.mockImplementation(ebadfResize)
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+
+    expect(() =>
+      dispatcher.callNotification('pty.resize', { id: PTY_1, cols: 120, rows: 40 })
+    ).not.toThrow()
+    // Repeats must stay contained too — this is the notification the client
+    // re-sends on every reconnect and every window resize.
+    expect(() =>
+      dispatcher.callNotification('pty.resize', { id: PTY_1, cols: 90, rows: 30 })
+    ).not.toThrow()
+
+    // Loss of an fd is not evidence the shell exited, so the claim is retained.
+    expect(handler.activePtyCount).toBe(1)
+    expect(stderr.mock.calls.map(([line]) => String(line)).join('')).toContain(
+      'ioctl(2) failed, EBADF'
+    )
+  })
+
+  it('still resizes a live PTY, with the clamped geometry', () => {
+    vi.spyOn(ptyShellUtils, 'isProcessAlive').mockReturnValue(true)
+
+    dispatcher.callNotification('pty.resize', { id: PTY_1, cols: 4_000, rows: 40 })
+
+    expect(resize).toHaveBeenCalledWith(500, 40)
+    expect(handler.activePtyCount).toBe(1)
+  })
+})

--- a/src/relay/pty-handler-spawn-admission.test.ts
+++ b/src/relay/pty-handler-spawn-admission.test.ts
@@ -87,6 +87,21 @@ describe('PtyHandler', () => {
     expect(notifMethods).not.toContain('pty.ackData')
   })
 
+  it('rescans the process table for a close decision but not for a poll', async () => {
+    const hasChildren = vi.mocked(ptyShellUtils.processHasChildren)
+    const { id } = (await spawnPty({ cols: 80, rows: 24 })) as { id: string }
+    hasChildren.mockClear()
+
+    await dispatcher.callRequest('pty.inspectProcess', { id })
+    // The poll shares the TTL-cached table the foreground lookup already took.
+    expect(hasChildren).toHaveBeenLastCalledWith(mockPtyInstance.pid)
+
+    await dispatcher.callRequest('pty.hasChildProcesses', { id })
+    // This RPC only ever gates a destructive decision (window close, workspace
+    // cleanup), so it has to see a child started inside the 500ms window.
+    expect(hasChildren).toHaveBeenLastCalledWith(mockPtyInstance.pid, { fresh: true })
+  })
+
   it('rejects strict process inspection for a missing relay PTY', async () => {
     await expect(dispatcher.callRequest('pty.inspectProcess', { id: 'missing' })).rejects.toThrow(
       'terminal_gone'

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -2084,18 +2084,23 @@ export class PtyHandler {
     if (!managed || managed.disposed) {
       return
     }
-    // Why probe first (same probe attach() and listProcesses() run): a shell
-    // that exited without node-pty's `onExit` leaves this entry holding a closed
-    // master fd, and `UnixTerminal.resize` has no fd guard — the ioctl throws
-    // `ioctl(2) failed, EBADF` straight out of this notification handler into the
-    // dispatcher's generic parse-error catch, where it is logged and nothing
-    // else. Nothing retired the entry, so it kept being advertised as live and
-    // kept holding `activePtyCount` above zero, which is what stops a relay with
+    // Why probe (same probe attach() and listProcesses() run): a shell that
+    // exited without node-pty's `onExit` leaves an undisposed entry behind, and
+    // while it stays the relay keeps advertising a dead shell and keeps holding
+    // `activePtyCount` above zero, which is what stops a relay with
     // `relayGracePeriodSeconds: 0` from ever reaching its idle-no-ptys exit
-    // (#12423).
+    // (#12423). This is retirement, not ioctl safety: only ESRCH from the host
+    // that owns the pid is evidence of `exited`.
     if (this.reapPtyProvenExited(managed)) {
       return
     }
+    // The patched node-pty retires `_fd` in the same block that gives up the
+    // master (config/patches/node-pty@1.1.0.patch), which makes a resize past
+    // that point a no-op rather than a TIOCSWINSZ aimed at a reused descriptor.
+    // That covers only part of the window and does not cover this process at
+    // all: libuv closes the fd synchronously inside `uv_close`, before the JS
+    // `'close'` that runs `_close()`, and a relay host installs node-pty from
+    // npm, where the patch is not applied. So the catch below stays.
     try {
       managed.pty.resize(cols, rows)
     } catch (err) {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -2240,13 +2240,22 @@ export class PtyHandler {
     managed.reapTimer = timer
   }
 
-  /** Retire every record for a PTY whose process is proven gone. Shared by the attach probe, the
-   *  listing probe and the post-shutdown sweep so the three cannot drift on what "gone" retires. */
-  private reapExitedPty(managed: ManagedPty): void {
+  /**
+   * Retire every record for a PTY whose process is proven gone. Shared by the attach probe, the
+   * listing probe and the post-shutdown sweep so the three cannot drift on what "gone" retires.
+   *
+   * `evidence` is not decoration: `exited` publishes a verdict to the client, and only ESRCH from
+   * the host that owns the pid earns it. The disposed-record sweep retires off our own
+   * bookkeeping, which says we tore the record down — not that the shell died — so it stays
+   * silent (docs/reference/ssh-execution-boundary.md).
+   */
+  private reapExitedPty(managed: ManagedPty, evidence: 'exited' | 'record-torn-down'): void {
     managed.physicalExit?.markExited()
     this.releaseRelayIngress(managed)
     this.flushPtyOutput(managed.id)
-    this.publishReapedExit(managed)
+    if (evidence === 'exited') {
+      this.publishReapedExit(managed)
+    }
     this.notifyExitListener(managed)
     this.agentSessionOwners.release(managed.id)
     disposeManagedPty(managed)
@@ -2264,7 +2273,8 @@ export class PtyHandler {
    * `-1` is this wire's "gone, status unrecoverable": the pid is proven absent
    * (ESRCH from the host that owns it) but nothing waited on the shell, so no
    * status exists. `ssh-relay-session` already publishes the same code for a
-   * dropped lease.
+   * dropped lease. Reached only from the proven-exited path — a client that acts
+   * on this retires the pane, so nothing weaker than ESRCH may reach it.
    */
   private publishReapedExit(managed: ManagedPty): void {
     // Why the guard: node-pty's own `onExit` already queued and published this
@@ -2296,7 +2306,7 @@ export class PtyHandler {
     if (!managed.pty.pid || isProcessAlive(managed.pty.pid)) {
       return false
     }
-    this.reapExitedPty(managed)
+    this.reapExitedPty(managed, 'exited')
     return true
   }
 
@@ -2503,7 +2513,7 @@ export class PtyHandler {
     }
     for (const [entryIndex, [id, managed]] of managedEntries.entries()) {
       if (managed.disposed) {
-        this.reapExitedPty(managed)
+        this.reapExitedPty(managed, 'record-torn-down')
         continue
       }
       if (this.reapPtyProvenExited(managed)) {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -2246,11 +2246,39 @@ export class PtyHandler {
     managed.physicalExit?.markExited()
     this.releaseRelayIngress(managed)
     this.flushPtyOutput(managed.id)
+    this.publishReapedExit(managed)
     this.notifyExitListener(managed)
     this.agentSessionOwners.release(managed.id)
     disposeManagedPty(managed)
     this.removePty(managed.id)
     this.clearPtyFlowState(managed.id)
+  }
+
+  /**
+   * A reap is an exit the client has to hear about. `notifyExitListener` is
+   * relay-internal, so a retirement that stops there leaves the pane mounted
+   * against a session the relay has already forgotten — the next attach answers
+   * `PTY "<id>" not found` and nothing before it said why. `resize` made that
+   * user-triggered.
+   *
+   * `-1` is this wire's "gone, status unrecoverable": the pid is proven absent
+   * (ESRCH from the host that owns it) but nothing waited on the shell, so no
+   * status exists. `ssh-relay-session` already publishes the same code for a
+   * dropped lease.
+   */
+  private publishReapedExit(managed: ManagedPty): void {
+    // Why the guard: node-pty's own `onExit` already queued and published this
+    // pty's real exit code before reaching here, and the sweep also reaps
+    // entries that path left behind.
+    if (managed.exitListenerNotified || this.pendingExitByPty.has(managed.id)) {
+      return
+    }
+    this.pendingExitByPty.set(managed.id, {
+      id: managed.id,
+      code: -1,
+      incarnationId: managed.incarnationId
+    })
+    this.publishPendingExit(managed.id)
   }
 
   /**
@@ -2410,7 +2438,12 @@ export class PtyHandler {
     if (!managed || managed.disposed) {
       return false
     }
-    return await processHasChildren(managed.pty.pid)
+    // Fresh, not TTL-cached: this RPC exists to gate destructive decisions (the
+    // window-close confirmation, workspace cleanup's idle evidence), which act
+    // on the answer once. `pty.inspectProcess` below stays on the shared
+    // snapshot because it is the polled path, where a scan per pane per tick is
+    // the fork storm the cache removed.
+    return await processHasChildren(managed.pty.pid, { fresh: true })
   }
 
   private async getForegroundProcess(params: Record<string, unknown>): Promise<string | null> {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -1963,8 +1963,7 @@ export class PtyHandler {
     }
 
     // Why: verify liveness because shells can exit without node-pty onExit.
-    if (managed.pty.pid && !isProcessAlive(managed.pty.pid)) {
-      this.reapExitedPty(managed)
+    if (this.reapPtyProvenExited(managed)) {
       throw new Error(`PTY "${id}" not found`)
     }
 
@@ -2082,8 +2081,34 @@ export class PtyHandler {
     const cols = Math.max(1, Math.min(500, Math.floor(Number(params.cols) || 80)))
     const rows = Math.max(1, Math.min(500, Math.floor(Number(params.rows) || 24)))
     const managed = this.ptys.get(id)
-    if (managed && !managed.disposed) {
+    if (!managed || managed.disposed) {
+      return
+    }
+    // Why probe first (same probe attach() and listProcesses() run): a shell
+    // that exited without node-pty's `onExit` leaves this entry holding a closed
+    // master fd, and `UnixTerminal.resize` has no fd guard — the ioctl throws
+    // `ioctl(2) failed, EBADF` straight out of this notification handler into the
+    // dispatcher's generic parse-error catch, where it is logged and nothing
+    // else. Nothing retired the entry, so it kept being advertised as live and
+    // kept holding `activePtyCount` above zero, which is what stops a relay with
+    // `relayGracePeriodSeconds: 0` from ever reaching its idle-no-ptys exit
+    // (#12423).
+    if (this.reapPtyProvenExited(managed)) {
+      return
+    }
+    try {
       managed.pty.resize(cols, rows)
+    } catch (err) {
+      // A failed ioctl observed the handle, not the host's process table, so on
+      // its own it is `unverifiable`. Re-probe: a now-absent pid retires the
+      // entry, anything else keeps it and is contained here rather than
+      // escaping as a parse error on every later resize.
+      if (this.reapPtyProvenExited(managed)) {
+        return
+      }
+      process.stderr.write(
+        `[pty-handler] resize failed for PTY ${id} whose process is still live or unverifiable: ${err instanceof Error ? err.message : String(err)}\n`
+      )
     }
   }
 
@@ -2183,9 +2208,7 @@ export class PtyHandler {
       if (this.ptys.get(managed.id) !== managed || managed.disposed) {
         return
       }
-      const pid = managed.pty.pid
-      if (pid && !isProcessAlive(pid)) {
-        this.reapExitedPty(managed)
+      if (this.reapPtyProvenExited(managed)) {
         return
       }
       if (attemptsRemaining <= 0) {
@@ -2223,6 +2246,25 @@ export class PtyHandler {
     disposeManagedPty(managed)
     this.removePty(managed.id)
     this.clearPtyFlowState(managed.id)
+  }
+
+  /**
+   * Retire this entry when the host proves its pid is gone; report whether it was.
+   *
+   * `managed.disposed` is bookkeeping, not liveness: it says we tore the record
+   * down, not that the shell died. A shell can exit without node-pty producing
+   * `onExit`, which leaves a non-disposed entry holding a handle whose master fd
+   * is already closed. Only `isProcessAlive` (ESRCH, from the host that owns the
+   * process) is positive evidence of absence; every other outcome is
+   * `unverifiable` and keeps its record and owner claim
+   * (docs/reference/ssh-execution-boundary.md).
+   */
+  private reapPtyProvenExited(managed: ManagedPty): boolean {
+    if (!managed.pty.pid || isProcessAlive(managed.pty.pid)) {
+      return false
+    }
+    this.reapExitedPty(managed)
+    return true
   }
 
   private async sendSignal(params: Record<string, unknown>): Promise<void> {
@@ -2422,8 +2464,11 @@ export class PtyHandler {
       }
     }
     for (const [entryIndex, [id, managed]] of managedEntries.entries()) {
-      if (managed.disposed || (managed.pty.pid && !isProcessAlive(managed.pty.pid))) {
+      if (managed.disposed) {
         this.reapExitedPty(managed)
+        continue
+      }
+      if (this.reapPtyProvenExited(managed)) {
         continue
       }
       // Reuse batched correlation; per-PTY tree scans recreate O(PTY × rows) work.

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -17,6 +17,7 @@ import { resetProcessTableSnapshotForTests } from '../shared/process-table-snaps
 import {
   getForegroundProcessName,
   isProcessAlive,
+  processHasChildren,
   resolveDefaultCwd,
   resolveWindowsDefaultShell
 } from './pty-shell-utils'
@@ -523,5 +524,66 @@ describe('getForegroundProcessName', () => {
     })
 
     await expect(getForegroundProcessName(100)).resolves.toBe('bash')
+  })
+})
+
+describe('processHasChildren', () => {
+  // Why these assert on argv, not just the answer: the defect in #13537 was the
+  // cost of the answer. `pgrep -P` forks per pane per poll and opens six procfs
+  // files per host process to resolve one ppid, so the contract worth pinning is
+  // "no fork of its own, and share the foreground lookup's cached table".
+  const PS_TABLE = ['100 1 Ss bash', '101 100 S+ node /opt/codex', '200 1 Ss zsh'].join('\n')
+
+  it('answers from the shared process table without forking pgrep', async () => {
+    await withProcessPlatform('linux', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return { stdout: PS_TABLE }
+        }
+        return new Error('unexpected command')
+      })
+
+      await expect(processHasChildren(100)).resolves.toBe(true)
+      await expect(processHasChildren(200)).resolves.toBe(false)
+
+      expect(execFileMock.mock.calls.map((call) => call[0])).not.toContain('pgrep')
+    })
+  })
+
+  it('shares one process-table capture across a burst of panes', async () => {
+    await withProcessPlatform('linux', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return { stdout: PS_TABLE }
+        }
+        return new Error('unexpected command')
+      })
+
+      const answers = await Promise.all([
+        processHasChildren(100),
+        processHasChildren(100),
+        processHasChildren(200),
+        getForegroundProcessName(100, 'bash')
+      ])
+
+      expect(answers).toEqual([true, true, false, 'codex'])
+      expect(execFileMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('reports no children when the process table is unreadable', async () => {
+    await withProcessPlatform('linux', async () => {
+      mockExecFile(() => new Error('ps table unavailable'))
+
+      await expect(processHasChildren(100)).resolves.toBe(false)
+    })
+  })
+
+  it('spawns nothing on Windows, where the answer was always false', async () => {
+    await withProcessPlatform('win32', async () => {
+      await expect(processHasChildren(100)).resolves.toBe(false)
+
+      expect(execFileMock).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -571,6 +571,29 @@ describe('processHasChildren', () => {
     })
   })
 
+  it('rescans for a close decision rather than serving a table from inside the TTL', async () => {
+    await withProcessPlatform('linux', async () => {
+      let table = PS_TABLE
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return { stdout: table }
+        }
+        return new Error('unexpected command')
+      })
+
+      // The poll answers from the cache, which is the whole point of the memo.
+      await expect(processHasChildren(200)).resolves.toBe(false)
+      table = [PS_TABLE, '201 200 S+ npm run build'].join('\n')
+      await expect(processHasChildren(200)).resolves.toBe(false)
+      expect(execFileMock).toHaveBeenCalledTimes(1)
+
+      // A close or cleanup acts on the answer once and destructively, so a
+      // child started inside the 500ms window has to be visible to it.
+      await expect(processHasChildren(200, { fresh: true })).resolves.toBe(true)
+      expect(execFileMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
   it('reports no children when the process table is unreadable', async () => {
     await withProcessPlatform('linux', async () => {
       mockExecFile(() => new Error('ps table unavailable'))

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -10,6 +10,7 @@ import {
 } from '../shared/agent-process-recognition'
 import { getFirstCommandToken } from '../shared/command-token-scanner'
 import {
+  getFreshProcessTableSnapshot,
   getProcessTableSnapshot,
   type ProcessTableIndex,
   type ProcessTableRow
@@ -180,15 +181,26 @@ export async function resolveProcessCwd(pid: number, fallbackCwd: string): Promi
  * ~4k opens per pgrep on a 690-process host, at up to 8 forks/sec (#13537).
  * `getForegroundProcessName` in the same RPC already captured the TTL-cached
  * `ps` table, whose index carries the parent/child map, so the answer is free.
+ *
+ * `fresh` opts out of that TTL. A poll can read a 500ms-old table because its
+ * next tick corrects it, but a close or cleanup decision acts on the answer
+ * once and destructively — a child that started inside the TTL would be killed
+ * with no confirmation. `pgrep` scanned per call, so anything that decides
+ * has to keep scanning per call.
  */
-export async function processHasChildren(pid: number): Promise<boolean> {
+export async function processHasChildren(
+  pid: number,
+  options?: { fresh?: boolean }
+): Promise<boolean> {
   // Windows has no `ps`; the previous `pgrep` fork always failed here too, so
   // this keeps the same answer without spawning anything to reach it.
   if (process.platform === 'win32') {
     return false
   }
   try {
-    const rows = await getProcessTableSnapshot()
+    const rows = options?.fresh
+      ? await getFreshProcessTableSnapshot()
+      : await getProcessTableSnapshot()
     return (getProcessTableIndex(rows).childrenByPpid.get(pid)?.length ?? 0) > 0
   } catch {
     return false

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -170,15 +170,26 @@ export async function resolveProcessCwd(pid: number, fallbackCwd: string): Promi
 }
 
 /**
- * Check whether a process has child processes (via pgrep).
+ * Check whether a process has child processes.
+ *
+ * Why the shared snapshot and not `pgrep -P`: this answers one field of
+ * `pty.inspectProcess`, which every tracked pane polls on a 750ms/2000ms
+ * cadence, and the fork was neither cached nor coalesced. procps-ng opens six
+ * procfs files per process to resolve a ppid — including a `/proc/<pid>/ctty`
+ * that never exists on Linux — so one call cost O(host process count) syscalls,
+ * ~4k opens per pgrep on a 690-process host, at up to 8 forks/sec (#13537).
+ * `getForegroundProcessName` in the same RPC already captured the TTL-cached
+ * `ps` table, whose index carries the parent/child map, so the answer is free.
  */
 export async function processHasChildren(pid: number): Promise<boolean> {
+  // Windows has no `ps`; the previous `pgrep` fork always failed here too, so
+  // this keeps the same answer without spawning anything to reach it.
+  if (process.platform === 'win32') {
+    return false
+  }
   try {
-    const { stdout } = await execFile('pgrep', ['-P', String(pid)], {
-      encoding: 'utf-8',
-      timeout: 3000
-    })
-    return stdout.trim().length > 0
+    const rows = await getProcessTableSnapshot()
+    return (getProcessTableIndex(rows).childrenByPpid.get(pid)?.length ?? 0) > 0
   } catch {
     return false
   }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15962,7 +15962,8 @@
           "none": "None",
           "search": "Search",
           "showUnreadOnly": "Show unread only",
-          "showChildAgents": "Show child agents"
+          "showChildAgents": "Show child agents",
+          "activityOptions": "Activity options"
         },
         "clearCompleted": {
           "clearedOne": "Cleared 1 completed agent",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17260,7 +17260,9 @@
   "dashboard": {
     "sidebar": {
       "label": "Agents",
-      "dashboardLabel": "Agent Dashboard"
+      "dashboardLabel": "Agent Dashboard",
+      "openActivity": "View activity",
+      "closeActivity": "Turn off activity view"
     }
   },
   "runtimeRpc": {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​686 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​686 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​411 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​49 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​362 |

<!-- /orca-pr-loc -->

Three long-session relay defects. Each has a test that fails before and passes after; both outputs below.

## #12423 — a resize ioctl against a closed fd, and the entry that never dies

`PtyHandler.resize` (`pty-handler.ts:2056`) gated only on `managed.disposed`, which is bookkeeping ("we tore the record down"), not liveness. The relay's own code documents the gap twice — `:1941` *"verify liveness because shells can exit without node-pty onExit"* and `:2377` *"an unverified entry advertised that session forever."*

When a shell exits without `onExit`, the entry stays in `this.ptys` with `disposed === false` while node-pty has already closed the master fd. `node-pty/lib/unixTerminal.js:253-259` has **no fd guard**, so the ioctl throws `ioctl(2) failed, EBADF` out of the notification handler and into the dispatcher's generic catch (`dispatcher-frame-codec.ts:29-35`) — which is exactly why the reporter's log says `Parse error: ioctl(2) failed, EBADF`. That catch logs and does nothing.

**Nothing retires the entry**, so it stays advertised as live and keeps `activePtyCount > 0`. That is the load-bearing consequence: `relay-grace-lifecycle.ts:65,88` and `relay-grace-branch.ts:114-119` key the idle-exit branch on `activePtyCount === 0`, so with `relayGracePeriodSeconds: 0` a relay pinned by dead entries **never reaches its idle exit** — the "wedged relay never exits" and "`ptys=4` stays at 4 no matter how many tabs I open" complaints.

Fix: `reapPtyProvenExited` retires only on `isProcessAlive` returning ESRCH-false — positive evidence of absence from the host that owns the process. `resize` probes before the ioctl and re-probes if it still throws; a provably dead pid is retired, anything else stays `unverifiable`, keeps its record and owner claim, and is contained with a stderr line. Per `ssh-execution-boundary.md`, a failed ioctl observes the *handle*, not the host's process table, so it is never on its own treated as `exited`. The three other inline liveness probes were routed onto the same helper so the four cannot drift.

**Caveat, stated plainly:** the use-after-free, the EBADF escape path and the never-retired entry are all proven. A literal 95%-CPU spin from this path was **not** reproduced, and the resize throw alone should not produce one — `FrameDecoder.drainTurn` is bounded per turn and `handleFrame` catches. The read is that the reporter's "spin" and "never exits" are the same stale-entry cause seen from two angles, plus #13537's separate `pgrep` storm. Fixed at the lifecycle level; if a spin persists it is a different defect and needs re-measuring.

```
BEFORE  AssertionError: expected [Function] to not throw an error but 'Error: ioctl(2) failed, EBADF' was thrown
        Tests  2 failed | 1 passed (3)
AFTER   Tests  3 passed (3)
```

## #13537 — the title is a misnomer; the relay never scans ctty, it forks something that does

`processHasChildren` (`pty-shell-utils.ts:177`) forked `pgrep -P <pid>` with **no cache, no TTL, no in-flight coalescing**, once per `pty.inspectProcess` — which every tracked pane polls at 750ms/2000ms up to a global 8/s cap. procps-ng opens six procfs files per process to resolve one ppid, including `/proc/<pid>/ctty`, which never exists on Linux. One call cost ~4,100 opens on the reporter's 690-process host.

The sibling `ps` scan is already TTL-cached at 500ms; this fork was the one uncapped term riding alongside it. Fix: answer from the shared cached table the *same RPC* already captured — `getProcessTableIndex(rows).childrenByPpid.get(pid)`. Zero forks; a burst of panes collapses to one `ps` per 500ms window. Windows returns `false` without spawning, identical to before (where the fork always failed).

```
BEFORE  - [ true, true, false, "codex" ]   (expected)
        + [ false, false, false, "codex" ] (received)
        Tests  3 failed | 30 passed (33)   — plus the Windows case timing out at 30s trying to fork
AFTER   Tests  33 passed (33)
```

## #13753 — the relay scanner had no parse cache at all

`session-scanner-parse-cache.ts` (mtime+size keyed, 4096-entry LRU) is wired only into the *local desktop* scanner. The relay sidecar's `parseRemoteSessionCandidate` (`remote-session-scanner.ts:220-232`) did an unconditional `readFile` + full parse per candidate — up to 2000 whole-file reads per pass plus 1000 for scope backfill. Its only memo, `titleCaches: new Map()` at `:60`, is allocated per call and discarded on return. The 30s cadence is a renderer throttle whose `force: true` bypasses every result cache in between, and the sidecar survives 10 idle minutes — so a cache placed there *would* span every tick; there just wasn't one.

Fix: a module-scope LRU keyed by path, validated on `(mtimeMs, sizeBytes, hostKey)`. `(mtime, size)` is sound because discovery already folds a source's `contentDependencyPath` stat into both, so a metadata-only transcript whose companion changed still looks changed. The read is *inside* the cached parse, so an unchanged transcript is never pulled off disk. Only completed parses are stored, so a transient failure cannot pin a wrong answer. **The 30s interval was not widened** — the root fix is not re-reading, not polling less.

```
BEFORE  AssertionError: expected [ …(3) ] to deeply equal []
        Tests  1 failed | 4 passed (5)
AFTER   Tests  5 passed (5)
```

## Verification

```
$ pnpm test src/relay/ src/main/ai-vault/
 Test Files  229 passed
      Tests  2051 passed | 2 skipped

$ pnpm tc:node                            # clean
$ pnpm run check:code-quality:changed     # 0 new findings across 7 changed files
```

`pty-handler-revive.test.ts > scopes HISTFILE past the wsl.exe wrapper` failed once in a combined run; it is pre-existing flake, passing in isolation both with and without these changes, and the stashed-fix baseline showed it green.

## Follow-ups found, deliberately not done

- `FORCED_SCAN_PREEMPT_AFTER_MS = 5_000` and the comment at `session-scanner-parse-cache.ts:172` both still claim a ~5s forced rescan; it is 30s now.
- Remote *discovery* is still unbounded — it `lstat`s every file in the corpus before any recency filter — so the per-pass syscall floor still grows with corpus size even though read/parse cost no longer does.

Fixes #12423, #13537, #13753

---

## ELI5

Three things made the remote helper burn CPU forever: resizing a terminal whose process had already died, forking a process-tree lookup on every poll, and re-reading every agent transcript on disk every 30 seconds.

## User-facing regression risk

- Terminal resize now checks the process is alive before the ioctl — one extra syscall per resize, on a path that is not hot.
- Entries whose process the host **proves** is gone are now retired. A PTY that was being advertised as live-but-dead will now disappear from listings, which is correct but is a visible change.
- **Honest limit:** the literal 95%-CPU spin in #12423 was not reproduced. The use-after-free and the never-retired entry are proven; if a spin persists it is a different defect.
