### PR TITLE
fix(automations): report an unverifiable process loss as lost, not failed

### DIFF
--- a/src/renderer/src/hooks/automation-dispatch-completion.ts
+++ b/src/renderer/src/hooks/automation-dispatch-completion.ts
@@ -14,6 +14,7 @@ import {
   UNCHANGED_AUTOMATION_AGENT_STATUS_ENTRY
 } from './automation-agent-status-entry-change'
 import type { Worktree } from '../../../shared/worktree/types'
+import { isProvenProcessExit } from '../../../shared/terminal-exit-cause'
 
 type MarkDispatchResult = (result: AutomationDispatchResult) => Promise<void>
 
@@ -33,6 +34,7 @@ export function createAutomationDispatchCompletion(args: {
   let pendingExitCode: number | null = null
   let pendingDone = false
   let completionMarked = false
+  let contactLost = false
   let unsubscribeAgentStatus = (): void => {}
   let unsubscribeSessionObserver = (): void => {}
   let releaseReuseDispatchTab = (): void => {}
@@ -85,8 +87,34 @@ export function createAutomationDispatchCompletion(args: {
       console.error('[automations] Failed to clear retired terminal identity:', error)
     }
   }
+  /**
+   * A lost PTY is not a result. Record nothing: the run keeps its non-final
+   * `dispatched` status, so it is never evicted from history and never shown as
+   * Failed for work that is very likely still running (on SSH, a relay whose
+   * reattach failed). Ownership of an unobservable run belongs to main's
+   * AutomationRunCompletionWatcher, which reports the truthful "lost the
+   * terminal for this run" instead of an exit code nobody witnessed.
+   *
+   * `finalize()` is deliberately never reached here — closing the terminal of a
+   * process we cannot prove dead is what orphans live work.
+   */
+  const abandonUnverifiableRun = (code: number): void => {
+    if (completionMarked || contactLost) {
+      return
+    }
+    contactLost = true
+    cleanupRunObservers()
+    args.releaseTerminalOwnership()
+    console.warn(
+      `[automations] Lost contact with the process for run ${args.run.id} (code ${code}); leaving the run dispatched rather than reporting an exit.`
+    )
+  }
   const markExitResult = async (code: number): Promise<void> => {
     if (completionMarked) {
+      return
+    }
+    if (!isProvenProcessExit(code)) {
+      abandonUnverifiableRun(code)
       return
     }
     completionMarked = true

--- a/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
+++ b/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AutomationDispatchResult } from '../../../shared/automations-types'
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({ agentStatusByPaneKey: {} }),
+    subscribe: vi.fn(() => () => {})
+  }
+}))
+
+const markDispatchResult = vi.fn<(result: AutomationDispatchResult) => Promise<void>>()
+const releaseTerminalOwnership = vi.fn()
+const finalizeTerminalOwnership = vi.fn(() => false)
+
+async function createCompletion() {
+  const { createAutomationDispatchCompletion } = await import('./automation-dispatch-completion')
+  const completion = createAutomationDispatchCompletion({
+    run: { id: 'run-1' } as never,
+    worktree: { id: 'wt-1', displayName: 'Automation worktree' } as never,
+    precheckResult: null,
+    markDispatchResult,
+    releaseTerminalOwnership,
+    finalizeTerminalOwnership
+  })
+  // The dispatch itself is already recorded before any exit can settle it.
+  await completion.settlePendingAfterDispatch()
+  markDispatchResult.mockClear()
+  return completion
+}
+
+/**
+ * Loss of contact is never evidence of process death
+ * (docs/reference/ssh-execution-boundary.md). The exit sentinel these readers
+ * receive is the same one the terminal panes already classify as unverifiable.
+ */
+describe('automation dispatch completion on an unverifiable loss', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    markDispatchResult.mockResolvedValue(undefined)
+    finalizeTerminalOwnership.mockReturnValue(false)
+  })
+
+  it('records no result, so the run keeps its non-final dispatched status', async () => {
+    // A -1 is a lost relay or a synthesized host-shutdown fanout. Reporting
+    // "exited with code -1" asserts a finish nobody witnessed; on SSH the
+    // automation is very likely still running.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const completion = await createCompletion()
+
+    completion.handleExit(-1)
+    await vi.waitFor(() => expect(releaseTerminalOwnership).toHaveBeenCalledOnce())
+
+    expect(markDispatchResult).not.toHaveBeenCalled()
+    // Closing a terminal whose process cannot be proven dead orphans live work.
+    expect(finalizeTerminalOwnership).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('still completes and finalizes a genuinely exited process', async () => {
+    const completion = await createCompletion()
+    finalizeTerminalOwnership.mockReturnValue(true)
+
+    completion.handleExit(0)
+    await vi.waitFor(() => expect(finalizeTerminalOwnership).toHaveBeenCalledOnce())
+
+    expect(markDispatchResult).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: 'run-1', status: 'completed', error: null })
+    )
+    expect(releaseTerminalOwnership).not.toHaveBeenCalled()
+  })
+
+  it('still reports a real automation failure as dispatch_failed', async () => {
+    const completion = await createCompletion()
+
+    completion.handleExit(9)
+    await vi.waitFor(() => expect(releaseTerminalOwnership).toHaveBeenCalledOnce())
+
+    expect(markDispatchResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'run-1',
+        status: 'dispatch_failed',
+        error: 'Automation process exited with code 9.'
+      })
+    )
+    expect(finalizeTerminalOwnership).not.toHaveBeenCalled()
+  })
+
+  it('lets a later done still complete a run whose contact was lost', async () => {
+    // The loss withheld a verdict rather than settling one, so positive
+    // evidence arriving afterwards must still be able to close the run.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const completion = await createCompletion()
+
+    completion.handleExit(-1)
+    await vi.waitFor(() => expect(releaseTerminalOwnership).toHaveBeenCalledOnce())
+    completion.handleAgentDone()
+
+    await vi.waitFor(() =>
+      expect(markDispatchResult).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'completed' })
+      )
+    )
+    warnSpy.mockRestore()
+  })
+})

