### PR TITLE
refactor(runtime): own socket liveness bounds in one component

### DIFF
--- a/src/main/runtime/rpc/accepted-socket-liveness.test.ts
+++ b/src/main/runtime/rpc/accepted-socket-liveness.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { WebSocket } from 'ws'
+import { AcceptedSocketLiveness } from './accepted-socket-liveness'
+
+const INTERVAL_MS = 100
+const PRE_AUTH_TIMEOUT_MS = 250
+
+function makeSocket(): WebSocket {
+  return { ping: vi.fn(), terminate: vi.fn() } as unknown as WebSocket
+}
+
+function timerOf(liveness: AcceptedSocketLiveness): ReturnType<typeof setInterval> | null {
+  return (liveness as unknown as { heartbeat: { timer: ReturnType<typeof setInterval> | null } })
+    .heartbeat.timer
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// The invariant this class exists for: between accept() and release(), a socket is always under
+// exactly one liveness bound — the pre-auth deadline before authenticate(), the heartbeat after.
+describe('AcceptedSocketLiveness', () => {
+  it('terminates a never-authenticated socket at the pre-auth deadline without ever probing it', async () => {
+    vi.useFakeTimers()
+    let now = 0
+    const liveness = new AcceptedSocketLiveness(PRE_AUTH_TIMEOUT_MS, INTERVAL_MS, () => now)
+    const socket = makeSocket()
+    liveness.accept(socket)
+    expect(timerOf(liveness)).not.toBeNull()
+
+    now += PRE_AUTH_TIMEOUT_MS
+    await vi.advanceTimersByTimeAsync(PRE_AUTH_TIMEOUT_MS)
+
+    expect(socket.ping).not.toHaveBeenCalled()
+    expect(socket.terminate).toHaveBeenCalledTimes(1)
+    liveness.release(socket)
+    expect(timerOf(liveness)).toBeNull()
+  })
+
+  it('swaps the deadline for heartbeat probing on authenticate, then reaps on the miss budget', async () => {
+    vi.useFakeTimers()
+    let now = 0
+    const liveness = new AcceptedSocketLiveness(PRE_AUTH_TIMEOUT_MS, INTERVAL_MS, () => now)
+    const socket = makeSocket()
+    liveness.accept(socket)
+    liveness.authenticate(socket)
+
+    // Pre-auth deadline is cancelled: nothing fires at its horizon but interval ticks.
+    // First probe lands on the first tick; a silent socket then banks misses to the budget.
+    for (const elapsed of [100, 200, 300]) {
+      now = elapsed
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS)
+      expect(socket.ping).toHaveBeenCalledTimes(elapsed / INTERVAL_MS)
+      expect(socket.terminate).not.toHaveBeenCalled()
+    }
+    now = 400
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS)
+    expect(socket.terminate).toHaveBeenCalledTimes(1)
+    liveness.release(socket)
+  })
+
+  it('keeps a responsive authenticated socket alive indefinitely', async () => {
+    vi.useFakeTimers()
+    let now = 0
+    const liveness = new AcceptedSocketLiveness(PRE_AUTH_TIMEOUT_MS, INTERVAL_MS, () => now)
+    const socket = makeSocket()
+    liveness.accept(socket)
+    liveness.authenticate(socket)
+
+    for (let tick = 1; tick <= 10; tick++) {
+      liveness.noteAlive(socket)
+      now = tick * INTERVAL_MS
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS)
+    }
+    expect(socket.terminate).not.toHaveBeenCalled()
+    expect(socket.ping).toHaveBeenCalledTimes(10)
+    liveness.release(socket)
+  })
+
+  it('release clears the pre-auth deadline and stops the shared timer on the last socket', async () => {
+    vi.useFakeTimers()
+    let now = 0
+    const liveness = new AcceptedSocketLiveness(PRE_AUTH_TIMEOUT_MS, INTERVAL_MS, () => now)
+    const first = makeSocket()
+    const second = makeSocket()
+    liveness.accept(first)
+    const sharedTimer = timerOf(liveness)
+    liveness.accept(second)
+    expect(timerOf(liveness)).toBe(sharedTimer)
+
+    liveness.release(first)
+    expect(timerOf(liveness)).toBe(sharedTimer)
+    liveness.release(second)
+    expect(timerOf(liveness)).toBeNull()
+
+    now += PRE_AUTH_TIMEOUT_MS * 2
+    await vi.advanceTimersByTimeAsync(PRE_AUTH_TIMEOUT_MS * 2)
+    expect(first.terminate).not.toHaveBeenCalled()
+    expect(second.terminate).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('stop clears membership so a restarted sweep cannot probe stale sockets', async () => {
+    vi.useFakeTimers()
+    let now = 0
+    const liveness = new AcceptedSocketLiveness(PRE_AUTH_TIMEOUT_MS, INTERVAL_MS, () => now)
+    const stale = makeSocket()
+    liveness.accept(stale)
+    liveness.authenticate(stale)
+    liveness.stop()
+
+    const fresh = makeSocket()
+    liveness.accept(fresh)
+    liveness.authenticate(fresh)
+    now += INTERVAL_MS
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS)
+
+    expect(stale.ping).not.toHaveBeenCalled()
+    expect(fresh.ping).toHaveBeenCalledTimes(1)
+    liveness.release(fresh)
+  })
+})

