### PR TITLE
docs(linux): say which package to install and how updates arrive

### DIFF
--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -344,11 +344,17 @@ user, especially when the listener is reachable beyond localhost.
 The Linux CLI is named `orca-ide`, not `orca`, so it never shadows the GNOME
 Orca screen reader at `/usr/bin/orca`. The `.deb` and `.rpm` packages put
 `orca-ide` on `PATH` themselves at install time; with the AppImage it arrives
-as `~/.local/bin/orca-ide` when the CLI is registered. On top of that, a
-packaged `orca serve` start also writes a bare `orca` into `~/.local/bin` that
-execs the same launcher — that is why the skills commands below can be typed as
-`orca`. It is skipped when a file Orca does not own already holds that name, so
-a host that really does run the screen reader keeps its own `orca`.
+as `~/.local/bin/orca-ide` when the CLI is registered.
+
+A packaged `orca serve` start also writes a bare `orca` into `~/.local/bin`
+that execs the same launcher, which is why the skills commands below can be
+typed as `orca`. It writes it while starting, so it is never the command that
+starts the server — the first launch is `orca-ide serve`, or the AppImage
+invoked directly as above. The write is best-effort: it is gated on a packaged
+build, it is skipped when no bundled launcher resolves, and it is skipped when
+a file Orca does not own already holds that name (ownership is a marker on the
+second line of the file). A host that really does run the screen reader keeps
+its own `orca`.
 
 ## Pairing troubleshooting
 

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -341,6 +341,15 @@ the command:
 This disables a security boundary. Prefer a dedicated unprivileged service
 user, especially when the listener is reachable beyond localhost.
 
+The Linux CLI is named `orca-ide`, not `orca`, so it never shadows the GNOME
+Orca screen reader at `/usr/bin/orca`. The `.deb` and `.rpm` packages put
+`orca-ide` on `PATH` themselves at install time; with the AppImage it arrives
+as `~/.local/bin/orca-ide` when the CLI is registered. On top of that, a
+packaged `orca serve` start also writes a bare `orca` into `~/.local/bin` that
+execs the same launcher — that is why the skills commands below can be typed as
+`orca`. It is skipped when a file Orca does not own already holds that name, so
+a host that really does run the screen reader keeps its own `orca`.
+
 ## Pairing troubleshooting
 
 - A pairing offer is a capability containing a device credential and E2EE

--- a/docs/site/content/docs/cli/overview.mdx
+++ b/docs/site/content/docs/cli/overview.mdx
@@ -14,7 +14,7 @@ import { Callout } from '@/components/docs/prose'
 
 The Orca CLI is the `orca` command-line interface for scripting a running Orca editor from any shell. Use it to create and inspect worktrees, drive agent terminals, open files and diffs, automate the built-in browser, run scheduled automations, share HTML/Markdown artifacts, and control Orca-native tools from scripts or AI agents.
 
-It ships with the desktop app; register it under [Settings → General → Orca CLI](/docs/settings).
+It ships with the desktop app; register it under [Settings → General → Orca CLI](/docs/settings). On Linux the command is `orca-ide`, because GNOME Orca's screen reader already owns `/usr/bin/orca` — see [Install → Linux](/docs/install#linux).
 
 Agents can install the matching Orca CLI skill with:
 

--- a/docs/site/content/docs/cli/reference.mdx
+++ b/docs/site/content/docs/cli/reference.mdx
@@ -16,6 +16,13 @@ command -v orca
 orca status --json
 ```
 
+<Callout title="On Linux the command is orca-ide">
+  GNOME Orca, the screen reader that ships with most GNOME desktops, already owns `/usr/bin/orca`,
+  so Orca's Linux CLI installs as `orca-ide` instead. Use `orca-ide` in your own shell; bare `orca`
+  works inside Orca's own terminals, and on a headless `orca serve` host. This page writes `orca`
+  throughout — substitute `orca-ide` on Linux. See [Install → Linux](/docs/install#linux).
+</Callout>
+
 If Orca is not already running:
 
 ```bash

