### PR TITLE
Fix AI Vault unresolved-owner runtime routing

### DIFF
--- a/src/main/ipc/ai-vault-resume.ts
+++ b/src/main/ipc/ai-vault-resume.ts
@@ -30,7 +30,10 @@ export async function prepareAiVaultSessionResume(
   assertLegacyAiVaultResumeAllowed(args)
   const executionHost = parseExecutionHostId(args.executionHostId)
   if (executionHost?.kind === 'runtime') {
-    if (!options.prepareRuntimeSessionResume) {
+    if (
+      executionHost.environmentId === 'unresolved-owner' ||
+      !options.prepareRuntimeSessionResume
+    ) {
       throw new Error('The session host is unavailable. Reconnect it and retry resume.')
     }
     return options.prepareRuntimeSessionResume(executionHost.environmentId, args)

--- a/src/main/ipc/ai-vault-runtime-scan.ts
+++ b/src/main/ipc/ai-vault-runtime-scan.ts
@@ -36,6 +36,9 @@ export async function scanRuntimeAiVaultSessions(args: {
 }): Promise<AiVaultListResult> {
   const { signal, ...scannerOptions } = args.options ?? {}
   throwIfAiVaultScanCancelled(signal)
+  if (args.hostInfo.environmentId === 'unresolved-owner') {
+    return runtimeScanIssueResult(args.hostInfo, 'Workspace ownership is unresolved.')
+  }
   if (!args.scanner) {
     return runtimeScanIssueResult(
       args.hostInfo,

--- a/src/main/ipc/ai-vault-session-title-routing.ts
+++ b/src/main/ipc/ai-vault-session-title-routing.ts
@@ -35,7 +35,7 @@ export async function resolveAiVaultSessionTitlesByHost(
       return { titles: [] }
     }
   }
-  if (parsed?.kind === 'runtime' && resolveRuntime) {
+  if (parsed?.kind === 'runtime' && parsed.environmentId !== 'unresolved-owner' && resolveRuntime) {
     return resolveRuntime(parsed.environmentId, args).catch(() => ({ titles: [] }))
   }
   return { titles: [] }

--- a/src/main/ipc/ai-vault-unresolved-owner.test.ts
+++ b/src/main/ipc/ai-vault-unresolved-owner.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AiVaultPrepareSessionResumeArgs } from '../../shared/ai-vault-resume-preparation'
+import { prepareAiVaultSessionResume } from './ai-vault-resume'
+import { scanRuntimeAiVaultSessions } from './ai-vault-runtime-scan'
+import { resolveAiVaultSessionTitlesByHost } from './ai-vault-session-title-routing'
+
+vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }))
+vi.mock('../ai-vault/session-title-resolver', () => ({
+  resolveLocalAiVaultSessionTitles: vi.fn()
+}))
+vi.mock('./ssh', () => ({ requestActiveSshAiVaultSessionTitles: vi.fn() }))
+
+const executionHostId = 'runtime:unresolved-owner' as const
+
+describe('AI Vault unresolved workspace owner routing', () => {
+  it('returns a host issue without scanning a runtime environment', async () => {
+    const scanner = vi.fn()
+
+    const result = await scanRuntimeAiVaultSessions({
+      hostInfo: { environmentId: 'unresolved-owner', executionHostId },
+      scanner
+    })
+
+    expect(result.sessions).toEqual([])
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        executionHostId,
+        kind: 'host',
+        path: 'unresolved-owner',
+        message: expect.stringContaining('ownership is unresolved')
+      })
+    ])
+    expect(scanner).not.toHaveBeenCalled()
+  })
+
+  it('settles title resolution without calling a runtime environment', async () => {
+    const resolveRuntime = vi.fn()
+
+    await expect(
+      resolveAiVaultSessionTitlesByHost(
+        {
+          executionHostScope: executionHostId,
+          requests: [{ agent: 'codex', sessionId: 'session-1' }]
+        },
+        resolveRuntime
+      )
+    ).resolves.toEqual({ titles: [] })
+    expect(resolveRuntime).not.toHaveBeenCalled()
+  })
+
+  it('rejects resume without preparing on a runtime environment', async () => {
+    const prepareSessionResume = vi.fn()
+    const prepareRuntimeSessionResume = vi.fn()
+    const args: AiVaultPrepareSessionResumeArgs = {
+      agent: 'codex',
+      filePath: '/managed/sessions/rollout.jsonl',
+      codexHome: '/managed',
+      executionHostId
+    }
+
+    await expect(
+      prepareAiVaultSessionResume(args, { prepareSessionResume, prepareRuntimeSessionResume })
+    ).rejects.toThrow('The session host is unavailable')
+    expect(prepareSessionResume).not.toHaveBeenCalled()
+    expect(prepareRuntimeSessionResume).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/web/web-preload-api-agent-providers.test.ts
+++ b/src/renderer/src/web/web-preload-api-agent-providers.test.ts
@@ -223,7 +223,7 @@ describe('web AI Vault preload API', () => {
     ])
   })
 
