### PR TITLE
fix(worktree): confirm the selected PR by number when its head is not in origin

### DIFF
--- a/src/main/github/selected-pr-branch-confirmation.test.ts
+++ b/src/main/github/selected-pr-branch-confirmation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import { confirmsSelectedGitHubPrByNumber } from './selected-pr-branch-confirmation'
+
+const pr = (overrides: Record<string, unknown> = {}) =>
+  ({
+    number: 42,
+    title: 'Upstream PR',
+    state: 'open',
+    url: 'https://example.com/pr/42',
+    checksStatus: 'success',
+    updatedAt: '2026-06-16T00:00:00.000Z',
+    mergeable: 'UNKNOWN',
+    headRefName: 'feature/fix',
+    ...overrides
+  }) as never
+
+describe('confirmsSelectedGitHubPrByNumber', () => {
+  const base = {
+    linkedPR: 42,
+    branchNameOverride: 'feature/fix',
+    branchName: 'feature/fix'
+  }
+
+  it('confirms when the selected PR heads this branch', async () => {
+    const lookupByNumber = vi.fn().mockResolvedValue(pr())
+
+    await expect(confirmsSelectedGitHubPrByNumber({ ...base, lookupByNumber })).resolves.toBe(true)
+    expect(lookupByNumber).toHaveBeenCalledWith(42)
+  })
+
+  it('rejects when the selected PR heads a different branch', async () => {
+    const lookupByNumber = vi.fn().mockResolvedValue(pr({ headRefName: 'someone/else' }))
+
+    await expect(confirmsSelectedGitHubPrByNumber({ ...base, lookupByNumber })).resolves.toBe(false)
+  })
+
+  it('rejects when the branch name override is not the branch being created', async () => {
+    const lookupByNumber = vi.fn().mockResolvedValue(pr())
+
+    await expect(
+      confirmsSelectedGitHubPrByNumber({ ...base, branchName: 'feature/fix-2', lookupByNumber })
+    ).resolves.toBe(false)
+    // Why: the override mismatch is decided before any request goes out.
+    expect(lookupByNumber).not.toHaveBeenCalled()
+  })
+
+  it('rejects without a selected review, and asks nothing', async () => {
+    const lookupByNumber = vi.fn().mockResolvedValue(pr())
+
+    await expect(
+      confirmsSelectedGitHubPrByNumber({ ...base, linkedPR: null, lookupByNumber })
+    ).resolves.toBe(false)
+    expect(lookupByNumber).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the lookup finds nothing', async () => {
+    const lookupByNumber = vi.fn().mockResolvedValue(null)
+
+    await expect(confirmsSelectedGitHubPrByNumber({ ...base, lookupByNumber })).resolves.toBe(false)
+  })
+
+  it('rejects when the lookup throws', async () => {
+    const lookupByNumber = vi.fn().mockRejectedValue(new Error('gh unavailable'))
+
+    await expect(confirmsSelectedGitHubPrByNumber({ ...base, lookupByNumber })).resolves.toBe(false)
+  })
+})

--- a/src/main/github/selected-pr-branch-confirmation.ts
+++ b/src/main/github/selected-pr-branch-confirmation.ts
@@ -1,0 +1,35 @@
+import type { getPRForBranch } from './client'
+
+type PRLookup = ReturnType<typeof getPRForBranch>
+
+/**
+ * Second opinion for "does this branch own the selected PR?" when the
+ * branch-name lookup came back empty.
+ *
+ * Why: branch lookup asks GitHub for a PR whose head is `{origin owner}:{branch}`,
+ * and falls back to the branch's tracked upstream when that misses. During worktree
+ * create the branch is the thing being named, so it has no tracked upstream and the
+ * fallback cannot run — a clone whose `origin` is a fork therefore never matches a PR
+ * opened from upstream or another fork (#16646). The sibling hosted-review path
+ * already passes the selected number for exactly this reason.
+ *
+ * Comparing the head ref rather than the number keeps this a real check: fetching by
+ * number makes the number match by construction, the head ref does not.
+ */
+export async function confirmsSelectedGitHubPrByNumber(args: {
+  lookupByNumber: (linkedPRNumber: number) => PRLookup
+  linkedPR: number | null | undefined
+  branchNameOverride: string | undefined
+  branchName: string
+}): Promise<boolean> {
+  if (typeof args.linkedPR !== 'number' || args.branchNameOverride !== args.branchName) {
+    return false
+  }
+  let pr: Awaited<PRLookup> = null
+  try {
+    pr = await args.lookupByNumber(args.linkedPR)
+  } catch {
+    return false
+  }
+  return pr?.number === args.linkedPR && pr?.headRefName === args.branchName
+}

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -27,6 +27,7 @@ import type {
   WorktreeHeadIdentity
 } from '../../shared/worktree/types'
 import { getPRForBranch } from '../github/client'
