### PR TITLE
fix(linux): stop offering updates a distro-managed install cannot apply

### DIFF
--- a/src/main/linux-package-downloaded-status.ts
+++ b/src/main/linux-package-downloaded-status.ts
@@ -9,6 +9,8 @@ import type { LinuxPackageArtifact } from './linux-package-update-recovery'
 
 export const LINUX_PACKAGE_MARKER_UNUSABLE_MESSAGE =
   'Orca could not verify the installed Linux package format, so it will not install this update automatically. Download the update from the official release page and install it manually.'
+export const LINUX_PACKAGE_EXTERNALLY_MANAGED_MESSAGE =
+  'This copy of Orca is managed by your system package manager, so Orca cannot install updates itself. Update Orca through your distribution instead.'
 export const LINUX_PACKAGE_MANUAL_INSTALL_MESSAGE =
   'Quit Orca before running the system package install command.'
 const PACKAGE_METADATA_UNUSABLE_MESSAGE =

--- a/src/main/linux-package-install-command.test.ts
+++ b/src/main/linux-package-install-command.test.ts
@@ -252,3 +252,54 @@ describe('buildLinuxPackageInstallCommand', () => {
     })
   })
 })
+
+describe('hasTrustedPackageManagerFor', () => {
+  it('accepts a deb host that has dpkg', async () => {
+    install('/usr/bin/dpkg')
+    const { hasTrustedPackageManagerFor } = await loadCommandModule()
+    expect(hasTrustedPackageManagerFor('deb')).toBe(true)
+  })
+
+  it('accepts a deb host that has only apt', async () => {
+    install('/usr/bin/apt')
+    const { hasTrustedPackageManagerFor } = await loadCommandModule()
+    expect(hasTrustedPackageManagerFor('deb')).toBe(true)
+  })
+
+  // The #17702 case: an Arch rebuild of the .deb inherits the marker but has no deb tooling.
+  it('rejects a deb marker on a host with only pacman', async () => {
+    install('/usr/bin/pacman')
+    install('/usr/bin/sudo')
+    const { hasTrustedPackageManagerFor } = await loadCommandModule()
+    expect(hasTrustedPackageManagerFor('deb')).toBe(false)
+  })
+
+  it('rejects an rpm marker on a host with only deb tooling', async () => {
+    install('/usr/bin/dpkg')
+    install('/usr/bin/apt')
+    const { hasTrustedPackageManagerFor } = await loadCommandModule()
+    expect(hasTrustedPackageManagerFor('rpm')).toBe(false)
+  })
+
+  it('accepts each rpm-family manager on its own', async () => {
+    for (const name of ['zypper', 'dnf', 'yum', 'rpm']) {
+      vi.resetModules()
+      executables = new Map()
+      install(`/usr/bin/${name}`)
+      const { hasTrustedPackageManagerFor } = await loadCommandModule()
+      expect(hasTrustedPackageManagerFor('rpm')).toBe(true)
+    }
+  })
+
+  it('ignores a package manager outside the trusted directories', async () => {
+    install('/home/user/.local/bin/dpkg')
+    const { hasTrustedPackageManagerFor } = await loadCommandModule()
+    expect(hasTrustedPackageManagerFor('deb')).toBe(false)
+  })
+
+  it('ignores a non-executable file at a trusted path', async () => {
+    install('/usr/bin/dpkg', { mode: 0o644 })
+    const { hasTrustedPackageManagerFor } = await loadCommandModule()
+    expect(hasTrustedPackageManagerFor('deb')).toBe(false)
+  })
+})

--- a/src/main/linux-package-install-command.ts
+++ b/src/main/linux-package-install-command.ts
@@ -53,6 +53,16 @@ export function resolveTrustedExecutable(name: string): string | null {
 }
 
 /**
+ * Whether this host has any package manager able to install the marker's format. A repackaged
+ * install (AUR, Nix, a container rebuild) inherits the `package-type` marker from the .deb/.rpm it
+ * was built from, so the marker alone never proves the host can act on it.
+ */
+export function hasTrustedPackageManagerFor(packageType: LinuxRootPackageType): boolean {
+  const candidates = packageType === 'deb' ? DEB_PACKAGE_MANAGERS : RPM_PACKAGE_MANAGERS
+  return candidates.some((candidate) => resolveTrustedExecutable(candidate.name) !== null)
+}
+
+/**
  * Builds the interactive command the user pastes into their own terminal. Every token except the
  * package path is a fixed literal, and the path is POSIX-single-quoted — Orca never runs this.
  */

--- a/src/main/linux-update-package-type.test.ts
+++ b/src/main/linux-update-package-type.test.ts
@@ -4,9 +4,15 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { LinuxPackageType, LinuxRootPackageType } from './linux-update-package-type'
 
-const { appMock } = vi.hoisted(() => ({ appMock: { isPackaged: true } }))
+const { appMock, hasTrustedPackageManagerForMock } = vi.hoisted(() => ({
+  appMock: { isPackaged: true },
+  hasTrustedPackageManagerForMock: vi.fn(() => true)
+}))
 
 vi.mock('electron', () => ({ app: appMock }))
+vi.mock('./linux-package-install-command', () => ({
+  hasTrustedPackageManagerFor: hasTrustedPackageManagerForMock
+}))
 
 const originalPlatform = process.platform
 const originalResourcesPath = process.resourcesPath as string | undefined
