### PR TITLE
fix(github-project): sort and group empty field values last in both directions

### DIFF
--- a/src/renderer/src/components/github-project/group-sort.test.ts
+++ b/src/renderer/src/components/github-project/group-sort.test.ts
@@ -33,6 +33,27 @@ const iterationField: GitHubProjectField = {
   ]
 }
 
+const assigneesField: GitHubProjectField = {
+  kind: 'field',
+  id: 'F_assignees',
+  name: 'Assignees',
+  dataType: 'ASSIGNEES'
+}
+
+const labelsField: GitHubProjectField = {
+  kind: 'field',
+  id: 'F_labels',
+  name: 'Labels',
+  dataType: 'LABELS'
+}
+
+const textField: GitHubProjectField = {
+  kind: 'field',
+  id: 'F_text',
+  name: 'Notes',
+  dataType: 'TEXT'
+}
+
 function makeRow(
   id: string,
   position: number,
@@ -206,6 +227,66 @@ describe('sortRows', () => {
     expect(sorted.map((r) => r.id)).toEqual(['rHas', 'rEmpty'])
   })
 
+  it('sorts an empty user list last in both directions, like a missing value', () => {
+    // Why: the DESC flip negated the empty branch, sending unassigned rows to the top.
+    const rows = [
+      makeRow('empty-list', 0, {
+        F_assignees: { kind: 'users', fieldId: 'F_assignees', users: [] }
+      }),
+      makeRow('alice', 1, {
+        F_assignees: {
+          kind: 'users',
+          fieldId: 'F_assignees',
+          users: [{ login: 'alice', name: null, avatarUrl: null }]
+        }
+      }),
+      makeRow('no-value', 2, {})
+    ]
+
+    for (const direction of ['ASC', 'DESC'] as const) {
+      const view = makeView(assigneesField, { direction, field: assigneesField })
+      const sorted = sortRows(makeTable(view, rows), rows)
+      expect(sorted.map((r) => r.id)).toEqual(['alice', 'empty-list', 'no-value'])
+    }
+  })
+
+  it('sorts an empty label list last in both directions, like a missing value', () => {
+    const rows = [
+      makeRow('empty-list', 0, {
+        F_labels: { kind: 'labels', fieldId: 'F_labels', labels: [] }
+      }),
+      makeRow('bug', 1, {
+        F_labels: {
+          kind: 'labels',
+          fieldId: 'F_labels',
+          labels: [{ name: 'bug', color: 'ff0000' }]
+        }
+      }),
+      makeRow('no-value', 2, {})
+    ]
+
+    for (const direction of ['ASC', 'DESC'] as const) {
+      const view = makeView(labelsField, { direction, field: labelsField })
+      const sorted = sortRows(makeTable(view, rows), rows)
+      expect(sorted.map((r) => r.id)).toEqual(['bug', 'empty-list', 'no-value'])
+    }
+  })
+
+  it('sorts a blank text value last in both directions, like a missing value', () => {
+    // Why reachable: the normalizer turns a null GitHub text/date into ''.
+    const rows = [
+      makeRow('blank', 0, { F_text: { kind: 'text', fieldId: 'F_text', text: '' } }),
+      makeRow('alpha', 1, { F_text: { kind: 'text', fieldId: 'F_text', text: 'alpha' } }),
+      makeRow('no-value', 2, {})
+    ]
+
+    for (const direction of ['ASC', 'DESC'] as const) {
+      const view = makeView(textField, { direction, field: textField })
+      const sorted = sortRows(makeTable(view, rows), rows)
+      expect(sorted.map((r) => r.id)).toEqual(['alpha', 'blank', 'no-value'])
+    }
+  })
+
   it('keeps sort fallback finite when row positions are absent', () => {
     const view = makeView(singleSelectField)
     const rows = [
@@ -220,6 +301,31 @@ describe('sortRows', () => {
 })
 
 describe('groupRows', () => {
+  it('groups a present-but-empty user list with the missing-value rows', () => {
+    // Why: an empty list fell through to a blank-label group, which renders as "All".
+    const view = { ...makeView(assigneesField), groupByFields: [assigneesField] }
+    const rows = [
+      makeRow('empty-list', 0, {
+        F_assignees: { kind: 'users', fieldId: 'F_assignees', users: [] }
+      }),
+      makeRow('alice', 1, {
+        F_assignees: {
+          kind: 'users',
+          fieldId: 'F_assignees',
+          users: [{ login: 'alice', name: null, avatarUrl: null }]
+        }
+      }),
+      makeRow('no-value', 2, {})
+    ]
+
+    const groups = groupRows(makeTable(view, rows), rows)
+
+    expect(groups.map((group) => [group.label, group.rows.map((r) => r.id)])).toEqual([
+      ['alice', ['alice']],
+      ['No Assignees', ['empty-list', 'no-value']]
+    ])
+  })
+
   it('places the empty group last', () => {
     const view = {
       ...makeView(singleSelectField),

--- a/src/shared/github/project-group-sort.ts
+++ b/src/shared/github/project-group-sort.ts
@@ -24,6 +24,29 @@ export type ProjectGroup = {
 
 const EMPTY_GROUP_KEY = '__empty__'
 
+type ProjectFieldValue = GitHubProjectRow['fieldValuesByFieldId'][string]
+
+/** False for anything that renders as an empty cell — absent, or present with a blank payload. */
+function hasNonEmptyFieldValue(value: ProjectFieldValue | undefined): boolean {
+  if (!value) {
+    return false
+  }
+  switch (value.kind) {
+    case 'users':
+      return Boolean(value.users[0]?.login)
+    case 'labels':
+      return Boolean(value.labels[0]?.name)
+    case 'text':
+      return value.text.trim().length > 0
+    case 'date':
+      return value.date.trim().length > 0
+    case 'iteration':
+    case 'number':
+    case 'single-select':
+      return true
+  }
+}
+
 // Why: use a finite sentinel instead of Infinity so subtractions in the sort
 // comparator stay finite. `Infinity - Infinity` is NaN, which makes
 // Array.sort's behavior implementation-defined and skips later tie-breaks.
@@ -35,7 +58,7 @@ function getFieldValueForGrouping(
   field: GitHubProjectField
 ): { key: string; label: string; orderHint: number; iteration: ProjectGroup['iteration'] } {
   const value = row.fieldValuesByFieldId[field.id]
-  if (!value) {
+  if (!hasNonEmptyFieldValue(value)) {
     return {
       key: EMPTY_GROUP_KEY,
       label: labelForEmpty(field),
@@ -144,14 +167,11 @@ function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProje
   const field = sort.field
   const aValue = a.fieldValuesByFieldId[field.id]
   const bValue = b.fieldValuesByFieldId[field.id]
-  if (!aValue && !bValue) {
-    return 0
-  }
-  if (!aValue) {
-    return 1
-  }
-  if (!bValue) {
-    return -1
+  // Why: return before the trailing DESC flip so empty sorts last in both directions.
+  const aFilled = hasNonEmptyFieldValue(aValue)
+  const bFilled = hasNonEmptyFieldValue(bValue)
+  if (!aFilled || !bFilled) {
+    return aFilled === bFilled ? 0 : aFilled ? -1 : 1
   }
 
   let cmp = 0
@@ -182,29 +202,9 @@ function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProje
   } else if (aValue.kind === 'text' && bValue.kind === 'text') {
     cmp = aValue.text.localeCompare(bValue.text)
   } else if (aValue.kind === 'users' && bValue.kind === 'users') {
-    const aLogin = aValue.users[0]?.login ?? ''
-    const bLogin = bValue.users[0]?.login ?? ''
-    if (!aLogin && !bLogin) {
-      cmp = 0
-    } else if (!aLogin) {
-      cmp = 1
-    } else if (!bLogin) {
-      cmp = -1
-    } else {
-      cmp = aLogin.localeCompare(bLogin)
-    }
+    cmp = (aValue.users[0]?.login ?? '').localeCompare(bValue.users[0]?.login ?? '')
   } else if (aValue.kind === 'labels' && bValue.kind === 'labels') {
-    const aName = aValue.labels[0]?.name ?? ''
-    const bName = bValue.labels[0]?.name ?? ''
-    if (!aName && !bName) {
-      cmp = 0
-    } else if (!aName) {
-      cmp = 1
-    } else if (!bName) {
-      cmp = -1
-    } else {
-      cmp = aName.localeCompare(bName)
-    }
+    cmp = (aValue.labels[0]?.name ?? '').localeCompare(bValue.labels[0]?.name ?? '')
   } else {
     // Why: unknown sort-field kind — ignore this sort field and fall through
     // to tie-breaks (and eventually row.position).


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​106 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​106 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Sorting a Projects table by a field that some rows leave blank scattered the blank rows across **both** ends of the table depending on direction, and grouping by that field produced a group whose header read the literal word "All". Blank now sorts and groups last, in both directions.

## What Changed

`compareSort` treated two shapes of "empty" differently:

- A **missing** value early-returned `1`/`-1`, *before* the trailing `return sort.direction === 'DESC' ? -cmp : cmp`.
- An **empty** `users`/`labels` list expressed the same intent as `cmp = 1`, which that same line then negated.

So in `DESC`, unassigned rows floated to the top while rows with no value at all stayed at the bottom.

`getFieldValueForGrouping` had the matching defect: it only checked `!value`, so an empty list fell through to `deriveStringValue` and produced a group with a blank label — which `ProjectGroupHeader` renders as "All" (and mobile as "Items").

Both paths now share one `hasNonEmptyFieldValue` predicate. It also covers `text: ''` and `date: ''`, which are reachable because the view normalizer maps a null GitHub text/date to the empty string (`project-view-field-normalization.ts:142,151`), and it `.trim()`s so a whitespace-only text cell counts as empty too. `number` deliberately returns `true` so `0` is not swallowed.

With empties handled up front, the users/labels comparators collapse to a plain `localeCompare`.

## Why

Two spellings of the same concept diverged around one negation. Collapsing them to a single predicate is what stops them drifting apart again. `hasNonEmptyFieldValue` is a `switch` with no `default`, so `noImplicitReturns` makes TypeScript fail the build if a new field kind is ever added without a decision here.

## Linked Issue

None. #15590 cited `#15358`, which does not exist in this repo — I could not find a real issue for this and did not want to invent a link. Happy to file one if you'd like the paper trail.

## Visual Proof

Captured from the **real** `ProjectViewList` component with the app's real `main.css` tokens, mounted over a fixture table. Six rows sorted **Assignees DESC**: two assigned, two with a present-but-empty `users: []`, two with the field absent entirely. All four empty rows render an identical `+ Assign` cell, so the ordering is the only thing distinguishing them.

### Sorting — Assignees, DESC

<details open>
<summary><b>Before</b> — empties split across both ends</summary>

![before-sort.png](https://github.com/user-attachments/assets/42ae102a-1ca1-42c6-9e02-1e1a24176abf)

`#102 Empty list A` and `#105 Empty list B` float to the **top**; `#103` and `#106` (no value at all) sink to the **bottom**. Four visually identical empty cells, two different answers.
</details>

<details open>
<summary><b>After</b> — every empty sorts last</summary>

![after-sort.png](https://github.com/user-attachments/assets/57cc7cd4-222c-434f-b39b-6d2507665239)

`bob` → `alice` (DESC), then all four empties in fetch order.
</details>

### Grouping — by Assignees

<details open>
<summary><b>Before</b> — a second empty group, labelled "All"</summary>

![before-group.png](https://github.com/user-attachments/assets/9712f65c-ea02-4882-b6e2-845ca84ff646)

The empty-list rows derive a blank label, which `ProjectGroupHeader.tsx:33` falls back to rendering as the literal word **"All"** — sitting *above* the real groups, with the genuine `No Assignees` bucket separately at the bottom.
</details>

<details open>
<summary><b>After</b> — one correctly labelled group, last</summary>

![after-group.png](https://github.com/user-attachments/assets/5b5f475d-e8ac-4eb2-a77a-d4d2689ed536)

`alice` → `bob` → `No Assignees (4)`.
</details>

## Testing

- [x] Automated tests added/updated
- [x] I manually tested these changes locally — the real `ProjectViewList` mounted over a fixture table; see Visual Proof

Four new cases in `group-sort.test.ts`, each written red first and observed failing against the pre-change module:

```
× sorts an empty user list last in both directions   expected ['empty-list','alice',...] to equal ['alice','empty-list',...]
× sorts an empty label list last in both directions  expected ['empty-list','bug',...]   to equal ['bug','empty-list',...]
× sorts a blank text value last in both directions   expected ['blank','alpha',...]      to equal ['alpha','blank',...]
× groups a present-but-empty user list with missing  expected [['',['empty-list']],...]  to equal [['alice',['alice']],...]
```

The `for (const direction of ['ASC','DESC'])` loop is the point: the users/labels cases pass `ASC` and fail `DESC`, which isolates the flip.

| Check | Result |
|---|---|
| `pnpm test src/renderer/src/components/github-project/` | 9 files / 61 passed |
| `pnpm test src/main/github/project-view src/shared/github` | 13 files / 77 passed |
| `pnpm tc:web` | exit 0 |
| `oxlint` / `oxfmt` | clean |

## AI Disclosure

Claude Opus 5 (via Claude Code) reviewed #15590, verified this fix independently against the pre-change module, and split it out.

## Review

- **Security:** none — pure client-side projection over already-normalized data, no new input surface.
- **Cross-platform:** no platform-dependent behavior.
- **Remote SSH:** none — no IPC or wire surface.
- **Mobile:** `mobile/src/tasks/use-mobile-tasks-project-projection.tsx` sorts and groups through this same shared module, so mobile inherits the fix with no parallel implementation to sync. Mobile's mirror field-value union has the same 7 kinds, so no drift.
- **Backwards compatibility:** group keys are never written back (`clearProjectFieldValue` deletes by `fieldId`); merging blank rows into `__empty__` only orphans a stale collapse-state Set entry, which is a no-op.
- **Performance:** replaces two branch chains with one predicate call.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

Split out of #15590 by @kaluli123123, credited as co-author. That PR bundled four unrelated fixes; this is one of the three that survived review (its fourth, the `paneKey` truncation, already landed on `main` in `fbe94ce` / #17159).

**Known adjacent gap, deliberately not fixed here:** `single-select` and `iteration` return `true` unconditionally, but both *can* be present-but-blank — `project-cache.ts:28-35,49-57` constructs `name: ''` / `title: ''` fallbacks. `iteration` is protected downstream (`value.title || meta?.title || 'Iteration'`), but `project-group-sort.ts:86` is a bare `label: value.name`, so a blank-name option still renders an "All" header. Pre-existing and untested; worth a follow-up that mirrors the iteration line.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` pass — typecheck/lint/affected suites pass locally; full `pnpm test` and `pnpm build` left to CI


