### PR TITLE
fix(ssh): prefer 1Password over the empty launchd agent on macOS

### DIFF
--- a/src/main/ssh/ssh-agent-identity-probe.test.ts
+++ b/src/main/ssh/ssh-agent-identity-probe.test.ts
@@ -1,0 +1,111 @@
+import { randomBytes } from 'node:crypto'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { createServer, type Server, type Socket } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { probeAgentIdentityCount } from './ssh-agent-identity-probe'
+
+const SSH_AGENT_IDENTITIES_ANSWER = 12
+const SSH_AGENT_FAILURE = 5
+
+function sshString(payload: Buffer): Buffer {
+  const length = Buffer.alloc(4)
+  length.writeUInt32BE(payload.length)
+  return Buffer.concat([length, payload])
+}
+
+function agentMessage(body: Buffer): Buffer {
+  return sshString(body)
+}
+
+/** A well-formed ed25519 blob: the probe only counts what ssh2 can parse. */
+function ed25519KeyBlob(): Buffer {
+  return Buffer.concat([sshString(Buffer.from('ssh-ed25519')), sshString(randomBytes(32))])
+}
+
+function identitiesAnswer(keyCount: number): Buffer {
+  const header = Buffer.alloc(5)
+  header.writeUInt8(SSH_AGENT_IDENTITIES_ANSWER, 0)
+  header.writeUInt32BE(keyCount, 1)
+  const keys = Array.from({ length: keyCount }, () =>
+    Buffer.concat([sshString(ed25519KeyBlob()), sshString(Buffer.from('probe@test'))])
+  )
+  return agentMessage(Buffer.concat([header, ...keys]))
+}
+
+const openServers: Server[] = []
+const openSockets: Socket[] = []
+const tempDirs: string[] = []
+
+function agentSocketPath(): string {
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\orca-agent-probe-${randomBytes(6).toString('hex')}`
+  }
+  const dir = mkdtempSync(join(tmpdir(), 'oa'))
+  tempDirs.push(dir)
+  return join(dir, 'a.sock')
+}
+
+async function startFakeAgent(onRequest: (socket: Socket) => void): Promise<string> {
+  const socketPath = agentSocketPath()
+  const server = createServer((socket) => {
+    openSockets.push(socket)
+    socket.once('data', () => onRequest(socket))
+  })
+  openServers.push(server)
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve))
+  return socketPath
+}
+
+afterEach(async () => {
+  for (const socket of openSockets.splice(0)) {
+    socket.destroy()
+  }
+  await Promise.all(
+    openServers
+      .splice(0)
+      .map((server) => new Promise<void>((resolve) => server.close(() => resolve())))
+  )
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('probeAgentIdentityCount', () => {
+  it('reports zero for an agent that answers with no identities', async () => {
+    const socketPath = await startFakeAgent((socket) => socket.end(identitiesAnswer(0)))
+
+    await expect(probeAgentIdentityCount(socketPath)).resolves.toBe(0)
+  })
+
+  it('reports the identity count for a populated agent', async () => {
+    const socketPath = await startFakeAgent((socket) => socket.end(identitiesAnswer(2)))
+
+    await expect(probeAgentIdentityCount(socketPath)).resolves.toBe(2)
+  })
+
+  it('reports unknown, not zero, when the agent refuses', async () => {
+    const socketPath = await startFakeAgent((socket) =>
+      socket.end(agentMessage(Buffer.from([SSH_AGENT_FAILURE])))
+    )
+
+    await expect(probeAgentIdentityCount(socketPath)).resolves.toBeUndefined()
+  })
+
+  it('reports unknown, not zero, when the agent hangs up without answering', async () => {
+    const socketPath = await startFakeAgent((socket) => socket.destroy())
+
+    await expect(probeAgentIdentityCount(socketPath)).resolves.toBeUndefined()
+  })
+
+  it('reports unknown, not zero, when the agent never answers', async () => {
+    const socketPath = await startFakeAgent(() => {})
+
+    await expect(probeAgentIdentityCount(socketPath, 50)).resolves.toBeUndefined()
+  })
+
+  it('reports unknown, not zero, when there is no agent at the path', async () => {
+    await expect(probeAgentIdentityCount(agentSocketPath())).resolves.toBeUndefined()
+  })
+})

--- a/src/main/ssh/ssh-agent-identity-probe.ts
+++ b/src/main/ssh/ssh-agent-identity-probe.ts
@@ -1,0 +1,41 @@
+import { createAgent } from 'ssh2'
+
+/**
+ * A local agent answers `REQUEST_IDENTITIES` in about a millisecond. This bound only
+ * exists so a wedged socket cannot stall a connect attempt behind it.
+ */
+export const AGENT_IDENTITY_PROBE_TIMEOUT_MS = 750
+
+/**
+ * How many identities the agent at `socketPath` offers, or `undefined` when it could
+ * not be asked.
+ *
+ * A refusal, a hang, or a reply we cannot read are all "unknown" — never zero. Nothing
+ * may read silence as an empty agent, because the caller's whole reason to ask is to
+ * decide against the socket it is probing.
+ */
+export function probeAgentIdentityCount(
+  socketPath: string,
+  timeoutMs: number = AGENT_IDENTITY_PROBE_TIMEOUT_MS
+): Promise<number | undefined> {
+  return new Promise((resolve) => {
+    let settled = false
+    const settle = (count: number | undefined): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      resolve(count)
+    }
+    const timer = setTimeout(() => settle(undefined), timeoutMs)
+    timer.unref?.()
+    try {
+      createAgent(socketPath).getIdentities((error, keys) =>
+        settle(error || !keys ? undefined : keys.length)
+      )
+    } catch {
+      settle(undefined)
+    }
+  })
+}

--- a/src/main/ssh/ssh-agent-socket-discovery.test.ts
+++ b/src/main/ssh/ssh-agent-socket-discovery.test.ts
@@ -12,9 +12,17 @@ vi.mock('node:os', () => ({
   homedir: () => TEST_HOME
 }))
 
+const mockProbeAgentIdentityCount = vi.fn<(socketPath: string) => Promise<number | undefined>>()
+vi.mock('./ssh-agent-identity-probe', () => ({
+  probeAgentIdentityCount: (socketPath: string) => mockProbeAgentIdentityCount(socketPath)
+}))
+
 import {
   discoverNativeAgentSocket,
+  isAppleLaunchdAgentSocket,
   listAgentSocketCandidates,
+  primeNativeAgentSocketPreference,
+  resetNativeAgentSocketPreference,
   WINDOWS_OPENSSH_AGENT_PIPE
 } from './ssh-agent-socket-discovery'
 import { getRemoteHostPlatform } from './ssh-remote-platform'
@@ -38,6 +46,9 @@ function usePlatform(platform: NodeJS.Platform): void {
 beforeEach(() => {
   mockExistsSync.mockReset()
   mockExistsSync.mockReturnValue(false)
+  mockProbeAgentIdentityCount.mockReset()
+  mockProbeAgentIdentityCount.mockResolvedValue(undefined)
+  resetNativeAgentSocketPreference()
   delete process.env.SSH_AUTH_SOCK
 })
 
@@ -171,5 +182,142 @@ describe('listAgentSocketCandidates host boundary', () => {
         remoteEnv: {}
       })
     ).toEqual([])
+  })
+})
+
+const LAUNCHD_AGENT_SOCKET = '/private/tmp/com.apple.launchd.aGt5gwfoiK/Listeners'
+
+function useMacOsWithOnePasswordInstalled(): void {
+  usePlatform('darwin')
+  mockExistsSync.mockImplementation((path) => path === MACOS_ONEPASSWORD_SOCKET)
+}
+
+describe('isAppleLaunchdAgentSocket', () => {
+  it('matches both spellings of the launchd listener, since /tmp is a symlink', () => {
+    expect(isAppleLaunchdAgentSocket(LAUNCHD_AGENT_SOCKET)).toBe(true)
+    expect(isAppleLaunchdAgentSocket('/tmp/com.apple.launchd.aGt5gwfoiK/Listeners')).toBe(true)
+  })
+
+  it('does not match a socket the user pointed somewhere themselves', () => {
+    expect(isAppleLaunchdAgentSocket('/Users/dev/.gnupg/S.gpg-agent.ssh')).toBe(false)
+    expect(isAppleLaunchdAgentSocket('/private/tmp/com.apple.launchd.aGt5gwfoiK/Other')).toBe(false)
+    expect(isAppleLaunchdAgentSocket('/private/tmp/com.apple.launchd.aGt/nested/Listeners')).toBe(
+      false
+    )
+  })
+})
+
+describe('the macOS launchd discriminator', () => {
+  it('prefers 1Password when the unchosen launchd agent proves it has nothing', async () => {
+    useMacOsWithOnePasswordInstalled()
+    process.env.SSH_AUTH_SOCK = LAUNCHD_AGENT_SOCKET
+    mockProbeAgentIdentityCount.mockResolvedValue(0)
+
+    await primeNativeAgentSocketPreference()
+
+    expect(discoverNativeAgentSocket()).toBe(MACOS_ONEPASSWORD_SOCKET)
+    expect(mockProbeAgentIdentityCount).toHaveBeenCalledWith(LAUNCHD_AGENT_SOCKET)
+  })
+
+  it('never overrides an agent the user actually populated', async () => {
+    useMacOsWithOnePasswordInstalled()
+    process.env.SSH_AUTH_SOCK = LAUNCHD_AGENT_SOCKET
+    mockProbeAgentIdentityCount.mockResolvedValue(1)
+
+    await primeNativeAgentSocketPreference()
+
+    expect(discoverNativeAgentSocket()).toBe(LAUNCHD_AGENT_SOCKET)
+  })
+
+  it('treats an agent that will not answer as unknown, not as empty', async () => {
+    useMacOsWithOnePasswordInstalled()
+    process.env.SSH_AUTH_SOCK = LAUNCHD_AGENT_SOCKET
+    mockProbeAgentIdentityCount.mockResolvedValue(undefined)
+
+    await primeNativeAgentSocketPreference()
+
+    expect(discoverNativeAgentSocket()).toBe(LAUNCHD_AGENT_SOCKET)
+  })
+
+  it('stops re-probing a socket that timed out, but keeps asking one that answered', async () => {
+    useMacOsWithOnePasswordInstalled()
+    process.env.SSH_AUTH_SOCK = LAUNCHD_AGENT_SOCKET
+
+    mockProbeAgentIdentityCount.mockResolvedValue(0)
+    await primeNativeAgentSocketPreference()
+    await primeNativeAgentSocketPreference()
+    expect(mockProbeAgentIdentityCount).toHaveBeenCalledTimes(2)
+
+    resetNativeAgentSocketPreference()
+    mockProbeAgentIdentityCount.mockReset()
+    mockProbeAgentIdentityCount.mockResolvedValue(undefined)
+    await primeNativeAgentSocketPreference()
+    await primeNativeAgentSocketPreference()
+    expect(mockProbeAgentIdentityCount).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-reads an agent that has since been given a key', async () => {
+    useMacOsWithOnePasswordInstalled()
+    process.env.SSH_AUTH_SOCK = LAUNCHD_AGENT_SOCKET
+
+    mockProbeAgentIdentityCount.mockResolvedValue(0)
+    await primeNativeAgentSocketPreference()
+    expect(discoverNativeAgentSocket()).toBe(MACOS_ONEPASSWORD_SOCKET)
+
+    mockProbeAgentIdentityCount.mockResolvedValue(1)
+    await primeNativeAgentSocketPreference()
+    expect(discoverNativeAgentSocket()).toBe(LAUNCHD_AGENT_SOCKET)
+  })
+
+  it('opens nothing when 1Password is not installed', async () => {
+    usePlatform('darwin')
+    process.env.SSH_AUTH_SOCK = LAUNCHD_AGENT_SOCKET
+    mockProbeAgentIdentityCount.mockResolvedValue(0)
+
+    await primeNativeAgentSocketPreference()
+
+    expect(mockProbeAgentIdentityCount).not.toHaveBeenCalled()
+    expect(discoverNativeAgentSocket()).toBe(LAUNCHD_AGENT_SOCKET)
+  })
+
+  it('opens nothing when the user pointed SSH_AUTH_SOCK somewhere themselves', async () => {
+    useMacOsWithOnePasswordInstalled()
+    process.env.SSH_AUTH_SOCK = '/Users/dev/.gnupg/S.gpg-agent.ssh'
+    mockProbeAgentIdentityCount.mockResolvedValue(0)
+
+    await primeNativeAgentSocketPreference()
+
+    expect(mockProbeAgentIdentityCount).not.toHaveBeenCalled()
+    expect(discoverNativeAgentSocket()).toBe('/Users/dev/.gnupg/S.gpg-agent.ssh')
+  })
+
+  it('leaves Linux alone: no launchd agent means no discriminator', async () => {
+    usePlatform('linux')
+    mockExistsSync.mockImplementation((path) => path === LINUX_ONEPASSWORD_SOCKET)
+    process.env.SSH_AUTH_SOCK = '/run/user/1000/keyring/ssh'
+    mockProbeAgentIdentityCount.mockResolvedValue(0)
+
+    await primeNativeAgentSocketPreference()
+
+    expect(mockProbeAgentIdentityCount).not.toHaveBeenCalled()
+    expect(discoverNativeAgentSocket()).toBe('/run/user/1000/keyring/ssh')
+  })
+
+  it('leaves Windows alone, whose pipe 1Password already serves', async () => {
+    usePlatform('win32')
+    process.env.SSH_AUTH_SOCK = WINDOWS_OPENSSH_AGENT_PIPE
+    mockProbeAgentIdentityCount.mockResolvedValue(0)
+
+    await primeNativeAgentSocketPreference()
+
+    expect(mockProbeAgentIdentityCount).not.toHaveBeenCalled()
+    expect(discoverNativeAgentSocket()).toBe(WINDOWS_OPENSSH_AGENT_PIPE)
+  })
+
+  it('holds to $SSH_AUTH_SOCK when nothing primed the decision', () => {
+    useMacOsWithOnePasswordInstalled()
+    process.env.SSH_AUTH_SOCK = LAUNCHD_AGENT_SOCKET
+
+    expect(discoverNativeAgentSocket()).toBe(LAUNCHD_AGENT_SOCKET)
   })
 })

--- a/src/main/ssh/ssh-agent-socket-discovery.ts
+++ b/src/main/ssh/ssh-agent-socket-discovery.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, posix } from 'node:path'
+import { probeAgentIdentityCount } from './ssh-agent-identity-probe'
 import { joinRemotePath, type RemoteHostPlatform } from './ssh-remote-platform'
 
 /**
@@ -110,15 +111,88 @@ function nativeAgentEndpointExists(endpoint: string): boolean {
 }
 
 /**
+ * The socket launchd hands every macOS GUI process. `/tmp` is a symlink to
+ * `/private/tmp`, so both spellings name the same listener.
+ *
+ * Because launchd always sets it, its presence says nothing about whether the user
+ * chose it — unlike any other `$SSH_AUTH_SOCK` value, which someone had to write.
+ */
+const APPLE_LAUNCHD_AGENT_SOCKET = /^\/(?:private\/)?tmp\/com\.apple\.launchd\.[^/]+\/Listeners$/
+
+export function isAppleLaunchdAgentSocket(socketPath: string): boolean {
+  return APPLE_LAUNCHD_AGENT_SOCKET.test(socketPath)
+}
+
+/**
+ * The launchd socket last proven to offer nothing, and the ones that would not say.
+ *
+ * An agent that answered is re-asked on the next attempt, so an `ssh-add` takes effect
+ * immediately. One that timed out is not: retrying it would only re-pay the timeout on
+ * every connect, and the incumbent stands either way.
+ */
+let emptyLaunchdAgentSocket: string | undefined
+const unreadableLaunchdAgentSockets = new Set<string>()
+
+/** The 1Password socket worth displacing an unchosen, empty launchd agent for. */
+function installedOnePasswordSocketOverLaunchd(envSocket: string | undefined): string | undefined {
+  if (process.platform !== 'darwin' || !envSocket || !isAppleLaunchdAgentSocket(envSocket)) {
+    return undefined
+  }
+  const endpoint = onePasswordAgentEndpoint({ kind: 'native' })
+  return endpoint && nativeAgentEndpointExists(endpoint) ? endpoint : undefined
+}
+
+/**
+ * Ask the incumbent macOS agent whether it has anything to offer, before
+ * {@link discoverNativeAgentSocket} has to choose.
+ *
+ * Deliberately not a "first socket with keys wins" sweep: it probes one socket, in the
+ * single ambiguous case where the user never picked the incumbent and a 1Password agent
+ * is installed beside it. Everywhere else — a populated agent, a socket the user pointed
+ * somewhere themselves, no 1Password — nothing is opened and nothing is overridden.
+ *
+ * Skipping this leaves resolution exactly as it was: `$SSH_AUTH_SOCK` wins.
+ */
+export async function primeNativeAgentSocketPreference(): Promise<void> {
+  emptyLaunchdAgentSocket = undefined
+  const envSocket = process.env.SSH_AUTH_SOCK
+  if (!envSocket || !installedOnePasswordSocketOverLaunchd(envSocket)) {
+    return
+  }
+  if (unreadableLaunchdAgentSockets.has(envSocket)) {
+    return
+  }
+  const identityCount = await probeAgentIdentityCount(envSocket)
+  if (identityCount === undefined) {
+    unreadableLaunchdAgentSockets.add(envSocket)
+    return
+  }
+  if (identityCount === 0) {
+    emptyLaunchdAgentSocket = envSocket
+  }
+}
+
+export function resetNativeAgentSocketPreference(): void {
+  emptyLaunchdAgentSocket = undefined
+  unreadableLaunchdAgentSockets.clear()
+}
+
+/**
  * The agent socket on the machine running this process — the only host ssh2 can reach.
  *
  * `$SSH_AUTH_SOCK` is returned as the user set it; the 1Password endpoint is a guess,
  * so it is only returned once proven present rather than handed over as a dead path.
+ * The one exception is the macOS agent nobody chose and that has already been proven
+ * empty — see {@link primeNativeAgentSocketPreference}.
  */
 export function discoverNativeAgentSocket(): string | undefined {
   const envSocket = process.env.SSH_AUTH_SOCK
   if (envSocket) {
-    return envSocket
+    return (
+      (emptyLaunchdAgentSocket === envSocket
+        ? installedOnePasswordSocketOverLaunchd(envSocket)
+        : undefined) ?? envSocket
+    )
   }
   const endpoint = onePasswordAgentEndpoint({ kind: 'native' })
   return endpoint && nativeAgentEndpointExists(endpoint) ? endpoint : undefined

--- a/src/main/ssh/ssh-auth-resolution.ts
+++ b/src/main/ssh/ssh-auth-resolution.ts
@@ -3,7 +3,10 @@ import { utils, type BaseAgent, type ParsedKey } from 'ssh2'
 import type { SshTarget } from '../../shared/ssh-types'
 import type { SshResolvedConfig } from './ssh-config-parser'
 import { createIdentityFilteredAgent } from './ssh-agent-identity-filter'
-import { discoverNativeAgentSocket } from './ssh-agent-socket-discovery'
+import {
+  discoverNativeAgentSocket,
+  primeNativeAgentSocketPreference
+} from './ssh-agent-socket-discovery'
 import { resolveSshConfigHomePath } from './ssh-config-path-expansion'
 import { isOpenSshConfigBackedTarget } from './system-ssh-args'
 
@@ -63,15 +66,41 @@ function expandIdentityAgentEnv(value: string): string | undefined {
   return missingEnv ? undefined : expanded
 }
 
-export function resolveAgentSocket(
-  target: Pick<SshTarget, 'identityAgent' | 'configHost' | 'source' | 'host'>,
-  resolved: Pick<SshResolvedConfig, 'identityAgent'> | null
+type AgentSocketTarget = Pick<SshTarget, 'identityAgent' | 'configHost' | 'source' | 'host'>
+type AgentSocketResolvedConfig = Pick<SshResolvedConfig, 'identityAgent'>
+
+function configuredIdentityAgentFor(
+  target: AgentSocketTarget,
+  resolved: AgentSocketResolvedConfig | null
 ): string | undefined {
   // Why: imported config-host targets may contain raw OpenSSH tokens like %d.
   // ssh -G resolves those tokens, so its value must win when available.
-  const configuredIdentityAgent = isOpenSshConfigBackedTarget(target)
+  return isOpenSshConfigBackedTarget(target)
     ? (resolved?.identityAgent ?? target.identityAgent)
     : (target.identityAgent ?? resolved?.identityAgent)
+}
+
+/**
+ * Settle anything {@link resolveAgentSocket} needs but cannot ask for synchronously.
+ *
+ * Only reached when the target leaves the agent to discovery — an explicit
+ * `IdentityAgent`, `none` included, is answered without opening any socket at all.
+ */
+export async function prepareAgentSocketResolution(
+  target: AgentSocketTarget,
+  resolved: AgentSocketResolvedConfig | null
+): Promise<void> {
+  if (configuredIdentityAgentFor(target, resolved) != null) {
+    return
+  }
+  await primeNativeAgentSocketPreference()
+}
+
+export function resolveAgentSocket(
+  target: AgentSocketTarget,
+  resolved: AgentSocketResolvedConfig | null
+): string | undefined {
+  const configuredIdentityAgent = configuredIdentityAgentFor(target, resolved)
   if (configuredIdentityAgent != null) {
     const trimmed = configuredIdentityAgent.trim()
     if (!trimmed || trimmed.toLowerCase() === 'none') {

--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -11,7 +11,11 @@ import {
 import { configurePrivateKeyAuthentication } from './ssh-private-key-authentication'
 import { isOpenSshConfigBackedTarget } from './system-ssh-args'
 
-export { findDefaultKeyFile, resolveAgentSocket } from './ssh-auth-resolution'
+export {
+  findDefaultKeyFile,
+  prepareAgentSocketResolution,
+  resolveAgentSocket
+} from './ssh-auth-resolution'
 
 export type SshCredentialKind = 'passphrase' | 'password' | 'keyboard-interactive'
 

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -39,6 +39,7 @@ import {
   isPassphraseError,
   sleep,
   buildConnectConfig,
+  prepareAgentSocketResolution,
   wrapRemoteCommandForPosixShell,
   createSshOperationAbortError,
   type SshExecOptions,
@@ -818,6 +819,12 @@ export class SshConnection {
     this.systemSshGssapiOnlyForSession = false
     this.useSystemSshTransport = false
 
+    // Why: buildConnectConfig is synchronous, so the one agent question that needs I/O
+    // has to be settled first; skipping it just leaves $SSH_AUTH_SOCK winning as before.
+    await prepareAgentSocketResolution(this.target, resolved)
+    if (!this.isCurrentConnectAttempt(connectGeneration)) {
+      throw this.createCancelledConnectAttemptError()
+    }
     const config = buildConnectConfig(this.target, resolved)
 
     // Why: ssh2 doesn't support ProxyCommand/ProxyJump natively; spawn the resolved proxy and pipe its stdin/stdout as config.sock.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​259 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​259 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​162 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 |

<!-- /orca-pr-loc -->

Closes #17826. Stacked on #17819 (`fix/ssh-1password-agent-socket-discovery`) — review that first.

## ELI5

#17819 taught Orca to find the 1Password SSH agent when `SSH_AUTH_SOCK` is unset. On macOS that never happens: launchd **always** sets `SSH_AUTH_SOCK` for GUI apps, so the fallback is dead code on the platform where 1Password SSH is most used.

This adds one narrow discriminator. Orca prefers 1Password only when **all three** hold:

1. the incumbent `SSH_AUTH_SOCK` is the Apple launchd agent, **and**
2. it answers "I have zero identities", **and**
3. a 1Password socket actually exists.

That is the one genuinely ambiguous case — an agent offering nothing, with a populated 1Password agent sitting right next to it. An agent the user actually populated is never overridden.

## Why not the obvious version

The original contributor PR (#12765, closed unmerged) probed every candidate and took "first socket with keys wins", which let 1Password beat a set-and-non-empty `SSH_AUTH_SOCK`. Its own doc admits that breaks mixed-agent hosts, and it cost ~1s per connect attempt. Here the probe runs **only** when conditions 1 and 3 already hold, so the common path opens nothing.

Caching is asymmetric on purpose: an agent that *answered* is re-probed next attempt, so an `ssh-add` takes effect immediately; one that *timed out* is remembered as unreadable and never re-probed, so a wedged agent cannot re-pay the timeout on every connect.

## User-facing regressions

**None expected.** Specifically:

- An explicit `IdentityAgent` (including `none`) still wins unconditionally — checked before anything is opened.
- Windows is untouched: the launchd path regex cannot match, and the override is gated on darwin. Covered by a test.
- Linux behavior is exactly #17819's.
- If the probe is skipped or fails, behavior degrades to today's: `$SSH_AUTH_SOCK` wins.
- Host scoping from #17819 is unchanged; only `native` reads this process's env.

The honest cost: up to 750ms added to a connect **only** for a macOS user whose launchd agent is empty *and* who has 1Password installed. For that user the connect currently fails outright.

## Testing

29 tests pass. The probe is exercised against a **real unix socket / named pipe**: zero identities, two identities, `SSH_AGENT_FAILURE`, hang-up, never-answers, no socket. Refusal/hang/unreadable all resolve `undefined`, never `0`, so a broken agent cannot be mistaken for an empty one.

**Not verified — no 1Password install available.** Nothing here proves the real group-container socket path is correct, that 1Password answers `REQUEST_IDENTITIES` as ssh2 expects, or that a real launchd agent reports zero on a machine with 1Password. The decision logic is tested against a mocked probe. **This needs one manual check on a Mac with 1Password SSH enabled before merge.**
