### PR TITLE
fix(ssh): stop an unanswered native-deps probe from wiping a healthy relay

### DIFF
--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -733,13 +733,25 @@ function missingNativeDepsFromProbe(output: string): RelayNativeDepName[] {
   return RELAY_NATIVE_DEP_NAMES.filter((name) => reported.includes(name))
 }
 
+/**
+ * `ok` — the probe answered and both deps loaded. `blocked` — the probe answered and named deps
+ * that failed to load. `unverifiable` — the probe never answered, which is evidence about the
+ * transport, not about the deps.
+ *
+ * Why `unverifiable` is not `blocked`: repairing on it does `rm -rf node_modules/node-pty` and a
+ * node-gyp source build (no Linux prebuild) against a relay that was never shown to be broken.
+ * Same verdict discipline as `src/main/orcad/node-pty-precondition.ts` and
+ * docs/reference/ssh-execution-boundary.md — loss of contact is not evidence.
+ */
+type RelayNativeDepsProbeStatus = 'ok' | 'blocked' | 'unverifiable'
+
 async function probeRequiredNativeDeps(
   conn: SshConnection,
   remoteDir: string,
   hostPlatform: RemoteHostPlatform,
   nodePath: string,
   signal?: AbortSignal
-): Promise<{ available: boolean; missing: RelayNativeDepName[] }> {
+): Promise<{ status: RelayNativeDepsProbeStatus; missing: RelayNativeDepName[] }> {
   const escapedNode = shellEscape(nodePath)
   const probeJs = nativeDepsProbeJs('ORCA-NATIVE-DEPS-OK')
   try {
@@ -757,11 +769,14 @@ async function probeRequiredNativeDeps(
           `(${escapedNode} -e ${shellEscape(probeJs)} 2>/dev/null || echo MISSING)`
         )
     const probe = await execHostCommand(conn, hostPlatform, command, { signal })
-    const available = probe.includes('ORCA-NATIVE-DEPS-OK')
-    return { available, missing: available ? [] : missingNativeDepsFromProbe(probe) }
+    return probe.includes('ORCA-NATIVE-DEPS-OK')
+      ? { status: 'ok', missing: [] }
+      : { status: 'blocked', missing: missingNativeDepsFromProbe(probe) }
   } catch {
     signal?.throwIfAborted()
-    return { available: false, missing: [...RELAY_NATIVE_DEP_NAMES] }
+    // Why: an unanswered probe says nothing about the deps; reporting MISSING here reset and
+    // recompiled healthy relays, turning one dropped exec channel into a multi-minute reconnect.
+    return { status: 'unverifiable', missing: [] }
   }
 }
 
