### PR TITLE
fix(orcad): stop demanding a spawn-helper only macOS builds

### DIFF
--- a/config/scripts/build-orcad-prebuilds.mjs
+++ b/config/scripts/build-orcad-prebuilds.mjs
@@ -177,10 +177,11 @@ function build() {
   copyFileSync(builtBinary, join(slotDir, 'pty.node'))
   console.log(`[orcad-prebuilds] stored ${slot}/pty.node`)
 
-  // Why spawn-helper ships too: on Unix node-pty posix_spawns build/Release/spawn-helper,
+  // Why spawn-helper ships too: on macOS node-pty posix_spawns build/Release/spawn-helper,
   // so a slot without it installs cleanly and then fails ENOENT the first time a user
-  // opens a terminal. Windows has no spawn-helper.
-  if (process.platform !== 'win32') {
+  // opens a terminal. binding.gyp builds the helper only under OS=="mac"; every other
+  // platform forks directly, so demanding one there fails a healthy Linux slot build.
+  if (process.platform === 'darwin') {
     const helperSource = join(dirname(builtBinary), 'spawn-helper')
     if (!existsSync(helperSource)) {
       throw new Error(`[orcad-prebuilds] spawn-helper missing at ${helperSource}`)

--- a/src/main/orcad/node-pty-prebuilt-slot.test.ts
+++ b/src/main/orcad/node-pty-prebuilt-slot.test.ts
@@ -17,6 +17,14 @@ const LINUX_GLIBC: NativeHostAbi = {
   nodeAbi: '127'
 }
 
+const DARWIN_ARM64: NativeHostAbi = {
+  platform: 'darwin',
+  arch: 'arm64',
+  libc: 'none',
+  glibcVersion: null,
+  nodeAbi: '127'
+}
+
 const dirs: string[] = []
 const temp = (): string => {
   const dir = mkdtempSync(join(tmpdir(), 'orcad-slot-'))
@@ -48,18 +56,32 @@ describe('resolveOrcadPrebuildsDir', () => {
 })
 
 describe('installPrebuiltSlot', () => {
-  it('installs the slot binary and spawn-helper into build/Release', () => {
+  it('installs the slot binary and spawn-helper into build/Release on macOS', () => {
+    const prebuilds = temp()
+    const nodePtyDir = temp()
+    stageSlot(prebuilds, 'darwin-arm64')
+
+    const outcome = installPrebuiltSlot({ abi: DARWIN_ARM64, nodePtyDir, prebuildsDir: prebuilds })
+
+    expect(outcome).toEqual({ installed: true, slot: 'darwin-arm64', spawnHelper: true })
+    expect(existsSync(join(nodePtyDir, 'build', 'Release', 'pty.node'))).toBe(true)
+    // Without the executable bit every spawn fails EACCES at the moment a user opens a terminal.
+    const helper = statSync(join(nodePtyDir, 'build', 'Release', 'spawn-helper'))
+    expect(helper.mode & 0o111).not.toBe(0)
+  })
+
+  it('installs a Linux slot without claiming a spawn-helper it never execs', () => {
+    // node-pty builds spawn-helper only under binding.gyp's OS=="mac"; reporting one off
+    // macOS is what made every Linux orcad boot degraded on spawn_helper_missing (#17844).
     const prebuilds = temp()
     const nodePtyDir = temp()
     stageSlot(prebuilds, 'linux-x64-glibc')
 
     const outcome = installPrebuiltSlot({ abi: LINUX_GLIBC, nodePtyDir, prebuildsDir: prebuilds })
 
-    expect(outcome).toEqual({ installed: true, slot: 'linux-x64-glibc', spawnHelper: true })
+    expect(outcome).toEqual({ installed: true, slot: 'linux-x64-glibc', spawnHelper: false })
     expect(existsSync(join(nodePtyDir, 'build', 'Release', 'pty.node'))).toBe(true)
-    // Without the executable bit every spawn fails EACCES at the moment a user opens a terminal.
-    const helper = statSync(join(nodePtyDir, 'build', 'Release', 'spawn-helper'))
-    expect(helper.mode & 0o111).not.toBe(0)
+    expect(existsSync(join(nodePtyDir, 'build', 'Release', 'spawn-helper'))).toBe(false)
   })
 
   it('will not load a glibc slot on a musl host', () => {

--- a/src/main/orcad/node-pty-prebuilt-slot.ts
+++ b/src/main/orcad/node-pty-prebuilt-slot.ts
@@ -16,6 +16,7 @@
 import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
+import { usesNodePtySpawnHelper } from '../../shared/node-pty-spawn-helper'
 import { nativeSlotName, type NativeHostAbi } from './native-host-abi'
 
 export type PrebuiltSlotManifest = {
@@ -103,11 +104,11 @@ export function installPrebuiltSlot(options: {
   mkdirSync(releaseDir, { recursive: true })
   copyFileSync(source, join(releaseDir, 'pty.node'))
 
-  // Why this matters as much as pty.node: on Unix node-pty posix_spawns
+  // Why this matters as much as pty.node: on macOS node-pty posix_spawns
   // build/Release/spawn-helper. Without it every spawn fails with ENOENT at the moment
   // a user opens a terminal, long after the "install succeeded" line.
   let spawnHelper = false
-  if (options.abi.platform !== 'win32') {
+  if (usesNodePtySpawnHelper(options.abi.platform)) {
     const helperSource = join(prebuildsDir, slot, 'spawn-helper')
     if (existsSync(helperSource)) {
       const helperDest = join(releaseDir, 'spawn-helper')

--- a/src/main/orcad/node-pty-precondition.test.ts
+++ b/src/main/orcad/node-pty-precondition.test.ts
@@ -31,10 +31,10 @@ const realNodePtyLoads = ((): boolean => {
   if (!existsSync(REAL_PTY_NODE)) {
     return false
   }
-  // Why spawn-helper too: a slot without it is legitimately 'degraded', so a test that
-  // expects 'ok' has an unsatisfiable premise on a host that lacks it. CI has the
-  // binding but not the helper, which is what made the previous gate insufficient.
-  if (process.platform !== 'win32' && !existsSync(REAL_SPAWN_HELPER)) {
+  // Why spawn-helper too: on macOS a slot without it is legitimately 'degraded', so a
+  // test that expects 'ok' has an unsatisfiable premise on a host that lacks it. Only
+  // macOS builds the helper, so gating other platforms on it never lets them run.
+  if (process.platform === 'darwin' && !existsSync(REAL_SPAWN_HELPER)) {
     return false
   }
   const probe = spawnSync(process.execPath, ['-e', `require(${JSON.stringify(REAL_PTY_NODE)})`], {
@@ -240,8 +240,8 @@ describe('checkNodePtyPrecondition', () => {
 
   // Why gated on the real binding: this asserts a LOAD outcome, so it needs a pty.node
   // built for the Node ABI. CI's shard never runs ensure-native-runtime, so the copy
-  // ENOENT'd there.
-  it.runIf(process.platform !== 'win32' && realNodePtyLoads)(
+  // ENOENT'd there. macOS only — it is the only platform that execs spawn-helper.
+  it.runIf(process.platform === 'darwin' && realNodePtyLoads)(
     'degrades rather than blocks when only spawn-helper is missing',
     () => {
       // node-pty posix_spawns spawn-helper, so this host loads fine and then fails ENOENT
@@ -255,6 +255,31 @@ describe('checkNodePtyPrecondition', () => {
       const verdict = checkNodePtyPrecondition({ nodePtyDir: dir, prebuildsDir: null })
 
       expect(verdict).toMatchObject({ status: 'degraded', reason: 'spawn_helper_missing' })
+    }
+  )
+
+  // Same staging as above, read through a Linux ABI: node-pty builds spawn-helper only
+  // under binding.gyp's OS=="mac", so demanding one here called every healthy Linux
+  // orcad degraded while its terminals worked (#17844). Gated on a loadable binding for
+  // the same reason as the macOS case; the ABI is what makes it a Linux verdict.
+  it.runIf(process.platform !== 'win32' && realNodePtyLoads)(
+    'does not call a Linux host degraded over a spawn-helper it never execs',
+    () => {
+      const dir = stageNodePty()
+      cpSync(
+        join(REAL_NODE_PTY, 'build', 'Release', 'pty.node'),
+        join(dir, 'build', 'Release', 'pty.node')
+      )
+      expect(existsSync(join(dir, 'build', 'Release', 'spawn-helper'))).toBe(false)
+
+      const verdict = checkNodePtyPrecondition({
+        nodePtyDir: dir,
+        prebuildsDir: null,
+        abi: { platform: 'linux', arch: 'x64', libc: 'glibc', glibcVersion: '2.31', nodeAbi: '127' }
+      })
+
+      expect(verdict).toMatchObject({ status: 'ok', slot: 'linux-x64-glibc' })
+      expect(verdict.reason).toBeUndefined()
     }
   )
 

--- a/src/main/orcad/node-pty-precondition.ts
+++ b/src/main/orcad/node-pty-precondition.ts
@@ -19,6 +19,7 @@ import { existsSync, accessSync, constants } from 'node:fs'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
 import { runProcessSync, type ProcessResult } from '../../shared/child-process/run-process'
+import { usesNodePtySpawnHelper } from '../../shared/node-pty-spawn-helper'
 import type { RuntimeTerminalUnavailableReason } from '../../shared/runtime-types'
 import {
   buildToolchainProbeCommand,
@@ -302,12 +303,12 @@ export function checkNodePtyPrecondition(
     }
   }
 
-  // Loaded. The remaining way terminals fail is spawn-time: node-pty posix_spawns
+  // Loaded. The remaining way terminals fail is spawn-time: on macOS node-pty posix_spawns
   // build/Release/spawn-helper, and a missing one turns every terminal.create into ENOENT
   // on a host that otherwise looks healthy. That is a degradation, not a boot blocker.
   const outcome = readNodePtyProbeOutcome(result)
   const loadedDir = outcome.kind === 'loaded' ? outcome.loadedDir : null
-  if (abi.platform !== 'win32') {
+  if (usesNodePtySpawnHelper(abi.platform)) {
     const helper = join(loadedDir || join(nodePtyDir, 'build', 'Release'), 'spawn-helper')
     if (!isExecutableFile(helper)) {
       return {

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -1,6 +1,7 @@
 import { basename, isAbsolute, join } from 'node:path'
 import { existsSync, accessSync, statSync, chmodSync, constants as fsConstants } from 'node:fs'
 import type * as pty from 'node-pty'
+import { usesNodePtySpawnHelper } from '../../shared/node-pty-spawn-helper'
 import {
   hostReportsChildExitStatus,
   wrapShellSpawnForMacosTccAttribution
@@ -82,9 +83,10 @@ export function resolveUnixShellPath(shellPath: string): string {
  * Why: when Electron packages the app via asar, the native spawn-helper
  * binary may lose its +x permission. This function detects and repairs
  * that so pty.spawn() does not fail with EACCES on first launch.
+ * macOS only — no other platform builds or execs the helper.
  */
 export function ensureNodePtySpawnHelperExecutable(): void {
-  if (didEnsureSpawnHelperExecutable || process.platform === 'win32') {
+  if (didEnsureSpawnHelperExecutable || !usesNodePtySpawnHelper(process.platform)) {
     return
   }
   didEnsureSpawnHelperExecutable = true

--- a/src/shared/node-pty-spawn-helper.test.ts
+++ b/src/shared/node-pty-spawn-helper.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { usesNodePtySpawnHelper } from './node-pty-spawn-helper'
+
+describe('usesNodePtySpawnHelper', () => {
+  it('is macOS only', () => {
+    // The predicate this file exists for: node-pty's binding.gyp declares the
+    // spawn-helper target inside OS=="mac". Reading it as "every non-Windows platform"
+    // is what reported spawn_helper_missing on healthy Linux hosts (#17844).
+    expect(usesNodePtySpawnHelper('darwin')).toBe(true)
+    for (const platform of ['linux', 'win32', 'freebsd', 'openbsd', 'sunos', 'aix']) {
+      expect(usesNodePtySpawnHelper(platform)).toBe(false)
+    }
+  })
+})

--- a/src/shared/node-pty-spawn-helper.ts
+++ b/src/shared/node-pty-spawn-helper.ts
@@ -1,0 +1,11 @@
+/**
+ * Whether node-pty execs its `spawn-helper` binary on a platform.
+ *
+ * Only macOS: binding.gyp declares the `spawn-helper` target inside `OS=="mac"`, and
+ * `src/unix/pty.cc` reads the helper path only under `#if defined(__APPLE__)`. Every
+ * other platform forks directly, so requiring the helper there calls a working host
+ * broken.
+ */
+export function usesNodePtySpawnHelper(platform: string): boolean {
+  return platform === 'darwin'
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

Fixes #17844

## What was wrong

`node-pty` declares the `spawn-helper` target inside `binding.gyp`'s `OS=="mac"` block, and `src/unix/pty.cc` reads the helper path only under `#if defined(__APPLE__)`. Every other platform forks directly and never execs it.

Four places asserted it on `!== 'win32'`:

| Site | Effect |
| --- | --- |
| `src/main/orcad/node-pty-precondition.ts` | returned `degraded` / `spawn_helper_missing` — the user-visible bug |
| `src/main/orcad/node-pty-prebuilt-slot.ts` | `spawnHelper` outcome always `false` off macOS, and pointlessly looked for a helper per slot |
| `src/main/providers/local-pty-utils.ts` | `ensureNodePtySpawnHelperExecutable()` ran a candidate loop that could never match |
| `config/scripts/build-orcad-prebuilds.mjs` | **threw** `spawn-helper missing at …` on a Linux slot build (not named in the issue; found by grepping for the predicate) |

The repo already knew the correct fact elsewhere — `config/scripts/ensure-native-runtime.mjs` and `rebuild-native-deps.mjs` both gate on `=== 'darwin'`, and `src/main/daemon/pty-subprocess/spawn-preflight.ts` has a `preflightMacNodePtySpawnEnvironment()` that returns early off macOS. The four sites above were the ones that disagreed.

## What changed

One shared predicate, `usesNodePtySpawnHelper(platform)` in `src/shared/node-pty-spawn-helper.ts`, carries the *why* in a single place; the three TypeScript sites call it and the build script (which cannot import TS) got the same predicate inline with a matching comment.

Deliberately left alone: `makeNodePtySpawnHelperExecutable()` in `src/main/ssh/ssh-relay-deploy.ts`. It runs `find … -name spawn-helper -exec chmod +x {} +`, which is a silent no-op when there is no helper. It asserts nothing and produces no verdict, so narrowing it would add risk for no behavior change.

## ELI5

When Orca opens a terminal it uses a library called `node-pty`. On macOS — and *only* on macOS — that library needs a small extra program on disk called `spawn-helper` to actually start your shell. On Linux and Windows it starts the shell itself and never looks for that file.

Orca's startup self-check didn't know that. It checked "am I on Windows? no? then the helper must be there" — which is true on a Mac and false on Linux. So every Linux Orca daemon looked for a file that is never built there, didn't find it, and announced itself as **degraded: spawn_helper_missing** — while, in the same boot, its own terminal self-test came back healthy and terminals worked perfectly. It was a working machine wearing a broken-machine sign.

The fix teaches the check the actual rule: *only macOS uses the helper*. Nothing about how terminals start changed — only who gets asked about the file.

## User-facing regressions

None known.

- **macOS** — no change. A loadable `node-pty` with a missing or non-executable `spawn-helper` is a real degradation there and is still reported as `spawn_helper_missing`, still repaired by `ensureNodePtySpawnHelperExecutable()`, and still shipped per slot by the prebuilds builder. This is the case the issue explicitly asked to preserve.
- **Windows** — no change. It was already excluded by the old predicate and is still excluded by the new one.
- **Linux** — the false `spawn_helper_missing` degradation goes away. An orcad host whose `node-pty` loads now reports `ok` instead of `degraded`, which matches what its own pty-spawn self-test already said. Two smaller consequences: `installPrebuiltSlot` now honestly returns `spawnHelper: false` for a Linux slot instead of copying a file nothing execs, and `pnpm build:orcad-prebuilds` no longer throws on a Linux slot build.

One thing worth naming plainly: on Linux this **removes** a startup warning. If some operator's tooling greps boot output for `spawn_helper_missing` as a proxy for "this is a Linux host", that string is gone. It was never true, so nothing real is lost — but it is a visible output change, and the honest place to say so is here.

## Tests

- `src/shared/node-pty-spawn-helper.test.ts` (new) — the predicate is macOS-only across `darwin`, `linux`, `win32`, and the BSDs. Runs everywhere.
- `src/main/orcad/node-pty-prebuilt-slot.test.ts` — the existing "installs the slot binary and spawn-helper" case now runs on a `darwin-arm64` ABI (where the assertion is true), plus a new Linux case proving the outcome reports `spawnHelper: false` and copies no helper. Runs everywhere; fully synthetic fixtures.
- `src/main/orcad/node-pty-precondition.test.ts` — new verdict-level case: a staged `node-pty` with a loadable `pty.node`, no `spawn-helper`, read through a Linux ABI, must come back `ok` with no reason. The pre-existing macOS "degrades rather than blocks" case is now gated to `darwin` (it was gated `!== 'win32'` on a `realNodePtyLoads` probe that itself required a helper — on Linux that gate could never be true, so the case was silently unreachable there).

### Red/green

Reverting only the shared predicate to the old `!== 'win32'` turns three assertions red across all three files:

```
$ sed -i '' "s/return platform === 'darwin'/return platform !== 'win32'/" src/shared/node-pty-spawn-helper.ts
$ npx vitest run --config config/vitest.config.ts \
    src/main/orcad/node-pty-prebuilt-slot.test.ts \
    src/main/orcad/node-pty-precondition.test.ts \
    src/shared/node-pty-spawn-helper.test.ts

 FAIL  src/shared/node-pty-spawn-helper.test.ts > usesNodePtySpawnHelper > is macOS only
 FAIL  src/main/orcad/node-pty-prebuilt-slot.test.ts > installPrebuiltSlot >
       installs a Linux slot without claiming a spawn-helper it never execs
       - "spawnHelper": false
       + "spawnHelper": true
 FAIL  src/main/orcad/node-pty-precondition.test.ts > checkNodePtyPrecondition >
       does not call a Linux host degraded over a spawn-helper it never execs
       - "status": "ok"
       + "status": "degraded"

 Test Files  3 failed (3)
      Tests  3 failed | 26 passed | 1 skipped (30)
EXIT=1
```

Restored:

```
$ sed -i '' "s/return platform !== 'win32'/return platform === 'darwin'/" src/shared/node-pty-spawn-helper.ts
$ npx vitest run --config config/vitest.config.ts \
    src/main/orcad/node-pty-prebuilt-slot.test.ts \
    src/main/orcad/node-pty-precondition.test.ts \
    src/shared/node-pty-spawn-helper.test.ts

 Test Files  3 passed (3)
      Tests  29 passed | 1 skipped (30)
EXIT=0
```

The one skip is pre-existing and unrelated (`probeLocalBuildToolchainHints > reuses the relay diagnosis on Linux`, Linux-only).

The `config/scripts/build-orcad-prebuilds.mjs` site has no test: reaching that line requires a real `node-gyp` compile of `node-pty`, which is not something the unit suite can stage. Its predicate is the same one, verified by reading `binding.gyp`.

### Verification

| Command | Result |
| --- | --- |
| `pnpm tc` | exit 0 |
| `vitest src/main/orcad/ src/main/providers/local-pty-launch-plan.test.ts src/main/daemon/pty-subprocess/` | 19 files passed, 1 skipped; 134 tests passed, 2 skipped; exit 0 |
| the three touched test files | 3 files passed; 29 passed, 1 skipped; exit 0 |
| `pnpm run check:code-quality:changed` | 0 new findings across 8 changed files; exit 0 |
| `oxfmt --check` on all 8 changed files | clean |
