### PR TITLE
fix(git): give WSL-hosted repos one FETCH_HEAD lock lane

### DIFF
--- a/src/shared/git-fetch-head-lock-key-derivation.test.ts
+++ b/src/shared/git-fetch-head-lock-key-derivation.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
+import * as path from 'node:path'
+
+const mocks = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  realpath: vi.fn(),
+  stat: vi.fn(),
+  runWithGitOperationLock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: mocks.readFile,
+  realpath: mocks.realpath,
+  stat: mocks.stat
+}))
+vi.mock('./git-operation-lock', () => ({
+  runWithGitOperationLock: mocks.runWithGitOperationLock
+}))
+
+import { runWithGitFetchHeadLock } from './git-fetch-head-lock'
+
+const GIT_DIR_ENTRY = { isDirectory: () => true, isFile: () => false }
+const GIT_FILE_ENTRY = { isDirectory: () => false, isFile: () => true }
+
+function lockKeys(): string[] {
+  return mocks.runWithGitOperationLock.mock.calls.map(([key]) => key as string)
+}
+
+/**
+ * An on-disk layout keyed by forward-slash spelling: a `gitdir:` payload or `commondir` body for
+ * every file that exists, and `null` for a `.git` directory. Anything absent throws, so a key
+ * derived from a path that exists nowhere cannot silently read a sibling's metadata.
+ */
+function mockLayout(entries: Record<string, string | null>): void {
+  const spell = (target: unknown): string => String(target).replaceAll('\\', '/')
+  mocks.stat.mockImplementation(async (target: string) => {
+    const entry = entries[spell(target)]
+    if (entry === undefined) {
+      throw new Error(`ENOENT ${spell(target)}`)
+    }
+    return entry === null ? GIT_DIR_ENTRY : GIT_FILE_ENTRY
+  })
+  mocks.readFile.mockImplementation(async (target: string) => {
+    const entry = entries[spell(target)]
+    if (!entry) {
+      throw new Error(`ENOENT ${spell(target)}`)
+    }
+    return entry
+  })
+}
+
+describe('FETCH_HEAD lock key derivation', () => {
+  let platformSpy: MockInstance<() => NodeJS.Platform> | undefined
+
+  const usePlatform = (platform: NodeJS.Platform): void => {
+    platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue(platform)
+  }
+
+  beforeEach(() => {
+    mocks.readFile.mockReset().mockRejectedValue(new Error('no metadata file'))
+    // Identity realpath: the paths under test are already canonical on their host.
+    mocks.realpath.mockReset().mockImplementation(async (target: string) => target)
+    mocks.stat.mockReset().mockResolvedValue(GIT_DIR_ENTRY)
+    mocks.runWithGitOperationLock
+      .mockReset()
+      .mockImplementation(async (_key, _signal, run) => run())
+  })
+
+  afterEach(() => {
+    platformSpy?.mockRestore()
+    platformSpy = undefined
+  })
+
+  it('folds the WSL UNC aliases and distro casing of one repo into a single lock key', async () => {
+    usePlatform('win32')
+
+    await runWithGitFetchHeadLock(String.raw`\\wsl$\Ubuntu\home\me\repo`, undefined, async () => 0)
+    await runWithGitFetchHeadLock(
+      String.raw`\\wsl.localhost\ubuntu\home\me\repo`,
+      undefined,
+      async () => 0
+    )
+
+    expect(lockKeys()).toEqual([
+      '//wsl.localhost/ubuntu/home/me/repo/.git/FETCH_HEAD',
+      '//wsl.localhost/ubuntu/home/me/repo/.git/FETCH_HEAD'
+    ])
+  })
+
+  it('leaves the two UNC spellings apart on a non-Windows host', async () => {
+    usePlatform('darwin')
+
+    await runWithGitFetchHeadLock(String.raw`\\wsl$\Ubuntu\home\me\repo`, undefined, async () => 0)
+    await runWithGitFetchHeadLock(
+      String.raw`\\wsl.localhost\ubuntu\home\me\repo`,
+      undefined,
+      async () => 0
+    )
+
+    const keys = lockKeys()
+    expect(keys[0]).not.toBe(keys[1])
+    expect(keys[0]).toBe(path.join(String.raw`\\wsl$\Ubuntu\home\me\repo`, '.git', 'FETCH_HEAD'))
+  })
+
+  it('puts a padded gitfile pointer in the same lane as its bare spelling', async () => {
+    usePlatform('darwin')
+    mocks.stat.mockResolvedValue(GIT_FILE_ENTRY)
+    const gitfile = (payload: string): void => {
+      mocks.readFile.mockImplementation(async (target: string) => {
+        if (String(target).endsWith('commondir')) {
+          throw new Error('no commondir')
+        }
+        return `gitdir:${payload}\n`
+      })
+    }
+
+    gitfile(' ../repo/.git/worktrees/wt')
+    await runWithGitFetchHeadLock('/work/wt', undefined, async () => 0)
+    // git's own read_gitfile_gently strips the padding, so both spellings name one repo.
+    gitfile('\t../repo/.git/worktrees/wt  ')
+    await runWithGitFetchHeadLock('/work/wt', undefined, async () => 0)
+
+    const keys = lockKeys()
+    expect(keys[0]).toBe(path.join('/work/repo/.git/worktrees/wt', 'FETCH_HEAD'))
+    expect(keys[1]).toBe(keys[0])
+  })
+
+  it("keeps a drive-spelled worktree on its own main checkout's lane", async () => {
+    usePlatform('win32')
+    mockLayout({
+      'C:/repo/.git': null,
+      'C:/workspace/wt-a/.git': 'gitdir: /mnt/c/repo/.git/worktrees/wt-a\n',
+      'C:/workspace/wt-b/.git': 'gitdir: /mnt/c/repo/.git/worktrees/wt-b\n',
+      'C:/repo/.git/worktrees/wt-a/commondir': '../..\n',
+      'C:/repo/.git/worktrees/wt-b/commondir': '../..\n'
+    })
+
+    await runWithGitFetchHeadLock(String.raw`C:\repo`, undefined, async () => 0)
+    await runWithGitFetchHeadLock(String.raw`C:\workspace\wt-a`, undefined, async () => 0)
+    await runWithGitFetchHeadLock(String.raw`C:\workspace\wt-b`, undefined, async () => 0)
+
+    // The drvfs prefix must be gone: `C:\mnt\c\repo` exists nowhere, so it dead-ends the walk and
+    // strands each worktree away from the main checkout it shares FETCH_HEAD with.
+    expect(lockKeys()).toEqual(Array(3).fill(String.raw`C:\repo\.git\FETCH_HEAD`))
+  })
+
+  it('keeps a WSL UNC repo and its linked worktree on one lane', async () => {
+    usePlatform('win32')
+    mockLayout({
+      '//wsl.localhost/Ubuntu/mnt/c/repo/.git': null,
+      '//wsl$/ubuntu/home/me/wt/.git': 'gitdir: /mnt/c/repo/.git/worktrees/wt\n',
+      '//wsl$/ubuntu/mnt/c/repo/.git/worktrees/wt/commondir': '../..\n'
+    })
+
+    // A main worktree's `.git` is a directory, so no pointer is translated and its key stays on the
+    // UNC spelling. Translating the linked worktree's pointer to `C:\...` would split the repo.
+    await runWithGitFetchHeadLock(
+      String.raw`\\wsl.localhost\Ubuntu\mnt\c\repo`,
+      undefined,
+      async () => 0
+    )
+    await runWithGitFetchHeadLock(String.raw`\\wsl$\ubuntu\home\me\wt`, undefined, async () => 0)
+
+    expect(lockKeys()).toEqual(Array(2).fill('//wsl.localhost/ubuntu/mnt/c/repo/.git/fetch_head'))
+  })
+
+  it("merges an absolute guest commondir into the main checkout's lane", async () => {
+    usePlatform('win32')
+    mockLayout({
+      'C:/repo/.git': null,
+      'C:/workspace/wt/.git': 'gitdir: /mnt/c/repo/.git/worktrees/wt\n',
+      // git may spell commondir absolutely; written by git-in-WSL it is a guest path.
+      'C:/repo/.git/worktrees/wt/commondir': '/mnt/c/repo/.git\n'
+    })
+
+    await runWithGitFetchHeadLock(String.raw`C:\repo`, undefined, async () => 0)
+    await runWithGitFetchHeadLock(String.raw`C:\workspace\wt`, undefined, async () => 0)
+
+    expect(lockKeys()).toEqual(Array(2).fill(String.raw`C:\repo\.git\FETCH_HEAD`))
+  })
+
+  it('walks to the drive root with Windows rules for a folder workspace', async () => {
+    usePlatform('win32')
+    mockLayout({})
+
+    await runWithGitFetchHeadLock(String.raw`C:\notes\inbox`, undefined, async () => 0)
+
+    // Nothing up the tree is a repo, so the walk must terminate at the drive root the way Windows
+    // spells it - not at a POSIX `.` that would put every folder workspace on one lane.
+    expect(lockKeys()[0]).toBe(String.raw`C:\.git\FETCH_HEAD`)
+  })
+
+  it('falls back to the Windows spelling when realpath fails', async () => {
+    usePlatform('win32')
+    mocks.realpath.mockRejectedValue(new Error('ELOOP'))
+    mockLayout({ 'C:/repo/.git': null })
+
+    await runWithGitFetchHeadLock(String.raw`C:\repo`, undefined, async () => 0)
+
+    expect(lockKeys()[0]).toBe(String.raw`C:\repo\.git\FETCH_HEAD`)
+  })
+
+  it("keeps today's key for a guest pointer Windows cannot address", async () => {
+    usePlatform('win32')
+    mocks.stat.mockResolvedValue(GIT_FILE_ENTRY)
+    mocks.readFile.mockImplementation(async (target: string) => {
+      if (String(target).endsWith('commondir')) {
+        throw new Error('no commondir')
+      }
+      return 'gitdir: /home/me/repo/.git/worktrees/wt\n'
+    })
+
+    await runWithGitFetchHeadLock(String.raw`C:\workspace\wt`, undefined, async () => 0)
+
+    // Unchanged from main: no distro is known, so the pointer stays on the current drive rather
+    // than becoming a new rootless `\home\...` lane.
+    expect(lockKeys()[0]).toBe(String.raw`C:\home\me\repo\.git\worktrees\wt\FETCH_HEAD`)
+  })
+
+  it('never fabricates a Windows drive path on a POSIX host', async () => {
+    usePlatform('darwin')
+    mockLayout({ '/work/wt/.git': 'gitdir: /mnt/c/repo/.git/worktrees/wt\n' })
+
+    await runWithGitFetchHeadLock('/work/wt', undefined, async () => 0)
+
+    // `/mnt/c` is an ordinary directory here, not a drvfs mount, so it must not become `C:\repo`.
+    expect(lockKeys()[0]).toBe('/mnt/c/repo/.git/worktrees/wt/FETCH_HEAD')
+  })
+
+  it('rejects promptly while a hung realpath is still pending', async () => {
+    usePlatform('win32')
+    let settleRealpath!: (value: string) => void
+    mocks.realpath.mockReturnValue(
+      new Promise<string>((resolve) => {
+        settleRealpath = resolve
+      })
+    )
+    const controller = new AbortController()
+
+    const pending = runWithGitFetchHeadLock(
+      String.raw`\\wsl.localhost\Ubuntu\home\me\repo`,
+      controller.signal,
+      async () => 0
+    )
+    // A caller-supplied reason must not change how callers classify the failure.
+    controller.abort(new TypeError('cancelled by user'))
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    settleRealpath('never observed')
+  })
+
+  it('rejects promptly while a hung metadata stat is still pending', async () => {
+    usePlatform('win32')
+    let settleStat!: (value: typeof GIT_DIR_ENTRY) => void
+    mocks.stat.mockReturnValue(
+      new Promise((resolve) => {
+        settleStat = resolve
+      })
+    )
+    const controller = new AbortController()
+
+    const pending = runWithGitFetchHeadLock(
+      String.raw`\\wsl.localhost\Ubuntu\home\me\repo`,
+      controller.signal,
+      async () => 0
+    )
+    await vi.waitFor(() => expect(mocks.stat).toHaveBeenCalled())
+    controller.abort()
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    settleStat(GIT_DIR_ENTRY)
+  })
+})

