### PR TITLE
fix(preload): make a dropped bridge key a compile error

### DIFF
--- a/src/preload/api/agent-status-bridge.ts
+++ b/src/preload/api/agent-status-bridge.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../shared/agent-status-types'
 import type { AgentInterruptInferenceRequest } from '../../shared/agent-interrupt-intent'
 import type { AgentQuestionAnsweredInferenceRequest } from '../../shared/agent-question-answered-intent'
+import type { PreloadApi } from '../api-types'
 
 export const agentStatusApi = {
   /** Listen for agent status updates forwarded from native hook receivers. */
@@ -85,4 +86,4 @@ export const agentStatusApi = {
   }): void => {
     ipcRenderer.send('agentStatus:transferPaneAuthority', args)
   }
-}
+} satisfies PreloadApi['agentStatus']

--- a/src/preload/api/agent-trust-bridge.ts
+++ b/src/preload/api/agent-trust-bridge.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const agentTrustApi = {
   markTrusted: (args: {
@@ -6,4 +7,4 @@ export const agentTrustApi = {
     workspacePath: string
     connectionId?: string
   }): Promise<void> => ipcRenderer.invoke('agentTrust:markTrusted', args)
-}
+} satisfies PreloadApi['agentTrust']

--- a/src/preload/api/ai-vault-bridge.ts
+++ b/src/preload/api/ai-vault-bridge.ts
@@ -10,19 +10,19 @@ import type {
 } from '../../shared/ai-vault-types'
 import type { AiVaultSessionTitlesArgs } from '../../shared/ai-vault-session-title'
 import type { AiVaultPrepareSessionResumeArgs } from '../../shared/ai-vault-resume-preparation'
+import type { PreloadApi } from '../api-types'
 
 export const aiVaultApi = {
-  listSessions: (args?: AiVaultListArgs): Promise<unknown> =>
-    ipcRenderer.invoke('aiVault:listSessions', args),
-  resolveSessionTitles: (args: AiVaultSessionTitlesArgs): Promise<unknown> =>
+  listSessions: (args?: AiVaultListArgs) => ipcRenderer.invoke('aiVault:listSessions', args),
+  resolveSessionTitles: (args: AiVaultSessionTitlesArgs) =>
     ipcRenderer.invoke('aiVault:resolveSessionTitles', args),
   cancelListSessions: (args: { requestToken: string }): Promise<void> =>
     ipcRenderer.invoke('aiVault:cancelListSessions', args),
-  prepareSessionResume: (args: AiVaultPrepareSessionResumeArgs): Promise<unknown> =>
+  prepareSessionResume: (args: AiVaultPrepareSessionResumeArgs) =>
     ipcRenderer.invoke('aiVault:prepareSessionResume', args),
-  listSubagentSessions: (args: AiVaultSubagentListArgs): Promise<unknown> =>
+  listSubagentSessions: (args: AiVaultSubagentListArgs) =>
     ipcRenderer.invoke('aiVault:listSubagentSessions', args),
-  getFirstUserPrompt: (args: AiVaultFirstUserPromptArgs): Promise<unknown> =>
+  getFirstUserPrompt: (args: AiVaultFirstUserPromptArgs) =>
     ipcRenderer.invoke('aiVault:getFirstUserPrompt', args),
   deleteSession: (args: AiVaultDeleteSessionArgs): Promise<AiVaultDeleteSessionResult> =>
     ipcRenderer.invoke('aiVault:deleteSession', args),
@@ -31,4 +31,4 @@ export const aiVaultApi = {
     ipcRenderer.on('aiVault:windowFocused', listener)
     return () => ipcRenderer.removeListener('aiVault:windowFocused', listener)
   }
-}
+} satisfies PreloadApi['aiVault']

--- a/src/preload/api/app-bridge.ts
+++ b/src/preload/api/app-bridge.ts
@@ -40,6 +40,7 @@ export const appApi = {
       throw new Error('Failed to stage renderer state before unload.')
     }
   },
+  awaitBeforeUnloadCheckpoint: () => awaitBeforeUnloadCheckpoint(),
   awaitFirstWindowStartupServices: (): Promise<void> =>
     ipcRenderer.invoke('app:awaitFirstWindowStartupServices'),
   prepareTerminalStartupRestoration: (): Promise<void> =>
@@ -73,4 +74,4 @@ export const appApi = {
     ipcRenderer.invoke('app:pickFloatingWorkspaceDirectory'),
   writeTerminalRenderDesyncEvidence: (args: WriteTerminalRenderDesyncEvidenceArgs) =>
     ipcRenderer.invoke('terminal:writeRenderDesyncEvidence', args)
-}
+} satisfies PreloadApi['app']

--- a/src/preload/api/automations-bridge.ts
+++ b/src/preload/api/automations-bridge.ts
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron'
-import type { ExternalAutomationManagerResult } from '../api-types'
+import type { ExternalAutomationManagerResult, PreloadApi } from '../api-types'
 import type {
   AutomationDispatchRequest,
   AutomationDispatchResult,
@@ -56,4 +56,4 @@ export const automationsApi = {
     ipcRenderer.on('automations:changed', listener)
     return () => ipcRenderer.removeListener('automations:changed', listener)
   }
-}
+} satisfies PreloadApi['automations']

--- a/src/preload/api/bitbucket-bridge.ts
+++ b/src/preload/api/bitbucket-bridge.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const bitbucketApi = {
   connect: (args: {
@@ -12,5 +13,5 @@ export const bitbucketApi = {
 
   disconnect: (): Promise<void> => ipcRenderer.invoke('bitbucket:disconnect'),
 
-  status: (): Promise<unknown> => ipcRenderer.invoke('bitbucket:status')
-}
+  status: () => ipcRenderer.invoke('bitbucket:status')
+} satisfies PreloadApi['bitbucket']

--- a/src/preload/api/browser-bridge-guest-registration-and-downloads.ts
+++ b/src/preload/api/browser-bridge-guest-registration-and-downloads.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../shared/browser-webauthn-account'
 import { readBrowserClientHostIdArgument } from '../../shared/browser-client-host-id-argument'
 import { browserClientPageRendererRequests } from '../preload-runtime-support'
+import type { PreloadApi } from '../api-types'
 
 export const browserGuestRegistrationAndDownloadsApi = {
   onClientPageRendererRequest: browserClientPageRendererRequests.subscribe,
@@ -194,4 +195,4 @@ export const browserGuestRegistrationAndDownloadsApi = {
     ipcRenderer.on('browser:download-finished', listener)
     return () => ipcRenderer.removeListener('browser:download-finished', listener)
   }
-}
+} satisfies Partial<PreloadApi['browser']>

--- a/src/preload/api/browser-bridge-page-interaction-and-sessions.ts
+++ b/src/preload/api/browser-bridge-page-interaction-and-sessions.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const browserPageInteractionAndSessionsApi = {
   onContextMenuRequested: (
@@ -81,23 +82,17 @@ export const browserPageInteractionAndSessionsApi = {
   },
   cancelDownload: (args: { downloadId: string }): Promise<boolean> =>
     ipcRenderer.invoke('browser:cancelDownload', args),
-  setGrabMode: (args: {
-    browserPageId: string
-    enabled: boolean
-  }): Promise<{ ok: true } | { ok: false; reason: string }> =>
+  setGrabMode: (args: { browserPageId: string; enabled: boolean }) =>
     ipcRenderer.invoke('browser:setGrabMode', args),
-  awaitGrabSelection: (args: { browserPageId: string; opId: string }): Promise<unknown> =>
+  awaitGrabSelection: (args: { browserPageId: string; opId: string }) =>
     ipcRenderer.invoke('browser:awaitGrabSelection', args),
   cancelGrab: (args: { browserPageId: string }): Promise<boolean> =>
     ipcRenderer.invoke('browser:cancelGrab', args),
   captureSelectionScreenshot: (args: {
     browserPageId: string
     rect: { x: number; y: number; width: number; height: number }
-  }): Promise<{ ok: true; screenshot: unknown } | { ok: false; reason: string }> =>
-    ipcRenderer.invoke('browser:captureSelectionScreenshot', args),
-  extractHoverPayload: (args: {
-    browserPageId: string
-  }): Promise<{ ok: true; payload: unknown } | { ok: false; reason: string }> =>
+  }) => ipcRenderer.invoke('browser:captureSelectionScreenshot', args),
+  extractHoverPayload: (args: { browserPageId: string }) =>
     ipcRenderer.invoke('browser:extractHoverPayload', args),
   onGrabModeToggle: (callback: (browserPageId: string) => void): (() => void) => {
     const listener = (_event: Electron.IpcRendererEvent, browserPageId: string) =>
@@ -115,7 +110,7 @@ export const browserPageInteractionAndSessionsApi = {
     ipcRenderer.on('browser:grabActionShortcut', listener)
     return () => ipcRenderer.removeListener('browser:grabActionShortcut', listener)
   },
-  sessionListProfiles: (): Promise<unknown[]> => ipcRenderer.invoke('browser:session:listProfiles'),
+  sessionListProfiles: () => ipcRenderer.invoke('browser:session:listProfiles'),
   prepareSshWorkspacePartition: (args: {
     targetId: string
     browserProfileId?: string
@@ -126,40 +121,28 @@ export const browserPageInteractionAndSessionsApi = {
     scope: 'default' | 'isolated' | 'imported'
     label: string
     userAgentMode?: 'clean' | 'native'
-  }): Promise<unknown> => ipcRenderer.invoke('browser:session:createProfile', args),
+  }) => ipcRenderer.invoke('browser:session:createProfile', args),
   sessionDeleteProfile: (args: { profileId: string }): Promise<boolean> =>
     ipcRenderer.invoke('browser:session:deleteProfile', args),
-  sessionImportCookies: (args: {
-    profileId: string
-  }): Promise<{ ok: true; profileId: string; summary: unknown } | { ok: false; reason: string }> =>
+  sessionImportCookies: (args: { profileId: string }) =>
     ipcRenderer.invoke('browser:session:importCookies', args),
   sessionResolvePartition: (args: { profileId: string | null }): Promise<string | null> =>
     ipcRenderer.invoke('browser:session:resolvePartition', args),
-  sessionDetectBrowsers: (): Promise<unknown[]> =>
-    ipcRenderer.invoke('browser:session:detectBrowsers'),
-  sessionDetectBrowsersForClientHost: (args: {
-    environmentId: string
-  }): Promise<unknown[] | null> =>
+  sessionDetectBrowsers: () => ipcRenderer.invoke('browser:session:detectBrowsers'),
+  sessionDetectBrowsersForClientHost: (args: { environmentId: string }) =>
     ipcRenderer.invoke('browser:session:detectBrowsersForClientHost', args),
-  sessionImportFromBrowser: (args: {
-    profileId: string
-    browserFamily: string
-  }): Promise<{ ok: true; profileId: string; summary: unknown } | { ok: false; reason: string }> =>
+  sessionImportFromBrowser: (args: { profileId: string; browserFamily: string }) =>
     ipcRenderer.invoke('browser:session:importFromBrowser', args),
   sessionImportFromBrowserForClientHost: (args: {
     environmentId: string
     profileId: string
     browserFamily: string
     browserProfile?: string
-  }): Promise<
-    { ok: true; profileId: string; summary: unknown } | { ok: false; reason: string } | null
-  > => ipcRenderer.invoke('browser:session:importFromBrowserForClientHost', args),
-  sessionClientRouteImportSources: (args: {
-    environmentId: string
-  }): Promise<Record<string, unknown>> =>
+  }) => ipcRenderer.invoke('browser:session:importFromBrowserForClientHost', args),
+  sessionClientRouteImportSources: (args: { environmentId: string }) =>
     ipcRenderer.invoke('browser:session:clientRouteImportSources', args),
   sessionClearDefaultCookies: (): Promise<boolean> =>
     ipcRenderer.invoke('browser:session:clearDefaultCookies'),
   notifyActiveTabChanged: (args: { browserPageId: string }): Promise<boolean> =>
     ipcRenderer.invoke('browser:activeTabChanged', args)
