### PR TITLE
fix(relay): signal capacity loss instead of dropping, hanging, or truncating

### DIFF
--- a/src/main/ipc/filesystem/filesystem-search-handlers.ts
+++ b/src/main/ipc/filesystem/filesystem-search-handlers.ts
@@ -223,7 +223,13 @@ export function registerFilesystemSearchHandlers(context: FilesystemHandlerConte
             signal: controller?.signal
           })
         }
-        return await listQuickOpenFiles(args.rootPath, store, args.excludePaths, controller?.signal)
+        return await listQuickOpenFiles(
+          args.rootPath,
+          store,
+          args.excludePaths,
+          controller?.signal,
+          args.maxResults
+        )
       } finally {
         listFilesCancellations.finish(event, args.requestToken, controller)
       }

--- a/src/main/ipc/remote-workspace-stale-resync.test.ts
+++ b/src/main/ipc/remote-workspace-stale-resync.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import {
+  REMOTE_WORKSPACE_STALE_NOTIFICATION,
+  type RemoteWorkspaceChangedEvent,
+  type RemoteWorkspaceSession
+} from '../../shared/remote-workspace-types'
+
+const { getActiveMultiplexerMock, getSshConnectionStoreMock } = vi.hoisted(() => ({
+  getActiveMultiplexerMock: vi.fn(),
+  getSshConnectionStoreMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() }
+}))
+
+vi.mock('./ssh', () => ({
+  getActiveMultiplexer: getActiveMultiplexerMock,
+  getSshConnectionStore: getSshConnectionStoreMock
+}))
+
+vi.mock('./remote-workspace-events', () => ({
+  registerRemoteWorkspaceNotificationHandler: vi.fn(() => vi.fn())
+}))
+
+import {
+  _resetRemoteWorkspaceCachesForTests,
+  handleRemoteWorkspaceNotification,
+  registerRemoteWorkspaceHandlers
+} from './remote-workspace'
+
+function session(activeTabId: string): RemoteWorkspaceSession {
+  return {
+    activeWorktreePath: '/remote/worktree',
+    activeTabId,
+    tabsByWorktreePath: {
+      '/remote/worktree': [{ id: activeTabId, worktreePath: '/remote/worktree' } as never]
+    },
+    terminalLayoutsByTabId: {}
+  }
+}
+
+describe('workspace.stale resync', () => {
+  const sent: RemoteWorkspaceChangedEvent[] = []
+  const request = vi.fn()
+  const store = { getRepo: vi.fn(), getWorkspaceSession: vi.fn() } as unknown as Store
+
+  beforeEach(() => {
+    sent.length = 0
+    request.mockReset()
+    _resetRemoteWorkspaceCachesForTests()
+    getActiveMultiplexerMock.mockReset()
+    getActiveMultiplexerMock.mockImplementation(() => ({ request }))
+    getSshConnectionStoreMock.mockReset()
+    getSshConnectionStoreMock.mockImplementation(() => ({
+      getTarget: (id: string) => ({ id, host: 'example.test', username: 'dev' }),
+      listTargets: () => []
+    }))
+    const win = {
+      isDestroyed: () => false,
+      webContents: {
+        send: (_channel: string, event: RemoteWorkspaceChangedEvent) => sent.push(event)
+      }
+    }
+    registerRemoteWorkspaceHandlers(store, () => win as never)
+  })
+
+  it('re-reads the snapshot through workspace.get and publishes it to the renderer', async () => {
+    request.mockResolvedValue({
+      namespace: 'target-1',
+      revision: 12,
+      updatedAt: 5,
+      schemaVersion: 1,
+      session: session('tab-from-other-device')
+    })
+
+    handleRemoteWorkspaceNotification('target-1', REMOTE_WORKSPACE_STALE_NOTIFICATION, {
+      namespace: 'target-1'
+    })
+    await vi.waitFor(() => expect(sent).toHaveLength(1))
+
+    expect(request).toHaveBeenCalledWith('workspace.get', { namespace: expect.any(String) })
+    expect(sent[0].targetId).toBe('target-1')
+    expect(sent[0].snapshot.revision).toBe(12)
+    expect(sent[0].snapshot.session.activeTabId).toBe('tab-from-other-device')
+    // The marker names no author, so the renderer's own-echo filter must not discard the resync.
+    expect(sent[0].sourceClientId).toBeUndefined()
+  })
+
+  it('collapses a burst of markers into one extra read rather than one read per marker', async () => {
+    const released: ((value: unknown) => void)[] = []
+    request.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          released.push(resolve)
+        })
+    )
+
+    for (let i = 0; i < 4; i++) {
+      handleRemoteWorkspaceNotification('target-1', REMOTE_WORKSPACE_STALE_NOTIFICATION, {
+        namespace: 'target-1'
+      })
+    }
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+
+    request.mockResolvedValue({
+      namespace: 'target-1',
+      revision: 3,
+      updatedAt: 1,
+      schemaVersion: 1,
+      session: session('tab-a')
+    })
+    released[0]?.({
+      namespace: 'target-1',
+      revision: 2,
+      updatedAt: 1,
+      schemaVersion: 1,
+      session: session('tab-a')
+    })
+
+    // Exactly one follow-up read for the markers that landed mid-flight: never zero, never four.
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2))
+    await Promise.resolve()
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('stays silent when the re-read finds the session it already had', async () => {
+    request.mockResolvedValue({
+      namespace: 'target-1',
+      revision: 4,
+      updatedAt: 1,
+      schemaVersion: 1,
+      session: session('tab-a')
+    })
+
+    handleRemoteWorkspaceNotification('target-1', REMOTE_WORKSPACE_STALE_NOTIFICATION, {
+      namespace: 'target-1'
+    })
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(sent).toHaveLength(1))
+
+    handleRemoteWorkspaceNotification('target-1', REMOTE_WORKSPACE_STALE_NOTIFICATION, {
+      namespace: 'target-1'
+    })
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2))
+    await Promise.resolve()
+    expect(sent).toHaveLength(1)
+  })
+})

--- a/src/main/ipc/remote-workspace-stale-resync.ts
+++ b/src/main/ipc/remote-workspace-stale-resync.ts
@@ -1,0 +1,62 @@
+import type { RemoteWorkspaceObservedSnapshot } from '../../shared/remote-workspace-types'
+import type { SshTarget } from '../../shared/ssh-types'
+import { getRemoteSnapshot } from './remote-workspace-relay-sync'
+import { getCachedRemoteWorkspaceSnapshot } from './remote-workspace-snapshot-cache'
+import { remoteWorkspaceSessionMatchesSnapshot } from './remote-workspace-snapshot-normalization'
+
+type PendingResync = { promise: Promise<void>; requeued: boolean }
+
+const pendingByTargetId = new Map<string, PendingResync>()
+
+export function _resetRemoteWorkspaceStaleResyncForTests(): void {
+  pendingByTargetId.clear()
+}
+
+export function isRemoteWorkspaceResyncInFlight(targetId: string): boolean {
+  return pendingByTargetId.has(targetId)
+}
+
+/**
+ * The relay told us it could not deliver a snapshot, so pull it. `workspace.get` is a response, and
+ * responses are admitted against the megabyte-scale control/legacy-response budget rather than the
+ * single ~12KB producer frame that refused the broadcast — the payload was never too big for the
+ * link, only for that one lane.
+ */
+export function resyncStaleRemoteWorkspace(
+  target: SshTarget,
+  deliver: (snapshot: RemoteWorkspaceObservedSnapshot) => void,
+  onError: (error: unknown) => void = () => {}
+): Promise<void> {
+  const existing = pendingByTargetId.get(target.id)
+  if (existing) {
+    // Why: a burst of markers must collapse to one extra read, but never to zero — a marker that
+    // arrived while a read was already in flight may describe a revision that read did not see.
+    existing.requeued = true
+    return existing.promise
+  }
+  const pending: PendingResync = { requeued: false, promise: Promise.resolve() }
+  pending.promise = (async () => {
+    try {
+      do {
+        pending.requeued = false
+        const previous = getCachedRemoteWorkspaceSnapshot(target.id)
+        const snapshot = await getRemoteSnapshot(target)
+        if (!snapshot) {
+          return
+        }
+        // Suppress the echo: our own patch response already cached this session, and re-publishing it
+        // makes the renderer rehydrate a state it authored.
+        if (remoteWorkspaceSessionMatchesSnapshot(previous, snapshot.session)) {
+          continue
+        }
+        deliver(snapshot)
+      } while (pending.requeued)
+    } catch (error) {
+      onError(error)
+    } finally {
+      pendingByTargetId.delete(target.id)
+    }
+  })()
+  pendingByTargetId.set(target.id, pending)
+  return pending.promise
+}

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -2,10 +2,13 @@ import { ipcMain, type BrowserWindow } from 'electron'
 import type { Store } from '../persistence'
 import { getActiveMultiplexer, getSshConnectionStore } from './ssh'
 import { exportRemoteWorkspaceSession } from '../../shared/remote-workspace-session-projection'
-import type {
-  RemoteWorkspaceChangedEvent,
-  RemoteWorkspaceObservedPatchResult,
-  RemoteWorkspaceSession
+import {
+  REMOTE_WORKSPACE_CHANGED_NOTIFICATION,
+  REMOTE_WORKSPACE_STALE_NOTIFICATION,
+  type RemoteWorkspaceChangedEvent,
+  type RemoteWorkspaceObservedPatchResult,
+  type RemoteWorkspaceObservedSnapshot,
+  type RemoteWorkspaceSession
 } from '../../shared/remote-workspace-types'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree/id'
@@ -29,6 +32,10 @@ import {
   rememberRemoteWorkspaceSnapshot
 } from './remote-workspace-snapshot-cache'
 import { normalizeSnapshot } from './remote-workspace-snapshot-normalization'
+import {
+  _resetRemoteWorkspaceStaleResyncForTests,
+  resyncStaleRemoteWorkspace
+} from './remote-workspace-stale-resync'
 
 let mainWindowGetter: (() => BrowserWindow | null) | null = null
 let unregisterRemoteWorkspaceNotifications: (() => void) | null = null
@@ -36,6 +43,7 @@ let unregisterRemoteWorkspaceNotifications: (() => void) | null = null
 export function _resetRemoteWorkspaceCachesForTests(): void {
   clearRemoteWorkspaceSnapshotCache()
   clearRemoteWorkspacePatchTails()
+  _resetRemoteWorkspaceStaleResyncForTests()
 }
 
 export function _getRemoteWorkspaceCacheSizesForTests(): {
@@ -119,12 +127,40 @@ function exportSessionForTarget(
   })
 }
 
