### PR TITLE
fix(i18n): extract translateSearchKeyword calls so settings-search keywords reach en.json

### DIFF
--- a/config/i18next.config.ts
+++ b/config/i18next.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     ],
     output,
     defaultNS: false,
-    functions: ['t', '*.t', 'translate', 'translateMain'],
+    functions: ['t', '*.t', 'translate', 'translateMain', 'translateSearchKeyword'],
     useTranslationNames: ['useTranslation'],
     sort: true,
     disablePlurals: true,

--- a/config/scripts/verify-localization-catalog.mjs
+++ b/config/scripts/verify-localization-catalog.mjs
@@ -11,7 +11,7 @@ import { repairTranslatedValue } from './locale-translation-policy.mjs'
 
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts'])
 const SKIP_PATH_PARTS = new Set(['.git', 'dist', 'node_modules', 'out', '__snapshots__', 'assets'])
-const LOCALIZATION_FUNCTION_NAMES = new Set(['t', 'translate', 'translateMain'])
+const LOCALIZATION_FUNCTION_NAMES = new Set(['t', 'translate', 'translateMain', 'translateSearchKeyword'])
 const PLACEHOLDER_RE = /\{\{[^}]+\}\}/g
 const LOCALES_RELATIVE_DIR = path.join('src', 'renderer', 'src', 'i18n', 'locales')
 export const LOCALIZATION_SOURCE_ROOTS = [

--- a/config/scripts/verify-localization-catalog.test.mjs
+++ b/config/scripts/verify-localization-catalog.test.mjs
@@ -51,6 +51,20 @@ describe('verify-localization-catalog', () => {
     expect(readJson(path.join(localesDir, 'es.json'))).toEqual({})
   })
 
+  it('bootstraps keys referenced only through translateSearchKeyword', async () => {
+    const { root, localesDir } = makeProject({
+      sourceText:
+        "import { translateSearchKeyword } from '@/components/settings/settings-search-keywords'\nexport const keywords = translateSearchKeyword('auto.components.settings.example.search.scroll', 'scroll')\n"
+    })
+
+    await expect(verifyLocalizationCatalog(root, { fix: false })).resolves.toBe(1)
+    await expect(verifyLocalizationCatalog(root, { fix: true })).resolves.toBe(0)
+
+    expect(readJson(path.join(localesDir, 'en.json'))).toEqual({
+      auto: { components: { settings: { example: { search: { scroll: 'scroll' } } } } }
+    })
+  })
+
   it('never overwrites mismatched translations or removes target-only entries', async () => {
     const { root, localesDir } = makeProject({
       sourceText:

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -136,7 +136,12 @@
       },
       "menuBarIcon": {
         "title": "Show Menu Bar Icon",
-        "description": "Keep an Orca shortcut and activity indicator in the macOS menu bar."
+        "description": "Keep an Orca shortcut and activity indicator in the macOS menu bar.",
+        "keyword": {
+          "menuBar": "menu bar",
+          "statusItem": "status item",
+          "activity": "activity"
+        }
       }
     },
     "browser": {
@@ -8790,7 +8795,8 @@
             "d2c6a0e8f1": "grok",
             "c1b5f9d7e0": "xai",
             "b0a4e8c6d9": "oauth",
-            "a9f3d7b5c8": "login"
+            "a9f3d7b5c8": "login",
+            "d16378a88f": "minimax"
           }
         },
         "advanced": {
@@ -8869,7 +8875,16 @@
             "agentPermissions": "Agent Permissions",
             "agentPermissionsDescription": "Switch agent permission defaults between Yolo and Manual.",
             "agentRuntime": "Agent Runtime",
-            "agentRuntimeDescription": "Choose whether agents are detected and launched on Windows or in WSL by default."
+            "agentRuntimeDescription": "Choose whether agents are detected and launched on Windows or in WSL by default.",
+            "runtime": "runtime",
+            "agentLocation": "agent location",
+            "installedAgentsWsl": "installed agents in wsl",
+            "permission": "permission",
+            "permissions": "permissions",
+            "yolo": "yolo",
+            "manual": "manual",
+            "skip": "skip",
+            "checks": "checks"
           }
         },
         "appearance": {
@@ -8992,7 +9007,11 @@
             },
             "leftSidebarAppearance": {
               "title": "Left Sidebar Appearance",
-              "description": "Make the left sidebar match your terminal, stay default, or use a tint."
+              "description": "Make the left sidebar match your terminal, stay default, or use a tint.",
+              "project": "project",
+              "terminal": "terminal",
+              "background": "background",
+              "tint": "tint"
             },
             "workspaceCardLayout": {
               "title": "Workspace Card Layout",
@@ -9007,7 +9026,15 @@
             },
             "showPinnedWorktreesInGroups": {
               "title": "Also show pinned worktrees in their original lists",
-              "description": "Pinned worktrees stay in Pinned and also appear in All, Project, Status, and PR."
+              "description": "Pinned worktrees stay in Pinned and also appear in All, Project, Status, and PR.",
+              "pinned": "pinned",
+              "worktree": "worktree",
+              "workspace": "workspace",
+              "all": "all",
+              "project": "project",
+              "status": "status",
+              "pr": "pr",
+              "duplicate": "duplicate"
             },
             "antigravityUsageTitle": "Antigravity Usage",
             "antigravityUsageDescription": "Show Antigravity subscription usage in the status bar.",
@@ -9017,7 +9044,15 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Usage percentages",
-            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining."
+            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining.",
+            "tray": {
+              "tray": "tray",
+              "system": "system tray",
+              "minimize": "minimize",
+              "close": "close",
+              "notification": "notification area",
+              "background": "background"
+            }
           }
         },
         "auto": {
@@ -9111,7 +9146,26 @@
             "a942905148": "URL opened when creating a new browser tab. Leave empty to open a blank tab.",
             "c3903322d2": "Default Home Page",
             "19ea5607cf": "Localhost Worktree Labels",
-            "4e0fdf0a3f": "Open workspace ports as worktree-specific Orca localhost URLs so browser tabs are easier to tell apart."
+            "4e0fdf0a3f": "Open workspace ports as worktree-specific Orca localhost URLs so browser tabs are easier to tell apart.",
+            "6f5199381e": "ports",
+            "8f036ea11f": "worktree",
+            "c4e3bf3282": "tabs",
+            "a8c55c9c91": "favicon",
+            "660c1dd007": "labels",
+            "clientHostedRemote": {
+              "remote": "remote",
+              "client": "client",
+              "host": "host",
+              "desktop": "desktop",
+              "placement": "placement"
+            },
+            "sshWorkspaceRouting": {
+              "ssh": "ssh",
+              "proxy": "proxy",
+              "tunnel": "tunnel",
+              "routing": "routing",
+              "network": "network"
+            }
           },
           "use": {
             "search": {
@@ -9318,12 +9372,26 @@
             "nativeChat": {
               "title": "Chat UI",
               "description": "Preview the desktop chat surface for supported agent terminal sessions.",
-              "grok": "grok"
+              "grok": "grok",
+              "native": "native",
+              "chat": "chat",
+              "claude": "claude",
+              "codex": "codex",
+              "openclaude": "openclaude",
+              "omp": "omp",
+              "terminal": "terminal",
+              "agent": "agent"
             },
             "agentDashboard": {
               "title": "Agent Dashboard",
               "description": "Kanban board for monitoring agents across worktrees, in-window or as a pop-out.",
-              "dashboard": "dashboard"
+              "dashboard": "dashboard",
+              "agent": "agent",
+              "kanban": "kanban",
+              "popout": "pop-out",
+              "board": "board",
+              "inWindow": "in-window",
+              "worktrees": "worktrees"
             }
           }
         },
