### PR TITLE
fix(remote-terminal): stop three latches that only cleared on an event that could never arrive

### DIFF
--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
@@ -135,11 +135,31 @@ describe('RemoteRuntimePtyRecoveryState', () => {
     expect(state.currentPhase).toBe('disconnected')
     expect(state.isCurrent(epoch)).toBe(false)
     expect(retry).not.toHaveBeenCalled()
+    state.dispose()
+  })
+
+  it('keeps a markDisconnected pane as revivable as the deadline it imitates', async () => {
+    vi.useFakeTimers()
+    const state = new RemoteRuntimePtyRecoveryState()
+    const retry = vi.fn()
+    const epoch = state.begin()
+    state.schedule(epoch, retry)
+
+    state.markDisconnected()
+
+    // Why: the latch stops self-initiated retries only; it must not un-register the pane.
+    await vi.advanceTimersByTimeAsync(300_000)
+    expect(retry).not.toHaveBeenCalled()
+    expect(state.currentPhase).toBe('disconnected')
+
+    expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(1)
+    expect(retry).toHaveBeenCalledWith(epoch + 1)
+    expect(state.currentPhase).toBe('recovering')
+    state.dispose()
   })
 
   it.each([
     ['healthy', (state: RemoteRuntimePtyRecoveryState) => state.markHealthy()],
-    ['disconnected', (state: RemoteRuntimePtyRecoveryState) => state.markDisconnected()],
     ['cancelled', (state: RemoteRuntimePtyRecoveryState) => state.cancel()],
     ['disposed', (state: RemoteRuntimePtyRecoveryState) => state.dispose()]
   ])('removes %s panes from the scheduled recovery registry', (_label, finish) => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
@@ -162,7 +162,11 @@ export class RemoteRuntimePtyRecoveryState {
     if (this.phase === 'disposed') {
       return
     }
-    this.clearTimers()
+    // Why: same latch the deadline arrives at, so it must be equally revivable — stop auto-retry but keep
+    // the parked retry registered for online/resume/reconnect. clearTimers() here would be strictly more
+    // destructive than exhausting the whole recovery budget.
+    this.stopRetryTimer()
+    this.clearDeadlineTimer()
     this.phase = 'disconnected'
     this.onChange?.()
   }

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-pending-host-surface-attach.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-pending-host-surface-attach.test.ts
@@ -212,6 +212,68 @@ describe('initial host-mirror attach against a surface published as pending-hand
     expect(transport.getRecoveryState?.().phase).toBe('recovering')
   })
 
