### PR TITLE
fix(orchestration): reject unavailable worker agents

### DIFF
--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -12,7 +12,8 @@ export type WslPreflightTarget = {
 
 export async function detectWslCommandsOnPath(
   wslTarget: WslPreflightTarget,
-  commands: readonly string[]
+  commands: readonly string[],
+  options: { failOnProbeError?: boolean } = {}
 ): Promise<Set<string>> {
   const uniqueCommands = [...new Set(commands.filter(Boolean))]
   if (uniqueCommands.length === 0) {
@@ -35,10 +36,12 @@ export async function detectWslCommandsOnPath(
     // second bespoke `[ -x ]` walk here duplicated the lookup script's own
     // `! -d` guard, which is how a directory once read as an installed CLI.
     buildPosixFallbackPathPrelude(),
-    `for cmd in ${commandList}; do`,
+    `for raw_cmd in ${commandList}; do`,
+    'cmd="$raw_cmd"',
+    'case "$cmd" in "~/"*) cmd="$HOME/${cmd#~/}" ;; esac',
     lookupScript,
     'if [ -n "$resolved" ]; then',
-    `printf '${WSL_AGENT_DETECTION_PREFIX}%s\\t%s\\n' "$cmd" "$resolved";`,
+    `printf '${WSL_AGENT_DETECTION_PREFIX}%s\\t%s\\n' "$raw_cmd" "$resolved";`,
     'fi',
     'done'
   ].join('\n')
@@ -56,11 +59,22 @@ export async function detectWslCommandsOnPath(
     })
     // runProcess resolves on a timeout and on a non-zero exit, so partial
     // stdout would otherwise read as a complete answer.
-    if (result.timedOut || result.code !== 0) {
+    if (result.environmentResolved === false || result.timedOut || result.code !== 0) {
+      if (options.failOnProbeError) {
+        throw Object.assign(new Error('The WSL execution host is unavailable.'), {
+          code: 'remote_runtime_unavailable'
+        })
+      }
       return new Set()
     }
     return parseWslDetectedCommands(result.stdout)
-  } catch {
+  } catch (error) {
+    if (options.failOnProbeError) {
+      throw Object.assign(new Error('The WSL execution host is unavailable.'), {
+        code: 'remote_runtime_unavailable',
+        cause: error
+      })
+    }
     return new Set()
   }
 }

--- a/src/main/preflight/agent-detection.ts
+++ b/src/main/preflight/agent-detection.ts
@@ -15,7 +15,6 @@ import { getBitbucketAuthStatus } from '../bitbucket/client'
 import { getGiteaAuthStatus } from '../gitea/client'
 import { _resetKnownHostsCache } from '../gitlab/gl-utils'
 import { mergePersistedWindowsPathAsync } from '../pty/windows-environment-path'
-import { getActiveMultiplexer } from '../ssh/ssh-target-registry'
 import {
   detectWslCommandsOnPath,
   type WslPreflightTarget
@@ -120,10 +119,6 @@ export function _resetPreflightCache(): void {
   preflightCacheEpoch += 1
 }
 
-function uniqueAgentIds(ids: Iterable<string>): string[] {
-  return [...new Set(ids)]
-}
-
 async function detectCommandRuntime(
   command: string,
   context?: PreflightRuntimeContext
@@ -140,12 +135,16 @@ async function detectCommandRuntime(
   return { installed: false }
 }
 
-export async function detectInstalledAgents(context?: PreflightRuntimeContext): Promise<string[]> {
+export async function detectInstalledAgents(
+  context?: PreflightRuntimeContext,
+  options: { failOnProbeError?: boolean } = {}
+): Promise<string[]> {
   const wslTarget = getPreflightWslTarget(context)
   if (wslTarget) {
     const foundCommands = await detectWslCommandsOnPath(
       wslTarget,
-      getTuiAgentDetectionProbeCommands(KNOWN_TUI_AGENT_DETECTION_COMMANDS, 'wsl')
+      getTuiAgentDetectionProbeCommands(KNOWN_TUI_AGENT_DETECTION_COMMANDS, 'wsl'),
+      options
     )
     return resolveDetectedTuiAgentIds(KNOWN_TUI_AGENT_DETECTION_COMMANDS, foundCommands, 'wsl')
   }
@@ -177,10 +176,11 @@ export async function detectInstalledAgents(context?: PreflightRuntimeContext): 
 }
 
 export async function detectInstalledAgentsWithShellPathHydration(
-  context?: PreflightRuntimeContext
+  context?: PreflightRuntimeContext,
+  options: { failOnProbeError?: boolean } = {}
 ): Promise<string[]> {
   await hydrateShellPathForAgentDetection(context)
-  return detectInstalledAgents(context)
+  return detectInstalledAgents(context, options)
 }
 
 export type RefreshAgentsResult = {
@@ -238,18 +238,7 @@ export async function refreshShellPathAndDetectAgents(
   }
 }
 
-export async function detectRemoteAgents(args: { connectionId: string }): Promise<string[]> {
-  const mux = getActiveMultiplexer(args.connectionId)
-  if (!mux || mux.isDisposed()) {
-    // Why: remote agent detection is passive UI polling. A disconnected host has
-    // no detectable agents until reconnect, but should not spam IPC errors.
-    return []
-  }
-  const result = (await mux.request('preflight.detectAgents', {
-    commands: KNOWN_TUI_AGENT_DETECTION_COMMANDS
-  })) as { agents: string[] }
-  return uniqueAgentIds(result.agents)
-}
+export { detectRemoteAgents } from './remote-agent-detection'
 
 async function isGhAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
   try {

--- a/src/main/preflight/remote-agent-detection.ts
+++ b/src/main/preflight/remote-agent-detection.ts
@@ -1,0 +1,44 @@
+import { getActiveMultiplexer } from '../ssh/ssh-target-registry'
+import { KNOWN_TUI_AGENT_DETECTION_COMMANDS } from '../../shared/tui-agent-detection-commands'
+import type { TuiAgentDetectionCommand } from '../../shared/tui-agent-detection-commands'
+
+function uniqueAgentIds(ids: Iterable<string>): string[] {
+  return [...new Set(ids)]
+}
+
+export async function detectRemoteAgents(args: {
+  connectionId: string
+  commands?: readonly TuiAgentDetectionCommand[]
+  requireAvailable?: boolean
+}): Promise<string[]> {
+  const mux = getActiveMultiplexer(args.connectionId)
+  if (!mux || mux.isDisposed()) {
+    if (args.requireAvailable) {
+      throw Object.assign(new Error('The remote execution host is unavailable.'), {
+        code: 'remote_runtime_unavailable'
+      })
+    }
+    return []
+  }
+  try {
+    const result = (await mux.request('preflight.detectAgents', {
+      commands: args.commands ?? KNOWN_TUI_AGENT_DETECTION_COMMANDS
+    })) as { agents: string[] }
+    return uniqueAgentIds(result.agents)
+  } catch (error) {
+    const code = (error as { code?: unknown })?.code
+    const transportFailure =
+      mux.isDisposed() ||
+      code === 'CONNECTION_LOST' ||
+      code === 'DISPOSED' ||
+      code === 'SSH_MUX_REQUEST_TIMEOUT' ||
+      (error instanceof Error && /connection|timed? out/i.test(error.message))
+    if (args.requireAvailable && transportFailure) {
+      throw Object.assign(new Error('The remote execution host is unavailable.'), {
+        code: 'remote_runtime_unavailable',
+        cause: error
+      })
+    }
+    throw error
+  }
+}

--- a/src/main/runtime/orca-runtime-agent-launch-validation.test.ts
+++ b/src/main/runtime/orca-runtime-agent-launch-validation.test.ts
@@ -125,6 +125,26 @@ describe('validateOrchestrationAgentLauncherForRepo', () => {
     })
   })
 
+  it('reports a missing agent from a repair-required runtime without probing its override', async () => {
+    const runtime = createRuntime({ agentCmdOverrides: { amp: 'managed-amp' } })
+    resolveLocalProjectRuntimeForRepo.mockReturnValue({
+      status: 'repair-required',
+      repair: {
+        projectId: 'repo-1',
+        preferredRuntime: { kind: 'wsl', distro: 'Ubuntu' },
+        reason: 'wsl-unavailable',
+        source: 'project-override',
+        cacheKey: 'repo-1'
+      }
+    })
+    detectInstalledAgents.mockResolvedValue([])
+
+    await expect(
+      runtime.validateOrchestrationAgentLauncherForRepo('amp', 'repo-1')
+    ).rejects.toMatchObject({ code: 'agent_not_available' })
+    expect(isCommandOnLocalPath).not.toHaveBeenCalled()
+  })
+
   it('validates claude-teams through Claude on Windows', async () => {
     const runtime = createRuntime()
     vi.spyOn(runtime, 'showRepo').mockResolvedValue(repo() as never)

--- a/src/main/runtime/orca-runtime-agent-launch-validation.test.ts
+++ b/src/main/runtime/orca-runtime-agent-launch-validation.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+
+const {
+  detectInstalledAgents,
+  detectRemoteAgents,
+  detectWslCommandsOnPath,
+  detectLocalManagedAgentCliPresence,
+  resolveLocalProjectRuntimeForRepo,
+  isCommandOnLocalPath
+} = vi.hoisted(() => ({
+  detectInstalledAgents: vi.fn<(...args: never[]) => Promise<string[]>>(),
+  detectRemoteAgents: vi.fn<(...args: never[]) => Promise<string[]>>(),
+  detectWslCommandsOnPath: vi.fn<(...args: never[]) => Promise<Set<string>>>(),
+  detectLocalManagedAgentCliPresence:
+    vi.fn<(...args: never[]) => Promise<Record<string, unknown>>>(),
+  resolveLocalProjectRuntimeForRepo: vi.fn(),
+  isCommandOnLocalPath: vi.fn()
+}))
+
+vi.mock('../preflight/agent-detection', () => ({
+  detectInstalledAgentsWithShellPathHydration: detectInstalledAgents,
+  detectRemoteAgents
+}))
+vi.mock('../ipc/preflight-wsl-agent-detection', () => ({ detectWslCommandsOnPath }))
+vi.mock('../agent-hooks/local-agent-cli-presence', () => ({ detectLocalManagedAgentCliPresence }))
+vi.mock('../project-runtime-git-options', () => ({ resolveLocalProjectRuntimeForRepo }))
+vi.mock('../ipc/command-path-resolver', () => ({ isCommandOnLocalPath }))
+vi.mock('../../shared/managed-agent-hook-targets', () => ({
+  getManagedAgentHookTarget: () => null
+}))
+
+const repo = (connectionId?: string) => ({
+  id: 'repo-1',
+  path: '/repo',
+  displayName: 'repo',
+  badgeColor: '#000',
+  addedAt: 0,
+  ...(connectionId ? { connectionId } : {})
+})
+
+function createRuntime(settings: Record<string, unknown> = {}) {
+  const runtime = new OrcaRuntimeService()
+  ;(runtime as unknown as { store: unknown }).store = {
+    getSettings: () => ({ agentCmdOverrides: {}, ...settings })
+  }
+  vi.spyOn(runtime, 'showRepo').mockResolvedValue(repo() as never)
+  return runtime
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+  resolveLocalProjectRuntimeForRepo.mockReturnValue(undefined)
+  detectInstalledAgents.mockResolvedValue([])
+  detectRemoteAgents.mockResolvedValue([])
+  detectWslCommandsOnPath.mockResolvedValue(new Set())
+  detectLocalManagedAgentCliPresence.mockResolvedValue({})
+  isCommandOnLocalPath.mockResolvedValue(false)
+})
+
+describe('validateOrchestrationAgentLauncherForRepo', () => {
+  it('uses strict remote detection and keeps remote unavailable errors', async () => {
+    const runtime = createRuntime()
+    vi.spyOn(runtime, 'showRepo').mockResolvedValue(repo('ssh-1') as never)
+    detectRemoteAgents.mockResolvedValue(['codex'])
+
+    await expect(
+      runtime.validateOrchestrationAgentLauncherForRepo('codex', 'repo-1')
+    ).resolves.toBeUndefined()
+    expect(detectRemoteAgents).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: 'ssh-1', requireAvailable: true })
+    )
+  })
+
+  it('includes a custom remote override in the probe request', async () => {
+    const runtime = createRuntime({ agentCmdOverrides: { codex: 'managed-codex --flag' } })
+    vi.spyOn(runtime, 'showRepo').mockResolvedValue(repo('ssh-1') as never)
+    detectRemoteAgents.mockResolvedValue(['codex'])
+
+    await runtime.validateOrchestrationAgentLauncherForRepo('codex', 'repo-1')
+    expect(detectRemoteAgents.mock.calls[0]?.[0]).toMatchObject({
+      commands: expect.arrayContaining([
+        expect.objectContaining({ id: 'codex', cmd: 'managed-codex' })
+      ])
+    })
+  })
+
+  it.each([
+    ['native', undefined, ['codex']],
+    ['wsl', { status: 'resolved', runtime: { kind: 'wsl', distro: 'Ubuntu' } }, ['codex']]
+  ])('accepts detected %s local agents', async (_name, projectRuntime, detected) => {
+    const runtime = createRuntime()
+    resolveLocalProjectRuntimeForRepo.mockReturnValue(projectRuntime)
+    detectInstalledAgents.mockResolvedValue(detected)
+
+    await expect(
+      runtime.validateOrchestrationAgentLauncherForRepo('codex', 'repo-1')
+    ).resolves.toBeUndefined()
+  })
+
+  it('accepts a native bare override with the inherited PATH', async () => {
+    const runtime = createRuntime({ agentCmdOverrides: { amp: 'managed-amp' } })
+    detectInstalledAgents.mockResolvedValue([])
+    isCommandOnLocalPath.mockResolvedValue(true)
+
+    await runtime.validateOrchestrationAgentLauncherForRepo('amp', 'repo-1')
+    expect(isCommandOnLocalPath).toHaveBeenCalledWith(
+      'managed-amp',
+      expect.objectContaining({ env: expect.objectContaining({ PATH: expect.any(String) }) })
+    )
+  })
+
+  it('probes a WSL override strictly and accepts it when found', async () => {
+    const runtime = createRuntime({ agentCmdOverrides: { codex: '~/bin/codex' } })
+    resolveLocalProjectRuntimeForRepo.mockReturnValue({
+      status: 'resolved',
+      runtime: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+    detectInstalledAgents.mockResolvedValue([])
+    detectWslCommandsOnPath.mockResolvedValue(new Set(['~/bin/codex']))
+
+    await runtime.validateOrchestrationAgentLauncherForRepo('codex', 'repo-1')
+    expect(detectWslCommandsOnPath).toHaveBeenCalledWith({ distro: 'Ubuntu' }, ['~/bin/codex'], {
+      failOnProbeError: true
+    })
+  })
+
+  it('validates claude-teams through Claude on Windows', async () => {
+    const runtime = createRuntime()
+    vi.spyOn(runtime, 'showRepo').mockResolvedValue(repo() as never)
+    vi.spyOn(
+      runtime as unknown as { getAgentLaunchPlatformForRepo: (repo: unknown) => NodeJS.Platform },
+      'getAgentLaunchPlatformForRepo'
+    ).mockReturnValue('win32')
+    detectInstalledAgents.mockResolvedValue(['claude'])
+
+    await expect(
+      runtime.validateOrchestrationAgentLauncherForRepo('claude-agent-teams', 'repo-1')
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/main/runtime/orca-runtime-get-terminal-interactive-wait.ts
+++ b/src/main/runtime/orca-runtime-get-terminal-interactive-wait.ts
@@ -14,6 +14,19 @@ import { selectExactWorkerProviderSession } from './orchestration/worker-provide
 import type { TuiAgent } from '../../shared/tui-agent'
 import { isTuiAgentEnabled } from '../../shared/tui-agent-selection'
 import { OrchestrationError } from './orchestration/orchestration-error'
+import {
+  detectInstalledAgentsWithShellPathHydration,
+  detectRemoteAgents
+} from '../preflight/agent-detection'
+import { detectWslCommandsOnPath } from '../ipc/preflight-wsl-agent-detection'
+import { detectLocalManagedAgentCliPresence } from '../agent-hooks/local-agent-cli-presence'
+import { getManagedAgentHookTarget } from '../../shared/managed-agent-hook-targets'
+import { resolveLocalProjectRuntimeForRepo } from '../project-runtime-git-options'
+import { extractExecutableToken } from '../../shared/managed-agent-command-token'
+import { TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
+import { KNOWN_TUI_AGENT_DETECTION_COMMANDS } from '../../shared/tui-agent-detection-commands'
+import { isCommandOnLocalPath } from '../ipc/command-path-resolver'
+import { buildLocalPreflightEnv } from '../ipc/preflight-local-env'
 
 export class OrcaRuntimeWithGetTerminalInteractiveWait extends OrcaRuntimeWithAdoptTerminalOrphansFromInventory {
   async getTerminalInteractiveWait(
@@ -176,6 +189,99 @@ export class OrcaRuntimeWithGetTerminalInteractiveWait extends OrcaRuntimeWithAd
       observedAfter,
       statuses: this.getAgentStatusSnapshotFn?.() ?? []
     })
+  }
+
+  async validateOrchestrationAgentLauncherForRepo(
+    agent: TuiAgent,
+    repoSelector: string
+  ): Promise<void> {
+    this.validateOrchestrationAgentLauncher(agent)
+    const settings = this.store?.getSettings()
+    if (!settings) {
+      return
+    }
+    const repo = await this.showRepo(repoSelector)
+    const projectRuntime = repo.connectionId
+      ? undefined
+      : resolveLocalProjectRuntimeForRepo(this.requireStore(), repo)
+    let detected: string[]
+    if (repo.connectionId) {
+      const override = extractExecutableToken(settings.agentCmdOverrides?.[agent])
+      const config = TUI_AGENT_CONFIG[agent]
+      const commands = override
+        ? [
+            ...KNOWN_TUI_AGENT_DETECTION_COMMANDS,
+            {
+              id: agent,
+              cmd: override,
+              ...(config.detectRequiredCommands
+                ? { requiredCommands: config.detectRequiredCommands }
+                : {}),
+              ...(config.detectUnsupportedRuntimes
+                ? { unsupportedRuntimes: config.detectUnsupportedRuntimes }
+                : {})
+            }
+          ]
+        : undefined
+      detected = await detectRemoteAgents({
+        connectionId: repo.connectionId,
+        commands,
+        requireAvailable: true
+      })
+    } else {
+      detected = await detectInstalledAgentsWithShellPathHydration(
+        { projectRuntime },
+        { failOnProbeError: true }
+      )
+      const override = extractExecutableToken(settings.agentCmdOverrides?.[agent])
+      if (
+        !detected.includes(agent) &&
+        override &&
+        projectRuntime?.status === 'resolved' &&
+        projectRuntime.runtime.kind === 'wsl'
+      ) {
+        const found = await detectWslCommandsOnPath(
+          { distro: projectRuntime.runtime.distro },
+          [override],
+          { failOnProbeError: true }
+        )
+        if (found.has(override)) {
+          return
+        }
+      }
+      if (
+        !detected.includes(agent) &&
+        override &&
+        projectRuntime?.status !== 'repair-required' &&
+        projectRuntime?.runtime.kind !== 'wsl'
+      ) {
+        const env = {
+          ...(buildLocalPreflightEnv() ?? process.env),
+          ...settings.agentDefaultEnv?.[agent]
+        }
+        const pathEnv = Object.entries(env).find(([key]) => key.toLowerCase() === 'path')?.[1]
+        const target = getManagedAgentHookTarget(agent)
+        if (target) {
+          const presence = await detectLocalManagedAgentCliPresence([target], settings, { pathEnv })
+          if (presence[agent]?.state === 'found') {
+            return
+          }
+        } else if (await isCommandOnLocalPath(override, { env, cwd: repo.path })) {
+          return
+        }
+      }
+    }
+    const usesClaudeTeamsFallback =
+      agent === 'claude-agent-teams' &&
+      detected.includes('claude') &&
+      (this.getAgentLaunchPlatformForRepo(repo) === 'win32' ||
+        (projectRuntime?.status === 'resolved' && projectRuntime.runtime.kind === 'wsl'))
+    if (!detected.includes(agent) && !usesClaudeTeamsFallback) {
+      throw new OrchestrationError(
+        'agent_not_available',
+        `Agent launcher ${agent} is not installed on the execution host.`
+      )
+    }
   }
 
   validateOrchestrationAgentLauncher(agent: TuiAgent): void {

--- a/src/main/runtime/orca-runtime-get-terminal-interactive-wait.ts
+++ b/src/main/runtime/orca-runtime-get-terminal-interactive-wait.ts
@@ -204,6 +204,8 @@ export class OrcaRuntimeWithGetTerminalInteractiveWait extends OrcaRuntimeWithAd
     const projectRuntime = repo.connectionId
       ? undefined
       : resolveLocalProjectRuntimeForRepo(this.requireStore(), repo)
+    const localRuntimeKind =
+      projectRuntime?.status === 'resolved' ? projectRuntime.runtime.kind : undefined
     let detected: string[]
     if (repo.connectionId) {
       const override = extractExecutableToken(settings.agentCmdOverrides?.[agent])
@@ -253,7 +255,7 @@ export class OrcaRuntimeWithGetTerminalInteractiveWait extends OrcaRuntimeWithAd
         !detected.includes(agent) &&
         override &&
         projectRuntime?.status !== 'repair-required' &&
-        projectRuntime?.runtime.kind !== 'wsl'
+        localRuntimeKind !== 'wsl'
       ) {
         const env = {
           ...(buildLocalPreflightEnv() ?? process.env),

--- a/src/main/runtime/rpc/errors.test.ts
+++ b/src/main/runtime/rpc/errors.test.ts
@@ -76,17 +76,19 @@ describe('mapRuntimeError', () => {
     })
   })
 
-  it.each(['remote_runtime_unavailable', 'runtime_timeout', 'invalid_runtime_response'])(
-    'preserves structured remote transport failure %s',
-    (code) => {
-      const error = Object.assign(new Error(`Remote transport failed: ${code}`), { code })
+  it.each([
+    'remote_runtime_unavailable',
+    'runtime_timeout',
+    'invalid_runtime_response',
+    'agent_not_available'
+  ])('preserves structured remote transport failure %s', (code) => {
+    const error = Object.assign(new Error(`Remote transport failed: ${code}`), { code })
 
-      expect(mapRuntimeError('req_1', { runtimeId: 'runtime-1' }, error)).toMatchObject({
-        ok: false,
-        error: { code, message: `Remote transport failed: ${code}` }
-      })
-    }
-  )
+    expect(mapRuntimeError('req_1', { runtimeId: 'runtime-1' }, error)).toMatchObject({
+      ok: false,
+      error: { code, message: `Remote transport failed: ${code}` }
+    })
+  })
 
   it.each([
     ['window_not_focused', 'keyboard input requires focus', 'restore-window'],

--- a/src/main/runtime/rpc/errors.ts
+++ b/src/main/runtime/rpc/errors.ts
@@ -113,6 +113,7 @@ const STRUCTURED_RUNTIME_PASSTHROUGH_CODES: ReadonlySet<string> = new Set([
   'dispatch_capability_invalid',
   'agent_unconfigured',
   'worker_prompt_too_large',
+  'agent_not_available',
   'terminal_worktree_mismatch',
   'terminal_is_coordinator',
   'request_mismatch',

--- a/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-start-receipt.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-start-receipt.test.ts
@@ -6,6 +6,7 @@ import {
 import { OrcaRuntimeService } from '../../../../orca-runtime'
 import { OrchestrationDb } from '../../../../orchestration/db'
 import { startFederatedWorker } from './federated-worker-start'
+import { OrchestrationError } from '../../../../orchestration/orchestration-error'
 
 describe('federated worker start receipt validation', () => {
   const databases: OrchestrationDb[] = []
@@ -87,5 +88,67 @@ describe('federated worker start receipt validation', () => {
         expectedEnvironmentPairingRevision: 73
       })
     }
+  })
+
+  it('keeps an unavailable-agent dispatch durable for a retry', async () => {
+    const db = new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    databases.push(db)
+    const run = db.createRun({
+      objective: 'federated worker',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: 'tab_coord:leaf_coord'
+    })
+    const task = db.createTask({ spec: 'remote work', runId: run.id })
+    vi.spyOn(runtime, 'resolveOrchestrationWorkerServer').mockReturnValue({
+      environmentId: 'environment_remote',
+      name: 'remote',
+      peerFingerprint: 'remote_peer'
+    })
+    vi.spyOn(runtime, 'callOrchestrationWorkerServer').mockImplementation(
+      async (_environmentId, method) => {
+        if (method === 'status.get') {
+          return {
+            capabilities: [
+              ORCHESTRATION_CONTRACT_RUNTIME_CAPABILITY,
+              ORCHESTRATION_FEDERATION_RUNTIME_CAPABILITY
+            ]
+          }
+        }
+        throw new OrchestrationError(
+          'agent_not_available',
+          'Agent launcher codex is not installed on the execution host.'
+        )
+      }
+    )
+
+    const result = (await startFederatedWorker({
+      params: {
+        task: task.id,
+        from: 'term_coord',
+        on: 'remote',
+        worktree: 'id:worktree_remote',
+        agent: 'codex'
+      },
+      runtime,
+      db,
+      runId: run.id,
+      task,
+      orchestrationMutation: {
+        callerFingerprint: 'caller',
+        requestId: 'remote_start',
+        method: 'orchestration.workerStart',
+        payloadHash: 'payload'
+      }
+    })) as { dispatchId: string; state: string }
+
+    expect(result.state).toBe('failed')
+    expect(db.getWorkerDispatch(result.dispatchId)).toMatchObject({
+      state: 'failed',
+      stage: 'remote_attach',
+      last_error: expect.stringContaining('not installed')
+    })
+    expect(db.getTask(task.id)?.status).toBe('failed')
   })
 })

--- a/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-start-receipts.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-start-receipts.ts
@@ -19,6 +19,7 @@ export function isKnownRemoteStartFailure(code: string): boolean {
   return [
     'invalid_argument',
     'agent_unconfigured',
+    'agent_not_available',
     'worktree_not_found_on_server',
     'terminal_worktree_mismatch',
     'capability_unsupported'

--- a/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-start.ts
@@ -268,6 +268,8 @@ export async function startFederatedWorker(args: {
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
     if (error instanceof OrchestrationError && isKnownRemoteStartFailure(error.code)) {
+      // Keep the failed dispatch durable: callers retry with the same mutation
+      // receipt, while the DB retains the failed attempt and its audit trail.
       const worker = db.failWorkerStart(started.dispatch.id, 'remote_attach', reason)
       return {
         runId,

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-agent-launch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-agent-launch.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { OrcaRuntimeService } from '../../../../orca-runtime'
 import { OrchestrationDb } from '../../../../orchestration/db'
+import { OrchestrationError } from '../../../../orchestration/orchestration-error'
 import { ORCHESTRATION_METHODS } from '../../orchestration'
 
 // Why: a federated worker terminal is created from an agent id. Passing that id
@@ -20,8 +21,10 @@ describe('federated worker agent launch', () => {
     const runtime = new OrcaRuntimeService()
     runtime.setOrchestrationDb(db)
     vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+    vi.spyOn(runtime, 'validateOrchestrationAgentLauncherForRepo').mockResolvedValue()
     vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({
-      id: 'folder:remote-workspace'
+      id: 'folder:remote-workspace',
+      repoId: 'repo-1'
     } as never)
     const createTerminal = vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
       handle: 'term_remote_worker',
@@ -104,5 +107,53 @@ describe('federated worker agent launch', () => {
       'id:folder:remote-workspace',
       expect.not.objectContaining({ command: expect.anything() })
     )
+  })
+
+  it('rejects an unavailable agent before persisting an exact-worktree attachment', async () => {
+    db = new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+    vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({
+      id: 'folder:remote-workspace',
+      repoId: 'repo-1'
+    } as never)
+    vi.spyOn(runtime, 'validateOrchestrationAgentLauncherForRepo').mockRejectedValue(
+      new OrchestrationError(
+        'agent_not_available',
+        'Agent launcher codex is not installed on the execution host.'
+      )
+    )
+    const method = ORCHESTRATION_METHODS.find(
+      (candidate) => candidate.name === 'orchestration.federationAttachStart'
+    )
+    if (!method) {
+      throw new Error('federationAttachStart method is not registered')
+    }
+
+    await expect(
+      method.handler(
+        method.params!.parse({
+          dispatchId: 'ctx_unavailable',
+          taskId: 'task_unavailable',
+          taskSpec: 'remote codex worker',
+          depth: 2,
+          protocolVersion: 3,
+          worktree: 'folder:remote-workspace',
+          agent: 'codex'
+        }),
+        {
+          runtime,
+          orchestrationMutation: {
+            callerFingerprint: 'home_peer',
+            requestId: 'request_unavailable',
+            method: 'orchestration.federationAttachStart',
+            payloadHash: 'unavailable_payload'
+          }
+        }
+      )
+    ).rejects.toMatchObject({ code: 'agent_not_available' })
+    expect(db.getRemoteDispatchAttachment('ctx_unavailable')).toBeUndefined()
+    expect(db.getMutationReceipt('home_peer', 'request_unavailable')).toBeUndefined()
   })
 })

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-agent-preflight.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-agent-preflight.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod'
+import type { TuiAgent } from '../../../../../../shared/tui-agent'
+import { isTuiAgent } from '../../../../../../shared/tui-agent-config'
+import type { OrcaRuntimeService } from '../../../../orca-runtime'
+import { OrchestrationError } from '../../../../orchestration/orchestration-error'
+import { defineMethod } from '../../../core'
+import { OptionalString, requiredString } from '../../../schemas'
+import { assertOrchestrationWorktreeCreationSupported } from '../worker/folder-worktree-placement'
+
+const FederationAgentPreflightParams = z.object({
+  worktree: requiredString('Missing remote worktree selector'),
+  repo: OptionalString,
+  agent: requiredString('Missing agent')
+})
+
+export async function validateFederatedAgentLauncherForRepo(
+  runtime: OrcaRuntimeService,
+  agent: TuiAgent | undefined,
+  repoSelector: string
+): Promise<void> {
+  if (agent) {
+    await runtime.validateOrchestrationAgentLauncherForRepo(agent, repoSelector)
+  }
+}
+
+export async function validateFederatedCreationPreflight(
+  runtime: OrcaRuntimeService,
+  agent: TuiAgent | undefined,
+  repo: string | undefined,
+  createsWorktree: boolean
+): Promise<void> {
+  if (!createsWorktree) {
+    return
+  }
+  await assertOrchestrationWorktreeCreationSupported({
+    runtime,
+    repoSelector: repo as string,
+    existingPlacement: 'an exact existing folder workspace'
+  })
+  await validateFederatedAgentLauncherForRepo(runtime, agent, repo as string)
+}
+
+export async function resolveFederatedExistingWorktreePreflight(
+  runtime: OrcaRuntimeService,
+  agent: TuiAgent | undefined,
+  worktreeSelector: string
+) {
+  const worktree = await runtime.showManagedTerminalWorkspace(worktreeSelector).catch(() => {
+    throw new OrchestrationError(
+      'worktree_not_found_on_server',
+      `Worktree ${worktreeSelector} was not found on the selected worker server.`
+    )
+  })
+  await validateFederatedAgentLauncherForRepo(runtime, agent, `id:${worktree.repoId}`)
+  return worktree
+}
+
+export const FEDERATION_AGENT_PREFLIGHT_METHOD = defineMethod({
+  name: 'orchestration.federationAgentPreflight',
+  params: FederationAgentPreflightParams,
+  handler: async (params, { runtime }) => {
+    if (!isTuiAgent(params.agent)) {
+      throw new OrchestrationError('agent_unconfigured', 'A configured agent is required.')
+    }
+    if (params.worktree === 'current' || params.worktree === 'new-child') {
+      throw new OrchestrationError(
+        'invalid_argument',
+        'A remote worker requires an exact existing worktree or new-top-level.'
+      )
+    }
+    if (params.worktree === 'new-top-level') {
+      if (!params.repo) {
+        throw new OrchestrationError(
+          'invalid_argument',
+          'Remote new-top-level requires an explicit repo.'
+        )
+      }
+      await validateFederatedAgentLauncherForRepo(runtime, params.agent, params.repo)
+      return { available: true }
+    }
+    await resolveFederatedExistingWorktreePreflight(runtime, params.agent, params.worktree)
+    return { available: true }
+  }
+})

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation.ts
@@ -62,6 +62,10 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS = [
           repoSelector: params.repo as string,
           existingPlacement: 'an exact existing folder workspace'
         })
+        await runtime.validateOrchestrationAgentLauncherForRepo(
+          agent as TuiAgent,
+          params.repo as string
+        )
       }
 
       const db = runtime.getOrchestrationDb()
@@ -152,6 +156,9 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS = [
               `Worktree ${params.worktree} was not found on the selected worker server.`
             )
           })
+          if (agent) {
+            await runtime.validateOrchestrationAgentLauncherForRepo(agent, `id:${worktree.repoId}`)
+          }
           effects.push(
             { kind: 'worktree', action: 'reused', id: worktree.id },
             { kind: 'setup', action: 'not_applicable', state: 'not_applicable' }

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation.ts
@@ -3,7 +3,6 @@ import { describeTerminalWaitBlockedReason } from '../../../../../../shared/term
 import { buildDispatchPreamble } from '../../../../orchestration/preamble'
 import { OrchestrationError } from '../../../../orchestration/orchestration-error'
 import { defineMethod } from '../../../core'
-import { assertOrchestrationWorktreeCreationSupported } from '../worker/folder-worktree-placement'
 import {
   appendFederationSetupEffect,
   appendFederationTerminalEffects,
@@ -17,6 +16,10 @@ import {
   persistFederatedSetupWaitOutcome
 } from './federation-setup'
 import { FederationAttachStartParams } from './federation-start-schema'
+import {
+  resolveFederatedExistingWorktreePreflight,
+  validateFederatedCreationPreflight
+} from './federation-agent-preflight'
 import { failFederatedAttachmentWithReceipt } from './federation-start-receipt'
 import { prepareFederationAttachmentWorkerStart } from '../worker/worker-start-validation'
 import {
@@ -56,17 +59,10 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS = [
         createsWorktree,
         runtime
       })
-      if (createsWorktree) {
-        await assertOrchestrationWorktreeCreationSupported({
-          runtime,
-          repoSelector: params.repo as string,
-          existingPlacement: 'an exact existing folder workspace'
-        })
-        await runtime.validateOrchestrationAgentLauncherForRepo(
-          agent as TuiAgent,
-          params.repo as string
-        )
-      }
+      const existingWorktree = createsWorktree
+        ? undefined
+        : await resolveFederatedExistingWorktreePreflight(runtime, agent, params.worktree)
+      await validateFederatedCreationPreflight(runtime, agent, params.repo, createsWorktree)
 
       const db = runtime.getOrchestrationDb()
       db.createRemoteDispatchAttachment({
@@ -81,7 +77,7 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS = [
       })
       const effects: FederationEffect[] = []
       let failedStage = createsWorktree ? 'worktree_create' : 'worktree_resolve'
-      let worktree
+      let worktree = existingWorktree
       let terminalHandle = params.terminal
       const setupSource = createsWorktree
         ? (params.setupSource ?? (params.setup ? 'explicit_request' : 'orchestration_default'))
@@ -150,15 +146,6 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS = [
           )
           appendFederationSetupEffect(effects, setup)
         } else {
-          worktree = await runtime.showManagedTerminalWorkspace(params.worktree).catch(() => {
-            throw new OrchestrationError(
-              'worktree_not_found_on_server',
-              `Worktree ${params.worktree} was not found on the selected worker server.`
-            )
-          })
-          if (agent) {
-            await runtime.validateOrchestrationAgentLauncherForRepo(agent, `id:${worktree.repoId}`)
-          }
           effects.push(
             { kind: 'worktree', action: 'reused', id: worktree.id },
             { kind: 'setup', action: 'not_applicable', state: 'not_applicable' }

--- a/src/main/runtime/rpc/methods/orchestration/worker/local-worker-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/local-worker-start.ts
@@ -65,6 +65,12 @@ export async function startLocalWorker(args: {
     : requestedWorktree === 'current'
       ? await runtime.showManagedTerminalWorkspace(`id:${coordinatorWorktreeId}`)
       : await runtime.showManagedTerminalWorkspace(requestedWorktree)
+  if (agent) {
+    const launchRepoSelector = createsWorktree
+      ? (params.repo ?? creationWorktree!.repoId)
+      : `id:${resolvedWorktree!.repoId}`
+    await runtime.validateOrchestrationAgentLauncherForRepo(agent, launchRepoSelector)
+  }
   if (params.terminal) {
     await assertExplicitWorkerTerminalUsable({
       runtime,

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-start-prompt-contract.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-start-prompt-contract.test.ts
@@ -110,6 +110,7 @@ async function createPromptContractHarness(
     candidate === handle ? `runtime_test:${handle}:1` : null
   )
   vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+  vi.spyOn(runtime, 'validateOrchestrationAgentLauncherForRepo').mockResolvedValue()
   vi.spyOn(runtime, 'showTerminal').mockResolvedValue({
     handle: 'term_coord',
     worktreeId: 'repo::parent',

--- a/src/renderer/src/components/terminal-pane/pty-connection-hidden-restore-fit-overflow.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-hidden-restore-fit-overflow.test.ts
@@ -145,6 +145,7 @@ describe('connectPanePty', () => {
   })
 
   afterEach(async () => {
+    vi.useRealTimers()
     await restoreTerminalTestGlobals()
   })
 


### PR DESCRIPTION
## ELI5

Orca now checks that a requested worker agent is available on the execution host before creating a terminal or dispatch record.

## Visual Proof

N/A — orchestration and host preflight behavior; no visual UI change.

## Summary
- validate worker-start launchers on the execution host before creating terminals or dispatch records
- preserve SSH/WSL unavailable probe states and support custom launcher probes
- classify unavailable-agent failures consistently across RPC and federation paths

Fixes #17943

## Validation
- `pnpm run check:code-quality:changed`
- `pnpm tc:node`
- targeted preflight, WSL, orchestration, federation, and RPC tests (102 passed)