-}
+} satisfies Partial<PreloadApi['browser']>

--- a/src/preload/api/browser-bridge.ts
+++ b/src/preload/api/browser-bridge.ts
@@ -1,7 +1,8 @@
 import { browserGuestRegistrationAndDownloadsApi } from './browser-bridge-guest-registration-and-downloads'
 import { browserPageInteractionAndSessionsApi } from './browser-bridge-page-interaction-and-sessions'
+import type { PreloadApi } from '../api-types'
 
 export const browserApi = {
   ...browserGuestRegistrationAndDownloadsApi,
   ...browserPageInteractionAndSessionsApi
-}
+} satisfies PreloadApi['browser']

--- a/src/preload/api/claude-accounts-bridge.ts
+++ b/src/preload/api/claude-accounts-bridge.ts
@@ -1,18 +1,18 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const claudeAccountsApi = {
-  list: (): Promise<unknown> => ipcRenderer.invoke('claudeAccounts:list'),
-  add: (args?: { runtime?: 'host' | 'wsl'; wslDistro?: string | null }): Promise<unknown> =>
+  list: () => ipcRenderer.invoke('claudeAccounts:list'),
+  add: (args?: { runtime?: 'host' | 'wsl'; wslDistro?: string | null }) =>
     ipcRenderer.invoke('claudeAccounts:add', args),
   cancelPendingLogin: (): Promise<boolean> =>
     ipcRenderer.invoke('claudeAccounts:cancelPendingLogin'),
-  reauthenticate: (args: { accountId: string }): Promise<unknown> =>
+  reauthenticate: (args: { accountId: string }) =>
     ipcRenderer.invoke('claudeAccounts:reauthenticate', args),
-  remove: (args: { accountId: string }): Promise<unknown> =>
-    ipcRenderer.invoke('claudeAccounts:remove', args),
+  remove: (args: { accountId: string }) => ipcRenderer.invoke('claudeAccounts:remove', args),
   select: (args: {
     accountId: string | null
     runtime?: 'host' | 'wsl'
     wslDistro?: string | null
-  }): Promise<unknown> => ipcRenderer.invoke('claudeAccounts:select', args)
-}
+  }) => ipcRenderer.invoke('claudeAccounts:select', args)
+} satisfies PreloadApi['claudeAccounts']

--- a/src/preload/api/claude-usage-bridge.ts
+++ b/src/preload/api/claude-usage-bridge.ts
@@ -1,4 +1,8 @@
 import { ipcRenderer } from 'electron'
 import { createUsageProviderApi } from '../usage-provider-api'
+import type { PreloadApi } from '../api-types'
 
-export const claudeUsageApi = createUsageProviderApi(ipcRenderer, 'claudeUsage')
+export const claudeUsageApi = createUsageProviderApi(
+  ipcRenderer,
+  'claudeUsage'
+) satisfies PreloadApi['claudeUsage']

--- a/src/preload/api/cli-bridge.ts
+++ b/src/preload/api/cli-bridge.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron'
 import type { CliInstallStatus } from '../../shared/cli-install-types'
+import type { PreloadApi } from '../api-types'
 
 export const cliApi = {
   getInstallStatus: (): Promise<CliInstallStatus> => ipcRenderer.invoke('cli:getInstallStatus'),
@@ -11,4 +12,4 @@ export const cliApi = {
     ipcRenderer.invoke('cli:installWsl', args),
   removeWsl: (args?: { distro?: string | null }): Promise<CliInstallStatus> =>
     ipcRenderer.invoke('cli:removeWsl', args)
-}
+} satisfies PreloadApi['cli']

--- a/src/preload/api/codex-accounts-bridge.ts
+++ b/src/preload/api/codex-accounts-bridge.ts
@@ -1,20 +1,18 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const codexAccountsApi = {
-  list: (): Promise<unknown> => ipcRenderer.invoke('codexAccounts:list'),
-  add: (args?: { runtime?: 'host' | 'wsl'; wslDistro?: string | null }): Promise<unknown> =>
+  list: () => ipcRenderer.invoke('codexAccounts:list'),
+  add: (args?: { runtime?: 'host' | 'wsl'; wslDistro?: string | null }) =>
     ipcRenderer.invoke('codexAccounts:add', args),
-  reauthenticate: (args: {
-    accountId: string
-    activateIfSelectionWasEmpty?: boolean
-  }): Promise<unknown> => ipcRenderer.invoke('codexAccounts:reauthenticate', args),
-  remove: (args: { accountId: string }): Promise<unknown> =>
-    ipcRenderer.invoke('codexAccounts:remove', args),
+  reauthenticate: (args: { accountId: string; activateIfSelectionWasEmpty?: boolean }) =>
+    ipcRenderer.invoke('codexAccounts:reauthenticate', args),
+  remove: (args: { accountId: string }) => ipcRenderer.invoke('codexAccounts:remove', args),
   select: (args: {
     accountId: string | null
     runtime?: 'host' | 'wsl'
     wslDistro?: string | null
-  }): Promise<unknown> => ipcRenderer.invoke('codexAccounts:select', args),
+  }) => ipcRenderer.invoke('codexAccounts:select', args),
   listStalePanes: (args: {
     ptyIds: string[]
   }): Promise<
@@ -29,4 +27,4 @@ export const codexAccountsApi = {
     ipcRenderer.invoke('codexAccounts:listRecordedPaneLanes', args),
   forgetStalePanes: (args: { ptyIds: string[] }): Promise<void> =>
     ipcRenderer.invoke('codexAccounts:forgetStalePanes', args)
-}
+} satisfies PreloadApi['codexAccounts']

--- a/src/preload/api/codex-config-sync-bridge.ts
+++ b/src/preload/api/codex-config-sync-bridge.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer } from 'electron'
 import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
+import type { PreloadApi } from '../api-types'
 
 export const codexConfigSyncApi = {
   status: (): Promise<CodexConfigSyncStatus> => ipcRenderer.invoke('codexConfigSync:status')
-}
+} satisfies PreloadApi['codexConfigSync']

--- a/src/preload/api/codex-usage-bridge.ts
+++ b/src/preload/api/codex-usage-bridge.ts
@@ -1,4 +1,8 @@
 import { ipcRenderer } from 'electron'
 import { createUsageProviderApi } from '../usage-provider-api'
+import type { PreloadApi } from '../api-types'
 
-export const codexUsageApi = createUsageProviderApi(ipcRenderer, 'codexUsage')
+export const codexUsageApi = createUsageProviderApi(
+  ipcRenderer,
+  'codexUsage'
+) satisfies PreloadApi['codexUsage']

--- a/src/preload/api/computer-use-permissions-bridge.ts
+++ b/src/preload/api/computer-use-permissions-bridge.ts
@@ -1,8 +1,9 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const computerUsePermissionsApi = {
-  getStatus: (): Promise<unknown> => ipcRenderer.invoke('computerUsePermissions:getStatus'),
-  openSetup: (args?: { id?: string }): Promise<unknown> =>
+  getStatus: () => ipcRenderer.invoke('computerUsePermissions:getStatus'),
+  openSetup: (args?: { id?: string }) =>
     ipcRenderer.invoke('computerUsePermissions:openSetup', args),
-  reset: (): Promise<unknown> => ipcRenderer.invoke('computerUsePermissions:reset')
-}
+  reset: () => ipcRenderer.invoke('computerUsePermissions:reset')
+} satisfies PreloadApi['computerUsePermissions']

--- a/src/preload/api/crash-reports-bridge.ts
+++ b/src/preload/api/crash-reports-bridge.ts
@@ -11,6 +11,7 @@ import type { RendererHeapStatistics } from '../../shared/renderer-heap-statisti
 import type { RendererProcessMemory } from '../../shared/renderer-process-memory'
 import { readRendererHeapStatistics } from '../renderer-heap-statistics-reader'
 import { readRendererProcessMemory } from '../renderer-process-memory-reader'
+import type { PreloadApi } from '../api-types'
 
 export const crashReportsApi = {
   getLatestPending: () => ipcRenderer.invoke('crashReports:getLatestPending'),
@@ -28,4 +29,4 @@ export const crashReportsApi = {
     ipcRenderer.invoke('crashReports:copyLatestDiagnostics', args),
   readHeapStatistics: (): RendererHeapStatistics | null => readRendererHeapStatistics(),
   readProcessMemory: (): Promise<RendererProcessMemory | null> => readRendererProcessMemory()
-}
+} satisfies PreloadApi['crashReports']

--- a/src/preload/api/dashboard-bridge.ts
+++ b/src/preload/api/dashboard-bridge.ts
@@ -5,6 +5,7 @@ import type {
   DashboardSnapshot,
   DashboardSpawnAgentArgs
 } from '../../shared/dashboard-snapshot'
+import type { PreloadApi } from '../api-types'
 
 export const dashboardApi = {
   // Open the pop-out dashboard window, or focus it if already open.
@@ -71,4 +72,4 @@ export const dashboardApi = {
     ipcRenderer.invoke('dashboardPopout:spawnAgent', args),
   sleepWorkspace: (args: DashboardSleepWorkspaceArgs): Promise<void> =>
     ipcRenderer.invoke('dashboardPopout:sleepWorkspace', args)
-}
+} satisfies PreloadApi['dashboard']

--- a/src/preload/api/developer-permissions-bridge.ts
+++ b/src/preload/api/developer-permissions-bridge.ts
@@ -1,11 +1,11 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const developerPermissionsApi = {
-  getStatus: (): Promise<unknown> => ipcRenderer.invoke('developerPermissions:getStatus'),
-  request: (args: { id: string }): Promise<unknown> =>
-    ipcRenderer.invoke('developerPermissions:request', args),
+  getStatus: () => ipcRenderer.invoke('developerPermissions:getStatus'),
+  request: (args: { id: string }) => ipcRenderer.invoke('developerPermissions:request', args),
   openSettings: (args: { id: string }): Promise<void> =>
     ipcRenderer.invoke('developerPermissions:openSettings', args),
-  testLocalNetworkConnection: (args: { host: string; port: number }): Promise<unknown> =>
+  testLocalNetworkConnection: (args: { host: string; port: number }) =>
     ipcRenderer.invoke('developerPermissions:testLocalNetworkConnection', args)
-}
+} satisfies PreloadApi['developerPermissions']

--- a/src/preload/api/diagnostics-bridge.ts
+++ b/src/preload/api/diagnostics-bridge.ts
@@ -1,15 +1,16 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const diagnosticsApi = {
-  getStatus: (): Promise<unknown> => ipcRenderer.invoke('diagnostics:getStatus'),
-  collectBundle: (lookbackMinutes?: number): Promise<unknown> =>
+  getStatus: () => ipcRenderer.invoke('diagnostics:getStatus'),
+  collectBundle: (lookbackMinutes?: number) =>
     ipcRenderer.invoke('diagnostics:collectBundle', lookbackMinutes),
   openBundlePreview: (bundleSubmissionId: string): Promise<void> =>
     ipcRenderer.invoke('diagnostics:openBundlePreview', bundleSubmissionId),
   discardBundlePreview: (bundleSubmissionId: string): Promise<void> =>
     ipcRenderer.invoke('diagnostics:discardBundlePreview', bundleSubmissionId),
-  uploadBundle: (bundleSubmissionId: string): Promise<unknown> =>
+  uploadBundle: (bundleSubmissionId: string) =>
     ipcRenderer.invoke('diagnostics:uploadBundle', bundleSubmissionId),
   deleteBundle: (ticketId: string): Promise<void> =>
     ipcRenderer.invoke('diagnostics:deleteBundle', ticketId)
-}
+} satisfies PreloadApi['diagnostics']

