### PR TITLE
fix(native-chat): ignore stale restored working status

### DIFF
--- a/src/renderer/src/components/native-chat/use-native-chat-hook-status.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-hook-status.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { resolveNativeChatHookState } from './use-native-chat-hook-status'
+
+describe('resolveNativeChatHookState', () => {
+  const now = 1_000_000
+
+  it('does not treat a restored working row as live activity', () => {
+    expect(
+      resolveNativeChatHookState(
+        {
+          state: 'working',
+          workingMode: undefined,
+          updatedAt: now,
+          restoredUnconfirmed: true
+        },
+        now
+      )
+    ).toBeNull()
+  })
+
+  it('keeps confirmed working activity live', () => {
+    expect(
+      resolveNativeChatHookState(
+        {
+          state: 'working',
+          workingMode: undefined,
+          updatedAt: now,
+          restoredUnconfirmed: false
+        },
+        now
+      )
+    ).toBe('working')
+  })
+
+  it('continues to suppress monitoring rows', () => {
+    expect(
+      resolveNativeChatHookState(
+        {
+          state: 'working',
+          workingMode: 'monitoring',
+          updatedAt: now,
+          restoredUnconfirmed: false
+        },
+        now
+      )
+    ).toBeNull()
+  })
+
+  it('does not keep an expired working row live', () => {
+    expect(
+      resolveNativeChatHookState(
+        {
+          state: 'working',
+          workingMode: undefined,
+          updatedAt: now - 30 * 60 * 1000 - 1,
+          restoredUnconfirmed: false
+        },
+        now
+      )
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-hook-status.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-hook-status.ts
@@ -1,16 +1,39 @@
 import { useAppStore } from '../../store'
-import type { AgentStatusState } from '../../../../shared/agent-status-types'
+import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry,
+  type AgentStatusState
+} from '../../../../shared/agent-status-types'
+
+/**
+ * Hydrated nonterminal rows are only recovery evidence until a live hook event
+ * confirms the turn. They must not make Native Chat look permanently busy.
+ */
+export function resolveNativeChatHookState(
+  entry:
+    | Pick<AgentStatusEntry, 'state' | 'workingMode' | 'updatedAt' | 'restoredUnconfirmed'>
+    | undefined,
+  now = Date.now()
+): AgentStatusState | null {
+  if (!entry || !isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)) {
+    return null
+  }
+  return entry.state === 'working' && entry.workingMode === 'monitoring' ? null : entry.state
+}
 
 export function useNativeChatHookStatus(
   paneKey: string
 ): readonly [AgentStatusState | null, number | null, boolean] {
+  // Freshness is time-based; subscribe to the scheduler epoch so a silent
+  // working row stops driving Native Chat when its TTL expires.
+  const agentStatusEpoch = useAppStore((store) => store.agentStatusEpoch)
+  void agentStatusEpoch
   // Why: primitive selectors keep unrelated pane/status updates from rerendering
   // native chat while still exposing the three fields used for reconciliation.
   const state = useAppStore((store) => {
     const entry = store.agentStatusByPaneKey[paneKey]
-    return entry?.state === 'working' && entry.workingMode === 'monitoring'
-      ? null
-      : (entry?.state ?? null)
+    return resolveNativeChatHookState(entry)
   })
   const stateStartedAt = useAppStore(
     (store) => store.agentStatusByPaneKey[paneKey]?.stateStartedAt ?? null

--- a/src/renderer/src/components/native-chat/use-native-chat-hook-status.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-hook-status.ts
@@ -1,6 +1,5 @@
 import { useAppStore } from '../../store'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
-import { getAgentStatusEpochNow } from '@/lib/agent-status-epoch-clock'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusEntry,
@@ -29,14 +28,12 @@ export function useNativeChatHookStatus(
   // Freshness is time-based; subscribe to the scheduler epoch so a silent
   // working row stops driving Native Chat when its TTL expires.
   const agentStatusEpoch = useAppStore((store) => store.agentStatusEpoch)
-  // Use the same epoch-scoped timestamp as other freshness consumers so a
-  // render cannot disagree with the sidebar at the stale boundary.
-  const agentStatusNow = getAgentStatusEpochNow(agentStatusEpoch)
+  void agentStatusEpoch
   // Why: primitive selectors keep unrelated pane/status updates from rerendering
   // native chat while still exposing the three fields used for reconciliation.
   const state = useAppStore((store) => {
     const entry = store.agentStatusByPaneKey[paneKey]
-    return resolveNativeChatHookState(entry, agentStatusNow)
+    return resolveNativeChatHookState(entry)
   })
   const stateStartedAt = useAppStore(
     (store) => store.agentStatusByPaneKey[paneKey]?.stateStartedAt ?? null

--- a/src/renderer/src/components/native-chat/use-native-chat-hook-status.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-hook-status.ts
@@ -1,5 +1,6 @@
 import { useAppStore } from '../../store'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import { getAgentStatusEpochNow } from '@/lib/agent-status-epoch-clock'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusEntry,
@@ -28,12 +29,14 @@ export function useNativeChatHookStatus(
   // Freshness is time-based; subscribe to the scheduler epoch so a silent
   // working row stops driving Native Chat when its TTL expires.
   const agentStatusEpoch = useAppStore((store) => store.agentStatusEpoch)
-  void agentStatusEpoch
+  // Use the same epoch-scoped timestamp as other freshness consumers so a
+  // render cannot disagree with the sidebar at the stale boundary.
+  const agentStatusNow = getAgentStatusEpochNow(agentStatusEpoch)
   // Why: primitive selectors keep unrelated pane/status updates from rerendering
   // native chat while still exposing the three fields used for reconciliation.
   const state = useAppStore((store) => {
     const entry = store.agentStatusByPaneKey[paneKey]
-    return resolveNativeChatHookState(entry)
+    return resolveNativeChatHookState(entry, agentStatusNow)
   })
   const stateStartedAt = useAppStore(
     (store) => store.agentStatusByPaneKey[paneKey]?.stateStartedAt ?? null

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session-visibility.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session-visibility.test.ts
@@ -122,7 +122,7 @@ describe('useNativeChatLiveSession visibility', () => {
   it('unsubscribes on hide, retains committed messages, and rejects hidden work', async () => {
     useAppStore.setState({
       agentStatusByPaneKey: {
-        [BASE_ARGS.paneKey]: { state: 'working', stateStartedAt: 100 }
+        [BASE_ARGS.paneKey]: { state: 'working', stateStartedAt: 100, updatedAt: Date.now() }
       }
     } as never)
     await render(BASE_ARGS)

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
@@ -385,7 +385,9 @@ describe('useNativeChatLiveSession — transport routing', () => {
 
   it("self-heals a stale 'working' hook once the turn-complete marker lands", async () => {
     useAppStore.setState({
-      agentStatusByPaneKey: { [PANE]: { state: 'working', stateStartedAt: 1 } as never }
+      agentStatusByPaneKey: {
+        [PANE]: { state: 'working', stateStartedAt: 1, updatedAt: Date.now() } as never
+      }
     })
     const transport = getMockTransport('env-1')
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
@@ -403,7 +405,9 @@ describe('useNativeChatLiveSession — transport routing', () => {
 
   it('stops foreground working UI when Claude enters monitoring', async () => {
     useAppStore.setState({
-      agentStatusByPaneKey: { [PANE]: { state: 'working', stateStartedAt: 1 } as never }
+      agentStatusByPaneKey: {
+        [PANE]: { state: 'working', stateStartedAt: 1, updatedAt: Date.now() } as never
+      }
     })
     const transport = getMockTransport('env-1')
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
@@ -419,7 +423,12 @@ describe('useNativeChatLiveSession — transport routing', () => {
     await act(async () => {
       useAppStore.setState({
         agentStatusByPaneKey: {
-          [PANE]: { state: 'working', workingMode: 'monitoring', stateStartedAt: 1 } as never
+          [PANE]: {
+            state: 'working',
+            workingMode: 'monitoring',
+            stateStartedAt: 1,
+            updatedAt: Date.now()
+          } as never
         }
       })
     })
@@ -429,7 +438,9 @@ describe('useNativeChatLiveSession — transport routing', () => {
 
   it('applies a lifecycle-only append after the final message frame', async () => {
     useAppStore.setState({
-      agentStatusByPaneKey: { [PANE]: { state: 'working', stateStartedAt: 1 } as never }
+      agentStatusByPaneKey: {
+        [PANE]: { state: 'working', stateStartedAt: 1, updatedAt: Date.now() } as never
+      }
     })
     const transport = getMockTransport('env-1')
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
@@ -456,7 +467,9 @@ describe('useNativeChatLiveSession — transport routing', () => {
 
   it('applies a terminal-side interruption frame without a local Stop action', async () => {
     useAppStore.setState({
-      agentStatusByPaneKey: { [PANE]: { state: 'working', stateStartedAt: 1 } as never }
+      agentStatusByPaneKey: {
+        [PANE]: { state: 'working', stateStartedAt: 1, updatedAt: Date.now() } as never
+      }
     })
     const transport = getMockTransport('env-1')
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
@@ -483,7 +496,9 @@ describe('useNativeChatLiveSession — transport routing', () => {
 
   it('does not let an older pagination read rewind a live completion', async () => {
     useAppStore.setState({
-      agentStatusByPaneKey: { [PANE]: { state: 'working', stateStartedAt: 1 } as never }
+      agentStatusByPaneKey: {
+        [PANE]: { state: 'working', stateStartedAt: 1, updatedAt: Date.now() } as never
+      }
     })
     const transport = getMockTransport('env-1')
     const many = Array.from({ length: NATIVE_CHAT_INITIAL_LIMIT }, (_unused, index) =>
@@ -529,7 +544,9 @@ describe('useNativeChatLiveSession — transport routing', () => {
 
   it('reconciles completion from a reconnect snapshot', async () => {
     useAppStore.setState({
-      agentStatusByPaneKey: { [PANE]: { state: 'working', stateStartedAt: 10 } as never }
+      agentStatusByPaneKey: {
+        [PANE]: { state: 'working', stateStartedAt: 10, updatedAt: Date.now() } as never
+      }
     })
     const transport = getMockTransport('env-1')
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
@@ -557,7 +574,9 @@ describe('useNativeChatLiveSession — transport routing', () => {
 
   it('reconciles interruption from a reconnect snapshot', async () => {
     useAppStore.setState({
-      agentStatusByPaneKey: { [PANE]: { state: 'working', stateStartedAt: 10 } as never }
+      agentStatusByPaneKey: {
+        [PANE]: { state: 'working', stateStartedAt: 10, updatedAt: Date.now() } as never
+      }
     })
     const transport = getMockTransport('env-1')
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
@@ -708,7 +727,9 @@ describe('useNativeChatLiveSession — notFound retry (#8401)', () => {
     const transport = getMockTransport('env-1', { autoSnapshot: false })
     transport.readSession.mockResolvedValue({ error: 'No transcript found', notFound: true })
     useAppStore.setState({
-      agentStatusByPaneKey: { [PANE]: { state: 'working', stateStartedAt: 1 } }
+      agentStatusByPaneKey: {
+        [PANE]: { state: 'working', stateStartedAt: 1, updatedAt: Date.now() }
+      }
     } as never)
 
     await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## Summary
- ignore `restoredUnconfirmed` and expired hook rows when deriving Native Chat activity
- subscribe Native Chat to the agent-status freshness epoch so silent rows decay after the existing TTL
- add regression coverage for restored, confirmed, monitoring, and expired statuses

## Root cause
Startup hydration marks old nonterminal hook rows as `restoredUnconfirmed`, but Native Chat's hook-status selector treated them as live `working` state. That left the Stop/typing state stuck after an hourly update or restart even when the agent had finished earlier.

## Validation
- `pnpm test src/renderer/src/components/native-chat/use-native-chat-hook-status.test.ts`
- `./node_modules/.bin/tsc --noEmit -p config/tsconfig.tc.web.json`
- `./node_modules/.bin/oxlint src/renderer/src/components/native-chat/use-native-chat-hook-status.ts src/renderer/src/components/native-chat/use-native-chat-hook-status.test.ts`
- Electron/CDP: attached to the target worktree instance, ran a real `codex exec` session, observed the visible working state and live hook row, then observed the row disappear after completion and the worktree return to Active.
## ELI5

Sometimes Orca reopened a chat and remembered that an agent had been working, even though that old status was only a recovery hint. The chat could then stay stuck showing “Stop” and typing forever. This change treats that remembered status as idle until a fresh agent event confirms the agent is really working.

## User-facing before / after

**Before:** After reopening or restoring a session, Native Chat could incorrectly show the Stop button and typing indicator indefinitely, even after the agent had already finished.

**After:** A freshly confirmed working agent still shows Stop and typing. A restored-but-unconfirmed working row now shows the normal Send button and idle state, so the composer is usable again.

### Before — confirmed working state

![Confirmed working — Stop and typing](https://github.com/user-attachments/assets/beeba7e2-3ba0-4358-a341-01106fe4fcc3)

### After — restored status treated as idle

![Restored-unconfirmed — Send and idle](https://github.com/user-attachments/assets/b0073db1-09ad-4aa8-9c70-0441e954276d)

### Idle baseline

![Idle baseline — Send](https://github.com/user-attachments/assets/62936713-0a9e-482b-899a-7144462089d3)