@@ -810,7 +825,8 @@ async function repairInstalledNativeDeps(
     lockResult === 'busy' || lockResult === 'error'
       ? await acquireRelayLaunchGcFence(conn, remoteDir, hostPlatform, signal)
       : undefined
-  if (initialProbe.available) {
+  // Why: only a probe that answered may trigger repair; an unverifiable one launches as-is and the next reconnect re-probes.
+  if (initialProbe.status !== 'blocked') {
     // Why: even a healthy reconnect stays fenced until launch liveness is observable, or cross-version GC can rename after this probe.
     if (lockResult !== 'acquired') {
       return { ownsInstallLock: false, gcClaimToken }
@@ -847,7 +863,9 @@ async function repairInstalledNativeDeps(
     // Why: older complete relay dirs predate @parcel/watcher; re-probe under the lock so only one reconnect mutates the dir.
     const probe = await probeRequiredNativeDeps(conn, remoteDir, hostPlatform, nodePath, signal)
     let repairNamespace: RelayInstallNamespace | undefined
-    if (!probe.available) {
+    if (probe.status !== 'ok') {
+      // Why: the locked re-probe can only narrow the repair; when it can't answer, the initial probe's answered evidence still stands.
+      const resetDeps = probe.status === 'unverifiable' ? initialProbe.missing : probe.missing
       // Why: only stamp ownership once the locked recheck proves this connection is the one about to write.
       repairNamespace = await createRelayLaunchNamespace(
         conn,
@@ -863,7 +881,7 @@ async function repairInstalledNativeDeps(
         hostPlatform,
         nodePath,
         signal,
-        probe.missing,
+        resetDeps,
         repairNamespace
       )
       await finalizeInstall(conn, remoteDir, hostPlatform, { signal, releaseLock: false })

--- a/src/main/ssh/ssh-relay-native-deps-probe-verdict.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-probe-verdict.test.ts
@@ -1,0 +1,226 @@
+// Why: the repair path used to map ANY probe failure to "all deps missing", so one dropped exec
+// channel rm -rf'd node-pty on a healthy relay and forced a node-gyp rebuild. Verdicts are
+// ok / blocked / unverifiable — see docs/reference/ssh-execution-boundary.md.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RelayInstallMarkerModule from './ssh-relay-install-marker'
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/mock/app' }
+}))
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+  readFileSync: vi.fn().mockReturnValue('0.1.0+testhash')
+}))
+
+vi.mock('./relay-protocol', () => ({
+  RELAY_VERSION: '0.1.0',
+  RELAY_REMOTE_DIR: '.orca-remote',
+  parseUnameToRelayPlatform: vi.fn().mockReturnValue('linux-x64'),
+  RELAY_SENTINEL: 'ORCA-RELAY v0.1.0 READY\n',
+  RELAY_SENTINEL_TIMEOUT_MS: 10_000
+}))
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  uploadDirectory: vi.fn().mockResolvedValue(undefined),
+  waitForSentinel: vi.fn().mockResolvedValue({
+    write: vi.fn(),
+    onData: vi.fn(),
+    onClose: vi.fn()
+  }),
+  isUnconfirmedSshCommandTermination: (error: unknown) =>
+    error instanceof Error &&
+    (error as Error & { sshChannelCloseConfirmed?: boolean }).sshChannelCloseConfirmed === false,
+  execCommand: vi.fn()
+}))
+
+vi.mock('./ssh-remote-node-resolution', () => ({
+  resolveRemoteNodePath: vi.fn().mockResolvedValue('/usr/bin/node')
+}))
+
+vi.mock('./ssh-relay-install-marker', async (importOriginal) => ({
+  ...(await importOriginal<typeof RelayInstallMarkerModule>()),
+  createRelayInstallMarkerFileName: () => '.sftp-namespace-00000000000000000000000000000000'
+}))
+
+vi.mock('./ssh-relay-versioned-install', () => ({
+  readLocalFullVersion: vi.fn().mockReturnValue('0.1.0+testhash'),
+  computeRemoteRelayDir: (home: string, v: string) => `${home}/.orca-remote/relay-${v}`,
+  isRelayAlreadyInstalled: vi.fn().mockResolvedValue(true),
+  finalizeInstall: vi.fn().mockResolvedValue(undefined),
+  abandonInstall: vi.fn().mockResolvedValue(undefined),
+  gcOldRelayVersions: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-relay-install-lock', () => ({
+  acquireInstallLock: vi.fn().mockResolvedValue(undefined),
+  RELAY_INSTALL_LOCK_NAME: '.install-lock'
+}))
+
+vi.mock('./ssh-relay-repair-lock', () => ({
+  tryAcquireRelayRepairLock: vi.fn().mockResolvedValue('acquired')
+}))
+
+vi.mock('./ssh-relay-gc-claim', () => ({
+  releaseRelayGcClaimWithRetry: vi.fn().mockResolvedValue('released'),
+  tryAcquireRelayGcClaim: vi.fn().mockResolvedValue('launch-token'),
+  waitForRelayGcClaimRelease: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-connection-utils', () => ({
+  shellEscape: (s: string) => `'${s}'`
+}))
+
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+import { execCommand, uploadDirectory } from './ssh-relay-deploy-helpers'
+import { parseUnameToRelayPlatform } from './relay-protocol'
+import { finalizeInstall, isRelayAlreadyInstalled } from './ssh-relay-versioned-install'
+import {
+  makeMockConnection,
+  type ExecResponse,
+  type SftpWriteCapture
+} from './ssh-relay-native-deps-install-fixture'
+
+const NODE_PTY_RESET = "rm -rf 'node_modules/node-pty'"
+const WATCHER_RESET = "rm -rf 'node_modules/@parcel/watcher'"
+
+describe('native-deps repair probe verdicts', () => {
+  const sftpCapture: SftpWriteCapture = { paths: [], contents: {}, execCallCountAtWrite: {} }
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(execCommand).mockReset().mockResolvedValue('')
+    vi.mocked(uploadDirectory).mockResolvedValue(undefined)
+    sftpCapture.paths.length = 0
+    for (const key of Object.keys(sftpCapture.contents)) {
+      delete sftpCapture.contents[key]
+    }
+    for (const key of Object.keys(sftpCapture.execCallCountAtWrite)) {
+      delete sftpCapture.execCallCountAtWrite[key]
+    }
+    vi.mocked(parseUnameToRelayPlatform).mockReturnValue('linux-x64')
+    vi.mocked(isRelayAlreadyInstalled).mockResolvedValue(true)
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  function feed(execResponses: ExecResponse[]): void {
+    const mockExec = vi.mocked(execCommand)
+    for (const response of execResponses) {
+      if (typeof response === 'string') {
+        mockExec.mockResolvedValueOnce(response)
+      } else {
+        mockExec.mockRejectedValueOnce(new Error(response.reject))
+      }
+    }
+  }
+
+  function execCommands(): string[] {
+    return vi.mocked(execCommand).mock.calls.map(([, command]) => command)
+  }
+
+  function warnings(): string[] {
+    return warnSpy.mock.calls.map((args) => String(args[0] ?? ''))
+  }
+
+  it('launches an intact relay when the health probe never answers', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed([
+      '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+      '/home/u',
+      { reject: 'SSH channel closed unexpectedly' }, // health probe: unverifiable, not MISSING
+      '', // launch namespace marker
+      'DEAD',
+      '', // publish the per-launch credential
+      'READY'
+    ])
+
+    // Assert the repair-avoidance facts before the launch outcome so a regression names the defect
+    // rather than the fixture drift that follows from an unexpected repair.
+    const outcome = await deployAndLaunchRelay(conn).then(
+      (result) => result,
+      (err: Error) => err
+    )
+
+    const commands = execCommands()
+    expect(warnings().some((message) => message.includes('Repairing missing native deps'))).toBe(
+      false
+    )
+    expect(commands.some((command) => command.includes(NODE_PTY_RESET))).toBe(false)
+    expect(commands.some((command) => command.includes(WATCHER_RESET))).toBe(false)
+    expect(commands.some((command) => command.includes('npm install'))).toBe(false)
+    // Exactly one probe: an unverifiable answer must not fall through to the locked re-probe.
+    expect(commands.filter((command) => command.includes('ORCA-NATIVE-DEPS-OK'))).toHaveLength(1)
+    expect(vi.mocked(finalizeInstall)).not.toHaveBeenCalled()
+    expect(outcome, 'lost contact must not abort the connection').not.toBeInstanceOf(Error)
+  })
+
+  it('still resets and repairs when the probe answers without the OK marker', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed([
+      '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+      '/home/u',
+      'MISSING', // answered, no marker line: both deps are genuinely broken
+      'MISSING', // re-probe under the repair lock
+      '', // SFTP-namespace install-owner marker (repair)
+      '', // npm install native deps
+      '', // chmod prebuilds
+      'ORCA-NPTY-PROBE-OK\n',
+      '', // rm probe stderr
+      'DEAD',
+      '', // publish the per-launch credential
+      'READY'
+    ])
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+
+    const install = execCommands().find((command) => command.includes('npm install')) ?? ''
+    expect(install).toContain(NODE_PTY_RESET)
+    expect(install).toContain(WATCHER_RESET)
+    expect(vi.mocked(finalizeInstall)).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips repair entirely when the probe answers OK', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed([
+      '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+      '/home/u',
+      'ORCA-NATIVE-DEPS-OK',
+      '', // launch namespace marker
+      'DEAD',
+      '', // publish the per-launch credential
+      'READY'
+    ])
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+
+    expect(execCommands().some((command) => command.includes('npm install'))).toBe(false)
+    expect(vi.mocked(finalizeInstall)).not.toHaveBeenCalled()
+  })
+
+  it('keeps the answered reset scope when the locked re-probe cannot answer', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed([
+      '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+      '/home/u',
+      'ORCA-NATIVE-DEPS-MISSING:@parcel/watcher\nMISSING', // answered: only the watcher is broken
+      { reject: 'SSH channel closed unexpectedly' }, // re-probe under the lock: unverifiable
+      '', // SFTP-namespace install-owner marker (repair)
+      '', // npm install native deps
+      '', // chmod prebuilds
+      'ORCA-NPTY-PROBE-OK\n',
+      '', // rm probe stderr
+      'DEAD',
+      '', // publish the per-launch credential
+      'READY'
+    ])
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+
+    const install = execCommands().find((command) => command.includes('npm install')) ?? ''
+    expect(install).toContain(WATCHER_RESET)
+    // The unanswered re-probe must not widen the reset to a dep no probe ever reported broken.
+    expect(install).not.toContain(NODE_PTY_RESET)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​226 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​226 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

Closes the destructive half of #17891's root cause. **Land this before #17920** — see sequencing below.

## ELI5

The relay's repair-path probe mapped **any** thrown error to "all native deps are missing":

```ts
} catch {
  signal?.throwIfAborted()
  return { available: false, missing: [...RELAY_NATIVE_DEP_NAMES] }
}
```

`available: false` does two things, and the second is the worse one:

1. it feeds `resetDeps` → `rm -rf 'node_modules/node-pty'` → full recompile (a node-gyp **source build** on Linux, which has no prebuild);
2. **it is what triggers the repair at all.**

So an unanswered probe against a **perfectly healthy relay** caused an unnecessary full reinstall plus source compile. That is a direct contributor to the report behind this sweep — *"SSH relays … taking several minutes to connect."* Loss of contact was being treated as proof of breakage, which `docs/reference/ssh-execution-boundary.md` forbids.

## The asymmetry that is the whole bug

The sibling probe already does this correctly. `probeInstalledNativeDeps` (`:1275`) has **no try/catch** — the error bubbles, the deploy fails, the lock releases, a later reconnect retries. Two tests deliberately pin that policy, one named *"lets a probe SSH-channel failure bubble up rather than silently mapping to MISSING."*

The discipline existed on the install path and was never applied to the repair path. That is the tenth instance in this sweep of a hazard guarded in one place and not its twin.

## The fix

Return type goes from `{ available: boolean }` to `{ status: 'ok' | 'blocked' | 'unverifiable'; missing }`, **reusing the vocabulary and rationale already written out** in `src/main/orcad/node-pty-precondition.ts:45-56`: *"a probe that times out or cannot spawn says nothing about node-pty, and refusing to boot on it would brick working hosts for a reason that was never established."*

1. The catch returns `{ status: 'unverifiable', missing: [] }` — an unanswered probe can no longer name a single dep for reset.
2. Only `blocked` repairs. Unverifiable takes the **existing** no-repair exit.
3. Locked re-probe: `resetDeps = probe.status === 'unverifiable' ? initialProbe.missing : probe.missing`.

**Point 3 is scope beyond the named catch, and it is load-bearing.** Without it, an initial probe answering "only `@parcel/watcher` is broken" followed by an unverifiable *re*-probe still widened the reset to `node-pty` — the same defect, one call site over. It preserves repair for genuine breakage (the answered initial probe's evidence stands) while never letting an unanswered probe author a reset list.

**One deliberate deviation from the brief.** I suggested routing unverifiable to the `lockResult === 'busy' | 'error'` degraded exit. The implementation used the healthy-probe exit instead: for `busy`/`error` the two are byte-identical, but the healthy exit also handles `acquired` correctly. Taking the busy/error exit under an acquired lock would return `ownsInstallLock: false` with an `undefined` `gcClaimToken`, **leaking the repair lock until stale recovery**. The deviation is correct and my brief was wrong.

## Scope fences held

- `missingNativeDepsFromProbe` (no marker line → all deps) is **untouched**. That path runs only when the probe *answered* and `|| echo MISSING` fired, which genuinely means broken — resetting is correct there.
- The all-missing-on-catch was **not** protecting "relay dir vanished": under an acquired lock the recheck calls `isRelayAlreadyInstalled` and throws `RelayDirectoryGcConflictError`; under `busy`/`error` the pre-existing `acquireRelayLaunchGcFence` throws the same. Verified, not assumed.

## User-facing regressions

**None expected.** Negative controls: a probe answering bare `MISSING` still resets **both** deps and runs `finalizeInstall`; a probe answering OK still skips `npm install`; the two pinned tests at `ssh-relay-native-deps-install.test.ts:395` and `:428` pass **unchanged** (that file is not in the diff — only 2 files changed).

**Behavior delta:** an unanswered probe against a healthy relay used to cost a full `npm install` plus a node-gyp build. It now costs one extra exec (the launch-namespace marker) and launches. If the deps really were broken, the next reconnect re-probes and repairs — no state is lost, only the destructive guess.

## Testing

New spec `ssh-relay-native-deps-probe-verdict.test.ts`. Before → after:
```
 ❯ ssh-relay-native-deps-probe-verdict.test.ts (4 tests | 2 failed)
   × launches an intact relay when the health probe never answers
   × keeps the answered reset scope when the locked re-probe cannot answer
```
```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

The test was restructured mid-implementation: it first failed only on fixture slot-drift (`Relay failed to start within 10s`) — a true failure for the wrong reason. Asserting the repair-avoidance facts *before* the launch outcome makes the pre-fix failure name the actual defect, and the second test prints the offending command:
```
Received: "... && rm -rf 'node_modules/node-pty'; rm -rf 'node_modules/@parcel/watcher'; ... npm install ..."
```

`pnpm test src/main/ssh` → 1798 passed / 16 skipped. `tc:node` clean. `check:code-quality:changed` 0 new findings. `check:max-lines-ratchet` OK. The 3 heaviest `src/main/ipc/ssh*` consumers also run (37 passed) since the return shape changed.

## Sequencing

**This should land before #17920.** It touches no artifact, manifest, or content hash, so **no host moves to a fresh install dir** — it costs zero reinstalls. #17920 forces exactly one reinstall per host and adds a third 240s command to a budget that is already 720s inside a 900s bound. Landing the free fix first is strictly dominant, and it removes the runaway that #17920 would otherwise lengthen.