--- a/src/preload/api/doc-preview-bridge.ts
+++ b/src/preload/api/doc-preview-bridge.ts
@@ -8,6 +8,7 @@ import {
   type DocPreviewFailure
 } from '../../shared/doc-preview-scheme'
 import type { DocPreviewGrantRequest } from '../api/doc-preview-api'
+import type { PreloadApi } from '../api-types'
 
 export const docPreviewApi = {
   mintGrant: (request: DocPreviewGrantRequest): Promise<{ grantId: string; url: string }> =>
@@ -28,4 +29,4 @@ export const docPreviewApi = {
     ipcRenderer.on(DOC_PREVIEW_LOAD_FAILURE_CHANNEL, listener)
     return () => ipcRenderer.removeListener(DOC_PREVIEW_LOAD_FAILURE_CHANNEL, listener)
   }
-}
+} satisfies PreloadApi['docPreview']

--- a/src/preload/api/e2e-bridge.ts
+++ b/src/preload/api/e2e-bridge.ts
@@ -1,5 +1,6 @@
 import { preloadE2EConfig } from '../e2e-config'
+import type { PreloadApi } from '../api-types'
 
 export const e2eApi = {
   getConfig: () => preloadE2EConfig
-}
+} satisfies PreloadApi['e2e']

--- a/src/preload/api/emulator-bridge.ts
+++ b/src/preload/api/emulator-bridge.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const emulatorApi = {
   startFrameStream: (args: {
@@ -95,4 +96,4 @@ export const emulatorApi = {
     ipcRenderer.on('ui:emulatorAutoAttach', listener)
     return () => ipcRenderer.removeListener('ui:emulatorAutoAttach', listener)
   }
-}
+} satisfies PreloadApi['emulator']

--- a/src/preload/api/export-bridge.ts
+++ b/src/preload/api/export-bridge.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const exportApi = {
   htmlToPdf: (args: {
@@ -7,4 +8,4 @@ export const exportApi = {
   }): Promise<
     { success: true; filePath: string } | { success: false; cancelled?: boolean; error?: string }
   > => ipcRenderer.invoke('export:html-to-pdf', args)
-}
+} satisfies PreloadApi['export']

--- a/src/preload/api/feedback-bridge.ts
+++ b/src/preload/api/feedback-bridge.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const feedbackApi = {
   submit: (args: {
@@ -10,4 +11,4 @@ export const feedbackApi = {
   }): Promise<
     { ok: true; imagesDelivered?: boolean } | { ok: false; status: number | null; error: string }
   > => ipcRenderer.invoke('feedback:submit', args)
-}
+} satisfies PreloadApi['feedback']

--- a/src/preload/api/fs-bridge.ts
+++ b/src/preload/api/fs-bridge.ts
@@ -8,6 +8,7 @@ import type {
   LocalLogTailReadResult,
   LocalLogTailWatchArgs
 } from '../../shared/local-log-tail-types'
+import type { PreloadApi } from '../api-types'
 
 export const fsApi = {
   readDir: (args: {
@@ -216,4 +217,4 @@ export const fsApi = {
     ipcRenderer.on('fs:changed', listener)
     return () => ipcRenderer.removeListener('fs:changed', listener)
   }
-}
+} satisfies PreloadApi['fs']

--- a/src/preload/api/gh-bridge-mutations-and-projects.ts
+++ b/src/preload/api/gh-bridge-mutations-and-projects.ts
@@ -35,11 +35,12 @@ import type {
   UpdateProjectItemFieldArgs
 } from '../../shared/github/project-request-types'
 import type { AppStarSource } from '../../shared/gh-star-source'
+import type { PreloadApi } from '../api-types'
 
 export const ghMutationsAndProjectsApi = {
   setPRAutoMerge: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     enabled: boolean
@@ -49,7 +50,7 @@ export const ghMutationsAndProjectsApi = {
     ipcRenderer.invoke('gh:setPRAutoMerge', args),
   updatePRState: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     updates: { state: 'open' | 'closed' }
@@ -58,7 +59,7 @@ export const ghMutationsAndProjectsApi = {
     ipcRenderer.invoke('gh:updatePRState', args),
   markPRReadyForReview: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     prRepo?: GitHubOwnerRepo | null
@@ -66,7 +67,7 @@ export const ghMutationsAndProjectsApi = {
     ipcRenderer.invoke('gh:markPRReadyForReview', args),
   requestPRReviewers: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     reviewers: string[]
@@ -75,7 +76,7 @@ export const ghMutationsAndProjectsApi = {
     ipcRenderer.invoke('gh:requestPRReviewers', args),
   removePRReviewers: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     reviewers: string[]
@@ -84,7 +85,7 @@ export const ghMutationsAndProjectsApi = {
     ipcRenderer.invoke('gh:removePRReviewers', args),
   updateIssue: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     number: number
     updates: unknown
@@ -92,7 +93,7 @@ export const ghMutationsAndProjectsApi = {
     ipcRenderer.invoke('gh:updateIssue', args),
   addIssueComment: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     number: number
     body: string
@@ -101,7 +102,7 @@ export const ghMutationsAndProjectsApi = {
   }): Promise<GitHubCommentResult> => ipcRenderer.invoke('gh:addIssueComment', args),
   addPRReviewCommentReply: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     commentId: number
@@ -113,7 +114,7 @@ export const ghMutationsAndProjectsApi = {
   }): Promise<GitHubCommentResult> => ipcRenderer.invoke('gh:addPRReviewCommentReply', args),
   addPRReviewComment: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     prRepo?: GitHubOwnerRepo | null
@@ -125,12 +126,12 @@ export const ghMutationsAndProjectsApi = {
   }): Promise<GitHubCommentResult> => ipcRenderer.invoke('gh:addPRReviewComment', args),
   listLabels: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
   }): Promise<string[]> => ipcRenderer.invoke('gh:listLabels', args),
   listAssignableUsers: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
   }): Promise<GitHubAssignableUser[]> => ipcRenderer.invoke('gh:listAssignableUsers', args),
   onWorkItemMutated: (
@@ -199,4 +200,4 @@ export const ghMutationsAndProjectsApi = {
     ipcRenderer.invoke('gh:listIssueTypesBySlug', args),
   updateIssueTypeBySlug: (args: UpdateIssueTypeBySlugArgs): Promise<GitHubProjectMutationResult> =>
     ipcRenderer.invoke('gh:updateIssueTypeBySlug', args)
-}
+} satisfies Partial<PreloadApi['gh']>

--- a/src/preload/api/gh-bridge-pull-requests-and-work-items.ts
+++ b/src/preload/api/gh-bridge-pull-requests-and-work-items.ts
@@ -9,33 +9,34 @@ import type { GitHubOwnerRepo } from '../../shared/github/pull-request-types'
 import type { GitHubWorkItem, ListWorkItemsResult } from '../../shared/github/work-item-types'
 import type { GitHubCreateIssueResult } from '../../shared/issue-mutation-types'
 import type { TaskSourceContext } from '../../shared/task-source-context'
+import type { PreloadApi } from '../api-types'
 
 export const ghPullRequestsAndWorkItemsApi = {
-  viewer: (): Promise<unknown> => ipcRenderer.invoke('gh:viewer'),
-  repoSlug: (args: { repoPath: string; repoId?: string }): Promise<unknown> =>
+  viewer: () => ipcRenderer.invoke('gh:viewer'),
+  repoSlug: (args: { repoPath: string; repoId?: string }) =>
     ipcRenderer.invoke('gh:repoSlug', args),
-  repoUpstream: (args: { repoPath: string; repoId?: string }): Promise<unknown> =>
+  repoUpstream: (args: { repoPath: string; repoId?: string }) =>
     ipcRenderer.invoke('gh:repoUpstream', args),
   prForBranch: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     branch: string
     linkedPRNumber?: number | null
     fallbackPRNumber?: number | null
     acceptMergedFallbackPR?: boolean
     currentHeadOid?: string | null
-  }): Promise<unknown> => ipcRenderer.invoke('gh:prForBranch', args),
-  refreshPRNow: (args: { candidate: GitHubPRRefreshCandidate }): Promise<unknown> =>
+  }) => ipcRenderer.invoke('gh:prForBranch', args),
+  refreshPRNow: (args: { candidate: GitHubPRRefreshCandidate }) =>
     ipcRenderer.invoke('gh:refreshPRNow', args),
   enqueuePRRefresh: (args: {
     candidate: GitHubPRRefreshCandidate
     reason: GitHubPRRefreshReason
     priority?: number
-  }): Promise<unknown> => ipcRenderer.invoke('gh:enqueuePRRefresh', args),
+  }) => ipcRenderer.invoke('gh:enqueuePRRefresh', args),
   reportVisiblePRRefreshCandidates: (args: {
     candidates: GitHubPRRefreshCandidate[]
     generation: number
-  }): Promise<unknown> => ipcRenderer.invoke('gh:reportVisiblePRRefreshCandidates', args),
+  }) => ipcRenderer.invoke('gh:reportVisiblePRRefreshCandidates', args),
   onPRRefreshEvent: (callback: (event: GitHubPRRefreshEvent) => void): (() => void) => {
     const listener = (_event: Electron.IpcRendererEvent, event: GitHubPRRefreshEvent): void =>
       callback(event)
@@ -44,42 +45,42 @@ export const ghPullRequestsAndWorkItemsApi = {
   },
   issue: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     number: number
-  }): Promise<unknown> => ipcRenderer.invoke('gh:issue', args),
+  }) => ipcRenderer.invoke('gh:issue', args),
   workItem: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     number: number
     type?: 'issue' | 'pr'
-  }): Promise<unknown> => ipcRenderer.invoke('gh:workItem', args),
+  }) => ipcRenderer.invoke('gh:workItem', args),
   workItemByOwnerRepo: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     owner: string
     repo: string
     host?: string
     number: number
     type: 'issue' | 'pr'
-  }): Promise<unknown> => ipcRenderer.invoke('gh:workItemByOwnerRepo', args),
+  }) => ipcRenderer.invoke('gh:workItemByOwnerRepo', args),
   workItemDetails: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     number: number
     type?: 'issue' | 'pr'
-  }): Promise<unknown> => ipcRenderer.invoke('gh:workItemDetails', args),
+  }) => ipcRenderer.invoke('gh:workItemDetails', args),
   notifyWorkItemMutated: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     type: 'issue' | 'pr'
     number: number
   }): Promise<boolean> => ipcRenderer.invoke('gh:notifyWorkItemMutated', args),
   prFileContents: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     prRepo?: GitHubOwnerRepo | null
@@ -88,12 +89,12 @@ export const ghPullRequestsAndWorkItemsApi = {
     status: string
     headSha: string
     baseSha: string
-  }): Promise<unknown> => ipcRenderer.invoke('gh:prFileContents', args),
-  listIssues: (args: { repoPath: string; repoId?: string; limit?: number }): Promise<unknown[]> =>
+  }) => ipcRenderer.invoke('gh:prFileContents', args),
+  listIssues: (args: { repoPath: string; repoId?: string; limit?: number }) =>
     ipcRenderer.invoke('gh:listIssues', args),
   createIssue: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     title: string
     body: string
@@ -104,7 +105,7 @@ export const ghPullRequestsAndWorkItemsApi = {
     ipcRenderer.invoke('gh:countWorkItems', args),
   listWorkItems: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     limit?: number
     query?: string
     page?: number
@@ -113,26 +114,26 @@ export const ghPullRequestsAndWorkItemsApi = {
     ipcRenderer.invoke('gh:listWorkItems', args),
   prChecks: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     headSha?: string
     prRepo?: GitHubOwnerRepo | null
     noCache?: boolean
-  }): Promise<unknown[]> => ipcRenderer.invoke('gh:prChecks', args),
+  }) => ipcRenderer.invoke('gh:prChecks', args),
   prCheckDetails: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     checkRunId?: number
     workflowRunId?: number
     checkName?: string
     url?: string | null
     prRepo?: GitHubOwnerRepo | null
