### PR TITLE
fix(i18n): localize remaining onboarding UI

### DIFF
--- a/src/renderer/src/components/onboarding/IntegrationsStep.tsx
+++ b/src/renderer/src/components/onboarding/IntegrationsStep.tsx
@@ -211,17 +211,52 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
         onOpenChange={setDialogOpen}
         overlayClassName="z-[110]"
         contentClassName="z-[120]"
-        connectLabel="Add Linear access"
+        connectLabel={translate(
+          'components.onboarding.integrations.linear.submitAccess',
+          'Add Linear access'
+        )}
       />
     </>
   )
 }
 
 const CAPABILITIES = [
-  'Start a workspace from any GitHub issue or pull request, prefilled with its title and context',
-  'Browse GitHub issues and pull requests in the Tasks view without leaving Orca',
-  'See issue state, review status, and CI checks on every worktree',
-  'Read, comment on, and merge pull requests without leaving Orca'
+  {
+    key: 'components.onboarding.integrations.capabilities.startWorkspaceFromIssue',
+    get value() {
+      return translate(
+        'components.onboarding.integrations.capabilities.startWorkspaceFromIssue',
+        'Start a workspace from any GitHub issue or pull request, prefilled with its title and context'
+      )
+    }
+  },
+  {
+    key: 'components.onboarding.integrations.capabilities.browseIssues',
+    get value() {
+      return translate(
+        'components.onboarding.integrations.capabilities.browseIssues',
+        'Browse GitHub issues and pull requests in the Tasks view without leaving Orca'
+      )
+    }
+  },
+  {
+    key: 'components.onboarding.integrations.capabilities.reviewStatus',
+    get value() {
+      return translate(
+        'components.onboarding.integrations.capabilities.reviewStatus',
+        'See issue state, review status, and CI checks on every worktree'
+      )
+    }
+  },
+  {
+    key: 'components.onboarding.integrations.capabilities.managePullRequests',
+    get value() {
+      return translate(
+        'components.onboarding.integrations.capabilities.managePullRequests',
+        'Read, comment on, and merge pull requests without leaving Orca'
+      )
+    }
+  }
 ] as const
 
 export function IntegrationsStep(): React.JSX.Element {
@@ -234,10 +269,10 @@ export function IntegrationsStep(): React.JSX.Element {
   return (
     <div className="space-y-6">
       <ul className="-mt-6 space-y-1.5 text-[14px] leading-relaxed text-muted-foreground">
-        {CAPABILITIES.map((line) => (
-          <li key={line} className="flex gap-2.5">
+        {CAPABILITIES.map(({ key, value }) => (
+          <li key={key} className="flex gap-2.5">
             <span className="mt-2 size-1 shrink-0 rounded-full bg-muted-foreground" aria-hidden />
-            <span>{line}</span>
+            <span>{value}</span>
           </li>
         ))}
       </ul>

--- a/src/renderer/src/components/onboarding/IntegrationsStep.tsx
+++ b/src/renderer/src/components/onboarding/IntegrationsStep.tsx
@@ -223,39 +223,20 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
 const CAPABILITIES = [
   {
     key: 'components.onboarding.integrations.capabilities.startWorkspaceFromIssue',
-    get value() {
-      return translate(
-        'components.onboarding.integrations.capabilities.startWorkspaceFromIssue',
-        'Start a workspace from any GitHub issue or pull request, prefilled with its title and context'
-      )
-    }
+    fallback:
+      'Start a workspace from any GitHub issue or pull request, prefilled with its title and context'
   },
   {
     key: 'components.onboarding.integrations.capabilities.browseIssues',
-    get value() {
-      return translate(
-        'components.onboarding.integrations.capabilities.browseIssues',
-        'Browse GitHub issues and pull requests in the Tasks view without leaving Orca'
-      )
-    }
+    fallback: 'Browse GitHub issues and pull requests in the Tasks view without leaving Orca'
   },
   {
     key: 'components.onboarding.integrations.capabilities.reviewStatus',
-    get value() {
-      return translate(
-        'components.onboarding.integrations.capabilities.reviewStatus',
-        'See issue state, review status, and CI checks on every worktree'
-      )
-    }
+    fallback: 'See issue state, review status, and CI checks on every worktree'
   },
   {
     key: 'components.onboarding.integrations.capabilities.managePullRequests',
-    get value() {
-      return translate(
-        'components.onboarding.integrations.capabilities.managePullRequests',
-        'Read, comment on, and merge pull requests without leaving Orca'
-      )
-    }
+    fallback: 'Read, comment on, and merge pull requests without leaving Orca'
   }
 ] as const
 
@@ -269,10 +250,10 @@ export function IntegrationsStep(): React.JSX.Element {
   return (
     <div className="space-y-6">
       <ul className="-mt-6 space-y-1.5 text-[14px] leading-relaxed text-muted-foreground">
-        {CAPABILITIES.map(({ key, value }) => (
+        {CAPABILITIES.map(({ key, fallback }) => (
           <li key={key} className="flex gap-2.5">
             <span className="mt-2 size-1 shrink-0 rounded-full bg-muted-foreground" aria-hidden />
-            <span>{value}</span>
+            <span>{translate(key, fallback)}</span>
           </li>
         ))}
       </ul>

--- a/src/renderer/src/components/onboarding/IntegrationsStep.tsx
+++ b/src/renderer/src/components/onboarding/IntegrationsStep.tsx
@@ -212,7 +212,7 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
         overlayClassName="z-[110]"
         contentClassName="z-[120]"
         connectLabel={translate(
-          'components.onboarding.integrations.linear.submitAccess',
+          'auto.components.onboarding.IntegrationsStep.04ef416712',
           'Add Linear access'
         )}
       />

--- a/src/renderer/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingFlow.tsx
@@ -90,11 +90,31 @@ const stepCopy = {
 } as const
 
 const stepTooltipLabels = {
-  agent: 'Default Agent',
-  theme: 'Appearance',
-  windows_terminal: 'Windows Terminal',
-  notifications: 'Notifications',
-  integrations: 'Integrations'
+  agent: {
+    get value() {
+      return translate('components.onboarding.flow.stepTooltip.agent', 'Default Agent')
+    }
+  },
+  theme: {
+    get value() {
+      return translate('components.onboarding.flow.stepTooltip.theme', 'Appearance')
+    }
+  },
+  windows_terminal: {
+    get value() {
+      return translate('components.onboarding.flow.stepTooltip.windowsTerminal', 'Windows Terminal')
+    }
+  },
+  notifications: {
+    get value() {
+      return translate('components.onboarding.flow.stepTooltip.notifications', 'Notifications')
+    }
+  },
+  integrations: {
+    get value() {
+      return translate('components.onboarding.flow.stepTooltip.integrations', 'Integrations')
+    }
+  }
 } as const
 
 type OnboardingFlowProps = {
@@ -113,7 +133,10 @@ export default function OnboardingFlow({
   const shouldShowSkipToProjectSetup = currentStep.id !== 'notifications'
   const shouldShowFooterBusy = Boolean(busyLabel)
   const footerPrimaryLabel =
-    busyLabel ?? (currentStep.id === 'notifications' ? 'Add your first project' : 'Continue')
+    busyLabel ??
+    (currentStep.id === 'notifications'
+      ? translate('components.onboarding.flow.actions.addFirstProject', 'Add your first project')
+      : translate('components.onboarding.flow.actions.continue', 'Continue'))
   const [skipConfirmOpen, setSkipConfirmOpen] = useState(false)
   const skipConfirmAdvancedViaRef = useRef<'button' | 'keyboard'>('button')
   const { next: flowNext, dismissOnboarding: flowDismissOnboarding } = flow
@@ -218,6 +241,7 @@ export default function OnboardingFlow({
               {flow.progressSteps.map(({ step, index: realStepIndex }, progressIdx) => {
                 const isActive = realStepIndex === stepIndex
                 const isDone = realStepIndex < stepIndex
+                const stepTooltipLabel = stepTooltipLabels[step.id].value
                 return (
                   <Tooltip key={step.id}>
                     <TooltipTrigger asChild>
@@ -236,14 +260,14 @@ export default function OnboardingFlow({
                         aria-label={translate(
                           'auto.components.onboarding.OnboardingFlow.adaa0aa627',
                           'Go to onboarding step {{value0}}: {{value1}}',
-                          { value0: progressIdx + 1, value1: stepTooltipLabels[step.id] }
+                          { value0: progressIdx + 1, value1: stepTooltipLabel }
                         )}
                         aria-current={isActive ? 'step' : undefined}
                         onClick={() => flow.jumpToStep(realStepIndex)}
                       />
                     </TooltipTrigger>
                     <TooltipContent side="top" sideOffset={8} style={{ zIndex: 110 }}>
-                      {stepTooltipLabels[step.id]}
+                      {stepTooltipLabel}
                     </TooltipContent>
                   </Tooltip>
                 )

--- a/src/renderer/src/components/onboarding/OnboardingSkipConfirmationDialog.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingSkipConfirmationDialog.tsx
@@ -22,8 +22,12 @@ export const ONBOARDING_SKIP_CONFIRMATION_COPY = {
       "It won't take long!"
     )
   },
-  skipLabel: 'Skip',
-  keepGoingLabel: 'No, keep going'
+  get skipLabel() {
+    return translate('components.onboarding.skipConfirmation.skip', 'Skip')
+  },
+  get keepGoingLabel() {
+    return translate('components.onboarding.skipConfirmation.keepGoing', 'No, keep going')
+  }
 } as const
 
 export function OnboardingSkipConfirmationDialog(props: {

--- a/src/renderer/src/components/onboarding/ThemeStep.tsx
+++ b/src/renderer/src/components/onboarding/ThemeStep.tsx
@@ -195,19 +195,19 @@ export function ThemeStep({ theme, onThemeChange, settings, updateSettings }: Th
     {
       id: 'system',
       label: translate('auto.components.onboarding.ThemeStep.827ea7b4a2', 'System'),
-      hint: 'Match OS',
+      hint: translate('components.onboarding.theme.hints.system', 'Match OS'),
       icon: Monitor
     },
     {
       id: 'dark',
       label: translate('auto.components.onboarding.ThemeStep.fa7b673ea9', 'Dark'),
-      hint: 'Easy on the eyes',
+      hint: translate('components.onboarding.theme.hints.dark', 'Easy on the eyes'),
       icon: Moon
     },
     {
       id: 'light',
       label: translate('auto.components.onboarding.ThemeStep.ad192706e6', 'Light'),
-      hint: 'Bright & crisp',
+      hint: translate('components.onboarding.theme.hints.light', 'Bright & crisp'),
       icon: Sun
     }
   ]

--- a/src/renderer/src/components/onboarding/use-onboarding-flow-actions.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow-actions.ts
@@ -117,7 +117,12 @@ export function useOnboardingFlowActions({
         if (result.ok) {
           trackCurrentStepCompleted(advancedVia)
           if (currentStep.id === 'notifications') {
-            setBusyLabel('Opening Add Project...')
+            setBusyLabel(
+              translate(
+                'components.onboarding.flow.actions.openingAddProject',
+                'Opening Add Project...'
+              )
+            )
             const closed = await closeWith('completed', ONBOARDING_FINAL_STEP, 'add_project_modal')
             if (closed) {
               openModal('add-repo')
@@ -190,7 +195,9 @@ export function useOnboardingFlowActions({
     const stepId = currentStep.id
     const stepNumber = currentStep.stepNumber
     const valueKind = currentStep.valueKind
-    setBusyLabel('Opening Add Project...')
+    setBusyLabel(
+      translate('components.onboarding.flow.actions.openingAddProject', 'Opening Add Project...')
+    )
     try {
       const closed = await closeWith('completed', ONBOARDING_FINAL_STEP, 'add_project_modal')
       if (!closed) {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16555,6 +16555,44 @@
     }
   },
   "components": {
+    "onboarding": {
+      "flow": {
+        "stepTooltip": {
+          "agent": "Default Agent",
+          "theme": "Appearance",
+          "windowsTerminal": "Windows Terminal",
+          "notifications": "Notifications",
+          "integrations": "Integrations"
+        },
+        "actions": {
+          "addFirstProject": "Add your first project",
+          "continue": "Continue",
+          "openingAddProject": "Opening Add Project..."
+        }
+      },
+      "skipConfirmation": {
+        "skip": "Skip",
+        "keepGoing": "No, keep going"
+      },
+      "theme": {
+        "hints": {
+          "system": "Match OS",
+          "dark": "Easy on the eyes",
+          "light": "Bright & crisp"
+        }
+      },
+      "integrations": {
+        "linear": {
+          "submitAccess": "Add Linear access"
+        },
+        "capabilities": {
+          "startWorkspaceFromIssue": "Start a workspace from any GitHub issue or pull request, prefilled with its title and context",
+          "browseIssues": "Browse GitHub issues and pull requests in the Tasks view without leaving Orca",
+          "reviewStatus": "See issue state, review status, and CI checks on every worktree",
+          "managePullRequests": "Read, comment on, and merge pull requests without leaving Orca"
+        }
+      }
+    },
     "jiraUserPicker": {
       "select": "Select {{value0}}",
       "search": "Search users",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16582,9 +16582,6 @@
         }
       },
       "integrations": {
-        "linear": {
-          "submitAccess": "Add Linear access"
-        },
         "capabilities": {
           "startWorkspaceFromIssue": "Start a workspace from any GitHub issue or pull request, prefilled with its title and context",
           "browseIssues": "Browse GitHub issues and pull requests in the Tasks view without leaving Orca",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14595,9 +14595,6 @@
         }
       },
       "integrations": {
-        "linear": {
-          "submitAccess": "Linear 액세스 추가"
-        },
         "capabilities": {
           "startWorkspaceFromIssue": "GitHub 이슈나 PR에서 제목과 컨텍스트가 미리 채워진 워크스페이스를 시작합니다",
           "browseIssues": "Orca를 떠나지 않고 작업 화면에서 GitHub 이슈와 PR을 탐색합니다",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14568,6 +14568,44 @@
     }
   },
   "components": {
+    "onboarding": {
+      "flow": {
+        "stepTooltip": {
+          "agent": "기본 Agent",
+          "theme": "테마",
+          "windowsTerminal": "Windows 터미널",
+          "notifications": "알림",
+          "integrations": "연동"
+        },
+        "actions": {
+          "addFirstProject": "첫 프로젝트 추가",
+          "continue": "계속",
+          "openingAddProject": "프로젝트 추가 화면을 여는 중…"
+        }
+      },
+      "skipConfirmation": {
+        "skip": "건너뛰기",
+        "keepGoing": "아니요, 계속하기"
+      },
+      "theme": {
+        "hints": {
+          "system": "OS 설정에 맞춤",
+          "dark": "눈이 편안한 화면",
+          "light": "밝고 선명한 화면"
+        }
+      },
+      "integrations": {
+        "linear": {
+          "submitAccess": "Linear 액세스 추가"
+        },
+        "capabilities": {
+          "startWorkspaceFromIssue": "GitHub 이슈나 PR에서 제목과 컨텍스트가 미리 채워진 워크스페이스를 시작합니다",
+          "browseIssues": "Orca를 떠나지 않고 작업 화면에서 GitHub 이슈와 PR을 탐색합니다",
+          "reviewStatus": "모든 워크트리에서 이슈 상태, 리뷰 상태 및 CI 체크를 확인합니다",
+          "managePullRequests": "Orca를 떠나지 않고 PR을 읽고, 댓글을 달고, 병합합니다"
+        }
+      }
+    },
     "native-chat": {
       "composer": {
         "imageUnsupported": "이 에이전트는 이미지 붙여넣기를 지원하지 않습니다.",


### PR DESCRIPTION
## ELI5

Some onboarding text was still hardcoded in English, so Korean users could see a mix of Korean and English during setup.

This change routes those strings through Orca's existing localization system and adds reviewed Korean translations.

## What Changed

- Localized remaining hardcoded user-facing strings in the onboarding flow.
- Added semantic onboarding entries to `en.json` and `ko.json`.
- Preserved the existing English copy as the fallback.
- Verified the affected onboarding behavior with the existing test suite.
- Reviewed the resulting Korean UI in the running Electron app.

## Why

Issue #17913 identified onboarding as one of the surfaces where hardcoded user-facing strings still bypass localization.

This PR addresses only the onboarding portion so the change stays small and reviewable.

## Linked Issue

Part of #17913

## Localization Notes

- Translated `Appearance` as `테마` in the onboarding step navigation because the corresponding `ThemeStep` specifically presents system, dark, and light theme choices.
- Kept `Agent` in English in the `기본 Agent` label as a deliberate developer-facing terminology choice for this onboarding context.
- Preserved technical literals such as `GitHub`, `PR`, `CI`, `Orca`, `Linear`, `Windows`, and `OS`.
- Reviewed Korean wording according to its UI role, including buttons, tooltips, theme hints, confirmation actions, and integration descriptions.

## Visual Proof

### Theme step

| Before | After |
| --- | --- |
|<img width="480" alt="th-before" src="https://github.com/user-attachments/assets/2702cd3e-e512-4a10-bf26-1efe09fe11d9" />|<img width="480" alt="th-after" src="https://github.com/user-attachments/assets/e3910657-d246-445a-b9ce-bb1b77a2a302" />|

### Skip confirmation

| Before | After |
| --- | --- |
| <img width="480" alt="bu-before" src="https://github.com/user-attachments/assets/a39f4b23-5225-4cdf-8a74-f3efb2e15ed3" />|<img width="480" alt="bu-after" src="https://github.com/user-attachments/assets/427a0457-e743-4b11-814e-e58e30159bd0" />|


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm run verify:localization-catalog`
- [x] `pnpm run verify:localization-extraction`
- [x] `pnpm run verify:localization-coverage`
- [x] Onboarding tests — 91 passed
- [x] Reviewed the Korean onboarding flow in the running Electron app

## AI Disclosure

Codex was used for implementation and code review assistance. ChatGPT was used to review Korean localization wording, with the final translations manually verified in the running Orca UI.

## Review

- **Cross-platform / SSH / Remote:** Localization-only UI changes; no platform-specific, execution, SSH, or remote behavior changed.
- **Agent / integrations:** No agent or integration behavior changed.
- **Performance:** No meaningful runtime impact expected.
- **UI quality:** Korean strings were reviewed in the running Electron app for fit, readability, and context.
- **Security:** No security-sensitive behavior changed.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Existing Korean onboarding terminology outside the hardcoded-string scope of this PR is intentionally unchanged.
- No release or version changes are included.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why, including an ELI5.
- [x] Before/after screenshots or videos are attached for the affected UI.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and compatibility impact considered.
- [x] Full `pnpm lint`, `pnpm test`, and `pnpm build` suite completed locally.

## Author

X: @mors119
