### PR TITLE
perf(git): skip the sparse probe for worktree listings that never read it

### DIFF
--- a/src/main/git/worktree-listing.ts
+++ b/src/main/git/worktree-listing.ts
@@ -97,7 +97,7 @@ export async function listWorktreesStrict(
   return annotateSparseCheckoutStatus(repoPath, visibleWorktrees, options)
 }
 
-async function annotateSparseCheckoutStatus(
+export async function annotateSparseCheckoutStatus(
   repoPath: string,
   worktrees: GitWorktreeInfo[],
   options: GitWorktreeExecOptions = {}

--- a/src/main/git/worktree-scan-cache-annotation-reuse.test.ts
+++ b/src/main/git/worktree-scan-cache-annotation-reuse.test.ts
@@ -1,0 +1,93 @@
+// The annotated listing is the graph listing plus a sparse probe: callers that read only
+// `worktree.path` must skip the probe, without costing a second `git worktree list`.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitWorktreeInfo } from '../../shared/worktree/types'
+
+const { detectSparseCheckoutMock, readWorktreeListMock, readTranslatedWorktreeGraphMock } =
+  vi.hoisted(() => ({
+    detectSparseCheckoutMock: vi.fn(),
+    readWorktreeListMock: vi.fn(),
+    readTranslatedWorktreeGraphMock: vi.fn()
+  }))
+
+vi.mock('./worktree-sparse-state', () => ({
+  detectSparseCheckout: detectSparseCheckoutMock,
+  resolveGitCommonDir: vi.fn()
+}))
+vi.mock('./worktree-list-reader', () => ({
+  readCheckedOutBranchRef: vi.fn(),
+  readRepoCommonDirFromGit: vi.fn(),
+  readRepoLocation: vi.fn(),
+  readTranslatedWorktreeGraph: readTranslatedWorktreeGraphMock,
+  readWorktreeHeadOid: vi.fn(),
+  readWorktreeList: readWorktreeListMock
+}))
+
+import { _resetWorktreeScanCacheForTests, listWorktreeGraph, listWorktrees } from './worktree'
+import { __resetSparseCheckoutStateCacheForTests } from './worktree-sparse-checkout-cache'
+
+const REPO = '\\\\wsl.localhost\\Ubuntu\\home\\me\\repo'
+const ROW: GitWorktreeInfo = {
+  path: 'C:\\wt\\x',
+  head: 'a'.repeat(40),
+  branch: 'refs/heads/feature',
+  isBare: false,
+  isMainWorktree: false
+}
+
+describe('graph and annotated worktree scans', () => {
+  beforeEach(() => {
+    detectSparseCheckoutMock.mockReset()
+    detectSparseCheckoutMock.mockResolvedValue(true)
+    readWorktreeListMock.mockReset()
+    readWorktreeListMock.mockResolvedValue([ROW])
+    readTranslatedWorktreeGraphMock.mockReset()
+    readTranslatedWorktreeGraphMock.mockResolvedValue([ROW])
+    _resetWorktreeScanCacheForTests()
+    __resetSparseCheckoutStateCacheForTests()
+  })
+
+  it('does not probe sparse state for a graph scan', async () => {
+    const rows = await listWorktreeGraph(REPO, { wslDistro: 'Ubuntu' })
+
+    expect(rows[0]?.path).toBe('C:\\wt\\x')
+    expect(rows[0]?.isSparse).toBeUndefined()
+    expect(detectSparseCheckoutMock).not.toHaveBeenCalled()
+  })
+
+  it('still probes sparse state for the annotated scan', async () => {
+    const rows = await listWorktrees(REPO, { wslDistro: 'Ubuntu' })
+
+    expect(rows[0]?.isSparse).toBe(true)
+    expect(detectSparseCheckoutMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads the git listing once for an overlapping graph and annotated scan', async () => {
+    const [graphRows, annotatedRows] = await Promise.all([
+      listWorktreeGraph(REPO, { wslDistro: 'Ubuntu' }),
+      listWorktrees(REPO, { wslDistro: 'Ubuntu' })
+    ])
+
+    expect(readTranslatedWorktreeGraphMock).toHaveBeenCalledTimes(1)
+    expect(graphRows[0]?.isSparse).toBeUndefined()
+    expect(annotatedRows[0]?.isSparse).toBe(true)
+  })
+
+  // Sharing the listing must not make the probe-free caller wait on the probe it opted out of.
+  it('resolves a graph scan while the annotated scan is still probing', async () => {
+    let releaseProbe!: () => void
+    detectSparseCheckoutMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseProbe = () => resolve(true)
+        })
+    )
+
+    const annotatedScan = listWorktrees(REPO, { wslDistro: 'Ubuntu' })
+    const graphRows = await listWorktreeGraph(REPO, { wslDistro: 'Ubuntu' })
+
+    expect(graphRows[0]?.path).toBe('C:\\wt\\x')
+    releaseProbe()
+    expect((await annotatedScan)[0]?.isSparse).toBe(true)
+  })
+})

