### PR TITLE
fix(ssh): close the pty master fd leak on relay hosts too

### DIFF
--- a/config/relay-assets/node-pty-1.1.0-master-cloexec-patch.cjs
+++ b/config/relay-assets/node-pty-1.1.0-master-cloexec-patch.cjs
@@ -1,0 +1,318 @@
+/**
+ * Relay-side pty-master close-on-exec patch for node-pty 1.1.0 (#17915).
+ *
+ * The app gets this through pnpm `patchedDependencies`; the relay installs stock
+ * node-pty from npm onto the host, where no pnpm patch reaches. Without it every
+ * later child of the relay -- pty children, git helpers, probes, agent CLIs --
+ * inherits each live master fd and keeps its /dev/pts device alive for the life
+ * of the relay (#8362).
+ *
+ * Linux only, deliberately: it is the only relay platform that takes forkpty()'s
+ * no-atomic-O_CLOEXEC path, and the only one that already compiles node-pty at
+ * install time, so the rebuild costs a second compile rather than a first one.
+ * macOS re-opens the tty through uv_tty_init's cloexec dup and Windows has no fds.
+ *
+ * Non-fatal by construction: the working build is moved aside before anything is
+ * touched and moved back on any failure, and a failed attempt drops a skip marker
+ * so the compile is attempted at most once per relay directory.
+ */
+
+const { spawnSync } = require('node:child_process')
+const { createHash } = require('node:crypto')
+const {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} = require('node:fs')
+const { dirname, join, resolve } = require('node:path')
+
+const EXPECTED_NODE_PTY_VERSION = '1.1.0'
+const ORIGINAL_SOURCE_SHA256 = '5e1005d6bdcfbe97b486ee415419fe7adae99035047f07340fbad36419e0bae6'
+const PATCHED_SOURCE_SHA256 = '97dea52199216c01b62070758f0f38621ae53adc16c221271dd35ae2d8ee3482'
+
+const STATUS_PREFIX = 'ORCA-NPTY-CLOEXEC:'
+const SKIP_MARKER_FILENAME = '.node-pty-cloexec-skip'
+const BACKUP_DIRNAME = '.orca-cloexec-prepatch-release'
+// Under the caller's 240s SSH command timeout, so the rollback below still runs.
+const REBUILD_TIMEOUT_MS = 200000
+const VERIFY_TIMEOUT_MS = 15000
+
+const FORWARD_DECLARATION = [
+  'static int\npty_nonblock(int);\n',
+  'static int\npty_nonblock(int);\n\nstatic int\npty_cloexec(int);\n'
+]
+
+const DEFINITION = [
+  `static int
+pty_nonblock(int fd) {
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags == -1) return -1;
+  return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+`,
+  `static int
+pty_nonblock(int fd) {
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags == -1) return -1;
+  return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+
+/**
+ * Orca: close-on-exec FD
+ *
+ * forkpty()/posix_openpt() have no atomic O_CLOEXEC, so a master left without
+ * FD_CLOEXEC is inherited by every later child of this process -- including
+ * later pty children -- which keeps its /dev/pts device and buffers alive long
+ * after its own session ends (#8362).
+ */
+
+static int
+pty_cloexec(int fd) {
+  int flags = fcntl(fd, F_GETFD);
+  if (flags == -1) return -1;
+  if (flags & FD_CLOEXEC) return 0;
+  return fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+}
+`
+]
+
+const FORKPTY_CALL_SITE = [
+  `    default:
+      if (pty_nonblock(master) == -1) {
+        throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
+      }
+  }
+`,
+  `    default:
+      if (pty_nonblock(master) == -1) {
+        throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
+      }
+      if (pty_cloexec(master) == -1) {
+        throw Napi::Error::New(napiEnv, "Could not set master fd to close-on-exec.");
+      }
+  }
+`
+]
+
+const REPLACEMENTS = [FORWARD_DECLARATION, DEFINITION, FORKPTY_CALL_SITE]
+
+function sourceSha256(source) {
+  return createHash('sha256').update(source).digest('hex')
+}
+
+function nodePtyDir(relayDir) {
+  return resolve(relayDir, 'node_modules', 'node-pty')
+}
+
+function inspectNodePtyUnixSource(relayDir) {
+  const ptyDir = nodePtyDir(relayDir)
+  const sourcePath = join(ptyDir, 'src', 'unix', 'pty.cc')
+  const version = JSON.parse(readFileSync(join(ptyDir, 'package.json'), 'utf8')).version
+  if (version !== EXPECTED_NODE_PTY_VERSION) {
+    throw new Error(`Refusing to patch node-pty ${version}; expected ${EXPECTED_NODE_PTY_VERSION}`)
+  }
+  return { ptyDir, sourcePath, source: readFileSync(sourcePath, 'utf8') }
+}
+
+function writeSourceAtomically(sourcePath, contents) {
+  const temporaryPath = `${sourcePath}.orca-patch-${process.pid}`
+  // Why: a terminated install must leave one of the two known source versions on disk.
+  try {
+    writeFileSync(temporaryPath, contents)
+    renameSync(temporaryPath, sourcePath)
+  } finally {
+    rmSync(temporaryPath, { force: true })
+  }
+}
+
+function rewriteSource(source, reverse) {
+  let rewritten = source
+  for (const [original, patched] of REPLACEMENTS) {
+    const from = reverse ? patched : original
+    const to = reverse ? original : patched
+    if (rewritten.split(from).length - 1 !== 1) {
+      throw new Error('Refusing to rewrite unexpected node-pty pty.cc source')
+    }
+    rewritten = rewritten.replace(from, to)
+  }
+  return rewritten
+}
+
+/** True when the patch was applied, false when it was already installed. */
+function patchNodePtyMasterCloexecSource(relayDir = process.cwd()) {
+  const inspected = inspectNodePtyUnixSource(relayDir)
+  const hash = sourceSha256(inspected.source)
+  if (hash === PATCHED_SOURCE_SHA256) {
+    return false
+  }
+  if (hash !== ORIGINAL_SOURCE_SHA256) {
+    throw new Error('Refusing to patch unexpected node-pty pty.cc source')
+  }
+  writeSourceAtomically(inspected.sourcePath, rewriteSource(inspected.source, false))
+  assertPatchedNodePtyMasterCloexecSource(relayDir)
+  return true
+}
+
+function assertPatchedNodePtyMasterCloexecSource(relayDir = process.cwd()) {
+  const inspected = inspectNodePtyUnixSource(relayDir)
+  if (sourceSha256(inspected.source) !== PATCHED_SOURCE_SHA256) {
+    throw new Error('node-pty pty master close-on-exec patch is not installed')
+  }
+}
+
+function revertNodePtyMasterCloexecSource(relayDir = process.cwd()) {
+  const inspected = inspectNodePtyUnixSource(relayDir)
+  if (sourceSha256(inspected.source) === ORIGINAL_SOURCE_SHA256) {
+    return false
+  }
+  writeSourceAtomically(inspected.sourcePath, rewriteSource(inspected.source, true))
+  return true
+}
+
+function rebuildNodePty(relayDir) {
+  const result = spawnSync('npm', ['rebuild', '--ignore-scripts=false', 'node-pty'], {
+    cwd: relayDir,
+    encoding: 'utf8',
+    timeout: REBUILD_TIMEOUT_MS,
+    windowsHide: true
+  })
+  if (result.error) {
+    throw new Error(`npm rebuild node-pty failed: ${result.error.message}`)
+  }
+  if (result.status !== 0) {
+    const tail = `${result.stdout || ''}${result.stderr || ''}`.trim().slice(-300)
+    throw new Error(`npm rebuild node-pty exited ${result.status ?? result.signal}: ${tail}`)
+  }
+}
+
+// Why a child: a bad build can abort the process on require, which would strand the
+// moved-aside working build. Why the reachability check: a host without /proc cannot
+// show inheritance, and an unobservable flag is not evidence the rebuild was wrong.
+const VERIFY_SCRIPT = `
+const pty = require(process.argv[1]);
+const term = pty.spawn('/bin/sh', ['-c', 'exit 0'], {
+  name: 'xterm-256color', cols: 80, rows: 24, cwd: process.cwd(), env: process.env
+});
+const probe = require('node:child_process').spawnSync('/bin/sh', ['-c', 'ls -l /proc/self/fd'], { encoding: 'utf8' });
+try { term.kill() } catch {}
+const listing = probe.stdout || '';
+if (probe.status !== 0 || !listing.includes('->')) { console.log('UNVERIFIED'); process.exit(0) }
+console.log(listing.includes('ptmx') ? 'INHERITED' : 'ISOLATED');
+process.exit(0);
+`
+
+/** 'isolated' when a later plain child no longer inherits the master, 'unverified' when /proc cannot say. */
+function verifyMasterNotInheritedByLaterChild(relayDir) {
+  const result = spawnSync(process.execPath, ['-e', VERIFY_SCRIPT, nodePtyDir(relayDir)], {
+    cwd: relayDir,
+    encoding: 'utf8',
+    timeout: VERIFY_TIMEOUT_MS,
+    windowsHide: true
+  })
+  const output = `${result.stdout || ''}`
+  if (result.status !== 0 || result.error) {
+    const tail = `${output}${result.stderr || ''}`.trim().slice(-300)
+    throw new Error(
+      `rebuilt node-pty did not load: ${tail || result.error?.message || result.signal}`
+    )
+  }
+  if (output.includes('INHERITED')) {
+    throw new Error('rebuilt node-pty still leaks the pty master into later children')
+  }
+  return output.includes('ISOLATED') ? 'isolated' : 'unverified'
+}
+
+function rollback(relayDir, releaseDir, backupDir) {
+  rmSync(releaseDir, { recursive: true, force: true })
+  try {
+    revertNodePtyMasterCloexecSource(relayDir)
+  } catch {
+    // The build that is about to be restored predates the patch either way.
+  }
+  if (existsSync(backupDir)) {
+    mkdirSync(dirname(releaseDir), { recursive: true })
+    renameSync(backupDir, releaseDir)
+  }
+}
+
+/**
+ * Patch and rebuild the host's node-pty, or leave it exactly as found.
+ * Never throws: the caller is on the connect path and a leaky relay beats no relay.
+ */
+function applyNodePtyMasterCloexecPatch(relayDir = process.cwd(), options = {}) {
+  const platform = options.platform || process.platform
+  const rebuild = options.rebuild || rebuildNodePty
+  const verify = options.verify || verifyMasterNotInheritedByLaterChild
+  if (platform !== 'linux') {
+    return 'skipped:not-linux'
+  }
+  const skipMarkerPath = join(relayDir, SKIP_MARKER_FILENAME)
+  if (existsSync(skipMarkerPath)) {
+    return 'skipped:earlier-attempt-failed'
+  }
+  const releaseDir = join(nodePtyDir(relayDir), 'build', 'Release')
+  const backupDir = join(nodePtyDir(relayDir), BACKUP_DIRNAME)
+  // A backup stranded by a connection that died mid-rebuild is stale by definition:
+  // whatever repaired node-pty since built from the source now on disk.
+  rmSync(backupDir, { recursive: true, force: true })
+
+  let inspected
+  try {
+    inspected = inspectNodePtyUnixSource(relayDir)
+  } catch (err) {
+    return `skipped:${err.message}`
+  }
+  const hash = sourceSha256(inspected.source)
+  if (hash === PATCHED_SOURCE_SHA256) {
+    return 'already-patched'
+  }
+  if (hash !== ORIGINAL_SOURCE_SHA256) {
+    return 'skipped:unexpected-source'
+  }
+  // No compiled build means the host runs a prebuild or nothing at all; rebuilding
+  // could only take away the artifact the probe just proved loadable.
+  if (!existsSync(join(releaseDir, 'pty.node'))) {
+    return 'skipped:no-compiled-build'
+  }
+
+  try {
+    renameSync(releaseDir, backupDir)
+  } catch (err) {
+    return `skipped:${err.message}`
+  }
+  try {
+    patchNodePtyMasterCloexecSource(relayDir)
+    rebuild(relayDir)
+    const verdict = verify(relayDir)
+    rmSync(backupDir, { recursive: true, force: true })
+    return verdict === 'isolated' ? 'patched' : 'patched-unverified'
+  } catch (err) {
+    rollback(relayDir, releaseDir, backupDir)
+    // Bounded on purpose: one compile attempt per relay directory, never a retry loop.
+    try {
+      writeFileSync(skipMarkerPath, `${new Date().toISOString()} ${err.message}\n`)
+    } catch {
+      // A relay dir we cannot write to will fail the cheap checks above next time anyway.
+    }
+    return `failed:${err.message}`
+  }
+}
+
+if (require.main === module) {
+  console.log(`${STATUS_PREFIX}${applyNodePtyMasterCloexecPatch()}`)
+}
+
+module.exports = {
+  EXPECTED_NODE_PTY_VERSION,
+  ORIGINAL_SOURCE_SHA256,
+  PATCHED_SOURCE_SHA256,
+  SKIP_MARKER_FILENAME,
+  STATUS_PREFIX,
+  applyNodePtyMasterCloexecPatch,
+  assertPatchedNodePtyMasterCloexecSource,
+  patchNodePtyMasterCloexecSource,
+  revertNodePtyMasterCloexecSource
+}