-  }): Promise<unknown> => ipcRenderer.invoke('gh:prCheckDetails', args),
+  }) => ipcRenderer.invoke('gh:prCheckDetails', args),
   rerunPRChecks: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     headSha?: string
@@ -142,15 +143,15 @@ export const ghPullRequestsAndWorkItemsApi = {
     ipcRenderer.invoke('gh:rerunPRChecks', args),
   prComments: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     prRepo?: GitHubOwnerRepo | null
     noCache?: boolean
-  }): Promise<unknown[]> => ipcRenderer.invoke('gh:prComments', args),
+  }) => ipcRenderer.invoke('gh:prComments', args),
   setPRCommentReaction: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     reactionSubjectId: string
     content: GitHubReactionContent
@@ -159,7 +160,7 @@ export const ghPullRequestsAndWorkItemsApi = {
   }): Promise<boolean> => ipcRenderer.invoke('gh:setPRCommentReaction', args),
   resolveReviewThread: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     threadId: string
     resolve: boolean
@@ -167,7 +168,7 @@ export const ghPullRequestsAndWorkItemsApi = {
   }): Promise<boolean> => ipcRenderer.invoke('gh:resolveReviewThread', args),
   setPRFileViewed: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     prRepo?: GitHubOwnerRepo | null
@@ -177,17 +178,17 @@ export const ghPullRequestsAndWorkItemsApi = {
   }): Promise<boolean> => ipcRenderer.invoke('gh:setPRFileViewed', args),
   updatePRTitle: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     prNumber: number
     title: string
     prRepo?: GitHubOwnerRepo | null
   }): Promise<boolean> => ipcRenderer.invoke('gh:updatePRTitle', args),
   mergePR: (args: {
     repoPath: string
-    repoId?: string
+    repoId?: string | null
     sourceContext?: TaskSourceContext | null
     prNumber: number
     method?: 'merge' | 'squash' | 'rebase'
     prRepo?: GitHubOwnerRepo | null
   }): Promise<{ ok: true } | { ok: false; error: string }> => ipcRenderer.invoke('gh:mergePR', args)
-}
+} satisfies Partial<PreloadApi['gh']>

--- a/src/preload/api/gh-bridge.ts
+++ b/src/preload/api/gh-bridge.ts
@@ -1,4 +1,8 @@
+import type { PreloadApi } from '../api-types'
 import { ghPullRequestsAndWorkItemsApi } from './gh-bridge-pull-requests-and-work-items'
 import { ghMutationsAndProjectsApi } from './gh-bridge-mutations-and-projects'
 
-export const ghApi = { ...ghPullRequestsAndWorkItemsApi, ...ghMutationsAndProjectsApi }
+export const ghApi = {
+  ...ghPullRequestsAndWorkItemsApi,
+  ...ghMutationsAndProjectsApi
+} satisfies PreloadApi['gh']

--- a/src/preload/api/git-bash-bridge.ts
+++ b/src/preload/api/git-bash-bridge.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const gitBashApi = {
   isAvailable: (): Promise<boolean> => ipcRenderer.invoke('gitBash:isAvailable')
-}
+} satisfies PreloadApi['gitBash']

--- a/src/preload/api/git-bridge.ts
+++ b/src/preload/api/git-bridge.ts
@@ -3,6 +3,7 @@ import type { GitForkSyncExpectedUpstream, GitForkSyncResult } from '../../share
 import type { GitStagingArea, GitUpstreamStatus } from '../../shared/git-status-types'
 import type { GitPushTarget } from '../../shared/worktree/types'
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
+import type { PreloadApi } from '../api-types'
 
 export const gitApi = {
   status: (args: {
@@ -13,7 +14,7 @@ export const gitApi = {
     reuseLineStats?: boolean
     branchLineTotalMergeBase?: string
     requestToken?: string
-  }): Promise<unknown> => ipcRenderer.invoke('git:status', args),
+  }) => ipcRenderer.invoke('git:status', args),
   cancelStatus: (args: { requestToken: string }): Promise<void> =>
     ipcRenderer.invoke('git:cancelStatus', args),
   setStatusUpstreamRefWatch: (args: {
@@ -29,7 +30,7 @@ export const gitApi = {
     submodulePath: string
     connectionId?: string
     area?: GitStagingArea
-  }): Promise<unknown> => ipcRenderer.invoke('git:submoduleStatus', args),
+  }) => ipcRenderer.invoke('git:submoduleStatus', args),
   checkIgnored: (args: {
     worktreePath: string
     paths: string[]
@@ -42,7 +43,7 @@ export const gitApi = {
   history: (
     args: { worktreePath: string; connectionId?: string } & GitHistoryOptions
   ): Promise<GitHistoryResult> => ipcRenderer.invoke('git:history', args),
-  conflictOperation: (args: { worktreePath: string; connectionId?: string }): Promise<unknown> =>
+  conflictOperation: (args: { worktreePath: string; connectionId?: string }) =>
     ipcRenderer.invoke('git:conflictOperation', args),
   abortMerge: (args: { worktreePath: string; connectionId?: string }): Promise<void> =>
     ipcRenderer.invoke('git:abortMerge', args),
@@ -54,17 +55,11 @@ export const gitApi = {
     staged: boolean
     compareAgainstHead?: boolean
     connectionId?: string
-  }): Promise<unknown> => ipcRenderer.invoke('git:diff', args),
-  branchCompare: (args: {
-    worktreePath: string
-    baseRef: string
-    connectionId?: string
-  }): Promise<unknown> => ipcRenderer.invoke('git:branchCompare', args),
-  commitCompare: (args: {
-    worktreePath: string
-    commitId: string
-    connectionId?: string
-  }): Promise<unknown> => ipcRenderer.invoke('git:commitCompare', args),
+  }) => ipcRenderer.invoke('git:diff', args),
+  branchCompare: (args: { worktreePath: string; baseRef: string; connectionId?: string }) =>
+    ipcRenderer.invoke('git:branchCompare', args),
+  commitCompare: (args: { worktreePath: string; commitId: string; connectionId?: string }) =>
+    ipcRenderer.invoke('git:commitCompare', args),
   upstreamStatus: (args: {
     worktreePath: string
     connectionId?: string
@@ -108,7 +103,7 @@ export const gitApi = {
     filePath: string
     oldPath?: string
     connectionId?: string
-  }): Promise<unknown> => ipcRenderer.invoke('git:branchDiff', args),
+  }) => ipcRenderer.invoke('git:branchDiff', args),
   commitDiff: (args: {
     worktreePath: string
     commitOid: string
@@ -116,7 +111,7 @@ export const gitApi = {
     filePath: string
     oldPath?: string
     connectionId?: string
-  }): Promise<unknown> => ipcRenderer.invoke('git:commitDiff', args),
+  }) => ipcRenderer.invoke('git:commitDiff', args),
   commit: (args: {
     worktreePath: string
     message: string
@@ -130,12 +125,12 @@ export const gitApi = {
     sourceControlAiResolvedParams?: unknown
     sourceControlAi?: unknown
     agentCmdOverrides?: Record<string, string>
-  }): Promise<unknown> => ipcRenderer.invoke('git:generateCommitMessage', args),
+  }) => ipcRenderer.invoke('git:generateCommitMessage', args),
   discoverCommitMessageModels: (args: {
     agentId: string
     worktreePath?: string
     connectionId?: string
-  }): Promise<unknown> => ipcRenderer.invoke('git:discoverCommitMessageModels', args),
+  }) => ipcRenderer.invoke('git:discoverCommitMessageModels', args),
   cancelGenerateCommitMessage: (args: {
     worktreePath: string
     connectionId?: string
@@ -154,7 +149,7 @@ export const gitApi = {
     sourceControlAiResolvedParams?: unknown
     sourceControlAi?: unknown
     agentCmdOverrides?: Record<string, string>
-  }): Promise<unknown> => ipcRenderer.invoke('git:generatePullRequestFields', args),
+  }) => ipcRenderer.invoke('git:generatePullRequestFields', args),
   cancelGeneratePullRequestFields: (args: {
     worktreePath: string
     connectionId?: string
@@ -197,4 +192,4 @@ export const gitApi = {
     sha: string
     connectionId?: string
   }): Promise<string | null> => ipcRenderer.invoke('git:remoteCommitUrl', args)
-}
+} satisfies PreloadApi['git']

--- a/src/preload/api/gl-bridge.ts
+++ b/src/preload/api/gl-bridge.ts
@@ -1,3 +1,4 @@
 import { glApi } from '../gitlab'
+import type { PreloadApi } from '../api-types'
 
-export const glApiBridge = glApi
+export const glApiBridge = glApi satisfies PreloadApi['gl']

--- a/src/preload/api/grok-accounts-bridge.ts
+++ b/src/preload/api/grok-accounts-bridge.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer } from 'electron'
 import type { GrokAccountStatus } from '../../shared/rate-limit-types'
+import type { PreloadApi } from '../api-types'
 
 export const grokAccountsApi = {
   getStatus: (): Promise<GrokAccountStatus> => ipcRenderer.invoke('grokAccounts:getStatus')
-}
+} satisfies PreloadApi['grokAccounts']

--- a/src/preload/api/hooks-bridge.ts
+++ b/src/preload/api/hooks-bridge.ts
@@ -1,22 +1,14 @@
 import { ipcRenderer } from 'electron'
 import type { WorktreeSetupLaunch } from '../../shared/worktree/launch-types'
 import type { ExecutionHostId } from '../../shared/execution-host'
+import type { PreloadApi } from '../api-types'
 
 export const hooksApi = {
-  check: (args: {
-    repoId: string
-    hostId?: ExecutionHostId
-  }): Promise<{
-    status?: 'ok' | 'error'
-    hasHooks: boolean
-    hooks: unknown
-    mayNeedUpdate: boolean
-  }> => ipcRenderer.invoke('hooks:check', args),
+  check: (args: { repoId: string; hostId?: ExecutionHostId }) =>
+    ipcRenderer.invoke('hooks:check', args),
 
-  inspectSetupScriptImports: (args: {
-    repoId: string
-    hostId?: ExecutionHostId
-  }): Promise<unknown[]> => ipcRenderer.invoke('hooks:inspectSetupScriptImports', args),
+  inspectSetupScriptImports: (args: { repoId: string; hostId?: ExecutionHostId }) =>
+    ipcRenderer.invoke('hooks:inspectSetupScriptImports', args),
 
   createIssueCommandRunner: (args: {
     repoId: string
@@ -41,4 +33,4 @@ export const hooksApi = {
     content: string
     hostId?: ExecutionHostId
   }): Promise<void> => ipcRenderer.invoke('hooks:writeIssueCommand', args)
-}
+} satisfies PreloadApi['hooks']

--- a/src/preload/api/hosted-review-bridge.ts
+++ b/src/preload/api/hosted-review-bridge.ts
@@ -1,12 +1,12 @@
 import { ipcRenderer } from 'electron'
 import type { HostedReviewForBranchArgs } from '../../shared/hosted-review'
+import type { PreloadApi } from '../api-types'
 
 export const hostedReviewApi = {
-  forBranch: (args: HostedReviewForBranchArgs): Promise<unknown> =>
+  forBranch: (args: HostedReviewForBranchArgs) =>
     ipcRenderer.invoke('hostedReview:forBranch', args),
-  getCreationEligibility: (args: unknown): Promise<unknown> =>
+  getCreationEligibility: (args: unknown) =>
     ipcRenderer.invoke('hostedReview:getCreationEligibility', args),
-  create: (args: unknown): Promise<unknown> => ipcRenderer.invoke('hostedReview:create', args),
-  createStacked: (args: unknown): Promise<unknown> =>
-    ipcRenderer.invoke('hostedReview:createStacked', args)
-}
+  create: (args: unknown) => ipcRenderer.invoke('hostedReview:create', args),
+  createStacked: (args: unknown) => ipcRenderer.invoke('hostedReview:createStacked', args)
+} satisfies PreloadApi['hostedReview']

