### PR TITLE
fix(release): verify minified telemetry constants

### DIFF
--- a/config/scripts/telemetry-bundle-constant-patterns.mjs
+++ b/config/scripts/telemetry-bundle-constant-patterns.mjs
@@ -1,2 +1,15 @@
-export const BUILD_IDENTITY_RE = /\b(?:const|let|var)\s+BUILD_IDENTITY\s*=\s*"(rc|stable)"/
-export const WRITE_KEY_RE = /\b(?:const|let|var)\s+WRITE_KEY\s*=\s*"(phc_[A-Za-z0-9_-]+)"/
+// Rolldown's minifier renames local declarations and prefers template literals.
+// Keep the named form strict; the verifier handles the lowered pair below.
+const DECLARED_NAME = '[A-Za-z_$][A-Za-z0-9_$]*'
+const STRING_QUOTE = '["`]'
+
+export const BUILD_IDENTITY_RE = new RegExp(
+  `\\b(?:const|let|var)\\s+BUILD_IDENTITY\\s*=\\s*${STRING_QUOTE}(rc|stable)${STRING_QUOTE}`
+)
+export const WRITE_KEY_RE = new RegExp(
+  `\\b(?:const|let|var)\\s+WRITE_KEY\\s*=\\s*${STRING_QUOTE}(phc_[A-Za-z0-9_-]+)${STRING_QUOTE}`
+)
+export const MINIFIED_TELEMETRY_CONSTANTS_RE = new RegExp(
+  `\\b(?:const|let|var)\\s+${DECLARED_NAME}\\s*=\\s*${STRING_QUOTE}(rc|stable)${STRING_QUOTE}` +
+    `\\s*,\\s*${DECLARED_NAME}\\s*=\\s*${STRING_QUOTE}(phc_[A-Za-z0-9_-]+)${STRING_QUOTE}`
+)

--- a/config/scripts/telemetry-bundle-constant-patterns.test.mjs
+++ b/config/scripts/telemetry-bundle-constant-patterns.test.mjs
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { BUILD_IDENTITY_RE, WRITE_KEY_RE } from './telemetry-bundle-constant-patterns.mjs'
+import {
+  BUILD_IDENTITY_RE,
+  MINIFIED_TELEMETRY_CONSTANTS_RE,
+  WRITE_KEY_RE
+} from './telemetry-bundle-constant-patterns.mjs'
 
 describe('telemetry bundle constant patterns', () => {
   it.each(['const', 'let', 'var'])('accepts %s declarations', (declaration) => {
@@ -12,5 +16,10 @@ describe('telemetry bundle constant patterns', () => {
     expect('const BUILD_IDENTITY = "dev"').not.toMatch(BUILD_IDENTITY_RE)
     expect('const WRITE_KEY = null').not.toMatch(WRITE_KEY_RE)
     expect('const WRITE_KEY = "example-key"').not.toMatch(WRITE_KEY_RE)
+  })
+
+  it('accepts rolldown-minified declarations', () => {
+    const minified = 'var qae=`stable`,Jae=`phc_abc123`'
+    expect(minified).toMatch(MINIFIED_TELEMETRY_CONSTANTS_RE)
   })
 })

--- a/config/scripts/verify-telemetry-constants.mjs
+++ b/config/scripts/verify-telemetry-constants.mjs
@@ -38,7 +38,11 @@ import { join, resolve } from 'node:path'
 // `node_modules`). If electron-builder ever drops it, promote this to a
 // direct devDependency in package.json.
 import { extractFile, listPackage } from '@electron/asar'
-import { BUILD_IDENTITY_RE, WRITE_KEY_RE } from './telemetry-bundle-constant-patterns.mjs'
+import {
+  BUILD_IDENTITY_RE,
+  MINIFIED_TELEMETRY_CONSTANTS_RE,
+  WRITE_KEY_RE
+} from './telemetry-bundle-constant-patterns.mjs'
 
 // Why resolve from import.meta.url instead of cwd: a release runner (or a
 // developer debugging locally) may invoke this script from a non-root cwd.
@@ -156,8 +160,11 @@ function verifyAsar(asarPath) {
 
   const buildIdentityMatch = BUILD_IDENTITY_RE.exec(indexJs)
   const writeKeyMatch = WRITE_KEY_RE.exec(indexJs)
+  const minifiedTelemetryMatch = MINIFIED_TELEMETRY_CONSTANTS_RE.exec(indexJs)
+  const resolvedBuildIdentity = buildIdentityMatch?.[1] ?? minifiedTelemetryMatch?.[1]
+  const resolvedWriteKey = writeKeyMatch?.[1] ?? minifiedTelemetryMatch?.[2]
 
-  if (!buildIdentityMatch) {
+  if (!resolvedBuildIdentity) {
     console.error(`::error::BUILD_IDENTITY constant missing or unexpected value in ${asarPath}`)
     const sample = indexJs.match(/.{0,80}BUILD_IDENTITY.{0,80}/g)?.slice(0, 5) ?? []
     for (const line of sample) {
@@ -165,7 +172,7 @@ function verifyAsar(asarPath) {
     }
     return null
   }
-  if (!writeKeyMatch) {
+  if (!resolvedWriteKey) {
     console.error(`::error::PostHog WRITE_KEY missing from ${asarPath}`)
     const sample = indexJs.match(/.{0,80}WRITE_KEY.{0,80}/g)?.slice(0, 5) ?? []
     for (const line of sample) {
@@ -174,7 +181,7 @@ function verifyAsar(asarPath) {
     return null
   }
 
-  return { asarPath, buildIdentity: buildIdentityMatch[1], writeKey: writeKeyMatch[1] }
+  return { asarPath, buildIdentity: resolvedBuildIdentity, writeKey: resolvedWriteKey }
 }
 
 // Why verify every match (not just the first): macOS dual-arch produces one


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |

<!-- /orca-pr-loc -->

## Summary

- recognize the paired minified telemetry identity and write-key declaration emitted by desktop production builds
- keep the readable named-declaration checks strict
- cover the minified output shape with a regression test

## Verification

- pnpm vitest run config/scripts/telemetry-bundle-constant-patterns.test.mjs
- pnpm tc
- pnpm run check:code-quality:changed
- exact verifier against a locally packed app.asar with stable identity and a synthetic phc_ key