--- a/src/main/git/worktree-scan-cache-sharing.test.ts
+++ b/src/main/git/worktree-scan-cache-sharing.test.ts
@@ -98,7 +98,9 @@ describe('listWorktrees in-flight sharing', () => {
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps graph and annotated scans separate despite sharing the same Git listing', async () => {
+  // The annotated scan is the graph scan plus a sparse probe, so the two share one `git worktree
+  // list` and only the annotated caller pays the probe. They ran Git twice before.
+  it('runs one git listing for concurrent graph and annotated scans', async () => {
     const resolvers: ((value: { stdout: string }) => void)[] = []
     gitExecFileAsyncMock.mockImplementation(
       () =>
@@ -109,13 +111,34 @@ describe('listWorktrees in-flight sharing', () => {
 
     const graphScan = listWorktreeGraph('/repo')
     const annotatedScan = listWorktrees('/repo')
-    expect(resolvers).toHaveLength(2)
+    expect(resolvers).toHaveLength(1)
 
     for (const resolve of resolvers) {
       resolve({ stdout: 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n' })
     }
     await Promise.all([graphScan, annotatedScan])
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  // Order must not matter: whichever runs first owns the listing and the other joins it.
+  it('runs one git listing when the annotated scan starts first', async () => {
+    const resolvers: ((value: { stdout: string }) => void)[] = []
+    gitExecFileAsyncMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
+
+    const annotatedScan = listWorktrees('/repo')
+    const graphScan = listWorktreeGraph('/repo')
+    expect(resolvers).toHaveLength(1)
+
+    for (const resolve of resolvers) {
+      resolve({ stdout: 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n' })
+    }
+    await Promise.all([annotatedScan, graphScan])
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
   it('keeps graph scans with an AbortSignal isolated from shared callers', async () => {
@@ -352,14 +375,15 @@ describe('listWorktrees in-flight sharing', () => {
     expect(scanResolvers).toHaveLength(1)
 
     await moveWorktree('/repo', '/repo-old', '/repo-new')
-    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 1, generations: 1 })
+    // Two entries per annotated scan: its own, plus the graph listing it shares with probe-free callers.
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 2, generations: 1 })
 
     const freshScan = listWorktrees('/repo')
-    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 2, generations: 1 })
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 4, generations: 1 })
 
     scanResolvers[1]?.('worktree /repo-new\nHEAD fresh\nbranch refs/heads/main\n')
     expect((await freshScan)[0]?.path).toBe('/repo-new')
-    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 1, generations: 1 })
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 2, generations: 1 })
 
     scanResolvers[0]?.('worktree /repo\nHEAD stale\nbranch refs/heads/main\n')
     expect((await staleScan)[0]?.path).toBe('/repo')
@@ -396,7 +420,7 @@ describe('listWorktrees in-flight sharing', () => {
     const newestScan = listWorktrees('/repo')
 
     expect(listCalls).toBe(3)
-    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 3, generations: 1 })
+    expect(_getWorktreeScanCacheSizesForTests()).toEqual({ inFlight: 6, generations: 1 })
 
     scanResolvers[0]?.()
     scanResolvers[2]?.()

--- a/src/main/git/worktree-scan-cache.ts
+++ b/src/main/git/worktree-scan-cache.ts
@@ -1,8 +1,8 @@
 import type { GitWorktreeInfo } from '../../shared/worktree/types'
 import {
+  annotateSparseCheckoutStatus,
   listWorktreeGraph as listWorktreeGraphUnshared,
-  listWorktreesStrict as listWorktreesStrictUnshared,
-  listWorktreesUnshared
+  listWorktreesStrict as listWorktreesStrictUnshared
 } from './worktree-listing'
 import type { GitWorktreeExecOptions } from './worktree-operation-options'
 import { WORKTREE_LIST_TIMEOUT_MS } from './worktree-operation-options'
@@ -91,6 +91,22 @@ function shareWorktreeScan(
 }
 
 /**
+ * Sparse annotation layered over the shared graph scan rather than its own `git worktree list`.
+ *
+ * Both paths soften a Git failure to `[]`, so they can share one listing; only this one pays the
+ * per-worktree sparse probe. That lets a caller which reads just `worktree.path` skip the probes
+ * without costing a second subprocess when it overlaps a badge reader — the two ran Git twice
+ * before. Strict stays on its own scan because it must be able to reject.
+ */
+async function runAnnotatedWorktreeScan(
+  repoPath: string,
+  options: GitWorktreeExecOptions
+): Promise<GitWorktreeInfo[]> {
+  const worktrees = await listWorktreeGraph(repoPath, options)
+  return annotateSparseCheckoutStatus(repoPath, worktrees, options)
+}
+
+/**
  * List all worktrees for a git repo at the given path. Concurrent calls for
  * the same repo share one scan (unless the caller passes an AbortSignal,
  * which must only cancel its own scan). Git failures soften to `[]`.
@@ -99,7 +115,7 @@ export function listWorktrees(
   repoPath: string,
   options: GitWorktreeExecOptions = {}
 ): Promise<GitWorktreeInfo[]> {
-  return shareWorktreeScan(repoPath, options, 'lenient', listWorktreesUnshared)
+  return shareWorktreeScan(repoPath, options, 'lenient', runAnnotatedWorktreeScan)
 }
 
 /**

--- a/src/main/ipc/created-worktree-root-prune.test.ts
+++ b/src/main/ipc/created-worktree-root-prune.test.ts
@@ -2,7 +2,7 @@ import type * as NodeFsPromises from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as RepoWorktrees from '../repo-worktrees'
-import { listRepoWorktrees } from '../repo-worktrees'
+import { listRepoWorktreeGraph } from '../repo-worktrees'
 import type { Store } from '../persistence'
 import type { Repo } from '../../shared/repo-types'
 import {
@@ -22,7 +22,7 @@ vi.mock('node:fs/promises', async () => {
 
 vi.mock('../repo-worktrees', async () => {
   const actual = await vi.importActual<typeof RepoWorktrees>('../repo-worktrees')
-  return { ...actual, listRepoWorktrees: vi.fn() }
+  return { ...actual, listRepoWorktreeGraph: vi.fn() }
 })
 
 const repo: Repo = {
@@ -56,10 +56,10 @@ describe('recovered worktree root pruning', () => {
   beforeEach(() => {
     invalidateAuthorizedRootsCache()
     __resetCreatedWorktreeRootsForTests()
-    vi.mocked(listRepoWorktrees).mockReset()
+    vi.mocked(listRepoWorktreeGraph).mockReset()
     // The #16520 outage itself: `listWorktrees` softens every Git failure to `[]`, so the rebuild
     // reports success with the recovered row missing and the probe is the only remaining evidence.
-    vi.mocked(listRepoWorktrees).mockResolvedValue([])
+    vi.mocked(listRepoWorktreeGraph).mockResolvedValue([])
     statMock.mockReset()
     statMock.mockResolvedValue({})
   })

--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -5,7 +5,7 @@ import { join, resolve } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from '../persistence'
 import type * as RepoWorktrees from '../repo-worktrees'
-import { listRepoWorktrees } from '../repo-worktrees'
+import { listRepoWorktreeGraph } from '../repo-worktrees'
 import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../shared/project-group-types'
 import type { Repo } from '../../shared/repo-types'
@@ -29,7 +29,7 @@ vi.mock('../repo-worktrees', async () => {
   const actual = await vi.importActual<typeof RepoWorktrees>('../repo-worktrees')
   return {
     ...actual,
-    listRepoWorktrees: vi.fn()
+    listRepoWorktreeGraph: vi.fn()
   }
 })
 
@@ -98,7 +98,7 @@ describe('filesystem auth worktree roots', () => {
   beforeEach(() => {
     invalidateAuthorizedRootsCache()
     __resetCreatedWorktreeRootsForTests()
-    vi.mocked(listRepoWorktrees).mockReset()
+    vi.mocked(listRepoWorktreeGraph).mockReset()
   })
 
   it('rebuilds the authorized roots cache for large worktree lists', async () => {
@@ -112,7 +112,7 @@ describe('filesystem auth worktree roots', () => {
         isMainWorktree: false
       })
     )
-    vi.mocked(listRepoWorktrees).mockResolvedValue(worktrees)
+    vi.mocked(listRepoWorktreeGraph).mockResolvedValue(worktrees)
     const store = makeStore()
 
     await rebuildAuthorizedRootsCache(store)
@@ -121,7 +121,7 @@ describe('filesystem auth worktree roots', () => {
     await expect(resolveRegisteredWorktreePath(lastWorktreePath, store)).resolves.toBe(
       resolve(lastWorktreePath)
     )
-    expect(listRepoWorktrees).toHaveBeenCalledTimes(1)
+    expect(listRepoWorktreeGraph).toHaveBeenCalledTimes(1)
   })
 
   it("keeps a repo's roots when its listing fails mid-rebuild", async () => {
@@ -129,7 +129,7 @@ describe('filesystem auth worktree roots', () => {
     // a worktree a create just recovered without a listing (#16520).
     const store = makeStore()
     registerCreatedWorktreeRoot(store, repo.id, '/linked/recovered')
-    vi.mocked(listRepoWorktrees).mockRejectedValue(new Error('git worktree list failed.'))
+    vi.mocked(listRepoWorktreeGraph).mockRejectedValue(new Error('git worktree list failed.'))
 
     await rebuildAuthorizedRootsCache(store)
 
@@ -146,7 +146,7 @@ describe('filesystem auth worktree roots', () => {
     await mkdir(recovered)
     const store = makeStore()
     registerCreatedWorktreeRoot(store, repo.id, recovered)
-    vi.mocked(listRepoWorktrees).mockResolvedValue([])
+    vi.mocked(listRepoWorktreeGraph).mockResolvedValue([])
 
     await rebuildAuthorizedRootsCache(store)
 
@@ -160,7 +160,7 @@ describe('filesystem auth worktree roots', () => {
     await mkdir(recovered)
     const store = makeStore()
     // Register mid-listing: the rebuild's own result was computed before this worktree existed.
-    vi.mocked(listRepoWorktrees).mockImplementation(async () => {
+    vi.mocked(listRepoWorktreeGraph).mockImplementation(async () => {
       registerCreatedWorktreeRoot(store, repo.id, recovered)
       return []
     })
@@ -174,7 +174,7 @@ describe('filesystem auth worktree roots', () => {
   it('retires a recovered root once the listing can see it again', async () => {
     const store = makeStore()
     registerCreatedWorktreeRoot(store, repo.id, '/linked/feature')
-    vi.mocked(listRepoWorktrees).mockResolvedValue([
+    vi.mocked(listRepoWorktreeGraph).mockResolvedValue([
       {
         path: '/linked/feature',
         head: '',
@@ -189,7 +189,7 @@ describe('filesystem auth worktree roots', () => {
     await expect(resolveRegisteredWorktreePath('/linked/feature', store)).resolves.toBe(
       resolve('/linked/feature')
     )
-    vi.mocked(listRepoWorktrees).mockResolvedValue([])
+    vi.mocked(listRepoWorktreeGraph).mockResolvedValue([])
     await rebuildAuthorizedRootsCache(store)
 
     await expect(resolveRegisteredWorktreePath('/linked/feature', store)).rejects.toThrow(
@@ -205,7 +205,7 @@ describe('filesystem auth worktree roots', () => {
     }))
     let active = 0
     let maxActive = 0
-    vi.mocked(listRepoWorktrees).mockImplementation(async () => {
+    vi.mocked(listRepoWorktreeGraph).mockImplementation(async () => {
       active += 1
       maxActive = Math.max(maxActive, active)
       await new Promise((resolve) => setTimeout(resolve, 1))
@@ -215,7 +215,7 @@ describe('filesystem auth worktree roots', () => {
 
     await rebuildAuthorizedRootsCache(makeStore(repos))
 
-    expect(listRepoWorktrees).toHaveBeenCalledTimes(repos.length)
+    expect(listRepoWorktreeGraph).toHaveBeenCalledTimes(repos.length)
     expect(maxActive).toBeLessThanOrEqual(8)
   })
 })
@@ -392,7 +392,7 @@ describe('filesystem-auth path containment', () => {
     vi.resetModules()
     vi.doMock('../repo-worktrees', () => ({
       isRepoRoot: vi.fn(),
-      listRepoWorktrees: vi.fn()
+      listRepoWorktreeGraph: vi.fn()
     }))
     vi.doMock('path', async () => {
       const path = await vi.importActual<typeof NodePath>('node:path')

--- a/src/main/ipc/filesystem-test-harness.ts
+++ b/src/main/ipc/filesystem-test-harness.ts
@@ -107,6 +107,7 @@ export const gitStatusModuleMock = {
 export const gitIgnoredPathsMock = { checkIgnoredPaths: checkIgnoredPathsMock }
 
 export const gitWorktreeMock = {
+  listWorktreeGraph: listWorktreesMock,
   listWorktrees: listWorktreesMock,
   listWorktreesStrict: listWorktreesMock
 }

--- a/src/main/ipc/filesystem/filesystem-source-control-ai-targets.ts
+++ b/src/main/ipc/filesystem/filesystem-source-control-ai-targets.ts
@@ -5,7 +5,7 @@ import type { CommitMessageAgentRuntimeTarget } from '../../text-generation/comm
 import type { CommitMessageGenerationTarget } from '../../text-generation/commit-message-text-generation'
 import { resolve } from 'node:path'
 import { getSshGitProvider } from '../../providers/ssh-git-dispatch'
-import { listRepoWorktrees } from '../../repo-worktrees'
+import { listRepoWorktreeGraph } from '../../repo-worktrees'
 import { resolveAuthorizedPath } from '../filesystem-auth'
 import { resolveRegisteredWorktreePath } from '../registered-worktree-roots-cache'
 import { splitWorktreeId } from '../../../shared/worktree/id'
@@ -77,7 +77,7 @@ async function localRepoOwnsWorktree(
     return true
   }
   try {
-    const worktrees = await listRepoWorktrees(repo)
+    const worktrees = await listRepoWorktreeGraph(repo)
     return worktrees.some((worktree) => candidatePaths.has(comparableLocalPath(worktree.path)))
   } catch {
     return false

--- a/src/main/ipc/hosted-review.test.ts
+++ b/src/main/ipc/hosted-review.test.ts
@@ -17,7 +17,7 @@ const {
   getHostedReviewCreationEligibilityMock,
   getHostedReviewForBranchMock,
   resolveRegisteredWorktreePathMock,
-  listRepoWorktreesMock
+  listRepoWorktreeGraphMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   createHostedReviewMock: vi.fn(),
@@ -25,7 +25,7 @@ const {
   getHostedReviewCreationEligibilityMock: vi.fn(),
   getHostedReviewForBranchMock: vi.fn(),
   resolveRegisteredWorktreePathMock: vi.fn(),
-  listRepoWorktreesMock: vi.fn()
+  listRepoWorktreeGraphMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -52,7 +52,7 @@ vi.mock('./registered-worktree-roots-cache', () => ({
 }))
 
 vi.mock('../repo-worktrees', () => ({
-  listRepoWorktrees: listRepoWorktreesMock
+  listRepoWorktreeGraph: listRepoWorktreeGraphMock
 }))
 
 import { registerHostedReviewHandlers } from './hosted-review'
@@ -97,7 +97,7 @@ describe('registerHostedReviewHandlers', () => {
     getHostedReviewCreationEligibilityMock.mockReset()
     getHostedReviewForBranchMock.mockReset()
     resolveRegisteredWorktreePathMock.mockReset()
-    listRepoWorktreesMock.mockReset()
+    listRepoWorktreeGraphMock.mockReset()
     store.getRepo.mockReset()
     store.getRepos.mockReset()
     store.getProjects.mockReset()
@@ -114,7 +114,7 @@ describe('registerHostedReviewHandlers', () => {
     store.getRepos.mockReturnValue([repo])
     store.getProjects.mockReturnValue([])
     store.getSettings.mockReturnValue({ localWindowsRuntimeDefault: { kind: 'windows-host' } })
-    listRepoWorktreesMock.mockResolvedValue([{ path: worktreePath }])
+    listRepoWorktreeGraphMock.mockResolvedValue([{ path: worktreePath }])
   })
 
   it('routes local WSL project review creation through main-process runtime options', async () => {
@@ -143,7 +143,7 @@ describe('registerHostedReviewHandlers', () => {
     ])
     const resolvedWorktreePath = resolve('/workspace/feature')
     resolveRegisteredWorktreePathMock.mockResolvedValue(resolvedWorktreePath)
-    listRepoWorktreesMock.mockResolvedValue([{ path: resolvedWorktreePath }])
+    listRepoWorktreeGraphMock.mockResolvedValue([{ path: resolvedWorktreePath }])
     createHostedReviewMock.mockResolvedValueOnce({
       ok: true,
       number: 42,
@@ -162,7 +162,7 @@ describe('registerHostedReviewHandlers', () => {
       title: 'Feature PR'
     })
 
-    expect(listRepoWorktreesMock).toHaveBeenCalledWith(localRepo, { wslDistro: 'Ubuntu' })
+    expect(listRepoWorktreeGraphMock).toHaveBeenCalledWith(localRepo, { wslDistro: 'Ubuntu' })
     expect(createHostedReviewMock).toHaveBeenCalledWith(
       resolvedWorktreePath,
       expect.objectContaining({
@@ -193,7 +193,7 @@ describe('registerHostedReviewHandlers', () => {
     store.getRepos.mockReturnValue([localRepo])
     const resolvedWorktreePath = resolve('/workspace/feature')
     resolveRegisteredWorktreePathMock.mockResolvedValue(resolvedWorktreePath)
-    listRepoWorktreesMock.mockResolvedValue([{ path: resolvedWorktreePath }])
+    listRepoWorktreeGraphMock.mockResolvedValue([{ path: resolvedWorktreePath }])
     createHostedReviewMock.mockResolvedValueOnce({ ok: true, number: 42, url: 'https://x/1' })
 
     registerHostedReviewHandlers(store as never, stats as never)

--- a/src/main/ipc/hosted-review.ts
+++ b/src/main/ipc/hosted-review.ts
@@ -16,7 +16,7 @@ import {
 import { createStackedHostedReview } from '../source-control/stacked-hosted-review-creation'
 import { getHostedReviewForBranch } from '../source-control/hosted-review'
 import { resolveRegisteredWorktreePath } from './registered-worktree-roots-cache'
-import { listRepoWorktrees } from '../repo-worktrees'
+import { listRepoWorktreeGraph } from '../repo-worktrees'
 import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
 import { getWorktreeSharedLinkPaths } from '../git/worktree-shared-directories'
 import { getRepoExecutionHostId } from '../../shared/execution-host'
@@ -68,7 +68,7 @@ async function resolveHostedReviewWorktreePath(
   }
   if (repo.connectionId) {
     const remoteWorktreePath = normalizeRemoteHostedReviewPath(worktreePath)
-    const repoWorktrees = await listRepoWorktrees(repo)
+    const repoWorktrees = await listRepoWorktreeGraph(repo)
     if (
       !repoWorktrees.some(
         (worktree) => normalizeRemoteHostedReviewPath(worktree.path) === remoteWorktreePath
@@ -82,8 +82,8 @@ async function resolveHostedReviewWorktreePath(
   const localGitOptions = getLocalProjectWorktreeGitOptions(store, repo)
   const repoWorktrees =
     Object.keys(localGitOptions).length > 0
-      ? await listRepoWorktrees(repo, localGitOptions)
-      : await listRepoWorktrees(repo)
+      ? await listRepoWorktreeGraph(repo, localGitOptions)
+      : await listRepoWorktreeGraph(repo)
   if (!repoWorktrees.some((worktree) => resolve(worktree.path) === resolvedWorktreePath)) {
     throw new Error('Access denied: worktree does not belong to repository')
   }

--- a/src/main/ipc/registered-worktree-roots-cache.ts
+++ b/src/main/ipc/registered-worktree-roots-cache.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import { withTimeout } from '../../shared/promise-timeout-fallback'
 import { getErrorCode } from '../git/worktree-operation-options'
 import type { Store } from '../persistence'
-import { isRepoRoot, listRepoWorktrees } from '../repo-worktrees'
+import { isRepoRoot, listRepoWorktreeGraph } from '../repo-worktrees'
 import { getLocalRepos } from './filesystem-allowed-roots'
 import { isDescendantOrEqual, normalizeExistingPath } from './filesystem-path-containment'
 
@@ -54,7 +54,7 @@ export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
       try {
         roots.push(resolve(repo.path))
 
-        for (const worktree of await listRepoWorktrees(repo)) {
+        for (const worktree of await listRepoWorktreeGraph(repo)) {
           roots.push(resolve(worktree.path))
         }
       } catch (error) {

--- a/src/main/repo-worktrees.test.ts
+++ b/src/main/repo-worktrees.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { listWorktreesMock, listWorktreesStrictMock } = vi.hoisted(() => ({
+const { listWorktreeGraphMock, listWorktreesMock, listWorktreesStrictMock } = vi.hoisted(() => ({
+  listWorktreeGraphMock: vi.fn(),
   listWorktreesMock: vi.fn(),
   listWorktreesStrictMock: vi.fn()
 }))
 
 vi.mock('./git/worktree', () => ({
+  listWorktreeGraph: listWorktreeGraphMock,
   listWorktrees: listWorktreesMock,
   listWorktreesStrict: listWorktreesStrictMock
 }))
@@ -14,11 +16,13 @@ import {
   createFolderWorktree,
   isRepoRoot,
   listLocalRepoWorktreesStrict,
+  listRepoWorktreeGraph,
   listRepoWorktrees
 } from './repo-worktrees'
 
 describe('repo-worktrees', () => {
   beforeEach(() => {
+    listWorktreeGraphMock.mockReset()
     listWorktreesMock.mockReset()
     listWorktreesStrictMock.mockReset()
   })
@@ -107,6 +111,49 @@ describe('repo-worktrees', () => {
 
     expect(listWorktreesMock).toHaveBeenCalledWith('/workspace/repo', { signal })
     expect(result).toHaveLength(1)
+  })
+
+  // Path-only callers must reach the probe-free listing, never the annotated one.
+  it('delegates to the graph listing without sparse annotation', async () => {
+    listWorktreeGraphMock.mockResolvedValue([
+      { path: '/workspace/repo', head: 'abc', branch: '', isBare: false, isMainWorktree: true }
+    ])
+
+    const result = await listRepoWorktreeGraph({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      kind: 'git'
+    })
+
+    expect(listWorktreeGraphMock).toHaveBeenCalledWith('/workspace/repo')
+    expect(listWorktreesMock).not.toHaveBeenCalled()
+    expect(result).toHaveLength(1)
+  })
+
+  it('returns the synthetic folder worktree from the graph listing', async () => {
+    const result = await listRepoWorktreeGraph({
+      id: 'repo-1',
+      path: '/workspace/folder',
+      displayName: 'folder',
+      badgeColor: '#000',
+      addedAt: 0,
+      kind: 'folder'
+    })
+
+    expect(listWorktreeGraphMock).not.toHaveBeenCalled()
+    expect(result).toEqual([
+      createFolderWorktree({
+        id: 'repo-1',
+        path: '/workspace/folder',
+        displayName: 'folder',
+        badgeColor: '#000',
+        addedAt: 0,
+        kind: 'folder'
+      })
+    ])
   })
 
   it('delegates strict local listing with the signal and WSL options', async () => {

--- a/src/main/repo-worktrees.ts
+++ b/src/main/repo-worktrees.ts
@@ -1,6 +1,6 @@
 import type { Repo } from '../shared/repo-types'
 import type { GitWorktreeInfo } from '../shared/worktree/types'
-import { listWorktrees, listWorktreesStrict } from './git/worktree'
+import { listWorktreeGraph, listWorktrees, listWorktreesStrict } from './git/worktree'
 import { isFolderRepo } from '../shared/repo-kind'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
 import { areWorktreePathsEqual } from './ipc/worktree-logic'
@@ -50,6 +50,29 @@ export async function listRepoWorktrees(
   return hasLocalRepoWorktreeListOptions(options)
     ? await listWorktrees(repo.path, options)
     : await listWorktrees(repo.path)
+}
+
+/**
+ * Worktree rows for callers that read only `worktree.path`.
+ *
+ * Skips the sparse-checkout probe behind the badge, which those callers discard. On a WSL repo the
+ * probe is a 9p stat plus a config read per worktree, re-paid cold after every worktree
+ * create/remove because that invalidates both the authorized-roots cache and the sparse cache.
+ */
+export async function listRepoWorktreeGraph(
+  repo: Repo,
+  options?: LocalRepoWorktreeListOptions
+): Promise<GitWorktreeInfo[]> {
+  if (isFolderRepo(repo)) {
+    return [createFolderWorktree(repo)]
+  }
+  if (repo.connectionId) {
+    const provider = getSshGitProvider(repo.connectionId)
+    return provider ? await provider.listWorktrees(repo.path) : []
+  }
+  return hasLocalRepoWorktreeListOptions(options)
+    ? await listWorktreeGraph(repo.path, options)
+    : await listWorktreeGraph(repo.path)
 }
 
 export async function listLocalRepoWorktreesStrict(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​197 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​33 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​164 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 |

<!-- /orca-pr-loc -->

## ELI5

Every worktree row Orca lists carries a little "this checkout is sparse" flag. Working out that
flag means touching the disk: check whether a `sparse-checkout` pattern file exists, and if it
does, read a git config to confirm the mode is actually on. Cheap on a local SSD. Not cheap on a
WSL repo, where every one of those touches crosses the 9p filesystem bridge.

Three places in Orca ask for the worktree list and then only ever look at `worktree.path`. They
never read the flag. But they were calling the listing that computes it, so they paid for that
disk work once per worktree and threw the answer away.

The worst of the three is the filesystem-authorization rebuild — the thing that decides which
folders Orca is allowed to open. It re-runs after **every worktree create and remove**. So the
loop was: create a worktree → the flag cache is dropped → the auth rebuild lists every worktree in
every repo and probes every one of them from cold → and discards all of it.

This PR gives those three callers a listing that just doesn't compute the flag.

The catch, and the reason this isn't a three-line change: Orca shares one `git worktree list`
between callers that ask at the same time, and it decides who can share with whom using a "kind"
tag. The probe-free listing and the flag-carrying listing were different kinds, so they couldn't
share — meaning "stop probing" would have quietly started a **second** `git worktree list`
whenever the auth rebuild overlapped a sidebar refresh. On macOS, Linux and native Windows that
trade is a loss: you'd save a few cheap stats and pay for a whole extra Git process.

So instead of making them two separate scans, the flag-carrying listing is now built *on top of*
the probe-free one — it runs that, then adds the flag. One Git call feeds both, and only the
caller that wants the flag pays for it. Those two used to run Git twice when they overlapped, so
the overlap case comes out **faster** than before rather than paying a toll for the opt-out.

**Analogy:** a delivery van drops parcels at every house on the street, and for each house someone
also walks up the drive to check whether the porch light is on. Three of the people waiting only
ever wanted to know which houses exist — they never asked about porch lights. Before, ordering
"no porch-light check" would have sent out a second van. Now there's still one van; the porch-light
walk is just an optional extra for whoever actually asked.

## What changed

`listRepoWorktreeGraph` routes path-only callers to `listWorktreeGraph`, which already existed as
the annotation-free listing (#17655). The three callers:

| Call site | What it reads | Why it runs |
|---|---|---|
| `registered-worktree-roots-cache.ts` | `resolve(worktree.path)` | filesystem-auth authorized roots; `invalidateAuthorizedRootsCache()` fires on every worktree create/remove plus repo add/clone/settings changes |
| `filesystem-source-control-ai-targets.ts` | `comparableLocalPath(worktree.path)` | does this local repo own this worktree path |
| `hosted-review.ts` | `resolve(worktree.path)` | worktree-belongs-to-repo check before granting access |

And the sharing fix that makes it free: `listWorktrees` is now `listWorktreeGraph` plus
annotation, rather than a parallel scan of its own. Both soften a Git failure to `[]`, so they can
share one listing. Strict keeps its own scan because it must be able to reject.

An annotated scan holds two in-flight entries now — its own, plus the graph listing it shares.
Keeping its own entry matters: `detectSparseCheckoutCached` dedupes revalidation but not the
initial fill, so two concurrent badge readers sharing only the graph scan would both probe.

## Why the cost was doubled, not just wasted

#17859 cached the probe; #17932 keyed that cache on the WSL distro, which fixed a wrong answer but
also meant the distro-less callers above populate a *second* entry per worktree — probed cold,
revalidated on their own five-minute loop, read by nobody. Worktree create/remove clears the sparse
cache and dirties the roots cache together, so both variants go cold at once and the discarded half
gets re-probed in full on the next auth check.

#17932 deferred this as "a separate, larger change." It turned out smaller than expected, because
`listWorktreeGraph` already existed — the work was in the sharing, not the listing.

## Per-platform delta

- **macOS / Linux** — fewer probes at the three call sites; one `git worktree list` instead of two
  when a graph and an annotated scan overlap.
- **native Windows, no WSL** — same, and the saved subprocess is the expensive half.
- **Windows + WSL** — the largest win. The discarded probes were 9p round-trips re-paid cold after
  every worktree create/remove.
- **SSH / relay** — none. `listRepoWorktreeGraph` returns through the same provider branch as
  `listRepoWorktrees` before reaching local Git.
- **Folder workspaces** — none. Both return the same synthetic folder worktree.

## Verification

**Live on Windows 11 + WSL (Ubuntu-24.04, distro Git 2.43.0)**, against the layout #17932 fixed —
repo inside the distro at `/home/neil/wsl-sparse-repro/repo`, worktrees on the Windows drive, so
the `.git` gitfile points at a guest path with no drive letter to derive. Distro Git emits no
`sparse` porcelain line, so the fallback probe is genuinely the path under test.

| Check | Result |
|---|---|
| sparse badge via `listWorktreesStrict` | `C:\wt\sparse-x:true` — unchanged |
| sparse badge via `listWorktrees` (now layered) | `C:\wt\sparse-x:true` — unchanged |
| `listWorktreeGraph` rows | same 3 rows, every `isSparse` undefined |
| sparse-cache entries after a roots-rebuild-style read | **0** |
| sparse-cache entries after a badge read | **3** (one per worktree) |

That last pair is the win, measured: one probe per worktree per rebuild, gone.

**Test suites**

- macOS full `src/main/`: 2948 files / 30012 passed. One unrelated flake
  (`ssh-remote-commands.test.ts`, zero worktree references, passes in isolation).
- Windows `src/main/git/` + the touched IPC consumers: 11 files / 30 tests fail — **identical to
  the `origin/main` baseline on the same machine** (`EPERM: operation not permitted, symlink`,
  needs Developer Mode). Branch adds 7 passing tests there.
- `pnpm tc` clean; `check:code-quality:changed` 0 new findings.

## Tests added

- `worktree-scan-cache-annotation-reuse.test.ts` — graph scan runs no probe; annotated scan still
  does; an overlapping pair reads the Git listing once; the graph caller resolves while the
  annotated one is still probing (the opt-out must not become a wait).
- `worktree-scan-cache-sharing.test.ts` — the two former "graph and annotated run Git twice" cases
  now assert one call, in both orders. In-flight count assertions updated for the nested entry.
- `repo-worktrees.test.ts` — `listRepoWorktreeGraph` reaches the graph listing and never the
  annotated one; folder repos still return the synthetic worktree.

## Not in this change

- The badge listing itself. It still probes, still annotates, still keys on the distro exactly as
  #17932 left it.
- The remaining `listRepoWorktrees` callers — they read `isSparse`, or feed rows to something that
  does.
