### PR TITLE
fix(worktree): widen git-common watch on event-batch overflow

### DIFF
--- a/src/main/ipc/worktree-base-directory-marker-poller.ts
+++ b/src/main/ipc/worktree-base-directory-marker-poller.ts
@@ -1,0 +1,289 @@
+import { readdir, stat } from 'node:fs/promises'
+import type { Dirent } from 'node:fs'
+import { join } from 'node:path'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import { forEachWithConcurrency } from '../../shared/map-with-concurrency'
+import type {
+  WorktreeBaseRepoWatchConfig,
+  WorktreeBaseWatchTarget
+} from './worktree-base-directory-event-filter'
+import type {
+  WorktreeBasePollerOptions,
+  WorktreeBasePollEvent,
+  WorktreeBaseSubscription,
+  WorktreePollerWindowVisibility
+} from './worktree-base-directory-poller'
+
+// Why: the mtime gate is an optimization, not a correctness boundary — some
+// filesystems have coarse dir timestamps, and pending `.git` markers expire.
+// A periodic ungated scan guarantees eventual convergence.
+export const WORKTREE_BASE_BACKSTOP_TICKS = 15
+
+// Why: a `.git` completion marker lands within moments of its worktree dir
+// (git writes it before populating the checkout). Dirs that never get one are
+// not worktrees; stop re-statting them after this many ticks and let the
+// backstop scan cover the pathological case.
+const PENDING_MARKER_MAX_TICKS = 300
+
+// Why: matches the git-common poller's fan-out bound (#17828) — bounded
+// concurrency turns hundreds of serial round trips into a handful of batches
+// without dumping every candidate onto libuv's 4-thread pool at once.
+const MARKER_PROBE_CONCURRENCY = 8
+
+function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
+  return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
+}
+
+async function dirSignature(path: string): Promise<string> {
+  try {
+    return statSignature(await stat(path))
+  } catch {
+    return 'missing'
+  }
+}
+
+async function hasGitMarker(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, '.git'))
+    return true
+  } catch {
+    return false
+  }
+}
+
+type BaseSnapshot = {
+  // worktree-candidate dir → whether its `.git` completion marker exists
+  markers: Map<string, boolean>
+  // dirs whose listing determines the candidate set: the root plus any
+  // nested repo containers. Their stat signatures gate the next full scan.
+  gateDirs: string[]
+  // index-aligned with gateDirs, each sampled *before* that dir's listing
+  gateSignatures: string[]
+}
+
+async function readdirSafe(path: string): Promise<Dirent[]> {
+  try {
+    return await readdir(path, { withFileTypes: true })
+  } catch {
+    return []
+  }
+}
+
+// Depth-1 worktree dirs (flat layout), plus depth-2 dirs under each nested
+// repo's container, mirroring what worktree-base-directory-event-filter
+// matches: `<wt>/.git` completion markers and `<wt>` deletions.
+async function snapshotBase(
+  rootPath: string,
+  repos: ReadonlyMap<string, WorktreeBaseRepoWatchConfig>
+): Promise<BaseSnapshot> {
+  const markers = new Map<string, boolean>()
+  const gateDirs = [rootPath]
+  // Why: sampling the signature before the listing makes a write that races the
+  // scan look stale next tick (one redundant rescan) instead of invisible until
+  // the backstop, which is up to 15 ticks of missed creates/deletes.
+  const gateSignatures = [await dirSignature(rootPath)]
+  const configs = [...repos.values()]
+  const includeFlat = configs.some((config) => !config.nestWorkspaces)
+  const nestedRepoNames = new Set(
+    configs
+      .filter((config) => config.nestWorkspaces)
+      .map((config) => normalizeRuntimePathForComparison(config.repoName))
+  )
+
+  // Root vanished or unreadable: readdirSafe yields [], producing the same
+  // empty markers/candidates result as the old watcher's error path.
+  const rootEntries = await readdirSafe(rootPath)
+
+  const candidates: string[] = []
+  for (const entry of rootEntries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+      continue
+    }
+    const entryPath = join(rootPath, entry.name)
+    if (includeFlat) {
+      candidates.push(entryPath)
+    }
+    if (nestedRepoNames.has(normalizeRuntimePathForComparison(entry.name))) {
+      gateDirs.push(entryPath)
+      gateSignatures.push(await dirSignature(entryPath))
+      const subEntries = await readdirSafe(entryPath)
+      for (const sub of subEntries) {
+        if (sub.isDirectory() || sub.isSymbolicLink()) {
+          candidates.push(join(entryPath, sub.name))
+        }
+      }
+    }
+  }
+
+  await forEachWithConcurrency(candidates, MARKER_PROBE_CONCURRENCY, async (dir) => {
+    markers.set(dir, await hasGitMarker(dir))
+  })
+  return { markers, gateDirs, gateSignatures }
+}
+
+function diffBase(prev: BaseSnapshot, next: BaseSnapshot): WorktreeBasePollEvent[] {
+  const events: WorktreeBasePollEvent[] = []
+  for (const [dir, marker] of next.markers) {
+    if (marker && prev.markers.get(dir) !== true) {
+      events.push({ type: 'create', path: join(dir, '.git') })
+    }
+  }
+  for (const dir of prev.markers.keys()) {
+    if (!next.markers.has(dir)) {
+      events.push({ type: 'delete', path: dir })
+    }
+  }
+  return events
+}
+
+export async function startBasePoller(
+  target: WorktreeBaseWatchTarget,
+  getRepos: () => ReadonlyMap<string, WorktreeBaseRepoWatchConfig>,
+  onEvents: (events: WorktreeBasePollEvent[]) => void,
+  pollIntervalMs: number,
+  visibility: WorktreePollerWindowVisibility,
+  options: WorktreeBasePollerOptions
+): Promise<WorktreeBaseSubscription> {
+  let disposed = false
+  let ticking = false
+  let tickCount = 0
+  let snapshot = await snapshotBase(target.path, getRepos())
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let parkedWhileHidden = false
+  const pendingMarkerMaxTicks = options.pendingMarkerMaxTicks ?? PENDING_MARKER_MAX_TICKS
+  // dir → first probe tick; null means backstop scans only
+  const markerProbeStartedAt = new Map<string, number | null>()
+  for (const [dir, marker] of snapshot.markers) {
+    if (!marker) {
+      markerProbeStartedAt.set(dir, 0)
+    }
+  }
+
+  const fullScan = async (): Promise<void> => {
+    options.onFullScan?.()
+    const next = await snapshotBase(target.path, getRepos())
+    await options.onSnapshotTaken?.(tickCount)
+    if (disposed) {
+      return
+    }
+    const events = diffBase(snapshot, next)
+    for (const [dir, marker] of next.markers) {
+      if (marker) {
+        markerProbeStartedAt.delete(dir)
+      } else if (!markerProbeStartedAt.has(dir)) {
+        markerProbeStartedAt.set(dir, tickCount)
+      }
+    }
+    for (const dir of markerProbeStartedAt.keys()) {
+      if (!next.markers.has(dir)) {
+        markerProbeStartedAt.delete(dir)
+      }
+    }
+    snapshot = next
+    if (events.length > 0) {
+      onEvents(events)
+    }
+  }
+
+  const checkPendingMarkers = async (): Promise<void> => {
+    const events: WorktreeBasePollEvent[] = []
+    for (const [dir, firstSeenTick] of markerProbeStartedAt) {
+      if (firstSeenTick === null) {
+        continue
+      }
+      if (tickCount - firstSeenTick > pendingMarkerMaxTicks) {
+        markerProbeStartedAt.set(dir, null)
+        continue
+      }
+      options.onPendingMarkerProbe?.(join(dir, '.git'))
+      if (await hasGitMarker(dir)) {
+        markerProbeStartedAt.delete(dir)
+        snapshot.markers.set(dir, true)
+        events.push({ type: 'create', path: join(dir, '.git') })
+      }
+    }
+    if (!disposed && events.length > 0) {
+      onEvents(events)
+    }
+  }
+
+  const poll = async (forceFullScan = false): Promise<void> => {
+    tickCount++
+    if (forceFullScan || tickCount % WORKTREE_BASE_BACKSTOP_TICKS === 0) {
+      await fullScan()
+      return
+    }
+    // Idle fast path: when the dirs whose listings define the candidate set
+    // are untouched, skip the readdir + per-candidate stat fan-out entirely.
+    const signatures = await Promise.all(snapshot.gateDirs.map(dirSignature))
+    const gateChanged =
+      signatures.length !== snapshot.gateSignatures.length ||
+      signatures.some((sig, index) => sig !== snapshot.gateSignatures[index])
+    if (gateChanged) {
+      await fullScan()
+      return
+    }
+    if (markerProbeStartedAt.size > 0) {
+      await checkPendingMarkers()
+    }
+  }
+
+  const tick = async (forceFullScan = false): Promise<void> => {
+    timer = null
+    if (disposed) {
+      return
+    }
+    if (!visibility.isWindowVisible()) {
+      parkedWhileHidden = true
+      return
+    }
+    if (ticking) {
+      return
+    }
+    ticking = true
+    // Why: measure from tick start so the cadence is start-to-start (like the old setInterval), not
+    // gap-after-completion — otherwise each visible refresh lands a full scan-duration late every tick.
+    const startedAt = Date.now()
+    try {
+      await poll(forceFullScan)
+    } catch {
+      // Transient fs error: keep the previous snapshot and retry next tick.
+    } finally {
+      ticking = false
+    }
+    if (!disposed) {
+      // Why: clamp to [0, pollIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
+      // otherwise make elapsed negative and push the next tick out by the adjustment (suppressing refreshes for
+      // minutes); the upper clamp caps the wait at one interval, the lower clamp keeps a long scan from going negative.
+      const nextDelay = Math.max(
+        0,
+        Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))
+      )
+      timer = setTimeout(() => void tick(), nextDelay)
+      timer.unref?.()
+    }
+  }
+
+  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
+    if (disposed || !parkedWhileHidden) {
+      return
+    }
+    parkedWhileHidden = false
+    // Why: the ordinary dir-signature gate can miss same-granule changes made
+    // while hidden; resume must diff a fresh full snapshot against the baseline.
+    void tick(true)
+  })
+
+  timer = setTimeout(() => void tick(), pollIntervalMs)
+  timer.unref?.()
+
+  return {
+    unsubscribe: async () => {
+      disposed = true
+      if (timer) {
+        clearTimeout(timer)
+      }
+      unsubscribeVisibility()
+    }
+  }
+}

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -1,14 +1,12 @@
-import { readdir, stat } from 'node:fs/promises'
-import type { Dirent } from 'node:fs'
-import { join } from 'node:path'
-import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
-import { forEachWithConcurrency } from '../../shared/map-with-concurrency'
 import { isMainWindowVisible, onMainWindowBecameVisible } from '../window/main-window-visibility'
 import type {
   WorktreeBaseRepoWatchConfig,
   WorktreeBaseWatchTarget
 } from './worktree-base-directory-event-filter'