@@ -19,6 +25,7 @@ let resourcesDir: string
 type PackageTypeModule = {
   getLinuxPackageType: () => LinuxPackageType
   getLinuxRootPackageType: () => LinuxRootPackageType | null
+  isExternallyManagedLinuxInstall: () => boolean
   isLegacyAppImageRuntimeIdentity: (identity: {
     appImagePath: unknown
     appDirPath: unknown
@@ -49,6 +56,7 @@ async function loadPackageType(): Promise<PackageTypeModule> {
 
 beforeEach(async () => {
   vi.resetModules()
+  hasTrustedPackageManagerForMock.mockReset().mockReturnValue(true)
   vi.spyOn(console, 'warn').mockImplementation(() => {})
   appMock.isPackaged = true
   delete process.env.APPIMAGE
@@ -303,5 +311,56 @@ describe('getLinuxRootPackageType', () => {
     const module = await loadPackageType()
     module.getLinuxPackageType()
     expect(warn).not.toHaveBeenCalled()
+  })
+})
+
+describe('isExternallyManagedLinuxInstall', () => {
+  // The #17702 case: an AUR/Nix/container rebuild of the .deb inherits `package-type` verbatim.
+  it('reports a deb marker with no deb package manager as externally managed', async () => {
+    hasTrustedPackageManagerForMock.mockReturnValue(false)
+    await writeMarker('deb')
+    const module = await loadPackageType()
+    expect(module.isExternallyManagedLinuxInstall()).toBe(true)
+    expect(hasTrustedPackageManagerForMock).toHaveBeenCalledWith('deb')
+  })
+
+  it('reports an rpm marker with no rpm package manager as externally managed', async () => {
+    hasTrustedPackageManagerForMock.mockReturnValue(false)
+    await writeMarker('rpm')
+    const module = await loadPackageType()
+    expect(module.isExternallyManagedLinuxInstall()).toBe(true)
+    expect(hasTrustedPackageManagerForMock).toHaveBeenCalledWith('rpm')
+  })
+
+  it('leaves a real deb host self-updatable', async () => {
+    await writeMarker('deb')
+    const module = await loadPackageType()
+    expect(module.isExternallyManagedLinuxInstall()).toBe(false)
+  })
+
+  it('never probes the host for an AppImage install', async () => {
+    hasTrustedPackageManagerForMock.mockReturnValue(false)
+    await writeMarker('AppImage')
+    const module = await loadPackageType()
+    expect(module.isExternallyManagedLinuxInstall()).toBe(false)
+    expect(hasTrustedPackageManagerForMock).not.toHaveBeenCalled()
+  })
+
+  it('never probes the host for an unusable marker', async () => {
+    hasTrustedPackageManagerForMock.mockReturnValue(false)
+    await writeMarker('snap')
+    const module = await loadPackageType()
+    expect(module.isExternallyManagedLinuxInstall()).toBe(false)
+    expect(hasTrustedPackageManagerForMock).not.toHaveBeenCalled()
+  })
+
+  it('probes the host at most once per process', async () => {
+    hasTrustedPackageManagerForMock.mockReturnValue(false)
+    await writeMarker('deb')
+    const module = await loadPackageType()
+    module.isExternallyManagedLinuxInstall()
+    module.isExternallyManagedLinuxInstall()
+    module.isExternallyManagedLinuxInstall()
+    expect(hasTrustedPackageManagerForMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/linux-update-package-type.ts
+++ b/src/main/linux-update-package-type.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { app } from 'electron'
+import { hasTrustedPackageManagerFor } from './linux-package-install-command'
 import type { LinuxRootPackageType } from '../shared/update-status-types'
 
 export type { LinuxRootPackageType }
@@ -10,6 +11,7 @@ export type LinuxPackageType = LinuxRootPackageType | 'non-root' | 'unusable'
 
 // Why: `undefined` means "not resolved yet"; every other value is stable for this process.
 let cachedPackageType: LinuxPackageType | undefined
+let cachedExternallyManaged: boolean | undefined
 
 // Bounded by construction: the marker is read at most once per process.
 function warnMarkerUnusable(detail: string): void {
@@ -112,4 +114,23 @@ export function getLinuxPackageType(): LinuxPackageType {
 export function getLinuxRootPackageType(): LinuxRootPackageType | null {
   const packageType = getLinuxPackageType()
   return packageType === 'deb' || packageType === 'rpm' ? packageType : null
+}
+
+/**
+ * Whether the marker claims a root package format this host cannot install. Repackagers (AUR, Nix,
+ * container rebuilds) unpack Orca's .deb and inherit its `package-type` verbatim, so the marker
+ * describes the artifact Orca was built as, never the system that now owns the install. Without a
+ * matching package manager no downloaded package can ever be applied here.
+ *
+ * A false positive is impossible by construction: this reuses the exact manager lists and resolver
+ * that `buildLinuxPackageInstallCommand` already loops over, so any host flagged here would have
+ * failed with `no-package-manager` after the download anyway. The gate only moves that verdict
+ * earlier — it never refuses a host that could have installed the update.
+ */
+export function isExternallyManagedLinuxInstall(): boolean {
+  if (cachedExternallyManaged === undefined) {
+    const packageType = getLinuxRootPackageType()
+    cachedExternallyManaged = packageType !== null && !hasTrustedPackageManagerFor(packageType)
+  }
+  return cachedExternallyManaged
 }

--- a/src/main/updater-events.test.ts
+++ b/src/main/updater-events.test.ts
@@ -2,17 +2,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { UpdateStatus } from '../shared/update-status-types'
 import type { registerAutoUpdaterHandlers } from './updater-events'
 
-const { appMock, nativeUpdaterMock, getLinuxPackageTypeMock, getLinuxRootPackageTypeMock } =
-  vi.hoisted(() => ({
-    appMock: {
-      isPackaged: true,
-      getVersion: vi.fn(() => '1.0.51'),
-      on: vi.fn()
-    },
-    nativeUpdaterMock: { on: vi.fn() },
-    getLinuxPackageTypeMock: vi.fn<() => 'deb' | 'rpm' | 'non-root' | 'unusable'>(() => 'deb'),
-    getLinuxRootPackageTypeMock: vi.fn<() => 'deb' | 'rpm' | null>(() => 'deb')
-  }))
+const {
+  appMock,
+  nativeUpdaterMock,
+  getLinuxPackageTypeMock,
+  getLinuxRootPackageTypeMock,
+  isExternallyManagedLinuxInstallMock
+} = vi.hoisted(() => ({
+  appMock: {
+    isPackaged: true,
+    getVersion: vi.fn(() => '1.0.51'),
+    on: vi.fn()
+  },
+  nativeUpdaterMock: { on: vi.fn() },
+  getLinuxPackageTypeMock: vi.fn<() => 'deb' | 'rpm' | 'non-root' | 'unusable'>(() => 'deb'),
+  getLinuxRootPackageTypeMock: vi.fn<() => 'deb' | 'rpm' | null>(() => 'deb'),
+  isExternallyManagedLinuxInstallMock: vi.fn<() => boolean>(() => false)
+}))
 
 vi.mock('electron', () => ({
   app: appMock,
@@ -23,7 +29,8 @@ vi.mock('electron', () => ({
 // Why: only the packaged-marker resolver is faked so the real artifact tracking runs.
 vi.mock('./linux-update-package-type', () => ({
   getLinuxPackageType: getLinuxPackageTypeMock,
-  getLinuxRootPackageType: getLinuxRootPackageTypeMock
+  getLinuxRootPackageType: getLinuxRootPackageTypeMock,
+  isExternallyManagedLinuxInstall: isExternallyManagedLinuxInstallMock
 }))
 
 vi.mock('./updater-changelog', () => ({ fetchChangelog: vi.fn().mockResolvedValue(null) }))
@@ -115,6 +122,8 @@ describe('registerAutoUpdaterHandlers linux package artifact tracking', () => {
     appMock.getVersion.mockReset().mockReturnValue('1.0.51')
     getLinuxPackageTypeMock.mockReset().mockReturnValue('deb')
     getLinuxRootPackageTypeMock.mockReset().mockReturnValue('deb')
+    isExternallyManagedLinuxInstallMock.mockReset().mockReturnValue(false)
+    appMock.isPackaged = true
   })
 
   const register = async (
@@ -254,6 +263,10 @@ describe('registerAutoUpdaterHandlers linux package artifact tracking', () => {
     const { emit, context, getArtifact } = await register()
     emit('update-downloaded', downloadedEvent())
 
+    // Why: the download already produced this exact status, so the assertion below could pass
+    // on that call alone. Clear it so only the second emit can satisfy it.
+    vi.mocked(context.sendStatus).mockClear()
+
     emit('update-not-available')
 
     expect(getArtifact()).toEqual(expect.objectContaining({ version: '1.0.61' }))
@@ -272,6 +285,10 @@ describe('registerAutoUpdaterHandlers linux package artifact tracking', () => {
   it('keeps manual-install recovery when a later check finds only the installed release', async () => {
     const { emit, context, getArtifact } = await register()
     emit('update-downloaded', downloadedEvent())
+
+    // Why: the download already produced this exact status, so the assertion below could pass
+    // on that call alone. Clear it so only the second emit can satisfy it.
+    vi.mocked(context.sendStatus).mockClear()
 
     emit('update-available', { version: '1.0.51' })
 
@@ -390,28 +407,38 @@ describe('registerAutoUpdaterHandlers linux package artifact tracking', () => {
     expect(getArtifact()).toBeNull()
   })
 
-  it('keeps manual-install recovery through a same-version recheck', async () => {
-    let status: UpdateStatus = { state: 'downloading', percent: 100, version: '1.0.61' }
-    const { emit, context, getArtifact } = await register({
-      getCurrentStatus: vi.fn(() => status)
-    })
-    emit('update-downloaded', downloadedEvent())
-
-    status = { state: 'checking' }
-    emit('update-available', { version: '1.0.61' })
-
-    expect(getArtifact()).toEqual(expect.objectContaining({ version: '1.0.61', path: DEB_PATH }))
-    await vi.waitFor(() =>
-      expect(context.sendStatus).toHaveBeenLastCalledWith({
-        state: 'error',
-        message: 'Quit Orca before running the system package install command.',
-        recovery: {
-          kind: 'linux-package-install',
-          packageType: 'deb',
-          reason: 'manual-install-required',
-          version: '1.0.61'
-        }
+  // #17702: the externallyManaged flag is spread onto the fallback object only, so a retained
+  // manual-install status must still win. Cross-version case: the host could self-update when it
+  // downloaded, and cannot now.
+  it.each([false, true])(
+    'keeps manual-install recovery through a same-version recheck (externallyManaged=%s)',
+    async (externallyManaged) => {
+      isExternallyManagedLinuxInstallMock.mockReturnValue(externallyManaged)
+      let status: UpdateStatus = { state: 'downloading', percent: 100, version: '1.0.61' }
+      const { emit, context, getArtifact } = await register({
+        getCurrentStatus: vi.fn(() => status)
       })
-    )
-  })
+      emit('update-downloaded', downloadedEvent())
+
+      // Why: the download already emitted the manual-install status, so waitFor would pass on that
+      // call alone. Clear it so the assertion can only be satisfied by the recheck.
+      vi.mocked(context.sendStatus).mockClear()
+      status = { state: 'checking' }
+      emit('update-available', { version: '1.0.61' })
+
+      expect(getArtifact()).toEqual(expect.objectContaining({ version: '1.0.61', path: DEB_PATH }))
+      await vi.waitFor(() =>
+        expect(context.sendStatus).toHaveBeenLastCalledWith({
+          state: 'error',
+          message: 'Quit Orca before running the system package install command.',
+          recovery: {
+            kind: 'linux-package-install',
+            packageType: 'deb',
+            reason: 'manual-install-required',
+            version: '1.0.61'
+          }
+        })
+      )
+    }
+  )
 })

--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -14,6 +14,7 @@ import {
   resolveLinuxPackageDownloadedStatus,
   shouldIgnoreDownloadedUpdateEvent
 } from './linux-package-downloaded-status'
+import { isExternallyManagedLinuxInstall } from './linux-update-package-type'
 import * as linuxPackageRecovery from './linux-package-update-recovery'
 
 const AUTO_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
@@ -202,7 +203,9 @@ export function registerAutoUpdaterHandlers({
           getRetainedLinuxPackageManualInstallStatus() ?? {
             state: 'available',
             version: info.version,
-            changelog
+            changelog,
+            // Why: the offer is real, but this host can never apply it — say so before a download is offered.
+            ...(isExternallyManagedLinuxInstall() ? { externallyManaged: true } : {})
           }
         )
       } finally {

--- a/src/main/updater-linux-package-recovery-actions.test.ts
+++ b/src/main/updater-linux-package-recovery-actions.test.ts
@@ -80,7 +80,8 @@ vi.mock('./updater-lifecycle-diagnostics', () => ({
 }))
 vi.mock('./linux-update-package-type', () => ({
   getLinuxPackageType: () => 'deb',
-  getLinuxRootPackageType: () => 'deb'
+  getLinuxRootPackageType: () => 'deb',
+  isExternallyManagedLinuxInstall: () => false
 }))
 vi.mock('./linux-package-update-recovery', () => ({
   captureLinuxPackageArtifact: vi.fn(() => getTrackedLinuxPackageArtifactMock()),

--- a/src/main/updater-test-harness.ts
+++ b/src/main/updater-test-harness.ts
@@ -48,6 +48,7 @@ type UpdaterModuleFactories = {
   linuxUpdatePackageType: () => {
     getLinuxPackageType: Mock<() => LinuxPackageType>
     getLinuxRootPackageType: Mock<() => 'deb' | 'rpm' | null>
+    isExternallyManagedLinuxInstall: Mock<() => boolean>
   }
   updaterLifecycleDiagnostics: () => { recordUpdaterLifecycle: UpdaterSpy }
   updaterChangelog: () => { fetchChangelog: UpdaterSpy }
@@ -74,6 +75,7 @@ export type UpdaterMocks = {
   powerMonitorOnMock: UpdaterSpy
   getLinuxPackageTypeMock: Mock<() => LinuxPackageType>
   getLinuxRootPackageTypeMock: Mock<() => 'deb' | 'rpm' | null>
+  isExternallyManagedLinuxInstallMock: Mock<() => boolean>
   recordUpdaterLifecycleMock: UpdaterSpy
   fetchChangelogMock: UpdaterSpy
   fetchNudgeMock: UpdaterSpy
@@ -214,6 +216,7 @@ export function createUpdaterMocks(): UpdaterMocks {
   const getLinuxPackageTypeMock = vi.fn<() => LinuxPackageType>(() => {
     return getLinuxRootPackageTypeMock() ?? 'non-root'
   })
+  const isExternallyManagedLinuxInstallMock = vi.fn<() => boolean>(() => false)
   const recordUpdaterLifecycleMock = vi.fn()
   const fetchChangelogMock = vi.fn()
   const fetchNudgeMock = vi.fn()
@@ -242,7 +245,8 @@ export function createUpdaterMocks(): UpdaterMocks {
     // Why: only the marker resolver is faked so the real artifact capture/redaction path stays under test.
     linuxUpdatePackageType: () => ({
       getLinuxPackageType: getLinuxPackageTypeMock,
-      getLinuxRootPackageType: getLinuxRootPackageTypeMock
+      getLinuxRootPackageType: getLinuxRootPackageTypeMock,
+      isExternallyManagedLinuxInstall: isExternallyManagedLinuxInstallMock
     }),
     updaterLifecycleDiagnostics: () => ({ recordUpdaterLifecycle: recordUpdaterLifecycleMock }),
     updaterChangelog: () => ({ fetchChangelog: fetchChangelogMock }),
@@ -290,6 +294,7 @@ export function createUpdaterMocks(): UpdaterMocks {
     getLinuxPackageTypeMock.mockReset().mockImplementation(() => {
       return getLinuxRootPackageTypeMock() ?? 'non-root'
     })
+    isExternallyManagedLinuxInstallMock.mockReset().mockReturnValue(false)
     recordUpdaterLifecycleMock.mockReset()
     fetchNudgeMock.mockReset().mockResolvedValue(null)
     shouldApplyNudgeMock.mockReset().mockReturnValue(false)
@@ -322,6 +327,7 @@ export function createUpdaterMocks(): UpdaterMocks {
     powerMonitorOnMock,
     getLinuxPackageTypeMock,
     getLinuxRootPackageTypeMock,
+    isExternallyManagedLinuxInstallMock,
     recordUpdaterLifecycleMock,
     fetchChangelogMock,
     fetchNudgeMock,

--- a/src/main/updater.headless-serve-install.test.ts
+++ b/src/main/updater.headless-serve-install.test.ts
@@ -78,7 +78,8 @@ vi.mock('electron-updater', () => ({ autoUpdater: autoUpdaterMock }))
 vi.mock('./electron-updater-loader', () => ({ loadElectronAutoUpdater: () => autoUpdaterMock }))
 vi.mock('./linux-update-package-type', () => ({
   getLinuxPackageType: () => 'non-root',
-  getLinuxRootPackageType: () => null
+  getLinuxRootPackageType: () => null,
+  isExternallyManagedLinuxInstall: () => false
 }))
 vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }))
 vi.mock('./ipc/pty', () => ({ killAllPty: killAllPtyMock }))

--- a/src/main/updater.install-failure-cause.test.ts
+++ b/src/main/updater.install-failure-cause.test.ts
@@ -102,7 +102,8 @@ vi.mock('./updater-lifecycle-diagnostics', () => ({
 }))
 vi.mock('./linux-update-package-type', () => ({
   getLinuxPackageType: () => 'non-root',
-  getLinuxRootPackageType: () => null
+  getLinuxRootPackageType: () => null,
+  isExternallyManagedLinuxInstall: () => false
 }))
 
 // The real electron-updater DebUpdater failure text when elevation is impossible.

--- a/src/main/updater.linux-externally-managed.test.ts
+++ b/src/main/updater.linux-externally-managed.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as UpdaterModule from './updater'
+import type { LinuxRootPackageType, UpdateStatus } from '../shared/update-status-types'
+
+const {
+  autoUpdaterMock,
+  getLinuxRootPackageTypeMock,
+  isExternallyManagedLinuxInstallMock,
+  recordUpdaterLifecycleMock,
+  fetchNewerReleaseTagsMock,
+  moduleFactories,
+  resetUpdaterMocks
+} = await vi.hoisted(async () => (await import('./updater-test-harness')).createUpdaterMocks())
+
+vi.mock('electron', () => moduleFactories.electron())
+vi.mock('electron-updater', () => moduleFactories.electronUpdater())
+vi.mock('./electron-updater-loader', () => moduleFactories.electronUpdaterLoader())
+vi.mock('@electron-toolkit/utils', () => moduleFactories.electronToolkitUtils())
+vi.mock('./ipc/pty', () => moduleFactories.ipcPty())
+vi.mock('./linux-update-package-type', () => moduleFactories.linuxUpdatePackageType())
+vi.mock('./updater-lifecycle-diagnostics', () => moduleFactories.updaterLifecycleDiagnostics())
+vi.mock('./updater-changelog', () => moduleFactories.updaterChangelog())
+vi.mock('./updater-nudge', () => moduleFactories.updaterNudge())
+vi.mock('./update-install-exit-watchdog', () => moduleFactories.updateInstallExitWatchdog())
+vi.mock('./updater-prerelease-feed', () => moduleFactories.updaterPrereleaseFeed())
+vi.mock('./local-builds/local-build-switch', () => moduleFactories.localBuildSwitch())
+vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBuildFeedServer())
+
+const EXTERNALLY_MANAGED_MESSAGE =
+  'This copy of Orca is managed by your system package manager, so Orca cannot install updates itself. Update Orca through your distribution instead.'
+
+/** #17702: a repackaged install (AUR, Nix, container rebuild) inherits the .deb `package-type`
+ *  marker but has no package manager that can apply an Orca-downloaded package. */
+describe('updater externally managed Linux installs', () => {
+  beforeEach(() => {
+    resetUpdaterMocks()
+  })
+
+  async function startUpdater(options: {
+    packageType: LinuxRootPackageType | null
+    externallyManaged: boolean
+  }): Promise<{ send: ReturnType<typeof vi.fn>; updater: typeof UpdaterModule }> {
+    getLinuxRootPackageTypeMock.mockReturnValue(options.packageType)
+    isExternallyManagedLinuxInstallMock.mockReturnValue(options.externallyManaged)
+    vi.useFakeTimers()
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: ['v1.0.61'], state: 'ready' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => autoUpdaterMock.emit('update-available', { version: '1.0.61' }))
+      return Promise.resolve(undefined)
+    })
+    const send = vi.fn()
+    const updater = await import('./updater')
+    updater.setupAutoUpdater({ webContents: { send } } as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      installMode: 'interactive'
+    })
+    return { send, updater }
+  }
+
+  function lastStatus(send: ReturnType<typeof vi.fn>): UpdateStatus | undefined {
+    return send.mock.calls.findLast(([channel]) => channel === 'updater:status')?.[1]
+  }
+
+  it('still reports the available release so the user can update through their distribution', async () => {
+    const { send, updater } = await startUpdater({ packageType: 'deb', externallyManaged: true })
+    updater.checkForUpdatesFromMenu()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(lastStatus(send)).toEqual({
+      state: 'available',
+      version: '1.0.61',
+      changelog: null,
+      externallyManaged: true
+    })
+  })
+
+  it('does not flag a real deb host', async () => {
+    const { send, updater } = await startUpdater({ packageType: 'deb', externallyManaged: false })
+    updater.checkForUpdatesFromMenu()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const status = lastStatus(send)
+    expect(status).toEqual({ state: 'available', version: '1.0.61', changelog: null })
+    expect(status && 'externallyManaged' in status).toBe(false)
+  })
+
+  it('refuses the download instead of spending it on a package it can never install', async () => {
+    const { send, updater } = await startUpdater({ packageType: 'deb', externallyManaged: true })
+    updater.checkForUpdatesFromMenu()
+    await vi.advanceTimersByTimeAsync(0)
+
+    updater.downloadUpdate()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled()
+    expect(lastStatus(send)).toEqual({
+      state: 'error',
+      message: EXTERNALLY_MANAGED_MESSAGE,
+      version: '1.0.61',
+      retryable: false
+    })
+  })
+
+  it('marks the refusal non-retryable so the card offers no Retry Download', async () => {
+    const { send, updater } = await startUpdater({ packageType: 'deb', externallyManaged: true })
+    updater.checkForUpdatesFromMenu()
+    await vi.advanceTimersByTimeAsync(0)
+    updater.downloadUpdate()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const status = lastStatus(send)
+    expect(status?.state === 'error' && status.retryable).toBe(false)
+  })
+
+  it('records the blocked download for field diagnosis', async () => {
+    const { updater } = await startUpdater({ packageType: 'deb', externallyManaged: true })
+    updater.checkForUpdatesFromMenu()
+    await vi.advanceTimersByTimeAsync(0)
+    updater.downloadUpdate()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(recordUpdaterLifecycleMock).toHaveBeenCalledWith(
+      'linux_package_externally_managed_download_blocked',
+      { version: '1.0.61' }
+    )
+  })
+
+  it('leaves an ordinary deb host able to download', async () => {
+    const { updater } = await startUpdater({ packageType: 'deb', externallyManaged: false })
+    updater.checkForUpdatesFromMenu()
+    await vi.advanceTimersByTimeAsync(0)
+    autoUpdaterMock.downloadUpdate.mockResolvedValue([])
+
+    updater.downloadUpdate()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled()
+  })
+
+  it('leaves an AppImage host able to download', async () => {
+    const { updater } = await startUpdater({ packageType: null, externallyManaged: false })
+    updater.checkForUpdatesFromMenu()
+    await vi.advanceTimersByTimeAsync(0)
+    autoUpdaterMock.downloadUpdate.mockResolvedValue([])
+
+    updater.downloadUpdate()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalled()
+  })
+})

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -35,9 +35,10 @@ import {
 } from './update-install-exit-watchdog'
 import { registerAutoUpdaterHandlers } from './updater-events'
 import { recordUpdaterLifecycle } from './updater-lifecycle-diagnostics'
-import { getLinuxPackageType } from './linux-update-package-type'
+import { getLinuxPackageType, isExternallyManagedLinuxInstall } from './linux-update-package-type'
 import {
   getRetainedLinuxPackageManualInstallStatus,
+  LINUX_PACKAGE_EXTERNALLY_MANAGED_MESSAGE,
   LINUX_PACKAGE_MARKER_UNUSABLE_MESSAGE
 } from './linux-package-downloaded-status'
 import {
@@ -2185,6 +2186,25 @@ export function downloadUpdate(): void {
   }
   const version = currentStatus.state === 'available' ? currentStatus.version : availableVersion
   if (!version) {
+    return
+  }
+  // Why: main owns this verdict, not the card — an older renderer or a direct IPC call must not be
+  // able to spend a package download that this host could never install.
+  if (isExternallyManagedLinuxInstall()) {
+    recordUpdaterLifecycle('linux_package_externally_managed_download_blocked', {
+      version
+    })
+    // Why: a pinned jump resolves to 'release' on Linux (no dev-channel artifact is built for it),
+    // so refusing without unwinding would strand isPinnedBuildActive and silently kill every
+    // background check for the rest of the process. A no-op on the ordinary release path.
+    clearAvailableUpdateContext()
+    restoreReleaseUpdateSource()
+    sendStatus({
+      state: 'error',
+      message: LINUX_PACKAGE_EXTERNALLY_MANAGED_MESSAGE,
+      version,
+      retryable: false
+    })
     return
   }
   if (deferHeadlessServeInstall('download', version)) {

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -236,7 +236,9 @@ export function UpdateCard(): React.JSX.Element | null {
       ? 'animate-update-card-exit'
       : 'animate-update-card-enter'
   const showReassurance =
-    !reassuranceSeen && (status.state === 'available' || status.state === 'downloading')
+    !reassuranceSeen &&
+    ((status.state === 'available' && !status.externallyManaged) ||
+      status.state === 'downloading')
   return (
     <div
       ref={cardRootRef}

--- a/src/renderer/src/components/maintenance/update-card/UpdateAvailableCardContent.tsx
+++ b/src/renderer/src/components/maintenance/update-card/UpdateAvailableCardContent.tsx
@@ -7,6 +7,18 @@ function isAnimatedGif(url: string | undefined): boolean {
   return typeof url === 'string' && url.toLowerCase().endsWith('.gif')
 }
 
+/** A package manager owns this install: the release is real but Orca can never apply it here. */
+function ExternallyManagedNote(): React.JSX.Element {
+  return (
+    <p className="text-xs leading-relaxed text-muted-foreground">
+      {translate(
+        'auto.components.UpdateCard.7f1a4c9e02',
+        'Your system package manager installed Orca, so update it from there — Orca cannot install this release itself.'
+      )}
+    </p>
+  )
+}
+
 export function UpdateAvailableRichContent({
   release,
   releasesBehind,
@@ -16,7 +28,8 @@ export function UpdateAvailableRichContent({
   onMediaError,
   onMediaLoad,
   onUpdate,
-  onClose
+  onClose,
+  externallyManaged = false
 }: {
   release: NonNullable<ChangelogData['release']>
   releasesBehind: number | null
@@ -27,6 +40,7 @@ export function UpdateAvailableRichContent({
   onMediaLoad: () => void
   onUpdate: () => void
   onClose: () => void
+  externallyManaged?: boolean
 }): React.JSX.Element {
   const showMedia =
     release.mediaUrl && !mediaFailed && !(prefersReducedMotion && isAnimatedGif(release.mediaUrl))
@@ -87,9 +101,13 @@ export function UpdateAvailableRichContent({
       >
         {translate('auto.components.UpdateCard.aad383aecc', 'Read the full release notes')}
       </button>
-      <Button variant="default" size="sm" onClick={onUpdate} className="w-full cursor-pointer">
-        {translate('auto.components.UpdateCard.ec8fe71cfc', 'Update')}
-      </Button>
+      {externallyManaged ? (
+        <ExternallyManagedNote />
+      ) : (
+        <Button variant="default" size="sm" onClick={onUpdate} className="w-full cursor-pointer">
+          {translate('auto.components.UpdateCard.ec8fe71cfc', 'Update')}
+        </Button>
+      )}
     </div>
   )
 }
@@ -98,12 +116,14 @@ export function UpdateAvailableSimpleContent({
   version,
   releaseUrl,
   onUpdate,
-  onClose
+  onClose,
+  externallyManaged = false
 }: {
   version: string
   releaseUrl?: string
   onUpdate: () => void
   onClose: () => void
+  externallyManaged?: boolean
 }): React.JSX.Element {
   return (
     <div className="flex flex-col gap-2.5 p-3.5">
@@ -126,9 +146,13 @@ export function UpdateAvailableSimpleContent({
           value0: version
         })}
       </p>
-      <p className="text-xs leading-relaxed text-muted-foreground">
-        {translate('auto.components.UpdateCard.fdd4a364fa', "Sessions won't be interrupted.")}
-      </p>
+      {externallyManaged ? (
+        <ExternallyManagedNote />
+      ) : (
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {translate('auto.components.UpdateCard.fdd4a364fa', "Sessions won't be interrupted.")}
+        </p>
+      )}
       {releaseUrl && (
         <button
           type="button"
@@ -138,14 +162,16 @@ export function UpdateAvailableSimpleContent({
           {translate('auto.components.UpdateCard.44324ef542', 'Release notes')}
         </button>
       )}
-      <Button
-        variant="default"
-        size="sm"
-        onClick={onUpdate}
-        className="mt-0.5 w-full cursor-pointer"
-      >
-        {translate('auto.components.UpdateCard.ec8fe71cfc', 'Update')}
-      </Button>
+      {!externallyManaged && (
+        <Button
+          variant="default"
+          size="sm"
+          onClick={onUpdate}
+          className="mt-0.5 w-full cursor-pointer"
+        >
+          {translate('auto.components.UpdateCard.ec8fe71cfc', 'Update')}
+        </Button>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/maintenance/update-card/UpdateCardStateContent.tsx
+++ b/src/renderer/src/components/maintenance/update-card/UpdateCardStateContent.tsx
@@ -132,6 +132,7 @@ export function UpdateCardStateContent({
       onMediaLoad={onMediaLoad}
       onUpdate={onUpdate}
       onClose={onDismiss}
+      externallyManaged={status.externallyManaged}
     />
   ) : (
     <UpdateAvailableSimpleContent
@@ -139,6 +140,7 @@ export function UpdateCardStateContent({
       releaseUrl={releaseUrl}
       onUpdate={onUpdate}
       onClose={onDismiss}
+      externallyManaged={status.externallyManaged}
     />
   )
 }

--- a/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
@@ -112,7 +112,7 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
             )}
           </Button>
 
-          {updateStatus.state === 'available' ? (
+          {updateStatus.state === 'available' && !updateStatus.externallyManaged ? (
             <Button
               variant="default"
               size="sm"
@@ -168,10 +168,15 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
                 'Version'
               )}{' '}
               {updateStatus.version}{' '}
-              {translate(
-                'auto.components.settings.GeneralUpdateSettingsSection.8311da27ba',
-                'is available. Click "Download Update" to download it.'
-              )}{' '}
+              {updateStatus.externallyManaged
+                ? translate(
+                    'auto.components.settings.GeneralUpdateSettingsSection.e3b9d21c07',
+                    'is available. Update Orca through your system package manager — Orca cannot install this release itself.'
+                  )
+                : translate(
+                    'auto.components.settings.GeneralUpdateSettingsSection.8311da27ba',
+                    'is available. Click "Download Update" to download it.'
+                  )}{' '}
               {updateStatus.source !== 'local' && (
                 <a
                   href={

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2292,7 +2292,8 @@
         "a4650b0dc4": "Could Not Use Local Build",
         "b1e390250d": "Could not complete the local build switch.",
         "d29740d175": "The selected build could not be used.",
-        "37d45c9ec1": "Choose Another Build"
+        "37d45c9ec1": "Choose Another Build",
+        "7f1a4c9e02": "Your system package manager installed Orca, so update it from there — Orca cannot install this release itself."
       },
       "WorktreeJumpPalette": {
         "ac037cfac2": "Move",
@@ -7051,7 +7052,8 @@
           "31fd7150cf": "Checking for updates...",
           "3394d1f663": "checking",
           "d69a09b672": "Updates are checked automatically on launch.",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "e3b9d21c07": "is available. Update Orca through your system package manager — Orca cannot install this release itself."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "Choose apps available from a workspace's Open in menu.",

--- a/src/shared/update-status-types.ts
+++ b/src/shared/update-status-types.ts
@@ -74,6 +74,9 @@ export type UpdateStatus = (
       // three-state ambiguity (undefined vs null vs present) and makes exhaustive
       // checks straightforward.
       changelog: ChangelogData | null
+      /** Linux only: a package manager owns this install, so Orca cannot apply the update itself.
+       *  Additive and optional — older clients simply keep offering their own download. */
+      externallyManaged?: boolean
     }
   | { state: 'not-available'; userInitiated?: boolean }
   | { state: 'downloading'; percent: number; version: string; activeNudgeId?: string }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​331 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​292 |
| Prod | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​129 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 |

<!-- /orca-pr-loc -->

Closes #17702.

## ELI5

If you installed Orca from a `.deb`, Orca remembers "I am a deb". Repackagers — the AUR, Nix, container rebuilds — unpack that same `.deb` and inherit the note verbatim, so Orca on Arch still believes it is a deb install. It then offers an update, downloads ~165 MB, and hands you a `sudo dpkg -i` command your machine cannot run. Now Orca checks whether the host actually has the matching package manager before offering anything. It still tells you a new version exists — you do want to know — but it points you at your distro instead of a download that leads nowhere.

## Root cause

Two compounding defects:

1. The `resources/package-type` marker is authoritative but never validated against the host, so any repackager that unpacks the `.deb` inherits `deb`.
2. Install feasibility was computed **after** the download, and after a Download click.

## What changed

`isExternallyManagedLinuxInstall()` validates the marker against the host: a `deb`/`rpm` marker with no matching package manager in the trusted directories means a package manager owns this install.

This reuses the exact manager lists and resolver that `buildLinuxPackageInstallCommand` already loops over, so **a false positive is impossible by construction** — any host flagged here would have failed with `no-package-manager` after the download anyway. The gate only moves that verdict earlier.

`downloadUpdate()` refuses authoritatively, because main owns this verdict rather than the card, and unwinds any pinned-build state first: a Linux pinned jump resolves to `'release'` (no dev-channel artifact is built for Linux), and stranding `isPinnedBuildActive` would silently kill every background update check for the rest of the process.

## Why the fix suggested in the issue cannot work

Writing `pacman` into the marker makes electron-updater construct a `PacmanUpdater`, whose `doDownloadUpdate` calls `findFile(files, "pacman", ["AppImage","deb","rpm"])`. Orca publishes no `.pacman` asset and the `not`-fallback finds nothing either, so `fileInfo` is `undefined` and `:23` dereferences it — surfacing as a generic "Update Error" **with a Retry Download button**.

## Verification

Detection validated in both directions across five distributions plus a real SSH host:

| Host | `apt`/`dpkg` present | Verdict for `marker=deb` |
|---|---|---|
| Ubuntu 24.04 (real hardware) | yes | self-updatable |
| Debian 12 | yes | self-updatable |
| Ubuntu 24.04 (container) | yes | self-updatable |
| Arch Linux — the reporter's platform | no | externally-managed |
| Fedora 40 | no | externally-managed |
| openSUSE Leap 15.6 | no | externally-managed |

`pnpm tc` clean. There is exactly one `downloadUpdate()` call site in `src` and `autoDownload` is unconditionally `false`, so the gate has no bypass.

## User-facing regressions

None intended, and none found.

The wire change is an **additive optional** `externallyManaged?: boolean` on the existing `available` status — no new `state` value — so older paired clients decode it unchanged. An old client never saw a Download button for these hosts anyway: `getRemoteServerUpdateSupport()` already returns `automatic: false` for any deb/rpm marker and the coordinator short-circuits to `phase: 'manual'` before reaching the `available` branch. There is no mobile consumer of `UpdateStatus` and it is not persisted, so no stale flag can be rehydrated after a user switches machines or the AUR ships a fixed build.

Two detection gaps remain, both pre-existing shapes this narrows rather than causes:

- **Arch with `dpkg` installed** (available from the AUR) is not flagged, so Orca still offers `sudo dpkg -i` on a pacman-managed box. Closing it needs an `/etc/os-release` `ID`/`ID_LIKE` check.
- **rpm-ostree atomic distributions** (Silverblue, Kinoite, Bazzite; openSUSE MicroOS) have both `rpm` and `dnf` but a read-only `/usr`, so `dnf install` fails. Detectable with a single `statSync` on `/run/ostree-booted`.