+function sendRemoteWorkspaceChanged(
+  targetId: string,
+  snapshot: RemoteWorkspaceObservedSnapshot,
+  sourceClientId: string | undefined
+): void {
+  const event: RemoteWorkspaceChangedEvent = {
+    targetId,
+    snapshot,
+    ...(sourceClientId !== undefined ? { sourceClientId } : {})
+  }
+  const win = mainWindowGetter?.()
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('remoteWorkspace:changed', event)
+  }
+}
+
 export function handleRemoteWorkspaceNotification(
   targetId: string,
   method: string,
   params: Record<string, unknown>
 ): void {
-  if (method !== 'workspace.changed') {
+  if (method === REMOTE_WORKSPACE_STALE_NOTIFICATION) {
+    const target = getSshConnectionStore()?.getTarget(targetId)
+    if (!target) {
+      return
+    }
+    // No sourceClientId on the resynced event: the marker names no author, and guessing one would
+    // let the renderer's own-echo filter discard another device's change.
+    void resyncStaleRemoteWorkspace(target, (snapshot) =>
+      sendRemoteWorkspaceChanged(targetId, snapshot, undefined)
+    )
+    return
+  }
+  if (method !== REMOTE_WORKSPACE_CHANGED_NOTIFICATION) {
     return
   }
   const target = getSshConnectionStore()?.getTarget(targetId)
@@ -139,15 +175,7 @@ export function handleRemoteWorkspaceNotification(
     sourceClientId === CLIENT_ID
       ? rememberLocallyPatchedRemoteWorkspaceSnapshot(targetId, snapshot)
       : rememberRemoteWorkspaceSnapshot(targetId, snapshot)
-  const event: RemoteWorkspaceChangedEvent = {
-    targetId,
-    snapshot: observedSnapshot,
-    sourceClientId
-  }
-  const win = mainWindowGetter?.()
-  if (win && !win.isDestroyed()) {
-    win.webContents.send('remoteWorkspace:changed', event)
-  }
+  sendRemoteWorkspaceChanged(targetId, observedSnapshot, sourceClientId)
 }
 
 export function registerRemoteWorkspaceHandlers(

--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -105,6 +105,13 @@ type EventedProcess = EventEmitter & {
   killed: boolean
 }
 
+// Windows writes read their source asynchronously before spawning, so a close emitted straight
+// after the call can beat the listener. Emit it from the spawn instead.
+function closeOnceSpawned(proc: EventedProcess): EventedProcess {
+  setImmediate(() => proc.emit('close', 0, null))
+  return proc
+}
+
 function createEventedProcess(): EventedProcess {
   const proc = new EventEmitter() as EventedProcess
   proc.stdin = Object.assign(new EventEmitter(), {
@@ -704,7 +711,7 @@ describe('spawnSystemSsh', () => {
 
   it('writes files to Windows system SSH targets with PowerShell stdin bytes', async () => {
     const proc = createEventedProcess()
-    spawnMock.mockReturnValue(proc)
+    spawnMock.mockImplementation(() => closeOnceSpawned(proc))
     const hostPlatform = getRemoteHostPlatform('win32-x64')
 
     const promise = writeFileViaSystemSsh(
@@ -713,7 +720,6 @@ describe('spawnSystemSsh', () => {
       '0.1.0',
       { hostPlatform }
     )
-    proc.emit('close', 0, null)
 
     await expect(promise).resolves.toBeUndefined()
     const args = spawnMock.mock.calls[0][1] as string[]
@@ -725,7 +731,7 @@ describe('spawnSystemSsh', () => {
 
   it('writes binary buffers to Windows system SSH targets with CreateNew mode', async () => {
     const proc = createEventedProcess()
-    spawnMock.mockReturnValue(proc)
+    spawnMock.mockImplementation(() => closeOnceSpawned(proc))
     const hostPlatform = getRemoteHostPlatform('win32-x64')
 
     const promise = writeBufferViaSystemSsh(
@@ -734,7 +740,6 @@ describe('spawnSystemSsh', () => {
       Buffer.from('png'),
       { hostPlatform, exclusive: true }
     )
-    proc.emit('close', 0, null)
 
     await expect(promise).resolves.toBeUndefined()
     const args = spawnMock.mock.calls[0][1] as string[]
@@ -775,7 +780,7 @@ describe('spawnSystemSsh', () => {
 
   it('forces standalone SSH for Windows file writes when requested', async () => {
     const proc = createEventedProcess()
-    spawnMock.mockReturnValue(proc)
+    spawnMock.mockImplementation(() => closeOnceSpawned(proc))
     const hostPlatform = getRemoteHostPlatform('win32-x64')
 
     const promise = writeFileViaSystemSsh(
@@ -784,7 +789,6 @@ describe('spawnSystemSsh', () => {
       '0.1.0',
       { hostPlatform, disableControlMaster: true }
     )
-    proc.emit('close', 0, null)
 
     await expect(promise).resolves.toBeUndefined()
     const args = spawnMock.mock.calls[0][1] as string[]
@@ -793,7 +797,7 @@ describe('spawnSystemSsh', () => {
     expect(args[standaloneControlIdx + 1]).toBe('none')
   })
 
-  it('uploads directories to Windows system SSH targets in one PowerShell batch', async () => {
+  it('uploads a Windows directory as a mkdir batch plus per-file writes, never one blob', async () => {
     const localDir = mkdtempSync(join(tmpdir(), 'orca-system-ssh-upload-'))
     writeFileSync(join(localDir, 'relay.js'), 'console.log("relay")')
     const spawned: EventedProcess[] = []
@@ -816,24 +820,17 @@ describe('spawnSystemSsh', () => {
     }
 
     const commands = spawnMock.mock.calls.map((call) => (call[1] as string[]).at(-1) ?? '')
-    expect(commands).toHaveLength(1)
+    // #16432: directories first (metadata only), then the file bytes on their own stdin. One batch
+    // meant base64-ing the whole bundle into a single PowerShell string, which the remote never read.
+    expect(commands).toHaveLength(2)
     expect(commands.every((command) => command.includes('powershell.exe'))).toBe(true)
     expect(commands.every((command) => !command.includes('/bin/sh'))).toBe(true)
     expect(commands.join('\n')).not.toContain('tar -xzf')
-    const payload = JSON.parse(spawned[0].stdin.end.mock.calls[0]?.[0] as string) as {
-      kind: string
-      path: string
-      contentsBase64?: string
-    }[]
-    expect(payload).toEqual(
-      expect.arrayContaining([
-        { kind: 'directory', path: 'C:/Users/me/.orca-remote/relay' },
-        {
-          kind: 'file',
-          path: 'C:/Users/me/.orca-remote/relay/relay.js',
-          contentsBase64: Buffer.from('console.log("relay")').toString('base64')
-        }
-      ])
+    expect(JSON.parse(spawned[0].stdin.end.mock.calls[0]?.[0] as string)).toEqual([
+      'C:/Users/me/.orca-remote/relay'
+    ])
+    expect(Buffer.from(spawned[1].stdin.end.mock.calls[0]?.[0] as Buffer).toString('utf-8')).toBe(
+      'console.log("relay")'
     )
   })
 

--- a/src/main/ssh/system-ssh-file-binary-transfer.ts
+++ b/src/main/ssh/system-ssh-file-binary-transfer.ts
@@ -74,7 +74,14 @@ export async function writeBufferViaSystemSsh(
 ): Promise<void> {
   throwIfAborted(options?.signal)
   if (options?.hostPlatform && isWindowsRemoteHost(options.hostPlatform)) {
-    await writeBufferViaSystemSshWindows(target, remotePath, contents, options)
+    await writeWindowsBytesViaSystemSsh(
+      target,
+      remotePath,
+      contents.length,
+      (offset, maxBytes) =>
+        Promise.resolve(contents.subarray(offset, Math.min(offset + maxBytes, contents.length))),
+      options
+    )
     return
   }
 
@@ -119,16 +126,28 @@ export async function uploadFileViaSystemSsh(
     }
     throwIfAborted(options?.signal)
 
-    const isWindows = options?.hostPlatform && isWindowsRemoteHost(options.hostPlatform)
+    if (options?.hostPlatform && isWindowsRemoteHost(options.hostPlatform)) {
+      // #16432: a Windows host cannot take a whole file through one stdin, however the local side
+      // paces it — see WINDOWS_STDIN_WRITE_CHUNK_BYTES. This is the path that carries the large
+      // files, so it is the one that has to be chunked and bounded.
+      await writeWindowsBytesViaSystemSsh(
+        target,
+        remotePath,
+        openedStat.size,
+        async (offset, maxBytes) => {
+          const buffer = Buffer.allocUnsafe(Math.min(maxBytes, openedStat.size - offset))
+          const { bytesRead } = await handle.read(buffer, 0, buffer.length, offset)
+          return buffer.subarray(0, bytesRead)
+        },
+        options
+      )
+      return
+    }
+
     const channel = spawnSystemSshCommand(
       target,
-      isWindows
-        ? makeWindowsWriteFileCommand(remotePath, options)
-        : makePosixWriteFileCommand(remotePath, options),
-      {
-        wrapCommand: !isWindows,
-        ...getSystemSshBuildArgsFromOperationOptions(options)
-      }
+      makePosixWriteFileCommand(remotePath, options),
+      getSystemSshBuildArgsFromOperationOptions(options)
     )
     const input = handle.createReadStream({ autoClose: false })
     try {
@@ -153,11 +172,79 @@ export async function uploadFileViaSystemSsh(
   }
 }
 
-async function writeBufferViaSystemSshWindows(
+/**
+ * #16432: Windows PowerShell 5.1 stops draining a redirected stdin over a non-pty ssh exec
+ * somewhere between 50KB and 1MB, depending on the host's `DefaultShell`, and it hangs rather than
+ * failing. The reporter measured that on both constructs he tried — `[Console]::In.ReadToEnd()` and
+ * `new IO.StreamReader([Console]::OpenStandardInput())`, the latter reading incrementally, which is
+ * why the limit cannot be attributed to materializing the payload. `Stream.CopyTo` reads the same
+ * `[Console]::OpenStandardInput()` object with the same incremental `Read` loop, so nothing in it
+ * escapes that limit either: no single write may exceed what one stdin is known to carry.
+ *
+ * 32KB is an order of magnitude under the low end of the measured range, and under 50KB, which the
+ * reporter measured succeeding against a stream reader on the worse of the two `DefaultShell`
+ * settings.
+ */
+export const WINDOWS_STDIN_WRITE_CHUNK_BYTES = 32 * 1024
+
+/** No Windows stdin write should ever outlive this; a wedged PowerShell never closes on its own. */
+export const WINDOWS_STDIN_WRITE_TIMEOUT_MS = 60_000
+
+/** Suffix for the path a multi-exec Windows write lands on before it is published by rename. */
+export const WINDOWS_STAGED_WRITE_SUFFIX = '.orca-partial'
+
+/**
+ * Splits one logical Windows write into stdin-sized execs.
+ *
+ * A write that needs more than one exec cannot land on the destination directly: a chunk failing
+ * mid-file would leave a truncated artifact under the real name with nothing marking it incomplete,
+ * and the retry would then meet its own leftovers — under `exclusive` the retry's `CreateNew` fails
+ * on them. Multi-exec creates therefore land on a staging path and are published by a rename, which
+ * is also where `exclusive` is enforced: once, at the destination, instead of smeared across the
+ * first chunk. A caller-requested append cannot be staged without reading the remote file back, so
+ * it keeps writing straight through, as its own protocol already implies.
+ */
+async function writeWindowsBytesViaSystemSsh(
   target: SshTarget,
   remotePath: string,
-  contents: Buffer,
+  totalBytes: number,
+  readChunk: (offset: number, maxBytes: number) => Promise<Buffer>,
   options: SystemSshWriteBufferOptions
+): Promise<void> {
+  throwIfAborted(options.signal)
+  const staged = !options.append && totalBytes > WINDOWS_STDIN_WRITE_CHUNK_BYTES
+  const writePath = staged ? `${remotePath}${WINDOWS_STAGED_WRITE_SUFFIX}` : remotePath
+  let offset = 0
+  // An empty write still has to run: it is what creates (or truncates) the file.
+  do {
+    const chunk = await readChunk(offset, WINDOWS_STDIN_WRITE_CHUNK_BYTES)
+    if (chunk.length === 0 && offset < totalBytes) {
+      throw new Error(`Source ran short during upload of ${remotePath}`)
+    }
+    await writeWindowsChunkViaSystemSsh(
+      target,
+      writePath,
+      chunk,
+      {
+        ...options,
+        append: staged ? offset > 0 : options.append === true || offset > 0,
+        exclusive: staged ? false : options.exclusive === true && offset === 0
+      },
+      offset
+    )
+    offset += chunk.length
+  } while (offset < totalBytes)
+  if (staged) {
+    await publishWindowsStagedWrite(target, writePath, remotePath, options)
+  }
+}
+
+async function writeWindowsChunkViaSystemSsh(
+  target: SshTarget,
+  remotePath: string,
+  chunk: Buffer,
+  options: SystemSshWriteBufferOptions,
+  offset: number
 ): Promise<void> {
   throwIfAborted(options.signal)
   const channel = spawnSystemSshCommand(target, makeWindowsWriteFileCommand(remotePath, options), {
@@ -167,10 +254,37 @@ async function writeBufferViaSystemSshWindows(
   const closePromise = awaitWithSystemSshAbort(
     options.signal,
     () => channel.close(),
-    waitForChannelClose(channel, `write ${remotePath}`)
+    waitForChannelClose(
+      channel,
+      `write ${remotePath} at offset ${offset}`,
+      WINDOWS_STDIN_WRITE_TIMEOUT_MS
+    )
   )
   if (!options.signal?.aborted) {
-    channel.stdin.end(contents)
+    channel.stdin.end(chunk)
+  }
+  await closePromise
+}
+
+async function publishWindowsStagedWrite(
+  target: SshTarget,
+  stagingPath: string,
+  remotePath: string,
+  options: SystemSshWriteBufferOptions
+): Promise<void> {
+  throwIfAborted(options.signal)
+  const channel = spawnSystemSshCommand(
+    target,
+    makeWindowsPublishStagedFileCommand(stagingPath, remotePath, options.exclusive === true),
+    { wrapCommand: false, ...getSystemSshBuildArgsFromOperationOptions(options) }
+  )
+  const closePromise = awaitWithSystemSshAbort(
+    options.signal,
+    () => channel.close(),
+    waitForChannelClose(channel, `publish ${remotePath}`, WINDOWS_STDIN_WRITE_TIMEOUT_MS)
+  )
+  if (!options.signal?.aborted) {
+    channel.stdin.end()
   }
   await closePromise
 }
@@ -189,6 +303,24 @@ function makeWindowsWriteFileCommand(
       '$inputStream = [Console]::OpenStandardInput()',
       `$outputStream = [System.IO.File]::Open($path, [System.IO.FileMode]::${fileMode}, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)`,
       'try { $inputStream.CopyTo($outputStream) } finally { $outputStream.Dispose() }'
+    ].join('; ')
+  )
+}
+
+// `File::Move` throws when the destination exists, which is exactly the exclusive contract; the
+// non-exclusive caller asked to replace, so it deletes first (a no-op on an absent path).
+function makeWindowsPublishStagedFileCommand(
+  stagingPath: string,
+  remotePath: string,
+  exclusive: boolean
+): string {
+  return powerShellCommand(
+    [
+      '$ErrorActionPreference = "Stop"',
+      `$staging = ${powerShellLiteral(stagingPath)}`,
+      `$path = ${powerShellLiteral(remotePath)}`,
+      ...(exclusive ? [] : ['[System.IO.File]::Delete($path)']),
+      '[System.IO.File]::Move($staging, $path)'
     ].join('; ')
   )
 }

--- a/src/main/ssh/system-ssh-file-transfer.ts
+++ b/src/main/ssh/system-ssh-file-transfer.ts
@@ -1,6 +1,5 @@
 import { spawn } from 'node:child_process'
-import { constants } from 'node:fs'
-import { lstat, open, readdir } from 'node:fs/promises'
+import { lstat, readdir } from 'node:fs/promises'
 import { join as pathJoin } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import type { SshTarget } from '../../shared/ssh-types'
@@ -22,7 +21,12 @@ import {
   waitForProcess,
   type ProcessResult
 } from './system-ssh-operation-lifecycle'
-import { writeBufferViaSystemSsh } from './system-ssh-file-binary-transfer'
+import {
+  uploadFileViaSystemSsh,
+  WINDOWS_STDIN_WRITE_CHUNK_BYTES,
+  WINDOWS_STDIN_WRITE_TIMEOUT_MS,
+  writeBufferViaSystemSsh
+} from './system-ssh-file-binary-transfer'
 
 type SystemSshOperationOptions = SystemSshBuildArgsOptions & {
   signal?: AbortSignal
@@ -109,33 +113,36 @@ async function uploadDirectoryViaSystemSshWindows(
   if (!hostPlatform) {
     throw new Error('Windows system SSH upload requires a remote host platform')
   }
-  const entries = await collectWindowsUploadEntries(
-    localDir,
-    remoteDir,
-    hostPlatform,
-    options.signal
-  )
-  await writeWindowsUploadPackageViaSystemSsh(target, entries, options)
+  const plan = await collectWindowsUploadPlan(localDir, remoteDir, hostPlatform, options.signal)
+  await createWindowsUploadDirectories(target, plan.directories, options)
+  for (const file of plan.files) {
+    throwIfAborted(options.signal)
+    // Reuses the single-file upload: it already opens O_NOFOLLOW, verifies the source did not
+    // change under it, and splits the bytes into stdin-sized writes staged under a partial name.
+    await uploadFileViaSystemSsh(target, file.localPath, file.remotePath, options)
+  }
 }
 
-type WindowsUploadEntry =
-  | {
-      kind: 'directory'
-      path: string
-    }
-  | {
-      kind: 'file'
-      path: string
-      contentsBase64: string
-    }
+type WindowsUploadPlan = {
+  directories: string[]
+  files: { localPath: string; remotePath: string }[]
+}
 
-async function collectWindowsUploadEntries(
+/**
+ * #16432: this used to base64 every artifact into one JSON array and push the whole ~1.9MB string
+ * into one PowerShell stdin. Base64 inflates the payload 1.33x, and Windows PowerShell 5.1 cannot
+ * read a stdin that large over a non-pty ssh exec — it blocks forever instead of failing. Nothing
+ * about a directory upload requires one frame: the plan carries paths only, and the bytes go per
+ * file, in writes bounded by WINDOWS_STDIN_WRITE_CHUNK_BYTES.
+ */
+async function collectWindowsUploadPlan(
   localDir: string,
   remoteDir: string,
   hostPlatform: RemoteHostPlatform,
-  signal: AbortSignal | undefined
-): Promise<WindowsUploadEntry[]> {
-  const entries: WindowsUploadEntry[] = [{ kind: 'directory', path: remoteDir }]
+  signal: AbortSignal | undefined,
+  plan: WindowsUploadPlan = { directories: [], files: [] }
+): Promise<WindowsUploadPlan> {
+  plan.directories.push(remoteDir)
   const dirEntries = await readdir(localDir, { withFileTypes: true })
   for (const entry of dirEntries) {
     throwIfAborted(signal)
@@ -146,75 +153,68 @@ async function collectWindowsUploadEntries(
       continue
     }
     if (statResult.isDirectory()) {
-      entries.push(
-        ...(await collectWindowsUploadEntries(localPath, remotePath, hostPlatform, signal))
-      )
+      await collectWindowsUploadPlan(localPath, remotePath, hostPlatform, signal, plan)
       continue
     }
-    const buffer = await readLocalUploadFile(localPath, statResult)
-    entries.push({ kind: 'file', path: remotePath, contentsBase64: buffer.toString('base64') })
+    plan.files.push({ localPath, remotePath })
   }
-  return entries
+  return plan
 }
 
-async function writeWindowsUploadPackageViaSystemSsh(
+// Why the JSON envelope survives here: a path list is metadata, so this payload stays in the
+// hundreds of bytes even for a deep tree. Batched anyway, so a pathological tree cannot walk back
+// into the same stdin size that wedges PowerShell.
+async function createWindowsUploadDirectories(
   target: SshTarget,
-  entries: WindowsUploadEntry[],
+  directories: readonly string[],
   options: SystemSshOperationOptions
 ): Promise<void> {
-  throwIfAborted(options.signal)
-  const channel = spawnSystemSshCommand(target, makeWindowsUploadPackageCommand(), {
-    wrapCommand: false,
-    ...getSystemSshBuildArgsFromOperationOptions(options)
-  })
-  const closePromise = awaitWithSystemSshAbort(
-    options.signal,
-    () => channel.close(),
-    waitForChannelClose(channel, 'windows relay upload')
-  )
-  if (!options.signal?.aborted) {
-    channel.stdin.end(JSON.stringify(entries))
-  }
-  await closePromise
-}
-
-async function readLocalUploadFile(
-  localPath: string,
-  statResult: Awaited<ReturnType<typeof lstat>>
-): Promise<Buffer> {
-  const handle = await open(localPath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
-  try {
-    const openedStat = await handle.stat()
-    if (
-      !openedStat.isFile() ||
-      openedStat.size !== statResult.size ||
-      (statResult.ino !== 0 && openedStat.ino !== 0 && openedStat.ino !== statResult.ino) ||
-      (statResult.dev !== 0 && openedStat.dev !== 0 && openedStat.dev !== statResult.dev)
-    ) {
-      throw new Error(`File changed during upload: ${localPath}`)
+  let batch: string[] = []
+  let batchBytes = 0
+  const flush = async (): Promise<void> => {
+    if (batch.length === 0) {
+      return
     }
-    return await handle.readFile()
-  } finally {
-    await handle.close()
+    const payload = JSON.stringify(batch)
+    batch = []
+    batchBytes = 0
+    throwIfAborted(options.signal)
+    const channel = spawnSystemSshCommand(target, makeWindowsCreateDirectoriesCommand(), {
+      wrapCommand: false,
+      ...getSystemSshBuildArgsFromOperationOptions(options)
+    })
+    const closePromise = awaitWithSystemSshAbort(
+      options.signal,
+      () => channel.close(),
+      waitForChannelClose(channel, 'windows relay upload mkdir', WINDOWS_STDIN_WRITE_TIMEOUT_MS)
+    )
+    if (!options.signal?.aborted) {
+      channel.stdin.end(payload)
+    }
+    await closePromise
   }
+  for (const directory of directories) {
+    const entryBytes = Buffer.byteLength(directory) + 4
+    if (batch.length > 0 && batchBytes + entryBytes > WINDOWS_STDIN_WRITE_CHUNK_BYTES) {
+      await flush()
+    }
+    batch.push(directory)
+    batchBytes += entryBytes
+  }
+  await flush()
 }
 
-function makeWindowsUploadPackageCommand(): string {
+function makeWindowsCreateDirectoriesCommand(): string {
   return powerShellCommand(
     [
       '$ErrorActionPreference = "Stop"',
-      '$json = [Console]::In.ReadToEnd()',
+      // The reporter measured this reader surviving 50KB where `[Console]::In` wedged at the same
+      // size (#16432); the batch above stays under that.
+      '$reader = New-Object System.IO.StreamReader([Console]::OpenStandardInput())',
+      'try { $json = $reader.ReadToEnd() } finally { $reader.Dispose() }',
       'if ([string]::IsNullOrWhiteSpace($json)) { return }',
-      '$items = $json | ConvertFrom-Json',
-      'foreach ($item in @($items)) {',
-      '  $path = [string]$item.path',
-      '  if ($item.kind -eq "directory") {',
-      '    $null = [System.IO.Directory]::CreateDirectory($path)',
-      '    continue',
-      '  }',
-      '  $parent = [System.IO.Path]::GetDirectoryName($path)',
-      '  if ($parent) { $null = [System.IO.Directory]::CreateDirectory($parent) }',
-      '  [System.IO.File]::WriteAllBytes($path, [Convert]::FromBase64String([string]$item.contentsBase64))',
+      'foreach ($path in @($json | ConvertFrom-Json)) {',
+      '  $null = [System.IO.Directory]::CreateDirectory([string]$path)',
       '}'
     ].join('; ')
   )

--- a/src/main/ssh/system-ssh-operation-lifecycle.ts
+++ b/src/main/ssh/system-ssh-operation-lifecycle.ts
@@ -3,13 +3,25 @@ import type { SystemSshCommandChannel } from './system-ssh-command'
 
 export type ProcessResult = { label: string; stderr: string }
 
+/**
+ * `timeoutMs` bounds a remote consumer that never returns. Windows PowerShell 5.1 cannot drain a
+ * large redirected stdin over a non-pty ssh exec (#16432): the remote process stays alive at idle
+ * CPU, writes nothing, and never closes — so without a bound this promise is simply never settled
+ * and the caller waits forever with no error to show.
+ */
 export function waitForChannelClose(
   channel: SystemSshCommandChannel,
-  label: string
+  label: string,
+  timeoutMs?: number
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     let stderr = ''
+    let timer: ReturnType<typeof setTimeout> | null = null
     const cleanup = (): void => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
       channel.stderr.off('data', onStderrData)
       channel.off('error', onError)
       channel.off('close', onClose)
@@ -17,6 +29,20 @@ export function waitForChannelClose(
     const settle = (fn: typeof resolve | typeof reject, val?: unknown): void => {
       cleanup()
       fn(val as never)
+    }
+    if (timeoutMs !== undefined) {
+      timer = setTimeout(() => {
+        // Settle before closing: the close we request would otherwise come back as a SIGTERM
+        // failure and mask the timeout, which is the only diagnosis a wedged remote gives.
+        settle(
+          reject,
+          new Error(
+            `${label} timed out after ${timeoutMs}ms with no response from the remote host: ${stderr.trim()}`
+          )
+        )
+        channel.close()
+      }, timeoutMs)
+      timer.unref?.()
     }
     const onStderrData = (data: Buffer): void => {
       stderr += data.toString('utf-8')

--- a/src/main/ssh/system-ssh-windows-upload.test.ts
+++ b/src/main/ssh/system-ssh-windows-upload.test.ts
@@ -1,0 +1,288 @@
+/**
+ * #16432: the Windows relay upload pushed the whole bundle into one PowerShell stdin, which
+ * Windows PowerShell 5.1 cannot drain over a non-pty ssh exec — the remote blocks forever, and
+ * `waitForChannelClose()` had no timeout, so the UI sat at "Connecting…" with no error. Covered
+ * here: no write exceeds one stdin's worth on any Windows path (bundle upload *and* single-file
+ * upload, which is the one that carries large files), a partial write never lands under the real
+ * name, and a remote that never closes fails instead of hanging.
+ */
+import { EventEmitter } from 'node:events'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough, Writable } from 'node:stream'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as SystemSshOperationLifecycle from './system-ssh-operation-lifecycle'
+
+const { spawnSystemSshCommandMock, waitForChannelCloseSpy } = vi.hoisted(() => ({
+  spawnSystemSshCommandMock: vi.fn(),
+  waitForChannelCloseSpy: vi.fn()
+}))
+
+vi.mock('./system-ssh-command', () => ({
+  spawnSystemSshCommand: spawnSystemSshCommandMock
+}))
+
+// Delegates to the real implementation; the spy only records whether each wait was given a bound.
+vi.mock('./system-ssh-operation-lifecycle', async (importActual) => {
+  const actual = (await importActual()) as typeof SystemSshOperationLifecycle
+  waitForChannelCloseSpy.mockImplementation(actual.waitForChannelClose)
+  return { ...actual, waitForChannelClose: waitForChannelCloseSpy }
+})
+
+import { uploadDirectoryViaSystemSsh } from './system-ssh-file-transfer'
+import {
+  uploadFileViaSystemSsh,
+  WINDOWS_STAGED_WRITE_SUFFIX,
+  WINDOWS_STDIN_WRITE_CHUNK_BYTES,
+  WINDOWS_STDIN_WRITE_TIMEOUT_MS,
+  writeBufferViaSystemSsh
+} from './system-ssh-file-binary-transfer'
+import { waitForChannelClose } from './system-ssh-operation-lifecycle'
+import { getRemoteHostPlatform } from './ssh-remote-platform'
+import type { SshTarget } from '../../shared/ssh-types'
+
+type FakeChannel = EventEmitter & {
+  stdin: Writable
+  stderr: PassThrough
+  close: () => void
+  written: Buffer
+}
+
+const target = { id: 'win-1', host: 'win.example', username: 'dev' } as unknown as SshTarget
+const hostPlatform = getRemoteHostPlatform('win32-x64')
+const remoteRoot = 'C:/Users/dev/.orca-remote'
+
+/** Recover the script from `powershell.exe ... -EncodedCommand <base64 utf-16le>`. */
+function decodePowerShellCommand(command: string): string {
+  const encoded = /-EncodedCommand (\S+)/.exec(command)?.[1]
+  return encoded === undefined ? command : Buffer.from(encoded, 'base64').toString('utf16le')
+}
+
+function createFakeChannel(onEnd: (channel: FakeChannel) => void): FakeChannel {
+  const channel = new EventEmitter() as FakeChannel
+  channel.written = Buffer.alloc(0)
+  channel.stderr = new PassThrough()
+  channel.stdin = new Writable({
+    write(chunk, _encoding, callback) {
+      channel.written = Buffer.concat([channel.written, Buffer.from(chunk)])
+      callback()
+    },
+    final(callback) {
+      callback()
+      onEnd(channel)
+    }
+  })
+  channel.close = () => channel.emit('close', null, 'SIGTERM')
+  return channel
+}
+
+type RecordedCommand = { script: string; stdin: Buffer }
+
+describe('Windows upload stdin framing', () => {
+  let localDir: string
+  const commands: RecordedCommand[] = []
+  /** Index of the spawn that should report a non-zero exit, to model a chunk failing mid-file. */
+  let failAtSpawn = -1
+
+  const fileWrites = (): RecordedCommand[] =>
+    commands.filter((command) => command.script.includes('FileMode]::'))
+  const writtenPath = (command: RecordedCommand): string =>
+    /\$path = '((?:[^']|'')*)'/.exec(command.script)?.[1].replace(/''/g, "'") ?? ''
+  const fileMode = (command: RecordedCommand): string | undefined =>
+    /FileMode\]::(\w+)/.exec(command.script)?.[1]
+
+  beforeEach(() => {
+    commands.length = 0
+    failAtSpawn = -1
+    waitForChannelCloseSpy.mockClear()
+    localDir = mkdtempSync(join(tmpdir(), 'orca-win-upload-'))
+    spawnSystemSshCommandMock.mockReset()
+    spawnSystemSshCommandMock.mockImplementation((_target: SshTarget, command: string) => {
+      const spawnIndex = spawnSystemSshCommandMock.mock.calls.length - 1
+      return createFakeChannel((channel) => {
+        commands.push({ script: decodePowerShellCommand(command), stdin: channel.written })
+        setImmediate(() =>
+          spawnIndex === failAtSpawn
+            ? channel.emit('close', 1, null)
+            : channel.emit('close', 0, null)
+        )
+      })
+    })
+  })
+
+  afterEach(async () => {
+    await rm(localDir, { recursive: true, force: true })
+  })
+
+  it('never pushes a whole artifact bundle into one PowerShell stdin', async () => {
+    mkdirSync(join(localDir, 'node'), { recursive: true })
+    // Comfortably past the ~50KB point at which the reporter measured PowerShell 5.1 wedging.
+    writeFileSync(join(localDir, 'node', 'relay.js'), Buffer.alloc(600 * 1024, 0x61))
+    writeFileSync(join(localDir, 'index.js'), Buffer.alloc(300 * 1024, 0x62))
+
+    await uploadDirectoryViaSystemSsh(target, localDir, remoteRoot, { hostPlatform })
+
+    const largest = Math.max(...commands.map((command) => command.stdin.length))
+    expect(largest).toBeLessThanOrEqual(WINDOWS_STDIN_WRITE_CHUNK_BYTES)
+    // The base64 + JSON envelope is gone entirely: nothing reads the bundle as one string.
+    expect(commands.some((command) => command.script.includes('FromBase64String'))).toBe(false)
+    // `[Console]::In` wedged at 50KB where the stream reader did not, so the mkdir batch — the one
+    // payload still read as a string — must use the reader the reporter measured surviving.
+    expect(commands.some((command) => command.script.includes('[Console]::In.ReadToEnd()'))).toBe(
+      false
+    )
+    expect(
+      commands.filter((command) => command.script.includes('StreamReader([Console]::'))
+    ).toHaveLength(1)
+  })
+
+  it('bounds the single-file upload too, which is the path large files take', async () => {
+    const contents = Buffer.alloc(WINDOWS_STDIN_WRITE_CHUNK_BYTES * 3 + 11, 0x64)
+    const localPath = join(localDir, 'big.node')
+    writeFileSync(localPath, contents)
+
+    await uploadFileViaSystemSsh(target, localPath, `${remoteRoot}/big.node`, { hostPlatform })
+
+    const writes = fileWrites()
+    expect(writes).toHaveLength(4)
+    expect(Math.max(...writes.map((write) => write.stdin.length))).toBe(
+      WINDOWS_STDIN_WRITE_CHUNK_BYTES
+    )
+    expect(Buffer.concat(writes.map((write) => write.stdin)).equals(contents)).toBe(true)
+    // A wedged PowerShell never closes on its own, so no wait on this path may be unbounded.
+    expect(
+      waitForChannelCloseSpy.mock.calls.every((call) => call[2] === WINDOWS_STDIN_WRITE_TIMEOUT_MS)
+    ).toBe(true)
+  })
+
+  it('writes every byte of every artifact across the chunked writes', async () => {
+    const contents = Buffer.alloc(WINDOWS_STDIN_WRITE_CHUNK_BYTES * 2 + 17, 0x63)
+    writeFileSync(join(localDir, 'relay.js'), contents)
+
+    await uploadDirectoryViaSystemSsh(target, localDir, remoteRoot, { hostPlatform })
+
+    const writes = fileWrites()
+    expect(writes).toHaveLength(3)
+    expect(Buffer.concat(writes.map((write) => write.stdin)).equals(contents)).toBe(true)
+    // Only the first write creates the staging file; the rest must extend it or it is truncated.
+    expect(writes.map(fileMode)).toEqual(['Create', 'Append', 'Append'])
+  })
+
+  it('still creates an empty artifact on the host', async () => {
+    writeFileSync(join(localDir, 'empty.txt'), '')
+
+    await uploadDirectoryViaSystemSsh(target, localDir, remoteRoot, { hostPlatform })
+
+    expect(fileWrites().map(writtenPath)).toEqual([`${remoteRoot}/empty.txt`])
+    expect(fileWrites()[0].stdin).toHaveLength(0)
+    expect(fileMode(fileWrites()[0])).toBe('Create')
+  })
+
+  it('lands a multi-chunk write on a staging path and publishes it by rename', async () => {
+    const remotePath = `${remoteRoot}/relay.js`
+    writeFileSync(join(localDir, 'relay.js'), Buffer.alloc(WINDOWS_STDIN_WRITE_CHUNK_BYTES + 1))
+
+    await uploadDirectoryViaSystemSsh(target, localDir, remoteRoot, { hostPlatform })
+
+    // Nothing touches the real name until every byte is on the host.
+    expect(fileWrites().map(writtenPath)).toEqual([
+      `${remotePath}${WINDOWS_STAGED_WRITE_SUFFIX}`,
+      `${remotePath}${WINDOWS_STAGED_WRITE_SUFFIX}`
+    ])
+    const publish = commands.at(-1)!
+    expect(publish.script).toContain('[System.IO.File]::Move($staging, $path)')
+    expect(publish.script).toContain('[System.IO.File]::Delete($path)')
+  })
+
+  it('leaves no truncated file under the real name when a chunk fails mid-file', async () => {
+    writeFileSync(join(localDir, 'relay.js'), Buffer.alloc(WINDOWS_STDIN_WRITE_CHUNK_BYTES * 3))
+    // Spawns: 0 = mkdir batch, 1..3 = chunk writes. Fail the second chunk.
+    failAtSpawn = 2
+
+    await expect(
+      uploadDirectoryViaSystemSsh(target, localDir, remoteRoot, { hostPlatform })
+    ).rejects.toThrow()
+
+    expect(fileWrites().map(writtenPath)).not.toContain(`${remoteRoot}/relay.js`)
+    expect(commands.some((command) => command.script.includes('::Move('))).toBe(false)
+  })
+
+  it('enforces exclusive once at the rename, so a retry is not blocked by its own leftovers', async () => {
+    const localPath = join(localDir, 'import.bin')
+    writeFileSync(localPath, Buffer.alloc(WINDOWS_STDIN_WRITE_CHUNK_BYTES + 1))
+
+    await uploadFileViaSystemSsh(target, localPath, `${remoteRoot}/import.bin`, {
+      hostPlatform,
+      exclusive: true
+    })
+
+    // CreateNew on chunk one would fail against a leftover staging file from a failed attempt;
+    // `File::Move` raising on an existing destination is what carries the exclusive contract.
+    expect(fileWrites().map(fileMode)).toEqual(['Create', 'Append'])
+    const publish = commands.at(-1)!
+    expect(publish.script).toContain('[System.IO.File]::Move($staging, $path)')
+    expect(publish.script).not.toContain('[System.IO.File]::Delete($path)')
+  })
+
+  it('keeps a single-chunk write on the destination, with the caller mode intact', async () => {
+    await writeBufferViaSystemSsh(target, `${remoteRoot}/version`, Buffer.from('1.2.3'), {
+      hostPlatform,
+      exclusive: true
+    })
+
+    expect(fileWrites()).toHaveLength(1)
+    expect(writtenPath(fileWrites()[0])).toBe(`${remoteRoot}/version`)
+    expect(fileMode(fileWrites()[0])).toBe('CreateNew')
+    expect(commands.some((command) => command.script.includes('::Move('))).toBe(false)
+  })
+
+  it('appends onto the destination rather than staging, since append cannot be staged', async () => {
+    const remotePath = `${remoteRoot}/log.bin`
+    await writeBufferViaSystemSsh(
+      target,
+      remotePath,
+      Buffer.alloc(WINDOWS_STDIN_WRITE_CHUNK_BYTES + 1),
+      { hostPlatform, append: true }
+    )
+
+    expect(fileWrites().map(writtenPath)).toEqual([remotePath, remotePath])
+    expect(fileWrites().map(fileMode)).toEqual(['Append', 'Append'])
+  })
+})
+
+describe('waitForChannelClose bounding', () => {
+  it('fails a remote that accepts stdin and never closes, instead of waiting forever', async () => {
+    vi.useFakeTimers()
+    try {
+      const channel = createFakeChannel(() => {})
+      const settled = vi.fn()
+      const promise = waitForChannelClose(channel as never, 'windows relay upload', 1_000)
+      promise.then(settled, settled)
+
+      await vi.advanceTimersByTimeAsync(999)
+      expect(settled).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(2)
+      await expect(promise).rejects.toThrow(/timed out after 1000ms with no response/)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('leaves an unbounded wait unbounded when no timeout is asked for', async () => {
+    vi.useFakeTimers()
+    try {
+      const channel = createFakeChannel(() => {})
+      const settled = vi.fn()
+      // POSIX `cat` drains its stdin; only the Windows writes need the bound.
+      void waitForChannelClose(channel as never, 'posix write').then(settled, settled)
+
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+      expect(settled).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/relay/fs-handler-list-files-result-limit.test.ts
+++ b/src/relay/fs-handler-list-files-result-limit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * #12547: the relay used to serialize an unbounded `fs.listFiles` reply into one response frame,
+ * which died as "Message too large" or over-capacity. #17954 fixed that by streaming the reply, so
+ * the size of a listing is no longer a correctness question and the host must NOT quietly impose a
+ * cap of its own — a caller that named no limit reads the array as the whole listing, and clients
+ * that predate `maxResults` on this call hardcode `truncated: false`, so a prefix would reach them
+ * as a complete tree with nothing on the wire to notice. The cap belongs to the caller; the host
+ * only clamps it to the ceiling the scan's retention budget assumes.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { runListFilesScanMock } = vi.hoisted(() => ({
+  runListFilesScanMock: vi.fn()
+}))
+
+vi.mock('./fs-list-files-fallback-chain', () => ({
+  runListFilesScan: runListFilesScanMock
+}))
+
+vi.mock('@parcel/watcher', () => ({ subscribe: vi.fn() }))
+
+import { FsHandler } from './fs-handler'
+import { RelayContext } from './context'
+import type { RelayDispatcher } from './dispatcher'
+import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../shared/quick-open-listing-limits'
+
+type ListFilesHandler = (
+  params: Record<string, unknown>,
+  context?: { clientId: number }
+) => Promise<unknown>
+
+function createHandler(): { listFiles: ListFilesHandler; dispose: () => void } {
+  const requestHandlers = new Map<string, ListFilesHandler>()
+  const dispatcher = {
+    onRequest: (method: string, handler: ListFilesHandler) => requestHandlers.set(method, handler),
+    onNotification: vi.fn(),
+    onClientDetached: vi.fn(),
+    notify: vi.fn(),
+    notifyBulk: vi.fn(),
+    publishProducerNotification: vi.fn(() => true),
+    activeClientIds: () => [],
+    producerEnvelopeBudget: () => Number.MAX_SAFE_INTEGER
+  } as unknown as RelayDispatcher
+  const handler = new FsHandler(dispatcher, new RelayContext(), {
+    dispose: vi.fn(),
+    forgetRoot: vi.fn(),
+    subscribe: vi.fn()
+  })
+  return { listFiles: requestHandlers.get('fs.listFiles')!, dispose: () => handler.dispose() }
+}
+
+describe('fs.listFiles result limit', () => {
+  let listFiles: ListFilesHandler
+  let dispose: () => void
+
+  beforeEach(() => {
+    runListFilesScanMock.mockReset()
+    runListFilesScanMock.mockResolvedValue([])
+    const created = createHandler()
+    listFiles = created.listFiles
+    dispose = created.dispose
+    return () => dispose()
+  })
+
+  function scanMaxResults(): unknown {
+    // runListFilesScan(rootPath, excludePathPrefixes, signal, maxResults, searchQuery)
+    return runListFilesScanMock.mock.calls[0][3]
+  }
+
+  it('leaves a request that omitted maxResults unbounded rather than silently prefixing it', async () => {
+    await listFiles({ rootPath: '/remote/root' }, { clientId: 1 })
+
+    expect(scanMaxResults()).toBeUndefined()
+  })
+
+  it('ignores a malformed maxResults rather than treating it as a cap', async () => {
+    await listFiles({ rootPath: '/remote/root', maxResults: 'all' }, { clientId: 1 })
+
+    expect(scanMaxResults()).toBeUndefined()
+  })
+
+  it('answers an uncapped request in full, however large the tree is', async () => {
+    const files = Array.from(
+      { length: QUICK_OPEN_LISTING_MAX_RESULTS + 500 },
+      (_, index) => `f${index}`
+    )
+    runListFilesScanMock.mockResolvedValue(files)
+
+    await expect(listFiles({ rootPath: '/remote/root' }, { clientId: 1 })).resolves.toEqual(files)
+  })
+
+  it('hands a client that named a cap the prefix it asked for', async () => {
+    runListFilesScanMock.mockResolvedValue(
+      Array.from({ length: QUICK_OPEN_LISTING_MAX_RESULTS }, (_, index) => `f${index}`)
+    )
+
+    const files = await listFiles(
+      { rootPath: '/remote/root', maxResults: QUICK_OPEN_LISTING_MAX_RESULTS },
+      { clientId: 1 }
+    )
+
+    expect(files).toHaveLength(QUICK_OPEN_LISTING_MAX_RESULTS)
+  })
+
+  it('keeps a smaller client limit and clamps a larger one', async () => {
+    await listFiles({ rootPath: '/remote/root', maxResults: 33 }, { clientId: 1 })
+    expect(scanMaxResults()).toBe(33)
+
+    runListFilesScanMock.mockClear()
+    await listFiles(
+      { rootPath: '/remote/root', maxResults: QUICK_OPEN_LISTING_MAX_RESULTS * 10 },
+      { clientId: 2 }
+    )
+    expect(scanMaxResults()).toBe(QUICK_OPEN_LISTING_MAX_RESULTS)
+  })
+})

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -25,6 +25,7 @@ import {
   writeRelayFile
 } from './fs-path-mutation-requests'
 import { buildExcludePathPrefixes } from '../shared/quick-open-filter'
+import { resolveQuickOpenResultLimit } from '../shared/quick-open-listing-limits'
 import { maybeStreamRpcResponse, type GitResponseStreamRegistry } from './git-response-stream'
 import { readRelayFileContent, readRelayFileStreamMetadata } from './fs-handler-file-read'
 import { readRelayFileRange } from './fs-handler-file-range'
@@ -217,11 +218,14 @@ export class FsHandler {
     context?: RequestContext
   ): Promise<unknown> {
     const rootPath = expandTilde(params.rootPath as string)
+    // Why no host-side default: #17954 made an oversized reply streamable, so a caller that names no
+    // limit gets its whole listing instead of an unannounced prefix it would report as complete.
+    // A requested limit is still clamped to the shared ceiling the scan's retention budget assumes.
     const maxResults =
       typeof params.maxResults === 'number' &&
       Number.isInteger(params.maxResults) &&
       params.maxResults > 0
-        ? Math.min(params.maxResults, 20_001)
+        ? resolveQuickOpenResultLimit(params.maxResults)
         : undefined
     const searchQuery =
       typeof params.searchQuery === 'string' && params.searchQuery.trim().length > 0

--- a/src/relay/relay-client-resync-marker.ts
+++ b/src/relay/relay-client-resync-marker.ts
@@ -1,0 +1,168 @@
+import type { RelayDispatcher } from './dispatcher'
+
+type RetainedMarker = { params: Record<string, unknown>; estimatedBytes: number }
+
+type MarkerState = {
+  method: string
+  // Why: one outstanding marker per (client, key) keeps sustained backpressure bounded.
+  inFlight: Set<string>
+  // Rejected markers, retained per client so they can be republished when the control lane frees up.
+  pending: Map<number, Map<string, RetainedMarker>>
+  capacityUnsubscribes: Map<number, () => void>
+}
+
+/**
+ * Publishes a small "your view is stale, re-read it" notification on the control lane after a
+ * producer-lane payload was refused. Shared by every producer whose oversized frame would otherwise
+ * desync a client silently; the marker is coalesced per key and retried on capacity, never dropped.
+ */
+export type RelayClientResyncMarkerPublisher = {
+  emit(clientId: number, markerKey: string, params: Record<string, unknown>): void
+  forgetClient(clientId: number): void
+}
+
+export function createRelayClientResyncMarkerPublisher(
+  dispatcher: RelayDispatcher,
+  method: string
+): RelayClientResyncMarkerPublisher {
+  const state: MarkerState = {
+    method,
+    inFlight: new Set(),
+    pending: new Map(),
+    capacityUnsubscribes: new Map()
+  }
+  // In-flight keys need no sweep here: closing a client settles every queued and written frame first.
+  dispatcher.onClientDetached((clientId) => {
+    // Not every detach retires the id: invalidateClient() detaches the primary without removing it and
+    // setWrite() revives it, so dropping the markers here would desync the state the reconnect restores.
+    if (dispatcher.isClientAttached(clientId)) {
+      return
+    }
+    forgetClientMarkers(state, clientId)
+  })
+  return {
+    emit(clientId, markerKey, params) {
+      const retained = state.pending.get(clientId)?.get(markerKey)
+      if (retained) {
+        // Latest generation wins: a retained marker that has not been sent yet must not replay a
+        // projection the producer has already moved past.
+        retained.params = params
+        retained.estimatedBytes = dispatcher.notificationFrameBytes(method, params)
+        return
+      }
+      // Per key, never per client alone: an outstanding marker for one subject must not suppress another's resync.
+      if (state.inFlight.has(markerId(clientId, markerKey))) {
+        return
+      }
+      publishMarker(dispatcher, state, clientId, markerKey, params)
+    },
+    forgetClient(clientId) {
+      forgetClientMarkers(state, clientId)
+    }
+  }
+}
+
+function markerId(clientId: number, markerKey: string): string {
+  return `${clientId} ${markerKey}`
+}
+
+function forgetClientMarkers(state: MarkerState, clientId: number): void {
+  // Unsubscribe first so no re-entrant flush can observe a half-cleared client.
+  state.capacityUnsubscribes.get(clientId)?.()
+  state.capacityUnsubscribes.delete(clientId)
+  state.pending.delete(clientId)
+}
+
+// Why: the control lane — on the producer lane the marker would hit the same full queue that just
+// rejected the payload and be dropped, silently desyncing the client.
+function publishMarker(
+  dispatcher: RelayDispatcher,
+  state: MarkerState,
+  clientId: number,
+  markerKey: string,
+  params: Record<string, unknown>,
+  estimatedBytes?: number
+): void {
+  const key = markerId(clientId, markerKey)
+  const frameBytes = estimatedBytes ?? dispatcher.notificationFrameBytes(state.method, params)
+  state.inFlight.add(key)
+  let settled = false
+  const accepted = dispatcher.tryNotifyClient(
+    clientId,
+    state.method,
+    params,
+    (result) => {
+      // Settles on write, drop, or client close, so the slot can never leak.
+      settled = true
+      state.inFlight.delete(key)
+      if (result.ok) {
+        return
+      }
+      // A frame the sink never wrote leaves the client just as desynced as a rejected one — setWrite
+      // fails every queued and in-flight frame this way. Retain unconditionally: a real detach clears
+      // it through onClientDetached, which fires after this settlement.
+      retainMarker(dispatcher, state, clientId, markerKey, params, frameBytes)
+    },
+    { controlOverflow: 'reject' }
+  )
+  if (accepted || settled) {
+    return
+  }
+  // Admission rejection has no settlement callback: retain the marker instead of desyncing the client.
+  state.inFlight.delete(key)
+  retainMarker(dispatcher, state, clientId, markerKey, params, frameBytes)
+}
+
+function retainMarker(
+  dispatcher: RelayDispatcher,
+  state: MarkerState,
+  clientId: number,
+  markerKey: string,
+  params: Record<string, unknown>,
+  estimatedBytes: number
+): void {
+  if (!state.capacityUnsubscribes.has(clientId)) {
+    const unsubscribe = dispatcher.onClientCapacity(clientId, () =>
+      flushPendingMarkers(dispatcher, state, clientId)
+    )
+    if (!unsubscribe) {
+      // The client went away between admission and arming, so there is nothing left to resync.
+      return
+    }
+    state.capacityUnsubscribes.set(clientId, unsubscribe)
+  }
+  const retained = state.pending.get(clientId)
+  if (retained) {
+    retained.set(markerKey, { params, estimatedBytes })
+    return
+  }
+  state.pending.set(clientId, new Map([[markerKey, { params, estimatedBytes }]]))
+}
+
+function flushPendingMarkers(
+  dispatcher: RelayDispatcher,
+  state: MarkerState,
+  clientId: number
+): void {
+  const retained = state.pending.get(clientId)
+  if (!retained) {
+    return
+  }
+  for (const [markerKey, marker] of Array.from(retained)) {
+    // Capacity fires on every lane; retry only frames the control queue can admit now.
+    if (!dispatcher.canAdmitControlFrame(clientId, marker.estimatedBytes)) {
+      continue
+    }
+    // Drop before republishing so a synchronous settlement cannot see the marker as still pending —
+    // and skip keys a re-entrant flush already took, which would otherwise send the marker twice.
+    if (!retained.delete(markerKey)) {
+      continue
+    }
+    publishMarker(dispatcher, state, clientId, markerKey, marker.params, marker.estimatedBytes)
+  }
+  // Identity check: a re-entrant flush may have retired this set and armed a fresh one to keep.
+  if (retained.size > 0 || state.pending.get(clientId) !== retained) {
+    return
+  }
+  forgetClientMarkers(state, clientId)
+}

--- a/src/relay/relay-watcher-event-emitter.ts
+++ b/src/relay/relay-watcher-event-emitter.ts
@@ -1,6 +1,10 @@
 import type { WatcherProcessEvent } from '../main/ipc/parcel-watcher-process'
 import { resolveRuntimePath } from '../shared/cross-platform-path'
 import type { RelayDispatcher } from './dispatcher'
+import {
+  createRelayClientResyncMarkerPublisher,
+  type RelayClientResyncMarkerPublisher
+} from './relay-client-resync-marker'
 
 type MappedWatcherEvent = {
   kind: string
@@ -13,15 +17,7 @@ type WatcherBatchSizing = {
   batchBytes: number
 }
 
-type OverflowMarkerState = {
-  // Why: one outstanding marker per (client, root) keeps sustained backpressure bounded.
-  inFlight: Set<string>
-  // Rejected markers, retained per client so they can be republished when the control lane frees up.
-  pending: Map<number, Map<string, number>>
-  capacityUnsubscribes: Map<number, () => void>
-}
-
-const overflowMarkerStates = new WeakMap<RelayDispatcher, OverflowMarkerState>()
+const overflowMarkerPublishers = new WeakMap<RelayDispatcher, RelayClientResyncMarkerPublisher>()
 
 export function emitRelayWatcherEvents(
   dispatcher: RelayDispatcher,
@@ -164,147 +160,26 @@ function publishWatcherBatchToClient(
   }
 }
 
-function overflowMarkerState(dispatcher: RelayDispatcher): OverflowMarkerState {
-  const existing = overflowMarkerStates.get(dispatcher)
+function overflowMarkerPublisher(dispatcher: RelayDispatcher): RelayClientResyncMarkerPublisher {
+  const existing = overflowMarkerPublishers.get(dispatcher)
   if (existing) {
     return existing
   }
-  const state: OverflowMarkerState = {
-    inFlight: new Set(),
-    pending: new Map(),
-    capacityUnsubscribes: new Map()
-  }
-  overflowMarkerStates.set(dispatcher, state)
-  // In-flight keys need no sweep here: closing a client settles every queued and written frame first.
-  dispatcher.onClientDetached((clientId) => {
-    // Not every detach retires the id: invalidateClient() detaches the primary without removing it and
-    // setWrite() revives it, so dropping the markers here would desync the tree the reconnect restores.
-    if (dispatcher.isClientAttached(clientId)) {
-      return
-    }
-    forgetClientMarkers(state, clientId)
-  })
-  return state
-}
-
-function forgetClientMarkers(state: OverflowMarkerState, clientId: number): void {
-  // Unsubscribe first so no re-entrant flush can observe a half-cleared client.
-  state.capacityUnsubscribes.get(clientId)?.()
-  state.capacityUnsubscribes.delete(clientId)
-  state.pending.delete(clientId)
+  const publisher = createRelayClientResyncMarkerPublisher(dispatcher, 'fs.changed')
+  overflowMarkerPublishers.set(dispatcher, publisher)
+  return publisher
 }
 
 function overflowMarkerParams(rootPath: string): Record<string, unknown> {
   return { events: [{ kind: 'overflow', absolutePath: rootPath }] }
 }
 
-// Why: the control lane — on the producer lane the marker would hit the same full queue that just
-// rejected the batch and be dropped, silently desyncing the remote file tree.
 function emitWatcherOverflowToClient(
   dispatcher: RelayDispatcher,
   clientId: number,
   rootPath: string
 ): void {
-  const state = overflowMarkerState(dispatcher)
-  // Per root, never per client alone: an outstanding marker for one tree must not suppress another's resync.
-  if (
-    state.inFlight.has(`${clientId} ${rootPath}`) ||
-    state.pending.get(clientId)?.has(rootPath) === true
-  ) {
-    return
-  }
-  publishOverflowMarker(dispatcher, state, clientId, rootPath)
-}
-
-function publishOverflowMarker(
-  dispatcher: RelayDispatcher,
-  state: OverflowMarkerState,
-  clientId: number,
-  rootPath: string,
-  estimatedBytes?: number
-): void {
-  const key = `${clientId} ${rootPath}`
-  const params = overflowMarkerParams(rootPath)
-  const frameBytes = estimatedBytes ?? dispatcher.notificationFrameBytes('fs.changed', params)
-  state.inFlight.add(key)
-  let settled = false
-  const accepted = dispatcher.tryNotifyClient(
-    clientId,
-    'fs.changed',
-    params,
-    (result) => {
-      // Settles on write, drop, or client close, so the slot can never leak.
-      settled = true
-      state.inFlight.delete(key)
-      if (result.ok) {
-        return
-      }
-      // A frame the sink never wrote leaves the tree just as desynced as a rejected one — setWrite
-      // fails every queued and in-flight frame this way. Retain unconditionally: a real detach clears
-      // it through onClientDetached, which fires after this settlement.
-      retainOverflowMarker(dispatcher, state, clientId, rootPath, frameBytes)
-    },
-    { controlOverflow: 'reject' }
-  )
-  if (accepted || settled) {
-    return
-  }
-  // Admission rejection has no settlement callback: retain the marker instead of desyncing the tree.
-  state.inFlight.delete(key)
-  retainOverflowMarker(dispatcher, state, clientId, rootPath, frameBytes)
-}
-
-function retainOverflowMarker(
-  dispatcher: RelayDispatcher,
-  state: OverflowMarkerState,
-  clientId: number,
-  rootPath: string,
-  estimatedBytes: number
-): void {
-  if (!state.capacityUnsubscribes.has(clientId)) {
-    const unsubscribe = dispatcher.onClientCapacity(clientId, () =>
-      flushPendingOverflowMarkers(dispatcher, state, clientId)
-    )
-    if (!unsubscribe) {
-      // The client went away between admission and arming, so there is nothing left to resync.
-      return
-    }
-    state.capacityUnsubscribes.set(clientId, unsubscribe)
-  }
-  const roots = state.pending.get(clientId)
-  if (roots) {
-    roots.set(rootPath, estimatedBytes)
-    return
-  }
-  state.pending.set(clientId, new Map([[rootPath, estimatedBytes]]))
-}
-
-function flushPendingOverflowMarkers(
-  dispatcher: RelayDispatcher,
-  state: OverflowMarkerState,
-  clientId: number
-): void {
-  const roots = state.pending.get(clientId)
-  if (!roots) {
-    return
-  }
-  for (const [rootPath, estimatedBytes] of Array.from(roots)) {
-    // Capacity fires on every lane; retry only frames the control queue can admit now.
-    if (!dispatcher.canAdmitControlFrame(clientId, estimatedBytes)) {
-      continue
-    }
-    // Drop before republishing so a synchronous settlement cannot see the marker as still pending —
-    // and skip roots a re-entrant flush already took, which would otherwise send the marker twice.
-    if (!roots.delete(rootPath)) {
-      continue
-    }
-    publishOverflowMarker(dispatcher, state, clientId, rootPath, estimatedBytes)
-  }
-  // Identity check: a re-entrant flush may have retired this set and armed a fresh one to keep.
-  if (roots.size > 0 || state.pending.get(clientId) !== roots) {
-    return
-  }
-  forgetClientMarkers(state, clientId)
+  overflowMarkerPublisher(dispatcher).emit(clientId, rootPath, overflowMarkerParams(rootPath))
 }
 
 export function emitRelayWatcherOverflow(

--- a/src/relay/workspace-session-handler.ts
+++ b/src/relay/workspace-session-handler.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from '
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import type { RelayDispatcher } from './dispatcher'
+import { publishWorkspaceSnapshotChange } from './workspace-snapshot-publication'
 
 type RemoteWorkspaceSnapshot = {
   namespace: string
@@ -151,11 +152,15 @@ export class WorkspaceSessionHandler {
       session: patch.session as Record<string, unknown>
     }
     this.write(snapshot)
-    this.dispatcher.notify('workspace.changed', {
-      namespace,
-      snapshot,
-      sourceClientId: typeof params.clientId === 'string' ? params.clientId : undefined
-    })
+    publishWorkspaceSnapshotChange(
+      this.dispatcher,
+      {
+        namespace,
+        snapshot,
+        sourceClientId: typeof params.clientId === 'string' ? params.clientId : undefined
+      },
+      namespace
+    )
     return { ok: true, snapshot }
   }
 

--- a/src/relay/workspace-snapshot-publication.test.ts
+++ b/src/relay/workspace-snapshot-publication.test.ts
@@ -1,0 +1,166 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+import { relayWriterControlReserve } from './dispatcher-writer-admission'
+import { encodeJsonRpcFrame, MessageType, type JsonRpcRequest } from './protocol'
+import { WorkspaceSessionHandler } from './workspace-session-handler'
+import {
+  REMOTE_WORKSPACE_CHANGED_NOTIFICATION,
+  REMOTE_WORKSPACE_STALE_NOTIFICATION
+} from '../shared/remote-workspace-types'
+
+// The relay runs on the REMOTE host, so the sink default is that host's Node major.
+// Node <= 21 defaults to a 16KB high-water mark, which is the 12288B capacity issue #15238 reports.
+const NODE21_HWM = 16 * 1024
+
+function decodeNotifications(
+  written: Buffer[]
+): { method: string; params: Record<string, unknown> }[] {
+  return written
+    .filter((buf) => buf[0] === MessageType.Regular)
+    .map((buf) => {
+      const len = buf.readUInt32BE(9)
+      return JSON.parse(buf.subarray(13, 13 + len).toString('utf-8')) as {
+        method?: string
+        params?: Record<string, unknown>
+      }
+    })
+    .filter(
+      (msg): msg is { method: string; params: Record<string, unknown> } =>
+        typeof msg.method === 'string'
+    )
+    .map((msg) => ({ method: msg.method, params: msg.params ?? {} }))
+}
+
+/** A session shaped like the report: several worktrees, each with a handful of tabs. */
+function oversizedSession(worktrees: number, tabsPerWorktree: number): Record<string, unknown> {
+  const tabsByWorktreePath: Record<string, unknown[]> = {}
+  const terminalLayoutsByTabId: Record<string, unknown> = {}
+  for (let w = 0; w < worktrees; w++) {
+    const worktreePath = `/home/dev/orca/workspaces/project/feature-branch-${w}`
+    tabsByWorktreePath[worktreePath] = Array.from({ length: tabsPerWorktree }, (_, t) => ({
+      id: `tab-${w}-${t}-1f7a4c2e-9b0d-4e51-8a63-2c9f0d1e4b7a`,
+      title: `claude — feature-branch-${w} — pane ${t}`,
+      worktreePath,
+      kind: 'terminal',
+      startupCommand: 'claude --dangerously-skip-permissions',
+      cwd: worktreePath
+    }))
+    for (let t = 0; t < tabsPerWorktree; t++) {
+      terminalLayoutsByTabId[`tab-${w}-${t}-1f7a4c2e-9b0d-4e51-8a63-2c9f0d1e4b7a`] = {
+        direction: 'row',
+        panes: [
+          { id: `pane-${w}-${t}-a`, size: 50, remoteSessionId: `orca-remote-${w}-${t}-a` },
+          { id: `pane-${w}-${t}-b`, size: 50, remoteSessionId: `orca-remote-${w}-${t}-b` }
+        ]
+      }
+    }
+  }
+  return {
+    activeWorktreePath: '/home/dev/orca/workspaces/project/feature-branch-0',
+    activeTabId: 'tab-0-0-1f7a4c2e-9b0d-4e51-8a63-2c9f0d1e4b7a',
+    tabsByWorktreePath,
+    terminalLayoutsByTabId
+  }
+}
+
+describe('workspace snapshot publication over a bounded producer frame', () => {
+  let baseDir: string
+  let dispatcher: RelayDispatcher
+  let written: Buffer[]
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'orca-workspace-publication-'))
+    written = []
+    dispatcher = new RelayDispatcher(
+      (data) => {
+        written.push(Buffer.from(data))
+        return true
+      },
+      {
+        writableHighWaterMark: () => NODE21_HWM,
+        writableLength: () => 0,
+        supportsWriteCallback: false
+      }
+    )
+    new WorkspaceSessionHandler(dispatcher, baseDir)
+  })
+
+  afterEach(() => {
+    dispatcher.dispose()
+    rmSync(baseDir, { recursive: true, force: true })
+  })
+
+  async function patch(session: Record<string, unknown>, id: number): Promise<void> {
+    const req: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id,
+      method: 'workspace.patch',
+      params: {
+        namespace: 'ssh_host_project',
+        baseRevision: id - 1,
+        clientId: 'client-a',
+        patch: { kind: 'replace-session', session }
+      }
+    }
+    dispatcher.feed(encodeJsonRpcFrame(req, id, 0))
+    await Promise.resolve()
+    await Promise.resolve()
+  }
+
+  it('publishes the snapshot inline while it fits the producer frame', async () => {
+    await patch(oversizedSession(1, 1), 1)
+
+    const methods = decodeNotifications(written).map((msg) => msg.method)
+    expect(methods).toContain(REMOTE_WORKSPACE_CHANGED_NOTIFICATION)
+    expect(methods).not.toContain(REMOTE_WORKSPACE_STALE_NOTIFICATION)
+  })
+
+  it('tells the client its view is stale instead of dropping an oversized snapshot', async () => {
+    const session = oversizedSession(3, 8)
+    // Pin the premise: this really is over the 12288B capacity the issue reports, so the assertion
+    // below measures the drop path and not a payload that happened to fit.
+    const capacity = NODE21_HWM - relayWriterControlReserve(NODE21_HWM)
+    expect(capacity).toBe(12288)
+    expect(
+      dispatcher.notificationFrameBytes(REMOTE_WORKSPACE_CHANGED_NOTIFICATION, {
+        namespace: 'ssh_host_project',
+        snapshot: {
+          namespace: 'ssh_host_project',
+          revision: 1,
+          updatedAt: 0,
+          schemaVersion: 1,
+          session
+        },
+        sourceClientId: 'client-a'
+      })
+    ).toBeGreaterThan(capacity)
+
+    await patch(session, 1)
+
+    const notifications = decodeNotifications(written)
+    expect(notifications.map((msg) => msg.method)).not.toContain(
+      REMOTE_WORKSPACE_CHANGED_NOTIFICATION
+    )
+    const stale = notifications.filter((msg) => msg.method === REMOTE_WORKSPACE_STALE_NOTIFICATION)
+    expect(stale).toHaveLength(1)
+    expect(stale[0].params).toEqual({ namespace: 'ssh_host_project' })
+  })
+
+  it('carries no revision or author, so a coalesced marker cannot replay a superseded generation', async () => {
+    const session = oversizedSession(3, 8)
+    await patch(session, 1)
+    written = []
+    await patch({ ...session, activeTabId: 'tab-1-1-1f7a4c2e-9b0d-4e51-8a63-2c9f0d1e4b7a' }, 2)
+
+    for (const marker of decodeNotifications(written).filter(
+      (msg) => msg.method === REMOTE_WORKSPACE_STALE_NOTIFICATION
+    )) {
+      expect(marker.params).not.toHaveProperty('revision')
+      expect(marker.params).not.toHaveProperty('sourceClientId')
+      expect(marker.params).not.toHaveProperty('snapshot')
+    }
+  })
+})

--- a/src/relay/workspace-snapshot-publication.ts
+++ b/src/relay/workspace-snapshot-publication.ts
@@ -1,0 +1,49 @@
+import {
+  REMOTE_WORKSPACE_CHANGED_NOTIFICATION,
+  REMOTE_WORKSPACE_STALE_NOTIFICATION
+} from '../shared/remote-workspace-types'
+import type { RelayDispatcher } from './dispatcher'
+import {
+  createRelayClientResyncMarkerPublisher,
+  type RelayClientResyncMarkerPublisher
+} from './relay-client-resync-marker'
+
+const stalePublishers = new WeakMap<RelayDispatcher, RelayClientResyncMarkerPublisher>()
+
+function stalePublisher(dispatcher: RelayDispatcher): RelayClientResyncMarkerPublisher {
+  const existing = stalePublishers.get(dispatcher)
+  if (existing) {
+    return existing
+  }
+  const publisher = createRelayClientResyncMarkerPublisher(
+    dispatcher,
+    REMOTE_WORKSPACE_STALE_NOTIFICATION
+  )
+  stalePublishers.set(dispatcher, publisher)
+  return publisher
+}
+
+/**
+ * Per client, because frame capacity is per client: one peer on a small sink must not cost the
+ * others their snapshot, and a peer that cannot take the snapshot still learns it is behind.
+ * The marker deliberately carries no revision or author — a coalesced marker would then replay a
+ * generation the producer has moved past, which is the same silent staleness this exists to remove.
+ */
+export function publishWorkspaceSnapshotChange(
+  dispatcher: RelayDispatcher,
+  params: Record<string, unknown>,
+  namespace: string
+): void {
+  for (const clientId of dispatcher.activeClientIds()) {
+    if (
+      dispatcher.publishProducerNotification(
+        clientId,
+        REMOTE_WORKSPACE_CHANGED_NOTIFICATION,
+        params
+      )
+    ) {
+      continue
+    }
+    stalePublisher(dispatcher).emit(clientId, namespace, { namespace })
+  }
+}

--- a/src/renderer/src/components/quick-open-file-list.react.test.tsx
+++ b/src/renderer/src/components/quick-open-file-list.react.test.tsx
@@ -7,6 +7,7 @@ import type { FolderWorkspace } from '../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../shared/project-group-types'
 import type { Worktree } from '../../../shared/worktree/types'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../../../shared/quick-open-listing-limits'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import { useRuntimeFileListForWorktree, type RuntimeFileListState } from './quick-open-file-list'
@@ -201,10 +202,40 @@ describe('useRuntimeFileListForWorktree', () => {
         rootPath: '/srv/platform',
         excludePaths: undefined,
         requestToken: expect.any(String),
+        // #12547: the caller names the cap so a full page is readable as truncation.
+        maxResults: QUICK_OPEN_LISTING_MAX_RESULTS,
         signal: expect.any(AbortSignal)
       }
     )
     expect(states.at(-1)?.files).toEqual(['packages/app/package.json'])
+    expect(states.at(-1)?.truncated).toBe(false)
+  })
+
+  // #12547: the host stops at the cap the caller names, so a full page is a prefix. Reporting
+  // truncated:false unconditionally is what left the user with a silent partial list.
+  it('reports a capped listing as truncated instead of as the whole workspace', async () => {
+    const states: RuntimeFileListState[] = []
+    const workspaceKey = folderWorkspaceKey('folder-workspace-1')
+    listRuntimeFilesMock.mockResolvedValue(
+      Array.from({ length: QUICK_OPEN_LISTING_MAX_RESULTS }, (_, i) => `src/file-${i}.ts`)
+    )
+
+    useAppStore.setState({
+      folderWorkspaces: [makeFolderWorkspace({ connectionId: 'ssh-1' })],
+      projectGroups: [makeProjectGroup({ connectionId: 'ssh-1' })],
+      repos: [],
+      worktreesByRepo: {}
+    } as Partial<AppState>)
+
+    await renderProbe({
+      enabled: true,
+      onState: (state) => states.push(state),
+      worktreeId: workspaceKey
+    })
+    await waitForListRuntimeFilesCall()
+
+    expect(states.at(-1)?.files).toHaveLength(QUICK_OPEN_LISTING_MAX_RESULTS)
+    expect(states.at(-1)?.truncated).toBe(true)
   })
 
   it('routes paired folder workspace queries to the owning runtime', async () => {

--- a/src/renderer/src/components/quick-open-file-list.ts
+++ b/src/renderer/src/components/quick-open-file-list.ts
@@ -5,6 +5,7 @@ import type { Worktree } from '../../../shared/worktree/types'
 import { isWindowsAbsolutePathLike } from '../../../shared/cross-platform-path'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { isQuickOpenRemoteQueryTooLarge } from '@/components/quick-open-search'
+import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../../../shared/quick-open-listing-limits'
 import {
   cancelRuntimeFileList,
   listRuntimeFiles,
@@ -261,8 +262,15 @@ export function useRuntimeFileListForWorktree({
           rootPath: worktreePath,
           excludePaths,
           requestToken,
+          maxResults: QUICK_OPEN_LISTING_MAX_RESULTS,
           signal: requestAbortController.signal
-        }).then((files) => ({ files, truncated: false }))
+        }).then((files) => ({
+          // #12547: naming the cap is what makes a full page readable as "there is more". Reporting
+          // false unconditionally is what made the truncation silent — the host bounds the scan to
+          // the cap it is given, so a full page means there are more paths behind it.
+          files,
+          truncated: files.length >= QUICK_OPEN_LISTING_MAX_RESULTS
+        }))
 
     void request
       .then((result) => {

--- a/src/renderer/src/runtime/runtime-file-search-client.ts
+++ b/src/renderer/src/runtime/runtime-file-search-client.ts
@@ -48,6 +48,10 @@ export async function listRuntimeFiles(
     rootPath: string
     excludePaths?: string[]
     requestToken?: string
+    // Why: naming the cap is what makes a full page readable as "there is more". The host returns
+    // the whole listing when no limit is named, so a caller that never states one cannot tell a
+    // bound from a total.
+    maxResults?: number
     signal?: AbortSignal
   }
 ): Promise<string[]> {
@@ -57,7 +61,8 @@ export async function listRuntimeFiles(
       rootPath: args.rootPath,
       connectionId: context.connectionId,
       excludePaths: args.excludePaths,
-      requestToken: args.requestToken
+      requestToken: args.requestToken,
+      ...(args.maxResults === undefined ? {} : { maxResults: args.maxResults })
     })
   }
   return callRuntimeRpc<string[]>(
@@ -65,7 +70,9 @@ export async function listRuntimeFiles(
     'files.listAll',
     {
       worktree: toRuntimeWorktreeSelector(context.worktreeId),
-      excludePaths: args.excludePaths
+      excludePaths: args.excludePaths,
+      // Optional on the host schema since #17954; an older host strips it and keeps its own default.
+      ...(args.maxResults === undefined ? {} : { maxResults: args.maxResults })
     },
     { timeoutMs: 15_000, ...(args.signal === undefined ? {} : { signal: args.signal }) }
   )

--- a/src/shared/remote-workspace-types.ts
+++ b/src/shared/remote-workspace-types.ts
@@ -59,6 +59,19 @@ export type RemoteWorkspaceObservedPatchResult =
       message?: string
     }
 
+export const REMOTE_WORKSPACE_CHANGED_NOTIFICATION = 'workspace.changed'
+
+/**
+ * Sent instead of `workspace.changed` when the snapshot frame did not fit the client's producer
+ * frame capacity. Carries no session: the client re-reads through `workspace.get`, whose response
+ * lane is budgeted in megabytes rather than in one ~12KB producer frame.
+ *
+ * Wire contract: a relay that predates this never sends it, and a client that predates it drops it
+ * the same way it drops any unknown notification method — which is exactly the silent drop this
+ * replaces, so an un-negotiated pairing is never worse than before.
+ */
+export const REMOTE_WORKSPACE_STALE_NOTIFICATION = 'workspace.stale'
+
 export type RemoteWorkspaceChangedEvent = {
   targetId: string
   snapshot: RemoteWorkspaceObservedSnapshot


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->
<!-- /orca-pr-loc -->

> **Rebased onto current `main` and squashed with #17934 into one commit.** #17934 is folded in and can be closed. They must not land apart: on its own this PR arms a 60 s write timeout on an unstaged chunked Windows upload, which turns a hang into a mid-file failure that leaves a truncated artifact under the real remote name. Evidence below.

Three failures with one shape: a payload past a fixed capacity was met with silence, with a wait that never ends, or with a prefix presented as a whole.

## #15238 — the workspace snapshot was silently dropped

`workspace-session-handler.ts:154` called `dispatcher.notify(...)`, which on rejection does nothing but `logDroppedProducerNotification` — one stderr line, no client-visible effect. Producer notifications are capped per frame at ¾ of the sink high-water mark (12288 B on a Node ≤21 remote), but `DispatcherWriterAdmission.admit` applies **no per-frame cap** to the `control` (1 MB) or `legacy-response` (2 MB) lanes. A 13.8 KB snapshot was never too big for the link, only for the one lane that broadcasts it unsolicited. So the relay publishes per client and, for a client whose sink refused the frame, sends a compact `workspace.stale` marker on the control lane; the client re-reads through `workspace.get`.

**Wire compatibility.** `relay-handshake.ts:129` enforces exact version equality, so a paired client and relay are always the same build — but the *failure shape* of `handleRemoteWorkspaceNotification` (`remote-workspace.ts:141`) is identical to `decodeTerminalStreamFrame` returning `null`: an unknown method vanishes silently. Hence:

- **A new `workspace.stale` method, not a new field on `workspace.changed`.** The tempting Rule-1 move — `workspace.changed` with `snapshot` omitted plus `truncated: true` — is *destructive* under Rule 3: `normalizeSnapshot(undefined, ns)` yields revision 0 and an empty session, which `rememberRemoteWorkspaceSnapshot` caches. An old client would replace its tab list with nothing, worse than the drop. A separate method degrades to exactly today's behaviour.
- **The marker carries `{ namespace }` only** — no `revision`, no `sourceClientId`. Markers coalesce per (client, namespace); one naming an author or generation would replay a projection the producer had moved past, re-creating the staleness being fixed.

The retention/retry machinery is **extracted** from the `fs.changed` overflow path into `relay-client-resync-marker.ts` rather than duplicated — the watcher emitter sheds ~130 lines and its 28 tests pass unchanged.

```
BEFORE  expected [] to have a length of 1 but got +0
        expected "vi.fn()" to be called 1 times, but got 0 times  (×3)
AFTER   6 passed
```
Fixture is 3 worktrees × 8 tabs ⇒ 13024 B, against the reported 13798 B.

## #16432 — the Windows upload hung, and the naive fix could truncate

The issue was attributed to `[Console]::In.ReadToEnd()` materializing the base64 bundle. That is not what the reporter measured: he also measured `new IO.StreamReader([Console]::OpenStandardInput())` — an *incremental* reader — hanging at 1 MB. The limit is in the stdin the host hands PowerShell over a non-pty ssh exec, not in the string the script builds. (A later measurement on real Windows PowerShell 5.1 confirmed `CopyTo` moves 2 MB through a plain pipe in under a second, so the constraint is the sshd exec channel specifically.)

- **`uploadFileViaSystemSsh` — the user file-import path (`ssh-connection.ts:567-587`) — was piping a whole file into one Windows stdin, unchunked and untimed.** That is the path large files take, and it was untouched by the first half of this work. It now chunks into 32 KB writes, each with a bounded wait.
- **The Windows directory upload reuses that single-file path** rather than repeating a weaker copy of chunk-read + write-buffer. `readLocalUploadFile`'s `isFile && size && ino && dev` TOCTOU verification comes back with it.
- **A Windows write needing more than one exec lands on `${remotePath}.orca-partial` and is published by `[System.IO.File]::Move`**, so a failed chunk cannot leave a truncated artifact under the real name. `exclusive` is enforced once at the rename, not on the first chunk, where a retry met its own leftovers.
- **The mkdir batch reads stdin through the stream reader the reporter measured surviving 50 KB**, not `[Console]::In`, which he measured wedging at that size. Paths only, batched, so a pathological tree cannot walk back into the same size.
- **`waitForChannelClose` takes an optional bound.** A wedged PowerShell stays alive at idle CPU and never closes, so without one the promise is never settled and the caller waits forever with no error. It settles *before* closing — closing first made the resulting `SIGTERM` mask the timeout, the only diagnosis a wedged remote gives.

### Why the two halves cannot land apart — truncation injected on both

A 262144 B source, upload driven through `uploadDirectoryViaSystemSsh` against a simulated Windows host, failing the 4th chunk write:

```
#17870 alone
  upload rejected:   write C:/…/relay/relay.js at offset 0 failed (exit 1)
  remote filesystem: C:/…/relay/relay.js  size=98304 B
  real-named artifact present: YES (98304 B of 262144)

#17870 + #17934 (this commit)
  upload rejected:   write C:/…/relay/relay.js.orca-partial at offset 98304 failed (exit 1)
  remote filesystem: C:/…/relay/relay.js.orca-partial  size=98304 B
  real-named artifact present: no
```

A truncated `relay.js` is a broken relay that looks installed.

## #12547 — Quick Open showed a prefix as the whole workspace

`quick-open-file-list.ts:265` hardcoded `truncated: false`. The mechanism "a full page means there is more" only works if the caller named the cap, and this caller named none. Quick Open now sends `QUICK_OPEN_LISTING_MAX_RESULTS` on the Electron IPC hop **and** the runtime-RPC hop (the optional `maxResults` field #17954 added to `files.listAll` but nothing was sending), and reads a full page as truncation — lighting the `quickOpen.moreMatchesAvailable` string that already existed, so no catalog change. The local `listQuickOpenFiles` path honours the cap too, which it previously ignored.

### What the rebase dropped, and why

Earlier revisions of this work also **clamped the host unconditionally** (#17870) and **escalated an uncapped request to an explicit error** (#17934). **#17954 landed today and removed the premise.** An oversized `fs.listFiles` reply is now streamed on the bulk lane; its commit message states the case directly — *"picking a ceiling to refuse at does not fix that, it just moves where it shows up and refuses listings that would have been delivered."*

Keeping either would have been a regression:

- the unconditional clamp re-introduces exactly the silent prefix this PR set out to kill, for every caller that names no limit;
- the throw hard-fails **three current in-tree callers that pass no options at all** — `runtime-file-commands-search-runtime-files.ts:81`, `filesystem-read-handlers.ts:125`, `runtime-file-commands-constructor.ts:41` — so the markdown panel and the mobile file browser break on any large remote workspace. That is this build calling itself.

So the host now returns the whole listing when no limit is named and only clamps a limit it was given. `fs-handler-list-files-bounded-response.test.ts` is renamed `fs-handler-list-files-result-limit.test.ts` and inverted: it asserts an uncapped request is answered in full, so nothing can quietly re-add a host-side default.

## Verification

```
$ pnpm tc                                     # clean
$ pnpm run check:code-quality:changed         # 0 new findings across 20 files
$ pnpm test src/relay src/main/ssh src/main/runtime
  866 files | 9790 passed | 27 skipped
$ pnpm test src/main/ipc src/renderer/src/components/quick-open-file-list.react.test.tsx
  1087 files | 11093 passed
```

Rebase check: of the 20 files touched, `main` had moved three since the merge base — `filesystem-search-handlers.ts` (inlined `QUICK_OPEN_SSH_LEGACY_RESULT_LIMIT`), `ssh-system-fallback.test.ts` (+3 unclaimed-alias cases from #17946), `fs-handler.ts` (#17954's streaming). All three verified present in the final file content, not just in the patch. No other file differs from `main`; `en.json` is untouched.

## Residual risk

The 32 KB chunk size is derived from the reporter's measurements, **not verified against a real Windows sshd**, which is the layer the constraint actually lives in. The 60 s bound makes the failure mode a timeout rather than a hang either way, and staging makes a mid-file failure non-destructive. It adds ~47 round-trips for a 1.5 MB bundle — cheap under ControlMaster, worth watching if deploy latency regresses. The reporter's own preferred fix (bsdtar, in Windows since 10 1803, reusing the POSIX transport and cutting the payload ~4.8×) remains the better long-term answer.

Fixes #15238, #16432
Refs #12547, #17954
Supersedes #17934

---

## ELI5

Three ways a remote connection dropped or hung on a large payload: workspace updates over ~12 KB were silently thrown away, leaving your tab list stale; a big Windows upload hung forever instead of erroring, and the obvious fix for that could leave half a file under the real name; and Quick Open showed you the first 20,001 files as if that were all of them.

## User-facing regression risk

- Windows uploads now go per file in 32 KB chunks: roughly 47 extra round-trips for a 1.5 MB bundle, and a failed upload now leaves a `.orca-partial` file behind instead of a truncated real one.
- Quick Open now reports "more matches available" on large workspaces where it previously showed a prefix silently. The listing itself is unchanged in size.
- **Reasoned, not host-verified:** the 32 KB chunk size comes from the reporter's measurements, not a real Windows sshd. A 60 s timeout bounds it regardless.

## Visual Proof

N/A — no visual or interaction change. The only user-visible surface is the existing `quickOpen.moreMatchesAvailable` hint, which now appears when it should.

## Testing

- [x] Unit / integration tests (`pnpm test src/relay src/main/ssh src/main/runtime src/main/ipc`)
- [x] Typecheck (`pnpm tc`)
- [x] Changed-code quality gate
- [x] Truncation injection reproduced on both the intermediate and combined states (above)
- Platforms: macOS (host). Windows upload path is covered by `system-ssh-windows-upload.test.ts` against a simulated host; no real Windows sshd was available.
