### PR TITLE
docs(wsl): note that the distro VHDX is a high-water mark, not a leak

### DIFF
--- a/docs/reference/wsl-command-execution.md
+++ b/docs/reference/wsl-command-execution.md
@@ -2,6 +2,8 @@
 
 Two properties of `wsl.exe` decide how every guest invocation has to be written. Both are silent
 when you get them wrong: the command still runs and still exits 0, it just returns the wrong bytes.
+Those are sections 1 and 2. A closing section answers the question that running Orca's writes
+inside a distro raises next: what happens to the distro's disk image.
 
 ## 1. Always `--exec`, never `--`
 
@@ -70,3 +72,102 @@ wsl.exe -d <distro> --exec /usr/bin/env PATH=… HOME=… /usr/bin/git -C <dir> 
 This is what the direct-git read path does. It is immune to both problems above by construction and
 avoids paying login-shell startup on every call, which also sidesteps profiles that block or print.
 Resolve the PATH/HOME once through a fenced probe, cache it per distro, then use this form.
+
+## Disk: the distro VHDX only grows
+
+Everything above puts Orca's writes inside the distro, which raises a separate question. WSL2 keeps
+the entire guest filesystem in a single dynamically-expanding `ext4.vhdx`. Deleting files inside
+the distro does free the blocks — for ext4 to reuse — but the host-visible `.vhdx` does not shrink
+on its own.
+
+### Finding the file
+
+The path depends on how the distro was installed, so do not assume one:
+
+| Install method         | `ext4.vhdx` lives under                                   |
+| ---------------------- | --------------------------------------------------------- |
+| recent `wsl --install` | `%LOCALAPPDATA%\wsl\{guid}\`                              |
+| Microsoft Store        | `%LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalState\` |
+| `wsl --import`         | wherever the operator pointed it                          |
+
+The install-agnostic answer is the registry, which records every distro's directory as `BasePath`:
+
+```powershell
+Get-ChildItem HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss |
+  ForEach-Object { Get-ItemProperty $_.PSPath } |
+  Select-Object DistributionName, BasePath
+```
+
+### Measured behavior
+
+WSL 2.7.11.0 / Ubuntu-24.04, one machine. Sizes are **size on disk** — allocated bytes, via
+`GetCompressedFileSize`, not the logical file length. That distinction matters below: on this
+machine the vhdx was not sparse, so the two numbers were identical, but on a sparse vhdx the
+logical size stays pinned at the high-water mark while only size on disk falls when space is
+reclaimed. Measure the wrong one and reclaim looks like it did nothing.
+
+| Step                               | `ext4.vhdx` size on disk (bytes) |
+| ---------------------------------- | -------------------------------- |
+| baseline                           | 21,673,017,344                   |
+| write 1 GiB                        | 22,746,759,168                   |
+| delete it                          | 22,746,759,168                   |
+| write a fresh incompressible 1 GiB | 22,746,759,168                   |
+| hold 3 GiB live at once            | 24,894,242,816                   |
+
+The fourth row is the point: the second gigabyte cost zero growth, because ext4 handed it the
+blocks the first one freed. Only exceeding the previous peak moved the file.
+
+### Reclaiming space
+
+Sparse mode lets the guest hand freed blocks back to the host, so the file can shrink instead of
+only growing. Two preconditions, both easy to miss: the distro has to be stopped (the vhdx cannot
+be converted while it is mounted), and `wsl --manage` exists only on WSL 2.5 and newer — check with
+`wsl --version`.
+
+```
+wsl --terminate <distro>
+wsl --manage <distro> --set-sparse true
+```
+
+The equivalent for distros not yet created is `sparseVhd = true` under `[experimental]` in
+`%UserProfile%\.wslconfig` — that file lives in the Windows user profile, **not** inside the distro
+and not at `~/.wslconfig`, and does not exist until you create it.
+
+Neither touches slack that already exists. For that, shut WSL down and compact the file by hand
+from an **elevated** prompt. `compact vdisk` on its own fails because no virtual disk is selected,
+so the `select` and the read-only `attach` are required, not optional:
+
+```
+wsl --shutdown
+diskpart
+DISKPART> select vdisk file="C:\path\to\ext4.vhdx"
+DISKPART> attach vdisk readonly
+DISKPART> compact vdisk
+DISKPART> detach vdisk
+DISKPART> exit
+```
+
+Two caveats, neither verified here: field reports say `compact vdisk` is a no-op on a vhdx that is
+already sparse (convert back with `--set-sparse false` first), and sparse mode's runtime cost was
+not measured. Microsoft's [disk-space guide](https://learn.microsoft.com/windows/wsl/disk-space)
+carries the current locate/expand/compact procedure and the `--manage` version floor;
+[`.wslconfig`](https://learn.microsoft.com/windows/wsl/wsl-config) carries `sparseVhd`. Enabling
+sparse mode and compacting are both per-machine decisions; Orca does not make either.
+
+On the measured machine the vhdx was **not** sparse: `fsutil sparse queryflag` reported "NOT set as
+sparse", and no `%UserProfile%\.wslconfig` existed to opt in. Microsoft documents `sparseVhd` as
+defaulting to `false`, so that is the expected state rather than a local quirk — but the flag is
+per-vhdx, set when the disk is created or by an explicit conversion, so check your own distro
+rather than assuming either way.
+
+### What this means for Orca
+
+A vhdx that grows as speculative worktree preparation and mirrored worktrees write into the distro
+is expected. Its size is monotonically non-decreasing and roughly tracks peak concurrent usage —
+but it can drift above peak, and the measurement above is the best case for reuse: the second
+gigabyte was allocated immediately after the first was freed, out of the same block group. Under
+sustained churn — many worktrees created and removed over weeks, no `fstrim`/discard, sparse off —
+allocation spreads and the file settles higher than live peak.
+
+So growth on its own is not evidence of a leak. Growth well above live peak usage is worth
+investigating, and is the case the reclaim steps above address.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 |

<!-- /orca-pr-loc -->

## Problem

Engineers running Orca on WSL watch the distro's `ext4.vhdx` grow as speculative worktree preparation and mirrored worktrees write into the distro, and reasonably ask whether Orca leaks disk. Nothing in the repo documented the answer, so the question gets re-derived by hand each time — and the two obvious next questions ("where is the file?", "how do I get the space back?") have wrong-by-default answers that cost more time than the original question.

WSL2 keeps the entire guest filesystem in one dynamically-expanding `ext4.vhdx`. Deleting files inside the distro **does** free the blocks for ext4 to reuse, but the host-visible `.vhdx` does not shrink on its own.

## What this change is

One section appended to the existing `docs/reference/wsl-command-execution.md` — the doc `AGENTS.md:52` and `src/main/wsl/wsl-runner.ts:14` already point at for WSL specifics. No new file and no rename: both inbound links reference the path, and the two sibling WSL docs cover probe failure vocabulary and test-coverage layers, neither of which fits. The doc's intro was widened in the same commit so it describes the whole file rather than only the invocation rules.

Four subsections:

**Finding the file.** The vhdx location depends on install method, so the doc gives all three (recent `wsl --install` → `%LOCALAPPDATA%\wsl\{guid}\`; Microsoft Store → `%LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalState\`; `wsl --import` → wherever the operator put it) plus the install-agnostic answer: a PowerShell one-liner reading `BasePath` from `HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss`.

**Measured behavior.** WSL 2.7.11.0 / Ubuntu-24.04, one machine. Sizes are **size on disk** — allocated bytes via `GetCompressedFileSize`, not logical file length. The doc says so, and says why it matters: on a sparse vhdx the logical size stays pinned at the high-water mark while only size-on-disk falls, so measuring the wrong one makes reclaim look like it did nothing.

| Step | `ext4.vhdx` size on disk (bytes) |
| --- | --- |
| baseline | 21,673,017,344 |
| write 1 GiB | 22,746,759,168 |
| delete it | 22,746,759,168 |
| write a fresh incompressible 1 GiB | 22,746,759,168 |
| hold 3 GiB live at once | 24,894,242,816 |

The fourth row is the load-bearing one: a second, freshly generated incompressible gigabyte cost **zero** growth because ext4 reused the blocks the first one freed. Only exceeding the previous peak moved the file.

**Reclaiming space.** `wsl --manage <distro> --set-sparse true` governs future slack, and the doc states its two preconditions rather than presenting it as directly runnable: the distro must be stopped (`wsl --terminate <distro>` is shown as the preceding line, since the vhdx cannot be converted while mounted) and `wsl --manage` exists only on WSL 2.5 and newer, per Microsoft's disk-space guide. The `.wslconfig` equivalent — `sparseVhd = true` under `[experimental]`, applying to newly created VHDs — is given at `%UserProfile%\.wslconfig`, the Windows user profile, with an explicit note that it is **not** `~/.wslconfig` inside the distro. Slack that already exists needs a shutdown plus a manual compact, given as a complete elevated `diskpart` sequence — `select vdisk file="…"` and `attach vdisk readonly` before `compact vdisk` — because `compact vdisk` on its own fails with no virtual disk selected. Both are per-machine decisions; Orca makes neither.

**What this means for Orca.** The vhdx size is monotonically non-decreasing and roughly tracks peak concurrent usage, but can drift above it. Growth alone is not evidence of a leak; growth well above live peak is.

## What changes for users

| Platform | Delta |
| --- | --- |
| macOS | no change — documentation only |
| Linux | no change — documentation only |
| Windows (native) | no change — documentation only |
| WSL-on-Windows | no change — documentation only |
| SSH | no change — documentation only |
| Relay | no change — documentation only |
| Folder workspaces | no change — documentation only |
| GitHub / GitLab / other providers | no change — documentation only |

Nothing executes. Zero files outside `docs/`.

## What this does NOT do

- Does not change any production code, config, test, or packaging.
- Does not make Orca enable sparse VHD, run `wsl --shutdown`/`wsl --terminate`, or compact anything. Those stay user-initiated, per-machine decisions.
- Does not reduce disk usage, or change how speculative preparation and mirrored worktrees write into a distro.
- Does not claim the reader's existing vhdx is or is not sparse. It reports `fsutil sparse queryflag` on one machine, cites Microsoft's documented `sparseVhd` default of `false` for newly created VHDs, and then tells the reader to check their own distro — because the flag is per-vhdx and set at creation or by explicit conversion.
- Does not claim anything about sparse mode's runtime cost, or verify the `diskpart` recipe or the sparse-blocks-compaction caveat by execution. Both are labeled unverified in the doc and sourced to Microsoft's guide and to field reports.
- Does not assert that the vhdx never drifts above live peak. It says the opposite.
- Does not add a docs index entry (there is no docs index), rename the file, or add an `AGENTS.md` bullet; the existing link already reaches it.

## Costs and residual risk

**Made worse: the diff more than tripled**, from 30 added lines to 101. The install-method table, the registry snippet, the size-on-disk paragraph, the `--set-sparse` preconditions, the `%UserProfile%` correction, and the full `diskpart` block are the bulk of it, and three `###` subheads were added to keep a ~100-line section navigable. Every line traces to a correctness fix; none is decorative — but this is a bigger docs commit than the topic first suggests.

