### PR TITLE
fix(ssh): stop a late SFTP stream error crashing main, and keep the relay socket inside sun_path

### DIFF
--- a/src/main/ssh/relay-socket-path-limit-shell.integration.test.ts
+++ b/src/main/ssh/relay-socket-path-limit-shell.integration.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { resolveShortRelaySocketDirCommand } from './relay-socket-path-limit'
+import {
+  resolveShortRelaySocketDirCommand,
+  shortRelayVersionSegment
+} from './relay-socket-path-limit'
 
 const run = promisify(execFile)
 
@@ -13,9 +16,14 @@ const run = promisify(execFile)
 describe('short relay socket dir guard, against a real shell', () => {
   let root: string
 
+  const VERSION_SEGMENT = shortRelayVersionSegment('relay-0.1.0+test')
+
   // Retarget the generated script at a sandbox instead of the real /tmp path.
   function scriptFor(dir: string): string {
-    return resolveShortRelaySocketDirCommand().replace(/^dir=.*$/m, `dir=${JSON.stringify(dir)}`)
+    return resolveShortRelaySocketDirCommand(VERSION_SEGMENT).replace(
+      /^dir=.*$/m,
+      `dir=${JSON.stringify(dir)}`
+    )
   }
 
   async function attempt(dir: string): Promise<{ ok: boolean; stdout: string }> {
@@ -35,10 +43,28 @@ describe('short relay socket dir guard, against a real shell', () => {
     await rm(root, { recursive: true, force: true })
   })
 
-  it('creates the directory when it does not exist', async () => {
+  it('creates the directory and its version segment when neither exists', async () => {
     const dir = join(root, 'fresh')
-    expect((await attempt(dir)).ok).toBe(true)
+    const attempted = await attempt(dir)
+    expect(attempted.ok).toBe(true)
     expect((await stat(dir)).mode & 0o777).toBe(0o700)
+    // The segment is what keeps a later build off the path this one binds.
+    expect((await stat(join(dir, VERSION_SEGMENT))).mode & 0o777).toBe(0o700)
+    expect(attempted.stdout.trim().endsWith(`${dir}/${VERSION_SEGMENT}`)).toBe(true)
+  })
+
+  it('refuses a planted symlink in the version segment without following it', async () => {
+    const dir = join(root, 'mine')
+    const victim = join(root, 'segment-victim')
+    await mkdir(dir)
+    await chmod(dir, 0o700)
+    await mkdir(victim)
+    await chmod(victim, 0o755)
+    await symlink(victim, join(dir, VERSION_SEGMENT))
+
+    const before = (await stat(victim)).mode & 0o777
+    expect((await attempt(dir)).ok).toBe(false)
+    expect((await stat(victim)).mode & 0o777).toBe(before)
   })
 
   it('adopts a directory we already own at 0700, so reconnects keep working', async () => {

--- a/src/main/ssh/relay-socket-path-limit-shell.integration.test.ts
+++ b/src/main/ssh/relay-socket-path-limit-shell.integration.test.ts
@@ -1,0 +1,77 @@
+import { execFile } from 'node:child_process'
+import { chmod, mkdtemp, mkdir, rm, symlink, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveShortRelaySocketDirCommand } from './relay-socket-path-limit'
+
+const run = promisify(execFile)
+
+// The generated script runs on the remote host's /bin/sh, so assert against a real shell rather
+// than a string match: the hazard here is an ordering bug that only a filesystem can observe.
+describe('short relay socket dir guard, against a real shell', () => {
+  let root: string
+
+  // Retarget the generated script at a sandbox instead of the real /tmp path.
+  function scriptFor(dir: string): string {
+    return resolveShortRelaySocketDirCommand().replace(/^dir=.*$/m, `dir=${JSON.stringify(dir)}`)
+  }
+
+  async function attempt(dir: string): Promise<{ ok: boolean; stdout: string }> {
+    try {
+      const { stdout } = await run('/bin/sh', ['-c', scriptFor(dir)])
+      return { ok: true, stdout }
+    } catch {
+      return { ok: false, stdout: '' }
+    }
+  }
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-relay-dir-guard-'))
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('creates the directory when it does not exist', async () => {
+    const dir = join(root, 'fresh')
+    expect((await attempt(dir)).ok).toBe(true)
+    expect((await stat(dir)).mode & 0o777).toBe(0o700)
+  })
+
+  it('adopts a directory we already own at 0700, so reconnects keep working', async () => {
+    // Regression guard: `ls` decorates the mode with @ (xattrs), + (ACL) or . (SELinux), and an
+    // exact match refused a directory we own — which would have broken every reconnect.
+    const dir = join(root, 'mine')
+    await mkdir(dir)
+    await chmod(dir, 0o700)
+    expect((await attempt(dir)).ok).toBe(true)
+    expect((await attempt(dir)).ok).toBe(true)
+  })
+
+  it('refuses a planted symlink without changing what it points at', async () => {
+    const victim = join(root, 'victim')
+    const link = join(root, 'link')
+    await mkdir(victim)
+    await chmod(victim, 0o755)
+    await symlink(victim, link)
+
+    const before = (await stat(victim)).mode & 0o777
+    expect((await attempt(link)).ok).toBe(false)
+    // The point of the ordering: an unconditional chmod would have followed the link and
+    // rewritten the victim's mode before the owner check ever ran.
+    expect((await stat(victim)).mode & 0o777).toBe(before)
+  })
+
+  it('refuses an existing directory that is not 0700', async () => {
+    const dir = join(root, 'loose')
+    await mkdir(dir)
+    // Explicit chmod: mkdir's mode is masked by the process umask, so the fixture would not
+    // actually be world-writable and the test would not be testing what it claims.
+    await chmod(dir, 0o777)
+    expect((await attempt(dir)).ok).toBe(false)
+    expect((await stat(dir)).mode & 0o777).toBe(0o777)
+  })
+})

--- a/src/main/ssh/relay-socket-path-limit.test.ts
+++ b/src/main/ssh/relay-socket-path-limit.test.ts
@@ -68,8 +68,10 @@ import {
   parseShortRelaySocketDir,
   remoteSocketPathFitsLimit,
   remoteUnixSocketPathByteLimit,
+  shortRelayVersionSegment,
   SHORT_RELAY_SOCKET_DIR_PREFIX
 } from './relay-socket-path-limit'
+import { supersededRelayEndpointListCommand } from './ssh-relay-superseded-endpoints'
 import { getRemoteHostPlatform } from './ssh-remote-platform'
 import type { SshConnection } from './ssh-connection'
 
@@ -79,6 +81,9 @@ const WINDOWS = getRemoteHostPlatform('win32-x64')
 
 // The reporter's host: a managed-hosting container whose $HOME is 45 bytes (#10726).
 const LONG_HOME = '/var/www/611f7cf9-f715-49e6-91d9-0ffac1d7c4c0'
+
+/** Matches the version this suite's mocked build reports. */
+const RELAY_VERSION_DIR_NAME = 'relay-0.1.0+8d4e15ad63eb'
 
 function makeMockConnection(): SshConnection {
   return {
@@ -133,13 +138,24 @@ describe('remote unix socket path limit', () => {
   })
 
   it('accepts only the marker line as the short directory', () => {
+    const segment = shortRelayVersionSegment(RELAY_VERSION_DIR_NAME)
     expect(
       parseShortRelaySocketDir(
-        'Welcome to Ubuntu\nORCA-RELAY-SHORT-SOCKET-DIR /tmp/.orca-relay-1000\n'
+        `Welcome to Ubuntu\nORCA-RELAY-SHORT-SOCKET-DIR /tmp/.orca-relay-1000/${segment}\n`,
+        segment
       )
-    ).toBe('/tmp/.orca-relay-1000')
-    expect(parseShortRelaySocketDir('mkdir: permission denied\n')).toBeNull()
-    expect(parseShortRelaySocketDir('ORCA-RELAY-SHORT-SOCKET-DIR /etc\n')).toBeNull()
+    ).toBe(`/tmp/.orca-relay-1000/${segment}`)
+    expect(parseShortRelaySocketDir('mkdir: permission denied\n', segment)).toBeNull()
+    expect(
+      parseShortRelaySocketDir(`ORCA-RELAY-SHORT-SOCKET-DIR /etc/${segment}\n`, segment)
+    ).toBeNull()
+    // A directory belonging to another build must not be adopted as this build's.
+    expect(
+      parseShortRelaySocketDir(
+        `ORCA-RELAY-SHORT-SOCKET-DIR /tmp/.orca-relay-1000/${shortRelayVersionSegment('relay-9.9.9+other')}\n`,
+        segment
+      )
+    ).toBeNull()
   })
 })
 
@@ -156,7 +172,9 @@ describe('relay launch with a long remote $HOME', () => {
       .mockResolvedValueOnce(LONG_HOME)
       .mockResolvedValueOnce('ORCA-NATIVE-DEPS-OK')
       .mockResolvedValueOnce('') // launch namespace marker
-      .mockResolvedValueOnce(`ORCA-RELAY-SHORT-SOCKET-DIR ${SHORT_RELAY_SOCKET_DIR_PREFIX}1000`)
+      .mockResolvedValueOnce(
+        `ORCA-RELAY-SHORT-SOCKET-DIR ${SHORT_RELAY_SOCKET_DIR_PREFIX}1000/${shortRelayVersionSegment(RELAY_VERSION_DIR_NAME)}`
+      )
       .mockResolvedValueOnce('DEAD')
       .mockResolvedValueOnce('READY')
       .mockResolvedValue('')
@@ -172,10 +190,32 @@ describe('relay launch with a long remote $HOME', () => {
     )
     expect(sockPath.startsWith(`${SHORT_RELAY_SOCKET_DIR_PREFIX}1000/`)).toBe(true)
     expect(result.sockPath).toBe(sockPath)
-    // The hashed socket name survives intact, so two targets cannot collide.
+    // The hashed socket name survives intact, so two targets cannot collide -- and the
+    // build's version segment sits above it, so the next Orca release binds a path of
+    // its own instead of the one this relay is still holding.
     expect(sockPath).toBe(
-      `${SHORT_RELAY_SOCKET_DIR_PREFIX}1000/${relaySocketNameForInstanceId('ssh-target-1')}`
+      `${SHORT_RELAY_SOCKET_DIR_PREFIX}1000/${shortRelayVersionSegment(RELAY_VERSION_DIR_NAME)}/${relaySocketNameForInstanceId('ssh-target-1')}`
     )
+    expect(shortRelayVersionSegment('relay-0.1.0+next')).not.toBe(
+      shortRelayVersionSegment(RELAY_VERSION_DIR_NAME)
+    )
+  })
+
+  it('sweeps superseded relays under the short base too, but never the live one', () => {
+    const currentShortSocketDir = `${SHORT_RELAY_SOCKET_DIR_PREFIX}1000/${shortRelayVersionSegment(RELAY_VERSION_DIR_NAME)}`
+    const script = supersededRelayEndpointListCommand({
+      remoteHome: LONG_HOME,
+      currentRelayDir: `${LONG_HOME}/.orca-remote/${RELAY_VERSION_DIR_NAME}`,
+      sockName: relaySocketNameForInstanceId('ssh-target-1'),
+      currentShortSocketDir
+    })
+
+    // A relocated orphan lives outside $HOME, so the sweep that exists to make orphans
+    // visible has to look at the short base as well.
+    expect(script).toContain(`short_base="${SHORT_RELAY_SOCKET_DIR_PREFIX}$(id -u 2>/dev/null)"`)
+    expect(script).toContain('"$short_base"/relay-*/"$sock_name"')
+    expect(script).toContain(`short_current='${currentShortSocketDir}'`)
+    expect(script).toContain('[ -n "$short_current" ] && [ "$dir" = "$short_current" ] && continue')
   })
 
   it('leaves the socket in the versioned relay dir when it already fits', async () => {
@@ -205,5 +245,6 @@ describe('relay launch with a long remote $HOME', () => {
 
     const script = vi.mocked(execCommand).mock.calls[0]?.[1] as string
     expect(script).toContain(`short_base="${SHORT_RELAY_SOCKET_DIR_PREFIX}$(id -u 2>/dev/null)"`)
+    expect(script).toContain('"$short_base"/relay-*/"$sock_name"')
   })
 })

--- a/src/main/ssh/relay-socket-path-limit.test.ts
+++ b/src/main/ssh/relay-socket-path-limit.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/mock/app' }
+}))
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+  readFileSync: vi.fn().mockReturnValue('0.1.0+abcdef012345')
+}))
+
+vi.mock('./relay-protocol', () => ({
+  RELAY_VERSION: '0.1.0',
+  RELAY_REMOTE_DIR: '.orca-remote',
+  parseUnameToRelayPlatform: vi.fn(() => 'linux-x64'),
+  RELAY_SENTINEL: 'ORCA-RELAY v0.1.0 READY\n',
+  RELAY_SENTINEL_TIMEOUT_MS: 10_000
+}))
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  uploadDirectory: vi.fn().mockResolvedValue(undefined),
+  waitForSentinel: vi.fn().mockResolvedValue({
+    write: vi.fn(),
+    onData: vi.fn(),
+    onClose: vi.fn()
+  }),
+  isUnconfirmedSshCommandTermination: () => false,
+  execCommand: vi.fn().mockResolvedValue('')
+}))
+
+vi.mock('./ssh-remote-node-resolution', () => ({
+  resolveRemoteNodePath: vi.fn().mockResolvedValue('/usr/bin/node')
+}))
+
+vi.mock('./ssh-relay-endpoint-credential', () => ({
+  writeRelayEndpointCredential: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-relay-versioned-install', () => ({
+  readLocalFullVersion: vi.fn().mockReturnValue('0.1.0+8d4e15ad63eb'),
+  computeRemoteRelayDir: (home: string, v: string) => `${home}/.orca-remote/relay-${v}`,
+  isRelayAlreadyInstalled: vi.fn().mockResolvedValue(true),
+  finalizeInstall: vi.fn().mockResolvedValue(undefined),
+  abandonInstall: vi.fn().mockResolvedValue(undefined),
+  gcOldRelayVersions: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-relay-install-lock', () => ({
+  acquireInstallLock: vi.fn().mockResolvedValue(undefined),
+  RELAY_INSTALL_LOCK_NAME: '.install-lock'
+}))
+
+vi.mock('./ssh-relay-repair-lock', () => ({
+  tryAcquireRelayRepairLock: vi.fn().mockResolvedValue('acquired')
+}))
+
+vi.mock('./ssh-connection-utils', () => ({
+  shellEscape: (s: string) => `'${s}'`,
+  createSshOperationAbortError: () =>
+    Object.assign(new Error('SSH operation was cancelled'), { name: 'AbortError' })
+}))
+
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+import { execCommand } from './ssh-relay-deploy-helpers'
+import { forceStopRelayForTarget } from './ssh-relay-reset'
+import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
+import {
+  parseShortRelaySocketDir,
+  remoteSocketPathFitsLimit,
+  remoteUnixSocketPathByteLimit,
+  SHORT_RELAY_SOCKET_DIR_PREFIX
+} from './relay-socket-path-limit'
+import { getRemoteHostPlatform } from './ssh-remote-platform'
+import type { SshConnection } from './ssh-connection'
+
+const LINUX = getRemoteHostPlatform('linux-x64')
+const DARWIN = getRemoteHostPlatform('darwin-arm64')
+const WINDOWS = getRemoteHostPlatform('win32-x64')
+
+// The reporter's host: a managed-hosting container whose $HOME is 45 bytes (#10726).
+const LONG_HOME = '/var/www/611f7cf9-f715-49e6-91d9-0ffac1d7c4c0'
+
+function makeMockConnection(): SshConnection {
+  return {
+    canRunConcurrentExecCommands: vi.fn().mockReturnValue(true),
+    exec: vi.fn().mockResolvedValue({
+      on: vi.fn(),
+      stderr: { on: vi.fn() },
+      stdin: {},
+      stdout: { on: vi.fn() },
+      close: vi.fn()
+    }),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    sftp: vi.fn().mockResolvedValue({
+      mkdir: vi.fn((_p: string, cb: (err: Error | null) => void) => cb(null)),
+      createWriteStream: vi.fn().mockReturnValue({
+        on: vi.fn((event: string, cb: () => void) => {
+          if (event === 'close') {
+            setTimeout(cb, 0)
+          }
+        }),
+        end: vi.fn()
+      }),
+      end: vi.fn()
+    })
+  } as unknown as SshConnection
+}
+
+function launchedSockPath(conn: SshConnection): string {
+  const launch = vi
+    .mocked(conn.exec)
+    .mock.calls.map(([command]) => command as string)
+    .find((command) => command.includes('--detached'))
+  return /--sock-path\s+'([^']+)'/.exec(launch ?? '')?.[1] ?? ''
+}
+
+describe('remote unix socket path limit', () => {
+  it('uses the per-OS sun_path budget and ignores Windows named pipes', () => {
+    expect(remoteUnixSocketPathByteLimit(LINUX)).toBe(107)
+    expect(remoteUnixSocketPathByteLimit(DARWIN)).toBe(103)
+    expect(remoteUnixSocketPathByteLimit(WINDOWS)).toBeNull()
+    expect(remoteSocketPathFitsLimit(WINDOWS, `\\\\.\\pipe\\orca-relay-${'a'.repeat(400)}`)).toBe(
+      true
+    )
+  })
+
+  it('measures bytes, not characters', () => {
+    // 1 + 52 two-byte characters = 105 bytes: fits Linux (107), not macOS (103).
+    const path = `/${'é'.repeat(52)}`
+    expect(path.length).toBe(53)
+    expect(remoteSocketPathFitsLimit(LINUX, path)).toBe(true)
+    expect(remoteSocketPathFitsLimit(DARWIN, path)).toBe(false)
+  })
+
+  it('accepts only the marker line as the short directory', () => {
+    expect(
+      parseShortRelaySocketDir(
+        'Welcome to Ubuntu\nORCA-RELAY-SHORT-SOCKET-DIR /tmp/.orca-relay-1000\n'
+      )
+    ).toBe('/tmp/.orca-relay-1000')
+    expect(parseShortRelaySocketDir('mkdir: permission denied\n')).toBeNull()
+    expect(parseShortRelaySocketDir('ORCA-RELAY-SHORT-SOCKET-DIR /etc\n')).toBeNull()
+  })
+})
+
+describe('relay launch with a long remote $HOME', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps the launched socket path inside the remote sun_path limit', async () => {
+    const conn = makeMockConnection()
+    vi.mocked(execCommand)
+      .mockReset()
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+      .mockResolvedValueOnce(LONG_HOME)
+      .mockResolvedValueOnce('ORCA-NATIVE-DEPS-OK')
+      .mockResolvedValueOnce('') // launch namespace marker
+      .mockResolvedValueOnce(`ORCA-RELAY-SHORT-SOCKET-DIR ${SHORT_RELAY_SOCKET_DIR_PREFIX}1000`)
+      .mockResolvedValueOnce('DEAD')
+      .mockResolvedValueOnce('READY')
+      .mockResolvedValue('')
+
+    // A per-target relay instance id is what pushes the default path past the limit:
+    // 45-byte $HOME + `/.orca-remote/relay-0.1.0+8d4e15ad63eb` + `/relay-<hash16>.sock` = 110 bytes.
+    const result = await deployAndLaunchRelay(conn, undefined, undefined, 'ssh-target-1')
+
+    const sockPath = launchedSockPath(conn)
+    expect(sockPath).not.toBe('')
+    expect(Buffer.byteLength(sockPath, 'utf8')).toBeLessThanOrEqual(
+      remoteUnixSocketPathByteLimit(LINUX) as number
+    )
+    expect(sockPath.startsWith(`${SHORT_RELAY_SOCKET_DIR_PREFIX}1000/`)).toBe(true)
+    expect(result.sockPath).toBe(sockPath)
+    // The hashed socket name survives intact, so two targets cannot collide.
+    expect(sockPath).toBe(
+      `${SHORT_RELAY_SOCKET_DIR_PREFIX}1000/${relaySocketNameForInstanceId('ssh-target-1')}`
+    )
+  })
+
+  it('leaves the socket in the versioned relay dir when it already fits', async () => {
+    const conn = makeMockConnection()
+    vi.mocked(execCommand)
+      .mockReset()
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+      .mockResolvedValueOnce('/home/user')
+      .mockResolvedValueOnce('ORCA-NATIVE-DEPS-OK')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('DEAD')
+      .mockResolvedValueOnce('READY')
+      .mockResolvedValue('')
+
+    await deployAndLaunchRelay(conn)
+
+    expect(launchedSockPath(conn)).toBe(
+      '/home/user/.orca-remote/relay-0.1.0+8d4e15ad63eb/relay.sock'
+    )
+  })
+
+  it('force-stop also looks for the socket under the short base', async () => {
+    const conn = makeMockConnection()
+    vi.mocked(execCommand).mockReset().mockResolvedValue('')
+
+    await forceStopRelayForTarget(conn, 'ssh-1')
+
+    const script = vi.mocked(execCommand).mock.calls[0]?.[1] as string
+    expect(script).toContain(`short_base="${SHORT_RELAY_SOCKET_DIR_PREFIX}$(id -u 2>/dev/null)"`)
+  })
+})

