### PR TITLE
fix(terminal): pin the grid to the bottom of its container

### DIFF
--- a/src/renderer/src/assets/terminal-container-geometry.test.ts
+++ b/src/renderer/src/assets/terminal-container-geometry.test.ts
@@ -15,4 +15,10 @@ describe('terminal container geometry', () => {
       /\.pane-link-tooltip\s*{[^}]*height:\s*var\(--orca-terminal-link-tooltip-height\);/s
     )
   })
+
+  it('pins the terminal grid to the container bottom so fit slack sits above row one', () => {
+    // Unprefixed: floating-workspace terminals mount outside .pane-manager-root.
+    expect(terminalCss).toMatch(/^\.xterm-container\s*{[^}]*justify-content:\s*flex-end;/ms)
+    expect(terminalCss).not.toMatch(/\.pane-manager-root \.xterm\s*{[^}]*height:\s*100%;/s)
+  })
 })

--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -26,7 +26,6 @@
 }
 
 .pane-manager-root .xterm {
-  height: 100%;
   width: 100%;
 }
 
@@ -502,6 +501,14 @@
    so Ghostty-imported window-padding-x/y can be applied without inline styles.
    The fallback 4px preserves the legacy default. */
 .xterm-container {
+  /* Why: FitAddon floors rows to whole cells, so up to one cell of the container
+     stays unused. xterm anchors the grid at the top and that slack lands under
+     the last row (the prompt); flex-end puts it above row one instead. `.xterm`
+     sizes to `.xterm-screen` (rows x cellHeight) while FitAddon measures this
+     container, so the row count is unaffected. */
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
   box-sizing: border-box;
   position: relative;
   width: calc(100% - var(--pane-padding-x, 4px));


### PR DESCRIPTION
## Problem

`FitAddon` floors the row count to whole cells, so up to one cell of the container's height is always left over. xterm anchors its grid at the **top** of `.xterm-container`, so that leftover sits **under the last row** — a blank strip below the shell prompt, and the prompt never reaches the pane's bottom edge.

It is most visible with full-screen TUIs (Claude Code, vim, lazygit) that paint their status line at the bottom: the status line floats one row above the pane edge.

## Before / after

Same pane, same content (vim, whose status line paints on the last row), 28px of leftover height. Only the placement of that leftover changes; the bottom edge of the terminal window is visible in both frames.

**Before** — the grid is top-anchored, so a blank strip sits between vim's status line and the window edge:

![before](https://raw.githubusercontent.com/ArtemYurov/orca/assets/terminal-bottom-fit-slack/before.png)

**After** — the grid is bottom-anchored, so the status line sits on the window edge:

![after](https://raw.githubusercontent.com/ArtemYurov/orca/assets/terminal-bottom-fit-slack/after.png)

## Fix

Make `.xterm-container` a column flex box with `justify-content: flex-end`, and drop `height: 100%` from `.pane-manager-root .xterm` so `.xterm` shrinks to `.xterm-screen` (rows × cellHeight) instead of stretching over the leftover.

`FitAddon` measures `.xterm-container`, whose box is unchanged, so **the row count and every PTY resize stay exactly the same** — only the leftover pixels move from below row N to above row 1, matching Ghostty's behavior.

The rule is intentionally unprefixed: floating-workspace terminals mount in a `.pane` **outside** `.pane-manager-root`, so a `.pane-manager-root`-scoped rule would leave them on the old behavior.

## Verification

- Measured over CDP against a packaged build, floating terminal running a live TUI:
  - before — `slackBottom: 28`, `slackTop: 0`, `display: block`
  - after — `slackBottom: 0`, `slackTop: 28`, `display: flex`
- Row count unchanged across the switch; no PTY resize is triggered.
- `src/renderer/src/assets/terminal-container-geometry.test.ts` extended to pin the unprefixed selector and to assert `.pane-manager-root .xterm` no longer sets `height: 100%`.
