### PR TITLE
fix(wsl): name an explicit Windows cwd for wsl.exe spawns

### DIFF
--- a/config/tsconfig.tc.web.json
+++ b/config/tsconfig.tc.web.json
@@ -20,6 +20,7 @@
     "../src/main/wsl-distro-retry.ts",
     "../src/main/wsl-running-distro-cache.ts",
     "../src/main/wsl.ts",
+    "../src/main/wsl-interop-spawn-directory.ts",
     "../src/main/persistence/applying-settings/ui-state-read.ts",
     "../src/main/persistence/applying-settings/ui-state-update.ts",
     "../src/main/persistence/applying-settings/ui-selection-normalization.ts",

--- a/src/main/agent-hooks/wsl-hook-relay-launch.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn((..._args: unknown[]) => ({ pid: 1 }))
+}))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+import { spawnWslRelayProcess } from './wsl-hook-relay-launch'
+
+describe('spawnWslRelayProcess', () => {
+  it('names an explicit Windows directory rather than inheriting one', () => {
+    spawnWslRelayProcess('Ubuntu', {}, '1.2.3')
+
+    // Why (#16463): the guest path is inside the `sh -c` command, so the Windows
+    // cwd only decides whether CreateProcessW succeeds. Omitting it inherits
+    // Orca's own — a `\\wsl.localhost` worktree the user can delete, after which
+    // every relay launch fails `spawn wsl.exe ENOENT` for the rest of the session.
+    expect(spawnMock).toHaveBeenCalledWith(
+      'wsl.exe',
+      expect.arrayContaining(['-d', 'Ubuntu', '--exec']),
+      expect.objectContaining({ cwd: expect.any(String) })
+    )
+  })
+})

--- a/src/main/agent-hooks/wsl-hook-relay-launch.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.ts
@@ -16,6 +16,7 @@ import {
 } from './wsl-hook-relay-sentinel'
 import { addOrcaWslInteropEnv } from '../pty/wsl-orca-env'
 import { runWslProcess } from '../wsl/wsl-runner'
