### PR TITLE
fix(git): recover commit ref badges on Git older than 2.43

### DIFF
--- a/docs/reference/git-compatibility.md
+++ b/docs/reference/git-compatibility.md
@@ -42,6 +42,17 @@ authority.
 | `merge-tree-write-tree`     | Derive real-merge conflicts and no-op tree proofs                       | Omit the conflict summary and keep conservative branch cleanup behavior before Git 2.38                                                                                                                    |
 | `merge-tree-merge-base`     | Supply the already-resolved merge base                                  | Use the older two-commit `merge-tree --write-tree` form                                                                                                                                                    |
 
+### Placeholders That Fail Open
+
+`GitCapabilityCache` records commands Git *rejects*. A `git log --format`
+placeholder Git does not know is not rejected: Git echoes it verbatim and exits
+zero, so there is no error to remember and no probe to cache. Ask for both forms
+in one record and pick at parse time.
+
+| Placeholder      | Preferred behavior                                                                                | Compatibility behavior                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `%(decorate:…)`  | Git 2.43 separates commit decorations with `\x1f`, so ref names containing commas survive         | The same record also carries `%D` (Git 2.10); an unexpanded `%(decorate` placeholder selects it, at the cost of comma-splitting |
+
 ## Why Not `simple-git`
 
 `simple-git` is a process wrapper around the installed Git binary. Its custom

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -15,6 +15,7 @@ import {
   isUnsupportedWorktreeListZError
 } from './git-worktree-command-capabilities'
 import { gitCredentialPromptGuardEnv } from './git-credential-prompt-env'
+import { GIT_HISTORY_COMMIT_FORMAT, parseGitHistoryLog } from './git-history-log-parser'
 import {
   githubPullRequestHeadLocalRef,
   gitlabMergeRequestHeadLocalRef,
@@ -377,5 +378,30 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
     await expect(
       runGit(['show', '--end-of-options', `${pinnedOid}:absent.txt`])
     ).rejects.toBeDefined()
+  })
+  // Why pin this: an older Git echoes %(decorate:…) and exits zero, so only %D
+  // in the same record carries the badges (#15507). Asserts the echo and the recovery.
+  it('reads commit decorations on both sides of the %(decorate:...) boundary', async () => {
+    await writeFile(join(repoPath, 'decorated.txt'), 'decorated\n')
+    await runGit(['add', 'decorated.txt'])
+    await runGit(['commit', '-qm', 'decorated commit'])
+    await runGit(['tag', 'compat-decorated'])
+    const head = (await runGit(['rev-parse', 'HEAD'])).stdout.trim()
+
+    const log = await runGit([
+      'log',
+      `--format=${GIT_HISTORY_COMMIT_FORMAT}`,
+      '-z',
+      '--decorate=full',
+      '-n1',
+      head
+    ])
+
+    expect(log.stdout.includes('%(decorate')).toBe(!supports(2, 43))
+
+    const [item] = parseGitHistoryLog(log.stdout)
+    expect(item?.id).toBe(head)
+    expect(item?.subject).toBe('decorated commit')
+    expect(item?.references?.map((ref) => ref.id)).toContain('refs/tags/compat-decorated')
   })
 })

--- a/src/shared/git-history-log-parser.ts
+++ b/src/shared/git-history-log-parser.ts
@@ -2,9 +2,15 @@ import type { GitHistoryItem, GitHistoryItemRef } from './git-history-types'
 import { iterateNulDelimitedFields } from './nul-delimited-fields'
 
 const GIT_HISTORY_DECORATION_SEPARATOR = '\x1f'
+const GIT_HISTORY_LEGACY_DECORATION_SEPARATOR = ','
 
+// Why %D too: %(decorate:…) is Git 2.43+, and older Git echoes it verbatim and exits zero.
+// Callers must pass --decorate=full; both fields emit short names otherwise, which parse to no refs.
 export const GIT_HISTORY_COMMIT_FORMAT =
