### PR TITLE
perf(worktree): make head-identity refresh incremental

### DIFF
--- a/src/main/ipc/worktree-base-directory-change-collector.test.ts
+++ b/src/main/ipc/worktree-base-directory-change-collector.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { join } from 'node:path'
+import {
+  collectLocalWorktreeBaseChanges,
+  collectRemoteWorktreeBaseChanges
+} from './worktree-base-directory-change-collector'
+import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
+import { EMPTY_HEAD_IDENTITY_SCOPE, FULL_HEAD_IDENTITY_SCOPE } from './worktree-head-identity-scope'
+
+const COMMON_DIR = join('/repos', 'project', '.git')
+
+function makeTarget(): WorktreeBaseWatchTarget {
+  return {
+    key: `git-common:local:${COMMON_DIR}`,
+    kind: 'git-common',
+    path: COMMON_DIR,
+    repos: new Map([['repo-1', { repoId: 'repo-1', repoName: 'project', nestWorkspaces: false }]])
+  }
+}
+
+describe('worktree base change collector', () => {
+  it('states the full head scope on overflow rather than leaving it absent', () => {
+    // Overflow means every event in the window was lost. Stating FULL here — not
+    // relying on a downstream `?? FULL` for a missing field — is what keeps a
+    // future caller that forwards this object from reading it as "nothing moved".
+    const changes = collectRemoteWorktreeBaseChanges(makeTarget(), [{ kind: 'overflow' }] as never)
+
+    expect(changes.overflow).toBe(true)
+    expect(changes.headIdentityScope).toEqual(FULL_HEAD_IDENTITY_SCOPE)
+  })
+
+  it('unions the head scopes of every event in a burst', () => {
+    const changes = collectLocalWorktreeBaseChanges(makeTarget(), [
+      { type: 'update', path: join(COMMON_DIR, 'worktrees', 'wt-a', 'logs', 'HEAD') },
+      { type: 'update', path: join(COMMON_DIR, 'worktrees', 'wt-b', 'HEAD') },
+      { type: 'update', path: join(COMMON_DIR, 'logs', 'HEAD') },
+      // Status-tier churn contributes nothing to the head scope.
+      { type: 'update', path: join(COMMON_DIR, 'worktrees', 'wt-c', 'index') }
+    ])
+
+    expect(changes.headIdentityScope).toEqual({
+      listing: false,
+      primary: true,
+      all: false,
+      entryNames: new Set(['wt-a', 'wt-b'])
+    })
+  })
+
+  it('lets one packed-refs write widen the whole burst to a full re-read', () => {
+    const changes = collectLocalWorktreeBaseChanges(makeTarget(), [
+      { type: 'update', path: join(COMMON_DIR, 'worktrees', 'wt-a', 'logs', 'HEAD') },
+      { type: 'update', path: join(COMMON_DIR, 'packed-refs') }
+    ])
+
+    expect(changes.headIdentityScope).toEqual(FULL_HEAD_IDENTITY_SCOPE)
+  })
+
+  it('keeps the head scope empty for a burst that can move no head', () => {
+    const changes = collectLocalWorktreeBaseChanges(makeTarget(), [
+      { type: 'create', path: join(COMMON_DIR, 'worktrees', 'wt-a', 'locked') },
+      { type: 'update', path: join(COMMON_DIR, 'worktrees', 'wt-a', 'index') },
+      { type: 'update', path: join(COMMON_DIR, 'config') }
+    ])
+
+    expect(changes.headIdentityScope).toEqual(EMPTY_HEAD_IDENTITY_SCOPE)
+    expect(changes.structureRepoIds).toEqual(['repo-1'])
+  })
+
+  it('narrows a rename to the entries on both sides', () => {
+    const changes = collectRemoteWorktreeBaseChanges(makeTarget(), [
+      {
+        kind: 'rename',
+        absolutePath: join(COMMON_DIR, 'worktrees', 'wt-new', 'HEAD'),
+        oldAbsolutePath: join(COMMON_DIR, 'worktrees', 'wt-old', 'HEAD')
+      }
+    ] as never)
+
+    expect(changes.headIdentityScope).toEqual({
+      listing: false,
+      primary: false,
+      all: false,
+      entryNames: new Set(['wt-old', 'wt-new'])
+    })
+  })
+})

--- a/src/main/ipc/worktree-base-directory-change-collector.ts
+++ b/src/main/ipc/worktree-base-directory-change-collector.ts
@@ -5,6 +5,7 @@ import {
 } from './worktree-base-directory-event-filter'
 import {
   EMPTY_HEAD_IDENTITY_SCOPE,
+  FULL_HEAD_IDENTITY_SCOPE,
   mergeHeadIdentityScopes,
   type WorktreeHeadIdentityScope
 } from './worktree-head-identity-scope'
@@ -44,13 +45,16 @@ function emptyBuckets(): ChangeBuckets {
   }
 }
 
