### PR TITLE
fix(usage): recognize Fable 5.1 usage limits

### DIFF
--- a/src/main/claude-usage/claude-model-pricing.test.ts
+++ b/src/main/claude-usage/claude-model-pricing.test.ts
@@ -48,6 +48,12 @@ describe('estimateCostUsd cache-write TTL rates', () => {
   it('still returns null for unknown models', () => {
     expect(estimateCostUsd('gpt-5', 0, 0, 0, 1_000_000, 1_000_000)).toBeNull()
   })
+
+  it('prices the Fable 5.1 model id with the existing Fable rates', () => {
+    expect(
+      estimateCostUsd('claude-fable-5-1', 1_000_000, 1_000_000, 1_000_000, 1_000_000)
+    ).toBeCloseTo(73.5)
+  })
 })
 
 // Published Claude Sonnet 5 rates (platform.claude.com/docs/en/about-claude/pricing):

--- a/src/main/claude-usage/scanner.test.ts
+++ b/src/main/claude-usage/scanner.test.ts
@@ -41,6 +41,33 @@ describe('parseClaudeUsageRecord', () => {
     })
   })
 
+  it('keeps a Fable 5.1 turn when optional usage fields are missing', () => {
+    const parsed = parseClaudeUsageRecord(
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 'session-fable-51',
+        timestamp: '2026-09-01T10:00:00.000Z',
+        message: {
+          model: 'claude-fable-5-1',
+          usage: { input_tokens: 100, cache_read_input_tokens: 10 }
+        }
+      })
+    )
+
+    expect(parsed).toEqual({
+      sessionId: 'session-fable-51',
+      timestamp: '2026-09-01T10:00:00.000Z',
+      model: 'claude-fable-5-1',
+      cwd: null,
+      gitBranch: null,
+      inputTokens: 100,
+      outputTokens: 0,
+      cacheReadTokens: 10,
+      cacheWriteTokens: 0,
+      cacheWrite1hTokens: 0
+    })
+  })
+
   it('splits the cache-write total by TTL when the breakdown is present', () => {
     const parsed = parseClaudeUsageRecord(
       JSON.stringify({

--- a/src/main/claude-usage/store.test.ts
+++ b/src/main/claude-usage/store.test.ts
@@ -375,6 +375,21 @@ describe('ClaudeUsageStore', () => {
         },
         {
           day: '2026-04-09',
+          model: 'claude-fable-5-1',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000,
+          cacheWrite1hTokens: 0
+        },
+        {
+          day: '2026-04-09',
           model: 'claude-sonnet-5-thinking',
           projectKey: 'worktree:repo-1::/workspace/repo-a',
           projectLabel: 'Repo A',
@@ -399,6 +414,9 @@ describe('ClaudeUsageStore', () => {
     expect(
       breakdown.find((row) => row.key === 'anthropic/claude-fable-5')?.estimatedCostUsd
     ).toBeCloseTo(73.5)
+    expect(breakdown.find((row) => row.key === 'claude-fable-5-1')?.estimatedCostUsd).toBeCloseTo(
+      73.5
+    )
     expect(
       breakdown.find((row) => row.key === 'claude-sonnet-5-thinking')?.estimatedCostUsd
     ).toBeCloseTo(14.7)

--- a/src/main/rate-limits/claude-fetcher-fable-usage.test.ts
+++ b/src/main/rate-limits/claude-fetcher-fable-usage.test.ts
@@ -144,6 +144,45 @@ describe('fetchClaudeRateLimits', () => {
     expect(fetchViaPty).not.toHaveBeenCalled()
   })
 
+  it('maps a scoped Fable point-release usage window', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
+      stripAuthEnv: false,
+      provenance: 'managed:account-1'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValueOnce(
+      JSON.stringify({ claudeAiOauth: { accessToken: 'oauth-token' } })
+    )
+    netFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          five_hour: { utilization: 36 },
+          seven_day: { utilization: 73 },
+          limits: [
+            {
+              kind: 'weekly_scoped',
+              percent: 77,
+              resets_at: '2026-09-08T20:00:00+00:00',
+              scope: { model: { display_name: 'Fable 5.1' } }
+            }
+          ]
+        }),
+        { status: 200 }
+      )
+    )
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      fableWeekly: {
+        usedPercent: 77,
+        resetsAt: Date.parse('2026-09-08T20:00:00+00:00')
+      }
+    })
+  })
+
   it('surfaces inactive scoped Fable usage over the legacy OAuth fallback', async () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {

--- a/src/main/rate-limits/claude-oauth-usage-request.ts
+++ b/src/main/rate-limits/claude-oauth-usage-request.ts
@@ -38,7 +38,7 @@ function mapFableWeeklyWindow(data: OAuthUsageResponse): RateLimitWindow | null 
         (limit) =>
           limit?.kind === 'weekly_scoped' &&
           Number.isFinite(limit.percent) &&
-          limit.scope?.model?.display_name?.trim().toLowerCase() === 'fable'
+          /^fable\b/i.test(limit.scope?.model?.display_name?.trim() ?? '')
       )
     : undefined
   return (


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

## Summary

- Match scoped Claude OAuth usage limits labeled Fable 5.1 and other Fable point releases.
- Preserve the existing Fable 5 pricing inheritance for claude-fable-5-1.
- Add parser, model-accounting, dashboard-breakdown, and usage-limit regression coverage, including missing optional token fields and mixed legacy/new model IDs.

## Reproduction

On origin/main, a deterministic scoped OAuth response with display_name Fable 5.1 returned fableWeekly: null because the matcher required an exact fable label.

## Validation

- 75 relevant tests passed across Claude usage and rate-limit suites.
- Changed-code quality and formatting checks passed.
- Read-only local transcript verification parsed representative legacy and Fable 5.1 sessions, including a mixed-version transcript.
- pnpm tc:node remains blocked by the pre-existing staleCleanupInFlight error in src/main/worktree-create-preparation.ts:66.

No prompts, secrets, credentials, OAuth tokens, or private session content were included.