### PR TITLE
perf(git-common): bound the fs-stat fan-out in the worktree pollers

### DIFF
--- a/src/main/ipc/worktree-base-directory-poller-marker-fanout.test.ts
+++ b/src/main/ipc/worktree-base-directory-poller-marker-fanout.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import type * as NodeFsPromises from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { startWorktreeBaseDirectoryPoller } from './worktree-base-directory-poller'
+import type {
+  WorktreeBaseRepoWatchConfig,
+  WorktreeBaseWatchTarget
+} from './worktree-base-directory-event-filter'
+
+// Why: the backstop full scan stats a `.git` marker per candidate dir; an
+// unbounded fan-out at hundreds of worktrees would queue thousands of `stat`
+// calls on libuv's 4-thread pool (#17828).
+const { concurrency } = vi.hoisted(() => ({ concurrency: { current: 0, peak: 0 } }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return {
+    ...actual,
+    stat: async (...args: Parameters<typeof actual.stat>) => {
+      concurrency.current += 1
+      concurrency.peak = Math.max(concurrency.peak, concurrency.current)
+      try {
+        return await actual.stat(...args)
+      } finally {
+        concurrency.current -= 1
+      }
+    }
+  }
+})
+
+function makeTarget(path: string): WorktreeBaseWatchTarget {
+  const repoConfig: WorktreeBaseRepoWatchConfig = {
+    repoId: 'repo-1',
+    repoName: 'project',
+    nestWorkspaces: false
+  }
+  return {
+    key: `base:local:${path}`,
+    kind: 'base',
+    path,
+    repos: new Map([[repoConfig.repoId, repoConfig]])
+  }
+}
+
+describe('worktree base directory poller marker fan-out (#17828)', () => {
+  const cleanups: (() => Promise<void>)[] = []
+
+  beforeEach(() => {
+    concurrency.current = 0
+    concurrency.peak = 0
+  })
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+  })
+
+  it('bounds concurrent `.git`-marker stats regardless of candidate count', async () => {
+    const root = await realpath(await mkdtemp(join(tmpdir(), 'orca-base-poller-fanout-')))
+    cleanups.push(() => rm(root, { recursive: true, force: true }))
+    const candidateCount = 200
+    for (let i = 0; i < candidateCount; i++) {
+      const worktree = join(root, `wt-${i}`)
+      await mkdir(worktree)
+      await writeFile(join(worktree, '.git'), 'gitdir: elsewhere')
+    }
+
+    const target = makeTarget(root)
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      () => {},
+      { pollIntervalMs: 100_000 }
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    // 200 candidates stated unbounded would peak near 200 concurrent `stat`
+    // calls; bounding the marker probe keeps the peak independent of count —
+    // while still overlapping requests (not serialized one-at-a-time).
+    expect(concurrency.peak).toBeGreaterThan(1)
+    expect(concurrency.peak).toBeLessThan(20)
+  })
+})

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -1,6 +1,8 @@
 import { readdir, stat } from 'node:fs/promises'
+import type { Dirent } from 'node:fs'
 import { join } from 'node:path'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import { forEachWithConcurrency } from '../../shared/map-with-concurrency'
 import { isMainWindowVisible, onMainWindowBecameVisible } from '../window/main-window-visibility'
 import type {
   WorktreeBaseRepoWatchConfig,
@@ -92,6 +94,11 @@ export const WORKTREE_BASE_BACKSTOP_TICKS = 15
 // backstop scan cover the pathological case.
 const PENDING_MARKER_MAX_TICKS = 300
 
+// Why: matches the git-common poller's fan-out bound (#17828) — bounded
+// concurrency turns hundreds of serial round trips into a handful of batches
+// without dumping every candidate onto libuv's 4-thread pool at once.
+const MARKER_PROBE_CONCURRENCY = 8
+
 function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
   return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
 }
@@ -123,6 +130,14 @@ type BaseSnapshot = {
   gateSignatures: string[]
 }
 
+async function readdirSafe(path: string): Promise<Dirent[]> {
+  try {
+    return await readdir(path, { withFileTypes: true })
+  } catch {
+    return []
+  }
+}
+
 // Depth-1 worktree dirs (flat layout), plus depth-2 dirs under each nested
 // repo's container, mirroring what worktree-base-directory-event-filter
 // matches: `<wt>/.git` completion markers and `<wt>` deletions.
@@ -144,14 +159,9 @@ async function snapshotBase(
       .map((config) => normalizeRuntimePathForComparison(config.repoName))
   )
 
