### PR TITLE
test(agent-map): retry the synthetic-ring click until the composer opens

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentMapWorkspaceContextMenu.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapWorkspaceContextMenu.test.tsx
@@ -345,8 +345,15 @@ describe('Agent Map workspace context menu', () => {
     )
 
     fireEvent.contextMenu(container.querySelector('[data-agent-map-project]')!)
-    fireEvent.click(
-      await screen.findByText('Create workspace for Documentation', {}, { timeout: 5_000 })
+    // Why retry the click: the ring's target settles from repo to group after the menu first
+    // mounts, which remounts the item — a click on the node the first query returned lands on a
+    // detached element and never reaches onSelect. Re-query and click until the modal opens.
+    await waitFor(
+      () => {
+        fireEvent.click(screen.getByText('Create workspace for Documentation'))
+        expect(useAppStore.getState().activeModal).toBe('new-workspace-composer')
+      },
+      { timeout: 5_000 }
     )
 
     expect(useAppStore.getState().modalData).toEqual({


### PR DESCRIPTION
## ELI5

One Agent Map test sometimes clicked a menu item that React had already thrown away, so nothing happened and the test failed for no real reason. It now keeps re-finding the item and clicking until the composer actually opens.

## What Changed

`AgentMapWorkspaceContextMenu.test.tsx › opens the folder-workspace composer from a synthetic project ring`: the one-shot `findByText` + `click` becomes a `waitFor` loop that re-queries the item and clicks until `activeModal` is the composer. Test-only; no component change.

## Why

The project ring's target first renders as `repo` and settles to `folder` (group) afterwards, which remounts the menu item. `findByText` resolves on the first node, and the click then lands on an element with `document.contains(item) === false` — `onSelect` never runs, `openModal` is never called, and the assertion sees the reset `modalData`. Probing a failing run confirmed both the detached node and the missing `openModal` call.

Split out of #17781 (which perturbs the timing enough to hit this ~3 in 10 runs; pristine `main` hit it 0 in 9), so that PR stays scoped to project identity. Landing this first keeps CI quiet for it.

## Linked Issue

Extracted from #17781; no separate issue.

## Visual Proof

N/A — test-only change with no visual or interaction effect.

## Testing

The file passes 5/5 in a row on the branch that exposed the race, and the rest of the file is untouched. `oxlint` / `oxfmt` / typecheck clean.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5).

## Author

X: [@oldcai](https://x.com/oldcai)

## Review

Covered by the reviews on #17781 (Codex, Claude reviewers, pullfrog, CodeRabbit) where this change first landed; pullfrog's incremental review of it came back clean.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

None — no platform, SSH, provider, or performance surface.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