-  '%H%n%aN%n%aE%n%at%n%ct%n%P%n%(decorate:prefix=,suffix=,separator=%x1f)%n%B'
+  '%H%n%aN%n%aE%n%at%n%ct%n%P%n%(decorate:prefix=,suffix=,separator=%x1f)%n%D%n%B'
+
+// Why exact-match: no ref name may contain the \x1f an old Git echoes here.
+const UNEXPANDED_DECORATE_PLACEHOLDER = `%(decorate:prefix=,suffix=,separator=${GIT_HISTORY_DECORATION_SEPARATOR})`
 
 export function shortGitHash(hash: string): string {
   return hash.slice(0, 7)
@@ -15,17 +21,18 @@ function commitSubject(message: string): string {
   return firstLine || '(no commit message)'
 }
 
-function parseGitDecorationRefs(raw: string, revision: string): GitHistoryItemRef[] {
+function parseGitDecorationRefs(
+  raw: string,
+  revision: string,
+  separator: string
+): GitHistoryItemRef[] {
   if (!raw.trim()) {
     return []
   }
 
   const refs: GitHistoryItemRef[] = []
-  // Why: Git permits commas in ref names, so Orca's git log format uses a
-  // control-character separator that Git ref names cannot contain.
-  const parts = raw.includes(GIT_HISTORY_DECORATION_SEPARATOR)
-    ? raw.split(GIT_HISTORY_DECORATION_SEPARATOR)
-    : raw.split(',')
+  // Why passed in: a lone decoration carries no separator, so sniffing `raw` split `feat,one`.
+  const parts = raw.split(separator)
 
   for (const part of parts) {
     const ref = part.trim()
@@ -115,8 +122,10 @@ export function parseGitHistoryLog(stdout: string): GitHistoryItem[] {
     const authorEmail = lines[2] ?? ''
     const authorDateSeconds = Number.parseInt(lines[3] ?? '', 10)
     const parents = (lines[5] ?? '').trim()
-    const decorations = lines[6] ?? ''
-    const message = lines.slice(7).join('\n').replace(/\n$/, '')
+    const decorateField = lines[6] ?? ''
+    const isLegacyGit = decorateField === UNEXPANDED_DECORATE_PLACEHOLDER
+    const decorations = isLegacyGit ? (lines[7] ?? '') : decorateField
+    const message = lines.slice(8).join('\n').replace(/\n$/, '')
 
     items.push({
       id: hash,
@@ -127,7 +136,11 @@ export function parseGitHistoryLog(stdout: string): GitHistoryItem[] {
       authorEmail: authorEmail || undefined,
       displayId: shortGitHash(hash),
       timestamp: Number.isFinite(authorDateSeconds) ? authorDateSeconds * 1000 : undefined,
-      references: parseGitDecorationRefs(decorations, hash)
+      references: parseGitDecorationRefs(
+        decorations,
+        hash,
+        isLegacyGit ? GIT_HISTORY_LEGACY_DECORATION_SEPARATOR : GIT_HISTORY_DECORATION_SEPARATOR
+      )
     })
   }
   return items

--- a/src/shared/git-history.test.ts
+++ b/src/shared/git-history.test.ts
@@ -16,6 +16,7 @@ function logRecord({
   hash,
   parents = [],
   decorations = '',
+  legacyDecorations = '',
   message,
   author = 'Ada Lovelace',
   timestamp = 1_700_000_000
@@ -23,6 +24,7 @@ function logRecord({
   hash: string
   parents?: string[]
   decorations?: string
+  legacyDecorations?: string
   message: string
   author?: string
   timestamp?: number
@@ -35,6 +37,7 @@ function logRecord({
     String(timestamp),
     parents.join(' '),
     decorations,
+    legacyDecorations,
     message
   ].join('\n')}\0`
 }
@@ -94,8 +97,12 @@ describe('git history parsing', () => {
     const stdout = logRecord({
       hash: HEAD_OID,
       parents: [BASE_OID],
-      decorations:
-        'HEAD -> refs/heads/feature, refs/remotes/origin/HEAD -> refs/remotes/origin/feature, refs/remotes/origin/feature, tag: refs/tags/v1.0.0',
+      decorations: [
+        'HEAD -> refs/heads/feature',
+        'refs/remotes/origin/HEAD -> refs/remotes/origin/feature',
+        'refs/remotes/origin/feature',
+        'tag: refs/tags/v1.0.0'
+      ].join(DECORATION_SEPARATOR),
       message: 'feat: add graph\n\nbody line'
     })
 
@@ -114,6 +121,39 @@ describe('git history parsing', () => {
       ['refs/heads/feature', 'feature', 'branches'],
       ['refs/remotes/origin/feature', 'origin/feature', 'remote branches'],
       ['refs/tags/v1.0.0', 'v1.0.0', 'tags']
+    ])
+  })
+
+  it('falls back to %D decorations when Git predates the %(decorate:…) placeholder', () => {
+    // Why: Git < 2.43 echoes the placeholder and exits zero (#15507).
+    const stdout = logRecord({
+      hash: HEAD_OID,
+      decorations: `%(decorate:prefix=,suffix=,separator=${DECORATION_SEPARATOR})`,
+      legacyDecorations: 'HEAD -> refs/heads/feature, tag: refs/tags/v1.0.0',
+      message: 'feat: add graph'
+    })
+
+    const [item] = parseGitHistoryLog(stdout)
+
+    expect(item?.subject).toBe('feat: add graph')
+    expect(item?.references?.map((ref) => [ref.id, ref.name, ref.category])).toEqual([
+      ['refs/heads/feature', 'feature', 'branches'],
+      ['refs/tags/v1.0.0', 'v1.0.0', 'tags']
+    ])
+  })
+
+  it('keeps a comma inside a lone decoration, which carries no separator', () => {
+    // Why: a lone decoration carries no separator, so sniffing for \x1f split it in two.
+    const stdout = logRecord({
+      hash: HEAD_OID,
+      decorations: 'HEAD -> refs/heads/feat,one',
+      message: 'initial'
+    })
+
+    const [item] = parseGitHistoryLog(stdout)
+
+    expect(item?.references?.map((ref) => [ref.id, ref.name])).toEqual([
+      ['refs/heads/feat,one', 'feat,one']
     ])
   })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |

<!-- /orca-pr-loc -->

## ELI5

If your Git is older than 2.43, every commit row in Source Control silently lost its branch, remote and tag badges — Orca asked for the decorations using a placeholder that old Git does not know, and old Git answers by printing the placeholder back at you and exiting **zero**, so nothing ever raised. Orca now asks for the decorations two ways in the same record and picks whichever one came back real.

## What Changed

`GIT_HISTORY_COMMIT_FORMAT` requested decorations with `%(decorate:prefix=,suffix=,separator=%x1f)`. That placeholder arrived in **Git 2.43.0**. Below it, Git echoes the text verbatim, exits 0, and `parseGitDecorationRefs` drops the result because it doesn't start with `refs/heads/` etc. Zero badges, no error.

The record now also carries **`%D`** (Git 2.10) on its own line. `isLegacyGit` is an exact match of line 6 against the unexpanded placeholder — safe because old Git expands the nested `%x1f` while echoing, and `check_ref_format` forbids control characters in ref names, so no real decoration can ever collide with it.

`%n` emits the `%D` line on **both** sides of the boundary, so the message index is a fixed `lines.slice(8)` either way. If the exact match ever failed on some vendor build, the failure mode is "no badges", not a corrupted commit message.

Separately, `parseGitDecorationRefs` now takes its separator from the field that produced the text instead of sniffing it. Sniffing was wrong for a *lone* decoration, which carries no separator at all: `refs/heads/feat,one` was split into `refs/heads/feat` plus a bogus `one`.

## Why

Per `docs/reference/git-compatibility.md`, the standard tool is `GitCapabilityCache` — but that records commands Git **rejects**. An unknown `--format` placeholder is not rejected, so there is no error to remember and no probe to cache. Asking for both fields in one record and choosing at parse time costs one extra field per commit and no extra process. The doc gains a short "Placeholders That Fail Open" section for this shape so the next person doesn't reach for the cache.

## Linked Issue

Fixes #15507

## Visual Proof

Not attached. The symptom is visual (ref badges in the Source Control Commits panel), but reproducing it needs a pre-2.43 Git binary driving a running build. Instead this is verified against **real** Git binaries — see Testing. Flagging the gap rather than writing `N/A`.

## Testing

- [x] Automated tests added/updated
- [x] I manually tested these changes locally — against real Git binaries in Docker, not a running UI

| Check | Result |
|---|---|
| `pnpm test src/shared/git-history.test.ts` | 12 passed |
| `git-binary-compatibility` vs **real Git 2.38.1** (pre-2.43, legacy path) | **11 passed** |
| `git-binary-compatibility` vs **real Git 2.49.1** (modern path) | **11 passed** |
| `pnpm tc:node` | exit 0 |
| `oxlint` / `oxfmt` | clean |

The new contract assertion is direction-aware — `expect(log.stdout.includes('%(decorate')).toBe(!supports(2, 43))` — so it pins the echo on old Git *and* the expansion on new Git, then asserts `refs/tags/compat-decorated` resolves either way. CI's compat matrix is 2.25.5 / 2.38.1 / 2.49.1, so two of three lanes exercise the legacy branch.

Both unit tests were confirmed red against the pre-change parser: the `%D` fallback test produced a message of `"HEAD -> refs/heads/feature, tag: refs/tags/v1.0.0\nfeat: add graph"`, and the comma test split the lone ref in two.

I also confirmed the premise directly rather than inferring it. Real Git 2.38.1, `od -c`:

```
%   (   d   e   c   o   r   a   t   e   :   p   r   e   f   i   x   =   ,
s   u   f   f   i   x   =   ,   s   e   p   a   r   a   t   o   r   = 037   )
EXIT=0
```

Note the `037` — old Git expands the inner `%x1f` while echoing the outer placeholder, which is exactly what the exact-match constant assumes.

Not run: `pnpm build` and the full Vitest suite.

## AI Disclosure

Claude Opus 5 (via Claude Code) reviewed #15590, verified this fix against real Git 2.32/2.38/2.49 in Docker, and split it out.

## Review

- **Security:** none — no new input surface, no credential or path handling.
- **Cross-platform:** the boundary is covered by the real-binary contract suite; behavior is identical on all three OSes since it depends only on the Git binary.
- **Remote SSH:** this is the case the fix restores — an SSH host with an older Git than the client. Both the format string and the parser run in the same process as the Git binary (`src/main/git/history.ts`, `src/relay/git-handler-read-operations.ts` both go through `loadGitHistoryFromExecutor`), so the choice is always made where the binary lives.
- **Remote wire:** no wire change. Raw stdout never crosses the boundary; only the parsed `GitHistoryItem[]`, whose shape is unchanged. The only published-content delta is that a new host now sends *correct* ref ids for comma-containing names to an old client — strictly a fix, no opcode or capability negotiation needed.
- **Mobile:** unaffected.
- **Backwards compatibility:** restores previously expected behavior; no persisted shape changes.
- **Performance:** one extra field per commit record, bounded by `GIT_HISTORY_MAX_LIMIT`.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

Split out of #15590 by @kaluli123123, credited as co-author.

Two small additions of mine on top of that work:

1. The doc entry moved out of the **Current Capabilities** table into its own section. Every other row there is a real `GitCapability` id from `git-capability-cache.ts`; `log-decorate-placeholder` is not one, and mixing the two kinds in one table is misleading. This also drops the whole-table column reflow from the diff.
2. A one-line comment on the format constant recording that callers must pass `--decorate=full`. Both fields emit short names without it, and short names match none of the parser's prefixes — a silent zero-badge trap identical to the one being fixed. Pre-existing, now written down.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached — see Visual Proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` pass — typecheck/lint/affected suites and both real-Git lanes pass locally; full `pnpm test` and `pnpm build` left to CI
