### PR TITLE
Auto-focus editor when opening new markdown file

### DIFF
--- a/src/renderer/src/store/slices/editor/actions/markdown-preview-actions.test.ts
+++ b/src/renderer/src/store/slices/editor/actions/markdown-preview-actions.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMarkdownPreviewActions } from './markdown-preview-actions'
+
+const mocks = vi.hoisted(() => ({
+  createUntitledMarkdownFileWithTemplateSelection: vi.fn()
+}))
+
+vi.mock('@/lib/create-untitled-markdown', () => ({
+  createUntitledMarkdownFileWithTemplateSelection:
+    mocks.createUntitledMarkdownFileWithTemplateSelection
+}))
+
+vi.mock('@/lib/editor-file-operation-owner', () => ({
+  assertEditorFileOperationCurrent: vi.fn(),
+  captureEditorFileOperationProvenance: vi.fn(() => ({
+    generation: {
+      route: { executionHostId: 'local', runtimeEnvironmentId: null },
+      runtimeEnvironmentGeneration: null
+    },
+    ownershipProjection: 'explicit'
+  })),
+  getEditorFileOperationContext: vi.fn(() => ({
+    settings: null,
+    worktreeId: 'wt-1',
+    worktreePath: '/repo',
+    expectedExecutionHostId: 'local'
+  }))
+}))
+
+describe('createMarkdownPreviewActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('hands focus to a newly created markdown editor', async () => {
+    const fileInfo = {
+      filePath: '/repo/untitled.md',
+      relativePath: 'untitled.md',
+      worktreeId: 'wt-1',
+      language: 'markdown',
+      isUntitled: true as const,
+      mode: 'edit' as const
+    }
+    mocks.createUntitledMarkdownFileWithTemplateSelection.mockResolvedValue(fileInfo)
+    const openFile = vi.fn()
+    const recordFeatureInteraction = vi.fn()
+    const state = {
+      activeWorktreeId: 'wt-1',
+      getKnownWorktreeById: vi.fn(() => ({ id: 'wt-1', path: '/repo' })),
+      openFile,
+      recordFeatureInteraction
+    }
+    const actions = createMarkdownPreviewActions(vi.fn() as never, (() => state) as never)
+
+    await actions.openNewMarkdownInActiveWorkspace('group-2')
+
+    expect(openFile).toHaveBeenCalledWith(fileInfo, {
+      preview: false,
+      targetGroupId: 'group-2',
+      focusEditor: true
+    })
+    expect(recordFeatureInteraction).toHaveBeenCalledWith('markdown-file-created')
+  })
+})