--- a/config/scripts/__fixtures__/node-pty-1.1.0-unix-pty.cc
+++ b/config/scripts/__fixtures__/node-pty-1.1.0-unix-pty.cc
@@ -1,0 +1,799 @@
+/**
+ * Copyright (c) 2012-2015, Christopher Jeffrey (MIT License)
+ * Copyright (c) 2017, Daniel Imms (MIT License)
+ *
+ * pty.cc:
+ *   This file is responsible for starting processes
+ *   with pseudo-terminal file descriptors.
+ *
+ * See:
+ *   man pty
+ *   man tty_ioctl
+ *   man termios
+ *   man forkpty
+ */
+
+/**
+ * Includes
+ */
+
+#define NODE_ADDON_API_DISABLE_DEPRECATED
+#include <napi.h>
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <thread>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+#include <signal.h>
+
+/* forkpty */
+/* http://www.gnu.org/software/gnulib/manual/html_node/forkpty.html */
+#if defined(__linux__)
+#include <pty.h>
+#elif defined(__APPLE__)
+#include <util.h>
+#elif defined(__FreeBSD__)
+#include <libutil.h>
+#include <termios.h>
+#elif defined(__OpenBSD__)
+#include <util.h>
+#include <termios.h>
+#endif
+
+/* Some platforms name VWERASE and VDISCARD differently */
+#if !defined(VWERASE) && defined(VWERSE)
+#define VWERASE	VWERSE
+#endif
+#if !defined(VDISCARD) && defined(VDISCRD)
+#define VDISCARD	VDISCRD
+#endif
+
+/* for pty_getproc */
+#if defined(__linux__)
+#include <stdio.h>
+#include <stdint.h>
+#elif defined(__APPLE__)
+#include <libproc.h>
+#include <os/availability.h>
+#include <paths.h>
+#include <spawn.h>
+#include <sys/event.h>
+#include <sys/sysctl.h>
+#include <termios.h>
+#endif
+
+/* NSIG - macro for highest signal + 1, should be defined */
+#ifndef NSIG
+#define NSIG 32
+#endif
+
+/* macOS 10.14 back does not define this constant */
+#ifndef POSIX_SPAWN_SETSID
+  #define POSIX_SPAWN_SETSID 1024
+#endif
+
+/* environ for execvpe */
+/* node/src/node_child_process.cc */
+#if !defined(__APPLE__)
+extern char **environ;
+#endif
+
+#if defined(__APPLE__)
+extern "C" {
+// Changes the current thread's directory to a path or directory file
+// descriptor. libpthread only exposes a syscall wrapper starting in
+// macOS 10.12, but the system call dates back to macOS 10.5. On older OSes,
+// the syscall is issued directly.
+int pthread_chdir_np(const char* dir) API_AVAILABLE(macosx(10.12));
+int pthread_fchdir_np(int fd) API_AVAILABLE(macosx(10.12));
+}
+
+#define HANDLE_EINTR(x) ({ \
+  int eintr_wrapper_counter = 0; \
+  decltype(x) eintr_wrapper_result; \
+  do { \
+    eintr_wrapper_result = (x); \
+  } while (eintr_wrapper_result == -1 && errno == EINTR && \
+           eintr_wrapper_counter++ < 100); \
+  eintr_wrapper_result; \
+})
+#endif
+
+struct ExitEvent {
+  int exit_code = 0, signal_code = 0;
+};
+
+void SetupExitCallback(Napi::Env env, Napi::Function cb, pid_t pid) {
+  std::thread *th = new std::thread;
+  // Don't use Napi::AsyncWorker which is limited by UV_THREADPOOL_SIZE.
+  auto tsfn = Napi::ThreadSafeFunction::New(
+      env,
+      cb,                           // JavaScript function called asynchronously
+      "SetupExitCallback_resource", // Name
+      0,                            // Unlimited queue
+      1,                            // Only one thread will use this initially
+      [th](Napi::Env) {   // Finalizer used to clean threads up
+        th->join();
+        delete th;
+      });
+  *th = std::thread([tsfn = std::move(tsfn), pid] {
+    auto callback = [](Napi::Env env, Napi::Function cb, ExitEvent *exit_event) {
+      cb.Call({Napi::Number::New(env, exit_event->exit_code),
+               Napi::Number::New(env, exit_event->signal_code)});
+      delete exit_event;
+    };
+
+    int ret;
+    int stat_loc;
+#if defined(__APPLE__)
+    // Based on
+    // https://source.chromium.org/chromium/chromium/src/+/main:base/process/kill_mac.cc;l=35-69?
+    int kq = HANDLE_EINTR(kqueue());
+    struct kevent change = {0};
+    EV_SET(&change, pid, EVFILT_PROC, EV_ADD, NOTE_EXIT, 0, NULL);
+    ret = HANDLE_EINTR(kevent(kq, &change, 1, NULL, 0, NULL));
+    if (ret == -1) {
+      if (errno == ESRCH) {
+        // At this point, one of the following has occurred:
+        // 1. The process has died but has not yet been reaped.
+        // 2. The process has died and has already been reaped.
+        // 3. The process is in the process of dying. It's no longer
+        //    kqueueable, but it may not be waitable yet either. Mark calls
+        //    this case the "zombie death race".
+        ret = HANDLE_EINTR(waitpid(pid, &stat_loc, WNOHANG));
+        if (ret == 0) {
+          ret = kill(pid, SIGKILL);
+          if (ret != -1) {
+            HANDLE_EINTR(waitpid(pid, &stat_loc, 0));
+          }
+        }
+      }
+    } else {
+      struct kevent event = {0};
+      ret = HANDLE_EINTR(kevent(kq, NULL, 0, &event, 1, NULL));
+      if (ret == 1) {
+        if ((event.fflags & NOTE_EXIT) &&
+            (event.ident == static_cast<uintptr_t>(pid))) {
+          // The process is dead or dying. This won't block for long, if at
+          // all.
+          HANDLE_EINTR(waitpid(pid, &stat_loc, 0));
+        }
+      }
+    }
+#else
+    while (true) {
+      errno = 0;
+      if ((ret = waitpid(pid, &stat_loc, 0)) != pid) {
+        if (ret == -1 && errno == EINTR) {
+          continue;
+        }
+        if (ret == -1 && errno == ECHILD) {
+          // XXX node v0.8.x seems to have this problem.
+          // waitpid is already handled elsewhere.
+          ;
+        } else {
+          assert(false);
+        }
+      }
+      break;
+    }
+#endif
+    ExitEvent *exit_event = new ExitEvent;
+    if (WIFEXITED(stat_loc)) {
+      exit_event->exit_code = WEXITSTATUS(stat_loc); // errno?
+    }
+    if (WIFSIGNALED(stat_loc)) {
+      exit_event->signal_code = WTERMSIG(stat_loc);
+    }
+    auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
+    switch (status) {
+      case napi_closing:
+        break;
+
+      case napi_queue_full:
+        Napi::Error::Fatal("SetupExitCallback", "Queue was full");
+
+      case napi_ok:
+        if (tsfn.Release() != napi_ok) {
+          Napi::Error::Fatal("SetupExitCallback", "ThreadSafeFunction.Release() failed");
+        }
+        break;
+
+      default:
+        Napi::Error::Fatal("SetupExitCallback", "ThreadSafeFunction.BlockingCall() failed");
+    }
+  });
+}
+
+/**
+ * Methods
+ */
+
+Napi::Value PtyFork(const Napi::CallbackInfo& info);
+Napi::Value PtyOpen(const Napi::CallbackInfo& info);
+Napi::Value PtyResize(const Napi::CallbackInfo& info);
+Napi::Value PtyGetProc(const Napi::CallbackInfo& info);
+
+/**
+ * Functions
+ */
+
+static int
+pty_nonblock(int);
+
+#if defined(__APPLE__)
+static char *
+pty_getproc(int);
+#else
+static char *
+pty_getproc(int, char *);
+#endif
+
+#if defined(__APPLE__) || defined(__OpenBSD__)
+static void
+pty_posix_spawn(char** argv, char** env,
+                const struct termios *termp,
+                const struct winsize *winp,
+                int* master,
+                pid_t* pid,
+                int* err);
+#endif
+
+struct DelBuf {
+  int len;
+  DelBuf(int len) : len(len) {}
+  void operator()(char **p) {
+    if (p == nullptr)
+      return;
+    for (int i = 0; i < len; i++)
+      free(p[i]);
+    delete[] p;
+  }
+};
+
+Napi::Value PtyFork(const Napi::CallbackInfo& info) {
+  Napi::Env napiEnv(info.Env());
+  Napi::HandleScope scope(napiEnv);
+
+  if (info.Length() != 11 ||
+      !info[0].IsString() ||
+      !info[1].IsArray() ||
+      !info[2].IsArray() ||
+      !info[3].IsString() ||
+      !info[4].IsNumber() ||
+      !info[5].IsNumber() ||
+      !info[6].IsNumber() ||
+      !info[7].IsNumber() ||
+      !info[8].IsBoolean() ||
+      !info[9].IsString() ||
+      !info[10].IsFunction()) {
+    throw Napi::Error::New(napiEnv, "Usage: pty.fork(file, args, env, cwd, cols, rows, uid, gid, utf8, helperPath, onexit)");
+  }
+
+  // file
+  std::string file = info[0].As<Napi::String>();
+
+  // args
+  Napi::Array argv_ = info[1].As<Napi::Array>();
+
+  // env
+  Napi::Array env_ = info[2].As<Napi::Array>();
+  int envc = env_.Length();
+  std::unique_ptr<char *, DelBuf> env_unique_ptr(new char *[envc + 1], DelBuf(envc + 1));
+  char **env = env_unique_ptr.get();
+  env[envc] = NULL;
+  for (int i = 0; i < envc; i++) {
+    std::string pair = env_.Get(i).As<Napi::String>();
+    env[i] = strdup(pair.c_str());
+  }
+
+  // cwd
+  std::string cwd_ = info[3].As<Napi::String>();
+
+  // size
+  struct winsize winp;
+  winp.ws_col = info[4].As<Napi::Number>().Int32Value();
+  winp.ws_row = info[5].As<Napi::Number>().Int32Value();
+  winp.ws_xpixel = 0;
+  winp.ws_ypixel = 0;
+
+#if !defined(__APPLE__)
+  // uid / gid
+  int uid = info[6].As<Napi::Number>().Int32Value();
+  int gid = info[7].As<Napi::Number>().Int32Value();
+#endif
+
+  // termios
+  struct termios t = termios();
+  struct termios *term = &t;
+  term->c_iflag = ICRNL | IXON | IXANY | IMAXBEL | BRKINT;
+  if (info[8].As<Napi::Boolean>().Value()) {
+#if defined(IUTF8)
+    term->c_iflag |= IUTF8;
+#endif
+  }
+  term->c_oflag = OPOST | ONLCR;
+  term->c_cflag = CREAD | CS8 | HUPCL;
+  term->c_lflag = ICANON | ISIG | IEXTEN | ECHO | ECHOE | ECHOK | ECHOKE | ECHOCTL;
+
+  term->c_cc[VEOF] = 4;
+  term->c_cc[VEOL] = -1;
+  term->c_cc[VEOL2] = -1;
+  term->c_cc[VERASE] = 0x7f;
+  term->c_cc[VWERASE] = 23;
+  term->c_cc[VKILL] = 21;
+  term->c_cc[VREPRINT] = 18;
+  term->c_cc[VINTR] = 3;
+  term->c_cc[VQUIT] = 0x1c;
+  term->c_cc[VSUSP] = 26;
+  term->c_cc[VSTART] = 17;
+  term->c_cc[VSTOP] = 19;
+  term->c_cc[VLNEXT] = 22;
+  term->c_cc[VDISCARD] = 15;
+  term->c_cc[VMIN] = 1;
+  term->c_cc[VTIME] = 0;
+
+  #if (__APPLE__)
+  term->c_cc[VDSUSP] = 25;
+  term->c_cc[VSTATUS] = 20;
+  #endif
+
+  cfsetispeed(term, B38400);
+  cfsetospeed(term, B38400);
+
+  // helperPath
+  std::string helper_path = info[9].As<Napi::String>();
+
+  pid_t pid;
+  int master;
+#if defined(__APPLE__)
+  int argc = argv_.Length();
+  int argl = argc + 4;
+  std::unique_ptr<char *, DelBuf> argv_unique_ptr(new char *[argl], DelBuf(argl));
+  char **argv = argv_unique_ptr.get();
+  argv[0] = strdup(helper_path.c_str());
+  argv[1] = strdup(cwd_.c_str());
+  argv[2] = strdup(file.c_str());
+  argv[argl - 1] = NULL;
+  for (int i = 0; i < argc; i++) {
+    std::string arg = argv_.Get(i).As<Napi::String>();
+    argv[i + 3] = strdup(arg.c_str());
+  }
+
+  int err = -1;
+  pty_posix_spawn(argv, env, term, &winp, &master, &pid, &err);
+  if (err != 0) {
+    throw Napi::Error::New(napiEnv, "posix_spawnp failed.");
+  }
+  if (pty_nonblock(master) == -1) {
+    throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
+  }
+#else
+  int argc = argv_.Length();
+  int argl = argc + 2;
+  std::unique_ptr<char *, DelBuf> argv_unique_ptr(new char *[argl], DelBuf(argl));
+  char** argv = argv_unique_ptr.get();
+  argv[0] = strdup(file.c_str());
+  argv[argl - 1] = NULL;
+  for (int i = 0; i < argc; i++) {
+    std::string arg = argv_.Get(i).As<Napi::String>();
+    argv[i + 1] = strdup(arg.c_str());
+  }
+
+  sigset_t newmask, oldmask;
+  struct sigaction sig_action;
+  // temporarily block all signals
+  // this is needed due to a race condition in openpty
+  // and to avoid running signal handlers in the child
+  // before exec* happened
+  sigfillset(&newmask);
+  pthread_sigmask(SIG_SETMASK, &newmask, &oldmask);
+
+  pid = forkpty(&master, nullptr, static_cast<termios*>(term), static_cast<winsize*>(&winp));
+
+  if (!pid) {
+    // remove all signal handler from child
+    sig_action.sa_handler = SIG_DFL;
+    sig_action.sa_flags = 0;
+    sigemptyset(&sig_action.sa_mask);
+    for (int i = 0 ; i < NSIG ; i++) {    // NSIG is a macro for all signals + 1
+      sigaction(i, &sig_action, NULL);
+    }
+  }
+
+  // reenable signals
+  pthread_sigmask(SIG_SETMASK, &oldmask, NULL);
+
+  switch (pid) {
+    case -1:
+      throw Napi::Error::New(napiEnv, "forkpty(3) failed.");
+    case 0:
+      if (strlen(cwd_.c_str())) {
+        if (chdir(cwd_.c_str()) == -1) {
+          perror("chdir(2) failed.");
+          _exit(1);
+        }
+      }
+
+      if (uid != -1 && gid != -1) {
+        if (setgid(gid) == -1) {
+          perror("setgid(2) failed.");
+          _exit(1);
+        }
+        if (setuid(uid) == -1) {
+          perror("setuid(2) failed.");
+          _exit(1);
+        }
+      }
+
+      {
+        char **old = environ;
+        environ = env;
+        execvp(argv[0], argv);
+        environ = old;
+        perror("execvp(3) failed.");
+        _exit(1);
+      }
+    default:
+      if (pty_nonblock(master) == -1) {
+        throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
+      }
+  }
+#endif
+
+  Napi::Object obj = Napi::Object::New(napiEnv);
+  obj.Set("fd", Napi::Number::New(napiEnv, master));
+  obj.Set("pid", Napi::Number::New(napiEnv, pid));
+  obj.Set("pty", Napi::String::New(napiEnv, ptsname(master)));
+
+  // Set up process exit callback.
+  Napi::Function cb = info[10].As<Napi::Function>();
+  SetupExitCallback(napiEnv, cb, pid);
+  return obj;
+}
+
+Napi::Value PtyOpen(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 2 ||
+      !info[0].IsNumber() ||
+      !info[1].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: pty.open(cols, rows)");
+  }
+
+  // size
+  struct winsize winp;
+  winp.ws_col = info[0].As<Napi::Number>().Int32Value();
+  winp.ws_row = info[1].As<Napi::Number>().Int32Value();
+  winp.ws_xpixel = 0;
+  winp.ws_ypixel = 0;
+
+  // pty
+  int master, slave;
+  int ret = openpty(&master, &slave, nullptr, NULL, static_cast<winsize*>(&winp));
+
+  if (ret == -1) {
+    throw Napi::Error::New(env, "openpty(3) failed.");
+  }
+
+  if (pty_nonblock(master) == -1) {
+    throw Napi::Error::New(env, "Could not set master fd to nonblocking.");
+  }
+
+  if (pty_nonblock(slave) == -1) {
+    throw Napi::Error::New(env, "Could not set slave fd to nonblocking.");
+  }
+
+  Napi::Object obj = Napi::Object::New(env);
+  obj.Set("master", Napi::Number::New(env, master));
+  obj.Set("slave", Napi::Number::New(env, slave));
+  obj.Set("pty", Napi::String::New(env, ptsname(master)));
+
+  return obj;
+}
+
+Napi::Value PtyResize(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 3 ||
+      !info[0].IsNumber() ||
+      !info[1].IsNumber() ||
+      !info[2].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: pty.resize(fd, cols, rows)");
+  }
+
+  int fd = info[0].As<Napi::Number>().Int32Value();
+
+  struct winsize winp;
+  winp.ws_col = info[1].As<Napi::Number>().Int32Value();
+  winp.ws_row = info[2].As<Napi::Number>().Int32Value();
+  winp.ws_xpixel = 0;
+  winp.ws_ypixel = 0;
+
+  if (ioctl(fd, TIOCSWINSZ, &winp) == -1) {
+    switch (errno) {
+      case EBADF:
+        throw Napi::Error::New(env, "ioctl(2) failed, EBADF");
+      case EFAULT:
+        throw Napi::Error::New(env, "ioctl(2) failed, EFAULT");
+      case EINVAL:
+        throw Napi::Error::New(env, "ioctl(2) failed, EINVAL");
+      case ENOTTY:
+        throw Napi::Error::New(env, "ioctl(2) failed, ENOTTY");
+    }
+    throw Napi::Error::New(env, "ioctl(2) failed");
+  }
+
+  return env.Undefined();
+}
+
+/**
+ * Foreground Process Name
+ */
+Napi::Value PtyGetProc(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+#if defined(__APPLE__)
+  if (info.Length() != 1 ||
+      !info[0].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: pty.process(pid)");
+  }
+
+  int fd = info[0].As<Napi::Number>().Int32Value();
+  char *name = pty_getproc(fd);
+#else
+  if (info.Length() != 2 ||
+      !info[0].IsNumber() ||
+      !info[1].IsString()) {
+    throw Napi::Error::New(env, "Usage: pty.process(fd, tty)");
+  }
+
+  int fd = info[0].As<Napi::Number>().Int32Value();
+
+  std::string tty_ = info[1].As<Napi::String>();
+  char *tty = strdup(tty_.c_str());
+  char *name = pty_getproc(fd, tty);
+  free(tty);
+#endif
+
+  if (name == NULL) {
+    return env.Undefined();
+  }
+
+  Napi::String name_ = Napi::String::New(env, name);
+  free(name);
+  return name_;
+}
+
+/**
+ * Nonblocking FD
+ */
+
+static int
+pty_nonblock(int fd) {
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags == -1) return -1;
+  return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+
+/**
+ * pty_getproc
+ * Taken from tmux.
+ */
+
+// Taken from: tmux (http://tmux.sourceforge.net/)
+// Copyright (c) 2009 Nicholas Marriott <nicm@users.sourceforge.net>
+// Copyright (c) 2009 Joshua Elsasser <josh@elsasser.org>
+// Copyright (c) 2009 Todd Carson <toc@daybefore.net>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF MIND, USE, DATA OR PROFITS, WHETHER
+// IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+// OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#if defined(__linux__)
+
+static char *
+pty_getproc(int fd, char *tty) {
+  FILE *f;
+  char *path, *buf;
+  size_t len;
+  int ch;
+  pid_t pgrp;
+  int r;
+
+  if ((pgrp = tcgetpgrp(fd)) == -1) {
+    return NULL;
+  }
+
+  r = asprintf(&path, "/proc/%lld/cmdline", (long long)pgrp);
+  if (r == -1 || path == NULL) return NULL;
+
+  if ((f = fopen(path, "r")) == NULL) {
+    free(path);
+    return NULL;
+  }
+
+  free(path);
+
+  len = 0;
+  buf = NULL;
+  while ((ch = fgetc(f)) != EOF) {
+    if (ch == '\0') break;
+    buf = (char *)realloc(buf, len + 2);
+    if (buf == NULL) return NULL;
+    buf[len++] = ch;
+  }
+
+  if (buf != NULL) {
+    buf[len] = '\0';
+  }
+
+  fclose(f);
+  return buf;
+}
+
+#elif defined(__APPLE__)
+
+static char *
+pty_getproc(int fd) {
+  int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, 0 };
+  size_t size;
+  struct kinfo_proc kp;
+
+  if ((mib[3] = tcgetpgrp(fd)) == -1) {
+    return NULL;
+  }
+
+  size = sizeof kp;
+  if (sysctl(mib, 4, &kp, &size, NULL, 0) == -1) {
+    return NULL;
+  }
+
+  if (size != (sizeof kp) || *kp.kp_proc.p_comm == '\0') {
+    return NULL;
+  }
+
+  return strdup(kp.kp_proc.p_comm);
+}
+
+#else
+
+static char *
+pty_getproc(int fd, char *tty) {
+  return NULL;
+}
+
+#endif
+
+#if defined(__APPLE__)
+static void
+pty_posix_spawn(char** argv, char** env,
+                const struct termios *termp,
+                const struct winsize *winp,
+                int* master,
+                pid_t* pid,
+                int* err) {
+  int low_fds[3];
+  size_t count = 0;
+
+  for (; count < 3; count++) {
+    low_fds[count] = posix_openpt(O_RDWR);
+    if (low_fds[count] >= STDERR_FILENO)
+      break;
+  }
+
+  int flags = POSIX_SPAWN_CLOEXEC_DEFAULT |
+              POSIX_SPAWN_SETSIGDEF |
+              POSIX_SPAWN_SETSIGMASK |
+              POSIX_SPAWN_SETSID;
+  *master = posix_openpt(O_RDWR);
+  if (*master == -1) {
+    return;
+  }
+
+  int res = grantpt(*master) || unlockpt(*master);
+  if (res == -1) {
+    return;
+  }
+
+  // Use TIOCPTYGNAME instead of ptsname() to avoid threading problems.
+  int slave;
+  char slave_pty_name[128];
+  res = ioctl(*master, TIOCPTYGNAME, slave_pty_name);
+  if (res == -1) {
+    return;
+  }
+
+  slave = open(slave_pty_name, O_RDWR | O_NOCTTY);
+  if (slave == -1) {
+    return;
+  }
+
+  if (termp) {
+    res = tcsetattr(slave, TCSANOW, termp);
+    if (res == -1) {
+      return;
+    };
+  }
+
+  if (winp) {
+    res = ioctl(slave, TIOCSWINSZ, winp);
+    if (res == -1) {
+      return;
+    }
+  }
+
+  posix_spawn_file_actions_t acts;
+  posix_spawn_file_actions_init(&acts);
+  posix_spawn_file_actions_adddup2(&acts, slave, STDIN_FILENO);
+  posix_spawn_file_actions_adddup2(&acts, slave, STDOUT_FILENO);
+  posix_spawn_file_actions_adddup2(&acts, slave, STDERR_FILENO);
+  posix_spawn_file_actions_addclose(&acts, slave);
+  posix_spawn_file_actions_addclose(&acts, *master);
+
+  posix_spawnattr_t attrs;
+  posix_spawnattr_init(&attrs);
+  *err = posix_spawnattr_setflags(&attrs, flags);
+  if (*err != 0) {
+    goto done;
+  }
+
+  sigset_t signal_set;
+  /* Reset all signal the child to their default behavior */
+  sigfillset(&signal_set);
+  *err = posix_spawnattr_setsigdefault(&attrs, &signal_set);
+  if (*err != 0) {
+    goto done;
+  }
+
+  /* Reset the signal mask for all signals */
+  sigemptyset(&signal_set);
+  *err = posix_spawnattr_setsigmask(&attrs, &signal_set);
+  if (*err != 0) {
+    goto done;
+  }
+
+  do
+    *err = posix_spawn(pid, argv[0], &acts, &attrs, argv, env);
+  while (*err == EINTR);
+done:
+  posix_spawn_file_actions_destroy(&acts);
+  posix_spawnattr_destroy(&attrs);
+
+  for (; count > 0; count--) {
+    close(low_fds[count]);
+  }
+}
+#endif
+
+/**
+ * Init
+ */
+
+Napi::Object init(Napi::Env env, Napi::Object exports) {
+  exports.Set("fork",    Napi::Function::New(env, PtyFork));
+  exports.Set("open",    Napi::Function::New(env, PtyOpen));
+  exports.Set("resize",  Napi::Function::New(env, PtyResize));
+  exports.Set("process", Napi::Function::New(env, PtyGetProc));
+  return exports;
+}
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/config/scripts/build-relay.mjs
+++ b/config/scripts/build-relay.mjs
@@ -57,6 +57,13 @@ const NODE_PTY_CONSOLE_LIST_PATCH_SOURCE = join(
   'relay-assets',
   NODE_PTY_CONSOLE_LIST_PATCH_FILENAME
 )
