### PR TITLE
fix(orchestration): keep an injected dispatch active when its turn start is unobserved

### DIFF
--- a/src/cli/handlers/orchestration/dispatch-handlers.ts
+++ b/src/cli/handlers/orchestration/dispatch-handlers.ts
@@ -17,6 +17,8 @@ export const ORCHESTRATION_DISPATCH_HANDLER: Record<string, CommandHandler> = {
     const result = await callOrchestrationMutation<{
       dispatch: { id: string; task_id: string; status: string } | null
       injected?: boolean
+      /** The preamble landed but the agent's turn start was not observed; do not re-inject. */
+      promptUnobserved?: boolean
       dryRun?: boolean
       preamble?: string
     }>(client, flags, 'orchestration.dispatch', {
@@ -34,7 +36,12 @@ export const ORCHESTRATION_DISPATCH_HANDLER: Record<string, CommandHandler> = {
         return value.preamble ?? ''
       }
       const base = `Dispatched ${value.dispatch?.task_id} -> ${value.dispatch?.id} [${value.dispatch?.status}]`
-      return value.preamble ? `${base}\n\n--- Preamble ---\n${value.preamble}` : base
+      const unobserved = value.promptUnobserved
+        ? `\nThe preamble was injected but the agent's turn start was not observed. It is in the composer; read the terminal before re-sending anything.`
+        : ''
+      return value.preamble
+        ? `${base}${unobserved}\n\n--- Preamble ---\n${value.preamble}`
+        : `${base}${unobserved}`
     })
   }
 }

--- a/src/main/runtime/rpc/methods/orchestration-dispatch-methods.ts
+++ b/src/main/runtime/rpc/methods/orchestration-dispatch-methods.ts
@@ -3,6 +3,7 @@ import { OrchestrationError } from '../../orchestration/orchestration-error'
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { resolveDispatchCreator } from './orchestration-dispatch-creator'
 import { buildInjectRejectionMessage } from './orchestration-inject-rejection-message'
+import { isAgentPromptStalledError } from '../../agent-prompt-submission-verification'
 import { resolveRunScope } from './orchestration-run-scope'
 import { DispatchParams, DispatchShowParams } from './orchestration-schemas'
 
@@ -123,21 +124,35 @@ export const ORCHESTRATION_DISPATCH_METHODS: RpcMethod[] = [
       })
 
       let injected = false
+      let promptUnobserved = false
       if (params.inject) {
         try {
           await runtime.sendTerminalAgentPrompt(to, preamble)
           injected = true
         } catch (err) {
-          db.failDispatch(ctx.id, err instanceof Error ? err.message : String(err))
-          throw err
+          // Why (#17066): the preamble is in the pane before verification runs, so a stall is an
+          // unobserved turn start, never proof it is missing. Failing here would revoke the capability
+          // the worker's heartbeat and worker_done need while it is already executing the task.
+          if (isAgentPromptStalledError(err)) {
+            injected = true
+            promptUnobserved = true
+            console.warn(
+              `[orchestration] dispatch ${ctx.id}: preamble injected into ${to} but its turn start was not observed; dispatch stays active`
+            )
+          } else {
+            db.failDispatch(ctx.id, err instanceof Error ? err.message : String(err))
+            throw err
+          }
         }
       }
 
       // Why: returnPreamble is opt-in because the preamble is several hundred bytes most callers don't need in the response.
-      if (params.returnPreamble) {
-        return { dispatch: ctx, injected, preamble }
+      return {
+        dispatch: ctx,
+        injected,
+        ...(promptUnobserved ? { promptUnobserved } : {}),
+        ...(params.returnPreamble ? { preamble } : {})
       }
-      return { dispatch: ctx, injected }
     }
   }),
 

--- a/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
@@ -327,6 +327,33 @@ describe('orchestration RPC methods', () => {
       expect(db.getActiveDispatchForTerminal('term_a')).toBeUndefined()
     })
 
