### PR TITLE
fix(relay): guard all three delivery release paths, and explain a restoring source

### DIFF
--- a/src/relay/relay-pty-source-publication.ts
+++ b/src/relay/relay-pty-source-publication.ts
@@ -65,20 +65,24 @@ export class RelayPtySourcePublication {
     context: RequestContext | undefined,
     recovery?: PtySourceRecoveryRequest
   ): false | 'opened' | 'rotated' | 'existing' | PtySourceRecoveryResult {
+    let current = this.deliveries.get(id)
+    // A superseded request can find the delivery its own replacement opened: releasing that fence
+    // resumes a send the replacement is still rotating, and cancelling it blanks the pane that owns
+    // it. So every bail-out below acts only on a record this caller still owns.
+    const owned = current?.clientId === context?.clientId ? current : undefined
     if (!context?.onResponseSettled) {
-      this.sender.releaseRotationFence(this.deliveries.get(id))
+      this.sender.releaseRotationFence(owned)
       return false
     }
     const mode = this.session.deliveryMode(context.clientId)
-    let current = this.deliveries.get(id)
     if (mode === 'unadmitted' || mode === 'subscriber') {
-      this.sender.releaseRotationFence(current)
+      this.sender.releaseRotationFence(owned)
       return false
     }
     if (mode === 'legacy-owner') {
-      if (current) {
-        this.session.cancelDelivery(current.identity, 'source-credit-disabled')
-        this.sender.wakeSendWaiters(current)
+      if (owned) {
+        this.session.cancelDelivery(owned.identity, 'source-credit-disabled')
+        this.sender.wakeSendWaiters(owned)
         this.deliveries.delete(id)
         this.onCapacity(id)
       }
@@ -88,7 +92,7 @@ export class RelayPtySourcePublication {
       current?.clientId === context.clientId &&
       !current.restoreRequired &&
       current.sourceExitState !== 'pending' &&
-      this.deliveryClosedUnderRecord(current)
+      ptySourceDeliveryClosed(this.session, current.identity)
     ) {
       // Why: a canceled delivery can never resume as 'existing'; retire it so re-attach opens fresh.
       this.sender.wakeSendWaiters(current)
@@ -219,7 +223,7 @@ export class RelayPtySourcePublication {
     }
     if (!output.sourceAccepted && !appendPtySourceOutput(this.session, record, output)) {
       this.counters.appendDenied++
-      if (this.deliveryClosedUnderRecord(record)) {
+      if (ptySourceDeliveryClosed(this.session, record.identity)) {
         this.sender.wakeSendWaiters(record)
         this.deliveries.delete(id)
         // Why: deferred — publish() can run inside flushPendingOutput's captured-queue drain,
@@ -273,10 +277,6 @@ export class RelayPtySourcePublication {
   dispose = (): void => {
     this.legacyExits.clear()
     this.sender.dispose()
-  }
-
-  private deliveryClosedUnderRecord(record: RelayPtySourceDeliveryRecord): boolean {
-    return ptySourceDeliveryClosed(this.session, record.identity)
   }
 
   private registerActivationSettlement(

--- a/src/relay/relay-pty-source-superseded-activation.test.ts
+++ b/src/relay/relay-pty-source-superseded-activation.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  RelayDispatcher,
+  type RelayClientSessionIdentity,
+  type RequestContext,
+  type SinkWriteSettlement
+} from './dispatcher'
+import { encodeJsonRpcFrame, MessageType } from './protocol'
+import { RelayPtySourcePublication } from './relay-pty-source-publication'
+import { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
+
+const endpointIdentity: RelayClientSessionIdentity = {
+  principal: 'endpoint-principal',
+  authenticated: true,
+  allowSessionOwner: true,
+  authenticationKind: 'endpoint-credential'
+}
+
+function requestFrame(id: number, method: string, params: Record<string, unknown>): Buffer {
+  return encodeJsonRpcFrame({ jsonrpc: '2.0', id, method, params }, id, 0)
+}
+
+function responseResult(buffer: Buffer): Record<string, unknown> | null {
+  if (buffer[0] !== MessageType.Regular) {
+    return null
+  }
+  const length = buffer.readUInt32BE(9)
+  const message = JSON.parse(buffer.subarray(13, 13 + length).toString('utf8'))
+  return message.id === undefined ? null : (message.result ?? null)
+}
+
+async function flushRequests(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve))
+}
+
+describe('PTY source activation from a superseded owner', () => {
+  let dispatcher: RelayDispatcher | null = null
+
+  afterEach(() => {
+    dispatcher?.dispose()
+    dispatcher = null
+  })
+
+  async function createHarness() {
+    const writes: Buffer[] = []
+    dispatcher = new RelayDispatcher(
+      (data, onSettled) => {
+        writes.push(Buffer.from(data))
+        onSettled({ ok: true })
+        return true
+      },
+      { supportsWriteCallback: true },
+      endpointIdentity
+    )
+    let publication: RelayPtySourcePublication
+    const adapter = new SshPtyConsumerSessionAdapter(dispatcher, 'build-a', undefined, (id) =>
+      publication.onCreditAvailable(id)
+    )
+    publication = new RelayPtySourcePublication(dispatcher, adapter, () => {})
+    dispatcher.feed(
+      requestFrame(1, 'pty.openClient', {
+        protocolVersion: 1,
+        clientInstanceId: 'client-1',
+        requestedRole: 'session-owner',
+        capabilities: { outputFlowControl: { versions: [1], requestedWindowSu: 4 } }
+      })
+    )
+    await flushRequests()
+    return { adapter, publication, writes }
+  }
+
+  function contextFor(
+    clientId: number,
+    settlements: ((result: SinkWriteSettlement) => void)[]
+  ): RequestContext {
+    return {
+      clientId,
+      isStale: () => false,
+      sessionIdentity: endpointIdentity,
+      onResponseSettled: (callback) => settlements.push(callback)
+    }
+  }
+
+  /**
+   * The superseded transport must not release, cancel or retire the delivery its own replacement
+   * opened: releasing the fence resumes a send the replacement is still rotating, and retiring it
+   * blanks the pane that owns it.
+   */
+  it('leaves the replacement delivery intact when the superseded owner re-activates', async () => {
+    const { publication, adapter, writes } = await createHarness()
+    const settlements: ((result: SinkWriteSettlement) => void)[] = []
+    expect(publication.activate('pty-1', 'incarnation-1', contextFor(1, settlements))).toBe(
+      'opened'
+    )
+    settlements[0]({ ok: true })
+    const activation = publication.receivingActivation('pty-1', 1)!
+    const ownerGrant = writes.map(responseResult).find((result) => result?.ownerLease)!
+
+    // The original transport arms its rotation fence while waiting for a checkpoint-safe send.
+    await expect(publication.waitForPendingSend('pty-1')).resolves.toBe(true)
+
+    const replacementWrites: Buffer[] = []
+    const replacementClientId = dispatcher!.attachClient(
+      (data, onSettled) => {
+        replacementWrites.push(Buffer.from(data))
+        onSettled({ ok: true })
+        return true
+      },
+      { supportsWriteCallback: true },
+      endpointIdentity
+    )
+    dispatcher!.feedClient(
+      replacementClientId,
+      requestFrame(2, 'pty.openClient', {
+        protocolVersion: 1,
+        clientInstanceId: 'client-1',
+        requestedRole: 'session-owner',
+        resume: {
+          ownerGeneration: ownerGrant.ownerGeneration,
+          ownerLease: ownerGrant.ownerLease
+        },
+        capabilities: { outputFlowControl: { versions: [1], requestedWindowSu: 4 } }
+      })
+    )
+    await flushRequests()
+
+    const replacementSettlements: ((result: SinkWriteSettlement) => void)[] = []
+    const recovery = {
+      status: 'checkpoint' as const,
+      clientGeneration: activation.clientGeneration,
+      ownerGeneration: activation.ownerGeneration,
+      ptyIncarnation: activation.ptyIncarnation,
+      deliveryToken: activation.deliveryToken,
+      acceptedSourceEndSu: 0
+    }
+    expect(
+      publication.activate(
+        'pty-1',
+        'incarnation-1',
+        contextFor(replacementClientId, replacementSettlements),
+        recovery
+      )
+    ).toMatchObject({ status: 'pending' })
+    replacementSettlements[0]({ ok: true })
+
+    // Arm the replacement fence, then let the superseded transport's activation resume. isStale()
+    // stays false on purpose: the superseded client is still attached, so production reaches the
+    // delivery-mode bail-outs rather than any stale early-out.
+    await expect(publication.waitForPendingSend('pty-1')).resolves.toBe(true)
+    const cancelDelivery = vi.spyOn(adapter, 'cancelDelivery')
+    expect(publication.activate('pty-1', 'incarnation-1', contextFor(1, []), recovery)).toBe(false)
+    expect(cancelDelivery).not.toHaveBeenCalled()
+    expect(publication.publish('pty-1', { data: 'replacement-output' }, false)).toBe(false)
+
+    // Release the replacement fence through its owning transport so no parked work is left behind.
+    expect(
+      publication.activate('pty-1', 'incarnation-1', contextFor(replacementClientId, []))
+    ).toBe('existing')
+    expect(replacementWrites.length).toBeGreaterThan(0)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -185,6 +185,19 @@ describe('humanizeTerminalError', () => {
     expect(humanized).not.toContain('exited')
   })
 
+  // A live PTY whose delivery was retired must never get the "open a new terminal" copy: acting on
+  // that abandons a running agent on the host.
+  it('describes a retired output source as reconnecting, not as a lost session', () => {
+    const humanized = humanizeTerminalError(
+      'SSH_PTY_SOURCE_RESTORE_REQUIRED: remote:2f1c:pty-7 checkpointUnavailable'
+    )
+    expect(humanized).not.toContain('SSH_PTY_SOURCE_RESTORE_REQUIRED')
+    expect(humanized).not.toContain('remote:2f1c:pty-7')
+    expect(humanized).not.toContain('checkpointUnavailable')
+    expect(humanized).not.toContain('Open a new terminal')
+    expect(humanized).toContain('still running')
+  })
+
   it('replaces only the unreattachable line in an aggregated error', () => {
     const humanized = humanizeTerminalError('Paste failed.\nSSH_SESSION_EXPIRED: orca:2f1c@@pty-7')
     expect(humanized.startsWith('Paste failed.\n')).toBe(true)
@@ -213,6 +226,14 @@ describe('isExplainedTerminalError', () => {
     expect(isExplainedTerminalError(LEGACY_HOST_GONE)).toBe(true)
     expect(
       isExplainedTerminalError('connect ECONNREFUSED /tmp/orca-terminal-host-v30-14cb7f94b511.sock')
+    ).toBe(true)
+  })
+
+  it('suppresses the issue link while a live session restores its output source', () => {
+    expect(
+      isExplainedTerminalError(
+        'SSH_PTY_SOURCE_RESTORE_REQUIRED: remote:2f1c:pty-7 checkpointUnavailable'
+      )
     ).toBe(true)
   })
 

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -35,6 +35,13 @@ const UNREATTACHABLE_SESSION_SOURCES = [
   'PTY "[^"\\r\\n]*" not found(?: \\(identity mismatch\\))?',
   '(?:SessionNotFoundError: )?Session not found: \\S+'
 ]
+// The relay answered and proved the shell is still running — only its output delivery was retired.
+// Deliberately NOT one of the sources above: that copy says to open a new terminal, which here
+// abandons a live agent. Same lastIndex hazard, so keep the test and replace forms separate.
+const SOURCE_RESTORE_REQUIRED_SOURCE =
+  'SSH_PTY_SOURCE_RESTORE_REQUIRED(?::[ \\t]*\\S*(?:[ \\t]+\\S+)?)?'
+const SOURCE_RESTORE_REQUIRED_PATTERN = new RegExp(SOURCE_RESTORE_REQUIRED_SOURCE)
+const SOURCE_RESTORE_REQUIRED_REPLACE_PATTERN = new RegExp(SOURCE_RESTORE_REQUIRED_SOURCE, 'g')
 const UNREATTACHABLE_SESSION_PATTERNS = UNREATTACHABLE_SESSION_SOURCES.map(
   (source) => new RegExp(source)
 )
@@ -77,6 +84,7 @@ export function isExplainedTerminalError(error: string): boolean {
       (line) =>
         TERMINAL_HOST_GONE_PATTERN.test(line) ||
         LEGACY_TERMINAL_HOST_GONE_PATTERN.test(line) ||
+        SOURCE_RESTORE_REQUIRED_PATTERN.test(line) ||
         UNREATTACHABLE_SESSION_PATTERNS.some((pattern) => pattern.test(line))
     )
 }
@@ -113,6 +121,12 @@ export function humanizeTerminalError(error: string): string {
         )
     humanized = humanized.replaceAll(PANE_OWNER_UNVERIFIED_MARKER, () => explanation)
   }
+  humanized = humanized.replace(SOURCE_RESTORE_REQUIRED_REPLACE_PATTERN, () =>
+    translate(
+      'auto.components.terminal.pane.TerminalErrorToast.sourceRestoring',
+      'Reconnecting this terminal — its output is being re-established. The session is still running.'
+    )
+  )
   humanized = humanizeUnreattachableSession(humanized)
   if (!isExplainedTerminalError(humanized)) {
     return humanized

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3087,7 +3087,8 @@
             "ownerUnknown": "Orca couldn't verify this terminal's owner.",
             "42b283ecfc": "Orca couldn't safely reconnect this terminal because the host couldn't verify its saved session. Orca left the saved session unchanged. Click Retry to try reconnecting now. If it still cannot reconnect, open a new terminal.",
             "e16012e31e": "The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered. Open a new terminal to continue.",
-            "sessionUnavailable": "Orca couldn't reattach to this pane's terminal session on the host. Open a new terminal to continue."
+            "sessionUnavailable": "Orca couldn't reattach to this pane's terminal session on the host. Open a new terminal to continue.",
+            "sourceRestoring": "Reconnecting this terminal — its output is being re-established. The session is still running."
           },
           "TerminalProcessExitOverlay": {
             "capacityTitle": "Git Bash console limit reached",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​182 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​182 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |

<!-- /orca-pr-loc -->

Replaces #18016. Ports only what the #17951 lease stack does not already have, expressed in the stack's existing vocabulary.

**Why this exists:** #18016 and the #17951 stack independently fixed the same defect with parallel vocabularies (`SSH_SOURCE_RESTORE_REQUIRED` vs `SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR`, retry 3 vs 2, `isProvenSshSessionGoneError` vs `isSshSessionGoneError`), conflicting on six files. #17951 is an ancestor of four PRs, so its vocabulary wins and #18016 should close in favour of this.

## Item 1 — the three-site ownership guard. **Zero sites were guarded, not one.**

I reported that the stack guarded one of three release/cancel sites in `activate()`. Checked: `src/relay/relay-pty-source-publication.ts` at the stack tip is **byte-identical to `main`** for this file. **None** of the three were guarded.

All three now derive ownership once and act only on a record the caller still owns:

```ts
const owned = current?.clientId === context?.clientId ? current : undefined
```

Three configurations of the same new test, verbatim:

| configuration | result |
|---|---|
| unguarded (stack tip) | FAIL — `AssertionError: expected true to be false` at `relay-pty-source-superseded-activation.test.ts:151:81` |
| **first site only** | FAIL — **identical** assertion, same line |
| all three guarded | PASS |

So the one-site fix #18016 shipped would not have closed the bug it targeted. The live path is the `unadmitted`/`subscriber` branch: a superseded transport released the rotation fence of the delivery **its own replacement had opened**, so a publish landed on a delivery still rotating.

Two deliberate non-ports, both flagged rather than silently dropped:
- **`clientTransportGeneration` / `sameClientTransport`** — that is #18016's *second* root cause (delivery record keyed on client id alone) and needs a new `RequestContext.transportGeneration` field the stack lacks. Ownership here is expressed with the stack's existing `record.clientId === context.clientId`, the same comparison `activate()` already makes twice below.
- **`context.isStale()` in the first bail-out** — a separate behavior change; out of scope.

One forced adjustment: the guard pushed the file to 301 counted lines against the 300 `max-lines` cap. Rather than a disable (forbidden), the one-line private wrapper `deliveryClosedUnderRecord` was inlined at its two call sites.

Residual behavior note, stated: an unowned record whose calling client is a `legacy-owner` is no longer cancelled by that caller. It stays owned by its actual source-owner client and is retired by that client's own settlement/exit path — which is the point.

## Item 2 — toast handling. Was missing, ported.

`SSH_PTY_SOURCE_RESTORE_REQUIRED` was matched nowhere in `TerminalErrorToast.tsx`, so the raw marker reached the user. It now has its own pattern, an `isExplainedTerminalError` entry, its own `humanizeTerminalError` replacement, and a `sourceRestoring` key.

Kept deliberately **out of `UNREATTACHABLE_SESSION_SOURCES`** — that copy says *"Open a new terminal"*, which here abandons a running agent.

The pattern is widened over #18016's, because the stack's message carries a trailing reason word that #18016's did not:
```
'SSH_PTY_SOURCE_RESTORE_REQUIRED(?::[ \t]*\S*(?:[ \t]+\S+)?)?'
```

Both new tests fail before / pass after:
- `describes a retired output source as reconnecting, not as a lost session` — before: `expected 'SSH_PTY_SOURCE_RESTORE_REQUIRED: remo…' not to contain 'SSH_PTY_SOURCE_RESTORE_REQUIRED'`
- `suppresses the issue link while a live session restores its output source` — before: `expected false to be true`

## Item 3 — render-time humanization. **Already present, skipped, no code written.**

`grep -rn "humanizeTerminalError" src/` returns exactly two hits, both in `TerminalErrorToast.tsx`: the definition and `const displayError = humanizeTerminalError(error)` at render. Nothing humanizes before storing, `remote-runtime-pty-transport.ts` stores the raw message, and `markRecoveryHealthy` replays those raw strings — so `clearPaneTerminalError`'s match still lines up. #18016's change to that file was an import swap only.

## User-facing regressions

**None expected.** The stack's token, retry count and predicate are untouched. Nothing certifies death from a `pty.attach` not-found (see #18029, which reverts exactly that).

## Testing

Both new/changed suites: 36 passed. Full relay `pty-source` set (12 files) + `dispatcher` + `ssh-pty-consumer-session-adapter`: 148 passed. All 421 `terminal-pane` suites: **4120 passed**. `tc:node` and `tc:web` clean; `check:code-quality:changed` 0 new findings across 47 files; `check:max-lines-ratchet` OK with no new bypasses.

## Not ported

`src/shared/ssh-pty-failure-tokens.ts`, `isProvenSshSessionGoneError` (a no-op over the stack's predicate once tokens are disjoint), the `= 3` retry constant, and the duplicate reattach/absence-verdict tests.