+const NODE_PTY_MASTER_CLOEXEC_PATCH_FILENAME = 'node-pty-1.1.0-master-cloexec-patch.cjs'
+const NODE_PTY_MASTER_CLOEXEC_PATCH_SOURCE = join(
+  ROOT,
+  'config',
+  'relay-assets',
+  NODE_PTY_MASTER_CLOEXEC_PATCH_FILENAME
+)
 // Written by build-windows-process-tree-relay-addon.mjs, which only runs on a
 // Windows machine.
 const WINDOWS_PROCESS_TREE_BUILD_DIR = join(ROOT, '.build', 'windows-process-tree')
@@ -126,6 +133,10 @@ for (const platform of RELAY_BUILD_PLATFORMS) {
       join(outDir, NODE_PTY_CONSOLE_LIST_PATCH_FILENAME)
     )
   }
+  copyFileSync(
+    NODE_PTY_MASTER_CLOEXEC_PATCH_SOURCE,
+    join(outDir, NODE_PTY_MASTER_CLOEXEC_PATCH_FILENAME)
+  )
   stageWindowsProcessTreeAddon(platform, outDir)
 
   await build({

--- a/config/scripts/node-pty-master-cloexec-patch.test.mjs
+++ b/config/scripts/node-pty-master-cloexec-patch.test.mjs
@@ -1,0 +1,229 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  SKIP_MARKER_FILENAME,
+  applyNodePtyMasterCloexecPatch,
+  assertPatchedNodePtyMasterCloexecSource,
+  patchNodePtyMasterCloexecSource,
+  revertNodePtyMasterCloexecSource
+} = require('../relay-assets/node-pty-1.1.0-master-cloexec-patch.cjs')
+
+// Byte-exact src/unix/pty.cc from the npm tarball the relay installs. The patch is keyed by its
+// sha256, so a fixture that drifted from what npm ships would make every assertion below vacuous.
+const STOCK_SOURCE = readFileSync(
+  resolve(import.meta.dirname, '__fixtures__', 'node-pty-1.1.0-unix-pty.cc'),
+  'utf8'
+)
+const projectDir = resolve(import.meta.dirname, '..', '..')
+const cleanupDirs = []
+
+afterEach(() => {
+  for (const dir of cleanupDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('SSH relay node-pty pty-master close-on-exec patch', () => {
+  it('adds the forkpty close-on-exec call and reverts to the published bytes', () => {
+    const fixture = writeRelayFixture()
+
+    expect(patchNodePtyMasterCloexecSource(fixture.root)).toBe(true)
+    const patched = readFileSync(fixture.sourcePath, 'utf8')
+    expect(patched).toContain('pty_cloexec(int fd)')
+    expect(patched).toContain('if (pty_cloexec(master) == -1)')
+    expect(() => assertPatchedNodePtyMasterCloexecSource(fixture.root)).not.toThrow()
+
+    expect(patchNodePtyMasterCloexecSource(fixture.root)).toBe(false)
+    expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(patched)
+
+    expect(revertNodePtyMasterCloexecSource(fixture.root)).toBe(true)
+    expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(STOCK_SOURCE)
+  })
+
+  it('refuses a different node-pty version or an unrecognized source', () => {
+    const wrongVersion = writeRelayFixture({ version: '1.2.0-beta.4' })
+    expect(() => patchNodePtyMasterCloexecSource(wrongVersion.root)).toThrow('expected 1.1.0')
+
+    const drifted = writeRelayFixture({
+      source: `${STOCK_SOURCE}\n// drift\n`
+    })
+    expect(() => patchNodePtyMasterCloexecSource(drifted.root)).toThrow('unexpected node-pty')
+
+    const tampered = writeRelayFixture()
+    patchNodePtyMasterCloexecSource(tampered.root)
+    writeFileSync(tampered.sourcePath, `${readFileSync(tampered.sourcePath, 'utf8')}\n// drift\n`)
+    expect(() => assertPatchedNodePtyMasterCloexecSource(tampered.root)).toThrow('not installed')
+  })
+
+  it('keeps the rebuilt addon once a later child no longer inherits the master', () => {
+    const fixture = writeRelayFixture()
+    const calls = []
+
+    const status = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'linux',
+      rebuild: () => {
+        calls.push('rebuild')
+        writeBuild(fixture, 'patched-build')
+      },
+      verify: () => 'isolated'
+    })
+
+    expect(status).toBe('patched')
+    expect(calls).toEqual(['rebuild'])
+    expect(readFileSync(fixture.buildPath, 'utf8')).toBe('patched-build')
+    expect(readFileSync(fixture.sourcePath, 'utf8')).not.toBe(STOCK_SOURCE)
+    expect(existsSync(fixture.backupDir)).toBe(false)
+    expect(existsSync(fixture.skipMarkerPath)).toBe(false)
+  })
+
+  it('keeps a rebuilt addon whose flag /proc could not confirm', () => {
+    const fixture = writeRelayFixture()
+
+    const status = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'linux',
+      rebuild: () => writeBuild(fixture, 'patched-build'),
+      verify: () => 'unverified'
+    })
+
+    expect(status).toBe('patched-unverified')
+    expect(readFileSync(fixture.buildPath, 'utf8')).toBe('patched-build')
+  })
+
+  it('restores the working build when the compile fails, and never retries it', () => {
+    const fixture = writeRelayFixture()
+    const calls = []
+
+    const failed = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'linux',
+      rebuild: () => {
+        calls.push('rebuild')
+        throw new Error('npm rebuild node-pty exited 1: no C++ toolchain')
+      },
+      verify: () => 'isolated'
+    })
+
+    expect(failed).toContain('failed:')
+    expect(failed).toContain('no C++ toolchain')
+    expect(readFileSync(fixture.buildPath, 'utf8')).toBe('stock-build')
+    expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(STOCK_SOURCE)
+    expect(existsSync(fixture.backupDir)).toBe(false)
+    expect(existsSync(fixture.skipMarkerPath)).toBe(true)
+
+    // Bounded, not backed off: a relay directory gets one compile attempt, ever.
+    const again = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'linux',
+      rebuild: () => calls.push('rebuild'),
+      verify: () => 'isolated'
+    })
+    expect(again).toBe('skipped:earlier-attempt-failed')
+    expect(calls).toEqual(['rebuild'])
+  })
+
+  it('restores the working build when the rebuilt addon still leaks the master', () => {
+    const fixture = writeRelayFixture()
+
+    const status = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'linux',
+      rebuild: () => writeBuild(fixture, 'still-leaky-build'),
+      verify: () => {
+        throw new Error('rebuilt node-pty still leaks the pty master into later children')
+      }
+    })
+
+    expect(status).toContain('still leaks')
+    expect(readFileSync(fixture.buildPath, 'utf8')).toBe('stock-build')
+    expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(STOCK_SOURCE)
+  })
+
+  it('never compiles on a platform that does not leak', () => {
+    for (const platform of ['darwin', 'win32']) {
+      const fixture = writeRelayFixture()
+      const calls = []
+      const status = applyNodePtyMasterCloexecPatch(fixture.root, {
+        platform,
+        rebuild: () => calls.push('rebuild'),
+        verify: () => 'isolated'
+      })
+      expect(status).toBe('skipped:not-linux')
+      expect(calls).toEqual([])
+      expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(STOCK_SOURCE)
+    }
+  })
+
+  it('leaves an already patched install alone', () => {
+    const fixture = writeRelayFixture()
+    patchNodePtyMasterCloexecSource(fixture.root)
+    const calls = []
+
+    const status = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'linux',
+      rebuild: () => calls.push('rebuild'),
+      verify: () => 'isolated'
+    })
+
+    expect(status).toBe('already-patched')
+    expect(calls).toEqual([])
+  })
+
+  it('will not rebuild an install that has no compiled addon to fall back on', () => {
+    const fixture = writeRelayFixture({ build: false })
+    const calls = []
+
+    const status = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'linux',
+      rebuild: () => calls.push('rebuild'),
+      verify: () => 'isolated'
+    })
+
+    expect(status).toBe('skipped:no-compiled-build')
+    expect(calls).toEqual([])
+    expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(STOCK_SOURCE)
+  })
+
+  it('discards a backup stranded by an interrupted rebuild', () => {
+    const fixture = writeRelayFixture()
+    mkdirSync(fixture.backupDir, { recursive: true })
+    writeFileSync(join(fixture.backupDir, 'pty.node'), 'stranded-build')
+
+    const status = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'linux',
+      rebuild: () => writeBuild(fixture, 'patched-build'),
+      verify: () => 'isolated'
+    })
+
+    expect(status).toBe('patched')
+    expect(existsSync(fixture.backupDir)).toBe(false)
+    expect(readFileSync(fixture.buildPath, 'utf8')).toBe('patched-build')
+  })
+})
+
+function writeRelayFixture({ version = '1.1.0', source = STOCK_SOURCE, build = true } = {}) {
+  const root = mkdtempSync(join(projectDir, '.node-pty-cloexec-patch-test-'))
+  cleanupDirs.push(root)
+  const nodePtyDir = join(root, 'node_modules', 'node-pty')
+  const sourcePath = join(nodePtyDir, 'src', 'unix', 'pty.cc')
+  const buildPath = join(nodePtyDir, 'build', 'Release', 'pty.node')
+  mkdirSync(join(nodePtyDir, 'src', 'unix'), { recursive: true })
+  writeFileSync(join(nodePtyDir, 'package.json'), JSON.stringify({ version }))
+  writeFileSync(sourcePath, source)
+  const fixture = {
+    root,
+    sourcePath,
+    buildPath,
+    backupDir: join(nodePtyDir, '.orca-cloexec-prepatch-release'),
+    skipMarkerPath: join(root, SKIP_MARKER_FILENAME)
+  }
+  if (build) {
+    writeBuild(fixture, 'stock-build')
+  }
+  return fixture
+}
+
+function writeBuild(fixture, contents) {
+  mkdirSync(resolve(fixture.buildPath, '..'), { recursive: true })
+  writeFileSync(fixture.buildPath, contents)
+}

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -729,6 +729,29 @@ const NODE_PTY_VERSION = '1.1.0'
 const NODE_PTY_CONSOLE_LIST_PATCH_FILENAME = 'node-pty-1.1.0-console-list-agent-patch.cjs'
 const NODE_PTY_MASTER_CLOEXEC_PATCH_FILENAME = 'node-pty-1.1.0-master-cloexec-patch.cjs'
 const NODE_PTY_CLOEXEC_STATUS_PREFIX = 'ORCA-NPTY-CLOEXEC:'