@@ -9495,7 +9563,24 @@
             "editorFontFamily": "Editor Font Family",
             "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
             "externalWorktrees": "External worktrees",
-            "externalWorktreesDescription": "Choose whether worktrees created outside Orca appear by default."
+            "externalWorktreesDescription": "Choose whether worktrees created outside Orca appear by default.",
+            "editorFontKw": "font",
+            "f96cdaf37d": "spellcheck",
+            "a51d23f4a1": "spell check",
+            "641358460a": "spelling",
+            "d755962089": "red underline",
+            "projectRuntime": "project runtime",
+            "runtime": "runtime",
+            "windowsHost": "windows host",
+            "wsl": "wsl",
+            "distro": "distro",
+            "execution": "execution",
+            "externalKeyword": "external",
+            "visibility": "visibility",
+            "sidebar": "sidebar",
+            "867dddea41": "pinned",
+            "5250cf0e48": "pin",
+            "afa37a34e1": "close"
           }
         },
         "git": {
@@ -9549,7 +9634,8 @@
             "upstream": "upstream",
             "localChanges": "local changes",
             "originMaster": "origin/master",
-            "committedChanges": "committed changes"
+            "committedChanges": "committed changes",
+            "diffBase": "diff base"
           }
         },
         "input": {
@@ -9744,7 +9830,13 @@
               "1de96ec8a6": "Show Orca Mobile Button",
               "682293cadf": "Show the Orca Mobile button at the top of the left sidebar.",
               "e4f4daea0e": "relay",
-              "5d5af8e041": "iphone"
+              "5d5af8e041": "iphone",
+              "74618577c7": "mobile",
+              "5e5b8878bf": "phone",
+              "5bff6a2ef0": "sidebar",
+              "6cf5f54ce1": "button",
+              "648eeada79": "hide",
+              "ac79fe4a04": "show"
             }
           }
         },
