### PR TITLE
fix(wsl): read untracked line counts through the host's worktree spelling

### DIFF
--- a/src/main/git/source-control/status-branch-line-total-input.ts
+++ b/src/main/git/source-control/status-branch-line-total-input.ts
@@ -8,6 +8,7 @@ import {
 import type { GitRuntimeOptions } from '../git-runtime-options'
 import { gitReadOptionsForWorktree } from '../git-runtime-options'
 import { gitExecFileAsync, gitOptionalLocksDisabledEnv } from '../runner'
+import { resolveWorktreeFilesystemPath } from './worktree-filesystem-path'
 import type { GetStatusOptions } from './get-status-options'
 
 /** Undefined — and therefore zero extra work — unless the caller asked for a total we can know exact. */
@@ -28,6 +29,8 @@ export function createBranchLineTotalInput(
     compute: () =>
       computeGitBranchLineTotal({
         worktreePath,
+        // Why: the untracked tally reads files directly, so it needs Node's spelling, not git's.
+        filesystemWorktreePath: resolveWorktreeFilesystemPath(worktreePath, options),
         // Why: the same path can be a different filesystem per WSL distro.
         hostKey: options.wslDistro ?? 'native',
         mergeBase,

--- a/src/main/git/source-control/status-line-stats.ts
+++ b/src/main/git/source-control/status-line-stats.ts
@@ -9,6 +9,7 @@ import {
 import type { GitRuntimeOptions } from '../git-runtime-options'
 import { gitReadOptionsForWorktree } from '../git-runtime-options'
 import { gitExecFileAsync, gitOptionalLocksDisabledEnv } from '../runner'
+import { resolveWorktreeFilesystemPath } from './worktree-filesystem-path'
 
 async function runNumstat(
   worktreePath: string,
@@ -56,7 +57,12 @@ export async function attachLineStats(
   const [stagedStats, unstagedStats, untrackedStats] = await Promise.all([
     hasStaged ? runNumstat(worktreePath, true, options) : Promise.resolve(emptyStats),
     hasUnstaged ? runNumstat(worktreePath, false, options) : Promise.resolve(emptyStats),
-    collectUntrackedAdditions(worktreePath, untrackedPaths, options.signal)
+    // Why: git took the guest path, but this read goes straight through Node's own namespace.
+    collectUntrackedAdditions(
+      resolveWorktreeFilesystemPath(worktreePath, options),
+      untrackedPaths,
+      options.signal
+    )
   ])
   for (const entry of entries) {
     const area = entry.area

--- a/src/main/git/source-control/worktree-filesystem-path.ts
+++ b/src/main/git/source-control/worktree-filesystem-path.ts
@@ -1,0 +1,37 @@
+import { resolveGitMetadataPath } from '../../../shared/git-metadata-path'
+import type { GitRuntimeOptions } from '../git-runtime-options'
+
+const GUEST_ROOTED_PATH = /^\/(?!\/)/
+
+/**
+ * Whether a worktree path is a guest spelling the resolver can safely re-spell.
+ *
+ * Single leading slash only: `//wsl.localhost/...` and `//wsl$/...` are UNC spellings that also
+ * start with `/`, and translating one prepends the distro root a second time. Trim-stable only:
+ * the resolver returns `rawPath.trim()`, which would silently point a worktree whose name has
+ * edge whitespace (legal on ext4) at a different directory.
+ */
+function isRespellableGuestPath(worktreePath: string): boolean {
+  return GUEST_ROOTED_PATH.test(worktreePath) && worktreePath === worktreePath.trim()
+}
+
+/**
+ * The worktree path as this process must spell it to open files inside it.
+ *
+ * Why: git executing in a WSL distro takes and reports guest paths, but Node reads them back
+ * through Win32, where `/home/me/repo` is drive-relative and `/mnt/c/repo` means `C:\mnt\c\repo`.
+ * Only reads that bypass git — direct lstat/open on working-tree files — need this; anything
+ * handed to the git runner keeps the execution host's spelling.
+ */
+export function resolveWorktreeFilesystemPath(
+  worktreePath: string,
+  options: GitRuntimeOptions = {}
+): string {
+  // The resolver is already an identity off win32; short-circuiting makes that structural.
+  if (process.platform !== 'win32' || !isRespellableGuestPath(worktreePath)) {
+    return worktreePath
+  }
+  // Unreachable: the resolver returns null only for an empty pointer, which the guard rejects.
+  // Kept so the never-null contract stays the resolver's to state, not ours to assert.
+  return resolveGitMetadataPath('', worktreePath, options) ?? worktreePath
+}

--- a/src/main/git/status-line-stats-host-paths.test.ts
+++ b/src/main/git/status-line-stats-host-paths.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Untracked line counts come from direct lstat/open calls, not from git, so on a Windows host
+ * driving a WSL distro they must be issued against the Win32 spelling of the worktree. These
+ * assert the exact path that reaches the filesystem: translated for a guest-rooted worktree,
+ * verbatim for one that is already spelled in this process's own namespace.
+ */
+import * as path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as FsPromises from 'node:fs/promises'
+import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
+import type { GitStatusEntry } from '../../shared/git-status-types'
+import { invalidateGitBranchLineTotalInFlight } from '../../shared/git-branch-line-total'
+
+const { lstatPaths, untrackedFiles } = vi.hoisted(() => ({
+  lstatPaths: [] as string[],
+  untrackedFiles: new Map<string, string>()
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromises>()
+  return {
+    ...actual,
+    lstat: async (target: string) => {
+      lstatPaths.push(target)
+      const contents = untrackedFiles.get(target)
+      if (contents === undefined) {
+        throw Object.assign(new Error(`ENOENT: ${target}`), { code: 'ENOENT' })
+      }
+      return {
+        size: Buffer.byteLength(contents),
+        // Distinct per read so the stat-keyed untracked cache never serves another case's entry.
+        mtimeMs: lstatPaths.length,
+        ctimeMs: lstatPaths.length,
+        isSymbolicLink: () => false,
+        isFile: () => true
+      }
+    }
+  }
+})
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => {
+  const actual = await importOriginal<typeof BoundedFileReader>()
+  return {
+    ...actual,
+    readNodeFileWithinLimit: async (target: string) => {
+      const contents = untrackedFiles.get(target)
+      if (contents === undefined) {
+        throw Object.assign(new Error(`ENOENT: ${target}`), { code: 'ENOENT' })
+      }
+      return { buffer: Buffer.from(contents) }
+    }
+  }
+})
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({ gitExecFileAsyncMock: vi.fn() }))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitExecFileAsyncBuffer: vi.fn(),
+  gitOptionalLocksDisabledEnv: (env: NodeJS.ProcessEnv = process.env) => env,
+  gitStreamStdout: vi.fn()
+}))
+
+import { attachLineStats } from './source-control/status-line-stats'
+import { createBranchLineTotalInput } from './source-control/status-branch-line-total-input'
+
+const GUEST_WORKTREE = '/home/me/repo'
+const UNC_WORKTREE = String.raw`\\wsl.localhost\Ubuntu\home\me\repo`
+const MERGE_BASE = 'a'.repeat(40)
+
+function untrackedEntry(entryPath: string): GitStatusEntry {
+  return { path: entryPath, area: 'untracked', status: 'added' }
+}
+
+describe('untracked line stats on a WSL worktree read by a Windows host', () => {
+  beforeEach(() => {
+    lstatPaths.length = 0
+    untrackedFiles.clear()
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+    invalidateGitBranchLineTotalInFlight()
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('counts an untracked file through the distro UNC spelling of the worktree', async () => {
+    const target = path.join(UNC_WORKTREE, 'fresh.txt')
+    untrackedFiles.set(target, 'one\ntwo\nthree\n')
+    const entries = [untrackedEntry('fresh.txt')]
+
+    const complete = await attachLineStats(GUEST_WORKTREE, entries, { wslDistro: 'Ubuntu' })
+
+    expect(lstatPaths).toEqual([target])
+    expect(entries[0].added).toBe(3)
+    expect(complete).toBe(true)
+  })
+
+  it('adds untracked lines to the branch total through the same spelling', async () => {
+    const target = path.join(UNC_WORKTREE, 'fresh.txt')
+    untrackedFiles.set(target, 'one\ntwo\nthree\n')
+    const input = createBranchLineTotalInput(
+      GUEST_WORKTREE,
+      [untrackedEntry('fresh.txt')],
+      { wslDistro: 'Ubuntu', branchLineTotalMergeBase: MERGE_BASE },
+      true
+    )
+
+    const total = await input?.compute()
+
+    expect(lstatPaths).toEqual([target])
+    expect(total?.added).toBe(3)
+  })
+
+  it('maps a drvfs worktree onto its drive spelling', async () => {
+    const target = path.join(String.raw`C:\repo`, 'fresh.txt')
+    untrackedFiles.set(target, 'one\n')
+    const entries = [untrackedEntry('fresh.txt')]
+
+    await attachLineStats('/mnt/c/repo', entries, { wslDistro: 'Ubuntu' })
+
+    expect(lstatPaths).toEqual([target])
+    expect(entries[0].added).toBe(1)
+  })
+
+  // One case per spelling in a single test: the guest row pins that re-spelling still happens, so
+  // the whole test dies if the production hunks are reverted, and each verbatim row pins one half
+  // of the guard that keeps a path this process can already open from being re-spelt onto nothing.
+  it('re-spells the guest form only, leaving every host-openable spelling byte-identical', async () => {
+    const cases: { worktree: string; expected: string }[] = [
+      { worktree: GUEST_WORKTREE, expected: UNC_WORKTREE },
+      { worktree: UNC_WORKTREE, expected: UNC_WORKTREE },
+      {
+        worktree: '//wsl.localhost/Ubuntu/home/me/repo',
+        expected: '//wsl.localhost/Ubuntu/home/me/repo'
+      },
+      { worktree: '//wsl$/Ubuntu/home/me/repo', expected: '//wsl$/Ubuntu/home/me/repo' },
+      { worktree: '/home/me/my repo ', expected: '/home/me/my repo ' }
+    ]
+
+    for (const { worktree, expected } of cases) {
+      lstatPaths.length = 0
+      untrackedFiles.clear()
+      const target = path.join(expected, 'fresh.txt')
+      untrackedFiles.set(target, 'one\ntwo\n')
+      const entries = [untrackedEntry('fresh.txt')]
+
+      await attachLineStats(worktree, entries, { wslDistro: 'Ubuntu' })
+
+      expect(lstatPaths, worktree).toEqual([target])
+      expect(entries[0].added, worktree).toBe(2)
+    }
+  })
+})

--- a/src/shared/git-branch-line-total.ts
+++ b/src/shared/git-branch-line-total.ts
@@ -183,6 +183,8 @@ export function invalidateGitBranchLineTotalInFlight(): void {
  */
 export async function computeGitBranchLineTotal(input: {
   worktreePath: string
+  /** Spelling for the direct untracked-file reads when the git host's differs; defaults to worktreePath. */
+  filesystemWorktreePath?: string
   /** Distinguishes hosts that can map the same path to different filesystems (WSL distro, relay). */
   hostKey: string
   mergeBase: string
@@ -227,7 +229,11 @@ export async function computeGitBranchLineTotal(input: {
     // Untracked files are invisible to a ranged diff but already render as
     // CHANGES rows, so they are added on top. Stat-keyed caching inside makes
     // this near-free when attachLineStats just read the same paths.
-    collectUntrackedAdditions(input.worktreePath, input.untrackedPaths, input.signal)
+    collectUntrackedAdditions(
+      input.filesystemWorktreePath ?? input.worktreePath,
+      input.untrackedPaths,
+      input.signal
+    )
   ])
   if (tracked === null) {
     return undefined


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​156 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​156 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |

<!-- /orca-pr-loc -->

## Problem

Untracked line counts do not come from git. `collectUntrackedAdditions` (`src/shared/git-uncommitted-line-stats.ts`) calls `lstat`/`open` on `path.join(worktreePath, relativePath)` directly, and `countFileAdditions` swallows any failure into `{}`.

When git executes inside a WSL distro, the worktree path it takes and reports can be a guest path. Node reads that back through Win32, where `/home/me/repo` is drive-relative and `/mnt/c/repo` means `C:\mnt\c\repo`. Every lstat then fails, so:

- untracked files render with no `+N`, and
- the branch line total silently undercounts them, because untracked additions are added on top of the ranged diff and their absence is indistinguishable from zero.

Stated plainly: this is defense-in-depth, not a fix for a reported failure. `translateWslOutputPaths` UNC-translates worktree paths whenever a distro is known, and I could not demonstrate a mainline path that currently hands an untranslated guest worktree path to `attachLineStats` on Windows. Judge it on that basis.

## What this does

New `src/main/git/source-control/worktree-filesystem-path.ts` (37 lines):

```ts
const GUEST_ROOTED_PATH = /^\/(?!\/)/

function isRespellableGuestPath(worktreePath: string): boolean {
  return GUEST_ROOTED_PATH.test(worktreePath) && worktreePath === worktreePath.trim()
}

export function resolveWorktreeFilesystemPath(
  worktreePath: string,
  options: GitRuntimeOptions = {}
): string {
  if (process.platform !== 'win32' || !isRespellableGuestPath(worktreePath)) {
    return worktreePath
  }
  return resolveGitMetadataPath('', worktreePath, options) ?? worktreePath
}
```

All three conditions are load-bearing, and together they are why this is not a thin call to the shared resolver:

- **Single leading slash.** `//wsl.localhost/Ubuntu/...` and `//wsl$/Ubuntu/...` are UNC spellings that also start with `/`, and `resolveGitMetadataPath` translates on `value.startsWith('/')`. For a WSL-runtime project `options.wslDistro` is always set regardless of how the path is spelled, so an already-UNC worktree would get its distro root prepended a second time (`\\wsl.localhost\Ubuntu\\wsl.localhost\Ubuntu\home\me\repo`) and every untracked lstat would ENOENT. Forward-slash UNC is a first-class spelling here (`parseWslUncPath` matches it, `normalizeRuntimePathSeparators` emits it, Git-for-Windows prints it). Same `/^\/(?!\/)/` guard `resolveWslRepoWorktreeBasePath` uses in `src/shared/wsl-paths.ts`, for the reason documented there.
- **Trim-stable only.** `resolveGitMetadataPath` returns `rawPath.trim()`. A worktree directory whose name has leading or trailing whitespace is legal on ext4, and trimming would re-spell it onto a *different* directory — turning "no untracked counts" (what main does) into "untracked counts read from the wrong tree". Those paths are returned verbatim on every platform, WSL included.
- **win32 only.** Off Windows the resolver is already an identity for these inputs (`translateGuestPointer` returns null when `platform !== 'win32'` and the base path names no distro, and `posix.isAbsolute` then returns the value unchanged). The early return makes the macOS/Linux no-op structural rather than derived from that argument.

The shared `resolveGitMetadataPath` is **not** modified, so no other caller (e.g. `repo-git-marker-scan.ts`) changes behavior.

Two call sites use it, for filesystem reads only — everything handed to the git runner keeps the execution host's spelling:

- `attachLineStats` → `collectUntrackedAdditions`
- `createBranchLineTotalInput` → a new optional `filesystemWorktreePath` on `computeGitBranchLineTotal`'s input, used for `collectUntrackedAdditions` and nothing else.

Both produce the identical string, so the stat-keyed untracked-stats cache still hits across them.

## What changes for users

Every row below was produced by executing the shipped helper, not reasoned about.

| Platform / mode | Change |
| --- | --- |
| macOS | **No change.** Not win32, so the path is returned verbatim before the resolver is reached — including any leading/trailing whitespace. |
| Linux | **No change**, same reason. |
| Native Windows, `C:\...` worktree | **No change.** No leading slash, returned verbatim. |
| Native Windows, `/mnt/<drive>/...` worktree | **Changes.** Now resolves to `<Drive>:\...` instead of being passed through to a guaranteed lstat failure. Native Windows never produces this spelling and the main-process status path is native/WSL only, so I believe it is unreachable; if reached, it turns a guaranteed failure into the correct file. Called out again under Costs — this is the one row that is not "no change". |
| Native Windows, other `/`-rooted worktree (`/home/me/repo`, no distro) | **No change.** `toWindowsWslDrivePath` returns null and `win32.isAbsolute` is true, so it comes back verbatim and lstat fails exactly as on main. |
| WSL-on-Windows, worktree spelled as a guest path (`/home/me/repo`, `/mnt/c/repo`) | **Fixed.** Untracked files get their `+N`; the branch line total includes them. This is the whole point of the change. |
| WSL-on-Windows, worktree already spelled `\\wsl.localhost\...` | **No change.** No leading forward slash; returned verbatim. |
| WSL-on-Windows, worktree already spelled `//wsl.localhost/...` or `//wsl$/...` | **No change.** Excluded by the single-leading-slash guard; returned verbatim, byte-identical to the backslash spelling's treatment. Without that guard this shape regressed from working counts to none. |
| WSL-on-Windows, worktree name with edge whitespace (`/home/me/my repo `) | **No change.** Trim-guarded, returned verbatim. Still counts nothing, exactly as main does — deliberately not "fixed", because the only available fix would read a different directory. |
| SSH | **No change.** `runtime-git-status-commands.ts` routes `connectionId` targets to `ssh-git-read-provider.ts`; the main-process `status-read.ts` path this touches is native/WSL only. |
| Relay | **No change.** `src/relay/git-status-branch-line-total.ts` builds its own input and does not set `filesystemWorktreePath`, so it takes the `?? input.worktreePath` default and is bit-identical on the wire. `src/relay/git-handler-status-ops.ts` is untouched. |
| Folder workspaces | **No change.** Nothing added assumes a git worktree beyond what the existing code already assumed. |
| GitLab / other providers | **No change.** No provider-specific code is touched. |

## What this does NOT do

- Does not reorder drvfs-before-UNC inside the shared resolver. That is the actual perf win on the source branch and it changes the *identity* of the returned string, which flows into diff-cache keys and path comparisons. Deliberately left out.
- Does not modify `resolveGitMetadataPath` itself. The guard lives in the new wrapper, so the gitfile/commondir callers are unaffected.
- Does not touch the relay or SSH branch-total input.
- Does not change any git argv, cwd, or exec routing. Only two direct filesystem reads move.
- Does not widen any signature to nullable. `resolveWorktreeFilesystemPath` returns `string`. The `?? worktreePath` is unreachable — the resolver returns null only for an empty pointer, and the guard rejects `''` — and is kept only so the never-null contract stays the resolver's to state rather than something this module asserts.
- Does not fix untracked counts for a WSL worktree whose directory name has edge whitespace. See the table row; that is a deliberate no-op.

## Costs and residual risk

- One extra string-only function call per status pass with entries. No I/O.
- **The one behavior change outside the stated blast radius**, restated so it is not only in a table: on a Windows host *without* a distro, a `/mnt/<drive>/...` worktree path now resolves to `<Drive>:\...`. Verified by running the helper: `'/mnt/c/repo' + {}` → `'C:\repo'`. I believe it is unreachable, and if reached it is an improvement, but it is not "no change" and the table says so.
- **A prior revision of this commit shipped a real regression**, caught in review: forward-slash UNC worktrees would have lost untracked counts they have today. Fixed and pinned, but it is evidence that this area is easy to get wrong by one predicate. A second review round found the trim half of the same problem.
- **Not verified on the target platform.** Every test mocks `node:fs/promises` and spies the `process.platform` getter. That proves the exact argument reaching `lstat`, which is the right assertion, but nothing here has executed against a real 9p mount or a real `\\wsl.localhost` share. For a change about Windows+WSL path spelling, "mechanism understood end to end" is satisfied; "verified on the target platform" is not.
- The `filesystemWorktreePath` field is optional and stays out of the branch-total lease key (`${hostKey}\0${worktreePath}\0${mergeBase}`), so coalescing/cooldown identity is unchanged. Confirmed by reading the key construction, not just asserted.

## Verification

**New tests** — `src/main/git/status-line-stats-host-paths.test.ts`, **4 tests, all 4 mutation-killed by reverting a production hunk.** Path semantics are driven by an explicit `process.platform` spy and literal spellings, and expected paths are built with `path.join(<base>, …)`, so the file runs identically on every host OS.

Each mutation was applied alone to the working tree, the suite run, the file restored:

| Mutation | Tests that FAIL |
| --- | --- |
| M1 — revert `status-line-stats.ts` to `collectUntrackedAdditions(worktreePath, …)` | 3 of 4: "counts an untracked file through the distro UNC spelling"; "maps a drvfs worktree onto its drive spelling"; "re-spells the guest form only…" |
| M2 — revert `status-branch-line-total-input.ts` (drop `filesystemWorktreePath`) | "adds untracked lines to the branch total through the same spelling" |
| M3 — revert `git-branch-line-total.ts` to `collectUntrackedAdditions(input.worktreePath, …)` | same test as M2 |
| M4a — drop the multi-slash half of the guard (`/^\/(?!\/)/` → `/^\//`) | "re-spells the guest form only…" |
| M4b — drop the trim-stability half of the guard | "re-spells the guest form only…" |
| M4c — drop the `platform !== 'win32'` half | **none** — and that is the expected result. The resolver is an identity off win32 for these inputs, so this guard is a short-circuit, not behavior. It therefore has no test, rather than an unkillable one. |

The fourth test walks five worktree spellings in one body — guest, backslash UNC, `//wsl.localhost/…`, `//wsl$/…`, whitespace-edged — asserting the exact `lstat` argument for each. The guest row is what makes it die under M1/full revert; the UNC rows kill M4a; the whitespace row kills M4b. The backslash-UNC row rides along inside a test that is independently mutation-killed, which is how the "both spellings are treated identically" claim is pinned without a standalone test that would survive its own mutation.

Two tests from an earlier revision were **deleted**, not kept ("still reports a complete pass when no distro can re-spell the worktree", "keeps the branch total on the same no-distro worktree"), and two more from the following revision were **folded** into the combined test rather than kept standalone ("leaves a forward-slash UNC worktree exactly as it was spelled", "leaves a POSIX-host worktree path byte-identical"). All four passed with every production hunk reverted. Nothing left in the file characterizes behavior main already has.

The original P1 was reproduced by writing its case first — `lstat` received `\\wsl.localhost\Ubuntu\\wsl.localhost\Ubuntu\home\me\repo/fresh.txt` — before the guard existed.

**Targeted regression suites**, 12 files / **161 tests**, all passing: `status-line-stats-host-paths`, `shared/git-metadata-path`, `shared/git-branch-line-total`, `shared/git-branch-line-total-soft-deadline`, `shared/git-uncommitted-line-stats`, `shared/git-status-branch-line-total-cache`, `git/status`, `status-branch-line-total-exec-contract`, `status-branch-line-total-relay-parity`, `status-branch-line-total-real-git`, `status-wsl-pathspecs`, `relay/git-status-branch-line-total`.

**Full `src/main/git`**: 199 files, **2215 passed, 5 skipped, 1 failed**. The failure is `command-runner/git-admission-storm-measurement.test.ts` (`ENOENT: scandir …/orca-git-storm-disabled-*/state`). That file is untouched by this commit, imports none of the five changed modules, and fails identically when run alone.

**Lint / format**: `oxfmt --write` then `oxlint` clean (exit 0) on all 5 changed files. `pnpm tc` is left to the serial runner per instructions.