--- a/src/renderer/src/store/slices/editor/actions/markdown-preview-actions.ts
+++ b/src/renderer/src/store/slices/editor/actions/markdown-preview-actions.ts
@@ -60,7 +60,11 @@ export function createMarkdownPreviewActions(
         if (!fileInfo) {
           return
         }
-        get().openFile(fileInfo, { preview: false, targetGroupId: groupId })
+        get().openFile(fileInfo, {
+          preview: false,
+          targetGroupId: groupId,
+          focusEditor: true
+        })
         get().recordFeatureInteraction('markdown-file-created')
       } catch (err) {
         toast.error(extractIpcErrorMessage(err, 'Failed to create untitled markdown file.'))

--- a/tests/e2e/tabs.spec.ts
+++ b/tests/e2e/tabs.spec.ts
@@ -18,8 +18,9 @@
  * (dnd-kit reorder); in those cases a DOM assertion still follows.
  */
 
-import { test, expect } from './helpers/orca-app'
+import { rm } from 'node:fs/promises'
 import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
 import {
   waitForSessionReady,
   waitForActiveWorktree,
@@ -116,6 +117,50 @@ test.describe('Tabs', () => {
         message: 'Menu-created terminal tab did not receive keyboard focus'
       })
       .toBe(storeActiveId)
+  })
+
+  test('clicking "+" then "New Markdown" focuses the editor', async ({
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  }) => {
+    let createdFilePath: string | null = null
+    registerPostElectronShutdownCleanup(async () => {
+      if (createdFilePath) {
+        await rm(createdFilePath, { force: true })
+      }
+    })
+
+    await orcaPage.getByRole('button', { name: 'New tab' }).click({ force: true })
+    const newMarkdownMenuItem = orcaPage.getByRole('menuitem', { name: /New Markdown/i }).first()
+    await newMarkdownMenuItem.click({ force: true })
+    await expect(newMarkdownMenuItem).toBeHidden({ timeout: 3_000 })
+
+    const editor = orcaPage.locator('.rich-markdown-editor')
+    await expect(editor).toBeVisible({ timeout: 25_000 })
+    const createdFile = await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      const file = state?.openFiles.find((candidate) => candidate.id === state.activeFileId)
+      return file ? { id: file.id, filePath: file.filePath } : null
+    })
+    expect(createdFile).not.toBeNull()
+    createdFilePath = createdFile?.filePath ?? null
+
+    await expect
+      .poll(() => editor.evaluate((element) => document.activeElement === element), {
+        timeout: 5_000,
+        message: 'Menu-created Markdown editor did not receive keyboard focus'
+      })
+      .toBe(true)
+
+    const sentinel = `autofocus-${Date.now()}`
+    // Why: typing through the page keyboard proves focus landed without an editor click.
+    await orcaPage.keyboard.type(sentinel)
+    await expect(editor).toContainText(sentinel)
+
+    await orcaPage.evaluate((fileId) => {
+      window.__store?.getState().closeFile(fileId)
+    }, createdFile!.id)
+    await expect(editor).toBeHidden()
   })
 
   /**

--- a/tests/e2e/tabs.spec.ts
+++ b/tests/e2e/tabs.spec.ts
@@ -130,20 +130,35 @@ test.describe('Tabs', () => {
       }
     })
 
+    const preExistingFileIds = await orcaPage.evaluate(
+      () => window.__store?.getState().openFiles.map((file) => file.id) ?? []
+    )
+
     await orcaPage.getByRole('button', { name: 'New tab' }).click({ force: true })
     const newMarkdownMenuItem = orcaPage.getByRole('menuitem', { name: /New Markdown/i }).first()
     await newMarkdownMenuItem.click({ force: true })
     await expect(newMarkdownMenuItem).toBeHidden({ timeout: 3_000 })
 
+    // Why: require an id that did not exist before the click, so an already-open
+    // Markdown file can't satisfy the assertions (or be deleted by cleanup), and
+    // record the path here so cleanup still has it if a later assertion fails.
+    const createdFileHandle = await orcaPage.waitForFunction(
+      (knownFileIds) => {
+        const state = window.__store?.getState()
+        const file = state?.openFiles.find((candidate) => candidate.id === state.activeFileId)
+        if (!file || knownFileIds.includes(file.id)) {
+          return null
+        }
+        return { id: file.id, filePath: file.filePath }
+      },
+      preExistingFileIds,
+      { timeout: 25_000 }
+    )
+    const createdFile = (await createdFileHandle.jsonValue())!
+    createdFilePath = createdFile.filePath
+
     const editor = orcaPage.locator('.rich-markdown-editor')
     await expect(editor).toBeVisible({ timeout: 25_000 })
-    const createdFile = await orcaPage.evaluate(() => {
-      const state = window.__store?.getState()
-      const file = state?.openFiles.find((candidate) => candidate.id === state.activeFileId)
-      return file ? { id: file.id, filePath: file.filePath } : null
-    })
-    expect(createdFile).not.toBeNull()
-    createdFilePath = createdFile?.filePath ?? null
 
     await expect
       .poll(() => editor.evaluate((element) => document.activeElement === element), {
@@ -159,7 +174,7 @@ test.describe('Tabs', () => {
 
     await orcaPage.evaluate((fileId) => {
       window.__store?.getState().closeFile(fileId)
-    }, createdFile!.id)
+    }, createdFile.id)
     await expect(editor).toBeHidden()
   })
 
@@ -421,7 +436,9 @@ test.describe('Tabs', () => {
       }
     }, worktreeId)
     await expect
-      .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, { timeout: 5_000 })
+      .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, {
+        timeout: 5_000
+      })
       .toBeGreaterThanOrEqual(3)
 
     const initialOrder = await getTabBarOrder(orcaPage, worktreeId)
@@ -448,7 +465,9 @@ test.describe('Tabs', () => {
       state.reorderUnifiedTabs(activeGroup.id, [...rest, first])
     }, worktreeId)
     await expect
-      .poll(async () => getTabBarOrder(orcaPage, worktreeId), { timeout: 3_000 })
+      .poll(async () => getTabBarOrder(orcaPage, worktreeId), {
+        timeout: 3_000
+      })
       .toEqual([b, c, a])
 
     // Activate the last tab in the new visible order, then walk left twice.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​128 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## Problem

When users create a new markdown file in the workspace, the editor isn't automatically focused, requiring them to manually click to start editing.

## Solution

Added `focusEditor: true` flag when opening newly created markdown files, so the editor receives focus immediately after the file is created.

## What Changed

- Pass `focusEditor: true` option to `openFile()` in `openNewMarkdownInActiveWorkspace()`
- Added test coverage verifying focus is handed to the new markdown editor

## Testing

- [x] Automated tests added: new `markdown-preview-actions.test.ts` with coverage for autofocus behavior