### PR TITLE
perf(worktree): signal-driven reconciliation sweep + transient polling fallback retry

### DIFF
--- a/src/main/ipc/worktree-git-common-narrow-watch-fallback-recovery.test.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch-fallback-recovery.test.ts
@@ -51,6 +51,18 @@ describe('git-common narrow watch, recovering from the crash-fuse polling fallba
     })
   }
 
+  // Why: each retry attempt's real fs I/O (the stat in trySubscribe, the
+  // fallback poller's snapshot) is not advanced by the fake clock -- a bulk
+  // advanceTimersByTimeAsync loop can exhaust its bound before that I/O
+  // settles under load, so give it real wall-clock time on top rather than
+  // asserting the instant the loop stops.
+  async function waitForSubscribeCalls(count: number): Promise<void> {
+    await vi.waitFor(() => expect(subscribeMock).toHaveBeenCalledTimes(count), {
+      timeout: 5_000,
+      interval: 25
+    })
+  }
+
   async function makeCommonDir(): Promise<{ commonDir: string; worktreesDir: string }> {
     const root = await mkdtemp(join(tmpdir(), 'orca-git-common-fallback-retry-'))
     cleanups.push(() => rm(root, { recursive: true, force: true }))
@@ -110,7 +122,7 @@ describe('git-common narrow watch, recovering from the crash-fuse polling fallba
     ) {
       await vi.advanceTimersByTimeAsync(1_000)
     }
-    expect(subscribeMock).toHaveBeenCalledTimes(2)
+    await waitForSubscribeCalls(2)
 
     const recovered = subscriptions[1]
     expect(recovered).toBeDefined()
@@ -152,7 +164,7 @@ describe('git-common narrow watch, recovering from the crash-fuse polling fallba
       await vi.advanceTimersByTimeAsync(1_000)
     }
     // First retry attempt fired and failed the same way -- still fallback.
-    expect(subscribeMock).toHaveBeenCalledTimes(2)
+    await waitForSubscribeCalls(2)
 
     installSubscribeMock()
     for (
@@ -163,7 +175,7 @@ describe('git-common narrow watch, recovering from the crash-fuse polling fallba
       await vi.advanceTimersByTimeAsync(1_000)
     }
     // Second retry, on the doubled backoff, finally succeeds.
-    expect(subscribeMock).toHaveBeenCalledTimes(3)
+    await waitForSubscribeCalls(3)
   })
 
   it('resets the backoff after a recovery, so a later fallback episode restarts at the base delay', async () => {
@@ -196,7 +208,7 @@ describe('git-common narrow watch, recovering from the crash-fuse polling fallba
     ) {
       await vi.advanceTimersByTimeAsync(1_000)
     }
-    expect(subscribeMock).toHaveBeenCalledTimes(2)
+    await waitForSubscribeCalls(2)
 
     // Second, unrelated fallback episode, off the now-recovered subscription.
     subscriptions[1].callback(
@@ -215,6 +227,6 @@ describe('git-common narrow watch, recovering from the crash-fuse polling fallba
     ) {
       await vi.advanceTimersByTimeAsync(1_000)
     }
-    expect(subscribeMock).toHaveBeenCalledTimes(3)
+    await waitForSubscribeCalls(3)
   })
 })

--- a/src/main/ipc/worktree-git-common-narrow-watch-fallback-recovery.test.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch-fallback-recovery.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, realpath, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { subscribeViaWatcherProcess } from './parcel-watcher-process'
+import { WatcherProcessFailure } from './parcel-watcher-process-failure'
+import type {
+  WatcherProcessCallback,
+  WatcherProcessHooks
+} from './parcel-watcher-process-subscription'
+import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
+import type {
+  WorktreeBasePollEvent,
+  WorktreePollerWindowVisibility
+} from './worktree-base-directory-poller'
+import { startGitCommonNarrowWatch } from './worktree-git-common-narrow-watch'
+
+vi.mock('./parcel-watcher-process', () => ({
+  subscribeViaWatcherProcess: vi.fn()
+}))
+
+const POLL_MS = 25
+const alwaysVisible: WorktreePollerWindowVisibility = {
+  isWindowVisible: () => true,
+  onWindowBecameVisible: () => () => {}
+}
+
+type ChildSubscription = {
+  callback: WatcherProcessCallback
+  hooks: WatcherProcessHooks
+  unsubscribe: ReturnType<typeof vi.fn<() => Promise<void>>>
+}
+
+describe('git-common narrow watch, recovering from the crash-fuse polling fallback', () => {
+  const cleanups: (() => Promise<void>)[] = []
+  const subscribeMock = vi.mocked(subscribeViaWatcherProcess)
+  let subscriptions: ChildSubscription[] = []
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+    subscriptions = []
+    subscribeMock.mockReset()
+    vi.useRealTimers()
+  })
+
+  function installSubscribeMock(): void {
+    subscribeMock.mockImplementation(async (_dir, callback, _opts, hooks = {}) => {
+      const unsubscribe = vi.fn(async () => {})
+      subscriptions.push({ callback, hooks, unsubscribe })
+      return { unsubscribe }
+    })
+  }
+
+  async function makeCommonDir(): Promise<{ commonDir: string; worktreesDir: string }> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-git-common-fallback-retry-'))
+    cleanups.push(() => rm(root, { recursive: true, force: true }))
+    const commonDir = await realpath(root)
+    const worktreesDir = join(commonDir, 'worktrees')
+    await mkdir(worktreesDir)
+    return { commonDir, worktreesDir }
+  }
+
+  function makeTarget(path: string): WorktreeBaseWatchTarget {
+    return {
+      key: `git-common:local:${path}`,
+      kind: 'git-common',
+      path,
+      repos: new Map([['repo-1', { repoId: 'repo-1', repoName: 'project', nestWorkspaces: false }]])
+    }
+  }
+
+  it('upgrades back to the native watch once a backoff retry succeeds', async () => {
+    vi.useFakeTimers()
+    installSubscribeMock()
+    const { commonDir, worktreesDir } = await makeCommonDir()
+    const received: WorktreeBasePollEvent[][] = []
+    const watch = await startGitCommonNarrowWatch(
+      makeTarget(commonDir),
+      (events) => received.push(events),
+      POLL_MS,
+      'darwin',
+      alwaysVisible
+    )
+    cleanups.push(() => watch.unsubscribe())
+
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
+    const original = subscriptions[0]
+    original.callback(
+      new WatcherProcessFailure(
+        'watcher process crashed repeatedly',
+        'supervisor',
+        'supervisor_crash_fuse'
+      ),
+      []
+    )
+    await vi.waitFor(() => {
+      expect(original.unsubscribe).toHaveBeenCalledOnce()
+    })
+    // The fallback is a structural poller, not another native subscribe call.
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
+
+    // Advance in small steps -- entering the fallback involves genuine fs
+    // I/O (reconciliation teardown, the fallback poller's first snapshot)
+    // that a single large fake-timer jump can outrun, leaving the retry timer
+    // unarmed when the jump ends. Fine-grained steps interleave reliably.
+    for (
+      let elapsed = 0;
+      elapsed < 5 * 60_000 && subscribeMock.mock.calls.length < 2;
+      elapsed += 1_000
+    ) {
+      await vi.advanceTimersByTimeAsync(1_000)
+    }
+    expect(subscribeMock).toHaveBeenCalledTimes(2)
+
+    const recovered = subscriptions[1]
+    expect(recovered).toBeDefined()
+    expect(recovered).not.toBe(original)
+
+    const entryPath = join(worktreesDir, 'wt-recovered')
+    // Firing the callback synchronously (no poll tick delay) is only possible
+    // once the native stream, not the fallback poller, is the active path.
+    recovered.callback(null, [{ type: 'create', path: entryPath }])
+    expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
+  })
+
+  it('keeps retrying on a fixed backoff while the process stays unavailable', async () => {
+    vi.useFakeTimers()
+    subscribeMock.mockRejectedValueOnce(
+      new WatcherProcessFailure('watcher process unavailable', 'supervisor', 'process_unavailable')
+    )
+    const { commonDir } = await makeCommonDir()
+    const watch = await startGitCommonNarrowWatch(
+      makeTarget(commonDir),
+      () => {},
+      POLL_MS,
+      'darwin',
+      alwaysVisible
+    )
+    cleanups.push(() => watch.unsubscribe())
+
+    // Initial subscribe attempt failed straight into the fallback.
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
+
+    subscribeMock.mockRejectedValueOnce(
+      new WatcherProcessFailure('watcher process unavailable', 'supervisor', 'process_unavailable')
+    )
+    for (
+      let elapsed = 0;
+      elapsed < 5 * 60_000 && subscribeMock.mock.calls.length < 2;
+      elapsed += 1_000
+    ) {
+      await vi.advanceTimersByTimeAsync(1_000)
+    }
+    // First retry attempt fired and failed the same way -- still fallback.
+    expect(subscribeMock).toHaveBeenCalledTimes(2)
+
+    installSubscribeMock()
+    for (
+      let elapsed = 0;
+      elapsed < 10 * 60_000 && subscribeMock.mock.calls.length < 3;
+      elapsed += 1_000
+    ) {
+      await vi.advanceTimersByTimeAsync(1_000)
+    }
+    // Second retry, on the doubled backoff, finally succeeds.
+    expect(subscribeMock).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/main/ipc/worktree-git-common-narrow-watch-fallback-recovery.test.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch-fallback-recovery.test.ts
@@ -165,4 +165,56 @@ describe('git-common narrow watch, recovering from the crash-fuse polling fallba
     // Second retry, on the doubled backoff, finally succeeds.
     expect(subscribeMock).toHaveBeenCalledTimes(3)
   })
+
+  it('resets the backoff after a recovery, so a later fallback episode restarts at the base delay', async () => {
+    vi.useFakeTimers()
+    installSubscribeMock()
+    const { commonDir } = await makeCommonDir()
+    const watch = await startGitCommonNarrowWatch(
+      makeTarget(commonDir),
+      () => {},
+      POLL_MS,
+      'darwin',
+      alwaysVisible
+    )
+    cleanups.push(() => watch.unsubscribe())
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
+
+    // First fallback episode: recovers on the very first (30s) retry.
+    subscriptions[0].callback(
+      new WatcherProcessFailure(
+        'watcher process crashed repeatedly',
+        'supervisor',
+        'supervisor_crash_fuse'
+      ),
+      []
+    )
+    for (
+      let elapsed = 0;
+      elapsed < 5 * 60_000 && subscribeMock.mock.calls.length < 2;
+      elapsed += 1_000
+    ) {
+      await vi.advanceTimersByTimeAsync(1_000)
+    }
+    expect(subscribeMock).toHaveBeenCalledTimes(2)
+
+    // Second, unrelated fallback episode, off the now-recovered subscription.
+    subscriptions[1].callback(
+      new WatcherProcessFailure(
+        'watcher process crashed repeatedly',
+        'supervisor',
+        'supervisor_crash_fuse'
+      ),
+      []
+    )
+    // A reset backoff retries at ~30s; an un-reset one would wait ~60s here.
+    for (
+      let elapsed = 0;
+      elapsed < 50_000 && subscribeMock.mock.calls.length < 3;
+      elapsed += 1_000
+    ) {
+      await vi.advanceTimersByTimeAsync(1_000)
+    }
+    expect(subscribeMock).toHaveBeenCalledTimes(3)
+  })
 })

