### PR TITLE
fix(codex): stop a cold WSL distro from reading as "this home is not yours"

### DIFF
--- a/src/main/codex-accounts/codex-managed-home-path.ts
+++ b/src/main/codex-accounts/codex-managed-home-path.ts
@@ -2,11 +2,10 @@ import { lstatSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'nod
 import { join, resolve } from 'node:path'
 import { app } from 'electron'
 import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
-import { quotePosixShell } from '../../shared/wsl-login-shell-command'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import type { CodexManagedAccount } from '../../shared/managed-account-types'
 import { getSystemCodexHomePath } from '../codex/codex-home-paths'
-import { runWslProcess } from '../wsl/wsl-runner'
+import { runWslProcess, type WslResult, type WslSpec } from '../wsl/wsl-runner'
 import {
   assertOwnedCodexManagedHomeVerdict,
   assertOwnedHostCodexManagedHomePath,
@@ -23,14 +22,12 @@ import {
   MARKER_ACCOUNT_MISMATCH_MESSAGE,
   OUTSIDE_MANAGED_ROOT_MESSAGE
 } from './wsl-codex-managed-home-probe'
+import {
+  buildWslManagedHomePreparationScript,
+  WSL_PREPARE_UNTRUSTED_EXITS
+} from './wsl-codex-managed-home-preparation'
 
 const WSL_MANAGED_HOME_TIMEOUT_MS = 5_000
-
-/** Exit codes the preparation script uses to report a *proven* foreign directory. */
-const WSL_PREPARE_UNTRUSTED_EXITS = new Map<number, string>([
-  [41, MISSING_OWNERSHIP_MARKER_MESSAGE],
-  [42, MARKER_ACCOUNT_MISMATCH_MESSAGE]
-])
 
 export class CodexManagedHomePath {
   constructor(private readonly validateWslPath: (distro: string, script: string) => string) {}
@@ -122,19 +119,10 @@ export class CodexManagedHomePath {
     ) {
       return
     }
-    const result = await runWslProcess({
+    const result = await this.runManagedHomePreparation({
       distro: wslInfo.distro,
       loginPath: 'none',
-      script: [
-        'set -euo pipefail',
-        `candidate=${quotePosixShell(wslInfo.linuxPath)}`,
-        `expected_marker=${quotePosixShell(account.id)}`,
-        'marker="$candidate/.orca-managed-home"',
-        'if [ -e "$candidate" ] && [ ! -f "$marker" ]; then exit 41; fi',
-        'if [ -f "$marker" ] && [ "$(cat "$marker")" != "$expected_marker" ]; then exit 42; fi',
-        'mkdir -p -- "$candidate"',
-        'printf "%s\\n" "$expected_marker" > "$marker"'
-      ].join('\n'),
+      script: buildWslManagedHomePreparationScript(wslInfo.linuxPath, account.id),
       shell: 'bash',
       timeoutMs: WSL_MANAGED_HOME_TIMEOUT_MS
     })
@@ -160,6 +148,20 @@ export class CodexManagedHomePath {
           `Preparing the managed Codex home in WSL ${wslInfo.distro} exited with code ${String(result.code)}.`
         )
       })
+    }
+  }
+
+  /**
+   * Why: `runWslProcess` rejects outright when `wsl.exe` cannot be launched —
+   * the canonical "could not check". Awaiting it bare let that rejection reach
+   * callers as a raw spawn error, or as a wrapper's non-Error string, so nothing
+   * downstream could recognise it as an unproven observation.
+   */
+  private async runManagedHomePreparation(spec: WslSpec): Promise<WslResult> {
+    try {
+      return await runWslProcess(spec)
+    } catch (error) {
+      throw new ManagedCodexHomeTemporarilyUnavailableError(undefined, { cause: error })
     }
   }
 

--- a/src/main/codex-accounts/codex-managed-home-path.ts
+++ b/src/main/codex-accounts/codex-managed-home-path.ts
@@ -1,15 +1,36 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { lstatSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { app } from 'electron'
+import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
 import { quotePosixShell } from '../../shared/wsl-login-shell-command'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import type { CodexManagedAccount } from '../../shared/managed-account-types'
 import { getSystemCodexHomePath } from '../codex/codex-home-paths'
-import { toWindowsWslPath } from '../wsl'
 import { runWslProcess } from '../wsl/wsl-runner'
-import { assertOwnedHostCodexManagedHomePath } from './host-codex-managed-home-ownership'
+import {
+  assertOwnedCodexManagedHomeVerdict,
+  assertOwnedHostCodexManagedHomePath,
+  ManagedCodexHomeTemporarilyUnavailableError,
+  MISSING_MANAGED_HOME_MESSAGE,
+  MISSING_OWNERSHIP_MARKER_MESSAGE,
+  UntrustedManagedCodexHomeError,
+  type HostCodexManagedHomeVerdict
+} from './host-codex-managed-home-ownership'
+import {
+  ACCOUNT_ID_MISMATCH_MESSAGE,
+  buildWslCodexManagedHomeProbeScript,
+  classifyWslCodexManagedHomeProbe,
+  MARKER_ACCOUNT_MISMATCH_MESSAGE,
+  OUTSIDE_MANAGED_ROOT_MESSAGE
+} from './wsl-codex-managed-home-probe'
 
 const WSL_MANAGED_HOME_TIMEOUT_MS = 5_000
+
+/** Exit codes the preparation script uses to report a *proven* foreign directory. */
+const WSL_PREPARE_UNTRUSTED_EXITS = new Map<number, string>([
+  [41, MISSING_OWNERSHIP_MARKER_MESSAGE],
+  [42, MARKER_ACCOUNT_MISMATCH_MESSAGE]
+])
 
 export class CodexManagedHomePath {
   constructor(private readonly validateWslPath: (distro: string, script: string) => string) {}
@@ -56,22 +77,26 @@ export class CodexManagedHomePath {
         expectedAccountId
       })
     }
+    // Why: the spelling of the persisted path is a fact the host already holds,
+    // so a mismatch is dispositive without asking the guest anything.
     if (
       !wslInfo.linuxPath.includes('/.local/share/orca/codex-accounts/') ||
       !wslInfo.linuxPath.endsWith('/home')
     ) {
-      throw new Error('Managed WSL Codex home is outside Orca account storage.')
+      throw new UntrustedManagedCodexHomeError(OUTSIDE_MANAGED_ROOT_MESSAGE)
     }
     if (
       expectedAccountId !== undefined &&
       !wslInfo.linuxPath.endsWith(`/.local/share/orca/codex-accounts/${expectedAccountId}/home`)
     ) {
-      throw new Error('Managed WSL Codex home does not match its persisted account ID.')
+      throw new UntrustedManagedCodexHomeError(ACCOUNT_ID_MISMATCH_MESSAGE)
     }
     if (process.platform === 'win32') {
       return this.assertWindowsWslPath(wslInfo, expectedAccountId)
     }
-    return this.assertMountedWslPath(candidatePath, wslInfo.linuxPath, expectedAccountId)
+    return assertOwnedCodexManagedHomeVerdict(
+      this.resolveMountedWslVerdict(candidatePath, wslInfo.linuxPath, expectedAccountId)
+    )
   }
 
   private recreateExpectedHostHome(account: CodexManagedAccount, originalError: unknown): string {
@@ -113,12 +138,28 @@ export class CodexManagedHomePath {
       shell: 'bash',
       timeoutMs: WSL_MANAGED_HOME_TIMEOUT_MS
     })
+    if (result.timedOut) {
+      throw new ManagedCodexHomeTemporarilyUnavailableError(undefined, {
+        cause: new Error(
+          `Preparing the managed Codex home in WSL ${wslInfo.distro} timed out after ${WSL_MANAGED_HOME_TIMEOUT_MS}ms.`
+        )
+      })
+    }
     // Why: 41/42 mean the path is not this account's home; re-auth must refuse
-    // rather than write credentials into someone else's directory.
-    if (result.code !== 0 || result.timedOut) {
-      throw new Error(
-        `Could not prepare the managed Codex home in WSL ${wslInfo.distro} for re-authentication.`
-      )
+    // rather than write credentials into someone else's directory. Every other
+    // non-zero exit — a cold distro, a missing shell, a 9p hiccup — proves
+    // nothing about ownership and must not read as a trust failure (STA-5616).
+    const untrustedReason =
+      typeof result.code === 'number' ? WSL_PREPARE_UNTRUSTED_EXITS.get(result.code) : undefined
+    if (untrustedReason !== undefined) {
+      throw new UntrustedManagedCodexHomeError(untrustedReason)
+    }
+    if (result.code !== 0) {
+      throw new ManagedCodexHomeTemporarilyUnavailableError(undefined, {
+        cause: new Error(
+          `Preparing the managed Codex home in WSL ${wslInfo.distro} exited with code ${String(result.code)}.`
+        )
+      })
     }
   }
 
@@ -126,68 +167,64 @@ export class CodexManagedHomePath {
     wslInfo: { distro: string; linuxPath: string },
     expectedAccountId?: string
   ): string {
+    const script = buildWslCodexManagedHomeProbeScript(wslInfo.linuxPath, expectedAccountId)
+    let stdout: string
     try {
-      const canonicalLinuxPath = this.validateWslPath(
-        wslInfo.distro,
-        [
-          'set -euo pipefail',
-          `candidate=${quotePosixShell(wslInfo.linuxPath)}`,
-          'managed_root="${HOME%/}/.local/share/orca/codex-accounts"',
-          'candidate_real=$(readlink -f -- "$candidate")',
-          'managed_root_real=$(readlink -f -- "$managed_root")',
-          'test -f "$candidate_real/.orca-managed-home"',
-          ...(expectedAccountId === undefined
-            ? [
-                'case "$candidate_real" in "$managed_root_real"/*/home) printf "%s\\n" "$candidate_real" ;; *) exit 35 ;; esac'
-              ]
-            : [
-                `expected_marker=${quotePosixShell(expectedAccountId)}`,
-                'test "$candidate_real" = "$managed_root_real/$expected_marker/home"',
-                'test "$(cat "$candidate_real/.orca-managed-home")" = "$expected_marker"',
-                'printf "%s\\n" "$candidate_real"'
-              ])
-        ].join('\n')
-      ).trim()
-      if (!canonicalLinuxPath) {
-        throw new Error('Managed Codex home directory does not exist on disk.')
-      }
-      return toWindowsWslPath(canonicalLinuxPath, wslInfo.distro)
+      stdout = this.validateWslPath(wslInfo.distro, script)
     } catch (error) {
-      throw new Error('Managed WSL Codex home is outside Orca account storage.', {
-        cause: error
-      })
+      // Why: the guest reports its observation on a tagged line and always exits
+      // 0, so a throw here is the runner failing — never evidence about the home.
+      return assertOwnedCodexManagedHomeVerdict(
+        classifyWslCodexManagedHomeProbe({ ran: false, error }, wslInfo.distro)
+      )
     }
+    return assertOwnedCodexManagedHomeVerdict(
+      classifyWslCodexManagedHomeProbe({ ran: true, stdout }, wslInfo.distro)
+    )
   }
 