+/**
+ * Whether the tree the patch left behind still leaks the pty master into every later child.
+ * `fixed` is the only outcome a shared cache entry may be published from.
+ */
+type NodePtyMasterCloexecOutcome = 'fixed' | 'unfixed'
+/**
+ * The statuses that leave a non-leaking tree. Deliberately an allowlist, not a `failed:` denylist:
+ * the script's `skipped:` family is mixed. `skipped:not-linux` is a platform that never leaks, but
+ * `skipped:earlier-attempt-failed`, `skipped:no-compiled-build`, `skipped:unexpected-source` and
+ * the two `skipped:<errno>` forms all mean the patch was refused and the leaky build is still on
+ * disk -- indistinguishable from `failed:` as far as what gets published.
+ */
+const NODE_PTY_CLOEXEC_FIXED_STATUSES: ReadonlySet<string> = new Set([
+  'patched',
+  // The rebuild ran from patched source; only the isolation check could not observe the result.
+  // An unobservable check is not a failed patch, and treating it as one would disable the shared
+  // cache on every host without `lsof`.
+  'patched-unverified',
+  'already-patched',
+  // Unreachable while the platform gate below short-circuits first, but it is the one `skipped:`
+  // that means "nothing to fix" rather than "would not fix it".
+  'skipped:not-linux'
+])
 // Exported for the relay-native-dependency-coverage test, which asserts every
 // native addon the relay bundle imports is either installed here or explicitly
 // declared as degrading without it.
