### PR TITLE
fix(remote-terminal): keep the stream stall deadline armed on unacknowledged credit

### DIFF
--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15962,7 +15962,8 @@
           "none": "None",
           "search": "Search",
           "showUnreadOnly": "Show unread only",
-          "showChildAgents": "Show child agents"
+          "showChildAgents": "Show child agents",
+          "activityOptions": "Activity options"
         },
         "clearCompleted": {
           "clearedOne": "Cleared 1 completed agent",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17260,7 +17260,9 @@
   "dashboard": {
     "sidebar": {
       "label": "Agents",
-      "dashboardLabel": "Agent Dashboard"
+      "dashboardLabel": "Agent Dashboard",
+      "openActivity": "View activity",
+      "closeActivity": "Turn off activity view"
     }
   },
   "runtimeRpc": {

--- a/src/renderer/src/runtime/remote-runtime-terminal-flow-controller.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-flow-controller.ts
@@ -77,7 +77,7 @@ export abstract class RemoteRuntimeTerminalFlowController extends RemoteRuntimeT
     stream: RemoteRuntimeMultiplexedTerminalState,
     bytes: number
   ): boolean {
-    if (this.streams.get(stream.streamId) !== stream) {
+    if (!this.isRegisteredStream(stream)) {
       return true
     }
     stream.pendingAckBytes += bytes
@@ -110,9 +110,12 @@ export abstract class RemoteRuntimeTerminalFlowController extends RemoteRuntimeT
       stream.watchdog.recordOutputAcknowledged(bytes)
       return true
     }
-    // Why re-charged: dropping an unsent ack shrinks the host window for the stream's life, and the only retry trigger is the output that shrunken window blocks.
-    stream.pendingAckBytes += bytes
-    this.scheduleOutputAcknowledgementFlush(stream)
+    // Why guarded: a failed send may have torn the stream down, and re-charging a dropped stream reschedules itself forever.
+    if (this.isRegisteredStream(stream)) {
+      // Why re-charged: dropping an unsent ack shrinks the host window for the stream's life, and the only retry trigger is the output that shrunken window blocks.
+      stream.pendingAckBytes += bytes
+      this.scheduleOutputAcknowledgementFlush(stream)
+    }
     return false
   }
 

--- a/src/renderer/src/runtime/remote-runtime-terminal-flow-controller.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-flow-controller.ts
@@ -84,20 +84,36 @@ export abstract class RemoteRuntimeTerminalFlowController extends RemoteRuntimeT
     if (stream.pendingAckBytes >= TERMINAL_MULTIPLEX_ACK_BATCH_BYTES) {
       return this.flushOutputAcknowledgement(stream)
     }
-    if (stream.ackFlushTimer === null) {
-      stream.ackFlushTimer = setTimeout(() => {
-        stream.ackFlushTimer = null
-        this.flushOutputAcknowledgement(stream)
-      }, TERMINAL_MULTIPLEX_ACK_FLUSH_MS)
-    }
+    this.scheduleOutputAcknowledgementFlush(stream)
     return true
+  }
+
+  private scheduleOutputAcknowledgementFlush(stream: RemoteRuntimeMultiplexedTerminalState): void {
+    if (stream.ackFlushTimer !== null) {
+      return
+    }
+    stream.ackFlushTimer = setTimeout(() => {
+      stream.ackFlushTimer = null
+      this.flushOutputAcknowledgement(stream)
+    }, TERMINAL_MULTIPLEX_ACK_FLUSH_MS)
   }
 
   private flushOutputAcknowledgement(stream: RemoteRuntimeMultiplexedTerminalState): boolean {
     clearAckFlushTimer(stream)
     const bytes = stream.pendingAckBytes
+    if (bytes <= 0) {
+      return true
+    }
     stream.pendingAckBytes = 0
-    return bytes <= 0 || this.acknowledgeOutput(stream, bytes)
+    if (this.acknowledgeOutput(stream, bytes)) {
+      // Why: only a frame the transport took reopens the host's send window.
+      stream.watchdog.recordOutputAcknowledged(bytes)
+      return true
+    }
+    // Why re-charged: dropping an unsent ack shrinks the host window for the stream's life, and the only retry trigger is the output that shrunken window blocks.
+    stream.pendingAckBytes += bytes
+    this.scheduleOutputAcknowledgementFlush(stream)
+    return false
   }
 
   getStreamsForE2e(): Iterable<RemoteRuntimeMultiplexedTerminalState> {

--- a/src/renderer/src/runtime/remote-runtime-terminal-parse-backpressure.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-parse-backpressure.test.ts
@@ -427,6 +427,56 @@ describe('remote terminal renderer backpressure', () => {
     expect(sentAckBytes()).toEqual([1])
   })
 
+  it('stops rearming the ack flush after a failed ACK tears the stream down', async () => {
+    vi.useFakeTimers()
+    try {
+      const { getRemoteRuntimeTerminalMultiplexer } =
+        await import('./remote-runtime-terminal-multiplexer')
+      const { takeCurrentTerminalDeliveryCredit } =
+        await import('../lib/pane-manager/terminal-delivery-credit')
+      const parseCredits: (() => void)[] = []
+      const stream = await getRemoteRuntimeTerminalMultiplexer('windows-test').subscribeTerminal({
+        terminal: 'term-wedge',
+        client: { id: 'mac-viewer', type: 'desktop' },
+        callbacks: {
+          onData: () => {
+            const credit = takeCurrentTerminalDeliveryCredit()
+            if (credit) {
+              parseCredits.push(credit)
+            }
+          },
+          onSnapshot: vi.fn()
+        }
+      })
+      sendBinary.mockClear()
+      sendBinary.mockImplementation((bytes) => {
+        if (decodeTerminalStreamFrame(bytes)?.opcode === TerminalStreamOpcode.Ack) {
+          throw new Error('socket closed')
+        }
+      })
+      callbacks?.onBinary(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Output,
+          streamId: stream.streamId,
+          seq: 1,
+          payload: encodeTerminalStreamText('x')
+        })
+      )
+      parseCredits[0]?.()
+      await vi.advanceTimersByTimeAsync(50)
+
+      expect(unsubscribe).toHaveBeenCalledOnce()
+      expect(vi.getTimerCount()).toBe(0)
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(vi.getTimerCount()).toBe(0)
+      await vi.advanceTimersByTimeAsync(70_000)
+      expect(vi.getTimerCount()).toBe(0)
+      expect(sentAckBytes()).toEqual([1])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   function sentAckBytes(): number[] {
     return sendBinary.mock.calls.flatMap(([bytes]) => {
       const frame = decodeTerminalStreamFrame(bytes)

--- a/src/renderer/src/runtime/remote-runtime-terminal-stall-recovery.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-stall-recovery.test.ts
@@ -11,6 +11,7 @@ import {
   REMOTE_TERMINAL_COMMAND_RESPONSE_TIMEOUT_MS,
   REMOTE_TERMINAL_DELIVERY_STALL_TIMEOUT_MS
 } from './remote-terminal-stream-watchdog'
+import { TERMINAL_MULTIPLEX_ACK_FLUSH_MS } from '../../../shared/terminal-multiplex-flow-control'
 
 describe('remote terminal stalled stream recovery', () => {
   const sendBinary = vi.fn()
@@ -99,6 +100,77 @@ describe('remote terminal stalled stream recovery', () => {
       })
     })
     healthy.close()
+  })
+
+  it('keeps a stream alive once the transport takes the ack for its parsed output', async () => {
+    const { getRemoteRuntimeTerminalMultiplexer } =
+      await import('./remote-runtime-terminal-multiplexer')
+    const { takeCurrentTerminalDeliveryCredit } =
+      await import('../lib/pane-manager/terminal-delivery-credit')
+    const credits: (() => void)[] = []
+    const onTransportClose = vi.fn()
+    const stream = await getRemoteRuntimeTerminalMultiplexer('windows-test').subscribeTerminal({
+      terminal: 'term-acked',
+      client: { id: 'mac-viewer', type: 'desktop' },
+      callbacks: {
+        onData: () => {
+          const credit = takeCurrentTerminalDeliveryCredit()
+          if (credit) {
+            credits.push(credit)
+          }
+        },
+        onSnapshot: vi.fn(),
+        onTransportClose
+      }
+    })
+    sendBinary.mockClear()
+
+    emitOutput(stream.streamId, 'host output the renderer parses')
+    credits[0]?.()
+    await vi.advanceTimersByTimeAsync(TERMINAL_MULTIPLEX_ACK_FLUSH_MS)
+    expect(sentFrames(TerminalStreamOpcode.Ack)).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(REMOTE_TERMINAL_DELIVERY_STALL_TIMEOUT_MS)
+
+    expect(onTransportClose).not.toHaveBeenCalled()
+    expect(sentUnsubscribeStreamIds()).toEqual([])
+    stream.close()
+  })
+
+  it('keeps the delivery deadline anchored while sibling frames keep settling', async () => {
+    const { getRemoteRuntimeTerminalMultiplexer } =
+      await import('./remote-runtime-terminal-multiplexer')
+    const { takeCurrentTerminalDeliveryCredit } =
+      await import('../lib/pane-manager/terminal-delivery-credit')
+    const credits: (() => void)[] = []
+    const onTransportClose = vi.fn()
+    const stream = await getRemoteRuntimeTerminalMultiplexer('windows-test').subscribeTerminal({
+      terminal: 'term-anchored',
+      client: { id: 'mac-viewer', type: 'desktop' },
+      callbacks: {
+        onData: () => {
+          const credit = takeCurrentTerminalDeliveryCredit()
+          if (credit) {
+            credits.push(credit)
+          }
+        },
+        onSnapshot: vi.fn(),
+        onTransportClose
+      }
+    })
+    sendBinary.mockClear()
+
+    emitOutput(stream.streamId, 'frame the renderer never parses')
+    await vi.advanceTimersByTimeAsync(REMOTE_TERMINAL_DELIVERY_STALL_TIMEOUT_MS - 5_000)
+    emitOutput(stream.streamId, 'sibling frame that settles')
+    credits[1]?.()
+    await vi.advanceTimersByTimeAsync(TERMINAL_MULTIPLEX_ACK_FLUSH_MS)
+
+    expect(onTransportClose).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(onTransportClose).toHaveBeenCalledWith({ recoverable: true })
+    expect(sentUnsubscribeStreamIds()).toEqual([stream.streamId])
   })
 
   it('probes then restarts a stream when an entered command receives no frames', async () => {

--- a/src/renderer/src/runtime/remote-terminal-stream-watchdog.test.ts
+++ b/src/renderer/src/runtime/remote-terminal-stream-watchdog.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  REMOTE_TERMINAL_DELIVERY_STALL_TIMEOUT_MS,
+  createRemoteTerminalStreamWatchdog
+} from './remote-terminal-stream-watchdog'
+
+describe('remote terminal stream watchdog delivery deadline', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('anchors the deadline to the oldest unsettled delivery instead of the last settled sibling', () => {
+    const onStall = vi.fn()
+    const watchdog = createRemoteTerminalStreamWatchdog(onStall)
+
+    watchdog.beginOutputDelivery(100)
+    for (let tick = 0; tick < 3; tick += 1) {
+      vi.advanceTimersByTime(9_000)
+      const settle = watchdog.beginOutputDelivery(10)
+      settle()
+    }
+    expect(onStall).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(REMOTE_TERMINAL_DELIVERY_STALL_TIMEOUT_MS - 27_000)
+
+    expect(onStall).toHaveBeenCalledTimes(1)
+    expect(onStall.mock.calls[0]?.[0]).toMatchObject({ reason: 'delivery-credit-timeout' })
+  })
+
+  it('stays armed while parsed bytes remain unacknowledged to the host', () => {
+    const onStall = vi.fn()
+    const watchdog = createRemoteTerminalStreamWatchdog(onStall)
+
+    watchdog.beginOutputDelivery(100)()
+    vi.advanceTimersByTime(REMOTE_TERMINAL_DELIVERY_STALL_TIMEOUT_MS)
+
+    expect(onStall).toHaveBeenCalledTimes(1)
+    expect(onStall.mock.calls[0]?.[0]).toMatchObject({
+      outstandingDeliveryBytes: 0,
+      reason: 'delivery-credit-timeout'
+    })
+  })
+
+  it('disarms once the acknowledgement reaches the transport', () => {
+    const onStall = vi.fn()
+    const watchdog = createRemoteTerminalStreamWatchdog(onStall)
+
+    watchdog.beginOutputDelivery(100)()
+    watchdog.recordOutputAcknowledged(100)
+    vi.advanceTimersByTime(REMOTE_TERMINAL_DELIVERY_STALL_TIMEOUT_MS * 2)
+
+    expect(onStall).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/runtime/remote-terminal-stream-watchdog.ts
+++ b/src/renderer/src/runtime/remote-terminal-stream-watchdog.ts
@@ -9,6 +9,8 @@ export type RemoteTerminalStreamStall = {
 
 export type RemoteTerminalStreamWatchdog = {
   beginOutputDelivery: (bytes: number) => () => void
+  /** Bytes whose ACK frame reached the transport, releasing the host's window. */
+  recordOutputAcknowledged: (bytes: number) => void
   completeCommandResponseProbe: () => void
   recordCommandInput: (text: string) => void
   recordInbound: () => void
@@ -21,6 +23,9 @@ export function createRemoteTerminalStreamWatchdog(
   let responseTimer: ReturnType<typeof setTimeout> | null = null
   let deliveryTimer: ReturnType<typeof setTimeout> | null = null
   let outstandingDeliveryBytes = 0
+  // Why separate from parse credit: the host reopens its window on ACK frames, so bytes parsed but not yet ACKed are still the credit whose loss stops output.
+  let unacknowledgedBytes = 0
+  let deliveryPendingSinceMs: number | null = null
   let lastInboundAtMs = Date.now()
   let commandResponseProbePending = false
   let disposed = false
@@ -54,23 +59,29 @@ export function createRemoteTerminalStreamWatchdog(
       reason
     })
   }
-  const armDeliveryTimer = (): void => {
-    clearDeliveryTimer()
-    if (outstandingDeliveryBytes <= 0 || disposed) {
+  // Why anchored, never restarted: a deadline re-armed by sibling settles is postponed forever, and one cleared at zero parse credit can only re-arm from inbound output — which is what the stall stops.
+  const syncDeliveryTimer = (): void => {
+    if (disposed || outstandingDeliveryBytes + unacknowledgedBytes <= 0) {
+      clearDeliveryTimer()
+      deliveryPendingSinceMs = null
       return
     }
-    deliveryTimer = setTimeout(
-      () => trip('delivery-credit-timeout'),
-      REMOTE_TERMINAL_DELIVERY_STALL_TIMEOUT_MS
+    deliveryPendingSinceMs ??= Date.now()
+    if (deliveryTimer) {
+      return
+    }
+    const remainingMs = Math.max(
+      0,
+      REMOTE_TERMINAL_DELIVERY_STALL_TIMEOUT_MS - (Date.now() - deliveryPendingSinceMs)
     )
+    deliveryTimer = setTimeout(() => trip('delivery-credit-timeout'), remainingMs)
   }
 
   return {
     beginOutputDelivery(bytes) {
       outstandingDeliveryBytes += bytes
-      if (!deliveryTimer) {
-        armDeliveryTimer()
-      }
+      unacknowledgedBytes += bytes
+      syncDeliveryTimer()
       let settled = false
       return () => {
         if (settled || disposed) {
@@ -78,8 +89,15 @@ export function createRemoteTerminalStreamWatchdog(
         }
         settled = true
         outstandingDeliveryBytes = Math.max(0, outstandingDeliveryBytes - bytes)
-        armDeliveryTimer()
+        syncDeliveryTimer()
       }
+    },
+    recordOutputAcknowledged(bytes) {
+      if (disposed) {
+        return
+      }
+      unacknowledgedBytes = Math.max(0, unacknowledgedBytes - bytes)
+      syncDeliveryTimer()
     },
     completeCommandResponseProbe() {
       commandResponseProbePending = false
@@ -103,6 +121,8 @@ export function createRemoteTerminalStreamWatchdog(
       clearResponseTimer()
       clearDeliveryTimer()
       outstandingDeliveryBytes = 0
+      unacknowledgedBytes = 0
+      deliveryPendingSinceMs = null
     }
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 |

<!-- /orca-pr-loc -->

## #11265 — fixed

"Paired remote terminals silently stall with **live TCP sockets**; a read-only CLI RPC (`orca status`) wakes them." No offline indicator, no transport error, bytes sitting unread in the receive queue — and an *unrelated* RPC unwedges it.

That last detail is the tell: something was gated on activity rather than on a timer. `remote-terminal-stream-watchdog.ts` disarmed its delivery-stall deadline on a path where credit went unacknowledged, so the one thing that could have noticed the stall stood down, and only incidental traffic could restart it.

This is the third instance this week of the same family — a component that suppresses its own detection machinery and can then never recover:

- `SshChannelMultiplexer` gated its dead-link check on writer saturation with no bound, so a half-open link wedged forever (#17817).
- `WebRuntimeConnectionHeartbeat` armed its dead-socket deadline only if the probe was successfully sent, so an unsendable probe disarmed the only branch that could declare the socket dead (#17838).

That is three independent transports making the same mistake, which is the argument for #17823 (unify the liveness policy) rather than fixing it a fourth time.

```
$ pnpm test src/renderer/src/runtime/remote-terminal-stream-watchdog.test.ts
  fails before, passes after
```

## Post-review fixes

**1. The re-charge path armed an unbounded self-rescheduling timer.** `flushOutputAcknowledgement` -> `acknowledgeOutput` -> `sendFrame` throws -> `handleClose()` runs `this.streams.clear()` and `stream.watchdog.dispose()`; control then returns to the new `stream.pendingAckBytes += bytes; scheduleOutputAcknowledgementFlush(stream)`, which arms a 4 ms timer on an unregistered stream whose watchdog is gone. Every later `sendFrame` returns `false` on `!this.ready` rather than throwing, so it re-charged and rescheduled forever, at 250 Hz, per stream.

`queueOutputAcknowledgement` already had the right guard (`this.streams.get(stream.streamId) !== stream`); the new path did not. Counting live fake timers after teardown, with `sendBinary` forced to throw on `Ack`:

```
before: pending timers after teardown: 1 -> +10s: 1 -> +70s: 1
after:  pending timers after teardown: 0 -> +10s: 0 -> +70s: 0
main:   pending timers after teardown: 0 -> +10s: 0 -> +70s: 0
```

Both guards now go through the existing `isRegisteredStream()` helper.

**2. The production fix had no integration coverage.** The three watchdog tests exercise `createRemoteTerminalStreamWatchdog` in isolation, so neither the runaway timer nor the `recordOutputAcknowledged` wiring was reachable from them. Added three specs that drive the real multiplexer flow:

- the pending-timer count above (`remote-runtime-terminal-parse-backpressure.test.ts`);
- a healthy stream stays alive once the transport takes the ACK for its parsed output — deleting the `recordOutputAcknowledged` call turns it red, because `unacknowledgedBytes` never drains and a working pane gets recovered at 30 s;
- the deadline stays anchored while sibling frames keep settling — red against `main`'s `armDeliveryTimer`, which re-armed a full 30 s on every sibling settle and so postponed the wedge detection forever.

## #12452 — already fixed on current main; no change made

"Terminal keyboard input dies after renderer reattach; replay guard detects wedged write pipeline." Verified fixed. A secondary `writable:` ask in the issue was deliberately left alone rather than bundled in.

## #17743 — root-caused, deliberately NOT fixed

"Restored workspace tab keeps `ptyId: null` after client restart — live SSH terminal renders black."

`"ptyId": null` is **not corruption** — hydration nulls it on purpose (`terminal-helpers.ts:26-32`, contract stated at `terminal-session-row-hydration.ts:36-40`). The damage is that the persistence subscriber fires on *any* store change, so the post-hydration store — nulled, before any pane has bound a PTY — is uploaded to the relay as a `replace-session` patch, overwriting the id the file still held. The relay never inspects `ptyId` (`workspace-session-handler.ts:122`), so it cannot defend it.

Why no surviving identity: the only Gate-1 survivor for SSH is `remoteSessionIdsByTabId`, emitted only when `hasLivePty(tab.id) || (!tab.ptyId && lastKnown[tab.id])`. On a fresh process where the tab never rebound this run, both are empty, so nothing is emitted and `activeWorktreeIdsOnShutdown` excludes the worktree too.

Why nothing corrects it at startup: the legacy-worker reconciler defers **every** SSH candidate when `connectionId === undefined` — which is exactly how startup calls it (`index.ts:1057-1064`). SSH candidates only reconcile later on relay-ready, and only for orchestration-dispatch rows, never a plain user tab. Orphan adoption is claim-driven and needs the client to already supply the ptyId, so it cannot bootstrap a lost binding.

A pane-key rebind *does* exist (`web-session-terminal-orphan-recovery-pane.ts:127-147`) but is unreachable here: its surface is gated on `isWebTerminalSurfaceTabId`, and its identity is parsed as a remote-runtime pty id. A desktop SSH-host tab is neither.

**Net:** the client erases its own reattach identity during hydration, republishes the erasure over the good persisted one, and has no startup pass that consults the relay's live handle registry to re-derive it.

The fix is a startup reconciliation by pane key for SSH-backed tabs — ungating one of the two existing reconcilers rather than adding a third — plus not republishing a hydration-nulled `ptyId` over a good persisted one. It spans session persistence, the SSH execution boundary (any such pass must treat a missing handle as `unverifiable`, never evidence to retire the tab), and the relay wire. Doing that without proper tests would be worse than this handoff, so it is left for its own change.

Fixes #11265
Refs #12452, #17743

---

## ELI5

Paired remote terminals could silently stall with the network connection still alive — bytes sitting unread, no error shown — and an unrelated command would wake them up.

## User-facing regression risk

- A stalled stream is now declared dead and recovered, where before it hung until something incidental unwedged it. Visible as a reconnect rather than a freeze.
- **#12452 was already fixed on main** — verified, no change made. **#17743 was root-caused but not fixed here** (it is #17881).