+import { resolveWslInteropSpawnCwd } from '../wsl-interop-spawn-directory'
 import { listRunningWslDistrosAsync } from '../wsl'
 import {
   WSL_HOOK_RELAY_BUNDLE_NAME,
@@ -137,7 +138,11 @@ export function spawnWslRelayProcess(
   return spawn('wsl.exe', ['-d', distro, '--exec', 'sh', '-c', command], {
     env,
     stdio: ['pipe', 'pipe', 'pipe'],
-    windowsHide: true
+    windowsHide: true,
+    // Why explicit (#16463): the guest path is in `command`, so the Windows cwd
+    // only decides whether CreateProcessW succeeds -- and an inherited one is a
+    // worktree the user can delete, which kills every later relay launch.
+    cwd: resolveWslInteropSpawnCwd()
   })
 }
 

--- a/src/main/cli/wsl-cli-installer.test.ts
+++ b/src/main/cli/wsl-cli-installer.test.ts
@@ -340,7 +340,13 @@ describe('WslCliInstaller', () => {
     expect(bridge).toContain('$ForwardArgs = @($args[$ForwardArgStart..($args.Count - 1)])')
     expect(bridge).toContain('if ([string]::IsNullOrEmpty($WslCwd))')
     expect(bridge).toContain('$env:ORCA_CLI_CWD = $WslCwd')
-    expect(bridge).toContain('Push-Location -LiteralPath (Split-Path -Parent $OrcaLauncher)')
+    expect(bridge).toContain('$LauncherDirectory = Split-Path -Parent $OrcaLauncher')
+    expect(bridge).toContain('Push-Location -LiteralPath $LauncherDirectory')
+    // Why (#16463): Push-Location moves only the PowerShell provider location.
+    // Without an explicit WorkingDirectory the started app inherits the caller's
+    // Win32 cwd — the user's worktree on \\wsl.localhost — and every wsl.exe
+    // spawn it makes dies with ENOENT once that worktree is removed.
+    expect(bridge).toContain('$StartInfo.WorkingDirectory = $LauncherDirectory')
     expect(bridge).toContain('function ConvertTo-NativeCommandLineArgument')
     expect(bridge).toContain("[void]$Quoted.Append([char]'\\', $BackslashCount * 2 + 1)")
     expect(bridge).toContain('$StartInfo.UseShellExecute = $false')

--- a/src/main/cli/wsl-cli-scripts.ts
+++ b/src/main/cli/wsl-cli-scripts.ts
@@ -88,7 +88,8 @@ try {
   } else {
     $env:ORCA_CLI_CWD = $WslCwd
   }
-  Push-Location -LiteralPath (Split-Path -Parent $OrcaLauncher)
+  $LauncherDirectory = Split-Path -Parent $OrcaLauncher
+  Push-Location -LiteralPath $LauncherDirectory
   # Why: Windows PowerShell 5.1 cannot losslessly splat strings to native argv.
   $StartInfo = [System.Diagnostics.ProcessStartInfo]::new()
   $StartInfo.FileName = $OrcaLauncher
@@ -96,6 +97,13 @@ try {
     ConvertTo-NativeCommandLineArgument $_
   }) -join ' ')
   $StartInfo.UseShellExecute = $false
+  # Why (#16463): Push-Location moves the PowerShell provider location, not the
+  # Win32 current directory, and an empty WorkingDirectory with UseShellExecute
+  # disabled means "inherit the caller's". Launched from a WSL shell that is the
+  # user's worktree on the 9P share, so without this the app stands in a
+  # directory Linux can delete -- after which every CreateProcessW it makes
+  # fails ERROR_PATH_NOT_FOUND, reported as: spawn wsl.exe ENOENT.
+  $StartInfo.WorkingDirectory = $LauncherDirectory
   $Process = [System.Diagnostics.Process]::Start($StartInfo)
   if ($null -eq $Process) {
     throw 'Unable to start the Orca Windows CLI launcher.'

--- a/src/main/git/command-runner/wsl-command-resolution.ts
+++ b/src/main/git/command-runner/wsl-command-resolution.ts
@@ -13,6 +13,7 @@ import {
   type WslProcessGroupTermination
 } from '../wsl-process-group-termination'
 import { translateArgForWsl, translateArgsForWsl } from './wsl-path-translation'
+import { resolveWslInteropSpawnCwd } from '../../wsl-interop-spawn-directory'
 
 // Env-assignment prefix for WSL-routed git, where spawn env can't cross the wsl.exe boundary; values are shell-safe unquoted.
 const GIT_OUTPUT_LOCALE_SHELL_PREFIX = Object.entries(UNTRANSLATED_GIT_OUTPUT_ENV)
@@ -111,7 +112,7 @@ export function resolveCommand(
           ...(linuxCwd ? ['-C', linuxCwd] : []),
           ...translatedArgs
         ],
-        cwd: undefined,
+        cwd: resolveWslInteropSpawnCwd(),
         wsl,
         wslMode: 'direct-git'
       },
@@ -130,7 +131,7 @@ export function resolveCommand(
         {
           binary: 'wsl.exe',
           args: buildWslExecArgs(wsl.distro, ['sh', '-lc', captured.command]),
-          cwd: undefined,
+          cwd: resolveWslInteropSpawnCwd(),
           wsl,
           wslMode: 'login-shell',
           captured
@@ -142,7 +143,7 @@ export function resolveCommand(
       {
         binary: 'wsl.exe',
         args: buildWslExecArgs(wsl.distro, ['sh', '-lc', buildWslLoginShellCommand(shellCmd)]),
-        cwd: undefined,
+        cwd: resolveWslInteropSpawnCwd(),
         wsl,
         wslMode: 'login-shell'
       },
@@ -154,8 +155,11 @@ export function resolveCommand(
     {
       binary: 'wsl.exe',
       args: buildWslExecArgs(wsl.distro, ['bash', '-c', shellCmd]),
-      // Why: the `cd` inside bash -c handles the directory; a UNC cwd on the Node process is redundant and can break Node internals.
-      cwd: undefined,
+      // Why: the `cd` inside bash -c handles the Linux directory. This names an
+      // explicit Windows directory anyway, because `undefined` makes
+      // CreateProcessW inherit the parent's — which is a deletable WSL UNC path
+      // when Orca was launched from a worktree (#16463).
+      cwd: resolveWslInteropSpawnCwd(),
       wsl,
       wslMode: 'non-login-shell'
     },

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -626,7 +626,11 @@ describe('runner execFile timeout handling', () => {
       expect(execFileMock).toHaveBeenCalledWith(
         'wsl.exe',
         ['-d', 'Ubuntu', '--exec', 'sh', '-lc', expect.any(String)],
-        expect.objectContaining({ cwd: undefined }),
+        // Why a concrete directory (#16463): `undefined` makes CreateProcessW inherit
+        // Orca's own cwd, a deletable WSL UNC path when it was launched from a
+        // worktree. The Linux directory still rides inside the command (/mnt/c/repo,
+        // asserted below).
+        expect.objectContaining({ cwd: expect.any(String) }),
         expect.any(Function)
       )
       // A read also warms the direct-git environment probe in the background, so
@@ -659,7 +663,11 @@ describe('runner execFile timeout handling', () => {
       expect(execFileMock).toHaveBeenCalledWith(
         'wsl.exe',
         ['-d', 'Ubuntu', '--exec', 'bash', '-c', expect.any(String)],
-        expect.objectContaining({ cwd: undefined }),
+        // Why a concrete directory (#16463): `undefined` makes CreateProcessW inherit
+        // Orca's own cwd, a deletable WSL UNC path when it was launched from a
+        // worktree. The Linux directory still rides inside the command (/mnt/c/repo,
+        // asserted below).
+        expect.objectContaining({ cwd: expect.any(String) }),
         expect.any(Function)
       )
       const shellCommand = execFileMock.mock.calls[0]?.[1]?.[5] as string

--- a/src/main/git/runner-wsl-gh-fallback.test.ts
+++ b/src/main/git/runner-wsl-gh-fallback.test.ts
@@ -99,7 +99,10 @@ describe('ghExecFileAsync WSL fallback', () => {
         '-c',
         "cd '/home/jinwoo/stably/noqa' && 'gh' 'issue' 'list' '--repo' 'stablyhq/noqa' '--json' 'number,title'"
       ],
-      expect.objectContaining({ cwd: undefined }),
+      // Why a concrete directory (#16463): `undefined` makes CreateProcessW inherit
+      // Orca's own cwd, a deletable WSL UNC path when it was launched from a
+      // worktree. The Linux directory still rides inside the command.
+      expect.objectContaining({ cwd: expect.any(String) }),
       expect.any(Function)
     )
     expect(execFileMock).toHaveBeenNthCalledWith(
@@ -382,7 +385,11 @@ describe('ghExecFileAsync WSL fallback', () => {
       2,
       'wsl.exe',
       ['-d', 'Ubuntu', '--exec', 'bash', '-c', "'gh' 'api' 'rate_limit'"],
-      expect.objectContaining({ cwd: undefined }),
+      // Why a concrete directory (#16463): `undefined` makes CreateProcessW inherit
+      // Orca's own cwd, a deletable WSL UNC path when it was launched from a
+      // worktree. This global call has no repo directory at all, so nothing about
+      // where it runs changes.
+      expect.objectContaining({ cwd: expect.any(String) }),
       expect.any(Function)
     )
   })
@@ -501,7 +508,11 @@ describe('ghExecFileAsync WSL fallback', () => {
       2,
       'wsl.exe',
       ['-d', 'Ubuntu', '--exec', 'bash', '-c', "'glab' 'api' 'projects'"],
-      expect.objectContaining({ cwd: undefined }),
+      // Why a concrete directory (#16463): `undefined` makes CreateProcessW inherit
+      // Orca's own cwd, a deletable WSL UNC path when it was launched from a
+      // worktree. This global call has no repo directory at all, so nothing about
+      // where it runs changes.
+      expect.objectContaining({ cwd: expect.any(String) }),
       expect.any(Function)
     )
   })

--- a/src/main/gitlab/gitlab-known-host-probe-wsl-fallback.test.ts
+++ b/src/main/gitlab/gitlab-known-host-probe-wsl-fallback.test.ts
@@ -76,7 +76,11 @@ describe('glab known-hosts probe on Windows', () => {
     expect(execFileMock).toHaveBeenCalledWith(
       'wsl.exe',
       ['-d', 'Ubuntu', '--exec', 'bash', '-c', "'glab' 'auth' 'status'"],
-      expect.objectContaining({ cwd: undefined }),
+      // Why a concrete directory (#16463): `undefined` makes CreateProcessW inherit
+      // Orca's own cwd, a deletable WSL UNC path when it was launched from a
+      // worktree. This probe has no repo directory at all, so nothing about where
+      // it runs changes. The native `glab` assertion above keeps `undefined`.
+      expect.objectContaining({ cwd: expect.any(String) }),
       expect.any(Function)
     )
   })

--- a/src/main/ipc/filesystem-watcher-wsl.test.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.test.ts
@@ -95,7 +95,11 @@ describe('createWslWatcher', () => {
       ['-d', 'Ubuntu', '--exec', 'sh', '-s', '--', '/home/me/repo'],
       expect.objectContaining({
         stdio: ['pipe', 'pipe', 'pipe'],
-        windowsHide: true
+        windowsHide: true,
+        // Why a concrete directory (#16463): the watched path rides in argv, so
+        // an omitted cwd only means CreateProcessW inherits Orca's -- a worktree
+        // that can be deleted, after which every watcher start is ENOENT.
+        cwd: expect.any(String)
       })
     )
   })

--- a/src/main/ipc/filesystem-watcher-wsl.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.ts
@@ -14,6 +14,7 @@ import { parseWslUncPath } from '../../shared/wsl-paths'
 import { createWslWatcherProcessExit, createWslWatcherStartup } from './wsl-watcher-process-exit'
 import { reserveWatcherChild, WatcherChildCapacityError } from './parcel-watcher-child-registry'
 import { createDebouncedBatch, type DebouncedBatch } from './filesystem-watcher-batch-control'
+import { resolveWslInteropSpawnCwd } from '../wsl-interop-spawn-directory'
 
 export type WatcherSubscription = {
   unsubscribe(): Promise<void>
@@ -244,7 +245,11 @@ export async function createWslWatcher(
   try {
     child = spawn('wsl.exe', ['-d', distro, '--exec', 'sh', '-s', '--', linuxPath], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      windowsHide: true
+      windowsHide: true,
+      // Why explicit (#16463): the watched directory rides in argv, and an
+      // inherited cwd is a worktree that can be deleted -- after which every
+      // watcher start fails `spawn wsl.exe ENOENT`.
+      cwd: resolveWslInteropSpawnCwd()
     })
   } catch (error) {
     releaseChildReservation()

--- a/src/main/local-worktree-filesystem.test.ts
+++ b/src/main/local-worktree-filesystem.test.ts
@@ -188,7 +188,11 @@ describe('local worktree filesystem runtime access', () => {
         1,
         expect.objectContaining({
           program: 'wsl.exe',
-          args: expect.arrayContaining(['-d', 'Ubuntu'])
+          args: expect.arrayContaining(['-d', 'Ubuntu']),
+          // Why a concrete directory (#16463): the guest path is inside the
+          // command, and these run while a worktree is being removed -- which is
+          // the cwd an omitted one would inherit.
+          cwd: expect.any(String)
         })
       )
       const removeArgs = runProcessMock.mock.calls[2]?.[0].args as string[]

--- a/src/main/local-worktree-filesystem.ts
+++ b/src/main/local-worktree-filesystem.ts
@@ -3,6 +3,7 @@ import { lstat, readFile } from 'node:fs/promises'
 import { buildWslExecArgs, quotePosixShell } from '../shared/wsl-login-shell-command'
 import { removeHostTree } from './host-tree-removal'
 import { toLinuxPath } from './wsl'
+import { resolveWslInteropSpawnCwd } from './wsl-interop-spawn-directory'
 import type { ReadPath, StatPath } from './worktree-orphan-gitdir-proof'
 
 export { toHostFilesystemPath, toHostRemovalPath } from './host-tree-removal'
@@ -36,6 +37,10 @@ async function runWslCommand(distro: string, command: string): Promise<string> {
   const result = await runProcess({
     program: 'wsl.exe',
     args: buildWslExecArgs(distro, ['sh', '-c', command]),
+    // Why explicit (#16463): the guest path is inside `command`, so this only
+    // decides whether CreateProcessW succeeds -- and these calls run while a
+    // worktree is being removed, which is the cwd an inherited one would be.
+    cwd: resolveWslInteropSpawnCwd(),
     timeoutMs: WSL_FILE_OPERATION_TIMEOUT_MS
   })
   if (result.timedOut) {

--- a/src/main/text-generation/commit-message-text-generation-local-subprocess.test.ts
+++ b/src/main/text-generation/commit-message-text-generation-local-subprocess.test.ts
@@ -164,7 +164,11 @@ describe('generateCommitMessageFromContext', () => {
         'wsl.exe',
         ['-d', 'Ubuntu 24.04', '--exec', 'sh', '-lc', expect.any(String)],
         expect.objectContaining({
-          cwd: undefined,
+          // Why a concrete directory (#16463): `undefined` makes CreateProcessW inherit
+          // Orca's own cwd, a deletable WSL UNC path when it was launched from a
+          // worktree. The Linux directory still rides inside the command (/mnt/c/repo,
+          // asserted below), so the Windows-side cwd never decides where the agent runs.
+          cwd: expect.any(String),
           windowsHide: true,
           env: expect.objectContaining({ CODEX_HOME: '/home/tester/.codex' })
         })

--- a/src/main/text-generation/commit-message-text-generation-model-discovery.test.ts
+++ b/src/main/text-generation/commit-message-text-generation-model-discovery.test.ts
@@ -235,7 +235,11 @@ describe('discoverCommitMessageModelsLocal', () => {
         'wsl.exe',
         ['-d', 'Ubuntu', '--exec', 'sh', '-lc', expect.any(String)],
         expect.objectContaining({
-          cwd: undefined,
+          // Why a concrete directory (#16463): `undefined` makes CreateProcessW inherit
+          // Orca's own cwd, a deletable WSL UNC path when it was launched from a
+          // worktree. The Linux directory still rides inside the command (/mnt/c/repo,
+          // asserted below), so the Windows-side cwd never decides where discovery runs.
+          cwd: expect.any(String),
           windowsHide: true
         })
       )

--- a/src/main/wsl-availability.ts
+++ b/src/main/wsl-availability.ts
@@ -1,4 +1,5 @@
 import { execFile, execFileSync } from 'node:child_process'
+import { resolveWslInteropSpawnCwd } from './wsl-interop-spawn-directory'
 
 type WslAvailabilityCache =
   | { available: true }
@@ -35,6 +36,9 @@ function wslAvailabilityRetryDelayMs(cache: { retryable: boolean; failures: numb
   return Math.min(base * 2 ** (cache.failures - 1), WSL_AVAILABILITY_MAX_RETRY_DELAY_MS)
 }
 
+// Why ENOENT stays definitive: it means wsl.exe is not on PATH. It used to also mean
+// "the cwd this process inherited was deleted", which is not answer-shaped at all --
+// naming an explicit spawn directory below is what removes that source (#16463).
 // Why: a non-zero exit (wsl.exe ran and said no) or ENOENT (not installed) is answer-shaped,
 // so it earns a long window rather than the short one a timeout gets. execFileSync reports the
 // exit code as `status`, the execFile callback as a numeric `code`; both must count as
@@ -95,7 +99,14 @@ function probeWslStatus(): Promise<void> {
     execFile(
       'wsl.exe',
       ['--status'],
-      { timeout: WSL_AVAILABILITY_PROBE_TIMEOUT_MS, windowsHide: true },
+      {
+        timeout: WSL_AVAILABILITY_PROBE_TIMEOUT_MS,
+        windowsHide: true,
+        // Why explicit (#16463): inheriting a cwd the user deleted makes
+        // CreateProcessW fail ENOENT, which this cache reads as "WSL is not
+        // installed" and holds on the definitive TTL with backoff.
+        cwd: resolveWslInteropSpawnCwd()
+      },
       (error: unknown) => {
         if (error) {
           reject(error)
@@ -129,7 +140,10 @@ export function isWslAvailable(): boolean {
   try {
     execFileSync('wsl.exe', ['--status'], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: WSL_AVAILABILITY_PROBE_TIMEOUT_MS
+      timeout: WSL_AVAILABILITY_PROBE_TIMEOUT_MS,
+      // Same reason as the async twin: they share one cache, so a false ENOENT
+      // from either poisons both.
+      cwd: resolveWslInteropSpawnCwd()
     })
     return cacheWslAvailabilityProbeResult(null, startedAtGeneration)
   } catch (error) {

--- a/src/main/wsl-interop-spawn-directory.test.ts
+++ b/src/main/wsl-interop-spawn-directory.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  resetWslInteropSpawnDirectoryCache,
+  resolveWslInteropSpawnCwd
+} from './wsl-interop-spawn-directory'
+
+// Regression coverage for #16463 ("Removing the worktree Orca was launched from
+// breaks every wsl.exe spawn for the rest of the session"). The WSL command
+// builders passed `cwd: undefined` meaning "the directory is inside the
+// command", but CreateProcessW reads NULL as "inherit the parent's" — and the
+// parent's was a `\\wsl.localhost\...` worktree Linux had just deleted. 1805 of
+// 1806 git calls then failed `spawn wsl.exe ENOENT` until the app restarted.
+
+const createdRoots: string[] = []
+
+function makeExistingDirectory(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-wsl-spawn-cwd-'))
+  createdRoots.push(dir)
+  return dir
+}
+
+const ENV_KEYS = ['ORCA_USER_DATA_PATH', 'USERPROFILE', 'HOMEDRIVE', 'HOMEPATH'] as const
+const savedEnv = new Map<string, string | undefined>()
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv.set(key, process.env[key])
+    delete process.env[key]
+  }
+  resetWslInteropSpawnDirectoryCache()
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const saved = savedEnv.get(key)
+    if (saved === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = saved
+    }
+  }
+  resetWslInteropSpawnDirectoryCache()
+  while (createdRoots.length > 0) {
+    rmSync(createdRoots.pop()!, { recursive: true, force: true })
+  }
+})
+
+describe('resolveWslInteropSpawnCwd', () => {
+  it('names the app-owned directory first, so no worktree can be the answer', () => {
+    const userData = makeExistingDirectory()
+    process.env.ORCA_USER_DATA_PATH = userData
+    process.env.USERPROFILE = makeExistingDirectory()
+
+    expect(resolveWslInteropSpawnCwd()).toBe(userData)
+  })
+
+  it('skips a candidate that does not resolve instead of naming it', () => {
+    process.env.ORCA_USER_DATA_PATH = join(tmpdir(), 'orca-wsl-spawn-cwd-never-created')
+    const profile = makeExistingDirectory()
+    process.env.USERPROFILE = profile
+
+    expect(resolveWslInteropSpawnCwd()).toBe(profile)
+  })
+
+  it('always names some directory rather than letting the spawn inherit one', () => {
+    // Why: inheriting is the failure mode. With no configured candidate at all
+    // the home directory and system root still stand between a spawn and the
+    // parent's cwd.
+    expect(resolveWslInteropSpawnCwd()).toEqual(expect.any(String))
+  })
+
+  it('re-answers after the directory it memoized goes away mid-session', () => {
+    // This is the incident: the chosen directory was valid when the process
+    // started and was deleted underneath it hours later. A memo that is never
+    // re-validated reproduces the original bug one layer up.
+    const doomed = makeExistingDirectory()
+    process.env.ORCA_USER_DATA_PATH = doomed
+    const survivor = makeExistingDirectory()
+    expect(resolveWslInteropSpawnCwd()).toBe(doomed)
+
+    rmSync(doomed, { recursive: true, force: true })
+    process.env.ORCA_USER_DATA_PATH = survivor
+
+    expect(resolveWslInteropSpawnCwd()).toBe(survivor)
+  })
+})

--- a/src/main/wsl-interop-spawn-directory.ts
+++ b/src/main/wsl-interop-spawn-directory.ts
@@ -1,0 +1,70 @@
+import { statSync } from 'node:fs'
+import { homedir } from 'node:os'
+
+/**
+ * A Windows directory that is safe to hand `wsl.exe` as its working directory.
+ *
+ * Why this exists (#16463): the WSL command builders set `cwd: undefined`,
+ * meaning "the directory is already expressed inside the command" — but that is
+ * not what `undefined` means to `CreateProcessW`. libuv passes NULL for
+ * `lpCurrentDirectory`, and NULL means *inherit the parent's*. Orca launched by
+ * `orca-ide` from a WSL shell inherits `\\wsl.localhost\<distro>\...\<worktree>`
+ * as its Win32 cwd; Linux can delete that directory out from under a Windows
+ * process across the 9P share, and from then on `CreateProcessW` fails
+ * `ERROR_PATH_NOT_FOUND` — surfaced by libuv as `spawn wsl.exe ENOENT`, for the
+ * rest of the process's life, for every repository.
+ *
+ * Naming an explicit directory removes the dependency on process-global state
+ * entirely, so a repaired or unrepaired `process.cwd()` cannot decide whether
+ * git works. It is never the cwd the command runs in: WSL invocations carry
+ * their Linux directory in `git -C`, a `cd` inside `bash -c`, or the `sh -c`
+ * wrapper `withGuestCwd` builds.
+ */
+
+let cachedSpawnCwd: string | null = null
+
+function isExistingDirectory(path: string | undefined | null): path is string {
+  if (!path) {
+    return false
+  }
+  try {
+    return statSync(path).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/** Test seam: forget the memoized directory so a later probe re-validates. */
+export function resetWslInteropSpawnDirectoryCache(): void {
+  cachedSpawnCwd = null
+}
+
+export function resolveWslInteropSpawnCwd(): string | undefined {
+  // Why re-validate: the answer is only useful while it still resolves, and the
+  // user's profile directory can go away on a roaming/mapped-drive host.
+  if (isExistingDirectory(cachedSpawnCwd)) {
+    return cachedSpawnCwd
+  }
+  const env = process.env
+  // Why this order: an app-owned directory first (it outlives every worktree),
+  // then the user's profile, then the system root as a floor that always exists.
+  // A root is fine here — nothing scans this directory, it is only the value
+  // `CreateProcessW` receives for `lpCurrentDirectory`.
+  const candidates: (string | undefined)[] = [
+    env.ORCA_USER_DATA_PATH,
+    env.USERPROFILE,
+    env.HOMEDRIVE && env.HOMEPATH ? `${env.HOMEDRIVE}${env.HOMEPATH}` : undefined,
+    homedir(),
+    env.SystemDrive ? `${env.SystemDrive}\\` : 'C:\\'
+  ]
+  for (const candidate of candidates) {
+    if (isExistingDirectory(candidate)) {
+      cachedSpawnCwd = candidate
+      return candidate
+    }
+  }
+  cachedSpawnCwd = null
+  // Why undefined rather than a guess: inheriting is still better than naming a
+  // directory we just proved does not exist.
+  return undefined
+}

--- a/src/main/wsl-unc-delete.test.ts
+++ b/src/main/wsl-unc-delete.test.ts
@@ -50,8 +50,11 @@ describe('tryDeleteWslUncPath', () => {
     })
 
     expect(execFileMock).toHaveBeenCalledTimes(1)
-    const [binary, spawnArgs] = execFileMock.mock.calls[0]
+    const [binary, spawnArgs, spawnOptions] = execFileMock.mock.calls[0]
     expect(binary).toBe('wsl.exe')
+    // Why a concrete directory (#16463): this deletes worktrees, so the cwd it
+    // would otherwise inherit is the very directory about to disappear.
+    expect(spawnOptions).toEqual(expect.objectContaining({ cwd: expect.any(String) }))
     expect(spawnArgs).toEqual([
       '-d',
       'Ubuntu',

--- a/src/main/wsl-unc-delete.ts
+++ b/src/main/wsl-unc-delete.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process'
 import { parseWslPath } from './wsl'
+import { resolveWslInteropSpawnCwd } from './wsl-interop-spawn-directory'
 import {
   containedDeleteCommand,
   rejectionFromWslDeleteStderr,
@@ -69,7 +70,9 @@ function execFileWsl(distro: string, command: string[]): Promise<void> {
       ['-d', distro, '--exec', ...command],
       // Why: a generous bound so deleting a large directory tree on the WSL fs
       // doesn't abort mid-delete, while still capping a wedged wsl.exe.
-      { encoding: 'utf-8', timeout: 30000 },
+      // Why an explicit cwd (#16463): the target rides in argv, and this deletes
+      // worktrees -- so an inherited cwd is exactly the directory about to go.
+      { encoding: 'utf-8', timeout: 30000, cwd: resolveWslInteropSpawnCwd() },
       (error, _stdout, stderr) => {
         if (error) {
           reject(wslDeleteError(error, stderr))

--- a/src/main/wsl.test.ts
+++ b/src/main/wsl.test.ts
@@ -392,6 +392,40 @@ describe('WSL availability cache', () => {
     })
   })
 
+  // Why this site matters more than the other wsl.exe spawns (#16463): ENOENT is
+  // deliberately non-retryable here, so a spawn that failed only because the
+  // inherited cwd had been deleted was cached as "WSL is not installed" on the
+  // 10-minute definitive TTL with exponential backoff. Git kept working and Orca
+  // reported WSL unavailable -- a worse state than the bug being fixed. Naming
+  // the directory is what keeps ENOENT meaning "wsl.exe is not on PATH".
+  it('names an explicit spawn directory on both probes, so no deleted cwd can read as ENOENT', async () => {
+    execFileSyncMock.mockReturnValueOnce('')
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(null, '', '')
+    })
+
+    withPlatform('win32', () => {
+      expect(isWslAvailable()).toBe(true)
+    })
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'wsl.exe',
+      ['--status'],
+      expect.objectContaining({ cwd: expect.any(String) })
+    )
+
+    // The two probes share one cache, so a false ENOENT from either poisons both.
+    _resetWslCachesForTests()
+    await withPlatformAsync('win32', async () => {
+      await expect(isWslAvailableAsync()).resolves.toBe(true)
+    })
+    expect(execFileMock).toHaveBeenCalledWith(
+      'wsl.exe',
+      ['--status'],
+      expect.objectContaining({ cwd: expect.any(String) }),
+      expect.any(Function)
+    )
+  })
+
   it('shares one wsl.exe spawn between concurrent async probes', async () => {
     execFileMock.mockImplementation((_command, _args, _options, callback) => {
       setTimeout(() => callback(null, '', ''), 0)

--- a/src/main/wsl.ts
+++ b/src/main/wsl.ts
@@ -7,6 +7,7 @@ import {
   _setWslAvailabilityCacheForTests,
   dropStaleWslAvailabilityFailure
 } from './wsl-availability'
+import { resolveWslInteropSpawnCwd } from './wsl-interop-spawn-directory'
 import {
   _resetRunningWslDistroCacheForTests,
   resolveRunningWslDistros
@@ -76,7 +77,8 @@ export function wslUncDirectoryExists(uncPath: string): boolean | null {
     const stdout = execFileSync('wsl.exe', getWslDirectoryProbeArgs(info), {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
-      encoding: 'utf8'
+      encoding: 'utf8',
+      cwd: resolveWslInteropSpawnCwd()
     })
     return parseWslDirectoryProbeOutput(stdout)
   } catch {
@@ -93,7 +95,8 @@ export function wslUncDirectoryExistsAsync(uncPath: string): Promise<boolean | n
     return Promise.resolve(null)
   }
   return new Promise((resolve) => {
-    execFile('wsl.exe', getWslDirectoryProbeArgs(info), { timeout: 5000 }, (_error, stdout) => {
+    const probeOpts = { timeout: 5000, cwd: resolveWslInteropSpawnCwd() }
+    execFile('wsl.exe', getWslDirectoryProbeArgs(info), probeOpts, (_error, stdout) => {
       // Why: wsl.exe uses numeric exits for both guest results and host failures; only the guest marker is authoritative.
       resolve(parseWslDirectoryProbeOutput(stdout))
     })
@@ -181,7 +184,8 @@ export function listWslDistros(): string[] {
     const output = execFileSync('wsl.exe', ['--list', '--quiet'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 5000
+      timeout: 5000,
+      cwd: resolveWslInteropSpawnCwd()
     })
     return cacheWslDistroList(parseWslDistros(output), probeSequence)
   } catch {
@@ -283,7 +287,8 @@ export function getWslHome(distro: string): string | null {
     const home = execFileSync('wsl.exe', ['-d', distro, '--exec', 'bash', '-c', 'echo $HOME'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 5000
+      timeout: 5000,
+      cwd: resolveWslInteropSpawnCwd()
     }).trim()
 
     if (!home || !home.startsWith('/')) {
@@ -382,7 +387,13 @@ function execFileUtf8(command: string, args: string[], env?: NodeJS.ProcessEnv):
     execFile(
       command,
       args,
-      { encoding: 'utf-8', env, timeout: 5000, windowsHide: true },
+      {
+        encoding: 'utf-8',
+        env,
+        timeout: 5000,
+        windowsHide: true,
+        cwd: resolveWslInteropSpawnCwd()
+      },
       (error, stdout) => {
         if (error) {
           reject(error)

--- a/src/main/wsl/__fixtures__/wsl-probe-failure-swallow-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-probe-failure-swallow-allowlist.txt
@@ -23,3 +23,9 @@ main/ipc/preflight-command-exec.ts
 main/ipc/preflight-test-harness.ts
 main/ipc/preflight-wsl-agent-detection.ts
 main/wsl.ts
+# Scanned only because the filename starts with `wsl`; it answers nothing about a
+# distro. The swallow is a `statSync` on a LOCAL WINDOWS directory, and only the
+# positive answer is memoized -- and re-validated on every call, which is the
+# point of the module (#16463). A failed stat drops to the next candidate for
+# that one call and is re-asked on the next, so there is no value to pin.
+main/wsl-interop-spawn-directory.ts


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​215 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​203 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​142 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​126 |

<!-- /orca-pr-loc -->

## ELI5

Orca is often launched by running `orca-ide` from a shell **inside** WSL — so the Windows-side Orca process starts life standing in a directory like `\\wsl.localhost\Ubuntu\home\you\some-worktree`.

Every time Orca shells out to `wsl.exe`, it said "I don't care what directory this runs in — the directory is written inside the command itself" and passed `cwd: undefined`. That reasoning is right about *Linux*, but `undefined` doesn't mean "no directory" to Windows. It means **inherit the parent's**, and Windows validates that directory before it will start anything.

So the moment you delete the worktree Orca was launched from, Orca is standing in a directory that no longer exists — and `CreateProcessW` refuses to start *any* child process, forever. Every git call, every probe, for every repo, until you restart the app. (In the original report: 1805 of 1806 git calls failed with `spawn wsl.exe ENOENT`.)

The fix is to stop inheriting: hand `wsl.exe` an explicit directory that Orca owns and that no worktree deletion can take away.

## What changed

- **New `src/main/wsl-interop-spawn-directory.ts`** — `resolveWslInteropSpawnCwd()` picks the first Windows directory that actually resolves, in order: `ORCA_USER_DATA_PATH` → `USERPROFILE` → `HOMEDRIVE`+`HOMEPATH` → `homedir()` → system root.

  It **re-validates its memo on every call**. That is the whole point rather than a detail: the hazard here is a directory that is valid at startup and deleted hours later, so a memo that is never re-checked would just reproduce the original bug one layer up. There is a regression test for exactly that.

- **`src/main/git/command-runner/wsl-command-resolution.ts`** — all four WSL branches (`direct-git`, captured login-shell, login-shell, non-login-shell) now name that directory instead of `undefined`.

- **`src/main/wsl.ts`** — the five `wsl.exe` probe spawns (sync/async directory probe, `--list`, sync `getWslHome`, and the shared `execFileUtf8` that backs `listWslDistrosAsync` / `listRunningWslDistrosAsync` / `getWslHomeAsync`).

- **`src/main/cli/wsl-cli-scripts.ts`** — the PowerShell bridge sets `$StartInfo.WorkingDirectory` explicitly. `Push-Location` only moves the PowerShell *provider* location, not the Win32 current directory, so with `UseShellExecute = $false` the launched app was inheriting the caller's cwd — the WSL worktree. This is what put Orca in the doomed directory in the first place.

- **`src/main/wsl/__fixtures__/wsl-probe-failure-swallow-allowlist.txt`** — see trade-offs.

## Why this doesn't move where anything runs

For a `wsl.exe` invocation, `cwd` sets `lpCurrentDirectory` on the **Windows** side only. The guest directory is carried *inside* the command — `git -C <linuxCwd>`, a `cd` inside `bash -c`, or the probe's own args. Changing the Windows cwd cannot move where the Linux-side command runs.

Re-audited against every `wsl.exe` spawn site on current `main`. The one site where no guest directory is carried is `resolveDefaultWslCli` (global `gh api rate_limit` / `glab api projects`), which is repo-independent by construction.

`main` already documents this same distinction in `wsl-runner.ts`: *"Why not `runProcess`'s `cwd`: that is a **Windows** directory for `wsl.exe`, not a guest one."*

## Trade-offs

- **A root directory is an acceptable last resort.** Nothing ever scans this path; it is only the value `CreateProcessW` receives for `lpCurrentDirectory`. (Contrast `resolveHiddenRateLimitPtyCwd`, which *does* need a bounded non-root directory because Claude's discovery walks it — different requirement, so not reused here.)

- **It can still return `undefined`.** If literally no candidate resolves, inheriting is better than naming a directory we just proved does not exist.

- **`statSync` per resolve.** Bounded: one stat on the cached path in the common case, and it buys the mid-session revalidation that the bug requires.

- **New allowlist entry** in `wsl-probe-failure-swallow-allowlist.txt`. The new file is caught by that ratchet only because its name starts with `wsl` — it answers nothing about a distro. The swallow is a `statSync` on a *local Windows* directory, and only the **positive** answer is memoized. A failed stat falls through to the next candidate for that one call and is re-asked on the next, so there is no value to pin. Noted inline in the fixture.

## Verification

- `pnpm vitest run --config config/vitest.config.ts` over `src/main/{git,cli,gitlab,text-generation,preflight,ipc}` — **582 files / 5964 tests pass**, plus `src/main/wsl*`, `src/main/providers/ssh-pty-provider-spawn`, and the renderer drop-handler / legacy-create suites.
- `pnpm lint` → exit 0 · `pnpm typecheck` → exit 0 · `node config/scripts/check-reliability-gates.mjs` → exit 0 (100 gates).
- **Mutation-verified.** Reverting only the three production files and re-running turns **9 tests across 6 files** red — one per updated assertion — then green again on restore.

Every updated `cwd` assertion is a **stale assertion encoding the old behaviour**, not evidence of an unintended change: each one is a `wsl.exe` spawn whose Linux path is still asserted in the same test body. The five `cwd: undefined` assertions in the same files that cover **native** `gh` / `glab` spawns are deliberately left untouched.

Fixes #16463
