### PR TITLE
fix(persistence): sweep rows owned by deregistered repo ids at load

### DIFF
--- a/src/main/orca-profiles/profile-project-worktree-identity.ts
+++ b/src/main/orca-profiles/profile-project-worktree-identity.ts
@@ -66,15 +66,18 @@ export function rekeyOwnerKey(
   return null
 }
 
-export function ownerKeyBelongsToRepo(ownerKey: string, repoId: string): boolean {
-  const rawOwnerKey = isWorktreeHostIdentity(ownerKey)
-    ? getWorktreeIdFromHostIdentity(ownerKey)
-    : ownerKey
-  if (isRepoWorktreeId(repoId, rawOwnerKey)) {
-    return true
+/** The worktree locator an owner key names, or null when the key is not worktree-scoped. */
+export function ownerKeyWorktreeId(ownerKey: string): string | null {
+  const scope = parseWorkspaceKey(ownerKey)
+  if (scope) {
+    return scope.type === 'worktree' ? scope.worktreeId : null
   }
-  const parsed = parseWorkspaceKey(ownerKey)
-  return parsed?.type === 'worktree' && isRepoWorktreeId(repoId, parsed.worktreeId)
+  return isWorktreeHostIdentity(ownerKey) ? getWorktreeIdFromHostIdentity(ownerKey) : ownerKey
+}
+
+export function ownerKeyBelongsToRepo(ownerKey: string, repoId: string): boolean {
+  const worktreeId = ownerKeyWorktreeId(ownerKey)
+  return worktreeId !== null && isRepoWorktreeId(repoId, worktreeId)
 }
 
 export function removeRepoWorktreeRecord<T>(

--- a/src/main/orca-profiles/profile-project-worktree-identity.ts
+++ b/src/main/orca-profiles/profile-project-worktree-identity.ts
@@ -66,18 +66,33 @@ export function rekeyOwnerKey(
   return null
 }
 
-/** The worktree locator an owner key names, or null when the key is not worktree-scoped. */
-export function ownerKeyWorktreeId(ownerKey: string): string | null {
+/**
+ * Every worktree locator an owner key could name.
+ *
+ * Two readings, because one key can be both: with a repo literally named `worktree`,
+ * `worktree::/p` is a `<repoId>::<path>` locator AND parses as a `worktree:` workspace key naming
+ * repo `` (empty). `ownerKeyBelongsToRepo` accepts either, so a caller that reasons about a key
+ * without a repo id in hand has to consider both or it will disagree with the predicate.
+ */
+export function ownerKeyWorktreeIds(ownerKey: string): string[] {
+  const rawOwnerKey = isWorktreeHostIdentity(ownerKey)
+    ? getWorktreeIdFromHostIdentity(ownerKey)
+    : ownerKey
   const scope = parseWorkspaceKey(ownerKey)
-  if (scope) {
-    return scope.type === 'worktree' ? scope.worktreeId : null
-  }
-  return isWorktreeHostIdentity(ownerKey) ? getWorktreeIdFromHostIdentity(ownerKey) : ownerKey
+  return scope?.type === 'worktree' && scope.worktreeId !== rawOwnerKey
+    ? [rawOwnerKey, scope.worktreeId]
+    : [rawOwnerKey]
 }
 
 export function ownerKeyBelongsToRepo(ownerKey: string, repoId: string): boolean {
-  const worktreeId = ownerKeyWorktreeId(ownerKey)
-  return worktreeId !== null && isRepoWorktreeId(repoId, worktreeId)
+  const rawOwnerKey = isWorktreeHostIdentity(ownerKey)
+    ? getWorktreeIdFromHostIdentity(ownerKey)
+    : ownerKey
+  if (isRepoWorktreeId(repoId, rawOwnerKey)) {
+    return true
+  }
+  const parsed = parseWorkspaceKey(ownerKey)
+  return parsed?.type === 'worktree' && isRepoWorktreeId(repoId, parsed.worktreeId)
 }
 
 export function removeRepoWorktreeRecord<T>(

--- a/src/main/persistence-cohort-and-identity-migration.test.ts
+++ b/src/main/persistence-cohort-and-identity-migration.test.ts
@@ -397,6 +397,8 @@ describe('Store.migrateWorktreeIdentity', () => {
 
   it('moves persisted mobile selections across reloads', async () => {
     const store = await createStore()
+    // Registered on purpose: rows owned by an unregistered repo id are swept as orphans on load.
+    store.addRepo(makeRepo({ id: 'repo1', path: '/repo1' }))
     store.setMobileClientTabSelections({
       'device-a': {
         [OLD]: { activeTabId: 'tab-1', activeGroupId: null, activeTabIdByGroupId: {} }

--- a/src/main/persistence-cross-host-pane-identity.test.ts
+++ b/src/main/persistence-cross-host-pane-identity.test.ts
@@ -10,6 +10,7 @@ import {
   createStore,
   writeDataFile,
   readDataFile,
+  makeRepo,
   makeTerminalTab
 } from './persistence-test-harness'
 
@@ -53,6 +54,11 @@ describe('cross-host pane identity migration', () => {
   it('refuses hostless alias and acknowledgement rewrites for a tab id two partitions share', async () => {
     writeDataFile({
       schemaVersion: 1,
+      // Registered on purpose: rows owned by an unregistered repo id are swept as orphans on load.
+      repos: [
+        makeRepo({ id: 'repo-local', path: '/repo-local' }),
+        makeRepo({ id: 'repo-a', path: '/repo-a' })
+      ],
       workspaceSession: makeLegacyPaneSession('repo-local', 'local-pty'),
       workspaceSessionsByHostId: {
         'ssh:host-a': makeLegacyPaneSession('repo-a', 'pty-a')

--- a/src/main/persistence-deregistered-repo-residue.test.ts
+++ b/src/main/persistence-deregistered-repo-residue.test.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { getDefaultWorkspaceSession } from '../shared/constants'
 import { composeWorktreeHostIdentity } from '../shared/worktree/host-qualified-identity'
-import { folderWorkspaceKey } from '../shared/workspace-scope'
+import { folderWorkspaceKey, worktreeWorkspaceKey } from '../shared/workspace-scope'
 import type { PersistedState } from '../shared/persisted-state-types'
 import {
   testState,
@@ -182,6 +182,40 @@ describe('deregistered repo residue', () => {
 
     // Self-clearing: with the residue gone nothing re-seeds the orphan id, so the next launch has
     // no work. Before the fix this stayed non-empty forever and every load scheduled another save.
+    const reloaded = await createStore()
+    expect(reloaded.sweepDeregisteredRepoResidue()).toEqual([])
+  })
+
+  // The session scalars are pruned by bespoke rules, not by owner key, so no owner-key loop reaches
+  // them. Each has to be able to seed the sweep on its own or an orphan named only there is stuck.
+  it.each([
+    { label: 'activeWorktreeId', session: { activeWorktreeId: GONE_WORKTREE } },
+    // Canonical `worktree:<id>` form, which needs unwrapping before the repo id is visible.
+    {
+      label: 'activeWorkspaceKey',
+      session: { activeWorkspaceKey: worktreeWorkspaceKey(GONE_WORKTREE) }
+    },
+    {
+      label: 'activeWorktreeIdsOnShutdown',
+      session: { activeWorktreeIdsOnShutdown: [GONE_WORKTREE] }
+    }
+  ])("clears $label when it is the orphan repo's only residue", async ({ session }) => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [makeRepo({ id: LIVE_REPO, path: '/workspace/live' })],
+      worktreeMeta: {},
+      workspaceSessionsByHostId: {
+        [RUNTIME_HOST]: { ...getDefaultWorkspaceSession(), ...session }
+      }
+    })
+
+    const store = await createStore()
+    store.flush()
+
+    const partition = store.getWorkspaceSession(RUNTIME_HOST)
+    expect(partition.activeWorktreeId ?? null).toBeNull()
+    expect(partition.activeWorkspaceKey ?? null).toBeNull()
+    expect(partition.activeWorktreeIdsOnShutdown ?? []).toEqual([])
     const reloaded = await createStore()
     expect(reloaded.sweepDeregisteredRepoResidue()).toEqual([])
   })

--- a/src/main/persistence-deregistered-repo-residue.test.ts
+++ b/src/main/persistence-deregistered-repo-residue.test.ts
@@ -1,0 +1,176 @@
+// Why this file exists: deregistering a project used to strand every row it owned. No sweeper could
+// reach them -- the missing-directory prune is gated on the repo still being registered, and a
+// paired client's mirror of a remote host's rows is keyed by ids that client never registers, so the
+// owning host's removal never reached it (#17776).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { rmSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { getDefaultWorkspaceSession } from '../shared/constants'
+import { composeWorktreeHostIdentity } from '../shared/worktree/host-qualified-identity'
+import { folderWorkspaceKey } from '../shared/workspace-scope'
+import type { PersistedState } from '../shared/persisted-state-types'
+import {
+  testState,
+  createStore,
+  writeDataFile,
+  readDataFile,
+  makeRepo,
+  makeTerminalTab
+} from './persistence-test-harness'
+
+vi.mock('./ssh/ssh-config-parser', () => ({
+  loadUserSshConfig: vi.fn(),
+  sshConfigHostsToTargets: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: { isEncryptionAvailable: () => false }
+}))
+
+vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('./telemetry/cohort-classifier', () => ({ getCohortAtEmit: vi.fn().mockReturnValue({}) }))
+
+const LIVE_REPO = 'live-repo'
+const GONE_REPO = 'gone-repo'
+const LIVE_WORKTREE = `${LIVE_REPO}::/workspace/live`
+const GONE_WORKTREE = `${GONE_REPO}::/workspace/orphan`
+const RUNTIME_HOST = 'runtime:env-a'
+
+const sessionFor = (worktreeId: string, tabId = 'tab-1') => ({
+  ...getDefaultWorkspaceSession(),
+  tabsByWorktree: {
+    [worktreeId]: [makeTerminalTab({ id: tabId, worktreeId })]
+  },
+  activeTabTypeByWorktree: { [worktreeId]: 'terminal' as const },
+  lastVisitedAtByWorktreeId: { [worktreeId]: 123 },
+  // The residue `profile-project-session-field-disposition` flags as leaking on repo removal.
+  sleepingAgentSessionsByPaneKey: {
+    [`${tabId}:leaf-1`]: {
+      paneKey: `${tabId}:leaf-1`,
+      tabId,
+      worktreeId,
+      agent: 'codex' as const,
+      providerSession: { key: 'session_id' as const, id: 'sess-1' },
+      prompt: 'sleeping',
+      state: 'waiting' as const,
+      capturedAt: 1,
+      updatedAt: 1,
+      origin: 'worktree-sleep' as const
+    }
+  }
+})
+
+describe('deregistered repo residue', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-orphan-sweep-'))
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('drops metadata, identity rows and sessions owned by an unregistered repo id', async () => {
+    const seed = await createStore()
+    seed.addRepo(makeRepo({ id: LIVE_REPO, path: '/workspace/live' }))
+    seed.addRepo(makeRepo({ id: GONE_REPO, path: '/workspace/orphan' }))
+    seed.setWorktreeMetaForHost(LIVE_WORKTREE, 'local', { displayName: 'Live' })
+    seed.setWorktreeMetaForHost(GONE_WORKTREE, 'local', { displayName: 'Orphan' })
+    seed.setWorkspaceSession(sessionFor(GONE_WORKTREE), 'local')
+    seed.flush()
+
+    // Deregister by hand: the point is that a row can outlive its repo however that happened.
+    const persisted = readDataFile() as PersistedState
+    persisted.repos = persisted.repos.filter((repo) => repo.id !== GONE_REPO)
+    writeDataFile(persisted)
+
+    const reloaded = await createStore()
+    reloaded.flush()
+    const swept = readDataFile() as PersistedState
+
+    expect(Object.keys(swept.worktreeMeta)).toEqual([LIVE_WORKTREE])
+    expect(swept.worktreeIdentityAliases).not.toHaveProperty(
+      composeWorktreeHostIdentity('local', GONE_WORKTREE)
+    )
+    expect(Object.keys(swept.worktreeMetaByIdentity ?? {})).toHaveLength(1)
+    const session = swept.workspaceSession
+    expect(session.tabsByWorktree).toEqual({})
+    expect(session.lastVisitedAtByWorktreeId).toEqual({})
+    expect(session.activeTabTypeByWorktree).toEqual({})
+    expect(session.sleepingAgentSessionsByPaneKey ?? {}).toEqual({})
+  })
+
+  it("sweeps a remote host's session partition the owning host's removal can never reach", async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [makeRepo({ id: LIVE_REPO, path: '/workspace/live' })],
+      worktreeMeta: {},
+      workspaceSessionsByHostId: {
+        [RUNTIME_HOST]: sessionFor(GONE_WORKTREE)
+      }
+    })
+
+    const store = await createStore()
+    store.flush()
+
+    const partition = store.getWorkspaceSession(RUNTIME_HOST)
+    expect(partition.tabsByWorktree).toEqual({})
+    expect(partition.activeTabTypeByWorktree).toEqual({})
+  })
+
+  it('keeps rows for every registered repo, on any execution host', async () => {
+    const remoteWorktree = `${LIVE_REPO}::/home/user/remote`
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [makeRepo({ id: LIVE_REPO, path: '/home/user/live', executionHostId: RUNTIME_HOST })],
+      worktreeMeta: { [remoteWorktree]: { hostId: RUNTIME_HOST, status: 'active' } },
+      workspaceSessionsByHostId: { [RUNTIME_HOST]: sessionFor(remoteWorktree) }
+    })
+
+    const store = await createStore()
+
+    expect(store.getWorktreeMeta(remoteWorktree)).toBeDefined()
+    const partition = store.getWorkspaceSession(RUNTIME_HOST)
+    expect(partition.tabsByWorktree[remoteWorktree]).toHaveLength(1)
+    // Also proves the sleeping-agent fixture is well-formed, so the sweep assertions above bite.
+    expect(Object.keys(partition.sleepingAgentSessionsByPaneKey ?? {})).toHaveLength(1)
+  })
+
+  it('leaves folder-workspace session rows alone: their keys name no repo', async () => {
+    const workspaceKey = folderWorkspaceKey('folder-1')
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      workspaceSession: {
+        ...getDefaultWorkspaceSession(),
+        lastVisitedAtByWorktreeId: { [workspaceKey]: 7 }
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getWorkspaceSession('local').lastVisitedAtByWorktreeId).toEqual({
+      [workspaceKey]: 7
+    })
+  })
+
+  // Why: a sweep that dirtied every launch would rewrite the profile forever and mask real changes.
+  it('leaves a profile with no orphans byte-identical across reloads', async () => {
+    const seed = await createStore()
+    seed.addRepo(makeRepo({ id: LIVE_REPO, path: '/workspace/live' }))
+    seed.setWorktreeMetaForHost(LIVE_WORKTREE, 'local', { displayName: 'Live' })
+    seed.setWorkspaceSession(sessionFor(LIVE_WORKTREE), 'local')
+    seed.flush()
+
+    const canonicalizing = await createStore()
+    canonicalizing.flush()
+    const canonical = JSON.stringify(readDataFile())
+
+    const reloaded = await createStore()
+    reloaded.flush()
+
+    expect(JSON.stringify(readDataFile())).toBe(canonical)
+  })
+})

--- a/src/main/persistence-deregistered-repo-residue.test.ts
+++ b/src/main/persistence-deregistered-repo-residue.test.ts
@@ -175,6 +175,10 @@ describe('deregistered repo residue', () => {
     const store = await createStore()
     store.flush()
     expect(store.getWorkspaceSession('local').sleepingAgentSessionsByPaneKey ?? {}).toEqual({})
+    // On disk, not just in memory: if the flush had not persisted the cleanup, the next load would
+    // silently redo it and the self-clearing assertion below would pass without meaning anything.
+    const persisted = readDataFile() as PersistedState
+    expect(persisted.workspaceSession.sleepingAgentSessionsByPaneKey ?? {}).toEqual({})
 
     // Self-clearing: with the residue gone nothing re-seeds the orphan id, so the next launch has
     // no work. Before the fix this stayed non-empty forever and every load scheduled another save.

--- a/src/main/persistence-deregistered-repo-residue.test.ts
+++ b/src/main/persistence-deregistered-repo-residue.test.ts
@@ -38,6 +38,21 @@ const LIVE_WORKTREE = `${LIVE_REPO}::/workspace/live`
 const GONE_WORKTREE = `${GONE_REPO}::/workspace/orphan`
 const RUNTIME_HOST = 'runtime:env-a'
 
+const sleepingAgentFor = (worktreeId: string, tabId = 'tab-1') => ({
+  [`${tabId}:leaf-1`]: {
+    paneKey: `${tabId}:leaf-1`,
+    tabId,
+    worktreeId,
+    agent: 'codex' as const,
+    providerSession: { key: 'session_id' as const, id: 'sess-1' },
+    prompt: 'sleeping',
+    state: 'waiting' as const,
+    capturedAt: 1,
+    updatedAt: 1,
+    origin: 'worktree-sleep' as const
+  }
+})
+
 const sessionFor = (worktreeId: string, tabId = 'tab-1') => ({
   ...getDefaultWorkspaceSession(),
   tabsByWorktree: {
@@ -46,20 +61,7 @@ const sessionFor = (worktreeId: string, tabId = 'tab-1') => ({
   activeTabTypeByWorktree: { [worktreeId]: 'terminal' as const },
   lastVisitedAtByWorktreeId: { [worktreeId]: 123 },
   // The residue `profile-project-session-field-disposition` flags as leaking on repo removal.
-  sleepingAgentSessionsByPaneKey: {
-    [`${tabId}:leaf-1`]: {
-      paneKey: `${tabId}:leaf-1`,
-      tabId,
-      worktreeId,
-      agent: 'codex' as const,
-      providerSession: { key: 'session_id' as const, id: 'sess-1' },
-      prompt: 'sleeping',
-      state: 'waiting' as const,
-      capturedAt: 1,
-      updatedAt: 1,
-      origin: 'worktree-sleep' as const
-    }
-  }
+  sleepingAgentSessionsByPaneKey: sleepingAgentFor(worktreeId, tabId)
 })
 
 describe('deregistered repo residue', () => {
@@ -154,6 +156,30 @@ describe('deregistered repo residue', () => {
     expect(store.getWorkspaceSession('local').lastVisitedAtByWorktreeId).toEqual({
       [workspaceKey]: 7
     })
+  })
+
+  // Regression: the pane-keyed records are pruned by the worktreeId they name, not by their own key,
+  // so an orphan whose ONLY residue is a sleeping agent survived -- and re-seeded the sweep on every
+  // launch, so the store never self-cleared and every load scheduled another save.
+  it("drops a sleeping agent that is the orphan repo's only residue, and self-clears", async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [makeRepo({ id: LIVE_REPO, path: '/workspace/live' })],
+      worktreeMeta: {},
+      workspaceSession: {
+        ...getDefaultWorkspaceSession(),
+        sleepingAgentSessionsByPaneKey: sleepingAgentFor(GONE_WORKTREE)
+      }
+    })
+
+    const store = await createStore()
+    store.flush()
+    expect(store.getWorkspaceSession('local').sleepingAgentSessionsByPaneKey ?? {}).toEqual({})
+
+    // Self-clearing: with the residue gone nothing re-seeds the orphan id, so the next launch has
+    // no work. Before the fix this stayed non-empty forever and every load scheduled another save.
+    const reloaded = await createStore()
+    expect(reloaded.sweepDeregisteredRepoResidue()).toEqual([])
   })
 
   // Why: a sweep that dirtied every launch would rewrite the profile forever and mask real changes.

--- a/src/main/persistence-host-partitioned-sessions.test.ts
+++ b/src/main/persistence-host-partitioned-sessions.test.ts
@@ -123,6 +123,9 @@ describe('Store host-partitioned workspace sessions', () => {
     }
   })
 
+  // Registered on purpose: rows owned by an unregistered repo id are swept as orphans on load.
+  const makeRepos = (...repoIds: string[]) => repoIds.map((id) => makeRepo({ id, path: `/${id}` }))
+
   it('migrates a legacy workspaceSession blob into the local partition', async () => {
     writeDataFile({
       schemaVersion: 1,
@@ -194,6 +197,7 @@ describe('Store host-partitioned workspace sessions', () => {
     writeDataFile({
       schemaVersion: 1,
       workspaceSession: makeHostSession('local-repo'),
+      repos: makeRepos('repo-ssh'),
       workspaceSessionsByHostId: {
         'ssh:ssh-1': makeLegacyPaneHostSession('repo-ssh', 'remote-pty')
       },
@@ -224,6 +228,7 @@ describe('Store host-partitioned workspace sessions', () => {
     writeDataFile({
       schemaVersion: 1,
       workspaceSession: makeHostSession('local-repo'),
+      repos: makeRepos('repo-a', 'repo-b'),
       workspaceSessionsByHostId: {
         'ssh:host-a': makeLegacyPaneHostSession('repo-a', 'pty-a'),
         'ssh:host-b': makeLegacyPaneHostSession('repo-b', 'pty-b')
@@ -488,6 +493,7 @@ describe('Store host-partitioned workspace sessions', () => {
 
   it('removes one orphaned worktree with a host-scoped topology fence', async () => {
     const store = await createStore()
+    store.addRepo(makeRepo({ id: 'repo-gone', path: '/repo-gone' }))
     const worktreeId = 'repo-gone::/workspace/stale'
     const session = {
       ...makeHostSession('repo-gone'),
@@ -728,6 +734,7 @@ describe('Store host-partitioned workspace sessions', () => {
     const worktreeId = 'repo-1::/worktree'
     writeDataFile({
       schemaVersion: 1,
+      repos: makeRepos('repo-1'),
       workspaceSessionsByHostId: {
         'runtime:good': makeHostSession('good-repo'),
         // activeRepoId must be string|null; a number fails the zod parse.
@@ -753,6 +760,7 @@ describe('Store host-partitioned workspace sessions', () => {
     const worktreeId = 'repo-1::/worktree'
     writeDataFile({
       schemaVersion: 1,
+      repos: makeRepos('repo-1'),
       workspaceSession: {
         ...makeHostSession('local-repo'),
         // A projected/truncated write can leave a top-level field the wrong type;
@@ -813,6 +821,7 @@ describe('Store host-partitioned workspace sessions', () => {
     const worktreeId = 'repo-1::/worktree'
     const profile = await canonicalize({
       schemaVersion: 1,
+      repos: makeRepos('repo-1'),
       workspaceSession: {
         ...makeHostSession('local-repo'),
         tabsByWorktree: { [worktreeId]: [makeTerminalTab({ id: 'tab-keep', worktreeId })] }
@@ -845,6 +854,7 @@ describe('Store host-partitioned workspace sessions', () => {
     const worktreeId = 'repo-1::/worktree'
     const profile = await canonicalize({
       schemaVersion: 1,
+      repos: makeRepos('repo-1'),
       workspaceSessionsByHostId: {
         'runtime:env-a': {
           ...makeHostSession('runtime-repo'),

--- a/src/main/persistence-initial-load.test.ts
+++ b/src/main/persistence-initial-load.test.ts
@@ -150,6 +150,8 @@ describe('Store', () => {
 
   it('does not restore a terminal tab after its durable close flush returns', async () => {
     const store = await createStore()
+    // Registered on purpose: rows owned by an unregistered repo id are swept as orphans on load.
+    store.addRepo(makeRepo({ id: 'repo-1', path: '/repo-1' }))
     const worktreeId = 'repo-1::/tmp/worktree-1'
     const tabId = 'terminal-1'
     const session: WorkspaceSessionState = {

--- a/src/main/persistence-native-chat-tab-view-mode.test.ts
+++ b/src/main/persistence-native-chat-tab-view-mode.test.ts
@@ -58,7 +58,7 @@ describe('Store native-chat tab viewMode persistence', () => {
     const WORKTREE = 'repo1::/worktree'
     writeDataFile({
       schemaVersion: 1,
-      repos: [makeRepo()],
+      repos: [makeRepo({ id: 'repo1', path: '/repo1' })],
       worktreeMeta: {},
       settings: {},
       ui: {},

--- a/src/main/persistence-repo-lifecycle.test.ts
+++ b/src/main/persistence-repo-lifecycle.test.ts
@@ -737,7 +737,10 @@ describe('Store', () => {
 
   it('reassignSshTargetId persists a worktree-meta-only re-point (no matching repo)', async () => {
     const store = await createStore()
-    // A meta on the old SSH host with no repo row — the re-point must still be persisted, not memory-only.
+    // A meta on the old SSH host with no repo row for that host — the re-point must still be
+    // persisted, not memory-only. The repo id stays registered so the load-time orphan sweep,
+    // which only reads repo ids, leaves the row alone.
+    store.addRepo(makeRepo({ id: 'r1', path: '/r1' }))
     store.setWorktreeMeta('r1::/remote/wt', { displayName: 'wt', hostId: 'ssh:ssh-old' })
 
     const repoIds = store.reassignSshTargetId('ssh-old', 'ssh-new')
@@ -787,6 +790,7 @@ describe('Store', () => {
 
   it('reassignSshTargetId re-keys a session partition stored under the old ssh host id', async () => {
     const store = await createStore()
+    store.addRepo(makeRepo({ id: 'r1', path: '/r1' }))
     store.setWorkspaceSession(
       {
         activeRepoId: null,

--- a/src/main/persistence-settings-update.test.ts
+++ b/src/main/persistence-settings-update.test.ts
@@ -708,7 +708,7 @@ describe('Store', () => {
     }
     writeDataFile({
       schemaVersion: 1,
-      repos: [makeRepo()],
+      repos: [makeRepo({ id: 'repo1', path: '/repo1' })],
       worktreeMeta: {
         'repo1::/worktree-a': { status: 'active' },
         'repo1::/worktree-b': { status: 'active' }

--- a/src/main/persistence-ssh-targets-and-pane-keys.test.ts
+++ b/src/main/persistence-ssh-targets-and-pane-keys.test.ts
@@ -346,7 +346,7 @@ describe('Store', () => {
     const acknowledgedAt = 1_700_000_000_000
     writeDataFile({
       schemaVersion: 1,
-      repos: [makeRepo()],
+      repos: [makeRepo({ id: 'repo1', path: '/repo1' })],
       worktreeMeta: {},
       settings: {},
       ui: {
@@ -408,7 +408,7 @@ describe('Store', () => {
 
     writeDataFile({
       schemaVersion: 1,
-      repos: [makeRepo()],
+      repos: [makeRepo({ id: 'repo1', path: '/repo1' })],
       worktreeMeta: {},
       settings: {},
       ui: {

--- a/src/main/persistence-worktree-lineage-and-backups.test.ts
+++ b/src/main/persistence-worktree-lineage-and-backups.test.ts
@@ -166,6 +166,8 @@ describe('Store', () => {
   describe('mobileClientTabSelectionsByDeviceId', () => {
     it('persists device tab selections across reloads and drops malformed payloads', async () => {
       const store = await createStore()
+      // Registered on purpose: rows owned by an unregistered repo id are swept as orphans on load.
+      store.addRepo(makeRepo({ id: 'repo-1', path: '/repo-1' }))
       store.setMobileClientTabSelections({
         'device-a': {
           'repo-1::/tmp/wt': { activeTabId: 'tab-1', activeGroupId: 'g1', activeTabIdByGroupId: {} }
@@ -188,6 +190,7 @@ describe('Store', () => {
     it('prunes selections for a removed repo worktree', async () => {
       const store = await createStore()
       store.addRepo(makeRepo())
+      store.addRepo(makeRepo({ id: 'other-repo', path: '/other-repo' }))
       store.setMobileClientTabSelections({
         'device-a': {
           'r1::/tmp/wt': {

--- a/src/main/persistence/loading-store/repo-lifecycle-operations.ts
+++ b/src/main/persistence/loading-store/repo-lifecycle-operations.ts
@@ -12,10 +12,13 @@ import {
 import { mergeProjectHostSetupCompatibilityState } from '../tracking-repos/project-host-compatibility'
 import { RepoOrderPersistenceOperations } from '../tracking-repos/repo-order-operations'
 import { pruneWorktreeStateForRepo as pruneWorktreeStateForRepoOperation } from '../tracking-repos/repo-worktree-pruning'
+import { collectDeregisteredRepoIds } from '../tracking-repos/deregistered-repo-residue'
 import { hydrateRepo as hydrateRepoOperation } from '../tracking-repos/repo-hydration'
 import { RepoUpdatePersistenceOperations } from '../tracking-repos/repo-update-operations'
 import { ProjectHostSetupPersistenceOperations } from '../tracking-repos/project-host-setup-update'
 import { bumpLocalWorktreeScanGeneration } from '../../local-worktree-scan-generation'
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 
 import type { StoreRuntimeState } from './store-runtime-state'
 import type { WriteSchedulingOperations } from './write-scheduling'
@@ -129,6 +132,33 @@ export class RepoLifecycleOperations {
     scheduleSave(this[repoLifecycleOperationsContext].scheduling)
   }
 
+  /**
+   * Drop every persisted row owned by a repo id that is no longer registered.
+   *
+   * Runs at load because no removal path can: `removeProject` only fires while the repo is still in
+   * `state.repos`, and a paired client's mirror of a remote host's rows is keyed by ids that client
+   * never registers, so the owning host's removal never reaches it (#17776). An orphan has no owner
+   * that could object, so this ignores the session-ownership and local-execution-host gates the
+   * missing-directory sweeper needs.
+   */
+  sweepDeregisteredRepoResidue(): string[] {
+    const state = this[repoLifecycleOperationsContext].runtime.state
+    const orphanRepoIds = collectDeregisteredRepoIds(state)
+    if (orphanRepoIds.size === 0) {
+      return []
+    }
+    for (const repoId of orphanRepoIds) {
+      pruneWorktreeStateForRepo(this, repoId, null)
+      state.workspaceSession = removeRepoFromWorkspaceSession(state.workspaceSession, repoId)
+      state.workspaceSessionsByHostId = removeRepoFromHostWorkspaceSessions(
+        state.workspaceSessionsByHostId,
+        repoId
+      )
+    }
+    pruneDeregisteredRepoUiResidue(state.ui, orphanRepoIds)
+    return [...orphanRepoIds]
+  }
+
   updateRepo(
     id: string,
     updates: Partial<
@@ -208,6 +238,26 @@ export function pruneMobileClientTabSelections(
     if (Object.keys(selectionsByWorktree).length === 0) {
       delete owner[repoLifecycleOperationsContext].runtime.state
         .mobileClientTabSelectionsByDeviceId?.[clientNavigationId]
+    }
+  }
+}
+
+function pruneDeregisteredRepoUiResidue(
+  ui: PersistedState['ui'],
+  orphanRepoIds: ReadonlySet<string>
+): void {
+  const isOrphanWorktree = (worktreeId: string): boolean =>
+    orphanRepoIds.has(getRepoIdFromWorktreeId(worktreeId))
+  if (ui.lastActiveRepoId && orphanRepoIds.has(ui.lastActiveRepoId)) {
+    ui.lastActiveRepoId = null
+  }
+  if (ui.lastActiveWorktreeId && isOrphanWorktree(ui.lastActiveWorktreeId)) {
+    ui.lastActiveWorktreeId = null
+  }
+  ui.filterRepoIds = ui.filterRepoIds?.filter((repoId) => !orphanRepoIds.has(repoId)) ?? []
+  for (const worktreeId of Object.keys(ui.showDotfilesByWorktree ?? {})) {
+    if (isOrphanWorktree(worktreeId)) {
+      delete ui.showDotfilesByWorktree?.[worktreeId]
     }
   }
 }

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -64,6 +64,9 @@ export class Store {
     )
     const adaptedProjectGroups = this.domains.adaptation.adaptFlatFolderScanProjectGroups()
     this.domains.adaptation.hydrateFolderWorkspaceDiffComments()
+    // Load is the only place an orphaned repo id can be swept: every removal path needs the repo to
+    // still be registered, so rows outlive their owner without one (#17776).
+    const sweptRepoIds = this.domains.repos.sweepDeregisteredRepoResidue()
     for (const entry of normalized.migrationUnsupportedEntries) {
       setMigrationUnsupportedPty(entry)
     }
@@ -78,7 +81,12 @@ export class Store {
       this.state.legacyPaneKeyAliasEntries = entries
       scheduleSave(this.domains.scheduling)
     })
-    if (normalized.changed || this.runtime.loadNeedsSave || adaptedProjectGroups) {
+    if (
+      normalized.changed ||
+      this.runtime.loadNeedsSave ||
+      adaptedProjectGroups ||
+      sweptRepoIds.length > 0
+    ) {
       scheduleSave(this.domains.scheduling)
     }
   }

--- a/src/main/persistence/tracking-repos/deregistered-repo-residue.ts
+++ b/src/main/persistence/tracking-repos/deregistered-repo-residue.ts
@@ -3,7 +3,7 @@ import { getWorktreeIdFromHostIdentity } from '../../../shared/worktree/host-qua
 import { splitWorktreeId } from '../../../shared/worktree/id'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
 import { SESSION_FIELDS_PRUNED_BY_OWNER_KEY } from '../../orca-profiles/profile-project-session-field-disposition'
-import { ownerKeyWorktreeId } from '../../orca-profiles/profile-project-worktree-identity'
+import { ownerKeyWorktreeIds } from '../../orca-profiles/profile-project-worktree-identity'
 
 /**
  * Repo ids that still own persisted rows but no longer appear in `state.repos`.
@@ -24,8 +24,21 @@ export function collectDeregisteredRepoIds(state: PersistedState): Set<string> {
       orphanRepoIds.add(repoId)
     }
   }
+  /**
+   * Seed from an owner key, which can read as two different locators (see `ownerKeyWorktreeIds`).
+   * All or nothing: if either reading names a live repo the key is that repo's, and seeding the
+   * other reading would hand the removal pass -- which accepts either -- a live row to delete.
+   */
   const addOwnerKey = (ownerKey: string): void => {
-    addWorktreeId(ownerKeyWorktreeId(ownerKey))
+    const repoIds = ownerKeyWorktreeIds(ownerKey).flatMap((worktreeId) => {
+      const repoId = splitWorktreeId(worktreeId)?.repoId
+      return repoId ? [repoId] : []
+    })
+    if (repoIds.length > 0 && repoIds.every((repoId) => !liveRepoIds.has(repoId))) {
+      for (const repoId of repoIds) {
+        orphanRepoIds.add(repoId)
+      }
+    }
   }
 
   // Deliberately not seeded from `sparsePresetsByRepo` or `retiredWorktreeNamesByRepo`: both are
@@ -71,6 +84,19 @@ export function collectDeregisteredRepoIds(state: PersistedState): Set<string> {
     for (const ownerKey of Object.keys(session.browserTabsByWorktree ?? {})) {
       addOwnerKey(ownerKey)
     }
+    // Pruned by bespoke rules rather than by owner key, so the loop above never reaches them.
+    for (const ownerKey of [
+      session.activeWorktreeId,
+      session.activeWorkspaceKey,
+      ...(session.activeWorktreeIdsOnShutdown ?? [])
+    ]) {
+      if (ownerKey) {
+        addOwnerKey(ownerKey)
+      }
+    }
+    // Not seeded from `terminalTopologyRevisionByRepoId`: its keys are bare repo ids by contract,
+    // and a bare key is exactly what `addWorktreeId` refuses to trust. Rows there are removed once
+    // any locator seeds their repo id, which every repo that ever opened a terminal has.
     for (const record of Object.values(session.sleepingAgentSessionsByPaneKey ?? {})) {
       addWorktreeId(record.worktreeId)
     }

--- a/src/main/persistence/tracking-repos/deregistered-repo-residue.ts
+++ b/src/main/persistence/tracking-repos/deregistered-repo-residue.ts
@@ -1,0 +1,82 @@
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import { getWorktreeIdFromHostIdentity } from '../../../shared/worktree/host-qualified-identity'
+import { splitWorktreeId } from '../../../shared/worktree/id'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { SESSION_FIELDS_PRUNED_BY_OWNER_KEY } from '../../orca-profiles/profile-project-session-field-disposition'
+import { ownerKeyWorktreeId } from '../../orca-profiles/profile-project-worktree-identity'
+
+/**
+ * Repo ids that still own persisted rows but no longer appear in `state.repos`.
+ *
+ * Why nothing else finds them: every other sweeper is gated on the repo still being registered, so
+ * deregistering a project stranded the rows it owned permanently — including a paired client's
+ * mirror of a remote host's session partition, which no local repo removal can reach (#17776).
+ */
+export function collectDeregisteredRepoIds(state: PersistedState): Set<string> {
+  const liveRepoIds = new Set(state.repos.map((repo) => repo.id))
+  const orphanRepoIds = new Set<string>()
+  // Only a full `<repoId>::<path>` locator seeds the set. A bare key -- a folder workspace id, a
+  // repo-keyed topology revision, a test-shaped locator -- cannot be told apart from a repo id, and
+  // guessing wrong here deletes live session state.
+  const addWorktreeId = (worktreeId: string | null | undefined): void => {
+    const repoId = worktreeId ? splitWorktreeId(worktreeId)?.repoId : undefined
+    if (repoId && !liveRepoIds.has(repoId)) {
+      orphanRepoIds.add(repoId)
+    }
+  }
+  const addOwnerKey = (ownerKey: string): void => {
+    addWorktreeId(ownerKeyWorktreeId(ownerKey))
+  }
+
+  // Deliberately not seeded from `sparsePresetsByRepo` or `retiredWorktreeNamesByRepo`: both are
+  // bounded, and dropping a retired-name row would let a re-added repo reissue a name onto a cwd
+  // that still holds a prior occupant's agent state.
+  for (const worktreeId of Object.keys(state.worktreeMeta)) {
+    addWorktreeId(worktreeId)
+  }
+  for (const alias of Object.keys(state.worktreeIdentityAliases ?? {})) {
+    addWorktreeId(getWorktreeIdFromHostIdentity(alias))
+  }
+  for (const [childId, lineage] of Object.entries(state.worktreeLineageById)) {
+    addWorktreeId(childId)
+    addWorktreeId(lineage.parentWorktreeId)
+  }
+  for (const [childKey, lineage] of Object.entries(state.workspaceLineageByChildKey)) {
+    addOwnerKey(childKey)
+    addOwnerKey(lineage.parentWorkspaceKey)
+  }
+  for (const selections of Object.values(state.mobileClientTabSelectionsByDeviceId ?? {})) {
+    for (const worktreeId of Object.keys(selections)) {
+      addWorktreeId(worktreeId)
+    }
+  }
+  const sessions: (WorkspaceSessionState | undefined)[] = [
+    state.workspaceSession,
+    ...Object.values(state.workspaceSessionsByHostId ?? {})
+  ]
+  for (const session of sessions) {
+    if (!session) {
+      continue
+    }
+    for (const field of SESSION_FIELDS_PRUNED_BY_OWNER_KEY) {
+      for (const ownerKey of Object.keys(
+        (session[field] as Record<string, unknown> | undefined) ?? {}
+      )) {
+        addOwnerKey(ownerKey)
+      }
+    }
+    for (const ownerKey of Object.keys(session.tabsByWorktree ?? {})) {
+      addOwnerKey(ownerKey)
+    }
+    for (const ownerKey of Object.keys(session.browserTabsByWorktree ?? {})) {
+      addOwnerKey(ownerKey)
+    }
+    for (const record of Object.values(session.sleepingAgentSessionsByPaneKey ?? {})) {
+      addWorktreeId(record.worktreeId)
+    }
+    for (const tombstone of Object.values(session.terminalSurfaceTombstonesByPaneKey ?? {})) {
+      addWorktreeId(tombstone.worktreeId)
+    }
+  }
+  return orphanRepoIds
+}

--- a/src/main/persistence/tracking-repos/repo-worktree-pruning.ts
+++ b/src/main/persistence/tracking-repos/repo-worktree-pruning.ts
@@ -2,6 +2,7 @@ import type { WorkspaceKey } from '../../../shared/folder-workspace-types'
 import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
 import { removeWorkspaceSessionOwners } from '../restoring-sessions/session-owner-removal'
 import {
   getExecutionHostIdFromWorktreeHostIdentity,
@@ -58,10 +59,26 @@ export function pruneWorktreeStateForRepo(
       }
     }
   }
-  collectPrefixedKeys(Object.keys(state.worktreeMeta))
-  collectPrefixedKeys(Object.keys(state.workspaceSession?.lastVisitedAtByWorktreeId ?? {}))
-  for (const session of Object.values(state.workspaceSessionsByHostId ?? {})) {
+  // Why the pane-keyed records contribute owner keys: they are pruned by the worktreeId they name,
+  // not by their own key, so a worktree with no meta and no visit row would otherwise keep its
+  // sleeping agents and tombstones forever -- and keep re-seeding the orphan sweep every load.
+  const collectScannedRecordOwners = (session: WorkspaceSessionState | undefined): void => {
     collectPrefixedKeys(Object.keys(session?.lastVisitedAtByWorktreeId ?? {}))
+    collectPrefixedKeys(
+      Object.values(session?.sleepingAgentSessionsByPaneKey ?? {}).map(
+        (record) => record.worktreeId
+      )
+    )
+    collectPrefixedKeys(
+      Object.values(session?.terminalSurfaceTombstonesByPaneKey ?? {}).map(
+        (tombstone) => tombstone.worktreeId
+      )
+    )
+  }
+  collectPrefixedKeys(Object.keys(state.worktreeMeta))
+  collectScannedRecordOwners(state.workspaceSession)
+  for (const session of Object.values(state.workspaceSessionsByHostId ?? {})) {
+    collectScannedRecordOwners(session)
   }
 
   for (const key of Object.keys(state.worktreeMeta)) {

--- a/src/main/ssh-reattach-pane-cardinality.test.ts
+++ b/src/main/ssh-reattach-pane-cardinality.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { rmSync, mkdtempSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { testState, createStore, makeTerminalTab, writeDataFile } from './persistence-test-harness'
+import {
+  testState,
+  createStore,
+  makeRepo,
+  makeTerminalTab,
+  writeDataFile
+} from './persistence-test-harness'
 import { TEST_LEAF_1, TEST_LEAF_2 } from './persistence-session-fixtures'
 import { getDefaultPersistedState } from '../shared/constants'
 
@@ -196,6 +202,8 @@ describe('STA-3077: an SSH reattach binds panes without grafting them back', () 
   it('does not clear and rebind a retired surface loaded from an older profile', async () => {
     const paneKey = `${TAB}:${TEST_LEAF_1}`
     const persisted = getDefaultPersistedState(testState.dir)
+    // Registered on purpose: rows owned by an unregistered repo id are swept as orphans on load.
+    persisted.repos = [makeRepo({ id: 'repo1', path: '/repo1' })]
     persisted.workspaceSession = {
       ...persisted.workspaceSession,
       ...sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-1' }),

--- a/src/main/worktree-identity-persistence.test.ts
+++ b/src/main/worktree-identity-persistence.test.ts
@@ -5,11 +5,25 @@ import { tmpdir } from 'node:os'
 import type { PersistedState } from '../shared/persisted-state-types'
 import { canonicalWorktreeIdentity } from '../shared/worktree/identity'
 import { composeWorktreeHostIdentity } from '../shared/worktree/host-qualified-identity'
-import { createStore, readDataFile, testState, writeDataFile } from './persistence-test-harness'
+import type { Store } from './persistence/loading-store/store'
+import {
+  createStore,
+  makeRepo,
+  readDataFile,
+  testState,
+  writeDataFile
+} from './persistence-test-harness'
 
 describe('host-qualified worktree metadata', () => {
   const worktreeId = 'repo-1::/workspace/feature'
   const ROTATED_INSTANCE_ID = '44444444-4444-4444-8444-444444444444'
+
+  // Registered on purpose: rows owned by an unregistered repo id are swept as orphans on load.
+  const createStoreWithRepo = (): Store => {
+    const store = createStore()
+    store.addRepo(makeRepo({ id: 'repo-1', path: '/workspace' }))
+    return store
+  }
 
   beforeEach(() => {
     testState.dir = mkdtempSync(join(tmpdir(), 'orca-worktree-identity-'))
@@ -52,7 +66,7 @@ describe('host-qualified worktree metadata', () => {
     })
   })
   it('reloads host-specific metadata without collapsing it to the legacy locator', () => {
-    const store = createStore()
+    const store = createStoreWithRepo()
     store.setWorktreeMetaForHost(worktreeId, 'local', { displayName: 'Local feature' })
     store.setWorktreeMetaForHost(worktreeId, 'ssh:build-box', { displayName: 'Remote feature' })
     store.flush()
@@ -72,7 +86,7 @@ describe('host-qualified worktree metadata', () => {
     expect(store.getWorktreeMetaForHost(worktreeId, 'local')?.comment).toBe('after')
   })
   it('backfills one stable instance for legacy metadata that omitted it', () => {
-    const seed = createStore()
+    const seed = createStoreWithRepo()
     seed.setWorktreeMeta(worktreeId, { displayName: 'Legacy feature' })
     seed.flush()
     const legacy = readDataFile() as PersistedState
@@ -97,7 +111,7 @@ describe('host-qualified worktree metadata', () => {
   // Fails open on purpose: an ambiguous alias used to brick reads and throw out of the worktree
   // listing loop, taking every workspace in the repo down with it and never self-healing.
   it('collapses an ambiguous locator onto its most recently active instance', () => {
-    const seed = createStore()
+    const seed = createStoreWithRepo()
     const first = seed.setWorktreeMetaForHost(worktreeId, 'local', { displayName: 'First' })
     seed.flush()
     const persisted = readDataFile() as PersistedState
@@ -262,7 +276,7 @@ describe('host-qualified worktree metadata', () => {
   it('repairs a missing canonical instance id while re-adopting an SSH target', () => {
     const oldHostId = 'ssh:old-target' as const
     const newHostId = 'ssh:new-target' as const
-    const seed = createStore()
+    const seed = createStoreWithRepo()
     seed.setWorktreeMetaForHost(worktreeId, oldHostId, { displayName: 'Remote feature' })
     seed.flush()
     const persisted = readDataFile() as PersistedState
@@ -318,7 +332,7 @@ describe('host-qualified worktree metadata', () => {
   it('deduplicates an equivalent destination during SSH target re-adoption', () => {
     const oldHostId = 'ssh:old-target' as const
     const newHostId = 'ssh:new-target' as const
-    const seed = createStore()
+    const seed = createStoreWithRepo()
     seed.setWorktreeMetaForHost(worktreeId, oldHostId, { displayName: 'Remote feature' })
     seed.flush()
     const persisted = readDataFile() as PersistedState


### PR DESCRIPTION
## ELI5

If you remove a project from Orca, all the leftover bookkeeping for it — its worktrees, its tabs, its sleeping agents — stayed in the profile file forever, because every cleanup routine first asks "is this project still registered?" and the answer is no. On a paired client those leftovers showed up in the sidebar as ghost worktrees under an "Unknown" project, and there was no way to get rid of them short of hand-editing JSON. Now the store cleans them up the next time it loads.

## What Changed

`Store` now reconciles its persisted rows against its own repo catalogue at load. Any repo id that owns rows but no longer appears in `state.repos` has those rows removed through the same path `removeProject` already uses.

- **New** `src/main/persistence/tracking-repos/deregistered-repo-residue.ts` — `collectDeregisteredRepoIds(state)` walks `worktreeMeta`, `worktreeIdentityAliases`, both lineage maps, `mobileClientTabSelectionsByDeviceId`, and every session partition (`workspaceSession` plus each `workspaceSessionsByHostId` entry, including `sleepingAgentSessionsByPaneKey` and `terminalSurfaceTombstonesByPaneKey` records) and returns the repo ids that are absent from `state.repos`.
- **`repo-lifecycle-operations.ts`** — `sweepDeregisteredRepoResidue()` runs `pruneWorktreeStateForRepo` + `removeRepoFromWorkspaceSession` + `removeRepoFromHostWorkspaceSessions` per orphan id, then clears orphaned `ui` residue (`lastActiveRepoId`, `lastActiveWorktreeId`, `filterRepoIds`, `showDotfilesByWorktree`).
- **`store.ts`** — invoked in the constructor; schedules a save only when something was actually swept.
- **`profile-project-worktree-identity.ts`** — extracted `ownerKeyWorktreeId`; `ownerKeyBelongsToRepo` now delegates to it. Behaviour-identical (the two branches are disjoint), it just makes "which worktree does this owner key name" reusable.

Two deliberate narrowings, both commented in the source:

- Only a full `<repoId>::<path>` locator seeds the orphan set. A bare key can be a folder workspace id or a repo-keyed topology revision, and it cannot be told apart from a repo id — guessing wrong there deletes live session state.
- `sparsePresetsByRepo` and `retiredWorktreeNamesByRepo` are left alone. Both are bounded, and dropping a retired-name row would let a re-added repo reissue a name onto a cwd that still holds a prior occupant's agent state.

## Why

Every path that removes a repo's rows is gated on the repo still being registered:

- `pruneSessionlessMissingLocalWorktreeMetadataForRepo` requires `repoStillMatches` (`state.repos` must contain the repo).
- `removeProject` / `removeProjectForHost` / `removeSourceRepo` all take a repo id the local store currently owns.

So the cleanup is gated on the very condition whose absence created the garbage. Once an id leaves the catalogue, nothing can reach its rows again — and on a paired client the mirror of a *remote* host's session partition is keyed by ids that client never registers, so a removal on the owning host can never reach it either.

Reconciling against the catalogue at load removes that dependency. It is safe to ignore the session-ownership and local-execution-host gates the missing-directory sweeper needs, because an orphan has no owner that could object; that is also what lets it reach the remote-host partitions.

**Scope — what this does not fix.** The issue also reports that ~93–99% of `worktreeMeta` rows are dangling. Most of those belong to repos that are *still registered*, whose directories are gone. That is a different root cause: `pruneMetadataMissingFromAuthoritativeLocalScan` has exactly one caller, `ipcMain.handle('worktrees:listAll')`, so a headless runtime host (no renderer) never sweeps its own repos, and the prune is gated to `LOCAL_EXECUTION_HOST_ID` with `!connectionId`, so a client never sweeps remote rows. Fixing that needs a host-authoritative listing rather than a client-side `stat` (see `docs/reference/ssh-execution-boundary.md`) and is being sent as a follow-up PR stacked on this one.

## Linked Issue

Refs #17776

## Visual Proof

`N/A` — no UI code changes. The user-visible effect is the disappearance of sidebar rows that were only ever rendered from orphaned persisted state; there is no new or altered UI surface to show.

## Testing

New `src/main/persistence-deregistered-repo-residue.test.ts`:

- drops metadata, identity rows and session rows (tabs, `lastVisitedAtByWorktreeId`, `activeTabTypeByWorktree`, `sleepingAgentSessionsByPaneKey`) owned by an unregistered repo id
- sweeps a `runtime:` host partition the owning host's removal can never reach
- **keeps** rows for a registered repo on a non-local execution host — and asserts the sleeping-agent fixture survives, so the sweep assertions above cannot pass vacuously
- leaves folder-workspace session keys alone
- leaves a profile with no orphans byte-identical across two reloads, so the sweep cannot dirty every launch

12 existing test files had fixtures that wrote worktree rows without ever registering the repo — they were relying on orphans surviving a reload. Each now registers the repo it names. `persistence-worktree-lineage-and-backups.test.ts` ("prunes selections for a removed repo worktree") keeps its original intent by registering `other-repo` too, so it still asserts that removing `r1` leaves another repo's selections untouched.

- `pnpm tc` — clean
- `pnpm run check:code-quality:changed` — 0 findings
- `pnpm test src/main/persistence` + the touched files — 853 passed
- Full `pnpm test src/main` — the only new failure was `ssh-reattach-pane-cardinality.test.ts`, a fixture of this same shape, now fixed. The remaining 7 failures reproduce on a stashed baseline (zsh live-shell, Electron dev-app rebuild, TUI transcript catchup, and two load-sensitive timeouts).

Platforms: logic is platform-independent (no path or shell handling). Verified on macOS. Remote/SSH covered by the `runtime:` and non-local-host tests above rather than a live host.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 4.5 (Claude Code).

## Review

### Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Security** — no new surface; strictly removes local persisted rows.
- **Cross-platform** — no path, shell or keyboard handling; `splitWorktreeId` is the existing separator-based parse used everywhere else.
- **Remote SSH / runtime** — this is the point of the change. It only ever consults `state.repos`, never the filesystem or a connection, so it makes no liveness claim about a remote host and does not touch the execution boundary. Loss of contact with a host cannot cause a sweep; only the repo leaving the client's own catalogue can.
- **Remote wire compatibility** — no wire change. Nothing new is exchanged between client and host.
- **Mobile** — orphaned `mobileClientTabSelectionsByDeviceId` rows are pruned via the existing `pruneMobileClientTabSelections` callback, same as project removal.
- **Backwards compatibility** — on the first launch after upgrade a profile carrying orphans is rewritten once; a clean profile is left byte-identical (pinned by a test). Nothing is removed that any code path could still resolve, since resolution goes through `state.repos`.
- **Performance** — one pass over the persisted collections at load, and it short-circuits before any mutation when no orphans exist. The removal loop is per orphan repo id, which is a small number in practice, and self-clearing after the first sweep.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally (`pnpm build` left to CI)
