### PR TITLE
fix(linux): route AppImage CLI through Electron preflight

### DIFF
--- a/src/main/cli/appimage-cli-wrapper.ts
+++ b/src/main/cli/appimage-cli-wrapper.ts
@@ -1,20 +1,6 @@
-const APPIMAGE_CLI_SCRIPT = [
-  '(async()=>{',
-  'try{',
-  'const path=require("path");',
-  'const appDir=process.env.APPDIR;',
-  'if(!appDir){console.error("Orca AppImage runtime did not set APPDIR.");process.exit(1);}',
-  'const cli=path.join(appDir,"resources","app.asar.unpacked","out","cli","index.js");',
-  'await Promise.resolve(require(cli).main(process.argv.slice(1)));',
-  '}catch(error){',
-  'console.error(error&&error.stack?error.stack:String(error));process.exit(1);',
-  '}',
-  '})();'
-].join('')
-
 export function buildAppImageCliWrapper(appImagePath: string): string {
-  // Why: AppImage mounts resources under a fresh FUSE path per launch, so the
-  // installed command must call the stable outer AppImage and resolve APPDIR.
+  // Why: AppRun may prepend Chromium-only flags, so enter Electron mode before
+  // the main-process preflight redirects this explicit launch into Node mode.
   return `#!/usr/bin/env bash
 set -euo pipefail
 APPIMAGE=${quoteShell(appImagePath)}
@@ -27,8 +13,8 @@ export ORCA_NODE_OPTIONS="\${NODE_OPTIONS-}"
 export ORCA_NODE_REPL_EXTERNAL_MODULE="\${NODE_REPL_EXTERNAL_MODULE-}"
 unset NODE_OPTIONS
 unset NODE_REPL_EXTERNAL_MODULE
-# Why: AppImage mount paths change on each launch; $APPDIR is the runtime mount.
-ELECTRON_RUN_AS_NODE=1 exec "$APPIMAGE" -e ${quoteShell(APPIMAGE_CLI_SCRIPT)} -- "$@"
+export ORCA_APPIMAGE_CLI_LAUNCH=1
+exec "$APPIMAGE" "$@"
 `
 }
 

--- a/src/main/cli/packaged-cli-assets.test.ts
+++ b/src/main/cli/packaged-cli-assets.test.ts
@@ -246,36 +246,23 @@ printf 'arg=%s\\n' "$@"
     }
   )
 