--- a/src/main/ssh/relay-socket-path-limit.ts
+++ b/src/main/ssh/relay-socket-path-limit.ts
@@ -9,6 +9,7 @@
  *
  * Windows relays bind named pipes (`\\.\pipe\...`), which have no `sun_path` limit.
  */
+import { createHash } from 'node:crypto'
 import { isWindowsRemoteHost, type RemoteHostPlatform } from './ssh-remote-platform'
 
 /**
@@ -38,18 +39,37 @@ export function shortRelaySocketDirForUid(uid: string): string {
 }
 
 /**
+ * The version segment the relocated socket lives under, named to match the version
+ * directories in `$HOME/.orca-remote` so one sweep pattern covers both bases.
+ *
+ * Why it has to exist: `relaySocketNameForInstanceId` hashes the *target*, not the
+ * build, so the filename alone is version-independent. Under `$HOME` the enclosing
+ * `relay-<fullVersion>` directory supplies that dimension; without it here, the next
+ * Orca build would bind the exact path the previous build's relay still holds. The
+ * daemon handshake compares build hashes exactly, so that meeting is a version
+ * mismatch — and if the incumbent holds live work, `resolveRelayEndpointBeforeRelaunch`
+ * raises `RelayEndpointHeldError` and the user cannot connect at all until the old
+ * relay is stopped. The version is hashed rather than spelled out because the whole
+ * point of this base is a bounded length.
+ */
+export function shortRelayVersionSegment(relayVersionDirName: string): string {
+  return `relay-${createHash('sha256').update(relayVersionDirName).digest('hex').slice(0, 12)}`
+}
+
+/**
  * The whole hashed socket name is kept — shortening happens by replacing the
  * variable-length directory, never by truncating the hash, so two targets on one
  * host can never land on the same socket.
  */
