### PR TITLE
fix(ci): age adhoc releases by publishedAt, not createdAt

### DIFF
--- a/.github/workflows/adhoc-mac-build.yml
+++ b/.github/workflows/adhoc-mac-build.yml
@@ -401,27 +401,51 @@ jobs:
             echo "::warning::Could not discard draft $TAG; remove it manually."
 
       - name: Prune expired adhoc releases
+        # Only after a live publish: $TAG is then a non-draft this step must not
+        # delete, and a run that failed before publishing has nothing to retire.
+        if: steps.publish_live.outcome == 'success'
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          # Protect the tag this run just shipped, so no filter mistake can delete
+          # a build minutes after the person who cut it was told it exists.
+          TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
           # Why compute the cutoff in bash rather than with jq's `now`: this runs
           # once per dispatch, and a fixed epoch makes the threshold visible in the
           # log when someone asks where their build went.
           cutoff=$(( $(date -u +%s) - ADHOC_RETAIN_DAYS * 86400 ))
-          echo "Pruning adhoc releases created before $(date -u -r "$cutoff" '+%Y-%m-%dT%H:%M:%SZ')"
+          echo "Pruning adhoc releases published before $(date -u -r "$cutoff" '+%Y-%m-%dT%H:%M:%SZ')"
           # --cleanup-tag so pruning does not leave orphan tags with no release or
           # assets attached. Drafts are excluded: a stale draft is the failure
           # path's business, not the retention window's.
-          stale="$(gh release list --repo "$ADHOC_REPO" --limit 200 --json tagName,createdAt,isDraft \
-            --jq "map(select(.isDraft | not)) | map(select((.createdAt | fromdateiso8601) < $cutoff)) | .[].tagName")"
+          #
+          # Age comes from publishedAt, never createdAt. GitHub reports createdAt
+          # as the date of the *commit* a release's tag points at, and every tag
+          # here is cut from this repo's one seed commit — so all of them carry
+          # that same createdAt, and the day the window rolled past it the entire
+          # channel expired at once and a single run deleted it. A release with no
+          # publishedAt is kept rather than aged by guesswork.
+          jq_filter='map(select(.isDraft | not))'
+          if [[ -n "${TAG:-}" ]]; then
+            jq_filter+=" | map(select(.tagName != \"${TAG//\"/\\\"}\"))"
+          fi
+          jq_filter+=" | map(select((.publishedAt // \"\") != \"\"))"
+          jq_filter+=" | map(select((.publishedAt | fromdateiso8601) < $cutoff)) | .[].tagName"
+          stale="$(gh release list --repo "$ADHOC_REPO" --limit 200 --json tagName,publishedAt,isDraft \
+            --jq "$jq_filter")"
           if [[ -z "$stale" ]]; then
             echo "Nothing to prune."
             exit 0
           fi
           while read -r tag; do
             [[ -n "$tag" ]] || continue
+            # Belt-and-suspenders: the filter above should already exclude $TAG.
+            if [[ -n "${TAG:-}" && "$tag" == "$TAG" ]]; then
+              echo "::warning::Prune list still included just-published $tag after protect; skipping delete."
+              continue
+            fi
             echo "Pruning $tag"
             gh release delete "$tag" --repo "$ADHOC_REPO" --yes --cleanup-tag || \
               echo "::warning::Could not prune $tag"


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |

<!-- /orca-pr-loc -->

## What broke

At `2026-09-01T10:42:54Z` the prune step of adhoc run [33498083596](https://github.com/stablyai/orca/actions/runs/33498083596) deleted **every adhoc release from Aug 13 through Sep 1** — 40+ releases, tags and assets, with `--cleanup-tag`. It deleted `v1.4.195-adhoc.20260901103540`, which that same run had published two minutes earlier. The Adhoc picker in Settings was left offering nothing newer than Aug 12.

## Root cause

The prune aged releases by `createdAt`:

```jq
map(select(.isDraft | not)) | map(select((.createdAt | fromdateiso8601) < $cutoff))
```

GitHub reports a release's `createdAt` as the date of the **commit its tag points at**, not when it was created or published. Every adhoc tag is cut against `stablyai/orca-adhoc`'s single seed commit:

```
ff9ca5b6  2026-08-02T09:46:58Z  Seed the repo so releases can be tagged
```

So all 59 releases in the repo share one `createdAt` of `2026-08-02T09:46:58Z`. With `ADHOC_RETAIN_DAYS: 30`, the cutoff crossed that timestamp for the first time today at 09:46:58 UTC:

| run | cutoff | result |
|---|---|---|
| 06:53 | `2026-08-02T07:02:50Z` — before the seed commit | `Nothing to prune.` |
| 10:34 | `2026-08-02T10:42:54Z` — past it | whole channel expired, 40+ deleted |

Nothing was changed in CI or in the app. A fixed date rolled past, and the channel deleted itself.

`hourly-mac-build.yml` and `daily-mac-build.yml` already hit the adjacent version of this (shared `createdAt` making their retain-count *sort* unstable) and moved to `publishedAt`. Adhoc was the last one still reading `createdAt`, and it reads it for age rather than for sort, which is the more destructive of the two.

## The fix

- Age on `publishedAt`, which is real publish recency.
- A release with no `publishedAt` is kept, never aged by guesswork.
- The tag this run just shipped is excluded from the candidate list, with a belt-and-suspenders skip in the delete loop (mirrors hourly/daily).
- Prune only runs when `publish_live` succeeded — a run that failed before publishing has nothing to retire, and the draft-discard step owns that path.

## Verification

Replayed both filters against a snapshot of the live `orca-adhoc` release JSON:

| scenario | old (`createdAt`) | new (`publishedAt`) |
|---|---|---|
| today | deletes **59** — every release in the repo | deletes **1**: `v1.4.164-adhoc.20260802094839`, genuinely published Aug 2 |
| just-published tag inside the stale range | would delete it | 0 deletions, tag protected |
| +60 days | — | 52 age out correctly; protected tag absent from the list |

Workflow YAML parses clean. `actionlint` isn't installed locally, so that check is CI's.

## Not recoverable

The deleted releases and their assets are gone. Anyone who needs one has to re-dispatch from their branch — the source commits are all still in `stablyai/orca`.

The 15 surviving Aug 11–13 builds are one dispatch away from the same fate: any adhoc run on unpatched `main` deletes them **and** its own output. Worth landing before the next cut.