--- a/src/preload/api/jira-bridge.ts
+++ b/src/preload/api/jira-bridge.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron'
 import type { JiraProjectStatusOrder } from '../../shared/jira-types'
+import type { PreloadApi } from '../api-types'
 
 export const jiraApi = {
   connect: (args: {
@@ -7,30 +8,21 @@ export const jiraApi = {
     email: string
     apiToken: string
     authType?: 'cloud' | 'server'
-  }): Promise<{ ok: true; viewer: unknown } | { ok: false; error: string }> =>
-    ipcRenderer.invoke('jira:connect', args),
+  }) => ipcRenderer.invoke('jira:connect', args),
 
   disconnect: (args?: { siteId?: string }): Promise<void> =>
     ipcRenderer.invoke('jira:disconnect', args),
 
-  selectSite: (args: { siteId: string }): Promise<unknown> =>
-    ipcRenderer.invoke('jira:selectSite', args),
+  selectSite: (args: { siteId: string }) => ipcRenderer.invoke('jira:selectSite', args),
 
-  status: (): Promise<unknown> => ipcRenderer.invoke('jira:status'),
+  status: () => ipcRenderer.invoke('jira:status'),
 
-  readStatus: (): Promise<unknown> => ipcRenderer.invoke('jira:readStatus'),
+  readStatus: () => ipcRenderer.invoke('jira:readStatus'),
 
-  testConnection: (args?: {
-    siteId?: string
-  }): Promise<{ ok: true; viewer: unknown } | { ok: false; error: string }> =>
-    ipcRenderer.invoke('jira:testConnection', args),
+  testConnection: (args?: { siteId?: string }) => ipcRenderer.invoke('jira:testConnection', args),
 
-  searchIssues: (args: {
-    jql: string
-    limit?: number
-    siteId?: string
-    requestId?: string
-  }): Promise<unknown[]> => ipcRenderer.invoke('jira:searchIssues', args),
+  searchIssues: (args: { jql: string; limit?: number; siteId?: string; requestId?: string }) =>
+    ipcRenderer.invoke('jira:searchIssues', args),
   cancelSearchIssues: (args: { requestId: string }): Promise<void> =>
     ipcRenderer.invoke('jira:cancelSearchIssues', args),
 
@@ -38,16 +30,12 @@ export const jiraApi = {
     filter?: 'assigned' | 'reported' | 'all' | 'done'
     limit?: number
     siteId?: string
-  }): Promise<unknown[]> => ipcRenderer.invoke('jira:listIssues', args),
+  }) => ipcRenderer.invoke('jira:listIssues', args),
 
-  getIssue: (args: { key: string; siteId?: string }): Promise<unknown> =>
-    ipcRenderer.invoke('jira:getIssue', args),
+  getIssue: (args: { key: string; siteId?: string }) => ipcRenderer.invoke('jira:getIssue', args),
 
-  lookupIssueSummary: (args: {
-    key: string
-    siteId: string
-    requestId?: string
-  }): Promise<unknown> => ipcRenderer.invoke('jira:lookupIssueSummary', args),
+  lookupIssueSummary: (args: { key: string; siteId: string; requestId?: string }) =>
+    ipcRenderer.invoke('jira:lookupIssueSummary', args),
   cancelIssueSummary: (args: { requestId: string }): Promise<void> =>
     ipcRenderer.invoke('jira:cancelIssueSummary', args),
 
@@ -75,36 +63,28 @@ export const jiraApi = {
   }): Promise<{ ok: true; id: string } | { ok: false; error: string }> =>
     ipcRenderer.invoke('jira:addIssueComment', args),
 
-  issueComments: (args: { key: string; siteId?: string }): Promise<unknown[]> =>
+  issueComments: (args: { key: string; siteId?: string }) =>
     ipcRenderer.invoke('jira:issueComments', args),
 
-  listProjects: (args?: { siteId?: string }): Promise<unknown[]> =>
-    ipcRenderer.invoke('jira:listProjects', args),
+  listProjects: (args?: { siteId?: string }) => ipcRenderer.invoke('jira:listProjects', args),
 
-  listIssueTypes: (args: { projectIdOrKey: string; siteId?: string }): Promise<unknown[]> =>
+  listIssueTypes: (args: { projectIdOrKey: string; siteId?: string }) =>
     ipcRenderer.invoke('jira:listIssueTypes', args),
 
-  listCreateFields: (args: {
-    projectIdOrKey: string
-    issueTypeId: string
-    siteId?: string
-  }): Promise<unknown[]> => ipcRenderer.invoke('jira:listCreateFields', args),
+  listCreateFields: (args: { projectIdOrKey: string; issueTypeId: string; siteId?: string }) =>
+    ipcRenderer.invoke('jira:listCreateFields', args),
 
-  listPriorities: (args?: { siteId?: string }): Promise<unknown[]> =>
-    ipcRenderer.invoke('jira:listPriorities', args),
+  listPriorities: (args?: { siteId?: string }) => ipcRenderer.invoke('jira:listPriorities', args),
 
-  listAssignableUsers: (args: {
-    key: string
-    query?: string
-    siteId?: string
-  }): Promise<unknown[]> => ipcRenderer.invoke('jira:listAssignableUsers', args),
-  searchUsers: (args?: { query?: string; siteId?: string }): Promise<unknown[]> =>
+  listAssignableUsers: (args: { key: string; query?: string; siteId?: string }) =>
+    ipcRenderer.invoke('jira:listAssignableUsers', args),
+  searchUsers: (args?: { query?: string; siteId?: string }) =>
     ipcRenderer.invoke('jira:searchUsers', args),
 
-  listTransitions: (args: { key: string; siteId?: string }): Promise<unknown[]> =>
+  listTransitions: (args: { key: string; siteId?: string }) =>
     ipcRenderer.invoke('jira:listTransitions', args),
   getProjectStatusOrder: (args: {
     projectKey: string
     siteId?: string
   }): Promise<JiraProjectStatusOrder> => ipcRenderer.invoke('jira:getProjectStatusOrder', args)
-}
+} satisfies PreloadApi['jira']

--- a/src/preload/api/keybindings-bridge.ts
+++ b/src/preload/api/keybindings-bridge.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron'
 import type { KeybindingActionId, KeybindingFileSnapshot } from '../../shared/keybindings'
+import type { PreloadApi } from '../api-types'
 
 export const keybindingsApi = {
   get: (): Promise<KeybindingFileSnapshot> => ipcRenderer.invoke('keybindings:get'),
@@ -17,4 +18,4 @@ export const keybindingsApi = {
     ipcRenderer.on('keybindings:changed', listener)
     return () => ipcRenderer.removeListener('keybindings:changed', listener)
   }
-}
+} satisfies PreloadApi['keybindings']

--- a/src/preload/api/linear-bridge.ts
+++ b/src/preload/api/linear-bridge.ts
@@ -1,37 +1,30 @@
 import { ipcRenderer } from 'electron'
 import type { LinearProjectDetail } from '../../shared/linear/project-types'
+import type { PreloadApi } from '../api-types'
 
 export const linearApi = {
-  connect: (args: {
-    apiKey: string
-  }): Promise<{ ok: true; viewer: unknown } | { ok: false; error: string }> =>
-    ipcRenderer.invoke('linear:connect', args),
+  connect: (args: { apiKey: string }) => ipcRenderer.invoke('linear:connect', args),
 
   disconnect: (args?: { workspaceId?: string }): Promise<void> =>
     ipcRenderer.invoke('linear:disconnect', args),
 
-  selectWorkspace: (args: { workspaceId: string }): Promise<unknown> =>
+  selectWorkspace: (args: { workspaceId: string }) =>
     ipcRenderer.invoke('linear:selectWorkspace', args),
 
-  status: (): Promise<unknown> => ipcRenderer.invoke('linear:status'),
+  status: () => ipcRenderer.invoke('linear:status'),
 
-  testConnection: (args?: {
-    workspaceId?: string
-  }): Promise<{ ok: true; viewer: unknown } | { ok: false; error: string }> =>
+  testConnection: (args?: { workspaceId?: string }) =>
     ipcRenderer.invoke('linear:testConnection', args),
 
-  searchIssues: (args: {
-    query: string
-    limit?: number
-    workspaceId?: string
-  }): Promise<unknown[]> => ipcRenderer.invoke('linear:searchIssues', args),
+  searchIssues: (args: { query: string; limit?: number; workspaceId?: string }) =>
+    ipcRenderer.invoke('linear:searchIssues', args),
 
   listIssues: (args?: {
     filter?: 'assigned' | 'created' | 'all' | 'completed'
     limit?: number
     workspaceId?: string
     attributeFilter?: unknown
-  }): Promise<unknown> => ipcRenderer.invoke('linear:listIssues', args),
+  }) => ipcRenderer.invoke('linear:listIssues', args),
 
   createIssue: (args: {
     teamId: string
@@ -49,7 +42,7 @@ export const linearApi = {
     | { ok: false; error: string }
   > => ipcRenderer.invoke('linear:createIssue', args),
 
-  getIssue: (args: { id: string; workspaceId?: string }): Promise<unknown> =>
+  getIssue: (args: { id: string; workspaceId?: string }) =>
     ipcRenderer.invoke('linear:getIssue', args),
 
   updateIssue: (args: {
@@ -66,18 +59,17 @@ export const linearApi = {
   }): Promise<{ ok: true; id: string } | { ok: false; error: string }> =>
     ipcRenderer.invoke('linear:addIssueComment', args),
 
-  issueComments: (args: { issueId: string; workspaceId?: string }): Promise<unknown[]> =>
+  issueComments: (args: { issueId: string; workspaceId?: string }) =>
     ipcRenderer.invoke('linear:issueComments', args),
 
-  listTeams: (args?: { workspaceId?: string }): Promise<unknown[]> =>
-    ipcRenderer.invoke('linear:listTeams', args),
+  listTeams: (args?: { workspaceId?: string }) => ipcRenderer.invoke('linear:listTeams', args),
 
   listProjects: (args?: {
     query?: string
     limit?: number
     workspaceId?: string
     force?: boolean
-  }): Promise<unknown> => ipcRenderer.invoke('linear:listProjects', args),
+  }) => ipcRenderer.invoke('linear:listProjects', args),
 
   createProject: (args: {
     name: string
@@ -94,7 +86,7 @@ export const linearApi = {
   }): Promise<{ ok: true; project: LinearProjectDetail } | { ok: false; error: string }> =>
     ipcRenderer.invoke('linear:createProject', args),
 
-  getProject: (args: { id: string; workspaceId: string; force?: boolean }): Promise<unknown> =>
+  getProject: (args: { id: string; workspaceId: string; force?: boolean }) =>
     ipcRenderer.invoke('linear:getProject', args),
 
   listProjectIssues: (args: {
@@ -102,42 +94,38 @@ export const linearApi = {
     limit?: number
     workspaceId: string
     force?: boolean
-  }): Promise<unknown> => ipcRenderer.invoke('linear:listProjectIssues', args),
+  }) => ipcRenderer.invoke('linear:listProjectIssues', args),
 
   listCustomViews: (args: {
     model: string
     limit?: number
     workspaceId?: string
     force?: boolean
-  }): Promise<unknown> => ipcRenderer.invoke('linear:listCustomViews', args),
+  }) => ipcRenderer.invoke('linear:listCustomViews', args),
 
