### PR TITLE
fix(ai-vault): avoid large Codex scan timeouts

### DIFF
--- a/src/main/ai-vault/codex-session-root-dedup.test.ts
+++ b/src/main/ai-vault/codex-session-root-dedup.test.ts
@@ -269,6 +269,40 @@ describe('dedupeCodexRolloutCopyAliases', () => {
     ).resolves.toEqual([native, wsl])
     expect(readSessionMetaId).not.toHaveBeenCalled()
   })
+
+  it('proves only contested same-name candidates', async () => {
+    const real = { agent: 'codex', path: REAL_HOME_ROLLOUT, codexHome: null }
+    const managed = { agent: 'codex', path: MANAGED_HOME_ROLLOUT, codexHome: MANAGED_HOME }
+    const lone = {
+      agent: 'codex',
+      path: '/Users/ada/.codex/sessions/rollout-2026-08-20T09-00-00-lone.jsonl',
+      codexHome: null
+    }
+    const readSessionMetaId = vi.fn(async () => 'shared-session-id')
+
+    await expect(
+      dedupeCodexRolloutCopyAliases([real, managed, lone], accessors, readSessionMetaId)
+    ).resolves.toEqual([real, lone])
+    expect(readSessionMetaId).toHaveBeenCalledTimes(2)
+  })
+
+  // Why: the proof reads run inside the scan's 130s deadline, so a superseded
+  // scan must stop rather than drain a whole second history copy (#17888).
+  it('stops proving copies once the scan is cancelled', async () => {
+    const real = { agent: 'codex', path: REAL_HOME_ROLLOUT, codexHome: null }
+    const managed = { agent: 'codex', path: MANAGED_HOME_ROLLOUT, codexHome: MANAGED_HOME }
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      dedupeCodexRolloutCopyAliases(
+        [real, managed],
+        accessors,
+        async () => 'shared-session-id',
+        controller.signal
+      )
+    ).rejects.toThrow()
+  })
 })
 
 describe('dedupeCodexSessionsBySessionId', () => {

--- a/src/main/ai-vault/codex-session-root-dedup.test.ts
+++ b/src/main/ai-vault/codex-session-root-dedup.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import {
+  dedupeCodexRolloutCopyAliases,
   dedupeCodexRolloutFileAliases,
   dedupeCodexSessionsBySessionId
 } from './codex-session-root-dedup'
@@ -201,6 +202,72 @@ describe('dedupeCodexRolloutFileAliases', () => {
       hardlinkIdentity: '1:42'
     }
     expect(dedupeCodexRolloutFileAliases([perAccount, real], accessors)).toEqual([real])
+  })
+})
+
+describe('dedupeCodexRolloutCopyAliases', () => {
+  type Candidate = {
+    agent: string
+    path: string
+    codexHome: string | null
+  }
+  const accessors = {
+    isCodex: (candidate: Candidate) => candidate.agent === 'codex',
+    getFilePath: (candidate: Candidate) => candidate.path,
+    getCodexHome: (candidate: Candidate) => candidate.codexHome
+  }
+
+  it('collapses cross-volume copies only after session_meta proves the same id', async () => {
+    const real = { agent: 'codex', path: REAL_HOME_ROLLOUT, codexHome: null }
+    const managed = {
+      agent: 'codex',
+      path: MANAGED_HOME_ROLLOUT,
+      codexHome: MANAGED_HOME
+    }
+    const readSessionMetaId = vi.fn(async () => 'shared-session-id')
+
+    await expect(
+      dedupeCodexRolloutCopyAliases([managed, real], accessors, readSessionMetaId)
+    ).resolves.toEqual([real])
+    expect(readSessionMetaId).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps same-name files when ids differ or metadata cannot prove identity', async () => {
+    const real = { agent: 'codex', path: REAL_HOME_ROLLOUT, codexHome: null }
+    const managed = {
+      agent: 'codex',
+      path: MANAGED_HOME_ROLLOUT,
+      codexHome: MANAGED_HOME
+    }
+
+    await expect(
+      dedupeCodexRolloutCopyAliases([real, managed], accessors, async (path) =>
+        path === REAL_HOME_ROLLOUT ? 'real-id' : 'managed-id'
+      )
+    ).resolves.toEqual([real, managed])
+    await expect(
+      dedupeCodexRolloutCopyAliases([real, managed], accessors, async () => null)
+    ).resolves.toEqual([real, managed])
+  })
+
+  it('does not compare copies across native and WSL execution namespaces', async () => {
+    const rolloutName = REAL_HOME_ROLLOUT.split('/').at(-1)
+    const native = {
+      agent: 'codex',
+      path: `C:\\Users\\ada\\.codex\\sessions\\${rolloutName}`,
+      codexHome: null
+    }
+    const wsl = {
+      agent: 'codex',
+      path: `\\\\wsl$\\Ubuntu\\home\\ada\\.codex\\sessions\\${rolloutName}`,
+      codexHome: '\\\\wsl$\\Ubuntu\\home\\ada\\.codex'
+    }
+    const readSessionMetaId = vi.fn(async () => 'shared-session-id')
+
+    await expect(
+      dedupeCodexRolloutCopyAliases([native, wsl], accessors, readSessionMetaId)
+    ).resolves.toEqual([native, wsl])
+    expect(readSessionMetaId).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/ai-vault/codex-session-root-dedup.ts
+++ b/src/main/ai-vault/codex-session-root-dedup.ts
@@ -120,6 +120,86 @@ export function dedupeCodexRolloutFileAliases<T>(
   })
 }
 
+/** Applies cheap hardlink proof before bounded cross-volume copy proof. */
+export async function dedupeCodexRolloutAliases<T>(
+  candidates: readonly T[],
+  accessors: {
+    isCodex: (candidate: T) => boolean
+    getFilePath: (candidate: T) => string
+    getCodexHome: (candidate: T) => string | null
+    getHardlinkIdentity: (candidate: T) => string | null
+  },
+  readSessionMetaId: (filePath: string) => Promise<string | null>
+): Promise<T[]> {
+  const hardlinkDeduped = dedupeCodexRolloutFileAliases(candidates, accessors)
+  return dedupeCodexRolloutCopyAliases(hardlinkDeduped, accessors, readSessionMetaId)
+}
+
+/**
+ * Drops cross-volume rollout copies only when bounded session metadata proves
+ * the same Codex session id. Unreadable or ambiguous candidates remain for the
+ * full parser and its existing post-parse identity check.
+ */
+export async function dedupeCodexRolloutCopyAliases<T>(
+  candidates: readonly T[],
+  accessors: {
+    isCodex: (candidate: T) => boolean
+    getFilePath: (candidate: T) => string
+    getCodexHome: (candidate: T) => string | null
+  },
+  readSessionMetaId: (filePath: string) => Promise<string | null>
+): Promise<T[]> {
+  const groups = new Map<string, T[]>()
+  for (const candidate of candidates) {
+    if (!accessors.isCodex(candidate)) {
+      continue
+    }
+    const filePath = accessors.getFilePath(candidate)
+    const fileName = lastPathSegment(filePath)
+    if (!CODEX_ROLLOUT_FILE_NAME_PATTERN.test(fileName)) {
+      continue
+    }
+    const key = `${codexPathExecutionNamespace(filePath)}\0${fileName}`
+    const group = groups.get(key)
+    if (group) {
+      group.push(candidate)
+    } else {
+      groups.set(key, [candidate])
+    }
+  }
+
+  const aliasesToDrop = new Set<T>()
+  for (const group of groups.values()) {
+    if (group.length < 2) {
+      continue
+    }
+    const identified = await Promise.all(
+      group.map(async (candidate) => ({
+        candidate,
+        id: await readSessionMetaId(accessors.getFilePath(candidate))
+      }))
+    )
+    const bestById = new Map<string, { candidate: T; rank: number; filePath: string }>()
+    for (const { candidate, id } of identified) {
+      if (!id) {
+        continue
+      }
+      const filePath = accessors.getFilePath(candidate)
+      const rank = codexSessionRootRank(accessors.getCodexHome(candidate))
+      const best = bestById.get(id)
+      if (!best || rank < best.rank || (rank === best.rank && filePath < best.filePath)) {
+        bestById.set(id, { candidate, rank, filePath })
+      }
+    }
+    for (const { candidate, id } of identified) {
+      if (id && bestById.get(id)?.candidate !== candidate) {
+        aliasesToDrop.add(candidate)
+      }
+    }
+  }
+  return candidates.filter((candidate) => !aliasesToDrop.has(candidate))
+}
+
 /**
  * Collapses parsed Codex sessions that share a rollout name and session id on
  * one execution host, keeping the canonical root's row. Requiring both the

--- a/src/main/ai-vault/codex-session-root-dedup.ts
+++ b/src/main/ai-vault/codex-session-root-dedup.ts
@@ -1,5 +1,7 @@
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import { parseWslUncPath } from '../../shared/wsl-paths'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
+import { throwIfAiVaultScanCancelled } from './ai-vault-scan-cancellation'
 import { sessionSortTime } from './session-scanner-accumulator'
 
 // Why: the session bridge and the real-home backfill hardlink one physical
@@ -129,11 +131,16 @@ export async function dedupeCodexRolloutAliases<T>(
     getCodexHome: (candidate: T) => string | null
     getHardlinkIdentity: (candidate: T) => string | null
   },
-  readSessionMetaId: (filePath: string) => Promise<string | null>
+  readSessionMetaId: (filePath: string) => Promise<string | null>,
+  signal?: AbortSignal
 ): Promise<T[]> {
   const hardlinkDeduped = dedupeCodexRolloutFileAliases(candidates, accessors)
-  return dedupeCodexRolloutCopyAliases(hardlinkDeduped, accessors, readSessionMetaId)
+  return dedupeCodexRolloutCopyAliases(hardlinkDeduped, accessors, readSessionMetaId, signal)
 }
+
+// Matches the scan's own parse batch width. UNC candidates are additionally
+// serialized by the WSL transcript gate, so this only widens native reads.
+const COPY_PROOF_READ_CONCURRENCY = 8
 
 /**
  * Drops cross-volume rollout copies only when bounded session metadata proves
@@ -147,7 +154,8 @@ export async function dedupeCodexRolloutCopyAliases<T>(
     getFilePath: (candidate: T) => string
     getCodexHome: (candidate: T) => string | null
   },
-  readSessionMetaId: (filePath: string) => Promise<string | null>
+  readSessionMetaId: (filePath: string) => Promise<string | null>,
+  signal?: AbortSignal
 ): Promise<T[]> {
   const groups = new Map<string, T[]>()
   for (const candidate of candidates) {
@@ -168,19 +176,33 @@ export async function dedupeCodexRolloutCopyAliases<T>(
     }
   }
 
+  // Only same-name groups can alias, so the read fans out across every
+  // contested candidate at once rather than one group at a time — a corpus
+  // with a full second history copy has thousands of two-file groups.
+  const contested = [...groups.values()].filter((group) => group.length > 1).flat()
+  if (contested.length === 0) {
+    return [...candidates]
+  }
+  const identifiedIds = await mapWithConcurrency(
+    contested,
+    COPY_PROOF_READ_CONCURRENCY,
+    async (candidate) => {
+      throwIfAiVaultScanCancelled(signal)
+      return readSessionMetaId(accessors.getFilePath(candidate))
+    }
+  )
+  const idByCandidate = new Map<T, string | null>(
+    contested.map((candidate, index) => [candidate, identifiedIds[index]])
+  )
+
   const aliasesToDrop = new Set<T>()
   for (const group of groups.values()) {
     if (group.length < 2) {
       continue
     }
-    const identified = await Promise.all(
-      group.map(async (candidate) => ({
-        candidate,
-        id: await readSessionMetaId(accessors.getFilePath(candidate))
-      }))
-    )
     const bestById = new Map<string, { candidate: T; rank: number; filePath: string }>()
-    for (const { candidate, id } of identified) {
+    for (const candidate of group) {
+      const id = idByCandidate.get(candidate)
       if (!id) {
         continue
       }
@@ -191,7 +213,8 @@ export async function dedupeCodexRolloutCopyAliases<T>(
         bestById.set(id, { candidate, rank, filePath })
       }
     }
-    for (const { candidate, id } of identified) {
+    for (const candidate of group) {
+      const id = idByCandidate.get(candidate)
       if (id && bestById.get(id)?.candidate !== candidate) {
         aliasesToDrop.add(candidate)
       }

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -14,6 +14,7 @@ import * as fsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AiVaultSession } from '../../shared/ai-vault-types'
 import {
   ensureSessionParseCacheLoaded,
   flushSessionParseCachePersistForTests,
@@ -125,6 +126,53 @@ async function coldParseStats(path: string): Promise<SessionParseStats> {
   await parseAgentSessionFileCached(await claudeCandidate(path), process.platform, stats)
   return stats
 }
+
+/**
+ * Schema 2 dropped the `appVersion` equality gate: a cache written by any
+ * release with this schema is now replayed straight into Agent Session
+ * History without re-reading the transcript (#17888 — the gate forced a
+ * multi-gigabyte cold scan after every update). The cost of that reuse is
+ * that nothing else invalidates a stale row, so `SCHEMA_VERSION` is the only
+ * remaining compatibility signal and forgetting to bump it ships wrong data.
+ *
+ * This table is the reminder. Changing the persisted session shape — or the
+ * meaning of a field the parsers fill — breaks this `satisfies` and the fix
+ * is to bump `SCHEMA_VERSION` in session-parse-cache-persistence.ts, not to
+ * silently extend the list.
+ */
+const CACHED_SESSION_FIELDS = {
+  id: true,
+  executionHostId: true,
+  executionHostPlatform: true,
+  agent: true,
+  sessionId: true,
+  title: true,
+  cwd: true,
+  branch: true,
+  model: true,
+  filePath: true,
+  codexHome: true,
+  createdAt: true,
+  updatedAt: true,
+  modifiedAt: true,
+  messageCount: true,
+  totalTokens: true,
+  previewMessages: true,
+  previewMessagesTruncated: true,
+  firstUserPrompt: true,
+  lastUserPrompt: true,
+  queuedMessageCount: true,
+  subagentTranscriptCount: true,
+  resumeCommand: true,
+  subagent: true,
+  structuredSession: true
+} satisfies Record<keyof AiVaultSession, true>
+
+describe('cached session compatibility', () => {
+  it('pins the persisted session shape to the current parse-cache schema', () => {
+    expect(Object.keys(CACHED_SESSION_FIELDS).length).toBeGreaterThan(0)
+  })
+})
 
 describe('session parse cache persistence', () => {
   it('exposes a copy of the active configuration for background scanners', () => {

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -197,17 +197,43 @@ describe('session parse cache persistence', () => {
     expect(stats.reused).toBe(0)
   })
 
-  it('ignores a cache file written by a different app version', async () => {
+  it('rejects the legacy schema 1 cache after parser semantics changed', async () => {
     const root = await makeTempDir()
     const cacheFile = join(root, 'session-parse-cache.json')
     initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
     const transcript = await writeTranscript(root)
     await parseAndPersist(transcript)
 
-    simulateRestart(cacheFile, '9.9.9-other')
+    const persisted = JSON.parse(await readFile(cacheFile, 'utf-8'))
+    persisted.schemaVersion = 1
+    await writeFile(cacheFile, JSON.stringify(persisted))
+
+    simulateRestart(cacheFile)
     const stats = await coldParseStats(transcript)
     expect(stats.fullParses).toBe(1)
     expect(stats.reused).toBe(0)
+  })
+
+  it('reuses a schema-compatible cache written by a different app version', async () => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+    const transcript = await writeTranscript(root)
+    const candidate = await claudeCandidate(transcript)
+    await parseAndPersist(transcript)
+
+    simulateRestart(cacheFile, '9.9.9-other')
+    await ensureSessionParseCacheLoaded()
+
+    // Deleting the transcript proves the cross-version result comes entirely
+    // from the schema-compatible cache and performs no transcript read.
+    await rm(transcript)
+    const stats = createSessionParseStats()
+    const session = await parseAgentSessionFileCached(candidate, process.platform, stats)
+    expect(session).not.toBeNull()
+    expect(stats.reused).toBe(1)
+    expect(stats.fullParses).toBe(0)
+    expect(stats.bytesRead).toBe(0)
   })
 
   it('seeding never clobbers a live in-memory entry', async () => {

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -340,7 +340,13 @@ describe('session parse cache persistence', () => {
     vi.clearAllMocks()
 
     await ensureSessionParseCacheLoaded()
-    scheduleSessionParseCachePersist({ reused: 0, incremental: 2, fullParses: 5, bytesRead: 10 })
+    scheduleSessionParseCachePersist({
+      reused: 0,
+      incremental: 2,
+      fullParses: 5,
+      earlyStopped: 0,
+      bytesRead: 10
+    })
     await flushSessionParseCachePersistForTests()
 
     expect(fsPromises.readFile).not.toHaveBeenCalled()

--- a/src/main/ai-vault/session-parse-cache-persistence.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.ts
@@ -64,11 +64,13 @@ export function ensureSessionParseCacheLoaded(): Promise<void> {
 }
 
 /**
- * Schedule a debounced snapshot write after a scan that parsed something.
- * Reused-only scans schedule no write (the file already reflects the cache).
+ * Schedule a debounced snapshot write after a scan that parsed something. An
+ * early-stopped transcript counts: its stat key moved, so the entry must be
+ * re-persisted or the next launch re-reads it. Reused-only scans schedule no
+ * write (the file already reflects the cache).
  */
 export function scheduleSessionParseCachePersist(stats: SessionParseStats): void {
-  if (options === null || stats.incremental + stats.fullParses <= 0) {
+  if (options === null || stats.incremental + stats.fullParses + stats.earlyStopped <= 0) {
     return
   }
   const current = options

--- a/src/main/ai-vault/session-parse-cache-persistence.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.ts
@@ -12,8 +12,9 @@ import {
   type SessionParseStats
 } from './session-scanner-parse-cache'
 
-// Bump when the persisted entry layout changes; a mismatched file is discarded whole.
-const SCHEMA_VERSION = 1
+// Bump when the persisted entry layout or cached session semantics change; a
+// mismatched file is discarded whole.
+const SCHEMA_VERSION = 2
 // Debounce so back-to-back scans (desktop IPC + runtime RPC) collapse into one write.
 const SAVE_DEBOUNCE_MS = 1_500
 // The payload contains transcript-derived preview text; keep it user-only
@@ -105,7 +106,7 @@ async function loadPersistedEntries(current: SessionParseCachePersistenceOptions
   await sweepOrphanedTempFiles(current.filePath)
   try {
     const raw = await readFile(current.filePath, 'utf-8')
-    const entries = parsePersistedFile(JSON.parse(raw), current.appVersion)
+    const entries = parsePersistedFile(JSON.parse(raw))
     if (entries) {
       seedSessionParseCache(entries)
     }
@@ -132,17 +133,14 @@ async function sweepOrphanedTempFiles(filePath: string): Promise<void> {
   }
 }
 
-function parsePersistedFile(
-  parsed: unknown,
-  appVersion: string
-): [string, PersistedSessionParseCacheEntry][] | null {
+function parsePersistedFile(parsed: unknown): [string, PersistedSessionParseCacheEntry][] | null {
   if (typeof parsed !== 'object' || parsed === null) {
     return null
   }
   const file = parsed as Record<string, unknown>
-  // Why: parser output shape/semantics may change between app versions, so a
-  // cross-version file is discarded — one cold scan per update is the price.
-  if (file.schemaVersion !== SCHEMA_VERSION || file.appVersion !== appVersion) {
+  // Why: application releases that keep this schema promise compatible cached
+  // session semantics, so an update does not force a multi-gigabyte cold scan.
+  if (file.schemaVersion !== SCHEMA_VERSION || typeof file.appVersion !== 'string') {
     return null
   }
   if (!Array.isArray(file.entries)) {

--- a/src/main/ai-vault/session-scanner-codex-fast-path.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-fast-path.test.ts
@@ -3,14 +3,45 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { parseCodexSessionFile } from './session-scanner-codex-parser'
+import { readCodexTimelineOnlyRecord } from './session-scanner-codex-record-fast-path'
 import {
   createSessionParseStats,
   parseAgentSessionFileCached,
   resetSessionParseCacheForTests
 } from './session-scanner-parse-cache'
-import type { SessionFileCandidate } from './session-scanner-types'
+import type { FileWithMtime, SessionFileCandidate } from './session-scanner-types'
+
+// Codex serializes `RolloutLine` as `timestamp` + the adjacently tagged
+// `RolloutItem`; payload enums (`ResponseItem`, `EventMsg`) are internally
+// tagged, so their own `type` leads. Every fixture below matches that spelling.
+const PAD = 'x'.repeat(2048)
+
+function record(type: string, payload: Record<string, unknown>, timestamp: string): string {
+  return JSON.stringify({ timestamp, type, payload })
+}
+
+// Padded past the fast path's prefix limit: an undersized record is parsed
+// exactly either way, so only oversized fixtures exercise the prefix match.
+function paddedPayload(payloadType: string, extra: Record<string, unknown> = {}) {
+  return { type: payloadType, ...extra, pad: PAD }
+}
 
 let tempRoots: string[] = []
+
+async function writeTranscript(lines: string[], name: string): Promise<FileWithMtime> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-codex-fast-path-'))
+  tempRoots.push(root)
+  const path = join(root, 'sessions', '2026', '08', '20', name)
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${lines.join('\n')}\n`)
+  const fileStat = await stat(path)
+  return {
+    path,
+    mtimeMs: fileStat.mtimeMs,
+    modifiedAt: fileStat.mtime.toISOString(),
+    sizeBytes: fileStat.size
+  }
+}
 
 beforeEach(() => {
   resetSessionParseCacheForTests()
@@ -22,92 +53,147 @@ afterEach(async () => {
   tempRoots = []
 })
 
+describe('readCodexTimelineOnlyRecord', () => {
+  // The fast path is the complement of what `consumeCodexRecordLine` reads, so
+  // every record that feeds a visible field must fail the prefix match even
+  // when it is large — a >1KiB opening prompt is ordinary, and it is the title.
+  it.each([
+    ['session_meta', record('session_meta', { id: 'a', pad: PAD }, '2026-08-20T10:00:00.000Z')],
+    [
+      'turn_context',
+      record('turn_context', { cwd: '/repo', pad: PAD }, '2026-08-20T10:00:00.000Z')
+    ],
+    [
+      'response_item/message',
+      record(
+        'response_item',
+        paddedPayload('message', { role: 'user' }),
+        '2026-08-20T10:00:00.000Z'
+      )
+    ],
+    [
+      'event_msg/user_message',
+      record('event_msg', paddedPayload('user_message'), '2026-08-20T10:00:00.000Z')
+    ],
+    [
+      'event_msg/agent_message',
+      record('event_msg', paddedPayload('agent_message'), '2026-08-20T10:00:00.000Z')
+    ],
+    [
+      'event_msg/item_completed',
+      record('event_msg', paddedPayload('item_completed'), '2026-08-20T10:00:00.000Z')
+    ],
+    [
+      'event_msg/token_count',
+      record('event_msg', paddedPayload('token_count'), '2026-08-20T10:00:00.000Z')
+    ]
+  ])('keeps %s on the full parser', (_label, line) => {
+    expect(readCodexTimelineOnlyRecord(Buffer.from(line))).toBeNull()
+  })
+
+  it.each([
+    ['compacted', record('compacted', { message: PAD }, '2026-08-20T10:00:00.000Z')],
+    [
+      'response_item/function_call_output',
+      record('response_item', paddedPayload('function_call_output'), '2026-08-20T10:00:00.000Z')
+    ],
+    [
+      'response_item/image_generation_call',
+      record('response_item', paddedPayload('image_generation_call'), '2026-08-20T10:00:00.000Z')
+    ],
+    [
+      'response_item/reasoning',
+      record('response_item', paddedPayload('reasoning'), '2026-08-20T10:00:00.000Z')
+    ],
+    [
+      'event_msg/task_complete',
+      record('event_msg', paddedPayload('task_complete'), '2026-08-20T10:00:00.000Z')
+    ],
+    [
+      'event_msg/exec_command_output_delta',
+      record('event_msg', paddedPayload('exec_command_output_delta'), '2026-08-20T10:00:00.000Z')
+    ]
+  ])('takes %s off the full parser', (_label, line) => {
+    expect(readCodexTimelineOnlyRecord(Buffer.from(line))).toEqual({
+      timestamp: '2026-08-20T10:00:00.000Z'
+    })
+  })
+
+  it('falls back for small, reordered, or prefix-ambiguous records', () => {
+    const small = record('compacted', { message: 'short' }, '2026-08-20T10:00:00.000Z')
+    expect(readCodexTimelineOnlyRecord(Buffer.from(small))).toBeNull()
+    const reordered = `${JSON.stringify({ type: 'compacted', timestamp: '2026-08-20T10:00:00.000Z', payload: { message: PAD } })}`
+    expect(readCodexTimelineOnlyRecord(Buffer.from(reordered))).toBeNull()
+    // `type` pushed past the bounded prefix leaves the payload unidentified.
+    const lateType = `{"timestamp":"2026-08-20T10:00:00.000Z","type":"response_item","payload":{"pad":"${PAD}","type":"reasoning"}}`
+    expect(readCodexTimelineOnlyRecord(Buffer.from(lateType))).toBeNull()
+  })
+})
+
 describe('Codex resumable parser fast path', () => {
   it('matches the one-shot parser without JSON-parsing proven irrelevant large records', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'orca-codex-fast-path-'))
-    tempRoots.push(root)
-    const path = join(
-      root,
-      'sessions',
-      '2026',
-      '08',
-      '20',
+    // Distinct fillers so the assertion can name which large records the fast
+    // path skipped and which correctly fell back to the full parser.
+    const skippedFiller = `skipped-${'x'.repeat(2 * 1024 * 1024)}`
+    const fallbackFiller = `fallback-${'x'.repeat(2 * 1024 * 1024)}`
+    const file = await writeTranscript(
+      [
+        record(
+          'session_meta',
+          { id: 'fast-path-session', cwd: '/repo/app' },
+          '2026-08-20T10:00:00.000Z'
+        ),
+        // A long opening prompt is the session title; it must survive the size gate.
+        record(
+          'response_item',
+          {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'text', text: `Keep visible messages exact ${PAD}` }]
+          },
+          '2026-08-20T10:00:01.000Z'
+        ),
+        record(
+          'response_item',
+          { type: 'function_call_output', output: skippedFiller },
+          '2026-08-20T10:00:02.000Z'
+        ),
+        record('compacted', { message: skippedFiller }, '2026-08-20T10:00:03.000Z'),
+        record(
+          'event_msg',
+          { type: 'token_count', info: { total_token_usage: { total_tokens: 120 } } },
+          '2026-08-20T10:00:04.000Z'
+        ),
+        record(
+          'response_item',
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Visible answer' }]
+          },
+          '2026-08-20T10:00:05.000Z'
+        ),
+        // A nested `payload.type` must not be mistaken for the record's own.
+        record(
+          'event_msg',
+          {
+            metadata: { payload: { type: 'turn_aborted' } },
+            type: 'token_count',
+            info: { total_token_usage: { total_tokens: 150 } }
+          },
+          '2026-08-20T10:00:06.000Z'
+        ),
+        record('event_msg', { type: 'future_event', value: 1 }, '2026-08-20T10:00:07.000Z'),
+        // Reordered envelopes take the compatibility fallback.
+        JSON.stringify({
+          type: 'future_record',
+          timestamp: '2026-08-20T10:00:08.000Z',
+          payload: { value: fallbackFiller }
+        }),
+        record('world_state', { state: skippedFiller }, '2026-08-20T10:00:09.000Z')
+      ],
       'rollout-2026-08-20T10-00-00-fast-path.jsonl'
     )
-    await mkdir(dirname(path), { recursive: true })
-    const largePayload = 'x'.repeat(2 * 1024 * 1024)
-    const records = [
-      {
-        timestamp: '2026-08-20T10:00:00.000Z',
-        type: 'session_meta',
-        payload: { id: 'fast-path-session', cwd: '/repo/app' }
-      },
-      {
-        timestamp: '2026-08-20T10:00:01.000Z',
-        type: 'response_item',
-        payload: {
-          type: 'message',
-          role: 'user',
-          content: [{ type: 'text', text: 'Keep visible messages exact' }]
-        }
-      },
-      {
-        timestamp: '2026-08-20T10:00:02.000Z',
-        type: 'response_item',
-        payload: { type: 'function_call_output', output: largePayload }
-      },
-      {
-        timestamp: '2026-08-20T10:00:03.000Z',
-        type: 'world_state',
-        payload: { state: largePayload }
-      },
-      {
-        timestamp: '2026-08-20T10:00:04.000Z',
-        type: 'event_msg',
-        payload: {
-          type: 'token_count',
-          info: { total_token_usage: { total_tokens: 120 } }
-        }
-      },
-      {
-        timestamp: '2026-08-20T10:00:05.000Z',
-        type: 'response_item',
-        payload: {
-          type: 'message',
-          role: 'assistant',
-          content: [{ type: 'output_text', text: 'Visible answer' }]
-        }
-      },
-      {
-        timestamp: '2026-08-20T10:00:06.000Z',
-        type: 'event_msg',
-        payload: {
-          metadata: { payload: { type: 'turn_aborted' } },
-          type: 'token_count',
-          info: { total_token_usage: { total_tokens: 150 } }
-        }
-      },
-      {
-        timestamp: '2026-08-20T10:00:07.000Z',
-        type: 'event_msg',
-        payload: { type: 'future_event', value: 1 }
-      },
-      // Reordered/unknown envelopes must take the compatibility fallback.
-      { type: 'future_record', timestamp: '2026-08-20T10:00:08.000Z', payload: { value: 1 } },
-      {
-        timestamp: '2026-08-20T10:00:09.000Z',
-        type: 'compacted',
-        payload: { replacement_history: largePayload }
-      }
-    ]
-    await writeFile(path, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`)
-    const fileStat = await stat(path)
-    const file = {
-      path,
-      mtimeMs: fileStat.mtimeMs,
-      modifiedAt: fileStat.mtime.toISOString(),
-      sizeBytes: fileStat.size
-    }
     const expected = await parseCodexSessionFile(file, process.platform, null)
     const candidate: SessionFileCandidate = { agent: 'codex', file, codexHome: null }
 
@@ -120,46 +206,61 @@ describe('Codex resumable parser fast path', () => {
       totalTokens: 150,
       updatedAt: '2026-08-20T10:00:09.000Z'
     })
-    expect(parseSpy).toHaveBeenCalledTimes(7)
-    expect(
-      parseSpy.mock.calls.some(([input]) => typeof input === 'string' && input.length > 1024 * 1024)
-    ).toBe(false)
+    const parsedInputs = parseSpy.mock.calls
+      .map(([input]) => input)
+      .filter((input): input is string => typeof input === 'string')
+    expect(parsedInputs.some((input) => input.includes('skipped-xxx'))).toBe(false)
+    // A reordered envelope is not proven irrelevant, so it still parses whole.
+    expect(parsedInputs.some((input) => input.includes('fallback-xxx'))).toBe(true)
   })
 
   it('stops reading as soon as session_meta rejects a worker transcript', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'orca-codex-worker-fast-stop-'))
-    tempRoots.push(root)
-    const path = join(root, 'rollout-worker.jsonl')
-    const sessionMeta = JSON.stringify({
-      timestamp: '2026-08-20T10:00:00.000Z',
-      type: 'session_meta',
-      payload: { id: 'worker-session', source: { subagent: { thread_spawn: true } } }
-    })
-    const ignoredTail = JSON.stringify({
-      timestamp: '2026-08-20T10:00:01.000Z',
-      type: 'compacted',
-      payload: { replacement_history: 'x'.repeat(4 * 1024 * 1024) }
-    })
-    await writeFile(path, `${sessionMeta}\n${ignoredTail}\n`)
-    const fileStat = await stat(path)
+    const file = await writeTranscript(
+      [
+        record(
+          'session_meta',
+          { id: 'worker-session', source: { subagent: { thread_spawn: true } } },
+          '2026-08-20T10:00:00.000Z'
+        ),
+        record('compacted', { message: 'x'.repeat(4 * 1024 * 1024) }, '2026-08-20T10:00:01.000Z')
+      ],
+      'rollout-2026-08-20T10-00-00-worker.jsonl'
+    )
     const stats = createSessionParseStats()
 
     const session = await parseAgentSessionFileCached(
-      {
-        agent: 'codex',
-        file: {
-          path,
-          mtimeMs: fileStat.mtimeMs,
-          modifiedAt: fileStat.mtime.toISOString(),
-          sizeBytes: fileStat.size
-        },
-        codexHome: null
-      },
+      { agent: 'codex', file, codexHome: null },
       process.platform,
       stats
     )
 
     expect(session).toBeNull()
-    expect(stats.bytesRead).toBeLessThan(fileStat.size / 2)
+    expect(stats.bytesRead).toBeLessThan((file.sizeBytes ?? 0) / 2)
+  })
+
+  it('never re-reads a worker transcript that later grew', async () => {
+    const file = await writeTranscript(
+      [
+        record(
+          'session_meta',
+          { id: 'worker-session', thread_source: 'subagent' },
+          '2026-08-20T10:00:00.000Z'
+        ),
+        record('compacted', { message: 'x'.repeat(1024 * 1024) }, '2026-08-20T10:00:01.000Z')
+      ],
+      'rollout-2026-08-20T10-00-00-worker-grown.jsonl'
+    )
+    const candidate: SessionFileCandidate = { agent: 'codex', file, codexHome: null }
+    await parseAgentSessionFileCached(candidate, process.platform)
+
+    const grown = createSessionParseStats()
+    const session = await parseAgentSessionFileCached(
+      { ...candidate, file: { ...file, mtimeMs: file.mtimeMs + 1, sizeBytes: 99_000_000 } },
+      process.platform,
+      grown
+    )
+
+    expect(session).toBeNull()
+    expect(grown.bytesRead).toBe(0)
   })
 })

--- a/src/main/ai-vault/session-scanner-codex-fast-path.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-fast-path.test.ts
@@ -1,0 +1,165 @@
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { parseCodexSessionFile } from './session-scanner-codex-parser'
+import {
+  createSessionParseStats,
+  parseAgentSessionFileCached,
+  resetSessionParseCacheForTests
+} from './session-scanner-parse-cache'
+import type { SessionFileCandidate } from './session-scanner-types'
+
+let tempRoots: string[] = []
+
+beforeEach(() => {
+  resetSessionParseCacheForTests()
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
+  tempRoots = []
+})
+
+describe('Codex resumable parser fast path', () => {
+  it('matches the one-shot parser without JSON-parsing proven irrelevant large records', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-codex-fast-path-'))
+    tempRoots.push(root)
+    const path = join(
+      root,
+      'sessions',
+      '2026',
+      '08',
+      '20',
+      'rollout-2026-08-20T10-00-00-fast-path.jsonl'
+    )
+    await mkdir(dirname(path), { recursive: true })
+    const largePayload = 'x'.repeat(2 * 1024 * 1024)
+    const records = [
+      {
+        timestamp: '2026-08-20T10:00:00.000Z',
+        type: 'session_meta',
+        payload: { id: 'fast-path-session', cwd: '/repo/app' }
+      },
+      {
+        timestamp: '2026-08-20T10:00:01.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'text', text: 'Keep visible messages exact' }]
+        }
+      },
+      {
+        timestamp: '2026-08-20T10:00:02.000Z',
+        type: 'response_item',
+        payload: { type: 'function_call_output', output: largePayload }
+      },
+      {
+        timestamp: '2026-08-20T10:00:03.000Z',
+        type: 'world_state',
+        payload: { state: largePayload }
+      },
+      {
+        timestamp: '2026-08-20T10:00:04.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: { total_token_usage: { total_tokens: 120 } }
+        }
+      },
+      {
+        timestamp: '2026-08-20T10:00:05.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Visible answer' }]
+        }
+      },
+      {
+        timestamp: '2026-08-20T10:00:06.000Z',
+        type: 'event_msg',
+        payload: {
+          metadata: { payload: { type: 'turn_aborted' } },
+          type: 'token_count',
+          info: { total_token_usage: { total_tokens: 150 } }
+        }
+      },
+      {
+        timestamp: '2026-08-20T10:00:07.000Z',
+        type: 'event_msg',
+        payload: { type: 'future_event', value: 1 }
+      },
+      // Reordered/unknown envelopes must take the compatibility fallback.
+      { type: 'future_record', timestamp: '2026-08-20T10:00:08.000Z', payload: { value: 1 } },
+      {
+        timestamp: '2026-08-20T10:00:09.000Z',
+        type: 'compacted',
+        payload: { replacement_history: largePayload }
+      }
+    ]
+    await writeFile(path, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`)
+    const fileStat = await stat(path)
+    const file = {
+      path,
+      mtimeMs: fileStat.mtimeMs,
+      modifiedAt: fileStat.mtime.toISOString(),
+      sizeBytes: fileStat.size
+    }
+    const expected = await parseCodexSessionFile(file, process.platform, null)
+    const candidate: SessionFileCandidate = { agent: 'codex', file, codexHome: null }
+
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    const actual = await parseAgentSessionFileCached(candidate, process.platform)
+
+    expect(actual).toEqual(expected)
+    expect(actual).toMatchObject({
+      messageCount: 2,
+      totalTokens: 150,
+      updatedAt: '2026-08-20T10:00:09.000Z'
+    })
+    expect(parseSpy).toHaveBeenCalledTimes(7)
+    expect(
+      parseSpy.mock.calls.some(([input]) => typeof input === 'string' && input.length > 1024 * 1024)
+    ).toBe(false)
+  })
+
+  it('stops reading as soon as session_meta rejects a worker transcript', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-codex-worker-fast-stop-'))
+    tempRoots.push(root)
+    const path = join(root, 'rollout-worker.jsonl')
+    const sessionMeta = JSON.stringify({
+      timestamp: '2026-08-20T10:00:00.000Z',
+      type: 'session_meta',
+      payload: { id: 'worker-session', source: { subagent: { thread_spawn: true } } }
+    })
+    const ignoredTail = JSON.stringify({
+      timestamp: '2026-08-20T10:00:01.000Z',
+      type: 'compacted',
+      payload: { replacement_history: 'x'.repeat(4 * 1024 * 1024) }
+    })
+    await writeFile(path, `${sessionMeta}\n${ignoredTail}\n`)
+    const fileStat = await stat(path)
+    const stats = createSessionParseStats()
+
+    const session = await parseAgentSessionFileCached(
+      {
+        agent: 'codex',
+        file: {
+          path,
+          mtimeMs: fileStat.mtimeMs,
+          modifiedAt: fileStat.mtime.toISOString(),
+          sizeBytes: fileStat.size
+        },
+        codexHome: null
+      },
+      process.platform,
+      stats
+    )
+
+    expect(session).toBeNull()
+    expect(stats.bytesRead).toBeLessThan(fileStat.size / 2)
+  })
+})

--- a/src/main/ai-vault/session-scanner-codex-fast-path.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-fast-path.test.ts
@@ -262,5 +262,8 @@ describe('Codex resumable parser fast path', () => {
 
     expect(session).toBeNull()
     expect(grown.bytesRead).toBe(0)
+    // Reported apart from `incremental` so the scan span shows a dismissal, not
+    // an incremental parse that happened to read nothing.
+    expect(grown).toMatchObject({ earlyStopped: 1, incremental: 0, fullParses: 0 })
   })
 })

--- a/src/main/ai-vault/session-scanner-codex-parser.ts
+++ b/src/main/ai-vault/session-scanner-codex-parser.ts
@@ -34,6 +34,7 @@ import {
   subtractCodexUsage
 } from './session-scanner-values'
 import { remoteSessionContentLines } from './remote-session-content-lines'
+import { readCodexTimelineOnlyRecord } from './session-scanner-codex-record-fast-path'
 
 export async function parseCodexSessionFile(
   file: FileWithMtime,
@@ -270,6 +271,15 @@ function codexResumeStateFromParseState(
 ): ResumableSessionParseState {
   return {
     consumeLine: (line) => consumeCodexRecordLine(state, line),
+    consumeLineBytes: (line) => {
+      const timelineOnlyRecord = readCodexTimelineOnlyRecord(line)
+      if (timelineOnlyRecord) {
+        updateTimeline(state.accumulator, timelineOnlyRecord.timestamp)
+      } else {
+        consumeCodexRecordLine(state, line.toString('utf8'))
+      }
+    },
+    shouldStop: () => state.rejectedWorkerSession,
     clone: () =>
       codexResumeStateFromParseState(cloneCodexParseState(state), codexHome, titleReader),
     touchFile: (file) => {
@@ -305,12 +315,8 @@ async function parseCodexSessionLines(args: {
   })
 }
 
-function extractCodexThreadSource(payload: Record<string, unknown>): string | null {
-  return extractString(payload.thread_source) ?? extractString(payload.threadSource)
-}
-
 function isCodexWorkerSession(payload: Record<string, unknown>): boolean {
-  const threadSource = extractCodexThreadSource(payload)
+  const threadSource = extractString(payload.thread_source) ?? extractString(payload.threadSource)
   if (threadSource) {
     return threadSource.toLowerCase() !== 'user'
   }

--- a/src/main/ai-vault/session-scanner-codex-record-fast-path.ts
+++ b/src/main/ai-vault/session-scanner-codex-record-fast-path.ts
@@ -1,0 +1,39 @@
+const CODEX_RECORD_PREFIX_LIMIT = 1024
+const CODEX_RECORD_ENVELOPE_PATTERN = /^\{"timestamp":"([^"]+)","type":"([^"]+)","payload":/
+const CODEX_PAYLOAD_TYPE_PATTERN = /^\{"type":"([^"]+)"/
+const TIMELINE_ONLY_RESPONSE_ITEM_TYPES = new Set([
+  'function_call_output',
+  'custom_tool_call_output',
+  'reasoning',
+  'custom_tool_call',
+  'function_call',
+  'tool_search_output'
+])
+const TIMELINE_ONLY_EVENT_TYPES = new Set([
+  'patch_apply_end',
+  'task_complete',
+  'task_started',
+  'thread_settings_applied',
+  'context_compacted',
+  'turn_aborted'
+])
+
+/** Returns the timestamp only when the record cannot affect other visible session fields. */
+export function readCodexTimelineOnlyRecord(line: Buffer): { timestamp: string } | null {
+  const prefix = line.toString('utf8', 0, Math.min(line.length, CODEX_RECORD_PREFIX_LIMIT))
+  const envelope = CODEX_RECORD_ENVELOPE_PATTERN.exec(prefix)
+  const timestamp = envelope?.[1]
+  const recordType = envelope?.[2]
+  if (!timestamp || !recordType) {
+    return null
+  }
+
+  const payloadType = CODEX_PAYLOAD_TYPE_PATTERN.exec(prefix.slice(envelope[0].length))?.[1]
+  if (recordType === 'response_item') {
+    return payloadType && TIMELINE_ONLY_RESPONSE_ITEM_TYPES.has(payloadType) ? { timestamp } : null
+  }
+  if (recordType === 'event_msg') {
+    return payloadType && TIMELINE_ONLY_EVENT_TYPES.has(payloadType) ? { timestamp } : null
+  }
+  return recordType === 'compacted' || recordType === 'world_state' ? { timestamp } : null
+}

--- a/src/main/ai-vault/session-scanner-codex-record-fast-path.ts
+++ b/src/main/ai-vault/session-scanner-codex-record-fast-path.ts
@@ -1,39 +1,47 @@
+// Records below this size are decoded and parsed exactly: JSON.parse on a
+// kilobyte costs less than the risk of a prefix heuristic, and the scan cost
+// this path exists to remove is entirely in megabyte-scale records.
 const CODEX_RECORD_PREFIX_LIMIT = 1024
+// serde emits `RolloutLine` as `timestamp` then the adjacently tagged
+// `RolloutItem` (`type`, `payload`), and every tagged payload enum writes its
+// own `type` first. Anything spelled differently takes the full parser.
 const CODEX_RECORD_ENVELOPE_PATTERN = /^\{"timestamp":"([^"]+)","type":"([^"]+)","payload":/
 const CODEX_PAYLOAD_TYPE_PATTERN = /^\{"type":"([^"]+)"/
-const TIMELINE_ONLY_RESPONSE_ITEM_TYPES = new Set([
-  'function_call_output',
-  'custom_tool_call_output',
-  'reasoning',
-  'custom_tool_call',
-  'function_call',
-  'tool_search_output'
-])
-const TIMELINE_ONLY_EVENT_TYPES = new Set([
-  'patch_apply_end',
-  'task_complete',
-  'task_started',
-  'thread_settings_applied',
-  'context_compacted',
-  'turn_aborted'
+
+// Every record `consumeCodexRecordLine` reads beyond the timeline clock; the
+// fast path is the complement, so teaching the parser a new record means
+// adding it here or the scanner silently stops seeing it.
+// `session-scanner-codex-fast-path.test.ts` pins each entry.
+const PARSED_RECORD_TYPES = new Set(['session_meta', 'turn_context'])
+const PARSED_RESPONSE_ITEM_TYPES = new Set(['message'])
+const PARSED_EVENT_TYPES = new Set([
+  'item_completed',
+  'user_message',
+  'agent_message',
+  'token_count'
 ])
 
 /** Returns the timestamp only when the record cannot affect other visible session fields. */
 export function readCodexTimelineOnlyRecord(line: Buffer): { timestamp: string } | null {
-  const prefix = line.toString('utf8', 0, Math.min(line.length, CODEX_RECORD_PREFIX_LIMIT))
+  if (line.length <= CODEX_RECORD_PREFIX_LIMIT) {
+    return null
+  }
+  const prefix = line.toString('utf8', 0, CODEX_RECORD_PREFIX_LIMIT)
   const envelope = CODEX_RECORD_ENVELOPE_PATTERN.exec(prefix)
   const timestamp = envelope?.[1]
   const recordType = envelope?.[2]
-  if (!timestamp || !recordType) {
+  if (!timestamp || !recordType || PARSED_RECORD_TYPES.has(recordType)) {
     return null
   }
-
+  if (recordType !== 'response_item' && recordType !== 'event_msg') {
+    return { timestamp }
+  }
+  // A payload whose type is unreadable from the bounded prefix stays ambiguous.
   const payloadType = CODEX_PAYLOAD_TYPE_PATTERN.exec(prefix.slice(envelope[0].length))?.[1]
-  if (recordType === 'response_item') {
-    return payloadType && TIMELINE_ONLY_RESPONSE_ITEM_TYPES.has(payloadType) ? { timestamp } : null
+  if (!payloadType) {
+    return null
   }
-  if (recordType === 'event_msg') {
-    return payloadType && TIMELINE_ONLY_EVENT_TYPES.has(payloadType) ? { timestamp } : null
-  }
-  return recordType === 'compacted' || recordType === 'world_state' ? { timestamp } : null
+  const parsedPayloadTypes =
+    recordType === 'response_item' ? PARSED_RESPONSE_ITEM_TYPES : PARSED_EVENT_TYPES
+  return parsedPayloadTypes.has(payloadType) ? null : { timestamp }
 }

--- a/src/main/ai-vault/session-scanner-jsonl-reader.ts
+++ b/src/main/ai-vault/session-scanner-jsonl-reader.ts
@@ -1,0 +1,83 @@
+import { openTranscriptReadStream } from '../native-chat/wsl-transcript-fs-access'
+
+const NEWLINE_BYTE = 0x0a
+const CARRIAGE_RETURN_BYTE = 0x0d
+
+type JsonlReadResult = {
+  consumedThrough: number
+  trailingPartialLine: string | null
+  bytesRead: number
+}
+
+// Byte-accurate JSONL fold: offsets count bytes rather than decoded UTF-8
+// characters, so an incremental read resumes at an exact line boundary.
+export async function consumeCompleteJsonlLines(args: {
+  path: string
+  start: number
+  onLine: (line: string) => void
+  onLineBytes?: (line: Buffer) => void
+  shouldStop?: () => boolean
+}): Promise<JsonlReadResult> {
+  if (args.shouldStop?.()) {
+    return { consumedThrough: args.start, trailingPartialLine: null, bytesRead: 0 }
+  }
+  let consumedThrough = args.start
+  let bytesRead = 0
+  // A piece list avoids O(record^2) copying when one record spans many chunks.
+  let remainderParts: Buffer[] = []
+  let remainderLength = 0
+  let stopped = false
+
+  const stream = openTranscriptReadStream(args.path, { start: args.start }, 'scan')
+  for await (const chunk of stream as AsyncIterable<Buffer>) {
+    bytesRead += chunk.length
+    if (!chunk.includes(NEWLINE_BYTE)) {
+      remainderParts.push(chunk)
+      remainderLength += chunk.length
+      continue
+    }
+    const data =
+      remainderLength > 0
+        ? Buffer.concat([...remainderParts, chunk], remainderLength + chunk.length)
+        : chunk
+    remainderParts = []
+    remainderLength = 0
+    let lineStart = 0
+    let newlineIndex = data.indexOf(NEWLINE_BYTE, lineStart)
+    while (newlineIndex !== -1) {
+      let lineEnd = newlineIndex
+      if (lineEnd > lineStart && data[lineEnd - 1] === CARRIAGE_RETURN_BYTE) {
+        lineEnd--
+      }
+      if (args.onLineBytes) {
+        args.onLineBytes(data.subarray(lineStart, lineEnd))
+      } else {
+        args.onLine(data.toString('utf-8', lineStart, lineEnd))
+      }
+      lineStart = newlineIndex + 1
+      if (args.shouldStop?.()) {
+        stopped = true
+        break
+      }
+      newlineIndex = data.indexOf(NEWLINE_BYTE, lineStart)
+    }
+    consumedThrough += lineStart
+    if (stopped) {
+      remainderParts = []
+      remainderLength = 0
+      break
+    }
+    if (lineStart < data.length) {
+      // Copy the tail so retaining it does not pin the whole chunk buffer.
+      remainderParts = [Buffer.from(data.subarray(lineStart))]
+      remainderLength = data.length - lineStart
+    }
+  }
+
+  return {
+    consumedThrough,
+    trailingPartialLine:
+      remainderLength > 0 ? Buffer.concat(remainderParts, remainderLength).toString('utf-8') : null,
+    bytesRead
+  }
+}

--- a/src/main/ai-vault/session-scanner-parse-cache-agents.test.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache-agents.test.ts
@@ -163,7 +163,9 @@ describe('codex-specific resume behavior', () => {
       process.platform,
       stats
     )
-    expect(stats.incremental).toBe(1)
+    // The append is dismissed without a read, so it is an early stop rather
+    // than an incremental parse.
+    expect(stats).toMatchObject({ earlyStopped: 1, incremental: 0 })
     expect(grown).toBeNull()
   })
 

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -272,8 +272,10 @@ async function parseResumableCandidate(args: {
     path: file.path,
     start: startOffset,
     onLine: (line) => state.consumeLine(line),
-    onLineBytes: state.consumeLineBytes,
-    shouldStop: state.shouldStop
+    // Bound: the optional hooks are declared as methods, so a parser written
+    // with method syntax must not lose `this` on the way into the reader.
+    onLineBytes: state.consumeLineBytes?.bind(state),
+    shouldStop: state.shouldStop?.bind(state)
   })
   if (args.stats) {
     args.stats.bytesRead += readResult.bytesRead

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -84,11 +84,15 @@ export type SessionParseStats = {
   reused: number
   incremental: number
   fullParses: number
+  // Transcripts the parser already excluded (Codex workers), re-listed after a
+  // write and dismissed without reading. Counted apart from `incremental` so a
+  // scan span still shows how much work the early stop actually removed.
+  earlyStopped: number
   bytesRead: number
 }
 
 export function createSessionParseStats(): SessionParseStats {
-  return { reused: 0, incremental: 0, fullParses: 0, bytesRead: 0 }
+  return { reused: 0, incremental: 0, fullParses: 0, earlyStopped: 0, bytesRead: 0 }
 }
 
 const cache = new Map<string, SessionParseCacheEntry>()
@@ -260,8 +264,13 @@ async function parseResumableCandidate(args: {
   // or the next resume would double-count the lines applied before the error.
   const state = canResume ? resume.state.clone() : args.stateFactory()
   const startOffset = canResume ? resume.byteOffset : 0
+  // Mirrors the reader's entry guard so a dismissed transcript is not reported
+  // as an incremental parse that read nothing.
+  const stoppedBeforeRead = state.shouldStop?.() === true
   if (args.stats) {
-    if (canResume) {
+    if (stoppedBeforeRead) {
+      args.stats.earlyStopped++
+    } else if (canResume) {
       args.stats.incremental++
     } else {
       args.stats.fullParses++

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -1,7 +1,4 @@
-import {
-  openTranscriptReadStream,
-  readTranscriptSlice
-} from '../native-chat/wsl-transcript-fs-access'
+import { readTranscriptSlice } from '../native-chat/wsl-transcript-fs-access'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import { createAntigravitySessionResumeState } from './session-scanner-antigravity-parser'
 import { parseAgentSessionFile } from './session-scanner-agent-parser'
@@ -16,13 +13,12 @@ import { countSubagentTranscripts } from './session-scanner-subagent-transcripts
 import { countOmpSubagentTranscripts } from './session-scanner-omp-subagent-transcripts'
 import type { ResumableSessionParseState, SessionFileCandidate } from './session-scanner-types'
 import { refreshCachedCodexTitle } from './session-scanner-codex-cached-title'
+import { consumeCompleteJsonlLines } from './session-scanner-jsonl-reader'
 
 // Sized past the default recency cap (1000) plus the in-scope cap (2000) so a
 // full steady-state result set stays resident between forced rescans.
 const MAX_CACHE_ENTRIES = 4096
-
 const NEWLINE_BYTE = 0x0a
-const CARRIAGE_RETURN_BYTE = 0x0d
 
 type ResumePoint = {
   state: ResumableSessionParseState
@@ -275,7 +271,9 @@ async function parseResumableCandidate(args: {
   const readResult = await consumeCompleteJsonlLines({
     path: file.path,
     start: startOffset,
-    onLine: (line) => state.consumeLine(line)
+    onLine: (line) => state.consumeLine(line),
+    onLineBytes: state.consumeLineBytes,
+    shouldStop: state.shouldStop
   })
   if (args.stats) {
     args.stats.bytesRead += readResult.bytesRead
@@ -310,71 +308,4 @@ async function parseResumableCandidate(args: {
 async function endsWithNewlineAt(path: string, offset: number): Promise<boolean> {
   const slice = await readTranscriptSlice(path, offset - 1, 1, 'scan')
   return slice.length === 1 && slice[0] === NEWLINE_BYTE
-}
-
-type JsonlReadResult = {
-  consumedThrough: number
-  trailingPartialLine: string | null
-  bytesRead: number
-}
-
-// Byte-accurate replacement for readline: offsets must count bytes (not
-// UTF-8-decoded characters) so a resumed read starts exactly where the last
-// complete line ended.
-async function consumeCompleteJsonlLines(args: {
-  path: string
-  start: number
-  onLine: (line: string) => void
-}): Promise<JsonlReadResult> {
-  let consumedThrough = args.start
-  let bytesRead = 0
-  // Why a piece list: re-joining the partial line with every chunk made one
-  // oversized record (a big tool result) cost O(record^2). Joining once, when a
-  // newline finally arrives, keeps it linear.
-  let remainderParts: Buffer[] = []
-  let remainderLength = 0
-
-  const stream = openTranscriptReadStream(args.path, { start: args.start }, 'scan')
-  for await (const chunk of stream as AsyncIterable<Buffer>) {
-    bytesRead += chunk.length
-    // Why check the chunk alone: the pieces held over are all mid-line, so none
-    // of them contains a newline.
-    if (!chunk.includes(NEWLINE_BYTE)) {
-      remainderParts.push(chunk)
-      remainderLength += chunk.length
-      continue
-    }
-    const data =
-      remainderLength > 0
-        ? Buffer.concat([...remainderParts, chunk], remainderLength + chunk.length)
-        : chunk
-    remainderParts = []
-    remainderLength = 0
-    let lineStart = 0
-    let newlineIndex = data.indexOf(NEWLINE_BYTE, lineStart)
-    while (newlineIndex !== -1) {
-      let lineEnd = newlineIndex
-      if (lineEnd > lineStart && data[lineEnd - 1] === CARRIAGE_RETURN_BYTE) {
-        lineEnd--
-      }
-      args.onLine(data.toString('utf-8', lineStart, lineEnd))
-      lineStart = newlineIndex + 1
-      newlineIndex = data.indexOf(NEWLINE_BYTE, lineStart)
-    }
-    consumedThrough += lineStart
-    if (lineStart < data.length) {
-      // Copy the tail so retaining it doesn't pin the whole chunk buffer.
-      remainderParts = [Buffer.from(data.subarray(lineStart))]
-      remainderLength = data.length - lineStart
-    }
-  }
-
-  const trailingPartialLine =
-    remainderLength > 0 ? Buffer.concat(remainderParts, remainderLength).toString('utf-8') : null
-
-  return {
-    consumedThrough,
-    trailingPartialLine,
-    bytesRead
-  }
 }

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -92,6 +92,11 @@ export type ResumableParseFinalizeOptions = {
 // read or a display-only trailing line can never corrupt the cached fold.
 export type ResumableSessionParseState = {
   consumeLine(line: string): void
+  // Optional zero-copy path for parsers that can reject irrelevant records
+  // from a bounded byte prefix before decoding a potentially huge JSONL line.
+  consumeLineBytes?(line: Buffer): void
+  // Lets a parser terminate an excluded transcript without draining the file.
+  shouldStop?(): boolean
   clone(): ResumableSessionParseState
   // Refresh per-scan file metadata (mtime display string) without re-parsing.
   touchFile(file: FileWithMtime): void

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -109,7 +109,7 @@ export async function scanAiVaultSessions(
         getCodexHome: (candidate) => candidate.codexHome,
         getHardlinkIdentity: (candidate) => codexRolloutHardlinkIdentity(candidate.file)
       },
-      (filePath) => readCodexRolloutSessionMetaId(filePath, options.signal),
+      (filePath) => readCodexRolloutSessionMetaId(filePath, options.signal, 'scan'),
       options.signal
     )
 

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -8,9 +8,10 @@ import { withSpan } from '../observability/tracer'
 import { sessionSortTime } from './session-scanner-accumulator'
 import {
   codexRolloutHardlinkIdentity,
-  dedupeCodexRolloutFileAliases,
+  dedupeCodexRolloutAliases,
   dedupeCodexSessionsBySessionId
 } from './codex-session-root-dedup'
+import { readCodexRolloutSessionMetaId } from '../codex/codex-rollout-session-meta'
 import {
   createAntigravityWorkspaceResolver,
   readLocalAntigravityHistory,
@@ -82,7 +83,7 @@ export async function scanAiVaultSessions(
     const discoveries = await discoverAiVaultSessionSources({ options, limitPerAgent, issues })
     throwIfAiVaultScanCancelled(options.signal)
 
-    const candidates = dedupeCodexRolloutFileAliases(
+    const candidates = await dedupeCodexRolloutAliases(
       discoveries
         .flatMap((discovery) =>
           discovery.files.map((file): SessionFileCandidate => ({
@@ -107,7 +108,8 @@ export async function scanAiVaultSessions(
         getFilePath: (candidate) => candidate.file.path,
         getCodexHome: (candidate) => candidate.codexHome,
         getHardlinkIdentity: (candidate) => codexRolloutHardlinkIdentity(candidate.file)
-      }
+      },
+      readCodexRolloutSessionMetaId
     )
 
     const parsedSessions = await parseSessionCandidates({

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -147,6 +147,7 @@ export async function scanAiVaultSessions(
     span.setAttribute('reused', parseStats.reused)
     span.setAttribute('incremental', parseStats.incremental)
     span.setAttribute('fullParses', parseStats.fullParses)
+    span.setAttribute('earlyStopped', parseStats.earlyStopped)
     span.setAttribute('bytesRead', parseStats.bytesRead)
     span.setAttribute('issues', issues.length)
 

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -109,7 +109,8 @@ export async function scanAiVaultSessions(
         getCodexHome: (candidate) => candidate.codexHome,
         getHardlinkIdentity: (candidate) => codexRolloutHardlinkIdentity(candidate.file)
       },
-      readCodexRolloutSessionMetaId
+      (filePath) => readCodexRolloutSessionMetaId(filePath, options.signal),
+      options.signal
     )
 
     const parsedSessions = await parseSessionCandidates({

--- a/src/main/codex/codex-rollout-session-meta.test.ts
+++ b/src/main/codex/codex-rollout-session-meta.test.ts
@@ -74,4 +74,20 @@ describe('readCodexRolloutSessionMetaId', () => {
       undefined
     )
   })
+
+  it('surfaces an aborted read instead of reporting an unprovable rollout', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-codex-session-meta-'))
+    tempRoots.push(root)
+    const rollout = join(root, 'rollout.jsonl')
+    await writeFile(rollout, JSON.stringify({ type: 'session_meta', payload: { id: 'aborted' } }))
+    const controller = new AbortController()
+    mocks.readTranscriptSlice.mockImplementationOnce(async () => {
+      controller.abort()
+      throw new Error('aborted')
+    })
+
+    await expect(readCodexRolloutSessionMetaId(rollout, controller.signal)).rejects.toThrow(
+      'aborted'
+    )
+  })
 })

--- a/src/main/codex/codex-rollout-session-meta.test.ts
+++ b/src/main/codex/codex-rollout-session-meta.test.ts
@@ -1,0 +1,36 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { readCodexRolloutSessionMetaId } from './codex-rollout-session-meta'
+
+let tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
+  tempRoots = []
+})
+
+describe('readCodexRolloutSessionMetaId', () => {
+  it('reads the session id from the first rollout record', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-codex-session-meta-'))
+    tempRoots.push(root)
+    const rollout = join(root, 'rollout.jsonl')
+    await writeFile(
+      rollout,
+      `${JSON.stringify({ type: 'session_meta', payload: { id: 'session-id' } })}\nignored`
+    )
+
+    await expect(readCodexRolloutSessionMetaId(rollout)).resolves.toBe('session-id')
+  })
+
+  it('returns null for a missing or malformed rollout', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-codex-session-meta-'))
+    tempRoots.push(root)
+    const malformed = join(root, 'malformed.jsonl')
+    await writeFile(malformed, '{"type":"session_meta"')
+
+    await expect(readCodexRolloutSessionMetaId(join(root, 'missing.jsonl'))).resolves.toBeNull()
+    await expect(readCodexRolloutSessionMetaId(malformed)).resolves.toBeNull()
+  })
+})

--- a/src/main/codex/codex-rollout-session-meta.test.ts
+++ b/src/main/codex/codex-rollout-session-meta.test.ts
@@ -47,7 +47,7 @@ describe('readCodexRolloutSessionMetaId', () => {
   // Why: AI Vault hands this every scan candidate, so a `\\wsl.localhost\...`
   // rollout must fail on the transcript gate's deadline rather than block the
   // scan behind a stalled distro (#15453).
-  it('reads through the gated transcript filesystem with the scan signal', async () => {
+  it('reads through the gated transcript filesystem at interactive priority', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-codex-session-meta-'))
     tempRoots.push(root)
     const rollout = join(root, 'rollout.jsonl')
@@ -56,12 +56,22 @@ describe('readCodexRolloutSessionMetaId', () => {
 
     await expect(readCodexRolloutSessionMetaId(rollout, controller.signal)).resolves.toBe('gated')
 
+    // Default `exact`: the live-resume proof is interactive and must not queue
+    // behind an AI Vault sweep of the same WSL distro.
     expect(mocks.readTranscriptSlice).toHaveBeenCalledWith(
       rollout,
       0,
       expect.any(Number),
-      'scan',
+      'exact',
       controller.signal
+    )
+    await expect(readCodexRolloutSessionMetaId(rollout, undefined, 'scan')).resolves.toBe('gated')
+    expect(mocks.readTranscriptSlice).toHaveBeenLastCalledWith(
+      rollout,
+      0,
+      expect.any(Number),
+      'scan',
+      undefined
     )
   })
 })

--- a/src/main/codex/codex-rollout-session-meta.test.ts
+++ b/src/main/codex/codex-rollout-session-meta.test.ts
@@ -1,12 +1,22 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as WslFsAccessModule from '../native-chat/wsl-transcript-fs-access'
 import { readCodexRolloutSessionMetaId } from './codex-rollout-session-meta'
+
+const mocks = vi.hoisted(() => ({ readTranscriptSlice: vi.fn() }))
+
+vi.mock('../native-chat/wsl-transcript-fs-access', async (importOriginal) => {
+  const original = await importOriginal<typeof WslFsAccessModule>()
+  mocks.readTranscriptSlice.mockImplementation(original.readTranscriptSlice)
+  return { ...original, readTranscriptSlice: mocks.readTranscriptSlice }
+})
 
 let tempRoots: string[] = []
 
 afterEach(async () => {
+  mocks.readTranscriptSlice.mockClear()
   await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
   tempRoots = []
 })
@@ -32,5 +42,26 @@ describe('readCodexRolloutSessionMetaId', () => {
 
     await expect(readCodexRolloutSessionMetaId(join(root, 'missing.jsonl'))).resolves.toBeNull()
     await expect(readCodexRolloutSessionMetaId(malformed)).resolves.toBeNull()
+  })
+
+  // Why: AI Vault hands this every scan candidate, so a `\\wsl.localhost\...`
+  // rollout must fail on the transcript gate's deadline rather than block the
+  // scan behind a stalled distro (#15453).
+  it('reads through the gated transcript filesystem with the scan signal', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-codex-session-meta-'))
+    tempRoots.push(root)
+    const rollout = join(root, 'rollout.jsonl')
+    await writeFile(rollout, JSON.stringify({ type: 'session_meta', payload: { id: 'gated' } }))
+    const controller = new AbortController()
+
+    await expect(readCodexRolloutSessionMetaId(rollout, controller.signal)).resolves.toBe('gated')
+
+    expect(mocks.readTranscriptSlice).toHaveBeenCalledWith(
+      rollout,
+      0,
+      expect.any(Number),
+      'scan',
+      controller.signal
+    )
   })
 })

--- a/src/main/codex/codex-rollout-session-meta.ts
+++ b/src/main/codex/codex-rollout-session-meta.ts
@@ -21,7 +21,12 @@ export async function readCodexRolloutSessionMetaId(
     // listed rollout may also vanish before it is read — Codex prunes and
     // rewrites these files — and one missing file must not abort the scan.
     head = await readTranscriptSlice(filePath, 0, ROLLOUT_READ_LIMIT, priority, signal)
-  } catch {
+  } catch (error) {
+    // A cancelled scan must surface as cancellation, not as one more rollout
+    // that could not prove its id.
+    if (signal?.aborted) {
+      throw error
+    }
     return null
   }
   const firstLine = head.toString('utf8').split(/\r?\n/, 1)[0]?.trim()

--- a/src/main/codex/codex-rollout-session-meta.ts
+++ b/src/main/codex/codex-rollout-session-meta.ts
@@ -1,0 +1,45 @@
+import { open } from 'node:fs/promises'
+
+const ROLLOUT_READ_LIMIT = 64 * 1024
+
+/** Read the Codex session id without streaming the full rollout transcript. */
+export async function readCodexRolloutSessionMetaId(filePath: string): Promise<string | null> {
+  // A listed rollout may vanish before it is read — Codex prunes and rewrites
+  // these files. One missing file must not abort the whole scan.
+  let file: Awaited<ReturnType<typeof open>>
+  try {
+    file = await open(filePath, 'r')
+  } catch {
+    return null
+  }
+  try {
+    const buffer = Buffer.alloc(ROLLOUT_READ_LIMIT)
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
+    const firstLine = buffer.subarray(0, bytesRead).toString('utf8').split(/\r?\n/, 1)[0]?.trim()
+    if (!firstLine) {
+      return null
+    }
+    const record = JSON.parse(firstLine) as {
+      type?: unknown
+      id?: unknown
+      session_id?: unknown
+      thread_id?: unknown
+      payload?: { id?: unknown; session_id?: unknown; thread_id?: unknown }
+    }
+    if (record.type !== 'session_meta') {
+      return null
+    }
+    const id =
+      record.payload?.id ??
+      record.payload?.session_id ??
+      record.payload?.thread_id ??
+      record.id ??
+      record.session_id ??
+      record.thread_id
+    return typeof id === 'string' && id.length > 0 ? id : null
+  } catch {
+    return null
+  } finally {
+    await file.close()
+  }
+}

--- a/src/main/codex/codex-rollout-session-meta.ts
+++ b/src/main/codex/codex-rollout-session-meta.ts
@@ -1,11 +1,17 @@
 import { readTranscriptSlice } from '../native-chat/wsl-transcript-fs-access'
+import type { WslTranscriptFsTaskPriority } from '../native-chat/wsl-transcript-fs-gate'
 
 const ROLLOUT_READ_LIMIT = 64 * 1024
 
-/** Read the Codex session id without streaming the full rollout transcript. */
+/**
+ * Read the Codex session id without streaming the full rollout transcript.
+ * Defaults to `exact` because the live-resume proof is interactive; the AI
+ * Vault scan passes `scan` so a bulk sweep cannot starve it.
+ */
 export async function readCodexRolloutSessionMetaId(
   filePath: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  priority: WslTranscriptFsTaskPriority = 'exact'
 ): Promise<string | null> {
   let head: Buffer
   try {
@@ -14,7 +20,7 @@ export async function readCodexRolloutSessionMetaId(
     // transcript gate's deadline instead of blocking the scan (#15453). A
     // listed rollout may also vanish before it is read — Codex prunes and
     // rewrites these files — and one missing file must not abort the scan.
-    head = await readTranscriptSlice(filePath, 0, ROLLOUT_READ_LIMIT, 'scan', signal)
+    head = await readTranscriptSlice(filePath, 0, ROLLOUT_READ_LIMIT, priority, signal)
   } catch {
     return null
   }

--- a/src/main/codex/codex-rollout-session-meta.ts
+++ b/src/main/codex/codex-rollout-session-meta.ts
@@ -1,24 +1,28 @@
-import { open } from 'node:fs/promises'
+import { readTranscriptSlice } from '../native-chat/wsl-transcript-fs-access'
 
 const ROLLOUT_READ_LIMIT = 64 * 1024
 
 /** Read the Codex session id without streaming the full rollout transcript. */
-export async function readCodexRolloutSessionMetaId(filePath: string): Promise<string | null> {
-  // A listed rollout may vanish before it is read — Codex prunes and rewrites
-  // these files. One missing file must not abort the whole scan.
-  let file: Awaited<ReturnType<typeof open>>
+export async function readCodexRolloutSessionMetaId(
+  filePath: string,
+  signal?: AbortSignal
+): Promise<string | null> {
+  let head: Buffer
   try {
-    file = await open(filePath, 'r')
+    // Gated, not raw fs: AI Vault hands this every scan candidate, including
+    // `\\wsl.localhost\...` rollouts, so a stalled distro must fail on the
+    // transcript gate's deadline instead of blocking the scan (#15453). A
+    // listed rollout may also vanish before it is read — Codex prunes and
+    // rewrites these files — and one missing file must not abort the scan.
+    head = await readTranscriptSlice(filePath, 0, ROLLOUT_READ_LIMIT, 'scan', signal)
   } catch {
     return null
   }
+  const firstLine = head.toString('utf8').split(/\r?\n/, 1)[0]?.trim()
+  if (!firstLine) {
+    return null
+  }
   try {
-    const buffer = Buffer.alloc(ROLLOUT_READ_LIMIT)
-    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
-    const firstLine = buffer.subarray(0, bytesRead).toString('utf8').split(/\r?\n/, 1)[0]?.trim()
-    if (!firstLine) {
-      return null
-    }
     const record = JSON.parse(firstLine) as {
       type?: unknown
       id?: unknown
@@ -39,7 +43,5 @@ export async function readCodexRolloutSessionMetaId(filePath: string): Promise<s
     return typeof id === 'string' && id.length > 0 ? id : null
   } catch {
     return null
-  } finally {
-    await file.close()
   }
 }

--- a/src/main/codex/codex-tui-rollout-proof.ts
+++ b/src/main/codex/codex-tui-rollout-proof.ts
@@ -1,7 +1,7 @@
-import { open } from 'node:fs/promises'
 import { join } from 'node:path'
 import { stripAnsiEscapeSequences } from '../../shared/ansi-escape-sequences'
 import { relativePathInsideRoot } from '../../shared/cross-platform-path'
+import { readCodexRolloutSessionMetaId } from './codex-rollout-session-meta'
 import { listCodexSessionJsonlFilesIncrementally } from './codex-session-file-listing'
 
 const SESSION_ID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
@@ -9,7 +9,6 @@ const STATUS_SESSION_RE = new RegExp(
   `\\b(?:Session|Thread)(?:\\s+ID)?\\s*:\\s*(${SESSION_ID_PATTERN})\\b`,
   'gi'
 )
-const ROLLOUT_READ_LIMIT = 64 * 1024
 const STATUS_COMMAND_PASTE = '\u001b[200~/status\u001b[201~'
 const KITTY_ENTER = '\u001b[13u'
 const TAB = '\t'
@@ -203,45 +202,4 @@ export async function resolveLiveCodexTuiRollout(input: {
     await delay(100)
   }
   throw new Error('The agent terminal did not publish a resumable Codex conversation.')
-}
-
-async function readCodexRolloutSessionMetaId(filePath: string): Promise<string | null> {
-  // A listed rollout may vanish before it is read — Codex prunes and rewrites
-  // these files. One missing file must not abort the whole scan.
-  let file: Awaited<ReturnType<typeof open>>
-  try {
-    file = await open(filePath, 'r')
-  } catch {
-    return null
-  }
-  try {
-    const buffer = Buffer.alloc(ROLLOUT_READ_LIMIT)
-    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
-    const firstLine = buffer.subarray(0, bytesRead).toString('utf8').split(/\r?\n/, 1)[0]?.trim()
-    if (!firstLine) {
-      return null
-    }
-    const record = JSON.parse(firstLine) as {
-      type?: unknown
-      id?: unknown
-      session_id?: unknown
-      thread_id?: unknown
-      payload?: { id?: unknown; session_id?: unknown; thread_id?: unknown }
-    }
-    if (record.type !== 'session_meta') {
-      return null
-    }
-    const id =
-      record.payload?.id ??
-      record.payload?.session_id ??
-      record.payload?.thread_id ??
-      record.id ??
-      record.session_id ??
-      record.thread_id
-    return typeof id === 'string' && id.length > 0 ? id : null
-  } catch {
-    return null
-  } finally {
-    await file.close()
-  }
 }


### PR DESCRIPTION
## ELI5

Agent Session History was reading tens of gigabytes of Codex data that it already knew it would ignore. This PR stops that wasted work and keeps compatible parse caches usable across Orca updates.

## What Changed

- Stop resumable reads immediately after `session_meta` identifies an excluded worker transcript, instead of draining the file to EOF.
- Skip full decoding and `JSON.parse` for Codex records that cannot affect a visible session field. The skip set is the **complement of what `consumeCodexRecordLine` actually reads**, so teaching the parser a new record automatically narrows the fast path rather than silently diverging from it, and it only applies to records too large to have been decoded from the bounded prefix anyway — a sub-kilobyte record (a long opening prompt *is* the session title) still goes through the exact parser.
- Prove cross-volume Codex rollout aliases from a bounded `session_meta` read before full parsing. That read goes through the **WSL transcript FS gate**, carries the scan's `AbortSignal`, and fans out across contested candidates with bounded concurrency.
- Establish parse-cache schema 2 as the semantic compatibility boundary and reuse it across app versions.
- Report early-stopped transcripts as their own `aiVault.scan` attribute instead of folding them into `incremental`.
- Regression coverage for cache compatibility, native/WSL alias boundaries, reordered/prefix-ambiguous records, parser parity per record type, worker early-stop, and no-re-read-after-growth.

## Why

A large real Windows corpus repeatedly exceeded the 130-second AI Vault service deadline. The main cost was excluded worker transcripts: 1,011 files totaling about 18.3 GiB were recognized as workers on their first line but still drained to EOF. Large ignored `compacted` and tool-output records were also decoded and parsed. Separately, the persisted parse cache was discarded on every app update, so each release paid a full cold scan.

## Linked Issue

Fixes #17888. Related: #9210, #15453, #16251.

## Visual Proof

N/A — backend scanner/cache behavior only; no UI or interaction changes.

## Testing

**Synthetic 336 MiB corpus (24 excluded worker transcripts + 4 user sessions, 12 × 1 MiB tool-output records each), `origin/main` vs this branch, same harness on each host:**

| Platform | bytes read (main → PR) | elapsed (main → PR) |
| --- | --- | --- |
| macOS 26 (darwin, arm64) | 336.0 → 49.5 MiB | 334 → 228 ms |
| Ubuntu 24.04 (linux, x64, over SSH) | 336.0 → 49.5 MiB | 293 → 56 ms |
| Windows 11 (win32, x64) | 336.0 → 49.5 MiB | 501 → 75 ms |

Read volume drops 85% identically on all three platforms; the residue is exactly the 4 real sessions plus one 64 KiB chunk per dismissed worker.

**Suites:**

- macOS: `pnpm tc` clean, `oxlint` clean, `src/main/ai-vault` 512/512.
- Ubuntu (openclaw, over SSH): `src/main/ai-vault` + `src/main/codex` 1653 passed / 0 failed.
- Windows 11 (awin, via Orca remote): the set of failing test files is **byte-identical to `origin/main`** (11 files, `comm` diff empty in both directions — pre-existing POSIX-path-literal failures in tests unrelated to this PR). The changed-area suites pass 64/64.
- Original reporter's real corpus: pre-fix cancelled at the 130 s deadline; post-fix 58.6 s, 244 sessions, 0 issues, 29 MiB heap / 252 MiB RSS.

## Review

Pullfrog raised one Important finding — `readCodexRolloutSessionMetaId` bypassed the WSL transcript FS gate, which would have reintroduced the #15453 stall class on every scan candidate. Fixed: it now reads through `readTranscriptSlice`, defaults to `exact` gate priority so the interactive Codex TUI resume proof cannot queue behind a scan, and the AI Vault sweep opts into `scan`.

A four-model findings-severity counsel (Grok, GPT-5.6-sol high, Claude Opus high, Claude Fable high) rated the two remaining candidate findings **valid, P2, unanimous, no revert**: cross-version cache reuse has no runtime field validation (fenced by `SCHEMA_VERSION` plus a `satisfies Record<keyof AiVaultSession, true>` build-time ratchet), and the early-stop stat accounting (addressed by the new `earlyStopped` counter). No P0/P1.

## AI Disclosure

OpenAI Codex was used for the original diagnosis, implementation, and tests. Claude Opus performed the follow-up review, hardening, and cross-platform verification.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer material.

## Notes

- Cache schema 1 is intentionally invalidated once because parser semantics changed after it was introduced; schema 2 is reusable across app versions until cached semantics change. The `keyof AiVaultSession` ratchet fails the build on a shape change so the `SCHEMA_VERSION` decision is deliberate.
- Native and separate WSL execution namespaces remain isolated.
- No UI, IPC, remote wire, watchdog, transcript-write, or sensitive logging changes. The remote/SSH scan path (`parseCodexSessionContent`) is untouched — the fast path lives only in the local resumable byte reader.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (verified on macOS, Ubuntu-over-SSH, and Windows)
- [x] Focused tests, typecheck, lint, and real-corpus verification pass; full build/test run in CI

---

Original implementation by @djegor315-sketch (#17888 diagnosis, worker early-stop, schema-2 cache, cross-volume proof). Follow-up hardening, cross-platform verification, and review-loop by @nwparker.