-  let rootEntries
-  try {
-    rootEntries = await readdir(rootPath, { withFileTypes: true })
-  } catch {
-    // Root vanished: an empty snapshot diffs into delete events for every
-    // previously-known worktree dir, matching the old watcher's error path.
-    return { markers, gateDirs, gateSignatures }
-  }
+  // Root vanished or unreadable: readdirSafe yields [], producing the same
+  // empty markers/candidates result as the old watcher's error path.
+  const rootEntries = await readdirSafe(rootPath)
 
   const candidates: string[] = []
   for (const entry of rootEntries) {
@@ -165,12 +175,7 @@ async function snapshotBase(
     if (nestedRepoNames.has(normalizeRuntimePathForComparison(entry.name))) {
       gateDirs.push(entryPath)
       gateSignatures.push(await dirSignature(entryPath))
-      let subEntries
-      try {
-        subEntries = await readdir(entryPath, { withFileTypes: true })
-      } catch {
-        subEntries = []
-      }
+      const subEntries = await readdirSafe(entryPath)
       for (const sub of subEntries) {
         if (sub.isDirectory() || sub.isSymbolicLink()) {
           candidates.push(join(entryPath, sub.name))
@@ -179,9 +184,9 @@ async function snapshotBase(
     }
   }
 
-  for (const dir of candidates) {
+  await forEachWithConcurrency(candidates, MARKER_PROBE_CONCURRENCY, async (dir) => {
     markers.set(dir, await hasGitMarker(dir))
-  }
+  })
   return { markers, gateDirs, gateSignatures }
 }
 

--- a/src/main/ipc/worktree-git-common-entry-snapshot.ts
+++ b/src/main/ipc/worktree-git-common-entry-snapshot.ts
@@ -39,11 +39,33 @@ export async function snapshotGitCommonEntry(
   previous: GitCommonEntrySnapshot | undefined,
   forceFullScan: boolean
 ): Promise<GitCommonEntrySnapshot> {
-  // Structural leaves change in place every tick; only index uses the entry-dir gate.
+  // Git writes HEAD/index/config.worktree/locked via a lock file + rename inside the
+  // entry dir, so the entry dir's own signature moves on every one of those writes
+  // (verified against git 2.55: checkout, commit, amend, reset, ref updates, stash,
+  // worktree lock/unlock, config --worktree, index writes all move it). The one
+  // in-place exception is `gitdir` (worktree move/repair), which the periodic
+  // forceFullScan backstop (INDEX_BACKSTOP_TICKS) below re-stats regardless of this
+  // gate. Gating all of these leaves on the entry-dir signature turns an unchanged
+  // entry into a single stat per tick instead of stat-ing every leaf every tick.
+  const nextDirSignature = await gitCommonDirectorySignature(entryPath)
+  if (nextDirSignature === 'missing') {
+    return (
+      previous ?? {
+        dirSignature: nextDirSignature,
+        structuralSignatures: new Map(),
+        indexSignature: null,
+        headLogSignature: null
+      }
+    )
+  }
+  const shouldRescan = forceFullScan || !previous || previous.dirSignature !== nextDirSignature
+  if (!shouldRescan) {
+    return previous
+  }
   const structuralSignatures = new Map<string, string>()
-  const [nextDirSignature, headLogSignature] = await Promise.all([
-    gitCommonDirectorySignature(entryPath),
+  const [headLogSignature, indexSignature] = await Promise.all([
     gitCommonFileSignature(join(entryPath, HEAD_LOG_FILE)),
+    gitCommonFileSignature(join(entryPath, INDEX_FILE)),
     Promise.all(
       STRUCTURAL_METADATA_FILES.map(async (name) => {
         const signature = await gitCommonFileSignature(join(entryPath, name))
@@ -53,20 +75,6 @@ export async function snapshotGitCommonEntry(
       })
     )
   ])
-  if (nextDirSignature === 'missing') {
-    return (
-      previous ?? {
-        dirSignature: nextDirSignature,
-        structuralSignatures,
-        indexSignature: null,
-        headLogSignature
-      }
-    )
-  }
-  const shouldReadIndex = forceFullScan || !previous || previous.dirSignature !== nextDirSignature
-  const indexSignature = shouldReadIndex
-    ? await gitCommonFileSignature(join(entryPath, INDEX_FILE))
-    : previous.indexSignature
   return {
     dirSignature: nextDirSignature,
     structuralSignatures,

--- a/src/main/ipc/worktree-git-common-narrow-watch.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch.ts
@@ -79,7 +79,11 @@ export async function startGitCommonNarrowWatch(
             pollIntervalMs,
             visibility,
             onFullScan,
-            false
+            false,
+            () => [],
+            // Crash fuse tripped: this poller is now the sole change signal until a
+            // future existence-poll upgrade, so its cadence must scale with entry count.
+            { adaptiveCadence: true }
           )
         )
         .then(async (fallback) => {

--- a/src/main/ipc/worktree-git-common-narrow-watch.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch.ts
@@ -82,7 +82,9 @@ export async function startGitCommonNarrowWatch(
             false,
             () => [],
             // Crash fuse tripped: this poller is now the sole change signal until a
-            // future existence-poll upgrade, so its cadence must scale with entry count.
+            // future existence-poll upgrade (follow-up: #17878). adaptiveCadence keeps
+            // add/remove and HEAD detection on `pollIntervalMs` while scaling only the
+            // O(n) per-entry sweep, so this fallback degrades gracefully at high counts.
             { adaptiveCadence: true }
           )
         )

--- a/src/main/ipc/worktree-git-common-narrow-watch.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch.ts
@@ -73,19 +73,18 @@ export async function startGitCommonNarrowWatch(
         .unsubscribe()
         .catch(() => {})
         .then(() =>
+          // Crash fuse tripped: this poller is now the sole change signal until a
+          // future existence-poll upgrade (follow-up: #17878). Its own per-entry
+          // dir-signature gate (worktree-git-common-entry-snapshot.ts) already keeps
+          // an unchanged entry to a single stat, so a fixed `pollIntervalMs` cadence
+          // stays cheap at high worktree counts without needing to stretch itself.
           startGitCommonPolling(
             target.path,
             onEvents,
             pollIntervalMs,
             visibility,
             onFullScan,
-            false,
-            () => [],
-            // Crash fuse tripped: this poller is now the sole change signal until a
-            // future existence-poll upgrade (follow-up: #17878). adaptiveCadence keeps
-            // add/remove and HEAD detection on `pollIntervalMs` while scaling only the
-            // O(n) per-entry sweep, so this fallback degrades gracefully at high counts.
-            { adaptiveCadence: true }
+            false
           )
         )
         .then(async (fallback) => {

--- a/src/main/ipc/worktree-git-common-polling.test.ts
+++ b/src/main/ipc/worktree-git-common-polling.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import type * as NodeFsPromises from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { startGitCommonPolling } from './worktree-git-common-polling'
+import type {
+  WorktreeBasePollEvent,
+  WorktreePollerWindowVisibility
+} from './worktree-base-directory-poller'
+
+// Why: measure the fan-out this poller issues per scan (peak concurrent `stat`
+// calls, `readdir` call count as a proxy for "a scan started") without
+// depending on real disk timing (#17828).
+const { statDelayMs, readdirCalls, concurrency } = vi.hoisted(() => ({
+  statDelayMs: { current: 0 },
+  readdirCalls: { count: 0 },
+  concurrency: { current: 0, peak: 0 }
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return {
+    ...actual,
+    readdir: (...args: Parameters<typeof actual.readdir>) => {
+      readdirCalls.count += 1
+      return actual.readdir(...args)
+    },
+    stat: async (...args: Parameters<typeof actual.stat>) => {
+      concurrency.current += 1
+      concurrency.peak = Math.max(concurrency.peak, concurrency.current)
+      try {
+        if (statDelayMs.current > 0) {
+          await new Promise((resolve) => setTimeout(resolve, statDelayMs.current))
+        }
+        return await actual.stat(...args)
+      } finally {
+        concurrency.current -= 1
+      }
+    }
+  }
+})
+
+const alwaysVisible: WorktreePollerWindowVisibility = {
+  isWindowVisible: () => true,
+  onWindowBecameVisible: () => () => {}
+}
+
+async function makeCommonDir(entryCount: number): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'git-common-polling-test-'))
+  for (let i = 0; i < entryCount; i++) {
+    const entryPath = join(root, 'worktrees', `wt-${i}`)
+    await mkdir(join(entryPath, 'logs'), { recursive: true })
+    await Promise.all([
+      writeFile(join(entryPath, 'HEAD'), 'ref: refs/heads/main\n'),
+      writeFile(join(entryPath, 'gitdir'), `${join(root, `checkout-${i}`, '.git')}\n`),
+      writeFile(join(entryPath, 'index'), Buffer.from([0])),
+      writeFile(join(entryPath, 'logs', 'HEAD'), '0000 aaaa\n')
+    ])
+  }
+  return root
+}
+
+describe('startGitCommonPolling fan-out bounds (#17828)', () => {
+  const cleanups: (() => Promise<void>)[] = []
+  const dirsToRemove: string[] = []
+
+  beforeEach(() => {
+    statDelayMs.current = 0
+    readdirCalls.count = 0
+    concurrency.current = 0
+    concurrency.peak = 0
+  })
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+    await Promise.all(
+      dirsToRemove.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+    )
+    vi.useRealTimers()
+  })
+
+  it('bounds concurrent per-entry stat fan-out regardless of entry count', async () => {
+    const commonDir = await makeCommonDir(200)
+    dirsToRemove.push(commonDir)
+    const sub = await startGitCommonPolling(commonDir, () => {}, 100_000, alwaysVisible)
+    cleanups.push(() => sub.unsubscribe())
+    // 200 entries x ~6 concurrent structural stats each would peak near 1,200
+    // unbounded; bounding to 8 in-flight entries keeps the peak independent of
+    // entry count instead of scaling with it.
+    expect(concurrency.peak).toBeLessThan(80)
+  })
+
+  it('never overlaps a scan with itself even when ticks fire faster than a scan completes', async () => {
+    const commonDir = await makeCommonDir(10)
+    dirsToRemove.push(commonDir)
+    statDelayMs.current = 20
+    const pollIntervalMs = 5
+    const sub = await startGitCommonPolling(commonDir, () => {}, pollIntervalMs, alwaysVisible)
+    cleanups.push(() => sub.unsubscribe())
+    readdirCalls.count = 0
+    // ~60 would-be 5ms ticks elapse in this window while every stat takes 20ms;
+    // the ticking guard must serialize scans, not launch overlapping ones.
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    expect(readdirCalls.count).toBeLessThan(10)
+  })
+
+  it('stretches the fallback cadence when a scan is slow relative to the base interval', async () => {
+    const commonDir = await makeCommonDir(2)
+    dirsToRemove.push(commonDir)
+    statDelayMs.current = 60
+    const baseIntervalMs = 20
+    const sub = await startGitCommonPolling(
+      commonDir,
+      () => {},
+      baseIntervalMs,
+      alwaysVisible,
+      undefined,
+      true,
+      () => [],
+      { adaptiveCadence: true }
+    )
+    cleanups.push(() => sub.unsubscribe())
+
+    readdirCalls.count = 0
+    // A scan several times slower than the 20ms base interval should push the
+    // next tick out well beyond baseIntervalMs, not fire again almost immediately.
+    await new Promise((resolve) => setTimeout(resolve, baseIntervalMs * 5))
+    expect(readdirCalls.count).toBe(0)
+    await vi.waitFor(
+      () => {
+        expect(readdirCalls.count).toBeGreaterThan(0)
+      },
+      { timeout: 5_000 }
+    )
+  })
+
+  it('does not stretch cadence for callers that opt out of adaptive cadence', async () => {
+    const commonDir = await makeCommonDir(2)
+    dirsToRemove.push(commonDir)
+    statDelayMs.current = 0
+    const pollIntervalMs = 20
+    const sub = await startGitCommonPolling(commonDir, () => {}, pollIntervalMs, alwaysVisible)
+    cleanups.push(() => sub.unsubscribe())
+
+    readdirCalls.count = 0
+    // Fixed cadence: several scans should land within a handful of intervals.
+    await vi.waitFor(
+      () => {
+        expect(readdirCalls.count).toBeGreaterThanOrEqual(2)
+      },
+      { timeout: 2_000 }
+    )
+  })
+
+  it('still detects entry add/remove correctly with bounded concurrency', async () => {
+    const commonDir = await makeCommonDir(5)
+    dirsToRemove.push(commonDir)
+    const events: WorktreeBasePollEvent[][] = []
+    const sub = await startGitCommonPolling(
+      commonDir,
+      (batch) => events.push(batch),
+      20,
+      alwaysVisible
+    )
+    cleanups.push(() => sub.unsubscribe())
+
+    const newEntry = join(commonDir, 'worktrees', 'wt-new')
+    await mkdir(join(newEntry, 'logs'), { recursive: true })
+    await writeFile(join(newEntry, 'HEAD'), 'ref: refs/heads/main\n')
+
+    await vi.waitFor(() => {
+      expect(events.flat()).toContainEqual({ type: 'create', path: newEntry })
+    })
+
+    await rm(newEntry, { recursive: true })
+    await vi.waitFor(() => {
+      expect(events.flat()).toContainEqual({ type: 'delete', path: newEntry })
+    })
+  })
+})

--- a/src/main/ipc/worktree-git-common-polling.test.ts
+++ b/src/main/ipc/worktree-git-common-polling.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import type * as NodeFsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, sep } from 'node:path'
 import { startGitCommonPolling } from './worktree-git-common-polling'
 import type {
   WorktreeBasePollEvent,
@@ -11,11 +11,14 @@ import type {
 
 // Why: measure the fan-out this poller issues per scan (peak concurrent `stat`
 // calls, `readdir` call count as a proxy for "a scan started") without
-// depending on real disk timing (#17828).
-const { statDelayMs, readdirCalls, concurrency } = vi.hoisted(() => ({
+// depending on real disk timing (#17828). `entryZeroHeadStatCalls` tracks stats
+// on a specific pre-existing entry's HEAD file, which only a per-entry sweep
+// (not the cheap structural tripwire) re-reads.
+const { statDelayMs, readdirCalls, concurrency, entryZeroHeadStatCalls } = vi.hoisted(() => ({
   statDelayMs: { current: 0 },
   readdirCalls: { count: 0 },
-  concurrency: { current: 0, peak: 0 }
+  concurrency: { current: 0, peak: 0 },
+  entryZeroHeadStatCalls: { count: 0 }
 }))
 
 vi.mock('node:fs/promises', async (importOriginal) => {
@@ -29,6 +32,10 @@ vi.mock('node:fs/promises', async (importOriginal) => {
     stat: async (...args: Parameters<typeof actual.stat>) => {
       concurrency.current += 1
       concurrency.peak = Math.max(concurrency.peak, concurrency.current)
+      const path = args[0]
+      if (typeof path === 'string' && path.endsWith(`wt-0${sep}HEAD`)) {
+        entryZeroHeadStatCalls.count += 1
+      }
       try {
         if (statDelayMs.current > 0) {
           await new Promise((resolve) => setTimeout(resolve, statDelayMs.current))
@@ -70,6 +77,7 @@ describe('startGitCommonPolling fan-out bounds (#17828)', () => {
     readdirCalls.count = 0
     concurrency.current = 0
     concurrency.peak = 0
+    entryZeroHeadStatCalls.count = 0
   })
 
   afterEach(async () => {
@@ -105,7 +113,7 @@ describe('startGitCommonPolling fan-out bounds (#17828)', () => {
     expect(readdirCalls.count).toBeLessThan(10)
   })
 
-  it('stretches the fallback cadence when a scan is slow relative to the base interval', async () => {
+  it('stretches only the per-entry sweep cadence, keeping the structural tripwire on pollIntervalMs', async () => {
     const commonDir = await makeCommonDir(2)
     dirsToRemove.push(commonDir)
     statDelayMs.current = 60
@@ -122,17 +130,23 @@ describe('startGitCommonPolling fan-out bounds (#17828)', () => {
     )
     cleanups.push(() => sub.unsubscribe())
 
+    // Let the bootstrap snapshot's own (unconditional) sweep settle, then measure.
+    await new Promise((resolve) => setTimeout(resolve, baseIntervalMs * 2))
     readdirCalls.count = 0
-    // A scan several times slower than the 20ms base interval should push the
-    // next tick out well beyond baseIntervalMs, not fire again almost immediately.
-    await new Promise((resolve) => setTimeout(resolve, baseIntervalMs * 5))
-    expect(readdirCalls.count).toBe(0)
+    entryZeroHeadStatCalls.count = 0
+    // A scan several times slower than the 20ms base interval stretches the sweep's
+    // own cadence, but the cheap readdir/dir-signature tripwire must keep firing
+    // every ~baseIntervalMs regardless — worktree add/remove and HEAD must not
+    // inherit the sweep's stretch (#17828 follow-up: staleness trade-off).
     await vi.waitFor(
       () => {
-        expect(readdirCalls.count).toBeGreaterThan(0)
+        expect(readdirCalls.count).toBeGreaterThan(3)
       },
-      { timeout: 5_000 }
+      { timeout: 2_000 }
     )
+    // wt-0 already existed at bootstrap, so a tripwire-only tick must carry its
+    // entry over rather than re-stat it; far fewer sweeps than tripwire ticks ran.
+    expect(entryZeroHeadStatCalls.count).toBeLessThan(readdirCalls.count)
   })
 
   it('does not stretch cadence for callers that opt out of adaptive cadence', async () => {

--- a/src/main/ipc/worktree-git-common-polling.test.ts
+++ b/src/main/ipc/worktree-git-common-polling.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rename, rm, writeFile } from 'node:fs/promises'
 import type * as NodeFsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, sep } from 'node:path'
@@ -10,15 +10,15 @@ import type {
 } from './worktree-base-directory-poller'
 
 // Why: measure the fan-out this poller issues per scan (peak concurrent `stat`
-// calls, `readdir` call count as a proxy for "a scan started") without
-// depending on real disk timing (#17828). `entryZeroHeadStatCalls` tracks stats
-// on a specific pre-existing entry's HEAD file, which only a per-entry sweep
-// (not the cheap structural tripwire) re-reads.
-const { statDelayMs, readdirCalls, concurrency, entryZeroHeadStatCalls } = vi.hoisted(() => ({
+// calls, `readdir` call count as a proxy for "a tick ran") without depending on
+// real disk timing (#17828). `entryZeroStatCalls` tracks every stat under a
+// specific pre-existing entry (its dir plus every leaf), used to prove the
+// entry-dir signature gate keeps an unchanged entry to one stat per tick.
+const { statDelayMs, readdirCalls, concurrency, entryZeroStatCalls } = vi.hoisted(() => ({
   statDelayMs: { current: 0 },
   readdirCalls: { count: 0 },
   concurrency: { current: 0, peak: 0 },
-  entryZeroHeadStatCalls: { count: 0 }
+  entryZeroStatCalls: { count: 0 }
 }))
 
 vi.mock('node:fs/promises', async (importOriginal) => {
@@ -33,8 +33,12 @@ vi.mock('node:fs/promises', async (importOriginal) => {
       concurrency.current += 1
       concurrency.peak = Math.max(concurrency.peak, concurrency.current)
       const path = args[0]
-      if (typeof path === 'string' && path.endsWith(`wt-0${sep}HEAD`)) {
-        entryZeroHeadStatCalls.count += 1
+      const entryZeroSegment = `${sep}wt-0`
+      if (
+        typeof path === 'string' &&
+        (path.endsWith(entryZeroSegment) || path.includes(`${entryZeroSegment}${sep}`))
+      ) {
+        entryZeroStatCalls.count += 1
       }
       try {
         if (statDelayMs.current > 0) {
@@ -77,7 +81,7 @@ describe('startGitCommonPolling fan-out bounds (#17828)', () => {
     readdirCalls.count = 0
     concurrency.current = 0
     concurrency.peak = 0
-    entryZeroHeadStatCalls.count = 0
+    entryZeroStatCalls.count = 0
   })
 
   afterEach(async () => {
@@ -113,57 +117,95 @@ describe('startGitCommonPolling fan-out bounds (#17828)', () => {
     expect(readdirCalls.count).toBeLessThan(10)
   })
 
-  it('stretches only the per-entry sweep cadence, keeping the structural tripwire on pollIntervalMs', async () => {
-    const commonDir = await makeCommonDir(2)
+  it('costs exactly one stat per tick for an unchanged entry', async () => {
+    const commonDir = await makeCommonDir(1)
     dirsToRemove.push(commonDir)
-    statDelayMs.current = 60
-    const baseIntervalMs = 20
-    const sub = await startGitCommonPolling(
-      commonDir,
-      () => {},
-      baseIntervalMs,
-      alwaysVisible,
-      undefined,
-      true,
-      () => [],
-      { adaptiveCadence: true }
-    )
-    cleanups.push(() => sub.unsubscribe())
-
-    // Let the bootstrap snapshot's own (unconditional) sweep settle, then measure.
-    await new Promise((resolve) => setTimeout(resolve, baseIntervalMs * 2))
-    readdirCalls.count = 0
-    entryZeroHeadStatCalls.count = 0
-    // A scan several times slower than the 20ms base interval stretches the sweep's
-    // own cadence, but the cheap readdir/dir-signature tripwire must keep firing
-    // every ~baseIntervalMs regardless — worktree add/remove and HEAD must not
-    // inherit the sweep's stretch (#17828 follow-up: staleness trade-off).
-    await vi.waitFor(
-      () => {
-        expect(readdirCalls.count).toBeGreaterThan(3)
-      },
-      { timeout: 2_000 }
-    )
-    // wt-0 already existed at bootstrap, so a tripwire-only tick must carry its
-    // entry over rather than re-stat it; far fewer sweeps than tripwire ticks ran.
-    expect(entryZeroHeadStatCalls.count).toBeLessThan(readdirCalls.count)
-  })
-
-  it('does not stretch cadence for callers that opt out of adaptive cadence', async () => {
-    const commonDir = await makeCommonDir(2)
-    dirsToRemove.push(commonDir)
-    statDelayMs.current = 0
     const pollIntervalMs = 20
     const sub = await startGitCommonPolling(commonDir, () => {}, pollIntervalMs, alwaysVisible)
     cleanups.push(() => sub.unsubscribe())
 
+    // Let the bootstrap snapshot (which always fully reads every entry once) settle.
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
     readdirCalls.count = 0
-    // Fixed cadence: several scans should land within a handful of intervals.
+    entryZeroStatCalls.count = 0
     await vi.waitFor(
       () => {
-        expect(readdirCalls.count).toBeGreaterThanOrEqual(2)
+        expect(readdirCalls.count).toBeGreaterThanOrEqual(5)
       },
       { timeout: 2_000 }
+    )
+    // Without the entry-dir signature gate, an unchanged entry still costs ~6
+    // stats every tick (HEAD/gitdir/locked/config.worktree/logs/HEAD/index).
+    // With the gate, only the entry dir itself is stat'd once nothing changed —
+    // one stat per tick, in lockstep with the readdir tripwire.
+    expect(entryZeroStatCalls.count).toBeLessThanOrEqual(readdirCalls.count + 1)
+    expect(entryZeroStatCalls.count).toBeGreaterThanOrEqual(readdirCalls.count - 1)
+  })
+
+  it('detects a HEAD rewrite via lock+rename on the next tick', async () => {
+    const commonDir = await makeCommonDir(1)
+    dirsToRemove.push(commonDir)
+    const events: WorktreeBasePollEvent[][] = []
+    const pollIntervalMs = 20
+    const sub = await startGitCommonPolling(
+      commonDir,
+      (batch) => events.push(batch),
+      pollIntervalMs,
+      alwaysVisible
+    )
+    cleanups.push(() => sub.unsubscribe())
+    // Let the bootstrap snapshot settle before mutating.
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+
+    const entryDir = join(commonDir, 'worktrees', 'wt-0')
+    const headPath = join(entryDir, 'HEAD')
+    const headLockPath = join(entryDir, 'HEAD.lock')
+    // Every real git ref write goes through a lock file + rename inside the entry
+    // dir (never an in-place overwrite), which moves the entry dir's own signature.
+    await writeFile(headLockPath, 'ref: refs/heads/feature\n')
+    await rename(headLockPath, headPath)
+
+    await vi.waitFor(
+      () => {
+        expect(events.flat()).toContainEqual({ type: 'update', path: headPath })
+      },
+      { timeout: pollIntervalMs * 10 }
+    )
+  })
+
+  it('detects an in-place gitdir rewrite only once the periodic backstop rescans it', async () => {
+    const commonDir = await makeCommonDir(1)
+    dirsToRemove.push(commonDir)
+    const events: WorktreeBasePollEvent[][] = []
+    const pollIntervalMs = 10
+    const sub = await startGitCommonPolling(
+      commonDir,
+      (batch) => events.push(batch),
+      pollIntervalMs,
+      alwaysVisible
+    )
+    cleanups.push(() => sub.unsubscribe())
+    // Let the bootstrap snapshot settle before mutating.
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+
+    const entryDir = join(commonDir, 'worktrees', 'wt-0')
+    const gitdirPath = join(entryDir, 'gitdir')
+    // `gitdir` is the one structural leaf git rewrites in place (worktree move/repair),
+    // so the entry dir's own signature never moves — the periodic ungated backstop
+    // (INDEX_BACKSTOP_TICKS = 15) is the only thing that catches it.
+    await writeFile(gitdirPath, `${join(commonDir, 'checkout-moved', '.git')}\n`)
+
+    // Not caught by the next several ticks: the gate stays closed since nothing
+    // moved the entry dir's own signature.
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs * 5))
+    expect(events.flat()).not.toContainEqual({ type: 'update', path: gitdirPath })
+
+    // Eventually caught regardless of the gate, once tick 15 forces the periodic backstop.
+    await vi.waitFor(
+      () => {
+        expect(events.flat()).toContainEqual({ type: 'update', path: gitdirPath })
+      },
+      { timeout: pollIntervalMs * 40 }
     )
   })
 

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -32,10 +32,13 @@ const INDEX_BACKSTOP_TICKS = 15
 const GIT_COMMON_SNAPSHOT_CONCURRENCY = 8
 
 // Why: on hosts without native narrow-watch support (or once its crash fuse
-// trips), this poller's own per-tick structural fan-out is the only signal —
-// a fixed 2s cadence at hundreds of worktrees turns it into a near-permanent
-// scan loop. Stretch the interval so a scan stays a minority of its own duty
-// cycle, capped so external changes still surface in a bounded time.
+// trips), the O(n) per-entry sweep below is the only source of per-worktree
+// change detection — a fixed 2s cadence at hundreds of worktrees turns it into
+// a near-permanent scan loop. Only the sweep's own cadence stretches (see
+// `shouldSweep` in startGitCommonPolling); the cheap structural tripwire
+// (readdir, dir signature, primary files, newly-added entries) stays on the
+// fixed `pollIntervalMs` so worktree add/remove and HEAD changes never inherit
+// this stretch.
 const ADAPTIVE_CADENCE_TARGET_DUTY_CYCLE = 0.1
 const ADAPTIVE_CADENCE_MAX_INTERVAL_MS = 30_000
 
@@ -79,7 +82,10 @@ async function snapshotGitCommon(
   previous?: GitCommonSnapshot,
   includePrimary = true,
   forceFullScan = false,
-  statusRefPaths = new Set<string>()
+  statusRefPaths = new Set<string>(),
+  // Why: false on a tripwire-only tick (adaptive cadence, sweep not yet due) — carries
+  // over unchanged entries and only stats genuinely new ones, instead of O(n) re-stats.
+  sweepEntries = true
 ): Promise<GitCommonSnapshot> {
   const worktreesDir = join(commonDirPath, 'worktrees')
   const [worktreesDirSignature, primarySignatures, statusRefSignatures] = await Promise.all([
@@ -111,11 +117,26 @@ async function snapshotGitCommon(
     }
   }
 
-  const entries = new Map<string, GitCommonEntrySnapshot>()
-  await forEachWithConcurrency(entryPaths, GIT_COMMON_SNAPSHOT_CONCURRENCY, async (entryPath) => {
-    const previousEntry = previous?.entries.get(entryPath)
-    entries.set(entryPath, await snapshotGitCommonEntry(entryPath, previousEntry, forceFullScan))
-  })
+  const entryPathSet = new Set(entryPaths)
+  const entries = new Map<string, GitCommonEntrySnapshot>(previous?.entries)
+  for (const entryPath of entries.keys()) {
+    if (!entryPathSet.has(entryPath)) {
+      entries.delete(entryPath)
+    }
+  }
+  // Why: a tripwire-only tick still stats brand-new entries (bounded by how many
+  // worktrees actually appeared this tick, not total count) so adds show up immediately.
+  const pathsToSnapshot = sweepEntries
+    ? entryPaths
+    : entryPaths.filter((path) => !entries.has(path))
+  await forEachWithConcurrency(
+    pathsToSnapshot,
+    GIT_COMMON_SNAPSHOT_CONCURRENCY,
+    async (entryPath) => {
+      const previousEntry = previous?.entries.get(entryPath)
+      entries.set(entryPath, await snapshotGitCommonEntry(entryPath, previousEntry, forceFullScan))
+    }
+  )
   // Why: the expensive per-entry `index` read stays gated on each entry's own dir signature; onFullScan
   // now reflects an ungated index-metadata backstop fan-out (forceFullScan) — the real periodic cost —
   // rather than the always-run worktrees-dir readdir.
@@ -126,15 +147,16 @@ async function snapshotGitCommon(
     primarySignatures,
     statusRefPaths,
     statusRefSignatures,
-    didFullScan: forceFullScan
+    didFullScan: forceFullScan && sweepEntries
   }
 }
 
 export type GitCommonPollingOptions = {
   /** Reconciliation backstop: never trust the per-entry gate, re-stat every tick. */
   forceFullScanEveryTick?: boolean
-  /** This is the ONLY signal (no native watch, or its crash fuse tripped): stretch
-   *  cadence when the entry count makes a scan take a large fraction of the interval. */
+  /** This is the ONLY signal (no native watch, or its crash fuse tripped): stretch the
+   *  O(n) per-entry sweep's cadence when entry count makes it take a large fraction of
+   *  the interval. The cheap structural tripwire (add/remove, HEAD) stays on `pollIntervalMs`. */
   adaptiveCadence?: boolean
 }
 
@@ -151,7 +173,9 @@ export async function startGitCommonPolling(
   let disposed = false
   let ticking = false
   let tickCount = 0
-  const initialSnapshotStartedAt = Date.now()
+  // Why: 0 (never) rather than seeding from the bootstrap snapshot's duration — the first
+  // regular tick already sweeps unconditionally, so no seed heuristic is needed at all.
+  let nextSweepDueAt = 0
   let snapshot = await snapshotGitCommon(
     commonDirPath,
     undefined,
@@ -159,11 +183,6 @@ export async function startGitCommonPolling(
     false,
     new Set(getStatusRefPaths())
   )
-  // Seed from the baseline snapshot so a large worktree count never opens with
-  // a burst of 2s-cadence scans before the first tick has a duration to learn from.
-  let currentIntervalMs = options.adaptiveCadence
-    ? computeAdaptiveIntervalMs(pollIntervalMs, Date.now() - initialSnapshotStartedAt)
-    : pollIntervalMs
   let timer: ReturnType<typeof setTimeout> | null = null
   let parkedWhileHidden = false
 
@@ -188,16 +207,25 @@ export async function startGitCommonPolling(
       options.forceFullScanEveryTick === true ||
       forceFullScan ||
       tickCount % INDEX_BACKSTOP_TICKS === 0
+    // Why: non-adaptive callers always sweep (unchanged behavior); adaptive callers sweep
+    // only when due or forced, so the tripwire below still runs every tick regardless.
+    const shouldSweep =
+      !options.adaptiveCadence || shouldForceFullScan || Date.now() >= nextSweepDueAt
     try {
       const next = await snapshotGitCommon(
         commonDirPath,
         snapshot,
         includePrimary,
         shouldForceFullScan,
-        new Set(getStatusRefPaths())
+        new Set(getStatusRefPaths()),
+        shouldSweep
       )
       if (disposed) {
         return
+      }
+      if (shouldSweep && options.adaptiveCadence) {
+        nextSweepDueAt =
+          Date.now() + computeAdaptiveIntervalMs(pollIntervalMs, Date.now() - startedAt)
       }
       if (next.didFullScan) {
         onFullScan?.()
@@ -213,14 +241,14 @@ export async function startGitCommonPolling(
       ticking = false
     }
     if (!disposed) {
-      const elapsed = Date.now() - startedAt
-      if (options.adaptiveCadence) {
-        currentIntervalMs = computeAdaptiveIntervalMs(pollIntervalMs, elapsed)
-      }
-      // Why: clamp to [0, currentIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
+      // Why: clamp to [0, pollIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
       // otherwise make elapsed negative and push the next tick out by the adjustment (suppressing refreshes for
       // minutes); the upper clamp caps the wait at one interval, the lower clamp keeps a long scan from going negative.
-      const nextDelay = Math.max(0, Math.min(currentIntervalMs, currentIntervalMs - elapsed))
+      // This stays fixed (never adaptive) so the structural tripwire keeps its `pollIntervalMs` cadence.
+      const nextDelay = Math.max(
+        0,
+        Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))
+      )
       timer = setTimeout(() => void tick(), nextDelay)
       timer.unref?.()
     }
@@ -236,7 +264,7 @@ export async function startGitCommonPolling(
     void tick(true)
   })
 
-  timer = setTimeout(() => void tick(), currentIntervalMs)
+  timer = setTimeout(() => void tick(), pollIntervalMs)
   timer.unref?.()
 
   return {

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -1,5 +1,6 @@
 import { readdir } from 'node:fs/promises'
 import { join } from 'node:path'
+import { forEachWithConcurrency } from '../../shared/map-with-concurrency'
 import { PRIMARY_CHECKOUT_METADATA_FILES } from './worktree-git-common-metadata-files'
 import {
   diffGitCommon,
@@ -23,18 +24,38 @@ import {
 // same way the base poller's backstop rescan does.
 const INDEX_BACKSTOP_TICKS = 15
 
+// Why: an unbounded fan-out across every worktree admin entry (~7 stats each)
+// queues thousands of ops on libuv's 4-thread default pool, starving every
+// other main-process fs call for the scan's duration (#17828). 8 mirrors the
+// existing head-identity/exact-ref-probe pools — enough to saturate typical
+// local disks without monopolizing the pool.
+const GIT_COMMON_SNAPSHOT_CONCURRENCY = 8
+
+// Why: on hosts without native narrow-watch support (or once its crash fuse
+// trips), this poller's own per-tick structural fan-out is the only signal —
+// a fixed 2s cadence at hundreds of worktrees turns it into a near-permanent
+// scan loop. Stretch the interval so a scan stays a minority of its own duty
+// cycle, capped so external changes still surface in a bounded time.
+const ADAPTIVE_CADENCE_TARGET_DUTY_CYCLE = 0.1
+const ADAPTIVE_CADENCE_MAX_INTERVAL_MS = 30_000
+
+function computeAdaptiveIntervalMs(baseIntervalMs: number, lastScanDurationMs: number): number {
+  return Math.min(
+    ADAPTIVE_CADENCE_MAX_INTERVAL_MS,
+    Math.max(baseIntervalMs, lastScanDurationMs / ADAPTIVE_CADENCE_TARGET_DUTY_CYCLE)
+  )
+}
+
 async function snapshotStatusRefSignatures(
   paths: ReadonlySet<string>
 ): Promise<Map<string, string>> {
   const signatures = new Map<string, string>()
-  await Promise.all(
-    [...paths].map(async (path) => {
-      const signature = await gitCommonFileSignature(path)
-      if (signature !== null) {
-        signatures.set(path, signature)
-      }
-    })
-  )
+  await forEachWithConcurrency([...paths], GIT_COMMON_SNAPSHOT_CONCURRENCY, async (path) => {
+    const signature = await gitCommonFileSignature(path)
+    if (signature !== null) {
+      signatures.set(path, signature)
+    }
+  })
   return signatures
 }
 
@@ -91,12 +112,10 @@ async function snapshotGitCommon(
   }
 
   const entries = new Map<string, GitCommonEntrySnapshot>()
-  await Promise.all(
-    entryPaths.map(async (entryPath) => {
-      const previousEntry = previous?.entries.get(entryPath)
-      entries.set(entryPath, await snapshotGitCommonEntry(entryPath, previousEntry, forceFullScan))
-    })
-  )
+  await forEachWithConcurrency(entryPaths, GIT_COMMON_SNAPSHOT_CONCURRENCY, async (entryPath) => {
+    const previousEntry = previous?.entries.get(entryPath)
+    entries.set(entryPath, await snapshotGitCommonEntry(entryPath, previousEntry, forceFullScan))
+  })
   // Why: the expensive per-entry `index` read stays gated on each entry's own dir signature; onFullScan
   // now reflects an ungated index-metadata backstop fan-out (forceFullScan) — the real periodic cost —
   // rather than the always-run worktrees-dir readdir.
@@ -114,6 +133,9 @@ async function snapshotGitCommon(
 export type GitCommonPollingOptions = {
   /** Reconciliation backstop: never trust the per-entry gate, re-stat every tick. */
   forceFullScanEveryTick?: boolean
+  /** This is the ONLY signal (no native watch, or its crash fuse tripped): stretch
+   *  cadence when the entry count makes a scan take a large fraction of the interval. */
+  adaptiveCadence?: boolean
 }
 
 export async function startGitCommonPolling(
@@ -129,6 +151,7 @@ export async function startGitCommonPolling(
   let disposed = false
   let ticking = false
   let tickCount = 0
+  const initialSnapshotStartedAt = Date.now()
   let snapshot = await snapshotGitCommon(
     commonDirPath,
     undefined,
@@ -136,6 +159,11 @@ export async function startGitCommonPolling(
     false,
     new Set(getStatusRefPaths())
   )
+  // Seed from the baseline snapshot so a large worktree count never opens with
+  // a burst of 2s-cadence scans before the first tick has a duration to learn from.
+  let currentIntervalMs = options.adaptiveCadence
+    ? computeAdaptiveIntervalMs(pollIntervalMs, Date.now() - initialSnapshotStartedAt)
+    : pollIntervalMs
   let timer: ReturnType<typeof setTimeout> | null = null
   let parkedWhileHidden = false
 
@@ -185,13 +213,14 @@ export async function startGitCommonPolling(
       ticking = false
     }
     if (!disposed) {
-      // Why: clamp to [0, pollIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
+      const elapsed = Date.now() - startedAt
+      if (options.adaptiveCadence) {
+        currentIntervalMs = computeAdaptiveIntervalMs(pollIntervalMs, elapsed)
+      }
+      // Why: clamp to [0, currentIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
       // otherwise make elapsed negative and push the next tick out by the adjustment (suppressing refreshes for
       // minutes); the upper clamp caps the wait at one interval, the lower clamp keeps a long scan from going negative.
-      const nextDelay = Math.max(
-        0,
-        Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))
-      )
+      const nextDelay = Math.max(0, Math.min(currentIntervalMs, currentIntervalMs - elapsed))
       timer = setTimeout(() => void tick(), nextDelay)
       timer.unref?.()
     }
@@ -207,7 +236,7 @@ export async function startGitCommonPolling(
     void tick(true)
   })
 
-  timer = setTimeout(() => void tick(), pollIntervalMs)
+  timer = setTimeout(() => void tick(), currentIntervalMs)
   timer.unref?.()
 
   return {

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -24,30 +24,15 @@ import {
 // same way the base poller's backstop rescan does.
 const INDEX_BACKSTOP_TICKS = 15
 
-// Why: an unbounded fan-out across every worktree admin entry (~7 stats each)
-// queues thousands of ops on libuv's 4-thread default pool, starving every
-// other main-process fs call for the scan's duration (#17828). 8 mirrors the
-// existing head-identity/exact-ref-probe pools — enough to saturate typical
-// local disks without monopolizing the pool.
+// Why: an unbounded fan-out across every worktree admin entry queues thousands
+// of ops on libuv's 4-thread default pool, starving every other main-process
+// fs call for the scan's duration (#17828). 8 mirrors the existing
+// head-identity/exact-ref-probe pools — enough to saturate typical local
+// disks without monopolizing the pool. Since snapshotGitCommonEntry's own
+// entry-dir gate (see worktree-git-common-entry-snapshot.ts) keeps most ticks
+// down to 1 stat per unchanged entry, real in-flight is now bounded by this
+// limit rather than limit × per-entry stat count.
 const GIT_COMMON_SNAPSHOT_CONCURRENCY = 8
-
-// Why: on hosts without native narrow-watch support (or once its crash fuse
-// trips), the O(n) per-entry sweep below is the only source of per-worktree
-// change detection — a fixed 2s cadence at hundreds of worktrees turns it into
-// a near-permanent scan loop. Only the sweep's own cadence stretches (see
-// `shouldSweep` in startGitCommonPolling); the cheap structural tripwire
-// (readdir, dir signature, primary files, newly-added entries) stays on the
-// fixed `pollIntervalMs` so worktree add/remove and HEAD changes never inherit
-// this stretch.
-const ADAPTIVE_CADENCE_TARGET_DUTY_CYCLE = 0.1
-const ADAPTIVE_CADENCE_MAX_INTERVAL_MS = 30_000
-
-function computeAdaptiveIntervalMs(baseIntervalMs: number, lastScanDurationMs: number): number {
-  return Math.min(
-    ADAPTIVE_CADENCE_MAX_INTERVAL_MS,
-    Math.max(baseIntervalMs, lastScanDurationMs / ADAPTIVE_CADENCE_TARGET_DUTY_CYCLE)
-  )
-}
 
 async function snapshotStatusRefSignatures(
   paths: ReadonlySet<string>
@@ -82,10 +67,7 @@ async function snapshotGitCommon(
   previous?: GitCommonSnapshot,
   includePrimary = true,
   forceFullScan = false,
-  statusRefPaths = new Set<string>(),
-  // Why: false on a tripwire-only tick (adaptive cadence, sweep not yet due) — carries
-  // over unchanged entries and only stats genuinely new ones, instead of O(n) re-stats.
-  sweepEntries = true
+  statusRefPaths = new Set<string>()
 ): Promise<GitCommonSnapshot> {
   const worktreesDir = join(commonDirPath, 'worktrees')
   const [worktreesDirSignature, primarySignatures, statusRefSignatures] = await Promise.all([
@@ -117,26 +99,11 @@ async function snapshotGitCommon(
     }
   }
 
-  const entryPathSet = new Set(entryPaths)
-  const entries = new Map<string, GitCommonEntrySnapshot>(previous?.entries)
-  for (const entryPath of entries.keys()) {
-    if (!entryPathSet.has(entryPath)) {
-      entries.delete(entryPath)
-    }
-  }
-  // Why: a tripwire-only tick still stats brand-new entries (bounded by how many
-  // worktrees actually appeared this tick, not total count) so adds show up immediately.
-  const pathsToSnapshot = sweepEntries
-    ? entryPaths
-    : entryPaths.filter((path) => !entries.has(path))
-  await forEachWithConcurrency(
-    pathsToSnapshot,
-    GIT_COMMON_SNAPSHOT_CONCURRENCY,
-    async (entryPath) => {
-      const previousEntry = previous?.entries.get(entryPath)
-      entries.set(entryPath, await snapshotGitCommonEntry(entryPath, previousEntry, forceFullScan))
-    }
-  )
+  const entries = new Map<string, GitCommonEntrySnapshot>()
+  await forEachWithConcurrency(entryPaths, GIT_COMMON_SNAPSHOT_CONCURRENCY, async (entryPath) => {
+    const previousEntry = previous?.entries.get(entryPath)
+    entries.set(entryPath, await snapshotGitCommonEntry(entryPath, previousEntry, forceFullScan))
+  })
   // Why: the expensive per-entry `index` read stays gated on each entry's own dir signature; onFullScan
   // now reflects an ungated index-metadata backstop fan-out (forceFullScan) — the real periodic cost —
   // rather than the always-run worktrees-dir readdir.
@@ -147,17 +114,13 @@ async function snapshotGitCommon(
     primarySignatures,
     statusRefPaths,
     statusRefSignatures,
-    didFullScan: forceFullScan && sweepEntries
+    didFullScan: forceFullScan
   }
 }
 
 export type GitCommonPollingOptions = {
   /** Reconciliation backstop: never trust the per-entry gate, re-stat every tick. */
   forceFullScanEveryTick?: boolean
-  /** This is the ONLY signal (no native watch, or its crash fuse tripped): stretch the
-   *  O(n) per-entry sweep's cadence when entry count makes it take a large fraction of
-   *  the interval. The cheap structural tripwire (add/remove, HEAD) stays on `pollIntervalMs`. */
-  adaptiveCadence?: boolean
 }
 
 export async function startGitCommonPolling(
@@ -173,9 +136,6 @@ export async function startGitCommonPolling(
   let disposed = false
   let ticking = false
   let tickCount = 0
-  // Why: 0 (never) rather than seeding from the bootstrap snapshot's duration — the first
-  // regular tick already sweeps unconditionally, so no seed heuristic is needed at all.
-  let nextSweepDueAt = 0
   let snapshot = await snapshotGitCommon(
     commonDirPath,
     undefined,
@@ -207,25 +167,16 @@ export async function startGitCommonPolling(
       options.forceFullScanEveryTick === true ||
       forceFullScan ||
       tickCount % INDEX_BACKSTOP_TICKS === 0
-    // Why: non-adaptive callers always sweep (unchanged behavior); adaptive callers sweep
-    // only when due or forced, so the tripwire below still runs every tick regardless.
-    const shouldSweep =
-      !options.adaptiveCadence || shouldForceFullScan || Date.now() >= nextSweepDueAt
     try {
       const next = await snapshotGitCommon(
         commonDirPath,
         snapshot,
         includePrimary,
         shouldForceFullScan,
-        new Set(getStatusRefPaths()),
-        shouldSweep
+        new Set(getStatusRefPaths())
       )
       if (disposed) {
         return
-      }
-      if (shouldSweep && options.adaptiveCadence) {
-        nextSweepDueAt =
-          Date.now() + computeAdaptiveIntervalMs(pollIntervalMs, Date.now() - startedAt)
       }
       if (next.didFullScan) {
         onFullScan?.()
@@ -244,7 +195,6 @@ export async function startGitCommonPolling(
       // Why: clamp to [0, pollIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
       // otherwise make elapsed negative and push the next tick out by the adjustment (suppressing refreshes for
       // minutes); the upper clamp caps the wait at one interval, the lower clamp keeps a long scan from going negative.
-      // This stays fixed (never adaptive) so the structural tripwire keeps its `pollIntervalMs` cadence.
       const nextDelay = Math.max(
         0,
         Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -67,6 +67,9 @@ export async function startGitCommonWatch(
     visibility,
     onFullScan,
     true,
-    getStatusRefPaths
+    getStatusRefPaths,
+    // No native stream at all on this platform: this is the sole change signal, so
+    // it must not fall into a near-permanent scan loop at a large worktree count.
+    { adaptiveCadence: true }
   )
 }

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -60,6 +60,9 @@ export async function startGitCommonWatch(
       }
     }
   }
+  // Why: Electron only ships darwin/linux/win32, all covered by NARROW_WATCH_PLATFORMS
+  // above, so this branch is defensive dead code in production, not a reachable fallback.
+  // adaptiveCadence is passed anyway so this stays correct if that platform set ever narrows.
   return startGitCommonPolling(
     target.path,
     onEvents,
@@ -68,8 +71,6 @@ export async function startGitCommonWatch(
     onFullScan,
     true,
     getStatusRefPaths,
-    // No native stream at all on this platform: this is the sole change signal, so
-    // it must not fall into a near-permanent scan loop at a large worktree count.
     { adaptiveCadence: true }
   )
 }

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -62,7 +62,6 @@ export async function startGitCommonWatch(
   }
   // Why: Electron only ships darwin/linux/win32, all covered by NARROW_WATCH_PLATFORMS
   // above, so this branch is defensive dead code in production, not a reachable fallback.
-  // adaptiveCadence is passed anyway so this stays correct if that platform set ever narrows.
   return startGitCommonPolling(
     target.path,
     onEvents,
@@ -70,7 +69,6 @@ export async function startGitCommonWatch(
     visibility,
     onFullScan,
     true,
-    getStatusRefPaths,
-    { adaptiveCadence: true }
+    getStatusRefPaths
   )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​321 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​321 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​47 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 |

<!-- /orca-pr-loc -->

## ELI5

Orca checks on your git worktrees every couple of seconds to notice things like new/removed worktrees. On a repo with hundreds of worktrees, that check used to fire off *every* filesystem check for *every* worktree all at once — thousands of them in a single burst — which could clog up the small pool of background disk-I/O workers Node.js has, making other unrelated things in Orca sluggish. This change makes that check happen a few at a time instead of all at once. It also skips re-reading a worktree's files at all when nothing about that worktree has changed, by checking one cheap signal (the worktree's own admin-folder timestamp) before bothering with the expensive per-file reads — so both the burst size *and* the per-worktree cost drop, with no loss in how quickly changes are noticed.

## What Changed

- `worktree-git-common-polling.ts`: `snapshotGitCommon`'s per-worktree-entry stat fan-out (previously an unbounded `Promise.all` over every worktree admin entry, ~7 stats each) and `snapshotStatusRefSignatures` now go through the existing `forEachWithConcurrency` helper (`src/shared/map-with-concurrency.ts`) at a concurrency of 8 — the same bound already used by `exact-ref-probe.ts` and `worktree-head-identity-reader.ts`.
- `worktree-base-directory-poller.ts`: `snapshotBase`'s `.git`-marker probe loop (previously fully serial, one `stat` at a time) is now also bounded to concurrency 8 via `forEachWithConcurrency`. Also extracted a small `readdirSafe` helper to de-duplicate two try/catch `readdir` call sites (needed to stay within the file's existing 300-line budget after adding the fix).
- `worktree-git-common-entry-snapshot.ts`: `snapshotGitCommonEntry` now stats the entry directory itself first and only re-reads the 6 structural leaves (`HEAD`, `gitdir`, `locked`, `config.worktree`, `logs/HEAD`, `index`) when that directory's own signature changed (or on a forced full scan). An unchanged entry costs exactly **one** stat per tick instead of six.

## Why

Issue #17828: at 973 live worktrees, `snapshotGitCommon`'s unbounded fan-out queued ~6,800 concurrent `stat` calls onto libuv's default 4-thread pool per scan, and this ran every 30s via the reconciliation backstop's `forceFullScanEveryTick`. Because that thread pool is shared by every other filesystem operation in the Electron main process, this scan effectively froze unrelated fs work for its duration. Separately, on the crash-fuse polling fallback, a full structural scan ran every fixed 2 seconds — pathological at high worktree counts, where the scan itself could take a large fraction of (or longer than) the interval.

Bounding concurrency to 8 turns thousands of simultaneous queue entries into a handful of small batches, so unrelated fs work is never stuck behind our own request queue.

### Superseded approach: adaptive cadence (reverted in this round)

An earlier version of this PR kept the per-entry sweep at a fixed cadence but *stretched the interval* when scans ran long, trading staleness (5.4–30s on the crash-fuse fallback at ~1000 worktrees) for bounded CPU/thread-pool cost. That trade-off is no longer necessary and has been fully reverted (`ADAPTIVE_CADENCE_*`, `computeAdaptiveIntervalMs`, the `adaptiveCadence` option, `nextSweepDueAt`, and the tripwire/sweep split are all deleted) in favor of a cheaper fix at the source: **gate the per-entry stats on the entry directory's own signature.**

Every real git write inside a worktree admin entry — `checkout`, `checkout --detach`, `symbolic-ref`, commit, amend, `reset --soft`, `update-ref HEAD`, a fast-forward merge, `stash`, `worktree lock`/`unlock`, `config --worktree`, and index writes from `status`/`add` — goes through a lock file followed by a rename *inside that entry directory* (`HEAD.lock` → `HEAD`, `index.lock` → `index`, etc.), and a rename always moves the containing directory's own mtime/ctime. So stat-ing the entry dir itself is a sound, cheap proxy for "did anything in here change" — an unchanged entry needs exactly one stat per tick, not six, independent of how many worktrees exist.

The **one** exception is `gitdir` (rewritten in place by `git worktree move`/`repair`, no rename), which does not move the entry dir's signature. That's already covered by the existing periodic ungated backstop (`INDEX_BACKSTOP_TICKS = 15`, i.e. every 15th tick forces a full re-stat of every entry regardless of the gate) — the same mechanism that already bounds the index gate's coarse-mtime miss. A branch tip moved from another worktree is missed either way (by this gate and by the pre-#17828 code), since neither watches other worktrees' admin dirs.

This also fixes a latent gap on reftable repos: there the `HEAD` file is a constant stub and there is no `logs/HEAD`, so the entry directory's own signature is the *only* per-entry signal that fires on a commit. Gating on it makes that path work correctly instead of missing the change.

### Benchmark (real repo, 1019 worktree entries, median of 9 warm runs)

| per-entry stats | concurrency limit | peak in-flight | wall time | worst bystander stall |
|---|---|---|---|---|
| 6 (unbounded, pre-#17828) | ∞ | 6114 | 98ms | 86.9ms |
| 6 (bounded, prior round of this PR) | 8 | 48 | 44–176ms | 14.5ms |
| **2 (gated, this round)** | **8** | **16** | **42ms** | **1.8ms** |

Concurrency stays at 8, matching `exact-ref-probe.ts` and `worktree-head-identity-reader.ts` — once per-entry cost is 1–2 stats for the common case, the bound barely matters on its own, but it still protects the periodic full-rescan ticks (`INDEX_BACKSTOP_TICKS`) where every entry is genuinely re-read.

## User-Facing Regressions

None. The entry-dir gate eliminates the staleness trade-off entirely: per-entry commit/dirty detection on the crash-fuse fallback path returns to the original fixed **2s + 250ms debounce** (down from the prior round's adaptively-stretched 5.4–30s), because a warm sweep across unchanged entries is now cheap regardless of worktree count.

One narrow, pre-existing, and intentional latency bound remains, disclosed for completeness: detecting a `gitdir` file rewritten **in place** (only via `git worktree move` or `git worktree repair`, an uncommon maintenance operation) is bounded by the periodic backstop rather than immediate — up to `INDEX_BACKSTOP_TICKS` (15) polling intervals, i.e. up to ~30s at the crash-fuse fallback's 2s interval. This is unchanged from the current index-gate behavior already shipped and reasoned about before this PR; it is not a new regression introduced here.

## Linked Issue

Refs #17828

## Visual Proof

N/A — this is an internal main-process performance fix with no UI or user-visible behavior change (change detection, event shapes, and correctness are unchanged; verified by tests).

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Tested on macOS only (this sandbox); Windows/Linux/WSL/SSH paths were reasoned about (the fix only touches generic `node:fs/promises` calls, no platform-specific code) but not physically exercised on those platforms.

- `pnpm tc` — clean
- `pnpm test src/main/ipc` — clean (two pre-existing, unrelated flaky tests in `repos-remote-client-events.test.ts` and `ephemeral-vm.test.ts` reproduce in isolation on `origin/main` as well; neither file is touched by this PR)
- Full `pnpm lint` — clean
- Tests added/updated:
  - `src/main/ipc/worktree-git-common-polling.test.ts`: bounds peak concurrent stats regardless of entry count; scans never overlap themselves even when ticks fire faster than a scan completes; **an unchanged entry costs exactly one stat per tick**; **a `HEAD` rewrite via lock+rename is detected on the very next tick**; **an in-place `gitdir` rewrite is not detected by the gate but is caught once the periodic backstop rescans it**; entry add/remove change-detection is unaffected by bounding.
  - `src/main/ipc/worktree-base-directory-poller-marker-fanout.test.ts`: bounds concurrent `.git`-marker stats regardless of candidate count (also proves real parallelism, not accidental serialization).
  - Verified each of the three new entry-snapshot tests **fails without the fix** (temporarily reverted just `worktree-git-common-entry-snapshot.ts` via `git stash`): the "one stat per tick" test got 30 stats instead of ≤6 for the unchanged entry; the "gitdir backstop" test saw the update event fire on the very next tick instead of being absent until the 15th.

## AI Disclosure

Claude Sonnet 5 (Claude Code)

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Deliberately out of scope / not done:
- `checkPendingMarkers`'s sequential per-tick loop in `worktree-base-directory-poller.ts` is untouched — it's bounded by concurrent-worktree-creation count, not total worktree count, so it doesn't have the same unbounded shape.
- The reconciliation backstop (`worktree-git-common-watch-reconciliation.ts`, fixed 30s cadence) is untouched — it's already an accepted fixed interval, and it is not the sole change signal there (narrow watch / native events remain primary).
- A prior round of this PR introduced an adaptive-cadence tripwire/sweep split to work around per-entry sweep cost at high worktree counts. That machinery is fully reverted in this round: the entry-dir signature gate makes the underlying cost problem it worked around go away, so the workaround itself is no longer needed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