@@ -9987,7 +10079,25 @@
             "projectRuntime": "Project Runtime",
             "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL.",
             "externalWorktrees": "External worktrees",
-            "externalWorktreesDescription": "Override whether worktrees created outside Orca appear for this project."
+            "externalWorktreesDescription": "Override whether worktrees created outside Orca appear for this project.",
+            "waitForSetupBeforeAgent": "wait for setup before starting agent",
+            "external": "external",
+            "visibility": "visibility",
+            "sidebar": "sidebar",
+            "fork": "fork",
+            "upstream": "upstream",
+            "syncFork": "sync fork",
+            "fastForward": "fast-forward",
+            "behindUpstream": "behind upstream",
+            "origin": "origin",
+            "defaultBranch": "default branch",
+            "runtime": "runtime",
+            "execution": "execution",
+            "windowsHost": "windows host",
+            "wsl": "wsl",
+            "distro": "distro",
+            "agentRuntime": "agent runtime",
+            "skillRuntime": "skill runtime"
           }
         },
         "runtime": {
@@ -10096,7 +10206,9 @@
               "c38c18be15": "selection",
               "797fdfe4ca": "select",
               "603818e8d8": "Automatically copy terminal selections to the clipboard as soon as a selection is made.",
-              "3bdc84f059": "Copy on Select"
+              "3bdc84f059": "Copy on Select",
+              "zellij": "zellij",
+              "grok": "grok"
             }
           },
           "search": {
@@ -10290,7 +10402,22 @@
               "title": "Theme Mode",
               "keyword_target": "target",
               "keyword_editing": "editing"
-            }
+            },
+            "39ea7c0d28": "terminal",
+            "scroll": "scroll",
+            "scrolling": "scrolling",
+            "speed": "speed",
+            "wheel": "wheel",
+            "trackpad": "trackpad",
+            "tui": "tui",
+            "a0c44061ee": "confirm",
+            "close_terminal": "close",
+            "running": "running",
+            "command": "command",
+            "agent": "agent",
+            "process": "process",
+            "prompt": "prompt",
+            "stop": "stop"
           },
           "windows": {
             "search": {
@@ -10770,7 +10897,12 @@
         "ephemeralVms": {
           "search": {
             "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment.",
-            "cloudVmTitle": "Cloud VM"
+            "cloudVmTitle": "Cloud VM",
+            "keywordVm": "vm",
+            "keywordSandbox": "sandbox",
+            "keywordCloud": "cloud",
+            "keywordRecipe": "recipe",
+            "keywordEphemeral": "ephemeral"
           }
         },
         "EphemeralVmsPane": {
@@ -10828,7 +10960,12 @@
               },
               "search": {
                 "title": "Linear",
-                "description": "Linear skill status, usage examples, and links to Task Sources setup."
+                "description": "Linear skill status, usage examples, and links to Task Sources setup.",
+                "linear": "linear",
+                "tickets": "tickets",
+                "issues": "issues",
+                "skill": "skill",
+                "orcaLinear": "orca-linear"
               }
             }
           }
@@ -11427,7 +11564,15 @@
           "allowPublishingWebDescription": "Desktop only. Open Settings → Artifacts on the host device to change this setting.",
           "allowPublishingDescription": "Publish HTML and Markdown files as links anyone with the URL can open. Existing links remain until you delete them from Artifacts.",
           "howToDescriptionDisabled": "Enable artifact sharing above to publish HTML or Markdown files as public links.",
