### PR TITLE
fix(macos): avoid duplicate synthetic text input

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -2664,7 +2664,6 @@ private enum Input {
                 throw ProviderError.coded("accessibility_error", "failed to create keyboard event")
             }
             down.keyboardSetUnicodeString(stringLength: 1, unicodeString: &char)
-            up.keyboardSetUnicodeString(stringLength: 1, unicodeString: &char)
             down.post(tap: .cghidEventTap)
             up.post(tap: .cghidEventTap)
         }

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentEntrypointSourceSafetyTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentEntrypointSourceSafetyTests.swift
@@ -34,6 +34,13 @@ final class AgentEntrypointSourceSafetyTests: XCTestCase {
         XCTAssertTrue(source.contains("event.flags = flags\n        event.postToPid(pid)"))
     }
 
+    func testSyntheticTextOnlyCarriesUnicodePayloadOnKeyDown() throws {
+        let source = try agentEntrypointSource()
+
+        XCTAssertTrue(source.contains("down.keyboardSetUnicodeString(stringLength: 1, unicodeString: &char)"))
+        XCTAssertFalse(source.contains("up.keyboardSetUnicodeString(stringLength: 1, unicodeString: &char)"))
+    }
+
     private func agentEntrypointSource() throws -> String {
         let testFile = URL(fileURLWithPath: #filePath)
         let packageRoot = testFile


### PR DESCRIPTION
## ELI5

A macOS computer-use typing action could insert the same text twice in Electron editors.

## What Changed

Removed the Unicode text payload from the synthetic key-up event while keeping it on key-down.

## Why

Both halves of the synthetic key pair carried insertion data, so Electron contentEditable controls could process the text twice. A key-up event should release the key without carrying a second text payload.

## Linked Issue

Fixes #17942

## Visual Proof

N/A - this is a native event-delivery correction with no UI rendering or layout change.

## Testing

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

Added a focused macOS source-safety regression test. The test and native XCTest require macOS; Ubuntu verification covered the baseline failure condition and final key-down-only invariant, while upstream CI must provide the native execution check.

## Review

@AmethystLiang @nwparker

## Notes

Security: no new input surface. Cross-platform support: the change is isolated to the macOS native provider; Linux and Windows paths are unchanged. Remote SSH, mobile, and Git provider behavior are unchanged. Performance impact is limited to correcting the existing synthetic event payload.

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)