### PR TITLE
fix(notifications): resolve folder workspace names in OS notification titles

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.folder-workspace.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.folder-workspace.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { dispatchTerminalNotification } from './use-notification-dispatch'
+import { findKnownWorktreeById } from '../../store/slices/worktrees/listing/detected-worktree-meta'
+
+// Why: split out of use-notification-dispatch.test.ts to keep both files under the
+// test-file max-lines budget.
+
+type MockState = {
+  activeWorktreeId: string | null
+  tabsByWorktree: Record<string, { id: string; ptyId?: string | null }[]>
+  ptyIdsByTabId: Record<string, string[]>
+  worktreesByRepo: Record<
+    string,
+    {
+      id: string
+      repoId: string
+      displayName?: string
+      branch?: string
+    }[]
+  >
+  repos: { id: string; displayName?: string; connectionId?: string | null }[]
+  folderWorkspaces: { id: string; projectGroupId: string; name: string; folderPath: string }[]
+  detectedWorktreesByRepo: Record<string, unknown[]>
+  getKnownWorktreeById: (worktreeId: string) => unknown
+  settings: {
+    experimentalTerminalAttention?: boolean
+    notifications?: {
+      customSoundPath?: string | null
+      customSoundId?: string | null
+    }
+  }
+  markWorktreeUnread: ReturnType<typeof vi.fn>
+}
+
+const playDesktopNotificationSound = vi.hoisted(() => vi.fn())
+let mockState: MockState
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mockState
+  }
+}))
+
+vi.mock('@/lib/desktop-notification-sound', () => ({
+  playDesktopNotificationSound
+}))
+
+function getLastNotificationDispatchArg(): Record<string, unknown> | undefined {
+  const dispatch = window.api.notifications.dispatch as unknown as ReturnType<typeof vi.fn>
+  return dispatch.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
+}
+
+describe('dispatchTerminalNotification folder workspaces', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockState = {
+      activeWorktreeId: 'wt-secondary',
+      tabsByWorktree: {
+        'wt-primary': [{ id: 'tab-1', ptyId: 'pty-1' }]
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-1']
+      },
+      worktreesByRepo: {
+        repo1: [
+          {
+            id: 'wt-primary',
+            repoId: 'repo1',
+            displayName: 'master',
+            branch: 'master'
+          }
+        ]
+      },
+      repos: [{ id: 'repo1', displayName: 'orca', connectionId: null }],
+      folderWorkspaces: [],
+      detectedWorktreesByRepo: {},
+      // The real resolver, bound to this mock state — keeps the folder tests
+      // exercising the actual folder-workspace projection.
+      getKnownWorktreeById: (worktreeId: string) =>
+        findKnownWorktreeById(
+          mockState as unknown as Parameters<typeof findKnownWorktreeById>[0],
+          worktreeId
+        ),
+      settings: { experimentalTerminalAttention: true, notifications: { customSoundPath: null } },
+      markWorktreeUnread: vi.fn()
+    }
+    vi.stubGlobal('window', {
+      api: {
+        notifications: {
+          dispatch: vi.fn().mockResolvedValue({ delivered: true })
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('resolves a folder workspace name for folder: workspace keys', () => {
+    mockState.folderWorkspaces = [
+      {
+        id: 'fw-1',
+        projectGroupId: 'group-1',
+        name: 'API-792 : Make portal permissions available',
+        folderPath: '/home/user/workspaces/api-792'
+      }
+    ]
+
+    dispatchTerminalNotification('folder:fw-1', {
+      source: 'agent-task-complete',
+      agentStatusSnapshot: {
+        state: 'done',
+        prompt: 'review the PR',
+        agentType: 'claude',
+        stateStartedAt: Date.now()
+      }
+    })
+
+    expect(getLastNotificationDispatchArg()).toMatchObject({
+      worktreeId: 'folder:fw-1',
+      worktreeLabel: 'API-792 : Make portal permissions available',
+      // Folder workspaces have no repo row; the title is the workspace name alone.
+      repoLabel: undefined
+    })
+  })
+
+  it('falls back to the raw key only when no folder workspace matches it', () => {
+    dispatchTerminalNotification('folder:unknown-workspace', {
+      source: 'agent-task-complete',
+      agentStatusSnapshot: {
+        state: 'done',
+        prompt: 'review the PR',
+        agentType: 'claude',
+        stateStartedAt: Date.now()
+      }
+    })
+
+    expect(getLastNotificationDispatchArg()).toMatchObject({
+      worktreeLabel: 'folder:unknown-workspace'
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -28,6 +28,7 @@ type MockState = {
     }[]
   >
   repos: { id: string; displayName?: string; connectionId?: string | null }[]
+  folderWorkspaces: { id: string; projectGroupId: string; name: string; folderPath: string }[]
   settings: {
     experimentalTerminalAttention?: boolean
     notifications?: {
@@ -139,6 +140,7 @@ describe('dispatchTerminalNotification', () => {
         ]
       },
       repos: [{ id: 'repo1', displayName: 'orca', connectionId: null }],
+      folderWorkspaces: [],
       settings: { experimentalTerminalAttention: true, notifications: { customSoundPath: null } },
       markWorktreeUnread: vi.fn(),
       markTerminalTabUnread: vi.fn(),
@@ -876,5 +878,49 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
     expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('resolves a folder workspace name for folder: workspace keys', () => {
+    mockState.folderWorkspaces = [
+      {
+        id: 'fw-1',
+        projectGroupId: 'group-1',
+        name: 'API-792 : Make portal permissions available',
+        folderPath: '/home/user/workspaces/api-792'
+      }
+    ]
+
+    dispatchTerminalNotification('folder:fw-1', {
+      source: 'agent-task-complete',
+      agentStatusSnapshot: {
+        state: 'done',
+        prompt: 'review the PR',
+        agentType: 'claude',
+        stateStartedAt: Date.now()
+      }
+    })
+
+    expect(getLastNotificationDispatchArg()).toMatchObject({
+      worktreeId: 'folder:fw-1',
+      worktreeLabel: 'API-792 : Make portal permissions available',
+      // Folder workspaces have no repo row; the title is the workspace name alone.
+      repoLabel: undefined
+    })
+  })
+
+  it('falls back to the raw key only when no folder workspace matches it', () => {
+    dispatchTerminalNotification('folder:unknown-workspace', {
+      source: 'agent-task-complete',
+      agentStatusSnapshot: {
+        state: 'done',
+        prompt: 'review the PR',
+        agentType: 'claude',
+        stateStartedAt: Date.now()
+      }
+    })
+
+    expect(getLastNotificationDispatchArg()).toMatchObject({
+      worktreeLabel: 'folder:unknown-workspace'
+    })
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../shared/agent-status-types'
 import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
+import { findKnownWorktreeById } from '../../store/slices/worktrees/listing/detected-worktree-meta'
 
 type MockState = {
   activeWorktreeId: string | null
@@ -29,6 +30,8 @@ type MockState = {
   >
   repos: { id: string; displayName?: string; connectionId?: string | null }[]
   folderWorkspaces: { id: string; projectGroupId: string; name: string; folderPath: string }[]
+  detectedWorktreesByRepo: Record<string, unknown[]>
+  getKnownWorktreeById: (worktreeId: string) => unknown
   settings: {
     experimentalTerminalAttention?: boolean
     notifications?: {
@@ -141,6 +144,14 @@ describe('dispatchTerminalNotification', () => {
       },
       repos: [{ id: 'repo1', displayName: 'orca', connectionId: null }],
       folderWorkspaces: [],
+      detectedWorktreesByRepo: {},
+      // The real resolver, bound to this mock state — keeps the folder tests
+      // exercising the actual folder-workspace projection.
+      getKnownWorktreeById: (worktreeId: string) =>
+        findKnownWorktreeById(
+          mockState as unknown as Parameters<typeof findKnownWorktreeById>[0],
+          worktreeId
+        ),
       settings: { experimentalTerminalAttention: true, notifications: { customSoundPath: null } },
       markWorktreeUnread: vi.fn(),
       markTerminalTabUnread: vi.fn(),

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -6,7 +6,6 @@ import {
 } from '../../../../shared/agent-status-types'
 import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
-import { findKnownWorktreeById } from '../../store/slices/worktrees/listing/detected-worktree-meta'
 
 type MockState = {
   activeWorktreeId: string | null
@@ -29,9 +28,6 @@ type MockState = {
     }[]
   >
   repos: { id: string; displayName?: string; connectionId?: string | null }[]
-  folderWorkspaces: { id: string; projectGroupId: string; name: string; folderPath: string }[]
-  detectedWorktreesByRepo: Record<string, unknown[]>
-  getKnownWorktreeById: (worktreeId: string) => unknown
   settings: {
     experimentalTerminalAttention?: boolean
     notifications?: {
@@ -143,15 +139,6 @@ describe('dispatchTerminalNotification', () => {
         ]
       },
       repos: [{ id: 'repo1', displayName: 'orca', connectionId: null }],
-      folderWorkspaces: [],
-      detectedWorktreesByRepo: {},
-      // The real resolver, bound to this mock state — keeps the folder tests
-      // exercising the actual folder-workspace projection.
-      getKnownWorktreeById: (worktreeId: string) =>
-        findKnownWorktreeById(
-          mockState as unknown as Parameters<typeof findKnownWorktreeById>[0],
-          worktreeId
-        ),
       settings: { experimentalTerminalAttention: true, notifications: { customSoundPath: null } },
       markWorktreeUnread: vi.fn(),
       markTerminalTabUnread: vi.fn(),
@@ -889,49 +876,5 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
     expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
-  })
-
-  it('resolves a folder workspace name for folder: workspace keys', () => {
-    mockState.folderWorkspaces = [
-      {
-        id: 'fw-1',
-        projectGroupId: 'group-1',
-        name: 'API-792 : Make portal permissions available',
-        folderPath: '/home/user/workspaces/api-792'
-      }
-    ]
-
-    dispatchTerminalNotification('folder:fw-1', {
-      source: 'agent-task-complete',
-      agentStatusSnapshot: {
-        state: 'done',
-        prompt: 'review the PR',
-        agentType: 'claude',
-        stateStartedAt: Date.now()
-      }
-    })
-
-    expect(getLastNotificationDispatchArg()).toMatchObject({
-      worktreeId: 'folder:fw-1',
-      worktreeLabel: 'API-792 : Make portal permissions available',
-      // Folder workspaces have no repo row; the title is the workspace name alone.
-      repoLabel: undefined
-    })
-  })
-
-  it('falls back to the raw key only when no folder workspace matches it', () => {
-    dispatchTerminalNotification('folder:unknown-workspace', {
-      source: 'agent-task-complete',
-      agentStatusSnapshot: {
-        state: 'done',
-        prompt: 'review the PR',
-        agentType: 'claude',
-        stateStartedAt: Date.now()
-      }
-    })
-
-    expect(getLastNotificationDispatchArg()).toMatchObject({
-      worktreeLabel: 'folder:unknown-workspace'
-    })
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -5,7 +5,6 @@ import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
 import { showBlockedNotificationFallbackToast } from '@/lib/blocked-notification-fallback'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
-import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { shareCompatibleTitleIdentityGroup } from '../../../../shared/agent-title-owner'
 import {
@@ -185,17 +184,15 @@ export function dispatchTerminalNotification(
   // construction; coupling the notification dispatcher to it would silently
   // drop the repo label if that format ever changes. The worktree object
   // itself is the source of truth for its owning repo.
-  // Folder workspaces are keyed `folder:<id>` and live outside the worktree
-  // map; without resolving them here the OS notification title falls back to
-  // the raw workspace key instead of the workspace name.
-  const workspaceScope = parseWorkspaceKey(worktreeId)
-  const folderWorkspace =
-    workspaceScope?.type === 'folder'
-      ? state.folderWorkspaces.find((item) => item.id === workspaceScope.folderWorkspaceId)
-      : undefined
+  // Folder workspaces are keyed `folder:<id>` and exist only in
+  // getKnownWorktreeById (#2989); without resolving them here the OS
+  // notification title falls back to the raw workspace key instead of the
+  // workspace name. Git worktrees keep the map path unchanged.
   const worktree =
     getWorktreeMapFromState(state).get(worktreeId) ??
-    (folderWorkspace ? folderWorkspaceToWorktree(folderWorkspace) : undefined)
+    (parseWorkspaceKey(worktreeId)?.type === 'folder'
+      ? state.getKnownWorktreeById(worktreeId)
+      : undefined)
   const repo = worktree ? getRepoMapFromState(state).get(worktree.repoId) : null
   const customSoundId = state.settings?.notifications?.customSoundId ?? 'system'
   const customSoundVolume = state.settings?.notifications?.customSoundVolume ?? null

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -5,6 +5,8 @@ import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
 import { showBlockedNotificationFallbackToast } from '@/lib/blocked-notification-fallback'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
+import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { shareCompatibleTitleIdentityGroup } from '../../../../shared/agent-title-owner'
 import {
   isFreshNonDoneAgentStatus,
@@ -183,7 +185,17 @@ export function dispatchTerminalNotification(
   // construction; coupling the notification dispatcher to it would silently
   // drop the repo label if that format ever changes. The worktree object
   // itself is the source of truth for its owning repo.
-  const worktree = getWorktreeMapFromState(state).get(worktreeId)
+  // Folder workspaces are keyed `folder:<id>` and live outside the worktree
+  // map; without resolving them here the OS notification title falls back to
+  // the raw workspace key instead of the workspace name.
+  const workspaceScope = parseWorkspaceKey(worktreeId)
+  const folderWorkspace =
+    workspaceScope?.type === 'folder'
+      ? state.folderWorkspaces.find((item) => item.id === workspaceScope.folderWorkspaceId)
+      : undefined
+  const worktree =
+    getWorktreeMapFromState(state).get(worktreeId) ??
+    (folderWorkspace ? folderWorkspaceToWorktree(folderWorkspace) : undefined)
   const repo = worktree ? getRepoMapFromState(state).get(worktree.repoId) : null
   const customSoundId = state.settings?.notifications?.customSoundId ?? 'system'
   const customSoundVolume = state.settings?.notifications?.customSoundVolume ?? null


### PR DESCRIPTION
### ELI5

An agent finishing in a folder workspace popped a notification titled `folder:d2990635-… - Claude finished` instead of the workspace's name. Now it shows the name.

### What Changed

- `dispatchTerminalNotification` (`use-notification-dispatch.ts`): when the worktree-map lookup misses and the id is a `folder:<id>` workspace key, resolve it via `parseWorkspaceKey` + `state.folderWorkspaces` and run it through the existing `folderWorkspaceToWorktree` adapter, so `displayName` flows into the notification exactly like a git worktree's would. Git worktrees take the same path as before.
- Two regression tests added to the existing `use-notification-dispatch.test.ts` suite: folder-key name resolution, and raw-key fallback when nothing matches.

### Why

The label resolution only consulted `getWorktreeMapFromState` (built from `worktreesByRepo`). Folder workspaces never appear there, so `worktreeLabel: worktree?.displayName || worktree?.branch || worktreeId` always degraded to the raw key for them. The folder-workspace list in the store is the source of truth for their names, and `folderWorkspaceToWorktree` is the established adapter for treating them as worktree-shaped values (same pattern as `use-worktree-meta-workspace.ts`).

A folder workspace has no repo row, so `repoLabel` stays unset and the title is the workspace name alone — the tests pin that shape.

Running this build since the fix was written, verified live on a folder workspace:

![Fixed notification showing the folder workspace name](https://raw.githubusercontent.com/DominionZA2/orca/assets/folder-notification-fix/notification-fixed-api792.png)

### Note for reviewers — interaction with #15001

#15001 proposes skipping OS notifications when the worktree lookup comes back empty (deleted-worktree cleanup). For folder workspaces that lookup is *always* empty, so a skip-on-miss gate would silence their completion notifications entirely. If both land, the folder-workspace resolution from this PR needs to run before any such gate.

Fixes #17986.

— claude-fable-5, high reasoning (on behalf of @DominionZA2)
