### PR TITLE
fix(native-chat): show pasted images while they save, and make them previewable

### DIFF
--- a/src/main/window/clipboard-image-temp-file.test.ts
+++ b/src/main/window/clipboard-image-temp-file.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { authorizeExternalPathMock, writeFileMock, getPathMock, writeFileBase64Mock } = vi.hoisted(
+  () => ({
+    authorizeExternalPathMock: vi.fn(),
+    writeFileMock: vi.fn(),
+    getPathMock: vi.fn(() => '/var/folders/ab/T'),
+    writeFileBase64Mock: vi.fn()
+  })
+)
+
+vi.mock('node:fs/promises', () => ({ default: { writeFile: writeFileMock } }))
+vi.mock('node:crypto', () => ({ randomUUID: () => 'uuid-1' }))
+vi.mock('../../shared/app-environment', () => ({
+  getAppEnvironment: () => ({ getPath: getPathMock })
+}))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  requireSshFilesystemProvider: () => ({
+    getTempDir: async () => '/remote/tmp',
+    writeFileBase64: writeFileBase64Mock
+  })
+}))
+vi.mock('../ipc/filesystem-auth', () => ({ authorizeExternalPath: authorizeExternalPathMock }))
+
+import { saveClipboardImageBufferAsTempFile } from './clipboard-image-temp-file'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('saveClipboardImageBufferAsTempFile', () => {
+  it('authorizes the local temp file so the composer can preview what it just wrote', async () => {
+    const savedPath = await saveClipboardImageBufferAsTempFile(Buffer.from([1, 2, 3]))
+
+    expect(writeFileMock).toHaveBeenCalledWith(savedPath, Buffer.from([1, 2, 3]))
+    // The OS temp dir is outside every allowed root, so an unauthorized path
+    // makes fs:readFile deny the preview read of Orca's own file.
+    expect(authorizeExternalPathMock).toHaveBeenCalledWith(savedPath)
+  })
+
+  it('does not authorize a local path for an SSH save', async () => {
+    const savedPath = await saveClipboardImageBufferAsTempFile(Buffer.from([1]), {
+      connectionId: 'conn-1'
+    })
+
+    expect(savedPath.startsWith('/remote/tmp/')).toBe(true)
+    expect(writeFileBase64Mock).toHaveBeenCalled()
+    expect(authorizeExternalPathMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window/clipboard-image-temp-file.ts
+++ b/src/main/window/clipboard-image-temp-file.ts
@@ -6,6 +6,7 @@ import { getAppEnvironment } from '../../shared/app-environment'
 import { requireSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 import { assertClipboardImageByteLengthWithinLimit } from '../../shared/clipboard-image'
+import { authorizeExternalPath } from '../ipc/filesystem-auth'
 
 export type SaveClipboardImageAsTempFileArgs = {
   connectionId?: string | null
@@ -41,5 +42,8 @@ export async function saveClipboardImageBufferAsTempFile(
 
   const tempPath = path.join(getAppEnvironment().getPath('temp'), fileName)
   await fs.writeFile(tempPath, buffer)
+  // Why: the OS temp dir is outside every allowed root, so without this the
+  // composer's own thumbnail/preview read of the file it just wrote is denied.
+  authorizeExternalPath(tempPath)
   return tempPath
 }

--- a/src/main/window/clipboard-image-thumbnail.test.ts
+++ b/src/main/window/clipboard-image-thumbnail.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildClipboardImageThumbnail } from './clipboard-image-thumbnail'
+
+function fakeImage(overrides: Partial<Parameters<typeof buildClipboardImageThumbnail>[0]>) {
+  return {
+    isEmpty: () => false,
+    getSize: () => ({ height: 10, width: 10 }),
+    resize: vi.fn(() => ({ toDataURL: () => 'data:image/png;base64,SMALL' })),
+    toDataURL: () => 'data:image/png;base64,FULL',
+    ...overrides
+  }
+}
+
+describe('buildClipboardImageThumbnail', () => {
+  it('downscales to the thumbnail budget but reports the source dimensions', () => {
+    const image = fakeImage({ getSize: () => ({ height: 1600, width: 3200 }) })
+
+    expect(buildClipboardImageThumbnail(image)).toEqual({
+      dataUrl: 'data:image/png;base64,SMALL',
+      height: 1600,
+      width: 3200
+    })
+    expect(image.resize).toHaveBeenCalledWith({ height: 160, quality: 'good', width: 320 })
+  })
+
+  it('skips the resize for an image that already fits', () => {
+    const image = fakeImage({ getSize: () => ({ height: 200, width: 320 }) })
+
+    expect(buildClipboardImageThumbnail(image)?.dataUrl).toBe('data:image/png;base64,FULL')
+    expect(image.resize).not.toHaveBeenCalled()
+  })
+
+  it('reports no thumbnail for an empty clipboard so text paste falls through', () => {
+    expect(buildClipboardImageThumbnail(fakeImage({ isEmpty: () => true }))).toBeNull()
+  })
+
+  it('reports no thumbnail rather than throwing for an oversized image', () => {
+    // The save call still surfaces the real too-large error; the probe only
+    // decides whether a placeholder chip is worth showing.
+    const image = fakeImage({ getSize: () => ({ height: 100_000, width: 100_000 }) })
+
+    expect(buildClipboardImageThumbnail(image)).toBeNull()
+    expect(image.resize).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window/clipboard-image-thumbnail.ts
+++ b/src/main/window/clipboard-image-thumbnail.ts
@@ -1,0 +1,45 @@
+import {
+  assertClipboardImageDimensionsWithinLimit,
+  clipboardImageThumbnailSize,
+  type ClipboardImageDimensions,
+  type ClipboardImageThumbnail
+} from '../../shared/clipboard-image'
+
+/** The slice of Electron's NativeImage this module needs, so the decision logic
+ *  is testable without an Electron runtime. */
+export type ClipboardImageLike = {
+  isEmpty: () => boolean
+  getSize: () => ClipboardImageDimensions
+  resize: (options: { height: number; width: number; quality: 'good' | 'better' | 'best' }) => {
+    toDataURL: () => string
+  }
+  toDataURL: () => string
+}
+
+/**
+ * In-memory preview of whatever image the clipboard holds. Writing the image to
+ * disk (or uploading it over SFTP) takes long enough that a composer with no
+ * feedback reads as a dropped paste, so this answers "is there an image, and
+ * what does it look like" without touching the filesystem.
+ */
+export function buildClipboardImageThumbnail(
+  image: ClipboardImageLike
+): ClipboardImageThumbnail | null {
+  if (image.isEmpty()) {
+    return null
+  }
+  const size = image.getSize()
+  try {
+    assertClipboardImageDimensionsWithinLimit(size)
+  } catch {
+    // Oversized images still report through the save call; the probe only
+    // decides whether to show a placeholder, so degrade to "no preview".
+    return null
+  }
+  const thumbnailSize = clipboardImageThumbnailSize(size)
+  const thumbnail =
+    thumbnailSize.width === size.width && thumbnailSize.height === size.height
+      ? image
+      : image.resize({ ...thumbnailSize, quality: 'good' })
+  return { dataUrl: thumbnail.toDataURL(), height: size.height, width: size.width }
+}

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -13,6 +13,7 @@ const {
   spawnMock,
   childStdinEndMock,
   resolveAuthorizedPathMock,
+  authorizeExternalPathMock,
   fsAccessMock,
   fsLstatMock,
   fsMkdirMock,
@@ -48,6 +49,7 @@ const {
     return child
   }),
   resolveAuthorizedPathMock: vi.fn(),
+  authorizeExternalPathMock: vi.fn(),
   fsAccessMock: vi.fn(),
   fsLstatMock: vi.fn(),
   fsMkdirMock: vi.fn(),
@@ -90,7 +92,8 @@ vi.mock('node:fs/promises', () => ({
 vi.mock('../ipc/filesystem-auth', () => ({
   PATH_ACCESS_DENIED_MESSAGE:
     'Access denied: path resolves outside allowed directories. If this blocks a legitimate workflow, please file a GitHub issue.',
-  resolveAuthorizedPath: resolveAuthorizedPathMock
+  resolveAuthorizedPath: resolveAuthorizedPathMock,
+  authorizeExternalPath: authorizeExternalPathMock
 }))
 
 vi.mock('node:crypto', () => ({
@@ -548,30 +551,7 @@ describe('registerClipboardHandlers', () => {
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeImage')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeFile')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:saveImageAsTempFile')
-  })
-
-  it('saves clipboard images to a local temp file when no connection is provided', async () => {
-    const png = Buffer.from([0, 1, 2, 3])
-    const expectedPath = join(
-      '/tmp',
-      'orca-paste-1760000000000-00000000-0000-4000-8000-000000000000.png'
-    )
-    clipboardReadImageMock.mockReturnValue({
-      getSize: () => ({ height: 1, width: 1 }),
-      isEmpty: () => false,
-      toPNG: () => png
-    })
-
-    registerClipboardHandlers({} as never)
-
-    const handlers = getRegisteredHandlers()
-    await expect(
-      handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), undefined)
-    ).resolves.toBe(expectedPath)
-    expect(fsWriteFileMock).toHaveBeenCalledWith(expectedPath, png)
-    expect(clipboardReadBufferMock).not.toHaveBeenCalled()
-    expect(fsOpenMock).not.toHaveBeenCalled()
-    expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
+    expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:readImageThumbnail')
   })
 
   it('does not inspect FileNameW when an empty image clipboard is read outside Windows', async () => {

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -23,7 +23,8 @@ import {
 import {
   assertClipboardImageBase64LengthWithinLimit,
   assertClipboardImageByteLengthWithinLimit,
-  assertClipboardImageDimensionsWithinLimit
+  assertClipboardImageDimensionsWithinLimit,
+  type ClipboardImageThumbnail
 } from '../../shared/clipboard-image'
 import {
   writeFileToClipboard,
@@ -37,6 +38,7 @@ import {
 } from './clipboard-remote-file-copy'
 import { saveClipboardImageBufferInRuntime } from './clipboard-runtime-image-upload'
 import { readWindowsClipboardImageFileAsPng } from './clipboard-windows-image-file'
+import { buildClipboardImageThumbnail } from './clipboard-image-thumbnail'
 import { writeClipboardTextAndVerify } from './clipboard-text-write-verify'
 import { isDashboardPopoutRenderer } from './dashboard-popout-window'
 
@@ -85,6 +87,7 @@ export function registerClipboardHandlers(store: Store): void {
   ipcMain.removeHandler('clipboard:writeImage')
   ipcMain.removeHandler('clipboard:writeFile')
   ipcMain.removeHandler('clipboard:saveImageAsTempFile')
+  ipcMain.removeHandler('clipboard:readImageThumbnail')
 
   void cleanupExpiredRemoteClipboardFiles()
   scheduleLegacyRemoteClipboardFileCleanup()
@@ -100,6 +103,12 @@ export function registerClipboardHandlers(store: Store): void {
       return assertClipboardTextWithinLimitWithYield(clipboard.readText('selection'), options)
     }
   )
+  // Why: an unanswered paste reads as a dropped paste, so the composer probes
+  // the clipboard in memory before the (slower) save lands.
+  ipcMain.handle('clipboard:readImageThumbnail', (event): ClipboardImageThumbnail | null => {
+    assertTrustedClipboardSender(event)
+    return buildClipboardImageThumbnail(clipboard.readImage())
+  })
   // Why: terminals need to detect clipboard images to support tools like Claude
   // Code that accept image input via paste. Writes the clipboard image to a
   // temp file and returns the path, or null if the clipboard has no image.

--- a/src/preload/api/ui-bridge-clipboard-and-window-controls.ts
+++ b/src/preload/api/ui-bridge-clipboard-and-window-controls.ts
@@ -10,6 +10,7 @@ import {
   type RichMarkdownContextMenuTableTarget
 } from '../../shared/rich-markdown-context-menu'
 import type { NativeFileDropPayload } from '../../shared/native-file-drop'
+import type { ClipboardImageThumbnail } from '../../shared/clipboard-image'
 import type { ReadClipboardTextOptions } from '../../shared/clipboard-text'
 import { subscribeNativeFileDrop } from '../preload-runtime-support'
 import type { PreloadApi } from '../api-types'
@@ -93,6 +94,8 @@ export const uiClipboardAndWindowControlsApi = {
     connectionId?: string | null
     runtimeEnvironmentId?: string | null
   }): Promise<string | null> => ipcRenderer.invoke('clipboard:saveImageAsTempFile', args),
+  readClipboardImageThumbnail: (): Promise<ClipboardImageThumbnail | null> =>
+    ipcRenderer.invoke('clipboard:readImageThumbnail'),
   writeClipboardText: (text: string): Promise<void> =>
     ipcRenderer.invoke('clipboard:writeText', text),
   writeTerminalClipboardText: (text: string): Promise<void> =>

--- a/src/preload/api/ui-window-api.ts
+++ b/src/preload/api/ui-window-api.ts
@@ -1,3 +1,4 @@
+import type { ClipboardImageThumbnail } from '../../shared/clipboard-image'
 import type { ReadClipboardTextOptions } from '../../shared/clipboard-text'
 import type { NativeFileDropPayload } from '../../shared/native-file-drop'
 import type {
@@ -12,6 +13,7 @@ export type UiWindowApi = {
     connectionId?: string | null
     runtimeEnvironmentId?: string | null
   }) => Promise<string | null>
+  readClipboardImageThumbnail: () => Promise<ClipboardImageThumbnail | null>
   writeClipboardText: (text: string) => Promise<void>
   writeTerminalClipboardText: (text: string) => Promise<void>
   writeSelectionClipboardText: (text: string) => Promise<void>

--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
     sessionOptionsSurface?: SessionOptionsSurface | null
     sessionOptionsSnapshot?: SessionOptionDescriptor[]
     attachDisabled?: boolean
+    sendButtonDisabled?: boolean
   } | null,
   modelSwitchOutcome: 'applied' as 'applied' | 'rejected' | 'interaction-required' | 'unknown',
   confirmationObserver: null as {
@@ -38,10 +39,11 @@ const mocks = vi.hoisted(() => ({
   createClaudeModelSwitchConfirmationObserver: vi.fn(),
   discoverCommitMessageModels: vi.fn(),
   draft: 'hello',
-  imageAttachments: [] as { id: string; path: string }[],
+  imageAttachments: [] as { id: string; path: string; pending?: boolean }[],
   getMainBufferSnapshot: vi.fn(),
   sendHandle: { cancel: vi.fn(), settleAfterMs: 500 },
   sendNativeChatMessage: vi.fn(),
+  sendNativeChatMessageWithImageAttachments: vi.fn(),
   sendNativeChatTypedCommand: vi.fn(),
   sendNativeChatMessageVerified: vi.fn(),
   typeNativeChatCommand: vi.fn(),
@@ -81,7 +83,8 @@ vi.mock('./native-chat-runtime-send', () => ({
   submitNativeChatPrompt: vi.fn()
 }))
 vi.mock('./native-chat-runtime-image-send', () => ({
-  sendNativeChatMessageWithImageAttachments: vi.fn()
+  sendNativeChatMessageWithImageAttachments: (...args: unknown[]) =>
+    mocks.sendNativeChatMessageWithImageAttachments(...args)
 }))
 vi.mock('./claude-model-switch-confirmation', () => ({
   createClaudeModelSwitchConfirmationObserver: (...args: unknown[]) =>
@@ -206,6 +209,7 @@ describe('NativeChatComposer', () => {
       ]
     })
     mocks.sendNativeChatMessage.mockReturnValue(mocks.sendHandle)
+    mocks.sendNativeChatMessageWithImageAttachments.mockReturnValue(mocks.sendHandle)
     mocks.sendNativeChatTypedCommand.mockReturnValue(mocks.sendHandle)
     mocks.sendNativeChatMessageVerified.mockResolvedValue(true)
     mocks.typeNativeChatCommand.mockResolvedValue(true)
@@ -339,6 +343,60 @@ describe('NativeChatComposer', () => {
 
     expect(send).toHaveBeenCalledWith('', mocks.imageAttachments)
     expect(mocks.setDraft).toHaveBeenCalledWith('')
+  })
+
+  it('disables Send and blocks a send while an image attachment is still pending', () => {
+    mocks.imageAttachments = [{ id: 'image-1', path: '', pending: true }]
+    render(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey="tab-1:leaf-1"
+        targetPtyId="pty-1"
+        agent="codex"
+      />
+    )
+
+    expect(mocks.fieldProps?.sendButtonDisabled).toBe(true)
+
+    act(() => mocks.fieldProps?.onSend?.())
+
+    expect(mocks.sendNativeChatMessage).not.toHaveBeenCalled()
+    expect(mocks.sendNativeChatTypedCommand).not.toHaveBeenCalled()
+    expect(mocks.sendNativeChatMessageWithImageAttachments).not.toHaveBeenCalled()
+  })
+
+  it('enables Send and dispatches once a pending attachment resolves', () => {
+    mocks.imageAttachments = [{ id: 'image-1', path: '', pending: true }]
+    const view = render(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey="tab-1:leaf-1"
+        targetPtyId="pty-1"
+        agent="codex"
+      />
+    )
+    expect(mocks.fieldProps?.sendButtonDisabled).toBe(true)
+
+    mocks.imageAttachments = [{ id: 'image-1', path: '/tmp/pasted.png' }]
+    view.rerender(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey="tab-1:leaf-1"
+        targetPtyId="pty-1"
+        agent="codex"
+      />
+    )
+    expect(mocks.fieldProps?.sendButtonDisabled).toBe(false)
+
+    act(() => mocks.fieldProps?.onSend?.())
+
+    expect(mocks.sendNativeChatMessageWithImageAttachments).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      'hello',
+      ['/tmp/pasted.png'],
+      undefined
+    )
   })
 
   it('types Codex slash composer sends instead of pasting them', () => {

--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -3,15 +3,10 @@ import { useAppStore } from '../../store'
 import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
 import { getVerifiedNativeChatCommands } from '../../../../shared/native-chat-agent-profiles'
-import {
-  isStructuredAgentSessionComposerCommand,
-  STRUCTURED_AGENT_SESSION_SLASH_COMMANDS
-} from '../../../../shared/structured-agent-session-composer'
-import { emitNativeChatMessageSent } from '@/lib/native-chat-telemetry'
+import { STRUCTURED_AGENT_SESSION_SLASH_COMMANDS } from '../../../../shared/structured-agent-session-composer'
 import {
   applyMentionSuggestion,
   EMPTY_HISTORY,
-  pushHistory,
   type HistoryState
 } from './native-chat-composer-state'
 import { useNativeChatDraft } from './use-native-chat-draft'
@@ -34,8 +29,8 @@ import type {
   NativeChatComposerHandle,
   NativeChatComposerProps
 } from './native-chat-composer-types'
-import { dispatchNativeChatStructuredComposerText } from './native-chat-structured-composer-dispatch'
 import { useNativeChatPtyComposerSend } from './use-native-chat-pty-composer-send'
+import { useNativeChatStructuredComposerSend } from './use-native-chat-structured-composer-send'
 import { useImeEnterGestureOwnership } from '@/lib/ime-composition-keyboard-event'
 import { useNativeChatComposerAppMenuSelection } from './use-native-chat-composer-app-menu-selection'
 
@@ -171,11 +166,21 @@ const NativeChatComposerPane = forwardRef<NativeChatComposerHandle, NativeChatCo
       setDraft,
       setNotice
     })
-    const { imageAttachments, attachResolvedPaths, clearImageAttachments, removeImageAttachment } =
-      attachments
+    const {
+      imageAttachments,
+      attachResolvedPaths,
+      clearImageAttachments,
+      removeImageAttachment,
+      beginPendingImageAttachment,
+      resolvePendingImageAttachment,
+      dropPendingImageAttachment
+    } = attachments
+    // A pasted image has no agent-readable path until its save lands; sending
+    // mid-save would ship the message without the image the chip promises.
+    const hasPendingAttachment = imageAttachments.some((attachment) => attachment.pending)
     const sendButtonDisabled = isWorking
       ? !hasPty || !onStop
-      : disabled || (draft.trim() === '' && imageAttachments.length === 0)
+      : disabled || hasPendingAttachment || (draft.trim() === '' && imageAttachments.length === 0)
 
     const { insertTypedText, focus } = useNativeChatTypedInsertion({
       textareaRef,
@@ -201,6 +206,9 @@ const NativeChatComposerPane = forwardRef<NativeChatComposerHandle, NativeChatCo
       caret,
       resolveAttachmentOwner,
       attachResolvedPaths,
+      beginPendingImageAttachment,
+      resolvePendingImageAttachment,
+      dropPendingImageAttachment,
       insertTypedText,
       setCaret,
       setNotice
@@ -236,41 +244,16 @@ const NativeChatComposerPane = forwardRef<NativeChatComposerHandle, NativeChatCo
     const sessionOptionsSurface = structuredTransport?.optionsSurface ?? ptySessionOptionsSurface
     const sessionOptionsSnapshot = structuredTransport?.optionSnapshot ?? ptySessionOptionsSnapshot
 
-    const sendStructured = useCallback(
-      (text: string, attachments = imageAttachments): void => {
-        if (!structuredTransport) {
-          return
-        }
-        if (attachments.length > 0 && isStructuredAgentSessionComposerCommand(text, agent)) {
-          structuredTransport.onError('Remove attachments before using a chat-session command.')
-          return
-        }
-        void dispatchNativeChatStructuredComposerText(structuredTransport, text, attachments)
-          .then(({ accepted, error }) => {
-            structuredTransport.onError(error)
-            if (!accepted) {
-              return
-            }
-            emitNativeChatMessageSent({ agent, runtime: structuredTransport.runtime })
-            setHistory((previous) => pushHistory(previous, text))
-            setDraft('')
-            setCaret(0)
-            clearSkillOrigin()
-            clearImageAttachments()
-          })
-          .catch((error) =>
-            structuredTransport.onError(error instanceof Error ? error.message : String(error))
-          )
-      },
-      [
-        agent,
-        clearImageAttachments,
-        clearSkillOrigin,
-        imageAttachments,
-        setDraft,
-        structuredTransport
-      ]
-    )
+    const sendStructured = useNativeChatStructuredComposerSend({
+      agent,
+      imageAttachments,
+      structuredTransport,
+      clearImageAttachments,
+      clearSkillOrigin,
+      setHistory,
+      setDraft,
+      setCaret
+    })
 
     const sendPty = useNativeChatPtyComposerSend({
       agent,
@@ -296,12 +279,23 @@ const NativeChatComposerPane = forwardRef<NativeChatComposerHandle, NativeChatCo
       setNotice
     })
     const send = useCallback(() => {
+      if (hasPendingAttachment) {
+        return
+      }
       if (!structuredTransport) {
         sendPty()
       } else if ((draft.trim() !== '' || imageAttachments.length > 0) && !disabled) {
         sendStructured(draft, imageAttachments)
       }
-    }, [disabled, draft, imageAttachments, sendPty, sendStructured, structuredTransport])
+    }, [
+      disabled,
+      draft,
+      hasPendingAttachment,
+      imageAttachments,
+      sendPty,
+      sendStructured,
+      structuredTransport
+    ])
 
     const interrupt = useCallback(() => {
       cancelPendingSends()

--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -55,8 +55,14 @@ export type NativeChatComposerFieldProps = {
 
 export type NativeChatComposerImageAttachment = {
   id: string
+  /** Empty while `pending`: the clipboard image has no agent-readable path yet. */
   path: string
   connectionId?: string
+  /** Clipboard thumbnail (blob/data URL) rendered before — and after — the file
+   *  lands, so the chip never waits on a disk round-trip to show something. */
+  previewUrl?: string
+  /** True while the pasted image is still being written to disk or uploaded. */
+  pending?: boolean
 }
 
 /**

--- a/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { NativeChatImageAttachmentPreview } from './NativeChatImageAttachmentPreview'
+import type { NativeChatComposerImageAttachment } from './NativeChatComposerField'
+
+const mocks = vi.hoisted(() => ({
+  useLocalImageSrc: vi.fn()
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/components/editor/useLocalImageSrc', () => ({
+  useLocalImageSrc: mocks.useLocalImageSrc
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  mocks.useLocalImageSrc.mockReset()
+})
+
+function renderPreview(attachment: NativeChatComposerImageAttachment): void {
+  vi.stubGlobal('IntersectionObserver', undefined)
+  render(<NativeChatImageAttachmentPreview attachment={attachment} onRemove={vi.fn()} />)
+}
+
+describe('NativeChatImageAttachmentPreview', () => {
+  it('shows the clipboard thumbnail and a spinner while pending', () => {
+    mocks.useLocalImageSrc.mockReturnValue(undefined)
+    renderPreview({ id: 'a1', path: '', previewUrl: 'blob:clipboard-1', pending: true })
+
+    expect(document.querySelector('.animate-spin')).toBeTruthy()
+    expect(screen.getByRole('img', { name: 'Saving pasted image…' }).getAttribute('src')).toBe(
+      'blob:clipboard-1'
+    )
+  })
+
+  it('renders no spinner once the attachment has settled', () => {
+    mocks.useLocalImageSrc.mockReturnValue('blob:on-disk-1')
+    renderPreview({ id: 'a1', path: '/tmp/example.png' })
+
+    expect(document.querySelector('.animate-spin')).toBeFalsy()
+  })
+
+  it('does not read the on-disk file while the attachment is pending', () => {
+    mocks.useLocalImageSrc.mockReturnValue(undefined)
+    renderPreview({ id: 'a1', path: '', previewUrl: 'blob:clipboard-1', pending: true })
+
+    expect(mocks.useLocalImageSrc).toHaveBeenCalledWith(undefined, '', undefined)
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatImageAttachmentPreview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Image as ImageIcon, X } from 'lucide-react'
+import { Image as ImageIcon, Loader2, X } from 'lucide-react'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { translate } from '@/i18n/i18n'
 import { basename } from '@/lib/path'
@@ -41,31 +41,55 @@ export function NativeChatImageAttachmentPreview({
     observer.observe(element)
     return () => observer.disconnect()
   }, [])
-  const previewSrc = useLocalImageSrc(
-    isNearViewport || isOpen ? attachment.path : undefined,
+  const isPending = attachment.pending === true
+  const localSrc = useLocalImageSrc(
+    !isPending && (isNearViewport || isOpen) ? attachment.path : undefined,
     attachment.path,
     attachment.connectionId
   )
+  // The clipboard thumbnail is already in this process, so it renders with no
+  // round-trip; the on-disk file only wins for the full-size dialog.
+  const thumbnailSrc = attachment.previewUrl ?? localSrc
+  const fullSizeSrc = localSrc ?? attachment.previewUrl
   const filename = isNativeChatPastedImagePath(attachment.path)
     ? translate('components.native-chat.composer.pastedImageLabel', 'Pasted image')
     : basename(attachment.path)
+  const pendingLabel = translate(
+    'components.native-chat.composer.imageSaving',
+    'Saving pasted image…'
+  )
+  const label = isPending ? pendingLabel : filename
 
   return (
     <>
       <div ref={thumbnailRef} className="relative size-14 shrink-0">
         <button
           type="button"
-          aria-label={`${translate('components.native-chat.composer.viewAttachment', 'View image')}: ${filename}`}
-          title={filename}
+          aria-label={
+            isPending
+              ? pendingLabel
+              : `${translate('components.native-chat.composer.viewAttachment', 'View image')}: ${label}`
+          }
+          aria-busy={isPending}
+          title={label}
           onClick={() => setIsOpen(true)}
           className="flex size-full items-center justify-center overflow-hidden rounded-md border border-border bg-background transition-colors hover:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          {previewSrc ? (
-            <img src={previewSrc} alt={filename} className="size-full object-cover" />
+          {thumbnailSrc ? (
+            <img
+              src={thumbnailSrc}
+              alt={label}
+              className={`size-full object-cover${isPending ? ' opacity-50' : ''}`}
+            />
           ) : (
             <ImageIcon className="size-5 text-muted-foreground" />
           )}
         </button>
+        {isPending ? (
+          <span className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-md bg-background/50">
+            <Loader2 className="size-4 animate-spin text-muted-foreground" />
+          </span>
+        ) : null}
         <button
           type="button"
           onClick={() => onRemove(attachment.id)}
@@ -80,23 +104,32 @@ export function NativeChatImageAttachmentPreview({
       </div>
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         <DialogContent className="flex max-h-[90vh] max-w-[90vw] flex-col gap-3 border-border bg-background p-3 sm:max-w-4xl">
-          <DialogTitle className="truncate text-sm">{filename}</DialogTitle>
+          <DialogTitle className="truncate text-sm">{label}</DialogTitle>
           <DialogDescription className="sr-only">
             {translate('components.native-chat.composer.imagePreview', 'Full-size image preview')}
           </DialogDescription>
           <div className="scrollbar-sleek flex min-h-0 items-center justify-center overflow-auto rounded-md bg-muted/20 p-2">
-            {previewSrc ? (
+            {fullSizeSrc ? (
               <img
-                src={previewSrc}
-                alt={filename}
+                src={fullSizeSrc}
+                alt={label}
                 className="max-h-[75vh] max-w-full object-contain"
               />
             ) : (
               <div className="flex items-center gap-2 py-12 text-sm text-muted-foreground">
-                <ImageIcon className="size-4" />
-                {translate(
-                  'components.native-chat.composer.imagePreviewUnavailable',
-                  'Preview unavailable'
+                {isPending ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    {pendingLabel}
+                  </>
+                ) : (
+                  <>
+                    <ImageIcon className="size-4" />
+                    {translate(
+                      'components.native-chat.composer.imagePreviewUnavailable',
+                      'Preview unavailable'
+                    )}
+                  </>
                 )}
               </div>
             )}

--- a/src/renderer/src/components/native-chat/native-chat-image-paste.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-paste.test.ts
@@ -1,38 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import {
-  getAgentImageHandling,
-  isNativeChatPastedImagePath,
-  resolveImagePaste
-} from './native-chat-image-paste'
+import { getAgentImageHandling, isNativeChatPastedImagePath } from './native-chat-image-paste'
 
 describe('image paste agent map', () => {
-  it('known image-capable agent attaches the temp file path', () => {
+  it('vision-capable TUIs take image attachments', () => {
     expect(getAgentImageHandling('claude')).toBe('attachment')
-    const result = resolveImagePaste('claude', '/tmp/orca-img-123.png')
-    expect(result).toEqual({ kind: 'attach', path: '/tmp/orca-img-123.png' })
-  })
-
-  it('codex also attaches image paths', () => {
-    expect(resolveImagePaste('codex', '/tmp/x.png')).toEqual({
-      kind: 'attach',
-      path: '/tmp/x.png'
-    })
-  })
-
-  it('grok attaches image paths like other vision-capable TUIs', () => {
+    expect(getAgentImageHandling('codex')).toBe('attachment')
     expect(getAgentImageHandling('grok')).toBe('attachment')
-    expect(resolveImagePaste('grok', '/tmp/orca-paste-1.png')).toEqual({
-      kind: 'attach',
-      path: '/tmp/orca-paste-1.png'
-    })
   })
 
   it('unknown/custom agent is unsupported', () => {
     expect(getAgentImageHandling('some-custom-agent')).toBe('unsupported')
-    expect(resolveImagePaste('some-custom-agent', '/tmp/x.png')).toEqual({
-      kind: 'unsupported',
-      agent: 'some-custom-agent'
-    })
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-image-paste.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-paste.ts
@@ -30,22 +30,6 @@ export function getAgentImageHandling(agent: AgentType): AgentImageHandling {
   return IMAGE_ATTACHMENT_AGENTS.has(agent) ? 'attachment' : 'unsupported'
 }
 
-export type ImagePasteResult =
-  | { kind: 'attach'; path: string }
-  | { kind: 'unsupported'; agent: AgentType }
-
-/**
- * Given the agent and the temp-file path the image was written to, decide what
- * (if anything) to attach. Attachment-capable agents receive the path through
- * the same bracketed image-paste channel as the terminal TUI.
- */
-export function resolveImagePaste(agent: AgentType, tempFilePath: string): ImagePasteResult {
-  if (getAgentImageHandling(agent) === 'attachment') {
-    return { kind: 'attach', path: tempFilePath }
-  }
-  return { kind: 'unsupported', agent }
-}
-
 export function isNativeChatImageAttachmentPath(path: string): boolean {
   return isImageDropPath(path)
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.test.tsx
@@ -260,4 +260,88 @@ describe('useNativeChatComposerAttachments', () => {
     )
     act(() => probe.root.unmount())
   })
+
+  it('settles a pending image attachment in place', async () => {
+    const probe = await renderProbe('pty-1')
+    let id: string | null = null
+    act(() => {
+      id = probe.latest().beginPendingImageAttachment('blob:preview-1')
+    })
+    expect(id).toBeTruthy()
+    expect(probe.latest().imageAttachments).toMatchObject([
+      { id, path: '', previewUrl: 'blob:preview-1', pending: true }
+    ])
+
+    act(() => {
+      probe.latest().resolvePendingImageAttachment(id as string, '/tmp/resolved.png', 'conn-1')
+    })
+
+    expect(probe.latest().imageAttachments).toMatchObject([
+      { id, path: '/tmp/resolved.png', previewUrl: 'blob:preview-1', connectionId: 'conn-1' }
+    ])
+    expect(probe.latest().imageAttachments[0]?.pending).toBeUndefined()
+    act(() => probe.root.unmount())
+  })
+
+  it('drops just the targeted pending chip', async () => {
+    const probe = await renderProbe('pty-1')
+    let firstId: string | null = null
+    let secondId: string | null = null
+    act(() => {
+      firstId = probe.latest().beginPendingImageAttachment('blob:preview-1')
+    })
+    act(() => {
+      secondId = probe.latest().beginPendingImageAttachment('blob:preview-2')
+    })
+
+    act(() => {
+      probe.latest().dropPendingImageAttachment(firstId as string)
+    })
+
+    expect(probe.latest().imageAttachments).toMatchObject([
+      { id: secondId, previewUrl: 'blob:preview-2', pending: true }
+    ])
+    act(() => probe.root.unmount())
+  })
+
+  it('excludes a pending chip from the scope cache while a settled chip persists', async () => {
+    const probe = await renderProbe('pty-1')
+    let pendingId: string | null = null
+    act(() => {
+      pendingId = probe.latest().beginPendingImageAttachment('blob:preview-1')
+    })
+    await act(async () => {
+      probe.latest().attachResolvedPaths(['/tmp/settled.png'])
+    })
+
+    const cached = readNativeChatAttachmentCache('pty-1')
+    expect(cached.some((attachment) => attachment.id === pendingId)).toBe(false)
+    expect(cached).toMatchObject([{ path: '/tmp/settled.png' }])
+    act(() => probe.root.unmount())
+  })
+
+  it('revokes a blob: preview URL on removal but not a data: preview URL', async () => {
+    const probe = await renderProbe('pty-1')
+    const revoke = vi.spyOn(URL, 'revokeObjectURL')
+    let blobId: string | null = null
+    act(() => {
+      blobId = probe.latest().beginPendingImageAttachment('blob:preview-1')
+    })
+    act(() => {
+      probe.latest().beginPendingImageAttachment('data:image/png;base64,AAAA')
+    })
+
+    act(() => {
+      probe.latest().dropPendingImageAttachment(blobId as string)
+    })
+    expect(revoke).toHaveBeenCalledWith('blob:preview-1')
+
+    // Only the remaining data: chip is left to clear; revoke must not fire again.
+    revoke.mockClear()
+    act(() => {
+      probe.latest().clearImageAttachments()
+    })
+    expect(revoke).not.toHaveBeenCalled()
+    act(() => probe.root.unmount())
+  })
 })

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.test.tsx
@@ -317,6 +317,7 @@ describe('useNativeChatComposerAttachments', () => {
     const cached = readNativeChatAttachmentCache('pty-1')
     expect(cached.some((attachment) => attachment.id === pendingId)).toBe(false)
     expect(cached).toMatchObject([{ path: '/tmp/settled.png' }])
+    expect(cached[0]?.previewUrl).toBeUndefined()
     act(() => probe.root.unmount())
   })
 

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
@@ -40,6 +40,9 @@ export function useNativeChatComposerAttachments({
   clearImageAttachments: () => void
   flushPendingAttachments: () => void
   removeImageAttachment: (id: string) => void
+  beginPendingImageAttachment: (previewUrl?: string) => string | null
+  resolvePendingImageAttachment: (id: string, path: string, connectionId?: string | null) => void
+  dropPendingImageAttachment: (id: string) => void
 } {
   const [imageAttachments, setImageAttachments] = useState<NativeChatComposerImageAttachment[]>(
     () => readNativeChatAttachmentCache(attachmentScopeKey)
@@ -72,6 +75,30 @@ export function useNativeChatComposerAttachments({
     [attachmentScopeKey]
   )
 
+  const nextAttachmentId = useCallback((): string => {
+    imageAttachmentCounter.current += 1
+    return `${Date.now()}-${imageAttachmentCounter.current}`
+  }, [])
+
+  // Local paths are only attachable when the composer's target runs locally;
+  // remote-runtime panes read a different filesystem than the one we resolved.
+  const attachmentTargetBlocked = useCallback((): boolean => {
+    const target = resolveTarget()
+    return (
+      (!target && !allowWithoutTarget) ||
+      Boolean(target && nativeChatComposerTargetIsRemote(target.ptyId))
+    )
+  }, [allowWithoutTarget, resolveTarget])
+
+  const noteAttachmentTargetBlocked = useCallback(() => {
+    setNotice(
+      translate(
+        'components.native-chat.composer.localAttachmentUnsupported',
+        'Local attachments are not available for remote sessions.'
+      )
+    )
+  }, [setNotice])
+
   const appendImageAttachments = useCallback(
     (paths: { path: string; connectionId?: string | null }[]) => {
       if (paths.length === 0) {
@@ -79,15 +106,55 @@ export function useNativeChatComposerAttachments({
       }
       updateImageAttachments((prev) => [
         ...prev,
-        ...paths.map(({ path, connectionId }) => {
-          imageAttachmentCounter.current += 1
-          return {
-            id: `${Date.now()}-${imageAttachmentCounter.current}`,
-            path,
-            connectionId: connectionId ?? undefined
-          }
-        })
+        ...paths.map(({ path, connectionId }) => ({
+          id: nextAttachmentId(),
+          path,
+          connectionId: connectionId ?? undefined
+        }))
       ])
+    },
+    [nextAttachmentId, updateImageAttachments]
+  )
+
+  // Placeholder chip shown the instant a paste starts, so a clipboard image that
+  // takes a beat to save (or upload over SSH) never reads as a dropped paste.
+  const beginPendingImageAttachment = useCallback(
+    (previewUrl?: string): string | null => {
+      if (disabledRef.current) {
+        return null
+      }
+      if (attachmentTargetBlocked()) {
+        noteAttachmentTargetBlocked()
+        return null
+      }
+      const id = nextAttachmentId()
+      updateImageAttachments((prev) => [...prev, { id, path: '', previewUrl, pending: true }])
+      return id
+    },
+    [attachmentTargetBlocked, nextAttachmentId, noteAttachmentTargetBlocked, updateImageAttachments]
+  )
+
+  const resolvePendingImageAttachment = useCallback(
+    (id: string, path: string, connectionId?: string | null) => {
+      updateImageAttachments((prev) =>
+        prev.map((attachment) =>
+          attachment.id === id
+            ? {
+                ...attachment,
+                path,
+                connectionId: connectionId ?? undefined,
+                pending: undefined
+              }
+            : attachment
+        )
+      )
+    },
+    [updateImageAttachments]
+  )
+
+  const dropPendingImageAttachment = useCallback(
+    (id: string) => {
+      updateImageAttachments((prev) => removeAttachmentById(prev, id))
     },
     [updateImageAttachments]
   )
@@ -120,17 +187,8 @@ export function useNativeChatComposerAttachments({
       focus: boolean,
       preserveNotice = false
     ) => {
-      const target = resolveTarget()
-      if (
-        (!target && !allowWithoutTarget) ||
-        (target && nativeChatComposerTargetIsRemote(target.ptyId))
-      ) {
-        setNotice(
-          translate(
-            'components.native-chat.composer.localAttachmentUnsupported',
-            'Local attachments are not available for remote sessions.'
-          )
-        )
+      if (attachmentTargetBlocked()) {
+        noteAttachmentTargetBlocked()
         return
       }
       const imagePaths = resolvedPaths.filter(({ path }) => isNativeChatImageAttachmentPath(path))
@@ -150,10 +208,10 @@ export function useNativeChatComposerAttachments({
       }
     },
     [
-      allowWithoutTarget,
       appendImageAttachments,
+      attachmentTargetBlocked,
       insertFileReferences,
-      resolveTarget,
+      noteAttachmentTargetBlocked,
       setNotice,
       textareaRef
     ]
@@ -201,11 +259,35 @@ export function useNativeChatComposerAttachments({
   return {
     imageAttachments,
     attachResolvedPaths,
-    clearImageAttachments: () => updateImageAttachments(() => []),
+    clearImageAttachments: () =>
+      updateImageAttachments((prev) => {
+        prev.forEach(releaseAttachmentPreview)
+        return []
+      }),
     flushPendingAttachments,
-    removeImageAttachment: (id) =>
-      updateImageAttachments((prev) => prev.filter((attachment) => attachment.id !== id))
+    removeImageAttachment: (id) => updateImageAttachments((prev) => removeAttachmentById(prev, id)),
+    beginPendingImageAttachment,
+    resolvePendingImageAttachment,
+    dropPendingImageAttachment
   }
+}
+
+/** Object URLs minted from a clipboard blob leak until revoked; data URLs don't. */
+function releaseAttachmentPreview(attachment: NativeChatComposerImageAttachment): void {
+  if (attachment.previewUrl?.startsWith('blob:')) {
+    URL.revokeObjectURL(attachment.previewUrl)
+  }
+}
+
+function removeAttachmentById(
+  attachments: readonly NativeChatComposerImageAttachment[],
+  id: string
+): NativeChatComposerImageAttachment[] {
+  const removed = attachments.find((attachment) => attachment.id === id)
+  if (removed) {
+    releaseAttachmentPreview(removed)
+  }
+  return attachments.filter((attachment) => attachment.id !== id)
 }
 
 const attachmentCache = new Map<string, NativeChatComposerImageAttachment[]>()
@@ -218,8 +300,11 @@ export function readNativeChatAttachmentCache(
 
 function writeNativeChatAttachmentCache(
   scopeKey: string,
-  attachments: readonly NativeChatComposerImageAttachment[]
+  cacheable: readonly NativeChatComposerImageAttachment[]
 ): void {
+  // A pending chip's save resolves into THIS hook instance; restoring one into a
+  // remount would strand it pending forever, so only settled chips are cached.
+  const attachments = cacheable.filter((attachment) => !attachment.pending)
   if (attachments.length === 0) {
     attachmentCache.delete(scopeKey)
     return

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
@@ -304,7 +304,12 @@ function writeNativeChatAttachmentCache(
 ): void {
   // A pending chip's save resolves into THIS hook instance; restoring one into a
   // remount would strand it pending forever, so only settled chips are cached.
-  const attachments = cacheable.filter((attachment) => !attachment.pending)
+  const attachments = cacheable
+    .filter((attachment) => !attachment.pending)
+    // Preview URLs can retain the full clipboard Blob (or a large data URL) for
+    // the lifetime of the scope cache. Settled attachments reload from their
+    // authorized path after a remount, so never retain the transient preview.
+    .map(({ previewUrl: _previewUrl, ...attachment }) => attachment)
   if (attachments.length === 0) {
     attachmentCache.delete(scopeKey)
     return

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-paste.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-paste.test.tsx
@@ -264,6 +264,36 @@ describe('useNativeChatComposerPaste', () => {
     expect(store.chips[0]).toMatchObject({ path: '/tmp/orca-paste-1.png', pending: false })
   })
 
+  it('does not settle a local path after the attachment owner changes', async () => {
+    let resolveSave: (path: string) => void = () => {}
+    let owner: NativeChatAttachmentOwner = { kind: 'local' }
+    mocks.saveClipboardImageAsTempFile.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveSave = resolve
+      })
+    )
+    const store = createChipStore()
+    const setNotice = vi.fn()
+    const probe = await renderProbe({
+      resolveAttachmentOwner: () => owner,
+      store,
+      setNotice
+    })
+
+    await act(async () => {
+      probe.latest().handlePaste(imagePasteEvent())
+    })
+    expect(store.chips).toHaveLength(1)
+
+    owner = sshOwner
+    await act(async () => {
+      resolveSave('/tmp/orca-paste-owner-changed.png')
+    })
+
+    expect(store.chips).toHaveLength(0)
+    expect(setNotice).toHaveBeenCalledWith('Worktree not ready — try again in a moment.')
+  })
+
   it('shows a pending chip for menu paste from the clipboard thumbnail probe', async () => {
     mocks.readClipboardImageThumbnail.mockResolvedValue({
       dataUrl: 'data:image/png;base64,AAA',

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-paste.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-paste.test.tsx
@@ -6,7 +6,8 @@ import type { NativeChatAttachmentOwner } from './native-chat-attachment-upload'
 
 const mocks = vi.hoisted(() => ({
   saveClipboardImageAsTempFile: vi.fn(),
-  readClipboardText: vi.fn()
+  readClipboardText: vi.fn(),
+  readClipboardImageThumbnail: vi.fn()
 }))
 
 vi.mock('@/i18n/i18n', () => ({
@@ -27,42 +28,73 @@ vi.stubGlobal('window', {
   api: {
     ui: {
       saveClipboardImageAsTempFile: mocks.saveClipboardImageAsTempFile,
-      readClipboardText: mocks.readClipboardText
+      readClipboardText: mocks.readClipboardText,
+      readClipboardImageThumbnail: mocks.readClipboardImageThumbnail
     }
   }
+})
+vi.stubGlobal('URL', {
+  createObjectURL: () => 'blob:clipboard-image',
+  revokeObjectURL: () => {}
 })
 
 import { useNativeChatComposerPaste } from './use-native-chat-composer-paste'
 
 type HookApi = ReturnType<typeof useNativeChatComposerPaste>
 
-function Probe({
-  disabled,
-  resolveAttachmentOwner,
-  attachResolvedPaths,
-  insertTypedText,
-  setNotice,
-  onReady
-}: {
+/** Mirrors the composer's attachment list so tests can assert what the user sees. */
+type FakeChip = { id: string; path: string; previewUrl?: string; pending: boolean }
+
+function createChipStore(): {
+  chips: FakeChip[]
+  begin: (previewUrl?: string) => string | null
+  resolve: (id: string, path: string, connectionId?: string | null) => void
+  drop: (id: string) => void
+  connectionIds: (string | null | undefined)[]
+} {
+  const chips: FakeChip[] = []
+  const connectionIds: (string | null | undefined)[] = []
+  let counter = 0
+  return {
+    chips,
+    connectionIds,
+    begin: (previewUrl) => {
+      counter += 1
+      const id = `chip-${counter}`
+      chips.push({ id, path: '', previewUrl, pending: true })
+      return id
+    },
+    resolve: (id, path, connectionId) => {
+      const chip = chips.find((candidate) => candidate.id === id)
+      if (chip) {
+        chip.path = path
+        chip.pending = false
+      }
+      connectionIds.push(connectionId)
+    },
+    drop: (id) => {
+      const index = chips.findIndex((candidate) => candidate.id === id)
+      if (index !== -1) {
+        chips.splice(index, 1)
+      }
+    }
+  }
+}
+
+type ProbeArgs = {
   disabled: boolean
   resolveAttachmentOwner: () => NativeChatAttachmentOwner
-  attachResolvedPaths: (paths: string[]) => void
+  attachResolvedPaths: (paths: string[], connectionId?: string | null) => void
+  beginPendingImageAttachment: (previewUrl?: string) => string | null
+  resolvePendingImageAttachment: (id: string, path: string, connectionId?: string | null) => void
+  dropPendingImageAttachment: (id: string) => void
   insertTypedText: (text: string) => boolean
   setNotice: (notice: string | null) => void
   onReady: (api: HookApi) => void
-}): null {
-  onReady(
-    useNativeChatComposerPaste({
-      agent: 'claude',
-      disabled,
-      caret: 0,
-      resolveAttachmentOwner,
-      attachResolvedPaths,
-      insertTypedText,
-      setCaret: () => {},
-      setNotice
-    })
-  )
+}
+
+function Probe({ onReady, ...args }: ProbeArgs): null {
+  onReady(useNativeChatComposerPaste({ agent: 'claude', caret: 0, setCaret: () => {}, ...args }))
   return null
 }
 
@@ -71,12 +103,14 @@ let root: Root | null = null
 async function renderProbe(args: {
   disabled?: boolean
   resolveAttachmentOwner: () => NativeChatAttachmentOwner
-  attachResolvedPaths?: (paths: string[]) => void
+  attachResolvedPaths?: (paths: string[], connectionId?: string | null) => void
+  store?: ReturnType<typeof createChipStore>
   insertTypedText?: (text: string) => boolean
   setNotice?: (notice: string | null) => void
 }): Promise<{ latest: () => HookApi; setDisabled: (disabled: boolean) => Promise<void> }> {
   const container = document.createElement('div')
   document.body.append(container)
+  const store = args.store ?? createChipStore()
   let api: HookApi | null = null
   root = createRoot(container)
   const render = async (disabled: boolean): Promise<void> => {
@@ -86,6 +120,9 @@ async function renderProbe(args: {
           disabled,
           resolveAttachmentOwner: args.resolveAttachmentOwner,
           attachResolvedPaths: args.attachResolvedPaths ?? (() => {}),
+          beginPendingImageAttachment: store.begin,
+          resolvePendingImageAttachment: store.resolve,
+          dropPendingImageAttachment: store.drop,
           insertTypedText: args.insertTypedText ?? (() => true),
           setNotice: args.setNotice ?? (() => {}),
           onReady: (next) => {
@@ -113,7 +150,9 @@ function imagePasteEvent(): {
   defaultPrevented: boolean
 } {
   return {
-    clipboardData: { items: [{ type: 'image/png' }] } as unknown as DataTransfer,
+    clipboardData: {
+      items: [{ type: 'image/png', getAsFile: () => new Blob([], { type: 'image/png' }) }]
+    } as unknown as DataTransfer,
     preventDefault: vi.fn(),
     defaultPrevented: false
   }
@@ -137,10 +176,10 @@ afterEach(() => {
 describe('useNativeChatComposerPaste', () => {
   it('does not save a clipboard image locally for a remote runtime', async () => {
     const setNotice = vi.fn()
-    const attachResolvedPaths = vi.fn()
+    const store = createChipStore()
     const probe = await renderProbe({
       resolveAttachmentOwner: () => ({ kind: 'runtime' }),
-      attachResolvedPaths,
+      store,
       setNotice
     })
 
@@ -150,18 +189,19 @@ describe('useNativeChatComposerPaste', () => {
       'Local attachments are not available for remote sessions.'
     )
     expect(mocks.saveClipboardImageAsTempFile).not.toHaveBeenCalled()
-    expect(attachResolvedPaths).not.toHaveBeenCalled()
+    expect(mocks.readClipboardImageThumbnail).not.toHaveBeenCalled()
+    expect(store.chips).toHaveLength(0)
   })
 
   it('surfaces a failed SSH image save through the composer notice', async () => {
     mocks.saveClipboardImageAsTempFile.mockRejectedValue(
       new Error('Remote connection dropped. Click Reconnect on the SSH target before retrying.')
     )
-    const attachResolvedPaths = vi.fn()
+    const store = createChipStore()
     const setNotice = vi.fn()
     const probe = await renderProbe({
       resolveAttachmentOwner: () => sshOwner,
-      attachResolvedPaths,
+      store,
       setNotice
     })
     await act(async () => {
@@ -170,24 +210,108 @@ describe('useNativeChatComposerPaste', () => {
     expect(setNotice).toHaveBeenCalledWith(
       'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
     )
-    expect(attachResolvedPaths).not.toHaveBeenCalled()
+    // The optimistic chip must not outlive a failed save.
+    expect(store.chips).toHaveLength(0)
   })
 
-  it('saves on the SSH host and attaches the returned remote path', async () => {
+  it('saves on the SSH host and settles the chip on the returned remote path', async () => {
     mocks.saveClipboardImageAsTempFile.mockResolvedValue('/remote/tmp/orca-paste-1.png')
+    const store = createChipStore()
     const attachResolvedPaths = vi.fn()
     const probe = await renderProbe({
       resolveAttachmentOwner: () => sshOwner,
+      store,
       attachResolvedPaths
     })
     await act(async () => {
       probe.latest().handlePaste(imagePasteEvent())
     })
     expect(mocks.saveClipboardImageAsTempFile).toHaveBeenCalledWith({ connectionId: 'conn-1' })
-    expect(attachResolvedPaths).toHaveBeenCalledWith(['/remote/tmp/orca-paste-1.png'])
+    expect(store.chips).toEqual([
+      {
+        id: 'chip-1',
+        path: '/remote/tmp/orca-paste-1.png',
+        previewUrl: 'blob:clipboard-image',
+        pending: false
+      }
+    ])
+    // The chip carries the SSH connection so its preview reads over SFTP.
+    expect(store.connectionIds).toEqual(['conn-1'])
+    expect(attachResolvedPaths).not.toHaveBeenCalled()
+  })
+
+  it('shows a pending chip before the save resolves', async () => {
+    let resolveSave: (path: string) => void = () => {}
+    mocks.saveClipboardImageAsTempFile.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveSave = resolve
+      })
+    )
+    const store = createChipStore()
+    const probe = await renderProbe({
+      resolveAttachmentOwner: () => ({ kind: 'local' }),
+      store
+    })
+    await act(async () => {
+      probe.latest().handlePaste(imagePasteEvent())
+    })
+    expect(store.chips).toEqual([
+      { id: 'chip-1', path: '', previewUrl: 'blob:clipboard-image', pending: true }
+    ])
+    await act(async () => {
+      resolveSave('/tmp/orca-paste-1.png')
+    })
+    expect(store.chips[0]).toMatchObject({ path: '/tmp/orca-paste-1.png', pending: false })
+  })
+
+  it('shows a pending chip for menu paste from the clipboard thumbnail probe', async () => {
+    mocks.readClipboardImageThumbnail.mockResolvedValue({
+      dataUrl: 'data:image/png;base64,AAA',
+      width: 1200,
+      height: 800
+    })
+    let resolveSave: (path: string) => void = () => {}
+    mocks.saveClipboardImageAsTempFile.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveSave = resolve
+      })
+    )
+    const store = createChipStore()
+    const probe = await renderProbe({
+      resolveAttachmentOwner: () => ({ kind: 'local' }),
+      store
+    })
+    await act(async () => {
+      probe.latest().pasteFromClipboard()
+    })
+    expect(store.chips).toEqual([
+      { id: 'chip-1', path: '', previewUrl: 'data:image/png;base64,AAA', pending: true }
+    ])
+    await act(async () => {
+      resolveSave('/tmp/orca-paste-2.png')
+    })
+    expect(store.chips[0]).toMatchObject({ path: '/tmp/orca-paste-2.png', pending: false })
+  })
+
+  it('attaches directly when no clipboard preview was available', async () => {
+    mocks.readClipboardImageThumbnail.mockResolvedValue(null)
+    mocks.saveClipboardImageAsTempFile.mockResolvedValue('C:\\Temp\\orca-paste-3.png')
+    const store = createChipStore()
+    const attachResolvedPaths = vi.fn()
+    const probe = await renderProbe({
+      resolveAttachmentOwner: () => ({ kind: 'local' }),
+      store,
+      attachResolvedPaths
+    })
+    await act(async () => {
+      probe.latest().pasteFromClipboard()
+    })
+    expect(store.chips).toHaveLength(0)
+    expect(attachResolvedPaths).toHaveBeenCalledWith(['C:\\Temp\\orca-paste-3.png'], null)
   })
 
   it('stops pasteFromClipboard on a failed save instead of falling through to text', async () => {
+    mocks.readClipboardImageThumbnail.mockResolvedValue(null)
     mocks.saveClipboardImageAsTempFile.mockRejectedValue(new Error('sftp down'))
     const insertTypedText = vi.fn()
     const setNotice = vi.fn()
@@ -205,17 +329,40 @@ describe('useNativeChatComposerPaste', () => {
   })
 
   it('still falls through to text when the clipboard holds no image', async () => {
+    mocks.readClipboardImageThumbnail.mockResolvedValue(null)
     mocks.saveClipboardImageAsTempFile.mockResolvedValue(null)
     mocks.readClipboardText.mockResolvedValue('hello')
     const insertTypedText = vi.fn()
+    const store = createChipStore()
     const probe = await renderProbe({
       resolveAttachmentOwner: () => ({ kind: 'local' }),
+      store,
       insertTypedText
     })
     await act(async () => {
       probe.latest().pasteFromClipboard()
     })
     expect(insertTypedText).toHaveBeenCalledWith('hello')
+    expect(store.chips).toHaveLength(0)
+  })
+
+  it('drops the pending chip when the clipboard changed between probe and save', async () => {
+    mocks.readClipboardImageThumbnail.mockResolvedValue({
+      dataUrl: 'data:image/png;base64,AAA',
+      width: 10,
+      height: 10
+    })
+    mocks.saveClipboardImageAsTempFile.mockResolvedValue(null)
+    mocks.readClipboardText.mockResolvedValue('hello')
+    const store = createChipStore()
+    const probe = await renderProbe({
+      resolveAttachmentOwner: () => ({ kind: 'local' }),
+      store
+    })
+    await act(async () => {
+      probe.latest().pasteFromClipboard()
+    })
+    expect(store.chips).toHaveLength(0)
   })
 
   it('suppresses the failure notice when the composer became disabled mid-save', async () => {

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
@@ -56,6 +56,21 @@ function ownerConnectionId(owner: NativeChatAttachmentOwner): string | null {
   return owner.kind === 'ssh' ? owner.connectionId : null
 }
 
+/** A save can outlive a worktree/connection switch; never settle its path into
+ * a composer whose backing host changed while the clipboard was in flight. */
+function attachmentOwnerStillMatches(
+  original: NativeChatAttachmentOwner,
+  current: NativeChatAttachmentOwner
+): boolean {
+  if (original.kind !== current.kind) {
+    return false
+  }
+  if (original.kind !== 'ssh') {
+    return true
+  }
+  return current.kind === 'ssh' && original.connectionId === current.connectionId
+}
+
 /**
  * Clipboard-paste behavior for the native chat composer: a clipboard image
  * becomes an attachment (TUI parity), otherwise text is inserted at the caret.
@@ -138,7 +153,19 @@ export function useNativeChatComposerPaste({
   /** Settle the chip started at paste time, or attach directly when the paste
    *  produced no placeholder (no clipboard preview was available). */
   const settleImagePaste = useCallback(
-    (pendingId: string | null, path: string, connectionId: string | null) => {
+    (
+      pendingId: string | null,
+      path: string,
+      connectionId: string | null,
+      originalOwner: NativeChatAttachmentOwner
+    ) => {
+      if (!attachmentOwnerStillMatches(originalOwner, resolveAttachmentOwner())) {
+        if (pendingId) {
+          dropPendingImageAttachment(pendingId)
+        }
+        setNotice(nativeChatWorktreeNotReadyNotice())
+        return
+      }
       if (pendingId) {
         resolvePendingImageAttachment(pendingId, path, connectionId)
       } else {
@@ -146,7 +173,13 @@ export function useNativeChatComposerPaste({
       }
       setNotice(null)
     },
-    [attachResolvedPaths, resolvePendingImageAttachment, setNotice]
+    [
+      attachResolvedPaths,
+      dropPendingImageAttachment,
+      resolveAttachmentOwner,
+      resolvePendingImageAttachment,
+      setNotice
+    ]
   )
 
   const handlePaste = useCallback(
@@ -194,7 +227,7 @@ export function useNativeChatComposerPaste({
           }
           return
         }
-        settleImagePaste(pendingId, saved.tempPath, ownerConnectionId(owner))
+        settleImagePaste(pendingId, saved.tempPath, ownerConnectionId(owner), owner)
         setCaret(caretAtPaste)
       })()
     },
@@ -247,7 +280,7 @@ export function useNativeChatComposerPaste({
           noteImagesUnsupported()
           return
         }
-        settleImagePaste(pendingId, saved.tempPath, ownerConnectionId(owner))
+        settleImagePaste(pendingId, saved.tempPath, ownerConnectionId(owner), owner)
         return
       }
       // Clipboard changed between the probe and the save: no image to attach.

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef } from 'react'
 import { translate } from '@/i18n/i18n'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import type { AgentType } from '../../../../shared/agent-status-types'
-import { resolveImagePaste } from './native-chat-image-paste'
+import { getAgentImageHandling } from './native-chat-image-paste'
 import { NATIVE_CHAT_CONTEXT_PASTE_MAX_BYTES } from './native-chat-composer-target'
 import {
   nativeChatLocalAttachmentUnsupportedNotice,
@@ -19,7 +19,10 @@ export type UseNativeChatComposerPasteArgs = {
   /** Resolved at paste time: SSH panes must save the clipboard image on the
    *  remote host, or the attached path names a file the agent cannot read. */
   resolveAttachmentOwner: () => NativeChatAttachmentOwner
-  attachResolvedPaths: (paths: string[]) => void
+  attachResolvedPaths: (paths: string[], connectionId?: string | null) => void
+  beginPendingImageAttachment: (previewUrl?: string) => string | null
+  resolvePendingImageAttachment: (id: string, path: string, connectionId?: string | null) => void
+  dropPendingImageAttachment: (id: string) => void
   insertTypedText: (text: string) => boolean
   setCaret: (caret: number) => void
   setNotice: (notice: string | null) => void
@@ -33,12 +36,24 @@ type ClipboardEventLike = {
   defaultPrevented: boolean
 }
 
-function clipboardEventHasImage(event: ClipboardEventLike): boolean {
+function clipboardEventImageFile(event: ClipboardEventLike): File | null {
   const data = event.clipboardData
   if (!data) {
-    return false
+    return null
   }
-  return Array.from(data.items).some((item) => item.type.startsWith('image/'))
+  const item = Array.from(data.items).find((candidate) => candidate.type.startsWith('image/'))
+  return item?.getAsFile() ?? null
+}
+
+/** Owners whose attachment path is a file this client can write right now. */
+function ownerAcceptsClipboardImage(
+  owner: NativeChatAttachmentOwner
+): owner is Extract<NativeChatAttachmentOwner, { kind: 'local' | 'ssh' }> {
+  return owner.kind === 'local' || owner.kind === 'ssh'
+}
+
+function ownerConnectionId(owner: NativeChatAttachmentOwner): string | null {
+  return owner.kind === 'ssh' ? owner.connectionId : null
 }
 
 /**
@@ -47,7 +62,12 @@ function clipboardEventHasImage(event: ClipboardEventLike): boolean {
  * `handlePaste` consumes a paste event (the textarea's onPaste *or* the
  * pane-level capture listener — the OS often retargets the event off the
  * focused textarea, so the pane listener is the reliable path);
- * `pasteFromClipboard` is the menu-driven path with no event in hand.
+ * `pasteFromClipboard` is the menu-driven path with no event in hand (on macOS
+ * Cmd+V is routed here, so it must feel just as immediate).
+ *
+ * Both paths show a pending attachment chip before the image is saved: writing
+ * the file (or uploading it over SFTP) takes long enough that silence reads as
+ * a dropped paste and invites duplicate pastes.
  */
 export function useNativeChatComposerPaste({
   agent,
@@ -55,6 +75,9 @@ export function useNativeChatComposerPaste({
   caret,
   resolveAttachmentOwner,
   attachResolvedPaths,
+  beginPendingImageAttachment,
+  resolvePendingImageAttachment,
+  dropPendingImageAttachment,
   insertTypedText,
   setCaret,
   setNotice
@@ -67,6 +90,7 @@ export function useNativeChatComposerPaste({
   // the captured closure would otherwise attach/insert into a guarded composer.
   const disabledRef = useRef(disabled)
   disabledRef.current = disabled
+  const acceptsImages = getAgentImageHandling(agent) === 'attachment'
 
   // Distinguishes 'empty' (no image on the clipboard — text may fall through)
   // from 'failed' (save errored — the flow must stop and say why).
@@ -102,22 +126,27 @@ export function useNativeChatComposerPaste({
     [setNotice]
   )
 
-  const attachClipboardImageTempFile = useCallback(
-    (tempPath: string) => {
-      const result = resolveImagePaste(agent, tempPath)
-      if (result.kind === 'unsupported') {
-        setNotice(
-          translate(
-            'components.native-chat.composer.imageUnsupported',
-            'Image paste is not supported for this agent.'
-          )
-        )
-        return
+  const noteImagesUnsupported = useCallback(() => {
+    setNotice(
+      translate(
+        'components.native-chat.composer.imageUnsupported',
+        'Image paste is not supported for this agent.'
+      )
+    )
+  }, [setNotice])
+
+  /** Settle the chip started at paste time, or attach directly when the paste
+   *  produced no placeholder (no clipboard preview was available). */
+  const settleImagePaste = useCallback(
+    (pendingId: string | null, path: string, connectionId: string | null) => {
+      if (pendingId) {
+        resolvePendingImageAttachment(pendingId, path, connectionId)
+      } else {
+        attachResolvedPaths([path], connectionId)
       }
-      attachResolvedPaths([result.path])
       setNotice(null)
     },
-    [agent, attachResolvedPaths, setNotice]
+    [attachResolvedPaths, resolvePendingImageAttachment, setNotice]
   )
 
   const handlePaste = useCallback(
@@ -131,7 +160,8 @@ export function useNativeChatComposerPaste({
       // textarea's native paste keeps its caret/undo behavior when it is the
       // event target. (When the OS retargets the paste off the textarea the
       // pane listener still routes text via pasteFromClipboard.)
-      if (!clipboardEventHasImage(event)) {
+      const imageFile = clipboardEventImageFile(event)
+      if (!imageFile) {
         return
       }
       event.preventDefault()
@@ -140,25 +170,45 @@ export function useNativeChatComposerPaste({
         setNotice(nativeChatWorktreeNotReadyNotice())
         return
       }
+      if (!acceptsImages) {
+        noteImagesUnsupported()
+        return
+      }
       // Why: snapshot the caret before the async temp-file round-trip — `caret`
       // state can move (further typing/selection) while the await is in flight.
       const caretAtPaste = caret
+      // The clipboard blob is already in this process, so the chip can show the
+      // real image on the same tick the paste happens — no round-trip at all.
+      const previewUrl = ownerAcceptsClipboardImage(owner)
+        ? URL.createObjectURL(imageFile)
+        : undefined
+      const pendingId = previewUrl ? beginPendingImageAttachment(previewUrl) : null
+      if (previewUrl && !pendingId) {
+        URL.revokeObjectURL(previewUrl)
+      }
       void (async () => {
         const saved = await saveClipboardImageForOwner(owner)
         if (saved.status !== 'saved' || disabledRef.current) {
+          if (pendingId) {
+            dropPendingImageAttachment(pendingId)
+          }
           return
         }
-        attachClipboardImageTempFile(saved.tempPath)
+        settleImagePaste(pendingId, saved.tempPath, ownerConnectionId(owner))
         setCaret(caretAtPaste)
       })()
     },
     [
-      attachClipboardImageTempFile,
+      acceptsImages,
+      beginPendingImageAttachment,
       caret,
+      dropPendingImageAttachment,
+      noteImagesUnsupported,
       resolveAttachmentOwner,
       saveClipboardImageForOwner,
       setCaret,
-      setNotice
+      setNotice,
+      settleImagePaste
     ]
   )
 
@@ -169,8 +219,23 @@ export function useNativeChatComposerPaste({
       // way to LEARN whether the clipboard holds an image. An image then gets
       // the not-ready notice (never a local-path attach for a possibly-remote
       // worktree); plain text falls through unaffected.
-      const saved = await saveClipboardImageForOwner(owner)
+      //
+      // The in-memory thumbnail probe runs alongside the save rather than before
+      // it: it answers first (it never touches disk or the network), so the chip
+      // appears while the save is still in flight and text paste stays as fast.
+      const wantsPlaceholder = acceptsImages && ownerAcceptsClipboardImage(owner)
+      const thumbnailPromise = wantsPlaceholder
+        ? window.api.ui.readClipboardImageThumbnail().catch(() => null)
+        : Promise.resolve(null)
+      const savePromise = saveClipboardImageForOwner(owner)
+      const thumbnail = await thumbnailPromise
+      const pendingId =
+        thumbnail && !disabledRef.current ? beginPendingImageAttachment(thumbnail.dataUrl) : null
+      const saved = await savePromise
       if (disabledRef.current || saved.status === 'failed') {
+        if (pendingId) {
+          dropPendingImageAttachment(pendingId)
+        }
         return
       }
       if (saved.status === 'saved') {
@@ -178,8 +243,16 @@ export function useNativeChatComposerPaste({
           setNotice(nativeChatWorktreeNotReadyNotice())
           return
         }
-        attachClipboardImageTempFile(saved.tempPath)
+        if (!acceptsImages) {
+          noteImagesUnsupported()
+          return
+        }
+        settleImagePaste(pendingId, saved.tempPath, ownerConnectionId(owner))
         return
+      }
+      // Clipboard changed between the probe and the save: no image to attach.
+      if (pendingId) {
+        dropPendingImageAttachment(pendingId)
       }
       const text = await window.api.ui
         .readClipboardText({ maxBytes: NATIVE_CHAT_CONTEXT_PASTE_MAX_BYTES })
@@ -192,11 +265,15 @@ export function useNativeChatComposerPaste({
       }
     })()
   }, [
-    attachClipboardImageTempFile,
+    acceptsImages,
+    beginPendingImageAttachment,
+    dropPendingImageAttachment,
     insertTypedText,
+    noteImagesUnsupported,
     resolveAttachmentOwner,
     saveClipboardImageForOwner,
-    setNotice
+    setNotice,
+    settleImagePaste
   ])
 
   return { handlePaste, pasteFromClipboard }

--- a/src/renderer/src/components/native-chat/use-native-chat-structured-composer-send.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-structured-composer-send.ts
@@ -1,0 +1,73 @@
+import { useCallback } from 'react'
+import { emitNativeChatMessageSent } from '@/lib/native-chat-telemetry'
+import { isStructuredAgentSessionComposerCommand } from '../../../../shared/structured-agent-session-composer'
+import type { AgentType } from '../../../../shared/agent-status-types'
+import { dispatchNativeChatStructuredComposerText } from './native-chat-structured-composer-dispatch'
+import { pushHistory, type HistoryState } from './native-chat-composer-state'
+import type { NativeChatStructuredComposerTransport } from './native-chat-composer-types'
+import type { NativeChatComposerImageAttachment } from './NativeChatComposerField'
+
+export type UseNativeChatStructuredComposerSendArgs = {
+  agent: AgentType
+  imageAttachments: readonly NativeChatComposerImageAttachment[]
+  structuredTransport?: NativeChatStructuredComposerTransport
+  clearImageAttachments: () => void
+  clearSkillOrigin: () => void
+  setHistory: (updater: (previous: HistoryState) => HistoryState) => void
+  setDraft: (value: string) => void
+  setCaret: (caret: number) => void
+}
+
+/** Send through the structured journal transport, clearing the composer only
+ *  once the transport accepts (the PTY path has its own sibling hook). */
+export function useNativeChatStructuredComposerSend({
+  agent,
+  imageAttachments,
+  structuredTransport,
+  clearImageAttachments,
+  clearSkillOrigin,
+  setHistory,
+  setDraft,
+  setCaret
+}: UseNativeChatStructuredComposerSendArgs): (
+  text: string,
+  attachments?: readonly NativeChatComposerImageAttachment[]
+) => void {
+  return useCallback(
+    (text: string, attachments = imageAttachments): void => {
+      if (!structuredTransport) {
+        return
+      }
+      if (attachments.length > 0 && isStructuredAgentSessionComposerCommand(text, agent)) {
+        structuredTransport.onError('Remove attachments before using a chat-session command.')
+        return
+      }
+      void dispatchNativeChatStructuredComposerText(structuredTransport, text, attachments)
+        .then(({ accepted, error }) => {
+          structuredTransport.onError(error)
+          if (!accepted) {
+            return
+          }
+          emitNativeChatMessageSent({ agent, runtime: structuredTransport.runtime })
+          setHistory((previous) => pushHistory(previous, text))
+          setDraft('')
+          setCaret(0)
+          clearSkillOrigin()
+          clearImageAttachments()
+        })
+        .catch((error) =>
+          structuredTransport.onError(error instanceof Error ? error.message : String(error))
+        )
+    },
+    [
+      agent,
+      clearImageAttachments,
+      clearSkillOrigin,
+      imageAttachments,
+      setCaret,
+      setDraft,
+      setHistory,
+      structuredTransport
+    ]
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16613,6 +16613,7 @@
         "removeAttachment": "Remove attachment",
         "pastedImageLabel": "Pasted image",
         "imagePasteFailed": "Image paste failed.",
+        "imageSaving": "Saving pasted image…",
         "worktreeNotReady": "Worktree not ready — try again in a moment.",
         "uploadingAttachments": "Uploading {{value0}} file(s) to remote…",
         "model": "Model",

--- a/src/renderer/src/web/preload-api/web-clipboard-api.ts
+++ b/src/renderer/src/web/preload-api/web-clipboard-api.ts
@@ -4,7 +4,9 @@ import {
   CLIPBOARD_IMAGE_MAX_SOURCE_BYTES,
   CLIPBOARD_IMAGE_TOO_LARGE_ERROR,
   assertClipboardImageByteLengthWithinLimit,
-  assertClipboardImageDimensionsWithinLimit
+  assertClipboardImageDimensionsWithinLimit,
+  clipboardImageThumbnailSize,
+  type ClipboardImageThumbnail
 } from '../../../../shared/clipboard-image'
 import { assertClipboardTextWriteWithinLimitWithYield } from '../../../../shared/clipboard-text'
 import { copyClipboardTextViaExecCommand } from '../web-clipboard-copy-fallback'
@@ -67,6 +69,50 @@ export async function convertImageBlobToPng(blob: Blob): Promise<Blob> {
         resolve(png)
       }, 'image/png')
     })
+  } finally {
+    bitmap.close()
+  }
+}
+
+async function readClipboardImageBlob(): Promise<Blob | null> {
+  const clipboard = navigator.clipboard as
+    | (Clipboard & { read?: () => Promise<ClipboardItem[]> })
+    | undefined
+  if (!clipboard?.read) {
+    return null
+  }
+  const items = await clipboard.read()
+  for (const item of items) {
+    const imageType = item.types.find((type) => type.startsWith('image/'))
+    if (imageType) {
+      return item.getType(imageType)
+    }
+  }
+  return null
+}
+
+/** Web counterpart of the main-process clipboard probe: decodes the clipboard
+ *  image once and returns a small preview so the composer can show a chip while
+ *  the full image is still being uploaded to the runtime. */
+export async function readClipboardImageThumbnail(): Promise<ClipboardImageThumbnail | null> {
+  const blob = await readClipboardImageBlob()
+  if (!blob) {
+    return null
+  }
+  assertClipboardImageBlobWithinLimit(blob)
+  const bitmap = await createImageBitmap(blob)
+  try {
+    assertClipboardImageDimensionsWithinLimit(bitmap)
+    const thumbnailSize = clipboardImageThumbnailSize(bitmap)
+    const canvas = document.createElement('canvas')
+    canvas.width = thumbnailSize.width
+    canvas.height = thumbnailSize.height
+    const context = canvas.getContext('2d')
+    if (!context) {
+      return null
+    }
+    context.drawImage(bitmap, 0, 0, thumbnailSize.width, thumbnailSize.height)
+    return { dataUrl: canvas.toDataURL('image/png'), height: bitmap.height, width: bitmap.width }
   } finally {
     bitmap.close()
   }

--- a/src/renderer/src/web/preload-api/web-ui-api.ts
+++ b/src/renderer/src/web/preload-api/web-ui-api.ts
@@ -7,6 +7,7 @@ import { omitPairingLocalUiFields } from '../../../../shared/pairing-local-ui-fi
 import type { PairedUiState } from '../../../../shared/pairing-local-ui-fields'
 import {
   readClipboardImagePngBase64,
+  readClipboardImageThumbnail,
   saveClipboardImageAsTempFileInRuntime,
   writeWebClipboardText
 } from './web-clipboard-api'
@@ -131,6 +132,7 @@ export function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       }
       return saveClipboardImageAsTempFileInRuntime(contentBase64, args)
     },
+    readClipboardImageThumbnail: () => readClipboardImageThumbnail().catch(() => null),
     writeClipboardText: writeWebClipboardText,
     writeTerminalClipboardText: writeWebClipboardText,
     writeSelectionClipboardText: () =>

--- a/src/shared/clipboard-image.ts
+++ b/src/shared/clipboard-image.ts
@@ -36,3 +36,29 @@ export function assertClipboardImageDimensionsWithinLimit({
     throw new Error(CLIPBOARD_IMAGE_TOO_LARGE_ERROR)
   }
 }
+
+/** Longest edge of the thumbnail the composer shows while the full clipboard
+ *  image is still being written to disk. Small enough to cross IPC instantly. */
+export const CLIPBOARD_IMAGE_THUMBNAIL_MAX_EDGE = 320
+
+export type ClipboardImageThumbnail = ClipboardImageDimensions & {
+  /** `data:image/png;base64,...` preview of the clipboard image. */
+  dataUrl: string
+}
+
+/** Scale `size` down so its longest edge fits the thumbnail budget. Returns the
+ *  input unchanged when it already fits, so small images skip the resize. */
+export function clipboardImageThumbnailSize({
+  height,
+  width
+}: ClipboardImageDimensions): ClipboardImageDimensions {
+  const longestEdge = Math.max(width, height)
+  if (longestEdge <= CLIPBOARD_IMAGE_THUMBNAIL_MAX_EDGE) {
+    return { height, width }
+  }
+  const scale = CLIPBOARD_IMAGE_THUMBNAIL_MAX_EDGE / longestEdge
+  return {
+    height: Math.max(1, Math.round(height * scale)),
+    width: Math.max(1, Math.round(width * scale))
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​514 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​87 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​427 |
| Prod | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​557 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​129 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​428 |

<!-- /orca-pr-loc -->

Pasting an image into the native chat composer showed nothing until the clipboard image finished saving, and the resulting chip could never render the image at all. Reported against restructured Codex chat; both problems affect every native chat agent.

## What was broken

**Preview never worked — path authorization, not rendering.** Clipboard pastes are written to the OS temp dir (`app.getPath('temp')`), which sits outside every allowed root, so the composer's own `fs:readFile` of the file Orca had just written was denied. `loadLocalImageAbsolutePath` swallows the throw, so the thumbnail silently fell back to a generic icon and the lightbox showed "Preview unavailable".

**The delay is the macOS paste route.** Cmd+V is intercepted in main (`before-input-event` → `ui:appMenuPaste`) and delivered through the app-menu paste channel, which has no clipboard blob in hand. The composer only learned an image existed *after* the save round-trip returned, so nothing appeared in the meantime — which reads as a dropped paste and invites repeat pasting.

## Changes

- `saveClipboardImageBufferAsTempFile` authorizes the path it writes, the same way other Orca-produced external files are handled. This is the preview fix.
- New `clipboard:readImageThumbnail` IPC — an in-memory clipboard probe returning a ≤320px data URL. It runs **alongside** the save rather than before it, so text paste gains no latency. The DOM-paste route needs no probe: it mints a blob URL from the clipboard file on the same tick.
- Attachments carry `pending` and `previewUrl`. The chip appears immediately with the real image dimmed under a spinner, then settles in place on the saved path.
- Send is blocked while any attachment is pending — a pending chip has no agent-readable path yet.
- Pending chips are kept out of the pane attachment cache, so a mid-save unmount cannot strand one that would block send forever. Blob previews are revoked on remove/clear.
- SSH pastes now carry their `connectionId` onto the chip, so remote previews read over SFTP. They previously did not.
- Split `useNativeChatStructuredComposerSend` and `buildClipboardImageThumbnail` into their own modules to stay under the max-lines caps; dropped `resolveImagePaste`, which became dead.

## Validation

Isolated dev instance (own user-data dir, private renderer port, CDP port-owner and `/@fs` 200/403 ownership proof), real Codex Chat tab, real 5120×2880 image on the macOS clipboard, driven through the actual macOS Cmd+V route:

| | |
|---|---|
| chip appears | 42–61 ms, `aria-busy=true`, spinner present, label "Saving pasted image…" |
| settles | ~141 ms, label "View image: Pasted image" |
| 3 rapid pastes | 3 independent pending chips, all settled, none stranded |
| Send while pending | disabled on every sampled tick |
| lightbox | opens the real on-disk image at 5120×2880 — not the 320px thumbnail, not "Preview unavailable" |

Ablation confirming the authorization fix, run live in the app:

- the clipboard temp file Orca wrote → `ok:image/png`
- a sibling path **in the same temp dir**, never authorized → `Access denied: path resolves outside allowed directories`

`pnpm tc` clean, oxlint clean, 1390 tests pass across `native-chat` and `main/window`.

The pending spinner itself is not screenshotted — the pending window is under 100 ms on this machine, so that state is covered by DOM probes in the live run plus unit tests rather than an image.

https://claude.ai/code/session_01NnEfY8NpfFtVnboLKnmgdW