-  getCustomView: (args: {
-    viewId: string
-    model: string
-    workspaceId: string
-    force?: boolean
-  }): Promise<unknown> => ipcRenderer.invoke('linear:getCustomView', args),
+  getCustomView: (args: { viewId: string; model: string; workspaceId: string; force?: boolean }) =>
+    ipcRenderer.invoke('linear:getCustomView', args),
 
   listCustomViewIssues: (args: {
     viewId: string
     limit?: number
     workspaceId: string
     force?: boolean
-  }): Promise<unknown> => ipcRenderer.invoke('linear:listCustomViewIssues', args),
+  }) => ipcRenderer.invoke('linear:listCustomViewIssues', args),
 
   listCustomViewProjects: (args: {
     viewId: string
     limit?: number
     workspaceId: string
     force?: boolean
-  }): Promise<unknown> => ipcRenderer.invoke('linear:listCustomViewProjects', args),
+  }) => ipcRenderer.invoke('linear:listCustomViewProjects', args),
 
-  teamStates: (args: { teamId: string; workspaceId?: string }): Promise<unknown[]> =>
+  teamStates: (args: { teamId: string; workspaceId?: string }) =>
     ipcRenderer.invoke('linear:teamStates', args),
 
-  teamLabels: (args: { teamId: string; workspaceId?: string }): Promise<unknown[]> =>
+  teamLabels: (args: { teamId: string; workspaceId?: string }) =>
     ipcRenderer.invoke('linear:teamLabels', args),
 
-  teamMembers: (args: { teamId: string; workspaceId?: string }): Promise<unknown[]> =>
+  teamMembers: (args: { teamId: string; workspaceId?: string }) =>
     ipcRenderer.invoke('linear:teamMembers', args)
-}
+} satisfies PreloadApi['linear']

--- a/src/preload/api/macos-tcc-prompts-bridge.ts
+++ b/src/preload/api/macos-tcc-prompts-bridge.ts
@@ -1,11 +1,14 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const macosTccPromptsApi = {
-  onThreshold: (callback: (payload: unknown) => void) => {
-    const listener = (_event: Electron.IpcRendererEvent, payload: unknown): void =>
+  onThreshold: (callback: (payload: { promptCount: number }) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: { promptCount: number }): void =>
       callback(payload)
     ipcRenderer.on('macosTccPrompts:threshold', listener)
-    return () => ipcRenderer.removeListener('macosTccPrompts:threshold', listener)
+    return (): void => {
+      ipcRenderer.removeListener('macosTccPrompts:threshold', listener)
+    }
   },
   consumePending: (): Promise<{ claimId: number; promptCount: number } | null> =>
     ipcRenderer.invoke('macosTccPrompts:consumePending'),
@@ -14,4 +17,4 @@ export const macosTccPromptsApi = {
   releasePending: (claimId: number): Promise<void> =>
     ipcRenderer.invoke('macosTccPrompts:releasePending', claimId),
   dismiss: (): Promise<void> => ipcRenderer.invoke('macosTccPrompts:dismiss')
-}
+} satisfies PreloadApi['macosTccPrompts']

--- a/src/preload/api/memory-bridge.ts
+++ b/src/preload/api/memory-bridge.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer } from 'electron'
 import type { MemorySnapshot } from '../../shared/process-stats-types'
+import type { PreloadApi } from '../api-types'
 
 export const memoryApi = {
   getSnapshot: (): Promise<MemorySnapshot> => ipcRenderer.invoke('memory:getSnapshot')
-}
+} satisfies PreloadApi['memory']

--- a/src/preload/api/minimax-credentials-bridge.ts
+++ b/src/preload/api/minimax-credentials-bridge.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const minimaxCredentialsApi = {
   getStatus: (): Promise<{ configured: boolean }> =>
@@ -7,4 +8,4 @@ export const minimaxCredentialsApi = {
     ipcRenderer.invoke('minimaxCredentials:saveCookie', cookie),
   clearCookie: (): Promise<{ configured: boolean }> =>
     ipcRenderer.invoke('minimaxCredentials:clearCookie')
-}
+} satisfies PreloadApi['minimaxCredentials']

--- a/src/preload/api/mobile-bridge.ts
+++ b/src/preload/api/mobile-bridge.ts
@@ -3,6 +3,7 @@ import type { MobileRelayStatus } from '../../shared/mobile-relay-status'
 import type { MobilePairingConnectionMode } from '../../shared/mobile-pairing-connection-mode'
 import type { RuntimePairingReach } from '../../shared/runtime-pairing-reach'
 import type { MobileRelayMintFailure } from '../../shared/mobile-relay-mint-failure'
+import type { PreloadApi } from '../api-types'
 
 export const mobileApi = {
   listNetworkInterfaces: (): Promise<{
@@ -92,4 +93,4 @@ export const mobileApi = {
     ipcRenderer.on('mobile:unpairedDeviceAuthFailure', listener)
     return () => ipcRenderer.removeListener('mobile:unpairedDeviceAuthFailure', listener)
   }
-}
+} satisfies PreloadApi['mobile']

--- a/src/preload/api/native-chat-bridge.ts
+++ b/src/preload/api/native-chat-bridge.ts
@@ -2,7 +2,8 @@ import { ipcRenderer } from 'electron'
 import type {
   NativeChatAppendedPayload,
   NativeChatReadSessionResult,
-  NativeChatSubscriptionFrame
+  NativeChatSubscriptionFrame,
+  PreloadApi
 } from '../api-types'
 import type { AgentType } from '../../shared/native-chat-types'
 
@@ -37,4 +38,4 @@ export const nativeChatApi = {
       ipcRenderer.send('nativeChat:unsubscribe', { subscriptionId: args.subscriptionId })
     }
   }
-}
+} satisfies PreloadApi['nativeChat']

--- a/src/preload/api/notebook-bridge.ts
+++ b/src/preload/api/notebook-bridge.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const notebookApi = {
   runPythonCell: (args: {
@@ -8,4 +9,4 @@ export const notebookApi = {
     connectionId?: string | null
   }): Promise<{ stdout: string; stderr: string; exitCode: number | null; error?: string }> =>
     ipcRenderer.invoke('notebook:runPythonCell', args)
-}
+} satisfies PreloadApi['notebook']

--- a/src/preload/api/notifications-bridge.ts
+++ b/src/preload/api/notifications-bridge.ts
@@ -8,6 +8,7 @@ import type {
   NotificationSoundPathResult,
   NotificationSoundResult
 } from '../../shared/notification-settings-types'
+import type { PreloadApi } from '../api-types'
 
 // Why: cache one shared Audio + blob URL per sound path so notifications do not re-read large files.
 let cachedNotificationSound: {
@@ -117,4 +118,4 @@ export const notificationsApi = {
       return { played: false, reason: 'playback-failed' }
     }
   }
-}
+} satisfies PreloadApi['notifications']

--- a/src/preload/api/onboarding-bridge.ts
+++ b/src/preload/api/onboarding-bridge.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron'
 import type { OnboardingState } from '../../shared/onboarding-state-types'
+import type { PreloadApi } from '../api-types'
 
 export const onboardingApi = {
   get: (): Promise<OnboardingState> => ipcRenderer.invoke('onboarding:get'),
@@ -8,4 +9,4 @@ export const onboardingApi = {
       checklist?: Partial<OnboardingState['checklist']>
     }
   ): Promise<OnboardingState> => ipcRenderer.invoke('onboarding:update', updates)
-}
+} satisfies PreloadApi['onboarding']

--- a/src/preload/api/open-code-usage-bridge.ts
+++ b/src/preload/api/open-code-usage-bridge.ts
@@ -1,4 +1,8 @@
 import { ipcRenderer } from 'electron'
 import { createUsageProviderApi } from '../usage-provider-api'
+import type { PreloadApi } from '../api-types'
 
-export const openCodeUsageApi = createUsageProviderApi(ipcRenderer, 'openCodeUsage')
+export const openCodeUsageApi = createUsageProviderApi(
+  ipcRenderer,
+  'openCodeUsage'
+) satisfies PreloadApi['openCodeUsage']

--- a/src/preload/api/pet-bridge.ts
+++ b/src/preload/api/pet-bridge.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron'
 import type { CustomPet } from '../../shared/pet-types'
+import type { PreloadApi } from '../api-types'
 
 export const petApi = {
   import: (): Promise<CustomPet | null> => ipcRenderer.invoke('pet:import'),
@@ -8,4 +9,4 @@ export const petApi = {
     ipcRenderer.invoke('pet:read', id, fileName, kind),
   delete: (id: string, fileName: string, kind?: 'image' | 'bundle'): Promise<void> =>
     ipcRenderer.invoke('pet:delete', id, fileName, kind)
-}
+} satisfies PreloadApi['pet']

--- a/src/preload/api/plugins-bridge.ts
+++ b/src/preload/api/plugins-bridge.ts
@@ -24,11 +24,8 @@ export const pluginsApi = {
     pluginKey: string
     panelId: string
   }): Promise<PluginPanelEntry | null> => ipcRenderer.invoke('plugins:readPanelEntry', args),
