### PR TITLE
fix(shared): stop isProvenProcessExit minting a proven exit without host evidence

### DIFF
--- a/src/shared/terminal-exit-cause.test.ts
+++ b/src/shared/terminal-exit-cause.test.ts
@@ -109,4 +109,20 @@ describe('isProvenProcessExit', () => {
     // A host shutdown can deliver -1 for every PTY without proving process death.
     expect(isProvenProcessExit(-1)).toBe(false)
   })
+
+  it('refuses to mint a proven exit from a 0 the host cannot vouch for', () => {
+    // #17955: a wrapper that never observed the child (macOS `login -flpq`,
+    // an SSH relay, a bare code) reports 0 for a clean finish, an OOM kill or
+    // an operator close alike. isProvenProcessExit must not treat that 0 as a
+    // proven exit when the caller knows its host cannot vouch for the child.
+    expect(
+      isProvenProcessExit(0, { hostReportsChildExitStatus: false })
+    ).toBe(false)
+    expect(isProvenProcessExit(0, { signal: 0 })).toBe(true)
+  })
+
+  it('keeps historical behaviour when no evidence is supplied', () => {
+    // Existing callers pass only an exit code; they must be unaffected.
+    expect(isProvenProcessExit(42)).toBe(true)
+  })
 })

--- a/src/shared/terminal-exit-cause.test.ts
+++ b/src/shared/terminal-exit-cause.test.ts
@@ -119,6 +119,9 @@ describe('isProvenProcessExit', () => {
       isProvenProcessExit(0, { hostReportsChildExitStatus: false })
     ).toBe(false)
     expect(isProvenProcessExit(0, { signal: 0 })).toBe(true)
+    // A positive signal is proof the process ended, even from a negative
+    // synthetic code — the signal must actually reach resolveProcessExitCause.
+    expect(isProvenProcessExit(-1, { signal: 9 })).toBe(true)
   })
 
   it('keeps historical behaviour when no evidence is supplied', () => {

--- a/src/shared/terminal-exit-cause.ts
+++ b/src/shared/terminal-exit-cause.ts
@@ -108,7 +108,21 @@ export function isDeliberateTerminalExit(cause: TerminalExitCause): boolean {
  * Negative codes are synthetic stop sentinels; they mean that the host lost
  * contact before it could vouch for the child, so downstream cleanup must use
  * the `unverifiable` path instead of treating the tab as exited.
+ *
+ * `evidence` mirrors what `resolveProcessExitCause` sees, so a caller that
+ * knows its host cannot vouch for the child (macOS `login -flpq` wrapper,
+ * SSH relay, a bare code with no cause) can refuse to mint a proven exit from
+ * an ambiguous `0` — the same evidence the sibling `resolveUnreportedExitCause`
+ * relies on. Callers without that knowledge keep the historical behaviour.
  */
-export function isProvenProcessExit(exitCode: number): boolean {
-  return resolveProcessExitCause({ exitCode }).kind !== 'unknown'
+export function isProvenProcessExit(
+  exitCode: number,
+  evidence?: {
+    signal?: number | null
+    hostReportsChildExitStatus?: boolean
+  }
+): boolean {
+  return (
+    resolveProcessExitCause({ exitCode, ...(evidence ?? {}) }).kind !== 'unknown'
+  )
 }

--- a/src/shared/terminal-exit-cause.ts
+++ b/src/shared/terminal-exit-cause.ts
@@ -112,15 +112,12 @@ export function isDeliberateTerminalExit(cause: TerminalExitCause): boolean {
  * `evidence` mirrors what `resolveProcessExitCause` sees, so a caller that
  * knows its host cannot vouch for the child (macOS `login -flpq` wrapper,
  * SSH relay, a bare code with no cause) can refuse to mint a proven exit from
- * an ambiguous `0` — the same evidence the sibling `resolveUnreportedExitCause`
- * relies on. Callers without that knowledge keep the historical behaviour.
+ * an ambiguous `0`, mirroring the distinction `resolveUnreportedExitCause`
+ * already draws. Callers without that knowledge keep the historical behaviour.
  */
 export function isProvenProcessExit(
   exitCode: number,
-  evidence?: {
-    signal?: number | null
-    hostReportsChildExitStatus?: boolean
-  }
+  evidence?: Omit<Parameters<typeof resolveProcessExitCause>[0], 'exitCode'>,
 ): boolean {
   return (
     resolveProcessExitCause({ exitCode, ...(evidence ?? {}) }).kind !== 'unknown'


### PR DESCRIPTION
Fixes #17955

## Problem
`isProvenProcessExit(exitCode)` called `resolveProcessExitCause({ exitCode })` without passing `signal` or `hostReportsChildExitStatus`. A `0` from a host that never observed its child (macOS `login -flpq` wrapper, an SSH relay forwarding a bare code, an older daemon) was therefore attributed as a **proven clean exit** — the exact value the module header calls ambiguous, and the one its sibling `resolveUnreportedExitCause()` deliberately refuses to read (`{ kind: 'unknown', reason: 'cause_unreported' }`).

`hostReportsChildExitStatus` exists precisely to say "this number describes a wrapper, not the agent" — `isProvenProcessExit` never passed it, so it could never reach that branch.

## Fix
`isProvenProcessExit` now accepts the same evidence `resolveProcessExitCause` already honours:

```ts
isProvenProcessExit(exitCode, evidence?: {
  signal?: number | null
  hostReportsChildExitStatus?: boolean
})
```

It forwards both flags through to `resolveProcessExitCause`. A caller that knows its host cannot vouch for the child (set `hostReportsChildExitStatus: false`) can no longer mint a proven exit from a bare `0` — it resolves to `{ kind: 'unknown', reason: 'host_status_unavailable' }`.

Existing callers pass nothing and keep the historical behaviour, so **no reachable path changes**. Per the issue, this is deliberately *not* folded into any respawn-gate branch — it has a separate blast radius.

## Validation
Loaded the real module (esbuild, node):
- `isProvenProcessExit(0, { hostReportsChildExitStatus: false })` → **false** (#17955)
- `isProvenProcessExit(0, { signal: 0 })` → true (signal 0 = absent, host vouches)
- `isProvenProcessExit(0)` / `(42)` → true (historical preservation)
- `isProvenProcessExit(-1)` → false (synthetic sentinel)
- Both changed files compile clean (esbuild).

Tests added in `terminal-exit-cause.test.ts` covering the new evidence path and historical default.