### PR TITLE
fix(ssh): stop a request that never left the client from tombstoning its operation id

### DIFF
--- a/src/main/providers/ssh-agent-session-create-operation.ts
+++ b/src/main/providers/ssh-agent-session-create-operation.ts
@@ -1,4 +1,7 @@
-import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+import {
+  isUndispatchedSshRequestError,
+  type SshChannelMultiplexer
+} from '../ssh/ssh-channel-multiplexer'
 import { AGENT_SESSION_CREATE_OPERATION_PROTOCOL_VERSION } from '../../shared/agent-session-host-authority'
 import { isPtyIncarnationId } from '../../shared/pty-incarnation'
 import type { PtySpawnResult } from './pty-spawn-result'
@@ -66,7 +69,10 @@ export async function requestSshAgentSessionCreate(args: {
         : undefined
     return await args.mux.request('pty.spawn', args.params, options)
   } catch (error) {
-    if (!args.operationId) {
+    // Why: a spawn the mux never framed cannot have left a PTY on the host, so fencing it would
+    // retain the 24h replay tombstone over an operation id whose create was never issued — every
+    // later replay then rethrows this failure instead of starting the agent the user asked for.
+    if (!args.operationId || isUndispatchedSshRequestError(error)) {
       throw error
     }
     const spawnError = error instanceof Error ? error : new Error(String(error))

--- a/src/main/providers/ssh-pty-provider-agent-session-create-operation.test.ts
+++ b/src/main/providers/ssh-pty-provider-agent-session-create-operation.test.ts
@@ -235,6 +235,79 @@ describe('SSH fresh agent-session create operations', () => {
     expect(request).toHaveBeenCalledTimes(2)
   })
 
+  it('leaves the replay fence off a create the disposed mux never dispatched', async () => {
+    const transport = createTransport()
+    const mux = new SshChannelMultiplexer(transport)
+    const liveProvider = new SshPtyProvider('conn-1', mux)
+    const operationId = 'e'.repeat(43)
+
+    // Why: prime the memoized capability probe, so the second spawn reaches the dispatch seam
+    // without a round trip — the ordering that lets a mid-preflight dispose land before it.
+    const primed = liveProvider.spawn({
+      cols: 80,
+      rows: 24,
+      command: 'codex',
+      agentSessionCreateOperationId: operationId
+    })
+    const capabilityRequest = await waitForRequest(transport, 'pty.getCapabilities')
+    transport.deliver(
+      responseFrame(
+        capabilityRequest.id as number,
+        { agentSessionCreateOperationVersion: AGENT_SESSION_CREATE_OPERATION_PROTOCOL_VERSION },
+        1
+      )
+    )
+    const spawnRequest = await waitForRequest(transport, 'pty.spawn')
+    transport.deliver(
+      responseFrame(spawnRequest.id as number, { id: 'pty-1', incarnationId: 'incarnation-1' }, 2)
+    )
+    await expect(primed).resolves.toMatchObject({ incarnationId: 'incarnation-1' })
+
+    mux.dispose('connection_lost')
+    const failure = await liveProvider
+      .spawn({
+        cols: 80,
+        rows: 24,
+        command: 'codex',
+        agentSessionCreateOperationId: 'f'.repeat(43)
+      })
+      .catch((error: unknown) => error)
+
+    expect((failure as { code?: unknown }).code).toBe('CONNECTION_LOST')
+    expect(failure).not.toHaveProperty('agentSessionOperationOutcome')
+    expect(
+      requestPayloads(transport).filter((payload) => payload.method === 'pty.spawn')
+    ).toHaveLength(1)
+  })
+
+  it('keeps the replay fence on a create the link lost after dispatch', async () => {
+    const transport = createTransport()
+    const mux = new SshChannelMultiplexer(transport)
+    const liveProvider = new SshPtyProvider('conn-1', mux)
+
+    const spawn = liveProvider.spawn({
+      cols: 80,
+      rows: 24,
+      command: 'codex',
+      agentSessionCreateOperationId: 'g'.repeat(43)
+    })
+    const capabilityRequest = await waitForRequest(transport, 'pty.getCapabilities')
+    transport.deliver(
+      responseFrame(
+        capabilityRequest.id as number,
+        { agentSessionCreateOperationVersion: AGENT_SESSION_CREATE_OPERATION_PROTOCOL_VERSION },
+        1
+      )
+    )
+    await waitForRequest(transport, 'pty.spawn')
+
+    mux.dispose('connection_lost')
+    const failure = await spawn.catch((error: unknown) => error)
+
+    expect((failure as { code?: unknown }).code).toBe('CONNECTION_LOST')
+    expect(failure).toMatchObject({ agentSessionOperationOutcome: 'unknown' })
+  })
+
   it('withholds same-turn source data until claim validation and isolates rollback', async () => {
     const transport = createTransport()
     const mux = new SshChannelMultiplexer(transport)

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -74,6 +74,20 @@ function sshMuxRequestTimeoutError(method: string, timeoutMs: number): Error {
   })
 }
 
+// Why: `request` rejects a disposed mux and an already-aborted signal before it frames anything,
+// so the peer provably never saw those calls. A caller fencing a possibly-applied mutation needs
+// that apart from a mid-flight loss, which carries the identical code and message.
+export function isUndispatchedSshRequestError(error: unknown): boolean {
+  return (
+    (error as { sshRequestUndispatched?: unknown } | null | undefined)?.sshRequestUndispatched ===
+    true
+  )
+}
+
+function markUndispatched<T extends Error>(error: T): T {
+  return Object.assign(error, { sshRequestUndispatched: true as const })
+}
+
 /**
  * True when a request may have run on the host despite failing here.
  *
@@ -82,9 +96,13 @@ function sshMuxRequestTimeoutError(method: string, timeoutMs: number): Error {
  * wedged link lost at TIMEOUT_MS turned what used to surface as SSH_MUX_REQUEST_TIMEOUT into
  * CONNECTION_LOST, so callers that phrase the verdict to a user must branch on this rather than on
  * the timeout alone or they silently start reporting absence
- * (docs/reference/ssh-execution-boundary.md).
+ * (docs/reference/ssh-execution-boundary.md). Only a request the multiplexer refused before framing
+ * anything is provably un-run — hence the undispatched carve-out.
  */
 export function isSshRequestOutcomeUnverifiable(error: unknown): boolean {
+  if (isUndispatchedSshRequestError(error)) {
+    return false
+  }
   const code = error instanceof Error ? (error as Error & { code?: unknown }).code : undefined
   return code === SSH_MUX_REQUEST_TIMEOUT_CODE || code === 'CONNECTION_LOST'
 }
@@ -230,12 +248,12 @@ export class SshChannelMultiplexer {
     options?: SshMultiplexerRequestOptions
   ): Promise<unknown> {
     if (this.disposed) {
-      throw this.disposedError()
+      throw markUndispatched(this.disposedError())
     }
     if (options?.signal?.aborted) {
       const error = new Error(`Request "${method}" was cancelled`) as Error & { name: string }
       error.name = 'AbortError'
-      throw error
+      throw markUndispatched(error)
     }
 
     const id = this.nextRequestId++

--- a/src/main/ssh/ssh-request-outcome-verdict.test.ts
+++ b/src/main/ssh/ssh-request-outcome-verdict.test.ts
@@ -23,6 +23,14 @@ describe('SSH request outcome verdict', () => {
     expect(isSshRequestOutcomeUnverifiable(createSshDisposalError('connection_lost'))).toBe(true)
   })
 
+  it('does not claim unverifiable for a request that never reached the wire', () => {
+    // A disposed mux rejects before framing anything, so the peer provably never saw it.
+    const undispatched = Object.assign(createSshDisposalError('connection_lost'), {
+      sshRequestUndispatched: true
+    })
+    expect(isSshRequestOutcomeUnverifiable(undispatched)).toBe(false)
+  })
+
   it('does not claim unverifiable for a deliberate shutdown', () => {
     expect(isSshRequestOutcomeUnverifiable(createSshDisposalError('shutdown'))).toBe(false)
   })

--- a/src/relay/dispatcher-client-lifecycle.ts
+++ b/src/relay/dispatcher-client-lifecycle.ts
@@ -129,8 +129,9 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
       nextOutgoingSeq: 1,
       highestReceivedSeq: 0,
       attachedAt: Date.now(),
-      lastReceivedAt: null,
-      keepaliveObserved: false,
+      lastReceivedAt: null as number | null,
+      keepaliveObserved: false as boolean,
+      readsPaused: false as boolean,
       generation: 0,
       closed: false,
       droppedNotificationLog: null,
@@ -144,7 +145,20 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
     client.decoder = new FrameDecoder(
       (frame) => this.handleFrame(client, frame),
       (error) => this.closeClient(client, error, client !== this.primaryClient),
-      { pause: sourceOptions?.pauseReads, resume: sourceOptions?.resumeReads }
+      {
+        // Why the flag is set here rather than inside the reaper: the decoder owns the pause, and
+        // the reaper must not count silence it caused itself.
+        pause: () => {
+          client.readsPaused = true
+          sourceOptions?.pauseReads?.()
+        },
+        // Why no clock rebase here: the decoder only pauses when it has a whole frame left to
+        // deliver, so every resume trails a turn that decoded one and refreshed lastReceivedAt.
+        resume: () => {
+          client.readsPaused = false
+          sourceOptions?.resumeReads?.()
+        }
+      }
     )
     client.writer = this.createWriter(client, write, sinkOptions)
     return client
@@ -156,6 +170,7 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
     client.attachedAt = Date.now()
     client.lastReceivedAt = null
     client.keepaliveObserved = false
+    client.readsPaused = false
     client.decoder.reset()
     client.generation++
     client.closed = false
@@ -231,7 +246,10 @@ export abstract class RelayDispatcherClientLifecycle extends RelayDispatcherClie
       if (client === this.primaryClient) {
         continue
       }
-      if (client.closed) {
+      // Why readsPaused short-circuits everything below: while the decoder holds reads paused for
+      // backpressure no frame can decode, so both clocks freeze. Judging either one then reaps a
+      // client the relay itself stopped listening to.
+      if (client.closed || client.readsPaused) {
         continue
       }
       // Why a client that has never spoken gets its own, much wider bound: a relay is launched

--- a/src/relay/dispatcher-contract.ts
+++ b/src/relay/dispatcher-contract.ts
@@ -63,6 +63,10 @@ export type RelayClient = {
   // judging it on inbound silence would kill `terminal wait`, `--wait` and `orchestration ask`
   // after 20s. Only a client that has proven it participates is eligible.
   keepaliveObserved: boolean
+  // Why: while the decoder holds reads paused for backpressure, no frame can decode, so
+  // lastReceivedAt freezes. Judging silence then would reap a client the relay itself stopped
+  // listening to. The client-side multiplexer guards the mirror case with decoderReadPaused.
+  readsPaused: boolean
   generation: number
   closed: boolean
   droppedNotificationLog: DroppedProducerNotificationLog | null

--- a/src/relay/dispatcher-silent-client-reaper.test.ts
+++ b/src/relay/dispatcher-silent-client-reaper.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RelayDispatcher } from './dispatcher'
-import { encodeJsonRpcFrame, encodeKeepAliveFrame, KEEPALIVE_SEND_MS, TIMEOUT_MS } from './protocol'
+import {
+  encodeJsonRpcFrame,
+  encodeKeepAliveFrame,
+  FRAME_DECODER_MAX_FRAMES_PER_TURN,
+  KEEPALIVE_SEND_MS,
+  TIMEOUT_MS
+} from './protocol'
 
 // The relay had no inbound-liveness signal at all: its writer parks forever on a half-open link, so
 // an abandoned viewer kept its owner lease and left the PTYs it held paused until the process died.
@@ -159,5 +165,78 @@ describe('RelayDispatcher silent-client reaper', () => {
     // Client id 1 is the primary sink; closing it would tear down the relay's own stdin/stdout and
     // nothing in production calls setWrite() to bring it back.
     expect(detachListener).not.toHaveBeenCalled()
+  })
+
+  // Real backpressure, not a private-state poke: a chunk carrying more frames than the decoder
+  // will deliver in one turn makes it pause the source and schedule a continuation. setImmediate
+  // is left unfaked here so that continuation cannot run inside advanceTimersByTime -- which is
+  // what keeps the pause held across the whole silence window.
+  function pauseClientReadsForReal(clientId: number, frames: number): void {
+    dispatcher.feedClient(
+      clientId,
+      Buffer.concat(
+        Array.from({ length: frames }, (_, index) => encodeKeepAliveFrame(index + 1, 0))
+      )
+    )
+  }
+
+  function useRealImmediates(): void {
+    // Everything but setImmediate: the decoder's continuation must not run inside
+    // advanceTimersByTime, or the pause it is holding would be released mid-assertion.
+    vi.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date']
+    })
+    vi.setSystemTime(0)
+  }
+
+  it('never reaps a client whose reads the relay itself paused', () => {
+    // The decoder pauses reads for backpressure, and while paused no frame decodes, so
+    // lastReceivedAt freezes. Counting that as silence would reap a client the relay stopped
+    // listening to — self-inflicted. The client-side multiplexer guards the mirror case with
+    // decoderReadPaused; this is the relay half.
+    useRealImmediates()
+    const detachListener = vi.fn()
+    const pauseReads = vi.fn()
+    const resumeReads = vi.fn()
+    dispatcher = new RelayDispatcher(() => true)
+    dispatcher.onClientDetached(detachListener)
+    const clientId = dispatcher.attachClient(() => true, undefined, undefined, {
+      pauseReads,
+      resumeReads
+    })
+
+    pauseClientReadsForReal(clientId, FRAME_DECODER_MAX_FRAMES_PER_TURN + 1)
+
+    // Asserted, because the reaper's guard is only reached if createClient still forwards the
+    // decoder's pause to the socket rather than swallowing it in its own wrapper.
+    expect(pauseReads).toHaveBeenCalledTimes(1)
+    expect(resumeReads).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(TIMEOUT_MS * 5)
+
+    expect(detachListener).not.toHaveBeenCalledWith(clientId, expect.anything())
+  })
+
+  it('lets the silence clock resume from the frames the paused turn finally decoded', async () => {
+    // The pause is only ever acquired with a whole frame still buffered, so the resuming turn
+    // decodes one and refreshes lastReceivedAt on its way out. That is what makes a plain
+    // readsPaused skip safe: no separate rebase is needed, and the client is judged again from the
+    // moment it was actually last heard.
+    useRealImmediates()
+    const detachListener = vi.fn()
+    const resumeReads = vi.fn()
+    dispatcher = new RelayDispatcher(() => true)
+    dispatcher.onClientDetached(detachListener)
+    const clientId = dispatcher.attachClient(() => true, undefined, undefined, { resumeReads })
+
+    pauseClientReadsForReal(clientId, FRAME_DECODER_MAX_FRAMES_PER_TURN + 1)
+    vi.advanceTimersByTime(TIMEOUT_MS * 5)
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(resumeReads).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(KEEPALIVE_SEND_MS)
+
+    expect(detachListener).not.toHaveBeenCalledWith(clientId, expect.anything())
   })
 })

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15962,7 +15962,8 @@
           "none": "None",
           "search": "Search",
           "showUnreadOnly": "Show unread only",
-          "showChildAgents": "Show child agents"
+          "showChildAgents": "Show child agents",
+          "activityOptions": "Activity options"
         },
         "clearCompleted": {
           "clearedOne": "Cleared 1 completed agent",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17260,7 +17260,9 @@
   "dashboard": {
     "sidebar": {
       "label": "Agents",
-      "dashboardLabel": "Agent Dashboard"
+      "dashboardLabel": "Agent Dashboard",
+      "openActivity": "View activity",
+      "closeActivity": "Turn off activity view"
     }
   },
   "runtimeRpc": {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​161 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​160 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 |

<!-- /orca-pr-loc -->

> Stacked on #17817. Review that first; retarget to `main` once it merges. The two must land together — #17817 widens the bug this PR fixes.

Found while auditing whether #17817/#17838/#17871 make reconnect lossy: they make three transports declare death faster, so anything fragile about in-flight RPCs gets hit more often.

## First, a correction to the premise I was working from

"Before #17817 a wedged link hung forever" is **not true at the RPC layer.** `ssh-channel-multiplexer.ts` gives every request a 30s client-local deadline that fires regardless of link state, so callers already got a definite-looking failure. What #17817 actually changes is 30s → 20s, a different error code, and **all in-flight requests torn down at once** instead of one at a time. A real widening, not a new class.

## The bug

`SshChannelMultiplexer.request` rejects a **disposed mux** and an **already-aborted signal** synchronously — before `nextRequestId++`, before `sendMessage`. Nothing is ever framed.

`requestSshAgentSessionCreate` tagged those `agentSessionOperationOutcome: 'unknown'` anyway. Its comment says "after request dispatch", but the catch covers pre-dispatch too. That sets `retainReplayFence` and tombstones the operation id for **24 hours**, so a create that provably never left the client becomes permanently unissuable under its own id — every mobile reconnect replay rethrows `SSH connection lost, reconnecting...` for a day.

Reachable because `SshAgentSessionCapabilities.supportsCreateOperations` memoizes its probe per-mux (`ssh-agent-session-capabilities.ts:34-49`): once primed, `SshPtyProvider.spawn` goes straight to the dispatch seam with no round trip, so a dispose landing during `createAgentSession`'s async preflight arrives at an already-disposed mux. **#17817 widens this directly.**

## What ships here

**1. The fence fix.** Mark the two pre-dispatch rejections in the multiplexer — the only place that knows whether a request was framed — and have the caller read that fact rather than infer it. Mid-flight losses carry an identical code and message and **keep** the fence, because a PTY may genuinely be live on the host.

Two regression tests against a real mux and transport. Reverting the fix makes the first fail (`expected … to not have property "agentSessionOperationOutcome"`) while *keeps the fence after dispatch* still passes — so it is not just disabling the fence.

A note on shape: my first attempt pre-checked `mux.isDisposed()` at the call site, and it broke `ssh-pty-provider-claim-incarnation.test.ts` against five partial mux stubs. That was the design saying the caller should not be the one asking.

**2. The undispatched carve-out on the unverifiable verdict.** #17817 introduces `isSshRequestOutcomeUnverifiable`, used by the three call sites that phrase a lost-link verdict to a user. Once the multiplexer can say a request was never framed, that predicate should say `false` for it — the peer provably never saw it, so it is not `unverifiable`, it is un-run. One test.

**3. A reaper guard for a pause the relay caused itself.** While the frame decoder holds reads paused for backpressure no frame can decode, so `lastReceivedAt` freezes. #17817's silence reaper would then reap a client the relay itself stopped listening to. The client-side multiplexer already guards the mirror case with `decoderReadPaused`; this is the relay half, and the flag is set inside `createClient`'s decoder wiring rather than in the reaper, because the decoder is what owns the pause.

The tests drive a real pause — a chunk carrying more frames than the decoder delivers in one turn, with `setImmediate` left unfaked so the continuation cannot run inside `advanceTimersByTime` — rather than poking the private flag. That is what makes the `createClient` wiring itself covered: swallowing either the `pauseReads` or the `resumeReads` forward fails a test, as does deleting the reaper's guard.

## Verification

```
$ pnpm tc                                                        # clean
$ pnpm test src/main/ssh src/relay src/main/text-generation src/main/ai-vault src/main/providers
 Test Files  471 passed | 3 skipped (474)
      Tests  5031 passed | 23 skipped (5054)
$ pnpm run check:code-quality:changed                            # 0 new findings
```

## One finding this audit produced that is NOT fixed here

**`pty.spawn` can leak an agent process unboundedly.** Filed separately — the host holds an idempotency ledger open for 24h while the client memoizes the *rejection* for 24h and never re-issues, so an agent CLI keeps running on the user's machine, invisible to the client. Closing it is the general replay layer, which was explicitly out of scope.

(An earlier revision of this body listed the three `unverifiable` verdict call sites here as unfixed. They are fixed — in #17817, where the regression originates. This PR only adds the undispatched carve-out on top.)

## Also audited: the socket-takeover TOCTOU — verdict is do not convert

An architectural review flagged `relay-socket-ownership.ts:100-113` as probe → unlink → listen with a race, and recommended bind-temp + `link()`. **The cited race is already closed** — the review stopped before the fence at `:191-205`: `blockedIdentity` is captured at `:151` *before* the probe, and `unlinkIfStillStale` re-stats at `:192` and compares dev + ino + ctimeNs immediately before the `unlinkSync` at `:200`, refusing on any mismatch. For a third party to bind there it must first unlink the stale inode and create a fresh one — new ctimeNs — so unlinking *its* socket cannot happen.

Three reasons not to convert anyway:

1. `bind()` on an AF_UNIX path **already has `link()`'s atomicity** — create-or-`EADDRINUSE` — so the retry `listen()` at `:72` already refuses a racer.
2. **Refuse-on-EEXIST cannot be our policy.** That reference can disable multiplexing because multiplexing is an optimization; the relay socket is the *only* ingress and its path is stable across restarts, so a SIGKILLed relay's leftover inode would brick the host permanently. Stale reclamation has to stay — which means keeping the probe and the fenced unlink, i.e. the only part with a window.
3. In Node the bind→listen gap is two back-to-back synchronous libuv calls in one tick; a temp-socket lifecycle would add leaked `.tmp` sockets on crash and spend `sun_path` budget on a path already ~83 of 104 bytes.

**Nothing in #17821 becomes unnecessary** — it answers "is the incumbent *process* live and does it hold PTYs" via `lsof` + argv re-verification, which `EEXIST` cannot answer.

One thing for whoever owns #17821: **`RelaySocketOwnership` has no direct test file.** Since that PR elevates this class to *the* authority, its "refuse to steal a socket that accepts" and "refuse when the inode changed" invariants deserve pinning.
