### PR TITLE
fix(build): settle the orcad watcher smoke on the child's ack, not its exit code

### DIFF
--- a/config/scripts/build-orcad.mjs
+++ b/config/scripts/build-orcad.mjs
@@ -286,20 +286,41 @@ async function smokeLoadWatcherChild() {
         child.kill('SIGKILL')
         resolve(`No 'subscribe-started' ack within 30s.\n${stderr.slice(0, 2000)}`)
       }, 30_000)
+      let settled = false
       const settle = (failure) => {
+        if (settled) {
+          return
+        }
+        settled = true
         clearTimeout(timer)
+        // Past the verdict the child's fate says nothing, so stop reading it as evidence
+        // and just reap it. Watching `exit` after this is what made a good build fail: the
+        // parent disconnects the instant it acks, a child that writes once more takes
+        // EPIPE on an unhandled 'error' and exits non-zero, and that was read as a load
+        // failure. It surfaces on slow hardware far more than on a fast one.
+        child.removeAllListeners('exit')
+        child.removeAllListeners('error')
+        if (child.connected) {
+          child.disconnect()
+        }
+        child.kill('SIGKILL')
         resolve(failure)
       }
       child.on('message', (message) => {
+        // The ack IS the verdict. It is emitted once the child's graph has resolved under
+        // plain Node, which is the only thing this gate claims to prove — deliberately
+        // before the native module is touched, so a build machine with no compiled
+        // @parcel/watcher still passes.
         if (message?.op === 'subscribe-started') {
-          child.disconnect()
+          settle(null)
         }
       })
       child.on('error', (error) => settle(`fork failed: ${error.message}`))
-      // Why exit and not disconnect: the child exits 0 on disconnect, so a non-zero code
-      // or a signal here is a load failure rather than a clean teardown.
+      // Only an exit BEFORE the ack is evidence: it means the graph never resolved.
       child.on('exit', (code, signal) =>
-        settle(code === 0 ? null : `exit code=${code} signal=${signal}\n${stderr.slice(0, 2000)}`)
+        settle(
+          `the child exited before acking: code=${code} signal=${signal}\n${stderr.slice(0, 2000)}`
+        )
       )
       child.send({ op: 'subscribe', id: 1, dir: probeDir, opts: {} })
     })

