### PR TITLE
fix(ssh): give supersession and id-recycling their own lease marks

### DIFF
--- a/src/main/persistence-ssh-remote-pty-leases.test.ts
+++ b/src/main/persistence-ssh-remote-pty-leases.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { rmSync, mkdtempSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { testState, createStore } from './persistence-test-harness'
+import { testState, createStore, writeDataFile } from './persistence-test-harness'
+import { getDefaultPersistedState } from '../shared/constants'
+import { sshRemotePtyLeaseAllowsReattach } from '../shared/ssh-types'
 import { TEST_LEAF_1, TEST_LEAF_2 } from './persistence-session-fixtures'
 
 // Stub the ~/.ssh/config parser so the SSH-import test drives the real Store with deterministic hosts, not the operator's actual ~/.ssh/config.
@@ -791,5 +793,90 @@ describe('Store', () => {
         expect.objectContaining({ ptyId: 'expired-pty', state: 'expired' })
       ])
     )
+  })
+})
+
+/**
+ * The lease loader is a strict whitelist, so a field it does not name is stripped on every launch
+ * and the mark that keeps a superseded predecessor out of the reattach set would silently stop
+ * working. Both skew directions are Rule 1 of docs/reference/remote-wire-compatibility.md: this
+ * build reads a row an older one wrote, and an older build ignores the keys it never heard of.
+ */
+describe('ssh remote pty lease route-retirement marks survive the disk round trip', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  function persistLeases(leases: unknown[]): void {
+    const persisted = getDefaultPersistedState(testState.dir)
+    writeDataFile({ ...persisted, sshRemotePtyLeases: leases })
+  }
+
+  it('salvages both marks rather than stripping them', async () => {
+    persistLeases([
+      {
+        targetId: 'ssh-1',
+        ptyId: 'pty-1',
+        state: 'expired',
+        createdAt: 1,
+        updatedAt: 2,
+        supersededBy: 'pty-2'
+      },
+      {
+        targetId: 'ssh-1',
+        ptyId: 'pty-3',
+        state: 'expired',
+        createdAt: 1,
+        updatedAt: 2,
+        relayIdRecycled: true
+      }
+    ])
+
+    const store = await createStore()
+
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
+      expect.objectContaining({ ptyId: 'pty-1', supersededBy: 'pty-2' }),
+      expect.objectContaining({ ptyId: 'pty-3', relayIdRecycled: true })
+    ])
+    expect(store.getSshRemotePtyLeases('ssh-1').filter(sshRemotePtyLeaseAllowsReattach)).toEqual([])
+  })
+
+  // A row an older build wrote carries neither mark. Absence must read as "orphan", which is the
+  // reattachable answer — the older build had no way to say otherwise.
+  it('reads a row written before the marks existed as a reattachable orphan', async () => {
+    persistLeases([
+      { targetId: 'ssh-1', ptyId: 'pty-1', state: 'expired', createdAt: 1, updatedAt: 2 }
+    ])
+
+    const store = await createStore()
+    const [lease] = store.getSshRemotePtyLeases('ssh-1')
+
+    expect(lease).toMatchObject({ ptyId: 'pty-1', state: 'expired' })
+    expect(lease.supersededBy).toBeUndefined()
+    expect(lease.relayIdRecycled).toBeUndefined()
+    expect(sshRemotePtyLeaseAllowsReattach(lease)).toBe(true)
+  })
+
+  it('drops a mistyped mark instead of trusting it', async () => {
+    persistLeases([
+      {
+        targetId: 'ssh-1',
+        ptyId: 'pty-1',
+        state: 'expired',
+        createdAt: 1,
+        updatedAt: 2,
+        supersededBy: 7,
+        relayIdRecycled: 'yes'
+      }
+    ])
+
+    const store = await createStore()
+    const [lease] = store.getSshRemotePtyLeases('ssh-1')
+
+    expect(lease.supersededBy).toBeUndefined()
+    expect(lease.relayIdRecycled).toBeUndefined()
   })
 })

--- a/src/main/persistence/leasing-ssh-ptys/ssh-normalization.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-normalization.ts
@@ -73,7 +73,13 @@ export function normalizeSshRemotePtyLease(value: unknown): SshRemotePtyLease | 
     createdAt: typeof raw.createdAt === 'number' ? raw.createdAt : now,
     updatedAt: typeof raw.updatedAt === 'number' ? raw.updatedAt : now,
     ...(typeof raw.lastAttachedAt === 'number' ? { lastAttachedAt: raw.lastAttachedAt } : {}),
