### PR TITLE
fix(palette): recompute quick-action availability when runtime status changes

### DIFF
--- a/src/renderer/src/components/use-worktree-jump-palette-quick-actions.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-quick-actions.ts
@@ -58,6 +58,7 @@ export function useWorktreeJumpPaletteQuickActions({
   groupsByWorktree,
   isLoading,
   settings,
+  runtimeStatusByEnvironmentId,
   deferredQuery,
   settingsResults
 }: WorktreeJumpPaletteQuickActionsInput) {
@@ -117,6 +118,9 @@ export function useWorktreeJumpPaletteQuickActions({
       openNewTerminalTabInActiveWorkspace
     ]
   )
+  // Why: buildQuickActionContext() reads the store imperatively, so these voided values are the
+  // memo's real inputs — each one is read (some transitively, e.g. runtimeStatusByEnvironmentId
+  // via the managed-browser creation policy) while availability is computed.
   const availableActionResults = useMemo(() => {
     void activeView
     void activeWorktreeId
@@ -127,6 +131,7 @@ export function useWorktreeJumpPaletteQuickActions({
     void groupsByWorktree
     void isLoading
     void settings?.activeRuntimeEnvironmentId
+    void runtimeStatusByEnvironmentId
     const context = buildQuickActionContext()
     return actionResults.filter((action) => action.isAvailable(context).available)
   }, [
@@ -140,7 +145,8 @@ export function useWorktreeJumpPaletteQuickActions({
     activeGroupIdByWorktree,
     groupsByWorktree,
     isLoading,
-    settings?.activeRuntimeEnvironmentId
+    settings?.activeRuntimeEnvironmentId,
+    runtimeStatusByEnvironmentId
   ])
   const middleItems = useMemo<(SettingsPaletteItem | QuickActionPaletteItem)[]>(
     () =>

--- a/src/renderer/src/components/worktree-jump-palette-quick-action-availability.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-quick-action-availability.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import { renderHook } from '@testing-library/react'
+import { createRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BROWSER_SCREENCAST_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
+import { buildCmdJActionResults } from '@/components/cmd-j/palette-results'
+import { getCmdJQuickActions } from '@/components/cmd-j/quick-actions'
+import { useWorktreeJumpPaletteQuickActions } from './use-worktree-jump-palette-quick-actions'
+
+const mocks = vi.hoisted(() => ({ state: {} as Record<string, unknown> }))
+
+vi.mock('@/store', () => ({ useAppStore: { getState: () => mocks.state } }))
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getRuntimeEnvironmentIdForWorktree: () => RUNTIME_ID
+}))
+vi.mock('@/components/sidebar/delete-worktree-flow', () => ({ runWorktreeDelete: vi.fn() }))
+
+const RUNTIME_ID = 'runtime-1'
+const WORKTREE_ID = 'repo-1::/repo/wt'
+
+function runtimeStatuses(capabilities: string[]): Map<string, unknown> {
+  return new Map([[RUNTIME_ID, { status: { capabilities, hostPlatform: 'darwin' } }]])
+}
+
+// Every input except runtimeStatusByEnvironmentId keeps a stable identity across rerenders,
+// so a recomputation can only come from the runtime status dependency itself.
+function buildStableProps() {
+  return {
+    openModal: vi.fn(),
+    openSettingsPage: vi.fn(),
+    openSettingsTarget: vi.fn(),
+    activeGroupSnapshotRef: createRef<null>(),
+    openNewBrowserTabInActiveWorkspace: vi.fn(),
+    openNewMarkdownInActiveWorkspace: vi.fn(),
+    openNewTerminalTabInActiveWorkspace: vi.fn(),
+    actionResults: buildCmdJActionResults(getCmdJQuickActions()),
+    activeView: 'terminal',
+    activeWorktreeId: WORKTREE_ID,
+    worktreesByRepo: mocks.state.worktreesByRepo,
+    repos: mocks.state.repos,
+    sshConnectionStates: mocks.state.sshConnectionStates,
+    activeGroupIdByWorktree: mocks.state.activeGroupIdByWorktree,
+    groupsByWorktree: mocks.state.groupsByWorktree,
+    isLoading: false,
+    settings: mocks.state.settings,
+    deferredQuery: 'new browser tab',
+    settingsResults: []
+  }
+}
+
+function renderQuickActions(initialStatuses: Map<string, unknown>) {
+  const stable = buildStableProps()
+  mocks.state.runtimeStatusByEnvironmentId = initialStatuses
+  const harness = renderHook(
+    (runtimeStatusByEnvironmentId: Map<string, unknown>) =>
+      useWorktreeJumpPaletteQuickActions({ ...stable, runtimeStatusByEnvironmentId } as never),
+    { initialProps: initialStatuses }
+  )
+  return {
+    offersBrowserAction: (): boolean =>
+      harness.result.current.middleItems.some((item) => item.id === 'quick-action:new-browser-tab'),
+    setRuntimeStatuses: (next: Map<string, unknown>): void => {
+      mocks.state.runtimeStatusByEnvironmentId = next
+      harness.rerender(next)
+    }
+  }
+}
+
+describe('worktree jump palette quick action availability', () => {
+  beforeEach(() => {
+    ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+    mocks.state = {
+      activeView: 'terminal',
+      activeWorktreeId: WORKTREE_ID,
+      worktreesByRepo: { 'repo-1': [{ id: WORKTREE_ID, repoId: 'repo-1' }] },
+      repos: [{ id: 'repo-1' }],
+      sshConnectionStates: new Map(),
+      activeGroupIdByWorktree: { [WORKTREE_ID]: 'group-1' },
+      groupsByWorktree: { [WORKTREE_ID]: [{ id: 'group-1' }] },
+      settings: { activeRuntimeEnvironmentId: RUNTIME_ID }
+    }
+  })
+  afterEach(() => {
+    delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+  })
+
+  it('drops the paired-web browser action when the runtime loses screencast capability', () => {
+    const palette = renderQuickActions(runtimeStatuses([BROWSER_SCREENCAST_RUNTIME_CAPABILITY]))
+    expect(palette.offersBrowserAction()).toBe(true)
+
+    palette.setRuntimeStatuses(runtimeStatuses([]))
+    expect(palette.offersBrowserAction()).toBe(false)
+  })
+
+  it('restores the browser action when a capable runtime comes back', () => {
+    const palette = renderQuickActions(runtimeStatuses([]))
+    expect(palette.offersBrowserAction()).toBe(false)
+
+    palette.setRuntimeStatuses(runtimeStatuses([BROWSER_SCREENCAST_RUNTIME_CAPABILITY]))
+    expect(palette.offersBrowserAction()).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts
+++ b/src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts
@@ -6,6 +6,7 @@ import { requestLazyChunkRecoveryReload } from './lazy-chunk-recovery-reload'
 describe('requestLazyChunkRecoveryReload', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it('refuses the reload when the staged checkpoint never reaches disk', async () => {
@@ -34,6 +35,34 @@ describe('requestLazyChunkRecoveryReload', () => {
       })
     ).resolves.toBe('unload-vetoed')
 
+    expect(order).toEqual(['flushed', 'reload'])
+  })
+
+  it('joins the preload checkpoint before navigating when no override is supplied', async () => {
+    const order: string[] = []
+    let flush: () => void = () => undefined
+    const awaitBeforeUnloadCheckpoint = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          flush = () => {
+            order.push('flushed')
+            resolve()
+          }
+        })
+    )
+    vi.stubGlobal('api', { app: { awaitBeforeUnloadCheckpoint } })
+    const reload = vi.spyOn(window.location, 'reload').mockImplementation(() => {
+      order.push('reload')
+      window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+    })
+
+    const outcome = requestLazyChunkRecoveryReload(window)
+    await vi.waitFor(() => expect(awaitBeforeUnloadCheckpoint).toHaveBeenCalledTimes(1))
+    expect(reload).not.toHaveBeenCalled()
+
+    flush()
+
+    await expect(outcome).resolves.toBe('unload-vetoed')
     expect(order).toEqual(['flushed', 'reload'])
   })
 })


### PR DESCRIPTION
The last finding from the post-merge audit, and the seventh casualty of PR #13909 being reverted by a stale split branch.

`use-worktree-jump-palette-quick-actions.ts` dropped `runtimeStatusByEnvironmentId` from a memo's dependency array. It **is** read during that computation, transitively:

`buildQuickActionContext` → `buildCmdJQuickActionContext` → `getClientCreationActionPolicy` → `client-creation-action-policy.ts:70` reads `state.runtimeStatusByEnvironmentId.get(id).status`

which produces `managedBrowserCreationEnabled`, deciding whether `new-browser-tab` is offered. `store/slices/runtime-status.ts:263` replaces the Map identity on update, so the dep would have fired. Nothing else forced recomputation.

**Effect:** the palette showed availability from a runtime-status snapshot that never refreshed — offering a browser action against a provider that had gone away, or hiding one that had come back. Paired-web only, exactly #13909's scope.

**Why no lint caught it:** the read is behind a `void x` statement, which `react-hooks/exhaustive-deps` does not see.

The pre-split original had a `quickActionAvailabilityInputs` memo listing this dep explicitly; the split inlined the deps and dropped this one, along with its rationale comment. Both restored.

New test holds every other input at stable identity and swaps only the runtime status map, asserting the action appears/disappears. Reverting just the dep makes both cases fail.