-  itRunsUnixShell('runs the AppImage CLI wrapper through APPDIR at runtime', async () => {
+  itRunsUnixShell('starts the AppImage in desktop mode and marks CLI launches', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-appimage-cli-'))
     try {
-      const appDir = join(root, 'Orca.AppDir')
-      const cliDir = join(appDir, 'resources', 'app.asar.unpacked', 'out', 'cli')
-      const cliPath = join(cliDir, 'index.js')
       const appImagePath = join(root, "Orca's AppImage.AppImage")
       const commandPath = join(root, 'orca-ide')
-      await mkdir(cliDir, { recursive: true })
-      await writeFile(
-        cliPath,
-        `exports.main = (argv) => {
-  console.log(JSON.stringify({
-    argv,
-    appDir: process.env.APPDIR,
-    runAsNode: process.env.ELECTRON_RUN_AS_NODE,
-    nodeOptions: process.env.NODE_OPTIONS ?? null,
-    orcaNodeOptions: process.env.ORCA_NODE_OPTIONS ?? null,
-    nodeReplExternalModule: process.env.NODE_REPL_EXTERNAL_MODULE ?? null,
-    orcaNodeReplExternalModule: process.env.ORCA_NODE_REPL_EXTERNAL_MODULE ?? null
-  }))
-}
-`,
-        'utf8'
-      )
       await writeFile(
         appImagePath,
         `#!/usr/bin/env bash
-export APPDIR="$FAKE_APPDIR"
-exec node "$@"
+exec node -e 'console.log(JSON.stringify({
+  argv: process.argv.slice(1),
+  cliLaunch: process.env.ORCA_APPIMAGE_CLI_LAUNCH ?? null,
+  runAsNode: process.env.ELECTRON_RUN_AS_NODE ?? null,
+  nodeOptions: process.env.NODE_OPTIONS ?? null,
+  orcaNodeOptions: process.env.ORCA_NODE_OPTIONS ?? null,
+  nodeReplExternalModule: process.env.NODE_REPL_EXTERNAL_MODULE ?? null,
+  orcaNodeReplExternalModule: process.env.ORCA_NODE_REPL_EXTERNAL_MODULE ?? null
+}))' -- --no-sandbox "$@"
 `,
         { encoding: 'utf8', mode: 0o755 }
       )
@@ -287,24 +274,23 @@ exec node "$@"
       const result = await execFileAsync(commandPath, ['--help', 'two words'], {
         env: {
           ...process.env,
-          FAKE_APPDIR: appDir,
           NODE_OPTIONS: '--trace-warnings',
           NODE_REPL_EXTERNAL_MODULE: 'external-loader'
         }
       })
       const payload = JSON.parse(result.stdout) as {
         argv: string[]
-        appDir: string
-        runAsNode: string
+        cliLaunch: string | null
+        runAsNode: string | null
         nodeOptions: string | null
         orcaNodeOptions: string | null
         nodeReplExternalModule: string | null
         orcaNodeReplExternalModule: string | null
       }
 
-      expect(payload.argv).toEqual(['--help', 'two words'])
-      expect(payload.appDir).toBe(appDir)
-      expect(payload.runAsNode).toBe('1')
+      expect(payload.argv).toEqual(['--no-sandbox', '--help', 'two words'])
+      expect(payload.cliLaunch).toBe('1')
+      expect(payload.runAsNode).toBeNull()
       expect(payload.nodeOptions).toBeNull()
       expect(payload.orcaNodeOptions).toBe('--trace-warnings')
       expect(payload.nodeReplExternalModule).toBeNull()

--- a/src/main/startup/appimage-cli-redirect.test.ts
+++ b/src/main/startup/appimage-cli-redirect.test.ts
@@ -130,6 +130,40 @@ describe('AppImage CLI redirect', () => {
     ).toEqual(['serve', '--help'])
   })
 
+  it('trusts explicit wrapper launches without a command allow-list match', () => {
+    expect(
+      getAppImageCliArgs(
+        ['AppRun', '--no-sandbox', 'future-command', '--json'],
+        {
+          APPIMAGE: '/opt/orca',
+          ORCA_APPIMAGE_CLI_LAUNCH: '1'
+        },
+        {
+          platform: 'linux',
+          isPackaged: true,
+          commandNames
+        }
+      )
+    ).toEqual(['future-command', '--json'])
+  })
+
+  it('redirects an explicit wrapper launch with no CLI arguments', () => {
+    expect(
+      getAppImageCliArgs(
+        ['AppRun', '--no-sandbox'],
+        {
+          APPIMAGE: '/opt/orca',
+          ORCA_APPIMAGE_CLI_LAUNCH: '1'
+        },
+        {
+          platform: 'linux',
+          isPackaged: true,
+          commandNames
+        }
+      )
+    ).toEqual([])
+  })
+
   it('still redirects serve help even when Chromium switches are present', () => {
     expect(
       getAppImageCliArgs(
@@ -207,5 +241,37 @@ describe('AppImage CLI redirect', () => {
         env: expect.objectContaining({ ORCA_APPIMAGE_NO_SANDBOX: '1' })
       })
     )
+  })
+
+  it('preserves wrapper-sanitized Node options without leaking the launch marker', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-appimage-cli-redirect-'))
+    const cliEntryPath = join(root, 'app.asar.unpacked', 'out', 'cli', 'index.js')
+    await mkdir(join(root, 'app.asar.unpacked', 'out', 'cli'), { recursive: true })
+    await writeFile(cliEntryPath, '', 'utf8')
+    const spawn = vi.fn((..._args: unknown[]) => ({ status: 0 }))
+
+    const result = maybeRedirectAppImageCliLaunch({
+      argv: ['AppRun', '--no-sandbox', 'status'],
+      env: {
+        APPIMAGE: '/opt/orca/orca-linux.AppImage',
+        ORCA_APPIMAGE_CLI_LAUNCH: '1',
+        ORCA_NODE_OPTIONS: '--inspect',
+        ORCA_NODE_REPL_EXTERNAL_MODULE: '/tmp/repl.js'
+      },
+      platform: 'linux',
+      isPackaged: true,
+      resourcesPath: root,
+      execPath: '/opt/orca/orca-ide',
+      commandNames,
+      spawn: spawn as never
+    })
+
+    expect(result).toEqual({ redirected: true, status: 0 })
+    const spawnOptions = spawn.mock.calls[0]?.[2] as { env: NodeJS.ProcessEnv } | undefined
+    expect(spawnOptions?.env).toMatchObject({
+      ORCA_NODE_OPTIONS: '--inspect',
+      ORCA_NODE_REPL_EXTERNAL_MODULE: '/tmp/repl.js'
+    })
+    expect(spawnOptions?.env).not.toHaveProperty('ORCA_APPIMAGE_CLI_LAUNCH')
   })
 })

--- a/src/main/startup/appimage-cli-redirect.ts
+++ b/src/main/startup/appimage-cli-redirect.ts
@@ -148,10 +148,13 @@ export function getAppImageCliArgs(
   }
 
   const args = argv.slice(1)
+  const cliArgs = args.filter((arg) => !APPIMAGE_DESKTOP_FLAGS.has(arg))
+  if (env.ORCA_APPIMAGE_CLI_LAUNCH === '1') {
+    return cliArgs
+  }
   if (args.length === 0) {
     return null
   }
-  const cliArgs = args.filter((arg) => !APPIMAGE_DESKTOP_FLAGS.has(arg))
   if (cliArgs.some((arg) => HELP_FLAGS.has(arg))) {
     return cliArgs
   }
@@ -200,10 +203,12 @@ function flagName(arg: string): string {
 
 function buildElectronRunAsNodeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const childEnv = { ...env }
-  childEnv.ORCA_NODE_OPTIONS = env.NODE_OPTIONS ?? ''
-  childEnv.ORCA_NODE_REPL_EXTERNAL_MODULE = env.NODE_REPL_EXTERNAL_MODULE ?? ''
+  childEnv.ORCA_NODE_OPTIONS = env.ORCA_NODE_OPTIONS ?? env.NODE_OPTIONS ?? ''
+  childEnv.ORCA_NODE_REPL_EXTERNAL_MODULE =
+    env.ORCA_NODE_REPL_EXTERNAL_MODULE ?? env.NODE_REPL_EXTERNAL_MODULE ?? ''
   childEnv.ELECTRON_RUN_AS_NODE = '1'
   delete childEnv.NODE_OPTIONS
   delete childEnv.NODE_REPL_EXTERNAL_MODULE
+  delete childEnv.ORCA_APPIMAGE_CLI_LAUNCH
   return childEnv
 }


### PR DESCRIPTION
# fix(linux): route AppImage CLI through Electron preflight

## Summary

AppRun can prepend `--no-sandbox` when unprivileged user namespaces are unavailable. Starting the outer AppImage with `ELECTRON_RUN_AS_NODE=1` makes Node reject that Chromium-only flag before the Orca CLI bootstrap runs.

This change marks registered-wrapper launches, enters Electron mode first, and lets the existing main-process preflight strip desktop flags before spawning the unpacked CLI with the inner Electron binary. It also preserves sanitized Node options across the redirect and removes the launch marker from the CLI child environment.

On the affected machine, restoring the CLI path allowed OpenAI Codex to create an Orca browser tab on the local desktop without the user opening it manually. Codex then navigated to Google and read the page's interactive snapshot, including the search box, buttons, and links.

> [!IMPORTANT]
> This fix and this PR description were produced by an AI coding agent. The affected browser workflow was functionally verified on one Linux machine, and targeted automated tests were run. The change has not received independent human code review, a packaged-AppImage end-to-end run, multi-platform testing, a security audit, performance benchmarking, or the repository's complete build and test matrix.

## ELI5

The Orca AppImage is both a desktop app and a way to start its command-line tool.

On this Linux machine, AppRun notices that the normal Chromium sandbox cannot start and automatically adds `--no-sandbox`. That flag makes sense when Orca is running as an Electron desktop application, but the installed `orca-ide` wrapper was forcing the AppImage to behave like plain Node.js immediately. Plain Node.js does not understand the Chromium flag, so it stopped before Orca's CLI could run.

The fix lets the AppImage start in Electron mode long enough to consume the Electron/Chromium-only flag. Orca's existing startup preflight then recognizes that the launch came from the registered CLI wrapper and starts the real CLI with the inner Electron executable in Node mode.

In short:

```text
Before
AppImage wrapper
  -> ELECTRON_RUN_AS_NODE=1
  -> AppRun adds --no-sandbox
  -> Node rejects --no-sandbox
  -> Orca CLI never starts

After
AppImage wrapper marks an explicit CLI launch
  -> AppRun adds --no-sandbox
  -> Electron accepts the Chromium flag
  -> Orca preflight strips desktop-only flags
  -> inner Electron starts the CLI in Node mode
  -> Orca CLI works
```

## What Changed

- The registered AppImage wrapper no longer starts the outer AppImage with `ELECTRON_RUN_AS_NODE=1` and an inline `-e` bootstrap.
- The wrapper exports `ORCA_APPIMAGE_CLI_LAUNCH=1` and executes the stable outer AppImage with the original CLI arguments.
- The Linux packaged-AppImage preflight treats that marker as an explicit CLI launch, independently of the conservative direct-launch command allow-list.
- Explicit wrapper launches with no arguments are redirected to the CLI, preserving the existing CLI-help behavior.
- AppRun-injected desktop flags such as `--no-sandbox` are removed before CLI argument parsing.
- `ORCA_NODE_OPTIONS` and `ORCA_NODE_REPL_EXTERNAL_MODULE` values already sanitized by the wrapper survive the Electron-to-Node redirect.
- `ORCA_APPIMAGE_CLI_LAUNCH` is removed from the CLI child environment so it cannot leak into later child launches.
- Regression tests cover:
  - desktop-mode wrapper startup;
  - simulated AppRun `--no-sandbox` injection;
  - argument forwarding;
  - explicit wrapper commands that are absent from the direct-launch allow-list;
  - zero-argument CLI launches;
  - Node option preservation; and
  - launch-marker cleanup.

The change is limited to the Linux packaged-AppImage CLI wrapper and AppImage startup redirect. The macOS, Windows, development, and non-AppImage launchers are not changed.

## Why

The registered Orca CLI was unusable on the affected host. Every command failed before reaching Orca's argument parser:

```text
$ ~/.local/bin/orca-ide skills get orca-cli
/tmp/.mount_orca.XXXXXX/orca-ide: bad option: --no-sandbox
```

The failure chain was:

1. Ubuntu's AppArmor policy restricted unprivileged user namespaces.
2. AppRun's user-namespace probe failed.
3. AppRun prepended `--no-sandbox` for Chromium/Electron compatibility.
4. The registered wrapper had already selected `ELECTRON_RUN_AS_NODE=1`.
5. Node rejected the Chromium-only flag before evaluating the CLI bootstrap.

This prevented agents from using the public Orca CLI, including the commands that create and control Orca's embedded browser tabs. The Orca UI and daemon themselves were healthy and on matching versions; manually opening another browser tab did not repair the agent control path.

The proposed approach uses Orca's existing AppImage CLI redirect instead of changing global AppArmor policy, disabling AppArmor, or requiring users to extract and maintain a second copy of every AppImage release. The wrapper provides an explicit marker, so it does not depend on a hand-maintained CLI command allow-list and remains compatible with future top-level CLI commands.

## Linked Issue

Fixes #11609

Issue: [Registered CLI exits with `bad option: --no-sandbox` on userns-restricted Linux](https://github.com/stablyai/orca/issues/11609)

## Environment

The problem and functional recovery were observed with:

| Component | Value |
| --- | --- |
| Operating system | Ubuntu 24.04.4 LTS (Noble Numbat) |
| Kernel | Linux 7.0.0-30-generic, x86_64 |
| Desktop | GNOME on X11 |
| CPU | Intel Core i5-1135G7, 8 logical CPUs |
| Memory | 15 GiB |
| Orca | 1.4.194, x64 AppImage |
| Orca CLI registration | `~/.local/bin/orca-ide` |
| Codex | `codex-cli 0.152.0` |
| Node.js | 24.12.0 |
| pnpm | 12.0.0 |

Relevant user-namespace state:

```text
kernel.apparmor_restrict_unprivileged_userns = 1
kernel.unprivileged_userns_clone = 1
user.max_user_namespaces = 55441

$ unshare -Ur true
unshare: write failed /proc/self/uid_map: Operation not permitted
```

Orca's desktop process and daemon were both running version `1.4.194`, ruling out the previously observed mixed-version daemon state as the cause of this failure.

## Visual Proof

No screenshots or videos are attached yet. Nothing in Orca's visual layout changes, but this is an interaction/behavior fix, so a before/after terminal capture and an after-fix browser recording should be attached to the PR rather than committed to the repository.

### Before

```text
$ orca-ide skills get orca-cli
/tmp/.mount_orca.XXXXXX/orca-ide: bad option: --no-sandbox
```

The registered CLI exited immediately, so Codex could not create or control an Orca browser tab.

### After functional recovery

Codex executed the equivalent public CLI workflow without the user opening a tab:

```text
$ orca-ide status --json
app.running: true
runtime.state: ready
runtime.reachable: true

$ orca-ide tab create --url https://google.com --json
ok: true
browserPageId: <generated-page-id>

$ orca-ide snapshot --page <generated-page-id> --json
origin: https://www.google.com/
```

The returned snapshot contained interactive references for the Google search box, search buttons, Gmail, Images, privacy links, and other page elements. This demonstrated that Codex could both create the local Orca browser tab and drive its automation surface.

The real-machine recovery used a temporary local wrapper workaround to restore CLI operation. The source implementation in this branch encodes the permanent redirect-based fix and is covered by automated tests, but it has not yet been packaged into an AppImage and exercised end to end.

## Testing

- [x] I functionally tested the affected workflow locally using a temporary wrapper recovery: Codex created an Orca browser tab, navigated to Google, and read its interactive snapshot.
- [x] Automated tests added/updated.

Commands run against commit `b87ef2d2865756132fcc301862990eedb4d0e4c9`:

```text
pnpm test \
  src/main/cli/packaged-cli-assets.test.ts \
  src/main/cli/cli-installer.test.ts \
  src/main/cli/cli-installer-command-conflicts.test.ts \
  src/main/cli/linux-bare-orca-dispatcher.test.ts \
  src/main/startup/appimage-cli-redirect.test.ts \
  src/main/startup/serve-mode-argv-cli-redirect-order.test.ts
```

Result: 6 test files passed, 51 tests passed.

```text
pnpm run check:code-quality:changed
```

Result: zero new findings across the four changed files.

```text
node --max-old-space-size=8192 node_modules/typescript/bin/tsc \
  --noEmit \
  -p config/tsconfig.node.json
```

Result: passed. The normal `pnpm tc:node` invocation first exhausted Node's approximately 4 GiB default heap and exited with code 134; rerunning the same Node TypeScript project with an 8 GiB heap completed successfully.

```text
pnpm exec oxfmt --write <four changed files>
git diff --check
```

Result: passed.

Not run locally:

- complete `pnpm lint`;
- complete `pnpm typecheck` across every project;
- complete `pnpm test` suite;
- `pnpm build` or a packaged AppImage build;
- packaged-AppImage end-to-end validation of this exact branch;
- macOS, Windows, SSH, remote-runtime, mobile, or headless-server testing; and
- performance or memory benchmarks.

## AI Disclosure

This diagnosis, implementation, regression coverage, commit, and PR description were produced by OpenAI Codex.

The agent:

- diagnosed the AppArmor/AppRun/Electron-as-Node interaction;
- applied and functionally tested a temporary local workaround;
- cloned the upstream repository into a clean checkout;
- created branch `nachfq/fix-appimage-cli-no-sandbox`;
- wrote the tests and source changes; and
- created commit `b87ef2d2865756132fcc301862990eedb4d0e4c9`.

No independent human code review, security review, performance review, or multi-platform verification has been performed.

## Review

Please focus review on these points:

### Correctness

- Confirm that an AppImage wrapper launch reliably exports `APPIMAGE` or `APPDIR` to the inner Electron process on all supported AppImage runtime versions.
- Confirm that zero-argument wrapper invocation should continue to print CLI help rather than open the desktop app.
- Confirm that stripping every `--no-sandbox` occurrence before CLI parsing is consistent with current AppImage behavior.
- Confirm that the registered-wrapper marker is the preferred way to bypass the direct-AppImage command allow-list.

### Security

- This change does not alter AppArmor, kernel user-namespace settings, or system-wide sandbox configuration.
- It does not add `--no-sandbox`; it handles the flag AppRun already injects on restricted hosts.
- The marked outer Electron process redirects during preflight, before creating a window or loading browser content.
- The marker is removed before the Node-mode CLI child starts, preventing accidental inheritance by later desktop launches.
- The marker selects CLI dispatch but is not an authentication or privilege boundary; review should confirm that treating it as an explicit CLI launch cannot widen access beyond commands already available to the invoking user.

### Cross-platform support

- The generated wrapper is used only for packaged Linux AppImages.
- The redirect remains guarded by Linux, packaged-build, and AppImage environment checks.
- macOS, Windows, development launchers, and installed non-AppImage Linux launchers are unchanged.
- Those platforms were not executed as part of this validation.

### SSH and remote runtimes

- RPC, selectors, pairing, SSH transport, and remote wire contracts are unchanged.
- The marker is removed before the CLI child can launch or communicate with other runtimes.
- SSH and paired-runtime workflows were considered but not tested.

### Mobile

- No mobile source, protocol, emulator, or companion-app behavior changes.
- Mobile behavior was not tested.

### Backwards compatibility

- Existing direct AppImage launches without the marker retain their current conservative command detection.
- Existing registered wrappers will differ from the newly generated content and should be reported as stale until Orca re-registers or updates them.
- CLI arguments and sanitized Node option values remain forwarded.
- Mixed-version remote behavior is unchanged because no wire contract changes.

### Performance

- Registered AppImage CLI invocations now enter the Electron main-process preflight before spawning the Node-mode CLI child.
- The existing redirect uses a synchronous child launch, so the outer process can remain alive until the CLI command exits.
- This was not benchmarked. Reviewers should pay particular attention to long-running commands such as `serve`, startup latency, process count, and peak memory use.

## Agent skill upstream boundary

- [x] Not applicable. This change does not copy, translate, or modify any upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Scope is limited to four files: the AppImage CLI wrapper, the AppImage startup redirect, and their regression tests.
- No dependencies, wire contracts, UI components, mobile code, or public command syntax were added.
- No global security setting was changed as part of the fix.
- The original working tree remained untouched; development was performed in a separate clean clone.
- The branch is local and was not pushed by the agent.

Known remaining validation gaps:

- build and run a packaged AppImage from this branch on a userns-restricted Linux host;
- verify `orca-ide` with no arguments, `status`, `skills get`, browser commands, terminal commands, and a long-running `serve` command;
- record before/after visual evidence and attach it through the PR UI or `gh image` rather than committing it;
- benchmark startup time, peak RSS/PSS, and persistent process count; and
- run the repository's complete CI matrix.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why, including an ELI5 explanation.
- [ ] Before/after screenshots or videos attached. The required captures still need to be uploaded with the PR.
- [ ] Independently reviewed for correctness, security, and performance. Only agent self-review and functional validation have been performed.
- [x] Cross-platform, SSH/remote, mobile, and path impact considered and documented; they were not executed locally.
- [ ] `pnpm lint`, full `pnpm typecheck`, full `pnpm test`, and `pnpm build` pass. Targeted tests, changed-file quality checks, Node typecheck, formatting, and `git diff --check` passed; CI or additional local runs must cover the rest.