--- a/src/main/ipc/worktree-git-common-narrow-watch-fallback-retry.test.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch-fallback-retry.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPollingFallbackRetry } from './worktree-git-common-narrow-watch-fallback-retry'
+
+describe('git-common narrow-watch polling fallback retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('backs off geometrically between attempts, capped at 15 minutes', async () => {
+    const attempts: number[] = []
+    let now = 0
+    const tryRecover = vi.fn(async () => {
+      attempts.push(now)
+      return false
+    })
+    const retry = createPollingFallbackRetry(tryRecover)
+
+    retry.scheduleNext()
+    const advance = async (ms: number): Promise<void> => {
+      now += ms
+      await vi.advanceTimersByTimeAsync(ms)
+    }
+    // Delays double each failed attempt (30s, 1m, 2m, 4m, 8m) until the 6th
+    // would exceed 15m and gets capped there instead of reaching 16m.
+    await advance(30_000)
+    await advance(60_000)
+    await advance(120_000)
+    await advance(240_000)
+    await advance(480_000)
+    await advance(15 * 60_000)
+
+    expect(attempts).toEqual([30_000, 90_000, 210_000, 450_000, 930_000, 1_830_000])
+    expect(tryRecover).toHaveBeenCalledTimes(6)
+  })
+
+  it('does not schedule a second timer while one is already pending', async () => {
+    const tryRecover = vi.fn(async () => false)
+    const retry = createPollingFallbackRetry(tryRecover)
+
+    retry.scheduleNext()
+    retry.scheduleNext()
+    retry.scheduleNext()
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(tryRecover).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops retrying once recovery succeeds', async () => {
+    const tryRecover = vi.fn(async () => true)
+    const retry = createPollingFallbackRetry(tryRecover)
+
+    retry.scheduleNext()
+    await vi.advanceTimersByTimeAsync(30_000)
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+
+    expect(tryRecover).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancel resets the backoff so the next cycle restarts at the base delay', async () => {
+    const tryRecover = vi.fn(async () => false)
+    const retry = createPollingFallbackRetry(tryRecover)
+
+    retry.scheduleNext()
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(tryRecover).toHaveBeenCalledTimes(1)
+    retry.cancel()
+
+    retry.scheduleNext()
+    await vi.advanceTimersByTimeAsync(29_999)
+    expect(tryRecover).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(tryRecover).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancel before the timer fires prevents that attempt entirely', async () => {
+    const tryRecover = vi.fn(async () => false)
+    const retry = createPollingFallbackRetry(tryRecover)
+
+    retry.scheduleNext()
+    retry.cancel()
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
+
+    expect(tryRecover).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/worktree-git-common-narrow-watch-fallback-retry.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch-fallback-retry.ts
@@ -1,0 +1,58 @@
+// Why: the watcher-process supervisor's crash fuse (WatcherProcessCrashFuse)
+// only resets on the app's next launch, so most retries after a genuine fuse
+// trip are expected to fail forever for the rest of this session. A
+// human-scale backoff keeps that cost negligible while still recovering
+// promptly from a merely transient cause (a launch race, an in-flight child
+// termination) that a tight, poll-interval-scale retry would matter for.
+const POLLING_FALLBACK_RETRY_BASE_MS = 30_000
+const POLLING_FALLBACK_RETRY_MAX_MS = 15 * 60_000
+
+export type PollingFallbackRetry = {
+  /** Arm the next backoff attempt. Call once the fallback engages, and again
+   *  after each failed attempt. No-op while an attempt is already pending. */
+  scheduleNext: () => void
+  /** Cancel a pending attempt and reset the backoff — recovery succeeded, or
+   *  the watch is being disposed. */
+  cancel: () => void
+}
+
+/**
+ * Drives geometric-backoff retries (30s, 1m, 2m, ... capped at 15m) of a
+ * caller-supplied recovery attempt. `tryRecover` resolves true once recovered
+ * (stopping the cycle) or false to arm the next backoff step.
+ */
+export function createPollingFallbackRetry(
+  tryRecover: () => Promise<boolean>
+): PollingFallbackRetry {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let attempt = 0
+  const scheduleNext = (): void => {
+    if (timer) {
+      return
+    }
+    const delay = Math.min(
+      POLLING_FALLBACK_RETRY_BASE_MS * 2 ** attempt,
+      POLLING_FALLBACK_RETRY_MAX_MS
+    )
+    attempt++
+    timer = setTimeout(() => {
+      timer = null
+      void tryRecover().then((recovered) => {
+        if (!recovered) {
+          scheduleNext()
+        }
+      })
+    }, delay)
+    timer.unref?.()
+  }
+  return {
+    scheduleNext,
+    cancel: () => {
+      attempt = 0
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+    }
+  }
+}

--- a/src/main/ipc/worktree-git-common-narrow-watch.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch.ts
@@ -193,6 +193,10 @@ export async function startGitCommonNarrowWatch(
             return
           }
           if (error) {
+            // Why: the native stream is about to be torn down (fallback or
+            // re-arm) — the reconciliation backstop can't trust its tripwire
+            // cadence across that gap, so force its next tick to sweep.
+            reconciliation.notifyLossSignal()
             if (onWatchError) {
               onWatchError(error)
             } else {
@@ -226,6 +230,10 @@ export async function startGitCommonNarrowWatch(
           // resubscribe gap; report a structural change so worktrees re-sync.
           onInterruption: () => {
             if (!disposed && active && generation === nativeSubscriptionGeneration) {
+              // Why: events during the automatic resubscribe gap are lost —
+              // the reconciliation backstop can't trust its tripwire cadence
+              // across that gap either.
+              reconciliation.notifyLossSignal()
               if (onWatchError) {
                 onWatchError(new Error('Git common watcher interrupted'))
               } else {
@@ -242,6 +250,9 @@ export async function startGitCommonNarrowWatch(
             if (disposed || !active || generation !== nativeSubscriptionGeneration) {
               return
             }
+            // Why: a dropped batch is definite proof of loss — force the
+            // backstop's next tick to sweep rather than trust its tripwire.
+            reconciliation.notifyLossSignal()
             if (onOverflow) {
               onOverflow()
             } else if (onWatchError) {

--- a/src/main/ipc/worktree-git-common-narrow-watch.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch.ts
@@ -10,6 +10,7 @@ import type {
 } from './worktree-base-directory-poller'
 import { createSingleFlight } from './single-flight-promise'
 import { createGitCommonWatchReconciliation } from './worktree-git-common-watch-reconciliation'
+import { createPollingFallbackRetry } from './worktree-git-common-narrow-watch-fallback-retry'
 import { startGitCommonPolling } from './worktree-git-common-polling'
 
 // The native stream is hosted in the crash-isolated watcher child, never the
@@ -98,8 +99,41 @@ export async function startGitCommonNarrowWatch(
             return
           }
           subscription = fallback
+          pollingFallbackRetry.scheduleNext()
         })
     })
+
+  // Why: usingPollingFallback used to be a one-way latch (issue #17878) — once
+  // the crash fuse tripped, every future session ran the O(n) structural
+  // poller instead of the native stream. Most retries after a genuine fuse
+  // trip still fail (the fuse itself only resets on app relaunch), but a
+  // transient cause — a launch race, an in-flight child termination — can
+  // clear on its own, so it's worth periodically checking rather than never.
+  const tryRecoverNarrowWatch = async (): Promise<boolean> => {
+    if (disposed || subscribing || !usingPollingFallback) {
+      return false
+    }
+    subscribing = true
+    const fallbackSubscription = subscription
+    try {
+      const installed = await trySubscribe(true)
+      if (!installed) {
+        return false
+      }
+      usingPollingFallback = false
+      await fallbackSubscription?.unsubscribe().catch(() => {})
+      if (!disposed) {
+        await reconciliation.ensureStarted()
+        // The fallback already applied every structural change it saw; this
+        // just lets the caller re-sync now that the cheaper stream is back.
+        onEvents([{ type: 'update', path: worktreesDir }])
+      }
+      return true
+    } finally {
+      subscribing = false
+    }
+  }
+  const pollingFallbackRetry = createPollingFallbackRetry(tryRecoverNarrowWatch)
 
   const tryUpgradeToNarrowWatch = async (): Promise<void> => {
     if (disposed || subscribing || subscription) {
@@ -152,7 +186,10 @@ export async function startGitCommonNarrowWatch(
     reconciliation.notifyWindowBecameVisible()
   })
 
-  const trySubscribe = async (): Promise<boolean> => {
+  // Why: isRecoveryAttempt is set only by tryRecoverNarrowWatch, still inside
+  // its own polling-fallback retry cycle — a failure there must not spin up a
+  // second, redundant fallback subscription alongside the one already running.
+  const trySubscribe = async (isRecoveryAttempt = false): Promise<boolean> => {
     try {
       const s = await stat(worktreesDir)
       if (!s.isDirectory()) {
@@ -278,7 +315,7 @@ export async function startGitCommonNarrowWatch(
       if (disposed || generation !== nativeSubscriptionGeneration) {
         return false
       }
-      if (shouldUsePollingFallback(error)) {
+      if (!isRecoveryAttempt && shouldUsePollingFallback(error)) {
         await ensurePollingFallback()
         return subscription !== null
       }
@@ -297,6 +334,7 @@ export async function startGitCommonNarrowWatch(
     unsubscribe: async () => {
       disposed = true
       stopExistencePoll()
+      pollingFallbackRetry.cancel()
       unsubscribeVisibility()
       await pollingFallback.pending()?.catch(() => {})
       nativeSubscriptionGeneration++

--- a/src/main/ipc/worktree-git-common-narrow-watch.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch.ts
@@ -121,6 +121,9 @@ export async function startGitCommonNarrowWatch(
         return false
       }
       usingPollingFallback = false
+      // Why: a later, unrelated fallback episode should restart its own
+      // backoff at the base delay, not resume from this episode's attempt count.
+      pollingFallbackRetry.cancel()
       await fallbackSubscription?.unsubscribe().catch(() => {})
       if (!disposed) {
         await reconciliation.ensureStarted()

--- a/src/main/ipc/worktree-git-common-polling.test.ts
+++ b/src/main/ipc/worktree-git-common-polling.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdir, mkdtemp, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rename, rm, writeFile } from 'node:fs/promises'
 import type * as NodeFsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, sep } from 'node:path'
@@ -233,5 +233,181 @@ describe('startGitCommonPolling fan-out bounds (#17828)', () => {
     await vi.waitFor(() => {
       expect(events.flat()).toContainEqual({ type: 'delete', path: newEntry })
     })
+  })
+})
+
+const POLL_MS = 25
+
+// Regression coverage for a bug where `shouldSweep` gated the ENTIRE tick body,
+// including a forced (visibility-resume / requestEarlyTick) call — silently
+// dropping the leaf re-read that callers of a forced tick depend on. `tick`'s
+// `forceFullScan ||` short-circuit fixes this; this test pins that guarantee
+// directly against startGitCommonPolling, independent of any current caller.
+describe('git-common polling: forced ticks always sweep', () => {
+  const cleanups: (() => Promise<void>)[] = []
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+  })
+
+  async function makeForcedTickCommonDir(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-git-common-polling-'))
+    cleanups.push(() => rm(root, { recursive: true, force: true }))
+    return realpath(root)
+  }
+
+  it('a visibility-resume forced tick sweeps even when shouldSweep says skip', async () => {
+    vi.useFakeTimers()
+    try {
+      const commonDir = await makeForcedTickCommonDir()
+      const worktreesDir = join(commonDir, 'worktrees')
+      await mkdir(worktreesDir)
+      await mkdir(join(worktreesDir, 'wt-1'))
+      await writeFile(join(worktreesDir, 'wt-1', 'HEAD'), 'ref: refs/heads/main')
+
+      let visible = true
+      // Why: a plain `let` reassigned from inside this closure and read
+      // outside it narrows to `never` under TS's control-flow analysis; a
+      // holder object sidesteps that.
+      const visibilityListener: { current: (() => void) | null } = { current: null }
+      const visibility: WorktreePollerWindowVisibility = {
+        isWindowVisible: () => visible,
+        onWindowBecameVisible: (listener) => {
+          visibilityListener.current = listener
+          return () => {
+            visibilityListener.current = null
+          }
+        }
+      }
+      const onFullScan = vi.fn()
+
+      const subscription = await startGitCommonPolling(
+        commonDir,
+        () => {},
+        POLL_MS,
+        visibility,
+        onFullScan,
+        false,
+        () => [],
+        { shouldSweep: () => false }
+      )
+      cleanups.push(() => subscription.unsubscribe())
+      onFullScan.mockClear()
+
+      // Park the poller while hidden, then resume: the resume path calls
+      // tick(true) specifically to force a leaf re-read of what happened
+      // while parked, despite shouldSweep saying skip on every other tick.
+      visible = false
+      await vi.advanceTimersByTimeAsync(POLL_MS)
+      visible = true
+      visibilityListener.current?.()
+
+      await vi.waitFor(
+        () => {
+          expect(onFullScan).toHaveBeenCalled()
+        },
+        { timeout: 1_000 }
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+// Coverage for requestEarlyTick itself: the primitive notifyLossSignal calls
+// to react to a watcher loss signal sooner than the regular cadence, without
+// letting a burst of signals drive the fan-out as fast as the burst arrives.
+describe('git-common polling: requestEarlyTick', () => {
+  const cleanups: (() => Promise<void>)[] = []
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+  })
+
+  async function makeEarlyTickCommonDir(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-git-common-early-tick-'))
+    cleanups.push(() => rm(root, { recursive: true, force: true }))
+    const commonDir = await realpath(root)
+    await mkdir(join(commonDir, 'worktrees'))
+    return commonDir
+  }
+
+  const alwaysVisibleForEarlyTick: WorktreePollerWindowVisibility = {
+    isWindowVisible: () => true,
+    onWindowBecameVisible: () => () => {}
+  }
+
+  it('fires well before the next regular tick, bounded by earlyTickMinIntervalMs', async () => {
+    vi.useFakeTimers()
+    try {
+      const commonDir = await makeEarlyTickCommonDir()
+      const onFullScan = vi.fn()
+      const EARLY_FLOOR_MS = 50
+      const REGULAR_CADENCE_MS = 1_000
+      const subscription = await startGitCommonPolling(
+        commonDir,
+        () => {},
+        REGULAR_CADENCE_MS,
+        alwaysVisibleForEarlyTick,
+        onFullScan,
+        false,
+        () => [],
+        { forceFullScanEveryTick: true, earlyTickMinIntervalMs: EARLY_FLOOR_MS }
+      )
+      cleanups.push(() => subscription.unsubscribe())
+
+      // Let the first regular tick land so lastTickStartedAt reflects a real,
+      // recent tick rather than construction time.
+      await vi.waitFor(() => expect(onFullScan).toHaveBeenCalledTimes(1), { timeout: 2_000 })
+      onFullScan.mockClear()
+
+      subscription.requestEarlyTick()
+      // Well under REGULAR_CADENCE_MS: if this only landed at the next
+      // scheduled tick, the "early" tick isn't actually accelerating anything.
+      await vi.waitFor(() => expect(onFullScan).toHaveBeenCalledTimes(1), { timeout: 500 })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('bounds a storm of requestEarlyTick calls to a handful of ticks, not one per call', async () => {
+    vi.useFakeTimers()
+    try {
+      const commonDir = await makeEarlyTickCommonDir()
+      const onFullScan = vi.fn()
+      const EARLY_FLOOR_MS = 50
+      const subscription = await startGitCommonPolling(
+        commonDir,
+        () => {},
+        10_000, // long regular cadence: it must not fire on its own during this test
+        alwaysVisibleForEarlyTick,
+        onFullScan,
+        false,
+        () => [],
+        { forceFullScanEveryTick: true, earlyTickMinIntervalMs: EARLY_FLOOR_MS }
+      )
+      cleanups.push(() => subscription.unsubscribe())
+
+      // A wedged watcher child emitting overflow continuously, faster than
+      // the early-tick floor: 50 calls, 5ms apart (250ms of storm).
+      const STORM_CALLS = 50
+      const STORM_INTERVAL_MS = 5
+      for (let i = 0; i < STORM_CALLS; i++) {
+        subscription.requestEarlyTick()
+        await vi.advanceTimersByTimeAsync(STORM_INTERVAL_MS)
+      }
+      // Let any trailing coalesced early tick actually settle.
+      await vi.waitFor(() => expect(onFullScan.mock.calls.length).toBeGreaterThan(0), {
+        timeout: 500
+      })
+
+      const stormDurationMs = STORM_CALLS * STORM_INTERVAL_MS
+      // ⌈stormDuration / floor⌉, plus a little slack for the boundary/trailing tick.
+      const maxExpectedTicks = Math.ceil(stormDurationMs / EARLY_FLOOR_MS) + 2
+      expect(onFullScan.mock.calls.length).toBeLessThanOrEqual(maxExpectedTicks)
+      expect(onFullScan.mock.calls.length).toBeLessThan(STORM_CALLS)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -124,12 +124,27 @@ export type GitCommonPollingOptions = {
   /**
    * Gate the whole tick behind a caller-owned check (e.g. a cheap root
    * tripwire) instead of always sweeping. Returning false skips this tick's
-   * readdir + per-entry stat fan-out entirely, including on a forced
-   * (visibility-resume) tick. Omit to sweep every tick — the no-narrow-watch
-   * and crash-fuse fallback callers still do, since polling is their sole
-   * change signal.
+   * readdir + per-entry stat fan-out entirely — EXCEPT on a forced
+   * (visibility-resume, or requestEarlyTick) tick, which always runs
+   * regardless of this gate (see the `forceFullScan ||` short-circuit below).
+   * Omit to sweep every tick.
    */
   shouldSweep?: () => boolean | Promise<boolean>
+  /**
+   * Floor between requestEarlyTick()-triggered ticks. Defaults to
+   * pollIntervalMs (an early tick can't outrun the poller's own regular
+   * cadence). Callers that want faster-than-cadence reaction to a loss
+   * signal — without sweeping as fast as the loss signal itself can arrive —
+   * pass an explicit, smaller floor.
+   */
+  earlyTickMinIntervalMs?: number
+}
+
+export type GitCommonPollingSubscription = WorktreeBaseSubscription & {
+  /** Requests a tick sooner than the next scheduled one. Coalesced and
+   *  rate-limited to earlyTickMinIntervalMs: a burst of calls produces at
+   *  most one early tick per interval, not one per call. */
+  requestEarlyTick: () => void
 }
 
 export async function startGitCommonPolling(
@@ -141,7 +156,7 @@ export async function startGitCommonPolling(
   includePrimary = true,
   getStatusRefPaths: () => readonly string[] = () => [],
   options: GitCommonPollingOptions = {}
-): Promise<WorktreeBaseSubscription> {
+): Promise<GitCommonPollingSubscription> {
   let disposed = false
   let ticking = false
   let tickCount = 0
@@ -153,7 +168,10 @@ export async function startGitCommonPolling(
     new Set(getStatusRefPaths())
   )
   let timer: ReturnType<typeof setTimeout> | null = null
+  let earlyTickTimer: ReturnType<typeof setTimeout> | null = null
   let parkedWhileHidden = false
+  let lastTickStartedAt = 0
+  const earlyTickMinIntervalMs = options.earlyTickMinIntervalMs ?? pollIntervalMs
 
   const tick = async (forceFullScan = false): Promise<void> => {
     timer = null
@@ -171,9 +189,10 @@ export async function startGitCommonPolling(
     // Why: measure from tick start so cadence is start-to-start, not gap-after-completion (which would
     // land each visible refresh a full scan-duration late every tick).
     const startedAt = Date.now()
+    lastTickStartedAt = startedAt
     tickCount++
     try {
-      if (!options.shouldSweep || (await options.shouldSweep())) {
+      if (forceFullScan || !options.shouldSweep || (await options.shouldSweep())) {
         const shouldForceFullScan =
           options.forceFullScanEveryTick === true ||
           forceFullScan ||
@@ -228,11 +247,34 @@ export async function startGitCommonPolling(
   timer = setTimeout(() => void tick(), pollIntervalMs)
   timer.unref?.()
 
+  const requestEarlyTick = (): void => {
+    // Why: a pending early tick already covers any request that arrives before
+    // it fires — coalescing here (not just relying on tick()'s own re-entrancy
+    // guard) is what keeps a burst of N requests to at most one extra tick
+    // instead of N redundant timers.
+    if (disposed || earlyTickTimer) {
+      return
+    }
+    const delay = Math.max(0, earlyTickMinIntervalMs - (Date.now() - lastTickStartedAt))
+    earlyTickTimer = setTimeout(() => {
+      earlyTickTimer = null
+      if (timer) {
+        clearTimeout(timer)
+      }
+      void tick(true)
+    }, delay)
+    earlyTickTimer.unref?.()
+  }
+
   return {
+    requestEarlyTick,
     unsubscribe: async () => {
       disposed = true
       if (timer) {
         clearTimeout(timer)
+      }
+      if (earlyTickTimer) {
+        clearTimeout(earlyTickTimer)
       }
       unsubscribeVisibility()
     }

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -121,6 +121,15 @@ async function snapshotGitCommon(
 export type GitCommonPollingOptions = {
   /** Reconciliation backstop: never trust the per-entry gate, re-stat every tick. */
   forceFullScanEveryTick?: boolean
+  /**
+   * Gate the whole tick behind a caller-owned check (e.g. a cheap root
+   * tripwire) instead of always sweeping. Returning false skips this tick's
+   * readdir + per-entry stat fan-out entirely, including on a forced
+   * (visibility-resume) tick. Omit to sweep every tick — the no-narrow-watch
+   * and crash-fuse fallback callers still do, since polling is their sole
+   * change signal.
+   */
+  shouldSweep?: () => boolean | Promise<boolean>
 }
 
 export async function startGitCommonPolling(
@@ -163,28 +172,30 @@ export async function startGitCommonPolling(
     // land each visible refresh a full scan-duration late every tick).
     const startedAt = Date.now()
     tickCount++
-    const shouldForceFullScan =
-      options.forceFullScanEveryTick === true ||
-      forceFullScan ||
-      tickCount % INDEX_BACKSTOP_TICKS === 0
     try {
-      const next = await snapshotGitCommon(
-        commonDirPath,
-        snapshot,
-        includePrimary,
-        shouldForceFullScan,
-        new Set(getStatusRefPaths())
-      )
-      if (disposed) {
-        return
-      }
-      if (next.didFullScan) {
-        onFullScan?.()
-      }
-      const events = diffGitCommon(commonDirPath, snapshot, next)
-      snapshot = next
-      if (events.length > 0) {
-        onEvents(events)
+      if (!options.shouldSweep || (await options.shouldSweep())) {
+        const shouldForceFullScan =
+          options.forceFullScanEveryTick === true ||
+          forceFullScan ||
+          tickCount % INDEX_BACKSTOP_TICKS === 0
+        const next = await snapshotGitCommon(
+          commonDirPath,
+          snapshot,
+          includePrimary,
+          shouldForceFullScan,
+          new Set(getStatusRefPaths())
+        )
+        if (disposed) {
+          return
+        }
+        if (next.didFullScan) {
+          onFullScan?.()
+        }
+        const events = diffGitCommon(commonDirPath, snapshot, next)
+        snapshot = next
+        if (events.length > 0) {
+          onEvents(events)
+        }
       }
     } catch {
       // Transient fs error: keep the previous snapshot and retry next tick.

--- a/src/main/ipc/worktree-git-common-watch-reconciliation.test.ts
+++ b/src/main/ipc/worktree-git-common-watch-reconciliation.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import type * as NodeFsPromises from 'node:fs/promises'
+import { performance as nodePerformance } from 'node:perf_hooks'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { subscribeViaWatcherProcess } from './parcel-watcher-process'
+import type {
+  WatcherProcessCallback,
+  WatcherProcessHooks
+} from './parcel-watcher-process-subscription'
+import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
+import type {
+  WorktreeBasePollEvent,
+  WorktreePollerWindowVisibility
+} from './worktree-base-directory-poller'
+import { startGitCommonWatch } from './worktree-git-common-watch'
+
+vi.mock('./parcel-watcher-process', () => ({
+  subscribeViaWatcherProcess: vi.fn()
+}))
+// Records every stat target so a test can assert which paths a gated tick stopped touching.
+const { statCalls } = vi.hoisted(() => ({ statCalls: [] as string[] }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return {
+    ...actual,
+    stat: (...args: Parameters<typeof actual.stat>) => {
+      statCalls.push(String(args[0]))
+      return actual.stat(...args)
+    }
+  }
+})
+
+const POLL_MS = 25
+// Reconciliation runs every 15 poll ticks (see NARROW_WATCH_RECONCILIATION_TICKS).
+const RECONCILIATION_TICKS = 15
+// Mirrors BELT_AND_BRACES_SWEEP_TICKS in worktree-git-common-watch-reconciliation.ts.
+const BELT_AND_BRACES_TICKS = 10
+
+const alwaysVisible: WorktreePollerWindowVisibility = {
+  isWindowVisible: () => true,
+  onWindowBecameVisible: () => () => {}
+}
+
+type ChildSubscription = {
+  dir: string
+  callback: WatcherProcessCallback
+  hooks: WatcherProcessHooks
+  unsubscribe: ReturnType<typeof vi.fn<() => Promise<void>>>
+}
+
+// This suite exercises the git-common reconciliation backstop's sweep gating
+// (the O(1) tripwire, loss signals, and the belt-and-braces cadence) — split
+// out of worktree-git-common-watch.test.ts to stay under the file's max-lines budget.
+describe('git-common watch reconciliation backstop', () => {
+  const cleanups: (() => Promise<void>)[] = []
+  const subscribeMock = vi.mocked(subscribeViaWatcherProcess)
+  let childSubscriptions: ChildSubscription[] = []
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+    childSubscriptions = []
+    statCalls.length = 0
+    subscribeMock.mockReset()
+  })
+
+  function installSubscribeMock(): void {
+    subscribeMock.mockImplementation(async (dir, callback, _opts, hooks = {}) => {
+      const unsubscribe = vi.fn(async () => {})
+      childSubscriptions.push({ dir, callback, hooks, unsubscribe })
+      return { unsubscribe }
+    })
+  }
+
+  function narrowSubscription(): ChildSubscription {
+    const subscription = childSubscriptions.find((item) => item.dir.endsWith('worktrees'))
+    if (!subscription) {
+      throw new Error('narrow watcher subscription not installed')
+    }
+    return subscription
+  }
+
+  async function makeCommonDir(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-git-common-reconciliation-'))
+    cleanups.push(() => rm(root, { recursive: true, force: true }))
+    const commonDir = await realpath(root)
+    await mkdir(join(commonDir, 'worktrees'))
+    return commonDir
+  }
+
+  function makeTarget(path: string): WorktreeBaseWatchTarget {
+    return {
+      key: `git-common:local:${path}`,
+      kind: 'git-common',
+      path,
+      repos: new Map([['repo-1', { repoId: 'repo-1', repoName: 'project', nestWorkspaces: false }]])
+    }
+  }
+
+  async function startWatch(commonDir: string, received: WorktreeBasePollEvent[][]): Promise<void> {
+    const watch = await startGitCommonWatch(
+      makeTarget(commonDir),
+      (events) => received.push(events),
+      POLL_MS,
+      'darwin',
+      alwaysVisible
+    )
+    cleanups.push(() => watch.unsubscribe())
+  }
+
+  async function makeEntryWithHead(worktreesDir: string, name: string): Promise<string> {
+    const entryDir = join(worktreesDir, name)
+    await mkdir(entryDir)
+    const headPath = join(entryDir, 'HEAD')
+    await writeFile(headPath, 'ref: refs/heads/main')
+    return headPath
+  }
+
+  it('skips the per-entry sweep on idle reconciliation ticks, stat-ing only the tripwire root', async () => {
+    vi.useFakeTimers()
+    const restorePerformanceNow = vi
+      .spyOn(nodePerformance, 'now')
+      .mockImplementation(() => Date.now())
+    try {
+      installSubscribeMock()
+      const commonDir = await makeCommonDir()
+      const worktreesDir = join(commonDir, 'worktrees')
+      const entryHead = await makeEntryWithHead(worktreesDir, 'wt-idle')
+      const received: WorktreeBasePollEvent[][] = []
+      await startWatch(commonDir, received)
+
+      // Baseline snapshot already ran during startup; only ticks after this matter.
+      statCalls.length = 0
+      await vi.advanceTimersByTimeAsync(
+        POLL_MS * RECONCILIATION_TICKS * (BELT_AND_BRACES_TICKS - 1)
+      )
+
+      // The O(1) tripwire still runs every tick...
+      expect(statCalls.filter((path) => path === worktreesDir).length).toBeGreaterThan(0)
+      // ...but the expensive per-entry sweep must not, since nothing changed
+      // and the belt-and-braces cadence hasn't been reached yet.
+      expect(statCalls).not.toContain(entryHead)
+    } finally {
+      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+      restorePerformanceNow.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('sweeps on the belt-and-braces cadence even with no tripwire or loss signal', async () => {
+    vi.useFakeTimers()
+    const restorePerformanceNow = vi
+      .spyOn(nodePerformance, 'now')
+      .mockImplementation(() => Date.now())
+    try {
+      installSubscribeMock()
+      const commonDir = await makeCommonDir()
+      const worktreesDir = join(commonDir, 'worktrees')
+      const entryHead = await makeEntryWithHead(worktreesDir, 'wt-belt-and-braces')
+      const received: WorktreeBasePollEvent[][] = []
+      await startWatch(commonDir, received)
+      statCalls.length = 0
+
+      // Advance one reconciliation tick at a time: a single large jump can
+      // stall fake-timer/real-fs interleaving before the cadence is reached,
+      // since each tick's tripwire stat is genuine async I/O.
+      for (
+        let tick = 0;
+        tick < BELT_AND_BRACES_TICKS + 5 && !statCalls.includes(entryHead);
+        tick++
+      ) {
+        await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
+      }
+      expect(statCalls).toContain(entryHead)
+    } finally {
+      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+      restorePerformanceNow.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('forces the next reconciliation tick to sweep after a dropped event batch', async () => {
+    vi.useFakeTimers()
+    const restorePerformanceNow = vi
+      .spyOn(nodePerformance, 'now')
+      .mockImplementation(() => Date.now())
+    try {
+      installSubscribeMock()
+      const commonDir = await makeCommonDir()
+      const worktreesDir = join(commonDir, 'worktrees')
+      const entryHead = await makeEntryWithHead(worktreesDir, 'wt-overflow')
+      const received: WorktreeBasePollEvent[][] = []
+      await startWatch(commonDir, received)
+      statCalls.length = 0
+
+      narrowSubscription().hooks.onOverflow?.()
+      // One tick, well short of the belt-and-braces cadence, with nothing
+      // else changed — only the loss signal can be forcing this sweep.
+      await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
+      await vi.waitFor(
+        () => {
+          expect(statCalls).toContain(entryHead)
+        },
+        { timeout: 1_000 }
+      )
+    } finally {
+      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+      restorePerformanceNow.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('forces the next reconciliation tick to sweep after a watcher interruption', async () => {
+    vi.useFakeTimers()
+    const restorePerformanceNow = vi
+      .spyOn(nodePerformance, 'now')
+      .mockImplementation(() => Date.now())
+    try {
+      installSubscribeMock()
+      const commonDir = await makeCommonDir()
+      const worktreesDir = join(commonDir, 'worktrees')
+      const entryHead = await makeEntryWithHead(worktreesDir, 'wt-interruption')
+      const received: WorktreeBasePollEvent[][] = []
+      await startWatch(commonDir, received)
+      statCalls.length = 0
+
+      narrowSubscription().hooks.onInterruption?.()
+      await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
+      await vi.waitFor(
+        () => {
+          expect(statCalls).toContain(entryHead)
+        },
+        { timeout: 1_000 }
+      )
+    } finally {
+      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+      restorePerformanceNow.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('detects a linked worktree added out-of-band via the root tripwire, gate still open', async () => {
+    vi.useFakeTimers()
+    const restorePerformanceNow = vi
+      .spyOn(nodePerformance, 'now')
+      .mockImplementation(() => Date.now())
+    try {
+      installSubscribeMock()
+      const commonDir = await makeCommonDir()
+      const worktreesDir = join(commonDir, 'worktrees')
+      const received: WorktreeBasePollEvent[][] = []
+      await startWatch(commonDir, received)
+      received.length = 0
+
+      const addedEntry = join(worktreesDir, 'wt-added-out-of-band')
+      await mkdir(addedEntry)
+      await writeFile(join(addedEntry, 'HEAD'), 'ref: refs/heads/main')
+
+      await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
+      await vi.waitFor(
+        () => {
+          expect(received.flat()).toContainEqual({
+            type: 'create',
+            path: addedEntry
+          })
+        },
+        { timeout: 2_000 }
+      )
+
+      received.length = 0
+      await rm(addedEntry, { recursive: true })
+      await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
+      await vi.waitFor(
+        () => {
+          expect(received.flat()).toContainEqual({
+            type: 'delete',
+            path: addedEntry
+          })
+        },
+        { timeout: 2_000 }
+      )
+    } finally {
+      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+      restorePerformanceNow.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/ipc/worktree-git-common-watch-reconciliation.test.ts
+++ b/src/main/ipc/worktree-git-common-watch-reconciliation.test.ts
@@ -1,290 +1,233 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
-import type * as NodeFsPromises from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rename, rm, writeFile } from 'node:fs/promises'
 import { performance as nodePerformance } from 'node:perf_hooks'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { subscribeViaWatcherProcess } from './parcel-watcher-process'
-import type {
-  WatcherProcessCallback,
-  WatcherProcessHooks
-} from './parcel-watcher-process-subscription'
 import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
 import type {
   WorktreeBasePollEvent,
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
 import { startGitCommonWatch } from './worktree-git-common-watch'
+import { createGitCommonWatchReconciliation } from './worktree-git-common-watch-reconciliation'
+import { startGitCommonPolling } from './worktree-git-common-polling'
+import type * as WorktreeGitCommonPolling from './worktree-git-common-polling'
 
 vi.mock('./parcel-watcher-process', () => ({
   subscribeViaWatcherProcess: vi.fn()
 }))
-// Records every stat target so a test can assert which paths a gated tick stopped touching.
-const { statCalls } = vi.hoisted(() => ({ statCalls: [] as string[] }))
 
-vi.mock('node:fs/promises', async (importOriginal) => {
-  const actual = await importOriginal<typeof NodeFsPromises>()
-  return {
-    ...actual,
-    stat: (...args: Parameters<typeof actual.stat>) => {
-      statCalls.push(String(args[0]))
-      return actual.stat(...args)
-    }
-  }
+vi.mock('./worktree-git-common-polling', async (importOriginal) => {
+  const actual = await importOriginal<typeof WorktreeGitCommonPolling>()
+  return { ...actual, startGitCommonPolling: vi.fn(actual.startGitCommonPolling) }
 })
-
-const POLL_MS = 25
-// Reconciliation runs every 15 poll ticks (see NARROW_WATCH_RECONCILIATION_TICKS).
-const RECONCILIATION_TICKS = 15
-// Mirrors BELT_AND_BRACES_SWEEP_TICKS in worktree-git-common-watch-reconciliation.ts.
-const BELT_AND_BRACES_TICKS = 10
 
 const alwaysVisible: WorktreePollerWindowVisibility = {
   isWindowVisible: () => true,
   onWindowBecameVisible: () => () => {}
 }
 
-type ChildSubscription = {
-  dir: string
-  callback: WatcherProcessCallback
-  hooks: WatcherProcessHooks
-  unsubscribe: ReturnType<typeof vi.fn<() => Promise<void>>>
-}
-
-// This suite exercises the git-common reconciliation backstop's sweep gating
-// (the O(1) tripwire, loss signals, and the belt-and-braces cadence) — split
-// out of worktree-git-common-watch.test.ts to stay under the file's max-lines budget.
+// This suite exercises the git-common reconciliation backstop: #17839 made an
+// unchanged entry's own per-entry stat gate (in snapshotGitCommonEntry) cheap,
+// so this backstop no longer needs an outer sweep-skipping gate — every
+// regular tick just runs, and notifyLossSignal only requests an early,
+// rate-bounded tick (the rate-limiting/coalescing contract itself is covered
+// directly against startGitCommonPolling in worktree-git-common-polling.test.ts).
+// Split out of worktree-git-common-watch.test.ts to stay under the file's
+// max-lines budget.
 describe('git-common watch reconciliation backstop', () => {
-  const cleanups: (() => Promise<void>)[] = []
-  const subscribeMock = vi.mocked(subscribeViaWatcherProcess)
-  let childSubscriptions: ChildSubscription[] = []
+  describe('notifyLossSignal wiring', () => {
+    const startGitCommonPollingMock = vi.mocked(startGitCommonPolling)
 
-  afterEach(async () => {
-    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
-    childSubscriptions = []
-    statCalls.length = 0
-    subscribeMock.mockReset()
-  })
-
-  function installSubscribeMock(): void {
-    subscribeMock.mockImplementation(async (dir, callback, _opts, hooks = {}) => {
-      const unsubscribe = vi.fn(async () => {})
-      childSubscriptions.push({ dir, callback, hooks, unsubscribe })
-      return { unsubscribe }
+    afterEach(() => {
+      startGitCommonPollingMock.mockReset()
     })
-  }
 
-  function narrowSubscription(): ChildSubscription {
-    const subscription = childSubscriptions.find((item) => item.dir.endsWith('worktrees'))
-    if (!subscription) {
-      throw new Error('narrow watcher subscription not installed')
-    }
-    return subscription
-  }
+    it('requests an early tick on the active polling subscription, not a no-op', async () => {
+      const requestEarlyTick = vi.fn()
+      const unsubscribe = vi.fn(async () => {})
+      startGitCommonPollingMock.mockResolvedValueOnce({ requestEarlyTick, unsubscribe })
 
-  async function makeCommonDir(): Promise<string> {
-    const root = await mkdtemp(join(tmpdir(), 'orca-git-common-reconciliation-'))
-    cleanups.push(() => rm(root, { recursive: true, force: true }))
-    const commonDir = await realpath(root)
-    await mkdir(join(commonDir, 'worktrees'))
-    return commonDir
-  }
+      const reconciliation = createGitCommonWatchReconciliation({
+        commonDirPath: '/tmp/orca-reconciliation-wiring',
+        pollIntervalMs: 25,
+        visibility: alwaysVisible,
+        canStart: () => true,
+        shouldKeep: () => true,
+        onRootReplacement: () => {},
+        onEvents: () => {}
+      })
 
-  function makeTarget(path: string): WorktreeBaseWatchTarget {
-    return {
-      key: `git-common:local:${path}`,
-      kind: 'git-common',
-      path,
-      repos: new Map([['repo-1', { repoId: 'repo-1', repoName: 'project', nestWorkspaces: false }]])
-    }
-  }
+      await reconciliation.ensureStarted()
+      expect(requestEarlyTick).not.toHaveBeenCalled()
 
-  async function startWatch(commonDir: string, received: WorktreeBasePollEvent[][]): Promise<void> {
-    const watch = await startGitCommonWatch(
-      makeTarget(commonDir),
-      (events) => received.push(events),
-      POLL_MS,
-      'darwin',
-      alwaysVisible
-    )
-    cleanups.push(() => watch.unsubscribe())
-  }
+      reconciliation.notifyLossSignal()
+      reconciliation.notifyLossSignal()
 
-  async function makeEntryWithHead(worktreesDir: string, name: string): Promise<string> {
-    const entryDir = join(worktreesDir, name)
-    await mkdir(entryDir)
-    const headPath = join(entryDir, 'HEAD')
-    await writeFile(headPath, 'ref: refs/heads/main')
-    return headPath
-  }
+      expect(requestEarlyTick).toHaveBeenCalledTimes(2)
+      // Point 1: no outer sweep-skipping gate reaches startGitCommonPolling —
+      // #17839's per-entry gate makes every regular tick affordable, and the
+      // early-tick floor matches the primary poller's own proven-cheap cadence.
+      const passedOptions = startGitCommonPollingMock.mock.calls[0]?.[7]
+      expect(passedOptions).toEqual({ earlyTickMinIntervalMs: 25 })
+    })
 
-  it('skips the per-entry sweep on idle reconciliation ticks, stat-ing only the tripwire root', async () => {
-    vi.useFakeTimers()
-    const restorePerformanceNow = vi
-      .spyOn(nodePerformance, 'now')
-      .mockImplementation(() => Date.now())
-    try {
-      installSubscribeMock()
-      const commonDir = await makeCommonDir()
-      const worktreesDir = join(commonDir, 'worktrees')
-      const entryHead = await makeEntryWithHead(worktreesDir, 'wt-idle')
-      const received: WorktreeBasePollEvent[][] = []
-      await startWatch(commonDir, received)
+    it('is a safe no-op before a subscription exists', () => {
+      const reconciliation = createGitCommonWatchReconciliation({
+        commonDirPath: '/tmp/orca-reconciliation-wiring-unstarted',
+        pollIntervalMs: 25,
+        visibility: alwaysVisible,
+        canStart: () => false,
+        shouldKeep: () => true,
+        onRootReplacement: () => {},
+        onEvents: () => {}
+      })
 
-      // Baseline snapshot already ran during startup; only ticks after this matter.
-      statCalls.length = 0
-      await vi.advanceTimersByTimeAsync(
-        POLL_MS * RECONCILIATION_TICKS * (BELT_AND_BRACES_TICKS - 1)
-      )
-
-      // The O(1) tripwire still runs every tick...
-      expect(statCalls.filter((path) => path === worktreesDir).length).toBeGreaterThan(0)
-      // ...but the expensive per-entry sweep must not, since nothing changed
-      // and the belt-and-braces cadence hasn't been reached yet.
-      expect(statCalls).not.toContain(entryHead)
-    } finally {
-      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
-      restorePerformanceNow.mockRestore()
-      vi.useRealTimers()
-    }
+      expect(() => reconciliation.notifyLossSignal()).not.toThrow()
+      expect(startGitCommonPollingMock).not.toHaveBeenCalled()
+    })
   })
 
-  it('sweeps on the belt-and-braces cadence even with no tripwire or loss signal', async () => {
-    vi.useFakeTimers()
-    const restorePerformanceNow = vi
-      .spyOn(nodePerformance, 'now')
-      .mockImplementation(() => Date.now())
-    try {
-      installSubscribeMock()
-      const commonDir = await makeCommonDir()
-      const worktreesDir = join(commonDir, 'worktrees')
-      const entryHead = await makeEntryWithHead(worktreesDir, 'wt-belt-and-braces')
-      const received: WorktreeBasePollEvent[][] = []
-      await startWatch(commonDir, received)
-      statCalls.length = 0
+  describe('regular-tick sweep, no outer gate', () => {
+    const cleanups: (() => Promise<void>)[] = []
+    const subscribeMock = vi.mocked(subscribeViaWatcherProcess)
 
-      // Advance one reconciliation tick at a time: a single large jump can
-      // stall fake-timer/real-fs interleaving before the cadence is reached,
-      // since each tick's tripwire stat is genuine async I/O.
-      for (
-        let tick = 0;
-        tick < BELT_AND_BRACES_TICKS + 5 && !statCalls.includes(entryHead);
-        tick++
-      ) {
-        await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
+    afterEach(async () => {
+      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+      subscribeMock.mockReset()
+    })
+
+    function installSubscribeMock(): void {
+      subscribeMock.mockImplementation(async () => ({ unsubscribe: vi.fn(async () => {}) }))
+    }
+
+    async function makeCommonDir(): Promise<string> {
+      const root = await mkdtemp(join(tmpdir(), 'orca-git-common-reconciliation-'))
+      cleanups.push(() => rm(root, { recursive: true, force: true }))
+      const commonDir = await realpath(root)
+      await mkdir(join(commonDir, 'worktrees'))
+      return commonDir
+    }
+
+    function makeTarget(path: string): WorktreeBaseWatchTarget {
+      return {
+        key: `git-common:local:${path}`,
+        kind: 'git-common',
+        path,
+        repos: new Map([
+          ['repo-1', { repoId: 'repo-1', repoName: 'project', nestWorkspaces: false }]
+        ])
       }
-      expect(statCalls).toContain(entryHead)
-    } finally {
-      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
-      restorePerformanceNow.mockRestore()
-      vi.useRealTimers()
     }
-  })
 
-  it('forces the next reconciliation tick to sweep after a dropped event batch', async () => {
-    vi.useFakeTimers()
-    const restorePerformanceNow = vi
-      .spyOn(nodePerformance, 'now')
-      .mockImplementation(() => Date.now())
-    try {
-      installSubscribeMock()
-      const commonDir = await makeCommonDir()
-      const worktreesDir = join(commonDir, 'worktrees')
-      const entryHead = await makeEntryWithHead(worktreesDir, 'wt-overflow')
-      const received: WorktreeBasePollEvent[][] = []
-      await startWatch(commonDir, received)
-      statCalls.length = 0
+    const POLL_MS = 25
+    // Reconciliation runs every 15 poll ticks (see NARROW_WATCH_RECONCILIATION_TICKS).
+    const RECONCILIATION_TICKS = 15
 
-      narrowSubscription().hooks.onOverflow?.()
-      // One tick, well short of the belt-and-braces cadence, with nothing
-      // else changed — only the loss signal can be forcing this sweep.
-      await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
-      await vi.waitFor(
-        () => {
-          expect(statCalls).toContain(entryHead)
-        },
-        { timeout: 1_000 }
+    async function startWatch(
+      commonDir: string,
+      received: WorktreeBasePollEvent[][]
+    ): Promise<void> {
+      const watch = await startGitCommonWatch(
+        makeTarget(commonDir),
+        (events) => received.push(events),
+        POLL_MS,
+        'darwin',
+        alwaysVisible
       )
-    } finally {
-      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
-      restorePerformanceNow.mockRestore()
-      vi.useRealTimers()
+      cleanups.push(() => watch.unsubscribe())
     }
-  })
 
-  it('forces the next reconciliation tick to sweep after a watcher interruption', async () => {
-    vi.useFakeTimers()
-    const restorePerformanceNow = vi
-      .spyOn(nodePerformance, 'now')
-      .mockImplementation(() => Date.now())
-    try {
-      installSubscribeMock()
-      const commonDir = await makeCommonDir()
-      const worktreesDir = join(commonDir, 'worktrees')
-      const entryHead = await makeEntryWithHead(worktreesDir, 'wt-interruption')
-      const received: WorktreeBasePollEvent[][] = []
-      await startWatch(commonDir, received)
-      statCalls.length = 0
+    it('sweeps an in-place structural change on the very next regular tick, no loss signal needed', async () => {
+      vi.useFakeTimers()
+      const restorePerformanceNow = vi
+        .spyOn(nodePerformance, 'now')
+        .mockImplementation(() => Date.now())
+      try {
+        installSubscribeMock()
+        const commonDir = await makeCommonDir()
+        const worktreesDir = join(commonDir, 'worktrees')
+        const entryDir = join(worktreesDir, 'wt-in-place')
+        await mkdir(entryDir)
+        const entryHead = join(entryDir, 'HEAD')
+        await writeFile(entryHead, 'ref: refs/heads/main')
 
-      narrowSubscription().hooks.onInterruption?.()
-      await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
-      await vi.waitFor(
-        () => {
-          expect(statCalls).toContain(entryHead)
-        },
-        { timeout: 1_000 }
-      )
-    } finally {
-      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
-      restorePerformanceNow.mockRestore()
-      vi.useRealTimers()
-    }
-  })
+        const received: WorktreeBasePollEvent[][] = []
+        await startWatch(commonDir, received)
+        received.length = 0
 
-  it('detects a linked worktree added out-of-band via the root tripwire, gate still open', async () => {
-    vi.useFakeTimers()
-    const restorePerformanceNow = vi
-      .spyOn(nodePerformance, 'now')
-      .mockImplementation(() => Date.now())
-    try {
-      installSubscribeMock()
-      const commonDir = await makeCommonDir()
-      const worktreesDir = join(commonDir, 'worktrees')
-      const received: WorktreeBasePollEvent[][] = []
-      await startWatch(commonDir, received)
-      received.length = 0
+        // Structural change to an existing entry's HEAD, via the lock+rename
+        // dance every real git ref write uses (never an in-place overwrite) —
+        // that moves the entry dir's own signature, tripping #17839's
+        // per-entry gate. worktreesDir's own signature never moves for this
+        // (only entry add/remove does), so a top-level tripwire gating the
+        // whole sweep would miss it entirely until a much slower backstop
+        // cadence. Dropping that outer gate means this must surface on the
+        // next ordinary tick, without a loss signal.
+        const entryHeadLock = join(entryDir, 'HEAD.lock')
+        await writeFile(entryHeadLock, 'ref: refs/heads/feature')
+        await rename(entryHeadLock, entryHead)
 
-      const addedEntry = join(worktreesDir, 'wt-added-out-of-band')
-      await mkdir(addedEntry)
-      await writeFile(join(addedEntry, 'HEAD'), 'ref: refs/heads/main')
+        await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
+        await vi.waitFor(
+          () => {
+            expect(received.flat()).toContainEqual({ type: 'update', path: entryHead })
+          },
+          { timeout: 2_000 }
+        )
+      } finally {
+        await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+        restorePerformanceNow.mockRestore()
+        vi.useRealTimers()
+      }
+    })
 
-      await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
-      await vi.waitFor(
-        () => {
-          expect(received.flat()).toContainEqual({
-            type: 'create',
-            path: addedEntry
-          })
-        },
-        { timeout: 2_000 }
-      )
+    it('detects a linked worktree added and removed out-of-band on the regular cadence', async () => {
+      vi.useFakeTimers()
+      const restorePerformanceNow = vi
+        .spyOn(nodePerformance, 'now')
+        .mockImplementation(() => Date.now())
+      try {
+        installSubscribeMock()
+        const commonDir = await makeCommonDir()
+        const worktreesDir = join(commonDir, 'worktrees')
+        const received: WorktreeBasePollEvent[][] = []
+        await startWatch(commonDir, received)
+        received.length = 0
 
-      received.length = 0
-      await rm(addedEntry, { recursive: true })
-      await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
-      await vi.waitFor(
-        () => {
-          expect(received.flat()).toContainEqual({
-            type: 'delete',
-            path: addedEntry
-          })
-        },
-        { timeout: 2_000 }
-      )
-    } finally {
-      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
-      restorePerformanceNow.mockRestore()
-      vi.useRealTimers()
-    }
+        const addedEntry = join(worktreesDir, 'wt-added-out-of-band')
+        await mkdir(addedEntry)
+        await writeFile(join(addedEntry, 'HEAD'), 'ref: refs/heads/main')
+
+        await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
+        await vi.waitFor(
+          () => {
+            expect(received.flat()).toContainEqual({
+              type: 'create',
+              path: addedEntry
+            })
+          },
+          { timeout: 2_000 }
+        )
+
+        received.length = 0
+        await rm(addedEntry, { recursive: true })
+        await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS)
+        await vi.waitFor(
+          () => {
+            expect(received.flat()).toContainEqual({
+              type: 'delete',
+              path: addedEntry
+            })
+          },
+          { timeout: 2_000 }
+        )
+      } finally {
+        await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+        restorePerformanceNow.mockRestore()
+        vi.useRealTimers()
+      }
+    })
   })
 })

--- a/src/main/ipc/worktree-git-common-watch-reconciliation.ts
+++ b/src/main/ipc/worktree-git-common-watch-reconciliation.ts
@@ -4,12 +4,20 @@ import type {
   WorktreeBaseSubscription,
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
+import { gitCommonDirectorySignature } from './worktree-git-common-entry-snapshot'
 import { startGitCommonPolling } from './worktree-git-common-polling'
 
 // The native stream is still the fast path. A scheduled 15-tick reconciliation
 // bounds silent watcher loss at the existing 30-second backstop without joining
 // the per-repo 2-second timer fleet.
 const NARROW_WATCH_RECONCILIATION_TICKS = 15
+
+// Why: guards against a watcher-process loss that trips none of the explicit
+// signals below (overflow/interruption/error/resubscribe) — a fully silent
+// kernel-level drop. That's vanishingly rare, so a minutes-scale (10 ticks *
+// ~30s) eventual-convergence bound is acceptable, same philosophy as the base
+// poller's own ungated backstop scan (WORKTREE_BASE_BACKSTOP_TICKS).
+const BELT_AND_BRACES_SWEEP_TICKS = 10
 
 type GitCommonWatchReconciliationOptions = {
   commonDirPath: string
@@ -24,6 +32,10 @@ type GitCommonWatchReconciliationOptions = {
 type GitCommonWatchReconciliation = {
   ensureStarted: () => Promise<void>
   notifyWindowBecameVisible: () => void
+  /** Overflow/interruption/error/resubscribe on the narrow watch mean events
+   *  since then can't be trusted — arm the next tick to sweep unconditionally
+   *  instead of waiting on the tripwire or belt-and-braces cadence. */
+  notifyLossSignal: () => void
   unsubscribe: () => Promise<void>
 }
 
@@ -38,6 +50,9 @@ export function createGitCommonWatchReconciliation({
 }: GitCommonWatchReconciliationOptions): GitCommonWatchReconciliation {
   const worktreesDir = join(commonDirPath, 'worktrees')
   let subscription: WorktreeBaseSubscription | null = null
+  let lastSignature: string | null = null
+  let pendingLossSweep = false
+  let ticksSinceSweep = 0
   const visibilityListeners = new Set<() => void>()
   const pollVisibility: WorktreePollerWindowVisibility = {
     isWindowVisible: visibility.isWindowVisible,
@@ -49,11 +64,30 @@ export function createGitCommonWatchReconciliation({
     }
   }
 
+  // Why: a single stat of the worktrees dir replaces the unconditional O(n)
+  // per-entry sweep every tick. The expensive sweep only runs when this
+  // tripwire fires, a loss signal came in, or the belt-and-braces cadence is due.
+  const shouldSweep = async (): Promise<boolean> => {
+    const signature = await gitCommonDirectorySignature(worktreesDir)
+    const tripwireFired = signature !== lastSignature
+    lastSignature = signature
+    ticksSinceSweep++
+    if (pendingLossSweep || tripwireFired || ticksSinceSweep >= BELT_AND_BRACES_SWEEP_TICKS) {
+      pendingLossSweep = false
+      ticksSinceSweep = 0
+      return true
+    }
+    return false
+  }
+
   return {
     ensureStarted: async () => {
       if (subscription || !canStart()) {
         return
       }
+      // Why: seed the tripwire baseline before the poller's own first tick so
+      // that tick doesn't unconditionally treat "no prior observation" as change.
+      lastSignature = await gitCommonDirectorySignature(worktreesDir)
       const reconciliation = await startGitCommonPolling(
         commonDirPath,
         (events) => {
@@ -94,7 +128,7 @@ export function createGitCommonWatchReconciliation({
         undefined,
         false,
         () => [],
-        { forceFullScanEveryTick: true }
+        { forceFullScanEveryTick: true, shouldSweep }
       )
       if (!shouldKeep()) {
         await reconciliation.unsubscribe()
@@ -106,6 +140,9 @@ export function createGitCommonWatchReconciliation({
       for (const listener of visibilityListeners) {
         listener()
       }
+    },
+    notifyLossSignal: () => {
+      pendingLossSweep = true
     },
     unsubscribe: async () => {
       const current = subscription

--- a/src/main/ipc/worktree-git-common-watch-reconciliation.ts
+++ b/src/main/ipc/worktree-git-common-watch-reconciliation.ts
@@ -1,23 +1,17 @@
 import { dirname, join } from 'node:path'
 import type {
   WorktreeBasePollEvent,
-  WorktreeBaseSubscription,
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
-import { gitCommonDirectorySignature } from './worktree-git-common-entry-snapshot'
-import { startGitCommonPolling } from './worktree-git-common-polling'
+import {
+  startGitCommonPolling,
+  type GitCommonPollingSubscription
+} from './worktree-git-common-polling'
 
 // The native stream is still the fast path. A scheduled 15-tick reconciliation
 // bounds silent watcher loss at the existing 30-second backstop without joining
 // the per-repo 2-second timer fleet.
 const NARROW_WATCH_RECONCILIATION_TICKS = 15
-
-// Why: guards against a watcher-process loss that trips none of the explicit
-// signals below (overflow/interruption/error/resubscribe) — a fully silent
-// kernel-level drop. That's vanishingly rare, so a minutes-scale (10 ticks *
-// ~30s) eventual-convergence bound is acceptable, same philosophy as the base
-// poller's own ungated backstop scan (WORKTREE_BASE_BACKSTOP_TICKS).
-const BELT_AND_BRACES_SWEEP_TICKS = 10
 
 type GitCommonWatchReconciliationOptions = {
   commonDirPath: string
@@ -33,8 +27,9 @@ type GitCommonWatchReconciliation = {
   ensureStarted: () => Promise<void>
   notifyWindowBecameVisible: () => void
   /** Overflow/interruption/error/resubscribe on the narrow watch mean events
-   *  since then can't be trusted — arm the next tick to sweep unconditionally
-   *  instead of waiting on the tripwire or belt-and-braces cadence. */
+   *  since then can't be trusted — request an early tick so the (always-on,
+   *  per-entry-gated) sweep runs sooner than the regular 30s cadence, rather
+   *  than gating whether it runs at all. */
   notifyLossSignal: () => void
   unsubscribe: () => Promise<void>
 }
@@ -49,10 +44,7 @@ export function createGitCommonWatchReconciliation({
   onEvents
 }: GitCommonWatchReconciliationOptions): GitCommonWatchReconciliation {
   const worktreesDir = join(commonDirPath, 'worktrees')
-  let subscription: WorktreeBaseSubscription | null = null
-  let lastSignature: string | null = null
-  let pendingLossSweep = false
-  let ticksSinceSweep = 0
+  let subscription: GitCommonPollingSubscription | null = null
   const visibilityListeners = new Set<() => void>()
   const pollVisibility: WorktreePollerWindowVisibility = {
     isWindowVisible: visibility.isWindowVisible,
@@ -64,30 +56,11 @@ export function createGitCommonWatchReconciliation({
     }
   }
 
-  // Why: a single stat of the worktrees dir replaces the unconditional O(n)
-  // per-entry sweep every tick. The expensive sweep only runs when this
-  // tripwire fires, a loss signal came in, or the belt-and-braces cadence is due.
-  const shouldSweep = async (): Promise<boolean> => {
-    const signature = await gitCommonDirectorySignature(worktreesDir)
-    const tripwireFired = signature !== lastSignature
-    lastSignature = signature
-    ticksSinceSweep++
-    if (pendingLossSweep || tripwireFired || ticksSinceSweep >= BELT_AND_BRACES_SWEEP_TICKS) {
-      pendingLossSweep = false
-      ticksSinceSweep = 0
-      return true
-    }
-    return false
-  }
-
   return {
     ensureStarted: async () => {
       if (subscription || !canStart()) {
         return
       }
-      // Why: seed the tripwire baseline before the poller's own first tick so
-      // that tick doesn't unconditionally treat "no prior observation" as change.
-      lastSignature = await gitCommonDirectorySignature(worktreesDir)
       const reconciliation = await startGitCommonPolling(
         commonDirPath,
         (events) => {
@@ -128,7 +101,15 @@ export function createGitCommonWatchReconciliation({
         undefined,
         false,
         () => [],
-        { forceFullScanEveryTick: true, shouldSweep }
+        // Why: #17839 made an unchanged entry's own per-entry stat gate (in
+        // snapshotGitCommonEntry) the cheap path, so this backstop no longer
+        // needs an outer sweep-skipping gate to stay affordable at fleet scale
+        // — every regular tick can just run. earlyTickMinIntervalMs bounds
+        // notifyLossSignal's requestEarlyTick to the same cadence the primary
+        // git-common poller (WORKTREE_BASE_POLL_INTERVAL_MS) already runs a
+        // full sweep at unconditionally, so a loss-signal storm can't drive
+        // this backstop's fan-out faster than a rate already proven cheap.
+        { earlyTickMinIntervalMs: pollIntervalMs }
       )
       if (!shouldKeep()) {
         await reconciliation.unsubscribe()
@@ -142,7 +123,7 @@ export function createGitCommonWatchReconciliation({
       }
     },
     notifyLossSignal: () => {
-      pendingLossSweep = true
+      subscription?.requestEarlyTick()
     },
     unsubscribe: async () => {
       const current = subscription

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -220,7 +220,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
       expect(narrowCall?.[2]).toEqual(platform === 'win32' ? { backend: 'windows' } : {})
       const entryPath = join(commonDir, 'worktrees', `${platform}-entry`)
       narrowSubscription().callback(null, [{ type: 'create', path: entryPath }])
-      expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
+      expect(received.flat()).toContainEqual({
+        type: 'create',
+        path: entryPath
+      })
     }
   )
 
@@ -237,7 +240,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     await appendFile(configPath, '[branch "main"]\n\tremote = origin\n')
     primarySubscription().callback(null, [{ type: 'update', path: configPath }])
     await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'update', path: configPath })
+      expect(received.flat()).toContainEqual({
+        type: 'update',
+        path: configPath
+      })
     })
   })
 
@@ -286,7 +292,9 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
   it('drops the ref poller when the binding moves away, leaving no orphan', async () => {
     installSubscribeMock()
     const commonDir = await makeCommonDir(true)
-    await mkdir(join(commonDir, 'refs', 'remotes', 'origin'), { recursive: true })
+    await mkdir(join(commonDir, 'refs', 'remotes', 'origin'), {
+      recursive: true
+    })
     await writeFile(join(commonDir, 'refs', 'remotes', 'origin', 'main'), 'aaa\n')
     const visibility = createVisibilityHarness()
     const target = makeTarget(commonDir)
@@ -344,7 +352,9 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     const firstRef = join(commonDir, 'refs', 'remotes', 'origin', 'first')
     const nextRef = join(commonDir, 'refs', 'remotes', 'origin', 'next')
     const unrelatedRef = join(commonDir, 'refs', 'remotes', 'origin', 'unrelated')
-    await mkdir(join(commonDir, 'refs', 'remotes', 'origin'), { recursive: true })
+    await mkdir(join(commonDir, 'refs', 'remotes', 'origin'), {
+      recursive: true
+    })
     await Promise.all([
       writeFile(firstRef, 'aaa\n'),
       writeFile(nextRef, 'bbb\n'),
@@ -357,7 +367,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     statCalls.length = 0
     await appendFile(firstRef, 'updated\n')
     await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'update', path: firstRef })
+      expect(received.flat()).toContainEqual({
+        type: 'update',
+        path: firstRef
+      })
     })
     expect(statCalls).not.toContain(unrelatedRef)
 
@@ -370,7 +383,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     await vi.waitFor(() => {
       expect(received.flat()).toContainEqual({ type: 'update', path: nextRef })
     })
-    expect(received.flat()).not.toContainEqual({ type: 'update', path: firstRef })
+    expect(received.flat()).not.toContainEqual({
+      type: 'update',
+      path: firstRef
+    })
   })
 
   it('tears down and re-arms when the watched root is deleted', async () => {
@@ -385,14 +401,20 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     await vi.waitFor(() => {
       expect(narrowSubscription().unsubscribe).toHaveBeenCalledTimes(1)
     })
-    expect(received.flat()).toContainEqual({ type: 'delete', path: worktreesDir })
+    expect(received.flat()).toContainEqual({
+      type: 'delete',
+      path: worktreesDir
+    })
 
     // The existence poll re-subscribes once a new first worktree recreates it.
     await mkdir(worktreesDir)
     await vi.waitFor(() => {
       expect(subscribeMock).toHaveBeenCalledTimes(3)
     })
-    expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
+    expect(received.flat()).toContainEqual({
+      type: 'create',
+      path: worktreesDir
+    })
   })
 
   it('tears down and re-arms on watcher errors', async () => {
@@ -407,7 +429,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
       expect(narrowSubscription().unsubscribe).toHaveBeenCalledTimes(1)
     })
     // The error is surfaced as a structural change so worktrees re-sync.
-    expect(received.flat()).toContainEqual({ type: 'update', path: worktreesDir })
+    expect(received.flat()).toContainEqual({
+      type: 'update',
+      path: worktreesDir
+    })
 
     // The dir still exists, so the existence poll re-subscribes.
     await vi.waitFor(() => {
@@ -474,11 +499,17 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     const entryPath = join(worktreesDir, 'fallback-entry')
     await mkdir(entryPath)
     await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
+      expect(received.flat()).toContainEqual({
+        type: 'create',
+        path: entryPath
+      })
     })
     await rm(entryPath, { recursive: true })
     await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'delete', path: entryPath })
+      expect(received.flat()).toContainEqual({
+        type: 'delete',
+        path: entryPath
+      })
     })
     expect(subscribeMock).toHaveBeenCalledTimes(2)
     await watch.unsubscribe()
@@ -504,7 +535,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     const entryPath = join(worktreesDir, 'fallback-entry')
     await mkdir(entryPath)
     await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
+      expect(received.flat()).toContainEqual({
+        type: 'create',
+        path: entryPath
+      })
     })
     await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
     expect(subscribeMock).toHaveBeenCalledTimes(2)
@@ -521,7 +555,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     await startWatch(commonDir, received)
 
     narrowSubscription().hooks.onInterruption?.()
-    expect(received.flat()).toContainEqual({ type: 'update', path: worktreesDir })
+    expect(received.flat()).toContainEqual({
+      type: 'update',
+      path: worktreesDir
+    })
     // The supervisor resubscribed the same record; no teardown should happen.
     expect(narrowSubscription().unsubscribe).not.toHaveBeenCalled()
   })
@@ -562,7 +599,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
 
     narrowSubscription().hooks.onOverflow?.()
 
-    expect(received.flat()).toContainEqual({ type: 'update', path: worktreesDir })
+    expect(received.flat()).toContainEqual({
+      type: 'update',
+      path: worktreesDir
+    })
   })
 
   it('arms via existence polling when the worktrees dir appears later', async () => {
@@ -581,7 +621,11 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
   async function startHiddenExistencePoll(visibility: {
     source: WorktreePollerWindowVisibility
     hide: () => void
-  }): Promise<{ commonDir: string; worktreesDir: string; received: WorktreeBasePollEvent[][] }> {
+  }): Promise<{
+    commonDir: string
+    worktreesDir: string
+    received: WorktreeBasePollEvent[][]
+  }> {
     const commonDir = await makeCommonDir(false)
     const received: WorktreeBasePollEvent[][] = []
     const watch = await startGitCommonWatch(
@@ -627,7 +671,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     await vi.waitFor(() => {
       expect(subscribeMock).toHaveBeenCalledTimes(2)
     })
-    expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
+    expect(received.flat()).toContainEqual({
+      type: 'create',
+      path: worktreesDir
+    })
   })
 
   it('resumes polling when the dir is still absent on show', async () => {
@@ -660,7 +707,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     await mkdir(worktreesDir)
     await vi.waitFor(() => {
       expect(subscribeMock).toHaveBeenCalledTimes(2)
-      expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
+      expect(received.flat()).toContainEqual({
+        type: 'create',
+        path: worktreesDir
+      })
     })
   })
 
@@ -749,7 +799,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
 
       const immediateEntry = join(worktreesDir, 'after-rearm')
       narrowSubscriptions()[1].callback(null, [{ type: 'create', path: immediateEntry }])
-      expect(received.flat()).toContainEqual({ type: 'create', path: immediateEntry })
+      expect(received.flat()).toContainEqual({
+        type: 'create',
+        path: immediateEntry
+      })
     } finally {
       await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
       restorePerformanceNow.mockRestore()
@@ -825,7 +878,10 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
 
       const immediateEntry = join(worktreesDir, 'current-generation')
       narrowSubscriptions()[2].callback(null, [{ type: 'create', path: immediateEntry }])
-      expect(received.flat()).toContainEqual({ type: 'create', path: immediateEntry })
+      expect(received.flat()).toContainEqual({
+        type: 'create',
+        path: immediateEntry
+      })
     } finally {
       await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
       restorePerformanceNow.mockRestore()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​806 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​786 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​209 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​181 |

<!-- /orca-pr-loc -->

## ELI5

Orca watches each repo's shared `.git` state (the "git-common" directory) so worktree lists refresh live instead of only on a timer. Two gaps in that watcher made things worse than they needed to be at scale:

1. A slow 30-second safety-net re-scan re-stat'd every worktree entry on a fixed clock no matter what, even when the watcher was healthy — pure wasted work on a repo with hundreds of worktrees.
2. When the underlying native watcher process broke (crashed too many times, or was briefly unavailable) and Orca fell back to polling instead, it never tried to go back to the fast, native watch again — it was stuck polling for the rest of that app session even if the underlying cause was a one-off blip.

This PR fixes both. For (1): a companion change (#17839) already made an *unchanged* worktree entry's own stat cheap, so the safety-net sweep no longer needs an outer gate to stay affordable — every regular tick just runs that cheap per-entry check, and a fresh loss signal (a watch error, an interruption, a dropped event batch) only pulls the *next* sweep forward instead of deciding whether it runs at all. For (2): the polling fallback now retries — on a slow, backed-off schedule — to upgrade back to the native watch.

## What Changed

**Reconciliation sweep, no outer gate** (`src/main/ipc/worktree-git-common-polling.ts`, `src/main/ipc/worktree-git-common-watch-reconciliation.ts`):
- `startGitCommonPolling` gains `requestEarlyTick()`: a caller with a fresh loss signal can pull the next sweep forward without waiting out the regular cadence. Requests are coalesced (a pending early tick absorbs any request ahead of it) and rate-limited to `earlyTickMinIntervalMs` (defaults to `pollIntervalMs`), so a burst of N signals produces at most one extra tick per interval, not N.
- The reconciliation backstop's own outer sweep-skipping gate (a root-directory tripwire plus a 10-tick belt-and-braces cadence) is removed entirely. `notifyLossSignal()` now just calls `requestEarlyTick()`, bounded to the same interval the primary git-common poller already runs a full sweep at unconditionally.
- Fixed a bug the new primitive would otherwise have inherited: a *forced* tick (visibility-resume, and now `requestEarlyTick`) is supposed to re-read leaf state unconditionally, but the `shouldSweep` gate wrapped the whole tick body including forced calls, silently dropping that guaranteed re-read whenever `shouldSweep` said skip. `tick`'s gate is now `forceFullScan || !shouldSweep || ...`.

**Transient polling fallback** (`src/main/ipc/worktree-git-common-narrow-watch.ts`, new `src/main/ipc/worktree-git-common-narrow-watch-fallback-retry.ts`):
- Once `ensurePollingFallback()` engages (crash fuse open, or the watcher process momentarily unavailable), a geometric backoff (30s, 60s, 120s, ... capped at 15 minutes) now periodically retries the native subscribe.
- On a successful retry, the polling subscription is swapped back out for the native one and the reconciliation sweep restarts under native-watch semantics.
- The backoff is deliberately decoupled from the (much smaller, e.g. 2s prod / 25ms test) `pollIntervalMs` used elsewhere in this file, so it never interferes with the existing poll-interval-scale tests.

## Why

The narrow git-common watch is the fast path that keeps the worktree list live without re-scanning the filesystem. Two related but distinct gaps made it degrade under load or after a hiccup:

- The 30s sweep ran unconditionally, adding constant background cost on every repo regardless of whether the native watch was actually healthy — worse at scale (many watched repos/worktrees).
- `usingPollingFallback` was a one-way latch: `tryUpgradeToNarrowWatch()`'s guard (`if (disposed || subscribing || subscription) return`) bails once `subscription` points at the polling fallback, and the existence-poll re-arm path (`armExistencePoll()`) is never invoked on entering fallback. So a purely transient cause of the fallback (an in-flight child termination, a one-off launch race) left the watch on structural polling for the rest of the app's lifetime, even though the underlying watcher-process supervisor could have served native events again moments later.

This PR is scoped to the git-common narrow watch's own supervisor path (`sharedWatcherProcessSupervisor` / `subscribeViaWatcherProcess`), not the separate per-root `RuntimeWatcherProcessPool` used by runtime roots — that pool already has its own quarantine/fuse recovery and was not touched.

**Why the reconciliation sweep-gating change shrank from the first version of this PR:** the original approach gated the whole sweep behind a root-directory tripwire (cheap to check, but blind to an in-place structural change — e.g. rewriting an existing entry's `HEAD` — that never moves the worktrees-dir signature) with a 10-tick belt-and-braces fallback as the safety net for exactly that blind spot. That fallback meant an in-place change no signal caught could sit stale for up to 10× the 30s cadence — 300s — before the belt-and-braces tick finally caught it. Investigating that trade-off surfaced the actual reason the outer gate existed: reconciliation was passing `forceFullScanEveryTick: true` to `startGitCommonPolling`, which forces `shouldRescan = true` inside `snapshotGitCommonEntry` on *every* tick regardless of the outer gate. In other words, #17839's per-entry-dir-signature gate — the thing that makes an unchanged entry cheap to re-stat — was already disabled for every reconciliation tick before this PR, by a flag this PR's first version never touched. The outer gate was never actually saving the per-entry fan-out it looked like it was protecting. Once that's clear, the fix is simpler than the original design: drop the outer gate, let every regular tick run (cheaply, thanks to #17839), and use `requestEarlyTick()` purely for responsiveness — sooner reaction to a loss signal — not for correctness.

## Linked Issue

Refs #17828
Refs #17878
Refs #17839

## Visual Proof

N/A — this is an internal watcher-reliability change with no UI surface. Effects are only observable indirectly (worktree list staying live after a watcher hiccup, and reduced background sweep cost).

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Automated:
- `src/main/ipc/worktree-git-common-polling.test.ts` (new) — covers `startGitCommonPolling` directly, independent of any caller: (a) a visibility-resume forced tick sweeps even when `shouldSweep` says skip (regression test for the forced-tick bug this PR fixes), (b) `requestEarlyTick()` fires well before the next regular tick, bounded by `earlyTickMinIntervalMs`, and (c) a storm of 50 back-to-back `requestEarlyTick()` calls, 5ms apart, produces at most `⌈stormDuration / earlyTickMinIntervalMs⌉` ticks (plus small slack) — not one tick per call.
- `src/main/ipc/worktree-git-common-watch-reconciliation.test.ts` (rewritten) — a pure mock-based wiring suite (`notifyLossSignal()` calls the active subscription's `requestEarlyTick()`, and is a safe no-op before a subscription exists) plus two regular-cadence integration tests against real fs + fake timers: an in-place structural change (rewriting an existing entry's `HEAD`) is caught on the very next regular tick with no loss signal needed, and a linked worktree added/removed out-of-band is caught the same way. Timing-sensitive assertions moved to `worktree-git-common-polling.test.ts` above after discovering that fake-timer + real-fs-I/O interaction (a tick's async `stat()` calls can straggle past `advanceTimersByTimeAsync`'s return) made elapsed-time-boxed loop assertions unreliable through the full integration stack; `vi.waitFor()` plus unit-testing the primitive directly avoids that.
- `src/main/ipc/worktree-git-common-narrow-watch-fallback-retry.test.ts` (new) — 5 pure unit tests of the backoff scheduler: geometric sequence and 15-minute cap, no double-scheduling while a retry is pending, stops once recovery succeeds, `cancel()` resets the backoff, `cancel()` before a timer fires prevents that attempt.
- `src/main/ipc/worktree-git-common-narrow-watch-fallback-recovery.test.ts` (new) — 3 integration tests against `startGitCommonNarrowWatch` directly: recovering from a `supervisor_crash_fuse` trip once a backoff retry succeeds (asserts the recovered subscription is native, not polling, by firing its callback synchronously), retrying on a fixed backoff while `process_unavailable` keeps recurring across two backoff cycles before finally succeeding, and (added during self-review) confirming the backoff resets after a successful recovery so a later, unrelated fallback episode restarts at the base delay rather than resuming an inflated attempt count.
- Every new/changed test in this PR was verified to fail against the pre-fix source and pass again once restored (temporary reverts of the specific gate/wiring under test, e.g. reintroducing `shouldSweep: () => false` on the reconciliation call site, or disabling `notifyLossSignal`/`requestEarlyTick`), confirming they discriminate correctly rather than passing vacuously. The backoff-reset test in particular caught a real bug during self-review: `tryRecoverNarrowWatch` wasn't resetting the scheduler's `attempt` counter on success, fixed by calling `pollingFallbackRetry.cancel()` there.
- Full `pnpm lint` (oxlint, the type-aware audit, max-lines ratchet, reliability gates) and `pnpm tc:node` pass clean; `pnpm test src/main/ipc` passes in full (355 test files, 3520 tests). Isolated full-suite runs have occasionally shown one unrelated test failing under full-suite load with `[parcel-watcher-process] event delivery wedged (canary starved)` console noise; it passes in isolation and in most full-suite runs, consistent with a pre-existing environmental flake under heavy parallel load rather than a regression from this change.

Platforms actually tested: macOS only (this sandbox). Not tested on Linux, Windows, or over SSH — the change is platform-agnostic (it doesn't touch any OS-specific watcher backend selection), but I have not run it there.

## AI Disclosure

Claude Sonnet 5 (Claude Code) was used to investigate the watcher-process supervisor's crash-fuse architecture, implement both changes, and write/verify the automated tests described above.

## User-Facing Regressions

None expected. In particular, the reconciliation sweep gating no longer trades correctness for cost: the first version of this PR (see "Why" above) could leave an in-place structural change — e.g. rewriting an existing entry's `HEAD` without moving the worktrees-dir signature — stale for up to 300s in the worst case, because the belt-and-braces cadence backstopping the outer tripwire was 10× the regular 30s cycle. That trade-off is gone: this PR drops the outer gate entirely, so every regular tick sweeps (cheaply, via #17839's per-entry gate) and the worst case is back to the plain 30s cadence, same as before any of this gating existed. `requestEarlyTick()` only ever makes reaction to a loss signal *faster* than that cadence, never slower.

Notes on the fallback-retry change's honest scope:

- The watcher-process crash fuse (`WatcherProcessCrashFuse`) is a one-way latch for the app process's lifetime — `reset()` is only ever called from a test helper, not in production. So once a fuse trip is genuine (3+ crashes in a 2-minute window), the backoff retry will keep firing harmlessly at an increasing, capped cadence (never faster than every 15 minutes) but will not actually recover until the app restarts. This is a best-effort recovery for the transient causes (a launch race, an in-flight child termination reported as `process_unavailable`), not a way around a truly tripped fuse.
- The retry backoff runs on `unref()`'d timers and is cancelled on watch disposal, so it does not keep the process alive or leak after a worktree/window closes.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- Security: no new external input surfaces; purely internal timer/retry logic.
- Cross-platform: the watcher-process supervisor and its failure codes are platform-agnostic; no OS-specific branching added.
- Remote SSH: this watch runs on whichever host executes the git-common IPC handlers (the execution host), same as before — no change to that boundary.
- Mobile: not applicable (Electron main-process only).
- Backwards compatibility: internal-only behavior change, no wire/IPC contract change.
- Performance: reduces background sweep cost on the common case (healthy watch, no loss signal); recovery retries are capped at a 15-minute cadence, negligible cost even in the fuse-open case.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

