### PR TITLE
fix(agents): clear the unread completion marker when acknowledging agents

### DIFF
--- a/src/renderer/src/store/slices/agent-status-ack-cleanup.test.ts
+++ b/src/renderer/src/store/slices/agent-status-ack-cleanup.test.ts
@@ -117,3 +117,31 @@ describe('acknowledgedAgentsByPaneKey cleanup on teardown', () => {
     expect(ackAt < newEntry.stateStartedAt).toBe(true)
   })
 })
+
+// Why: only the terminal-view path cleared unreadAgentCompletionPanes, so an
+// Activity-page ack left the tab dot lit.
+describe('acknowledgeAgents clears the unread agent-completion marker', () => {
+  it('drops the pane from unreadAgentCompletionPanes', () => {
+    const store = createTestStore()
+    store.getState().setAgentStatus('tab-1:0', { state: 'done', prompt: 'p', agentType: 'claude' })
+    store.getState().markAgentCompletionPaneUnread('tab-1:0')
+    expect(store.getState().unreadAgentCompletionPanes['tab-1:0']).toBe(true)
+
+    store.getState().acknowledgeAgents(['tab-1:0'])
+
+    expect(store.getState().unreadAgentCompletionPanes['tab-1:0']).toBeUndefined()
+  })
+
+  it('leaves other panes and the terminal-bell unread map untouched', () => {
+    const store = createTestStore()
+    store.getState().markAgentCompletionPaneUnread('tab-1:0')
+    store.getState().markAgentCompletionPaneUnread('tab-2:0')
+    store.getState().markTerminalPaneUnread('tab-1:0')
+
+    store.getState().acknowledgeAgents(['tab-1:0'])
+
+    expect(store.getState().unreadAgentCompletionPanes['tab-2:0']).toBe(true)
+    // Why: a BEL is a separate signal; acking the agent must not silence it.
+    expect(store.getState().unreadTerminalPanes['tab-1:0']).toBe(true)
+  })
+})