-          "allowPublishingSearchDescription": "Allow Orca to publish HTML and Markdown files as public links."
+          "allowPublishingSearchDescription": "Allow Orca to publish HTML and Markdown files as public links.",
+          "keywordArtifacts": "artifacts",
+          "keywordShare": "share",
+          "keywordPublish": "publish",
+          "keywordPublic": "public",
+          "keywordPermission": "permission",
+          "keywordHtml": "HTML",
+          "keywordMarkdown": "Markdown",
+          "keywordUpload": "upload"
         },
         "orcaAccount": {
           "connected": "Connected",
@@ -11449,7 +11594,14 @@
           "relayTitle": "Orca Relay",
           "relayDescription": "Connect Orca Mobile to this desktop across cellular or any Wi-Fi.",
           "skillsTitle": "Skill sharing",
-          "skillsDescription": "Share one skill or a whole set behind an unlisted link, and install them on any machine you use."
+          "skillsDescription": "Share one skill or a whole set behind an unlisted link, and install them on any machine you use.",
+          "keywordAccount": "account",
+          "keywordLogin": "login",
+          "keywordLogout": "logout",
+          "keywordSignIn": "sign in",
+          "keywordSignOut": "sign out",
+          "keywordRelay": "relay",
+          "keywordCloud": "cloud"
         },
         "automations": {
           "showButton": "Show Automations Button",
@@ -11465,7 +11617,11 @@
           "openAutomations": "Open Automations",
           "openAutomationsDescription": "Create schedules and inspect recent runs.",
           "title": "Automations",
-          "description": "Schedule agent work and choose whether Automations appears in the sidebar."
+          "description": "Schedule agent work and choose whether Automations appears in the sidebar.",
+          "keywordAutomations": "automations",
+          "keywordSchedule": "schedule",
+          "keywordAgent": "agent",
+          "keywordRuns": "runs"
         },
         "AgentAwakeSetting": {
           "on": "On",
@@ -11513,7 +11669,13 @@
           "unshare": "Unshare",
           "showButton": "Show Skills button",
           "showButtonDescription": "Show the Skills shortcut in the sidebar.",
-          "manageInSkills": "Manage in Skills"
+          "manageInSkills": "Manage in Skills",
+          "keywordSkills": "skills",
+          "keywordShare": "share",
+          "keywordBundle": "bundle",
+          "keywordLink": "link",
+          "keywordUnlisted": "unlisted",
+          "keywordRevoke": "revoke"
         },
         "bitbucket": {
           "credentials": {


### PR DESCRIPTION
## ELI5

Settings search keywords are declared through `translateSearchKeyword(key, fallback)`, but neither the i18next extractor nor the catalog sync knew about that wrapper. So keys added through it never reached `en.json`, and no locale — built-in or language pack — could translate them.

## What Changed

- `config/i18next.config.ts` — added `translateSearchKeyword` to `extract.functions`, so `verify:localization-extraction` sees the wrapper's keys.
- `config/scripts/verify-localization-catalog.mjs` — added it to `LOCALIZATION_FUNCTION_NAMES`, so `sync:localization-catalog` collects and bootstraps them. The two lists have to move together: the first one alone turns `verify:localization-extraction` red, because the extractor then finds keys the sync tool still cannot write.
- `src/renderer/src/i18n/locales/en.json` — regenerated with `pnpm run sync:localization-catalog`: **154 keys added, 0 changed, 0 removed** (155 at the time of opening; `agentDashboard.dashboard` has since landed in `main`).
- `config/scripts/verify-localization-catalog.test.mjs` — a test that bootstraps a key referenced only through the wrapper.

The wrapper's signature is `(key, fallback, options?)`, the same shape as `translate`, so both tools read it the same way they already read `translateMain`.

## Why

Measured against `v1.4.194`:

- `translateSearchKeyword` is called with **1 090** distinct keys. **935** were in `en.json`; **155** were not, and were therefore missing from `ko`, `ja`, `zh` and `es` as well. All of them are settings-search keywords (`auto.components.settings.*.search.*`) plus the `keyword*` entries under `orcaAccount` and `artifacts`.
- The wrapper (`src/renderer/src/components/settings/settings-search-keywords.ts`) calls `translate(key, fallback)` internally, so the keys are fully localizable at runtime — they were just invisible to both tools.
- `verify-localization-extraction.mjs` could not catch this on `main`: it compares the extracted catalog with `en.json`, and a key missing from both sides is not a mismatch. The 935 keys that *were* in `en.json` showed up as statically unreferenced orphans for the same reason.

A concrete example of what packs have to do in the meantime, and why it is fragile: mine supplements `en.json` by scanning the shipped bundle for those key/fallback pairs. Between 1.4.194 and 1.4.195 the bundle's minification changed — `translate` became a one-letter alias and the strings moved to template literals — and the scan silently returned nothing. Nothing in Orca broke; the pack just lost the 152 keys with no error to point at. Keys that live in `en.json` do not have that failure mode.

## Verification

- `verify:localization-catalog` — exit 0
- `verify:localization-extraction` — exit 0 (with `en.json` reverted it fails on the 155 keys, as expected)
- `verify-localization-catalog.test.mjs` — 8 passed, including the new case

## On `englishOnly` keywords

11 of the 155 keys are called with `englishOnly: true`, so `translate()` is never reached for them and the `en.json` entries are inert. They still land in the catalog because both tools key off the first argument, same as any other call. Harmless, but if you would rather keep them out, an `englishOnly` check in `collectLocalizationKeyReferences` would do it — happy to add that here or in a follow-up.

## Linked Issue

Part of #17913 — the third category discussed there.

Author: @IMGusev with Claude