-  private assertMountedWslPath(
+  /**
+   * The same gate for a WSL home reached through a mount rather than `wsl.exe`.
+   * Reads go through `statSync`/`lstatSync` rather than `existsSync` so an EPERM
+   * or EIO cannot be folded into "does not exist" (STA-4422's collapse).
+   */
+  private resolveMountedWslVerdict(
     candidatePath: string,
     linuxPath: string,
     expectedAccountId?: string
-  ): string {
+  ): HostCodexManagedHomeVerdict {
     if (linuxPath.split('/').includes('..')) {
-      throw new Error('Managed WSL Codex home is outside Orca account storage.')
+      return { kind: 'untrusted', reason: OUTSIDE_MANAGED_ROOT_MESSAGE }
     }
-    if (!existsSync(candidatePath)) {
-      throw new Error('Managed Codex home directory does not exist on disk.')
+    try {
+      statSync(candidatePath)
+    } catch (error) {
+      if (isDefinitiveAbsence(error)) {
+        return { kind: 'untrusted', reason: MISSING_MANAGED_HOME_MESSAGE }
+      }
+      return { kind: 'indeterminate', error }
     }
     const markerPath = join(candidatePath, '.orca-managed-home')
-    if (!existsSync(markerPath)) {
-      throw new Error('Managed Codex home is missing Orca ownership marker.')
+    let markerContents: string
+    try {
+      if (!lstatSync(markerPath).isFile()) {
+        return { kind: 'untrusted', reason: MISSING_OWNERSHIP_MARKER_MESSAGE }
+      }
+      markerContents = readFileSync(markerPath, 'utf-8')
+    } catch (error) {
+      if (isDefinitiveAbsence(error)) {
+        return { kind: 'untrusted', reason: MISSING_OWNERSHIP_MARKER_MESSAGE }
+      }
+      return { kind: 'indeterminate', error }
     }
-    if (
-      expectedAccountId !== undefined &&
-      readFileSync(markerPath, 'utf-8').trim() !== expectedAccountId
-    ) {
-      throw new Error('Managed WSL Codex home ownership marker does not match its account ID.')
+    if (expectedAccountId !== undefined && markerContents.trim() !== expectedAccountId) {
+      return { kind: 'untrusted', reason: MARKER_ACCOUNT_MISMATCH_MESSAGE }
     }
-    return candidatePath
+    return { kind: 'owned', homePath: candidatePath }
   }
 
   private isMissingHomeError(error: unknown): boolean {
-    return (
-      error instanceof Error &&
-      error.message === 'Managed Codex home directory does not exist on disk.'
-    )
+    return error instanceof Error && error.message === MISSING_MANAGED_HOME_MESSAGE
   }
 
   private pathsEqual(left: string, right: string): boolean {

--- a/src/main/codex-accounts/codex-managed-home-path.ts
+++ b/src/main/codex-accounts/codex-managed-home-path.ts
@@ -2,6 +2,7 @@ import { lstatSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'nod
 import { join, resolve } from 'node:path'
 import { app } from 'electron'
 import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
+import { readUntrustedString } from '../../shared/untrusted-value-fields'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import type { CodexManagedAccount } from '../../shared/managed-account-types'
 import { getSystemCodexHomePath } from '../codex/codex-home-paths'
@@ -24,7 +25,7 @@ import {
 } from './wsl-codex-managed-home-probe'
 import {
   buildWslManagedHomePreparationScript,
-  WSL_PREPARE_UNTRUSTED_EXITS
+  interpretWslPreparationResult
 } from './wsl-codex-managed-home-preparation'
 
 const WSL_MANAGED_HOME_TIMEOUT_MS = 5_000
@@ -32,16 +33,27 @@ const WSL_MANAGED_HOME_TIMEOUT_MS = 5_000
 export class CodexManagedHomePath {
   constructor(private readonly validateWslPath: (distro: string, script: string) => string) {}
 
+  /** Creates the root; for the write paths (add, recreate) that need it to exist. */
   getRoot(): string {
-    const root = join(app.getPath('userData'), 'codex-accounts')
+    const root = this.rootPath()
     mkdirSync(root, { recursive: true })
     return root
+  }
+
+  /**
+   * Why a non-creating spelling: `assert` is a *gate*. Reset-credit validation
+   * and other read-only callers must be able to refuse without touching the
+   * filesystem, and creating the root as a side effect of asking a question is
+   * how a check becomes a mutation.
+   */
+  private rootPath(): string {
+    return join(app.getPath('userData'), 'codex-accounts')
   }
 
   assertHostOwnership(candidatePath: string, expectedAccountId: string): string {
     return assertOwnedHostCodexManagedHomePath({
       candidatePath,
-      managedAccountsRoot: join(app.getPath('userData'), 'codex-accounts'),
+      managedAccountsRoot: this.rootPath(),
       systemCodexHomePath: getSystemCodexHomePath(),
       expectedAccountId
     })
@@ -69,7 +81,7 @@ export class CodexManagedHomePath {
     if (!wslInfo) {
       return assertOwnedHostCodexManagedHomePath({
         candidatePath,
-        managedAccountsRoot: this.getRoot(),
+        managedAccountsRoot: this.rootPath(),
         systemCodexHomePath: getSystemCodexHomePath(),
         expectedAccountId
       })
@@ -126,27 +138,13 @@ export class CodexManagedHomePath {
       shell: 'bash',
       timeoutMs: WSL_MANAGED_HOME_TIMEOUT_MS
     })
-    if (result.timedOut) {
-      throw new ManagedCodexHomeTemporarilyUnavailableError(undefined, {
-        cause: new Error(
-          `Preparing the managed Codex home in WSL ${wslInfo.distro} timed out after ${WSL_MANAGED_HOME_TIMEOUT_MS}ms.`
-        )
-      })
+    const outcome = interpretWslPreparationResult(result, wslInfo.distro)
+    if (outcome.kind === 'untrusted') {
+      throw new UntrustedManagedCodexHomeError(outcome.reason)
     }
-    // Why: 41/42 mean the path is not this account's home; re-auth must refuse
-    // rather than write credentials into someone else's directory. Every other
-    // non-zero exit — a cold distro, a missing shell, a 9p hiccup — proves
-    // nothing about ownership and must not read as a trust failure (STA-5616).
-    const untrustedReason =
-      typeof result.code === 'number' ? WSL_PREPARE_UNTRUSTED_EXITS.get(result.code) : undefined
-    if (untrustedReason !== undefined) {
-      throw new UntrustedManagedCodexHomeError(untrustedReason)
-    }
-    if (result.code !== 0) {
+    if (outcome.kind === 'indeterminate') {
       throw new ManagedCodexHomeTemporarilyUnavailableError(undefined, {
-        cause: new Error(
-          `Preparing the managed Codex home in WSL ${wslInfo.distro} exited with code ${String(result.code)}.`
-        )
+        cause: new Error(outcome.reason)
       })
     }
   }
@@ -225,8 +223,14 @@ export class CodexManagedHomePath {
     return { kind: 'owned', homePath: candidatePath }
   }
 
+  /**
+   * Why not `instanceof` plus a bare `.message`: this decides whether re-auth may
+   * RECREATE the home, and it runs on whatever `assert` threw. A revoked Proxy
+   * throws on the prototype walk and a hostile getter throws on the read, either
+   * of which would escape the catch that exists to make this path total.
+   */
   private isMissingHomeError(error: unknown): boolean {
-    return error instanceof Error && error.message === MISSING_MANAGED_HOME_MESSAGE
+    return readUntrustedString(error, 'message') === MISSING_MANAGED_HOME_MESSAGE
   }
 
   private pathsEqual(left: string, right: string): boolean {

--- a/src/main/codex-accounts/codex-reset-credit-scope-validation.ts
+++ b/src/main/codex-accounts/codex-reset-credit-scope-validation.ts
@@ -108,8 +108,14 @@ export function validateCodexResetCreditScope(
       )
     }
   }
-  if (validation.kind === 'providerMutation' && expectedScope.target.runtime === 'host') {
-    dependencies.managedHomePaths.assertHostOwnership(account.managedHomePath, account.id)
+  if (validation.kind === 'providerMutation') {
+    // Why both runtimes: spending a reset credit is an irreversible provider
+    // mutation, so the home must be PROVEN to be this account's whichever
+    // runtime holds it — the WSL lane was skipping the check entirely. `assert`
+    // routes a host path to the host gate and a WSL path to the guest probe,
+    // and throws the temporary-unavailable error when it cannot tell, which the
+    // coordinator already refuses on rather than spending the credit.
+    dependencies.managedHomePaths.assert(account.managedHomePath, account.id)
   }
   return { managedHomePath: account.managedHomePath, rateLimits: rateLimitState }
 }

--- a/src/main/codex-accounts/host-codex-managed-home-ownership.ts
+++ b/src/main/codex-accounts/host-codex-managed-home-ownership.ts
@@ -10,6 +10,9 @@ type HostCodexManagedHomeOwnershipOptions = {
 }
 
 export const MISSING_MANAGED_HOME_MESSAGE = 'Managed Codex home directory does not exist on disk.'
+/** Shared with the WSL probe so the two lanes cannot drift apart on this wording. */
+export const MISSING_OWNERSHIP_MARKER_MESSAGE =
+  'Managed Codex home is missing Orca ownership marker.'
 
 /**
  * Why: the gate answers two different questions and callers act on them very
@@ -156,7 +159,7 @@ function evaluate({
     // Why: the marker is required, so its definitive absence is structural — but
     // an unreadable marker is not evidence of anything.
     if (isDefinitiveAbsence(error)) {
-      return { kind: 'untrusted', reason: 'Managed Codex home is missing Orca ownership marker.' }
+      return { kind: 'untrusted', reason: MISSING_OWNERSHIP_MARKER_MESSAGE }
     }
     return { kind: 'indeterminate', error }
   }
@@ -193,7 +196,11 @@ export function resolveHostCodexManagedHomeVerdict(
 export function assertOwnedHostCodexManagedHomePath(
   options: HostCodexManagedHomeOwnershipOptions
 ): string {
-  const verdict = evaluate(options)
+  return assertOwnedCodexManagedHomeVerdict(evaluate(options))
+}
+
+/** Shared by the host and WSL lanes so neither can invent its own error mapping. */
+export function assertOwnedCodexManagedHomeVerdict(verdict: HostCodexManagedHomeVerdict): string {
   if (verdict.kind === 'owned') {
     return verdict.homePath
   }

--- a/src/main/codex-accounts/host-codex-managed-home-ownership.ts
+++ b/src/main/codex-accounts/host-codex-managed-home-ownership.ts
@@ -13,6 +13,9 @@ export const MISSING_MANAGED_HOME_MESSAGE = 'Managed Codex home directory does n
 /** Shared with the WSL probe so the two lanes cannot drift apart on this wording. */
 export const MISSING_OWNERSHIP_MARKER_MESSAGE =
   'Managed Codex home is missing Orca ownership marker.'
+/** A marker that is not a regular file proves nothing, whatever it resolves to. */
+export const MARKER_NOT_REGULAR_FILE_MESSAGE =
+  'Managed Codex home ownership marker is not a regular file.'
 
 /**
  * Why: the gate answers two different questions and callers act on them very
@@ -164,10 +167,7 @@ function evaluate({
     return { kind: 'indeterminate', error }
   }
   if (!markerIsRegularFile) {
-    return {
-      kind: 'untrusted',
-      reason: 'Managed Codex home ownership marker is not a regular file.'
-    }
+    return { kind: 'untrusted', reason: MARKER_NOT_REGULAR_FILE_MESSAGE }
   }
   if (expectedAccountId !== undefined && markerContents.trim() !== expectedAccountId) {
     return {

--- a/src/main/codex-accounts/reset-credit-wsl-ownership-gate.test.ts
+++ b/src/main/codex-accounts/reset-credit-wsl-ownership-gate.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildCodexResetCreditExpectedScope } from '../../shared/codex-reset-credit-scope'
+import type { CodexManagedAccount } from '../../shared/managed-account-types'
+import { toCodexManagedAccountSummary } from './codex-account-service-types'
+import type { CodexManagedHomePath } from './codex-managed-home-path'
+import {
+  ManagedCodexHomeTemporarilyUnavailableError,
+  UntrustedManagedCodexHomeError
+} from './host-codex-managed-home-ownership'
+import {
+  createResetCreditLimits,
+  createResetRateLimitState
+} from './service-reset-credit-test-fixtures'
+import { validateCodexResetCreditScope } from './codex-reset-credit-scope-validation'
+
+/**
+ * Spending a reset credit is an irreversible provider mutation. It was gated on
+ * proven ownership for `runtime: 'host'` only, so a WSL selection reached the
+ * provider with no ownership check at all — a different bug from misclassifying
+ * one, and the reason the tri-state was bypassable from a normal caller.
+ */
+const WSL_TARGET = { runtime: 'wsl' as const, wslDistro: 'Ubuntu' }
+
+function wslAccount(): CodexManagedAccount {
+  return {
+    id: 'account-wsl',
+    email: 'wsl@example.com',
+    managedHomePath:
+      '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.local\\share\\orca\\codex-accounts\\account-wsl\\home',
+    managedHomeRuntime: 'wsl',
+    wslDistro: 'Ubuntu',
+    wslLinuxHomePath: '/home/dev/.local/share/orca/codex-accounts/account-wsl/home',
+    providerAccountId: null,
+    workspaceLabel: null,
+    workspaceAccountId: null,
+    createdAt: 10,
+    updatedAt: 20,
+    lastAuthenticatedAt: 20
+  }
+}
+
+function buildDependencies(assertImpl: () => string) {
+  const account = wslAccount()
+  const limits = createResetCreditLimits()
+  const rateLimitState = createResetRateLimitState(limits, WSL_TARGET)
+  const assertSpy = vi.fn(assertImpl)
+  const expectedScope = buildCodexResetCreditExpectedScope({
+    target: WSL_TARGET,
+    account: toCodexManagedAccountSummary(account),
+    limits
+  })
+  if (!expectedScope) {
+    throw new Error('fixture did not produce a reset-credit scope')
+  }
+  return {
+    expectedScope,
+    assertSpy,
+    dependencies: {
+      store: {
+        getSettings: () => ({
+          codexManagedAccounts: [account],
+          activeCodexManagedAccountId: null,
+          activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: account.id } }
+        })
+      },
+      rateLimits: { getState: () => rateLimitState },
+      managedHomePaths: { assert: assertSpy } as unknown as CodexManagedHomePath,
+      toSummary: toCodexManagedAccountSummary
+    } as never
+  }
+}
+
+describe('reset-credit ownership gate on the WSL lane', () => {
+  it('proves ownership before an irreversible provider mutation', () => {
+    const { expectedScope, assertSpy, dependencies } = buildDependencies(
+      () =>
+        '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.local\\share\\orca\\codex-accounts\\account-wsl\\home'
+    )
+
+    validateCodexResetCreditScope(
+      expectedScope,
+      { kind: 'providerMutation', requireCurrentOffer: false },
+      dependencies
+    )
+
+    expect(assertSpy).toHaveBeenCalledWith(wslAccount().managedHomePath, 'account-wsl')
+  })
+
+  it('refuses when the home is proven to belong to another account', () => {
+    const { expectedScope, dependencies } = buildDependencies(() => {
+      throw new UntrustedManagedCodexHomeError('marker mismatch')
+    })
+
+    expect(() =>
+      validateCodexResetCreditScope(
+        expectedScope,
+        { kind: 'providerMutation', requireCurrentOffer: false },
+        dependencies
+      )
+    ).toThrow(UntrustedManagedCodexHomeError)
+  })
+
+  it('refuses when ownership could not be determined', () => {
+    const { expectedScope, dependencies } = buildDependencies(() => {
+      throw new ManagedCodexHomeTemporarilyUnavailableError()
+    })
+
+    expect(() =>
+      validateCodexResetCreditScope(
+        expectedScope,
+        { kind: 'providerMutation', requireCurrentOffer: false },
+        dependencies
+      )
+    ).toThrow(ManagedCodexHomeTemporarilyUnavailableError)
+  })
+
+  it('does not gate a settled replay, which mutates nothing', () => {
+    const { expectedScope, assertSpy, dependencies } = buildDependencies(() => {
+      throw new Error('the gate must not run here')
+    })
+
+    validateCodexResetCreditScope(expectedScope, { kind: 'settledReplay' }, dependencies)
+
+    expect(assertSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/codex-accounts/service-wsl-accounts.test.ts
+++ b/src/main/codex-accounts/service-wsl-accounts.test.ts
@@ -34,6 +34,11 @@ function decodeEncodedWslBashCommand(command: string): string {
   return encoded ? Buffer.from(encoded, 'base64').toString('utf8') : command
 }
 
+/** The tagged line the guest prints for an Orca-owned home (STA-5616 protocol). */
+function ownedProbeVerdict(linuxPath: string): string {
+  return `ORCA_CODEX_HOME_VERDICT:owned:${Buffer.from(linuxPath, 'utf-8').toString('base64')}\n`
+}
+
 function wslOk(stdout = ''): WslResult {
   return { environmentResolved: true, code: 0, stdout, stderr: '', timedOut: false }
 }
@@ -133,7 +138,7 @@ describe('CodexAccountService config sync', () => {
     writeFileSync(wslCanonicalConfigPath, 'model_instructions_file = "instructions.md"\n', 'utf-8')
 
     vi.doMock('node:child_process', () => ({
-      execFileSync: vi.fn(() => `${wslLinuxHomePath}\n`),
+      execFileSync: vi.fn(() => ownedProbeVerdict(wslLinuxHomePath)),
       spawn: vi.fn()
     }))
     vi.doMock('../../shared/wsl-paths', () => ({
@@ -210,7 +215,7 @@ describe('CodexAccountService config sync', () => {
       const script = decodeEncodedWslBashCommand(String(args.at(-1)))
       expect(args.slice(0, 2)).toEqual(['-d', 'Debian'])
       expect(script).toContain('readlink -f')
-      return `${wslLinuxHomePath}\n`
+      return ownedProbeVerdict(wslLinuxHomePath)
     })
     const runWslProcessMock = vi.fn(async (spec: WslSpec) => {
       const script = String(spec.script)
@@ -343,7 +348,7 @@ describe('CodexAccountService config sync', () => {
       const script = decodeEncodedWslBashCommand(String(args.at(-1)))
       expect(args.slice(0, 2)).toEqual(['-d', 'Debian'])
       expect(script).toContain('readlink -f')
-      return `${wslLinuxHomePath}\n`
+      return ownedProbeVerdict(wslLinuxHomePath)
     })
     const runWslProcessMock = vi.fn(async (spec: WslSpec) => {
       const script = String(spec.script)
@@ -421,7 +426,7 @@ describe('CodexAccountService config sync', () => {
       const script = decodeEncodedWslBashCommand(String(args.at(-1)))
       expect(args.slice(0, 2)).toEqual(['-d', 'Debian'])
       expect(script).toContain('readlink -f')
-      return `${wslLinuxHomePath}\n`
+      return ownedProbeVerdict(wslLinuxHomePath)
     })
     const runWslProcessMock = vi.fn(async (spec: WslSpec) => {
       const script = String(spec.script)
@@ -508,7 +513,7 @@ describe('CodexAccountService config sync', () => {
     const execFileSyncMock = vi.fn((_command: string, args: string[]) => {
       const script = decodeEncodedWslBashCommand(String(args.at(-1)))
       if (script.includes('readlink -f')) {
-        return `${wslLinuxHomePath}\n`
+        return ownedProbeVerdict(wslLinuxHomePath)
       }
       return ''
     })
@@ -641,7 +646,7 @@ describe('CodexAccountService config sync', () => {
     const execFileSyncMock = vi.fn((_command: string, args: string[]) => {
       const script = decodeEncodedWslBashCommand(String(args.at(-1)))
       if (script.includes('readlink -f')) {
-        return `${wslLinuxHomePath}\n`
+        return ownedProbeVerdict(wslLinuxHomePath)
       }
       return ''
     })
@@ -762,10 +767,8 @@ describe('CodexAccountService config sync', () => {
           expect(script).toContain(
             'test "$candidate_real" = "$managed_root_real/$expected_marker/home"'
           )
-          expect(script).toContain(
-            'test "$(cat "$candidate_real/.orca-managed-home")" = "$expected_marker"'
-          )
-          return `${wslLinuxHomePath}\n`
+          expect(script).toContain('test "$contents" = "$expected_marker"')
+          return ownedProbeVerdict(wslLinuxHomePath)
         }
         return ''
       }),

--- a/src/main/codex-accounts/service-wsl-accounts.test.ts
+++ b/src/main/codex-accounts/service-wsl-accounts.test.ts
@@ -765,9 +765,11 @@ describe('CodexAccountService config sync', () => {
         if (script.includes('readlink -f')) {
           expect(script).toContain("expected_marker='account-1'")
           expect(script).toContain(
-            'test "$candidate_real" = "$managed_root_real/$expected_marker/home"'
+            'if [ "$candidate_real" != "$managed_root_real/$expected_marker/home" ]; then tag account-mismatch; fi'
           )
-          expect(script).toContain('test "$contents" = "$expected_marker"')
+          expect(script).toContain(
+            'if [ "$contents" != "$expected_marker" ]; then tag marker-mismatch; fi'
+          )
           return ownedProbeVerdict(wslLinuxHomePath)
         }
         return ''

--- a/src/main/codex-accounts/sta-5616-hostile-error-and-spawn-failure.test.ts
+++ b/src/main/codex-accounts/sta-5616-hostile-error-and-spawn-failure.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeFs from 'node:fs'
+import type * as WslPaths from '../../shared/wsl-paths'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// PR #18001 review follow-ups: two ways a failure escaped the tri-state.
+//   1. `isDefinitiveAbsence` read `.code` off an arbitrary thrown value, so an
+//      error-like object with a throwing accessor escaped the fail-closed catch.
+//   2. `runWslProcess` REJECTING (wsl.exe missing/unlaunchable) was never caught,
+//      so the canonical "could not check" reached callers untyped.
+
+const statFaults = vi.hoisted(() => {
+  const held = new Map<string, () => never>()
+  return {
+    hold(path: string, thrower: () => never): void {
+      held.set(path, thrower)
+    },
+    reset(): void {
+      held.clear()
+    },
+    consume(target: unknown): void {
+      const thrower = typeof target === 'string' ? held.get(target) : undefined
+      if (thrower) {
+        thrower()
+      }
+    }
+  }
+})
+
+const realFs = vi.hoisted(() => ({ rmSync: null as typeof NodeFs.rmSync | null }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  realFs.rmSync = actual.rmSync
+  const patched = {
+    ...actual,
+    statSync: (...args: unknown[]) => {
+      statFaults.consume(args[0])
+      return (actual.statSync as (...a: unknown[]) => unknown)(...args)
+    },
+    lstatSync: (...args: unknown[]) => {
+      statFaults.consume(args[0])
+      return (actual.lstatSync as (...a: unknown[]) => unknown)(...args)
+    }
+  }
+  return { ...patched, default: patched }
+})
+
+vi.mock('electron', () => ({ app: { getPath: () => '/unused-user-data' } }))
+
+const runWslProcessMock = vi.hoisted(() => vi.fn())
+vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
+
+const mountedPathAlias = vi.hoisted(() => ({ hostPath: '', linuxPath: '' }))
+vi.mock('../../shared/wsl-paths', async (importOriginal) => {
+  const actual = await importOriginal<typeof WslPaths>()
+  return {
+    ...actual,
+    parseWslUncPath: (path: string) =>
+      path === mountedPathAlias.hostPath && path !== ''
+        ? { distro: 'Ubuntu', linuxPath: mountedPathAlias.linuxPath }
+        : actual.parseWslUncPath(path)
+  }
+})
+
+import { CodexManagedHomePath } from './codex-managed-home-path'
+import {
+  MARKER_NOT_REGULAR_FILE_MESSAGE,
+  ManagedCodexHomeTemporarilyUnavailableError,
+  UntrustedManagedCodexHomeError
+} from './host-codex-managed-home-ownership'
+import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
+
+const ACCOUNT_ID = 'account-1'
+const LINUX_HOME = `/home/dev/.local/share/orca/codex-accounts/${ACCOUNT_ID}/home`
+
+let originalPlatform: PropertyDescriptor | undefined
+
+beforeEach(() => {
+  originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  statFaults.reset()
+  runWslProcessMock.mockReset()
+  mountedPathAlias.hostPath = ''
+  mountedPathAlias.linuxPath = ''
+})
+
+afterEach(() => {
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+  vi.restoreAllMocks()
+})
+
+describe('isDefinitiveAbsence on values it did not create', () => {
+  it('does not let a throwing errno accessor escape', () => {
+    const hostile = {
+      get code(): string {
+        throw new Error('accessor exploded')
+      }
+    }
+
+    expect(() => isDefinitiveAbsence(hostile)).not.toThrow()
+    expect(isDefinitiveAbsence(hostile)).toBe(false)
+  })
+
+  it('does not treat a non-string errno as absence', () => {
+    expect(isDefinitiveAbsence({ code: ['ENOENT'] })).toBe(false)
+    expect(isDefinitiveAbsence({ code: 2 })).toBe(false)
+  })
+
+  it.each([undefined, null, 'ENOENT', 42, Symbol('ENOENT')])(
+    'survives a thrown %s without throwing',
+    (thrown) => {
+      expect(() => isDefinitiveAbsence(thrown)).not.toThrow()
+      expect(isDefinitiveAbsence(thrown)).toBe(false)
+    }
+  )
+
+  it('still recognises the real absence codes', () => {
+    expect(isDefinitiveAbsence(Object.assign(new Error('x'), { code: 'ENOENT' }))).toBe(true)
+    expect(isDefinitiveAbsence(Object.assign(new Error('x'), { code: 'ENOTDIR' }))).toBe(true)
+    expect(isDefinitiveAbsence(Object.assign(new Error('x'), { code: 'EPERM' }))).toBe(false)
+  })
+})
+
+describe('mounted WSL gate against a hostile thrown value', () => {
+  let mountRoot: string
+  let mountedHome: string
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    mountRoot = mkdtempSync(join(tmpdir(), 'orca-18001-'))
+    mountedHome = join(mountRoot, 'home')
+    mkdirSync(mountedHome, { recursive: true })
+    writeFileSync(join(mountedHome, '.orca-managed-home'), `${ACCOUNT_ID}\n`, 'utf-8')
+    mountedPathAlias.hostPath = mountedHome
+    mountedPathAlias.linuxPath = LINUX_HOME
+  })
+
+  afterEach(() => {
+    realFs.rmSync?.(mountRoot, { recursive: true, force: true })
+  })
+
+  it('classifies a stat failure whose errno accessor throws as indeterminate', () => {
+    statFaults.hold(mountedHome, () => {
+      throw {
+        get code(): string {
+          throw new Error('accessor exploded')
+        }
+      }
+    })
+
+    expect(() => new CodexManagedHomePath(() => '').assert(mountedHome, ACCOUNT_ID)).toThrow(
+      ManagedCodexHomeTemporarilyUnavailableError
+    )
+  })
+
+  it('classifies a thrown non-object as indeterminate', () => {
+    statFaults.hold(join(mountedHome, '.orca-managed-home'), () => {
+      throw 'the filesystem said no'
+    })
+
+    expect(() => new CodexManagedHomePath(() => '').assert(mountedHome, ACCOUNT_ID)).toThrow(
+      ManagedCodexHomeTemporarilyUnavailableError
+    )
+  })
+})
+
+describe('re-authentication preparation when wsl.exe cannot be launched', () => {
+  const account = {
+    id: ACCOUNT_ID,
+    email: 'dev@example.com',
+    managedHomePath: `\\\\wsl.localhost\\Ubuntu${LINUX_HOME.replace(/\//g, '\\')}`,
+    managedHomeRuntime: 'wsl' as const,
+    wslDistro: 'Ubuntu',
+    wslLinuxHomePath: LINUX_HOME,
+    providerAccountId: null,
+    workspaceLabel: null,
+    workspaceAccountId: null,
+    createdAt: 0,
+    updatedAt: 0,
+    lastAuthenticatedAt: 0
+  }
+
+  function ownedVerdict(): string {
+    return `ORCA_CODEX_HOME_VERDICT:owned:${Buffer.from(LINUX_HOME, 'utf-8').toString('base64')}\n`
+  }
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+  })
+
+  it('classifies a spawn rejection as indeterminate', async () => {
+    const spawnFailure: NodeJS.ErrnoException = new Error('spawn wsl.exe ENOENT')
+    spawnFailure.code = 'ENOENT'
+    runWslProcessMock.mockRejectedValue(spawnFailure)
+    const paths = new CodexManagedHomePath(() => ownedVerdict())
+
+    let thrown: unknown
+    try {
+      await paths.ensureForReauthentication(account)
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(ManagedCodexHomeTemporarilyUnavailableError)
+    expect((thrown as Error).cause).toBe(spawnFailure)
+  })
+
+  it('classifies a non-Error rejection from a wrapper as indeterminate', async () => {
+    runWslProcessMock.mockRejectedValue('wsl.exe is not on PATH')
+    const paths = new CodexManagedHomePath(() => ownedVerdict())
+
+    await expect(paths.ensureForReauthentication(account)).rejects.toBeInstanceOf(
+      ManagedCodexHomeTemporarilyUnavailableError
+    )
+  })
+
+  it('refuses when preparation finds a symlink in the marker position', async () => {
+    // Exit 43: the guest must not `printf >` through a symlink, which would
+    // write the account id into whatever the link points at.
+    runWslProcessMock.mockResolvedValue({
+      code: 43,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      environmentResolved: true
+    })
+    const paths = new CodexManagedHomePath(() => ownedVerdict())
+
+    let thrown: unknown
+    try {
+      await paths.ensureForReauthentication(account)
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(UntrustedManagedCodexHomeError)
+    expect((thrown as Error).message).toBe(MARKER_NOT_REGULAR_FILE_MESSAGE)
+  })
+
+  it('still resolves when preparation succeeds', async () => {
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      environmentResolved: true
+    })
+    const paths = new CodexManagedHomePath(() => ownedVerdict())
+
+    await expect(paths.ensureForReauthentication(account)).resolves.toBe(account.managedHomePath)
+  })
+})

--- a/src/main/codex-accounts/sta-5616-wsl-ownership-transient-collapse.test.ts
+++ b/src/main/codex-accounts/sta-5616-wsl-ownership-transient-collapse.test.ts
@@ -1,0 +1,386 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import type * as WslPaths from '../../shared/wsl-paths'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// STA-5616 regression: the WSL ownership probe collapsed every failure into a
+// TRUST verdict, so a cold distro, a 5s timeout, or a 9p hiccup was
+// indistinguishable from "this home is not Orca-owned". The host lane has had
+// the owned/untrusted/indeterminate tri-state since STA-4422; only a
+// *dispositive* untrusted verdict may clear durable state.
+
+const rmSyncMock = vi.hoisted(() => vi.fn())
+
+/** `rmSync` is mocked below, so fixture teardown needs the unmocked original. */
+const realFs = vi.hoisted(() => ({ rmSync: null as typeof NodeFs.rmSync | null }))
+
+/** Paths that fail every read with an injected errno, modelling a held 9p/AV lock. */
+const fsFaults = vi.hoisted(() => {
+  const held = new Map<string, string>()
+  return {
+    hold(path: string, code: string): void {
+      held.set(path, code)
+    },
+    reset(): void {
+      held.clear()
+    },
+    consume(target: unknown, syscall: string): void {
+      const code = typeof target === 'string' ? held.get(target) : undefined
+      if (!code) {
+        return
+      }
+      const error: NodeJS.ErrnoException = new Error(`${code}: ${syscall} '${String(target)}'`)
+      error.code = code
+      error.syscall = syscall
+      error.path = String(target)
+      throw error
+    }
+  }
+})
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  realFs.rmSync = actual.rmSync
+  const patched = {
+    ...actual,
+    rmSync: rmSyncMock,
+    statSync: (...args: unknown[]) => {
+      fsFaults.consume(args[0], 'stat')
+      return (actual.statSync as (...a: unknown[]) => unknown)(...args)
+    },
+    lstatSync: (...args: unknown[]) => {
+      fsFaults.consume(args[0], 'lstat')
+      return (actual.lstatSync as (...a: unknown[]) => unknown)(...args)
+    }
+  }
+  return { ...patched, default: patched }
+})
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/unused-user-data' }
+}))
+
+/** Lets a real temp dir stand in for a drvfs/9p mount of a WSL managed home. */
+const mountedPathAlias = vi.hoisted(() => ({ hostPath: '', linuxPath: '' }))
+
+vi.mock('../../shared/wsl-paths', async (importOriginal) => {
+  const actual = await importOriginal<typeof WslPaths>()
+  return {
+    ...actual,
+    parseWslUncPath: (path: string) =>
+      path === mountedPathAlias.hostPath && path !== ''
+        ? { distro: 'Ubuntu', linuxPath: mountedPathAlias.linuxPath }
+        : actual.parseWslUncPath(path)
+  }
+})
+
+const runWslProcessMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
+
+import { CodexManagedHomeLifecycle } from './codex-managed-home-lifecycle'
+import { CodexManagedHomePath } from './codex-managed-home-path'
+import {
+  ManagedCodexHomeTemporarilyUnavailableError,
+  UntrustedManagedCodexHomeError
+} from './host-codex-managed-home-ownership'
+
+const DISTRO = 'Ubuntu'
+const ACCOUNT_ID = 'account-1'
+const LINUX_HOME = `/home/dev/.local/share/orca/codex-accounts/${ACCOUNT_ID}/home`
+const UNC_HOME = `\\\\wsl.localhost\\${DISTRO}${LINUX_HOME.replace(/\//g, '\\')}`
+
+/** The tagged line the guest prints for an Orca-owned home. */
+function ownedVerdict(linuxPath = LINUX_HOME): string {
+  return `ORCA_CODEX_HOME_VERDICT:owned:${Buffer.from(linuxPath, 'utf-8').toString('base64')}\n`
+}
+
+/** A `wsl.exe` run that never produced output: killed at the 5s timeout. */
+function timeoutFailure(): Error {
+  const error = new Error('spawnSync wsl.exe ETIMEDOUT') as NodeJS.ErrnoException & {
+    signal?: string
+    status?: number | null
+  }
+  error.code = 'ETIMEDOUT'
+  error.signal = 'SIGTERM'
+  error.status = null
+  return error
+}
+
+let originalPlatform: PropertyDescriptor | undefined
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
+beforeEach(() => {
+  originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  setPlatform('win32')
+  rmSyncMock.mockReset()
+  runWslProcessMock.mockReset()
+  fsFaults.reset()
+  mountedPathAlias.hostPath = ''
+  mountedPathAlias.linuxPath = ''
+})
+
+afterEach(() => {
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+  vi.restoreAllMocks()
+})
+
+describe('WSL Codex ownership probe classification', () => {
+  it('reports a probe timeout as indeterminate, not as an untrusted home', () => {
+    const paths = new CodexManagedHomePath(() => {
+      throw timeoutFailure()
+    })
+
+    let thrown: unknown
+    try {
+      paths.assert(UNC_HOME, ACCOUNT_ID)
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(ManagedCodexHomeTemporarilyUnavailableError)
+    expect(thrown).not.toBeInstanceOf(UntrustedManagedCodexHomeError)
+  })
+
+  it('reports a probe that emits no verdict as indeterminate', () => {
+    const paths = new CodexManagedHomePath(() => '')
+
+    expect(() => paths.assert(UNC_HOME, ACCOUNT_ID)).toThrow(
+      ManagedCodexHomeTemporarilyUnavailableError
+    )
+  })
+
+  it('still reports a marker owned by another account as a dispositive untrusted verdict', () => {
+    const paths = new CodexManagedHomePath(() => 'ORCA_CODEX_HOME_VERDICT:marker-mismatch\n')
+
+    let thrown: unknown
+    try {
+      paths.assert(UNC_HOME, ACCOUNT_ID)
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(UntrustedManagedCodexHomeError)
+    expect(thrown).not.toBeInstanceOf(ManagedCodexHomeTemporarilyUnavailableError)
+  })
+
+  it('still reports a missing ownership marker as a dispositive untrusted verdict', () => {
+    const paths = new CodexManagedHomePath(() => 'ORCA_CODEX_HOME_VERDICT:missing-marker\n')
+
+    expect(() => paths.assert(UNC_HOME, ACCOUNT_ID)).toThrow(UntrustedManagedCodexHomeError)
+  })
+
+  it('resolves an owned home back to its Windows spelling', () => {
+    const paths = new CodexManagedHomePath(() => ownedVerdict())
+
+    expect(paths.assert(UNC_HOME, ACCOUNT_ID)).toBe(UNC_HOME)
+  })
+
+  it('rejects a structurally foreign WSL path as untrusted without running a probe', () => {
+    const probe = vi.fn(() => '')
+    const paths = new CodexManagedHomePath(probe)
+
+    expect(() =>
+      paths.assert(`\\\\wsl.localhost\\${DISTRO}\\home\\dev\\.codex`, ACCOUNT_ID)
+    ).toThrow(UntrustedManagedCodexHomeError)
+    expect(probe).not.toHaveBeenCalled()
+  })
+
+  it('rejects a managed path spelled for another account as untrusted without a probe', () => {
+    const probe = vi.fn(() => '')
+    const paths = new CodexManagedHomePath(probe)
+    const otherAccountHome = UNC_HOME.replace(ACCOUNT_ID, 'someone-else')
+
+    expect(() => paths.assert(otherAccountHome, ACCOUNT_ID)).toThrow(UntrustedManagedCodexHomeError)
+    expect(probe).not.toHaveBeenCalled()
+  })
+})
+
+describe('WSL managed home cleanup after a fail-once probe', () => {
+  it('does not delete a freshly authenticated WSL home when the probe failed transiently', () => {
+    // Models the real add path: the ownership re-gate inside identity read hits a
+    // transient fault, `add` rolls back, and the rollback's own re-gate succeeds
+    // because the fault was transient. Before STA-5616 that deleted the home.
+    let calls = 0
+    const paths = new CodexManagedHomePath(() => {
+      calls += 1
+      if (calls === 1) {
+        throw timeoutFailure()
+      }
+      return ownedVerdict()
+    })
+    const lifecycle = new CodexManagedHomeLifecycle(paths)
+
+    let addFailure: unknown
+    try {
+      paths.assert(UNC_HOME, ACCOUNT_ID)
+    } catch (error) {
+      addFailure = error
+    }
+    lifecycle.removeUnlessUnproven(addFailure, UNC_HOME, ACCOUNT_ID)
+
+    expect(rmSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('still deletes the home when the add failed for a proven reason', () => {
+    // Control for the case above: same rollback, same healthy probe, but a
+    // failure that is not an unproven observation. Cleanup must still run.
+    const paths = new CodexManagedHomePath(() => ownedVerdict())
+    const lifecycle = new CodexManagedHomeLifecycle(paths)
+
+    lifecycle.removeUnlessUnproven(
+      new Error('Codex login completed, but Orca could not resolve the account email.'),
+      UNC_HOME,
+      ACCOUNT_ID
+    )
+
+    expect(rmSyncMock).toHaveBeenCalled()
+  })
+
+  it('refuses to delete a home the probe proved belongs to another account', () => {
+    const paths = new CodexManagedHomePath(() => 'ORCA_CODEX_HOME_VERDICT:marker-mismatch\n')
+    const lifecycle = new CodexManagedHomeLifecycle(paths)
+
+    let addFailure: unknown
+    try {
+      paths.assert(UNC_HOME, ACCOUNT_ID)
+    } catch (error) {
+      addFailure = error
+    }
+    lifecycle.removeUnlessUnproven(addFailure, UNC_HOME, ACCOUNT_ID)
+
+    expect(addFailure).toBeInstanceOf(UntrustedManagedCodexHomeError)
+    expect(rmSyncMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('WSL managed home preparation for re-authentication', () => {
+  const account = {
+    id: ACCOUNT_ID,
+    email: 'dev@example.com',
+    managedHomePath: UNC_HOME,
+    managedHomeRuntime: 'wsl' as const,
+    wslDistro: DISTRO,
+    wslLinuxHomePath: LINUX_HOME,
+    providerAccountId: null,
+    workspaceLabel: null,
+    workspaceAccountId: null,
+    createdAt: 0,
+    updatedAt: 0,
+    lastAuthenticatedAt: 0
+  }
+
+  // A kill at the deadline can still report a zero status, so `timedOut` has to
+  // be read on its own rather than inferred from the exit code.
+  it.each([null, 0])(
+    'reports a preparation timed out at exit %s as indeterminate',
+    async (code) => {
+      runWslProcessMock.mockResolvedValue({
+        code,
+        stdout: '',
+        stderr: '',
+        timedOut: true,
+        environmentResolved: true
+      })
+      const paths = new CodexManagedHomePath(() => ownedVerdict())
+
+      await expect(paths.ensureForReauthentication(account)).rejects.toBeInstanceOf(
+        ManagedCodexHomeTemporarilyUnavailableError
+      )
+    }
+  )
+
+  it('reports a foreign directory found during preparation as untrusted', async () => {
+    runWslProcessMock.mockResolvedValue({
+      code: 41,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      environmentResolved: true
+    })
+    const paths = new CodexManagedHomePath(() => ownedVerdict())
+
+    await expect(paths.ensureForReauthentication(account)).rejects.toBeInstanceOf(
+      UntrustedManagedCodexHomeError
+    )
+  })
+
+  it('reports an unexplained preparation exit as indeterminate', async () => {
+    runWslProcessMock.mockResolvedValue({
+      code: 127,
+      stdout: '',
+      stderr: 'bash: not found',
+      timedOut: false,
+      environmentResolved: true
+    })
+    const paths = new CodexManagedHomePath(() => ownedVerdict())
+
+    await expect(paths.ensureForReauthentication(account)).rejects.toBeInstanceOf(
+      ManagedCodexHomeTemporarilyUnavailableError
+    )
+  })
+})
+
+describe('mounted WSL Codex home reached through the filesystem, not wsl.exe', () => {
+  let mountRoot: string
+  let mountedHome: string
+
+  beforeEach(() => {
+    setPlatform('linux')
+    mountRoot = mkdtempSync(join(tmpdir(), 'orca-sta-5616-'))
+    mountedHome = join(mountRoot, 'home')
+    mkdirSync(mountedHome, { recursive: true })
+    writeFileSync(join(mountedHome, '.orca-managed-home'), `${ACCOUNT_ID}\n`, 'utf-8')
+    mountedPathAlias.hostPath = mountedHome
+    mountedPathAlias.linuxPath = LINUX_HOME
+  })
+
+  afterEach(() => {
+    realFs.rmSync!(mountRoot, { recursive: true, force: true })
+  })
+
+  function assertMounted(): string {
+    return new CodexManagedHomePath(() => '').assert(mountedHome, ACCOUNT_ID)
+  }
+
+  it('accepts a marked home under the managed root', () => {
+    expect(assertMounted()).toBe(mountedHome)
+  })
+
+  it('reports a home the filesystem refuses to stat as indeterminate', () => {
+    fsFaults.hold(mountedHome, 'EPERM')
+
+    expect(assertMounted).toThrow(ManagedCodexHomeTemporarilyUnavailableError)
+  })
+
+  it('reports an unreadable ownership marker as indeterminate, not as a missing one', () => {
+    fsFaults.hold(join(mountedHome, '.orca-managed-home'), 'EBUSY')
+
+    expect(assertMounted).toThrow(ManagedCodexHomeTemporarilyUnavailableError)
+  })
+
+  it('still reports a definitively absent marker as untrusted', () => {
+    realFs.rmSync!(join(mountedHome, '.orca-managed-home'))
+
+    expect(assertMounted).toThrow(UntrustedManagedCodexHomeError)
+  })
+
+  it('still reports a definitively absent home as untrusted', () => {
+    realFs.rmSync!(mountedHome, { recursive: true })
+
+    expect(assertMounted).toThrow(UntrustedManagedCodexHomeError)
+  })
+
+  it('still reports a marker owned by another account as untrusted', () => {
+    writeFileSync(join(mountedHome, '.orca-managed-home'), 'someone-else\n', 'utf-8')
+
+    expect(assertMounted).toThrow(UntrustedManagedCodexHomeError)
+  })
+})

--- a/src/main/codex-accounts/wsl-codex-managed-home-preparation-script.test.ts
+++ b/src/main/codex-accounts/wsl-codex-managed-home-preparation-script.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  buildWslManagedHomePreparationScript,
+  WSL_PREPARE_INDETERMINATE_EXIT,
+  WSL_PREPARE_MARKER_MISMATCH_EXIT,
+  WSL_PREPARE_MARKER_MISSING_EXIT,
+  WSL_PREPARE_MARKER_NOT_REGULAR_EXIT
+} from './wsl-codex-managed-home-preparation'
+
+/**
+ * The preparation script WRITES, and only exits 41/42/43 may be read as a trust
+ * verdict. Running it for real is the only way to pin that: mocking the runner
+ * asserts the mapping while leaving the script itself unexercised.
+ */
+const ACCOUNT_ID = 'account-1'
+
+describe.skipIf(process.platform === 'win32')('WSL managed home preparation script', () => {
+  let root: string
+  let candidate: string
+  let marker: string
+  const sealed: string[] = []
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-wsl-prepare-'))
+    candidate = join(root, '.local', 'share', 'orca', 'codex-accounts', ACCOUNT_ID, 'home')
+    marker = join(candidate, '.orca-managed-home')
+    sealed.length = 0
+  })
+
+  afterEach(() => {
+    for (const path of sealed) {
+      try {
+        chmodSync(path, 0o755)
+      } catch {
+        // already gone
+      }
+    }
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function prepare(): number {
+    const result = spawnSync(
+      'bash',
+      ['-c', buildWslManagedHomePreparationScript(candidate, ACCOUNT_ID)],
+      { encoding: 'utf-8', timeout: 20_000 }
+    )
+    return result.status ?? -1
+  }
+
+  it('creates the home and marker on a first run', () => {
+    expect(prepare()).toBe(0)
+    expect(readFileSync(marker, 'utf-8')).toBe(`${ACCOUNT_ID}\n`)
+  })
+
+  it('is idempotent over an already-prepared home', () => {
+    expect(prepare()).toBe(0)
+    expect(prepare()).toBe(0)
+    expect(readFileSync(marker, 'utf-8')).toBe(`${ACCOUNT_ID}\n`)
+  })
+
+  it('refuses a symlinked marker and does not write through it', () => {
+    const decoy = join(root, 'decoy')
+    writeFileSync(decoy, 'untouched\n', 'utf-8')
+    mkdirSync(candidate, { recursive: true })
+    symlinkSync(decoy, marker)
+
+    expect(prepare()).toBe(WSL_PREPARE_MARKER_NOT_REGULAR_EXIT)
+    expect(readFileSync(decoy, 'utf-8')).toBe('untouched\n')
+    expect(lstatSync(marker).isSymbolicLink()).toBe(true)
+  })
+
+  it('refuses a directory in the marker position', () => {
+    mkdirSync(marker, { recursive: true })
+
+    expect(prepare()).toBe(WSL_PREPARE_MARKER_NOT_REGULAR_EXIT)
+  })
+
+  it('refuses an existing home that has no marker', () => {
+    mkdirSync(candidate, { recursive: true })
+
+    expect(prepare()).toBe(WSL_PREPARE_MARKER_MISSING_EXIT)
+  })
+
+  it('refuses a home marked for another account', () => {
+    mkdirSync(candidate, { recursive: true })
+    writeFileSync(marker, 'someone-else\n', 'utf-8')
+
+    expect(prepare()).toBe(WSL_PREPARE_MARKER_MISMATCH_EXIT)
+  })
+
+  it('reports "could not tell" rather than a foreign home when it cannot list', () => {
+    // A present home Orca simply cannot read must not exit 41 — re-auth refuses
+    // on 41, so that would lock the user out of their own account.
+    mkdirSync(candidate, { recursive: true })
+    writeFileSync(marker, `${ACCOUNT_ID}\n`, 'utf-8')
+    sealed.push(candidate)
+    chmodSync(candidate, 0o000)
+
+    const status = prepare()
+
+    expect(status).not.toBe(WSL_PREPARE_MARKER_MISSING_EXIT)
+    expect(status).not.toBe(WSL_PREPARE_MARKER_MISMATCH_EXIT)
+    expect(status).not.toBe(WSL_PREPARE_MARKER_NOT_REGULAR_EXIT)
+    expect(status).not.toBe(0)
+  })
+
+  it('reports "could not tell" when the marker is listed but unreadable', () => {
+    mkdirSync(candidate, { recursive: true })
+    writeFileSync(marker, `${ACCOUNT_ID}\n`, 'utf-8')
+    sealed.push(candidate)
+    chmodSync(candidate, 0o444) // readable (listable) but not searchable
+
+    expect(prepare()).toBe(WSL_PREPARE_INDETERMINATE_EXIT)
+  })
+
+  it('leaves nothing behind when it refuses', () => {
+    mkdirSync(candidate, { recursive: true })
+    writeFileSync(marker, 'someone-else\n', 'utf-8')
+
+    prepare()
+
+    expect(readFileSync(marker, 'utf-8')).toBe('someone-else\n')
+    expect(existsSync(join(candidate, '.orca-managed-home.tmp'))).toBe(false)
+  })
+})

--- a/src/main/codex-accounts/wsl-codex-managed-home-preparation.ts
+++ b/src/main/codex-accounts/wsl-codex-managed-home-preparation.ts
@@ -1,0 +1,58 @@
+import { quotePosixShell } from '../../shared/wsl-login-shell-command'
+import {
+  MARKER_NOT_REGULAR_FILE_MESSAGE,
+  MISSING_OWNERSHIP_MARKER_MESSAGE
+} from './host-codex-managed-home-ownership'
+import { MARKER_ACCOUNT_MISMATCH_MESSAGE } from './wsl-codex-managed-home-probe'
+
+/**
+ * Re-auth creates the managed home in the guest before the read probe gates it.
+ * It runs as a separate script because it *writes*, and the exit codes below are
+ * the only ones that may be read as a trust verdict — every other status is a
+ * failure to determine, which the host maps to indeterminate (STA-5616).
+ */
+export const WSL_PREPARE_MARKER_MISSING_EXIT = 41
+export const WSL_PREPARE_MARKER_MISMATCH_EXIT = 42
+export const WSL_PREPARE_MARKER_NOT_REGULAR_EXIT = 43
+/** Reserved so the guest can say "I could not tell" instead of guessing. */
+export const WSL_PREPARE_INDETERMINATE_EXIT = 44
+
+export const WSL_PREPARE_UNTRUSTED_EXITS = new Map<number, string>([
+  [WSL_PREPARE_MARKER_MISSING_EXIT, MISSING_OWNERSHIP_MARKER_MESSAGE],
+  [WSL_PREPARE_MARKER_MISMATCH_EXIT, MARKER_ACCOUNT_MISMATCH_MESSAGE],
+  [WSL_PREPARE_MARKER_NOT_REGULAR_EXIT, MARKER_NOT_REGULAR_FILE_MESSAGE]
+])
+
+/**
+ * Why the listing dance around a missing marker: `test -e` fails identically for
+ * "not there" and "cannot look", so exiting 41 straight off it would report an
+ * unreadable home as a foreign one — and re-auth refuses on 41. Absence is only
+ * dispositive when the home can be listed and the marker is not in it.
+ */
+export function buildWslManagedHomePreparationScript(
+  linuxPath: string,
+  expectedAccountId: string
+): string {
+  return [
+    'set -euo pipefail',
+    `candidate=${quotePosixShell(linuxPath)}`,
+    `expected_marker=${quotePosixShell(expectedAccountId)}`,
+    'marker="$candidate/.orca-managed-home"',
+    // lstat first: writing through a symlink would put the account id into
+    // whatever the link points at, before any ownership check has run.
+    `if [ -h "$marker" ]; then exit ${WSL_PREPARE_MARKER_NOT_REGULAR_EXIT}; fi`,
+    'if [ -e "$candidate" ]; then',
+    '  if [ ! -e "$marker" ]; then',
+    `    ls -A -- "$candidate" >/dev/null 2>&1 || exit ${WSL_PREPARE_INDETERMINATE_EXIT}`,
+    '    if ls -A -- "$candidate" 2>/dev/null | grep -Fxq -- .orca-managed-home; then',
+    `      exit ${WSL_PREPARE_INDETERMINATE_EXIT}`,
+    '    fi',
+    `    exit ${WSL_PREPARE_MARKER_MISSING_EXIT}`,
+    '  fi',
+    `  if [ ! -f "$marker" ]; then exit ${WSL_PREPARE_MARKER_NOT_REGULAR_EXIT}; fi`,
+    `  if [ "$(cat -- "$marker")" != "$expected_marker" ]; then exit ${WSL_PREPARE_MARKER_MISMATCH_EXIT}; fi`,
+    'fi',
+    'mkdir -p -- "$candidate"',
+    `printf '%s\\n' "$expected_marker" > "$marker"`
+  ].join('\n')
+}

--- a/src/main/codex-accounts/wsl-codex-managed-home-preparation.ts
+++ b/src/main/codex-accounts/wsl-codex-managed-home-preparation.ts
@@ -1,4 +1,6 @@
 import { quotePosixShell } from '../../shared/wsl-login-shell-command'
+import { readUntrustedBoolean, readUntrustedExitCode } from '../../shared/untrusted-value-fields'
+import { buildWslGuestObservationPrelude } from './wsl-guest-filesystem-observation'
 import {
   MARKER_NOT_REGULAR_FILE_MESSAGE,
   MISSING_OWNERSHIP_MARKER_MESSAGE
@@ -24,10 +26,10 @@ export const WSL_PREPARE_UNTRUSTED_EXITS = new Map<number, string>([
 ])
 
 /**
- * Why the listing dance around a missing marker: `test -e` fails identically for
- * "not there" and "cannot look", so exiting 41 straight off it would report an
- * unreadable home as a foreign one — and re-auth refuses on 41. Absence is only
- * dispositive when the home can be listed and the marker is not in it.
+ * Every observation goes through `kind_of`, and every read is status-checked, so
+ * a failure can only reach `WSL_PREPARE_INDETERMINATE_EXIT`. Exits 41/42/43 are
+ * reachable only from a successful read — re-auth refuses on them, so a failed
+ * observation arriving there would lock a user out of their own account.
  */
 export function buildWslManagedHomePreparationScript(
   linuxPath: string,
@@ -35,24 +37,72 @@ export function buildWslManagedHomePreparationScript(
 ): string {
   return [
     'set -euo pipefail',
+    ...buildWslGuestObservationPrelude(WSL_PREPARE_INDETERMINATE_EXIT),
     `candidate=${quotePosixShell(linuxPath)}`,
     `expected_marker=${quotePosixShell(expectedAccountId)}`,
     'marker="$candidate/.orca-managed-home"',
-    // lstat first: writing through a symlink would put the account id into
-    // whatever the link points at, before any ownership check has run.
-    `if [ -h "$marker" ]; then exit ${WSL_PREPARE_MARKER_NOT_REGULAR_EXIT}; fi`,
+    // `-e` is trusted only when it says yes. Its "no" is not turned into a
+    // verdict: it falls through to `mkdir -p`, and under `set -e` a home that
+    // could not be created fails the script into the indeterminate lane.
     'if [ -e "$candidate" ]; then',
-    '  if [ ! -e "$marker" ]; then',
-    `    ls -A -- "$candidate" >/dev/null 2>&1 || exit ${WSL_PREPARE_INDETERMINATE_EXIT}`,
-    '    if ls -A -- "$candidate" 2>/dev/null | grep -Fxq -- .orca-managed-home; then',
-    `      exit ${WSL_PREPARE_INDETERMINATE_EXIT}`,
-    '    fi',
-    `    exit ${WSL_PREPARE_MARKER_MISSING_EXIT}`,
-    '  fi',
-    `  if [ ! -f "$marker" ]; then exit ${WSL_PREPARE_MARKER_NOT_REGULAR_EXIT}; fi`,
-    `  if [ "$(cat -- "$marker")" != "$expected_marker" ]; then exit ${WSL_PREPARE_MARKER_MISMATCH_EXIT}; fi`,
+    '  kind_of "$marker" "$candidate" .orca-managed-home',
+    '  case "$KIND" in',
+    `    absent) exit ${WSL_PREPARE_MARKER_MISSING_EXIT} ;;`,
+    '    regular) ;;',
+    // Writing through a symlink would put the account id into whatever the link
+    // points at, before any ownership check has run.
+    `    *) exit ${WSL_PREPARE_MARKER_NOT_REGULAR_EXIT} ;;`,
+    '  esac',
+    '  contents=$(cat -- "$marker") || unknown',
+    `  if [ "$contents" != "$expected_marker" ]; then exit ${WSL_PREPARE_MARKER_MISMATCH_EXIT}; fi`,
     'fi',
     'mkdir -p -- "$candidate"',
     `printf '%s\\n' "$expected_marker" > "$marker"`
   ].join('\n')
+}
+
+/**
+ * Turns whatever the runner resolved into a verdict. Split out so the shape
+ * check lives beside the exit-code table rather than in the caller, where an
+ * unvalidated `result.timedOut` used to throw straight past the fail-closed path.
+ */
+export type WslPreparationOutcome =
+  | { kind: 'prepared' }
+  | { kind: 'untrusted'; reason: string }
+  | { kind: 'indeterminate'; reason: string }
+
+export function interpretWslPreparationResult(
+  result: unknown,
+  distro: string
+): WslPreparationOutcome {
+  const timedOut = readUntrustedBoolean(result, 'timedOut')
+  if (timedOut === undefined) {
+    return {
+      kind: 'indeterminate',
+      reason: `Preparing the managed Codex home in WSL ${distro} returned an unreadable result.`
+    }
+  }
+  if (timedOut) {
+    return {
+      kind: 'indeterminate',
+      reason: `Preparing the managed Codex home in WSL ${distro} timed out.`
+    }
+  }
+  const code = readUntrustedExitCode(result, 'code')
+  if (code === undefined || code === null) {
+    return {
+      kind: 'indeterminate',
+      reason: `Preparing the managed Codex home in WSL ${distro} reported no exit code.`
+    }
+  }
+  const untrustedReason = WSL_PREPARE_UNTRUSTED_EXITS.get(code)
+  if (untrustedReason !== undefined) {
+    return { kind: 'untrusted', reason: untrustedReason }
+  }
+  return code === 0
+    ? { kind: 'prepared' }
+    : {
+        kind: 'indeterminate',
+        reason: `Preparing the managed Codex home in WSL ${distro} exited with code ${String(code)}.`
+      }
 }

--- a/src/main/codex-accounts/wsl-codex-managed-home-probe-script.test.ts
+++ b/src/main/codex-accounts/wsl-codex-managed-home-probe-script.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+vi.mock('../wsl', () => ({
+  toWindowsWslPath: (linuxPath: string, distro: string) =>
+    `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
+}))
+
+import {
+  buildWslCodexManagedHomeProbeScript,
+  classifyWslCodexManagedHomeProbe
+} from './wsl-codex-managed-home-probe'
+
+/**
+ * Runs the real guest script under a POSIX shell against real fixtures, because
+ * the defects this covers are shell semantics — `test -e` and `test -f` report
+ * the same status for "absent" and "cannot look" — which no string assertion on
+ * the generated script can catch.
+ */
+const DISTRO = 'Ubuntu'
+const ACCOUNT_ID = 'account-1'
+
+describe.skipIf(process.platform === 'win32')('WSL probe script against a real filesystem', () => {
+  let guestHome: string
+  let managedRoot: string
+  let accountDir: string
+  let candidate: string
+  let marker: string
+  const restoreModes: string[] = []
+
+  beforeEach(() => {
+    guestHome = mkdtempSync(join(tmpdir(), 'orca-wsl-probe-'))
+    managedRoot = join(guestHome, '.local', 'share', 'orca', 'codex-accounts')
+    accountDir = join(managedRoot, ACCOUNT_ID)
+    candidate = join(accountDir, 'home')
+    marker = join(candidate, '.orca-managed-home')
+    mkdirSync(candidate, { recursive: true })
+    writeFileSync(marker, `${ACCOUNT_ID}\n`, 'utf-8')
+    restoreModes.length = 0
+  })
+
+  afterEach(() => {
+    for (const path of restoreModes) {
+      try {
+        chmodSync(path, 0o755)
+      } catch {
+        // already gone
+      }
+    }
+    rmSync(guestHome, { recursive: true, force: true })
+  })
+
+  function seal(path: string): void {
+    restoreModes.push(path)
+    chmodSync(path, 0o000)
+  }
+
+  function probe(expectedAccountId: string | undefined = ACCOUNT_ID) {
+    const script = buildWslCodexManagedHomeProbeScript(candidate, expectedAccountId)
+    let stdout: string
+    try {
+      stdout = execFileSync('bash', ['-c', script], {
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: guestHome },
+        timeout: 20_000
+      })
+    } catch (error) {
+      return classifyWslCodexManagedHomeProbe({ ran: false, error }, DISTRO)
+    }
+    return classifyWslCodexManagedHomeProbe({ ran: true, stdout }, DISTRO)
+  }
+
+  it('accepts a real, correctly marked managed home', () => {
+    // The guest canonicalises, and macOS resolves the temp root through /private.
+    const canonical = realpathSync(candidate)
+
+    expect(probe()).toEqual({
+      kind: 'owned',
+      homePath: `\\\\wsl.localhost\\${DISTRO}${canonical.replace(/\//g, '\\')}`
+    })
+  })
+
+  it('reports a home whose parent directory cannot be searched as indeterminate', () => {
+    // The home is present; only permission is missing. `test -e` cannot tell that
+    // from absence, and an absence tag is a trust verdict.
+    seal(accountDir)
+
+    expect(probe().kind).toBe('indeterminate')
+  })
+
+  it('reports a marker that cannot be reached as indeterminate', () => {
+    seal(candidate)
+
+    expect(probe().kind).toBe('indeterminate')
+  })
+
+  it('reports a symlink loop in the home position as indeterminate', () => {
+    // `test -e` fails with ELOOP while the entry is still listed in its parent,
+    // so "not stattable" and "not there" are genuinely different observations.
+    rmSync(candidate, { recursive: true })
+    symlinkSync(join(accountDir, 'loop-b'), candidate)
+    symlinkSync(candidate, join(accountDir, 'loop-b'))
+
+    expect(probe().kind).toBe('indeterminate')
+  })
+
+  it('still reports a genuinely absent home as untrusted', () => {
+    rmSync(candidate, { recursive: true })
+
+    expect(probe()).toEqual({
+      kind: 'untrusted',
+      reason: 'Managed Codex home directory does not exist on disk.'
+    })
+  })
+
+  it('still reports a genuinely absent marker as untrusted', () => {
+    rmSync(marker)
+
+    expect(probe()).toEqual({
+      kind: 'untrusted',
+      reason: 'Managed Codex home is missing Orca ownership marker.'
+    })
+  })
+
+  it('refuses a symlinked marker even when its target holds the right account id', () => {
+    const decoy = join(guestHome, 'decoy-marker')
+    writeFileSync(decoy, `${ACCOUNT_ID}\n`, 'utf-8')
+    rmSync(marker)
+    symlinkSync(decoy, marker)
+
+    expect(probe()).toEqual({
+      kind: 'untrusted',
+      reason: 'Managed Codex home ownership marker is not a regular file.'
+    })
+  })
+
+  it('refuses a directory in the marker position', () => {
+    rmSync(marker)
+    mkdirSync(marker)
+
+    expect(probe().kind).toBe('untrusted')
+  })
+
+  it('still reports a marker belonging to another account as untrusted', () => {
+    writeFileSync(marker, 'someone-else\n', 'utf-8')
+
+    expect(probe()).toEqual({
+      kind: 'untrusted',
+      reason: 'Managed WSL Codex home ownership marker does not match its account ID.'
+    })
+  })
+
+  it('still reports a home outside the managed root as untrusted', () => {
+    const stray = join(guestHome, 'elsewhere', 'home')
+    mkdirSync(stray, { recursive: true })
+    writeFileSync(join(stray, '.orca-managed-home'), `${ACCOUNT_ID}\n`, 'utf-8')
+    candidate = stray
+
+    expect(probe(undefined).kind).toBe('untrusted')
+  })
+})

--- a/src/main/codex-accounts/wsl-codex-managed-home-probe.test.ts
+++ b/src/main/codex-accounts/wsl-codex-managed-home-probe.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../wsl', () => ({
+  toWindowsWslPath: (linuxPath: string, distro: string) =>
+    `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
+}))
+
+import {
+  ACCOUNT_ID_MISMATCH_MESSAGE,
+  buildWslCodexManagedHomeProbeScript,
+  classifyWslCodexManagedHomeProbe,
+  MARKER_ACCOUNT_MISMATCH_MESSAGE,
+  OUTSIDE_MANAGED_ROOT_MESSAGE
+} from './wsl-codex-managed-home-probe'
+import {
+  MISSING_MANAGED_HOME_MESSAGE,
+  MISSING_OWNERSHIP_MARKER_MESSAGE
+} from './host-codex-managed-home-ownership'
+
+const DISTRO = 'Ubuntu'
+const LINUX_HOME = '/home/dev/.local/share/orca/codex-accounts/account-1/home'
+
+function tagged(value: string): string {
+  return `ORCA_CODEX_HOME_VERDICT:${value}\n`
+}
+
+function owned(linuxPath = LINUX_HOME): string {
+  return tagged(`owned:${Buffer.from(linuxPath, 'utf-8').toString('base64')}`)
+}
+
+describe('buildWslCodexManagedHomeProbeScript', () => {
+  it('single-quotes the candidate path so a crafted path cannot inject shell', () => {
+    const script = buildWslCodexManagedHomeProbeScript("/home/dev/'; rm -rf /; '", 'account-1')
+
+    expect(script).toContain(`candidate='/home/dev/'\\''; rm -rf /; '\\'''`)
+    expect(script).not.toMatch(/^\s*rm -rf/m)
+  })
+
+  it('pins the home to the expected account when one is given', () => {
+    const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME, 'account-1')
+
+    expect(script).toContain(`expected_marker='account-1'`)
+    expect(script).toContain('test "$candidate_real" = "$managed_root_real/$expected_marker/home"')
+    expect(script).toContain('test "$contents" = "$expected_marker"')
+  })
+
+  it('accepts any managed account home when no account is given', () => {
+    const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME)
+
+    expect(script).not.toContain('expected_marker')
+    expect(script).toContain('test -n "$contents" || tag marker-mismatch')
+  })
+
+  it('never lets the guest end on a bare non-zero exit for an ownership fact', () => {
+    const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME, 'account-1')
+
+    // Every structural fact is reported through `tag`, which exits 0; the bare
+    // `exit 1`s are reserved for reads that failed and prove nothing.
+    expect(script).not.toContain('exit 35')
+    expect(script.match(/\|\| exit 1$/gm)?.length).toBeGreaterThan(0)
+  })
+})
+
+describe('classifyWslCodexManagedHomeProbe', () => {
+  it('treats a runner failure as indeterminate', () => {
+    const cause = new Error('spawnSync wsl.exe ETIMEDOUT')
+
+    const verdict = classifyWslCodexManagedHomeProbe({ ran: false, error: cause }, DISTRO)
+
+    expect(verdict.kind).toBe('indeterminate')
+    expect((verdict as { error: Error }).error.cause).toBe(cause)
+  })
+
+  it.each([
+    ['', 'no output at all'],
+    ['/home/dev/some/path\n', 'a bare path, as the pre-STA-5616 protocol emitted'],
+    [`${owned()}trailing chatter\n`, 'output after the verdict'],
+    [`${owned()}${owned()}`, 'two verdicts'],
+    [tagged('who-knows'), 'an unrecognised tag'],
+    [tagged('owned:!!!not-base64!!!'), 'an undecodable path']
+  ])('treats %j as indeterminate (%s)', (stdout) => {
+    expect(classifyWslCodexManagedHomeProbe({ ran: true, stdout }, DISTRO).kind).toBe(
+      'indeterminate'
+    )
+  })
+
+  it.each([
+    ['missing-home', MISSING_MANAGED_HOME_MESSAGE],
+    ['missing-marker', MISSING_OWNERSHIP_MARKER_MESSAGE],
+    ['marker-mismatch', MARKER_ACCOUNT_MISMATCH_MESSAGE],
+    ['account-mismatch', ACCOUNT_ID_MISMATCH_MESSAGE],
+    ['outside-managed-root', OUTSIDE_MANAGED_ROOT_MESSAGE]
+  ])('treats the %s tag as a dispositive untrusted verdict', (tag, reason) => {
+    expect(classifyWslCodexManagedHomeProbe({ ran: true, stdout: tagged(tag) }, DISTRO)).toEqual({
+      kind: 'untrusted',
+      reason
+    })
+  })
+
+  it('decodes an owned verdict back to its Windows spelling', () => {
+    expect(classifyWslCodexManagedHomeProbe({ ran: true, stdout: owned() }, DISTRO)).toEqual({
+      kind: 'owned',
+      homePath: `\\\\wsl.localhost\\Ubuntu${LINUX_HOME.replace(/\//g, '\\')}`
+    })
+  })
+
+  it('tolerates CRLF and NUL padding from the wsl.exe pipe', () => {
+    const stdout = `${String.fromCharCode(0)} ${owned().trimEnd()}\r\n`
+
+    expect(classifyWslCodexManagedHomeProbe({ ran: true, stdout }, DISTRO).kind).toBe('owned')
+  })
+
+  it('carries a home whose name embeds the tag without truncating it', () => {
+    const oddPath = '/home/dev/.local/share/orca/codex-accounts/ORCA_CODEX_HOME_VERDICT:x/home'
+
+    const verdict = classifyWslCodexManagedHomeProbe({ ran: true, stdout: owned(oddPath) }, DISTRO)
+
+    expect(verdict).toEqual({
+      kind: 'owned',
+      homePath: `\\\\wsl.localhost\\Ubuntu${oddPath.replace(/\//g, '\\')}`
+    })
+  })
+})

--- a/src/main/codex-accounts/wsl-codex-managed-home-probe.test.ts
+++ b/src/main/codex-accounts/wsl-codex-managed-home-probe.test.ts
@@ -13,6 +13,7 @@ import {
   OUTSIDE_MANAGED_ROOT_MESSAGE
 } from './wsl-codex-managed-home-probe'
 import {
+  MARKER_NOT_REGULAR_FILE_MESSAGE,
   MISSING_MANAGED_HOME_MESSAGE,
   MISSING_OWNERSHIP_MARKER_MESSAGE
 } from './host-codex-managed-home-ownership'
@@ -51,6 +52,26 @@ describe('buildWslCodexManagedHomeProbeScript', () => {
     expect(script).toContain('test -n "$contents" || tag marker-mismatch')
   })
 
+  it('never tags absence straight off a failed `test`', () => {
+    const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME, 'account-1')
+
+    // `test -e ... || tag missing-*` is the collapse: a status of 1 means
+    // "absent OR could not look". Absence must route through prove_absent.
+    expect(script).not.toMatch(/test -e [^\n]*\|\| tag missing/)
+    expect(script).toMatch(/test -e "\$candidate" \|\| prove_absent /)
+    expect(script).toMatch(/test -e "\$marker" \|\| prove_absent /)
+  })
+
+  it('rejects a symlinked marker before reading it', () => {
+    const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME, 'account-1')
+    const lines = script.split('\n')
+
+    expect(script).toContain('test -h "$marker" && tag marker-not-regular')
+    expect(lines.findIndex((l) => l.includes('test -h "$marker"'))).toBeLessThan(
+      lines.findIndex((l) => l.includes('cat -- "$marker"'))
+    )
+  })
+
   it('never lets the guest end on a bare non-zero exit for an ownership fact', () => {
     const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME, 'account-1')
 
@@ -87,6 +108,7 @@ describe('classifyWslCodexManagedHomeProbe', () => {
   it.each([
     ['missing-home', MISSING_MANAGED_HOME_MESSAGE],
     ['missing-marker', MISSING_OWNERSHIP_MARKER_MESSAGE],
+    ['marker-not-regular', MARKER_NOT_REGULAR_FILE_MESSAGE],
     ['marker-mismatch', MARKER_ACCOUNT_MISMATCH_MESSAGE],
     ['account-mismatch', ACCOUNT_ID_MISMATCH_MESSAGE],
     ['outside-managed-root', OUTSIDE_MANAGED_ROOT_MESSAGE]

--- a/src/main/codex-accounts/wsl-codex-managed-home-probe.test.ts
+++ b/src/main/codex-accounts/wsl-codex-managed-home-probe.test.ts
@@ -41,34 +41,57 @@ describe('buildWslCodexManagedHomeProbeScript', () => {
     const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME, 'account-1')
 
     expect(script).toContain(`expected_marker='account-1'`)
-    expect(script).toContain('test "$candidate_real" = "$managed_root_real/$expected_marker/home"')
-    expect(script).toContain('test "$contents" = "$expected_marker"')
+    expect(script).toContain(
+      'if [ "$candidate_real" != "$managed_root_real/$expected_marker/home" ]; then tag account-mismatch; fi'
+    )
+    expect(script).toContain(
+      'if [ "$contents" != "$expected_marker" ]; then tag marker-mismatch; fi'
+    )
   })
 
   it('accepts any managed account home when no account is given', () => {
     const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME)
 
     expect(script).not.toContain('expected_marker')
-    expect(script).toContain('test -n "$contents" || tag marker-mismatch')
+    expect(script).toContain('case "$contents" in "") tag marker-mismatch ;; esac')
   })
 
-  it('never tags absence straight off a failed `test`', () => {
+  it('never derives a verdict from a raw filesystem test or a pipeline', () => {
     const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME, 'account-1')
 
-    // `test -e ... || tag missing-*` is the collapse: a status of 1 means
-    // "absent OR could not look". Absence must route through prove_absent.
-    expect(script).not.toMatch(/test -e [^\n]*\|\| tag missing/)
-    expect(script).toMatch(/test -e "\$candidate" \|\| prove_absent /)
-    expect(script).toMatch(/test -e "\$marker" \|\| prove_absent /)
+    // The invariant: a tag may only follow a command that SUCCEEDED. A `test`
+    // that failed, or a pipeline whose exit status conflates "no match" with
+    // "the producer died", must never reach one.
+    expect(script).not.toMatch(/test -[a-z] [^\n]*\|\| *tag /)
+    expect(script).not.toMatch(/test -[a-z] [^\n]*&& *tag /)
+    expect(script).not.toMatch(/\| *grep[^\n]*(&&|\|\|) *(tag|exit)/)
   })
 
-  it('rejects a symlinked marker before reading it', () => {
+  it('observes every path through the single guarded primitive', () => {
     const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME, 'account-1')
-    const lines = script.split('\n')
 
-    expect(script).toContain('test -h "$marker" && tag marker-not-regular')
-    expect(lines.findIndex((l) => l.includes('test -h "$marker"'))).toBeLessThan(
-      lines.findIndex((l) => l.includes('cat -- "$marker"'))
+    expect(script).toContain('kind_of "$candidate" "$candidate_parent" "$candidate_name"')
+    expect(script).toContain('kind_of "$marker" "$candidate_real" .orca-managed-home')
+    expect(script).toContain('case "$KIND" in absent) tag missing-home ;; esac')
+    expect(script).toContain('*) tag marker-not-regular ;;')
+  })
+
+  it('sends every failed capture to the unknown exit rather than a tag', () => {
+    const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME, 'account-1')
+    const captures = script.split('\n').filter((line) => line.includes('=$('))
+
+    expect(captures.length).toBeGreaterThan(3)
+    for (const line of captures) {
+      expect(line).toMatch(/\|\| *(unknown|_meta=)/)
+    }
+  })
+
+  it('classifies the marker before reading it', () => {
+    const script = buildWslCodexManagedHomeProbeScript(LINUX_HOME, 'account-1')
+    const scriptLines = script.split('\n')
+
+    expect(scriptLines.findIndex((l) => l.includes('kind_of "$marker"'))).toBeLessThan(
+      scriptLines.findIndex((l) => l.includes('cat -- "$marker"'))
     )
   })
 
@@ -78,7 +101,7 @@ describe('buildWslCodexManagedHomeProbeScript', () => {
     // Every structural fact is reported through `tag`, which exits 0; the bare
     // `exit 1`s are reserved for reads that failed and prove nothing.
     expect(script).not.toContain('exit 35')
-    expect(script.match(/\|\| exit 1$/gm)?.length).toBeGreaterThan(0)
+    expect(script.match(/\|\| unknown$/gm)?.length).toBeGreaterThan(0)
   })
 })
 

--- a/src/main/codex-accounts/wsl-codex-managed-home-probe.ts
+++ b/src/main/codex-accounts/wsl-codex-managed-home-probe.ts
@@ -1,0 +1,122 @@
+import { quotePosixShell } from '../../shared/wsl-login-shell-command'
+import { toWindowsWslPath } from '../wsl'
+import {
+  MISSING_MANAGED_HOME_MESSAGE,
+  MISSING_OWNERSHIP_MARKER_MESSAGE,
+  type HostCodexManagedHomeVerdict
+} from './host-codex-managed-home-ownership'
+
+/**
+ * Why a tagged line instead of exit codes: under `set -e` an absent home, a
+ * marker owned by another account, a `readlink` failure, and `wsl.exe` failing
+ * to start a cold distro all abort with the same status and empty stdout, so no
+ * exit code is observable evidence of *which* happened. The guest states its
+ * observation and exits 0; only a parsed tag is dispositive, and everything else
+ * — no tag, extra output, a throw from the runner, a timeout — is indeterminate.
+ * That inverts the old default under which a cold distro read as "this home is
+ * not Orca-owned" (STA-5616).
+ */
+const VERDICT_TAG = 'ORCA_CODEX_HOME_VERDICT:'
+
+export const OUTSIDE_MANAGED_ROOT_MESSAGE =
+  'Managed WSL Codex home is outside Orca account storage.'
+export const ACCOUNT_ID_MISMATCH_MESSAGE =
+  'Managed WSL Codex home does not match its persisted account ID.'
+export const MARKER_ACCOUNT_MISMATCH_MESSAGE =
+  'Managed WSL Codex home ownership marker does not match its account ID.'
+
+/** What the host observed of the probe run itself, before any verdict parsing. */
+export type WslCodexManagedHomeProbeOutcome =
+  | { ran: true; stdout: string }
+  | { ran: false; error: unknown }
+
+/**
+ * The canonical path is base64'd because it is interpolated into a
+ * line-oriented protocol: a newline anywhere under `$HOME` would otherwise split
+ * the verdict in two and read as a malformed probe.
+ */
+export function buildWslCodexManagedHomeProbeScript(
+  linuxPath: string,
+  expectedAccountId?: string
+): string {
+  return [
+    'set -uo pipefail',
+    `tag() { printf '${VERDICT_TAG}%s\\n' "$1"; exit 0; }`,
+    `candidate=${quotePosixShell(linuxPath)}`,
+    'managed_root="${HOME%/}/.local/share/orca/codex-accounts"',
+    // Definitive absence is the one structural fact the host lane also treats as
+    // a verdict; re-auth recreates the home from it rather than refusing.
+    'test -e "$candidate" || tag missing-home',
+    'candidate_real=$(readlink -f -- "$candidate") || exit 1',
+    'managed_root_real=$(readlink -f -- "$managed_root") || exit 1',
+    'marker="$candidate_real/.orca-managed-home"',
+    'test -f "$marker" || tag missing-marker',
+    'contents=$(cat -- "$marker") || exit 1',
+    'case "$candidate_real" in "$managed_root_real"/*/home) ;; *) tag outside-managed-root ;; esac',
+    ...(expectedAccountId === undefined
+      ? ['test -n "$contents" || tag marker-mismatch']
+      : [
+          `expected_marker=${quotePosixShell(expectedAccountId)}`,
+          'test "$candidate_real" = "$managed_root_real/$expected_marker/home" || tag account-mismatch',
+          'test "$contents" = "$expected_marker" || tag marker-mismatch'
+        ]),
+    "encoded=$(printf '%s' \"$candidate_real\" | base64 | tr -d '\\n') || exit 1",
+    'tag "owned:$encoded"'
+  ].join('\n')
+}
+
+function indeterminate(message: string, cause?: unknown): HostCodexManagedHomeVerdict {
+  return { kind: 'indeterminate', error: new Error(message, cause ? { cause } : undefined) }
+}
+
+/** Base64 round-trips so a truncated or garbled payload cannot become a path. */
+function decodeCanonicalPath(encoded: string): string | null {
+  if (!encoded) {
+    return null
+  }
+  const decoded = Buffer.from(encoded, 'base64').toString('utf-8')
+  return decoded && Buffer.from(decoded, 'utf-8').toString('base64') === encoded ? decoded : null
+}
+
+const UNTRUSTED_TAGS = new Map<string, string>([
+  ['missing-home', MISSING_MANAGED_HOME_MESSAGE],
+  ['missing-marker', MISSING_OWNERSHIP_MARKER_MESSAGE],
+  ['marker-mismatch', MARKER_ACCOUNT_MISMATCH_MESSAGE],
+  ['account-mismatch', ACCOUNT_ID_MISMATCH_MESSAGE],
+  ['outside-managed-root', OUTSIDE_MANAGED_ROOT_MESSAGE]
+])
+
+export function classifyWslCodexManagedHomeProbe(
+  outcome: WslCodexManagedHomeProbeOutcome,
+  distro: string
+): HostCodexManagedHomeVerdict {
+  if (!outcome.ran) {
+    return {
+      kind: 'indeterminate',
+      error: new Error('WSL Codex ownership probe could not run.', { cause: outcome.error })
+    }
+  }
+  const lines = outcome.stdout
+    .replaceAll(String.fromCharCode(0), '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  const tagged = lines.filter((line) => line.startsWith(VERDICT_TAG))
+  // The tag is the guest's last act, so anything after it means the run did not
+  // end where the protocol says it ends.
+  if (tagged.length !== 1 || lines.at(-1) !== tagged[0]) {
+    return indeterminate('WSL Codex ownership probe did not report exactly one verdict.')
+  }
+  const value = tagged[0].slice(VERDICT_TAG.length)
+  const untrustedReason = UNTRUSTED_TAGS.get(value)
+  if (untrustedReason !== undefined) {
+    return { kind: 'untrusted', reason: untrustedReason }
+  }
+  if (!value.startsWith('owned:')) {
+    return indeterminate('WSL Codex ownership probe reported an unknown verdict.')
+  }
+  const canonicalPath = decodeCanonicalPath(value.slice('owned:'.length))
+  return canonicalPath
+    ? { kind: 'owned', homePath: toWindowsWslPath(canonicalPath, distro) }
+    : indeterminate('WSL Codex ownership probe reported an undecodable path.')
+}

--- a/src/main/codex-accounts/wsl-codex-managed-home-probe.ts
+++ b/src/main/codex-accounts/wsl-codex-managed-home-probe.ts
@@ -1,6 +1,7 @@
 import { quotePosixShell } from '../../shared/wsl-login-shell-command'
 import { toWindowsWslPath } from '../wsl'
 import {
+  MARKER_NOT_REGULAR_FILE_MESSAGE,
   MISSING_MANAGED_HOME_MESSAGE,
   MISSING_OWNERSHIP_MARKER_MESSAGE,
   type HostCodexManagedHomeVerdict
@@ -42,15 +43,26 @@ export function buildWslCodexManagedHomeProbeScript(
   return [
     'set -uo pipefail',
     `tag() { printf '${VERDICT_TAG}%s\\n' "$1"; exit 0; }`,
+    // `test -e` returns the same status for "absent" and "cannot look" (EACCES on
+    // a parent, EIO, ELOOP), so a bare `|| tag missing` would rebuild the very
+    // collapse this probe exists to remove. Absence is only dispositive when the
+    // parent can be listed AND the entry is not in it; every other shape exits
+    // non-zero, which the host reads as indeterminate.
+    'prove_absent() { ls -A -- "$1" >/dev/null 2>&1 || exit 1; ' +
+      'ls -A -- "$1" 2>/dev/null | grep -Fxq -- "$2" && exit 1; tag "$3"; }',
     `candidate=${quotePosixShell(linuxPath)}`,
     'managed_root="${HOME%/}/.local/share/orca/codex-accounts"',
-    // Definitive absence is the one structural fact the host lane also treats as
-    // a verdict; re-auth recreates the home from it rather than refusing.
-    'test -e "$candidate" || tag missing-home',
+    'candidate_parent=$(dirname -- "$candidate") || exit 1',
+    'candidate_name=$(basename -- "$candidate") || exit 1',
+    'test -e "$candidate" || prove_absent "$candidate_parent" "$candidate_name" missing-home',
     'candidate_real=$(readlink -f -- "$candidate") || exit 1',
     'managed_root_real=$(readlink -f -- "$managed_root") || exit 1',
     'marker="$candidate_real/.orca-managed-home"',
-    'test -f "$marker" || tag missing-marker',
+    // lstat before stat, mirroring the host lane: a symlink marker is not
+    // ownership proof however trustworthy the file it points at looks.
+    'test -h "$marker" && tag marker-not-regular',
+    'test -e "$marker" || prove_absent "$candidate_real" .orca-managed-home missing-marker',
+    'test -f "$marker" || tag marker-not-regular',
     'contents=$(cat -- "$marker") || exit 1',
     'case "$candidate_real" in "$managed_root_real"/*/home) ;; *) tag outside-managed-root ;; esac',
     ...(expectedAccountId === undefined
@@ -81,6 +93,7 @@ function decodeCanonicalPath(encoded: string): string | null {
 const UNTRUSTED_TAGS = new Map<string, string>([
   ['missing-home', MISSING_MANAGED_HOME_MESSAGE],
   ['missing-marker', MISSING_OWNERSHIP_MARKER_MESSAGE],
+  ['marker-not-regular', MARKER_NOT_REGULAR_FILE_MESSAGE],
   ['marker-mismatch', MARKER_ACCOUNT_MISMATCH_MESSAGE],
   ['account-mismatch', ACCOUNT_ID_MISMATCH_MESSAGE],
   ['outside-managed-root', OUTSIDE_MANAGED_ROOT_MESSAGE]

--- a/src/main/codex-accounts/wsl-codex-managed-home-probe.ts
+++ b/src/main/codex-accounts/wsl-codex-managed-home-probe.ts
@@ -1,4 +1,6 @@
 import { quotePosixShell } from '../../shared/wsl-login-shell-command'
+import { readUntrustedBoolean, readUntrustedString } from '../../shared/untrusted-value-fields'
+import { buildWslGuestObservationPrelude } from './wsl-guest-filesystem-observation'
 import { toWindowsWslPath } from '../wsl'
 import {
   MARKER_NOT_REGULAR_FILE_MESSAGE,
@@ -18,6 +20,9 @@ import {
  * not Orca-owned" (STA-5616).
  */
 const VERDICT_TAG = 'ORCA_CODEX_HOME_VERDICT:'
+
+/** Any non-zero status is indeterminate; this one just names the intent. */
+const PROBE_UNKNOWN_EXIT = 1
 
 export const OUTSIDE_MANAGED_ROOT_MESSAGE =
   'Managed WSL Codex home is outside Orca account storage.'
@@ -42,39 +47,51 @@ export function buildWslCodexManagedHomeProbeScript(
 ): string {
   return [
     'set -uo pipefail',
+    ...buildWslGuestObservationPrelude(PROBE_UNKNOWN_EXIT),
     `tag() { printf '${VERDICT_TAG}%s\\n' "$1"; exit 0; }`,
-    // `test -e` returns the same status for "absent" and "cannot look" (EACCES on
-    // a parent, EIO, ELOOP), so a bare `|| tag missing` would rebuild the very
-    // collapse this probe exists to remove. Absence is only dispositive when the
-    // parent can be listed AND the entry is not in it; every other shape exits
-    // non-zero, which the host reads as indeterminate.
-    'prove_absent() { ls -A -- "$1" >/dev/null 2>&1 || exit 1; ' +
-      'ls -A -- "$1" 2>/dev/null | grep -Fxq -- "$2" && exit 1; tag "$3"; }',
     `candidate=${quotePosixShell(linuxPath)}`,
     'managed_root="${HOME%/}/.local/share/orca/codex-accounts"',
-    'candidate_parent=$(dirname -- "$candidate") || exit 1',
-    'candidate_name=$(basename -- "$candidate") || exit 1',
-    'test -e "$candidate" || prove_absent "$candidate_parent" "$candidate_name" missing-home',
-    'candidate_real=$(readlink -f -- "$candidate") || exit 1',
-    'managed_root_real=$(readlink -f -- "$managed_root") || exit 1',
+    'candidate_parent=$(dirname -- "$candidate") || unknown',
+    'candidate_name=$(basename -- "$candidate") || unknown',
+    // Absence is the only structural fact worth a tag here, and `kind_of` will
+    // not report it without a listing that proves it.
+    'kind_of "$candidate" "$candidate_parent" "$candidate_name"',
+    'case "$KIND" in absent) tag missing-home ;; esac',
+    'candidate_real=$(readlink -f -- "$candidate") || unknown',
+    'managed_root_real=$(readlink -f -- "$managed_root") || unknown',
     'marker="$candidate_real/.orca-managed-home"',
-    // lstat before stat, mirroring the host lane: a symlink marker is not
-    // ownership proof however trustworthy the file it points at looks.
-    'test -h "$marker" && tag marker-not-regular',
-    'test -e "$marker" || prove_absent "$candidate_real" .orca-managed-home missing-marker',
-    'test -f "$marker" || tag marker-not-regular',
-    'contents=$(cat -- "$marker") || exit 1',
+    // One typed observation replaces the old -h/-e/-f chain, each link of which
+    // was trusted in the negative and so could turn a stat failure into a
+    // verdict. A symlink marker is not ownership proof (host-lane parity).
+    'kind_of "$marker" "$candidate_real" .orca-managed-home',
+    'case "$KIND" in',
+    '  absent) tag missing-marker ;;',
+    '  regular) ;;',
+    '  *) tag marker-not-regular ;;',
+    'esac',
+    'contents=$(cat -- "$marker") || unknown',
     'case "$candidate_real" in "$managed_root_real"/*/home) ;; *) tag outside-managed-root ;; esac',
     ...(expectedAccountId === undefined
-      ? ['test -n "$contents" || tag marker-mismatch']
+      ? ['case "$contents" in "") tag marker-mismatch ;; esac']
       : [
           `expected_marker=${quotePosixShell(expectedAccountId)}`,
-          'test "$candidate_real" = "$managed_root_real/$expected_marker/home" || tag account-mismatch',
-          'test "$contents" = "$expected_marker" || tag marker-mismatch'
+          'if [ "$candidate_real" != "$managed_root_real/$expected_marker/home" ]; then tag account-mismatch; fi',
+          'if [ "$contents" != "$expected_marker" ]; then tag marker-mismatch; fi'
         ]),
-    "encoded=$(printf '%s' \"$candidate_real\" | base64 | tr -d '\\n') || exit 1",
+    "encoded=$(printf '%s' \"$candidate_real\" | base64 | tr -d '\\n') || unknown",
     'tag "owned:$encoded"'
   ].join('\n')
+}
+
+/** The one place that reads a raw field; kept local so nothing else dereferences the outcome. */
+function readField(value: unknown, key: string): unknown {
+  try {
+    return value === null || typeof value !== 'object'
+      ? undefined
+      : (value as Record<string, unknown>)[key]
+  } catch {
+    return undefined
+  }
 }
 
 function indeterminate(message: string, cause?: unknown): HostCodexManagedHomeVerdict {
@@ -103,13 +120,24 @@ export function classifyWslCodexManagedHomeProbe(
   outcome: WslCodexManagedHomeProbeOutcome,
   distro: string
 ): HostCodexManagedHomeVerdict {
-  if (!outcome.ran) {
+  // Why every field is read defensively: this value crosses a subprocess/IPC
+  // boundary, so its runtime shape is not guaranteed by its type. A malformed
+  // or hostile outcome must become indeterminate, not an untyped throw that no
+  // caller can recognise as an unproven observation.
+  const ran = readUntrustedBoolean(outcome, 'ran')
+  if (ran !== true) {
     return {
       kind: 'indeterminate',
-      error: new Error('WSL Codex ownership probe could not run.', { cause: outcome.error })
+      error: new Error('WSL Codex ownership probe could not run.', {
+        cause: ran === false ? readField(outcome, 'error') : outcome
+      })
     }
   }
-  const lines = outcome.stdout
+  const stdout = readUntrustedString(outcome, 'stdout')
+  if (stdout === undefined) {
+    return indeterminate('WSL Codex ownership probe returned no readable output.')
+  }
+  const lines = stdout
     .replaceAll(String.fromCharCode(0), '')
     .split(/\r?\n/)
     .map((line) => line.trim())

--- a/src/main/codex-accounts/wsl-guest-filesystem-observation.ts
+++ b/src/main/codex-accounts/wsl-guest-filesystem-observation.ts
@@ -1,0 +1,62 @@
+/**
+ * The shell half of the ownership tri-state.
+ *
+ * Every WSL ownership defect in STA-5616 has been the same mistake in a new
+ * place: a shell construct where "I could not look" and "the answer is no" share
+ * one representation. `test -e` returns 1 for absent AND for EACCES on a parent.
+ * `cmd | grep -q` returns non-zero when grep found nothing AND when the producer
+ * died mid-pipe. `$(cat f)` yields an empty string when the file is empty AND
+ * when the read failed. Each was patched individually and the class came back.
+ *
+ * So the guest observes through exactly one primitive, `kind_of`, under one
+ * invariant:
+ *
+ *   A dispositive answer may only be derived from a command that SUCCEEDED.
+ *   A filesystem `test` may be trusted when it says yes, never when it says no.
+ *   No decision is ever read from a pipeline's exit status.
+ *
+ * `kind_of` reports the type of one path, or exits with the caller's
+ * "unknown" status. It never reports absence without a complete, successful
+ * directory listing to back it — and that listing's status is checked
+ * separately from whether the name appears in it, because those are different
+ * questions and conflating them is exactly the bug.
+ */
+
+/** Exit status meaning "the guest could not determine this"; never a verdict. */
+export type GuestUnknownExit = number
+
+/**
+ * Emits the shared prelude. `KIND` is set to one of `absent`, `regular`,
+ * `symlink`, `dir`, `other`; callers branch on it with `case`, which operates on
+ * a shell variable and therefore cannot fail for I/O reasons.
+ */
+export function buildWslGuestObservationPrelude(unknownExit: GuestUnknownExit): string[] {
+  return [
+    // A literal newline, so a listing can be searched with `case` instead of a
+    // pipeline whose exit status conflates "no match" with "producer died".
+    "NL='",
+    "'",
+    `unknown() { exit ${unknownExit}; }`,
+    // $1 path, $2 its parent, $3 its basename.
+    'kind_of() {',
+    '  _meta=$(ls -ldn -- "$1" 2>/dev/null) || _meta=',
+    '  if [ -n "$_meta" ]; then',
+    '    case "$_meta" in',
+    '      -*) KIND=regular ;;',
+    '      l*) KIND=symlink ;;',
+    '      d*) KIND=dir ;;',
+    '      *) KIND=other ;;',
+    '    esac',
+    '    return 0',
+    '  fi',
+    // `ls -ld` failing means absent OR unreadable, which are different answers.
+    // Only a listing of the parent separates them, and only if it succeeds.
+    '  _listing=$(ls -A -- "$2" 2>/dev/null) || unknown',
+    '  case "$NL$_listing$NL" in',
+    '    *"$NL$3$NL"*) unknown ;;',
+    '    *) KIND=absent ;;',
+    '  esac',
+    '  return 0',
+    '}'
+  ]
+}

--- a/src/main/codex-accounts/wsl-guest-observation-failure.test.ts
+++ b/src/main/codex-accounts/wsl-guest-observation-failure.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+
+vi.mock('../wsl', () => ({
+  toWindowsWslPath: (linuxPath: string, distro: string) =>
+    `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
+}))
+
+import {
+  buildWslCodexManagedHomeProbeScript,
+  classifyWslCodexManagedHomeProbe
+} from './wsl-codex-managed-home-probe'
+import {
+  buildWslManagedHomePreparationScript,
+  WSL_PREPARE_INDETERMINATE_EXIT,
+  WSL_PREPARE_MARKER_MISMATCH_EXIT,
+  WSL_PREPARE_MARKER_MISSING_EXIT
+} from './wsl-codex-managed-home-preparation'
+
+/**
+ * R2 review: a *failed* observation must never reach a dispositive answer. These
+ * cases are all shell-level, so they run the real scripts. Two need a listing
+ * that succeeds once and then disagrees with itself, which no fixture can
+ * produce on a quiet filesystem — a shimmed `ls` earlier on PATH supplies it.
+ */
+const DISTRO = 'Ubuntu'
+const ACCOUNT_ID = 'account-1'
+
+describe.skipIf(process.platform === 'win32')('guest observation failures', () => {
+  let guestHome: string
+  let accountDir: string
+  let candidate: string
+  let marker: string
+  let shimDir: string
+  const sealed: string[] = []
+
+  beforeEach(() => {
+    guestHome = mkdtempSync(join(tmpdir(), 'orca-guest-fail-'))
+    accountDir = join(guestHome, '.local', 'share', 'orca', 'codex-accounts', ACCOUNT_ID)
+    candidate = join(accountDir, 'home')
+    marker = join(candidate, '.orca-managed-home')
+    shimDir = join(guestHome, 'shim-bin')
+    mkdirSync(shimDir, { recursive: true })
+    mkdirSync(candidate, { recursive: true })
+    writeFileSync(marker, `${ACCOUNT_ID}\n`, 'utf-8')
+    sealed.length = 0
+  })
+
+  afterEach(() => {
+    for (const path of sealed) {
+      try {
+        chmodSync(path, 0o755)
+      } catch {
+        // already gone
+      }
+    }
+    rmSync(guestHome, { recursive: true, force: true })
+  })
+
+  /**
+   * An `ls` whose first call answers truthfully and whose later calls do not —
+   * the shape of an EIO mid-listing, a SIGPIPE from `grep -q` closing early, or
+   * a directory mutated between two listings.
+   */
+  function installDisagreeingLs(firstCallOutput: string): void {
+    const counter = join(guestHome, 'ls-calls')
+    writeFileSync(
+      join(shimDir, 'ls'),
+      [
+        '#!/bin/sh',
+        'case "$*" in',
+        '  *-ld*) exec /bin/ls "$@" ;;',
+        'esac',
+        `n=$(cat ${JSON.stringify(counter)} 2>/dev/null || echo 0)`,
+        'n=$((n+1))',
+        `printf '%s' "$n" > ${JSON.stringify(counter)}`,
+        'if [ "$n" = 1 ]; then',
+        `  printf '%s\\n' ${JSON.stringify(firstCallOutput)}`,
+        '  exit 0',
+        'fi',
+        'exit 0',
+        ''
+      ].join('\n'),
+      { encoding: 'utf-8', mode: 0o755 }
+    )
+  }
+
+  function shimmedPath(): string {
+    return `${shimDir}${delimiter}${process.env.PATH ?? ''}`
+  }
+
+  function probe(env: NodeJS.ProcessEnv = {}) {
+    const script = buildWslCodexManagedHomeProbeScript(candidate, ACCOUNT_ID)
+    try {
+      const stdout = execFileSync('bash', ['-c', script], {
+        encoding: 'utf-8',
+        env: { ...process.env, HOME: guestHome, ...env },
+        timeout: 20_000
+      })
+      return classifyWslCodexManagedHomeProbe({ ran: true, stdout }, DISTRO)
+    } catch (error) {
+      return classifyWslCodexManagedHomeProbe({ ran: false, error }, DISTRO)
+    }
+  }
+
+  function prepare(env: NodeJS.ProcessEnv = {}): number {
+    const result = spawnSync(
+      'bash',
+      ['-c', buildWslManagedHomePreparationScript(candidate, ACCOUNT_ID)],
+      { encoding: 'utf-8', env: { ...process.env, HOME: guestHome, ...env }, timeout: 20_000 }
+    )
+    return result.status ?? -1
+  }
+
+  it('does not call a home absent when the listing that would prove it disagreed', () => {
+    // The home is present but unstattable (ELOOP), so absence must be proved by
+    // listing. A listing that reports the entry once and not again has not
+    // proved anything.
+    rmSync(candidate, { recursive: true })
+    symlinkSync(join(accountDir, 'loop'), candidate)
+    symlinkSync(candidate, join(accountDir, 'loop'))
+    installDisagreeingLs('home')
+
+    expect(probe({ PATH: shimmedPath() }).kind).toBe('indeterminate')
+  })
+
+  it('does not call a marker missing when the listing that would prove it disagreed', () => {
+    // The marker is genuinely gone from disk, but the first listing reports it.
+    // The two observations conflict, so nothing has been established.
+    rmSync(marker)
+    installDisagreeingLs('.orca-managed-home')
+
+    const status = prepare({ PATH: shimmedPath() })
+
+    expect(status).not.toBe(WSL_PREPARE_MARKER_MISSING_EXIT)
+    expect(status).toBe(WSL_PREPARE_INDETERMINATE_EXIT)
+  })
+
+  it('does not call a marker foreign when its contents could not be read', () => {
+    // The marker is a regular file holding the right account id; only the read
+    // is denied. Exit 42 refuses re-auth, so this locks the user out.
+    sealed.push(marker)
+    chmodSync(marker, 0o000)
+
+    const status = prepare()
+
+    expect(status).not.toBe(WSL_PREPARE_MARKER_MISMATCH_EXIT)
+    expect(status).toBe(WSL_PREPARE_INDETERMINATE_EXIT)
+  })
+
+  it('does not call a marker foreign when its contents could not be read, in the probe', () => {
+    sealed.push(marker)
+    chmodSync(marker, 0o000)
+
+    expect(probe().kind).toBe('indeterminate')
+  })
+})

--- a/src/main/codex-accounts/wsl-malformed-outcome.test.ts
+++ b/src/main/codex-accounts/wsl-malformed-outcome.test.ts
@@ -1,0 +1,306 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeFs from 'node:fs'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+vi.mock('../wsl', () => ({
+  toWindowsWslPath: (linuxPath: string, distro: string) =>
+    `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
+}))
+/** A real writable userData root: the host lane mkdirs it before any gate runs. */
+const userDataDir = vi.hoisted(() => ({ path: '' }))
+
+vi.mock('electron', () => ({ app: { getPath: () => userDataDir.path } }))
+
+const mkdirFault = vi.hoisted(() => {
+  let thrower: (() => never) | null = null
+  return {
+    set(next: () => never): void {
+      thrower = next
+    },
+    reset(): void {
+      thrower = null
+    },
+    consume(): void {
+      if (thrower) {
+        thrower()
+      }
+    }
+  }
+})
+
+const statFaults = vi.hoisted(() => {
+  const held = new Map<string, () => never>()
+  return {
+    hold(path: string, thrower: () => never): void {
+      held.set(path, thrower)
+    },
+    reset(): void {
+      held.clear()
+    },
+    consume(target: unknown): void {
+      const thrower = typeof target === 'string' ? held.get(target) : undefined
+      if (thrower) {
+        thrower()
+      }
+    }
+  }
+})
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  const patched = {
+    ...actual,
+    statSync: (...args: unknown[]) => {
+      statFaults.consume(args[0])
+      return (actual.statSync as (...a: unknown[]) => unknown)(...args)
+    },
+    mkdirSync: (...args: unknown[]) => {
+      mkdirFault.consume()
+      return (actual.mkdirSync as (...a: unknown[]) => unknown)(...args)
+    }
+  }
+  return { ...patched, default: patched }
+})
+
+const runWslProcessMock = vi.hoisted(() => vi.fn())
+vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
+
+import { classifyWslCodexManagedHomeProbe } from './wsl-codex-managed-home-probe'
+import { CodexManagedHomePath } from './codex-managed-home-path'
+import { ManagedCodexHomeTemporarilyUnavailableError } from './host-codex-managed-home-ownership'
+
+/**
+ * R2 review: values crossing the runner boundary are not Orca's own. A malformed
+ * or hostile shape must become `indeterminate`, never a raw throw that no caller
+ * can recognise as an unproven observation.
+ */
+const DISTRO = 'Ubuntu'
+const ACCOUNT_ID = 'account-1'
+const LINUX_HOME = `/home/dev/.local/share/orca/codex-accounts/${ACCOUNT_ID}/home`
+const UNC_HOME = `\\\\wsl.localhost\\${DISTRO}${LINUX_HOME.replace(/\//g, '\\')}`
+const HOST_HOME_PATH = '/host/managed/home'
+
+/** Built lazily: reading the field is the whole point, so it must not fire at collection. */
+function withThrowingGetter(base: Record<string, unknown>, field: string): object {
+  const target: Record<string, unknown> = { ...base }
+  Object.defineProperty(target, field, {
+    get(): never {
+      throw new Error(`${field} accessor exploded`)
+    },
+    enumerable: true
+  })
+  return target
+}
+
+function revokedProxy(): object {
+  const { proxy, revoke } = Proxy.revocable({ ran: true, stdout: '' }, {})
+  revoke()
+  return proxy
+}
+
+let originalPlatform: PropertyDescriptor | undefined
+
+beforeEach(() => {
+  originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+  runWslProcessMock.mockReset()
+  statFaults.reset()
+  mkdirFault.reset()
+  userDataDir.path = mkdtempSync(join(tmpdir(), 'orca-r2-userdata-'))
+})
+
+afterEach(() => {
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+  vi.restoreAllMocks()
+})
+
+describe('probe outcomes that are not the shape the classifier expects', () => {
+  const malformed: [string, () => unknown][] = [
+    ['null', () => null],
+    ['undefined', () => undefined],
+    ['a string', () => 'ORCA_CODEX_HOME_VERDICT:owned:x'],
+    ['a number', () => 7],
+    ['an empty object', () => ({})],
+    ['ran:true with null stdout', () => ({ ran: true, stdout: null })],
+    ['ran:true with a numeric stdout', () => ({ ran: true, stdout: 42 })],
+    ['ran:true with no stdout at all', () => ({ ran: true })],
+    ['a throwing `ran` getter', () => withThrowingGetter({}, 'ran')],
+    ['a throwing `stdout` getter', () => withThrowingGetter({ ran: true }, 'stdout')],
+    ['a revoked proxy', () => revokedProxy()]
+  ]
+
+  it.each(malformed)('classifies %s as indeterminate without throwing', (_label, build) => {
+    let verdict: unknown
+    expect(() => {
+      verdict = classifyWslCodexManagedHomeProbe(build() as never, DISTRO)
+    }).not.toThrow()
+    expect((verdict as { kind: string }).kind).toBe('indeterminate')
+  })
+
+  it('still reads a well-formed outcome', () => {
+    const encoded = Buffer.from(LINUX_HOME, 'utf-8').toString('base64')
+
+    expect(
+      classifyWslCodexManagedHomeProbe(
+        { ran: true, stdout: `ORCA_CODEX_HOME_VERDICT:owned:${encoded}\n` },
+        DISTRO
+      ).kind
+    ).toBe('owned')
+  })
+})
+
+describe('preparation results that are not the shape the caller expects', () => {
+  const account = {
+    id: ACCOUNT_ID,
+    email: 'dev@example.com',
+    managedHomePath: UNC_HOME,
+    managedHomeRuntime: 'wsl' as const,
+    wslDistro: DISTRO,
+    wslLinuxHomePath: LINUX_HOME,
+    providerAccountId: null,
+    workspaceLabel: null,
+    workspaceAccountId: null,
+    createdAt: 0,
+    updatedAt: 0,
+    lastAuthenticatedAt: 0
+  }
+
+  function ownedProbe(): string {
+    return `ORCA_CODEX_HOME_VERDICT:owned:${Buffer.from(LINUX_HOME, 'utf-8').toString('base64')}\n`
+  }
+
+  const malformed: [string, () => unknown][] = [
+    ['null', () => null],
+    ['undefined', () => undefined],
+    ['a string', () => 'done'],
+    ['an empty object', () => ({})],
+    ['a non-boolean timedOut', () => ({ timedOut: 'no', code: 0 })],
+    ['a non-numeric code', () => ({ timedOut: false, code: '0' })],
+    ['a throwing `timedOut` getter', () => withThrowingGetter({}, 'timedOut')],
+    ['a throwing `code` getter', () => withThrowingGetter({ timedOut: false }, 'code')]
+  ]
+
+  it.each(malformed)('reports %s as the typed indeterminate error', async (_label, build) => {
+    runWslProcessMock.mockResolvedValue(build())
+    const paths = new CodexManagedHomePath(() => ownedProbe())
+
+    await expect(paths.ensureForReauthentication(account)).rejects.toBeInstanceOf(
+      ManagedCodexHomeTemporarilyUnavailableError
+    )
+  })
+
+  it('still accepts a well-formed successful result', async () => {
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      environmentResolved: true
+    })
+    const paths = new CodexManagedHomePath(() => ownedProbe())
+
+    await expect(paths.ensureForReauthentication(account)).resolves.toBe(UNC_HOME)
+  })
+})
+
+describe('missing-home detection against a hostile failure', () => {
+  const account = {
+    id: ACCOUNT_ID,
+    email: 'dev@example.com',
+    managedHomePath: HOST_HOME_PATH,
+    managedHomeRuntime: 'host' as const,
+    wslDistro: null,
+    wslLinuxHomePath: null,
+    providerAccountId: null,
+    workspaceLabel: null,
+    workspaceAccountId: null,
+    createdAt: 0,
+    updatedAt: 0,
+    lastAuthenticatedAt: 0
+  }
+
+  /**
+   * Driven through the real filesystem seam rather than a spy on `assert`:
+   * `vi.spyOn` records the thrown value and trips a revoked proxy's traps
+   * itself, which would test the harness instead of the gate.
+   */
+  it('reports a hostile stat failure as the typed temporary error, not a raw throw', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    statFaults.hold(HOST_HOME_PATH, () => {
+      const { proxy, revoke } = Proxy.revocable(new Error('gone'), {})
+      revoke()
+      throw proxy
+    })
+    const paths = new CodexManagedHomePath(() => {
+      throw new Error('unused')
+    })
+
+    let thrown: unknown
+    try {
+      await paths.ensureForReauthentication(account)
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(ManagedCodexHomeTemporarilyUnavailableError)
+  })
+
+  /**
+   * `getRoot()` mkdirs before the gate builds any verdict, so a throw there is
+   * the one failure that reaches the catch UNWRAPPED — which is exactly the
+   * shape `isMissingHomeError` has to survive.
+   */
+  it.each([
+    ['a throwing message accessor', () => withThrowingGetter({ code: 'EPERM' }, 'message')],
+    [
+      'a revoked proxy',
+      () => {
+        const { proxy, revoke } = Proxy.revocable(new Error('gone'), {})
+        revoke()
+        return proxy
+      }
+    ],
+    ['a bare string', () => 'the filesystem said no']
+  ])('propagates %s from the gate without attempting recreation', async (_label, build) => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    const planted = build()
+    mkdirFault.set((() => {
+      throw planted
+    }) as () => never)
+    const paths = new CodexManagedHomePath(() => {
+      throw new Error('unused')
+    })
+
+    let thrown: unknown
+    let threwSomething = false
+    try {
+      await paths.ensureForReauthentication(account)
+    } catch (error) {
+      thrown = error
+      threwSomething = true
+    }
+
+    // Identity, not `instanceof`: inspecting a revoked proxy throws, which is
+    // precisely the failure mode this guards against.
+    expect(threwSomething).toBe(true)
+    expect(thrown === planted).toBe(true)
+  })
+
+  it('does not recreate the home when the failure message cannot be read', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    statFaults.hold(HOST_HOME_PATH, () => {
+      throw withThrowingGetter({ code: 'EPERM' }, 'message')
+    })
+    const paths = new CodexManagedHomePath(() => {
+      throw new Error('unused')
+    })
+
+    await expect(paths.ensureForReauthentication(account)).rejects.toBeInstanceOf(
+      ManagedCodexHomeTemporarilyUnavailableError
+    )
+  })
+})

--- a/src/shared/definitive-filesystem-absence.ts
+++ b/src/shared/definitive-filesystem-absence.ts
@@ -12,6 +12,26 @@
  * category error this predicate exists to prevent.
  */
 export function isDefinitiveAbsence(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException | null)?.code
+  const code = readErrnoCode(error)
   return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
+/**
+ * Why the guard rather than a plain `?.code`: this runs inside `catch` blocks
+ * that must fail closed, and a `catch` receives whatever was thrown — a string,
+ * a Proxy, an object whose `code` is an accessor that throws. Reading the
+ * property directly lets that accessor's exception escape the very catch meant
+ * to normalise it, so the caller never gets the indeterminate verdict. An
+ * unreadable or non-string code is not absence; it is not evidence at all.
+ */
+function readErrnoCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) {
+    return undefined
+  }
+  try {
+    const code = (error as { code?: unknown }).code
+    return typeof code === 'string' ? code : undefined
+  } catch {
+    return undefined
+  }
 }

--- a/src/shared/definitive-filesystem-absence.ts
+++ b/src/shared/definitive-filesystem-absence.ts
@@ -1,3 +1,5 @@
+import { readUntrustedString } from './untrusted-value-fields'
+
 /**
  * The single errno allowlist for "this path is definitively not there".
  *
@@ -12,26 +14,6 @@
  * category error this predicate exists to prevent.
  */
 export function isDefinitiveAbsence(error: unknown): boolean {
-  const code = readErrnoCode(error)
+  const code = readUntrustedString(error, 'code')
   return code === 'ENOENT' || code === 'ENOTDIR'
-}
-
-/**
- * Why the guard rather than a plain `?.code`: this runs inside `catch` blocks
- * that must fail closed, and a `catch` receives whatever was thrown — a string,
- * a Proxy, an object whose `code` is an accessor that throws. Reading the
- * property directly lets that accessor's exception escape the very catch meant
- * to normalise it, so the caller never gets the indeterminate verdict. An
- * unreadable or non-string code is not absence; it is not evidence at all.
- */
-function readErrnoCode(error: unknown): string | undefined {
-  if (typeof error !== 'object' || error === null) {
-    return undefined
-  }
-  try {
-    const code = (error as { code?: unknown }).code
-    return typeof code === 'string' ? code : undefined
-  } catch {
-    return undefined
-  }
 }

--- a/src/shared/untrusted-value-fields.test.ts
+++ b/src/shared/untrusted-value-fields.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import {
+  readUntrustedBoolean,
+  readUntrustedExitCode,
+  readUntrustedString
+} from './untrusted-value-fields'
+
+/**
+ * This module is the single funnel every ownership site reads through, so the
+ * hostile shapes are pinned here once rather than at each call site.
+ */
+function throwingGetter(field: string, base: Record<string, unknown> = {}): object {
+  const target: Record<string, unknown> = { ...base }
+  Object.defineProperty(target, field, {
+    get(): never {
+      throw new Error('accessor exploded')
+    },
+    enumerable: true
+  })
+  return target
+}
+
+function revokedProxy(): object {
+  const { proxy, revoke } = Proxy.revocable({ code: 'ENOENT', ran: true, timedOut: false }, {})
+  revoke()
+  return proxy
+}
+
+const hostile: [string, () => unknown][] = [
+  ['null', () => null],
+  ['undefined', () => undefined],
+  ['a string', () => 'ENOENT'],
+  ['a number', () => 7],
+  ['a symbol', () => Symbol('ENOENT')],
+  ['a throwing getter', () => throwingGetter('code')],
+  ['a revoked proxy', () => revokedProxy()],
+  [
+    'a proxy whose get trap throws',
+    () =>
+      new Proxy(
+        {},
+        {
+          get(): never {
+            throw new Error('trap exploded')
+          }
+        }
+      )
+  ]
+]
+
+describe.each(hostile)('reading a field off %s', (_label, build) => {
+  it('never throws and never answers', () => {
+    const value = build()
+
+    expect(() => readUntrustedString(value, 'code')).not.toThrow()
+    expect(() => readUntrustedBoolean(value, 'ran')).not.toThrow()
+    expect(() => readUntrustedExitCode(value, 'code')).not.toThrow()
+    expect(readUntrustedString(value, 'code')).toBeUndefined()
+    expect(readUntrustedBoolean(value, 'ran')).toBeUndefined()
+    expect(readUntrustedExitCode(value, 'code')).toBeUndefined()
+  })
+})
+
+describe('reading well-formed fields', () => {
+  it('returns strings only when the field is a string', () => {
+    expect(readUntrustedString({ code: 'ENOENT' }, 'code')).toBe('ENOENT')
+    expect(readUntrustedString({ code: 2 }, 'code')).toBeUndefined()
+    expect(readUntrustedString({ code: ['ENOENT'] }, 'code')).toBeUndefined()
+  })
+
+  it('returns booleans only when the field is a boolean', () => {
+    expect(readUntrustedBoolean({ timedOut: true }, 'timedOut')).toBe(true)
+    expect(readUntrustedBoolean({ timedOut: false }, 'timedOut')).toBe(false)
+    expect(readUntrustedBoolean({ timedOut: 'true' }, 'timedOut')).toBeUndefined()
+    expect(readUntrustedBoolean({ timedOut: 1 }, 'timedOut')).toBeUndefined()
+  })
+
+  it('keeps a null exit code distinct from an unreadable one', () => {
+    // `null` means "killed by a signal", which is a real answer; `undefined`
+    // means the field could not be read at all.
+    expect(readUntrustedExitCode({ code: null }, 'code')).toBeNull()
+    expect(readUntrustedExitCode({ code: 0 }, 'code')).toBe(0)
+    expect(readUntrustedExitCode({ code: 41 }, 'code')).toBe(41)
+    expect(readUntrustedExitCode({}, 'code')).toBeUndefined()
+    expect(readUntrustedExitCode({ code: '41' }, 'code')).toBeUndefined()
+    expect(readUntrustedExitCode({ code: Number.NaN }, 'code')).toBeUndefined()
+  })
+
+  it('reads through a function, which is also a property bag', () => {
+    const carrier = Object.assign(() => undefined, { code: 'ENOTDIR' })
+
+    expect(readUntrustedString(carrier, 'code')).toBe('ENOTDIR')
+  })
+})

--- a/src/shared/untrusted-value-fields.ts
+++ b/src/shared/untrusted-value-fields.ts
@@ -1,0 +1,47 @@
+/**
+ * The host half of the ownership tri-state: reading fields off values Orca did
+ * not construct.
+ *
+ * A `catch` receives whatever was thrown — a string, `undefined`, a revoked
+ * Proxy, an object whose getter throws. A subprocess wrapper resolves whatever
+ * it likes. Reading `value.code` or `value.stdout` directly lets that read's own
+ * exception escape the very guard meant to normalise it, so the caller gets
+ * neither an answer nor a typed failure. That has now happened at four separate
+ * sites in this lane, so every such read goes through here.
+ *
+ * The contract is uniform: an unreadable or wrongly-typed field is `undefined`,
+ * which callers must treat as "could not determine" — never as a negative
+ * answer.
+ */
+function readField(value: unknown, key: string): unknown {
+  if (value === null || (typeof value !== 'object' && typeof value !== 'function')) {
+    return undefined
+  }
+  try {
+    return (value as Record<string, unknown>)[key]
+  } catch {
+    return undefined
+  }
+}
+
+export function readUntrustedString(value: unknown, key: string): string | undefined {
+  const field = readField(value, key)
+  return typeof field === 'string' ? field : undefined
+}
+
+export function readUntrustedBoolean(value: unknown, key: string): boolean | undefined {
+  const field = readField(value, key)
+  return typeof field === 'boolean' ? field : undefined
+}
+
+/**
+ * `null` is a real value for an exit code (killed by signal), so it is reported
+ * distinctly from `undefined`, which means the field could not be read.
+ */
+export function readUntrustedExitCode(value: unknown, key: string): number | null | undefined {
+  const field = readField(value, key)
+  if (field === null) {
+    return null
+  }
+  return typeof field === 'number' && Number.isFinite(field) ? field : undefined
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1821 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1812 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​520 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​82 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​438 |

<!-- /orca-pr-loc -->

Fixes STA-5616.

A Codex account whose home lives in a WSL distro could be reported as "not yours" simply because the
distro was asleep — and that answer was allowed to clear your saved account selection.

## What changes

- **A distro that is not running is no longer mistaken for a stranger's folder.** The ownership check
  runs a short command inside the distro. If it timed out, could not start, or the distro was cold,
  Orca reported that as a positive finding that the folder was not Orca's — and only that finding is
  allowed to clear your persisted selection. Those are now separate answers.
- **"I could not check" never clears your selection.** It refuses the operation and leaves your
  account settings alone, so re-authenticating after waking a distro finds everything where you left
  it.
- **A real "this is not yours" still behaves exactly as before.** When the check actually completes
  and reports the folder is outside Orca's storage, the existing behaviour is unchanged.

## ELI5

Orca keeps each Codex account's files in its own folder. Before touching one, it knocks on the door
and asks "is this yours?"

If the folder was inside a WSL distro that had gone to sleep, nobody answered the knock — and Orca
treated silence as "no, this belongs to someone else", then forgot which account you had selected.
Silence is not an answer. Orca now waits, refuses to act, and leaves your settings alone.

## Why it was possible

The WSL branch ran a short probe and collapsed every outcome into one error. A timeout, a distro that
was not running, a process that could not start, and a genuine "outside Orca storage" were
indistinguishable — and the rule that only a proven trust failure may clear a selection had nothing
to distinguish. The host lane already made that distinction; the WSL lane never got it.

## Testing

Reproduced before fixing: a test showing a transient probe failure producing a trust verdict on
unfixed code, then flipped to assert the selection survives. 47 tests across three suites.

Every new guard was mutation-tested — reverted one at a time, with the specific assertion confirmed
failing without it, and each mutation confirmed to have actually applied before its result was
trusted.

## What this does not do

- **It does not extract the shared vocabulary.** Three lanes now express the same
  owned / not-yours / could-not-tell distinction. Merging them is real work rather than a rename —
  one lane needs a "missing" answer that another carries differently — and folding a refactor into a
  data-safety fix is how the previous attempt at this ticket stalled. Kept separate deliberately.
- **The probe timeout is unchanged.** What changed is how a timeout is classified, not how long
  Orca waits.