**Unverified content, labeled as such.** The `diskpart` sequence and the "compaction is a no-op on an already-sparse vhdx" caveat were not executed here; they are sourced to Microsoft's documentation and field reports and marked "neither verified here". The exact diskpart error text is paraphrased rather than quoted, deliberately, because it could not be confirmed on this machine. A reader following the recipe is following a citation, not a reproduction. The same applies to the `--set-sparse` preconditions: the "distro must be stopped" and "WSL 2.5+" constraints come from Microsoft's disk-space guide, which documents them for `wsl --manage` as a whole, not for `--set-sparse` in isolation.

**Single-machine measurement.** WSL 2.7.11.0, Ubuntu-24.04, one host, one run. The doc leads with that. The mechanism it explains — VHDX as high-water mark, ext4 reusing freed extents — is not version-specific and is the part readers will rely on; the byte counts are illustration. A future WSL release could change the sparse default or the `--manage` surface and date the reclaim subsection.

**The measurement is the best case.** Rows 3–4 free 1 GiB and immediately reallocate 1 GiB, which ext4 satisfies from the extents it just released in the same block group. The doc now says this explicitly rather than generalizing from it. The fragmented / sustained-churn case is described but was **not** measured, so the drift claim is reasoned, not observed.

**Staleness is the only failure mode.** Nothing here reaches a runtime path on any platform, so a wrong line costs a reader time, not correctness.