--- a/src/main/runtime/rpc/accepted-socket-liveness.ts
+++ b/src/main/runtime/rpc/accepted-socket-liveness.ts
@@ -1,0 +1,80 @@
+import type { WebSocket } from 'ws'
+import { RemoteRuntimeServerHeartbeat } from './remote-runtime-server-heartbeat'
+
+// Why: every accepted socket must sit under exactly one liveness bound at all times — the pre-auth
+// deadline until it authenticates, the heartbeat reaper after. Owning both transitions here means a
+// future long-lived unauthenticated flow cannot silently opt out of policing (STA-3231 follow-up);
+// it would need an explicit exemption in this class.
+export class AcceptedSocketLiveness {
+  private readonly heartbeat: RemoteRuntimeServerHeartbeat
+  private readonly accepted = new Set<WebSocket>()
+  // Why: heartbeat probes only authenticated sockets — control frames during the E2EE handshake
+  // close strict native mobile WS stacks with 1006 (issue #12140).
+  private readonly authenticated = new Set<WebSocket>()
+  private readonly preAuthTimers = new WeakMap<WebSocket, ReturnType<typeof setTimeout>>()
+
+  constructor(
+    private readonly preAuthTimeoutMs: number,
+    heartbeatIntervalMs: number,
+    heartbeatNow?: () => number,
+    warningClientCount?: number
+  ) {
+    this.heartbeat = new RemoteRuntimeServerHeartbeat(
+      heartbeatIntervalMs,
+      heartbeatNow,
+      warningClientCount
+    )
+  }
+
+  accept(ws: WebSocket): void {
+    this.accepted.add(ws)
+    this.heartbeat.noteAlive(ws)
+    const preAuthTimer = setTimeout(() => {
+      if (!this.authenticated.has(ws)) {
+        // Why: a silent auto-ponging client would otherwise hold a finite mobile slot forever without starting the E2EE handshake.
+        ws.terminate()
+      }
+    }, this.preAuthTimeoutMs)
+    preAuthTimer.unref?.()
+    this.preAuthTimers.set(ws, preAuthTimer)
+    if (this.accepted.size === 1) {
+      this.heartbeat.start(() => this.authenticated)
+    }
+  }
+
+  // Why: swaps the pre-auth deadline for heartbeat membership atomically, so the socket is never
+  // under both bounds or neither.
+  authenticate(ws: WebSocket): void {
+    this.clearPreAuthTimer(ws)
+    this.authenticated.add(ws)
+  }
+
+  noteAlive(ws: WebSocket): void {
+    this.heartbeat.noteAlive(ws)
+  }
+
+  release(ws: WebSocket): void {
+    this.clearPreAuthTimer(ws)
+    this.accepted.delete(ws)
+    this.authenticated.delete(ws)
+    if (this.accepted.size === 0) {
+      this.heartbeat.stop()
+    }
+  }
+
+  stop(): void {
+    this.heartbeat.stop()
+    // Why: clearing membership here (not just timers) keeps a stop/start overlap from probing
+    // terminated sockets whose close events have not flushed yet.
+    this.accepted.clear()
+    this.authenticated.clear()
+  }
+
+  private clearPreAuthTimer(ws: WebSocket): void {
+    const timer = this.preAuthTimers.get(ws)
+    if (timer) {
+      clearTimeout(timer)
+      this.preAuthTimers.delete(ws)
+    }
+  }
+}

