### PR TITLE
fix(wsl): stop runWslProcess inheriting a removable spawn directory

### DIFF
--- a/src/main/wsl/wsl-runner.test.ts
+++ b/src/main/wsl/wsl-runner.test.ts
@@ -236,7 +236,10 @@ describe('guest cwd', () => {
   it('cds inside the guest rather than passing a Windows cwd to wsl.exe', async () => {
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
     await runWslProcess({ loginPath: 'preferred', program: '/usr/bin/git', cwd: '/home/u/repo' })
-    expect(runProcessMock.mock.calls.at(-1)?.[0].cwd).toBeUndefined()
+    // The contract is that the GUEST path never becomes wsl.exe's Windows cwd,
+    // not that there is no cwd: inheriting one is its own bug (#16463).
+    expect(runProcessMock.mock.calls.at(-1)?.[0].cwd).not.toBe('/home/u/repo')
+    expect(runProcessMock.mock.calls.at(-1)?.[0].cwd).toEqual(expect.any(String))
     expect(lastArgv()).toContain('/home/u/repo')
     expect(lastArgv()).toContain('sh')
   })

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -1,6 +1,7 @@
 import { addWslEnvKeys } from '../../shared/wsl-env'
 import { commandLineLength, MAX_COMMAND_LINE_CHARS } from '../../shared/windows-command-line-budget'
 import { runProcess } from '../../shared/child-process/run-process'
+import { resolveWslInteropSpawnCwd } from '../wsl-interop-spawn-directory'
 import { buildWslExecArgs } from '../../shared/wsl-login-shell-command'
 import { getWslGuestEnvironment, type WslGuestEnvironment } from './wsl-guest-environment'
 import { resolveWslExecutablePath } from './wsl-executable-path'
@@ -239,6 +240,10 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
   const result = await runProcess({
     program: resolveWslExecutablePath(),
     args: buildWslExecArgs(spec.distro, argv),
+    // Name a Windows directory rather than inheriting one: an inherited cwd that
+    // is later deleted (the worktree Orca launched from) fails every later spawn
+    // (#16463). Never the guest cwd -- withGuestCwd still cds inside.
+    cwd: resolveWslInteropSpawnCwd(),
     env: buildHostEnv(spec.env),
     input: delivery === 'stdin' ? spec.script : undefined,
     timeoutMs: remainingMs,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

Stacked on #17834. Without this, that PR says "Fixes #16463" but fixes the minority of spawn sites.

## Why

#17834 names an explicit Windows cwd for the `wsl.exe` spawns in `wsl-command-resolution.ts` and `wsl.ts`. But **25 production files route through `runWslProcess`**, which passed no `cwd` at all — so the bulk of WSL spawns still inherited, and #16463 survived on the majority path: delete the worktree Orca launched from, and every later spawn fails for the rest of the session.

## The test that had to change, and why it is not a contract violation

Adding the cwd turned `wsl-runner.test.ts` red:

```
it("cds inside the guest rather than passing a Windows cwd to wsl.exe", ...)
  expect(runProcessMock...cwd).toBeUndefined()
```

The real invariant is in that test name and in the production comment — *"Why not `runProcess`'s `cwd`: that is a **Windows** directory for `wsl.exe`"*. The rule is **the guest path must never become the Windows cwd**. `withGuestCwd` still `cd`s inside the guest, so that holds unchanged.

`toBeUndefined()` was a proxy for the rule, and it is a leaky one: an *inherited* directory also satisfies it, while being exactly the bug. Retargeted to assert the actual meaning — not the guest path, and present.

## Verification

Mutation-verified: removing the `cwd` line turns that test red; restoring returns green.

`pnpm lint` 0 · `pnpm typecheck` 0 · reliability gates 0 (100) · `src/main/{wsl,git,cli}` under the repo config: **226 files / 2484 tests passed**.

## Note

The salvage agent found this, reverted it, and escalated rather than silently overruling a documented contract in a module it was not sent to change. That was the right instinct — the call needed an owner, not a quiet edit.