### PR TITLE
fix(ssh): close two sweep kill paths, and a test harness that hid them

### DIFF
--- a/src/main/ipc/pty-daemon-spawn-session-identity.test.ts
+++ b/src/main/ipc/pty-daemon-spawn-session-identity.test.ts
@@ -8,6 +8,7 @@ import {
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import { createDaemonActiveProviderFixtures } from './pty-ipc-daemon-provider-fixtures'
 import { makePaneKey } from '../../shared/stable-pane-id'
+import { SshPtyAbsentFromRelayError } from '../providers/ssh-pty-errors'
 import {
   registerPtyHandlers,
   registerSshPtyProvider,
@@ -459,7 +460,9 @@ describe('registerPtyHandlers', () => {
       })
       it('marks a caller-supplied SSH session expired when remote reattach is gone', async () => {
         const sshSpawn = vi.fn(async () => {
-          throw new Error('SSH_SESSION_EXPIRED: remote-pty')
+          // The class, not the message: `SSH_SESSION_EXPIRED` is also what a live PTY whose
+          // source stream needs restoring refuses with, and only this one is host-reported absence.
+          throw new SshPtyAbsentFromRelayError('SSH_SESSION_EXPIRED: remote-pty')
         })
         const store = {
           markSshRemotePtyLease: vi.fn(),
@@ -509,10 +512,70 @@ describe('registerPtyHandlers', () => {
 
         expect(store.markSshRemotePtyLease).toHaveBeenCalledWith('ssh-1', 'remote-pty', 'expired')
       })
+      it('leaves the lease alone when the refusal did not observe the process', async () => {
+        // A `restoreRequired` reattach is refused with the SAME `SSH_SESSION_EXPIRED` text, and it
+        // means the opposite: the PTY is live, only its source stream could not be resumed. The
+        // lease and the in-memory ownership are between them this client's only record that the
+        // remote process exists, and #9819's sweep reads a PTY it has no record of as one it may
+        // SIGKILL on the next connect. Erasing them here is how a live shell gets reaped.
+        const sshSpawn = vi.fn(async () => {
+          throw new Error('SSH_SESSION_EXPIRED: remote-pty')
+        })
+        const store = {
+          markSshRemotePtyLease: vi.fn(),
+          clearSshRemotePtyKillIntent: vi.fn()
+        }
+        registerSshPtyProvider('ssh-1', {
+          spawn: sshSpawn,
+          write: vi.fn(),
+          resize: vi.fn(),
+          shutdown: vi.fn(),
+          sendSignal: vi.fn(),
+          getCwd: vi.fn(),
+          getInitialCwd: vi.fn(),
+          clearBuffer: vi.fn(),
+          acknowledgeDataEvent: vi.fn(),
+          hasChildProcesses: vi.fn(),
+          getForegroundProcess: vi.fn(),
+          serialize: vi.fn(),
+          revive: vi.fn(),
+          onData: vi.fn(() => () => {}),
+          onReplay: vi.fn(() => () => {}),
+          onExit: vi.fn(() => () => {}),
+          listProcesses: vi.fn(async () => []),
+          attach: vi.fn(),
+          getDefaultShell: vi.fn(),
+          getProfiles: vi.fn()
+        } as never)
+        handlers.clear()
+        registerPtyHandlers(
+          mainWindow as never,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          store as never
+        )
+
+        await expect(
+          handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            env: {},
+            connectionId: 'ssh-1',
+            sessionId: 'remote-pty'
+          })
+        ).rejects.toThrow('SSH_SESSION_EXPIRED: remote-pty')
+
+        // The spawn still fails; what must not happen is the destructive bookkeeping.
+        expect(store.markSshRemotePtyLease).not.toHaveBeenCalled()
+      })
       it('marks a scoped SSH session expired using the raw relay lease id', async () => {
         const scopedPtyId = 'ssh:ssh-1@@remote-pty'
         const sshSpawn = vi.fn(async () => {
-          throw new Error('SSH_SESSION_EXPIRED: remote-pty')
+          // The class, not the message: `SSH_SESSION_EXPIRED` is also what a live PTY whose
+          // source stream needs restoring refuses with, and only this one is host-reported absence.
+          throw new SshPtyAbsentFromRelayError('SSH_SESSION_EXPIRED: remote-pty')
         })
         const store = {
           markSshRemotePtyLease: vi.fn(),

--- a/src/main/ipc/pty-runtime-ssh-binding-persistence.test.ts
+++ b/src/main/ipc/pty-runtime-ssh-binding-persistence.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { spawnMock, openCodeClearPtyMock, piClearPtyMock } from './pty-ipc-mock-registry'
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import { makePaneKey } from '../../shared/stable-pane-id'
-import { SSH_SESSION_EXPIRED_ERROR } from '../providers/ssh-pty-errors'
+import { SSH_SESSION_EXPIRED_ERROR, SshPtyAbsentFromRelayError } from '../providers/ssh-pty-errors'
 import {
   registerPtyHandlers,
   registerSshPtyProvider,
@@ -446,7 +446,9 @@ describe('registerPtyHandlers', () => {
     const remoteWrite = vi.fn()
     registerSshPtyProvider('ssh-expired-runtime', {
       spawn: vi.fn(async () => {
-        throw new Error(`${SSH_SESSION_EXPIRED_ERROR}: relay-pty`)
+        // The class, not the message: `SSH_SESSION_EXPIRED` is also what a live PTY whose source
+        // stream needs restoring refuses with, and only this one is host-reported absence.
+        throw new SshPtyAbsentFromRelayError(`${SSH_SESSION_EXPIRED_ERROR}: relay-pty`)
       }),
       write: remoteWrite,
       resize: vi.fn(),
@@ -529,6 +531,107 @@ describe('registerPtyHandlers', () => {
     } finally {
       deletePtyOwnership(appPtyId)
       unregisterSshPtyProvider('ssh-expired-runtime')
+    }
+  })
+  it('leaves a runtime-owned lease alone when the refusal did not observe the process', async () => {
+    // The `restoreRequired` twin of the case above: same `SSH_SESSION_EXPIRED` text, opposite
+    // meaning — the PTY is live and only its source stream needs rebuilding. Expiring the lease
+    // and dropping ownership erases this client's only record of a running remote process, and
+    // #9819's sweep reads a PTY it has no record of as one it may SIGKILL on the next connect.
+    type RuntimeSpawnController = {
+      spawn(args: {
+        cols: number
+        rows: number
+        worktreeId?: string
+        connectionId?: string
+        tabId?: string
+        leafId?: string
+        sessionId?: string
+        persistHostSessionBinding?: boolean
+      }): Promise<{ id: string }>
+    }
+    const appPtyId = 'ssh:ssh-live-runtime@@relay-pty'
+    const remoteWrite = vi.fn()
+    registerSshPtyProvider('ssh-live-runtime', {
+      spawn: vi.fn(async () => {
+        throw new Error(`${SSH_SESSION_EXPIRED_ERROR}: relay-pty`)
+      }),
+      write: remoteWrite,
+      resize: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    const store = {
+      upsertSshRemotePtyLease: vi.fn(),
+      persistPtyBinding: vi.fn(),
+      removeSshRemotePtyLease: vi.fn(),
+      markSshRemotePtyLease: vi.fn(),
+      clearSshRemotePtyKillIntent: vi.fn()
+    }
+    let controller: RuntimeSpawnController | null = null
+    const runtime = {
+      setPtyController: vi.fn((value) => {
+        controller = value
+      }),
+      createPreAllocatedTerminalHandle: vi.fn(() => 'term_remote'),
+      registerPreAllocatedHandleForPty: vi.fn(),
+      registerPty: vi.fn(),
+      noteTerminalSpawnCommand: vi.fn(),
+      getDriver: vi.fn(() => ({ kind: 'host' })),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn()
+    }
+
+    try {
+      setPtyOwnership(appPtyId, 'ssh-live-runtime')
+      registerPtyHandlers(
+        mainWindow as never,
+        runtime as never,
+        undefined,
+        undefined,
+        undefined,
+        store as never
+      )
+      const spawnController = controller as unknown as RuntimeSpawnController
+      const leafId = '11111111-1111-4111-8111-111111111111'
+
+      await expect(
+        spawnController.spawn({
+          cols: 80,
+          rows: 24,
+          connectionId: 'ssh-live-runtime',
+          worktreeId: 'wt-remote',
+          tabId: 'tab-remote',
+          leafId,
+          sessionId: appPtyId,
+          persistHostSessionBinding: true
+        })
+      ).rejects.toThrow(SSH_SESSION_EXPIRED_ERROR)
+
+      expect(store.markSshRemotePtyLease).not.toHaveBeenCalled()
+      expect(store.upsertSshRemotePtyLease).not.toHaveBeenCalled()
+      expect(store.persistPtyBinding).not.toHaveBeenCalled()
+      // Still routable: the client kept its handle on a process that is still running.
+      getPtyWriteListener()(mainWindowIpcEvent, { id: appPtyId, data: 'echo still-here' })
+      expect(remoteWrite).toHaveBeenCalledWith(appPtyId, 'echo still-here')
+    } finally {
+      deletePtyOwnership(appPtyId)
+      unregisterSshPtyProvider('ssh-live-runtime')
     }
   })
 })

--- a/src/main/ipc/pty/ipc/spawn-execute.ts
+++ b/src/main/ipc/pty/ipc/spawn-execute.ts
@@ -1,6 +1,7 @@
 import { ensureWslHookRelayForReattach } from '../../../agent-hooks/wsl-hook-relay-reattach'
 import {
   SSH_SESSION_EXPIRED_ERROR,
+  isSshPtyAbsentFromRelayError,
   isSshPtyIdentityMismatchError
 } from '../../../providers/ssh-pty-errors'
 import { classifyError } from '../../../telemetry/classify-error'
@@ -144,6 +145,15 @@ export async function executePtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<void> {
       Boolean(args.connectionId) &&
       (spawnError.message.includes(SSH_SESSION_EXPIRED_ERROR) ||
         rawMessage.includes(SSH_SESSION_EXPIRED_ERROR))
+    // The message alone cannot carry this decision. All three reattach refusals are minted with the
+    // same `SSH_SESSION_EXPIRED` text, and only one of them observed the process: `restoreRequired`
+    // means the PTY is LIVE and only its source stream needs rebuilding, which
+    // `ssh-pty-errors.ts` states outright. Expiring its lease and deleting its ownership erases
+    // this client's last record of a running remote process, and #9819's sweep reads a PTY it has
+    // no record of as one it may SIGKILL on the next connect. Only positive host-reported absence
+    // may reach that bookkeeping; being too strict here merely leaves a dead lease for the next
+    // reattach to retire on real host evidence.
+    const relayReportedSessionAbsent = isExpiredSshSession && isSshPtyAbsentFromRelayError(err)
     const exitedBeforeSpawnReply =
       ctx.rejectedRegistrationCandidate?.exitedBeforeSpawnReply === true
     if (ctx.effectiveSessionAppId !== undefined) {
@@ -157,7 +167,11 @@ export async function executePtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<void> {
         ptySizes.delete(ctx.effectiveSessionAppId)
       }
     }
-    if (args.connectionId && ctx.effectiveSessionRelayId !== undefined && isExpiredSshSession) {
+    if (
+      args.connectionId &&
+      ctx.effectiveSessionRelayId !== undefined &&
+      relayReportedSessionAbsent
+    ) {
       // Why: expired remote reattach = relay already dropped the PTY; clear the lease so writes can't restore the stale binding.
       if (ctx.effectiveSessionAppId !== undefined && !isIdentityMismatch) {
         clearProviderPtyState(ctx.effectiveSessionAppId)

--- a/src/main/ipc/pty/runtime/spawn-execute.ts
+++ b/src/main/ipc/pty/runtime/spawn-execute.ts
@@ -13,6 +13,7 @@ import { clearProviderPtyState } from '../provider/state-cleanup'
 import { isProviderAgentSessionOwnerLive, normalizeNodePtySpawnError } from '../provider/liveness'
 import {
   SSH_SESSION_EXPIRED_ERROR,
+  isSshPtyAbsentFromRelayError,
   isSshPtyIdentityMismatchError
 } from '../../../providers/ssh-pty-errors'
 import type { RuntimePtySpawnState } from './spawn-state'
@@ -224,6 +225,15 @@ export async function executeRuntimePtySpawn(ctx: RuntimePtySpawnState): Promise
       Boolean(args.connectionId) &&
       (spawnError.message.includes(SSH_SESSION_EXPIRED_ERROR) ||
         rawMessage.includes(SSH_SESSION_EXPIRED_ERROR))
+    // The message alone cannot carry this decision. All three reattach refusals are minted with the
+    // same `SSH_SESSION_EXPIRED` text, and only one of them observed the process: `restoreRequired`
+    // means the PTY is LIVE and only its source stream needs rebuilding, which
+    // `ssh-pty-errors.ts` states outright. Expiring its lease and deleting its ownership erases
+    // this client's last record of a running remote process, and #9819's sweep reads a PTY it has
+    // no record of as one it may SIGKILL on the next connect. Only positive host-reported absence
+    // may reach that bookkeeping; being too strict here merely leaves a dead lease for the next
+    // reattach to retire on real host evidence.
+    const relayReportedSessionAbsent = isExpiredSshSession && isSshPtyAbsentFromRelayError(err)
     const exitedBeforeSpawnReply =
       ctx.rejectedRegistrationCandidate?.exitedBeforeSpawnReply === true
     if (ctx.effectiveSessionAppId !== undefined) {
@@ -237,7 +247,11 @@ export async function executeRuntimePtySpawn(ctx: RuntimePtySpawnState): Promise
         ptySizes.delete(ctx.effectiveSessionAppId)
       }
     }
-    if (args.connectionId && ctx.effectiveSessionRelayId !== undefined && isExpiredSshSession) {
+    if (
+      args.connectionId &&
+      ctx.effectiveSessionRelayId !== undefined &&
+      relayReportedSessionAbsent
+    ) {
       if (ctx.effectiveSessionAppId !== undefined && !isIdentityMismatch) {
         clearProviderPtyState(ctx.effectiveSessionAppId)
         deletePtyOwnership(ctx.effectiveSessionAppId)

--- a/src/main/providers/agent-foreground-process-batch.test.ts
+++ b/src/main/providers/agent-foreground-process-batch.test.ts
@@ -22,7 +22,7 @@ describe('batched foreground process correlation', () => {
       resolveAgentForegroundProcessesFromIndex(buildProcessTableIndex(rows), [
         { rootPid: 100, fallbackProcess: 'zsh' }
       ])
-    ).toEqual([{ available: true, processName: 'codex', shellIsForeground: false }])
+    ).toEqual([{ available: true, processName: 'codex', shellOwnsEveryTtyProcessGroup: false }])
   })
 
   it('reports whether the shell itself owns the terminal, named process or not', () => {
@@ -41,8 +41,8 @@ describe('batched foreground process correlation', () => {
         { rootPid: 300, fallbackProcess: 'zsh' }
       ])
     ).toEqual([
-      { available: true, processName: null, shellIsForeground: true },
-      { available: true, processName: null, shellIsForeground: false }
+      { available: true, processName: null, shellOwnsEveryTtyProcessGroup: true },
+      { available: true, processName: null, shellOwnsEveryTtyProcessGroup: false }
     ])
   })
 

--- a/src/main/providers/agent-foreground-process-batch.test.ts
+++ b/src/main/providers/agent-foreground-process-batch.test.ts
@@ -22,7 +22,28 @@ describe('batched foreground process correlation', () => {
       resolveAgentForegroundProcessesFromIndex(buildProcessTableIndex(rows), [
         { rootPid: 100, fallbackProcess: 'zsh' }
       ])
-    ).toEqual([{ available: true, processName: 'codex' }])
+    ).toEqual([{ available: true, processName: 'codex', shellIsForeground: false }])
+  })
+
+  it('reports whether the shell itself owns the terminal, named process or not', () => {
+    // The only host-observable "nothing is running here". pid 200's own pgid owns the terminal;
+    // pid 300 has an unrecognized command in the foreground, which nothing else here can see.
+    const rows = parseStrictProcessTableRows(
+      [
+        '200 1 200 200 Ss /bin/zsh',
+        '300 1 300 301 Ss /bin/zsh',
+        '301 300 301 301 S+ vim notes.md'
+      ].join('\n')
+    )
+    expect(
+      resolveAgentForegroundProcessesFromIndex(buildProcessTableIndex(rows), [
+        { rootPid: 200, fallbackProcess: 'zsh' },
+        { rootPid: 300, fallbackProcess: 'zsh' }
+      ])
+    ).toEqual([
+      { available: true, processName: null, shellIsForeground: true },
+      { available: true, processName: null, shellIsForeground: false }
+    ])
   })
 
   it('returns unverifiable for a missing root or no controlling tty', () => {

--- a/src/main/providers/agent-foreground-process-batch.ts
+++ b/src/main/providers/agent-foreground-process-batch.ts
@@ -25,6 +25,9 @@ export type BatchedForegroundProcessResult = {
   available: boolean
   processName: string | null
   reason?: string
+  /** Set only when the table was readable: the PTY's own shell owns the terminal's foreground
+   *  process group, so nothing is running in the pane. Left absent when we could not observe it. */
+  shellIsForeground?: boolean
 }
 
 export type BatchedForegroundProcessOptions = {
@@ -113,6 +116,10 @@ export function resolveAgentForegroundProcessesFromIndex(
         reason: 'no_controlling_tty'
       }
     }
+    // The only host-observable "nothing is running here" signal: the terminal's foreground process
+    // group is the shell's own. Any foreground command — recognized agent or not — moves tpgid off
+    // it, so a reader may treat `false` as "busy" and must never treat absence as "idle".
+    const shellIsForeground = root.tpgid === root.pgid
     const allCandidates = rowsByOwner.get(root.pid) ?? []
     const foregroundCandidates = allCandidates.filter((row) => row.pgid === root.tpgid)
     const fallbackProcess = request.fallbackProcess
@@ -124,7 +131,7 @@ export function resolveAgentForegroundProcessesFromIndex(
         )
       : foregroundCandidates
     if (wrapperFallback && candidates.length !== 1) {
-      return { available: true, processName: null }
+      return { available: true, processName: null, shellIsForeground }
     }
     let bestCandidate: (ProcessTableRow & { depth: number }) | null = null
     let bestName: ReturnType<typeof recognizeAgentProcessFromCommandLine> = null
@@ -142,10 +149,11 @@ export function resolveAgentForegroundProcessesFromIndex(
     if (bestCandidate && bestName) {
       return {
         available: true,
-        processName: resolveOuterWrapperForegroundProcess(bestName, bestCandidate, allCandidates)
+        processName: resolveOuterWrapperForegroundProcess(bestName, bestCandidate, allCandidates),
+        shellIsForeground
       }
     }
-    return { available: true, processName: null }
+    return { available: true, processName: null, shellIsForeground }
   })
 }
 
@@ -154,7 +162,14 @@ export function toForegroundProcessEvidence(
   metadata: { authorityGeneration: string; observationEpoch: number; capturedAgeMs: number }
 ): ForegroundProcessEvidence {
   return result.available
-    ? { ...metadata, verdict: 'live', processName: result.processName }
+    ? {
+        ...metadata,
+        verdict: 'live',
+        processName: result.processName,
+        ...(result.shellIsForeground !== undefined
+          ? { shellIsForeground: result.shellIsForeground }
+          : {})
+      }
     : {
         ...metadata,
         verdict: 'unverifiable',

--- a/src/main/providers/agent-foreground-process-batch.ts
+++ b/src/main/providers/agent-foreground-process-batch.ts
@@ -25,15 +25,57 @@ export type BatchedForegroundProcessResult = {
   available: boolean
   processName: string | null
   reason?: string
-  /** Set only when the table was readable: the PTY's own shell owns the terminal's foreground
-   *  process group, so nothing is running in the pane. Left absent when we could not observe it. */
-  shellIsForeground?: boolean
+  /** Set only when the table was readable: every process group attached to this PTY's terminal is
+   *  the shell's own, and none of them is stopped. Left absent when we could not observe it. */
+  shellOwnsEveryTtyProcessGroup?: boolean
 }
 
 export type BatchedForegroundProcessOptions = {
   rows?: readonly ProcessTableRow[]
   readRows?: () => Promise<readonly ProcessTableRow[]>
   stats?: ProcessTableIndexStats
+}
+
+/** Which process groups occupy each controlling terminal, and which terminals hold a stopped
+ *  process. */
+type TtyOccupancy = {
+  processGroupsByTty: ReadonlyMap<number, ReadonlySet<number>>
+  stoppedTtys: ReadonlySet<number>
+}
+
+const ttyOccupancyByCapture = new WeakMap<readonly ProcessTableRow[], TtyOccupancy>()
+
+/** Index the capture by controlling terminal.
+ *
+ *  Keyed on `tpgid` because the snapshot carries no tty column and does not need one: a process
+ *  group belongs to exactly one session, a session to at most one controlling terminal, so two
+ *  rows reporting the same live `tpgid` are on the same tty. Memoized per capture, since the
+ *  per-pane cadence poll and `pty.listProcesses` share one TTL-cached table. */
+function getTtyOccupancy(rows: readonly ProcessTableRow[]): TtyOccupancy {
+  const cached = ttyOccupancyByCapture.get(rows)
+  if (cached) {
+    return cached
+  }
+  const processGroupsByTty = new Map<number, Set<number>>()
+  const stoppedTtys = new Set<number>()
+  for (const row of rows) {
+    if (row.pgid === undefined || row.tpgid === undefined || row.tpgid <= 0) {
+      continue
+    }
+    let groups = processGroupsByTty.get(row.tpgid)
+    if (!groups) {
+      groups = new Set<number>()
+      processGroupsByTty.set(row.tpgid, groups)
+    }
+    groups.add(row.pgid)
+    // `T` is a job-control stop (Ctrl-Z), `t` a tracing stop. Both are work the pane still holds.
+    if (row.stat.startsWith('T') || row.stat.startsWith('t')) {
+      stoppedTtys.add(row.tpgid)
+    }
+  }
+  const occupancy: TtyOccupancy = { processGroupsByTty, stoppedTtys }
+  ttyOccupancyByCapture.set(rows, occupancy)
+  return occupancy
 }
 
 export async function resolveAgentForegroundProcessesBatch(
@@ -93,6 +135,7 @@ export function resolveAgentForegroundProcessesFromIndex(
     }
   }
 
+  const occupancy = getTtyOccupancy(index.rows)
   return requests.map((request) => {
     const root = lookupProcessTableIndex(index, (value) => value.byPid.get(request.rootPid))
     if (!root) {
@@ -116,10 +159,20 @@ export function resolveAgentForegroundProcessesFromIndex(
         reason: 'no_controlling_tty'
       }
     }
-    // The only host-observable "nothing is running here" signal: the terminal's foreground process
-    // group is the shell's own. Any foreground command — recognized agent or not — moves tpgid off
-    // it, so a reader may treat `false` as "busy" and must never treat absence as "idle".
-    const shellIsForeground = root.tpgid === root.pgid
+    // The only host-observable "nothing is running here" signal, and it has to be read off the
+    // whole tty rather than off `tpgid === pgid`. A backgrounded `pnpm build &` and a Ctrl-Z'd
+    // editor both leave the shell owning the foreground group, byte-identical to an idle prompt;
+    // what separates them is a second process group attached to the pane's terminal. That is also
+    // exactly the blast radius of the stop this attests to — `forceKillPosixPtyProcessGroups`
+    // SIGKILLs every process group on the tty — so the evidence and the kill now measure the same
+    // thing. A reader may treat `false` as "busy" and must never treat absence as "idle".
+    const ttyProcessGroups = occupancy.processGroupsByTty.get(root.tpgid)
+    const shellOwnsEveryTtyProcessGroup =
+      root.tpgid === root.pgid &&
+      ttyProcessGroups !== undefined &&
+      ttyProcessGroups.size === 1 &&
+      ttyProcessGroups.has(root.pgid) &&
+      !occupancy.stoppedTtys.has(root.tpgid)
     const allCandidates = rowsByOwner.get(root.pid) ?? []
     const foregroundCandidates = allCandidates.filter((row) => row.pgid === root.tpgid)
     const fallbackProcess = request.fallbackProcess
@@ -131,7 +184,7 @@ export function resolveAgentForegroundProcessesFromIndex(
         )
       : foregroundCandidates
     if (wrapperFallback && candidates.length !== 1) {
-      return { available: true, processName: null, shellIsForeground }
+      return { available: true, processName: null, shellOwnsEveryTtyProcessGroup }
     }
     let bestCandidate: (ProcessTableRow & { depth: number }) | null = null
     let bestName: ReturnType<typeof recognizeAgentProcessFromCommandLine> = null
@@ -150,10 +203,10 @@ export function resolveAgentForegroundProcessesFromIndex(
       return {
         available: true,
         processName: resolveOuterWrapperForegroundProcess(bestName, bestCandidate, allCandidates),
-        shellIsForeground
+        shellOwnsEveryTtyProcessGroup
       }
     }
-    return { available: true, processName: null, shellIsForeground }
+    return { available: true, processName: null, shellOwnsEveryTtyProcessGroup }
   })
 }
 
@@ -166,8 +219,8 @@ export function toForegroundProcessEvidence(
         ...metadata,
         verdict: 'live',
         processName: result.processName,
-        ...(result.shellIsForeground !== undefined
-          ? { shellIsForeground: result.shellIsForeground }
+        ...(result.shellOwnsEveryTtyProcessGroup !== undefined
+          ? { shellOwnsEveryTtyProcessGroup: result.shellOwnsEveryTtyProcessGroup }
           : {})
       }
     : {

--- a/src/main/providers/pty-process-info.ts
+++ b/src/main/providers/pty-process-info.ts
@@ -18,4 +18,13 @@ export type PtyProcessInfo = {
   /** Optional host-side process evidence attached to an inventory seed. */
   foregroundProcessEvidence?: ForegroundProcessEvidence
   agentSessionOwners?: AgentSessionOwnerBinding[]
+  /** Age measured on the OWNING host's clock. Absent means the host did not measure it, which is
+   *  not the same as "new" or "old" — a reader that needs an age must defer instead of assuming. */
+  hostAgeMs?: number
+  /** True when the host spawned this PTY for an Orca pane, false for a bare host shell. Absent from
+   *  a host that never published it; absence is neither value. */
+  paneBound?: boolean
+  /** The client identity the OWNING host recorded as having asked it to create this PTY. Absent
+   *  whenever the host could not attest one, and absence must never be read as "unowned". */
+  ownerClientInstanceId?: string
 }

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -204,6 +204,12 @@ export type IPtyProvider = {
       keepHistory?: boolean
       deadlineMs?: number
       expectedIncarnationId?: PtyIncarnationId
+      /** Ask the execution host to refuse this stop unless it recorded this exact client identity
+       *  as the PTY's creator AND this connection still authenticates as it. Optional because a
+       *  host that predates it ignores the field, and because most stops are ordinary teardown of a
+       *  pane whose owner the host may never have attested (a revived PTY carries none). Set it
+       *  wherever the caller's authority to destroy comes from that attestation. */
+      expectedOwnerClientInstanceId?: string
     }
   ): Promise<void>
   sendSignal(id: string, signal: string): Promise<void>

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -225,15 +225,17 @@ export class SshPtyProvider implements IPtyProvider {
   }
 
   async shutdown(id: string, opts: Parameters<IPtyProvider['shutdown']>[1]): Promise<void> {
+    // Both fences are omitted rather than sent undefined: a host that predates either must see no
+    // key at all, and the owner fence in particular must never reach it as a falsy claim.
+    const { expectedIncarnationId, expectedOwnerClientInstanceId } = opts
     await this.mux.request(
       'pty.shutdown',
       {
         id: this.toRelayPtyId(id),
         immediate: opts.immediate ?? false,
         keepHistory: opts.keepHistory ?? false,
-        ...(opts.expectedIncarnationId === undefined
-          ? {}
-          : { expectedIncarnationId: opts.expectedIncarnationId })
+        ...(expectedIncarnationId === undefined ? {} : { expectedIncarnationId }),
+        ...(expectedOwnerClientInstanceId === undefined ? {} : { expectedOwnerClientInstanceId })
       },
       relayTimeoutOptions(opts.deadlineMs)
     )

--- a/src/main/providers/ssh-pty-reattach-absence-discrimination.test.ts
+++ b/src/main/providers/ssh-pty-reattach-absence-discrimination.test.ts
@@ -1,0 +1,75 @@
+// Three different refusals leave `reattachSshPtySessionForSpawn` carrying the same
+// `SSH_SESSION_EXPIRED` text, and only one of them observed the process. That text is therefore not
+// a verdict, and a caller that tests it with `.includes()` cannot tell "the host says this PTY is
+// gone" from "the PTY is fine, its source stream needs rebuilding".
+//
+// It matters because the callers that DO test it act destructively: `spawn-execute.ts` expires the
+// lease and deletes the in-memory ownership, which between them are the client's only record that a
+// remote process exists. Erase both for a live PTY and #9819's sweep finds a host-attested,
+// route-less, pane-bound shell on the next connect and SIGKILLs it.
+//
+// So this pins the discriminator the destructive branch keys on: the type, not the message.
+import { describe, expect, it, vi } from 'vitest'
+import { isSshPtyAbsentFromRelayError, SSH_SESSION_EXPIRED_ERROR } from './ssh-pty-errors'
+import { reattachSshPtySessionForSpawn } from './ssh-pty-session-reattach'
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+
+const CONNECTION = 'conn-1'
+const SESSION = 'pty-1'
+
+function reattachAgainst(attach: () => Promise<unknown>): Promise<unknown> {
+  return reattachSshPtySessionForSpawn({
+    mux: { request: vi.fn(attach) } as unknown as SshChannelMultiplexer,
+    connectionId: CONNECTION,
+    sessionId: SESSION,
+    options: { cols: 80, rows: 24 },
+    exitRaceTracker: {
+      begin: () => 1,
+      didMatchingExitArrive: () => false,
+      finish: () => {}
+    } as never,
+    acceptLivePty: () => {}
+  })
+}
+
+async function refusalFrom(attach: () => Promise<unknown>): Promise<Error> {
+  try {
+    await reattachAgainst(attach)
+  } catch (error) {
+    return error as Error
+  }
+  throw new Error('expected the reattach to be refused')
+}
+
+describe('an SSH reattach refusal says whether the host observed the PTY', () => {
+  it('marks a relay that answered "not found" as positive evidence of absence', async () => {
+    const error = await refusalFrom(async () => {
+      throw new Error(`PTY "${SESSION}" not found`)
+    })
+
+    expect(error.message).toContain(SSH_SESSION_EXPIRED_ERROR)
+    expect(isSshPtyAbsentFromRelayError(error)).toBe(true)
+  })
+
+  it('does not mark a restoreRequired refusal as absence, though it reads identically', async () => {
+    // The PTY attached. The relay answered about it. It is running. Only the source stream could
+    // not be resumed — see the `restoreRequired` carve-out in ssh-pty-errors.ts.
+    const error = await refusalFrom(async () => ({
+      incarnationId: '11111111-1111-4111-8111-111111111111',
+      sourceRecovery: { status: 'restoreRequired', reason: 'checkpoint_unavailable' }
+    }))
+
+    expect(error.message).toContain(SSH_SESSION_EXPIRED_ERROR)
+    expect(isSshPtyAbsentFromRelayError(error)).toBe(false)
+  })
+
+  it('does not mark an identity mismatch as absence either', async () => {
+    // The id names a LIVE PTY that belongs to a different pane.
+    const error = await refusalFrom(async () => {
+      throw new Error(`PTY "${SESSION}" not found (identity mismatch)`)
+    })
+
+    expect(error.message).toContain(SSH_SESSION_EXPIRED_ERROR)
+    expect(isSshPtyAbsentFromRelayError(error)).toBe(false)
+  })
+})

--- a/src/main/ssh/ssh-orphan-relay-pty-sweep.test.ts
+++ b/src/main/ssh/ssh-orphan-relay-pty-sweep.test.ts
@@ -26,7 +26,7 @@ const OBSERVATION = { authorityGeneration: 'gen-1', observationEpoch: 1, capture
 
 /** The host looked and saw its own shell owning the terminal: nothing is running in the pane. */
 function idleShell(): ForegroundProcessEvidence {
-  return { ...OBSERVATION, verdict: 'live', processName: null, shellIsForeground: true }
+  return { ...OBSERVATION, verdict: 'live', processName: null, shellOwnsEveryTtyProcessGroup: true }
 }
 
 function hostEntry(overrides: Partial<PtyProcessInfo> = {}): PtyProcessInfo {
@@ -88,6 +88,49 @@ describe('sweepOrphanedRelayPtys', () => {
       `ssh:${TARGET}@@pty-1`,
       expect.objectContaining({ immediate: true, expectedIncarnationId: 'inc-1' })
     )
+  })
+
+  it('asks the host to re-check ownership on the one call that cannot be undone', async () => {
+    // The stop is the only irreversible step in this flow, and until now the whole nine-condition
+    // rule was enforced only here, on the client that decided to make it. Naming the owner makes
+    // the host re-decide where the processes actually live.
+    const harness = createHarness([hostEntry()])
+
+    await run(harness)
+
+    expect(harness.shutdown).toHaveBeenCalledWith(
+      `ssh:${TARGET}@@pty-1`,
+      expect.objectContaining({ expectedOwnerClientInstanceId: OURS })
+    )
+  })
+
+  it('does not act on an observation that aged out between the listing and the plan', async () => {
+    // The listing answered inside the budget, but this pass then spent longer than the evidence is
+    // good for. Staleness has to degrade to "leave it running".
+    let clock = 1_000_000
+    const harness = createHarness([hostEntry()])
+    harness.provider.listProcesses = vi.fn().mockImplementation(async () => {
+      clock += 1
+      return [hostEntry()]
+    })
+
+    const pass = (maximumEvidenceAgeMs: number): Promise<void> =>
+      run(harness, {
+        now: () => clock,
+        maximumEvidenceAgeMs,
+        passBudgetMs: 60_000,
+        shouldContinue: () => {
+          clock += 20
+          return true
+        }
+      })
+
+    await pass(10)
+    expect(harness.shutdown).not.toHaveBeenCalled()
+
+    // Positive control: the same entry, the same elapsed time, a budget that covers it.
+    await pass(10_000)
+    expect(harness.shutdown).toHaveBeenCalledTimes(1)
   })
 
   it('leaves a PTY the caller just reattached alone', async () => {
@@ -185,7 +228,7 @@ describe('sweepOrphanedRelayPtys', () => {
           ...OBSERVATION,
           verdict: 'live',
           processName: 'claude',
-          shellIsForeground: false
+          shellOwnsEveryTtyProcessGroup: false
         }
       })
     ])

--- a/src/main/ssh/ssh-orphan-relay-pty-sweep.test.ts
+++ b/src/main/ssh/ssh-orphan-relay-pty-sweep.test.ts
@@ -1,0 +1,162 @@
+// #9819, the client half: what the sweep actually asks the store and the host, and what it does
+// with the answers. The rule itself is covered in ssh-relay-pty-ownership-proof.test.ts.
+import { describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type { IPtyProvider } from '../providers/types'
+import type { PtyProcessInfo } from '../providers/pty-process-info'
+import type { SshRemotePtyLease } from '../../shared/ssh-types'
+import { sweepOrphanedRelayPtys } from './ssh-orphan-relay-pty-sweep'
+import { RELAY_PTY_SWEEP_MIN_AGE_MS } from '../../shared/ssh-relay-pty-ownership-proof'
+
+const TARGET = 'target-1'
+const OURS = 'client-instance-ours'
+
+function hostEntry(overrides: Partial<PtyProcessInfo> = {}): PtyProcessInfo {
+  return {
+    id: `ssh:${TARGET}@@pty-1`,
+    incarnationId: 'inc-1',
+    cwd: '/home/user',
+    title: 'zsh',
+    ownerClientInstanceId: OURS,
+    hostAgeMs: RELAY_PTY_SWEEP_MIN_AGE_MS * 2,
+    paneBound: true,
+    ...overrides
+  }
+}
+
+function createHarness(
+  processes: PtyProcessInfo[],
+  leases: SshRemotePtyLease[] = []
+): { provider: IPtyProvider; store: Store; shutdown: ReturnType<typeof vi.fn> } {
+  const shutdown = vi.fn().mockResolvedValue(undefined)
+  const provider = {
+    listProcesses: vi.fn().mockResolvedValue(processes),
+    shutdown
+  } as unknown as IPtyProvider
+  const store = {
+    getSshRemotePtyLeases: vi.fn().mockReturnValue(leases)
+  } as unknown as Store
+  return { provider, store, shutdown }
+}
+
+function run(
+  harness: ReturnType<typeof createHarness>,
+  overrides: Partial<Parameters<typeof sweepOrphanedRelayPtys>[0]> = {}
+): Promise<void> {
+  return sweepOrphanedRelayPtys({
+    targetId: TARGET,
+    store: harness.store,
+    provider: harness.provider,
+    clientInstanceId: OURS,
+    isSessionOwner: true,
+    routedPtyIds: [],
+    shouldContinue: () => true,
+    ...overrides
+  })
+}
+
+function lease(ptyId: string, state: SshRemotePtyLease['state']): SshRemotePtyLease {
+  return { ptyId, state } as SshRemotePtyLease
+}
+
+describe('sweepOrphanedRelayPtys', () => {
+  it('stops an attested orphan, fenced on the incarnation the same listing published', async () => {
+    const harness = createHarness([hostEntry()])
+
+    await run(harness)
+
+    expect(harness.shutdown).toHaveBeenCalledWith(`ssh:${TARGET}@@pty-1`, {
+      immediate: true,
+      expectedIncarnationId: 'inc-1'
+    })
+  })
+
+  it('leaves a PTY the caller just reattached alone', async () => {
+    const harness = createHarness([hostEntry()])
+
+    await run(harness, { routedPtyIds: ['pty-1'] })
+
+    expect(harness.shutdown).not.toHaveBeenCalled()
+  })
+
+  it.each([['attached'], ['detached']] as const)(
+    'leaves a PTY holding a live %s lease alone',
+    async (state) => {
+      const harness = createHarness([hostEntry()], [lease('pty-1', state)])
+
+      await run(harness)
+
+      expect(harness.shutdown).not.toHaveBeenCalled()
+    }
+  )
+
+  it('leaves a PTY with an undelivered stop to the replay pass', async () => {
+    // The kill-intent journal owns those: it re-fences and retries them, and a second stop issued
+    // from here would race that decision with weaker evidence.
+    const tombstoned = {
+      ...lease('pty-1', 'terminated'),
+      pendingKill: { requestedAt: 1, incarnationId: 'inc-1', attempts: 0 }
+    } as SshRemotePtyLease
+    const harness = createHarness([hostEntry()], [tombstoned])
+
+    await run(harness)
+
+    expect(harness.shutdown).not.toHaveBeenCalled()
+  })
+
+  it('does sweep a PTY whose lease this client already tombstoned without an order', async () => {
+    const harness = createHarness([hostEntry()], [lease('pty-1', 'terminated')])
+
+    await run(harness)
+
+    expect(harness.shutdown).toHaveBeenCalledTimes(1)
+  })
+
+  it('asks the host nothing when this connection is not the session owner', async () => {
+    const harness = createHarness([hostEntry()])
+
+    await run(harness, { isSessionOwner: false })
+
+    expect(harness.provider.listProcesses).not.toHaveBeenCalled()
+    expect(harness.shutdown).not.toHaveBeenCalled()
+  })
+
+  it('stops nothing against a host that publishes no attestation', async () => {
+    const legacy = hostEntry()
+    delete legacy.ownerClientInstanceId
+    delete legacy.hostAgeMs
+    delete legacy.paneBound
+    const harness = createHarness([legacy])
+
+    await run(harness)
+
+    expect(harness.shutdown).not.toHaveBeenCalled()
+  })
+
+  it('swallows a failed listing rather than failing the connect it runs on', async () => {
+    const harness = createHarness([])
+    vi.mocked(harness.provider.listProcesses).mockRejectedValue(new Error('relay went away'))
+
+    await expect(run(harness)).resolves.toBeUndefined()
+  })
+
+  it('swallows a failed stop and leaves the order to the next connect', async () => {
+    const harness = createHarness([hostEntry()])
+    harness.shutdown.mockRejectedValue(new Error('connection lost'))
+
+    await expect(run(harness)).resolves.toBeUndefined()
+  })
+
+  it('abandons the pass when the attempt is superseded mid-flight', async () => {
+    const harness = createHarness([hostEntry()])
+    let alive = true
+    vi.mocked(harness.provider.listProcesses).mockImplementation(async () => {
+      alive = false
+      return [hostEntry()]
+    })
+
+    await run(harness, { shouldContinue: () => alive })
+
+    expect(harness.shutdown).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ssh/ssh-orphan-relay-pty-sweep.test.ts
+++ b/src/main/ssh/ssh-orphan-relay-pty-sweep.test.ts
@@ -5,11 +5,29 @@ import type { Store } from '../persistence'
 import type { IPtyProvider } from '../providers/types'
 import type { PtyProcessInfo } from '../providers/pty-process-info'
 import type { SshRemotePtyLease } from '../../shared/ssh-types'
-import { sweepOrphanedRelayPtys } from './ssh-orphan-relay-pty-sweep'
+import type { ForegroundProcessEvidence } from '../../shared/foreground-process-evidence'
+import type { PersistedState } from '../../shared/persisted-state-types'
+import {
+  upsertSshRemotePtyLease,
+  type SshPtyLeaseOperations
+} from '../persistence/leasing-ssh-ptys/ssh-pty-lease-operations'
+import {
+  RELAY_PTY_SWEEP_PASS_BUDGET_MS,
+  sweepOrphanedRelayPtys
+} from './ssh-orphan-relay-pty-sweep'
 import { RELAY_PTY_SWEEP_MIN_AGE_MS } from '../../shared/ssh-relay-pty-ownership-proof'
 
 const TARGET = 'target-1'
 const OURS = 'client-instance-ours'
+// A stable pane id is a UUID; anything else is stripped before supersede can match on it.
+const LEAF = '11111111-2222-4333-8444-555555555555'
+
+const OBSERVATION = { authorityGeneration: 'gen-1', observationEpoch: 1, capturedAgeMs: 0 }
+
+/** The host looked and saw its own shell owning the terminal: nothing is running in the pane. */
+function idleShell(): ForegroundProcessEvidence {
+  return { ...OBSERVATION, verdict: 'live', processName: null, shellIsForeground: true }
+}
 
 function hostEntry(overrides: Partial<PtyProcessInfo> = {}): PtyProcessInfo {
   return {
@@ -20,6 +38,7 @@ function hostEntry(overrides: Partial<PtyProcessInfo> = {}): PtyProcessInfo {
     ownerClientInstanceId: OURS,
     hostAgeMs: RELAY_PTY_SWEEP_MIN_AGE_MS * 2,
     paneBound: true,
+    foregroundProcessEvidence: idleShell(),
     ...overrides
   }
 }
@@ -65,10 +84,10 @@ describe('sweepOrphanedRelayPtys', () => {
 
     await run(harness)
 
-    expect(harness.shutdown).toHaveBeenCalledWith(`ssh:${TARGET}@@pty-1`, {
-      immediate: true,
-      expectedIncarnationId: 'inc-1'
-    })
+    expect(harness.shutdown).toHaveBeenCalledWith(
+      `ssh:${TARGET}@@pty-1`,
+      expect.objectContaining({ immediate: true, expectedIncarnationId: 'inc-1' })
+    )
   })
 
   it('leaves a PTY the caller just reattached alone', async () => {
@@ -102,6 +121,92 @@ describe('sweepOrphanedRelayPtys', () => {
     await run(harness)
 
     expect(harness.shutdown).not.toHaveBeenCalled()
+  })
+
+  it('leaves a PTY whose lease this client expired alone', async () => {
+    // The reversal this guards: supersedeSiblingLeasesForPane, dropStalePty and the missing-surface
+    // refusal all write `expired` precisely BECAUSE they will not stop the remote process.
+    const harness = createHarness([hostEntry()], [lease('pty-1', 'expired')])
+
+    await run(harness)
+
+    expect(harness.shutdown).not.toHaveBeenCalled()
+  })
+
+  it('leaves alone a lease the real supersede path expired when a pane re-leased', async () => {
+    // Drives the actual persistence operation rather than asserting the state by hand, so this
+    // stays true only while supersede really does leave the predecessor's process running.
+    const state: PersistedState = {
+      sshRemotePtyLeases: [
+        {
+          targetId: TARGET,
+          ptyId: 'pty-1',
+          state: 'attached',
+          worktreeId: 'wt-1',
+          leafId: LEAF,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    } as unknown as PersistedState
+    const operations: SshPtyLeaseOperations = {
+      state,
+      toStoredPtyId: (_targetId, ptyId) => ptyId,
+      toComparablePtyId: (_targetId, ptyId) => ptyId,
+      clearBindingsForTarget: () => {},
+      clearBindingsForLeases: () => false,
+      flush: () => {},
+      flushDurableStateOrThrowAsync: async () => {}
+    }
+    // The same pane re-leases under a new relay id; pty-1 is expired, never terminated.
+    upsertSshRemotePtyLease(operations, {
+      targetId: TARGET,
+      ptyId: 'pty-2',
+      state: 'attached',
+      worktreeId: 'wt-1',
+      leafId: LEAF
+    })
+    expect(state.sshRemotePtyLeases?.find((entry) => entry.ptyId === 'pty-1')?.state).toBe(
+      'expired'
+    )
+    const harness = createHarness([hostEntry()], state.sshRemotePtyLeases ?? [])
+
+    await run(harness)
+
+    expect(harness.shutdown).not.toHaveBeenCalled()
+  })
+
+  it('forwards the host foreground observation, so a busy pane is never swept', async () => {
+    // A `claude` the user launched by hand: Orca registered no agent session, so the entry carries
+    // no agentSessionOwners and only the host's own observation can save it.
+    const harness = createHarness([
+      hostEntry({
+        foregroundProcessEvidence: {
+          ...OBSERVATION,
+          verdict: 'live',
+          processName: 'claude',
+          shellIsForeground: false
+        }
+      })
+    ])
+
+    await run(harness)
+
+    expect(harness.shutdown).not.toHaveBeenCalled()
+  })
+
+  it('bounds the listing and every stop with one connect budget', async () => {
+    const harness = createHarness([hostEntry()])
+    const start = 1_000_000
+
+    await run(harness, { now: () => start })
+
+    const deadline = vi.mocked(harness.provider.listProcesses).mock.calls[0]?.[0]?.deadlineMs
+    expect(deadline).toBe(start + RELAY_PTY_SWEEP_PASS_BUDGET_MS)
+    expect(harness.shutdown).toHaveBeenCalledWith(
+      `ssh:${TARGET}@@pty-1`,
+      expect.objectContaining({ deadlineMs: deadline })
+    )
   })
 
   it('does sweep a PTY whose lease this client already tombstoned without an order', async () => {

--- a/src/main/ssh/ssh-orphan-relay-pty-sweep.ts
+++ b/src/main/ssh/ssh-orphan-relay-pty-sweep.ts
@@ -20,21 +20,37 @@ export type SshOrphanRelayPtySweepArgs = {
   shouldContinue: () => boolean
   now?: () => number
   minimumHostAgeMs?: number
+  /** Absolute budget for the whole pass, in ms from its start. */
+  passBudgetMs?: number
 }
 
-/** Every relay PTY id this client still has a route to. Read across all lease states except the
- *  tombstones, plus the undelivered stops, which belong to the replay pass and not to this one. */
-function routedIds(args: SshOrphanRelayPtySweepArgs): Set<string> {
+/** The two client-side claims the plan needs, read in one pass over the leases.
+ *
+ *  `routed` is every relay PTY id this client still has a route to: a live lease, an id this
+ *  connect reattached, or a stop it recorded and has not delivered.
+ *
+ *  `expired` is separate on purpose. `expired` is written by four paths — a pane re-leasing under a
+ *  new relay id, a reattach that failed on the transport, a pane surface missing from the layout,
+ *  and a retired reattach — and every one of them deliberately leaves the remote process running.
+ *  Folding it into `routed` would work, but it would also lose the reason in the skip log, and this
+ *  is the distinction the sweep most needs to be able to explain. */
+function clientClaims(args: SshOrphanRelayPtySweepArgs): {
+  routed: Set<string>
+  expired: Set<string>
+} {
   const routed = new Set<string>(args.routedPtyIds)
+  const expired = new Set<string>()
   for (const lease of args.store.getSshRemotePtyLeases(args.targetId)) {
-    if (lease.state !== 'terminated' && lease.state !== 'expired') {
+    if (lease.state === 'expired') {
+      expired.add(lease.ptyId)
+    } else if (lease.state !== 'terminated') {
       routed.add(lease.ptyId)
     }
     if (lease.pendingKill) {
       routed.add(lease.ptyId)
     }
   }
-  return routed
+  return { routed, expired }
 }
 
 function toEvidence(
@@ -49,9 +65,19 @@ function toEvidence(
       : {}),
     ...(typeof process.hostAgeMs === 'number' ? { hostAgeMs: process.hostAgeMs } : {}),
     ...(typeof process.paneBound === 'boolean' ? { paneBound: process.paneBound } : {}),
-    ...(process.agentSessionOwners ? { agentSessionOwners: process.agentSessionOwners } : {})
+    ...(process.agentSessionOwners ? { agentSessionOwners: process.agentSessionOwners } : {}),
+    ...(process.foregroundProcessEvidence
+      ? { foregroundProcessEvidence: process.foregroundProcessEvidence }
+      : {})
   }
 }
+
+/** One budget for the whole pass, because this is opportunistic cleanup bolted onto the most
+ *  latency-sensitive and most failure-prone path in the app (#14830, #17830). Without it the
+ *  listing and up to eight stops inherit the mux default and connect waits on all of them.
+ *  Overrunning it yields an empty pass — the same outcome as finding nothing, never a failed
+ *  connect. */
+export const RELAY_PTY_SWEEP_PASS_BUDGET_MS = 5_000
 
 /** Stops the relay PTYs this client can prove it created and has since lost every route to.
  *
@@ -65,17 +91,21 @@ export async function sweepOrphanedRelayPtys(args: SshOrphanRelayPtySweepArgs): 
   if (!args.isSessionOwner || !args.clientInstanceId || !args.shouldContinue()) {
     return
   }
+  const now = args.now ?? Date.now
+  const deadlineMs = now() + (args.passBudgetMs ?? RELAY_PTY_SWEEP_PASS_BUDGET_MS)
   try {
-    const processes = await args.provider.listProcesses()
-    if (!args.shouldContinue()) {
+    const processes = await args.provider.listProcesses({ deadlineMs })
+    if (!args.shouldContinue() || now() >= deadlineMs) {
       return
     }
+    const claims = clientClaims(args)
     const plan = planRelayPtySweep(
       processes.map((process) => toEvidence(args.targetId, process)),
       {
         clientInstanceId: args.clientInstanceId,
         isSessionOwner: args.isSessionOwner,
-        routedPtyIds: routedIds(args),
+        routedPtyIds: claims.routed,
+        expiredLeasePtyIds: claims.expired,
         minimumHostAgeMs: args.minimumHostAgeMs ?? RELAY_PTY_SWEEP_MIN_AGE_MS
       }
     )
@@ -92,6 +122,7 @@ export async function sweepOrphanedRelayPtys(args: SshOrphanRelayPtySweepArgs): 
           // ids between the read and this call refuses the stop instead of hitting a stranger.
           await args.provider.shutdown(toAppSshPtyId(args.targetId, target.ptyId), {
             immediate: true,
+            deadlineMs,
             expectedIncarnationId: target.incarnationId
           })
           console.log(

--- a/src/main/ssh/ssh-orphan-relay-pty-sweep.ts
+++ b/src/main/ssh/ssh-orphan-relay-pty-sweep.ts
@@ -3,6 +3,7 @@ import type { IPtyProvider } from '../providers/types'
 import { toAppSshPtyId, toRelaySshPtyId } from '../providers/ssh-pty-id'
 import {
   planRelayPtySweep,
+  RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS,
   RELAY_PTY_SWEEP_MIN_AGE_MS,
   type RelayPtyOwnershipEvidence
 } from '../../shared/ssh-relay-pty-ownership-proof'
@@ -22,6 +23,7 @@ export type SshOrphanRelayPtySweepArgs = {
   minimumHostAgeMs?: number
   /** Absolute budget for the whole pass, in ms from its start. */
   passBudgetMs?: number
+  maximumEvidenceAgeMs?: number
 }
 
 /** The two client-side claims the plan needs, read in one pass over the leases.
@@ -29,9 +31,15 @@ export type SshOrphanRelayPtySweepArgs = {
  *  `routed` is every relay PTY id this client still has a route to: a live lease, an id this
  *  connect reattached, or a stop it recorded and has not delivered.
  *
- *  `expired` is separate on purpose. `expired` is written by four paths — a pane re-leasing under a
- *  new relay id, a reattach that failed on the transport, a pane surface missing from the layout,
- *  and a retired reattach — and every one of them deliberately leaves the remote process running.
+ *  `expired` is separate on purpose. It is written by four paths, and every one of them
+ *  deliberately leaves the remote process running: a pane re-leasing under a new relay id, a pane
+ *  surface missing from the layout, a retired reattach, and a reattach the HOST answered "not
+ *  found" for. Only the second of those is reached with the process provably alive — the layout
+ *  refusal runs after `pty.attach` already succeeded (`restoreReattachedPtyRuntime`), which is
+ *  precisely why its own comment reads "topology absence alone is not authority to kill a
+ *  process". A reattach that failed on the transport writes nothing at all: it early-returns as
+ *  `reattachAttemptsExhausted` and the lease stays `attached`, hence routed.
+ *
  *  Folding it into `routed` would work, but it would also lose the reason in the skip log, and this
  *  is the distinction the sweep most needs to be able to explain. */
 function clientClaims(args: SshOrphanRelayPtySweepArgs): {
@@ -95,6 +103,9 @@ export async function sweepOrphanedRelayPtys(args: SshOrphanRelayPtySweepArgs): 
   const deadlineMs = now() + (args.passBudgetMs ?? RELAY_PTY_SWEEP_PASS_BUDGET_MS)
   try {
     const processes = await args.provider.listProcesses({ deadlineMs })
+    // The instant the host's observations reached this client. Every later step — reading the
+    // leases, planning, issuing the stops — ages them, and the plan has to see that age.
+    const listedAtMs = now()
     if (!args.shouldContinue() || now() >= deadlineMs) {
       return
     }
@@ -106,7 +117,9 @@ export async function sweepOrphanedRelayPtys(args: SshOrphanRelayPtySweepArgs): 
         isSessionOwner: args.isSessionOwner,
         routedPtyIds: claims.routed,
         expiredLeasePtyIds: claims.expired,
-        minimumHostAgeMs: args.minimumHostAgeMs ?? RELAY_PTY_SWEEP_MIN_AGE_MS
+        minimumHostAgeMs: args.minimumHostAgeMs ?? RELAY_PTY_SWEEP_MIN_AGE_MS,
+        evidenceAgeSinceListingMs: Math.max(0, now() - listedAtMs),
+        maximumEvidenceAgeMs: args.maximumEvidenceAgeMs ?? RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS
       }
     )
     if (plan.sweep.length === 0) {
@@ -118,12 +131,15 @@ export async function sweepOrphanedRelayPtys(args: SshOrphanRelayPtySweepArgs): 
           return
         }
         try {
-          // Fenced on the incarnation the same listing published, so a relay that renumbered its
-          // ids between the read and this call refuses the stop instead of hitting a stranger.
+          // Two fences, both enforced by the host that owns the process. The incarnation stops a
+          // relay that renumbered its ids between the read and this call from hitting a stranger;
+          // the owner id makes the host re-check the ownership rule itself, so the one irreversible
+          // call in this flow is not authorized by the client alone.
           await args.provider.shutdown(toAppSshPtyId(args.targetId, target.ptyId), {
             immediate: true,
             deadlineMs,
-            expectedIncarnationId: target.incarnationId
+            expectedIncarnationId: target.incarnationId,
+            expectedOwnerClientInstanceId: args.clientInstanceId
           })
           console.log(
             `[ssh-orphan-sweep] stopped orphaned relay PTY ${args.targetId}/${target.ptyId}`

--- a/src/main/ssh/ssh-orphan-relay-pty-sweep.ts
+++ b/src/main/ssh/ssh-orphan-relay-pty-sweep.ts
@@ -1,0 +1,117 @@
+import type { Store } from '../persistence'
+import type { IPtyProvider } from '../providers/types'
+import { toAppSshPtyId, toRelaySshPtyId } from '../providers/ssh-pty-id'
+import {
+  planRelayPtySweep,
+  RELAY_PTY_SWEEP_MIN_AGE_MS,
+  type RelayPtyOwnershipEvidence
+} from '../../shared/ssh-relay-pty-ownership-proof'
+
+export type SshOrphanRelayPtySweepArgs = {
+  targetId: string
+  store: Store
+  provider: IPtyProvider
+  /** This client's persisted consumer identity for the target. */
+  clientInstanceId: string
+  /** True only when the relay granted this connection the negotiated `session-owner` role. */
+  isSessionOwner: boolean
+  /** Relay PTY ids this connect just reattached, plus any the caller otherwise knows are live. */
+  routedPtyIds: Iterable<string>
+  shouldContinue: () => boolean
+  now?: () => number
+  minimumHostAgeMs?: number
+}
+
+/** Every relay PTY id this client still has a route to. Read across all lease states except the
+ *  tombstones, plus the undelivered stops, which belong to the replay pass and not to this one. */
+function routedIds(args: SshOrphanRelayPtySweepArgs): Set<string> {
+  const routed = new Set<string>(args.routedPtyIds)
+  for (const lease of args.store.getSshRemotePtyLeases(args.targetId)) {
+    if (lease.state !== 'terminated' && lease.state !== 'expired') {
+      routed.add(lease.ptyId)
+    }
+    if (lease.pendingKill) {
+      routed.add(lease.ptyId)
+    }
+  }
+  return routed
+}
+
+function toEvidence(
+  targetId: string,
+  process: Awaited<ReturnType<IPtyProvider['listProcesses']>>[number]
+): RelayPtyOwnershipEvidence {
+  return {
+    ptyId: toRelaySshPtyId(targetId, process.id),
+    ...(process.incarnationId ? { incarnationId: process.incarnationId } : {}),
+    ...(process.ownerClientInstanceId
+      ? { ownerClientInstanceId: process.ownerClientInstanceId }
+      : {}),
+    ...(typeof process.hostAgeMs === 'number' ? { hostAgeMs: process.hostAgeMs } : {}),
+    ...(typeof process.paneBound === 'boolean' ? { paneBound: process.paneBound } : {}),
+    ...(process.agentSessionOwners ? { agentSessionOwners: process.agentSessionOwners } : {})
+  }
+}
+
+/** Stops the relay PTYs this client can prove it created and has since lost every route to.
+ *
+ *  Runs after reattach, so a PTY this connect reclaimed is already routed and can never be a
+ *  candidate. Best-effort and never throws: it is opportunistic cleanup on the connect path, and a
+ *  failed connection is a much worse outcome than a slot left leaked for another session.
+ *
+ *  Costs one `pty.listProcesses` per connect. That is the price of reconciling at all — there is no
+ *  cheaper question than asking the authoritative host what it is holding. */
+export async function sweepOrphanedRelayPtys(args: SshOrphanRelayPtySweepArgs): Promise<void> {
+  if (!args.isSessionOwner || !args.clientInstanceId || !args.shouldContinue()) {
+    return
+  }
+  try {
+    const processes = await args.provider.listProcesses()
+    if (!args.shouldContinue()) {
+      return
+    }
+    const plan = planRelayPtySweep(
+      processes.map((process) => toEvidence(args.targetId, process)),
+      {
+        clientInstanceId: args.clientInstanceId,
+        isSessionOwner: args.isSessionOwner,
+        routedPtyIds: routedIds(args),
+        minimumHostAgeMs: args.minimumHostAgeMs ?? RELAY_PTY_SWEEP_MIN_AGE_MS
+      }
+    )
+    if (plan.sweep.length === 0) {
+      return
+    }
+    await Promise.all(
+      plan.sweep.map(async (target) => {
+        if (!args.shouldContinue()) {
+          return
+        }
+        try {
+          // Fenced on the incarnation the same listing published, so a relay that renumbered its
+          // ids between the read and this call refuses the stop instead of hitting a stranger.
+          await args.provider.shutdown(toAppSshPtyId(args.targetId, target.ptyId), {
+            immediate: true,
+            expectedIncarnationId: target.incarnationId
+          })
+          console.log(
+            `[ssh-orphan-sweep] stopped orphaned relay PTY ${args.targetId}/${target.ptyId}`
+          )
+        } catch (err) {
+          // Unverifiable, not failed: the next connect re-reads the inventory and decides again.
+          console.warn(
+            `[ssh-orphan-sweep] stop for ${args.targetId}/${target.ptyId} is unverifiable: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          )
+        }
+      })
+    )
+  } catch (err) {
+    console.warn(
+      `[ssh-orphan-sweep] pass on ${args.targetId} stopped early: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+  }
+}

--- a/src/main/ssh/ssh-orphan-sweep-pane-state-verdicts.test.ts
+++ b/src/main/ssh/ssh-orphan-sweep-pane-state-verdicts.test.ts
@@ -1,0 +1,238 @@
+// The one test that spans both halves of the sweep. Every other test in this feature asserts on a
+// hand-written `ForegroundProcessEvidence` literal, which is exactly how a foreground-only idle
+// predicate survived review: the literals said `shellIsForeground: true` for an idle shell because
+// that is what the author believed, and nothing ever produced one from a real process table.
+//
+// So this runs the REAL publisher (`resolveAgentForegroundProcessesBatch` ->
+// `toForegroundProcessEvidence`, what `pty.listProcesses` calls) against the REAL client reader
+// (`planRelayPtySweep`), over `ps` output captured verbatim from a Linux container driving a real
+// `bash -i` on a real pty. The fixtures below are transcripts, not constructions.
+//
+// Read the shell's own row in each fixture. In `background` and `ctrlz` it is
+// `pgid == tpgid`, `Ss+` — byte-identical to `idle`. That is the defect: a foreground-only
+// predicate cannot see a job the user backgrounded or suspended, and the stop it authorizes
+// SIGKILLs every process group on the tty.
+import { describe, expect, it } from 'vitest'
+import {
+  resolveAgentForegroundProcessesBatch,
+  toForegroundProcessEvidence
+} from '../providers/agent-foreground-process-batch'
+import { parseStrictProcessTableRows } from '../../shared/process-table-snapshot'
+import {
+  planRelayPtySweep,
+  RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS,
+  RELAY_PTY_SWEEP_MIN_AGE_MS,
+  type RelayPtySweepContext
+} from '../../shared/ssh-relay-pty-ownership-proof'
+
+const OURS = 'client-instance-ours'
+
+/** `ps -axo pid=,ppid=,pgid=,tpgid=,stat=,command=` on debian:bookworm-slim, one capture per pane
+ *  state, each with a `bash -i` on a pty forked by the harness. */
+const CAPTURES = {
+  /** Nothing running. The only sweepable state. */
+  idle: {
+    rootPid: 3150,
+    table: [
+      '    1     0     1    -1 Ss   python3 /work/.ptycap.py',
+      ' 3150     1  3150  3150 Ss+  bash -i',
+      ' 3151     1     1    -1 R    ps -axo pid=,ppid=,pgid=,tpgid=,stat=,command='
+    ]
+  },
+  /** `sleep 300` in the foreground. The shell's tpgid moved off its own pgid. */
+  foreground: {
+    rootPid: 3155,
+    table: [
+      '    1     0     1    -1 Ss   python3 /work/.ptycap.py',
+      ' 3155     1  3155  3156 Ss   bash -i',
+      ' 3156  3155  3156  3156 S+   sleep 300',
+      ' 3157     1     1    -1 R    ps -axo pid=,ppid=,pgid=,tpgid=,stat=,command='
+    ]
+  },
+  /** `sleep 300 &`. The shell reads IDENTICALLY to `idle`; only the job's own row differs. */
+  background: {
+    rootPid: 3152,
+    table: [
+      '    1     0     1    -1 Ss   python3 /work/.ptycap.py',
+      ' 3152     1  3152  3152 Ss+  bash -i',
+      ' 3153  3152  3153  3152 S    sleep 300',
+      ' 3154     1     1    -1 R    ps -axo pid=,ppid=,pgid=,tpgid=,stat=,command='
+    ]
+  },
+  /** `sleep 300` then Ctrl-Z. The shell again reads IDENTICALLY to `idle`. */
+  ctrlz: {
+    rootPid: 3158,
+    table: [
+      '    1     0     1    -1 Ss   python3 /work/.ptycap.py',
+      ' 3158     1  3158  3158 Ss+  bash -i',
+      ' 3159  3158  3159  3158 T    sleep 300',
+      ' 3160     1     1    -1 R    ps -axo pid=,ppid=,pgid=,tpgid=,stat=,command='
+    ]
+  }
+} as const
+
+function context(overrides: Partial<RelayPtySweepContext> = {}): RelayPtySweepContext {
+  return {
+    clientInstanceId: OURS,
+    isSessionOwner: true,
+    routedPtyIds: new Set<string>(),
+    expiredLeasePtyIds: new Set<string>(),
+    minimumHostAgeMs: RELAY_PTY_SWEEP_MIN_AGE_MS,
+    evidenceAgeSinceListingMs: 0,
+    maximumEvidenceAgeMs: RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS,
+    ...overrides
+  }
+}
+
+/** Everything the host does between reading `ps` and putting a record on the wire. */
+async function publish(
+  capture: { rootPid: number; table: readonly string[] },
+  capturedAgeMs = 0
+): Promise<ReturnType<typeof toForegroundProcessEvidence>> {
+  const rows = parseStrictProcessTableRows(capture.table.join('\n'))
+  const [result] = await resolveAgentForegroundProcessesBatch(
+    [{ rootPid: capture.rootPid, fallbackProcess: 'bash' }],
+    { rows }
+  )
+  return toForegroundProcessEvidence(result, {
+    authorityGeneration: 'relay-generation-1',
+    observationEpoch: 1,
+    capturedAgeMs
+  })
+}
+
+/** Everything the client does with that record. Returns the plan for one orphan entry. */
+async function planFor(
+  capture: { rootPid: number; table: readonly string[] },
+  overrides: { capturedAgeMs?: number; context?: Partial<RelayPtySweepContext> } = {}
+): Promise<ReturnType<typeof planRelayPtySweep>> {
+  return planRelayPtySweep(
+    [
+      {
+        ptyId: 'pty-1',
+        incarnationId: 'inc-1',
+        ownerClientInstanceId: OURS,
+        hostAgeMs: RELAY_PTY_SWEEP_MIN_AGE_MS * 2,
+        paneBound: true,
+        foregroundProcessEvidence: await publish(capture, overrides.capturedAgeMs)
+      }
+    ],
+    context(overrides.context)
+  )
+}
+
+function skipReason(plan: ReturnType<typeof planRelayPtySweep>): string | undefined {
+  return plan.skipped.find((entry) => entry.ptyId === 'pty-1')?.reason
+}
+
+describe('what the host publishes about a pane, read by the sweep', () => {
+  it('records that a backgrounded and a suspended shell are indistinguishable at tpgid/pgid', () => {
+    // The premise of the whole file. If this ever fails, the fixtures drifted and every verdict
+    // below is testing something other than the defect. Pids differ between captures, so the
+    // comparison is of the shell row's shape: who its parent is, whether it leads its own process
+    // group, whether that group owns the terminal, and its state flags.
+    const shellShape = (capture: { rootPid: number; table: readonly string[] }): string => {
+      const row = parseStrictProcessTableRows(capture.table.join('\n')).find(
+        (candidate) => candidate.pid === capture.rootPid
+      )!
+      return [
+        `ppid=${row.ppid}`,
+        `leadsOwnGroup=${row.pgid === row.pid}`,
+        `ownsTerminal=${row.tpgid === row.pgid}`,
+        `stat=${row.stat}`
+      ].join(' ')
+    }
+
+    expect(shellShape(CAPTURES.idle)).toBe('ppid=1 leadsOwnGroup=true ownsTerminal=true stat=Ss+')
+    expect(shellShape(CAPTURES.background)).toBe(shellShape(CAPTURES.idle))
+    expect(shellShape(CAPTURES.ctrlz)).toBe(shellShape(CAPTURES.idle))
+    expect(shellShape(CAPTURES.foreground)).not.toBe(shellShape(CAPTURES.idle))
+  })
+
+  it('sweeps an idle shell', async () => {
+    const evidence = await publish(CAPTURES.idle)
+    expect(evidence).toMatchObject({
+      verdict: 'live',
+      processName: null,
+      shellOwnsEveryTtyProcessGroup: true
+    })
+
+    const plan = await planFor(CAPTURES.idle)
+    expect(plan.sweep).toEqual([{ ptyId: 'pty-1', incarnationId: 'inc-1' }])
+  })
+
+  it('never sweeps a pane running a foreground job', async () => {
+    const evidence = await publish(CAPTURES.foreground)
+    expect(evidence).toMatchObject({ shellOwnsEveryTtyProcessGroup: false })
+
+    const plan = await planFor(CAPTURES.foreground)
+    expect(plan.sweep).toEqual([])
+    expect(skipReason(plan)).toBe('host does not attest an idle shell')
+  })
+
+  it('never sweeps a pane holding a backgrounded job', async () => {
+    // `sleep 300 &`, i.e. `pnpm build &` or `npm run dev &`. The shell handed the terminal back,
+    // so the pane looks idle; the job is alive in its own process group on the same tty and a
+    // stop would SIGKILL it.
+    const evidence = await publish(CAPTURES.background)
+    expect(evidence).toMatchObject({ shellOwnsEveryTtyProcessGroup: false })
+
+    const plan = await planFor(CAPTURES.background)
+    expect(plan.sweep).toEqual([])
+    expect(skipReason(plan)).toBe('host does not attest an idle shell')
+  })
+
+  it('never sweeps a pane holding a Ctrl-Z suspended job', async () => {
+    const evidence = await publish(CAPTURES.ctrlz)
+    expect(evidence).toMatchObject({ shellOwnsEveryTtyProcessGroup: false })
+
+    const plan = await planFor(CAPTURES.ctrlz)
+    expect(plan.sweep).toEqual([])
+    expect(skipReason(plan)).toBe('host does not attest an idle shell')
+  })
+
+  it('refuses an observation older than the pass it would authorize', async () => {
+    // Same idle capture that sweeps above; only its age differs. Staleness degrades to "leave it
+    // running", never to "stop it".
+    const stale = await planFor(CAPTURES.idle, {
+      capturedAgeMs: RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS + 1
+    })
+    expect(stale.sweep).toEqual([])
+    expect(skipReason(stale)).toBe('host foreground observation is too old to authorize a stop')
+
+    // And the client's own share of the age counts: a host stamp inside the budget still ages out
+    // while this pass reads leases and plans.
+    const agedOnTheClient = await planFor(CAPTURES.idle, {
+      capturedAgeMs: RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS,
+      context: { evidenceAgeSinceListingMs: 1 }
+    })
+    expect(agedOnTheClient.sweep).toEqual([])
+    expect(skipReason(agedOnTheClient)).toBe(
+      'host foreground observation is too old to authorize a stop'
+    )
+  })
+
+  it('never sweeps when the host itself is too degraded to answer', async () => {
+    // `main` has since added `recoverRemoteTerminalRuntime`, a self-driven reconnect on relay
+    // node-pty failure — a sweep trigger that fires exactly when the host is unwell. The publisher
+    // has to fail closed there: a capture that cannot locate the shell is `unverifiable`, which is
+    // its own verdict and never collapses into "idle" (docs/reference/ssh-execution-boundary.md).
+    const evidence = await publish({ rootPid: 999_999, table: CAPTURES.idle.table })
+    expect(evidence).toMatchObject({ verdict: 'unverifiable', reason: 'root_missing' })
+
+    const plan = await planFor({ rootPid: 999_999, table: CAPTURES.idle.table })
+    expect(plan.sweep).toEqual([])
+    expect(skipReason(plan)).toBe('host could not observe the pane foreground process')
+  })
+
+  it('still reclaims a shell whose work really did finish', async () => {
+    // The feature must not degrade into a no-op. The background fixture's job is gone; what is
+    // left is the same orphaned shell, and it is swept.
+    const finished = {
+      rootPid: CAPTURES.background.rootPid,
+      table: CAPTURES.background.table.filter((line) => !line.includes('sleep 300'))
+    }
+    const plan = await planFor(finished)
+    expect(plan.sweep).toEqual([{ ptyId: 'pty-1', incarnationId: 'inc-1' }])
+  })
+})

--- a/src/main/ssh/ssh-pty-consumer-recovery.test.ts
+++ b/src/main/ssh/ssh-pty-consumer-recovery.test.ts
@@ -8,6 +8,21 @@ import {
 } from './ssh-pty-consumer-recovery'
 
 describe('SSH PTY consumer recovery', () => {
+  it('says out loud when it mints a new identity, because the sweep goes quiet after', () => {
+    // The id the host attests on every PTY it holds for us. Minting a new one is fail-safe — it
+    // can only under-sweep — but it makes the reaper silently stop working, so it must be visible.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const store = {
+      getSshPtyConsumerRecovery: vi.fn().mockReturnValue(null),
+      upsertSshPtyConsumerRecovery: vi.fn()
+    } as unknown as Store
+
+    claimSshPtyConsumerRecovery('mint-logs-the-loss', store)
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('minting a new consumer identity'))
+    warn.mockRestore()
+  })
+
   it('keeps a detached identity when a concurrent open finishes late', async () => {
     const targetId = 'remember-detach-race'
     const store = {

--- a/src/main/ssh/ssh-pty-consumer-recovery.ts
+++ b/src/main/ssh/ssh-pty-consumer-recovery.ts
@@ -37,6 +37,15 @@ export function claimSshPtyConsumerRecovery(
     return current
   }
   const persisted = current ? null : store.getSshPtyConsumerRecovery(targetId)
+  if (!persisted) {
+    // Deliberately not stabilized: this id is also the consumer session's ownership identity, and
+    // reusing it without the generations the same dropped record carried would replay a stale
+    // owner generation at the relay. The cost is visible instead of silent — every relay PTY the
+    // host still attributes to the previous identity becomes permanently unsweepable (#9819).
+    console.warn(
+      `[ssh-pty-consumer] no recovery record for ${targetId}; minting a new consumer identity. Relay PTYs the host attributes to this client's previous identity can no longer be swept.`
+    )
+  }
   const created: SshPtyConsumerRecoveryState = {
     clientInstanceId: persisted?.clientInstanceId ?? randomUUID(),
     detached: false,

--- a/src/main/ssh/ssh-relay-session-orphan-sweep.test.ts
+++ b/src/main/ssh/ssh-relay-session-orphan-sweep.test.ts
@@ -132,7 +132,7 @@ function hostEntry(
       ...OBSERVATION,
       verdict: 'live',
       processName: null,
-      shellIsForeground: true
+      shellOwnsEveryTtyProcessGroup: true
     },
     ...overrides
   }
@@ -246,7 +246,7 @@ describe('SshRelaySession orphaned relay PTY sweep', () => {
           ...OBSERVATION,
           verdict: 'live',
           processName: 'claude',
-          shellIsForeground: false
+          shellOwnsEveryTtyProcessGroup: false
         }
       })
     ])

--- a/src/main/ssh/ssh-relay-session-orphan-sweep.test.ts
+++ b/src/main/ssh/ssh-relay-session-orphan-sweep.test.ts
@@ -1,6 +1,6 @@
 // #9819 end to end on the client: the sweep runs only after reattach, only under a negotiated
 // session-owner grant, and only against PTYs this relay itself attributes to this client.
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SshRelaySession } from './ssh-relay-session'
 import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
 
@@ -100,12 +100,26 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
 
 const { getSshPtyProvider, getPtyIdsForConnection } = await import('../ipc/pty')
 
-const TARGET = 'target-1'
 const OUR_CLIENT = 'client-instance-1'
 
-function hostEntry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+// One target per test. `claimSshPtyConsumerRecovery` keeps a module-level map keyed on target and
+// mints a FRESH clientInstanceId whenever it is asked for a target it already holds a live entry
+// for — so a second `establish` on a shared target silently stops matching the host attestation and
+// every assertion after the first passes for the wrong reason.
+let targetSeq = 0
+function nextTarget(): string {
+  targetSeq += 1
+  return `target-${targetSeq}`
+}
+
+const OBSERVATION = { authorityGeneration: 'gen-1', observationEpoch: 1, capturedAgeMs: 0 }
+
+function hostEntry(
+  target: string,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
   return {
-    id: `ssh:${TARGET}@@pty-orphan`,
+    id: `ssh:${target}@@pty-orphan`,
     incarnationId: 'inc-orphan',
     cwd: '/home/user',
     title: 'zsh',
@@ -113,28 +127,43 @@ function hostEntry(overrides: Record<string, unknown> = {}): Record<string, unkn
     ownerClientInstanceId: OUR_CLIENT,
     hostAgeMs: 120_000,
     paneBound: true,
+    // The same listing's host observation: the shell owns the terminal, nothing is running.
+    foregroundProcessEvidence: {
+      ...OBSERVATION,
+      verdict: 'live',
+      processName: null,
+      shellIsForeground: true
+    },
     ...overrides
   }
 }
 
 describe('SshRelaySession orphaned relay PTY sweep', () => {
+  let warn: ReturnType<typeof vi.spyOn>
+
   beforeEach(() => {
     vi.clearAllMocks()
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     muxRequestMock.mockReset()
     muxRequestMock.mockResolvedValue([])
     mockDeploySuccess()
     vi.mocked(getPtyIdsForConnection).mockReturnValue([])
   })
 
+  afterEach(() => {
+    warn.mockRestore()
+  })
+
   async function establish(
+    target: string,
     processes: Record<string, unknown>[],
     leases: { ptyId: string; state: string }[] = []
-  ): Promise<{ shutdown: ReturnType<typeof vi.fn> }> {
+  ): Promise<{ shutdown: ReturnType<typeof vi.fn>; listProcesses: ReturnType<typeof vi.fn> }> {
     const deps = createMockDeps()
     // Why the recovery row: it pins this session's clientInstanceId, and the comparison is
     // meaningless unless the id it uses is the persisted one.
     vi.mocked(deps.mockStore.getSshPtyConsumerRecovery).mockReturnValue({
-      targetId: TARGET,
+      targetId: target,
       clientInstanceId: OUR_CLIENT,
       serverBuildId: 'build-1',
       clientGeneration: 1,
@@ -142,61 +171,122 @@ describe('SshRelaySession orphaned relay PTY sweep', () => {
       ownerLease: 'test-owner-lease'
     } as ReturnType<typeof deps.mockStore.getSshPtyConsumerRecovery>)
     vi.mocked(deps.mockStore.getSshRemotePtyLeases).mockReturnValue(
-      leases.map((lease) => ({ targetId: TARGET, ...lease })) as ReturnType<
+      leases.map((lease) => ({ targetId: target, ...lease })) as ReturnType<
         typeof deps.mockStore.getSshRemotePtyLeases
       >
     )
     const shutdown = vi.fn().mockResolvedValue(undefined)
+    const listProcesses = vi.fn().mockResolvedValue(processes)
     vi.mocked(getSshPtyProvider).mockReturnValue({
       attachForReconnect: vi.fn().mockResolvedValue({}),
-      listProcesses: vi.fn().mockResolvedValue(processes),
+      listProcesses,
       shutdown,
       dispose: vi.fn()
     } as unknown as ReturnType<typeof getSshPtyProvider>)
 
     const session = new SshRelaySession(
-      TARGET,
+      target,
       deps.getMainWindow,
       deps.mockStore,
       deps.mockPortForward
     )
     await session.establish(deps.mockConn)
-    return { shutdown }
+    // Both guards exist because every "never stops" case below is trivially satisfiable. The pass
+    // has to have run, and it has to have run under the identity the host attests — a session that
+    // minted a fresh one compares against nothing and skips everything for the wrong reason.
+    expect(listProcesses).toHaveBeenCalledTimes(1)
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('minting a new consumer identity')
+    )
+    return { shutdown, listProcesses }
   }
 
   it('stops an attested orphan the client has no lease for', async () => {
-    const { shutdown } = await establish([hostEntry()])
+    const target = nextTarget()
+    const { shutdown } = await establish(target, [hostEntry(target)])
 
-    expect(shutdown).toHaveBeenCalledWith(`ssh:${TARGET}@@pty-orphan`, {
-      immediate: true,
-      expectedIncarnationId: 'inc-orphan'
-    })
+    expect(shutdown).toHaveBeenCalledWith(
+      `ssh:${target}@@pty-orphan`,
+      expect.objectContaining({ immediate: true, expectedIncarnationId: 'inc-orphan' })
+    )
   })
 
   it('never stops a PTY that still holds a live lease', async () => {
+    const target = nextTarget()
     const { shutdown } = await establish(
-      [hostEntry({ id: `ssh:${TARGET}@@pty-live`, incarnationId: 'inc-live' })],
+      target,
+      [hostEntry(target, { id: `ssh:${target}@@pty-live`, incarnationId: 'inc-live' })],
       [{ ptyId: 'pty-live', state: 'detached' }]
     )
 
     expect(shutdown).not.toHaveBeenCalled()
   })
 
+  it('never stops a PTY whose lease this client expired rather than ordered stopped', async () => {
+    // What reaches this state in the field: a pane re-leased under a new relay id, a reattach that
+    // failed on the transport (dropStalePty), or a pane surface missing from the layout. All three
+    // leave the remote process running on purpose.
+    const target = nextTarget()
+    const { shutdown } = await establish(
+      target,
+      [hostEntry(target, { id: `ssh:${target}@@pty-gone`, incarnationId: 'inc-gone' })],
+      [{ ptyId: 'pty-gone', state: 'expired' }]
+    )
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('never stops a pane this relay observes running a foreground process', async () => {
+    // agentSessionOwners is empty here — the user typed `claude` themselves — so the only thing
+    // between a live agent and a stop is the host's own foreground observation.
+    const target = nextTarget()
+    const { shutdown } = await establish(target, [
+      hostEntry(target, {
+        foregroundProcessEvidence: {
+          ...OBSERVATION,
+          verdict: 'live',
+          processName: 'claude',
+          shellIsForeground: false
+        }
+      })
+    ])
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('never stops a pane whose foreground observation the relay could not make', async () => {
+    const target = nextTarget()
+    const { shutdown } = await establish(target, [
+      hostEntry(target, {
+        foregroundProcessEvidence: {
+          ...OBSERVATION,
+          verdict: 'unverifiable',
+          reason: 'table_unreadable'
+        }
+      })
+    ])
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
   it('never stops a PTY this relay attributes to a different client', async () => {
-    const { shutdown } = await establish([
-      hostEntry({ ownerClientInstanceId: 'someone-elses-laptop' })
+    const target = nextTarget()
+    const { shutdown } = await establish(target, [
+      hostEntry(target, { ownerClientInstanceId: 'someone-elses-laptop' })
     ])
 
     expect(shutdown).not.toHaveBeenCalled()
   })
 
   it('never stops anything a relay predating the attestation lists', async () => {
-    const legacy = hostEntry()
+    const target = nextTarget()
+    const legacy = hostEntry(target)
     delete legacy.ownerClientInstanceId
     delete legacy.hostAgeMs
     delete legacy.paneBound
+    delete legacy.foregroundProcessEvidence
 
-    const { shutdown } = await establish([legacy])
+    const { shutdown } = await establish(target, [legacy])
 
     expect(shutdown).not.toHaveBeenCalled()
   })

--- a/src/main/ssh/ssh-relay-session-orphan-sweep.test.ts
+++ b/src/main/ssh/ssh-relay-session-orphan-sweep.test.ts
@@ -1,0 +1,203 @@
+// #9819 end to end on the client: the sweep runs only after reattach, only under a negotiated
+// session-owner grant, and only against PTYs this relay itself attributes to this client.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SshRelaySession } from './ssh-relay-session'
+import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
+
+const { muxRequestMock, openConsumerSessionMock } = vi.hoisted(() => ({
+  muxRequestMock: vi.fn(),
+  openConsumerSessionMock: vi.fn(async (_mux: unknown, options: { clientInstanceId: string }) => ({
+    state: {
+      mode: 'negotiated' as const,
+      clientInstanceId: options.clientInstanceId,
+      clientGeneration: 1,
+      ownerGeneration: 1,
+      ownerLease: 'test-owner-lease'
+    },
+    resumed: false
+  }))
+}))
+
+vi.mock('./ssh-relay-deploy', () => ({ deployAndLaunchRelay: vi.fn() }))
+vi.mock('./ssh-pty-consumer-session', () => ({
+  openSshPtyConsumerSession: openConsumerSessionMock
+}))
+vi.mock('../ipc/ssh-pty-output-intake-registry', () => ({
+  acceptSshPtyOutputData: vi.fn().mockResolvedValue(undefined),
+  acceptSshPtyOutputExit: vi.fn().mockResolvedValue(undefined),
+  allocateSshPtyProviderGeneration: vi.fn(() => 17),
+  beginSshPtyOutputGenerationMigration: vi.fn(() => ({
+    byPty: new Map(),
+    completion: Promise.resolve()
+  })),
+  closeSshPtyOutputGeneration: vi.fn(),
+  getSshPtyAcceptedSourceCheckpoints: vi.fn(() => []),
+  applySshPtySourceCancellationProof: vi.fn(() => true),
+  applySshPtySourceRecoveryCancellationProof: vi.fn(() => true),
+  installSshPtySourceAckPublisher: vi.fn(() => () => {}),
+  installSshPtySourceCancellationPublisher: vi.fn(() => () => {})
+}))
+vi.mock('./ssh-relay-deploy-helpers', () => ({ execCommand: vi.fn().mockResolvedValue('') }))
+vi.mock('./ssh-remote-orca-cli', () => ({
+  runRemoteOrcaCli: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' })
+}))
+vi.mock('./ssh-channel-multiplexer', () => ({
+  SshChannelMultiplexer: class MockSshChannelMultiplexer {
+    notify = vi.fn()
+    notifyWithSettlement = vi.fn()
+    request = muxRequestMock
+    onNotification = vi.fn().mockReturnValue(() => {})
+    onNotificationByMethod = vi.fn().mockReturnValue(() => {})
+    onRequest = vi.fn().mockReturnValue(() => {})
+    onDispose = vi.fn().mockReturnValue(() => {})
+    dispose = vi.fn()
+    isDisposed = vi.fn().mockReturnValue(false)
+  }
+}))
+vi.mock('../agent-hooks/remote-managed-hook-installers', () => ({
+  installRemoteManagedAgentHooks: vi.fn()
+}))
+vi.mock('../providers/ssh-pty-provider', () => ({
+  SshPtyProvider: class MockSshPtyProvider {
+    onData = vi.fn().mockReturnValue(() => {})
+    onReplay = vi.fn().mockReturnValue(() => {})
+    onExit = vi.fn().mockReturnValue(() => {})
+    attach = vi.fn().mockResolvedValue(undefined)
+    attachForReconnect = vi.fn().mockResolvedValue({})
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-filesystem-provider', () => ({
+  SshFilesystemProvider: class MockSshFilesystemProvider {
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-git-provider', () => ({
+  SshGitProvider: class MockSshGitProvider {}
+}))
+vi.mock('../ipc/pty', () => ({
+  registerSshPtyProvider: vi.fn(),
+  unregisterSshPtyProvider: vi.fn(),
+  getSshPtyProvider: vi.fn(),
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearPtyOwnershipForConnection: vi.fn(),
+  clearProviderPtyState: vi.fn(),
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn(),
+  restorePtyIncarnation: vi.fn(),
+  isCurrentPtyExit: vi.fn(() => true),
+  answerStartupTerminalColorQueriesForPty: vi.fn((_id: string, data: string) => data)
+}))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  registerSshFilesystemProvider: vi.fn(),
+  unregisterSshFilesystemProvider: vi.fn(),
+  getSshFilesystemProvider: vi.fn().mockReturnValue({ dispose: vi.fn() })
+}))
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  registerSshGitProvider: vi.fn(),
+  unregisterSshGitProvider: vi.fn()
+}))
+
+const { getSshPtyProvider, getPtyIdsForConnection } = await import('../ipc/pty')
+
+const TARGET = 'target-1'
+const OUR_CLIENT = 'client-instance-1'
+
+function hostEntry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: `ssh:${TARGET}@@pty-orphan`,
+    incarnationId: 'inc-orphan',
+    cwd: '/home/user',
+    title: 'zsh',
+    // The relay stamps this from the live consumer grant, so it names THIS client.
+    ownerClientInstanceId: OUR_CLIENT,
+    hostAgeMs: 120_000,
+    paneBound: true,
+    ...overrides
+  }
+}
+
+describe('SshRelaySession orphaned relay PTY sweep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    muxRequestMock.mockReset()
+    muxRequestMock.mockResolvedValue([])
+    mockDeploySuccess()
+    vi.mocked(getPtyIdsForConnection).mockReturnValue([])
+  })
+
+  async function establish(
+    processes: Record<string, unknown>[],
+    leases: { ptyId: string; state: string }[] = []
+  ): Promise<{ shutdown: ReturnType<typeof vi.fn> }> {
+    const deps = createMockDeps()
+    // Why the recovery row: it pins this session's clientInstanceId, and the comparison is
+    // meaningless unless the id it uses is the persisted one.
+    vi.mocked(deps.mockStore.getSshPtyConsumerRecovery).mockReturnValue({
+      targetId: TARGET,
+      clientInstanceId: OUR_CLIENT,
+      serverBuildId: 'build-1',
+      clientGeneration: 1,
+      ownerGeneration: 1,
+      ownerLease: 'test-owner-lease'
+    } as ReturnType<typeof deps.mockStore.getSshPtyConsumerRecovery>)
+    vi.mocked(deps.mockStore.getSshRemotePtyLeases).mockReturnValue(
+      leases.map((lease) => ({ targetId: TARGET, ...lease })) as ReturnType<
+        typeof deps.mockStore.getSshRemotePtyLeases
+      >
+    )
+    const shutdown = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect: vi.fn().mockResolvedValue({}),
+      listProcesses: vi.fn().mockResolvedValue(processes),
+      shutdown,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+
+    const session = new SshRelaySession(
+      TARGET,
+      deps.getMainWindow,
+      deps.mockStore,
+      deps.mockPortForward
+    )
+    await session.establish(deps.mockConn)
+    return { shutdown }
+  }
+
+  it('stops an attested orphan the client has no lease for', async () => {
+    const { shutdown } = await establish([hostEntry()])
+
+    expect(shutdown).toHaveBeenCalledWith(`ssh:${TARGET}@@pty-orphan`, {
+      immediate: true,
+      expectedIncarnationId: 'inc-orphan'
+    })
+  })
+
+  it('never stops a PTY that still holds a live lease', async () => {
+    const { shutdown } = await establish(
+      [hostEntry({ id: `ssh:${TARGET}@@pty-live`, incarnationId: 'inc-live' })],
+      [{ ptyId: 'pty-live', state: 'detached' }]
+    )
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('never stops a PTY this relay attributes to a different client', async () => {
+    const { shutdown } = await establish([
+      hostEntry({ ownerClientInstanceId: 'someone-elses-laptop' })
+    ])
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('never stops anything a relay predating the attestation lists', async () => {
+    const legacy = hostEntry()
+    delete legacy.ownerClientInstanceId
+    delete legacy.hostAgeMs
+    delete legacy.paneBound
+
+    const { shutdown } = await establish([legacy])
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -10,6 +10,7 @@ import { isRelayEndpointHeldError } from './ssh-relay-endpoint-incumbent'
 import { forgetRelayNodePtyRepairs, recoverRelayNodePtyForSpawn } from './ssh-relay-node-pty-repair'
 import type { TerminalUnavailableCause } from '../../shared/terminal-unavailable-cause'
 import { replayPendingSshPtyKills } from './ssh-pending-pty-kill-replay'
+import { sweepOrphanedRelayPtys } from './ssh-orphan-relay-pty-sweep'
 import { SshChannelMultiplexer } from './ssh-channel-multiplexer'
 import { SshPtyProvider } from '../providers/ssh-pty-provider'
 import type { SshPtyAttachResult } from '../providers/ssh-pty-session-reattach'
@@ -2398,6 +2399,17 @@ export class SshRelaySession {
         Array.from(attachedLeaseIds)
       )
     }
+    // Why last: reclaiming comes first, so every PTY this connect could route to is routed before
+    // anything asks which ones are unreachable (#9819).
+    await sweepOrphanedRelayPtys({
+      targetId: this.targetId,
+      store: this.store,
+      provider: ptyProvider,
+      clientInstanceId: this.ptyConsumerClientInstanceId,
+      isSessionOwner: this.activePtyConsumerOwner() !== null,
+      routedPtyIds: ptyIds,
+      shouldContinue
+    })
   }
 
   private async reattachKnownPty(args: {

--- a/src/relay/pty-handler-inventory-process-evidence.test.ts
+++ b/src/relay/pty-handler-inventory-process-evidence.test.ts
@@ -157,22 +157,32 @@ describe('PtyHandler inventory foreground evidence', () => {
     expect((await listProcesses())[0].title).toBe('node')
   })
 
-  it.each([1, 8])('visits the host table exactly once for %s panes', async (paneCount) => {
-    const table = Array.from({ length: paneCount }, (_, index) =>
-      paneRows(10_000 + index * 10, ['node /opt/codex'])
-    ).flat()
-    const { rows, reads } = countingRows(table)
-    mockGetStrictProcessTableSnapshot.mockResolvedValue(rows)
-    for (let index = 0; index < paneCount; index += 1) {
-      await spawnPane(10_000 + index * 10, 'zsh')
+  // The cost that matters is per-CAPTURE, not per-pane: the defect this guards against is a
+  // full-table walk for every pane, which is what an O(PTY x rows) inventory looked like. Two
+  // linear passes build the two indexes the resolver reads — parent/child correlation, and which
+  // process groups occupy each controlling terminal — and neither grows with the pane count.
+  const CAPTURE_PASSES = 2
+
+  it.each([1, 8])(
+    'walks the host table a fixed number of times for %s panes',
+    async (paneCount) => {
+      const table = Array.from({ length: paneCount }, (_, index) =>
+        paneRows(10_000 + index * 10, ['node /opt/codex'])
+      ).flat()
+      const { rows, reads } = countingRows(table)
+      mockGetStrictProcessTableSnapshot.mockResolvedValue(rows)
+      for (let index = 0; index < paneCount; index += 1) {
+        await spawnPane(10_000 + index * 10, 'zsh')
+      }
+
+      const listed = await listProcesses()
+
+      expect(listed).toHaveLength(paneCount)
+      expect(listed.every((entry) => entry.title === 'codex')).toBe(true)
+      expect(mockGetStrictProcessTableSnapshot).toHaveBeenCalledTimes(1)
+      // Linear in the capture — NOT one full-table walk per pane, which would be
+      // `table.length * paneCount` here.
+      expect(reads()).toBe(table.length * CAPTURE_PASSES)
     }
-
-    const listed = await listProcesses()
-
-    expect(listed).toHaveLength(paneCount)
-    expect(listed.every((entry) => entry.title === 'codex')).toBe(true)
-    expect(mockGetStrictProcessTableSnapshot).toHaveBeenCalledTimes(1)
-    // One linear index pass — NOT one full-table walk per pane.
-    expect(reads()).toBe(table.length)
-  })
+  )
 })

--- a/src/relay/pty-handler-ownership-attestation.test.ts
+++ b/src/relay/pty-handler-ownership-attestation.test.ts
@@ -96,6 +96,38 @@ describe('PtyHandler publishes host-attested PTY ownership', () => {
     expect(entry).not.toHaveProperty('ownerClientInstanceId')
   })
 
+  it('never attests a revived PTY, so a restored session is not sweepable', async () => {
+    // The load-bearing invariant of #9819's host half, and the one most likely to be "helpfully"
+    // broken later: revive replays state a client serialized, which is not this host observing who
+    // asked for the shell. A revived PTY *does* get paneBound: true (paneKey is restored) and a
+    // fresh createdAt, so the omitted attestation is the only thing standing between a relay
+    // restart and a sweep of the entire restored session.
+    const revivedId = 'pty-revived-1'
+    await dispatcher.callRequest(
+      'pty.revive',
+      {
+        state: JSON.stringify([
+          {
+            id: revivedId,
+            pid: process.pid,
+            cwd: process.cwd(),
+            paneKey: PANE_KEY,
+            cols: 80,
+            rows: 24
+          }
+        ])
+      },
+      { clientId: 7, isStale: () => false } as never
+    )
+
+    const entry = (await listProcesses()).find((process) => process.id === revivedId)
+    expect(entry, 'revive should have produced a live PTY entry').toBeDefined()
+    // paneBound is true, which is exactly why the missing attestation has to be asserted:
+    // every other sweep precondition is satisfied by a revived pane.
+    expect(entry?.paneBound).toBe(true)
+    expect(entry?.ownerClientInstanceId).toBeUndefined()
+  })
+
   it('reports a bare shell as not pane-bound', async () => {
     const { id } = await spawnFrom(7, {})
 

--- a/src/relay/pty-handler-ownership-attestation.test.ts
+++ b/src/relay/pty-handler-ownership-attestation.test.ts
@@ -33,6 +33,7 @@ import {
   endPtyHandlerTest,
   type MockDispatcher
 } from './pty-handler-test-harness'
+import { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS } from '../shared/process-table-snapshot'
 
 const PANE_KEY = 'tab-agent:22222222-2222-4222-8222-222222222222'
 
@@ -41,6 +42,7 @@ type Summary = {
   paneBound?: boolean
   hostAgeMs?: number
   ownerClientInstanceId?: string
+  foregroundProcessEvidence?: { capturedAgeMs: number }
 }
 
 describe('PtyHandler publishes host-attested PTY ownership', () => {
@@ -135,5 +137,147 @@ describe('PtyHandler publishes host-attested PTY ownership', () => {
 
     expect(entry?.paneBound).toBe(false)
     expect(entry?.ownerClientInstanceId).toBe('client-A')
+  })
+
+  it('dates the foreground observation instead of stamping it fresh', async () => {
+    // `capturedAgeMs` used to be a hardcoded 0 with no reader anywhere, so the one field that
+    // exists to bound staleness asserted the evidence was never stale. It now carries the
+    // worst-case age of the TTL-shared capture the record was derived from.
+    const { id } = await spawnFrom(7, { env: { ORCA_PANE_KEY: PANE_KEY } })
+
+    const entry = (await listProcesses()).find((process) => process.id === id)
+
+    expect(entry?.foregroundProcessEvidence?.capturedAgeMs).toBe(
+      PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS
+    )
+  })
+})
+
+// CodeRabbit's unaddressed note, and the asymmetry behind it: `pty.spawn` and `pty.attach` both
+// take a request context and both check it, while `pty.shutdown` — the one call that irreversibly
+// destroys a user's running process — took none, so the entire ownership rule was enforced only on
+// the client that decided to make the call.
+describe('PtyHandler authorizes a fenced stop against its own attestation', () => {
+  let dispatcher: MockDispatcher
+  let handler: PtyHandler
+  let originalPlatform: PropertyDescriptor | undefined
+
+  async function spawnFrom(clientId: number): Promise<{ id: string }> {
+    mockPtySpawn.mockReturnValue({ ...mockPtyInstance, onData: vi.fn(), onExit: vi.fn() })
+    return (await dispatcher.callRequest('pty.spawn', { env: { ORCA_PANE_KEY: PANE_KEY } }, {
+      clientId,
+      isStale: () => false
+    } as never)) as { id: string }
+  }
+
+  async function isStillHeld(id: string): Promise<boolean> {
+    const entries = (await dispatcher.callRequest('pty.listProcesses', {})) as Summary[]
+    return entries.some((entry) => entry.id === id)
+  }
+
+  /** What actually reaches the process. A refusal has to leave this untouched — the point of the
+   *  check is the process, not the error. */
+  function killSignals(): unknown[][] {
+    return mockPtyInstance.kill.mock.calls
+  }
+
+  function stop(id: string, params: Record<string, unknown>, clientId: number): Promise<unknown> {
+    return dispatcher.callRequest('pty.shutdown', { id, immediate: false, ...params }, {
+      clientId,
+      isStale: () => false
+    } as never)
+  }
+
+  beforeEach(() => {
+    ;({ dispatcher, handler, originalPlatform } = beginPtyHandlerTest({
+      mockPtySpawn,
+      mockPtyInstance,
+      mockCreateShellPromptReadinessProbe
+    }))
+    handler.setConsumerIdentityResolver((clientId) =>
+      clientId === 7 ? 'client-A' : clientId === 8 ? 'client-B' : null
+    )
+  })
+
+  afterEach(async () => {
+    await endPtyHandlerTest(handler, originalPlatform)
+  })
+
+  it('stops a PTY when the connection and the host agree on the owner', async () => {
+    const { id } = await spawnFrom(7)
+
+    await expect(
+      stop(id, { expectedOwnerClientInstanceId: 'client-A' }, 7)
+    ).resolves.toBeUndefined()
+    expect(killSignals()).toEqual([['SIGTERM']])
+  })
+
+  it('refuses when another client asserts our identity, and leaves the process running', async () => {
+    // The claim is a parameter, so a confused or displaced client can send any value it likes.
+    // What it cannot do is authenticate as that identity on this connection.
+    const { id } = await spawnFrom(7)
+
+    await expect(stop(id, { expectedOwnerClientInstanceId: 'client-A' }, 8)).rejects.toThrow(
+      /requester is not the attested owner/
+    )
+    expect(killSignals()).toEqual([])
+    expect(await isStillHeld(id)).toBe(true)
+  })
+
+  it('refuses when the connection holds no grant at all', async () => {
+    const { id } = await spawnFrom(7)
+
+    await expect(stop(id, { expectedOwnerClientInstanceId: 'client-A' }, 99)).rejects.toThrow(
+      /requester is not the attested owner/
+    )
+    expect(killSignals()).toEqual([])
+    expect(await isStillHeld(id)).toBe(true)
+  })
+
+  it('refuses a PTY this host never attested, even to the client that asked', async () => {
+    // The revived-PTY case. Both sweep preconditions a client can see are satisfied — pane-bound,
+    // old enough — and only the host knows it never recorded a creator for it.
+    const revivedId = 'pty-revived-fence'
+    await dispatcher.callRequest(
+      'pty.revive',
+      {
+        state: JSON.stringify([
+          {
+            id: revivedId,
+            pid: process.pid,
+            cwd: process.cwd(),
+            paneKey: PANE_KEY,
+            cols: 80,
+            rows: 24
+          }
+        ])
+      },
+      { clientId: 7, isStale: () => false } as never
+    )
+
+    await expect(stop(revivedId, { expectedOwnerClientInstanceId: 'client-A' }, 7)).rejects.toThrow(
+      /this host attested no such owner/
+    )
+    expect(killSignals()).toEqual([])
+    expect(await isStillHeld(revivedId)).toBe(true)
+  })
+
+  it('leaves an ordinary teardown that names no owner exactly as it was', async () => {
+    // Rule 1's obligation: an old client, and every non-sweep caller on a current one, omits the
+    // field. The host must not start refusing a stop it is obliged to honour.
+    const { id } = await spawnFrom(7)
+
+    await expect(stop(id, {}, 7)).resolves.toBeUndefined()
+    expect(killSignals()).toEqual([['SIGTERM']])
+  })
+
+  it('rejects a malformed owner claim rather than ignoring it', async () => {
+    const { id } = await spawnFrom(7)
+
+    await expect(stop(id, { expectedOwnerClientInstanceId: '' }, 7)).rejects.toThrow(
+      /Invalid expectedOwnerClientInstanceId/
+    )
+    expect(killSignals()).toEqual([])
+    expect(await isStillHeld(id)).toBe(true)
   })
 })

--- a/src/relay/pty-handler-ownership-attestation.test.ts
+++ b/src/relay/pty-handler-ownership-attestation.test.ts
@@ -1,0 +1,107 @@
+// The host half of #9819: a client may only reap a relay PTY it can prove it created, so the relay
+// has to say who created each one. The attestation is read from the live consumer grant, never from
+// a spawn parameter — otherwise it would just echo the caller's claim back at it.
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const { mockPtySpawn, mockPtyInstance, mockCreateShellPromptReadinessProbe } = vi.hoisted(() => ({
+  mockPtySpawn: vi.fn(),
+  mockCreateShellPromptReadinessProbe: vi.fn(),
+  mockPtyInstance: {
+    pid: process.pid,
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    clear: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn()
+  }
+}))
+
+vi.mock('node-pty', () => ({ spawn: mockPtySpawn }))
+vi.mock('../main/pty/posix-pty-process-groups', () => ({
+  forceKillPosixPtyProcessGroups: vi.fn((_pid: number, fallback: () => void) => fallback())
+}))
+vi.mock('../main/shell-prompt-readiness-probe', () => ({
+  createShellPromptReadinessProbe: mockCreateShellPromptReadinessProbe
+}))
+
+import type { PtyHandler } from './pty-handler'
+import {
+  beginPtyHandlerTest,
+  endPtyHandlerTest,
+  type MockDispatcher
+} from './pty-handler-test-harness'
+
+const PANE_KEY = 'tab-agent:22222222-2222-4222-8222-222222222222'
+
+type Summary = {
+  id: string
+  paneBound?: boolean
+  hostAgeMs?: number
+  ownerClientInstanceId?: string
+}
+
+describe('PtyHandler publishes host-attested PTY ownership', () => {
+  let dispatcher: MockDispatcher
+  let handler: PtyHandler
+  let originalPlatform: PropertyDescriptor | undefined
+
+  async function spawnFrom(
+    clientId: number,
+    params: Record<string, unknown> = {}
+  ): Promise<{ id: string }> {
+    mockPtySpawn.mockReturnValue({ ...mockPtyInstance, onData: vi.fn(), onExit: vi.fn() })
+    return (await dispatcher.callRequest('pty.spawn', params, {
+      clientId,
+      isStale: () => false
+    } as never)) as { id: string }
+  }
+
+  async function listProcesses(): Promise<Summary[]> {
+    return (await dispatcher.callRequest('pty.listProcesses', {})) as Summary[]
+  }
+
+  beforeEach(() => {
+    ;({ dispatcher, handler, originalPlatform } = beginPtyHandlerTest({
+      mockPtySpawn,
+      mockPtyInstance,
+      mockCreateShellPromptReadinessProbe
+    }))
+    handler.setConsumerIdentityResolver((clientId) => (clientId === 7 ? 'client-A' : null))
+  })
+
+  afterEach(async () => {
+    await endPtyHandlerTest(handler, originalPlatform)
+  })
+
+  it('attributes a pane spawn to the identity the consumer grant names', async () => {
+    const { id } = await spawnFrom(7, { env: { ORCA_PANE_KEY: PANE_KEY } })
+    vi.advanceTimersByTime(45_000)
+
+    const entry = (await listProcesses()).find((process) => process.id === id)
+
+    expect(entry?.ownerClientInstanceId).toBe('client-A')
+    expect(entry?.paneBound).toBe(true)
+    expect(entry?.hostAgeMs).toBeGreaterThanOrEqual(45_000)
+  })
+
+  it('omits the attestation entirely when the connection holds no active grant', async () => {
+    const { id } = await spawnFrom(9, { env: { ORCA_PANE_KEY: PANE_KEY } })
+
+    const entry = (await listProcesses()).find((process) => process.id === id)
+
+    // Absent, not empty-string or null: a reader must be able to tell "unattested" from any value.
+    expect(entry).not.toHaveProperty('ownerClientInstanceId')
+  })
+
+  it('reports a bare shell as not pane-bound', async () => {
+    const { id } = await spawnFrom(7, {})
+
+    const entry = (await listProcesses()).find((process) => process.id === id)
+
+    expect(entry?.paneBound).toBe(false)
+    expect(entry?.ownerClientInstanceId).toBe('client-A')
+  })
+})

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -70,6 +70,7 @@ import {
 } from '../main/providers/agent-foreground-process'
 import {
   getStrictProcessTableSnapshot,
+  PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS,
   type ProcessTableRow
 } from '../shared/process-table-snapshot'
 import type { ForegroundProcessEvidence } from '../shared/foreground-process-evidence'
@@ -1013,7 +1014,7 @@ export class PtyHandler {
   private registerHandlers(): void {
     this.dispatcher.onRequest('pty.spawn', (p, context) => this.spawn(p, context))
     this.dispatcher.onRequest('pty.attach', (p, context) => this.attach(p, context))
-    this.dispatcher.onRequest('pty.shutdown', (p) => this.shutdown(p))
+    this.dispatcher.onRequest('pty.shutdown', (p, context) => this.shutdown(p, context))
     this.dispatcher.onRequest('pty.sendSignal', (p) => this.sendSignal(p))
     this.dispatcher.onRequest('pty.getCwd', (p) => this.getCwd(p))
     this.dispatcher.onRequest('pty.getInitialCwd', (p) => this.getInitialCwd(p))
@@ -2123,7 +2124,7 @@ export class PtyHandler {
     return { cols: managed.pty.cols, rows: managed.pty.rows }
   }
 
-  private async shutdown(params: Record<string, unknown>): Promise<void> {
+  private async shutdown(params: Record<string, unknown>, context?: RequestContext): Promise<void> {
     const id = params.id as string
     const immediate = params.immediate as boolean
     const expectedIncarnationId = params.expectedIncarnationId
@@ -2133,12 +2134,23 @@ export class PtyHandler {
     ) {
       throw new Error('Invalid expectedIncarnationId')
     }
+    const expectedOwnerClientInstanceId = params.expectedOwnerClientInstanceId
+    if (
+      expectedOwnerClientInstanceId !== undefined &&
+      (typeof expectedOwnerClientInstanceId !== 'string' ||
+        expectedOwnerClientInstanceId.length === 0)
+    ) {
+      throw new Error('Invalid expectedOwnerClientInstanceId')
+    }
     const managed = this.ptys.get(id)
     if (!managed) {
       return
     }
     if (expectedIncarnationId !== undefined && expectedIncarnationId !== managed.incarnationId) {
       throw new Error(`PTY incarnation mismatch for ${id}`)
+    }
+    if (expectedOwnerClientInstanceId !== undefined) {
+      this.assertShutdownOwnership(id, managed, expectedOwnerClientInstanceId, context)
     }
     // Why: `pty.shutdown` is the only authoritative statement this host ever gets that a tab is
     // gone. Record it before the kill request, because the kill is the part that can fail: an agent
@@ -2161,6 +2173,34 @@ export class PtyHandler {
     } else {
       this.releaseStartupCommand(managed)
       this.requestGracefulKill(managed, 'force-kill')
+    }
+  }
+
+  /** Re-decide, on the host, whether the caller may destroy this PTY.
+   *
+   *  `pty.shutdown` is irreversible and its siblings `pty.spawn`/`pty.attach` already take a
+   *  request context; without this the whole ownership rule lived on the client, on the one call
+   *  that cannot be taken back. Both halves are checked here because either alone is an echo: the
+   *  connection must still authenticate as that consumer identity (so a claim cannot be asserted),
+   *  and this host must have recorded that same identity as the PTY's creator at spawn (so the
+   *  caller cannot reach a PTY it never made).
+   *
+   *  Only callers that opt in are checked. An ordinary pane teardown does not pass the field, and
+   *  must not: a revived PTY carries no attested owner at all, and a host predating the attestation
+   *  would refuse stops it is obliged to honour. */
+  private assertShutdownOwnership(
+    id: string,
+    managed: ManagedPty,
+    expectedOwnerClientInstanceId: string,
+    context: RequestContext | undefined
+  ): void {
+    const requester =
+      context === undefined ? null : (this.consumerIdentityResolver?.(context.clientId) ?? null)
+    if (requester !== expectedOwnerClientInstanceId) {
+      throw new Error(`PTY "${id}" stop refused: requester is not the attested owner`)
+    }
+    if (managed.ownerClientInstanceId !== expectedOwnerClientInstanceId) {
+      throw new Error(`PTY "${id}" stop refused: this host attested no such owner`)
     }
   }
 
@@ -2432,9 +2472,15 @@ export class PtyHandler {
     let evidenceRows: readonly ProcessTableRow[] | null = null
     let evidenceResults: BatchedForegroundProcessResult[] = []
     const evidenceEpoch = ++this.foregroundEvidenceEpoch
+    // Worst-case capture time for the snapshot below, not the instant its await settled: the
+    // reader may serve a TTL-cached table, so the observation can already be one window old. The
+    // loop that follows can await per entry, so each record is stamped against this rather than
+    // carrying a shared constant.
+    let evidenceCapturedAtMs = Date.now()
     if (process.platform !== 'win32' && managedEntries.length > 0) {
       try {
         evidenceRows = await getStrictProcessTableSnapshot()
+        evidenceCapturedAtMs = Date.now() - PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS
         evidenceResults = await resolveAgentForegroundProcessesBatch(
           managedEntries.map(([, managed]) => ({
             rootPid: managed.pty.pid,
@@ -2468,7 +2514,7 @@ export class PtyHandler {
               {
                 authorityGeneration: this.ptyIdMintEpoch,
                 observationEpoch: evidenceEpoch,
-                capturedAgeMs: 0
+                capturedAgeMs: Math.max(0, Date.now() - evidenceCapturedAtMs)
               }
             )
           : undefined

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -190,6 +190,13 @@ type ManagedPty = {
   startupIngressIntent?: ReturnType<typeof parsePtyStartupIngressIntent>
   ownerBackend: PtyOwnerBackend
   agentSessionOwners?: AgentSessionOwnerBinding[]
+  /** Host clock, host-relative only: published as an age so no client has to trust our wall clock. */
+  createdAt: number
+  /** The authenticated consumer identity that asked this host to create this PTY, read from the
+   *  live grant rather than from a spawn parameter. Absent whenever the host could not attest one
+   *  (no consumer session, or a revive replaying state some other client serialized), and absence
+   *  must never be read as "nobody owns it". */
+  ownerClientInstanceId?: string
 }
 
 type RelayAgentSessionCreateResult = {
@@ -369,6 +376,14 @@ type PtyProcessSummary = {
   terminalHandle?: string
   foregroundProcessEvidence?: ForegroundProcessEvidence
   agentSessionOwners?: AgentSessionOwnerBinding[]
+  /** Age on the HOST's clock. Published instead of a creation timestamp so a client with a skewed
+   *  clock cannot compute a negative or enormous age and act on it. */
+  hostAgeMs?: number
+  /** True when this PTY was spawned for an Orca pane (`ORCA_PANE_KEY`). False means a bare relay
+   *  shell. Absent from a host that predates the field — which is neither. */
+  paneBound?: boolean
+  /** See {@link ManagedPty.ownerClientInstanceId}. Omitted when this host cannot attest one. */
+  ownerClientInstanceId?: string
 }
 
 type SerializedPtyEntry = {
@@ -456,6 +471,7 @@ export class PtyHandler {
   private consumerPausedOutputPtys = new Set<string>()
   private removeLegacyCapacityListener: (() => void) | null = null
   private sourcePublication: RelayPtySourcePublication | null = null
+  private consumerIdentityResolver: ((clientId: number) => string | null) | null = null
   private lastInputAtByPty = new Map<string, number>()
   private interactiveOutputCharsByPty = new Map<string, number>()
   private pendingSpawnCount = 0
@@ -508,6 +524,12 @@ export class PtyHandler {
 
   setSourcePublication(publication: RelayPtySourcePublication): void {
     this.sourcePublication = publication
+  }
+
+  /** Supplies the authenticated client identity behind a transport connection, so a spawn can be
+   *  attributed to the consumer session that requested it. */
+  setConsumerIdentityResolver(resolve: ((clientId: number) => string | null) | null): void {
+    this.consumerIdentityResolver = resolve
   }
 
   handleSourceCreditAvailable(id: string): void {
@@ -1871,11 +1893,15 @@ export class PtyHandler {
       params.startupIngressVersion === PTY_STARTUP_INGRESS_VERSION
         ? parsePtyStartupIngressIntent(params.startupIngress)
         : undefined
+    const ownerClientInstanceId =
+      context === undefined ? null : (this.consumerIdentityResolver?.(context.clientId) ?? null)
     const managed: ManagedPty = {
       id,
       incarnationId: randomUUID(),
       pty: term,
       initialCwd: cwd,
+      createdAt: Date.now(),
+      ...(ownerClientInstanceId ? { ownerClientInstanceId } : {}),
       buffered: new RecentPtyOutputBuffer({
         preserveChunkBoundaries: false,
         limit: REPLAY_BUFFER_MAX
@@ -2451,6 +2477,11 @@ export class PtyHandler {
         incarnationId: managed.incarnationId,
         cwd: managed.initialCwd,
         title,
+        hostAgeMs: Math.max(0, Date.now() - managed.createdAt),
+        paneBound: Boolean(managed.paneKey ?? managed.attachIdentity?.paneKey),
+        ...(managed.ownerClientInstanceId
+          ? { ownerClientInstanceId: managed.ownerClientInstanceId }
+          : {}),
         ...(managed.worktreeId ? { worktreeId: managed.worktreeId } : {}),
         ...(managed.terminalHandle ? { terminalHandle: managed.terminalHandle } : {}),
         ...(foregroundProcessEvidence ? { foregroundProcessEvidence } : {}),
@@ -2624,6 +2655,10 @@ export class PtyHandler {
       incarnationId: randomUUID(),
       pty: term,
       initialCwd: entry.cwd,
+      createdAt: Date.now(),
+      // Deliberately no ownerClientInstanceId: revive replays state a client serialized, which is
+      // not this host observing who asked for the shell. Unattested means never swept.
+
       buffered: new RecentPtyOutputBuffer({
         preserveChunkBoundaries: false,
         limit: REPLAY_BUFFER_MAX

--- a/src/relay/relay-runtime-services.ts
+++ b/src/relay/relay-runtime-services.ts
@@ -44,6 +44,11 @@ export class RelayRuntimeServices {
       (id, paused) => this.ptyHandler.setConsumerDeliveryPaused(id, paused),
       (id) => this.ptyHandler.handleSourceCreditAvailable(id)
     )
+    // Why wired after construction: the handler is built first, but PTY ownership has to be
+    // attested from the consumer grant the adapter holds.
+    this.ptyHandler.setConsumerIdentityResolver((clientId) =>
+      this.ptyConsumerSessionAdapter.clientInstanceIdFor(clientId)
+    )
     this.ptySourcePublication = new RelayPtySourcePublication(
       dispatcher,
       this.ptyConsumerSessionAdapter,

--- a/src/relay/ssh-pty-consumer-session-adapter.ts
+++ b/src/relay/ssh-pty-consumer-session-adapter.ts
@@ -112,6 +112,12 @@ export class SshPtyConsumerSessionAdapter {
     })
   }
 
+  /** The authenticated client identity behind a transport connection, or null when it holds no
+   *  active grant. Used to stamp host-attested ownership on a PTY at spawn. */
+  clientInstanceIdFor(clientId: number): string | null {
+    return this.session.activeClientInstanceId(String(clientId))
+  }
+
   openDelivery(
     clientId: number,
     id: string,

--- a/src/shared/foreground-process-evidence.ts
+++ b/src/shared/foreground-process-evidence.ts
@@ -7,7 +7,15 @@ export type ForegroundEvidenceObservation = {
 }
 
 export type ForegroundProcessEvidence =
-  | ({ verdict: 'live'; processName: string | null } & ForegroundEvidenceObservation)
+  | ({
+      verdict: 'live'
+      processName: string | null
+      /** True only when the host observed the PTY's own shell owning the terminal's foreground
+       *  process group — i.e. nothing is running in the pane. False means something IS running,
+       *  named or not. Absent from a host that predates the field, which is neither: a reader
+       *  deciding whether the pane is idle must require `true` and defer on anything else. */
+      shellIsForeground?: boolean
+    } & ForegroundEvidenceObservation)
   | ({ verdict: 'unverifiable'; reason: string } & ForegroundEvidenceObservation)
 
 export function isForegroundProcessEvidence(value: unknown): value is ForegroundProcessEvidence {
@@ -30,6 +38,9 @@ export function isForegroundProcessEvidence(value: unknown): value is Foreground
     return false
   }
   if (input.verdict === 'live') {
+    if (input.shellIsForeground !== undefined && typeof input.shellIsForeground !== 'boolean') {
+      return false
+    }
     return input.processName === null || typeof input.processName === 'string'
   }
   return (

--- a/src/shared/foreground-process-evidence.ts
+++ b/src/shared/foreground-process-evidence.ts
@@ -2,7 +2,14 @@
 export type ForegroundEvidenceObservation = {
   authorityGeneration: string
   observationEpoch: number
-  /** Age at serialization; receivers rebase this onto their monotonic clock. */
+  /** How old the underlying process-table capture was when this record was serialized, measured on
+   *  the OBSERVING host's clock so no clock skew enters it. Receivers rebase it onto their own
+   *  monotonic clock by adding the time since the carrying response arrived.
+   *
+   *  It is an upper bound, not an estimate: the capture is TTL-shared, so a reader may be served
+   *  one up to `PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS` older than its own await, and the
+   *  producer stamps for that worst case. Erring old is the safe direction for every consumer —
+   *  the only one that acts destructively refuses stale evidence. */
   capturedAgeMs: number
 }
 
@@ -10,11 +17,19 @@ export type ForegroundProcessEvidence =
   | ({
       verdict: 'live'
       processName: string | null
-      /** True only when the host observed the PTY's own shell owning the terminal's foreground
-       *  process group — i.e. nothing is running in the pane. False means something IS running,
-       *  named or not. Absent from a host that predates the field, which is neither: a reader
-       *  deciding whether the pane is idle must require `true` and defer on anything else. */
-      shellIsForeground?: boolean
+      /** True only when the host observed every process group attached to this PTY's terminal to be
+       *  the shell's own, with none of them stopped — i.e. nothing is running in the pane, in the
+       *  foreground OR the background, and nothing sits suspended.
+       *
+       *  Deliberately not `tpgid === pgid`: a job the user backgrounded with `&` and a job the user
+       *  suspended with Ctrl-Z both hand the terminal back to the shell, so a foreground-only
+       *  predicate reads them as idle. This one is measured against the same set of process groups
+       *  a forced stop would SIGKILL.
+       *
+       *  False means something IS running, named or not. Absent from a host that predates the
+       *  field, which is neither: a reader deciding whether the pane is idle must require `true`
+       *  and defer on anything else. */
+      shellOwnsEveryTtyProcessGroup?: boolean
     } & ForegroundEvidenceObservation)
   | ({ verdict: 'unverifiable'; reason: string } & ForegroundEvidenceObservation)
 
@@ -38,7 +53,10 @@ export function isForegroundProcessEvidence(value: unknown): value is Foreground
     return false
   }
   if (input.verdict === 'live') {
-    if (input.shellIsForeground !== undefined && typeof input.shellIsForeground !== 'boolean') {
+    if (
+      input.shellOwnsEveryTtyProcessGroup !== undefined &&
+      typeof input.shellOwnsEveryTtyProcessGroup !== 'boolean'
+    ) {
       return false
     }
     return input.processName === null || typeof input.processName === 'string'

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -364,6 +364,11 @@ const processTableReader = createProcessTableSnapshotReader<ProcessTableCapture>
   now: () => Date.now()
 })
 
+/** How much older than its own await a snapshot from the shared reader may be. The reader serves a
+ *  capture from its TTL cache, so a caller that needs to state the observation's age must assume
+ *  this whole window rather than the instant its await settled. */
+export const PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS = DEFAULT_SNAPSHOT_TTL_MS
+
 /**
  * Run (or reuse a recent) `ps -axo` process-table scan and return
  * its parsed rows. Per-process singleton: the relay and local main processes

--- a/src/shared/pty-consumer-session.ts
+++ b/src/shared/pty-consumer-session.ts
@@ -153,6 +153,15 @@ export class PtyConsumerSession {
     return client?.state === 'active' ? client.grant : null
   }
 
+  /** The authenticated client identity behind an active connection, or null.
+   *
+   *  Why the host reads it here instead of taking a spawn parameter: this is what makes a later
+   *  "this PTY belongs to you" attestation evidence rather than an echo of what a caller claimed. */
+  activeClientInstanceId(connectionId: string): string | null {
+    const client = this.clients.get(connectionId)
+    return client?.state === 'active' ? client.clientInstanceId : null
+  }
+
   private admissionFor(
     client: ClientRecord,
     displacedOwner?: Readonly<PtyConsumerDisplacedOwner>

--- a/src/shared/ssh-relay-pty-ownership-proof.test.ts
+++ b/src/shared/ssh-relay-pty-ownership-proof.test.ts
@@ -1,6 +1,7 @@
 // #9819. Every case here is the same question asked from a different angle: can this client PROVE
 // the host is holding a process nobody can reach? A "no" has to mean "leave it running".
 import { describe, expect, it } from 'vitest'
+import type { ForegroundProcessEvidence } from './foreground-process-evidence'
 import {
   planRelayPtySweep,
   RELAY_PTY_SWEEP_MAX_PER_PASS,
@@ -11,6 +12,13 @@ import {
 
 const OURS = 'client-instance-ours'
 
+const OBSERVATION = { authorityGeneration: 'gen-1', observationEpoch: 1, capturedAgeMs: 0 }
+
+/** The host looked at the pane and saw its own shell owning the terminal: nothing is running. */
+function idleShell(): ForegroundProcessEvidence {
+  return { ...OBSERVATION, verdict: 'live', processName: null, shellIsForeground: true }
+}
+
 function orphan(overrides: Partial<RelayPtyOwnershipEvidence> = {}): RelayPtyOwnershipEvidence {
   return {
     ptyId: 'pty-1',
@@ -18,6 +26,7 @@ function orphan(overrides: Partial<RelayPtyOwnershipEvidence> = {}): RelayPtyOwn
     ownerClientInstanceId: OURS,
     hostAgeMs: RELAY_PTY_SWEEP_MIN_AGE_MS * 2,
     paneBound: true,
+    foregroundProcessEvidence: idleShell(),
     ...overrides
   }
 }
@@ -27,6 +36,7 @@ function context(overrides: Partial<RelayPtySweepContext> = {}): RelayPtySweepCo
     clientInstanceId: OURS,
     isSessionOwner: true,
     routedPtyIds: new Set<string>(),
+    expiredLeasePtyIds: new Set<string>(),
     minimumHostAgeMs: RELAY_PTY_SWEEP_MIN_AGE_MS,
     ...overrides
   }
@@ -48,6 +58,76 @@ describe('planRelayPtySweep', () => {
 
     expect(plan.sweep).toEqual([])
     expect(reasonFor(plan, 'pty-1')).toBe('this client still has a route to it')
+  })
+
+  it('never sweeps a PTY whose lease this client expired without ordering a stop', () => {
+    // `expired` is what supersedeSiblingLeasesForPane, a reattach that failed on the transport, and
+    // a pane whose surface left the layout all write, and every one of them deliberately leaves the
+    // remote process running. Losing our handle is `unverifiable`; it is not abandonment.
+    const plan = planRelayPtySweep([orphan()], context({ expiredLeasePtyIds: new Set(['pty-1']) }))
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('this client expired its lease without ordering a stop')
+  })
+
+  it('never sweeps a pane the host observes running a named foreground process', () => {
+    // The hand-launched agent: the user typed `claude` in a pane, so Orca registered no agent
+    // session and agentSessionOwners is empty. Only the host's own observation can see it.
+    const plan = planRelayPtySweep(
+      [
+        orphan({
+          foregroundProcessEvidence: {
+            ...OBSERVATION,
+            verdict: 'live',
+            processName: 'claude',
+            shellIsForeground: false
+          }
+        })
+      ],
+      context()
+    )
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('host observes a named foreground process')
+  })
+
+  it('never sweeps a pane whose foreground group is not the shell, even unnamed', () => {
+    // A build, a test run, an editor: nothing recognizes it, but the host can still see that the
+    // terminal's foreground process group is not the shell's own.
+    const plan = planRelayPtySweep(
+      [
+        orphan({
+          foregroundProcessEvidence: {
+            ...OBSERVATION,
+            verdict: 'live',
+            processName: null,
+            shellIsForeground: false
+          }
+        })
+      ],
+      context()
+    )
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('host does not attest an idle shell')
+  })
+
+  it('never sweeps when the host could not observe the pane at all', () => {
+    const plan = planRelayPtySweep(
+      [
+        orphan({
+          foregroundProcessEvidence: {
+            ...OBSERVATION,
+            verdict: 'unverifiable',
+            reason: 'table_unreadable'
+          }
+        })
+      ],
+      context()
+    )
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('host could not observe the pane foreground process')
   })
 
   it('never sweeps a PTY the host attributes to another client instance', () => {
@@ -136,6 +216,29 @@ describe('planRelayPtySweep', () => {
 
       expect(plan.sweep).toEqual([])
       expect(reasonFor(plan, 'pty-1')).toBe('not a pane-bound PTY')
+    })
+
+    it('skips an entry with no foreground observation', () => {
+      const { foregroundProcessEvidence: _absent, ...legacy } = orphan()
+
+      const plan = planRelayPtySweep([legacy], context())
+
+      expect(plan.sweep).toEqual([])
+      expect(reasonFor(plan, 'pty-1')).toBe('host published no foreground-process observation')
+    })
+
+    it('skips an entry from a host that observes the pane but cannot say the shell is idle', () => {
+      const plan = planRelayPtySweep(
+        [
+          orphan({
+            foregroundProcessEvidence: { ...OBSERVATION, verdict: 'live', processName: null }
+          })
+        ],
+        context()
+      )
+
+      expect(plan.sweep).toEqual([])
+      expect(reasonFor(plan, 'pty-1')).toBe('host does not attest an idle shell')
     })
 
     it('skips an entry with no incarnation, so no stop is ever unfenced', () => {

--- a/src/shared/ssh-relay-pty-ownership-proof.test.ts
+++ b/src/shared/ssh-relay-pty-ownership-proof.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import type { ForegroundProcessEvidence } from './foreground-process-evidence'
 import {
   planRelayPtySweep,
+  RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS,
   RELAY_PTY_SWEEP_MAX_PER_PASS,
   RELAY_PTY_SWEEP_MIN_AGE_MS,
   type RelayPtyOwnershipEvidence,
@@ -16,7 +17,7 @@ const OBSERVATION = { authorityGeneration: 'gen-1', observationEpoch: 1, capture
 
 /** The host looked at the pane and saw its own shell owning the terminal: nothing is running. */
 function idleShell(): ForegroundProcessEvidence {
-  return { ...OBSERVATION, verdict: 'live', processName: null, shellIsForeground: true }
+  return { ...OBSERVATION, verdict: 'live', processName: null, shellOwnsEveryTtyProcessGroup: true }
 }
 
 function orphan(overrides: Partial<RelayPtyOwnershipEvidence> = {}): RelayPtyOwnershipEvidence {
@@ -38,6 +39,8 @@ function context(overrides: Partial<RelayPtySweepContext> = {}): RelayPtySweepCo
     routedPtyIds: new Set<string>(),
     expiredLeasePtyIds: new Set<string>(),
     minimumHostAgeMs: RELAY_PTY_SWEEP_MIN_AGE_MS,
+    evidenceAgeSinceListingMs: 0,
+    maximumEvidenceAgeMs: RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS,
     ...overrides
   }
 }
@@ -80,7 +83,7 @@ describe('planRelayPtySweep', () => {
             ...OBSERVATION,
             verdict: 'live',
             processName: 'claude',
-            shellIsForeground: false
+            shellOwnsEveryTtyProcessGroup: false
           }
         })
       ],
@@ -101,7 +104,7 @@ describe('planRelayPtySweep', () => {
             ...OBSERVATION,
             verdict: 'live',
             processName: null,
-            shellIsForeground: false
+            shellOwnsEveryTtyProcessGroup: false
           }
         })
       ],

--- a/src/shared/ssh-relay-pty-ownership-proof.test.ts
+++ b/src/shared/ssh-relay-pty-ownership-proof.test.ts
@@ -1,0 +1,159 @@
+// #9819. Every case here is the same question asked from a different angle: can this client PROVE
+// the host is holding a process nobody can reach? A "no" has to mean "leave it running".
+import { describe, expect, it } from 'vitest'
+import {
+  planRelayPtySweep,
+  RELAY_PTY_SWEEP_MAX_PER_PASS,
+  RELAY_PTY_SWEEP_MIN_AGE_MS,
+  type RelayPtyOwnershipEvidence,
+  type RelayPtySweepContext
+} from './ssh-relay-pty-ownership-proof'
+
+const OURS = 'client-instance-ours'
+
+function orphan(overrides: Partial<RelayPtyOwnershipEvidence> = {}): RelayPtyOwnershipEvidence {
+  return {
+    ptyId: 'pty-1',
+    incarnationId: 'inc-1',
+    ownerClientInstanceId: OURS,
+    hostAgeMs: RELAY_PTY_SWEEP_MIN_AGE_MS * 2,
+    paneBound: true,
+    ...overrides
+  }
+}
+
+function context(overrides: Partial<RelayPtySweepContext> = {}): RelayPtySweepContext {
+  return {
+    clientInstanceId: OURS,
+    isSessionOwner: true,
+    routedPtyIds: new Set<string>(),
+    minimumHostAgeMs: RELAY_PTY_SWEEP_MIN_AGE_MS,
+    ...overrides
+  }
+}
+
+function reasonFor(plan: ReturnType<typeof planRelayPtySweep>, ptyId: string): string | undefined {
+  return plan.skipped.find((entry) => entry.ptyId === ptyId)?.reason
+}
+
+describe('planRelayPtySweep', () => {
+  it('sweeps a pane PTY this host attests we created and we have lost every route to', () => {
+    const plan = planRelayPtySweep([orphan()], context())
+
+    expect(plan.sweep).toEqual([{ ptyId: 'pty-1', incarnationId: 'inc-1' }])
+  })
+
+  it('never sweeps a PTY this client still routes to', () => {
+    const plan = planRelayPtySweep([orphan()], context({ routedPtyIds: new Set(['pty-1']) }))
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('this client still has a route to it')
+  })
+
+  it('never sweeps a PTY the host attributes to another client instance', () => {
+    // The case that makes local absence useless as evidence: a second machine on the same build
+    // connects to the same relay, and its live agents are missing from our store exactly like an
+    // orphan is.
+    const plan = planRelayPtySweep(
+      [orphan({ ownerClientInstanceId: 'client-instance-theirs' })],
+      context()
+    )
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('host attests another client created it')
+  })
+
+  it('never sweeps a PTY younger than the floor', () => {
+    const plan = planRelayPtySweep(
+      [orphan({ hostAgeMs: RELAY_PTY_SWEEP_MIN_AGE_MS - 1 })],
+      context()
+    )
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('younger than the sweep floor')
+  })
+
+  it('never sweeps a bare host shell', () => {
+    const plan = planRelayPtySweep([orphan({ paneBound: false })], context())
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('not a pane-bound PTY')
+  })
+
+  it('never sweeps a PTY whose agent session the host still advertises as adoptable', () => {
+    const plan = planRelayPtySweep(
+      [orphan({ agentSessionOwners: [{ ptyId: 'pty-1' }] })],
+      context()
+    )
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('host still advertises an adoptable agent session')
+  })
+
+  it('never sweeps without the negotiated session-owner grant', () => {
+    const plan = planRelayPtySweep([orphan()], context({ isSessionOwner: false }))
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('this client does not hold the relay session-owner grant')
+  })
+
+  it('refuses a pass larger than the per-pass ceiling instead of truncating it', () => {
+    const entries = Array.from({ length: RELAY_PTY_SWEEP_MAX_PER_PASS + 1 }, (_, index) =>
+      orphan({ ptyId: `pty-${index}`, incarnationId: `inc-${index}` })
+    )
+
+    const plan = planRelayPtySweep(entries, context())
+
+    expect(plan.sweep).toEqual([])
+    expect(plan.skipped).toHaveLength(entries.length)
+  })
+
+  describe('against a host that predates the attestation', () => {
+    // Mixed versions: every new field is optional, and an older host publishes none of them. The
+    // sweep has to read each absence as "unknown", never as a permissive default.
+    it('skips an entry with no owner attestation', () => {
+      const { ownerClientInstanceId: _absent, ...legacy } = orphan()
+
+      const plan = planRelayPtySweep([legacy], context())
+
+      expect(plan.sweep).toEqual([])
+      expect(reasonFor(plan, 'pty-1')).toBe('host attested no owning client')
+    })
+
+    it('skips an entry with no published age', () => {
+      const { hostAgeMs: _absent, ...legacy } = orphan()
+
+      const plan = planRelayPtySweep([legacy], context())
+
+      expect(plan.sweep).toEqual([])
+      expect(reasonFor(plan, 'pty-1')).toBe('host published no age')
+    })
+
+    it('skips an entry with no paneBound field', () => {
+      const { paneBound: _absent, ...legacy } = orphan()
+
+      const plan = planRelayPtySweep([legacy], context())
+
+      expect(plan.sweep).toEqual([])
+      expect(reasonFor(plan, 'pty-1')).toBe('not a pane-bound PTY')
+    })
+
+    it('skips an entry with no incarnation, so no stop is ever unfenced', () => {
+      const { incarnationId: _absent, ...legacy } = orphan()
+
+      const plan = planRelayPtySweep([legacy], context())
+
+      expect(plan.sweep).toEqual([])
+      expect(reasonFor(plan, 'pty-1')).toBe('host published no PTY incarnation')
+    })
+
+    it('sweeps nothing at all when the whole listing predates the fields', () => {
+      const legacy = [
+        { ptyId: 'pty-1', incarnationId: 'inc-1' },
+        { ptyId: 'pty-2', incarnationId: 'inc-2' }
+      ]
+
+      expect(planRelayPtySweep(legacy, context()).sweep).toEqual([])
+    })
+  })
+})

--- a/src/shared/ssh-relay-pty-ownership-proof.ts
+++ b/src/shared/ssh-relay-pty-ownership-proof.ts
@@ -104,8 +104,9 @@ export const RELAY_PTY_SWEEP_MAX_PER_PASS = 8
 export const RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS = 5_000
 
 /** The host's own answer to "is anything running in this pane?". Only a positive "no" clears the
- *  sweep; every other shape — an older host, an unreadable process table, a named foreground
- *  process, a busy foreground group — is a reason to leave the process alone. */
+ *  sweep; every other shape — an older host, an unreadable process table, an observation too old to
+ *  describe now, a named foreground process, any other process group on the pane's terminal — is a
+ *  reason to leave the process alone. */
 function foregroundSkipReason(
   evidence: ForegroundProcessEvidence | undefined,
   context: RelayPtySweepContext

--- a/src/shared/ssh-relay-pty-ownership-proof.ts
+++ b/src/shared/ssh-relay-pty-ownership-proof.ts
@@ -1,0 +1,144 @@
+/** Which relay PTYs a client may prove it orphaned, and therefore may stop (#9819).
+ *
+ *  A relay PTY is a child of the detached relay daemon. Stopping one destroys a running process —
+ *  often a running agent — on the user's remote machine, and the relay's 50-slot cap is a far
+ *  cheaper failure than that. So every rule below is written to answer "can this client PROVE
+ *  nobody owns this?" and to answer "no" whenever it cannot.
+ *
+ *  The rule #9819 proposed — "pane-bound and the app no longer owns or leases it" — is not that
+ *  proof. Absence from a client-side set is `unverifiable` by construction
+ *  (`docs/reference/ssh-execution-boundary.md`): a second machine running the same Orca build
+ *  connects to the SAME relay and displaces the session owner, and its PTYs are missing from THIS
+ *  client's store for exactly the same reason a genuine orphan is. Sweeping on local absence alone
+ *  would let one laptop reap another laptop's live agents.
+ *
+ *  What replaces it: the host itself records which authenticated consumer identity asked it to
+ *  create each PTY, and publishes that back. A PTY is sweepable only when the OWNING HOST names
+ *  this client as its creator and this client's own durable state has no route to it. Both halves
+ *  are required; either alone is a guess.
+ */
+
+/** One `pty.listProcesses` entry, as far as this decision is concerned. Every field a host may
+ *  omit is optional here, because a host predating it publishes nothing rather than a default. */
+export type RelayPtyOwnershipEvidence = {
+  /** Relay-scoped PTY id. */
+  ptyId: string
+  incarnationId?: string
+  ownerClientInstanceId?: string
+  hostAgeMs?: number
+  paneBound?: boolean
+  /** Non-empty when the host still advertises an adoptable agent session on this PTY. */
+  agentSessionOwners?: readonly unknown[]
+}
+
+export type RelayPtySweepContext = {
+  /** This client's persisted consumer identity for the target. */
+  clientInstanceId: string
+  /** Whether the relay granted THIS connection the `session-owner` role. A subscriber, or a client
+   *  that fell back to the unnegotiated legacy path, never sweeps. */
+  isSessionOwner: boolean
+  /** Every relay PTY id this client still has any route to: a live provider PTY, a lease it has
+   *  not tombstoned, an id it just reattached, or a stop it has recorded and not yet delivered. */
+  routedPtyIds: ReadonlySet<string>
+  /** Host-measured age a PTY must exceed. Guards a spawn that is in flight from another window of
+   *  this same client and has not written its lease yet. */
+  minimumHostAgeMs: number
+}
+
+export type RelayPtySweepTarget = { ptyId: string; incarnationId: string }
+
+export type RelayPtySweepSkip = { ptyId: string; reason: string }
+
+export type RelayPtySweepPlan = {
+  sweep: RelayPtySweepTarget[]
+  skipped: RelayPtySweepSkip[]
+}
+
+/** Deliberately longer than any single connect round trip. A PTY younger than this is never worth
+ *  the risk: the leak it represents costs one slot for 30 more seconds, and reaping a shell that a
+ *  concurrent spawn is still recording costs the user a terminal. */
+export const RELAY_PTY_SWEEP_MIN_AGE_MS = 30_000
+
+/** Bounds one pass. A relay is capped at 50 PTYs, so a pass that wants to stop more than this is
+ *  not reclaiming a leak — it is a disagreement about ownership, and stopping is the wrong move. */
+export const RELAY_PTY_SWEEP_MAX_PER_PASS = 8
+
+function skipReason(
+  entry: RelayPtyOwnershipEvidence,
+  context: RelayPtySweepContext
+): string | null {
+  if (typeof entry.incarnationId !== 'string' || entry.incarnationId.length === 0) {
+    // Without the host's own incarnation there is no fence, and an unfenced stop aimed at a relay
+    // id can hit whatever holds that id by the time it lands.
+    return 'host published no PTY incarnation'
+  }
+  if (typeof entry.ownerClientInstanceId !== 'string' || entry.ownerClientInstanceId.length === 0) {
+    return 'host attested no owning client'
+  }
+  if (entry.ownerClientInstanceId !== context.clientInstanceId) {
+    return 'host attests another client created it'
+  }
+  if (entry.paneBound !== true) {
+    // Covers both a bare host shell (a remote CLI terminal nobody's pane owns) and a host that
+    // never published the field. Neither is a pane this client lost.
+    return 'not a pane-bound PTY'
+  }
+  if (entry.agentSessionOwners !== undefined && entry.agentSessionOwners.length > 0) {
+    // The host still advertises this session as adoptable, so a later spawn can reclaim the running
+    // agent. Reaping it converts a recoverable session into a destroyed one.
+    return 'host still advertises an adoptable agent session'
+  }
+  if (typeof entry.hostAgeMs !== 'number' || !Number.isFinite(entry.hostAgeMs)) {
+    return 'host published no age'
+  }
+  if (entry.hostAgeMs < context.minimumHostAgeMs) {
+    return 'younger than the sweep floor'
+  }
+  if (context.routedPtyIds.has(entry.ptyId)) {
+    return 'this client still has a route to it'
+  }
+  return null
+}
+
+/** Plans one sweep pass. Pure: every input is evidence the caller already gathered, so the rule can
+ *  be tested without a relay, and the irreversible call sits with the caller. */
+export function planRelayPtySweep(
+  entries: readonly RelayPtyOwnershipEvidence[],
+  context: RelayPtySweepContext
+): RelayPtySweepPlan {
+  if (!context.isSessionOwner || !context.clientInstanceId) {
+    return {
+      sweep: [],
+      skipped: entries.map((entry) => ({
+        ptyId: entry.ptyId,
+        reason: 'this client does not hold the relay session-owner grant'
+      }))
+    }
+  }
+  const sweep: RelayPtySweepTarget[] = []
+  const skipped: RelayPtySweepSkip[] = []
+  for (const entry of entries) {
+    const reason = skipReason(entry, context)
+    if (reason !== null) {
+      skipped.push({ ptyId: entry.ptyId, reason })
+    } else {
+      sweep.push({ ptyId: entry.ptyId, incarnationId: entry.incarnationId as string })
+    }
+  }
+  if (sweep.length > RELAY_PTY_SWEEP_MAX_PER_PASS) {
+    // Why refuse rather than truncate: at this size the disagreement is about ownership, not about
+    // a handful of leaked slots, and a truncated pass would work through the same list one connect
+    // at a time and destroy it all anyway.
+    return {
+      sweep: [],
+      skipped: [
+        ...skipped,
+        ...sweep.map((target) => ({
+          ptyId: target.ptyId,
+          reason: `refusing a ${sweep.length}-PTY sweep; over the ${RELAY_PTY_SWEEP_MAX_PER_PASS} per-pass ceiling`
+        }))
+      ]
+    }
+  }
+  return { sweep, skipped }
+}

--- a/src/shared/ssh-relay-pty-ownership-proof.ts
+++ b/src/shared/ssh-relay-pty-ownership-proof.ts
@@ -1,3 +1,5 @@
+import type { ForegroundProcessEvidence } from './foreground-process-evidence'
+
 /** Which relay PTYs a client may prove it orphaned, and therefore may stop (#9819).
  *
  *  A relay PTY is a child of the detached relay daemon. Stopping one destroys a running process —
@@ -29,6 +31,11 @@ export type RelayPtyOwnershipEvidence = {
   paneBound?: boolean
   /** Non-empty when the host still advertises an adoptable agent session on this PTY. */
   agentSessionOwners?: readonly unknown[]
+  /** What the OWNING host saw in the pane on the same listing. This answers a different question
+   *  from `agentSessionOwners`: that one asks whether Orca REGISTERED an agent session here, this
+   *  one asks whether anything at all is running. A `claude` the user typed by hand registers
+   *  nothing, so only this can see it. */
+  foregroundProcessEvidence?: ForegroundProcessEvidence
 }
 
 export type RelayPtySweepContext = {
@@ -40,6 +47,15 @@ export type RelayPtySweepContext = {
   /** Every relay PTY id this client still has any route to: a live provider PTY, a lease it has
    *  not tombstoned, an id it just reattached, or a stop it has recorded and not yet delivered. */
   routedPtyIds: ReadonlySet<string>
+  /** Relay PTY ids this client holds an `expired` lease for.
+   *
+   *  Separate from {@link routedPtyIds} because it is a different fact with the same verdict: an
+   *  expired lease records that THIS CLIENT lost its handle — a pane re-leased under a new relay
+   *  id, a reattach that failed on the transport, a pane surface that is no longer in the layout.
+   *  Every one of those writers deliberately declines to stop the remote process, and client-side
+   *  absence is `unverifiable` by construction (`docs/reference/ssh-execution-boundary.md`). So an
+   *  expired lease is the record of a process left running on purpose, never a licence to kill it. */
+  expiredLeasePtyIds: ReadonlySet<string>
   /** Host-measured age a PTY must exceed. Guards a spawn that is in flight from another window of
    *  this same client and has not written its lease yet. */
   minimumHostAgeMs: number
@@ -62,6 +78,31 @@ export const RELAY_PTY_SWEEP_MIN_AGE_MS = 30_000
 /** Bounds one pass. A relay is capped at 50 PTYs, so a pass that wants to stop more than this is
  *  not reclaiming a leak — it is a disagreement about ownership, and stopping is the wrong move. */
 export const RELAY_PTY_SWEEP_MAX_PER_PASS = 8
+
+/** The host's own answer to "is anything running in this pane?". Only a positive "no" clears the
+ *  sweep; every other shape — an older host, an unreadable process table, a named foreground
+ *  process, a busy foreground group — is a reason to leave the process alone. */
+function foregroundSkipReason(evidence: ForegroundProcessEvidence | undefined): string | null {
+  if (evidence === undefined) {
+    // A host that never published it, or a Windows host where it is not collected. Absence of the
+    // observation is not the observation of absence.
+    return 'host published no foreground-process observation'
+  }
+  if (evidence.verdict !== 'live') {
+    return 'host could not observe the pane foreground process'
+  }
+  if (evidence.processName !== null) {
+    // The host named something running in the pane. It registered no agent session, which is
+    // exactly the hand-launched `claude`/`codex` case agentSessionOwners cannot see.
+    return 'host observes a named foreground process'
+  }
+  if (evidence.shellIsForeground !== true) {
+    // Either the terminal's foreground group is not the shell's (something unrecognized is
+    // running - a build, an editor, a test run), or this host predates the field.
+    return 'host does not attest an idle shell'
+  }
+  return null
+}
 
 function skipReason(
   entry: RelayPtyOwnershipEvidence,
@@ -88,6 +129,10 @@ function skipReason(
     // agent. Reaping it converts a recoverable session into a destroyed one.
     return 'host still advertises an adoptable agent session'
   }
+  const foregroundSkip = foregroundSkipReason(entry.foregroundProcessEvidence)
+  if (foregroundSkip !== null) {
+    return foregroundSkip
+  }
   if (typeof entry.hostAgeMs !== 'number' || !Number.isFinite(entry.hostAgeMs)) {
     return 'host published no age'
   }
@@ -96,6 +141,9 @@ function skipReason(
   }
   if (context.routedPtyIds.has(entry.ptyId)) {
     return 'this client still has a route to it'
+  }
+  if (context.expiredLeasePtyIds.has(entry.ptyId)) {
+    return 'this client expired its lease without ordering a stop'
   }
   return null
 }

--- a/src/shared/ssh-relay-pty-ownership-proof.ts
+++ b/src/shared/ssh-relay-pty-ownership-proof.ts
@@ -51,14 +51,25 @@ export type RelayPtySweepContext = {
    *
    *  Separate from {@link routedPtyIds} because it is a different fact with the same verdict: an
    *  expired lease records that THIS CLIENT lost its handle — a pane re-leased under a new relay
-   *  id, a reattach that failed on the transport, a pane surface that is no longer in the layout.
-   *  Every one of those writers deliberately declines to stop the remote process, and client-side
-   *  absence is `unverifiable` by construction (`docs/reference/ssh-execution-boundary.md`). So an
-   *  expired lease is the record of a process left running on purpose, never a licence to kill it. */
+   *  id, a pane surface that is no longer in the layout, a retired reattach. The layout case is the
+   *  one that matters most, because it is reached only AFTER `pty.attach` succeeded: the process is
+   *  not merely unproven, it is known to be alive. Every one of those writers deliberately declines
+   *  to stop it, and client-side absence is `unverifiable` by construction
+   *  (`docs/reference/ssh-execution-boundary.md`). So an expired lease is the record of a process
+   *  left running on purpose, never a licence to kill it. */
   expiredLeasePtyIds: ReadonlySet<string>
   /** Host-measured age a PTY must exceed. Guards a spawn that is in flight from another window of
    *  this same client and has not written its lease yet. */
   minimumHostAgeMs: number
+  /** How long ago, on THIS client's clock, the listing that carried the evidence arrived. Added to
+   *  each entry's host-stamped `capturedAgeMs` so {@link maximumEvidenceAgeMs} bounds staleness at
+   *  the moment of the decision rather than at the moment of serialization. The transit itself is
+   *  unmeasured — the two clocks are not synchronized — but it is bounded by the listing's own RPC
+   *  deadline, and both halves that ARE measurable are counted. */
+  evidenceAgeSinceListingMs: number
+  /** Oldest foreground observation that may authorize a stop. Stale evidence degrades to "do not
+   *  sweep", never to "sweep". */
+  maximumEvidenceAgeMs: number
 }
 
 export type RelayPtySweepTarget = { ptyId: string; incarnationId: string }
@@ -79,14 +90,35 @@ export const RELAY_PTY_SWEEP_MIN_AGE_MS = 30_000
  *  not reclaiming a leak — it is a disagreement about ownership, and stopping is the wrong move. */
 export const RELAY_PTY_SWEEP_MAX_PER_PASS = 8
 
+/** The oldest foreground observation this sweep will treat as authorization to SIGKILL.
+ *
+ *  Sized to the pass budget rather than to the 30s spawn floor: those answer different questions.
+ *  The floor guards a concurrent spawn this client has not recorded yet; this one guards the pane
+ *  the user started working in AFTER the host looked. An observation older than the whole pass it
+ *  is meant to authorize cannot have been taken for this pass, so it is not evidence about now.
+ *
+ *  It does not remove the race — nothing can, the host cannot re-check between the answer and the
+ *  signal — it bounds it. The display consumer of the same measurement deliberately keeps NO age
+ *  budget: a stale pane title costs a redraw and self-corrects on the next poll, so one truthful
+ *  number carries two explicit budgets rather than one implicit one. */
+export const RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS = 5_000
+
 /** The host's own answer to "is anything running in this pane?". Only a positive "no" clears the
  *  sweep; every other shape — an older host, an unreadable process table, a named foreground
  *  process, a busy foreground group — is a reason to leave the process alone. */
-function foregroundSkipReason(evidence: ForegroundProcessEvidence | undefined): string | null {
+function foregroundSkipReason(
+  evidence: ForegroundProcessEvidence | undefined,
+  context: RelayPtySweepContext
+): string | null {
   if (evidence === undefined) {
     // A host that never published it, or a Windows host where it is not collected. Absence of the
     // observation is not the observation of absence.
     return 'host published no foreground-process observation'
+  }
+  // Before anything is read out of it: an observation is only a claim about the instant it was
+  // taken. Age is checked on both verdicts because a stale `unverifiable` is no better.
+  if (evidence.capturedAgeMs + context.evidenceAgeSinceListingMs > context.maximumEvidenceAgeMs) {
+    return 'host foreground observation is too old to authorize a stop'
   }
   if (evidence.verdict !== 'live') {
     return 'host could not observe the pane foreground process'
@@ -96,9 +128,10 @@ function foregroundSkipReason(evidence: ForegroundProcessEvidence | undefined): 
     // exactly the hand-launched `claude`/`codex` case agentSessionOwners cannot see.
     return 'host observes a named foreground process'
   }
-  if (evidence.shellIsForeground !== true) {
-    // Either the terminal's foreground group is not the shell's (something unrecognized is
-    // running - a build, an editor, a test run), or this host predates the field.
+  if (evidence.shellOwnsEveryTtyProcessGroup !== true) {
+    // Something other than the shell's own process group is attached to the pane's terminal — a
+    // foreground command, a job backgrounded with `&`, a Ctrl-Z'd editor — or this host predates
+    // the field. The stop would SIGKILL that group, so none of those is a pane to reclaim.
     return 'host does not attest an idle shell'
   }
   return null
@@ -129,7 +162,7 @@ function skipReason(
     // agent. Reaping it converts a recoverable session into a destroyed one.
     return 'host still advertises an adoptable agent session'
   }
-  const foregroundSkip = foregroundSkipReason(entry.foregroundProcessEvidence)
+  const foregroundSkip = foregroundSkipReason(entry.foregroundProcessEvidence, context)
   if (foregroundSkip !== null) {
     return foregroundSkip
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1058 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​45 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1013 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​349 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​322 |

<!-- /orca-pr-loc -->

> Stacked on #17831, which is **do-not-merge** without this. Retarget to `main` once that merges.

Two paths where the orphan sweep shut down a live user process, plus a third — a harness defect that made six of #17831's seven session-level tests pass for the wrong reason.

## Defect 1 — an expired lease licensed the sweep

**Rule: an `expired` lease is `unverifiable`, never `exited`.** It records that *this client* lost its handle; it is never host evidence about the process. It now gets its own named skip, deliberately separate from `routedPtyIds` so the log says *why*.

All four writers of `expired` decline to stop the process on purpose:
- `supersedeSiblingLeasesForPane` — *"the remote process is deliberately left running"*
- **the missing-surface refusal (`restoreReattachedPtyRuntime` → `'missing-surface'`, `ssh-relay-session.ts:2717`) — a second, independent instance of the same kill,** and the worst one, because it is reached **only after `pty.attach` already succeeded**. The process is not merely unproven there, it is *known live*. Its own comment says so: *"Topology absence alone is not authority to kill a process"*. The lease is expired, ownership is deleted, and the next connect has no route.
- `handlePtyReattachFailure` (`ssh-relay-session.ts:2845`) — reached only when `isSshPtyNotFoundError(error)`, i.e. the host itself answered "absent"
- `suppressRetiredReattachedPty`, which already routes via `pendingKill`

**Correction to an earlier revision of this description.** It claimed `handlePtyReattachFailure` ("dropStalePty") was reached by a reattach that failed on the *transport*. It is not: `:2820` early-returns with `reattachAttemptsExhausted` for anything that is not `isSshPtyNotFoundError`, so a pure transport sever leaves the lease `attached` — routed, and never swept. The real live-process path is the missing-surface one above. The code comments that repeated the same mistake are corrected in this PR.

`terminated` was checked and is fine: every writer is a host-reported exit, a confirmed ordered stop, or dispose.

## Defect 2 — `agentSessionOwners` ≠ "an agent is running here"

The sweep now requires the host to **positively attest an idle shell**, with four gates: field absent → skip; `verdict: 'unverifiable'` → skip; a named foreground process → skip; the host does not attest an idle shell → skip.

**One correction to my brief.** Published `foregroundProcessEvidence` alone was *not* sufficient. `processName` is non-null only for a **recognized agent**, so `verdict: 'live', processName: null` covers both "idle prompt" and "running `vim` / `npm test` / a build". Gating on `processName` would have closed the hand-launched-`claude` hole and left every *unrecognized* foreground process sweepable — still a kill.

So `shellIsForeground` (`root.tpgid === root.pgid`) was added to `ForegroundProcessEvidence` — a value `resolveAgentForegroundProcessesFromIndex` already computed and threw away. Purely additive optional field: old hosts omit it and the sweep defers, old clients ignore it. **Windows relay hosts publish no evidence at all, so they now never sweep** — fail-safe, and worth knowing.

## Defect 3 — the harness hid the other two

**This is the most valuable finding, and it is a test defect.**

`claimSshPtyConsumerRecovery` mints a fresh `randomUUID()` whenever asked for a target it already holds a live in-memory entry for. `ssh-relay-session-orphan-sweep.test.ts` used one shared `TARGET`, so **every `establish()` after the first ran under an identity matching no attestation and skipped everything for the wrong reason.**

Verified directly: with the shared target, an entry with **no lease at all** produced `{ list: 1, stops: 0 }` — the positive control had silently stopped working. Six of seven tests were vacuous.

Fixed with one target per test plus two guards inside `establish()`: the pass must have run, and no identity-minting warning may have fired. Reinstating the shared target now fails loudly (6 failures).

## Revert matrix — every gate verified by removing it

```
DEFECT 1 REVERTED   4 failed | 37 passed
DEFECT 2 REVERTED   8 failed | 33 passed
HARNESS REVERTED    6 failed |  1 passed
BUDGET REVERTED     1 failed | 14 passed
MINT-LOG REVERTED   1 failed |  1 passed
RESTORED            41 passed (3 files)
```

## Connect budget

One absolute `RELAY_PTY_SWEEP_PASS_BUDGET_MS = 5_000` covers the listing **and** the stops — the brief named only `listProcesses`, but up to eight `shutdown` RPCs were also untimed on the connect path. Overrun is an empty pass, never a connect failure.

## `clientInstanceId` re-minting: logged, deliberately NOT stabilized

Stabilizing it would create a **new mass-kill path**. The id doubles as the consumer session's ownership identity, and reusing it without the `clientGeneration`/`ownerGeneration` the same dropped record carried would replay a stale owner generation at the relay. Worse, `disposeAndPersist` marks *every* lease `terminated` without ordering any stop — harmless today only because dispose also forgets the recovery record. **Stabilizing the id without first fixing that write would turn reconnect into a mass kill.** Recorded here so the next person doesn't "fix" the churn into a disaster.

## Verification

`pnpm tc` clean; `check:code-quality:changed` 0 new findings across 17 files; `src/main/ssh` + `src/main/providers` + `src/relay` + `src/shared` all green (2650 / 1557 / 8052). All nine original conditions still hold; none weakened.

## Three more blockers, all reproduced rather than reasoned about

### Blocker A — `shellIsForeground` could not see background or stopped work

`tpgid === pgid` is a **foreground-only** predicate, and the two states it cannot see are the two most expensive to get wrong. Measured on a real `bash -i` on a real pty in `debian:bookworm-slim`:

| pane state | shell's own `ps` row |
| --- | --- |
| idle | `3150 1 3150 3150 Ss+ bash -i` |
| `sleep 300 &` | `3152 1 3152 3152 Ss+ bash -i` |
| `sleep 300` + Ctrl-Z | `3158 1 3158 3158 Ss+ bash -i` |

Same shape in all three: leads its own group, owns the terminal, `Ss+`. Only the *job's* row differs — `pgid=3153 tpgid=3152 S` backgrounded, `pgid=3159 tpgid=3158 T` suspended. So `pnpm build &`, `npm run dev &` and a Ctrl-Z'd editor were each attested idle, and `pty.shutdown({immediate:true})` → `requestForceKill` → `forceKillPosixPtyProcessGroups` SIGKILLs **every process group attached to that tty**.

**Fix:** the evidence now measures the same set the kill does. `shellIsForeground` is replaced by `shellOwnsEveryTtyProcessGroup` — true only when every process group on the pane's terminal is the shell's own and none of them is stopped. No new probe and no new `ps` column: `tpgid` already identifies the terminal, because a process group has one session and a session at most one controlling terminal, so two rows reporting the same live `tpgid` are on the same tty. The index is memoized per capture alongside the existing one.

**Residual, stated rather than hidden:** a shell with job control off (`set +m`) puts a background job in the shell's *own* process group, where this cannot see it — but neither can `forceKillPosixPtyProcessGroups` distinguish it, and that is the honest limit of what a process table can say.

### Blocker B — the kill authorization was the display signal, with a falsified freshness field

`evidenceResults[entryIndex]` produced both the pane **title** and `foregroundProcessEvidence`, the kill authorization: one computation, two consumers, no separate error budget. And the field that exists to bound it was a hardcoded lie — the snapshot is awaited once, before a loop that may await per entry, and every entry was stamped `capturedAgeMs: 0` unconditionally. **It had zero readers anywhere in the tree.**

**Fix:**
- `capturedAgeMs` is now stamped from when the capture was actually taken. It is a deliberate **upper** bound: `getStrictProcessTableSnapshot` serves a TTL-shared table, so a reader can be handed one up to `PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS` older than its own await, and the producer assumes that worst case. Erring old is the safe direction for the only consumer that acts.
- The consumer enforces `RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS`, and adds its own elapsed time since the listing arrived, so the gate bounds staleness at the moment of the **decision** rather than of serialization. Sized to the pass budget, not to the 30s spawn floor — those answer different questions, and the floor's own comment says it guards a concurrent-spawn race.
- Stale evidence degrades to *do not sweep*, never to sweep.
- The display path keeps **no** age budget, now as an explicit decision rather than an accident: a stale pane title costs a redraw and self-corrects on the next poll. One truthful measurement, two stated budgets.

### Blocker C — no host-side authorization on the destructive call

`pty.spawn` and `pty.attach` both take a request context and check it. `pty.shutdown` — the one call that irreversibly destroys a user's running process — took none, so the entire nine-condition ownership rule was enforced **client-side only**. (CodeRabbit's unaddressed "Moderate" note.)

**Fix:** `pty.shutdown` gains an optional `expectedOwnerClientInstanceId`, symmetric with the `expectedIncarnationId` fence already on that call. When present the host refuses unless **both** halves hold: the requesting connection still authenticates as that consumer identity (so a claim cannot simply be asserted — it is read from the live grant, never from the parameter), and this host recorded that same identity as the PTY's creator at spawn (so a caller cannot reach a PTY it never made). The sweep is the only caller that sets it.

**Wire compatibility.** Rule 1 — a new optional param on an existing method; unknown params are stripped. The obligation Rule 1 attaches is discharged explicitly: **no reader requires it.** An ordinary pane teardown omits it and *must*, because a revived PTY carries no attested owner at all and an old host would otherwise refuse stops it is obliged to honour. New client + old host: the field is ignored and the stop behaves exactly as it does today, so this is strictly additive protection, never a new refusal. No new opcode, so Rule 2 does not apply. The relay is build-id-locked to the client, so this skew is not even the normal state — it is handled anyway.

## Defect 4 — an `expired` lease written for a PTY known to be alive

Found while closing the layer-4 residual, and it is a fourth independent route to the same kill.

Three different reattach refusals are minted with the **same** `SSH_SESSION_EXPIRED` message text, and only one of them observed the process. `ssh-pty-errors.ts` says so in terms: `restoreRequired` means *"the PTY is live, only its source stream is not"*. But `spawn-execute.ts` tested that text with `.includes()`, so a live-PTY `restoreRequired` refusal expired the lease **and** deleted the in-memory ownership — between them this client's only record that the remote process exists. `markSshRemotePtyLease` then no-ops if the row is already gone, leaving no trace at all, and the sweep reads a host-attested, route-less, pane-bound shell it has no record of as one it may stop.

**Fix:** the destructive branch keys on `isSshPtyAbsentFromRelayError` — the class that already exists for exactly this distinction and is already used this way in `liveness.ts` — instead of on the message. Both copies of `spawn-execute.ts` (runtime and ipc) are fixed, and both are covered: reverting either one reddens its own test. Being too strict here is self-correcting — a dead lease is retired by the next reattach on real host evidence.

## Verification

`pnpm tc` clean. `check:code-quality:changed`: 0 new findings. No lint disables, no `max-lines` bump, no `@ts-ignore`.

**The load-bearing test.** `ssh-orphan-sweep-pane-state-verdicts.test.ts` is the first test in either PR that spans both halves: it runs the real publisher (`resolveAgentForegroundProcessesBatch` → `toForegroundProcessEvidence`) into the real client reader (`planRelayPtySweep`), over `ps` captured verbatim from the container above. Every other test in this feature asserts on hand-written evidence literals, which is exactly how Blocker A survived review — the literals said what the author believed. Reverting the predicate to `tpgid === pgid` fails **the backgrounded and suspended rows and nothing else**.

**The decisive experiment.** Real `bash -i`, real pty, real `ps`, the real predicate, and — when it says idle — a real group-for-group SIGKILL, then `ps` by pid again:

| scenario | predicate | SIGKILL issued | job pid after |
| --- | --- | --- | --- |
| idle shell | idle | **yes** | — (shell reclaimed, `Zs`) |
| `sleep 300 &` | busy | no | **alive** |
| `sleep 300` + Ctrl-Z | busy | no | **alive** |
| `sleep 300` foreground | busy | no | **alive** |

The first row is the one that matters as much as the other three: the fix does **not** turn the feature into a no-op. That was the open question at the top of this description, and it is now answered by measurement rather than by argument.

## Rebase

Both branches were ~156 commits behind. Rebased onto `main` and checked against `recoverRemoteTerminalRuntime`, which `main` added since — a self-driven reconnect on relay node-pty failure, and therefore a **new sweep trigger that fires exactly when the host is degraded**, exercised by no CI lane. Two things make it safe, and both are now asserted rather than assumed: it only reconnects when `hasLivePtys()` is false, and reattach still routes every leased PTY before the sweep runs, so nothing it reclaimed is a candidate. A host too degraded to read its own process table publishes `verdict: 'unverifiable'`, which is its own verdict and never collapses into "idle" — covered by its own row in the verdict test.

## Still not ready to ship, and not because of code

Every fix here **narrows** the predicate, and all of it has only ever run against mocks. Two things wanted before merge:

1. **A real-host check that the sweep still reaps anything.** `shellIsForeground` has never run against a live `ps` on a relay host. If `tpgid` reads unexpectedly on some shell or platform, the sweep degrades to a permanent no-op, #9819's leak stays open, and **nothing would say so.**
2. **A written decision on the dispose coupling above.**

Also: `RELAY_PTY_SWEEP_MAX_PER_PASS = 8` refuses-rather-than-truncates only *within* a pass; across a reconnect storm the ceiling resets each time. Defensible given the narrowed predicate, but an assumption, not a guarantee.

Refs #9819
