### PR TITLE
fix(terminal): keep a deliberately slept workspace cold until it is woken

### DIFF
--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -190,6 +190,27 @@ describe('runSleepWorktree', () => {
     expect(mocks.clearWorktreeSleepIntent).not.toHaveBeenCalled()
   })
 
+  it('marks each worktree only when its own teardown starts', async () => {
+    let releaseFirst: () => void = () => {}
+    mocks.state.shutdownWorktreeBrowsers.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = resolve
+        })
+    )
+
+    const run = runSleepWorktrees(['wt-1', 'wt-2'])
+    await Promise.resolve()
+
+    // Why: wt-2 is still awake while wt-1 tears down; marking it early would
+    // hold its panes cold and swallow its activity.
+    expect(mocks.markWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
+    expect(mocks.markWorktreeSleepIntent).not.toHaveBeenCalledWith('wt-2')
+    releaseFirst()
+    await run
+    expect(mocks.markWorktreeSleepIntent).toHaveBeenCalledWith('wt-2')
+  })
+
   it('surfaces a toast and skips terminals when browsers throws', async () => {
     mocks.state.activeWorktreeId = 'wt-1'
     mocks.state.shutdownWorktreeBrowsers.mockRejectedValueOnce(new Error('boom'))

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -95,19 +95,17 @@ describe('runSleepWorktree', () => {
     expect(activeClear).toBeLessThan(browsersCall)
   })
 
-  it('marks active sleep intent before clearing the active slept worktree', async () => {
+  it('marks sleep intent before clearing the active slept worktree and keeps it after teardown', async () => {
     mocks.state.activeWorktreeId = 'wt-1'
 
     await runSleepWorktree('wt-1')
 
     expect(mocks.markWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
-    expect(mocks.clearWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
     const markCall = mocks.markWorktreeSleepIntent.mock.invocationCallOrder[0]
     const activeClear = mocks.state.setActiveWorktree.mock.invocationCallOrder[0]
-    const terminalShutdown = mocks.state.shutdownWorktreeTerminals.mock.invocationCallOrder[0]
-    const clearCall = mocks.clearWorktreeSleepIntent.mock.invocationCallOrder[0]
     expect(markCall).toBeLessThan(activeClear)
-    expect(terminalShutdown).toBeLessThan(clearCall)
+    // Why: the marker outlives a successful sleep so mounted panes stay cold until an explicit wake.
+    expect(mocks.clearWorktreeSleepIntent).not.toHaveBeenCalled()
   })
 
   it('preserves active row position through section-scoped sidebar row ids', async () => {
@@ -181,14 +179,15 @@ describe('runSleepWorktree', () => {
     expect(pinnedGetBoundingClientRect).not.toHaveBeenCalled()
   })
 
-  it('leaves activeWorktreeId alone when sleeping a background worktree', async () => {
+  it('leaves activeWorktreeId alone and marks a background worktree slept', async () => {
     mocks.state.activeWorktreeId = 'wt-other'
 
     await runSleepWorktree('wt-1')
 
     expect(mocks.state.setActiveWorktree).not.toHaveBeenCalled()
     expect(mocks.state.suppressPtyExit).not.toHaveBeenCalled()
-    expect(mocks.markWorktreeSleepIntent).not.toHaveBeenCalled()
+    expect(mocks.markWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
+    expect(mocks.clearWorktreeSleepIntent).not.toHaveBeenCalled()
   })
 
   it('surfaces a toast and skips terminals when browsers throws', async () => {

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -44,7 +44,8 @@ vi.mock('@/store', () => ({
 vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }))
 vi.mock('@/lib/worktree-sleep-intent', () => ({
   clearWorktreeSleepIntent: mocks.clearWorktreeSleepIntent,
-  markWorktreeSleepIntent: mocks.markWorktreeSleepIntent
+  markWorktreeSleepIntent: mocks.markWorktreeSleepIntent,
+  withWorktreeSleepTeardown: (_worktreeId: string, teardown: () => Promise<unknown>) => teardown()
 }))
 
 import { runSleepWorktree, runSleepWorktrees } from './sleep-worktree-flow'
@@ -219,14 +220,6 @@ describe('runSleepWorktree', () => {
     await run
 
     expect(mocks.clearWorktreeSleepIntent).toHaveBeenLastCalledWith('wt-2')
-  })
-
-  it('re-asserts the marker after teardown so a late PTY bind cannot un-sleep it', async () => {
-    await runSleepWorktree('wt-1')
-
-    const marks = mocks.markWorktreeSleepIntent.mock.invocationCallOrder
-    const terminalShutdown = mocks.state.shutdownWorktreeTerminals.mock.invocationCallOrder[0]
-    expect(marks.some((order) => order > terminalShutdown)).toBe(true)
   })
 
   it('marks each worktree only when its own teardown starts', async () => {

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -1,9 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => {
-  const state = {
-    activeWorktreeId: null as string | null,
-    setActiveWorktree: vi.fn(),
+  const state: {
+    activeWorktreeId: string | null
+    setActiveWorktree: ReturnType<typeof vi.fn>
+    shutdownWorktreeBrowsers: ReturnType<typeof vi.fn>
+    shutdownWorktreeTerminals: ReturnType<typeof vi.fn>
+    suppressPtyExit: ReturnType<typeof vi.fn>
+    consumeSuppressedPtyExit: ReturnType<typeof vi.fn>
+    tabsByWorktree: Record<string, { id: string }[]>
+    ptyIdsByTabId: Record<string, string[]>
+  } = {
+    activeWorktreeId: null,
+    setActiveWorktree: vi.fn((worktreeId: string | null) => {
+      state.activeWorktreeId = worktreeId
+    }),
     shutdownWorktreeBrowsers: vi.fn().mockResolvedValue(undefined),
     shutdownWorktreeTerminals: vi.fn().mockResolvedValue(undefined),
     suppressPtyExit: vi.fn(),
@@ -188,6 +199,34 @@ describe('runSleepWorktree', () => {
     expect(mocks.state.suppressPtyExit).not.toHaveBeenCalled()
     expect(mocks.markWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
     expect(mocks.clearWorktreeSleepIntent).not.toHaveBeenCalled()
+  })
+
+  it('leaves a worktree the user activated mid-batch awake', async () => {
+    let releaseFirst: () => void = () => {}
+    mocks.state.shutdownWorktreeBrowsers.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = resolve
+        })
+    )
+
+    const run = runSleepWorktrees(['wt-1', 'wt-2'])
+    await Promise.resolve()
+    // Why: the user clicked wt-2 while wt-1 was tearing down; sleeping it anyway
+    // must not leave the active workspace marked with no clear pending.
+    mocks.state.activeWorktreeId = 'wt-2'
+    releaseFirst()
+    await run
+
+    expect(mocks.clearWorktreeSleepIntent).toHaveBeenLastCalledWith('wt-2')
+  })
+
+  it('re-asserts the marker after teardown so a late PTY bind cannot un-sleep it', async () => {
+    await runSleepWorktree('wt-1')
+
+    const marks = mocks.markWorktreeSleepIntent.mock.invocationCallOrder
+    const terminalShutdown = mocks.state.shutdownWorktreeTerminals.mock.invocationCallOrder[0]
+    expect(marks.some((order) => order > terminalShutdown)).toBe(true)
   })
 
   it('marks each worktree only when its own teardown starts', async () => {

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -1,6 +1,10 @@
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
-import { clearWorktreeSleepIntent, markWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
+import {
+  clearWorktreeSleepIntent,
+  markWorktreeSleepIntent,
+  withWorktreeSleepTeardown
+} from '@/lib/worktree-sleep-intent'
 import { VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT } from '@/hooks/useVirtualizedScrollAnchor'
 import { translate } from '@/i18n/i18n'
 
@@ -167,7 +171,7 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
         // other teardown runs, terminals second so the PTY kill uses the same
         // ordering on both paths. Without the browser thunk here, sleep leaks
         // browserPagesByWorkspace entries and live webviews for the slept worktree.
-        await shutdownWorktreeBrowsers(worktreeId)
+        await withWorktreeSleepTeardown(worktreeId, () => shutdownWorktreeBrowsers(worktreeId))
       } catch (err) {
         console.error('[sleep-worktree] browser shutdown failed', { worktreeId, error: err })
         failedWorktreeIds.add(worktreeId)
@@ -182,17 +186,15 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
         // history dir (local) or relay session id (SSH); it also captures
         // serializer buffers into buffersByLeafId for SSH wake to reseed
         // scrollback. See DESIGN_DOC_TERMINAL_HISTORY_FIX_V2.md §3.3.c.
-        await shutdownWorktreeTerminals(worktreeId, { keepIdentifiers: true })
-        if (typeof window !== 'undefined' && window.api?.ephemeralVm?.suspendWorkspace) {
-          await window.api.ephemeralVm.suspendWorkspace({ workspaceId: worktreeId })
-        }
-        // Why: a spawn that resolved during teardown binds a PTY and clears the marker;
-        // the workspace is asleep now, so re-assert it. A workspace the user activated
-        // meanwhile is awake by their choice and must not be left marked.
+        await withWorktreeSleepTeardown(worktreeId, async () => {
+          await shutdownWorktreeTerminals(worktreeId, { keepIdentifiers: true })
+          if (typeof window !== 'undefined' && window.api?.ephemeralVm?.suspendWorkspace) {
+            await window.api.ephemeralVm.suspendWorkspace({ workspaceId: worktreeId })
+          }
+        })
+        // Why: a workspace the user activated during the batch is awake by their choice.
         if (useAppStore.getState().activeWorktreeId === worktreeId) {
           clearWorktreeSleepIntent(worktreeId)
-        } else {
-          markWorktreeSleepIntent(worktreeId)
         }
       } catch (err) {
         console.error('[sleep-worktree] terminal or host suspension failed', {

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -141,16 +141,15 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
     shutdownWorktreeBrowsers,
     shutdownWorktreeTerminals
   } = useAppStore.getState()
-  // Why: mark before any teardown so exits do not stamp activity and the panes
-  // left mounted stay cold until an explicit wake (#10205). Kept off the store
-  // so it cannot disturb the sidebar's scroll restoration.
-  for (const worktreeId of worktreeIds) {
-    markWorktreeSleepIntent(worktreeId)
-  }
   const sleptActiveWorktreeId =
     activeWorktreeId && worktreeIds.includes(activeWorktreeId) ? activeWorktreeId : null
   if (sleptActiveWorktreeId) {
     const restoreSidebarPosition = preserveSidebarWorktreePosition(sleptActiveWorktreeId)
+    // Why: clearing the active workspace can unmount TerminalPanes before
+    // shutdownWorktreeTerminals writes PTY suppressions; mark first so those
+    // exits do not stamp activity. Kept off the store so it cannot disturb the
+    // sidebar's scroll restoration.
+    markWorktreeSleepIntent(sleptActiveWorktreeId)
     setActiveWorktree(null)
     restoreSidebarPosition()
   }
@@ -158,6 +157,10 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
   const failedWorktreeIds = new Set<string>()
   try {
     for (const worktreeId of worktreeIds) {
+      // Why: the marker outlives teardown so the panes left mounted stay cold
+      // until an explicit wake (#10205); mark per workspace so an earlier
+      // slow teardown never leaves a later, still-awake one marked.
+      markWorktreeSleepIntent(worktreeId)
       try {
         // Why: sleep mirrors removeWorktree's shutdown sequence — browsers first
         // so destroyPersistentWebview unregisters the Chromium guests before any

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -141,15 +141,16 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
     shutdownWorktreeBrowsers,
     shutdownWorktreeTerminals
   } = useAppStore.getState()
-  let activeSleepIntentWorktreeId: string | null = null
-  if (activeWorktreeId && worktreeIds.includes(activeWorktreeId)) {
-    const restoreSidebarPosition = preserveSidebarWorktreePosition(activeWorktreeId)
-    // Why: clearing the active workspace can unmount TerminalPanes before
-    // shutdownWorktreeTerminals writes PTY suppressions. Use a non-rendering
-    // intent marker so those exits do not stamp activity, without inserting an
-    // extra Zustand update that can disturb the sidebar's scroll restoration.
-    markWorktreeSleepIntent(activeWorktreeId)
-    activeSleepIntentWorktreeId = activeWorktreeId
+  // Why: mark before any teardown so exits do not stamp activity and the panes
+  // left mounted stay cold until an explicit wake (#10205). Kept off the store
+  // so it cannot disturb the sidebar's scroll restoration.
+  for (const worktreeId of worktreeIds) {
+    markWorktreeSleepIntent(worktreeId)
+  }
+  const sleptActiveWorktreeId =
+    activeWorktreeId && worktreeIds.includes(activeWorktreeId) ? activeWorktreeId : null
+  if (sleptActiveWorktreeId) {
+    const restoreSidebarPosition = preserveSidebarWorktreePosition(sleptActiveWorktreeId)
     setActiveWorktree(null)
     restoreSidebarPosition()
   }
@@ -192,12 +193,12 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
       }
     }
   } finally {
-    if (activeSleepIntentWorktreeId) {
-      clearWorktreeSleepIntent(activeSleepIntentWorktreeId)
-      if (failedWorktreeIds.has(activeSleepIntentWorktreeId)) {
-        // Why: any failed sleep step must leave the workspace visible and retryable.
-        setActiveWorktree(activeSleepIntentWorktreeId)
-      }
+    // Why: a failed sleep leaves the workspace awake and retryable.
+    for (const worktreeId of failedWorktreeIds) {
+      clearWorktreeSleepIntent(worktreeId)
+    }
+    if (sleptActiveWorktreeId && failedWorktreeIds.has(sleptActiveWorktreeId)) {
+      setActiveWorktree(sleptActiveWorktreeId)
     }
   }
   if (errors.length > 0) {

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -186,6 +186,14 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
         if (typeof window !== 'undefined' && window.api?.ephemeralVm?.suspendWorkspace) {
           await window.api.ephemeralVm.suspendWorkspace({ workspaceId: worktreeId })
         }
+        // Why: a spawn that resolved during teardown binds a PTY and clears the marker;
+        // the workspace is asleep now, so re-assert it. A workspace the user activated
+        // meanwhile is awake by their choice and must not be left marked.
+        if (useAppStore.getState().activeWorktreeId === worktreeId) {
+          clearWorktreeSleepIntent(worktreeId)
+        } else {
+          markWorktreeSleepIntent(worktreeId)
+        }
       } catch (err) {
         console.error('[sleep-worktree] terminal or host suspension failed', {
           worktreeId,

--- a/src/renderer/src/components/terminal-pane/pty-connection-deliberate-sleep-guard.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-deliberate-sleep-guard.test.ts
@@ -185,6 +185,53 @@ describe('deliberate sleep keeps mounted panes cold', () => {
     expect(transport.connect).not.toHaveBeenCalled()
   })
 
+  it('connects a waiting pane once the workspace is woken', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { clearWorktreeSleepIntent, markWorktreeSleepIntent } =
+      await import('@/lib/worktree-sleep-intent')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      activeWorktreeId: 'wt-other',
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-woken', ptyId: 'wt-1@@dead' }] }
+    }
+    markWorktreeSleepIntent('wt-1')
+    const deps = createDeps({
+      tabId: 'tab-woken',
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'wt-1@@dead' },
+      isVisibleRef: { current: false }
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+    expect(transport.connect).not.toHaveBeenCalled()
+
+    clearWorktreeSleepIntent('wt-1')
+    await flushAsyncTicks()
+
+    expect(transport.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops the wake listener when a waiting pane is disposed', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { clearWorktreeSleepIntent, markWorktreeSleepIntent } =
+      await import('@/lib/worktree-sleep-intent')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    markWorktreeSleepIntent('wt-1')
+    const deps = createDeps({ tabId: 'tab-disposed', isVisibleRef: { current: false } })
+
+    const binding = connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+    binding.dispose()
+    clearWorktreeSleepIntent('wt-1')
+    await flushAsyncTicks()
+
+    expect(transport.connect).not.toHaveBeenCalled()
+  })
+
   it('still connects a slept pane that carries a queued startup', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const { markWorktreeSleepIntent } = await import('@/lib/worktree-sleep-intent')

--- a/src/renderer/src/components/terminal-pane/pty-connection-deliberate-sleep-guard.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-deliberate-sleep-guard.test.ts
@@ -1,0 +1,222 @@
+import type * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushAsyncTicks } from './pty-connection-test-async'
+import {
+  createMockTransport,
+  createPane,
+  createManager,
+  LEAF_1,
+  type MockTransport
+} from './pty-connection-test-pane-fixtures'
+import { buildPaneConnectionDeps } from './pty-connection-test-deps'
+import { createInitialStoreState } from './pty-connection-test-store-fixtures'
+import type { StoreState } from './pty-connection-test-store-state'
+import {
+  installTerminalTestGlobals,
+  restoreTerminalTestGlobals
+} from './pty-connection-test-environment'
+
+const {
+  resetAndRefreshAllTerminalWebglAtlases,
+  scheduleTerminalWebglAtlasRecovery,
+  scheduleRuntimeGraphSync,
+  shouldSeedCacheTimerOnInitialTitle,
+  toastInfo,
+  notifyCodexPaneBoundForStaleSweep
+} = vi.hoisted(() => ({
+  resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
+  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleRuntimeGraphSync: vi.fn(),
+  shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
+  toastInfo: vi.fn(),
+  notifyCodexPaneBoundForStaleSweep: vi.fn()
+}))
+
+let mockStoreState: StoreState
+let transportFactoryQueue: MockTransport[] = []
+let createdTransportOptions: Record<string, unknown>[] = []
+let storeSubscribers: ((state: StoreState) => void)[] = []
+
+vi.mock('@/runtime/sync-runtime-graph', () => ({
+  scheduleRuntimeGraphSync
+}))
+
+vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resetAndRefreshAllTerminalWebglAtlases
+}))
+
+vi.mock('./terminal-webgl-atlas-recovery', () => ({
+  scheduleTerminalWebglAtlasRecovery
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mockStoreState,
+    subscribe: (listener: (state: StoreState) => void) => {
+      storeSubscribers.push(listener)
+      return () => {
+        storeSubscribers = storeSubscribers.filter((candidate) => candidate !== listener)
+      }
+    }
+  }
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const { buildAgentStatusModuleMock } = await import('./pty-connection-test-environment')
+  return buildAgentStatusModuleMock(await importOriginal<Record<string, unknown>>())
+})
+
+vi.mock('./cache-timer-seeding', () => ({
+  shouldSeedCacheTimerOnInitialTitle
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    info: toastInfo
+  }
+}))
+
+vi.mock('@/lib/codex-stale-pane-sweep', () => ({
+  notifyCodexPaneBoundForStaleSweep
+}))
+
+// Why: the working→idle test invokes the real useNotificationDispatch hook outside React, so useCallback must pass through (safe suite-wide: no test here renders React).
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof React>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn
+  }
+})
+
+vi.mock('./pty-transport', () => ({
+  createIpcPtyTransport: vi.fn((options: Record<string, unknown>) => {
+    createdTransportOptions.push(options)
+    const nextTransport = transportFactoryQueue.shift()
+    if (!nextTransport) {
+      throw new Error('No mock transport queued')
+    }
+    return nextTransport
+  })
+}))
+
+vi.mock('./remote-runtime-pty-transport', () => ({
+  createRemoteRuntimePtyTransport: vi.fn(
+    (_environmentId: string, options: Record<string, unknown>) => {
+      createdTransportOptions.push(options)
+      const nextTransport = transportFactoryQueue.shift()
+      if (!nextTransport) {
+        throw new Error('No mock transport queued')
+      }
+      return nextTransport
+    }
+  )
+}))
+
+// Why: stub only getEagerPtyBufferHandle so tests can simulate a live eager buffer (adopt path) without standing up the real IPC dispatcher.
+vi.mock('./pty-dispatcher', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    getEagerPtyBufferHandle: vi.fn(() => undefined)
+  }
+})
+
+function createDeps(overrides: Record<string, unknown> = {}) {
+  return buildPaneConnectionDeps(() => mockStoreState, overrides)
+}
+
+describe('deliberate sleep keeps mounted panes cold', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    transportFactoryQueue = []
+    createdTransportOptions = []
+    storeSubscribers = []
+    mockStoreState = createInitialStoreState(() => mockStoreState)
+    installTerminalTestGlobals()
+  })
+
+  afterEach(async () => {
+    const { clearWorktreeSleepIntent } = await import('@/lib/worktree-sleep-intent')
+    clearWorktreeSleepIntent('wt-1')
+    await restoreTerminalTestGlobals()
+  })
+
+  // Why: manual sleep keeps tab.ptyId as a wake hint, so a remount would take the
+  // REATTACH arm and the daemon would respawn a shell for the dead id (#10205).
+  it('does not reattach a slept pane through its retained session id', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { markWorktreeSleepIntent } = await import('@/lib/worktree-sleep-intent')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      activeWorktreeId: 'wt-other',
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-slept', ptyId: 'wt-1@@dead' }] }
+    }
+    markWorktreeSleepIntent('wt-1')
+    const deps = createDeps({
+      tabId: 'tab-slept',
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'wt-1@@dead' },
+      isVisibleRef: { current: false }
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    expect(transport.connect).not.toHaveBeenCalled()
+  })
+
+  it('does not fresh-spawn a slept pane that has no session id', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { markWorktreeSleepIntent } = await import('@/lib/worktree-sleep-intent')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = { ...mockStoreState, activeWorktreeId: 'wt-other' }
+    markWorktreeSleepIntent('wt-1')
+    const deps = createDeps({ tabId: 'tab-slept-bare', isVisibleRef: { current: false } })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    expect(transport.connect).not.toHaveBeenCalled()
+  })
+
+  it('still connects a slept pane that carries a queued startup', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { markWorktreeSleepIntent } = await import('@/lib/worktree-sleep-intent')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    markWorktreeSleepIntent('wt-1')
+    const deps = createDeps({
+      tabId: 'tab-slept-startup',
+      isVisibleRef: { current: false },
+      startup: { command: 'printf wake', launchAgent: undefined }
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    expect(transport.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('connects normally once the marker is released', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    const deps = createDeps({
+      tabId: 'tab-awake',
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'wt-1@@live' },
+      isVisibleRef: { current: false }
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    expect(transport.connect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection-deliberate-sleep-guard.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-deliberate-sleep-guard.test.ts
@@ -313,10 +313,16 @@ describe('deliberate sleep keeps mounted panes cold', () => {
     const binding = connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
     await flushAsyncTicks()
     binding.dispose()
+    // Why: the connect body already refuses a disposed session, so prove the
+    // listener itself is gone: a wake after dispose reaches no subscriber.
+    const wakeCalls: number[] = []
+    const { onWorktreeSleepIntentCleared } = await import('@/lib/worktree-sleep-intent')
+    onWorktreeSleepIntentCleared('wt-1', () => wakeCalls.push(1))
     clearWorktreeSleepIntent('wt-1')
     await flushAsyncTicks()
 
     expect(transport.connect).not.toHaveBeenCalled()
+    expect(wakeCalls).toHaveLength(1)
   })
 
   it('still connects a slept pane that carries a queued startup', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection-deliberate-sleep-guard.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-deliberate-sleep-guard.test.ts
@@ -214,6 +214,38 @@ describe('deliberate sleep keeps mounted panes cold', () => {
     expect(transport.connect).toHaveBeenCalledTimes(1)
   })
 
+  it('does not connect a waiting pane whose tab was remounted by the wake', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { clearWorktreeSleepIntent, markWorktreeSleepIntent } =
+      await import('@/lib/worktree-sleep-intent')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      activeWorktreeId: 'wt-other',
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-remounted', ptyId: 'wt-1@@dead', generation: 0 }] }
+    }
+    markWorktreeSleepIntent('wt-1')
+    const deps = createDeps({
+      tabId: 'tab-remounted',
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'wt-1@@dead' },
+      isVisibleRef: { current: false }
+    })
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    // Why: activation bumps generation in the same set() that precedes the clear.
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-remounted', ptyId: 'wt-1@@dead', generation: 1 }] }
+    }
+    clearWorktreeSleepIntent('wt-1')
+    await flushAsyncTicks()
+
+    expect(transport.connect).not.toHaveBeenCalled()
+  })
+
   it('drops the wake listener when a waiting pane is disposed', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const { clearWorktreeSleepIntent, markWorktreeSleepIntent } =

--- a/src/renderer/src/components/terminal-pane/pty-connection-deliberate-sleep-guard.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-deliberate-sleep-guard.test.ts
@@ -246,6 +246,61 @@ describe('deliberate sleep keeps mounted panes cold', () => {
     expect(transport.connect).not.toHaveBeenCalled()
   })
 
+  it('resumes a waiting pane mounted under a unified tab id', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { clearWorktreeSleepIntent, markWorktreeSleepIntent } =
+      await import('@/lib/worktree-sleep-intent')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      activeWorktreeId: 'wt-other',
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-entity', ptyId: null, generation: 3 }] },
+      getTab: (id: string) =>
+        id === 'unified-1' ? { id, contentType: 'terminal', entityId: 'tab-entity' } : null
+    } as never
+    markWorktreeSleepIntent('wt-1')
+    const deps = createDeps({ tabId: 'unified-1', isVisibleRef: { current: false } })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+    expect(transport.connect).not.toHaveBeenCalled()
+
+    clearWorktreeSleepIntent('wt-1')
+    await flushAsyncTicks()
+
+    expect(transport.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms after a wake so a second sleep can hold the pane again', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { clearWorktreeSleepIntent, markWorktreeSleepIntent } =
+      await import('@/lib/worktree-sleep-intent')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    let releaseCwd: (cwd: string) => void = () => {}
+    const cwdPromise = new Promise<string>((resolve) => {
+      releaseCwd = resolve
+    })
+    markWorktreeSleepIntent('wt-1')
+    const deps = createDeps({ tabId: 'tab-resleep', isVisibleRef: { current: false }, cwdPromise })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+    // Wake: the pane leaves the sleep gate and parks on the cwd gate.
+    clearWorktreeSleepIntent('wt-1')
+    await flushAsyncTicks()
+    // Sleep again before the cwd settles, then wake again.
+    markWorktreeSleepIntent('wt-1')
+    releaseCwd('/cwd')
+    await flushAsyncTicks()
+    expect(transport.connect).not.toHaveBeenCalled()
+    clearWorktreeSleepIntent('wt-1')
+    await flushAsyncTicks()
+
+    expect(transport.connect).toHaveBeenCalledTimes(1)
+  })
+
   it('drops the wake listener when a waiting pane is disposed', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const { clearWorktreeSleepIntent, markWorktreeSleepIntent } =

--- a/src/renderer/src/components/terminal-pane/pty-connection/connect-pane-pty.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/connect-pane-pty.ts
@@ -36,7 +36,7 @@ import { installPtyInputRecovery } from './pty-input-recovery'
 import { installPtyInputForward } from './pty-input-forward'
 import { installPtyResizeGeometry } from './pty-resize-geometry'
 import { installSessionReconcileDispose } from './session-reconcile-dispose'
-import { resolveTerminalTabId } from './terminal-tab-id'
+import { findTerminalTabForPane } from './terminal-tab-id'
 
 /**
  * Establishes a binding between a terminal pane and its corresponding PTY stream,
@@ -50,43 +50,8 @@ export function connectPanePty(
   const session = { pane, manager, deps } as ConnectPanePtySession
   session.shouldRefreshForegroundSynchronously = (): boolean =>
     !session.manager.hasWebglRenderer(session.pane.id)
-  const state = useAppStore.getState()
-  const unifiedTab = state.getTab?.(deps.tabId)
-  const initialOwnerWorktreeId =
-    state.getTerminalTabOwnerWorktreeId?.(deps.tabId) ??
-    (unifiedTab?.contentType === 'terminal'
-      ? state.getTerminalTabOwnerWorktreeId?.(unifiedTab.entityId)
-      : null)
-  const terminalTabId = resolveTerminalTabId(
-    {
-      getTab: state.getTab,
-      hasTerminalTab: (candidateId) =>
-        Boolean(
-          state.tabsByWorktree[deps.worktreeId]?.some(
-            (candidate) => candidate.id === candidateId
-          ) ||
-          (initialOwnerWorktreeId
-            ? state.tabsByWorktree[initialOwnerWorktreeId]?.some(
-                (candidate) => candidate.id === candidateId
-              )
-            : false)
-        )
-    },
-    deps.tabId
-  )
-  const ownerWorktreeId =
-    state.getTerminalTabOwnerWorktreeId?.(terminalTabId) ?? initialOwnerWorktreeId
-  const terminalTab =
-    state.tabsByWorktree[deps.worktreeId]?.find((candidate) => candidate.id === terminalTabId) ??
-    (ownerWorktreeId
-      ? state.tabsByWorktree[ownerWorktreeId]?.find((candidate) => candidate.id === terminalTabId)
-      : undefined) ??
-    // Why: folder/worktree migrations can leave the pane's render key stale for one commit.
-    Object.values(state.tabsByWorktree)
-      .find((tabs) => tabs.some((candidate) => candidate.id === terminalTabId))
-      ?.find((candidate) => candidate.id === terminalTabId)
-  const tab = terminalTab ?? (unifiedTab && 'generation' in unifiedTab ? unifiedTab : null)
-  session.tabGeneration = tab?.generation ?? 0
+  session.tabGeneration =
+    findTerminalTabForPane(useAppStore.getState(), deps.worktreeId, deps.tabId)?.generation ?? 0
   // Why: recovery ownership belongs to this xterm instance. A request that
   // settles after remount must not remount its already-replaced successor.
   session.terminalRecoveryGeneration = captureTerminalPaneRecoveryGeneration(session.deps.tabId)

--- a/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
@@ -14,7 +14,7 @@ import type {
 } from './fresh-spawn-types'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
-import { resolveTerminalTabId } from './terminal-tab-id'
+import { findTerminalTabForPane } from './terminal-tab-id'
 
 export function bindStartFreshSpawn(session: ConnectPanePtySession): void {
   session.startFreshSpawn = (
@@ -113,51 +113,10 @@ export function bindStartFreshSpawn(session: ConnectPanePtySession): void {
       ...(coldRestoreOverride ? { launchToken: coldRestoreOverride.launchToken } : {}),
       ...(coldRestoreOverride ? { launchAgent: coldRestoreOverride.agent } : {}),
       ...(session.shouldDeclareHiddenAtSpawn() ? { initiallyHidden: true } : {}),
-      shouldContinue: () => {
-        const state = useAppStore.getState()
-        const unifiedTab = state.getTab?.(session.deps.tabId)
-        const initialOwnerWorktreeId =
-          state.getTerminalTabOwnerWorktreeId?.(session.deps.tabId) ??
-          (unifiedTab?.contentType === 'terminal'
-            ? state.getTerminalTabOwnerWorktreeId?.(unifiedTab.entityId)
-            : null)
-        const terminalTabId = resolveTerminalTabId(
-          {
-            getTab: state.getTab,
-            hasTerminalTab: (candidateId) =>
-              Boolean(
-                state.tabsByWorktree[session.deps.worktreeId]?.some(
-                  (candidate) => candidate.id === candidateId
-                ) ||
-                (initialOwnerWorktreeId
-                  ? state.tabsByWorktree[initialOwnerWorktreeId]?.some(
-                      (candidate) => candidate.id === candidateId
-                    )
-                  : false)
-              )
-          },
-          session.deps.tabId
-        )
-        const ownerWorktreeId =
-          state.getTerminalTabOwnerWorktreeId?.(terminalTabId) ?? initialOwnerWorktreeId
-        const terminalTab =
-          state.tabsByWorktree[session.deps.worktreeId]?.find(
-            (candidate) => candidate.id === terminalTabId
-          ) ??
-          (ownerWorktreeId
-            ? state.tabsByWorktree[ownerWorktreeId]?.find(
-                (candidate) => candidate.id === terminalTabId
-              )
-            : undefined)
-        const fallbackTab = Object.values(state.tabsByWorktree)
-          .find((tabs) => tabs.some((candidate) => candidate.id === terminalTabId))
-          ?.find((candidate) => candidate.id === terminalTabId)
-        const currentTab =
-          terminalTab ??
-          fallbackTab ??
-          (unifiedTab && 'generation' in unifiedTab ? unifiedTab : null)
-        return !session.disposed && (currentTab?.generation ?? 0) === session.tabGeneration
-      },
+      shouldContinue: () =>
+        !session.disposed &&
+        (findTerminalTabForPane(useAppStore.getState(), session.deps.worktreeId, session.deps.tabId)
+          ?.generation ?? 0) === session.tabGeneration,
       callbacks: outputCallbacks.callbacks
     })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection/run-deferred-connect.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/run-deferred-connect.ts
@@ -2,7 +2,7 @@ import { createTerminalZeroDimensionsMessage } from '../../../../../shared/termi
 import { isWorktreeRemovalFenceError } from '../../../../../shared/worktree/removal-fence-error'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { createCodexBackfillErrorDetector } from '../codex-backfill-error-detector'
-import { hasWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
+import { hasWorktreeSleepIntent, onWorktreeSleepIntentCleared } from '@/lib/worktree-sleep-intent'
 
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
 import { recordPtyConnectDiagnostic } from './pty-connect-limits'
@@ -28,9 +28,38 @@ export function installRunDeferredConnect(session: ConnectPanePtySession): void 
   const cwdPromise = session.deps.cwdPromise
   let cwdPromiseSettled = cwdPromise === undefined
   let cwdPromiseWaitStarted = false
+  let wakeWaitStarted = false
 
   session.runDeferredConnect = (): void => {
     if (session.connectStarted) {
+      return
+    }
+    // Why: a deliberately slept workspace keeps its panes mounted, so connecting
+    // would reattach the retained session id and respawn the shell (#10205).
+    // Wait for the wake instead; a queued startup is an explicit launch.
+    if (hasWorktreeSleepIntent(session.deps.worktreeId) && !session.paneStartup) {
+      session.cancelScheduledConnectFrame()
+      if (session.connectFallbackTimer !== null) {
+        clearTimeout(session.connectFallbackTimer)
+        session.connectFallbackTimer = null
+      }
+      if (!wakeWaitStarted) {
+        wakeWaitStarted = true
+        recordPtyConnectDiagnostic(
+          `pane=${session.pane.id} tab=${session.deps.tabId} -> WAIT FOR WAKE (deliberate sleep)`
+        )
+        const unsubscribe = onWorktreeSleepIntentCleared(session.deps.worktreeId, () => {
+          const index = session.waitTeardowns.indexOf(unsubscribe)
+          if (index !== -1) {
+            session.waitTeardowns.splice(index, 1)
+          }
+          if (!session.disposed) {
+            session.runDeferredConnect()
+          }
+        })
+        // Why: disposal unsubscribes so a torn-down pane never connects on a later wake.
+        session.waitTeardowns.push(unsubscribe)
+      }
       return
     }
     if (!cwdPromiseSettled) {
@@ -81,15 +110,6 @@ export function installRunDeferredConnect(session: ConnectPanePtySession): void 
       session.connectFallbackTimer = null
     }
     if (session.disposed) {
-      return
-    }
-    // Why: a deliberately slept workspace keeps its panes mounted, so any later
-    // remount would reattach its retained session id and respawn the shell
-    // (#10205). A queued startup is an explicit launch and still connects.
-    if (hasWorktreeSleepIntent(session.deps.worktreeId) && !session.paneStartup) {
-      recordPtyConnectDiagnostic(
-        `pane=${session.pane.id} tab=${session.deps.tabId} -> SKIP CONNECT (deliberate sleep)`
-      )
       return
     }
     safeFit(session.pane)

--- a/src/renderer/src/components/terminal-pane/pty-connection/run-deferred-connect.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/run-deferred-connect.ts
@@ -2,8 +2,10 @@ import { createTerminalZeroDimensionsMessage } from '../../../../../shared/termi
 import { isWorktreeRemovalFenceError } from '../../../../../shared/worktree/removal-fence-error'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { createCodexBackfillErrorDetector } from '../codex-backfill-error-detector'
+import { hasWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
+import { recordPtyConnectDiagnostic } from './pty-connect-limits'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
 import { bindBuildColdRestoreAgentResumeStartup } from './cold-restore-resume-startup'
@@ -79,6 +81,15 @@ export function installRunDeferredConnect(session: ConnectPanePtySession): void 
       session.connectFallbackTimer = null
     }
     if (session.disposed) {
+      return
+    }
+    // Why: a deliberately slept workspace keeps its panes mounted, so any later
+    // remount would reattach its retained session id and respawn the shell
+    // (#10205). A queued startup is an explicit launch and still connects.
+    if (hasWorktreeSleepIntent(session.deps.worktreeId) && !session.paneStartup) {
+      recordPtyConnectDiagnostic(
+        `pane=${session.pane.id} tab=${session.deps.tabId} -> SKIP CONNECT (deliberate sleep)`
+      )
       return
     }
     safeFit(session.pane)

--- a/src/renderer/src/components/terminal-pane/pty-connection/run-deferred-connect.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/run-deferred-connect.ts
@@ -7,6 +7,7 @@ import { hasWorktreeSleepIntent, onWorktreeSleepIntentCleared } from '@/lib/work
 
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
 import { recordPtyConnectDiagnostic } from './pty-connect-limits'
+import { findTerminalTabForPane } from './terminal-tab-id'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
 import { bindBuildColdRestoreAgentResumeStartup } from './cold-restore-resume-startup'
@@ -50,15 +51,18 @@ export function installRunDeferredConnect(session: ConnectPanePtySession): void 
           `pane=${session.pane.id} tab=${session.deps.tabId} -> WAIT FOR WAKE (deliberate sleep)`
         )
         const unsubscribe = onWorktreeSleepIntentCleared(session.deps.worktreeId, () => {
+          wakeWaitStarted = false
           const index = session.waitTeardowns.indexOf(unsubscribe)
           if (index !== -1) {
             session.waitTeardowns.splice(index, 1)
           }
           // Why: an activation wake bumps the tab generation in the same tick and the
           // remounted pane connects on its own; a stale generation must not connect too.
-          const currentTab = Object.values(useAppStore.getState().tabsByWorktree)
-            .flat()
-            .find((candidate) => candidate.id === session.deps.tabId)
+          const currentTab = findTerminalTabForPane(
+            useAppStore.getState(),
+            session.deps.worktreeId,
+            session.deps.tabId
+          )
           if (!session.disposed && (currentTab?.generation ?? 0) === session.tabGeneration) {
             session.runDeferredConnect()
           }

--- a/src/renderer/src/components/terminal-pane/pty-connection/run-deferred-connect.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/run-deferred-connect.ts
@@ -1,6 +1,7 @@
 import { createTerminalZeroDimensionsMessage } from '../../../../../shared/terminal-zero-dimensions-diagnostic'
 import { isWorktreeRemovalFenceError } from '../../../../../shared/worktree/removal-fence-error'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
+import { useAppStore } from '@/store'
 import { createCodexBackfillErrorDetector } from '../codex-backfill-error-detector'
 import { hasWorktreeSleepIntent, onWorktreeSleepIntentCleared } from '@/lib/worktree-sleep-intent'
 
@@ -53,7 +54,12 @@ export function installRunDeferredConnect(session: ConnectPanePtySession): void 
           if (index !== -1) {
             session.waitTeardowns.splice(index, 1)
           }
-          if (!session.disposed) {
+          // Why: an activation wake bumps the tab generation in the same tick and the
+          // remounted pane connects on its own; a stale generation must not connect too.
+          const currentTab = Object.values(useAppStore.getState().tabsByWorktree)
+            .flat()
+            .find((candidate) => candidate.id === session.deps.tabId)
+          if (!session.disposed && (currentTab?.generation ?? 0) === session.tabGeneration) {
             session.runDeferredConnect()
           }
         })

--- a/src/renderer/src/components/terminal-pane/pty-connection/terminal-tab-id.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/terminal-tab-id.ts
@@ -13,3 +13,54 @@ export function resolveTerminalTabId(state: TerminalTabLookup, tabId: string): s
   const unifiedTab = state.getTab?.(tabId)
   return unifiedTab?.contentType === 'terminal' ? unifiedTab.entityId : tabId
 }
+
+type TerminalTabRecord = { id: string; generation?: number }
+type TerminalTabState = {
+  getTab?: (
+    tabId: string
+  ) => ({ contentType: string; entityId: string } & Partial<TerminalTabRecord>) | null
+  tabsByWorktree: Record<string, readonly TerminalTabRecord[]>
+  getTerminalTabOwnerWorktreeId?: (tabId: string) => string | null | undefined
+}
+
+/**
+ * Resolve the live terminal tab (or unified tab) a pane renders for, by either id
+ * form. Why the fallbacks: folder/worktree migrations can leave the pane's render
+ * key stale for one commit, and a unified id's terminal tab lives under entityId.
+ */
+export function findTerminalTabForPane(
+  state: TerminalTabState,
+  worktreeId: string,
+  tabId: string
+): TerminalTabRecord | null {
+  const unifiedTab = state.getTab?.(tabId)
+  const initialOwnerWorktreeId =
+    state.getTerminalTabOwnerWorktreeId?.(tabId) ??
+    (unifiedTab?.contentType === 'terminal'
+      ? state.getTerminalTabOwnerWorktreeId?.(unifiedTab.entityId)
+      : null)
+  const hasTabIn = (id: string | null | undefined, candidateId: string): boolean =>
+    Boolean(id && state.tabsByWorktree[id]?.some((candidate) => candidate.id === candidateId))
+  const terminalTabId = resolveTerminalTabId(
+    {
+      getTab: state.getTab,
+      hasTerminalTab: (candidateId) =>
+        hasTabIn(worktreeId, candidateId) || hasTabIn(initialOwnerWorktreeId, candidateId)
+    },
+    tabId
+  )
+  const ownerWorktreeId =
+    state.getTerminalTabOwnerWorktreeId?.(terminalTabId) ?? initialOwnerWorktreeId
+  const byId = (id: string | null | undefined): TerminalTabRecord | undefined =>
+    id ? state.tabsByWorktree[id]?.find((candidate) => candidate.id === terminalTabId) : undefined
+  return (
+    byId(worktreeId) ??
+    byId(ownerWorktreeId) ??
+    Object.values(state.tabsByWorktree)
+      .flat()
+      .find((candidate) => candidate.id === terminalTabId) ??
+    (unifiedTab && 'generation' in unifiedTab
+      ? { id: unifiedTab.entityId, generation: unifiedTab.generation }
+      : null)
+  )
+}

--- a/src/renderer/src/lib/worktree-sleep-intent.ts
+++ b/src/renderer/src/lib/worktree-sleep-intent.ts
@@ -2,14 +2,35 @@
 // Any pane connect that runs while the marker is set waits here, and the clear
 // that marks the workspace awake resumes every waiting connect.
 const sleepingWorktreeIds = new Set<string>()
+const tearingDownWorktreeIds = new Set<string>()
 const wakeListenersByWorktreeId = new Map<string, Set<() => void>>()
 
 export function markWorktreeSleepIntent(worktreeId: string): void {
   sleepingWorktreeIds.add(worktreeId)
 }
 
+/**
+ * Why: a spawn that resolves while the sleep teardown is still awaiting its host
+ * would bind a PTY and clear the marker, waking every waiting pane mid-sleep.
+ * Binds during the teardown window are not wakes.
+ */
+export async function withWorktreeSleepTeardown<T>(
+  worktreeId: string,
+  teardown: () => Promise<T>
+): Promise<T> {
+  tearingDownWorktreeIds.add(worktreeId)
+  try {
+    return await teardown()
+  } finally {
+    tearingDownWorktreeIds.delete(worktreeId)
+  }
+}
+
 export function clearWorktreeSleepIntent(worktreeId: string | null): void {
-  if (!worktreeId || !sleepingWorktreeIds.delete(worktreeId)) {
+  if (!worktreeId || tearingDownWorktreeIds.has(worktreeId)) {
+    return
+  }
+  if (!sleepingWorktreeIds.delete(worktreeId)) {
     return
   }
   const listeners = wakeListenersByWorktreeId.get(worktreeId)
@@ -27,6 +48,7 @@ export function clearWorktreeSleepIntent(worktreeId: string | null): void {
 // Why: a purged worktree must not wake its panes; they are being unmounted.
 export function forgetWorktreeSleepIntent(worktreeId: string): void {
   sleepingWorktreeIds.delete(worktreeId)
+  tearingDownWorktreeIds.delete(worktreeId)
   wakeListenersByWorktreeId.delete(worktreeId)
 }
 

--- a/src/renderer/src/lib/worktree-sleep-intent.ts
+++ b/src/renderer/src/lib/worktree-sleep-intent.ts
@@ -1,11 +1,16 @@
+// Why: a slept workspace keeps its panes mounted with only dead PTYs behind them.
+// Until the user explicitly opens it (or something binds a PTY to it), any
+// remount of those panes must stay cold instead of reattaching or respawning.
 const sleepingWorktreeIds = new Set<string>()
 
 export function markWorktreeSleepIntent(worktreeId: string): void {
   sleepingWorktreeIds.add(worktreeId)
 }
 
-export function clearWorktreeSleepIntent(worktreeId: string): void {
-  sleepingWorktreeIds.delete(worktreeId)
+export function clearWorktreeSleepIntent(worktreeId: string | null): void {
+  if (worktreeId) {
+    sleepingWorktreeIds.delete(worktreeId)
+  }
 }
 
 export function hasWorktreeSleepIntent(worktreeId: string | null): boolean {

--- a/src/renderer/src/lib/worktree-sleep-intent.ts
+++ b/src/renderer/src/lib/worktree-sleep-intent.ts
@@ -15,7 +15,12 @@ export function clearWorktreeSleepIntent(worktreeId: string | null): void {
   const listeners = wakeListenersByWorktreeId.get(worktreeId)
   wakeListenersByWorktreeId.delete(worktreeId)
   for (const listener of listeners ?? []) {
-    listener()
+    try {
+      listener()
+    } catch (error) {
+      // Why: one pane's connect failure must not strand its siblings or throw out of a store action.
+      console.error('[sleep-intent] wake listener failed', { worktreeId, error })
+    }
   }
 }
 

--- a/src/renderer/src/lib/worktree-sleep-intent.ts
+++ b/src/renderer/src/lib/worktree-sleep-intent.ts
@@ -1,18 +1,42 @@
 // Why: a slept workspace keeps its panes mounted with only dead PTYs behind them.
-// Until the user explicitly opens it (or something binds a PTY to it), any
-// remount of those panes must stay cold instead of reattaching or respawning.
+// Any pane connect that runs while the marker is set waits here, and the clear
+// that marks the workspace awake resumes every waiting connect.
 const sleepingWorktreeIds = new Set<string>()
+const wakeListenersByWorktreeId = new Map<string, Set<() => void>>()
 
 export function markWorktreeSleepIntent(worktreeId: string): void {
   sleepingWorktreeIds.add(worktreeId)
 }
 
 export function clearWorktreeSleepIntent(worktreeId: string | null): void {
-  if (worktreeId) {
-    sleepingWorktreeIds.delete(worktreeId)
+  if (!worktreeId || !sleepingWorktreeIds.delete(worktreeId)) {
+    return
   }
+  const listeners = wakeListenersByWorktreeId.get(worktreeId)
+  wakeListenersByWorktreeId.delete(worktreeId)
+  for (const listener of listeners ?? []) {
+    listener()
+  }
+}
+
+// Why: a purged worktree must not wake its panes; they are being unmounted.
+export function forgetWorktreeSleepIntent(worktreeId: string): void {
+  sleepingWorktreeIds.delete(worktreeId)
+  wakeListenersByWorktreeId.delete(worktreeId)
 }
 
 export function hasWorktreeSleepIntent(worktreeId: string | null): boolean {
   return worktreeId !== null && sleepingWorktreeIds.has(worktreeId)
+}
+
+export function onWorktreeSleepIntentCleared(worktreeId: string, listener: () => void): () => void {
+  const listeners = wakeListenersByWorktreeId.get(worktreeId) ?? new Set<() => void>()
+  listeners.add(listener)
+  wakeListenersByWorktreeId.set(worktreeId, listeners)
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0 && wakeListenersByWorktreeId.get(worktreeId) === listeners) {
+      wakeListenersByWorktreeId.delete(worktreeId)
+    }
+  }
 }

--- a/src/renderer/src/store/slices/worktree-sleep-intent-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/worktree-sleep-intent-lifecycle.test.ts
@@ -1,13 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  clearWorktreeSleepIntent,
-  hasWorktreeSleepIntent,
-  markWorktreeSleepIntent
-} from '@/lib/worktree-sleep-intent'
+import * as intent from '@/lib/worktree-sleep-intent'
 import { buildWorktreePurgeState } from './worktrees/teardown/worktree-purge-state'
 import { createTestStore, makeWorktree, seedStore } from './store-test-helpers'
 import { createStoreCascadesMockApi } from './store-cascades-test-harness'
 
+const { clearWorktreeSleepIntent, hasWorktreeSleepIntent, markWorktreeSleepIntent } = intent
 const WORKTREE_ID = 'repo1::/path/wt1'
 const FOLDER_KEY = 'folder:folder-1'
 
@@ -92,13 +89,47 @@ describe('worktree sleep intent lifecycle', () => {
     expect(hasWorktreeSleepIntent(WORKTREE_ID)).toBe(false)
   })
 
-  it('is pruned when the worktree is purged', () => {
+  it('is released when a tab is created with a live PTY', () => {
     const store = createTestStore()
     seedWorktree(store)
     markWorktreeSleepIntent(WORKTREE_ID)
 
+    store.getState().createTab(WORKTREE_ID, undefined, undefined, {
+      activate: false,
+      initialPtyId: 'pty-cli-created'
+    })
+
+    expect(hasWorktreeSleepIntent(WORKTREE_ID)).toBe(false)
+  })
+
+  it('notifies wake listeners once and only on a real clear', () => {
+    const { onWorktreeSleepIntentCleared } = intent
+    const woke = vi.fn()
+    markWorktreeSleepIntent(WORKTREE_ID)
+    const unsubscribe = onWorktreeSleepIntentCleared(WORKTREE_ID, woke)
+
+    clearWorktreeSleepIntent('repo1::/path/other')
+    expect(woke).not.toHaveBeenCalled()
+    clearWorktreeSleepIntent(WORKTREE_ID)
+    clearWorktreeSleepIntent(WORKTREE_ID)
+    expect(woke).toHaveBeenCalledTimes(1)
+
+    markWorktreeSleepIntent(WORKTREE_ID)
+    clearWorktreeSleepIntent(WORKTREE_ID)
+    expect(woke).toHaveBeenCalledTimes(1)
+    unsubscribe()
+  })
+
+  it('is forgotten without waking panes when the worktree is purged', () => {
+    const store = createTestStore()
+    seedWorktree(store)
+    markWorktreeSleepIntent(WORKTREE_ID)
+    const woke = vi.fn()
+    intent.onWorktreeSleepIntentCleared(WORKTREE_ID, woke)
+
     store.setState(buildWorktreePurgeState(store.getState(), [WORKTREE_ID]))
 
     expect(hasWorktreeSleepIntent(WORKTREE_ID)).toBe(false)
+    expect(woke).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/store/slices/worktree-sleep-intent-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/worktree-sleep-intent-lifecycle.test.ts
@@ -120,6 +120,20 @@ describe('worktree sleep intent lifecycle', () => {
     unsubscribe()
   })
 
+  it('keeps notifying siblings when one wake listener throws', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const woke = vi.fn()
+    markWorktreeSleepIntent(WORKTREE_ID)
+    intent.onWorktreeSleepIntentCleared(WORKTREE_ID, () => {
+      throw new Error('boom')
+    })
+    intent.onWorktreeSleepIntentCleared(WORKTREE_ID, woke)
+
+    expect(() => clearWorktreeSleepIntent(WORKTREE_ID)).not.toThrow()
+    expect(woke).toHaveBeenCalledTimes(1)
+    errorSpy.mockRestore()
+  })
+
   it('is forgotten without waking panes when the worktree is purged', () => {
     const store = createTestStore()
     seedWorktree(store)

--- a/src/renderer/src/store/slices/worktree-sleep-intent-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/worktree-sleep-intent-lifecycle.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearWorktreeSleepIntent,
+  hasWorktreeSleepIntent,
+  markWorktreeSleepIntent
+} from '@/lib/worktree-sleep-intent'
+import { buildWorktreePurgeState } from './worktrees/teardown/worktree-purge-state'
+import { createTestStore, makeWorktree, seedStore } from './store-test-helpers'
+import { createStoreCascadesMockApi } from './store-cascades-test-harness'
+
+const WORKTREE_ID = 'repo1::/path/wt1'
+const FOLDER_KEY = 'folder:folder-1'
+
+createStoreCascadesMockApi()
+
+function seedWorktree(store: ReturnType<typeof createTestStore>): void {
+  seedStore(store, {
+    worktreesByRepo: {
+      repo1: [makeWorktree({ id: WORKTREE_ID, repoId: 'repo1', path: '/path/wt1' })]
+    },
+    refreshGitHubForWorktree: vi.fn(),
+    refreshGitHubForWorktreeIfStale: vi.fn()
+  })
+}
+
+// Why this suite exists: the sleep marker outlives teardown so mounted panes stay cold
+// (#10205). Every route that makes a workspace awake again must release it, or the
+// workspace is stuck cold and its PTY exits stop counting as activity.
+describe('worktree sleep intent lifecycle', () => {
+  beforeEach(() => {
+    clearWorktreeSleepIntent(WORKTREE_ID)
+    clearWorktreeSleepIntent(FOLDER_KEY)
+  })
+
+  it('is released by activating the worktree', () => {
+    const store = createTestStore()
+    seedWorktree(store)
+    markWorktreeSleepIntent(WORKTREE_ID)
+
+    store.getState().setActiveWorktree(WORKTREE_ID)
+
+    expect(hasWorktreeSleepIntent(WORKTREE_ID)).toBe(false)
+  })
+
+  it('survives the sleep flow clearing the active selection', () => {
+    const store = createTestStore()
+    seedWorktree(store)
+    markWorktreeSleepIntent(WORKTREE_ID)
+
+    store.getState().setActiveWorktree(null)
+
+    expect(hasWorktreeSleepIntent(WORKTREE_ID)).toBe(true)
+  })
+
+  it('is released by activating a folder workspace', () => {
+    const store = createTestStore()
+    store.setState({
+      folderWorkspaces: [
+        {
+          id: 'folder-1',
+          projectGroupId: 'group-1',
+          name: 'Folder',
+          folderPath: '/folder',
+          executionHostId: 'local',
+          linkedTask: null,
+          comment: '',
+          isArchived: false,
+          isUnread: false,
+          isPinned: false,
+          sortOrder: 0,
+          lastActivityAt: 0,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+    markWorktreeSleepIntent(FOLDER_KEY)
+
+    store.getState().setActiveFolderWorkspace('folder-1')
+
+    expect(hasWorktreeSleepIntent(FOLDER_KEY)).toBe(false)
+  })
+
+  it('is released when any PTY binds to a tab in the worktree', () => {
+    const store = createTestStore()
+    seedWorktree(store)
+    const tab = store.getState().createTab(WORKTREE_ID, undefined, undefined, { activate: false })
+    markWorktreeSleepIntent(WORKTREE_ID)
+
+    store.getState().updateTabPtyId(tab.id, 'pty-cli-created')
+
+    expect(hasWorktreeSleepIntent(WORKTREE_ID)).toBe(false)
+  })
+
+  it('is pruned when the worktree is purged', () => {
+    const store = createTestStore()
+    seedWorktree(store)
+    markWorktreeSleepIntent(WORKTREE_ID)
+
+    store.setState(buildWorktreePurgeState(store.getState(), [WORKTREE_ID]))
+
+    expect(hasWorktreeSleepIntent(WORKTREE_ID)).toBe(false)
+  })
+})

--- a/src/renderer/src/store/slices/worktree-sleep-intent-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/worktree-sleep-intent-lifecycle.test.ts
@@ -120,6 +120,24 @@ describe('worktree sleep intent lifecycle', () => {
     unsubscribe()
   })
 
+  it('ignores a PTY bind that lands while the sleep teardown is in flight', async () => {
+    const store = createTestStore()
+    seedWorktree(store)
+    const tab = store.getState().createTab(WORKTREE_ID, undefined, undefined, { activate: false })
+    markWorktreeSleepIntent(WORKTREE_ID)
+    const woke = vi.fn()
+    intent.onWorktreeSleepIntentCleared(WORKTREE_ID, woke)
+
+    await intent.withWorktreeSleepTeardown(WORKTREE_ID, async () => {
+      store.getState().updateTabPtyId(tab.id, 'pty-late-spawn')
+    })
+
+    expect(hasWorktreeSleepIntent(WORKTREE_ID)).toBe(true)
+    expect(woke).not.toHaveBeenCalled()
+    store.getState().updateTabPtyId(tab.id, 'pty-after-teardown')
+    expect(hasWorktreeSleepIntent(WORKTREE_ID)).toBe(false)
+  })
+
   it('keeps notifying siblings when one wake listener throws', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const woke = vi.fn()

--- a/src/renderer/src/store/slices/worktrees/session/set-active-folder-workspace.ts
+++ b/src/renderer/src/store/slices/worktrees/session/set-active-folder-workspace.ts
@@ -20,7 +20,6 @@ export function createSetActiveFolderWorkspace(
     if (!workspace) {
       return
     }
-    clearWorktreeSleepIntent(workspaceKey)
     if (shouldDeferActivationTerminalPrep()) {
       markInputQuietSchedulerInput()
     }
@@ -124,6 +123,8 @@ export function createSetActiveFolderWorkspace(
           : s.folderWorkspaces
       }
     })
+    // Why: cleared after the set() so a waiting pane connects against the activated state.
+    clearWorktreeSleepIntent(workspaceKey)
     if (workspace.isUnread) {
       void get().updateFolderWorkspace(
         folderWorkspaceId,

--- a/src/renderer/src/store/slices/worktrees/session/set-active-folder-workspace.ts
+++ b/src/renderer/src/store/slices/worktrees/session/set-active-folder-workspace.ts
@@ -8,6 +8,7 @@ import {
   folderWorkspaceMatchesHost
 } from '../listing/detected-worktree-meta'
 import { shouldDeferActivationTerminalPrep } from './activation-terminal-prep'
+import { clearWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 
 export function createSetActiveFolderWorkspace(
   set: WorktreeSliceSet,
@@ -19,6 +20,7 @@ export function createSetActiveFolderWorkspace(
     if (!workspace) {
       return
     }
+    clearWorktreeSleepIntent(workspaceKey)
     if (shouldDeferActivationTerminalPrep()) {
       markInputQuietSchedulerInput()
     }

--- a/src/renderer/src/store/slices/worktrees/session/set-active-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/session/set-active-worktree.ts
@@ -24,6 +24,7 @@ import {
 } from '../listing/detected-worktree-meta'
 import { persistPassiveWorktreeMetaForOwner } from '../listing/worktree-owner-settings'
 import { resolveActivatedWorktreeSurface } from './active-worktree-surface'
+import { clearWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 import {
   pendingActivationTerminalPrepCancels,
   shouldDeferActivationTerminalPrep
@@ -41,6 +42,8 @@ export function createSetActiveWorktree(
       }
       return false
     }
+    // Why: any activation is an explicit wake; null is the sleep flow clearing selection.
+    clearWorktreeSleepIntent(worktreeId)
     const workspaceScope = worktreeId ? parseWorkspaceKey(worktreeId) : null
     if (worktreeId && shouldDeferActivationTerminalPrep()) {
       markInputQuietSchedulerInput()

--- a/src/renderer/src/store/slices/worktrees/session/set-active-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/session/set-active-worktree.ts
@@ -42,8 +42,6 @@ export function createSetActiveWorktree(
       }
       return false
     }
-    // Why: any activation is an explicit wake; null is the sleep flow clearing selection.
-    clearWorktreeSleepIntent(worktreeId)
     const workspaceScope = worktreeId ? parseWorkspaceKey(worktreeId) : null
     if (worktreeId && shouldDeferActivationTerminalPrep()) {
       markInputQuietSchedulerInput()
@@ -208,6 +206,11 @@ export function createSetActiveWorktree(
         ...tabsByWorktreeUpdate
       }
     })
+
+    // Why: any activation is an explicit wake (null is the sleep flow clearing selection).
+    // Cleared after the set() above so a pane still waiting on the marker connects once,
+    // in the remounted generation, instead of connecting and then being remounted.
+    clearWorktreeSleepIntent(worktreeId)
 
     if (worktreeId && shouldPrepareTerminalTabs) {
       const prepareTerminalTabs = (): void => {

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
@@ -6,7 +6,7 @@ import { parseExecutionHostId } from '../../../../../../shared/execution-host'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { getActiveRuntimeTarget } from '../../../../runtime/runtime-rpc-client'
 import { forgetHugeRepoWarningDismissalsForWorktrees } from '@/lib/source-control-huge-repo-warning-dismissals'
-import { clearWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
+import { forgetWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 import { showPreservedBranchToast } from '@/components/sidebar/preserved-branch-toast'
 import {
   resolveWorktreeOperationRouteResult,
@@ -223,7 +223,7 @@ export function createRemoveWorktree(
 
       // Why: invalidate stale probes once deletion is authoritative, so an old toast can't mutate a same-path replacement.
       forgetHugeRepoWarningDismissalsForWorktrees([worktreeId])
-      clearWorktreeSleepIntent(worktreeId)
+      forgetWorktreeSleepIntent(worktreeId)
       // Why: forget-local is legal while the host is unreachable, so record the removal here too — otherwise an
       // in-flight metadata read that snapshotted this row re-appends it, and disconnected polls never drop it.
       if (hostId && parseExecutionHostId(hostId)?.kind === 'ssh') {

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
@@ -6,6 +6,7 @@ import { parseExecutionHostId } from '../../../../../../shared/execution-host'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { getActiveRuntimeTarget } from '../../../../runtime/runtime-rpc-client'
 import { forgetHugeRepoWarningDismissalsForWorktrees } from '@/lib/source-control-huge-repo-warning-dismissals'
+import { clearWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 import { showPreservedBranchToast } from '@/components/sidebar/preserved-branch-toast'
 import {
   resolveWorktreeOperationRouteResult,
@@ -222,6 +223,7 @@ export function createRemoveWorktree(
 
       // Why: invalidate stale probes once deletion is authoritative, so an old toast can't mutate a same-path replacement.
       forgetHugeRepoWarningDismissalsForWorktrees([worktreeId])
+      clearWorktreeSleepIntent(worktreeId)
       // Why: forget-local is legal while the host is unreachable, so record the removal here too — otherwise an
       // in-flight metadata read that snapshotted this row re-appends it, and disconnected polls never drop it.
       if (hostId && parseExecutionHostId(hostId)?.kind === 'ssh') {

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
@@ -8,6 +8,7 @@ import { createWorktreePurgeOmitters } from './worktree-purge-omitters'
 import { removeDeleteStatesForWorktreeIds } from './worktree-delete-state'
 import { removeWorktreeVisitEntriesForTargets } from '@/lib/worktree-visit-recency'
 import { forgetAmbiguousOwnerWarnings } from '../listing/worktree-owner-settings'
+import { clearWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 
 export function buildWorktreePurgeState(
   s: AppState,
@@ -18,6 +19,10 @@ export function buildWorktreePurgeState(
   )
   const worktreeIdSet = new Set(normalizedTargets.map((target) => target.id))
   pruneHostedReviewLinkMutationGenerations(worktreeIdSet)
+  // Why: ids are repo::path, so a worktree recreated at the same path must not inherit a stale sleep.
+  for (const id of worktreeIdSet) {
+    clearWorktreeSleepIntent(id)
+  }
   // Why: every authoritative and explicit purge converges here, so a deleted path can't inherit stale UI state.
   forgetHugeRepoWarningDismissalsForWorktrees(worktreeIdSet)
   forgetAmbiguousOwnerWarnings(worktreeIdSet)

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
@@ -8,7 +8,7 @@ import { createWorktreePurgeOmitters } from './worktree-purge-omitters'
 import { removeDeleteStatesForWorktreeIds } from './worktree-delete-state'
 import { removeWorktreeVisitEntriesForTargets } from '@/lib/worktree-visit-recency'
 import { forgetAmbiguousOwnerWarnings } from '../listing/worktree-owner-settings'
-import { clearWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
+import { forgetWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 
 export function buildWorktreePurgeState(
   s: AppState,
@@ -21,7 +21,7 @@ export function buildWorktreePurgeState(
   pruneHostedReviewLinkMutationGenerations(worktreeIdSet)
   // Why: ids are repo::path, so a worktree recreated at the same path must not inherit a stale sleep.
   for (const id of worktreeIdSet) {
-    clearWorktreeSleepIntent(id)
+    forgetWorktreeSleepIntent(id)
   }
   // Why: every authoritative and explicit purge converges here, so a deleted path can't inherit stale UI state.
   forgetHugeRepoWarningDismissalsForWorktrees(worktreeIdSet)

--- a/src/renderer/src/store/terminals/terminal-pty-bindings.ts
+++ b/src/renderer/src/store/terminals/terminal-pty-bindings.ts
@@ -9,6 +9,7 @@ import {
   isRemoteRuntimePtyId
 } from './terminal-pty-identities'
 import { omitUnverifiedPtyLossTabIds } from './terminal-unverified-pty-loss'
+import { clearWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 import { omitDisownedPtyIds } from './terminal-disowned-pty-sources'
 
 export function createTerminalPtyBindingActions(
@@ -120,6 +121,8 @@ export function createTerminalPtyBindingActions(
           }
           break
         }
+        // Why: a bound PTY means the workspace is awake by any route (CLI, automation, client wake), not only activation.
+        clearWorktreeSleepIntent(worktreeId)
         // Why: the first active PTY changes sorting, except activation-spawn side effects.
         const isFirstPty = existingPtyIds.length === 0
         const isActiveWorktree = worktreeId != null && s.activeWorktreeId === worktreeId

--- a/src/renderer/src/store/terminals/terminal-pty-bindings.ts
+++ b/src/renderer/src/store/terminals/terminal-pty-bindings.ts
@@ -121,8 +121,6 @@ export function createTerminalPtyBindingActions(
           }
           break
         }
-        // Why: a bound PTY means the workspace is awake by any route (CLI, automation, client wake), not only activation.
-        clearWorktreeSleepIntent(worktreeId)
         // Why: the first active PTY changes sorting, except activation-spawn side effects.
         const isFirstPty = existingPtyIds.length === 0
         const isActiveWorktree = worktreeId != null && s.activeWorktreeId === worktreeId
@@ -278,6 +276,8 @@ export function createTerminalPtyBindingActions(
           ...(shouldBumpSortEpoch ? { sortEpoch: s.sortEpoch + 1 } : {})
         }
       })
+      // Why: a bound PTY means the workspace is awake by any route (CLI, automation, client wake), not only activation.
+      clearWorktreeSleepIntent(worktreeId)
       // Why: activation spawns come from clicking a worktree, not work in it — skip the lastActivityAt stamp and sortEpoch bump; other spawn reasons still bump.
       if (worktreeId && !wasActivationSpawn && !isRemoteRuntimeMirror) {
         get().bumpWorktreeActivity(worktreeId)

--- a/src/renderer/src/store/terminals/terminal-tab-creation.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-creation.ts
@@ -1,3 +1,4 @@
+import { clearWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import { isValidHostTerminalTabId } from '../../../../shared/terminal-tab-id'
 import { emptyLayoutSnapshot, singlePaneLayoutSnapshot } from '../slices/terminal-helpers'
@@ -271,6 +272,10 @@ export function createTerminalTabCreationActions(
           }
         }
       })
+      if (options?.initialPtyId) {
+        // Why: a tab born with a live PTY (CLI/runtime create) wakes the workspace like any other bind.
+        clearWorktreeSleepIntent(worktreeId)
+      }
       const shouldRecordInteraction =
         options?.recordInteraction ?? (!options?.pendingActivationSpawn && !options?.initialPtyId)
       if (shouldRecordInteraction) {

--- a/tests/e2e/helpers/slept-workspace-probe.ts
+++ b/tests/e2e/helpers/slept-workspace-probe.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared probes for GH #10205: a deliberately slept workspace must stay cold.
+ * Drives the shipping sleep path (sidebar context menu) and reads both the
+ * renderer's live PTY model and host truth.
+ */
+import type { Locator, Page } from '@stablyai/playwright-test'
+import { expect } from '@stablyai/playwright-test'
+import { ensureTerminalVisible } from './store'
+import { waitForActivePanePtyId, waitForActiveTerminalManager } from './terminal'
+
+export type WorkspaceSample = {
+  livePtyCount: number
+  tabCount: number
+  tabIds: string[]
+  mountedTabIds: string[]
+  tabPtyHints: (string | null)[]
+}
+
+export function rowLocator(page: Page, worktreeId: string): Locator {
+  return page
+    .locator(
+      `[data-worktree-sidebar] [role="option"][data-worktree-id=${JSON.stringify(worktreeId)}]`
+    )
+    .first()
+}
+
+export async function readWorkspaceSample(
+  page: Page,
+  worktreeId: string
+): Promise<WorkspaceSample> {
+  return page.evaluate((id) => {
+    const state = window.__store?.getState()
+    if (!state) {
+      throw new Error('window.__store is not available')
+    }
+    const tabs = state.tabsByWorktree[id] ?? []
+    const tabIds = new Set(tabs.map((tab) => tab.id))
+    const managers = window.__paneManagers
+    return {
+      livePtyCount: tabs.reduce(
+        (count, tab) => count + (state.ptyIdsByTabId[tab.id]?.length ?? 0),
+        0
+      ),
+      tabCount: tabs.length,
+      tabIds: tabs.map((tab) => tab.id),
+      mountedTabIds: managers
+        ? Array.from(managers.keys()).filter((tabId) => tabIds.has(tabId))
+        : [],
+      tabPtyHints: tabs.map((tab) => tab.ptyId ?? null)
+    }
+  }, worktreeId)
+}
+
+/** Host-side truth: a revived workspace shows a freshly created live session here. */
+export async function readHostLiveTerminalCount(page: Page, worktreeId: string): Promise<number> {
+  return (await page.evaluate(async (id) => {
+    const result = await window.api.runtime.call({
+      method: 'terminal.list',
+      params: { worktree: `id:${id}`, requireFreshPtyLiveness: true }
+    })
+    if (!result.ok) {
+      throw new Error(result.error.message)
+    }
+    return (result.result as { totalCount: number }).totalCount
+  }, worktreeId)) as number
+}
+
+/** Connect-verdict lines (REATTACH / ATTACH / FRESH SPAWN / SKIP SPAWN) for one workspace. */
+export async function readConnectDiagnostics(page: Page, worktreeId: string): Promise<string[]> {
+  return page.evaluate((id) => {
+    const state = window.__store?.getState()
+    const target = globalThis as unknown as Record<string, unknown>
+    const diag = (target.__ptyConnectDiag as string[] | undefined) ?? []
+    const tabIds = new Set((state?.tabsByWorktree[id] ?? []).map((tab) => tab.id))
+    // Pane ids restart at 1 per worktree, so a verdict line is attributed to the
+    // tab named by the most recent connect line for that same pane id.
+    const tabByPaneId = new Map<string, string>()
+    const owned: string[] = []
+    for (const line of diag) {
+      const connect = /^pane=(\d+) tab=(\S+)/.exec(line)
+      if (connect) {
+        tabByPaneId.set(connect[1], connect[2])
+        if (tabIds.has(connect[2])) {
+          owned.push(line)
+        }
+        continue
+      }
+      const verdict = /^pane=(\d+) ->/.exec(line)
+      if (verdict) {
+        const tabId = tabByPaneId.get(verdict[1])
+        if (tabId && tabIds.has(tabId)) {
+          owned.push(line)
+        }
+      }
+    }
+    return owned
+  }, worktreeId)
+}
+
+export async function giveWorkspaceALivePty(page: Page, worktreeId: string): Promise<string> {
+  await page.evaluate((id) => {
+    window.__store?.getState().setActiveWorktree(id)
+  }, worktreeId)
+  await ensureTerminalVisible(page)
+  await waitForActiveTerminalManager(page, 30_000)
+  return waitForActivePanePtyId(page, 30_000)
+}
+
+/** The shipping sleep path: right-click the sidebar row, click "Sleep". */
+export async function sleepWorkspaceViaSidebar(page: Page, worktreeId: string): Promise<void> {
+  const row = rowLocator(page, worktreeId)
+  await expect(row).toBeVisible()
+  await row.scrollIntoViewIfNeeded()
+  const scope = row.locator('[data-worktree-context-menu-scope="worktree"]').first()
+  const target = (await scope.count()) > 0 ? scope : row
+  await target.click({ button: 'right' })
+  const sleepItem = page.getByRole('menuitem', { name: 'Sleep', exact: true }).first()
+  await expect(sleepItem).toBeVisible()
+  await sleepItem.click()
+}
+
+export async function activateWorkspaceByClick(page: Page, worktreeId: string): Promise<void> {
+  const row = rowLocator(page, worktreeId)
+  await expect(row).toBeVisible()
+  await row.scrollIntoViewIfNeeded()
+  await row.click()
+  await expect
+    .poll(() => page.evaluate(() => window.__store?.getState().activeWorktreeId ?? null), {
+      timeout: 10_000,
+      message: `sidebar click did not activate ${worktreeId}`
+    })
+    .toBe(worktreeId)
+}

--- a/tests/e2e/helpers/slept-workspace-probe.ts
+++ b/tests/e2e/helpers/slept-workspace-probe.ts
@@ -77,7 +77,7 @@ export async function readConnectDiagnostics(page: Page, worktreeId: string): Pr
     const tabByPaneId = new Map<string, string>()
     const owned: string[] = []
     for (const line of diag) {
-      const connect = /^pane=(\d+) tab=(\S+)/.exec(line)
+      const connect = /^pane=(\d+) tab=(\S+) /.exec(line)
       if (connect) {
         tabByPaneId.set(connect[1], connect[2])
         if (tabIds.has(connect[2])) {

--- a/tests/e2e/slept-workspace-remount-wake.spec.ts
+++ b/tests/e2e/slept-workspace-remount-wake.spec.ts
@@ -72,7 +72,8 @@ test('remounting a slept hidden pane does not respawn its PTY', async ({ orcaPag
   expect(remounted, 'remountTerminalTabForRecovery did not find the slept tab').toBe(true)
   await assertStaysCold(orcaPage, slept)
 
-  // Non-vacuity: a deliberate click must still wake it.
+  // Non-vacuity: a deliberate click must still wake it, and exactly once — the
+  // waiting pane and its remounted successor must not both reattach.
   await activateWorkspaceByClick(orcaPage, slept)
   await expect
     .poll(async () => (await readWorkspaceSample(orcaPage, slept)).livePtyCount, {
@@ -80,4 +81,7 @@ test('remounting a slept hidden pane does not respawn its PTY', async ({ orcaPag
       message: 'the slept workspace never wakes even on deliberate activation'
     })
     .toBeGreaterThan(0)
+  await orcaPage.waitForTimeout(3_000)
+  expect((await readWorkspaceSample(orcaPage, slept)).livePtyCount).toBe(1)
+  expect(await readHostLiveTerminalCount(orcaPage, slept)).toBe(1)
 })

--- a/tests/e2e/slept-workspace-remount-wake.spec.ts
+++ b/tests/e2e/slept-workspace-remount-wake.spec.ts
@@ -35,6 +35,8 @@ async function assertStaysCold(page: Page, worktreeId: string): Promise<void> {
   expect(peakLivePty, 'slept workspace grew a live PTY').toBe(0)
   expect(peakTabs, 'slept workspace grew a tab').toBe(1)
   expect(hostLive, 'host created a session for the slept workspace').toBe(0)
+  // Why: proves the gate held rather than the pane having quietly unmounted.
+  expect(diag.at(-1), 'remounted pane did not wait for the wake').toContain('WAIT FOR WAKE')
 }
 
 test('remounting a slept hidden pane does not respawn its PTY', async ({ orcaPage }) => {

--- a/tests/e2e/slept-workspace-remount-wake.spec.ts
+++ b/tests/e2e/slept-workspace-remount-wake.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * GH #10205: a manual sleep keeps the tab's session id as a wake hint, so a later
+ * remount of its still-mounted pane reattaches that dead id and the daemon spawns
+ * a fresh shell. Production parking timings are deliberate: a shrunk park delay
+ * unmounts the slept panes and hides the behavior.
+ */
+import type { Page } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { getAllWorktreeIds, waitForSessionReady } from './helpers/store'
+import {
+  activateWorkspaceByClick,
+  giveWorkspaceALivePty,
+  readConnectDiagnostics,
+  readHostLiveTerminalCount,
+  readWorkspaceSample,
+  sleepWorkspaceViaSidebar
+} from './helpers/slept-workspace-probe'
+
+const OBSERVATION_MS = 8_000
+const SAMPLE_INTERVAL_MS = 200
+
+async function assertStaysCold(page: Page, worktreeId: string): Promise<void> {
+  let peakLivePty = 0
+  let peakTabs = 0
+  const deadline = Date.now() + OBSERVATION_MS
+  while (Date.now() < deadline) {
+    const sample = await readWorkspaceSample(page, worktreeId)
+    peakLivePty = Math.max(peakLivePty, sample.livePtyCount)
+    peakTabs = Math.max(peakTabs, sample.tabCount)
+    await page.waitForTimeout(SAMPLE_INTERVAL_MS)
+  }
+  const hostLive = await readHostLiveTerminalCount(page, worktreeId)
+  const diag = await readConnectDiagnostics(page, worktreeId)
+  console.error(`[#10205] ${JSON.stringify({ peakLivePty, peakTabs, hostLive, diag })}`)
+  expect(peakLivePty, 'slept workspace grew a live PTY').toBe(0)
+  expect(peakTabs, 'slept workspace grew a tab').toBe(1)
+  expect(hostLive, 'host created a session for the slept workspace').toBe(0)
+}
+
+test('remounting a slept hidden pane does not respawn its PTY', async ({ orcaPage }) => {
+  await waitForSessionReady(orcaPage)
+  const [slept, other] = await getAllWorktreeIds(orcaPage)
+  expect(other, 'seeded repo must expose two worktrees').toBeTruthy()
+  await giveWorkspaceALivePty(orcaPage, slept)
+  await giveWorkspaceALivePty(orcaPage, other)
+  await activateWorkspaceByClick(orcaPage, slept)
+  expect((await readWorkspaceSample(orcaPage, slept)).livePtyCount).toBeGreaterThan(0)
+
+  await sleepWorkspaceViaSidebar(orcaPage, slept)
+  await expect
+    .poll(async () => (await readWorkspaceSample(orcaPage, slept)).livePtyCount, {
+      timeout: 20_000,
+      message: 'sleep did not release the workspace PTYs'
+    })
+    .toBe(0)
+  await activateWorkspaceByClick(orcaPage, other)
+
+  const sample = await readWorkspaceSample(orcaPage, slept)
+  const sleptTabId = sample.tabIds[0]
+  expect(sleptTabId, 'slept workspace must retain a tab').toBeTruthy()
+  // Presence preconditions: the pane is still mounted and still carries its wake hint,
+  // otherwise a remount has nothing to reattach and the oracle passes vacuously.
+  expect(sample.mountedTabIds, 'slept pane was parked before the remount').toContain(sleptTabId)
+  expect(sample.tabPtyHints[0], 'sleep must keep the session id as a wake hint').toBeTruthy()
+
+  const remounted = await orcaPage.evaluate(
+    (tabId) => window.__store?.getState().remountTerminalTabForRecovery(tabId) ?? false,
+    sleptTabId
+  )
+  expect(remounted, 'remountTerminalTabForRecovery did not find the slept tab').toBe(true)
+  await assertStaysCold(orcaPage, slept)
+
+  // Non-vacuity: a deliberate click must still wake it.
+  await activateWorkspaceByClick(orcaPage, slept)
+  await expect
+    .poll(async () => (await readWorkspaceSample(orcaPage, slept)).livePtyCount, {
+      timeout: 40_000,
+      message: 'the slept workspace never wakes even on deliberate activation'
+    })
+    .toBeGreaterThan(0)
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​812 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​801 |
| Prod | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​214 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​104 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 |

<!-- /orca-pr-loc -->

## ELI5

Putting a workspace to sleep must keep it asleep until you open it. Before this fix, anything that re-mounted one of its terminal panes behind the scenes brought the shell back.

**Scope, stated plainly:** this closes the mechanism, not a reproduced user journey. The two field triggers reported in #10205 (sleeping the focused workspace revives a background-slept one; clicking an agent row or answering an agent question) do **not** reproduce on current `origin/main`: I drove both through the sidebar against identical builds of main and this branch, and both stayed cold on main with zero connect attempts. The mechanism is still real and deterministic: any remount of a slept pane reattaches its retained dead session id and the daemon spawns a fresh shell. The e2e proves that by calling the shipping remount entry point directly.

## What changed

- The existing in-memory sleep-intent marker now outlives a successful sleep instead of being cleared in `finally`.
- The deferred pane connect waits while the marker is set and the pane has no queued startup, and resumes when the marker clears. This sits before both the reattach and fresh-spawn arms; manual sleep keeps `tab.ptyId` as a wake hint, so a remount otherwise reattaches the dead session id and the daemon's create-or-attach spawns a fresh shell. A waiting pane resumes only if its tab generation is still current (resolved by either tab id form through one shared live lookup), so an activation that remounts the tab does not also connect the stale pane, and it re-arms so a later sleep can hold it again.
- The marker is released on activation (`setActiveWorktree` after its generation bump, `setActiveFolderWorkspace`), on any PTY binding to one of the workspace's tabs (`updateTabPtyId`, `createTab` with an initial PTY, which covers CLI, automation, and client wakes), and forgotten without waking anything on purge (`removeWorktree`, `buildWorktreePurgeState`).
- The sleep flow marks each workspace when its own teardown starts and re-asserts the marker after teardown, so a spawn that resolves mid-sleep cannot un-sleep it; a workspace the user activated during a batch sleep is released instead. Failed sleeps release the marker for the failed workspace only.

## Why

The community root cause in #13343 by @gatsby74 is right: the wake is the renderer pane-connect path. This PR lands that design with the gate moved to the connect entry, so it covers both connect arms, and with clear-on-bind so non-activation wakes never leave a workspace stuck cold.

## Linked issue

Fixes #10205 (STA-2449). Related: #13343 (source of the design, co-authored), #14705 (delete-focus fallback).

## Testing

- New e2e `tests/e2e/slept-workspace-remount-wake.spec.ts`: sleeps a workspace via the sidebar, activates another, forces a pane remount through `remountTerminalTabForRecovery` (the production entry point used by terminal pane recovery: undeliverable or host-rejected input, stalled write pipeline, replay-guard wedge, the Retry button on the pane-owner-unverified toast; the direct-SSH retry chain and all-dead activation bump the tab generation the same way), and asserts zero live PTYs, zero host sessions, and no tab growth over 8s, then proves a deliberate click still wakes it. Fails on `origin/main` (live PTY 1, host session 1, verdict `REATTACH`), passes here (verdict `WAIT FOR WAKE (deliberate sleep)`, asserted).
- New unit suites: connect gate (reattach arm, fresh-spawn arm, resume on wake, no resume for a remounted generation, listener dropped on dispose, queued startup still connects) and marker lifecycle (activation, null selection, folder activation, PTY bind, tab created with a PTY, listener semantics, purge forgets without waking).
- Local probe: a deliberate wake of a waiting pane produces exactly one connect and one host session.
- Existing `terminal-sleep-wake-restore`, `terminal-attention`, `terminal-cold-activation-deferral`, `local-cli-terminal-retention` e2e pass locally.
- Full renderer unit suites (14.7k tests), `pnpm tc`, `check:code-quality:changed` pass.
- Four adversarial review rounds; every finding fixed with a regression test.
- Not reproduced: #10205 Trigger A (focused-workspace sleep cascade, both slept-in-background and slept-while-focused variants) and Trigger B (agent-row activation) pass on current `origin/main`. Those reports are from July builds.

## Compatibility and boundaries

- No persisted or wire changes; the marker is renderer memory only. Restart cold state is already modelled by `activeWorktreeIdsOnShutdown`, which excludes slept worktrees.
- Folder workspaces use the same key for mark and clear. SSH and paired-runtime panes go through the same connect entry.

## AI disclosure

Implementation, reproduction, and review were AI-assisted; verification was run locally.

