### PR TITLE
fix(ssh): let an expired lease reattach its orphan instead of stranding it

### DIFF
--- a/src/main/persistence-host-partitioned-sessions.test.ts
+++ b/src/main/persistence-host-partitioned-sessions.test.ts
@@ -17,7 +17,6 @@ import {
   makeWorkspaceLineage
 } from './persistence-test-harness'
 import { worktreeWorkspaceKey } from '../shared/workspace-scope'
-import { TEST_LEAF_1 } from './persistence-session-fixtures'
 
 // Stub the ~/.ssh/config parser so the SSH-import test drives the real Store with deterministic hosts, not the operator's actual ~/.ssh/config.
 const { loadUserSshConfigMock, sshConfigHostsToTargetsMock } = vi.hoisted(() => ({
@@ -93,35 +92,6 @@ describe('Store host-partitioned workspace sessions', () => {
       }
     }
   }
-
-  const makeBoundHostSession = (ptyId: string | null): WorkspaceSessionState => ({
-    ...getDefaultWorkspaceSession(),
-    activeRepoId: 'repo-1',
-    activeWorktreeId: 'repo-1::/worktree',
-    activeTabId: 'tab-1',
-    tabsByWorktree: {
-      'repo-1::/worktree': [
-        {
-          id: 'tab-1',
-          worktreeId: 'repo-1::/worktree',
-          title: 'Terminal',
-          customTitle: null,
-          color: null,
-          sortOrder: 0,
-          createdAt: 1,
-          ptyId
-        }
-      ]
-    },
-    terminalLayoutsByTabId: {
-      'tab-1': {
-        root: { type: 'leaf', leafId: TEST_LEAF_1 },
-        activeLeafId: TEST_LEAF_1,
-        expandedLeafId: null,
-        ptyIdsByLeafId: ptyId ? { [TEST_LEAF_1]: ptyId } : {}
-      }
-    }
-  })
 
   // Registered on purpose: rows owned by an unregistered repo id are swept as orphans on load.
   const makeRepos = (...repoIds: string[]) => repoIds.map((id) => makeRepo({ id, path: `/${id}` }))
@@ -395,108 +365,6 @@ describe('Store host-partitioned workspace sessions', () => {
     expect(
       store.getWorkspaceSession('runtime:env-b').terminalTopologyRevisionByRepoId?.duplicate
     ).toBe(7)
-  })
-
-  it('persists an SSH PTY binding only in the SSH host partition', async () => {
-    const store = await createStore()
-    store.setWorkspaceSession(makeBoundHostSession(null), 'local')
-    store.setWorkspaceSession(makeBoundHostSession(null), 'ssh:ssh-1')
-
-    store.persistPtyBinding(
-      {
-        worktreeId: 'repo-1::/worktree',
-        tabId: 'tab-1',
-        leafId: TEST_LEAF_1,
-        ptyId: 'ssh:ssh-1@@remote-pty'
-      },
-      'ssh:ssh-1'
-    )
-
-    expect(
-      store.getWorkspaceSession('ssh:ssh-1').tabsByWorktree['repo-1::/worktree'][0]?.ptyId
-    ).toBe('ssh:ssh-1@@remote-pty')
-    expect(
-      store.getWorkspaceSession('local').tabsByWorktree['repo-1::/worktree'][0]?.ptyId
-    ).toBeNull()
-  })
-
-  it('rolls back a failed SSH PTY binding flush in the SSH host partition', async () => {
-    const store = await createStore()
-    store.setWorkspaceSession(makeBoundHostSession(null), 'local')
-    store.setWorkspaceSession(makeBoundHostSession(null), 'ssh:ssh-1')
-    const flush = vi.spyOn(store, 'flushOrThrow').mockImplementationOnce(() => {
-      throw new Error('disk unavailable')
-    })
-
-    expect(() =>
-      store.persistPtyBinding(
-        {
-          worktreeId: 'repo-1::/worktree',
-          tabId: 'tab-1',
-          leafId: TEST_LEAF_1,
-          ptyId: 'ssh:ssh-1@@remote-pty'
-        },
-        'ssh:ssh-1'
-      )
-    ).toThrow('disk unavailable')
-    flush.mockRestore()
-
-    expect(
-      store.getWorkspaceSession('ssh:ssh-1').tabsByWorktree['repo-1::/worktree'][0]?.ptyId
-    ).toBeNull()
-    expect(
-      store.getWorkspaceSession('local').tabsByWorktree['repo-1::/worktree'][0]?.ptyId
-    ).toBeNull()
-  })
-
-  it('clears terminated SSH PTY bindings from the SSH partition and legacy local copy', async () => {
-    const store = await createStore()
-    const ptyId = 'ssh:ssh-1@@remote-pty'
-    store.setWorkspaceSession(makeBoundHostSession(ptyId), 'local')
-    store.setWorkspaceSession(makeBoundHostSession(ptyId), 'ssh:ssh-1')
-    store.upsertSshRemotePtyLease({
-      targetId: 'ssh-1',
-      ptyId: 'remote-pty',
-      worktreeId: 'repo-1::/worktree',
-      tabId: 'tab-1',
-      leafId: TEST_LEAF_1,
-      state: 'attached'
-    })
-
-    store.markSshRemotePtyLease('ssh-1', ptyId, 'terminated')
-
-    for (const hostId of ['local', 'ssh:ssh-1']) {
-      const session = store.getWorkspaceSession(hostId)
-      expect(session.tabsByWorktree['repo-1::/worktree'][0]?.ptyId).toBeNull()
-      expect(session.terminalLayoutsByTabId['tab-1']?.ptyIdsByLeafId).toEqual({})
-    }
-  })
-
-  // `expired` only records that the client lost its route, so both partitions keep the binding the
-  // pane needs to reattach to a remote shell nothing has attested is dead.
-  it('keeps expired SSH PTY bindings in the SSH partition and legacy local copy', async () => {
-    const store = await createStore()
-    const ptyId = 'ssh:ssh-1@@remote-pty'
-    store.setWorkspaceSession(makeBoundHostSession(ptyId), 'local')
-    store.setWorkspaceSession(makeBoundHostSession(ptyId), 'ssh:ssh-1')
-    store.upsertSshRemotePtyLease({
-      targetId: 'ssh-1',
-      ptyId: 'remote-pty',
-      worktreeId: 'repo-1::/worktree',
-      tabId: 'tab-1',
-      leafId: TEST_LEAF_1,
-      state: 'attached'
-    })
-
-    store.markSshRemotePtyLease('ssh-1', ptyId, 'expired')
-
-    for (const hostId of ['local', 'ssh:ssh-1']) {
-      const session = store.getWorkspaceSession(hostId)
-      expect(session.tabsByWorktree['repo-1::/worktree'][0]?.ptyId).toBe(ptyId)
-      expect(session.terminalLayoutsByTabId['tab-1']?.ptyIdsByLeafId).toEqual({
-        [TEST_LEAF_1]: ptyId
-      })
-    }
   })
 
   it('defaults an omitted hostId to the local partition', async () => {

--- a/src/main/persistence-host-partitioned-sessions.test.ts
+++ b/src/main/persistence-host-partitioned-sessions.test.ts
@@ -449,7 +449,32 @@ describe('Store host-partitioned workspace sessions', () => {
     ).toBeNull()
   })
 
-  it('clears expired SSH PTY bindings from the SSH partition and legacy local copy', async () => {
+  it('clears terminated SSH PTY bindings from the SSH partition and legacy local copy', async () => {
+    const store = await createStore()
+    const ptyId = 'ssh:ssh-1@@remote-pty'
+    store.setWorkspaceSession(makeBoundHostSession(ptyId), 'local')
+    store.setWorkspaceSession(makeBoundHostSession(ptyId), 'ssh:ssh-1')
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId: 'repo-1::/worktree',
+      tabId: 'tab-1',
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+
+    store.markSshRemotePtyLease('ssh-1', ptyId, 'terminated')
+
+    for (const hostId of ['local', 'ssh:ssh-1']) {
+      const session = store.getWorkspaceSession(hostId)
+      expect(session.tabsByWorktree['repo-1::/worktree'][0]?.ptyId).toBeNull()
+      expect(session.terminalLayoutsByTabId['tab-1']?.ptyIdsByLeafId).toEqual({})
+    }
+  })
+
+  // `expired` only records that the client lost its route, so both partitions keep the binding the
+  // pane needs to reattach to a remote shell nothing has attested is dead.
+  it('keeps expired SSH PTY bindings in the SSH partition and legacy local copy', async () => {
     const store = await createStore()
     const ptyId = 'ssh:ssh-1@@remote-pty'
     store.setWorkspaceSession(makeBoundHostSession(ptyId), 'local')
@@ -467,8 +492,10 @@ describe('Store host-partitioned workspace sessions', () => {
 
     for (const hostId of ['local', 'ssh:ssh-1']) {
       const session = store.getWorkspaceSession(hostId)
-      expect(session.tabsByWorktree['repo-1::/worktree'][0]?.ptyId).toBeNull()
-      expect(session.terminalLayoutsByTabId['tab-1']?.ptyIdsByLeafId).toEqual({})
+      expect(session.tabsByWorktree['repo-1::/worktree'][0]?.ptyId).toBe(ptyId)
+      expect(session.terminalLayoutsByTabId['tab-1']?.ptyIdsByLeafId).toEqual({
+        [TEST_LEAF_1]: ptyId
+      })
     }
   })
 

--- a/src/main/persistence-host-partitioned-ssh-pty-bindings.test.ts
+++ b/src/main/persistence-host-partitioned-ssh-pty-bindings.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { rmSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { WorkspaceSessionState } from '../shared/workspace-session-state-types'
+import { getDefaultWorkspaceSession } from '../shared/constants'
+import { testState, createStore } from './persistence-test-harness'
+import { TEST_LEAF_1 } from './persistence-session-fixtures'
+
+const { trackMock, getCohortAtEmitMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+  getCohortAtEmitMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => testState.dir
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf-8'),
+    decryptString: (ciphertext: Buffer) => {
+      const decoded = ciphertext.toString('utf-8')
+      if (!decoded.startsWith('encrypted:')) {
+        throw new Error('invalid ciphertext')
+      }
+      return decoded.slice('encrypted:'.length)
+    }
+  }
+}))
+
+vi.mock('./telemetry/client', () => ({
+  track: trackMock
+}))
+
+vi.mock('./telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: getCohortAtEmitMock
+}))
+
+describe('Store SSH remote PTY bindings across host partitions', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  const makeBoundHostSession = (ptyId: string | null): WorkspaceSessionState => ({
+    ...getDefaultWorkspaceSession(),
+    activeRepoId: 'repo-1',
+    activeWorktreeId: 'repo-1::/worktree',
+    activeTabId: 'tab-1',
+    tabsByWorktree: {
+      'repo-1::/worktree': [
+        {
+          id: 'tab-1',
+          worktreeId: 'repo-1::/worktree',
+          title: 'Terminal',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1,
+          ptyId
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {
+      'tab-1': {
+        root: { type: 'leaf', leafId: TEST_LEAF_1 },
+        activeLeafId: TEST_LEAF_1,
+        expandedLeafId: null,
+        ptyIdsByLeafId: ptyId ? { [TEST_LEAF_1]: ptyId } : {}
+      }
+    }
+  })
+
+  it('persists an SSH PTY binding only in the SSH host partition', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(makeBoundHostSession(null), 'local')
+    store.setWorkspaceSession(makeBoundHostSession(null), 'ssh:ssh-1')
+
+    store.persistPtyBinding(
+      {
+        worktreeId: 'repo-1::/worktree',
+        tabId: 'tab-1',
+        leafId: TEST_LEAF_1,
+        ptyId: 'ssh:ssh-1@@remote-pty'
+      },
+      'ssh:ssh-1'
+    )
+
+    expect(
+      store.getWorkspaceSession('ssh:ssh-1').tabsByWorktree['repo-1::/worktree'][0]?.ptyId
+    ).toBe('ssh:ssh-1@@remote-pty')
+    expect(
+      store.getWorkspaceSession('local').tabsByWorktree['repo-1::/worktree'][0]?.ptyId
+    ).toBeNull()
+  })
+
+  it('rolls back a failed SSH PTY binding flush in the SSH host partition', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(makeBoundHostSession(null), 'local')
+    store.setWorkspaceSession(makeBoundHostSession(null), 'ssh:ssh-1')
+    const flush = vi.spyOn(store, 'flushOrThrow').mockImplementationOnce(() => {
+      throw new Error('disk unavailable')
+    })
+
+    expect(() =>
+      store.persistPtyBinding(
+        {
+          worktreeId: 'repo-1::/worktree',
+          tabId: 'tab-1',
+          leafId: TEST_LEAF_1,
+          ptyId: 'ssh:ssh-1@@remote-pty'
+        },
+        'ssh:ssh-1'
+      )
+    ).toThrow('disk unavailable')
+    flush.mockRestore()
+
+    expect(
+      store.getWorkspaceSession('ssh:ssh-1').tabsByWorktree['repo-1::/worktree'][0]?.ptyId
+    ).toBeNull()
+    expect(
+      store.getWorkspaceSession('local').tabsByWorktree['repo-1::/worktree'][0]?.ptyId
+    ).toBeNull()
+  })
+
+  it('clears terminated SSH PTY bindings from the SSH partition and legacy local copy', async () => {
+    const store = await createStore()
+    const ptyId = 'ssh:ssh-1@@remote-pty'
+    store.setWorkspaceSession(makeBoundHostSession(ptyId), 'local')
+    store.setWorkspaceSession(makeBoundHostSession(ptyId), 'ssh:ssh-1')
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId: 'repo-1::/worktree',
+      tabId: 'tab-1',
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+
+    store.markSshRemotePtyLease('ssh-1', ptyId, 'terminated')
+
+    for (const hostId of ['local', 'ssh:ssh-1']) {
+      const session = store.getWorkspaceSession(hostId)
+      expect(session.tabsByWorktree['repo-1::/worktree'][0]?.ptyId).toBeNull()
+      expect(session.terminalLayoutsByTabId['tab-1']?.ptyIdsByLeafId).toEqual({})
+    }
+  })
+
+  // `expired` only records that the client lost its route, so both partitions keep the binding the
+  // pane needs to reattach to a remote shell nothing has attested is dead.
+  it('keeps expired SSH PTY bindings in the SSH partition and legacy local copy', async () => {
+    const store = await createStore()
+    const ptyId = 'ssh:ssh-1@@remote-pty'
+    store.setWorkspaceSession(makeBoundHostSession(ptyId), 'local')
+    store.setWorkspaceSession(makeBoundHostSession(ptyId), 'ssh:ssh-1')
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId: 'repo-1::/worktree',
+      tabId: 'tab-1',
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+
+    store.markSshRemotePtyLease('ssh-1', ptyId, 'expired')
+
+    for (const hostId of ['local', 'ssh:ssh-1']) {
+      const session = store.getWorkspaceSession(hostId)
+      expect(session.tabsByWorktree['repo-1::/worktree'][0]?.ptyId).toBe(ptyId)
+      expect(session.terminalLayoutsByTabId['tab-1']?.ptyIdsByLeafId).toEqual({
+        [TEST_LEAF_1]: ptyId
+      })
+    }
+  })
+})

--- a/src/main/persistence-layout-binding-recovery.test.ts
+++ b/src/main/persistence-layout-binding-recovery.test.ts
@@ -211,7 +211,9 @@ describe('Store', () => {
     expect(leafId).not.toBe(TEST_LEAF_2)
   })
 
-  it('does not restore cleared SSH bindings after a lease expired', async () => {
+  // An `expired` lease means reattach gave up, not that the remote shell died. Dropping the
+  // binding here left the pane unable to re-adopt a process that is still running.
+  it('restores a cleared SSH binding after a lease expired so the pane can reattach', async () => {
     const store = await createStore()
     store.upsertSshRemotePtyLease({
       targetId: 'ssh-1',
@@ -220,6 +222,79 @@ describe('Store', () => {
       tabId: 'tab1',
       leafId: TEST_LEAF_1,
       state: 'expired'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'remote-pty'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [TEST_LEAF_1]: 'remote-pty' }
+        }
+      }
+    })
+
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    })
+
+    const session = store.getWorkspaceSession()
+    expect(session.tabsByWorktree.wt1[0].ptyId).toBe('remote-pty')
+    expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({
+      [TEST_LEAF_1]: 'remote-pty'
+    })
+  })
+
+  it('does not restore cleared SSH bindings after a lease was terminated', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      state: 'terminated'
     })
     store.setWorkspaceSession({
       activeRepoId: 'r1',

--- a/src/main/persistence-ssh-remote-pty-binding-replay.test.ts
+++ b/src/main/persistence-ssh-remote-pty-binding-replay.test.ts
@@ -213,7 +213,9 @@ describe('Store', () => {
     })
   })
 
-  it('does not resurrect a host binding after its SSH lease expires', async () => {
+  // `expired` is the client admitting it lost its route; the remote shell may still be running,
+  // so the pane keeps the binding it needs to reattach.
+  it('restores a host binding after its SSH lease expires', async () => {
     const store = await createStore()
     const hostId = 'ssh:ssh-1'
     const session: WorkspaceSessionState = {
@@ -251,6 +253,64 @@ describe('Store', () => {
       tabId: 'tab1',
       leafId: TEST_LEAF_1,
       state: 'expired'
+    })
+    store.setWorkspaceSession(
+      {
+        ...session,
+        tabsByWorktree: {
+          wt1: [{ ...session.tabsByWorktree.wt1[0]!, ptyId: null }]
+        },
+        terminalLayoutsByTabId: {
+          tab1: { ...session.terminalLayoutsByTabId.tab1!, ptyIdsByLeafId: {} }
+        }
+      },
+      hostId
+    )
+    const persisted = store.getWorkspaceSession(hostId)
+    expect(persisted.tabsByWorktree.wt1[0]!.ptyId).toBe('ssh:ssh-1@@expired')
+    expect(persisted.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({
+      [TEST_LEAF_1]: 'ssh:ssh-1@@expired'
+    })
+  })
+
+  it('does not resurrect a host binding after its SSH lease was terminated', async () => {
+    const store = await createStore()
+    const hostId = 'ssh:ssh-1'
+    const session: WorkspaceSessionState = {
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'ssh:ssh-1@@expired'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [TEST_LEAF_1]: 'ssh:ssh-1@@expired' }
+        }
+      }
+    }
+    store.setWorkspaceSession(session, hostId)
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'expired',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      state: 'terminated'
     })
     store.setWorkspaceSession(
       {

--- a/src/main/persistence-ssh-remote-pty-leases.test.ts
+++ b/src/main/persistence-ssh-remote-pty-leases.test.ts
@@ -45,6 +45,47 @@ vi.mock('./telemetry/cohort-classifier', () => ({
   getCohortAtEmit: getCohortAtEmitMock
 }))
 
+/** One SSH pane bound to `ssh:ssh-1@@remote-pty` in both the tab row and the leaf map. */
+async function storeWithBoundSshPane(): Promise<Awaited<ReturnType<typeof createStore>>> {
+  const store = await createStore()
+  store.upsertSshRemotePtyLease({
+    targetId: 'ssh-1',
+    ptyId: 'remote-pty',
+    worktreeId: 'wt1',
+    tabId: 'tab1',
+    leafId: TEST_LEAF_1,
+    state: 'attached'
+  })
+  store.setWorkspaceSession({
+    activeRepoId: 'r1',
+    activeWorktreeId: 'wt1',
+    activeTabId: 'tab1',
+    tabsByWorktree: {
+      wt1: [
+        {
+          id: 'tab1',
+          worktreeId: 'wt1',
+          title: 'Terminal',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1,
+          ptyId: 'ssh:ssh-1@@remote-pty'
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {
+      tab1: {
+        root: { type: 'leaf', leafId: TEST_LEAF_1 },
+        activeLeafId: TEST_LEAF_1,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [TEST_LEAF_1]: 'ssh:ssh-1@@remote-pty' }
+      }
+    }
+  })
+  return store
+}
+
 describe('Store', () => {
   beforeEach(() => {
     testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
@@ -150,6 +191,87 @@ describe('Store', () => {
       [TEST_LEAF_2]: 'remote-pty-2'
     })
   })
+
+  // A partial renderer map is only repaired when a lease says the omitted sibling still belongs to
+  // this host. `expired` says the client lost its route, not that the sibling died — repair it.
+  // `terminated` is the operator-close state and must stay refused.
+  it.each([
+    ['expired', { [TEST_LEAF_1]: 'remote-pty-1', [TEST_LEAF_2]: 'remote-pty-2' }],
+    ['terminated', { [TEST_LEAF_1]: 'remote-pty-1' }]
+  ] as const)(
+    'repairs a partial renderer snapshot for a %s sibling lease only when it is not terminated',
+    async (siblingState, expected) => {
+      const store = await createStore()
+      store.upsertSshRemotePtyLease({
+        targetId: 'ssh-1',
+        ptyId: 'remote-pty-1',
+        worktreeId: 'wt1',
+        tabId: 'tab1',
+        leafId: TEST_LEAF_1,
+        state: 'detached'
+      })
+      store.upsertSshRemotePtyLease({
+        targetId: 'ssh-1',
+        ptyId: 'remote-pty-2',
+        worktreeId: 'wt1',
+        tabId: 'tab1',
+        leafId: TEST_LEAF_2,
+        state: siblingState
+      })
+      const layout = {
+        root: {
+          type: 'split' as const,
+          direction: 'horizontal' as const,
+          first: { type: 'leaf' as const, leafId: TEST_LEAF_1 },
+          second: { type: 'leaf' as const, leafId: TEST_LEAF_2 },
+          ratio: 0.5
+        },
+        activeLeafId: TEST_LEAF_1,
+        expandedLeafId: null
+      }
+      const tabs = {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      }
+      store.setWorkspaceSession({
+        activeRepoId: 'r1',
+        activeWorktreeId: 'wt1',
+        activeTabId: 'tab1',
+        tabsByWorktree: tabs,
+        terminalLayoutsByTabId: {
+          tab1: {
+            ...layout,
+            ptyIdsByLeafId: { [TEST_LEAF_1]: 'remote-pty-1', [TEST_LEAF_2]: 'remote-pty-2' }
+          }
+        }
+      })
+
+      // The renderer republishes only the leaf it still knows about.
+      store.setWorkspaceSession({
+        activeRepoId: 'r1',
+        activeWorktreeId: 'wt1',
+        activeTabId: 'tab1',
+        tabsByWorktree: tabs,
+        terminalLayoutsByTabId: {
+          tab1: { ...layout, ptyIdsByLeafId: { [TEST_LEAF_1]: 'remote-pty-1' } }
+        }
+      })
+
+      expect(store.getWorkspaceSession().terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual(
+        expected
+      )
+    }
+  )
 
   it('does not restore layout bindings for leaves removed from the incoming layout', async () => {
     const store = await createStore()
@@ -506,43 +628,12 @@ describe('Store', () => {
     ])
   })
 
-  it('clears workspace bindings when marking an SSH remote PTY lease expired', async () => {
-    const store = await createStore()
-    store.upsertSshRemotePtyLease({
-      targetId: 'ssh-1',
-      ptyId: 'remote-pty',
-      worktreeId: 'wt1',
-      tabId: 'tab1',
-      leafId: TEST_LEAF_1,
-      state: 'attached'
-    })
-    store.setWorkspaceSession({
-      activeRepoId: 'r1',
-      activeWorktreeId: 'wt1',
-      activeTabId: 'tab1',
-      tabsByWorktree: {
-        wt1: [
-          {
-            id: 'tab1',
-            worktreeId: 'wt1',
-            title: 'Terminal',
-            customTitle: null,
-            color: null,
-            sortOrder: 0,
-            createdAt: 1,
-            ptyId: 'ssh:ssh-1@@remote-pty'
-          }
-        ]
-      },
-      terminalLayoutsByTabId: {
-        tab1: {
-          root: { type: 'leaf', leafId: TEST_LEAF_1 },
-          activeLeafId: TEST_LEAF_1,
-          expandedLeafId: null,
-          ptyIdsByLeafId: { [TEST_LEAF_1]: 'ssh:ssh-1@@remote-pty' }
-        }
-      }
-    })
+  // `expired` never means the shell exited — every writer records that the CLIENT lost its route
+  // (superseded sibling, recycled relay id, persistPtyBinding refusal, failed reattach, relay
+  // reset). Wiping the binding here made adoptStablePane return null and forced createTerminal
+  // into a fresh spawn, stranding a remote process that is still running.
+  it('keeps workspace bindings when marking an SSH remote PTY lease expired', async () => {
+    const store = await storeWithBoundSshPane()
 
     store.markSshRemotePtyLease('ssh-1', 'ssh:ssh-1@@remote-pty', 'expired')
 
@@ -553,8 +644,41 @@ describe('Store', () => {
         state: 'expired'
       })
     ])
+    expect(session.tabsByWorktree.wt1[0].ptyId).toBe('ssh:ssh-1@@remote-pty')
+    expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({
+      [TEST_LEAF_1]: 'ssh:ssh-1@@remote-pty'
+    })
+  })
+
+  it('clears workspace bindings when marking an SSH remote PTY lease terminated', async () => {
+    const store = await storeWithBoundSshPane()
+
+    store.markSshRemotePtyLease('ssh-1', 'ssh:ssh-1@@remote-pty', 'terminated')
+
+    const session = store.getWorkspaceSession()
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
+      expect.objectContaining({
+        ptyId: 'remote-pty',
+        state: 'terminated'
+      })
+    ])
     expect(session.tabsByWorktree.wt1[0].ptyId).toBeNull()
     expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({})
+  })
+
+  // The bulk writer takes the same decision; only the operator-close state may unbind a pane.
+  it('keeps workspace bindings for a bulk expire and clears them for a bulk terminate', async () => {
+    const expiredStore = await storeWithBoundSshPane()
+    expiredStore.markSshRemotePtyLeases('ssh-1', 'expired')
+    expect(expiredStore.getWorkspaceSession().terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({
+      [TEST_LEAF_1]: 'ssh:ssh-1@@remote-pty'
+    })
+
+    const terminatedStore = await storeWithBoundSshPane()
+    terminatedStore.markSshRemotePtyLeases('ssh-1', 'terminated')
+    expect(
+      terminatedStore.getWorkspaceSession().terminalLayoutsByTabId.tab1.ptyIdsByLeafId
+    ).toEqual({})
   })
 
   it('removes SSH remote PTY leases when callers pass scoped app ids', async () => {

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
@@ -90,6 +90,22 @@ function supersedeSiblingLeasesForPane(
   }
 }
 
+/**
+ * Only `terminated` unbinds a pane. It is the operator-close state and the one written after a
+ * host-acknowledged stop; `expired` records that the CLIENT lost its route and says nothing about
+ * the remote shell (docs/reference/ssh-execution-boundary.md). Wiping the binding on `expired` made
+ * `resolvePersistedStablePaneOwner` return null, so `adoptStablePane` gave up and `createTerminal`
+ * spawned a replacement over a process that was still running. Keeping it buys a reattach ATTEMPT
+ * only — a genuinely dead shell is retired by `attachStablePaneOwner` on the relay's own absence
+ * answer, which then falls through to a fresh spawn.
+ *
+ * Supersession is the one place `expired` still scrubs a binding, and it does so explicitly in
+ * `supersedeSiblingLeasesForPane`: there a NEWER lease for the same pane is the evidence.
+ */
+function leaseStateWithdrawsBinding(state: SshRemotePtyLease['state']): boolean {
+  return state === 'terminated'
+}
+
 export function getSshRemotePtyLeases(
   state: PersistedState,
   targetId?: string
@@ -149,7 +165,7 @@ function updateSshRemotePtyLeaseStates(
 ): boolean {
   const now = Date.now()
   let changed = false
-  const shouldClearBindings = state === 'terminated' || state === 'expired'
+  const shouldClearBindings = leaseStateWithdrawsBinding(state)
   const leasesToClear: SshRemotePtyLease[] = []
   operations.state.sshRemotePtyLeases ??= []
   for (const lease of operations.state.sshRemotePtyLeases) {
@@ -237,7 +253,7 @@ export function markSshRemotePtyLease(
   if (!lease) {
     return
   }
-  const shouldClearBindings = state === 'terminated' || state === 'expired'
+  const shouldClearBindings = leaseStateWithdrawsBinding(state)
   if (lease.state === state) {
     if (shouldClearBindings && operations.clearBindingsForLeases(targetId, [lease])) {
       operations.flush()

--- a/src/main/persistence/loading-store/terminal-binding-recovery.ts
+++ b/src/main/persistence/loading-store/terminal-binding-recovery.ts
@@ -8,6 +8,22 @@ import type { StoreRuntimeState } from './store-runtime-state'
 
 type TerminalBindingRecoveryOperationsRuntime = Pick<StoreRuntimeState, 'state'>
 
+/**
+ * `terminated` is the only lease state that withdraws a pane binding. It is the operator-close
+ * state, and the one written after a host-acknowledged stop.
+ *
+ * `expired` is deliberately not death: every writer of it records that the CLIENT lost its route —
+ * a superseded sibling, a recycled relay id, a persistPtyBinding refusal, a failed reattach, a
+ * relay reset — and `docs/reference/ssh-execution-boundary.md` grades all of those `unverifiable`.
+ * Refusing the binding there strands a remote shell that is still running behind a pane that can no
+ * longer reach it. Keeping it authorizes a reattach ATTEMPT, never a respawn: when the shell really
+ * is gone, `attachStablePaneOwner` retires the binding on the relay's own absence answer and falls
+ * through to a fresh spawn.
+ */
+function sshRemotePtyLeaseWithdrawsBinding(lease: SshRemotePtyLease): boolean {
+  return lease.state === 'terminated'
+}
+
 export class TerminalBindingRecoveryOperations {
   constructor(private readonly runtime: TerminalBindingRecoveryOperationsRuntime) {}
 
@@ -40,7 +56,7 @@ export class TerminalBindingRecoveryOperations {
     const leases = this.runtime.state.sshRemotePtyLeases?.filter((entry) =>
       this.sshRemotePtyLeaseMatchesBinding(entry, binding)
     )
-    return !leases?.some((lease) => lease.state === 'terminated' || lease.state === 'expired')
+    return !leases?.some(sshRemotePtyLeaseWithdrawsBinding)
   }
 
   getRelayPtyIdForSshLeaseComparison(targetId: string, ptyId: string): string {
@@ -91,8 +107,7 @@ export class TerminalBindingRecoveryOperations {
       this.runtime.state.sshRemotePtyLeases?.some(
         (lease) =>
           this.sshRemotePtyLeaseMatchesBinding(lease, binding) &&
-          lease.state !== 'terminated' &&
-          lease.state !== 'expired'
+          !sshRemotePtyLeaseWithdrawsBinding(lease)
       ) ?? false
     )
   }

--- a/src/main/ssh-expired-lease-pane-readoption.test.ts
+++ b/src/main/ssh-expired-lease-pane-readoption.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { rmSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { makePaneKey } from '../shared/stable-pane-id'
+import { resolvePersistedStablePaneOwner } from './ipc/pty/pane/stable-owner'
+import { testState, createStore, makeTerminalTab } from './persistence-test-harness'
+import { TEST_LEAF_1 } from './persistence-session-fixtures'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: { isEncryptionAvailable: () => false }
+}))
+
+const TARGET = 'ssh-1'
+const HOST_ID = 'ssh:ssh-1' as const
+const WORKTREE = 'repo1::/worktree'
+const TAB = 'tab-1'
+const APP_PTY_ID = 'ssh:ssh-1@@remote-pty'
+
+function storeWithBoundRemotePane(): ReturnType<typeof createStore> {
+  const store = createStore()
+  store.upsertSshRemotePtyLease({
+    targetId: TARGET,
+    ptyId: 'remote-pty',
+    worktreeId: WORKTREE,
+    tabId: TAB,
+    leafId: TEST_LEAF_1,
+    state: 'attached'
+  })
+  store.setWorkspaceSession(
+    {
+      activeRepoId: 'repo1',
+      activeWorktreeId: WORKTREE,
+      activeTabId: TAB,
+      tabsByWorktree: {
+        [WORKTREE]: [makeTerminalTab({ id: TAB, ptyId: APP_PTY_ID, worktreeId: WORKTREE })]
+      },
+      terminalLayoutsByTabId: {
+        [TAB]: {
+          root: { type: 'leaf', leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [TEST_LEAF_1]: APP_PTY_ID }
+        }
+      }
+    },
+    HOST_ID
+  )
+  return store
+}
+
+/**
+ * `adoptStablePane` re-adopts a pane only while `resolvePersistedStablePaneOwner` can still name
+ * its PTY. A null owner is what routes `createTerminal` to a fresh spawn — over a remote shell that
+ * `expired` never claimed had died.
+ */
+describe('a pane whose SSH lease expired can still be re-adopted', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('keeps the persisted owner after the lease expires, so adoption reattaches', () => {
+    const store = storeWithBoundRemotePane()
+
+    store.markSshRemotePtyLease(TARGET, APP_PTY_ID, 'expired')
+
+    expect(
+      resolvePersistedStablePaneOwner(store, makePaneKey(TAB, TEST_LEAF_1), WORKTREE, TARGET)
+    ).toMatchObject({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: APP_PTY_ID })
+  })
+
+  // Negative control for #17957: an operator close leaves `terminated`, and that must still unbind
+  // the pane rather than re-adopting a shell the user deliberately stopped.
+  it('drops the persisted owner after the lease is terminated', () => {
+    const store = storeWithBoundRemotePane()
+
+    store.markSshRemotePtyLease(TARGET, APP_PTY_ID, 'terminated')
+
+    expect(
+      resolvePersistedStablePaneOwner(store, makePaneKey(TAB, TEST_LEAF_1), WORKTREE, TARGET)
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​880 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​165 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​715 |
| Prod | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​226 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​214 |

<!-- /orca-pr-loc -->

Stacked on #17957 — review that first. Closes the **reverse** expression of the bug #17957 fixed.

## ELI5

#17957 stopped Orca respawning a shell that was still alive. This fixes the same conflation pointing the other way: a shell that **is** still alive gets declared unrestorable, so the pane can never reattach to it. The user's terminal comes back empty and their running job is orphaned — still burning CPU on the remote host, invisible and unreachable.

The cause is one word doing two jobs. The SSH lease state `'expired'` **never means the shell exited** — all 8 writers were audited in this sweep and zero attest exit. `ssh-connection-handlers.ts:126` already says so: *"'expired' records that reattach gave up, never that the remote shell died — those are precisely the orphans."* Three readers didn't honor it.

An `expired` lease now permits a **reattach attempt** (exactly what an orphan needs) while still not authorizing a **respawn**. Those are different actions and the code conflated them.

## Changes

- `terminal-binding-recovery.ts` — `isRestorablePtyBinding` and `hasRestorableSshRemotePtyLease` both now consult one `sshRemotePtyLeaseWithdrawsBinding(lease)`, true only for `terminated`.
- `ssh-pty-lease-operations.ts:151`/`:239` — both `shouldClearBindings` sites now call `leaseStateWithdrawsBinding(state)`, `terminated`-only.
- **Deliberately untouched:** `supersedeSiblingLeasesForPane`'s own `clearBindingsForLeases` (line 88). That is the one place `expired` legitimately scrubs a binding, because there a *newer lease for the same pane* is the evidence — so the 2→19→20 lease fan-out fix stays intact.
- `persistence-host-partitioned-sessions.test.ts` pinned cross-partition clearing on `expired`; retargeted to `terminated` (keeping the cross-partition coverage) and added the `expired`-retention counterpart.

## A genuinely dead shell still cleans up — on stronger evidence than before

Keeping the binding buys a reattach **attempt**: `adoptStablePane` → `attachStablePaneOwner` → `provider.spawn({attachOnly:true})`.

- Relay answers absent → `isPtyAlreadyGoneError` (which requires `SshPtyAbsentFromRelayError`/`isSshPtyNotFoundError`, **not** a message match) → `runtime.onPtyExit` + `retirePersistedStablePaneOwner` + fall through to a fresh spawn.
- Lost link or timeout → throws without retiring and without respawning; the pane retries next connect and converges the moment the relay answers.

No forever-retry loop, no stuck pane.

## Why this cannot regress #17957

The change strictly **reduces** respawns: where the pane previously found `null` and went straight to `createTerminal`'s fresh spawn, it now attaches first. `recoverTerminalPane`'s gates read runtime state, not the persisted binding, and are untouched — as are #17958's id comparison, #17955's `isProvenProcessExit`, and the two defects in #17962/#17963.

## User-facing regressions

**None expected.** Negative controls pin every unchanged behavior, green before *and* after:

- `terminated` still clears bindings — single writer, bulk writer, both host partitions.
- `terminated` still blocks binding replay; `drops the persisted owner after the lease is terminated` still passes, so an operator close still goes null.
- `stable-pane-relay-absence-respawn.test.ts` (8) — dead shell retires + respawns; lost link / timeout / unverifiable daemon cleanup keep the binding and refuse to respawn.
- `ssh-reattach-pane-cardinality.test.ts` (15) — supersession, and `holds the live lease count flat across ten reconnects`.
- `orca-runtime.test.ts` (1223) — includes #17957's gates and the pinned `does not recover a pane whose authoritative SSH lease was terminated`.

## Testing

Fail-before, verbatim:
```
 ❯ src/main/ssh-expired-lease-pane-readoption.test.ts (2 tests | 1 failed)
     × keeps the persisted owner after the lease expires, so adoption reattaches
 ❯ src/main/persistence-ssh-remote-pty-binding-replay.test.ts (7 tests | 1 failed)
     × restores a host binding after its SSH lease expires
 ❯ src/main/persistence-layout-binding-recovery.test.ts (8 tests | 1 failed)
     × restores a cleared SSH binding after a lease expired so the pane can reattach
 ❯ src/main/persistence-host-partitioned-sessions.test.ts (28 tests | 1 failed)
     × keeps expired SSH PTY bindings in the SSH partition and legacy local copy
 ❯ src/main/persistence-ssh-remote-pty-leases.test.ts (17 tests | 3 failed)
 Test Files  5 failed | 3 passed (8)
      Tests  7 failed | 84 passed (91)
```
Pass-after: `Test Files 8 passed (8) / Tests 1306 passed | 1 skipped (1307)`.

`tc:node` and `tc:web` clean; `check:code-quality:changed` 0 new findings across 24 files.

Full-repo sweeps show 6 pre-existing/load-related failures in unrelated subsystems (`run-electron-vite-dev`, `git-admission-storm-measurement`, `git-command-timeout-behavior`, `managed-hook-runtime`, `legacy-wsl-runtime-auth-drain-apply-script`) — four pass in isolation, and `run-electron-vite-dev`'s two reproduce on the base commit with these changes stashed. Renderer: 1 failure (`AgentMapWorkspaceContextMenu`) that passes in isolation.

## Two more readers of the same conflation, deliberately left alone

`ssh-relay-session.ts:2276` (`reattachKnownPtys`) and `:1986` filter `expired` out of the relay's bulk reattach set. `:2276` is **defensible as written**: `expired` also carries superseded siblings, and reattaching those is exactly the 2→19→20 fan-out `supersedeSiblingLeasesForPane` exists to prevent. It cannot be flipped without first splitting supersession out of `expired`.

Consequence: after an app restart the orphan is recovered through the `adoptStablePane` path, not the relay's bulk reattach. That path is what this PR restores and what the new test pins.

Splitting supersession into its own lease state (or a `supersededBy` field) would let `:2276` be corrected too — but that needs the relay-start identity the STA-3077 note at `ssh-pty-lease-operations.ts:118-122` says the lease does not yet carry. Toward the SSH/remote consolidation, that is the shape of the real fix.
