### PR TITLE
fix(ssh): answer every MFA stage, stop dialling an unclaimed alias, and say where a clone failed

### DIFF
--- a/src/main/ssh/ssh-config-alias-claim.test.ts
+++ b/src/main/ssh/ssh-config-alias-claim.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { parseSshConfigAliasClaims } from './ssh-config-parser'
+import { sshConfigMayClaimAlias } from './ssh-config-alias-claim'
+
+function mayClaim(config: string, alias: string): boolean {
+  return sshConfigMayClaimAlias(alias, parseSshConfigAliasClaims(config))
+}
+
+describe('sshConfigMayClaimAlias', () => {
+  it('treats a wildcard-only config as proof that nothing claims the alias', () => {
+    const config = `
+Host *
+  ProxyCommand nc -X connect -x proxy:8080 %h %p
+  ForwardAgent yes
+`
+    expect(mayClaim(config, 'prod')).toBe(false)
+  })
+
+  it('keeps a Host block that names the alias authoritative', () => {
+    const config = `
+Host *
+  ProxyCommand nc %h %p
+Host prod
+  HostName prod.internal
+`
+    expect(mayClaim(config, 'prod')).toBe(true)
+  })
+
+  it('keeps a glob that reaches the alias authoritative', () => {
+    // parseSshConfig drops these, which is why the claim check cannot reuse it.
+    const config = `
+Host prod-*
+  HostName prod.internal
+`
+    expect(mayClaim(config, 'prod-web')).toBe(true)
+    expect(mayClaim(config, 'stage-web')).toBe(false)
+  })
+
+  it('matches single-character wildcards the way OpenSSH does', () => {
+    expect(mayClaim('Host prod?\n  User ops\n', 'prod1')).toBe(true)
+    expect(mayClaim('Host prod?\n  User ops\n', 'prod12')).toBe(false)
+  })
+
+  it('refuses to answer once any Match block is present', () => {
+    const config = `
+Host *
+  ProxyCommand nc %h %p
+Match host prod
+  User ops
+`
+    expect(mayClaim(config, 'prod')).toBe(true)
+  })
+
+  it('ignores a negated pattern as a claim of its own', () => {
+    expect(mayClaim('Host * !prod\n  ForwardAgent yes\n', 'prod')).toBe(false)
+  })
+
+  it('reads an unreadable config as uncertainty, not absence', () => {
+    expect(sshConfigMayClaimAlias('prod', null)).toBe(true)
+  })
+
+  it('reads an empty alias as uncertainty', () => {
+    expect(sshConfigMayClaimAlias('', parseSshConfigAliasClaims('Host *\n'))).toBe(true)
+  })
+})
+
+describe('parseSshConfigAliasClaims', () => {
+  it('retains the raw pattern groups and flags Match blocks', () => {
+    expect(
+      parseSshConfigAliasClaims('Host a b*  # comment\n  User x\nMatch final\n  User y\n')
+    ).toEqual({ hostPatternGroups: [['a', 'b*']], hasMatchBlock: true })
+  })
+})

--- a/src/main/ssh/ssh-config-alias-claim.test.ts
+++ b/src/main/ssh/ssh-config-alias-claim.test.ts
@@ -51,8 +51,15 @@ Match host prod
     expect(mayClaim(config, 'prod')).toBe(true)
   })
 