@@ -1220,14 +1243,30 @@ async function installNativeDeps(
   // published -- and by contract immutable -- shared cache entry. Patching afterwards would write
   // through the link, and `.deps-complete` would already have published an unpatched tree that
   // every later host links and skips.
-  if (probe.available) {
-    await applyNodePtyMasterCloexecPatch(conn, remoteDir, platform, hostPlatform, nodePath, signal)
-  }
+  const cloexec = probe.available
+    ? await applyNodePtyMasterCloexecPatch(
+        conn,
+        remoteDir,
+        platform,
+        hostPlatform,
+        nodePath,
+        signal
+      )
+    : 'unfixed'
 
   // Why promotion is gated on the probe and not on npm's exit code: an entry is shared, so the
   // only evidence worth publishing is this host having loaded both addons out of that tree.
+  // Why it is gated on the patch too: a refused or rolled-back patch leaves the pre-patch leaky
+  // build in place, and the cache key hashes this patch's bytes -- so publishing it would hand
+  // every later host on the machine a tree that links, probes loadable, and skips patching.
   if (probe.available && cacheContext && cache) {
-    await promoteRelayNativeDepsCache(conn, cacheContext, cache.key)
+    if (cloexec === 'fixed') {
+      await promoteRelayNativeDepsCache(conn, cacheContext, cache.key)
+    } else {
+      console.warn(
+        `[ssh-relay][NPTY-CLOEXEC-UNSHARED] keeping the native deps at ${remoteDir} (${platform}) private; the tree still leaks the pty master, so it is not publishable as ${cache.key}`
+      )
+    }
   }
 
   // MISSING is non-fatal by design: the relay still serves fs/git/preflight; only native-backed ops fail on hosts that can't build the addons.
@@ -1251,6 +1290,9 @@ async function installNativeDeps(
  *
  * Why a shared cache entry never reaches here: the caller returns as soon as a linked tree probes
  * loadable, so this only ever rewrites a `node_modules` the relay directory still owns privately.
+ *
+ * Returns whether the tree that is left behind still leaks, which is what decides publishability.
+ * The script exits 0 on every outcome by design, so the status line is the only evidence there is.
  */
 async function applyNodePtyMasterCloexecPatch(
   conn: SshConnection,
@@ -1259,11 +1301,11 @@ async function applyNodePtyMasterCloexecPatch(
   hostPlatform: RemoteHostPlatform,
   nodePath: string,
   signal?: AbortSignal
-): Promise<void> {
+): Promise<NodePtyMasterCloexecOutcome> {
   // Linux is the only relay platform that takes forkpty()'s no-O_CLOEXEC path; macOS and Windows
   // ship prebuilds, so forcing a rebuild there would add a first compile to fix nothing.
   if (isWindowsRemoteHost(hostPlatform) || !platform.startsWith('linux')) {
-    return
+    return 'fixed'
   }
   try {
     const command = commandWithNodePath(
@@ -1282,7 +1324,16 @@ async function applyNodePtyMasterCloexecPatch(
         .map((line) => line.trim())
         .find((line) => line.startsWith(NODE_PTY_CLOEXEC_STATUS_PREFIX))
         ?.slice(NODE_PTY_CLOEXEC_STATUS_PREFIX.length) ?? 'no-status'
+    if (!NODE_PTY_CLOEXEC_FIXED_STATUSES.has(status)) {
+      // Warn, not log: the script exits 0 on a refusal too, so this line is the only thing that
+      // says the relay directory will leak a master into every child for its whole life.
+      console.warn(
+        `[ssh-relay][NPTY-CLOEXEC-UNFIXED] pty master still leaks at ${remoteDir} (${platform}): ${status}`
+      )
+      return 'unfixed'
+    }
     console.log(`[ssh-relay][NPTY-CLOEXEC] ${remoteDir} (${platform}): ${status}`)
+    return 'fixed'
   } catch (err) {
     signal?.throwIfAborted()
     // Never fatal: the script restores the working build itself, and a leaky relay beats none. An
@@ -1290,6 +1341,9 @@ async function applyNodePtyMasterCloexecPatch(
     console.warn(
       `[ssh-relay][NPTY-CLOEXEC-FAIL] pty master cloexec patch failed at ${remoteDir} (${platform}): ${(err as Error).message}`
     )
+    // An exec that never answered cannot say which build is on disk, and a tree nobody can vouch
+    // for is exactly the one not to share.
+    return 'unfixed'
   }
 }
 

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -1248,6 +1248,9 @@ async function installNativeDeps(
  *
  * Why it is bounded: the remote script attempts the compile at most once per relay directory, and
  * the directory is content-hashed over the relay manifest -- so at most one compile per bundle.
+ *
+ * Why a shared cache entry never reaches here: the caller returns as soon as a linked tree probes
+ * loadable, so this only ever rewrites a `node_modules` the relay directory still owns privately.
  */
 async function applyNodePtyMasterCloexecPatch(
   conn: SshConnection,

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -727,6 +727,8 @@ function uploadStageNamespaceIfSupported(
 
 const NODE_PTY_VERSION = '1.1.0'
 const NODE_PTY_CONSOLE_LIST_PATCH_FILENAME = 'node-pty-1.1.0-console-list-agent-patch.cjs'
+const NODE_PTY_MASTER_CLOEXEC_PATCH_FILENAME = 'node-pty-1.1.0-master-cloexec-patch.cjs'
+const NODE_PTY_CLOEXEC_STATUS_PREFIX = 'ORCA-NPTY-CLOEXEC:'
 // Exported for the relay-native-dependency-coverage test, which asserts every
 // native addon the relay bundle imports is either installed here or explicitly
 // declared as degrading without it.
@@ -1213,6 +1215,15 @@ async function installNativeDeps(
     }
   }
 
+  // Why this precedes promotion: the patch renames `node-pty/build/Release`, runs `npm rebuild`
+  // and rolls back inside `node_modules`, and promotion turns that directory into a symlink to a
+  // published -- and by contract immutable -- shared cache entry. Patching afterwards would write
+  // through the link, and `.deps-complete` would already have published an unpatched tree that
+  // every later host links and skips.
+  if (probe.available) {
+    await applyNodePtyMasterCloexecPatch(conn, remoteDir, platform, hostPlatform, nodePath, signal)
+  }
+
   // Why promotion is gated on the probe and not on npm's exit code: an entry is shared, so the
   // only evidence worth publishing is this host having loaded both addons out of that tree.
   if (probe.available && cacheContext && cache) {
@@ -1223,6 +1234,58 @@ async function installNativeDeps(
   if (!probe.available) {
     console.warn(
       `[ssh-relay][NPTY-MISSING] native deps installed but require() failed at ${remoteDir} (${platform}). stdout=${probe.output.trim().slice(-200)} stderr=${probe.stderr.trim().slice(-500)}`
+    )
+  }
+}
+
+/**
+ * Re-apply the pty-master FD_CLOEXEC patch the app gets from pnpm to the host's npm copy (#17915).
+ *
+ * Why it is safe to rebuild under a live relay: this only runs from installNativeDeps, so only on a
+ * freshly created directory or a locked repair, and a relay already serving PTYs has pty.node mapped
+ * -- replacing the file on disk does not touch the running process. It keeps the build it started
+ * with and picks up the patched one when it restarts.
+ *
+ * Why it is bounded: the remote script attempts the compile at most once per relay directory, and
+ * the directory is content-hashed over the relay manifest -- so at most one compile per bundle.
+ */
+async function applyNodePtyMasterCloexecPatch(
+  conn: SshConnection,
+  remoteDir: string,
+  platform: RelayPlatform,
+  hostPlatform: RemoteHostPlatform,
+  nodePath: string,
+  signal?: AbortSignal
+): Promise<void> {
+  // Linux is the only relay platform that takes forkpty()'s no-O_CLOEXEC path; macOS and Windows
+  // ship prebuilds, so forcing a rebuild there would add a first compile to fix nothing.
+  if (isWindowsRemoteHost(hostPlatform) || !platform.startsWith('linux')) {
+    return
+  }
+  try {
+    const command = commandWithNodePath(
+      hostPlatform,
+      nodePath,
+      remoteDir,
+      `${shellEscape(nodePath)} ${shellEscape(NODE_PTY_MASTER_CLOEXEC_PATCH_FILENAME)} 2>&1`
+    )
+    const output = await execHostCommand(conn, hostPlatform, command, {
+      timeoutMs: NATIVE_DEPS_COMMAND_TIMEOUT_MS,
+      signal
+    })
+    const status =
+      output
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find((line) => line.startsWith(NODE_PTY_CLOEXEC_STATUS_PREFIX))
+        ?.slice(NODE_PTY_CLOEXEC_STATUS_PREFIX.length) ?? 'no-status'
+    console.log(`[ssh-relay][NPTY-CLOEXEC] ${remoteDir} (${platform}): ${status}`)
+  } catch (err) {
+    signal?.throwIfAborted()
+    // Never fatal: the script restores the working build itself, and a leaky relay beats none. An
+    // interrupted rebuild leaves node-pty unloadable, which the existing repair path reinstalls.
+    console.warn(
+      `[ssh-relay][NPTY-CLOEXEC-FAIL] pty master cloexec patch failed at ${remoteDir} (${platform}): ${(err as Error).message}`
     )
   }
 }

--- a/src/main/ssh/ssh-relay-native-deps-cache-deploy.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache-deploy.test.ts
@@ -85,6 +85,9 @@ import {
 } from './ssh-relay-native-deps-cache-commands'
 
 // Everything after the probe on a healthy install: stderr cleanup, stage cleanup, launch.
+// Stdout of the relay-side pty-master cloexec patch, which runs on Linux hosts once a
+// freshly installed node-pty loads (#17915).
+const NPTY_CLOEXEC_PATCHED = 'ORCA-NPTY-CLOEXEC:patched\n'
 const LAUNCH_TAIL: ExecResponse[] = ['', 'DEAD', '', 'READY']
 
 describe('relay native-deps cache on the deploy path', () => {
@@ -165,6 +168,7 @@ describe('relay native-deps cache on the deploy path', () => {
         '', // chmod prebuilds
         'ORCA-NPTY-PROBE-OK\n',
         '', // rm probe stderr
+        NPTY_CLOEXEC_PATCHED,
         RELAY_NATIVE_CACHE_PROMOTED,
         ...LAUNCH_TAIL
       ])
@@ -214,6 +218,7 @@ describe('relay native-deps cache on the deploy path', () => {
       '', // chmod prebuilds
       'ORCA-NPTY-PROBE-OK\n',
       '', // rm probe stderr
+      NPTY_CLOEXEC_PATCHED,
       '', // publication is attempted and answers nothing
       ...LAUNCH_TAIL
     ])
@@ -235,6 +240,7 @@ describe('relay native-deps cache on the deploy path', () => {
         '', // chmod prebuilds
         'ORCA-NPTY-PROBE-OK\n',
         '', // rm probe stderr
+        NPTY_CLOEXEC_PATCHED,
         '', // promotion attempt (the entry already exists, so it is declined)
         ...LAUNCH_TAIL
       ])
@@ -264,6 +270,7 @@ describe('relay native-deps cache on the deploy path', () => {
       '', // chmod prebuilds
       'ORCA-NPTY-PROBE-OK\n',
       '', // rm probe stderr
+      NPTY_CLOEXEC_PATCHED,
       'DEAD',
       '', // publish the per-launch credential
       'READY'

--- a/src/main/ssh/ssh-relay-native-deps-cache.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache.ts
@@ -26,7 +26,9 @@
  *
  * Linux's `node-pty-1.1.0-master-cloexec-patch.cjs` also mutates in place, but it stays inside rule
  * 1: the deploy path runs it before promotion, and returns early on a linked entry, so it only ever
- * touches a private tree. Its bytes are in the key, so a patched build never links a pre-patch entry.
+ * touches a private tree. Its bytes are in the key, so a patched build never links a pre-patch
+ * entry -- and a tree whose patch was refused or rolled back is not promoted at all, because under
+ * that same key it would publish the leak to every later host on the machine.
  */
 import { createHash } from 'node:crypto'
 import { RELAY_REMOTE_DIR } from './relay-protocol'

--- a/src/main/ssh/ssh-relay-native-deps-cache.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache.ts
@@ -23,6 +23,10 @@
  * Windows is deliberately excluded. node-pty's npm tarball ships win32 prebuilts, so there is no
  * compile to avoid there, and `node-pty-1.1.0-console-list-agent-patch.cjs` mutates the installed
  * tree in place — which rule 1 forbids for a shared one.
+ *
+ * Linux's `node-pty-1.1.0-master-cloexec-patch.cjs` also mutates in place, but it stays inside rule
+ * 1: the deploy path runs it before promotion, and returns early on a linked entry, so it only ever
+ * touches a private tree. Its bytes are in the key, so a patched build never links a pre-patch entry.
  */
 import { createHash } from 'node:crypto'
 import { RELAY_REMOTE_DIR } from './relay-protocol'

--- a/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
@@ -15,6 +15,9 @@ export type SftpWriteCapture = {
 
 type SftpCallback = (err: Error | null, resolved?: string) => void
 const NO_SUCH_SFTP_FILE = Object.assign(new Error('No such file'), { code: 2 })
+// Stdout of the relay-side pty-master cloexec patch; kept as a literal so the fixture states the
+// wire token it is standing in for rather than importing the module under test.
+const NODE_PTY_CLOEXEC_STATUS_PREFIX = 'ORCA-NPTY-CLOEXEC:'
 
 export function makeMockConnection(capture: SftpWriteCapture): SshConnection {
   // Why: production attaches/removes real listeners (including prependOnceListener), so the fake must be an emitter.
@@ -196,6 +199,8 @@ export function makeExecResponses(opts: {
   }
   // Publication is gated on the probe: only a tree this host actually loaded is shared.
   if (loadable) {
+    // The cloexec patch runs first, so what gets published is already patched.
+    slots.push(`${NODE_PTY_CLOEXEC_STATUS_PREFIX}patched\n`)
     slots.push('') // promote the private tree into the shared native-deps cache
   }
   slots.push('', 'DEAD', '', 'READY') // clean stage root, launch, credential, readiness

--- a/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
@@ -199,7 +199,8 @@ export function makeExecResponses(opts: {
   }
   // Publication is gated on the probe: only a tree this host actually loaded is shared.
   if (loadable) {
-    // The cloexec patch runs first, so what gets published is already patched.
+    // The cloexec patch runs first, and publication is gated on its status, so `patched` is what
+    // makes the promote exec below reachable at all.
     slots.push(`${NODE_PTY_CLOEXEC_STATUS_PREFIX}patched\n`)
     slots.push('') // promote the private tree into the shared native-deps cache
   }

--- a/src/main/ssh/ssh-relay-native-deps-install.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install.test.ts
@@ -630,6 +630,7 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
       '', // chmod prebuilds
       'ORCA-NPTY-PROBE-OK\n',
       '', // rm probe stderr
+      'ORCA-NPTY-CLOEXEC:patched\n', // pty-master cloexec patch on the loadable node-pty
       'DEAD',
       '', // publish the per-launch credential
       'READY'

--- a/src/main/ssh/ssh-relay-native-deps-probe-verdict.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-probe-verdict.test.ts
@@ -85,6 +85,9 @@ import {
   type SftpWriteCapture
 } from './ssh-relay-native-deps-install-fixture'
 
+// Stdout of the relay-side pty-master cloexec patch, which runs on Linux hosts once a
+// freshly installed node-pty loads (#17915).
+const NPTY_CLOEXEC_PATCHED = 'ORCA-NPTY-CLOEXEC:patched\n'
 const NODE_PTY_RESET = "rm -rf 'node_modules/node-pty'"
 const WATCHER_RESET = "rm -rf 'node_modules/@parcel/watcher'"
 
@@ -225,6 +228,7 @@ describe('native-deps repair probe verdicts', () => {
       '', // chmod prebuilds
       'ORCA-NPTY-PROBE-OK\n',
       '', // rm probe stderr
+      NPTY_CLOEXEC_PATCHED,
       'DEAD',
       '', // publish the per-launch credential
       'READY'
@@ -281,6 +285,7 @@ describe('native-deps repair probe verdicts', () => {
       '', // chmod prebuilds
       'ORCA-NPTY-PROBE-OK\n',
       '', // rm probe stderr
+      NPTY_CLOEXEC_PATCHED,
       'DEAD',
       '', // publish the per-launch credential
       'READY'
@@ -324,6 +329,7 @@ describe('native-deps repair probe verdicts', () => {
       '', // chmod prebuilds
       'ORCA-NPTY-PROBE-OK\n',
       '', // rm probe stderr
+      NPTY_CLOEXEC_PATCHED,
       'DEAD',
       '', // publish the per-launch credential
       'READY'

--- a/src/main/ssh/ssh-relay-node-pty-spawn-repair.test.ts
+++ b/src/main/ssh/ssh-relay-node-pty-spawn-repair.test.ts
@@ -103,6 +103,9 @@ const ABI_MISMATCH: TerminalUnavailableCause = {
 
 // The relay dir is complete but node-pty will not load, which is exactly what the spawn-time cause
 // describes. @parcel/watcher is healthy, so only node-pty is reset and rebuilt.
+// Stdout of the relay-side pty-master cloexec patch, which runs on Linux hosts once a
+// freshly installed node-pty loads (#17915).
+const NPTY_CLOEXEC_PATCHED = 'ORCA-NPTY-CLOEXEC:patched\n'
 const NODE_PTY_BROKEN = 'ORCA-NATIVE-DEPS-MISSING:node-pty\nMISSING'
 
 function repairSucceedsResponses(): ExecResponse[] {
@@ -116,6 +119,7 @@ function repairSucceedsResponses(): ExecResponse[] {
     '', // chmod prebuilds
     'ORCA-NPTY-PROBE-OK\n', // node-pty loads again
     '', // rm -f probe stderr
+    NPTY_CLOEXEC_PATCHED,
     'DEAD',
     '', // publish the per-launch credential
     'READY'

--- a/src/main/ssh/ssh-relay-pty-master-cloexec-install.test.ts
+++ b/src/main/ssh/ssh-relay-pty-master-cloexec-install.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RelayInstallMarkerModule from './ssh-relay-install-marker'
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/mock/app' }
+}))
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+  readFileSync: vi.fn().mockReturnValue('0.1.0+testhash')
+}))
+
+vi.mock('./relay-protocol', () => ({
+  RELAY_VERSION: '0.1.0',
+  RELAY_REMOTE_DIR: '.orca-remote',
+  parseUnameToRelayPlatform: vi.fn().mockReturnValue('linux-x64'),
+  RELAY_SENTINEL: 'ORCA-RELAY v0.1.0 READY\n',
+  RELAY_SENTINEL_TIMEOUT_MS: 10_000
+}))
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  uploadDirectory: vi.fn().mockResolvedValue(undefined),
+  waitForSentinel: vi.fn().mockResolvedValue({
+    write: vi.fn(),
+    onData: vi.fn(),
+    onClose: vi.fn()
+  }),
+  isUnconfirmedSshCommandTermination: (error: unknown) =>
+    error instanceof Error &&
+    (error as Error & { sshChannelCloseConfirmed?: boolean }).sshChannelCloseConfirmed === false,
+  execCommand: vi.fn()
+}))
+
+vi.mock('./ssh-remote-node-resolution', () => ({
+  resolveRemoteNodePath: vi.fn().mockResolvedValue('/usr/bin/node')
+}))
+
+vi.mock('./ssh-relay-install-marker', async (importOriginal) => ({
+  ...(await importOriginal<typeof RelayInstallMarkerModule>()),
+  createRelayInstallMarkerFileName: () => '.sftp-namespace-00000000000000000000000000000000'
+}))
+
+vi.mock('./ssh-relay-versioned-install', () => ({
+  readLocalFullVersion: vi.fn().mockReturnValue('0.1.0+testhash'),
+  computeRemoteRelayDir: (home: string, v: string) => `${home}/.orca-remote/relay-${v}`,
+  isRelayAlreadyInstalled: vi.fn().mockResolvedValue(false),
+  finalizeInstall: vi.fn().mockResolvedValue(undefined),
+  abandonInstall: vi.fn().mockResolvedValue(undefined),
+  gcOldRelayVersions: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-relay-install-lock', () => ({
+  acquireInstallLock: vi.fn().mockResolvedValue(undefined),
+  RELAY_INSTALL_LOCK_NAME: '.install-lock'
+}))
+
+vi.mock('./ssh-relay-repair-lock', () => ({
+  tryAcquireRelayRepairLock: vi.fn().mockResolvedValue('acquired')
+}))
+
+vi.mock('./ssh-relay-gc-claim', () => ({
+  releaseRelayGcClaimWithRetry: vi.fn().mockResolvedValue('released'),
+  tryAcquireRelayGcClaim: vi.fn().mockResolvedValue('launch-token'),
+  waitForRelayGcClaimRelease: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-connection-utils', () => ({
+  shellEscape: (s: string) => `'${s}'`
+}))
+
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+import { execCommand } from './ssh-relay-deploy-helpers'
+import { parseUnameToRelayPlatform } from './relay-protocol'
+import {
+  makeExecResponses,
+  makeStagedFirstInstallExecPrefix,
+  makeMockConnection,
+  type ExecResponse,
+  type SftpWriteCapture
+} from './ssh-relay-native-deps-install-fixture'
+
+const PATCH_ASSET = 'node-pty-1.1.0-master-cloexec-patch.cjs'
+
+/**
+ * The relay installs stock node-pty from npm, so the app's pnpm patch never reaches it and every
+ * later child of the relay inherits a live pty master (#17915). The compile that closes it sits on
+ * the connect path, so what these specs pin is the blast radius, not the patch itself.
+ */
+describe('relay pty-master close-on-exec patch on the install path', () => {
+  const sftpCapture: SftpWriteCapture = {
+    paths: [],
+    contents: {},
+    execCallCountAtWrite: {}
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(execCommand).mockReset().mockResolvedValue('')
+    sftpCapture.paths.length = 0
+    vi.mocked(parseUnameToRelayPlatform).mockReturnValue('linux-x64')
+  })
+
+  function feed(execResponses: ExecResponse[]): void {
+    const mockExec = vi.mocked(execCommand)
+    for (const response of execResponses) {
+      if (typeof response === 'string') {
+        mockExec.mockResolvedValueOnce(response)
+      } else {
+        mockExec.mockRejectedValueOnce(new Error(response.reject))
+      }
+    }
+  }
+
+  function patchCommands(): string[] {
+    return vi
+      .mocked(execCommand)
+      .mock.calls.map(([, command]) => command)
+      .filter((command) => command.includes(PATCH_ASSET))
+  }
+
+  it('runs the patch on a Linux relay once node-pty is proven loadable', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(makeExecResponses({ npmInstall: 'ok', probe: 'ok' }))
+
+    await deployAndLaunchRelay(conn)
+
+    expect(patchCommands()).toHaveLength(1)
+    expect(patchCommands()[0]).toContain("'/usr/bin/node'")
+  })
+
+  it('leaves an unloadable node-pty alone rather than rebuilding it blind', async () => {
+    // A relay that could not build node-pty has nothing to fall back to, and the existing
+    // reinstall path owns that repair.
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      makeExecResponses({
+        npmInstall: 'ok',
+        probe: 'missing',
+        repairProbe: 'missing'
+      })
+    )
+
+    await deployAndLaunchRelay(conn)
+
+    expect(patchCommands()).toEqual([])
+  })
+
+  it('never adds a compile to a macOS relay, which does not leak the master', async () => {
+    vi.mocked(parseUnameToRelayPlatform).mockReturnValue('darwin-arm64')
+    const conn = makeMockConnection(sftpCapture)
+    feed([
+      ...makeStagedFirstInstallExecPrefix(),
+      '', // npm install native deps
+      '', // chmod prebuilds
+      'ORCA-NPTY-PROBE-OK\n',
+      '', // rm probe stderr
+      '', // clean stage root
+      'DEAD',
+      '', // publish the per-launch credential
+      'READY'
+    ])
+
+    await deployAndLaunchRelay(conn)
+
+    expect(patchCommands()).toEqual([])
+  })
+
+  it('connects anyway when the patch command fails outright', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    const responses = makeExecResponses({ npmInstall: 'ok', probe: 'ok' })
+    const patchSlot = responses.findIndex(
+      (response) => typeof response === 'string' && response.includes('ORCA-NPTY-CLOEXEC:')
+    )
+    expect(patchSlot).toBeGreaterThan(-1)
+    responses[patchSlot] = { reject: 'no such file or directory' }
+    feed(responses)
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+  })
+})

--- a/src/main/ssh/ssh-relay-pty-master-cloexec-install.test.ts
+++ b/src/main/ssh/ssh-relay-pty-master-cloexec-install.test.ts
@@ -131,6 +131,34 @@ describe('relay pty-master close-on-exec patch on the install path', () => {
       .filter((command) => command.includes(PATCH_ASSET))
   }
 
+  /** Whether this deploy elected itself publisher of the shared entry. */
+  function promoted(): boolean {
+    return vi
+      .mocked(execCommand)
+      .mock.calls.some(([, command]) => command.includes('mkdir "$cache"'))
+  }
+
+  /**
+   * A cache-miss first install whose patch reports `status`. The promote slot is fed either way,
+   * so a run that wrongly promotes reads a valid response rather than falling off the end -- the
+   * assertion has to be the absence of the command itself, not a downstream crash.
+   */
+  function firstInstallReporting(status: string): ExecResponse[] {
+    return [
+      ...makeStagedFirstInstallExecPrefix(),
+      '', // npm install native deps
+      '', // chmod prebuilds
+      'ORCA-NPTY-PROBE-OK\n',
+      '', // rm probe stderr
+      `ORCA-NPTY-CLOEXEC:${status}\n`,
+      '', // promote into the shared native-deps cache, if this deploy still gets that far
+      '', // clean stage root
+      'DEAD',
+      '', // publish the per-launch credential
+      'READY'
+    ]
+  }
+
   it('runs the patch on a Linux relay once node-pty is proven loadable', async () => {
     const conn = makeMockConnection(sftpCapture)
     feed(makeExecResponses({ npmInstall: 'ok', probe: 'ok' }))
@@ -158,6 +186,61 @@ describe('relay pty-master close-on-exec patch on the install path', () => {
     expect(patchAt).toBeGreaterThan(-1)
     expect(promoteAt).toBeGreaterThan(-1)
     expect(patchAt).toBeLessThan(promoteAt)
+  })
+
+  it('does not publish a tree whose patch failed and rolled back', async () => {
+    // The script rolls `pty.cc` and `build/Release` back to the pre-patch, still-leaky build and
+    // reports `failed:` with exit 0, so nothing throws. Publishing that tree would be worse than
+    // the leak this PR closes: the key hashes the patch's bytes, so every later host on the
+    // machine links the entry, probes it loadable, and skips patching. Stay private instead.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const conn = makeMockConnection(sftpCapture)
+      feed(firstInstallReporting('failed:npm rebuild node-pty failed: gyp ERR! not found: make'))
+
+      await deployAndLaunchRelay(conn)
+
+      expect(patchCommands()).toHaveLength(1)
+      expect(promoted()).toBe(false)
+      expect(warn.mock.calls.map((args) => String(args[0] ?? '')).join('\n')).toContain(
+        '[ssh-relay][NPTY-CLOEXEC-UNSHARED]'
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('does not publish a tree the patch refused to touch', async () => {
+    // `skipped:` is not one verdict. Every form except `skipped:not-linux` means the patch was
+    // declined and the leaky build is still on disk, which is indistinguishable from `failed:`
+    // as far as what would get published.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const conn = makeMockConnection(sftpCapture)
+      feed(firstInstallReporting('skipped:earlier-attempt-failed'))
+
+      await deployAndLaunchRelay(conn)
+
+      expect(promoted()).toBe(false)
+      // A refusal exits 0, so the warn is the only signal that this host stayed leaky.
+      expect(warn.mock.calls.map((args) => String(args[0] ?? '')).join('\n')).toContain(
+        '[ssh-relay][NPTY-CLOEXEC-UNFIXED]'
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('still publishes a tree that was patched but whose isolation check could not run', async () => {
+    // `patched-unverified` rebuilt from patched source; only the check that watches a later child
+    // could not observe the result. An unobservable check is not a failed patch, and refusing to
+    // publish here would disable the shared cache on every host without `lsof`.
+    const conn = makeMockConnection(sftpCapture)
+    feed(firstInstallReporting('patched-unverified'))
+
+    await deployAndLaunchRelay(conn)
+
+    expect(promoted()).toBe(true)
   })
 
   it('never patches through a symlink into an entry another relay already published', async () => {

--- a/src/main/ssh/ssh-relay-pty-master-cloexec-install.test.ts
+++ b/src/main/ssh/ssh-relay-pty-master-cloexec-install.test.ts
@@ -78,6 +78,12 @@ import {
   type ExecResponse,
   type SftpWriteCapture
 } from './ssh-relay-native-deps-install-fixture'
+import { RELAY_NATIVE_CACHE_LINKED } from './ssh-relay-native-deps-cache-commands'
+import { RELAY_ARTIFACTS } from '../../shared/relay-artifacts'
+import {
+  computeRelayNativeDepsCacheKey,
+  RELAY_NATIVE_DEPS_PATCH_ARTIFACT_PATTERN
+} from './ssh-relay-native-deps-cache'
 
 const PATCH_ASSET = 'node-pty-1.1.0-master-cloexec-patch.cjs'
 
@@ -111,6 +117,13 @@ describe('relay pty-master close-on-exec patch on the install path', () => {
     }
   }
 
+  function firstInstall(cacheAnswer: string, tail: ExecResponse[]): ExecResponse[] {
+    const prefix = makeStagedFirstInstallExecPrefix()
+    // The prefix's last slot is the shared native-deps cache probe.
+    prefix[prefix.length - 1] = cacheAnswer
+    return [...prefix, ...tail]
+  }
+
   function patchCommands(): string[] {
     return vi
       .mocked(execCommand)
@@ -126,6 +139,46 @@ describe('relay pty-master close-on-exec patch on the install path', () => {
 
     expect(patchCommands()).toHaveLength(1)
     expect(patchCommands()[0]).toContain("'/usr/bin/node'")
+  })
+
+  it('patches the private tree before it is published to the shared native-deps cache', async () => {
+    // Promotion moves `node_modules` into `~/.orca-remote/native/<key>` and leaves a symlink
+    // behind, and a published entry is immutable by contract. Patching afterwards would rename,
+    // rebuild and roll back inside a tree every other relay on the host links -- and the
+    // `.deps-complete` written by promotion would have published an unpatched tree that every
+    // later host links and skips. The ordering is invisible in review, so pin it.
+    const conn = makeMockConnection(sftpCapture)
+    feed(makeExecResponses({ npmInstall: 'ok', probe: 'ok' }))
+
+    await deployAndLaunchRelay(conn)
+
+    const commands = vi.mocked(execCommand).mock.calls.map(([, command]) => command)
+    const patchAt = commands.findIndex((command) => command.includes(PATCH_ASSET))
+    const promoteAt = commands.findIndex((command) => command.includes('mkdir "$cache"'))
+    expect(patchAt).toBeGreaterThan(-1)
+    expect(promoteAt).toBeGreaterThan(-1)
+    expect(patchAt).toBeLessThan(promoteAt)
+  })
+
+  it('never patches through a symlink into an entry another relay already published', async () => {
+    // A linked entry was built under a key that hashes this patch's bytes, so it is already
+    // patched; re-running the patch would rebuild inside the shared tree.
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      firstInstall(RELAY_NATIVE_CACHE_LINKED, [
+        '', // chmod prebuilds, through the symlink
+        'ORCA-NPTY-PROBE-OK\n',
+        '', // rm probe stderr
+        '', // clean stage root
+        'DEAD',
+        '', // publish the per-launch credential
+        'READY'
+      ])
+    )
+
+    await deployAndLaunchRelay(conn)
+
+    expect(patchCommands()).toEqual([])
   })
 
   it('leaves an unloadable node-pty alone rather than rebuilding it blind', async () => {
@@ -154,6 +207,7 @@ describe('relay pty-master close-on-exec patch on the install path', () => {
       '', // chmod prebuilds
       'ORCA-NPTY-PROBE-OK\n',
       '', // rm probe stderr
+      '', // promote into the shared native-deps cache
       '', // clean stage root
       'DEAD',
       '', // publish the per-launch credential
@@ -176,5 +230,24 @@ describe('relay pty-master close-on-exec patch on the install path', () => {
     feed(responses)
 
     await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+  })
+})
+
+describe('the shipped patch is part of the shared native-deps cache key', () => {
+  it('mints a new entry, so a pre-fix unpatched tree is never linked by a patched build', () => {
+    const artifact = RELAY_ARTIFACTS.find((entry) => entry.filename === PATCH_ASSET)
+    expect(artifact).toBeDefined()
+    // A windowsOnly artifact never reaches a Linux relay dir, so it would drop out of the key.
+    expect(artifact?.windowsOnly).toBeFalsy()
+    expect(RELAY_NATIVE_DEPS_PATCH_ARTIFACT_PATTERN.test(PATCH_ASSET)).toBe(true)
+
+    const deps = { 'node-pty': '1.1.0' }
+    expect(
+      computeRelayNativeDepsCacheKey({
+        platform: 'linux-x64',
+        deps,
+        patchSources: [{ filename: PATCH_ASSET, contents: 'patch bytes' }]
+      })
+    ).not.toBe(computeRelayNativeDepsCacheKey({ platform: 'linux-x64', deps }))
   })
 })

--- a/src/main/ssh/ssh-relay-sftp-namespace-install.test.ts
+++ b/src/main/ssh/ssh-relay-sftp-namespace-install.test.ts
@@ -105,6 +105,9 @@ const RELAY_SUFFIX = '.orca-remote/relay-0.1.0+testhash'
 const SHELL_RELAY_DIR = `${SHELL_HOME}/${RELAY_SUFFIX}`
 const SFTP_RELAY_DIR = `${SFTP_HOME}/${RELAY_SUFFIX}`
 const MARKER_PATTERN = /\.sftp-namespace-[0-9a-f]{32}/
+// Stdout of the relay-side pty-master cloexec patch, which runs on Linux hosts once a
+// freshly installed node-pty loads (#17915).
+const NPTY_CLOEXEC_PATCHED = 'ORCA-NPTY-CLOEXEC:patched\n'
 const STAGE_OWNER = '.sftp-namespace-00000000000000000000000000000000'
 const STAGE_RESERVED = `__ORCA_UPLOAD_STAGE_SLOT__${STAGE_OWNER}:slot-0`
 const STAGE_PROMOTED = `__ORCA_UPLOAD_STAGE_PROMOTION__${STAGE_OWNER}:PROMOTED`
@@ -256,6 +259,7 @@ const POSIX_FIRST_INSTALL = [
   '', // chmod prebuilds
   'ORCA-NPTY-PROBE-OK\n',
   '', // rm probe stderr
+  NPTY_CLOEXEC_PATCHED,
   '', // promote into the shared native-deps cache
   '', // clean stage root
   'DEAD',
@@ -275,6 +279,7 @@ const POSIX_SYSTEM_SSH_FIRST_INSTALL = [
   '', // chmod prebuilds
   'ORCA-NPTY-PROBE-OK\n',
   '', // rm probe stderr
+  NPTY_CLOEXEC_PATCHED,
   '', // promote into the shared native-deps cache
   '', // clean stage root
   'DEAD',
@@ -293,6 +298,7 @@ const POSIX_REPAIR = [
   '', // chmod prebuilds
   'ORCA-NPTY-PROBE-OK\n',
   '', // rm probe stderr
+  NPTY_CLOEXEC_PATCHED,
   'DEAD',
   '', // publish the per-launch credential
   'READY'
@@ -703,6 +709,7 @@ describe('relay repair writes on a split SFTP namespace', () => {
       '', // chmod prebuilds
       'ORCA-NPTY-PROBE-OK\n',
       '', // rm probe stderr
+      NPTY_CLOEXEC_PATCHED,
       'DEAD',
       '', // remote credential generation
       'READY'
@@ -733,6 +740,7 @@ describe('relay repair writes on a split SFTP namespace', () => {
       '', // chmod prebuilds
       'ORCA-NPTY-PROBE-OK\n',
       '', // rm probe stderr
+      NPTY_CLOEXEC_PATCHED,
       'DEAD',
       '', // remote credential generation
       'READY'

--- a/src/shared/relay-artifacts.ts
+++ b/src/shared/relay-artifacts.ts
@@ -51,6 +51,11 @@ export const RELAY_ARTIFACTS: readonly RelayArtifact[] = [
   // title request with no title and no error.
   { filename: 'wsl-transcript-fs-process-entry.js' },
   { filename: 'node-pty-1.1.0-console-list-agent-patch.cjs', windowsOnly: true },
+  // Only Linux relays run it, but it ships everywhere: the manifest's only
+  // platform axis is Windows, and a second one would buy nothing but a fork in
+  // the hash. Its presence is what moves a host to a fresh relay directory, and
+  // therefore to a re-install that can apply it.
+  { filename: 'node-pty-1.1.0-master-cloexec-patch.cjs' },
   // Optional because only a Windows build machine can compile it. Without it the
   // relay reads the process table through a PowerShell scan instead -- slower,
   // but correct, so a relay built anywhere else is still shippable.

--- a/src/shared/relay-optional-artifacts.test.ts
+++ b/src/shared/relay-optional-artifacts.test.ts
@@ -31,4 +31,12 @@ describe('optional relay artifacts', () => {
     expect(relayArtifactFilenames(true)).toContain('relay.js')
     expect(relayArtifactFilenames(true)).toContain('node-pty-1.1.0-console-list-agent-patch.cjs')
   })
+
+  it('ships the pty-master cloexec patch to every platform', () => {
+    // Only Linux runs it, but its bytes are what change the relay content hash, and therefore what
+    // moves an upgrading host to a fresh directory whose install can apply it (#17915).
+    for (const isWindows of [true, false]) {
+      expect(relayArtifactFilenames(isWindows)).toContain('node-pty-1.1.0-master-cloexec-patch.cjs')
+    }
+  })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1398 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1398 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​467 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​466 |

<!-- /orca-pr-loc -->

> Stacked on #17914. Review that first; retarget to `main` once it merges.

Closes #17915 — the half of #8362 that #17914 left open, which is the half that matters, because the leak is Linux-only and relay hosts are overwhelmingly Linux.

## Option 2 is dead, and it was measured rather than argued

Bumping the relay pin to `node-pty@1.2.0-beta.4` **does not fix the bug.** Upstream's `pty_close_inherited_fds()` is called at `pty.cc:473`, inside `case 0:` of the forkpty switch — in the *pty child*, just before `execvp`. The parent's master is never marked. Measured on `node:22`:

```
node-pty 1.2.0-beta.4 master fd=26 flags=00404002 cloexec=false
later PTY child ptmx rows:            none
later child_process child ptmx rows:  26 -> /dev/pts/ptmx
```

So a beta bump fixes the pty-child half and leaves the `child_process` half — every git helper, probe and agent CLI — still holding dead terminals open. That kills the option before its beta status, its desync from the app's pinned 1.1.0, or the coverage test asserting they match (`relay-native-dependency-coverage.test.ts:93`) even come up.

## Option 1 is far cheaper than #17915 assumed

I was worried this adds a node-gyp compile to the most failure-prone path in SSH. It does not, because **`node-pty@1.1.0` ships no Linux prebuild** — only `darwin-{x64,arm64}` and `win32-{x64,arm64}`. Every Linux relay install *already* runs `node-gyp rebuild`; that is why `installNativeDeps` has a toolchain probe and a node-pty-less fallback in the first place.

So this adds a **second** compile to a path that already compiles, on the only platform that leaks. Measured: initial install 19-23s, patch + rebuild **5s**, second run 0s (`already-patched`). macOS and Windows relays are excluded entirely — they use prebuilds and do not leak, so forcing a rebuild there would add a *first* compile to fix nothing.

## Failure behaviour — the property that mattered most

The remote script refuses unless: platform is Linux; no skip marker exists; node-pty is exactly 1.1.0 **and `src/unix/pty.cc` hashes to the published sha**; and there is an existing `build/Release/pty.node` to fall back on. It then renames the working build aside, patches, rebuilds (200s cap, inside the caller's 240s), and verifies **in a child process** — a bad build can abort on require — that a plain `child_process` child's `/proc/self/fd` has no `ptmx`.

On any failure — non-zero npm, timeout, npm missing, addon will not load, or still leaking — it deletes the partial build, reverts `pty.cc` to the published bytes, renames the backup back, writes a skip marker, and prints `ORCA-NPTY-CLOEXEC:failed:<reason>`. **It never throws**, and the TS caller swallows the command entirely. Verified in-container with a corrupted `binding.gyp`:

```
status head:        failed:npm rebuild node-pty exited 1: ...gyp ERR! not ok
node-pty still loads: true
pty.cc sha:         5e1005d6...  (the published bytes)
build/Release:      pty.node
second attempt:     skipped:earlier-attempt-failed
```

If `/proc` cannot answer it returns `patched-unverified` and **keeps** the build — an unobservable flag is not evidence the rebuild was wrong. If the SSH channel dies mid-rebuild, node-pty fails the existing probe, the existing repair path reinstalls from already-patched source, and the next run reaps the stranded backup. **One compile attempt per relay directory, ever** — no backoff loop.

## Before / after (docker, `node:22`, relay-style `npm install`)

```
BEFORE  master fd=26 flags=00404002  cloexec=false
        later PTY child ptmx:            26 -> /dev/pts/ptmx
        later child_process child ptmx:  26 -> /dev/pts/ptmx
AFTER   master fd=26 flags=002404002 cloexec=true
        later PTY child ptmx:            none
        later child_process child ptmx:  none
```

**Does a relay host stop accumulating `/dev/pts` devices? Yes**, once it lands on a relay directory built with this asset. Two honest carve-outs: a relay process already running keeps its `dlopen`'d unpatched binary until it restarts, and a host whose compile fails stays leaky-but-working.

## Reuse, not a parallel mechanism

Delivery follows the existing precedent exactly — `config/relay-assets/*.cjs`, declared in `RELAY_ARTIFACTS`, copied by `build-relay.mjs`, uploaded and probed through `relayArtifactFilenames`. Shipping the asset on all platforms is deliberate: its bytes enter the relay content hash, which is what moves an upgrading host onto a fresh directory whose install can apply it. Execution is Linux-gated.

Application is one call at the end of `installNativeDeps`, reached only after `probeInstalledNativeDeps` proves node-pty loadable — so it runs only on a freshly created directory or a locked repair. A relay already serving PTYs has `pty.node` mapped, so replacing the file underneath it does not touch the running process.

## Verification

10 relay/deploy test files: 136 passed, 7 skipped. `pnpm tc:node` clean. `check:code-quality:changed`: 0 new findings.

New: `node-pty-master-cloexec-patch.test.mjs` (10 cases — anchors, round-trip revert, version/source refusal, rollback on failed compile, rollback on a still-leaking build, the one-attempt bound, platform gate, no-build guard, stranded-backup reaping) against a byte-exact vendored `pty.cc` fixture; and `ssh-relay-pty-master-cloexec-install.test.ts` (runs on Linux after a healthy probe, skipped on darwin, skipped when node-pty is unloadable, connect still succeeds when the command rejects).

Fixes #17915
Refs #8362