### PR TITLE
fix(ssh): compare lease and runtime pty ids in one form so pane recovery runs

### DIFF
--- a/src/main/persistence/loading-store/terminal-binding-recovery.ts
+++ b/src/main/persistence/loading-store/terminal-binding-recovery.ts
@@ -1,6 +1,6 @@
 import type { TerminalPaneLayoutNode } from '../../../shared/terminal-tab-types'
 import type { SshRemotePtyLease } from '../../../shared/ssh-types'
-import { toRelaySshPtyId } from '../../providers/ssh-pty-id'
+import { toComparableRelaySshPtyId, toRelaySshPtyId } from '../../providers/ssh-pty-id'
 import { isTerminalLeafId } from '../../../shared/stable-pane-id'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 
@@ -60,11 +60,7 @@ export class TerminalBindingRecoveryOperations {
   }
 
   getRelayPtyIdForSshLeaseComparison(targetId: string, ptyId: string): string {
-    try {
-      return toRelaySshPtyId(targetId, ptyId)
-    } catch {
-      return ptyId
-    }
+    return toComparableRelaySshPtyId(targetId, ptyId)
   }
 
   getRelayPtyIdForSshLeaseStorage(targetId: string, ptyId: string): string {

--- a/src/main/providers/ssh-pty-id.ts
+++ b/src/main/providers/ssh-pty-id.ts
@@ -1,2 +1,7 @@
-export { parseAppSshPtyId, toAppSshPtyId, toRelaySshPtyId } from '../../shared/ssh-pty-id'
+export {
+  parseAppSshPtyId,
+  toAppSshPtyId,
+  toComparableRelaySshPtyId,
+  toRelaySshPtyId
+} from '../../shared/ssh-pty-id'
 export type { ParsedSshPtyId } from '../../shared/ssh-pty-id'

--- a/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
+++ b/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../shared/runtime-types'
 import { headlessBrowserTabsUnchanged } from './mobile-session-browser-equality'
 import { appendBrowserTabOrder } from './mobile-session-browser-group-projection'
-import { parseAppSshPtyId } from '../../shared/ssh-pty-id'
+import { parseAppSshPtyId, toComparableRelaySshPtyId } from '../../shared/ssh-pty-id'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import type { RuntimeStore } from './runtime-store-contract'
 import { SSH_PANE_RECOVERY_GRACE_MS } from './orca-runtime-core'
@@ -100,18 +100,20 @@ export class OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs extends Or
   ): ReturnType<NonNullable<RuntimeStore['getSshRemotePtyLeases']>>[number] | null {
     const now = Date.now()
     return (
-      this.store
-        ?.getSshRemotePtyLeases?.()
-        .find(
-          (lease) =>
-            lease.state === 'expired' &&
-            lease.worktreeId === worktreeId &&
-            lease.tabId === tabId &&
-            (ptyId === undefined || lease.ptyId === ptyId) &&
-            (leafId === undefined || lease.leafId === undefined || lease.leafId === leafId) &&
-            lease.updatedAt <= now &&
-            now - lease.updatedAt <= SSH_PANE_RECOVERY_GRACE_MS
-        ) ?? null
+      this.store?.getSshRemotePtyLeases?.().find(
+        (lease) =>
+          lease.state === 'expired' &&
+          lease.worktreeId === worktreeId &&
+          lease.tabId === tabId &&
+          // Leases store RELAY form (`toStoredPtyId` -> `toRelaySshPtyId`); the runtime hands us
+          // the APP form (`ssh:<target>@@pty-3`). A raw `===` therefore never held for an SSH
+          // pane, which is what kept this reader's only ptyId-qualified caller inert.
+          (ptyId === undefined ||
+            lease.ptyId === toComparableRelaySshPtyId(lease.targetId, ptyId)) &&
+          (leafId === undefined || lease.leafId === undefined || lease.leafId === leafId) &&
+          lease.updatedAt <= now &&
+          now - lease.updatedAt <= SSH_PANE_RECOVERY_GRACE_MS
+      ) ?? null
     )
   }
 