-    ...(typeof raw.lastDetachedAt === 'number' ? { lastDetachedAt: raw.lastDetachedAt } : {})
+    ...(typeof raw.lastDetachedAt === 'number' ? { lastDetachedAt: raw.lastDetachedAt } : {}),
+    // Whitelisted or the loader would strip them on every launch, and a superseded predecessor
+    // would come back reattachable — the fan-out this mark exists to prevent.
+    ...(typeof raw.supersededBy === 'string' && raw.supersededBy.length > 0
+      ? { supersededBy: raw.supersededBy }
+      : {}),
+    ...(raw.relayIdRecycled === true ? { relayIdRecycled: true as const } : {})
   }
 }
 

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
@@ -45,7 +45,9 @@ function durablyBoundPtyIdForPane(
  * the next reattach fans out over both — the reported 2 -> 19 -> 20 across three reconnects.
  *
  * Superseded leases are marked `expired`, never `terminated`: losing a lease is not evidence the
- * shell died, so the remote process is deliberately left running.
+ * shell died, so the remote process is deliberately left running. They also carry `supersededBy`,
+ * which is what keeps them out of the bulk reattach set now that plain `expired` no longer does —
+ * the winner's ptyId is already in hand here, so recording it needs no relay-start identity.
  */
 function supersedeSiblingLeasesForPane(
   operations: SshPtyLeaseOperations,
@@ -74,12 +76,20 @@ function supersedeSiblingLeasesForPane(
       // Leaf only: a lease freezes its tabId, so a pane broken out into a new tab would otherwise
       // never compete with its own predecessor — which is the reported cardinality growth.
       lease.leafId !== winner.leafId ||
-      lease.state === 'terminated' ||
-      lease.state === 'expired'
+      lease.state === 'terminated'
     ) {
       continue
     }
+    if (lease.state === 'expired') {
+      // An already-expired predecessor is superseded by the same evidence, and marking it is what
+      // bounds the reattach set: without this, every past orphan for this pane stays reattachable
+      // forever. `updatedAt` stays put — bumping it would make a stale lease look recent to
+      // `getRecentExpiredSshLease`.
+      lease.supersededBy = winner.ptyId
+      continue
+    }
     lease.state = 'expired'
+    lease.supersededBy = winner.ptyId
     lease.updatedAt = now
     superseded.push(lease)
   }
@@ -147,6 +157,13 @@ export function upsertSshRemotePtyLease(
     ...definedLease,
     createdAt: existing?.createdAt ?? normalizedLease.createdAt ?? now,
     updatedAt: normalizedLease.updatedAt ?? now
+  }
+  // A relay renumbers from `pty-1` on every start, so `existing` can be a RECYCLED id. Route
+  // retirement belongs to the shell that lost, never to whatever claims the id next — drop both
+  // marks the moment this id is claimed live again, and let supersession re-derive them below.
+  if (next.state === 'attached' || next.state === 'detached') {
+    delete next.supersededBy
+    delete next.relayIdRecycled
   }
   if (existingIndex !== -1) {
     operations.state.sshRemotePtyLeases[existingIndex] = next
@@ -240,11 +257,17 @@ export async function markSshRemotePtyLeasesAttachedAsync(
   }
 }
 
+/** `relayIdRecycled` is the pending-stop replay's evidence that the host now lists this id under a
+ *  different incarnation. It is set here rather than inferred, because nothing downstream can
+ *  re-derive it, and it must land even when the lease is already `expired`. */
+export type MarkSshRemotePtyLeaseOptions = { relayIdRecycled?: true }
+
 export function markSshRemotePtyLease(
   operations: SshPtyLeaseOperations,
   targetId: string,
   ptyId: string,
-  state: SshRemotePtyLease['state']
+  state: SshRemotePtyLease['state'],
+  options?: MarkSshRemotePtyLeaseOptions
 ): void {
   const relayPtyId = operations.toStoredPtyId(targetId, ptyId)
   const lease = operations.state.sshRemotePtyLeases?.find(
@@ -253,9 +276,16 @@ export function markSshRemotePtyLease(
   if (!lease) {
     return
   }
+  const recycledChanged = options?.relayIdRecycled === true && lease.relayIdRecycled !== true
+  if (recycledChanged) {
+    lease.relayIdRecycled = true
+  }
   const shouldClearBindings = leaseStateWithdrawsBinding(state)
   if (lease.state === state) {
-    if (shouldClearBindings && operations.clearBindingsForLeases(targetId, [lease])) {
+    if (
+      (shouldClearBindings && operations.clearBindingsForLeases(targetId, [lease])) ||
+      recycledChanged
+    ) {
       operations.flush()
     }
     return

--- a/src/main/persistence/loading-store/ssh-lease-recovery-operations.ts
+++ b/src/main/persistence/loading-store/ssh-lease-recovery-operations.ts
@@ -13,6 +13,7 @@ import {
 import {
   getSshRemotePtyLeases as getSshRemotePtyLeasesOperation,
   markSshRemotePtyLease as markSshRemotePtyLeaseOperation,
+  type MarkSshRemotePtyLeaseOptions,
   markSshRemotePtyLeases as markSshRemotePtyLeasesOperation,
   markSshRemotePtyLeasesAsync as markSshRemotePtyLeasesAsyncOperation,
   markSshRemotePtyLeasesAttachedAsync as markSshRemotePtyLeasesAttachedAsyncOperation,
@@ -120,8 +121,13 @@ export class SshLeaseRecoveryOperations {
     )
   }
 
-  markSshRemotePtyLease(targetId: string, ptyId: string, state: SshRemotePtyLease['state']): void {
-    markSshRemotePtyLeaseOperation(getSshPtyLeaseOperations(this), targetId, ptyId, state)
+  markSshRemotePtyLease(
+    targetId: string,
+    ptyId: string,
+    state: SshRemotePtyLease['state'],
+    options?: MarkSshRemotePtyLeaseOptions
+  ): void {
+    markSshRemotePtyLeaseOperation(getSshPtyLeaseOperations(this), targetId, ptyId, state, options)
   }
 
   removeSshRemotePtyLease(targetId: string, ptyId: string): void {

--- a/src/main/ssh-reattach-pane-cardinality.test.ts
+++ b/src/main/ssh-reattach-pane-cardinality.test.ts
@@ -11,6 +11,7 @@ import {
 } from './persistence-test-harness'
 import { TEST_LEAF_1, TEST_LEAF_2 } from './persistence-session-fixtures'
 import { getDefaultPersistedState } from '../shared/constants'
+import { sshRemotePtyLeaseAllowsReattach } from '../shared/ssh-types'
 
 vi.mock('electron', () => ({
   app: { getPath: () => testState.dir },
@@ -105,6 +106,17 @@ function liveLeasePtyIds(store: ReturnType<typeof createStore>): string[] {
   return store
     .getSshRemotePtyLeases(TARGET)
     .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
+    .map((lease) => lease.ptyId)
+}
+
+/**
+ * What `reattachKnownPtys` actually feeds to `pty.attach`. Goes through the shipped predicate
+ * rather than restating it, so the two cannot drift into the fan-out this suite exists to pin.
+ */
+function bulkReattachPtyIds(store: ReturnType<typeof createStore>): string[] {
+  return store
+    .getSshRemotePtyLeases(TARGET)
+    .filter(sshRemotePtyLeaseAllowsReattach)
     .map((lease) => lease.ptyId)
 }
 
@@ -418,5 +430,120 @@ describe('STA-3077: one pane keeps at most one live remote lease', () => {
       leafId: TEST_LEAF_1,
       state: 'detached'
     })
+  })
+})
+
+describe('STA-3077: `expired` separates a superseded sibling from an orphan', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  const paneLease = { targetId: TARGET, worktreeId: WORKTREE, tabId: TAB, leafId: TEST_LEAF_1 }
+
+  async function storeWithPane(ptyId: string) {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId }))
+    store.upsertSshRemotePtyLease({ ...paneLease, ptyId, state: 'attached' })
+    return store
+  }
+
+  // The negative control on the whole change: reattaching the predecessor is the 2 -> 19 -> 20
+  // fan-out, and supersession is the only evidence that separates it from an orphan.
+  it('never bulk-reattaches a superseded sibling', async () => {
+    const store = await storeWithPane('pty-1')
+
+    paneBindsTo(store, { tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-2' })
+    store.upsertSshRemotePtyLease({ ...paneLease, ptyId: 'pty-2', state: 'attached' })
+
+    const predecessor = store.getSshRemotePtyLeases(TARGET).find((entry) => entry.ptyId === 'pty-1')
+    expect(predecessor).toMatchObject({ state: 'expired', supersededBy: 'pty-2' })
+    expect(bulkReattachPtyIds(store)).toEqual(['pty-2'])
+  })
+
+  // The cardinality invariant restated on the set that actually reaches `pty.attach`.
+  it('holds the bulk reattach set flat across ten reconnects of one pane', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithPane({ tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-0' }))
+
+    for (let reconnect = 0; reconnect < 10; reconnect++) {
+      paneBindsTo(store, { tabId: TAB, leafId: TEST_LEAF_1, ptyId: `pty-${reconnect}` })
+      store.upsertSshRemotePtyLease({ ...paneLease, ptyId: `pty-${reconnect}`, state: 'attached' })
+    }
+
+    expect(bulkReattachPtyIds(store)).toEqual(['pty-9'])
+  })
+
+  // The orphan the split buys back: nothing observed this shell, so the bulk path may ask.
+  it('bulk-reattaches an expired lease whose reattach only lost contact', async () => {
+    const store = await storeWithPane('pty-1')
+
+    store.markSshRemotePtyLease(TARGET, 'pty-1', 'expired')
+
+    const orphan = store.getSshRemotePtyLeases(TARGET)[0]
+    expect(orphan).toMatchObject({ state: 'expired' })
+    expect(orphan.supersededBy).toBeUndefined()
+    expect(orphan.relayIdRecycled).toBeUndefined()
+    expect(bulkReattachPtyIds(store)).toEqual(['pty-1'])
+  })
+
+  // Without this the orphan above stays reattachable forever and every past reconnect adds one
+  // more `pty.attach` to each handshake. A newer lease is the same evidence either way.
+  it('marks an already-expired orphan superseded once a newer lease wins the pane', async () => {
+    const store = await storeWithPane('pty-1')
+    store.markSshRemotePtyLease(TARGET, 'pty-1', 'expired')
+    const orphanUpdatedAt = store.getSshRemotePtyLeases(TARGET)[0].updatedAt
+
+    paneBindsTo(store, { tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-2' })
+    store.upsertSshRemotePtyLease({ ...paneLease, ptyId: 'pty-2', state: 'attached' })
+
+    const predecessor = store.getSshRemotePtyLeases(TARGET).find((entry) => entry.ptyId === 'pty-1')
+    expect(predecessor).toMatchObject({ state: 'expired', supersededBy: 'pty-2' })
+    // `getRecentExpiredSshLease` reads `updatedAt` as recency; a stale lease must not look fresh.
+    expect(predecessor?.updatedAt).toBe(orphanUpdatedAt)
+    expect(bulkReattachPtyIds(store)).toEqual(['pty-2'])
+  })
+
+  // A relay renumbers from `pty-1` on every start, so this row can be a different shell. The mark
+  // belongs to the lease that lost, never to whatever claims the id next.
+  it('clears the supersession mark when the id is re-upserted as a live lease', async () => {
+    const store = await storeWithPane('pty-1')
+    paneBindsTo(store, { tabId: TAB, leafId: TEST_LEAF_1, ptyId: 'pty-2' })
+    store.upsertSshRemotePtyLease({ ...paneLease, ptyId: 'pty-2', state: 'attached' })
+
+    // A restarted relay hands `pty-1` to a new shell for a different pane.
+    store.upsertSshRemotePtyLease({
+      targetId: TARGET,
+      ptyId: 'pty-1',
+      worktreeId: WORKTREE,
+      tabId: OTHER_TAB,
+      leafId: TEST_LEAF_2,
+      state: 'attached'
+    })
+
+    const recycled = store.getSshRemotePtyLeases(TARGET).find((entry) => entry.ptyId === 'pty-1')
+    expect(recycled?.supersededBy).toBeUndefined()
+    expect(bulkReattachPtyIds(store).sort()).toEqual(['pty-1', 'pty-2'])
+  })
+
+  // The pending-stop replay's `relay-id-recycled` retirement relied on `expired` alone to keep the
+  // lease out of the reattach that runs one step later; it now says so.
+  it('never bulk-reattaches a lease whose relay id was recycled', async () => {
+    const store = await storeWithPane('pty-1')
+
+    store.markSshRemotePtyLease(TARGET, 'pty-1', 'expired', { relayIdRecycled: true })
+
+    expect(store.getSshRemotePtyLeases(TARGET)[0]).toMatchObject({ relayIdRecycled: true })
+    expect(bulkReattachPtyIds(store)).toEqual([])
+  })
+
+  it('never bulk-reattaches a terminated lease, marked or not', async () => {
+    const store = await storeWithPane('pty-1')
+
+    store.markSshRemotePtyLease(TARGET, 'pty-1', 'terminated')
+
+    expect(bulkReattachPtyIds(store)).toEqual([])
   })
 })

--- a/src/main/ssh/ssh-pending-pty-kill-replay.test.ts
+++ b/src/main/ssh/ssh-pending-pty-kill-replay.test.ts
@@ -23,6 +23,7 @@ function createStoreStub(entries: SshPendingPtyKillEntry[]): {
   cleared: string[]
   terminated: string[]
   expired: string[]
+  recycled: string[]
   attempts: string[]
   remaining: () => string[]
 } {
@@ -30,6 +31,7 @@ function createStoreStub(entries: SshPendingPtyKillEntry[]): {
   const cleared: string[] = []
   const terminated: string[] = []
   const expired: string[] = []
+  const recycled: string[] = []
   const attempts: string[] = []
   const store = {
     getSshRemotePtyKillIntents: vi.fn((_target: string, now: number) =>
@@ -42,13 +44,18 @@ function createStoreStub(entries: SshPendingPtyKillEntry[]): {
       backing = backing.filter((item) => item.ptyId !== ptyId)
       cleared.push(ptyId)
     }),
-    markSshRemotePtyLease: vi.fn((_target: string, ptyId: string, state: string) => {
-      if (state === 'terminated') {
-        terminated.push(ptyId)
-      } else if (state === 'expired') {
-        expired.push(ptyId)
+    markSshRemotePtyLease: vi.fn(
+      (_target: string, ptyId: string, state: string, options?: { relayIdRecycled?: true }) => {
+        if (state === 'terminated') {
+          terminated.push(ptyId)
+        } else if (state === 'expired') {
+          expired.push(ptyId)
+          if (options?.relayIdRecycled) {
+            recycled.push(ptyId)
+          }
+        }
       }
-    }),
+    ),
     noteSshRemotePtyKillReplayAttempt: vi.fn((_target: string, ptyId: string) => {
       attempts.push(ptyId)
     })
@@ -58,6 +65,7 @@ function createStoreStub(entries: SshPendingPtyKillEntry[]): {
     cleared,
     terminated,
     expired,
+    recycled,
     attempts,
     remaining: () => backing.map((item) => item.ptyId)
   }
@@ -128,7 +136,9 @@ describe('replayPendingSshPtyKills', () => {
 
   // #16970: a redeployed relay renumbers from pty-1, so this id now names someone else's shell.
   it('refuses to kill a recycled relay id and expires the lease that named it', async () => {
-    const { store, cleared, terminated, expired } = createStoreStub([entry('pty-1', 'inc-a')])
+    const { store, cleared, terminated, expired, recycled } = createStoreStub([
+      entry('pty-1', 'inc-a')
+    ])
     const { provider, shutdown } = createProviderStub([
       { relayPtyId: 'pty-1', incarnationId: 'inc-fresh' }
     ])
@@ -144,6 +154,9 @@ describe('replayPendingSshPtyKills', () => {
     // Declining to kill is only half of it: the reattach one step later fences on paneKey/tabId and
     // never on incarnation, so an untouched lease would bind the user's old pane to that stranger.
     expect(expired).toEqual(['pty-1'])
+    // `expired` alone no longer buys that: it also names orphans the reattach is meant to re-adopt,
+    // so the recycling has to be recorded on the lease itself.
+    expect(recycled).toEqual(['pty-1'])
     // `expired`, not `terminated` — losing the route is not evidence the shell died.
     expect(terminated).toEqual([])
   })

--- a/src/main/ssh/ssh-pending-pty-kill-replay.ts
+++ b/src/main/ssh/ssh-pending-pty-kill-replay.ts
@@ -48,10 +48,13 @@ function retire(
   if (reason === 'host-reports-absent' || reason === 'stop-confirmed') {
     args.store.markSshRemotePtyLease(args.targetId, relayPtyId, 'terminated')
   } else if (reason === 'relay-id-recycled') {
-    // Why this must happen: the reattach one step later filters on lease state and fences only on
-    // paneKey/tabId, never on incarnation. Leaving this lease active hands the user's old pane to
-    // whatever process now holds the recycled id.
-    args.store.markSshRemotePtyLease(args.targetId, relayPtyId, 'expired')
+    // Why this must happen: the reattach one step later fences only on paneKey/tabId, never on
+    // incarnation. Leaving this lease reattachable hands the user's old pane to whatever process
+    // now holds the recycled id. `expired` alone no longer excludes it — that state also covers
+    // orphans the reattach is now meant to re-adopt — so the recycling is recorded explicitly.
+    args.store.markSshRemotePtyLease(args.targetId, relayPtyId, 'expired', {
+      relayIdRecycled: true
+    })
   }
   console.log(
     `[ssh-pending-kill] retired stop for ${args.targetId}/${relayPtyId} (${reason.replace(/-/g, ' ')})`

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -513,7 +513,19 @@ describe('SshRelaySession', () => {
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
       { targetId: 'target-1', ptyId: 'pty-live', state: 'detached' },
       { targetId: 'target-1', ptyId: 'pty-live-2', state: 'detached' },
-      { targetId: 'target-1', ptyId: 'pty-expired', state: 'expired' }
+      // `expired` records that the CLIENT lost its route, so this is an orphan, not a corpse — the
+      // reattach is the only thing that can find out which.
+      { targetId: 'target-1', ptyId: 'pty-orphaned', state: 'expired' },
+      // Retired routes, each for its own reason. Re-adopting the first is the lease fan-out; the
+      // second would hand this pane to whatever shell now holds the recycled id.
+      { targetId: 'target-1', ptyId: 'pty-superseded', state: 'expired', supersededBy: 'pty-live' },
+      {
+        targetId: 'target-1',
+        ptyId: 'pty-recycled',
+        state: 'expired',
+        relayIdRecycled: true
+      },
+      { targetId: 'target-1', ptyId: 'pty-terminated', state: 'terminated' }
     ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
 
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
@@ -522,12 +534,15 @@ describe('SshRelaySession', () => {
 
     expect(mockAttach).toHaveBeenCalledWith('pty-live')
     expect(mockAttach).toHaveBeenCalledWith('pty-live-2')
-    expect(mockAttach).not.toHaveBeenCalledWith('pty-expired')
+    expect(mockAttach).toHaveBeenCalledWith('pty-orphaned')
+    expect(mockAttach).not.toHaveBeenCalledWith('pty-superseded')
+    expect(mockAttach).not.toHaveBeenCalledWith('pty-recycled')
+    expect(mockAttach).not.toHaveBeenCalledWith('pty-terminated')
     expect(setPtyOwnership).toHaveBeenCalledWith('ssh:target-1@@pty-live', 'target-1')
     expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledOnce()
     expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledWith(
       'target-1',
-      expect.arrayContaining(['pty-live', 'pty-live-2'])
+      expect.arrayContaining(['pty-live', 'pty-live-2', 'pty-orphaned'])
     )
   })
 

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -80,7 +80,8 @@ import {
   type DetectedPort,
   MAX_SSH_RELAY_GRACE_PERIOD_SECONDS,
   MIN_SSH_RELAY_GRACE_PERIOD_SECONDS,
-  SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD
+  SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD,
+  sshRemotePtyLeaseAllowsReattach
 } from '../../shared/ssh-types'
 import { normalizeRemoteArtifactInput } from '../../shared/artifact-cli-bridge'
 import type { Store } from '../persistence'
@@ -2034,10 +2035,7 @@ export class SshRelaySession {
     }
     const activeLease = this.store
       .getSshRemotePtyLeases(this.targetId)
-      .find(
-        (lease) =>
-          lease.ptyId === relayPtyId && lease.state !== 'terminated' && lease.state !== 'expired'
-      )
+      .find((lease) => lease.ptyId === relayPtyId && sshRemotePtyLeaseAllowsReattach(lease))
     const activeLeaseByPtyId = activeLease
       ? new Map<string, SshPtyLease>([[relayPtyId, activeLease]])
       : new Map<string, SshPtyLease>()
@@ -2324,9 +2322,12 @@ export class SshRelaySession {
     if (!shouldContinue()) {
       return
     }
+    // Why not `state !== 'expired'`: that state covers both a superseded sibling (re-adopting it is
+    // the 2 -> 19 -> 20 fan-out) and an orphan whose reattach merely lost contact. Only the first
+    // carries a retirement mark, and only it has to be skipped.
     const activeLeases = this.store
       .getSshRemotePtyLeases(this.targetId)
-      .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
+      .filter((lease) => sshRemotePtyLeaseAllowsReattach(lease))
     const activeLeaseByPtyId = new Map(activeLeases.map((lease) => [lease.ptyId, lease]))
     const leasedPtyIds = activeLeases.map((lease) => lease.ptyId)
     // Why: pass pane identity so the relay can reject cross-generation id collisions; tabId falls back for pre-leafId leases.

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -216,6 +216,33 @@ export type SshRemotePtyLease = {
   /** A stop this client asked for and could not confirm, replayed on the next handshake to this
    *  same target. See `shared/ssh-pending-pty-kill.ts`. Never on the wire — client-local. */
   pendingKill?: SshPendingPtyKill
+  /** Stored-form ptyId of the newer lease that won this pane, written only by supersession — which
+   *  already holds the winner in hand. Cleared whenever this id is re-upserted live, so a RECYCLED
+   *  relay id cannot inherit its predecessor's mark. */
+  supersededBy?: string
+  /** The host listed this ptyId under a different PTY incarnation, so the id no longer routes to
+   *  this lease's shell. Written only by the pending-stop replay's `relay-id-recycled` retirement. */
+  relayIdRecycled?: true
+}
+
+/**
+ * `expired` says only that the CLIENT lost its route, never that the remote shell died
+ * (docs/reference/ssh-execution-boundary.md), so it covers two unrelated cases. Two writers can
+ * prove the route is dead for good — a newer lease won the pane, or the relay handed the id to
+ * another shell — and re-adopting either is the 2 -> 19 -> 20 lease fan-out or a pane handed to a
+ * stranger's process. An `expired` lease carrying neither mark is an orphan, not a corpse, and a
+ * reattach is the only thing that can tell those apart.
+ */
+export function sshRemotePtyLeaseAllowsReattach(
+  lease: Pick<SshRemotePtyLease, 'state' | 'supersededBy' | 'relayIdRecycled'>
+): boolean {
+  if (lease.state === 'terminated') {
+    return false
+  }
+  return (
+    lease.state !== 'expired' ||
+    (lease.supersededBy === undefined && lease.relayIdRecycled !== true)
+  )
 }
 
 /** Main-owned relay lease needed to reclaim PTY delivery after a desktop restart. */


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​253 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 |

<!-- /orca-pr-loc -->

Stacked on #17965 — review that first. Closes the last conflation in the SSH lease vocabulary, and unblocks the two readers #17965 had to leave alone.

## ELI5

The lease state `'expired'` was **one word doing three unrelated jobs**:

1. *"reattach gave up / we lost contact"* — the genuine orphan, which we want to reattach.
2. *"superseded by a newer lease for the same pane"* — must never be reattached, or you get the 2→19→20 lease fan-out.
3. *"the relay recycled this id onto a different shell"* — must never be reattached, or the user's old pane is handed to whatever process now holds `pty-1`.

Because those are indistinguishable, `ssh-relay-session.ts:1985`/`:2272` had to exclude **all** `expired` leases from bulk reattach — so genuine orphans were never bulk-reattached either. This gives jobs 2 and 3 their own marks, so job 1 can finally be reattached.

| field | sole writer | meaning |
|---|---|---|
| `supersededBy?: string` | `supersedeSiblingLeasesForPane` | winner's stored-form ptyId |
| `relayIdRecycled?: true` | pending-stop replay `relay-id-recycled` | host lists this id under a different incarnation |

One predicate, `sshRemotePtyLeaseAllowsReattach` (`src/shared/ssh-types.ts`), is now used by both call sites. `terminated` still returns false unconditionally.

## The third job was not in the brief and would have been a silent regression

I briefed this as a two-way split. It isn't. `ssh-pending-pty-kill-replay.ts:50-58` writes `expired` for a third reason, and its comment says the write exists *solely* to be filtered out by the reattach one step later:

> *"the reattach one step later filters on lease state and fences only on paneKey/tabId, never on incarnation. Leaving this lease active hands the user's old pane to whatever process now holds the recycled id."*

A `supersededBy`-only change would have reopened that hole, and **the paneKey fence cannot catch it** — which is exactly why the state was used. Hence two marks, not one.

## STA-3077 was not the blocker

#17965 concluded this needed relay-start identity per the STA-3077 note. That note (`ssh-pty-lease-operations.ts:118-122`) guards `upsertSshRemotePtyLease`'s `(targetId, ptyId)` match against a **recycled** `pty-N` — a different path. `supersedeSiblingLeasesForPane` already holds `winner.ptyId` at line 63. Recording the winner needed nothing new.

## Recycled ids cannot inherit a stale mark

Both marks are deleted in `upsertSshRemotePtyLease` when the merged lease lands `attached`/`detached`. A restarted relay handing `pty-1` to a new shell produces a live upsert, which clears the predecessor's mark before supersession re-derives anything. If a mark ever did leak, the failure direction is **exclusion** — today's behavior — never fan-out.

Supersession also stamps already-`expired` predecessors for the same pane (`supersededBy` only; state and `updatedAt` untouched, since bumping `updatedAt` would make a stale row look fresh to `getRecentExpiredSshLease`, which #17958 owns). Without that, every past orphan for a pane stays in the reattach set forever and each reconnect adds another `pty.attach`. The invariant is now **at most one non-superseded expired lease per pane** — the newest, i.e. the actual orphan.

## Persistence and wire

`normalizeSshRemotePtyLease` is a strict whitelist, so both fields are named there or they'd be stripped on every launch (`ssh-pending-pty-kill.ts:25-27` records that failure having shipped once). Rule 1 holds both directions: an older build's row carries neither mark and reads as *orphan* — the only thing that build could have meant — and an older build ignores keys it never heard of. Mistyped values are dropped rather than trusted. `cross-version-terminal-wire.unit.test.ts`: 10 passed.

## User-facing regressions

**One accepted cost, stated plainly:** leases expired by **Reset Relay** now enter the bulk set. A reset relay is fresh, so `pty.attach` answers not-found and `ssh-relay-session.ts:2838` re-expires it — the same convergence `adoptStablePane` already reaches after #17965, just earlier. The stamping above bounds it to one stale row per pane until that pane next spawns.

Otherwise none. Negative controls pin every exclusion: superseded siblings, recycled ids, and `terminated` leases are all still excluded from bulk reattach, and the cardinality suite stays flat.

## Testing

Before (source reverted, new tests in place):
```
 ❯ src/main/ssh/ssh-pending-pty-kill-replay.test.ts (15 tests | 1 failed)
     × refuses to kill a recycled relay id and expires the lease that named it
 ❯ src/main/persistence-ssh-remote-pty-leases.test.ts (20 tests | 2 failed)
     × salvages both marks rather than stripping them
     × reads a row written before the marks existed as a reattachable orphan
 ❯ src/main/ssh-reattach-pane-cardinality.test.ts (20 tests | 7 failed)
     × never bulk-reattaches a superseded sibling
     × holds the bulk reattach set flat across ten reconnects of one pane
     × bulk-reattaches an expired lease whose reattach only lost contact
     × marks an already-expired orphan superseded once a newer lease wins the pane
     × clears the supersession mark when the id is re-upserted as a live lease
     × never bulk-reattaches a lease whose relay id was recycled
     × never bulk-reattaches a terminated lease, marked or not
 Test Files  3 failed (3)
      Tests  10 failed | 45 passed (55)
```
After: `Test Files 4 passed (4) / Tests 90 passed (90)`.

Regression sweep across `src/main/ssh`, `persistence`, `ipc`, `providers`, `runtime`, `src/relay`: **14602 passed | 44 skipped**. `tc:node` / `tc:web` / `tc:cli` clean. `check:code-quality:changed`: 0 new findings across 31 files.

## Toward consolidation

This is the vocabulary prerequisite for merging SSH into the orca remote: every lease state now means exactly one thing, so the two subsystems can share one predicate instead of each re-deriving intent from an overloaded enum. Several bugs in this sweep (#17957, #17962, #17965) had the same root cause — one path guarding a hazard its twin did not.
