### PR TITLE
fix(wsl): resolve conflict and working-tree probes in the host path namespace

### DIFF
--- a/src/main/git/source-control/git-conflict-operation.ts
+++ b/src/main/git/source-control/git-conflict-operation.ts
@@ -9,8 +9,11 @@ import { resolveGitDir } from './resolve-git-dir'
 
 // Why: the git-status → existsSync race can miss a transient HEAD; fall back to 'unknown' for one poll cycle.
 // Why: detect rebase from rebase-merge/ or rebase-apply/ dirs (persist all steps), not REBASE_HEAD (partial, lingers → stale badge).
-export async function detectConflictOperation(worktreePath: string): Promise<GitConflictOperation> {
-  const gitDir = await resolveGitDir(worktreePath)
+export async function detectConflictOperation(
+  worktreePath: string,
+  options: Pick<GitRuntimeOptions, 'wslDistro'> = {}
+): Promise<GitConflictOperation> {
+  const gitDir = await resolveGitDir(worktreePath, options)
   const mergeHead = path.join(gitDir, 'MERGE_HEAD')
   const cherryPickHead = path.join(gitDir, 'CHERRY_PICK_HEAD')
   const rebaseMergeDir = path.join(gitDir, 'rebase-merge')

--- a/src/main/git/source-control/resolve-git-dir.ts
+++ b/src/main/git/source-control/resolve-git-dir.ts
@@ -1,14 +1,25 @@
 import { readFile } from 'node:fs/promises'
 import * as path from 'node:path'
+import { resolveGitMetadataPath, resolveWorktreeHostPath } from '../../../shared/git-metadata-path'
 import { parseGitdirMarkerPayload } from '../../../shared/gitdir-marker-payload'
+import type { GitRuntimeOptions } from '../git-runtime-options'
 
-export async function resolveGitDir(worktreePath: string): Promise<string> {
-  const dotGitPath = path.join(worktreePath, '.git')
+export async function resolveGitDir(
+  worktreePath: string,
+  options: Pick<GitRuntimeOptions, 'wslDistro'> = {}
+): Promise<string> {
+  // Why: git in a WSL distro reports the worktree in the guest namespace, but this read and the
+  // pointer resolve below both run in the Windows main process, where that spelling names nothing.
+  // A relative pointer (`worktree.useRelativePaths`) resolves against it too, so a guest-spelled
+  // base would make Win32 resolve it drive-relative.
+  // Null only for an empty path; the caller's spelling keeps the pre-existing fallback.
+  const hostWorktreePath = resolveWorktreeHostPath(worktreePath, options) ?? worktreePath
+  const dotGitPath = path.join(hostWorktreePath, '.git')
 
   try {
     const gitDir = parseGitdirMarkerPayload(await readFile(dotGitPath, 'utf-8'))
     if (gitDir) {
-      return path.resolve(worktreePath, gitDir)
+      return resolveGitMetadataPath(hostWorktreePath, gitDir, options) ?? dotGitPath
     }
   } catch {
     // `.git` is likely a directory in a non-worktree checkout.

--- a/src/main/git/source-control/status-conflict-entries.ts
+++ b/src/main/git/source-control/status-conflict-entries.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { access } from 'node:fs/promises'
 import * as path from 'node:path'
 import type {
   GitConflictKind,
@@ -78,10 +78,15 @@ async function getConflictCompatibilityStatus(
     return 'deleted'
   }
 
+  // Why async: on a WSL worktree this path is a `\\wsl.localhost\...` share, and a sync probe
+  // per asymmetric conflict blocks the Electron main thread for a 9p round trip each.
   try {
-    return existsSync(path.join(worktreePath, filePath)) ? 'modified' : 'deleted'
-  } catch {
-    // Why: on an fs check failure, 'modified' is safer — it keeps the row visible rather than falsely showing 'deleted'.
+    await access(path.join(worktreePath, filePath))
     return 'modified'
+  } catch (error) {
+    // Why: only a definite "not there" reads as deleted; any other fs failure keeps the row visible
+    // rather than falsely showing 'deleted'.
+    const code = (error as NodeJS.ErrnoException).code
+    return code === 'ENOENT' || code === 'ENOTDIR' ? 'deleted' : 'modified'
   }
 }

--- a/src/main/git/source-control/status-read.ts
+++ b/src/main/git/source-control/status-read.ts
@@ -12,6 +12,7 @@ import {
   clearGitStatusLineStatsCacheKey,
   reuseOrRecomputeGitStatusLineStats
 } from '../../../shared/git-status-line-stats-cache'
+import { resolveWorktreeHostPath } from '../../../shared/git-metadata-path'
 import { gitOptionalLocksDisabledEnv, gitStreamStdout } from '../runner'
 import { findExistingWorktreeSymlinkPaths } from '../worktree-symlink-detection'
 import type { GetStatusOptions } from './get-status-options'
@@ -80,14 +81,19 @@ function getStatusReadKey(worktreePath: string, options: GetStatusOptions): stri
 async function dropSharedSymlinkUntrackedEntries(
   worktreePath: string,
   entries: GitStatusEntry[],
-  sharedLinkPaths: readonly string[]
+  options: GetStatusOptions
 ): Promise<void> {
+  const sharedLinkPaths = options.sharedLinkPaths ?? []
   // Why: a clean tree has no untracked entries, so this costs nothing on the
   // common status-poll path — no syscall, no config read, no subprocess.
   if (sharedLinkPaths.length === 0 || !entries.some((entry) => entry.area === 'untracked')) {
     return
   }
-  const sharedLinks = new Set(await findExistingWorktreeSymlinkPaths(worktreePath, sharedLinkPaths))
+  const sharedLinks = new Set(
+    await findExistingWorktreeSymlinkPaths(worktreePath, sharedLinkPaths, {
+      wslDistro: options.wslDistro
+    })
+  )
   if (sharedLinks.size === 0) {
     return
   }
@@ -112,7 +118,7 @@ async function runGetStatus(
   const limit = resolveGitStatusLimit(options.limit)
 
   // Why: detectConflictOperation and git status are independent, so run them concurrently to save I/O latency.
-  const conflictPromise = detectConflictOperation(worktreePath)
+  const conflictPromise = detectConflictOperation(worktreePath, options)
   // Why: core.quotePath=false keeps non-ASCII paths as raw UTF-8, not octal escapes, so entry.path is readable and lookups match.
   const statusArgs = [
     '-c',
@@ -167,6 +173,8 @@ async function runGetStatus(
 
   const entries: GitStatusEntry[] = []
   const { head, branch, upstreamName, upstreamAheadBehind } = parser.branch
+  // Why: git runs in the distro and answers in its namespace; the working-tree probes below run here.
+  const hostWorktreePath = resolveWorktreeHostPath(worktreePath, options) ?? worktreePath
 
   // Why: resolve deferred conflicts in Git's output order so the cap cannot hide
   // an early conflict behind ordinary rows that appeared later in the stream.
@@ -177,14 +185,14 @@ async function runGetStatus(
     if (record.type === 'entry') {
       entries.push(record.entry)
     } else {
-      const unmergedEntry = await parseUnmergedEntry(worktreePath, record.line)
+      const unmergedEntry = await parseUnmergedEntry(hostWorktreePath, record.line)
       if (unmergedEntry) {
         entries.push(unmergedEntry)
       }
     }
   }
 
-  await dropSharedSymlinkUntrackedEntries(worktreePath, entries, options.sharedLinkPaths ?? [])
+  await dropSharedSymlinkUntrackedEntries(worktreePath, entries, options)
 
   if (statusSucceeded && !didHitLimit && shouldProbeEffectiveUpstreamStatus(branch, upstreamName)) {
     const branchName = getShortBranchName(branch)

--- a/src/main/git/status-conflict-operations.test.ts
+++ b/src/main/git/status-conflict-operations.test.ts
@@ -147,4 +147,100 @@ describe('detectConflictOperation', () => {
 
     await expect(detectConflictOperation('/repo')).resolves.toBe('unknown')
   })
+
+  // Both cases below assert the probed prefix rather than the joined string so they exercise
+  // Win32 pointer resolution on every host, where `path.join` still uses the host separator.
+  it('probes the drive spelling of a drvfs gitdir pointer on Windows', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    readFileMock.mockResolvedValue('gitdir: /mnt/c/Users/me/repo/.git/worktrees/feature\n')
+    accessMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+
+    try {
+      await expect(detectConflictOperation(String.raw`C:\Users\me\repo\feature`)).resolves.toBe(
+        'unknown'
+      )
+      for (const [target] of accessMock.mock.calls) {
+        expect(target).toContain(String.raw`C:\Users\me\repo\.git\worktrees\feature`)
+      }
+      expect(accessMock).toHaveBeenCalledTimes(4)
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
+
+  // The worktree path itself can be guest-spelled (git in the distro reports it that way), so the
+  // gitfile read has to be translated too or it ENOENTs before any pointer resolution happens.
+  it('reads the gitfile at the host spelling of a guest-spelled worktree', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    readFileMock.mockResolvedValue('gitdir: /mnt/c/Users/me/repo/.git/worktrees/feature\n')
+    accessMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+
+    try {
+      await expect(detectConflictOperation('/mnt/c/Users/me/repo/feature')).resolves.toBe('unknown')
+      expect(readFileMock).toHaveBeenCalledTimes(1)
+      expect(readFileMock.mock.calls[0][0]).toContain(String.raw`C:\Users\me\repo\feature`)
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
+
+  // A plain clone inside the distro has a `.git` directory, so the gitfile read fails and the
+  // markers are probed under the worktree itself — that fallback needs the host spelling too.
+  it('probes a directory .git under the distro share when the caller names one', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    readFileMock.mockRejectedValue(Object.assign(new Error('EISDIR'), { code: 'EISDIR' }))
+    accessMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+
+    try {
+      await expect(
+        detectConflictOperation('/home/me/repo/feature', { wslDistro: 'Ubuntu' })
+      ).resolves.toBe('unknown')
+      expect(readFileMock.mock.calls[0][0]).toContain(
+        String.raw`\\wsl.localhost\Ubuntu\home\me\repo\feature`
+      )
+      for (const [target] of accessMock.mock.calls) {
+        expect(target).toContain(String.raw`\\wsl.localhost\Ubuntu\home\me\repo\feature`)
+      }
+      expect(accessMock).toHaveBeenCalledTimes(4)
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
+
+  // `git worktree repair --relative-paths` (2.48+) writes `gitdir: ../../..`, which the guest
+  // spelling of the worktree would resolve drive-relative on Win32.
+  it('resolves a relative gitdir pointer against the host spelling of the worktree', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    readFileMock.mockResolvedValue('gitdir: ../.git/worktrees/feature\n')
+    accessMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+
+    try {
+      await expect(detectConflictOperation('/mnt/c/Users/me/repo/feature')).resolves.toBe('unknown')
+      for (const [target] of accessMock.mock.calls) {
+        expect(target).toContain(String.raw`C:\Users\me\repo\.git\worktrees\feature`)
+      }
+      expect(accessMock).toHaveBeenCalledTimes(4)
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
+
+  it('probes the distro UNC share when the caller names one', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    readFileMock.mockResolvedValue('gitdir: /home/me/repo/.git/worktrees/feature\n')
+    accessMock.mockImplementation(async (target: string) =>
+      target.includes(String.raw`\\wsl.localhost\Ubuntu\home\me\repo\.git\worktrees\feature`) &&
+      target.endsWith('MERGE_HEAD')
+        ? undefined
+        : Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+    )
+
+    try {
+      await expect(
+        detectConflictOperation(String.raw`C:\Users\me\repo\feature`, { wslDistro: 'Ubuntu' })
+      ).resolves.toBe('merge')
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
 })

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -15,8 +15,7 @@ const {
   readFileMock,
   statMock,
   rmMock,
-  accessMock,
-  existsSyncMock
+  accessMock
 } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
   gitExecFileAsyncBufferMock: vi.fn(),
@@ -26,8 +25,7 @@ const {
   readFileMock: vi.fn(),
   statMock: vi.fn(),
   rmMock: vi.fn(),
-  accessMock: vi.fn(),
-  existsSyncMock: vi.fn()
+  accessMock: vi.fn()
 }))
 
 vi.mock('./runner', () =>
@@ -49,11 +47,6 @@ vi.mock('fs/promises', () =>
   })
 )
 
-// Why still here: unmerged-entry parsing probes the working tree through node:fs directly.
-vi.mock('fs', () => ({
-  existsSync: existsSyncMock
-}))
-
 vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) =>
   createBoundedFileReaderModuleMock(await importOriginal<typeof BoundedFileReader>(), {
     readFileMock,
@@ -71,7 +64,6 @@ describe('getStatus', () => {
     gitStreamOptionsMock.mockReset()
     lstatMock.mockReset()
     readFileMock.mockReset()
-    existsSyncMock.mockReset()
     accessMock.mockReset()
     accessMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
     // Why: untracked line counting stats a file before reading it; any
@@ -130,11 +122,9 @@ describe('getStatus', () => {
     })
   })
 
-  it('falls back to modified when the filesystem existence check throws', async () => {
+  it('falls back to modified when the working-tree probe fails for a non-absence reason', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockImplementation(() => {
-      throw new Error('stat failed')
-    })
+    accessMock.mockRejectedValue(Object.assign(new Error('EIO'), { code: 'EIO' }))
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
         'u AU N... 100644 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc src/new.ts\n'
@@ -144,6 +134,61 @@ describe('getStatus', () => {
 
     expect(result.entries[0]?.status).toBe('modified')
     expect(result.entries[0]?.conflictKind).toBe('added_by_us')
+  })
+
+  // Why both cases normalize separators: git reports the worktree in the WSL guest namespace, and
+  // the assertion is about which path is probed, not which separator this host's `path` emits.
+  it('probes the conflict working tree through the distro spelling on Windows', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    readFileMock.mockResolvedValue('gitdir: /home/me/repo/.git/worktrees/feature\n')
+    accessMock.mockImplementation(async (target: string) => {
+      if (String(target).endsWith('new.ts')) {
+        return undefined
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout:
+        'u DU N... 100644 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc src/new.ts\n'
+    })
+
+    try {
+      const result = await getStatus('/home/me/repo/feature', { wslDistro: 'Ubuntu' })
+
+      const probed = accessMock.mock.calls.map(([target]) => String(target).replaceAll('\\', '/'))
+      expect(probed).toContain('//wsl.localhost/Ubuntu/home/me/repo/feature/src/new.ts')
+      expect(result.entries[0]?.status).toBe('modified')
+      expect(result.entries[0]?.conflictKind).toBe('deleted_by_us')
+      // The conflict-marker probes travel the same way.
+      expect(
+        probed.filter((target) =>
+          target.startsWith('//wsl.localhost/Ubuntu/home/me/repo/.git/worktrees/feature/')
+        )
+      ).toHaveLength(4)
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
+
+  it('probes shared symlinks through the distro spelling on Windows', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    readFileMock.mockResolvedValue('gitdir: /home/me/repo/.git/worktrees/feature\n')
+    lstatMock.mockResolvedValue({ isSymbolicLink: () => true })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '? node_modules\n' })
+
+    try {
+      const result = await getStatus('/home/me/repo/feature', {
+        wslDistro: 'Ubuntu',
+        sharedLinkPaths: ['node_modules']
+      })
+
+      expect(String(lstatMock.mock.calls[0]?.[0]).replaceAll('\\', '/')).toContain(
+        '//wsl.localhost/Ubuntu/home/me/repo/feature/node_modules'
+      )
+      expect(result.entries).toEqual([])
+    } finally {
+      platformSpy.mockRestore()
+    }
   })
 
   it('passes core.quotePath=false and round-trips UTF-8 paths', async () => {
@@ -632,7 +677,6 @@ describe('getStatus', () => {
 
   it('caps unmerged conflicts and keeps the visible conflict rows', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(true)
     const lines = [
       'u UU S... 160000 160000 160000 160000 aa bb cc vendor/submodule',
       ...Array.from(
@@ -655,7 +699,6 @@ describe('getStatus', () => {
 
   it('keeps an early conflict ahead of later ordinary rows at the cap', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(true)
     const lines = [
       '? before.ts',
       'u UU N... 100644 100644 100644 100644 aa bb cc conflict.ts',

--- a/src/main/git/worktree-diff-stamp-host-paths.test.ts
+++ b/src/main/git/worktree-diff-stamp-host-paths.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { readFileMock, statMock } = vi.hoisted(() => ({
+  readFileMock: vi.fn(),
+  statMock: vi.fn()
+}))
+
+vi.mock('fs/promises', () => ({
+  readFile: readFileMock,
+  stat: statMock
+}))
+
+import { readWorktreeDiffStamp } from './source-control/worktree-diff-stamp'
+
+const slashed = (value: unknown): string => String(value).replaceAll('\\', '/')
+const missing = () => Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+
+// Why this file: git in a WSL distro reports the worktree as `/mnt/c/...`, and the gitdir resolve
+// reaches it on its own. If the working-tree read did not travel the same way, the stamp would be
+// built from a real HEAD and a permanently absent file — a settled diff that survives every edit.
+describe('readWorktreeDiffStamp on a drvfs-spelled WSL worktree', () => {
+  beforeEach(() => {
+    readFileMock.mockReset()
+    statMock.mockReset()
+    readFileMock.mockImplementation(async (target: string) => {
+      const value = slashed(target)
+      if (value === 'C:/repo/wt/.git') {
+        return 'gitdir: /mnt/c/repo/.git/worktrees/wt\n'
+      }
+      // Detached HEAD, so the stamp needs no ref-store walk.
+      if (value === 'C:/repo/.git/worktrees/wt/HEAD') {
+        return `${'a'.repeat(40)}\n`
+      }
+      throw missing()
+    })
+    statMock.mockImplementation(async (target: string) =>
+      slashed(target) === 'C:/repo/wt/src/a.ts'
+        ? { mtimeMs: 1_000, size: 12, ino: 7 }
+        : Promise.reject(missing())
+    )
+  })
+
+  it('stamps the working-tree file through the same host spelling as the gitdir', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    try {
+      const stamp = await readWorktreeDiffStamp('/mnt/c/repo/wt', 'src/a.ts', true)
+
+      expect(stamp).not.toBeNull()
+      expect(statMock.mock.calls.map(([target]) => slashed(target))).toContain(
+        'C:/repo/wt/src/a.ts'
+      )
+      // The working-tree component is what moves when the user edits, so it has to be present.
+      expect(stamp?.newestMtimeMs).toBe(1_000)
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
+})

--- a/src/main/git/worktree-symlink-detection.ts
+++ b/src/main/git/worktree-symlink-detection.ts
@@ -1,5 +1,6 @@
 import { lstat } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { resolveWorktreeHostPath } from '../../shared/git-metadata-path'
 
 // Why this is a leaf module rather than part of ipc/worktree-symlinks: status
 // and review-creation need only the read-only "is this a symlink" question, and
@@ -32,10 +33,19 @@ export function getSafeRelativePath(rawPath: string): SafeRelativePathResult {
   return { safe: true, rel }
 }
 
+export type WorktreeSymlinkDetectionOptions = {
+  /** Distro that spelled `worktreePath`, for a Windows host reopening a guest path. */
+  wslDistro?: string
+}
+
 export async function findExistingWorktreeSymlinkPaths(
   worktreePath: string,
-  paths: readonly string[]
+  paths: readonly string[],
+  options: WorktreeSymlinkDetectionOptions = {}
 ): Promise<string[]> {
+  // Why: git in a WSL distro reports the worktree in the guest namespace, but this lstat runs in
+  // the Windows main process, where that spelling names nothing.
+  const hostWorktreePath = resolveWorktreeHostPath(worktreePath, options) ?? worktreePath
   const symlinkPaths: string[] = []
   for (const rawPath of paths) {
     const safePath = getSafeRelativePath(rawPath)
@@ -43,7 +53,7 @@ export async function findExistingWorktreeSymlinkPaths(
       continue
     }
     try {
-      if ((await lstat(resolve(worktreePath, safePath.rel))).isSymbolicLink()) {
+      if ((await lstat(resolve(hostWorktreePath, safePath.rel))).isSymbolicLink()) {
         symlinkPaths.push(safePath.rel)
       }
     } catch {

--- a/src/main/ipc/filesystem-conflict-operation-routing.test.ts
+++ b/src/main/ipc/filesystem-conflict-operation-routing.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  handlers,
+  store,
+  REPO_PATH,
+  WORKTREE_FEATURE_PATH,
+  detectConflictOperationMock,
+  resetFilesystemIpcMocks
+} from './filesystem-test-harness'
+
+const getLocalGitOptionsForRegisteredWorktreeMock = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', async () => (await import('./filesystem-test-harness')).electronMock)
+vi.mock('fs/promises', async () => (await import('./filesystem-test-harness')).fsPromisesMock)
+vi.mock(
+  '../wsl-unc-delete',
+  async () => (await import('./filesystem-test-harness')).wslUncDeleteMock
+)
+vi.mock(
+  '../crash-reporting/crash-breadcrumb-store',
+  async () => (await import('./filesystem-test-harness')).crashBreadcrumbMock
+)
+vi.mock(
+  '../local-downloaded-folder-promotion',
+  async () => (await import('./filesystem-test-harness')).folderPromotionMock
+)
+vi.mock(
+  '../git/status',
+  async () => (await import('./filesystem-test-harness')).gitStatusModuleMock
+)
+vi.mock(
+  '../git/check-ignored-paths',
+  async () => (await import('./filesystem-test-harness')).gitIgnoredPathsMock
+)
+vi.mock('../git/worktree', async () => (await import('./filesystem-test-harness')).gitWorktreeMock)
+vi.mock(
+  '../providers/ssh-filesystem-dispatch',
+  async () => (await import('./filesystem-test-harness')).sshFilesystemDispatchMock
+)
+vi.mock(
+  '../providers/ssh-git-dispatch',
+  async () => (await import('./filesystem-test-harness')).sshGitDispatchMock
+)
+vi.mock('./local-worktree-runtime-options', () => ({
+  getLocalGitOptionsForRegisteredWorktree: getLocalGitOptionsForRegisteredWorktreeMock,
+  getLocalGitOptionsForRepo: vi.fn(() => ({})),
+  getLocalRepoForRegisteredWorktree: vi.fn(() => undefined)
+}))
+
+import { registerFilesystemHandlers } from './filesystem'
+import {
+  registerWorktreeRootsForRepo,
+  invalidateAuthorizedRootsCache
+} from './registered-worktree-roots-cache'
+
+// Why: `git:conflictOperation` reads the worktree's `.git` pointer directly, so it has to run in
+// the same host namespace as that worktree's git — a WSL project answers in the guest namespace.
+describe('git:conflictOperation local routing', () => {
+  beforeEach(() => {
+    resetFilesystemIpcMocks()
+    invalidateAuthorizedRootsCache()
+    getLocalGitOptionsForRegisteredWorktreeMock.mockReset()
+    getLocalGitOptionsForRegisteredWorktreeMock.mockReturnValue({ wslDistro: 'Ubuntu' })
+    detectConflictOperationMock.mockResolvedValue('merge')
+  })
+
+  it("probes with the registered worktree's local git options", async () => {
+    registerWorktreeRootsForRepo(store as never, 'repo-1', [REPO_PATH, WORKTREE_FEATURE_PATH])
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('git:conflictOperation')!(null, { worktreePath: WORKTREE_FEATURE_PATH })
+    ).resolves.toBe('merge')
+
+    expect(getLocalGitOptionsForRegisteredWorktreeMock).toHaveBeenCalledWith(
+      store,
+      WORKTREE_FEATURE_PATH,
+      WORKTREE_FEATURE_PATH
+    )
+    expect(detectConflictOperationMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH, {
+      wslDistro: 'Ubuntu'
+    })
+  })
+})

--- a/src/main/ipc/filesystem-test-harness.ts
+++ b/src/main/ipc/filesystem-test-harness.ts
@@ -28,6 +28,7 @@ export const realpathMock: IpcMock = vi.fn()
 export const lstatMock: IpcMock = vi.fn()
 export const commitChangesMock: IpcMock = vi.fn()
 export const getStatusMock: IpcMock = vi.fn()
+export const detectConflictOperationMock: IpcMock = vi.fn()
 export const abortMergeMock: IpcMock = vi.fn()
 export const abortRebaseMock: IpcMock = vi.fn()
 export const getDiffMock: IpcMock = vi.fn()
@@ -88,6 +89,7 @@ export const folderPromotionMock = {
 export const gitStatusModuleMock = {
   commitChanges: commitChangesMock,
   getStatus: getStatusMock,
+  detectConflictOperation: detectConflictOperationMock,
   abortMerge: abortMergeMock,
   abortRebase: abortRebaseMock,
   getDiff: getDiffMock,

--- a/src/main/ipc/filesystem/filesystem-git-status-handlers.ts
+++ b/src/main/ipc/filesystem/filesystem-git-status-handlers.ts
@@ -223,7 +223,12 @@ export function registerFilesystemGitStatusHandlers(context: FilesystemHandlerCo
         return provider.detectConflictOperation(args.worktreePath)
       }
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
-      return detectConflictOperation(worktreePath)
+      const gitOptions = getLocalGitOptionsForRegisteredWorktree(
+        store,
+        args.worktreePath,
+        worktreePath
+      )
+      return detectConflictOperation(worktreePath, gitOptions)
     }
   )
 

--- a/src/main/runtime/runtime-git-conflict-operation-routing.test.ts
+++ b/src/main/runtime/runtime-git-conflict-operation-routing.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as GitStatusModule from '../git/status'
+
+const detectConflictOperationMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../git/status', async () => ({
+  ...(await vi.importActual<typeof GitStatusModule>('../git/status')),
+  detectConflictOperation: detectConflictOperationMock
+}))
+
+import { RuntimeGitStatusCommands } from './runtime-git-status-commands'
+
+// Why: the conflict badge the runtime RPC serves is read from the worktree's `.git` pointer, so it
+// must run in the same host namespace as the target's git — a WSL target's paths are guest-spelled.
+describe('getRuntimeGitConflictOperation', () => {
+  beforeEach(() => {
+    detectConflictOperationMock.mockReset()
+    detectConflictOperationMock.mockResolvedValue('merge')
+  })
+
+  it("probes with the target's local git options", async () => {
+    const commands = new RuntimeGitStatusCommands({
+      resolveRuntimeGitTarget: async () => ({
+        worktree: { path: '/home/me/repo/feature' },
+        localGitOptions: { wslDistro: 'Ubuntu' }
+      })
+    } as never)
+
+    await expect(commands.getRuntimeGitConflictOperation('id:wt-1')).resolves.toBe('merge')
+
+    expect(detectConflictOperationMock).toHaveBeenCalledWith('/home/me/repo/feature', {
+      wslDistro: 'Ubuntu'
+    })
+  })
+})

--- a/src/main/runtime/runtime-git-status-commands.ts
+++ b/src/main/runtime/runtime-git-status-commands.ts
@@ -116,7 +116,7 @@ export class RuntimeGitStatusCommands {
       }
       return provider.detectConflictOperation(target.worktree.path)
     }
-    return detectConflictOperation(target.worktree.path)
+    return detectConflictOperation(target.worktree.path, localGitOptionsForTarget(target))
   }
 
   async checkoutRuntimeGitBranch(

--- a/src/main/source-control/hosted-review-creation-git-state.ts
+++ b/src/main/source-control/hosted-review-creation-git-state.ts
@@ -268,7 +268,7 @@ export async function hasUncommittedChanges(
   if (records.length === 0) {
     return false
   }
-  return await anyRecordIsUserDirt(repoPath, records, options.sharedLinkPaths ?? [])
+  return await anyRecordIsUserDirt(repoPath, records, options)
 }
 
 /** True when any record is real user work rather than a shared symlink Orca put
@@ -280,14 +280,21 @@ export async function hasUncommittedChanges(
 async function anyRecordIsUserDirt(
   worktreePath: string,
   records: readonly PorcelainV1Record[],
-  sharedLinkPaths: readonly string[]
+  options: HostedReviewExecutionOptions
 ): Promise<boolean> {
+  const sharedLinkPaths = options.sharedLinkPaths ?? []
   if (sharedLinkPaths.length === 0 || !records.some((record) => record.xy === '??')) {
     return true
   }
   // Why: only entries that are configured AND really symlinks are excluded, so a
   // regular file the user created at a configured name still blocks creation.
-  const sharedLinks = new Set(await findExistingWorktreeSymlinkPaths(worktreePath, sharedLinkPaths))
+  // Why the distro: git ran in the guest, so an untranslated lstat fails here and this
+  // fail-closed check would block review creation over Orca's own symlink.
+  const sharedLinks = new Set(
+    await findExistingWorktreeSymlinkPaths(worktreePath, sharedLinkPaths, {
+      wslDistro: getHostedReviewLocalGitOptions(options).wslDistro
+    })
+  )
   return records.some((record) => record.xy !== '??' || !sharedLinks.has(record.path))
 }
 

--- a/src/main/source-control/hosted-review-dirty-preflight-wsl-paths.test.ts
+++ b/src/main/source-control/hosted-review-dirty-preflight-wsl-paths.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock, findExistingWorktreeSymlinkPathsMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  findExistingWorktreeSymlinkPathsMock: vi.fn()
+}))
+
+vi.mock('../github/gh-utils', () => ({
+  acquire: vi.fn(),
+  release: vi.fn(),
+  ghExecFileAsync: vi.fn(),
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+vi.mock('../git/worktree-symlink-detection', () => ({
+  findExistingWorktreeSymlinkPaths: findExistingWorktreeSymlinkPathsMock
+}))
+
+import { hasUncommittedChanges } from './hosted-review-creation-git-state'
+
+// Why: git ran inside the distro and answered in its namespace, so the fail-closed shared-symlink
+// check must lstat the host spelling — otherwise it never recognises Orca's own symlink and blocks
+// review creation on a permanently "dirty" WSL worktree.
+describe('hasUncommittedChanges shared-symlink probe', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    findExistingWorktreeSymlinkPathsMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '?? node_modules\0', stderr: '' })
+    findExistingWorktreeSymlinkPathsMock.mockResolvedValue(['node_modules'])
+  })
+
+  it('passes the configured distro through to the probe', async () => {
+    await expect(
+      hasUncommittedChanges('/home/me/repo/feature', null, {
+        localGitExecOptions: { wslDistro: 'Ubuntu' },
+        sharedLinkPaths: ['node_modules']
+      })
+    ).resolves.toBe(false)
+
+    expect(findExistingWorktreeSymlinkPathsMock).toHaveBeenCalledWith(
+      '/home/me/repo/feature',
+      ['node_modules'],
+      { wslDistro: 'Ubuntu' }
+    )
+  })
+})

--- a/src/shared/git-metadata-path.test.ts
+++ b/src/shared/git-metadata-path.test.ts
@@ -47,6 +47,18 @@ describe('resolveGitMetadataPath', () => {
     ).toBe(String.raw`\\wsl.localhost\Ubuntu\home\me\repo\.git`)
   })
 
+  // Git for Windows spells a UNC gitdir with forward slashes; that is already a host path, and
+  // translating it would produce `\\wsl.localhost\Ubuntu\\wsl.localhost\Ubuntu\...`.
+  it('keeps a forward-slash UNC pointer verbatim rather than re-prefixing the share', () => {
+    expect(
+      resolveGitMetadataPath(
+        String.raw`\\wsl.localhost\Ubuntu\home\me\repo\feature`,
+        '//wsl.localhost/Ubuntu/home/me/repo/.git/worktrees/feature',
+        { platform: 'win32', wslDistro: 'Ubuntu' }
+      )
+    ).toBe('//wsl.localhost/Ubuntu/home/me/repo/.git/worktrees/feature')
+  })
+
   it('lets the distro encoded by a WSL UNC base outrank the caller-named one', () => {
     expect(
       resolveGitMetadataPath(
@@ -167,5 +179,44 @@ describe('resolveWorktreeHostPath', () => {
 
   it.each(['', '   '])('has no spelling for an empty worktree path %j', (worktreePath) => {
     expect(resolveWorktreeHostPath(worktreePath, { platform: 'win32' })).toBeNull()
+  })
+
+  it('maps a drvfs worktree to its drive spelling on a Windows host', () => {
+    expect(resolveWorktreeHostPath('/mnt/c/Users/me/repo/feature', { platform: 'win32' })).toBe(
+      String.raw`C:\Users\me\repo\feature`
+    )
+  })
+
+  it('maps a guest worktree through a caller-named distro', () => {
+    expect(
+      resolveWorktreeHostPath('/home/me/repo/feature', { platform: 'win32', wslDistro: 'Ubuntu' })
+    ).toBe(String.raw`\\wsl.localhost\Ubuntu\home\me\repo\feature`)
+  })
+
+  it('keeps a guest worktree verbatim on Windows when no distro names it', () => {
+    expect(resolveWorktreeHostPath('/home/me/repo/feature', { platform: 'win32' })).toBe(
+      '/home/me/repo/feature'
+    )
+  })
+
+  it('ignores a caller-named distro on a POSIX host', () => {
+    expect(
+      resolveWorktreeHostPath('/home/me/repo/feature', { platform: 'linux', wslDistro: 'Ubuntu' })
+    ).toBe('/home/me/repo/feature')
+    expect(
+      resolveWorktreeHostPath('/mnt/c/repo/feature', { platform: 'darwin', wslDistro: 'Ubuntu' })
+    ).toBe('/mnt/c/repo/feature')
+  })
+
+  // `//x` is a host UNC spelling, not a guest path: translating it would prepend a second share.
+  // A relative path is deliberately absent: the wrapper resolves one against the cwd.
+  it.each([
+    String.raw`C:\Users\me\repo\feature`,
+    String.raw`\\wsl.localhost\Ubuntu\home\me\repo\feature`,
+    '//wsl.localhost/Ubuntu/home/me/repo/feature'
+  ])('leaves a non-guest worktree path untouched: %j', (worktreePath) => {
+    expect(resolveWorktreeHostPath(worktreePath, { platform: 'win32', wslDistro: 'Ubuntu' })).toBe(
+      worktreePath
+    )
   })
 })

--- a/src/shared/git-metadata-path.ts
+++ b/src/shared/git-metadata-path.ts
@@ -1,6 +1,11 @@
 import { posix, win32 } from 'node:path'
 import { parseWslUncPath, toWindowsWslDrivePath, toWindowsWslPath } from './wsl-paths'
 
+// Why the single-leading-slash rule: only `/x` is a guest-namespace path. `//x` is already a host
+// UNC spelling that Win32 opens as-is, and translating it would prepend a second share prefix.
+// Same guard `resolveWslRepoWorktreeBasePath` uses for the same ambiguity.
+const GUEST_ROOTED_PATH = /^\/(?!\/)/
+
 export type GitMetadataPathOptions = {
   /** Host that reads the pointer back. Defaults to the current process platform. */
   platform?: NodeJS.Platform
@@ -26,7 +31,7 @@ export function resolveGitMetadataPath(
   if (!value) {
     return null
   }
-  if (value.startsWith('/')) {
+  if (GUEST_ROOTED_PATH.test(value)) {
     const translated = translateGuestPointer(value, basePath, platform, options.wslDistro)
     if (translated) {
       return translated
@@ -61,7 +66,9 @@ function translateGuestPointer(
 }
 
 /**
- * The reading host's spelling of a worktree *directory*.
+ * The reading host's spelling of a worktree *directory*. Git inside WSL answers in the guest
+ * namespace, so a Windows host reopening one of those paths needs the drvfs drive or the distro's
+ * UNC share.
  *
  * A directory is not a pointer: `resolveGitMetadataPath` trims because a gitfile payload carries a
  * trailing newline, but a directory name may legally begin or end with whitespace on POSIX. Keep


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​430 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​414 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 |

<!-- /orca-pr-loc -->

# Problem

Git running inside a WSL distro writes `.git` gitdir pointers, and answers `status --porcelain=v2`, in the guest namespace. Node reads both back in the Windows main process, where `/mnt/c/repo/.git` resolves to `C:\mnt\c\repo\.git` and `/home/me/wt` names nothing at all.

Four filesystem probes were built directly on those fabricated paths, so they always came back "absent":

- **`detectConflictOperation`** — `resolveGitDir` did `path.resolve(worktreePath, gitdirPointer)`. Measured on real hardware for the Windows-spelled-worktree case: `resolveGitDir('C:\Users\me\wt')` on a WSL-created worktree returns `C:\mnt\c\...`, which does not exist. All four marker probes (`MERGE_HEAD`, `CHERRY_PICK_HEAD`, `rebase-merge/`, `rebase-apply/`) miss and the operation reads `'unknown'`, so merge/rebase/cherry-pick badges silently go missing.
- **`parseUnmergedEntry`** — the `deleted_by_*` / `added_by_*` compat status came from `existsSync(path.join(worktreePath, filePath))`. On an untranslated worktree path that is always false, so every such conflict renders as `'deleted'` regardless of what is actually in the working tree.
- **`findExistingWorktreeSymlinkPaths`, from status** — the `lstat` fails, so Orca's own shared symlinks (`node_modules` and friends) are never dropped from untracked entries and show up as user changes in a permanently "dirty" worktree.
- **`findExistingWorktreeSymlinkPaths`, from the hosted-review dirty preflight** — the same `lstat`, but this caller fails *closed* by design. An unreadable shared symlink counts as uncommitted work, so PR/MR creation is blocked outright with a false "uncommitted changes" over a symlink Orca itself created and the user cannot commit.

# What this change does

**`resolveGitDir` computes the host spelling of the worktree once**, at the top, and uses it for both the gitfile read and the pointer resolve. That matters in two separate ways:

- The worktree path can itself be guest-spelled (`/mnt/c/repo/wt`, `/home/me/wt`). Reading `.git` at the untranslated path ENOENTs before any pointer resolution happens, so the whole function was unreachable on that input. When the gitfile read fails legitimately — a plain clone inside the distro, where `.git` is a directory — the marker probes now run under the translated `.git` too.
- A *relative* pointer, what `worktree.useRelativePaths` / `git worktree repair --relative-paths` (git 2.48+) writes, is resolved against that base. A guest-spelled base made Win32 take it as drive-relative.

The pointer itself resolves through the already-landed `resolveGitMetadataPath` (#17804) instead of `path.resolve`, and `resolveGitDir` gains an optional `{ wslDistro }` for a caller whose base path does not encode a distro.

`resolveWorktreeHostPath` is the same translation rule applied to a worktree path rather than a metadata pointer. `status-read` computes it once and hands it to `parseUnmergedEntry`, and forwards the distro to `findExistingWorktreeSymlinkPaths`. `hasUncommittedChanges` forwards the same distro into its fail-closed preflight.

**Only a single-leading-slash path is guest namespace now.** Both `resolveWorktreeHostPath` and `resolveGitMetadataPath` guard with `/^\/(?!\/)/` — the same rule `resolveWslRepoWorktreeBasePath` already uses for the same ambiguity. `//wsl.localhost/Ubuntu/...` (the forward-slash spelling Git for Windows writes into a gitfile) is already a host UNC path; translating it produced `\\wsl.localhost\Ubuntu\\wsl.localhost\Ubuntu\...`.

`detectConflictOperation` forwards the option; the three callers that reach it — `status-read`, the runtime RPC (`runtime-git-status-commands.ts`), and the `git:conflictOperation` IPC (`filesystem.ts`) — pass the git options they already hold and already pass to their immediate neighbours (`getHistory`, `abortMerge`).

`getConflictCompatibilityStatus` moves from `existsSync` to async `access`. This commit is what makes that path real: once the worktree path is correct it is a `\\wsl.localhost\<distro>\...` share, and a sync probe per asymmetric conflict blocks the Electron main thread for a 9p round trip on every status poll — the same reason `detectConflictOperation` was converted earlier.

`resolveGitDir` keeps `Promise<string>` and `parseUnmergedEntry` keeps `worktreePath: string`. No new nullability enters the type system.

## The other `resolveGitDir` callers

The translation lives *inside* `resolveGitDir`, so its three other production callers change behavior for a guest-spelled path even though two of them are untouched source:

| Caller | Effect |
| --- | --- |
| `worktree-sparse-state.ts` (`detectSparseCheckout`) | Untouched source. Now finds `info/sparse-checkout` on a drvfs-spelled WSL worktree where it previously always answered "not sparse". Correct direction, and the only way that badge can appear there. |
| `worktree-diff-stamp.ts` (`readWorktreeDiffStamp`) | **Changed here, deliberately.** It would otherwise have gained a real HEAD and index while its `.gitmodules` and working-tree stats stayed fabricated — a stamp blind to edits, which is exactly the staleness the settled-diff cache exists to prevent. It now translates its worktree base with the same one-liner, so all four components live in one namespace or none do. |
| `worktree-listing.ts` (`readRepoCommonDirFromDisk`) | Untouched and inert either way. It gates on `stat(join(repoPath, '.git'))` with the *untranslated* repo path, so a guest-spelled repo offers no common-dir candidate before `resolveGitDir` is reached. The create-path `resolveGitDir(repoPath).then(resolveGitCommonDir)` witness is unchanged. |

# What changes for users

| Platform / mode | Delta |
| --- | --- |
| **macOS** | **No change.** Guest-pointer translation is gated to `win32`, and a caller-named distro is explicitly ignored off Windows (pinned by test). `resolveWorktreeHostPath` returns its input, so every path joined here is byte-identical. |
| **Linux** | **No change.** Same gate. |
| **native Windows, no WSL** | **No behavioral change.** No path here starts with a single `/`, so nothing is translated and `resolveWorktreeHostPath` returns its input. One string-identity difference: an *absolute* gitdir pointer is now returned verbatim (`C:/repo/.git/worktrees/x`) instead of `path.resolve`-normalized (`C:\repo\.git\worktrees\x`). Every consumer either re-joins it (`path.join` in the marker probes, the index/HEAD reads, sparse-checkout) or normalizes before comparing (`isSameCommonDirPath` → `areWorktreePathsEqual`, which does `win32.normalize(win32.resolve(...)).toLowerCase()`). It is not used as a cache key: `readWorktreeDiffStamp`'s stamp value keys on the worktree path and the component texts, not the gitdir string. |
| **WSL-on-Windows, drvfs worktree (`/mnt/c/...`)** | Fixed. The worktree and the pointer both resolve to `C:\...` instead of the non-existent `C:\mnt\c\...`. Conflict badges appear; `deleted_by_us` / `added_by_them` rows get their real compat status; shared symlinks are dropped again; the review preflight stops falsely blocking; sparse-checkout detection starts working; the diff stamp becomes usable *and* edit-sensitive at the same time. A relative pointer resolves to `C:\repo\.git\worktrees\x` instead of `\mnt\c\repo\.git\worktrees\x`. Needs no configured distro. |
| **WSL-on-Windows, UNC worktree path (`\\wsl.localhost\...`)** | Fixed for the pointer, unchanged in cost. The distro already came from the UNC base before this change; what changes is that `resolveGitDir` now consults it at all. `resolveWorktreeHostPath` leaves the base untouched, so the returned string identity is unchanged in this case. A forward-slash `//wsl.localhost/...` gitdir pointer is now left alone instead of being re-prefixed with a second share. |
| **WSL-on-Windows, guest worktree path (`/home/me/wt`) with a distro named** | Fixed. The gitfile is read at `\\wsl.localhost\<distro>\home\me\wt\.git`, the pointer resolves through the same share, and the working-tree and symlink probes follow. This is the case the round-2 code could not reach at all. |
| **WSL-on-Windows, guest worktree path with no distro named** | Unchanged. There is nothing to translate to, so every path stays verbatim, ENOENT, and the pre-existing fail-safe (`'unknown'` for one poll cycle; `null` stamp, so no diff caching) applies exactly as today. |
| **SSH** | **No change.** All four entry points return through the `getSshGitProvider` branch before reaching any of this code. |
| **relay** | **No change.** `src/relay/git-handler-status-ops.ts` keeps its own `resolveGitDir` and its own `parseUnmergedEntry`; they execute on the remote host, already in that host's namespace. No wire field, opcode, or published content changed. |
| **folder workspace** | **No change.** A folder workspace has no gitdir pointer and no unmerged entries on this path; `resolveGitDir` returns `<path>/.git` as before. |
| **GitLab / other providers** | **No change.** Nothing here is provider-aware; the review-preflight fix is in provider-agnostic code shared by all of them. |
| **Git version** | **No change in requirement.** No new subcommand, option, or output format. The gitfile marker format predates 2.25; the relative-pointer case is 2.48+ *input* that the code now parses correctly, not a command we issue. |

# What this does NOT do

- It does **not** reorder drvfs-before-UNC inside `resolveGitMetadataPath`. Main resolves a caller-named distro before the drvfs drive spelling, and that ordering is kept. Consequence: on a drvfs-hosted WSL repo where the caller *does* name a distro, a `/mnt/c/...` pointer still resolves through `\\wsl.localhost\<distro>\mnt\c\...` (9p) rather than direct NTFS. Correct but slower than it could be, and still strictly better than today, where the same case resolves to a path that does not exist. The reorder changes the *identity* of the returned string, which flows into settled-diff cache keys and `areWorktreePathsEqual` comparisons; it needs a real Windows+WSL box and is deliberately out of scope.
- It does **not** thread a distro into `readWorktreeDiffStamp` or `detectSparseCheckout`. Both translate with no caller-named distro, which covers drvfs and leaves `/home/...` exactly as it is today. Threading the distro through `file-diff.ts` is the diff-stamp slice's job; this commit only removes the namespace *asymmetry* it would otherwise have introduced there.
- It does **not** batch or parallelize the per-conflict working-tree probes. They are still one `access` per asymmetric conflict, awaited in order inside `status-read`'s record loop. They no longer block the main thread, which is the defect being closed.
- It does **not** touch the untracked line-stat / branch-total reads, the working-tree diff reads themselves, or submodule path resolution. Those are separate slices.
- It does **not** touch `getSafeRelativePath`. An earlier local revision weakened its guard from main's `WINDOWS_DRIVE_DESIGNATOR` regex to `posix.isAbsolute || win32.isAbsolute`, which misses the drive-RELATIVE `C:foo` form that regex was added for. That hunk was dropped.
- It does **not** change `src/relay/git-handler-status-ops.ts`, which has a near-identical `resolveGitDir` that now differs from the main-process one. That divergence is pre-existing in shape and intentional here: the relay's copy runs on the host that owns the paths.

# Costs and residual risk

- **One new shared export.** `resolveWorktreeHostPath` lives beside `resolveGitMetadataPath` and reuses its private `translateGuestPointer`, so there is exactly one place where the guest→host rule is written.
- **The `//` guard also changes two pre-existing callers.** `resolveGitMetadataPath` is already used by `src/main/ipc/workspace-cleanup-activity.ts` and `src/main/git/repo-git-marker-scan.ts` (2 sites). For them the guard only stops a `//wsl.localhost/...` pointer from being double-prefixed; every other input takes the same branch as before. Both areas' suites pass.
- **The distro is only as good as its source.** If a project's configured WSL distro is wrong, a `/home/...` path resolves to a UNC share that does not exist — ENOENT, same fail-safe as naming no distro. It cannot resolve to a *different real* path, because a distro name is a share name.
- **The compat-status error semantics changed shape.** `existsSync` collapsed every failure into `false`, so the old `catch → 'modified'` branch was reachable only if `existsSync` itself threw, which it effectively never does; in practice any error read as `'deleted'`. The new code reads `'deleted'` only on ENOENT/ENOTDIR and `'modified'` on anything else (EIO, EACCES, a dead 9p mount). This is a real behavior change on the error path, and it is strictly the safer direction: it keeps the conflict row visible instead of falsely claiming the file was deleted.
- **The status hot path gains awaits, not concurrency.** Each asymmetric conflict is still one round trip, now off the main thread rather than on it. Wall-clock latency for a worktree with many `deleted_by_*` conflicts on a slow 9p mount is comparable; what improves is that the renderer is no longer frozen while it happens.
- **Sparse detection and diff stamping start doing real I/O where they previously failed fast.** On a drvfs-spelled WSL worktree `detectSparseCheckout` now stats a real file per worktree per poll (it already fast-paths on the stat miss) and `readWorktreeDiffStamp` now performs its four real reads instead of bailing at the first. That is the cost of them working at all.
- **A shared test harness grew.** `src/main/ipc/filesystem-test-harness.ts` gained a `detectConflictOperation` mock in its `../git/status` module stub. Nine other suites consume that harness; all were re-run green (9 files / 118 tests + 1 skipped).
- **The diff reaches into a second subsystem.** The hosted-review preflight fix is not the status badge, but it is the same defect in the more damaging place (it blocks review creation rather than mis-rendering a row), so it is fixed here rather than filed.
- **No real 9p mount was exercised.** Only the Windows-spelled-worktree + guest-pointer case was measured on real hardware; every other case here is reasoned from the path rules and pinned by tests that mock `node:fs/promises` and spy the `process.platform` getter. That proves which argument reaches `readFile` / `access` / `lstat` / `stat`, which is the right thing to assert, but nothing in this change has run against an actual WSL filesystem. Stated as a limit, not glossed.

# Verification

**Tests** (macOS host; platform-dependent cases spy `process.platform` and compare separator-normalized strings, so they run and mean the same thing on every host)

- Targeted set — `status.test.ts`, `status-conflict-operations.test.ts`, `worktree-diff-stamp-host-paths.test.ts`, `git-metadata-path.test.ts`, the two new routing tests, the new preflight test, and `hosted-review-creation-shared-symlinks.test.ts`: **8 files / 83 tests passed**.
- `npx vitest run src/main/git src/shared/git-metadata-path.test.ts`, excluding the pre-existing-broken `git-admission-storm-measurement.test.ts`: **197 files / 2,248 tests passed**, 2 files + 5 tests skipped.
- `src/main/source-control` plus the directly-affected consumers (`worktree-symlinks`, `workspace-cleanup-activity`, `runtime-git-api-contract`): **18 files / 205 tests passed**.
- Remaining `filesystem-test-harness` consumers: **9 files / 118 passed, 1 skipped**.
- `npx vitest run src/main/ipc src/main/runtime src/main/source-control` is environmentally flaky at this parallelism (`getUserDataPath`, electron mocks) and its counts drift by several files between identical runs on the *same* tree. Paired measurement: this commit **84 failed files / 546 failed tests / 10,363 passed**, against the base tree (`HEAD~1`, produced by reverse-applying this diff in place) **86 / 548 / 10,358**; an earlier run of this same commit's tree gave 88 / 551. The run was grepped for the four new test files: none of them appears in the failure list.
- `npx vitest run src/main/git src/shared src/relay` (same exclusion) surfaces 8 more failing files, all repo-wide source scanners (`export-let-function-initializer-ban`, `windows-transient-lock-removal`, `wsl-exec-mode-separator`) and timing tests (`setup-agent-sequencing`, `relay/subprocess`) hitting the 5 s test timeout under load. The four-file scanner subset was re-run on the base tree: **identical 7 failures**.
- `npx oxfmt --write` and `npx oxlint` on all 18 changed files: clean, exit 0. No `max-lines` disable added.

**Mutation checks** — every kept test was verified by reverting the production hunk it covers, confirming the test fails, then restoring the file byte-for-byte. All 14 mutations kill:

| # | Reverted hunk | Suite | Result |
| --- | --- | --- | --- |
| 1 | `resolve-git-dir.ts` gitfile read → `path.join(worktreePath, '.git')` | `status-conflict-operations` | FAIL 2/14 |
| 2 | `resolve-git-dir.ts` resolve base → `worktreePath` (relative-pointer fix) | `status-conflict-operations` | FAIL 1/14 |
| 3 | `resolve-git-dir.ts` → `path.resolve(worktreePath, gitDir)` | `status-conflict-operations` + `status` | FAIL 4/43 |
| 4 | `git-metadata-path.ts` `GUEST_ROOTED_PATH` → `startsWith('/')` in `resolveGitMetadataPath` | `git-metadata-path` | FAIL 1/29 |
| 5 | same, in `resolveWorktreeHostPath` | `git-metadata-path` | FAIL 1/29 |
| 6 | `status-read.ts` `parseUnmergedEntry(hostWorktreePath, …)` → `worktreePath` | `status` | FAIL 1/29 |
| 7 | `status-read.ts` `detectConflictOperation(worktreePath, options)` → no options | `status` | FAIL 1/29 |
| 8 | `status-read.ts` `wslDistro: options.wslDistro` → `undefined` | `status` | FAIL 1/29 |
| 9 | `worktree-symlink-detection.ts` `resolve(hostWorktreePath, …)` → `worktreePath` | `status` | FAIL 1/29 |
| 10 | `status-conflict-entries.ts` `await access` → `existsSync` | `status` | FAIL 2/29 |
| 11 | `filesystem.ts` `detectConflictOperation(worktreePath, gitOptions)` → no options | `filesystem-conflict-operation-routing` | FAIL 1/1 |
| 12 | `runtime-git-status-commands.ts` `localGitOptionsForTarget(target)` → no options | `runtime-git-conflict-operation-routing` | FAIL 1/1 |
| 13 | `hosted-review-creation-git-state.ts` `findExistingWorktreeSymlinkPaths(…, { wslDistro })` → no options | `hosted-review-dirty-preflight-wsl-paths` | FAIL 1/1 |
| 14 | `worktree-diff-stamp.ts` `.gitmodules` + working-tree joins → `worktreePath` | `worktree-diff-stamp-host-paths` | FAIL 1/1 |

The eight `resolveWorktreeHostPath` cases in `git-metadata-path.test.ts` cannot pass on the reverted tree at all — the function does not exist there.