### PR TITLE
fix(runtime): reclaim a fenced agent-session spawn from host inventory

### DIFF
--- a/src/main/runtime/orca-runtime-agent-session-operation.test.ts
+++ b/src/main/runtime/orca-runtime-agent-session-operation.test.ts
@@ -66,6 +66,50 @@ function createRuntime(provider?: {
   return runtime
 }
 
+// Why: an SSH-backed workspace whose spawn response was lost — the leak in #17929.
+function installRemoteReclaimHarness(
+  runtime: OrcaRuntimeService,
+  listProcesses: ReturnType<typeof vi.fn>
+): void {
+  const handleByPtyId = new Map<string, string>()
+  Object.assign(runtime, {
+    ptyController: { listProcesses },
+    resolveTerminalWorkspaceLaunchScope: vi.fn(async () => ({
+      id: 'worktree-1',
+      path: '/remote/worktree-1',
+      connectionId: 'ssh-1'
+    })),
+    executionOwnerSupportsAgentSessionOperation: vi.fn(async () => true),
+    markWorkspaceTrustedForAgent: vi.fn(async () => {}),
+    adoptControllerTerminalHandle: vi.fn((ptyId: string, handle: string) => {
+      handleByPtyId.set(ptyId, handle)
+    }),
+    recordPtyWorktree: vi.fn((ptyId: string, worktreeId: string, state: { title?: string }) => ({
+      ptyId,
+      worktreeId,
+      title: state.title ?? null
+    })),
+    issuePtyHandle: vi.fn((pty: { ptyId: string }) => handleByPtyId.get(pty.ptyId))
+  })
+}
+
+async function fenceRemoteAgentSessionSpawn(runtime: OrcaRuntimeService) {
+  const failure = Object.assign(new Error('execution_owner_unavailable'), {
+    agentSessionOperationOutcome: 'unknown' as const
+  })
+  const createTerminal = vi
+    .spyOn(runtime, 'createTerminal')
+    .mockImplementation(async (_worktree, opts) => {
+      opts?.onPtySpawnCommitted?.()
+      throw failure
+    })
+  const id = operationId()
+  await expect(runtime.createAgentSession(request(id), { clientId: 'device-a' })).rejects.toThrow(
+    failure.message
+  )
+  return { createTerminal, failure, id }
+}
+
 describe('agent-session create operation ledger', () => {
   it('selects legacy before trust, spawn, or ledger state for an old daemon', async () => {
     const provider = {
@@ -285,6 +329,81 @@ describe('agent-session create operation ledger', () => {
     await expect(runtime.createAgentSession(request(id), { clientId: 'device-a' })).rejects.toThrow(
       failure.message
     )
+    await expect(runtime.createAgentSession(request(id), { clientId: 'device-a' })).rejects.toThrow(
+      failure.message
+    )
+    expect(createTerminal).toHaveBeenCalledOnce()
+  })
+
+  it('reclaims a fenced remote spawn the host is still holding', async () => {
+    const runtime = createRuntime()
+    const listProcesses = vi.fn(async () => [] as never[])
+    installRemoteReclaimHarness(runtime, listProcesses)
+    const { createTerminal, id, failure } = await fenceRemoteAgentSessionSpawn(runtime)
+    const orphanHandle = createTerminal.mock.calls[0]?.[1]?.preAllocatedHandle as string
+    listProcesses.mockResolvedValue([
+      {
+        id: 'ssh-1:pty2:e:1',
+        cwd: '/remote/worktree-1',
+        title: 'codex',
+        worktreeId: 'worktree-1',
+        terminalHandle: orphanHandle
+      }
+    ] as never)
+
+    await expect(
+      runtime.createAgentSession(request(id), { clientId: 'device-a' })
+    ).resolves.toMatchObject({
+      disposition: 'replayed',
+      terminal: { handle: orphanHandle, ptyId: 'ssh-1:pty2:e:1', worktreeId: 'worktree-1' }
+    })
+    expect(listProcesses).toHaveBeenCalledWith('ssh-1')
+    expect(createTerminal).toHaveBeenCalledOnce()
+    expect(failure.message).toBe('execution_owner_unavailable')
+  })
+
+  it('replays the fenced failure when host inventory proves the spawn is gone', async () => {
+    const runtime = createRuntime()
+    const listProcesses = vi.fn(async () => [] as never[])
+    installRemoteReclaimHarness(runtime, listProcesses)
+    const { createTerminal, id, failure } = await fenceRemoteAgentSessionSpawn(runtime)
+
+    await expect(runtime.createAgentSession(request(id), { clientId: 'device-a' })).rejects.toThrow(
+      failure.message
+    )
+    expect(listProcesses).toHaveBeenCalledWith('ssh-1')
+    expect(createTerminal).toHaveBeenCalledOnce()
+  })
+
+  it('replays the fenced failure when the remote host cannot answer', async () => {
+    const runtime = createRuntime()
+    const listProcesses = vi.fn(async () => {
+      throw new Error('relay offline')
+    })
+    installRemoteReclaimHarness(runtime, listProcesses)
+    const { createTerminal, id, failure } = await fenceRemoteAgentSessionSpawn(runtime)
+
+    await expect(runtime.createAgentSession(request(id), { clientId: 'device-a' })).rejects.toThrow(
+      failure.message
+    )
+    expect(createTerminal).toHaveBeenCalledOnce()
+  })
+
+  it('refuses to adopt a same-handle PTY that belongs to another workspace', async () => {
+    const runtime = createRuntime()
+    const listProcesses = vi.fn(async () => [] as never[])
+    installRemoteReclaimHarness(runtime, listProcesses)
+    const { createTerminal, id, failure } = await fenceRemoteAgentSessionSpawn(runtime)
+    listProcesses.mockResolvedValue([
+      {
+        id: 'ssh-1:pty2:e:9',
+        cwd: '/remote/worktree-2',
+        title: 'codex',
+        worktreeId: 'worktree-2',
+        terminalHandle: createTerminal.mock.calls[0]?.[1]?.preAllocatedHandle
+      }
+    ] as never)
+
     await expect(runtime.createAgentSession(request(id), { clientId: 'device-a' })).rejects.toThrow(
       failure.message
     )

--- a/src/main/runtime/orca-runtime-create-agent-session.ts
+++ b/src/main/runtime/orca-runtime-create-agent-session.ts
@@ -24,6 +24,10 @@ import {
 } from '../../shared/tui-agent-launch-defaults'
 import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '../../shared/tui-agent-startup'
 import type { RuntimeTerminalCreate } from '../../shared/runtime-types'
+import type {
+  AgentSessionCreateOperation,
+  AgentSessionCreateReclaimIdentity
+} from './runtime-terminal-contracts'
 import {
   deterministicAgentSessionUuid,
   isAgentSessionOperationOutcomeUnknown
@@ -72,7 +76,16 @@ export class OrcaRuntimeWithCreateAgentSession extends OrcaRuntimeWithGetAgentSe
       if (existing.fingerprint !== requestFingerprint) {
         throw new Error('agent_session_operation_conflict')
       }
-      const replayed = await existing.promise
+      let replayed: RuntimeCreateAgentSessionResult
+      try {
+        replayed = await existing.promise
+      } catch (error) {
+        const reclaimed = await this.reclaimFencedAgentSessionSpawn(existing.reclaim.identity)
+        if (!reclaimed) {
+          throw error
+        }
+        return { terminal: reclaimed, disposition: 'replayed' }
+      }
       return { ...replayed, disposition: 'replayed' }
     }
     if (now - operationTimestamp > AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS) {
@@ -96,6 +109,7 @@ export class OrcaRuntimeWithCreateAgentSession extends OrcaRuntimeWithGetAgentSe
       throw new Error('agent_session_operation_capacity')
     }
     let retainReplayFence = false
+    const reclaim: AgentSessionCreateOperation['reclaim'] = {}
     const operation = (async (): Promise<RuntimeCreateAgentSessionResult> => {
       // Why: reserve the client operation before any async preflight so concurrent retries cannot
       // both observe an empty ledger and reach the execution owner independently.
@@ -187,6 +201,13 @@ export class OrcaRuntimeWithCreateAgentSession extends OrcaRuntimeWithGetAgentSe
       const operationLeafId =
         request.placement?.leafId ?? deterministicAgentSessionUuid(`${executionOperationId}:leaf`)
       const operationHandle = `term_${deterministicAgentSessionUuid(`${executionOperationId}:handle`)}`
+      // Why: recorded before dispatch — this handle is exported into the PTY as
+      // ORCA_TERMINAL_HANDLE, so it is the only name a lost spawn can be re-found by.
+      reclaim.identity = {
+        worktreeId: workspace.id,
+        connectionId: workspace.connectionId ?? null,
+        terminalHandle: operationHandle
+      }
       try {
         terminal = await this.createTerminal(`id:${workspace.id}`, {
           command: startup.launchCommand,
@@ -216,7 +237,8 @@ export class OrcaRuntimeWithCreateAgentSession extends OrcaRuntimeWithGetAgentSe
     })()
     this.agentSessionCreateOperations.set(operationKey, {
       fingerprint: requestFingerprint,
-      promise: operation
+      promise: operation,
+      reclaim
     })
     const expireOperation = (): void => {
       const expiresAt = Math.max(now, operationTimestamp) + AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS
@@ -243,6 +265,27 @@ export class OrcaRuntimeWithCreateAgentSession extends OrcaRuntimeWithGetAgentSe
         this.agentSessionCreateOperations.delete(operationKey)
       }
       throw error
+    }
+  }
+
+  // Why: the host may still hold the PTY this operation launched. Adoption-only —
+  // this never spawns and never kills, so an unreachable or silent host just replays
+  // the original failure instead of authorising anything.
+  private async reclaimFencedAgentSessionSpawn(
+    identity: AgentSessionCreateReclaimIdentity | undefined
+  ): Promise<RuntimeTerminalCreate | null> {
+    if (!identity) {
+      return null
+    }
+    try {
+      return await this.reconcileRemoteTerminalCreate(
+        identity.worktreeId,
+        identity.terminalHandle,
+        identity.connectionId
+      )
+    } catch {
+      // Unverifiable or ambiguous inventory is never evidence the PTY exited.
+      return null
     }
   }
 }

--- a/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
+++ b/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
@@ -52,13 +52,16 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
 
   protected async reconcileRemoteTerminalCreate(
     worktreeId: string,
-    terminalHandle: string
+    terminalHandle: string,
+    // Why: an aggregate listing drops a non-answering SSH host silently, which would read as
+    // absence. Scoping to the owning host makes an unreachable relay throw instead.
+    connectionId?: string | null
   ): Promise<RuntimeTerminalCreate | null> {
     if (!this.ptyController?.listProcesses) {
       throw new Error('runtime_unavailable')
     }
     const listed = await withTimeoutResult(
-      this.ptyController.listProcesses(),
+      this.ptyController.listProcesses(connectionId),
       PTY_CONTROLLER_LIST_TIMEOUT_MS
     )
     if (!listed.ok) {

--- a/src/main/runtime/runtime-terminal-contracts.ts
+++ b/src/main/runtime/runtime-terminal-contracts.ts
@@ -54,9 +54,19 @@ export type TerminalCreateOptions = {
   deferMobileSessionPublish?: boolean
 }
 
+/** Identity a fenced spawn can be re-found by in the execution host's own inventory. */
+export type AgentSessionCreateReclaimIdentity = {
+  worktreeId: string
+  connectionId: string | null
+  terminalHandle: string
+}
+
 export type AgentSessionCreateOperation = {
   fingerprint: string
   promise: Promise<RuntimeCreateAgentSessionResult>
+  // Why: a lost pty.spawn response leaves the host holding a live PTY the client
+  // never named; this is the name it was launched under, so a replay can adopt it.
+  reclaim: { identity?: AgentSessionCreateReclaimIdentity }
 }
 
 export type PtyForegroundAgentRefresh = {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 |

<!-- /orca-pr-loc -->

Addresses #17929. **No general RPC replay layer was needed** — the mechanism already existed and was simply unreachable from the agent-session path.

## ELI5

When an agent-session spawn is dispatched and the link dies before the response arrives, the relay has already created the PTY. The client fences the failure and memoizes the rejection for 24h, so it never learns the PTY exists. Nothing reclaims it: the reattach set is built only from spawn responses main actually received, and the relay never exits because one live PTY keeps it non-idle. The orphan also holds one of `MAX_RELAY_PTY_SESSIONS = 50`.

This makes the fenced operation, on replay, ask the **execution host** whether it is already holding that work — and adopt it if so.

## Two corrections to the issue text

**1. "The client has no name for what it lost" is false.** `createAgentSession` mints a deterministic `operationHandle` from the operation id, passes it as `preAllocatedHandle`, which is exported into the PTY as `ORCA_TERMINAL_HANDLE`, stored by the relay, **published back in `pty.listProcesses`** (`pty-handler.ts:2431`), and preserved through `mapSshPtyProcessList`. The evidence needed to re-find the orphan was already on the wire — nothing on the SSH path consumed it. Only the *host-minted pty id* is unknown, and that is not the identity a reclaim needs.

**2. "#17831's sweep does not cover this" is moot** — #17831 is not merged, so `ssh-orphan-relay-pty-sweep.ts` does not exist on main. There is no sweep at all.

## Why no replay layer

The issue's own "cheap intermediate" — re-issue `pty.spawn` and let the relay ledger dedupe — is the worse option: relay-specific, dependent on the relay's 24h ledger surviving, and it re-enters a spawn path.

**`reconcileRemoteTerminalCreate`** already does the right thing and is transport-agnostic: it matches host inventory by `terminalHandle`, refuses ambiguity (>1 match → conflict), refuses to read unknown inventory as absence, and cross-checks the worktree. It runs through `ptyController.listProcesses`, so it works for SSH relay, orca remote, daemon and local alike — **it survives the SSH → orca-remote consolidation by construction**. It is the same shape the daemon already uses (`ptySessionIdForAgentCreateOperation`): a client-derived deterministic name supplied at spawn, so the client can re-find its work without a replay log. It was reachable only from the remote-client `terminal.create` retry, never from the agent-session path.

For the record, a general replay layer would have needed per-connection monotonic sequencing, a persisted unacked queue, exactly-once *effect* for `pty.spawn` (needing a dedup key — the deterministic operation id already is one), retention outliving a relay PTY that can live for days, and a defined terminal state when the peer never returns (which is the `unverifiable` verdict the boundary doc already mandates). Each is either already solved by the existing idempotency ledgers or is host-inventory reconciliation wearing a different hat.

## The fix

Four files, +179/−4.

- `runtime-terminal-contracts.ts` — `AgentSessionCreateOperation` gains `reclaim: { identity? }` (worktreeId, connectionId, terminalHandle).
- `orca-runtime-create-agent-session.ts` — records that identity immediately before dispatch; on replay of a **rejected** operation, delegates to `reconcileRemoteTerminalCreate` and returns `{ terminal, disposition: 'replayed' }` on adoption. Any failure or `null` **rethrows the original error unchanged**.
- `orca-runtime-terminal-create-deduplication.ts` — `reconcileRemoteTerminalCreate` takes an optional `connectionId` and scopes the listing to the owning host. **This matters:** the aggregate listing silently drops a non-answering SSH provider (`operations.ts:244-250`), which would read as proof of absence. Scoped, an unreachable relay throws → `runtime_unavailable` → original error replayed.

**Adoption only — it never spawns and never kills.** No client-side inference authorises anything; the execution host's own inventory is the sole authority. The handle is `sha256`-derived from the operation id, so only a PTY launched by that exact operation can carry it, and the worktree is cross-checked on top.

## User-facing regressions

**None expected.** The existing `dedupeTerminalCreate` caller is unchanged (still passes no `connectionId`), so no shipped behavior moves.

**Old-client / wire impact: none.** No RPC params, opcodes or published content change. `terminalHandle` in `pty.listProcesses` is an existing field the relay has always emitted; this only adds a consumer. Against a relay too old to emit it, the match count is zero and the original failure is replayed — today's behavior.

## Testing

Before:
```
     × reclaims a fenced remote spawn the host is still holding
     × replays the fenced failure when host inventory proves the spawn is gone
AssertionError: promise rejected "Error: execution_owner_unavailable { agentSessionOperationOutcome: '…' }" instead of resolving
 Test Files  1 failed (1)
      Tests  2 failed | 14 passed (16)
```
After: `Test Files 2 passed (2) / Tests 25 passed (25)`.

Negative controls: authoritative inventory lacking the handle replays the failure and does **not** respawn; a throwing inventory replays the failure; a same-handle PTY in another worktree is refused. A genuinely dead peer creates no retry work — the reclaim is lazy, fires only on explicit caller replay, and is bounded by the existing 24h expiry. Pre-existing pins still pass unchanged.

`pnpm test src/main/runtime/` → 6045 tests passed. `pnpm tc` clean. `check:code-quality:changed` 0 new findings.

## What this does not close — the exact seam

**The reclaim is armed but its trigger is narrow.** `createAgentSessionCreateOperation` replays only when the failure is *not* a `RuntimeRpcCallError` — i.e. only on client↔host transport loss. When the **host↔relay** link is what wedged, the host answers with an RPC error, the client does not replay, and a user retrying by hand mints a new `clientOperationId` → new handle → **a second agent**. So this converts the leak into a reclaim wherever a replay happens, but does not guarantee one happens.

The seam for closing it is `refreshPtyWorktreeRecordsWithControllerInventory` (`:187-192`): it already runs on reconnect, already lists every host, and already calls `adoptControllerTerminalHandle`. It re-registers the orphan's handle so the CLI can address it, but never tells the fenced operation and never restores a UI surface. Hooking the ledger into that pass is the natural next step — deliberately not done here, because it turns a lazy caller-driven lookup into standing background work bounded only by the 24h TTL, which is the "retries forever" shape this sweep has been avoiding. That trade-off deserves its own decision.

**Adjacent, unfixed, same class:** `dedupeTerminalCreate` still calls `reconcileRemoteTerminalCreate` without a `connectionId`, so for an SSH workspace an unreachable relay is dropped from the aggregate listing and reads as absence → the retry spawns a duplicate shell. The one-argument fix is now available; left out as out-of-scope with no failing test to anchor it.