+import { confirmsSelectedGitHubPrByNumber } from '../github/selected-pr-branch-confirmation'
 import { listWorktrees, addWorktree, addSparseWorktree } from '../git/worktree'
 import type { AddWorktreeOptions, AddWorktreeResult } from '../git/worktree'
 import { consumePreparedWorktreeCreate } from '../worktree-create-preparation'
@@ -729,11 +730,16 @@ function hasLocalGitOptions(gitOptions: { wslDistro?: string }): boolean {
 function getLocalGitHubPrForBranch(
   repoPath: string,
   branchName: string,
-  gitOptions: { wslDistro?: string }
+  gitOptions: { wslDistro?: string },
+  linkedPRNumber: number | null = null
 ): ReturnType<typeof getPRForBranch> {
   return hasLocalGitOptions(gitOptions)
-    ? getPRForBranch(repoPath, branchName, null, null, null, { localGitExecOptions: gitOptions })
-    : getPRForBranch(repoPath, branchName)
+    ? getPRForBranch(repoPath, branchName, linkedPRNumber, null, null, {
+        localGitExecOptions: gitOptions
+      })
+    : linkedPRNumber === null
+      ? getPRForBranch(repoPath, branchName)
+      : getPRForBranch(repoPath, branchName, linkedPRNumber)
 }
 
 function hasRemoteCommitObject(
@@ -2263,6 +2269,22 @@ export async function createLocalWorktree(
               lastBranchConflictKind = null
             } else if (lastExistingPR) {
               lastExistingReviewNumber = lastExistingPR.number
+            } else if (
+              !lookupFailed &&
+              (await confirmsSelectedGitHubPrByNumber({
+                lookupByNumber: (linkedPRNumber) =>
+                  getLocalGitHubPrForBranch(
+                    repo.path,
+                    branchName,
+                    localWorktreeGitOptions,
+                    linkedPRNumber
+                  ),
+                linkedPR: args.linkedPR,
+                branchNameOverride: args.branchNameOverride,
+                branchName
+              }))
+            ) {
+              lastBranchConflictKind = null
             }
           } else if (selectedReview) {
             let hostedReview: Awaited<ReturnType<typeof getSelectedHostedReviewForBranch>> = null

--- a/src/main/ipc/worktrees-pr-head-outside-origin.test.ts
+++ b/src/main/ipc/worktrees-pr-head-outside-origin.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  listWorktreesMock,
+  addWorktreeMock,
+  getBranchConflictKindMock,
+  getPRForBranchMock,
+  computeWorktreePathMock
+} from './worktrees-test-module-mocks'
+import { handlers, setupWorktreeHandlers, store } from './worktrees-test-harness'
+
+vi.mock('electron', async () =>
+  (await import('./worktrees-test-module-mocks')).electronModuleMock()
+)
+vi.mock('../git/worktree', async () =>
+  (await import('./worktrees-test-module-mocks')).gitWorktreeModuleMock()
+)
+vi.mock('../git/runner', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRunnerModuleMock()
+)
+vi.mock('../git/repo', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRepoModuleMock()
+)
+vi.mock('../git/git-username', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resolveLocalGitUsername: (await import('./worktrees-test-module-mocks'))
+    .resolveLocalGitUsernameMock
+}))
+vi.mock('../github/client', async () =>
+  (await import('./worktrees-test-module-mocks')).githubClientModuleMock()
+)
+vi.mock('../source-control/hosted-review', async () =>
+  (await import('./worktrees-test-module-mocks')).hostedReviewModuleMock()
+)
+vi.mock('../providers/ssh-git-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshGitDispatchModuleMock()
+)
+vi.mock('../providers/ssh-filesystem-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshFilesystemDispatchModuleMock()
+)
+vi.mock('./worktree-symlinks', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeSymlinksModuleMock()
+)
+vi.mock('./ssh', async () => (await import('./worktrees-test-module-mocks')).sshModuleMock())
+vi.mock('../ssh/ssh-target-registry', async () =>
+  (await import('./worktrees-test-module-mocks')).sshTargetRegistryModuleMock()
+)
+vi.mock('../hooks', async () => (await import('./worktrees-test-module-mocks')).hooksModuleMock())
+vi.mock('../setup-runner-script-text', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupRunnerScriptTextModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../worktree-runner-script', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeRunnerScriptModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../effective-hook-config', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).effectiveHookConfigModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../setup-hook-env-vars', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupHookEnvVarsModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('./worktree-logic', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeLogicModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../terminal-history-deletion', async () =>
+  (await import('./worktrees-test-module-mocks')).terminalHistoryDeletionModuleMock()
+)
+vi.mock('../ports/advertised-url-watcher', async () =>
+  (await import('./worktrees-test-module-mocks')).advertisedUrlWatcherModuleMock()
+)
+vi.mock('../workspace-cleanup-scan-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupScanSnapshotModuleMock()
+)
+vi.mock('../workspace-space-analysis-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceSpaceAnalysisSnapshotModuleMock()
+)
+vi.mock('../workspace-cleanup-removal-snapshot-prune', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupRemovalSnapshotPruneModuleMock()
+)
+vi.mock('../runtime/worktree-teardown', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeTeardownModuleMock()
+)
+vi.mock('./pty', async () => (await import('./worktrees-test-module-mocks')).ptyModuleMock())
+
+describe('worktree create when the PR head is not in origin', () => {
+  beforeEach(() => {
+    setupWorktreeHandlers()
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    })
+    listWorktreesMock.mockImplementation(async () =>
+      addWorktreeMock.mock.calls.map((call: unknown[]) => ({
+        path: call[1] as string,
+        head: 'abc123',
+        branch: `refs/heads/${call[2] as string}`,
+        isBare: false,
+        isMainWorktree: false
+      }))
+    )
+    computeWorktreePathMock.mockImplementation(
+      (_repoPath: string, name: string) => `/workspace/${name}`
+    )
+    // A clone whose `origin` is a fork: branch lookup asks for `origin-owner:branch`
+    // and finds nothing, because the PR head lives upstream. Only the exact
+    // by-number lookup can see it.
+    getPRForBranchMock.mockImplementation(
+      async (_repoPath: unknown, _branch: unknown, linkedPRNumber?: unknown) =>
+        linkedPRNumber === 42
+          ? {
+              number: 42,
+              title: 'Upstream PR',
+              state: 'open',
+              url: 'https://example.com/pr/42',
+              checksStatus: 'success',
+              updatedAt: '2026-06-16T00:00:00.000Z',
+              mergeable: 'UNKNOWN',
+              headRefName: 'feature/fix'
+            }
+          : null
+    )
+  })
+
+  it('keeps the PR branch name when only the by-number lookup can see the PR', async () => {
+    getBranchConflictKindMock.mockResolvedValueOnce('remote')
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'fix-title',
+      baseBranch: 'abc123',
+      branchNameOverride: 'feature/fix',
+      linkedPR: 42,
+      pushTarget: { remoteName: 'origin', branchName: 'feature/fix' }
+    })
+
+    expect(addWorktreeMock.mock.calls.map((call: unknown[]) => call[2])).toEqual(['feature/fix'])
+  })
+
+  it('still suffixes when the selected PR heads a different branch', async () => {
+    getBranchConflictKindMock.mockResolvedValueOnce('remote')
+    getPRForBranchMock.mockImplementation(
+      async (_repoPath: unknown, _branch: unknown, linkedPRNumber?: unknown) =>
+        linkedPRNumber === 42
+          ? {
+              number: 42,
+              title: 'Upstream PR',
+              state: 'open',
+              url: 'https://example.com/pr/42',
+              checksStatus: 'success',
+              updatedAt: '2026-06-16T00:00:00.000Z',
+              mergeable: 'UNKNOWN',
+              headRefName: 'someone/else'
+            }
+          : null
+    )
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'fix-title',
+      baseBranch: 'abc123',
+      branchNameOverride: 'feature/fix',
+      linkedPR: 42,
+      pushTarget: { remoteName: 'origin', branchName: 'feature/fix' }
+    })
+
+    expect(addWorktreeMock.mock.calls.map((call: unknown[]) => call[2])).toEqual(['feature/fix-2'])
+  })
+})