--- a/src/main/runtime/orca-runtime-resolve-terminal-pane.ts
+++ b/src/main/runtime/orca-runtime-resolve-terminal-pane.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../shared/runtime-types'
 import type { RuntimeProviderSnapshotReadOptions } from './runtime-terminal-contracts'
 import { parsePaneKey } from '../../shared/stable-pane-id'
+import { sshRemotePtyLeaseAllowsReattach } from '../../shared/ssh-types'
 import {
   buildVisibleSnapshotReadFallback,
   labelTerminalReadSource,
@@ -77,10 +78,20 @@ export class OrcaRuntimeWithResolveTerminalPane extends OrcaRuntimeWithGetTermin
       }
       throw new Error('terminal_not_recoverable')
     }
-    if (
-      !this.getRecentExpiredSshLease(expectedWorktreeId, parsed.tabId, parsed.leafId, pty.ptyId)
-    ) {
+    const expiredLease = this.getRecentExpiredSshLease(
+      expectedWorktreeId,
+      parsed.tabId,
+      parsed.leafId,
+      pty.ptyId
+    )
+    if (!expiredLease) {
       // Why: an explicit close leaves a terminated lease; only relay expiry authorizes shell recreation.
+      throw new Error('terminal_not_recoverable')
+    }
+    // Why: a superseded or relay-id-recycled lease is `expired` for a reason that already names the
+    // successor — the pane's id no longer routes to the shell this lease describes, so recovering
+    // through it would adopt a stranger's process or re-race a pane that already moved on.
+    if (!sshRemotePtyLeaseAllowsReattach(expiredLease)) {
       throw new Error('terminal_not_recoverable')
     }
     // Why an `expired` lease is not on its own authority to spawn a replacement: every writer of

--- a/src/main/runtime/orca-runtime-test-fixtures.spec.ts
+++ b/src/main/runtime/orca-runtime-test-fixtures.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '../../shared/agent-prompt-injection'
 import { getDefaultWorkspaceSession } from '../../shared/constants'
 import { makePaneKey } from '../../shared/stable-pane-id'
+import { toComparableRelaySshPtyId } from '../../shared/ssh-pty-id'
 import {
   computeWorktreePathMock,
   ensurePathWithinWorkspaceMock
@@ -598,10 +599,13 @@ const store = {
   getProjects: () => []
 }
 
+// Callers pass the pane's APP-form pty id; the lease stores RELAY form, exactly as
+// upsertSshRemotePtyLease does through toStoredPtyId. Non-SSH ids pass through untouched.
 function createRuntimeWithSshLease(
   ptyId: string,
   tabId: string,
-  state: 'expired' | 'terminated' = 'expired'
+  state: 'expired' | 'terminated' = 'expired',
+  marks: { supersededBy?: string; relayIdRecycled?: true } = {}
 ): RuntimeService {
   const now = Date.now()
   return new OrcaRuntimeService({
@@ -609,13 +613,14 @@ function createRuntimeWithSshLease(
     getSshRemotePtyLeases: () => [
       {
         targetId: 'ssh-target',
-        ptyId,
+        ptyId: toComparableRelaySshPtyId('ssh-target', ptyId),
         worktreeId: TEST_WORKTREE_ID,
         tabId,
         leafId: HEADLESS_LEAF_ID,
         state,
         createdAt: now,
-        updatedAt: now
+        updatedAt: now,
+        ...marks
       }
     ]
   })

--- a/src/main/runtime/orca-runtime-tests/terminal-handles.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-handles.spec.ts
@@ -521,15 +521,18 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('does not recover a pane whose authoritative SSH lease was terminated', async () => {
+    // An SSH pane, so this exercises the same id-form path recovery now travels: `terminated` is
+    // also the operator-close state (ssh:terminateSessions), so it must never resurrect a pane.
     const tabId = 'tab-terminated'
-    const runtime = createRuntimeWithSshLease('pty-terminated', tabId, 'terminated')
+    const appPtyId = 'ssh:ssh-target@@pty-terminated'
+    const runtime = createRuntimeWithSshLease(appPtyId, tabId, 'terminated')
     const paneKey = makePaneKey(tabId, HEADLESS_LEAF_ID)
-    runtime.registerPty('pty-terminated', TEST_WORKTREE_ID, null, {
+    runtime.registerPty(appPtyId, TEST_WORKTREE_ID, 'ssh-target', {
       tabId,
       leafId: HEADLESS_LEAF_ID
     })
     const handle = runtime.resolveTerminalPane(paneKey, TEST_WORKTREE_ID).handle
-    runtime.onPtyExit('pty-terminated', 0)
+    runtime.onPtyExit(appPtyId, 0)
     const createTerminal = vi.spyOn(runtime, 'createTerminal')
 
     await expect(runtime.recoverTerminalPane(paneKey, TEST_WORKTREE_ID, handle)).rejects.toThrow(
@@ -538,16 +541,14 @@ describe('OrcaRuntimeService', () => {
     expect(createTerminal).not.toHaveBeenCalled()
   })
 
-  it('never matches an SSH pane against its own lease, because the two ids are in different forms', async () => {
-    // Characterization, not an endorsement. Leases are stored in RELAY form: upsertSshRemotePtyLease
-    // and markSshRemotePtyLease both run ids through toStoredPtyId -> toRelaySshPtyId ("pty-3").
-    // getRecentExpiredSshLease compares that against the runtime's APP-form pty id
-    // ("ssh:target@@pty-3") with a raw ===, so for a real SSH pane the lease is never found and
-    // recoverTerminalPane refuses before it can spawn anything. That makes the expired-lease branch
-    // unreachable for exactly the panes it names — see the report accompanying this change.
+  it('matches an SSH pane against its own lease across the relay/app id forms', async () => {
+    // Leases are stored in RELAY form: upsertSshRemotePtyLease and markSshRemotePtyLease both run
+    // ids through toStoredPtyId -> toRelaySshPtyId ("pty-3"). The runtime holds the APP form
+    // ("ssh:ssh-target@@pty-3"). getRecentExpiredSshLease compared the two raw, so this branch was
+    // unreachable for exactly the panes it names; it now normalizes before comparing.
     const tabId = 'tab-id-form'
     const appPtyId = 'ssh:ssh-target@@pty-3'
-    const runtime = createRuntimeWithSshLease('pty-3', tabId)
+    const runtime = createRuntimeWithSshLease(appPtyId, tabId)
     const paneKey = makePaneKey(tabId, HEADLESS_LEAF_ID)
     runtime.registerPty(appPtyId, TEST_WORKTREE_ID, 'ssh-target', {
       tabId,
@@ -564,6 +565,57 @@ describe('OrcaRuntimeService', () => {
       title: null,
       surface: 'background'
     })
+
+    await expect(
+      runtime.recoverTerminalPane(paneKey, TEST_WORKTREE_ID, handle)
+    ).resolves.toMatchObject({ handle: 'term-replacement' })
+    // createTerminal is the re-adopt entry point, not a bare spawn: it calls adoptStablePane first,
+    // so a surviving orphan is reattached and only a host-confirmed absence falls through to a
+    // fresh shell.
+    expect(createTerminal).toHaveBeenCalledWith(`id:${TEST_WORKTREE_ID}`, {
+      tabId,
+      leafId: HEADLESS_LEAF_ID,
+      focus: false
+    })
+  })
+
+  it('does not recover a pane whose expired lease was superseded by a newer one', async () => {
+    // #17966 split supersession out of plain `expired`: `supersededBy` names the lease that won
+    // this pane, so this id no longer routes to the shell the lease describes.
+    const tabId = 'tab-superseded'
+    const appPtyId = 'ssh:ssh-target@@pty-5'
+    const runtime = createRuntimeWithSshLease(appPtyId, tabId, 'expired', {
+      supersededBy: 'pty-6'
+    })
+    const paneKey = makePaneKey(tabId, HEADLESS_LEAF_ID)
+    runtime.registerPty(appPtyId, TEST_WORKTREE_ID, 'ssh-target', {
+      tabId,
+      leafId: HEADLESS_LEAF_ID
+    })
+    const handle = runtime.resolveTerminalPane(paneKey, TEST_WORKTREE_ID).handle
+    runtime.onPtyExit(appPtyId, 0)
+    const createTerminal = vi.spyOn(runtime, 'createTerminal')
+
+    await expect(runtime.recoverTerminalPane(paneKey, TEST_WORKTREE_ID, handle)).rejects.toThrow(
+      'terminal_not_recoverable'
+    )
+    expect(createTerminal).not.toHaveBeenCalled()
+  })
+
+  it('does not recover a pane whose expired lease had its relay id recycled', async () => {
+    const tabId = 'tab-recycled'
+    const appPtyId = 'ssh:ssh-target@@pty-7'
+    const runtime = createRuntimeWithSshLease(appPtyId, tabId, 'expired', {
+      relayIdRecycled: true
+    })
+    const paneKey = makePaneKey(tabId, HEADLESS_LEAF_ID)
+    runtime.registerPty(appPtyId, TEST_WORKTREE_ID, 'ssh-target', {
+      tabId,
+      leafId: HEADLESS_LEAF_ID
+    })
+    const handle = runtime.resolveTerminalPane(paneKey, TEST_WORKTREE_ID).handle
+    runtime.onPtyExit(appPtyId, 0)
+    const createTerminal = vi.spyOn(runtime, 'createTerminal')
 
     await expect(runtime.recoverTerminalPane(paneKey, TEST_WORKTREE_ID, handle)).rejects.toThrow(
       'terminal_not_recoverable'

--- a/src/main/ssh-expired-lease-pane-readoption.test.ts
+++ b/src/main/ssh-expired-lease-pane-readoption.test.ts
@@ -4,6 +4,9 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { makePaneKey } from '../shared/stable-pane-id'
 import { resolvePersistedStablePaneOwner } from './ipc/pty/pane/stable-owner'
+import { adoptStablePane } from './ipc/pty/pane/adopt-stable'
+import { sshProviders } from './ipc/pty/provider/registry'
+import type { IPtyProvider } from './providers/types'
 import { testState, createStore, makeTerminalTab } from './persistence-test-harness'
 import { TEST_LEAF_1 } from './persistence-session-fixtures'
 
@@ -11,6 +14,7 @@ vi.mock('electron', () => ({
   app: { getPath: () => testState.dir },
   safeStorage: { isEncryptionAvailable: () => false }
 }))
+vi.mock('node-pty', () => ({ spawn: vi.fn(), default: { spawn: vi.fn() } }))
 
 const TARGET = 'ssh-1'
 const HOST_ID = 'ssh:ssh-1' as const
@@ -84,5 +88,70 @@ describe('a pane whose SSH lease expired can still be re-adopted', () => {
     expect(
       resolvePersistedStablePaneOwner(store, makePaneKey(TAB, TEST_LEAF_1), WORKTREE, TARGET)
     ).toBeNull()
+  })
+})
+
+/**
+ * The other half of #17958: once `recoverTerminalPane` can find its lease it calls `createTerminal`,
+ * whose FIRST act is `adoptStablePane`. These pin that this is a re-adopt entry point — an
+ * attach-only reattach for a surviving orphan, and a fresh spawn only once the host itself answers
+ * that the PTY is absent.
+ */
+describe('recovery through createTerminal reattaches before it respawns', () => {
+  const PANE_KEY = makePaneKey(TAB, TEST_LEAF_1)
+  const ADOPT_ARGS = {
+    cols: 120,
+    rows: 40,
+    cwd: '/worktree',
+    connectionId: TARGET,
+    worktreeId: WORKTREE,
+    preAllocatedHandle: 'term-recovery',
+    tabId: TAB,
+    leafId: TEST_LEAF_1
+  }
+
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+    sshProviders.delete(TARGET)
+  })
+
+  it('reattaches the surviving orphan instead of spawning a second shell', async () => {
+    const store = storeWithBoundRemotePane()
+    store.markSshRemotePtyLease(TARGET, APP_PTY_ID, 'expired')
+    const spawn = vi.fn(async (options: { sessionId?: string; attachOnly?: boolean }) => {
+      void options
+      return { id: APP_PTY_ID, isReattach: true as const, pid: 4242 }
+    })
+    sshProviders.set(TARGET, { spawn } as unknown as IPtyProvider)
+
+    const adopted = await adoptStablePane(undefined, store, ADOPT_ARGS)
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(spawn.mock.calls[0]?.[0]).toMatchObject({
+      sessionId: APP_PTY_ID,
+      attachOnly: true,
+      command: undefined,
+      launchAgent: undefined
+    })
+    expect(adopted?.result).toMatchObject({ id: APP_PTY_ID, isReattach: true })
+    expect(adopted?.owner).toMatchObject({ ptyId: APP_PTY_ID, hasPersistedBinding: true })
+  })
+
+  it('falls through to a fresh spawn once the host answers that the PTY is absent', async () => {
+    const store = storeWithBoundRemotePane()
+    store.markSshRemotePtyLease(TARGET, APP_PTY_ID, 'expired')
+    const spawn = vi.fn(async () => {
+      throw new Error('PTY "remote-pty" not found')
+    })
+    sshProviders.set(TARGET, { spawn } as unknown as IPtyProvider)
+
+    // A null adoption is exactly what routes createTerminal to a fresh shell, so a pane whose
+    // shell genuinely died still gets a working terminal.
+    await expect(adoptStablePane(undefined, store, ADOPT_ARGS)).resolves.toBeNull()
+    expect(resolvePersistedStablePaneOwner(store, PANE_KEY, WORKTREE, TARGET)).toBeNull()
   })
 })

--- a/src/shared/ssh-pty-id.ts
+++ b/src/shared/ssh-pty-id.ts
@@ -65,3 +65,16 @@ export function toRelaySshPtyId(connectionId: string, ptyId: string): string {
   }
   return parsed.relayPtyId
 }
+
+/**
+ * Relay form for COMPARING an id against a stored SSH lease or binding, which are written in relay
+ * form. Unlike `toRelaySshPtyId` this never throws: an id naming a different target is simply not
+ * this target's pty, and a reader asking "is this the same pty?" wants `false`, not an exception.
+ */
+export function toComparableRelaySshPtyId(connectionId: string, ptyId: string): string {
+  try {
+    return toRelaySshPtyId(connectionId, ptyId)
+  } catch {
+    return ptyId
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​393 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​368 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​41 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 |

<!-- /orca-pr-loc -->

Closes #17958. Stacked on #17966 — review that first.

## ELI5

SSH pane recovery **has never run.** Leases are stored in relay form (`pty-3`); the reader compared them raw against the runtime's app form (`ssh:target@@pty-3`), so the equality never held and `recoverTerminalPane` always threw `terminal_not_recoverable`. `toComparablePtyId` existed right beside it, unused.

#17958 said this could not be fixed alone: switching the path on would have introduced duplicate spawns, since every `expired` writer was audited as non-attesting. **That ordering constraint is satisfied by the stack below this PR** — verified by reading the code on the branch, not just the log:

- #17957 — `recoverTerminalPane` refuses when liveness is `live` or `unverifiable`.
- #17965 — `expired` no longer withdraws the pane binding, so an orphan can reattach.
- #17966 — `supersededBy` / `relayIdRecycled` exist, so `expired` means exactly one thing.

## It reattaches; it does not respawn

Traced end to end and pinned with tests rather than read:

`recoverTerminalPane` → `createTerminal(..., {focus: false})` → no `rendererBacked`, so `shouldCreateInBackground` is true → **the first act is `adoptStablePane`, before any spawn** → `resolveStablePaneOwner` finds the persisted binding (retained because #17965 stopped `expired` withdrawing it) → `attachStablePaneOwner` calls `provider.spawn({ sessionId: owner.ptyId, attachOnly: true })`.

That is a reattach. A fresh shell happens only when the provider raises `isPtyAlreadyGoneError` — the relay's own "PTY not found" — which retires the binding and lets `createTerminal` spawn. **The attach attempt is itself the arbiter**, so #17958's warned-about duplicate-spawn cannot occur.

The common orphan case never reaches `createTerminal` at all: a failed relay reattach writes `expired` **and** a synthetic `pty:exit -1`, which grades `unverifiable`, and #17957's gate refuses. This path fires for an `expired` lease whose PTY has no `live`/`unverifiable` verdict — a host-confirmed exit, or a pane with no verdict recorded.

## A second inert test found along the way

**#17957's `still recreates a shell for an SSH pane whose host confirmed the exit` was also inert in production.** It only passed because the fixture `createRuntimeWithSshLease` stored the lease in **app** form, which `upsertSshRemotePtyLease` never writes. Making the fixture apply the same relay-form conversion production does is what exposed it — and it then failed, correctly.

## Changes

- `src/shared/ssh-pty-id.ts` — extracted the tolerant normalizer as `toComparableRelaySshPtyId` (the try/catch wrapper previously inline in `getRelayPtyIdForSshLeaseComparison`, which now delegates to it). One implementation, not two.
- `orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts:95` — `lease.ptyId === toComparableRelaySshPtyId(lease.targetId, ptyId)`.
- `orca-runtime-resolve-terminal-pane.ts` — `recoverTerminalPane` also refuses a lease that `sshRemotePtyLeaseAllowsReattach` disqualifies (superseded / recycled).

**Why the primitive and not a `RuntimeStore` member:** `getRelayPtyIdForSshLeaseComparison` is a method on a persistence class reachable only through instance wiring; neither `RuntimeStore` nor `Store` exposes it. Plumbing it as an optional member would have **re-created this exact bug** — every test mock store lacks it, so it would silently fall back to the raw compare.

The other two callers of `getRecentExpiredSshLease` (`:90`, `:122`) pass no `ptyId`, so the normalized branch short-circuits and their behavior is unchanged. The supersession check went in `recoverTerminalPane` rather than the shared getter deliberately, to keep their pane-coordinate retention exactly as-is.

## User-facing regressions

**None expected.** Negative controls, all passing:

- operator-closed `terminated` still refuses — and that test was **upgraded to a real SSH pane**, so it now exercises the live path instead of a non-SSH id that never reached the comparison;
- superseded and relay-id-recycled leases both refuse;
- a genuinely dead shell still gets a working terminal via the fresh-spawn fallthrough.

## Testing

Before (production change reverted, tests in place):
```
 ❯ src/main/runtime/orca-runtime.test.ts (1226 tests | 2 failed | 1 skipped)
     × matches an SSH pane against its own lease across the relay/app id forms
     × still recreates a shell for an SSH pane whose host confirmed the exit
AssertionError: promise rejected "Error: terminal_not_recoverable" instead of resolving
 ❯ OrcaRuntimeService.recoverTerminalPane orca-runtime-resolve-terminal-pane.ts:84:13
      Tests  2 failed | 1223 passed | 1 skipped (1226)
```
After:
```
 ✓ matches an SSH pane against its own lease across the relay/app id forms
 ✓ does not recover a pane whose expired lease was superseded by a newer one
 ✓ does not recover a pane whose expired lease had its relay id recycled
 ✓ does not recover a pane whose authoritative SSH lease was terminated
 ✓ does not recreate a shell for an expired lease whose PTY liveness is unverifiable
 ✓ still recreates a shell for an SSH pane whose host confirmed the exit
 ✓ reattaches the surviving orphan instead of spawning a second shell
 ✓ falls through to a fresh spawn once the host answers that the PTY is absent
```

Suites: `orca-runtime.test.ts` 1225 passed | 1 skipped; +5 lease/binding suites 1283 passed; +7 further suites 68 passed. `tc:node`, `tc:web` clean. `check:code-quality:changed` 0 new findings across 35 files.
