### PR TITLE
fix(git): read the diff working tree and stamp through the host path spelling

### DIFF
--- a/src/main/git/source-control/file-diff.ts
+++ b/src/main/git/source-control/file-diff.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path'
 import type { GitDiffResult } from '../../../shared/git-diff-compare-types'
+import { resolveWorktreeHostPath } from '../../../shared/git-metadata-path'
 import { stableInFlightKey } from '../../../shared/in-flight-promise-dedupe'
 import type { GitRuntimeOptions } from '../git-runtime-options'
 import { gitRuntimeOptionsKey } from './git-runtime-options-cache-key'
@@ -7,6 +8,7 @@ import { gitDiffReadDedupe, settledDiffCache } from './git-read-cache-invalidati
 import { readWorktreeDiffStamp } from './worktree-diff-stamp'
 import { buildDiffResult } from './diff-result'
 import {
+  type GitBlobReadResult,
   readGitBlobAtIndexPath,
   readGitBlobAtOidPath,
   readUnstagedLeftBlob,
@@ -76,7 +78,7 @@ async function loadDiffThroughSettledCache(
   // lands entirely inside that window would otherwise leave the fence covering only the git read.
   const readGeneration = settledDiffCache.beginRead()
   // A staged diff compares HEAD to the index, so the working tree is not one of its inputs.
-  const stamp = await readWorktreeDiffStamp(worktreePath, filePath, !staged)
+  const stamp = await readWorktreeDiffStamp(worktreePath, filePath, !staged, options)
   const cached = settledDiffCache.get(readKey, stamp)
   if (cached) {
     return cached
@@ -173,11 +175,15 @@ async function loadDiff(
     } else {
       // The left chain (index→HEAD) is sequential within itself, but the working
       // tree read is a plain fs read that does not depend on it.
+      // Git can run in the distro against a raw Linux worktree path while Node reads it through Win32.
+      const hostWorktreePath = resolveWorktreeHostPath(worktreePath, options)
       const [leftBlob, workingTreeBlob] = await Promise.all([
         compareAgainstHead
           ? readGitBlobAtOidPath(worktreePath, 'HEAD', filePath, options)
           : readUnstagedLeftBlob(worktreePath, filePath, options),
-        readWorkingTreeFile(path.join(worktreePath, filePath))
+        hostWorktreePath
+          ? readWorkingTreeFile(path.join(hostWorktreePath, filePath))
+          : Promise.resolve(UNSPELLABLE_WORKING_TREE_READ)
       ])
       originalContent = leftBlob.content
       originalIsBinary = leftBlob.isBinary
@@ -203,6 +209,14 @@ async function loadDiff(
     return { result: { ...result, modifiedDeleted: true }, reusable: !readFailed }
   }
   return { result, reusable: !readFailed }
+}
+
+/** A worktree path with no host spelling is a read failure, never a proven deletion. */
+const UNSPELLABLE_WORKING_TREE_READ: GitBlobReadResult = {
+  content: '',
+  isBinary: false,
+  exists: true,
+  failed: true
 }
 
 function notReusable(result: GitDiffResult): LoadedDiff {

--- a/src/main/git/source-control/worktree-diff-stamp.ts
+++ b/src/main/git/source-control/worktree-diff-stamp.ts
@@ -1,5 +1,7 @@
 import { readFile, stat } from 'node:fs/promises'
 import * as path from 'node:path'
+import { resolveWorktreeHostPath } from '../../../shared/git-metadata-path'
+import type { GitRuntimeOptions } from '../git-runtime-options'
 import { resolveGitDir } from './resolve-git-dir'
 
 /**
@@ -68,11 +70,18 @@ export function isDiffStampClockSkewed(stamp: WorktreeDiffStamp): boolean {
 export async function readWorktreeDiffStamp(
   worktreePath: string,
   filePath: string,
-  includeWorkingTree: boolean
+  includeWorkingTree: boolean,
+  options: Pick<GitRuntimeOptions, 'wslDistro'> = {}
 ): Promise<WorktreeDiffStamp | null> {
   const capturedAtMs = Date.now()
   try {
-    const gitDir = await resolveGitDir(worktreePath)
+    // Git can run in the distro against a raw Linux worktree path while Node stats it through Win32.
+    const hostWorktreePath = resolveWorktreeHostPath(worktreePath, options)
+    if (!hostWorktreePath) {
+      // Only an empty worktree path lands here, and nothing about it is provably unchanged.
+      return null
+    }
+    const gitDir = await resolveGitDir(hostWorktreePath)
     const [head, index, gitmodules, workingTree] = await Promise.all([
       readHeadComponent(gitDir),
       // Over-invalidates on purpose: git run outside Orca (a terminal `git status`/`git add`)
@@ -81,9 +90,9 @@ export async function readWorktreeDiffStamp(
       // index from the stamp, because `git add` then becomes invisible and the cache serves a
       // pre-staging diff.
       readFileStampComponent(path.join(gitDir, 'index')),
-      readFileStampComponent(path.join(worktreePath, '.gitmodules')),
+      readFileStampComponent(path.join(hostWorktreePath, '.gitmodules')),
       includeWorkingTree
-        ? readWorkingTreeComponent(path.join(worktreePath, filePath))
+        ? readWorkingTreeComponent(path.join(hostWorktreePath, filePath))
         : Promise.resolve(ABSENT)
     ])
     if (!head) {

--- a/src/main/git/status-diff-settled-cache.test.ts
+++ b/src/main/git/status-diff-settled-cache.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as path from 'node:path'
 import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
 import { createBoundedFileReaderModuleMock, createGitRunnerModuleMock } from './status-test-harness'
 
@@ -147,6 +148,86 @@ describe('settled diff cache', () => {
     expect(blobReadCount()).toBe(spawnsAfterFirst)
     expect(second).toEqual(first)
     expect(settledDiffCache.stats().hits).toBe(1)
+  })
+
+  // A WSL-routed read whose worktree path never went through UNC translation: git resolves
+  // `/home/...` inside the distro, but every Node read here has to be spelled for Win32.
+  describe('on a Windows host reading a raw Linux WSL worktree path', () => {
+    const WSL_WORKTREE = '/home/me/repo/feature'
+    const WSL_OPTIONS = { wslDistro: 'Ubuntu' }
+    const HOST_WORKTREE = String.raw`\\wsl.localhost\Ubuntu\home\me\repo\feature`
+    let platformDescriptor: PropertyDescriptor | undefined
+
+    beforeEach(() => {
+      platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      files.clear()
+      // `.git` is a directory here, so the gitdir is the worktree path plus a segment.
+      writeFile(path.join(HOST_WORKTREE, '.git/HEAD'), 'ref: refs/heads/main\n')
+      writeFile(path.join(HOST_WORKTREE, '.git/refs/heads/main'), `${'a'.repeat(40)}\n`)
+      writeFile(path.join(HOST_WORKTREE, '.git/index'), 'index-bytes')
+      writeFile(path.join(HOST_WORKTREE, FILE), 'working-tree-content')
+    })
+
+    afterEach(() => {
+      if (platformDescriptor) {
+        Object.defineProperty(process, 'platform', platformDescriptor)
+      }
+    })
+
+    it('reads the working tree through the host spelling instead of reporting a deletion', async () => {
+      const result = await getDiff(WSL_WORKTREE, FILE, false, false, WSL_OPTIONS)
+
+      expect(result.modifiedContent).toBe('working-tree-content')
+      expect(readFileMock).toHaveBeenCalledWith(path.join(HOST_WORKTREE, FILE))
+      expect(readFileMock).not.toHaveBeenCalledWith(path.join(WSL_WORKTREE, FILE))
+    })
+
+    it('stamps through the host spelling so the second read does not respawn git', async () => {
+      await getDiff(WSL_WORKTREE, FILE, false, false, WSL_OPTIONS)
+      const spawnsAfterFirst = blobReadCount()
+
+      await getDiff(WSL_WORKTREE, FILE, false, false, WSL_OPTIONS)
+
+      expect(spawnsAfterFirst).toBeGreaterThan(0)
+      expect(blobReadCount()).toBe(spawnsAfterFirst)
+      expect(settledDiffCache.stats().hits).toBe(1)
+      expect(statMock).toHaveBeenCalledWith(path.join(HOST_WORKTREE, '.git/index'))
+    })
+
+    // Each stamp component has to be stat'd under the host spelling too: one that permanently
+    // misses is a constant, so the stamp stops moving and the cache serves a stale diff.
+    it('invalidates when the working tree file is edited under the host spelling', async () => {
+      await getDiff(WSL_WORKTREE, FILE, false, false, WSL_OPTIONS)
+      const spawnsAfterFirst = blobReadCount()
+
+      writeFile(path.join(HOST_WORKTREE, FILE), 'edited-in-another-editor')
+      const second = await getDiff(WSL_WORKTREE, FILE, false, false, WSL_OPTIONS)
+
+      expect(blobReadCount()).toBeGreaterThan(spawnsAfterFirst)
+      expect(second.modifiedContent).toBe('edited-in-another-editor')
+    })
+
+    it('invalidates when .gitmodules appears under the host spelling', async () => {
+      await getDiff(WSL_WORKTREE, FILE, false, false, WSL_OPTIONS)
+      const spawnsAfterFirst = blobReadCount()
+
+      writeFile(path.join(HOST_WORKTREE, '.gitmodules'), '[submodule "vendor"]\n')
+      await getDiff(WSL_WORKTREE, FILE, false, false, WSL_OPTIONS)
+
+      expect(blobReadCount()).toBeGreaterThan(spawnsAfterFirst)
+      expect(statMock).toHaveBeenCalledWith(path.join(HOST_WORKTREE, '.gitmodules'))
+    })
+  })
+
+  // An empty worktree path has no host spelling, and `path.join('', x)` is a *relative* path:
+  // every fs read would land in the process cwd, which in dev is Orca's own checkout.
+  it('reads nothing relative to the cwd when the worktree path has no host spelling', async () => {
+    await getDiff('', FILE, false)
+
+    expect(statMock).not.toHaveBeenCalledWith(FILE)
+    expect(readFileMock).not.toHaveBeenCalledWith('.git', 'utf-8')
+    expect(settledDiffCache.stats().entries).toBe(0)
   })
 
   // The four invalidation axes, one per diff input. Each proves the stale result is

--- a/src/shared/git-metadata-path.test.ts
+++ b/src/shared/git-metadata-path.test.ts
@@ -1,6 +1,6 @@
 import { posix, win32 } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { resolveGitMetadataPath } from './git-metadata-path'
+import { resolveGitMetadataPath, resolveWorktreeHostPath } from './git-metadata-path'
 
 const hostIsWindows = process.platform === 'win32'
 
@@ -144,5 +144,28 @@ describe('resolveGitMetadataPath', () => {
     expect(resolveGitMetadataPath('/repo/worktree', '../.git/worktrees/feature')).toBe(
       (hostIsWindows ? win32 : posix).resolve('/repo/worktree', '../.git/worktrees/feature')
     )
+  })
+})
+
+describe('resolveWorktreeHostPath', () => {
+  // A gitfile payload ends in a newline; a directory name can end in a space, and trimming one
+  // away points every read at a directory that does not exist.
+  it.each(['/repo/my feature ', ' /repo/my feature'])(
+    'keeps whitespace that belongs to the directory name (%j)',
+    (worktreePath) => {
+      expect(resolveWorktreeHostPath(worktreePath, { platform: 'linux' })).toBe(worktreePath)
+      expect(resolveWorktreeHostPath(worktreePath, { platform: 'win32' })).toBe(worktreePath)
+    }
+  )
+
+  it('still translates a guest directory for a Windows reader', () => {
+    expect(
+      resolveWorktreeHostPath('/home/me/repo', { platform: 'win32', wslDistro: 'Ubuntu' })
+    ).toBe(String.raw`\\wsl.localhost\Ubuntu\home\me\repo`)
+    expect(resolveWorktreeHostPath('/mnt/c/repo', { platform: 'win32' })).toBe(String.raw`C:\repo`)
+  })
+
+  it.each(['', '   '])('has no spelling for an empty worktree path %j', (worktreePath) => {
+    expect(resolveWorktreeHostPath(worktreePath, { platform: 'win32' })).toBeNull()
   })
 })

--- a/src/shared/git-metadata-path.ts
+++ b/src/shared/git-metadata-path.ts
@@ -59,3 +59,19 @@ function translateGuestPointer(
   }
   return wslDistro ? toWindowsWslPath(value, wslDistro) : toWindowsWslDrivePath(value)
 }
+
+/**
+ * The reading host's spelling of a worktree *directory*.
+ *
+ * A directory is not a pointer: `resolveGitMetadataPath` trims because a gitfile payload carries a
+ * trailing newline, but a directory name may legally begin or end with whitespace on POSIX. Keep
+ * the caller's spelling whenever the resolver only trimmed it, so a host that translates nothing
+ * reads exactly the path it was given.
+ */
+export function resolveWorktreeHostPath(
+  worktreePath: string,
+  options: GitMetadataPathOptions = {}
+): string | null {
+  const resolved = resolveGitMetadataPath('', worktreePath, options)
+  return resolved === worktreePath.trim() ? worktreePath : resolved
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​106 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​104 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 |

<!-- /orca-pr-loc -->

## Problem

Git can execute inside a WSL distro against a raw Linux worktree path while Node, on the Windows side, reads the same files back through Win32. `path.join('/home/me/repo/feature', 'src/file.ts')` on win32 produces the *drive-relative* `\home\me\repo\feature\src\file.ts`, which resolves against whatever the current drive happens to be and almost always ENOENTs. The same mis-spelling hits the drvfs form, where `/mnt/c/repo` should read as `C:\repo`.

Two consequences, both on the Node side only — git already works, because it receives the Linux path as its cwd and resolves it inside the distro:

1. **A file that exists renders as DELETED.** `loadDiff`'s unstaged working-tree read missed, `readWorkingTreeFile` mapped ENOENT to `exists: false`, and `buildDiffResult` showed the file as deleted. This is the user-visible one.
2. **The settled diff cache never validated.** `readWorktreeDiffStamp` could not find `.git`, so `readHeadComponent` returned null, so the stamp was null, so `settledDiffCache` neither hit nor stored. Every diff respawned `git show` — on a WSL worktree, two `wsl.exe` spawns the cache exists specifically to avoid.

## What this does

Both paths now spell the worktree *directory* for the reading host before any `fs` call, via a new `resolveWorktreeHostPath` wrapper around the resolver that landed in #17804:

- `readWorktreeDiffStamp` takes an optional 4th arg `options: Pick<GitRuntimeOptions, 'wslDistro'> = {}` and uses the host spelling for `resolveGitDir`, the `.gitmodules` stat, and the working-tree stat. The HEAD/ref/index reads derive from `gitDir` and follow automatically.
- `loadDiffThroughSettledCache` threads `options` through to the stamp.
- `loadDiff`'s unstaged branch reads `path.join(hostWorktreePath, filePath)`.

**Why a wrapper and not `resolveGitMetadataPath` directly:** the resolver trims, because a gitfile payload carries a trailing newline. A worktree *directory* name is not that input — it may legally begin or end with whitespace on POSIX. `resolveWorktreeHostPath` keeps the caller's spelling whenever the resolver only trimmed it, so `/repo/my feature ` is passed through byte-identically instead of silently becoming `/repo/my feature` (which would miss, come back `exists: false`, and render as deleted — the exact bug this PR fixes, on the platforms it claims not to touch). The resolver's own pointer contract and its three existing pointer callers are unchanged.

The stamp's opaque `value` still embeds the caller's **original** `worktreePath`, so settled-cache identity is byte-identical and no cache key moves.

### Nullability

`readWorktreeDiffStamp` was **already** `Promise<WorktreeDiffStamp | null>` before this PR, with exactly one caller (`file-diff.ts`) that treats null as a cache miss. No new nullability enters the type system, and the resolver's never-null-for-a-non-empty-pointer contract is untouched — the wrapper returns `string | null` with the identical meaning. The only unspellable input is an empty worktree path, handled locally as "not provably unchanged" in the stamp and as a read *failure* (`exists: true, failed: true`) rather than a proven deletion in `file-diff`. No signature is widened.

## What changes for users

| Platform | Delta |
|---|---|
| macOS | **No change.** An absolute POSIX path is returned verbatim, including one whose directory name carries leading or trailing whitespace. |
| Linux | **No change.** Same reason. |
| Native Windows (no WSL) | **No change.** A `C:\...` or plain `\\server\share\...` path is already absolute for win32 and passes through verbatim. |
| Windows + WSL, UNC worktree path (`\\wsl.localhost\Ubuntu\...`) | **No change.** Already absolute for win32; passes through verbatim. This is today's common case. |
| Windows + WSL, drvfs worktree path (`/mnt/c/repo`) | **Fixed.** Reads as `C:\repo` instead of the drive-relative `\mnt\c\repo`. Needs no distro name. |
| Windows + WSL, Linux worktree path with a named distro (`/home/me/repo`) | **Fixed.** Reads as `\\wsl.localhost\Ubuntu\home\me\repo`. The deleted-file misrender goes away and the diff cache starts hitting. |
| Windows, POSIX path, no distro and not a drvfs mount | **No change.** Passes through verbatim, same ENOENT, same existing fallback. |
| SSH | **No change.** `runtime-git-diff-commands.ts` and the `git:diff` IPC both route to `provider.getDiff` for a connection, so this local code is never reached. |
| Relay / remote | **No change.** No RPC param, wire field, stream opcode, or published content is touched. The relay host runs this same local code and gets the same fix. |
| Folder workspace (non-git) | **No change.** `.git` is absent either way, `resolveGitDir` returns the same fallback, and the stamp stays null exactly as today. |
| GitLab / other providers | **Not applicable.** No provider-specific or review code is touched. |

## What this does NOT do

- **It does not fix `resolveGitDir` itself.** For a drvfs repo whose worktree Orca already spells `C:\repo\feature`, the gitfile payload `gitdir: /mnt/c/repo/.git/worktrees/feature` is still mis-resolved by `path.resolve` to `C:\mnt\c\repo\.git\...`, so the stamp still returns null in that specific shape. Separate one-line change, separate PR; this one neither fixes nor regresses it.
- **It does not touch submodule path resolution.** `resolveSubmoduleWorktreePath` is the path-escape guard and has a near-identical twin in `src/relay/git-handler-submodule-ops.ts`; changing it without escape tests on both is out of scope.
- **It does not change `readHeadComponent`'s `commondir` resolution.** The relative `../..` git actually writes takes the identical `path.resolve` branch, and an absolute POSIX `commondir` under a WSL UNC `gitDir` already resolves correctly because the UNC root is `\\wsl.localhost\<distro>\`.
- **It does not reorder drvfs-before-UNC inside the shared resolver.** That changes the identity of returned strings and needs a real Windows+WSL box.
- **It adds no Git command, option, or version dependency.** Git 2.25 baseline is unaffected.

## Costs and residual risk

- One extra pure function call per diff read. No I/O added or removed on the unaffected paths.
- **Translation still trims.** `resolveWorktreeHostPath` preserves whitespace only when no translation happened; a guest directory named `/home/me/repo ` loses its trailing space on a Windows reader. Reachable only on win32, where such a name is not addressable anyway, and the previous behavior for that shape was a drive-relative miss.
- **A relative worktree path** (no caller passes one) is now resolved against the process cwd instead of joined relative to it. Same file in every case except a relative name that itself ends in whitespace.
- **`UNSPELLABLE_WORKING_TREE_READ`'s `exists`/`failed` fields are correct but not observable today:** the stamp is null for the same input, so nothing can be cached and `reusable` cannot be read back. They are there so the branch stays right if `loadDiff` ever gains a second caller. The test pins the observable part — that no read lands on a cwd-relative path.
- **Test realism:** every test here mocks `node:fs/promises` and spoofs `process.platform`. They prove which path string reaches `stat`/`readFile`, which is the right assertion, but none of this has executed against a real 9p mount on a Windows+WSL box, and this repo's CI has no such runner.
- **Honest framing of the trigger:** I could not demonstrate a mainline path that hands `getDiff` an untranslated POSIX worktree path on Windows today — `translateWslOutputPaths` UNC-translates worktree paths whenever a distro is known, `getWslHome` returns the UNC spelling, and `resolveWslRepoWorktreeBasePath` normalizes a configured Linux base. The drvfs case is the most plausible live one. Treat this as defense-in-depth that is a strict no-op on every configuration above except the two marked Fixed, not as the repair of a reported failure.

## Verification

- `npx vitest run src/main/git src/shared/git-metadata-path.test.ts` → **196 files / 2241 tests passed**, 2 files and 5 tests skipped. One failure, `git-admission-storm-measurement.test.ts > reports bounded-concurrency before and after measurements` (ENOENT scandir on its own temp state dir), is **pre-existing and environmental**: it fails identically in isolation and spawns real git children without touching any changed module.
- `npx vitest run src/main/git/status-diff-settled-cache.test.ts` → 21/21 (16 pre-existing, 5 new).
- `npx vitest run src/shared/git-metadata-path.test.ts` → 25/25 (19 pre-existing, 6 new cases across 3 new tests).
- `npx oxfmt --write` then `npx oxlint` on all five changed files → clean, exit 0.

### Mutation checks

All eight production substitutions and branches were reverted one at a time and the suite re-run. Each fails at least one test, and no new test survives its own mutation.

| Reverted | Failing test |
|---|---|
| file-diff working-tree read → `path.join(worktreePath, filePath)` | `reads the working tree through the host spelling instead of reporting a deletion`; `invalidates when the working tree file is edited under the host spelling` |
| stamp working-tree component → `worktreePath` | `invalidates when the working tree file is edited under the host spelling` |
| stamp `.gitmodules` stat → `worktreePath` | `invalidates when .gitmodules appears under the host spelling` |
| stamp `resolveGitDir` → `worktreePath` | `stamps through the host spelling so the second read does not respawn git` |
| `options` threading at the `readWorktreeDiffStamp` call | `stamps through the host spelling…`; `invalidates when .gitmodules appears…` |
| wrapper's untrimmed preservation → `return resolved` | `keeps whitespace that belongs to the directory name` (both cases) |
| `UNSPELLABLE_WORKING_TREE_READ` → a cwd-relative `readWorkingTreeFile` | `reads nothing relative to the cwd when the worktree path has no host spelling` |
| stamp's null early return → `hostWorktreePath ?? worktreePath` | `reads nothing relative to the cwd when the worktree path has no host spelling` |

The settled-cache tests seed the fake filesystem through the platform-bound `path` module rather than `path.win32`, so they assert real behavior on a POSIX CI host as well as on Windows and are not gated on the host platform.