--- a/src/renderer/src/lib/agent-background-session-exit.ts
+++ b/src/renderer/src/lib/agent-background-session-exit.ts
@@ -1,0 +1,32 @@
+import { useAppStore } from '@/store'
+import {
+  isProvenProcessExit,
+  UNVERIFIED_PROCESS_EXIT_CODE
+} from '../../../shared/terminal-exit-cause'
+
+/**
+ * The code a runtime `terminal.wait` actually reported.
+ *
+ * Why not `?? 0`: a wait that answers without a status observed nothing, and a
+ * fabricated zero would be read downstream as a clean finish.
+ */
+export function runtimeWaitExitCode(wait: { exitCode?: number | null }): number {
+  return wait.exitCode ?? UNVERIFIED_PROCESS_EXIT_CODE
+}
+
+/**
+ * Settle a background agent tab's PTY binding when its session ends.
+ *
+ * Mirrors the rule the mounted panes follow (pty-exit-hibernate.ts): only a
+ * proven exit drops the tab↔PTY identity. A synthetic loss sentinel retires the
+ * transport alone, so the binding stays for reconnect to adopt and the tab is
+ * marked so orphan cleanup cannot sweep an agent that may still be running.
+ */
+export function settleTabPtyBinding(tabId: string, ptyId: string, code: number): void {
+  const state = useAppStore.getState()
+  if (isProvenProcessExit(code)) {
+    state.clearTabPtyId(tabId, ptyId)
+    return
+  }
+  state.markUnverifiedPtyLoss(tabId)
+}