## Verification

- 1 file changed, **101 insertions, 0 deletions** — confirmed via `git diff HEAD~1 HEAD --numstat`. No `.ts`/`.tsx`/config/lockfile/test touched.
- Both external claims were re-checked against the primary source this round, not from memory: `learn.microsoft.com/windows/wsl/wsl-config` states the `.wslconfig` location is "`%UserProfile%\.wslconfig`, outside of a WSL distribution" and lists `sparseVhd` default `false`; `learn.microsoft.com/windows/wsl/disk-space` states "The `wsl --manage` command is only available to WSL releases 2.5 and higher" and begins every `--manage` procedure with terminating WSL instances.
- `grep -n '~/\.wslconfig'` over the file returns exactly one hit — the sentence that explicitly tells the reader the file is *not* there.
- `npx oxfmt --write docs/reference/wsl-command-execution.md` — clean.
- `npx prettier --check docs/reference/wsl-command-execution.md` — "All matched files use Prettier code style!"
- `npx oxlint docs/reference/wsl-command-execution.md` — "No files found to lint", expected and correct for markdown.
- **Tests: none added, none kept, none run — and therefore no mutation verification is claimed or possible.** There is no executable surface in this change, so there is no production hunk to revert and no test that could fail against one. This is stated rather than omitted because "mutation-verified" is otherwise an unanswered question on every PR.
- Table arithmetic re-derived independently, not copied: baseline → 1 GiB is exactly `+1,073,741,824`; the delete and second-gigabyte rows are byte-identical to the peak; 3 GiB live is exactly `+2,147,483,648` over that peak. All five values are exactly MiB-aligned, consistent with the cluster-aligned allocated-size capture the doc names.
- Both sibling WSL docs (`wsl-probe-failure-semantics.md`, `wsl-runner-verification.md`) were read to re-confirm neither is a better home, and both inbound references (`AGENTS.md:52`, `src/main/wsl/wsl-runner.ts:14`) link by path, so no rename is required and none was made.
- `git status --porcelain` empty; exactly one commit ahead of `main`; `nwparker/wsl-vhdx-sparse-doc` points at `723cffd8e5bf`; not pushed.