-  invokeCommand: (args: {
-    pluginKey: string
-    commandId: string
-    args?: unknown
-  }): Promise<unknown> => ipcRenderer.invoke('plugins:invokeCommand', args),
+  invokeCommand: (args: { pluginKey: string; commandId: string; args?: unknown }) =>
+    ipcRenderer.invoke('plugins:invokeCommand', args),
   panelAction: (args: {
     sessionToken: string
     action: string

--- a/src/preload/api/preflight-bridge.ts
+++ b/src/preload/api/preflight-bridge.ts
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron'
-import type { PreflightRuntimeContext, RefreshAgentsResult } from '../api-types'
+import type { PreflightRuntimeContext, PreloadApi, RefreshAgentsResult } from '../api-types'
 
 export const preflightApi = {
   check: (args?: {
@@ -40,4 +40,4 @@ export const preflightApi = {
     gitBashAvailable: boolean
     hostPlatform: NodeJS.Platform | null
   }> => ipcRenderer.invoke('preflight:detectRemoteWindowsTerminalCapabilities', args)
-}
+} satisfies PreloadApi['preflight']

--- a/src/preload/api/pty-bridge-session-control.ts
+++ b/src/preload/api/pty-bridge-session-control.ts
@@ -15,6 +15,7 @@ import type {
 import type { TerminalViewAttributes } from '../../shared/terminal-view-attributes'
 import type { PtyMainDeliveryDiagnostics } from '../../shared/pty-delivery-diagnostics'
 import type { AgentKind, LaunchSource, RequestKind } from '../../shared/telemetry-events'
+import type { PreloadApi } from '../api-types'
 
 export const ptySessionControlApi = {
   spawn: (opts: {
@@ -204,4 +205,4 @@ export const ptySessionControlApi = {
     ipcRenderer.invoke('pty:hasChildProcesses', { id }),
   getForegroundProcess: (id: string): Promise<string | null> =>
     ipcRenderer.invoke('pty:getForegroundProcess', { id })
-}
+} satisfies Partial<PreloadApi['pty']>

--- a/src/preload/api/pty-bridge-stream-and-serialization.ts
+++ b/src/preload/api/pty-bridge-stream-and-serialization.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer } from 'electron'
 import type { PtyModelRestoreNeededEvent } from '../../shared/pty-model-restore-marker'
 import type { TerminalSideEffectBatch } from '../../shared/terminal-side-effect-facts'
+import type { PreloadApi } from '../api-types'
 
 export const ptyStreamAndSerializationApi = {
   inspectProcess: (
@@ -138,4 +139,4 @@ export const ptyStreamAndSerializationApi = {
     restart: () => ipcRenderer.invoke('pty:management:restart'),
     macTccAttribution: () => ipcRenderer.invoke('pty:management:macTccAttribution')
   }
-}
+} satisfies Partial<PreloadApi['pty']>

--- a/src/preload/api/pty-bridge.ts
+++ b/src/preload/api/pty-bridge.ts
@@ -1,4 +1,8 @@
+import type { PreloadApi } from '../api-types'
 import { ptySessionControlApi } from './pty-bridge-session-control'
 import { ptyStreamAndSerializationApi } from './pty-bridge-stream-and-serialization'
 
-export const ptyApi = { ...ptySessionControlApi, ...ptyStreamAndSerializationApi }
+export const ptyApi = {
+  ...ptySessionControlApi,
+  ...ptyStreamAndSerializationApi
+} satisfies PreloadApi['pty']

--- a/src/preload/api/pwsh-bridge.ts
+++ b/src/preload/api/pwsh-bridge.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const pwshApi = {
   isAvailable: (): Promise<boolean> => ipcRenderer.invoke('pwsh:isAvailable')
-}
+} satisfies PreloadApi['pwsh']

--- a/src/preload/api/rate-limits-bridge.ts
+++ b/src/preload/api/rate-limits-bridge.ts
@@ -4,6 +4,7 @@ import type {
   RateLimitRuntimeTarget,
   RateLimitState
 } from '../../shared/rate-limit-types'
+import type { PreloadApi } from '../api-types'
 
 export const rateLimitsApi = {
   get: (): Promise<RateLimitState> => ipcRenderer.invoke('rateLimits:get'),
@@ -27,4 +28,4 @@ export const rateLimitsApi = {
     ipcRenderer.on('rateLimits:update', listener)
     return () => ipcRenderer.removeListener('rateLimits:update', listener)
   }
-}
+} satisfies PreloadApi['rateLimits']

--- a/src/preload/api/runtime-bridge.ts
+++ b/src/preload/api/runtime-bridge.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../shared/runtime-types'
 import type { RuntimeRpcResponse } from '../../shared/runtime-rpc-envelope'
 import type { RuntimeEnvironmentSubscriptionHandle } from '../runtime-environment-subscriptions'
+import type { PreloadApi } from '../api-types'
 
 export const runtimeApi = {
   syncWindowGraph: (graph: RuntimeRendererSyncWindowGraph): Promise<RuntimeSyncWindowGraphResult> =>
@@ -141,4 +142,4 @@ export const runtimeApi = {
     ipcRenderer.on('runtime:clientHostedBrowserRowsChanged', listener)
     return () => ipcRenderer.removeListener('runtime:clientHostedBrowserRowsChanged', listener)
   }
-}
+} satisfies PreloadApi['runtime']

--- a/src/preload/api/runtime-environments-bridge.ts
+++ b/src/preload/api/runtime-environments-bridge.ts
@@ -9,6 +9,7 @@ import {
   subscribeRuntimeEnvironmentFromPreload,
   type RuntimeEnvironmentSubscriptionHandle
 } from '../runtime-environment-subscriptions'
+import type { PreloadApi } from '../api-types'
 
 export const runtimeEnvironmentsApi = {
   list: (): Promise<PublicKnownRuntimeEnvironment[]> =>
@@ -90,4 +91,4 @@ export const runtimeEnvironmentsApi = {
     }
   ): Promise<RuntimeEnvironmentSubscriptionHandle> =>
     subscribeRuntimeEnvironmentFromPreload(ipcRenderer, args, callbacks)
-}
+} satisfies PreloadApi['runtimeEnvironments']

--- a/src/preload/api/settings-bridge.ts
+++ b/src/preload/api/settings-bridge.ts
@@ -4,22 +4,20 @@ import type {
   WarpThemeImportPreview,
   WarpThemeImportSource
 } from '../../shared/terminal-custom-themes'
+import type { PreloadApi } from '../api-types'
 
 export const settingsApi = {
-  get: (): Promise<unknown> => ipcRenderer.invoke('settings:get'),
+  get: () => ipcRenderer.invoke('settings:get'),
 
   // Why: blocking read for the few startup decisions (terminal side-effect authority) that can't wait for async hydration. Call sparingly.
-  getSync: (): unknown => ipcRenderer.sendSync('settings:get-sync'),
+  getSync: () => ipcRenderer.sendSync('settings:get-sync'),
 
-  set: (args: Record<string, unknown>): Promise<unknown> =>
-    ipcRenderer.invoke('settings:set', args),
+  set: (args: Record<string, unknown>) => ipcRenderer.invoke('settings:set', args),
 
-  setActiveRuntimeEnvironmentPreference: (args: {
-    environmentId: string | null
-  }): Promise<unknown> =>
+  setActiveRuntimeEnvironmentPreference: (args: { environmentId: string | null }) =>
     ipcRenderer.invoke('settings:set-active-runtime-environment-preference', args),
 
-  updatePRBotAuthorOverride: (args: { author: string; isBot: boolean }): Promise<unknown> =>
+  updatePRBotAuthorOverride: (args: { author: string; isBot: boolean }) =>
     ipcRenderer.invoke('settings:update-pr-bot-author-override', args),
 
   listFonts: (): Promise<string[]> => ipcRenderer.invoke('settings:listFonts'),
@@ -36,4 +34,4 @@ export const settingsApi = {
     ipcRenderer.on('settings:changed', listener)
     return () => ipcRenderer.removeListener('settings:changed', listener)
   }
-}
+} satisfies PreloadApi['settings']

--- a/src/preload/api/shell-bridge.ts
+++ b/src/preload/api/shell-bridge.ts
@@ -4,6 +4,7 @@ import type {
   ShellOpenExternalEditorResult,
   ShellOpenLocalPathResult
 } from '../../shared/shell-open-types'
+import type { PreloadApi } from '../api-types'
 
 export const shellApi = {
   openPath: (path: string): Promise<void> => ipcRenderer.invoke('shell:openPath', path),
@@ -38,4 +39,4 @@ export const shellApi = {
 
   copyFile: (args: { srcPath: string; destPath: string }): Promise<void> =>
     ipcRenderer.invoke('shell:copyFile', args)
-}
+} satisfies PreloadApi['shell']

--- a/src/preload/api/skills-bridge.ts
+++ b/src/preload/api/skills-bridge.ts
@@ -37,6 +37,7 @@ import type {
   SkillUpdateRun,
   SkillUpdateStartResult
 } from '../../shared/skill-freshness'
+import type { PreloadApi } from '../api-types'
 
 export const skillsApi = {
   discover: (target?: SkillDiscoveryTarget): Promise<SkillDiscoveryResult> =>
@@ -126,4 +127,4 @@ export const skillsApi = {
     ipcRenderer.on('skills:updateRun', listener)
     return () => ipcRenderer.removeListener('skills:updateRun', listener)
   }
-}
+} satisfies PreloadApi['skills']

--- a/src/preload/api/speech-bridge.ts
+++ b/src/preload/api/speech-bridge.ts
@@ -6,6 +6,7 @@ import type {
   SpeechModelState,
   SpeechTranscriptEvent
 } from '../../shared/speech-types'
+import type { PreloadApi } from '../api-types'
 
 export const speechApi = {
   getCatalog: (): Promise<SpeechModelManifest[]> => ipcRenderer.invoke('speech:getCatalog'),
@@ -78,4 +79,4 @@ export const speechApi = {
     ipcRenderer.on('speech:error', listener)
     return () => ipcRenderer.removeListener('speech:error', listener)
   }
-}
+} satisfies PreloadApi['speech']

--- a/src/preload/api/ssh-bridge.ts
+++ b/src/preload/api/ssh-bridge.ts
@@ -17,6 +17,7 @@ import {
   admitSshDetectedPorts
 } from '../../shared/ssh-retained-payload-admission'
 import type { FilesystemPathFlavor } from '../../shared/filesystem-entry-types'
+import type { PreloadApi } from '../api-types'
 
 export const sshApi = {
   listTargets: (): Promise<SshTarget[]> => ipcRenderer.invoke('ssh:listTargets'),
@@ -180,4 +181,4 @@ export const sshApi = {
 
   submitCredential: (args: { requestId: string; value: string | null }): Promise<void> =>
     ipcRenderer.invoke('ssh:submitCredential', args)
-}
+} satisfies PreloadApi['ssh']

--- a/src/preload/api/star-nag-bridge.ts
+++ b/src/preload/api/star-nag-bridge.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const starNagApi = {
   onShow: (
@@ -27,4 +28,4 @@ export const starNagApi = {
     ipcRenderer.invoke('star-nag:agentValueMoment'),
   showAgentValueMoment: (): Promise<void> => ipcRenderer.invoke('star-nag:showAgentValueMoment'),
   onboardingCompleted: (): Promise<void> => ipcRenderer.invoke('star-nag:onboardingCompleted')
-}
+} satisfies PreloadApi['starNag']

--- a/src/preload/api/stats-bridge.ts
+++ b/src/preload/api/stats-bridge.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const statsApi = {
   getSummary: (): Promise<{
@@ -7,4 +8,4 @@ export const statsApi = {
     totalAgentTimeMs: number
     firstEventAt: number | null
   }> => ipcRenderer.invoke('stats:summary')
-}
+} satisfies PreloadApi['stats']

--- a/src/preload/api/terminal-preview-bridge.ts
+++ b/src/preload/api/terminal-preview-bridge.ts
@@ -3,6 +3,7 @@ import type {
   TerminalPreviewConnectResult,
   TerminalPreviewDataPayload
 } from '../../shared/terminal-preview'
+import type { PreloadApi } from '../api-types'
 
 export const terminalPreviewApi = {
   connect: (
@@ -30,4 +31,4 @@ export const terminalPreviewApi = {
     ipcRenderer.on('terminalPreview:data', listener)
     return () => ipcRenderer.removeListener('terminalPreview:data', listener)
   }
-}
+} satisfies PreloadApi['terminalPreview']

--- a/src/preload/api/ui-bridge-clipboard-and-window-controls.ts
+++ b/src/preload/api/ui-bridge-clipboard-and-window-controls.ts
@@ -12,6 +12,7 @@ import {
 import type { NativeFileDropPayload } from '../../shared/native-file-drop'
 import type { ReadClipboardTextOptions } from '../../shared/clipboard-text'
 import { subscribeNativeFileDrop } from '../preload-runtime-support'
+import type { PreloadApi } from '../api-types'
 
 export const uiClipboardAndWindowControlsApi = {
   onOpenDiffFromMobile: (
@@ -195,4 +196,4 @@ export const uiClipboardAndWindowControlsApi = {
   notifyWindowRevealed: (): void => {
     ipcRenderer.send('ui:window-revealed')
   }
-}
+} satisfies Partial<PreloadApi['ui']>

--- a/src/preload/api/ui-bridge-state-and-menu-commands.ts
+++ b/src/preload/api/ui-bridge-state-and-menu-commands.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer } from 'electron'
 import type { PersistedUIState } from '../../shared/persisted-ui-state-types'
 import type { KeybindingActionId } from '../../shared/keybindings'
+import type { PreloadApi } from '../api-types'
 
 export const uiStateAndMenuCommandsApi = {
   get: () => ipcRenderer.invoke('ui:get'),
@@ -164,4 +165,4 @@ export const uiStateAndMenuCommandsApi = {
   replyTabCreate: (reply: { requestId: string; browserPageId?: string; error?: string }): void => {
     ipcRenderer.send('browser:tabCreateReply', reply)
   }
-}
+} satisfies Partial<PreloadApi['ui']>

--- a/src/preload/api/ui-bridge-tab-and-browser-commands.ts
+++ b/src/preload/api/ui-bridge-tab-and-browser-commands.ts
@@ -6,6 +6,7 @@ import type {
   WorktreeSetupLaunch
 } from '../../shared/worktree/launch-types'
 import { browserFindSubscriptions } from '../preload-runtime-support'
+import type { PreloadApi } from '../api-types'
 
 export const uiTabAndBrowserCommandsApi = {
   onRequestTabSetProfile: (
@@ -200,4 +201,4 @@ export const uiTabAndBrowserCommandsApi = {
     ipcRenderer.on('ui:activateWorktree', listener)
     return () => ipcRenderer.removeListener('ui:activateWorktree', listener)
   }
-}
+} satisfies Partial<PreloadApi['ui']>

--- a/src/preload/api/ui-bridge-terminal-and-session-tabs.ts
+++ b/src/preload/api/ui-bridge-terminal-and-session-tabs.ts
@@ -11,6 +11,7 @@ import type {
   RuntimeTerminalCreateRequestPayload,
   RuntimeTerminalPresentation
 } from '../../shared/runtime-types'
+import type { PreloadApi } from '../api-types'
 
 export const uiTerminalAndSessionTabsApi = {
   onCreateTerminal: (
@@ -211,4 +212,4 @@ export const uiTerminalAndSessionTabsApi = {
     ipcRenderer.on('ui:openFileFromMobile', listener)
     return () => ipcRenderer.removeListener('ui:openFileFromMobile', listener)
   }
-}
+} satisfies Partial<PreloadApi['ui']>

--- a/src/preload/api/wsl-bridge.ts
+++ b/src/preload/api/wsl-bridge.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
 
 export const wslApi = {
   isAvailable: (): Promise<boolean> => ipcRenderer.invoke('wsl:isAvailable'),
   listDistros: (): Promise<string[]> => ipcRenderer.invoke('wsl:listDistros')
-}
+} satisfies PreloadApi['wsl']

--- a/src/preload/app-restart-checkpoint-routing.test.ts
+++ b/src/preload/app-restart-checkpoint-routing.test.ts
@@ -92,6 +92,20 @@ describe('native preload destructive app actions', () => {
     })
   }
 
