### PR TITLE
fix(relay): stream an oversized fs.listFiles reply instead of refusing it

### DIFF
--- a/config/scripts/run-ssh-docker-e2e.mjs
+++ b/config/scripts/run-ssh-docker-e2e.mjs
@@ -71,6 +71,7 @@ const result = spawnSync(
     'tests/e2e/ssh-ai-vault-session-history.spec.ts',
     'tests/e2e/ssh-cold-activation-restore.spec.ts',
     'tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts',
+    'tests/e2e/ssh-docker-quick-open-large-listing.spec.ts',
     'tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts',
     'tests/e2e/ssh-docker-transport-drop-recovery.spec.ts',
     'tests/e2e/ssh-external-image-preview.spec.ts',

--- a/src/main/providers/ssh-filesystem-provider.test.ts
+++ b/src/main/providers/ssh-filesystem-provider.test.ts
@@ -486,14 +486,16 @@ describe('SshFilesystemProvider', () => {
     expect(result).toEqual(searchResult)
   })
 
-  it('listFiles sends fs.listFiles request', async () => {
+  // Why #12547: a monorepo listing does not fit one control-lane frame, so the request opts into
+  // response streaming. An old relay ignores `__streamResponse` and answers plainly, which is the
+  // plain-array case each of these asserts.
+  it('listFiles sends a streamable fs.listFiles request', async () => {
     mux.request.mockResolvedValue(['src/index.ts', 'package.json'])
     const result = await provider.listFiles('/home/user/project')
-    expect(mux.request).toHaveBeenCalledWith(
-      'fs.listFiles',
-      { rootPath: '/home/user/project' },
-      { signal: undefined }
-    )
+    expect(mux.request).toHaveBeenCalledWith('fs.listFiles', {
+      rootPath: '/home/user/project',
+      __streamResponse: true
+    })
     expect(result).toEqual(['src/index.ts', 'package.json'])
   })
 
@@ -503,26 +505,22 @@ describe('SshFilesystemProvider', () => {
       maxResults: 20_000,
       searchQuery: 'target'
     })
-    expect(mux.request).toHaveBeenCalledWith(
-      'fs.listFiles',
-      {
-        rootPath: '/home/user/project',
-        excludePaths: ['/home/user/project/worktrees/b'],
-        maxResults: 20_000,
-        searchQuery: 'target'
-      },
-      { signal: undefined }
-    )
+    expect(mux.request).toHaveBeenCalledWith('fs.listFiles', {
+      rootPath: '/home/user/project',
+      excludePaths: ['/home/user/project/worktrees/b'],
+      maxResults: 20_000,
+      searchQuery: 'target',
+      __streamResponse: true
+    })
   })
 
   it('listFiles omits excludePaths when empty', async () => {
     mux.request.mockResolvedValue([])
     await provider.listFiles('/home/user/project', { excludePaths: [] })
-    expect(mux.request).toHaveBeenCalledWith(
-      'fs.listFiles',
-      { rootPath: '/home/user/project' },
-      { signal: undefined }
-    )
+    expect(mux.request).toHaveBeenCalledWith('fs.listFiles', {
+      rootPath: '/home/user/project',
+      __streamResponse: true
+    })
   })
 
   it('listFiles forwards the cancellation signal to the mux request (#7721)', async () => {
@@ -531,8 +529,8 @@ describe('SshFilesystemProvider', () => {
     await provider.listFiles('/home/user/project', { signal: controller.signal })
     expect(mux.request).toHaveBeenCalledWith(
       'fs.listFiles',
-      { rootPath: '/home/user/project' },
-      { signal: controller.signal }
+      { rootPath: '/home/user/project', __streamResponse: true },
+      { signal: controller.signal, timeoutMs: undefined }
     )
   })
 

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -1,6 +1,7 @@
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 import { isMethodNotFoundError, readFileViaStream } from '../ssh/ssh-filesystem-stream-reader'
 import { uploadBuffer } from '../ssh/sftp-upload'
+import { requestGitStreamable } from '../ssh/ssh-git-response-stream-reader'
 import { lstatViaSftp } from './ssh-filesystem-provider-sftp'
 import {
   downloadFileViaSftp,
@@ -314,7 +315,11 @@ export class SshFilesystemProvider implements IFilesystemProvider {
     // Why #7721: the signal lets a workspace switch send rpc.cancel so the
     // relay aborts the full-tree scan instead of stacking abandoned scans
     // that starve interactive fs.readDir/fs.stat on the shared SSH channel.
-    return (await this.mux.request('fs.listFiles', params, {
+    // Why streamable: a monorepo listing serializes past the relay's 1 MiB control lane, and the
+    // lane it demotes to is refused under unrelated producer load. Opting in moves it to the bulk
+    // lane in chunks; an old relay ignores the flag and answers plainly, which the reader detects
+    // by the sentinel marker being absent.
+    return (await requestGitStreamable(this.mux, 'fs.listFiles', params, {
       signal: options?.signal
     })) as string[]
   }

--- a/src/main/runtime/rpc/methods/files-list-all-page-size.test.ts
+++ b/src/main/runtime/rpc/methods/files-list-all-page-size.test.ts
@@ -1,0 +1,53 @@
+/**
+ * #12547: `files.listAll` did not declare `maxResults`, so "the client names its cap and a full page
+ * means there is more" was wired only on the Electron IPC hop. Web and mobile were saved incidentally,
+ * by `remoteFileContentBudget` defaulting the cap inside `listRuntimeFiles`.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { RpcDispatcher } from '../dispatcher'
+import type { RpcRequest } from '../core'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { FILE_METHODS } from './files'
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+describe('files.listAll page size', () => {
+  // Why #12547: `maxResults` was wired only on the Electron IPC hop, so "a full page means there is
+  // more" was true for a desktop client and incidental for web/mobile. Declaring it here is a new
+  // optional field (wire rule 1): an older host strips it and keeps its own default.
+  it('forwards a client-named page size for a selected worktree', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      listRuntimeFiles: vi.fn().mockResolvedValue(['src/index.ts'])
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('files.listAll', { worktree: 'id:wt-1', maxResults: 20_001 })
+    )
+
+    expect(runtime.listRuntimeFiles).toHaveBeenCalledWith('id:wt-1', {
+      excludePaths: undefined,
+      maxResults: 20_001
+    })
+    expect(response).toMatchObject({ ok: true, result: ['src/index.ts'] })
+  })
+
+  // Why refuse rather than fall back: no released client sends this field, so a malformed value is a
+  // bug in the caller, not skew — the same call `files.search` already makes for its own maxResults.
+  it('refuses a malformed page size instead of silently picking one', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      listRuntimeFiles: vi.fn().mockResolvedValue(['src/index.ts'])
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('files.listAll', { worktree: 'id:wt-1', maxResults: -3 })
+    )
+
+    expect(response).toMatchObject({ ok: false })
+  })
+})

--- a/src/main/runtime/rpc/methods/files.ts
+++ b/src/main/runtime/rpc/methods/files.ts
@@ -93,8 +93,13 @@ const FileSearch = WorktreeSelector.extend({
   maxResults: z.number().int().positive().optional()
 })
 
+// Why: `maxResults` is a new optional field (wire rule 1) — an older host strips it and keeps its
+// own default. It existed only on the Electron IPC hop, so "the client names its cap and a full page
+// means there is more" was true for desktop and merely incidental for web and mobile, which were
+// saved by `remoteFileContentBudget` defaulting the cap inside `listRuntimeFiles`.
 const FileListAll = WorktreeSelector.extend({
-  excludePaths: z.array(z.string()).optional()
+  excludePaths: z.array(z.string()).optional(),
+  maxResults: z.number().int().positive().optional()
 })
 
 const FileUnwatch = z.object({
@@ -236,6 +241,7 @@ export const FILE_METHODS: RpcAnyMethod[] = [
       const maxContentBytes = remoteFileContentBudget(clientKind, requestId)
       return runtime.listRuntimeFiles(params.worktree, {
         excludePaths: params.excludePaths,
+        ...(params.maxResults === undefined ? {} : { maxResults: params.maxResults }),
         ...(signal === undefined ? {} : { signal }),
         ...(maxContentBytes === undefined ? {} : { maxContentBytes })
       })

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -25,6 +25,7 @@ import {
   writeRelayFile
 } from './fs-path-mutation-requests'
 import { buildExcludePathPrefixes } from '../shared/quick-open-filter'
+import { maybeStreamRpcResponse, type GitResponseStreamRegistry } from './git-response-stream'
 import { readRelayFileContent, readRelayFileStreamMetadata } from './fs-handler-file-read'
 import { readRelayFileRange } from './fs-handler-file-range'
 import { FileRangeReadRequestError } from '../shared/file-range-read'
@@ -47,12 +48,19 @@ export class FsHandler {
   private watchRegistry: RelayFilesystemWatchRegistry
   private streamRegistry = new RelayStreamRegistry()
   private listFilesScans = new ListFilesScanCoordinator()
+  private readonly responseStreams: GitResponseStreamRegistry | undefined
 
   constructor(
     dispatcher: RelayDispatcher,
     _context: RelayContext,
-    watcherPool?: RelayWatcherProcessPool
+    watcherPool?: RelayWatcherProcessPool,
+    // Why passed in rather than owned: GitHandler registers the `git.responseAck` route every pump
+    // is credited through, and a client keys reassembly on `streamId` alone — see the header of
+    // git-response-stream.ts. Without one this handler answers plainly, which is the pre-streaming
+    // behavior rather than a stream nothing can credit.
+    responseStreams?: GitResponseStreamRegistry
   ) {
+    this.responseStreams = responseStreams
     this.dispatcher = dispatcher
     this.watchRegistry = new RelayFilesystemWatchRegistry(dispatcher, watcherPool)
     this.registerHandlers()
@@ -204,7 +212,10 @@ export class FsHandler {
     }
   }
 
-  private listFiles(params: Record<string, unknown>, context?: RequestContext): Promise<string[]> {
+  private async listFiles(
+    params: Record<string, unknown>,
+    context?: RequestContext
+  ): Promise<unknown> {
     const rootPath = expandTilde(params.rootPath as string)
     const maxResults =
       typeof params.maxResults === 'number' &&
@@ -224,13 +235,21 @@ export class FsHandler {
     // Why #7721: full-tree scans are the relay's most expensive request; the
     // coordinator caps them at one per client, coalescing duplicates and
     // aborting a stale scan when the workspace changes or the host cancels.
-    return this.listFilesScans.run({
+    const files = await this.listFilesScans.run({
       clientId: context?.clientId ?? 0,
       key: JSON.stringify([rootPath, excludePathPrefixes, maxResults, searchQuery]),
       signal: context?.signal,
       start: (signal) =>
         runListFilesScan(rootPath, excludePathPrefixes, signal, maxResults, searchQuery)
     })
+    // Why: a full listing of a real monorepo serializes past the 1 MiB control lane — Orca's own
+    // checkout is 22.6k paths averaging 58 characters, so a 20,001-row page is ~1.2MB — and the
+    // legacy-response lane it demotes to is refused under unrelated producer load. Streaming makes
+    // size stop being a correctness question instead of picking a row or byte ceiling to refuse at.
+    // A client that did not opt in still gets the plain array, exactly as before.
+    return this.responseStreams
+      ? maybeStreamRpcResponse(files, params, context, this.responseStreams, this.dispatcher)
+      : files
   }
 
   private async workspaceSpaceScan(params: Record<string, unknown>, context: RequestContext) {

--- a/src/relay/fs-list-files-large-response.integration.test.ts
+++ b/src/relay/fs-list-files-large-response.integration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * #12547: a full `fs.listFiles` reply for a real monorepo does not fit the relay's control lane.
+ *
+ * Orca's own checkout is ~22.6k tracked paths averaging 58 characters, so a 20,001-row page
+ * serializes to ~1.2MB — past `DISPATCHER_CONTROL_QUEUE_MAX_BYTES`, which demotes it to the
+ * `legacy-response` lane where an unrelated producer backlog can refuse it. Refusing at a fixed row
+ * or byte ceiling only moves where that shows up; streaming removes it, so these run the real
+ * dispatcher, the real FsHandler and the real client multiplexer over an in-memory pipe and assert
+ * an over-budget listing arrives intact — in both wire directions.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { runListFilesScanMock } = vi.hoisted(() => ({ runListFilesScanMock: vi.fn() }))
+
+vi.mock('./fs-list-files-fallback-chain', () => ({ runListFilesScan: runListFilesScanMock }))
+vi.mock('@parcel/watcher', () => ({ subscribe: vi.fn() }))
+
+import {
+  SshChannelMultiplexer,
+  type MultiplexerTransport
+} from '../main/ssh/ssh-channel-multiplexer'
+import { requestGitStreamable } from '../main/ssh/ssh-git-response-stream-reader'
+import { RelayContext } from './context'
+import { RelayDispatcher } from './dispatcher'
+import { DISPATCHER_CONTROL_QUEUE_MAX_BYTES } from './dispatcher-writer-admission'
+import { FsHandler } from './fs-handler'
+import { GitHandler } from './git-handler'
+import { GitResponseStreamRegistry } from './git-response-stream'
+import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../shared/quick-open-listing-limits'
+
+/** Shaped like this repository: `packages/<name>/src/...`, ~58 characters. */
+function monorepoPaths(count: number): string[] {
+  return Array.from(
+    { length: count },
+    (_, index) =>
+      `packages/pkg-${String(index % 64).padStart(2, '0')}/src/renderer/components/entry-${String(index).padStart(6, '0')}.tsx`
+  )
+}
+
+describe('Integration: an over-budget fs.listFiles reply (#12547)', () => {
+  let mux: SshChannelMultiplexer
+  let dispatcher: RelayDispatcher
+  let fsHandler: FsHandler
+  let gitHandler: GitHandler
+  let writtenFrames: number[]
+
+  beforeEach(() => {
+    runListFilesScanMock.mockReset()
+    writtenFrames = []
+
+    let relayFeed: (data: Buffer) => void
+    const clientDataCallbacks: ((data: Buffer) => void)[] = []
+    const clientTransport: MultiplexerTransport = {
+      write: (data: Buffer) => {
+        setImmediate(() => relayFeed?.(data))
+      },
+      onData: (cb) => {
+        clientDataCallbacks.push(cb)
+      },
+      onClose: () => {}
+    }
+    dispatcher = new RelayDispatcher((data: Buffer) => {
+      writtenFrames.push(data.length)
+      setImmediate(() => {
+        for (const cb of clientDataCallbacks) {
+          cb(data)
+        }
+      })
+      return true
+    })
+    relayFeed = (data: Buffer) => dispatcher.feed(data)
+    // Why: the same single registry production wires, so `git.responseAck` — registered by
+    // GitHandler — credits the pump an fs.listFiles stream parks on.
+    const responseStreams = new GitResponseStreamRegistry()
+    const context = new RelayContext()
+    fsHandler = new FsHandler(dispatcher, context, undefined, responseStreams)
+    gitHandler = new GitHandler(dispatcher, context, undefined, responseStreams)
+    mux = new SshChannelMultiplexer(clientTransport)
+  })
+
+  afterEach(() => {
+    mux.dispose()
+    dispatcher.dispose()
+    fsHandler.dispose()
+    gitHandler.dispose()
+  })
+
+  it('delivers a page too large for the control lane, in chunks no frame has to carry', async () => {
+    const files = monorepoPaths(QUICK_OPEN_LISTING_MAX_RESULTS)
+    // Precondition, measured from the payload rather than asserted between two constants: this is
+    // the listing that does not fit, which is what makes the rest of the test mean anything.
+    expect(Buffer.byteLength(JSON.stringify(files), 'utf8')).toBeGreaterThan(
+      DISPATCHER_CONTROL_QUEUE_MAX_BYTES
+    )
+    runListFilesScanMock.mockResolvedValue(files)
+
+    const received = await requestGitStreamable(mux, 'fs.listFiles', {
+      rootPath: '/remote/root',
+      maxResults: QUICK_OPEN_LISTING_MAX_RESULTS
+    })
+
+    expect(received).toEqual(files)
+    expect(Math.max(...writtenFrames)).toBeLessThan(DISPATCHER_CONTROL_QUEUE_MAX_BYTES)
+  })
+
+  it('still answers a client that never opts into streaming, with the whole array', async () => {
+    const files = monorepoPaths(QUICK_OPEN_LISTING_MAX_RESULTS)
+    runListFilesScanMock.mockResolvedValue(files)
+
+    // Why: an old client sends neither `__streamResponse` nor `maxResults`. It gets one plain frame
+    // on the legacy-response lane, as it did before this call ever learned to stream.
+    const received = await mux.request('fs.listFiles', { rootPath: '/remote/root' })
+
+    expect(received).toEqual(files)
+    expect(Math.max(...writtenFrames)).toBeGreaterThan(DISPATCHER_CONTROL_QUEUE_MAX_BYTES)
+  })
+
+  it('leaves a reply that fits on the plain response path', async () => {
+    const files = monorepoPaths(100)
+    runListFilesScanMock.mockResolvedValue(files)
+
+    const received = await requestGitStreamable(mux, 'fs.listFiles', {
+      rootPath: '/remote/root',
+      maxResults: 100
+    })
+
+    expect(received).toEqual(files)
+    expect(Math.max(...writtenFrames)).toBeLessThan(DISPATCHER_CONTROL_QUEUE_MAX_BYTES)
+  })
+})

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -10,8 +10,7 @@ import {
   createSubmodulePathsCache,
   type SubmodulePathsCache
 } from './git-handler-submodule-ops'
-import { GitResponseStreamRegistry } from './git-response-stream'
-import { GIT_RESPONSE_STREAM_THRESHOLD } from './protocol'
+import { GitResponseStreamRegistry, maybeStreamRpcResponse } from './git-response-stream'
 import { clearGitStatusLineStatsCache } from '../shared/git-status-line-stats-cache'
 import { invalidateGitBranchLineTotalInFlight } from '../shared/git-branch-line-total'
 import { buildRelayGitEnv, buildRelayUnattendedGitEnv } from './relay-command-env'
@@ -68,9 +67,6 @@ export class GitHandler {
   private dispatcher: RelayDispatcher
   private readonly gitDiffReadDedupe = new InFlightPromiseDedupe<unknown>()
   private readonly gitCapabilities = new GitCapabilityCache()
-  // Why: use the bulk lane so large responses do not block interactive PTY echo.
-  private readonly responseStreams = new GitResponseStreamRegistry()
-
   // Why: cache .gitmodules per instance to avoid SSH reads and test leakage.
   private submodulePathsCache: SubmodulePathsCache = createSubmodulePathsCache()
 
@@ -78,7 +74,12 @@ export class GitHandler {
   constructor(
     dispatcher: RelayDispatcher,
     _context: RelayContext,
-    private readonly watcherRegistry?: GitHandlerWatcherRegistry
+    private readonly watcherRegistry?: GitHandlerWatcherRegistry,
+    // Why: use the bulk lane so large responses do not block interactive PTY echo. This handler
+    // registers the `git.responseAck` route below, so in production it takes the relay's single
+    // registry and FsHandler is handed the same one — see the header of git-response-stream.ts for
+    // why a second registry both collides on stream ids and stalls on credit.
+    private readonly responseStreams: GitResponseStreamRegistry = new GitResponseStreamRegistry()
   ) {
     this.dispatcher = dispatcher
     const handlers = createGitHandlerOperationSet({
@@ -132,14 +133,7 @@ export class GitHandler {
     params: Record<string, unknown>,
     context: RequestContext | undefined
   ): unknown {
-    if (params.__streamResponse !== true || !context) {
-      return result
-    }
-    const payload = Buffer.from(JSON.stringify(result ?? null), 'utf-8')
-    if (payload.length <= GIT_RESPONSE_STREAM_THRESHOLD) {
-      return result
-    }
-    return this.responseStreams.startStream(payload, this.dispatcher, context)
+    return maybeStreamRpcResponse(result, params, context, this.responseStreams, this.dispatcher)
   }
 
   private clearGitMutationReadCaches(): void {

--- a/src/relay/git-response-stream.ts
+++ b/src/relay/git-response-stream.ts
@@ -1,11 +1,22 @@
-// Streams large git RPC responses (diff family + exec) onto the bulk lane in
-// chunks instead of one JSON-RPC frame, so a big diff cannot head-of-line-block
-// interactive pty.data echo on the shared SSH channel. Mirrors the fs
-// read-stream credit-window pattern (see fs-handler-file-read.ts) but the
-// payload is an in-memory serialized string rather than a file handle.
+// Streams large RPC responses onto the bulk lane in chunks instead of one
+// JSON-RPC frame, so a big reply cannot head-of-line-block interactive pty.data
+// echo on the shared SSH channel. Mirrors the fs read-stream credit-window
+// pattern (see fs-handler-file-read.ts) but the payload is an in-memory
+// serialized string rather than a file handle.
+//
+// ONE REGISTRY PER RELAY. The `git.*` method names below are the shipped wire
+// spelling and are permanent, the way an opcode number is, so a second handler
+// that needs streaming (`fs.listFiles` is the first) shares this instance rather
+// than minting its own. A second registry is not an option: a client keys
+// reassembly on `streamId` alone, so two would hand out the same id and
+// cross-feed each other's chunks, and only the handler that registers
+// `git.responseAck` can credit the ack window a pump parks on — the other's
+// streams would stall at STREAM_ACK_WINDOW_CHUNKS forever. See
+// `relay-runtime-services.ts` for the wiring.
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import {
   GIT_RESPONSE_CHUNK_SIZE,
+  GIT_RESPONSE_STREAM_THRESHOLD,
   STREAM_ACK_WINDOW_CHUNKS,
   STREAM_ACK_STALL_RECHECK_MS,
   type GitResponseStreamMarker
@@ -219,4 +230,30 @@ export class GitResponseStreamRegistry {
     }
     this.streams.clear()
   }
+}
+
+/**
+ * Opt-in response streaming, shared by every handler that can answer with a
+ * payload too large for one control-lane frame.
+ *
+ * `__streamResponse` is its own negotiation in both directions: an old client
+ * never sends it and gets the plain result, and an old relay ignores it and
+ * answers plainly, which the client detects by the sentinel marker being absent.
+ * So there is no new method and no capability to advertise.
+ */
+export function maybeStreamRpcResponse(
+  result: unknown,
+  params: Record<string, unknown>,
+  context: RequestContext | undefined,
+  registry: GitResponseStreamRegistry,
+  dispatcher: RelayDispatcher
+): unknown {
+  if (params.__streamResponse !== true || !context) {
+    return result
+  }
+  const payload = Buffer.from(JSON.stringify(result ?? null), 'utf-8')
+  if (payload.length <= GIT_RESPONSE_STREAM_THRESHOLD) {
+    return result
+  }
+  return registry.startStream(payload, dispatcher, context)
 }

--- a/src/relay/relay-runtime-services.ts
+++ b/src/relay/relay-runtime-services.ts
@@ -6,6 +6,7 @@ import { RelayContext, expandTilde } from './context'
 import { PtyHandler } from './pty-handler'
 import { FsHandler } from './fs-handler'
 import { GitHandler } from './git-handler'
+import { GitResponseStreamRegistry } from './git-response-stream'
 import { PreflightHandler } from './preflight-handler'
 import { ExternalAutomationsHandler } from './external-automations-handler'
 import { PortScanHandler } from './port-scan-handler'
@@ -51,13 +52,17 @@ export class RelayRuntimeServices {
     )
     this.ptyHandler.setSourcePublication(this.ptySourcePublication)
 
-    this.fsHandler = new FsHandler(dispatcher, context)
+    // Why one instance for both handlers: a client reassembles a streamed reply by `streamId` alone,
+    // so two registries would hand out the same id, and only GitHandler routes the `git.responseAck`
+    // credit every pump waits on. A second registry is not an option — see git-response-stream.ts.
+    const responseStreams = new GitResponseStreamRegistry()
+    this.fsHandler = new FsHandler(dispatcher, context, undefined, responseStreams)
     const watchRegistry = this.fsHandler.getWatchRegistry()
     this.ptyHandler.setWorktreeRemovalCoordinator(watchRegistry)
     watchRegistry.setWorktreePtyTeardown((rootPath) =>
       this.ptyHandler.shutdownForWorktreePath(rootPath)
     )
-    this.gitHandler = new GitHandler(dispatcher, context, watchRegistry)
+    this.gitHandler = new GitHandler(dispatcher, context, watchRegistry, responseStreams)
     const preflightHandler = new PreflightHandler(dispatcher)
     this.skillInstallHandler = new SkillInstallHandler(dispatcher)
     const externalAutomationsHandler = new ExternalAutomationsHandler(dispatcher)

--- a/tests/e2e/helpers/docker-ssh-relay-target.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-target.ts
@@ -211,6 +211,16 @@ export function writeDockerSshRelayTargetFile(
   )
 }
 
+/** Why not `writeDockerSshRelayTargetFile`: that one passes the contents as a shell argument, so a
+ * payload the size of a real repository's path list exceeds ARG_MAX before it reaches the shell. */
+export function copyFileIntoDockerSshRelayTarget(
+  target: DockerSshRelayTarget,
+  localPath: string,
+  remotePath: string
+): void {
+  run('docker', ['cp', localPath, `${target.containerName}:${remotePath}`], { timeoutMs: 120_000 })
+}
+
 export function startDockerSshRelayTarget(testInfo: TestInfo): DockerSshRelayTarget {
   const host = process.env.ORCA_E2E_SSH_TARGET_HOST?.trim() || '127.0.0.1'
   if (host === 'localhost' || host === '::1' || host.startsWith('127.')) {

--- a/tests/e2e/ssh-docker-quick-open-large-listing.spec.ts
+++ b/tests/e2e/ssh-docker-quick-open-large-listing.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * #12547 acceptance: open a repository the size of Orca's own checkout over SSH and list its files.
+ *
+ * The remote tree is seeded from this repository's real `git ls-files` output, so the payload has
+ * the shape that broke: ~22.6k paths averaging 58 characters, whose 20,001-row page serializes to
+ * ~1.2MB — past `DISPATCHER_CONTROL_QUEUE_MAX_BYTES`. Both wire directions are exercised over the
+ * real relay: a current client, and a client that names no `maxResults` at all.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { expect, test } from './helpers/orca-app'
+import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
+import {
+  cleanupDockerSshRelayTarget,
+  copyFileIntoDockerSshRelayTarget,
+  execDockerSshRelayTargetCommand,
+  shellQuote,
+  startDockerSshRelayTarget,
+  type DockerSshRelayTarget
+} from './helpers/docker-ssh-relay-target'
+import { ensureDockerSshRelayImage } from './helpers/docker-ssh-relay-image'
+import { waitForSessionReady } from './helpers/store'
+import { shouldIncludeQuickOpenPath } from '../../src/shared/quick-open-filter'
+
+const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
+const REMOTE_REPO_PATH = '/tmp/orca-quick-open-large-listing-repo'
+const REMOTE_PATH_LIST = '/tmp/orca-quick-open-large-listing-paths.txt'
+/** What the desktop client asks for; a full page is what it reads as "there is more". */
+const CLIENT_PAGE_SIZE = 20_001
+
+function thisRepositoryTrackedPaths(): string[] {
+  const root = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim()
+  // Why -z: `git ls-files` C-quotes any path with a special character, which would seed a tree that
+  // does not match the one being measured.
+  return execFileSync('git', ['ls-files', '-z'], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024 * 256
+  })
+    .split('\0')
+    .filter(Boolean)
+}
+
+function seedRemoteTree(target: DockerSshRelayTarget, paths: string[]): void {
+  const stagingDir = mkdtempSync(path.join(tmpdir(), 'orca-quick-open-large-listing-'))
+  try {
+    const localList = path.join(stagingDir, 'paths.txt')
+    writeFileSync(localList, `${paths.join('\n')}\n`)
+    copyFileIntoDockerSshRelayTarget(target, localList, REMOTE_PATH_LIST)
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true })
+  }
+  const seedScript = [
+    "const fs = require('fs'), path = require('path')",
+    `const list = fs.readFileSync(${JSON.stringify(REMOTE_PATH_LIST)}, 'utf8').split('\\n').filter(Boolean)`,
+    'const seen = new Set()',
+    'for (const entry of list) {',
+    '  const dir = path.dirname(entry)',
+    '  if (dir !== "." && !seen.has(dir)) { fs.mkdirSync(dir, { recursive: true }); seen.add(dir) }',
+    "  fs.writeFileSync(entry, '')",
+    '}'
+  ].join(';')
+  const encoded = Buffer.from(seedScript, 'utf8').toString('base64')
+  execDockerSshRelayTargetCommand(
+    target,
+    [
+      `rm -rf ${shellQuote(REMOTE_REPO_PATH)}`,
+      `mkdir -p ${shellQuote(REMOTE_REPO_PATH)}`,
+      `cd ${shellQuote(REMOTE_REPO_PATH)}`,
+      'git init -q',
+      'git config user.email e2e@test.local',
+      'git config user.name "Orca Docker SSH E2E"',
+      `node -e ${shellQuote(`eval(Buffer.from('${encoded}', 'base64').toString('utf8'))`)}`,
+      'git add -A',
+      'git commit -q -m "seed monorepo-shaped tree"'
+    ].join(' && ')
+  )
+}
+
+test.skip(!RUN_DOCKER_SSH, 'Set ORCA_E2E_SSH_DOCKER=1 to run the Docker SSH relay lane')
+
+test('lists a monorepo-sized remote workspace, with and without a client page size (#12547)', async ({
+  orcaPage
+}, testInfo) => {
+  test.setTimeout(420_000)
+  let target: DockerSshRelayTarget | null = null
+  try {
+    const trackedPaths = thisRepositoryTrackedPaths()
+    expect(trackedPaths.length).toBeGreaterThan(CLIENT_PAGE_SIZE)
+    // Why the real predicate rather than a copy of it: Quick Open prunes a few tracked paths on
+    // purpose (`.husky/` among them), and a hand-written expectation would go stale the first time
+    // that list changes and read as a transport bug.
+    const listablePaths = trackedPaths.filter(shouldIncludeQuickOpenPath)
+    // Precondition, measured rather than assumed: the page a current client asks for does not fit
+    // one control-lane frame, which is the listing that used to be refused outright.
+    expect(
+      Buffer.byteLength(JSON.stringify(trackedPaths.slice(0, CLIENT_PAGE_SIZE)), 'utf8')
+    ).toBeGreaterThan(1024 * 1024)
+
+    ensureDockerSshRelayImage(process.cwd())
+    target = startDockerSshRelayTarget(testInfo)
+    seedRemoteTree(target, trackedPaths)
+
+    await waitForSessionReady(orcaPage)
+    const connected = await connectDockerSshRelayTarget(orcaPage, target, {
+      remotePath: REMOTE_REPO_PATH
+    })
+
+    const listFiles = async (maxResults?: number): Promise<string[]> =>
+      orcaPage.evaluate(
+        ({ connectionId, rootPath, maxResults }) =>
+          window.api.fs.listFiles({
+            rootPath,
+            connectionId,
+            ...(maxResults === undefined ? {} : { maxResults })
+          }),
+        { connectionId: connected.targetId, rootPath: REMOTE_REPO_PATH, maxResults }
+      )
+
+    const currentClient = await listFiles(CLIENT_PAGE_SIZE)
+    expect(currentClient).toHaveLength(CLIENT_PAGE_SIZE)
+
+    // Why: a client that predates `maxResults` on this call sends none at all, and it cannot
+    // reassemble a streamed reply either — it has to be answered on the plain response path.
+    const oldClient = await listFiles()
+    expect(oldClient).toHaveLength(listablePaths.length)
+    expect(new Set(oldClient)).toEqual(new Set(listablePaths))
+  } finally {
+    cleanupDockerSshRelayTarget(target)
+  }
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​348 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​325 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​26 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 |

<!-- /orca-pr-loc -->

Closes #12547. **Standalone on `main`** — previously stacked on #17934 / #17870; it is not any more, and neither is needed. See "Unstacked" below.

## ELI5

Opening Orca's own checkout over SSH cannot list its files in one response frame. The relay demotes any reply over 1 MiB to a lane whose admission depends on unrelated producer load, so a listing that big is delivered or refused depending on what else the host is doing.

Picking a ceiling to refuse at — a row count or a byte budget — does not fix that. It moves where the failure shows up, and it refuses listings that would have been delivered. This routes `fs.listFiles` through `__streamResponse`, the opt-in response streaming that already carries large git diffs onto the bulk lane, so the size of a listing stops being a correctness question.

## The measurement

Against the real `limitQuickOpenFilesBySerializedBytes` and this repository's own tracked file list — 22,617 paths, 58.2 characters average:

| | serialized | fits a 1,044,480-byte budget? |
| :--- | ---: | :--- |
| 20,001-row page (current client) | 1,223,415 B | no — 17,168 / 20,001 |
| uncapped (client that sends no `maxResults`) | 1,346,611 B | no — 17,168 / 22,617 |

Break-even is roughly 49 characters of average path. Any `packages/<name>/src/...` monorepo is over the line. After this change no budget is consulted: the 1.22 MB page becomes 10 chunks of 128 KB on the bulk lane, and the sentinel that replaces it in the response frame is ~150 bytes.

## Wire compatibility

`tests/e2e/cross-version-wire/` does not cover file RPCs, so there is no CI record for this. The reasoning, by hand:

- **Old client + new host.** Sends neither `__streamResponse` nor `maxResults`. `maybeStreamRpcResponse` returns the plain array and it goes out on the `legacy-response` lane exactly as today. No change.
- **New client + old host.** Sends `__streamResponse: true`; an old relay reads only `rootPath` / `maxResults` / `searchQuery` / `excludePaths` and ignores the extra key, answering plainly. `isGitResponseStreamMarker` is false, so the reader returns the plain value. **Rule 1.**
- **No Rule 2 exposure.** `__streamResponse` is self-negotiating in both directions — there is no new method, no new opcode, and nothing to advertise in a handshake. That property is the reason this is the right mechanism rather than a new one.
- **`files.listAll` + `maxResults`.** New optional zod field. An old host `.strip()`s it and keeps its existing 20,001 default; a new host sees `undefined` from an old client and falls back to the same default. Additive both ways. **Rule 1.**

## One registry per relay

`FsHandler` and `GitHandler` now share a single `GitResponseStreamRegistry`, constructed in `relay-runtime-services.ts`. This is a constraint, not a preference, and the header of `git-response-stream.ts` says so for the next handler that wants streaming:

- a client keys reassembly on `streamId` alone, so two registries would hand out the same id and cross-feed each other's chunks;
- only the handler that registers `git.responseAck` can credit the ack window a pump parks on, so the other's streams would stall at `STREAM_ACK_WINDOW_CHUNKS` forever.

`FsHandler` takes it as an optional argument and, without one, answers plainly rather than emitting a stream nothing can credit.

## Testing

- **`tests/e2e/ssh-docker-quick-open-large-listing.spec.ts`** (new) seeds a Docker SSH container from this repository's own `git ls-files -z` and lists it over the real relay. Both directions pass: the 20,001-row page comes back whole, and a request naming no `maxResults` returns all 22,618 listable paths. The expectation is derived from the real `shouldIncludeQuickOpenPath` rather than a hand-written list — Quick Open prunes `.husky/` on purpose, and a copied list would go stale and read as a transport bug.
- **`src/relay/fs-list-files-large-response.integration.test.ts`** (new) runs the real `RelayDispatcher` + `FsHandler` + `GitHandler` + `SshChannelMultiplexer` over an in-memory pipe. Its precondition is measured from the payload, not asserted between two constants, and the streamed and plain cases assert opposite frame-size outcomes on the same payload. Verified to fail when the streaming call is reverted.
- `pnpm tc` clean. `src/relay` 1584 passed. `src/shared` 6549 passed. `check:code-quality:changed` 0 findings.
- `src/main/runtime/automation-change-publication.test.ts` times out at 30s on this machine — reproduced 3/3 on unmodified `main`, pre-existing and unrelated.

## Unstacked

This was stacked on #17934, which is stacked on #17870; both are held on their own findings. The dependency was not real. Against `main`, the change is "share the registry, and return `maybeStreamRpcResponse(...)` instead of returning the scan directly". The row-cap raise and the uncapped-listing throw those PRs introduce are **deliberately left behind** — they belong to those PRs and are part of what is being held. Nothing here asserts on them.

Note that the byte budget an earlier revision of this PR proposed is gone entirely, along with `src/relay/fs-list-files-response-budget.ts` and its tautological `expect(BUDGET).toBeLessThan(DISPATCHER_CONTROL_QUEUE_MAX_BYTES)` self-comparison. Deliverability is the transport's problem, and since #17968 an over-budget response already fails its own request rather than closing the client.