-function emptyChanges(): WorktreeBaseCollectedChanges {
+// Why: overflow means every event in the window was lost, so the scope must be
+// stated as FULL here rather than left to a downstream `?? FULL` on an absent
+// field — a caller that forwards this object must not read it as "nothing moved".
+function overflowChanges(): WorktreeBaseCollectedChanges {
   return {
-    overflow: false,
+    overflow: true,
     structureRepoIds: [],
     gitStatusRepoIds: [],
     headIdentityRepoIds: [],
-    headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
+    headIdentityScope: FULL_HEAD_IDENTITY_SCOPE
   }
 }
 
@@ -103,7 +107,7 @@ export function collectRemoteWorktreeBaseChanges(
   const buckets = emptyBuckets()
   for (const event of events) {
     if (event.kind === 'overflow') {
-      return { ...emptyChanges(), overflow: true }
+      return overflowChanges()
     }
     if (event.kind === 'rename') {
       if (event.oldAbsolutePath) {

--- a/src/main/ipc/worktree-base-directory-change-collector.ts
+++ b/src/main/ipc/worktree-base-directory-change-collector.ts
@@ -3,6 +3,11 @@ import {
   classifyWorktreeBaseChange,
   type WorktreeBaseWatchTarget
 } from './worktree-base-directory-event-filter'
+import {
+  EMPTY_HEAD_IDENTITY_SCOPE,
+  mergeHeadIdentityScopes,
+  type WorktreeHeadIdentityScope
+} from './worktree-head-identity-scope'
 
 type WorktreeBaseWatcherEvent = {
   type: 'create' | 'update' | 'delete'
@@ -14,6 +19,7 @@ export type WorktreeBaseCollectedChanges = {
   structureRepoIds: string[]
   gitStatusRepoIds: string[]
   headIdentityRepoIds: string[]
+  headIdentityScope: WorktreeHeadIdentityScope
 }
 
 export function hasCollectedWorktreeBaseChanges(changes: WorktreeBaseCollectedChanges): boolean {
@@ -26,13 +32,15 @@ type ChangeBuckets = {
   structureRepoIds: Set<string>
   gitStatusRepoIds: Set<string>
   headIdentityRepoIds: Set<string>
+  headIdentityScope: WorktreeHeadIdentityScope
 }
 
 function emptyBuckets(): ChangeBuckets {
   return {
     structureRepoIds: new Set<string>(),
     gitStatusRepoIds: new Set<string>(),
-    headIdentityRepoIds: new Set<string>()
+    headIdentityRepoIds: new Set<string>(),
+    headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
   }
 }
 
@@ -41,7 +49,8 @@ function emptyChanges(): WorktreeBaseCollectedChanges {
     overflow: false,
     structureRepoIds: [],
     gitStatusRepoIds: [],
-    headIdentityRepoIds: []
+    headIdentityRepoIds: [],
+    headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
   }
 }
 
@@ -60,6 +69,10 @@ function addMatchingChange(
   for (const repoId of change.headIdentityRepoIds) {
     buckets.headIdentityRepoIds.add(repoId)
   }
+  buckets.headIdentityScope = mergeHeadIdentityScopes(
+    buckets.headIdentityScope,
+    change.headIdentityScope
+  )
 }
 
 function toCollectedChanges(buckets: ChangeBuckets): WorktreeBaseCollectedChanges {
@@ -67,7 +80,8 @@ function toCollectedChanges(buckets: ChangeBuckets): WorktreeBaseCollectedChange
     overflow: false,
     structureRepoIds: [...buckets.structureRepoIds],
     gitStatusRepoIds: [...buckets.gitStatusRepoIds],
-    headIdentityRepoIds: [...buckets.headIdentityRepoIds]
+    headIdentityRepoIds: [...buckets.headIdentityRepoIds],
+    headIdentityScope: buckets.headIdentityScope
   }
 }
 

--- a/src/main/ipc/worktree-base-directory-event-filter.test.ts
+++ b/src/main/ipc/worktree-base-directory-event-filter.test.ts
@@ -5,6 +5,13 @@ import {
   matchingWorktreeBaseRepoIds,
   type WorktreeBaseWatchTarget
 } from './worktree-base-directory-event-filter'
+import {
+  EMPTY_HEAD_IDENTITY_SCOPE,
+  FULL_HEAD_IDENTITY_SCOPE,
+  headIdentityScopeForEntry,
+  LISTING_HEAD_IDENTITY_SCOPE,
+  PRIMARY_HEAD_IDENTITY_SCOPE
+} from './worktree-head-identity-scope'
 
 const COMMON_DIR = join('/repos', 'project', '.git')
 
@@ -28,7 +35,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: ['repo-1'],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: headIdentityScopeForEntry('wt-a')
     })
     expect(
       classifyWorktreeBaseChange(target, {
@@ -38,7 +46,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: ['repo-1'],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: LISTING_HEAD_IDENTITY_SCOPE
     })
     expect(
       matchingWorktreeBaseRepoIds(target, {
@@ -50,7 +59,12 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
 
   it('classifies primary-checkout branch metadata as structural and index as status-only', () => {
     const target = makeGitCommonTarget()
-    for (const file of ['HEAD', 'packed-refs']) {
+    // A primary HEAD write can only move the primary checkout's head, while a
+    // packed-refs rewrite can move any branch oid with no admin-dir event.
+    for (const [file, headIdentityScope] of [
+      ['HEAD', PRIMARY_HEAD_IDENTITY_SCOPE],
+      ['packed-refs', FULL_HEAD_IDENTITY_SCOPE]
+    ] as const) {
       expect(
         classifyWorktreeBaseChange(target, {
           type: 'update',
@@ -59,7 +73,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
       ).toEqual({
         structureRepoIds: ['repo-1'],
         gitStatusRepoIds: [],
-        headIdentityRepoIds: []
+        headIdentityRepoIds: [],
+        headIdentityScope
       })
     }
     expect(
@@ -70,7 +85,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: ['repo-1'],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
   })
 
@@ -84,7 +100,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: ['repo-1'],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
     expect(
       classifyWorktreeBaseChange(target, {
@@ -94,7 +111,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
   })
 
@@ -109,7 +127,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: ['repo-1']
+      headIdentityRepoIds: ['repo-1'],
+      headIdentityScope: headIdentityScopeForEntry('wt-a')
     })
     expect(
       classifyWorktreeBaseChange(target, {
@@ -119,7 +138,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: ['repo-1']
+      headIdentityRepoIds: ['repo-1'],
+      headIdentityScope: PRIMARY_HEAD_IDENTITY_SCOPE
     })
     // Per-ref reflogs churn on fetches and stay ignored.
     expect(
@@ -130,7 +150,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
     expect(
       classifyWorktreeBaseChange(target, {
@@ -140,7 +161,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
   })
 
@@ -154,7 +176,9 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: ['repo-1'],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      // Sparse-flag only: structural, but provably cannot move a head.
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
     expect(
       classifyWorktreeBaseChange(target, {
@@ -164,7 +188,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: ['repo-1'],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
   })
 
@@ -181,7 +206,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: ['repo-1'],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
     const boundPaths = [
       join(COMMON_DIR, 'refs', 'remotes', 'origin', 'main'),
@@ -195,7 +221,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
         expect(classifyWorktreeBaseChange(target, { type, path })).toEqual({
           structureRepoIds: [],
           gitStatusRepoIds: ['repo-1'],
-          headIdentityRepoIds: []
+          headIdentityRepoIds: [],
+          headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
         })
       }
     }
@@ -208,7 +235,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
     expect(
       classifyWorktreeBaseChange(target, {
@@ -218,7 +246,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
   })
 
@@ -238,7 +267,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: ['repo-1'],
       gitStatusRepoIds: [],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: headIdentityScopeForEntry('wt a')
     })
     expect(
       classifyWorktreeBaseChange(target, {
@@ -248,7 +278,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: ['repo-1'],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
     expect(
       classifyWorktreeBaseChange(target, {
@@ -258,7 +289,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     ).toEqual({
       structureRepoIds: [],
       gitStatusRepoIds: ['repo-1'],
-      headIdentityRepoIds: []
+      headIdentityRepoIds: [],
+      headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
     })
   })
 
@@ -278,7 +310,24 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
       expect(classifyWorktreeBaseChange(target, { type: 'update', path })).toEqual({
         structureRepoIds: [],
         gitStatusRepoIds: [],
-        headIdentityRepoIds: []
+        headIdentityRepoIds: [],
+        headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
+      })
+    }
+  })
+
+  it('widens to a full head re-read when the worktrees admin root itself changes', () => {
+    const target = makeGitCommonTarget()
+    // `git worktree prune` can delete and a later add recreate this dir; the
+    // watcher's stream is bound to the old inode, so no cached entry is trusted.
+    for (const type of ['create', 'update', 'delete'] as const) {
+      expect(
+        classifyWorktreeBaseChange(target, { type, path: join(COMMON_DIR, 'worktrees') })
+      ).toEqual({
+        structureRepoIds: ['repo-1'],
+        gitStatusRepoIds: [],
+        headIdentityRepoIds: [],
+        headIdentityScope: FULL_HEAD_IDENTITY_SCOPE
       })
     }
   })

--- a/src/main/ipc/worktree-base-directory-event-filter.test.ts
+++ b/src/main/ipc/worktree-base-directory-event-filter.test.ts
@@ -47,7 +47,12 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
       structureRepoIds: ['repo-1'],
       gitStatusRepoIds: [],
       headIdentityRepoIds: [],
-      headIdentityScope: LISTING_HEAD_IDENTITY_SCOPE
+      // Named as well as listed, so a remove+add reusing the name cannot keep
+      // serving the removed worktree's cached head.
+      headIdentityScope: {
+        ...LISTING_HEAD_IDENTITY_SCOPE,
+        entryNames: new Set(['wt-b'])
+      }
     })
     expect(
       matchingWorktreeBaseRepoIds(target, {

--- a/src/main/ipc/worktree-base-directory-event-filter.ts
+++ b/src/main/ipc/worktree-base-directory-event-filter.ts
@@ -2,6 +2,14 @@ import {
   normalizeRuntimePathForComparison,
   relativePathInsideRoot
 } from '../../shared/cross-platform-path'
+import {
+  EMPTY_HEAD_IDENTITY_SCOPE,
+  FULL_HEAD_IDENTITY_SCOPE,
+  headIdentityScopeForEntry,
+  LISTING_HEAD_IDENTITY_SCOPE,
+  PRIMARY_HEAD_IDENTITY_SCOPE,
+  type WorktreeHeadIdentityScope
+} from './worktree-head-identity-scope'
 
 type WorktreeBaseWatcherEvent = {
   type: 'create' | 'update' | 'delete'
@@ -15,6 +23,9 @@ export type WorktreeBaseChangeClass = {
   // status churn, but distinct so only these re-read head identities. An index
   // rewrite cannot move HEAD, so it must never land here.
   headIdentityRepoIds: string[]
+  // Which slice of the common dir's head identities this event can have moved.
+  // Every classification must state one; `EMPTY` is a claim that no head moved.
+  headIdentityScope: WorktreeHeadIdentityScope
 }
 
 export type WorktreeBaseWatchKind = 'base' | 'git-common'
@@ -99,13 +110,24 @@ function matchingBaseRepoIds(
 // ignored.
 // `config.worktree` is structural because it is the only file whose write
 // flips `git worktree list`'s sparse flag, and no status/commit path touches
-// it — so it cannot re-open the index-churn fanout this classifier closes.
-const GIT_COMMON_PRIMARY_STRUCTURAL_FILES = new Set(['HEAD', 'packed-refs', 'config.worktree'])
+// it — so it cannot re-open the index-churn fanout this classifier closes, and
+// it can move no head either. A rewritten `packed-refs` by contrast can move
+// any branch oid without touching a single admin dir, so no cached head
+// survives it.
+const GIT_COMMON_PRIMARY_STRUCTURAL_SCOPES = new Map<string, WorktreeHeadIdentityScope>([
+  ['HEAD', PRIMARY_HEAD_IDENTITY_SCOPE],
+  ['packed-refs', FULL_HEAD_IDENTITY_SCOPE],
+  ['config.worktree', EMPTY_HEAD_IDENTITY_SCOPE]
+])
 // `config` is status-tier: an external `git push -u` writes only
 // branch.<name>.remote/merge there, and a config write can move neither HEAD
 // nor the worktree listing.
 const GIT_COMMON_PRIMARY_STATUS_FILES = new Set(['index', 'config'])
 const GIT_COMMON_LINKED_STRUCTURAL_FILES = new Set(['HEAD', 'gitdir', 'locked', 'config.worktree'])
+// `HEAD` carries the branch and `gitdir` the checkout path; `locked` and
+// `config.worktree` are written by `git worktree lock` / sparse toggles, neither
+// of which can move a head.
+const GIT_COMMON_LINKED_HEAD_SOURCE_FILES = new Set(['HEAD', 'gitdir'])
 const GIT_COMMON_LINKED_STATUS_FILES = new Set(['index'])
 
 // `logs/HEAD` is the head-identity trigger for head moves that rewrite no
@@ -138,14 +160,19 @@ function allRepoIds(target: WorktreeBaseWatchTarget): string[] {
 const NO_CHANGE: WorktreeBaseChangeClass = {
   structureRepoIds: [],
   gitStatusRepoIds: [],
-  headIdentityRepoIds: []
+  headIdentityRepoIds: [],
+  headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
 }
 
-function structuralChange(repoIds: string[]): WorktreeBaseChangeClass {
+function structuralChange(
+  repoIds: string[],
+  headIdentityScope: WorktreeHeadIdentityScope = EMPTY_HEAD_IDENTITY_SCOPE
+): WorktreeBaseChangeClass {
   return {
     structureRepoIds: repoIds,
     gitStatusRepoIds: [],
-    headIdentityRepoIds: []
+    headIdentityRepoIds: [],
+    headIdentityScope
   }
 }
 
@@ -153,15 +180,20 @@ function gitStatusChange(repoIds: string[]): WorktreeBaseChangeClass {
   return {
     structureRepoIds: [],
     gitStatusRepoIds: repoIds,
-    headIdentityRepoIds: []
+    headIdentityRepoIds: [],
+    headIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE
   }
 }
 
-function headIdentityChange(repoIds: string[]): WorktreeBaseChangeClass {
+function headIdentityChange(
+  repoIds: string[],
+  headIdentityScope: WorktreeHeadIdentityScope
+): WorktreeBaseChangeClass {
   return {
     structureRepoIds: [],
     gitStatusRepoIds: [],
-    headIdentityRepoIds: repoIds
+    headIdentityRepoIds: repoIds,
+    headIdentityScope
   }
 }
 
@@ -178,10 +210,13 @@ function classifyGitCommonEvent(
   const repoIds = allRepoIds(target)
   if (parts.length === 1) {
     if (parts[0] === 'worktrees') {
-      return structuralChange(repoIds)
+      // The admin root itself appearing, vanishing, or being swapped means the
+      // watcher's view of every entry is suspect.
+      return structuralChange(repoIds, FULL_HEAD_IDENTITY_SCOPE)
     }
-    if (GIT_COMMON_PRIMARY_STRUCTURAL_FILES.has(parts[0])) {
-      return structuralChange(repoIds)
+    const primaryScope = GIT_COMMON_PRIMARY_STRUCTURAL_SCOPES.get(parts[0])
+    if (primaryScope) {
+      return structuralChange(repoIds, primaryScope)
     }
     if (GIT_COMMON_PRIMARY_STATUS_FILES.has(parts[0])) {
       return gitStatusChange(repoIds)
@@ -190,7 +225,7 @@ function classifyGitCommonEvent(
   }
   if (parts[0] !== 'worktrees') {
     if (isHeadLogParts(parts, 0)) {
-      return headIdentityChange(repoIds)
+      return headIdentityChange(repoIds, PRIMARY_HEAD_IDENTITY_SCOPE)
     }
     if (isBoundUpstreamRef(target, event.path, parts)) {
       return gitStatusChange(repoIds)
@@ -198,18 +233,25 @@ function classifyGitCommonEvent(
     return NO_CHANGE
   }
   if (parts.length === 2) {
-    return event.type === 'update' ? NO_CHANGE : structuralChange(repoIds)
+    return event.type === 'update'
+      ? NO_CHANGE
+      : structuralChange(repoIds, LISTING_HEAD_IDENTITY_SCOPE)
   }
   if (parts.length === 3) {
     if (GIT_COMMON_LINKED_STRUCTURAL_FILES.has(parts[2])) {
-      return structuralChange(repoIds)
+      return structuralChange(
+        repoIds,
+        GIT_COMMON_LINKED_HEAD_SOURCE_FILES.has(parts[2])
+          ? headIdentityScopeForEntry(parts[1])
+          : EMPTY_HEAD_IDENTITY_SCOPE
+      )
     }
     if (GIT_COMMON_LINKED_STATUS_FILES.has(parts[2])) {
       return gitStatusChange(repoIds)
     }
   }
   if (isHeadLogParts(parts, 2)) {
-    return headIdentityChange(repoIds)
+    return headIdentityChange(repoIds, headIdentityScopeForEntry(parts[1]))
   }
   return NO_CHANGE
 }

--- a/src/main/ipc/worktree-base-directory-event-filter.ts
+++ b/src/main/ipc/worktree-base-directory-event-filter.ts
@@ -7,6 +7,7 @@ import {
   FULL_HEAD_IDENTITY_SCOPE,
   headIdentityScopeForEntry,
   LISTING_HEAD_IDENTITY_SCOPE,
+  mergeHeadIdentityScopes,
   PRIMARY_HEAD_IDENTITY_SCOPE,
   type WorktreeHeadIdentityScope
 } from './worktree-head-identity-scope'
@@ -233,9 +234,15 @@ function classifyGitCommonEvent(
     return NO_CHANGE
   }
   if (parts.length === 2) {
+    // Name the entry as well as the listing: a remove+add reusing one admin dir
+    // name coalesces into a single refresh, and the listing alone would keep
+    // serving the removed worktree's cached head.
     return event.type === 'update'
       ? NO_CHANGE
-      : structuralChange(repoIds, LISTING_HEAD_IDENTITY_SCOPE)
+      : structuralChange(
+          repoIds,
+          mergeHeadIdentityScopes(LISTING_HEAD_IDENTITY_SCOPE, headIdentityScopeForEntry(parts[1]))
+        )
   }
   if (parts.length === 3) {
     if (GIT_COMMON_LINKED_STRUCTURAL_FILES.has(parts[2])) {

--- a/src/main/ipc/worktree-base-directory-notifications.ts
+++ b/src/main/ipc/worktree-base-directory-notifications.ts
@@ -5,6 +5,12 @@ import {
   refreshWorktreeHeadIdentities,
   type WorktreeHeadIdentityRefreshState
 } from './worktree-head-identity-refresh'
+import {
+  EMPTY_HEAD_IDENTITY_SCOPE,
+  FULL_HEAD_IDENTITY_SCOPE,
+  mergeHeadIdentityScopes,
+  type WorktreeHeadIdentityScope
+} from './worktree-head-identity-scope'
 import { notifyWorktreeGitStatusMetadataChanged } from './worktree-remote'
 import { notifyWatchedWorktreeCatalogChanged } from './watched-worktree-catalog-notification'
 
@@ -14,6 +20,7 @@ export type WorktreeBaseNotificationWatch = WorktreeBaseWatchTarget & {
   pendingStructureRepoIds: Set<string>
   pendingGitStatusRepoIds: Set<string>
   pendingHeadIdentityRepoIds: Set<string>
+  pendingHeadIdentityScope: WorktreeHeadIdentityScope
   headIdentityRefresh: WorktreeHeadIdentityRefreshState
   disposed: boolean
 }
@@ -24,6 +31,7 @@ export function clearPendingWorktreeBaseNotifications(watch: WorktreeBaseNotific
   watch.pendingStructureRepoIds.clear()
   watch.pendingGitStatusRepoIds.clear()
   watch.pendingHeadIdentityRepoIds.clear()
+  watch.pendingHeadIdentityScope = EMPTY_HEAD_IDENTITY_SCOPE
 }
 
 export function supportsWorktreeHeadIdentityRefresh(watch: WorktreeBaseNotificationWatch): boolean {
@@ -47,6 +55,13 @@ export function scheduleWorktreeBaseNotification(
   for (const repoId of changes.headIdentityRepoIds ?? []) {
     watch.pendingHeadIdentityRepoIds.add(repoId)
   }
+  // Why: callers that cannot attribute the burst to specific worktrees (watcher
+  // failure, event overflow) omit the scope entirely; that is a loss of
+  // knowledge, so it must widen to a full re-read rather than narrow to nothing.
+  watch.pendingHeadIdentityScope = mergeHeadIdentityScopes(
+    watch.pendingHeadIdentityScope,
+    changes.headIdentityScope ?? FULL_HEAD_IDENTITY_SCOPE
+  )
   clearTimeout(watch.notifyTimer ?? undefined)
   watch.notifyTimer = setTimeout(() => {
     watch.notifyTimer = null
@@ -62,6 +77,7 @@ export function scheduleWorktreeBaseNotification(
       )
     )
     const emitHeadIdentities = pendingStructure.length === 0
+    const headIdentityScope = watch.pendingHeadIdentityScope
     clearPendingWorktreeBaseNotifications(watch)
     for (const repoId of pendingStructure) {
       notifyWatchedWorktreeCatalogChanged(watch.mainWindow, repoId, watch.connectionId)
@@ -73,7 +89,12 @@ export function scheduleWorktreeBaseNotification(
       supportsWorktreeHeadIdentityRefresh(watch) &&
       (pendingStructure.length > 0 || hasHeadIdentity)
     ) {
-      void refreshWorktreeHeadIdentities(watch, watch.headIdentityRefresh, emitHeadIdentities)
+      void refreshWorktreeHeadIdentities(
+        watch,
+        watch.headIdentityRefresh,
+        emitHeadIdentities,
+        headIdentityScope
+      )
     }
   }, WATCH_DEBOUNCE_MS)
 }

--- a/src/main/ipc/worktree-base-directory-watcher.test.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.test.ts
@@ -32,7 +32,8 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
 }))
 
 vi.mock('./worktree-head-identity-reader', () => ({
-  readGitCommonHeadIdentities: vi.fn(async () => [])
+  readGitCommonHeadIdentities: vi.fn(async () => []),
+  createWorktreeHeadIdentityCache: () => ({ entries: new Map(), entryNames: null, primary: null })
 }))
 
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
@@ -624,6 +625,70 @@ describe('worktree base directory watcher', () => {
     await vi.advanceTimersByTimeAsync(300)
     await vi.advanceTimersByTimeAsync(0)
     expect(notifyWorktreeHeadIdentitiesChanged).not.toHaveBeenCalled()
+  })
+
+  it('scopes a linked reflog head read to the worktree the event named', async () => {
+    await syncWorktreeBaseDirectoryWatchers(makeStore([makeRepo()]) as never, makeWindow() as never)
+    await vi.advanceTimersByTimeAsync(0)
+    vi.mocked(readGitCommonHeadIdentities).mockClear()
+
+    emit(PROJECT_GIT_COMMON_DIR, [
+      {
+        type: 'update',
+        path: join(PROJECT_GIT_COMMON_DIR, 'worktrees', 'external-5104', 'logs', 'HEAD')
+      }
+    ])
+    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(readGitCommonHeadIdentities).toHaveBeenCalledWith(
+      PROJECT_GIT_COMMON_DIR,
+      expect.anything(),
+      { listing: false, primary: false, all: false, entryNames: new Set(['external-5104']) }
+    )
+  })
+
+  it('re-reads every head identity when the watcher loses events', async () => {
+    await syncWorktreeBaseDirectoryWatchers(makeStore([makeRepo()]) as never, makeWindow() as never)
+    await vi.advanceTimersByTimeAsync(0)
+    vi.mocked(readGitCommonHeadIdentities).mockClear()
+
+    // A watcher failure attributes to no worktree, so nothing may stay cached.
+    pollerOptions
+      .get(PROJECT_GIT_COMMON_DIR)
+      ?.onWatchError?.(new Error('Git common watcher interrupted'))
+    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(readGitCommonHeadIdentities).toHaveBeenCalledWith(
+      PROJECT_GIT_COMMON_DIR,
+      expect.anything(),
+      {
+        listing: true,
+        primary: true,
+        all: true,
+        entryNames: new Set()
+      }
+    )
+  })
+
+  it('reads no head identities for a worktree lock write', async () => {
+    await syncWorktreeBaseDirectoryWatchers(makeStore([makeRepo()]) as never, makeWindow() as never)
+    await vi.advanceTimersByTimeAsync(0)
+    vi.mocked(readGitCommonHeadIdentities).mockClear()
+
+    // `git worktree lock` is structural for the listing but can move no head.
+    emit(PROJECT_GIT_COMMON_DIR, [
+      {
+        type: 'create',
+        path: join(PROJECT_GIT_COMMON_DIR, 'worktrees', 'external-5104', 'locked')
+      }
+    ])
+    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(notifyWorktreesChanged).toHaveBeenCalledTimes(1)
+    expect(readGitCommonHeadIdentities).not.toHaveBeenCalled()
   })
 
   it('never reads head identities for SSH watches', async () => {

--- a/src/main/ipc/worktree-base-directory-watcher.test.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.test.ts
@@ -32,7 +32,7 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
 }))
 
 vi.mock('./worktree-head-identity-reader', () => ({
-  readGitCommonHeadIdentities: vi.fn(async () => []),
+  readGitCommonHeadIdentities: vi.fn(async () => ({ identities: [], listingComplete: true })),
   createWorktreeHeadIdentityCache: () => ({ entries: new Map(), entryNames: null, primary: null })
 }))
 
@@ -43,6 +43,7 @@ import {
   notifyWorktreesChanged
 } from './worktree-remote'
 import { readGitCommonHeadIdentities } from './worktree-head-identity-reader'
+import type { WorktreeHeadIdentity } from '../../shared/worktree/types'
 import { startWorktreeBaseDirectoryPoller } from './worktree-base-directory-poller'
 import {
   disposeWorktreeBaseDirectoryWatchers,
@@ -91,6 +92,10 @@ function makeWindow(options: { destroyed?: () => boolean } = {}) {
   }
 }
 
+function mockHeadIdentities(identities: WorktreeHeadIdentity[]): void {
+  vi.mocked(readGitCommonHeadIdentities).mockResolvedValue({ identities, listingComplete: true })
+}
+
 function emit(root: string, events: WorktreeBasePollEvent[]): void {
   const callback = watcherCallbacks.get(root)
   if (!callback) {
@@ -106,7 +111,7 @@ describe('worktree base directory watcher', () => {
     unsubscribeMocks.clear()
     pollerOptions.clear()
     vi.mocked(getSshFilesystemProvider).mockReturnValue(undefined)
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([])
+    mockHeadIdentities([])
     vi.mocked(startWorktreeBaseDirectoryPoller).mockImplementation(
       async (target, _getRepos, onEvents, options) => {
         const unsubscribe = vi.fn(async () => {})
@@ -415,7 +420,7 @@ describe('worktree base directory watcher', () => {
 
   it('emits head identities for a linked reflog head move without structural fanout', async () => {
     const linkedWorktree = absolutePath('workspace', 'worktrees', 'project', 'external-5104')
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([
+    mockHeadIdentities([
       {
         worktreePath: linkedWorktree,
         head: 'aaa111',
@@ -426,7 +431,7 @@ describe('worktree base directory watcher', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     // External commit --amend: only logs/HEAD moves, no index write.
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([
+    mockHeadIdentities([
       {
         worktreePath: linkedWorktree,
         head: 'bbb222',
@@ -456,7 +461,7 @@ describe('worktree base directory watcher', () => {
 
   it('makes zero head-identity reads on an index-only burst across linked and primary checkouts', async () => {
     const linkedWorktree = absolutePath('workspace', 'worktrees', 'project', 'external-5104')
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([
+    mockHeadIdentities([
       {
         worktreePath: linkedWorktree,
         head: 'aaa111',
@@ -491,15 +496,11 @@ describe('worktree base directory watcher', () => {
   })
 
   it('emits head identities for a primary-checkout reflog head move', async () => {
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([
-      { worktreePath: PROJECT_ROOT, head: 'aaa111', branch: 'refs/heads/main' }
-    ])
+    mockHeadIdentities([{ worktreePath: PROJECT_ROOT, head: 'aaa111', branch: 'refs/heads/main' }])
     await syncWorktreeBaseDirectoryWatchers(makeStore([makeRepo()]) as never, makeWindow() as never)
     await vi.advanceTimersByTimeAsync(0)
 
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([
-      { worktreePath: PROJECT_ROOT, head: 'bbb222', branch: 'refs/heads/main' }
-    ])
+    mockHeadIdentities([{ worktreePath: PROJECT_ROOT, head: 'bbb222', branch: 'refs/heads/main' }])
     emit(PROJECT_GIT_COMMON_DIR, [
       { type: 'update', path: join(PROJECT_GIT_COMMON_DIR, 'logs', 'HEAD') }
     ])
@@ -518,7 +519,7 @@ describe('worktree base directory watcher', () => {
 
   it('coalesces an index and reflog burst into one head read and one status refresh', async () => {
     const linkedWorktree = absolutePath('workspace', 'worktrees', 'project', 'external-5104')
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([
+    mockHeadIdentities([
       {
         worktreePath: linkedWorktree,
         head: 'aaa111',
@@ -530,7 +531,7 @@ describe('worktree base directory watcher', () => {
     vi.mocked(readGitCommonHeadIdentities).mockClear()
 
     // reset --soft rewrites the index and appends logs/HEAD in the same burst.
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([
+    mockHeadIdentities([
       {
         worktreePath: linkedWorktree,
         head: 'bbb222',
@@ -558,7 +559,7 @@ describe('worktree base directory watcher', () => {
 
   it('debounces successive reflog events into a single head read', async () => {
     const linkedWorktree = absolutePath('workspace', 'worktrees', 'project', 'external-5104')
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([
+    mockHeadIdentities([
       {
         worktreePath: linkedWorktree,
         head: 'aaa111',
@@ -586,7 +587,7 @@ describe('worktree base directory watcher', () => {
 
   it('re-baselines head identities silently on structural notifications', async () => {
     const linkedWorktree = absolutePath('workspace', 'worktrees', 'project', 'external-5104')
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([
+    mockHeadIdentities([
       {
         worktreePath: linkedWorktree,
         head: 'aaa111',
@@ -597,7 +598,7 @@ describe('worktree base directory watcher', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     // Branch switch: structural path owns the refresh via the full listing.
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([
+    mockHeadIdentities([
       {
         worktreePath: linkedWorktree,
         head: 'ccc333',

--- a/src/main/ipc/worktree-base-directory-watcher.test.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.test.ts
@@ -32,8 +32,14 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
 }))
 
 vi.mock('./worktree-head-identity-reader', () => ({
-  readGitCommonHeadIdentities: vi.fn(async () => ({ identities: [], listingComplete: true })),
-  createWorktreeHeadIdentityCache: () => ({ entries: new Map(), entryNames: null, primary: null })
+  readGitCommonHeadIdentities: vi.fn(async () => ({ identities: [], complete: true })),
+  createWorktreeHeadIdentityCache: () => ({
+    entries: new Map(),
+    unverified: new Set(),
+    entryNames: null,
+    primary: null,
+    primaryUnverified: false
+  })
 }))
 
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
@@ -93,7 +99,7 @@ function makeWindow(options: { destroyed?: () => boolean } = {}) {
 }
 
 function mockHeadIdentities(identities: WorktreeHeadIdentity[]): void {
-  vi.mocked(readGitCommonHeadIdentities).mockResolvedValue({ identities, listingComplete: true })
+  vi.mocked(readGitCommonHeadIdentities).mockResolvedValue({ identities, complete: true })
 }
 
 function emit(root: string, events: WorktreeBasePollEvent[]): void {

--- a/src/main/ipc/worktree-base-directory-watcher.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.ts
@@ -3,8 +3,7 @@ import type { Store } from '../persistence'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
   createWorktreeHeadIdentityRefreshState,
-  refreshWorktreeHeadIdentities,
-  type WorktreeHeadIdentityRefreshState
+  refreshWorktreeHeadIdentities
 } from './worktree-head-identity-refresh'
 import {
   collectLocalWorktreeBaseChanges,
@@ -14,9 +13,11 @@ import {
 import {
   clearPendingWorktreeBaseNotifications,
   scheduleWorktreeBaseNotification,
-  supportsWorktreeHeadIdentityRefresh
+  supportsWorktreeHeadIdentityRefresh,
+  type WorktreeBaseNotificationWatch
 } from './worktree-base-directory-notifications'
 import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
+import { EMPTY_HEAD_IDENTITY_SCOPE } from './worktree-head-identity-scope'
 import {
   buildWorktreeBaseDirectoryWatchTargets,
   clearWorktreeBaseDirectoryWatchTargetWarnings
@@ -35,17 +36,10 @@ import {
 } from './worktree-git-status-ref-watch'
 import { WorktreeWatcherFailureRefreshCooldown } from './worktree-watcher-failure-refresh-cooldown'
 
-type ActiveWatch = WorktreeBaseWatchTarget & {
-  mainWindow: BrowserWindow
+type ActiveWatch = WorktreeBaseNotificationWatch & {
   subscription: { unsubscribe: () => Promise<void> }
-  notifyTimer: ReturnType<typeof setTimeout> | null
-  pendingStructureRepoIds: Set<string>
-  pendingGitStatusRepoIds: Set<string>
-  pendingHeadIdentityRepoIds: Set<string>
-  headIdentityRefresh: WorktreeHeadIdentityRefreshState
   gitStatusRefPaths: Set<string>
   watcherFailureRefresh: WorktreeWatcherFailureRefreshCooldown
-  disposed: boolean
 }
 
 const activeWatches = new Map<string, ActiveWatch>()
@@ -126,6 +120,7 @@ function createActiveWatch(
     pendingStructureRepoIds: new Set(),
     pendingGitStatusRepoIds: new Set(),
     pendingHeadIdentityRepoIds: new Set(),
+    pendingHeadIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE,
     headIdentityRefresh: createWorktreeHeadIdentityRefreshState(),
     gitStatusRefPaths,
     watcherFailureRefresh: new WorktreeWatcherFailureRefreshCooldown(),

--- a/src/main/ipc/worktree-base-directory-watcher.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.ts
@@ -3,6 +3,7 @@ import type { Store } from '../persistence'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
   createWorktreeHeadIdentityRefreshState,
+  disposeWorktreeHeadIdentityRefreshState,
   refreshWorktreeHeadIdentities
 } from './worktree-head-identity-refresh'
 import {
@@ -228,6 +229,7 @@ async function removeWatch(key: string): Promise<void> {
   activeWatches.delete(key)
   watch.disposed = true
   clearTimeout(watch.notifyTimer ?? undefined)
+  disposeWorktreeHeadIdentityRefreshState(watch.headIdentityRefresh)
   clearPendingWorktreeBaseNotifications(watch)
   await watch.subscription.unsubscribe().catch((error) => {
     console.warn(`[worktree-base-watcher] failed to unwatch ${watch.path}:`, error)

--- a/src/main/ipc/worktree-head-identity-reader-concurrency.test.ts
+++ b/src/main/ipc/worktree-head-identity-reader-concurrency.test.ts
@@ -40,7 +40,7 @@ describe('readGitCommonHeadIdentities concurrency', () => {
   })
 
   it('overlaps linked-worktree metadata reads while preserving listing order', async () => {
-    const identities = await readGitCommonHeadIdentities('/repo/common')
+    const { identities } = await readGitCommonHeadIdentities('/repo/common')
 
     expect(identities).toHaveLength(WORKTREE_COUNT)
     expect(identities.map((identity) => identity.worktreePath)).toEqual(

--- a/src/main/ipc/worktree-head-identity-reader-incremental.test.ts
+++ b/src/main/ipc/worktree-head-identity-reader-incremental.test.ts
@@ -160,6 +160,59 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     expect(cache.entries.has('wt-b')).toBe(false)
   })
 
+  it('re-reads an admin entry whose name was removed and immediately reused', async () => {
+    const { commonDir, cache, pathA } = await seed()
+    // One debounce window can coalesce `git worktree remove` + `git worktree
+    // add` onto the same admin dir name, so the listing alone is not enough.
+    await rm(join(commonDir, 'worktrees', 'wt-a'), { recursive: true, force: true })
+    await writeLooseRef(commonDir, 'refs/heads/reused', OID_D)
+    const reusedPath = await addLinkedWorktree(commonDir, 'wt-a', 'ref: refs/heads/reused')
+
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      mergeHeadIdentityScopes(LISTING_HEAD_IDENTITY_SCOPE, headIdentityScopeForEntry('wt-a'))
+    )
+
+    expect(reusedPath).toBe(pathA)
+    expect(identities).toContainEqual({
+      worktreePath: reusedPath,
+      head: OID_D,
+      branch: 'refs/heads/reused'
+    })
+  })
+
+  it('keeps the memo when the worktrees listing fails for anything but absence', async () => {
+    const { commonDir, cache, pathA, pathB } = await seed()
+    // Stand in for EIO/ESTALE/EMFILE: readdir rejects with ENOTDIR, which is
+    // not evidence that every worktree was removed.
+    await rm(join(commonDir, 'worktrees'), { recursive: true, force: true })
+    await writeFile(join(commonDir, 'worktrees'), 'not a directory\n')
+
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      LISTING_HEAD_IDENTITY_SCOPE
+    )
+
+    expect(headOf(identities, pathA)).toBe(OID_B)
+    expect(headOf(identities, pathB)).toBe(OID_C)
+  })
+
+  it('reports an absent worktrees dir as genuinely empty', async () => {
+    const { commonDir, cache, pathA } = await seed()
+    await rm(join(commonDir, 'worktrees'), { recursive: true, force: true })
+
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      LISTING_HEAD_IDENTITY_SCOPE
+    )
+
+    expect(headOf(identities, pathA)).toBeUndefined()
+    expect(cache.entries.size).toBe(0)
+  })
+
   it('re-reads every entry after a packed-refs rewrite', async () => {
     const { commonDir, cache, pathA, pathB } = await seed()
     // A fetch repacked refs: the loose files are gone and the oids moved, with

--- a/src/main/ipc/worktree-head-identity-reader-incremental.test.ts
+++ b/src/main/ipc/worktree-head-identity-reader-incremental.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import {
+  createWorktreeHeadIdentityCache,
+  readGitCommonHeadIdentities,
+  type WorktreeHeadIdentityCache
+} from './worktree-head-identity-reader'
+import {
+  FULL_HEAD_IDENTITY_SCOPE,
+  headIdentityScopeForEntry,
+  LISTING_HEAD_IDENTITY_SCOPE,
+  mergeHeadIdentityScopes,
+  PRIMARY_HEAD_IDENTITY_SCOPE
+} from './worktree-head-identity-scope'
+
+const OID_A = 'a'.repeat(40)
+const OID_B = 'b'.repeat(40)
+const OID_C = 'c'.repeat(40)
+const OID_D = 'd'.repeat(40)
+
+describe('readGitCommonHeadIdentities (incremental)', () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  })
+
+  async function writeLooseRef(commonDir: string, ref: string, oid: string): Promise<void> {
+    const refPath = join(commonDir, ...ref.split('/'))
+    await mkdir(dirname(refPath), { recursive: true })
+    await writeFile(refPath, `${oid}\n`)
+  }
+
+  async function makeCommonDir(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-head-incremental-'))
+    roots.push(root)
+    const commonDir = join(root, 'checkout', '.git')
+    await mkdir(commonDir, { recursive: true })
+    await writeFile(join(commonDir, 'HEAD'), 'ref: refs/heads/main\n')
+    await writeLooseRef(commonDir, 'refs/heads/main', OID_A)
+    return commonDir
+  }
+
+  async function addLinkedWorktree(commonDir: string, name: string, head: string): Promise<string> {
+    const entry = join(commonDir, 'worktrees', name)
+    await mkdir(entry, { recursive: true })
+    await writeFile(join(entry, 'HEAD'), `${head}\n`)
+    const worktreePath = join(dirname(dirname(commonDir)), name)
+    await mkdir(worktreePath, { recursive: true })
+    await writeFile(join(entry, 'gitdir'), `${join(worktreePath, '.git')}\n`)
+    return worktreePath
+  }
+
+  function headOf(
+    identities: { worktreePath: string; head: string }[],
+    worktreePath: string
+  ): string | undefined {
+    return identities.find((identity) => identity.worktreePath === worktreePath)?.head
+  }
+
+  async function seed(): Promise<{
+    commonDir: string
+    cache: WorktreeHeadIdentityCache
+    pathA: string
+    pathB: string
+  }> {
+    const commonDir = await makeCommonDir()
+    await writeLooseRef(commonDir, 'refs/heads/feature-a', OID_B)
+    await writeLooseRef(commonDir, 'refs/heads/feature-b', OID_C)
+    const pathA = await addLinkedWorktree(commonDir, 'wt-a', 'ref: refs/heads/feature-a')
+    const pathB = await addLinkedWorktree(commonDir, 'wt-b', 'ref: refs/heads/feature-b')
+    const cache = createWorktreeHeadIdentityCache()
+    // Cold start: no cache and no scope, so every entry is read.
+    const identities = await readGitCommonHeadIdentities(commonDir, cache)
+    expect(identities).toHaveLength(3)
+    expect(headOf(identities, pathA)).toBe(OID_B)
+    expect(headOf(identities, pathB)).toBe(OID_C)
+    return { commonDir, cache, pathA, pathB }
+  }
+
+  it('reads every entry on cold start with an empty cache', async () => {
+    const { cache } = await seed()
+    expect([...cache.entries.keys()].sort()).toEqual(['wt-a', 'wt-b'])
+    expect(cache.primary?.head).toBe(OID_A)
+  })
+
+  it('re-reads only the committing worktree and leaves the rest cached', async () => {
+    const { commonDir, cache, pathA, pathB } = await seed()
+
+    // A commit in wt-a moves its branch; wt-b's branch also moves on disk but
+    // no watcher event named it, so the incremental read must not observe it.
+    await writeLooseRef(commonDir, 'refs/heads/feature-a', OID_D)
+    await writeLooseRef(commonDir, 'refs/heads/feature-b', OID_D)
+
+    const scoped = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      headIdentityScopeForEntry('wt-a')
+    )
+    expect(headOf(scoped, pathA)).toBe(OID_D)
+    expect(headOf(scoped, pathB)).toBe(OID_C)
+
+    const followUp = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      headIdentityScopeForEntry('wt-b')
+    )
+    expect(headOf(followUp, pathB)).toBe(OID_D)
+  })
+
+  it('picks up a branch switch through the entry scope', async () => {
+    const { commonDir, cache, pathA } = await seed()
+    await writeLooseRef(commonDir, 'refs/heads/other', OID_D)
+    await writeFile(join(commonDir, 'worktrees', 'wt-a', 'HEAD'), 'ref: refs/heads/other\n')
+
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      headIdentityScopeForEntry('wt-a')
+    )
+
+    expect(identities).toContainEqual({
+      worktreePath: pathA,
+      head: OID_D,
+      branch: 'refs/heads/other'
+    })
+  })
+
+  it('adds an externally created worktree through the listing scope', async () => {
+    const { commonDir, cache, pathA } = await seed()
+    await writeLooseRef(commonDir, 'refs/heads/feature-c', OID_D)
+    const pathC = await addLinkedWorktree(commonDir, 'wt-c', 'ref: refs/heads/feature-c')
+    // The other entries move on disk with no event of their own and must stay cached.
+    await writeLooseRef(commonDir, 'refs/heads/feature-a', OID_D)
+
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      LISTING_HEAD_IDENTITY_SCOPE
+    )
+
+    expect(headOf(identities, pathC)).toBe(OID_D)
+    expect(headOf(identities, pathA)).toBe(OID_B)
+  })
+
+  it('drops an externally removed worktree through the listing scope', async () => {
+    const { commonDir, cache, pathA, pathB } = await seed()
+    await rm(join(commonDir, 'worktrees', 'wt-b'), { recursive: true, force: true })
+
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      LISTING_HEAD_IDENTITY_SCOPE
+    )
+
+    expect(identities.map((identity) => identity.worktreePath)).toEqual([dirname(commonDir), pathA])
+    expect(headOf(identities, pathB)).toBeUndefined()
+    expect(cache.entries.has('wt-b')).toBe(false)
+  })
+
+  it('re-reads every entry after a packed-refs rewrite', async () => {
+    const { commonDir, cache, pathA, pathB } = await seed()
+    // A fetch repacked refs: the loose files are gone and the oids moved, with
+    // no event under any admin dir.
+    await rm(join(commonDir, 'refs', 'heads'), { recursive: true, force: true })
+    await writeFile(
+      join(commonDir, 'packed-refs'),
+      [
+        '# pack-refs with: peeled fully-peeled sorted',
+        `${OID_D} refs/heads/main`,
+        `${OID_D} refs/heads/feature-a`,
+        `${OID_D} refs/heads/feature-b`,
+        ''
+      ].join('\n')
+    )
+
+    const identities = await readGitCommonHeadIdentities(commonDir, cache, FULL_HEAD_IDENTITY_SCOPE)
+
+    expect(headOf(identities, dirname(commonDir))).toBe(OID_D)
+    expect(headOf(identities, pathA)).toBe(OID_D)
+    expect(headOf(identities, pathB)).toBe(OID_D)
+  })
+
+  it('keeps a worktree whose checkout was deleted behind Orca back', async () => {
+    const { commonDir, cache, pathA } = await seed()
+    // Only the checkout is gone; git prunes the admin entry lazily, and the
+    // structural listing — not this reader — owns the prunable verdict.
+    await rm(pathA, { recursive: true, force: true })
+
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      mergeHeadIdentityScopes(LISTING_HEAD_IDENTITY_SCOPE, headIdentityScopeForEntry('wt-a'))
+    )
+
+    expect(headOf(identities, pathA)).toBe(OID_B)
+  })
+
+  it('follows a branch shared by several worktrees without re-reading them', async () => {
+    const commonDir = await makeCommonDir()
+    await writeLooseRef(commonDir, 'refs/heads/shared', OID_B)
+    // `git worktree add --force` lets two worktrees hold one branch, and only
+    // the committing one gets a HEAD reflog append.
+    const pathA = await addLinkedWorktree(commonDir, 'wt-a', 'ref: refs/heads/shared')
+    const pathB = await addLinkedWorktree(commonDir, 'wt-b', 'ref: refs/heads/shared')
+    const cache = createWorktreeHeadIdentityCache()
+    await readGitCommonHeadIdentities(commonDir, cache)
+
+    await writeLooseRef(commonDir, 'refs/heads/shared', OID_D)
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      headIdentityScopeForEntry('wt-a')
+    )
+
+    expect(headOf(identities, pathA)).toBe(OID_D)
+    expect(headOf(identities, pathB)).toBe(OID_D)
+  })
+
+  it('propagates a primary-checkout head move to a linked worktree on the same branch', async () => {
+    const commonDir = await makeCommonDir()
+    const pathA = await addLinkedWorktree(commonDir, 'wt-a', 'ref: refs/heads/main')
+    const cache = createWorktreeHeadIdentityCache()
+    await readGitCommonHeadIdentities(commonDir, cache)
+
+    await writeLooseRef(commonDir, 'refs/heads/main', OID_D)
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      PRIMARY_HEAD_IDENTITY_SCOPE
+    )
+
+    expect(headOf(identities, dirname(commonDir))).toBe(OID_D)
+    expect(headOf(identities, pathA)).toBe(OID_D)
+  })
+
+  it('drops entries whose branch stopped resolving instead of serving a stale head', async () => {
+    const commonDir = await makeCommonDir()
+    await writeLooseRef(commonDir, 'refs/heads/shared', OID_B)
+    const pathA = await addLinkedWorktree(commonDir, 'wt-a', 'ref: refs/heads/shared')
+    const pathB = await addLinkedWorktree(commonDir, 'wt-b', 'ref: refs/heads/shared')
+    const cache = createWorktreeHeadIdentityCache()
+    await readGitCommonHeadIdentities(commonDir, cache)
+
+    await rm(join(commonDir, 'refs', 'heads', 'shared'), { force: true })
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      headIdentityScopeForEntry('wt-a')
+    )
+
+    expect(headOf(identities, pathA)).toBeUndefined()
+    expect(headOf(identities, pathB)).toBeUndefined()
+  })
+
+  it('never caches a miss, so a transient unreadable entry is retried', async () => {
+    const commonDir = await makeCommonDir()
+    const entry = join(commonDir, 'worktrees', 'wt-a')
+    await mkdir(entry, { recursive: true })
+    await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/feature-a\n')
+    const cache = createWorktreeHeadIdentityCache()
+
+    // No `gitdir` yet (mid `git worktree add`): unresolvable, so nothing is memoized.
+    expect(await readGitCommonHeadIdentities(commonDir, cache)).toHaveLength(1)
+    expect(cache.entries.has('wt-a')).toBe(false)
+
+    await writeLooseRef(commonDir, 'refs/heads/feature-a', OID_B)
+    const worktreePath = join(dirname(dirname(commonDir)), 'wt-a')
+    await writeFile(join(entry, 'gitdir'), `${join(worktreePath, '.git')}\n`)
+
+    // A later refresh that never names wt-a still recovers it.
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      PRIMARY_HEAD_IDENTITY_SCOPE
+    )
+    expect(headOf(identities, worktreePath)).toBe(OID_B)
+  })
+
+  it('follows a relocated gitdir through the entry scope', async () => {
+    const { commonDir, cache, pathA } = await seed()
+    const movedPath = join(dirname(dirname(commonDir)), 'wt-a-moved')
+    await writeFile(join(commonDir, 'worktrees', 'wt-a', 'gitdir'), `${join(movedPath, '.git')}\n`)
+
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      headIdentityScopeForEntry('wt-a')
+    )
+
+    expect(headOf(identities, movedPath)).toBe(OID_B)
+    expect(headOf(identities, pathA)).toBeUndefined()
+  })
+
+  it('matches admin entry names across case folding', async () => {
+    const { commonDir, cache, pathA } = await seed()
+    await writeLooseRef(commonDir, 'refs/heads/feature-a', OID_D)
+
+    const identities = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      headIdentityScopeForEntry('WT-A')
+    )
+
+    expect(headOf(identities, pathA)).toBe(OID_D)
+  })
+})

--- a/src/main/ipc/worktree-head-identity-reader-incremental.test.ts
+++ b/src/main/ipc/worktree-head-identity-reader-incremental.test.ts
@@ -197,6 +197,19 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
 
     expect(headOf(identities, pathA)).toBe(OID_B)
     expect(headOf(identities, pathB)).toBe(OID_C)
+    // The add/remove that triggered the burst is still unseen, so the next
+    // refresh must re-enumerate whatever scope it is given.
+    expect(cache.entryNames).toBeNull()
+
+    await rm(join(commonDir, 'worktrees'), { force: true })
+    await writeLooseRef(commonDir, 'refs/heads/feature-c', OID_D)
+    const pathC = await addLinkedWorktree(commonDir, 'wt-c', 'ref: refs/heads/feature-c')
+    const recovered = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      headIdentityScopeForEntry('wt-a')
+    )
+    expect(headOf(recovered, pathC)).toBe(OID_D)
   })
 
   it('reports an absent worktrees dir as genuinely empty', async () => {

--- a/src/main/ipc/worktree-head-identity-reader-incremental.test.ts
+++ b/src/main/ipc/worktree-head-identity-reader-incremental.test.ts
@@ -15,6 +15,11 @@ import {
   PRIMARY_HEAD_IDENTITY_SCOPE
 } from './worktree-head-identity-scope'
 
+const readIdentities = async (
+  ...args: Parameters<typeof readGitCommonHeadIdentities>
+): Promise<Awaited<ReturnType<typeof readGitCommonHeadIdentities>>['identities']> =>
+  (await readGitCommonHeadIdentities(...args)).identities
+
 const OID_A = 'a'.repeat(40)
 const OID_B = 'b'.repeat(40)
 const OID_C = 'c'.repeat(40)
@@ -73,7 +78,7 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     const pathB = await addLinkedWorktree(commonDir, 'wt-b', 'ref: refs/heads/feature-b')
     const cache = createWorktreeHeadIdentityCache()
     // Cold start: no cache and no scope, so every entry is read.
-    const identities = await readGitCommonHeadIdentities(commonDir, cache)
+    const identities = await readIdentities(commonDir, cache)
     expect(identities).toHaveLength(3)
     expect(headOf(identities, pathA)).toBe(OID_B)
     expect(headOf(identities, pathB)).toBe(OID_C)
@@ -94,19 +99,11 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     await writeLooseRef(commonDir, 'refs/heads/feature-a', OID_D)
     await writeLooseRef(commonDir, 'refs/heads/feature-b', OID_D)
 
-    const scoped = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      headIdentityScopeForEntry('wt-a')
-    )
+    const scoped = await readIdentities(commonDir, cache, headIdentityScopeForEntry('wt-a'))
     expect(headOf(scoped, pathA)).toBe(OID_D)
     expect(headOf(scoped, pathB)).toBe(OID_C)
 
-    const followUp = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      headIdentityScopeForEntry('wt-b')
-    )
+    const followUp = await readIdentities(commonDir, cache, headIdentityScopeForEntry('wt-b'))
     expect(headOf(followUp, pathB)).toBe(OID_D)
   })
 
@@ -115,11 +112,7 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     await writeLooseRef(commonDir, 'refs/heads/other', OID_D)
     await writeFile(join(commonDir, 'worktrees', 'wt-a', 'HEAD'), 'ref: refs/heads/other\n')
 
-    const identities = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      headIdentityScopeForEntry('wt-a')
-    )
+    const identities = await readIdentities(commonDir, cache, headIdentityScopeForEntry('wt-a'))
 
     expect(identities).toContainEqual({
       worktreePath: pathA,
@@ -135,11 +128,7 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     // The other entries move on disk with no event of their own and must stay cached.
     await writeLooseRef(commonDir, 'refs/heads/feature-a', OID_D)
 
-    const identities = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      LISTING_HEAD_IDENTITY_SCOPE
-    )
+    const identities = await readIdentities(commonDir, cache, LISTING_HEAD_IDENTITY_SCOPE)
 
     expect(headOf(identities, pathC)).toBe(OID_D)
     expect(headOf(identities, pathA)).toBe(OID_B)
@@ -149,11 +138,7 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     const { commonDir, cache, pathA, pathB } = await seed()
     await rm(join(commonDir, 'worktrees', 'wt-b'), { recursive: true, force: true })
 
-    const identities = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      LISTING_HEAD_IDENTITY_SCOPE
-    )
+    const identities = await readIdentities(commonDir, cache, LISTING_HEAD_IDENTITY_SCOPE)
 
     expect(identities.map((identity) => identity.worktreePath)).toEqual([dirname(commonDir), pathA])
     expect(headOf(identities, pathB)).toBeUndefined()
@@ -168,7 +153,7 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     await writeLooseRef(commonDir, 'refs/heads/reused', OID_D)
     const reusedPath = await addLinkedWorktree(commonDir, 'wt-a', 'ref: refs/heads/reused')
 
-    const identities = await readGitCommonHeadIdentities(
+    const identities = await readIdentities(
       commonDir,
       cache,
       mergeHeadIdentityScopes(LISTING_HEAD_IDENTITY_SCOPE, headIdentityScopeForEntry('wt-a'))
@@ -189,11 +174,7 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     await rm(join(commonDir, 'worktrees'), { recursive: true, force: true })
     await writeFile(join(commonDir, 'worktrees'), 'not a directory\n')
 
-    const identities = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      LISTING_HEAD_IDENTITY_SCOPE
-    )
+    const identities = await readIdentities(commonDir, cache, LISTING_HEAD_IDENTITY_SCOPE)
 
     expect(headOf(identities, pathA)).toBe(OID_B)
     expect(headOf(identities, pathB)).toBe(OID_C)
@@ -204,11 +185,7 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     await rm(join(commonDir, 'worktrees'), { force: true })
     await writeLooseRef(commonDir, 'refs/heads/feature-c', OID_D)
     const pathC = await addLinkedWorktree(commonDir, 'wt-c', 'ref: refs/heads/feature-c')
-    const recovered = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      headIdentityScopeForEntry('wt-a')
-    )
+    const recovered = await readIdentities(commonDir, cache, headIdentityScopeForEntry('wt-a'))
     expect(headOf(recovered, pathC)).toBe(OID_D)
   })
 
@@ -216,17 +193,13 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     const { commonDir, cache, pathA } = await seed()
     await rm(join(commonDir, 'worktrees'), { recursive: true, force: true })
 
-    const identities = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      LISTING_HEAD_IDENTITY_SCOPE
-    )
+    const identities = await readIdentities(commonDir, cache, LISTING_HEAD_IDENTITY_SCOPE)
 
     expect(headOf(identities, pathA)).toBeUndefined()
     expect(cache.entries.size).toBe(0)
   })
 
-  it('re-reads every entry after a packed-refs rewrite', async () => {
+  it('needs the full scope, not a narrow one, to survive a packed-refs rewrite', async () => {
     const { commonDir, cache, pathA, pathB } = await seed()
     // A fetch repacked refs: the loose files are gone and the oids moved, with
     // no event under any admin dir.
@@ -242,7 +215,13 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
       ].join('\n')
     )
 
-    const identities = await readGitCommonHeadIdentities(commonDir, cache, FULL_HEAD_IDENTITY_SCOPE)
+    // Negative control: this is exactly why `packed-refs` must classify to the
+    // full scope — any narrower scope misses the repack for unnamed entries.
+    const narrow = await readIdentities(commonDir, cache, headIdentityScopeForEntry('wt-a'))
+    expect(headOf(narrow, pathA)).toBe(OID_D)
+    expect(headOf(narrow, pathB)).toBe(OID_C)
+
+    const identities = await readIdentities(commonDir, cache, FULL_HEAD_IDENTITY_SCOPE)
 
     expect(headOf(identities, dirname(commonDir))).toBe(OID_D)
     expect(headOf(identities, pathA)).toBe(OID_D)
@@ -255,7 +234,7 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     // structural listing — not this reader — owns the prunable verdict.
     await rm(pathA, { recursive: true, force: true })
 
-    const identities = await readGitCommonHeadIdentities(
+    const identities = await readIdentities(
       commonDir,
       cache,
       mergeHeadIdentityScopes(LISTING_HEAD_IDENTITY_SCOPE, headIdentityScopeForEntry('wt-a'))
@@ -272,31 +251,39 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     const pathA = await addLinkedWorktree(commonDir, 'wt-a', 'ref: refs/heads/shared')
     const pathB = await addLinkedWorktree(commonDir, 'wt-b', 'ref: refs/heads/shared')
     const cache = createWorktreeHeadIdentityCache()
-    await readGitCommonHeadIdentities(commonDir, cache)
+    await readIdentities(commonDir, cache)
 
     await writeLooseRef(commonDir, 'refs/heads/shared', OID_D)
-    const identities = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      headIdentityScopeForEntry('wt-a')
-    )
+    // Make wt-b unreadable: if the replay re-read it, it would resolve to
+    // nothing and drop out. Surviving with the new oid proves it was replayed
+    // from the memo rather than re-read.
+    await rm(join(commonDir, 'worktrees', 'wt-b', 'gitdir'), { force: true })
+    const identities = await readIdentities(commonDir, cache, headIdentityScopeForEntry('wt-a'))
 
     expect(headOf(identities, pathA)).toBe(OID_D)
     expect(headOf(identities, pathB)).toBe(OID_D)
+  })
+
+  it('re-enumerates when the scope names an entry the memoized listing lacks', async () => {
+    const { commonDir, cache } = await seed()
+    await writeLooseRef(commonDir, 'refs/heads/feature-c', OID_D)
+    const pathC = await addLinkedWorktree(commonDir, 'wt-c', 'ref: refs/heads/feature-c')
+
+    // An entry-only scope (`worktrees/wt-c/HEAD`) with no listing bit must not
+    // resolve to zero work just because the memo predates the entry.
+    const identities = await readIdentities(commonDir, cache, headIdentityScopeForEntry('wt-c'))
+
+    expect(headOf(identities, pathC)).toBe(OID_D)
   })
 
   it('propagates a primary-checkout head move to a linked worktree on the same branch', async () => {
     const commonDir = await makeCommonDir()
     const pathA = await addLinkedWorktree(commonDir, 'wt-a', 'ref: refs/heads/main')
     const cache = createWorktreeHeadIdentityCache()
-    await readGitCommonHeadIdentities(commonDir, cache)
+    await readIdentities(commonDir, cache)
 
     await writeLooseRef(commonDir, 'refs/heads/main', OID_D)
-    const identities = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      PRIMARY_HEAD_IDENTITY_SCOPE
-    )
+    const identities = await readIdentities(commonDir, cache, PRIMARY_HEAD_IDENTITY_SCOPE)
 
     expect(headOf(identities, dirname(commonDir))).toBe(OID_D)
     expect(headOf(identities, pathA)).toBe(OID_D)
@@ -308,14 +295,10 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     const pathA = await addLinkedWorktree(commonDir, 'wt-a', 'ref: refs/heads/shared')
     const pathB = await addLinkedWorktree(commonDir, 'wt-b', 'ref: refs/heads/shared')
     const cache = createWorktreeHeadIdentityCache()
-    await readGitCommonHeadIdentities(commonDir, cache)
+    await readIdentities(commonDir, cache)
 
     await rm(join(commonDir, 'refs', 'heads', 'shared'), { force: true })
-    const identities = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      headIdentityScopeForEntry('wt-a')
-    )
+    const identities = await readIdentities(commonDir, cache, headIdentityScopeForEntry('wt-a'))
 
     expect(headOf(identities, pathA)).toBeUndefined()
     expect(headOf(identities, pathB)).toBeUndefined()
@@ -329,7 +312,7 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     const cache = createWorktreeHeadIdentityCache()
 
     // No `gitdir` yet (mid `git worktree add`): unresolvable, so nothing is memoized.
-    expect(await readGitCommonHeadIdentities(commonDir, cache)).toHaveLength(1)
+    expect(await readIdentities(commonDir, cache)).toHaveLength(1)
     expect(cache.entries.has('wt-a')).toBe(false)
 
     await writeLooseRef(commonDir, 'refs/heads/feature-a', OID_B)
@@ -337,11 +320,7 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     await writeFile(join(entry, 'gitdir'), `${join(worktreePath, '.git')}\n`)
 
     // A later refresh that never names wt-a still recovers it.
-    const identities = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      PRIMARY_HEAD_IDENTITY_SCOPE
-    )
+    const identities = await readIdentities(commonDir, cache, PRIMARY_HEAD_IDENTITY_SCOPE)
     expect(headOf(identities, worktreePath)).toBe(OID_B)
   })
 
@@ -350,25 +329,35 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     const movedPath = join(dirname(dirname(commonDir)), 'wt-a-moved')
     await writeFile(join(commonDir, 'worktrees', 'wt-a', 'gitdir'), `${join(movedPath, '.git')}\n`)
 
-    const identities = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      headIdentityScopeForEntry('wt-a')
-    )
+    const identities = await readIdentities(commonDir, cache, headIdentityScopeForEntry('wt-a'))
 
     expect(headOf(identities, movedPath)).toBe(OID_B)
     expect(headOf(identities, pathA)).toBeUndefined()
+  })
+
+  it('matches admin entry names across unicode normalization', async () => {
+    const commonDir = await makeCommonDir()
+    await writeLooseRef(commonDir, 'refs/heads/accent', OID_B)
+    // Decomposed on disk (what APFS hands back for a name typed as NFD), and the
+    // watcher may report either form; the fold has to bridge them.
+    const decomposed = 'wt-e\u0301'
+    const composed = decomposed.normalize('NFC')
+    expect(composed).not.toBe(decomposed)
+    const path = await addLinkedWorktree(commonDir, decomposed, 'ref: refs/heads/accent')
+    const cache = createWorktreeHeadIdentityCache()
+    await readIdentities(commonDir, cache)
+
+    await writeLooseRef(commonDir, 'refs/heads/accent', OID_D)
+    const identities = await readIdentities(commonDir, cache, headIdentityScopeForEntry(composed))
+
+    expect(headOf(identities, path)).toBe(OID_D)
   })
 
   it('matches admin entry names across case folding', async () => {
     const { commonDir, cache, pathA } = await seed()
     await writeLooseRef(commonDir, 'refs/heads/feature-a', OID_D)
 
-    const identities = await readGitCommonHeadIdentities(
-      commonDir,
-      cache,
-      headIdentityScopeForEntry('WT-A')
-    )
+    const identities = await readIdentities(commonDir, cache, headIdentityScopeForEntry('WT-A'))
 
     expect(headOf(identities, pathA)).toBe(OID_D)
   })

--- a/src/main/ipc/worktree-head-identity-reader-incremental.test.ts
+++ b/src/main/ipc/worktree-head-identity-reader-incremental.test.ts
@@ -304,6 +304,56 @@ describe('readGitCommonHeadIdentities (incremental)', () => {
     expect(headOf(identities, pathB)).toBeUndefined()
   })
 
+  it('keeps the last verified identity when an entry read fails transiently', async () => {
+    const { commonDir, cache, pathA, pathB } = await seed()
+    // EISDIR stands in for EIO/EACCES/ENFILE: the read fails for a reason that
+    // is not absence, so the entry is UNKNOWN — never reported as gone.
+    await rm(join(commonDir, 'worktrees', 'wt-a', 'HEAD'))
+    await mkdir(join(commonDir, 'worktrees', 'wt-a', 'HEAD'))
+
+    const scoped = await readIdentities(commonDir, cache, headIdentityScopeForEntry('wt-a'))
+    expect(headOf(scoped, pathA)).toBe(OID_B)
+    expect(cache.unverified.has('wt-a')).toBe(true)
+
+    // And an unknown never evicts a sibling that merely shares the branch.
+    expect(headOf(scoped, pathB)).toBe(OID_C)
+
+    // Retried on the very next pass even though nothing names it, and the pass
+    // is reported incomplete so it cannot pass for a freshness checkpoint.
+    const stillBroken = await readGitCommonHeadIdentities(commonDir, cache)
+    expect(stillBroken.complete).toBe(false)
+
+    await rm(join(commonDir, 'worktrees', 'wt-a', 'HEAD'), { recursive: true })
+    await writeFile(join(commonDir, 'worktrees', 'wt-a', 'HEAD'), 'ref: refs/heads/feature-a\n')
+    await writeLooseRef(commonDir, 'refs/heads/feature-a', OID_D)
+    const recovered = await readGitCommonHeadIdentities(
+      commonDir,
+      cache,
+      PRIMARY_HEAD_IDENTITY_SCOPE
+    )
+    expect(headOf(recovered.identities, pathA)).toBe(OID_D)
+    expect(recovered.complete).toBe(true)
+    expect(cache.unverified.size).toBe(0)
+  })
+
+  it('does not evict a whole branch when one entry read fails transiently', async () => {
+    const commonDir = await makeCommonDir()
+    await writeLooseRef(commonDir, 'refs/heads/shared', OID_B)
+    const pathA = await addLinkedWorktree(commonDir, 'wt-a', 'ref: refs/heads/shared')
+    const pathB = await addLinkedWorktree(commonDir, 'wt-b', 'ref: refs/heads/shared')
+    const cache = createWorktreeHeadIdentityCache()
+    await readIdentities(commonDir, cache)
+
+    // The shared ref itself becomes unreadable while wt-a is the scoped entry.
+    await rm(join(commonDir, 'refs', 'heads', 'shared'))
+    await mkdir(join(commonDir, 'refs', 'heads', 'shared'))
+    const identities = await readIdentities(commonDir, cache, headIdentityScopeForEntry('wt-a'))
+
+    // An unknown must not be replayed onto siblings as "this branch is gone".
+    expect(headOf(identities, pathA)).toBe(OID_B)
+    expect(headOf(identities, pathB)).toBe(OID_B)
+  })
+
   it('never caches a miss, so a transient unreadable entry is retried', async () => {
     const commonDir = await makeCommonDir()
     const entry = join(commonDir, 'worktrees', 'wt-a')

--- a/src/main/ipc/worktree-head-identity-reader.test.ts
+++ b/src/main/ipc/worktree-head-identity-reader.test.ts
@@ -4,6 +4,11 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { readGitCommonHeadIdentities } from './worktree-head-identity-reader'
 
+const readIdentities = async (
+  ...args: Parameters<typeof readGitCommonHeadIdentities>
+): Promise<Awaited<ReturnType<typeof readGitCommonHeadIdentities>>['identities']> =>
+  (await readGitCommonHeadIdentities(...args)).identities
+
 const OID_A = 'a'.repeat(40)
 const OID_B = 'b'.repeat(40)
 const OID_C = 'c'.repeat(40)
@@ -49,7 +54,7 @@ describe('readGitCommonHeadIdentities', () => {
     const linkedPath = join(dirname(commonDir), '..', 'linked-wt')
     await addLinkedWorktree(commonDir, 'linked-wt', linkedPath, 'ref: refs/heads/feature')
 
-    const identities = await readGitCommonHeadIdentities(commonDir)
+    const identities = await readIdentities(commonDir)
 
     expect(identities).toContainEqual({
       worktreePath: dirname(commonDir),
@@ -71,7 +76,7 @@ describe('readGitCommonHeadIdentities', () => {
       `# pack-refs with: peeled fully-peeled sorted\n${OID_C} refs/heads/main\n^${OID_A}\n`
     )
 
-    const identities = await readGitCommonHeadIdentities(commonDir)
+    const identities = await readIdentities(commonDir)
 
     expect(identities).toEqual([
       { worktreePath: dirname(commonDir), head: OID_C, branch: 'refs/heads/main' }
@@ -82,7 +87,7 @@ describe('readGitCommonHeadIdentities', () => {
     const commonDir = await makeCommonDir()
     await writeFile(join(commonDir, 'HEAD'), `${OID_B}\n`)
 
-    const identities = await readGitCommonHeadIdentities(commonDir)
+    const identities = await readIdentities(commonDir)
 
     expect(identities).toEqual([{ worktreePath: dirname(commonDir), head: OID_B, branch: null }])
   })
@@ -91,7 +96,7 @@ describe('readGitCommonHeadIdentities', () => {
     const commonDir = await makeCommonDir()
     await writeFile(join(commonDir, 'HEAD'), 'ref: refs/heads/unborn\n')
 
-    expect(await readGitCommonHeadIdentities(commonDir)).toEqual([])
+    expect(await readIdentities(commonDir)).toEqual([])
   })
 
   it('resolves relative gitdir entries against the metadata dir', async () => {
@@ -102,7 +107,7 @@ describe('readGitCommonHeadIdentities', () => {
     await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/feature\n')
     await writeFile(join(entry, 'gitdir'), `${join('..', '..', '..', '..', 'rel-wt', '.git')}\n`)
 
-    const identities = await readGitCommonHeadIdentities(commonDir)
+    const identities = await readIdentities(commonDir)
 
     expect(identities).toEqual([
       {
@@ -125,7 +130,7 @@ describe('readGitCommonHeadIdentities', () => {
       'refs//heads'
     ]) {
       await writeFile(join(commonDir, 'HEAD'), `ref: ${ref}\n`)
-      expect(await readGitCommonHeadIdentities(commonDir)).toEqual([])
+      expect(await readIdentities(commonDir)).toEqual([])
     }
   })
 
@@ -133,10 +138,10 @@ describe('readGitCommonHeadIdentities', () => {
     const commonDir = await makeCommonDir()
     await writeFile(join(commonDir, 'HEAD'), 'ref: refs/heads/main\n')
     await writeLooseRef(commonDir, 'refs/heads/main', 'not-an-object-id')
-    expect(await readGitCommonHeadIdentities(commonDir)).toEqual([])
+    expect(await readIdentities(commonDir)).toEqual([])
 
     await writeFile(join(commonDir, 'HEAD'), 'this is not a detached oid\n')
-    expect(await readGitCommonHeadIdentities(commonDir)).toEqual([])
+    expect(await readIdentities(commonDir)).toEqual([])
   })
 
   it('omits the primary row for non-standard common dir layouts', async () => {
@@ -147,6 +152,6 @@ describe('readGitCommonHeadIdentities', () => {
     await writeFile(join(commonDir, 'HEAD'), 'ref: refs/heads/main\n')
     await writeLooseRef(commonDir, 'refs/heads/main', OID_A)
 
-    expect(await readGitCommonHeadIdentities(commonDir)).toEqual([])
+    expect(await readIdentities(commonDir)).toEqual([])
   })
 })

--- a/src/main/ipc/worktree-head-identity-reader.ts
+++ b/src/main/ipc/worktree-head-identity-reader.ts
@@ -230,9 +230,12 @@ export async function readGitCommonHeadIdentities(
   }
 
   let entryNames = cache.entryNames
+  let listingStale = false
   if (entryNames === null || scope.all || scope.listing) {
     const listing = await listLinkedEntryNames(commonDirPath)
-    if (listing !== null) {
+    if (listing === null) {
+      listingStale = true
+    } else {
       entryNames = listing
       const listed = new Set(listing)
       for (const name of cache.entries.keys()) {
@@ -267,7 +270,10 @@ export async function readGitCommonHeadIdentities(
   })
   applyResolvedRefOids(cache, resolved)
 
-  cache.entryNames = entryNames
+  // A failed listing means the add/remove that triggered this burst is not in
+  // the candidate set yet, so forget the listing rather than wait for another
+  // listing event to arrive: the next refresh re-enumerates whatever its scope.
+  cache.entryNames = listingStale ? null : entryNames
   const identities: WorktreeHeadIdentity[] = cache.primary ? [cache.primary] : []
   for (const name of entryNames) {
     const identity = cache.entries.get(name)

--- a/src/main/ipc/worktree-head-identity-reader.ts
+++ b/src/main/ipc/worktree-head-identity-reader.ts
@@ -154,12 +154,15 @@ async function readLinkedEntryIdentity(
   )
 }
 
-async function listLinkedEntryNames(commonDirPath: string): Promise<string[]> {
+// Why: mirrors worktree-git-common-polling — a TRANSIENT readdir failure
+// (EIO/ESTALE/EMFILE, network hiccup) must not masquerade as "every worktree
+// removed" and drop the whole memo. Only a genuinely absent dir is empty.
+async function listLinkedEntryNames(commonDirPath: string): Promise<string[] | null> {
   try {
     const entries = await readdir(join(commonDirPath, 'worktrees'), { withFileTypes: true })
     return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name)
-  } catch {
-    return []
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT' ? [] : null
   }
 }
 
@@ -228,13 +231,21 @@ export async function readGitCommonHeadIdentities(
 
   let entryNames = cache.entryNames
   if (entryNames === null || scope.all || scope.listing) {
-    entryNames = await listLinkedEntryNames(commonDirPath)
-    const listed = new Set(entryNames)
-    for (const name of cache.entries.keys()) {
-      if (!listed.has(name)) {
-        cache.entries.delete(name)
+    const listing = await listLinkedEntryNames(commonDirPath)
+    if (listing !== null) {
+      entryNames = listing
+      const listed = new Set(listing)
+      for (const name of cache.entries.keys()) {
+        if (!listed.has(name)) {
+          cache.entries.delete(name)
+        }
       }
     }
+  }
+  if (entryNames === null) {
+    // Unreadable on the very first pass: report only the primary and leave the
+    // memo unset so the next refresh re-enumerates.
+    return cache.primary ? [cache.primary] : []
   }
 
   const staleNames = entryNames.filter(

--- a/src/main/ipc/worktree-head-identity-reader.ts
+++ b/src/main/ipc/worktree-head-identity-reader.ts
@@ -33,6 +33,14 @@ export function createWorktreeHeadIdentityCache(): WorktreeHeadIdentityCache {
   return { entries: new Map(), entryNames: null, primary: null }
 }
 
+export type GitCommonHeadIdentityRead = {
+  identities: WorktreeHeadIdentity[]
+  /** False when `worktrees/` could not be enumerated this pass, so any entry
+   *  added since the last good listing is missing from `identities`. Callers
+   *  that treat a full read as a freshness checkpoint must not do so on false. */
+  listingComplete: boolean
+}
+
 /** ref → oid resolved during one pass; null means the ref no longer resolves. */
 type ResolvedRefOids = Map<string, string | null>
 
@@ -166,10 +174,25 @@ async function listLinkedEntryNames(commonDirPath: string): Promise<string[] | n
   }
 }
 
+function knowsEveryScopedEntry(
+  entryKeys: readonly string[],
+  scope: WorktreeHeadIdentityScope
+): boolean {
+  if (scope.entryNames.size === 0) {
+    return true
+  }
+  const known = new Set(entryKeys)
+  return [...scope.entryNames].every((key) => known.has(key))
+}
+
 // Why: `git worktree add --force` lets several worktrees share one branch, and
 // only the committing worktree's HEAD reflog is appended. Replaying every ref
 // resolved this pass onto the cached entries that point at it keeps the others
 // current without re-reading their metadata.
+// A ref that stopped resolving evicts every cached row on it, including rows
+// this pass never read: if the ref really is gone their oids are stale, and we
+// cannot tell that from a transient miss. Evicting costs a re-read next pass;
+// keeping would serve a head we can no longer justify.
 function retargetCachedIdentity(
   identity: WorktreeHeadIdentity,
   resolved: ResolvedRefOids
@@ -209,7 +232,7 @@ export async function readGitCommonHeadIdentities(
   commonDirPath: string,
   cache: WorktreeHeadIdentityCache = createWorktreeHeadIdentityCache(),
   scope: WorktreeHeadIdentityScope = FULL_HEAD_IDENTITY_SCOPE
-): Promise<WorktreeHeadIdentity[]> {
+): Promise<GitCommonHeadIdentityRead> {
   let packedRefsPromise: Promise<Map<string, string>> | null = null
   const packedRefs = (): Promise<Map<string, string>> =>
     (packedRefsPromise ??= readPackedRefs(commonDirPath))
@@ -231,32 +254,46 @@ export async function readGitCommonHeadIdentities(
 
   let entryNames = cache.entryNames
   let listingStale = false
-  if (entryNames === null || scope.all || scope.listing) {
+  let relisted = false
+  const relist = async (): Promise<void> => {
+    relisted = true
     const listing = await listLinkedEntryNames(commonDirPath)
     if (listing === null) {
       listingStale = true
-    } else {
-      entryNames = listing
-      const listed = new Set(listing)
-      for (const name of cache.entries.keys()) {
-        if (!listed.has(name)) {
-          cache.entries.delete(name)
-        }
+      return
+    }
+    listingStale = false
+    entryNames = listing
+    const present = new Set(listing)
+    for (const name of cache.entries.keys()) {
+      if (!present.has(name)) {
+        cache.entries.delete(name)
       }
     }
+  }
+  if (entryNames === null || scope.all || scope.listing) {
+    await relist()
   }
   if (entryNames === null) {
     // Unreadable on the very first pass: report only the primary and leave the
     // memo unset so the next refresh re-enumerates.
-    return cache.primary ? [cache.primary] : []
+    return { identities: cache.primary ? [cache.primary] : [], listingComplete: false }
+  }
+
+  let entryKeys = entryNames.map(headIdentityEntryKey)
+  // Why: a scope naming an entry the memoized listing does not know means the
+  // listing is behind, not that the entry may be skipped. Never let a named
+  // entry resolve to zero work.
+  if (!relisted && !knowsEveryScopedEntry(entryKeys, scope)) {
+    await relist()
+    entryKeys = entryNames.map(headIdentityEntryKey)
   }
 
   const staleNames = entryNames.filter(
-    (name) =>
-      scope.all || !cache.entries.has(name) || scope.entryNames.has(headIdentityEntryKey(name))
+    (name, index) => scope.all || !cache.entries.has(name) || scope.entryNames.has(entryKeys[index])
   )
-  // mapWithConcurrency retains input order, so publishing identities stays
-  // deterministic while independent worktree metadata reads overlap.
+  // Bounded fan-out so a burst cannot flood the libuv threadpool; publication
+  // order comes from `entryNames` below, not from completion order.
   const reads = await mapWithConcurrency(staleNames, HEAD_IDENTITY_READ_CONCURRENCY, (name) =>
     readLinkedEntryIdentity(commonDirPath, name, packedRefs, resolved)
   )
@@ -281,5 +318,5 @@ export async function readGitCommonHeadIdentities(
       identities.push(identity)
     }
   }
-  return identities
+  return { identities, listingComplete: !listingStale }
 }

--- a/src/main/ipc/worktree-head-identity-reader.ts
+++ b/src/main/ipc/worktree-head-identity-reader.ts
@@ -24,38 +24,59 @@ const HEAD_IDENTITY_READ_CONCURRENCY = 8
 export type WorktreeHeadIdentityCache = {
   /** admin entry dir name → last resolved identity. */
   entries: Map<string, WorktreeHeadIdentity>
+  /** Entries whose last read failed for a reason other than absence. The memo
+   *  keeps their last verified identity; the next pass must re-read them. */
+  unverified: Set<string>
   /** last `worktrees/` listing, in readdir order; null before first enumeration. */
   entryNames: string[] | null
   primary: WorktreeHeadIdentity | null
+  primaryUnverified: boolean
 }
 
 export function createWorktreeHeadIdentityCache(): WorktreeHeadIdentityCache {
-  return { entries: new Map(), entryNames: null, primary: null }
+  return {
+    entries: new Map(),
+    unverified: new Set(),
+    entryNames: null,
+    primary: null,
+    primaryUnverified: false
+  }
 }
 
 export type GitCommonHeadIdentityRead = {
   identities: WorktreeHeadIdentity[]
-  /** False when `worktrees/` could not be enumerated this pass, so any entry
-   *  added since the last good listing is missing from `identities`. Callers
-   *  that treat a full read as a freshness checkpoint must not do so on false. */
-  listingComplete: boolean
+  /** False when this pass did not fully observe the repo — `worktrees/` could
+   *  not be enumerated, or an entry's metadata could not be read. Callers that
+   *  treat a full read as a freshness checkpoint must not do so on false. */
+  complete: boolean
 }
 
 /** ref → oid resolved during one pass; null means the ref no longer resolves. */
 type ResolvedRefOids = Map<string, string | null>
 
-async function readTrimmedFile(path: string): Promise<string | null> {
+// Why: a read that failed for any reason other than absence is an UNKNOWN, not
+// an absence — the same distinction AGENTS.md draws for the SSH verdict
+// vocabulary. Collapsing the two evicts identities Orca still knows and turns a
+// single EMFILE into a full re-read of every worktree on the next pass.
+const UNREADABLE = Symbol('unreadable')
+type Unreadable = typeof UNREADABLE
+
+async function readTrimmedFile(path: string): Promise<string | null | Unreadable> {
   try {
     return (await readFile(path, 'utf8')).trim()
-  } catch {
-    return null
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT' ? null : UNREADABLE
   }
 }
 
 // packed-refs lines are `<oid> <ref>`; `#` headers and `^` peel lines skipped.
-async function readPackedRefs(commonDirPath: string): Promise<Map<string, string>> {
+async function readPackedRefs(commonDirPath: string): Promise<Map<string, string> | Unreadable> {
   const refs = new Map<string, string>()
   const content = await readTrimmedFile(join(commonDirPath, 'packed-refs'))
+  if (content === UNREADABLE) {
+    return UNREADABLE
+  }
+  // No packed-refs file at all is a fact: every ref is loose.
   if (content === null) {
     return refs
   }
@@ -93,8 +114,8 @@ function asObjectId(value: string | null | undefined): string | null {
 async function resolveRefToOid(
   commonDirPath: string,
   ref: string,
-  packedRefs: () => Promise<Map<string, string>>
-): Promise<string | null> {
+  packedRefs: () => Promise<Map<string, string> | Unreadable>
+): Promise<string | null | Unreadable> {
   let current = ref
   for (let depth = 0; depth < MAX_SYMREF_DEPTH; depth++) {
     if (!isSafeRefName(current)) {
@@ -102,8 +123,12 @@ async function resolveRefToOid(
     }
     // Branch refs are shared repo state, so loose files live in the common dir.
     const loose = await readTrimmedFile(join(commonDirPath, ...current.split('/')))
+    if (loose === UNREADABLE) {
+      return UNREADABLE
+    }
     if (loose === null) {
-      return asObjectId((await packedRefs()).get(current))
+      const packed = await packedRefs()
+      return packed === UNREADABLE ? UNREADABLE : asObjectId(packed.get(current))
     }
     if (loose.startsWith('ref: ')) {
       current = loose.slice('ref: '.length).trim()
@@ -118,16 +143,24 @@ async function readHeadIdentity(
   commonDirPath: string,
   headFilePath: string,
   worktreePath: string,
-  packedRefs: () => Promise<Map<string, string>>,
+  packedRefs: () => Promise<Map<string, string> | Unreadable>,
   resolved: ResolvedRefOids
-): Promise<WorktreeHeadIdentity | null> {
+): Promise<WorktreeHeadIdentity | null | Unreadable> {
   const head = await readTrimmedFile(headFilePath)
+  if (head === UNREADABLE) {
+    return UNREADABLE
+  }
   if (!head) {
     return null
   }
   if (head.startsWith('ref: ')) {
     const ref = head.slice('ref: '.length).trim()
     const oid = await resolveRefToOid(commonDirPath, ref, packedRefs)
+    // Only definite outcomes are replayed onto siblings; an unknown must not
+    // evict every other worktree that shares this branch.
+    if (oid === UNREADABLE) {
+      return UNREADABLE
+    }
     resolved.set(ref, oid)
     // Unborn branches (no commit yet) stay covered by the structural listing.
     if (!oid) {
@@ -142,11 +175,14 @@ async function readHeadIdentity(
 async function readLinkedEntryIdentity(
   commonDirPath: string,
   entryName: string,
-  packedRefs: () => Promise<Map<string, string>>,
+  packedRefs: () => Promise<Map<string, string> | Unreadable>,
   resolved: ResolvedRefOids
-): Promise<WorktreeHeadIdentity | null> {
+): Promise<WorktreeHeadIdentity | null | Unreadable> {
   const entryPath = join(commonDirPath, 'worktrees', entryName)
   const gitdirContent = await readTrimmedFile(join(entryPath, 'gitdir'))
+  if (gitdirContent === UNREADABLE) {
+    return UNREADABLE
+  }
   if (!gitdirContent) {
     return null
   }
@@ -233,8 +269,8 @@ export async function readGitCommonHeadIdentities(
   cache: WorktreeHeadIdentityCache = createWorktreeHeadIdentityCache(),
   scope: WorktreeHeadIdentityScope = FULL_HEAD_IDENTITY_SCOPE
 ): Promise<GitCommonHeadIdentityRead> {
-  let packedRefsPromise: Promise<Map<string, string>> | null = null
-  const packedRefs = (): Promise<Map<string, string>> =>
+  let packedRefsPromise: Promise<Map<string, string> | Unreadable> | null = null
+  const packedRefs = (): Promise<Map<string, string> | Unreadable> =>
     (packedRefsPromise ??= readPackedRefs(commonDirPath))
   const resolved: ResolvedRefOids = new Map()
 
@@ -242,14 +278,18 @@ export async function readGitCommonHeadIdentities(
   // primary checkout path; bare/custom GIT_DIR layouts have no primary row.
   if (basename(commonDirPath) !== '.git') {
     cache.primary = null
-  } else if (scope.all || scope.primary || cache.primary === null) {
-    cache.primary = await readHeadIdentity(
+  } else if (scope.all || scope.primary || cache.primary === null || cache.primaryUnverified) {
+    const primary = await readHeadIdentity(
       commonDirPath,
       join(commonDirPath, 'HEAD'),
       dirname(commonDirPath),
       packedRefs,
       resolved
     )
+    cache.primaryUnverified = primary === UNREADABLE
+    if (primary !== UNREADABLE) {
+      cache.primary = primary
+    }
   }
 
   let entryNames = cache.entryNames
@@ -277,7 +317,7 @@ export async function readGitCommonHeadIdentities(
   if (entryNames === null) {
     // Unreadable on the very first pass: report only the primary and leave the
     // memo unset so the next refresh re-enumerates.
-    return { identities: cache.primary ? [cache.primary] : [], listingComplete: false }
+    return { identities: cache.primary ? [cache.primary] : [], complete: false }
   }
 
   let entryKeys = entryNames.map(headIdentityEntryKey)
@@ -290,7 +330,12 @@ export async function readGitCommonHeadIdentities(
   }
 
   const staleNames = entryNames.filter(
-    (name, index) => scope.all || !cache.entries.has(name) || scope.entryNames.has(entryKeys[index])
+    (name, index) =>
+      scope.all ||
+      !cache.entries.has(name) ||
+      // Retried promptly: an unknown from last pass is not evidence of anything.
+      cache.unverified.has(name) ||
+      scope.entryNames.has(entryKeys[index])
   )
   // Bounded fan-out so a burst cannot flood the libuv threadpool; publication
   // order comes from `entryNames` below, not from completion order.
@@ -299,6 +344,12 @@ export async function readGitCommonHeadIdentities(
   )
   staleNames.forEach((name, index) => {
     const identity = reads[index]
+    if (identity === UNREADABLE) {
+      // Unknown, not absent: keep the last verified identity and retry next pass.
+      cache.unverified.add(name)
+      return
+    }
+    cache.unverified.delete(name)
     if (identity) {
       cache.entries.set(name, identity)
     } else {
@@ -318,5 +369,8 @@ export async function readGitCommonHeadIdentities(
       identities.push(identity)
     }
   }
-  return { identities, listingComplete: !listingStale }
+  return {
+    identities,
+    complete: !listingStale && cache.unverified.size === 0 && !cache.primaryUnverified
+  }
 }

--- a/src/main/ipc/worktree-head-identity-reader.ts
+++ b/src/main/ipc/worktree-head-identity-reader.ts
@@ -1,8 +1,12 @@
 import { readdir, readFile } from 'node:fs/promises'
-import type { Dirent } from 'node:fs'
 import { basename, dirname, isAbsolute, join } from 'node:path'
 import type { WorktreeHeadIdentity } from '../../shared/worktree/types'
 import { mapWithConcurrency } from '../../shared/map-with-concurrency'
+import {
+  FULL_HEAD_IDENTITY_SCOPE,
+  headIdentityEntryKey,
+  type WorktreeHeadIdentityScope
+} from './worktree-head-identity-scope'
 
 // Why: the whole point of this reader is replacing `git worktree list` fanout
 // with bounded metadata-file reads, so head freshness never re-creates the
@@ -13,6 +17,24 @@ const MAX_SYMREF_DEPTH = 5
 // bounded while avoiding a serial round trip per linked worktree (especially
 // noticeable on WSL/UNC and network-backed worktrees).
 const HEAD_IDENTITY_READ_CONCURRENCY = 8
+
+/** Per-common-dir memo so a scoped refresh re-reads only the entries a watcher
+ *  burst could have moved. Misses are never cached: an unresolvable read may be
+ *  a transient fs error, so it must be retried rather than remembered. */
+export type WorktreeHeadIdentityCache = {
+  /** admin entry dir name → last resolved identity. */
+  entries: Map<string, WorktreeHeadIdentity>
+  /** last `worktrees/` listing, in readdir order; null before first enumeration. */
+  entryNames: string[] | null
+  primary: WorktreeHeadIdentity | null
+}
+
+export function createWorktreeHeadIdentityCache(): WorktreeHeadIdentityCache {
+  return { entries: new Map(), entryNames: null, primary: null }
+}
+
+/** ref → oid resolved during one pass; null means the ref no longer resolves. */
+type ResolvedRefOids = Map<string, string | null>
 
 async function readTrimmedFile(path: string): Promise<string | null> {
   try {
@@ -88,7 +110,8 @@ async function readHeadIdentity(
   commonDirPath: string,
   headFilePath: string,
   worktreePath: string,
-  packedRefs: () => Promise<Map<string, string>>
+  packedRefs: () => Promise<Map<string, string>>,
+  resolved: ResolvedRefOids
 ): Promise<WorktreeHeadIdentity | null> {
   const head = await readTrimmedFile(headFilePath)
   if (!head) {
@@ -97,6 +120,7 @@ async function readHeadIdentity(
   if (head.startsWith('ref: ')) {
     const ref = head.slice('ref: '.length).trim()
     const oid = await resolveRefToOid(commonDirPath, ref, packedRefs)
+    resolved.set(ref, oid)
     // Unborn branches (no commit yet) stay covered by the structural listing.
     if (!oid) {
       return null
@@ -107,65 +131,135 @@ async function readHeadIdentity(
   return detachedOid ? { worktreePath, head: detachedOid, branch: null } : null
 }
 
+async function readLinkedEntryIdentity(
+  commonDirPath: string,
+  entryName: string,
+  packedRefs: () => Promise<Map<string, string>>,
+  resolved: ResolvedRefOids
+): Promise<WorktreeHeadIdentity | null> {
+  const entryPath = join(commonDirPath, 'worktrees', entryName)
+  const gitdirContent = await readTrimmedFile(join(entryPath, 'gitdir'))
+  if (!gitdirContent) {
+    return null
+  }
+  // `gitdir` holds `<worktree>/.git`, absolute or (with relative-path
+  // worktrees) relative to the entry dir.
+  const gitdirAbsolute = isAbsolute(gitdirContent) ? gitdirContent : join(entryPath, gitdirContent)
+  return readHeadIdentity(
+    commonDirPath,
+    join(entryPath, 'HEAD'),
+    dirname(gitdirAbsolute),
+    packedRefs,
+    resolved
+  )
+}
+
+async function listLinkedEntryNames(commonDirPath: string): Promise<string[]> {
+  try {
+    const entries = await readdir(join(commonDirPath, 'worktrees'), { withFileTypes: true })
+    return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name)
+  } catch {
+    return []
+  }
+}
+
+// Why: `git worktree add --force` lets several worktrees share one branch, and
+// only the committing worktree's HEAD reflog is appended. Replaying every ref
+// resolved this pass onto the cached entries that point at it keeps the others
+// current without re-reading their metadata.
+function retargetCachedIdentity(
+  identity: WorktreeHeadIdentity,
+  resolved: ResolvedRefOids
+): WorktreeHeadIdentity | null {
+  if (identity.branch === null || !resolved.has(identity.branch)) {
+    return identity
+  }
+  const oid = resolved.get(identity.branch) ?? null
+  return oid === null ? null : { ...identity, head: oid }
+}
+
+function applyResolvedRefOids(cache: WorktreeHeadIdentityCache, resolved: ResolvedRefOids): void {
+  if (resolved.size === 0) {
+    return
+  }
+  for (const [name, identity] of cache.entries) {
+    const next = retargetCachedIdentity(identity, resolved)
+    if (next === null) {
+      cache.entries.delete(name)
+    } else if (next !== identity) {
+      cache.entries.set(name, next)
+    }
+  }
+  if (cache.primary) {
+    cache.primary = retargetCachedIdentity(cache.primary, resolved)
+  }
+}
+
 /** Reads head/branch for the primary checkout and every linked worktree of a
  *  Git common dir using only metadata-file reads (HEAD, gitdir, loose refs,
  *  packed-refs) — no Git subprocess. Unresolvable entries are skipped so
- *  callers never overwrite store state with partial reads. */
+ *  callers never overwrite store state with partial reads.
+ *
+ *  Pass a `cache` plus a narrowed `scope` to re-read only the entries a watcher
+ *  burst could have moved; the defaults re-read everything. */
 export async function readGitCommonHeadIdentities(
-  commonDirPath: string
+  commonDirPath: string,
+  cache: WorktreeHeadIdentityCache = createWorktreeHeadIdentityCache(),
+  scope: WorktreeHeadIdentityScope = FULL_HEAD_IDENTITY_SCOPE
 ): Promise<WorktreeHeadIdentity[]> {
   let packedRefsPromise: Promise<Map<string, string>> | null = null
   const packedRefs = (): Promise<Map<string, string>> =>
     (packedRefsPromise ??= readPackedRefs(commonDirPath))
+  const resolved: ResolvedRefOids = new Map()
 
-  const identities: WorktreeHeadIdentity[] = []
   // Only the standard `<checkout>/.git` layout maps a common dir back to its
   // primary checkout path; bare/custom GIT_DIR layouts have no primary row.
-  if (basename(commonDirPath) === '.git') {
-    const primary = await readHeadIdentity(
+  if (basename(commonDirPath) !== '.git') {
+    cache.primary = null
+  } else if (scope.all || scope.primary || cache.primary === null) {
+    cache.primary = await readHeadIdentity(
       commonDirPath,
       join(commonDirPath, 'HEAD'),
       dirname(commonDirPath),
-      packedRefs
+      packedRefs,
+      resolved
     )
-    if (primary) {
-      identities.push(primary)
+  }
+
+  let entryNames = cache.entryNames
+  if (entryNames === null || scope.all || scope.listing) {
+    entryNames = await listLinkedEntryNames(commonDirPath)
+    const listed = new Set(entryNames)
+    for (const name of cache.entries.keys()) {
+      if (!listed.has(name)) {
+        cache.entries.delete(name)
+      }
     }
   }
 
-  let entries: Dirent[]
-  try {
-    entries = await readdir(join(commonDirPath, 'worktrees'), { withFileTypes: true })
-  } catch {
-    return identities
-  }
-
-  const linkedEntries = entries.filter((entry) => entry.isDirectory())
+  const staleNames = entryNames.filter(
+    (name) =>
+      scope.all || !cache.entries.has(name) || scope.entryNames.has(headIdentityEntryKey(name))
+  )
   // mapWithConcurrency retains input order, so publishing identities stays
   // deterministic while independent worktree metadata reads overlap.
-  const linkedIdentities = await mapWithConcurrency(
-    linkedEntries,
-    HEAD_IDENTITY_READ_CONCURRENCY,
-    async (entry) => {
-      const entryPath = join(commonDirPath, 'worktrees', entry.name)
-      const gitdirContent = await readTrimmedFile(join(entryPath, 'gitdir'))
-      if (!gitdirContent) {
-        return null
-      }
-      // `gitdir` holds `<worktree>/.git`, absolute or (with relative-path
-      // worktrees) relative to the entry dir.
-      const gitdirAbsolute = isAbsolute(gitdirContent)
-        ? gitdirContent
-        : join(entryPath, gitdirContent)
-      return readHeadIdentity(
-        commonDirPath,
-        join(entryPath, 'HEAD'),
-        dirname(gitdirAbsolute),
-        packedRefs
-      )
-    }
+  const reads = await mapWithConcurrency(staleNames, HEAD_IDENTITY_READ_CONCURRENCY, (name) =>
+    readLinkedEntryIdentity(commonDirPath, name, packedRefs, resolved)
   )
-  for (const identity of linkedIdentities) {
+  staleNames.forEach((name, index) => {
+    const identity = reads[index]
+    if (identity) {
+      cache.entries.set(name, identity)
+    } else {
+      cache.entries.delete(name)
+    }
+  })
+  applyResolvedRefOids(cache, resolved)
+
+  cache.entryNames = entryNames
+  const identities: WorktreeHeadIdentity[] = cache.primary ? [cache.primary] : []
+  for (const name of entryNames) {
+    const identity = cache.entries.get(name)
     if (identity) {
       identities.push(identity)
     }

--- a/src/main/ipc/worktree-head-identity-refresh.test.ts
+++ b/src/main/ipc/worktree-head-identity-refresh.test.ts
@@ -116,6 +116,30 @@ describe('refreshWorktreeHeadIdentities', () => {
     expect(lastScope()).toEqual(PRIMARY_HEAD_IDENTITY_SCOPE)
   })
 
+  it('still takes the periodic re-baseline when only empty-scope events arrive', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    await refreshWorktreeHeadIdentities(host, state, false)
+    vi.mocked(readGitCommonHeadIdentities).mockClear()
+
+    // `git worktree lock`/`unlock` and sparse toggles classify to the empty
+    // scope. They must not be able to starve the re-baseline that bounds the
+    // window where a ref moved with no event under any admin dir.
+    vi.advanceTimersByTime(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS)
+    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([identity('bbb')])
+    await refreshWorktreeHeadIdentities(host, state, true, EMPTY_HEAD_IDENTITY_SCOPE)
+
+    expect(lastScope()).toEqual(FULL_HEAD_IDENTITY_SCOPE)
+    expect(notifyWorktreeHeadIdentitiesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1', [
+      identity('bbb')
+    ])
+
+    // The promotion also re-arms the interval, so the next empty burst is free.
+    vi.mocked(readGitCommonHeadIdentities).mockClear()
+    await refreshWorktreeHeadIdentities(host, state, true, EMPTY_HEAD_IDENTITY_SCOPE)
+    expect(readGitCommonHeadIdentities).not.toHaveBeenCalled()
+  })
+
   it('merges the scopes of refreshes queued behind an in-flight read', async () => {
     const host = makeHost()
     const state = createWorktreeHeadIdentityRefreshState()

--- a/src/main/ipc/worktree-head-identity-refresh.test.ts
+++ b/src/main/ipc/worktree-head-identity-refresh.test.ts
@@ -6,7 +6,10 @@ vi.mock('./worktree-remote', () => ({
 }))
 
 vi.mock('./worktree-head-identity-reader', () => ({
-  readGitCommonHeadIdentities: vi.fn(async () => [] as WorktreeHeadIdentity[]),
+  readGitCommonHeadIdentities: vi.fn(async () => ({
+    identities: [] as WorktreeHeadIdentity[],
+    listingComplete: true
+  })),
   createWorktreeHeadIdentityCache: vi.fn(() => ({
     entries: new Map(),
     entryNames: null,
@@ -31,11 +34,13 @@ import {
 const COMMON_DIR = '/repos/project/.git'
 const WT_A = '/repos/wt-a'
 
+const windowState = { destroyed: false }
+
 function makeHost(): Parameters<typeof refreshWorktreeHeadIdentities>[0] {
   return {
     path: COMMON_DIR,
     repos: new Map([['repo-1', {}]]),
-    mainWindow: { isDestroyed: () => false } as never,
+    mainWindow: { isDestroyed: () => windowState.destroyed } as never,
     disposed: false
   }
 }
@@ -44,15 +49,20 @@ function identity(head: string): WorktreeHeadIdentity {
   return { worktreePath: WT_A, head, branch: 'refs/heads/feature' }
 }
 
+function mockRead(identities: WorktreeHeadIdentity[] = [], listingComplete = true): void {
+  vi.mocked(readGitCommonHeadIdentities).mockResolvedValue({ identities, listingComplete })
+}
+
 function lastScope(): unknown {
   return vi.mocked(readGitCommonHeadIdentities).mock.calls.at(-1)?.[2]
 }
 
 describe('refreshWorktreeHeadIdentities', () => {
   beforeEach(() => {
+    windowState.destroyed = false
     vi.useFakeTimers()
     vi.mocked(readGitCommonHeadIdentities).mockReset()
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([])
+    mockRead()
     vi.mocked(notifyWorktreeHeadIdentitiesChanged).mockClear()
   })
 
@@ -62,7 +72,7 @@ describe('refreshWorktreeHeadIdentities', () => {
 
   it('reads everything on cold start and does not emit off a missing baseline', async () => {
     const state = createWorktreeHeadIdentityRefreshState()
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([identity('aaa')])
+    mockRead([identity('aaa')])
 
     await refreshWorktreeHeadIdentities(makeHost(), state, true, headIdentityScopeForEntry('wt-a'))
 
@@ -74,10 +84,10 @@ describe('refreshWorktreeHeadIdentities', () => {
   it('forwards a narrowed scope once a baseline exists', async () => {
     const host = makeHost()
     const state = createWorktreeHeadIdentityRefreshState()
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([identity('aaa')])
+    mockRead([identity('aaa')])
     await refreshWorktreeHeadIdentities(host, state, false)
 
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([identity('bbb')])
+    mockRead([identity('bbb')])
     await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
 
     expect(lastScope()).toEqual(headIdentityScopeForEntry('wt-a'))
@@ -126,18 +136,42 @@ describe('refreshWorktreeHeadIdentities', () => {
     // scope. They must not be able to starve the re-baseline that bounds the
     // window where a ref moved with no event under any admin dir.
     vi.advanceTimersByTime(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS)
-    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([identity('bbb')])
-    await refreshWorktreeHeadIdentities(host, state, true, EMPTY_HEAD_IDENTITY_SCOPE)
+    mockRead([identity('bbb')])
+    // An empty scope only ever reaches the refresh from a structural burst, so
+    // the reachable pairing is `emit: false`: the promotion's job here is
+    // baseline/cache hygiene, and the structural catalog notification that runs
+    // in the same flush is what publishes the head.
+    await refreshWorktreeHeadIdentities(host, state, false, EMPTY_HEAD_IDENTITY_SCOPE)
 
     expect(lastScope()).toEqual(FULL_HEAD_IDENTITY_SCOPE)
-    expect(notifyWorktreeHeadIdentitiesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1', [
-      identity('bbb')
-    ])
+    expect(notifyWorktreeHeadIdentitiesChanged).not.toHaveBeenCalled()
+
+    // Re-baselined, so the next narrow burst diffs against the fresh head
+    // instead of re-reporting a move the catalog already published.
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+    expect(notifyWorktreeHeadIdentitiesChanged).not.toHaveBeenCalled()
 
     // The promotion also re-arms the interval, so the next empty burst is free.
     vi.mocked(readGitCommonHeadIdentities).mockClear()
-    await refreshWorktreeHeadIdentities(host, state, true, EMPTY_HEAD_IDENTITY_SCOPE)
+    await refreshWorktreeHeadIdentities(host, state, false, EMPTY_HEAD_IDENTITY_SCOPE)
     expect(readGitCommonHeadIdentities).not.toHaveBeenCalled()
+  })
+
+  it('does not arm the freshness clock on a full read that could not enumerate', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    // A full read whose `worktrees/` listing failed has not seen entries added
+    // since the last good listing, so it is not a freshness checkpoint.
+    mockRead([identity('aaa')], false)
+    await refreshWorktreeHeadIdentities(host, state, false)
+    mockRead([identity('aaa')])
+
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+    expect(lastScope()).toEqual(FULL_HEAD_IDENTITY_SCOPE)
+
+    // That one enumerated, so the clock arms and the next narrow burst stays narrow.
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+    expect(lastScope()).toEqual(headIdentityScopeForEntry('wt-a'))
   })
 
   it('merges the scopes of refreshes queued behind an in-flight read', async () => {
@@ -149,7 +183,7 @@ describe('refreshWorktreeHeadIdentities', () => {
     vi.mocked(readGitCommonHeadIdentities).mockImplementationOnce(
       () =>
         new Promise((resolve) => {
-          release = () => resolve([])
+          release = () => resolve({ identities: [], listingComplete: true })
         })
     )
     const inFlight = refreshWorktreeHeadIdentities(
@@ -185,6 +219,109 @@ describe('refreshWorktreeHeadIdentities', () => {
     expect(lastScope()).toEqual(FULL_HEAD_IDENTITY_SCOPE)
   })
 
+  it('keeps the baseline when a notify throws so the move is retried', async () => {
+    const host = makeHost()
+    host.repos = new Map([
+      ['repo-1', {}],
+      ['repo-2', {}]
+    ])
+    const state = createWorktreeHeadIdentityRefreshState()
+    mockRead([identity('aaa')])
+    await refreshWorktreeHeadIdentities(host, state, false)
+
+    // A send into destroyed chrome throws part-way through the repo loop.
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockRead([identity('bbb')])
+    vi.mocked(notifyWorktreeHeadIdentitiesChanged).mockImplementationOnce(() => {
+      throw new Error('webContents destroyed')
+    })
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+
+    // The baseline must still hold `aaa`, so the next refresh re-reports `bbb`
+    // rather than diffing it away as already published.
+    vi.mocked(notifyWorktreeHeadIdentitiesChanged).mockClear()
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+    expect(notifyWorktreeHeadIdentitiesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1', [
+      identity('bbb')
+    ])
+    expect(notifyWorktreeHeadIdentitiesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-2', [
+      identity('bbb')
+    ])
+  })
+
+  it('folds a queued scope back in when its re-run met a destroyed window', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    await refreshWorktreeHeadIdentities(host, state, false)
+
+    let release: () => void = () => {}
+    vi.mocked(readGitCommonHeadIdentities).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve({ identities: [], listingComplete: true })
+        })
+    )
+    const inFlight = refreshWorktreeHeadIdentities(
+      host,
+      state,
+      true,
+      headIdentityScopeForEntry('wt-a')
+    )
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-b'))
+    // macOS recreates the window while the watch lives on: the queued re-run
+    // returns at the teardown guard and must not lose the scope with it.
+    windowState.destroyed = true
+    release()
+    await inFlight
+    await vi.advanceTimersByTimeAsync(0)
+
+    windowState.destroyed = false
+    vi.mocked(readGitCommonHeadIdentities).mockClear()
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-c'))
+
+    expect(lastScope()).toEqual({
+      listing: false,
+      primary: false,
+      all: false,
+      entryNames: new Set(['wt-b', 'wt-c'])
+    })
+  })
+
+  it('does not treat a read discarded by teardown as a freshness checkpoint', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    await refreshWorktreeHeadIdentities(host, state, false)
+    vi.advanceTimersByTime(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS)
+
+    vi.mocked(readGitCommonHeadIdentities).mockImplementationOnce(async () => {
+      windowState.destroyed = true
+      return { identities: [identity('bbb')], listingComplete: true }
+    })
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+
+    windowState.destroyed = false
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+    expect(lastScope()).toEqual(FULL_HEAD_IDENTITY_SCOPE)
+  })
+
+  it('carries forward baseline rows an incomplete listing could not observe', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    const other = { worktreePath: '/repos/wt-b', head: 'ccc', branch: 'refs/heads/other' }
+    mockRead([identity('aaa'), other])
+    await refreshWorktreeHeadIdentities(host, state, false)
+
+    // Enumeration failed, so wt-b is missing from this pass entirely.
+    mockRead([identity('aaa')], false)
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+    expect(notifyWorktreeHeadIdentitiesChanged).not.toHaveBeenCalled()
+
+    // Listing recovers with wt-b unchanged: it must not be reported as moved.
+    mockRead([identity('aaa'), other])
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+    expect(notifyWorktreeHeadIdentitiesChanged).not.toHaveBeenCalled()
+  })
+
   it('never emits for a window torn down mid-read', async () => {
     const host = makeHost()
     const state = createWorktreeHeadIdentityRefreshState()
@@ -192,7 +329,7 @@ describe('refreshWorktreeHeadIdentities', () => {
 
     vi.mocked(readGitCommonHeadIdentities).mockImplementationOnce(async () => {
       host.disposed = true
-      return [identity('bbb')]
+      return { identities: [identity('bbb')], listingComplete: true }
     })
     await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
 

--- a/src/main/ipc/worktree-head-identity-refresh.test.ts
+++ b/src/main/ipc/worktree-head-identity-refresh.test.ts
@@ -21,6 +21,7 @@ import { notifyWorktreeHeadIdentitiesChanged } from './worktree-remote'
 import { readGitCommonHeadIdentities } from './worktree-head-identity-reader'
 import {
   createWorktreeHeadIdentityRefreshState,
+  disposeWorktreeHeadIdentityRefreshState,
   HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS,
   refreshWorktreeHeadIdentities
 } from './worktree-head-identity-refresh'
@@ -51,6 +52,12 @@ function identity(head: string): WorktreeHeadIdentity {
 
 function mockRead(identities: WorktreeHeadIdentity[] = [], listingComplete = true): void {
   vi.mocked(readGitCommonHeadIdentities).mockResolvedValue({ identities, listingComplete })
+}
+
+// Advance only the clock, so promotion-on-the-next-event is exercised without
+// the one-shot catch-up timer firing and muddling the assertion.
+function skipInterval(): void {
+  vi.setSystemTime(Date.now() + HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS)
 }
 
 function lastScope(): unknown {
@@ -118,7 +125,7 @@ describe('refreshWorktreeHeadIdentities', () => {
 
     // A ref can move with no event under any admin dir (`git update-ref` from a
     // sibling worktree), so the blind window has to be bounded.
-    vi.advanceTimersByTime(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS)
+    skipInterval()
     await refreshWorktreeHeadIdentities(host, state, true, PRIMARY_HEAD_IDENTITY_SCOPE)
     expect(lastScope()).toEqual(FULL_HEAD_IDENTITY_SCOPE)
 
@@ -135,7 +142,7 @@ describe('refreshWorktreeHeadIdentities', () => {
     // `git worktree lock`/`unlock` and sparse toggles classify to the empty
     // scope. They must not be able to starve the re-baseline that bounds the
     // window where a ref moved with no event under any admin dir.
-    vi.advanceTimersByTime(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS)
+    skipInterval()
     mockRead([identity('bbb')])
     // An empty scope only ever reaches the refresh from a structural burst, so
     // the reachable pairing is `emit: false`: the promotion's job here is
@@ -291,7 +298,7 @@ describe('refreshWorktreeHeadIdentities', () => {
     const host = makeHost()
     const state = createWorktreeHeadIdentityRefreshState()
     await refreshWorktreeHeadIdentities(host, state, false)
-    vi.advanceTimersByTime(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS)
+    skipInterval()
 
     vi.mocked(readGitCommonHeadIdentities).mockImplementationOnce(async () => {
       windowState.destroyed = true
@@ -320,6 +327,69 @@ describe('refreshWorktreeHeadIdentities', () => {
     mockRead([identity('aaa'), other])
     await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
     expect(notifyWorktreeHeadIdentitiesChanged).not.toHaveBeenCalled()
+  })
+
+  it('catches up with no further events after a scoped refresh', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    mockRead([identity('aaa')])
+    await refreshWorktreeHeadIdentities(host, state, false)
+
+    // A scoped pass leaves any drift it could not see unbounded, so it arms a
+    // one-shot catch-up rather than waiting for an event that may never come.
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+    expect(lastScope()).toEqual(headIdentityScopeForEntry('wt-a'))
+
+    // External `git update-ref` moved the head with no watched write, then total
+    // silence: no burst, no debounce flush, nothing.
+    mockRead([identity('bbb')])
+    await vi.advanceTimersByTimeAsync(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS)
+
+    expect(lastScope()).toEqual(FULL_HEAD_IDENTITY_SCOPE)
+    expect(notifyWorktreeHeadIdentitiesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1', [
+      identity('bbb')
+    ])
+    disposeWorktreeHeadIdentityRefreshState(state)
+  })
+
+  it('schedules nothing while idle, so a quiet repo costs no background reads', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    mockRead([identity('aaa')])
+    // Cold start is a full pass: it disarms rather than arming, because nothing
+    // is outstanding after a full read.
+    await refreshWorktreeHeadIdentities(host, state, false)
+    expect(state.rebaselineTimer).toBeNull()
+
+    vi.mocked(readGitCommonHeadIdentities).mockClear()
+    await vi.advanceTimersByTimeAsync(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS * 5)
+    expect(readGitCommonHeadIdentities).not.toHaveBeenCalled()
+
+    // Re-baseline so the scoped pass below stays scoped, then check that the
+    // catch-up it arms disarms once it has run: never a recurring poll.
+    await refreshWorktreeHeadIdentities(host, state, false, FULL_HEAD_IDENTITY_SCOPE)
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+    expect(state.rebaselineTimer).not.toBeNull()
+    await vi.advanceTimersByTimeAsync(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS)
+    expect(state.rebaselineTimer).toBeNull()
+
+    vi.mocked(readGitCommonHeadIdentities).mockClear()
+    await vi.advanceTimersByTimeAsync(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS * 5)
+    expect(readGitCommonHeadIdentities).not.toHaveBeenCalled()
+  })
+
+  it('stops the catch-up when the watch is disposed', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    mockRead([identity('aaa')])
+    await refreshWorktreeHeadIdentities(host, state, false)
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+
+    disposeWorktreeHeadIdentityRefreshState(state)
+    vi.mocked(readGitCommonHeadIdentities).mockClear()
+    await vi.advanceTimersByTimeAsync(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS * 2)
+
+    expect(readGitCommonHeadIdentities).not.toHaveBeenCalled()
   })
 
   it('never emits for a window torn down mid-read', async () => {

--- a/src/main/ipc/worktree-head-identity-refresh.test.ts
+++ b/src/main/ipc/worktree-head-identity-refresh.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorktreeHeadIdentity } from '../../shared/worktree/types'
+
+vi.mock('./worktree-remote', () => ({
+  notifyWorktreeHeadIdentitiesChanged: vi.fn()
+}))
+
+vi.mock('./worktree-head-identity-reader', () => ({
+  readGitCommonHeadIdentities: vi.fn(async () => [] as WorktreeHeadIdentity[]),
+  createWorktreeHeadIdentityCache: vi.fn(() => ({
+    entries: new Map(),
+    entryNames: null,
+    primary: null
+  }))
+}))
+
+import { notifyWorktreeHeadIdentitiesChanged } from './worktree-remote'
+import { readGitCommonHeadIdentities } from './worktree-head-identity-reader'
+import {
+  createWorktreeHeadIdentityRefreshState,
+  HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS,
+  refreshWorktreeHeadIdentities
+} from './worktree-head-identity-refresh'
+import {
+  EMPTY_HEAD_IDENTITY_SCOPE,
+  FULL_HEAD_IDENTITY_SCOPE,
+  headIdentityScopeForEntry,
+  PRIMARY_HEAD_IDENTITY_SCOPE
+} from './worktree-head-identity-scope'
+
+const COMMON_DIR = '/repos/project/.git'
+const WT_A = '/repos/wt-a'
+
+function makeHost(): Parameters<typeof refreshWorktreeHeadIdentities>[0] {
+  return {
+    path: COMMON_DIR,
+    repos: new Map([['repo-1', {}]]),
+    mainWindow: { isDestroyed: () => false } as never,
+    disposed: false
+  }
+}
+
+function identity(head: string): WorktreeHeadIdentity {
+  return { worktreePath: WT_A, head, branch: 'refs/heads/feature' }
+}
+
+function lastScope(): unknown {
+  return vi.mocked(readGitCommonHeadIdentities).mock.calls.at(-1)?.[2]
+}
+
+describe('refreshWorktreeHeadIdentities', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(readGitCommonHeadIdentities).mockReset()
+    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([])
+    vi.mocked(notifyWorktreeHeadIdentitiesChanged).mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reads everything on cold start and does not emit off a missing baseline', async () => {
+    const state = createWorktreeHeadIdentityRefreshState()
+    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([identity('aaa')])
+
+    await refreshWorktreeHeadIdentities(makeHost(), state, true, headIdentityScopeForEntry('wt-a'))
+
+    // A scoped first call still cannot trust an empty memo.
+    expect(lastScope()).toEqual(FULL_HEAD_IDENTITY_SCOPE)
+    expect(notifyWorktreeHeadIdentitiesChanged).not.toHaveBeenCalled()
+  })
+
+  it('forwards a narrowed scope once a baseline exists', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([identity('aaa')])
+    await refreshWorktreeHeadIdentities(host, state, false)
+
+    vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([identity('bbb')])
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+
+    expect(lastScope()).toEqual(headIdentityScopeForEntry('wt-a'))
+    expect(notifyWorktreeHeadIdentitiesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1', [
+      identity('bbb')
+    ])
+  })
+
+  it('reads nothing when the burst provably cannot move a head', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    await refreshWorktreeHeadIdentities(host, state, false)
+    vi.mocked(readGitCommonHeadIdentities).mockClear()
+
+    // A `locked` / `config.worktree` write classifies to the empty scope.
+    await refreshWorktreeHeadIdentities(host, state, true, EMPTY_HEAD_IDENTITY_SCOPE)
+
+    expect(readGitCommonHeadIdentities).not.toHaveBeenCalled()
+  })
+
+  it('promotes one refresh per interval back to a full re-read', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    await refreshWorktreeHeadIdentities(host, state, false)
+
+    await refreshWorktreeHeadIdentities(host, state, true, PRIMARY_HEAD_IDENTITY_SCOPE)
+    expect(lastScope()).toEqual(PRIMARY_HEAD_IDENTITY_SCOPE)
+
+    // A ref can move with no event under any admin dir (`git update-ref` from a
+    // sibling worktree), so the blind window has to be bounded.
+    vi.advanceTimersByTime(HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS)
+    await refreshWorktreeHeadIdentities(host, state, true, PRIMARY_HEAD_IDENTITY_SCOPE)
+    expect(lastScope()).toEqual(FULL_HEAD_IDENTITY_SCOPE)
+
+    await refreshWorktreeHeadIdentities(host, state, true, PRIMARY_HEAD_IDENTITY_SCOPE)
+    expect(lastScope()).toEqual(PRIMARY_HEAD_IDENTITY_SCOPE)
+  })
+
+  it('merges the scopes of refreshes queued behind an in-flight read', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    await refreshWorktreeHeadIdentities(host, state, false)
+
+    let release: () => void = () => {}
+    vi.mocked(readGitCommonHeadIdentities).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve([])
+        })
+    )
+    const inFlight = refreshWorktreeHeadIdentities(
+      host,
+      state,
+      true,
+      headIdentityScopeForEntry('wt-a')
+    )
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-b'))
+    await refreshWorktreeHeadIdentities(host, state, true, PRIMARY_HEAD_IDENTITY_SCOPE)
+    release()
+    await inFlight
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(lastScope()).toEqual({
+      listing: false,
+      primary: true,
+      all: false,
+      entryNames: new Set(['wt-b'])
+    })
+  })
+
+  it('re-reads everything after a failed read rather than trusting a partial memo', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    await refreshWorktreeHeadIdentities(host, state, false)
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(readGitCommonHeadIdentities).mockRejectedValueOnce(new Error('EIO'))
+
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+
+    expect(lastScope()).toEqual(FULL_HEAD_IDENTITY_SCOPE)
+  })
+
+  it('never emits for a window torn down mid-read', async () => {
+    const host = makeHost()
+    const state = createWorktreeHeadIdentityRefreshState()
+    await refreshWorktreeHeadIdentities(host, state, false)
+
+    vi.mocked(readGitCommonHeadIdentities).mockImplementationOnce(async () => {
+      host.disposed = true
+      return [identity('bbb')]
+    })
+    await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
+
+    expect(notifyWorktreeHeadIdentitiesChanged).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/worktree-head-identity-refresh.test.ts
+++ b/src/main/ipc/worktree-head-identity-refresh.test.ts
@@ -8,12 +8,14 @@ vi.mock('./worktree-remote', () => ({
 vi.mock('./worktree-head-identity-reader', () => ({
   readGitCommonHeadIdentities: vi.fn(async () => ({
     identities: [] as WorktreeHeadIdentity[],
-    listingComplete: true
+    complete: true
   })),
   createWorktreeHeadIdentityCache: vi.fn(() => ({
     entries: new Map(),
+    unverified: new Set(),
     entryNames: null,
-    primary: null
+    primary: null,
+    primaryUnverified: false
   }))
 }))
 
@@ -50,8 +52,8 @@ function identity(head: string): WorktreeHeadIdentity {
   return { worktreePath: WT_A, head, branch: 'refs/heads/feature' }
 }
 
-function mockRead(identities: WorktreeHeadIdentity[] = [], listingComplete = true): void {
-  vi.mocked(readGitCommonHeadIdentities).mockResolvedValue({ identities, listingComplete })
+function mockRead(identities: WorktreeHeadIdentity[] = [], complete = true): void {
+  vi.mocked(readGitCommonHeadIdentities).mockResolvedValue({ identities, complete })
 }
 
 // Advance only the clock, so promotion-on-the-next-event is exercised without
@@ -190,7 +192,7 @@ describe('refreshWorktreeHeadIdentities', () => {
     vi.mocked(readGitCommonHeadIdentities).mockImplementationOnce(
       () =>
         new Promise((resolve) => {
-          release = () => resolve({ identities: [], listingComplete: true })
+          release = () => resolve({ identities: [], complete: true })
         })
     )
     const inFlight = refreshWorktreeHeadIdentities(
@@ -265,7 +267,7 @@ describe('refreshWorktreeHeadIdentities', () => {
     vi.mocked(readGitCommonHeadIdentities).mockImplementationOnce(
       () =>
         new Promise((resolve) => {
-          release = () => resolve({ identities: [], listingComplete: true })
+          release = () => resolve({ identities: [], complete: true })
         })
     )
     const inFlight = refreshWorktreeHeadIdentities(
@@ -302,7 +304,7 @@ describe('refreshWorktreeHeadIdentities', () => {
 
     vi.mocked(readGitCommonHeadIdentities).mockImplementationOnce(async () => {
       windowState.destroyed = true
-      return { identities: [identity('bbb')], listingComplete: true }
+      return { identities: [identity('bbb')], complete: true }
     })
     await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
 
@@ -399,7 +401,7 @@ describe('refreshWorktreeHeadIdentities', () => {
 
     vi.mocked(readGitCommonHeadIdentities).mockImplementationOnce(async () => {
       host.disposed = true
-      return { identities: [identity('bbb')], listingComplete: true }
+      return { identities: [identity('bbb')], complete: true }
     })
     await refreshWorktreeHeadIdentities(host, state, true, headIdentityScopeForEntry('wt-a'))
 

--- a/src/main/ipc/worktree-head-identity-refresh.ts
+++ b/src/main/ipc/worktree-head-identity-refresh.ts
@@ -89,12 +89,15 @@ export async function refreshWorktreeHeadIdentities(
     state.queuedEmit ||= emit
     return
   }
+  // Resolve BEFORE the skip: an empty scope is still an opportunity to take the
+  // periodic re-baseline, and a repo whose only churn is `git worktree
+  // lock`/`unlock` or a sparse toggle must not be able to starve it forever.
+  const effectiveScope = resolveScope(state, scope)
   // Nothing the burst touched can move a head (a `locked` or `config.worktree`
-  // write), and the baseline is already established: read nothing.
-  if (state.baseline !== null && isEmptyHeadIdentityScope(scope)) {
+  // write) and no re-baseline is due: read nothing.
+  if (state.baseline !== null && isEmptyHeadIdentityScope(effectiveScope)) {
     return
   }
-  const effectiveScope = resolveScope(state, scope)
   state.inFlight = true
   try {
     const identities = await readGitCommonHeadIdentities(host.path, state.cache, effectiveScope)

--- a/src/main/ipc/worktree-head-identity-refresh.ts
+++ b/src/main/ipc/worktree-head-identity-refresh.ts
@@ -28,15 +28,16 @@ export type WorktreeHeadIdentityRefreshState = {
   inFlight: boolean
   queuedScope: WorktreeHeadIdentityScope | null
   queuedEmit: boolean
+  /** One-shot catch-up armed only by a scoped pass; see `scheduleRebaseline`. */
+  rebaselineTimer: ReturnType<typeof setTimeout> | null
 }
 
 // Why: a ref can move with no event under any admin dir — `git update-ref
 // refs/heads/x` from a sibling worktree appends no HEAD reflog for the worktree
 // that has `x` checked out (verified on git 2.44). Scoped refreshes cannot see
-// that, so promote back to a full re-read on the first refresh that runs once
-// this interval has elapsed. This is opportunistic, not a timer: it caps the
-// cost of staying correct at one full read per interval of watcher activity,
-// but a fully idle repo still refreshes nothing at all (as it did before).
+// that, so a full re-read is forced this long after the last one, whether or
+// not another event arrives. This is also what bounds the blast radius of any
+// invalidation bug in the scoping itself.
 export const HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS = 60_000
 
 export function createWorktreeHeadIdentityRefreshState(): WorktreeHeadIdentityRefreshState {
@@ -46,8 +47,43 @@ export function createWorktreeHeadIdentityRefreshState(): WorktreeHeadIdentityRe
     lastFullReadAtMs: 0,
     inFlight: false,
     queuedScope: null,
-    queuedEmit: false
+    queuedEmit: false,
+    rebaselineTimer: null
   }
+}
+
+export function disposeWorktreeHeadIdentityRefreshState(
+  state: WorktreeHeadIdentityRefreshState
+): void {
+  clearTimeout(state.rebaselineTimer ?? undefined)
+  state.rebaselineTimer = null
+}
+
+/** Arms the one-shot catch-up that turns "stale until some later event happens
+ *  to arrive" into "stale at most one interval". Only a scoped pass arms it, so
+ *  the timer exists only after an event: an idle repo schedules nothing, and a
+ *  full pass disarms because nothing is outstanding after one. */
+function scheduleRebaseline(
+  host: HeadIdentityWatchHost,
+  state: WorktreeHeadIdentityRefreshState
+): void {
+  disposeWorktreeHeadIdentityRefreshState(state)
+  if (host.disposed || host.mainWindow.isDestroyed()) {
+    return
+  }
+  const dueInMs = Math.max(
+    0,
+    state.lastFullReadAtMs + HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS - Date.now()
+  )
+  const timer = setTimeout(() => {
+    state.rebaselineTimer = null
+    // `emit: true`: unlike a structural burst, nothing else runs alongside this
+    // to correct the drift, so a silent re-baseline would bury it forever.
+    void refreshWorktreeHeadIdentities(host, state, true, FULL_HEAD_IDENTITY_SCOPE)
+  }, dueInMs)
+  // Never hold the process open for a freshness backstop.
+  timer.unref?.()
+  state.rebaselineTimer = timer
 }
 
 function headIdentitySignature(identity: { head: string; branch: string | null }): string {
@@ -170,6 +206,12 @@ export async function refreshWorktreeHeadIdentities(
       // Leave the queue armed: if this call cannot proceed (destroyed window),
       // the next refresh folds it back in at the entry above.
       void refreshWorktreeHeadIdentities(host, state, state.queuedEmit, state.queuedScope)
+    } else if (effectiveScope.all) {
+      // A full pass just ran (or failed while running full — re-arming there
+      // would spin on a persistent fs error). Nothing is outstanding.
+      disposeWorktreeHeadIdentityRefreshState(state)
+    } else {
+      scheduleRebaseline(host, state)
     }
   }
 }

--- a/src/main/ipc/worktree-head-identity-refresh.ts
+++ b/src/main/ipc/worktree-head-identity-refresh.ts
@@ -156,7 +156,7 @@ export async function refreshWorktreeHeadIdentities(
   }
   state.inFlight = true
   try {
-    const { identities, listingComplete } = await readGitCommonHeadIdentities(
+    const { identities, complete } = await readGitCommonHeadIdentities(
       host.path,
       state.cache,
       effectiveScope
@@ -165,15 +165,15 @@ export async function refreshWorktreeHeadIdentities(
       return
     }
     // After the teardown check, so a read whose result is discarded cannot pass
-    // for a checkpoint. A read that could not enumerate `worktrees/` has not
-    // seen entries added since the last good listing, so it is not one either.
-    if (effectiveScope.all && listingComplete) {
+    // for a checkpoint. A read that could not enumerate `worktrees/`, or that hit
+    // an unreadable entry, has not observed the whole repo — not one either.
+    if (effectiveScope.all && complete) {
       state.lastFullReadAtMs = Date.now()
     }
     const baseline = state.baseline
     // Rows this pass could not observe are carried forward: dropping them would
     // make the next successful listing report every linked worktree as changed.
-    const nextBaseline = listingComplete ? new Map<string, string>() : new Map(baseline ?? [])
+    const nextBaseline = complete ? new Map<string, string>() : new Map(baseline ?? [])
     for (const identity of identities) {
       nextBaseline.set(identity.worktreePath, headIdentitySignature(identity))
     }

--- a/src/main/ipc/worktree-head-identity-refresh.ts
+++ b/src/main/ipc/worktree-head-identity-refresh.ts
@@ -33,8 +33,10 @@ export type WorktreeHeadIdentityRefreshState = {
 // Why: a ref can move with no event under any admin dir — `git update-ref
 // refs/heads/x` from a sibling worktree appends no HEAD reflog for the worktree
 // that has `x` checked out (verified on git 2.44). Scoped refreshes cannot see
-// that, so promote one refresh per interval back to a full re-read. This bounds
-// the blind window instead of relying on unrelated fleet churn to trip a scan.
+// that, so promote back to a full re-read on the first refresh that runs once
+// this interval has elapsed. This is opportunistic, not a timer: it caps the
+// cost of staying correct at one full read per interval of watcher activity,
+// but a fully idle repo still refreshes nothing at all (as it did before).
 export const HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS = 60_000
 
 export function createWorktreeHeadIdentityRefreshState(): WorktreeHeadIdentityRefreshState {
@@ -89,40 +91,73 @@ export async function refreshWorktreeHeadIdentities(
     state.queuedEmit ||= emit
     return
   }
+  // Why: the queued re-run below can be handed to a window that was destroyed
+  // mid-read (macOS recreates it while the watch lives on), and that call
+  // returns at the guard above. Fold anything still queued into this request so
+  // a stranded scope is never dropped on the floor.
+  const requestedScope = state.queuedScope
+    ? mergeHeadIdentityScopes(state.queuedScope, scope)
+    : scope
+  const requestedEmit = emit || state.queuedEmit
+  state.queuedScope = null
+  state.queuedEmit = false
   // Resolve BEFORE the skip: an empty scope is still an opportunity to take the
   // periodic re-baseline, and a repo whose only churn is `git worktree
   // lock`/`unlock` or a sparse toggle must not be able to starve it forever.
-  const effectiveScope = resolveScope(state, scope)
+  const effectiveScope = resolveScope(state, requestedScope)
   // Nothing the burst touched can move a head (a `locked` or `config.worktree`
   // write) and no re-baseline is due: read nothing.
+  //
+  // Load-bearing invariant behind the promotion above: an empty scope only ever
+  // reaches here from `structuralChange(repoIds, EMPTY)`, which populates
+  // `pendingStructure` for EVERY repo on this watch (`allRepoIds`), which forces
+  // `emit: false`. So a promoted re-baseline triggered by an empty-scope burst
+  // corrects the baseline silently and publishes nothing — safe precisely
+  // because the same flush already sent that watch's repos a catalog
+  // notification, and the renderer's authoritative listing carries the head.
   if (state.baseline !== null && isEmptyHeadIdentityScope(effectiveScope)) {
     return
   }
   state.inFlight = true
   try {
-    const identities = await readGitCommonHeadIdentities(host.path, state.cache, effectiveScope)
-    if (effectiveScope.all) {
-      state.lastFullReadAtMs = Date.now()
-    }
+    const { identities, listingComplete } = await readGitCommonHeadIdentities(
+      host.path,
+      state.cache,
+      effectiveScope
+    )
     if (host.disposed || host.mainWindow.isDestroyed()) {
       return
     }
+    // After the teardown check, so a read whose result is discarded cannot pass
+    // for a checkpoint. A read that could not enumerate `worktrees/` has not
+    // seen entries added since the last good listing, so it is not one either.
+    if (effectiveScope.all && listingComplete) {
+      state.lastFullReadAtMs = Date.now()
+    }
     const baseline = state.baseline
-    state.baseline = new Map(
-      identities.map((identity) => [identity.worktreePath, headIdentitySignature(identity)])
-    )
-    if (!baseline || !emit) {
-      return
+    // Rows this pass could not observe are carried forward: dropping them would
+    // make the next successful listing report every linked worktree as changed.
+    const nextBaseline = listingComplete ? new Map<string, string>() : new Map(baseline ?? [])
+    for (const identity of identities) {
+      nextBaseline.set(identity.worktreePath, headIdentitySignature(identity))
     }
-    const changed = identities.filter(
-      (identity) => baseline.get(identity.worktreePath) !== headIdentitySignature(identity)
-    )
-    if (changed.length === 0) {
-      return
-    }
-    for (const repoId of host.repos.keys()) {
+    // Why `emit: false` is safe to publish nothing: the only classification that
+    // reaches here with a head-moving scope and no emit is a structural burst,
+    // and structural bursts notify the worktree catalog for every repo on this
+    // watch — the renderer's authoritative listing carries the head. So a silent
+    // pass is always paired with a stronger refresh, never a dropped update.
+    const changed =
+      baseline && requestedEmit
+        ? identities.filter(
+            (identity) => baseline.get(identity.worktreePath) !== headIdentitySignature(identity)
+          )
+        : []
+    for (const repoId of changed.length > 0 ? host.repos.keys() : []) {
       notifyWorktreeHeadIdentitiesChanged(host.mainWindow, repoId, changed)
     }
+    // Last, so a send that throws part-way leaves the old baseline and the next
+    // refresh re-diffs instead of silently dropping the move.
+    state.baseline = nextBaseline
   } catch (error) {
     console.warn(`[worktree-base-watcher] head identity read failed for ${host.path}:`, error)
     // A failed read leaves the cache in an unknown state; force the next
@@ -132,11 +167,9 @@ export async function refreshWorktreeHeadIdentities(
   } finally {
     state.inFlight = false
     if (state.queuedScope && !host.disposed) {
-      const queuedScope = state.queuedScope
-      const queuedEmit = state.queuedEmit
-      state.queuedScope = null
-      state.queuedEmit = false
-      void refreshWorktreeHeadIdentities(host, state, queuedEmit, queuedScope)
+      // Leave the queue armed: if this call cannot proceed (destroyed window),
+      // the next refresh folds it back in at the entry above.
+      void refreshWorktreeHeadIdentities(host, state, state.queuedEmit, state.queuedScope)
     }
   }
 }

--- a/src/main/ipc/worktree-head-identity-refresh.ts
+++ b/src/main/ipc/worktree-head-identity-refresh.ts
@@ -1,6 +1,17 @@
 import type { BrowserWindow } from 'electron'
 import { notifyWorktreeHeadIdentitiesChanged } from './worktree-remote'
-import { readGitCommonHeadIdentities } from './worktree-head-identity-reader'
+import {
+  createWorktreeHeadIdentityCache,
+  readGitCommonHeadIdentities,
+  type WorktreeHeadIdentityCache
+} from './worktree-head-identity-reader'
+import {
+  EMPTY_HEAD_IDENTITY_SCOPE,
+  FULL_HEAD_IDENTITY_SCOPE,
+  isEmptyHeadIdentityScope,
+  mergeHeadIdentityScopes,
+  type WorktreeHeadIdentityScope
+} from './worktree-head-identity-scope'
 
 type HeadIdentityWatchHost = {
   path: string
@@ -12,40 +23,84 @@ type HeadIdentityWatchHost = {
 export type WorktreeHeadIdentityRefreshState = {
   /** worktreePath → `${head} ${branch}` from the last metadata-file read. */
   baseline: Map<string, string> | null
+  cache: WorktreeHeadIdentityCache
+  lastFullReadAtMs: number
   inFlight: boolean
-  queued: boolean
+  queuedScope: WorktreeHeadIdentityScope | null
   queuedEmit: boolean
 }
 
+// Why: a ref can move with no event under any admin dir — `git update-ref
+// refs/heads/x` from a sibling worktree appends no HEAD reflog for the worktree
+// that has `x` checked out (verified on git 2.44). Scoped refreshes cannot see
+// that, so promote one refresh per interval back to a full re-read. This bounds
+// the blind window instead of relying on unrelated fleet churn to trip a scan.
+export const HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS = 60_000
+
 export function createWorktreeHeadIdentityRefreshState(): WorktreeHeadIdentityRefreshState {
-  return { baseline: null, inFlight: false, queued: false, queuedEmit: false }
+  return {
+    baseline: null,
+    cache: createWorktreeHeadIdentityCache(),
+    lastFullReadAtMs: 0,
+    inFlight: false,
+    queuedScope: null,
+    queuedEmit: false
+  }
 }
 
 function headIdentitySignature(identity: { head: string; branch: string | null }): string {
   return `${identity.head} ${identity.branch ?? ''}`
 }
 
+function resolveScope(
+  state: WorktreeHeadIdentityRefreshState,
+  scope: WorktreeHeadIdentityScope
+): WorktreeHeadIdentityScope {
+  if (scope.all || state.baseline === null) {
+    return FULL_HEAD_IDENTITY_SCOPE
+  }
+  return Date.now() - state.lastFullReadAtMs >= HEAD_IDENTITY_FULL_REBASELINE_INTERVAL_MS
+    ? FULL_HEAD_IDENTITY_SCOPE
+    : scope
+}
+
 /** Diffs metadata-file head reads against the previous baseline and notifies
  *  only actual head moves, so status-only churn (index rewrites from external
  *  `git status`) stays silent and never re-enters structural fanout. Passing
  *  `emit: false` re-baselines without notifying — structural ticks already
- *  run the authoritative worktree listing. */
+ *  run the authoritative worktree listing.
+ *
+ *  `scope` narrows the read to the worktrees a watcher burst could have moved;
+ *  omitting it (watcher errors, event overflow, cold start) re-reads everything. */
 export async function refreshWorktreeHeadIdentities(
   host: HeadIdentityWatchHost,
   state: WorktreeHeadIdentityRefreshState,
-  emit: boolean
+  emit: boolean,
+  scope: WorktreeHeadIdentityScope = FULL_HEAD_IDENTITY_SCOPE
 ): Promise<void> {
   if (host.disposed || host.mainWindow.isDestroyed()) {
     return
   }
   if (state.inFlight) {
-    state.queued = true
+    state.queuedScope = mergeHeadIdentityScopes(
+      state.queuedScope ?? EMPTY_HEAD_IDENTITY_SCOPE,
+      scope
+    )
     state.queuedEmit ||= emit
     return
   }
+  // Nothing the burst touched can move a head (a `locked` or `config.worktree`
+  // write), and the baseline is already established: read nothing.
+  if (state.baseline !== null && isEmptyHeadIdentityScope(scope)) {
+    return
+  }
+  const effectiveScope = resolveScope(state, scope)
   state.inFlight = true
   try {
-    const identities = await readGitCommonHeadIdentities(host.path)
+    const identities = await readGitCommonHeadIdentities(host.path, state.cache, effectiveScope)
+    if (effectiveScope.all) {
+      state.lastFullReadAtMs = Date.now()
+    }
     if (host.disposed || host.mainWindow.isDestroyed()) {
       return
     }
@@ -67,13 +122,18 @@ export async function refreshWorktreeHeadIdentities(
     }
   } catch (error) {
     console.warn(`[worktree-base-watcher] head identity read failed for ${host.path}:`, error)
+    // A failed read leaves the cache in an unknown state; force the next
+    // refresh to re-read every entry rather than trust a partial memo.
+    state.cache = createWorktreeHeadIdentityCache()
+    state.lastFullReadAtMs = 0
   } finally {
     state.inFlight = false
-    if (state.queued && !host.disposed) {
+    if (state.queuedScope && !host.disposed) {
+      const queuedScope = state.queuedScope
       const queuedEmit = state.queuedEmit
-      state.queued = false
+      state.queuedScope = null
       state.queuedEmit = false
-      void refreshWorktreeHeadIdentities(host, state, queuedEmit)
+      void refreshWorktreeHeadIdentities(host, state, queuedEmit, queuedScope)
     }
   }
 }

--- a/src/main/ipc/worktree-head-identity-scope.ts
+++ b/src/main/ipc/worktree-head-identity-scope.ts
@@ -1,0 +1,90 @@
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+
+// Which slice of a Git common dir's head identities a watcher burst can have
+// moved. Absence of a scope always means "unknown" and must resolve to the full
+// scope — only an explicit, provable narrowing may skip a metadata read.
+
+export type WorktreeHeadIdentityScope = {
+  /** Re-enumerate `worktrees/`: an admin entry may have appeared or vanished. */
+  listing: boolean
+  /** Re-read the primary checkout's HEAD. */
+  primary: boolean
+  /** Re-read every entry: a global signal (packed-refs rewrite, lost events). */
+  all: boolean
+  /** Admin entry dir keys (see `headIdentityEntryKey`) whose head may have moved. */
+  entryNames: ReadonlySet<string>
+}
+
+const NO_ENTRY_NAMES: ReadonlySet<string> = new Set<string>()
+
+export const EMPTY_HEAD_IDENTITY_SCOPE: WorktreeHeadIdentityScope = Object.freeze({
+  listing: false,
+  primary: false,
+  all: false,
+  entryNames: NO_ENTRY_NAMES
+})
+
+export const FULL_HEAD_IDENTITY_SCOPE: WorktreeHeadIdentityScope = Object.freeze({
+  listing: true,
+  primary: true,
+  all: true,
+  entryNames: NO_ENTRY_NAMES
+})
+
+export const PRIMARY_HEAD_IDENTITY_SCOPE: WorktreeHeadIdentityScope = Object.freeze({
+  listing: false,
+  primary: true,
+  all: false,
+  entryNames: NO_ENTRY_NAMES
+})
+
+export const LISTING_HEAD_IDENTITY_SCOPE: WorktreeHeadIdentityScope = Object.freeze({
+  listing: true,
+  primary: false,
+  all: false,
+  entryNames: NO_ENTRY_NAMES
+})
+
+// Why: the watcher reports the admin dir name the OS gave it while the reader
+// uses its own `readdir` name. Fold NFC/NFD and case so the two always agree —
+// over-matching only costs one redundant read, under-matching loses an update.
+export function headIdentityEntryKey(name: string): string {
+  return normalizeRuntimePathForComparison(name).toLowerCase()
+}
+
+export function headIdentityScopeForEntry(name: string): WorktreeHeadIdentityScope {
+  return {
+    listing: false,
+    primary: false,
+    all: false,
+    entryNames: new Set([headIdentityEntryKey(name)])
+  }
+}
+
+export function mergeHeadIdentityScopes(
+  first: WorktreeHeadIdentityScope,
+  second: WorktreeHeadIdentityScope
+): WorktreeHeadIdentityScope {
+  if (first.all) {
+    return first
+  }
+  if (second.all) {
+    return second
+  }
+  if (second.entryNames.size === 0 && !second.listing && !second.primary) {
+    return first
+  }
+  if (first.entryNames.size === 0 && !first.listing && !first.primary) {
+    return second
+  }
+  return {
+    listing: first.listing || second.listing,
+    primary: first.primary || second.primary,
+    all: false,
+    entryNames: new Set([...first.entryNames, ...second.entryNames])
+  }
+}
+
+export function isEmptyHeadIdentityScope(scope: WorktreeHeadIdentityScope): boolean {
+  return !scope.all && !scope.listing && !scope.primary && scope.entryNames.size === 0
+}

--- a/src/main/runtime/external-worktree-paired-client-discovery.integration.test.ts
+++ b/src/main/runtime/external-worktree-paired-client-discovery.integration.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { listWorktrees, listWorktreesStrict } from '../git/worktree'
 import { scheduleWorktreeBaseNotification } from '../ipc/worktree-base-directory-notifications'
 import { createWorktreeHeadIdentityRefreshState } from '../ipc/worktree-head-identity-refresh'
+import { EMPTY_HEAD_IDENTITY_SCOPE } from '../ipc/worktree-head-identity-scope'
 import { setWorktreeCatalogRemoteClientNotifier } from '../ipc/watched-worktree-catalog-notification'
 import { OrcaRuntimeService } from './orca-runtime'
 import {
@@ -166,6 +167,7 @@ describe('external worktree discovery for paired clients', () => {
       pendingStructureRepoIds: new Set<string>(),
       pendingGitStatusRepoIds: new Set<string>(),
       pendingHeadIdentityRepoIds: new Set<string>(),
+      pendingHeadIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE,
       headIdentityRefresh: createWorktreeHeadIdentityRefreshState(),
       disposed: false
     }
@@ -352,6 +354,7 @@ describe('external worktree discovery for paired clients', () => {
       pendingStructureRepoIds: new Set<string>(),
       pendingGitStatusRepoIds: new Set<string>(),
       pendingHeadIdentityRepoIds: new Set<string>(),
+      pendingHeadIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE,
       headIdentityRefresh: createWorktreeHeadIdentityRefreshState(),
       disposed: false
     }
@@ -437,6 +440,7 @@ describe('external worktree discovery for paired clients', () => {
       pendingStructureRepoIds: new Set<string>(),
       pendingGitStatusRepoIds: new Set<string>(),
       pendingHeadIdentityRepoIds: new Set<string>(),
+      pendingHeadIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE,
       headIdentityRefresh: createWorktreeHeadIdentityRefreshState(),
       disposed: false
     }
@@ -493,6 +497,7 @@ describe('external worktree discovery for paired clients', () => {
       pendingStructureRepoIds: new Set<string>(),
       pendingGitStatusRepoIds: new Set<string>(),
       pendingHeadIdentityRepoIds: new Set<string>(),
+      pendingHeadIdentityScope: EMPTY_HEAD_IDENTITY_SCOPE,
       headIdentityRefresh: createWorktreeHeadIdentityRefreshState(),
       disposed: false
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1092 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​47 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1045 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​623 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​108 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​515 |

<!-- /orca-pr-loc -->

## ELI5

When you commit in one worktree, Orca used to re-read the head/branch of **every** worktree in the repo to find out what changed. On a checkout with ~1,000 worktrees that is ~2,800 file reads (~1 second of main-process disk work) — and it ran on every commit anywhere, so a busy fleet of agents kept the main process in a permanent scan loop.

The file-watcher already tells us *which* worktree's metadata changed. Now we use that: re-read only the worktrees that could have moved, and remember the rest. A commit in one worktree costs 2 file reads instead of 2,816.

## What Changed

New `src/main/ipc/worktree-head-identity-scope.ts` defines a `WorktreeHeadIdentityScope` (`listing` / `primary` / `all` / `entryNames`) describing which slice of a Git common dir's head identities a watcher burst could have moved.

- **`worktree-base-directory-event-filter.ts`** — every git-common event classification now also states a head-identity scope (see the invalidation table below).
- **`worktree-base-directory-change-collector.ts` / `-notifications.ts`** — scopes union across a burst and across the 250ms debounce window. A caller that omits the scope (watcher failure, event overflow) widens to the full scope, never narrows.
- **`worktree-head-identity-reader.ts`** — `readGitCommonHeadIdentities(commonDir, cache?, scope?)` memoizes per-entry identities and re-reads only what the scope names. Defaults are unchanged behaviour (full read, throwaway cache), so every existing call site and test keeps working.
- **`worktree-head-identity-refresh.ts`** — owns the cache, merges scopes for the queued single-flight re-run, skips the read entirely when the burst provably moved no head, and promotes one refresh per 60s back to a full re-read.
- **`worktree-base-directory-watcher.ts`** — `ActiveWatch` now derives from `WorktreeBaseNotificationWatch` instead of restating its fields.

### Invalidation triggers (each one defended)

| Watcher event | Scope | Why that is safe |
|---|---|---|
| `worktrees/<n>/logs/HEAD` | entry `<n>` | Git appends this on every head move made *through* that worktree. |
| `worktrees/<n>/HEAD` | entry `<n>` | Branch switch / detach in that worktree only. |
| `worktrees/<n>/gitdir` | entry `<n>` | `git worktree move` — changes that worktree's path only. |
| `worktrees/<n>` create/delete | listing **+** entry `<n>` | Re-enumerate. The entry name is added too: a remove+add reusing one admin name coalesces into a single refresh, and listing alone would keep serving the removed worktree's cached head. |
| `worktrees/` itself | **full** | `git worktree prune` can delete and a later add recreate the dir; the native stream is bound to the old inode, so nothing is trusted. |
| `packed-refs` | **full** | A repack can move any branch oid with no event under any admin dir. |
| primary `HEAD`, `logs/HEAD` | primary | Only the primary checkout's head. |
| `worktrees/<n>/locked`, `config.worktree` | **empty** (no read at all) | `git worktree lock` and the sparse flag are structural for the listing but cannot move a head. |
| `index`, `config`, upstream refs | **empty** | Status tier; an index rewrite cannot move HEAD (pre-existing invariant). |
| watcher failure / event overflow / cold start / read error | **full** | Loss of knowledge must widen, never narrow. |

Three more safety properties, all tested:

1. **Misses are never memoized.** An unresolvable read (mid-`git worktree add`, transient EIO) is retried on the next refresh rather than remembered as "no identity".
2. **Shared-branch replay.** `git worktree add --force` lets several worktrees hold one branch, and only the committing one gets a HEAD reflog append. Every ref resolved during a pass is replayed onto cached entries pointing at it — no extra reads, and if the ref stopped resolving those entries are dropped rather than served stale.
3. **Bounded blind window.** Verified on git 2.44: `git update-ref refs/heads/x <oid>` run from a sibling worktree appends **no** HEAD reflog for the worktree that has `x` checked out, so no scoped signal exists. A scoped pass therefore arms a one-shot, unref'd timer that forces one full re-baseline 60s after the last full read and then disarms — bounding staleness at 60s whether or not another event ever arrives, with zero cost on an idle repo. See the Review section.

## Why

Fixes the "Make head-identity refresh incremental" workstream in #17828 — the worst *steady-state* offender in that audit.

`readGitCommonHeadIdentities` was O(worktrees) in main-process fs I/O and ran on both head-identity events (`logs/HEAD` appends — i.e. **every commit in any of the 973 worktrees**) and structural events, behind a 250ms debounce and a single-flight with a queued re-run. Under fleet-wide agent activity the queued re-run re-armed before the previous scan finished, so it degenerated into a continuous ~1.1s scan loop that never let the process idle.

The existing mitigations were all "make the O(n) scan cheaper or less frequent" — parallelised reads (30ca6bc953b), the debounce, the single-flight. This extends them with the one thing they were missing: the watcher events already carry *which* path changed, so the scan does not have to be O(n) at all.

Alternative considered and rejected: stat-gating each entry's `HEAD`/`gitdir` and skipping unchanged ones. That is still an O(worktrees) fan-out (989 stats) into a 4-thread libuv pool — the same class of problem #17828 flags elsewhere — for a ~3x win instead of ~1,400x.

## User-Facing Regressions

One, and it is a genuine narrowing — an earlier draft of this PR described it as "unchanged from before", which was wrong.

- A ref moved with **no watched filesystem write** — `git update-ref` from a sibling worktree, or similar raw plumbing — is reflected in the sidebar's head/branch after up to the 60s re-baseline interval. Previously the next event anywhere in the repo corrected it in ~1.5s. Ordinary commits, checkouts, amends, rebases and `git worktree add`/`remove` all write watched paths and are scoped correctly, so they are unaffected.

Better than before in one direction: the event-then-total-silence case was previously **unbounded** (the old code had no timer either), and the one-shot catch-up timer now bounds it at 60s.

Also worth naming: a latent cache-invalidation bug would now persist until the next full-scope pass rather than being corrected on the next refresh. The 60s re-baseline is what bounds that blast radius, which is part of why it is load-bearing.

**Not a regression:** one full ~1.1s metadata read per 60s of activity, versus the same read per event before.

## Linked Issue

Refs #17828

## Visual Proof

`N/A` — no UI change. This is a main-process fs-I/O change behind the existing `worktrees:head-identities-changed` IPC notification; the payload shape, the renderer apply path (`worktree-head-identity-apply.ts`), and what the sidebar renders are all untouched. The user-visible effect is that the same updates arrive without the main process burning a CPU-second per commit.

## Performance

Measured on the reporter's real checkout (`~/projects/orca`, **989 linked worktree admin entries**, 80k refs, 4.1 MB `packed-refs`, 12 GB `.git`), macOS 15 / APFS / M-series, read-only.

**File I/O per refresh** (page-cache independent — the honest number):

| Refresh shape | `readFile` | `readdir` |
|---|---|---|
| **before** — full re-read, every event | **2,846** | 1 |
| after — commit in one worktree | **2** | 0 |
| after — 20-worktree debounce burst + primary | 59 | 0 |
| after — external `git worktree add` / `remove` | 0 | 1 |

Re-measured against the final code after all review fixes. (The checkout grew from 989 to 995 admin entries between the wall-clock run below and this one, which is why the "before" count moved with it.)

**Wall clock**, 30 interleaved iterations in one process so both sides see identical page-cache state:

| Refresh shape | p50 | p95 | max |
|---|---|---|---|
| **before** — full re-read, every event | **60.9 ms** | 133.5 ms | 180.5 ms |
| after — commit in one worktree | **0.52 ms** | 8.9 ms | 9.1 ms |
| after — 20-worktree burst | 9.7 ms | 12.9 ms | 17.3 ms |
| after — `git worktree add` / `remove` | 1.0 ms | 1.4 ms | 1.5 ms |

Those "before" numbers are the *warm-page-cache floor*. With a realistic cache the same full read measured **1234 / 943 / 913 / 903 / 548 ms** across five runs in a fresh process — matching the 1.08 s recorded in #17828. So the steady-state saving is between 120x (fully warm) and ~1,800x (realistic), and the 60s re-baseline caps the worst case at roughly one full read per minute instead of one per event.

The scoped p95 of ~9 ms is the `packed-refs` parse: a worktree whose branch tip is packed rather than loose costs one 4.1 MB parse for that pass. It is deliberately not cached across passes — an 80k-entry ref map is ~20 MB resident per repo, which is a bad trade for a tail that is already 100x better than the thing it replaced.

No new timers, no new watchers, no new subprocesses. Read concurrency stays at 8 and now applies to a far smaller set, so libuv threadpool pressure strictly decreases.

## Testing

- `pnpm tc` — clean
- `pnpm test src/main/ipc src/main/runtime/external-worktree-paired-client-discovery.integration.test.ts` — **354 files / 3,533 tests passing**, 1 skipped
- `pnpm run check:code-quality:changed` — 0 new findings across 12 changed files (native, type-aware, React Doctor)
- `pnpm exec oxlint src/main` — clean, including `max-lines` (no disables added; `ActiveWatch` was deduped against `WorktreeBaseNotificationWatch` to stay under the limit)

New tests, one per invalidation trigger, against a real temp-dir Git metadata fixture:

- `worktree-head-identity-reader-incremental.test.ts` (20) — cold start; commit in one worktree (and proof the others are *not* re-read); branch switch; external `worktree add`; external `worktree remove`; admin name removed and immediately reused; `packed-refs` rewrite **with a negative control showing a narrow scope misses it**; checkout deleted behind Orca's back; shared-branch replay (linked↔linked and primary↔linked, proven memo-only by making the sibling unreadable); ref that stopped resolving; misses never memoized; relocated `gitdir`; a scope naming an entry the memo lacks; case folding and NFC/NFD normalization; transient `readdir` failure vs. genuinely absent `worktrees/`.
- `worktree-head-identity-refresh.test.ts` (16, new) — cold start forces full; narrowed scope forwarded once a baseline exists; empty scope performs **zero** reads; 60s promotion; **an empty-scope burst still takes the promotion once the interval elapses (with the reachable `emit: false` pairing), and re-arms it**; a read that could not enumerate does not arm the clock; a read discarded by teardown does not arm it either; queued scopes merge rather than drop; a queued scope stranded by a destroyed window is folded back in; an incomplete listing carries forward unobserved baseline rows; a throwing notify leaves the move to be retried; read failure forces a full re-read; no emit for a window torn down mid-read; **the catch-up runs with no further events at all; a quiet repo issues zero background reads and the timer disarms after firing rather than becoming a poll; disposal stops it.**
- `worktree-base-directory-change-collector.test.ts` (5, new) — overflow states FULL; scopes union across a burst; one `packed-refs` write widens the whole burst; a burst that can move no head keeps the scope empty; a rename scopes both sides.
- `worktree-base-directory-event-filter.test.ts` — every classification now asserts its scope, plus a new case for the `worktrees/` root.
- `worktree-base-directory-watcher.test.ts` — end-to-end: a linked `logs/HEAD` event reaches the reader with exactly that entry's scope; a watcher failure reaches it with the full scope; a `locked` write performs no read at all.

Real-git sanity check (not just synthetic fixtures) — a throwaway repo with five linked worktrees on git 2.44, one detached and one sharing `feat-1` with `wt-1` via `git worktree add --force`. Cold read, then a real `git commit` in `wt-1`, then one refresh scoped to `{wt-1}`:

```
COLD main            a8d7254f refs/heads/master
COLD wt-1            a8d7254f refs/heads/feat-1
COLD wt-2            a8d7254f refs/heads/feat-2
COLD wt-3            a8d7254f refs/heads/feat-3
COLD wt-detached     a8d7254f (detached)
COLD wt-shared       a8d7254f refs/heads/feat-1
--- committed in wt-1; refreshing with scope = {wt-1}
WARM main            a8d7254f refs/heads/master
WARM wt-1            7ad68812 refs/heads/feat-1   <- moved
WARM wt-2            a8d7254f refs/heads/feat-2
WARM wt-3            a8d7254f refs/heads/feat-3
WARM wt-detached     a8d7254f (detached)
WARM wt-shared       7ad68812 refs/heads/feat-1   <- moved via the shared-branch replay, zero extra reads
```

Platforms actually tested: **macOS 15 (arm64) only** — unit/integration suites plus the read-only benchmark against the real 989-worktree checkout. Linux and Windows are **not** hand-tested; they are covered by CI and by the path handling being unchanged (`join`/`basename`/`dirname` throughout, entry names always sourced from `readdir` rather than from event strings, and event↔readdir name matching folded through the existing `normalizeRuntimePathForComparison` so NFC/NFD and case-insensitive volumes agree). SSH is unaffected by construction: `supportsWorktreeHeadIdentityRefresh` still requires `kind === 'git-common' && !connectionId`, so remote watches never enter this path — verified by the existing "never reads head identities for SSH watches" test. Folder workspaces use the `base` watch kind and likewise never enter it.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 (Claude Code)

## Review

Three adversarial review seats plus the PR's bot reviewers ran against this branch. **Ten real defects were found and fixed before merge; none shipped. Every fix carries a test verified to fail without it** (checked by reverting each fix in isolation and confirming exactly one test goes red).

### The one that mattered most

The 60s full-rebaseline promotion — the entire mechanism bounding the "ref moved with zero events under this admin dir" blind spot — was **unreachable whenever the triggering burst had an empty head-identity scope.** The skip guarded on the raw caller-supplied `scope` and returned *before* `resolveScope` ran, so `lastFullReadAtMs` was never re-evaluated:

```ts
// before — broken
if (state.baseline !== null && isEmptyHeadIdentityScope(scope)) { return }
const effectiveScope = resolveScope(state, scope)

// after
const effectiveScope = resolveScope(state, scope)
if (state.baseline !== null && isEmptyHeadIdentityScope(effectiveScope)) { return }
```

Not exotic: `git worktree lock`/`unlock` and the `config.worktree` sparse toggle all classify to the empty scope and all still trigger a refresh — and Orca's own prepared-checkout flow locks and unlocks on every create. A repo dominated by that churn could starve the promotion indefinitely.

The original suite could not catch it: it tested the empty-scope skip without advancing time, and tested interval promotion with a non-empty scope, but never combined them. It now does — and, on review feedback, tests the *reachable* pairing (`emit: false`, not `emit: true`; production can never produce `emit: true` with an empty scope, because the only producer of an empty scope is `structuralChange`, which always populates `pendingStructure`, which forces `emit: false`).

That invariant is now documented at the guard, because it is the whole reason a silent re-baseline is safe: `emit === false` is exactly equivalent to "a catalog notification fired in the same flush for every repo on this watch" (`allRepoIds` returns all of `target.repos`), and the renderer's authoritative listing carries the head.

### The rest

| # | Defect | Fix |
|---|---|---|
| 2 | The refresh layer inferred "enumeration failed" from `cache.entryNames === null` — a reader-owned field whose null *also* means "cold start". Fragile in production, inexpressible in a mock. | `readGitCommonHeadIdentities` returns `{ identities, listingComplete }`. |
| 3 | A read discarded by teardown still armed the 60s freshness clock. | Arm it after the teardown check, and only when `listingComplete`. |
| 4 | A queued refresh whose re-run met a destroyed window (macOS recreates it while the watch lives on) was cleared and dropped on the floor. | The queue stays armed and is folded into the next request. |
| 5 | An incomplete listing replaced the baseline wholesale, so recovery reported every linked worktree as changed. | Carry forward the rows the pass could not observe. |
| 6 | `state.baseline` advanced before notifying, so a send into destroyed chrome lost the move for the un-notified repos. | Advance the baseline last. |
| 7 | `scope.entryNames` was a silent no-op for a name absent from the memoized listing — safe only because `diffGitCommon` happens to emit a dir-level create for a new entry. | An unknown named entry forces a re-enumeration, removing the unstated dependency. |
| 8 | Overflow relied on a downstream `?? FULL` catching an *absent* field, while `emptyChanges()` materialised it as a present `EMPTY`. One refactor from silently converting "we lost every event" into "nothing moved". | `overflowChanges()` states FULL at the construction site. |
| 9 | A `git worktree remove` + `add` reusing one admin dir name inside a debounce window produced a listing-only scope, keeping the removed worktree's cached head. | Entry create/delete names the entry as well as the listing. |
| 10 | A non-`ENOENT` `readdir` failure re-cached the *stale* listing, deferring an add/remove reported in that same burst. | Drop the memoized listing on failure so the next refresh re-enumerates. |

Two tests were also strengthened after a seat showed they could not distinguish the behaviour they claimed: the `packed-refs` test gained a negative control (a narrow scope demonstrably *misses* the repack), and "follows a shared branch **without re-reading them**" now makes the sibling's metadata unreadable, so it only passes if the sibling really was replayed from the memo rather than re-read.

### Round three: bot reviewers

Two reviewers independently flagged the same real defect, and it was a violation of a rule this repo already writes down.

**Transient read failures were treated as absence.** `readTrimmedFile` collapsed every errno to `null`, so an `EIO`/`EACCES`/`ENFILE` on a `gitdir`, `HEAD`, loose ref, or `packed-refs` read was indistinguishable from the file being absent — and the caller deletes the cached identity on `null`. That is the same conflation `AGENTS.md` forbids for the SSH execution boundary, where "loss of contact is never evidence of process death". Fixed in `ff70acd08e5`: reads report three outcomes, and an unknown keeps the entry's last verified identity, is never replayed onto siblings sharing the branch as "this ref is gone", marks the entry unverified so the next pass re-reads it whatever its scope, and reports the pass incomplete so it cannot arm the freshness clock. (`listingComplete` became `complete` accordingly.)

One correction for the record, since it changed the triage: the *stated* consequence — that an evicted entry stays evicted until the next full pass — did not hold. `staleNames` already contains `!cache.entries.has(name)`, so an evicted entry was re-read on the next pass of any scope; misses were deliberately never memoized. The real cost was that a single `EMFILE` evicted every entry it touched and the next pass re-read all of them — the ~2,846-read full scan this PR exists to eliminate, plus a spurious re-publish of every row. A failure-path performance regression and a vocabulary bug rather than stale UI, but a defect either way.

The third bot comment asked for the re-baseline to be scheduled independently of watcher events; that is the one-shot timer already landed in `8f1871c351a` (see above). The `resolveScope` report is marked resolved by its author.

### Reviewed and deliberately kept

- **A ref that stopped resolving evicts every cached row on it**, including rows the pass never read. A seat flagged this as evicting good data. Kept, and now commented: if the ref really is gone those oids are stale, and a transient miss is indistinguishable from a real deletion. Eviction costs a re-read; keeping would serve a head we can no longer justify. Confirmed on review to cause **no UI flicker** — an evicted row is simply absent from `identities`, so it is never in `changed` and never published; the renderer keeps its last value until the next pass restores it (`worktrees:head-identities-changed` only ever carries updates, never removals).
- **A second memo of `worktrees/` alongside `worktree-git-common-polling.ts`'s.** Flagged under AGENTS.md "Reuse Before Reimplementing", and a fair hit on its face. Rejected because the poller is not an always-current source on the platforms that matter: on macOS/Linux/Windows the narrow native watch is the fast path and `startGitCommonPolling` only runs as the **30s reconciliation backstop**, so binding head identity to it would make head freshness 30s stale on every supported desktop. The reader needs to enumerate on demand; the shared thing is the *policy* (ENOENT is authoritative-empty, anything else keeps the previous listing), which is deliberately mirrored with a comment pointing at the original.

### No residual staleness — the catch-up is a timer now

An earlier revision of this PR shipped the re-baseline as *opportunistic*: it rode the next refresh. A reviewer correctly pushed back that this is a **real narrowing**, not merely a pre-existing gap. Pre-PR, a ref move that writes no watched path (`git update-ref refs/heads/x` from a sibling worktree, raw plumbing) was corrected by the *very next event anywhere in the repo* — ~250ms debounce plus a full read, call it ~1.5s. Opportunistically it would have been corrected only by the first refresh occurring after the interval: a stale commit hash on that sidebar row for up to 60s under continuous activity.

That is now closed. `refreshWorktreeHeadIdentities` arms a **one-shot, unref'd timer** when a *scoped* pass completes, firing one full re-baseline an interval after the last full read, then disarming:

- **A full pass disarms rather than arms.** Nothing is outstanding after a full read, so the timer can never become a recurring background poll. (Also why a full pass that *failed* does not re-arm — that would spin on a persistent fs error.)
- **The timer only exists after an event.** An idle repo schedules nothing and reads nothing, so this does not reintroduce the continuous background work #17828 exists to remove.
- **It emits.** Unlike a structural burst, nothing else runs alongside a timer-driven re-baseline to correct the drift, so a silent one would bury it forever.
- Cleared on watch disposal.

Cost: O(1) timer per *active* repo and at most one full read per interval — the same operation the old code ran on **every event**, 60x rarer. And it strictly improves on pre-PR behaviour: "stale until the next event that happens to arrive" becomes "stale at most one interval, period", which also closes the event-then-total-silence case that was open before this PR.

This is also what bounds the blast radius of any *undiscovered* invalidation bug in the scoping itself. Pre-PR, any such bug was bounded to one refresh because every refresh read everything; with scoping, the catch-up is the thing that keeps the bound finite. That is the strongest argument for it being a timer rather than a hope.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security** — unchanged. The ref-name safety checks (`isSafeRefName`, `OBJECT_ID_PATTERN`) and the "never emit non-hex content" invariant are untouched. The one new value derived from a watcher event string is the entry-name Set key, which is used *only* for set membership; every filesystem path is still built from `readdir` names, so a crafted event path cannot steer a read.
- **Cross-platform** — see Testing. No new platform branches.
- **Remote SSH** — not reachable from this path (gated on `!connectionId`).
- **Mobile** — no mobile-facing surface touched; nothing in `mobile/` imports any changed symbol.
- **Backwards compatibility** — no persisted state, no schema, no wire format, no IPC payload change. The cache is process-local and per-watch, dropped with the watch.
- **Performance** — see the Performance section.

### Deliberately not done

- Did not touch the 250ms debounce, the single-flight, or the 2s poll cadence — all still load-bearing, and this change composes with them.
- Did not memoize the parsed `packed-refs` map across refreshes (memory, see Performance).
- Did not widen the watch to `logs/refs/**`, which would catch the `update-ref`-from-a-sibling case exactly but reintroduces the ref-scale fanout #17828 is trying to kill. The one-shot 60s catch-up is the bounded answer instead.
- Did not address the other #17828 workstreams (prewarm hit rate, `pack-refs` maintenance, leaked `pr-*` remotes, the sparse-checkout annotation, `findRemoteNameForUrl`).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
