### PR TITLE
fix(ssh): log an unanswered native-deps probe instead of launching silently

### DIFF
--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -854,10 +854,17 @@ async function probeRequiredNativeDeps(
       return { status: 'unverifiable', missing: [] }
     }
     return { status: 'blocked', missing }
-  } catch {
+  } catch (error) {
     signal?.throwIfAborted()
     // Why: an unanswered probe says nothing about the deps; reporting MISSING here reset and
     // recompiled healthy relays, turning one dropped exec channel into a multi-minute reconnect.
+    // Why: the wrongful rebuild was the only visible symptom, so without this line a dropped exec
+    // channel leaves no trace at all.
+    console.warn(
+      `[ssh-relay] Native deps probe unanswered at ${remoteDir}; treating as unverifiable: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
     return { status: 'unverifiable', missing: [] }
   }
 }

--- a/src/main/ssh/ssh-relay-native-deps-probe-verdict.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-probe-verdict.test.ts
@@ -153,6 +153,11 @@ describe('native-deps repair probe verdicts', () => {
     expect(warnings().some((message) => message.includes('Repairing missing native deps'))).toBe(
       false
     )
+    // Why: the wrongful rebuild used to be the only visible symptom of a dropped exec channel.
+    expect(
+      warnings().some((message) => message.includes('Native deps probe unanswered')),
+      'an unanswered probe must still leave a trace'
+    ).toBe(true)
     expect(commands.some((command) => command.includes(NODE_PTY_RESET))).toBe(false)
     expect(commands.some((command) => command.includes(WATCHER_RESET))).toBe(false)
     expect(commands.some((command) => command.includes('npm install'))).toBe(false)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15962,7 +15962,8 @@
           "none": "None",
           "search": "Search",
           "showUnreadOnly": "Show unread only",
-          "showChildAgents": "Show child agents"
+          "showChildAgents": "Show child agents",
+          "activityOptions": "Activity options"
         },
         "clearCompleted": {
           "clearedOne": "Cleared 1 completed agent",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17260,7 +17260,9 @@
   "dashboard": {
     "sidebar": {
       "label": "Agents",
-      "dashboardLabel": "Agent Dashboard"
+      "dashboardLabel": "Agent Dashboard",
+      "openActivity": "View activity",
+      "closeActivity": "Turn off activity view"
     }
   },
   "runtimeRpc": {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

Follow-up to #17979 (merged). Addresses valid review feedback: the fix made a real transport failure silent.

## ELI5

#17979 stopped an unanswered native-deps probe from wiping a healthy relay. But the wrongful rebuild **was the only visible symptom** of a dropped exec channel — it surfaced as a loud `Repairing missing native deps` warning plus a visible build. Removing it means a genuine transport failure now leaves **zero trace**: the relay just launches.

This adds a `console.warn` on the unverifiable path, so lost contact is still reported without being acted on destructively.

The install-path sibling already does this — its callers log the same class of failure as `[NATIVE-DEPS-REBUILD-FAIL]` / `[NPTY-MISSING]`. This is the repair path catching up to it, which is the same twin-asymmetry that produced #17979 itself.

```ts
console.warn(
  `[ssh-relay] Native deps probe unanswered at ${remoteDir}; launching without repair: ${…}`
)
```

The error message is included, so a torn channel and a timed-out `require()` are distinguishable in logs.

## User-facing regressions

**None.** Log-only — no control flow, no repair decision, no lock handling changes. The relay still launches exactly as #17979 made it.

## Testing

Extends the existing `launches an intact relay when the health probe never answers` case rather than adding a parallel one, so the trace assertion sits directly beside the repair-avoidance assertions it complements.

Before (production change reverted, test in place):
```
 × launches an intact relay when the health probe never answers 4ms
AssertionError: an unanswered probe must still leave a trace: expected false to be true
    153|       'an unanswered probe must still leave a trace'
      Tests  1 failed | 3 passed (4)
```
After:
```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

`pnpm tc:node` clean. `check:code-quality:changed` → 0 new findings across 2 files.

## Credit

Caught by automated review on #17979, which flagged that the install-path sibling surfaces this failure loudly while the repair path now swallows it. The observation was correct and worth acting on.