-  it('ignores a negated pattern as a claim of its own', () => {
-    expect(mayClaim('Host * !prod\n  ForwardAgent yes\n', 'prod')).toBe(false)
+  it('reads any negated group as uncertainty, because OpenSSH still applies its positives', () => {
+    // `Host * !prod` routes stage; answering false there would licence overriding a block the user
+    // wrote. The exempted alias is not worth a second matching rule to recover.
+    expect(mayClaim('Host * !prod\n  ForwardAgent yes\n', 'stage')).toBe(true)
+    expect(mayClaim('Host * !prod\n  ForwardAgent yes\n', 'prod')).toBe(true)
+  })
+
+  it('still proves absence when no group negates', () => {
+    expect(mayClaim('Host *\n  ForwardAgent yes\nHost prod\n  User ops\n', 'stage')).toBe(false)
   })
 
   it('reads an unreadable config as uncertainty, not absence', () => {

--- a/src/main/ssh/ssh-config-alias-claim.ts
+++ b/src/main/ssh/ssh-config-alias-claim.ts
@@ -10,7 +10,8 @@ import { parseSshConfigAliasClaims, type SshConfigAliasClaims } from './ssh-conf
  * `Match` block other than a bare catch-all applies to it.
  *
  * Sound in the negative direction only. `false` means the parsed config proves nothing claims the
- * alias; every uncertainty (unreadable file, any `Match` block, any pattern that might match)
+ * alias; every uncertainty (unreadable file, any `Match` block, any negated `Host` group, any
+ * pattern that might match)
  * answers `true`, because "we could not tell" must never be read as "no block exists". Callers use
  * `false` as licence to override what OpenSSH would resolve, so a wrong `false` breaks a config the
  * user explicitly wrote, which is worse than the routing bug it exists to fix.
@@ -29,12 +30,14 @@ export function sshConfigMayClaimAlias(
     return true
   }
   return claims.hostPatternGroups.some((patterns) =>
-    patterns.some(
-      (pattern) =>
-        !pattern.startsWith('!') &&
-        !isCatchAllHostPattern(pattern) &&
-        matchesHostPattern(pattern, normalizedAlias)
-    )
+    // A negation makes the whole group uncertain: `Host * !prod` still routes every other alias,
+    // so skipping both the catch-all and the `!` would answer "unclaimed" for one that is claimed.
+    patterns.some((pattern) => pattern.startsWith('!'))
+      ? true
+      : patterns.some(
+          (pattern) =>
+            !isCatchAllHostPattern(pattern) && matchesHostPattern(pattern, normalizedAlias)
+        )
   )
 }
 

--- a/src/main/ssh/ssh-config-alias-claim.ts
+++ b/src/main/ssh/ssh-config-alias-claim.ts
@@ -1,0 +1,100 @@
+import { existsSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { normalizeSshConfigAlias } from '../../shared/ssh-config-alias'
+import { expandSshConfigIncludes } from './ssh-config-include-expander'
+import { parseSshConfigAliasClaims, type SshConfigAliasClaims } from './ssh-config-parser'
+
+/**
+ * Whether anything in the user's ssh_config could claim this alias — i.e. whether a `Host` or
+ * `Match` block other than a bare catch-all applies to it.
+ *
+ * Sound in the negative direction only. `false` means the parsed config proves nothing claims the
+ * alias; every uncertainty (unreadable file, any `Match` block, any pattern that might match)
+ * answers `true`, because "we could not tell" must never be read as "no block exists". Callers use
+ * `false` as licence to override what OpenSSH would resolve, so a wrong `false` breaks a config the
+ * user explicitly wrote, which is worse than the routing bug it exists to fix.
+ */
+export function sshConfigMayClaimAlias(
+  alias: string,
+  claims: SshConfigAliasClaims | null
+): boolean {
+  const normalizedAlias = normalizeSshConfigAlias(alias)
+  if (!normalizedAlias || claims === null) {
+    return true
+  }
+  // A Match block's criteria (exec, originalhost, user, …) are not modelled here, and one that
+  // routes this alias is indistinguishable from one that does not.
+  if (claims.hasMatchBlock) {
+    return true
+  }
+  return claims.hostPatternGroups.some((patterns) =>
+    patterns.some(
+      (pattern) =>
+        !pattern.startsWith('!') &&
+        !isCatchAllHostPattern(pattern) &&
+        matchesHostPattern(pattern, normalizedAlias)
+    )
+  )
+}
+
+/** `Host *` — the block every alias matches, which is exactly the one that proves nothing. */
+function isCatchAllHostPattern(pattern: string): boolean {
+  return pattern.length > 0 && /^\*+$/.test(pattern)
+}
+
+function matchesHostPattern(pattern: string, normalizedAlias: string): boolean {
+  let expression = ''
+  for (const character of normalizeSshConfigAlias(pattern)) {
+    if (character === '*') {
+      expression += '.*'
+    } else if (character === '?') {
+      expression += '.'
+    } else {
+      expression += character.replace(/[.+^${}()|[\]\\]/, '\\$&')
+    }
+  }
+  return new RegExp(`^${expression}$`).test(normalizedAlias)
+}
+
+// Bounds how long an edit to an Included file can go unnoticed; buildSshArgs runs per remote
+// command, so re-expanding Includes every time is not an option.
+const CLAIM_CACHE_TTL_MS = 5_000
+
+let cachedClaims: { key: string; readAt: number; claims: SshConfigAliasClaims } | null = null
+
+export function invalidateSshConfigAliasClaimCache(): void {
+  cachedClaims = null
+}
+
+/**
+ * Parse of `~/.ssh/config` (Includes expanded), or null when it cannot be read.
+ *
+ * Null and empty are different answers here: an absent or unreadable file is the uncertainty case,
+ * while a readable file with no matching block is the proof {@link sshConfigMayClaimAlias} needs.
+ */
+export function loadUserSshConfigAliasClaims(): SshConfigAliasClaims | null {
+  const configPath = join(homedir(), '.ssh', 'config')
+  try {
+    if (!existsSync(configPath)) {
+      return null
+    }
+    // Why key on the root file only: an edited Include can go unnoticed, so the cache also expires.
+    const stats = statSync(configPath)
+    const key = `${stats.mtimeMs}:${stats.size}`
+    const now = Date.now()
+    if (cachedClaims?.key === key && now - cachedClaims.readAt < CLAIM_CACHE_TTL_MS) {
+      return cachedClaims.claims
+    }
+    const claims = parseSshConfigAliasClaims(expandSshConfigIncludes(configPath))
+    cachedClaims = { key, readAt: now, claims }
+    return claims
+  } catch {
+    return null
+  }
+}
+
+/** Convenience wrapper over the two above; used where the caller has no claims to inject. */
+export function mayUserSshConfigClaimAlias(alias: string): boolean {
+  return sshConfigMayClaimAlias(alias, loadUserSshConfigAliasClaims())
+}

--- a/src/main/ssh/ssh-config-parser.ts
+++ b/src/main/ssh/ssh-config-parser.ts
@@ -145,6 +145,46 @@ function appendHosts(target: SshConfigHost[], entries: SshConfigHost[]): void {
   }
 }
 
+/**
+ * Every `Host` pattern list in a config, plus whether any `Match` block is present.
+ *
+ * Deliberately raw where {@link parseSshConfig} is not: that one keeps only concrete aliases
+ * because it mints importable targets, so a `Host prod.*` or a `Match host prod` route is
+ * invisible to it. Answering "does anything in this file claim this alias?" needs those back.
+ */
+export type SshConfigAliasClaims = {
+  hostPatternGroups: string[][]
+  hasMatchBlock: boolean
+}
+
+export function parseSshConfigAliasClaims(content: string): SshConfigAliasClaims {
+  const hostPatternGroups: string[][] = []
+  let hasMatchBlock = false
+
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+    const directive = parseConfigDirective(line)
+    if (!directive) {
+      continue
+    }
+    if (directive.key === 'host') {
+      const patterns = splitHostPatterns(directive.rawValue)
+      if (patterns.length > 0) {
+        hostPatternGroups.push(patterns)
+      }
+      continue
+    }
+    if (directive.key === 'match') {
+      hasMatchBlock = true
+    }
+  }
+
+  return { hostPatternGroups, hasMatchBlock }
+}
+
 function parseConfigDirective(line: string): { key: string; rawValue: string } | null {
   const match = line.match(/^([^=\s]+)(?:\s*=\s*|\s+)(.*)$/)
   if (!match) {

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -74,6 +74,7 @@ import {
   isTransientReconnectError
 } from './ssh-reconnect-error-classification'
 import { SshReconnectLadder } from './ssh-reconnect-ladder'
+import { mayUserSshConfigClaimAlias } from './ssh-config-alias-claim'
 import { getPassphrasePrivateKeyPath } from './ssh-private-key-authentication'
 import {
   requiresSystemSshForSecurityKey,
@@ -1300,6 +1301,11 @@ export class SshConnection {
     const options: SystemSshBuildArgsOptions = {}
     if (this.systemSshResolvedConfig) {
       options.resolvedConfig = this.systemSshResolvedConfig
+    }
+    // Why here and not inside buildSshArgs: the verdict reads ~/.ssh/config, and an arg builder
+    // that consults the filesystem answers differently on every machine, tests included.
+    if (this.target.configHost && !mayUserSshConfigClaimAlias(this.target.configHost)) {
+      options.aliasClaimedByConfig = false
     }
     if (this.systemSshControlMasterDisabledForSession) {
       options.disableControlMaster = true

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -108,7 +108,9 @@ type SshRemoteFileOptions = {
 
 /** Bounds the trust-source reads that run before the handshake, which nothing else times out. */
 const HOST_KEY_SOURCE_READ_TIMEOUT_MS = 5_000
-const SSH_KEYBOARD_INTERACTIVE_MAX_ROUNDS = 4
+// Counts every INFO_REQUEST of the handshake, so it must cover each partial-success stage the auth
+// queue will answer (MAX_PARTIAL_SUCCESS_STAGES) times the rounds a PAM stack spends per stage.
+const SSH_KEYBOARD_INTERACTIVE_MAX_ROUNDS = 8
 const SSH_KEYBOARD_INTERACTIVE_READY_TIMEOUT_MS = SSH_CREDENTIAL_TIMEOUT_MS + 5_000
 const SSH_KEYBOARD_INTERACTIVE_MAX_PROMPTS = 8
 const SSH_KEYBOARD_INTERACTIVE_TEXT_MAX = 4_096

--- a/src/main/ssh/ssh-multi-factor-authentication.test.ts
+++ b/src/main/ssh/ssh-multi-factor-authentication.test.ts
@@ -1,0 +1,251 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  Client,
+  Server as Ssh2Server,
+  utils,
+  type AuthContext,
+  type Connection,
+  type KeyboardAuthContext,
+  type PasswordAuthContext
+} from 'ssh2'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { SshTarget } from '../../shared/ssh-types'
+import type { SshResolvedConfig } from './ssh-config-parser'
+import { buildConnectConfig } from './ssh-connection-utils'
+
+// OpenSSH's default; a host that burns it disconnects before the MFA stage is reached.
+const MAX_AUTH_TRIES = 6
+const PASSWORD = 'stage-one-password'
+const PASSCODE = '123456'
+
+type AuthStage = 'password' | 'keyboard-interactive'
+
+type MfaServer = {
+  port: number
+  attempts: string[]
+  close: () => Promise<void>
+}
+
+/** An OpenSSH-style `AuthenticationMethods a,b` host: each stage partial-succeeds into the next. */
+async function startMultiFactorServer(stages: AuthStage[]): Promise<MfaServer> {
+  const attempts: string[] = []
+  const connections = new Set<Connection>()
+  // Ed25519 keygen can produce an invalid 31-byte key; ECDSA points always start with 0x04.
+  const hostKey = utils.generateKeyPairSync('ecdsa', { bits: 256 }).private
+  const server = new Ssh2Server({ hostKeys: [hostKey] }, (connection) => {
+    connections.add(connection)
+    connection.on('error', () => {})
+    connection.on('close', () => connections.delete(connection))
+    let stage = 0
+    let failures = 0
+    const remaining = (): AuthStage[] => [stages[stage]!]
+    const fail = (context: AuthContext): void => {
+      failures += 1
+      if (failures >= MAX_AUTH_TRIES) {
+        connection.end()
+        return
+      }
+      context.reject(remaining(), false)
+    }
+    connection.on('authentication', (context) => {
+      attempts.push(context.method)
+      if (context.method === 'none') {
+        context.reject(remaining(), false)
+        return
+      }
+      if (context.method !== stages[stage]) {
+        fail(context)
+        return
+      }
+      if (context.method === 'password') {
+        if ((context as PasswordAuthContext).password !== PASSWORD) {
+          fail(context)
+          return
+        }
+        stage += 1
+        if (stage === stages.length) {
+          context.accept()
+          return
+        }
+        context.reject(remaining(), true)
+        return
+      }
+      const keyboard = context as KeyboardAuthContext
+      keyboard.prompt(
+        [{ prompt: 'Duo passcode:', echo: false }],
+        'Duo two-factor login',
+        'Approve the push or enter a passcode.',
+        (answers) => {
+          if (answers?.[0] !== PASSCODE) {
+            fail(context)
+            return
+          }
+          stage += 1
+          if (stage === stages.length) {
+            context.accept()
+            return
+          }
+          context.reject(remaining(), true)
+        }
+      )
+    })
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject)
+      resolve()
+    })
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('MFA fixture did not bind a TCP port')
+  }
+  return {
+    port: address.port,
+    attempts,
+    close: async () => {
+      for (const connection of connections) {
+        connection.end()
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  }
+}
+
+function makeTarget(port: number, overrides: Partial<SshTarget> = {}): SshTarget {
+  return {
+    id: 'mfa-target',
+    label: 'hpc',
+    source: 'manual',
+    host: '127.0.0.1',
+    port,
+    username: 'fixture',
+    ...overrides
+  }
+}
+
+function makeResolved(port: number, identityFile: string[]): SshResolvedConfig {
+  return {
+    hostname: '127.0.0.1',
+    port,
+    user: 'fixture',
+    identityFile,
+    identitiesOnly: true,
+    forwardAgent: false,
+    proxyUseFdpass: false,
+    controlMaster: 'no',
+    controlPersist: 'no',
+    userKnownHostsFiles: [],
+    globalKnownHostsFiles: [],
+    strictHostKeyChecking: 'ask',
+    hashKnownHosts: false,
+    updateHostKeys: 'no'
+  }
+}
+
+/** Drives ssh2 the way SshConnection does: one credential per keyboard-interactive prompt. */
+function connectWithOrcaConfig(
+  target: SshTarget,
+  resolved: SshResolvedConfig | null,
+  password: string | undefined,
+  answers: string[]
+): { ready: Promise<void>; prompts: string[] } {
+  const prompts: string[] = []
+  const config = buildConnectConfig(target, resolved, {
+    includeAgent: false,
+    includePrivateKey: true
+  })
+  if (password != null) {
+    config.password = password
+  }
+  const ready = new Promise<void>((resolve, reject) => {
+    const client = new Client()
+    let answerIndex = 0
+    client.on('keyboard-interactive', (_name, _instructions, _lang, requested, finish) => {
+      for (const requestedPrompt of requested) {
+        prompts.push(requestedPrompt.prompt)
+      }
+      finish(requested.map(() => answers[answerIndex++] ?? ''))
+    })
+    client.once('ready', () => {
+      client.end()
+      resolve()
+    })
+    client.once('error', reject)
+    client.once('close', () => reject(new Error('SSH connection closed during authentication')))
+    client.connect({ ...config, hostVerifier: () => true, readyTimeout: 10_000 })
+  })
+  return { ready, prompts }
+}
+
+describe('multi-stage SSH authentication', () => {
+  let tempDir: string
+  let keyPaths: string[]
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'orca-mfa-'))
+    keyPaths = ['id_a', 'id_b'].map((name) => {
+      const path = join(tempDir, name)
+      writeFileSync(path, utils.generateKeyPairSync('ecdsa', { bits: 256 }).private)
+      return path
+    })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('answers a keyboard-interactive stage that follows a password partial success', async () => {
+    const server = await startMultiFactorServer(['password', 'keyboard-interactive'])
+    try {
+      const { ready, prompts } = connectWithOrcaConfig(makeTarget(server.port), null, PASSWORD, [
+        PASSCODE
+      ])
+
+      await expect(ready).resolves.toBeUndefined()
+      expect(prompts).toEqual(['Duo passcode:'])
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('answers a second keyboard-interactive stage after the first partially succeeds', async () => {
+    const server = await startMultiFactorServer(['keyboard-interactive', 'keyboard-interactive'])
+    try {
+      const { ready, prompts } = connectWithOrcaConfig(makeTarget(server.port), null, undefined, [
+        PASSCODE,
+        PASSCODE
+      ])
+
+      await expect(ready).resolves.toBeUndefined()
+      expect(prompts).toEqual(['Duo passcode:', 'Duo passcode:'])
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('reaches the MFA stage without burning the host auth-try budget on rejected keys', async () => {
+    const server = await startMultiFactorServer(['password', 'keyboard-interactive'])
+    try {
+      const target = makeTarget(server.port, { source: 'ssh-config', configHost: 'hpc' })
+      const { ready } = connectWithOrcaConfig(
+        target,
+        makeResolved(server.port, keyPaths),
+        PASSWORD,
+        [PASSCODE]
+      )
+
+      await expect(ready).resolves.toBeUndefined()
+      // After the password stage partially succeeds the host only offers keyboard-interactive;
+      // re-offering keys there is what exhausts MaxAuthTries on real MFA hosts.
+      expect(server.attempts.filter((method) => method === 'publickey')).toHaveLength(0)
+    } finally {
+      await server.close()
+    }
+  })
+})

--- a/src/main/ssh/ssh-multi-key-authentication.test.ts
+++ b/src/main/ssh/ssh-multi-key-authentication.test.ts
@@ -77,6 +77,18 @@ function nextAuth(
   return result ?? false
 }
 
+function partialSuccessAuth(
+  config: ConnectConfig,
+  authsLeft: AuthenticationType[]
+): AuthenticationType | AnyAuthMethod | false {
+  let result: AuthenticationType | AnyAuthMethod | false | undefined
+  const handler = config.authHandler as AuthHandlerMiddleware
+  handler(authsLeft, true, (attempt) => {
+    result = attempt
+  })
+  return result ?? false
+}
+
 describe('ordered SSH private-key authentication', () => {
   beforeEach(() => {
     vi.stubEnv('SSH_AUTH_SOCK', '')
@@ -128,9 +140,53 @@ describe('ordered SSH private-key authentication', () => {
     })
 
     expect(manual.privateKey).toEqual(Buffer.from('/keys/manual'))
-    expect(manual.authHandler).toBeUndefined()
     expect(unresolvedImport.privateKey).toEqual(Buffer.from('/keys/stale-imported'))
-    expect(unresolvedImport.authHandler).toBeUndefined()
+    // Single-key targets are still ordered by Orca's handler so an MFA host reaches
+    // keyboard-interactive once per stage rather than once per connection.
+    expect(nextAuth(manual, true)).toMatchObject({ type: 'none' })
+    expect(nextAuth(manual, false)).toMatchObject({
+      type: 'publickey',
+      key: Buffer.from('/keys/manual')
+    })
+    expect(nextAuth(manual, false)).toBe('keyboard-interactive')
+  })
+
+  it('re-offers keyboard-interactive for each partial-success MFA stage', () => {
+    const config = buildConnectConfig(makeTarget(), makeResolved(), {
+      includeAgent: false,
+      includePrivateKey: true
+    })
+    config.password = 'stage-one'
+
+    expect(nextAuth(config, true)).toMatchObject({ type: 'none' })
+    expect(nextAuth(config, false)).toMatchObject({ type: 'password' })
+    // Partial success: the host accepted the password and now offers only the challenge.
+    expect(partialSuccessAuth(config, ['keyboard-interactive'])).toBe('keyboard-interactive')
+    expect(partialSuccessAuth(config, ['keyboard-interactive'])).toBe('keyboard-interactive')
+  })
+
+  it('stops re-offering methods the host no longer accepts after a partial success', () => {
+    const config = buildConnectConfig(makeTarget(), makeResolved(), {
+      includeAgent: false,
+      includePrivateKey: true
+    })
+
+    expect(nextAuth(config, true)).toMatchObject({ type: 'none' })
+    expect(partialSuccessAuth(config, ['keyboard-interactive'])).toBe('keyboard-interactive')
+    expect(nextAuth(config, false)).toBe(false)
+  })
+
+  it('bounds the number of partial-success stages it will answer', () => {
+    const config = buildConnectConfig(makeTarget(), makeResolved(), {
+      includeAgent: false,
+      includePrivateKey: true
+    })
+
+    expect(nextAuth(config, true)).toMatchObject({ type: 'none' })
+    for (let stage = 0; stage < 4; stage += 1) {
+      expect(partialSuccessAuth(config, ['keyboard-interactive'])).toBe('keyboard-interactive')
+    }
+    expect(partialSuccessAuth(config, ['keyboard-interactive'])).toBe(false)
   })
 
   it('offers every resolved key for a manually owned config-picker target', () => {

--- a/src/main/ssh/ssh-multi-key-authentication.test.ts
+++ b/src/main/ssh/ssh-multi-key-authentication.test.ts
@@ -123,6 +123,15 @@ describe('ordered SSH private-key authentication', () => {
     expect(mockReadFileSync).not.toHaveBeenCalledWith('/keys/stale-imported')
   })
 
+  it('still offers the ssh-agent when no readable key precedes it', () => {
+    vi.stubEnv('SSH_AUTH_SOCK', '/tmp/agent.sock')
+    const config = buildConnectConfig(makeTarget({ identityFile: undefined }), null)
+
+    expect(nextAuth(config, true)).toMatchObject({ type: 'none' })
+    expect(nextAuth(config, false)).toMatchObject({ type: 'agent', agent: '/tmp/agent.sock' })
+    expect(nextAuth(config, false)).toBe('keyboard-interactive')
+  })
+
   it('keeps explicit manual keys and unresolved imported keys as singular overrides', () => {
     const manual = buildConnectConfig(
       makeTarget({

--- a/src/main/ssh/ssh-private-key-authentication.ts
+++ b/src/main/ssh/ssh-private-key-authentication.ts
@@ -3,6 +3,16 @@ import type { PrivateKeyFile } from './ssh-auth-resolution'
 
 const passphraseKeyPaths = new WeakMap<ConnectConfig, string>()
 
+// Bounds an `AuthenticationMethods a,b,c` ladder so a host that keeps replying
+// "partial success" cannot keep the client prompting forever.
+const MAX_PARTIAL_SUCCESS_STAGES = 4
+
+function authMethodName(attempt: AuthenticationType | AnyAuthMethod): AuthenticationType {
+  const type = typeof attempt === 'string' ? attempt : attempt.type
+  // Agent identities are signed as publickey; a server's method list never names 'agent'.
+  return type === 'agent' ? 'publickey' : type
+}
+
 function buildAuthQueue(
   config: ConnectConfig,
   keys: PrivateKeyFile[]
@@ -35,21 +45,34 @@ export function configurePrivateKeyAuthentication(
   passphraseKeyPath?: string
 ): void {
   const firstKey = keys[0]
-  if (!firstKey) {
-    return
-  }
-  config.privateKey = firstKey.contents
-  if (passphraseKeyPath) {
-    passphraseKeyPaths.set(config, passphraseKeyPath)
-  }
-  if (keys.length === 1) {
-    return
+  if (firstKey) {
+    config.privateKey = firstKey.contents
+    if (passphraseKeyPath) {
+      passphraseKeyPaths.set(config, passphraseKeyPath)
+    }
   }
 
+  // Why this replaces ssh2's own handler for every target, not just multi-key ones: ssh2 walks one
+  // flat method list exactly once, so keyboard-interactive can only ever be offered a single time.
+  // An MFA host running `AuthenticationMethods keyboard-interactive,keyboard-interactive` (or any
+  // ladder whose last stage is a second challenge) partial-succeeds the first stage and then finds
+  // the list exhausted — reported to the user as "All configured authentication methods failed".
   let queue: (AuthenticationType | AnyAuthMethod)[] = []
-  config.authHandler = (authsLeft, _partialSuccess, next) => {
+  let partialSuccessStagesLeft = MAX_PARTIAL_SUCCESS_STAGES
+  config.authHandler = (authsLeft, partialSuccess, next) => {
     if (authsLeft == null) {
       queue = buildAuthQueue(config, keys)
+      partialSuccessStagesLeft = MAX_PARTIAL_SUCCESS_STAGES
+    } else if (partialSuccess && partialSuccessStagesLeft > 0) {
+      // A stage was accepted and the host now demands another method. Restart from a fresh queue
+      // narrowed to what it still offers: re-offering keys it has stopped accepting is what
+      // exhausts MaxAuthTries before the challenge is ever shown.
+      partialSuccessStagesLeft -= 1
+      const offered = Array.isArray(authsLeft) ? authsLeft : []
+      queue = buildAuthQueue(config, keys).filter((attempt) => {
+        const method = authMethodName(attempt)
+        return method !== 'none' && offered.includes(method)
+      })
     }
     const attempt = queue.shift()
     next((attempt ?? false) as Parameters<NextAuthHandler>[0])

--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -268,6 +268,52 @@ describe('spawnSystemSsh', () => {
     expect(args).not.toContain('ProxyCommand=ignored')
   })
 
+  it('states the stored endpoint when no Host block claims the alias', () => {
+    // A wildcard `Host *` supplies the proxy for every alias, so an alias whose own block is gone
+    // still reads as config-backed and gets dialled bare - the #11746 P1.
+    const args = buildSshArgs(
+      createTarget({
+        source: 'ssh-config',
+        configHost: 'prod',
+        host: '10.0.0.5',
+        port: 2222,
+        username: 'deploy'
+      }),
+      { aliasClaimedByConfig: false }
+    )
+
+    expect(args).toContain('Hostname=10.0.0.5')
+    expect(args.slice(args.indexOf('-p'))).toContain('2222')
+    expect(args.slice(args.indexOf('-l'))).toContain('deploy')
+    // The alias is still the destination so OpenSSH keeps applying the wildcard's proxy.
+    expect(args.at(-1)).toBe('prod')
+    expect(args).not.toContain('deploy@prod')
+    expect(args).not.toContain('-i')
+    expect(args).not.toContain('-J')
+  })
+
+  it('stays a no-op when the stored endpoint matches the unclaimed alias', () => {
+    const args = buildSshArgs(
+      createTarget({ source: 'ssh-config', configHost: 'prod', host: 'prod', username: '' }),
+      { aliasClaimedByConfig: false }
+    )
+
+    expect(args.some((arg) => arg.startsWith('Hostname='))).toBe(false)
+    expect(args).not.toContain('-p')
+    expect(args).not.toContain('-l')
+    expect(args.at(-1)).toBe('prod')
+  })
+
+  it('leaves a manual target alone even when nothing claims its alias', () => {
+    const args = buildSshArgs(
+      createTarget({ source: 'manual', configHost: 'prod', host: '10.0.0.5', port: 2222 }),
+      { aliasClaimedByConfig: false }
+    )
+
+    expect(args.some((arg) => arg.startsWith('Hostname='))).toBe(false)
+    expect(args).toContain('deploy@prod')
+  })
+
   it('passes an explicit main-owned OpenSSH config as one argument', () => {
     const args = buildSshArgs(createTarget({ configHost: 'isolated-host', source: 'ssh-config' }), {
       configFile: '/tmp/orca isolated/ssh_config'

--- a/src/main/ssh/system-ssh-args.ts
+++ b/src/main/ssh/system-ssh-args.ts
@@ -8,6 +8,14 @@ export type SystemSshBuildArgsOptions = {
   suppressOrcaControlMaster?: boolean
   gssapiOnly?: boolean
   nonInteractive?: boolean
+  /**
+   * `false` only when the parsed ssh_config proves no `Host`/`Match` block claims `configHost`.
+   *
+   * Absent or `true` keeps the config alias fully authoritative, which is right whenever a block
+   * really does name it — and is the only safe default, since a caller that cannot answer must not
+   * be read as having answered "nothing claims it". See `sshConfigMayClaimAlias`.
+   */
+  aliasClaimedByConfig?: boolean
 }
 
 export function buildSshArgs(target: SshTarget, options?: SystemSshBuildArgsOptions): string[] {
@@ -50,6 +58,15 @@ export function buildSshArgs(target: SshTarget, options?: SystemSshBuildArgsOpti
   }
 
   const useConfigHost = shouldUseOpenSshConfigHost(target)
+
+  // Why: a wildcard `Host *` block supplies ProxyCommand/ProxyJump for every alias, so an alias
+  // whose own Host block was renamed or deleted still looks config-backed and gets dialled bare —
+  // as the wildcard's user, at the wildcard's host, discarding the endpoint Orca stored. Keep the
+  // system transport (OpenSSH must still apply that proxy) but state the stored endpoint, and only
+  // where the config proves no block claims the alias.
+  if (useConfigHost && options?.aliasClaimedByConfig === false) {
+    appendUnclaimedAliasEndpoint(args, target)
+  }
 
   if (!useConfigHost && target.port !== 22) {
     args.push('-p', String(target.port))
@@ -122,6 +139,9 @@ export function getSystemSshBuildArgsFromOperationOptions(
   if (options?.nonInteractive === true) {
     buildArgsOptions.nonInteractive = true
   }
+  if (options?.aliasClaimedByConfig === false) {
+    buildArgsOptions.aliasClaimedByConfig = false
+  }
   return Object.keys(buildArgsOptions).length === 0 ? undefined : buildArgsOptions
 }
 
@@ -170,6 +190,27 @@ function hasEnabledControlMaster(value: string | undefined): boolean {
 function hasEnabledControlPath(value: string | undefined): boolean {
   const normalized = value?.trim().toLowerCase()
   return normalized != null && normalized !== '' && normalized !== 'none'
+}
+
+/**
+ * Restore only Hostname/Port/User, and only where they diverge from the alias.
+ *
+ * Not `-i`/`-J`/ProxyCommand: the wildcard block is still the route to this network, and `-o
+ * Hostname=` does not change which blocks OpenSSH selects (matching uses the original destination),
+ * so the proxy keeps applying and `%h` now expands to the host we actually mean.
+ */
+function appendUnclaimedAliasEndpoint(args: string[], target: SshTarget): void {
+  const alias = target.configHost
+  const storedHost = target.host.trim()
+  if (storedHost && alias && storedHost !== alias) {
+    args.push('-o', `Hostname=${storedHost}`)
+  }
+  if (target.port && target.port !== 22) {
+    args.push('-p', String(target.port))
+  }
+  if (target.username) {
+    args.push('-l', target.username)
+  }
 }
 
 function shouldUseOpenSshConfigHost(target: SshTarget): boolean {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15962,7 +15962,8 @@
           "none": "None",
           "search": "Search",
           "showUnreadOnly": "Show unread only",
-          "showChildAgents": "Show child agents"
+          "showChildAgents": "Show child agents",
+          "activityOptions": "Activity options"
         },
         "clearCompleted": {
           "clearedOne": "Cleared 1 completed agent",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17260,7 +17260,9 @@
   "dashboard": {
     "sidebar": {
       "label": "Agents",
-      "dashboardLabel": "Agent Dashboard"
+      "dashboardLabel": "Agent Dashboard",
+      "openActivity": "View activity",
+      "closeActivity": "Turn off activity view"
     }
   },
   "runtimeRpc": {

--- a/src/shared/git-clone-failure-message.test.ts
+++ b/src/shared/git-clone-failure-message.test.ts
@@ -107,6 +107,16 @@ describe('getGitCloneFailureMessage', () => {
     ).toBe("fatal: repository 'https://github.com/org/repo.git/' not found")
   })
 
+  it('withholds SSH guidance when the failing transport was HTTPS', () => {
+    // Git reuses this line for the HTTP remote helper, so the string alone does not prove SSH.
+    const stderr =
+      'remote: Invalid username or token.\n' +
+      "fatal: Authentication failed for 'https://github.com/org/repo.git/'\n" +
+      'fatal: Could not read from remote repository.\n'
+
+    expect(getGitCloneFailureMessage(stderr)).not.toContain('BatchMode=yes')
+  })
+
   it('does not repeat the guidance when a relay message is re-parsed', () => {
     const relayMessage = `Clone failed: ${getGitCloneFailureMessage(
       'git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.\n'

--- a/src/shared/git-clone-failure-message.test.ts
+++ b/src/shared/git-clone-failure-message.test.ts
@@ -71,4 +71,49 @@ describe('getGitCloneFailureMessage', () => {
     )
     expect(usedLineSplit).toBe(false)
   })
+
+  it('names the non-interactive remote clone when a key could not be offered', () => {
+    const stderr =
+      "Cloning into 'repo'...\n" +
+      'git@github.com: Permission denied (publickey).\n' +
+      'fatal: Could not read from remote repository.\n'
+
+    const message = getGitCloneFailureMessage(stderr)
+
+    expect(message).toContain('fatal: Could not read from remote repository.')
+    expect(message).toContain('BatchMode=yes')
+    expect(message).toContain('ssh-add')
+  })
+
+  it('points host key failures at the machine that runs the clone', () => {
+    const stderr = 'Host key verification failed.\nfatal: Could not read from remote repository.\n'
+
+    const message = getGitCloneFailureMessage(stderr)
+
+    expect(message).toContain('known_hosts')
+    expect(message).not.toContain('ssh-add')
+  })
+
+  it('still explains where an unrecognised SSH clone failure ran', () => {
+    const stderr =
+      'kex_exchange_identification: read: Connection reset by peer\nfatal: Could not read from remote repository.\n'
+
+    expect(getGitCloneFailureMessage(stderr)).toContain('BatchMode=yes')
+  })
+
+  it('leaves non-SSH clone failures untouched', () => {
+    expect(
+      getGitCloneFailureMessage("fatal: repository 'https://github.com/org/repo.git/' not found")
+    ).toBe("fatal: repository 'https://github.com/org/repo.git/' not found")
+  })
+
+  it('does not repeat the guidance when a relay message is re-parsed', () => {
+    const relayMessage = `Clone failed: ${getGitCloneFailureMessage(
+      'git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.\n'
+    )}`
+
+    const reparsed = getGitCloneFailureMessage(relayMessage)
+
+    expect(reparsed.match(/BatchMode=yes/g)).toHaveLength(1)
+  })
 })

--- a/src/shared/git-clone-failure-message.ts
+++ b/src/shared/git-clone-failure-message.ts
@@ -1,6 +1,44 @@
 import { stripCredentialsFromMessage } from './git-remote-error'
 
+// Why: clones run under nonInteractiveGitEnv (GIT_TERMINAL_PROMPT=0, empty SSH_ASKPASS,
+// `ssh -o BatchMode=yes`) so a background clone cannot hang on a prompt nobody sees. The cost is
+// that git's own SSH errors read identically to an ordinary permission problem, and on a remote
+// or paired-runtime clone the user is looking at their own working local `git clone` while Orca
+// fails — with nothing in the message saying the clone ran somewhere else, without their agent.
+const CLONE_HOST_NOTE =
+  'The clone runs non-interactively (BatchMode=yes) on the machine that will hold the repository, using the SSH keys and agent on that machine rather than the ones on this computer.'
+const CLONE_KEY_HINT = `${CLONE_HOST_NOTE} A passphrase-protected key cannot prompt there, so load it into an agent on that machine (ssh-add) and retry.`
+const CLONE_HOST_KEY_HINT = `${CLONE_HOST_NOTE} It has not trusted this host key yet — connect once from a shell on that machine to record it in its known_hosts.`
+
 export function getGitCloneFailureMessage(
+  stderr: string,
+  options: { clonePath?: string | null } = {}
+): string {
+  return appendCloneTransportGuidance(
+    getGitCloneFailureLine(stderr, options),
+    stripCredentialsFromMessage(stderr)
+  )
+}
+
+/** Guidance the raw git error omits: where the clone ran, and why nothing could prompt there. */
+function appendCloneTransportGuidance(message: string, scrubbedStderr: string): string {
+  // Re-entrant: remote-repo-clone re-parses a message the relay already built.
+  if (message.includes(CLONE_HOST_NOTE)) {
+    return message
+  }
+  if (/host key verification failed/i.test(scrubbedStderr)) {
+    return `${message} ${CLONE_HOST_KEY_HINT}`
+  }
+  if (/permission denied \(([^)]*publickey[^)]*)\)/i.test(scrubbedStderr)) {
+    return `${message} ${CLONE_KEY_HINT}`
+  }
+  // Every other SSH-transport failure still needs the one fact the reporter was missing.
+  return /could not read from remote repository/i.test(scrubbedStderr)
+    ? `${message} ${CLONE_HOST_NOTE}`
+    : message
+}
+
+function getGitCloneFailureLine(
   stderr: string,
   options: { clonePath?: string | null } = {}
 ): string {

--- a/src/shared/git-clone-failure-message.ts
+++ b/src/shared/git-clone-failure-message.ts
@@ -10,6 +10,10 @@ const CLONE_HOST_NOTE =
 const CLONE_KEY_HINT = `${CLONE_HOST_NOTE} A passphrase-protected key cannot prompt there, so load it into an agent on that machine (ssh-add) and retry.`
 const CLONE_HOST_KEY_HINT = `${CLONE_HOST_NOTE} It has not trusted this host key yet — connect once from a shell on that machine to record it in its known_hosts.`
 
+/** An ssh(1) diagnostic, i.e. a line only the SSH transport can have produced. */
+const SSH_TRANSPORT_DIAGNOSTIC =
+  /\bssh|permission denied \(|connection (?:closed|reset|refused|timed out) by/i
+
 export function getGitCloneFailureMessage(
   stderr: string,
   options: { clonePath?: string | null } = {}
@@ -32,8 +36,11 @@ function appendCloneTransportGuidance(message: string, scrubbedStderr: string): 
   if (/permission denied \(([^)]*publickey[^)]*)\)/i.test(scrubbedStderr)) {
     return `${message} ${CLONE_KEY_HINT}`
   }
-  // Every other SSH-transport failure still needs the one fact the reporter was missing.
-  return /could not read from remote repository/i.test(scrubbedStderr)
+  // Every other SSH-transport failure still needs the one fact the reporter was missing — but only
+  // once something proves the transport was SSH: git prints this same line for the HTTP remote
+  // helper, where a note about keys and agents is simply wrong.
+  return /could not read from remote repository/i.test(scrubbedStderr) &&
+    SSH_TRANSPORT_DIAGNOSTIC.test(scrubbedStderr)
     ? `${message} ${CLONE_HOST_NOTE}`
     : message
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​499 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​497 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​276 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​263 |

<!-- /orca-pr-loc -->

Three connect-path failures. The first two are "the user cannot get in at all".

## #8622 + #16820 are the same bug — and were half-fixed yesterday

Both are ssh2 never being told to try keyboard-interactive. It builds `authsAllowed` at `ssh2/lib/client.js:836-844` and only pushes `keyboard-interactive` when `config.tryKeyboard` is set; with the list exhausted it emits the reporters' exact string at `:863`.

**Every released tag through v1.4.194 lacks `tryKeyboard`.** It landed on `main` in `fbe94ceff68` yesterday and is in **no tag** (`git merge-base --is-ancestor fbe94ceff68 v1.4.194` fails). So both reporters were right, and both are fixed by an unreleased commit.

**What was still broken.** ssh2 walks one flat method list exactly once (`makeSimpleAuthHandler`, `client.js:2047-2057`), so keyboard-interactive can only ever be offered **once per connection**. An `AuthenticationMethods` ladder ending in a second challenge partial-succeeds stage one and then finds the list empty. Orca's own handler (`ssh-private-key-authentication.ts:50`) had the same defect — it **ignored its `partialSuccess` argument entirely**, and only ran when `keys.length > 1`.

Now it runs for every target, and on a `SSH_MSG_USERAUTH_FAILURE` carrying partial success it rebuilds its queue narrowed to the methods the host still offers (bounded to 4 stages); `SSH_KEYBOARD_INTERACTIVE_MAX_ROUNDS` goes 4 → 8 to cover them. **No new prompt surface** — `SshPassphraseDialog.tsx:110` already handles `kind === 'keyboard-interactive'`.

Proved against a **real ssh2 server**, not the mock harness:

```
BEFORE  × answers a second keyboard-interactive stage after the first partially succeeds
        × reaches the MFA stage without burning the host auth-try budget on rejected keys
        Caused by: Error: All configured authentication methods failed
          at doNextAuth ssh2/lib/client.js:863
        expected [ 'publickey', 'publickey' ] to have a length of +0 but got 2
        Tests  2 failed | 1 passed (3)
AFTER   Tests  3 passed (3)
```

## #11746 — reproduced by execution, fixed for system-SSH, honestly scoped

Bundled the real modules and ran them against the issue's exact inputs: `buildSshArgs` emits `["-o","BatchMode=no","-T",…,"--","prod"]` — byte-identical to the report. The stored `10.0.0.5:2222/deploy` is discarded because a `Host *` block makes the target look config-backed.

`hostBlockMatch` does not exist anywhere and PR #11707 is still open, so this could not be fixed as written. **`ssh -G` cannot supply the signal either** — it prints the merged config and answers for unknown aliases too. The config file is the only source of truth.

Reusing the existing `configHostMatches` was not safe: `parseSshConfig` drops glob'd `Host prod.*` lines and `Match` blocks, so it would call a real config **absent**. New `parseSshConfigAliasClaims` retains raw patterns and flags `Match`; `sshConfigMayClaimAlias` is **sound in the negative direction only** — an unreadable file, any `Match` block, or any non-catch-all pattern that might match all answer "claimed". Only a *proven-unclaimed* alias licenses the override, and then only `Hostname`/`Port`/`User` — never `-i`, `-J` or ProxyCommand.

The verdict is **injected** into `buildSshArgs`, not read there: an arg builder that stats `~/.ssh/config` answers differently on every machine, including in tests. Default is today's behaviour.

**The conflicting test did not need rewriting.** `ssh-system-fallback.test.ts:249-269` passes no `resolved` *and* no verdict, so it now exercises the safe default — and what it was protecting (a real `Host` block staying authoritative) is exactly what that default means. It stays green unchanged, with three new sibling cases beside it.

**Scope:** system-SSH transport only, via `getSystemSshBuildArgsOptions()` — exec, file transfer, relay deploy, the GitHub probe, the relay transport spawn. Port-forward processes build their own options and keep today's behaviour. **The ssh2 half (#11707) is untouched and still live.**

**One consequence to weigh before merge:** `-o Hostname=<stored>` moves OpenSSH's known_hosts lookup from the alias to the real host. That is *stricter* — checking the endpoint we actually reach — but a first connection after the fix can prompt. `HostKeyAlias` was deliberately not added, since it would pin the check to a name that no longer designates anything.

## #14533 — the title is wrong; fixed the diagnosis, not the forwarding

`SSH_AUTH_SOCK`/`HOME`/`PATH` **are** inherited through `orca serve`, and no agent forwarding to a paired runtime exists anywhere — because that transport is Orca's own E2EE runtime RPC, with no ssh connection to hang `agentForward` off.

The real mechanism: `nonInteractiveGitEnv()` sets `GIT_SSH_COMMAND='ssh -o BatchMode=yes'` plus empty `SSH_ASKPASS`, so **a passphrase-protected key with no agent loaded fails under Orca while the same `git clone` typed by hand on that box succeeds** — and the error never says why.

Fixed in the one shared builder, `git-clone-failure-message.ts`, so the relay path and the runtime path both get it: publickey refusal → name BatchMode and say `ssh-add` **on that machine**; host-key failure → point at that machine's `known_hosts`; any other SSH failure → still state where it ran. Non-SSH failures untouched, and the builder is re-entrant so re-parsing a relay message cannot double-append.

**Not done, deliberately:** agent forwarding (a feature and a security decision, worth its own issue), and weakening `BatchMode=yes` — making it interactive would trade a clear failure for a silent hang.

## Verification

```
src/main/ssh/          129 passed | 2 skipped (131)   1800 passed | 16 skipped
src/relay/ + ipc/repos/ + runtime/                    697 passed
src/shared/                                           604 passed
pnpm tc:node                                          clean
check:code-quality:changed          0 new findings across 11 files
sync:localization-catalog           no diff
```

Fixes #8622, #16820
Refs #11746, #14533, #11707