### PR TITLE
perf(git): cache sparse-checkout annotation on worktree listing

### DIFF
--- a/src/main/git/remove-worktree-test-harness.ts
+++ b/src/main/git/remove-worktree-test-harness.ts
@@ -2,6 +2,7 @@ import { expect, type Mock } from 'vitest'
 
 import { clearGitCapabilityStateForTests } from './git-capability-state'
 import { _resetWorktreeScanCacheForTests } from './worktree'
+import { __resetSparseCheckoutStateCacheForTests } from './worktree-sparse-checkout-cache'
 
 export type MockResult = {
   error?: Error
@@ -89,6 +90,7 @@ export type WorktreeTrashMocks = {
 export function resetWorktreeRemovalState(trashMocks: WorktreeTrashMocks): void {
   clearGitCapabilityStateForTests()
   _resetWorktreeScanCacheForTests()
+  __resetSparseCheckoutStateCacheForTests()
   // Default: the checkout cannot be renamed aside, so removal deletes it in place.
   trashMocks.moveWorktreeDirectoryToTrashMock.mockReset()
   trashMocks.moveWorktreeDirectoryToTrashMock.mockResolvedValue(undefined)

--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -668,7 +668,7 @@ describe('removeWorktree sparse-checkout cache invalidation', () => {
   })
 
   it('drops the removed worktree path so a re-created worktree at the same path is re-detected', async () => {
-    await detectSparseCheckoutCached('/repo-feature')
+    await detectSparseCheckoutCached('/repo', '/repo-feature')
     expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(1)
 
     mockGitCommands({
@@ -690,7 +690,7 @@ branch refs/heads/feature/test
     // re-annotates every row it saw (including the untouched main worktree), caching a fresh entry
     // for `/repo`. Only the removed path's own entry must be gone, proven by a fresh stat call below.
     const statCallsBefore = statMock.mock.calls.length
-    expect(await detectSparseCheckoutCached('/repo-feature')).toBe(false)
+    expect(await detectSparseCheckoutCached('/repo', '/repo-feature')).toBe(false)
     expect(statMock.mock.calls.length).toBeGreaterThan(statCallsBefore)
   })
 })

--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -54,6 +54,10 @@ import {
 } from './remove-worktree-test-harness'
 
 import { removeWorktree, WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS } from './worktree'
+import {
+  __getSparseCheckoutStateCacheSizeForTests,
+  detectSparseCheckoutCached
+} from './worktree-sparse-checkout-cache'
 
 const mockGitCommands = createGitCommandMocker(gitExecFileAsyncMock)
 const getGitCalls = createGitCallReader(gitExecFileAsyncMock)
@@ -648,5 +652,45 @@ branch refs/heads/main
       ])
     )
     expect(calls).not.toContain('git worktree prune')
+  })
+})
+
+describe('removeWorktree sparse-checkout cache invalidation', () => {
+  beforeEach(() => {
+    resetWorktreeGitMocks({
+      gitExecFileAsyncMock,
+      gitExecFileSyncMock,
+      translateWslOutputPathsMock,
+      statMock,
+      readFileMock,
+      resolveGitDirMock
+    })
+  })
+
+  it('drops the removed worktree path so a re-created worktree at the same path is re-detected', async () => {
+    await detectSparseCheckoutCached('/repo-feature')
+    expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(1)
+
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      }
+    })
+
+    await removeWorktree('/repo', '/repo-feature', false, { deleteBranch: false })
+
+    // Why not assert size 0: the pre-removal `listWorktrees` lookup inside `performRemoveWorktree`
+    // re-annotates every row it saw (including the untouched main worktree), caching a fresh entry
+    // for `/repo`. Only the removed path's own entry must be gone, proven by a fresh stat call below.
+    const statCallsBefore = statMock.mock.calls.length
+    expect(await detectSparseCheckoutCached('/repo-feature')).toBe(false)
+    expect(statMock.mock.calls.length).toBeGreaterThan(statCallsBefore)
   })
 })

--- a/src/main/git/worktree-listing.ts
+++ b/src/main/git/worktree-listing.ts
@@ -19,7 +19,8 @@ import {
   normalizeLocalBranchRef
 } from './worktree-operation-options'
 import { areWorktreePathsEqual, translateWorktreePath } from './worktree-path-comparison'
-import { detectSparseCheckout, resolveGitCommonDir } from './worktree-sparse-state'
+import { detectSparseCheckoutCached } from './worktree-sparse-checkout-cache'
+import { resolveGitCommonDir } from './worktree-sparse-state'
 import { resolveGitDir } from './source-control/resolve-git-dir'
 
 const SPARSE_CHECKOUT_DETECTION_CONCURRENCY = 8
