### PR TITLE
fix(agent-send): acknowledge delivery when picker closes before send completes

### DIFF
--- a/src/renderer/src/store/slices/ui-agent-send-target.test.ts
+++ b/src/renderer/src/store/slices/ui-agent-send-target.test.ts
@@ -342,6 +342,37 @@ describe('createUISlice agent send target mode', () => {
     expect(store.getState().agentSendPopoverTargetMode).toBeNull()
   })
 
+  it('acknowledges delivery when the picker closes before the send completes', async () => {
+    const store = createUIStore()
+    const onPromptDelivered = vi.fn()
+    const write = deferred<{ status: 'sent' }>()
+    seedAgentSendState(store)
+    mocks.sendNotesToActiveAgentSession.mockReturnValue(write.promise)
+    store.getState().openAgentSendPopoverTargetMode({
+      id: 'send-1',
+      worktreeId,
+      source: 'diff-notes',
+      prompt: 'Review this',
+      label: 'All unsent notes',
+      launchSource: 'notes_send',
+      onPromptDelivered
+    })
+
+    const send = store.getState().sendPromptToSidebarAgentTarget(readyPaneKey)
+    store.getState().closeAgentSendPopoverTargetMode('send-1')
+    write.resolve({ status: 'sent' })
+
+    await expect(send).resolves.toBe(true)
+    expect(onPromptDelivered).toHaveBeenCalledTimes(1)
+    expect(mocks.track).toHaveBeenCalledWith('agent_prompt_sent', {
+      agent_kind: 'codex',
+      launch_source: 'notes_send',
+      request_kind: 'followup'
+    })
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Sent to Codex')
+    expect(store.getState().agentSendPopoverTargetMode).toBeNull()
+  })
+
   it('does not let an older send close a reopened popover with the same id', async () => {
     const store = createUIStore()
     const onPromptDelivered = vi.fn()
@@ -371,7 +402,7 @@ describe('createUISlice agent send target mode', () => {
     const reopenedMode = store.getState().agentSendPopoverTargetMode
 
     write.resolve({ status: 'sent' })
-    await expect(send).resolves.toBe(false)
+    await expect(send).resolves.toBe(true)
 
     expect(store.getState().agentSendPopoverTargetMode).toBe(reopenedMode)
     expect(store.getState().agentSendPopoverTargetMode).toMatchObject({
@@ -379,9 +410,9 @@ describe('createUISlice agent send target mode', () => {
       prompt: 'Review this again',
       status: 'open'
     })
-    expect(onPromptDelivered).not.toHaveBeenCalled()
-    expect(mocks.track).not.toHaveBeenCalled()
-    expect(mocks.toastSuccess).not.toHaveBeenCalled()
+    expect(onPromptDelivered).toHaveBeenCalledTimes(1)
+    expect(mocks.track).toHaveBeenCalledTimes(1)
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Sent to Codex')
     expect(mocks.toastError).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -1193,10 +1193,6 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       return current?.id === mode.id && current.instanceId === mode.instanceId
     }
 
-    if (!stillCurrent()) {
-      return false
-    }
-
     if (result.status !== 'sent') {
       const message = activeAgentNotesSendFailureMessage(result.status, { explicitTarget: true })
       set((s) =>
@@ -1225,11 +1221,10 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       return false
     }
 
-    const [{ toast }, { track }] = await Promise.all([import('sonner'), import('@/lib/telemetry')])
-    if (!stillCurrent()) {
-      return false
-    }
+    // Delivery ack, telemetry, and toast belong to the completed send, not to the
+    // picker that launched it; only the close below is scoped to this instance.
     mode.onPromptDelivered?.()
+    const [{ toast }, { track }] = await Promise.all([import('sonner'), import('@/lib/telemetry')])
     track('agent_prompt_sent', {
       agent_kind: agentKindForAgentType(target.entry.agentType),
       launch_source: mode.launchSource,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 |

<!-- /orca-pr-loc -->

## Problem

When the user closes the agent send popover before the prompt delivery completes, the delivery acknowledgment, telemetry tracking, and success toast don't fire. The send succeeds silently without user confirmation.

## Solution

Removed the early-return check that prevented callback execution when the picker closed. Delivery acknowledgment, telemetry, and success toast now always execute for successful sends regardless of picker state. Only the popover state cleanup remains scoped to the current picker instance. Added test coverage for picker-closes-before-send-completes scenario.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated (new test case + updated existing test)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)