### PR TITLE
fix: require fresh automation working edge before completion

### DIFF
--- a/src/renderer/src/hooks/automation-dispatch-handler.ts
+++ b/src/renderer/src/hooks/automation-dispatch-handler.ts
@@ -26,6 +26,10 @@ function acquireReuseDispatchTab(tabId: string): (() => void) | null {
   return () => activeReuseDispatchTabIds.delete(tabId)
 }
 
+/**
+ * Dispatches one automation run into a background agent session and persists
+ * completion only after the submitted prompt reaches its own working state.
+ */
 export async function handleAutomationDispatchRequest({
   automation,
   run,
@@ -181,11 +185,7 @@ export async function handleAutomationDispatchRequest({
         // Why: fresh launches can replay a stale non-boundary done before the
         // submitted automation prompt reaches working. Completion requires the
         // prompt's own working edge, just like reuse-session dispatches.
-        if (
-          payload.state !== 'done' ||
-          payload.sessionBoundary === true ||
-          !backgroundSawWorking
-        ) {
+        if (payload.state !== 'done' || payload.sessionBoundary === true || !backgroundSawWorking) {
           return
         }
         completion.handleAgentDone()

--- a/src/renderer/src/hooks/automation-dispatch-handler.ts
+++ b/src/renderer/src/hooks/automation-dispatch-handler.ts
@@ -164,6 +164,7 @@ export async function handleAutomationDispatchRequest({
         }
       }
     }
+    let backgroundSawWorking = false
     const result = await launchAgentBackgroundSession({
       agent: automation.agentId,
       worktreeId: worktree.id,
@@ -173,8 +174,18 @@ export async function handleAutomationDispatchRequest({
       onData: completion.appendOutput,
       onAgentStatus: (payload) => {
         completion.captureAssistantMessage(payload.lastAssistantMessage)
-        // Why: session-boundary done = launch connect, not run completion (see observeAgentStatus).
-        if (payload.state !== 'done' || payload.sessionBoundary === true) {
+        if (payload.state === 'working') {
+          backgroundSawWorking = true
+          return
+        }
+        // Why: fresh launches can replay a stale non-boundary done before the
+        // submitted automation prompt reaches working. Completion requires the
+        // prompt's own working edge, just like reuse-session dispatches.
+        if (
+          payload.state !== 'done' ||
+          payload.sessionBoundary === true ||
+          !backgroundSawWorking
+        ) {
           return
         }
         completion.handleAgentDone()
@@ -193,7 +204,9 @@ export async function handleAutomationDispatchRequest({
       releaseTerminalOwnership()
     }
     const launchedTabId = result.tabId
-    completion.observeAgentStatus(result.paneKey, dispatchStartedAt)
+    completion.observeAgentStatus(result.paneKey, dispatchStartedAt, {
+      requireWorkingAfterStart: true
+    })
     try {
       await markDispatchResult({
         runId: run.id,

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -876,6 +876,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
       .mockRejectedValueOnce(new Error('completion persistence unavailable'))
       .mockResolvedValueOnce(undefined)
     mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
+      args.onAgentStatus?.({ state: 'working' })
       args.onAgentStatus?.({ state: 'done' })
       return {
         tabId: 'agent-tab',
@@ -918,6 +919,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
     })
 
     await registerAndDispatch()
+    onAgentStatus?.({ state: 'working' })
     onAgentStatus?.({ state: 'done' })
     onAgentStatus?.({ state: 'done' })
     await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledOnce())

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -572,6 +572,10 @@ describe('useAutomationDispatchEvents setup launch', () => {
 
     await registerAndDispatch()
     launchArgs.onAgentStatus?.({ state: 'done' })
+    await Promise.resolve()
+    expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
+    launchArgs.onAgentStatus?.({ state: 'working' })
+    launchArgs.onAgentStatus?.({ state: 'done' })
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
 
     expect(order).toEqual([
@@ -618,6 +622,53 @@ describe('useAutomationDispatchEvents setup launch', () => {
     expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
 
     launchArgs.onAgentStatus?.({ state: 'done' })
+    await Promise.resolve()
+    expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
+    launchArgs.onAgentStatus?.({ state: 'working' })
+    launchArgs.onAgentStatus?.({ state: 'done' })
+    await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
+  })
+
+  it('ignores stale done in the fresh status-store observer until working', async () => {
+    const paneKey = 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d'
+    await registerAndDispatch()
+    if (!latestStoreSubscriber) {
+      throw new Error('agent status observer was not registered')
+    }
+    const startedAt = Date.now() + 1
+    state.agentStatusByPaneKey = {
+      [paneKey]: {
+        paneKey,
+        state: 'done',
+        prompt: 'stale',
+        updatedAt: startedAt,
+        stateStartedAt: startedAt,
+        stateHistory: []
+      }
+    }
+    latestStoreSubscriber()
+    await Promise.resolve()
+    expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
+
+    state.agentStatusByPaneKey[paneKey] = {
+      paneKey,
+      state: 'working',
+      prompt: 'automation',
+      updatedAt: startedAt + 1,
+      stateStartedAt: startedAt + 1,
+      stateHistory: []
+    }
+    latestStoreSubscriber()
+    state.agentStatusByPaneKey[paneKey] = {
+      paneKey,
+      state: 'done',
+      prompt: 'automation',
+      updatedAt: startedAt + 2,
+      stateStartedAt: startedAt + 2,
+      stateHistory: []
+    }
+    latestStoreSubscriber()
+
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
   })
 


### PR DESCRIPTION
## ELI5

A newly launched automation can inherit an old `done` status. It now waits until the new agent is observed in `working` before accepting `done`.

## What Changed

- Require a post-launch `working` edge before fresh background runs can complete.
- Apply the same fence to direct status callbacks and the status-store observer.
- Add regression coverage for stale `done`, session-boundary `done`, store-observer status changes, and persistence failures.

## Why

A Claude automation was marked completed from its startup prompt echo while the actual terminal remained open and idle. Fresh runs need evidence that the newly launched agent started before a completion signal is trusted.

## Linked Issue

Fixes #18131

## Visual Proof

N/A. This changes background completion bookkeeping without a UI change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Verified after rebasing onto current `origin/main`:
- `pnpm test src/renderer/src/hooks/useAutomationDispatchEvents.test.ts` (23 tests)
- `pnpm tc`
- `pnpm run check:code-quality:changed`
- `git diff --check`

## AI Disclosure

Implemented with Codex assistance and reviewed by Pullfrog and CodeRabbit.

## Review

Pullfrog and CodeRabbit reported no remaining actionable findings before the rebase. The rewritten head is under fresh automated review.

## Agent skill upstream boundary

- [x] Not applicable. No skill installer source or skill bundle content is changed.

## Notes

No security, cross-platform path, SSH, mobile, compatibility, or performance behavior is changed. The gate is scoped to fresh background automation completion.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Visual proof is N/A because there is no UI change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Focused tests, typecheck, and changed-code quality checks pass