+  it('never reads an empty tab inventory as a closed remote terminal', async () => {
+    let hostRepublished = false
+    runtimeCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'session.tabs.activate' || args.method === 'session.tabs.list') {
+        return Promise.resolve({
+          ok: true,
+          result: hostSessionSnapshot(hostRepublished ? 'ready' : 'absent')
+        })
+      }
+      return Promise.resolve({ ok: true, result: { terminal: { handle: 'duplicate-terminal' } } })
+    })
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onError = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'leaf-1'
+    })
+
+    const connect = transport.connect({ url: '', callbacks: { onError } })
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    // A snapshot with no surface for the tab is a client-side view of a host that may still be
+    // republishing — unknown liveness, so no terminal-closed verdict may be surfaced.
+    expect(onError).not.toHaveBeenCalled()
+
+    hostRepublished = true
+    await vi.advanceTimersByTimeAsync(HOST_SURFACE_ATTACH_WINDOW_MS)
+    await expect(connect).resolves.toMatchObject({ id: 'remote:env-1@@terminal-1' })
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(subscribedTerminalHandles()).toContain('terminal-1')
+  })
+
+  it('keeps a pane whose tab inventory stayed empty revivable instead of latching an error', async () => {
+    runtimeCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'session.tabs.activate' || args.method === 'session.tabs.list') {
+        return Promise.resolve({ ok: true, result: hostSessionSnapshot('absent') })
+      }
+      return Promise.resolve({ ok: true, result: { terminal: { handle: 'duplicate-terminal' } } })
+    })
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const { REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS } =
+      await import('./remote-runtime-pty-recovery-state')
+    const onError = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'leaf-1'
+    })
+
+    const connect = transport.connect({ url: '', callbacks: { onError } })
+    await vi.advanceTimersByTimeAsync(
+      HOST_SURFACE_ATTACH_WINDOW_MS + REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS
+    )
+    await expect(connect).resolves.toBeUndefined()
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+    expect(transport.retryRecovery?.()).toBe(true)
+  })
+
   it('stops re-activating once an activation outcome is unobservable', async () => {
     let activations = 0
     runtimeCall.mockImplementation((args: { method: string }) => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -672,7 +672,14 @@ export function createRemoteRuntimePtyTransport(
           getHostSessionTerminalSurfaces(snapshot, hostTabId, {
             matchRequestedLeaf: false
           }).length > 0
-        return siblingStillExists ? false : null
+        if (siblingStillExists) {
+          return false
+        }
+        // Why: a populated surface list missing only this leaf is positive absence, but a list carrying no
+        // surface at all for the tab is a client-side snapshot of a host that may still be republishing.
+        // Keep polling inside the bounded window and let it expire as unknown liveness, never as removal.
+        nextRequest = 'list'
+        continue
       }
       // Why: a host relaunch republishes the surface unmaterialized, and only activation can mint its PTY — list-only polling waits forever.
       nextRequest = activationOutcomeUnknown ? 'list' : 'activate'

--- a/src/renderer/src/runtime/web-session-terminal-orphan-absence-across-republication.test.ts
+++ b/src/renderer/src/runtime/web-session-terminal-orphan-absence-across-republication.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ENVIRONMENT_ID,
+  listResult,
+  makeSnapshot,
+  makeState
+} from './__fixtures__/web-session-terminal-orphan-recovery-regression-fixtures'
+import {
+  clearWebSessionTerminalOrphanRecoveryForTests,
+  recoverWebSessionTerminalOrphansBeforeApply
+} from './web-session-terminal-orphan-recovery'
+
+const LEAVES = [{ leafId: 'leaf-1', handle: 'term-ghost' }]
+
+describe('inventory absence confirmed across host republications', () => {
+  beforeEach(() => {
+    clearWebSessionTerminalOrphanRecoveryForTests()
+  })
+
+  it('prunes a binding two fresh-liveness inventories omit even when the host re-published between them', async () => {
+    const worktree = 'repo::ghost-across-republication'
+    const state = makeState(worktree, LEAVES)
+    const call = vi.fn(async ({ method }: { method: string }) => {
+      if (method === 'terminal.list') {
+        return { ok: true as const, result: listResult(worktree, []) }
+      }
+      return { ok: false as const, error: { code: 'conflict', message: 'unexpected' } }
+    })
+
+    // Every host publication mints a new epoch; the surface identity being confirmed absent does not change.
+    const first = await recoverWebSessionTerminalOrphansBeforeApply(
+      state,
+      makeSnapshot(worktree, 'epoch-1', LEAVES),
+      ENVIRONMENT_ID,
+      { call: call as never }
+    )
+    expect(first?.tabs).toEqual([
+      expect.objectContaining({ leafId: 'leaf-1', terminal: 'term-ghost' })
+    ])
+
+    const second = await recoverWebSessionTerminalOrphansBeforeApply(
+      state,
+      makeSnapshot(worktree, 'epoch-2', LEAVES),
+      ENVIRONMENT_ID,
+      { call: call as never }
+    )
+
+    expect(second?.tabs).toEqual([])
+  })
+
+  it('restarts confirmation when the host lists the surface again', async () => {
+    const worktree = 'repo::ghost-relisted'
+    const state = makeState(worktree, LEAVES)
+    let listedTerminals: readonly Record<string, unknown>[] = []
+    const call = vi.fn(async ({ method }: { method: string }) => {
+      if (method === 'terminal.list') {
+        return { ok: true as const, result: listResult(worktree, listedTerminals) }
+      }
+      return { ok: false as const, error: { code: 'conflict', message: 'unexpected' } }
+    })
+
+    await recoverWebSessionTerminalOrphansBeforeApply(
+      state,
+      makeSnapshot(worktree, 'epoch-1', LEAVES),
+      ENVIRONMENT_ID,
+      { call: call as never }
+    )
+    listedTerminals = [{ handle: 'term-ghost', ptyId: 'pty-1', incarnationId: 'inc-1' }]
+    await recoverWebSessionTerminalOrphansBeforeApply(
+      state,
+      makeSnapshot(worktree, 'epoch-2', LEAVES),
+      ENVIRONMENT_ID,
+      { call: call as never }
+    )
+    listedTerminals = []
+
+    const third = await recoverWebSessionTerminalOrphansBeforeApply(
+      state,
+      makeSnapshot(worktree, 'epoch-3', LEAVES),
+      ENVIRONMENT_ID,
+      { call: call as never }
+    )
+
+    // A live sighting resets the count; one later absence is not two.
+    expect(third?.tabs).toEqual([
+      expect.objectContaining({ leafId: 'leaf-1', terminal: 'term-ghost' })
+    ])
+  })
+})

--- a/src/renderer/src/runtime/web-session-terminal-orphan-recovery-cache.ts
+++ b/src/renderer/src/runtime/web-session-terminal-orphan-recovery-cache.ts
@@ -141,11 +141,11 @@ function inventoryAbsenceCoordinates(args: {
       surfaceKey: args.surface.surfaceKey,
       expectedEnvironmentPairingRevision: args.expectedEnvironmentPairingRevision
     }),
-    fingerprint: [
-      args.snapshot.publicationEpoch,
-      args.surface.handle,
-      args.surface.expectedPtyId ?? ''
-    ].join('\0')
+    // Why no publicationEpoch: the fingerprint identifies the *surface* being confirmed absent, not the
+    // snapshot that carried it. Folding the epoch in required both observations to come from one
+    // publication — which is the same evidence counted twice — and reset the count whenever the host
+    // republished, so a host that re-publishes between inventories could never reach two.
+    fingerprint: [args.surface.handle, args.surface.expectedPtyId ?? ''].join('\0')
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​172 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​171 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

Three issues, three subsystems, **one shape**: an identity folded into the clear-condition that rotates during the very reconnect meant to clear it — or inventory absence read as host evidence of exit.

## 1. #15141 — an empty tab inventory read as "closed"

`waitForHostSessionHandle` returned `null` when the list snapshot carried **no** terminal surface at all for the tab, which surfaced `"Remote terminal was closed."` That path set `connecting = false`, began no recovery epoch, parked no retry, and never called `markRecoveryHealthy()` — so `onErrorCleared` could never fire and **the pane had literally no path back**.

It now keeps polling inside the bounded window and expires as `undefined` (unknown liveness), which the caller already handles by beginning an epoch and parking a retry for online / resume / reconnect.

The two genuine removal-evidence paths are untouched: a host `tab_not_found` / `terminal_not_found` reply to `session.tabs.activate`, and positive absence — the tab's surfaces *are* listed and this leaf is not among them.

Worth noting main already had the *other* half of this — pane-scoped errors and `markRecoveryHealthy()` → `onErrorCleared` → `clearPaneTerminalError`. What was missing was any code path that reached them.

```
BEFORE  × never reads an empty tab inventory as a closed remote terminal
        expected "vi.fn()" to not be called, but was called 1 times
          1st call: [ "Remote terminal was closed." ]
        × keeps a pane whose tab inventory stayed empty revivable instead of latching an error
        Tests  2 failed | 8 passed (10)
AFTER   Tests  10 passed (10)
```

## 2. #17824 — a UI latch more destructive than the timeout it imitates

`markDisconnected()` used `clearTimers()` → `clearRetryTimer()`, nulling `pendingRetry` and deleting the pane from `scheduledRecoveries`. The **deadline** path reaches the *same* `'disconnected'` phase via `stopRetryTimer()` precisely so the pane stays revivable. Now they match; `retryNow()` already handled `phase === 'disconnected'` by minting a fresh epoch.

Also removed `'disconnected'` from the `it.each('removes %s panes from the scheduled recovery registry')` table — that row came from #8255 (generic registry hygiene), not #12650, and directly contradicted its sibling test `'keeps a timed-out pane revivable through the scheduled recovery registry'`.

```
BEFORE  × keeps a markDisconnected pane as revivable as the deadline it imitates
        expected +0 to be 1
AFTER   Tests  15 passed (15)
```

## 3. #9585 — the cleanest instance of the shape

`confirmSurfaceInventoryAbsence` requires two authoritative inventories to omit the same surface — but the fingerprint was `publicationEpoch + handle + expectedPtyId`. **Folding in the epoch meant both observations had to come from one publication** (the same evidence counted twice), and the counter reset to 1 on every host republication. A host that republishes between inventories — exactly what a runtime restart does — could never reach two, so the stale binding was retained forever and re-injected as a synthetic ready row by `mergeRetainedTerminalSurfaces`. That is the "reappears on reconnect, not prunable" behaviour.

Fingerprint is now the surface identity only. **This does not loosen what counts as evidence:** removal still requires `requireFreshPtyLiveness: true`, `!listed.truncated`, a verifiable `hostScope`, a non-pending surface and no duplicate handles — and any live sighting still resets the count.

```
BEFORE  × prunes a binding two fresh-liveness inventories omit even when the host re-published between them
        expected [] to deeply equal [ { "id": "host-tab::leaf-1", "status": "ready", … } ]
AFTER   Tests  2 passed (2)
```

## #15140 — already fixed on main, no change

`SharedControlDiagnosticsTracker.markReady()` now clears `lastError` and `lastClose`, with a call-site comment naming this exact symptom: *"Left set, a recovered host reads 'Connected' next to a stale failure forever."* Regression test asserts `{ state: 'ready', lastError: null, lastClose: null }` after close + reconnect. Landed in `aabcc57366c` (#17531).

## #15317 — diagnosed, seam located, deliberately not fixed

Same shape, different subsystem, but the fix needs a product decision I would not make unilaterally:

- `resolveClaudePaneStatus` overrides a `done` lead back to `working` when a roster/background/cron latch holds the pane.
- `hasRunningNonAgentTask` **fails active** — a malformed entry, an untyped entry, or any non-agent type without an explicitly terminal status returns `true`. **One unrecognized `type` string pins the pane forever.**
- The relay has no reconciliation, TTL or probe: pane state clears on exactly two triggers, PTY exit and tab retirement. An idle-but-alive PTY hits neither.
- The only unconditional reset is `SessionStart(startup|resume|clear)` — precisely what the reporter injected synthetically to clear it.
- The host-side sweep that would correct this already lists these latches in its candidate gate, but is disqualified for remote panes by `connectionId === null && isLocalExecutionHost(...)` and runs once at startup. **Widening it would violate the execution boundary** — a remote agent can never appear in a local process index, and that doc says so.

So the only available correction is a time-bounded latch expiry on the relay. That is a semantics change in a heavily-litigated area (#11838 added the latch; #11219 / #15202 / #14375 refined it) and the window length is a product call. Handing over the seam rather than landing a speculative TTL.

## Verification

```
pnpm test src/renderer/src/components/terminal-pane/ src/renderer/src/runtime/ src/shared/
  1183 passed | 4 skipped   (11,862 tests)
pnpm tc:node / pnpm tc:web   clean
check:code-quality:changed   0 new findings across 6 files
```

Every before/after above was produced by reverting the source and keeping the tests. One unrelated pre-existing full-suite ordering flake in `AgentMapWorkspaceContextMenu.test.tsx`, which passes in isolation with and without these changes and touches none of the edited files.

No new user-facing strings — this change *removes* a surfacing path.

Fixes #15141, #9585, #17824, #17825
Refs #15140, #15317