--- a/src/renderer/src/store/slices/ui-slice-test-harness.ts
+++ b/src/renderer/src/store/slices/ui-slice-test-harness.ts
@@ -20,6 +20,8 @@ export function createUIStore(): StoreApi<AppState> {
     combinedDiffFileTreeWidth: 256,
     rightSidebarTab: 'explorer',
     rightSidebarExplorerView: 'files',
+    // Why: acknowledgeAgents clears the agent-completion marker the terminal slice owns.
+    unreadAgentCompletionPanes: {},
     ...createSettingsSearchState(args[0]),
     ...createWorktreeNavHistorySlice(...(args as Parameters<typeof createWorktreeNavHistorySlice>)),
     ...createUISlice(...(args as Parameters<typeof createUISlice>))

--- a/src/renderer/src/store/slices/ui/ui-slice-agent-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-agent-actions.ts
@@ -211,7 +211,16 @@ export function createUiAgentActions(
         const migrationUnsupported = Object.values(s.migrationUnsupportedByPtyId ?? {})
         // Why: only reallocate if an ack advances; compare prev<stamp not !== — the stamp ticks every ms and !== would rewrite the map every call.
         let next: Record<string, number> | null = null
+        // Why: one ack, two records — leaving the completion marker set keeps the tab dot,
+        // the ⌘J row and the floating-workspace dot lit with nothing left to read.
+        let nextUnreadCompletions: Record<string, true> | null = null
         for (const key of paneKeys) {
+          if (s.unreadAgentCompletionPanes[key]) {
+            if (nextUnreadCompletions === null) {
+              nextUnreadCompletions = { ...s.unreadAgentCompletionPanes }
+            }
+            delete nextUnreadCompletions[key]
+          }
           const prev = s.acknowledgedAgentsByPaneKey[key] ?? 0
           // Why not plain Date.now(): a remote/SSH execution host can stamp a turn ahead of this clock,
           // and every unread rule is `ackAt < turnTimestamp`. A behind-the-turn ack can never clear the
@@ -252,7 +261,13 @@ export function createUiAgentActions(
             next[key] = stamp
           }
         }
-        return next ? { acknowledgedAgentsByPaneKey: next } : s
+        if (!next && !nextUnreadCompletions) {
+          return s
+        }
+        return {
+          ...(next ? { acknowledgedAgentsByPaneKey: next } : {}),
+          ...(nextUnreadCompletions ? { unreadAgentCompletionPanes: nextUnreadCompletions } : {})
+        }
       })
       const notificationIds = [...notificationIdsToDismiss]
       if (notificationIds.length > 0 && typeof window !== 'undefined') {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 |

<!-- /orca-pr-loc -->

## ELI5

Acknowledging an agent from the Activity page marked it read in one place but not the other, so the little "done" dot stayed lit on the tab, in the ⌘J palette and on the floating workspace launcher — with nothing left to read. The ack now clears both records.

## What Changed

An agent completion writes several attention records. Two of them are keyed by pane:

- `acknowledgedAgentsByPaneKey` — the timestamp every `ackAt < turnTimestamp` unread rule compares against.
- `unreadAgentCompletionPanes` — a separate marker read by `terminal-tab-activity-status.ts` (tab dot), `palette-live-status.tsx` (⌘J rows) and `selectFloatingWorkspaceHasUnread` (floating launcher dot), **none of which consult the first map**.

`acknowledgeAgents` only wrote the first. The only thing clearing the second was `clearTerminalPaneUnread`, which just one ack path calls (`useAutoAckViewedAgent`, the terminal-view flow). Every other ack — `activity-thread-actions.ts`, `ActivityPrototypePage.tsx`, `AgentDashboardDrawer.tsx`, `useDashboardPopoutBridge.ts`, `focus-terminal-pane-event.ts` — left the dot lit.

The clear happens inside the existing `set`, so one ack stays one store commit. It's a targeted delete rather than a call to `clearTerminalPaneUnread`, because that helper *also* drops `unreadTerminalPanes` — which would silence a BEL the user never saw. There's a test pinning that.

## Why

This is step 2 of the three-part fix written out in #15445, and the only one that is purely a bug. Steps 1 and 3 change what the sidebar badge counts and when a worktree's coarse `isUnread` flag is cleared — both are product decisions about the badge's meaning, so they're deliberately left for a separate change rather than smuggled in here.

## Linked Issue

Refs #15445 — step 2 of that issue's "Fix" section only. Steps 1 and 3 remain open on purpose (see Why).

## Visual Proof

Not attached. The symptom is a lit unread dot and I did not capture before/after against a running build. Flagging it as a genuine gap rather than writing `N/A`.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally — exercised through the store, not a running build

Both new tests were written red first. With the clear removed:

```
× drops the pane from unreadAgentCompletionPanes
  Tests  1 failed | 6 passed (7)
```

| Check | Result |
|---|---|
| `agent-status-ack-cleanup` | 7 passed |
| `ui-acknowledge-agents-clock-skew`, `store-sleep-agent-status-retention`, `useAutoAckViewedAgent`, `terminal-tab-activity-status`, `selectors`, `palette-live-status` | 7 files / **102 passed** |
| `pnpm tc:web` | exit 0 |
| `oxlint` / `oxfmt` | clean |

Also verified by hand, since a silent no-op was the obvious way for this fix to be worthless:

- **Keys match.** Both maps are keyed `${tabId}:${leafId}`. The unread marker is written from `use-notification-dispatch.ts:168` with `event.paneKey`, which originates as the coordinator's `paneKey` — the same value keying `agentStatusByPaneKey` and the same one Activity threads carry. Not a ptyId, not a tab id.
- **The partial return is safe.** `acknowledgeAgents` can now return an object containing only `unreadAgentCompletionPanes`. The store is plain `create<AppState>()` with one middleware (`withReactCommitCascadeWriteProbe`) that forwards `(partial, replace)` verbatim and never injects `replace: true`, so this is zustand's default shallow merge. It cannot wipe sibling state.
- **No re-set race.** `markAgentCompletionPaneUnread` has exactly one caller, gated on a fresh `agent-task-complete` event, and nothing derives this map from a source of truth — so an ack that doesn't advance `acknowledgedAgentsByPaneKey` can't have the dot immediately re-set.

## AI Disclosure

Claude Opus 5 (via Claude Code) reviewed #15590, verified this fix independently, and split it out.

## Review

- **Security:** none — renderer store state only.
- **Cross-platform:** no platform-dependent behavior.
- **Remote SSH:** none — no IPC or wire surface. The surrounding clock-skew handling for remote-stamped turns is untouched, and its suite still passes.
- **Mobile:** unaffected.
- **Backwards compatibility:** `unreadAgentCompletionPanes` is in-memory; no persisted shape changes.
- **Performance:** the map is only copied when a key is actually present, matching the existing "only reallocate if an ack advances" discipline two lines below.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

Split out of #15590 by @kaluli123123, credited as co-author. That PR wrote this against `store/slices/ui.ts`, which `main` has since split; this is the same fix re-landed on `store/slices/ui/ui-slice-agent-actions.ts`.

`ui-slice-test-harness.ts` gains an explicit `unreadAgentCompletionPanes: {}` — it builds a UI-slice-only store, and the UI slice now reads a map the terminal slice owns.

**Second known gap, surfaced in final review:** `unacknowledgeAgents` — the Activity "Mark thread unread" bell — only touches `acknowledgedAgentsByPaneKey`, so after this fix an ack-then-unack leaves the thread showing unread in Activity while the tab dot stays dark. Pre-existing asymmetry (that action never touched this map, before or after), and relighting a dot the user has already looked at is a judgement call rather than an obvious fix — so it's noted rather than smuggled in. Worth a fast follow-up.

**Known remaining gap, deliberately not fixed here:** the same completion event also calls `markWorktreeUnread` and, under `experimentalTerminalAttention`, `markTerminalTabUnread` / `markTerminalPaneUnread`. An Activity-page ack still leaves those set, so with that setting **on** the tab dot survives via `unreadTerminalTabs`. The setting is off by default, and clearing those maps means deciding whether an agent ack should also silence a BEL — which is #15445 step 3, a product call.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached — see Visual Proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` pass — typecheck/lint/affected suites pass locally; full `pnpm test` and `pnpm build` left to CI

