### PR TITLE
perf(ssh): share relay native deps across bundles instead of recompiling per install dir

### DIFF
--- a/src/main/ssh/remote-install-gc.ts
+++ b/src/main/ssh/remote-install-gc.ts
@@ -22,6 +22,7 @@ import {
   tryAcquireRelayGcClaim
 } from './ssh-relay-gc-claim'
 import { cleanupRelayGcTombstones } from './ssh-relay-gc-tombstone'
+import { gcRelayNativeDepsCache } from './ssh-relay-native-deps-cache-gc'
 import {
   listRemoteInstallBaseDirsCommand,
   MAX_RELAY_GC_LISTING_ENTRIES,
@@ -245,12 +246,25 @@ export async function gcOldRelayVersions(
   options?: {
     windowsNodePath?: string
     windowsSockNames?: string[]
+    /**
+     * Cache entries this connection depends on, whether or not it links to them. Also the gate:
+     * a caller that could not compute a key is not using the shared-cache model on this host, and
+     * a pass only ever collects what its own model created (see `remote-install-model.ts`).
+     */
+    nativeDepsCacheKeys?: readonly string[]
   }
 ): Promise<void> {
   await gcOldRemoteInstallVersions(conn, RELAY_INSTALL_MODEL, remoteHome, currentDirAbsPath, host, {
     ...options,
     isDirLive: (dir) => hasLiveRelaySocket(conn, dir, host, options)
   })
+  // Why after and not before: version-dir removal is what turns a cache entry unreferenced, so
+  // running it second lets one pass reclaim both instead of leaving the tree for the next connect.
+  if (options?.nativeDepsCacheKeys?.length) {
+    await gcRelayNativeDepsCache(conn, host, remoteHome, {
+      pinnedKeys: options.nativeDepsCacheKeys
+    }).catch(() => {})
+  }
 }
 
 async function hasLiveRelaySocket(

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -33,6 +33,12 @@ import {
   abandonInstall,
   gcOldRelayVersions
 } from './ssh-relay-versioned-install'
+import {
+  attachRelayNativeDepsCache,
+  promoteRelayNativeDepsCache,
+  resolveRelayNativeDepsCacheKey,
+  type RelayNativeDepsCacheContext
+} from './ssh-relay-native-deps-cache-install'
 import { acquireInstallLock } from './ssh-relay-install-lock'
 import { tryAcquireRelayRepairLock } from './ssh-relay-repair-lock'
 import {
@@ -519,7 +525,8 @@ async function deployAndLaunchRelayAttempt(
             nodePath,
             deploySignal,
             [],
-            launchNamespace
+            launchNamespace,
+            remoteHome
           )
           console.log('[ssh-relay] Native deps installed')
 
@@ -584,7 +591,16 @@ async function deployAndLaunchRelayAttempt(
     .then(() =>
       gcOldRelayVersions(conn, remoteHome, remoteRelayDir, hostPlatform, {
         windowsNodePath: launched.nodePath,
-        windowsSockNames: [relaySocketNameForInstanceId(relayInstanceId)]
+        windowsSockNames: [relaySocketNameForInstanceId(relayInstanceId)],
+        // Why pin rather than rely on the symlink alone: a deploy that fell back to a
+        // per-directory install has no reference to show, and its key must still survive.
+        nativeDepsCacheKeys: [
+          resolveRelayNativeDepsCacheKey({
+            platform,
+            localRelayDir,
+            deps: RELAY_NATIVE_DEPS
+          })
+        ].filter((key): key is string => key !== null)
       })
     )
     .catch(() => {})
@@ -974,8 +990,27 @@ async function installNativeDeps(
   nodePath: string,
   signal?: AbortSignal,
   resetDeps: RelayNativeDepName[] = [],
-  namespace?: RelayInstallNamespace
+  namespace?: RelayInstallNamespace,
+  remoteHome?: string
 ): Promise<void> {
+  // Why a repair opts out: reset does `rm -rf node_modules/node-pty`, and through a shared
+  // symlink that is every relay on the host losing its addon. Repairs detach and install
+  // privately instead (the install command's own prefix drops the link).
+  const localRelayDir = resetDeps.length === 0 && remoteHome ? getLocalRelayPath(platform) : null
+  const cacheContext: RelayNativeDepsCacheContext | null =
+    remoteHome && localRelayDir
+      ? {
+          hostPlatform,
+          remoteHome,
+          relayDir: remoteDir,
+          platform,
+          localRelayDir,
+          deps: RELAY_NATIVE_DEPS,
+          signal
+        }
+      : null
+  const cache = cacheContext ? await attachRelayNativeDepsCache(conn, cacheContext) : null
+
   const writeRelayPackageJson = async (deps: Record<string, string>): Promise<void> => {
     await writeRelayFile(
       conn,
@@ -1003,13 +1038,32 @@ async function installNativeDeps(
   // Why: type:commonjs pins module resolution against Node default flips or a remote ~/.npmrc type=module.
   await writeRelayPackageJson(RELAY_NATIVE_DEPS)
 
+  if (cache?.mode === 'linked') {
+    await makeNodePtySpawnHelperExecutable(conn, remoteDir, hostPlatform, signal)
+    const linkedProbe = await probeInstalledNativeDeps(
+      conn,
+      remoteDir,
+      hostPlatform,
+      nodePath,
+      signal
+    )
+    if (linkedProbe.available) {
+      return
+    }
+    // Why fall through rather than repair the entry: it is shared, and something else on this
+    // host may be running out of it right now. This directory installs its own copy instead.
+    console.warn(
+      `[ssh-relay][NATIVE-CACHE-UNUSABLE] shared entry ${cache.key} did not load at ${remoteDir} (${platform}); installing per-directory. stderr=${linkedProbe.stderr.trim().slice(-500)}`
+    )
+  }
+
   try {
     const installArgs = Object.entries(RELAY_NATIVE_DEPS)
       .map(([dep, version]) => shellEscape(`${dep}@${version}`))
       .join(' ')
     // Why: npm reports a present package as up to date even if a native file was deleted; reset only deps the probe found broken.
     const resetCommand = resetNativeDepsCommand(hostPlatform, resetDeps)
-    const resetPrefix = resetCommand ? `${resetCommand}; ` : ''
+    const resetPrefix = `${detachSharedNativeDepsCommand(hostPlatform)}${resetCommand ? `${resetCommand}; ` : ''}`
     const command = isWindowsRemoteHost(hostPlatform)
       ? commandWithNodePath(
           hostPlatform,
@@ -1118,12 +1172,32 @@ async function installNativeDeps(
     }
   }
 
+  // Why promotion is gated on the probe and not on npm's exit code: an entry is shared, so the
+  // only evidence worth publishing is this host having loaded both addons out of that tree.
+  if (probe.available && cacheContext && cache) {
+    await promoteRelayNativeDepsCache(conn, cacheContext, cache.key)
+  }
+
   // MISSING is non-fatal by design: the relay still serves fs/git/preflight; only native-backed ops fail on hosts that can't build the addons.
   if (!probe.available) {
     console.warn(
       `[ssh-relay][NPTY-MISSING] native deps installed but require() failed at ${remoteDir} (${platform}). stdout=${probe.output.trim().slice(-200)} stderr=${probe.stderr.trim().slice(-500)}`
     )
   }
+}
+
+/**
+ * Drop a shared-cache symlink before anything writes into `node_modules`.
+ *
+ * Why it prefixes every install rather than living in its own exec: `rm -rf node_modules/node-pty`
+ * and `npm install` both follow the link, so a repair on one relay directory would otherwise
+ * rewrite the tree every other relay on the host is running out of.
+ */
+function detachSharedNativeDepsCommand(hostPlatform: RemoteHostPlatform): string {
+  if (isWindowsRemoteHost(hostPlatform)) {
+    return ''
+  }
+  return 'if [ -L node_modules ]; then rm -f node_modules; fi; '
 }
 
 function resetNativeDepsCommand(
@@ -1200,7 +1274,7 @@ async function installNativeDepsWithoutNodePty(
       hostPlatform,
       nodePath,
       remoteDir,
-      `${resetCommand}; npm install --ignore-scripts=false --omit=dev --no-audit --no-fund ${installArgs} 2>&1`
+      `${detachSharedNativeDepsCommand(hostPlatform)}${resetCommand}; npm install --ignore-scripts=false --omit=dev --no-audit --no-fund ${installArgs} 2>&1`
     ),
     { timeoutMs: NATIVE_DEPS_COMMAND_TIMEOUT_MS, signal }
   )

--- a/src/main/ssh/ssh-relay-native-deps-cache-commands.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache-commands.ts
@@ -1,0 +1,210 @@
+/**
+ * The remote shell for the shared native-deps cache (`ssh-relay-native-deps-cache.ts`).
+ *
+ * Every script here is POSIX `sh` and answers with one token, because the only alternative to a
+ * token is inferring success from an exit status the transport can also produce. A command that
+ * cannot answer is a cache miss, never a licence to delete: `MISS` and `NOT_PROMOTED` both leave
+ * the relay directory owning its own `node_modules`, which is exactly today's behaviour.
+ */
+import { shellEscape } from './ssh-connection-utils'
+import {
+  RELAY_NATIVE_DEPS_CACHE_COMPLETE_NAME,
+  RELAY_NATIVE_DEPS_CACHE_TOMBSTONE_PREFIX,
+  relayNativeDepsCacheBaseDir,
+  relayNativeDepsCacheEntryDir,
+  relayNativeDepsCacheNodeModulesPath,
+  remoteInstallRootDir
+} from './ssh-relay-native-deps-cache'
+import { joinRemotePath, type RemoteHostPlatform } from './ssh-remote-platform'
+
+export const RELAY_NATIVE_CACHE_LINKED = '__ORCA_NATIVE_CACHE__LINKED'
+export const RELAY_NATIVE_CACHE_SEEDED = '__ORCA_NATIVE_CACHE__SEEDED'
+export const RELAY_NATIVE_CACHE_MISS = '__ORCA_NATIVE_CACHE__MISS'
+export const RELAY_NATIVE_CACHE_PROMOTED = '__ORCA_NATIVE_CACHE__PROMOTED'
+export const RELAY_NATIVE_CACHE_NOT_PROMOTED = '__ORCA_NATIVE_CACHE__NOT_PROMOTED'
+export const RELAY_NATIVE_CACHE_LIST_OK = '__ORCA_NATIVE_CACHE__LIST_OK'
+export const RELAY_NATIVE_CACHE_REFS_OK = '__ORCA_NATIVE_CACHE__REFS_OK'
+export const RELAY_NATIVE_CACHE_REFS_ERR = '__ORCA_NATIVE_CACHE__REFS_ERR'
+
+/**
+ * How old an entry without `.deps-complete` must be before another deploy may reclaim it. Well
+ * past the 15-minute deploy ceiling, so a live installer is never mistaken for a crashed one.
+ * Reclaiming is safe at any age in principle — nothing links an entry until it is complete — but
+ * the margin is what keeps that argument from resting on a single `[ -f ]`.
+ */
+const CACHE_TAKEOVER_MINUTES = 120
+
+/** A crashed GC pass leaves a tombstone; it drains once no in-flight pass could still own it. */
+const CACHE_TOMBSTONE_SWEEP_MINUTES = 30
+
+/** Bounds every listing, matching `MAX_RELAY_GC_LISTING_ENTRIES`' role for version dirs. */
+export const MAX_RELAY_NATIVE_CACHE_LISTING_ENTRIES = 64
+
+export type RelayNativeDepsCachePaths = {
+  host: RemoteHostPlatform
+  remoteHome: string
+  relayDir: string
+  key: string
+}
+
+function cachePaths(paths: RelayNativeDepsCachePaths): {
+  base: string
+  entry: string
+  target: string
+  nodeModules: string
+  root: string
+} {
+  const { host, remoteHome, relayDir, key } = paths
+  return {
+    base: relayNativeDepsCacheBaseDir(host, remoteHome),
+    entry: relayNativeDepsCacheEntryDir(host, remoteHome, key),
+    target: relayNativeDepsCacheNodeModulesPath(host, remoteHome, key),
+    nodeModules: joinRemotePath(host, relayDir, 'node_modules'),
+    root: remoteInstallRootDir(host, remoteHome)
+  }
+}
+
+/**
+ * Link a complete entry into the relay directory, or seed a private tree from a sibling relay
+ * directory that already has a matching one.
+ *
+ * The seed exists so the first deploy after this ships does not recompile once more on a host
+ * that already paid for the compile. It is not trusted: the copy is a plain private install until
+ * the normal probe loads both addons, and only then is it promoted.
+ */
+export function ensureRelayNativeDepsCacheCommand(
+  paths: RelayNativeDepsCachePaths,
+  deps: Readonly<Record<string, string>>
+): string {
+  const { entry, target, nodeModules, root } = cachePaths(paths)
+  // Why grep the sibling's manifest: an older Orca pinned different versions, and a
+  // toolchain-skip host wrote one with node-pty removed. Both must fail to qualify.
+  const depGuards = Object.entries(deps).map(
+    ([name, version]) => `grep -F -q ${shellEscape(`"${name}":"${version}"`)} "$pj" || continue`
+  )
+  return [
+    `cache=${shellEscape(entry)}`,
+    `target=${shellEscape(target)}`,
+    `nm=${shellEscape(nodeModules)}`,
+    `root=${shellEscape(root)}`,
+    `if [ -f "$cache/${RELAY_NATIVE_DEPS_CACHE_COMPLETE_NAME}" ] && [ -d "$target" ]; then`,
+    '  if [ -L "$nm" ]; then',
+    `    if [ "$(readlink "$nm" 2>/dev/null)" = "$target" ]; then printf '%s\\n' ${RELAY_NATIVE_CACHE_LINKED}; exit 0; fi`,
+    '    rm -f "$nm" 2>/dev/null || true',
+    '  fi',
+    `  if [ ! -e "$nm" ] && ln -s "$target" "$nm" 2>/dev/null; then printf '%s\\n' ${RELAY_NATIVE_CACHE_LINKED}; exit 0; fi`,
+    `  printf '%s\\n' ${RELAY_NATIVE_CACHE_MISS}; exit 0`,
+    'fi',
+    'if [ ! -e "$nm" ] && [ ! -L "$nm" ]; then',
+    '  for cand in "$root"/relay-*/node_modules; do',
+    '    [ -d "$cand" ] || continue',
+    '    [ -L "$cand" ] && continue',
+    '    [ -d "$cand/node-pty" ] || continue',
+    '    [ -d "$cand/@parcel/watcher" ] || continue',
+    '    pj="${cand%/node_modules}/package.json"',
+    '    [ -f "$pj" ] || continue',
+    ...depGuards.map((guard) => `    ${guard}`),
+    '    seed="$nm.seed.$$"',
+    '    rm -rf "$seed" 2>/dev/null || true',
+    '    if cp -Rp "$cand" "$seed" 2>/dev/null && mv "$seed" "$nm" 2>/dev/null; then',
+    `      printf '%s\\n' ${RELAY_NATIVE_CACHE_SEEDED}; exit 0`,
+    '    fi',
+    '    rm -rf "$seed" 2>/dev/null || true',
+    '    break',
+    '  done',
+    'fi',
+    `printf '%s\\n' ${RELAY_NATIVE_CACHE_MISS}`
+  ].join('\n')
+}
+
+/**
+ * Publish a probe-verified private tree as the shared entry, then link the relay directory to it.
+ *
+ * `mkdir "$cache"` is the election: exactly one deploy creates the directory, and a loser keeps
+ * its own tree rather than writing into someone else's. `.deps-complete` is written last, after
+ * the symlink exists, so an entry is never linkable before it is referenced.
+ */
+export function promoteRelayNativeDepsCacheCommand(paths: RelayNativeDepsCachePaths): string {
+  const { base, entry, target, nodeModules } = cachePaths(paths)
+  const notPromoted = `printf '%s\\n' ${RELAY_NATIVE_CACHE_NOT_PROMOTED}`
+  return [
+    `base=${shellEscape(base)}`,
+    `cache=${shellEscape(entry)}`,
+    `target=${shellEscape(target)}`,
+    `nm=${shellEscape(nodeModules)}`,
+    `[ -d "$nm" ] || { ${notPromoted}; exit 0; }`,
+    `if [ -L "$nm" ]; then ${notPromoted}; exit 0; fi`,
+    `mkdir -p "$base" 2>/dev/null || { ${notPromoted}; exit 0; }`,
+    `if [ -d "$cache" ] && [ ! -f "$cache/${RELAY_NATIVE_DEPS_CACHE_COMPLETE_NAME}" ]; then`,
+    `  if [ -n "$(find "$cache" -maxdepth 0 -mmin +${CACHE_TAKEOVER_MINUTES} 2>/dev/null)" ]; then`,
+    '    rm -rf "$cache" 2>/dev/null || true',
+    '  fi',
+    'fi',
+    `mkdir "$cache" 2>/dev/null || { ${notPromoted}; exit 0; }`,
+    'if mv "$nm" "$target" 2>/dev/null; then',
+    '  if ln -s "$target" "$nm" 2>/dev/null; then',
+    `    : > "$cache/${RELAY_NATIVE_DEPS_CACHE_COMPLETE_NAME}" 2>/dev/null || true`,
+    `    if [ -f "$cache/${RELAY_NATIVE_DEPS_CACHE_COMPLETE_NAME}" ]; then printf '%s\\n' ${RELAY_NATIVE_CACHE_PROMOTED}; exit 0; fi`,
+    '  fi',
+    '  rm -f "$nm" 2>/dev/null || true',
+    // Why the rm is conditional on the move back: a failed restore leaves the only copy of the
+    // tree inside an incomplete entry. Deleting it there would cost the relay its native deps.
+    '  if mv "$target" "$nm" 2>/dev/null; then rm -rf "$cache" 2>/dev/null || true; fi',
+    `  ${notPromoted}; exit 0`,
+    'fi',
+    'rm -rf "$cache" 2>/dev/null || true',
+    notPromoted
+  ].join('\n')
+}
+
+/** Complete entries only; an incomplete one belongs to an installer, not to GC. */
+export function listRelayNativeDepsCacheEntriesCommand(
+  host: RemoteHostPlatform,
+  remoteHome: string
+): string {
+  const base = relayNativeDepsCacheBaseDir(host, remoteHome)
+  return [
+    `base=${shellEscape(base)}`,
+    `[ -d "$base" ] || { printf '%s\\n' ${RELAY_NATIVE_CACHE_LIST_OK}; exit 0; }`,
+    `find "$base" -maxdepth 1 -name ${shellEscape(`${RELAY_NATIVE_DEPS_CACHE_TOMBSTONE_PREFIX}*`)} -mmin +${CACHE_TOMBSTONE_SWEEP_MINUTES} -exec rm -rf {} + 2>/dev/null || true`,
+    'n=0',
+    'for d in "$base"/*/; do',
+    '  [ -d "$d" ] || continue',
+    `  [ -f "$d${RELAY_NATIVE_DEPS_CACHE_COMPLETE_NAME}" ] || continue`,
+    '  name=${d%/}',
+    '  name=${name##*/}',
+    `  printf 'ENTRY %s\\n' "$name"`,
+    '  n=$((n+1))',
+    `  if [ "$n" -ge ${MAX_RELAY_NATIVE_CACHE_LISTING_ENTRIES} ]; then break; fi`,
+    'done',
+    `printf '%s\\n' ${RELAY_NATIVE_CACHE_LIST_OK}`
+  ].join('\n')
+}
+
+/**
+ * Every symlinked `node_modules` under `~/.orca-remote/`, as its raw target.
+ *
+ * The scan is deliberately wider than `relay-*`: a directory this client does not recognise still
+ * counts as a referrer. An unreadable link or an overrun listing answers `REFS_ERR`, which stops
+ * the whole pass — an incomplete reference list is not evidence that anything is unreferenced.
+ */
+export function listRelayNativeDepsCacheReferencesCommand(
+  host: RemoteHostPlatform,
+  remoteHome: string
+): string {
+  const root = remoteInstallRootDir(host, remoteHome)
+  return [
+    `root=${shellEscape(root)}`,
+    `[ -d "$root" ] || { printf '%s\\n' ${RELAY_NATIVE_CACHE_REFS_OK}; exit 0; }`,
+    'n=0',
+    'for d in "$root"/*/node_modules; do',
+    '  [ -L "$d" ] || continue',
+    '  t=$(readlink "$d" 2>/dev/null) || t=""',
+    `  if [ -z "$t" ]; then printf '%s\\n' ${RELAY_NATIVE_CACHE_REFS_ERR}; exit 0; fi`,
+    `  printf 'REF %s\\n' "$t"`,
+    '  n=$((n+1))',
+    `  if [ "$n" -ge ${MAX_RELAY_NATIVE_CACHE_LISTING_ENTRIES} ]; then printf '%s\\n' ${RELAY_NATIVE_CACHE_REFS_ERR}; exit 0; fi`,
+    'done',
+    `printf '%s\\n' ${RELAY_NATIVE_CACHE_REFS_OK}`
+  ].join('\n')
+}

--- a/src/main/ssh/ssh-relay-native-deps-cache-deploy.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache-deploy.test.ts
@@ -1,0 +1,301 @@
+// The claim this file has to hold up: a second deploy of a *different bundle* to the same host
+// runs no `npm install` at all. Everything else here is the fallback ladder underneath it — a
+// host that cannot link, cannot publish, or answers nothing still deploys exactly as before.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RelayInstallMarkerModule from './ssh-relay-install-marker'
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/mock/app' }
+}))
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+  readFileSync: vi.fn().mockReturnValue('0.1.0+testhash')
+}))
+
+vi.mock('./relay-protocol', () => ({
+  RELAY_VERSION: '0.1.0',
+  RELAY_REMOTE_DIR: '.orca-remote',
+  parseUnameToRelayPlatform: vi.fn().mockReturnValue('linux-x64'),
+  RELAY_SENTINEL: 'ORCA-RELAY v0.1.0 READY\n',
+  RELAY_SENTINEL_TIMEOUT_MS: 10_000
+}))
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  uploadDirectory: vi.fn().mockResolvedValue(undefined),
+  waitForSentinel: vi.fn().mockResolvedValue({
+    write: vi.fn(),
+    onData: vi.fn(),
+    onClose: vi.fn()
+  }),
+  isUnconfirmedSshCommandTermination: (error: unknown) =>
+    error instanceof Error &&
+    (error as Error & { sshChannelCloseConfirmed?: boolean }).sshChannelCloseConfirmed === false,
+  execCommand: vi.fn()
+}))
+
+vi.mock('./ssh-remote-node-resolution', () => ({
+  resolveRemoteNodePath: vi.fn().mockResolvedValue('/usr/bin/node')
+}))
+
+vi.mock('./ssh-relay-install-marker', async (importOriginal) => ({
+  ...(await importOriginal<typeof RelayInstallMarkerModule>()),
+  createRelayInstallMarkerFileName: () => '.sftp-namespace-00000000000000000000000000000000'
+}))
+
+vi.mock('./ssh-relay-versioned-install', () => ({
+  readLocalFullVersion: vi.fn().mockReturnValue('0.1.0+testhash'),
+  computeRemoteRelayDir: (home: string, v: string) => `${home}/.orca-remote/relay-${v}`,
+  isRelayAlreadyInstalled: vi.fn().mockResolvedValue(false),
+  finalizeInstall: vi.fn().mockResolvedValue(undefined),
+  abandonInstall: vi.fn().mockResolvedValue(undefined),
+  gcOldRelayVersions: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-relay-install-lock', () => ({
+  acquireInstallLock: vi.fn().mockResolvedValue(undefined),
+  RELAY_INSTALL_LOCK_NAME: '.install-lock'
+}))
+
+vi.mock('./ssh-relay-repair-lock', () => ({
+  tryAcquireRelayRepairLock: vi.fn().mockResolvedValue('acquired')
+}))
+
+vi.mock('./ssh-relay-gc-claim', () => ({
+  releaseRelayGcClaimWithRetry: vi.fn().mockResolvedValue('released'),
+  tryAcquireRelayGcClaim: vi.fn().mockResolvedValue('launch-token'),
+  waitForRelayGcClaimRelease: vi.fn().mockResolvedValue(undefined)
+}))
+
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+import { execCommand, uploadDirectory } from './ssh-relay-deploy-helpers'
+import { parseUnameToRelayPlatform } from './relay-protocol'
+import { isRelayAlreadyInstalled, gcOldRelayVersions } from './ssh-relay-versioned-install'
+import {
+  makeMockConnection,
+  makeStagedFirstInstallExecPrefix,
+  type ExecResponse,
+  type SftpWriteCapture
+} from './ssh-relay-native-deps-install-fixture'
+import {
+  RELAY_NATIVE_CACHE_LINKED,
+  RELAY_NATIVE_CACHE_MISS,
+  RELAY_NATIVE_CACHE_PROMOTED
+} from './ssh-relay-native-deps-cache-commands'
+
+// Everything after the probe on a healthy install: stderr cleanup, stage cleanup, launch.
+const LAUNCH_TAIL: ExecResponse[] = ['', 'DEAD', '', 'READY']
+
+describe('relay native-deps cache on the deploy path', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  const sftpCapture: SftpWriteCapture = { paths: [], contents: {}, execCallCountAtWrite: {} }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(execCommand).mockReset().mockResolvedValue('')
+    vi.mocked(uploadDirectory).mockResolvedValue(undefined)
+    sftpCapture.paths.length = 0
+    for (const k of Object.keys(sftpCapture.contents)) {
+      delete sftpCapture.contents[k]
+    }
+    for (const k of Object.keys(sftpCapture.execCallCountAtWrite)) {
+      delete sftpCapture.execCallCountAtWrite[k]
+    }
+    vi.mocked(parseUnameToRelayPlatform).mockReturnValue('linux-x64')
+    vi.mocked(isRelayAlreadyInstalled).mockResolvedValue(false)
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  function feed(responses: ExecResponse[]): void {
+    const mockExec = vi.mocked(execCommand)
+    for (const r of responses) {
+      if (typeof r === 'string') {
+        mockExec.mockResolvedValueOnce(r)
+      } else {
+        mockExec.mockRejectedValueOnce(new Error(r.reject))
+      }
+    }
+  }
+
+  function execCommands(): string[] {
+    return vi.mocked(execCommand).mock.calls.map(([, command]) => command)
+  }
+
+  /**
+   * A first install whose cache probe answers `cacheAnswer`. The prefix's last slot is the cache
+   * probe, so overriding it is the only difference between a hit and a miss.
+   */
+  function firstInstall(cacheAnswer: string, tail: ExecResponse[]): ExecResponse[] {
+    const prefix = makeStagedFirstInstallExecPrefix()
+    prefix[prefix.length - 1] = cacheAnswer
+    return [...prefix, ...tail]
+  }
+
+  it('runs no npm install when a different bundle finds a complete entry on the host', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      firstInstall(RELAY_NATIVE_CACHE_LINKED, [
+        '', // chmod prebuilds, through the symlink
+        'ORCA-NPTY-PROBE-OK\n',
+        '', // rm probe stderr
+        ...LAUNCH_TAIL
+      ])
+    )
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+
+    const commands = execCommands()
+    expect(commands.some((c) => c.includes('npm install'))).toBe(false)
+    expect(commands.some((c) => c.includes('npm rebuild'))).toBe(false)
+    // The bundle still gets its own directory; only the native tree is shared.
+    expect(commands.some((c) => c.includes('.orca-remote/relay-0.1.0+testhash'))).toBe(true)
+    expect(commands.some((c) => /\.orca-remote\/native\/linux-x64-[0-9a-f]{16}/.test(c))).toBe(true)
+  })
+
+  it('still installs on the first deploy, then publishes the tree the probe loaded', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      firstInstall(RELAY_NATIVE_CACHE_MISS, [
+        '', // npm install
+        '', // chmod prebuilds
+        'ORCA-NPTY-PROBE-OK\n',
+        '', // rm probe stderr
+        RELAY_NATIVE_CACHE_PROMOTED,
+        ...LAUNCH_TAIL
+      ])
+    )
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+
+    const commands = execCommands()
+    const install = commands.find((c) => c.includes('npm install')) ?? ''
+    expect(install).toContain('node-pty@1.1.0')
+    // The install runs in the relay directory; publication moves the finished tree afterwards.
+    expect(install).toContain('.orca-remote/relay-0.1.0+testhash')
+    const promote = commands.findLast((c) => c.includes('mkdir "$cache"')) ?? ''
+    expect(promote).toContain(': > "$cache/.deps-complete"')
+  })
+
+  it('does not publish a tree the probe could not load', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      firstInstall(RELAY_NATIVE_CACHE_MISS, [
+        '', // npm install
+        '', // chmod prebuilds
+        'MISSING\n',
+        '', // cat probe stderr
+        '', // rm probe stderr
+        '', // npm rebuild
+        '', // chmod prebuilds after rebuild
+        'MISSING\n',
+        '', // cat stderr after rebuild
+        '', // rm stderr after rebuild
+        ...LAUNCH_TAIL
+      ])
+    )
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+
+    expect(execCommands().some((c) => c.includes('mkdir "$cache"'))).toBe(false)
+  })
+
+  it('installs per-directory when the host cannot answer the cache probe at all', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    const prefix = makeStagedFirstInstallExecPrefix()
+    prefix[prefix.length - 1] = { reject: 'mkdir: Read-only file system' }
+    feed([
+      ...prefix,
+      '', // npm install still runs
+      '', // chmod prebuilds
+      'ORCA-NPTY-PROBE-OK\n',
+      '', // rm probe stderr
+      '', // publication is attempted and answers nothing
+      ...LAUNCH_TAIL
+    ])
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+
+    expect(execCommands().some((c) => c.includes('npm install'))).toBe(true)
+  })
+
+  it('falls back to its own install when a linked entry does not load on this host', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      firstInstall(RELAY_NATIVE_CACHE_LINKED, [
+        '', // chmod prebuilds
+        'MISSING\n', // the shared tree does not load here
+        '', // cat probe stderr
+        '', // rm probe stderr
+        '', // npm install, privately, after the prefix detaches the symlink
+        '', // chmod prebuilds
+        'ORCA-NPTY-PROBE-OK\n',
+        '', // rm probe stderr
+        '', // promotion attempt (the entry already exists, so it is declined)
+        ...LAUNCH_TAIL
+      ])
+    )
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+
+    const install = execCommands().find((c) => c.includes('npm install')) ?? ''
+    // Why this prefix is the whole point: npm follows the symlink, and every other relay on the
+    // host is running out of the tree on the other side of it.
+    expect(install).toContain('if [ -L node_modules ]; then rm -f node_modules; fi;')
+    const warnings = warnSpy.mock.calls.map((args) => String(args[0] ?? ''))
+    expect(warnings.some((m) => m.includes('[ssh-relay][NATIVE-CACHE-UNUSABLE]'))).toBe(true)
+  })
+
+  it('detaches rather than resetting through the link when repairing an installed relay', async () => {
+    vi.mocked(isRelayAlreadyInstalled).mockResolvedValue(true)
+    const conn = makeMockConnection(sftpCapture)
+    const bothMissing = 'ORCA-NATIVE-DEPS-MISSING:node-pty,@parcel/watcher\nMISSING'
+    feed([
+      '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+      '/home/u',
+      bothMissing, // health probe before the repair lock
+      bothMissing, // re-probe under the lock
+      '', // install-owner marker
+      '', // npm install
+      '', // chmod prebuilds
+      'ORCA-NPTY-PROBE-OK\n',
+      '', // rm probe stderr
+      'DEAD',
+      '', // publish the per-launch credential
+      'READY'
+    ])
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+
+    const commands = execCommands()
+    // A repair never consults the shared entry: its reset would rewrite a tree it does not own.
+    expect(commands.some((c) => c.includes('.orca-remote/native/'))).toBe(false)
+    const install = commands.find((c) => c.includes('npm install')) ?? ''
+    expect(install).toContain('if [ -L node_modules ]; then rm -f node_modules; fi;')
+    expect(install).toContain("rm -rf 'node_modules/node-pty'")
+  })
+
+  it('pins its own key so a GC pass cannot collect the entry this connection depends on', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      firstInstall(RELAY_NATIVE_CACHE_LINKED, [
+        '', // chmod prebuilds
+        'ORCA-NPTY-PROBE-OK\n',
+        '', // rm probe stderr
+        ...LAUNCH_TAIL
+      ])
+    )
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+    await vi.waitFor(() => expect(vi.mocked(gcOldRelayVersions)).toHaveBeenCalled())
+
+    const options = vi.mocked(gcOldRelayVersions).mock.calls.at(-1)?.[4]
+    expect(options?.nativeDepsCacheKeys).toEqual([
+      expect.stringMatching(/^linux-x64-[0-9a-f]{16}$/)
+    ])
+  })
+})