--- a/config/scripts/build-orcad.mjs
+++ b/config/scripts/build-orcad.mjs
@@ -293,10 +293,10 @@ async function smokeLoadWatcherChild() {
   })
   try {
     return await new Promise((resolve) => {
-      const timer = setTimeout(() => {
-        child.kill('SIGKILL')
-        resolve(`No 'subscribe-started' ack within 30s.\n${stderr.slice(0, 2000)}`)
-      }, 30_000)
+      const timer = setTimeout(
+        () => settle(`No 'subscribe-started' ack within 30s.\n${stderr.slice(0, 2000)}`),
+        30_000
+      )
       let settled = false
       const settle = (failure) => {
         if (settled) {
@@ -311,10 +311,30 @@ async function smokeLoadWatcherChild() {
         // failure. It surfaces on slow hardware far more than on a fast one.
         child.removeAllListeners('exit')
         child.removeAllListeners('error')
+        // The child outlives the verdict by a few ms, and an emitter with no 'error'
+        // listener throws on emit — so a stray kill/EPIPE error here would crash the build
+        // this function just passed.
+        child.on('error', () => {})
         if (child.connected) {
           child.disconnect()
         }
-        child.kill('SIGKILL')
+        // Why still wait for the exit we just stopped grading: the caller's `finally`
+        // removes probeDir and canaryDir, and a child that still holds a native watcher
+        // handle on either fails that rmSync with EBUSY/EPERM on Windows, where kill()
+        // only *starts* an asynchronous TerminateProcess. Only the timing is used; the
+        // code and signal are never read again. Bounded, so an unreapable child degrades
+        // to a leaked temp dir rather than a hung build.
+        if (child.exitCode === null && child.signalCode === null) {
+          const reaped = setTimeout(() => resolve(failure), 5_000)
+          child.once('exit', () => {
+            clearTimeout(reaped)
+            resolve(failure)
+          })
+          child.kill('SIGKILL')
+          return
+        }
+        // Already dead — usually the exit-before-ack failure, whose own `exit` event is
+        // what called this. Waiting for a second one would just burn the deadline.
         resolve(failure)
       }
       child.on('message', (message) => {
@@ -336,7 +356,15 @@ async function smokeLoadWatcherChild() {
       child.send({ op: 'subscribe', id: 1, dir: probeDir, opts: {} })
     })
   } finally {
-    rmSync(probeDir, { recursive: true, force: true })
-    rmSync(canaryDir, { recursive: true, force: true })
+    // Best-effort on purpose, matching removeWatcherCanaryDirectory: `force` only covers
+    // ENOENT, so a handle this smoke does not control could still surface EBUSY/EPERM.
+    // A leaked temp dir must never fail a build whose watcher child loaded cleanly.
+    for (const dir of [probeDir, canaryDir]) {
+      try {
+        rmSync(dir, { recursive: true, force: true })
+      } catch {
+        // Housekeeping only; the verdict above already stands.
+      }
+    }
   }
 }

--- a/config/scripts/build-orcad.mjs
+++ b/config/scripts/build-orcad.mjs
@@ -275,7 +275,18 @@ if (process.exitCode !== 1) {
  */
 async function smokeLoadWatcherChild() {
   const probeDir = mkdtempSync(join(tmpdir(), 'orcad-watcher-smoke-'))
-  const child = fork(WATCHER_OUT_FILE, [], { stdio: ['ignore', 'ignore', 'pipe', 'ipc'] })
+  // Why hand the child a canary dir instead of letting it make its own: the child only
+  // cleans up a self-made dir from an `exit` handler it registers *after* the canary's
+  // native subscribe resolves. That has not happened by the time the ack lands, and never
+  // happens at all on a machine with no compiled @parcel/watcher — the case this gate
+  // exists to pass. Either way the smoke leaks an empty orca-watcher-canary-* dir per
+  // build. ORCA_WATCHER_CANARY_DIR is the seam the real host uses for exactly this
+  // (see parcel-watcher-child-launch.ts); given one, the child leaves cleanup to us.
+  const canaryDir = mkdtempSync(join(tmpdir(), 'orcad-watcher-smoke-canary-'))
+  const child = fork(WATCHER_OUT_FILE, [], {
+    stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+    env: { ...process.env, ORCA_WATCHER_CANARY_DIR: canaryDir }
+  })
   let stderr = ''
   child.stderr?.on('data', (chunk) => {
     stderr += String(chunk)
@@ -326,5 +337,6 @@ async function smokeLoadWatcherChild() {
     })
   } finally {
     rmSync(probeDir, { recursive: true, force: true })
+    rmSync(canaryDir, { recursive: true, force: true })
   }
 }


### PR DESCRIPTION
## ELI5

The orcad build has a check that makes sure `@parcel/watcher` can load. That check
failed perfectly good builds about one run in three, because it waited to see how
the child process *died* instead of listening for the answer the child had already
given.

## What Changed

One file, `config/scripts/build-orcad.mjs`, in `smokeLoadWatcherChild()`:

- The gate now settles on the child's `subscribe-started` ack.
- `settle()` detaches the `exit` and `error` listeners, closes the IPC channel and
  reaps the child, so nothing after the verdict can overwrite it.
- A `settled` latch keeps the first verdict.
- An `exit` **before** the ack still fails, and the message says so explicitly.
- **The child is reaped before its temp dirs are removed.** Settling on the ack
  alone resolved while the child was still alive — and `kill()` only *starts* an
  asynchronous terminate on Windows — so the caller's `finally` could `rmSync`
  `probeDir`/`canaryDir` while the child still held native watcher handles on
  them. `force` covers only ENOENT and `maxRetries` defaults to 0, so that
  surfaces as EBUSY/EPERM and fails an otherwise good build: the exact class of
  flake this PR exists to remove, reintroduced by its own first draft. The old
  code was immune only by accident, because it resolved from the `exit` handler.
  The wait is bounded at 5s and skipped when the child is already dead, so an
  unreapable child leaks a temp dir rather than hanging the build.
- **The smoke owns the child's canary directory**, handed through the same seam
  the real host uses. Previously the child created its own and cleaned it from an
  `exit` handler registered only after the canary's native subscribe resolved —
  which never happens on a machine with no compiled `@parcel/watcher`, the case
  this gate exists to pass. Every build leaked an empty `orca-watcher-canary-*`.
- The ack timeout routes through `settle()` so the latch is genuinely
  authoritative, and temp cleanup is best-effort — housekeeping must never fail a
  build whose watcher child loaded cleanly.

## Why

The parent disconnected the IPC channel the instant the child acked. A child that
wrote once more after that took EPIPE on an unhandled `'error'` event and exited
non-zero — and the gate read that as "@parcel/watcher failed to load".

Nothing was wrong with the build. The verdict was already in when the ack arrived;
the gate just kept watching a process whose fate no longer meant anything. It
surfaces far more on slow hardware than fast, which is exactly the profile of a
race that reads as flake.

The ack is the real verdict: it is emitted once the child's module graph has
resolved under plain Node, which is all this gate claims to prove. It runs
deliberately *before* the native module is touched, so a build machine with no
compiled `@parcel/watcher` still passes.

A gate that fails good builds at this rate is worse than no gate, because it
teaches everyone to re-run it — and then it cannot catch the real failure either.

## Linked Issue

Fixes #17845

## Visual Proof

`N/A` — build tooling. No runtime or UI surface.

## Testing

The failure is a race, so the evidence is repetition rather than a unit test:

- Before: the orcad build failed at the watcher smoke step roughly one run in three
  on a Synology NAS (slow disk, modest CPU), passing on re-run with no changes.
- After: repeated builds on the same hardware settle on the ack every time.
- The genuine-failure path is still exercised: a child that exits before acking
  fails the gate with `the child exited before acking: code=... signal=...`.

Platforms: reproduced and fixed on Linux (Synology DSM). The script is
platform-neutral Node; the race is timing, not platform, so a slow Windows or
macOS runner would hit it too.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No automated test: this is a build script whose failure mode is a timing race
against a forked child. A test would either re-implement the race or assert the
listener wiring, and neither would have caught the original defect. The
verification above is repetition on the hardware that reproduced it.

## AI Disclosure

Claude Opus 5 wrote the commit and this description. I reviewed both and ran the
repeated builds.

## Review

- **Cross-platform:** platform-neutral Node (`child_process` fork + IPC). No
  platform branch added. `SIGKILL` on the reap is used on a child this script
  itself forked; on Windows Node maps it to a terminate, which is the intent.
- **SSH/remote/local:** build-time only; no runtime path.
- **Agents/integrations:** none.
- **Performance:** the verdict is reached at the ack rather than at exit, but the
  gate still waits (bounded at 5s) for the child to die before removing its temp
  dirs, so wall-clock is comparable to before rather than faster. An earlier
  revision of this description claimed a speedup; that was written against a
  draft that resolved without reaping, which is the bug fixed in `8b9d0e1217`.
- **UI:** none.
- **Security:** none. No new input is parsed and no new process is spawned — the
  child was already forked here.
- **Backwards compatibility:** a genuinely broken `@parcel/watcher` still fails the
  build. Only the false-negative path changes.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Independent of my other open PRs — single file, no shared surface.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

