### PR TITLE
fix(ssh): stop expiring relay-reset leases when the force-stop threw

### DIFF
--- a/src/main/ipc/ssh-connection-handlers.ts
+++ b/src/main/ipc/ssh-connection-handlers.ts
@@ -60,14 +60,21 @@ async function doResetRelay(targetId: string, target: SshTarget): Promise<void> 
     assertSshConnectsNotFenced()
     conn = await connectionManager!.connect(target)
   }
+  let relayStopAcknowledged = false
   try {
     await forceStopRelayForTarget(conn, targetId)
+    relayStopAcknowledged = true
   } finally {
     const ptyIds = new Set(getPtyIdsForConnection(targetId))
     for (const lease of persistedStore!.getSshRemotePtyLeases(targetId)) {
       if (lease.state !== 'terminated' && lease.state !== 'expired') {
         ptyIds.add(lease.ptyId)
-        persistedStore!.markSshRemotePtyLease(targetId, lease.ptyId, 'expired')
+        // Why: only a host-acknowledged force-stop may retire a lease. When it threw we never
+        // observed those shells, so expiring them would record a verdict we do not hold; mirrors
+        // ssh:terminateSessions, and the next connect re-attaches (or expires) them on evidence.
+        if (relayStopAcknowledged) {
+          persistedStore!.markSshRemotePtyLease(targetId, lease.ptyId, 'expired')
+        }
       }
     }
     // Why: reset force-kills the remote relay, so every local PTY handle it owned is stale even if the reset command failed after SIGTERM.

--- a/src/main/ipc/ssh-relay-reset-resume.test.ts
+++ b/src/main/ipc/ssh-relay-reset-resume.test.ts
@@ -77,6 +77,38 @@ describe('SSH IPC handlers', () => {
     expect(mockConnectionManager.disconnect).toHaveBeenCalledWith('ssh-1')
   })
 
+  // A force-stop that threw observed nothing about the remote shells, so expiring their leases
+  // would record a verdict Orca never obtained (docs/reference/ssh-execution-boundary.md).
+  it('ssh:resetRelay keeps leases alive when the force-stop never reported a result', async () => {
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    const conn = {}
+    mockSshStore.getTarget.mockReturnValue(target)
+    mockConnectionManager.connect.mockResolvedValue(conn)
+    mockConnectionManager.getConnection.mockReturnValue(undefined)
+    mockStore.getSshRemotePtyLeases.mockReturnValue([
+      { targetId: 'ssh-1', ptyId: 'pty-1', state: 'detached' },
+      { targetId: 'ssh-1', ptyId: 'pty-2', state: 'attached' }
+    ])
+    vi.mocked(getPtyIdsForConnection).mockReturnValue([])
+    mockForceStopRelayForTarget.mockRejectedValueOnce(new Error('channel closed'))
+
+    await expect(handlers.get('ssh:resetRelay')!(null, { targetId: 'ssh-1' })).rejects.toThrow(
+      'channel closed'
+    )
+
+    expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalled()
+    // The local handles are still stale — only the host-side verdict is withheld.
+    expect(clearProviderPtyState).toHaveBeenCalledWith('ssh:ssh-1@@pty-1')
+    expect(deletePtyOwnership).toHaveBeenCalledWith('ssh:ssh-1@@pty-2')
+    expect(mockConnectionManager.disconnect).toHaveBeenCalledWith('ssh-1')
+  })
+
   it('ssh:resetRelay clears scoped live PTYs while expiring raw leases', async () => {
     const target: SshTarget = {
       id: 'ssh-1',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

Fixes the relay-reset path recording a verdict it never obtained. Found during the SSH bug sweep (#17817–#17957).

## ELI5

`ssh:resetRelay` bulk-expired every lease on the target inside a `finally` block — so it fired **even when `forceStopRelayForTarget` threw**. A failed stop means we don't know what happened to those shells; marking their leases dead records a conclusion we never reached. Per `docs/reference/ssh-execution-boundary.md`, loss of contact is never evidence of process death.

Now the expire only runs when the force-stop actually fulfilled:

```ts
let relayStopAcknowledged = false
try {
  await forceStopRelayForTarget(conn, targetId)
  relayStopAcknowledged = true
} finally {
  ...
    if (relayStopAcknowledged) {
      persistedStore!.markSshRemotePtyLease(targetId, lease.ptyId, 'expired')
    }
```

This copies the model already used correctly in the sibling path at `ssh-connection-handlers.ts:156`, which only marks `terminated` when `provider.shutdown` fulfilled and whose comment explicitly keeps the lease alive when shutdown failed.

Local handle cleanup (`clearProviderPtyState` / `deletePtyOwnership`), the credential-flag clear, and the `disconnect` all stay unconditional in the `finally` — those are stale either way and record no verdict. The error still propagates to the IPC caller.

## Nothing is stranded by leaving the leases alone

The next connect resolves them **on evidence**: `ssh-relay-session.ts:2274-2276` and `:1982-1987` both filter `state !== 'terminated' && state !== 'expired'` and attempt reattach.

- If the relay really died, reattach fails not-found and `handlePtyReattachFailure` expires them.
- If it survived — the force-stop threw before killing anything — **the terminals come back**, which is the correct outcome for a failed reset.

`ssh:terminateSessions` also still reaches them.

## User-facing regressions

**None expected.** The only behavior change is on the throw path, where the previous behavior was to record a false verdict. A successful reset is unchanged.

Negative controls: the pre-existing `'ssh:resetRelay force-stops the remote relay and expires tracked leases'` and `'ssh:resetRelay clears scoped live PTYs while expiring raw leases'` both still pass. The new test also asserts local handles are still cleared on the throw path.

**Old-client impact: none.** Main-process only — no RPC params, stream frames, or published content changed.

## Testing

New test `ssh-relay-reset-resume.test.ts` → *'ssh:resetRelay keeps leases alive when the force-stop never reported a result'*.

Before:
```
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 2 times
  1st vi.fn() call: [ "ssh-1", "pty-1", "expired" ]
  2nd vi.fn() call: [ "ssh-1", "pty-2", "expired" ]
 Test Files  1 failed (1)
      Tests  1 failed | 13 passed (14)
```
After:
```
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Suites: 5 files / 50 tests and 3 files / 43 tests green. `tc:node`, `tc:web` clean; `check:code-quality:changed` 0 new findings.
