### PR TITLE
Fix Agent Dashboard terminal focus ownership

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
@@ -3,6 +3,7 @@
 import '@testing-library/jest-dom/vitest'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
 import type {
   DashboardCard,
   DashboardCardTerminalInput
@@ -16,10 +17,12 @@ vi.mock('./AgentTerminalPreview', () => ({
   AgentTerminalPreview: ({
     ptyId,
     terminalInput,
+    onClose,
     className
   }: {
     ptyId: string
     terminalInput?: DashboardCardTerminalInput | null
+    onClose?: () => void
     className?: string
   }) => (
     <div
@@ -29,6 +32,7 @@ vi.mock('./AgentTerminalPreview', () => ({
       className={className}
     >
       <textarea data-testid="preview-terminal-input" className="xterm" />
+      <button type="button" data-testid="preview-close-shortcut" onClick={onClose} />
     </div>
   )
 }))
@@ -166,9 +170,37 @@ describe('AgentTerminalDialog', () => {
     render(<AgentTerminalPanel card={card()} onOpenChange={() => {}} onReveal={() => {}} />)
 
     expect(screen.getByRole('dialog', { name: 'wt' })).toHaveAttribute('data-state', 'open')
+
     expect(screen.getByTestId('preview')).toHaveClass('min-h-0', 'flex-1')
     expect(document.querySelector('[data-slot="dialog-overlay"]')).not.toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'wt' })).toBeInTheDocument()
+  })
+
+  it('restores the invoking map agent after the focused terminal closes by shortcut', () => {
+    function Host(): React.JSX.Element {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Selected agent
+          </button>
+          {open ? (
+            <AgentTerminalPanel card={card()} onOpenChange={setOpen} onReveal={() => {}} />
+          ) : null}
+        </>
+      )
+    }
+    render(<Host />)
+    const agent = screen.getByRole('button', { name: 'Selected agent' })
+    agent.focus()
+    fireEvent.click(agent)
+    const terminal = screen.getByTestId('preview-terminal-input')
+    terminal.focus()
+
+    fireEvent.click(screen.getByTestId('preview-close-shortcut'))
+
+    expect(screen.queryByRole('dialog', { name: 'wt' })).not.toBeInTheDocument()
+    expect(agent).toHaveFocus()
   })
 
   it('lets a nested Radix layer consume Escape before closing the panel', () => {

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
@@ -2,7 +2,7 @@
 
 import '@testing-library/jest-dom/vitest'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type {
   DashboardCard,
   DashboardCardTerminalInput
@@ -27,7 +27,9 @@ vi.mock('./AgentTerminalPreview', () => ({
       data-pty-id={ptyId}
       data-terminal-input={terminalInput === null ? 'null' : JSON.stringify(terminalInput)}
       className={className}
-    />
+    >
+      <textarea data-testid="preview-terminal-input" className="xterm" />
+    </div>
   )
 }))
 
@@ -136,6 +138,28 @@ describe('AgentTerminalDialog', () => {
       tabId: 'tab1',
       leafId: 'leaf1'
     })
+  })
+
+  it('opens in inspection mode and lets bare Escape close the dialog', async () => {
+    const onOpenChange = vi.fn()
+    render(<AgentTerminalDialog card={card()} onOpenChange={onOpenChange} onReveal={() => {}} />)
+
+    const title = screen.getByRole('heading', { name: 'wt' })
+    await waitFor(() => expect(title).toHaveFocus())
+
+    fireEvent.keyDown(title, { key: 'Escape' })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('leaves Escape to the terminal after the user focuses it', () => {
+    const onOpenChange = vi.fn()
+    render(<AgentTerminalDialog card={card()} onOpenChange={onOpenChange} onReveal={() => {}} />)
+
+    const terminalInput = screen.getByTestId('preview-terminal-input')
+    terminalInput.focus()
+    fireEvent.keyDown(terminalInput, { key: 'Escape' })
+
+    expect(onOpenChange).not.toHaveBeenCalled()
   })
 
   it('reuses the terminal surface as a non-modal adjacent panel', () => {

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId } from 'react'
+import { useEffect, useId, useRef } from 'react'
 import { SquareArrowOutUpRight, XIcon } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
@@ -76,6 +76,7 @@ function AgentTerminalFrame({
         <AgentTerminalPreview
           ptyId={card.ptyId}
           terminalInput={card.terminalInput ?? null}
+          onClose={() => onOpenChange(false)}
           className={previewClassName}
         />
       ) : (
@@ -108,6 +109,7 @@ export function AgentTerminalDialog({
   onOpenChange,
   onReveal
 }: AgentTerminalDialogProps): React.JSX.Element {
+  const titleRef = useRef<HTMLHeadingElement>(null)
   return (
     <Dialog open={card !== null} onOpenChange={onOpenChange}>
       {card ? (
@@ -120,26 +122,26 @@ export function AgentTerminalDialog({
           // dialogs), which misaligns against this p-0 compact header; render
           // it inside the header row instead so it centers with the title.
           showCloseButton={false}
-          // Why: Esc must reach the agent (interrupt) when typing in the
-          // terminal, not dismiss the dialog; xterm has already consumed the
-          // keystroke by the time Radix sees it. Click-outside still closes.
-          onEscapeKeyDown={(e) => {
-            if (e.target instanceof HTMLElement && e.target.closest('.xterm')) {
-              e.preventDefault()
-            }
+          // Why: inspection is the safe initial state. Only an explicit click
+          // or Tab into xterm grants the live PTY keyboard ownership.
+          onOpenAutoFocus={(event) => {
+            event.preventDefault()
+            titleRef.current?.focus()
           }}
-          // Why: the preview focuses its terminal once the snapshot paints;
-          // Radix's default focus target would tug focus away first.
-          onOpenAutoFocus={(e) => {
-            if (card.ptyId) {
-              e.preventDefault()
+          onEscapeKeyDown={(event) => {
+            if (event.target instanceof HTMLElement && event.target.closest('.xterm')) {
+              event.preventDefault()
             }
           }}
         >
           <AgentTerminalFrame
             card={card}
             title={
-              <DialogTitle className="text-[12px] leading-normal font-semibold">
+              <DialogTitle
+                ref={titleRef}
+                tabIndex={-1}
+                className="text-[12px] leading-normal font-semibold outline-none"
+              >
                 {card.worktreeName}
               </DialogTitle>
             }

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef } from 'react'
+import { useEffect, useId, useLayoutEffect, useRef } from 'react'
 import { SquareArrowOutUpRight, XIcon } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
@@ -164,6 +164,12 @@ export function AgentTerminalPanel({
   className?: string
 }): React.JSX.Element {
   const titleId = useId()
+
+  useLayoutEffect(() => {
+    const returnFocus =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null
+    return () => returnFocus?.focus()
+  }, [])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
@@ -576,6 +576,28 @@ describe('AgentTerminalPreview', () => {
     expect(terminal.input).not.toHaveBeenCalled()
     expect(input).not.toHaveBeenCalled()
   })
+  it('keeps unrelated pane shortcuts from closing the preview', async () => {
+    platformState.value = 'darwin'
+    const onClose = vi.fn()
+    render(<AgentTerminalPreview ptyId="pty-1" onClose={onClose} />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    await waitFor(() => expect(terminal.customKeyHandler).not.toBeNull())
+
+    const keydown = new KeyboardEvent('keydown', {
+      key: 'k',
+      code: 'KeyK',
+      metaKey: true,
+      cancelable: true
+    })
+    const handled = terminal.customKeyHandler!(keydown)
+
+    expect(handled).toBe(false)
+    expect(keydown.defaultPrevented).toBe(true)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(terminal.input).not.toHaveBeenCalled()
+    expect(input).not.toHaveBeenCalled()
+  })
 
   it('keeps the existing terminal visible without taking focus during resync', async () => {
     let resolveRefresh!: (value: {

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
@@ -10,6 +10,7 @@ const terminalHarness = vi.hoisted(() => ({
     writeCallbacks: (() => void)[]
     onDataListener: ((data: string) => void) | null
     dispose: ReturnType<typeof vi.fn>
+    focus: ReturnType<typeof vi.fn>
     resize: ReturnType<typeof vi.fn>
     reset: ReturnType<typeof vi.fn>
     paste: ReturnType<typeof vi.fn>
@@ -553,7 +554,7 @@ describe('AgentTerminalPreview', () => {
     expect(terminal.input).not.toHaveBeenCalled()
   })
 
-  it('keeps the existing terminal visible while a resync snapshot is captured', async () => {
+  it('keeps the existing terminal visible without taking focus during resync', async () => {
     let resolveRefresh!: (value: {
       snapshot: { data: string; cols: number; rows: number; seq: number }
       replay: string[]
@@ -572,6 +573,12 @@ describe('AgentTerminalPreview', () => {
     const view = render(<AgentTerminalPreview ptyId="pty-1" />)
     await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
     const terminal = terminalHarness.instances[0]!
+    expect(terminal.focus).not.toHaveBeenCalled()
+    expect(view.container.firstElementChild).toHaveClass(
+      'focus-within:ring-1',
+      'focus-within:ring-inset',
+      'focus-within:ring-ring'
+    )
 
     act(() => emitData?.({ type: 'resync', ptyId: 'pty-1' }))
     await waitFor(() => expect(connect).toHaveBeenCalledTimes(2))
@@ -591,6 +598,7 @@ describe('AgentTerminalPreview', () => {
     expect(terminalHarness.instances).toHaveLength(1)
     expect(terminal.dispose).not.toHaveBeenCalled()
     expect(view.queryByText(/No live terminal/)).not.toBeInTheDocument()
+    expect(terminal.focus).not.toHaveBeenCalled()
   })
 
   it('disposes a stale terminal when resync confirms the pty is gone', async () => {

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
@@ -2,7 +2,7 @@
 
 import '@testing-library/jest-dom/vitest'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 
 const terminalHarness = vi.hoisted(() => ({
   instances: [] as {
@@ -10,7 +10,7 @@ const terminalHarness = vi.hoisted(() => ({
     writeCallbacks: (() => void)[]
     onDataListener: ((data: string) => void) | null
     dispose: ReturnType<typeof vi.fn>
-    focus: ReturnType<typeof vi.fn>
+    focus: Mock
     resize: ReturnType<typeof vi.fn>
     reset: ReturnType<typeof vi.fn>
     paste: ReturnType<typeof vi.fn>
@@ -552,6 +552,29 @@ describe('AgentTerminalPreview', () => {
 
     expect(handled).toBe(true)
     expect(terminal.input).not.toHaveBeenCalled()
+  })
+
+  it('closes the preview on the configured pane-close shortcut', async () => {
+    platformState.value = 'darwin'
+    const onClose = vi.fn()
+    render(<AgentTerminalPreview ptyId="pty-1" onClose={onClose} />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    await waitFor(() => expect(terminal.customKeyHandler).not.toBeNull())
+
+    const keydown = new KeyboardEvent('keydown', {
+      key: 'w',
+      code: 'KeyW',
+      metaKey: true,
+      cancelable: true
+    })
+    const handled = terminal.customKeyHandler!(keydown)
+
+    expect(handled).toBe(false)
+    expect(keydown.defaultPrevented).toBe(true)
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(terminal.input).not.toHaveBeenCalled()
+    expect(input).not.toHaveBeenCalled()
   })
 
   it('keeps the existing terminal visible without taking focus during resync', async () => {

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -53,11 +53,13 @@ function clamp(value: number, min: number, max: number): number {
 export function AgentTerminalPreview({
   ptyId,
   terminalInput = null,
+  onClose,
   className
 }: {
   ptyId: string
   /** Host-input facts relayed with the card; null routes bytes by client OS. */
   terminalInput?: DashboardCardTerminalInput | null
+  onClose?: () => void
   className?: string
 }): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -70,6 +72,7 @@ export function AgentTerminalPreview({
   const settingsRef = useRef(settings)
   const macOptionAsAltRef = useRef(macOptionAsAlt)
   const terminalInputRef = useRef(terminalInput)
+  const onCloseRef = useRef(onClose)
   const { terminalTheme, terminalMode } = useMemo(() => {
     if (!settings) {
       return { terminalTheme: null, terminalMode: 'dark' as const }
@@ -93,7 +96,8 @@ export function AgentTerminalPreview({
     settingsRef.current = settings
     macOptionAsAltRef.current = macOptionAsAlt
     terminalInputRef.current = terminalInput
-  }, [settings, macOptionAsAlt, terminalInput])
+    onCloseRef.current = onClose
+  }, [settings, macOptionAsAlt, terminalInput, onClose])
 
   useEffect(() => {
     setPtyGone(false)
@@ -202,6 +206,7 @@ export function AgentTerminalPreview({
         claimImeKeyEvent: (event) => imeBridge?.claimKeyEvent(event) ?? false,
         pasteClipboardText: (activeElement, source) =>
           void pasteClipboardText(activeElement, source),
+        onClose: () => onCloseRef.current?.(),
         // Why: route through terminal.input so the chord's bytes carry core's user-input signal, like typed keys.
         sendInput: (data) => terminal?.input(data),
         getShortcutContext: () => ({
@@ -312,7 +317,6 @@ export function AgentTerminalPreview({
       }
       scheduleFit()
       gridClaim.schedule()
-      terminal.focus()
     }
 
     const setup = async (replaceExisting = false): Promise<void> => {
@@ -418,12 +422,11 @@ export function AgentTerminalPreview({
 
   return (
     // Why: a size FIXED by the viewport (not shrink-to-fit) + overflow-hidden
-    // keeps the dialog stable no matter how wide/tall the pane's serialized
     // buffer is. The terminal keeps the pane's true dimensions and is scaled/
     // clipped to fit; createPreviewBoxFit anchors the end that shows the cursor.
     <div
       className={cn(
-        'relative h-[calc(100vh-140px)] w-full overflow-hidden bg-background p-1.5',
+        'relative h-[calc(100vh-140px)] w-full overflow-hidden bg-background p-1.5 outline-none focus-within:ring-1 focus-within:ring-inset focus-within:ring-ring',
         className
       )}
       style={terminalTheme?.background ? { backgroundColor: terminalTheme.background } : undefined}

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
@@ -28,6 +28,7 @@ export function installPreviewTerminalKeyHandler(args: {
   terminal: Terminal
   claimImeKeyEvent: (event: KeyboardEvent) => boolean
   pasteClipboardText: (activeElement: Element | null, source: 'keyboard') => void
+  onClose?: () => void
   sendInput: (data: string) => void
   /** Everything but optionKeyLocations, which this installer tracks itself. */
   getShortcutContext: () => Omit<PreviewShortcutContext, 'optionKeyLocations'>
@@ -199,8 +200,10 @@ export function installPreviewTerminalKeyHandler(args: {
       // `default` so a newly added action has to be classified here, not
       // silently swallowed.
       case 'clearActivePane':
-      case 'clearPaneTitle':
       case 'closeActivePane':
+        args.onClose?.()
+        return consumeEvent(event)
+      case 'clearPaneTitle':
       case 'copySelection':
       case 'equalizePaneSizes':
       case 'focusPane':

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
@@ -199,10 +199,10 @@ export function installPreviewTerminalKeyHandler(args: {
       // e.g. Ctrl+Shift+D as a bare Ctrl+D. Listed one by one rather than under a
       // `default` so a newly added action has to be classified here, not
       // silently swallowed.
-      case 'clearActivePane':
       case 'closeActivePane':
         args.onClose?.()
         return consumeEvent(event)
+      case 'clearActivePane':
       case 'clearPaneTitle':
       case 'copySelection':
       case 'equalizePaneSizes':

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
@@ -194,14 +194,14 @@ export function installPreviewTerminalKeyHandler(args: {
         nativeOnlyShortcutTracker.armKeyDown(event)
         event.stopImmediatePropagation()
         return false
-      // Why: pane-scoped chords have no target in a preview dialog. Swallow them
-      // — a pane never sends these bytes to the shell, and xterm would encode
-      // e.g. Ctrl+Shift+D as a bare Ctrl+D. Listed one by one rather than under a
-      // `default` so a newly added action has to be classified here, not
-      // silently swallowed.
+      // The pane-close action maps cleanly to dismissing this preview; it
+      // never closes the real pane or writes bytes to its PTY.
       case 'closeActivePane':
         args.onClose?.()
         return consumeEvent(event)
+      // Why: the remaining pane-scoped chords have no target in a preview.
+      // Swallow them so xterm cannot encode an app chord as terminal input.
+      // List them explicitly so every new action must be classified.
       case 'clearActivePane':
       case 'clearPaneTitle':
       case 'copySelection':


### PR DESCRIPTION
## ELI5

Opening an Agent Dashboard terminal preview no longer immediately gives the live agent your keyboard. The preview opens in a safe inspection state: Escape closes it. Click or Tab into the terminal to interact with the real PTY; from then on Escape reaches the agent normally.

## What Changed

- Focus the dialog title when an agent preview opens instead of auto-focusing xterm.
- Remove the reconnect/resync `terminal.focus()` call so terminal refreshes never steal input ownership.
- Keep Escape scoped by actual focus: dialog focus closes the preview; `.xterm` focus forwards Escape to the PTY.
- Add a `focus-within` ring using the existing `ring` token so pointer and keyboard focus ownership are visible.
- Route the configured terminal close-pane action to close the preview without writing bytes to the PTY.
- Keep unrelated pane shortcuts, including terminal clear, swallowed as before.
- Add regression coverage for initial focus, Escape routing, resync, close-pane, focus styling, and unrelated pane shortcuts.

## Why

Fixes #17581.

The previous flow called `terminal.focus()` as soon as the preview snapshot painted. A surface presented as a dismissible dialog therefore behaved like a live terminal before the user explicitly entered it: bare Escape was forwarded as `\x1b` and could interrupt the agent.

Unlike #16857's global bare-Escape filter, this preserves full terminal behavior after explicit focus. The boundary is input ownership, not a permanently disabled terminal key. The close-pane routing also coordinates with #13958/#13961.

## Linked Issue

Fixes #17581

## Visual Proof

After opening a dashboard card, focus lands on the dialog title (`focus-demo`), not xterm. Escape closes this detail while leaving the Agent Dashboard open.

__omp_shell("[Agent Dashboard terminal preview in inspection state](https://github.com/user-attachments/assets/5c017ec7-626e-4e49-91d1-9f7bf658cba6)")

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Automated:

```text
./node_modules/.bin/vitest run --config config/vitest.config.ts \
  src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx \
  src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx \
  src/renderer/src/components/dashboard/AgentDashboardDrawer.test.tsx \
  src/renderer/src/components/dashboard-popout/AgentKanbanBoard.test.tsx \
  src/renderer/src/components/dashboard-popout/preview-terminal-shortcuts.test.ts

5 test files passed; 65 tests passed.

./node_modules/.bin/tsc --noEmit -p config/tsconfig.tc.web.json
./node_modules/.bin/oxlint <changed files>
./node_modules/.bin/oxlint --config config/oxlint-react-doctor.json <changed files>
./node_modules/.bin/oxfmt --check <changed files>
```

Manual, Linux Electron dev build via Playwright CDP:

1. Enabled Agent Dashboard and injected one live dashboard card into the dev renderer store.
2. Opened the card and observed `document.activeElement` was the `H2` title, not `.xterm`.
3. Pressed Escape and observed the terminal detail close while the outer Agent Dashboard remained open.
4. Verified the rendered inspection state shown above.

Not manually exercised: macOS, Windows, SSH, mobile. The changed logic is renderer-only; remote/local previews share the same component and relayed `terminalInput` remains unchanged.

## AI Disclosure

OpenAI Codex GPT-5.6 was used for repository analysis, implementation, tests, and review. The final change was manually exercised in the Linux Electron app and independently code-reviewed; one reviewer finding about `terminal.clear` fallthrough was fixed and regression-tested before submission.

## Review

Focus on the Radix capture-phase Escape boundary and the xterm `attachCustomKeyEventHandler` action split. Expected contract:

- Initial dialog focus: title.
- Escape outside `.xterm`: close preview.
- Escape inside `.xterm`: PTY owns it.
- Resync: never calls `focus()`.
- Close-pane shortcut: closes preview, no PTY bytes.
- Clear-pane shortcut: does not close preview.

## Agent skill upstream boundary

- [x] Not applicable; this change touches no agent skill installer/source.

## Notes

- No wire, IPC, runtime, SSH, mobile, or persistence contract changes.
- No new dependencies or localization strings.
- Uses existing design-system `ring` token.
- The source PR #16857 is credited by canonical issue #17581; this implementation takes the focus-ownership approach rather than globally blocking bare Escape.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after interaction proof attached
- [x] Self-reviewed for correctness, cross-platform keyboard behavior, remote compatibility, performance, and accessibility
