### PR TITLE
fix(ssh): route four host-blind seams through the resolved execution host

### DIFF
--- a/src/cli/handlers/project.ts
+++ b/src/cli/handlers/project.ts
@@ -10,7 +10,7 @@ import type {
   ProjectHostSetupUpdateArgs,
   ProjectHostSetupUpdateResult
 } from '../../shared/project-types'
-import type { ExecutionHostId } from '../../shared/execution-host'
+import { getSshTargetIdForExecutionHost, type ExecutionHostId } from '../../shared/execution-host'
 import type { RepoKind } from '../../shared/repo-types'
 import type { CommandHandler, HandlerContext } from '../dispatch'
 import {
@@ -111,10 +111,14 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
   },
   'project setup-existing-folder': async ({ flags, client, cwd, json }) => {
     const rawPath = getRequiredStringFlag(flags, 'path')
+    const hostId = getRequiredHostId(flags)
+    // An SSH host's filesystem is not the CLI's, so resolving a relative path against the client
+    // cwd would register a path that names the wrong machine.
+    const pathIsOffClient = client.isRemote || getSshTargetIdForExecutionHost(hostId) !== null
     const args: ProjectHostSetupExistingFolderArgs = {
       projectId: getRequiredStringFlag(flags, 'project'),
-      hostId: getRequiredHostId(flags),
-      path: resolveRepoPathArgument(rawPath, cwd, client.isRemote, 'Remote project setup'),
+      hostId,
+      path: resolveRepoPathArgument(rawPath, cwd, pathIsOffClient, 'Remote project setup'),
       kind: getOptionalRepoKind(flags),
       displayName: getOptionalStringFlag(flags, 'display-name')
     }

--- a/src/cli/index-project-setup.test.ts
+++ b/src/cli/index-project-setup.test.ts
@@ -481,6 +481,37 @@ describe('orca cli worktree awareness', () => {
     process.exitCode = priorExitCode
   })
 
+  it('rejects SSH project setup relative paths, which name the client filesystem', async () => {
+    // A local CLI reaching an `ssh:*` host is still off-client: resolving `./orca` against the
+    // CLI cwd would register a path that exists on the wrong machine.
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      [
+        'project',
+        'setup-existing-folder',
+        '--project',
+        'github:stablyai/orca',
+        '--host',
+        'ssh:openclaw',
+        '--path',
+        './orca',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+      'Remote project setup requires --path to be an absolute path on the remote server.'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
   it('rejects remote repo.add relative paths instead of resolving against client cwd', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/main/ipc/remote-workspace-patch-queue.test.ts
+++ b/src/main/ipc/remote-workspace-patch-queue.test.ts
@@ -77,8 +77,11 @@ describe('remoteWorkspace:setForConnectedTargets patch queue', () => {
   const handlers = new Map<string, (event: unknown, args: unknown) => unknown>()
   const muxByTargetId = new Map<string, { request: ReturnType<typeof vi.fn> }>()
   const getRepoMock = vi.fn<Store['getRepo']>()
+  // Ownership resolution reads the catalog, not one id-keyed row, so the fake has to project one.
+  const KNOWN_REPO_IDS = ['repo-target-1', 'repo-target-2', 'repo-reset', 'repo-newer']
   const store = {
-    getRepo: getRepoMock
+    getRepo: getRepoMock,
+    getRepos: () => KNOWN_REPO_IDS.map((repoId) => getRepoMock(repoId)).filter(Boolean)
   } as unknown as Store
 
   const target: SshTarget = {

--- a/src/main/ipc/remote-workspace.test.ts
+++ b/src/main/ipc/remote-workspace.test.ts
@@ -153,8 +153,10 @@ describe('remoteWorkspace:setForConnectedTargets', () => {
   const muxByTargetId = new Map<string, { request: ReturnType<typeof vi.fn> }>()
   const getRepoMock = vi.fn<Store['getRepo']>()
   const getWorkspaceSessionMock = vi.fn<Store['getWorkspaceSession']>()
+  // Ownership resolution reads the catalog, not one id-keyed row, so the fake has to project one.
   const store = {
     getRepo: getRepoMock,
+    getRepos: () => [getRepoMock('repo-target-1')].filter(Boolean),
     getWorkspaceSession: getWorkspaceSessionMock
   } as unknown as Store
 

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -12,7 +12,10 @@ import {
 } from '../../shared/remote-workspace-types'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree/id'
-import { parseExecutionHostId } from '../../shared/execution-host'
+import {
+  createRepoRowExecutionHostLookup,
+  resolveWorktreeExecutionHost
+} from '../../shared/worktree-execution-host-resolution'
 import { getRemoteWorkspaceNamespace } from './remote-workspace-namespace'
 import { registerRemoteWorkspaceNotificationHandler } from './remote-workspace-events'
 import { CLIENT_ID } from './remote-workspace-client-identity'
@@ -108,12 +111,15 @@ function targetForWorktree(
   worktreeId: string,
   executionHostId?: string
 ): string | null {
-  const parsedHostId = parseExecutionHostId(executionHostId)
-  if (parsedHostId?.kind === 'ssh') {
-    return parsedHostId.targetId
-  }
-  const repoId = getRepoIdFromWorktreeId(worktreeId)
-  return store.getRepo(repoId)?.connectionId ?? null
+  // Why: this decides which SSH target a workspace session is exported to. The old fallback read
+  // `getRepo(id)?.connectionId`, which is host-blind — the same repo id can name rows on several
+  // hosts, so a session could be published to a machine that never owned the worktree (#11163).
+  // Unresolvable ownership exports to nobody rather than guessing.
+  const resolution = resolveWorktreeExecutionHost(
+    createRepoRowExecutionHostLookup(store.getRepos()),
+    { repoId: getRepoIdFromWorktreeId(worktreeId), hostId: executionHostId ?? null }
+  )
+  return resolution.kind === 'resolved' ? resolution.connectionId : null
 }
 
 function exportSessionForTarget(

--- a/src/main/ipc/repos/remote-home-path.ts
+++ b/src/main/ipc/repos/remote-home-path.ts
@@ -1,4 +1,4 @@
-import { getActiveMultiplexer } from '../ssh'
+import { getActiveMultiplexer } from '../../ssh/ssh-target-registry'
 
 export async function resolveRemoteHomePath(connectionId: string, path: string): Promise<string> {
   if (path !== '~' && path !== '~/' && !path.startsWith('~/')) {

--- a/src/main/ipc/repos/remote-repo-registration.test.ts
+++ b/src/main/ipc/repos/remote-repo-registration.test.ts
@@ -1,0 +1,124 @@
+// Registration is now the runtime's SSH path too (`projectHostSetup.setupExistingFolder --host
+// ssh:*`), so what it stamps decides what every downstream host resolver can read. It minted
+// `connectionId`-only rows, leaving the unified spelling permanently empty, and deduped by raw
+// `connectionId`, which cannot see a row stamped `executionHostId: 'ssh:*'`.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../shared/repo-types'
+
+const getSshGitProviderMock = vi.hoisted(() => vi.fn())
+vi.mock('../../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
+}))
+
+vi.mock('../../repo-icon-autodetect', () => ({
+  detectRepoIconAndUpstream: vi.fn(async () => ({}))
+}))
+
+vi.mock('../../ssh/ssh-target-registry', () => ({
+  getActiveMultiplexer: vi.fn(() => null)
+}))
+
+vi.mock('./remote-home-path', () => ({
+  resolveRemoteHomePath: vi.fn(async (_connectionId: string, path: string) => path)
+}))
+
+import { addRemoteRepoFromPath } from './remote-repo-registration'
+
+function makeStore(repos: Repo[]) {
+  return {
+    getRepos: () => repos,
+    getSshTarget: () => undefined,
+    addRepo: (repo: Repo) => {
+      repos.push(repo)
+    }
+  }
+}
+
+describe('addRemoteRepoFromPath', () => {
+  beforeEach(() => {
+    getSshGitProviderMock.mockReset()
+    getSshGitProviderMock.mockReturnValue({
+      isGitRepoAsync: vi.fn(async () => ({ isRepo: true, rootPath: '/srv/app' }))
+    })
+  })
+
+  it('stamps the unified execution-host spelling alongside the legacy connection id', async () => {
+    const repos: Repo[] = []
+    const result = await addRemoteRepoFromPath(makeStore(repos) as never, {
+      connectionId: 'm4air',
+      remotePath: '/srv/app'
+    })
+
+    expect('error' in result).toBe(false)
+    const repo = (result as { repo: Repo }).repo
+    expect(repo.connectionId).toBe('m4air')
+    expect(repo.executionHostId).toBe('ssh:m4air')
+  })
+
+  it('dedupes against a row that names the host in the unified spelling only', async () => {
+    const existing = {
+      id: 'existing',
+      path: '/srv/app',
+      displayName: 'app',
+      badgeColor: '#000',
+      addedAt: 0,
+      executionHostId: 'ssh:m4air'
+    } as Repo
+    const repos: Repo[] = [existing]
+
+    const result = await addRemoteRepoFromPath(makeStore(repos) as never, {
+      connectionId: 'm4air',
+      remotePath: '/srv/app'
+    })
+
+    expect(result).toEqual({ repo: existing, alreadyExisted: true })
+    expect(repos).toHaveLength(1)
+  })
+
+  it('does not dedupe onto a row on a different SSH host at the same path', async () => {
+    // Two hosts can both hold /srv/app. Matching on path alone registers one host's repo as the
+    // other's — the mirror image of the id-only lookup this change removes.
+    const repos: Repo[] = [
+      {
+        id: 'openclaw-row',
+        path: '/srv/app',
+        displayName: 'app',
+        badgeColor: '#000',
+        addedAt: 0,
+        connectionId: 'openclaw'
+      } as Repo
+    ]
+
+    const result = await addRemoteRepoFromPath(makeStore(repos) as never, {
+      connectionId: 'm4air',
+      remotePath: '/srv/app'
+    })
+
+    expect((result as { alreadyExisted: boolean }).alreadyExisted).toBe(false)
+    expect((result as { repo: Repo }).repo.executionHostId).toBe('ssh:m4air')
+    expect(repos).toHaveLength(2)
+  })
+
+  it('does not dedupe onto a local row that carries a stale connection id', async () => {
+    // The pullfrog case: a row declaring itself local must not answer as an SSH host.
+    const repos: Repo[] = [
+      {
+        id: 'local-row',
+        path: '/srv/app',
+        displayName: 'app',
+        badgeColor: '#000',
+        addedAt: 0,
+        executionHostId: 'local',
+        connectionId: 'develop'
+      } as Repo
+    ]
+
+    const result = await addRemoteRepoFromPath(makeStore(repos) as never, {
+      connectionId: 'develop',
+      remotePath: '/srv/app'
+    })
+
+    expect((result as { alreadyExisted: boolean }).alreadyExisted).toBe(false)
+    expect(repos).toHaveLength(2)
+  })
+})

--- a/src/main/ipc/repos/remote-repo-registration.ts
+++ b/src/main/ipc/repos/remote-repo-registration.ts
@@ -6,7 +6,7 @@ import { normalizeRuntimePathForComparison } from '../../../shared/cross-platfor
 import { getRepoSshConnectionId } from '../../../shared/execution-host'
 import { getSshGitProvider } from '../../providers/ssh-git-dispatch'
 import { detectRepoIconAndUpstream } from '../../repo-icon-autodetect'
-import { getActiveMultiplexer } from '../ssh'
+import { getActiveMultiplexer } from '../../ssh/ssh-target-registry'
 import { resolveRemoteHomePath } from './remote-home-path'
 
 export async function addRemoteRepoFromPath(

--- a/src/main/ipc/repos/remote-repo-registration.ts
+++ b/src/main/ipc/repos/remote-repo-registration.ts
@@ -3,7 +3,7 @@ import type { Store } from '../../persistence'
 import type { Repo } from '../../../shared/repo-types'
 import { DEFAULT_REPO_BADGE_COLOR } from '../../../shared/constants'
 import { normalizeRuntimePathForComparison } from '../../../shared/cross-platform-path'
-import { getRepoSshConnectionId } from '../../../shared/execution-host'
+import { getRepoSshConnectionId, toSshExecutionHostId } from '../../../shared/execution-host'
 import { getSshGitProvider } from '../../providers/ssh-git-dispatch'
 import { detectRepoIconAndUpstream } from '../../repo-icon-autodetect'
 import { getActiveMultiplexer } from '../../ssh/ssh-target-registry'
@@ -95,6 +95,9 @@ export async function addRemoteRepoFromPath(
     addedAt: Date.now(),
     kind: repoKind,
     connectionId: args.connectionId,
+    // Stamp the unified spelling at creation: this is now the runtime's SSH registration path too,
+    // and minting `connectionId`-only rows leaves every host-resolving reader on the legacy field.
+    executionHostId: toSshExecutionHostId(args.connectionId),
     ...(repoKind === 'git'
       ? {
           externalWorktreeVisibilityLegacy: false,

--- a/src/main/ipc/repos/remote-repo-registration.ts
+++ b/src/main/ipc/repos/remote-repo-registration.ts
@@ -3,6 +3,7 @@ import type { Store } from '../../persistence'
 import type { Repo } from '../../../shared/repo-types'
 import { DEFAULT_REPO_BADGE_COLOR } from '../../../shared/constants'
 import { normalizeRuntimePathForComparison } from '../../../shared/cross-platform-path'
+import { getRepoSshConnectionId } from '../../../shared/execution-host'
 import { getSshGitProvider } from '../../providers/ssh-git-dispatch'
 import { detectRepoIconAndUpstream } from '../../repo-icon-autodetect'
 import { getActiveMultiplexer } from '../ssh'
@@ -26,11 +27,13 @@ export async function addRemoteRepoFromPath(
   let repoKind: 'git' | 'folder' = args.kind ?? 'git'
   let resolvedPath = await resolveRemoteHomePath(args.connectionId, args.remotePath)
 
+  // Resolve the host: a row stamped only `executionHostId: 'ssh:*'` is the same registration, and
+  // missing it here registers a duplicate repo for a path the host already owns.
   const existing = store
     .getRepos()
     .find(
       (repo) =>
-        repo.connectionId === args.connectionId &&
+        getRepoSshConnectionId(repo) === args.connectionId &&
         normalizeRuntimePathForComparison(repo.path) ===
           normalizeRuntimePathForComparison(resolvedPath)
     )
@@ -61,7 +64,7 @@ export async function addRemoteRepoFromPath(
     .getRepos()
     .find(
       (repo) =>
-        repo.connectionId === args.connectionId &&
+        getRepoSshConnectionId(repo) === args.connectionId &&
         normalizeRuntimePathForComparison(repo.path) ===
           normalizeRuntimePathForComparison(resolvedPath)
     )

--- a/src/main/runtime/agent-terminal-launch-trust-host.test.ts
+++ b/src/main/runtime/agent-terminal-launch-trust-host.test.ts
@@ -1,0 +1,107 @@
+// launchAgentTerminal read `store.getRepo(worktree.repoId)?.connectionId` for the trust write —
+// host-blind, so the same repo id on two hosts wrote a remote path into the client's agent config
+// and the agent on the host never saw the trust (#11163). Every sibling call site already passes
+// the resolved `workspace.connectionId`; this was the last one that did not.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromId: vi.fn(() => null) },
+  webContents: { fromId: vi.fn(() => null) },
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp'), isPackaged: false }
+}))
+
+import { OrcaRuntimeService } from './orca-runtime'
+
+const REMOTE_PATH = '/srv/app-feature'
+
+type RuntimeInternals = {
+  resolveWorktreeSelector: (selector: string) => Promise<unknown>
+  buildStartupForAgent: (repo: unknown, agent: unknown, prompt: string) => unknown
+  markWorkspaceTrustedForAgent: (
+    agent: unknown,
+    connectionId: string | null | undefined,
+    path: string
+  ) => Promise<void>
+  createTerminal: (selector: string, opts: unknown) => Promise<unknown>
+}
+
+function makeRuntime(repos: readonly Record<string, unknown>[], hostId?: string) {
+  const store = {
+    getSettings: () => ({ disabledTuiAgents: [], workspaceDir: '/tmp/workspaces' }),
+    getProjectHostSetups: () => [],
+    getRepos: () => repos,
+    getRepo: (id: string) => repos.find((repo) => repo.id === id)
+  }
+  const runtime = new OrcaRuntimeService(store as never)
+  const internals = runtime as unknown as RuntimeInternals
+  vi.spyOn(internals, 'resolveWorktreeSelector').mockResolvedValue({
+    id: 'repo-shared::/srv/app-feature',
+    repoId: 'repo-shared',
+    path: REMOTE_PATH,
+    ...(hostId ? { hostId } : {})
+  })
+  vi.spyOn(internals, 'buildStartupForAgent').mockReturnValue({
+    agent: 'codex',
+    startup: { command: 'codex', env: {}, startupCommandDelivery: 'none', telemetry: {} }
+  })
+  const markTrusted = vi.fn(async () => {})
+  vi.spyOn(internals, 'markWorkspaceTrustedForAgent').mockImplementation(markTrusted)
+  vi.spyOn(internals, 'createTerminal').mockResolvedValue({ id: 'pty-1' })
+  return { runtime, markTrusted }
+}
+
+describe('launchAgentTerminal trust write', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('writes trust on the host the worktree names, not on a rival row', async () => {
+    // Two SSH hosts publish the same repo id; the worktree is on m4air.
+    const { runtime, markTrusted } = makeRuntime(
+      [
+        { id: 'repo-shared', path: '/home/me/app', connectionId: 'openclaw' },
+        { id: 'repo-shared', path: '/srv/app', connectionId: 'm4air' }
+      ],
+      'ssh:m4air'
+    )
+
+    await runtime.launchAgentTerminal('id:repo-shared::/srv/app-feature', {
+      agent: 'codex',
+      prompt: 'go'
+    } as never)
+
+    expect(markTrusted).toHaveBeenCalledWith('codex', 'm4air', REMOTE_PATH)
+  })
+
+  it('writes trust locally for a local worktree even when a remote row shares the id', async () => {
+    const { runtime, markTrusted } = makeRuntime(
+      [
+        { id: 'repo-shared', path: '/srv/app', connectionId: 'm4air' },
+        { id: 'repo-shared', path: '/home/me/app' }
+      ],
+      'local'
+    )
+
+    await runtime.launchAgentTerminal('id:repo-shared::/srv/app-feature', {
+      agent: 'codex',
+      prompt: 'go'
+    } as never)
+
+    expect(markTrusted).toHaveBeenCalledWith('codex', null, REMOTE_PATH)
+  })
+
+  it('refuses rather than guessing when rival rows disagree and the worktree names no host', async () => {
+    const { runtime } = makeRuntime([
+      { id: 'repo-shared', path: '/srv/app', connectionId: 'm4air' },
+      { id: 'repo-shared', path: '/home/me/app' }
+    ])
+
+    await expect(
+      runtime.launchAgentTerminal('id:repo-shared::/srv/app-feature', {
+        agent: 'codex',
+        prompt: 'go'
+      } as never)
+    ).rejects.toThrow('worktree_execution_host_unresolved')
+  })
+})

--- a/src/main/runtime/managed-worktree-create-execution-host.test.ts
+++ b/src/main/runtime/managed-worktree-create-execution-host.test.ts
@@ -1,0 +1,155 @@
+// createManagedWorktree used to pick remote-vs-local from the raw `connectionId` field, so a repo
+// stamped only `executionHostId: 'ssh:*'` ran `git worktree add` on the client against a remote
+// path — and the folder branch, which returns before that check, wrote agent trust locally for a
+// remote workspace. Both are the #11163 shape: read the execution host, never one spelling of it.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromId: vi.fn(() => null) },
+  webContents: { fromId: vi.fn(() => null) },
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp'), isPackaged: false }
+}))
+
+const createRuntimeFolderWorktreeMock = vi.hoisted(() => vi.fn())
+vi.mock('./runtime-folder-worktree-create', () => ({
+  createRuntimeFolderWorktree: createRuntimeFolderWorktreeMock
+}))
+
+const createRuntimeLocalManagedWorktreeMock = vi.hoisted(() => vi.fn())
+vi.mock('./runtime-local-worktree-create', () => ({
+  createRuntimeLocalManagedWorktree: createRuntimeLocalManagedWorktreeMock
+}))
+
+const trustMocks = vi.hoisted(() => ({
+  local: vi.fn(async () => {}),
+  remote: vi.fn(async () => {})
+}))
+vi.mock('./runtime-worktree-agent-startup', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  markLocalWorktreeTrusted: trustMocks.local,
+  markRemoteWorktreeTrusted: trustMocks.remote
+}))
+
+import { OrcaRuntimeService } from './orca-runtime'
+
+const TARGET_ID = 'remote-1'
+const REMOTE_PATH = '/srv/app'
+
+type RuntimeInternals = {
+  resolveRepoSelector: (selector: string) => Promise<unknown>
+  createManagedRemoteWorktree: (repo: unknown, args: unknown) => Promise<unknown>
+  resolveLineageForWorktreeCreate: (input: unknown) => Promise<unknown>
+  recordCreatedWorktreeLineage: (worktree: unknown, resolution: unknown) => unknown
+}
+
+function makeRuntime(repo: Record<string, unknown>): {
+  runtime: OrcaRuntimeService
+  createRemote: ReturnType<typeof vi.fn>
+} {
+  const store = {
+    getSettings: () => ({ disabledTuiAgents: [], workspaceDir: '/tmp/workspaces' }),
+    getProjectHostSetups: () => []
+  }
+  const runtime = new OrcaRuntimeService(store as never)
+  const internals = runtime as unknown as RuntimeInternals
+  vi.spyOn(internals, 'resolveRepoSelector').mockResolvedValue(repo)
+  vi.spyOn(internals, 'resolveLineageForWorktreeCreate').mockResolvedValue(null)
+  vi.spyOn(internals, 'recordCreatedWorktreeLineage').mockReturnValue({
+    lineage: null,
+    workspaceLineage: null,
+    warnings: []
+  })
+  const createRemote = vi.fn().mockResolvedValue({
+    worktree: { id: 'wt-1', path: '/srv/app-feature', branch: 'feature' }
+  })
+  vi.spyOn(internals, 'createManagedRemoteWorktree').mockImplementation(createRemote)
+  return { runtime, createRemote }
+}
+
+describe('createManagedWorktree execution-host routing', () => {
+  beforeEach(() => {
+    createRuntimeFolderWorktreeMock.mockReset()
+    createRuntimeFolderWorktreeMock.mockResolvedValue({ worktree: { id: 'folder-1' } })
+    createRuntimeLocalManagedWorktreeMock.mockReset()
+    // Name the defect in the failure output: reaching this mock means a remote repo was routed
+    // into a client-side `git worktree add`.
+    createRuntimeLocalManagedWorktreeMock.mockRejectedValue(
+      new Error('local_worktree_create_ran_for_remote_repo')
+    )
+    trustMocks.local.mockClear()
+    trustMocks.remote.mockClear()
+  })
+
+  it('creates on the SSH host for a repo stamped executionHostId only', async () => {
+    const { runtime, createRemote } = makeRuntime({
+      id: 'repo-remote',
+      path: REMOTE_PATH,
+      kind: 'git',
+      executionHostId: `ssh:${TARGET_ID}`
+    })
+
+    await runtime.createManagedWorktree({ repoSelector: 'repo-remote', name: 'feature' } as never)
+
+    // A local `git worktree add` against a remote path is the silent-substitution failure.
+    expect(createRuntimeLocalManagedWorktreeMock).not.toHaveBeenCalled()
+    expect(createRemote).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'repo-remote', connectionId: TARGET_ID }),
+      expect.anything()
+    )
+  })
+
+  it('still creates on the SSH host for a legacy connectionId-only repo', async () => {
+    const { runtime, createRemote } = makeRuntime({
+      id: 'repo-remote',
+      path: REMOTE_PATH,
+      kind: 'git',
+      connectionId: TARGET_ID
+    })
+
+    await runtime.createManagedWorktree({ repoSelector: 'repo-remote', name: 'feature' } as never)
+
+    expect(createRuntimeLocalManagedWorktreeMock).not.toHaveBeenCalled()
+    expect(createRemote).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: TARGET_ID }),
+      expect.anything()
+    )
+  })
+
+  it('marks a folder workspace trusted on its SSH host, not on the client', async () => {
+    const { runtime } = makeRuntime({
+      id: 'repo-folder',
+      path: REMOTE_PATH,
+      kind: 'folder',
+      connectionId: TARGET_ID,
+      executionHostId: `ssh:${TARGET_ID}`
+    })
+
+    await runtime.createManagedWorktree({ repoSelector: 'repo-folder', name: 'notes' } as never)
+
+    const deps = createRuntimeFolderWorktreeMock.mock.calls[0]?.[0]?.deps
+    await deps.markTrusted('codex', '/srv/app')
+
+    expect(trustMocks.remote).toHaveBeenCalledWith('codex', TARGET_ID, '/srv/app')
+    expect(trustMocks.local).not.toHaveBeenCalled()
+  })
+
+  it('keeps a local folder workspace trusted on the client', async () => {
+    const { runtime } = makeRuntime({
+      id: 'repo-folder-local',
+      path: '/Users/me/notes',
+      kind: 'folder'
+    })
+
+    await runtime.createManagedWorktree({
+      repoSelector: 'repo-folder-local',
+      name: 'notes'
+    } as never)
+
+    const deps = createRuntimeFolderWorktreeMock.mock.calls[0]?.[0]?.deps
+    await deps.markTrusted('codex', '/Users/me/notes')
+
+    expect(trustMocks.local).toHaveBeenCalledWith('codex', '/Users/me/notes')
+    expect(trustMocks.remote).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/orca-runtime-create-managed-worktree.ts
+++ b/src/main/runtime/orca-runtime-create-managed-worktree.ts
@@ -4,6 +4,7 @@ import type { RuntimeManagedWorktreeCreateArgs } from './runtime-managed-worktre
 import type { CreateWorktreeResult } from '../../shared/worktree/create-types'
 import { isTuiAgentEnabled } from '../../shared/tui-agent-selection'
 import { isFolderRepo } from '../../shared/repo-kind'
+import { getRepoSshConnectionId } from '../../shared/execution-host'
 import { createRuntimeFolderWorktree } from './runtime-folder-worktree-create'
 import { createRuntimeLocalManagedWorktree } from './runtime-local-worktree-create'
 import { prepareRuntimeLocalWorktreeSetup } from './runtime-local-worktree-setup'
@@ -56,7 +57,13 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
         draftStartup?.agent ??
         (requestedAgentEnabled ? requestedAgent : undefined))
     const effectiveDraftPaste = args.startupDraftPaste ?? draftStartup?.draftPaste
+    // Resolve the execution host once: SSH ownership has two spellings, and reading the raw
+    // `connectionId` field routes an `executionHostId: 'ssh:*'`-only repo down the local path,
+    // which runs `git worktree add` on the client against a remote path.
+    const sshConnectionId = getRepoSshConnectionId(repo)
     if (isFolderRepo(repo)) {
+      // A folder workspace is a registration, not a filesystem create, so it is host-agnostic —
+      // except for the agent trust write, which must land on the host that will run the agent.
       return createRuntimeFolderWorktree({
         request: args,
         repo,
@@ -68,7 +75,8 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
           store: this.store,
           ptySpawnAvailable: Boolean(this.ptyController?.spawn),
           createTerminal: (selector, options) => this.createTerminal(selector, options),
-          markTrusted: (agent, path) => this.markLocalWorkspaceTrustedForAgent(agent, path),
+          markTrusted: (agent, path) =>
+            this.markWorkspaceTrustedForAgent(agent, sshConnectionId, path),
           pasteDraft: (handle, draft) => this.pasteStartupDraftWhenReady(handle, draft),
           sendFollowup: (handle, followup) => this.sendStartupFollowupWhenReady(handle, followup),
           invalidateResolvedWorktrees: () => this.invalidateResolvedWorktreeCache(),
@@ -89,15 +97,20 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
     const lineageInput =
       args.lineage || args.comment ? { ...args.lineage, comment: args.comment } : undefined
     const lineageResolution = await this.resolveLineageForWorktreeCreate(lineageInput)
-    if (repo.connectionId) {
-      const result = await this.createManagedRemoteWorktree(repo, {
-        ...args,
-        activate: args.activate,
-        ...(effectiveStartup ? { startup: effectiveStartup } : {}),
-        ...(effectiveStartupFollowup ? { startupFollowup: effectiveStartupFollowup } : {}),
-        ...(effectiveCreatedWithAgent ? { createdWithAgent: effectiveCreatedWithAgent } : {}),
-        ...(effectiveDraftPaste ? { startupDraftPaste: effectiveDraftPaste } : {})
-      })
+    if (sshConnectionId) {
+      // Why normalize the row: the remote-create pipeline reads `repo.connectionId!` at every
+      // depth, so hand it the connection the resolved host actually names.
+      const result = await this.createManagedRemoteWorktree(
+        { ...repo, connectionId: sshConnectionId },
+        {
+          ...args,
+          activate: args.activate,
+          ...(effectiveStartup ? { startup: effectiveStartup } : {}),
+          ...(effectiveStartupFollowup ? { startupFollowup: effectiveStartupFollowup } : {}),
+          ...(effectiveCreatedWithAgent ? { createdWithAgent: effectiveCreatedWithAgent } : {}),
+          ...(effectiveDraftPaste ? { startupDraftPaste: effectiveDraftPaste } : {})
+        }
+      )
       const recordedLineage = this.recordCreatedWorktreeLineage(result.worktree, lineageResolution)
       this.emitWorktreeLifecycle({
         kind: 'created',

--- a/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
+++ b/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
@@ -19,7 +19,7 @@ import type { Repo } from '../../shared/repo-types'
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
 import type { RuntimeWorktreeScanResult } from './repo-worktree-resolution-scan'
 import { getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
-import { getRepoExecutionHostId } from '../../shared/execution-host'
+import { getRepoExecutionHostId, getRepoSshConnectionId } from '../../shared/execution-host'
 import type { RuntimeWorktreeScanCache } from './orca-runtime-core'
 import { resolveWorktreeScanCacheTtlMs } from './runtime-worktree-scan-cache'
 
@@ -135,17 +135,21 @@ export class OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget extends 
     repo: Repo,
     projectRuntimeByRepoId?: ReadonlyMap<string, ProjectExecutionRuntimeResolution>
   ): Promise<RuntimeWorktreeScanResult> {
+    // Resolve the execution host, not the raw field: an `executionHostId: 'ssh:*'` row with no
+    // `connectionId` would otherwise get a local project runtime and a `local:default` cache key,
+    // so its scan neither routes remotely nor re-runs when the SSH provider is replaced.
+    const sshConnectionId = getRepoSshConnectionId(repo)
     const projectRuntime = projectRuntimeByRepoId
       ? projectRuntimeByRepoId.get(repo.id)
-      : !repo.connectionId
+      : !sshConnectionId
         ? resolveLocalProjectRuntimeForRepo(this.requireStore(), repo)
         : undefined
     const runtimeKey = projectRuntime
       ? projectRuntime.status === 'resolved'
         ? projectRuntime.runtime.cacheKey
         : projectRuntime.repair.cacheKey
-      : repo.connectionId
-        ? `ssh:${repo.connectionId}:${getSshGitProviderGeneration(repo.connectionId)}`
+      : sshConnectionId
+        ? `ssh:${sshConnectionId}:${getSshGitProviderGeneration(sshConnectionId)}`
         : 'local:default'
     const now = Date.now()
     const scanScopeKey = `${repo.id}\0${getRepoExecutionHostId(repo)}`
@@ -176,7 +180,7 @@ export class OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget extends 
         return this.listRepoWorktreesForResolution(repo, projectRuntimeByRepoId)
       }
       if (
-        (refresh.result.ok || !repo.connectionId) &&
+        (refresh.result.ok || !sshConnectionId) &&
         this.worktreeScanInFlight.get(scanScopeKey)?.promise === promise
       ) {
         const entry: RuntimeWorktreeScanCache = {

--- a/src/main/runtime/orca-runtime-preserved-branch-cleanup.ts
+++ b/src/main/runtime/orca-runtime-preserved-branch-cleanup.ts
@@ -26,6 +26,8 @@ import { RuntimeAccountController } from './runtime-account-controller'
 import { RuntimeMobileSpeechCatalog } from './runtime-mobile-speech-catalog'
 import { RuntimeMobileDictationController } from './runtime-mobile-dictation-controller'
 import { RuntimeProjectHostSetupController } from './runtime-project-host-setup-controller'
+import { addRemoteRepoFromPath } from '../ipc/repos/remote-repo-registration'
+import type { Store } from '../persistence'
 import { RuntimeProjectGroupController } from './runtime-project-group-controller'
 import { RuntimeNestedRepoImport } from './runtime-nested-repo-import'
 import { RuntimeRepositoryRegistrationController } from './runtime-repository-registration-controller'
@@ -194,6 +196,17 @@ export class OrcaRuntimeWithPreservedBranchCleanup extends OrcaRuntimeWithTermin
     listRepos: () => this.listRepos(),
     addRepo: (path, kind, hostId) =>
       (this as RuntimeCommandSurfaceHost<this>).addRepo(path, kind, hostId),
+    addRemoteRepo: async (remote) => {
+      // The same registration the desktop IPC handler uses, so both surfaces agree on SSH hosts.
+      const result = await addRemoteRepoFromPath(this.requireStore() as unknown as Store, remote)
+      if ('error' in result) {
+        throw new Error(result.error)
+      }
+      this.invalidateResolvedWorktreeCache()
+      this.invalidateWorktreeScanCacheForRepo(result.repo.id)
+      this.notifyReposChanged()
+      return result.repo
+    },
     cloneRepo: (url, destination, hostId) =>
       (this as RuntimeCommandSurfaceHost<this>).cloneRepo(url, destination, hostId),
     invalidateResolvedWorktrees: () => this.invalidateResolvedWorktreeCache(),

--- a/src/main/runtime/orca-runtime-refresh-repo-worktree-scan.ts
+++ b/src/main/runtime/orca-runtime-refresh-repo-worktree-scan.ts
@@ -17,7 +17,7 @@ import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 import type { GitWorktreeInfo } from '../../shared/worktree/types'
 import { listStoredWorktreeRowsForRepo } from './repo-worktree-row-resolution'
 import type { ResolvedWorktree } from './runtime-worktree-path-identity'
-import { getRepoExecutionHostId } from '../../shared/execution-host'
+import { getRepoExecutionHostId, getRepoSshConnectionId } from '../../shared/execution-host'
 
 export class OrcaRuntimeWithRefreshRepoWorktreeScan extends OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget {
   /**
@@ -31,8 +31,10 @@ export class OrcaRuntimeWithRefreshRepoWorktreeScan extends OrcaRuntimeWithListK
   ): Promise<RuntimeWorktreeScanRefresh> {
     const scannedAt = Date.now()
     // SSH and WSL-routed repos run Git off-host, so a local admin-dir read cannot describe them.
+    // Resolve the execution host rather than reading `connectionId`: a row stamped only
+    // `executionHostId: 'ssh:*'` is just as off-host, and fingerprinting it stats client paths.
     const fingerprintCapable =
-      !repo.connectionId &&
+      !getRepoSshConnectionId(repo) &&
       // Why: a repo whose scan TTL already reaches the reconciliation interval can never reuse a
       // fingerprint, so reading one would be pure work. Agent-scratch roots are that case today.
       resolveWorktreeScanCacheTtlMs(repo) < WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS &&
@@ -92,13 +94,17 @@ export class OrcaRuntimeWithRefreshRepoWorktreeScan extends OrcaRuntimeWithListK
     repo: Repo,
     projectRuntime: ProjectExecutionRuntimeResolution | undefined
   ): Promise<RuntimeWorktreeScanResult> {
-    if (!repo.connectionId) {
+    // Why not `repo.connectionId`: SSH ownership has two spellings, and a repo carrying only
+    // `executionHostId: 'ssh:*'` would otherwise be scanned on the client against a remote path —
+    // `git worktree list` then reports nothing, so the remote worktrees never resolve at all.
+    const sshConnectionId = getRepoSshConnectionId(repo)
+    if (!sshConnectionId) {
       return await scanLocalRepoWorktreesForResolution(
         repo.path,
         getLocalProjectWorktreeGitOptionsForRuntime(repo, projectRuntime)
       )
     }
-    const provider = getSshGitProvider(repo.connectionId)
+    const provider = getSshGitProvider(sshConnectionId)
     if (!provider) {
       return { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
     }
@@ -149,7 +155,7 @@ export class OrcaRuntimeWithRefreshRepoWorktreeScan extends OrcaRuntimeWithListK
 
   protected invalidateSshWorktreeScanCacheInternal(targetId: string): void {
     const repos = this.store?.getRepos() ?? []
-    const affectedRepos = repos.filter((repo) => repo.connectionId === targetId)
+    const affectedRepos = repos.filter((repo) => getRepoSshConnectionId(repo) === targetId)
     const affectedScopeKeys = new Set(
       affectedRepos.map((repo) => `${repo.id}\0${getRepoExecutionHostId(repo)}`)
     )

--- a/src/main/runtime/orca-runtime-resolve-browser-network-execution-host-for-worktree.ts
+++ b/src/main/runtime/orca-runtime-resolve-browser-network-execution-host-for-worktree.ts
@@ -10,6 +10,7 @@ import {
 import { resolveRuntimeBrowserNetworkExecutionHost } from './runtime-browser-network-execution-host'
 import { resolveLocalProjectRuntimeForWorktreeId } from '../local-project-runtime-resolution'
 import { getRegisteredSshState } from '../ssh/ssh-target-registry'
+import { resolveWorktreeLaunchHost } from './worktree-launch-host-repo'
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../shared/workspace-scope'
 import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { ResolvedWorktree } from './runtime-worktree-path-identity'
@@ -124,7 +125,16 @@ export class OrcaRuntimeWithResolveBrowserNetworkExecutionHostForWorktree extend
     const parsed = parseWorkspaceKey(workspaceSelector)
     const worktreeSelector = parsed?.type === 'worktree' ? `id:${parsed.worktreeId}` : selector
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
-    const repo = this.store?.getRepo(worktree.repoId) ?? null
+    // Why: `getRepo(id)` is host-blind and the same repo id can exist on local, SSH and runtime
+    // hosts. Reading `connectionId` off an arbitrary row reports "local" for a remote worktree and
+    // spawns its PTY on the client with the remote cwd (#11163). Loss of a usable answer is
+    // `unresolved`, never `local`.
+    const resolution = resolveWorktreeLaunchHost(this.store?.getRepos() ?? [], worktree)
+    if (resolution.kind === 'ambiguous') {
+      throw new Error('worktree_execution_host_unresolved')
+    }
+    // Metadata only (display name, hook settings); the routing decision is `resolution.connectionId`.
+    const repo = resolution.repo ?? this.store?.getRepo(worktree.repoId) ?? null
     triggerTerminalSpawnPushTargetMaterialization(
       worktree.path,
       worktree.pushTarget,
@@ -137,7 +147,7 @@ export class OrcaRuntimeWithResolveBrowserNetworkExecutionHostForWorktree extend
       scope: {
         id: worktree.id,
         path: worktree.path,
-        connectionId: repo?.connectionId ?? null,
+        connectionId: resolution.connectionId,
         repo,
         folderWorkspace: null
       },

--- a/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
+++ b/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
@@ -8,6 +8,7 @@ import { PTY_CONTROLLER_LIST_TIMEOUT_MS } from './orca-runtime-postlude'
 import { inferWorktreeIdFromPtyId } from './runtime-worktree-path-identity'
 import { getRegisteredSshState } from '../ssh/ssh-target-registry'
 import { LOCAL_EXECUTION_HOST_ID, toSshExecutionHostId } from '../../shared/execution-host'
+import { resolveWorktreeLaunchHost } from './worktree-launch-host-repo'
 import type { TuiAgent } from '../../shared/tui-agent'
 
 export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithCreateAgentSession {
@@ -143,12 +144,20 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
     opts: { agent: TuiAgent; prompt: string; title?: string }
   ): Promise<RuntimeTerminalCreate> {
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
-    const repo = this.store?.getRepo(worktree.repoId)
+    // Why: the trust write lands in an agent's config on the machine that runs it, keyed by the
+    // workspace path. `getRepo(id)` is host-blind, so reading `connectionId` off it wrote a remote
+    // path into the *client's* config — the agent on the host never sees the trust (#11163).
+    // Same shape as the folder-create trust write fixed alongside this; the agent-launch half.
+    const resolution = resolveWorktreeLaunchHost(this.store?.getRepos() ?? [], worktree)
+    if (resolution.kind === 'ambiguous') {
+      throw new Error('worktree_execution_host_unresolved')
+    }
+    const repo = resolution.repo ?? this.store?.getRepo(worktree.repoId)
     if (!repo) {
       throw new Error('Repository for the selected workspace is no longer available.')
     }
     const startup = this.buildStartupForAgent(repo, opts.agent, opts.prompt)
-    await this.markWorkspaceTrustedForAgent(opts.agent, repo.connectionId, worktree.path)
+    await this.markWorkspaceTrustedForAgent(opts.agent, resolution.connectionId, worktree.path)
     return await this.createTerminal(`id:${worktree.id}`, {
       command: startup.startup.command,
       env: startup.startup.env,

--- a/src/main/runtime/orca-runtime-tests/repository-project-operations.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/repository-project-operations.spec.ts
@@ -588,7 +588,7 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it('refuses SSH hosts instead of setting the project up on the local machine', async () => {
+  it('never sets an SSH-hosted project up on the local machine', async () => {
     // Why: both inputs must be paths the pre-guard code would have accepted. An unwritable
     // destination fails at mkdir and a non-repo path fails at isGitRepo, which would leave the
     // side-effect assertions below unable to observe the local clone/probe they exist to catch.
@@ -639,11 +639,14 @@ describe('OrcaRuntimeService', () => {
       // first so a regression reports the corruption rather than stopping at the first throw.
       expect(spawnSpy).not.toHaveBeenCalled()
       expect(repos).toHaveLength(0)
+      // Cloning onto an SSH host has no implementation here, so it still refuses outright.
       expect(cloneError).toMatchObject({
-        message: expect.stringMatching(/SSH hosts are not supported/)
+        message: expect.stringMatching(/Cloning onto an SSH host is not supported/)
       })
+      // Registering an existing remote path does have one, so this now fails on the host's own
+      // terms — the SSH connection is not registered — rather than on a categorical refusal.
       expect(existingFolderError).toMatchObject({
-        message: expect.stringMatching(/SSH hosts are not supported/)
+        message: expect.stringMatching(/SSH connection "openclaw" not found or not connected/)
       })
     } finally {
       spawnSpy.mockRestore()

--- a/src/main/runtime/runtime-project-host-setup-controller.test.ts
+++ b/src/main/runtime/runtime-project-host-setup-controller.test.ts
@@ -1,0 +1,120 @@
+// The CLI/runtime RPC used to refuse `--host ssh:*` with "set the project up from the Orca desktop
+// app" — while the desktop IPC handler in the *same process* routed it correctly through
+// addRemoteRepoFromPath. Safe but wrong: the process refusing is the one that owns the connection.
+import { describe, expect, it, vi } from 'vitest'
+import { RuntimeProjectHostSetupController } from './runtime-project-host-setup-controller'
+import { getProjectHostSetupForRepo } from '../../shared/project-host-setup-lookup'
+import { projectHostSetupProjectionFromRepos } from '../../shared/project-host-setup-projection'
+import type { Repo } from '../../shared/repo-types'
+
+const TARGET_ID = 'target-1'
+const REMOTE_PATH = '/srv/app'
+
+const remoteRepo = {
+  id: 'repo-remote',
+  path: REMOTE_PATH,
+  displayName: 'app',
+  badgeColor: 'blue',
+  addedAt: 1,
+  kind: 'git',
+  connectionId: TARGET_ID
+} as unknown as Repo
+
+function makeController(): {
+  controller: RuntimeProjectHostSetupController
+  addRepo: ReturnType<typeof vi.fn>
+  addRemoteRepo: ReturnType<typeof vi.fn>
+  cloneRepo: ReturnType<typeof vi.fn>
+  projectId: string
+} {
+  const store = {
+    getProjects: () => projectHostSetupProjectionFromRepos([remoteRepo]).projects,
+    getProjectHostSetups: () => [],
+    updateRepo: (_id: string, updates: Record<string, unknown>) => ({ ...remoteRepo, ...updates })
+  }
+  const addRepo = vi.fn().mockResolvedValue(remoteRepo)
+  const addRemoteRepo = vi.fn().mockResolvedValue(remoteRepo)
+  const cloneRepo = vi.fn().mockResolvedValue(remoteRepo)
+  const controller = new RuntimeProjectHostSetupController({
+    getStore: () => store as never,
+    listRepos: () => [remoteRepo],
+    addRepo,
+    addRemoteRepo,
+    cloneRepo,
+    invalidateResolvedWorktrees: vi.fn(),
+    invalidateWorktreeScan: vi.fn(),
+    notifyReposChanged: vi.fn()
+  })
+  return {
+    controller,
+    addRepo,
+    addRemoteRepo,
+    cloneRepo,
+    projectId: getProjectHostSetupForRepo([], remoteRepo).projectId
+  }
+}
+
+describe('RuntimeProjectHostSetupController host routing', () => {
+  it('registers an existing folder on an SSH host instead of refusing it (#11163)', async () => {
+    const { controller, addRepo, addRemoteRepo, projectId } = makeController()
+
+    const result = await controller.setupExistingFolder({
+      projectId,
+      hostId: `ssh:${TARGET_ID}`,
+      path: REMOTE_PATH,
+      kind: 'git'
+    })
+
+    expect(addRemoteRepo).toHaveBeenCalledWith({
+      connectionId: TARGET_ID,
+      remotePath: REMOTE_PATH,
+      kind: 'git'
+    })
+    // The local registration path validates the path against the client filesystem.
+    expect(addRepo).not.toHaveBeenCalled()
+    expect(result.repo.id).toBe(remoteRepo.id)
+  })
+
+  it('decodes a percent-encoded SSH target back to its connection id', async () => {
+    const { controller, addRemoteRepo, projectId } = makeController()
+
+    await controller.setupExistingFolder({
+      projectId,
+      hostId: 'ssh:my%20host',
+      path: REMOTE_PATH,
+      kind: 'folder'
+    })
+
+    expect(addRemoteRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: 'my host', kind: 'folder' })
+    )
+  })
+
+  it('still uses the local registration for local and runtime hosts', async () => {
+    const { controller, addRepo, addRemoteRepo, projectId } = makeController()
+
+    await controller.setupExistingFolder({
+      projectId,
+      hostId: 'local',
+      path: REMOTE_PATH,
+      kind: 'git'
+    })
+
+    expect(addRepo).toHaveBeenCalledWith(REMOTE_PATH, 'git', 'local')
+    expect(addRemoteRepo).not.toHaveBeenCalled()
+  })
+
+  it('refuses to clone onto an SSH host, because nothing here clones remotely', async () => {
+    const { controller, cloneRepo, projectId } = makeController()
+
+    await expect(
+      controller.setupClone({
+        projectId,
+        hostId: `ssh:${TARGET_ID}`,
+        url: 'https://example.com/app.git',
+        destination: REMOTE_PATH
+      })
+    ).rejects.toThrow(/Cloning onto an SSH host is not supported/)
+    expect(cloneRepo).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/runtime-project-host-setup-controller.ts
+++ b/src/main/runtime/runtime-project-host-setup-controller.ts
@@ -13,7 +13,11 @@ import type {
   ProjectUpdateArgs
 } from '../../shared/project-types'
 import type { Repo } from '../../shared/repo-types'
-import { parseExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
+import {
+  getSshTargetIdForExecutionHost,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from '../../shared/execution-host'
 import { getProjectIdForProviderIdentity } from '../../shared/project-host-setup-projection'
 import { getProjectHostSetupForRepo } from '../../shared/project-host-setup-lookup'
 import { invalidateAuthorizedRootsCache } from '../ipc/filesystem-auth'
@@ -24,18 +28,29 @@ type RuntimeProjectHostSetupDependencies = {
   getStore: () => RuntimeStore | null
   listRepos: () => Repo[]
   addRepo: (path: string, kind: 'folder' | 'git', hostId: ExecutionHostId) => Promise<Repo>
+  /** Register an existing path that lives on an SSH host; `addRepo` only reaches local/runtime hosts. */
+  addRemoteRepo: (args: {
+    connectionId: string
+    remotePath: string
+    displayName?: string
+    kind: 'folder' | 'git'
+  }) => Promise<Repo>
   cloneRepo: (url: string, destination: string, hostId: ExecutionHostId) => Promise<Repo>
   invalidateResolvedWorktrees: () => void
   invalidateWorktreeScan: (repoId: string) => void
   notifyReposChanged: () => void
 }
 
-function assertHostIsSupported(hostId: ExecutionHostId | null | undefined): void {
+// Why clone alone still refuses: nothing in this process clones onto an SSH host. `cloneRepo` runs
+// `git clone` on the client, so accepting `ssh:*` here would register the client's copy as the
+// host's repo — a local answer to a remote question. Registering an existing remote path, by
+// contrast, has a correct implementation this process already uses over IPC.
+function assertCloneHostIsSupported(hostId: ExecutionHostId | null | undefined): void {
   if (parseExecutionHostId(hostId)?.kind !== 'ssh') {
     return
   }
   throw new Error(
-    'SSH hosts are not supported by this operation. Set the project up from the Orca desktop app, which owns the SSH connection.'
+    'Cloning onto an SSH host is not supported. Clone the repository on the host, then set the project up from that existing folder.'
   )
 }
 
@@ -82,18 +97,25 @@ export class RuntimeProjectHostSetupController {
     if (!this.deps.getStore()) {
       throw new Error('runtime_unavailable')
     }
-    assertHostIsSupported(args.hostId)
+    const kind = args.kind === 'folder' ? 'folder' : 'git'
     const knownRepoIds = new Set(this.deps.listRepos().map((repo) => repo.id))
-    const repo = await this.deps.addRepo(
-      args.path,
-      args.kind === 'folder' ? 'folder' : 'git',
-      args.hostId
-    )
+    // Why route rather than refuse: this process owns the SSH connection, and its own IPC handler
+    // already registers `ssh:*` hosts correctly. Refusing here only made the CLI and runtime RPC
+    // disagree with the desktop app about what the same process can do.
+    const sshTargetId = getSshTargetIdForExecutionHost(args.hostId)
+    const repo = sshTargetId
+      ? await this.deps.addRemoteRepo({
+          connectionId: sshTargetId,
+          remotePath: args.path,
+          ...(args.displayName ? { displayName: args.displayName } : {}),
+          kind
+        })
+      : await this.deps.addRepo(args.path, kind, args.hostId)
     return this.completeSetup(args, repo, !knownRepoIds.has(repo.id))
   }
 
   async setupClone(args: ProjectHostSetupCloneArgs): Promise<ProjectHostSetupResult> {
-    assertHostIsSupported(args.hostId)
+    assertCloneHostIsSupported(args.hostId)
     const knownRepoIds = new Set(this.deps.listRepos().map((repo) => repo.id))
     const repo = await this.deps.cloneRepo(args.url, args.destination, args.hostId)
     return this.completeSetup(

--- a/src/main/runtime/runtime-workspace-session-controller.ts
+++ b/src/main/runtime/runtime-workspace-session-controller.ts
@@ -8,6 +8,7 @@ import {
 import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree/id'
+import { workspaceSessionPartitionHostId } from '../../shared/workspace-session-partition-owner'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import type { RuntimeStore } from './runtime-store-contract'
 
@@ -44,7 +45,11 @@ export class RuntimeWorkspaceSessionController {
     }
     const resolvedWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
     const repo = store?.getRepo?.(getRepoIdFromWorktreeId(resolvedWorktreeId))
-    return repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
+    // Why: SSH worktrees keep their own `ssh:<targetId>` partition here while the renderer writes
+    // them to 'local'; the shared owner map records that divergence (#12723).
+    return repo
+      ? workspaceSessionPartitionHostId(getRepoExecutionHostId(repo), 'host-partition')
+      : LOCAL_EXECUTION_HOST_ID
   }
 
   getHostId(worktreeId: string): ExecutionHostId {

--- a/src/main/runtime/runtime-worktree-selection.test.ts
+++ b/src/main/runtime/runtime-worktree-selection.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { runtimeRepoMatchesExecutionHost } from './runtime-worktree-selection'
+
+describe('runtimeRepoMatchesExecutionHost', () => {
+  it('matches an unstamped SSH repo against its own host (#11163)', () => {
+    // The row spells its ownership as `connectionId`; the request spells it as `ssh:<target>`.
+    // Rejecting it here makes repo-add/clone dedupe register a second row for the same path.
+    expect(runtimeRepoMatchesExecutionHost({ connectionId: 'target-1' }, 'ssh:target-1')).toBe(true)
+  })
+
+  it('matches a stamped SSH repo against its own host', () => {
+    expect(
+      runtimeRepoMatchesExecutionHost(
+        { connectionId: 'target-1', executionHostId: 'ssh:target-1' },
+        'ssh:target-1'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects an unstamped SSH repo against a different SSH host', () => {
+    expect(runtimeRepoMatchesExecutionHost({ connectionId: 'target-1' }, 'ssh:target-2')).toBe(
+      false
+    )
+  })
+
+  it('rejects an unstamped SSH repo against local and runtime hosts', () => {
+    expect(runtimeRepoMatchesExecutionHost({ connectionId: 'target-1' }, 'local')).toBe(false)
+    expect(runtimeRepoMatchesExecutionHost({ connectionId: 'target-1' }, 'runtime:env-1')).toBe(
+      false
+    )
+  })
+
+  it('keeps a host-less legacy repo adoptable by any host', () => {
+    expect(runtimeRepoMatchesExecutionHost({}, 'runtime:env-1')).toBe(true)
+    expect(runtimeRepoMatchesExecutionHost({}, 'local')).toBe(true)
+    expect(runtimeRepoMatchesExecutionHost({}, 'ssh:target-1')).toBe(true)
+  })
+
+  it('matches any repo when the caller names no host', () => {
+    expect(runtimeRepoMatchesExecutionHost({ connectionId: 'target-1' })).toBe(true)
+    expect(runtimeRepoMatchesExecutionHost({ executionHostId: 'runtime:env-1' }, null)).toBe(true)
+  })
+
+  it('keeps a stamped repo bound to the host it names', () => {
+    expect(runtimeRepoMatchesExecutionHost({ executionHostId: 'runtime:env-1' }, 'local')).toBe(
+      false
+    )
+    expect(
+      runtimeRepoMatchesExecutionHost(
+        { executionHostId: 'local', connectionId: 'target-1' },
+        'local'
+      )
+    ).toBe(true)
+  })
+})

--- a/src/main/runtime/runtime-worktree-selection.ts
+++ b/src/main/runtime/runtime-worktree-selection.ts
@@ -1,5 +1,5 @@
 import type { Repo } from '../../shared/repo-types'
-import type { ExecutionHostId } from '../../shared/execution-host'
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
 import { splitWorktreeId } from '../../shared/worktree/id'
 import type { GitPushTarget } from '../../shared/worktree/types'
 
@@ -38,8 +38,9 @@ export function getRuntimeWorktreeRemovalOptionsKey(
 }
 
 // Null executionHostId means host-unaware: path-only callers match any repo, and the first runtime
-// host can adopt a legacy (unstamped) repo. But an unstamped repo with a connectionId is an SSH repo
-// (resolves to ssh:<id>), so it must not be adopted/matched by a runtime host at the same path.
+// host can adopt a legacy (unstamped) repo. A repo that names a host in *either* spelling matches
+// only that host — including its own ssh:<connectionId>, which an executionHostId-only comparison
+// used to reject, so an unstamped SSH repo failed to dedupe against itself.
 export function runtimeRepoMatchesExecutionHost(
   repo: Pick<Repo, 'connectionId' | 'executionHostId'>,
   executionHostId?: ExecutionHostId | null
@@ -47,10 +48,10 @@ export function runtimeRepoMatchesExecutionHost(
   if (executionHostId == null) {
     return true
   }
-  if (repo.executionHostId != null) {
-    return repo.executionHostId === executionHostId
+  if (repo.executionHostId == null && repo.connectionId == null) {
+    return true
   }
-  return repo.connectionId == null
+  return getRepoExecutionHostId(repo) === executionHostId
 }
 
 export function parseExactWorktreeIdSelector(

--- a/src/main/runtime/worktree-launch-host-repo.test.ts
+++ b/src/main/runtime/worktree-launch-host-repo.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorktreeLaunchHost } from './worktree-launch-host-repo'
+
+// Why (#11163): the terminal launch scope read
+// `store.getRepo(worktree.repoId)?.connectionId ?? null` — one spelling of one arbitrarily chosen
+// row instead of the worktree's execution host. A remote worktree then spawns its PTY on the
+// client with the remote cwd (`DaemonProtocolError: Working directory "…" does not exist`).
+describe('resolveWorktreeLaunchHost', () => {
+  const localRow = { id: 'shared', path: '/local/repo' }
+  const sshRow = { id: 'shared', path: '/remote/repo', connectionId: 'ssh-b' }
+
+  it('reports ambiguous when duplicate repo rows disagree about the owning host', () => {
+    expect(resolveWorktreeLaunchHost([localRow, sshRow], { repoId: 'shared' })).toEqual({
+      kind: 'ambiguous'
+    })
+  })
+
+  it('resolves the row for the host the worktree names', () => {
+    expect(
+      resolveWorktreeLaunchHost([localRow, sshRow], { repoId: 'shared', hostId: 'ssh:ssh-b' })
+    ).toEqual({ kind: 'resolved', repo: sshRow, connectionId: 'ssh-b' })
+    expect(
+      resolveWorktreeLaunchHost([localRow, sshRow], { repoId: 'shared', hostId: 'local' })
+    ).toEqual({ kind: 'resolved', repo: localRow, connectionId: null })
+  })
+
+  it('never hands a runtime-owned worktree a client SSH connection', () => {
+    const clientOwnedRow = { id: 'r', path: '/p', connectionId: 'ssh-client' }
+    expect(
+      resolveWorktreeLaunchHost([clientOwnedRow], { repoId: 'r', hostId: 'runtime:env-a' })
+    ).toEqual({ kind: 'resolved', repo: clientOwnedRow, connectionId: null })
+    // Two rows and no match: nothing names the owner, so the row is not evidence either.
+    expect(
+      resolveWorktreeLaunchHost([clientOwnedRow, { id: 'r', path: '/q' }], {
+        repoId: 'r',
+        hostId: 'runtime:env-a'
+      })
+    ).toEqual({ kind: 'resolved', repo: null, connectionId: null })
+  })
+
+  it('leaves a single unambiguous row alone', () => {
+    expect(resolveWorktreeLaunchHost([sshRow], { repoId: 'shared' })).toEqual({
+      kind: 'resolved',
+      repo: sshRow,
+      connectionId: 'ssh-b'
+    })
+    expect(resolveWorktreeLaunchHost([localRow], { repoId: 'shared' })).toEqual({
+      kind: 'resolved',
+      repo: localRow,
+      connectionId: null
+    })
+    expect(resolveWorktreeLaunchHost([], { repoId: 'shared' })).toEqual({
+      kind: 'resolved',
+      repo: null,
+      connectionId: null
+    })
+  })
+})

--- a/src/main/runtime/worktree-launch-host-repo.test.ts
+++ b/src/main/runtime/worktree-launch-host-repo.test.ts
@@ -24,16 +24,52 @@ describe('resolveWorktreeLaunchHost', () => {
     ).toEqual({ kind: 'resolved', repo: localRow, connectionId: null })
   })
 
-  it('never hands a runtime-owned worktree a client SSH connection', () => {
+  // The settled rule: the execution host is authoritative, and a row on some *other* host is never
+  // evidence about this one — not for the connection, and not for the metadata row either. This is
+  // the question `getRepoSshConnectionId` and `getSshTargetIdForExecutionHost` once answered two
+  // ways; they now compose, and `execution-host.test.ts` pins the composition.
+  it('never hands a worktree a connection belonging to a different host', () => {
     const clientOwnedRow = { id: 'r', path: '/p', connectionId: 'ssh-client' }
     expect(
       resolveWorktreeLaunchHost([clientOwnedRow], { repoId: 'r', hostId: 'runtime:env-a' })
-    ).toEqual({ kind: 'resolved', repo: clientOwnedRow, connectionId: null })
-    // Two rows and no match: nothing names the owner, so the row is not evidence either.
+    ).toEqual({ kind: 'resolved', repo: null, connectionId: null })
+    // Even the runtime host's *own* row contributes no PTY route: its nested target lives in that
+    // machine's namespace, so spawning against it here would dial the wrong box. The renderer
+    // reads the same resolution and does want that id — see execution-host.test.ts.
+    const nestedRow = {
+      id: 'r',
+      path: '/p',
+      connectionId: 'ssh-nested',
+      executionHostId: 'runtime:env-a' as const
+    }
     expect(
-      resolveWorktreeLaunchHost([clientOwnedRow, { id: 'r', path: '/q' }], {
+      resolveWorktreeLaunchHost([nestedRow], { repoId: 'r', hostId: 'runtime:env-a' })
+    ).toEqual({ kind: 'resolved', repo: nestedRow, connectionId: null })
+    // Two SSH hosts, one shared repo id: the worktree's own host wins outright.
+    expect(
+      resolveWorktreeLaunchHost([{ id: 'r', path: '/p', connectionId: 'openclaw' }], {
         repoId: 'r',
-        hostId: 'runtime:env-a'
+        hostId: 'ssh:m4air'
+      })
+    ).toEqual({ kind: 'resolved', repo: null, connectionId: 'm4air' })
+    expect(
+      resolveWorktreeLaunchHost(
+        [
+          { id: 'r', path: '/p', connectionId: 'openclaw' },
+          { id: 'r', path: '/q', connectionId: 'm4air' }
+        ],
+        { repoId: 'r', hostId: 'ssh:m4air' }
+      )
+    ).toEqual({
+      kind: 'resolved',
+      repo: { id: 'r', path: '/q', connectionId: 'm4air' },
+      connectionId: 'm4air'
+    })
+    // A row declaring itself local hands out no SSH connection, whatever `connectionId` says.
+    expect(
+      resolveWorktreeLaunchHost([{ id: 'r', path: '/p', connectionId: 'openclaw' }], {
+        repoId: 'r',
+        hostId: 'local'
       })
     ).toEqual({ kind: 'resolved', repo: null, connectionId: null })
   })

--- a/src/main/runtime/worktree-launch-host-repo.ts
+++ b/src/main/runtime/worktree-launch-host-repo.ts
@@ -1,10 +1,9 @@
 import {
-  LOCAL_EXECUTION_HOST_ID,
-  getRepoExecutionHostId,
-  getSshTargetIdForExecutionHost,
-  normalizeExecutionHostId,
-  type ExecutionHostId
-} from '../../shared/execution-host'
+  createRepoRowExecutionHostLookup,
+  resolveWorktreeExecutionHost,
+  type ExecutionHostOwnerRow
+} from '../../shared/worktree-execution-host-resolution'
+import { getSshTargetIdForExecutionHost } from '../../shared/execution-host'
 import type { Repo } from '../../shared/repo-types'
 
 export type LaunchHostRepo = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
@@ -14,41 +13,31 @@ export type WorktreeLaunchHostResolution<T extends LaunchHostRepo> =
   | { kind: 'ambiguous' }
 
 /**
- * Pick the repo row that owns a worktree's execution, and read the SSH connection off the
- * resolved host rather than off whichever row an id-only lookup happened to return.
+ * Main-side adapter over the shared execution-host rule
+ * (`src/shared/worktree-execution-host-resolution.ts`), which the renderer's owner index answers
+ * with too. Two things are local to this side:
  *
- * The same repo id can exist on local, SSH and runtime hosts at once — `setResolvedRepoGitUsername`
- * already refuses id-only lookups for that reason. A host-blind `getRepo(id)` can hand a remote
- * worktree the local row, whose `connectionId` reads `null`, and the PTY then spawns on the client
- * with the remote cwd (#11163). Conflicting rows with nothing to disambiguate them resolve
- * `ambiguous`, never "local".
+ * - rival rows that disagree about the host are `ambiguous` and the launch scope throws, while an
+ *   id nobody carries stays "no repo, no connection" — the launch path's long-standing behaviour
+ *   for a worktree whose repo row has gone;
+ * - the connection comes off the *host*, not the resolved row. This is a client-dialable PTY
+ *   route, so a `runtime:` host contributes nothing: its nested SSH target belongs to that
+ *   machine's namespace and spawning against it here would dial the wrong box. The renderer wants
+ *   the opposite answer from the same resolution, which is why the shared type carries both.
  */
-export function resolveWorktreeLaunchHost<T extends LaunchHostRepo>(
+export function resolveWorktreeLaunchHost<T extends LaunchHostRepo & ExecutionHostOwnerRow>(
   repos: readonly T[],
-  worktree: { repoId: string; hostId?: ExecutionHostId | null }
+  worktree: { repoId: string; hostId?: string | null }
 ): WorktreeLaunchHostResolution<T> {
-  const rows = repos.filter((repo) => repo.id === worktree.repoId)
-  const worktreeHostId = normalizeExecutionHostId(worktree.hostId)
-  if (worktreeHostId) {
-    // The worktree names its own host, which outranks the repo fallback.
-    const match = rows.find((repo) => getRepoExecutionHostId(repo) === worktreeHostId)
-    return {
-      kind: 'resolved',
-      repo: match ?? (rows.length === 1 ? (rows[0] ?? null) : null),
-      connectionId: getSshTargetIdForExecutionHost(worktreeHostId)
-    }
+  const resolution = resolveWorktreeExecutionHost(createRepoRowExecutionHostLookup(repos), worktree)
+  if (resolution.kind === 'unresolved') {
+    return resolution.reason === 'ambiguous'
+      ? { kind: 'ambiguous' }
+      : { kind: 'resolved', repo: null, connectionId: null }
   }
-  if (rows.length === 0) {
-    return { kind: 'resolved', repo: null, connectionId: null }
-  }
-  const hostIds = new Set<ExecutionHostId>(rows.map((repo) => getRepoExecutionHostId(repo)))
-  if (hostIds.size > 1) {
-    return { kind: 'ambiguous' }
-  }
-  const hostId = [...hostIds][0] ?? LOCAL_EXECUTION_HOST_ID
   return {
     kind: 'resolved',
-    repo: rows[0] ?? null,
-    connectionId: getSshTargetIdForExecutionHost(hostId)
+    repo: resolution.owner,
+    connectionId: getSshTargetIdForExecutionHost(resolution.hostId)
   }
 }

--- a/src/main/runtime/worktree-launch-host-repo.ts
+++ b/src/main/runtime/worktree-launch-host-repo.ts
@@ -1,0 +1,54 @@
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  getRepoExecutionHostId,
+  getSshTargetIdForExecutionHost,
+  normalizeExecutionHostId,
+  type ExecutionHostId
+} from '../../shared/execution-host'
+import type { Repo } from '../../shared/repo-types'
+
+export type LaunchHostRepo = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+
+export type WorktreeLaunchHostResolution<T extends LaunchHostRepo> =
+  | { kind: 'resolved'; repo: T | null; connectionId: string | null }
+  | { kind: 'ambiguous' }
+
+/**
+ * Pick the repo row that owns a worktree's execution, and read the SSH connection off the
+ * resolved host rather than off whichever row an id-only lookup happened to return.
+ *
+ * The same repo id can exist on local, SSH and runtime hosts at once — `setResolvedRepoGitUsername`
+ * already refuses id-only lookups for that reason. A host-blind `getRepo(id)` can hand a remote
+ * worktree the local row, whose `connectionId` reads `null`, and the PTY then spawns on the client
+ * with the remote cwd (#11163). Conflicting rows with nothing to disambiguate them resolve
+ * `ambiguous`, never "local".
+ */
+export function resolveWorktreeLaunchHost<T extends LaunchHostRepo>(
+  repos: readonly T[],
+  worktree: { repoId: string; hostId?: ExecutionHostId | null }
+): WorktreeLaunchHostResolution<T> {
+  const rows = repos.filter((repo) => repo.id === worktree.repoId)
+  const worktreeHostId = normalizeExecutionHostId(worktree.hostId)
+  if (worktreeHostId) {
+    // The worktree names its own host, which outranks the repo fallback.
+    const match = rows.find((repo) => getRepoExecutionHostId(repo) === worktreeHostId)
+    return {
+      kind: 'resolved',
+      repo: match ?? (rows.length === 1 ? (rows[0] ?? null) : null),
+      connectionId: getSshTargetIdForExecutionHost(worktreeHostId)
+    }
+  }
+  if (rows.length === 0) {
+    return { kind: 'resolved', repo: null, connectionId: null }
+  }
+  const hostIds = new Set<ExecutionHostId>(rows.map((repo) => getRepoExecutionHostId(repo)))
+  if (hostIds.size > 1) {
+    return { kind: 'ambiguous' }
+  }
+  const hostId = [...hostIds][0] ?? LOCAL_EXECUTION_HOST_ID
+  return {
+    kind: 'resolved',
+    repo: rows[0] ?? null,
+    connectionId: getSshTargetIdForExecutionHost(hostId)
+  }
+}

--- a/src/main/runtime/worktree-scan-execution-host-routing.test.ts
+++ b/src/main/runtime/worktree-scan-execution-host-routing.test.ts
@@ -1,0 +1,214 @@
+// SSH ownership has two spellings on a repo row: the legacy `connectionId` field and the unified
+// `executionHostId: 'ssh:*'`. This suite pins the scan and the terminal launch that follows it for
+// the second spelling — the seam #17909 identified but could not test end to end (#11163).
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronMocks = vi.hoisted(() => {
+  const ipcMain = {
+    on: vi.fn(() => ipcMain),
+    removeListener: vi.fn(() => ipcMain),
+    emit: vi.fn(() => true)
+  }
+  return {
+    BrowserWindow: { fromId: vi.fn((): unknown => null) },
+    webContents: { fromId: vi.fn((): unknown => null) },
+    ipcMain,
+    app: { getPath: vi.fn(() => '/tmp'), isPackaged: false }
+  }
+})
+vi.mock('electron', () => electronMocks)
+
+const getSshGitProviderMock = vi.hoisted(() => vi.fn())
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock,
+  getSshGitProviderGeneration: vi.fn(() => 0),
+  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE: 'unavailable',
+  requireSshGitProvider: (connectionId: string) => getSshGitProviderMock(connectionId)
+}))
+
+const listWorktreesStrictMock = vi.hoisted(() => vi.fn())
+vi.mock('../git/worktree', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  listWorktreesStrict: listWorktreesStrictMock
+}))
+
+vi.mock('./repo-worktree-admin-fingerprint', () => ({
+  readRepoWorktreeAdminFingerprint: vi.fn(async () => null)
+}))
+
+import { OrcaRuntimeService } from './orca-runtime'
+
+const TARGET_ID = 'remote-1'
+const REPO_ID = 'repo-remote'
+const REPO_PATH = '/srv/app'
+const WORKTREE_PATH = '/srv/app-feature'
+const WORKTREE_ID = `${REPO_ID}::${WORKTREE_PATH}`
+const MAIN_WORKTREE_ID = `${REPO_ID}::${REPO_PATH}`
+
+function makeMeta(overrides: Record<string, unknown> = {}) {
+  return {
+    displayName: 'feature',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+/** One repo row owned by an SSH host, stamped with `executionHostId` only — no `connectionId`. */
+function makeStore(repoOverrides: Record<string, unknown>) {
+  const metaById: Record<string, ReturnType<typeof makeMeta>> = {
+    [WORKTREE_ID]: makeMeta({
+      hostId: `ssh:${TARGET_ID}`,
+      instanceId: '11111111-1111-4111-8111-111111111111'
+    }),
+    [MAIN_WORKTREE_ID]: makeMeta({
+      displayName: 'main',
+      hostId: `ssh:${TARGET_ID}`,
+      instanceId: '22222222-2222-4222-8222-222222222222'
+    })
+  }
+  const repos = [
+    {
+      id: REPO_ID,
+      path: REPO_PATH,
+      displayName: 'app',
+      badgeColor: 'blue',
+      addedAt: 1,
+      ...repoOverrides
+    }
+  ]
+  const store = {
+    getRepo: (id: string) => repos.find((repo) => repo.id === id),
+    getRepos: () => repos,
+    getAllWorktreeMeta: () => metaById,
+    getWorktreeMeta: (id: string) => metaById[id],
+    setWorktreeMeta: (id: string, meta: Record<string, unknown>) => {
+      metaById[id] = { ...(metaById[id] ?? makeMeta()), ...meta } as never
+      return metaById[id]
+    },
+    removeWorktreeMeta: () => {},
+    getAllWorktreeLineage: () => ({}),
+    getAllWorkspaceLineage: () => ({}),
+    removeWorktreeLineage: vi.fn(),
+    removeWorkspaceLineage: vi.fn(),
+    getGitHubCache: () => undefined as never,
+    getSettings: () => ({
+      workspaceDir: '/tmp/workspaces',
+      nestWorkspaces: false,
+      refreshLocalBaseRefOnWorktreeCreate: false,
+      branchPrefix: 'none',
+      branchPrefixCustom: ''
+    }),
+    getProjects: () => []
+  }
+  return store
+}
+
+type RuntimeInternals = {
+  listResolvedWorktrees: () => Promise<{ id: string; path: string; hostId?: string }[]>
+}
+
+function makeRuntime(repoOverrides: Record<string, unknown>): {
+  runtime: OrcaRuntimeService
+  list: () => Promise<{ id: string; path: string; hostId?: string }[]>
+} {
+  const runtime = new OrcaRuntimeService(makeStore(repoOverrides) as never)
+  return {
+    runtime,
+    list: () => (runtime as unknown as RuntimeInternals).listResolvedWorktrees()
+  }
+}
+
+describe('worktree scan execution-host routing', () => {
+  beforeEach(() => {
+    getSshGitProviderMock.mockReset()
+    listWorktreesStrictMock.mockReset()
+    listWorktreesStrictMock.mockResolvedValue([])
+  })
+
+  it('scans an executionHostId-only SSH repo over its SSH provider, not on the client', async () => {
+    const listWorktrees = vi.fn(async () => [
+      { path: REPO_PATH, head: 'abc', branch: 'main', isBare: false, isMainWorktree: true },
+      { path: WORKTREE_PATH, head: 'def', branch: 'feature', isBare: false, isMainWorktree: false }
+    ])
+    getSshGitProviderMock.mockReturnValue({ listWorktrees })
+    const { list } = makeRuntime({ executionHostId: `ssh:${TARGET_ID}` })
+
+    const worktrees = await list()
+
+    expect(getSshGitProviderMock).toHaveBeenCalledWith(TARGET_ID)
+    expect(listWorktrees).toHaveBeenCalledWith(REPO_PATH)
+    // A client-side `git worktree list` against a remote path is the silent-substitution failure.
+    expect(listWorktreesStrictMock).not.toHaveBeenCalled()
+    expect(worktrees.map((worktree) => worktree.path).sort()).toEqual([REPO_PATH, WORKTREE_PATH])
+    expect(worktrees.every((worktree) => worktree.hostId === `ssh:${TARGET_ID}`)).toBe(true)
+  })
+
+  it('routes the PTY of an executionHostId-only SSH worktree to its host', async () => {
+    getSshGitProviderMock.mockReturnValue({
+      listWorktrees: async () => [
+        { path: REPO_PATH, head: 'abc', branch: 'main', isBare: false, isMainWorktree: true },
+        {
+          path: WORKTREE_PATH,
+          head: 'def',
+          branch: 'feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]
+    })
+    const { runtime } = makeRuntime({ executionHostId: `ssh:${TARGET_ID}` })
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-1' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    } as never)
+
+    await runtime.createTerminal(`id:${WORKTREE_ID}`)
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: TARGET_ID, cwd: WORKTREE_PATH })
+    )
+  })
+
+  it('still routes a legacy connectionId-only SSH repo the same way', async () => {
+    getSshGitProviderMock.mockReturnValue({
+      listWorktrees: async () => [
+        { path: REPO_PATH, head: 'abc', branch: 'main', isBare: false, isMainWorktree: true },
+        {
+          path: WORKTREE_PATH,
+          head: 'def',
+          branch: 'feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]
+    })
+    const { runtime } = makeRuntime({ connectionId: TARGET_ID })
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-1' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    } as never)
+
+    await runtime.createTerminal(`id:${WORKTREE_ID}`)
+
+    expect(getSshGitProviderMock).toHaveBeenCalledWith(TARGET_ID)
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: TARGET_ID, cwd: WORKTREE_PATH })
+    )
+  })
+})

--- a/src/renderer/src/lib/connection-context.test.ts
+++ b/src/renderer/src/lib/connection-context.test.ts
@@ -525,6 +525,36 @@ describe('getConnectionIdFromState', () => {
     expect(getConnectionIdFromState(state, 'repo-ssh::/home/neil/repo-feature')).toBe('ssh-2')
   })
 
+  it('refuses to resolve a connection when duplicate repo rows disagree about the owning host', () => {
+    // Why (#17799): a repo id carried by two rows — one runtime-owned, one holding a
+    // client-owned SSH connection — must not hand the client's connection to the runtime.
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [
+        makeRepo({ id: 'repo-dup', executionHostId: 'runtime:env-a' }),
+        makeRepo({ id: 'repo-dup', connectionId: 'ssh-client' })
+      ],
+      worktreesByRepo: {}
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-dup::/home/neil/repo-feature')).toBeUndefined()
+  })
+
+  it('still resolves duplicate repo rows that agree about the owning host', () => {
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [
+        makeRepo({ id: 'repo-dup', connectionId: 'ssh-same' }),
+        makeRepo({ id: 'repo-dup', connectionId: 'ssh-same', path: '/home/neil/other' })
+      ],
+      worktreesByRepo: {}
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-dup::/home/neil/repo-feature')).toBe('ssh-same')
+  })
+
   it('indexes immutable worktree and repo snapshots once across repeated selector calls', () => {
     let worktreeIdReads = 0
     let repoIdReads = 0

--- a/src/renderer/src/lib/connection-context.test.ts
+++ b/src/renderer/src/lib/connection-context.test.ts
@@ -27,6 +27,27 @@ function makeRepo(overrides: Partial<Repo> & { id: string }): Repo {
   }
 }
 
+function makeWorktree(overrides: Partial<Worktree> & { id: string; repoId: string }): Worktree {
+  return {
+    path: '/srv/repo',
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'Workspace',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
 describe('getConnectionId', () => {
   afterEach(() => {
     useAppStore.setState(initialState, true)
@@ -553,6 +574,102 @@ describe('getConnectionIdFromState', () => {
     }
 
     expect(getConnectionIdFromState(state, 'repo-dup::/home/neil/repo-feature')).toBe('ssh-same')
+  })
+
+  it('never hands a worktree the SSH connection of a different host', () => {
+    // Why (#11163): two SSH hosts, one shared repo id. The worktree names `ssh:m4air`; the only
+    // indexed row belongs to `openclaw`. An id-only fallback after the host lookup misses answers
+    // with the wrong host's connection — "Reconnect openclaw" on an m4air pane, and file reads
+    // routed to a machine that never held the path.
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [makeRepo({ id: 'repo-shared', connectionId: 'openclaw' })],
+      worktreesByRepo: {
+        'repo-shared': [
+          makeWorktree({
+            id: 'repo-shared::/srv/repo',
+            repoId: 'repo-shared',
+            hostId: 'ssh:m4air'
+          })
+        ]
+      }
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-shared::/srv/repo')).toBe('m4air')
+  })
+
+  it('never hands a runtime-hosted worktree a client-owned SSH connection', () => {
+    // The row is on `ssh:openclaw`, not on the runtime host, so it says nothing about this
+    // worktree. This is the cross-host case, not the nested-SSH one below.
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [makeRepo({ id: 'repo-shared', connectionId: 'openclaw' })],
+      worktreesByRepo: {
+        'repo-shared': [
+          makeWorktree({
+            id: 'repo-shared::/srv/repo',
+            repoId: 'repo-shared',
+            hostId: 'runtime:awin'
+          })
+        ]
+      }
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-shared::/srv/repo')).toBeNull()
+  })
+
+  it('keeps a runtime host nested SSH target, which decides local readability', () => {
+    // `repoWithFetchedOwner` stamps the runtime host and spreads the nested target through. The
+    // pane pairs it with the environment (`selectRuntimeAwareSshStatus`) for reconnect state, and
+    // `isNativeChatTranscriptLocalReadable` treats a null here as "this client can read it" — so
+    // dropping it would send a transcript read to the wrong machine.
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [
+        makeRepo({
+          id: 'repo-runtime',
+          connectionId: 'ssh-nested',
+          executionHostId: 'runtime:env-a'
+        })
+      ],
+      worktreesByRepo: {
+        'repo-runtime': [
+          makeWorktree({
+            id: 'repo-runtime::/srv/repo',
+            repoId: 'repo-runtime',
+            hostId: 'runtime:env-a',
+            runtimeOwnerEnvironmentId: 'env-a'
+          })
+        ]
+      }
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-runtime::/srv/repo')).toBe('ssh-nested')
+  })
+
+  it('resolves the row on the SSH host the worktree names when both hosts carry the id', () => {
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [
+        makeRepo({ id: 'repo-shared', connectionId: 'openclaw' }),
+        makeRepo({ id: 'repo-shared', connectionId: 'm4air', path: '/srv/repo' })
+      ],
+      worktreesByRepo: {
+        'repo-shared': [
+          makeWorktree({
+            id: 'repo-shared::/srv/repo',
+            repoId: 'repo-shared',
+            hostId: 'ssh:m4air'
+          })
+        ]
+      }
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-shared::/srv/repo')).toBe('m4air')
   })
 
   it('indexes immutable worktree and repo snapshots once across repeated selector calls', () => {

--- a/src/renderer/src/lib/connection-owner-resolution.ts
+++ b/src/renderer/src/lib/connection-owner-resolution.ts
@@ -1,5 +1,10 @@
 import type { AppState } from '@/store/types'
-import { getIndexedRepoMap, getIndexedWorktreeMap } from '@/store/worktree-repo-index'
+import {
+  findIndexedRepoOwnerForHost,
+  resolveIndexedRepoOwner,
+  resolveIndexedWorktreeOwner
+} from './worktree-runtime-owner-index'
+import { getRepoSshConnectionId, normalizeExecutionHostId } from '../../../shared/execution-host'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
@@ -60,10 +65,32 @@ export function getConnectionIdFromState(
   }
   // Why: owner resolution runs from retained Zustand selectors, so unrelated
   // store writes must not flatten every worktree or scan every repository.
-  const worktree = getIndexedWorktreeMap(state.worktreesByRepo).get(worktreeId)
+  const worktreeResolution = resolveIndexedWorktreeOwner(state.worktreesByRepo, worktreeId)
+  if (worktreeResolution.kind === 'ambiguous') {
+    // Why (#17799): rows that disagree about the owner cannot name a connection.
+    // `undefined` is this module's documented "cannot determine the host" answer;
+    // collapsing it to `null` would authorize a local read of a remote path.
+    return undefined
+  }
+  const worktree = worktreeResolution.kind === 'resolved' ? worktreeResolution.owner : undefined
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = getIndexedRepoMap(state.repos).get(repoId)
-  return repo ? (repo.connectionId ?? null) : undefined
+  // Why (#17799): take the connection off the same host record the rest of owner
+  // resolution used. A host-blind, last-wins repo lookup can pair a runtime owner
+  // with a client-owned SSH connection the runtime has never heard of.
+  const worktreeHostId = normalizeExecutionHostId(worktree?.hostId)
+  const hostScopedRepo = worktreeHostId
+    ? findIndexedRepoOwnerForHost(state.repos, repoId, worktreeHostId)
+    : null
+  if (hostScopedRepo) {
+    return getRepoSshConnectionId(hostScopedRepo)
+  }
+  const repoResolution = resolveIndexedRepoOwner(state.repos, repoId)
+  if (repoResolution.kind === 'ambiguous') {
+    return undefined
+  }
+  return repoResolution.kind === 'resolved'
+    ? getRepoSshConnectionId(repoResolution.owner)
+    : undefined
 }
 
 export function getConnectionIdForFileFromState(

--- a/src/renderer/src/lib/connection-owner-resolution.ts
+++ b/src/renderer/src/lib/connection-owner-resolution.ts
@@ -4,7 +4,7 @@ import {
   resolveIndexedRepoOwner,
   resolveIndexedWorktreeOwner
 } from './worktree-runtime-owner-index'
-import { getRepoSshConnectionId, normalizeExecutionHostId } from '../../../shared/execution-host'
+import { resolveWorktreeExecutionHost } from '../../../shared/worktree-execution-host-resolution'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
@@ -74,23 +74,16 @@ export function getConnectionIdFromState(
   }
   const worktree = worktreeResolution.kind === 'resolved' ? worktreeResolution.owner : undefined
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  // Why (#17799): take the connection off the same host record the rest of owner
-  // resolution used. A host-blind, last-wins repo lookup can pair a runtime owner
-  // with a client-owned SSH connection the runtime has never heard of.
-  const worktreeHostId = normalizeExecutionHostId(worktree?.hostId)
-  const hostScopedRepo = worktreeHostId
-    ? findIndexedRepoOwnerForHost(state.repos, repoId, worktreeHostId)
-    : null
-  if (hostScopedRepo) {
-    return getRepoSshConnectionId(hostScopedRepo)
-  }
-  const repoResolution = resolveIndexedRepoOwner(state.repos, repoId)
-  if (repoResolution.kind === 'ambiguous') {
-    return undefined
-  }
-  return repoResolution.kind === 'resolved'
-    ? getRepoSshConnectionId(repoResolution.owner)
-    : undefined
+  // Why (#17799, #11163): one rule, shared with main's launch scope. The renderer's contribution is
+  // only the memoized index — unrelated store writes must not rescan every repository.
+  const resolution = resolveWorktreeExecutionHost(
+    {
+      byId: (id) => resolveIndexedRepoOwner(state.repos, id),
+      byHost: (id, hostId) => findIndexedRepoOwnerForHost(state.repos, id, hostId)
+    },
+    { repoId, hostId: worktree?.hostId ?? null }
+  )
+  return resolution.kind === 'resolved' ? resolution.connectionId : undefined
 }
 
 export function getConnectionIdForFileFromState(

--- a/src/renderer/src/lib/workspace-session-host-persistence.ts
+++ b/src/renderer/src/lib/workspace-session-host-persistence.ts
@@ -9,6 +9,7 @@ import {
   parseExecutionHostId,
   type ExecutionHostId
 } from '../../../shared/execution-host'
+import { workspaceSessionPartitionHostId } from '../../../shared/workspace-session-partition-owner'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 import {
@@ -187,8 +188,9 @@ export function buildHostSessionRouting(state: HostPersistenceState): HostSessio
     if (!repoHostId) {
       return LOCAL_EXECUTION_HOST_ID
     }
-    const parsed = parseExecutionHostId(repoHostId)
-    return parsed?.kind === 'runtime' ? parsed.id : LOCAL_EXECUTION_HOST_ID
+    // Why: SSH-owned worktrees stay in the 'local' partition here while the runtime writes them to
+    // `ssh:<targetId>`; the shared owner map records that divergence (#12723).
+    return workspaceSessionPartitionHostId(repoHostId, 'local-partition')
   }
   return { hostIdByWorktreeId, claims }
 }

--- a/src/shared/execution-host.test.ts
+++ b/src/shared/execution-host.test.ts
@@ -4,7 +4,9 @@ import {
   LOCAL_EXECUTION_HOST_ID,
   getLocalExecutionHostLabel,
   getRepoExecutionHostId,
+  getRepoSshConnectionId,
   getSettingsFocusedExecutionHostId,
+  getSshTargetIdForExecutionHost,
   getWorktreeExecutionHostId,
   normalizeExecutionHostOrder,
   normalizeExecutionHostScope,
@@ -111,6 +113,41 @@ describe('execution host identity', () => {
       getWorktreeExecutionHostId({}, { connectionId: 'repo-owner' }, 'runtime:focused-host')
     ).toBe('ssh:repo-owner')
     expect(getWorktreeExecutionHostId({}, {}, 'runtime:focused-host')).toBe('runtime:focused-host')
+  })
+
+  // These two look interchangeable and are not: one answers "which SSH target holds this row's
+  // files", the other "which connection may this client dial". They agree except on a runtime
+  // host, where a nested target exists but is not dialable from here — so the pane that reads it
+  // needs one answer and the PTY route needs the other.
+  it('distinguishes the SSH target holding a row from the connection this client may dial', () => {
+    // Legacy spelling: `connectionId` alone *is* the host, so both answers agree.
+    expect(getRepoSshConnectionId({ connectionId: 'openclaw' })).toBe('openclaw')
+    expect(getSshTargetIdForExecutionHost('ssh:openclaw')).toBe('openclaw')
+    // Unified spelling, no legacy field.
+    expect(getRepoSshConnectionId({ executionHostId: 'ssh:m4air' })).toBe('m4air')
+
+    // A row declaring itself local hands out no SSH connection, whatever the legacy field says:
+    // `local` has no SSH namespace to nest in, so the two spellings are contradicting each other.
+    expect(
+      getRepoSshConnectionId({ executionHostId: 'local', connectionId: 'openclaw' })
+    ).toBeNull()
+
+    // A runtime host does have its own namespace, and a nested target appears only in this field.
+    // Dropping it would make a nested-SSH workspace read as local — which is what decides whether
+    // this client tries to read the transcript itself.
+    expect(
+      getRepoSshConnectionId({ executionHostId: 'runtime:env-a', connectionId: 'ssh-nested' })
+    ).toBe('ssh-nested')
+    // ...but that id is not dialable from this client alone, so the routing answer stays null.
+    expect(getSshTargetIdForExecutionHost('runtime:env-a')).toBeNull()
+    // A runtime host with no nested target is simply not on SSH.
+    expect(getRepoSshConnectionId({ executionHostId: 'runtime:env-a' })).toBeNull()
+
+    // An ephemeral-VM target is an ordinary client-dialable target and stays an `ssh:` host.
+    expect(getRepoSshConnectionId({ connectionId: 'runtime-ssh-vm-1' })).toBe('runtime-ssh-vm-1')
+    expect(getRepoExecutionHostId({ connectionId: 'runtime-ssh-vm-1' })).toBe(
+      'ssh:runtime-ssh-vm-1'
+    )
   })
 
   it('derives focused host compatibility from active runtime settings', () => {

--- a/src/shared/execution-host.ts
+++ b/src/shared/execution-host.ts
@@ -166,6 +166,24 @@ export function getRepoExecutionHostId(
   return connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID
 }
 
+// Why: SSH ownership has two spellings on a repo row — the legacy `connectionId`
+// field and the unified `executionHostId`. Routing that reads the raw field answers
+// "local" for a row that only carries `ssh:<target>`, which runs a remote operation
+// on the client. Resolve the host first, then read the connection off it.
+export function getRepoSshConnectionId(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): string | null {
+  const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
+  return parsed?.kind === 'ssh' ? parsed.targetId : null
+}
+
+export function getSshTargetIdForExecutionHost(
+  executionHostId: string | null | undefined
+): string | null {
+  const parsed = parseExecutionHostId(executionHostId)
+  return parsed?.kind === 'ssh' ? parsed.targetId : null
+}
+
 export function getWorktreeExecutionHostId(
   worktree: Pick<Worktree, 'hostId'>,
   repo: Pick<Repo, 'connectionId' | 'executionHostId'> | undefined,

--- a/src/shared/execution-host.ts
+++ b/src/shared/execution-host.ts
@@ -166,29 +166,42 @@ export function getRepoExecutionHostId(
   return connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID
 }
 
-// Why: SSH ownership has two spellings on a repo row — the legacy `connectionId`
-// field and the unified `executionHostId`. Routing that reads the raw field answers
-// "local" for a row that only carries `ssh:<target>`, which runs a remote operation
-// on the client. Resolve the host first, then read the connection off it.
-//
-// Why the fallback: a row whose execution host is a *runtime* can still reach a nested
-// SSH target, and that target only ever appears in `connectionId`. Returning null for
-// those rows answers "local" for a nested-SSH worktree — the same defect in reverse.
-export function getRepoSshConnectionId(
-  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
-): string | null {
-  const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
-  if (parsed?.kind === 'ssh') {
-    return parsed.targetId
-  }
-  return normalizeHostPart(repo.connectionId) ?? null
-}
-
 export function getSshTargetIdForExecutionHost(
   executionHostId: string | null | undefined
 ): string | null {
   const parsed = parseExecutionHostId(executionHostId)
   return parsed?.kind === 'ssh' ? parsed.targetId : null
+}
+
+// Why: SSH ownership has two spellings on a repo row — the legacy `connectionId`
+// field and the unified `executionHostId`. Routing that reads the raw field answers
+// "local" for a row that only carries `ssh:<target>`, which runs a remote operation
+// on the client. Resolve the host first, then read the connection off it.
+//
+// The two hosts that are not themselves SSH are not the same case:
+//
+//   - `local` has no SSH namespace to nest in, so a surviving `connectionId` is a row
+//     contradicting itself — the shape main's `resolveRepoOwnershipEvidence` calls
+//     `contradictory`. Answering with it hands out an SSH connection for a row that declares
+//     itself local.
+//   - `runtime:<env>` is a different machine with its own SSH targets, and a nested one appears
+//     only in this field (`repoWithFetchedOwner` spreads it through). It is not dialable on its
+//     own, but it is addressable as the pair (environmentId, targetId) — which is how the
+//     renderer reads it, recovering the environment from the worktree and looking the target up
+//     inside it (`selectRuntimeAwareSshStatus`). Dropping it makes a nested-SSH workspace read
+//     as local, which is what decides whether a transcript is read on this client.
+//
+// So this answers "which SSH target holds this row's files", not "which connection may this
+// client dial". `getSshTargetIdForExecutionHost` answers the latter; callers routing a
+// client-local PTY or Git provider want that one instead.
+export function getRepoSshConnectionId(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): string | null {
+  const host = parseExecutionHostId(getRepoExecutionHostId(repo))
+  if (host?.kind === 'ssh') {
+    return host.targetId
+  }
+  return host?.kind === 'runtime' ? normalizeHostPart(repo.connectionId) : null
 }
 
 export function getWorktreeExecutionHostId(

--- a/src/shared/execution-host.ts
+++ b/src/shared/execution-host.ts
@@ -170,11 +170,18 @@ export function getRepoExecutionHostId(
 // field and the unified `executionHostId`. Routing that reads the raw field answers
 // "local" for a row that only carries `ssh:<target>`, which runs a remote operation
 // on the client. Resolve the host first, then read the connection off it.
+//
+// Why the fallback: a row whose execution host is a *runtime* can still reach a nested
+// SSH target, and that target only ever appears in `connectionId`. Returning null for
+// those rows answers "local" for a nested-SSH worktree — the same defect in reverse.
 export function getRepoSshConnectionId(
   repo: Pick<Repo, 'connectionId' | 'executionHostId'>
 ): string | null {
   const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
-  return parsed?.kind === 'ssh' ? parsed.targetId : null
+  if (parsed?.kind === 'ssh') {
+    return parsed.targetId
+  }
+  return normalizeHostPart(repo.connectionId) ?? null
 }
 
 export function getSshTargetIdForExecutionHost(

--- a/src/shared/workspace-session-partition-owner.test.ts
+++ b/src/shared/workspace-session-partition-owner.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { workspaceSessionPartitionHostId } from './workspace-session-partition-owner'
+
+// Why (#12723): the renderer and the runtime used two independent owner maps for the same
+// worktree's session state. They now share one function, so the divergence is a single argument
+// and cannot drift further. Behaviour on both sides is unchanged.
+describe('workspaceSessionPartitionHostId', () => {
+  it('keeps runtime worktrees in their own partition on both sides', () => {
+    expect(workspaceSessionPartitionHostId('runtime:env-a', 'local-partition')).toBe(
+      'runtime:env-a'
+    )
+    expect(workspaceSessionPartitionHostId('runtime:env-a', 'host-partition')).toBe('runtime:env-a')
+  })
+
+  it('keeps local worktrees local on both sides', () => {
+    expect(workspaceSessionPartitionHostId('local', 'local-partition')).toBe('local')
+    expect(workspaceSessionPartitionHostId('local', 'host-partition')).toBe('local')
+  })
+
+  it('records the SSH divergence as the only difference between the two models', () => {
+    expect(workspaceSessionPartitionHostId('ssh:devbox', 'local-partition')).toBe('local')
+    expect(workspaceSessionPartitionHostId('ssh:devbox', 'host-partition')).toBe('ssh:devbox')
+  })
+
+  it('falls back to the local partition for unparseable host ids', () => {
+    expect(workspaceSessionPartitionHostId(null, 'host-partition')).toBe('local')
+    expect(workspaceSessionPartitionHostId('nonsense', 'host-partition')).toBe('local')
+  })
+})

--- a/src/shared/workspace-session-partition-owner.ts
+++ b/src/shared/workspace-session-partition-owner.ts
@@ -1,0 +1,39 @@
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from './execution-host'
+
+/**
+ * Where an SSH-owned worktree's durable session state lives.
+ *
+ * This is the single axis on which the renderer and the main-process runtime disagree today
+ * (stablyai/orca#12723). Both sides now compute their partition through this function so the
+ * divergence is one argument in one place instead of two independently drifting owner maps:
+ *
+ * - `local-partition` — the renderer's shipping model. SSH worktrees keep their session state in
+ *   the `local` partition; partitioning them would double-own the data.
+ * - `host-partition` — the runtime's shipping model (#12671). Pane retirement, windowless PTY
+ *   handoff and orchestration fences read-modify-write `ssh:<targetId>`.
+ *
+ * Both partitions hold real data written by shipping builds, so neither side can simply adopt the
+ * other's answer: flipping a resolver orphans whichever store it stops reading. Converging needs a
+ * read-both transition (generalize `workspaceSessionPartitionIdsForHost`) and should converge on
+ * `host-partition`, since Orca Remote — SSH's successor — is already partitioned as `runtime:*`.
+ * Until then this function preserves today's behaviour exactly on both sides.
+ */
+export type WorkspaceSessionSshOwnership = 'local-partition' | 'host-partition'
+
+export function workspaceSessionPartitionHostId(
+  executionHostId: string | null | undefined,
+  sshOwnership: WorkspaceSessionSshOwnership
+): ExecutionHostId {
+  const parsed = parseExecutionHostId(executionHostId)
+  if (parsed?.kind === 'runtime') {
+    return parsed.id
+  }
+  if (parsed?.kind === 'ssh') {
+    return sshOwnership === 'host-partition' ? parsed.id : LOCAL_EXECUTION_HOST_ID
+  }
+  return LOCAL_EXECUTION_HOST_ID
+}

--- a/src/shared/worktree-execution-host-resolution.test.ts
+++ b/src/shared/worktree-execution-host-resolution.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createRepoRowExecutionHostLookup,
+  resolveWorktreeExecutionHost
+} from './worktree-execution-host-resolution'
+
+// Why (#11163, #17799): main's terminal launch scope and the renderer's owner index both answer
+// "which host does this worktree execute on". They used to answer it separately, and disagreed —
+// main derived the host from the worktree while the renderer fell back to an id-only repo lookup,
+// so a pane on one SSH host was routed to another. One rule now, exercised here directly.
+const resolve = (
+  repos: readonly { id: string; connectionId?: string; executionHostId?: string }[],
+  worktree: { repoId: string; hostId?: string | null }
+): ReturnType<typeof resolveWorktreeExecutionHost> =>
+  resolveWorktreeExecutionHost(createRepoRowExecutionHostLookup(repos as never), worktree) as never
+
+describe('resolveWorktreeExecutionHost', () => {
+  describe('the worktree names its own host', () => {
+    it('routes to that host even when the only row belongs to a different SSH host', () => {
+      // The reproduced defect: `ssh:m4air` worktree, sole row on `openclaw`.
+      expect(
+        resolve([{ id: 'r', connectionId: 'openclaw' }], { repoId: 'r', hostId: 'ssh:m4air' })
+      ).toEqual({ kind: 'resolved', hostId: 'ssh:m4air', connectionId: 'm4air', owner: null })
+    })
+
+    it('answers before the repo row hydrates, because the host is not a guess', () => {
+      // Deliberate change from "unresolved": #6648 blocks destructive ops while the *host* is
+      // unknown. A worktree naming `ssh:m4air` is not that case — the repo row adds nothing the
+      // host id has not already settled, and refusing here stalls a remote pane on hydration.
+      expect(resolve([], { repoId: 'r', hostId: 'ssh:m4air' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:m4air',
+        connectionId: 'm4air',
+        owner: null
+      })
+    })
+
+    it('picks the row on that host when both SSH hosts carry the id', () => {
+      const openclaw = { id: 'r', connectionId: 'openclaw' }
+      const m4air = { id: 'r', connectionId: 'm4air' }
+      expect(resolve([openclaw, m4air], { repoId: 'r', hostId: 'ssh:m4air' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:m4air',
+        connectionId: 'm4air',
+        owner: m4air
+      })
+      expect(resolve([openclaw, m4air], { repoId: 'r', hostId: 'ssh:openclaw' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:openclaw',
+        connectionId: 'openclaw',
+        owner: openclaw
+      })
+    })
+
+    it('matches a row that names the host in either spelling', () => {
+      const stamped = { id: 'r', executionHostId: 'ssh:m4air' }
+      expect(resolve([stamped], { repoId: 'r', hostId: 'ssh:m4air' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:m4air',
+        connectionId: 'm4air',
+        owner: stamped
+      })
+    })
+
+    it('takes no connection from a row on a different host, whatever this host is', () => {
+      // The row lives on `ssh:openclaw`; neither a local nor a runtime worktree may borrow it.
+      for (const hostId of ['local', 'runtime:env-a']) {
+        expect(resolve([{ id: 'r', connectionId: 'openclaw' }], { repoId: 'r', hostId })).toEqual({
+          kind: 'resolved',
+          hostId,
+          connectionId: null,
+          owner: null
+        })
+      }
+    })
+
+    it('reads a runtime host nested SSH target off the row on that same host', () => {
+      // Not a cross-host borrow: this row *is* the runtime host's row, and the nested target
+      // appears nowhere else. Nulling it makes the workspace read as local, which decides whether
+      // this client tries to read a transcript that lives on the nested host.
+      const nested = { id: 'r', connectionId: 'ssh-nested', executionHostId: 'runtime:env-a' }
+      expect(resolve([nested], { repoId: 'r', hostId: 'runtime:env-a' })).toEqual({
+        kind: 'resolved',
+        hostId: 'runtime:env-a',
+        connectionId: 'ssh-nested',
+        owner: nested
+      })
+    })
+
+    it('gives a local row no SSH connection even when it carries a stale one', () => {
+      const contradictory = { id: 'r', connectionId: 'openclaw', executionHostId: 'local' }
+      expect(resolve([contradictory], { repoId: 'r', hostId: 'local' })).toEqual({
+        kind: 'resolved',
+        hostId: 'local',
+        connectionId: null,
+        owner: contradictory
+      })
+    })
+  })
+
+  describe('the worktree names no host', () => {
+    it('resolves from the sole row, in either spelling', () => {
+      const legacy = { id: 'r', connectionId: 'openclaw' }
+      expect(resolve([legacy], { repoId: 'r' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:openclaw',
+        connectionId: 'openclaw',
+        owner: legacy
+      })
+      const stamped = { id: 'r', executionHostId: 'ssh:m4air' }
+      expect(resolve([stamped], { repoId: 'r' })).toEqual({
+        kind: 'resolved',
+        hostId: 'ssh:m4air',
+        connectionId: 'm4air',
+        owner: stamped
+      })
+      const local = { id: 'r' }
+      expect(resolve([local], { repoId: 'r' })).toEqual({
+        kind: 'resolved',
+        hostId: 'local',
+        connectionId: null,
+        owner: local
+      })
+    })
+
+    it('refuses when rival rows disagree about the host, including two SSH hosts', () => {
+      expect(
+        resolve(
+          [
+            { id: 'r', connectionId: 'openclaw' },
+            { id: 'r', connectionId: 'm4air' }
+          ],
+          {
+            repoId: 'r'
+          }
+        )
+      ).toEqual({ kind: 'unresolved', reason: 'ambiguous' })
+      expect(
+        resolve([{ id: 'r', connectionId: 'openclaw' }, { id: 'r' }], { repoId: 'r' })
+      ).toEqual({ kind: 'unresolved', reason: 'ambiguous' })
+    })
+
+    it('treats the two spellings of one host as agreement, not conflict', () => {
+      expect(
+        resolve(
+          [
+            { id: 'r', connectionId: 'm4air' },
+            { id: 'r', executionHostId: 'ssh:m4air' }
+          ],
+          { repoId: 'r' }
+        )
+      ).toMatchObject({ kind: 'resolved', hostId: 'ssh:m4air', connectionId: 'm4air' })
+    })
+
+    it('reports an unknown owner distinctly from a conflicting one', () => {
+      expect(resolve([], { repoId: 'r' })).toEqual({ kind: 'unresolved', reason: 'unknown' })
+    })
+  })
+
+  it('ignores an unparseable host id rather than treating it as a host', () => {
+    const row = { id: 'r', connectionId: 'openclaw' }
+    expect(resolve([row], { repoId: 'r', hostId: 'ssh:' })).toMatchObject({
+      kind: 'resolved',
+      connectionId: 'openclaw'
+    })
+  })
+})

--- a/src/shared/worktree-execution-host-resolution.ts
+++ b/src/shared/worktree-execution-host-resolution.ts
@@ -1,0 +1,109 @@
+/**
+ * One rule for "which host does this worktree execute on, and what connection routes there".
+ *
+ * Main and the renderer both have to answer it — the terminal launch scope picks a PTY route from
+ * it, the renderer picks a file-read route and the reconnect affordance from it — so the rule lives
+ * here instead of being re-derived per side. Two re-derivations already disagreed: main answered
+ * from the worktree's own host while the renderer fell back to an id-only repo lookup, so a pane on
+ * `ssh:m4air` was offered "Reconnect openclaw" and read its files off openclaw (#11163).
+ *
+ * `unresolved` is a distinct answer, never "local": the same repo id can exist on a local, an SSH
+ * and a runtime host at once, and loss of a usable answer must fail closed rather than authorize a
+ * client-side read of a remote path (#6648, #17799).
+ */
+
+import type { Repo } from './repo-types'
+import {
+  getRepoExecutionHostId,
+  getRepoSshConnectionId,
+  getSshTargetIdForExecutionHost,
+  normalizeExecutionHostId,
+  type ExecutionHostId
+} from './execution-host'
+
+export type ExecutionHostOwnerRow = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+
+export type ExecutionHostOwnerMatch<T> =
+  | { kind: 'resolved'; owner: T }
+  | { kind: 'missing' }
+  | { kind: 'ambiguous' }
+
+/**
+ * How a caller finds repo rows. Main scans the store array; the renderer answers from a
+ * WeakMap-memoized index because owner resolution runs inside retained selectors. That is a
+ * performance difference, not a different rule.
+ */
+export type ExecutionHostOwnerLookup<T extends ExecutionHostOwnerRow> = {
+  /** The row for `repoId`, or `ambiguous` when rival rows disagree about the owning host. */
+  byId: (repoId: string) => ExecutionHostOwnerMatch<T>
+  /** The row for `repoId` on exactly `hostId`, or null when that host carries no row. */
+  byHost: (repoId: string, hostId: ExecutionHostId) => T | null
+}
+
+export type WorktreeExecutionHostResolution<T extends ExecutionHostOwnerRow> =
+  | {
+      kind: 'resolved'
+      hostId: ExecutionHostId
+      /**
+       * The SSH target whose filesystem holds this workspace — for a `runtime:` host, its nested
+       * target, addressable only as the pair with `hostId`. Callers deciding what *this client*
+       * may dial (a PTY route, a Git provider) must use `getSshTargetIdForExecutionHost(hostId)`
+       * instead; this field can name a host the client cannot reach on its own.
+       */
+      connectionId: string | null
+      /** Display metadata only. The decisions are `hostId` / `connectionId`. */
+      owner: T | null
+    }
+  | { kind: 'unresolved'; reason: 'ambiguous' | 'unknown' }
+
+export function resolveWorktreeExecutionHost<T extends ExecutionHostOwnerRow>(
+  lookup: ExecutionHostOwnerLookup<T>,
+  worktree: { repoId: string; hostId?: string | null }
+): WorktreeExecutionHostResolution<T> {
+  const worktreeHostId = normalizeExecutionHostId(worktree.hostId)
+  if (worktreeHostId) {
+    // The worktree names its own host, which outranks every repo row. A row on a *different* host
+    // is not evidence about this one — falling back to it is the cross-host leak: one SSH host's
+    // pane routed to another. A row on *this* host still is evidence, and is the only place a
+    // runtime's nested SSH target appears.
+    const owner = lookup.byHost(worktree.repoId, worktreeHostId)
+    return {
+      kind: 'resolved',
+      hostId: worktreeHostId,
+      connectionId:
+        getSshTargetIdForExecutionHost(worktreeHostId) ??
+        (owner ? getRepoSshConnectionId(owner) : null),
+      owner
+    }
+  }
+  const match = lookup.byId(worktree.repoId)
+  if (match.kind !== 'resolved') {
+    return { kind: 'unresolved', reason: match.kind === 'ambiguous' ? 'ambiguous' : 'unknown' }
+  }
+  return {
+    kind: 'resolved',
+    hostId: getRepoExecutionHostId(match.owner),
+    connectionId: getRepoSshConnectionId(match.owner),
+    owner: match.owner
+  }
+}
+
+/** Array-backed lookup for callers holding the whole repo list (main's store). */
+export function createRepoRowExecutionHostLookup<T extends ExecutionHostOwnerRow>(
+  repos: readonly T[]
+): ExecutionHostOwnerLookup<T> {
+  const rowsFor = (repoId: string): T[] => repos.filter((repo) => repo.id === repoId)
+  return {
+    byId: (repoId) => {
+      const rows = rowsFor(repoId)
+      if (rows.length === 0) {
+        return { kind: 'missing' }
+      }
+      const hostIds = new Set(rows.map((repo) => getRepoExecutionHostId(repo)))
+      const owner = rows[0]
+      return hostIds.size > 1 || !owner ? { kind: 'ambiguous' } : { kind: 'resolved', owner }
+    },
+    byHost: (repoId, hostId) =>
+      rowsFor(repoId).find((repo) => getRepoExecutionHostId(repo) === hostId) ?? null
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​818 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​814 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​136 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​52 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​84 |

<!-- /orca-pr-loc -->

> Stacked on #17909. Review that first; retarget to `main` once it merges.

Closes four of the five residual host-blind sites #17909 identified and left. The unifying rule throughout: resolve the **execution host** via `getRepoExecutionHostId` / `getWorktreeExecutionHostId`, never the raw `connectionId` field — SSH ownership has two spellings, and code reading only one is wrong for half the rows.

## Site 1 — the worktree scan (this is the one that mattered)

`orca-runtime-refresh-repo-worktree-scan.ts` keyed on `repo.connectionId`, so a repo stamped `executionHostId: 'ssh:*'` without a `connectionId` never resolved a remote worktree at all. **Its caller mattered as much as the sites #17909 listed:** an `ssh:*`-only row was also getting a *local* project runtime and a `local:default` scan cache key — so the scan never re-ran when the SSH provider generation changed — and a failed remote scan was cached as authoritative.

This unblocked the end-to-end proof #17909 attempted and abandoned:

```
BEFORE  × scans an executionHostId-only SSH repo over its SSH provider, not on the client
          expected "vi.fn()" to be called with [ 'remote-1' ]; Number of calls: 0
        × routes the PTY of an executionHostId-only SSH worktree to its host
          Error: selector_not_found
            at OrcaRuntimeService.resolveWorktreeSelector ...:105
        Tests  2 failed | 1 passed (3)
AFTER   Tests  3 passed (3)
```

That `selector_not_found` is exactly the blocker #17909 described. A third case (legacy `connectionId`-only) proves the fix is not just "route everything remotely".

## Site 2 — managed-worktree create, and the `isFolderRepo` question

`:90` now branches on the resolved SSH connection. The remote pipeline reads `repo.connectionId!` at a dozen depths, so rather than teach each one the second spelling, the row is normalised once at the branch.

**On `isFolderRepo` returning before the check — it is a real bug, but narrower than it looks.** The create itself is host-agnostic: a folder workspace is a registration, not a filesystem operation, and its terminals route through the resolver #17909 fixed. The actual leak is one line — `markTrusted` was hard-wired to `markLocalWorkspaceTrustedForAgent`, so a folder repo on an SSH host wrote Codex/Cursor/Copilot trust into the **client's** config keyed by a **remote** path. The remote agent never sees the trust; the client gets a bogus entry.

```
BEFORE  × creates on the SSH host for a repo stamped executionHostId only
          Error: local_worktree_create_ran_for_remote_repo
        × marks a folder workspace trusted on its SSH host, not on the client
        Tests  2 failed | 2 passed (4)
AFTER   Tests  4 passed (4)
```

## Site 3 — `runtimeRepoMatchesExecutionHost`

A row naming a host in *either* spelling now matches only that host, while a genuinely host-less legacy row stays adoptable — the documented case the old shape existed to protect.

```
BEFORE  × matches an unstamped SSH repo against its own host — expected false to be true
AFTER   Tests  7 passed (7)
```

## Site 4 — `assertHostIsSupported`, split, and the split is the finding

The two operations behind that one guard are not the same:

- **`setupExistingFolder` now routes** `ssh:*` through `addRemoteRepoFromPath` — the exact function the desktop IPC handler in the same process already uses.
- **`setupClone` still refuses**, with an accurate message. There is no remote clone anywhere in this process: `cloneRepo` runs `git clone` on the client and there is no `projectHostSetups:clone` IPC handler at all. Accepting `ssh:*` would have registered the client's copy as the host's repo. The old message was wrong for both — false for existing-folder, misleading for clone.

Two consequences handled rather than left:

1. An existing spec pinned the old wording; retargeted at what it actually protects (`spawnSpy` not called, `repos` empty), which still holds.
2. **A regression this PR introduced and closed:** making `--host ssh:*` reachable made relative CLI paths newly reachable there, and `resolveRepoPathArgument` only guards when the *client* is remote — so `--host ssh:x --path ./orca` sent the client's cwd as the remote path. Guarded, with its own fail-before test showing that literal value.

Also fixed the mirror-image blindness in `addRemoteRepoFromPath`'s dedupe, since the runtime now routes through it.

## Site 5 — `getRepo(id)`: handed off with data, not attempted

Of the 45 non-test `.getRepo(` call sites:

- **30 host-deciding** — the row picks an SSH vs local git/filesystem provider, a PTY route, a WSL distro, a trust write, or a worktree create target. Worst: `orca-runtime-persist-headless-terminal-title.ts:168` (every runtime git exec) and `:189`; `register-worktree-create-handlers.ts:40`; `register-worktree-catalog-handlers.ts:170`.
- **3 destructive** — `worktree-removal-repo-owner.ts:36`, `folder-repo-git-upgrade.ts:121`, `first-work-folder-rename.ts:42` (irreversible `moveWorktree`).
- 5 metadata-only, 7 existence checks — safe.

That is a store-contract change needing a host argument or an ambiguity refusal threaded through 33 real decision sites, several destructive. Doing it alongside four other fixes would make all five unreviewable. Two host-safe patterns already exist to migrate onto: `resolveWorktreeLaunchHost`, and the `getRepoExecutionHostId`-filtered `getRepos()` used correctly at `base-ref-query-handlers.ts:198-203` and two other sites. Suggested order: the destructive three first (cheap to fail closed), then the git/filesystem target resolvers, then the rest.

## Verification

| Check | Result |
|---|---|
| 4 new/changed test files | 18 passed |
| `src/main/runtime` + `ipc` + `persistence` | 965 files, **10380 passed** \| 21 skipped |
| `src/cli` | 107 files, **1019 passed** |
| `orca-runtime.test.ts` | 1220 passed \| 1 skipped |
| `pnpm tc:node`, `pnpm tc:cli` | exit 0 |
| `check:code-quality:changed` | 0 new findings across 24 files |

## Is #11163 closable?

**Not yet — but the gap is now one named thing instead of five.** Sites 1-4 have fail-before/pass-after tests, and site 1 is closed *provably*. What remains is site 5, plus one residual worth naming: `runtime-worktree-agent-startup.ts:60` still branches agent detection on raw `repo.connectionId` — same shape, and it belongs with the site-5 sweep rather than bolted on here.

Refs #11163

---

## Update — retitled, rebased, and two more twins closed

**Retitled.** The old title, "close the remaining host-blind seams behind #11163", was not what this
does. Measured on `src/main` + `src/renderer`, non-test, raw `repo.connectionId` / `repo?.connectionId`
reads: **532 on `main`, 519 after both PRs — 13 converted, ~2%.** The body already admitted this
("Not yet — but the gap is now one named thing instead of five"); the title now says it too.

Rebased onto current `main` and onto the reworked #17909. `en.json` verified byte-identical to
`main` (the rebase-loss check, since a stale branch copy silently dropping keys is how three reverts
happened in this sweep).

### Inherited from #17909: one shared resolver

`getRepoSshConnectionId` no longer fires for a `local` host, which fixes the **pullfrog** finding
this PR depended on. That matters here specifically: this PR wires that function into the scan, its
cache key, fingerprint capability, cache invalidation, and the remote-repo dedupe — and the old
`kind !== 'ssh'` fallback made `setup-existing-folder --host ssh:develop` falsely dedupe onto a
**local** row. Covered by a test.

The fix is narrow on purpose. An earlier revision also dropped the field for a `runtime:` host;
review caught that as a regression (it removed a nested-SSH pane's reconnect affordance and made a
remote transcript read as locally readable), so a runtime host keeps its nested target. The
distinction matters to this PR's own uses: `fingerprintCapable` wants the *ownership* answer — a
runtime-hosted row is not locally fingerprintable — which is what it now gets.

### Two named twins, now closed rather than listed

- **`orca-runtime-terminal-create-deduplication.ts:151`** — `launchAgentTerminal` did
  `getRepo(worktree.repoId)` then `markWorkspaceTrustedForAgent(agent, repo.connectionId, …)`: the
  identical trust-write bug this PR fixes for folder creates, still live for agent launches. Every
  sibling call site already passes the resolved `workspace.connectionId`; this was the last that did
  not. Fail-before/pass-after with two SSH hosts.
- **`remote-workspace.ts:103`** — `targetForWorktree` kept the host-blind
  `getRepo(repoId)?.connectionId` fallback that **is** the #11163 defect, deciding which SSH target
  a workspace session is exported to. Unresolvable ownership now exports to nobody rather than
  guessing.

### `addRemoteRepoFromPath` no longer mints legacy-only rows

It created repos with `connectionId` and **no `executionHostId`**, so this PR's new routing path kept
minting rows in exactly the spelling the PR works around. It now stamps
`toSshExecutionHostId(connectionId)` at creation. Safe for target rename: `reassignSshTargetId`
already migrates both spellings (`ssh-target-reassignment.ts:70-80`).

### Tests

Every duplicate-row case in this PR was local-vs-ssh or runtime-vs-ssh. Added **two different SSH
hosts** throughout — including a dedupe case where two hosts hold the same path, the mirror image of
the id-only lookup this PR removes.

| Check | Result |
|---|---|
| `pnpm tc` | exit 0 |
| `src/main` + `renderer/src/lib` + `shared` + `cli` | **43327 passed** \| 268 skipped |
| requested scope (`ssh`/`runtime`/`persistence`/`ipc`/`lib`/`shared`/`cli`) | **25321 passed** \| 110 skipped |
| `check:code-quality:changed` | 0 new findings across 34 files |

Two failures seen only under the full 4300-file parallel run (`ssh-remote-commands.test.ts` 30s
timeout; a daemon scrollback spec) pass in isolation and touch untouched timing paths.

### Still open

Site 5 (`getRepo(id)` itself, ~30 host-deciding call sites, 3 destructive) is unchanged and still
the named gap, with the same suggested order. `runtime-worktree-agent-startup.ts:60` also still
branches agent detection on raw `repo.connectionId`.

