### PR TITLE
fix(relay): fail an oversized response instead of closing the client

### DIFF
--- a/src/relay/dispatcher-capacity-degradation.test.ts
+++ b/src/relay/dispatcher-capacity-degradation.test.ts
@@ -59,6 +59,14 @@ function makeBoundedClient(highWaterMark: number): BoundedClient {
   return client
 }
 
+// Why: the sink accepts every write but never settles it, so control-lane bytes stay retained and the
+// queue fills, while the writer keeps pumping the other lanes — the shape of a peer whose socket is behind.
+function makeUnsettledWriteClient(highWaterMark: number): BoundedClient {
+  const client = makeBoundedClient(highWaterMark)
+  client.options = { ...client.options, supportsWriteCallback: true }
+  return client
+}
+
 function decodePayload(frame: Buffer): Record<string, unknown> {
   const length = frame.readUInt32BE(9)
   return JSON.parse(frame.subarray(13, 13 + length).toString('utf-8'))
@@ -460,6 +468,94 @@ describe('RelayDispatcher bounded-capacity degradation', () => {
       expect(response.id).toBe(78)
       expect(response.error.code).toBe(RelayErrorCode.ResponseOverCapacity)
       expect(response.error.message).toBe('Relay response exceeded the bounded transport capacity')
+    } finally {
+      bounded.dispose()
+    }
+  })
+
+  it('answers an over-budget response with a capacity error instead of closing the connection', async () => {
+    const primary = makeUnsettledWriteClient(65536)
+    const bounded = new RelayDispatcher(primary.write, primary.options)
+    try {
+      const clientId = bounded.activeClientIds()[0]
+      bounded.onRequest('fs.listFiles', async () => ({ paths: 'x'.repeat(700 * 1024) }))
+      bounded.onRequest('workspace.get', async () => ({ name: 'workspace' }))
+
+      bounded.feed(encodeJsonRpcFrame({ jsonrpc: '2.0', id: 91, method: 'fs.listFiles' }, 1, 0))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(primary.frames).toHaveLength(1)
+
+      // The first reply still holds the shared control budget, so the second cannot fit under 1 MiB.
+      bounded.feed(encodeJsonRpcFrame({ jsonrpc: '2.0', id: 92, method: 'fs.listFiles' }, 2, 0))
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(primary.closes).toBe(0)
+      expect(bounded.isClientAttached(clientId)).toBe(true)
+      expect(primary.frames).toHaveLength(2)
+      const rejected = decodePayload(primary.frames[1]) as unknown as {
+        id: number
+        error: { code: number; message: string }
+      }
+      expect(rejected.id).toBe(92)
+      expect(rejected.error.code).toBe(RelayErrorCode.ResponseOverCapacity)
+      expect(rejected.error.message).toBe('Relay response exceeded the bounded transport capacity')
+
+      // Every other pane and request on this connection keeps working.
+      bounded.feed(encodeJsonRpcFrame({ jsonrpc: '2.0', id: 93, method: 'workspace.get' }, 3, 0))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(decodePayload(primary.frames[2])).toMatchObject({
+        id: 93,
+        result: { name: 'workspace' }
+      })
+
+      bounded.notify('pty.data', { paneId: 'pane-1', data: 'still-live' })
+      expect(decodePayload(primary.frames[3])).toMatchObject({ method: 'pty.data' })
+      expect(primary.closes).toBe(0)
+    } finally {
+      bounded.dispose()
+    }
+  })
+
+  it('still closes the client when a protocol-critical control frame overflows', () => {
+    const primary = makeUnsettledWriteClient(65536)
+    const bounded = new RelayDispatcher(primary.write, primary.options)
+    try {
+      const clientId = bounded.activeClientIds()[0]
+      bounded.notifyClient(clientId, 'workspace.stale', { blob: 'x'.repeat(700 * 1024) })
+      expect(primary.closes).toBe(0)
+
+      // Replay is never re-sent, so an unnoticed drop strands the pane: overflow here stays fatal.
+      bounded.notify('pty.replay', { paneKey: 'tab-1:pane-1', data: 'y'.repeat(700 * 1024) })
+      expect(primary.closes).toBe(1)
+    } finally {
+      bounded.dispose()
+    }
+  })
+
+  it('drops an unsendable response without closing when even the capacity error will not fit', async () => {
+    const primary = makeUnsettledWriteClient(65536)
+    const bounded = new RelayDispatcher(primary.write, primary.options)
+    try {
+      const clientId = bounded.activeClientIds()[0]
+      const settlements: SinkWriteSettlement[] = []
+      bounded.onRequest('workspace.get', async (_params, context) => {
+        context.onResponseSettled?.((result) => settlements.push(result))
+        return { name: 'workspace' }
+      })
+      for (let index = 0; index < DISPATCHER_CONTROL_QUEUE_MAX_FRAMES; index += 1) {
+        bounded.notifyClient(clientId, `control.${index}`)
+      }
+      const framesBefore = primary.frames.length
+
+      bounded.feed(encodeJsonRpcFrame({ jsonrpc: '2.0', id: 94, method: 'workspace.get' }, 1, 0))
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Nothing goes out, but the connection lives and the caller's own request timeout settles it.
+      expect(primary.closes).toBe(0)
+      expect(primary.frames).toHaveLength(framesBefore)
+      expect(settlements).toEqual([
+        { ok: false, error: new Error('Relay response was not admitted') }
+      ])
     } finally {
       bounded.dispose()
     }

--- a/src/relay/dispatcher-rpc-routing.ts
+++ b/src/relay/dispatcher-rpc-routing.ts
@@ -203,12 +203,17 @@ export abstract class RelayDispatcherRpcRouting extends RelayDispatcherFrameCode
     const frame = this.prepareFrame(msg)
     const lane =
       frame.frameBytes > DISPATCHER_CONTROL_QUEUE_MAX_BYTES ? 'legacy-response' : 'control'
-    const accepted = this.enqueuePreparedFrame(client, frame, lane, onSettled)
+    // Why 'reject': the control lane is a shared budget, so a reply that fits the 1 MiB ceiling alone
+    // still overflows it under concurrent traffic. Fatal admission would close the connection — every
+    // pane on the host — over one listing. A response is the droppable class of control frame: it
+    // carries an id, so the substitute below tells that one caller, and pty.replay/notifyControl keep
+    // the fatal default because a silent drop there desyncs the client with nothing to retry.
+    const accepted = this.enqueuePreparedFrame(client, frame, lane, onSettled, 'reject')
     if (accepted) {
       return true
     }
     // Why: an oversized response must fail its own request; closing would kill every pane on the host.
-    // A rejected first enqueue either left onSettled untouched or closed the client, so exactly one settlement happens.
+    // A rejected first enqueue leaves onSettled untouched, so exactly one settlement happens.
     return this.enqueuePreparedFrame(
       client,
       this.prepareFrame({
@@ -227,7 +232,10 @@ export abstract class RelayDispatcherRpcRouting extends RelayDispatcherFrameCode
           settlement.ok
             ? { ok: false, error: new Error(RESPONSE_OVER_CAPACITY_MESSAGE) }
             : settlement
-        )
+        ),
+      // Why 'reject': if even ~150 bytes will not fit, the caller's own request timeout settles it.
+      // Closing to report that one request failed is the outcome this whole path exists to avoid.
+      'reject'
     )
   }
 

--- a/src/relay/fs-handler-file-range.test.ts
+++ b/src/relay/fs-handler-file-range.test.ts
@@ -105,10 +105,10 @@ describe('readRelayFileRange', () => {
   // which the writer refuses once the producer queue is busy -- so an over-wide
   // cap fails with ResponseOverCapacity depending on unrelated load.
   //
-  // Fitting the lane once is not enough: the control queue is a SHARED budget
-  // and overflowing it closes the client, so a full-cap frame has to leave room
-  // for a second one. Anything wider lets two pipelined tail reads -- or one
-  // read racing an unrelated response -- kill the connection.
+  // Fitting the lane once is not enough: the control queue is a SHARED budget,
+  // so a full-cap frame has to leave room for a second one. Anything wider lets
+  // two pipelined tail reads -- or one read racing an unrelated response --
+  // fail as ResponseOverCapacity on load that has nothing to do with them.
   it('leaves control-queue headroom for a second full-cap window', async () => {
     const contents = Buffer.allocUnsafe(MAX_FILE_RANGE_READ_BYTES)
     for (let i = 0; i < contents.length; i++) {

--- a/src/shared/file-range-read.ts
+++ b/src/shared/file-range-read.ts
@@ -8,10 +8,11 @@
  *  frames to ~350 KB, so a full-cap response takes the control lane instead.
  *
  *  The control lane is a shared budget, not a per-frame one: two full-cap
- *  responses fit alongside each other, and the third overflows -- which for a
- *  response is fatal, it closes the client. That is the same exposure every
- *  control-lane response already carries (`fs.readFile` frames any sub-1 MiB
- *  file the same way), and the two-deep headroom is pinned by a test. Widening
+ *  responses fit alongside each other, and the third is refused. That refusal
+ *  costs the one request -- `sendResponse` admits responses with
+ *  `controlOverflow: 'reject'` and substitutes a `ResponseOverCapacity` error
+ *  rather than closing the connection -- but it still turns on unrelated load,
+ *  so the two-deep headroom that keeps it rare is pinned by a test. Widening
  *  the cap spends that headroom, so bigger transfers belong on the ack-paced
  *  bulk lane (`fs.readFileStream`) rather than on a wider window here.
  *


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​96 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

Stacked on #17954 — review that first. Fixes the latent hazard #17954 found and deliberately left alone.

## ELI5

An oversized RPC response **closed the whole connection** instead of failing the one request. On a large remote workspace a single Quick Open listing could drop the user's entire remote session — every terminal on that host going with it. This is live today, not introduced by the stacked PRs.

Now an oversized response returns an error on the connection and everything else keeps running.

## This was a bug, not a design choice — the intent was already written down

`sendResponse` already carried the comment:

> *"an oversized response must fail its own request; closing would kill every pane on the host"*

The control-lane branch just never reached it. Fatal admission closes the client **before** the substitute error is attempted, and `enqueuePreparedFrame` then short-circuits on `client.closed`. So the substitute only ever worked for the `legacy-response` lane (frames >1 MiB), never for the shared-budget overflow #17954 flagged.

## The fatal close *is* deliberate for other control traffic — and stays

Every control-lane producer was read. Two classes, and the codebase already distinguishes them:

**Un-droppable — keeps the fatal default:**
- `notify('pty.replay')` (`dispatcher-notification-publication.ts:33`), with a standing comment: *"replay is never re-sent, so it takes the control lane where overflow is fatal — the writer closes the client and reconnect reloads history rather than stranding a short buffer."*
- `notifyControl` (`:131`) — calls `closeClient` itself on rejection.
- `notifyClient`/`tryNotifyClient` (`:110`) — caller-selectable, defaults fatal.

**Droppable:**
- Relay→client requests (`dispatcher-rpc-routing.ts:254`) — **already** passed `'reject'`. That is the author's own precedent: a frame with an id and one waiting caller is droppable.
- RPC responses — same property, plus a `ResponseOverCapacity` substitute path written for exactly this purpose.

## The client always settles; only the close costs terminals

From `ssh-channel-multiplexer.ts`:
- **Errored response** → `handleResponse` (`:510`) rejects the pending promise with the message and `code`. Usable error, no hang.
- **Closed connection** → `dispose()` (`:374`) rejects *every* pending request and tears down the session.
- **Silent drop** → the 30s `REQUEST_TIMEOUT_MS` rejects and sends `rpc.cancel`. Bounded.

All three settle. Only one costs the user their panes.

## User-facing regressions

**None.** The only behavior change is that a case which previously killed the session now returns an error.

Corner case covered: when even the ~150-byte substitute cannot be admitted, that is also `'reject'` rather than fatal — no frame, no close, the host-side fence settles, and the client's timeout is the backstop. Killing every pane to report one failed listing is the outcome this path exists to avoid.

**No budget was changed.** `QUICK_OPEN_LISTING_MAX_RESPONSE_BYTES` and `MAX_FILE_RANGE_READ_BYTES` are untouched — the ~11k-file cap question #17954 raised is a product decision and stays open.

## Wire compatibility (Rule 3)

Changes **published content, not frame shape**: a listing that used to drop the connection now returns `{"error":{"code":-33008,"message":"Relay response exceeded the bounded transport capacity"}}`.

Old-client impact is benign — that decode path is version-independent, `ResponseOverCapacity` (-33008) has shipped since 2026-08-01, and nothing switches on the code. No opcode, no capability, no new field. `cross-version-terminal-wire.unit.test.ts` 10/10.

## Testing

Before:
```
 FAIL  src/relay/dispatcher-capacity-degradation.test.ts > answers an over-budget response with a capacity error instead of closing the connection
AssertionError: expected 1 to be +0
 FAIL  src/relay/dispatcher-capacity-degradation.test.ts > drops an unsendable response without closing when even the capacity error will not fit
AssertionError: expected 1 to be +0
 Test Files  1 failed (1)
      Tests  2 failed | 19 passed (21)
```
After: `Tests 21 passed (21)`.

**Negative control** — `still closes the client when a protocol-critical control frame overflows` — passed before *and* after, so `pty.replay` overflow still closes as designed.

`pnpm test src/relay src/main/ssh`: 3373 passed | 18 skipped. `tc:node` clean. `check:code-quality:changed`: 0 new findings across 25 files.

The new `makeUnsettledWriteClient` harness models a peer whose socket is behind — writes accepted but never settled, so control bytes stay retained while other lanes keep pumping. The existing `makeSaturatingClient` cannot express that shape because it blocks every lane.

Comment-only corrections in `file-range-read.ts` and `fs-handler-file-range.test.ts`, which both asserted "overflowing it closes the client" — now false. The two-deep-headroom rationale survives (it keeps the refusal rare) and its pinning test is unchanged.

## Caveat

This fixes the **failure mode**, not the **frequency**. Because the control lane is a shared budget, a near-1 MiB listing still fails under unrelated concurrent load. That is the product decision #17954 raised, deliberately left open.