@@ -110,7 +111,7 @@ async function annotateSparseCheckoutStatus(
       if (!worktree || worktree.isBare || worktree.isSparse) {
         continue
       }
-      const isSparse = await detectSparseCheckout(worktree.path)
+      const isSparse = await detectSparseCheckoutCached(worktree.path)
       if (isSparse) {
         annotated[index] = { ...worktree, isSparse }
       }

--- a/src/main/git/worktree-listing.ts
+++ b/src/main/git/worktree-listing.ts
@@ -62,7 +62,7 @@ export async function listWorktreesUnshared(
     const visibleWorktrees = options.includeCreatePreparations
       ? worktrees
       : worktrees.filter((worktree) => !isWorktreeCreatePreparation(worktree))
-    return annotateSparseCheckoutStatus(visibleWorktrees)
+    return annotateSparseCheckoutStatus(repoPath, visibleWorktrees)
   } catch (err) {
     if (getErrorCode(err) === 'ENOENT') {
       try {
@@ -94,10 +94,11 @@ export async function listWorktreesStrict(
   const visibleWorktrees = options.includeCreatePreparations
     ? worktrees
     : worktrees.filter((worktree) => !isWorktreeCreatePreparation(worktree))
-  return annotateSparseCheckoutStatus(visibleWorktrees)
+  return annotateSparseCheckoutStatus(repoPath, visibleWorktrees)
 }
 
 async function annotateSparseCheckoutStatus(
+  repoPath: string,
   worktrees: GitWorktreeInfo[]
 ): Promise<GitWorktreeInfo[]> {
   const annotated = [...worktrees]
@@ -111,7 +112,7 @@ async function annotateSparseCheckoutStatus(
       if (!worktree || worktree.isBare || worktree.isSparse) {
         continue
       }
-      const isSparse = await detectSparseCheckoutCached(worktree.path)
+      const isSparse = await detectSparseCheckoutCached(repoPath, worktree.path)
       if (isSparse) {
         annotated[index] = { ...worktree, isSparse }
       }
@@ -254,7 +255,7 @@ export async function describeCreatedWorktree(
       return undefined
     }
   }
-  const [described] = await annotateSparseCheckoutStatus([
+  const [described] = await annotateSparseCheckoutStatus(repoPath, [
     {
       path: translateWorktreePath(created.topLevel, repoPath, options),
       head,

--- a/src/main/git/worktree-move.test.ts
+++ b/src/main/git/worktree-move.test.ts
@@ -65,8 +65,8 @@ describe('moveWorktree', () => {
 
   it('drops cached sparse-checkout state for both the old and new path', async () => {
     detectSparseCheckoutMock.mockResolvedValue(true)
-    await detectSparseCheckoutCached('/ws/cunner')
-    await detectSparseCheckoutCached('/ws/worktree-creation-spinner')
+    await detectSparseCheckoutCached('/repo', '/ws/cunner')
+    await detectSparseCheckoutCached('/repo', '/ws/worktree-creation-spinner')
     expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(2)
 
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
@@ -77,8 +77,8 @@ describe('moveWorktree', () => {
 
   it('drops cached sparse-checkout state for both paths even when the move fails', async () => {
     detectSparseCheckoutMock.mockResolvedValue(true)
-    await detectSparseCheckoutCached('/ws/cunner')
-    await detectSparseCheckoutCached('/ws/taken')
+    await detectSparseCheckoutCached('/repo', '/ws/cunner')
+    await detectSparseCheckoutCached('/repo', '/ws/taken')
 
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('fatal: destination exists'))
     await expect(moveWorktree('/repo', '/ws/cunner', '/ws/taken')).rejects.toThrow()

--- a/src/main/git/worktree-move.test.ts
+++ b/src/main/git/worktree-move.test.ts
@@ -5,12 +5,14 @@ const {
   gitExecFileAsyncMock,
   gitExecFileSyncMock,
   translateWslOutputPathsMock,
-  moveWorktreeDirectoryToTrashMock
+  moveWorktreeDirectoryToTrashMock,
+  detectSparseCheckoutMock
 } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
   gitExecFileSyncMock: vi.fn(),
   translateWslOutputPathsMock: vi.fn((output: string) => output),
-  moveWorktreeDirectoryToTrashMock: vi.fn()
+  moveWorktreeDirectoryToTrashMock: vi.fn(),
+  detectSparseCheckoutMock: vi.fn()
 }))
 
 vi.mock('./runner', () => ({
@@ -26,8 +28,17 @@ vi.mock('../worktree-trash', () => ({
   scheduleWorktreeTrashDeletion: vi.fn()
 }))
 
+vi.mock('./worktree-sparse-state', () => ({
+  detectSparseCheckout: detectSparseCheckoutMock,
+  resolveGitCommonDir: vi.fn()
+}))
+
 import { moveWorktree } from './worktree'
 import { registerWorktreeSuiteHooks } from './worktree-test-harness'
+import {
+  __getSparseCheckoutStateCacheSizeForTests,
+  detectSparseCheckoutCached
+} from './worktree-sparse-checkout-cache'
 
 registerWorktreeSuiteHooks()
 
@@ -50,5 +61,28 @@ describe('moveWorktree', () => {
     await expect(moveWorktree('/repo', '/ws/cunner', '/ws/taken')).rejects.toThrow(
       'destination exists'
     )
+  })
+
+  it('drops cached sparse-checkout state for both the old and new path', async () => {
+    detectSparseCheckoutMock.mockResolvedValue(true)
+    await detectSparseCheckoutCached('/ws/cunner')
+    await detectSparseCheckoutCached('/ws/worktree-creation-spinner')
+    expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(2)
+
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    await moveWorktree('/repo', '/ws/cunner', '/ws/worktree-creation-spinner')
+
+    expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(0)
+  })
+
+  it('drops cached sparse-checkout state for both paths even when the move fails', async () => {
+    detectSparseCheckoutMock.mockResolvedValue(true)
+    await detectSparseCheckoutCached('/ws/cunner')
+    await detectSparseCheckoutCached('/ws/taken')
+
+    gitExecFileAsyncMock.mockRejectedValueOnce(new Error('fatal: destination exists'))
+    await expect(moveWorktree('/repo', '/ws/cunner', '/ws/taken')).rejects.toThrow()
+
+    expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(0)
   })
 })

--- a/src/main/git/worktree-move.ts
+++ b/src/main/git/worktree-move.ts
@@ -23,8 +23,8 @@ export async function moveWorktree(
     // A failed move can still have rewritten one `.git` marker, so re-probe both paths.
     invalidateWslLinkedWorktreeGitRouting(oldPath)
     invalidateWslLinkedWorktreeGitRouting(newPath)
-    invalidateSparseCheckoutState(oldPath)
-    invalidateSparseCheckoutState(newPath)
+    invalidateSparseCheckoutState(repoPath, oldPath)
+    invalidateSparseCheckoutState(repoPath, newPath)
     bumpWorktreeScanGeneration(repoPath)
   }
 }

--- a/src/main/git/worktree-move.ts
+++ b/src/main/git/worktree-move.ts
@@ -2,6 +2,7 @@ import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
 import { invalidateWslLinkedWorktreeGitRouting } from './wsl-linked-worktree-git-routing'
 import { bumpWorktreeScanGeneration } from './worktree-scan-cache'
+import { invalidateSparseCheckoutState } from './worktree-sparse-checkout-cache'
 
 /**
  * Move a worktree with `git worktree move` (not `fs.rename`, which corrupts the
@@ -22,6 +23,8 @@ export async function moveWorktree(
     // A failed move can still have rewritten one `.git` marker, so re-probe both paths.
     invalidateWslLinkedWorktreeGitRouting(oldPath)
     invalidateWslLinkedWorktreeGitRouting(newPath)
+    invalidateSparseCheckoutState(oldPath)
+    invalidateSparseCheckoutState(newPath)
     bumpWorktreeScanGeneration(repoPath)
   }
 }

--- a/src/main/git/worktree-path-comparison.ts
+++ b/src/main/git/worktree-path-comparison.ts
@@ -2,18 +2,22 @@ import { posix, win32 } from 'node:path'
 import type { GitWorktreeExecOptions } from './worktree-operation-options'
 import { translateWslOutputPaths } from './runner'
 
+/** Normalize a worktree path for cross-platform comparison/keying: resolved, and case-folded on Windows syntax. */
+export function canonicalWorktreePath(pathValue: string, platform = process.platform): string {
+  return platform === 'win32' || looksLikeWindowsPath(pathValue)
+    ? win32.normalize(win32.resolve(pathValue)).toLowerCase()
+    : posix.normalize(posix.resolve(pathValue))
+}
+
 export function areWorktreePathsEqual(
   leftPath: string,
   rightPath: string,
   platform = process.platform
 ): boolean {
   if (platform === 'win32' || looksLikeWindowsPath(leftPath) || looksLikeWindowsPath(rightPath)) {
-    return (
-      win32.normalize(win32.resolve(leftPath)).toLowerCase() ===
-      win32.normalize(win32.resolve(rightPath)).toLowerCase()
-    )
+    return canonicalWorktreePath(leftPath, 'win32') === canonicalWorktreePath(rightPath, 'win32')
   }
-  return posix.normalize(posix.resolve(leftPath)) === posix.normalize(posix.resolve(rightPath))
+  return canonicalWorktreePath(leftPath, platform) === canonicalWorktreePath(rightPath, platform)
 }
 
 function looksLikeWindowsPath(pathValue: string): boolean {

--- a/src/main/git/worktree-removal.ts
+++ b/src/main/git/worktree-removal.ts
@@ -41,7 +41,7 @@ export async function removeWorktree(
     )
   } finally {
     invalidateWslLinkedWorktreeGitRouting(worktreePath)
-    invalidateSparseCheckoutState(worktreePath)
+    invalidateSparseCheckoutState(repoPath, worktreePath)
     bumpWorktreeScanGeneration(repoPath)
   }
 }

--- a/src/main/git/worktree-removal.ts
+++ b/src/main/git/worktree-removal.ts
@@ -23,6 +23,7 @@ import {
 import { areWorktreePathsEqual } from './worktree-path-comparison'
 import { assertWorktreeCleanForRemoval } from './worktree-removal-preflight'
 import { bumpWorktreeScanGeneration, listWorktrees } from './worktree-scan-cache'
+import { invalidateSparseCheckoutState } from './worktree-sparse-checkout-cache'
 
 /**
  * Remove a worktree.
@@ -40,6 +41,7 @@ export async function removeWorktree(
     )
   } finally {
     invalidateWslLinkedWorktreeGitRouting(worktreePath)
+    invalidateSparseCheckoutState(worktreePath)
     bumpWorktreeScanGeneration(repoPath)
   }
 }

--- a/src/main/git/worktree-sparse-checkout-cache.test.ts
+++ b/src/main/git/worktree-sparse-checkout-cache.test.ts
@@ -13,9 +13,20 @@ import {
   __getSparseCheckoutStateCacheSizeForTests,
   __resetSparseCheckoutStateCacheForTests,
   clearSparseCheckoutStateCache,
+  clearSparseCheckoutStateCacheForRepo,
   detectSparseCheckoutCached,
-  invalidateSparseCheckoutState
+  invalidateSparseCheckoutState,
+  onSparseCheckoutStateChanged
 } from './worktree-sparse-checkout-cache'
+
+const RECONCILE_WINDOW_MS = 5 * 60_000
+
+// A real setTimeout tick, not a faked one, to flush the microtask chain a background
+// stale-while-revalidate detect runs on without needing vi.useFakeTimers() (which would also
+// have to fake Date.now(), the thing these tests drive manually via the Date.now spy below).
+async function flushBackgroundRevalidation(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
 
 beforeEach(() => {
   detectSparseCheckoutMock.mockReset()
@@ -23,11 +34,11 @@ beforeEach(() => {
 })
 
 describe('detectSparseCheckoutCached', () => {
-  it('caches a detection result across repeated calls for the same path', async () => {
+  it('caches a detection result across repeated calls for the same repo+path', async () => {
     detectSparseCheckoutMock.mockResolvedValue(true)
 
-    expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(true)
-    expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(true)
+    expect(await detectSparseCheckoutCached('/repo', '/repo/wt-a')).toBe(true)
+    expect(await detectSparseCheckoutCached('/repo', '/repo/wt-a')).toBe(true)
 
     expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(1)
   })
@@ -37,64 +48,140 @@ describe('detectSparseCheckoutCached', () => {
       async (worktreePath: string) => worktreePath === '/repo/wt-sparse'
     )
 
-    expect(await detectSparseCheckoutCached('/repo/wt-sparse')).toBe(true)
-    expect(await detectSparseCheckoutCached('/repo/wt-full')).toBe(false)
+    expect(await detectSparseCheckoutCached('/repo', '/repo/wt-sparse')).toBe(true)
+    expect(await detectSparseCheckoutCached('/repo', '/repo/wt-full')).toBe(false)
     expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('scopes the cache by repo, so the same path under two repos is detected independently', async () => {
+    detectSparseCheckoutMock.mockResolvedValue(true)
+
+    expect(await detectSparseCheckoutCached('/repo-a', '/shared-mount/wt')).toBe(true)
+    expect(await detectSparseCheckoutCached('/repo-b', '/shared-mount/wt')).toBe(true)
+
+    expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats an equivalent path spelling (trailing slash, redundant segment) as the same cache entry', async () => {
+    detectSparseCheckoutMock.mockResolvedValue(true)
+
+    expect(await detectSparseCheckoutCached('/repo', '/repo/wt-a')).toBe(true)
+    expect(await detectSparseCheckoutCached('/repo', '/repo/./wt-a/')).toBe(true)
+
+    expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(1)
   })
 
   it('caches a false result too, so a worktree that stays non-sparse costs one detect', async () => {
     detectSparseCheckoutMock.mockResolvedValue(false)
 
-    expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(false)
-    expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(false)
+    expect(await detectSparseCheckoutCached('/repo', '/repo/wt-a')).toBe(false)
+    expect(await detectSparseCheckoutCached('/repo', '/repo/wt-a')).toBe(false)
 
     expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(1)
   })
 
-  it('re-detects once the reconcile window elapses, bounding staleness from unwitnessed external edits', async () => {
-    vi.useFakeTimers()
+  it('serves the stale value immediately past the reconcile window and corrects it in the background', async () => {
+    const nowSpy = vi.spyOn(Date, 'now')
     try {
-      detectSparseCheckoutMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+      nowSpy.mockReturnValue(1_000)
+      detectSparseCheckoutMock.mockResolvedValueOnce(false)
+      expect(await detectSparseCheckoutCached('/repo', '/repo/wt-a')).toBe(false)
 
-      expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(false)
-
-      // Just under the 5-minute reconcile window: still trusts the cached value.
-      vi.advanceTimersByTime(5 * 60_000 - 1)
-      expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(false)
+      // Just under the window: still trusts the cached value, no re-detect.
+      nowSpy.mockReturnValue(1_000 + RECONCILE_WINDOW_MS - 1)
+      expect(await detectSparseCheckoutCached('/repo', '/repo/wt-a')).toBe(false)
       expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(1)
 
-      // Past the window: re-detects and picks up the external toggle.
-      vi.advanceTimersByTime(2)
-      expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(true)
+      // Past the window: both calls return the (stale) cached value, and only one kicks a
+      // background re-detect. Read both without awaiting in between — the underlying function
+      // never suspends before returning the stale value, so two calls issued back-to-back in the
+      // same tick are the only reliable way to observe "both concurrent callers stay stale" without
+      // racing the background revalidation's own microtask.
+      nowSpy.mockReturnValue(1_000 + RECONCILE_WINDOW_MS + 1)
+      detectSparseCheckoutMock.mockResolvedValueOnce(true)
+      const firstPastWindow = detectSparseCheckoutCached('/repo', '/repo/wt-a')
+      const secondPastWindow = detectSparseCheckoutCached('/repo', '/repo/wt-a')
+      expect(await firstPastWindow).toBe(false)
+      expect(await secondPastWindow).toBe(false)
+      expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(2)
+
+      await flushBackgroundRevalidation()
+
+      // The corrected value is now served without needing another window to elapse.
+      expect(await detectSparseCheckoutCached('/repo', '/repo/wt-a')).toBe(true)
       expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(2)
     } finally {
-      vi.useRealTimers()
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('notifies the registered change listener only when a background revalidation flips the answer', async () => {
+    const listener = vi.fn()
+    onSparseCheckoutStateChanged(listener)
+    const nowSpy = vi.spyOn(Date, 'now')
+    try {
+      nowSpy.mockReturnValue(1_000)
+      detectSparseCheckoutMock.mockResolvedValueOnce(false)
+      await detectSparseCheckoutCached('/repo', '/repo/wt-a')
+
+      nowSpy.mockReturnValue(1_000 + RECONCILE_WINDOW_MS + 1)
+      detectSparseCheckoutMock.mockResolvedValueOnce(false)
+      await detectSparseCheckoutCached('/repo', '/repo/wt-a')
+      await flushBackgroundRevalidation()
+      expect(listener).not.toHaveBeenCalled()
+
+      nowSpy.mockReturnValue(1_000 + 2 * RECONCILE_WINDOW_MS + 2)
+      detectSparseCheckoutMock.mockResolvedValueOnce(true)
+      await detectSparseCheckoutCached('/repo', '/repo/wt-a')
+      await flushBackgroundRevalidation()
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledWith('/repo', '/repo/wt-a', true)
+    } finally {
+      nowSpy.mockRestore()
+      onSparseCheckoutStateChanged(undefined)
     }
   })
 })
 
 describe('invalidateSparseCheckoutState', () => {
-  it('drops only the named path, leaving other cached paths untouched', async () => {
+  it('drops only the named repo+path, leaving other cached paths untouched', async () => {
     detectSparseCheckoutMock.mockResolvedValue(true)
-    await detectSparseCheckoutCached('/repo/wt-a')
-    await detectSparseCheckoutCached('/repo/wt-b')
+    await detectSparseCheckoutCached('/repo', '/repo/wt-a')
+    await detectSparseCheckoutCached('/repo', '/repo/wt-b')
 
-    invalidateSparseCheckoutState('/repo/wt-a')
+    invalidateSparseCheckoutState('/repo', '/repo/wt-a')
     expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(1)
 
     detectSparseCheckoutMock.mockClear()
-    await detectSparseCheckoutCached('/repo/wt-a')
-    await detectSparseCheckoutCached('/repo/wt-b')
+    await detectSparseCheckoutCached('/repo', '/repo/wt-a')
+    await detectSparseCheckoutCached('/repo', '/repo/wt-b')
     expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(1)
     expect(detectSparseCheckoutMock).toHaveBeenCalledWith('/repo/wt-a')
   })
 })
 
-describe('clearSparseCheckoutStateCache', () => {
-  it('drops every cached path, matching the blunt clear-all used on any worktree-change notification', async () => {
+describe('clearSparseCheckoutStateCacheForRepo', () => {
+  it('drops only the named repo`s entries, leaving a sibling repo`s warm cache intact', async () => {
     detectSparseCheckoutMock.mockResolvedValue(true)
-    await detectSparseCheckoutCached('/repo/wt-a')
-    await detectSparseCheckoutCached('/repo/wt-b')
+    await detectSparseCheckoutCached('/repo-a', '/repo-a/wt-1')
+    await detectSparseCheckoutCached('/repo-b', '/repo-b/wt-1')
+    expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(2)
+
+    clearSparseCheckoutStateCacheForRepo('/repo-a')
+    expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(1)
+
+    detectSparseCheckoutMock.mockClear()
+    await detectSparseCheckoutCached('/repo-a', '/repo-a/wt-1')
+    await detectSparseCheckoutCached('/repo-b', '/repo-b/wt-1')
+    expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('clearSparseCheckoutStateCache', () => {
+  it('drops every cached path across every repo, matching the fallback used when a repo cannot be resolved', async () => {
+    detectSparseCheckoutMock.mockResolvedValue(true)
+    await detectSparseCheckoutCached('/repo-a', '/repo-a/wt-1')
+    await detectSparseCheckoutCached('/repo-b', '/repo-b/wt-1')
     expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(2)
 
     clearSparseCheckoutStateCache()

--- a/src/main/git/worktree-sparse-checkout-cache.test.ts
+++ b/src/main/git/worktree-sparse-checkout-cache.test.ts
@@ -115,6 +115,34 @@ describe('detectSparseCheckoutCached', () => {
     }
   })
 
+  it('does not resurrect an entry that was explicitly invalidated while a background revalidation was in flight', async () => {
+    const nowSpy = vi.spyOn(Date, 'now')
+    let resolveDetect: (isSparse: boolean) => void = () => {}
+    try {
+      nowSpy.mockReturnValue(1_000)
+      detectSparseCheckoutMock.mockResolvedValueOnce(false)
+      await detectSparseCheckoutCached('/repo', '/repo/wt-a')
+
+      // Past the window: kicks a background re-detect that we hold open.
+      nowSpy.mockReturnValue(1_000 + RECONCILE_WINDOW_MS + 1)
+      detectSparseCheckoutMock.mockImplementationOnce(
+        () => new Promise<boolean>((resolve) => (resolveDetect = resolve))
+      )
+      await detectSparseCheckoutCached('/repo', '/repo/wt-a')
+
+      // The worktree is removed (or the repo cache is cleared) while the detect above is in flight.
+      invalidateSparseCheckoutState('/repo', '/repo/wt-a')
+      expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(0)
+
+      // The in-flight detect now resolves; it must not write the entry back.
+      resolveDetect(true)
+      await flushBackgroundRevalidation()
+      expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(0)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
   it('notifies the registered change listener only when a background revalidation flips the answer', async () => {
     const listener = vi.fn()
     onSparseCheckoutStateChanged(listener)

--- a/src/main/git/worktree-sparse-checkout-cache.test.ts
+++ b/src/main/git/worktree-sparse-checkout-cache.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { detectSparseCheckoutMock } = vi.hoisted(() => ({
+  detectSparseCheckoutMock: vi.fn()
+}))
+
+vi.mock('./worktree-sparse-state', () => ({
+  detectSparseCheckout: detectSparseCheckoutMock,
+  resolveGitCommonDir: vi.fn()
+}))
+
+import {
+  __getSparseCheckoutStateCacheSizeForTests,
+  __resetSparseCheckoutStateCacheForTests,
+  clearSparseCheckoutStateCache,
+  detectSparseCheckoutCached,
+  invalidateSparseCheckoutState
+} from './worktree-sparse-checkout-cache'
+
+beforeEach(() => {
+  detectSparseCheckoutMock.mockReset()
+  __resetSparseCheckoutStateCacheForTests()
+})
+
+describe('detectSparseCheckoutCached', () => {
+  it('caches a detection result across repeated calls for the same path', async () => {
+    detectSparseCheckoutMock.mockResolvedValue(true)
+
+    expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(true)
+    expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(true)
+
+    expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('detects each distinct worktree path independently', async () => {
+    detectSparseCheckoutMock.mockImplementation(
+      async (worktreePath: string) => worktreePath === '/repo/wt-sparse'
+    )
+
+    expect(await detectSparseCheckoutCached('/repo/wt-sparse')).toBe(true)
+    expect(await detectSparseCheckoutCached('/repo/wt-full')).toBe(false)
+    expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('caches a false result too, so a worktree that stays non-sparse costs one detect', async () => {
+    detectSparseCheckoutMock.mockResolvedValue(false)
+
+    expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(false)
+    expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(false)
+
+    expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-detects once the reconcile window elapses, bounding staleness from unwitnessed external edits', async () => {
+    vi.useFakeTimers()
+    try {
+      detectSparseCheckoutMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
+      expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(false)
+
+      // Just under the 5-minute reconcile window: still trusts the cached value.
+      vi.advanceTimersByTime(5 * 60_000 - 1)
+      expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(false)
+      expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(1)
+
+      // Past the window: re-detects and picks up the external toggle.
+      vi.advanceTimersByTime(2)
+      expect(await detectSparseCheckoutCached('/repo/wt-a')).toBe(true)
+      expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('invalidateSparseCheckoutState', () => {
+  it('drops only the named path, leaving other cached paths untouched', async () => {
+    detectSparseCheckoutMock.mockResolvedValue(true)
+    await detectSparseCheckoutCached('/repo/wt-a')
+    await detectSparseCheckoutCached('/repo/wt-b')
+
+    invalidateSparseCheckoutState('/repo/wt-a')
+    expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(1)
+
+    detectSparseCheckoutMock.mockClear()
+    await detectSparseCheckoutCached('/repo/wt-a')
+    await detectSparseCheckoutCached('/repo/wt-b')
+    expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(1)
+    expect(detectSparseCheckoutMock).toHaveBeenCalledWith('/repo/wt-a')
+  })
+})
+
+describe('clearSparseCheckoutStateCache', () => {
+  it('drops every cached path, matching the blunt clear-all used on any worktree-change notification', async () => {
+    detectSparseCheckoutMock.mockResolvedValue(true)
+    await detectSparseCheckoutCached('/repo/wt-a')
+    await detectSparseCheckoutCached('/repo/wt-b')
+    expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(2)
+
+    clearSparseCheckoutStateCache()
+
+    expect(__getSparseCheckoutStateCacheSizeForTests()).toBe(0)
+  })
+})

--- a/src/main/git/worktree-sparse-checkout-cache.test.ts
+++ b/src/main/git/worktree-sparse-checkout-cache.test.ts
@@ -143,6 +143,39 @@ describe('detectSparseCheckoutCached', () => {
     }
   })
 
+  it('does not let a stale in-flight revalidation clobber a fresh value written after remove+recreate at the same path', async () => {
+    const nowSpy = vi.spyOn(Date, 'now')
+    let resolveStaleDetect: (isSparse: boolean) => void = () => {}
+    try {
+      nowSpy.mockReturnValue(1_000)
+      detectSparseCheckoutMock.mockResolvedValueOnce(false)
+      await detectSparseCheckoutCached('/repo', '/repo/wt-a')
+
+      // Past the window: kicks a background re-detect that we hold open (simulates a slow probe
+      // racing a worktree removal + recreation at the same path).
+      nowSpy.mockReturnValue(1_000 + RECONCILE_WINDOW_MS + 1)
+      detectSparseCheckoutMock.mockImplementationOnce(
+        () => new Promise<boolean>((resolve) => (resolveStaleDetect = resolve))
+      )
+      await detectSparseCheckoutCached('/repo', '/repo/wt-a')
+
+      // The worktree is removed (invalidate) and a new one is recreated at the exact same path,
+      // repopulating the key with a fresh, different value via a normal cold read.
+      invalidateSparseCheckoutState('/repo', '/repo/wt-a')
+      detectSparseCheckoutMock.mockResolvedValueOnce(true)
+      expect(await detectSparseCheckoutCached('/repo', '/repo/wt-a')).toBe(true)
+
+      // The stale in-flight detect from before the remove+recreate now resolves with the old
+      // answer. A presence-only guard would let this overwrite the fresh entry above; the fix
+      // must compare entry identity and refuse to write back over a value it didn't produce.
+      resolveStaleDetect(false)
+      await flushBackgroundRevalidation()
+      expect(await detectSparseCheckoutCached('/repo', '/repo/wt-a')).toBe(true)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
   it('notifies the registered change listener only when a background revalidation flips the answer', async () => {
     const listener = vi.fn()
     onSparseCheckoutStateChanged(listener)

--- a/src/main/git/worktree-sparse-checkout-cache.ts
+++ b/src/main/git/worktree-sparse-checkout-cache.ts
@@ -67,7 +67,7 @@ export async function detectSparseCheckoutCached(
   }
   // Stale-while-revalidate: serve the still-cached value now and correct it in the background,
   // deduplicated so concurrent readers past the window don't each start their own probe.
-  cached.revalidating ??= revalidateInBackground(key, repoPath, worktreePath, cached.isSparse)
+  cached.revalidating ??= revalidateInBackground(key, repoPath, worktreePath, cached)
   return cached.isSparse
 }
 
@@ -75,25 +75,24 @@ async function revalidateInBackground(
   key: string,
   repoPath: string,
   worktreePath: string,
-  previousIsSparse: boolean
+  startingEntry: SparseCheckoutCacheEntry
 ): Promise<void> {
   try {
     const isSparse = await detectSparseCheckout(worktreePath)
-    // Guard against a race with an explicit invalidate/clear that ran while this was in flight:
-    // if the key is gone, something deliberately dropped it (removed/moved worktree, repo-scoped
-    // clear) and writing the stale result back would resurrect an entry that should stay absent
-    // until the next real read.
-    if (sparseCheckoutStateCache.has(key)) {
+    // Identity guard against a race with an explicit invalidate/clear -- or a remove+recreate at
+    // the same path that repopulates the key with a fresh cold read -- while this was in flight.
+    // A `has()`/presence check can't tell "still mine" from "someone else's fresh value" sharing
+    // the key; comparing the map's current entry object to the one we started from can.
+    if (sparseCheckoutStateCache.get(key) === startingEntry) {
       sparseCheckoutStateCache.set(key, { isSparse, cachedAt: Date.now() })
     }
-    if (isSparse !== previousIsSparse) {
+    if (isSparse !== startingEntry.isSparse) {
       changeListener?.(repoPath, worktreePath, isSparse)
     }
   } catch {
-    // Leave the stale entry in place (if not already replaced/invalidated); the next read retries.
-    const entry = sparseCheckoutStateCache.get(key)
-    if (entry?.revalidating) {
-      entry.revalidating = undefined
+    // Leave whatever's there in place; the next read past the window retries.
+    if (sparseCheckoutStateCache.get(key) === startingEntry) {
+      startingEntry.revalidating = undefined
     }
   }
 }

--- a/src/main/git/worktree-sparse-checkout-cache.ts
+++ b/src/main/git/worktree-sparse-checkout-cache.ts
@@ -79,7 +79,13 @@ async function revalidateInBackground(
 ): Promise<void> {
   try {
     const isSparse = await detectSparseCheckout(worktreePath)
-    sparseCheckoutStateCache.set(key, { isSparse, cachedAt: Date.now() })
+    // Guard against a race with an explicit invalidate/clear that ran while this was in flight:
+    // if the key is gone, something deliberately dropped it (removed/moved worktree, repo-scoped
+    // clear) and writing the stale result back would resurrect an entry that should stay absent
+    // until the next real read.
+    if (sparseCheckoutStateCache.has(key)) {
+      sparseCheckoutStateCache.set(key, { isSparse, cachedAt: Date.now() })
+    }
     if (isSparse !== previousIsSparse) {
       changeListener?.(repoPath, worktreePath, isSparse)
     }

--- a/src/main/git/worktree-sparse-checkout-cache.ts
+++ b/src/main/git/worktree-sparse-checkout-cache.ts
@@ -1,50 +1,120 @@
+import { canonicalWorktreePath } from './worktree-path-comparison'
 import { detectSparseCheckout } from './worktree-sparse-state'
 
-// Why: `git worktree list` never reports sparse-checkout state (no such porcelain field exists), so
-// every listing paid a per-worktree fs.stat + config read — measured at ~9x the cost of the `git
-// worktree list` call it decorates on a 1000-worktree repo. Cache the result per worktree path.
+// Why: `git worktree list` only emits a `sparse` porcelain line on newer Git (annotateSparseCheckoutStatus
+// already skips rows where that's set), but Orca's compatibility baseline is Git 2.25, which predates it —
+// so every listing still paid a per-worktree fs.stat + config read on the fallback path, measured at ~9x
+// the cost of the `git worktree list` call it decorates on a 1000-worktree repo. Cache the result, scoped
+// per repo so churn in one repo can't evict another's warm entries.
 //
 // Invalidation coverage:
 //  - Orca-driven remove/move: explicit calls below (worktree-removal.ts, worktree-move.ts).
 //  - External `git sparse-checkout` toggle while extensions.worktreeConfig is on: it rewrites
 //    `config.worktree`, which the git-common-dir watcher already classifies as structural and
-//    routes through notifyWorktreesChanged -> the invalidator this module registers.
+//    routes through notifyWorktreesChanged -> the invalidator this module registers (repo-scoped).
 //  - External toggle with extensions.worktreeConfig off, or a bare pattern-file edit: unwitnessed
 //    by the watcher (same blind spot `readRepoWorktreeAdminFingerprint` already documents and
-//    accepts), bounded by the reconcile window below instead.
+//    accepts). Past the reconcile window below, a read still returns instantly from the stale entry
+//    but also kicks a deduplicated background re-detect; a flip fires the change listener (wired to
+//    the existing worktrees-changed notification) so the visible staleness window collapses from the
+//    interval to one refresh cycle instead of blocking the listing that noticed it. That notification
+//    itself runs the invalidator registered below, so a flip is immediately followed by a full clear
+//    of the repo's cache (not just the one entry) -- an intentionally forced one-time full re-detect
+//    on the rare edge that actually flipped, rather than partial state that could quietly diverge.
 //  - App cold start: the map starts empty, so the first read is always a fresh detect.
 const SPARSE_CHECKOUT_CACHE_RECONCILE_INTERVAL_MS = 5 * 60_000
 
 type SparseCheckoutCacheEntry = {
   isSparse: boolean
   cachedAt: number
+  revalidating?: Promise<void>
 }
 
+export type SparseCheckoutChangeListener = (
+  repoPath: string,
+  worktreePath: string,
+  isSparse: boolean
+) => void
+
 const sparseCheckoutStateCache = new Map<string, SparseCheckoutCacheEntry>()
+let changeListener: SparseCheckoutChangeListener | undefined
+
+function cacheKey(repoPath: string, worktreePath: string): string {
+  return `${canonicalWorktreePath(repoPath)}\0${canonicalWorktreePath(worktreePath)}`
+}
+
+/** Wired by the ipc/ layer to the shared worktrees-changed notification; last registration wins. */
+export function onSparseCheckoutStateChanged(
+  listener: SparseCheckoutChangeListener | undefined
+): void {
+  changeListener = listener
+}
 
 /** Cached wrapper around {@link detectSparseCheckout}; see module doc for invalidation coverage. */
-export async function detectSparseCheckoutCached(worktreePath: string): Promise<boolean> {
-  const cached = sparseCheckoutStateCache.get(worktreePath)
-  if (cached && Date.now() - cached.cachedAt < SPARSE_CHECKOUT_CACHE_RECONCILE_INTERVAL_MS) {
+export async function detectSparseCheckoutCached(
+  repoPath: string,
+  worktreePath: string
+): Promise<boolean> {
+  const key = cacheKey(repoPath, worktreePath)
+  const cached = sparseCheckoutStateCache.get(key)
+  if (!cached) {
+    const isSparse = await detectSparseCheckout(worktreePath)
+    sparseCheckoutStateCache.set(key, { isSparse, cachedAt: Date.now() })
+    return isSparse
+  }
+  if (Date.now() - cached.cachedAt < SPARSE_CHECKOUT_CACHE_RECONCILE_INTERVAL_MS) {
     return cached.isSparse
   }
-  const isSparse = await detectSparseCheckout(worktreePath)
-  sparseCheckoutStateCache.set(worktreePath, { isSparse, cachedAt: Date.now() })
-  return isSparse
+  // Stale-while-revalidate: serve the still-cached value now and correct it in the background,
+  // deduplicated so concurrent readers past the window don't each start their own probe.
+  cached.revalidating ??= revalidateInBackground(key, repoPath, worktreePath, cached.isSparse)
+  return cached.isSparse
+}
+
+async function revalidateInBackground(
+  key: string,
+  repoPath: string,
+  worktreePath: string,
+  previousIsSparse: boolean
+): Promise<void> {
+  try {
+    const isSparse = await detectSparseCheckout(worktreePath)
+    sparseCheckoutStateCache.set(key, { isSparse, cachedAt: Date.now() })
+    if (isSparse !== previousIsSparse) {
+      changeListener?.(repoPath, worktreePath, isSparse)
+    }
+  } catch {
+    // Leave the stale entry in place (if not already replaced/invalidated); the next read retries.
+    const entry = sparseCheckoutStateCache.get(key)
+    if (entry?.revalidating) {
+      entry.revalidating = undefined
+    }
+  }
 }
 
 /** Drop one worktree's cached state; call when Orca itself removes or moves a worktree path. */
-export function invalidateSparseCheckoutState(worktreePath: string): void {
-  sparseCheckoutStateCache.delete(worktreePath)
+export function invalidateSparseCheckoutState(repoPath: string, worktreePath: string): void {
+  sparseCheckoutStateCache.delete(cacheKey(repoPath, worktreePath))
 }
 
-/** Clear every cached entry; wired to the shared worktree-change invalidator registry in ipc/. */
+/** Clear one repo's cached entries; wired to the shared worktree-change invalidator registry in ipc/. */
+export function clearSparseCheckoutStateCacheForRepo(repoPath: string): void {
+  const prefix = `${canonicalWorktreePath(repoPath)}\0`
+  for (const key of sparseCheckoutStateCache.keys()) {
+    if (key.startsWith(prefix)) {
+      sparseCheckoutStateCache.delete(key)
+    }
+  }
+}
+
+/** Clear every cached entry; fallback for a change notification whose repo can't be resolved to a path. */
 export function clearSparseCheckoutStateCache(): void {
   sparseCheckoutStateCache.clear()
 }
 
 export function __resetSparseCheckoutStateCacheForTests(): void {
   sparseCheckoutStateCache.clear()
+  changeListener = undefined
 }
 
 export function __getSparseCheckoutStateCacheSizeForTests(): number {

--- a/src/main/git/worktree-sparse-checkout-cache.ts
+++ b/src/main/git/worktree-sparse-checkout-cache.ts
@@ -1,0 +1,52 @@
+import { detectSparseCheckout } from './worktree-sparse-state'
+
+// Why: `git worktree list` never reports sparse-checkout state (no such porcelain field exists), so
+// every listing paid a per-worktree fs.stat + config read — measured at ~9x the cost of the `git
+// worktree list` call it decorates on a 1000-worktree repo. Cache the result per worktree path.
+//
+// Invalidation coverage:
+//  - Orca-driven remove/move: explicit calls below (worktree-removal.ts, worktree-move.ts).
+//  - External `git sparse-checkout` toggle while extensions.worktreeConfig is on: it rewrites
+//    `config.worktree`, which the git-common-dir watcher already classifies as structural and
+//    routes through notifyWorktreesChanged -> the invalidator this module registers.
+//  - External toggle with extensions.worktreeConfig off, or a bare pattern-file edit: unwitnessed
+//    by the watcher (same blind spot `readRepoWorktreeAdminFingerprint` already documents and
+//    accepts), bounded by the reconcile window below instead.
+//  - App cold start: the map starts empty, so the first read is always a fresh detect.
+const SPARSE_CHECKOUT_CACHE_RECONCILE_INTERVAL_MS = 5 * 60_000
+
+type SparseCheckoutCacheEntry = {
+  isSparse: boolean
+  cachedAt: number
+}
+
+const sparseCheckoutStateCache = new Map<string, SparseCheckoutCacheEntry>()
+
+/** Cached wrapper around {@link detectSparseCheckout}; see module doc for invalidation coverage. */
+export async function detectSparseCheckoutCached(worktreePath: string): Promise<boolean> {
+  const cached = sparseCheckoutStateCache.get(worktreePath)
+  if (cached && Date.now() - cached.cachedAt < SPARSE_CHECKOUT_CACHE_RECONCILE_INTERVAL_MS) {
+    return cached.isSparse
+  }
+  const isSparse = await detectSparseCheckout(worktreePath)
+  sparseCheckoutStateCache.set(worktreePath, { isSparse, cachedAt: Date.now() })
+  return isSparse
+}
+
+/** Drop one worktree's cached state; call when Orca itself removes or moves a worktree path. */
+export function invalidateSparseCheckoutState(worktreePath: string): void {
+  sparseCheckoutStateCache.delete(worktreePath)
+}
+
+/** Clear every cached entry; wired to the shared worktree-change invalidator registry in ipc/. */
+export function clearSparseCheckoutStateCache(): void {
+  sparseCheckoutStateCache.clear()
+}
+
+export function __resetSparseCheckoutStateCacheForTests(): void {
+  sparseCheckoutStateCache.clear()
+}
+
+export function __getSparseCheckoutStateCacheSizeForTests(): number {
+  return sparseCheckoutStateCache.size
+}

--- a/src/main/git/worktree-sparse-checkout.test.ts
+++ b/src/main/git/worktree-sparse-checkout.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { listWorktrees, parseCoreSparseCheckoutFlag } from './worktree'
+import { listWorktrees, parseCoreSparseCheckoutFlag, removeWorktree } from './worktree'
 
 const tempRoots: string[] = []
 
@@ -106,6 +106,32 @@ describe('sparse-checkout detection', () => {
 
       expect(git(repoPath, ['config', '--get', 'core.sparseCheckout']).trim()).toBe('true')
       expect(mainWorktree(await listWorktrees(repoPath)).isSparse).toBe(true)
+    }
+  )
+})
+
+describe('sparse-checkout cache invalidation across the worktree lifecycle', () => {
+  it.skipIf(process.platform === 'win32')(
+    'does not leak a stale sparse badge onto a worktree created at a removed worktree`s path',
+    async () => {
+      const repoPath = await createRepoWithTwoDirs()
+      const linkedPath = path.join(path.dirname(repoPath), 'linked')
+
+      git(repoPath, ['worktree', 'add', '-b', 'sparse-branch', linkedPath])
+      git(linkedPath, ['sparse-checkout', 'set', 'keep'])
+
+      const beforeRemoval = await listWorktrees(repoPath)
+      const sparseRow = beforeRemoval.find((worktree) => worktree.branch.endsWith('sparse-branch'))
+      expect(sparseRow?.isSparse).toBe(true)
+
+      // Removing through Orca's own removeWorktree (not a raw `git worktree remove`) exercises the
+      // cache-invalidation hook this listing now relies on instead of a fresh stat every time.
+      await removeWorktree(repoPath, linkedPath, true)
+      git(repoPath, ['worktree', 'add', '-b', 'full-branch', linkedPath])
+
+      const afterRecreate = await listWorktrees(repoPath)
+      const fullRow = afterRecreate.find((worktree) => worktree.branch.endsWith('full-branch'))
+      expect(fullRow?.isSparse).toBeFalsy()
     }
   )
 })

--- a/src/main/git/worktree-test-harness.ts
+++ b/src/main/git/worktree-test-harness.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, vi } from 'vitest'
 
 import { clearGitCapabilityStateForTests } from './git-capability-state'
+import { __resetSparseCheckoutStateCacheForTests } from './worktree-sparse-checkout-cache'
 
 /** Root hooks every worktree suite shares: pristine capability cache, no ambient add-timeout override. */
 export function registerWorktreeSuiteHooks(): void {
   beforeEach(() => {
     clearGitCapabilityStateForTests()
+    __resetSparseCheckoutStateCacheForTests()
     // Why: addWorktree reads the override at call time, so a developer's ambient value must not leak in.
     // `undefined` deletes the key, matching production's unset case rather than an empty string.
     vi.stubEnv('ORCA_WORKTREE_ADD_TIMEOUT_MS', undefined)

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -20,7 +20,10 @@ import { registerWorktreeRemovalHandlers } from './worktrees/removal/register-wo
 import type { WorktreeIpcContext } from './worktrees/worktree-ipc-context'
 
 registerDetectedWorktreeScanInvalidation()
-registerSparseCheckoutCacheInvalidation()
+
+// Why not module scope like the invalidation above: this needs `mainWindow`/`store`, which only
+// exist once a window is attached, and must track the current ones across re-registration.
+let disposeSparseCheckoutCacheInvalidation: (() => void) | undefined
 
 const WORKTREE_HANDLER_CHANNELS = [
   'worktrees:listAll',
@@ -70,6 +73,12 @@ export function registerWorktreeHandlers(
   for (const channel of WORKTREE_HANDLER_CHANNELS) {
     ipcMain.removeHandler(channel)
   }
+
+  disposeSparseCheckoutCacheInvalidation?.()
+  disposeSparseCheckoutCacheInvalidation = registerSparseCheckoutCacheInvalidation(
+    mainWindow,
+    store
+  )
 
   registerWorktreeCatalogHandlers(context)
   registerHostCatalogHandlers(context)

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -13,12 +13,14 @@ import { registerDetectedWorktreeHandlers } from './worktrees/listing/register-d
 import { registerHostCatalogHandlers } from './worktrees/listing/register-host-catalog-handlers'
 import { registerWorktreeCatalogHandlers } from './worktrees/listing/register-worktree-catalog-handlers'
 import { registerDetectedWorktreeScanInvalidation } from './worktrees/listing/register-detected-worktree-scan-invalidation'
+import { registerSparseCheckoutCacheInvalidation } from './worktrees/listing/register-sparse-checkout-cache-invalidation'
 import { registerWorktreeMetadataHandlers } from './worktrees/metadata/register-worktree-metadata-handlers'
 import { registerWorktreeForgetHandlers } from './worktrees/removal/register-worktree-forget-handlers'
 import { registerWorktreeRemovalHandlers } from './worktrees/removal/register-worktree-removal-handlers'
 import type { WorktreeIpcContext } from './worktrees/worktree-ipc-context'
 
 registerDetectedWorktreeScanInvalidation()
+registerSparseCheckoutCacheInvalidation()
 
 const WORKTREE_HANDLER_CHANNELS = [
   'worktrees:listAll',

--- a/src/main/ipc/worktrees/listing/register-sparse-checkout-cache-invalidation.test.ts
+++ b/src/main/ipc/worktrees/listing/register-sparse-checkout-cache-invalidation.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Store } from '../../../persistence/loading-store/store'
+import { runWorktreeChangeInvalidators } from '../../worktree-change-invalidators'
+import { registerSparseCheckoutCacheInvalidation } from './register-sparse-checkout-cache-invalidation'
+
+const {
+  clearSparseCheckoutStateCacheMock,
+  clearSparseCheckoutStateCacheForRepoMock,
+  onSparseCheckoutStateChangedMock,
+  notifyWorktreesChangedMock
+} = vi.hoisted(() => ({
+  clearSparseCheckoutStateCacheMock: vi.fn(),
+  clearSparseCheckoutStateCacheForRepoMock: vi.fn(),
+  onSparseCheckoutStateChangedMock: vi.fn(),
+  notifyWorktreesChangedMock: vi.fn()
+}))
+
+vi.mock('../../../git/worktree-sparse-checkout-cache', () => ({
+  clearSparseCheckoutStateCache: clearSparseCheckoutStateCacheMock,
+  clearSparseCheckoutStateCacheForRepo: clearSparseCheckoutStateCacheForRepoMock,
+  onSparseCheckoutStateChanged: onSparseCheckoutStateChangedMock
+}))
+
+vi.mock('../../worktree-remote', () => ({
+  notifyWorktreesChanged: notifyWorktreesChangedMock
+}))
+
+function makeStore(repos: Repo[]): Store {
+  return {
+    getRepo: (id: string) => repos.find((repo) => repo.id === id),
+    getRepos: () => repos
+  } as unknown as Store
+}
+
+const mainWindow = {} as never
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('registerSparseCheckoutCacheInvalidation', () => {
+  it('clears only the resolved repo`s cache when the invalidator registry fires', () => {
+    const store = makeStore([{ id: 'repo-1', path: '/repo-1' } as Repo])
+    const dispose = registerSparseCheckoutCacheInvalidation(mainWindow, store)
+    try {
+      runWorktreeChangeInvalidators('repo-1')
+      expect(clearSparseCheckoutStateCacheForRepoMock).toHaveBeenCalledWith('/repo-1')
+      expect(clearSparseCheckoutStateCacheMock).not.toHaveBeenCalled()
+    } finally {
+      dispose()
+    }
+  })
+
+  it('falls back to a full clear when the repo cannot be resolved', () => {
+    const store = makeStore([])
+    const dispose = registerSparseCheckoutCacheInvalidation(mainWindow, store)
+    try {
+      runWorktreeChangeInvalidators('unknown-repo')
+      expect(clearSparseCheckoutStateCacheMock).toHaveBeenCalledTimes(1)
+      expect(clearSparseCheckoutStateCacheForRepoMock).not.toHaveBeenCalled()
+    } finally {
+      dispose()
+    }
+  })
+
+  it('forwards a background stale-while-revalidate flip to the shared worktrees-changed notification', () => {
+    const store = makeStore([{ id: 'repo-1', path: '/repo-1' } as Repo])
+    const dispose = registerSparseCheckoutCacheInvalidation(mainWindow, store)
+    try {
+      const listener = onSparseCheckoutStateChangedMock.mock.calls.at(-1)?.[0]
+      listener?.('/repo-1', '/repo-1/wt-a', true)
+      expect(notifyWorktreesChangedMock).toHaveBeenCalledWith(mainWindow, 'repo-1')
+    } finally {
+      dispose()
+    }
+  })
+
+  it('drops the change listener on disposal so a stale window/store stops receiving flips', () => {
+    const store = makeStore([{ id: 'repo-1', path: '/repo-1' } as Repo])
+    const dispose = registerSparseCheckoutCacheInvalidation(mainWindow, store)
+    dispose()
+    expect(onSparseCheckoutStateChangedMock).toHaveBeenLastCalledWith(undefined)
+  })
+})

--- a/src/main/ipc/worktrees/listing/register-sparse-checkout-cache-invalidation.ts
+++ b/src/main/ipc/worktrees/listing/register-sparse-checkout-cache-invalidation.ts
@@ -1,0 +1,6 @@
+import { clearSparseCheckoutStateCache } from '../../../git/worktree-sparse-checkout-cache'
+import { registerWorktreeChangeInvalidator } from '../../worktree-change-invalidators'
+
+export function registerSparseCheckoutCacheInvalidation(): void {
+  registerWorktreeChangeInvalidator(clearSparseCheckoutStateCache)
+}

--- a/src/main/ipc/worktrees/listing/register-sparse-checkout-cache-invalidation.ts
+++ b/src/main/ipc/worktrees/listing/register-sparse-checkout-cache-invalidation.ts
@@ -1,6 +1,41 @@
-import { clearSparseCheckoutStateCache } from '../../../git/worktree-sparse-checkout-cache'
+import type { BrowserWindow } from 'electron'
+import type { Store } from '../../../persistence/loading-store/store'
+import {
+  clearSparseCheckoutStateCache,
+  clearSparseCheckoutStateCacheForRepo,
+  onSparseCheckoutStateChanged
+} from '../../../git/worktree-sparse-checkout-cache'
+import { areWorktreePathsEqual } from '../../../git/worktree-path-comparison'
 import { registerWorktreeChangeInvalidator } from '../../worktree-change-invalidators'
+import { notifyWorktreesChanged } from '../../worktree-remote'
 
-export function registerSparseCheckoutCacheInvalidation(): void {
-  registerWorktreeChangeInvalidator(clearSparseCheckoutStateCache)
+/**
+ * Scope worktree-change invalidation to the affected repo (falling back to a full clear when the
+ * repo can't be resolved, e.g. it was already removed from the store), and forward a background
+ * stale-while-revalidate flip to the same worktrees-changed notification other mutations use.
+ */
+export function registerSparseCheckoutCacheInvalidation(
+  mainWindow: BrowserWindow,
+  store: Store
+): () => void {
+  const unregisterInvalidator = registerWorktreeChangeInvalidator((repoId) => {
+    const repoPath = store.getRepo(repoId)?.path
+    if (repoPath) {
+      clearSparseCheckoutStateCacheForRepo(repoPath)
+    } else {
+      clearSparseCheckoutStateCache()
+    }
+  })
+  onSparseCheckoutStateChanged((repoPath) => {
+    const repo = store
+      .getRepos()
+      .find((candidate) => areWorktreePathsEqual(candidate.path, repoPath))
+    if (repo) {
+      notifyWorktreesChanged(mainWindow, repo.id)
+    }
+  })
+  return () => {
+    unregisterInvalidator()
+    onSparseCheckoutStateChanged(undefined)
+  }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​411 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​408 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​205 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 |

<!-- /orca-pr-loc -->

## ELI5

Every time Orca lists a repo's worktrees, it also checks each one for whether it's a "sparse" checkout (partial working tree). That check was re-done from scratch, every single time, for every worktree -- even though the answer almost never changes. On a repo with ~1000 worktrees this dwarfed the cost of the actual `git worktree list` call it was decorating. This PR remembers the answer per worktree, scoped per repo, so repeat listings are nearly free, while still catching every real reason the answer could change (worktree removed/moved, sparse checkout toggled through Orca or externally, app restart) -- including a background self-correction if something changes it externally without Orca noticing right away.

## What Changed

- Added `src/main/git/worktree-sparse-checkout-cache.ts`: a cache (`detectSparseCheckoutCached`) wrapping the existing `detectSparseCheckout`, keyed by repo path + worktree path so entries from different repos never collide or evict each other.
- Cache keys (and invalidation lookups) go through a new `canonicalWorktreePath()`, extracted from the existing `areWorktreePathsEqual` normalization (`src/main/git/worktree-path-comparison.ts`) -- resolved and case-folded on Windows syntax -- so two different spellings of the same path (trailing slash, `.` segment, drive-letter casing) always hit the same entry instead of silently diverging.
- Replaced the original hard 5-minute cutoff with stale-while-revalidate: once an entry is past the reconcile window, a read still returns the cached value immediately, but also kicks a deduplicated background re-detect. If that re-detect flips the answer, it fires the same worktrees-changed notification other mutations already use, so the fix propagates on its own without waiting for the next explicit trigger.
- `src/main/git/worktree-listing.ts`'s `annotateSparseCheckoutStatus` now takes `repoPath` and calls the cached wrapper (with both the repo and worktree path) instead of hitting the filesystem on every listing.
- Explicit invalidation on the two Orca-driven mutations that change a worktree's path: `removeWorktree` (`worktree-removal.ts`) and `moveWorktree` (`worktree-move.ts`), for both old and new paths, both now repo-scoped.
- `src/main/ipc/worktrees/listing/register-sparse-checkout-cache-invalidation.ts` (rewritten): resolves the invalidator registry's `repoId` to a repo path via the `Store` and clears only that repo's entries (falling back to a full clear if the repo can't be resolved, e.g. it was already removed), and forwards a stale-while-revalidate flip to `notifyWorktreesChanged` by resolving the repo path back to a `repoId`. This needs both `mainWindow` and `store`, so registration moved from module-load time into `registerWorktreeHandlers`, with a disposer so re-invoking it (already-supported re-registration) doesn't stack duplicate listeners.
- The background revalidation's write-back is now guarded by **entry identity**, not key presence: it captures the exact cache-entry object it started from and only writes its result back if that object is still the one at the key. A presence check (`has(key)`) can't distinguish "nothing touched this key" from "something invalidated it and a fresh cold read already repopulated it" -- a worktree removed and recreated at the same path while a stale re-detect is in flight would otherwise let the old result overwrite the new one.
- Added/extended test-suite reset hooks (`remove-worktree-test-harness.ts`, `worktree-test-harness.ts`) so the new module-level cache doesn't leak state across test cases.

## Why

`git worktree list --porcelain` predates sparse-checkout awareness on Orca's Git 2.25 compatibility baseline: newer Git versions do emit a `sparse` porcelain line (Orca's own parser handles it -- `src/main/git/worktree-list-parser.ts:38-39` -- and `annotateSparseCheckoutStatus` already skips rows where it's set), but on the baseline we support, Orca still has to derive it itself via a per-worktree `fs.stat` + config read (`detectSparseCheckout`). On a real user's repo with 973 live worktrees, `git worktree list --porcelain -z` itself ran in 0.135s, but the sparse-checkout annotation pass over all worktrees (concurrency 8) took ~0.58-1.0s -- roughly 9x the cost of the git call it decorates. This runs on every listing (lenient and strict), so it directly slows down worktree-heavy operations at scale (see #17828).

Caching per-path is safe here because sparse-checkout state changes only through a small, enumerable set of triggers, all of which are covered:
1. **Worktree created** -- new path, never cached, first read is always fresh.
2. **Worktree removed** -- explicit `invalidateSparseCheckoutState(repoPath, worktreePath)`.
3. **Worktree moved** -- explicit invalidation of both old and new paths.
4. **External `git sparse-checkout` toggle with `extensions.worktreeConfig` on** -- rewrites `config.worktree`, which the existing git-common-dir watcher already classifies as structural and routes through `notifyWorktreesChanged` -> the repo-scoped invalidator this module registers.
5. **External toggle with `extensions.worktreeConfig` off, or a bare pattern-file edit** -- not observed by the watcher (this is the exact same blind spot `readRepoWorktreeAdminFingerprint` already documents and accepts). Rather than sitting stale for a fixed window, a read past the window now serves the cached value and kicks a background re-detect, so the visible staleness collapses from the full window down to one refresh cycle, at no added cost to the listing that noticed it.
6. **App cold start** -- the cache is an empty in-memory `Map`, so the first read after launch is always a fresh detect.

I deliberately did not widen the file-watcher classifier to watch `info/sparse-checkout` directly or reclassify the shared `config` file as structural: `git sparse-checkout disable` never rewrites the pattern file at all (only flips config), so watching it alone wouldn't catch every mutation anyway, and reclassifying the shared `config` file as structural would reopen the "index-churn fanout" the existing classifier's own comments say it was designed to avoid. Similarly, true zero-staleness for the unwitnessed case (item 5) would require a dedicated watcher per repo's `info/sparse-checkout` file and `config.worktree` regardless of `extensions.worktreeConfig` -- 973 additional watchers on the motivating user's repo alone -- which is out of proportion to a cosmetic badge; stale-while-revalidate gets the practical benefit (bounded, self-correcting staleness) without that cost.

**Benchmark** (synthetic fixture, 1 main + 984 linked worktrees under `/tmp`, never touching a real checkout):
- `git worktree list --porcelain -z`: ~207ms
- Sparse annotation, uncached, per listing: ~140-300ms (paid every single listing)
- Sparse annotation, cached, cold (first listing): ~199ms (comparable to before)
- Sparse annotation, cached, warm (every subsequent listing within the reconcile window): ~0.3ms

So steady-state repeat listings -- which is what polling/refresh does in practice -- go from paying the full per-worktree stat+config-read fan-out every time to effectively free, a ~470x reduction for that specific cost on this fixture. The canonicalization, repo-scoping, and stale-while-revalidate changes above don't materially change these numbers (still O(1) map lookups on the warm path); they close correctness gaps in the caching layer itself, not its throughput.

## User-Facing Regressions

One, and it is cosmetic.

- The sparse-checkout badge can be **one refresh cycle stale** after an external `git sparse-checkout` toggle in a repo with `extensions.worktreeConfig` disabled — the one mutation no watcher signal witnesses. Modern `sparse-checkout set` enables `worktreeConfig` itself, so this needs old git or hand-edited config.

Nothing functional reads this cached value. Every consumer on this path is display-only (sidebar badge, status-bar row, metadata merge); the one behavioural gate — provisioned-root adoption refusing sparse checkouts — is SSH-only and reads sparse state through the SSH provider, not this cache.

Stale-while-revalidate replaced an earlier hard 5-minute window, so a flip now surfaces on the next refresh rather than after a timeout.

**True zero staleness is out of scope:** it would need a watcher per worktree gitdir (~973 on the motivating machine), which is exactly the fan-out this effort exists to remove.

## Linked Issue

Refs #17828

## Visual Proof

N/A -- pure backend performance change, no UI/behavior difference. Sparse badges in the sidebar render identically; only how fast (and how precisely) we compute them changes.

## Testing

- `src/main/git/worktree-sparse-checkout-cache.test.ts`: unit tests for caching, per-path independence, repo-scoping (same path under two repos cached independently), path-spelling canonicalization (trailing slash / `.` segment treated as the same entry), false-result caching, stale-while-revalidate past the reconcile window, and change-listener notification only on an actual flip. Includes two race regressions: a background revalidation resolving after its entry was explicitly invalidated must not resurrect it, and (the identity-guard fix) a background revalidation resolving after its entry was invalidated *and repopulated with a different value by a fresh cold read* must not clobber that fresh value -- verified this second test fails against the earlier `has(key)`-based guard and only passes with the reference-identity check.
- Extended `src/main/git/worktree-move.test.ts` and `src/main/git/remove-worktree.test.ts` with cache-invalidation coverage for both success and failure paths (now passing `repoPath` explicitly).
- Extended `src/main/git/worktree-sparse-checkout.test.ts` with a real-git end-to-end test proving a worktree recreated at a just-removed worktree's path never inherits a stale sparse badge.
- New `src/main/ipc/worktrees/listing/register-sparse-checkout-cache-invalidation.test.ts`: unit tests for repo-scoped clearing, the full-clear fallback when a repo can't be resolved, forwarding a stale-while-revalidate flip to `notifyWorktreesChanged`, and listener cleanup on disposal.
- Ran a synthetic ~1000-worktree benchmark under `/tmp` (see numbers above); never touched a real checkout.
- `pnpm tc:node`, targeted `pnpm test` (`src/main/git/worktree*`, `src/main/ipc/worktrees`: 556 tests passing / 1 pre-existing skip), and `pnpm run check:code-quality:changed` all pass clean.
- Tested platforms: macOS only (local dev machine). Sparse-checkout tests already skip on `win32` per the existing repo convention (`it.skipIf(process.platform === 'win32')`) since sparse-checkout mechanics are POSIX-path-sensitive in this test file; I did not have Linux/Windows/WSL/SSH hardware to test against, so I relied on tracing the existing watcher/invalidation code paths, plus the new `canonicalWorktreePath` unit coverage, for cross-platform correctness rather than live verification there.

- [x] I manually tested these changes locally (macOS)
- [x] Automated tests added/updated (see above)

## AI Disclosure

Claude Sonnet 5 (Claude Code)

## Review

This PR was self-reviewed, unlike other PRs in this effort that went through adversarial review. An independent review pass was subsequently run against it and specifically checked for: an unbounded-staleness path, a functional (not just cosmetic) `isSparse` consumer on the cached path, and a sibling-repo cache-key bug -- and found none. Every `isSparse` consumer reached through this cache is cosmetic (sidebar badge, status-bar row, metadata merge); the one functional gate that refuses sparse checkouts (provisioned-root SSH adoption) reads sparse state through the SSH provider, not this cache, so it's unaffected. The review credited the double backstop -- the reconcile window/stale-while-revalidate plus the invalidator registry's clear-all fallback -- as what makes that verdict hold even before this round's repo-scoping and canonicalization landed.

That same review requested three concrete improvements over disclosing them as residual risk, which this revision implements: canonical (normalized, case-folded) cache keys on both read and invalidate; scoping cache reads/clears by repo path instead of one shared namespace; and stale-while-revalidate in place of the hard cutoff. While implementing the third, I found and flagged a new race it introduced -- a background revalidation resolving after its entry was explicitly invalidated could resurrect it -- and shipped a fix guarded by `sparseCheckoutStateCache.has(key)`.

**That fix was insufficient, and bot review caught it correctly.** Both greptile (P1) and pullfrog independently flagged that a presence check can't distinguish "nothing touched this key" from "something invalidated it and a fresh, unrelated value already landed there" -- concretely, a worktree removed and recreated at the same generated path (Orca's own create flow does this, and the motivating user runs ~981 worktrees) while a stale re-detect is in flight would let the old result overwrite the new one for a full reconcile window. This is the second time this exact race was raised on this PR (I found the presence-vs-identity gap in principle during my own readiness pass but chose a guard that didn't actually close it); the corrected fix compares the map's current entry to the *exact object* the revalidation captured when it started, not just key presence -- the approach both bots independently suggested -- and a new regression test asserts the fresh value survives a stale write-back attempt, failing against the old guard and passing against the new one.

True zero-staleness for the one remaining unwitnessed case (external sparse-checkout toggle with `extensions.worktreeConfig` off, or a raw pattern-file edit, per Why item 5) would require a dedicated filesystem watcher per repo's `info/sparse-checkout` file -- 973 additional watchers on the motivating user's repo alone. That's intentionally out of scope for a cosmetic badge; stale-while-revalidate bounds the same staleness to one refresh cycle instead.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: no new subprocess/network/eval surfaces; the cache wraps an existing filesystem-only detection function.
- Cross-platform: underlying detection logic (`detectSparseCheckout`/`resolveGitDir`) is unchanged; the cache adds an in-memory layer keyed by `canonicalWorktreePath(repoPath) + canonicalWorktreePath(worktreePath)`, the same normalization `areWorktreePathsEqual` already uses for Windows/WSL path-spelling differences, so the previously-disclosed path-spelling cache-key risk is closed rather than mitigated.
- Remote/SSH: no new remote I/O; reuses the same locally-resolved `resolveGitDir` path resolution the uncached detector already used.
- Backward compatibility: purely in-memory, ephemeral cache -- no persisted schema, no migration, no data-loss vector.
- Performance: this is the primary target of the change; see benchmark numbers above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

