### PR TITLE
fix(preload): type the ssh terminateSessions bridge result

### DIFF
--- a/src/preload/api/ssh-bridge.ts
+++ b/src/preload/api/ssh-bridge.ts
@@ -10,7 +10,8 @@ import type {
   SshTarget,
   SshTargetUpdateInput,
   PortForwardEntry,
-  EnrichedDetectedPort
+  EnrichedDetectedPort,
+  SshTerminateSessionsResult
 } from '../../shared/ssh-types'
 import {
   admitSshConnectionStateForAuthorityReconciliation,
@@ -51,7 +52,7 @@ export const sshApi = {
   disconnect: (args: { targetId: string }): Promise<void> =>
     ipcRenderer.invoke('ssh:disconnect', args),
 
-  terminateSessions: (args: { targetId: string }): Promise<void> =>
+  terminateSessions: (args: { targetId: string }): Promise<SshTerminateSessionsResult> =>
     ipcRenderer.invoke('ssh:terminateSessions', args),
 
   resetRelay: (args: { targetId: string }): Promise<void> =>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

Repairs a semantic conflict from #17833, which left `main` failing `pnpm tc:node`.

#17833 changed `SshApi.terminateSessions` to return `Promise<SshTerminateSessionsResult>` and updated `src/preload/api/ssh-api.ts`. But `main` gained `src/preload/api/ssh-bridge.ts` via the preload split (`d1abe28471e`) and its `satisfies PreloadApi` annotation (`401664298fa`) **after** #17833's last CI run, so the two merged cleanly as text and did not compile:

```
src/preload/api/ssh-bridge.ts(54,3): error TS2322: Type '(args) => Promise<void>' is not assignable to type '(args) => Promise<SshTerminateSessionsResult>'
```

This is a pure type annotation change with no runtime effect: the bridge already forwarded the IPC result, it was just declared as `void`. Same fix as `adhoc/ssh-sweep-combined`'s `ssh-bridge.ts:55`.

## Testing

`pnpm tc` (all projects) passes on `main` + this change.

## User-facing regressions

None.