### PR TITLE
fix(ssh): resolve the worktree's execution host instead of guessing from one repo row

### DIFF
--- a/src/main/runtime/orca-runtime-resolve-browser-network-execution-host-for-worktree.ts
+++ b/src/main/runtime/orca-runtime-resolve-browser-network-execution-host-for-worktree.ts
@@ -10,6 +10,7 @@ import {
 import { resolveRuntimeBrowserNetworkExecutionHost } from './runtime-browser-network-execution-host'
 import { resolveLocalProjectRuntimeForWorktreeId } from '../local-project-runtime-resolution'
 import { getRegisteredSshState } from '../ssh/ssh-target-registry'
+import { resolveWorktreeLaunchHost } from './worktree-launch-host-repo'
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../shared/workspace-scope'
 import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { ResolvedWorktree } from './runtime-worktree-path-identity'
@@ -124,7 +125,16 @@ export class OrcaRuntimeWithResolveBrowserNetworkExecutionHostForWorktree extend
     const parsed = parseWorkspaceKey(workspaceSelector)
     const worktreeSelector = parsed?.type === 'worktree' ? `id:${parsed.worktreeId}` : selector
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
-    const repo = this.store?.getRepo(worktree.repoId) ?? null
+    // Why: `getRepo(id)` is host-blind and the same repo id can exist on local, SSH and runtime
+    // hosts. Reading `connectionId` off an arbitrary row reports "local" for a remote worktree and
+    // spawns its PTY on the client with the remote cwd (#11163). Loss of a usable answer is
+    // `unresolved`, never `local`.
+    const resolution = resolveWorktreeLaunchHost(this.store?.getRepos() ?? [], worktree)
+    if (resolution.kind === 'ambiguous') {
+      throw new Error('worktree_execution_host_unresolved')
+    }
+    // Metadata only (display name, hook settings); the routing decision is `resolution.connectionId`.
+    const repo = resolution.repo ?? this.store?.getRepo(worktree.repoId) ?? null
     triggerTerminalSpawnPushTargetMaterialization(
       worktree.path,
       worktree.pushTarget,
@@ -137,7 +147,7 @@ export class OrcaRuntimeWithResolveBrowserNetworkExecutionHostForWorktree extend
       scope: {
         id: worktree.id,
         path: worktree.path,
-        connectionId: repo?.connectionId ?? null,
+        connectionId: resolution.connectionId,
         repo,
         folderWorkspace: null
       },

--- a/src/main/runtime/runtime-workspace-session-controller.ts
+++ b/src/main/runtime/runtime-workspace-session-controller.ts
@@ -8,6 +8,7 @@ import {
 import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree/id'
+import { workspaceSessionPartitionHostId } from '../../shared/workspace-session-partition-owner'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import type { RuntimeStore } from './runtime-store-contract'
 
@@ -44,7 +45,11 @@ export class RuntimeWorkspaceSessionController {
     }
     const resolvedWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
     const repo = store?.getRepo?.(getRepoIdFromWorktreeId(resolvedWorktreeId))
-    return repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
+    // Why: SSH worktrees keep their own `ssh:<targetId>` partition here while the renderer writes
+    // them to 'local'; the shared owner map records that divergence (#12723).
+    return repo
+      ? workspaceSessionPartitionHostId(getRepoExecutionHostId(repo), 'host-partition')
+      : LOCAL_EXECUTION_HOST_ID
   }
 
   getHostId(worktreeId: string): ExecutionHostId {

--- a/src/main/runtime/worktree-launch-host-repo.test.ts
+++ b/src/main/runtime/worktree-launch-host-repo.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorktreeLaunchHost } from './worktree-launch-host-repo'
+
+// Why (#11163): the terminal launch scope read
+// `store.getRepo(worktree.repoId)?.connectionId ?? null` — one spelling of one arbitrarily chosen
+// row instead of the worktree's execution host. A remote worktree then spawns its PTY on the
+// client with the remote cwd (`DaemonProtocolError: Working directory "…" does not exist`).
+describe('resolveWorktreeLaunchHost', () => {
+  const localRow = { id: 'shared', path: '/local/repo' }
+  const sshRow = { id: 'shared', path: '/remote/repo', connectionId: 'ssh-b' }
+
+  it('reports ambiguous when duplicate repo rows disagree about the owning host', () => {
+    expect(resolveWorktreeLaunchHost([localRow, sshRow], { repoId: 'shared' })).toEqual({
+      kind: 'ambiguous'
+    })
+  })
+
+  it('resolves the row for the host the worktree names', () => {
+    expect(
+      resolveWorktreeLaunchHost([localRow, sshRow], { repoId: 'shared', hostId: 'ssh:ssh-b' })
+    ).toEqual({ kind: 'resolved', repo: sshRow, connectionId: 'ssh-b' })
+    expect(
+      resolveWorktreeLaunchHost([localRow, sshRow], { repoId: 'shared', hostId: 'local' })
+    ).toEqual({ kind: 'resolved', repo: localRow, connectionId: null })
+  })
+
+  it('never hands a runtime-owned worktree a client SSH connection', () => {
+    const clientOwnedRow = { id: 'r', path: '/p', connectionId: 'ssh-client' }
+    expect(
+      resolveWorktreeLaunchHost([clientOwnedRow], { repoId: 'r', hostId: 'runtime:env-a' })
+    ).toEqual({ kind: 'resolved', repo: clientOwnedRow, connectionId: null })
+    // Two rows and no match: nothing names the owner, so the row is not evidence either.
+    expect(
+      resolveWorktreeLaunchHost([clientOwnedRow, { id: 'r', path: '/q' }], {
+        repoId: 'r',
+        hostId: 'runtime:env-a'
+      })
+    ).toEqual({ kind: 'resolved', repo: null, connectionId: null })
+  })
+
+  it('leaves a single unambiguous row alone', () => {
+    expect(resolveWorktreeLaunchHost([sshRow], { repoId: 'shared' })).toEqual({
+      kind: 'resolved',
+      repo: sshRow,
+      connectionId: 'ssh-b'
+    })
+    expect(resolveWorktreeLaunchHost([localRow], { repoId: 'shared' })).toEqual({
+      kind: 'resolved',
+      repo: localRow,
+      connectionId: null
+    })
+    expect(resolveWorktreeLaunchHost([], { repoId: 'shared' })).toEqual({
+      kind: 'resolved',
+      repo: null,
+      connectionId: null
+    })
+  })
+})

--- a/src/main/runtime/worktree-launch-host-repo.test.ts
+++ b/src/main/runtime/worktree-launch-host-repo.test.ts
@@ -24,16 +24,52 @@ describe('resolveWorktreeLaunchHost', () => {
     ).toEqual({ kind: 'resolved', repo: localRow, connectionId: null })
   })
 
-  it('never hands a runtime-owned worktree a client SSH connection', () => {
+  // The settled rule: the execution host is authoritative, and a row on some *other* host is never
+  // evidence about this one — not for the connection, and not for the metadata row either. This is
+  // the question `getRepoSshConnectionId` and `getSshTargetIdForExecutionHost` once answered two
+  // ways; they now compose, and `execution-host.test.ts` pins the composition.
+  it('never hands a worktree a connection belonging to a different host', () => {
     const clientOwnedRow = { id: 'r', path: '/p', connectionId: 'ssh-client' }
     expect(
       resolveWorktreeLaunchHost([clientOwnedRow], { repoId: 'r', hostId: 'runtime:env-a' })
-    ).toEqual({ kind: 'resolved', repo: clientOwnedRow, connectionId: null })
-    // Two rows and no match: nothing names the owner, so the row is not evidence either.
+    ).toEqual({ kind: 'resolved', repo: null, connectionId: null })
+    // Even the runtime host's *own* row contributes no PTY route: its nested target lives in that
+    // machine's namespace, so spawning against it here would dial the wrong box. The renderer
+    // reads the same resolution and does want that id — see execution-host.test.ts.
+    const nestedRow = {
+      id: 'r',
+      path: '/p',
+      connectionId: 'ssh-nested',
+      executionHostId: 'runtime:env-a' as const
+    }
     expect(
-      resolveWorktreeLaunchHost([clientOwnedRow, { id: 'r', path: '/q' }], {
+      resolveWorktreeLaunchHost([nestedRow], { repoId: 'r', hostId: 'runtime:env-a' })
+    ).toEqual({ kind: 'resolved', repo: nestedRow, connectionId: null })
+    // Two SSH hosts, one shared repo id: the worktree's own host wins outright.
+    expect(
+      resolveWorktreeLaunchHost([{ id: 'r', path: '/p', connectionId: 'openclaw' }], {
         repoId: 'r',
-        hostId: 'runtime:env-a'
+        hostId: 'ssh:m4air'
+      })
+    ).toEqual({ kind: 'resolved', repo: null, connectionId: 'm4air' })
+    expect(
+      resolveWorktreeLaunchHost(
+        [
+          { id: 'r', path: '/p', connectionId: 'openclaw' },
+          { id: 'r', path: '/q', connectionId: 'm4air' }
+        ],
+        { repoId: 'r', hostId: 'ssh:m4air' }
+      )
+    ).toEqual({
+      kind: 'resolved',
+      repo: { id: 'r', path: '/q', connectionId: 'm4air' },
+      connectionId: 'm4air'
+    })
+    // A row declaring itself local hands out no SSH connection, whatever `connectionId` says.
+    expect(
+      resolveWorktreeLaunchHost([{ id: 'r', path: '/p', connectionId: 'openclaw' }], {
+        repoId: 'r',
+        hostId: 'local'
       })
     ).toEqual({ kind: 'resolved', repo: null, connectionId: null })
   })

--- a/src/main/runtime/worktree-launch-host-repo.ts
+++ b/src/main/runtime/worktree-launch-host-repo.ts
@@ -1,10 +1,9 @@
 import {
-  LOCAL_EXECUTION_HOST_ID,
-  getRepoExecutionHostId,
-  getSshTargetIdForExecutionHost,
-  normalizeExecutionHostId,
-  type ExecutionHostId
-} from '../../shared/execution-host'
+  createRepoRowExecutionHostLookup,
+  resolveWorktreeExecutionHost,
+  type ExecutionHostOwnerRow
+} from '../../shared/worktree-execution-host-resolution'
+import { getSshTargetIdForExecutionHost } from '../../shared/execution-host'
 import type { Repo } from '../../shared/repo-types'
 
 export type LaunchHostRepo = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
@@ -14,41 +13,31 @@ export type WorktreeLaunchHostResolution<T extends LaunchHostRepo> =
   | { kind: 'ambiguous' }
 
 /**
- * Pick the repo row that owns a worktree's execution, and read the SSH connection off the
- * resolved host rather than off whichever row an id-only lookup happened to return.
+ * Main-side adapter over the shared execution-host rule
+ * (`src/shared/worktree-execution-host-resolution.ts`), which the renderer's owner index answers
+ * with too. Two things are local to this side:
  *
- * The same repo id can exist on local, SSH and runtime hosts at once — `setResolvedRepoGitUsername`
- * already refuses id-only lookups for that reason. A host-blind `getRepo(id)` can hand a remote
- * worktree the local row, whose `connectionId` reads `null`, and the PTY then spawns on the client
- * with the remote cwd (#11163). Conflicting rows with nothing to disambiguate them resolve
- * `ambiguous`, never "local".
+ * - rival rows that disagree about the host are `ambiguous` and the launch scope throws, while an
+ *   id nobody carries stays "no repo, no connection" — the launch path's long-standing behaviour
+ *   for a worktree whose repo row has gone;
+ * - the connection comes off the *host*, not the resolved row. This is a client-dialable PTY
+ *   route, so a `runtime:` host contributes nothing: its nested SSH target belongs to that
+ *   machine's namespace and spawning against it here would dial the wrong box. The renderer wants
+ *   the opposite answer from the same resolution, which is why the shared type carries both.
  */
-export function resolveWorktreeLaunchHost<T extends LaunchHostRepo>(
+export function resolveWorktreeLaunchHost<T extends LaunchHostRepo & ExecutionHostOwnerRow>(
   repos: readonly T[],
-  worktree: { repoId: string; hostId?: ExecutionHostId | null }
+  worktree: { repoId: string; hostId?: string | null }
 ): WorktreeLaunchHostResolution<T> {
-  const rows = repos.filter((repo) => repo.id === worktree.repoId)
-  const worktreeHostId = normalizeExecutionHostId(worktree.hostId)
-  if (worktreeHostId) {
-    // The worktree names its own host, which outranks the repo fallback.
-    const match = rows.find((repo) => getRepoExecutionHostId(repo) === worktreeHostId)
-    return {
-      kind: 'resolved',
-      repo: match ?? (rows.length === 1 ? (rows[0] ?? null) : null),
-      connectionId: getSshTargetIdForExecutionHost(worktreeHostId)
-    }
+  const resolution = resolveWorktreeExecutionHost(createRepoRowExecutionHostLookup(repos), worktree)
+  if (resolution.kind === 'unresolved') {
+    return resolution.reason === 'ambiguous'
+      ? { kind: 'ambiguous' }
+      : { kind: 'resolved', repo: null, connectionId: null }
   }
-  if (rows.length === 0) {
-    return { kind: 'resolved', repo: null, connectionId: null }
-  }
-  const hostIds = new Set<ExecutionHostId>(rows.map((repo) => getRepoExecutionHostId(repo)))
-  if (hostIds.size > 1) {
-    return { kind: 'ambiguous' }
-  }
-  const hostId = [...hostIds][0] ?? LOCAL_EXECUTION_HOST_ID
   return {
     kind: 'resolved',
-    repo: rows[0] ?? null,
-    connectionId: getSshTargetIdForExecutionHost(hostId)
+    repo: resolution.owner,
+    connectionId: getSshTargetIdForExecutionHost(resolution.hostId)
   }
 }

--- a/src/main/runtime/worktree-launch-host-repo.ts
+++ b/src/main/runtime/worktree-launch-host-repo.ts
@@ -1,0 +1,54 @@
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  getRepoExecutionHostId,
+  getSshTargetIdForExecutionHost,
+  normalizeExecutionHostId,
+  type ExecutionHostId
+} from '../../shared/execution-host'
+import type { Repo } from '../../shared/repo-types'
+
+export type LaunchHostRepo = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+
+export type WorktreeLaunchHostResolution<T extends LaunchHostRepo> =
+  | { kind: 'resolved'; repo: T | null; connectionId: string | null }
+  | { kind: 'ambiguous' }
+
+/**
+ * Pick the repo row that owns a worktree's execution, and read the SSH connection off the
+ * resolved host rather than off whichever row an id-only lookup happened to return.
+ *
+ * The same repo id can exist on local, SSH and runtime hosts at once — `setResolvedRepoGitUsername`
+ * already refuses id-only lookups for that reason. A host-blind `getRepo(id)` can hand a remote
+ * worktree the local row, whose `connectionId` reads `null`, and the PTY then spawns on the client
+ * with the remote cwd (#11163). Conflicting rows with nothing to disambiguate them resolve
+ * `ambiguous`, never "local".
+ */
+export function resolveWorktreeLaunchHost<T extends LaunchHostRepo>(
+  repos: readonly T[],
+  worktree: { repoId: string; hostId?: ExecutionHostId | null }
+): WorktreeLaunchHostResolution<T> {
+  const rows = repos.filter((repo) => repo.id === worktree.repoId)
+  const worktreeHostId = normalizeExecutionHostId(worktree.hostId)
+  if (worktreeHostId) {
+    // The worktree names its own host, which outranks the repo fallback.
+    const match = rows.find((repo) => getRepoExecutionHostId(repo) === worktreeHostId)
+    return {
+      kind: 'resolved',
+      repo: match ?? (rows.length === 1 ? (rows[0] ?? null) : null),
+      connectionId: getSshTargetIdForExecutionHost(worktreeHostId)
+    }
+  }
+  if (rows.length === 0) {
+    return { kind: 'resolved', repo: null, connectionId: null }
+  }
+  const hostIds = new Set<ExecutionHostId>(rows.map((repo) => getRepoExecutionHostId(repo)))
+  if (hostIds.size > 1) {
+    return { kind: 'ambiguous' }
+  }
+  const hostId = [...hostIds][0] ?? LOCAL_EXECUTION_HOST_ID
+  return {
+    kind: 'resolved',
+    repo: rows[0] ?? null,
+    connectionId: getSshTargetIdForExecutionHost(hostId)
+  }
+}

--- a/src/renderer/src/lib/connection-context.test.ts
+++ b/src/renderer/src/lib/connection-context.test.ts
@@ -525,6 +525,36 @@ describe('getConnectionIdFromState', () => {
     expect(getConnectionIdFromState(state, 'repo-ssh::/home/neil/repo-feature')).toBe('ssh-2')
   })
 
+  it('refuses to resolve a connection when duplicate repo rows disagree about the owning host', () => {
+    // Why (#17799): a repo id carried by two rows — one runtime-owned, one holding a
+    // client-owned SSH connection — must not hand the client's connection to the runtime.
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [
+        makeRepo({ id: 'repo-dup', executionHostId: 'runtime:env-a' }),
+        makeRepo({ id: 'repo-dup', connectionId: 'ssh-client' })
+      ],
+      worktreesByRepo: {}
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-dup::/home/neil/repo-feature')).toBeUndefined()
+  })
+
+  it('still resolves duplicate repo rows that agree about the owning host', () => {
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [
+        makeRepo({ id: 'repo-dup', connectionId: 'ssh-same' }),
+        makeRepo({ id: 'repo-dup', connectionId: 'ssh-same', path: '/home/neil/other' })
+      ],
+      worktreesByRepo: {}
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-dup::/home/neil/repo-feature')).toBe('ssh-same')
+  })
+
   it('indexes immutable worktree and repo snapshots once across repeated selector calls', () => {
     let worktreeIdReads = 0
     let repoIdReads = 0

--- a/src/renderer/src/lib/connection-context.test.ts
+++ b/src/renderer/src/lib/connection-context.test.ts
@@ -27,6 +27,27 @@ function makeRepo(overrides: Partial<Repo> & { id: string }): Repo {
   }
 }
 
+function makeWorktree(overrides: Partial<Worktree> & { id: string; repoId: string }): Worktree {
+  return {
+    path: '/srv/repo',
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'Workspace',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
 describe('getConnectionId', () => {
   afterEach(() => {
     useAppStore.setState(initialState, true)
@@ -553,6 +574,102 @@ describe('getConnectionIdFromState', () => {
     }
 
     expect(getConnectionIdFromState(state, 'repo-dup::/home/neil/repo-feature')).toBe('ssh-same')
+  })
+
+  it('never hands a worktree the SSH connection of a different host', () => {
+    // Why (#11163): two SSH hosts, one shared repo id. The worktree names `ssh:m4air`; the only
+    // indexed row belongs to `openclaw`. An id-only fallback after the host lookup misses answers
+    // with the wrong host's connection — "Reconnect openclaw" on an m4air pane, and file reads
+    // routed to a machine that never held the path.
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [makeRepo({ id: 'repo-shared', connectionId: 'openclaw' })],
+      worktreesByRepo: {
+        'repo-shared': [
+          makeWorktree({
+            id: 'repo-shared::/srv/repo',
+            repoId: 'repo-shared',
+            hostId: 'ssh:m4air'
+          })
+        ]
+      }
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-shared::/srv/repo')).toBe('m4air')
+  })
+
+  it('never hands a runtime-hosted worktree a client-owned SSH connection', () => {
+    // The row is on `ssh:openclaw`, not on the runtime host, so it says nothing about this
+    // worktree. This is the cross-host case, not the nested-SSH one below.
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [makeRepo({ id: 'repo-shared', connectionId: 'openclaw' })],
+      worktreesByRepo: {
+        'repo-shared': [
+          makeWorktree({
+            id: 'repo-shared::/srv/repo',
+            repoId: 'repo-shared',
+            hostId: 'runtime:awin'
+          })
+        ]
+      }
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-shared::/srv/repo')).toBeNull()
+  })
+
+  it('keeps a runtime host nested SSH target, which decides local readability', () => {
+    // `repoWithFetchedOwner` stamps the runtime host and spreads the nested target through. The
+    // pane pairs it with the environment (`selectRuntimeAwareSshStatus`) for reconnect state, and
+    // `isNativeChatTranscriptLocalReadable` treats a null here as "this client can read it" — so
+    // dropping it would send a transcript read to the wrong machine.
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [
+        makeRepo({
+          id: 'repo-runtime',
+          connectionId: 'ssh-nested',
+          executionHostId: 'runtime:env-a'
+        })
+      ],
+      worktreesByRepo: {
+        'repo-runtime': [
+          makeWorktree({
+            id: 'repo-runtime::/srv/repo',
+            repoId: 'repo-runtime',
+            hostId: 'runtime:env-a',
+            runtimeOwnerEnvironmentId: 'env-a'
+          })
+        ]
+      }
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-runtime::/srv/repo')).toBe('ssh-nested')
+  })
+
+  it('resolves the row on the SSH host the worktree names when both hosts carry the id', () => {
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [
+        makeRepo({ id: 'repo-shared', connectionId: 'openclaw' }),
+        makeRepo({ id: 'repo-shared', connectionId: 'm4air', path: '/srv/repo' })
+      ],
+      worktreesByRepo: {
+        'repo-shared': [
+          makeWorktree({
+            id: 'repo-shared::/srv/repo',
+            repoId: 'repo-shared',
+            hostId: 'ssh:m4air'
+          })
+        ]
+      }
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-shared::/srv/repo')).toBe('m4air')
   })
 
   it('indexes immutable worktree and repo snapshots once across repeated selector calls', () => {

--- a/src/renderer/src/lib/connection-owner-resolution.ts
+++ b/src/renderer/src/lib/connection-owner-resolution.ts
@@ -1,5 +1,10 @@
 import type { AppState } from '@/store/types'
-import { getIndexedRepoMap, getIndexedWorktreeMap } from '@/store/worktree-repo-index'
+import {
+  findIndexedRepoOwnerForHost,
+  resolveIndexedRepoOwner,
+  resolveIndexedWorktreeOwner
+} from './worktree-runtime-owner-index'
+import { getRepoSshConnectionId, normalizeExecutionHostId } from '../../../shared/execution-host'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
@@ -60,10 +65,32 @@ export function getConnectionIdFromState(
   }
   // Why: owner resolution runs from retained Zustand selectors, so unrelated
   // store writes must not flatten every worktree or scan every repository.
-  const worktree = getIndexedWorktreeMap(state.worktreesByRepo).get(worktreeId)
+  const worktreeResolution = resolveIndexedWorktreeOwner(state.worktreesByRepo, worktreeId)
+  if (worktreeResolution.kind === 'ambiguous') {
+    // Why (#17799): rows that disagree about the owner cannot name a connection.
+    // `undefined` is this module's documented "cannot determine the host" answer;
+    // collapsing it to `null` would authorize a local read of a remote path.
+    return undefined
+  }
+  const worktree = worktreeResolution.kind === 'resolved' ? worktreeResolution.owner : undefined
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = getIndexedRepoMap(state.repos).get(repoId)
-  return repo ? (repo.connectionId ?? null) : undefined
+  // Why (#17799): take the connection off the same host record the rest of owner
+  // resolution used. A host-blind, last-wins repo lookup can pair a runtime owner
+  // with a client-owned SSH connection the runtime has never heard of.
+  const worktreeHostId = normalizeExecutionHostId(worktree?.hostId)
+  const hostScopedRepo = worktreeHostId
+    ? findIndexedRepoOwnerForHost(state.repos, repoId, worktreeHostId)
+    : null
+  if (hostScopedRepo) {
+    return getRepoSshConnectionId(hostScopedRepo)
+  }
+  const repoResolution = resolveIndexedRepoOwner(state.repos, repoId)
+  if (repoResolution.kind === 'ambiguous') {
+    return undefined
+  }
+  return repoResolution.kind === 'resolved'
+    ? getRepoSshConnectionId(repoResolution.owner)
+    : undefined
 }
 
 export function getConnectionIdForFileFromState(

--- a/src/renderer/src/lib/connection-owner-resolution.ts
+++ b/src/renderer/src/lib/connection-owner-resolution.ts
@@ -4,7 +4,7 @@ import {
   resolveIndexedRepoOwner,
   resolveIndexedWorktreeOwner
 } from './worktree-runtime-owner-index'
-import { getRepoSshConnectionId, normalizeExecutionHostId } from '../../../shared/execution-host'
+import { resolveWorktreeExecutionHost } from '../../../shared/worktree-execution-host-resolution'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
@@ -74,23 +74,16 @@ export function getConnectionIdFromState(
   }
   const worktree = worktreeResolution.kind === 'resolved' ? worktreeResolution.owner : undefined
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  // Why (#17799): take the connection off the same host record the rest of owner
-  // resolution used. A host-blind, last-wins repo lookup can pair a runtime owner
-  // with a client-owned SSH connection the runtime has never heard of.
-  const worktreeHostId = normalizeExecutionHostId(worktree?.hostId)
-  const hostScopedRepo = worktreeHostId
-    ? findIndexedRepoOwnerForHost(state.repos, repoId, worktreeHostId)
-    : null
-  if (hostScopedRepo) {
-    return getRepoSshConnectionId(hostScopedRepo)
-  }
-  const repoResolution = resolveIndexedRepoOwner(state.repos, repoId)
-  if (repoResolution.kind === 'ambiguous') {
-    return undefined
-  }
-  return repoResolution.kind === 'resolved'
-    ? getRepoSshConnectionId(repoResolution.owner)
-    : undefined
+  // Why (#17799, #11163): one rule, shared with main's launch scope. The renderer's contribution is
+  // only the memoized index — unrelated store writes must not rescan every repository.
+  const resolution = resolveWorktreeExecutionHost(
+    {
+      byId: (id) => resolveIndexedRepoOwner(state.repos, id),
+      byHost: (id, hostId) => findIndexedRepoOwnerForHost(state.repos, id, hostId)
+    },
+    { repoId, hostId: worktree?.hostId ?? null }
+  )
+  return resolution.kind === 'resolved' ? resolution.connectionId : undefined
 }
 
 export function getConnectionIdForFileFromState(

--- a/src/renderer/src/lib/workspace-session-host-persistence.ts
+++ b/src/renderer/src/lib/workspace-session-host-persistence.ts
@@ -9,6 +9,7 @@ import {
   parseExecutionHostId,
   type ExecutionHostId
 } from '../../../shared/execution-host'
+import { workspaceSessionPartitionHostId } from '../../../shared/workspace-session-partition-owner'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 import {
@@ -187,8 +188,9 @@ export function buildHostSessionRouting(state: HostPersistenceState): HostSessio
     if (!repoHostId) {
       return LOCAL_EXECUTION_HOST_ID
     }
-    const parsed = parseExecutionHostId(repoHostId)
-    return parsed?.kind === 'runtime' ? parsed.id : LOCAL_EXECUTION_HOST_ID
+    // Why: SSH-owned worktrees stay in the 'local' partition here while the runtime writes them to
+    // `ssh:<targetId>`; the shared owner map records that divergence (#12723).
+    return workspaceSessionPartitionHostId(repoHostId, 'local-partition')
   }
   return { hostIdByWorktreeId, claims }
 }

--- a/src/shared/execution-host.test.ts
+++ b/src/shared/execution-host.test.ts
@@ -4,7 +4,9 @@ import {
   LOCAL_EXECUTION_HOST_ID,
   getLocalExecutionHostLabel,
   getRepoExecutionHostId,
+  getRepoSshConnectionId,
   getSettingsFocusedExecutionHostId,
+  getSshTargetIdForExecutionHost,
   getWorktreeExecutionHostId,
   normalizeExecutionHostOrder,
   normalizeExecutionHostScope,
@@ -111,6 +113,41 @@ describe('execution host identity', () => {
       getWorktreeExecutionHostId({}, { connectionId: 'repo-owner' }, 'runtime:focused-host')
     ).toBe('ssh:repo-owner')
     expect(getWorktreeExecutionHostId({}, {}, 'runtime:focused-host')).toBe('runtime:focused-host')
+  })
+
+  // These two look interchangeable and are not: one answers "which SSH target holds this row's
+  // files", the other "which connection may this client dial". They agree except on a runtime
+  // host, where a nested target exists but is not dialable from here — so the pane that reads it
+  // needs one answer and the PTY route needs the other.
+  it('distinguishes the SSH target holding a row from the connection this client may dial', () => {
+    // Legacy spelling: `connectionId` alone *is* the host, so both answers agree.
+    expect(getRepoSshConnectionId({ connectionId: 'openclaw' })).toBe('openclaw')
+    expect(getSshTargetIdForExecutionHost('ssh:openclaw')).toBe('openclaw')
+    // Unified spelling, no legacy field.
+    expect(getRepoSshConnectionId({ executionHostId: 'ssh:m4air' })).toBe('m4air')
+
+    // A row declaring itself local hands out no SSH connection, whatever the legacy field says:
+    // `local` has no SSH namespace to nest in, so the two spellings are contradicting each other.
+    expect(
+      getRepoSshConnectionId({ executionHostId: 'local', connectionId: 'openclaw' })
+    ).toBeNull()
+
+    // A runtime host does have its own namespace, and a nested target appears only in this field.
+    // Dropping it would make a nested-SSH workspace read as local — which is what decides whether
+    // this client tries to read the transcript itself.
+    expect(
+      getRepoSshConnectionId({ executionHostId: 'runtime:env-a', connectionId: 'ssh-nested' })
+    ).toBe('ssh-nested')
+    // ...but that id is not dialable from this client alone, so the routing answer stays null.
+    expect(getSshTargetIdForExecutionHost('runtime:env-a')).toBeNull()
+    // A runtime host with no nested target is simply not on SSH.
+    expect(getRepoSshConnectionId({ executionHostId: 'runtime:env-a' })).toBeNull()
+
+    // An ephemeral-VM target is an ordinary client-dialable target and stays an `ssh:` host.
+    expect(getRepoSshConnectionId({ connectionId: 'runtime-ssh-vm-1' })).toBe('runtime-ssh-vm-1')
+    expect(getRepoExecutionHostId({ connectionId: 'runtime-ssh-vm-1' })).toBe(
+      'ssh:runtime-ssh-vm-1'
+    )
   })
 
   it('derives focused host compatibility from active runtime settings', () => {

--- a/src/shared/execution-host.ts
+++ b/src/shared/execution-host.ts
@@ -166,6 +166,24 @@ export function getRepoExecutionHostId(
   return connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID
 }
 
+// Why: SSH ownership has two spellings on a repo row — the legacy `connectionId`
+// field and the unified `executionHostId`. Routing that reads the raw field answers
+// "local" for a row that only carries `ssh:<target>`, which runs a remote operation
+// on the client. Resolve the host first, then read the connection off it.
+export function getRepoSshConnectionId(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): string | null {
+  const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
+  return parsed?.kind === 'ssh' ? parsed.targetId : null
+}
+
+export function getSshTargetIdForExecutionHost(
+  executionHostId: string | null | undefined
+): string | null {
+  const parsed = parseExecutionHostId(executionHostId)
+  return parsed?.kind === 'ssh' ? parsed.targetId : null
+}
+
 export function getWorktreeExecutionHostId(
   worktree: Pick<Worktree, 'hostId'>,
   repo: Pick<Repo, 'connectionId' | 'executionHostId'> | undefined,

--- a/src/shared/execution-host.ts
+++ b/src/shared/execution-host.ts
@@ -166,29 +166,42 @@ export function getRepoExecutionHostId(
   return connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID
 }
 
-// Why: SSH ownership has two spellings on a repo row — the legacy `connectionId`
-// field and the unified `executionHostId`. Routing that reads the raw field answers
-// "local" for a row that only carries `ssh:<target>`, which runs a remote operation
-// on the client. Resolve the host first, then read the connection off it.
-//
-// Why the fallback: a row whose execution host is a *runtime* can still reach a nested
-// SSH target, and that target only ever appears in `connectionId`. Returning null for
-// those rows answers "local" for a nested-SSH worktree — the same defect in reverse.
-export function getRepoSshConnectionId(
-  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
-): string | null {
-  const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
-  if (parsed?.kind === 'ssh') {
-    return parsed.targetId
-  }
-  return normalizeHostPart(repo.connectionId) ?? null
-}
-
 export function getSshTargetIdForExecutionHost(
   executionHostId: string | null | undefined
 ): string | null {
   const parsed = parseExecutionHostId(executionHostId)
   return parsed?.kind === 'ssh' ? parsed.targetId : null
+}
+
+// Why: SSH ownership has two spellings on a repo row — the legacy `connectionId`
+// field and the unified `executionHostId`. Routing that reads the raw field answers
+// "local" for a row that only carries `ssh:<target>`, which runs a remote operation
+// on the client. Resolve the host first, then read the connection off it.
+//
+// The two hosts that are not themselves SSH are not the same case:
+//
+//   - `local` has no SSH namespace to nest in, so a surviving `connectionId` is a row
+//     contradicting itself — the shape main's `resolveRepoOwnershipEvidence` calls
+//     `contradictory`. Answering with it hands out an SSH connection for a row that declares
+//     itself local.
+//   - `runtime:<env>` is a different machine with its own SSH targets, and a nested one appears
+//     only in this field (`repoWithFetchedOwner` spreads it through). It is not dialable on its
+//     own, but it is addressable as the pair (environmentId, targetId) — which is how the
+//     renderer reads it, recovering the environment from the worktree and looking the target up
+//     inside it (`selectRuntimeAwareSshStatus`). Dropping it makes a nested-SSH workspace read
+//     as local, which is what decides whether a transcript is read on this client.
+//
+// So this answers "which SSH target holds this row's files", not "which connection may this
+// client dial". `getSshTargetIdForExecutionHost` answers the latter; callers routing a
+// client-local PTY or Git provider want that one instead.
+export function getRepoSshConnectionId(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): string | null {
+  const host = parseExecutionHostId(getRepoExecutionHostId(repo))
+  if (host?.kind === 'ssh') {
+    return host.targetId
+  }
+  return host?.kind === 'runtime' ? normalizeHostPart(repo.connectionId) : null
 }
 
 export function getWorktreeExecutionHostId(

--- a/src/shared/execution-host.ts
+++ b/src/shared/execution-host.ts
@@ -170,11 +170,18 @@ export function getRepoExecutionHostId(
 // field and the unified `executionHostId`. Routing that reads the raw field answers
 // "local" for a row that only carries `ssh:<target>`, which runs a remote operation
 // on the client. Resolve the host first, then read the connection off it.
+//
+// Why the fallback: a row whose execution host is a *runtime* can still reach a nested
+// SSH target, and that target only ever appears in `connectionId`. Returning null for
+// those rows answers "local" for a nested-SSH worktree — the same defect in reverse.
 export function getRepoSshConnectionId(
   repo: Pick<Repo, 'connectionId' | 'executionHostId'>
 ): string | null {
   const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
-  return parsed?.kind === 'ssh' ? parsed.targetId : null
+  if (parsed?.kind === 'ssh') {
+    return parsed.targetId
+  }
+  return normalizeHostPart(repo.connectionId) ?? null
 }
 
 export function getSshTargetIdForExecutionHost(

--- a/src/shared/workspace-session-partition-owner.test.ts
+++ b/src/shared/workspace-session-partition-owner.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { workspaceSessionPartitionHostId } from './workspace-session-partition-owner'
+
+// Why (#12723): the renderer and the runtime used two independent owner maps for the same
+// worktree's session state. They now share one function, so the divergence is a single argument
+// and cannot drift further. Behaviour on both sides is unchanged.
+describe('workspaceSessionPartitionHostId', () => {
+  it('keeps runtime worktrees in their own partition on both sides', () => {
+    expect(workspaceSessionPartitionHostId('runtime:env-a', 'local-partition')).toBe(
+      'runtime:env-a'
+    )
+    expect(workspaceSessionPartitionHostId('runtime:env-a', 'host-partition')).toBe('runtime:env-a')
+  })
+
+  it('keeps local worktrees local on both sides', () => {
+    expect(workspaceSessionPartitionHostId('local', 'local-partition')).toBe('local')
+    expect(workspaceSessionPartitionHostId('local', 'host-partition')).toBe('local')
+  })
+
+  it('records the SSH divergence as the only difference between the two models', () => {
+    expect(workspaceSessionPartitionHostId('ssh:devbox', 'local-partition')).toBe('local')
+    expect(workspaceSessionPartitionHostId('ssh:devbox', 'host-partition')).toBe('ssh:devbox')
+  })
+
+  it('falls back to the local partition for unparseable host ids', () => {
+    expect(workspaceSessionPartitionHostId(null, 'host-partition')).toBe('local')
+    expect(workspaceSessionPartitionHostId('nonsense', 'host-partition')).toBe('local')
+  })
+})

--- a/src/shared/workspace-session-partition-owner.ts
+++ b/src/shared/workspace-session-partition-owner.ts
@@ -1,0 +1,39 @@
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from './execution-host'
+
+/**
+ * Where an SSH-owned worktree's durable session state lives.
+ *
+ * This is the single axis on which the renderer and the main-process runtime disagree today
+ * (stablyai/orca#12723). Both sides now compute their partition through this function so the
+ * divergence is one argument in one place instead of two independently drifting owner maps:
+ *
+ * - `local-partition` — the renderer's shipping model. SSH worktrees keep their session state in
+ *   the `local` partition; partitioning them would double-own the data.
+ * - `host-partition` — the runtime's shipping model (#12671). Pane retirement, windowless PTY
+ *   handoff and orchestration fences read-modify-write `ssh:<targetId>`.
+ *
+ * Both partitions hold real data written by shipping builds, so neither side can simply adopt the
+ * other's answer: flipping a resolver orphans whichever store it stops reading. Converging needs a
+ * read-both transition (generalize `workspaceSessionPartitionIdsForHost`) and should converge on
+ * `host-partition`, since Orca Remote — SSH's successor — is already partitioned as `runtime:*`.
+ * Until then this function preserves today's behaviour exactly on both sides.
+ */
+export type WorkspaceSessionSshOwnership = 'local-partition' | 'host-partition'
+
+export function workspaceSessionPartitionHostId(
+  executionHostId: string | null | undefined,
+  sshOwnership: WorkspaceSessionSshOwnership
+): ExecutionHostId {
+  const parsed = parseExecutionHostId(executionHostId)
+  if (parsed?.kind === 'runtime') {
+    return parsed.id
+  }
+  if (parsed?.kind === 'ssh') {
+    return sshOwnership === 'host-partition' ? parsed.id : LOCAL_EXECUTION_HOST_ID
+  }
+  return LOCAL_EXECUTION_HOST_ID
+}

--- a/src/shared/worktree-execution-host-resolution.test.ts
+++ b/src/shared/worktree-execution-host-resolution.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createRepoRowExecutionHostLookup,
+  resolveWorktreeExecutionHost
+} from './worktree-execution-host-resolution'
+
+// Why (#11163, #17799): main's terminal launch scope and the renderer's owner index both answer
+// "which host does this worktree execute on". They used to answer it separately, and disagreed —
+// main derived the host from the worktree while the renderer fell back to an id-only repo lookup,
+// so a pane on one SSH host was routed to another. One rule now, exercised here directly.
+const resolve = (
+  repos: readonly { id: string; connectionId?: string; executionHostId?: string }[],
+  worktree: { repoId: string; hostId?: string | null }
+): ReturnType<typeof resolveWorktreeExecutionHost> =>
+  resolveWorktreeExecutionHost(createRepoRowExecutionHostLookup(repos as never), worktree) as never
+
+describe('resolveWorktreeExecutionHost', () => {
+  describe('the worktree names its own host', () => {
+    it('routes to that host even when the only row belongs to a different SSH host', () => {
+      // The reproduced defect: `ssh:m4air` worktree, sole row on `openclaw`.
+      expect(
+        resolve([{ id: 'r', connectionId: 'openclaw' }], { repoId: 'r', hostId: 'ssh:m4air' })
+      ).toEqual({ kind: 'resolved', hostId: 'ssh:m4air', connectionId: 'm4air', owner: null })
+    })
+
+    it('answers before the repo row hydrates, because the host is not a guess', () => {
+      // Deliberate change from "unresolved": #6648 blocks destructive ops while the *host* is
+      // unknown. A worktree naming `ssh:m4air` is not that case — the repo row adds nothing the
+      // host id has not already settled, and refusing here stalls a remote pane on hydration.
+      expect(resolve([], { repoId: 'r', hostId: 'ssh:m4air' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:m4air',
+        connectionId: 'm4air',
+        owner: null
+      })
+    })
+
+    it('picks the row on that host when both SSH hosts carry the id', () => {
+      const openclaw = { id: 'r', connectionId: 'openclaw' }
+      const m4air = { id: 'r', connectionId: 'm4air' }
+      expect(resolve([openclaw, m4air], { repoId: 'r', hostId: 'ssh:m4air' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:m4air',
+        connectionId: 'm4air',
+        owner: m4air
+      })
+      expect(resolve([openclaw, m4air], { repoId: 'r', hostId: 'ssh:openclaw' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:openclaw',
+        connectionId: 'openclaw',
+        owner: openclaw
+      })
+    })
+
+    it('matches a row that names the host in either spelling', () => {
+      const stamped = { id: 'r', executionHostId: 'ssh:m4air' }
+      expect(resolve([stamped], { repoId: 'r', hostId: 'ssh:m4air' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:m4air',
+        connectionId: 'm4air',
+        owner: stamped
+      })
+    })
+
+    it('takes no connection from a row on a different host, whatever this host is', () => {
+      // The row lives on `ssh:openclaw`; neither a local nor a runtime worktree may borrow it.
+      for (const hostId of ['local', 'runtime:env-a']) {
+        expect(resolve([{ id: 'r', connectionId: 'openclaw' }], { repoId: 'r', hostId })).toEqual({
+          kind: 'resolved',
+          hostId,
+          connectionId: null,
+          owner: null
+        })
+      }
+    })
+
+    it('reads a runtime host nested SSH target off the row on that same host', () => {
+      // Not a cross-host borrow: this row *is* the runtime host's row, and the nested target
+      // appears nowhere else. Nulling it makes the workspace read as local, which decides whether
+      // this client tries to read a transcript that lives on the nested host.
+      const nested = { id: 'r', connectionId: 'ssh-nested', executionHostId: 'runtime:env-a' }
+      expect(resolve([nested], { repoId: 'r', hostId: 'runtime:env-a' })).toEqual({
+        kind: 'resolved',
+        hostId: 'runtime:env-a',
+        connectionId: 'ssh-nested',
+        owner: nested
+      })
+    })
+
+    it('gives a local row no SSH connection even when it carries a stale one', () => {
+      const contradictory = { id: 'r', connectionId: 'openclaw', executionHostId: 'local' }
+      expect(resolve([contradictory], { repoId: 'r', hostId: 'local' })).toEqual({
+        kind: 'resolved',
+        hostId: 'local',
+        connectionId: null,
+        owner: contradictory
+      })
+    })
+  })
+
+  describe('the worktree names no host', () => {
+    it('resolves from the sole row, in either spelling', () => {
+      const legacy = { id: 'r', connectionId: 'openclaw' }
+      expect(resolve([legacy], { repoId: 'r' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:openclaw',
+        connectionId: 'openclaw',
+        owner: legacy
+      })
+      const stamped = { id: 'r', executionHostId: 'ssh:m4air' }
+      expect(resolve([stamped], { repoId: 'r' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:m4air',
+        connectionId: 'm4air',
+        owner: stamped
+      })
+      const local = { id: 'r' }
+      expect(resolve([local], { repoId: 'r' })).toEqual({
+        kind: 'resolved',
+        hostId: 'local',
+        connectionId: null,
+        owner: local
+      })
+    })
+
+    it('refuses when rival rows disagree about the host, including two SSH hosts', () => {
+      expect(
+        resolve(
+          [
+            { id: 'r', connectionId: 'openclaw' },
+            { id: 'r', connectionId: 'm4air' }
+          ],
+          {
+            repoId: 'r'
+          }
+        )
+      ).toEqual({ kind: 'unresolved', reason: 'ambiguous' })
+      expect(
+        resolve([{ id: 'r', connectionId: 'openclaw' }, { id: 'r' }], { repoId: 'r' })
+      ).toEqual({ kind: 'unresolved', reason: 'ambiguous' })
+    })
+
+    it('treats the two spellings of one host as agreement, not conflict', () => {
+      expect(
+        resolve(
+          [
+            { id: 'r', connectionId: 'm4air' },
+            { id: 'r', executionHostId: 'ssh:m4air' }
+          ],
+          { repoId: 'r' }
+        )
+      ).toMatchObject({ kind: 'resolved', hostId: 'ssh:m4air', connectionId: 'm4air' })
+    })
+
+    it('reports an unknown owner distinctly from a conflicting one', () => {
+      expect(resolve([], { repoId: 'r' })).toEqual({ kind: 'unresolved', reason: 'unknown' })
+    })
+  })
+
+  it('ignores an unparseable host id rather than treating it as a host', () => {
+    const row = { id: 'r', connectionId: 'openclaw' }
+    expect(resolve([row], { repoId: 'r', hostId: 'ssh:' })).toMatchObject({
+      kind: 'resolved',
+      connectionId: 'openclaw'
+    })
+  })
+})

--- a/src/shared/worktree-execution-host-resolution.ts
+++ b/src/shared/worktree-execution-host-resolution.ts
@@ -1,0 +1,109 @@
+/**
+ * One rule for "which host does this worktree execute on, and what connection routes there".
+ *
+ * Main and the renderer both have to answer it — the terminal launch scope picks a PTY route from
+ * it, the renderer picks a file-read route and the reconnect affordance from it — so the rule lives
+ * here instead of being re-derived per side. Two re-derivations already disagreed: main answered
+ * from the worktree's own host while the renderer fell back to an id-only repo lookup, so a pane on
+ * `ssh:m4air` was offered "Reconnect openclaw" and read its files off openclaw (#11163).
+ *
+ * `unresolved` is a distinct answer, never "local": the same repo id can exist on a local, an SSH
+ * and a runtime host at once, and loss of a usable answer must fail closed rather than authorize a
+ * client-side read of a remote path (#6648, #17799).
+ */
+
+import type { Repo } from './repo-types'
+import {
+  getRepoExecutionHostId,
+  getRepoSshConnectionId,
+  getSshTargetIdForExecutionHost,
+  normalizeExecutionHostId,
+  type ExecutionHostId
+} from './execution-host'
+
+export type ExecutionHostOwnerRow = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+
+export type ExecutionHostOwnerMatch<T> =
+  | { kind: 'resolved'; owner: T }
+  | { kind: 'missing' }
+  | { kind: 'ambiguous' }
+
+/**
+ * How a caller finds repo rows. Main scans the store array; the renderer answers from a
+ * WeakMap-memoized index because owner resolution runs inside retained selectors. That is a
+ * performance difference, not a different rule.
+ */
+export type ExecutionHostOwnerLookup<T extends ExecutionHostOwnerRow> = {
+  /** The row for `repoId`, or `ambiguous` when rival rows disagree about the owning host. */
+  byId: (repoId: string) => ExecutionHostOwnerMatch<T>
+  /** The row for `repoId` on exactly `hostId`, or null when that host carries no row. */
+  byHost: (repoId: string, hostId: ExecutionHostId) => T | null
+}
+
+export type WorktreeExecutionHostResolution<T extends ExecutionHostOwnerRow> =
+  | {
+      kind: 'resolved'
+      hostId: ExecutionHostId
+      /**
+       * The SSH target whose filesystem holds this workspace — for a `runtime:` host, its nested
+       * target, addressable only as the pair with `hostId`. Callers deciding what *this client*
+       * may dial (a PTY route, a Git provider) must use `getSshTargetIdForExecutionHost(hostId)`
+       * instead; this field can name a host the client cannot reach on its own.
+       */
+      connectionId: string | null
+      /** Display metadata only. The decisions are `hostId` / `connectionId`. */
+      owner: T | null
+    }
+  | { kind: 'unresolved'; reason: 'ambiguous' | 'unknown' }
+
+export function resolveWorktreeExecutionHost<T extends ExecutionHostOwnerRow>(
+  lookup: ExecutionHostOwnerLookup<T>,
+  worktree: { repoId: string; hostId?: string | null }
+): WorktreeExecutionHostResolution<T> {
+  const worktreeHostId = normalizeExecutionHostId(worktree.hostId)
+  if (worktreeHostId) {
+    // The worktree names its own host, which outranks every repo row. A row on a *different* host
+    // is not evidence about this one — falling back to it is the cross-host leak: one SSH host's
+    // pane routed to another. A row on *this* host still is evidence, and is the only place a
+    // runtime's nested SSH target appears.
+    const owner = lookup.byHost(worktree.repoId, worktreeHostId)
+    return {
+      kind: 'resolved',
+      hostId: worktreeHostId,
+      connectionId:
+        getSshTargetIdForExecutionHost(worktreeHostId) ??
+        (owner ? getRepoSshConnectionId(owner) : null),
+      owner
+    }
+  }
+  const match = lookup.byId(worktree.repoId)
+  if (match.kind !== 'resolved') {
+    return { kind: 'unresolved', reason: match.kind === 'ambiguous' ? 'ambiguous' : 'unknown' }
+  }
+  return {
+    kind: 'resolved',
+    hostId: getRepoExecutionHostId(match.owner),
+    connectionId: getRepoSshConnectionId(match.owner),
+    owner: match.owner
+  }
+}
+
+/** Array-backed lookup for callers holding the whole repo list (main's store). */
+export function createRepoRowExecutionHostLookup<T extends ExecutionHostOwnerRow>(
+  repos: readonly T[]
+): ExecutionHostOwnerLookup<T> {
+  const rowsFor = (repoId: string): T[] => repos.filter((repo) => repo.id === repoId)
+  return {
+    byId: (repoId) => {
+      const rows = rowsFor(repoId)
+      if (rows.length === 0) {
+        return { kind: 'missing' }
+      }
+      const hostIds = new Set(rows.map((repo) => getRepoExecutionHostId(repo)))
+      const owner = rows[0]
+      return hostIds.size > 1 || !owner ? { kind: 'ambiguous' } : { kind: 'resolved', owner }
+    },
+    byHost: (repoId, hostId) =>
+      rowsFor(repoId).find((repo) => getRepoExecutionHostId(repo) === hostId) ?? null
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​474 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​474 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​275 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​266 |

<!-- /orca-pr-loc -->

## The shared defect

All three issues are one shape: **a resolver reads one spelling of one arbitrarily-chosen row instead of resolving the worktree's execution host.** The seam already exists — `getRepoExecutionHostId` / `getWorktreeExecutionHostId` in `src/shared/execution-host.ts` — and each path bypasses it for raw `repo.connectionId` plus a host-blind lookup by id.

Two facts make that unsafe, and the codebase already documents both:

1. **SSH ownership has two spellings.** `Repo.executionHostId` permits `` `ssh:${string}` ``, and `getRepoExecutionHostId` treats it as authoritative over `connectionId`.
2. **One repo id can name several rows on different hosts.** `project-host-operations.ts:207` is a first-wins `repos.find(r => r.id === id)` — and ten lines below, `setResolvedRepoGitUsername` **refuses that exact lookup**: *"the same id can exist on several execution hosts, and an id-only lookup would write one host's username onto a sibling host's row."* The renderer had the identical hazard.

## #17799 — fixed at the seam

`getConnectionIdFromState` resolved through last-wins maps and returned `repo.connectionId ?? null`, while its sibling `getRuntimeEnvironmentIdForWorktree` used the ambiguity-aware `resolveIndexedWorktreeOwner` / `resolveIndexedRepoOwner`. Two resolvers, one host-aware, feeding one decision.

It now resolves the worktree first, prefers `findIndexedRepoOwnerForHost` so the connection comes off the **same host record** the runtime owner came from, and derives the connection via a new `getRepoSshConnectionId` rather than reading `.connectionId` — so a `runtime:`-owned row can no longer hand out a client SSH connection, and an `ssh:`-only row is no longer read as local.

**On the "`null` means local" trap:** no new state was introduced. `undefined` was *already* this module's documented "cannot determine the host" — `isWorktreeConnectionResolved` exists purely to test for it, added for #6648, the same failure mode. Every non-test consumer was audited; the table is in the commit. Summary: `file-explorer-operation-owner` → `unresolved`, blocks destructive ops; `useAgentDetectionTarget` → skip; `isNativeChatTranscriptLocalReadable` → false; the file-preview family all compare `=== null` so `undefined` never takes the local branch. The single coercion (`use-tab-bar-runtime-model:136`) is display-only, deciding which Windows shells to *offer*. **No consumer turns `undefined` into "run it locally"** — nothing here can reach a teardown RPC the way #14004 did.

```
BEFORE  AssertionError: expected 'ssh-client' to be undefined
AFTER   Tests  20 passed (20)
```
Two tests: the ambiguous case refuses, and duplicate rows that *agree* still resolve — so the fix isn't just "refuse more".

## #11163 — partly fixed; the PTY-routing seam

`resolveTerminalWorkspaceLaunchTarget` did `this.store?.getRepo(worktree.repoId)` then `connectionId: repo?.connectionId ?? null` — and that `connectionId` is the routing key handed straight to `ptyController.spawn`. `getRepo` is host-blind, so a remote worktree whose repo id also has a local row gets the local row, `connectionId` reads `null`, and **the PTY spawns on the client with the remote cwd** — producing `DaemonProtocolError: Working directory "…" does not exist`, exactly the reported error. It ignored `worktree.hostId` entirely.

The damning part: **98 lines above, in the same class**, `resolveBrowserNetworkExecutionHostForWorktree` answers the identical question correctly with `getWorktreeExecutionHostId(worktree, repo)`. The seam existed; the terminal path bypassed it.

New `worktree-launch-host-repo.ts` selects the row for the host the worktree names and returns `ambiguous` when rows conflict; the launch scope throws `worktree_execution_host_unresolved` rather than falling back to local.

**Honest note on the test:** it is a unit test of the new resolver, so it "fails before" only trivially. An end-to-end `createTerminal` test was attempted and abandoned, and the reason is itself a finding — the worktree **scan** is host-blind on the same field, so an `executionHostId:'ssh:*'`-only repo never resolves a remote worktree at all, and duplicate-id rows fail selector resolution before reaching the launch scope. That needs the scan seam fixed first.

**Residual host-blind sites found and deliberately not fixed** (each needs its own change): the worktree scan (`orca-runtime-refresh-repo-worktree-scan.ts:95,101`); managed-worktree create (`:90`, and note `isFolderRepo` returns *before* that check, so a folder repo on an SSH host takes the local path); `getRepo` itself (fixing it would fix ~100 downstream readers but is a store-contract change); `runtimeRepoMatchesExecutionHost` over-rejecting an unstamped SSH repo against its own host; and `assertHostIsSupported` refusing `--host ssh:*` from the CLI while the **same process** routes it correctly via IPC.

**Verdict: partly fixed, not closable.**

## #12723 — contained, not converged

Confirmed in both directions: the renderer collapses `ssh:*` to `local`; `runtime-workspace-session-controller.ts:47` returns `ssh:<targetId>` verbatim. Same worktree, two durable homes, **both written by the shipping build.**

Not converged, deliberately: flipping either resolver orphans whichever store it stops reading, and a safe migration needs a read-both transition generalizing `workspaceSessionPartitionIdsForHost` — larger than this task and not something to land half-done next to session state.

Instead: one shared owner map, `workspaceSessionPartitionHostId(hostId, sshOwnership)`, with the renderer passing `'local-partition'` and the runtime `'host-partition'`. **Behaviour on both sides is byte-identical** (33 existing tests unchanged and passing). The divergence is now one argument in one documented place, and the comment records the decision: converge on `host-partition`, because Orca Remote already partitions as `runtime:*`, so collapsing SSH deepens the fork while partitioning it moves toward one model. Flipping becomes a one-line change plus the migration.

Its test is characterization, not fail-before/pass-after — stated plainly rather than dressed up.

## Verification

| Check | Result |
|---|---|
| `orca-runtime.test.ts` | 1220 passed, twice isolated |
| All 6 changed/new test files | 1281 passed \| 1 skipped |
| `pnpm tc:node` / `pnpm tc:web` | exit 0 |
| `check:code-quality:changed` | passed |

One flake seen in a run that raced `oxfmt --write` over 22k files (`worktree-removal-and-reconciliation.spec.ts:289`); clean on re-run and in isolation, and that path is untouched here.

Fixes #17799
Refs #11163, #12723

---

## ELI5

Orca sometimes acted on the wrong machine. When two projects shared an id — one local, one on an SSH host — a lookup grabbed whichever row it saw first, so a remote terminal could launch locally with a remote path and fail with a confusing 'directory does not exist'.

## User-facing regression risk

- **Ambiguous ownership now refuses instead of guessing.** Every consumer was audited: none turns the unresolved answer into 'run it locally', and destructive paths block. Duplicate rows that *agree* still resolve normally.
- **#11163 is partly fixed** — the PTY-routing seam is fixed, but the worktree scan and managed-worktree create are still host-blind. Not closable.
- **#12723 is contained, not converged.** Behaviour is byte-identical on both sides; the divergence is now one documented argument in one place. Converging needs a read-both migration, because both partitions hold real data written by the shipping build and flipping either side would orphan the other.


---

## Update — the renderer half was still wrong, and is now fixed

Rebased onto current `main`. Review found the PR's central claim false for the renderer:

```
BEFORE  hostId 'ssh:m4air',    sole repo row {connectionId:'openclaw'}  ->  'openclaw'
        hostId 'runtime:awin', sole repo row {connectionId:'openclaw'}  ->  'openclaw'
AFTER   'm4air'  /  null
```

`getConnectionIdFromState` preferred `findIndexedRepoOwnerForHost`, but when that missed it fell
through to an **id-only** lookup and answered with whatever host that row named. So a pane on
`ssh:m4air` was offered "Reconnect openclaw" (`terminal-pane-host-state.ts:28`) and the
file-drop/paste paths read off `openclaw`. The main-side resolver *in this same PR* answered
`'m4air'` — two resolvers, one right and one wrong, on identical input, which is verbatim what this
PR said it removes. `main` is equally wrong, so it is not a regression, but the claim did not hold.

### One resolver, two adapters

New `src/shared/worktree-execution-host-resolution.ts` holds the rule; both sides adapt to it:

- main's `resolveWorktreeLaunchHost` is now the array adapter plus its `unresolved` → throw mapping;
- the renderer passes its WeakMap index in as the lookup — the memoizing adapter it always was.

The intersection is the discriminator plus `connectionId: string | null`. The repo row rides along
as display metadata and is still fallback-patched at the main call site.

### The nested-SSH rule — corrected after review

An earlier revision of this PR made `getRepoSshConnectionId` compose with
`getSshTargetIdForExecutionHost`, on the premise that the two "contradicted" each other for a
runtime host carrying a nested `connectionId`. **That premise was wrong, and review caught it.**

They are not two answers to one question; they are two questions:

| | question | runtime host with a nested target |
|---|---|---|
| `getRepoSshConnectionId(repo)` | which SSH target holds this row's files? | the nested target |
| `getSshTargetIdForExecutionHost(hostId)` | which connection may *this client* dial? | `null` |

Collapsing them broke `terminal-pane-host-state.test.ts` — the one red lane — and the failure was
real, not a stale expectation:

- **The reconnect affordance disappeared.** `selectRuntimeAwareSshStatus(state, environmentId,
  targetId)` looks up `sshStateByEnvironment.get(environmentId).connectionStates.get(targetId)`.
  The `(environmentId, ssh host)` pair *is* expressible and *is* expressed — the renderer recovers
  the environment from the worktree and pairs it with the target. Nulling the target half removed a
  nested-SSH pane's way back to its session.
- **Worse: `nativeChatTranscriptIsLocalReadable` flipped `false → true`.**
  `isNativeChatTranscriptLocalReadable` treats `null` as "this client can read it", and ~14 call
  sites gate transcript reads on it. That is the exact failure class this sweep exists to remove —
  a client inferring something only the host can know.

The rule now distinguishes the two non-SSH hosts, because they are not alike:

- **`local`** has no SSH namespace to nest in, so a surviving `connectionId` is a row contradicting
  itself — the shape main's own `resolveRepoOwnershipEvidence` calls `contradictory`. This is the
  **pullfrog** finding, and it is fixed: a row declaring itself local hands out no SSH connection.
- **`runtime:<env>`** is a different machine *with* its own SSH targets, and a nested one appears
  only in this field. It is kept.

`project-host-routing.ts:73` nulling the field is not counter-evidence: it stops a paired client
treating that id as *client-local configuration*, which is the routing question — and the routing
answer is still `null`. Main's launch adapter now derives its PTY route from `hostId`, never from
the row, so the two consumers get opposite answers from one resolution by design.

**The cross-host leak fix is unaffected** and is the part that stands: a row on a *different* host
is never evidence about this one. A row on the worktree's *own* host still is — that is where the
nested target legitimately lives.

### Confirmed bot findings, both fixed

- **pullfrog, `execution-host.ts:184`** — the fallback fired for `kind !== 'ssh'`, which includes
  `local`: `getRepoSshConnectionId({executionHostId:'local', connectionId:'openclaw'})` returned
  `'openclaw'`. A row declaring itself local handed out an SSH connection. Fixed narrowly: `local`
  yields no connection, while a runtime host keeps its nested one.
- **CodeRabbit, `connection-owner-resolution.ts:93`** — the id-only fallback after host resolution;
  the severe variant is the cross-host leak above.

### Tests

No test in either PR used **two different SSH hosts** — every duplicate case was local-vs-ssh or
runtime-vs-ssh, which is exactly why the leak survived. Added at three levels (shared rule, main
adapter, renderer). Both renderer tests also used `worktreesByRepo: {}`, so a PR titled "resolve the
*worktree's* execution host" had no renderer test where a worktree carried a `hostId`; the new ones
do.

| Check | Result |
|---|---|
| `pnpm tc` | exit 0 |
| whole `src` tree (`main`+`renderer`+`shared`+`cli`+`preload`) | **67499 passed** \| 267 skipped |
| previously-red `terminal-pane-host-state.test.ts` | passing |
| `check:code-quality:changed` | 0 new findings |
| `en.json` vs `main` | byte-identical (no drift from the rebase) |

