### PR TITLE
fix(tooling): run oxlint gates without a Windows .cmd shim

### DIFF
--- a/config/scripts/check-changed-code-quality.mjs
+++ b/config/scripts/check-changed-code-quality.mjs
@@ -4,6 +4,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 import { resolvePullRequestDiffBase } from './git-pull-request-diff-base.mjs'
+import { resolveOxlintInvocation } from './oxlint-cli-invocation.mjs'
 
 const SOURCE_FILE_PATTERN = /\.(?:[cm]?[jt]sx?)$/
 export const OXLINT_SCANS = [
@@ -285,11 +286,12 @@ function isSuppressedDiagnostic(diagnostic, root) {
 }
 
 function runOxlintScan(root, scan, files) {
-  const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
-  const result = spawnSync(pnpm, ['exec', 'oxlint', ...scan.args, '--format', 'json', ...files], {
+  const { command, prefixArgs } = resolveOxlintInvocation(root)
+  const result = spawnSync(command, [...prefixArgs, ...scan.args, '--format', 'json', ...files], {
     cwd: root,
     encoding: 'utf8',
-    maxBuffer: 128 * 1024 * 1024
+    maxBuffer: 128 * 1024 * 1024,
+    windowsHide: true
   })
   if (result.error) {
     throw result.error

--- a/config/scripts/check-react-doctor-changed.mjs
+++ b/config/scripts/check-react-doctor-changed.mjs
@@ -1,16 +1,21 @@
 import { spawnSync } from 'node:child_process'
 import process from 'node:process'
 import { resolvePullRequestDiffBase } from './git-pull-request-diff-base.mjs'
+import { resolvePnpmCliInvocation } from './pnpm-cli-invocation.mjs'
 
 const requestedBase =
   process.argv.slice(2).find((argument) => argument !== '--') ??
   process.env.ORCA_CODE_QUALITY_BASE ??
   'origin/main'
 const base = resolvePullRequestDiffBase(process.cwd(), requestedBase)
-const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+// Why the shim and not a direct binary: `dlx` fetches react-doctor on demand, so
+// only the pnpm CLI can run it. resolvePnpmCliInvocation picks the shell-free
+// `node <pnpm cli>` form whenever npm_execpath exposes one.
+const { command, prefixArgs, shell } = resolvePnpmCliInvocation()
 const result = spawnSync(
-  pnpm,
+  command,
   [
+    ...prefixArgs,
     'dlx',
     'react-doctor@0.9.1',
     '.',
@@ -26,7 +31,7 @@ const result = spawnSync(
     '--blocking',
     'error'
   ],
-  { stdio: 'inherit' }
+  { stdio: 'inherit', shell, windowsHide: true }
 )
 
 if (result.error) {

--- a/config/scripts/check-react-doctor-changed.mjs
+++ b/config/scripts/check-react-doctor-changed.mjs
@@ -8,9 +8,17 @@ const requestedBase =
   process.env.ORCA_CODE_QUALITY_BASE ??
   'origin/main'
 const base = resolvePullRequestDiffBase(process.cwd(), requestedBase)
+// Why validate rather than trust: `base` arrives from argv or the environment and
+// below it can reach cmd.exe unquoted, because resolvePnpmCliInvocation still
+// falls back to a shell when it cannot find a directly spawnable pnpm. Everything
+// git accepts as a revision fits this set; nothing cmd.exe treats as syntax does.
+const GIT_REVISION = /^[A-Za-z0-9._/@^~-]+$/
+if (!GIT_REVISION.test(base)) {
+  throw new Error(`Refusing to pass an unsafe diff base to pnpm: ${base}`)
+}
 // Why the shim and not a direct binary: `dlx` fetches react-doctor on demand, so
-// only the pnpm CLI can run it. resolvePnpmCliInvocation picks the shell-free
-// `node <pnpm cli>` form whenever npm_execpath exposes one.
+// only the pnpm CLI can run it. resolvePnpmCliInvocation prefers whatever
+// npm_execpath exposes -- pnpm 12's own pnpm.exe, spawned with no shell.
 const { command, prefixArgs, shell } = resolvePnpmCliInvocation()
 const result = spawnSync(
   command,

--- a/config/scripts/check-react-doctor-changed.mjs
+++ b/config/scripts/check-react-doctor-changed.mjs
@@ -10,8 +10,9 @@ const requestedBase =
 const base = resolvePullRequestDiffBase(process.cwd(), requestedBase)
 // Why validate rather than trust: `base` arrives from argv or the environment and
 // below it can reach cmd.exe unquoted, because resolvePnpmCliInvocation still
-// falls back to a shell when it cannot find a directly spawnable pnpm. Everything
-// git accepts as a revision fits this set; nothing cmd.exe treats as syntax does.
+// falls back to a shell when it cannot find a directly spawnable pnpm. It accepts
+// SHAs, tags, ref paths and the ^ ~ .. suffixes -- not reflog syntax like HEAD@{1},
+// because braces stay out of anything bound for cmd.exe. The error names the base.
 const GIT_REVISION = /^[A-Za-z0-9._/@^~-]+$/
 if (!GIT_REVISION.test(base)) {
   throw new Error(`Refusing to pass an unsafe diff base to pnpm: ${base}`)

--- a/config/scripts/check-react-doctor-changed.test.mjs
+++ b/config/scripts/check-react-doctor-changed.test.mjs
@@ -1,0 +1,29 @@
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import process from 'node:process'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..')
+const script = path.join(repoRoot, 'config', 'scripts', 'check-react-doctor-changed.mjs')
+
+function runWithBase(base) {
+  return spawnSync(process.execPath, [script, base], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    windowsHide: true
+  })
+}
+
+describe('check-react-doctor-changed diff base', () => {
+  // The pnpm invocation can still fall back to a shell, so an unvalidated base
+  // would reach cmd.exe unquoted. Rejection has to happen before the spawn.
+  it.each(['main & calc', 'main | whoami', 'main"x', '%PATH%', 'main $(id)'])(
+    'refuses %j',
+    (base) => {
+      const result = runWithBase(base)
+
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain('Refusing to pass an unsafe diff base')
+    }
+  )
+})

--- a/config/scripts/lint-react-doctor-changed.mjs
+++ b/config/scripts/lint-react-doctor-changed.mjs
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
+import { resolveOxlintInvocation } from './oxlint-cli-invocation.mjs'
 
 const SOURCE_FILE_PATTERN = /\.(?:[cm]?[jt]sx?)$/
 
@@ -31,11 +32,11 @@ if (lintTargets.length === 0) {
   process.exit(0)
 }
 
-const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+const { command, prefixArgs } = resolveOxlintInvocation()
 const result = spawnSync(
-  pnpm,
-  ['exec', 'oxlint', '--config', 'config/oxlint-react-doctor.json', ...lintTargets],
-  { stdio: 'inherit' }
+  command,
+  [...prefixArgs, '--config', 'config/oxlint-react-doctor.json', ...lintTargets],
+  { stdio: 'inherit', windowsHide: true }
 )
 
 if (result.error) {

--- a/config/scripts/mobile-pairing-qrcode-import-plugin.test.mjs
+++ b/config/scripts/mobile-pairing-qrcode-import-plugin.test.mjs
@@ -3,11 +3,10 @@ import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { resolveOxlintInvocation } from './oxlint-cli-invocation.mjs'
 
 const pluginPath = path.resolve('config/oxlint-plugins/mobile-pairing-qrcode-import.mjs')
-const oxlintPath = path.resolve(
-  process.platform === 'win32' ? 'node_modules/.bin/oxlint.cmd' : 'node_modules/.bin/oxlint'
-)
+const oxlint = resolveOxlintInvocation()
 
 function lintSource(source) {
   const directory = mkdtempSync(path.join(tmpdir(), 'orca-qrcode-import-lint-'))
@@ -22,9 +21,11 @@ function lintSource(source) {
       rules: { 'mobile-pairing/no-eager-qrcode-import': 'error' }
     })
   )
-  const result = spawnSync(oxlintPath, ['--config', configPath, '--format', 'json', sourcePath], {
-    encoding: 'utf8'
-  })
+  const result = spawnSync(
+    oxlint.command,
+    [...oxlint.prefixArgs, '--config', configPath, '--format', 'json', sourcePath],
+    { encoding: 'utf8', windowsHide: true }
+  )
   if (result.error) {
     throw result.error
   }

--- a/config/scripts/oxlint-cli-invocation.mjs
+++ b/config/scripts/oxlint-cli-invocation.mjs
@@ -1,0 +1,23 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import process from 'node:process'
+
+// Why not `pnpm exec oxlint` / `node_modules/.bin/oxlint.cmd`: both land on a
+// Windows .cmd shim, and Node >= 20 refuses to spawn one without `shell: true`
+// (the CVE-2024-27980 mitigation), so every lint gate died with EINVAL before
+// linting anything. Oxlint's bin is a plain Node script, so run it under this
+// process's own node — no shim, no shell, no quoting question.
+export function resolveOxlintInvocation(root = process.cwd()) {
+  const requireFromRoot = createRequire(path.join(root, 'package.json'))
+  // Oxlint's "exports" hides ./bin, so read the manifest and walk to its bin entry.
+  const manifestPath = requireFromRoot.resolve('oxlint/package.json')
+  const binField = requireFromRoot('oxlint/package.json').bin
+  const binEntry = typeof binField === 'string' ? binField : binField?.oxlint
+  if (!binEntry) {
+    throw new Error('oxlint package.json declares no "oxlint" bin entry.')
+  }
+  return {
+    command: process.execPath,
+    prefixArgs: [path.resolve(path.dirname(manifestPath), binEntry)]
+  }
+}

--- a/config/scripts/oxlint-cli-invocation.test.mjs
+++ b/config/scripts/oxlint-cli-invocation.test.mjs
@@ -1,0 +1,33 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { describe, expect, it } from 'vitest'
+import { resolveOxlintInvocation } from './oxlint-cli-invocation.mjs'
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..')
+
+describe('resolveOxlintInvocation', () => {
+  it('runs oxlint under this process node, never through a shim', () => {
+    const { command, prefixArgs } = resolveOxlintInvocation(repoRoot)
+
+    expect(command).toBe(process.execPath)
+    expect(prefixArgs).toHaveLength(1)
+    // The EINVAL that killed the changed-code gate came from spawning a .cmd.
+    expect(prefixArgs[0]).not.toMatch(/\.(cmd|bat)$/i)
+    expect(existsSync(prefixArgs[0])).toBe(true)
+  })
+
+  it('spawns without a shell and produces Oxlint JSON', () => {
+    const { command, prefixArgs } = resolveOxlintInvocation(repoRoot)
+    const result = spawnSync(
+      command,
+      [...prefixArgs, '--help'],
+      // shell:false is the point: the shim form throws EINVAL here on Windows.
+      { cwd: repoRoot, encoding: 'utf8', shell: false, windowsHide: true }
+    )
+
+    expect(result.error).toBeUndefined()
+    expect(result.stdout).toContain('oxlint')
+  })
+})

--- a/config/scripts/windows-cmd-shim-spawn-boundary.test.mjs
+++ b/config/scripts/windows-cmd-shim-spawn-boundary.test.mjs
@@ -5,47 +5,66 @@ import { describe, expect, it } from 'vitest'
 /**
  * Guard the one idiom that keeps re-killing Windows tooling.
  *
- * Node >= 20 refuses to spawn a `.cmd`/`.bat` without `shell: true` (the
+ * Node >= 20 refuses to spawn a Windows batch shim without `shell: true` (the
  * CVE-2024-27980 mitigation), so `spawnSync('pnpm.cmd', …)` throws EINVAL
  * before the command runs at all. On Windows that reads as a broken toolchain
  * rather than a failing check, so the failure gets shrugged off — which is
  * exactly how `check:code-quality:changed` ran dead for months.
  *
- * `src/` has its own chokepoint (runProcess) and its own ratchet. `config/`
- * scripts are plain `.mjs` outside that module boundary, so they need this
- * narrower one: the shim idiom may not appear in a new script. The list only
- * shrinks. Resolve the real executable instead — `oxlint-cli-invocation.mjs`
- * and `windows-process-tree-gyp-rebuild.mjs` show the shape.
+ * `src/` has its own chokepoint (runProcess) and its own ratchet. These trees
+ * are plain `.mjs` run by bare `node`, outside that module boundary, so they
+ * need this narrower one: a batch-shim command literal may not appear in a new
+ * script. The list only shrinks. Resolve the real executable instead —
+ * `oxlint-cli-invocation.mjs` and `windows-process-tree-gyp-rebuild.mjs` show
+ * the shape.
+ *
+ * Deliberately a text match on any `.cmd`/`.bat` literal, not on a list of
+ * runner names: these trees already spawn vitest, playwright, electron-builder
+ * and tsc, and the next offender is as likely to be one of those as it is to be
+ * pnpm. A literal is all a copy-paste carries. A shim assembled in a template
+ * literal stays uncatchable this way; that is the accepted ceiling of a text
+ * ratchet, and the reason `src/` gets a real chokepoint instead.
  */
-const WINDOWS_SHIM_LITERAL = /['"][\w./\\-]*(?:pnpm|npm|npx|yarn|node-gyp|oxlint)\.(?:cmd|bat)['"]/i
+const WINDOWS_SHIM_LITERAL = /['"][\w./\\-]*\.(?:cmd|bat)['"]/i
 
-/** Scripts that still carry the idiom, held as data so it reads as the list it is. */
+const SCANNED_ROOTS = ['config/scripts', 'tests/tools']
+
+/** Scripts that still name a batch shim, held as data so it reads as the list it is. */
 const WINDOWS_SHIM_SPAWN_ALLOWLIST = [
   // Owns the pnpm invocation decision for every other script.
-  'pnpm-cli-invocation.mjs',
-  'pnpm-cli-invocation.test.mjs',
-  // macOS-only build paths; the win32 branch is dead code there.
-  'build-mac-local.mjs',
-  // Benchmarks, repros and e2e drivers — developer-invoked, never a CI gate.
-  'build-orcad-prebuilds.mjs',
-  'ensure-native-runtime.test.mjs',
-  'run-ai-vault-typing-bench.mjs',
-  'run-ephemeral-vm-runtime-store-rollback-repro.mjs',
-  'run-local-ssh-browser-routing-e2e.mjs',
-  'run-multi-client-navigation-e2e.mjs',
-  'run-multi-workspace-typing-bench.mjs',
-  'run-nested-runtime-ssh-e2e.mjs',
-  'run-ssh-client-hosted-browser-drop-reconnect-e2e.mjs',
-  'run-ssh-codex-artifacts-repro-e2e.mjs',
-  'run-ssh-docker-e2e.mjs',
-  'run-ssh-docker-perf-e2e.mjs',
-  'run-ssh-docker-terminal-parking-e2e.mjs',
-  'run-ssh-docker-watcher-isolation-e2e.mjs',
-  'run-ssh-staged-upload-reliability.mjs',
-  'run-terminal-ibus-hangul-e2e.mjs',
-  'run-terminal-scale-perf-e2e.mjs',
-  // Routes npx.cmd through an explicit `cmd.exe /d /s /c`, which is the correct form.
-  'verify-skill-update-roundtrip.mjs'
+  'config/scripts/pnpm-cli-invocation.mjs',
+  'config/scripts/pnpm-cli-invocation.test.mjs',
+  // Write or assert on shim files rather than spawning one.
+  'config/scripts/dev-cli-terminal-wrapper.mjs',
+  'config/scripts/dev-cli-terminal-wrapper.test.mjs',
+  'config/scripts/electron-builder-config.test.mjs',
+  'config/scripts/ensure-native-runtime.test.mjs',
+  'config/scripts/live-remote-freeze-rpc.mjs',
+  'config/scripts/remote-agent-session-authority-repro.mjs',
+  // macOS-only build path; the win32 branch is dead code there.
+  'config/scripts/build-mac-local.mjs',
+  // Benchmarks, repros and e2e drivers — developer-invoked or Linux-only in CI.
+  'config/scripts/build-orcad-prebuilds.mjs',
+  'config/scripts/run-ai-vault-typing-bench.mjs',
+  'config/scripts/run-ephemeral-vm-runtime-store-rollback-repro.mjs',
+  'config/scripts/run-local-ssh-browser-routing-e2e.mjs',
+  'config/scripts/run-multi-client-navigation-e2e.mjs',
+  'config/scripts/run-multi-workspace-typing-bench.mjs',
+  'config/scripts/run-nested-runtime-ssh-e2e.mjs',
+  'config/scripts/run-ssh-client-hosted-browser-drop-reconnect-e2e.mjs',
+  'config/scripts/run-ssh-codex-artifacts-repro-e2e.mjs',
+  'config/scripts/run-ssh-docker-e2e.mjs',
+  'config/scripts/run-ssh-docker-perf-e2e.mjs',
+  'config/scripts/run-ssh-docker-terminal-parking-e2e.mjs',
+  'config/scripts/run-ssh-docker-watcher-isolation-e2e.mjs',
+  'config/scripts/run-ssh-staged-upload-reliability.mjs',
+  'config/scripts/run-terminal-ibus-hangul-e2e.mjs',
+  'config/scripts/run-terminal-scale-perf-e2e.mjs',
+  // Routes its shim through an explicit `cmd.exe /d /s /c`, which is the correct form.
+  'config/scripts/verify-skill-update-roundtrip.mjs',
+  'tests/tools/benchmarks/startup-time-bench.mjs',
+  'tests/tools/benchmarks/worktree-deletion-dev-bench.mjs',
+  'tests/tools/repro-terminal-send-submit.mjs'
 ]
 
 /** Drop comment-only lines so prose about the old idiom is not an offender. */
@@ -56,28 +75,47 @@ function codeText(contents) {
     .join('\n')
 }
 
-describe('windows cmd shim spawn boundary', () => {
-  const scriptsDir = import.meta.dirname
-  const scripts = readdirSync(scriptsDir).filter((name) => /\.[cm]?js$/.test(name))
-  const offenders = scripts.filter((name) =>
-    WINDOWS_SHIM_LITERAL.test(codeText(readFileSync(path.join(scriptsDir, name), 'utf8')))
+// Why recursive: a future config/scripts/<subdir>/ would otherwise escape silently.
+function collectScripts(directory, repoRoot, found = []) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const full = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name !== 'node_modules') {
+        collectScripts(full, repoRoot, found)
+      }
+      continue
+    }
+    if (/\.[cm]?js$/.test(entry.name)) {
+      found.push(path.relative(repoRoot, full).split(path.sep).join('/'))
+    }
+  }
+  return found
+}
+
+describe('windows batch shim spawn boundary', () => {
+  const repoRoot = path.resolve(import.meta.dirname, '..', '..')
+  const scripts = SCANNED_ROOTS.flatMap((root) =>
+    collectScripts(path.join(repoRoot, root), repoRoot)
+  )
+  const offenders = scripts.filter((relativePath) =>
+    WINDOWS_SHIM_LITERAL.test(codeText(readFileSync(path.join(repoRoot, relativePath), 'utf8')))
   )
 
   it('scans a plausible number of scripts', () => {
-    // A broken directory or extension filter would make the guard silently vacuous.
+    // A broken root or extension filter would make the guard silently vacuous.
     expect(scripts.length).toBeGreaterThan(100)
   })
 
-  it('has no unlisted script spawning a Windows .cmd shim', () => {
+  it('has no unlisted script naming a Windows batch shim', () => {
     const unlisted = offenders.filter((name) => !WINDOWS_SHIM_SPAWN_ALLOWLIST.includes(name))
     expect(
       unlisted,
-      'Node cannot spawn a .cmd without a shell. Resolve the real executable — see oxlint-cli-invocation.mjs.'
+      'Node cannot spawn a Windows batch shim without a shell. Resolve the real executable — see oxlint-cli-invocation.mjs.'
     ).toEqual([])
   })
 
   it('has no stale allowlist entry', () => {
     const stale = WINDOWS_SHIM_SPAWN_ALLOWLIST.filter((name) => !offenders.includes(name))
-    expect(stale, 'Script no longer names a .cmd shim — delete the line.').toEqual([])
+    expect(stale, 'Script no longer names a batch shim — delete the line.').toEqual([])
   })
 })

--- a/config/scripts/windows-cmd-shim-spawn-boundary.test.mjs
+++ b/config/scripts/windows-cmd-shim-spawn-boundary.test.mjs
@@ -1,0 +1,83 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guard the one idiom that keeps re-killing Windows tooling.
+ *
+ * Node >= 20 refuses to spawn a `.cmd`/`.bat` without `shell: true` (the
+ * CVE-2024-27980 mitigation), so `spawnSync('pnpm.cmd', …)` throws EINVAL
+ * before the command runs at all. On Windows that reads as a broken toolchain
+ * rather than a failing check, so the failure gets shrugged off — which is
+ * exactly how `check:code-quality:changed` ran dead for months.
+ *
+ * `src/` has its own chokepoint (runProcess) and its own ratchet. `config/`
+ * scripts are plain `.mjs` outside that module boundary, so they need this
+ * narrower one: the shim idiom may not appear in a new script. The list only
+ * shrinks. Resolve the real executable instead — `oxlint-cli-invocation.mjs`
+ * and `windows-process-tree-gyp-rebuild.mjs` show the shape.
+ */
+const WINDOWS_SHIM_LITERAL = /['"][\w./\\-]*(?:pnpm|npm|npx|yarn|node-gyp|oxlint)\.(?:cmd|bat)['"]/i
+
+/** Scripts that still carry the idiom, held as data so it reads as the list it is. */
+const WINDOWS_SHIM_SPAWN_ALLOWLIST = [
+  // Owns the pnpm invocation decision for every other script.
+  'pnpm-cli-invocation.mjs',
+  'pnpm-cli-invocation.test.mjs',
+  // macOS-only build paths; the win32 branch is dead code there.
+  'build-mac-local.mjs',
+  // Benchmarks, repros and e2e drivers — developer-invoked, never a CI gate.
+  'build-orcad-prebuilds.mjs',
+  'ensure-native-runtime.test.mjs',
+  'run-ai-vault-typing-bench.mjs',
+  'run-ephemeral-vm-runtime-store-rollback-repro.mjs',
+  'run-local-ssh-browser-routing-e2e.mjs',
+  'run-multi-client-navigation-e2e.mjs',
+  'run-multi-workspace-typing-bench.mjs',
+  'run-nested-runtime-ssh-e2e.mjs',
+  'run-ssh-client-hosted-browser-drop-reconnect-e2e.mjs',
+  'run-ssh-codex-artifacts-repro-e2e.mjs',
+  'run-ssh-docker-e2e.mjs',
+  'run-ssh-docker-perf-e2e.mjs',
+  'run-ssh-docker-terminal-parking-e2e.mjs',
+  'run-ssh-docker-watcher-isolation-e2e.mjs',
+  'run-ssh-staged-upload-reliability.mjs',
+  'run-terminal-ibus-hangul-e2e.mjs',
+  'run-terminal-scale-perf-e2e.mjs',
+  // Routes npx.cmd through an explicit `cmd.exe /d /s /c`, which is the correct form.
+  'verify-skill-update-roundtrip.mjs'
+]
+
+/** Drop comment-only lines so prose about the old idiom is not an offender. */
+function codeText(contents) {
+  return contents
+    .split('\n')
+    .filter((line) => !/^\s*(?:\/\/|\/\*|\*)/.test(line))
+    .join('\n')
+}
+
+describe('windows cmd shim spawn boundary', () => {
+  const scriptsDir = import.meta.dirname
+  const scripts = readdirSync(scriptsDir).filter((name) => /\.[cm]?js$/.test(name))
+  const offenders = scripts.filter((name) =>
+    WINDOWS_SHIM_LITERAL.test(codeText(readFileSync(path.join(scriptsDir, name), 'utf8')))
+  )
+
+  it('scans a plausible number of scripts', () => {
+    // A broken directory or extension filter would make the guard silently vacuous.
+    expect(scripts.length).toBeGreaterThan(100)
+  })
+
+  it('has no unlisted script spawning a Windows .cmd shim', () => {
+    const unlisted = offenders.filter((name) => !WINDOWS_SHIM_SPAWN_ALLOWLIST.includes(name))
+    expect(
+      unlisted,
+      'Node cannot spawn a .cmd without a shell. Resolve the real executable — see oxlint-cli-invocation.mjs.'
+    ).toEqual([])
+  })
+
+  it('has no stale allowlist entry', () => {
+    const stale = WINDOWS_SHIM_SPAWN_ALLOWLIST.filter((name) => !offenders.includes(name))
+    expect(stale, 'Script no longer names a .cmd shim — delete the line.').toEqual([])
+  })
+})

--- a/config/scripts/windows-cmd-shim-spawn-boundary.test.mjs
+++ b/config/scripts/windows-cmd-shim-spawn-boundary.test.mjs
@@ -21,9 +21,15 @@ import { describe, expect, it } from 'vitest'
  * Deliberately a text match on any `.cmd`/`.bat` literal, not on a list of
  * runner names: these trees already spawn vitest, playwright, electron-builder
  * and tsc, and the next offender is as likely to be one of those as it is to be
- * pnpm. A literal is all a copy-paste carries. A shim assembled in a template
- * literal stays uncatchable this way; that is the accepted ceiling of a text
- * ratchet, and the reason `src/` gets a real chokepoint instead.
+ * pnpm. A literal is all a copy-paste carries.
+ *
+ * Two shapes this does not catch, both accepted. A shim assembled in a template
+ * literal, and a drive-lettered path — 'C:\tools\pnpm.cmd' — since a colon is
+ * not in the class. Real code builds those with path.join, whose 'pnpm.cmd'
+ * argument is caught. Also note codeText only drops lines that BEGIN with a
+ * comment marker, so a trailing `// 'pnpm.cmd'` false-positives; that fails
+ * closed. All of which is the ceiling of a text ratchet, and the reason `src/`
+ * gets a real chokepoint instead.
  */
 const WINDOWS_SHIM_LITERAL = /['"][\w./\\-]*\.(?:cmd|bat)['"]/i
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​196 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​190 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​50 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 |

<!-- /orca-pr-loc -->

## The bug

`pnpm run check:code-quality:changed` could not run at all on Windows under Node 24. It spawned `pnpm.cmd` without a shell, which Node refuses under the CVE-2024-27980 mitigation, so the gate died **before linting anything** — and it died looking like a broken toolchain rather than a failing check. Seven agents hit this independently during the Windows remediation effort and every one hand-ran `oxlint` instead. Silently-dead gate: anyone who shrugs at the stack trace ships unlinted changes.

### Reproduction (Windows 11, Node v24.18.0, pnpm 12)

```
$ node config/scripts/check-changed-code-quality.mjs
node:internal/child_process:1143
    result.error = new ErrnoException(result.error, 'spawnSync ' + options.file);
                   ^
Error: spawnSync pnpm.cmd EINVAL
    at Object.spawnSync (node:internal/child_process:1143:20)
    at runOxlintScan (…/config/scripts/check-changed-code-quality.mjs:289:18)
    at main (…/config/scripts/check-changed-code-quality.mjs:319:25) {
  errno: -4071,
  code: 'EINVAL',
  syscall: 'spawnSync pnpm.cmd',
  path: 'pnpm.cmd',
  spawnargs: [ 'exec', 'oxlint', '--report-unused-disable-directives-severity',
               'warn', '--format', 'json', 'src/shared/scratch-gate-probe.ts' ]
}
```

(A clean tree exits early with "no changed JavaScript or TypeScript", so the crash only shows once there is something to lint — which is part of why it survived.)

## Inventory of affected call sites

Every non-`src/` script that spawns a Windows `.cmd`/`.bat` shim (`pnpm.cmd`, `npx.cmd`, `.bin/oxlint.cmd`) or a bare package-runner name. `shell=false` means it throws EINVAL on Windows under Node >= 20.

**Fixed here — gates a Windows developer or CI actually runs:**

| Site | Call | Status |
| --- | --- | --- |
| `config/scripts/check-changed-code-quality.mjs:288` | `spawnSync('pnpm.cmd', ['exec','oxlint',…])` | **fixed** — the reported bug |
| `config/scripts/lint-react-doctor-changed.mjs:34` | `spawnSync('pnpm.cmd', ['exec','oxlint',…])` | **fixed** — same defect, `lint:react-doctor:changed` |
| `config/scripts/mobile-pairing-qrcode-import-plugin.test.mjs:8` | `spawnSync('node_modules/.bin/oxlint.cmd', …)` | **fixed** — this vitest file was failing on Windows with the same EINVAL |
| `config/scripts/check-react-doctor-changed.mjs:10` | `spawnSync('pnpm.cmd', ['dlx','react-doctor@0.9.1',…])` | **fixed** — routed through the existing `resolvePnpmCliInvocation()`, plus diff-base validation (below) |

**Left alone, deliberately — benchmarks, repros, e2e drivers and platform-specific builds.** All now pinned by the ratchet, so the list can only shrink:

`build-mac-local.mjs:34` (macOS-only), `build-orcad-prebuilds.mjs:135` (`npx.cmd node-gyp`), `run-ai-vault-typing-bench.mjs:28`, `run-ephemeral-vm-runtime-store-rollback-repro.mjs:79`, `run-local-ssh-browser-routing-e2e.mjs:19,25`, `run-multi-client-navigation-e2e.mjs:18,24`, `run-multi-workspace-typing-bench.mjs:41`, `run-nested-runtime-ssh-e2e.mjs:3`, `run-ssh-client-hosted-browser-drop-reconnect-e2e.mjs:19,25`, `run-ssh-codex-artifacts-repro-e2e.mjs:10,22`, `run-ssh-docker-e2e.mjs:19,64`, `run-ssh-docker-perf-e2e.mjs:10,19`, `run-ssh-docker-terminal-parking-e2e.mjs:19,27`, `run-ssh-docker-watcher-isolation-e2e.mjs:18,24`, `run-ssh-staged-upload-reliability.mjs:55`, `run-terminal-ibus-hangul-e2e.mjs:195` (Linux ibus), `run-terminal-scale-perf-e2e.mjs:21`.

One correction to an earlier draft of this description, which claimed none of these is a gate: **`run-ephemeral-vm-runtime-store-rollback-repro.mjs:79` is invoked by a CI gate** — `pr.yml:128`, inside `static_analysis`. It runs on ubuntu, so its win32 branch is dead in CI, but it stays latent for a Windows developer running that script by hand. The rest are genuinely developer-invoked.

**Already correct, no change:**

- `config/scripts/verify-skill-update-roundtrip.mjs:140` — routes `npx.cmd` through an explicit `cmd.exe /d /s /c`, the correct Windows form. (This one does run on windows-latest in CI.)
- `config/scripts/ensure-native-runtime.mjs:386` — bare `'pnpm'` with `shell: process.platform === 'win32'`; runs, though it carries the usual quoting caveat.
- `config/scripts/windows-process-tree-gyp-rebuild.mjs` and `config/scripts/run-typecheck-projects-in-parallel.mjs` — already resolve `node_modules/…/node-gyp.js` and `node_modules/typescript/bin/tsc` and spawn them under `process.execPath`. This PR follows their shape.

## The fix, and why this one

New `config/scripts/oxlint-cli-invocation.mjs` resolves oxlint's own bin (a plain Node script) from the repo manifest and returns `{ command: process.execPath, prefixArgs: [binPath] }`. Callers spawn that.

**Why not route through pnpm at all.** Not because pnpm is unspawnable — an earlier draft of this description claimed that, and it was wrong on both halves. Under `pnpm run`, pnpm 12 *does* set `npm_execpath`, to a real `pnpm.exe`, and `pnpm-cli-invocation.mjs:10-19` turns that into `{ command: <pnpm.exe>, prefixArgs: [], shell: false }` — directly spawnable, no shell. The package directory also contains `bin/pnpm.mjs`, which `JS_CLI_EXTENSION` at `:3` matches.

The real reason is that **going direct does not depend on being launched under `pnpm run`.** These gates are also run as bare `node config/scripts/…` — that is how the seven agents hit the bug and how it was reproduced above — and there `npm_execpath` is absent, so every pnpm route degrades to the shim. A gate should not have two different reliabilities depending on how it was started. Going direct also drops three `pnpm` spawns per run.

Also considered and rejected:

- **`shell: true`** — reintroduces quoting hazards on a call whose argv is a caller-supplied list of changed file paths, and AGENTS.md is explicit that it silently disables `windowsHide`.
- **Reuse `src/shared/child-process/` (`runProcess`/`spawnProcess`)** — not viable across the boundary. These are `.mjs` scripts run by bare `node`, and the helpers are `.ts` under the Electron/node tsconfig with no build step available at gate time. Forcing it would mean compiling `src/` to lint `src/`.
- **Sibling PR #17869's `windows-cmd-shim-resolution.ts`** — read for prior art on shim shapes, not depended on (this branches from `main`, and it lives on the wrong side of the same module boundary).

`check-react-doctor-changed.mjs` is the one case that genuinely needs the pnpm CLI — `dlx` fetches `react-doctor@0.9.1` on demand — so it reuses the repo's existing `resolvePnpmCliInvocation()` rather than growing a second answer to the same question. Because that helper can still fall back to a shell when it finds no directly spawnable pnpm, and because `base` comes from argv or `ORCA_CODE_QUALITY_BASE` and is passed through verbatim by `git-pull-request-diff-base.mjs`, caller text would otherwise reach `cmd.exe` unquoted — exactly the hazard cited above for rejecting `shell: true`. `base` is now validated against `/^[A-Za-z0-9._/@^~-]+$/` before the spawn:

```
$ node config/scripts/check-react-doctor-changed.mjs 'main & calc.exe'
Error: Refusing to pass an unsafe diff base to pnpm: main & calc.exe
```

Every realistic revision passes (`origin/main`, `HEAD^`, `HEAD~2`, `488f66c56ae4`, `v1.4.188`, `refs/heads/OrcaWin/fix-windows-lint-gate`); every shell-metacharacter form is rejected. Covered by `check-react-doctor-changed.test.mjs` (5 cases), which asserts refusal happens before any spawn.

## Proof the gate catches a real violation

A scratch file with deliberate faults, on the fixed gate:

```
$ node config/scripts/check-changed-code-quality.mjs
::error file=src/shared/scratch-gate-probe.ts,line=2,title=eslint(no-unused-vars)::Variable 'unusedLocal' is declared but never used…
code quality: 2 new finding(s) across 6 changed file(s).
src/shared/scratch-gate-probe.ts:2 eslint(no-unused-vars): Variable 'unusedLocal' is declared but never used…
src/shared/scratch-gate-probe.ts:3 eslint(no-debugger): `debugger` statement is not allowed
type-aware code quality: 0 new finding(s) across 6 changed file(s).
React Doctor: 0 new finding(s) across 6 changed file(s).
Changed-code quality gate failed with 2 finding(s) since 488f66c56ae4.
EXIT=1
```

The **type-aware** scan needs `oxlint-tsgolint`, which `pnpm exec` used to put on `PATH` — so it was checked separately that going direct did not quietly turn that scan into a no-op:

```
$ # src/shared/scratch-gate-probe.ts: `await value` on a plain string
type-aware code quality: 1 new finding(s) across 8 changed file(s).
src/shared/scratch-gate-probe.ts:2 typescript(await-thenable): Unexpected `await` of a non-Promise (non-"Thenable") value.
Changed-code quality gate failed with 1 finding(s) since 488f66c56ae4.
```

Review confirmed this independently and went further: re-run under `env -i` with `PATH` stripped to `System32` plus `nodejs`, the type-aware scan still emits `typescript(await-thenable)`. The mechanism is that `require.resolve('oxlint/package.json')` returns the realpath inside the `.pnpm` virtual store, where the peer `oxlint-tsgolint` sits alongside — resolution never depended on `PATH`. `runOxlintScan` also throws on `result.error` and on empty stdout, so there is no silent-degrade path.

On a clean tree, against this PR's own diff:

```
$ node config/scripts/check-changed-code-quality.mjs
code quality: 0 new finding(s) across 8 changed file(s).
type-aware code quality: 0 new finding(s) across 8 changed file(s).
React Doctor: 0 new finding(s) across 8 changed file(s).
Changed-code quality gate passed since 488f66c56ae4.
EXIT=0
```

## Recommendation on extending the ratchet beyond `src/`

**Do not extend `child-process-import-boundary.test.ts`.** Its allowlist is already 182 entries for `src/` alone, and its remedy — "use `runProcess`" — is unreachable from `.mjs` scripts run by bare `node`. Pointing it at `config/scripts/` would add ~100 permanently-allowlisted entries for which no fix is available. That is a large allowlist guarding nothing.

**Added instead: `config/scripts/windows-cmd-shim-spawn-boundary.test.mjs`** — a narrow ratchet on the idiom that actually spreads this defect. It scans `config/scripts` and `tests/tools` recursively (431 files) for any quoted `.cmd`/`.bat` command literal; **29 known offenders**, listed inline, only-shrinks, with a stale-entry check that keeps it from going vacuous against a dead regex.

Deliberately a match on *any* batch-shim literal rather than a list of runner names. An earlier revision matched only `pnpm|npm|npx|yarn|node-gyp|oxlint`, and review demonstrated the gap: `spawnSync('vitest.cmd', [])` sailed through, even though these trees already spawn vitest, playwright, electron-builder and tsc. Widening cost 8 more allowlist entries — scripts that write or assert on shim files rather than spawn them (`dev-cli-terminal-wrapper.mjs` and its test, `electron-builder-config.test.mjs`, `live-remote-freeze-rpc.mjs`, `remote-agent-session-authority-repro.mjs`) plus the three in `tests/tools`, which sat outside both this ratchet and `src/`.

Verified it bites, on all three gaps review identified:

```
+   "config/scripts/zz-vitest-probe.mjs"          # spawnSync('vitest.cmd', [])
+   "config/scripts/zzprobe/nested.mjs"           # a subdirectory, previously unscanned
+   "config/scripts/zz-backslash-probe.mjs"       # "node_modules\.bin\vitest.cmd"
```

Known ceiling, accepted: a shim assembled in a template literal stays uncatchable by a text ratchet, and `codeText` only strips lines that *begin* with a comment marker, so a trailing `// 'pnpm.cmd'` false-positives. Both fail closed. A lint rule was considered instead, but "spawns a batch shim without a shell" needs the options object as well as the target — a dataflow question, not a syntactic one — while the text ratchet catches the copy-paste that actually happens at a fraction of the cost.

## Verification

- **Typecheck** — `run-typecheck-projects-in-parallel.mjs` (all 3 projects): clean, exit 0.
- **Lint** — `oxlint config/scripts`: clean. `oxfmt --check` on all touched files: clean. This PR's own diff through the fixed gate: 0 findings across all 3 scans.
- **Tests** — new: `oxlint-cli-invocation.test.mjs` (2), `windows-cmd-shim-spawn-boundary.test.mjs` (3), `check-react-doctor-changed.test.mjs` (5). Related existing suites all pass: `check-changed-code-quality`, `pnpm-cli-invocation`, `mobile-pairing-qrcode-import-plugin`, `pr-workflow-lint-parity`, `windows-pty-native-capability-workflow`.
- **Whole `config/scripts` suite, before vs after**: 15 failing files / 23 failing tests -> **14 failing files / 22 failing tests**. The file that flipped to green is `mobile-pairing-qrcode-import-plugin.test.mjs`, fixed by this PR. No new failures.

**Pre-existing failures, stated honestly.** The 14 remaining failures are pre-existing, unrelated to this change, Windows-local, and **cause not diagnosed**. An earlier draft attributed them to this box's junctioned-`node_modules` workaround; that is contradicted by the evidence — review measured an identical 15/23 baseline on a repaired full install, so the failures survive the repair and are not virtual-store artifacts. The failing set is dominated by Windows-specific files (`build-windows-cli-launcher`, `trim-windows-icon-source`, `resolve-7za-path`, `install-electron-package-binary`, `verify-dev-channel-packaging`, `check-runtime-electron-ratchet`), which reads as genuine pre-existing Windows-local breakage. Out of scope for this PR.

## Deliberately left alone

- The 17 benchmark / repro / e2e / macOS-build scripts listed above. They are developer-invoked (one, noted, is also a Linux-only CI gate), several have a dead win32 branch by construction, and none can be exercised on this box — changing them blind would be worse than recording them. The ratchet pins the list so it cannot grow.
- `ensure-native-runtime.mjs`'s `shell: true` and `verify-skill-update-roundtrip.mjs`'s `cmd.exe /d /s /c` form — both run correctly today.
- `resolvePnpmCliInvocation()`'s `shell: true` fallback. It is reachable whenever `npm_execpath` is absent, which is the bare-`node` case; the diff-base validation above closes the injection path this PR opened, but hardening the helper itself is a separate change from unbreaking the lint gate.
