### PR TITLE
fix(daemon): stop malformed control and hello frames killing the daemon

### DIFF
--- a/src/main/daemon/daemon-client-connections.ts
+++ b/src/main/daemon/daemon-client-connections.ts
@@ -39,6 +39,12 @@ type DaemonClientConnectionOptions = {
  * The minimum a control frame must carry to be routable: an `id` the reply can be
  * correlated against. Anything else is undispatchable, not merely unknown — an unknown
  * method still gets an error reply, but only if we know where to send it.
+ *
+ * The narrowing asserts *routability, not method validity*, and stopping at `id` is
+ * deliberate: `type` belongs to `DaemonRequestRouter.route`, which ends its switch with
+ * `throw new Error('Unknown request type: …')` and so answers a bad method with a reply.
+ * Checking `type` here would demote that reply to a silent drop, which is the one outcome
+ * a client cannot debug.
  */
 export function isDispatchableRequest(message: unknown): message is DaemonRequest {
   return (

--- a/src/main/daemon/daemon-client-connections.ts
+++ b/src/main/daemon/daemon-client-connections.ts
@@ -118,6 +118,16 @@ export class DaemonClientConnections {
   }
 
   private handleFirstMessage(socket: Socket, message: unknown): void {
+    // The same unchecked cast as the control parser had, one frame earlier and before any
+    // token is checked: `JSON.parse('null')` is a valid frame, and reading `.type` off it
+    // threw synchronously inside the socket's `data` handler — an uncaught exception, so
+    // the daemon died before it could reject the hello.
+    if (typeof message !== 'object' || message === null) {
+      this.options.log.log('client-hello-rejected', { reason: 'not-an-object' })
+      socket.write(encodeNdjson({ type: 'hello', ok: false, error: 'Expected hello' }))
+      socket.destroy()
+      return
+    }
     const hello = message as HelloMessage
     if (hello.type !== 'hello') {
       this.options.log.log('client-hello-rejected', { reason: 'expected-hello' })

--- a/src/main/daemon/daemon-client-connections.ts
+++ b/src/main/daemon/daemon-client-connections.ts
@@ -35,6 +35,20 @@ type DaemonClientConnectionOptions = {
   onStreamDisconnected: (clientId: string) => void
 }
 
+/**
+ * The minimum a control frame must carry to be routable: an `id` the reply can be
+ * correlated against. Anything else is undispatchable, not merely unknown — an unknown
+ * method still gets an error reply, but only if we know where to send it.
+ */
+export function isDispatchableRequest(message: unknown): message is DaemonRequest {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    typeof (message as { id?: unknown }).id === 'string' &&
+    (message as { id: string }).id.length > 0
+  )
+}
+
 export class DaemonClientConnections {
   private readonly clients = new Map<string, ConnectedDaemonClient>()
   private readonly transportSockets = new Set<Socket>()
@@ -197,7 +211,21 @@ export class DaemonClientConnections {
   private setupControlParser(socket: Socket, clientId: string): void {
     const decoder = new StringDecoder('utf8')
     const parser = createNdjsonParser(
-      (message) => this.options.onControlRequest(socket, clientId, message as DaemonRequest),
+      (message) => {
+        // `as DaemonRequest` asserted a shape nothing had checked: the parser hands through
+        // any parsed JSON, `null` included. One frame without a usable `id` was enough to
+        // take the daemon down — and the daemon is the process kept alive precisely so
+        // terminals outlive everything else. Dropping is the only correlatable answer,
+        // since a reply needs the id the frame did not carry.
+        if (!isDispatchableRequest(message)) {
+          this.options.log.log('control-frame-dropped', {
+            clientId,
+            reason: 'missing-or-invalid-id'
+          })
+          return
+        }
+        this.options.onControlRequest(socket, clientId, message)
+      },
       () => {}
     )
     socket.removeAllListeners('data')

--- a/src/main/daemon/daemon-server-malformed-frame.test.ts
+++ b/src/main/daemon/daemon-server-malformed-frame.test.ts
@@ -133,6 +133,27 @@ describe('malformed control frames', () => {
   )
 
   it.skipIf(process.platform === 'win32')(
+    'error-replies rather than drops when the id is usable but the method is not',
+    async () => {
+      await startServer()
+      const control = await connectControl('control-1')
+
+      // The boundary stops at `id` on purpose. A frame carrying one is answerable, so an
+      // unknown or absent `type` belongs to the router and gets a reply — pinned here so
+      // that tightening `isDispatchableRequest` to check `type` fails loudly rather than
+      // quietly demoting these to drops.
+      for (const frame of [{ id: 'unknown-method', type: 'nope' }, { id: 'no-method' }]) {
+        control.write(encodeNdjson(frame))
+        expect(await nextFrame(control)).toMatchObject({
+          id: frame.id,
+          ok: false,
+          error: expect.stringContaining('Unknown request type')
+        })
+      }
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
     'returns rather than throwing when a caller bypasses the parser',
     async () => {
       await startServer()

--- a/src/main/daemon/daemon-server-malformed-frame.test.ts
+++ b/src/main/daemon/daemon-server-malformed-frame.test.ts
@@ -1,44 +1,32 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { connect, type Socket } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DaemonServer } from './daemon-server'
-import { DaemonClient } from './client'
 import { isDispatchableRequest } from './daemon-client-connections'
 import { getDaemonSocketPath } from './daemon-spawner'
+import { encodeNdjson } from './ndjson'
 import type { SubprocessHandle } from './session-subprocess-handle'
-import type { DaemonRequest } from './types'
+import { PROTOCOL_VERSION, type DaemonRequest } from './types'
 
-function createMockSubprocess(): SubprocessHandle {
-  let notifyExit: ((code: number) => void) | null = null
-  const exit = (): void => notifyExit?.(0)
-  return {
-    pid: 44444,
-    getForegroundProcess: () => null,
-    write() {},
-    resize() {},
-    kill: exit,
-    terminateOwnedTree: () => 'unavailable' as const,
-    forceKill: exit,
-    signal() {},
-    onData() {},
-    onExit(callback) {
-      notifyExit = callback
-    },
-    dispose() {}
-  }
+function unusedSubprocess(): SubprocessHandle {
+  throw new Error('Test must not create a PTY')
 }
 
 type DaemonServerPrivate = {
   handleRequest(socket: unknown, clientId: string, request: DaemonRequest): Promise<void>
 }
 
+/** Every shape the parser hands through that carries no id a reply could be correlated against. */
+const UNROUTABLE_FRAMES = [null, 42, 'string', [], {}, { type: 'ping' }, { id: 42 }, { id: '' }]
+
 /**
  * The daemon is the process deliberately kept alive so terminals outlive the runtime, the
  * supervisor and an update. Killing it destroys every terminal on the host — the same harm
  * `KillMode=process` exists to prevent, reached from the client side instead.
  *
- * A frame with no `id` used to do exactly that: the `.id` read sat one line above the
+ * A frame with no usable `id` used to do exactly that: the `.id` read sat one line above the
  * try/catch that was already there, so the TypeError escaped as an unhandled rejection and
  * the daemon's uncaughtException handler rethrew it.
  */
@@ -47,7 +35,7 @@ describe('malformed control frames', () => {
   let socketPath: string
   let tokenPath: string
   let server: DaemonServer
-  let client: DaemonClient | null = null
+  const sockets: Socket[] = []
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'daemon-malformed-frame-'))
@@ -56,39 +44,91 @@ describe('malformed control frames', () => {
   })
 
   afterEach(async () => {
-    client?.disconnect()
-    client = null
+    for (const socket of sockets.splice(0)) {
+      socket.destroy()
+    }
     await server?.shutdown()
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it.skipIf(process.platform === 'win32')(
-    'keeps serving after a frame with no usable id',
-    async () => {
-      server = new DaemonServer({
-        socketPath,
-        tokenPath,
-        spawnSubprocess: () => createMockSubprocess()
+  async function startServer(): Promise<void> {
+    server = new DaemonServer({ socketPath, tokenPath, spawnSubprocess: unusedSubprocess })
+    await server.start()
+  }
+
+  async function openSocket(): Promise<Socket> {
+    const socket = connect(socketPath)
+    sockets.push(socket)
+    await new Promise<void>((resolve, reject) => {
+      socket.once('connect', resolve)
+      socket.once('error', reject)
+    })
+    return socket
+  }
+
+  /** Reads exactly one NDJSON frame, so each step can await the daemon's own answer. */
+  function nextFrame(socket: Socket): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      socket.once('data', (data) => {
+        resolve(JSON.parse(data.toString().split('\n')[0]) as Record<string, unknown>)
       })
-      await server.start()
+      socket.once('error', reject)
+      socket.once('close', () => reject(new Error('closed before a frame arrived')))
+    })
+  }
+
+  async function connectControl(clientId: string): Promise<Socket> {
+    const socket = await openSocket()
+    socket.write(
+      encodeNdjson({
+        type: 'hello',
+        version: PROTOCOL_VERSION,
+        token: readFileSync(tokenPath, 'utf8').trim(),
+        clientId,
+        role: 'control'
+      })
+    )
+    expect(await nextFrame(socket)).toMatchObject({ type: 'hello', ok: true })
+    return socket
+  }
+
+  /** A ping round-trip is the proof of life: it needs the parser, the router and the reply. */
+  async function expectStillServing(socket: Socket, id: string): Promise<void> {
+    socket.write(encodeNdjson({ id, type: 'ping' }))
+    expect(await nextFrame(socket)).toMatchObject({ id, ok: true, payload: { pong: true } })
+  }
+
+  it.skipIf(process.platform === 'win32')(
+    'drops unroutable frames at the socket and keeps serving the same connection',
+    async () => {
+      await startServer()
+      const control = await connectControl('control-1')
+
+      // Fed as raw bytes through the real NDJSON parser, which is the boundary the guard
+      // sits on. Driving `handleRequest` directly would skip it entirely.
+      for (const frame of UNROUTABLE_FRAMES) {
+        control.write(`${JSON.stringify(frame)}\n`)
+      }
+
+      // "Nothing threw" would pass equally against a daemon that had already exited, so
+      // prove the same connection still round-trips after the malformed frames.
+      await expectStillServing(control, 'after-malformed')
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'returns rather than throwing when a caller bypasses the parser',
+    async () => {
+      await startServer()
       const daemon = server as unknown as DaemonServerPrivate
 
-      // Every shape the parser can hand through, `null` included — it casts whatever JSON
-      // parsed straight to DaemonRequest.
-      for (const frame of [null, undefined, {}, { type: 'write' }, { id: 42 }, { id: '' }]) {
+      // The parser guard cannot protect `handleRequest` from its in-process callers, so the
+      // id read carries its own guard. Without it the rejection escapes as an unhandled one.
+      for (const frame of [...UNROUTABLE_FRAMES, undefined]) {
         await expect(
           daemon.handleRequest({}, 'control-1', frame as unknown as DaemonRequest)
         ).resolves.toBeUndefined()
       }
-
-      // The assertion that matters. "No throw escaped" would pass equally against a daemon
-      // that had already exited cleanly, so prove it is still accepting connections and
-      // still doing work.
-      client = new DaemonClient({ socketPath, tokenPath })
-      await client.ensureConnected()
-      await expect(
-        client.request('createOrAttach', { sessionId: 'after-malformed', cols: 80, rows: 24 })
-      ).resolves.toMatchObject({ isNew: true })
     }
   )
 })
@@ -96,12 +136,9 @@ describe('malformed control frames', () => {
 describe('isDispatchableRequest', () => {
   // A reply has to be correlated against an id, so a frame without one is undispatchable
   // rather than merely unknown: an unknown method still gets an error reply.
-  it.each([null, undefined, 42, 'string', [], {}, { type: 'write' }, { id: 42 }, { id: '' }])(
-    'refuses %o',
-    (message) => {
-      expect(isDispatchableRequest(message)).toBe(false)
-    }
-  )
+  it.each([...UNROUTABLE_FRAMES, undefined])('refuses %o', (message) => {
+    expect(isDispatchableRequest(message)).toBe(false)
+  })
 
   it('accepts a frame carrying a non-empty string id', () => {
     expect(isDispatchableRequest({ id: 'notify_1', type: 'write' })).toBe(true)

--- a/src/main/daemon/daemon-server-malformed-frame.test.ts
+++ b/src/main/daemon/daemon-server-malformed-frame.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DaemonServer } from './daemon-server'
+import { DaemonClient } from './client'
+import { isDispatchableRequest } from './daemon-client-connections'
+import { getDaemonSocketPath } from './daemon-spawner'
+import type { SubprocessHandle } from './session-subprocess-handle'
+import type { DaemonRequest } from './types'
+
+function createMockSubprocess(): SubprocessHandle {
+  let notifyExit: ((code: number) => void) | null = null
+  const exit = (): void => notifyExit?.(0)
+  return {
+    pid: 44444,
+    getForegroundProcess: () => null,
+    write() {},
+    resize() {},
+    kill: exit,
+    terminateOwnedTree: () => 'unavailable' as const,
+    forceKill: exit,
+    signal() {},
+    onData() {},
+    onExit(callback) {
+      notifyExit = callback
+    },
+    dispose() {}
+  }
+}
+
+type DaemonServerPrivate = {
+  handleRequest(socket: unknown, clientId: string, request: DaemonRequest): Promise<void>
+}
+
+/**
+ * The daemon is the process deliberately kept alive so terminals outlive the runtime, the
+ * supervisor and an update. Killing it destroys every terminal on the host — the same harm
+ * `KillMode=process` exists to prevent, reached from the client side instead.
+ *
+ * A frame with no `id` used to do exactly that: the `.id` read sat one line above the
+ * try/catch that was already there, so the TypeError escaped as an unhandled rejection and
+ * the daemon's uncaughtException handler rethrew it.
+ */
+describe('malformed control frames', () => {
+  let dir: string
+  let socketPath: string
+  let tokenPath: string
+  let server: DaemonServer
+  let client: DaemonClient | null = null
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'daemon-malformed-frame-'))
+    socketPath = getDaemonSocketPath(dir)
+    tokenPath = join(dir, 'test.token')
+  })
+
+  afterEach(async () => {
+    client?.disconnect()
+    client = null
+    await server?.shutdown()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps serving after a frame with no usable id',
+    async () => {
+      server = new DaemonServer({
+        socketPath,
+        tokenPath,
+        spawnSubprocess: () => createMockSubprocess()
+      })
+      await server.start()
+      const daemon = server as unknown as DaemonServerPrivate
+
+      // Every shape the parser can hand through, `null` included — it casts whatever JSON
+      // parsed straight to DaemonRequest.
+      for (const frame of [null, undefined, {}, { type: 'write' }, { id: 42 }, { id: '' }]) {
+        await expect(
+          daemon.handleRequest({}, 'control-1', frame as unknown as DaemonRequest)
+        ).resolves.toBeUndefined()
+      }
+
+      // The assertion that matters. "No throw escaped" would pass equally against a daemon
+      // that had already exited cleanly, so prove it is still accepting connections and
+      // still doing work.
+      client = new DaemonClient({ socketPath, tokenPath })
+      await client.ensureConnected()
+      await expect(
+        client.request('createOrAttach', { sessionId: 'after-malformed', cols: 80, rows: 24 })
+      ).resolves.toMatchObject({ isNew: true })
+    }
+  )
+})
+
+describe('isDispatchableRequest', () => {
+  // A reply has to be correlated against an id, so a frame without one is undispatchable
+  // rather than merely unknown: an unknown method still gets an error reply.
+  it.each([null, undefined, 42, 'string', [], {}, { type: 'write' }, { id: 42 }, { id: '' }])(
+    'refuses %o',
+    (message) => {
+      expect(isDispatchableRequest(message)).toBe(false)
+    }
+  )
+
+  it('accepts a frame carrying a non-empty string id', () => {
+    expect(isDispatchableRequest({ id: 'notify_1', type: 'write' })).toBe(true)
+  })
+})

--- a/src/main/daemon/daemon-server-malformed-frame.test.ts
+++ b/src/main/daemon/daemon-server-malformed-frame.test.ts
@@ -117,6 +117,22 @@ describe('malformed control frames', () => {
   )
 
   it.skipIf(process.platform === 'win32')(
+    'survives a first frame that is not an object and keeps accepting new clients',
+    async () => {
+      await startServer()
+
+      // `null` never reached the id guard: the hello handler read `.type` off it first, and
+      // that throw is synchronous inside the socket's data handler — before any token check,
+      // so it needed no credentials at all.
+      const hostile = await openSocket()
+      hostile.write('null\n')
+      expect(await nextFrame(hostile)).toMatchObject({ type: 'hello', ok: false })
+
+      await expectStillServing(await connectControl('control-after-hostile'), 'after-hostile')
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
     'returns rather than throwing when a caller bypasses the parser',
     async () => {
       await startServer()

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -123,8 +123,17 @@ export class DaemonServer {
       },
       onLastAuthenticatedClientDisconnected: () =>
         this.lifecycle.onLastAuthenticatedClientDisconnected(),
-      onControlRequest: (socket, clientId, request) =>
-        void this.handleRequest(socket, clientId, request),
+      onControlRequest: (socket, clientId, request) => {
+        // Why a catch and not bare `void`: an unhandled rejection reaches the daemon's
+        // uncaughtException handler, which rethrows anything that is not a native PTY
+        // error. One escaping throw is therefore fatal to every terminal on the host.
+        void this.handleRequest(socket, clientId, request).catch((error: unknown) => {
+          this.log.log('control-request-failed', {
+            clientId,
+            message: error instanceof Error ? error.message : String(error)
+          })
+        })
+      },
       onControlReplaced: (clientId) => {
         this.preparations.cancelForClient(clientId)
         this.historySeedTransfers.clearOwner(clientId)
@@ -257,6 +266,13 @@ export class DaemonServer {
     clientId: string,
     request: DaemonRequest
   ): Promise<void> {
+    // Why `typeof` and not a bare `.id`: this read used to sit one line above the try
+    // below, so a frame without an `id` threw a TypeError that escaped as an unhandled
+    // rejection and killed the daemon — taking every running terminal with it. The try
+    // was already there; only this line was outside it.
+    if (typeof request?.id !== 'string' || request.id.length === 0) {
+      return
+    }
     const isNotify = request.id.startsWith(NOTIFY_PREFIX)
     try {
       const result = await this.requestRouter.route(clientId, request)


### PR DESCRIPTION
## ELI5

The terminal daemon is the process kept alive on purpose so your terminals survive
restarts and updates. One badly-formed message on its control socket killed it —
and every terminal on the machine with it. This makes it drop the bad message
instead.

## What Changed

Four guards across two frame paths, plus tests that drive a real daemon over a real
socket.

**The pre-auth one is the most serious, and was found during review of this PR:**

- **`daemon-client-connections.ts`, `handleFirstMessage`** — the *hello* handler
  carried the same unchecked cast one frame earlier: `const hello = message as
  HelloMessage; if (hello.type !== 'hello')`. `JSON.parse('null')` is a valid
  frame, so `.type` threw. Two things make this worse than the control-frame case:
  the throw is **synchronous** inside the socket's `data` handler — `onRecord` is
  invoked outside the `try` that wraps `JSON.parse` in
  `main-process-ndjson-framer.ts` — so it is an uncaught exception rather than a
  rejection; and it runs **before the token comparison**, so it needs no
  credentials. Anything that can open the socket could end every terminal on the
  host with one `null\n`. It is now rejected exactly as any other unusable first
  frame is: `Expected hello`, then destroy.

- **`daemon-client-connections.ts`** — new `isDispatchableRequest()` at the NDJSON
  boundary. `createNdjsonParser` hands through any parsed JSON, `null` included,
  and the callback asserted `as DaemonRequest` over it without checking anything.
  Frames with no usable `id` are now dropped and logged as `control-frame-dropped`
  with the client id.
- **`daemon-server.ts`, dispatch site** — `void this.handleRequest(...)` now
  carries a `.catch` that logs `control-request-failed`.
- **`daemon-server.ts`, `handleRequest`** — the `request.id` read is guarded with
  `typeof`, so the defect cannot return via a caller that bypasses the parser.

An unknown *method* still gets a proper error reply. That path was never broken.
Only an **unroutable** frame is dropped, and dropping is the only correlatable
answer available: a reply needs the `id` the frame did not carry.

## Why

`handleRequest` read `request.id` one line above a try/catch that was already
there:

```ts
const isNotify = request.id.startsWith(NOTIFY_PREFIX)   // outside the try
try { ... }
```

On a frame without an `id`, that throws a TypeError. It escaped as an unhandled
rejection, reached the daemon's `uncaughtException` handler, and was rethrown
because it is not a native PTY error. One malformed frame, every terminal gone.

Why three guards and not one: each of the three independently allowed it, and the
one that actually threw is the least likely to be the one a future caller hits.
Fixing only the parser would leave `handleRequest` throwing for anyone who calls
it directly; fixing only `handleRequest` would leave every other rejection in that
async chain still fatal, because reaching `uncaughtException` at all is what turns
a routine error into a host-wide outage.

## Linked Issue

Fixes #17841

## Visual Proof

`N/A` — daemon-internal protocol handling. No UI or interaction surface; the
user-visible effect is the absence of a crash.

## Testing

`src/main/daemon/daemon-server-malformed-frame.test.ts` starts a real
`DaemonServer` on a real unix socket, writes each malformed shape, and asserts the
daemon is still alive and still answers a well-formed request afterwards.

**Confirmed to fail against the pre-fix code before it was kept** — the test was
written against the unpatched server first and observed to take the daemon down,
so it is guarding the actual defect rather than restating the fix.

Platforms: developed and reproduced on Linux (Synology DSM). The code path is
platform-neutral — it is JSON parsing and promise handling, with no platform
branch. Not separately exercised on macOS or Windows.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 wrote the commits and this description. I reviewed them and ran the
verification on my own hardware.

## Review

- **Cross-platform:** no platform branches added or touched. Unix-socket vs named
  pipe transport is unchanged; the guards sit above the transport.
- **SSH/remote/local:** the control socket is local to the host. A remote client
  reaching the daemon through the relay goes through the same dispatch, so it gets
  the same protection.
- **Agents/integrations:** none. No agent-specific or provider-specific behaviour.
- **Performance:** one `typeof` check and one property read per control frame,
  against a code path that already parses JSON per frame. The `.catch` allocates
  only on rejection. Not measurable.
- **UI:** none.
- **Security:** the hello-frame case above was an **unauthenticated** denial of
  service against every terminal on the host — it precedes the token check, so
  socket reachability was the only requirement. The control-frame case needs an
  authenticated client. Both are closed. Drops are logged with the client id, a
  generated identifier rather than user content; the malformed payload itself is
  never logged.
- **Backwards compatibility:** a well-formed frame behaves identically. The only
  behaviour change is for frames that previously crashed the process.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Disjoint from my other open PRs — this touches only `src/main/daemon/`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

