### PR TITLE
fix(ssh): keep remote PowerShell commands inside what sshd's cmd.exe accepts

### DIFF
--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -14,7 +14,8 @@ import {
 } from '../powershell-osc133-bootstrap'
 import { quoteStartupArg } from '../../shared/tui-agent-startup-shell'
 
-const CMD_EXE_COMMAND_LINE_MAX_CHARS = 8191
+/** cmd.exe's own documented ceiling; callers that go through sshd budget below it. */
+export const CMD_EXE_COMMAND_LINE_MAX_CHARS = 8191
 const STARTUP_COMMAND_TEXT_MAX_CHARS = 6000
 const POWERSHELL_ENCODED_COMMAND_ARG_MAX_CHARS = 28_000
 const CMD_UTF8_SETUP_COMMAND = 'chcp 65001 > nul'

--- a/src/main/ssh/ssh-relay-sftp-namespace-install.test.ts
+++ b/src/main/ssh/ssh-relay-sftp-namespace-install.test.ts
@@ -85,6 +85,7 @@ import {
   RELAY_DEPLOY_TIMEOUT_MS
 } from './ssh-relay-deploy-timing'
 import { parseUnameToRelayPlatform } from './relay-protocol'
+import { decodeRemotePowerShellScript } from './ssh-remote-powershell'
 import {
   abandonInstall,
   finalizeInstall,
@@ -154,8 +155,7 @@ function issuedMarkerNames(): string[] {
 }
 
 function decodeCommand(command: string): string {
-  const match = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/)
-  return match ? Buffer.from(match[1], 'base64').toString('utf16le') : command
+  return decodeRemotePowerShellScript(command)
 }
 
 function execCommands(): string[] {

--- a/src/main/ssh/ssh-remote-commands.test.ts
+++ b/src/main/ssh/ssh-remote-commands.test.ts
@@ -13,6 +13,7 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { decodeRemotePowerShellScript } from './ssh-remote-powershell'
 import {
   lockAgeSecondsCommand,
   tryCreateInstallLockCommand,
@@ -63,8 +64,7 @@ const powerShell51Executable =
     : undefined
 
 function decodePowerShellCommand(command: string): string {
-  const match = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/)
-  return match ? Buffer.from(match[1], 'base64').toString('utf16le') : ''
+  return command.includes('-EncodedCommand ') ? decodeRemotePowerShellScript(command) : ''
 }
 
 function runShellCommand(command: string): Promise<string> {

--- a/src/main/ssh/ssh-remote-powershell.ts
+++ b/src/main/ssh/ssh-remote-powershell.ts
@@ -1,12 +1,14 @@
 import { gunzipSync, gzipSync } from 'node:zlib'
 import { encodePowerShellCommand } from '../../shared/powershell-command-encoding'
-import { CMD_EXE_MAX_COMMAND_LINE_CHARS } from '../../shared/windows-command-line-budget'
+import { CMD_EXE_COMMAND_LINE_MAX_CHARS } from '../providers/windows-shell-args'
 export {
   quotePowerShellLiteral as powerShellLiteral,
   quotePowerShellNativeArgument as powerShellNativeArg
 } from '../../shared/powershell-native-argument'
 
-// Margin for the `/c` wrapper sshd puts around the command before cmd.exe counts it.
+// Why cmd.exe and not the 32767 CreateProcess cap: Windows OpenSSH runs every exec request
+// through sshd's DefaultShell, cmd.exe on a stock install. Budget under cmd.exe's own ceiling
+// to leave room for the `/c` wrapper sshd adds before cmd.exe counts the line.
 const WINDOWS_REMOTE_COMMAND_LINE_BUDGET_CHARS = 8_000
 
 export function powerShellCommand(script: string): string {
@@ -19,7 +21,7 @@ export function powerShellCommand(script: string): string {
   const compressed = encodedPowerShellCommand(selfExtractingPowerShellScript(script))
   if (compressed.length > WINDOWS_REMOTE_COMMAND_LINE_BUDGET_CHARS) {
     throw new Error(
-      `Remote Windows command needs ${compressed.length} characters; sshd's cmd.exe refuses more than ${CMD_EXE_MAX_COMMAND_LINE_CHARS}.`
+      `Remote Windows command needs ${compressed.length} characters; Orca budgets ${WINDOWS_REMOTE_COMMAND_LINE_BUDGET_CHARS} for a line sshd hands to cmd.exe, which itself refuses more than ${CMD_EXE_COMMAND_LINE_MAX_CHARS}.`
     )
   }
   return compressed

--- a/src/main/ssh/ssh-remote-powershell.ts
+++ b/src/main/ssh/ssh-remote-powershell.ts
@@ -1,9 +1,57 @@
+import { gunzipSync, gzipSync } from 'node:zlib'
 import { encodePowerShellCommand } from '../../shared/powershell-command-encoding'
+import { CMD_EXE_MAX_COMMAND_LINE_CHARS } from '../../shared/windows-command-line-budget'
 export {
   quotePowerShellLiteral as powerShellLiteral,
   quotePowerShellNativeArgument as powerShellNativeArg
 } from '../../shared/powershell-native-argument'
 
+// Margin for the `/c` wrapper sshd puts around the command before cmd.exe counts it.
+const WINDOWS_REMOTE_COMMAND_LINE_BUDGET_CHARS = 8_000
+
 export function powerShellCommand(script: string): string {
+  const inline = encodedPowerShellCommand(script)
+  if (inline.length <= WINDOWS_REMOTE_COMMAND_LINE_BUDGET_CHARS) {
+    return inline
+  }
+  // Why: these scripts are repetitive enough that gzip beats the UTF-16LE tax by
+  // ~4x, which is the difference between a line cmd.exe runs and one it refuses.
+  const compressed = encodedPowerShellCommand(selfExtractingPowerShellScript(script))
+  if (compressed.length > WINDOWS_REMOTE_COMMAND_LINE_BUDGET_CHARS) {
+    throw new Error(
+      `Remote Windows command needs ${compressed.length} characters; sshd's cmd.exe refuses more than ${CMD_EXE_MAX_COMMAND_LINE_CHARS}.`
+    )
+  }
+  return compressed
+}
+
+function encodedPowerShellCommand(script: string): string {
   return `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodePowerShellCommand(script)}`
+}
+
+/** Orca-prefixed names so the payload can never shadow the bootstrap's own state. */
+function selfExtractingPowerShellScript(script: string): string {
+  const payload = gzipSync(Buffer.from(script, 'utf-8'), { level: 9 }).toString('base64')
+  return [
+    `$OrcaScriptBytes = [Convert]::FromBase64String('${payload}')`,
+    '$OrcaScriptMemory = New-Object System.IO.MemoryStream -ArgumentList (,$OrcaScriptBytes)',
+    '$OrcaScriptGzip = New-Object System.IO.Compression.GZipStream -ArgumentList $OrcaScriptMemory, ([System.IO.Compression.CompressionMode]::Decompress)',
+    '$OrcaScriptReader = New-Object System.IO.StreamReader -ArgumentList $OrcaScriptGzip, ([System.Text.Encoding]::UTF8)',
+    '$OrcaScriptText = $OrcaScriptReader.ReadToEnd()',
+    '$OrcaScriptReader.Dispose()',
+    'Invoke-Expression $OrcaScriptText'
+  ].join('\n')
+}
+
+/** Inverse of `powerShellCommand`: the script the host will actually run. */
+export function decodeRemotePowerShellScript(command: string): string {
+  const encoded = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/u)?.[1]
+  if (!encoded) {
+    return command
+  }
+  const script = Buffer.from(encoded, 'base64').toString('utf16le')
+  const payload = script.match(
+    /^\$OrcaScriptBytes = \[Convert\]::FromBase64String\('([A-Za-z0-9+/=]+)'\)/u
+  )?.[1]
+  return payload ? gunzipSync(Buffer.from(payload, 'base64')).toString('utf-8') : script
 }

--- a/src/main/ssh/ssh-remote-windows-command-line-limit.test.ts
+++ b/src/main/ssh/ssh-remote-windows-command-line-limit.test.ts
@@ -1,0 +1,78 @@
+import { gunzipSync } from 'node:zlib'
+import { describe, expect, it } from 'vitest'
+import { CMD_EXE_MAX_COMMAND_LINE_CHARS } from '../../shared/windows-command-line-budget'
+import { getRemoteHostPlatform } from './ssh-remote-platform'
+import { tryStealInstallLockCommand } from './ssh-relay-install-lock-commands'
+import { decodeRemotePowerShellScript, powerShellCommand } from './ssh-remote-powershell'
+import {
+  cleanupOwnedRelayUploadStageCommand,
+  promoteOwnedRelayUploadStageCommand,
+  recoverOneStaleRelayUploadStageCommand,
+  reserveRelayUploadStageCommand,
+  type RelayUploadStageSlot
+} from './ssh-relay-upload-stage-commands'
+
+const windows = getRemoteHostPlatform('win32-x64')
+const owner = '.sftp-namespace-123e4567e89b12d3a456426614174000'
+const pool = 'C:\\Users\\orca\\.orca-remote\\.upload-stages'
+const stage: RelayUploadStageSlot = {
+  poolDir: pool,
+  slotName: 'slot-0',
+  slotDir: `${pool}\\slot-0`,
+  claimDir: `${pool}\\claim-0`,
+  deleteDir: `${pool}\\delete-0`
+}
+
+// Why: sshd runs an exec request through its DefaultShell, which is cmd.exe on a
+// stock Windows OpenSSH install, and cmd.exe refuses a longer line with exit 1
+// and a localized "The command line is too long" — the whole connect dies there.
+describe('Windows remote command line limit', () => {
+  it.each([
+    ['recover stale upload stage', recoverOneStaleRelayUploadStageCommand(windows, pool)],
+    ['reserve upload stage', reserveRelayUploadStageCommand(windows, pool, owner)],
+    [
+      'promote upload stage',
+      promoteOwnedRelayUploadStageCommand(windows, stage, owner, 'C:\\Users\\orca\\.orca-remote')
+    ],
+    ['cleanup upload stage', cleanupOwnedRelayUploadStageCommand(windows, stage, owner)],
+    [
+      'steal stale install lock',
+      tryStealInstallLockCommand(windows, 'C:\\Users\\orca\\.orca-remote\\relay', 1_200)
+    ]
+  ])('keeps the %s command inside what sshd\u2019s cmd.exe accepts', (_name, command) => {
+    expect(command.length).toBeLessThanOrEqual(CMD_EXE_MAX_COMMAND_LINE_CHARS)
+  })
+
+  it('leaves a command that already fits byte-identical', () => {
+    const script = "Write-Output ([Environment]::GetFolderPath('UserProfile'))"
+    expect(decodeRemotePowerShellScript(powerShellCommand(script))).toBe(script)
+  })
+
+  it('carries an oversized script through gzip without altering it', () => {
+    const script = Array.from(
+      { length: 200 },
+      (_unused, index) => `Write-Output ${index}; $slot = 'C:\\Users\\orca\\stage-${index}'`
+    ).join('\n')
+    const command = powerShellCommand(script)
+    expect(command.length).toBeLessThanOrEqual(CMD_EXE_MAX_COMMAND_LINE_CHARS)
+    expect(decodeRemotePowerShellScript(command)).toBe(script)
+    const bootstrap = Buffer.from(
+      command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)$/u)?.[1] ?? '',
+      'base64'
+    ).toString('utf16le')
+    const payload = bootstrap.match(/FromBase64String\('([A-Za-z0-9+/=]+)'\)/u)?.[1] ?? ''
+    expect(gunzipSync(Buffer.from(payload, 'base64')).toString('utf-8')).toBe(script)
+    expect(bootstrap).toContain('Invoke-Expression $OrcaScriptText')
+  })
+
+  it('refuses a script no encoding can fit instead of letting cmd.exe reject it', () => {
+    let seed = 12345
+    const incompressible = Array.from({ length: 60_000 }, () => {
+      seed = (seed * 1103515245 + 12345) % 2147483648
+      return String.fromCharCode(97 + (seed % 26))
+    }).join('')
+    expect(() => powerShellCommand(`Write-Output '${incompressible}'`)).toThrow(
+      /sshd's cmd\.exe refuses more than 8191/u
+    )
+  })
+})

--- a/src/main/ssh/ssh-remote-windows-command-line-limit.test.ts
+++ b/src/main/ssh/ssh-remote-windows-command-line-limit.test.ts
@@ -1,6 +1,6 @@
 import { gunzipSync } from 'node:zlib'
 import { describe, expect, it } from 'vitest'
-import { CMD_EXE_MAX_COMMAND_LINE_CHARS } from '../../shared/windows-command-line-budget'
+import { CMD_EXE_COMMAND_LINE_MAX_CHARS } from '../providers/windows-shell-args'
 import { getRemoteHostPlatform } from './ssh-remote-platform'
 import { tryStealInstallLockCommand } from './ssh-relay-install-lock-commands'
 import { decodeRemotePowerShellScript, powerShellCommand } from './ssh-remote-powershell'
@@ -40,7 +40,7 @@ describe('Windows remote command line limit', () => {
       tryStealInstallLockCommand(windows, 'C:\\Users\\orca\\.orca-remote\\relay', 1_200)
     ]
   ])('keeps the %s command inside what sshd\u2019s cmd.exe accepts', (_name, command) => {
-    expect(command.length).toBeLessThanOrEqual(CMD_EXE_MAX_COMMAND_LINE_CHARS)
+    expect(command.length).toBeLessThanOrEqual(CMD_EXE_COMMAND_LINE_MAX_CHARS)
   })
 
   it('leaves a command that already fits byte-identical', () => {
@@ -54,7 +54,7 @@ describe('Windows remote command line limit', () => {
       (_unused, index) => `Write-Output ${index}; $slot = 'C:\\Users\\orca\\stage-${index}'`
     ).join('\n')
     const command = powerShellCommand(script)
-    expect(command.length).toBeLessThanOrEqual(CMD_EXE_MAX_COMMAND_LINE_CHARS)
+    expect(command.length).toBeLessThanOrEqual(CMD_EXE_COMMAND_LINE_MAX_CHARS)
     expect(decodeRemotePowerShellScript(command)).toBe(script)
     const bootstrap = Buffer.from(
       command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)$/u)?.[1] ?? '',
@@ -72,7 +72,7 @@ describe('Windows remote command line limit', () => {
       return String.fromCharCode(97 + (seed % 26))
     }).join('')
     expect(() => powerShellCommand(`Write-Output '${incompressible}'`)).toThrow(
-      /sshd's cmd\.exe refuses more than 8191/u
+      /Orca budgets 8000 for a line sshd hands to cmd\.exe/u
     )
   })
 })

