### PR TITLE
test(orchestration): fail loudly on an unexpected second detection call

### DIFF
--- a/src/main/runtime/rpc/orchestration-legacy-coordinator-race.test.ts
+++ b/src/main/runtime/rpc/orchestration-legacy-coordinator-race.test.ts
@@ -656,9 +656,21 @@ describe('legacy coordinator takeover races', () => {
     const detectionStarted = new Promise<void>((resolve) => {
       signalDetectionStarted = resolve
     })
+    let detectionCalls = 0
     vi.spyOn(harness.runtime, 'isTerminalRunningAgent').mockImplementation(
       () =>
-        new Promise<boolean>((resolve) => {
+        new Promise<boolean>((resolve, reject) => {
+          detectionCalls += 1
+          // Why reject instead of re-arming: a second call would overwrite resolveDetection and
+          // strand the first promise, hanging to a timeout instead of naming what changed.
+          if (detectionCalls > 1) {
+            reject(
+              new Error(
+                `isTerminalRunningAgent was called ${detectionCalls} times; this test drives exactly one detection.`
+              )
+            )
+            return
+          }
           resolveDetection = resolve
           signalDetectionStarted?.()
         })


### PR DESCRIPTION
Incidental hardening found while chasing a reported flake in `orchestration-legacy-coordinator-race.test.ts`.

The `isTerminalRunningAgent` mock overwrote `resolveDetection` on every call. If the product ever called it twice, the first promise would be stranded and the test would hang to a 30s timeout rather than saying what changed. A test that hangs instead of failing is how a real bug gets mistaken for infrastructure noise.

A second call now rejects immediately, naming the unexpected re-invocation.

**On the flake itself: unreproduced, and no change made to the test or the product.** 12/12 clean under the exact command it was reported from (a combined run with the child-process boundary suite, ~6,150 tests per run), plus 30/30 under full CPU saturation and 20/20 alongside a sibling suite. The target test runs in 22ms against a 30s timeout.

The reasoning, which holds regardless: Vitest's `forks` pool runs the sibling suite in separate OS processes, so its fs storm can starve this process but cannot reorder microtasks inside it. Within the process the sequence is closed — the handler cannot advance past `await isTerminalRunningAgent` until the test calls `resolveDetection`, and the takeover happens before that call. The product's recheck-then-write is atomic for the same reason: `revalidateLegacyCoordinator()` and `db.createDispatchContext()` are synchronous and adjacent, and `revalidate` compares an integer `consumer_generation` against a snapshot rather than a timestamp, so there is no clock-resolution tie-break.

**Falsifiable consequence:** the only load-sensitive failure mode left is a timeout. If this test ever fails under load reporting the `legacy_read_only` assertion rather than `Test timed out`, the code as written cannot explain it and it should be re-examined at the source.