### PR TITLE
fix(worktree): restore the stale-cleanup signal after the module split

### DIFF
--- a/src/main/worktree-create-preparation-stale-cleanup.ts
+++ b/src/main/worktree-create-preparation-stale-cleanup.ts
@@ -74,6 +74,11 @@ export async function cleanupStalePreparations(
   }
 }
 
+/** True while a crash-recovery scan is running, which means a create is in flight or imminent. */
+export function hasPendingStalePreparationCleanup(): boolean {
+  return staleCleanupInFlight.size > 0
+}
+
 export function resetStalePreparationCleanupForTests(): void {
   staleCleanupInFlight.clear()
 }

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -39,6 +39,7 @@ vi.mock('./ipc/worktree-logic', () => ({
 import {
   _resetWorktreeCreatePreparationsForTests,
   consumePreparedWorktreeCreate,
+  hasPendingWorktreeCreatePreparations,
   prepareWorktreeCreateForRepo
 } from './worktree-create-preparation'
 
@@ -476,6 +477,23 @@ describe('worktree create preparation registry', () => {
       baseBranch: 'origin/main'
     })
   }
+
+  it('reports a pending create while a stale-cleanup scan is running', async () => {
+    let releaseListing!: () => void
+    mocks.listWorktreeGraph.mockReturnValueOnce(
+      new Promise((resolve) => {
+        releaseListing = () => resolve([])
+      })
+    )
+    const arming = prepareWorktreeCreateForRepo(store, repo, 'origin/main')
+    await Promise.resolve()
+
+    // Why: the idle gate must not start repo maintenance while crash recovery is mid-scan.
+    expect(hasPendingWorktreeCreatePreparations()).toBe(true)
+
+    releaseListing()
+    await arming
+  })
 
   it('does not re-arm after an isolated create', async () => {
     await prepareWorktreeCreateForRepo(store, repo, 'origin/main')

--- a/src/main/worktree-create-preparation.test.ts
+++ b/src/main/worktree-create-preparation.test.ts
@@ -486,7 +486,11 @@ describe('worktree create preparation registry', () => {
       })
     )
     const arming = prepareWorktreeCreateForRepo(store, repo, 'origin/main')
-    await Promise.resolve()
+    // Anchor on the scan actually starting, not on a fixed number of microtasks: an await added
+    // ahead of it would otherwise make this pass vacuously rather than fail.
+    while (mocks.listWorktreeGraph.mock.calls.length === 0) {
+      await Promise.resolve()
+    }
 
     // Why: the idle gate must not start repo maintenance while crash recovery is mid-scan.
     expect(hasPendingWorktreeCreatePreparations()).toBe(true)

--- a/src/main/worktree-create-preparation.ts
+++ b/src/main/worktree-create-preparation.ts
@@ -26,6 +26,7 @@ import {
 } from './worktree-create-preparation-burst'
 import {
   cleanupStalePreparations,
+  hasPendingStalePreparationCleanup,
   resetStalePreparationCleanupForTests
 } from './worktree-create-preparation-stale-cleanup'
 import { toHostFilesystemPath } from './host-tree-removal'
@@ -63,7 +64,7 @@ const preparations = new Map<string, PreparationEntry>()
 
 /** A prepared checkout is a create that is either in flight or imminent. */
 export function hasPendingWorktreeCreatePreparations(): boolean {
-  return preparations.size > 0 || staleCleanupInFlight.size > 0
+  return preparations.size > 0 || hasPendingStalePreparationCleanup()
 }
 
 function pathOps(path: string): Pick<typeof posix, 'dirname' | 'join' | 'normalize'> {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

Two changes were each fine on their own, but together they broke the build on `main`: one moved a variable into a new file, the other started using that variable from the old file. This puts the reader and the variable back in touch.

## What Changed

`hasPendingWorktreeCreatePreparations` in `src/main/worktree-create-preparation.ts` read `staleCleanupInFlight` directly. #17829 moved that map into `src/main/worktree-create-preparation-stale-cleanup.ts`, where it is module-private, leaving the reference dangling.

Rather than re-export the map, this exposes a predicate from the module that owns it — `hasPendingStalePreparationCleanup()` — so the map stays private and the caller asks a question instead of reaching for state.

Also adds a test for the signal itself: while a stale-cleanup scan is in flight, `hasPendingWorktreeCreatePreparations()` must report `true`. That behaviour had no direct coverage, which is why the split could remove it silently.

## Why

**`main` is currently broken.** `pnpm tc` fails with:

```
src/main/worktree-create-preparation.ts(66,35): error TS2304: Cannot find name 'staleCleanupInFlight'.
```

This fails `typecheck` and therefore `verify` for **every** PR targeting `main`, because CI builds `refs/pull/<n>/merge` — a merge against the current tip — not the PR branch alone.

Worth recording how it got in, since neither side was careless: **#17857** (`d7123591ceb`, "pack the loose refs Orca's own fetches leave behind") added `hasPendingWorktreeCreatePreparations` reading `staleCleanupInFlight`, while **#17829**'s module split — which made that map module-private — was in review. Each passed `pnpm tc` and full CI against its own base. Git merged them without a textual conflict; the incompatibility is semantic, so nothing flagged it until the merged tree was typechecked.

This is why CI building `refs/pull/<n>/merge` matters: a red `typecheck` on an unrelated PR can originate on `main` rather than in that PR's diff. Three separate branches investigated this failure as their own before it was traced here.

The signal matters: `repo-maintenance-idle-gate.ts:33` uses it to decide whether a create is in flight or imminent before starting background `pack-refs` maintenance. A wrong answer there means maintenance starts during a create.

Refs #17828

## User-Facing Regressions

None. This restores behaviour that #17899 introduced and #17829 accidentally removed at compile time; there is no runtime behaviour change relative to either PR's intent.

## Visual Proof

N/A — build fix, no UI or interaction change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

`pnpm tc` clean (fails on `main` without this), full `pnpm lint` clean, and `src/main/worktree-create-preparation.test.ts` + `src/main/repo-maintenance-idle-gate.test.ts` pass (32 tests). The new test holds a stale-cleanup scan open and asserts the pending signal is `true` while it runs. It anchors on the scan actually starting (spinning until `listWorktreeGraph` is called) rather than on a fixed number of microtasks — an `await` added ahead of it would otherwise make the test pass vacuously instead of fail, which is the same fragility class that let the original regression through.

Platforms: developed and tested on **macOS**. No platform-specific code paths touched — this is a module-boundary fix.

## AI Disclosure

Claude Opus 5 (Claude Code).

## Review

Please land this ahead of the other #17828 PRs; they are all blocked on it. #17922 carries an equivalent fix on its own branch (`b523b9a3ea4`) — that one should be dropped on rebase in favour of this, so the fix lands once.

## Agent skill upstream boundary

N/A
