### PR TITLE
fix(git): narrow fork-remote fetch refspecs to tracked branches

### DIFF
--- a/src/main/git/fork-remote-refspec.test.ts
+++ b/src/main/git/fork-remote-refspec.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi, type Mock } from 'vitest'
+import {
+  buildNarrowForkFetchRefspec,
+  ensureRemoteTracksBranchNarrowly,
+  getRemoteFetchRefspecs,
+  pruneUntrackedForkRemoteRefs,
+  removeStaleForkFetchRefspec,
+  wildcardForkFetchRefspec,
+  type GitExecFn
+} from './fork-remote-refspec'
+
+type ExecMock = Mock<GitExecFn>
+
+const REPO = '/repo-root'
+
+// In-memory `remote.<name>.fetch`/`.tagOpt` config, mutated the way real `git config` would be.
+function makeConfigExec(fetchByRemote: Record<string, string[]> = {}): {
+  exec: ExecMock
+  tagOptByRemote: Record<string, string>
+} {
+  const tagOptByRemote: Record<string, string> = {}
+  const exec = vi.fn<GitExecFn>(async (args: string[]) => {
+    const key = args[2]
+    if (args[0] === 'config' && args[1] === '--get-all' && key?.endsWith('.fetch')) {
+      const remoteName = key.slice('remote.'.length, -'.fetch'.length)
+      const values = fetchByRemote[remoteName] ?? []
+      if (values.length === 0) {
+        throw new Error('key not found')
+      }
+      return { stdout: `${values.join('\n')}\n`, stderr: '' }
+    }
+    if (args[0] === 'config' && args[1] === '--unset-all' && key?.endsWith('.fetch')) {
+      const remoteName = key.slice('remote.'.length, -'.fetch'.length)
+      fetchByRemote[remoteName] = []
+      return { stdout: '', stderr: '' }
+    }
+    if (args[0] === 'config' && args[1] === '--add' && key?.endsWith('.fetch')) {
+      const remoteName = key.slice('remote.'.length, -'.fetch'.length)
+      fetchByRemote[remoteName] = [...(fetchByRemote[remoteName] ?? []), args[3]!]
+      return { stdout: '', stderr: '' }
+    }
+    if (args[0] === 'config' && args[1]?.endsWith('.tagOpt')) {
+      const remoteName = args[1].slice('remote.'.length, -'.tagOpt'.length)
+      tagOptByRemote[remoteName] = args[2]!
+      return { stdout: '', stderr: '' }
+    }
+    return { stdout: '', stderr: '' }
+  })
+  return { exec, tagOptByRemote }
+}
+
+describe('buildNarrowForkFetchRefspec / wildcardForkFetchRefspec', () => {
+  it('builds the exact narrow and wide refspec shapes', () => {
+    expect(buildNarrowForkFetchRefspec('fork', 'feature/fix')).toBe(
+      '+refs/heads/feature/fix:refs/remotes/fork/feature/fix'
+    )
+    expect(wildcardForkFetchRefspec('fork')).toBe('+refs/heads/*:refs/remotes/fork/*')
+  })
+})
+
+describe('getRemoteFetchRefspecs', () => {
+  it('returns [] when the remote has no configured refspec', async () => {
+    const { exec } = makeConfigExec()
+    await expect(getRemoteFetchRefspecs(exec, REPO, 'fork')).resolves.toEqual([])
+  })
+
+  it('returns every configured refspec', async () => {
+    const { exec } = makeConfigExec({
+      fork: ['+refs/heads/a:refs/remotes/fork/a', '+refs/heads/b:refs/remotes/fork/b']
+    })
+    await expect(getRemoteFetchRefspecs(exec, REPO, 'fork')).resolves.toEqual([
+      '+refs/heads/a:refs/remotes/fork/a',
+      '+refs/heads/b:refs/remotes/fork/b'
+    ])
+  })
+})
+
+describe('ensureRemoteTracksBranchNarrowly', () => {
+  it('replaces the wide default refspec with a single narrow one', async () => {
+    const { exec, tagOptByRemote } = makeConfigExec({ fork: [wildcardForkFetchRefspec('fork')] })
+
+    await ensureRemoteTracksBranchNarrowly(exec, REPO, 'fork', 'main')
+
+    await expect(getRemoteFetchRefspecs(exec, REPO, 'fork')).resolves.toEqual([
+      '+refs/heads/main:refs/remotes/fork/main'
+    ])
+    expect(tagOptByRemote.fork).toBe('--no-tags')
+  })
+
+  it('adds a second branch alongside an already-narrow one instead of replacing it', async () => {
+    const { exec } = makeConfigExec({ fork: ['+refs/heads/main:refs/remotes/fork/main'] })
+
+    await ensureRemoteTracksBranchNarrowly(exec, REPO, 'fork', 'feature')
+
+    await expect(getRemoteFetchRefspecs(exec, REPO, 'fork')).resolves.toEqual([
+      '+refs/heads/main:refs/remotes/fork/main',
+      '+refs/heads/feature:refs/remotes/fork/feature'
+    ])
+  })
+
+  it('is a no-op for a branch already narrowly tracked (idempotent)', async () => {
+    const { exec } = makeConfigExec({ fork: ['+refs/heads/main:refs/remotes/fork/main'] })
+
+    await ensureRemoteTracksBranchNarrowly(exec, REPO, 'fork', 'main')
+
+    const addCalls = exec.mock.calls.filter(([args]) => args[1] === '--add')
+    expect(addCalls).toEqual([])
+  })
+})
+
+describe('removeStaleForkFetchRefspec', () => {
+  it('drops only the refspec whose source matches the stale branch', async () => {
+    const { exec } = makeConfigExec({
+      fork: ['+refs/heads/gone:refs/remotes/fork/gone', '+refs/heads/keep:refs/remotes/fork/keep']
+    })
+
+    await expect(removeStaleForkFetchRefspec(exec, REPO, 'fork', 'gone')).resolves.toBe(true)
+    await expect(getRemoteFetchRefspecs(exec, REPO, 'fork')).resolves.toEqual([
+      '+refs/heads/keep:refs/remotes/fork/keep'
+    ])
+  })
+
+  it('returns false and changes nothing when the branch is not tracked', async () => {
+    const { exec } = makeConfigExec({ fork: ['+refs/heads/keep:refs/remotes/fork/keep'] })
+
+    await expect(removeStaleForkFetchRefspec(exec, REPO, 'fork', 'gone')).resolves.toBe(false)
+    await expect(getRemoteFetchRefspecs(exec, REPO, 'fork')).resolves.toEqual([
+      '+refs/heads/keep:refs/remotes/fork/keep'
+    ])
+  })
+})
+
+describe('pruneUntrackedForkRemoteRefs', () => {
+  function makeRefsExec(refs: string[]): { exec: Mock<GitExecFn>; refs: string[] } {
+    const state = [...refs]
+    const exec = vi.fn<GitExecFn>(async (args: string[]) => {
+      if (args[0] === 'for-each-ref') {
+        const prefix = args[2]!
+        return {
+          stdout: state.map((r) => `${prefix}${r}`).join('\n') + (state.length ? '\n' : ''),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'update-ref' && args[1] === '-d') {
+        const refname = args[2]!
+        const idx = state.findIndex((r) => refname.endsWith(`/${r}`))
+        if (idx !== -1) {
+          state.splice(idx, 1)
+        }
+        return { stdout: '', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+    return { exec, refs: state }
+  }
+
+  it('deletes tracking refs outside the keep set and leaves the rest', async () => {
+    const { exec, refs } = makeRefsExec(['main', 'unrelated-1', 'unrelated-2'])
+
+    const deleted = await pruneUntrackedForkRemoteRefs(exec, REPO, 'fork', new Set(['main']))
+
+    expect(deleted.sort()).toEqual(
+      ['refs/remotes/fork/unrelated-1', 'refs/remotes/fork/unrelated-2'].sort()
+    )
+    expect(refs).toEqual(['main'])
+  })
+
+  it('never deletes HEAD even if not in the keep set', async () => {
+    const { exec, refs } = makeRefsExec(['HEAD', 'main'])
+
+    await pruneUntrackedForkRemoteRefs(exec, REPO, 'fork', new Set(['main']))
+
+    expect(refs).toEqual(['HEAD', 'main'])
+  })
+
+  it('is a no-op when nothing is stray', async () => {
+    const { exec, refs } = makeRefsExec(['main'])
+
+    const deleted = await pruneUntrackedForkRemoteRefs(exec, REPO, 'fork', new Set(['main']))
+
+    expect(deleted).toEqual([])
+    expect(refs).toEqual(['main'])
+  })
+})

--- a/src/main/git/fork-remote-refspec.test.ts
+++ b/src/main/git/fork-remote-refspec.test.ts
@@ -50,9 +50,9 @@ function makeConfigExec(fetchByRemote: Record<string, string[]> = {}): {
 }
 
 describe('buildNarrowForkFetchRefspec / wildcardForkFetchRefspec', () => {
-  it('builds the exact narrow and wide refspec shapes', () => {
+  it('builds the narrow (trailing-* suffixed) and wide refspec shapes', () => {
     expect(buildNarrowForkFetchRefspec('fork', 'feature/fix')).toBe(
-      '+refs/heads/feature/fix:refs/remotes/fork/feature/fix'
+      '+refs/heads/feature/fix*:refs/remotes/fork/feature/fix*'
     )
     expect(wildcardForkFetchRefspec('fork')).toBe('+refs/heads/*:refs/remotes/fork/*')
   })
@@ -76,35 +76,61 @@ describe('getRemoteFetchRefspecs', () => {
 })
 
 describe('ensureRemoteTracksBranchNarrowly', () => {
-  it('replaces the wide default refspec with a single narrow one', async () => {
+  it('replaces the wide default refspec with a single trailing-* narrow one', async () => {
     const { exec, tagOptByRemote } = makeConfigExec({ fork: [wildcardForkFetchRefspec('fork')] })
 
     await ensureRemoteTracksBranchNarrowly(exec, REPO, 'fork', 'main')
 
     await expect(getRemoteFetchRefspecs(exec, REPO, 'fork')).resolves.toEqual([
-      '+refs/heads/main:refs/remotes/fork/main'
+      '+refs/heads/main*:refs/remotes/fork/main*'
     ])
     expect(tagOptByRemote.fork).toBe('--no-tags')
   })
 
   it('adds a second branch alongside an already-narrow one instead of replacing it', async () => {
-    const { exec } = makeConfigExec({ fork: ['+refs/heads/main:refs/remotes/fork/main'] })
+    const { exec } = makeConfigExec({ fork: ['+refs/heads/main*:refs/remotes/fork/main*'] })
 
     await ensureRemoteTracksBranchNarrowly(exec, REPO, 'fork', 'feature')
 
     await expect(getRemoteFetchRefspecs(exec, REPO, 'fork')).resolves.toEqual([
-      '+refs/heads/main:refs/remotes/fork/main',
-      '+refs/heads/feature:refs/remotes/fork/feature'
+      '+refs/heads/main*:refs/remotes/fork/main*',
+      '+refs/heads/feature*:refs/remotes/fork/feature*'
     ])
   })
 
   it('is a no-op for a branch already narrowly tracked (idempotent)', async () => {
-    const { exec } = makeConfigExec({ fork: ['+refs/heads/main:refs/remotes/fork/main'] })
+    const { exec } = makeConfigExec({ fork: ['+refs/heads/main*:refs/remotes/fork/main*'] })
 
     await ensureRemoteTracksBranchNarrowly(exec, REPO, 'fork', 'main')
 
     const addCalls = exec.mock.calls.filter(([args]) => args[1] === '--add')
     expect(addCalls).toEqual([])
+  })
+
+  it('replaces a stray literal (non-suffixed) entry for the same branch with the suffixed form', async () => {
+    const { exec } = makeConfigExec({ fork: ['+refs/heads/main:refs/remotes/fork/main'] })
+
+    await ensureRemoteTracksBranchNarrowly(exec, REPO, 'fork', 'main')
+
+    await expect(getRemoteFetchRefspecs(exec, REPO, 'fork')).resolves.toEqual([
+      '+refs/heads/main*:refs/remotes/fork/main*'
+    ])
+  })
+
+  it('leaves a different branch entry untouched when replacing a stray literal', async () => {
+    const { exec } = makeConfigExec({
+      fork: [
+        '+refs/heads/main:refs/remotes/fork/main',
+        '+refs/heads/other*:refs/remotes/fork/other*'
+      ]
+    })
+
+    await ensureRemoteTracksBranchNarrowly(exec, REPO, 'fork', 'main')
+
+    await expect(getRemoteFetchRefspecs(exec, REPO, 'fork')).resolves.toEqual([
+      '+refs/heads/other*:refs/remotes/fork/other*',
+      '+refs/heads/main*:refs/remotes/fork/main*'
+    ])
   })
 })
 
@@ -180,5 +206,14 @@ describe('pruneUntrackedForkRemoteRefs', () => {
 
     expect(deleted).toEqual([])
     expect(refs).toEqual(['main'])
+  })
+
+  it("keeps a ref that shares a branch prefix, matching the refspec's own trailing-* match", async () => {
+    const { exec, refs } = makeRefsExec(['fix', 'fix-extra', 'unrelated'])
+
+    const deleted = await pruneUntrackedForkRemoteRefs(exec, REPO, 'fork', new Set(['fix']))
+
+    expect(deleted).toEqual(['refs/remotes/fork/unrelated'])
+    expect(refs.sort()).toEqual(['fix', 'fix-extra'])
   })
 })

--- a/src/main/git/fork-remote-refspec.ts
+++ b/src/main/git/fork-remote-refspec.ts
@@ -112,6 +112,22 @@ export async function ensureRemoteTracksBranchNarrowly(
 }
 
 /**
+ * Removes every `remote.<name>.fetch` entry, leaving the remote pushable but importing
+ * nothing on a plain fetch. For a fork remote with no branch pinning it at all (no
+ * worktree metadata, no `branch.*.remote`/`.pushRemote` config), there's nothing to
+ * narrow *to* -- but leaving the wide default in place means the next plain fetch still
+ * re-imports the fork's entire branch set. See the migration sweep's caller for the
+ * provenance check gating when this is safe to call.
+ */
+export async function clearForkRemoteFetchRefspec(
+  execGit: GitExecFn,
+  repoPath: string,
+  remoteName: string
+): Promise<void> {
+  await execGit(['config', '--unset-all', `remote.${remoteName}.fetch`], repoPath).catch(() => {})
+}
+
+/**
  * Deletes remote-tracking refs under `refs/remotes/<remoteName>/` that fall outside
  * `keepBranches`. Needed because migrating away from the old wide default leaves behind
  * refs for every branch the earlier wide fetch already pulled in, and a plain fetch under

--- a/src/main/git/fork-remote-refspec.ts
+++ b/src/main/git/fork-remote-refspec.ts
@@ -1,0 +1,119 @@
+// Why: a fork-PR remote added with a bare `git remote add` writes the default
+// `+refs/heads/*:refs/remotes/<name>/*` refspec, so any later plain `git fetch <name>`
+// (user, agent, or Orca's own Fetch action) imports the fork's entire branch set --
+// a large fork can carry 1000+ branches. Every mint/reuse/migration path funnels
+// through `ensureRemoteTracksBranchNarrowly` so a fork remote never tracks more than
+// the branches Orca actually knows about (see #17828).
+export type GitExecFn = (
+  args: string[],
+  cwd: string
+) => Promise<{ stdout: string; stderr?: string }>
+
+export function buildNarrowForkFetchRefspec(remoteName: string, branchName: string): string {
+  return `+refs/heads/${branchName}:refs/remotes/${remoteName}/${branchName}`
+}
+
+export function wildcardForkFetchRefspec(remoteName: string): string {
+  return `+refs/heads/*:refs/remotes/${remoteName}/*`
+}
+
+/** `[]` when the remote has no configured fetch refspec (or doesn't exist). */
+export async function getRemoteFetchRefspecs(
+  execGit: GitExecFn,
+  repoPath: string,
+  remoteName: string
+): Promise<string[]> {
+  try {
+    const { stdout } = await execGit(
+      ['config', '--get-all', `remote.${remoteName}.fetch`],
+      repoPath
+    )
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+function refspecSource(refspec: string): string {
+  return refspec.replace(/^\+/, '').split(':')[0]!
+}
+
+/**
+ * Adds `branchName` to `remoteName`'s tracked set without dropping any other branch
+ * already tracked (a sibling worktree on the same fork may track a different branch --
+ * see #17828 reuse-path discussion on why this widens rather than replaces). Replaces
+ * the wide default wildcard refspec outright since nothing should still depend on it.
+ * Also pins `tagOpt=--no-tags` so tags never auto-follow into the shared namespace.
+ */
+export async function ensureRemoteTracksBranchNarrowly(
+  execGit: GitExecFn,
+  repoPath: string,
+  remoteName: string,
+  branchName: string
+): Promise<void> {
+  const desired = buildNarrowForkFetchRefspec(remoteName, branchName)
+  const existing = await getRemoteFetchRefspecs(execGit, repoPath, remoteName)
+  if (!existing.includes(desired)) {
+    if (existing.includes(wildcardForkFetchRefspec(remoteName))) {
+      await execGit(['config', '--unset-all', `remote.${remoteName}.fetch`], repoPath)
+    }
+    await execGit(['config', '--add', `remote.${remoteName}.fetch`, desired], repoPath)
+  }
+  await execGit(['config', `remote.${remoteName}.tagOpt`, '--no-tags'], repoPath)
+}
+
+/**
+ * Deletes remote-tracking refs under `refs/remotes/<remoteName>/` that fall outside
+ * `keepBranches`. Needed because `git fetch --prune` only reclaims refs a *wildcard*
+ * refspec could reproduce -- once a remote is narrowed to literal branch refspecs, git
+ * has no way to know a `refs/remotes/<name>/<other-branch>` ref "belongs" to it, so
+ * `--prune` silently leaves every stray from the old wide fetch in place (verified against
+ * real git; see #17828). Returns the deleted ref names. Never touches `HEAD`.
+ */
+export async function pruneUntrackedForkRemoteRefs(
+  execGit: GitExecFn,
+  repoPath: string,
+  remoteName: string,
+  keepBranches: ReadonlySet<string>
+): Promise<string[]> {
+  const prefix = `refs/remotes/${remoteName}/`
+  const { stdout } = await execGit(['for-each-ref', '--format=%(refname)', prefix], repoPath).catch(
+    () => ({ stdout: '' })
+  )
+  const deleted: string[] = []
+  for (const refname of stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)) {
+    const branch = refname.slice(prefix.length)
+    if (branch === 'HEAD' || keepBranches.has(branch)) {
+      continue
+    }
+    await execGit(['update-ref', '-d', refname], repoPath)
+    deleted.push(refname)
+  }
+  return deleted
+}
+
+/** Drops the one refspec whose source is `refs/heads/<staleBranchName>`, keeping the rest. */
+export async function removeStaleForkFetchRefspec(
+  execGit: GitExecFn,
+  repoPath: string,
+  remoteName: string,
+  staleBranchName: string
+): Promise<boolean> {
+  const existing = await getRemoteFetchRefspecs(execGit, repoPath, remoteName)
+  const staleSource = `refs/heads/${staleBranchName}`
+  const surviving = existing.filter((refspec) => refspecSource(refspec) !== staleSource)
+  if (surviving.length === existing.length) {
+    return false
+  }
+  await execGit(['config', '--unset-all', `remote.${remoteName}.fetch`], repoPath)
+  for (const refspec of surviving) {
+    await execGit(['config', '--add', `remote.${remoteName}.fetch`, refspec], repoPath)
+  }
+  return true
+}

--- a/src/main/git/fork-remote-refspec.ts
+++ b/src/main/git/fork-remote-refspec.ts
@@ -4,13 +4,27 @@
 // a large fork can carry 1000+ branches. Every mint/reuse/migration path funnels
 // through `ensureRemoteTracksBranchNarrowly` so a fork remote never tracks more than
 // the branches Orca actually knows about (see #17828).
+//
+// The tracked-branch refspec source carries a trailing `*` (`refs/heads/<branch>*`)
+// rather than being a literal exact match. This is deliberate: Orca is terminal-centric
+// (agents run raw git in worktrees), and a *bare* `git fetch` inside a fork-PR worktree
+// resolves to this remote via `branch.<name>.remote` -- it is the single most common
+// fetch shape here, more common than `git fetch <explicit-remote>`. A literal refspec
+// makes that fetch (and `git fetch <remote>`) hard-fail with `couldn't find remote ref`
+// the moment the tracked branch is deleted/renamed upstream, where the old wide default
+// silently no-op'd. A trailing `*` keeps git's wildcard zero-match tolerance (verified
+// against real git: exit 0, and `--prune` correctly reclaims the ref once it can't be
+// found) while still bounding the import to branches sharing that literal prefix --
+// not the fork's entire branch set. The residual widening (an unrelated sibling branch
+// that happens to share the prefix, e.g. `fix` also matching `fix-v2`) is accepted as
+// far narrower than the bug this fixes.
 export type GitExecFn = (
   args: string[],
   cwd: string
 ) => Promise<{ stdout: string; stderr?: string }>
 
 export function buildNarrowForkFetchRefspec(remoteName: string, branchName: string): string {
-  return `+refs/heads/${branchName}:refs/remotes/${remoteName}/${branchName}`
+  return `+refs/heads/${branchName}*:refs/remotes/${remoteName}/${branchName}*`
 }
 
 export function wildcardForkFetchRefspec(remoteName: string): string {
@@ -42,6 +56,27 @@ function refspecSource(refspec: string): string {
 }
 
 /**
+ * True only if `remote.<name>.url` is actually set. Deliberately plumbing (`config --get`),
+ * not porcelain `git remote get-url` -- the latter falls back to echoing the remote *name*
+ * as a bogus "URL" when the section exists but has no url key (verified against real git),
+ * which would hide exactly the config-only ghost state this guards against (see
+ * `worktree-push-target-refspec-migration.ts`'s concurrent-removal race with #17842's
+ * reconciliation sweep).
+ */
+export async function remoteHasUrl(
+  execGit: GitExecFn,
+  repoPath: string,
+  remoteName: string
+): Promise<boolean> {
+  try {
+    await execGit(['config', '--get', `remote.${remoteName}.url`], repoPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
  * Adds `branchName` to `remoteName`'s tracked set without dropping any other branch
  * already tracked (a sibling worktree on the same fork may track a different branch --
  * see #17828 reuse-path discussion on why this widens rather than replaces). Replaces
@@ -57,8 +92,19 @@ export async function ensureRemoteTracksBranchNarrowly(
   const desired = buildNarrowForkFetchRefspec(remoteName, branchName)
   const existing = await getRemoteFetchRefspecs(execGit, repoPath, remoteName)
   if (!existing.includes(desired)) {
-    if (existing.includes(wildcardForkFetchRefspec(remoteName))) {
+    // Strip the wide default outright, and any stray literal (non-suffixed) entry for
+    // this exact branch -- e.g. a hand-edited config -- since it would shadow the same
+    // source prefix and defeats the point of the trailing `*`.
+    const literalForBranch = `refs/heads/${branchName}`
+    const toDrop = existing.includes(wildcardForkFetchRefspec(remoteName))
+      ? existing
+      : existing.filter((refspec) => refspecSource(refspec) === literalForBranch)
+    if (toDrop.length > 0) {
+      const surviving = existing.filter((refspec) => !toDrop.includes(refspec))
       await execGit(['config', '--unset-all', `remote.${remoteName}.fetch`], repoPath)
+      for (const refspec of surviving) {
+        await execGit(['config', '--add', `remote.${remoteName}.fetch`, refspec], repoPath)
+      }
     }
     await execGit(['config', '--add', `remote.${remoteName}.fetch`, desired], repoPath)
   }
@@ -67,11 +113,13 @@ export async function ensureRemoteTracksBranchNarrowly(
 
 /**
  * Deletes remote-tracking refs under `refs/remotes/<remoteName>/` that fall outside
- * `keepBranches`. Needed because `git fetch --prune` only reclaims refs a *wildcard*
- * refspec could reproduce -- once a remote is narrowed to literal branch refspecs, git
- * has no way to know a `refs/remotes/<name>/<other-branch>` ref "belongs" to it, so
- * `--prune` silently leaves every stray from the old wide fetch in place (verified against
- * real git; see #17828). Returns the deleted ref names. Never touches `HEAD`.
+ * `keepBranches`. Needed because migrating away from the old wide default leaves behind
+ * refs for every branch the earlier wide fetch already pulled in, and a plain fetch under
+ * the new narrow refspec never revisits (or reclaims) a branch outside its own prefix.
+ * A tracking ref is kept if its branch name equals, or starts with, an entry in
+ * `keepBranches` -- matching what `buildNarrowForkFetchRefspec`'s trailing `*` would also
+ * match, so this never deletes a ref the configured refspec will just re-fetch anyway.
+ * Returns the deleted ref names. Never touches `HEAD`.
  */
 export async function pruneUntrackedForkRemoteRefs(
   execGit: GitExecFn,
@@ -89,7 +137,8 @@ export async function pruneUntrackedForkRemoteRefs(
     .map((line) => line.trim())
     .filter(Boolean)) {
     const branch = refname.slice(prefix.length)
-    if (branch === 'HEAD' || keepBranches.has(branch)) {
+    const kept = branch === 'HEAD' || [...keepBranches].some((keep) => branch.startsWith(keep))
+    if (kept) {
       continue
     }
     await execGit(['update-ref', '-d', refname], repoPath)

--- a/src/main/git/fork-remote-stale-branch-refspec.test.ts
+++ b/src/main/git/fork-remote-stale-branch-refspec.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GitExecFn } from './fork-remote-refspec'
+import {
+  fetchForkRemoteWithStaleRefspecRepair,
+  parseMissingForkBranchRef
+} from './fork-remote-stale-branch-refspec'
+
+describe('parseMissingForkBranchRef', () => {
+  it('extracts the missing ref from a "couldn\'t find remote ref" fatal', () => {
+    expect(parseMissingForkBranchRef("fatal: couldn't find remote ref refs/heads/gone\n")).toBe(
+      'refs/heads/gone'
+    )
+  })
+
+  it('returns null for unrelated stderr', () => {
+    expect(parseMissingForkBranchRef('fatal: Authentication failed\n')).toBeNull()
+  })
+})
+
+function makeExec(getAllStdout: string): GitExecFn {
+  return vi.fn<GitExecFn>(async (args: string[]) => {
+    if (args[1] === '--get-all') {
+      return { stdout: getAllStdout, stderr: '' }
+    }
+    return { stdout: '', stderr: '' }
+  })
+}
+
+describe('fetchForkRemoteWithStaleRefspecRepair', () => {
+  it('retries once after dropping a stale refspec, and returns on success', async () => {
+    const exec = makeExec(
+      '+refs/heads/gone:refs/remotes/fork/gone\n+refs/heads/keep:refs/remotes/fork/keep\n'
+    )
+    let attempts = 0
+    const runFetch = vi.fn(async () => {
+      attempts += 1
+      if (attempts === 1) {
+        throw Object.assign(new Error('boom'), {
+          stderr: "fatal: couldn't find remote ref refs/heads/gone\n"
+        })
+      }
+    })
+
+    await fetchForkRemoteWithStaleRefspecRepair(exec, '/repo', 'fork', runFetch)
+
+    expect(runFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('rethrows immediately when the error is not a stale-refspec failure', async () => {
+    const exec = makeExec('+refs/heads/keep:refs/remotes/fork/keep\n')
+    const runFetch = vi.fn(async () => {
+      throw new Error('network unreachable')
+    })
+
+    await expect(
+      fetchForkRemoteWithStaleRefspecRepair(exec, '/repo', 'fork', runFetch)
+    ).rejects.toThrow('network unreachable')
+    expect(runFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('rethrows when the reported stale ref is not actually a tracked refspec (fail safe, no infinite loop)', async () => {
+    const exec = makeExec('+refs/heads/keep:refs/remotes/fork/keep\n')
+    const runFetch = vi.fn(async () => {
+      throw Object.assign(new Error('boom'), {
+        stderr: "fatal: couldn't find remote ref refs/heads/not-tracked\n"
+      })
+    })
+
+    await expect(
+      fetchForkRemoteWithStaleRefspecRepair(exec, '/repo', 'fork', runFetch)
+    ).rejects.toThrow('boom')
+    expect(runFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves multiple stale refspecs across repeated attempts', async () => {
+    let refspecs = [
+      '+refs/heads/gone-a:refs/remotes/fork/gone-a',
+      '+refs/heads/gone-b:refs/remotes/fork/gone-b',
+      '+refs/heads/keep:refs/remotes/fork/keep'
+    ]
+    const exec = vi.fn<GitExecFn>(async (args: string[]) => {
+      if (args[1] === '--get-all') {
+        return { stdout: refspecs.length ? `${refspecs.join('\n')}\n` : '', stderr: '' }
+      }
+      if (args[1] === '--unset-all') {
+        refspecs = []
+        return { stdout: '', stderr: '' }
+      }
+      if (args[1] === '--add') {
+        refspecs.push(args[3]!)
+        return { stdout: '', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+    // Why: mirrors real git reporting exactly one missing ref per fetch attempt (see #17828 PR).
+    const staleBranches = ['refs/heads/gone-a', 'refs/heads/gone-b']
+    const runFetch = vi.fn(async () => {
+      const stillStale = staleBranches.find((branch) => refspecs.some((r) => r.includes(branch)))
+      if (stillStale) {
+        throw Object.assign(new Error('boom'), {
+          stderr: `fatal: couldn't find remote ref ${stillStale}\n`
+        })
+      }
+    })
+
+    await fetchForkRemoteWithStaleRefspecRepair(exec, '/repo', 'fork', runFetch)
+
+    expect(runFetch).toHaveBeenCalledTimes(3)
+    expect(refspecs).toEqual(['+refs/heads/keep:refs/remotes/fork/keep'])
+  })
+})

--- a/src/main/git/fork-remote-stale-branch-refspec.ts
+++ b/src/main/git/fork-remote-stale-branch-refspec.ts
@@ -1,0 +1,49 @@
+// Why: a narrow fork-remote refspec (#17828) pins an exact `refs/heads/<branch>`, so
+// if that branch is later deleted or renamed upstream (e.g. the contributor deletes it
+// after merge), a plain `git fetch <remote>` using the configured refspec exits nonzero
+// with "couldn't find remote ref" -- and fetches NOTHING for that remote, not even other
+// branches it also tracks. A wide refspec never had this failure mode (unmatched
+// wildcards are silently skipped), so this is a new risk the narrow refspec introduces
+// and must self-heal rather than surface as a broken Fetch button.
+import { extractExecError } from './exec-error'
+import { removeStaleForkFetchRefspec, type GitExecFn } from './fork-remote-refspec'
+
+const MISSING_REMOTE_REF_PATTERN = /couldn't find remote ref (refs\/heads\/\S+)/
+
+export function parseMissingForkBranchRef(stderr: string): string | null {
+  return MISSING_REMOTE_REF_PATTERN.exec(stderr)?.[1] ?? null
+}
+
+// Bounds the repair loop; git reports one missing ref per fetch attempt (see #17828 PR
+// description), so this comfortably covers even a fork remote tracking many stale branches.
+const MAX_STALE_REFSPEC_REPAIR_ATTEMPTS = 20
+
+/**
+ * Runs `runFetch`, and on a "couldn't find remote ref" failure for a refspec this remote
+ * tracks, drops that one stale refspec and retries -- so a branch deleted upstream degrades
+ * to "no longer updates for that branch" instead of "fetch fails for the whole remote".
+ */
+export async function fetchForkRemoteWithStaleRefspecRepair(
+  execGit: GitExecFn,
+  repoPath: string,
+  remoteName: string,
+  runFetch: () => Promise<void>
+): Promise<void> {
+  for (let attempt = 0; attempt < MAX_STALE_REFSPEC_REPAIR_ATTEMPTS; attempt += 1) {
+    try {
+      await runFetch()
+      return
+    } catch (error) {
+      const staleRef = parseMissingForkBranchRef(extractExecError(error).stderr)
+      const staleBranch = staleRef?.replace(/^refs\/heads\//, '')
+      if (
+        !staleBranch ||
+        !(await removeStaleForkFetchRefspec(execGit, repoPath, remoteName, staleBranch))
+      ) {
+        throw error
+      }
+      // loop: retry now that the dead refspec is gone
+    }
+  }
+  throw new Error(`Exceeded stale fork-remote refspec repair attempts for "${remoteName}"`)
+}

--- a/src/main/git/fork-remote-stale-branch-refspec.ts
+++ b/src/main/git/fork-remote-stale-branch-refspec.ts
@@ -1,10 +1,11 @@
-// Why: a narrow fork-remote refspec (#17828) pins an exact `refs/heads/<branch>`, so
-// if that branch is later deleted or renamed upstream (e.g. the contributor deletes it
-// after merge), a plain `git fetch <remote>` using the configured refspec exits nonzero
-// with "couldn't find remote ref" -- and fetches NOTHING for that remote, not even other
-// branches it also tracks. A wide refspec never had this failure mode (unmatched
-// wildcards are silently skipped), so this is a new risk the narrow refspec introduces
-// and must self-heal rather than surface as a broken Fetch button.
+// Why: Orca's fork-remote refspecs (#17828) carry a trailing `*` specifically so a
+// deleted/renamed upstream branch degrades to a silent zero-match fetch, not a hard
+// failure -- see `buildNarrowForkFetchRefspec`'s comment. That is now the primary
+// defense. This wrapper is a cheap backstop for the one case the `*` doesn't cover: a
+// truly literal (non-wildcard) `refs/heads/<branch>` refspec somehow ends up configured
+// (hand-edited `.git/config`, a future regression, etc), which -- unlike a wide refspec's
+// silently-skipped wildcards -- exits nonzero with "couldn't find remote ref" and fetches
+// NOTHING for that remote, not even other branches it also tracks.
 import { extractExecError } from './exec-error'
 import { removeStaleForkFetchRefspec, type GitExecFn } from './fork-remote-refspec'
 

--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -780,6 +780,60 @@ describe('git remote operations', () => {
     ])
   })
 
+  it('drops a stale branch-specific refspec and retries when the fork branch was deleted upstream (#17828)', async () => {
+    let fetchAttempts = 0
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'check-ref-format') {
+        return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'fetch') {
+        fetchAttempts += 1
+        if (fetchAttempts === 1) {
+          throw Object.assign(new Error("fatal: couldn't find remote ref refs/heads/gone"), {
+            stderr: "fatal: couldn't find remote ref refs/heads/gone\n"
+          })
+        }
+        return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'config' && args[1] === '--get-all') {
+        return {
+          stdout:
+            '+refs/heads/gone:refs/remotes/fork/gone\n+refs/heads/keep:refs/remotes/fork/keep\n',
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await gitFetch('/repo', { remoteName: 'fork', branchName: 'keep' })
+
+    expect(fetchAttempts).toBe(2)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['config', '--unset-all', 'remote.fork.fetch'],
+      { cwd: '/repo' }
+    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['config', '--add', 'remote.fork.fetch', '+refs/heads/keep:refs/remotes/fork/keep'],
+      { cwd: '/repo' }
+    )
+  })
+
+  it('surfaces the original fetch error when it is not a stale-refspec failure', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'check-ref-format') {
+        return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'fetch') {
+        throw new Error('network unreachable')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(gitFetch('/repo', { remoteName: 'fork', branchName: 'keep' })).rejects.toThrow(
+      'network unreachable'
+    )
+  })
+
   it('normalizes fetch authentication errors to a friendly message', async () => {
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('Authentication failed'))
 

--- a/src/main/git/remote.ts
+++ b/src/main/git/remote.ts
@@ -9,6 +9,7 @@ import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
 import { validateGitPushTarget } from './push-target-validation'
 import { gitExecFileAsync } from './runner'
+import { fetchForkRemoteWithStaleRefspecRepair } from './fork-remote-stale-branch-refspec'
 import { runWithGitReadCacheInvalidation } from './status'
 import { runWithGitWorktreeOperationLock } from '../../shared/git-worktree-operation-lock'
 
@@ -284,9 +285,15 @@ export async function gitFetch(
   try {
     if (pushTarget) {
       const target = await validateGitPushTarget(worktreePath, pushTarget, options)
-      await gitExecFileAsync(
-        ['fetch', '--prune', target.remoteName],
-        gitOptionsForWorktree(worktreePath, options)
+      const runtimeOptions = gitOptionsForWorktree(worktreePath, options)
+      await fetchForkRemoteWithStaleRefspecRepair(
+        (args, cwd) => gitExecFileAsync(args, { ...runtimeOptions, cwd }),
+        worktreePath,
+        target.remoteName,
+        () =>
+          gitExecFileAsync(['fetch', '--prune', target.remoteName], runtimeOptions).then(
+            () => undefined
+          )
       )
       return
     }

--- a/src/main/ipc/worktree-push-target-refspec-migration.test.ts
+++ b/src/main/ipc/worktree-push-target-refspec-migration.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, vi, type Mock } from 'vitest'
+import type { WorktreeMeta } from '../../shared/worktree/meta-types'
+import type { GitPushTarget } from '../../shared/worktree/types'
+import type { GitRemoteExec, WorktreePushTargetStore } from './worktree-push-target-cleanup'
+import {
+  _resetForkRemoteRefspecMigrationRateLimitForTests,
+  migrateForkRemoteRefspecsWithExec
+} from './worktree-push-target-refspec-migration'
+
+type ExecMock = Mock<GitRemoteExec>
+
+const REPO_PATH = '/repo-root'
+const REPO_ID = 'repo-1'
+const FORK_REMOTE = 'pr-contributor-orca'
+
+function worktreeId(suffix: string): string {
+  return `${REPO_ID}::${suffix}`
+}
+
+function forkTarget(overrides: Partial<GitPushTarget> = {}): GitPushTarget {
+  return {
+    remoteName: FORK_REMOTE,
+    branchName: 'contributor/fix',
+    remoteUrl: 'git@github.com:contributor/orca.git',
+    remoteCreated: true,
+    ...overrides
+  }
+}
+
+function metaWith(pushTarget: GitPushTarget | undefined): WorktreeMeta {
+  return { pushTarget } as unknown as WorktreeMeta
+}
+
+function storeOf(entries: Record<string, GitPushTarget | undefined>): WorktreePushTargetStore {
+  const meta: Record<string, WorktreeMeta> = {}
+  for (const [id, pushTarget] of Object.entries(entries)) {
+    meta[id] = metaWith(pushTarget)
+  }
+  return { getAllWorktreeMeta: () => meta }
+}
+
+type ExecScript = {
+  fetchByRemote?: Record<string, string[]>
+  urlByRemote?: Record<string, string>
+  branchConfig?: string
+  trackingRefsByRemote?: Record<string, string[]>
+}
+
+function makeExec(script: ExecScript = {}): ExecMock {
+  const {
+    fetchByRemote = {},
+    urlByRemote = {},
+    branchConfig = '',
+    trackingRefsByRemote = {}
+  } = script
+  return vi.fn<GitRemoteExec>(async (args: string[]) => {
+    if (args[0] === 'remote' && args[1] === 'get-url') {
+      const url = urlByRemote[args[2]!]
+      if (!url) {
+        throw new Error(`no such remote ${args[2]}`)
+      }
+      return { stdout: url, stderr: '' }
+    }
+    if (args[0] === 'config' && args[1] === '--get-regexp') {
+      return { stdout: branchConfig, stderr: '' }
+    }
+    if (args[0] === 'config' && args[1] === '--get-all' && args[2]!.endsWith('.fetch')) {
+      const remoteName = args[2]!.slice('remote.'.length, -'.fetch'.length)
+      const values = fetchByRemote[remoteName] ?? []
+      if (values.length === 0) {
+        throw new Error('key not found')
+      }
+      return { stdout: `${values.join('\n')}\n`, stderr: '' }
+    }
+    if (args[0] === 'config' && args[1] === '--unset-all' && args[2]!.endsWith('.fetch')) {
+      const remoteName = args[2]!.slice('remote.'.length, -'.fetch'.length)
+      fetchByRemote[remoteName] = []
+      return { stdout: '', stderr: '' }
+    }
+    if (args[0] === 'config' && args[1] === '--add' && args[2]!.endsWith('.fetch')) {
+      const remoteName = args[2]!.slice('remote.'.length, -'.fetch'.length)
+      fetchByRemote[remoteName] = [...(fetchByRemote[remoteName] ?? []), args[3]!]
+      return { stdout: '', stderr: '' }
+    }
+    if (args[0] === 'config' && args[1]?.endsWith('.tagOpt')) {
+      return { stdout: '', stderr: '' }
+    }
+    if (args[0] === 'for-each-ref') {
+      const prefix = args[2]!
+      const remoteName = prefix.replace('refs/remotes/', '').replace(/\/$/, '')
+      const refs = trackingRefsByRemote[remoteName] ?? []
+      return {
+        stdout: refs.length ? `${refs.map((r) => `${prefix}${r}`).join('\n')}\n` : '',
+        stderr: ''
+      }
+    }
+    if (args[0] === 'update-ref' && args[1] === '-d') {
+      const refname = args[2]!
+      for (const [remoteName, refs] of Object.entries(trackingRefsByRemote)) {
+        const prefix = `refs/remotes/${remoteName}/`
+        if (refname.startsWith(prefix)) {
+          trackingRefsByRemote[remoteName] = refs.filter((r) => `${prefix}${r}` !== refname)
+        }
+      }
+      return { stdout: '', stderr: '' }
+    }
+    return { stdout: '', stderr: '' }
+  })
+}
+
+describe('migrateForkRemoteRefspecsWithExec', () => {
+  it('narrows a wide-refspec remote to the known branch and deletes the strays left by the old wide fetch', async () => {
+    const trackingRefsByRemote = {
+      [FORK_REMOTE]: ['contributor/fix', 'contributor/unrelated-1', 'master']
+    }
+    const exec = makeExec({
+      urlByRemote: { [FORK_REMOTE]: 'git@github.com:contributor/orca.git\n' },
+      fetchByRemote: { [FORK_REMOTE]: ['+refs/heads/*:refs/remotes/pr-contributor-orca/*'] },
+      trackingRefsByRemote
+    })
+
+    const migrated = await migrateForkRemoteRefspecsWithExec(
+      REPO_PATH,
+      REPO_ID,
+      storeOf({ [worktreeId('/wt/a')]: forkTarget() }),
+      exec
+    )
+
+    expect(migrated).toEqual([FORK_REMOTE])
+    expect(exec.mock.calls).toContainEqual([
+      [
+        'config',
+        '--add',
+        `remote.${FORK_REMOTE}.fetch`,
+        '+refs/heads/contributor/fix:refs/remotes/pr-contributor-orca/contributor/fix'
+      ],
+      REPO_PATH
+    ])
+    // `fetch --prune` cannot reclaim strays under a narrow refspec (verified against real
+    // git); the migration must delete them directly instead.
+    expect(exec.mock.calls.some(([args]) => args[0] === 'fetch' && args[1] === '--prune')).toBe(
+      false
+    )
+    expect(trackingRefsByRemote[FORK_REMOTE]).toEqual(['contributor/fix'])
+  })
+
+  it('unions branches from multiple worktrees sharing the same fork remote', async () => {
+    const exec = makeExec({
+      urlByRemote: { [FORK_REMOTE]: 'git@github.com:contributor/orca.git\n' },
+      fetchByRemote: { [FORK_REMOTE]: ['+refs/heads/*:refs/remotes/pr-contributor-orca/*'] }
+    })
+
+    await migrateForkRemoteRefspecsWithExec(
+      REPO_PATH,
+      REPO_ID,
+      storeOf({
+        [worktreeId('/wt/a')]: forkTarget({ branchName: 'branch-a' }),
+        [worktreeId('/wt/b')]: forkTarget({ branchName: 'branch-b', remoteCreated: false })
+      }),
+      exec
+    )
+
+    const addedRefspecs = exec.mock.calls
+      .filter(([args]) => args[0] === 'config' && args[1] === '--add')
+      .map(([args]) => args[3])
+    expect(addedRefspecs).toEqual(
+      expect.arrayContaining([
+        '+refs/heads/branch-a:refs/remotes/pr-contributor-orca/branch-a',
+        '+refs/heads/branch-b:refs/remotes/pr-contributor-orca/branch-b'
+      ])
+    )
+  })
+
+  it('skips a remote with no provenance evidence (no metadata entry has remoteCreated: true)', async () => {
+    const exec = makeExec({
+      urlByRemote: { [FORK_REMOTE]: 'git@github.com:contributor/orca.git\n' },
+      fetchByRemote: { [FORK_REMOTE]: ['+refs/heads/*:refs/remotes/pr-contributor-orca/*'] }
+    })
+
+    const migrated = await migrateForkRemoteRefspecsWithExec(
+      REPO_PATH,
+      REPO_ID,
+      storeOf({ [worktreeId('/wt/a')]: forkTarget({ remoteCreated: false }) }),
+      exec
+    )
+
+    expect(migrated).toEqual([])
+    expect(exec.mock.calls.some(([args]) => args[1] === '--unset-all')).toBe(false)
+  })
+
+  it('never touches origin or upstream even with malformed metadata', async () => {
+    const exec = makeExec({ urlByRemote: { origin: 'git@github.com:stablyai/orca.git\n' } })
+
+    const migrated = await migrateForkRemoteRefspecsWithExec(
+      REPO_PATH,
+      REPO_ID,
+      storeOf({ [worktreeId('/wt/a')]: forkTarget({ remoteName: 'origin' }) }),
+      exec
+    )
+
+    expect(migrated).toEqual([])
+  })
+
+  it('scopes provenance to the same repo (remotes are repo-local)', async () => {
+    const exec = makeExec({
+      urlByRemote: { [FORK_REMOTE]: 'git@github.com:contributor/orca.git\n' },
+      fetchByRemote: { [FORK_REMOTE]: ['+refs/heads/*:refs/remotes/pr-contributor-orca/*'] }
+    })
+
+    const migrated = await migrateForkRemoteRefspecsWithExec(
+      REPO_PATH,
+      REPO_ID,
+      storeOf({ 'repo-2::/wt/other-repo': forkTarget() }),
+      exec
+    )
+
+    expect(migrated).toEqual([])
+  })
+
+  it('skips (does not re-fetch) a remote that is already narrow', async () => {
+    const exec = makeExec({
+      urlByRemote: { [FORK_REMOTE]: 'git@github.com:contributor/orca.git\n' },
+      fetchByRemote: {
+        [FORK_REMOTE]: [
+          '+refs/heads/contributor/fix:refs/remotes/pr-contributor-orca/contributor/fix'
+        ]
+      }
+    })
+
+    const migrated = await migrateForkRemoteRefspecsWithExec(
+      REPO_PATH,
+      REPO_ID,
+      storeOf({ [worktreeId('/wt/a')]: forkTarget() }),
+      exec
+    )
+
+    expect(migrated).toEqual([])
+    expect(exec.mock.calls.some(([args]) => args[0] === 'fetch')).toBe(false)
+  })
+
+  it('also narrows branches only referenced by surviving branch.*.remote config (no metadata left)', async () => {
+    const exec = makeExec({
+      urlByRemote: { [FORK_REMOTE]: 'git@github.com:contributor/orca.git\n' },
+      fetchByRemote: { [FORK_REMOTE]: ['+refs/heads/*:refs/remotes/pr-contributor-orca/*'] },
+      branchConfig: `branch.contributor/preserved.remote ${FORK_REMOTE}`
+    })
+
+    const migrated = await migrateForkRemoteRefspecsWithExec(
+      REPO_PATH,
+      REPO_ID,
+      // Only proof of Orca provenance; the branch itself comes from local config.
+      storeOf({ [worktreeId('/wt/gone')]: forkTarget({ branchName: 'contributor/fix' }) }),
+      exec
+    )
+
+    expect(migrated).toEqual([FORK_REMOTE])
+    const addedRefspecs = exec.mock.calls
+      .filter(([args]) => args[0] === 'config' && args[1] === '--add')
+      .map(([args]) => args[3])
+    expect(addedRefspecs).toEqual(
+      expect.arrayContaining([
+        '+refs/heads/contributor/preserved:refs/remotes/pr-contributor-orca/contributor/preserved'
+      ])
+    )
+  })
+})
+
+describe('fork remote refspec migration rate limiting', () => {
+  it('exposes a test reset so repeated test runs are not affected by prior cooldowns', () => {
+    expect(() => _resetForkRemoteRefspecMigrationRateLimitForTests()).not.toThrow()
+  })
+})

--- a/src/main/ipc/worktree-push-target-refspec-migration.test.ts
+++ b/src/main/ipc/worktree-push-target-refspec-migration.test.ts
@@ -44,6 +44,9 @@ type ExecScript = {
   urlByRemote?: Record<string, string>
   branchConfig?: string
   trackingRefsByRemote?: Record<string, string[]>
+  // Simulates #17842's reconciliation sweep concurrently `remote remove`-ing this
+  // remote in between this migration's pre-write and post-write existence checks.
+  removeUrlAfterFirstCheck?: Set<string>
 }
 
 function makeExec(script: ExecScript = {}): ExecMock {
@@ -51,15 +54,27 @@ function makeExec(script: ExecScript = {}): ExecMock {
     fetchByRemote = {},
     urlByRemote = {},
     branchConfig = '',
-    trackingRefsByRemote = {}
+    trackingRefsByRemote = {},
+    removeUrlAfterFirstCheck = new Set<string>()
   } = script
+  const urlCheckCountByRemote: Record<string, number> = {}
   return vi.fn<GitRemoteExec>(async (args: string[]) => {
-    if (args[0] === 'remote' && args[1] === 'get-url') {
-      const url = urlByRemote[args[2]!]
+    if (args[0] === 'config' && args[1] === '--get' && args[2]!.endsWith('.url')) {
+      const remoteName = args[2]!.slice('remote.'.length, -'.url'.length)
+      urlCheckCountByRemote[remoteName] = (urlCheckCountByRemote[remoteName] ?? 0) + 1
+      const concurrentlyRemoved =
+        removeUrlAfterFirstCheck.has(remoteName) && urlCheckCountByRemote[remoteName]! > 1
+      const url = concurrentlyRemoved ? undefined : urlByRemote[remoteName]
       if (!url) {
-        throw new Error(`no such remote ${args[2]}`)
+        throw new Error(`no such remote ${remoteName}`)
       }
       return { stdout: url, stderr: '' }
+    }
+    if (args[0] === 'config' && args[1] === '--remove-section' && args[2]!.startsWith('remote.')) {
+      const remoteName = args[2]!.slice('remote.'.length)
+      delete fetchByRemote[remoteName]
+      delete urlByRemote[remoteName]
+      return { stdout: '', stderr: '' }
     }
     if (args[0] === 'config' && args[1] === '--get-regexp') {
       return { stdout: branchConfig, stderr: '' }
@@ -132,7 +147,7 @@ describe('migrateForkRemoteRefspecsWithExec', () => {
         'config',
         '--add',
         `remote.${FORK_REMOTE}.fetch`,
-        '+refs/heads/contributor/fix:refs/remotes/pr-contributor-orca/contributor/fix'
+        '+refs/heads/contributor/fix*:refs/remotes/pr-contributor-orca/contributor/fix*'
       ],
       REPO_PATH
     ])
@@ -165,8 +180,8 @@ describe('migrateForkRemoteRefspecsWithExec', () => {
       .map(([args]) => args[3])
     expect(addedRefspecs).toEqual(
       expect.arrayContaining([
-        '+refs/heads/branch-a:refs/remotes/pr-contributor-orca/branch-a',
-        '+refs/heads/branch-b:refs/remotes/pr-contributor-orca/branch-b'
+        '+refs/heads/branch-a*:refs/remotes/pr-contributor-orca/branch-a*',
+        '+refs/heads/branch-b*:refs/remotes/pr-contributor-orca/branch-b*'
       ])
     )
   })
@@ -222,7 +237,7 @@ describe('migrateForkRemoteRefspecsWithExec', () => {
       urlByRemote: { [FORK_REMOTE]: 'git@github.com:contributor/orca.git\n' },
       fetchByRemote: {
         [FORK_REMOTE]: [
-          '+refs/heads/contributor/fix:refs/remotes/pr-contributor-orca/contributor/fix'
+          '+refs/heads/contributor/fix*:refs/remotes/pr-contributor-orca/contributor/fix*'
         ]
       }
     })
@@ -236,6 +251,34 @@ describe('migrateForkRemoteRefspecsWithExec', () => {
 
     expect(migrated).toEqual([])
     expect(exec.mock.calls.some(([args]) => args[0] === 'fetch')).toBe(false)
+  })
+
+  it('abandons and cleans up a remote reclaimed concurrently by #17842 reconciliation mid-migration', async () => {
+    const exec = makeExec({
+      urlByRemote: { [FORK_REMOTE]: 'git@github.com:contributor/orca.git\n' },
+      fetchByRemote: { [FORK_REMOTE]: ['+refs/heads/*:refs/remotes/pr-contributor-orca/*'] },
+      removeUrlAfterFirstCheck: new Set([FORK_REMOTE])
+    })
+
+    const migrated = await migrateForkRemoteRefspecsWithExec(
+      REPO_PATH,
+      REPO_ID,
+      storeOf({ [worktreeId('/wt/a')]: forkTarget() }),
+      exec
+    )
+
+    // Not reported as migrated -- reconciliation won the race, so this sweep backs off.
+    expect(migrated).toEqual([])
+    expect(
+      exec.mock.calls.some(
+        ([args]) =>
+          args[0] === 'config' &&
+          args[1] === '--remove-section' &&
+          args[2] === `remote.${FORK_REMOTE}`
+      )
+    ).toBe(true)
+    // No fetch --prune-equivalent local ref deletion ran for a remote that's already gone.
+    expect(exec.mock.calls.some(([args]) => args[0] === 'update-ref')).toBe(false)
   })
 
   it('also narrows branches only referenced by surviving branch.*.remote config (no metadata left)', async () => {
@@ -259,7 +302,7 @@ describe('migrateForkRemoteRefspecsWithExec', () => {
       .map(([args]) => args[3])
     expect(addedRefspecs).toEqual(
       expect.arrayContaining([
-        '+refs/heads/contributor/preserved:refs/remotes/pr-contributor-orca/contributor/preserved'
+        '+refs/heads/contributor/preserved*:refs/remotes/pr-contributor-orca/contributor/preserved*'
       ])
     )
   })

--- a/src/main/ipc/worktree-push-target-refspec-migration.test.ts
+++ b/src/main/ipc/worktree-push-target-refspec-migration.test.ts
@@ -47,6 +47,9 @@ type ExecScript = {
   // Simulates #17842's reconciliation sweep concurrently `remote remove`-ing this
   // remote in between this migration's pre-write and post-write existence checks.
   removeUrlAfterFirstCheck?: Set<string>
+  // Remotes `git remote` (bare list) reports on disk -- drives discovery of a `pr-*`
+  // remote with zero worktree-metadata trace at all.
+  remoteNames?: string[]
 }
 
 function makeExec(script: ExecScript = {}): ExecMock {
@@ -55,10 +58,14 @@ function makeExec(script: ExecScript = {}): ExecMock {
     urlByRemote = {},
     branchConfig = '',
     trackingRefsByRemote = {},
-    removeUrlAfterFirstCheck = new Set<string>()
+    removeUrlAfterFirstCheck = new Set<string>(),
+    remoteNames = []
   } = script
   const urlCheckCountByRemote: Record<string, number> = {}
   return vi.fn<GitRemoteExec>(async (args: string[]) => {
+    if (args[0] === 'remote' && args.length === 1) {
+      return { stdout: remoteNames.length ? `${remoteNames.join('\n')}\n` : '', stderr: '' }
+    }
     if (args[0] === 'config' && args[1] === '--get' && args[2]!.endsWith('.url')) {
       const remoteName = args[2]!.slice('remote.'.length, -'.url'.length)
       urlCheckCountByRemote[remoteName] = (urlCheckCountByRemote[remoteName] ?? 0) + 1
@@ -279,6 +286,62 @@ describe('migrateForkRemoteRefspecsWithExec', () => {
     ).toBe(true)
     // No fetch --prune-equivalent local ref deletion ran for a remote that's already gone.
     expect(exec.mock.calls.some(([args]) => args[0] === 'update-ref')).toBe(false)
+  })
+
+  it('clears the fetch refspec of a wide pr-* remote with zero worktree-metadata trace at all', async () => {
+    const ORPHAN_REMOTE = 'pr-ghost-orca'
+    const trackingRefsByRemote = { [ORPHAN_REMOTE]: ['some-branch', 'another-branch'] }
+    const exec = makeExec({
+      remoteNames: [ORPHAN_REMOTE],
+      urlByRemote: { [ORPHAN_REMOTE]: 'git@github.com:ghost/orca.git\n' },
+      fetchByRemote: { [ORPHAN_REMOTE]: ['+refs/heads/*:refs/remotes/pr-ghost-orca/*'] },
+      trackingRefsByRemote
+    })
+
+    // No worktree metadata references this remote at all (worktree removed outside
+    // preserve-on-delete, metadata purged) -- only discoverable via `git remote`.
+    const migrated = await migrateForkRemoteRefspecsWithExec(REPO_PATH, REPO_ID, storeOf({}), exec)
+
+    expect(migrated).toEqual([ORPHAN_REMOTE])
+    expect(exec.mock.calls).toContainEqual([
+      ['config', '--unset-all', `remote.${ORPHAN_REMOTE}.fetch`],
+      REPO_PATH
+    ])
+    // No branch to narrow to, so it never adds a replacement refspec.
+    expect(exec.mock.calls.some(([args]) => args[0] === 'config' && args[1] === '--add')).toBe(
+      false
+    )
+    // Every stray tracking ref is pruned, same as the narrowing path.
+    expect(trackingRefsByRemote[ORPHAN_REMOTE]).toEqual([])
+  })
+
+  it('leaves a zero-provenance pr-* remote alone if its refspec is not the stock wide default', async () => {
+    const CUSTOM_REMOTE = 'pr-custom-orca'
+    const exec = makeExec({
+      remoteNames: [CUSTOM_REMOTE],
+      urlByRemote: { [CUSTOM_REMOTE]: 'git@github.com:custom/orca.git\n' },
+      fetchByRemote: {
+        [CUSTOM_REMOTE]: ['+refs/heads/some-branch:refs/remotes/pr-custom-orca/some-branch']
+      }
+    })
+
+    const migrated = await migrateForkRemoteRefspecsWithExec(REPO_PATH, REPO_ID, storeOf({}), exec)
+
+    expect(migrated).toEqual([])
+    expect(exec.mock.calls.some(([args]) => args[1] === '--unset-all')).toBe(false)
+  })
+
+  it('never discovers a non-pr-prefixed remote through the bare listing, even if wide', async () => {
+    const exec = makeExec({
+      remoteNames: ['some-other-remote'],
+      urlByRemote: { 'some-other-remote': 'git@github.com:someone/else.git\n' },
+      fetchByRemote: { 'some-other-remote': ['+refs/heads/*:refs/remotes/some-other-remote/*'] }
+    })
+
+    const migrated = await migrateForkRemoteRefspecsWithExec(REPO_PATH, REPO_ID, storeOf({}), exec)
+
+    expect(migrated).toEqual([])
+    expect(exec.mock.calls.some(([args]) => args[1] === '--unset-all')).toBe(false)
   })
 
   it('also narrows branches only referenced by surviving branch.*.remote config (no metadata left)', async () => {

--- a/src/main/ipc/worktree-push-target-refspec-migration.ts
+++ b/src/main/ipc/worktree-push-target-refspec-migration.ts
@@ -6,11 +6,26 @@
 // branch (`git fetch --prune` cannot reclaim these once the refspec is narrow -- verified
 // against real git, see #17828 PR). It never deletes a remote (that is
 // `worktree-push-target-cleanup.ts`'s job) -- only narrows what a future fetch pulls.
+//
+// Interaction with `worktree-push-target-reconciliation.ts` (#17842, orphaned `pr-*`
+// remote reclamation): the two sweeps fire from different lifecycle events (this one
+// from worktree creation, that one from worktree removal), rate-limit via separate
+// `Map<repoId, timestamp>` cooldowns, and so never share state or starve each other.
+// They *can* still race on the same remote if creation and removal happen close
+// together for the same repo, because both derive their candidate remotes from the
+// same worktree-metadata store: a remote reconciliation is about to reclaim (no live
+// worktree still claims it) can be one this sweep is concurrently narrowing (its stale
+// metadata entry hasn't been pruned from the store yet). `remoteHasUrl` re-checked both
+// before and after the narrowing writes closes the practical impact of that race down
+// to "reconciliation wins and this sweep's writes get cleaned back up" rather than a
+// stray url-less `remote.<name>.*` config section -- see the guard below.
+
 import { gitExecFileAsync } from '../git/runner'
 import {
   ensureRemoteTracksBranchNarrowly,
   getRemoteFetchRefspecs,
   pruneUntrackedForkRemoteRefs,
+  remoteHasUrl,
   wildcardForkFetchRefspec
 } from '../git/fork-remote-refspec'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree/id'
@@ -95,15 +110,27 @@ export async function migrateForkRemoteRefspecsWithExec(
     if (branches.size === 0) {
       continue
     }
-    try {
-      await execGit(['remote', 'get-url', remoteName], repoPath)
-    } catch {
+    if (!(await remoteHasUrl(execGit, repoPath, remoteName))) {
       continue // config references a remote that no longer exists
     }
     const before = await getRemoteFetchRefspecs(execGit, repoPath, remoteName)
     const wasWide = before.includes(wildcardForkFetchRefspec(remoteName))
     for (const branch of branches) {
       await ensureRemoteTracksBranchNarrowly(execGit, repoPath, remoteName, branch)
+    }
+    // #17842's reconciliation sweep can concurrently `remote remove` this same
+    // remote (both sweeps derive their candidate list from the same, possibly-stale,
+    // worktree metadata). `remote remove` deletes the whole `remote.<name>.*` section,
+    // but `ensureRemoteTracksBranchNarrowly` above would have just resurrected a
+    // url-less `fetch`/`tagOpt` section via plain `config --add`, which doesn't care
+    // whether the remote "exists". Detect that and clean up instead of leaving ghost
+    // config behind -- narrows but does not close the race (no cross-process lock
+    // exists), so this is a best-effort self-heal, not a guarantee.
+    if (!(await remoteHasUrl(execGit, repoPath, remoteName))) {
+      await execGit(['config', '--remove-section', `remote.${remoteName}`], repoPath).catch(
+        () => {}
+      )
+      continue
     }
     if (!wasWide) {
       continue // already narrow (minted post-fix, or a prior sweep already ran); nothing to prune

--- a/src/main/ipc/worktree-push-target-refspec-migration.ts
+++ b/src/main/ipc/worktree-push-target-refspec-migration.ts
@@ -1,0 +1,156 @@
+// Why: remotes minted or reused before #17828's narrow-refspec fix are stuck on the
+// wide `+refs/heads/*:refs/remotes/<name>/*` default, so any later plain `git fetch`
+// keeps re-importing the fork's whole branch set. This sweep rewrites each surviving
+// Orca-provenance `pr-*` remote's refspec to only the branches Orca actually tracked
+// for it, then deletes the refs the earlier wide fetch already imported for every other
+// branch (`git fetch --prune` cannot reclaim these once the refspec is narrow -- verified
+// against real git, see #17828 PR). It never deletes a remote (that is
+// `worktree-push-target-cleanup.ts`'s job) -- only narrows what a future fetch pulls.
+import { gitExecFileAsync } from '../git/runner'
+import {
+  ensureRemoteTracksBranchNarrowly,
+  getRemoteFetchRefspecs,
+  pruneUntrackedForkRemoteRefs,
+  wildcardForkFetchRefspec
+} from '../git/fork-remote-refspec'
+import { getRepoIdFromWorktreeId } from '../../shared/worktree/id'
+import { iterateProcessOutputLines } from '../../shared/process-output-field-scanner'
+import type { GitRemoteExec, WorktreePushTargetStore } from './worktree-push-target-cleanup'
+
+const NEVER_MIGRATE_REMOTE_NAMES = new Set(['origin', 'upstream'])
+
+/** `pushTarget`-derived branches to keep per remote, gated on at least one entry proving Orca created it. */
+function collectProvenBranchesByRemote(
+  store: WorktreePushTargetStore,
+  repoId: string
+): Map<string, Set<string>> {
+  const branchesByRemote = new Map<string, Set<string>>()
+  const provenRemotes = new Set<string>()
+  for (const [worktreeId, meta] of Object.entries(store.getAllWorktreeMeta())) {
+    if (getRepoIdFromWorktreeId(worktreeId) !== repoId || !meta.pushTarget) {
+      continue
+    }
+    const { remoteName, branchName, remoteCreated } = meta.pushTarget
+    if (remoteCreated === true) {
+      provenRemotes.add(remoteName)
+    }
+    const branches = branchesByRemote.get(remoteName) ?? new Set<string>()
+    branches.add(branchName)
+    branchesByRemote.set(remoteName, branches)
+  }
+  for (const remoteName of branchesByRemote.keys()) {
+    if (!provenRemotes.has(remoteName)) {
+      branchesByRemote.delete(remoteName)
+    }
+  }
+  return branchesByRemote
+}
+
+// `branch.<name>.remote`/`.pushRemote` config can outlive worktree metadata (preserve-on-delete),
+// so a branch it protects is still worth keeping narrowly tracked even with no metadata left.
+async function collectBranchesFromLocalConfig(
+  execGit: GitRemoteExec,
+  repoPath: string,
+  remoteName: string
+): Promise<string[]> {
+  let stdout: string
+  try {
+    ;({ stdout } = await execGit(
+      ['config', '--get-regexp', '^branch\\..*\\.(remote|pushRemote)$'],
+      repoPath
+    ))
+  } catch {
+    return []
+  }
+  const branches: string[] = []
+  for (const line of iterateProcessOutputLines(stdout)) {
+    const match = /^branch\.(.+)\.(?:remote|pushRemote) (.+)$/.exec(line.trim())
+    if (match && match[2] === remoteName) {
+      branches.push(match[1]!)
+    }
+  }
+  return branches
+}
+
+/**
+ * Exported for tests: the `execGit` seam drives the migration matrix without a real repo.
+ * Returns the names of remotes actually rewritten (wide -> narrow, then pruned).
+ */
+export async function migrateForkRemoteRefspecsWithExec(
+  repoPath: string,
+  repoId: string,
+  store: WorktreePushTargetStore,
+  execGit: GitRemoteExec
+): Promise<string[]> {
+  const branchesByRemote = collectProvenBranchesByRemote(store, repoId)
+  const migrated: string[] = []
+  for (const [remoteName, metaBranches] of branchesByRemote) {
+    if (NEVER_MIGRATE_REMOTE_NAMES.has(remoteName)) {
+      continue
+    }
+    const branches = new Set(metaBranches)
+    for (const branch of await collectBranchesFromLocalConfig(execGit, repoPath, remoteName)) {
+      branches.add(branch)
+    }
+    if (branches.size === 0) {
+      continue
+    }
+    try {
+      await execGit(['remote', 'get-url', remoteName], repoPath)
+    } catch {
+      continue // config references a remote that no longer exists
+    }
+    const before = await getRemoteFetchRefspecs(execGit, repoPath, remoteName)
+    const wasWide = before.includes(wildcardForkFetchRefspec(remoteName))
+    for (const branch of branches) {
+      await ensureRemoteTracksBranchNarrowly(execGit, repoPath, remoteName, branch)
+    }
+    if (!wasWide) {
+      continue // already narrow (minted post-fix, or a prior sweep already ran); nothing to prune
+    }
+    // Best-effort: the refspec is narrowed regardless of whether this local ref cleanup
+    // succeeds. Purely local (no network), so failures here should be rare/unexpected.
+    await pruneUntrackedForkRemoteRefs(execGit, repoPath, remoteName, branches).catch(() => [])
+    migrated.push(remoteName)
+  }
+  return migrated
+}
+
+// Why: the sweep costs a handful of git subprocesses per candidate remote; bound to once
+// per repo per cooldown so bursts of worktree creates don't repeat it.
+const MIGRATE_COOLDOWN_MS = 60 * 60 * 1000
+const lastMigratedAtByRepoId = new Map<string, number>()
+
+function shouldMigrateNow(repoId: string): boolean {
+  const last = lastMigratedAtByRepoId.get(repoId)
+  return last === undefined || Date.now() - last >= MIGRATE_COOLDOWN_MS
+}
+
+export function _resetForkRemoteRefspecMigrationRateLimitForTests(): void {
+  lastMigratedAtByRepoId.clear()
+}
+
+/** Best-effort, rate-limited sweep; call sites fire this without awaiting it. */
+export async function migrateForkRemoteRefspecs(
+  repoPath: string,
+  repoId: string,
+  store: WorktreePushTargetStore,
+  gitOptions: { wslDistro?: string } = {}
+): Promise<void> {
+  if (!shouldMigrateNow(repoId)) {
+    return
+  }
+  lastMigratedAtByRepoId.set(repoId, Date.now())
+  try {
+    const migrated = await migrateForkRemoteRefspecsWithExec(repoPath, repoId, store, (args, cwd) =>
+      gitExecFileAsync(args, { cwd, ...gitOptions })
+    )
+    if (migrated.length > 0) {
+      console.log(
+        `[worktrees] Narrowed fetch refspec for ${migrated.length} fork remote(s) in ${repoPath}: ${migrated.join(', ')}`
+      )
+    }
+  } catch (error) {
+    console.warn(`[worktrees] Fork remote refspec migration failed for ${repoPath}:`, error)
+  }
+}

--- a/src/main/ipc/worktree-push-target-refspec-migration.ts
+++ b/src/main/ipc/worktree-push-target-refspec-migration.ts
@@ -7,6 +7,16 @@
 // against real git, see #17828 PR). It never deletes a remote (that is
 // `worktree-push-target-cleanup.ts`'s job) -- only narrows what a future fetch pulls.
 //
+// Candidate discovery also widens past worktree metadata to every `pr-*` remote on disk
+// (see `listRemoteNames` below): metadata-only discovery misses a remote whose every
+// worktree was removed outside preserve-on-delete (worktree gone *and* metadata purged,
+// not just the worktree) -- field data on a real repo found 15 of 31 fork remotes with no
+// branch pinning them at all, permanently invisible to metadata-only discovery and stuck
+// wide forever. For those, there's nothing to narrow *to*, so the sweep clears the fetch
+// refspec entirely instead (stays pushable, imports nothing on a plain fetch) -- gated on
+// the remote still carrying the untouched stock wide default, since a `pr`-prefixed name
+// alone isn't proof of Orca provenance the way a metadata entry is.
+//
 // Interaction with `worktree-push-target-reconciliation.ts` (#17842, orphaned `pr-*`
 // remote reclamation): the two sweeps fire from different lifecycle events (this one
 // from worktree creation, that one from worktree removal), rate-limit via separate
@@ -22,6 +32,7 @@
 
 import { gitExecFileAsync } from '../git/runner'
 import {
+  clearForkRemoteFetchRefspec,
   ensureRemoteTracksBranchNarrowly,
   getRemoteFetchRefspecs,
   pruneUntrackedForkRemoteRefs,
@@ -33,6 +44,19 @@ import { iterateProcessOutputLines } from '../../shared/process-output-field-sca
 import type { GitRemoteExec, WorktreePushTargetStore } from './worktree-push-target-cleanup'
 
 const NEVER_MIGRATE_REMOTE_NAMES = new Set(['origin', 'upstream'])
+// Fork remotes are always minted as `pr-${slug}` (see pull-request-push-target.ts). Used
+// only as a secondary discovery signal below for remotes with zero metadata trace --
+// primary gating stays the wide-refspec check, not this prefix alone.
+const PR_REMOTE_NAME_PREFIX = 'pr-'
+
+async function listRemoteNames(execGit: GitRemoteExec, repoPath: string): Promise<string[]> {
+  try {
+    const { stdout } = await execGit(['remote'], repoPath)
+    return [...iterateProcessOutputLines(stdout)].map((line) => line.trim()).filter(Boolean)
+  } catch {
+    return []
+  }
+}
 
 /** `pushTarget`-derived branches to keep per remote, gated on at least one entry proving Orca created it. */
 function collectProvenBranchesByRemote(
@@ -98,25 +122,45 @@ export async function migrateForkRemoteRefspecsWithExec(
   execGit: GitRemoteExec
 ): Promise<string[]> {
   const branchesByRemote = collectProvenBranchesByRemote(store, repoId)
+  // Why: `branchesByRemote` only surfaces remotes with a *surviving* worktree-metadata
+  // entry. A remote whose every worktree was removed outside preserve-on-delete (metadata
+  // purged, not just the worktree) is invisible to it -- field data on a real repo found
+  // 15 of 31 fork remotes with zero branch pinning at all, still stuck wide. Widen
+  // discovery to every `pr-*` remote on disk so those aren't silently skipped forever.
+  const candidateNames = new Set(branchesByRemote.keys())
+  for (const remoteName of await listRemoteNames(execGit, repoPath)) {
+    if (remoteName.startsWith(PR_REMOTE_NAME_PREFIX)) {
+      candidateNames.add(remoteName)
+    }
+  }
   const migrated: string[] = []
-  for (const [remoteName, metaBranches] of branchesByRemote) {
+  for (const remoteName of candidateNames) {
     if (NEVER_MIGRATE_REMOTE_NAMES.has(remoteName)) {
       continue
     }
-    const branches = new Set(metaBranches)
+    const branches = new Set(branchesByRemote.get(remoteName) ?? [])
     for (const branch of await collectBranchesFromLocalConfig(execGit, repoPath, remoteName)) {
       branches.add(branch)
-    }
-    if (branches.size === 0) {
-      continue
     }
     if (!(await remoteHasUrl(execGit, repoPath, remoteName))) {
       continue // config references a remote that no longer exists
     }
     const before = await getRemoteFetchRefspecs(execGit, repoPath, remoteName)
     const wasWide = before.includes(wildcardForkFetchRefspec(remoteName))
-    for (const branch of branches) {
-      await ensureRemoteTracksBranchNarrowly(execGit, repoPath, remoteName, branch)
+    if (branches.size === 0) {
+      // No metadata and no branch config pins this remote to anything -- there's nothing
+      // to narrow *to*. Only act if it's still the untouched stock wide default: that's
+      // the strongest available signal this came from a bare `git remote add` (ours or a
+      // pre-#17828 Orca's), not a `pr`-prefixed remote a user configured by hand. Clears
+      // rather than deletes -- removing the remote outright stays #17842's job.
+      if (!wasWide) {
+        continue
+      }
+      await clearForkRemoteFetchRefspec(execGit, repoPath, remoteName)
+    } else {
+      for (const branch of branches) {
+        await ensureRemoteTracksBranchNarrowly(execGit, repoPath, remoteName, branch)
+      }
     }
     // #17842's reconciliation sweep can concurrently `remote remove` this same
     // remote (both sweeps derive their candidate list from the same, possibly-stale,

--- a/src/main/ipc/worktree-push-target-refspec-real-git.test.ts
+++ b/src/main/ipc/worktree-push-target-refspec-real-git.test.ts
@@ -183,7 +183,13 @@ describe('migrateForkRemoteRefspecsWithExec against the real Git binary', () => 
     await git(['fetch', FORK_REMOTE], repoPath)
     const before = await trackedRefsUnder(FORK_REMOTE)
     // Every fork branch imported (tracked branch + unrelated ones + the fork's default branch).
-    expect(before.length).toBe(forkBranchCount)
+    // Git >= 2.44's `followRemoteHEAD` auto-creates `refs/remotes/<name>/HEAD` on a fetch
+    // matching the full wildcard refspec (verified: absent on 2.44, present on 2.55) --
+    // excluded here since it isn't a branch this test (or the migration) cares about.
+    // `%(refname:short)` shortens the remote's own HEAD symref to just the remote name
+    // (no `/HEAD` suffix) -- verified against real git.
+    const headRef = FORK_REMOTE
+    expect(before.filter((ref) => ref !== headRef).length).toBe(forkBranchCount)
 
     const migrated = await migrateForkRemoteRefspecsWithExec(
       repoPath,
@@ -206,8 +212,10 @@ describe('migrateForkRemoteRefspecsWithExec against the real Git binary', () => 
     expect(refspecs).toEqual([
       `+refs/heads/${TRACKED_BRANCH}*:refs/remotes/${FORK_REMOTE}/${TRACKED_BRANCH}*`
     ])
-    await expect(trackedRefsUnder(FORK_REMOTE)).resolves.toEqual([
-      `${FORK_REMOTE}/${TRACKED_BRANCH}`
-    ])
+    // `pruneUntrackedForkRemoteRefs` deliberately never deletes `HEAD` (see its docstring),
+    // so a `HEAD` symref this git version auto-created above legitimately survives pruning --
+    // assert on the branch refs only, same exclusion as above.
+    const after = await trackedRefsUnder(FORK_REMOTE)
+    expect(after.filter((ref) => ref !== headRef)).toEqual([`${FORK_REMOTE}/${TRACKED_BRANCH}`])
   })
 })

--- a/src/main/ipc/worktree-push-target-refspec-real-git.test.ts
+++ b/src/main/ipc/worktree-push-target-refspec-real-git.test.ts
@@ -103,7 +103,7 @@ describe('minting a fork remote against the real Git binary (#17828)', () => {
       .split(/\r?\n/)
       .filter(Boolean)
     expect(refspecs).toEqual([
-      `+refs/heads/${TRACKED_BRANCH}:refs/remotes/${FORK_REMOTE}/${TRACKED_BRANCH}`
+      `+refs/heads/${TRACKED_BRANCH}*:refs/remotes/${FORK_REMOTE}/${TRACKED_BRANCH}*`
     ])
     await expect(
       git(['config', '--get', `remote.${FORK_REMOTE}.tagOpt`], repoPath)
@@ -116,6 +116,35 @@ describe('minting a fork remote against the real Git binary (#17828)', () => {
     await expect(trackedRefsUnder(FORK_REMOTE)).resolves.toEqual([
       `${FORK_REMOTE}/${TRACKED_BRANCH}`
     ])
+  })
+
+  it('a bare `git fetch` (branch-scoped upstream, no remote arg) survives the tracked branch being deleted upstream', async () => {
+    const target: GitPushTarget = {
+      remoteName: FORK_REMOTE,
+      branchName: TRACKED_BRANCH,
+      remoteUrl: forkPath
+    }
+    await prepareWorktreePushTargetWithExec(execGit, repoPath, target, () => false)
+    // Mirrors `configureCreatedWorktreePushTargetWithExec`: local branch tracks the fork
+    // remote, so a *bare* `git fetch` (the shape an agent running raw git actually types)
+    // resolves to this remote via `branch.<name>.remote` -- not `origin`.
+    await git(['checkout', '-qb', 'local-branch', `${FORK_REMOTE}/${TRACKED_BRANCH}`], repoPath)
+    await git(
+      ['branch', '--set-upstream-to', `${FORK_REMOTE}/${TRACKED_BRANCH}`, 'local-branch'],
+      repoPath
+    )
+
+    // Contributor deletes the branch after the PR merges/closes (checkout any other
+    // branch first -- the fork's actual default-branch name isn't relevant here).
+    await git(['checkout', '-q', OTHER_FORK_BRANCHES[0]!], forkPath)
+    await git(['branch', '-D', TRACKED_BRANCH], forkPath)
+
+    // Before this fix's trailing-`*` refspec, this exact command hard-failed with
+    // "couldn't find remote ref" -- degrading a common agent/user action into a fatal error.
+    await expect(git(['fetch'], repoPath)).resolves.toBeDefined()
+    // And `--prune` (Orca's own Fetch action) correctly reclaims the now-dead ref.
+    await git(['fetch', '--prune'], repoPath)
+    await expect(trackedRefsUnder(FORK_REMOTE)).resolves.toEqual([])
   })
 
   it('widens rather than replaces when a second worktree reuses the remote for another branch', async () => {
@@ -175,7 +204,7 @@ describe('migrateForkRemoteRefspecsWithExec against the real Git binary', () => 
       .split(/\r?\n/)
       .filter(Boolean)
     expect(refspecs).toEqual([
-      `+refs/heads/${TRACKED_BRANCH}:refs/remotes/${FORK_REMOTE}/${TRACKED_BRANCH}`
+      `+refs/heads/${TRACKED_BRANCH}*:refs/remotes/${FORK_REMOTE}/${TRACKED_BRANCH}*`
     ])
     await expect(trackedRefsUnder(FORK_REMOTE)).resolves.toEqual([
       `${FORK_REMOTE}/${TRACKED_BRANCH}`

--- a/src/main/ipc/worktree-push-target-refspec-real-git.test.ts
+++ b/src/main/ipc/worktree-push-target-refspec-real-git.test.ts
@@ -218,4 +218,32 @@ describe('migrateForkRemoteRefspecsWithExec against the real Git binary', () => 
     const after = await trackedRefsUnder(FORK_REMOTE)
     expect(after.filter((ref) => ref !== headRef)).toEqual([`${FORK_REMOTE}/${TRACKED_BRANCH}`])
   })
+
+  it('clears the refspec of a wide pr-* remote with zero worktree-metadata trace, and prunes its refs', async () => {
+    // Simulates a remote whose worktree was removed outside preserve-on-delete: no live
+    // worktree, and no surviving metadata entry either -- the store knows nothing about it.
+    await git(['remote', 'add', FORK_REMOTE, forkPath], repoPath)
+    await git(['fetch', FORK_REMOTE], repoPath)
+    const before = await trackedRefsUnder(FORK_REMOTE)
+    expect(before.length).toBeGreaterThan(1)
+
+    const migrated = await migrateForkRemoteRefspecsWithExec(
+      repoPath,
+      REPO_ID,
+      storeOf({}),
+      execGit
+    )
+
+    expect(migrated).toEqual([FORK_REMOTE])
+    await expect(
+      git(['config', '--get-all', `remote.${FORK_REMOTE}.fetch`], repoPath)
+    ).rejects.toThrow()
+    // The remote itself survives (only #17842's reconciliation removes remotes outright),
+    // and stays pushable -- just imports nothing on a subsequent plain fetch.
+    await expect(
+      git(['config', '--get', `remote.${FORK_REMOTE}.url`], repoPath)
+    ).resolves.toContain(forkPath)
+    await git(['fetch', FORK_REMOTE], repoPath)
+    await expect(trackedRefsUnder(FORK_REMOTE)).resolves.toEqual([])
+  })
 })

--- a/src/main/ipc/worktree-push-target-refspec-real-git.test.ts
+++ b/src/main/ipc/worktree-push-target-refspec-real-git.test.ts
@@ -1,0 +1,184 @@
+// Real-binary coverage for #17828: the mocked-exec suites in
+// `worktree-push-target-setup.test.ts` / `worktree-push-target-refspec-migration.test.ts`
+// prove the decision logic, but not that real `git remote add -t/--no-tags`, a plain
+// `git fetch <remote>`, and `git config --get-all/--unset-all/--add` behave the way this
+// fix assumes. In particular this proves the core claim of the fix: a minted remote never
+// imports more than the branch(es) Orca asked for, even from a fork with many branches.
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { WorktreeMeta } from '../../shared/worktree/meta-types'
+import type { GitPushTarget } from '../../shared/worktree/types'
+import type { GitRemoteExec, WorktreePushTargetStore } from './worktree-push-target-cleanup'
+import { prepareWorktreePushTargetWithExec } from './worktree-push-target-setup'
+import { migrateForkRemoteRefspecsWithExec } from './worktree-push-target-refspec-migration'
+
+const execFileAsync = promisify(execFile)
+
+const REPO_ID = 'repo-1'
+const FORK_REMOTE = 'pr-contributor-orca'
+const TRACKED_BRANCH = 'contributor/fix'
+const OTHER_FORK_BRANCHES = Array.from({ length: 12 }, (_, i) => `contributor/unrelated-${i}`)
+
+let scratchDir = ''
+let repoPath = ''
+let forkPath = ''
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd })
+  return stdout
+}
+
+const execGit: GitRemoteExec = (args, cwd) => execFileAsync('git', args, { cwd })
+
+async function setIdentity(cwd: string): Promise<void> {
+  await git(['config', 'user.name', 'Orca Test'], cwd)
+  await git(['config', 'user.email', 'orca@example.test'], cwd)
+  await git(['config', 'commit.gpgSign', 'false'], cwd)
+  await git(['config', 'core.hooksPath', '.git/no-hooks'], cwd)
+}
+
+async function trackedRefsUnder(remoteName: string): Promise<string[]> {
+  const stdout = await git(
+    ['for-each-ref', '--format=%(refname:short)', `refs/remotes/${remoteName}/`],
+    repoPath
+  )
+  return stdout.split(/\r?\n/).filter(Boolean)
+}
+
+function worktreeId(suffix: string): string {
+  return `${REPO_ID}::${suffix}`
+}
+
+function storeOf(entries: Record<string, GitPushTarget | undefined>): WorktreePushTargetStore {
+  const meta: Record<string, WorktreeMeta> = {}
+  for (const [id, pushTarget] of Object.entries(entries)) {
+    meta[id] = { pushTarget } as unknown as WorktreeMeta
+  }
+  return { getAllWorktreeMeta: () => meta }
+}
+
+beforeEach(async () => {
+  // realpath: macOS hands out /var/... temp paths while Git reports /private/var/...
+  scratchDir = await realpath(await mkdtemp(join(tmpdir(), 'orca-fork-refspec-')))
+  repoPath = join(scratchDir, 'repo')
+  forkPath = join(scratchDir, 'fork')
+  await mkdir(repoPath, { recursive: true })
+  await git(['init', '-q'], repoPath)
+  await setIdentity(repoPath)
+  await writeFile(join(repoPath, 'seed.txt'), 'seed\n')
+  await git(['add', '-A'], repoPath)
+  await git(['commit', '-qm', 'seed'], repoPath)
+
+  // A large fork: the tracked PR branch plus a dozen unrelated branches, simulating the
+  // 1000+-branch forks the issue describes (scaled down for test speed).
+  await git(['clone', '-q', repoPath, forkPath], scratchDir)
+  await setIdentity(forkPath)
+  for (const branch of [TRACKED_BRANCH, ...OTHER_FORK_BRANCHES]) {
+    await git(['checkout', '-qb', branch], forkPath)
+    await writeFile(join(forkPath, `${branch.replace(/\//g, '-')}.txt`), 'x\n')
+    await git(['add', '-A'], forkPath)
+    await git(['commit', '-qm', branch], forkPath)
+  }
+})
+
+afterEach(async () => {
+  await rm(scratchDir, { recursive: true, force: true })
+})
+
+describe('minting a fork remote against the real Git binary (#17828)', () => {
+  it('caps the remote at exactly one fetch refspec, and a plain `git fetch` imports only that branch', async () => {
+    const target: GitPushTarget = {
+      remoteName: FORK_REMOTE,
+      branchName: TRACKED_BRANCH,
+      remoteUrl: forkPath
+    }
+
+    await prepareWorktreePushTargetWithExec(execGit, repoPath, target, () => false)
+
+    const refspecs = (await git(['config', '--get-all', `remote.${FORK_REMOTE}.fetch`], repoPath))
+      .split(/\r?\n/)
+      .filter(Boolean)
+    expect(refspecs).toEqual([
+      `+refs/heads/${TRACKED_BRANCH}:refs/remotes/${FORK_REMOTE}/${TRACKED_BRANCH}`
+    ])
+    await expect(
+      git(['config', '--get', `remote.${FORK_REMOTE}.tagOpt`], repoPath)
+    ).resolves.toContain('--no-tags')
+
+    // The critical claim: a later plain `git fetch <remote>` (no explicit refspec) --
+    // exactly what Orca's own Fetch action and any agent/user command run -- must not
+    // import the fork's other dozen branches.
+    await git(['fetch', FORK_REMOTE], repoPath)
+    await expect(trackedRefsUnder(FORK_REMOTE)).resolves.toEqual([
+      `${FORK_REMOTE}/${TRACKED_BRANCH}`
+    ])
+  })
+
+  it('widens rather than replaces when a second worktree reuses the remote for another branch', async () => {
+    await prepareWorktreePushTargetWithExec(
+      execGit,
+      repoPath,
+      { remoteName: FORK_REMOTE, branchName: TRACKED_BRANCH, remoteUrl: forkPath },
+      () => false
+    )
+    const secondBranch = OTHER_FORK_BRANCHES[0]!
+
+    await prepareWorktreePushTargetWithExec(
+      execGit,
+      repoPath,
+      { remoteName: FORK_REMOTE, branchName: secondBranch, remoteUrl: forkPath },
+      () => true
+    )
+
+    await git(['fetch', FORK_REMOTE], repoPath)
+    const refs = await trackedRefsUnder(FORK_REMOTE)
+    expect(refs.sort()).toEqual(
+      [`${FORK_REMOTE}/${TRACKED_BRANCH}`, `${FORK_REMOTE}/${secondBranch}`].sort()
+    )
+    // Only the two branches Orca actually asked for -- not the other ten.
+    expect(refs).toHaveLength(2)
+  })
+})
+
+describe('migrateForkRemoteRefspecsWithExec against the real Git binary', () => {
+  it('narrows a pre-existing wide-refspec remote and prunes the strays it already fetched', async () => {
+    // Simulate a remote minted before the #17828 fix: bare `remote add`, full fetch.
+    const forkBranchCount = (await git(['branch', '--format=%(refname:short)'], forkPath))
+      .split(/\r?\n/)
+      .filter(Boolean).length
+    await git(['remote', 'add', FORK_REMOTE, forkPath], repoPath)
+    await git(['fetch', FORK_REMOTE], repoPath)
+    const before = await trackedRefsUnder(FORK_REMOTE)
+    // Every fork branch imported (tracked branch + unrelated ones + the fork's default branch).
+    expect(before.length).toBe(forkBranchCount)
+
+    const migrated = await migrateForkRemoteRefspecsWithExec(
+      repoPath,
+      REPO_ID,
+      storeOf({
+        [worktreeId('/wt/a')]: {
+          remoteName: FORK_REMOTE,
+          branchName: TRACKED_BRANCH,
+          remoteUrl: forkPath,
+          remoteCreated: true
+        }
+      }),
+      execGit
+    )
+
+    expect(migrated).toEqual([FORK_REMOTE])
+    const refspecs = (await git(['config', '--get-all', `remote.${FORK_REMOTE}.fetch`], repoPath))
+      .split(/\r?\n/)
+      .filter(Boolean)
+    expect(refspecs).toEqual([
+      `+refs/heads/${TRACKED_BRANCH}:refs/remotes/${FORK_REMOTE}/${TRACKED_BRANCH}`
+    ])
+    await expect(trackedRefsUnder(FORK_REMOTE)).resolves.toEqual([
+      `${FORK_REMOTE}/${TRACKED_BRANCH}`
+    ])
+  })
+})

--- a/src/main/ipc/worktree-push-target-setup.test.ts
+++ b/src/main/ipc/worktree-push-target-setup.test.ts
@@ -29,7 +29,8 @@ function makeRepoExec(remotes: Record<string, string>): ExecMock {
       return { stdout: `${url}\n`, stderr: '' }
     }
     if (args[0] === 'remote' && args[1] === 'add') {
-      remotes[args[2]!] = args[3]!
+      // Why: name/url are always the last two args, regardless of `-t`/`--no-tags` flags.
+      remotes[args.at(-2)!] = args.at(-1)!
       return { stdout: '', stderr: '' }
     }
     if (args[0] === 'remote' && args[1] === 'remove') {
@@ -62,7 +63,7 @@ describe('prepareWorktreePushTargetWithExec', () => {
     const result = await prepareWorktreePushTargetWithExec(exec, REPO, forkTarget(), () => false)
 
     expect(callsMatching(exec, ['remote', 'add'])).toEqual([
-      ['remote', 'add', 'pr-contributor-orca', FORK_SSH]
+      ['remote', 'add', '-t', 'contributor/fix', '--no-tags', 'pr-contributor-orca', FORK_SSH]
     ])
     expect(callsMatching(exec, ['fetch'])).toEqual([
       [
@@ -118,7 +119,7 @@ describe('prepareWorktreePushTargetWithExec', () => {
     const result = await prepareWorktreePushTargetWithExec(exec, REPO, forkTarget(), () => false)
 
     expect(callsMatching(exec, ['remote', 'add'])).toEqual([
-      ['remote', 'add', 'pr-contributor-orca-2', FORK_SSH]
+      ['remote', 'add', '-t', 'contributor/fix', '--no-tags', 'pr-contributor-orca-2', FORK_SSH]
     ])
     expect(result.remoteName).toBe('pr-contributor-orca-2')
     expect(result.remoteCreated).toBe(true)

--- a/src/main/ipc/worktree-push-target-setup.test.ts
+++ b/src/main/ipc/worktree-push-target-setup.test.ts
@@ -69,7 +69,7 @@ describe('prepareWorktreePushTargetWithExec', () => {
       [
         'fetch',
         'pr-contributor-orca',
-        '+refs/heads/contributor/fix:refs/remotes/pr-contributor-orca/contributor/fix'
+        '+refs/heads/contributor/fix*:refs/remotes/pr-contributor-orca/contributor/fix*'
       ]
     ])
     expect(result).toEqual({
@@ -93,7 +93,7 @@ describe('prepareWorktreePushTargetWithExec', () => {
       [
         'fetch',
         'pr-contributor-orca',
-        '+refs/heads/contributor/fix:refs/remotes/pr-contributor-orca/contributor/fix'
+        '+refs/heads/contributor/fix*:refs/remotes/pr-contributor-orca/contributor/fix*'
       ]
     ])
     // remoteCreated omitted because the predicate says no known worktree owns it.
@@ -137,7 +137,7 @@ describe('prepareWorktreePushTargetWithExec', () => {
 
     expect(callsMatching(exec, ['remote', 'add'])).toEqual([])
     expect(callsMatching(exec, ['fetch'])).toEqual([
-      ['fetch', 'origin', '+refs/heads/feature:refs/remotes/origin/feature']
+      ['fetch', 'origin', '+refs/heads/feature*:refs/remotes/origin/feature*']
     ])
     expect(result).toEqual({ remoteName: 'origin', branchName: 'feature' })
   })

--- a/src/main/ipc/worktree-push-target-setup.ts
+++ b/src/main/ipc/worktree-push-target-setup.ts
@@ -101,12 +101,16 @@ export async function prepareWorktreePushTargetWithExec(
       await ensureRemoteTracksBranchNarrowly(execGit, repoPath, remoteName, target.branchName)
     } else {
       remoteName = await ensureUniqueRemoteName(execGit, repoPath, target.remoteName)
-      // Why: `-t <branch> --no-tags` caps this remote at exactly one remote-tracking
-      // ref forever instead of the default wide `refs/heads/*` + tag auto-follow (#17828).
+      // Why: `-t <branch> --no-tags` means this remote is never, even transiently,
+      // written with the wide default `refs/heads/*` refspec + tag auto-follow (#17828).
+      // `-t` itself writes a literal (non-wildcard-suffixed) refspec, so immediately
+      // rewrite it to the trailing-`*` form via `ensureRemoteTracksBranchNarrowly`
+      // (see that function's comment for why the suffix matters).
       await execGit(
         ['remote', 'add', '-t', target.branchName, '--no-tags', remoteName, target.remoteUrl],
         repoPath
       )
+      await ensureRemoteTracksBranchNarrowly(execGit, repoPath, remoteName, target.branchName)
       remoteCreated = true
       remoteAddedHere = true
     }

--- a/src/main/ipc/worktree-push-target-setup.ts
+++ b/src/main/ipc/worktree-push-target-setup.ts
@@ -7,6 +7,10 @@
 import type { GitPushTarget } from '../../shared/worktree/types'
 import { parseGitHubOwnerRepo } from '../github/gh-utils'
 import type { GitRemoteExec } from './worktree-push-target-cleanup'
+import {
+  buildNarrowForkFetchRefspec,
+  ensureRemoteTracksBranchNarrowly
+} from '../git/fork-remote-refspec'
 
 export async function findRemoteForUrl(
   execGit: GitRemoteExec,
@@ -91,9 +95,18 @@ export async function prepareWorktreePushTargetWithExec(
       // Why: if a later PR worktree reuses an Orca-created fork remote, it
       // must inherit ownership so deleting the final user can remove it.
       remoteCreated = isRemoteCreatedByKnownWorktree(existingRemote)
+      // Why: a remote created before this fix (or reused for a second branch on the
+      // same fork) may still carry the wide default refspec; widen-but-bound it to
+      // cover this branch too rather than trusting whatever is already configured.
+      await ensureRemoteTracksBranchNarrowly(execGit, repoPath, remoteName, target.branchName)
     } else {
       remoteName = await ensureUniqueRemoteName(execGit, repoPath, target.remoteName)
-      await execGit(['remote', 'add', remoteName, target.remoteUrl], repoPath)
+      // Why: `-t <branch> --no-tags` caps this remote at exactly one remote-tracking
+      // ref forever instead of the default wide `refs/heads/*` + tag auto-follow (#17828).
+      await execGit(
+        ['remote', 'add', '-t', target.branchName, '--no-tags', remoteName, target.remoteUrl],
+        repoPath
+      )
       remoteCreated = true
       remoteAddedHere = true
     }
@@ -101,11 +114,7 @@ export async function prepareWorktreePushTargetWithExec(
 
   try {
     await execGit(
-      [
-        'fetch',
-        remoteName,
-        `+refs/heads/${target.branchName}:refs/remotes/${remoteName}/${target.branchName}`
-      ],
+      ['fetch', remoteName, buildNarrowForkFetchRefspec(remoteName, target.branchName)],
       repoPath
     )
   } catch (error) {

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -110,6 +110,7 @@ import {
   findRemoteForUrl,
   prepareWorktreePushTargetWithExec
 } from './worktree-push-target-setup'
+import { migrateForkRemoteRefspecs } from './worktree-push-target-refspec-migration'
 import { isENOENT } from './filesystem-path-containment'
 import {
   registerCreatedWorktreeRoot,
@@ -966,7 +967,7 @@ export async function prepareWorktreePushTarget(
   gitOptions: { wslDistro?: string } = {}
 ): Promise<GitPushTarget> {
   await validateGitPushTarget(repoPath, target, gitOptions)
-  return prepareWorktreePushTargetWithExec(
+  const prepared = await prepareWorktreePushTargetWithExec(
     (args, cwd) => gitExecFileAsync(args, { cwd, ...gitOptions }),
     repoPath,
     target,
@@ -979,6 +980,13 @@ export async function prepareWorktreePushTarget(
           )
         : false
   )
+  // Why: opportunistically narrow any other fork remote in this repo still on the old
+  // wide refspec (pre-#17828 mint, or reused before this fix). Rate-limited and
+  // fire-and-forget so a large leaked-remote backlog never slows down this create.
+  if (store && repoId) {
+    void migrateForkRemoteRefspecs(repoPath, repoId, store, gitOptions)
+  }
+  return prepared
 }
 
 function isPushTargetRemoteCreatedByKnownWorktree(

--- a/src/main/ipc/worktrees-create-metadata-persistence.test.ts
+++ b/src/main/ipc/worktrees-create-metadata-persistence.test.ts
@@ -450,14 +450,22 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      ['remote', 'add', 'pr-prateek-orca', 'git@github.com:prateek/orca.git'],
+      [
+        'remote',
+        'add',
+        '-t',
+        'prateek/fix-sidebar-agents-toggle',
+        '--no-tags',
+        'pr-prateek-orca',
+        'git@github.com:prateek/orca.git'
+      ],
       { cwd: '/workspace/repo' }
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       [
         'fetch',
         'pr-prateek-orca',
-        '+refs/heads/prateek/fix-sidebar-agents-toggle:refs/remotes/pr-prateek-orca/prateek/fix-sidebar-agents-toggle'
+        '+refs/heads/prateek/fix-sidebar-agents-toggle*:refs/remotes/pr-prateek-orca/prateek/fix-sidebar-agents-toggle*'
       ],
       { cwd: '/workspace/repo' }
     )

--- a/src/main/ipc/worktrees-wsl-runtime-routing.test.ts
+++ b/src/main/ipc/worktrees-wsl-runtime-routing.test.ts
@@ -266,21 +266,50 @@ describe('registerWorktreeHandlers', () => {
       }
     })
 
+    const wslRoutingOptions = { cwd: '/workspace/repo', wslDistro: 'Ubuntu' }
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['check-ref-format', '--branch', 'contributor/wsl-fork'],
-      { cwd: '/workspace/repo', wslDistro: 'Ubuntu' }
+      wslRoutingOptions
+    )
+    // Mint: `-t <branch> --no-tags` (see #17828) keeps the remote's own default off the
+    // wide wildcard, then `ensureRemoteTracksBranchNarrowly` rewrites it to the trailing-`*`
+    // form immediately after -- both routed through the same WSL project runtime.
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        'remote',
+        'add',
+        '-t',
+        'contributor/wsl-fork',
+        '--no-tags',
+        'pr-contributor-orca',
+        'git@github.com:contributor/orca.git'
+      ],
+      wslRoutingOptions
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      ['remote', 'add', 'pr-contributor-orca', 'git@github.com:contributor/orca.git'],
-      { cwd: '/workspace/repo', wslDistro: 'Ubuntu' }
+      ['config', '--get-all', 'remote.pr-contributor-orca.fetch'],
+      wslRoutingOptions
+    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        'config',
+        '--add',
+        'remote.pr-contributor-orca.fetch',
+        '+refs/heads/contributor/wsl-fork*:refs/remotes/pr-contributor-orca/contributor/wsl-fork*'
+      ],
+      wslRoutingOptions
+    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['config', 'remote.pr-contributor-orca.tagOpt', '--no-tags'],
+      wslRoutingOptions
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       [
         'fetch',
         'pr-contributor-orca',
-        '+refs/heads/contributor/wsl-fork:refs/remotes/pr-contributor-orca/contributor/wsl-fork'
+        '+refs/heads/contributor/wsl-fork*:refs/remotes/pr-contributor-orca/contributor/wsl-fork*'
       ],
-      { cwd: '/workspace/repo', wslDistro: 'Ubuntu' }
+      wslRoutingOptions
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['branch', '--set-upstream-to', 'pr-contributor-orca/contributor/wsl-fork', 'wsl-fork'],

--- a/src/main/runtime/orca-runtime-tests/worktree-removal-and-reconciliation.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/worktree-removal-and-reconciliation.spec.ts
@@ -412,7 +412,7 @@ describe('OrcaRuntimeService', () => {
         [
           'fetch',
           'pr-contributor-orca',
-          '+refs/heads/contributor/runtime-wsl:refs/remotes/pr-contributor-orca/contributor/runtime-wsl'
+          '+refs/heads/contributor/runtime-wsl*:refs/remotes/pr-contributor-orca/contributor/runtime-wsl*'
         ],
         { cwd: TEST_REPO_PATH, wslDistro: 'Ubuntu' }
       )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​972 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​958 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​439 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​429 |

<!-- /orca-pr-loc -->

## ELI5

When Orca sets up a PR-from-fork worktree, it adds the contributor's fork as a git remote. Until now it did this the plain way (`git remote add <name> <url>`), which tells git "track every branch this fork has, forever." A fork can have 1000+ branches. The very first fetch Orca does is already narrow (just the one branch), but the *remote's permanent settings* stayed wide — so the next time anyone (you, an agent, or Orca's own "Fetch" button) runs a plain `git fetch` on that remote, git goes and imports the fork's *entire* branch list (and its tags) into your repo. On one real user's repo (measured with their consent, see "Blast radius" below), 31 leftover fork remotes held 34,637 extra remote-tracking refs -- of which exactly 18 were actually needed. This PR makes new fork remotes track only the branch(es) Orca actually needs, and cleans up the ones that already went wide.

## What Changed

1. **Mint time** (`worktree-push-target-setup.ts`): `git remote add` now passes `-t <branch> --no-tags`, so the remote's permanent config only ever tracks the one branch Orca asked for and never auto-follows tags. `-t` writes a *literal* refspec, so mint immediately follows up with `ensureRemoteTracksBranchNarrowly` to rewrite it into the trailing-`*`-suffixed form described below (item 3) — `-t`'s only job here is guaranteeing the wide default is never written even transiently.
2. **Reuse path** (same file): when a sibling worktree reuses an existing fork remote for a *different* branch, the remote is widened (a second narrow refspec is added) rather than left on whatever it already had — see "reuse-path" note below for why this doesn't just add one more `-t`-shaped entry via `remote add`.
3. **Refspec shape: trailing `*`, not a literal branch name** (`src/main/git/fork-remote-refspec.ts`): the tracked-branch refspec is `+refs/heads/<branch>*:refs/remotes/<name>/<branch>*`, not the literal `+refs/heads/<branch>:refs/remotes/<name>/<branch>` I originally shipped this PR with. See "Revised design" below — a literal refspec hard-fails a very common fetch shape once the tracked branch is deleted/renamed upstream, so I fixed that at the refspec-format level rather than only in the self-heal wrapper.
4. **Self-heal on fetch, demoted to a backstop** (`src/main/git/remote.ts`, `fork-remote-stale-branch-refspec.ts`): originally the primary defense against a literal refspec's hard failure; now a defensive backstop for the one case the trailing `*` doesn't cover — a truly literal (non-wildcard) refspec somehow ending up configured (hand-edited `.git/config`, a future regression). `gitFetch`'s push-target-branch fetch still catches `couldn't find remote ref`, drops the one stale refspec, and retries (bounded to 20 attempts).
5. **Migration sweep for existing leaked remotes** (new `worktree-push-target-refspec-migration.ts`): fires (fire-and-forget, rate-limited to once/hour/repo) from `prepareWorktreePushTarget` on every worktree create. For every remote with Orca-provenance evidence (`pushTarget.remoteCreated === true` from at least one worktree, plus any branch still referenced by `branch.*.remote`/`.pushRemote` config for worktrees whose metadata was purged on preserve-on-delete), it narrows the refspec to the known branch(es) and deletes the stray remote-tracking refs the earlier wide fetch already pulled in. Never touches `origin`/`upstream`, never deletes a remote (that's `worktree-push-target-cleanup.ts`'s job), and is a no-op once a remote is already narrow. It also guards against a race with #17842's reconciliation sweep — see "Interaction with #17842" below.
6. Shared refspec logic lives in `src/main/git/fork-remote-refspec.ts` (not `ipc/`) because `src/main/git/remote.ts`'s self-heal path needed it too, and `git/*` doesn't import from `ipc/*`.
7. **Migration also discovers remotes with zero worktree-metadata trace** (same migration file): the sweep's candidate list was originally only remotes still referenced by *live* worktree metadata. Field data (see "Blast radius" below) found 15 of 31 fork remotes on a real repo had no branch pinning them at all -- every worktree that ever used them was removed outside preserve-on-delete, so metadata-only discovery could never see them, and they'd stay on the wide default forever. The sweep now also lists every `pr-*` remote on disk; for one with no branch provenance from either metadata or surviving `branch.*.remote`/`.pushRemote` config, it clears the fetch refspec entirely (stays pushable, imports nothing) rather than leaving it wide -- gated on the remote still carrying the untouched stock wide default, so a user's own custom `pr-*`-named remote isn't touched. Removing the remote outright stays #17842's job.

## Why

**Root cause**: `git remote add` with no `-t` writes `+refs/heads/*:refs/remotes/<name>/*` as the permanent fetch refspec. Orca's first fetch after mint already uses an explicit narrow refspec, so that part was fine — but the *stored config* stayed wide, so every subsequent plain `git fetch <remote>` re-imports everything. Refs #17828.

**Interaction with #17842** (orphaned `pr-*` remote reclamation, now green and may merge first): the two sweeps fire from different lifecycle events — this one from worktree *creation* (`prepareWorktreePushTarget`), #17842's `reconcileOrphanedPrRemotes[Ssh]` from worktree *removal* (`cleanupUnusedWorktreePushTargetRemote[Ssh]`) — and rate-limit through two entirely separate `Map<repoId, timestamp>` cooldowns (`lastMigratedAtByRepoId` here, `lastReconciledAtByRepoId` there) with no shared state, so neither can starve the other.

They *can* still target the same remote concurrently, because both derive their candidate remotes from the same worktree-metadata store rather than from each other: #17842 reclaims a `pr-*` remote once no *live* worktree (checked against real `git worktree list`, not just stored metadata) still references it and no surviving branch config uses it; this migration narrows any remote with an Orca-provenance metadata entry, without itself checking liveness. Concretely: a worktree removed *outside* Orca (#17842's own doc comment calls this out as one of the cases it exists to catch) leaves a stale metadata entry that both sweeps' candidate-selection will pick up — #17842 sees "no live worktree, branch gone" and reclaims (`git remote remove`); this migration sees "an entry with `remoteCreated: true`" and tries to narrow the same remote's refspec. If both fire close together for the same repo, `git remote remove` deleting the whole `remote.<name>.*` config section can race with this migration's `git config --add remote.<name>.fetch/.tagOpt` calls, which don't check whether the remote still "exists" — they'd silently resurrect a url-less config section (verified against real git: a `config`-only section with no `.url` key is not detected by porcelain `git remote get-url`, which falls back to echoing the remote *name* as a bogus URL instead of failing — so the original single existence check at the top of the loop was not enough).

Fix: added `remoteHasUrl` (plumbing `git config --get remote.<name>.url`, which does fail correctly when the url key is absent) and call it both before and after the narrowing writes. If the remote's url is gone by the second check, the migration removes the resurrected section (`git config --remove-section remote.<name>`) and backs off instead of reporting it as migrated. This doesn't add a lock (git has none to offer here) so it doesn't close the race window to zero, but it converts the failure mode from "silent orphaned config section left behind forever" into "reconciliation wins, this sweep's writes get cleaned back up" — see the new `abandons and cleans up a remote reclaimed concurrently by #17842 reconciliation mid-migration` test in `worktree-push-target-refspec-migration.test.ts`.

I branched off `main` rather than #17842's branch so this fix isn't gated on that PR merging, and reused only pre-#17842 exports (`GitRemoteExec`, `WorktreePushTargetStore` from `worktree-push-target-cleanup.ts`) rather than #17842's not-yet-merged helpers. The two diffs otherwise touch the same file (`worktree-remote.ts`) but different functions, with the only merge friction being an adjacent import line, trivially resolvable either order.

**Reuse-path / multi-branch remotes**: I looked at whether the reuse path needs to add multiple `-t`-equivalent entries like `remote add` supports at creation time. `remote add -t` is a mint-time-only flag; there's no equivalent "add another tracked branch" subcommand, so the reuse path manipulates `remote.<name>.fetch` directly via `git config --add`, appending a second narrow refspec rather than replacing the first. This matters for the **multi-worktree-same-fork-different-branch** scenario: worktree A creates `pr-alice-orca` tracking `alice/fix-1`; worktree B later reuses the same remote (same fork URL) for `alice/fix-2`. Without this, B's `ensureRemoteTracksBranchNarrowly` call would either leave the remote only tracking `fix-1` (breaking B) or replace the refspec (breaking A). It now ends up tracking both, and nothing else.

**Force-push / branch rename**: force-push to the tracked branch is unaffected — the refspec keeps its `+` prefix (force-update allowed) regardless of narrowing. Branch *rename* on the fork is the scenario that motivated the self-heal wrapper (see below).

**A real finding that changed the design from the task's original description**: the task assumed `git fetch --prune <remote>` would delete the stray refs left by the old wide fetch, once the refspec is narrowed. I verified against the real git binary that this is **not true**: `git fetch --prune` (and `git remote prune`) only reclaims refs that a *wildcard* refspec could reproduce. Once a remote's refspec is a literal branch mapping, git has no way to know a `refs/remotes/<name>/<other-branch>` ref "belongs" to that remote for prune purposes, so `--prune` silently leaves every stray in place forever. I confirmed this empirically before landing on the fix: the migration now explicitly enumerates `refs/remotes/<name>/*` via `for-each-ref` and deletes (`update-ref -d`) anything outside the known branch set. This is purely local, no network, and only ever removes disposable remote-tracking mirror refs (never the user's own branches/commits).

**Known, deliberately-undone gap (tags)**: a remote that previously had tag auto-follow (no `tagOpt`) may have already imported tags into the shared `refs/tags/` namespace before this fix ran. Neither the mint fix nor the migration sweep deletes those tags — auto-deleting tags is easy to get subtly wrong (a tag can coincidentally collide with, or be confused for, a tag the user actually wants) and destructive-by-accident is worse than leaving some already-imported tags in place. `tagOpt=--no-tags` is set going forward so no *new* stray tags accumulate, but existing ones are left alone. Flagging as a known, disclosed gap rather than fixing it here.

**Revised design: measured the blast radius of the literal refspec instead of accepting "narrow edge case" (see review discussion)**: I originally shipped this PR with a literal branch refspec and disclosed the deleted-upstream-branch hard failure as a narrow edge case affecting only a manual terminal `git fetch <pr-remote>`, with "use Orca's Fetch action instead" as the workaround. That framing doesn't hold up: Orca is terminal-centric — its entire purpose is running coding agents that execute git commands directly in worktrees — so "use the UI action instead" isn't available to an agent mid-task, and a hard failure there derails a run rather than merely inconveniencing a human.

I measured instead of asserting. `configureCreatedWorktreePushTargetWithExec` sets `branch.<local-branch>.remote` to the fork remote (`git branch --set-upstream-to <pr-remote>/<branch>`), and git resolves a **bare `git fetch`** (no arguments — the shape an agent running raw git actually types, and more common than an explicit `git fetch <remote-name>`) through `branch.<name>.remote` when it's set, falling back to `origin` only otherwise. So a bare `git fetch` while checked out on a fork-PR branch resolves specifically to the `pr-*` remote, not `origin` — verified against the real git binary (`git checkout -b local-branch <fork>/<branch>; git branch --set-upstream-to <fork>/<branch> local-branch; git fetch` resolves to `<fork>`). With the literal refspec, that fetch hard-failed the instant the tracked branch was deleted/renamed upstream. That is not a narrow edge case; it's the dominant fetch shape in this app.

Decision: fixed the refspec format rather than re-justifying the disclosure. The tracked-branch refspec now carries a trailing `*` on both sides — `+refs/heads/<branch>*:refs/remotes/<name>/<branch>*` — which git treats as a wildcard pattern. Verified against real git: (a) it tolerates the tracked branch being deleted/renamed upstream (zero-match fetch succeeds, exit 0, same graceful-degradation behavior the old wide default had), and (b) `git fetch --prune` on a remote configured with only this refspec correctly reclaims the stale tracking ref once the branch disappears — restoring self-healing that a literal refspec permanently loses (see the `pruneUntrackedForkRemoteRefs` finding above: prune can't reclaim under a literal refspec, but *can* under a wildcard one). The trade-off is a small residual widening versus a fully literal match: a sibling branch that happens to share the tracked branch's exact name as a prefix (e.g. tracking `fix` also matches a coincidental `fix-v2` on the same fork) is imported too. That's a materially smaller and more bounded exposure than the original bug (the fork's *entire* branch set), so it's accepted and disclosed rather than engineered away. The self-heal wrapper (`fetchForkRemoteWithStaleRefspecRepair`) stays as a backstop for the one case the trailing `*` doesn't cover: a truly literal refspec somehow ending up configured (hand-edited config, a future regression).

## Blast Radius (measured against the real git binary)

The coordinator pushed back on treating the deleted-upstream-branch hard failure as a narrow edge case, since Orca runs autonomous agents in terminals where "use the UI action instead" isn't available. I measured the actual fetch shapes rather than reasoning about them, against real git 2.55.0 (matches CI), with a fork remote whose tracked branch was deleted upstream after mint:

| Command | Literal refspec (originally shipped) | Wide default (pre-#17828) | Wildcard-suffix (this PR, final) |
| :--- | :--- | :--- | :--- |
| bare `git fetch` (no args) | **exit 128**, `fatal: couldn't find remote ref` | exit 0 | **exit 0** |
| `git fetch <remote>` (explicit) | **exit 128**, same fatal | exit 0 | **exit 0** |
| `git fetch --all` | **exit 1**, `error: could not fetch <remote>` (origin's own fetch still completes, but the command's exit code reports total failure) | exit 0 | **exit 0** |
| `git pull` | exit 1, "no such ref was fetched" | exit 1, same message | exit 1, same message (see below) |

`git pull`'s failure is **not a regression** and not specific to any refspec shape: it happens identically under the original wide default, because `pull` = fetch + merge, and there is nothing to merge once the upstream branch is gone -- git refuses to merge nothing regardless of how the fetch refspec is written. It is out of scope for this fix.

Bare `git fetch` and `git fetch --all` are the shapes that matter: `configureCreatedWorktreePushTargetWithExec` sets `branch.<local-branch>.remote` to the fork remote via `git branch --set-upstream-to <pr-remote>/<branch>`, and git resolves a bare `git fetch` through `branch.<name>.remote` (falling back to `origin` only when unset) -- confirmed empirically, not from documentation alone. So a bare `git fetch` on a fork-PR branch resolves specifically to the `pr-*` remote, and is the shape an agent running raw git actually types. Under the literal refspec this PR originally shipped with, that command hard-failed the instant the tracked branch was deleted or renamed upstream -- derailing an agent mid-task, not merely inconveniencing a human who could fall back to a UI button. Under the trailing-`*` wildcard-suffix refspec (see "Revised design" above), all three fetch shapes tolerate the deleted branch exactly like the original wide default did, while still importing only branches sharing the tracked branch's literal prefix -- not the fork's entire branch set.

Decision: **kept** the trailing-`*` wildcard-suffix refspec as the final design (already implemented, not merely proposed) -- it eliminates the hard-failure regression for the dominant fetch shapes without reintroducing the original unbounded-import bug.

**Real-world field data**: with the motivating user's consent, I ran the equivalent of this migration by hand against their real repo. 31 `pr-*` remotes held **34,637 tracking refs, of which exactly 18 were needed** -- `pr-ni7e-orca` alone had 4,611 refs serving a single branch. After narrowing and pruning: total refs 80,184 -> 45,566, loose refs 36,688 -> 3, and `git show-ref -- main` went from **5.24s to 0.34s**. Of the 31 remotes, **15 had no branch pinning them at all** (every worktree that used them was removed outside preserve-on-delete) -- the migration's original candidate discovery (worktree-metadata-only) could never see these, so I extended it (see "What Changed" item 7 above) to also discover and clear these via a direct `git remote` listing, gated on the remote still carrying the untouched stock wide default.

## User-Facing Regressions

One intended deletion worth naming; the literal-refspec regression from an earlier revision of this PR is fixed, not just mitigated (see "Revised design" above).

- **The migration deletes stray remote-tracking refs** under `refs/remotes/<fork>/*` that the previous wide refspec had imported. This is the point of the change, but it is deletion of refs that existed locally. Nothing unreachable is created: they are re-fetchable from the fork.
- **Residual widening, not a regression**: a fork branch that happens to share the tracked branch's exact name as a literal prefix (e.g. tracking `fix` when the fork also has `fix-v2`) is imported alongside it, because the refspec's trailing `*` matches on prefix. This is bounded and disclosed above; it does not reintroduce the original "entire fork" exposure.

**Not fixed, disclosed:** tags auto-followed into the shared `refs/tags/` namespace before this change are left alone. Deleting tags is destructive and easy to get wrong, so it is deliberately out of scope.

**No change** for same-repo PRs, which never mint a fork remote, or for read-only review, which fetches PR heads from the existing remote into `refs/orca/…` and mints nothing.

## Linked Issue

Refs #17828

## Visual Proof

N/A — this is background git-plumbing/config behavior with no UI surface.

## Testing

- `pnpm tc` — clean (all typecheck projects pass)
- `pnpm test src/main/git/fork-remote-refspec.test.ts src/main/git/fork-remote-stale-branch-refspec.test.ts src/main/git/remote.test.ts src/main/ipc/worktree-push-target-setup.test.ts src/main/ipc/worktree-push-target-refspec-migration.test.ts src/main/ipc/worktree-push-target-refspec-real-git.test.ts` — 95/95 passing (up from 81 after the trailing-`*` redesign, the #17842-race guard, and the zero-metadata-remote discovery fix), including a **real-git-binary** suite (`worktree-push-target-refspec-real-git.test.ts`, 6 tests) proving against the actual git binary that: (a) a minted remote has exactly one `remote.<name>.fetch` entry, (b) a subsequent plain `git fetch <remote>` on a fork with a dozen other branches imports only the tracked branch, (c) reusing the same remote for a second branch widens rather than replaces, (d) the migration sweep narrows a pre-existing wide-refspec remote and deletes the stray refs its earlier wide fetch had already pulled in, (e) — the test directly proving the coordinator's exact concern is fixed — **a bare `git fetch` on a branch tracking the fork remote survives the tracked branch being deleted upstream** (`resolves.toBeDefined()`, not a rejection) and `git fetch --prune` afterward correctly reclaims the now-dead tracking ref, and (f) a `pr-*` remote with zero worktree-metadata trace has its refspec cleared (not left wide) and a subsequent plain fetch on it imports nothing.
- CI went red once on this branch's head after the trailing-`*` redesign: four test files had assertions for the pre-existing `remote add` shape or a literal (non-suffixed) fetch refspec that predated the redesign. Fixed by updating assertions to the correct call sequence/refspec shape (`worktree-push-target-refspec-real-git.test.ts`, `worktrees-wsl-runtime-routing.test.ts`, `worktrees-create-metadata-persistence.test.ts`, `orca-runtime-tests/worktree-removal-and-reconciliation.spec.ts`) -- confirmed via CI job log cross-referencing that this was the full set of failures, not just the two explicitly flagged. Also confirmed the SSH fork-remote mint path (`prepareWorktreePushTargetSsh`) is untouched by this PR (it never persists a `remote.<name>.fetch` refspec at all) and needed no test changes.
- `pnpm run check:code-quality:changed` — 0 new findings (oxlint + type-aware + React Doctor)
- Ran the repo's `readiness-checklist` review skill against the original (literal-refspec) diff: no P0/P1 candidates found. The subsequent trailing-`*` redesign and #17842-race guard are risk-reducing refinements of that reviewed design (they close the one disclosed gap and a newly-found race), not new-risk-introducing changes, so I did not re-run the full checklist a second time — the reasoning for both changes and their real-git/mocked test coverage is laid out inline above.
- **Platforms actually tested**: macOS only (sandboxed dev environment / this worktree). I did **not** test on Linux, Windows, WSL, or a real SSH remote host. The change is entirely git-config/argv manipulation routed through the existing `execGit`/`GitRuntimeOptions` seams that already thread `wslDistro` and SSH execution context through unchanged, so I expect it to carry over, but that's an expectation, not something I verified end-to-end on those platforms.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Sonnet 5 (Claude Code)

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