--- a/src/renderer/src/lib/agent-background-session-test-state.ts
+++ b/src/renderer/src/lib/agent-background-session-test-state.ts
@@ -49,6 +49,7 @@ export type AgentBackgroundSessionTestState = {
   closeTab: TestMock
   setTabLayout: TestMock
   clearTabPtyId: TestMock
+  markUnverifiedPtyLoss: TestMock
   setAgentStatus: TestMock
   registerAgentLaunchConfig: TestMock
   clearAgentLaunchConfig: TestMock
@@ -114,6 +115,7 @@ export function createAgentBackgroundSessionTestState(mocks: {
     closeTab: mocks.closeTab,
     setTabLayout: mocks.setTabLayout,
     clearTabPtyId: vi.fn(),
+    markUnverifiedPtyLoss: vi.fn(),
     setAgentStatus: vi.fn(),
     registerAgentLaunchConfig: mocks.registerAgentLaunchConfig,
     clearAgentLaunchConfig: vi.fn()

--- a/src/renderer/src/lib/automation-session-observer.test.ts
+++ b/src/renderer/src/lib/automation-session-observer.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { toAppSshPtyId } from '../../../shared/ssh-pty-id'
+import { UNVERIFIED_PROCESS_EXIT_CODE } from '../../../shared/terminal-exit-cause'
 
 const mockSubscribeToPtyData = vi.fn()
 const mockSubscribeToPtyExit = vi.fn()
@@ -151,6 +152,51 @@ describe('observeExistingAutomationSession', () => {
       { connectionId: null }
     )
     expect(onAgentStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a runtime wait that carried no status as unverified, not as a clean exit', async () => {
+    // `exitCode ?? 0` fabricated a clean finish out of an absent status, so a
+    // host that answered without one was read as a completed automation.
+    state.terminalLayoutsByTabId = {
+      'tab-1': { ptyIdsByLeafId: { [LEAF_ID]: 'remote:env-1@@terminal-9' } }
+    }
+    state.ptyIdsByTabId = { 'tab-1': ['remote:env-1@@terminal-9'] }
+    mockCallRuntimeRpc.mockResolvedValue({ wait: {} })
+    const onExit = vi.fn()
+    const { observeExistingAutomationSession } = await import('./automation-session-observer')
+
+    await observeExistingAutomationSession({
+      ptyId: 'remote:env-1@@terminal-9',
+      paneKey: PANE_KEY,
+      runId: 'run-1',
+      onData: vi.fn(),
+      onAgentStatus: vi.fn(),
+      onExit
+    })
+
+    await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1))
+    expect(onExit).toHaveBeenCalledWith(UNVERIFIED_PROCESS_EXIT_CODE)
+  })
+
+  it('still forwards a status the runtime host did report', async () => {
+    state.terminalLayoutsByTabId = {
+      'tab-1': { ptyIdsByLeafId: { [LEAF_ID]: 'remote:env-1@@terminal-9' } }
+    }
+    state.ptyIdsByTabId = { 'tab-1': ['remote:env-1@@terminal-9'] }
+    mockCallRuntimeRpc.mockResolvedValue({ wait: { exitCode: 0 } })
+    const onExit = vi.fn()
+    const { observeExistingAutomationSession } = await import('./automation-session-observer')
+
+    await observeExistingAutomationSession({
+      ptyId: 'remote:env-1@@terminal-9',
+      paneKey: PANE_KEY,
+      runId: 'run-1',
+      onData: vi.fn(),
+      onAgentStatus: vi.fn(),
+      onExit
+    })
+
+    await vi.waitFor(() => expect(onExit).toHaveBeenCalledWith(0))
   })
 
   it('stamps the exact SSH PTY in the legacy renderer fallback', async () => {

--- a/src/renderer/src/lib/automation-session-observer.ts
+++ b/src/renderer/src/lib/automation-session-observer.ts
@@ -9,6 +9,7 @@ import {
 } from '@/runtime/runtime-terminal-stream'
 import { useAppStore } from '@/store'
 import { createAgentStatusOscProcessor } from '../../../shared/agent-status-osc'
+import { runtimeWaitExitCode } from '@/lib/agent-background-session-exit'
 import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
 import { isMainTerminalSideEffectAuthorityForPty } from '@/components/terminal-pane/terminal-side-effect-facts-handler'
 import { resolveLiveAgentStatusConnectionRouting } from '@/lib/agent-status-connection-ownership'
@@ -93,7 +94,7 @@ export async function observeExistingAutomationSession(args: {
     )
       .then((result) => {
         if (!disposed) {
-          onExit(result.wait.exitCode ?? 0)
+          onExit(runtimeWaitExitCode(result.wait))
         }
       })
       .catch(() => {})

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -474,6 +474,31 @@ describe('launchAgentBackgroundSession', () => {
     )
     expect(onExit).toHaveBeenCalledWith('pty-1', 0)
     expect(unsubscribe).toHaveBeenCalled()
+    expect(state.markUnverifiedPtyLoss).not.toHaveBeenCalled()
+  })
+
+  it('keeps the tab bound to its PTY when contact was lost rather than observed', async () => {
+    // Same rule the terminal panes follow: a -1 sentinel retires the transport
+    // only. Clearing the binding would leave a reconnect with nothing to adopt
+    // and let orphan cleanup sweep a tab whose agent may still be running.
+    mockSubscribeToPtyExit.mockReturnValue(vi.fn())
+    const onExit = vi.fn()
+    const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
+
+    await launchAgentBackgroundSession({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      prompt: 'run the automation',
+      onExit
+    })
+
+    const sidecar = mockSubscribeToPtyExit.mock.calls[0]?.[1] as (code: number) => void
+    sidecar(-1)
+
+    const tabId = expectReservedAgentBackgroundTabId(mockSpawn)
+    expect(state.clearTabPtyId).not.toHaveBeenCalled()
+    expect(state.markUnverifiedPtyLoss).toHaveBeenCalledWith(tabId)
+    expect(onExit).toHaveBeenCalledWith('pty-1', -1)
   })
 
   it('leaves no tab behind if PTY spawn fails', async () => {

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -40,6 +40,7 @@ import {
 } from '@/lib/adopt-agent-background-session-tab'
 import { createBackgroundAgentStatusConsumer } from '@/lib/background-agent-status-consumer'
 import { isWslUncPath } from '../../../shared/wsl-paths'
+import { runtimeWaitExitCode, settleTabPtyBinding } from '@/lib/agent-background-session-exit'
 
 export async function launchAgentBackgroundSession(
   args: LaunchAgentBackgroundSessionArgs
@@ -145,7 +146,7 @@ export async function launchAgentBackgroundSession(
     unsubscribeData()
     sshStartupDelivery.clear()
     if (tab) {
-      useAppStore.getState().clearTabPtyId(tab.id, exitPtyId)
+      settleTabPtyBinding(tab.id, exitPtyId, code)
     }
     useAppStore.getState().clearAgentLaunchConfig(paneKey)
     onExit?.(exitPtyId, code)
@@ -279,7 +280,7 @@ export async function launchAgentBackgroundSession(
         { terminal: runtimeTerminalHandle, for: 'exit' },
         { timeoutMs: 24 * 60 * 60 * 1000 }
       )
-        .then((result) => handleExit(ptyId, result.wait.exitCode ?? 0))
+        .then((result) => handleExit(ptyId, runtimeWaitExitCode(result.wait)))
         .catch(() => {})
     } else {
       // Why the incarnation: a relay-recycled id can hold the previous owner's exit, and draining

--- a/src/shared/terminal-exit-cause.test.ts
+++ b/src/shared/terminal-exit-cause.test.ts
@@ -109,4 +109,22 @@ describe('isProvenProcessExit', () => {
     // A host shutdown can deliver -1 for every PTY without proving process death.
     expect(isProvenProcessExit(-1)).toBe(false)
   })
+
+  it('answers whether the process ended, not why — so it may differ from the cause on zero', () => {
+    // Deliberate, not an oversight: an unknowable *reason* is not an unknown
+    // *fact of death*. Collapsing these would strand every cleanly-exited pane.
+    expect(resolveUnreportedExitCause(0)).toEqual({ kind: 'unknown', reason: 'cause_unreported' })
+    expect(isProvenProcessExit(0)).toBe(true)
+  })
+
+  it('keeps a shell that a user closed with `exit` tearing down on macOS', () => {
+    // login(1) wraps every macOS local PTY once the TCC preflight passes, so
+    // hostReportsChildExitStatus is false for essentially all of them. login
+    // forks the shell and waits, so its exit still proves the shell died —
+    // routing that evidence through here would leave the pane mounted forever.
+    expect(
+      resolveProcessExitCause({ exitCode: 0, signal: 0, hostReportsChildExitStatus: false }).kind
+    ).toBe('unknown')
+    expect(isProvenProcessExit(0)).toBe(true)
+  })
 })

--- a/src/shared/terminal-exit-cause.ts
+++ b/src/shared/terminal-exit-cause.ts
@@ -35,6 +35,16 @@ export type TerminalExitUnknownReason =
 export const OPERATOR_CLOSE_EXIT_CAUSE: TerminalExitCause = { kind: 'operator_close' }
 
 /**
+ * The code every surface uses for "contact was lost before the host could vouch
+ * for this process". `resolveProcessExitCause` reads it as `stop_unverified`
+ * and {@link isProvenProcessExit} rejects it.
+ *
+ * A reader handed an *optional* status by a host must default to this, never to
+ * `0`: `exitCode ?? 0` mints a clean finish out of an absence of evidence.
+ */
+export const UNVERIFIED_PROCESS_EXIT_CODE = -1
+
+/**
  * Build a cause from what the host actually observed.
  *
  * `hostReportsChildExitStatus: false` means the number and signal below describe

--- a/src/shared/terminal-exit-cause.ts
+++ b/src/shared/terminal-exit-cause.ts
@@ -108,6 +108,23 @@ export function isDeliberateTerminalExit(cause: TerminalExitCause): boolean {
  * Negative codes are synthetic stop sentinels; they mean that the host lost
  * contact before it could vouch for the child, so downstream cleanup must use
  * the `unverifiable` path instead of treating the tab as exited.
+ *
+ * This asks *whether* the process ended; the cause resolvers above ask *why*.
+ * The two deliberately disagree about `0`, and that is not a defect:
+ *
+ * - `resolveUnreportedExitCause(0)` is `unknown` because a bare zero cannot
+ *   distinguish a clean finish from a signal — an unknowable **reason**.
+ * - `isProvenProcessExit(0)` is `true` because a host only forwards a
+ *   non-negative code after its provider observed the process end — a known
+ *   **fact of death**, whatever the reason.
+ *
+ * Do not route `hostReportsChildExitStatus` or `signal` through here to
+ * "narrow" the zero. `login(1)` wraps every macOS local PTY once the TCC
+ * preflight passes, so `hostReportsChildExitStatus` is false for essentially
+ * all of them (macos-tcc-login-shell.ts) — yet login forks the shell and waits,
+ * so its own exit *is* evidence the shell died. Treating those as unproven
+ * would strand every macOS pane that a user closed with `exit`, which is the
+ * mirror-image regression of reporting a lost host as exited.
  */
 export function isProvenProcessExit(exitCode: number): boolean {
   return resolveProcessExitCause({ exitCode }).kind !== 'unknown'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​194 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​194 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​94 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 |

<!-- /orca-pr-loc -->

Closes #17955 — but **not** the way that issue proposed. Half of it was my analysis error; the other half was real and worse than reported.

## Part A — the reported defect is not a defect, and "fixing" it would break every macOS terminal

#17955 claimed `isProvenProcessExit(0) === true` is a bug because its sibling `resolveUnreportedExitCause` maps the same `0` to `unknown`. That disagreement is the **design**, not an oversight:

- The cause resolvers answer *why* it ended. A bare `0` cannot separate a clean finish from a signalled death — an unknowable **reason**.
- `isProvenProcessExit` answers *whether* it ended. A host only forwards a non-negative code after its provider observed the process end — a known **fact of death**, whatever the reason.

The proposed fix — routing `hostReportsChildExitStatus` into the predicate — is actively harmful. That flag is false **only** when the spawned file is `/usr/bin/login` (`macos-tcc-login-shell.ts:320-322`), and `wrapShellSpawnForMacosTccAttribution` wraps **every macOS local PTY** once the TCC preflight passes. Feeding it in would make every macOS terminal an "unverified loss", so **no pane would ever close after a user typed `exit`** — on the default macOS configuration.

That is precisely the mirror-image regression #17955 itself warned about.

The premise was also checked directly: every loss-of-contact path delivers a **negative** code to these consumers — `ssh-relay-session.ts:2836` (`code: -1`, the exact reattach-failure case in the issue) and `daemon-provider-restart.ts` (`fanoutSyntheticExits(-1)`). The renderer reconcile that defaults to `0` (`session-reconcile-dispose.ts:45`) excludes SSH and remote ids by construction (`terminal-dead-session-reconcile.ts:44-52`), so it fires only on an authoritative local listing.

**Commit 1 changes no behavior.** It documents the whether/why split on the predicate and adds two regression tests that fail if someone "fixes" it as the issue proposed.

## Part B — the live half was real, and there was a second fabrication the issue missed

Both automation readers consumed the raw exit code with no vocabulary guard, so a `-1` unverifiable loss surfaced as `status: 'dispatch_failed'` with `error: "Automation process exited with code -1."` — telling the user their automation **failed** when all that happened is we lost contact, and on SSH the automation is very likely still running.

The second one, not named in the issue: both readers did `result.wait.exitCode ?? 0` on the runtime `terminal.wait` RPC (`automation-session-observer.ts:96`, `launch-agent-background-session.ts:282`). A host that answered **without** a status was reported as a **clean, successful automation**. Same class of error, failing in the more dangerous direction. Both now share `runtimeWaitExitCode`, defaulting to the new `UNVERIFIED_PROCESS_EXIT_CODE`.

### The product decision, stated plainly

On unverifiable loss the completion tracker **records no result at all.**

Chosen over retry or a new status because the codebase already has the right owner: `markDispatchResult({status:'dispatched'})` hands the run to main's `AutomationRunCompletionWatcher`, whose `describeStrandedAutomationRun` already emits the truthful *"Orca lost the terminal for this run before it reported completion"* and is documented as never claiming completion. So the run stays non-final — shown as "Launched", never evicted, never "Failed" — and the existing authority closes it out truthfully on its own timeline. The guard permits a later `done` to complete the run normally; note that `abandonUnverifiableRun` calls `cleanupRunObservers()`, which tears down the `unsubscribeAgentStatus` subscription such a `done` would arrive on, so in practice the `AutomationRunCompletionWatcher` is the authority that closes the run out. This fails safe — the watcher reports truthfully — but the guard is permissive, not a delivery guarantee.

`finalize()` is never reached: closing a terminal whose process cannot be proven dead is what orphans live work.

**No new run status, no wire change, no new user-facing string** — `sync:localization-catalog` produces no diff, verified.

Also gated `clearTabPtyId` in `launch-agent-background-session.ts` to match `pty-exit-hibernate.ts`. Clearing the tab↔PTY binding on an unverified loss leaves reconnect nothing to adopt and lets orphan cleanup sweep a possibly-live agent — the "cold-start a duplicate over the same worktree" hazard. It now calls `markUnverifiedPtyLoss`.

## User-facing regressions

**None expected.** Both negative controls are explicit tests and pass: a proven `0` still completes **and finalizes**; a real exit `9` still reports `dispatch_failed` with its original message.

## Testing

Failing before, verbatim:
```
FAIL automation-dispatch-unverifiable-loss.test.ts > records no result, so the run keeps its non-final dispatched status
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
  1st vi.fn() call:
    Array [ Object { "error": "Automation process exited with code -1.", "status": "dispatch_failed", ... } ]

FAIL automation-session-observer.test.ts > reports a runtime wait that carried no status as unverified, not as a clean exit
AssertionError: expected "vi.fn()" to be called with arguments: [ undefined ]
Received: -   undefined  +   0

FAIL launch-agent-background-session.test.ts > keeps the tab bound to its PTY when contact was lost rather than observed
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
```
After: `Test Files 640 passed (640) | Tests 5662 passed | 1 skipped (5663)`. `tc:node`, `tc:web`, `check:code-quality:changed` (0 new findings) clean.

The pre-commit hook rejected the first attempt with `max-lines`. Rather than disable the rule (forbidden by AGENTS.md), the two exit-vocabulary concerns were extracted into `src/renderer/src/lib/agent-background-session-exit.ts` and the new completion test given its own file instead of growing the 800-line integration suite.

## Toward consolidation

The terminal-pane subsystem honors the `live`/`unverifiable`/`exited` vocabulary at all ~8 of its consumers; the automation path bypassed it entirely. That twin-divergence shape is the root cause behind #17957, #17962, #17965, and #17966 as well — the strongest ongoing argument for collapsing SSH and remote onto one path.

