### PR TITLE
docs(win): keep -EncodedCommand for the PTY OSC 133 bootstrap (MDE finding declined)

### DIFF
--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -175,6 +175,7 @@ export function getShellLaunchConfig(
       args: [
         '-NoLogo',
         '-NoExit',
+        // Why base64 and not -Command: see powershell-osc133-bootstrap.ts (MDE review).
         '-EncodedCommand',
         encodePowerShellCommand(getPowerShellOsc133Bootstrap())
       ],

--- a/src/main/powershell-osc133-bootstrap.test.ts
+++ b/src/main/powershell-osc133-bootstrap.test.ts
@@ -3,6 +3,9 @@ import {
   encodePowerShellCommand,
   getPowerShellOsc133Bootstrap
 } from './powershell-osc133-bootstrap'
+import { getShellLaunchConfig } from './daemon/shell-ready'
+import { resolveWindowsShellLaunchArgs } from './providers/windows-shell-args'
+import { STARTUP_COMMAND_FEATURES } from './shell-startup-launch-intent-fixtures'
 
 describe('PowerShell OSC 133 bootstrap', () => {
   it('wraps prompt/readline without bypassing profiles or execution policy', () => {
@@ -43,5 +46,32 @@ describe('PowerShell OSC 133 bootstrap', () => {
     expect(encodePowerShellCommand('Write-Output ok')).toBe(
       Buffer.from('Write-Output ok', 'utf16le').toString('base64')
     )
+  })
+
+  // Why pinned: the MDE review (see powershell-osc133-bootstrap.ts) declined a
+  // switch to -Command. Any future delivery shape must still hand PowerShell this
+  // payload byte for byte -- comments, quotes, `$` and newlines included.
+  describe.each([
+    [
+      'daemon shell-ready',
+      () => getShellLaunchConfig('powershell.exe', STARTUP_COMMAND_FEATURES).args ?? []
+    ],
+    [
+      'windows shell args',
+      () => resolveWindowsShellLaunchArgs('pwsh.exe', 'C:\\repo', 'C:\\repo').shellArgs
+    ]
+  ])('%s PowerShell launch', (_name, getArgs) => {
+    it('delivers the bootstrap unmangled', () => {
+      const args = getArgs()
+      const encodedIndex = args.indexOf('-EncodedCommand')
+
+      expect(encodedIndex).toBeGreaterThanOrEqual(0)
+      expect(args).not.toContain('-Command')
+      expect(args).not.toContain('-ExecutionPolicy')
+
+      const delivered = Buffer.from(args[encodedIndex + 1] ?? '', 'base64').toString('utf16le')
+
+      expect(delivered.startsWith(getPowerShellOsc133Bootstrap())).toBe(true)
+    })
   })
 })

--- a/src/main/powershell-osc133-bootstrap.ts
+++ b/src/main/powershell-osc133-bootstrap.ts
@@ -2,6 +2,39 @@ import { getPowerShellOmpShellWrapper } from './pty/omp-shell-wrapper'
 import { getPowerShellCodexShellLaunchPreflight } from './pty/codex-shell-launch-preflight'
 export { encodePowerShellCommand } from '../shared/powershell-command-encoding'
 
+/**
+ * Why every PTY site delivers this payload as `-EncodedCommand` and keeps doing so.
+ *
+ * An MDE report named the base64 a contributing "suspicious PowerShell" signal and
+ * pointed at VS Code as the counter-example. VS Code and its forks actually ship
+ * `["-noexit","-command",'try { . "{0}\\...\\shellIntegration.ps1" } catch {}']` -- a
+ * one-liner that dot-sources a *file*, not inline script. Dot-sourcing is
+ * execution-policy gated; inline text is not. Measured on Windows 11:
+ *
+ *   policy        dot-source .ps1   -Command inline   -EncodedCommand
+ *   Restricted    blocked           runs              runs
+ *   AllSigned     blocked           runs              runs
+ *   RemoteSigned  runs              runs              runs
+ *
+ * So VS Code's shape silently drops OSC 133 -- and with it foreground-process and
+ * exit-code tracking -- on exactly the locked-down fleets MDE runs on; its `catch {}`
+ * is that failure being swallowed.
+ *
+ * Inline `-Command` does carry this payload intact through node-pty/ConPTY (verified
+ * on powershell.exe 5.1 and pwsh 7.6.5), so the switch is feasible; it is declined
+ * because it costs more signal than it removes. No PTY site spells `-ExecutionPolicy
+ * Bypass`, so base64 is the whole of what would go, and AMSI and script-block logging
+ * decode it anyway -- nothing is hidden from MDE today. What would change is the
+ * process command line, which would then carry `$ExecutionContext.SessionState.
+ * LanguageMode`, a `function Global:prompt` override and `[char]27`-assembled control
+ * sequences in clear text: higher-signal for command-line heuristics than an opaque
+ * token with no `Bypass` beside it.
+ *
+ * The payload is also not static -- providers/windows-shell-args.ts appends the PTY
+ * cwd and the queued startup command. #7978 had to move cmd.exe startup commands off
+ * `/K` to stdin because node-pty's argv escaping mangled their quotes; PowerShell
+ * never needed that workaround, because `-EncodedCommand` is quoting-proof.
+ */
 const POWERSHELL_OSC133_BOOTSTRAP = `# Orca OSC 133 shell integration for PowerShell.
 # Profiles have already loaded normally by the time -EncodedCommand runs.
 # Restore managed ownership before the shell-integration compatibility guard.

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -122,6 +122,7 @@ export function getShellLaunchConfig(
       args: [
         '-NoLogo',
         '-NoExit',
+        // Why base64 and not -Command: see powershell-osc133-bootstrap.ts (MDE review).
         '-EncodedCommand',
         encodePowerShellCommand(getPowerShellOsc133Bootstrap())
       ],

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -202,6 +202,7 @@ export function resolveWindowsShellLaunchArgs(
     const powerShellCommand = getPowerShellEncodedCommand(nativeCwd, startupCommand)
     // Why: foreground-process status on Windows depends on OSC 133 C/D, and
     // PowerShell needs a prompt/readline bootstrap after profiles finish.
+    // Why base64 and not -Command: see powershell-osc133-bootstrap.ts (MDE review).
     return {
       shellArgs: ['-NoLogo', '-NoExit', '-EncodedCommand', powerShellCommand.encodedCommand],
       ...(powerShellCommand.startupCommandDeliveredInShellArgs


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 |

<!-- /orca-pr-loc -->

## Outcome: analysis + documentation. No behaviour change.

The MDE report's root cause 3 lists three `-EncodedCommand` sites. The primary one
(`src/relay/windows-port-scan.ts`, `-ExecutionPolicy Bypass` + base64) is being fixed
separately. This PR evaluates the *contributing* one it names —
`src/main/daemon/shell-ready.ts:178`, the OSC 133 PTY bootstrap — and **declines to
change it**, recording why in the code so the next reader of the report does not
re-litigate it.

The command line is untouched. What changes: a rationale block in
`src/main/powershell-osc133-bootstrap.ts`, one-line pointers at the three PTY launch
sites, and a round-trip ratchet test.

---

### 1. What VS Code actually does (measured, not quoted from the report)

No VS Code install on the test box, but Cursor (a VS Code fork shipping the upstream
shell-integration code verbatim) is present. From
`resources/app/out/vs/platform/terminal/node/ptyHostMain.js`:

```js
K.set("windows-pwsh",["-noexit","-command",
  'try { . "{0}\\out\\vs\\workbench\\contrib\\terminal\\common\\scripts\\shellIntegration.ps1" } catch {}{1}'])
K.set("windows-pwsh-login",["-l","-noexit","-command",
  'try { . "{0}\\...\\shellIntegration.ps1" } catch {}{1}'])
```

So the report's "VS Code uses `-Command`" is true but incomplete. VS Code's `-Command`
payload is a **one-liner that dot-sources a file** — not inline script. That is not a
free win; it trades a base64 token for an execution-policy dependency. The pty host
contains **zero** references to `ExecutionPolicy` (`grep -c` → 0); the `catch {}` is the
policy failure being swallowed. `shellIntegration.ps1` ships **unsigned**
(`Get-AuthenticodeSignature` → `NotSigned`, 12,939 bytes).

Measured on this Windows 11 box, unsigned local `.ps1`, `Unblock-File`'d, per
`-ExecutionPolicy` scope:

| policy | dot-source `.ps1` | `-Command` inline | `-EncodedCommand` |
| --- | --- | --- | --- |
| Restricted | **blocked** | runs | runs |
| AllSigned | **blocked** | runs | runs |
| RemoteSigned | runs | runs | runs |

Under Restricted/AllSigned the file shape fails with *"cannot be loaded because running
scripts is disabled on this system"*. VS Code's shell integration silently does not load
there — precisely the locked-down managed fleets where MDE is deployed. Orca cannot take
that shape: losing the bootstrap loses OSC 133, and with it Windows foreground-process
and exit-code tracking.

(Incidentally reproduced live: this box's own `Microsoft.PowerShell_profile.ps1` under
OneDrive is policy-blocked in every PTY launch, while the `-EncodedCommand` bootstrap
runs fine.)

### 2. Does inline `-Command` survive node-pty? Yes — honestly, it does.

Payload: 5,449 chars, 114 lines, 13 `#` comment lines, 34 `"`, 96 `$`, one `@{}` hash
literal. Encoded: 14,532 chars.

Driven through real `node-pty` + ConPTY on this box, `-NoLogo -NoExit -Command <payload>`
against both `powershell.exe` 5.1 and `pwsh.exe` 7.6.5 produced OSC 133
`["A","B","C","D;0","A","B"]` — byte-identical to the `-EncodedCommand` baseline — with a
usable prompt. Newlines survive `argsToCommandLine`, the `#` comments do not swallow the
script, and node-pty's `\"` escaping round-trips. Repeated with the full
`resolveWindowsShellLaunchArgs` payload (cwd restore + a queued startup command carrying
embedded `""` quotes, the #7978 shape): also correct under both shapes.

Length is not the blocker either — `-Command` is *shorter* (5,525 vs 14,579 chars of
command line).

**So this is not a "it would break" finding. It is a "it is not worth it" finding.**

### 3. Why it is declined anyway

**The signal removed is small.** No PTY site spells `-ExecutionPolicy Bypass`. Base64
alone, with no `Bypass` beside it, is the weak half of the report's own pairing — the
report ranks this site as contributing, not primary.

**Nothing is currently hidden from MDE.** AMSI and script-block logging receive the
decoded script for `-EncodedCommand` just as for `-Command`. The only thing base64
changes is the text in `DeviceProcessEvents.ProcessCommandLine`.

**And that text would get worse, not better.** Measured presence in the *process command
line* under each shape:

| token on the command line | `-Command` | `-EncodedCommand` |
| --- | --- | --- |
| `$ExecutionContext.SessionState.LanguageMode` | yes | no |
| `function Global:prompt` | yes | no |
| `Set-StrictMode -Off` | yes | no |
| `[char]27` | yes | no |
| `[Console]::Write` | yes | no |
| `.Invoke()` | yes | no |
| `-CommandType Application,ExternalScript` | yes | no |

`SessionState.LanguageMode` is the canonical Constrained-Language-Mode probe used by
AMSI/CLM-bypass tooling; a `Global:prompt` override is documented prompt-hijack
persistence; `[char]27`-assembled control sequences read as obfuscation. Switching would
put ~5.5 KB of that vocabulary in clear text on every PowerShell terminal Orca opens,
in exchange for dropping one `-EncodedCommand` tag. That is a worse EDR posture, not a
better one.

**Blast radius is three sites, not one.** The same shape is built at
`src/main/daemon/shell-ready.ts:173`, `src/main/providers/local-pty-shell-ready.ts:120`
and `src/main/providers/windows-shell-args.ts:206`. Changing only the site the report
names leaves the signal in place while splitting the contract. The third site also
appends the PTY cwd and the queued startup command into the same payload — arbitrary
text. #7978 already had to move cmd.exe startup commands off `/K` to stdin because
node-pty's argv escaping mangled their quotes ("Unlike PowerShell's -EncodedCommand,
cmd.exe has no robust argv-quoting path"). `-EncodedCommand` is why PowerShell never
needed that workaround, and giving it up makes every future edit to a 114-line payload a
silent quoting risk.

### 4. Tradeoff vs the port-scan site

| | `windows-port-scan.ts` (being fixed) | PTY bootstrap (this PR) |
| --- | --- | --- |
| signal dropped | `-ExecutionPolicy Bypass` **and** base64 | base64 only |
| replaced by | a short one-liner | 5.5 KB of high-keyword inline script |
| user-supplied text in payload | none | cwd + queued startup command |
| launch sites | 1 | 3 |
| functional risk | none | quoting/ConPTY, uncovered by design |
| verdict | unambiguous win | negative expected value |

---

### Changes

- `src/main/powershell-osc133-bootstrap.ts` — rationale block above the payload (its
  single source of truth, imported by all three sites).
- `shell-ready.ts`, `local-pty-shell-ready.ts`, `windows-shell-args.ts` — one-line
  pointers at each `-EncodedCommand`.
- `powershell-osc133-bootstrap.test.ts` — new ratchet: both launch builders must deliver
  the bootstrap **byte for byte**, and must not carry `-Command` or `-ExecutionPolicy`.
  This is the executable form of the analysis: any future delivery shape has to satisfy
  it. (The `-EncodedCommand` shape itself was already pinned by
  `pty-subprocess-windows-shell-launch.test.ts`, `windows-shell-args.test.ts` and
  `local-pty-provider-windows-shell-launch.test.ts`; the round-trip was not.)

`src/main/agent-hooks/windows-powershell-hook-launcher.ts` is deliberately untouched.

### Risks for a reviewer

- This is a **decline**. If the security team's requirement is "zero `-EncodedCommand` in
  the process tree" as a policy rather than a detection-quality goal, that requirement
  overrides this analysis — but the fix then has to be a shipped signed `.ps1` plus a
  policy story, not a flag swap, or PowerShell terminals silently lose OSC 133 on
  Restricted/AllSigned hosts.
- The `-Command` feasibility result is measured on one Windows 11 box, PowerShell 5.1 and
  pwsh 7.6.5. It argues *against* the "it cannot work" case, so a reviewer should not read
  it as clearance to make the switch on other grounds.
- The keyword table is about what lands in command-line telemetry. It is not a claim about
  how any specific MDE rule scores; no alert was reproduced either way.