--- a/src/main/ssh/ssh-relay-native-deps-cache-gc.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache-gc.ts
@@ -1,0 +1,243 @@
+/**
+ * Garbage collection for the shared native-deps cache.
+ *
+ * This is the part that can hurt: a cache entry is the only copy of node-pty for every relay
+ * directory that links to it, so a wrong deletion takes native modules away from a running relay.
+ * The discipline is `remote-install-gc.ts`': **an unanswered probe blocks deletion.** A listing
+ * that does not end in its own OK token, a symlink whose target will not read, a reference whose
+ * shape this client does not recognise — each aborts the entire pass rather than narrowing it.
+ * Loss of contact is never evidence that a tree is unreferenced
+ * (`docs/reference/ssh-execution-boundary.md`).
+ *
+ * Deletion is then the same three-step move `remote-install-gc.ts` uses for version dirs: rename
+ * to a tombstone, re-read the references under the rename, and only then remove. A deploy that
+ * linked the entry between the first listing and the rename shows up in the recheck, and its tree
+ * is moved back.
+ */
+import type { SshConnection } from './ssh-connection'
+import { execCommand } from './ssh-relay-deploy-helpers'
+import {
+  isRelayNativeDepsCacheEntryName,
+  relayNativeDepsCacheBaseDir,
+  relayNativeDepsCacheNodeModulesPath,
+  supportsRelayNativeDepsCache,
+  RELAY_NATIVE_DEPS_CACHE_TOMBSTONE_PREFIX
+} from './ssh-relay-native-deps-cache'
+import {
+  listRelayNativeDepsCacheEntriesCommand,
+  listRelayNativeDepsCacheReferencesCommand,
+  MAX_RELAY_NATIVE_CACHE_LISTING_ENTRIES,
+  RELAY_NATIVE_CACHE_LIST_OK,
+  RELAY_NATIVE_CACHE_REFS_OK
+} from './ssh-relay-native-deps-cache-commands'
+import { moveRemoteTreeCommand, removeRemoteTreeCommand } from './ssh-remote-commands'
+import { joinRemotePath, type RemoteHostPlatform } from './ssh-remote-platform'
+
+type ReferenceScan =
+  | { readable: true; referencedKeys: Set<string> }
+  /** Anything this client could not fully account for. No entry may be deleted on it. */
+  | { readable: false }
+
+function execHostCommand(
+  conn: SshConnection,
+  host: RemoteHostPlatform,
+  command: string
+): Promise<string> {
+  return execCommand(conn, command, { wrapCommand: host.commandDialect !== 'powershell' })
+}
+
+/**
+ * Remove complete cache entries that nothing links to.
+ *
+ * `pinnedKeys` is the connection's own key. The referencing symlink is written before the entry
+ * becomes listable, so a live entry is already protected by the reference scan; the pin is there
+ * so a deploy that fell back to a per-directory install cannot have its key deleted underneath a
+ * retry either.
+ */
+export async function gcRelayNativeDepsCache(
+  conn: SshConnection,
+  host: RemoteHostPlatform,
+  remoteHome: string,
+  options?: { pinnedKeys?: readonly string[] }
+): Promise<void> {
+  if (!supportsRelayNativeDepsCache(host)) {
+    return
+  }
+  const base = relayNativeDepsCacheBaseDir(host, remoteHome)
+  let entries: string[]
+  try {
+    entries = parseCacheEntryListing(
+      await execHostCommand(conn, host, listRelayNativeDepsCacheEntriesCommand(host, remoteHome))
+    )
+  } catch {
+    return
+  }
+  if (entries.length === 0) {
+    return
+  }
+  const scan = await scanCacheReferences(conn, host, remoteHome)
+  if (!scan.readable) {
+    return
+  }
+  const pinned = new Set(options?.pinnedKeys ?? [])
+  const candidates = entries.filter((key) => !scan.referencedKeys.has(key) && !pinned.has(key))
+  const removed: string[] = []
+  for (const key of candidates) {
+    if (await removeUnreferencedCacheEntry(conn, host, remoteHome, base, key)) {
+      removed.push(key)
+    }
+  }
+  if (removed.length > 0) {
+    console.log(
+      `[relay] native-deps cache GC: removed ${removed.length} entry(ies): ${removed.join(', ')}`
+    )
+  }
+}
+
+async function removeUnreferencedCacheEntry(
+  conn: SshConnection,
+  host: RemoteHostPlatform,
+  remoteHome: string,
+  base: string,
+  key: string
+): Promise<boolean> {
+  const entryDir = joinRemotePath(host, base, key)
+  const tombstone = joinRemotePath(
+    host,
+    base,
+    `${RELAY_NATIVE_DEPS_CACHE_TOMBSTONE_PREFIX}${key}.${process.pid}.${Date.now()}`
+  )
+  try {
+    const moved = await execHostCommand(
+      conn,
+      host,
+      moveRemoteTreeCommand(host, entryDir, tombstone)
+    )
+    if (moved.trim() !== 'MOVED') {
+      return false
+    }
+  } catch {
+    return false
+  }
+  // Why recheck under the rename: a deploy that read `.deps-complete` before it moved can still
+  // be creating its symlink. Its reference now names a path that no longer exists, so restoring
+  // the tree is the only outcome that leaves that relay with working native deps.
+  let recheck: ReferenceScan
+  try {
+    recheck = await scanCacheReferences(conn, host, remoteHome)
+  } catch {
+    recheck = { readable: false }
+  }
+  if (!recheck.readable || recheck.referencedKeys.has(key)) {
+    await execHostCommand(conn, host, moveRemoteTreeCommand(host, tombstone, entryDir)).catch(
+      () => {}
+    )
+    return false
+  }
+  try {
+    await execHostCommand(conn, host, removeRemoteTreeCommand(host, tombstone))
+    return true
+  } catch {
+    // The sweep in the entry listing drains a tombstone this pass could not remove.
+    return false
+  }
+}
+
+async function scanCacheReferences(
+  conn: SshConnection,
+  host: RemoteHostPlatform,
+  remoteHome: string
+): Promise<ReferenceScan> {
+  let output: string
+  try {
+    output = await execHostCommand(
+      conn,
+      host,
+      listRelayNativeDepsCacheReferencesCommand(host, remoteHome)
+    )
+  } catch {
+    return { readable: false }
+  }
+  const lines = output.split(/\r?\n/).map((line) => line.trim())
+  if (!lines.includes(RELAY_NATIVE_CACHE_REFS_OK)) {
+    return { readable: false }
+  }
+  const referencedKeys = new Set<string>()
+  const base = relayNativeDepsCacheBaseDir(host, remoteHome)
+  for (const line of lines) {
+    if (!line.startsWith('REF ')) {
+      continue
+    }
+    const attribution = attributeReference(line.slice('REF '.length), base, host, remoteHome)
+    if (attribution.kind === 'unattributable') {
+      return { readable: false }
+    }
+    if (attribution.kind === 'entry') {
+      referencedKeys.add(attribution.key)
+    }
+  }
+  return { readable: true, referencedKeys }
+}
+
+type ReferenceAttribution =
+  | { kind: 'entry'; key: string }
+  /** A link that points somewhere else entirely; it holds no cache entry alive. */
+  | { kind: 'outside' }
+  | { kind: 'unattributable' }
+
+/**
+ * Which cache entry a symlink target names.
+ *
+ * A relative target is `unattributable` on purpose. Every link Orca writes is absolute, so a
+ * relative one is a tree with a history this pass cannot reconstruct, and guessing which entry it
+ * resolves to is exactly the inference that deletes a live relay's modules.
+ */
+function attributeReference(
+  target: string,
+  base: string,
+  host: RemoteHostPlatform,
+  remoteHome: string
+): ReferenceAttribution {
+  if (!target.startsWith('/') || target.includes('/../') || target.endsWith('/..')) {
+    return { kind: 'unattributable' }
+  }
+  if (!target.startsWith(`${base}/`)) {
+    return { kind: 'outside' }
+  }
+  const rest = target.slice(base.length + 1).split('/')
+  if (
+    rest.length !== 2 ||
+    rest[1] !== 'node_modules' ||
+    !isRelayNativeDepsCacheEntryName(rest[0])
+  ) {
+    return { kind: 'unattributable' }
+  }
+  // Why rebuild the path rather than trust the split: the target must be exactly what this client
+  // writes for that key, not merely something that parses into two plausible segments.
+  return target === relayNativeDepsCacheNodeModulesPath(host, remoteHome, rest[0])
+    ? { kind: 'entry', key: rest[0] }
+    : { kind: 'unattributable' }
+}
+
+function parseCacheEntryListing(output: string): string[] {
+  const lines = output.split(/\r?\n/).map((line) => line.trim())
+  if (!lines.includes(RELAY_NATIVE_CACHE_LIST_OK)) {
+    return []
+  }
+  const entries: string[] = []
+  for (const line of lines) {
+    if (!line.startsWith('ENTRY ')) {
+      continue
+    }
+    const name = line.slice('ENTRY '.length)
+    // Why re-validate a name the host produced: it is about to be interpolated into `mv` and
+    // `rm -rf`. Only names this client could itself have minted are eligible.
+    if (
+      isRelayNativeDepsCacheEntryName(name) &&
+      entries.length < MAX_RELAY_NATIVE_CACHE_LISTING_ENTRIES
+    ) {
+      entries.push(name)
+    }
+  }
+  return entries
+}

