### PR TITLE
test(child-process): make the import ratchet able to fail

### DIFF
--- a/src/shared/child-process/child-process-import-boundary.test.ts
+++ b/src/shared/child-process/child-process-import-boundary.test.ts
@@ -23,10 +23,19 @@ const CHILD_PROCESS_IMPORT_ALLOWLIST: readonly string[] = readFileSync(
   .map((line) => line.trim())
   .filter((line) => line.length > 0 && !line.startsWith('#'))
 
+/**
+ * The true count of files importing child_process directly.
+ *
+ * May only ever be DECREASED, and only by migrating a file off
+ * `node:child_process`. Raising it is never the fix.
+ */
+const DIRECT_IMPORTER_PIN = 160
+
 const IMPORT_PATTERN =
   /(?:from\s+['"]node:child_process['"]|from\s+['"]child_process['"]|require\(\s*['"]node:child_process['"]|require\(\s*['"]child_process['"])/
 
-const OWNER_DIRECTORY = 'src/shared/child-process'
+// Why: trailing slash, so a sibling like src/shared/child-process-foo.ts is scanned, not exempted.
+const OWNER_DIRECTORY = 'src/shared/child-process/'
 const SCANNED_EXTENSIONS = ['.ts', '.tsx']
 const IGNORED_DIRECTORIES = new Set([
   'node_modules',
@@ -110,9 +119,22 @@ describe('child_process import boundary', () => {
     expect(stale, 'Allowlist entry no longer imports child_process — delete the line.').toEqual([])
   })
 
-  it('never grows', () => {
-    // The count is asserted separately from membership so a swap (one file
-    // migrated, one added) still fails loudly.
-    expect(offenders.length).toBeLessThanOrEqual(CHILD_PROCESS_IMPORT_ALLOWLIST.length)
+  it('holds the offender count at the pin', () => {
+    // Bounding by the allowlist's own length proves nothing: the two move
+    // together, so a swap (one file migrated off, one new file added with its
+    // entry) kept the bound satisfied. The pin is a literal for that reason.
+    expect(
+      offenders.length,
+      `${offenders.length} files import child_process directly; the pin is ${DIRECT_IMPORTER_PIN}. ` +
+        'Never raise the pin -- migrate the file to runProcess/spawnProcess from ' +
+        'src/shared/child-process instead.'
+    ).toBeLessThanOrEqual(DIRECT_IMPORTER_PIN)
+    // A pin left above reality is how a ratchet rots: it re-opens room for the
+    // next direct import to land for free.
+    expect(
+      offenders.length,
+      `Only ${offenders.length} files import child_process directly. Lower DIRECT_IMPORTER_PIN to ` +
+        `${offenders.length} to keep the ground you just took.`
+    ).toBeGreaterThanOrEqual(DIRECT_IMPORTER_PIN)
   })
 })

--- a/src/shared/child-process/windows-console-visibility.test.ts
+++ b/src/shared/child-process/windows-console-visibility.test.ts
@@ -27,6 +27,15 @@ const ALLOWLIST: readonly string[] = readAllowlist(
   join(__dirname, '__fixtures__', 'windows-console-visibility-allowlist.txt')
 )
 
+/**
+ * The true count of files spawning without `windowsHide`.
+ *
+ * May only ever be DECREASED, and only by fixing a call site. Set equality with
+ * the allowlist does not bound this: a swap (one file fixed and delisted, one
+ * new file added with its entry) satisfies both membership assertions.
+ */
+const UNHIDDEN_SPAWNER_PIN = 68
+
 const CHILD_PROCESS_IMPORT =
   /from\s+['"](?:node:)?child_process['"]|require\(\s*['"](?:node:)?child_process['"]/
 // Includes the promisified and renamed spellings -- `execAsync`, `spawnDetached`,
@@ -165,5 +174,19 @@ describe('direct child-process calls hide the Windows console', () => {
   it('carries no stale allowlist entry', () => {
     // A fixed file must leave the list, or the ratchet stops ratcheting.
     expect(ALLOWLIST.filter((path) => !offenders.includes(path))).toEqual([])
+  })
+
+  it('holds the offender count at the pin', () => {
+    expect(
+      offenders.length,
+      `${offenders.length} files spawn without windowsHide; the pin is ${UNHIDDEN_SPAWNER_PIN}. ` +
+        'Never raise the pin -- add the flag, or route the call through run-process.ts.'
+    ).toBeLessThanOrEqual(UNHIDDEN_SPAWNER_PIN)
+    // A pin left above reality re-opens room for the next unguarded spawn.
+    expect(
+      offenders.length,
+      `Only ${offenders.length} files spawn without windowsHide. Lower UNHIDDEN_SPAWNER_PIN to ` +
+        `${offenders.length} to keep the ground you just took.`
+    ).toBeGreaterThanOrEqual(UNHIDDEN_SPAWNER_PIN)
   })
 })


### PR DESCRIPTION
`never grows` asserted `offenders.length <= CHILD_PROCESS_IMPORT_ALLOWLIST.length` — but the two membership assertions above it already force the offender set and the allowlist to be equal, so once they pass this one cannot fail. Its comment claimed it catches a swap (one file migrated off `node:child_process`, one new file added); that is precisely the case it let through, because both sides move together.

Pins the true count (160) and asserts **both** directions.

**Proof it bites** — the swap the old assertion missed (new importer + its allowlist entry; old bound would have been 161 ≤ 161, pass):
```
AssertionError: 161 files import child_process directly; the pin is 160. Never raise the pin --
migrate the file to runProcess/spawnProcess from src/shared/child-process instead.
```
And the stale-high pin, which is how ratchets rot — banking the same ground twice:
```
AssertionError: Only 160 files import child_process directly. Lower DIRECT_IMPORTER_PIN to 160
to keep the ground you just took.
```

The sibling `windows-console-visibility` ratchet had no count assertion at all but the identical gap, so it gets the same test.

Also anchors the owner-directory exemption with a trailing slash: `startsWith('src/shared/child-process')` would have silently exempted a future `src/shared/child-process-foo.ts` from the scan entirely.