### PR TITLE
fix(orcad): assert spawn-helper on darwin only, not on every non-Windows host

### DIFF
--- a/config/scripts/build-orcad-prebuilds.mjs
+++ b/config/scripts/build-orcad-prebuilds.mjs
@@ -177,10 +177,14 @@ function build() {
   copyFileSync(builtBinary, join(slotDir, 'pty.node'))
   console.log(`[orcad-prebuilds] stored ${slot}/pty.node`)
 
-  // Why spawn-helper ships too: on Unix node-pty posix_spawns build/Release/spawn-helper,
-  // so a slot without it installs cleanly and then fails ENOENT the first time a user
-  // opens a terminal. Windows has no spawn-helper.
-  if (process.platform !== 'win32') {
+  // Why darwin and not `!== 'win32'`: node-pty builds spawn-helper inside binding.gyp's
+  // `OS=="mac"` block and execs it only under `#if defined(__APPLE__)`, and the Orca patch
+  // adds only ldflags to the linux block. A macOS slot without the helper installs cleanly
+  // and then fails ENOENT the first time a user opens a terminal, so the throw stays for
+  // darwin. On Linux node-gyp never emits one, so the old guard threw on all four `linux-*`
+  // entries of MATRIX_SLOTS. Matches ensure-native-runtime.mjs and rebuild-native-deps.mjs,
+  // which were already darwin-only.
+  if (process.platform === 'darwin') {
     const helperSource = join(dirname(builtBinary), 'spawn-helper')
     if (!existsSync(helperSource)) {
       throw new Error(`[orcad-prebuilds] spawn-helper missing at ${helperSource}`)

--- a/src/main/daemon/daemon-launched-child.ts
+++ b/src/main/daemon/daemon-launched-child.ts
@@ -78,7 +78,7 @@ export async function launchDaemonChild(
       stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
       // Why: run the byte-identical relocated Orca.exe so the image path sits outside the updater's kill zone.
       ...(relocatedExecPath ? { execPath: relocatedExecPath } : {}),
-      // Why: run the fork as plain Node so Electron's GPU/display init can't interfere with node-pty's posix_spawn of the spawn-helper.
+      // Why: run the fork as plain Node so Electron's GPU/display init can't interfere with node-pty's PTY spawn (via spawn-helper on macOS, forked directly elsewhere).
       env: {
         ...process.env,
         ELECTRON_RUN_AS_NODE: '1',

--- a/src/main/orcad/node-pty-prebuilt-slot.test.ts
+++ b/src/main/orcad/node-pty-prebuilt-slot.test.ts
@@ -17,6 +17,14 @@ const LINUX_GLIBC: NativeHostAbi = {
   nodeAbi: '127'
 }
 
+const DARWIN_ARM64: NativeHostAbi = {
+  platform: 'darwin',
+  arch: 'arm64',
+  libc: 'none',
+  glibcVersion: null,
+  nodeAbi: '127'
+}
+
 const dirs: string[] = []
 const temp = (): string => {
   const dir = mkdtempSync(join(tmpdir(), 'orcad-slot-'))
@@ -48,15 +56,30 @@ describe('resolveOrcadPrebuildsDir', () => {
 })
 
 describe('installPrebuiltSlot', () => {
-  it('installs the slot binary and spawn-helper into build/Release', () => {
+  it('installs the slot binary, and no spawn-helper, on linux', () => {
     const prebuilds = temp()
     const nodePtyDir = temp()
+    // The fixture ships a helper deliberately: a real linux slot never does, and copying
+    // one anyway would recreate the premise that made every Linux host boot `degraded` —
+    // node-pty builds spawn-helper only under binding.gyp's `OS=="mac"` and execs it only
+    // under `#if defined(__APPLE__)`.
     stageSlot(prebuilds, 'linux-x64-glibc')
 
     const outcome = installPrebuiltSlot({ abi: LINUX_GLIBC, nodePtyDir, prebuildsDir: prebuilds })
 
-    expect(outcome).toEqual({ installed: true, slot: 'linux-x64-glibc', spawnHelper: true })
+    expect(outcome).toEqual({ installed: true, slot: 'linux-x64-glibc' })
     expect(existsSync(join(nodePtyDir, 'build', 'Release', 'pty.node'))).toBe(true)
+    expect(existsSync(join(nodePtyDir, 'build', 'Release', 'spawn-helper'))).toBe(false)
+  })
+
+  it('installs the spawn-helper executable on darwin, which is the one platform that execs it', () => {
+    const prebuilds = temp()
+    const nodePtyDir = temp()
+    stageSlot(prebuilds, 'darwin-arm64')
+
+    const outcome = installPrebuiltSlot({ abi: DARWIN_ARM64, nodePtyDir, prebuildsDir: prebuilds })
+
+    expect(outcome).toEqual({ installed: true, slot: 'darwin-arm64' })
     // Without the executable bit every spawn fails EACCES at the moment a user opens a terminal.
     const helper = statSync(join(nodePtyDir, 'build', 'Release', 'spawn-helper'))
     expect(helper.mode & 0o111).not.toBe(0)

--- a/src/main/orcad/node-pty-prebuilt-slot.ts
+++ b/src/main/orcad/node-pty-prebuilt-slot.ts
@@ -70,7 +70,8 @@ export function readPrebuiltSlotManifest(prebuildsDir: string): PrebuiltSlotMani
 }
 
 /**
- * Copy `<prebuilds>/<slot>/pty.node` (and `spawn-helper`) into node-pty's `build/Release`.
+ * Copy `<prebuilds>/<slot>/pty.node` (and, on macOS only, `spawn-helper`) into node-pty's
+ * `build/Release`.
  *
  * Refuses on an ABI mismatch instead of copying: a binary built for another
  * `NODE_MODULE_VERSION` cannot load, and installing it would replace a "no prebuilt"

--- a/src/main/orcad/node-pty-prebuilt-slot.ts
+++ b/src/main/orcad/node-pty-prebuilt-slot.ts
@@ -26,7 +26,7 @@ export type PrebuiltSlotManifest = {
 }
 
 export type PrebuiltSlotOutcome =
-  | { installed: true; slot: string; spawnHelper: boolean }
+  | { installed: true; slot: string }
   | {
       installed: false
       slot: string
@@ -103,18 +103,22 @@ export function installPrebuiltSlot(options: {
   mkdirSync(releaseDir, { recursive: true })
   copyFileSync(source, join(releaseDir, 'pty.node'))
 
-  // Why this matters as much as pty.node: on Unix node-pty posix_spawns
-  // build/Release/spawn-helper. Without it every spawn fails with ENOENT at the moment
-  // a user opens a terminal, long after the "install succeeded" line.
-  let spawnHelper = false
-  if (options.abi.platform !== 'win32') {
+  // macOS only, and the guard says so rather than saying `!== 'win32'`: node-pty builds
+  // spawn-helper inside its binding.gyp `OS=="mac"` block and its native pty.cc reads the
+  // helper path only under `#if defined(__APPLE__)`. A Linux host forks directly and never
+  // execs it, so no slot ships one and there is nothing to install. Asserting otherwise is
+  // what made every Linux deployment boot `degraded` before it was fixed in
+  // node-pty-precondition.ts, and the claim outliving the fix is how that comes back.
+  if (options.abi.platform === 'darwin') {
     const helperSource = join(prebuildsDir, slot, 'spawn-helper')
     if (existsSync(helperSource)) {
       const helperDest = join(releaseDir, 'spawn-helper')
       copyFileSync(helperSource, helperDest)
       chmodSync(helperDest, 0o755)
-      spawnHelper = true
     }
   }
-  return { installed: true, slot, spawnHelper }
+  // Why no spawnHelper in the outcome: nothing read it, and once the guard above became
+  // darwin-only its `false` meant "normal on Linux" rather than "something is wrong" —
+  // an inverted field nobody consumes is worse than no field.
+  return { installed: true, slot }
 }

--- a/src/main/orcad/node-pty-precondition.test.ts
+++ b/src/main/orcad/node-pty-precondition.test.ts
@@ -31,10 +31,12 @@ const realNodePtyLoads = ((): boolean => {
   if (!existsSync(REAL_PTY_NODE)) {
     return false
   }
-  // Why spawn-helper too: a slot without it is legitimately 'degraded', so a test that
-  // expects 'ok' has an unsatisfiable premise on a host that lacks it. CI has the
-  // binding but not the helper, which is what made the previous gate insufficient.
-  if (process.platform !== 'win32' && !existsSync(REAL_SPAWN_HELPER)) {
+  // Why darwin only: a macOS slot without the helper is legitimately 'degraded', so a test
+  // expecting 'ok' has an unsatisfiable premise there. Linux never ships one — node-pty
+  // builds spawn-helper only under binding.gyp's `OS=="mac"` — so demanding it here held
+  // this gate false on every Linux host and silently skipped the load-dependent tests on
+  // the one platform whose verdict this change is about.
+  if (process.platform === 'darwin' && !existsSync(REAL_SPAWN_HELPER)) {
     return false
   }
   const probe = spawnSync(process.execPath, ['-e', `require(${JSON.stringify(REAL_PTY_NODE)})`], {
@@ -210,14 +212,16 @@ describe('checkNodePtyPrecondition', () => {
    * daemon self-test reported a healthy pty-spawn round trip in the same output.
    */
   const stageLoadableNodePtyWithoutHelper = (): string | null => {
-    const built = join(REAL_NODE_PTY, 'build', 'Release', 'pty.node')
-    if (!existsSync(built)) {
-      // Unprepared checkout: the probe would be `blocked` before reaching the helper check,
-      // so the fixture cannot state anything about it.
+    if (!realNodePtyLoads) {
+      // Why realNodePtyLoads and not existsSync: both tests below assert a verdict reached
+      // only *after* the load probe succeeds, and CI ships a pty.node built for Electron's
+      // ABI — present, yet it fails to `require` under plain Node. Gating on existence would
+      // run them there against a `blocked` verdict, the exact trap this file's header
+      // documents.
       return null
     }
     const dir = stageNodePty()
-    cpSync(built, join(dir, 'build', 'Release', 'pty.node'))
+    cpSync(REAL_PTY_NODE, join(dir, 'build', 'Release', 'pty.node'))
     expect(existsSync(join(dir, 'build', 'Release', 'spawn-helper'))).toBe(false)
     return dir
   }
@@ -288,8 +292,9 @@ describe('checkNodePtyPrecondition', () => {
 
   // Why gated on the real binding: this asserts a LOAD outcome, so it needs a pty.node
   // built for the Node ABI. CI's shard never runs ensure-native-runtime, so the copy
-  // ENOENT'd there.
-  it.runIf(process.platform !== 'win32' && realNodePtyLoads)(
+  // ENOENT'd there. Why darwin: it passes no `abi`, so it reads the real host's — and off
+  // macOS a missing helper is now correctly `ok`, which the linux case above asserts.
+  it.runIf(process.platform === 'darwin' && realNodePtyLoads)(
     'degrades rather than blocks when only spawn-helper is missing',
     () => {
       // node-pty posix_spawns spawn-helper, so this host loads fine and then fails ENOENT

--- a/src/main/orcad/node-pty-precondition.test.ts
+++ b/src/main/orcad/node-pty-precondition.test.ts
@@ -203,6 +203,54 @@ describe('checkNodePtyPrecondition', () => {
     expect(verdict.reason).not.toBe('spawn_helper_missing')
   })
 
+  /**
+   * node-pty builds `spawn-helper` only inside its binding.gyp `OS=="mac"` block, and its
+   * native `pty.cc` reads the helper path only under `#if defined(__APPLE__)`. Requiring it
+   * on every non-Windows host made real Linux deployments boot `degraded` while their own
+   * daemon self-test reported a healthy pty-spawn round trip in the same output.
+   */
+  const stageLoadableNodePtyWithoutHelper = (): string | null => {
+    const built = join(REAL_NODE_PTY, 'build', 'Release', 'pty.node')
+    if (!existsSync(built)) {
+      // Unprepared checkout: the probe would be `blocked` before reaching the helper check,
+      // so the fixture cannot state anything about it.
+      return null
+    }
+    const dir = stageNodePty()
+    cpSync(built, join(dir, 'build', 'Release', 'pty.node'))
+    expect(existsSync(join(dir, 'build', 'Release', 'spawn-helper'))).toBe(false)
+    return dir
+  }
+
+  it('accepts a Linux host with no spawn-helper, which is every Linux host', () => {
+    const dir = stageLoadableNodePtyWithoutHelper()
+    if (!dir) {
+      return
+    }
+    const verdict = checkNodePtyPrecondition({
+      nodePtyDir: dir,
+      prebuildsDir: null,
+      abi: { ...detectNativeHostAbi(), platform: 'linux' }
+    })
+
+    expect(verdict.reason).not.toBe('spawn_helper_missing')
+    expect(verdict.status).toBe('ok')
+  })
+
+  it('still requires it on darwin, where node-pty actually execs it', () => {
+    const dir = stageLoadableNodePtyWithoutHelper()
+    if (!dir) {
+      return
+    }
+    const verdict = checkNodePtyPrecondition({
+      nodePtyDir: dir,
+      prebuildsDir: null,
+      abi: { ...detectNativeHostAbi(), platform: 'darwin' }
+    })
+
+    expect(verdict).toMatchObject({ status: 'degraded', reason: 'spawn_helper_missing' })
+  })
+
   it('blocks when node-pty is not resolvable at all', () => {
     const verdict = checkNodePtyPrecondition({ nodePtyDir: null, prebuildsDir: null })
     expect(verdict).toMatchObject({ status: 'blocked', reason: 'dependency_missing' })

--- a/src/main/orcad/node-pty-precondition.ts
+++ b/src/main/orcad/node-pty-precondition.ts
@@ -302,11 +302,14 @@ export function checkNodePtyPrecondition(
     }
   }
 
-  // Loaded. The remaining way terminals fail is spawn-time: node-pty posix_spawns
-  // build/Release/spawn-helper, and a missing one turns every terminal.create into ENOENT
-  // on a host that otherwise looks healthy. That is a degradation, not a boot blocker.
+  // Loaded. The remaining way terminals fail is spawn-time, but only on macOS: node-pty
+  // builds `spawn-helper` inside its binding.gyp `OS=="mac"` block and its native
+  // `pty.cc` reads the helper path only under `#if defined(__APPLE__)`, so a Linux host
+  // forks directly and never execs it. Guarding this on `!== 'win32'` made every Linux
+  // deployment boot `degraded` while its own daemon self-test reported a healthy
+  // pty-spawn round trip in the same output.
   const loadedDir = result.stdout.split(PROBE_OK_TOKEN)[1]?.trim().split('\n')[0]?.trim()
-  if (abi.platform !== 'win32') {
+  if (abi.platform === 'darwin') {
     const helper = join(loadedDir || join(nodePtyDir, 'build', 'Release'), 'spawn-helper')
     if (!isExecutableFile(helper)) {
       return {

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -82,9 +82,15 @@ export function resolveUnixShellPath(shellPath: string): string {
  * Why: when Electron packages the app via asar, the native spawn-helper
  * binary may lose its +x permission. This function detects and repairs
  * that so pty.spawn() does not fail with EACCES on first launch.
+ *
+ * macOS only. node-pty builds spawn-helper inside its binding.gyp `OS=="mac"` block and
+ * execs it only under `#if defined(__APPLE__)`; every other platform forks directly, so
+ * there is no such binary to repair. The guard used to read `!== 'win32'`, which was
+ * harmless here — the candidate loop simply found nothing — but it is the same false
+ * premise that made every Linux deployment boot `degraded` from the precondition check.
  */
 export function ensureNodePtySpawnHelperExecutable(): void {
-  if (didEnsureSpawnHelperExecutable || process.platform === 'win32') {
+  if (didEnsureSpawnHelperExecutable || process.platform !== 'darwin') {
     return
   }
   didEnsureSpawnHelperExecutable = true


### PR DESCRIPTION
## ELI5

Every Linux `orcad` boots reporting itself "degraded" because it can't find a file
called `spawn-helper`. node-pty only ever builds that file on macOS. The host was
fine; the check was wrong.

## What Changed

Five platform guards go from `!== 'win32'` to `=== 'darwin'`, plus one stale
comment and one stale docstring.

- **`node-pty-precondition.ts`** — the user-visible one. It returned `degraded` /
  `spawn_helper_missing` on every Linux host.
- **`node-pty-prebuilt-slot.ts`** — looked for a helper in each prebuild slot. The
  `spawnHelper` field is removed from the result rather than corrected: nothing
  read it, and once the guard is darwin-only its `false` means "normal on Linux",
  not "something is wrong". An inverted flag nobody consumes is worse than no flag.
- **`local-pty-utils.ts`** — `ensureNodePtySpawnHelperExecutable()`. Harmless in
  practice, since its candidate loop simply found nothing, but it is the same false
  premise and leaving one copy is how the other two grow back.
- **`daemon-launched-child.ts`** — a comment describing the fork as feeding
  "node-pty's posix_spawn of the spawn-helper", corrected for the same reason.
- **`node-pty-precondition.test.ts`** — `realNodePtyLoads`, the gate gating the
  load-dependent tests, carried the same premise. Because no Linux node-pty ships a
  helper, that gate was **false on every Linux host**, so those tests silently
  skipped on the one platform this PR is about. Found while auditing; see the
  Testing section.
- **`config/scripts/build-orcad-prebuilds.mjs`** — the worst of the set, and the
  only one that was a hard failure rather than a wrong verdict. It copied the
  helper on `!== 'win32'` and **threw** when it was absent, while
  `MATRIX_SLOTS` requires four `linux-*` slots — so building any Linux slot threw.
  The `throw` is kept for darwin, where it is real protection. Caught by Pullfrog;
  my own audit had grepped `src/` and not `config/`.

## Why

node-pty builds `spawn-helper` inside binding.gyp's `OS=="mac"` block, and its
native `pty.cc` reads the helper path only under `#if defined(__APPLE__)`. Every
other platform forks directly and never execs it. So on Linux the file is not
missing — it is not a thing that exists.

The contradiction was visible in a single run: the daemon's own self-test reported
a healthy pty-spawn round trip in the same output where the precondition check
called the host degraded. Two verdicts about one working host, and the operator
sees the wrong one.

Removing the `spawnHelper` field is the part worth a second look. It was in the
public shape of `installPrebuiltSlot`'s result; I checked and nothing anywhere
reads it, so this is dead surface rather than a behaviour change.

**macOS behaviour is deliberately unchanged.** A loadable node-pty with a missing
or non-executable helper is a real degradation there, and still reports as one.

## Linked Issue

Fixes #17844

## Visual Proof

`N/A` — startup precondition check. The visible change is a spurious "degraded"
warning no longer appearing on Linux; there is no UI surface.

## Testing

The precondition tests are split into a **linux case** asserting no helper is
required and a **darwin case** asserting the executable bit, so the two platforms
are pinned separately rather than by one guard that happens to pass.

**Confirmed to fail against the pre-fix code before they were kept.**

**What actually runs where, stated plainly.** The two new *precondition* tests
assert a verdict reached only after node-pty loads, so they are gated on
`realNodePtyLoads`. CI ships a `pty.node` built for *Electron's* ABI — present, but
it fails to `require` under plain Node — so on CI both return early rather than
assert. They execute on a host prepared with `ensure-native-runtime --runtime=node`,
which is where I ran them.

The unconditional coverage of this change is therefore the **prebuilt-slot tests**,
which are pure fixture-based and run everywhere: they pin that a linux slot installs
no helper and a darwin slot installs one with the executable bit.

An earlier revision of this branch gated that fixture on `existsSync(pty.node)`
instead. That would have run the tests on CI and compared against a `blocked`
verdict — a red CI, caused by the exact trap the file's own header comment
documents. Fixed in `89d4345` before any reviewer had to catch it.

The prebuilt-slot tests assert the darwin-only install path and that the result no
longer carries `spawnHelper`.

Platforms: verified on Linux (Synology DSM) against a built artifact — orcad boots
`ok` rather than `degraded`, with terminals working, which was already true before
and is now reported correctly. The darwin path is covered by test, not by hardware;
I don't have a Mac in the loop for this one, so a macOS reviewer's eye on that case
is welcome.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 wrote the commits and this description. I reviewed them and ran the
Linux verification.

## Review

- **Cross-platform:** this is entirely a cross-platform correctness fix. Windows is
  unaffected (previously excluded, still excluded). macOS keeps its existing
  assertion. Linux and other Unixes stop being held to a macOS-only requirement.
- **SSH/remote/local:** the same precondition runs for a relay deployed to a remote
  Linux host, so remote installs stop reporting a false degradation too.
- **Agents/integrations:** none — this is below the agent layer.
- **Performance:** strictly less work off macOS (a filesystem existence check and a
  chmod attempt are skipped).
- **UI:** the spurious degradation banner/warning no longer appears on Linux.
- **Security:** slightly narrower — `ensureNodePtySpawnHelperExecutable()` no
  longer attempts a `chmod` on non-macOS hosts. It never found a target there, so
  no behaviour is lost.
- **Backwards compatibility:** `installPrebuiltSlot`'s result drops `spawnHelper`.
  Verified no consumer exists in the tree.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Independent of my other open PRs — no shared files.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