--- a/src/main/ssh/ssh-relay-native-deps-cache-install.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache-install.ts
@@ -1,0 +1,209 @@
+/**
+ * The deploy-side half of the shared native-deps cache: resolve this build's key, try to link an
+ * existing entry, and publish a probe-verified tree afterwards.
+ *
+ * Both entry points answer with a value, never an exception. The cache is an optimization on a
+ * path that must still connect a host with a read-only home, no `ln`, or an SSH server that drops
+ * the channel — every one of those is a plain per-directory install, which is what the relay did
+ * before this existed.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { SshConnection } from './ssh-connection'
+import { RELAY_ARTIFACTS } from '../../shared/relay-artifacts'
+import { execCommand } from './ssh-relay-deploy-helpers'
+import { NATIVE_DEPS_COMMAND_TIMEOUT_MS } from './ssh-relay-deploy-timing'
+import {
+  computeRelayNativeDepsCacheKey,
+  supportsRelayNativeDepsCache,
+  RELAY_NATIVE_DEPS_PATCH_ARTIFACT_PATTERN,
+  type RelayNativeDepsCachePatchSource
+} from './ssh-relay-native-deps-cache'
+import {
+  ensureRelayNativeDepsCacheCommand,
+  promoteRelayNativeDepsCacheCommand,
+  RELAY_NATIVE_CACHE_LINKED,
+  RELAY_NATIVE_CACHE_PROMOTED,
+  RELAY_NATIVE_CACHE_SEEDED,
+  type RelayNativeDepsCachePaths
+} from './ssh-relay-native-deps-cache-commands'
+import type { RemoteHostPlatform } from './ssh-remote-platform'
+
+/**
+ * `linked` — the relay directory now points at a complete shared entry and needs no install.
+ * `private` — it owns (or is about to own) its own tree, which promotion may later publish.
+ */
+export type RelayNativeDepsCacheAttachment = {
+  mode: 'linked' | 'private'
+  key: string
+}
+
+export type RelayNativeDepsCacheContext = {
+  hostPlatform: RemoteHostPlatform
+  remoteHome: string
+  relayDir: string
+  platform: string
+  localRelayDir: string
+  deps: Readonly<Record<string, string>>
+  signal?: AbortSignal
+}
+
+function execHostCommand(
+  conn: SshConnection,
+  host: RemoteHostPlatform,
+  command: string,
+  signal?: AbortSignal
+): Promise<string> {
+  return execCommand(conn, command, {
+    wrapCommand: host.commandDialect !== 'powershell',
+    // Why the native-deps budget and not the default 30s: a seeding copy moves a whole
+    // node_modules on the host's own disk, which is fast but not instant on a cold cache.
+    timeoutMs: NATIVE_DEPS_COMMAND_TIMEOUT_MS,
+    signal
+  })
+}
+
+/**
+ * Every shipped artifact that patches the installed native tree, read for hashing.
+ *
+ * Reading is best-effort by design: a patch this client cannot read must not silently drop out of
+ * the key, so an unreadable one disables the cache rather than producing a key that claims the
+ * patch was applied.
+ */
+export function readRelayNativeDepsPatchSources(
+  localRelayDir: string
+): RelayNativeDepsCachePatchSource[] | null {
+  const sources: RelayNativeDepsCachePatchSource[] = []
+  for (const artifact of RELAY_ARTIFACTS) {
+    if (!RELAY_NATIVE_DEPS_PATCH_ARTIFACT_PATTERN.test(artifact.filename)) {
+      continue
+    }
+    const path = join(localRelayDir, artifact.filename)
+    try {
+      if (!existsSync(path)) {
+        continue
+      }
+      sources.push({ filename: artifact.filename, contents: readFileSync(path, 'utf-8') })
+    } catch {
+      return null
+    }
+  }
+  return sources
+}
+
+/** This build's cache key, or null when it cannot be computed and the cache must stay off. */
+export function resolveRelayNativeDepsCacheKey(context: {
+  platform: string
+  localRelayDir: string
+  deps: Readonly<Record<string, string>>
+}): string | null {
+  const patchSources = readRelayNativeDepsPatchSources(context.localRelayDir)
+  if (!patchSources) {
+    return null
+  }
+  try {
+    return computeRelayNativeDepsCacheKey({
+      platform: context.platform,
+      deps: context.deps,
+      patchSources
+    })
+  } catch (err) {
+    console.warn(
+      `[ssh-relay] Native-deps cache key unavailable for ${context.platform}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+    return null
+  }
+}
+
+/**
+ * Link a complete entry, or leave the relay directory to install privately.
+ *
+ * Returns null when the cache is off for this host, which keeps the caller on the exact command
+ * sequence it ran before the cache existed.
+ */
+export async function attachRelayNativeDepsCache(
+  conn: SshConnection,
+  context: RelayNativeDepsCacheContext
+): Promise<RelayNativeDepsCacheAttachment | null> {
+  if (!supportsRelayNativeDepsCache(context.hostPlatform)) {
+    return null
+  }
+  const key = resolveRelayNativeDepsCacheKey(context)
+  if (!key) {
+    return null
+  }
+  const paths = cachePathsFor(context, key)
+  try {
+    const output = await execHostCommand(
+      conn,
+      context.hostPlatform,
+      ensureRelayNativeDepsCacheCommand(paths, context.deps),
+      context.signal
+    )
+    if (output.includes(RELAY_NATIVE_CACHE_LINKED)) {
+      console.log(`[ssh-relay] Native deps linked from shared cache entry ${key}`)
+      return { mode: 'linked', key }
+    }
+    if (output.includes(RELAY_NATIVE_CACHE_SEEDED)) {
+      console.log(`[ssh-relay] Seeded native deps for ${key} from an existing install on this host`)
+    }
+    return { mode: 'private', key }
+  } catch (err) {
+    context.signal?.throwIfAborted()
+    // Why still 'private' and not null: the relay directory owns nothing yet either way, and the
+    // install that follows is identical. Promotion afterwards is separately best-effort.
+    console.warn(
+      `[ssh-relay] Native-deps cache probe for ${key} failed; installing per-directory: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+    return { mode: 'private', key }
+  }
+}
+
+/**
+ * Publish a private tree the probe just loaded, and link the relay directory to it.
+ *
+ * Called only after `probeInstalledNativeDeps` reported both addons loadable on this host, so an
+ * entry is never published on the strength of a successful `npm install` alone.
+ */
+export async function promoteRelayNativeDepsCache(
+  conn: SshConnection,
+  context: RelayNativeDepsCacheContext,
+  key: string
+): Promise<void> {
+  try {
+    const output = await execHostCommand(
+      conn,
+      context.hostPlatform,
+      promoteRelayNativeDepsCacheCommand(cachePathsFor(context, key)),
+      context.signal
+    )
+    console.log(
+      output.includes(RELAY_NATIVE_CACHE_PROMOTED)
+        ? `[ssh-relay] Published native deps as shared cache entry ${key}`
+        : `[ssh-relay] Native deps stay per-directory; shared cache entry ${key} was not published`
+    )
+  } catch (err) {
+    context.signal?.throwIfAborted()
+    console.warn(
+      `[ssh-relay] Could not publish native-deps cache entry ${key}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+  }
+}
+
+function cachePathsFor(
+  context: RelayNativeDepsCacheContext,
+  key: string
+): RelayNativeDepsCachePaths {
+  return {
+    host: context.hostPlatform,
+    remoteHome: context.remoteHome,
+    relayDir: context.relayDir,
+    key
+  }
+}

--- a/src/main/ssh/ssh-relay-native-deps-cache-shell.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache-shell.test.ts
@@ -1,0 +1,243 @@
+// The cache's safety argument is made of `sh`, not TypeScript: `mkdir` elects the publisher,
+// `.deps-complete` gates linking, and a failed publish must put the tree back. Asserting on the
+// command strings cannot show any of that, so these run the real scripts against a real tree.
+
+import { execFileSync } from 'node:child_process'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+  existsSync,
+  lstatSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { getRemoteHostPlatform } from './ssh-remote-platform'
+import {
+  computeRelayNativeDepsCacheKey,
+  relayNativeDepsCacheEntryDir,
+  relayNativeDepsCacheNodeModulesPath
+} from './ssh-relay-native-deps-cache'
+import {
+  ensureRelayNativeDepsCacheCommand,
+  listRelayNativeDepsCacheEntriesCommand,
+  listRelayNativeDepsCacheReferencesCommand,
+  promoteRelayNativeDepsCacheCommand,
+  RELAY_NATIVE_CACHE_LINKED,
+  RELAY_NATIVE_CACHE_LIST_OK,
+  RELAY_NATIVE_CACHE_MISS,
+  RELAY_NATIVE_CACHE_NOT_PROMOTED,
+  RELAY_NATIVE_CACHE_PROMOTED,
+  RELAY_NATIVE_CACHE_REFS_OK,
+  RELAY_NATIVE_CACHE_SEEDED
+} from './ssh-relay-native-deps-cache-commands'
+
+const HOST = getRemoteHostPlatform('linux-x64')
+const DEPS = { 'node-pty': '1.1.0', '@parcel/watcher': '2.5.6' } as const
+const KEY = computeRelayNativeDepsCacheKey({ platform: 'linux-x64', deps: DEPS })
+
+// Debian and Ubuntu point /bin/sh at dash, which is stricter than the bash-in-sh-mode that macOS
+// ships; run against both when both exist so a bashism cannot pass here and fail on a host.
+const SHELLS = ['/bin/sh', '/bin/dash'].filter((shell) => existsSync(shell))
+
+describe.runIf(process.platform !== 'win32').each(SHELLS)(
+  'relay native-deps cache shell scripts (%s)',
+  (shell) => {
+    let home: string
+
+    const relayDir = (version: string): string => join(home, '.orca-remote', `relay-${version}`)
+
+    function sh(command: string): string {
+      return execFileSync(shell, ['-c', command], { encoding: 'utf-8' })
+    }
+
+    /** A relay directory holding its own installed tree, exactly as `npm install` leaves it. */
+    function makePrivateInstall(version: string, deps: Record<string, string> = DEPS): string {
+      const dir = relayDir(version)
+      mkdirSync(join(dir, 'node_modules', 'node-pty', 'build'), { recursive: true })
+      mkdirSync(join(dir, 'node_modules', '@parcel', 'watcher'), { recursive: true })
+      writeFileSync(join(dir, 'node_modules', 'node-pty', 'build', 'pty.node'), 'binary')
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: deps }))
+      return dir
+    }
+
+    function ensure(version: string): string {
+      return sh(
+        ensureRelayNativeDepsCacheCommand(
+          { host: HOST, remoteHome: home, relayDir: relayDir(version), key: KEY },
+          DEPS
+        )
+      ).trim()
+    }
+
+    function promote(version: string): string {
+      return sh(
+        promoteRelayNativeDepsCacheCommand({
+          host: HOST,
+          remoteHome: home,
+          relayDir: relayDir(version),
+          key: KEY
+        })
+      ).trim()
+    }
+
+    beforeEach(() => {
+      home = mkdtempSync(join(tmpdir(), 'orca-relay-cache-'))
+      mkdirSync(join(home, '.orca-remote'), { recursive: true })
+    })
+
+    afterEach(() => {
+      rmSync(home, { recursive: true, force: true })
+    })
+
+    it('publishes a probe-verified tree and links the relay directory to it', () => {
+      makePrivateInstall('0.1.0+aaa')
+
+      expect(promote('0.1.0+aaa')).toBe(RELAY_NATIVE_CACHE_PROMOTED)
+
+      const target = relayNativeDepsCacheNodeModulesPath(HOST, home, KEY)
+      expect(readlinkSync(join(relayDir('0.1.0+aaa'), 'node_modules'))).toBe(target)
+      expect(statSync(join(target, 'node-pty', 'build', 'pty.node')).isFile()).toBe(true)
+      expect(
+        existsSync(join(relayNativeDepsCacheEntryDir(HOST, home, KEY), '.deps-complete'))
+      ).toBe(true)
+    })
+
+    it('links a second bundle to the published tree with no install of its own', () => {
+      makePrivateInstall('0.1.0+aaa')
+      promote('0.1.0+aaa')
+
+      // A different bundle: fresh directory, no node_modules, nothing installed.
+      mkdirSync(relayDir('0.1.0+bbb'), { recursive: true })
+      expect(ensure('0.1.0+bbb')).toBe(RELAY_NATIVE_CACHE_LINKED)
+
+      const linked = join(relayDir('0.1.0+bbb'), 'node_modules')
+      expect(readlinkSync(linked)).toBe(relayNativeDepsCacheNodeModulesPath(HOST, home, KEY))
+      expect(statSync(join(linked, 'node-pty', 'build', 'pty.node')).isFile()).toBe(true)
+    })
+
+    it('will not link an entry whose completion sentinel is absent', () => {
+      makePrivateInstall('0.1.0+aaa')
+      promote('0.1.0+aaa')
+      rmSync(join(relayNativeDepsCacheEntryDir(HOST, home, KEY), '.deps-complete'))
+
+      mkdirSync(relayDir('0.1.0+bbb'), { recursive: true })
+      expect(ensure('0.1.0+bbb')).toBe(RELAY_NATIVE_CACHE_MISS)
+      expect(existsSync(join(relayDir('0.1.0+bbb'), 'node_modules'))).toBe(false)
+    })
+
+    it('seeds from a sibling install rather than recompiling once more', () => {
+      makePrivateInstall('0.1.0+aaa')
+      mkdirSync(relayDir('0.1.0+bbb'), { recursive: true })
+
+      expect(ensure('0.1.0+bbb')).toBe(RELAY_NATIVE_CACHE_SEEDED)
+
+      const seeded = join(relayDir('0.1.0+bbb'), 'node_modules')
+      expect(lstatSync(seeded).isSymbolicLink()).toBe(false)
+      expect(statSync(join(seeded, 'node-pty', 'build', 'pty.node')).isFile()).toBe(true)
+      // The source is untouched, so a relay running out of it is unaffected.
+      expect(existsSync(join(relayDir('0.1.0+aaa'), 'node_modules', 'node-pty'))).toBe(true)
+    })
+
+    it('refuses to seed from a sibling pinned to different versions', () => {
+      makePrivateInstall('0.1.0+aaa', { 'node-pty': '1.0.0', '@parcel/watcher': '2.5.6' })
+      mkdirSync(relayDir('0.1.0+bbb'), { recursive: true })
+
+      expect(ensure('0.1.0+bbb')).toBe(RELAY_NATIVE_CACHE_MISS)
+      expect(existsSync(join(relayDir('0.1.0+bbb'), 'node_modules'))).toBe(false)
+    })
+
+    it('refuses to seed from a sibling that had node-pty skipped', () => {
+      makePrivateInstall('0.1.0+aaa')
+      rmSync(join(relayDir('0.1.0+aaa'), 'node_modules', 'node-pty'), { recursive: true })
+      mkdirSync(relayDir('0.1.0+bbb'), { recursive: true })
+
+      expect(ensure('0.1.0+bbb')).toBe(RELAY_NATIVE_CACHE_MISS)
+    })
+
+    it('leaves a directory that installed for itself alone', () => {
+      makePrivateInstall('0.1.0+aaa')
+      promote('0.1.0+aaa')
+      const own = makePrivateInstall('0.1.0+bbb')
+
+      expect(ensure('0.1.0+bbb')).toBe(RELAY_NATIVE_CACHE_MISS)
+      expect(lstatSync(join(own, 'node_modules')).isSymbolicLink()).toBe(false)
+    })
+
+    it('elects exactly one publisher and leaves the loser its own tree', () => {
+      makePrivateInstall('0.1.0+aaa')
+      makePrivateInstall('0.1.0+bbb')
+
+      expect(promote('0.1.0+aaa')).toBe(RELAY_NATIVE_CACHE_PROMOTED)
+      expect(promote('0.1.0+bbb')).toBe(RELAY_NATIVE_CACHE_NOT_PROMOTED)
+
+      // The loser must not have handed its tree to an entry it lost the race for.
+      const loser = join(relayDir('0.1.0+bbb'), 'node_modules')
+      expect(lstatSync(loser).isSymbolicLink()).toBe(false)
+      expect(statSync(join(loser, 'node-pty', 'build', 'pty.node')).isFile()).toBe(true)
+    })
+
+    it('never republishes through a symlink it already holds', () => {
+      makePrivateInstall('0.1.0+aaa')
+      promote('0.1.0+aaa')
+
+      expect(promote('0.1.0+aaa')).toBe(RELAY_NATIVE_CACHE_NOT_PROMOTED)
+      expect(statSync(join(relayDir('0.1.0+aaa'), 'node_modules', 'node-pty')).isDirectory()).toBe(
+        true
+      )
+    })
+
+    it('survives removing a linked relay directory without touching the shared tree', () => {
+      makePrivateInstall('0.1.0+aaa')
+      promote('0.1.0+aaa')
+      mkdirSync(relayDir('0.1.0+bbb'), { recursive: true })
+      ensure('0.1.0+bbb')
+
+      // Exactly what version GC does to an idle directory.
+      sh(`rm -rf ${JSON.stringify(relayDir('0.1.0+bbb'))}`)
+
+      const target = relayNativeDepsCacheNodeModulesPath(HOST, home, KEY)
+      expect(statSync(join(target, 'node-pty', 'build', 'pty.node')).isFile()).toBe(true)
+    })
+
+    it('reports the published entry and every symlink that references it', () => {
+      makePrivateInstall('0.1.0+aaa')
+      promote('0.1.0+aaa')
+
+      const entries = sh(listRelayNativeDepsCacheEntriesCommand(HOST, home)).trim().split('\n')
+      expect(entries).toEqual([`ENTRY ${KEY}`, RELAY_NATIVE_CACHE_LIST_OK])
+
+      const refs = sh(listRelayNativeDepsCacheReferencesCommand(HOST, home)).trim().split('\n')
+      expect(refs).toEqual([
+        `REF ${relayNativeDepsCacheNodeModulesPath(HOST, home, KEY)}`,
+        RELAY_NATIVE_CACHE_REFS_OK
+      ])
+    })
+
+    it('reports a symlink no Orca version wrote, so GC can refuse the pass', () => {
+      makePrivateInstall('0.1.0+aaa')
+      promote('0.1.0+aaa')
+      mkdirSync(relayDir('0.1.0+bbb'), { recursive: true })
+      symlinkSync('../relay-0.1.0+aaa/node_modules', join(relayDir('0.1.0+bbb'), 'node_modules'))
+
+      const refs = sh(listRelayNativeDepsCacheReferencesCommand(HOST, home)).trim().split('\n')
+      expect(refs).toContain('REF ../relay-0.1.0+aaa/node_modules')
+      expect(refs.at(-1)).toBe(RELAY_NATIVE_CACHE_REFS_OK)
+    })
+
+    it('answers cleanly on a host that has never installed anything', () => {
+      expect(sh(listRelayNativeDepsCacheEntriesCommand(HOST, home)).trim()).toBe(
+        RELAY_NATIVE_CACHE_LIST_OK
+      )
+      expect(sh(listRelayNativeDepsCacheReferencesCommand(HOST, home)).trim()).toBe(
+        RELAY_NATIVE_CACHE_REFS_OK
+      )
+    })
+  }
+)

--- a/src/main/ssh/ssh-relay-native-deps-cache.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache.test.ts
@@ -1,0 +1,277 @@
+// The cache is shared across every relay directory on a host, so these cover the two things that
+// make sharing safe: the key changes when the tree's inputs change, and GC refuses to delete on
+// anything short of a complete, attributable reference listing.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  execCommand: vi.fn()
+}))
+
+import { execCommand } from './ssh-relay-deploy-helpers'
+import type { SshConnection } from './ssh-connection'
+import { getRemoteHostPlatform } from './ssh-remote-platform'
+import {
+  computeRelayNativeDepsCacheKey,
+  isRelayNativeDepsCacheEntryName,
+  relayNativeDepsCacheEntryDir,
+  relayNativeDepsCacheNodeModulesPath,
+  supportsRelayNativeDepsCache
+} from './ssh-relay-native-deps-cache'
+import {
+  ensureRelayNativeDepsCacheCommand,
+  promoteRelayNativeDepsCacheCommand,
+  RELAY_NATIVE_CACHE_LIST_OK,
+  RELAY_NATIVE_CACHE_REFS_ERR,
+  RELAY_NATIVE_CACHE_REFS_OK
+} from './ssh-relay-native-deps-cache-commands'
+import { gcRelayNativeDepsCache } from './ssh-relay-native-deps-cache-gc'
+
+const POSIX = getRemoteHostPlatform('linux-x64')
+const WINDOWS = getRemoteHostPlatform('win32-x64')
+const HOME = '/home/u'
+const DEPS = { 'node-pty': '1.1.0', '@parcel/watcher': '2.5.6' } as const
+const KEY = computeRelayNativeDepsCacheKey({ platform: 'linux-x64', deps: DEPS })
+const RELAY_DIR = `${HOME}/.orca-remote/relay-0.1.0+aaa`
+
+const conn = {} as SshConnection
+const mockExec = vi.mocked(execCommand)
+
+function refsOk(...targets: string[]): string {
+  return [...targets.map((t) => `REF ${t}`), RELAY_NATIVE_CACHE_REFS_OK].join('\n')
+}
+
+function listing(...keys: string[]): string {
+  return [...keys.map((k) => `ENTRY ${k}`), RELAY_NATIVE_CACHE_LIST_OK].join('\n')
+}
+
+describe('computeRelayNativeDepsCacheKey', () => {
+  it('keys on the dependency set, not on the relay bundle', () => {
+    expect(computeRelayNativeDepsCacheKey({ platform: 'linux-x64', deps: DEPS })).toBe(KEY)
+    expect(
+      computeRelayNativeDepsCacheKey({
+        platform: 'linux-x64',
+        deps: { '@parcel/watcher': '2.5.6', 'node-pty': '1.1.0' }
+      })
+    ).toBe(KEY)
+  })
+
+  it('mints a new entry when a dependency version moves', () => {
+    expect(
+      computeRelayNativeDepsCacheKey({
+        platform: 'linux-x64',
+        deps: { ...DEPS, 'node-pty': '1.2.0' }
+      })
+    ).not.toBe(KEY)
+  })
+
+  it('mints a new entry when a patch applied to the tree changes', () => {
+    const withPatch = computeRelayNativeDepsCacheKey({
+      platform: 'linux-x64',
+      deps: DEPS,
+      patchSources: [{ filename: 'node-pty-1.1.0-patch.cjs', contents: 'a' }]
+    })
+    const withChangedPatch = computeRelayNativeDepsCacheKey({
+      platform: 'linux-x64',
+      deps: DEPS,
+      patchSources: [{ filename: 'node-pty-1.1.0-patch.cjs', contents: 'b' }]
+    })
+    expect(withPatch).not.toBe(KEY)
+    expect(withChangedPatch).not.toBe(withPatch)
+  })
+
+  it('separates platforms so one host never links another architecture', () => {
+    expect(computeRelayNativeDepsCacheKey({ platform: 'linux-arm64', deps: DEPS })).not.toBe(KEY)
+    expect(KEY.startsWith('linux-x64-')).toBe(true)
+  })
+
+  it('refuses a platform it cannot recognise rather than building a path from it', () => {
+    expect(() => computeRelayNativeDepsCacheKey({ platform: '../../etc', deps: DEPS })).toThrow(
+      /Unsafe relay native-deps cache key/
+    )
+    expect(isRelayNativeDepsCacheEntryName('../../etc')).toBe(false)
+    expect(isRelayNativeDepsCacheEntryName(KEY)).toBe(true)
+  })
+
+  it('leaves Windows on the per-directory install', () => {
+    expect(supportsRelayNativeDepsCache(POSIX)).toBe(true)
+    expect(supportsRelayNativeDepsCache(WINDOWS)).toBe(false)
+  })
+})
+
+describe('ensureRelayNativeDepsCacheCommand', () => {
+  const command = ensureRelayNativeDepsCacheCommand(
+    { host: POSIX, remoteHome: HOME, relayDir: RELAY_DIR, key: KEY },
+    DEPS
+  )
+
+  it('links only an entry that carries the completion sentinel', () => {
+    expect(command).toContain(`[ -f "$cache/.deps-complete" ]`)
+    expect(command).toContain('ln -s "$target" "$nm"')
+    expect(command).toContain(relayNativeDepsCacheNodeModulesPath(POSIX, HOME, KEY))
+  })
+
+  it('never overwrites a directory the relay installed for itself', () => {
+    // The link is only created on a path that does not exist; a real node_modules reads as a miss.
+    expect(command).toContain('if [ ! -e "$nm" ] && ln -s "$target" "$nm"')
+  })
+
+  it('seeds only from a sibling whose manifest pins the same versions', () => {
+    for (const [name, version] of Object.entries(DEPS)) {
+      expect(command).toContain(`grep -F -q '"${name}":"${version}"' "$pj"`)
+    }
+    expect(command).toContain('[ -d "$cand/node-pty" ] || continue')
+  })
+})
+
+describe('promoteRelayNativeDepsCacheCommand', () => {
+  const command = promoteRelayNativeDepsCacheCommand({
+    host: POSIX,
+    remoteHome: HOME,
+    relayDir: RELAY_DIR,
+    key: KEY
+  })
+
+  it('elects one publisher with mkdir rather than a lock', () => {
+    expect(command).toContain('mkdir "$cache" 2>/dev/null')
+  })
+
+  it('writes the completion sentinel after the symlink exists', () => {
+    expect(command.indexOf('ln -s "$target" "$nm"')).toBeLessThan(
+      command.indexOf(': > "$cache/.deps-complete"')
+    )
+  })
+
+  it('never deletes the entry unless the tree made it back to the relay directory', () => {
+    expect(command).toContain('if mv "$target" "$nm" 2>/dev/null; then rm -rf "$cache"')
+  })
+
+  it('refuses to publish a directory that is already a shared symlink', () => {
+    expect(command).toContain('if [ -L "$nm" ]; then')
+  })
+})
+
+describe('gcRelayNativeDepsCache', () => {
+  beforeEach(() => {
+    mockExec.mockReset().mockResolvedValue('')
+  })
+
+  it('removes an entry nothing links to', async () => {
+    mockExec
+      .mockResolvedValueOnce(listing(KEY))
+      .mockResolvedValueOnce(refsOk())
+      .mockResolvedValueOnce('MOVED')
+      .mockResolvedValueOnce(refsOk())
+      .mockResolvedValueOnce('')
+
+    await gcRelayNativeDepsCache(conn, POSIX, HOME)
+
+    const last = mockExec.mock.calls.at(-1)?.[1] ?? ''
+    expect(last).toContain('rm -rf')
+    expect(last).toContain('.gc-tombstone.')
+  })
+
+  it('keeps an entry a live relay depends on', async () => {
+    mockExec
+      .mockResolvedValueOnce(listing(KEY))
+      .mockResolvedValueOnce(refsOk(relayNativeDepsCacheNodeModulesPath(POSIX, HOME, KEY)))
+
+    await gcRelayNativeDepsCache(conn, POSIX, HOME)
+
+    expect(mockExec).toHaveBeenCalledTimes(2)
+    expect(mockExec.mock.calls.some(([, c]) => c.startsWith('rm -rf'))).toBe(false)
+  })
+
+  it('keeps every entry when the reference listing never answers', async () => {
+    mockExec.mockResolvedValueOnce(listing(KEY)).mockResolvedValueOnce('REF /somewhere\n')
+
+    await gcRelayNativeDepsCache(conn, POSIX, HOME)
+
+    expect(mockExec).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps every entry when the reference scan reports an unreadable link', async () => {
+    mockExec.mockResolvedValueOnce(listing(KEY)).mockResolvedValueOnce(RELAY_NATIVE_CACHE_REFS_ERR)
+
+    await gcRelayNativeDepsCache(conn, POSIX, HOME)
+
+    expect(mockExec).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps every entry when a reference has a shape this client never writes', async () => {
+    // A relative target cannot be attributed to an entry without guessing what it resolves to.
+    mockExec
+      .mockResolvedValueOnce(listing(KEY))
+      .mockResolvedValueOnce(refsOk('../native/x/node_modules'))
+
+    await gcRelayNativeDepsCache(conn, POSIX, HOME)
+
+    expect(mockExec).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores a link that points outside the cache entirely', async () => {
+    mockExec
+      .mockResolvedValueOnce(listing(KEY))
+      .mockResolvedValueOnce(refsOk('/opt/shared/node_modules'))
+      .mockResolvedValueOnce('MOVED')
+      .mockResolvedValueOnce(refsOk('/opt/shared/node_modules'))
+      .mockResolvedValueOnce('')
+
+    await gcRelayNativeDepsCache(conn, POSIX, HOME)
+
+    expect(mockExec.mock.calls.some(([, c]) => c.startsWith('rm -rf'))).toBe(true)
+  })
+
+  it('restores the tree when a deploy links the entry after the tombstone rename', async () => {
+    mockExec
+      .mockResolvedValueOnce(listing(KEY))
+      .mockResolvedValueOnce(refsOk())
+      .mockResolvedValueOnce('MOVED')
+      .mockResolvedValueOnce(refsOk(relayNativeDepsCacheNodeModulesPath(POSIX, HOME, KEY)))
+      .mockResolvedValueOnce('MOVED')
+
+    await gcRelayNativeDepsCache(conn, POSIX, HOME)
+
+    const last = mockExec.mock.calls.at(-1)?.[1] ?? ''
+    expect(last).toContain('mv ')
+    expect(last).toContain(relayNativeDepsCacheEntryDir(POSIX, HOME, KEY))
+    expect(mockExec.mock.calls.some(([, c]) => c.startsWith('rm -rf'))).toBe(false)
+  })
+
+  it('restores the tree when the recheck itself cannot answer', async () => {
+    mockExec
+      .mockResolvedValueOnce(listing(KEY))
+      .mockResolvedValueOnce(refsOk())
+      .mockResolvedValueOnce('MOVED')
+      .mockRejectedValueOnce(new Error('channel closed'))
+      .mockResolvedValueOnce('MOVED')
+
+    await gcRelayNativeDepsCache(conn, POSIX, HOME)
+
+    expect(mockExec.mock.calls.some(([, c]) => c.startsWith('rm -rf'))).toBe(false)
+  })
+
+  it('never removes a pinned key', async () => {
+    mockExec.mockResolvedValueOnce(listing(KEY)).mockResolvedValueOnce(refsOk())
+
+    await gcRelayNativeDepsCache(conn, POSIX, HOME, { pinnedKeys: [KEY] })
+
+    expect(mockExec).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops a listed name it could not have minted rather than interpolating it', async () => {
+    mockExec
+      .mockResolvedValueOnce(`ENTRY ../../.ssh\n${RELAY_NATIVE_CACHE_LIST_OK}`)
+      .mockResolvedValueOnce(refsOk())
+
+    await gcRelayNativeDepsCache(conn, POSIX, HOME)
+
+    expect(mockExec).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing on a host that never creates entries', async () => {
+    await gcRelayNativeDepsCache(conn, WINDOWS, 'C:\\Users\\u')
+
+    expect(mockExec).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ssh/ssh-relay-native-deps-cache.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache.ts
@@ -1,0 +1,145 @@
+/**
+ * Where the relay's compiled native dependencies live, and what their identity is keyed on.
+ *
+ * A relay install directory is keyed on the JS bundle hash, which moves on every commit to
+ * `src/relay/` or the `src/shared/` it pulls in. `node_modules` used to live inside it, so a
+ * dependency set that is a pinned constant (`RELAY_NATIVE_DEPS`) was reinstalled — and on Linux,
+ * where node-pty ships no prebuild, recompiled from source — on every new bundle (#18009). The
+ * directory key was coupled to the wrong quantity.
+ *
+ * The tree now lives at `~/.orca-remote/native/<relayPlatform>-<depsHash>/node_modules` and each
+ * relay directory holds a symlink to it. Three rules make one tree safe to share:
+ *
+ * 1. **A published entry is immutable.** `.deps-complete` is written last, only after a probe on
+ *    this host loaded both addons. Nothing installs, rebuilds or resets into a published entry: a
+ *    repair detaches the symlink and installs privately, so a host with a broken toolchain can
+ *    never `rm -rf node_modules/node-pty` out from under a live relay that shares the tree.
+ * 2. **Publication elects one winner with `mkdir`.** The entry either does not exist (this deploy
+ *    builds it privately and promotes it) or is already complete (this deploy links it). There is
+ *    no window in which two deploys write one tree, so no client-side lock is needed.
+ * 3. **Every failure degrades to today's per-directory install.** A host that cannot symlink,
+ *    cannot create the directory, or answers nothing still deploys, one bundle at a time.
+ *
+ * Windows is deliberately excluded. node-pty's npm tarball ships win32 prebuilts, so there is no
+ * compile to avoid there, and `node-pty-1.1.0-console-list-agent-patch.cjs` mutates the installed
+ * tree in place — which rule 1 forbids for a shared one.
+ */
+import { createHash } from 'node:crypto'
+import { RELAY_REMOTE_DIR } from './relay-protocol'
+import { RELAY_BUILD_PLATFORMS } from '../../shared/relay-artifacts'
+import { isWindowsRemoteHost, joinRemotePath, type RemoteHostPlatform } from './ssh-remote-platform'
+
+/** Sibling of `relay-<version>` and `orcad-<version>`; owned by neither model's version GC. */
+export const RELAY_NATIVE_DEPS_CACHE_DIR_NAME = 'native'
+
+/** Written last. Its presence is the only thing that makes an entry linkable. */
+export const RELAY_NATIVE_DEPS_CACHE_COMPLETE_NAME = '.deps-complete'
+
+/** Hidden so the entry listing skips it, and swept by age so a crashed pass drains. */
+export const RELAY_NATIVE_DEPS_CACHE_TOMBSTONE_PREFIX = '.gc-tombstone.'
+
+/**
+ * Bump when the remote install starts mutating the installed tree in a way the hashed inputs
+ * below cannot see — a new `npm rebuild` flag, a new post-install step, a patch applied by
+ * something other than a shipped `node-pty-*` artifact. A published entry is never repaired in
+ * place; only a new key retires it.
+ */
+export const RELAY_NATIVE_DEPS_CACHE_EPOCH = 1
+
+/**
+ * Shipped relay artifacts that patch the installed native tree. Their bytes go into the key, so
+ * changing a patch mints a new entry instead of leaving hosts on a tree built from the old one.
+ */
+export const RELAY_NATIVE_DEPS_PATCH_ARTIFACT_PATTERN = /^node-pty-.*\.(cjs|js|patch)$/
+
+const CACHE_KEY_HASH_LENGTH = 16
+
+const CACHE_ENTRY_NAME_REGEX = new RegExp(
+  `^(${RELAY_BUILD_PLATFORMS.join('|')})-[0-9a-f]{${CACHE_KEY_HASH_LENGTH}}$`
+)
+
+export type RelayNativeDepsCachePatchSource = {
+  filename: string
+  contents: string
+}
+
+/**
+ * `<relayPlatform>-<sha256 prefix>` over the dependency set, the epoch, and every patch the
+ * remote install applies. Platform and arch stay in the name rather than the hash so an operator
+ * reading `~/.orca-remote/native/` can tell what an entry is for.
+ */
+export function computeRelayNativeDepsCacheKey(input: {
+  platform: string
+  deps: Readonly<Record<string, string>>
+  patchSources?: readonly RelayNativeDepsCachePatchSource[]
+}): string {
+  const hash = createHash('sha256')
+  hash.update(`epoch ${RELAY_NATIVE_DEPS_CACHE_EPOCH}\n`)
+  for (const [name, version] of Object.entries(input.deps).sort(([a], [b]) => (a < b ? -1 : 1))) {
+    hash.update(`dep ${name} ${version}\n`)
+  }
+  const patches = [...(input.patchSources ?? [])].sort((a, b) => (a.filename < b.filename ? -1 : 1))
+  for (const patch of patches) {
+    hash.update(
+      `patch ${patch.filename} ${createHash('sha256').update(patch.contents).digest('hex')}\n`
+    )
+  }
+  const key = `${input.platform}-${hash.digest('hex').slice(0, CACHE_KEY_HASH_LENGTH)}`
+  if (!isRelayNativeDepsCacheEntryName(key)) {
+    // Why: the key reaches the host inside `mv` and `rm -rf`; an unrecognized platform must
+    // disable the cache rather than arrive as a path fragment nobody validated.
+    throw new Error(`Unsafe relay native-deps cache key: ${JSON.stringify(key)}`)
+  }
+  return key
+}
+
+/**
+ * Whether a name the host listed is one this client may move or delete. Every GC candidate goes
+ * through here before it reaches a shell.
+ */
+export function isRelayNativeDepsCacheEntryName(name: string): boolean {
+  return CACHE_ENTRY_NAME_REGEX.test(name)
+}
+
+/** `~/.orca-remote` — the parent both relay dirs and the cache sit under. */
+export function remoteInstallRootDir(host: RemoteHostPlatform, remoteHome: string): string {
+  return joinRemotePath(host, remoteHome, RELAY_REMOTE_DIR)
+}
+
+/** `~/.orca-remote/native` */
+export function relayNativeDepsCacheBaseDir(host: RemoteHostPlatform, remoteHome: string): string {
+  return joinRemotePath(
+    host,
+    remoteInstallRootDir(host, remoteHome),
+    RELAY_NATIVE_DEPS_CACHE_DIR_NAME
+  )
+}
+
+/** `~/.orca-remote/native/<key>` */
+export function relayNativeDepsCacheEntryDir(
+  host: RemoteHostPlatform,
+  remoteHome: string,
+  key: string
+): string {
+  if (!isRelayNativeDepsCacheEntryName(key)) {
+    throw new Error(`Unsafe relay native-deps cache key: ${JSON.stringify(key)}`)
+  }
+  return joinRemotePath(host, relayNativeDepsCacheBaseDir(host, remoteHome), key)
+}
+
+/** `~/.orca-remote/native/<key>/node_modules` — the symlink target, and the reference identity. */
+export function relayNativeDepsCacheNodeModulesPath(
+  host: RemoteHostPlatform,
+  remoteHome: string,
+  key: string
+): string {
+  return joinRemotePath(host, relayNativeDepsCacheEntryDir(host, remoteHome, key), 'node_modules')
+}
+
+/**
+ * Windows hosts install node-pty from an npm prebuilt and then patch the tree in place, so they
+ * keep the per-directory install. Nothing else about their deploy changes.
+ */
+export function supportsRelayNativeDepsCache(host: RemoteHostPlatform): boolean {
+  return !isWindowsRemoteHost(host)
+}

--- a/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
@@ -64,7 +64,9 @@ export function makeStagedFirstInstallExecPrefix(): ExecResponse[] {
     `__ORCA_UPLOAD_STAGE_SLOT__${STAGE_OWNER}:slot-0`,
     '', // chmod staged node
     '', // final install namespace marker
-    `__ORCA_UPLOAD_STAGE_PROMOTION__${STAGE_OWNER}:PROMOTED`
+    `__ORCA_UPLOAD_STAGE_PROMOTION__${STAGE_OWNER}:PROMOTED`,
+    // Shared native-deps cache probe; an empty answer is a miss, so the per-directory install runs.
+    ''
   ]
 }
 
@@ -168,8 +170,10 @@ export function makeExecResponses(opts: {
   ]
   // Cleanup execs only run when the probe resolved (not when it rejected).
   const probeResolved = typeof probeSlot === 'string'
+  let loadable = false
   if (probeResolved) {
     const probeOk = probeSlot.includes('ORCA-NPTY-PROBE-OK')
+    loadable = probeOk
     if (!probeOk) {
       slots.push('') // cat stderr (graceful failure path captures detail)
     }
@@ -179,11 +183,16 @@ export function makeExecResponses(opts: {
       slots.push('') // chmod prebuilds after rebuild
       const repairProbe = opts.repairProbe === 'ok' ? 'ORCA-NPTY-PROBE-OK\n' : 'MISSING\n'
       slots.push(repairProbe)
-      if (!repairProbe.includes('ORCA-NPTY-PROBE-OK')) {
+      loadable = repairProbe.includes('ORCA-NPTY-PROBE-OK')
+      if (!loadable) {
         slots.push('') // cat stderr after unsuccessful rebuild
       }
       slots.push('') // rm -f stderr after rebuild probe
     }
+  }
+  // Publication is gated on the probe: only a tree this host actually loaded is shared.
+  if (loadable) {
+    slots.push('') // promote the private tree into the shared native-deps cache
   }
   slots.push('', 'DEAD', '', 'READY') // clean stage root, launch, credential, readiness
   return slots

--- a/src/main/ssh/ssh-relay-sftp-namespace-install.test.ts
+++ b/src/main/ssh/ssh-relay-sftp-namespace-install.test.ts
@@ -250,10 +250,12 @@ const POSIX_FIRST_INSTALL = [
   '', // chmod staged node
   '', // final install namespace marker
   STAGE_PROMOTED,
+  '', // shared native-deps cache probe (miss)
   '', // npm install native deps
   '', // chmod prebuilds
   'ORCA-NPTY-PROBE-OK\n',
   '', // rm probe stderr
+  '', // promote into the shared native-deps cache
   '', // clean stage root
   'DEAD',
   '', // publish the per-launch credential
@@ -267,10 +269,12 @@ const POSIX_SYSTEM_SSH_FIRST_INSTALL = [
   STAGE_RESERVED,
   '', // chmod staged node
   STAGE_PROMOTED,
+  '', // shared native-deps cache probe (miss)
   '', // npm install native deps
   '', // chmod prebuilds
   'ORCA-NPTY-PROBE-OK\n',
   '', // rm probe stderr
+  '', // promote into the shared native-deps cache
   '', // clean stage root
   'DEAD',
   '', // publish the per-launch credential


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​825 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​825 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​911 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​904 |

<!-- /orca-pr-loc -->

Closes the first option in #18009 — **item A's root cause**. Removes the recompile that happens on every relay bundle change.

## ELI5

Relay `node_modules` lived **inside** the bundle-hash-keyed directory `~/.orca-remote/relay-<version>+<hash>`, with no reuse path and GC deleting the old dir wholesale. So **any byte change in `src/relay/` or the `src/shared/` it pulls in** minted a new directory and a fresh `npm install` — a node-gyp **source compile** on Linux, since node-pty ships no Linux prebuild.

Measured: 105 commits touched `src/relay` and 501 touched `src/shared` in 30 days, across **31 of 31 days**. `NATIVE_DEPS_COMMAND_TIMEOUT_MS` is 240s inside a 900s deploy budget — **eight of the fifteen deploy minutes were native deps**, on a dependency set that is a pinned constant and hasn't changed in this sweep.

The directory key was coupled to the wrong quantity: identity churned at the rate of the JS bundle, while the expensive contents changed approximately never.

Now `node_modules` lives at `~/.orca-remote/native/<relayPlatform>-<depsHash>/node_modules`, and each relay directory holds a symlink to it. `depsHash` covers `RELAY_NATIVE_DEPS`, an explicit epoch constant, **and the bytes of every shipped `node-pty-*` patch artifact** — so a patch change mints a new entry rather than leaving hosts on a tree built from the old one.

## The four design questions, answered with evidence

**1. Link, not copy.** `probeInstalledNativeDeps` runs `node -e require(...)` with cwd = the relay dir, and `makeNodePtySpawnHelperExecutable` runs `find <relayDir>/node_modules/node-pty/prebuilds`. Both resolve through the symlink unchanged — **neither needed a code change**. Node realpaths module paths, so node-pty and `@parcel/watcher` load their own siblings out of the shared tree.

**Windows is excluded rather than given a junction**, and deliberately: node-pty's npm tarball already ships win32 prebuilts (no compile to avoid), and `node-pty-1.1.0-console-list-agent-patch.cjs` mutates the installed tree **in place**, which the immutability rule forbids for a shared one. The defect is Linux-only.

**2. GC is reference-based, not refcounted — and did not need to be a bigger project.** The symlink *is* the reference, so there is no counter to drift. `remote-install-gc.ts`'s discipline is carried over verbatim: a listing that doesn't end in its own OK token, an unreadable link, or a reference shape this client never writes **aborts the whole pass**, not just that candidate. Deletion is the same three-step move — tombstone-rename → re-read references under the rename → remove — so a deploy that linked between the listing and the rename shows up in the recheck and gets its tree moved back.

**3. No lock was needed, and `ssh-relay-install-lock.ts` is deliberately not invoked.** Publication elects with `mkdir "$cache"`, which is atomic and yields exactly one winner; a loser keeps its own tree. Because a published entry is **immutable**, there is no window where two deploys write one tree — the lock would have guarded nothing and added ~8 execs to the miss path. The crashed-winner case (entry exists, no `.deps-complete`) is reclaimed by an age rule, safe precisely because nothing links an entry until it is complete.

**4. Migration seeds from an existing install.** A first deploy on an existing host seeds by `cp -Rp` from a sibling `relay-*/node_modules` whose `package.json` pins the same versions **and** still has node-pty (so a toolchain-skip install can't qualify) — no recompile, no network. The seed isn't trusted: it stays a private install until the normal probe loads it, and only then is it published.

## The hazard this could have introduced

A repair does `rm -rf node_modules/node-pty` — which through a shared symlink would be **every relay on the host losing its addon**. Two things close it: repairs opt out of the cache entirely (`resetDeps.length === 0` gate), and every `npm install` is prefixed with `if [ -L node_modules ]; then rm -f node_modules; fi;` — zero extra execs, since it rides the existing install exec. A linked entry that fails to load falls back to a private install for that directory and never repairs the shared one.

## Exec-count impact

Cache **hit: net zero** (the ensure exec replaces the `npm install` exec). Miss: +2. Repair and Windows: unchanged, so `makeRepairToolchainSkipExecResponses` and the repair sequences needed no edits.

## User-facing regressions

**None expected.** The fallback is intact: if the cache cannot be created or used, the deploy proceeds with today's per-directory install.

One accepted limitation, documented in the module header: if a published entry later stops loading (a host-level Node or glibc change), each relay directory heals itself privately at today's cost, and the entry is not invalidated — invalidating in place would mean deleting a tree a running relay may hold.

## Testing

`pnpm test src/main/ssh`: baseline **1798 passed**; after **1855 passed**, 16 skipped. No pre-existing test changed its assertions except two fixture slots.

Before/after on the six required deploy behaviours — with `ssh-relay-deploy.ts` stashed to its pre-change state: `Tests 6 failed | 1 passed (7)`, including the headline `× runs no npm install when a different bundle finds a complete entry on the host`. Restored: `Tests 7 passed (7)`.

`ssh-relay-native-deps-cache-shell.test.ts` runs the **real scripts against a real temp tree under both `/bin/sh` and `dash`** (Debian/Ubuntu's `/bin/sh`) — 26 tests covering publish/link/seed, one-winner election, a loser keeping its tree, and `rm -rf` of a linked relay dir leaving the shared tree intact. Asserting on command strings could not have shown any of that.

`tc:node` clean; `check:code-quality:changed` 0 findings across 11 files.

## Note on the alternative

#1693 (prebuilt slots) was assessed and is much further away — the CI matrix does not exist, `build-orcad-prebuilds.mjs` cannot produce a Linux slot, nothing ships the prebuilds directory, and the `nodeAbi` gate would reject on every real host since the relay borrows the host's Node. See the correction comment on #18009. This PR needs none of that.
