### PR TITLE
Fix Agents sidebar crash in plain-HTTP Remote Web

### DIFF
--- a/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.test.ts
@@ -203,9 +203,23 @@ afterEach(() => {
   useAppStore.setState(initialAppState, true)
   vi.useRealTimers()
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 describe('useAiVaultSessionRefresh refocus behavior', () => {
+  it('refreshes in a non-secure context without crypto.randomUUID', async () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: (bytes: Uint8Array) => bytes.fill(0)
+    })
+
+    await renderHook()
+    await flushMicrotasks()
+
+    expect(lastCallArgs()).toMatchObject({
+      requestToken: '00000000-0000-4000-8000-000000000000'
+    })
+  })
+
   it('uses the shared scan cache on local panel entry', async () => {
     await renderHook()
     await flushMicrotasks()

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
@@ -10,6 +10,7 @@ import {
   requestedExecutionHostScope,
   type ExecutionHostScope
 } from '../../../../shared/execution-host'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 import { useAppStore } from '@/store'
 import type { AiVaultSessionLimit } from './ai-vault-session-limit'
 import { AiVaultSessionPublicationGate } from './ai-vault-session-publication-gate'
@@ -90,7 +91,7 @@ export function useAiVaultSessionRefresh(
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const requestTokenRef = useRef<string>(undefined!)
-  requestTokenRef.current ??= crypto.randomUUID()
+  requestTokenRef.current ??= createBrowserUuid()
   const refreshIdRef = useRef(0)
   const refreshInFlightRef = useRef(false)
   const pendingRefreshRef = useRef(false)


### PR DESCRIPTION
## ELI5

The Agents sidebar asked the browser for a UUID API that plain-HTTP pages do not expose. It now uses the renderer UUID helper that already handles those pages safely.

## What Changed

- Generate the AiVault refresh request token with `createBrowserUuid`.
- Add a hook-level regression test for a non-secure browser context where `getRandomValues` exists but `randomUUID` does not.

## Why

Remote Web can be opened from a LAN address over plain HTTP. In that non-secure context, `crypto.randomUUID` is unavailable, so initializing the AiVault refresh hook threw during render and the Agents right-sidebar ErrorBoundary reappeared on every tab switch.

Reusing `createBrowserUuid` keeps native UUID generation in secure contexts and uses the existing browser fallback elsewhere, without changing the remote wire contract.

## Linked Issue

Fixes #18096

## Visual Proof

N/A — this prevents a render crash and does not change layout or visuals.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Commands run:

- `pnpm test src/renderer/src/components/right-sidebar/ai-vault-session-refresh.test.ts` — 35 passed
- `pnpm run check:code-quality:changed` — passed with 0 new ordinary, type-aware, or React Doctor findings across 2 files

Tested on macOS. The change is browser-only, uses no platform-specific paths or shortcuts, preserves SSH/folder workspace behavior, and makes no remote wire change.

## AI Disclosure

OpenAI Codex was used to implement and verify this focused fix.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security boundary, persistence, process-management, mobile, Git provider, or performance behavior changed. The request token remains a local cancellation identity and is not an authentication credential.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)