--- a/src/main/runtime/runtime-local-worktree-create-candidate.ts
+++ b/src/main/runtime/runtime-local-worktree-create-candidate.ts
@@ -137,17 +137,21 @@ export async function resolveRuntimeLocalWorktreeCreateCandidate(args: {
         let existingPR: Awaited<ReturnType<typeof getPRForBranch>> | null = null
         const selectedReview = getSelectedReviewBranch(args.request)
         if (selectedReview?.provider === 'github') {
+          let lookupFailed = false
           try {
             existingPR = await getLocalGitHubPrForBranch(
               args.repo.path,
               branchName,
               args.localWorktreeGitOptions
             )
-          } catch {}
+          } catch {
+            lookupFailed = true
+          }
           if (isMatchingSelectedGitHubPr(existingPR, args.request, branchName)) {
             branchConflictKind = null
             selectedReviewConflictMatched = true
           } else if (
+            !lookupFailed &&
             !existingPR &&
             (await confirmsSelectedGitHubPrByNumber({
               lookupByNumber: (linkedPRNumber) =>

--- a/src/main/runtime/runtime-local-worktree-create-candidate.ts
+++ b/src/main/runtime/runtime-local-worktree-create-candidate.ts
@@ -24,6 +24,7 @@ import {
   isAllowedPushTargetRemoteConflict,
   isMatchingSelectedGitHubPr
 } from './selected-review-branch'
+import { confirmsSelectedGitHubPrByNumber } from '../github/selected-pr-branch-confirmation'
 import {
   canCheckoutExistingLocalBranch,
   getLocalGitHubPrForBranch,
@@ -144,6 +145,23 @@ export async function resolveRuntimeLocalWorktreeCreateCandidate(args: {
             )
           } catch {}
           if (isMatchingSelectedGitHubPr(existingPR, args.request, branchName)) {
+            branchConflictKind = null
+            selectedReviewConflictMatched = true
+          } else if (
+            !existingPR &&
+            (await confirmsSelectedGitHubPrByNumber({
+              lookupByNumber: (linkedPRNumber) =>
+                getLocalGitHubPrForBranch(
+                  args.repo.path,
+                  branchName,
+                  args.localWorktreeGitOptions,
+                  linkedPRNumber
+                ),
+              linkedPR: args.request.linkedPR,
+              branchNameOverride: args.request.branchNameOverride,
+              branchName
+            }))
+          ) {
             branchConflictKind = null
             selectedReviewConflictMatched = true
           }

--- a/src/main/runtime/runtime-worktree-create-git.ts
+++ b/src/main/runtime/runtime-worktree-create-git.ts
@@ -77,13 +77,16 @@ export async function canCheckoutExistingLocalBranch(
 export function getLocalGitHubPrForBranch(
   repoPath: string,
   branchName: string,
-  gitOptions: { wslDistro?: string }
+  gitOptions: { wslDistro?: string },
+  linkedPRNumber: number | null = null
 ): ReturnType<typeof getPRForBranch> {
   return hasLocalGitOptions(gitOptions)
-    ? getPRForBranch(repoPath, branchName, null, null, null, {
+    ? getPRForBranch(repoPath, branchName, linkedPRNumber, null, null, {
         localGitExecOptions: gitOptions
       })
-    : getPRForBranch(repoPath, branchName)
+    : linkedPRNumber === null
+      ? getPRForBranch(repoPath, branchName)
+      : getPRForBranch(repoPath, branchName, linkedPRNumber)
 }
 
 export async function getSelectedHostedReviewForBranch(


### PR DESCRIPTION
## ELI5

Open a worktree for someone's pull request and Orca sometimes names the branch `their-branch-2`. This makes it use the real name when your `origin` is your own fork.

## What Changed

When the branch-name lookup that confirms "does this branch own the selected PR?" comes back empty, ask a second time by PR number and accept the answer only if the PR's head ref equals the branch being created.

The existing branch lookup is untouched and still runs first. Both create paths get the fallback — `src/main/ipc/worktree-remote.ts` and `src/main/runtime/runtime-local-worktree-create-candidate.ts`.

## Why

`getPRForBranch` asks GitHub for a PR whose head is `{owner}:{branch}`, and the owner is always `origin`:

```ts
// github-api-repository.ts
return { candidates, headRepo: origin }
```

That qualifier is deliberate, and the case where the head lives elsewhere is already handled: when the qualified lookup misses, the resolver reads the branch's tracked upstream and retries under that remote's owner. `client-tracked-upstream-fork-owner.test.ts` covers it.

**That retry cannot run during worktree create.** It gets its input from `for-each-ref --format=%(refname)%00%(upstream) refs/heads` — the tracked upstreams of branches that already exist — and during create the branch is the thing being named. So for a clone whose `origin` is a fork, every lookup asks for `my-fork:branch`, a PR opened from upstream or another fork never matches, the remote conflict stands, and both the branch and the folder take a `-N` suffix.

I reproduced the mechanism by taking that existing suite and changing one thing — `refs/heads` returns nothing:

```
gh calls: 2
  repos/upstream-owner/repo/pulls?head=my-fork:feature/x&state=all
  repos/my-fork/repo/pulls?head=my-fork:feature/x&state=all
getOwnerRepoForRemote calls: 0      <- the tracked-upstream retry never runs
result: null
```

The reporter of #16646 confirmed it against their own clone: the owner-qualified query returns `0` while the unqualified one finds the PR.

**Why by number, and why compare the head ref.** The sibling hosted-review path already passes the selected number (`getSelectedHostedReviewForBranch` forwards `linkedGitHubPR`), so this aligns the GitHub path with what its neighbour does. Fetching by number would make `pr.number === linkedPR` true by construction, so the check compares `pr.headRefName` to the branch instead — a branch that does not head the selected PR still gets the suffix, covered by a test here.

## Linked Issue

Refs #16646 — this is the "origin is a fork and the PR head is not in it" path. #16699 (merged) fixed the orphaned-prefix path and #17021 covers the fork-PR-with-no-push-target path; the issue stays open until all three are addressed, so no closing keyword.

## Visual Proof

`N/A` — no UI change. The user-visible effect is the created branch and folder name, asserted directly by the tests below.

## Testing

Windows 11, Node 24. `pnpm build`, project typecheck, `oxlint`, `oxfmt` and the max-lines ratchet all pass locally.

New `src/main/ipc/worktrees-pr-head-outside-origin.test.ts` drives the real `worktrees:create` handler with a mock that only answers the by-number lookup — the shape of a clone whose `origin` is a fork:

| case | before | after |
|---|---|---|
| **only the by-number lookup can see the PR** | **`feature/fix-2`** | **`feature/fix`** |
| the selected PR heads a different branch | `feature/fix-2` | `feature/fix-2` |

I confirmed the first fails without the source change (`git stash` on the three source files, re-run: exactly that one fails, the second passes), so it targets this defect rather than passing incidentally.

Also run: `worktrees-existing-branch-checkout`, `worktrees-local-create-flow`, `worktrees-wsl-runtime-routing`, `worktrees-windows`, `github-repo-access-guards`, `github-wsl-runtime-routing`, `worktrees-preserved-branch-fork-remote`, `worktrees-ssh-fork-push-target-remote`, `selected-review-branch` — 10 files, 100 tests, all passing.

Several of those assert the lookup's exact arguments, including the `null` linked number. Keeping the first lookup unchanged and adding the second as a fallback leaves every one of those assertions intact.

`src/main/runtime/` also contains PTY/daemon suites that fail on this machine; they fail identically with and without this change (a local native-build problem, filed separately as #18052).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Opus 5 (Claude Code). I traced both create paths by hand, reproduced the mechanism before writing the fix, and verified the new test fails without it.

## Review

The judgement call worth a second opinion is scope: the same missing-tracked-upstream reasoning applies to any create-time confirmation, but I only changed the GitHub branch path, because the hosted-review path already passes the number and `getPRForBranch` itself is shared with the PR refresh coordinator, the queue drainer and the forge providers — its `headRepo` identity is also what rate-limit accounting keys on, so I did not want to touch it.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security** — no widening. The conflict is still cleared only after a lookup confirms ownership; the fallback adds a head-ref equality check on top of the number, so it is stricter than the neighbouring hosted-review path, not looser.
- **Efficiency** — the extra call happens only where the current code has already failed and is about to suffix the branch, so no request is added to any path that works today.
- **Cross-platform** — argument logic only, no platform-dependent code. Verified on Windows.
- **Remote SSH** — `createRemoteWorktree` confirms through `getSelectedHostedReviewForBranch`, which already forwards the selected number; unchanged here.
- **Git providers** — GitLab, Bitbucket, Azure DevOps and Gitea go through that same hosted path and are unaffected.
- **Mobile / backwards compatibility** — no wire, schema or IPC change.

One thing a reviewer may want to fold in separately: `isAllowedPushTargetRemoteConflict`, `isMatchingSelectedGitHubPr`, `getSelectedReviewBranch`, `getSelectedReviewLookupHints` and `getLocalGitHubPrForBranch` each exist twice, once in `worktree-remote.ts` and once under `src/main/runtime/`. I changed both copies rather than deduplicating, to keep this PR behavioural-only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADAPnmpPBMctKbwkj2i9NS
