### PR TITLE
fix(ssh): stop respawning an agent onto a PTY the relay just proved alive

### DIFF
--- a/src/main/providers/ssh-pty-errors.ts
+++ b/src/main/providers/ssh-pty-errors.ts
@@ -1,5 +1,13 @@
 export const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
 export const SSH_PTY_IDENTITY_MISMATCH_ERROR = 'SSH_PTY_IDENTITY_MISMATCH'
+/**
+ * The relay accepted the attach for a PTY it had just proven alive and only retired the stale
+ * output delivery. Deliberately not `SSH_SESSION_EXPIRED`: every consumer of that token retires the
+ * pane binding and cold-restores the agent, which duplicates a running agent onto one transcript
+ * (docs/reference/ssh-execution-boundary.md — respawning needs host evidence of absence, and this
+ * reply is host evidence of the opposite).
+ */
+export const SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR = 'SSH_PTY_SOURCE_RESTORE_REQUIRED'
 
 export function isSshPtyNotFoundError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)

--- a/src/main/providers/ssh-pty-live-source-restore-respawn.test.ts
+++ b/src/main/providers/ssh-pty-live-source-restore-respawn.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR,
+  SSH_SESSION_EXPIRED_ERROR,
+  isSshPtyAbsentFromRelayError
+} from './ssh-pty-errors'
+import { SshPtyProvider } from './ssh-pty-provider'
+
+const RESTORE_REQUIRED = {
+  incarnationId: 'incarnation-1',
+  sourceRecovery: { status: 'restoreRequired', reason: 'checkpointUnavailable' }
+}
+
+function providerWithAttachReplies(replies: unknown[]): {
+  provider: SshPtyProvider
+  request: ReturnType<typeof vi.fn>
+} {
+  const request = vi.fn()
+  for (const reply of replies) {
+    request.mockResolvedValueOnce(reply)
+  }
+  const mux = {
+    request,
+    notify: vi.fn(),
+    onNotification: vi.fn().mockReturnValue(vi.fn())
+  }
+  return { provider: new SshPtyProvider('conn-1', mux as never), request }
+}
+
+describe('a live PTY whose source delivery needs restoring', () => {
+  // The relay only reaches a restoreRequired reply after finding the managed PTY and confirming its
+  // process is alive, so the reply is evidence of liveness. `SSH_SESSION_EXPIRED` is the token every
+  // caller uses to retire the pane binding and cold-restore the agent — emitting it here put a
+  // second `claude --resume` onto the transcript of a still-running one (#11006), and leaked the
+  // abandoned remote PTY on every reconnect until the host refused to fork (#9034).
+  it('does not claim the session expired after the retry still needs a restore', async () => {
+    const { provider, request } = providerWithAttachReplies([RESTORE_REQUIRED, RESTORE_REQUIRED])
+
+    const rejection = await provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-1' }).then(
+      () => undefined,
+      (error: unknown) => error
+    )
+
+    expect((rejection as Error).message).not.toContain(SSH_SESSION_EXPIRED_ERROR)
+    expect((rejection as Error).message).toContain(SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR)
+    expect(isSshPtyAbsentFromRelayError(rejection)).toBe(false)
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('reattaches the live PTY when the retry opens a fresh delivery', async () => {
+    const { provider, request } = providerWithAttachReplies([
+      RESTORE_REQUIRED,
+      { incarnationId: 'incarnation-1', replay: 'restored scrollback' }
+    ])
+
+    const result = await provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-1' })
+
+    expect(result).toMatchObject({
+      id: 'ssh:conn-1@@pty-1',
+      isReattach: true,
+      replay: 'restored scrollback'
+    })
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops retrying rather than stacking a delivery on an unconfirmed cancellation', async () => {
+    const request = vi.fn().mockResolvedValue({
+      ...RESTORE_REQUIRED,
+      sourceActivation: {
+        status: 'pending',
+        clientGeneration: 1,
+        ownerGeneration: 1,
+        ptyIncarnation: 'incarnation-1',
+        deliveryToken: 'token-1',
+        checkpointSourceEndSu: 0,
+        recoveryEndSu: 0
+      }
+    })
+    const rollback = vi.fn().mockResolvedValue(false)
+    const mux = {
+      request,
+      notify: vi.fn(),
+      onNotification: vi.fn().mockReturnValue(vi.fn())
+    }
+    const provider = new SshPtyProvider('conn-1', mux as never)
+    const outputState = (provider as unknown as { outputState: Record<string, unknown> })
+      .outputState
+    outputState.installReceivingActivation = () => ({
+      commit: vi.fn(),
+      rollback,
+      transferToRecovery: vi.fn()
+    })
+
+    const rejection = await provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-1' }).then(
+      () => undefined,
+      (error: unknown) => error
+    )
+
+    expect((rejection as Error).message).toContain(SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR)
+    expect((rejection as Error).message).not.toContain(SSH_SESSION_EXPIRED_ERROR)
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(rollback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/providers/ssh-pty-provider-reattach-incarnation.test.ts
+++ b/src/main/providers/ssh-pty-provider-reattach-incarnation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { SSH_SESSION_EXPIRED_ERROR } from './ssh-pty-errors'
+import { SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR } from './ssh-pty-errors'
 import { SshPtyProvider } from './ssh-pty-provider'
 
 describe('SSH PTY provider session reattach incarnation', () => {
@@ -30,7 +30,7 @@ describe('SSH PTY provider session reattach incarnation', () => {
     )
   })
 
-  it('fails closed when generic reattach requires source restoration', async () => {
+  it('fails closed without claiming expiry when reattach requires source restoration', async () => {
     const mux = {
       request: vi.fn().mockResolvedValue({
         incarnationId: 'incarnation-reattached',
@@ -44,8 +44,10 @@ describe('SSH PTY provider session reattach incarnation', () => {
     }
     const provider = new SshPtyProvider('conn-1', mux as never)
 
+    // The relay proved the PTY alive before answering restoreRequired, so the rejection must not
+    // carry the token that makes callers retire the binding and cold-restore the agent.
     await expect(provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-old' })).rejects.toThrow(
-      `${SSH_SESSION_EXPIRED_ERROR}: pty-old`
+      new RegExp(`^${SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR}: pty-old`)
     )
   })
 })

--- a/src/main/providers/ssh-pty-reattach-absence-discrimination.test.ts
+++ b/src/main/providers/ssh-pty-reattach-absence-discrimination.test.ts
@@ -1,7 +1,9 @@
-// Three different refusals leave `reattachSshPtySessionForSpawn` carrying the same
-// `SSH_SESSION_EXPIRED` text, and only one of them observed the process. That text is therefore not
-// a verdict, and a caller that tests it with `.includes()` cannot tell "the host says this PTY is
-// gone" from "the PTY is fine, its source stream needs rebuilding".
+// Two refusals still leave `reattachSshPtySessionForSpawn` carrying the same `SSH_SESSION_EXPIRED`
+// text, and only one of them observed the process. That text is therefore not a verdict, and a
+// caller that tests it with `.includes()` cannot tell "the host says this PTY is gone" from "the id
+// names a live PTY that belongs to another pane". The restoreRequired refusal no longer shares the
+// token at all — it carries `SSH_PTY_SOURCE_RESTORE_REQUIRED`, because the relay proved that PTY
+// alive and only the output delivery was stale.
 //
 // It matters because the callers that DO test it act destructively: `spawn-execute.ts` expires the
 // lease and deletes the in-memory ownership, which between them are the client's only record that a
@@ -10,7 +12,11 @@
 //
 // So this pins the discriminator the destructive branch keys on: the type, not the message.
 import { describe, expect, it, vi } from 'vitest'
-import { isSshPtyAbsentFromRelayError, SSH_SESSION_EXPIRED_ERROR } from './ssh-pty-errors'
+import {
+  isSshPtyAbsentFromRelayError,
+  SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR,
+  SSH_SESSION_EXPIRED_ERROR
+} from './ssh-pty-errors'
 import { reattachSshPtySessionForSpawn } from './ssh-pty-session-reattach'
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 
@@ -51,15 +57,17 @@ describe('an SSH reattach refusal says whether the host observed the PTY', () =>
     expect(isSshPtyAbsentFromRelayError(error)).toBe(true)
   })
 
-  it('does not mark a restoreRequired refusal as absence, though it reads identically', async () => {
+  it('gives a restoreRequired refusal its own token instead of the expiry text', async () => {
     // The PTY attached. The relay answered about it. It is running. Only the source stream could
-    // not be resumed — see the `restoreRequired` carve-out in ssh-pty-errors.ts.
+    // not be resumed — see the `restoreRequired` carve-out in ssh-pty-errors.ts. Carrying the
+    // expiry token here made every `.includes()` caller retire a live pane's binding.
     const error = await refusalFrom(async () => ({
       incarnationId: '11111111-1111-4111-8111-111111111111',
       sourceRecovery: { status: 'restoreRequired', reason: 'checkpoint_unavailable' }
     }))
 
-    expect(error.message).toContain(SSH_SESSION_EXPIRED_ERROR)
+    expect(error.message).toContain(SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR)
+    expect(error.message).not.toContain(SSH_SESSION_EXPIRED_ERROR)
     expect(isSshPtyAbsentFromRelayError(error)).toBe(false)
   })
 

--- a/src/main/providers/ssh-pty-relay-absence-verdict.test.ts
+++ b/src/main/providers/ssh-pty-relay-absence-verdict.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   SSH_PTY_IDENTITY_MISMATCH_ERROR,
+  SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR,
   SSH_SESSION_EXPIRED_ERROR,
   isSshPtyAbsentFromRelayError
 } from './ssh-pty-errors'
@@ -73,6 +74,8 @@ describe('SSH PTY relay absence verdict', () => {
     )
 
     expect(isSshPtyAbsentFromRelayError(rejection)).toBe(false)
-    expect((rejection as Error).message).toContain(SSH_SESSION_EXPIRED_ERROR)
+    // Nor may it wear the expiry token: that is what the renderer retires a pane binding on.
+    expect((rejection as Error).message).not.toContain(SSH_SESSION_EXPIRED_ERROR)
+    expect((rejection as Error).message).toContain(SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR)
   })
 })

--- a/src/main/providers/ssh-pty-session-reattach.ts
+++ b/src/main/providers/ssh-pty-session-reattach.ts
@@ -2,6 +2,7 @@ import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 import { isPtyIncarnationId, type PtyIncarnationId } from '../../shared/pty-incarnation'
 import {
   SSH_PTY_IDENTITY_MISMATCH_ERROR,
+  SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR,
   SSH_SESSION_EXPIRED_ERROR,
   SshPtyAbsentFromRelayError,
   isSshPtyIdentityMismatchError,
@@ -172,6 +173,8 @@ function sameSourceActivation(
 
 export type { PtySourceRecoveryRequest }
 
+const RESTORE_REQUIRED_ATTACH_ATTEMPTS = 2
+
 export async function reattachSshPtySession(args: {
   mux: SshChannelMultiplexer
   connectionId: string
@@ -270,8 +273,8 @@ export async function reattachSshPtySessionWithExitFence(
 
 /**
  * The full reattach path a spawn takes when it carries a sessionId: fence the
- * exit race, reject a session the relay can no longer restore, and commit or
- * roll back the source-activation lease.
+ * exit race, reopen a delivery the relay retired, and commit or roll back the
+ * source-activation lease.
  *
  * Lives here rather than in SshPtyProvider.spawn so the lease's commit and
  * rollback stay in one place — a caller that only wrapped the fence could
@@ -282,24 +285,44 @@ export async function reattachSshPtySessionForSpawn(
     acceptLivePty: (relayPtyId: string) => void
   }
 ): Promise<PtySpawnResult> {
-  let result: SshPtyReattachResult | undefined
-  try {
-    result = await reattachSshPtySessionWithExitFence(args)
-    if (result.sourceRecovery?.status === 'restoreRequired') {
-      throw new Error(
-        `${SSH_SESSION_EXPIRED_ERROR}: ${toRelaySshPtyId(args.connectionId, result.id)}`
-      )
+  let restoreRequiredReason = 'unknown'
+  // The relay retires the stale delivery as it answers restoreRequired, so the next attach opens a
+  // fresh one with full replay. One immediate retry keeps the ordinary reconnect off the renderer's
+  // 15s-cooldown pane-recovery ladder.
+  for (let attempt = 0; attempt < RESTORE_REQUIRED_ATTACH_ATTEMPTS; attempt++) {
+    let result: SshPtyReattachResult | undefined
+    try {
+      result = await reattachSshPtySessionWithExitFence(args)
+      if (result.sourceRecovery?.status === 'restoreRequired') {
+        restoreRequiredReason = result.sourceRecovery.reason
+        const lease = result.sourceActivationLease
+        // An unconfirmed cancellation must not stack a second delivery on the first.
+        if (lease && !(await lease.rollback())) {
+          break
+        }
+        continue
+      }
+      args.acceptLivePty(result.id)
+      result.sourceActivationLease?.commit()
+      const {
+        sourceActivationLease: _lease,
+        sourceRecovery: _sourceRecovery,
+        ...spawnResult
+      } = result
+      return spawnResult
+    } catch (error) {
+      result?.sourceActivationLease?.rollback()
+      throw error
     }
-    args.acceptLivePty(result.id)
-    result.sourceActivationLease?.commit()
-    const {
-      sourceActivationLease: _lease,
-      sourceRecovery: _sourceRecovery,
-      ...spawnResult
-    } = result
-    return spawnResult
-  } catch (error) {
-    result?.sourceActivationLease?.rollback()
-    throw error
   }
+  // Why not SSH_SESSION_EXPIRED: the relay only reaches a restoreRequired reply after finding the
+  // managed PTY and confirming its process is alive, so this is `unverifiable` about the delivery
+  // and positive evidence the PTY is live. Claiming expiry here made the caller retire the pane
+  // binding and cold-restore the agent into a second copy of a running session.
+  throw new Error(
+    `${SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR}: ${toRelaySshPtyId(
+      args.connectionId,
+      args.sessionId
+    )} ${restoreRequiredReason}`
+  )
 }

--- a/src/renderer/src/components/terminal-pane/ipc-pty-connect.ts
+++ b/src/renderer/src/components/terminal-pane/ipc-pty-connect.ts
@@ -12,10 +12,10 @@ import {
 import { projectIpcPtyConnectResult } from './ipc-pty-connect-result'
 import { waitAtTerminalPtyPreSpawnE2EBarrier } from './terminal-pty-pre-spawn-e2e-barrier'
 import type { IpcPtySessionHandlers } from './ipc-pty-session-handlers'
+import { isSshSessionGoneError } from './pty-connection/pty-connect-limits'
 import { spawnIpcPty } from './ipc-pty-spawn-request'
 import type { IpcPtyTransportOptions, PtyConnectResult, PtyTransport } from './pty-transport-types'
 
-const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
 const SSH_PTY_CONNECTION_MISMATCH_MARKER = 'belongs to SSH connection'
 
 type PtyConnectOptions = Parameters<PtyTransport['connect']>[0]
@@ -183,8 +183,7 @@ function handleConnectError(
   if (
     connectionId &&
     options.sessionId &&
-    (message.includes(SSH_SESSION_EXPIRED_ERROR) ||
-      message.includes(SSH_PTY_CONNECTION_MISMATCH_MARKER))
+    (isSshSessionGoneError(message) || message.includes(SSH_PTY_CONNECTION_MISMATCH_MARKER))
   ) {
     return { id: options.sessionId, sessionExpired: true }
   }

--- a/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-attach.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-attach.ts
@@ -3,12 +3,9 @@ import { useAppStore } from '@/store'
 import { isRuntimeOwnedSshTargetId } from '../../../../../shared/execution-host'
 import { resolveSshPaneConnectGate } from '../ssh-pane-connect-gate'
 
-import {
-  isSshSessionExpiredError,
-  waitForUserInitiatedSshConnect,
-  waitForSshConnection
-} from './ssh-session-connect'
+import { waitForUserInitiatedSshConnect, waitForSshConnection } from './ssh-session-connect'
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
+import { isSshSessionGoneError } from './pty-connect-limits'
 import { toProcessExitStartup } from './process-exit-startup'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
@@ -153,7 +150,7 @@ export function runDeferredSessionAttach(session: ConnectPanePtySession): void {
           session.clearHiddenOutputRestoreState()
           const outputCallbacks = session.captureTransportOutputCallbacks(
             (message) => {
-              if (isSshSessionExpiredError(message)) {
+              if (isSshSessionGoneError(message)) {
                 expiredReattachError = true
                 return
               }
@@ -287,7 +284,7 @@ export function runDeferredSessionAttach(session: ConnectPanePtySession): void {
               if (session.rejectObsoleteDirectSshReattach(pendingSessionId)) {
                 return
               }
-              if (isSshSessionExpiredError(err)) {
+              if (isSshSessionGoneError(err)) {
                 useAppStore.getState().removeDeferredSshSessionId(session.deps.tabId)
                 session.clearExitedPanePtyLayoutBinding(pendingSessionId)
                 session.deps.clearTabPtyId(session.deps.tabId, pendingSessionId)

--- a/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-reattach-connect.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-reattach-connect.ts
@@ -1,6 +1,6 @@
 import { warnTerminalLifecycleAnomaly } from '../terminal-lifecycle-diagnostics'
 import { recordPtyConnectDiagnostic } from './pty-connect-limits'
-import { isSshSessionExpiredError } from './ssh-session-connect'
+import { isSshSessionGoneError } from './pty-connect-limits'
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
 import { toProcessExitStartup } from './process-exit-startup'
 import { recoverUnverifiableDirectSshReattach } from './direct-ssh-reattach-recovery'
@@ -28,7 +28,7 @@ export function startDeferredSessionReattach(
   const coldRestoreStartup = session.buildColdRestoreAgentResumeStartup()
   const outputCallbacks = session.captureTransportOutputCallbacks(
     (message) => {
-      if (isSshSessionExpiredError(message)) {
+      if (isSshSessionGoneError(message)) {
         expiredReattachError = true
         return
       }
@@ -165,7 +165,7 @@ export function startDeferredSessionReattach(
         ptyId: deferredReattachSessionId,
         reason: message
       })
-      if (session.connectionId && isSshSessionExpiredError(err)) {
+      if (session.connectionId && isSshSessionGoneError(err)) {
         session.clearExitedPanePtyLayoutBinding(deferredReattachSessionId)
         session.deps.clearTabPtyId(session.deps.tabId, deferredReattachSessionId)
         session.startFreshColdRestoreAgentResume(coldRestoreStartup, {

--- a/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-reattach-connect.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-reattach-connect.ts
@@ -1,6 +1,5 @@
 import { warnTerminalLifecycleAnomaly } from '../terminal-lifecycle-diagnostics'
-import { recordPtyConnectDiagnostic } from './pty-connect-limits'
-import { isSshSessionGoneError } from './pty-connect-limits'
+import { isSshSessionGoneError, recordPtyConnectDiagnostic } from './pty-connect-limits'
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
 import { toProcessExitStartup } from './process-exit-startup'
 import { recoverUnverifiableDirectSshReattach } from './direct-ssh-reattach-recovery'

--- a/src/renderer/src/components/terminal-pane/pty-connection/pty-connect-limits.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pty-connect-limits.ts
@@ -3,6 +3,25 @@ import { e2eConfig } from '@/lib/e2e-config'
 export const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 export const pendingSpawnGenerationByPaneKey = new Map<string, number>()
 export const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
+const SSH_PTY_IDENTITY_MISMATCH_ERROR = 'SSH_PTY_IDENTITY_MISMATCH'
+
+/**
+ * True only when the host answered that this pane's PTY is gone, which is the one thing that
+ * licenses retiring the binding and cold-restoring the agent into a fresh shell.
+ *
+ * The mismatch suffix is excluded because it means the opposite: the relay found a LIVE PTY under
+ * that id owned by another pane, and says nothing about this pane's process. Respawning there puts
+ * a second agent on one transcript (docs/reference/ssh-execution-boundary.md). Main already refuses
+ * to respawn on it — `isPtyAlreadyGoneError` takes the class, not the message — so a bare substring
+ * test here silently disagreed with the gate one process over.
+ */
+export function isSshSessionGoneError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return (
+    message.includes(SSH_SESSION_EXPIRED_ERROR) &&
+    !message.includes(SSH_PTY_IDENTITY_MISMATCH_ERROR)
+  )
+}
 // Why: relay requests expire at 30s; leave one second for their fallback before re-arming locally.
 export const DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS = 31_000
 export const REMOTE_PTY_ID_PREFIX = 'remote:'

--- a/src/renderer/src/components/terminal-pane/pty-connection/ssh-session-connect.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/ssh-session-connect.ts
@@ -1,5 +1,4 @@
 import { useAppStore } from '@/store'
-import { SSH_SESSION_EXPIRED_ERROR } from './pty-connect-limits'
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
 
 // Why: when multiple panes/tabs need the same deferred SSH connection,
@@ -10,10 +9,6 @@ export type SshConnectResult = { connected: true } | { connected: false; error: 
 type UserInitiatedSshConnectOutcome = 'connected' | 'cancelled' | 'failed'
 
 const sshConnectPromises = new Map<string, Promise<SshConnectResult>>()
-
-export function isSshSessionExpiredError(err: unknown): boolean {
-  return (err instanceof Error ? err.message : String(err)).includes(SSH_SESSION_EXPIRED_ERROR)
-}
 
 function sshPromptConnectOutcomeForStatus(
   status: string | undefined,

--- a/src/renderer/src/components/terminal-pane/pty-connection/ssh-session-gone-verdict.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/ssh-session-gone-verdict.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { isSshSessionGoneError } from './pty-connect-limits'
+
+// The only gate the renderer has for "retire this pane's binding and cold-restore the agent into a
+// fresh shell". Anything it accepts that is not host-attested absence puts a second `--resume` on a
+// running agent's transcript (docs/reference/ssh-execution-boundary.md).
+describe('the renderer verdict that licenses replacing a pane PTY', () => {
+  it('accepts the relay answering that this pane PTY is gone', () => {
+    expect(isSshSessionGoneError(new Error('SSH_SESSION_EXPIRED: ssh:conn-1@@pty-1'))).toBe(true)
+  })
+
+  // The relay found a LIVE PTY under that id belonging to another pane. It observed nothing about
+  // this pane's process, and main's own gate (`isPtyAlreadyGoneError`) already refuses to respawn
+  // on it — the renderer read the same message as absence and respawned anyway.
+  it('refuses an identity mismatch, which names a live PTY owned by another pane', () => {
+    expect(
+      isSshSessionGoneError(
+        new Error('SSH_SESSION_EXPIRED: ssh:conn-1@@pty-1 SSH_PTY_IDENTITY_MISMATCH')
+      )
+    ).toBe(false)
+  })
+
+  it('refuses an identity mismatch wrapped by the IPC boundary', () => {
+    expect(
+      isSshSessionGoneError(
+        "Error invoking remote method 'pty:spawn': Error: SSH_SESSION_EXPIRED: ssh:conn-1@@pty-1 SSH_PTY_IDENTITY_MISMATCH"
+      )
+    ).toBe(false)
+  })
+
+  // A live PTY whose output delivery needs reopening: main no longer wears the expiry token for it,
+  // and the verdict must stay `unverifiable` even if some future caller reintroduces the wording.
+  it('refuses a source-restore verdict for a PTY the relay just proved alive', () => {
+    expect(
+      isSshSessionGoneError(
+        new Error('SSH_PTY_SOURCE_RESTORE_REQUIRED: ssh:conn-1@@pty-1 checkpointUnavailable')
+      )
+    ).toBe(false)
+  })
+
+  it.each([
+    ['a lost link', 'SSH connection lost, reconnecting...'],
+    ['a request timeout', 'Request "pty.attach" timed out after 10000ms'],
+    ['a disposed multiplexer', 'Multiplexer disposed']
+  ])('refuses %s', (_label, message) => {
+    expect(isSshSessionGoneError(new Error(message))).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​177 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​165 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 |

<!-- /orca-pr-loc -->

Corruption-class: two `claude --resume` processes writing one transcript file.

## #11006 — the gate was never host-attested, and #12448's fix could not reach it

**#12448 hardened only the main-side gate** (`isSshPtyAbsentFromRelayError` → `isPtyAlreadyGoneError` → `spawnForStablePane`). It deliberately kept the error **message** byte-identical — and the renderer's respawn gate reads the message, not the class.

The chain:

1. `relay-pty-source-publication.ts:117-127` answers `restoreRequired` — but only *after* `pty-handler.ts:1006-1015` found the managed PTY and confirmed `isProcessAlive(managed.pty.pid)`. **That reply is positive host evidence of liveness.**
2. `ssh-pty-session-reattach.ts:288-292` converted it to `Error("SSH_SESSION_EXPIRED: <relayId>")`.
3. `spawn-execute.ts:143-172` matched the substring → cleared provider state, deleted ownership, marked the lease `expired`.
4. `ipc-pty-connect.ts:186` → `{ sessionExpired: true }`.
5. → `startFreshColdRestoreAgentResume` → a fresh PTY **plus** the agent resume command. Two `claude --resume` on one transcript.

A second gate of the same class: `reattachSshPtySession:231` emits that same token for an **identity mismatch** — which `ssh-pty-errors.ts:14-24` itself documents as *"the id names a live PTY belonging to another pane"*. Main refuses to respawn on it; the renderer's `.includes('SSH_SESSION_EXPIRED')` did not.

**Fixed at the gate, not with a downstream dedupe.** `restoreRequired` now retries once (the relay retires the stale delivery as it answers, so attempt 2 opens a fresh one with full replay) and then throws `SSH_PTY_SOURCE_RESTORE_REQUIRED`, which claims nothing about absence — existing callers already route non-absence to a remount-and-reattach with no shell restart. The renderer's verdict is now `isSshSessionGoneError`, which excludes the identity-mismatch suffix, replacing a duplicated substring test in two files.

```
BEFORE  × does not claim the session expired after the retry still needs a restore
        × reattaches the live PTY when the retry opens a fresh delivery
        × stops retrying rather than stacking a delivery on an unconfirmed cancellation
        expected 'SSH_SESSION_EXPIRED: pty-1' not to contain 'SSH_SESSION_EXPIRED'
        Tests  3 failed (3)
AFTER   Tests  3 passed (3)

BEFORE  × refuses an identity mismatch, which names a live PTY owned by another pane
        × refuses an identity mismatch wrapped by the IPC boundary
        Tests  2 failed | 5 passed (7)
AFTER   Tests  7 passed (7)
```

## #9034 — the same bug's resource consequence, fixed by the same change

Not separate. The `sessionExpired` branch drops the client binding and marks the lease `expired` but **never kills the remote PTY** — correctly, since there is no evidence it should. So every reconnect hitting `restoreRequired` left one more live detached PTY on the host *and* spawned a replacement, until `posix_spawnp failed`. Fixing the gate removes the source. No dedupe added.

## #12447 — not reproducible, verified by mutation rather than by reading

I disabled the `isRetiredReattachedPtySurface` guard **and** dropped `mayReviveRetiredSurface: false` from the reattach bind, then ran the suites:

```
× suppresses a 'local'-partition retired surface from a 'current' relay
× suppresses a 'host'-partition retired surface from a 'current' relay
× suppresses a 'local'-partition retired surface from a 'legacy' relay
× suppresses a 'host'-partition retired surface from a 'legacy' relay
× restores and persists exact incarnation proof from reconnect attach
```

Both partitions and both relay generations are pinned, with negative controls (*"reattaches a moved pane despite a … tombstone"*) so the guard cannot over-fire. `persistPtyBinding` refuses **before any mutation** — confirmed, the only code above it is pure reads. Guards restored; nothing landed.

**But the `claude --resume`-on-weeks-old-sessions half of #12447 did reach production**, through #11006's `sessionExpired` branch, and is closed by this commit.

## Why #12448's regression net did not catch this

Reverting its classification does fail two tests — so the *class* is guarded. But the **message** it deliberately left unchanged is what #11006 travelled on, and `stable-pane-relay-absence-respawn.test.ts` kept passing under the revert because it injects errors directly and never sees the message path.

Two existing tests pinned the buggy contract and were retargeted, with reasoning in-comment.

## Three weaker-than-host-attested respawn gates found and NOT touched

Each deserves its own change; recording them so they are not lost:

- `ipc-pty-connect.ts:187` — `SSH_PTY_CONNECTION_MISMATCH_MARKER` is thrown **purely client-side** by `ssh-pty-id.ts:51,64` and still mints `sessionExpired: true` → respawn + resume. **No host in the loop at all.**
- `orca-runtime-resolve-terminal-pane.ts:73-97` — accepts `!pty.connected` (loss of contact) plus an `expired` lease within a 30s grace as authority to `createTerminal`, i.e. the host spawns a new remote shell. Several writers of that `expired` state are themselves client-side.
- `direct-ssh-pane-retry-ledger.ts:77-96` — `if (!args.tabPtyId) return true`: absence from a client-side map arms a generation bump that lands on the fresh-spawn path.

## Verification

```
providers + terminal-pane + ssh + ipc/pty     695 files, 7359 passed | 27 skipped
src/main + relay + shared                     3681 passed
tc:node / tc:web                              clean
check:code-quality:changed                    0 new findings across 10 files
```

One pre-existing unrelated failure (`run-electron-vite-dev.test.ts`, mac dev-app symlink copy), confirmed failing identically on a clean stash.

Fixes #11006, #9034
Refs #12447, #12448