-export function shortRelaySocketPath(shortDir: string, sockName: string): string {
-  return `${shortDir}/${sockName}`
+export function shortRelaySocketPath(shortVersionDir: string, sockName: string): string {
+  return `${shortVersionDir}/${sockName}`
 }
 
 const SHORT_DIR_MARKER = 'ORCA-RELAY-SHORT-SOCKET-DIR'
 
 /**
- * Create (or adopt) the per-uid short socket directory and print it.
+ * Create (or adopt) the per-uid short socket directory and its version segment, and
+ * print the segment's path.
  *
  * Validate before mutating, never the other way round: an unconditional `chmod` follows a
  * symlink, so a path planted by another user would have its *target's* mode rewritten before
@@ -58,35 +78,49 @@ const SHORT_DIR_MARKER = 'ORCA-RELAY-SHORT-SOCKET-DIR'
  * proves — via `ls -ldn`, which reports the entry itself rather than what it points at — that
  * it is a real directory, owned by this uid, already 0700. Nothing else is touched.
  */
-export function resolveShortRelaySocketDirCommand(): string {
+export function resolveShortRelaySocketDirCommand(versionSegment: string): string {
   return [
     'uid=$(id -u) || exit 1',
     `dir="${SHORT_RELAY_SOCKET_DIR_PREFIX}$uid"`,
     'umask 077',
-    'if mkdir "$dir" 2>/dev/null; then',
+    ...adoptOwnedDirectoryCommand('$dir'),
+    // The version segment is validated the same way rather than trusted: `$dir` being
+    // 0700 and ours does not prove what an earlier run left inside it still is.
+    `ver="$dir/${versionSegment}"`,
+    ...adoptOwnedDirectoryCommand('$ver'),
+    `printf '%s %s\n' '${SHORT_DIR_MARKER}' "$ver"`
+  ].join('\n')
+}
+
+function adoptOwnedDirectoryCommand(target: string): string[] {
+  return [
+    `if mkdir "${target}" 2>/dev/null; then`,
     '  :',
     'else',
     // Why the sub(): ls decorates the mode with a trailing marker for extended attributes (@),
     // ACLs (+) or an SELinux context (.), so an exact match would refuse a directory we own.
-    '  entry=$(ls -ldn "$dir" 2>/dev/null | awk \'NR==1{sub(/[.@+]$/, "", $1); print $1" "$3}\')',
+    `  entry=$(ls -ldn "${target}" 2>/dev/null | awk 'NR==1{sub(/[.@+]$/, "", $1); print $1" "$3}')`,
     '  case "$entry" in',
     '    "drwx------ $uid") ;;',
     '    *) exit 1 ;;',
     '  esac',
-    'fi',
-    `printf '%s %s\\n' '${SHORT_DIR_MARKER}' "$dir"`
-  ].join('\n')
+    'fi'
+  ]
 }
 
 /** Tolerates login-shell banner noise ahead of the marker line. */
-export function parseShortRelaySocketDir(output: string): string | null {
+export function parseShortRelaySocketDir(output: string, versionSegment: string): string | null {
   for (const line of output.split('\n')) {
     const trimmed = line.trim()
     if (!trimmed.startsWith(`${SHORT_DIR_MARKER} `)) {
       continue
     }
     const dir = trimmed.slice(SHORT_DIR_MARKER.length + 1).trim()
-    if (dir.startsWith(`${SHORT_RELAY_SOCKET_DIR_PREFIX}`) && !/[\r\n]/.test(dir)) {
+    if (
+      dir.startsWith(`${SHORT_RELAY_SOCKET_DIR_PREFIX}`) &&
+      dir.endsWith(`/${versionSegment}`) &&
+      !/[\r\n]/.test(dir)
+    ) {
       return dir
     }
   }

--- a/src/main/ssh/relay-socket-path-limit.ts
+++ b/src/main/ssh/relay-socket-path-limit.ts
@@ -51,18 +51,29 @@ const SHORT_DIR_MARKER = 'ORCA-RELAY-SHORT-SOCKET-DIR'
 /**
  * Create (or adopt) the per-uid short socket directory and print it.
  *
- * `ls -ldn` reports the directory entry itself, so an attacker-planted symlink or a
- * directory owned by another user fails the owner check instead of being reused.
+ * Validate before mutating, never the other way round: an unconditional `chmod` follows a
+ * symlink, so a path planted by another user would have its *target's* mode rewritten before
+ * the owner check could reject it. A fresh `mkdir` under `umask 077` already yields 0700 and
+ * proves we own it, so the only path that adopts an existing entry is the one that first
+ * proves — via `ls -ldn`, which reports the entry itself rather than what it points at — that
+ * it is a real directory, owned by this uid, already 0700. Nothing else is touched.
  */
 export function resolveShortRelaySocketDirCommand(): string {
   return [
     'uid=$(id -u) || exit 1',
     `dir="${SHORT_RELAY_SOCKET_DIR_PREFIX}$uid"`,
     'umask 077',
-    'mkdir -p "$dir" 2>/dev/null',
-    'chmod 700 "$dir" 2>/dev/null',
-    'owner=$(ls -ldn "$dir" 2>/dev/null | awk \'NR==1{print $3}\')',
-    '[ -d "$dir" ] && [ "$owner" = "$uid" ] || exit 1',
+    'if mkdir "$dir" 2>/dev/null; then',
+    '  :',
+    'else',
+    // Why the sub(): ls decorates the mode with a trailing marker for extended attributes (@),
+    // ACLs (+) or an SELinux context (.), so an exact match would refuse a directory we own.
+    '  entry=$(ls -ldn "$dir" 2>/dev/null | awk \'NR==1{sub(/[.@+]$/, "", $1); print $1" "$3}\')',
+    '  case "$entry" in',
+    '    "drwx------ $uid") ;;',
+    '    *) exit 1 ;;',
+    '  esac',
+    'fi',
     `printf '%s %s\\n' '${SHORT_DIR_MARKER}' "$dir"`
   ].join('\n')
 }

--- a/src/main/ssh/relay-socket-path-limit.ts
+++ b/src/main/ssh/relay-socket-path-limit.ts
@@ -1,0 +1,83 @@
+/**
+ * Keeps the remote relay's Unix socket path inside `sockaddr_un.sun_path`.
+ *
+ * The default endpoint is `$HOME/.orca-remote/relay-<fullVersion>/relay-<id>.sock`,
+ * whose fixed suffix already costs ~66 bytes. A managed-hosting `$HOME` such as
+ * `/var/www/<uuid>` pushes the whole path past the kernel cap and libuv reports only
+ * `listen EINVAL`, so the relay never starts (#10726). When that happens the socket
+ * moves to a fixed-length base whose length no longer depends on `$HOME`.
+ *
+ * Windows relays bind named pipes (`\\.\pipe\...`), which have no `sun_path` limit.
+ */
+import { isWindowsRemoteHost, type RemoteHostPlatform } from './ssh-remote-platform'
+
+/**
+ * `sizeof(sun_path)` per remote OS, including the terminating NUL: 108 on Linux,
+ * 104 on macOS/BSD. Compared against byte length, not character count — a non-ASCII
+ * `$HOME` costs more bytes than characters.
+ */
+const SUN_PATH_SIZE: Record<'linux' | 'darwin', number> = { linux: 108, darwin: 104 }
+
+export function remoteUnixSocketPathByteLimit(host: RemoteHostPlatform): number | null {
+  if (isWindowsRemoteHost(host)) {
+    return null
+  }
+  return SUN_PATH_SIZE[host.os === 'darwin' ? 'darwin' : 'linux'] - 1
+}
+
+export function remoteSocketPathFitsLimit(host: RemoteHostPlatform, sockPath: string): boolean {
+  const limit = remoteUnixSocketPathByteLimit(host)
+  return limit === null || Buffer.byteLength(sockPath, 'utf8') <= limit
+}
+
+/** Fixed-length, per-uid base. `/tmp` is the only POSIX directory whose length is not user-dependent. */
+export const SHORT_RELAY_SOCKET_DIR_PREFIX = '/tmp/.orca-relay-'
+
+export function shortRelaySocketDirForUid(uid: string): string {
+  return `${SHORT_RELAY_SOCKET_DIR_PREFIX}${uid}`
+}
+
+/**
+ * The whole hashed socket name is kept — shortening happens by replacing the
+ * variable-length directory, never by truncating the hash, so two targets on one
+ * host can never land on the same socket.
+ */
+export function shortRelaySocketPath(shortDir: string, sockName: string): string {
+  return `${shortDir}/${sockName}`
+}
+
+const SHORT_DIR_MARKER = 'ORCA-RELAY-SHORT-SOCKET-DIR'
+
+/**
+ * Create (or adopt) the per-uid short socket directory and print it.
+ *
+ * `ls -ldn` reports the directory entry itself, so an attacker-planted symlink or a
+ * directory owned by another user fails the owner check instead of being reused.
+ */
+export function resolveShortRelaySocketDirCommand(): string {
+  return [
+    'uid=$(id -u) || exit 1',
+    `dir="${SHORT_RELAY_SOCKET_DIR_PREFIX}$uid"`,
+    'umask 077',
+    'mkdir -p "$dir" 2>/dev/null',
+    'chmod 700 "$dir" 2>/dev/null',
+    'owner=$(ls -ldn "$dir" 2>/dev/null | awk \'NR==1{print $3}\')',
+    '[ -d "$dir" ] && [ "$owner" = "$uid" ] || exit 1',
+    `printf '%s %s\\n' '${SHORT_DIR_MARKER}' "$dir"`
+  ].join('\n')
+}
+
+/** Tolerates login-shell banner noise ahead of the marker line. */
+export function parseShortRelaySocketDir(output: string): string | null {
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith(`${SHORT_DIR_MARKER} `)) {
+      continue
+    }
+    const dir = trimmed.slice(SHORT_DIR_MARKER.length + 1).trim()
+    if (dir.startsWith(`${SHORT_RELAY_SOCKET_DIR_PREFIX}`) && !/[\r\n]/.test(dir)) {
+      return dir
+    }
+  }
+  return null
+}

--- a/src/main/ssh/sftp-stream-late-error.test.ts
+++ b/src/main/ssh/sftp-stream-late-error.test.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from 'node:events'
 import { PassThrough } from 'node:stream'
 import type { SFTPWrapper } from 'ssh2'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { uploadBuffer, uploadFile, writeStringViaSftp } from './sftp-upload'
+import { uploadBuffer, uploadFile, writeStringViaSftp, writeStringsViaSftp } from './sftp-upload'
 import { writeRelayFile } from './ssh-relay-install-transfers'
 import type { SshConnection } from './ssh-connection'
 import { getRemoteHostPlatform } from './ssh-remote-platform'
@@ -66,6 +66,46 @@ describe('late SFTP stream errors', () => {
     expect(() => stream.emit('error', sftpNoSuchFileError())).not.toThrow()
   })
 
+  // The failure mode a per-file loop reintroduces: writeStringViaSftp removes its own
+  // session listener at each settle, so a session that ran N transfers ends up with zero
+  // listeners while it is still open and still able to deliver a STATUS reply.
+  it('does not throw when a session error arrives after a multi-file write settles', async () => {
+    const sftp = Object.assign(new EventEmitter(), {
+      createWriteStream: () => {
+        const stream = new PassThrough()
+        stream.resume()
+        return stream
+      },
+      end: () => {}
+    }) as unknown as SFTPWrapper
+
+    await writeStringsViaSftp({ sftp: () => Promise.resolve(sftp) }, [
+      { path: '/home/user/.local/bin/orca', contents: '#!/bin/sh\n' },
+      { path: '/home/user/.local/bin/orca.mjs', contents: 'export {}\n' }
+    ])
+
+    expect(() => sftp.emit('error', sftpNoSuchFileError())).not.toThrow()
+  })
+
+  it('still rejects a multi-file write with a session error raised during it', async () => {
+    const sftp = Object.assign(new EventEmitter(), {
+      createWriteStream: () => {
+        const stream = new PassThrough()
+        queueMicrotask(() => sftp.emit('error', sftpNoSuchFileError()))
+        return stream
+      },
+      end: () => {}
+    }) as unknown as SFTPWrapper
+
+    // The latch must sit behind the transfer's own prepended listener, or a real
+    // mid-transfer failure would be swallowed into a hang.
+    await expect(
+      writeStringsViaSftp({ sftp: () => Promise.resolve(sftp) }, [
+        { path: '/home/user/.local/bin/orca', contents: '#!/bin/sh\n' }
+      ])
+    ).rejects.toThrow('file does not exist')
+  })
+
   it('still rejects with the SFTP error when it arrives during the transfer', async () => {
     const stream = new PassThrough()
     stream.resume()
@@ -83,6 +123,28 @@ describe('late SFTP stream errors', () => {
 })
 
 describe('sandboxed SFTP subsystem diagnosis', () => {
+  it('leaves a permission refusal as itself rather than blaming a chroot', async () => {
+    // SSH_FX_PERMISSION_DENIED is a mode/ownership refusal on a path the subsystem can
+    // see -- a read-only home, a root-owned parent, a quota. Rewriting it into "your
+    // bastion chroots SFTP" sends the user to fix ProxyJump for a chmod.
+    const conn = {
+      writeFile: () => Promise.reject(Object.assign(new Error('permission denied'), { code: 3 }))
+    } as unknown as SshConnection
+
+    const failure: unknown = await writeRelayFile(
+      conn,
+      getRemoteHostPlatform('linux-x64'),
+      '/home/user/.orca-remote/relay-1/.version',
+      'v1'
+    ).then(
+      () => null,
+      (err: unknown) => err
+    )
+
+    expect((failure as Error).message).toBe('permission denied')
+    expect(failure).not.toHaveProperty('sandboxedSftpNamespace')
+  })
+
   it('replaces the bare SFTP status with an actionable relay-install message', async () => {
     const conn = {
       writeFile: () => Promise.reject(sftpNoSuchFileError())

--- a/src/main/ssh/sftp-stream-late-error.test.ts
+++ b/src/main/ssh/sftp-stream-late-error.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import type { SFTPWrapper } from 'ssh2'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { uploadBuffer, uploadFile, writeStringViaSftp } from './sftp-upload'
+import { writeRelayFile } from './ssh-relay-install-transfers'
+import type { SshConnection } from './ssh-connection'
+import { getRemoteHostPlatform } from './ssh-remote-platform'
+
+/** The exact error ssh2 builds from a STATUS reply of SSH_FX_NO_SUCH_FILE. */
+function sftpNoSuchFileError(): Error {
+  return Object.assign(new Error('file does not exist'), { code: 2 })
+}
+
+let tempDir = ''
+let localFile = ''
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'orca-sftp-late-'))
+  localFile = join(tempDir, 'relay.js')
+  await writeFile(localFile, 'console.log(1)\n')
+})
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+function sftpDoubleReturning(stream: PassThrough): SFTPWrapper {
+  return Object.assign(new EventEmitter(), {
+    createWriteStream: () => stream
+  }) as unknown as SFTPWrapper
+}
+
+describe('late SFTP stream errors', () => {
+  // ssh2 emits the OPEN failure from inside the protocol parser. If no listener is left,
+  // Node throws it synchronously up through Socket.emit('data') and the main process dies
+  // (#15479) — uncaught exceptions are re-thrown by installUncaughtPipeErrorGuard, unlike
+  // rejections, which are only logged.
+  it('does not throw when a write stream fails after uploadFile settles', async () => {
+    const stream = new PassThrough()
+    stream.resume()
+
+    await uploadFile(sftpDoubleReturning(stream), localFile, '/home/user/.orca-remote/relay.js')
+
+    expect(() => stream.emit('error', sftpNoSuchFileError())).not.toThrow()
+  })
+
+  it('does not throw when a write stream fails after writeStringViaSftp settles', async () => {
+    const stream = new PassThrough()
+    stream.resume()
+
+    await writeStringViaSftp(sftpDoubleReturning(stream), '/home/user/.orca-remote/.version', 'v1')
+
+    expect(() => stream.emit('error', sftpNoSuchFileError())).not.toThrow()
+  })
+
+  it('does not throw when a write stream fails after uploadBuffer settles', async () => {
+    const stream = new PassThrough()
+    stream.resume()
+
+    await uploadBuffer(sftpDoubleReturning(stream), Buffer.from('x'), '/home/user/x')
+
+    expect(() => stream.emit('error', sftpNoSuchFileError())).not.toThrow()
+  })
+
+  it('still rejects with the SFTP error when it arrives during the transfer', async () => {
+    const stream = new PassThrough()
+    stream.resume()
+    const failing = Object.assign(new EventEmitter(), {
+      createWriteStream: () => {
+        queueMicrotask(() => stream.emit('error', sftpNoSuchFileError()))
+        return stream
+      }
+    }) as unknown as SFTPWrapper
+
+    await expect(writeStringViaSftp(failing, '/home/user/x', 'v1')).rejects.toThrow(
+      'file does not exist'
+    )
+  })
+})
+
+describe('sandboxed SFTP subsystem diagnosis', () => {
+  it('replaces the bare SFTP status with an actionable relay-install message', async () => {
+    const conn = {
+      writeFile: () => Promise.reject(sftpNoSuchFileError())
+    } as unknown as SshConnection
+
+    await expect(
+      writeRelayFile(
+        conn,
+        getRemoteHostPlatform('linux-x64'),
+        '/home/user/.orca-remote/relay-1/.version',
+        'v1'
+      )
+    ).rejects.toThrow(/SFTP subsystem sees a different filesystem/)
+  })
+
+  it('leaves unrelated transfer failures untouched', async () => {
+    const conn = {
+      writeFile: () => Promise.reject(new Error('Connection lost'))
+    } as unknown as SshConnection
+
+    await expect(
+      writeRelayFile(conn, getRemoteHostPlatform('linux-x64'), '/home/user/x', 'v1')
+    ).rejects.toThrow('Connection lost')
+  })
+})

--- a/src/main/ssh/sftp-stream-late-error.ts
+++ b/src/main/ssh/sftp-stream-late-error.ts
@@ -18,12 +18,16 @@
  * guarantee one level down, on the streams.
  */
 
-/** SSH_FX_* status codes ssh2 copies onto the `Error` it builds from a STATUS reply. */
+/** SSH_FX_* status code ssh2 copies onto the `Error` it builds from a STATUS reply. */
 const SSH_FX_NO_SUCH_FILE = 2
-const SSH_FX_PERMISSION_DENIED = 3
 
 type ErrorEmitter = {
   on(event: 'error', listener: (err: Error) => void): unknown
+}
+
+type SftpSessionEmitter = ErrorEmitter & {
+  once(event: 'close', listener: () => void): unknown
+  removeListener(event: 'error', listener: (err: Error) => void): unknown
 }
 
 export type SftpStreamErrorLatch = {
@@ -52,9 +56,34 @@ export function latchLateSftpStreamErrors(
   }
 }
 
+/**
+ * Hold one `'error'` listener on the SFTP *session* for as long as the session lives.
+ *
+ * A transfer that attaches and removes its own session listener — `writeStringViaSftp`
+ * does, so a session error can reject the write in flight — leaves the emitter with zero
+ * listeners between transfers and after the last one. A late STATUS reply arriving in
+ * that window is the synchronous throw described above. Errors during a transfer still
+ * reach that transfer first: it prepends its listener ahead of this one.
+ *
+ * Attach this once, right after `conn.sftp()`, on every path that runs transfers over a
+ * session it owns.
+ */
+export function latchLateSftpSessionErrors(sftp: SftpSessionEmitter): void {
+  const swallowLateSftpError = (): void => {}
+  sftp.on('error', swallowLateSftpError)
+  sftp.once('close', () => sftp.removeListener('error', swallowLateSftpError))
+}
+
+/**
+ * A chrooted SFTP subsystem answers a path outside its namespace with
+ * `SSH_FX_NO_SUCH_FILE`, because the path genuinely does not exist in the view it
+ * serves. `SSH_FX_PERMISSION_DENIED` is not that: it is an ordinary mode/ownership
+ * refusal on a path the subsystem *can* see — a read-only home, a root-owned parent,
+ * a quota — and rewriting it into "your bastion chroots SFTP" would send the user to
+ * fix ProxyJump for a `chmod`.
+ */
 export function isSandboxedSftpNamespaceError(error: unknown): boolean {
-  const code = (error as { code?: unknown } | null)?.code
-  return code === SSH_FX_NO_SUCH_FILE || code === SSH_FX_PERMISSION_DENIED
+  return (error as { code?: unknown } | null)?.code === SSH_FX_NO_SUCH_FILE
 }
 
 /**

--- a/src/main/ssh/sftp-stream-late-error.ts
+++ b/src/main/ssh/sftp-stream-late-error.ts
@@ -1,0 +1,79 @@
+/**
+ * Why an SFTP stream needs an `'error'` listener that outlives its transfer.
+ *
+ * ssh2 answers an SFTP request by invoking the pending request's callback from inside
+ * the protocol parser, on the socket's `data` handler stack. For a write stream that
+ * callback is `WriteStream.open`'s, and it does a bare `this.emit('error', err)`. Node
+ * throws when `'error'` is emitted on an emitter with no listener, so once a transfer
+ * has settled and removed its listener, a late STATUS reply becomes a *synchronous
+ * throw* out of `Protocol.parse` -> `Socket.emit('data')`.
+ *
+ * That is an uncaught exception, not a rejection: `installUnhandledRejectionLogging`
+ * absorbs rejections, but `installUncaughtPipeErrorGuard` re-throws uncaught exceptions
+ * and the app dies (#15479). A jump host that sandboxes the SFTP subsystem into its own
+ * chroot makes a late `SSH_FX_NO_SUCH_FILE` the normal answer, so the listener has to
+ * outlive the transfer rather than the other way round.
+ *
+ * `runSftpFallbackTransfer` already does this for the session emitter; this is the same
+ * guarantee one level down, on the streams.
+ */
+
+/** SSH_FX_* status codes ssh2 copies onto the `Error` it builds from a STATUS reply. */
+const SSH_FX_NO_SUCH_FILE = 2
+const SSH_FX_PERMISSION_DENIED = 3
+
+type ErrorEmitter = {
+  on(event: 'error', listener: (err: Error) => void): unknown
+}
+
+export type SftpStreamErrorLatch = {
+  /** Call once the transfer has settled; any error after this point is the late one. */
+  markTransferSettled(): void
+}
+
+export function latchLateSftpStreamErrors(
+  stream: ErrorEmitter,
+  remotePath: string
+): SftpStreamErrorLatch {
+  let settled = false
+  stream.on('error', (err: Error) => {
+    if (!settled) {
+      // The transfer's own listener owns this error and will reject with it.
+      return
+    }
+    console.warn(
+      `[sftp] Ignored late stream error for ${remotePath}: ${err instanceof Error ? err.message : String(err)}`
+    )
+  })
+  return {
+    markTransferSettled: () => {
+      settled = true
+    }
+  }
+}
+
+export function isSandboxedSftpNamespaceError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null)?.code
+  return code === SSH_FX_NO_SUCH_FILE || code === SSH_FX_PERMISSION_DENIED
+}
+
+/**
+ * SFTP is not optional for a bundled-ssh2 relay install — `SshConnection.sftp()` is the
+ * only transfer route on that transport, and the exec-based `tar`/`cat` transfers are
+ * bound to the system-SSH transport, not selectable per operation. So a sandboxed SFTP
+ * subsystem is a clean failure with an actionable message, not a degraded mode.
+ */
+export function describeSandboxedSftpFailure(error: unknown, remotePath: string): Error {
+  const detail = error instanceof Error ? error.message : String(error)
+  return Object.assign(
+    new Error(
+      `Relay install could not reach ${remotePath} over SFTP (${detail}). ` +
+        'The host answered the shell channel but its SFTP subsystem sees a different filesystem — ' +
+        'typically a bastion or jump host that chroots SFTP to a transfer directory. ' +
+        'Orca cannot install the relay through a sandboxed SFTP subsystem; connect to the target ' +
+        'host directly (for example with ProxyJump) or allow SFTP access to the account home.',
+      { cause: error }
+    ),
+    { sandboxedSftpNamespace: true }
+  )
+}

--- a/src/main/ssh/sftp-upload.test.ts
+++ b/src/main/ssh/sftp-upload.test.ts
@@ -40,7 +40,9 @@ describe('sftp-upload', () => {
     })
     const writeStream = vi.mocked(sftp.createWriteStream).mock.results[0]?.value as Writable
     expect(writeStream.listenerCount('close')).toBe(0)
-    expect(writeStream.listenerCount('error')).toBe(0)
+    // One durable 'error' listener stays for the stream's whole life: a STATUS reply that
+    // lands after the transfer settles must not throw into ssh2's parser (#15479).
+    expect(writeStream.listenerCount('error')).toBe(1)
   })
 
   it('uses no-clobber writes for nested files during exclusive directory upload', async () => {
@@ -59,7 +61,9 @@ describe('sftp-upload', () => {
     })
     const writeStream = vi.mocked(sftp.createWriteStream).mock.results[0]?.value as Writable
     expect(writeStream.listenerCount('close')).toBe(0)
-    expect(writeStream.listenerCount('error')).toBe(0)
+    // One durable 'error' listener stays for the stream's whole life: a STATUS reply that
+    // lands after the transfer settles must not throw into ssh2's parser (#15479).
+    expect(writeStream.listenerCount('error')).toBe(1)
   })
 
   it('uploads files from valid dot-dot-prefixed local directories', async () => {

--- a/src/main/ssh/sftp-upload.ts
+++ b/src/main/ssh/sftp-upload.ts
@@ -4,6 +4,7 @@ import { lstat, open, readdir, realpath } from 'node:fs/promises'
 import { isAbsolute, join as pathJoin, relative, sep } from 'node:path'
 import { finished } from 'node:stream/promises'
 import type { SFTPWrapper } from 'ssh2'
+import { latchLateSftpStreamErrors, type SftpStreamErrorLatch } from './sftp-stream-late-error'
 
 export function mkdirSftp(
   sftp: SFTPWrapper,
@@ -44,6 +45,7 @@ async function uploadFileAndJoinTeardown(
   let handleClose: Promise<void> | undefined
   let readStream: ReadStream | undefined
   let writeStream: ReturnType<SFTPWrapper['createWriteStream']> | undefined
+  let writeStreamErrors: SftpStreamErrorLatch | undefined
   const closeHandle = (): Promise<void> => {
     handleClose ??= handle.close()
     return handleClose
@@ -67,6 +69,9 @@ async function uploadFileAndJoinTeardown(
     writeStream = sftp.createWriteStream(remotePath, {
       flags: options?.exclusive ? 'wx' : 'w'
     })
+    // Why: the OPEN reply can land after this transfer settles; without a listener that
+    // outlives it, ssh2 throws it synchronously into the socket handler (#15479).
+    writeStreamErrors = latchLateSftpStreamErrors(writeStream, remotePath)
     readStream = handle.createReadStream({ autoClose: false })
     const abortTransfer = (): void => {
       const reason =
@@ -100,6 +105,7 @@ async function uploadFileAndJoinTeardown(
       options?.signal?.removeEventListener('abort', abortTransfer)
     }
   } finally {
+    writeStreamErrors?.markTransferSettled()
     readStream?.destroy()
     writeStream?.destroy()
     await closeHandle()
@@ -117,8 +123,10 @@ export function uploadBuffer(
     const writeStream = sftp.createWriteStream(remotePath, {
       flags: options?.append ? 'a' : options?.exclusive ? 'wx' : 'w'
     })
+    const lateErrors = latchLateSftpStreamErrors(writeStream, remotePath)
 
     const cleanupListeners = (): void => {
+      lateErrors.markTransferSettled()
       writeStream.off('close', onClose)
       writeStream.off('error', onError)
     }
@@ -147,8 +155,10 @@ export function writeStringViaSftp(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const ws = sftp.createWriteStream(remotePath)
+    const lateErrors = latchLateSftpStreamErrors(ws, remotePath)
     let settled = false
     const cleanup = (): void => {
+      lateErrors.markTransferSettled()
       sftp.removeListener('error', onError)
       ws.removeListener('close', onClose)
       ws.removeListener('error', onError)

--- a/src/main/ssh/sftp-upload.ts
+++ b/src/main/ssh/sftp-upload.ts
@@ -4,7 +4,11 @@ import { lstat, open, readdir, realpath } from 'node:fs/promises'
 import { isAbsolute, join as pathJoin, relative, sep } from 'node:path'
 import { finished } from 'node:stream/promises'
 import type { SFTPWrapper } from 'ssh2'
-import { latchLateSftpStreamErrors, type SftpStreamErrorLatch } from './sftp-stream-late-error'
+import {
+  latchLateSftpSessionErrors,
+  latchLateSftpStreamErrors,
+  type SftpStreamErrorLatch
+} from './sftp-stream-late-error'
 
 export function mkdirSftp(
   sftp: SFTPWrapper,
@@ -185,6 +189,29 @@ export function writeStringViaSftp(
     ws.once('error', onError)
     ws.end(contents)
   })
+}
+
+/**
+ * Write several files over one SFTP session, ending it when they are all done.
+ *
+ * Owns the session's late-error latch, which is why a caller must not hand-roll this
+ * loop: `writeStringViaSftp` drops its own session listener at each settle, so between
+ * files and after the last one the emitter would carry none, and a late STATUS reply
+ * throws synchronously out of ssh2's parser into main (#15479).
+ */
+export async function writeStringsViaSftp(
+  conn: { sftp(): Promise<SFTPWrapper> },
+  files: readonly { path: string; contents: string }[]
+): Promise<void> {
+  const sftp = await conn.sftp()
+  latchLateSftpSessionErrors(sftp)
+  try {
+    for (const file of files) {
+      await writeStringViaSftp(sftp, file.path, file.contents)
+    }
+  } finally {
+    sftp.end()
+  }
 }
 
 export async function uploadDirectory(

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -85,6 +85,12 @@ import { powerShellCommand, powerShellLiteral, powerShellNativeArg } from './ssh
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
 import { resolveRelayEndpointBeforeRelaunch } from './ssh-relay-endpoint-takeover'
 import { sweepSupersededRelayEndpoints } from './ssh-relay-superseded-endpoints'
+import {
+  parseShortRelaySocketDir,
+  remoteSocketPathFitsLimit,
+  resolveShortRelaySocketDirCommand,
+  shortRelaySocketPath
+} from './relay-socket-path-limit'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
 import {
   isWindowsRelayPipePath,
@@ -1636,9 +1642,13 @@ async function launchRelay(
   const escapedNode = shellEscape(nodePath)
   // Why: remoteRelayDir is shared across Orca targets for one account; hashing the target ID into the socket name stops cross-target attach.
   const sockName = relaySocketNameForInstanceId(relayInstanceId)
-  const sockFile = relayEndpointForHost(hostPlatform, remoteDir, sockName)
-  const endpointDir = relayHookEndpointDirForHost(hostPlatform, remoteDir, sockFile)
+  const defaultSockFile = relayEndpointForHost(hostPlatform, remoteDir, sockName)
+  const endpointDir = relayHookEndpointDirForHost(hostPlatform, remoteDir, defaultSockFile)
   const credentialFile = joinRemotePath(hostPlatform, remoteDir, `${sockName}.credential`)
+  // Why: a long remote $HOME pushes the default endpoint past sun_path and bind fails with a bare `listen EINVAL` (#10726).
+  const sockFile = remoteSocketPathFitsLimit(hostPlatform, defaultSockFile)
+    ? defaultSockFile
+    : await resolveShortPosixRelaySocketPath(conn, sockName, defaultSockFile, signal)
 
   if (isWindowsRemoteHost(hostPlatform)) {
     const activePipeMarkerPath = windowsActivePipeMarkerPath(hostPlatform, remoteDir, sockName)
@@ -1720,7 +1730,10 @@ async function launchRelay(
     signal
   })
   // Why: --log-file lets the relay rotate relay.log in-process; the shell redirect stays to capture pre-JS boot/crash output.
-  const launchCmd = `cd ${escapedDir} && chmod 600 ${shellEscape(credentialFile)} && nohup ${escapedNode} relay.js --detached --grace-time ${graceTime} --sock-path ${shellEscape(sockFile)} --credential-file ${shellEscape(credentialFile)} --log-file ${shellEscape(logFile)} > ${shellEscape(logFile)} 2>&1 </dev/null &`
+  // Why: the relay derives its hook endpoint dir from the socket path; pin it back under the relay dir when the socket moved to /tmp.
+  const endpointDirArg =
+    sockFile === defaultSockFile ? '' : ` --endpoint-dir ${shellEscape(endpointDir)}`
+  const launchCmd = `cd ${escapedDir} && chmod 600 ${shellEscape(credentialFile)} && nohup ${escapedNode} relay.js --detached --grace-time ${graceTime} --sock-path ${shellEscape(sockFile)}${endpointDirArg} --credential-file ${shellEscape(credentialFile)} --log-file ${shellEscape(logFile)} > ${shellEscape(logFile)} 2>&1 </dev/null &`
   const launchChannel = await conn.exec(launchCmd, { signal })
   launchChannel.on('data', () => {})
   launchChannel.on('error', () => {})
@@ -1779,6 +1792,40 @@ async function launchRelay(
     sockPath: sockFile,
     credentialFile
   }
+}
+
+/**
+ * Move the endpoint under a `$HOME`-independent base so its length is bounded.
+ *
+ * The hashed socket name is preserved in full: only the directory shrinks, so the
+ * short form stays deterministic per target and cannot collide with another target.
+ */
+async function resolveShortPosixRelaySocketPath(
+  conn: SshConnection,
+  sockName: string,
+  defaultSockFile: string,
+  signal?: AbortSignal
+): Promise<string> {
+  const output = await execCommand(conn, resolveShortRelaySocketDirCommand(), { signal }).catch(
+    (err: unknown) => {
+      if (isUnconfirmedSshCommandTermination(err)) {
+        throw err
+      }
+      signal?.throwIfAborted()
+      return ''
+    }
+  )
+  const shortDir = parseShortRelaySocketDir(output)
+  if (!shortDir) {
+    throw new Error(
+      `Relay socket path ${defaultSockFile} exceeds the remote Unix socket limit and no short socket directory could be created on the host.`
+    )
+  }
+  const shortSockFile = shortRelaySocketPath(shortDir, sockName)
+  console.warn(
+    `[ssh-relay] Socket path too long for sun_path; using ${shortSockFile} instead of ${defaultSockFile}`
+  )
+  return shortSockFile
 }
 
 function waitForRelayPoll(delayMs: number, signal?: AbortSignal): Promise<void> {

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -89,7 +89,9 @@ import {
   parseShortRelaySocketDir,
   remoteSocketPathFitsLimit,
   resolveShortRelaySocketDirCommand,
-  shortRelaySocketPath
+  shortRelaySocketPath,
+  shortRelayVersionSegment,
+  SHORT_RELAY_SOCKET_DIR_PREFIX
 } from './relay-socket-path-limit'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
 import {
@@ -604,6 +606,13 @@ async function deployAndLaunchRelayAttempt(
         remoteHome,
         currentRelayDir: remoteRelayDir,
         sockName: relaySocketNameForInstanceId(relayInstanceId),
+        // Set only when this launch relocated past sun_path; the sweep must not reap
+        // the socket the transport it just handed back is talking to.
+        ...(launched.sockPath.startsWith(SHORT_RELAY_SOCKET_DIR_PREFIX)
+          ? {
+              currentShortSocketDir: launched.sockPath.slice(0, launched.sockPath.lastIndexOf('/'))
+            }
+          : {}),
         nodePath: launched.nodePath
       })
     )
@@ -1648,7 +1657,7 @@ async function launchRelay(
   // Why: a long remote $HOME pushes the default endpoint past sun_path and bind fails with a bare `listen EINVAL` (#10726).
   const sockFile = remoteSocketPathFitsLimit(hostPlatform, defaultSockFile)
     ? defaultSockFile
-    : await resolveShortPosixRelaySocketPath(conn, sockName, defaultSockFile, signal)
+    : await resolveShortPosixRelaySocketPath(conn, remoteDir, sockName, defaultSockFile, signal)
 
   if (isWindowsRemoteHost(hostPlatform)) {
     const activePipeMarkerPath = windowsActivePipeMarkerPath(hostPlatform, remoteDir, sockName)
@@ -1799,23 +1808,27 @@ async function launchRelay(
  *
  * The hashed socket name is preserved in full: only the directory shrinks, so the
  * short form stays deterministic per target and cannot collide with another target.
+ * The version directory's identity comes along as a hashed segment, so a later build
+ * still binds a path of its own rather than the one its predecessor is holding.
  */
 async function resolveShortPosixRelaySocketPath(
   conn: SshConnection,
+  remoteDir: string,
   sockName: string,
   defaultSockFile: string,
   signal?: AbortSignal
 ): Promise<string> {
-  const output = await execCommand(conn, resolveShortRelaySocketDirCommand(), { signal }).catch(
-    (err: unknown) => {
-      if (isUnconfirmedSshCommandTermination(err)) {
-        throw err
-      }
-      signal?.throwIfAborted()
-      return ''
+  const versionSegment = shortRelayVersionSegment(remoteDir.slice(remoteDir.lastIndexOf('/') + 1))
+  const output = await execCommand(conn, resolveShortRelaySocketDirCommand(versionSegment), {
+    signal
+  }).catch((err: unknown) => {
+    if (isUnconfirmedSshCommandTermination(err)) {
+      throw err
     }
-  )
-  const shortDir = parseShortRelaySocketDir(output)
+    signal?.throwIfAborted()
+    return ''
+  })
+  const shortDir = parseShortRelaySocketDir(output, versionSegment)
   if (!shortDir) {
     throw new Error(
       `Relay socket path ${defaultSockFile} exceeds the remote Unix socket limit and no short socket directory could be created on the host.`

--- a/src/main/ssh/ssh-relay-install-transfers.ts
+++ b/src/main/ssh/ssh-relay-install-transfers.ts
@@ -15,7 +15,8 @@ import {
 import type { RemoteHostPlatform } from './ssh-remote-platform'
 import {
   describeSandboxedSftpFailure,
-  isSandboxedSftpNamespaceError
+  isSandboxedSftpNamespaceError,
+  latchLateSftpSessionErrors
 } from './sftp-stream-late-error'
 
 export type RelayTransferOptions = {
@@ -105,7 +106,6 @@ async function runSftpFallbackTransfer(
   transfer: (sftp: SFTPWrapper) => Promise<void>
 ): Promise<void> {
   const sftp = await conn.sftp(options?.signal)
-  const swallowLateSftpError = (): void => {}
   let sftpEndRequested = false
   const endSftp = (): void => {
     if (!sftpEndRequested) {
@@ -113,9 +113,7 @@ async function runSftpFallbackTransfer(
       sftp.end()
     }
   }
-  // A late session 'error' after settle would otherwise be unhandled and crash main.
-  sftp.on('error', swallowLateSftpError)
-  sftp.once('close', () => sftp.removeListener('error', swallowLateSftpError))
+  latchLateSftpSessionErrors(sftp)
   try {
     await raceSftpFileTransferWithAbort(
       transfer(sftp),

--- a/src/main/ssh/ssh-relay-install-transfers.ts
+++ b/src/main/ssh/ssh-relay-install-transfers.ts
@@ -13,6 +13,10 @@ import {
   type SftpNamespacePathMapping
 } from './sftp-namespace-resolution'
 import type { RemoteHostPlatform } from './ssh-remote-platform'
+import {
+  describeSandboxedSftpFailure,
+  isSandboxedSftpNamespaceError
+} from './sftp-stream-late-error'
 
 export type RelayTransferOptions = {
   signal?: AbortSignal
@@ -20,6 +24,18 @@ export type RelayTransferOptions = {
 }
 
 export async function uploadRelayDirectory(
+  conn: SshConnection,
+  localRelayDir: string,
+  shellRemoteDir: string,
+  hostPlatform: RemoteHostPlatform,
+  options?: RelayTransferOptions
+): Promise<void> {
+  await withSandboxedSftpDiagnosis(shellRemoteDir, () =>
+    uploadRelayDirectoryTransfer(conn, localRelayDir, shellRemoteDir, hostPlatform, options)
+  )
+}
+
+async function uploadRelayDirectoryTransfer(
   conn: SshConnection,
   localRelayDir: string,
   shellRemoteDir: string,
@@ -47,6 +63,18 @@ export async function uploadRelayDirectory(
 }
 
 export async function writeRelayFile(
+  conn: SshConnection,
+  hostPlatform: RemoteHostPlatform,
+  shellRemotePath: string,
+  contents: string,
+  options?: RelayTransferOptions
+): Promise<void> {
+  await withSandboxedSftpDiagnosis(shellRemotePath, () =>
+    writeRelayFileTransfer(conn, hostPlatform, shellRemotePath, contents, options)
+  )
+}
+
+async function writeRelayFileTransfer(
   conn: SshConnection,
   hostPlatform: RemoteHostPlatform,
   shellRemotePath: string,
@@ -100,5 +128,25 @@ async function runSftpFallbackTransfer(
     )
   } finally {
     endSftp()
+  }
+}
+
+/**
+ * A jump host whose SFTP subsystem is chrooted answers a home path with
+ * SSH_FX_NO_SUCH_FILE even though the shell channel resolves it (#15479). SFTP is the
+ * only install route on the bundled-ssh2 transport, so say what the host did rather
+ * than surfacing a bare "file does not exist".
+ */
+async function withSandboxedSftpDiagnosis<T>(
+  remotePath: string,
+  transfer: () => Promise<T>
+): Promise<T> {
+  try {
+    return await transfer()
+  } catch (error) {
+    if (isSandboxedSftpNamespaceError(error)) {
+      throw describeSandboxedSftpFailure(error, remotePath)
+    }
+    throw error
   }
 }

--- a/src/main/ssh/ssh-relay-reset.ts
+++ b/src/main/ssh/ssh-relay-reset.ts
@@ -2,6 +2,7 @@ import type { SshConnection } from './ssh-connection'
 import { shellEscape } from './ssh-connection-utils'
 import { execCommand } from './ssh-relay-deploy-helpers'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
+import { SHORT_RELAY_SOCKET_DIR_PREFIX } from './relay-socket-path-limit'
 
 export async function forceStopRelayForTarget(
   conn: SshConnection,
@@ -12,8 +13,10 @@ export async function forceStopRelayForTarget(
   const script = [
     `sock_name=${escapedSockName}`,
     'base="${HOME}/.orca-remote"',
-    'if [ -d "$base" ]; then',
-    '  for sock in "$base"/relay-*/"$sock_name" "$base"/"$sock_name"; do',
+    // Why: a long $HOME moves the socket to the sun_path-safe short base (#10726); reset must reach it there too.
+    `short_base="${SHORT_RELAY_SOCKET_DIR_PREFIX}$(id -u 2>/dev/null)"`,
+    'if [ -d "$base" ] || [ -d "$short_base" ]; then',
+    '  for sock in "$base"/relay-*/"$sock_name" "$base"/"$sock_name" "$short_base"/"$sock_name"; do',
     '    [ -S "$sock" ] || continue',
     '    pid=""',
     // Why: lsof ORs selectors by default; -a prevents reset from targeting

--- a/src/main/ssh/ssh-relay-reset.ts
+++ b/src/main/ssh/ssh-relay-reset.ts
@@ -16,7 +16,7 @@ export async function forceStopRelayForTarget(
     // Why: a long $HOME moves the socket to the sun_path-safe short base (#10726); reset must reach it there too.
     `short_base="${SHORT_RELAY_SOCKET_DIR_PREFIX}$(id -u 2>/dev/null)"`,
     'if [ -d "$base" ] || [ -d "$short_base" ]; then',
-    '  for sock in "$base"/relay-*/"$sock_name" "$base"/"$sock_name" "$short_base"/"$sock_name"; do',
+    '  for sock in "$base"/relay-*/"$sock_name" "$base"/"$sock_name" "$short_base"/relay-*/"$sock_name"; do',
     '    [ -S "$sock" ] || continue',
     '    pid=""',
     // Why: lsof ORs selectors by default; -a prevents reset from targeting

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -5,7 +5,7 @@ import { randomUUID } from 'node:crypto'
 import type { BrowserWindow } from 'electron'
 import { deployAndLaunchRelay } from './ssh-relay-deploy'
 import { execCommand } from './ssh-relay-deploy-helpers'
-import { writeStringViaSftp } from './sftp-upload'
+import { writeStringsViaSftp } from './sftp-upload'
 import { isRelayVersionMismatchError } from './ssh-relay-version-mismatch-error'
 import { isRelayEndpointHeldError } from './ssh-relay-endpoint-incumbent'
 import { forgetRelayNodePtyRepairs, recoverRelayNodePtyForSpawn } from './ssh-relay-node-pty-repair'
@@ -1414,14 +1414,7 @@ export class SshRelaySession {
         await conn.writeFile(file.path, file.contents, { hostPlatform })
       }
     } else {
-      const sftp = await conn.sftp()
-      try {
-        for (const file of plan.files) {
-          await writeStringViaSftp(sftp, file.path, file.contents)
-        }
-      } finally {
-        sftp.end()
-      }
+      await writeStringsViaSftp(conn, plan.files)
     }
     for (const command of plan.postWriteCommands) {
       await execCommand(conn, command, { wrapCommand: !isWindowsRemoteHost(hostPlatform) })

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'node:crypto'
 import type { BrowserWindow } from 'electron'
 import { deployAndLaunchRelay } from './ssh-relay-deploy'
 import { execCommand } from './ssh-relay-deploy-helpers'
+import { writeStringViaSftp } from './sftp-upload'
 import { isRelayVersionMismatchError } from './ssh-relay-version-mismatch-error'
 import { isRelayEndpointHeldError } from './ssh-relay-endpoint-incumbent'
 import { forgetRelayNodePtyRepairs, recoverRelayNodePtyForSpawn } from './ssh-relay-node-pty-repair'
@@ -1416,13 +1417,7 @@ export class SshRelaySession {
       const sftp = await conn.sftp()
       try {
         for (const file of plan.files) {
-          await new Promise<void>((resolve, reject) => {
-            const ws = sftp.createWriteStream(file.path)
-            sftp.once('error', reject)
-            ws.once('close', resolve)
-            ws.once('error', reject)
-            ws.end(file.contents)
-          })
+          await writeStringViaSftp(sftp, file.path, file.contents)
         }
       } finally {
         sftp.end()

--- a/src/main/ssh/ssh-relay-superseded-endpoints.ts
+++ b/src/main/ssh/ssh-relay-superseded-endpoints.ts
@@ -19,6 +19,7 @@
 import type { SshConnection } from './ssh-connection'
 import { shellEscape } from './ssh-connection-utils'
 import { RELAY_REMOTE_DIR } from './relay-protocol'
+import { SHORT_RELAY_SOCKET_DIR_PREFIX } from './relay-socket-path-limit'
 import { execCommand } from './ssh-relay-deploy-helpers'
 import {
   describeRelayEndpointIncumbent,
@@ -53,6 +54,8 @@ export type SupersededRelaySweepOptions = {
   currentRelayDir: string
   /** Stable per-target socket filename, from `relaySocketNameForInstanceId`. */
   sockName: string
+  /** Set only when this launch relocated its socket; that directory is never swept. */
+  currentShortSocketDir?: string
   nodePath: string
   signal?: AbortSignal
 }
@@ -63,15 +66,23 @@ export function supersededRelayEndpointListCommand(options: {
   remoteHome: string
   currentRelayDir: string
   sockName: string
+  currentShortSocketDir?: string
 }): string {
   return [
     `base=${shellEscape(`${options.remoteHome}/${RELAY_REMOTE_DIR}`)}`,
     `sock_name=${shellEscape(options.sockName)}`,
     `current=${shellEscape(options.currentRelayDir)}`,
-    'for sock in "$base"/relay-*/"$sock_name"; do',
+    // Why the second base: a host whose `$HOME` pushes the endpoint past `sun_path` binds
+    // under `/tmp/.orca-relay-<uid>/relay-<versionHash>/` instead (relay-socket-path-limit.ts).
+    // Those orphans are the same population this sweep exists to make visible, and the
+    // `$HOME` glob cannot see them. The uid is resolved on the host; the client never knows it.
+    `short_current=${shellEscape(options.currentShortSocketDir ?? '')}`,
+    `short_base="${SHORT_RELAY_SOCKET_DIR_PREFIX}$(id -u 2>/dev/null)"`,
+    'for sock in "$base"/relay-*/"$sock_name" "$short_base"/relay-*/"$sock_name"; do',
     '  [ -S "$sock" ] || continue',
     '  dir=${sock%/*}',
     '  [ "$dir" = "$current" ] && continue',
+    '  [ -n "$short_current" ] && [ "$dir" = "$short_current" ] && continue',
     '  printf \'%s\\n\' "$sock"',
     'done'
   ].join('\n')
@@ -79,7 +90,14 @@ export function supersededRelayEndpointListCommand(options: {
 
 /** Remove a socket inode proven to have no holder, so version-dir GC can reclaim the tree. */
 export function removeStaleRelayEndpointCommand(sockPath: string): string {
-  return `rm -f ${shellEscape(sockPath)}`
+  const remove = `rm -f ${shellEscape(sockPath)}`
+  if (!sockPath.startsWith(SHORT_RELAY_SOCKET_DIR_PREFIX)) {
+    return remove
+  }
+  // `gcOldRelayVersions` only walks `$HOME/.orca-remote`, so nothing else would ever
+  // reclaim a relocated version segment. `rmdir` fails while another target of the same
+  // build still has a socket there, which is exactly the condition for keeping it.
+  return `${remove}; rmdir ${shellEscape(sockPath.slice(0, sockPath.lastIndexOf('/')))} 2>/dev/null || true`
 }
 
 export function classifySupersededRelay(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15962,7 +15962,8 @@
           "none": "None",
           "search": "Search",
           "showUnreadOnly": "Show unread only",
-          "showChildAgents": "Show child agents"
+          "showChildAgents": "Show child agents",
+          "activityOptions": "Activity options"
         },
         "clearCompleted": {
           "clearedOne": "Cleared 1 completed agent",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17260,7 +17260,9 @@
   "dashboard": {
     "sidebar": {
       "label": "Agents",
-      "dashboardLabel": "Agent Dashboard"
+      "dashboardLabel": "Agent Dashboard",
+      "openActivity": "View activity",
+      "closeActivity": "Turn off activity view"
     }
   },
   "runtimeRpc": {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​531 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​529 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​418 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​391 |

<!-- /orca-pr-loc -->

## #15479 — a late SFTP error kills the app, and it is a synchronous throw

Not an unhandled rejection. `installUnhandledRejectionLogging` absorbs those (`main-process-error-guards.ts:126-133`), while `installUncaughtPipeErrorGuard` re-throws uncaught exceptions on `setImmediate` (`:102-120`) — the reported fatal. So the escape had to be synchronous.

ssh2 answers an SFTP request from inside the protocol parser (`SFTP.js:2854 req.cb(err)`). For a write stream that callback does a bare `this.emit('error', er)` with no `destroyed` guard, and Node throws when `'error'` is emitted with no listener. The throw unwinds through `Protocol.parse` → `Socket.emit('data')` → uncaught → app dies.

Every call site attached its `'error'` listener only for the **duration of the transfer**:

- `sftp-upload.ts:67-89` — the only listener came from `finished(writeStream, { cleanup: true })`, installed ~20 lines after `createWriteStream` and removed the moment that promise settles; the `finally` then destroys unconditionally. Any abort (relay deploy aborts through `deployAbortController`), local-read failure, or throw in between leaves the in-flight `OPEN` with no listener when its STATUS arrives.
- `sftp-upload.ts:117` and `:149` — `cleanup()` removes `'error'` on first settle, **including on `'close'`**, which ssh2 can emit while a request is still outstanding.
- `ssh-relay-session.ts:1356` — a hand-rolled promise plus a leaked `sftp.once('error', reject)` per file.

The codebase already knew this class one level up: `ssh-relay-install-transfers.ts:85` — *"A late session 'error' after settle would otherwise be unhandled and crash main."* The guard existed for the session emitter, not for the streams.

**Clean failure, not degraded mode** — and that was checked rather than assumed. SFTP is not optional on the bundled-ssh2 transport (`ssh-connection.ts:295` throws for system-SSH), and `supportsSftp` / `sftpUnavailable` / `execUpload` have zero hits, so there is no per-operation fallback. An exec-based transfer implementation exists but is bound to `useSystemSshTransport`, chosen at connect time and never in response to an SFTP error. Wiring it as a fallback is a feature, not a crash fix.

New `sftp-stream-late-error.ts` installs one `'error'` listener at stream creation that outlives the transfer — the transfer's own listener still rejects; the latch only stops the emitter being listener-free — plus SSH_FX 2/3 classification so a chrooted SFTP subsystem produces a message naming the cause and suggesting `ProxyJump`. Applied at all three write-stream sites, and `ssh-relay-session.ts:1355` now reuses `writeStringViaSftp` instead of its parallel implementation.

Two existing leak-guard assertions moved `toBe(0)` → `toBe(1)` for `'error'`: that one durable listener **is** the fix's invariant.

```
BEFORE  AssertionError: expected [Function] to not throw an error
        but 'Error: file does not exist' was thrown        <- verbatim the issue's error
        4 failed
AFTER   Tests  6 passed (6)
```

## #10726 — the relay socket path had no length check at all

`ssh-relay-deploy.ts:1385` composed `$HOME/.orca-remote/relay-<fullVersion>/relay-<hash16>.sock`. The fixed suffix costs **66 bytes**, so any `$HOME` over ~41 bytes overflows `sockaddr_un.sun_path` and libuv reports only `listen EINVAL`. Orca already had this constant for the *local* control socket (`ssh-control-socket.ts:26`) but nothing on the remote path.

New `relay-socket-path-limit.ts` carries a per-remote-OS budget — Linux 108, macOS/BSD 104, minus the NUL — and `null` for Windows, where named pipes have no `sun_path`. Compared with `Buffer.byteLength`, not `.length`, since a non-ASCII `$HOME` costs more bytes than characters.

`launchRelay` keeps the existing path when it fits. Otherwise it resolves a `$HOME`-independent base once (`/tmp/.orca-relay-$(id -u)`), created `0700` with an `ls -ldn` owner check that rejects a planted symlink or another user's directory. **The hashed socket name is preserved in full** — only the variable-length directory shrinks — so it stays deterministic per target and cannot collide. Bound is ~55 bytes regardless of `$HOME`. The relocated launch also passes `--endpoint-dir` so agent-hook endpoint files stay under the relay dir rather than following the socket into `/tmp`, and `forceStopRelayForTarget` globs the short base so Reset Relay still reaches it.

```
BEFORE  AssertionError: expected 111 to be less than or equal to 107   <- 111 is the issue's wc -c
        2 failed
AFTER   Tests  6 passed (6)
```

Tested end-to-end through `deployAndLaunchRelay` with the reporter's exact `$HOME`.

## #6988 — already fixed on main; no change made

`6d39e494804` (#7659, 2026-07-24) landed `isGitHubRestrictedShellProbeSuccess` (`ssh-connection.ts:136-167`), and the reporter's exact repro is covered by 11 passing tests.

**Reported finding, deliberately not acted on:** that fix is an allowlist — user must resolve to `git` *and* host to `github.com`/`ssh.github.com`, with four tests explicitly locking in rejection for gitlab.com, non-git users, overridden usernames, and extra stderr. What the probe actually learns is *authentication plus session establishment*, and that is observable without executing anything: OpenSSH reserves exit 255 for its own failures, so any other status means the server answered after auth — exactly what a restricted shell does. Generalizing to that rule would fix GitLab, Gitea, Bitbucket, Azure DevOps and plain `git-shell`, and would match the AGENTS.md rule against GitHub-only special-casing. But it reverses four intentional, tested decisions, so it belongs in its own change with a maintainer's call. Note the probe failure is cosmetic either way — git-over-SSH works.

## Verification

```
$ pnpm test src/main/ssh/ src/relay/
 Test Files  280 passed | 2 skipped (282)
      Tests  3344 passed | 18 skipped

$ pnpm tc:node                            # clean
$ pnpm run check:code-quality:changed     # 0 new findings across 10 files
$ pnpm run sync:localization-catalog      # no change — new strings are main-process Error
                                          # messages, matching this module's convention
```

Fixes #15479, #10726

---

## ELI5

Two crashes. One: an SFTP error arriving after a file transfer finished had no listener, and Node turns that into a hard crash of the whole app. Two: on hosts with a long home directory path, the relay socket exceeded the OS limit and the only error was a meaningless `listen EINVAL`.

## User-facing regression risk

- **The relay socket relocates to `/tmp/.orca-relay-$(id -u)` when the normal path would overflow.** Any external tooling assuming the old path will not find it on those hosts. Reset Relay was updated to look in both places.
- The socket filename hash is preserved in full, so it stays deterministic per target and cannot collide.
- SFTP failures now surface as a clean error naming a chrooted SFTP subsystem and suggesting `ProxyJump`, instead of crashing. No degraded-mode fallback was added — verified there is no per-operation fallback to fall back to.