+    it('keeps an injected dispatch active when the turn start is not observed', async () => {
+      setup()
+      provideInjectIdentity()
+      const task = db.createTask({ spec: 'work' })
+      vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(true)
+      vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockRejectedValue(
+        new Error('agent_prompt_stalled')
+      )
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const result = (await call('orchestration.dispatch', {
+        task: task.id,
+        to: 'term_a',
+        inject: true
+      })) as {
+        dispatch: { id: string; status: string }
+        injected: boolean
+        promptUnobserved?: boolean
+      }
+
+      // Why: the preamble is in the composer; revoking here rejects the worker's own worker_done.
+      expect(result).toMatchObject({ injected: true, promptUnobserved: true })
+      expect(result.dispatch.status).toBe('dispatched')
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getDispatchContextById(result.dispatch.id)?.capability_revoked_at).toBeNull()
+    })
+
     it('uses caller-provided dev mode for injected preamble', async () => {
       setup()
       provideInjectIdentity()


### PR DESCRIPTION
## ELI5

`dispatch --inject` types the task into an agent's terminal and then waits to see the agent start working. When it could not see that, it marked the dispatch failed and revoked the worker's credentials — even though the task was already sitting in the agent's input box and the agent went on to do the work. Every progress report the worker then sent was rejected. Now, when the only problem is "we did not see the turn start", the dispatch stays active and the response says so.

## What Changed

- `src/main/runtime/rpc/methods/orchestration-dispatch-methods.ts`: when `sendTerminalAgentPrompt` throws `agent_prompt_stalled`, the dispatch is left `dispatched`, the capability stays valid, the response gains `promptUnobserved: true`, and a warning is logged. Any other error still fails the dispatch as before. This mirrors the coordinator's `dispatched-unobserved` handling from #16590.
- `src/cli/handlers/orchestration/dispatch-handlers.ts`: the human-readable output tells the caller the preamble is in the composer and to read the terminal before re-sending anything.
- `src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts`: a stalled injection keeps the dispatch `dispatched`, the task `dispatched`, and `capability_revoked_at` null.

## Why

#17066: ten consecutive `dispatch --inject` runs against an idle Codex terminal returned `agent_prompt_stalled` about 7 s after injection, the preamble sat unsubmitted in the composer, a manual Enter made Codex run the task, and every `heartbeat` / `worker_done` was rejected with `Dispatch <id> capability is revoked`. The same pattern is reported for Hermes/opencode (#16660) and Grok (#16902). #16590 already stopped `worker-start` and the coordinator from revoking on this verdict; the `--inject` path still called `db.failDispatch`, which sets `capability_revoked_at`. The prompt bytes are written before verification, so a stall on this path can never prove the preamble is missing — failing the dispatch and revoking is the wrong default. Making the first Enter land reliably is a separate PR (agent-prompt composer observation); this one stops the lifecycle damage when it does not.

## Linked Issue

Refs #17066, #16660, #16902

## Visual Proof

N/A — RPC/CLI behavior only. `orca orchestration dispatch --inject` on a stall now prints the dispatch as `[dispatched]` plus a one-line note instead of `{"ok": false, "error": {"code": "agent_prompt_stalled"}}`.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Ran on Windows 11:

```
pnpm test src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts   # 33 passed
pnpm tc:node && pnpm tc:cli
oxlint + oxfmt on the changed files
```

## AI Disclosure

Written with Claude Code (Claude Fable 5.1) under direction of @Tauri-EPO.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Wire compatibility: `promptUnobserved` is a new optional response field; old CLIs ignore it and see `injected: true`. Behavior change to weigh: a caller that used the stall error as a signal to retry no longer gets an error. #17066 and #15976 both document that retry as harmful (it pastes on top of the parked preamble), so the new default matches what the field reports asked for.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — `tc:node`, `tc:cli`, the dispatch RPC tests and oxlint on changed files pass locally; full lint/build left to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