--- a/docs/site/content/docs/cli/reference.mdx
+++ b/docs/site/content/docs/cli/reference.mdx
@@ -9,19 +9,28 @@ The `orca` CLI talks to a running Orca runtime. Use it when a shell script or ag
 
 ## Verify the runtime
 
-Register the CLI under [Settings → General → Orca CLI](/docs/settings), then check that it can reach Orca:
+Register the CLI under [Settings → General → Orca CLI](/docs/settings), then check that it can reach Orca.
+
+<Callout title="On Linux the command is orca-ide">
+  GNOME Orca — the screen reader that ships with most GNOME desktops — already owns `/usr/bin/orca`,
+  so Orca's Linux CLI installs as `orca-ide`. Do not check for it with `command -v orca`: that
+  succeeds on a GNOME desktop and resolves to the screen reader, not to Orca. This page writes
+  `orca` throughout — read it as `orca-ide` on Linux. See [Install → Linux](/docs/install#linux).
+</Callout>
+
+On macOS and Windows:
 
 ```bash
 command -v orca
 orca status --json
 ```
 
-<Callout title="On Linux the command is orca-ide">
-  GNOME Orca, the screen reader that ships with most GNOME desktops, already owns `/usr/bin/orca`,
-  so Orca's Linux CLI installs as `orca-ide` instead. Use `orca-ide` in your own shell; bare `orca`
-  works inside Orca's own terminals, and on a headless `orca serve` host. This page writes `orca`
-  throughout — substitute `orca-ide` on Linux. See [Install → Linux](/docs/install#linux).
-</Callout>
+On Linux:
+
+```bash
+command -v orca-ide
+orca-ide status --json
+```
 
 If Orca is not already running:
 

--- a/docs/site/content/docs/install.mdx
+++ b/docs/site/content/docs/install.mdx
@@ -31,7 +31,9 @@ import { Callout } from '@/components/docs/prose'
   </li>
   <li>
     **Linux:**
-    [AppImage](https://github.com/stablyai/orca/releases/latest/download/orca-linux.AppImage) ·
+    AppImage
+    [x64](https://github.com/stablyai/orca/releases/latest/download/orca-linux.AppImage) ·
+    [arm64](https://github.com/stablyai/orca/releases/latest/download/orca-linux-arm64.AppImage) ·
     [.deb](https://github.com/stablyai/orca/releases) ·
     [.rpm](https://github.com/stablyai/orca/releases) — see [Linux](#linux) for which to pick
   </li>
@@ -90,7 +92,7 @@ The default shell can be set to PowerShell or CMD under [Settings → Terminal](
 
 ### Linux
 
-Every release publishes three Linux packages — an **AppImage**, a **`.deb`**, and an **`.rpm`**. They contain the same app. What differs is how updates reach you, so pick on that.
+Each published release ships three Linux packages — an **AppImage**, a **`.deb`**, and an **`.rpm`** — for both x64 and arm64. They contain the same app. What differs is how updates reach you, so pick on that.
 
 | Package      | Pick it when                                              | Updates                                                           |
 | ------------ | --------------------------------------------------------- | ----------------------------------------------------------------- |
@@ -98,21 +100,23 @@ Every release publishes three Linux packages — an **AppImage**, a **`.deb`**, 
 | **`.deb`**   | You manage software with `apt` on Debian or Ubuntu        | Orca tells you a version is out and hands you the install command |
 | **`.rpm`**   | You manage software with `dnf`, `yum`, or `zypper`        | Same as `.deb`                                                    |
 
-The AppImage has a stable download link and needs `chmod +x` before its first run. The `.deb` and `.rpm` filenames carry the version and architecture (`orca-ide_<version>_<arch>.deb`, `orca-ide-<version>.<arch>.rpm`), so take them from the [Releases page](https://github.com/stablyai/orca/releases) rather than a fixed URL.
+The AppImage has a stable download link per architecture — [`orca-linux.AppImage`](https://github.com/stablyai/orca/releases/latest/download/orca-linux.AppImage) for x64 and [`orca-linux-arm64.AppImage`](https://github.com/stablyai/orca/releases/latest/download/orca-linux-arm64.AppImage) for arm64 — and needs `chmod +x` before its first run, because GitHub release assets carry no permission bits. The `.deb` and `.rpm` filenames carry the version and architecture, and the two formats spell architecture differently (`orca-ide_<version>_amd64.deb` or `_arm64.deb`; `orca-ide-<version>.x86_64.rpm` or `.aarch64.rpm`), so take those from the [Releases page](https://github.com/stablyai/orca/releases) rather than a fixed URL.
 
 #### How updating works
 
 **The AppImage self-updates.** Choose it if you want automatic updates. Orca checks for a new release, you click **Update**, and it replaces the AppImage in place — the same flow as macOS and Windows.
 
-**The `.deb` and `.rpm` do not self-update.** Orca still notices the new version and downloads the package, then gives you a **Copy Install Command** button. The command names the file it just downloaded:
+**The `.deb` and `.rpm` do not self-update.** Orca still notices the new version and downloads the package, then gives you a **Copy Install Command** button. Copy it rather than retyping it: Orca resolves every program to an absolute path in a trusted system directory and single-quotes the package path, so what you paste looks like this:
 
 ```
-sudo apt install -- /home/you/.cache/orca-updater/pending/orca-ide_1.4.194_amd64.deb
+/usr/bin/sudo /usr/bin/apt install -- '/home/you/.cache/orca-updater/pending/orca-ide_1.4.194_amd64.deb'
 ```
 
-Run it in your own terminal, then quit and reopen Orca. Orca deliberately never escalates privileges to do this for you: installing a system package needs root, `orca serve` runs as an unprivileged user, and a headless machine has no authentication agent to prompt. VS Code and Signal make the same call on `.deb`.
+Which package manager appears depends on what your system actually has: `apt`, else `dpkg -i`, for a `.deb`; `zypper`, `dnf`, `yum`, then `rpm -Uvh` for an `.rpm`. The download directory follows `XDG_CACHE_HOME` when that is set and falls back to `~/.cache` when it is not.
 
-**A distro-managed build is left alone.** If you are running a repackaged Orca — an AUR build, a Nix derivation, a container image that unpacks the `.deb` — Orca sees that no matching package manager owns this install and stops offering a download it could never apply. It still reports that a new version exists, so you can update the way you normally would.
+**Quit Orca before you run the command**, then reopen it once the install finishes. You are replacing the files of a running application, and the package manager cannot swap them safely underneath a live process. Orca deliberately never escalates privileges to do this for you: installing a system package needs root, `orca serve` runs as an unprivileged user, and a headless machine has no authentication agent to prompt. VS Code and Signal make the same call on `.deb`.
+
+**A distro-managed build is left alone.** If you are running a repackaged Orca — an AUR build, a Nix derivation — Orca sees that no package manager it can drive owns this install and stops offering a download it could never apply. It still reports that a new version exists, so you can update the way you normally would.
 
 <Callout title="Planned: a signed apt/yum repository">
   [#18086](https://github.com/stablyai/orca/issues/18086) tracks publishing a signed repository so
@@ -127,9 +131,9 @@ On Linux the [Orca CLI](/docs/cli/reference) installs as **`orca-ide`**, not `or
 - The `.deb` and `.rpm` put `orca-ide` on your `PATH` at install time, as `/usr/bin/orca-ide`.
 - With the AppImage, register the CLI from [Settings → General → Orca CLI](/docs/settings). That installs `~/.local/bin/orca-ide`.
 - Inside Orca's own terminals, bare `orca` works. Orca puts a shim on the `PATH` of the terminals it manages, so agents and scripts running there use the same command as on macOS and Windows.
-- On a headless [`orca serve`](/docs/remote-servers) host, Orca also installs a bare `orca` into `~/.local/bin`, unless a file it does not own already holds that name.
+- On a headless host, a packaged `orca serve` writes a bare `orca` into `~/.local/bin` as it starts, unless a file it does not own already holds that name. It writes that *during* startup, so it is never what starts the server — the first launch is always [`orca-ide serve`](/docs/remote-servers).
 
-So: `orca-ide` in your own shell, `orca` inside Orca. If you want the short name everywhere and you do not use the screen reader, link it yourself:
+Do not verify with `command -v orca`: on a GNOME desktop that succeeds and resolves to the screen reader. Use `orca-ide` in your own shell and `orca` inside Orca. If you want the short name everywhere and you do not use the screen reader, link it yourself:
 
 ```
 ln -s "$(command -v orca-ide)" ~/.local/bin/orca

--- a/docs/site/content/docs/install.mdx
+++ b/docs/site/content/docs/install.mdx
@@ -32,7 +32,8 @@ import { Callout } from '@/components/docs/prose'
   <li>
     **Linux:**
     [AppImage](https://github.com/stablyai/orca/releases/latest/download/orca-linux.AppImage) ·
-    [.deb](https://github.com/stablyai/orca/releases)
+    [.deb](https://github.com/stablyai/orca/releases) ·
+    [.rpm](https://github.com/stablyai/orca/releases) — see [Linux](#linux) for which to pick
   </li>
   <li>Older versions: [GitHub Releases](https://github.com/stablyai/orca/releases).</li>
 </ul>
@@ -58,6 +59,8 @@ On first launch Orca will:
 ## Updates
 
 Orca auto-updates by default, tracking the **stable** channel. Stable releases are vetted; **RC (release candidate)** builds ship new features first, often daily.
+
+On Linux, whether Orca can apply an update itself depends on which package you installed. See [Linux](#linux) before you pick one.
 
 There is no permanent in-app opt-in for the RC channel. Modifier clicks on **Check for Updates** ([Settings → General → Updates](/docs/settings), or the app / Help menu):
 
@@ -87,4 +90,47 @@ The default shell can be set to PowerShell or CMD under [Settings → Terminal](
 
 ### Linux
 
-AppImage and `.deb` builds are available. See the Releases page for details.
+Every release publishes three Linux packages — an **AppImage**, a **`.deb`**, and an **`.rpm`**. They contain the same app. What differs is how updates reach you, so pick on that.
+
+| Package      | Pick it when                                              | Updates                                                           |
+| ------------ | --------------------------------------------------------- | ----------------------------------------------------------------- |
+| **AppImage** | You want Orca to update itself, like on macOS and Windows | Orca downloads and applies the update in place                    |
+| **`.deb`**   | You manage software with `apt` on Debian or Ubuntu        | Orca tells you a version is out and hands you the install command |
+| **`.rpm`**   | You manage software with `dnf`, `yum`, or `zypper`        | Same as `.deb`                                                    |
+
+The AppImage has a stable download link and needs `chmod +x` before its first run. The `.deb` and `.rpm` filenames carry the version and architecture (`orca-ide_<version>_<arch>.deb`, `orca-ide-<version>.<arch>.rpm`), so take them from the [Releases page](https://github.com/stablyai/orca/releases) rather than a fixed URL.
+
+#### How updating works
+
+**The AppImage self-updates.** Choose it if you want automatic updates. Orca checks for a new release, you click **Update**, and it replaces the AppImage in place — the same flow as macOS and Windows.
+
+**The `.deb` and `.rpm` do not self-update.** Orca still notices the new version and downloads the package, then gives you a **Copy Install Command** button. The command names the file it just downloaded:
+
+```
+sudo apt install -- /home/you/.cache/orca-updater/pending/orca-ide_1.4.194_amd64.deb
+```
+
+Run it in your own terminal, then quit and reopen Orca. Orca deliberately never escalates privileges to do this for you: installing a system package needs root, `orca serve` runs as an unprivileged user, and a headless machine has no authentication agent to prompt. VS Code and Signal make the same call on `.deb`.
+
+**A distro-managed build is left alone.** If you are running a repackaged Orca — an AUR build, a Nix derivation, a container image that unpacks the `.deb` — Orca sees that no matching package manager owns this install and stops offering a download it could never apply. It still reports that a new version exists, so you can update the way you normally would.
+
+<Callout title="Planned: a signed apt/yum repository">
+  [#18086](https://github.com/stablyai/orca/issues/18086) tracks publishing a signed repository so
+  your OS package manager owns Orca updates the way it owns everything else. It does not exist yet —
+  today, `.deb` and `.rpm` updates are the manual step described above.
+</Callout>
+
+#### The CLI command is `orca-ide`
+
+On Linux the [Orca CLI](/docs/cli/reference) installs as **`orca-ide`**, not `orca`. GNOME Orca — the screen reader that ships by default on Ubuntu and other GNOME desktops — already owns `/usr/bin/orca`, and Orca will not shadow it. The `.deb` and `.rpm` packages are named `orca-ide` for the same reason.
+
+- The `.deb` and `.rpm` put `orca-ide` on your `PATH` at install time, as `/usr/bin/orca-ide`.
+- With the AppImage, register the CLI from [Settings → General → Orca CLI](/docs/settings). That installs `~/.local/bin/orca-ide`.
+- Inside Orca's own terminals, bare `orca` works. Orca puts a shim on the `PATH` of the terminals it manages, so agents and scripts running there use the same command as on macOS and Windows.
+- On a headless [`orca serve`](/docs/remote-servers) host, Orca also installs a bare `orca` into `~/.local/bin`, unless a file it does not own already holds that name.
+
+So: `orca-ide` in your own shell, `orca` inside Orca. If you want the short name everywhere and you do not use the screen reader, link it yourself:
+
+```
+ln -s "$(command -v orca-ide)" ~/.local/bin/orca
+```

--- a/docs/site/content/docs/remote-servers.mdx
+++ b/docs/site/content/docs/remote-servers.mdx
@@ -126,6 +126,14 @@ Use `orca serve` when the host should run without the desktop window—for examp
 
 Install Orca and its bundled CLI on the server, then run:
 
+<Callout title="On Linux, start it with orca-ide serve">
+  The Linux CLI is named `orca-ide`, because GNOME Orca's screen reader already owns
+  `/usr/bin/orca`. A packaged `orca serve` does write a bare `orca` into `~/.local/bin`, but only
+  while it is starting, so that shim can never be the command that starts the server. Read
+  `orca serve` as `orca-ide serve` throughout this page when the host is Linux. See
+  [Install → Linux](/docs/install#linux).
+</Callout>
+
 ```bash
 orca serve --pairing-address <server-tailscale-ip-or-hostname>
 ```

--- a/docs/site/content/docs/ways-to-run.mdx
+++ b/docs/site/content/docs/ways-to-run.mdx
@@ -52,10 +52,10 @@ Keep Orca running on a machine you control—an old laptop, Mac mini, home serve
 
 **Easiest setup:** install Orca and Tailscale on both computers. On the server, open **Settings → Remote Orca Servers → Advertise this app as a server → New Link**, choose its Tailscale address, and generate an access link. On the client, choose **Add Server** and paste that link.
 
-For a headless Linux server or service-managed VM, use `orca serve` as the alternative:
+For a headless Linux server or service-managed VM, use `orca serve` as the alternative. On Linux the CLI is named `orca-ide`, so the first launch is:
 
 ```bash
-orca serve --pairing-address <reachable-tailscale-ip-or-hostname>
+orca-ide serve --pairing-address <reachable-tailscale-ip-or-hostname>
 ```
 
 Full detail: [Remote Orca Servers](/docs/remote-servers).


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 |

<!-- /orca-pr-loc -->

Closes #5188. Closes #10987.

## ELI5

You download Orca for Linux and there are three files. The docs told you about two of them and said "see the Releases page for details," which is the documentation equivalent of a shrug. Nothing told you that the choice you are making at that moment is really a choice about updates: the AppImage keeps itself up to date, and the `.deb`/`.rpm` cannot — they hand you a command to run instead.

Then you install it, read the CLI docs, type `orca`, and get command-not-found, because on Linux the command is `orca-ide`. That was written down in exactly one place: an agent skill file, which no human reads.

This PR writes both things down where people actually look.

## What changed

**`docs/site/content/docs/install.mdx`** — the Linux section grows from one sentence into an actual guide:

- A table that picks the package by how you want updates to arrive.
- **AppImage self-updates** in place. Pick it if you want the macOS/Windows experience.
- **`.deb`/`.rpm` do not.** Orca detects the version, downloads the package, and gives you a **Copy Install Command** button. It never escalates privileges to install for you — that needs root, `orca serve` runs unprivileged, and a headless box has no auth agent to prompt. VS Code and Signal make the same call.
- A **distro-managed rebuild** (AUR, Nix, container) is detected and not offered a download it cannot apply.
- `#18086` (signed apt/yum repo) is called out as **planned, not shipped**.
- Added **`.rpm`** to the download list. Release CI builds it (`release-cut.yml`: `--linux AppImage deb rpm`) and `verify-release-required-assets.mjs` requires the artifact — omitting it was a plain bug.

**`docs/site/content/docs/cli/reference.mdx` and `cli/overview.mdx`** — state that the Linux command is `orca-ide`, why (GNOME Orca owns `/usr/bin/orca`), and where bare `orca` does work.

**`docs/reference/headless-linux-server.md`** — same note. This is load-bearing there: the guide's `orca skills install` lines look like typos until you know a packaged `orca serve` start installs a bare-`orca` dispatcher.

## Sequencing — please read before merging

⚠️ **This should land with or after #18100**, not before.

Three claims here — "never escalates privileges", "a distro-managed rebuild is detected", and **"quit Orca before running the install command"** — are **not true on `main` today**. They are true on the merged packaging stack (#17318, #17918), but those merged into stacked branches, not `main`. On `main` right now, `.deb`/`.rpm` updates still attempt a `pkexec`/polkit privileged install via electron-updater's `DebUpdater`/`RpmUpdater`, and the copy-command flow is a *recovery path after that fails* (`src/main/linux-package-install-diagnostic.ts` classifies the polkit failure modes). There is no `externallyManaged` symbol on `main`. The quit ordering is the sharpest of the three: main's recovery card tells the user to run the command and *then* quit, while the stack reverses it to quit-first and retitles the card "Automatic Install Failed" → "Manual Install Required" (`linux-package-downloaded-status.ts` `LINUX_PACKAGE_MANUAL_INSTALL_MESSAGE`). Publishing this page against `main` would therefore hand users the *older* and less safe ordering.

#18100 lands that stack on `main` and is still open. Merging this doc PR first would publish docs that describe behaviour no shipped build has.

Everything else here (package names, `orca-ide`, install paths, `.rpm` being published, the PTY shim, the serve dispatcher) is true on `main` today.

## User-facing regressions

None. Documentation only — no product code, no config, no build inputs. Four Markdown/MDX files.

## Verification

All doc-lock gates pass, before and after:

- `config/scripts/headless-serve-shutdown-workflow.test.mjs` (the `rg -l 'headless-linux-server' config/scripts` hit)
- `src/main/startup/single-instance-lock-headless-exit.test.ts` — also asserts on `headless-linux-server.md`
- `config/scripts/orca-cli-skill-guidance.test.mjs` — prose lock over the `orca-cli` skill
- `docs/site/tests/docs-package.test.mjs` — the only gate over `content/docs/`

`20 passed` on the first three, `13 passed` on the docs-site suite.

