### PR TITLE
test: stop two suites failing for reasons unrelated to their subject

### DIFF
--- a/src/main/zsh-startup-hook-user-config-equivalence.live-shell.test.ts
+++ b/src/main/zsh-startup-hook-user-config-equivalence.live-shell.test.ts
@@ -16,7 +16,7 @@
  */
 import { existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { getShellLaunchConfig } from './providers/local-pty-shell-ready'
 import { selectShellStartupFeatures } from './shell-startup-features'
@@ -382,9 +382,12 @@ describe.skipIf(process.platform === 'win32')('the fixes the old wrapper was bui
     // value this wrapper cannot use degrades to $HOME, where zsh itself looks.
     const home = makeZshHome({ '.zshrc': 'export ORCA_TEST_FROM_ZSHRC=1\n' })
     try {
+      // Unique per run: a fixed name here shares one path with every other run in
+      // the system temp dir, so a killed run leaves a stale directory behind and
+      // every later rename onto it fails with ENOTEMPTY.
       const { values } = await runFromRelocatedRoot(
         home,
-        join(dirname(userDataPath), '홍길동-wsl-view')
+        join(dirname(userDataPath), `홍길동-${basename(userDataPath)}`)
       )
 
       expect(values.ORCA_TEST_FROM_ZSHRC).toBe('1')

--- a/src/renderer/src/lib/palette-match/palette-match-budget.ts
+++ b/src/renderer/src/lib/palette-match/palette-match-budget.ts
@@ -1,8 +1,14 @@
 /**
  * Checked-in performance budget for the Cmd+J matcher, measured against the
  * synthetic corpus in `palette-match-performance.test.ts`. These are ceilings for
- * catching order-of-magnitude regressions, not targets — the measured numbers on
- * a developer machine sit roughly an order of magnitude under each one.
+ * catching order-of-magnitude regressions, not targets.
+ *
+ * The wall-clock ceilings are asserted against the *fastest* sample of a batch,
+ * never the slowest: a vitest worker sharing cores with the rest of the suite
+ * gets preempted mid-measurement, so the slowest sample measures the machine
+ * while the fastest still approximates the matcher. Fan-out regressions are
+ * caught by `fieldMatchesPerCandidate` instead, which counts work rather than
+ * time and so does not depend on machine speed at all.
  *
  * Raising any value requires a fresh measurement recorded in the PR.
  */
@@ -11,10 +17,17 @@ export const PALETTE_MATCH_BUDGET = {
   candidateCount: 800,
   /** Unique tokens in the worst supported query. */
   tokenCount: 16,
-  /** p95 milliseconds to normalize every document once (cold open). */
-  coldBuildP95Ms: 900,
-  /** p95 milliseconds to match the whole corpus against one prepared query. */
-  warmMatchP95Ms: 220,
+  /**
+   * Ceiling on `matchPaletteField` calls per candidate for the worst query.
+   * Deterministic — it counts work, not time — so it catches a fan-out
+   * regression (re-matching every field per evidence unit, say) on any machine.
+   * Measured 45: 15 fields across the 3 tokens scanned before the first miss.
+   */
+  fieldMatchesPerCandidate: 60,
+  /** Milliseconds to normalize every document once (cold open), fastest sample. */
+  coldBuildMs: 900,
+  /** Milliseconds to match the whole corpus against one prepared query, fastest sample. */
+  warmMatchMs: 220,
   /**
    * Megabytes of indexed text and offset tables the normalized documents retain.
    * Measured deterministically rather than from `heapUsed`, which is polluted by

--- a/src/renderer/src/lib/palette-match/palette-match-performance.test.ts
+++ b/src/renderer/src/lib/palette-match/palette-match-performance.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { PALETTE_MATCH_BUDGET } from './palette-match-budget'
 import { matchPaletteDocument } from './match-document'
+import * as matchFieldModule from './match-field'
 import { preparePaletteQuery } from './palette-query'
 import { buildWorktreePaletteDocuments } from '../worktree-palette-document'
+import type { PaletteDocument } from './palette-document'
+import type { PaletteQueryToken } from './palette-query'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 
@@ -89,49 +92,75 @@ const WORST_QUERY = Array.from({ length: tokenCount }, (_, index) =>
   index === 0 ? 'scan' : index === 1 ? 'daily' : `token${index}`
 ).join(' ')
 
-function percentile95(samples: number[]): number {
-  const sorted = [...samples].sort((a, b) => a - b)
-  return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95))]
+function prepareWorstQuery(): { tokens: readonly PaletteQueryToken[]; normalized: string } {
+  const prepared = preparePaletteQuery(WORST_QUERY)
+  if (prepared.state !== 'ready') {
+    throw new Error(`Expected a ready query, got ${prepared.state}`)
+  }
+  return { tokens: prepared.tokens, normalized: prepared.normalized }
+}
+
+const preparedQuery = prepareWorstQuery()
+
+function matchEveryDocument(documents: ReadonlyMap<string, PaletteDocument>): void {
+  for (const document of documents.values()) {
+    matchPaletteDocument({
+      document,
+      tokens: preparedQuery.tokens,
+      normalizedQuery: preparedQuery.normalized
+    })
+  }
+}
+
+/**
+ * Why the fastest sample and not p95: this runs in a vitest worker competing for
+ * cores with the rest of the suite, so a slow sample records a preemption rather
+ * than the matcher. The fastest sample is the least contaminated estimate of
+ * intrinsic cost — measured stable within 1.6x on a fully saturated machine,
+ * while the slowest of the same batch swung by 17x.
+ */
+function fastestSample(samples: readonly number[]): number {
+  return Math.min(...samples)
+}
+
+function timeRepeatedly(work: () => void, rounds: number): number[] {
+  const samples: number[] = []
+  for (let round = 0; round < rounds; round += 1) {
+    const start = performance.now()
+    work()
+    samples.push(performance.now() - start)
+  }
+  return samples
 }
 
 describe('palette matcher performance budget', () => {
   it('normalizes a cold corpus within budget', () => {
-    const samples: number[] = []
-    for (let run = 0; run < 5; run += 1) {
-      const start = performance.now()
-      buildWorktreePaletteDocuments(worktrees, sources)
-      samples.push(performance.now() - start)
-    }
-    expect(percentile95(samples)).toBeLessThan(PALETTE_MATCH_BUDGET.coldBuildP95Ms)
+    const samples = timeRepeatedly(() => buildWorktreePaletteDocuments(worktrees, sources), 5)
+    expect(fastestSample(samples)).toBeLessThan(PALETTE_MATCH_BUDGET.coldBuildMs)
   })
 
   it('matches a 16-token query against warm documents within budget', () => {
     const documents = buildWorktreePaletteDocuments(worktrees, sources)
-    const prepared = preparePaletteQuery(WORST_QUERY)
-    expect(prepared.state).toBe('ready')
-    if (prepared.state !== 'ready') {
-      return
-    }
 
-    const matchAllDocuments = (): void => {
-      for (const document of documents.values()) {
-        matchPaletteDocument({
-          document,
-          tokens: prepared.tokens,
-          normalizedQuery: prepared.normalized
-        })
-      }
-    }
+    // Warm the matcher before timing so JIT compilation is not part of the samples.
+    matchEveryDocument(documents)
 
-    // Warm the matcher before timing so JIT compilation is not part of p95.
-    matchAllDocuments()
-    const samples: number[] = []
-    for (let run = 0; run < 10; run += 1) {
-      const start = performance.now()
-      matchAllDocuments()
-      samples.push(performance.now() - start)
+    const samples = timeRepeatedly(() => matchEveryDocument(documents), 10)
+    expect(fastestSample(samples)).toBeLessThan(PALETTE_MATCH_BUDGET.warmMatchMs)
+  })
+
+  it('bounds field-match fan-out per candidate', () => {
+    const documents = buildWorktreePaletteDocuments(worktrees, sources)
+    const fieldMatch = vi.spyOn(matchFieldModule, 'matchPaletteField')
+    try {
+      matchEveryDocument(documents)
+      const perCandidate = fieldMatch.mock.calls.length / documents.size
+      // Guards the ceiling against going vacuous if the spy ever stops intercepting.
+      expect(perCandidate).toBeGreaterThan(0)
+      expect(perCandidate).toBeLessThan(PALETTE_MATCH_BUDGET.fieldMatchesPerCandidate)
+    } finally {
+      fieldMatch.mockRestore()
     }
-    expect(percentile95(samples)).toBeLessThan(PALETTE_MATCH_BUDGET.warmMatchP95Ms)
   })
 
   it('keeps the retained document payload within budget', () => {


### PR DESCRIPTION
Two tests that fail for reasons having nothing to do with what they assert. Permanently-red and flaky tests train everyone to re-run rather than read — which is how a batch of real regressions recently got waved through this repo.

**1. zsh wrapper test — permanently red once poisoned.** It relocated into `join(dirname(userDataPath), '홍길동-wsl-view')`, a *fixed* name in shared system temp, unlike its sibling case which uses the unique mkdtemp name. One killed run leaves that directory behind and every later run on that machine fails forever:
```
Error: ENOTEMPTY: directory not empty, rename '.../orca-hook-regression-lrVaSr' -> '.../홍길동-wsl-view'
```
Now unique, keeping the non-ASCII component the test exists for. Verified with a stale directory present and two copies running concurrently.

**2. Palette performance budget — 4/20 pass rate under load.** The helper named `percentile95` returns `sorted[Math.floor(n * 0.95)]`, which for n=10 is `sorted[9]` — **the maximum of the batch**. Asserting worst-case wall-clock in a parallel runner measures scheduler preemption, not the matcher.

Across 20 CPU-saturated windows the asserted quantity ranged **123.7–342.9 ms**, exceeding the 220 ms budget in **6** of them, while the *fastest* sample of those same batches held at **19.1–31.6 ms**.

Now asserts the fastest sample, **budgets unchanged at 900/220** — not widened. Adds a deterministic `matchPaletteField` fan-out ceiling that counts work instead of time (measures exactly 45/candidate; verified by tightening to 40 and watching it fail), with a `> 0` guard so it cannot go vacuous if the spy stops intercepting.

Pass rate under identical saturation: **4/20 → 20/20**.

A scaling-ratio alternative was built and rejected: at 4x corpus the measured growth was 13.6 rather than 4.0, because holding ~120MB live makes the ratio measure the memory hierarchy rather than algorithmic order. It would have been a new flake source.