+import { startBasePoller } from './worktree-base-directory-marker-poller'
 import { startGitCommonWatch } from './worktree-git-common-watch'
+
+export { WORKTREE_BASE_BACKSTOP_TICKS } from './worktree-base-directory-marker-poller'
 
 export type WorktreeBasePollEvent = { type: 'create' | 'update' | 'delete'; path: string }
 
@@ -63,6 +61,8 @@ export type WorktreeBasePollerOptions = {
   visibility?: WorktreePollerWindowVisibility
   getGitStatusRefPaths?: () => readonly string[]
   onWatchError?: (error: Error) => void
+  /** Called when the watcher child dropped an event batch (git-common narrow watch only). */
+  onOverflow?: () => void
   /** Test hook: called whenever a full snapshot scan runs (vs. a gated skip). */
   onFullScan?: () => void
   /** Test hook: called before a pending `.git` marker stat. */
@@ -82,280 +82,6 @@ export type WorktreeBasePollerOptions = {
 // calls per tick. 2s is fast enough for external `git worktree add/remove`;
 // Orca's own worktree operations notify the renderer directly.
 export const WORKTREE_BASE_POLL_INTERVAL_MS = 2_000
-
-// Why: the mtime gate is an optimization, not a correctness boundary — some
-// filesystems have coarse dir timestamps, and pending `.git` markers expire.
-// A periodic ungated scan guarantees eventual convergence.
-export const WORKTREE_BASE_BACKSTOP_TICKS = 15
-
-// Why: a `.git` completion marker lands within moments of its worktree dir
-// (git writes it before populating the checkout). Dirs that never get one are
-// not worktrees; stop re-statting them after this many ticks and let the
-// backstop scan cover the pathological case.
-const PENDING_MARKER_MAX_TICKS = 300
-
-// Why: matches the git-common poller's fan-out bound (#17828) — bounded
-// concurrency turns hundreds of serial round trips into a handful of batches
-// without dumping every candidate onto libuv's 4-thread pool at once.
-const MARKER_PROBE_CONCURRENCY = 8
-
-function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
-  return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
-}
-
-async function dirSignature(path: string): Promise<string> {
-  try {
-    return statSignature(await stat(path))
-  } catch {
-    return 'missing'
-  }
-}
-
-async function hasGitMarker(dir: string): Promise<boolean> {
-  try {
-    await stat(join(dir, '.git'))
-    return true
-  } catch {
-    return false
-  }
-}
-
-type BaseSnapshot = {
-  // worktree-candidate dir → whether its `.git` completion marker exists
-  markers: Map<string, boolean>
-  // dirs whose listing determines the candidate set: the root plus any
-  // nested repo containers. Their stat signatures gate the next full scan.
-  gateDirs: string[]
-  // index-aligned with gateDirs, each sampled *before* that dir's listing
-  gateSignatures: string[]
-}
-
-async function readdirSafe(path: string): Promise<Dirent[]> {
-  try {
-    return await readdir(path, { withFileTypes: true })
-  } catch {
-    return []
-  }
-}
-
-// Depth-1 worktree dirs (flat layout), plus depth-2 dirs under each nested
-// repo's container, mirroring what worktree-base-directory-event-filter
-// matches: `<wt>/.git` completion markers and `<wt>` deletions.
-async function snapshotBase(
-  rootPath: string,
-  repos: ReadonlyMap<string, WorktreeBaseRepoWatchConfig>
-): Promise<BaseSnapshot> {
-  const markers = new Map<string, boolean>()
-  const gateDirs = [rootPath]
-  // Why: sampling the signature before the listing makes a write that races the
-  // scan look stale next tick (one redundant rescan) instead of invisible until
-  // the backstop, which is up to 15 ticks of missed creates/deletes.
-  const gateSignatures = [await dirSignature(rootPath)]
-  const configs = [...repos.values()]
-  const includeFlat = configs.some((config) => !config.nestWorkspaces)
-  const nestedRepoNames = new Set(
-    configs
-      .filter((config) => config.nestWorkspaces)
-      .map((config) => normalizeRuntimePathForComparison(config.repoName))
-  )
-
-  // Root vanished or unreadable: readdirSafe yields [], producing the same
-  // empty markers/candidates result as the old watcher's error path.
-  const rootEntries = await readdirSafe(rootPath)
-
-  const candidates: string[] = []
-  for (const entry of rootEntries) {
-    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
-      continue
-    }
-    const entryPath = join(rootPath, entry.name)
-    if (includeFlat) {
-      candidates.push(entryPath)
-    }
-    if (nestedRepoNames.has(normalizeRuntimePathForComparison(entry.name))) {
-      gateDirs.push(entryPath)
-      gateSignatures.push(await dirSignature(entryPath))
-      const subEntries = await readdirSafe(entryPath)
-      for (const sub of subEntries) {
-        if (sub.isDirectory() || sub.isSymbolicLink()) {
-          candidates.push(join(entryPath, sub.name))
-        }
-      }
-    }
-  }
-
-  await forEachWithConcurrency(candidates, MARKER_PROBE_CONCURRENCY, async (dir) => {
-    markers.set(dir, await hasGitMarker(dir))
-  })
-  return { markers, gateDirs, gateSignatures }
-}
-
-function diffBase(prev: BaseSnapshot, next: BaseSnapshot): WorktreeBasePollEvent[] {
-  const events: WorktreeBasePollEvent[] = []
-  for (const [dir, marker] of next.markers) {
-    if (marker && prev.markers.get(dir) !== true) {
-      events.push({ type: 'create', path: join(dir, '.git') })
-    }
-  }
-  for (const dir of prev.markers.keys()) {
-    if (!next.markers.has(dir)) {
-      events.push({ type: 'delete', path: dir })
-    }
-  }
-  return events
-}
-
-async function startBasePoller(
-  target: WorktreeBaseWatchTarget,
-  getRepos: () => ReadonlyMap<string, WorktreeBaseRepoWatchConfig>,
-  onEvents: (events: WorktreeBasePollEvent[]) => void,
-  pollIntervalMs: number,
-  visibility: WorktreePollerWindowVisibility,
-  options: WorktreeBasePollerOptions
-): Promise<WorktreeBaseSubscription> {
-  let disposed = false
-  let ticking = false
-  let tickCount = 0
-  let snapshot = await snapshotBase(target.path, getRepos())
-  let timer: ReturnType<typeof setTimeout> | null = null
-  let parkedWhileHidden = false
-  const pendingMarkerMaxTicks = options.pendingMarkerMaxTicks ?? PENDING_MARKER_MAX_TICKS
-  // dir → first probe tick; null means backstop scans only
-  const markerProbeStartedAt = new Map<string, number | null>()
-  for (const [dir, marker] of snapshot.markers) {
-    if (!marker) {
-      markerProbeStartedAt.set(dir, 0)
-    }
-  }
-
-  const fullScan = async (): Promise<void> => {
-    options.onFullScan?.()
-    const next = await snapshotBase(target.path, getRepos())
-    await options.onSnapshotTaken?.(tickCount)
-    if (disposed) {
-      return
-    }
-    const events = diffBase(snapshot, next)
-    for (const [dir, marker] of next.markers) {
-      if (marker) {
-        markerProbeStartedAt.delete(dir)
-      } else if (!markerProbeStartedAt.has(dir)) {
-        markerProbeStartedAt.set(dir, tickCount)
-      }
-    }
-    for (const dir of markerProbeStartedAt.keys()) {
-      if (!next.markers.has(dir)) {
-        markerProbeStartedAt.delete(dir)
-      }
-    }
-    snapshot = next
-    if (events.length > 0) {
-      onEvents(events)
-    }
-  }
-
-  const checkPendingMarkers = async (): Promise<void> => {
-    const events: WorktreeBasePollEvent[] = []
-    for (const [dir, firstSeenTick] of markerProbeStartedAt) {
-      if (firstSeenTick === null) {
-        continue
-      }
-      if (tickCount - firstSeenTick > pendingMarkerMaxTicks) {
-        markerProbeStartedAt.set(dir, null)
-        continue
-      }
-      options.onPendingMarkerProbe?.(join(dir, '.git'))
-      if (await hasGitMarker(dir)) {
-        markerProbeStartedAt.delete(dir)
-        snapshot.markers.set(dir, true)
-        events.push({ type: 'create', path: join(dir, '.git') })
-      }
-    }
-    if (!disposed && events.length > 0) {
-      onEvents(events)
-    }
-  }
-
-  const poll = async (forceFullScan = false): Promise<void> => {
-    tickCount++
-    if (forceFullScan || tickCount % WORKTREE_BASE_BACKSTOP_TICKS === 0) {
-      await fullScan()
-      return
-    }
-    // Idle fast path: when the dirs whose listings define the candidate set
-    // are untouched, skip the readdir + per-candidate stat fan-out entirely.
-    const signatures = await Promise.all(snapshot.gateDirs.map(dirSignature))
-    const gateChanged =
-      signatures.length !== snapshot.gateSignatures.length ||
-      signatures.some((sig, index) => sig !== snapshot.gateSignatures[index])
-    if (gateChanged) {
-      await fullScan()
-      return
-    }
-    if (markerProbeStartedAt.size > 0) {
-      await checkPendingMarkers()
-    }
-  }
-
-  const tick = async (forceFullScan = false): Promise<void> => {
-    timer = null
-    if (disposed) {
-      return
-    }
-    if (!visibility.isWindowVisible()) {
-      parkedWhileHidden = true
-      return
-    }
-    if (ticking) {
-      return
-    }
-    ticking = true
-    // Why: measure from tick start so the cadence is start-to-start (like the old setInterval), not
-    // gap-after-completion — otherwise each visible refresh lands a full scan-duration late every tick.
-    const startedAt = Date.now()
-    try {
-      await poll(forceFullScan)
-    } catch {
-      // Transient fs error: keep the previous snapshot and retry next tick.
-    } finally {
-      ticking = false
-    }
-    if (!disposed) {
-      // Why: clamp to [0, pollIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
-      // otherwise make elapsed negative and push the next tick out by the adjustment (suppressing refreshes for
-      // minutes); the upper clamp caps the wait at one interval, the lower clamp keeps a long scan from going negative.
-      const nextDelay = Math.max(
-        0,
-        Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))
-      )
-      timer = setTimeout(() => void tick(), nextDelay)
-      timer.unref?.()
-    }
-  }
-
-  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
-    if (disposed || !parkedWhileHidden) {
-      return
-    }
-    parkedWhileHidden = false
-    // Why: the ordinary dir-signature gate can miss same-granule changes made
-    // while hidden; resume must diff a fresh full snapshot against the baseline.
-    void tick(true)
-  })
-
-  timer = setTimeout(() => void tick(), pollIntervalMs)
-  timer.unref?.()
-
-  return {
-    unsubscribe: async () => {
-      disposed = true
-      if (timer) {
-        clearTimeout(timer)
-      }
-      unsubscribeVisibility()
-    }
-  }
-}
 
 /** Watches the shallow paths a worktree base target cares about and emits
  *  watcher-shaped events. Resolves once the baseline (snapshot or narrow
@@ -378,7 +104,8 @@ export async function startWorktreeBaseDirectoryPoller(
       visibility,
       options.onFullScan,
       options.getGitStatusRefPaths,
-      options.onWatchError
+      options.onWatchError,
+      options.onOverflow
     )
   }
   return startBasePoller(target, getRepos, onEvents, pollIntervalMs, visibility, options)

--- a/src/main/ipc/worktree-base-directory-watch-events.ts
+++ b/src/main/ipc/worktree-base-directory-watch-events.ts
@@ -1,0 +1,90 @@
+import {
+  collectLocalWorktreeBaseChanges,
+  collectRemoteWorktreeBaseChanges,
+  hasCollectedWorktreeBaseChanges
+} from './worktree-base-directory-change-collector'
+import {
+  scheduleWorktreeBaseNotification,
+  type WorktreeBaseNotificationWatch
+} from './worktree-base-directory-notifications'
+import {
+  invalidateActiveGitStatusRefResolution,
+  invalidateGitStatusRefResolutionForPaths
+} from './worktree-git-status-ref-watch'
+import type { WorktreeWatcherFailureRefreshCooldown } from './worktree-watcher-failure-refresh-cooldown'
+
+export type ActiveWatch = WorktreeBaseNotificationWatch & {
+  subscription: { unsubscribe: () => Promise<void> }
+  gitStatusRefPaths: Set<string>
+  watcherFailureRefresh: WorktreeWatcherFailureRefreshCooldown
+}
+
+export function handleLocalWatchEvents(
+  watch: ActiveWatch,
+  error: Error | null,
+  events: { type: 'create' | 'update' | 'delete'; path: string }[],
+  getActiveWatches: () => Iterable<ActiveWatch>
+): void {
+  if (watch.disposed || watch.mainWindow.isDestroyed()) {
+    return
+  }
+  if (error) {
+    console.warn(`[worktree-base-watcher] watcher failed for ${watch.path}:`, error)
+    invalidateActiveGitStatusRefResolution(watch, getActiveWatches)
+    if (watch.watcherFailureRefresh.consume()) {
+      scheduleWorktreeBaseNotification(watch, { structureRepoIds: [...watch.repos.keys()] })
+    }
+    return
+  }
+  watch.watcherFailureRefresh.reset()
+  invalidateGitStatusRefResolutionForPaths(
+    watch,
+    events.map((event) => event.path),
+    getActiveWatches
+  )
+  const changes = collectLocalWorktreeBaseChanges(watch, events)
+  if (hasCollectedWorktreeBaseChanges(changes)) {
+    scheduleWorktreeBaseNotification(watch, changes)
+  }
+}
+
+// Why: after a dropped event batch nothing about the prior state can be
+// trusted — widen unconditionally (structural + status + head-identity),
+// same shape as the remote overflow branch below, bypassing the watcher-error
+// cooldown so a burst of overflows during one bulk op cannot suppress the
+// refresh the fleet actually needs.
+export function handleWatchOverflow(
+  watch: ActiveWatch,
+  getActiveWatches: () => Iterable<ActiveWatch>
+): void {
+  if (watch.disposed || watch.mainWindow.isDestroyed()) {
+    return
+  }
+  invalidateActiveGitStatusRefResolution(watch, getActiveWatches)
+  scheduleWorktreeBaseNotification(watch, { structureRepoIds: [...watch.repos.keys()] })
+}
+
+export function handleRemoteWatchEvents(
+  watch: ActiveWatch,
+  events: Parameters<typeof collectRemoteWorktreeBaseChanges>[1],
+  getActiveWatches: () => Iterable<ActiveWatch>
+): void {
+  if (watch.disposed || watch.mainWindow.isDestroyed()) {
+    return
+  }
+  invalidateGitStatusRefResolutionForPaths(
+    watch,
+    events.flatMap((event) =>
+      event.kind === 'overflow' ? [] : [event.absolutePath, event.oldAbsolutePath]
+    ),
+    getActiveWatches
+  )
+  const changes = collectRemoteWorktreeBaseChanges(watch, events)
+  if (changes.overflow) {
+    handleWatchOverflow(watch, getActiveWatches)
+    return
+  }
+  if (hasCollectedWorktreeBaseChanges(changes)) {
+    scheduleWorktreeBaseNotification(watch, changes)
+  }
+}

--- a/src/main/ipc/worktree-base-directory-watcher.test.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.test.ts
@@ -404,6 +404,46 @@ describe('worktree base directory watcher', () => {
     expect(notifyWorktreesChanged).toHaveBeenCalledOnce()
   })
 
+  it('widens an overflowed local git-common watch to a structural refresh', async () => {
+    await syncWorktreeBaseDirectoryWatchers(makeStore([makeRepo()]) as never, makeWindow() as never)
+    const onOverflow = pollerOptions.get(PROJECT_GIT_COMMON_DIR)?.onOverflow
+
+    const request = {
+      worktreeId: `repo-1::${PROJECT_ROOT}`,
+      worktreePath: PROJECT_ROOT,
+      executionHostId: 'local',
+      branch: 'refs/heads/feature',
+      upstreamName: 'origin/feature'
+    }
+    const resolve = vi.fn(async () => 'refs/remotes/origin/feature')
+    await setWorktreeGitStatusRefWatch(request, resolve)
+
+    onOverflow?.()
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(notifyWorktreesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1')
+    // Overflow is definite proof of loss, not a possibly-transient error — it
+    // invalidates the cached ref resolution unconditionally.
+    await setWorktreeGitStatusRefWatch(request, resolve)
+    expect(resolve).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not throttle repeated overflow refreshes the way watcher-error refreshes are throttled', async () => {
+    await syncWorktreeBaseDirectoryWatchers(makeStore([makeRepo()]) as never, makeWindow() as never)
+    const onOverflow = pollerOptions.get(PROJECT_GIT_COMMON_DIR)?.onOverflow
+
+    onOverflow?.()
+    await vi.advanceTimersByTimeAsync(300)
+    onOverflow?.()
+    await vi.advanceTimersByTimeAsync(300)
+
+    // A watcher-error burst within the 60s cooldown window collapses to one
+    // refresh (see "throttles repeated structural refreshes from watcher
+    // failures" above); overflow must not inherit that gate, since a bulk op
+    // can legitimately overflow more than once before it settles.
+    expect(notifyWorktreesChanged).toHaveBeenCalledTimes(2)
+  })
+
   it('keeps linked HEAD and lock metadata structural', async () => {
     await syncWorktreeBaseDirectoryWatchers(makeStore([makeRepo()]) as never, makeWindow() as never)
 

--- a/src/main/ipc/worktree-base-directory-watcher.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.ts
@@ -7,15 +7,8 @@ import {
   refreshWorktreeHeadIdentities
 } from './worktree-head-identity-refresh'
 import {
-  collectLocalWorktreeBaseChanges,
-  collectRemoteWorktreeBaseChanges,
-  hasCollectedWorktreeBaseChanges
-} from './worktree-base-directory-change-collector'
-import {
   clearPendingWorktreeBaseNotifications,
-  scheduleWorktreeBaseNotification,
-  supportsWorktreeHeadIdentityRefresh,
-  type WorktreeBaseNotificationWatch
+  supportsWorktreeHeadIdentityRefresh
 } from './worktree-base-directory-notifications'
 import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
 import { EMPTY_HEAD_IDENTITY_SCOPE } from './worktree-head-identity-scope'
@@ -30,18 +23,16 @@ import {
 import {
   applyActiveGitStatusRefBinding,
   clearActiveGitStatusRefBinding,
-  invalidateActiveGitStatusRefResolution,
-  invalidateGitStatusRefResolutionForPaths,
   updateActiveGitStatusRefBinding,
   type GitStatusRefBindingRequest
 } from './worktree-git-status-ref-watch'
 import { WorktreeWatcherFailureRefreshCooldown } from './worktree-watcher-failure-refresh-cooldown'
-
-type ActiveWatch = WorktreeBaseNotificationWatch & {
-  subscription: { unsubscribe: () => Promise<void> }
-  gitStatusRefPaths: Set<string>
-  watcherFailureRefresh: WorktreeWatcherFailureRefreshCooldown
-}
+import {
+  handleLocalWatchEvents,
+  handleRemoteWatchEvents,
+  handleWatchOverflow,
+  type ActiveWatch
+} from './worktree-base-directory-watch-events'
 
 const activeWatches = new Map<string, ActiveWatch>()
 let syncGeneration = 0
@@ -52,59 +43,6 @@ export function setWorktreeGitStatusRefWatch(
   resolveUpstreamRef: (signal: AbortSignal) => Promise<string | undefined>
 ): Promise<void> {
   return updateActiveGitStatusRefBinding(args, () => activeWatches.values(), resolveUpstreamRef)
-}
-
-function handleLocalWatchEvents(
-  watch: ActiveWatch,
-  error: Error | null,
-  events: { type: 'create' | 'update' | 'delete'; path: string }[]
-): void {
-  if (watch.disposed || watch.mainWindow.isDestroyed()) {
-    return
-  }
-  if (error) {
-    console.warn(`[worktree-base-watcher] watcher failed for ${watch.path}:`, error)
-    invalidateActiveGitStatusRefResolution(watch, () => activeWatches.values())
-    if (watch.watcherFailureRefresh.consume()) {
-      scheduleWorktreeBaseNotification(watch, { structureRepoIds: [...watch.repos.keys()] })
-    }
-    return
-  }
-  watch.watcherFailureRefresh.reset()
-  invalidateGitStatusRefResolutionForPaths(
-    watch,
-    events.map((event) => event.path),
-    () => activeWatches.values()
-  )
-  const changes = collectLocalWorktreeBaseChanges(watch, events)
-  if (hasCollectedWorktreeBaseChanges(changes)) {
-    scheduleWorktreeBaseNotification(watch, changes)
-  }
-}
-
-function handleRemoteWatchEvents(
-  watch: ActiveWatch,
-  events: Parameters<typeof collectRemoteWorktreeBaseChanges>[1]
-): void {
-  if (watch.disposed || watch.mainWindow.isDestroyed()) {
-    return
-  }
-  invalidateGitStatusRefResolutionForPaths(
-    watch,
-    events.flatMap((event) =>
-      event.kind === 'overflow' ? [] : [event.absolutePath, event.oldAbsolutePath]
-    ),
-    () => activeWatches.values()
-  )
-  const changes = collectRemoteWorktreeBaseChanges(watch, events)
-  if (changes.overflow) {
-    invalidateActiveGitStatusRefResolution(watch, () => activeWatches.values())
-    scheduleWorktreeBaseNotification(watch, { structureRepoIds: [...watch.repos.keys()] })
-    return
-  }
-  if (hasCollectedWorktreeBaseChanges(changes)) {
-    scheduleWorktreeBaseNotification(watch, changes)
-  }
 }
 
 function createActiveWatch(
@@ -146,7 +84,7 @@ async function subscribeTarget(
       if (!currentWatch || currentWatch.disposed) {
         return
       }
-      handleRemoteWatchEvents(currentWatch, events)
+      handleRemoteWatchEvents(currentWatch, events, () => activeWatches.values())
     })
     activeWatch = createActiveWatch(
       target,
@@ -167,7 +105,7 @@ async function subscribeTarget(
     (events) => {
       const currentWatch = activeWatches.get(target.key) ?? activeWatch
       if (currentWatch && !currentWatch.disposed) {
-        handleLocalWatchEvents(currentWatch, null, events)
+        handleLocalWatchEvents(currentWatch, null, events, () => activeWatches.values())
       }
     },
     {
@@ -178,7 +116,13 @@ async function subscribeTarget(
       onWatchError: (error) => {
         const currentWatch = activeWatches.get(target.key) ?? activeWatch
         if (currentWatch && !currentWatch.disposed) {
-          handleLocalWatchEvents(currentWatch, error, [])
+          handleLocalWatchEvents(currentWatch, error, [], () => activeWatches.values())
+        }
+      },
+      onOverflow: () => {
+        const currentWatch = activeWatches.get(target.key) ?? activeWatch
+        if (currentWatch) {
+          handleWatchOverflow(currentWatch, () => activeWatches.values())
         }
       }
     }

--- a/src/main/ipc/worktree-git-common-narrow-watch.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch.ts
@@ -24,7 +24,12 @@ export async function startGitCommonNarrowWatch(
   platform: NodeJS.Platform,
   visibility: WorktreePollerWindowVisibility,
   onFullScan?: () => void,
-  onWatchError?: (error: Error) => void
+  onWatchError?: (error: Error) => void,
+  // Why: a dropped event batch (>5,000 events, e.g. a fleet-wide bulk op) is a
+  // harder loss signal than a transient error — nothing about the prior state
+  // can be trusted, so this bypasses onWatchError's failure cooldown instead
+  // of reusing it.
+  onOverflow?: () => void
 ): Promise<WorktreeBaseSubscription> {
   const worktreesDir = join(target.path, 'worktrees')
   const watcherOptions = platform === 'win32' ? { backend: 'windows' as const } : {}
@@ -226,6 +231,23 @@ export async function startGitCommonNarrowWatch(
               } else {
                 onEvents([{ type: 'update', path: worktreesDir }])
               }
+            }
+          },
+          // Why: the watcher child drops the whole batch past 5,000 events
+          // (native FSEvents overflow maps to the same op) instead of reporting
+          // which paths changed. Unlike a transient error, this is definite
+          // proof of loss, so it always widens rather than falling back to the
+          // failure-cooldown-gated onWatchError path.
+          onOverflow: () => {
+            if (disposed || !active || generation !== nativeSubscriptionGeneration) {
+              return
+            }
+            if (onOverflow) {
+              onOverflow()
+            } else if (onWatchError) {
+              onWatchError(new Error('Git common watcher overflowed'))
+            } else {
+              onEvents([{ type: 'update', path: worktreesDir }])
             }
           }
         }

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -526,6 +526,45 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     expect(narrowSubscription().unsubscribe).not.toHaveBeenCalled()
   })
 
+  it('routes a dropped event batch through the dedicated overflow callback', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const received: WorktreeBasePollEvent[][] = []
+    const onOverflow = vi.fn()
+    const watch = await startGitCommonWatch(
+      makeTarget(commonDir),
+      (events) => received.push(events),
+      POLL_MS,
+      'darwin',
+      alwaysVisible,
+      undefined,
+      () => [],
+      undefined,
+      onOverflow
+    )
+    cleanups.push(() => watch.unsubscribe())
+
+    narrowSubscription().hooks.onOverflow?.()
+
+    expect(onOverflow).toHaveBeenCalledOnce()
+    // The dedicated callback owns the refresh; the generic event/error paths
+    // must not also fire so the caller cannot double-count the same loss.
+    expect(received).toEqual([])
+    expect(narrowSubscription().unsubscribe).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a structural change when no overflow callback is wired', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const worktreesDir = join(commonDir, 'worktrees')
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received)
+
+    narrowSubscription().hooks.onOverflow?.()
+
+    expect(received.flat()).toContainEqual({ type: 'update', path: worktreesDir })
+  })
+
   it('arms via existence polling when the worktrees dir appears later', async () => {
     installSubscribeMock()
     const commonDir = await makeCommonDir(false)

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -31,7 +31,8 @@ export async function startGitCommonWatch(
   visibility: WorktreePollerWindowVisibility,
   onFullScan?: () => void,
   getStatusRefPaths: () => readonly string[] = () => [],
-  onWatchError?: (error: Error) => void
+  onWatchError?: (error: Error) => void,
+  onOverflow?: () => void
 ): Promise<WorktreeBaseSubscription> {
   if (supportsNarrowWatch(platform)) {
     const [narrowWatch, primaryWatch] = await Promise.all([
@@ -42,7 +43,8 @@ export async function startGitCommonWatch(
         platform,
         visibility,
         onFullScan,
-        onWatchError
+        onWatchError,
+        onOverflow
       ),
       startGitCommonPrimaryWatch(
         target.path,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​429 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​355 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 |

<!-- /orca-pr-loc -->

## ELI5

Orca watches each repo's `worktrees/` folder for changes (new/removed worktrees) using a native file-watcher. That watcher has a safety limit: if more than 5,000 filesystem events happen in one burst (e.g. a fleet-wide bulk operation touching hundreds of worktrees at once), it gives up on reporting exactly what changed and instead says "I dropped everything, I don't know what happened" (an "overflow"). Orca's code for handling this watcher was listening for every other kind of failure (crashes, interruptions, the folder itself getting deleted) but had never been told to listen for this specific "I gave up" signal. So when an overflow happened, Orca just... didn't notice, and the worktree list could silently go stale until the next unrelated refresh. This PR wires up that missing signal so an overflow now always triggers a fresh, full re-check.

## What Changed

- `startGitCommonNarrowWatch` now consumes the watcher child's existing (but previously unused) `onOverflow` hook instead of silently ignoring it.
- Threaded a new optional `onOverflow` callback end-to-end: `startGitCommonNarrowWatch` → `startGitCommonWatch` → `startWorktreeBaseDirectoryPoller`'s options → `worktree-base-directory-watcher.ts`.
- Added a dedicated `handleWatchOverflow` path (shared with the existing remote/SSH overflow branch) that widens unconditionally — structural, git-status-ref, and head-identity — and deliberately bypasses the existing 60s watcher-error refresh cooldown, since overflow is definite proof of loss (not a possibly-transient error), and a single bulk operation can legitimately overflow more than once before settling.
- Split two files that crossed the repo's 300-line gate as a result of this change into more specifically-named modules (pure extraction, no behavior change):
  - `worktree-base-directory-poller.ts` → the `.git`-marker-based fallback poller moved to `worktree-base-directory-marker-poller.ts`.
  - `worktree-base-directory-watcher.ts` → the three watch-event handler functions moved to `worktree-base-directory-watch-events.ts`.
- Deliberately did **not** wire `onOverflow` into `startGitCommonPrimaryWatch` (the shallow watch over a handful of fixed metadata files) — that watcher observes too few paths to realistically hit the 5,000-event threshold, so scope stayed on the narrow watch per the reported root cause.

## Why

Issue #17828 is about worktree operations degrading at scale. Investigating the root cause turned up that the git-common watcher stack already signals nearly every loss mode — watcher-child crash/interruption, resubscribe, root-directory deletion — through either `onWatchError` or dedicated handling, **except** event-batch overflow. `@parcel/watcher`'s host caps a single delivered batch at 5,000 events (`MAX_BATCHED_WATCHER_EVENTS`); past that it drops the whole batch and reports `{op: 'overflow'}` instead. `WatcherProcessHooks` already defined `onOverflow` and it was already plumbed all the way through the host/child/in-process-fallback stack (see `parcel-watcher-process-subscription.ts`, `parcel-watcher-event-delivery.ts`) — `startGitCommonNarrowWatch` simply never consumed it. That's the actual gap, and it's most likely to bite exactly during the fleet-wide bulk operations this issue is about, since those are what generate event bursts large enough to overflow.

This is intentionally the first of a small stack of changes for #17828. A second PR will demote the git-common reconciliation backstop's unconditional 30s full sweep (`worktree-git-common-watch-reconciliation.ts`, `forceFullScanEveryTick: true`) to a cheap O(1) tripwire that only triggers an expensive full sweep on a loss signal — this overflow signal being one of the inputs it needs. That PR depends on this one landing first, so it's kept separate.

## Loss modes and coverage

| Loss mode | Signal | Handling |
|---|---|---|
| Watcher-child error | `error` callback arg | `onWatchError` → cooldown-gated structural refresh |
| Watcher-child crash/interruption | `onInterruption` hook | `onWatchError` (same path as above) |
| Root (`worktrees/`) deleted | `delete` event for the root path | Immediate teardown + re-arm existence poll |
| Watcher-process crash-fuse tripped | thrown error classified by `isWatcherProcessFailure` | Falls back to polling (`ensurePollingFallback`) |
| **Event-batch overflow (>5,000 events)** | **`onOverflow` hook** | **This PR: unconditional structural + status-ref + head-identity widen, bypassing the failure cooldown** |

### Loop safety: why widening on overflow can't feed back into another overflow

An overflow-triggered refresh cannot cause a second overflow, by construction:

- `handleWatchOverflow` (`src/main/ipc/worktree-base-directory-watch-events.ts:63-72`) does zero filesystem writes — it only invalidates a cached resolution (`invalidateActiveGitStatusRefResolution`) and calls `scheduleWorktreeBaseNotification`. Nothing in that call chain touches disk, so it cannot itself generate the burst of fs events (>5,000 in one batch) that overflow requires.
- `scheduleWorktreeBaseNotification` (`src/main/ipc/worktree-base-directory-notifications.ts:33-79`) is a 250ms trailing debounce (`WATCH_DEBOUNCE_MS`, line 21): every call clears and reschedules a single timer (line 50), so a storm of overflow calls — e.g. the "more than once before settling" case this PR explicitly handles — collapses to one flush 250ms after the last one, not one per call.
- The one async refresh in that flush, `refreshWorktreeHeadIdentities` (`src/main/ipc/worktree-head-identity-refresh.ts:32-77`), is single-flighted: an `inFlight` guard (checked at lines 41-45) makes a call that arrives mid-refresh set `queued`/`queuedEmit` and return immediately instead of starting a second concurrent read; at most one queued follow-up runs after the current one finishes (lines 71-76). Re-entrancy — a refresh synchronously triggering another refresh — is structurally impossible here: it's gated by that boolean flag, not by recursion depth, so there is no path to unbounded nesting.
- The refresh itself, `readGitCommonHeadIdentities` (`src/main/ipc/worktree-head-identity-reader.ts`), only calls `readdir`/`readFile` — the file is explicitly documented as "spawn-free" (lines 7-8) — and never writes, so it can't perturb the very directory the watcher is observing.

This scoping matters for the next PR in this stack (#17933) too: `notifyLossSignal()` (wired from this same `onOverflow` hook there) is idempotent by the same reasoning — calling it any number of times in a burst has the same effect as calling it once, since it only ever requests a sweep sooner, coalesced to a single pending request, never guarantees one runs per call.

## Linked Issue

Refs #17828 (root-cause fix 1 of a small stack; see #17839 and #17878 below)

## Visual Proof

N/A — this is an internal file-watcher correctness fix with no UI surface. There is no user-visible before/after state to screenshot; the effect (a worktree list staying in sync after a filesystem event burst) is not something a screenshot can meaningfully show.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally (see platform note below)

Automated:
- Added tests proving overflow routes through the dedicated callback and that events/errors are not double-reported (`worktree-git-common-watch.test.ts`).
- Added a fallback test showing overflow still widens (via a synthetic structural event) when no dedicated `onOverflow` callback is wired.
- Added tests proving overflow widens a local git-common watch to a full structural refresh, invalidates the cached git-status-ref resolution, and is **not** throttled by the existing 60s watcher-error cooldown even across repeated overflows (`worktree-base-directory-watcher.test.ts`).
- Verified all four new tests fail without the fix (temporarily stashed the non-test changes and re-ran) before confirming they pass with it.
- Full suite: `pnpm tc` clean, `pnpm test src/main/ipc` — 3505 passed / 11 skipped, 0 failed, `pnpm run check:code-quality:changed` — 0 new findings.

Platforms actually tested: automated tests only, run on macOS (Apple Silicon) in this sandbox. I did not manually exercise this on a real Linux/Windows/WSL host or over SSH — the change is platform-agnostic Node/TypeScript logic (no OS-specific branching), and the narrow watch is already exercised on darwin/linux/win32 via the existing shared test suite with mocked `subscribeViaWatcherProcess`, but I have not personally validated on non-macOS hardware.

## User-Facing Regressions

None expected. This only adds a previously-missing refresh trigger; it does not remove, delay, or gate any existing refresh path. The one behavior change users could notice: a repo that experiences a very large burst of filesystem churn (thousands of events in one narrow-watch batch) will now trigger an extra full worktree-list refresh where before it silently missed doing so — this is strictly more correct, not a regression, though on extremely large checkouts, a repeated overflow burst could now trigger back-to-back full refreshes without the usual 60s cooldown (by design — see "Why" above). No new latency, memory, or platform-specific behavior is introduced for the common (non-overflowing) case.

## AI Disclosure

Claude Sonnet 5 (Claude Code) was used to investigate the root cause, implement this change, write the added tests, and draft this PR description.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- Cross-platform: no OS-specific code added; `onOverflow` is wired the same way on darwin/linux/win32 (the platforms `supportsNarrowWatch` covers).
- Remote/SSH: out of scope — the SSH filesystem provider's overflow path (`worktree-base-directory-watcher.ts`'s `handleRemoteWatchEvents`) already had this exact handling; this PR only closes the equivalent gap on the local git-common watch, and both now share the same `handleWatchOverflow` helper.
- Folder workspaces: unaffected — `startGitCommonNarrowWatch` only runs for `git-common` targets, not the generic marker-based poller used for non-git-common/folder-workspace targets.
- Backwards/wire compatibility: no IPC/RPC surface or wire format touched; this is purely internal main-process watcher plumbing.
- Performance: negligible — one additional callback wired per subscription; the actual work done on overflow is a widen equivalent to what already happens on a watcher error.
- Related: #17839 (bounded-concurrency fan-out for full sweeps — unaffected by this PR, no shared files with conflicting changes) and #17878 (tracks making the crash-fuse polling fallback transient — separate follow-up).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