--- a/src/shared/windows-command-line-budget.ts
+++ b/src/shared/windows-command-line-budget.ts
@@ -15,18 +15,6 @@
 export const MAX_COMMAND_LINE_CHARS = 30_000
 
 /**
- * The much smaller cap that applies once cmd.exe is in the chain.
- *
- * cmd.exe refuses a longer line outright — exit 1 and a localized "The command
- * line is too long" — and it is in the chain more often than it looks: Windows
- * OpenSSH runs every exec request through sshd's `DefaultShell`, which is
- * cmd.exe on a stock install. So a command Orca sends to a Windows SSH host is
- * charged this budget, not the 32767 one, and `-EncodedCommand` spends 2.67
- * characters per script character on the way there.
- */
-export const CMD_EXE_MAX_COMMAND_LINE_CHARS = 8_191
-
-/**
  * What `CreateProcess` will count.
  *
  * libuv escapes every `"` and doubles a backslash run before a quote, so a

--- a/src/shared/windows-command-line-budget.ts
+++ b/src/shared/windows-command-line-budget.ts
@@ -15,6 +15,18 @@
 export const MAX_COMMAND_LINE_CHARS = 30_000
 
 /**
+ * The much smaller cap that applies once cmd.exe is in the chain.
+ *
+ * cmd.exe refuses a longer line outright — exit 1 and a localized "The command
+ * line is too long" — and it is in the chain more often than it looks: Windows
+ * OpenSSH runs every exec request through sshd's `DefaultShell`, which is
+ * cmd.exe on a stock install. So a command Orca sends to a Windows SSH host is
+ * charged this budget, not the 32767 one, and `-EncodedCommand` spends 2.67
+ * characters per script character on the way there.
+ */
+export const CMD_EXE_MAX_COMMAND_LINE_CHARS = 8_191
+
+/**
  * What `CreateProcess` will count.
  *
  * libuv escapes every `"` and doubles a backslash run before a quote, so a


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 |

<!-- /orca-pr-loc -->

## #16126 — "SSH connect fails locally before connecting"

The triage wording is misleading: nothing fails locally. A **remote** exec dies before the relay is ever uploaded.

Windows OpenSSH runs every `exec` request through sshd's `DefaultShell`, which is **cmd.exe on a stock install**, and cmd.exe refuses a command line over **8191 characters** with exit 1 and a localized *"The command line is too long"* — the reporter's `La línea de comandos es demasiado larga`.

`powerShellCommand` spends **2.67 characters per script character** (UTF-16LE → base64), and five commands on the first-connect path were already over:

| command | chars |
|---|---|
| `recoverWindowsRelayUploadStageCommand` | **23,210** |
| `promoteWindowsRelayUploadStageCommand` | 20,646 |
| `cleanupWindowsRelayUploadStageCommand` | 19,798 |
| `tryStealInstallLockCommand` | 11,798 |
| `reserveWindowsRelayUploadStageCommand` | 9,434 |

The 23,210-character one is the **first exec in the fresh-install branch** (`ssh-relay-deploy.ts:419`), reached the moment `alreadyInstalled` is false — i.e. exactly "create a new project through SSH". Platform detection (~1KB) succeeds first, which is why the connect gets far enough to *look* like it is working and then dies.

**The codebase already knew about this class** — `src/shared/windows-command-line-budget.ts` and `windows-shell-args.ts:17` hold `CMD_EXE_COMMAND_LINE_MAX_CHARS = 8191`. The remote path simply had no budget applied.

## The fix

`powerShellCommand` falls back to a gzip self-extracting bootstrap when the inline form exceeds an 8,000-char budget (margin for sshd's `/c` wrapper); the worst command lands at ~6.5KB. **Commands that already fit are byte-identical.** If even the compressed form cannot fit, it throws naming the limit rather than letting cmd.exe answer in the host's locale.

```
BEFORE  AssertionError: expected 23210 to be less than or equal to 8191
        AssertionError: expected 20646 to be less than or equal to 8191
        AssertionError: expected 19798 to be less than or equal to 8191
        AssertionError: expected 11798 to be less than or equal to 8191
        AssertionError: expected  9434 to be less than or equal to 8191
        Tests  8 failed (8)
AFTER   Tests  8 passed (8)
```

**Verified against a real interpreter, not a mock.** Installed portable pwsh 7.4.6 and ran the existing `ssh-relay-upload-stage-commands.test.ts` suite, which decodes each command and executes it — all 21 pass, and every PowerShell case now runs *through the gzip bootstrap*, proving `Invoke-Expression` preserves the semantics those scripts depend on. Separately confirmed under pwsh that `Invoke-Expression` handles the `Add-Type @'…'@` here-string and that `exit N` inside it exits the process (`probe-ok` / `exit=7`, `should-not-print` suppressed) — the two things that could have silently broken.

**Caveat stated plainly:** decompression uses `System.IO.Compression.GZipStream`, which lives in `System.dll` on .NET Framework so it needs no assembly load on Windows PowerShell 5.1 — but it *is* blocked under Constrained Language Mode. That is not a new constraint: the payload scripts already use `Add-Type` and `[System.IO.File]::WriteAllText`, both CLM-blocked.

## Three issues investigated and NOT fixed here, with evidence

The brief's overlap hypotheses did not hold, which is the first finding.

**#16789 — already fixed on main.** `mobile-relay-e2ee-link.ts` had `socket.onerror = () => this.fail(new Error('relay transport error'))`. Native WebSockets fire `error` just before `close`, so the generic error won the race and **destroyed the typed relay close code on every dial**. Not merely an unreadable log — every recovery branch keys on `RelayOuterError`, so `disable-relay-credential`, `retry-after-host-offline` and the grace-token credential repair never fired. That is exactly "works once, then cannot reconnect": the first dial had a good credential; after rotation the redial got 4401, the generic error hid it, and it fell to plain 500ms→30s backoff forever — the reporter's log verbatim. Fixed by #16293 (2026-08-24); reporter was on mobile 0.0.44, cut 2026-08-16. Proved by reverting the two lines: 4 regression tests fail, restored 12/12 pass.

**#16238 — already fixed on main, and not the same defect as #16789** (different files, commits, subsystems). `resolvePairingInviteThroughDirector` rejected any reply whose `assignmentEpoch <= stored` as fatal — but the director has **no "assignment unchanged" verb**, so with sticky assignments an equal-epoch reply *is* that answer and is the steady state. Every transient cell-dial failure made pairing recovery unwinnable and fell back to the host's LAN address, which cannot work over LTE. Fixed by #16659 (2026-08-26); issue filed two days earlier. The anti-rollback contract is unchanged — a non-newer move is confirmed and re-dialled, never adopted or persisted.

**#16731 — not fixed on main; open PR #16732 covers 2 of 3, and the issue's first diagnosis is wrong.** Claims 2 and 3 verified present (a fire-and-forget focus dispatch with no pending-intent registry; two reveal paths skipping `activateAndRevealWorktree`, which is why entering from the sidebar works). **Claim 1 is false on main:** SSH PTY data *does* reach the headless emulator and `subscribeToTerminalData`, and the emulator is disposed only on PTY exit, not pane unmount — so an SSH PTY that has emitted any byte previews fine while cold-parked.

The real residual is narrower and **not SSH-specific**: a PTY that has produced **zero** bytes has no emulator, no serializer and no snapshot, so `ptyGone` is set. Same shape as #17945 — *a client-side absence read as host evidence of exit*, which the execution-boundary doc forbids; the honest verdict is `unverifiable`.

**Consequence for #16732:** its planned SSH-specific "remote preview unavailable" message keyed on `isSshPty` would still lie for a **local** zero-output pane, and would fire for SSH panes that preview fine. The correct discriminator is "does the runtime still know this PTY" — already available in the same handler via `runtime.getTerminalSize(ptyId)`. Recommend folding that into #16732 rather than opening a fifth PR against the same files.

## Verification

```
pnpm test src/main/ssh          1815 passed | 12 skipped   (ORCA_POWERSHELL_EXECUTABLE → real pwsh)
pnpm test ssh-browse            15 passed
mobile relay transport          48/48
pnpm tc:node                    clean
check:code-quality:changed      0 new findings across 5 files
```

Fixes #16126
Refs #16238, #16789, #16731, #16732