--- a/src/shared/git-fetch-head-lock.ts
+++ b/src/shared/git-fetch-head-lock.ts
@@ -1,6 +1,13 @@
 import * as path from 'node:path'
 import { readFile, realpath, stat } from 'node:fs/promises'
+import { waitForPromiseWithSignal } from './abort-signal-reason'
+import { parseGitdirMarkerPayload } from './gitdir-marker-payload'
 import { runWithGitOperationLock } from './git-operation-lock'
+import {
+  foldWslUncPathCaseInsensitiveParts,
+  isWslUncPath,
+  toWindowsWslDrivePath
+} from './wsl-paths'
 
 function abortError(): Error {
   const error = new Error('The operation was aborted.')
@@ -79,25 +86,80 @@ export function resolveGitFetchHeadCommand(
   return { needsLock: writesFetchHead || updatesRemoteTrackingRef, cwd, gitDir }
 }
 
+/**
+ * `node:path` itself, spelled so a test can drive the Win32 rules on a POSIX runner. Node picks the
+ * same submodule for the default export, so this is the host's own behaviour, not an emulation.
+ */
+function hostPath(): typeof path.posix {
+  return process.platform === 'win32' ? path.win32 : path.posix
+}
+
+/**
+ * Where a Git metadata pointer (a `.git` gitfile payload or a `commondir`) lands in the reading
+ * host's namespace.
+ *
+ * Why: git running inside WSL writes these in the guest namespace, and under a drive-spelled base
+ * `path.resolve` reads `/mnt/c/repo/.git` as the non-existent `C:\mnt\c\repo\.git`, so the commondir
+ * walk dead-ends and every linked worktree of one repo gets its own fetch lane.
+ *
+ * Why the UNC base is excluded rather than handed to `resolveGitMetadataPath`: win32 `path.resolve`
+ * already carries a WSL UNC base's distro onto a guest-rooted pointer, and a main worktree's `.git`
+ * is a directory with no pointer to translate, so its key stays on that UNC spelling. Rewriting only
+ * the linked worktrees to `C:\...` would split one repo across two lanes.
+ */
+function resolveMetadataPointer(basePath: string, rawPointer: string): string {
+  if (process.platform === 'win32' && !isWslUncPath(basePath)) {
+    const drivePath = toWindowsWslDrivePath(rawPointer)
+    if (drivePath) {
+      return drivePath
+    }
+  }
+  return hostPath().resolve(basePath, rawPointer)
+}
+
+/**
+ * Windows aliases `\\wsl$` to `\\wsl.localhost` and folds the distro name and any drvfs tail
+ * case-insensitively, so two spellings of one WSL repo must not open two fetch lanes.
+ */
+function canonicalizeFetchHeadLockKey(key: string): string {
+  if (process.platform !== 'win32') {
+    return key
+  }
+  return foldWslUncPathCaseInsensitiveParts(key) ?? key
+}
+
+/** `realpath` takes no signal, so a hung 9P/UNC lookup outlives the cancelled fetch without this. */
+async function realpathOrResolve(target: string, signal: AbortSignal | undefined): Promise<string> {
+  try {
+    return await waitForPromiseWithSignal(realpath(target), signal)
+  } catch {
+    // Why the synthetic error rather than the signal's reason: callers classify on `name`.
+    if (signal?.aborted) {
+      throw abortError()
+    }
+    return hostPath().resolve(target)
+  }
+}
+
 async function fetchLockPath(
   worktreePath: string,
   signal: AbortSignal | undefined,
   explicitGitDir?: string
 ): Promise<string> {
-  let current = await realpath(worktreePath).catch(() => path.resolve(worktreePath))
+  let current = await realpathOrResolve(worktreePath, signal)
   let gitDir = explicitGitDir
   while (!gitDir) {
-    const dotGitPath = path.join(current, '.git')
+    const dotGitPath = hostPath().join(current, '.git')
     try {
-      const metadata = await stat(dotGitPath)
+      const metadata = await waitForPromiseWithSignal(stat(dotGitPath), signal)
       if (metadata.isDirectory()) {
         gitDir = dotGitPath
         break
       }
       const contents = await readFile(dotGitPath, { encoding: 'utf-8', signal })
-      const match = contents.match(/^gitdir:\s*(.+)\s*$/m)
-      if (match) {
-        gitDir = path.resolve(current, match[1])
+      const marker = parseGitdirMarkerPayload(contents)
+      if (marker) {
+        gitDir = resolveMetadataPointer(current, marker)
         break
       }
     } catch {
@@ -105,26 +167,29 @@ async function fetchLockPath(
         throw abortError()
       }
     }
-    const parent = path.dirname(current)
+    const parent = hostPath().dirname(current)
     if (parent === current) {
-      gitDir = path.join(current, '.git')
+      gitDir = hostPath().join(current, '.git')
       break
     }
     current = parent
   }
   let commonGitDir = gitDir
   try {
-    const contents = await readFile(path.join(gitDir, 'commondir'), { encoding: 'utf-8', signal })
+    const contents = await readFile(hostPath().join(gitDir, 'commondir'), {
+      encoding: 'utf-8',
+      signal
+    })
     if (contents.trim()) {
-      commonGitDir = path.resolve(gitDir, contents.trim())
+      commonGitDir = resolveMetadataPointer(gitDir, contents.trim())
     }
   } catch {
     if (signal?.aborted) {
       throw abortError()
     }
   }
-  const canonicalGitDir = await realpath(commonGitDir).catch(() => path.resolve(commonGitDir))
-  return path.join(canonicalGitDir, 'FETCH_HEAD')
+  const canonicalGitDir = await realpathOrResolve(commonGitDir, signal)
+  return canonicalizeFetchHeadLockKey(hostPath().join(canonicalGitDir, 'FETCH_HEAD'))
 }
 
 export async function runWithGitFetchHeadLock<T>(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​273 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​273 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |

<!-- /orca-pr-loc -->

# Problem

`runWithGitFetchHeadLock` serializes every `git fetch`/`git pull` that writes FETCH_HEAD, keyed on the worktree's resolved common Git directory. On a Windows host two derivations split one repo into several lanes, so sibling fetches on the same repo race the very FETCH_HEAD write the lock exists to serialize:

1. **UNC aliasing.** Windows aliases `\\wsl$` to `\\wsl.localhost` and folds the distro name and any drvfs tail case-insensitively. `\\wsl$\Ubuntu\home\me\repo` and `\\wsl.localhost\ubuntu\home\me\repo` are one directory but produced two lock keys.
2. **Drvfs pointers under a drive-spelled base.** git running inside WSL writes `.git` gitfile and `commondir` payloads in the guest namespace. Under a base like `C:\workspace\wt`, `path.resolve` reads `/mnt/c/repo/.git/worktrees/wt` as `C:\mnt\c\repo\.git\worktrees\wt`, which exists nowhere, so the `commondir` read fails and every linked worktree got its own dead-end key while the main checkout keyed on `C:\repo\.git`.

Separately, `realpath` and `stat` take no `AbortSignal`, so cancelling a fetch still blocked behind a hung 9P/UNC lookup before the promise could reject.

This file is on the path of every `git fetch` and is used by both the main process and the relay, so the burden of proof is on the direction of every key change, not on the intent.

# Derivation: what the key is, before and after

Derived with an fs-mocked probe that runs **this module** and a faithful emulation of the **pre-change** derivation side by side, both under Win32 path rules (`process.platform` spied to `win32`, so `hostPath()` selects `path.win32` exactly as a real Windows host's default `path` export does). "Split" means one repo gaining two lanes — the failure mode this change must never introduce.

| # | Layout (Windows host) | Before | After | Direction |
| --- | --- | --- | --- | --- |
| **a1** | **MAIN worktree, `.git` a DIRECTORY on drvfs, drive-spelled** — `C:\repo` | `C:\repo\.git\FETCH_HEAD` | `C:\repo\.git\FETCH_HEAD` | **identical** |
| **a2** | **MAIN worktree, `.git` a DIRECTORY on drvfs, UNC-spelled** — `\\wsl.localhost\Ubuntu\mnt\c\repo` | `\\wsl.localhost\Ubuntu\mnt\c\repo\.git\FETCH_HEAD` | `//wsl.localhost/ubuntu/mnt/c/repo/.git/fetch_head` | fold only — pure function of the finished key |
| **b1** | **LINKED worktree with a gitfile, drive base** — `C:\ws\wt-a` and `C:\ws\wt-b`, each `gitdir: /mnt/c/repo/.git/worktrees/<wt>`, `commondir` `../..`, alongside main `C:\repo` | main `C:\repo\.git\FETCH_HEAD`; wt-a `C:\mnt\c\repo\.git\worktrees\wt-a\FETCH_HEAD`; wt-b `…\wt-b\FETCH_HEAD` (**three lanes**) | all three `C:\repo\.git\FETCH_HEAD` (**one lane**) | **merge** |
| **b2** | **LINKED worktree with a gitfile, UNC base** — `\\wsl.localhost\Ubuntu\home\me\wt` + main `\\wsl.localhost\Ubuntu\mnt\c\repo` (Orca's documented WSL layout, the one the prior revision split) | both `\\wsl.localhost\Ubuntu\mnt\c\repo\.git\FETCH_HEAD` | both `//wsl.localhost/ubuntu/mnt/c/repo/.git/fetch_head` | **identity-neutral — still one lane** |
| **c** | **UNC-spelled repo, pure 9p** — `\\wsl.localhost\Ubuntu\home\me\repo` + linked worktree `…\home\me\wt` | both `\\wsl.localhost\Ubuntu\home\me\repo\.git\FETCH_HEAD` | both `//wsl.localhost/ubuntu/home/me/repo/.git/FETCH_HEAD` | fold only, still one lane |
| **d** | **Same repo reached by both spellings** — `C:\repo` and `\\wsl.localhost\Ubuntu\mnt\c\repo` | `C:\repo\.git\FETCH_HEAD` vs `\\wsl.localhost\Ubuntu\mnt\c\repo\.git\FETCH_HEAD` (**split**) | `C:\repo\.git\FETCH_HEAD` vs `//wsl.localhost/ubuntu/mnt/c/repo/.git/fetch_head` (**still split**) | unchanged — pre-existing, not a regression |
| **e** | **Mixed: UNC main + drive-spelled linked worktree** | `\\wsl.localhost\…\repo\.git\FETCH_HEAD` vs `C:\mnt\c\repo\.git\worktrees\wt\FETCH_HEAD` (**split**) | `//wsl.localhost/…/fetch_head` vs `C:\repo\.git\FETCH_HEAD` (**still split**) | unchanged — pre-existing, not a regression |
| **f** | **Native Windows repo + worktree, no WSL** | `C:\repo\.git\FETCH_HEAD` (both) | identical | **no change** |
| **g** | **Relative gitfile pointer** (`gitdir: ../../.git/worktrees/wt`) | `C:\repo\.git\FETCH_HEAD` (both) | identical | **no change** |
| **h** | **Folder workspace, no repo anywhere** | `C:\.git\FETCH_HEAD`; `\\wsl.localhost\Ubuntu\.git\FETCH_HEAD` | `C:\.git\FETCH_HEAD`; `//wsl.localhost/ubuntu/.git/FETCH_HEAD` | no change / fold only |
| **i** | **Gitfile marker NOT at offset 0** (`"\ngitdir: C:/repo/.git/worktrees/wt"`) | `C:\repo\.git\FETCH_HEAD` | `C:\.git\FETCH_HEAD` | **SPLIT — the one narrowing; see Costs** |
| **j** | **Absolute guest `commondir`** (`/mnt/c/repo/.git`) under a drive base | main `C:\repo\.git\FETCH_HEAD`; wt `C:\mnt\c\repo\.git\worktrees\wt\FETCH_HEAD` (**split**) | both `C:\repo\.git\FETCH_HEAD` | **merge** |

**Why b2 is safe, and why it is the correctness-critical part of this revision.** win32 `path.resolve` already carries a WSL UNC base's distro onto a guest-rooted pointer — verified directly: `path.win32.resolve('\\\\wsl.localhost\\Ubuntu\\home\\me\\wt', '/mnt/c/repo/.git')` returns `\\wsl.localhost\Ubuntu\mnt\c\repo\.git`, a path that exists. A main worktree's `.git` is a **directory**, not a gitfile, so there is no pointer to translate and its key stays on that UNC spelling. Rewriting only the linked worktrees to `C:\...` there would split one repo across two lanes — which is exactly what the previous revision of this branch did. `resolveMetadataPointer` is therefore gated on `process.platform === 'win32' && !isWslUncPath(basePath)`, and removing that guard fails a test.

**Why the fold cannot split, by construction.** `canonicalizeFetchHeadLockKey` is a pure function applied to the *finished* key, after every read and `realpath`. Equal inputs stay equal, so it can only merge. The `win32` guard is pinned in the opposite direction by a test asserting the two UNC spellings stay apart on a non-Windows host.

**Why the drvfs translation cannot split.** `toWindowsWslDrivePath` returns null for anything that is not `/mnt/<letter>`. The single surviving delta is `C:\mnt\c\X` → `C:\X`, and `C:\mnt\c\X` is a spelling *derived from* bytes that live at `C:\X`, so the rewrite can only join a linked worktree to the common directory its own main checkout already keys on.

# What changes for users

| Platform / setup | What changes |
| --- | --- |
| **macOS** | **No lock-key change** except the gitfile-parser deltas (payload trim and case-insensitive marker merge; a marker not at offset 0 is no longer honoured — layout **i**). Every WSL branch is gated off; `hostPath()` returns `path.posix`, which is what `path` already is. Cancelling a fetch during a hung `realpath`/`stat` now rejects promptly. |
| **Linux** | **No change.** Identical to macOS. |
| **Native Windows, no WSL** | **No change** (layouts **f**, **g**, **h**). `foldWslUncPathCaseInsensitiveParts` returns null for a non-WSL path so the key is returned untouched, and `toWindowsWslDrivePath` returns null for any pointer that is not `/mnt/<letter>` — which a native repo never writes. Same parser deltas and prompt cancellation as macOS. |
| **WSL-on-Windows, repo reached by two UNC spellings** | The two spellings now share one fetch lane instead of racing. `\\wsl$` vs `\\wsl.localhost`, distro casing, and drvfs tail casing all fold. |
| **WSL-on-Windows, drvfs worktree under a drive-spelled base** (layout **b1**, **j**) | The pointer resolves to the real `C:\repo\.git\worktrees\wt`, so `commondir` succeeds and every linked worktree shares the main checkout's `C:\repo\.git\FETCH_HEAD` lane. Previously each got a dead-end key of its own. |
| **WSL-on-Windows, repo and worktrees reached by UNC** (Orca's documented layout, **b2**/**c**) | **No change, and that is the point.** Behaviour is byte-identical once the fold is applied to both keys. The previous revision of this branch split this layout; a test now pins it. |
| **WSL-on-Windows, guest pointer with no derivable Windows spelling** (`gitdir: /home/me/repo/.git` under a drive base) | **No change.** `toWindowsWslDrivePath` returns null and today's `path.resolve` key is kept. |
| **SSH** | **No change.** Exported signatures are untouched, and the key is derived on the host that runs the command — `src/relay/git-handler.ts` executes on the remote, where `process.platform !== 'win32'` gates off every WSL branch. |
| **Relay** | **No change** beyond the above. `src/relay/git-handler.ts` and `src/main/git/command-runner/git-exec-file.ts` call the same API with the same arguments; neither file is touched. |
| **Folder workspaces** | **No change** (layout **h**). The parent walk terminates the same way for a non-repo directory (`dirname(current) === current` → `<root>/.git`). |
| **GitLab / other providers** | **No change.** Nothing here is provider-aware. |
| **Git version compatibility** | **No change.** No new Git subcommand or option. Only the on-disk gitfile/`commondir` format is read, which is stable well below the 2.25 baseline. No `GitCapabilityCache` surface is touched. |

# What this does NOT do

- **Does not merge a drvfs repo's UNC and drive spellings** (layout **d**). `\\wsl.localhost\Ubuntu\mnt\c\repo` and `C:\repo` are the same FETCH_HEAD file but still get two lanes, exactly as today. The fold could emit the drive spelling, but it lowercases the drvfs tail (`...\.git\fetch_head`) where a drive key does not (`...\.git\FETCH_HEAD`), so agreeing them would require lowercasing native Windows drive keys too — a much wider change to keys Orca produces on every Windows host, for a two-spellings-of-one-repo case Orca does not itself create.
- **Does not merge a UNC-spelled main checkout with a drive-spelled linked worktree** (layout **e**). They split today too, so this is an unfixed case, not a regression.
- **No `--git-dir` gitfile dereferencing.** An explicit `--git-dir=<worktree>/.git` is still not followed to the shared common dir. That would make N worktrees of one repo serialize fetches that run in parallel today — a lock split from the caller's perspective. It is also unreachable: nothing in `src/` emits `--git-dir` as a global option to a fetch or pull, and `src/relay/git-exec-validator.ts` lists it in `GLOBAL_DENIED_FLAGS`.
- **No `wslDistro` hint threading.** `resolveGitFetchHeadCommand` and `runWithGitFetchHeadLock` keep their signatures. Translating non-drvfs guest pointers via a caller-supplied distro would move the key for every WSL repo on Windows, gated on a hint this module cannot validate.
- **No raw-POSIX identity fallback.** Returning the pointer verbatim for an untranslatable `/home/me/repo` is a narrowing: the repo and its linked worktrees would stop sharing a lane. Pinned as a mutation.
- **No `resolveGitMetadataPath` call.** Routing drvfs pointers through it is what produced the previous revision's lane split (its drive-spelling preference disagreed with the UNC spelling a main worktree's `.git` directory produces). Removed; the module's never-null contract is untouched and not widened.
- **No `resolveGitFetchHeadCommand` argument-parsing change.** `-C` and `--git-dir` resolution is untouched.
- **No observability.** Nothing records which lane a fetch took. A future wrong key change would still be invisible until a user reports "cannot lock ref" or an unexplained stall — which is how the previous revision's split went unnoticed until review.

# Costs and residual risk

- **Gitfile marker position — this change SPLITS a lane here, and it is the only place it does.** The shared `parseGitdirMarkerPayload` accepts `gitdir:` only at offset 0, matching git's `read_gitfile_gently`; the replaced regex carried an `m` flag and accepted it on any line. A `.git` file whose first line is something else now falls through to the parent walk, moving the key from the pointed-at common dir to an ancestor (layout **i**: `C:\repo\.git\FETCH_HEAD` → `C:\.git\FETCH_HEAD`). This applies on **every** platform including macOS and Linux. **The split has no instance:** run against real git 2.44.0, that exact file makes `git fetch`, `git status` and `git rev-parse --git-dir` all fail with `fatal: invalid gitfile format: …/wt/.git`. No fetch runs in such a worktree, so nothing that previously serialized can now race. Kept rather than reverted because matching git's own parser is the correct semantics and the alternative is a hand-rolled regex duplicating a shared module — but the direction is stated here, not claimed away.
- **Case-insensitive marker.** The shared parser matches `GITDIR:` where the old regex did not, and where `read_gitfile_gently` does not. A widening; not a form git emits.
- **Payload padding.** `gitdir:\t../x  ` is now trimmed, matching git. A widening: it merges with the bare spelling.
- **drvfs prefix collision.** `toWindowsWslDrivePath` maps `/mnt/c/X` to `C:\X`. If a distro has a non-drvfs mount at `/mnt/c`, that repo now shares a lane with a real `C:\...` repo. Direction is merge — extra serialization, never a lost lock. Previously it produced the equally-wrong-but-fictional `C:\mnt\c\X`.
- **One pathological narrowing.** If a real directory `C:\mnt\c\repo` exists on a Windows host, a drvfs worktree and that unrelated native repo stop sharing the accidental dead-end lane they share today. Two unrelated repos ceasing to over-serialize is not a lost lock, but it is a key move.
- **Three `hostPath()` call sites cannot be mutation-pinned, and are proved to be non-behaviour instead.** The walk's `join(current, '.git')`, the drive-root `join(current, '.git')` and `join(gitDir, 'commondir')` all survive a revert to `path`, because the final `hostPath().join(canonicalGitDir, 'FETCH_HEAD')` re-normalizes separators across the whole key (`C:\/.git` → `C:\.git\FETCH_HEAD`) and because the first two feed only `stat`/`readFile` lookups. Pinning them would need a separator-strict fs mock, which is unfaithful to Windows (Windows accepts `/` and `\` interchangeably) and would pin a mock artifact. Every `hostPath()` site that *can* change a key — `dirname`, the `realpath` fallback `resolve`, and the final `join` — now is pinned.
- **`hostPath()` costs one branch per path operation on the fetch path.** It returns exactly the submodule Node itself selects for the `path` default export, so it is a runtime no-op on every real host. It exists so the Win32 derivation is testable on a POSIX runner, which is what lets the Windows cases be mutation-verified at all.
- **`AbortError` shape is pinned deliberately.** `waitForPromiseWithSignal` would surface a caller-supplied `signal.reason`; the wrappers rethrow this module's existing synthetic `AbortError` so callers that classify on `error.name` see no change. A test asserts this with `controller.abort(new TypeError(...))`.
- **Shared lock namespace.** `runWithGitOperationLock`'s `Map` is shared with `runWithGitWorktreeOperationLock`, whose keys are plain worktree paths. The fold applies only to fetch keys, and every fetch key carries a `FETCH_HEAD`/`fetch_head` suffix that a worktree path does not, so the namespaces still cannot collide. The key is only ever a `Map` key, never a filesystem path, so the changed separators and lowercasing are safe.

# Verification

**Files changed:** 2 — `src/shared/git-fetch-head-lock.ts` (+77/−12, 203 lines total against the 300-line cap, no `max-lines` disable) and a new `src/shared/git-fetch-head-lock-key-derivation.test.ts` (273 lines).

**Tests:** 12 new in `git-fetch-head-lock-key-derivation.test.ts` plus the 12 existing real-fs tests in `git-fetch-head-lock.test.ts` — **24 pass, 0 fail**. Also green together with `git-metadata-path.test.ts`, `wsl-paths.test.ts`, `relay/git-handler.test.ts` and `main/git/command-runner/git-exec-admission-lifetime.test.ts` — **100 pass across 6 files**. No test is gated on the host platform: `process.platform` is spied and the `win32`/`posix` submodules are selected at call time, so the Windows cases run on every runner.

**Broader run** over `src/shared`, `src/relay` and `src/main/git/command-runner`: **8086 passed / 12 failed / 71 skipped across 768 files**. All 12 failures are unrelated. Re-running just those 8 files in isolation on this branch gives 10 failed / 105 passed; re-running the same 8 with `src/shared/git-fetch-head-lock.ts` restored from `HEAD~1` and the new test file removed gives 9 failed / 106 passed across the same 6 files (`git-admission-storm-measurement` — deterministic ENOENT on a temp state dir; `export-let-function-initializer-ban`; `remote-runtime-shared-control-connection`; `setup-agent-sequencing` ×4; `windows-transient-lock-removal`; `wsl-exec-mode-separator`). The count varies between runs on the same commit because the residue is timeout flake, not this change.

**Mutation checks — 14 independent production-hunk reverts. Every one is caught, and all 12 tests in the new file are pinned by at least one; none survived, so none was deleted.**

| Revert | Test(s) that fail |
| --- | --- |
| Fold body replaced with `return key` | folds the WSL UNC aliases and distro casing of one repo into a single lock key **+** keeps a WSL UNC repo and its linked worktree on one lane |
| Fold's `win32` gate removed | leaves the two UNC spellings apart on a non-Windows host |
| Old `/^gitdir:\s*(.+)\s*$/m` restored | puts a padded gitfile pointer in the same lane as its bare spelling |
| Whole drvfs translation removed | keeps a drive-spelled worktree on its own main checkout's lane **+** merges an absolute guest commondir into the main checkout's lane |
| `process.platform === 'win32'` gate on translation removed | never fabricates a Windows drive path on a POSIX host |
| **`!isWslUncPath(basePath)` guard removed** (the prior P1) | **keeps a WSL UNC repo and its linked worktree on one lane** |
| `toWindowsWslDrivePath(rawPointer)` → `rawPointer` (the raw-POSIX identity fallback this PR rejects) | keeps a drive-spelled worktree on its own main checkout's lane **+** merges an absolute guest commondir **+** keeps today's key for a guest pointer Windows cannot address |
| **commondir call site → plain `hostPath().resolve`** (was unpinned) | **merges an absolute guest commondir into the main checkout's lane** (new) |
| **`hostPath().dirname` → `path.dirname` on the parent walk** (was unpinned) | **walks to the drive root with Windows rules for a folder workspace** (new) |
| **`hostPath().resolve` → `path.resolve` in the realpath fallback** (was unpinned) | **falls back to the Windows spelling when realpath fails** (new) |
| `realpath` unwrapped from `waitForPromiseWithSignal` | rejects promptly while a hung realpath is still pending (times out, 5005ms) |
| `stat` unwrapped | rejects promptly while a hung metadata stat is still pending (times out, 5006ms) |
| `throw signal.reason` instead of `abortError()` | rejects promptly while a hung realpath is still pending (`name` becomes `TypeError`) |
| `hostPath()` always returns `path.posix` | 6 tests: drive-spelled worktree lane, WSL UNC one lane, absolute guest commondir, drive-root folder workspace, realpath fallback, guest pointer Windows cannot address |

Two of these (the `win32` gates) are identity guards verified in the opposite direction: they fail when the change is made *more* aggressive, pinning that macOS/Linux keys stay unchanged. Three `join` call sites survive their reverts and are documented above as provably unobservable rather than presented as covered.

**Real-git check:** the one narrowing (layout **i**) was tested against git 2.44.0 on a scratch repo in `/tmp`, not reasoned about: `printf '\ngitdir: …' > wt/.git` makes `git fetch` fail with `fatal: invalid gitfile format`.

**Lint/format:** `npx oxfmt --write` then `npx oxlint` on both files, exit 0.

**Typecheck:** `pnpm tc` not run per instructions; instead `tsc --noEmit` over `src/shared/**/*` and `src/types/**/*` through `config/tsconfig.node.json` — 0 diagnostics.