-  it('returns unavailable history for explicit non-runtime host scopes', async () => {
+  it('returns unavailable history for scopes outside the active runtime', async () => {
     const runtimeCalls: { method: string; params: unknown }[] = []
     vi.doMock('./web-runtime-client', () => ({
       WebRuntimeClient: class {
@@ -246,18 +246,15 @@ describe('web AI Vault preload API', () => {
     const { installWebPreloadApi } = await import('./web-preload-api')
     installWebPreloadApi()
 
-    await expect(
-      globals.window.api.aiVault.listSessions({ executionHostScope: 'local' })
-    ).resolves.toEqual({
-      sessions: [],
-      issues: [
-        expect.objectContaining({
-          executionHostId: 'local',
-          agent: 'codex'
-        })
-      ],
-      scannedAt: expect.any(String)
-    })
+    for (const executionHostScope of ['local', 'runtime:unresolved-owner'] as const) {
+      await expect(
+        globals.window.api.aiVault.listSessions({ executionHostScope })
+      ).resolves.toEqual({
+        sessions: [],
+        issues: [expect.objectContaining({ executionHostId: executionHostScope, agent: 'codex' })],
+        scannedAt: expect.any(String)
+      })
+    }
     expect(runtimeCalls).toEqual([])
   })
 })


### PR DESCRIPTION
## ELI5

When Orca cannot decide which host owns a workspace, it uses an internal placeholder. AI Vault was treating that placeholder like a real paired server; it now reports the host as unavailable without contacting any server.

## What Changed

- Return a host issue before AI Vault list scanning can call runtime transport for `runtime:unresolved-owner`.
- Settle title lookup with no titles and reject resume as unavailable for the same sentinel.
- Cover desktop list/title/resume routing and the existing Remote Web unavailable path with transport-not-called assertions.

## Why

`runtime:unresolved-owner` records an ownership conflict; it is not a saved runtime environment ID. Failing closed at the existing AI Vault transport seams prevents repeated `Unknown environment` / `invalid_argument` calls and avoids an unsafe local or SSH fallback.

## Linked Issue

Fixes #18097

## Visual Proof

N/A — this changes host-routing failure handling and adds no visual or interaction surface.

## Testing

- `pnpm test src/main/ipc/ai-vault-unresolved-owner.test.ts` — 3 passed
- `pnpm test src/renderer/src/web/web-preload-api-agent-providers.test.ts` — 5 passed
- `pnpm test src/main/ipc/ai-vault.test.ts` — 48 passed before the focused regression cases were moved out to satisfy the existing max-lines rule
- `pnpm run check:code-quality:changed` — 0 new findings across 5 changed files
- Pre-commit oxlint, React doctor, and oxfmt checks passed

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Implemented with Codex under supervised Orca orchestration.

## Review

The production diff adds only sentinel guards at the three existing desktop AI Vault transport seams. Remote Web already rejected scopes outside its active runtime, so only its existing test was extended; no runtime RPC shape, capability, stream opcode, SSH behavior, or folder-workspace ownership logic changed.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer material.

## Notes

Cross-platform behavior is string-based and platform-independent. SSH routing remains unchanged and has no local fallback; mixed desktop/runtime versions remain compatible because the guard is client-side and introduces no wire changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Visual proof is marked N/A because there is no UI change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and backwards-compatibility impact considered
- [ ] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` were not run; targeted tests and changed-file quality checks passed