### PR TITLE
perf(worktrees): gate worktree metadata hygiene on evidence, not on every listing

### DIFF
--- a/src/main/ipc/worktrees/listing/authoritative-local-worktree-metadata-pruning.ts
+++ b/src/main/ipc/worktrees/listing/authoritative-local-worktree-metadata-pruning.ts
@@ -85,7 +85,12 @@ export async function pruneMetadataMissingFromAuthoritativeLocalScan({
     worktreeRetentionPathComparisonKey(repo.path, platform),
     ...gitWorktrees.map((worktree) => worktreeRetentionPathComparisonKey(worktree.path, platform))
   ])
-  const probeCandidates = scan.metadata.flatMap((metadata) => {
+  // Why: only rows a delete could still accept are worth a filesystem probe. This is advisory —
+  // `pruneSessionlessMissingLocalWorktreeMetadataForRepo` re-checks authoritatively — so it can only
+  // ever shrink the `stat` fan-out, never widen what gets removed (#17775).
+  const removableCandidates =
+    store.selectProbeableLocalWorktreeMetadataCandidates?.(scan) ?? scan.metadata
+  const probeCandidates = removableCandidates.flatMap((metadata) => {
     const { worktreeId } = metadata
     const parsed = splitWorktreeId(worktreeId)
     const nativeAbsolute = parsed

--- a/src/main/ipc/worktrees/listing/detected-provider-listing.ts
+++ b/src/main/ipc/worktrees/listing/detected-provider-listing.ts
@@ -51,6 +51,7 @@ export async function listDetectedWorktreesForCapturedRepo(
     let freshScan = true
     let sideEffectToken: DetectedWorktreeSideEffectToken | undefined
     let metadataPrune: DetectedWorktreeMetadataPrune | undefined
+    let hygieneDue: boolean | undefined
     if (isFolderRepo(repo)) {
       if (!isCurrent()) {
         return null
@@ -102,6 +103,7 @@ export async function listDetectedWorktreesForCapturedRepo(
       freshScan = scan.fresh
       sideEffectToken = scan.sideEffectToken
       metadataPrune = scan.metadataPrune
+      hygieneDue = scan.hygieneDue
     }
     const aborted = abortedResult()
     if (aborted) {
@@ -123,7 +125,8 @@ export async function listDetectedWorktreesForCapturedRepo(
       await applyFreshDetectedWorktreeScanSideEffects(store, repo, gitWorktrees, metadataPrune, {
         isCurrent: () => isCurrent() && !providerAbort?.signal.aborted,
         sideEffectToken,
-        signal: providerAbort?.signal
+        signal: providerAbort?.signal,
+        ...(hygieneDue === undefined ? {} : { hygieneDue })
       })
       const aborted = abortedResult()
       if (aborted) {

--- a/src/main/ipc/worktrees/listing/detected-worktree-scan-cache.ts
+++ b/src/main/ipc/worktrees/listing/detected-worktree-scan-cache.ts
@@ -16,6 +16,13 @@ import {
   resetLocalWorktreeScanGenerationsForTests
 } from '../../../local-worktree-scan-generation'
 import { pruneLineageForMissingRepoWorktrees } from '../../../worktree-lineage-pruning'
+import {
+  __resetLocalWorktreeMetadataPruneGateForTests,
+  isLocalWorktreeMetadataPruneDue,
+  markLocalWorktreeMetadataPruneStarted,
+  recordLocalWorktreeListingForPruneGate,
+  requireLocalWorktreeMetadataPrune
+} from '../../../local-worktree-metadata-prune-gate'
 import { pruneMetadataMissingFromAuthoritativeLocalScan } from './authoritative-local-worktree-metadata-pruning'
 
 // Why: absorb renderer polling bursts while bounding external worktree-change lag to one short refresh window.
@@ -30,6 +37,7 @@ export type DetectedWorktreeScan = {
   invalidated: boolean
   promise: Promise<GitWorktreeInfo[]>
   sideEffectToken: DetectedWorktreeSideEffectToken
+  hygieneDue: boolean
   metadataPrune?: DetectedWorktreeMetadataPrune
 }
 
@@ -46,6 +54,8 @@ export type DetectedWorktreeScanResult = {
   gitWorktrees: GitWorktreeInfo[]
   fresh: boolean
   sideEffectToken?: DetectedWorktreeSideEffectToken
+  /** Whether this scan owns the repo's next store-hygiene pass; absent means "not from a local scan". */
+  hygieneDue?: boolean
   metadataPrune?: DetectedWorktreeMetadataPrune
 }
 
@@ -54,6 +64,7 @@ export const detectedWorktreeScanInFlight = new Map<string, DetectedWorktreeScan
 
 export function invalidateDetectedWorktreeScanCache(repoId: string): void {
   bumpLocalWorktreeScanGeneration(repoId)
+  requireLocalWorktreeMetadataPrune(repoId)
   const keyPrefix = `${repoId}\0`
   for (const key of new Set([
     ...detectedWorktreeScanCache.keys(),
@@ -80,6 +91,7 @@ export function __resetDetectedWorktreeScanCacheForTests(): void {
   detectedWorktreeScanCache.clear()
   detectedWorktreeScanInFlight.clear()
   resetLocalWorktreeScanGenerationsForTests()
+  __resetLocalWorktreeMetadataPruneGateForTests()
 }
 
 export function __getDetectedWorktreeScanCacheStatsForTests(): {
@@ -120,13 +132,21 @@ export async function listDetectedGitWorktrees(
   // those aliases equivalent, so only native-host scans carry destructive expectations.
   const generation = getLocalWorktreeScanGeneration(repo.id)
   const authorizedRootsRevision = getRegisteredWorktreeRootsRevision(repo.id)
-  const metadataPruneExpectation = localWorktreeGitOptions.wslDistro
-    ? undefined
-    : store.captureNativeLocalWorktreeMetadataScanExpectation(repo)
+  // Why: capturing the expectation walks the repo's whole metadata table and the prune that follows
+  // stats every path-missing row, so both run only against evidence that the answer changed (#17775).
+  const hygieneDue = isLocalWorktreeMetadataPruneDue(repo.id)
+  if (hygieneDue) {
+    markLocalWorktreeMetadataPruneStarted(repo.id)
+  }
+  const metadataPruneExpectation =
+    hygieneDue && !localWorktreeGitOptions.wslDistro
+      ? store.captureNativeLocalWorktreeMetadataScanExpectation(repo)
+      : undefined
   const scan: DetectedWorktreeScan = {
     invalidated: false,
     promise: listRepoWorktrees(repo, localWorktreeGitOptions),
     sideEffectToken: { generation, authorizedRootsRevision },
+    hygieneDue,
     ...(metadataPruneExpectation
       ? {
           metadataPrune: {
@@ -138,6 +158,12 @@ export async function listDetectedGitWorktrees(
   detectedWorktreeScanInFlight.set(cacheKey, scan)
   try {
     const gitWorktrees = await scan.promise
+    // Why: the backstop signal. A listing that no longer matches the one the last pass ran against
+    // invalidates its conclusions even when no event reported the change.
+    recordLocalWorktreeListingForPruneGate(
+      repo.id,
+      gitWorktrees.map((worktree) => worktree.path)
+    )
     const routingUnchanged =
       getDetectedWorktreeScanCacheKey(repo.id, getLocalProjectWorktreeGitOptions(store, repo)) ===
       cacheKey
@@ -153,7 +179,7 @@ export async function listDetectedGitWorktrees(
     return {
       gitWorktrees,
       fresh,
-      ...(fresh ? { sideEffectToken: scan.sideEffectToken } : {}),
+      ...(fresh ? { sideEffectToken: scan.sideEffectToken, hygieneDue: scan.hygieneDue } : {}),
       ...(fresh && scan.metadataPrune ? { metadataPrune: scan.metadataPrune } : {})
     }
   } finally {
@@ -172,9 +198,11 @@ export async function applyFreshDetectedWorktreeScanSideEffects(
     isCurrent?: () => boolean
     sideEffectToken?: DetectedWorktreeSideEffectToken
     signal?: AbortSignal
+    /** Undefined means the caller owns no cadence (non-local providers); it keeps the eager behavior. */
+    hygieneDue?: boolean
   } = {}
 ): Promise<boolean> {
-  const { isCurrent = () => true, sideEffectToken, signal } = options
+  const { isCurrent = () => true, sideEffectToken, signal, hygieneDue = true } = options
   const generationCurrent = () =>
     sideEffectToken === undefined ||
     isLocalWorktreeScanGenerationCurrent(repo.id, sideEffectToken.generation)
@@ -211,12 +239,17 @@ export async function applyFreshDetectedWorktreeScanSideEffects(
     return false
   }
   rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-  pruneLineageForMissingRepoWorktrees(
-    store,
-    repo,
-    gitWorktrees,
-    preservedMetadataCandidateIds ? { preservedMetadataCandidateIds } : undefined
-  )
+  // Why: lineage retention is decided against the metadata rows the prune preserved, so running it
+  // without that pass would drop lineage for rows the pass would have kept. Both halves share the
+  // hygiene cadence instead.
+  if (hygieneDue) {
+    pruneLineageForMissingRepoWorktrees(
+      store,
+      repo,
+      gitWorktrees,
+      preservedMetadataCandidateIds ? { preservedMetadataCandidateIds } : undefined
+    )
+  }
   return true
 }
 

--- a/src/main/ipc/worktrees/listing/detected-worktree-scan-hygiene-gate.test.ts
+++ b/src/main/ipc/worktrees/listing/detected-worktree-scan-hygiene-gate.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import type { GitWorktreeInfo } from '../../../../shared/worktree/types'
+
+const { listRepoWorktreesMock, pruneLineageMock, pruneMetadataMock, registerWorktreeRootsMock } =
+  vi.hoisted(() => ({
+    listRepoWorktreesMock: vi.fn(),
+    pruneLineageMock: vi.fn(),
+    pruneMetadataMock: vi.fn(),
+    registerWorktreeRootsMock: vi.fn()
+  }))
+
+vi.mock('../../../repo-worktrees', () => ({ listRepoWorktrees: listRepoWorktreesMock }))
+vi.mock('../../../project-runtime-git-options', () => ({
+  getLocalProjectWorktreeGitOptions: () => ({})
+}))
+vi.mock('../../registered-worktree-roots-cache', () => ({
+  getRegisteredWorktreeRootsRevision: () => 1,
+  registerWorktreeRootsForRepo: registerWorktreeRootsMock
+}))
+vi.mock('../../../worktree-lineage-pruning', () => ({
+  pruneLineageForMissingRepoWorktrees: pruneLineageMock
+}))
+vi.mock('./authoritative-local-worktree-metadata-pruning', () => ({
+  pruneMetadataMissingFromAuthoritativeLocalScan: pruneMetadataMock
+}))
+
+const {
+  DETECTED_WORKTREE_SCAN_CACHE_TTL_MS,
+  __resetDetectedWorktreeScanCacheForTests,
+  applyFreshDetectedWorktreeScanSideEffects,
+  invalidateDetectedWorktreeScanCache,
+  listDetectedGitWorktrees
+} = await import('./detected-worktree-scan-cache')
+const { invalidateLocalWorktreeMetadataPruneInputs } =
+  await import('../../../local-worktree-metadata-prune-gate')
+
+const repo = { id: 'repo-1', path: '/repos/one', displayName: 'one' } as Repo
+
+function worktreeAt(path: string): GitWorktreeInfo {
+  return { path, head: 'abc', branch: 'main', isBare: false, isMainWorktree: path === repo.path }
+}
+
+const captureExpectation = vi.fn(() => ({ repo: { id: repo.id }, metadata: [] }))
+const store = { captureNativeLocalWorktreeMetadataScanExpectation: captureExpectation } as never
+
+/** Each listing must miss the TTL cache, the way a renderer poll past the window does. */
+function advancePastListingTtl(): void {
+  vi.setSystemTime(Date.now() + DETECTED_WORKTREE_SCAN_CACHE_TTL_MS + 1)
+}
+
+describe('detected worktree scan hygiene gate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    listRepoWorktreesMock.mockReset().mockResolvedValue([worktreeAt(repo.path)])
+    captureExpectation.mockClear()
+    pruneLineageMock.mockReset()
+    pruneMetadataMock
+      .mockReset()
+      .mockResolvedValue({ scanGenerationCurrent: true, preservedMetadataCandidateIds: new Set() })
+    registerWorktreeRootsMock.mockReset()
+    __resetDetectedWorktreeScanCacheForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('runs hygiene once and then never again while nothing changes', async () => {
+    const first = await listDetectedGitWorktrees(store, repo)
+    expect(first.hygieneDue).toBe(true)
+    expect(first.metadataPrune).toBeDefined()
+
+    for (let poll = 0; poll < 20; poll += 1) {
+      advancePastListingTtl()
+      const scan = await listDetectedGitWorktrees(store, repo)
+      expect(scan.fresh).toBe(true)
+      expect(scan.hygieneDue).toBe(false)
+      expect(scan.metadataPrune).toBeUndefined()
+    }
+    expect(captureExpectation).toHaveBeenCalledTimes(1)
+  })
+
+  it('still lists on every cache miss while hygiene is parked', async () => {
+    await listDetectedGitWorktrees(store, repo)
+    advancePastListingTtl()
+    await listDetectedGitWorktrees(store, repo)
+
+    expect(listRepoWorktreesMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-runs hygiene after a worktree lifecycle event', async () => {
+    await listDetectedGitWorktrees(store, repo)
+    invalidateDetectedWorktreeScanCache(repo.id)
+
+    expect((await listDetectedGitWorktrees(store, repo)).hygieneDue).toBe(true)
+    expect(captureExpectation).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-runs hygiene when ownership state may have released a row', async () => {
+    await listDetectedGitWorktrees(store, repo)
+    advancePastListingTtl()
+    expect((await listDetectedGitWorktrees(store, repo)).hygieneDue).toBe(false)
+
+    invalidateLocalWorktreeMetadataPruneInputs()
+
+    advancePastListingTtl()
+    expect((await listDetectedGitWorktrees(store, repo)).hygieneDue).toBe(true)
+    expect(captureExpectation).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-runs hygiene when the listing changes with no event to report it', async () => {
+    await listDetectedGitWorktrees(store, repo)
+    advancePastListingTtl()
+    expect((await listDetectedGitWorktrees(store, repo)).hygieneDue).toBe(false)
+
+    // An external `git worktree remove` nobody notified us about.
+    listRepoWorktreesMock.mockResolvedValue([worktreeAt(repo.path), worktreeAt('/repos/one-wt')])
+    advancePastListingTtl()
+    await listDetectedGitWorktrees(store, repo)
+
+    advancePastListingTtl()
+    expect((await listDetectedGitWorktrees(store, repo)).hygieneDue).toBe(true)
+  })
+
+  it('skips both prune halves on a scan that does not own the hygiene pass', async () => {
+    await applyFreshDetectedWorktreeScanSideEffects(
+      store,
+      repo,
+      [worktreeAt(repo.path)],
+      undefined,
+      {
+        hygieneDue: false
+      }
+    )
+
+    expect(pruneMetadataMock).not.toHaveBeenCalled()
+    expect(pruneLineageMock).not.toHaveBeenCalled()
+    // Authorized roots are listing state, not hygiene; they must still be refreshed.
+    expect(registerWorktreeRootsMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('prunes lineage when the caller owns the hygiene pass', async () => {
+    await applyFreshDetectedWorktreeScanSideEffects(
+      store,
+      repo,
+      [worktreeAt(repo.path)],
+      undefined,
+      {
+        hygieneDue: true
+      }
+    )
+
+    expect(pruneLineageMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the eager behavior for callers that carry no gate', async () => {
+    await applyFreshDetectedWorktreeScanSideEffects(store, repo, [worktreeAt(repo.path)])
+
+    expect(pruneLineageMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ipc/worktrees/listing/register-worktree-catalog-handlers.ts
+++ b/src/main/ipc/worktrees/listing/register-worktree-catalog-handlers.ts
@@ -91,6 +91,7 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
         let freshScan = true
         let sideEffectToken: DetectedWorktreeSideEffectToken | undefined
         let metadataPrune: DetectedWorktreeMetadataPrune | undefined
+        let hygieneDue: boolean | undefined
         if (isFolderRepo(repo)) {
           return listVisibleFolderWorkspaces(store, repo)
         } else if (repo.connectionId) {
@@ -121,6 +122,7 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
           freshScan = scan.fresh
           sideEffectToken = scan.sideEffectToken
           metadataPrune = scan.metadataPrune
+          hygieneDue = scan.hygieneDue
         }
         if (freshScan) {
           await applyFreshDetectedWorktreeScanSideEffects(
@@ -129,7 +131,8 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
             gitWorktrees,
             metadataPrune,
             {
-              sideEffectToken
+              sideEffectToken,
+              ...(hygieneDue === undefined ? {} : { hygieneDue })
             }
           )
         }
@@ -183,6 +186,7 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
       let freshScan = true
       let sideEffectToken: DetectedWorktreeSideEffectToken | undefined
       let metadataPrune: DetectedWorktreeMetadataPrune | undefined
+      let hygieneDue: boolean | undefined
       if (isFolderRepo(repo)) {
         return listVisibleFolderWorkspaces(store, repo)
       } else if (repo.connectionId) {
@@ -213,10 +217,12 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
         freshScan = scan.fresh
         sideEffectToken = scan.sideEffectToken
         metadataPrune = scan.metadataPrune
+        hygieneDue = scan.hygieneDue
       }
       if (freshScan) {
         await applyFreshDetectedWorktreeScanSideEffects(store, repo, gitWorktrees, metadataPrune, {
-          sideEffectToken
+          sideEffectToken,
+          ...(hygieneDue === undefined ? {} : { hygieneDue })
         })
       }
       loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)

--- a/src/main/local-worktree-metadata-prune-gate.test.ts
+++ b/src/main/local-worktree-metadata-prune-gate.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  __resetLocalWorktreeMetadataPruneGateForTests,
+  forgetLocalWorktreeMetadataPruneGate,
+  invalidateLocalWorktreeMetadataPruneInputs,
+  isLocalWorktreeMetadataPruneDue,
+  markLocalWorktreeMetadataPruneStarted,
+  recordLocalWorktreeListingForPruneGate,
+  requireLocalWorktreeMetadataPrune
+} from './local-worktree-metadata-prune-gate'
+
+describe('local worktree metadata prune gate', () => {
+  beforeEach(() => {
+    __resetLocalWorktreeMetadataPruneGateForTests()
+  })
+
+  it('is due for a repo it has never seen', () => {
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(true)
+  })
+
+  it('stays undue indefinitely once a pass ran and nothing changed', () => {
+    markLocalWorktreeMetadataPruneStarted('repo-1')
+
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(false)
+    recordLocalWorktreeListingForPruneGate('repo-1', ['/a', '/b'])
+    recordLocalWorktreeListingForPruneGate('repo-1', ['/b', '/a'])
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(false)
+  })
+
+  it('re-arms one repo on its own worktree lifecycle event', () => {
+    markLocalWorktreeMetadataPruneStarted('repo-1')
+    markLocalWorktreeMetadataPruneStarted('repo-2')
+
+    requireLocalWorktreeMetadataPrune('repo-1')
+
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(true)
+    expect(isLocalWorktreeMetadataPruneDue('repo-2')).toBe(false)
+  })
+
+  it('re-arms every repo when ownership state may have released a row', () => {
+    markLocalWorktreeMetadataPruneStarted('repo-1')
+    markLocalWorktreeMetadataPruneStarted('repo-2')
+
+    invalidateLocalWorktreeMetadataPruneInputs()
+
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(true)
+    expect(isLocalWorktreeMetadataPruneDue('repo-2')).toBe(true)
+  })
+
+  it('runs each repo once per invalidation, not once per scan', () => {
+    invalidateLocalWorktreeMetadataPruneInputs()
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(true)
+    markLocalWorktreeMetadataPruneStarted('repo-1')
+
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(false)
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(false)
+  })
+
+  it('does not re-arm on the first listing it observes', () => {
+    markLocalWorktreeMetadataPruneStarted('repo-1')
+
+    recordLocalWorktreeListingForPruneGate('repo-1', ['/a'])
+
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(false)
+  })
+
+  it('re-arms when a later listing differs from the one the last pass ran against', () => {
+    recordLocalWorktreeListingForPruneGate('repo-1', ['/a', '/b'])
+    markLocalWorktreeMetadataPruneStarted('repo-1')
+
+    recordLocalWorktreeListingForPruneGate('repo-1', ['/a'])
+
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(true)
+  })
+
+  it('drops gate state for a deregistered repo', () => {
+    recordLocalWorktreeListingForPruneGate('repo-1', ['/a'])
+    markLocalWorktreeMetadataPruneStarted('repo-1')
+
+    forgetLocalWorktreeMetadataPruneGate('repo-1')
+
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(true)
+    // The forgotten fingerprint must not later read as a change against a stale entry.
+    recordLocalWorktreeListingForPruneGate('repo-1', ['/a'])
+    markLocalWorktreeMetadataPruneStarted('repo-1')
+    expect(isLocalWorktreeMetadataPruneDue('repo-1')).toBe(false)
+  })
+})

--- a/src/main/local-worktree-metadata-prune-gate.ts
+++ b/src/main/local-worktree-metadata-prune-gate.ts
@@ -89,3 +89,15 @@ export function __resetLocalWorktreeMetadataPruneGateForTests(): void {
   observedGenerationByRepo.clear()
   listingFingerprintByRepo.clear()
 }
+
+/** Repo teardown: a full removal retires this repo's gate, and either shape can unpin rows in
+ *  other repos, so the shared inputs are always re-armed. */
+export function retireLocalWorktreeMetadataPruneStateForRepo(
+  repoId: string,
+  hostId: string | null
+): void {
+  if (hostId === null) {
+    forgetLocalWorktreeMetadataPruneGate(repoId)
+  }
+  invalidateLocalWorktreeMetadataPruneInputs()
+}

--- a/src/main/local-worktree-metadata-prune-gate.ts
+++ b/src/main/local-worktree-metadata-prune-gate.ts
@@ -1,0 +1,91 @@
+/**
+ * Decides whether a detected-worktree scan owes the store a metadata-hygiene pass.
+ *
+ * The pass captures a prune expectation over the repo's whole metadata table, `stat`s every
+ * path-missing candidate, then prunes metadata and lineage. That is O(all rows) and destructive, so
+ * it must not ride a polled read path: on a store whose dangling rows outnumber live worktrees
+ * ~100:1 it re-derives an answer it already has, forever, pinning the main process in filesystem
+ * completion callbacks (#17775). Rows pinned by a persisted session are never removable, so the
+ * repetition cannot even make progress.
+ *
+ * Nothing the pass reads changes on its own, so it is gated on evidence rather than a clock:
+ *  - a worktree lifecycle event for the repo (the existing worktree-change invalidator hub),
+ *  - a mutation that can make some row *more* removable (see `invalidate…PruneInputs`),
+ *  - the repo's git listing differing from the one the last pass ran against.
+ * With none of those, the pass is a provable repeat and is skipped outright.
+ *
+ * Why only "more removable" mutations count: the listing path itself writes worktree metadata
+ * (discovery backfill, host-ownership stamping), so bumping on every metadata write would re-arm
+ * the gate from the very scan it gates and restore the storm. Additions and updates can only
+ * preserve more rows, so staleness there is harmless.
+ *
+ * The failure direction is deliberate. A signal we miss leaves a dangling row in place until the
+ * next one arrives — hygiene lags, and nothing is deleted that would not have been deleted anyway.
+ */
+
+/** Bumped by evidence that some row may have become removable; repos re-run the pass once each. */
+let pruneInputsGeneration = 0
+const observedGenerationByRepo = new Map<string, number>()
+const listingFingerprintByRepo = new Map<string, string>()
+
+/** True until the repo has run a pass against the current generation — so also on the first scan. */
+export function isLocalWorktreeMetadataPruneDue(repoId: string): boolean {
+  return observedGenerationByRepo.get(repoId) !== pruneInputsGeneration
+}
+
+/**
+ * Claim the pending pass. Recorded when the expectation is captured rather than when the prune
+ * finishes: a scan that is invalidated or fails mid-flight must not re-arm the full capture on the
+ * very next listing poll, and any real change re-bumps the generation anyway.
+ */
+export function markLocalWorktreeMetadataPruneStarted(repoId: string): void {
+  observedGenerationByRepo.set(repoId, pruneInputsGeneration)
+}
+
+/** One repo's worktrees changed (create/remove/rename). */
+export function requireLocalWorktreeMetadataPrune(repoId: string): void {
+  observedGenerationByRepo.delete(repoId)
+}
+
+/**
+ * Some metadata row may have become removable — a worktree-meta/identity/lineage row was deleted,
+ * or a session, lease, automation or selection released its claim on a workspace. Repo-agnostic
+ * because ownership is global state: a session release can unpin a row in any repo.
+ */
+export function invalidateLocalWorktreeMetadataPruneInputs(): void {
+  pruneInputsGeneration += 1
+}
+
+/**
+ * Backstop for changes no event reported: if Git now lists a different set of worktrees than the
+ * last pass ran against, that pass's conclusions no longer describe this repo. Costs one join over
+ * a list we already hold.
+ */
+export function recordLocalWorktreeListingForPruneGate(
+  repoId: string,
+  worktreePaths: readonly string[]
+): void {
+  const fingerprint = [...worktreePaths].sort().join('\0')
+  const previous = listingFingerprintByRepo.get(repoId)
+  if (previous === fingerprint) {
+    return
+  }
+  listingFingerprintByRepo.set(repoId, fingerprint)
+  // Why not on the first listing: a repo we have never scanned is already due by default, and the
+  // scan that produced this listing is the pass that covers it. Re-arming here would double it.
+  if (previous !== undefined) {
+    requireLocalWorktreeMetadataPrune(repoId)
+  }
+}
+
+/** A deregistered repo leaves no reason to retain its gate state. */
+export function forgetLocalWorktreeMetadataPruneGate(repoId: string): void {
+  observedGenerationByRepo.delete(repoId)
+  listingFingerprintByRepo.delete(repoId)
+}
+
+export function __resetLocalWorktreeMetadataPruneGateForTests(): void {
+  pruneInputsGeneration = 0
+  observedGenerationByRepo.clear()
+  listingFingerprintByRepo.clear()
+}

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
@@ -3,6 +3,7 @@ import type { PersistedState } from '../../../shared/persisted-state-types'
 import type { SshRemotePtyLease } from '../../../shared/ssh-types'
 import { isTerminalLeafId } from '../../../shared/stable-pane-id'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { invalidateLocalWorktreeMetadataPruneInputs } from '../../local-worktree-metadata-prune-gate'
 
 export type SshPtyLeaseOperations = {
   state: PersistedState
@@ -272,6 +273,8 @@ export function removeSshRemotePtyLease(
     (lease) => lease.targetId !== targetId || lease.ptyId !== relayPtyId
   )
   if (operations.state.sshRemotePtyLeases.length !== before) {
+    // Why: the lease may have been the last claim on a dangling metadata row (#17775).
+    invalidateLocalWorktreeMetadataPruneInputs()
     operations.flush()
   }
 }
@@ -287,6 +290,8 @@ export function removeSshRemotePtyLeases(
     (lease) => lease.targetId !== targetId
   )
   if (operations.state.sshRemotePtyLeases.length !== before) {
+    // Why: the leases may have been the last claim on dangling metadata rows (#17775).
+    invalidateLocalWorktreeMetadataPruneInputs()
     operations.flush()
   }
 }

--- a/src/main/persistence/loading-store/metadata-lineage-operations.ts
+++ b/src/main/persistence/loading-store/metadata-lineage-operations.ts
@@ -13,6 +13,7 @@ import {
 import type { StoreRuntimeState } from './store-runtime-state'
 import type { WriteSchedulingOperations } from './write-scheduling'
 import type { SessionHostPartitionOperations } from './session-host-partitions'
+import { invalidateLocalWorktreeMetadataPruneInputs } from '../../local-worktree-metadata-prune-gate'
 import { scheduleSave } from './write-scheduling'
 import {
   hasPersistedWorkspaceSession,
@@ -32,6 +33,7 @@ import { mergeWorktreeMetaForWrite } from './worktree-meta-write-normalization'
 import {
   captureNativeLocalWorktreeMetadataScanExpectation as captureNativeLocalWorktreeMetadataScanExpectationOperation,
   pruneSessionlessMissingLocalWorktreeMetadataForRepo as pruneSessionlessMissingLocalWorktreeMetadataForRepoOperation,
+  selectProbeableLocalWorktreeMetadataCandidates as selectProbeableLocalWorktreeMetadataCandidatesOperation,
   type LocalWorktreeMetadataPruneExpectation,
   type NativeLocalWorktreeMetadataScanExpectation
 } from '../tracking-repos/missing-local-worktree-metadata-pruning'
@@ -197,7 +199,19 @@ export class MetadataLineageOperations {
         }
       )
     }
+    // Why: dropping a row can free the identity key that was vetoing an unrelated row's removal, so
+    // the metadata prune needs to look again — it is otherwise waiting on evidence (#17775).
+    invalidateLocalWorktreeMetadataPruneInputs()
     scheduleSave(this[metadataLineageOperationsContext].scheduling)
+  }
+
+  selectProbeableLocalWorktreeMetadataCandidates(
+    scan: NativeLocalWorktreeMetadataScanExpectation
+  ): readonly LocalWorktreeMetadataPruneExpectation[] {
+    return selectProbeableLocalWorktreeMetadataCandidatesOperation(
+      this[metadataLineageOperationsContext].runtime.state,
+      scan
+    )
   }
 
   pruneSessionlessMissingLocalWorktreeMetadataForRepo(

--- a/src/main/persistence/loading-store/repo-lifecycle-operations.ts
+++ b/src/main/persistence/loading-store/repo-lifecycle-operations.ts
@@ -13,10 +13,7 @@ import { mergeProjectHostSetupCompatibilityState } from '../tracking-repos/proje
 import { RepoOrderPersistenceOperations } from '../tracking-repos/repo-order-operations'
 import { pruneWorktreeStateForRepo as pruneWorktreeStateForRepoOperation } from '../tracking-repos/repo-worktree-pruning'
 import { collectDeregisteredRepoIds } from '../tracking-repos/deregistered-repo-residue'
-import {
-  forgetLocalWorktreeMetadataPruneGate,
-  invalidateLocalWorktreeMetadataPruneInputs
-} from '../../local-worktree-metadata-prune-gate'
+import { retireLocalWorktreeMetadataPruneStateForRepo } from '../../local-worktree-metadata-prune-gate'
 import { hydrateRepo as hydrateRepoOperation } from '../tracking-repos/repo-hydration'
 import { RepoUpdatePersistenceOperations } from '../tracking-repos/repo-update-operations'
 import { ProjectHostSetupPersistenceOperations } from '../tracking-repos/project-host-setup-update'
@@ -227,10 +224,7 @@ export function pruneWorktreeStateForRepo(
   )
   // Why: this drops metadata, lineage, leases and session owners in bulk, which can unpin rows in
   // other repos, and a full removal retires this repo's own gate state (#17775).
-  if (hostId === null) {
-    forgetLocalWorktreeMetadataPruneGate(id)
-  }
-  invalidateLocalWorktreeMetadataPruneInputs()
+  retireLocalWorktreeMetadataPruneStateForRepo(id, hostId)
 }
 
 export function pruneMobileClientTabSelections(

--- a/src/main/persistence/loading-store/repo-lifecycle-operations.ts
+++ b/src/main/persistence/loading-store/repo-lifecycle-operations.ts
@@ -13,6 +13,10 @@ import { mergeProjectHostSetupCompatibilityState } from '../tracking-repos/proje
 import { RepoOrderPersistenceOperations } from '../tracking-repos/repo-order-operations'
 import { pruneWorktreeStateForRepo as pruneWorktreeStateForRepoOperation } from '../tracking-repos/repo-worktree-pruning'
 import { collectDeregisteredRepoIds } from '../tracking-repos/deregistered-repo-residue'
+import {
+  forgetLocalWorktreeMetadataPruneGate,
+  invalidateLocalWorktreeMetadataPruneInputs
+} from '../../local-worktree-metadata-prune-gate'
 import { hydrateRepo as hydrateRepoOperation } from '../tracking-repos/repo-hydration'
 import { RepoUpdatePersistenceOperations } from '../tracking-repos/repo-update-operations'
 import { ProjectHostSetupPersistenceOperations } from '../tracking-repos/project-host-setup-update'
@@ -221,6 +225,12 @@ export function pruneWorktreeStateForRepo(
     hostId,
     (matchesWorktreeId) => pruneMobileClientTabSelections(owner, matchesWorktreeId)
   )
+  // Why: this drops metadata, lineage, leases and session owners in bulk, which can unpin rows in
+  // other repos, and a full removal retires this repo's own gate state (#17775).
+  if (hostId === null) {
+    forgetLocalWorktreeMetadataPruneGate(id)
+  }
+  invalidateLocalWorktreeMetadataPruneInputs()
 }
 
 export function pruneMobileClientTabSelections(

--- a/src/main/persistence/loading-store/session-host-partitions.ts
+++ b/src/main/persistence/loading-store/session-host-partitions.ts
@@ -13,6 +13,7 @@ import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 import { readTerminalScrollbackSnapshotSync } from '../../terminal-scrollback-snapshots'
 import { preserveRuntimeAuthoredWorkspaceSessionFields } from '../runtime-authored-workspace-session-fields'
 import { findWorktreeIdForTab } from '../restoring-sessions/pane-identity-migration'
+import { invalidateLocalWorktreeMetadataPruneInputs } from '../../local-worktree-metadata-prune-gate'
 import {
   removeWorkspaceSessionOwner,
   workspaceSessionPartitionIdsForHost
@@ -132,6 +133,9 @@ export function removeWorkspaceSessionOwnerInPartition(
   if (!session) {
     return
   }
+  // Why: a session was the last thing pinning some dangling metadata row; releasing it is the
+  // evidence the metadata prune waits for, and there is no other signal that it happened (#17775).
+  invalidateLocalWorktreeMetadataPruneInputs()
   if (resolved === LOCAL_EXECUTION_HOST_ID) {
     owner[sessionHostPartitionOperationsContext].runtime.state.workspaceSession = session
   } else {

--- a/src/main/persistence/loading-store/store-prune-gate-signals.test.ts
+++ b/src/main/persistence/loading-store/store-prune-gate-signals.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Drives the real `Store`, because the value of the prune gate is entirely in whether the shipping
+ * write paths signal it. A mutation that unwires the call site survives any test that pokes the gate
+ * module directly.
+ */
+import { mkdtempSync, realpathSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => tmpdir(),
+    getName: () => 'orca-test',
+    getVersion: () => '0.0.0-test',
+    isPackaged: false,
+    on: () => {},
+    whenReady: () => Promise.resolve()
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (value: Buffer) => value.toString()
+  },
+  ipcMain: { on: () => {}, handle: () => {} },
+  BrowserWindow: { getAllWindows: () => [] }
+}))
+
+const { Store } = await import('./store')
+const {
+  __resetLocalWorktreeMetadataPruneGateForTests,
+  isLocalWorktreeMetadataPruneDue,
+  markLocalWorktreeMetadataPruneStarted
+} = await import('../../local-worktree-metadata-prune-gate')
+
+const REPO_ID = 'repo-1'
+const WORKTREE_ID = `${REPO_ID}::/tmp/worktree-a`
+
+const stores: InstanceType<typeof Store>[] = []
+
+beforeEach(() => {
+  __resetLocalWorktreeMetadataPruneGateForTests()
+})
+
+afterEach(() => {
+  // Leaving a debounced save armed would write into a temp dir after the test file finishes.
+  for (const store of stores.splice(0)) {
+    store.flush()
+  }
+  vi.restoreAllMocks()
+})
+
+function createStore(): InstanceType<typeof Store> {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), 'orca-store-prune-gate-')))
+  const store = new Store({ dataFile: join(dir, 'orca-data.json') })
+  stores.push(store)
+  return store
+}
+
+/** Park the gate the way a completed hygiene pass does. */
+function parkGate(): void {
+  markLocalWorktreeMetadataPruneStarted(REPO_ID)
+  expect(isLocalWorktreeMetadataPruneDue(REPO_ID)).toBe(false)
+}
+
+describe('store signals to the worktree metadata prune gate', () => {
+  it('re-arms the gate when a session releases its claim on a worktree', () => {
+    const store = createStore()
+    store.setWorkspaceSession({
+      activeRepoId: REPO_ID,
+      activeWorktreeId: WORKTREE_ID,
+      activeTabId: 'tab-1',
+      tabsByWorktree: { [WORKTREE_ID]: [{ id: 'tab-1', worktreeId: WORKTREE_ID }] },
+      terminalLayoutsByTabId: {}
+    } as unknown as WorkspaceSessionState)
+    parkGate()
+
+    store.removeWorkspaceSessionStateForWorktree(WORKTREE_ID)
+
+    expect(isLocalWorktreeMetadataPruneDue(REPO_ID)).toBe(true)
+  })
+
+  it('re-arms the gate when a metadata row is removed', () => {
+    const store = createStore()
+    store.setWorktreeMeta(WORKTREE_ID, { displayName: 'a', hostId: 'local' })
+    parkGate()
+
+    store.removeWorktreeMeta(WORKTREE_ID)
+
+    expect(isLocalWorktreeMetadataPruneDue(REPO_ID)).toBe(true)
+  })
+
+  it('leaves the gate parked for writes that only add or update a claim', () => {
+    const store = createStore()
+    parkGate()
+
+    store.setWorktreeMeta(WORKTREE_ID, { displayName: 'a', hostId: 'local' })
+    store.setWorktreeMeta(WORKTREE_ID, { displayName: 'b', hostId: 'local' })
+
+    // Why this matters: the worktree listing itself stamps metadata on every scan, so a gate that
+    // re-armed on ordinary writes would restore the storm it exists to stop (#17775).
+    expect(isLocalWorktreeMetadataPruneDue(REPO_ID)).toBe(false)
+  })
+})

--- a/src/main/persistence/scheduling-automations/automation-definition-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-definition-operations.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { invalidateLocalWorktreeMetadataPruneInputs } from '../../local-worktree-metadata-prune-gate'
 import type {
   Automation,
   AutomationCreateInput,
@@ -262,5 +263,7 @@ export function deleteAutomation(
   operations.state.automationRuns = (operations.state.automationRuns ?? []).filter(
     (entry) => entry.automationId !== id
   )
+  // Why: the automation and its unfinished runs were pinning their workspace; both are gone (#17775).
+  invalidateLocalWorktreeMetadataPruneInputs()
   operations.flush()
 }

--- a/src/main/persistence/scheduling-automations/automation-run-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-run-operations.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from 'node:crypto'
+import { isFinalAutomationRunStatus } from '../../../shared/automations-types'
+import { invalidateLocalWorktreeMetadataPruneInputs } from '../../local-worktree-metadata-prune-gate'
 import type {
   Automation,
   AutomationDispatchResult,
@@ -182,6 +184,10 @@ export function updateAutomationRun(
   operations.state.automationRuns = operations.state.automationRuns.map((run) =>
     run.id === result.runId ? updated : run
   )
+  if (!isFinalAutomationRunStatus(current.status) && isFinalAutomationRunStatus(updated.status)) {
+    // Why: only a non-final run pins its workspace, so finishing releases the claim (#17775).
+    invalidateLocalWorktreeMetadataPruneInputs()
+  }
   touchAutomation(operations.state, updated.automationId, now)
   operations.flush()
   return updated

--- a/src/main/persistence/tracking-repos/local-worktree-metadata-scan-expectation.ts
+++ b/src/main/persistence/tracking-repos/local-worktree-metadata-scan-expectation.ts
@@ -203,6 +203,39 @@ function aliasesStillMatch(
   })
 }
 
+/**
+ * Whether the local host is structurally allowed to drop this row, ignoring concurrent-change checks.
+ *
+ * Pure over persisted state — no filesystem, no expectation — so a caller can decide *before* paying
+ * for a `stat` whether a delete could ever accept the row. Several of these predicates reject the
+ * same row on every pass forever (a locator also known on a remote host keeps a second alias; a
+ * legacy row pinned to another host; identity rows that drifted or dangle), which is what turned the
+ * prune into an unbounded no-progress loop in #17775.
+ */
+export function isLocallyRemovableWorktreeMetadataRow(
+  state: PersistedState,
+  worktreeId: string,
+  currentAliases: readonly MetadataAliasEntry[]
+): boolean {
+  const localAlias = composeWorktreeHostIdentity(LOCAL_EXECUTION_HOST_ID, worktreeId)
+  if (currentAliases.some(([alias]) => alias !== localAlias)) {
+    return false
+  }
+  const legacy = state.worktreeMeta[worktreeId]
+  const identityKeys = state.worktreeIdentityAliases?.[localAlias]
+  if (identityKeys && identityKeys.length !== 1) {
+    return false
+  }
+  const canonical = identityKeys?.[0] ? state.worktreeMetaByIdentity?.[identityKeys[0]] : undefined
+  return !(
+    (legacy?.hostId && legacy.hostId !== LOCAL_EXECUTION_HOST_ID) ||
+    (canonical?.hostId && canonical.hostId !== LOCAL_EXECUTION_HOST_ID) ||
+    (identityKeys && !canonical) ||
+    (legacy && canonical && !isDeepStrictEqual(legacy, canonical)) ||
+    (!legacy && !canonical)
+  )
+}
+
 export function removeRevalidatedLocalWorktreeMetadata(
   state: PersistedState,
   expected: LocalWorktreeMetadataPruneExpectation,
@@ -211,29 +244,13 @@ export function removeRevalidatedLocalWorktreeMetadata(
 ): boolean {
   if (
     !rowStillMatches(state.worktreeMeta, expected.worktreeId, expected.expectedLegacy) ||
-    !aliasesStillMatch(state, expected, currentAliases)
+    !aliasesStillMatch(state, expected, currentAliases) ||
+    !isLocallyRemovableWorktreeMetadataRow(state, expected.worktreeId, currentAliases)
   ) {
     return false
   }
   const localAlias = composeWorktreeHostIdentity(LOCAL_EXECUTION_HOST_ID, expected.worktreeId)
-  if (currentAliases.some(([alias]) => alias !== localAlias)) {
-    return false
-  }
-  const legacy = state.worktreeMeta[expected.worktreeId]
   const identityKeys = state.worktreeIdentityAliases?.[localAlias]
-  if (identityKeys && identityKeys.length !== 1) {
-    return false
-  }
-  const canonical = identityKeys?.[0] ? state.worktreeMetaByIdentity?.[identityKeys[0]] : undefined
-  if (
-    (legacy?.hostId && legacy.hostId !== LOCAL_EXECUTION_HOST_ID) ||
-    (canonical?.hostId && canonical.hostId !== LOCAL_EXECUTION_HOST_ID) ||
-    (identityKeys && !canonical) ||
-    (legacy && canonical && !isDeepStrictEqual(legacy, canonical)) ||
-    (!legacy && !canonical)
-  ) {
-    return false
-  }
   if (identityKeys?.[0]) {
     removedIdentityKeys?.add(identityKeys[0])
   }

--- a/src/main/persistence/tracking-repos/missing-local-worktree-metadata-pruning.ts
+++ b/src/main/persistence/tracking-repos/missing-local-worktree-metadata-pruning.ts
@@ -13,6 +13,7 @@ import {
 } from '../restoring-sessions/session-worktree-ownership'
 import {
   indexMetadataAliasesForWorktreeIds,
+  isLocallyRemovableWorktreeMetadataRow,
   removeRevalidatedLocalWorktreeMetadata,
   type LocalWorktreeMetadataPruneExpectation,
   type NativeLocalWorktreeMetadataScanExpectation
@@ -105,6 +106,42 @@ function isValidCandidateId(
       ? isWindowsAbsolutePathLike(parsed.worktreePath)
       : parsed.worktreePath.startsWith('/')) &&
     !worktreeId.includes(FOLDER_WORKSPACE_INSTANCE_SEPARATOR)
+  )
+}
+
+/**
+ * The captured candidates a delete could still accept, decided without touching the disk.
+ *
+ * Why this exists: the caller `stat`s every candidate whose path Git no longer lists, then discovers
+ * here that most of them are refused anyway — pinned by a persisted session, or structurally
+ * unremovable on this host. Those verdicts are pure functions of persisted state, so paying for the
+ * filesystem first inverts the cheap and expensive halves of the decision. On a store with ~1.4k
+ * dangling rows that was the bulk of a permanent `stat` storm (#17775).
+ *
+ * Deliberately advisory: `pruneSessionlessMissingLocalWorktreeMetadataForRepo` re-checks everything
+ * authoritatively against the capture, so a disagreement here costs at most a wasted `stat` or a row
+ * lingering one more pass — it can never widen what gets deleted.
+ */
+export function selectProbeableLocalWorktreeMetadataCandidates(
+  state: PersistedState,
+  scan: NativeLocalWorktreeMetadataScanExpectation,
+  platform = process.platform
+): readonly LocalWorktreeMetadataPruneExpectation[] {
+  const candidateIds = new Set(scan.metadata.map(({ worktreeId }) => worktreeId))
+  if (candidateIds.size === 0) {
+    return scan.metadata
+  }
+  const sessionOwners = collectPersistedWorkspaceOwners(state, candidateIds, platform)
+  const aliasesByWorktreeId = indexMetadataAliasesForWorktreeIds(state, candidateIds)
+  return scan.metadata.filter(
+    ({ worktreeId }) =>
+      isValidCandidateId(scan.repo.id, worktreeId, platform) &&
+      !sessionOwners.has(worktreeId) &&
+      isLocallyRemovableWorktreeMetadataRow(
+        state,
+        worktreeId,
+        aliasesByWorktreeId.get(worktreeId) ?? []
+      )
   )
 }
 

--- a/src/main/persistence/tracking-repos/probeable-local-worktree-metadata-candidates.test.ts
+++ b/src/main/persistence/tracking-repos/probeable-local-worktree-metadata-candidates.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultPersistedState } from '../../../shared/constants'
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { Repo } from '../../../shared/repo-types'
+import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import {
+  captureNativeLocalWorktreeMetadataScanExpectation,
+  pruneSessionlessMissingLocalWorktreeMetadataForRepo,
+  selectProbeableLocalWorktreeMetadataCandidates
+} from './missing-local-worktree-metadata-pruning'
+
+const REPO_ID = 'repo-1'
+
+function makeRepo(): Repo {
+  return {
+    id: REPO_ID,
+    path: '/workspace/repo',
+    displayName: 'repo',
+    badgeColor: '#000',
+    addedAt: 0
+  }
+}
+
+function makeMeta(worktreeId: string, overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
+  return {
+    instanceId: `instance-${worktreeId}`,
+    hostId: 'local',
+    displayName: worktreeId,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+function makeState(): PersistedState {
+  const state = getDefaultPersistedState('/home/test')
+  state.repos = [makeRepo()]
+  return state
+}
+
+function probeableIds(state: PersistedState): string[] {
+  const scan = captureNativeLocalWorktreeMetadataScanExpectation(state, state.repos[0]!)
+  return selectProbeableLocalWorktreeMetadataCandidates(state, scan, 'linux').map(
+    ({ worktreeId }) => worktreeId
+  )
+}
+
+describe('selectProbeableLocalWorktreeMetadataCandidates', () => {
+  it('keeps an ordinary sessionless local row', () => {
+    const state = makeState()
+    const id = `${REPO_ID}::/workspace/gone`
+    state.worktreeMeta[id] = makeMeta(id)
+
+    expect(probeableIds(state)).toEqual([id])
+  })
+
+  it('drops a row a persisted session still pins', () => {
+    const state = makeState()
+    const pinned = `${REPO_ID}::/workspace/pinned`
+    const free = `${REPO_ID}::/workspace/free`
+    state.worktreeMeta[pinned] = makeMeta(pinned)
+    state.worktreeMeta[free] = makeMeta(free)
+    state.ui.lastActiveWorktreeId = pinned
+
+    expect(probeableIds(state)).toEqual([free])
+  })
+
+  it('drops a row whose locator is also known on a remote host', () => {
+    const state = makeState()
+    const shared = `${REPO_ID}::/workspace/shared`
+    const free = `${REPO_ID}::/workspace/free`
+    state.worktreeMeta[shared] = makeMeta(shared)
+    state.worktreeMeta[free] = makeMeta(free)
+    state.worktreeIdentityAliases = { [`ssh:box|${shared}`]: ['identity-1'] }
+
+    expect(probeableIds(state)).toEqual([free])
+  })
+
+  it('drops a row pinned to another execution host', () => {
+    const state = makeState()
+    const remote = `${REPO_ID}::/workspace/remote`
+    state.worktreeMeta[remote] = makeMeta(remote, { hostId: 'ssh:box' })
+
+    expect(probeableIds(state)).toEqual([])
+  })
+
+  it('never widens what the authoritative prune would remove', () => {
+    const state = makeState()
+    const ids = [
+      `${REPO_ID}::/workspace/free`,
+      `${REPO_ID}::/workspace/pinned`,
+      `${REPO_ID}::/workspace/remote`
+    ]
+    state.worktreeMeta[ids[0]] = makeMeta(ids[0])
+    state.worktreeMeta[ids[1]] = makeMeta(ids[1])
+    state.worktreeMeta[ids[2]] = makeMeta(ids[2], { hostId: 'ssh:box' })
+    state.ui.lastActiveWorktreeId = ids[1]
+
+    const scan = captureNativeLocalWorktreeMetadataScanExpectation(state, state.repos[0]!)
+    const selected = selectProbeableLocalWorktreeMetadataCandidates(state, scan, 'linux')
+    // Feeding the unfiltered capture to the authoritative prune must reach the same verdict.
+    const removed = pruneSessionlessMissingLocalWorktreeMetadataForRepo(
+      state,
+      scan,
+      scan.metadata,
+      'linux'
+    )
+
+    expect(selected.map(({ worktreeId }) => worktreeId)).toEqual(removed)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​474 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​474 |
| Prod | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​268 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​240 |

<!-- /orca-pr-loc -->

Fixes #17775 (the CPU/heat half).

## The bug

Dangling `worktreeMeta` pruning rode the detected-worktree listing — a **polled read path**. Every pass did two things that are O(all metadata rows for the repo):

1. Captured a prune expectation over the whole table — a `JSON.stringify` per row.
2. `stat`ed every path-missing candidate.

...and then discovered most rows are refused anyway. That's the inversion: the cheap half of the decision ran *after* the expensive half.

Worse, a large class of rows is **permanently** refused, so the work repeated forever without converging. The reporter's store (1,458 meta rows, 98.7% path-missing, 13 repos, 5s listing TTL) turns that into a sustained ~288 `stat`/s plus megabytes of `JSON.stringify` per minute in the main process — matching the reported `uv__work_done` → `node::fs::AfterInteger` sample.

The permanently-refused rows are rejected by predicates that are **pure functions of persisted state** — chiefly a locator also known on a remote host (which leaves a second identity alias that vetoes removal, `local-worktree-metadata-scan-expectation.ts:219`) and a legacy row pinned to another execution host (`:229`). Neither needs the disk, and neither changes on its own.

## The fix

**1. Probe only rows a delete could accept.** New `selectProbeableLocalWorktreeMetadataCandidates` applies session-ownership and structural-removability filters *before* the filesystem. Advisory by construction — `pruneSessionlessMissingLocalWorktreeMetadataForRepo` still re-checks authoritatively — so it can only shrink the `stat` fan-out, never widen a delete.

**2. One definition of removability.** Extracted `isLocallyRemovableWorktreeMetadataRow` so probe-avoidance and the delete cannot drift apart.

**3. Gate hygiene on evidence, not on a clock.** The metadata + lineage prune now runs only on:
- a worktree lifecycle event for the repo (existing worktree-change invalidator hub),
- a mutation that can make a row *more* removable — session-owner release, metadata removal, SSH lease release, automation run finishing or being deleted, repo deregistration,
- a git listing differing from the one the last pass ran against (backstop for changes no event reported).

With none of those, the pass is a provable repeat and is skipped. **Steady state is zero hygiene passes.**

### The constraint that shaped this

The listing path *itself* writes worktree metadata (`worktree-discovery-metadata.ts:61`, discovery backfill and host-ownership stamping). A gate that re-armed on any metadata write would re-arm from the very scan it gates and restore the storm. So the gate deliberately ignores writes that only **add or update** a claim — those can only preserve more rows. There is an explicit negative test for this.

### Failure direction

One-way by design: a signal we miss leaves a dangling row in place until the next one arrives. Hygiene lags; nothing is deleted that would not have been deleted anyway.

## Testing

- `pnpm tc` clean; `pnpm run check:code-quality:changed` → 0 findings.
- `src/main/persistence src/main/ipc`: **4335 passed**.
- Full `src/main`: **29652 passed, 4 failed** — all verified unrelated. `run-electron-vite-dev` ×2 fail identically on the baseline commit; `codex-session-index-heal-state` and `terminal-history-tombstone-retry` are main-thread timing tests that pass 3/3 in isolation on this branch and fail only under parallel suite load.

New tests:
- `local-worktree-metadata-prune-gate.test.ts` — gate semantics (8).
- `detected-worktree-scan-hygiene-gate.test.ts` — gated scan path, including a 20-poll/one-capture convergence assertion (8).
- `probeable-local-worktree-metadata-candidates.test.ts` — selector, including an equivalence check that it selects exactly what the authoritative prune removes (5).
- `store-prune-gate-signals.test.ts` — drives the **real `Store`** (3), because a mutation unwiring a call site would survive any test that pokes the gate module directly.

## Scope — deliberately not covered

- **`git worktree list` volume** (5133 of 11318 trace spans). The 5s listing TTL is still a floor of ~1 exec per repo per 5s while the renderer polls. Removing it means change-gating the scan cache off the existing base-directory poller — same root cause as open #15882.
- **Why those rows are unremovable at all** — that is the store leak, #17776. The reporter explicitly asked not to merge the fixes. This PR stops the leak *costing* CPU; it does not drain it.
- **`diagnostics memory` CPU contradicting `ps`** (expectation 3 in the issue) — untouched.

## Adjacent bug found, not fixed here

`repoStillMatches` / `routingStillMatches` compare repo, project and settings by **object identity**, across a window that spans the git subprocess *and* the FS probe. Any replacement of those objects during that window rejects every row for the repo. Under write churn that presents as non-convergence. It belongs to #17776, flagging rather than fixing.
