### PR TITLE
fix(terminal): stop a restarted client publishing away its own SSH reattach identity

### DIFF
--- a/src/renderer/src/lib/workspace-session-patch.ts
+++ b/src/renderer/src/lib/workspace-session-patch.ts
@@ -77,6 +77,8 @@ export function buildWorkspaceSessionPatch(
       'tabsByWorktree',
       'ptyIdsByTabId',
       'lastKnownRelayPtyIdByTabId',
+      'pendingReconnectPtyIdByTabId',
+      'deferredSshSessionIdsByTabId',
       'repos',
       'worktreesByRepo'
     ] as const)

--- a/src/renderer/src/lib/workspace-session-relevant-fields.test.ts
+++ b/src/renderer/src/lib/workspace-session-relevant-fields.test.ts
@@ -37,7 +37,9 @@ describe('SESSION_RELEVANT_FIELDS', () => {
     defaultTerminalTabsAppliedByWorktreeId: true,
     closedTerminalTabTombstonesByTabId: true,
     sleepingAgentSessionsByPaneKey: true,
-    clientHostedBrowserCloseIntentsByEnvironment: true
+    clientHostedBrowserCloseIntentsByEnvironment: true,
+    pendingReconnectPtyIdByTabId: true,
+    deferredSshSessionIdsByTabId: true
   }
 
   it('contains every key of WorkspaceSessionSnapshot', () => {

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -61,6 +61,9 @@ export type WorkspaceSessionSnapshot = Pick<
   activeWorkspaceExecutionHostId?: AppState['activeWorkspaceExecutionHostId']
   sleepingAgentSessionsByPaneKey?: AppState['sleepingAgentSessionsByPaneKey']
   clientHostedBrowserCloseIntentsByEnvironment?: AppState['clientHostedBrowserCloseIntentsByEnvironment']
+  /** Optional so the many partial snapshot fixtures keep type-checking; see buildTerminalSessionData. */
+  pendingReconnectPtyIdByTabId?: AppState['pendingReconnectPtyIdByTabId']
+  deferredSshSessionIdsByTabId?: AppState['deferredSshSessionIdsByTabId']
 }
 
 // Why: shallow-equality gate for the debounced session writer; _exhaustive below keeps it in sync with the snapshot type.
@@ -97,7 +100,9 @@ export const SESSION_RELEVANT_FIELDS = [
   'defaultTerminalTabsAppliedByWorktreeId',
   'closedTerminalTabTombstonesByTabId',
   'sleepingAgentSessionsByPaneKey',
-  'clientHostedBrowserCloseIntentsByEnvironment'
+  'clientHostedBrowserCloseIntentsByEnvironment',
+  'pendingReconnectPtyIdByTabId',
+  'deferredSshSessionIdsByTabId'
 ] as const satisfies readonly (keyof WorkspaceSessionSnapshot)[]
 
 type _MissingSessionField = Exclude<
@@ -222,8 +227,18 @@ export function buildTerminalSessionData(
 
   // Why: relay reconnect keeps lastKnown but clears tab.ptyId; the !tab.ptyId guard excludes slept tabs (which keep ptyId as a wake hint).
   const lastKnown = snapshot.lastKnownRelayPtyIdByTabId
+  // Why the two reconnect maps (#17743): hydration nulls tab.ptyId, empties ptyIdsByTabId, and
+  // never restores lastKnown, so on a fresh process they are the ONLY surviving handle for a
+  // relay-backed tab between restore and rebind. Persisting without them republishes the nulled
+  // row over the id the file (and the relay snapshot) still held, which is the client's own
+  // bookkeeping being read as evidence the remote PTY is gone. Both already count as live
+  // ownership for the orphan sweep (terminal-orphan-helpers) and for retirement planning.
+  const pendingReconnect = snapshot.pendingReconnectPtyIdByTabId ?? {}
+  const deferredSshSessions = snapshot.deferredSshSessionIdsByTabId ?? {}
+  const restoredSessionId = (tabId: string): string | undefined =>
+    lastKnown[tabId] || pendingReconnect[tabId] || deferredSshSessions[tabId]
   const hasReconnectableSession = (tab: { id: string; ptyId: string | null }): boolean =>
-    hasLivePty(tab.id) || (!tab.ptyId && Boolean(lastKnown[tab.id]))
+    hasLivePty(tab.id) || (!tab.ptyId && Boolean(restoredSessionId(tab.id)))
 
   const activeWorktreeIdsOnShutdown = Object.entries(tabsByWorktree)
     .filter(([, tabs]) => tabs.some(hasReconnectableSession))
@@ -249,7 +264,7 @@ export function buildTerminalSessionData(
       if (!hasReconnectableSession(tab)) {
         continue
       }
-      const sessionId = tab.ptyId || lastKnown[tab.id]
+      const sessionId = tab.ptyId || restoredSessionId(tab.id)
       if (sessionId) {
         remoteSessionIdsByTabId[tab.id] = sessionId
       }

--- a/src/renderer/src/store/terminals/restored-relay-session-identity.test.ts
+++ b/src/renderer/src/store/terminals/restored-relay-session-identity.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
+import { buildWorkspaceSessionPayload } from '@/lib/workspace-session'
+import { getOrphanTerminalIds } from '../slices/terminal-orphan-helpers'
+import { createTestStore, makeTab, makeWorktree } from '../slices/store-test-helpers'
+
+const TARGET_ID = 'target'
+const REPO_ID = 'repo-ssh'
+const WORKTREE_ID = `${REPO_ID}::/work/demo`
+const TAB_ID = 'tab-ssh'
+const RELAY_PTY_ID = 'ssh:target@@pty-42'
+
+function connectedSshState(status: 'connected' | 'disconnected') {
+  return new Map([
+    [TARGET_ID, { targetId: TARGET_ID, status, error: null, reconnectAttempt: 0 }]
+  ]) as never
+}
+
+function seedStore(status: 'connected' | 'disconnected' = 'connected') {
+  const store = createTestStore()
+  store.setState({
+    repos: [
+      {
+        id: REPO_ID,
+        path: '/work/demo',
+        displayName: 'demo',
+        badgeColor: '#000',
+        addedAt: 1,
+        connectionId: TARGET_ID,
+        executionHostId: 'ssh:target'
+      }
+    ],
+    worktreesByRepo: {
+      [REPO_ID]: [
+        makeWorktree({
+          id: WORKTREE_ID,
+          repoId: REPO_ID,
+          path: '/work/demo',
+          hostId: 'ssh:target'
+        })
+      ]
+    },
+    sshConnectionStates: connectedSshState(status),
+    sshTargetsHydrated: true,
+    sshTargetLabels: new Map([[TARGET_ID, 'demo host']]),
+    hydrationSucceeded: true
+  })
+  return store
+}
+
+/** What the previous run wrote: a live relay session recorded on the row AND in the id map. */
+function persistedSession(): WorkspaceSessionState {
+  return {
+    activeRepoId: REPO_ID,
+    activeWorktreeId: WORKTREE_ID,
+    activeTabId: TAB_ID,
+    tabsByWorktree: {
+      [WORKTREE_ID]: [makeTab({ id: TAB_ID, worktreeId: WORKTREE_ID, ptyId: RELAY_PTY_ID })]
+    },
+    terminalLayoutsByTabId: {},
+    activeWorktreeIdsOnShutdown: [WORKTREE_ID],
+    activeTabIdByWorktree: { [WORKTREE_ID]: TAB_ID },
+    remoteSessionIdsByTabId: { [TAB_ID]: RELAY_PTY_ID },
+    activeConnectionIdsAtShutdown: [TARGET_ID]
+  }
+}
+
+describe('restored relay session identity (#17743)', () => {
+  it('does not republish a hydration-nulled ptyId over the persisted relay session id', () => {
+    const store = seedStore()
+    store.getState().hydrateWorkspaceSession(persistedSession())
+
+    // Hydration deliberately nulls the row; that is the contract, not the bug.
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].ptyId).toBeNull()
+    expect(store.getState().ptyIdsByTabId[TAB_ID]).toEqual([])
+    expect(store.getState().lastKnownRelayPtyIdByTabId[TAB_ID]).toBeUndefined()
+
+    const payload = buildWorkspaceSessionPayload(store.getState())
+
+    expect(payload.remoteSessionIdsByTabId).toEqual({ [TAB_ID]: RELAY_PTY_ID })
+    expect(payload.activeWorktreeIdsOnShutdown).toContain(WORKTREE_ID)
+    expect(payload.activeConnectionIdsAtShutdown).toEqual([TARGET_ID])
+  })
+
+  it('rebinds the restored tab to its live relay PTY and keeps publishing that id', async () => {
+    const store = seedStore()
+    store.getState().hydrateWorkspaceSession(persistedSession())
+
+    await store.getState().reconnectPersistedTerminals()
+
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].ptyId).toBe(RELAY_PTY_ID)
+    expect(store.getState().ptyIdsByTabId[TAB_ID]).toEqual([RELAY_PTY_ID])
+    expect(buildWorkspaceSessionPayload(store.getState()).remoteSessionIdsByTabId).toEqual({
+      [TAB_ID]: RELAY_PTY_ID
+    })
+  })
+
+  it('keeps a deferred relay session id after a disconnect clears the row binding', async () => {
+    const store = seedStore('disconnected')
+    store.getState().hydrateWorkspaceSession(persistedSession())
+    await store.getState().reconnectPersistedTerminals()
+
+    expect(store.getState().deferredSshSessionIdsByTabId[TAB_ID]).toBe(RELAY_PTY_ID)
+
+    // A relay drop clears the row binding. Loss of contact is not evidence the remote PTY exited,
+    // so the handle must survive into the next write.
+    store.getState().clearDirectSshTargetPtyBindings(TARGET_ID)
+
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].ptyId).toBeNull()
+    expect(store.getState().ptyIdsByTabId[TAB_ID]).toEqual([])
+    expect(buildWorkspaceSessionPayload(store.getState()).remoteSessionIdsByTabId).toEqual({
+      [TAB_ID]: RELAY_PTY_ID
+    })
+  })
+
+  it('leaves a tab whose relay handle is unverifiable alone instead of retiring it', async () => {
+    const store = seedStore('disconnected')
+    store.getState().hydrateWorkspaceSession(persistedSession())
+    await store.getState().reconnectPersistedTerminals()
+    store.getState().clearDirectSshTargetPtyBindings(TARGET_ID)
+
+    // No live PTY, no row binding, host unreachable — `unverifiable`, never `exited`.
+    expect([...getOrphanTerminalIds(store.getState(), WORKTREE_ID)]).toEqual([])
+    expect(store.getState().tabsByWorktree[WORKTREE_ID].map((tab) => tab.id)).toEqual([TAB_ID])
+  })
+
+  it('does not invent a session id for a tab that never had one', () => {
+    const store = seedStore()
+    const session = persistedSession()
+    session.tabsByWorktree[WORKTREE_ID] = [
+      makeTab({ id: TAB_ID, worktreeId: WORKTREE_ID, ptyId: null })
+    ]
+    delete session.remoteSessionIdsByTabId
+    delete session.activeConnectionIdsAtShutdown
+    session.activeWorktreeIdsOnShutdown = []
+    store.getState().hydrateWorkspaceSession(session)
+
+    const payload = buildWorkspaceSessionPayload(store.getState())
+
+    expect(payload.remoteSessionIdsByTabId).toBeUndefined()
+    expect(payload.activeWorktreeIdsOnShutdown).toEqual([])
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​145 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 |

<!-- /orca-pr-loc -->

## #17743 — the reconciler was never missing; its input was being destroyed

`ptyId: null` after restart is **not corruption** — `clearTransientTerminalState` nulls it deliberately during hydration. The bug is that the nulled state gets published back over the good persisted one, and the relay cannot defend it: `workspace-session-handler.ts` `patch()` checks only `kind === 'replace-session'` and writes the session verbatim, never inspecting `ptyId`.

The load-bearing fact: **`lastKnownRelayPtyIdByTabId` is never hydrated from disk.** It initialises `{}` (`terminals.ts:64`) and is written only when a relay PTY actually binds (`terminal-pty-bindings.ts:249`). On a fresh process it is empty, and hydration sets `ptyIdsByTabId` to `[]` for every tab — so all three inputs to the Gate‑1 predicate at `workspace-session.ts:225-226` were empty, and the tab published no session id at all.

That is self-reinforcing: one lossy write leaves the *next* startup with nothing to reconnect from.

## Three claims in the handoff I was given turned out to be wrong

Worth recording, because two of them would have sent this the wrong way:

1. **"The persistence subscriber fires on any store change, so the nulled store is uploaded."** Not on the ordinary path — every write is gated on `workspaceSessionReady && hydrationSucceeded`, and `workspaceSessionReady` flips inside `reconnectPersistedTerminals` in the **same `set()`** that restores `tab.ptyId`. The loss happens only where reconnect restores nothing: its `ids.length === 0` early exit, a direct-SSH snapshot apply whose merged `activeWorktreeIdsOnShutdown` is already empty, and a post-reconnect `clearDirectSshTerminalBindings` on a tab that only reached the deferred stage.
2. **"No identity survives."** Right about the outcome, wrong about the cause. Hydration **does** carry the identity into store state — `workspace-terminal-reconnect-plan.ts:71-75` copies `session.remoteSessionIdsByTabId` into `pendingReconnectPtyIdByTabId`. The input existed; `buildTerminalSessionData` simply never looked at it.
3. **"Ungate one of the two existing reconcilers."** Neither can reach this tab. `runLegacyWorkerTerminalRecovery` iterates candidates that all carry a `dispatchId` — orchestration rows; a plain user tab has none. And `web-session-terminal-orphan-recovery-pane.ts` resolves over the **runtime-environment** RPC (`terminal.resolvePane`), which a direct-SSH relay does not register — its surface is `pty.*` / `workspace.*` / `git.*`. Ungating `isWebTerminalSurfaceTabId` would hand a desktop SSH tab a call with no transport.

## The fix is alignment, not a new mechanism

`buildTerminalSessionData` now counts `pendingReconnectPtyIdByTabId` and `deferredSshSessionIdsByTabId` as reconnectable-session evidence, behind the unchanged `!tab.ptyId` guard that excludes slept tabs. That makes persistence use the same "does this tab own a session" answer that the orphan sweep (`terminal-orphan-helpers.ts:24-36`) and retirement planning (`terminal-tab-retirement.ts:77-79`) **already** use — persistence was the one place out of step.

Nothing is fabricated: a tab that never had a handle still publishes none, and there is a test for it. Per `ssh-execution-boundary.md` a missing handle is treated as `unverifiable`, never as evidence; no path retires a tab or kills a PTY as a result.

**Wire compatibility:** no field, shape or opcode change. This is Rule 3 — what the client publishes. `remoteSessionIdsByTabId` / `activeWorktreeIdsOnShutdown` are now populated where they were previously dropped, and those are the same values the same client published *before* the restart. An old peer sees a session id where it previously saw an unexplained gap, which is strictly the pre-restart picture.

## Verification

```
BEFORE (fix stashed, tests kept)
  × does not republish a hydration-nulled ptyId over the persisted relay session id
  × keeps a deferred relay session id after a disconnect clears the row binding
  AssertionError: expected undefined to deeply equal { 'tab-ssh': 'ssh:target@@pty-42' }
  Tests  2 failed | 3 passed (5)

AFTER
  Test Files  5 passed (5)
      Tests  40 passed (40)
```

New `restored-relay-session-identity.test.ts` drives the real store: hydrate keeps the id; reconnect rebinds `tab.ptyId` to the live relay PTY; a deferred id survives a disconnect that clears the row binding; the unverifiable tab is not swept by `getOrphanTerminalIds`; a tab that never had a handle gets no invented id.

Renderer `lib/` + `store/` sweep: 797 passed / 1 failed — `palette-match-performance.test.ts`, a wall-clock budget that fails identically with this change stashed. `pnpm tc:node` clean; `check:code-quality:changed` 0 new findings.

## What this does not do

It fixes the bug going forward but cannot repair an **already-damaged** snapshot — one whose `~/.orca/sessions/<namespace>.json` already reads `ptyId: null` with no `remoteSessionIdsByTabId`. That needs new capability, and the shape is known:

1. `PtyProcessSummary` (`pty-handler.ts:370`) omits `paneKey`/`tabId` even though the relay tracks both internally. Adding them as **optional** fields is Rule 1 — an old relay just omits them and the pass degrades to a no-op.
2. Reconcile at the existing seam: `applyDirectSshRemoteWorkspaceSnapshot` (`remote-workspace-snapshot-apply.ts:226-249`) already runs a scoped `reconnectPersistedTerminals` inside the write-suppression window. Seed `pendingReconnectPtyIdByTabId` there from a live PTY whose published pane key names the tab, reusing the whole existing rebind path.
3. Non-negotiable: an unmatched tab is left exactly as it is. A relay omitting the fields, a listing that times out, and a tab with no match are all `unverifiable`.

Refs #17743

(Deliberately `Refs`, not `Fixes`: this stops the erasure at its source, but does not repair snapshots already damaged by it. Auto-closing the issue would hide that remaining half.)

---

## ELI5

After restarting Orca, a restored tab for a live SSH terminal came back blank. Orca was erasing its own note of which remote terminal the tab belonged to, then saving that erasure over the good copy.

## User-facing regression risk

- Publishes a session id in cases where it previously published nothing. Those are the same values the same client published *before* the restart, so an old peer sees the pre-restart picture rather than an unexplained gap.
- **Does not repair an already-damaged saved session.** If your session file already reads `ptyId: null` with no session id, there is nothing left to reconnect from; that needs the follow-up described in the PR.