--- a/src/main/runtime/rpc/ws-transport-accept-order.test.ts
+++ b/src/main/runtime/rpc/ws-transport-accept-order.test.ts
@@ -4,8 +4,10 @@ import WebSocket from 'ws'
 import { WebSocketTransport } from './ws-transport'
 
 type TransportLifecycle = {
-  heartbeat: { timer: ReturnType<typeof setInterval> | null }
-  heartbeatConnections: Set<WebSocket>
+  liveness: {
+    heartbeat: { timer: ReturnType<typeof setInterval> | null }
+    accepted: Set<WebSocket>
+  }
   handleConnection(ws: WebSocket): void
   wss: { clients: Set<WebSocket> }
 }
@@ -69,15 +71,15 @@ describe('WebSocketTransport accepted socket ordering', () => {
     expect(firstProbeListeners).toEqual({ pong: 1, message: 1, close: 1, error: 1 })
     expect(events.slice(0, 4)).toEqual(['open', 'ping', 'ready', 'pong'])
     expect(socket.terminate).not.toHaveBeenCalled()
-    expect(lifecycle.heartbeatConnections.size).toBe(1)
+    expect(lifecycle.liveness.accepted.size).toBe(1)
     expect(vi.getTimerCount()).toBe(1)
 
     events.push('close')
     socket.emit('close')
 
     expect(events.at(-1)).toBe('close')
-    expect(lifecycle.heartbeatConnections.size).toBe(0)
-    expect(lifecycle.heartbeat.timer).toBeNull()
+    expect(lifecycle.liveness.accepted.size).toBe(0)
+    expect(lifecycle.liveness.heartbeat.timer).toBeNull()
     expect(vi.getTimerCount()).toBe(0)
     expect(
       ['pong', 'message', 'close', 'error'].map((event) => socket.listenerCount(event))
@@ -112,8 +114,8 @@ describe('WebSocketTransport accepted socket ordering', () => {
 
     expect(socket.terminate).toHaveBeenCalledTimes(1)
     expect(events).toEqual(['open', 'ping', 'ping', 'ping', 'close'])
-    expect(lifecycle.heartbeatConnections.size).toBe(0)
-    expect(lifecycle.heartbeat.timer).toBeNull()
+    expect(lifecycle.liveness.accepted.size).toBe(0)
+    expect(lifecycle.liveness.heartbeat.timer).toBeNull()
     expect(vi.getTimerCount()).toBe(0)
   })
 
@@ -132,7 +134,7 @@ describe('WebSocketTransport accepted socket ordering', () => {
 
     lifecycle.handleConnection(firstSocket)
     transport.setClientId(firstSocket, 'first-client')
-    const sharedTimer = lifecycle.heartbeat.timer
+    const sharedTimer = lifecycle.liveness.heartbeat.timer
     expect(firstPingTimes).toEqual([])
 
     await vi.advanceTimersByTimeAsync(50)
@@ -149,7 +151,7 @@ describe('WebSocketTransport accepted socket ordering', () => {
     lifecycle.wss.clients.add(laterSocket)
     lifecycle.handleConnection(laterSocket)
 
-    expect(lifecycle.heartbeat.timer).toBe(sharedTimer)
+    expect(lifecycle.liveness.heartbeat.timer).toBe(sharedTimer)
     expect(laterPingTimes).toEqual([])
     expect(vi.getTimerCount()).toBe(2)
 
@@ -175,8 +177,8 @@ describe('WebSocketTransport accepted socket ordering', () => {
     ).toEqual([0, 0, 0, 0])
 
     firstSocket.emit('close')
-    expect(lifecycle.heartbeatConnections.size).toBe(0)
-    expect(lifecycle.heartbeat.timer).toBeNull()
+    expect(lifecycle.liveness.accepted.size).toBe(0)
+    expect(lifecycle.liveness.heartbeat.timer).toBeNull()
     expect(vi.getTimerCount()).toBe(0)
   })
 
@@ -202,8 +204,8 @@ describe('WebSocketTransport accepted socket ordering', () => {
 
     expect(events.slice(0, 4)).toEqual(['open', 'ping', 'error', 'close'])
     expect(socket.close).toHaveBeenCalledTimes(1)
-    expect(lifecycle.heartbeatConnections.size).toBe(0)
-    expect(lifecycle.heartbeat.timer).toBeNull()
+    expect(lifecycle.liveness.accepted.size).toBe(0)
+    expect(lifecycle.liveness.heartbeat.timer).toBeNull()
     expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -17,11 +17,13 @@ function makeTls() {
 
 function heartbeatLifecycle(transport: WebSocketTransport) {
   return transport as unknown as {
-    heartbeat: {
-      timer: ReturnType<typeof setInterval> | null
-      alive: WeakSet<WebSocket>
+    liveness: {
+      heartbeat: {
+        timer: ReturnType<typeof setInterval> | null
+        alive: WeakSet<WebSocket>
+      }
+      accepted: Set<WebSocket>
     }
-    heartbeatConnections: Set<WebSocket>
     wss: { clients: Set<WebSocket> }
     handleConnection(ws: WebSocket): void
   }
@@ -34,8 +36,8 @@ async function waitForHeartbeatLifecycle(
 ): Promise<void> {
   await vi.waitFor(() => {
     const lifecycle = heartbeatLifecycle(transport)
-    expect(lifecycle.heartbeatConnections.size).toBe(connectionCount)
-    expect(lifecycle.heartbeat.timer !== null).toBe(armed)
+    expect(lifecycle.liveness.accepted.size).toBe(connectionCount)
+    expect(lifecycle.liveness.heartbeat.timer !== null).toBe(armed)
   })
 }
 
@@ -100,30 +102,30 @@ describe('WebSocketTransport', () => {
     await transport.start()
 
     const lifecycle = heartbeatLifecycle(transport)
-    expect(lifecycle.heartbeat.timer).toBeNull()
-    expect(lifecycle.heartbeatConnections.size).toBe(0)
+    expect(lifecycle.liveness.heartbeat.timer).toBeNull()
+    expect(lifecycle.liveness.accepted.size).toBe(0)
 
     const firstClient = await connectWs(transport)
     await waitForHeartbeatLifecycle(transport, 1, true)
     const firstServerSocket = Array.from(lifecycle.wss.clients)[0]
     expect(firstServerSocket).toBeDefined()
     // Note: periodic probes run on timer interval ticks; assert the arm/disarm lifecycle only.
-    const firstTimer = lifecycle.heartbeat.timer
+    const firstTimer = lifecycle.liveness.heartbeat.timer
 
     const secondClient = await connectWs(transport)
     await waitForHeartbeatLifecycle(transport, 2, true)
-    expect(lifecycle.heartbeat.timer).toBe(firstTimer)
+    expect(lifecycle.liveness.heartbeat.timer).toBe(firstTimer)
 
     firstClient.close()
     await waitForHeartbeatLifecycle(transport, 1, true)
-    expect(lifecycle.heartbeat.timer).toBe(firstTimer)
+    expect(lifecycle.liveness.heartbeat.timer).toBe(firstTimer)
 
     secondClient.close()
     await waitForHeartbeatLifecycle(transport, 0, false)
 
     const thirdClient = await connectWs(transport)
     await waitForHeartbeatLifecycle(transport, 1, true)
-    expect(lifecycle.heartbeat.timer).not.toBe(firstTimer)
+    expect(lifecycle.liveness.heartbeat.timer).not.toBe(firstTimer)
 
     thirdClient.close()
     await waitForHeartbeatLifecycle(transport, 0, false)
@@ -144,16 +146,16 @@ describe('WebSocketTransport', () => {
     transport.onConnectionClose(closeHandler)
 
     lifecycle.handleConnection(socket)
-    expect(lifecycle.heartbeatConnections.size).toBe(1)
-    expect(lifecycle.heartbeat.timer).not.toBeNull()
+    expect(lifecycle.liveness.accepted.size).toBe(1)
+    expect(lifecycle.liveness.heartbeat.timer).not.toBeNull()
 
     socket.emit('error', new Error('connection reset'))
     socket.emit('close')
 
     expect(closeHandler).toHaveBeenCalledTimes(1)
     expect(socket.close).toHaveBeenCalledTimes(1)
-    expect(lifecycle.heartbeatConnections.size).toBe(0)
-    expect(lifecycle.heartbeat.timer).toBeNull()
+    expect(lifecycle.liveness.accepted.size).toBe(0)
+    expect(lifecycle.liveness.heartbeat.timer).toBeNull()
   })
 
   it('handles request/response round-trip', async () => {

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -4,7 +4,7 @@ import { createServer as createHttpServer, type Server as HttpServer } from 'nod
 import { WebSocketServer, type WebSocket } from 'ws'
 import type { RpcTransport } from './transport'
 import { createStaticWebClientHandler } from './static-web-client-handler'
-import { RemoteRuntimeServerHeartbeat } from './remote-runtime-server-heartbeat'
+import { AcceptedSocketLiveness } from './accepted-socket-liveness'
 
 const MAX_WS_MESSAGE_BYTES = 1024 * 1024
 // Why: one desktop remote-host client can hold many concurrent streams, so keep the cap high enough that stale streams don't starve control RPCs.
@@ -48,8 +48,7 @@ export class WebSocketTransport implements RpcTransport {
   private readonly port: number
   private readonly tlsCert: string | undefined
   private readonly tlsKey: string | undefined
-  private readonly heartbeat: RemoteRuntimeServerHeartbeat
-  private readonly preAuthTimeoutMs: number
+  private readonly liveness: AcceptedSocketLiveness
   private readonly staticRoot: string | undefined
   private readonly fallbackPort: number | undefined
   private readonly preferPinnedPort: boolean
@@ -61,8 +60,6 @@ export class WebSocketTransport implements RpcTransport {
     | null = null
   // Why: maps each socket to its authenticated clientId so close can report which device disconnected.
   private wsClientIds = new Map<WebSocket, string>()
-  private heartbeatConnections = new Set<WebSocket>()
-  private preAuthTimers = new WeakMap<WebSocket, ReturnType<typeof setTimeout>>()
 
   constructor({
     host,
@@ -80,12 +77,12 @@ export class WebSocketTransport implements RpcTransport {
     this.port = port
     this.tlsCert = tlsCert
     this.tlsKey = tlsKey
-    this.heartbeat = new RemoteRuntimeServerHeartbeat(
+    this.liveness = new AcceptedSocketLiveness(
+      preAuthTimeoutMs ?? PRE_AUTH_TIMEOUT_MS,
       heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS,
       heartbeatNow,
       MAX_WS_CONNECTIONS
     )
-    this.preAuthTimeoutMs = preAuthTimeoutMs ?? PRE_AUTH_TIMEOUT_MS
     this.staticRoot = staticRoot
     this.fallbackPort = fallbackPort
     this.preferPinnedPort = preferPinnedPort === true
@@ -104,7 +101,7 @@ export class WebSocketTransport implements RpcTransport {
 
   setClientId(ws: WebSocket, clientId: string): void {
     this.wsClientIds.set(ws, clientId)
-    this.clearPreAuthTimer(ws)
+    this.liveness.authenticate(ws)
   }
 
   terminateClientConnections(clientId: string): number {
@@ -225,8 +222,7 @@ export class WebSocketTransport implements RpcTransport {
     const httpServer = this.httpServer
     this.wss = null
     this.httpServer = null
-    this.heartbeat.stop()
-    this.heartbeatConnections.clear()
+    this.liveness.stop()
 
     if (wss) {
       for (const client of wss.clients) {
@@ -253,11 +249,11 @@ export class WebSocketTransport implements RpcTransport {
   private handleConnection(ws: WebSocket): void {
     let finalized = false
     const onPong = (): void => {
-      this.heartbeat.noteAlive(ws)
+      this.liveness.noteAlive(ws)
     }
     const onMessage = (data: WebSocket.RawData, isBinary: boolean): void => {
       // Why: any inbound frame counts as proof of life, so an actively-talking client isn't reaped mid-request.
-      this.heartbeat.noteAlive(ws)
+      this.liveness.noteAlive(ws)
       const msg =
         typeof data === 'string'
           ? data
@@ -289,28 +285,13 @@ export class WebSocketTransport implements RpcTransport {
       ws.off('message', onMessage)
       ws.off('close', finalizeConnection)
       ws.off('error', onError)
-      this.clearPreAuthTimer(ws)
-      this.heartbeatConnections.delete(ws)
-      if (this.heartbeatConnections.size === 0) {
-        this.heartbeat.stop()
-      }
+      this.liveness.release(ws)
       const clientId = this.wsClientIds.get(ws) ?? null
       this.wsClientIds.delete(ws)
       const hasOtherConnections =
         clientId !== null && Array.from(this.wsClientIds.values()).includes(clientId)
       this.connectionCloseHandler?.(clientId, ws, hasOtherConnections)
     }
-
-    const preAuthTimer = setTimeout(() => {
-      if (!this.wsClientIds.has(ws)) {
-        // Why: a silent auto-ponging client would otherwise hold a finite mobile slot forever without starting the E2EE handshake.
-        ws.terminate()
-      }
-    }, this.preAuthTimeoutMs)
-    if (typeof preAuthTimer.unref === 'function') {
-      preAuthTimer.unref()
-    }
-    this.preAuthTimers.set(ws, preAuthTimer)
 
     ws.on('pong', onPong)
     ws.on('message', onMessage)
@@ -320,21 +301,7 @@ export class WebSocketTransport implements RpcTransport {
     ws.on('error', onError)
 
     // Why: install lifecycle ownership before periodic heartbeat ticks can observe this socket.
-    this.heartbeatConnections.add(ws)
-    this.heartbeat.noteAlive(ws)
-    if (this.heartbeatConnections.size === 1) {
-      // Unauthenticated sockets are protected by the pre-auth timeout; heartbeat probes begin only
-      // after E2EE binds a client id, avoiding control frames during the handshake.
-      this.heartbeat.start(() => this.wsClientIds.keys())
-    }
-  }
-
-  private clearPreAuthTimer(ws: WebSocket): void {
-    const timer = this.preAuthTimers.get(ws)
-    if (timer) {
-      clearTimeout(timer)
-      this.preAuthTimers.delete(ws)
-    }
+    this.liveness.accept(ws)
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​156 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​127 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​43 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |

<!-- /orca-pr-loc -->

## Summary

Follow-up to #17810. That fix made heartbeat probing conditional on authentication, which left a latent coupling: a socket escaped liveness policing by *absence* (not being in `wsClientIds`), so a future long-lived unauthenticated flow would silently opt out of both the pre-auth deadline and the heartbeat reaper, leaking capped connection slots.

This extracts `AcceptedSocketLiveness`, which owns both bounds and their transitions:

- `accept(ws)` — arms the pre-auth deadline and starts the shared heartbeat timer on the first socket
- `authenticate(ws)` — atomically swaps the deadline for heartbeat membership
- `release(ws)` / `stop()` — clears everything, stopping the timer with the last socket

The invariant is now enforced by construction: between accept and release, a socket is always under exactly one bound. A future exemption has to be an explicit, reviewable method on this class. `ws-transport.ts` drops `heartbeatConnections`, `preAuthTimers`, and `clearPreAuthTimer` (~50 lines).

Also fixes a small latent window: `stop()` now clears membership, so a fast transport stop/start can no longer sweep terminated sockets whose close events have not flushed yet.

## Behavior

No wire change; no client change needed. Pre-auth timing, probe cadence, miss budget, and reap semantics are unchanged. The only behavioral deltas: probe membership is tracked by the component (kept in lockstep by `setClientId`), and the stale-probe-after-stop fix above.

## Validation

- New `accepted-socket-liveness.test.ts` pins the invariant: a never-authenticated socket is terminated at the deadline and never probed; authenticate swaps bounds; release/stop clear timers and membership; a restarted sweep cannot probe stale sockets.
- Heartbeat/transport suites (6 files): 47/47 passed, re-run after the pre-commit format pass.
- Transport-adjacent suites (mobile IPC, static-web, bind-host, socket wiring, auth ACL, relay E2EE integration, all of `runtime-rpc/`): 208/208 passed.
- `pnpm tc` passed; changed-code quality gate (oxlint, type-aware, React Doctor): 0 findings.
- Reliability-gate oracle assertions for the #17810 invariant pass unmodified.