+  it('exposes the durable checkpoint join the lazy-chunk recovery reload depends on', async () => {
+    const api = await loadApi()
+    invoke.mockResolvedValue({ ok: true })
+
+    await expect(api.app.awaitBeforeUnloadCheckpoint()).resolves.toBeUndefined()
+    expect(invoke).toHaveBeenCalledWith('app:await-before-unload-checkpoint')
+
+    invoke.mockResolvedValue({ ok: false })
+
+    await expect(api.app.awaitBeforeUnloadCheckpoint()).rejects.toThrow(
+      'Failed to persist renderer state before unload.'
+    )
+  })
+
   it('preserves both macOS keyboard preload adapters', async () => {
     const api = await loadApi()
     invoke.mockResolvedValue(undefined)

--- a/src/preload/gitlab.ts
+++ b/src/preload/gitlab.ts
@@ -12,23 +12,21 @@ type GitLabRepoSelectorArgs = {
 }
 
 export const glApi = {
-  viewer: (): Promise<unknown> => ipcRenderer.invoke('gitlab:viewer'),
-  diagnoseAuth: (): Promise<unknown> => ipcRenderer.invoke('gitlab:diagnoseAuth'),
-  rateLimit: (args?: { force?: boolean; host?: string | null }): Promise<unknown> =>
+  viewer: () => ipcRenderer.invoke('gitlab:viewer'),
+  diagnoseAuth: () => ipcRenderer.invoke('gitlab:diagnoseAuth'),
+  rateLimit: (args?: { force?: boolean; host?: string | null }) =>
     ipcRenderer.invoke('gitlab:rateLimit', args),
 
-  projectSlug: (args: GitLabRepoSelectorArgs): Promise<unknown> =>
-    ipcRenderer.invoke('gitlab:projectSlug', args),
+  projectSlug: (args: GitLabRepoSelectorArgs) => ipcRenderer.invoke('gitlab:projectSlug', args),
 
   mrForBranch: (
     args: GitLabRepoSelectorArgs & {
       branch: string
       linkedMRIid?: number | null
     }
-  ): Promise<unknown> => ipcRenderer.invoke('gitlab:mrForBranch', args),
+  ) => ipcRenderer.invoke('gitlab:mrForBranch', args),
 
-  mr: (args: GitLabRepoSelectorArgs & { iid: number }): Promise<unknown> =>
-    ipcRenderer.invoke('gitlab:mr', args),
+  mr: (args: GitLabRepoSelectorArgs & { iid: number }) => ipcRenderer.invoke('gitlab:mr', args),
 
   listMRs: (
     args: GitLabRepoSelectorArgs & {
@@ -37,7 +35,7 @@ export const glApi = {
       perPage?: number
       query?: string
     }
-  ): Promise<unknown> => ipcRenderer.invoke('gitlab:listMRs', args),
+  ) => ipcRenderer.invoke('gitlab:listMRs', args),
 
   listWorkItems: (
     args: GitLabRepoSelectorArgs & {
@@ -46,9 +44,9 @@ export const glApi = {
       perPage?: number
       query?: string
     }
-  ): Promise<unknown> => ipcRenderer.invoke('gitlab:listWorkItems', args),
+  ) => ipcRenderer.invoke('gitlab:listWorkItems', args),
 
-  issue: (args: GitLabRepoSelectorArgs & { number: number }): Promise<unknown> =>
+  issue: (args: GitLabRepoSelectorArgs & { number: number }) =>
     ipcRenderer.invoke('gitlab:issue', args),
 
   listIssues: (
@@ -58,8 +56,7 @@ export const glApi = {
       limit?: number
       page?: number
     }
-  ): Promise<{ items: unknown[]; totalPages?: number; error?: unknown }> =>
-    ipcRenderer.invoke('gitlab:listIssues', args),
+  ) => ipcRenderer.invoke('gitlab:listIssues', args),
 
   createIssue: (
     args: GitLabRepoSelectorArgs & {
@@ -77,25 +74,23 @@ export const glApi = {
   ): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke('gitlab:updateIssue', args),
 
-  addIssueComment: (
-    args: GitLabRepoSelectorArgs & { number: number; body: string }
-  ): Promise<unknown> => ipcRenderer.invoke('gitlab:addIssueComment', args),
+  addIssueComment: (args: GitLabRepoSelectorArgs & { number: number; body: string }) =>
+    ipcRenderer.invoke('gitlab:addIssueComment', args),
 
   listLabels: (args: GitLabRepoSelectorArgs): Promise<string[]> =>
     ipcRenderer.invoke('gitlab:listLabels', args),
 
-  listAssignableUsers: (args: GitLabRepoSelectorArgs): Promise<unknown[]> =>
+  listAssignableUsers: (args: GitLabRepoSelectorArgs) =>
     ipcRenderer.invoke('gitlab:listAssignableUsers', args),
 
-  todos: (args: GitLabRepoSelectorArgs): Promise<unknown[]> =>
-    ipcRenderer.invoke('gitlab:todos', args),
+  todos: (args: GitLabRepoSelectorArgs) => ipcRenderer.invoke('gitlab:todos', args),
 
   workItemDetails: (
     args: GitLabRepoSelectorArgs & {
       iid: number
       type: 'issue' | 'mr'
     }
-  ): Promise<unknown> => ipcRenderer.invoke('gitlab:workItemDetails', args),
+  ) => ipcRenderer.invoke('gitlab:workItemDetails', args),
 
   closeMR: (
     args: GitLabRepoSelectorArgs & {
@@ -133,9 +128,9 @@ export const glApi = {
       reviewerIds: number[]
       projectRef?: unknown
     }
-  ): Promise<unknown> => ipcRenderer.invoke('gitlab:updateMRReviewers', args),
+  ) => ipcRenderer.invoke('gitlab:updateMRReviewers', args),
 
-  addMRComment: (args: GitLabRepoSelectorArgs & { iid: number; body: string }): Promise<unknown> =>
+  addMRComment: (args: GitLabRepoSelectorArgs & { iid: number; body: string }) =>
     ipcRenderer.invoke('gitlab:addMRComment', args),
 
   addMRInlineComment: (
@@ -144,7 +139,7 @@ export const glApi = {
       input: unknown
       projectRef?: unknown
     }
-  ): Promise<unknown> => ipcRenderer.invoke('gitlab:addMRInlineComment', args),
+  ) => ipcRenderer.invoke('gitlab:addMRInlineComment', args),
 
   resolveMRDiscussion: (
     args: GitLabRepoSelectorArgs & {
@@ -152,15 +147,14 @@ export const glApi = {
       discussionId: string
       resolved: boolean
     }
-  ): Promise<unknown> => ipcRenderer.invoke('gitlab:resolveMRDiscussion', args),
+  ) => ipcRenderer.invoke('gitlab:resolveMRDiscussion', args),
 
   jobTrace: (
     args: GitLabRepoSelectorArgs & { jobId: number; projectRef?: unknown; logExcerpt?: boolean }
-  ): Promise<unknown> => ipcRenderer.invoke('gitlab:jobTrace', args),
+  ) => ipcRenderer.invoke('gitlab:jobTrace', args),
 
-  retryJob: (
-    args: GitLabRepoSelectorArgs & { jobId: number; projectRef?: unknown }
-  ): Promise<unknown> => ipcRenderer.invoke('gitlab:retryJob', args),
+  retryJob: (args: GitLabRepoSelectorArgs & { jobId: number; projectRef?: unknown }) =>
+    ipcRenderer.invoke('gitlab:retryJob', args),
 
   workItemByPath: (
     args: GitLabRepoSelectorArgs & {
@@ -169,5 +163,5 @@ export const glApi = {
       iid: number
       type: 'issue' | 'mr'
     }
-  ): Promise<unknown> => ipcRenderer.invoke('gitlab:workItemByPath', args)
+  ) => ipcRenderer.invoke('gitlab:workItemByPath', args)
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -182,7 +182,7 @@ const api = {
   mobile: mobileApi,
   agentStatus: agentStatusApi,
   speech: speechApi
-}
+} satisfies PreloadApi
 
 if (process.contextIsolated) {
   try {
@@ -193,6 +193,5 @@ if (process.contextIsolated) {
   }
 } else {
   window.electron = electronAPI
-  // @ts-expect-error (define in dts)
   window.api = api
 }


### PR DESCRIPTION
During the preload split, two live methods — `jira.searchUsers` and `runtimeEnvironments.retryControlConnection` — were silently dropped. Neither failed typecheck: the bridge modules carried no `satisfies` annotation and the composed `api` object was unannotated, so a missing key was only a runtime `undefined is not a function` in the renderer. They were found by hand-walking the exposed surface.

Each module now `satisfies` its slice of `PreloadApi` — the type `window.api` is already declared as, so the contract supplies the shape rather than a parallel copy that could drift. Split part-files use `Partial<...>` (a part isn't a nameable slice), while the composing file's full `satisfies` catches deletions.

**Proof it bites.** Deleting the exact key that was dropped:
```
src/preload/api/jira-bridge.ts(87,3): error TS2741: Property 'searchUsers' is missing
  in type '{ connect: ... }' but required in type 'JiraApi'.
src/preload/index.ts(196,3): error TS2322: Type '{ app: {...} }' is not assignable to type 'PreloadApi'.
```

**Fallout worth knowing:** turning this on surfaced **106 real type errors** — bridges locally annotating `Promise<unknown>`, `unknown[]`, `viewer: unknown` over contracts declaring concrete types. The bridge wasn't merely unguarded, it was erasing types the renderer relied on. Those local annotations are removed so the contract supplies the type.

Also re-lands `app.awaitBeforeUnloadCheckpoint`, declared in `app-api.ts` and called at `lazy-chunk-recovery-reload.ts:55` but never actually exposed, so that path optional-chained to a no-op and navigated without joining the checkpoint. Its `ipcMain` handler exists. The missing key was caught **by the new annotation**, not by hand.

`pnpm tc` clean · `oxlint` clean · 509 files / 4793 tests pass.