### PR TITLE
feat(terminal): make the contrast floor user-configurable (#10754)

### DIFF
--- a/mobile/src/terminal/terminal-webview-payload-hash.test.ts
+++ b/mobile/src/terminal/terminal-webview-payload-hash.test.ts
@@ -6,8 +6,8 @@ import { XTERM_HTML } from './terminal-webview-html'
 // uncovered region ships silently. A diff here means the emitted WebView source changed —
 // update these values only when that change is deliberate, and only after checking the
 // document still runs. Refactors that merely move slice boundaries must leave them alone.
-const EXPECTED_SHA256 = '42cc000faddc3b58b8fd4855f848c7878f0cd6166c613f66d733645e8e1b9608'
-const EXPECTED_LENGTH = 729776
+const EXPECTED_SHA256 = '5c69dce3236662c381abbfb5d2d6b7163e0f4dd6841d72753733f9470326fee3'
+const EXPECTED_LENGTH = 730428
 
 describe('terminal WebView payload', () => {
   it('composes the expected document', () => {

--- a/mobile/src/terminal/terminal-webview-theme-injected.test.ts
+++ b/mobile/src/terminal/terminal-webview-theme-injected.test.ts
@@ -76,4 +76,43 @@ describe('mobile terminal-webview contrast floor gate', () => {
     context.applyTerminalTheme({ theme: { background: '#1e242a' } })
     expect(term.options.minimumContrastRatio).toBe(DARK_FLOOR)
   })
+
+  // #10754: the desktop user can lower or disable the floor. Mobile mirrors the desktop gate, so the
+  // published value has to win here or the same session renders differently on the phone.
+  describe('published desktop override', () => {
+    function applyOn(term: { options: { minimumContrastRatio: number } }, input: unknown): void {
+      const context = loadThemeInjected({
+        term,
+        document: {
+          documentElement: { style: { background: '' } },
+          body: { style: { background: '' } }
+        }
+      }) as Record<string, unknown> & { applyTerminalTheme: (input: unknown) => void }
+      context.applyTerminalTheme(input)
+    }
+
+    it('uses the published floor instead of the luminance gate', () => {
+      const term = { options: { minimumContrastRatio: 0 } }
+      applyOn(term, { theme: { background: '#1e242a' }, minimumContrastRatio: 1 })
+      expect(term.options.minimumContrastRatio).toBe(1)
+    })
+
+    it("clamps a published floor to xterm's 1-21 window", () => {
+      const term = { options: { minimumContrastRatio: 0 } }
+      applyOn(term, { theme: { background: '#1e242a' }, minimumContrastRatio: 99 })
+      expect(term.options.minimumContrastRatio).toBe(21)
+      applyOn(term, { theme: { background: '#1e242a' }, minimumContrastRatio: 0 })
+      expect(term.options.minimumContrastRatio).toBe(1)
+    })
+
+    it('falls back to the luminance gate for an older host that omits the field', () => {
+      const term = { options: { minimumContrastRatio: 0 } }
+      for (const published of [undefined, null, 'off', Number.NaN]) {
+        applyOn(term, { theme: { background: '#1e242a' }, minimumContrastRatio: published })
+        expect(term.options.minimumContrastRatio).toBe(DARK_FLOOR)
+        applyOn(term, { theme: { background: '#ffffff' }, minimumContrastRatio: published })
+        expect(term.options.minimumContrastRatio).toBe(LIGHT_FLOOR)
+      }
+    })
+  })
 })

--- a/mobile/src/terminal/terminal-webview-theme-injected.ts
+++ b/mobile/src/terminal/terminal-webview-theme-injected.ts
@@ -5,7 +5,8 @@ import { colors } from '../theme/mobile-theme'
 // #7934/#10104): a dark composed background gets a mild floor of 3 to rescue near-background body text
 // (e.g. Antigravity's #262b30 on #1e242a) without over-brightening vibrant ANSI colors; a light
 // background keeps the WCAG-AA 4.5 floor. Gate on the composed background luminance, not app mode,
-// because either theme slot can hold either kind of theme.
+// because either theme slot can hold either kind of theme. An explicit desktop override published on
+// the theme payload (#10754) wins over the luminance gate; older hosts simply omit it.
 export const TERMINAL_WEBVIEW_THEME_JS = `
   var DARK_BG_MIN_CONTRAST = 3;
   var LIGHT_BG_MIN_CONTRAST = 4.5;
@@ -63,6 +64,12 @@ export const TERMINAL_WEBVIEW_THEME_JS = `
     return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
   }
 
+  // Clamp an explicit desktop override to xterm's 1-21 range; null means "no usable override".
+  function normalizeTerminalContrastOverride(value) {
+    if (typeof value !== 'number' || !isFinite(value)) return null;
+    return Math.min(21, Math.max(1, value));
+  }
+
   // Pick the xterm minimumContrastRatio floor from the composed terminal background.
   // Unparseable input defaults to the dark floor so agent output never stays invisible.
   function resolveTerminalContrastFloor(background) {
@@ -100,7 +107,13 @@ export const TERMINAL_WEBVIEW_THEME_JS = `
     var background = terminalTheme.background || '${colors.terminalBg}';
     document.documentElement.style.background = background;
     document.body.style.background = background;
-    terminalMinimumContrastRatio = resolveTerminalContrastFloor(background);
+    // Why prefer the published value: the desktop user may have lowered or disabled the floor (#10754);
+    // an older host omits the field and the luminance gate stays authoritative.
+    var publishedFloor = normalizeTerminalContrastOverride(
+      input && typeof input === 'object' ? input.minimumContrastRatio : undefined
+    );
+    terminalMinimumContrastRatio =
+      publishedFloor === null ? resolveTerminalContrastFloor(background) : publishedFloor;
     if (term) {
       term.options.theme = terminalTheme;
       term.options.minimumContrastRatio = terminalMinimumContrastRatio;

--- a/src/main/persistence/applying-settings/settings-update-terminal-contrast.test.ts
+++ b/src/main/persistence/applying-settings/settings-update-terminal-contrast.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import { updateSettings, type SettingsMutationOperations } from './settings-update'
+
+function makeOperations(): SettingsMutationOperations {
+  return {
+    // Only the fields updateSettings reads; the rest of GlobalSettings is irrelevant to the clamp.
+    state: { settings: { terminalFontSize: 14 }, repos: [] } as unknown as PersistedState,
+    bumpLocalWorktreeScanGeneration: vi.fn(),
+    removeRetainedBlob: vi.fn(),
+    scheduleSave: vi.fn(),
+    notifySettingsChanged: vi.fn()
+  }
+}
+
+// #10754: desktop IPC, the web RPC and the CLI all reach the store through this boundary, and xterm
+// throws on a non-finite minimumContrastRatio, so the clamp cannot live in the settings UI alone.
+describe('updateSettings terminalMinimumContrastRatio', () => {
+  it('persists an in-range floor unchanged', () => {
+    const operations = makeOperations()
+
+    expect(
+      updateSettings(operations, { terminalMinimumContrastRatio: 1 }).terminalMinimumContrastRatio
+    ).toBe(1)
+    expect(
+      updateSettings(operations, { terminalMinimumContrastRatio: 4.5 }).terminalMinimumContrastRatio
+    ).toBe(4.5)
+  })
+
+  it('clamps a hand-edited value into xterm range', () => {
+    const operations = makeOperations()
+
+    expect(
+      updateSettings(operations, { terminalMinimumContrastRatio: 0 }).terminalMinimumContrastRatio
+    ).toBe(1)
+    expect(
+      updateSettings(operations, { terminalMinimumContrastRatio: 500 }).terminalMinimumContrastRatio
+    ).toBe(21)
+  })
+
+  it('drops an unusable value back to automatic rather than storing it', () => {
+    const operations = makeOperations()
+
+    expect(
+      updateSettings(operations, {
+        terminalMinimumContrastRatio: Number.NaN
+      }).terminalMinimumContrastRatio
+    ).toBeUndefined()
+    expect(
+      updateSettings(operations, {
+        terminalMinimumContrastRatio: 'off' as unknown as number
+      }).terminalMinimumContrastRatio
+    ).toBeUndefined()
+  })
+
+  it('clears the override so the automatic floor comes back', () => {
+    const operations = makeOperations()
+
+    updateSettings(operations, { terminalMinimumContrastRatio: 1 })
+    expect(
+      updateSettings(operations, { terminalMinimumContrastRatio: undefined })
+        .terminalMinimumContrastRatio
+    ).toBeUndefined()
+  })
+
+  it('leaves a stored floor alone when an unrelated setting is written', () => {
+    const operations = makeOperations()
+
+    updateSettings(operations, { terminalMinimumContrastRatio: 1 })
+    expect(updateSettings(operations, { terminalFontSize: 15 }).terminalMinimumContrastRatio).toBe(
+      1
+    )
+  })
+})

--- a/src/main/persistence/applying-settings/settings-update.ts
+++ b/src/main/persistence/applying-settings/settings-update.ts
@@ -9,6 +9,7 @@ import { normalizeTerminalQuickCommands } from '../../../shared/terminal-quick-c
 import { normalizeTerminalCustomThemes } from '../../../shared/terminal-custom-themes'
 import { normalizeTerminalCursorStyleDefault } from '../../../shared/terminal-cursor-style-settings'
 import { normalizeDesktopTerminalScrollbackRows } from '../../../shared/terminal-scrollback-policy'
+import { normalizeTerminalMinimumContrastRatio } from '../../../shared/terminal-minimum-contrast-settings'
 import { normalizeTaskProviderSettings } from '../../../shared/task-providers'
 import { normalizeOpenInApplications } from '../../../shared/open-in-applications'
 import { normalizeTerminalShortcutPolicy } from '../../../shared/keybindings'
@@ -121,6 +122,13 @@ export function updateSettings(
   if ('terminalScrollbackRows' in updates) {
     sanitizedUpdates.terminalScrollbackRows = normalizeDesktopTerminalScrollbackRows(
       updates.terminalScrollbackRows
+    )
+  }
+  // Why here: every writer (desktop IPC, web RPC, CLI) crosses this boundary, so xterm can never be
+  // handed an out-of-range floor, and undefined stays undefined to mean "automatic" (#10754).
+  if ('terminalMinimumContrastRatio' in updates) {
+    sanitizedUpdates.terminalMinimumContrastRatio = normalizeTerminalMinimumContrastRatio(
+      updates.terminalMinimumContrastRatio
     )
   }
   if (

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-options.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-options.test.ts
@@ -58,6 +58,43 @@ describe('buildPreviewTerminalOptions', () => {
     scrollback: 1000
   }
 
+  // #10754: the dashboard preview renders the agent's live buffer, so it has to reproduce the same
+  // contrast floor the pane used or a Powerline statusline looks different in the popout.
+  it('mirrors the automatic contrast floor when no override is set', () => {
+    expect(
+      buildPreviewTerminalOptions({
+        ...base,
+        terminalInput: null,
+        theme: { background: '#1e242a' }
+      }).minimumContrastRatio
+    ).toBe(3)
+    expect(
+      buildPreviewTerminalOptions({
+        ...base,
+        terminalInput: null,
+        theme: { background: '#ffffff' },
+        themeMode: 'light'
+      }).minimumContrastRatio
+    ).toBe(4.5)
+  })
+
+  it('honors the user contrast override, clamped to xterm range', () => {
+    expect(
+      buildPreviewTerminalOptions({
+        ...base,
+        terminalInput: null,
+        settings: { ...SETTINGS, terminalMinimumContrastRatio: 1 }
+      }).minimumContrastRatio
+    ).toBe(1)
+    expect(
+      buildPreviewTerminalOptions({
+        ...base,
+        terminalInput: null,
+        settings: { ...SETTINGS, terminalMinimumContrastRatio: 0 }
+      }).minimumContrastRatio
+    ).toBe(1)
+  })
+
   it('keeps the kitty advertisement and skips ConPTY options off Windows', () => {
     const options = buildPreviewTerminalOptions({
       ...base,

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-options.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-options.ts
@@ -80,7 +80,8 @@ export function buildPreviewTerminalOptions(args: {
     theme: args.theme ?? undefined,
     minimumContrastRatio: resolveTerminalMinimumContrastRatio(
       args.theme?.background,
-      args.themeMode
+      args.themeMode,
+      args.settings?.terminalMinimumContrastRatio
     )
   }
 }

--- a/src/renderer/src/components/settings/SettingsFormControls.number-field.test.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.number-field.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { NumberField } from './SettingsFormControls'
+
+afterEach(cleanup)
+
+// #10754: an optional setting needs a way back to "unset". Without a clear path the field can pin a
+// value but never restore Orca's automatic behavior, which is the state most users should be in.
+describe('NumberField clearable fields', () => {
+  it('renders the placeholder and commits nothing while the value is unset', () => {
+    render(
+      <NumberField
+        label="Minimum Contrast Ratio"
+        description=""
+        value={undefined}
+        min={1}
+        max={21}
+        placeholder="Auto"
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+      />
+    )
+
+    const input = screen.getByLabelText('Minimum Contrast Ratio') as HTMLInputElement
+    expect(input.value).toBe('')
+    expect(input.getAttribute('placeholder')).toBe('Auto')
+  })
+
+  it('clears the setting when the field is emptied', () => {
+    const onChange = vi.fn()
+    const onClear = vi.fn()
+    render(
+      <NumberField
+        label="Minimum Contrast Ratio"
+        description=""
+        value={1}
+        min={1}
+        max={21}
+        placeholder="Auto"
+        onChange={onChange}
+        onClear={onClear}
+      />
+    )
+
+    const input = screen.getByLabelText('Minimum Contrast Ratio')
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+
+    expect(onClear).toHaveBeenCalledTimes(1)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('still snaps back to the current value when the field is not clearable', () => {
+    const onChange = vi.fn()
+    render(<NumberField label="Font Size" description="" value={14} min={6} onChange={onChange} />)
+
+    const input = screen.getByLabelText('Font Size') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input.value).toBe('14')
+  })
+
+  it('clamps a committed value into the min/max window', () => {
+    const onChange = vi.fn()
+    render(
+      <NumberField
+        label="Minimum Contrast Ratio"
+        description=""
+        value={undefined}
+        min={1}
+        max={21}
+        onChange={onChange}
+        onClear={vi.fn()}
+      />
+    )
+
+    const input = screen.getByLabelText('Minimum Contrast Ratio')
+    fireEvent.change(input, { target: { value: '99' } })
+    fireEvent.blur(input)
+
+    expect(onChange).toHaveBeenCalledWith(21)
+  })
+})

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -262,13 +262,17 @@ type ColorFieldProps = {
 type NumberFieldProps = {
   label: string
   description: string
-  value: number
+  /** undefined renders the field empty — pair it with `placeholder` and `onClear` for an unset state. */
+  value: number | undefined
   defaultValue?: number
   min: number
   max?: number
   step?: number
   integer?: boolean
   onChange: (value: number) => void
+  /** When set, emptying the field clears the setting instead of snapping back to the current value. */
+  onClear?: () => void
+  placeholder?: string
   suffix?: string
   className?: string
 }
@@ -316,6 +320,8 @@ export function NumberField({
   step = 1,
   integer = false,
   onChange,
+  onClear,
+  placeholder,
   suffix,
   className
 }: NumberFieldProps): React.JSX.Element {
@@ -331,6 +337,11 @@ export function NumberField({
   const commit = (): void => {
     const trimmed = draft.trim()
     if (trimmed === '') {
+      if (onClear) {
+        // Clearable fields treat empty as "unset" so the caller can fall back to its automatic value.
+        onClear()
+        return
+      }
       // Empty input — reset to current value rather than committing 0
       setDraft(Number.isFinite(value) ? String(value) : '')
       return
@@ -369,6 +380,7 @@ export function NumberField({
             max={max}
             step={step}
             aria-label={label}
+            placeholder={placeholder}
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
             onBlur={commit}

--- a/src/renderer/src/components/settings/TerminalContrastSetting.test.tsx
+++ b/src/renderer/src/components/settings/TerminalContrastSetting.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+import { useState } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { TerminalContrastSetting } from './TerminalContrastSetting'
+
+vi.mock('./SearchableSetting', () => ({ SearchableSetting: ({ children }) => children }))
+afterEach(cleanup)
+
+function mount(initial: number | undefined = undefined): ReturnType<typeof vi.fn> {
+  const persist = vi.fn()
+  function Harness(): React.JSX.Element {
+    const [settings, setSettings] = useState({
+      terminalMinimumContrastRatio: initial
+    } as GlobalSettings)
+    return (
+      <TerminalContrastSetting
+        settings={settings}
+        updateSettings={(patch) => {
+          persist(patch)
+          setSettings((previous) => ({ ...previous, ...patch }))
+        }}
+      />
+    )
+  }
+  render(<Harness />)
+  return persist
+}
+
+describe('terminal contrast modes', () => {
+  it('lets users turn correction off and restore automatic without editing a number', () => {
+    const persist = mount()
+    expect(screen.getByRole('radio', { name: 'Automatic' }).getAttribute('aria-checked')).toBe(
+      'true'
+    )
+    expect(screen.queryByRole('spinbutton')).toBeNull()
+    fireEvent.click(screen.getByRole('radio', { name: 'Off' }))
+    expect(persist).toHaveBeenLastCalledWith({ terminalMinimumContrastRatio: 1 })
+    expect(screen.queryByRole('spinbutton')).toBeNull()
+    fireEvent.click(screen.getByRole('radio', { name: 'Automatic' }))
+    expect(persist).toHaveBeenLastCalledWith({ terminalMinimumContrastRatio: undefined })
+  })
+
+  it('restores the custom target when toggling through off and automatic', () => {
+    const persist = mount(7)
+    fireEvent.click(screen.getByRole('radio', { name: 'Off' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Automatic' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Custom' }))
+    expect(persist).toHaveBeenLastCalledWith({ terminalMinimumContrastRatio: 7 })
+    expect((screen.getByRole('spinbutton') as HTMLInputElement).value).toBe('7')
+  })
+
+  it('starts custom at a usable target and bounds precise input', () => {
+    const persist = mount()
+    fireEvent.click(screen.getByRole('radio', { name: 'Custom' }))
+    expect(persist).toHaveBeenLastCalledWith({ terminalMinimumContrastRatio: 4.5 })
+    const input = screen.getByRole('spinbutton')
+    fireEvent.change(input, { target: { value: '99' } })
+    fireEvent.blur(input)
+    expect(persist).toHaveBeenLastCalledWith({ terminalMinimumContrastRatio: 21 })
+    fireEvent.change(input, { target: { value: '1' } })
+    fireEvent.blur(input)
+    expect(screen.getByRole('radio', { name: 'Off' }).getAttribute('aria-checked')).toBe('true')
+  })
+})

--- a/src/renderer/src/components/settings/TerminalContrastSetting.tsx
+++ b/src/renderer/src/components/settings/TerminalContrastSetting.tsx
@@ -1,0 +1,137 @@
+import { useRef, useState } from 'react'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { Slider } from '../ui/slider'
+import { NumberField, SettingsRow, SettingsSegmentedControl } from './SettingsFormControls'
+import { SearchableSetting } from './SearchableSetting'
+import {
+  LIGHT_BG_MIN_CONTRAST,
+  MIN_TERMINAL_CONTRAST_RATIO,
+  MAX_TERMINAL_CONTRAST_RATIO,
+  normalizeTerminalMinimumContrastRatio
+} from '@/lib/terminal-contrast-correction'
+import { translate } from '@/i18n/i18n'
+
+type ContrastMode = 'auto' | 'off' | 'custom'
+
+type Props = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function TerminalContrastSetting({ settings, updateSettings }: Props): React.JSX.Element {
+  const value = normalizeTerminalMinimumContrastRatio(settings.terminalMinimumContrastRatio)
+  const mode: ContrastMode = value === undefined ? 'auto' : value === 1 ? 'off' : 'custom'
+  const lastCustomValue = useRef(LIGHT_BG_MIN_CONTRAST)
+  const [draft, setDraft] = useState(value ?? LIGHT_BG_MIN_CONTRAST)
+  const [previousValue, setPreviousValue] = useState(value)
+  if (value !== previousValue) {
+    setPreviousValue(value)
+    setDraft(value ?? LIGHT_BG_MIN_CONTRAST)
+  }
+  const title = translate('auto.components.settings.contrast.title', 'Color Contrast')
+  const description = translate(
+    'auto.components.settings.contrast.description',
+    'Improve text readability or preserve the colors chosen by terminal programs.'
+  )
+  const ratioLabel = translate('auto.components.settings.contrast.ratio', 'Contrast target')
+  const selectMode = (next: ContrastMode): void => {
+    if (mode === 'custom' && value !== undefined) {
+      lastCustomValue.current = value
+    }
+    updateSettings({
+      terminalMinimumContrastRatio:
+        next === 'auto' ? undefined : next === 'off' ? 1 : lastCustomValue.current
+    })
+  }
+
+  return (
+    <SearchableSetting
+      title={title}
+      description={description}
+      keywords={[
+        'terminal',
+        'contrast',
+        'minimum',
+        'ratio',
+        'readability',
+        'accessibility',
+        'wcag',
+        'powerline',
+        'statusline',
+        'dim',
+        'washed out',
+        'colors'
+      ]}
+    >
+      <SettingsRow
+        label={title}
+        description={
+          mode === 'auto'
+            ? translate(
+                'auto.components.settings.contrast.autoDescription',
+                'Balances readability with your terminal theme. Recommended.'
+              )
+            : mode === 'off'
+              ? translate(
+                  'auto.components.settings.contrast.offDescription',
+                  'Keeps program colors unchanged, including dim text and Powerline separators.'
+                )
+              : translate(
+                  'auto.components.settings.contrast.customDescription',
+                  'Choose how much to increase contrast between text and its background.'
+                )
+        }
+        className="flex-wrap [&>div:first-child]:min-w-48"
+        control={
+          <SettingsSegmentedControl<ContrastMode>
+            ariaLabel={title}
+            value={mode}
+            onChange={selectMode}
+            options={[
+              {
+                value: 'auto',
+                label: translate('auto.components.settings.contrast.auto', 'Automatic')
+              },
+              { value: 'off', label: translate('auto.components.settings.contrast.off', 'Off') },
+              {
+                value: 'custom',
+                label: translate('auto.components.settings.contrast.custom', 'Custom')
+              }
+            ]}
+          />
+        }
+      />
+      {mode === 'custom' && (
+        <div className="space-y-3 pb-4">
+          <NumberField
+            label={ratioLabel}
+            description={translate(
+              'auto.components.settings.contrast.targetDescription',
+              'Higher values increase contrast where possible. Background colors stay unchanged.'
+            )}
+            value={draft}
+            min={MIN_TERMINAL_CONTRAST_RATIO}
+            max={MAX_TERMINAL_CONTRAST_RATIO}
+            step={0.1}
+            suffix=":1"
+            onChange={(ratio) => updateSettings({ terminalMinimumContrastRatio: ratio })}
+          />
+          <Slider
+            value={[draft]}
+            min={MIN_TERMINAL_CONTRAST_RATIO + 0.1}
+            max={MAX_TERMINAL_CONTRAST_RATIO}
+            step={0.1}
+            thumbLabels={[ratioLabel]}
+            thumbValueLabels={[`${draft}:1`]}
+            onValueChange={([ratio]) => setDraft(ratio)}
+            onValueCommit={([ratio]) => updateSettings({ terminalMinimumContrastRatio: ratio })}
+          />
+          <div className="flex justify-between text-xs text-muted-foreground">
+            <span>{translate('auto.components.settings.contrast.subtle', 'Subtle')}</span>
+            <span>{translate('auto.components.settings.contrast.strong', 'Strong')}</span>
+          </div>
+        </div>
+      )}
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/TerminalRenderingSection.tsx
+++ b/src/renderer/src/components/settings/TerminalRenderingSection.tsx
@@ -1,11 +1,42 @@
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import {
+  NumberField,
   SettingsRow,
   SettingsSegmentedControl,
   SettingsSubsectionHeader
 } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
+import {
+  DARK_BG_MIN_CONTRAST,
+  LIGHT_BG_MIN_CONTRAST,
+  MAX_TERMINAL_CONTRAST_RATIO,
+  MIN_TERMINAL_CONTRAST_RATIO,
+  normalizeTerminalMinimumContrastRatio
+} from '@/lib/terminal-contrast-correction'
 import { translate } from '@/i18n/i18n'
+
+// Why spell out the automatic pair: the effective floor depends on the composed pane background, so
+// the row can only describe the rule, not a single number.
+function describeMinimumContrastRatio(value: number | undefined): string {
+  if (value === undefined) {
+    return translate(
+      'auto.components.settings.TerminalPane.minimumContrast.automatic',
+      'Automatic: {{light}} on light backgrounds, {{dark}} on dark.',
+      { light: LIGHT_BG_MIN_CONTRAST, dark: DARK_BG_MIN_CONTRAST }
+    )
+  }
+  if (value === MIN_TERMINAL_CONTRAST_RATIO) {
+    return translate(
+      'auto.components.settings.TerminalPane.minimumContrast.disabled',
+      'Correction off. Programs that rely on low contrast, like Powerline separators, render as sent.'
+    )
+  }
+  return translate(
+    'auto.components.settings.TerminalPane.minimumContrast.pinned',
+    'Foreground colors are lifted until they reach {{ratio}}:1 against the background.',
+    { ratio: value }
+  )
+}
 
 type TerminalRenderingSectionProps = {
   settings: GlobalSettings
@@ -16,6 +47,10 @@ export function TerminalRenderingSection({
   settings,
   updateSettings
 }: TerminalRenderingSectionProps): React.JSX.Element {
+  const effectiveMinimumContrastRatio = normalizeTerminalMinimumContrastRatio(
+    settings.terminalMinimumContrastRatio
+  )
+
   return (
     <section key="rendering" className="space-y-3">
       <SettingsSubsectionHeader
@@ -89,6 +124,53 @@ export function TerminalRenderingSection({
                 ]}
               />
             }
+          />
+        </SearchableSetting>
+
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.TerminalPane.minimumContrast.title',
+            'Minimum Contrast Ratio'
+          )}
+          description={translate(
+            'auto.components.settings.TerminalPane.minimumContrast.description',
+            'Lifts terminal foreground colors that sit too close to the background. Leave blank for automatic, or set 1 to render program colors exactly as sent.'
+          )}
+          keywords={[
+            'terminal',
+            'contrast',
+            'minimum',
+            'ratio',
+            'readability',
+            'accessibility',
+            'wcag',
+            'powerline',
+            'statusline',
+            'dim',
+            'washed out',
+            'colors'
+          ]}
+        >
+          <NumberField
+            label={translate(
+              'auto.components.settings.TerminalPane.minimumContrast.title',
+              'Minimum Contrast Ratio'
+            )}
+            description={describeMinimumContrastRatio(effectiveMinimumContrastRatio)}
+            value={effectiveMinimumContrastRatio}
+            min={MIN_TERMINAL_CONTRAST_RATIO}
+            max={MAX_TERMINAL_CONTRAST_RATIO}
+            step={0.5}
+            placeholder={translate(
+              'auto.components.settings.TerminalPane.minimumContrast.placeholder',
+              'Auto'
+            )}
+            suffix={translate(
+              'auto.components.settings.TerminalPane.minimumContrast.suffix',
+              'blank = automatic, 1 = off'
+            )}
+            onChange={(value) => updateSettings({ terminalMinimumContrastRatio: value })}
+            onClear={() => updateSettings({ terminalMinimumContrastRatio: undefined })}
           />
         </SearchableSetting>
       </div>

--- a/src/renderer/src/components/settings/TerminalRenderingSection.tsx
+++ b/src/renderer/src/components/settings/TerminalRenderingSection.tsx
@@ -33,7 +33,7 @@ function describeMinimumContrastRatio(value: number | undefined): string {
   }
   return translate(
     'auto.components.settings.TerminalPane.minimumContrast.pinned',
-    'Foreground colors are lifted until they reach {{ratio}}:1 against the background.',
+    'Targets {{ratio}}:1 contrast for foreground colors, where possible.',
     { ratio: value }
   )
 }

--- a/src/renderer/src/components/settings/TerminalRenderingSection.tsx
+++ b/src/renderer/src/components/settings/TerminalRenderingSection.tsx
@@ -1,42 +1,12 @@
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import {
-  NumberField,
   SettingsRow,
   SettingsSegmentedControl,
   SettingsSubsectionHeader
 } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
-import {
-  DARK_BG_MIN_CONTRAST,
-  LIGHT_BG_MIN_CONTRAST,
-  MAX_TERMINAL_CONTRAST_RATIO,
-  MIN_TERMINAL_CONTRAST_RATIO,
-  normalizeTerminalMinimumContrastRatio
-} from '@/lib/terminal-contrast-correction'
+import { TerminalContrastSetting } from './TerminalContrastSetting'
 import { translate } from '@/i18n/i18n'
-
-// Why spell out the automatic pair: the effective floor depends on the composed pane background, so
-// the row can only describe the rule, not a single number.
-function describeMinimumContrastRatio(value: number | undefined): string {
-  if (value === undefined) {
-    return translate(
-      'auto.components.settings.TerminalPane.minimumContrast.automatic',
-      'Automatic: {{light}} on light backgrounds, {{dark}} on dark.',
-      { light: LIGHT_BG_MIN_CONTRAST, dark: DARK_BG_MIN_CONTRAST }
-    )
-  }
-  if (value === MIN_TERMINAL_CONTRAST_RATIO) {
-    return translate(
-      'auto.components.settings.TerminalPane.minimumContrast.disabled',
-      'Correction off. Programs that rely on low contrast, like Powerline separators, render as sent.'
-    )
-  }
-  return translate(
-    'auto.components.settings.TerminalPane.minimumContrast.pinned',
-    'Targets {{ratio}}:1 contrast for foreground colors, where possible.',
-    { ratio: value }
-  )
-}
 
 type TerminalRenderingSectionProps = {
   settings: GlobalSettings
@@ -47,10 +17,6 @@ export function TerminalRenderingSection({
   settings,
   updateSettings
 }: TerminalRenderingSectionProps): React.JSX.Element {
-  const effectiveMinimumContrastRatio = normalizeTerminalMinimumContrastRatio(
-    settings.terminalMinimumContrastRatio
-  )
-
   return (
     <section key="rendering" className="space-y-3">
       <SettingsSubsectionHeader
@@ -127,52 +93,7 @@ export function TerminalRenderingSection({
           />
         </SearchableSetting>
 
-        <SearchableSetting
-          title={translate(
-            'auto.components.settings.TerminalPane.minimumContrast.title',
-            'Minimum Contrast Ratio'
-          )}
-          description={translate(
-            'auto.components.settings.TerminalPane.minimumContrast.description',
-            'Lifts terminal foreground colors that sit too close to the background. Leave blank for automatic, or set 1 to render program colors exactly as sent.'
-          )}
-          keywords={[
-            'terminal',
-            'contrast',
-            'minimum',
-            'ratio',
-            'readability',
-            'accessibility',
-            'wcag',
-            'powerline',
-            'statusline',
-            'dim',
-            'washed out',
-            'colors'
-          ]}
-        >
-          <NumberField
-            label={translate(
-              'auto.components.settings.TerminalPane.minimumContrast.title',
-              'Minimum Contrast Ratio'
-            )}
-            description={describeMinimumContrastRatio(effectiveMinimumContrastRatio)}
-            value={effectiveMinimumContrastRatio}
-            min={MIN_TERMINAL_CONTRAST_RATIO}
-            max={MAX_TERMINAL_CONTRAST_RATIO}
-            step={0.5}
-            placeholder={translate(
-              'auto.components.settings.TerminalPane.minimumContrast.placeholder',
-              'Auto'
-            )}
-            suffix={translate(
-              'auto.components.settings.TerminalPane.minimumContrast.suffix',
-              'blank = automatic, 1 = off'
-            )}
-            onChange={(value) => updateSettings({ terminalMinimumContrastRatio: value })}
-            onClear={() => updateSettings({ terminalMinimumContrastRatio: undefined })}
-          />
-        </SearchableSetting>
+        <TerminalContrastSetting settings={settings} updateSettings={updateSettings} />
       </div>
     </section>
   )

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -206,7 +206,8 @@ export function TerminalSettingsPreview({
     // Why: share applyTerminalAppearance's gating helper (#7934) so the preview can't drift from live panes.
     terminal.options.minimumContrastRatio = resolveTerminalMinimumContrastRatio(
       composedTheme.background,
-      effectiveMode
+      effectiveMode,
+      settings.terminalMinimumContrastRatio
     )
     // Why: xterm renders an alpha-channel background opaque unless allowTransparency is set (matches applyTerminalAppearance).
     terminal.options.allowTransparency =
@@ -218,7 +219,12 @@ export function TerminalSettingsPreview({
     // Why reset() not clear(): buffer ends mid-line on the prompt, so clear()+write would duplicate the trailing fragment.
     terminal.reset()
     terminal.write(PREVIEW_BUFFER)
-  }, [composedTheme, effectiveMode, settings.terminalBackgroundOpacity])
+  }, [
+    composedTheme,
+    effectiveMode,
+    settings.terminalBackgroundOpacity,
+    settings.terminalMinimumContrastRatio
+  ])
 
   useEffect(() => {
     const terminal = terminalRef.current

--- a/src/renderer/src/components/settings/setting-labels.ts
+++ b/src/renderer/src/components/settings/setting-labels.ts
@@ -10,6 +10,7 @@ export const SETTING_LABELS: Partial<Record<keyof GlobalSettings, string>> = {
   terminalFastScrollSensitivity: 'Fast Scroll Speed',
   terminalTuiScrollSensitivity: 'TUI Scroll Speed',
   terminalBackgroundOpacity: 'Background Opacity',
+  terminalMinimumContrastRatio: 'Minimum Contrast Ratio',
   terminalCursorStyle: 'Cursor Style',
   terminalCursorBlink: 'Cursor Blink',
   terminalCursorOpacity: 'Cursor Opacity',

--- a/src/renderer/src/components/settings/setting-labels.ts
+++ b/src/renderer/src/components/settings/setting-labels.ts
@@ -10,7 +10,7 @@ export const SETTING_LABELS: Partial<Record<keyof GlobalSettings, string>> = {
   terminalFastScrollSensitivity: 'Fast Scroll Speed',
   terminalTuiScrollSensitivity: 'TUI Scroll Speed',
   terminalBackgroundOpacity: 'Background Opacity',
-  terminalMinimumContrastRatio: 'Minimum Contrast Ratio',
+  terminalMinimumContrastRatio: 'Color Contrast',
   terminalCursorStyle: 'Cursor Style',
   terminalCursorBlink: 'Cursor Blink',
   terminalCursorOpacity: 'Cursor Opacity',

--- a/src/renderer/src/components/settings/terminal-typography-search.ts
+++ b/src/renderer/src/components/settings/terminal-typography-search.ts
@@ -128,6 +128,55 @@ export const getTerminalRenderingSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword('auto.components.settings.terminal.search.7d924d870d', 'graphics'),
       ...translateSearchKeyword('auto.components.settings.terminal.search.1abcf4d7de', 'linux')
     ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.terminal.search.minimumContrast.title',
+      'Minimum Contrast Ratio'
+    ),
+    description: translate(
+      'auto.components.settings.terminal.search.minimumContrast.description',
+      'Lifts terminal foreground colors that sit too close to the background. Leave blank for automatic, or set 1 to render program colors exactly as sent.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.terminal.search.f66a7cf715', 'terminal'),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrast.contrast',
+        'contrast'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrast.minimum',
+        'minimum'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrast.ratio',
+        'ratio'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrast.readability',
+        'readability'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrast.wcag',
+        'wcag'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrast.powerline',
+        'powerline'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrast.statusline',
+        'statusline'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrast.dim',
+        'dim'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrast.colors',
+        'colors'
+      )
+    ]
   }
 ])
 

--- a/src/renderer/src/components/settings/terminal-typography-search.ts
+++ b/src/renderer/src/components/settings/terminal-typography-search.ts
@@ -132,11 +132,11 @@ export const getTerminalRenderingSearchEntries = createLocalizedCatalog(() => [
   {
     title: translate(
       'auto.components.settings.terminal.search.minimumContrast.title',
-      'Minimum Contrast Ratio'
+      'Color Contrast'
     ),
     description: translate(
       'auto.components.settings.terminal.search.minimumContrast.description',
-      'Lifts terminal foreground colors that sit too close to the background. Leave blank for automatic, or set 1 to render program colors exactly as sent.'
+      'Improve text readability or preserve the colors chosen by terminal programs.'
     ),
     keywords: [
       ...translateSearchKeyword('auto.components.settings.terminal.search.f66a7cf715', 'terminal'),

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -268,6 +268,46 @@ describe('applyTerminalAppearance theme assignment', () => {
     expect(pane.terminal.options.minimumContrastRatio).toBe(4.5)
   })
 
+  // #10754: a Powerline statusline draws its segment separators in the neighbouring segment's
+  // background color, so the automatic floor turns every invisible seam into a bright line.
+  it('lets the user setting disable contrast correction on a dark theme', () => {
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, theme: 'dark', terminalMinimumContrastRatio: 1 })
+
+    expect(pane.terminal.options.minimumContrastRatio).toBe(1)
+  })
+
+  it('lets the user setting override the light-background floor as well', () => {
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, theme: 'light', terminalMinimumContrastRatio: 1 })
+
+    expect(pane.terminal.options.minimumContrastRatio).toBe(1)
+  })
+
+  it('clamps an out-of-range user setting before it reaches xterm', () => {
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, theme: 'dark', terminalMinimumContrastRatio: 99 })
+
+    expect(pane.terminal.options.minimumContrastRatio).toBe(21)
+  })
+
+  it('returns to the automatic floor when the user setting is cleared live', () => {
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, theme: 'dark', terminalMinimumContrastRatio: 1 })
+    expect(pane.terminal.options.minimumContrastRatio).toBe(1)
+
+    apply(pane, { ...settings, theme: 'dark', terminalMinimumContrastRatio: undefined })
+    expect(pane.terminal.options.minimumContrastRatio).toBe(3)
+  })
+
   it('skips the minimumContrastRatio write on a no-op re-apply (preserves xterm contrast cache)', () => {
     const pane = makePane(1)
     let writes = 0

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -170,7 +170,8 @@ export function applyTerminalAppearance(
     // Why value-gated: writing minimumContrastRatio clears xterm's contrast cache, so skip on no-op re-applies.
     const minimumContrastRatio = resolveTerminalMinimumContrastRatio(
       theme?.background,
-      appearance.mode
+      appearance.mode,
+      settings.terminalMinimumContrastRatio
     )
     if (pane.terminal.options.minimumContrastRatio !== minimumContrastRatio) {
       pane.terminal.options.minimumContrastRatio = minimumContrastRatio

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8634,7 +8634,7 @@
             "description": "Lifts terminal foreground colors that sit too close to the background. Leave blank for automatic, or set 1 to render program colors exactly as sent.",
             "automatic": "Automatic: {{light}} on light backgrounds, {{dark}} on dark.",
             "disabled": "Correction off. Programs that rely on low contrast, like Powerline separators, render as sent.",
-            "pinned": "Foreground colors are lifted until they reach {{ratio}}:1 against the background.",
+            "pinned": "Targets {{ratio}}:1 contrast for foreground colors, where possible.",
             "placeholder": "Auto",
             "suffix": "blank = automatic, 1 = off"
           }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8628,6 +8628,15 @@
             "fastDescription": "Extra multiplier while scrolling with a modifier key.",
             "tui": "TUI",
             "tuiDescription": "Discrete wheel reports for full-screen terminal apps."
+          },
+          "minimumContrast": {
+            "title": "Minimum Contrast Ratio",
+            "description": "Lifts terminal foreground colors that sit too close to the background. Leave blank for automatic, or set 1 to render program colors exactly as sent.",
+            "automatic": "Automatic: {{light}} on light backgrounds, {{dark}} on dark.",
+            "disabled": "Correction off. Programs that rely on low contrast, like Powerline separators, render as sent.",
+            "pinned": "Foreground colors are lifted until they reach {{ratio}}:1 against the background.",
+            "placeholder": "Auto",
+            "suffix": "blank = automatic, 1 = off"
           }
         },
         "TerminalSettingsPreview": {
@@ -10489,7 +10498,20 @@
             "agent": "agent",
             "process": "process",
             "prompt": "prompt",
-            "stop": "stop"
+            "stop": "stop",
+            "minimumContrast": {
+              "title": "Minimum Contrast Ratio",
+              "description": "Lifts terminal foreground colors that sit too close to the background. Leave blank for automatic, or set 1 to render program colors exactly as sent.",
+              "contrast": "contrast",
+              "minimum": "minimum",
+              "ratio": "ratio",
+              "readability": "readability",
+              "wcag": "wcag",
+              "powerline": "powerline",
+              "statusline": "statusline",
+              "dim": "dim",
+              "colors": "colors"
+            }
           },
           "windows": {
             "search": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10500,8 +10500,8 @@
             "prompt": "prompt",
             "stop": "stop",
             "minimumContrast": {
-              "title": "Minimum Contrast Ratio",
-              "description": "Lifts terminal foreground colors that sit too close to the background. Leave blank for automatic, or set 1 to render program colors exactly as sent.",
+              "title": "Color Contrast",
+              "description": "Improve text readability or preserve the colors chosen by terminal programs.",
               "contrast": "contrast",
               "minimum": "minimum",
               "ratio": "ratio",
@@ -11836,6 +11836,20 @@
         },
         "NativeChatSupportedAgents": {
           "label": "Supported agents:"
+        },
+        "contrast": {
+          "title": "Color Contrast",
+          "description": "Improve text readability or preserve the colors chosen by terminal programs.",
+          "ratio": "Contrast target",
+          "autoDescription": "Balances readability with your terminal theme. Recommended.",
+          "offDescription": "Keeps program colors unchanged, including dim text and Powerline separators.",
+          "customDescription": "Choose how much to increase contrast between text and its background.",
+          "auto": "Automatic",
+          "off": "Off",
+          "custom": "Custom",
+          "targetDescription": "Higher values increase contrast where possible. Background colors stay unchanged.",
+          "subtle": "Subtle",
+          "strong": "Strong"
         }
       },
       "right": {

--- a/src/renderer/src/lib/terminal-contrast-correction.test.ts
+++ b/src/renderer/src/lib/terminal-contrast-correction.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   DARK_BG_MIN_CONTRAST,
   LIGHT_BG_MIN_CONTRAST,
+  MAX_TERMINAL_CONTRAST_RATIO,
+  MIN_TERMINAL_CONTRAST_RATIO,
+  normalizeTerminalMinimumContrastRatio,
   resolveTerminalMinimumContrastRatio
 } from './terminal-contrast-correction'
 import { TERMINAL_THEME_CATALOG } from './terminal-themes'
@@ -39,6 +42,63 @@ describe('resolveTerminalMinimumContrastRatio', () => {
 
   it('treats an undefined/transparent background as dark', () => {
     expect(resolveTerminalMinimumContrastRatio(undefined, 'dark')).toBe(DARK_BG_MIN_CONTRAST)
+  })
+})
+
+// #10754: the automatic floor rewrites deliberately low-contrast TUI output (Powerline seams, dimmed
+// secondary text), so the user setting has to win over the luminance gate on both backgrounds.
+describe('resolveTerminalMinimumContrastRatio with a user override', () => {
+  it('lets 1 disable contrast correction on a dark background', () => {
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', 1)).toBe(1)
+  })
+
+  it('lets 1 disable contrast correction on a light background too', () => {
+    expect(resolveTerminalMinimumContrastRatio('#ffffff', 'light', 1)).toBe(1)
+  })
+
+  it('honors an intermediate override instead of the automatic floor', () => {
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', 1.5)).toBe(1.5)
+    expect(resolveTerminalMinimumContrastRatio('#ffffff', 'light', 7)).toBe(7)
+  })
+
+  it("clamps an out-of-range override to xterm's 1-21 window", () => {
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', 0)).toBe(
+      MIN_TERMINAL_CONTRAST_RATIO
+    )
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', -5)).toBe(
+      MIN_TERMINAL_CONTRAST_RATIO
+    )
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', 99)).toBe(
+      MAX_TERMINAL_CONTRAST_RATIO
+    )
+  })
+
+  it('falls back to the automatic floor when the override is unset or unusable', () => {
+    // A hand-edited settings file can carry any of these; xterm throws on a non-finite option.
+    for (const value of [undefined, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', value)).toBe(
+        DARK_BG_MIN_CONTRAST
+      )
+      expect(resolveTerminalMinimumContrastRatio('#ffffff', 'light', value)).toBe(
+        LIGHT_BG_MIN_CONTRAST
+      )
+    }
+  })
+})
+
+describe('normalizeTerminalMinimumContrastRatio', () => {
+  it('returns undefined for anything that is not a usable number', () => {
+    for (const value of [undefined, null, '3', Number.NaN, Number.POSITIVE_INFINITY, {}]) {
+      expect(normalizeTerminalMinimumContrastRatio(value)).toBeUndefined()
+    }
+  })
+
+  it('passes in-range values through and clamps the rest', () => {
+    expect(normalizeTerminalMinimumContrastRatio(1)).toBe(1)
+    expect(normalizeTerminalMinimumContrastRatio(4.5)).toBe(4.5)
+    expect(normalizeTerminalMinimumContrastRatio(21)).toBe(21)
+    expect(normalizeTerminalMinimumContrastRatio(0.5)).toBe(1)
+    expect(normalizeTerminalMinimumContrastRatio(1000)).toBe(21)
   })
 })
 

--- a/src/renderer/src/lib/terminal-contrast-correction.ts
+++ b/src/renderer/src/lib/terminal-contrast-correction.ts
@@ -1,4 +1,11 @@
 import { isTerminalBackgroundLight } from '@/lib/terminal-title-contrast'
+import { normalizeTerminalMinimumContrastRatio } from '../../../shared/terminal-minimum-contrast-settings'
+
+export {
+  MAX_TERMINAL_CONTRAST_RATIO,
+  MIN_TERMINAL_CONTRAST_RATIO,
+  normalizeTerminalMinimumContrastRatio
+} from '../../../shared/terminal-minimum-contrast-settings'
 
 // xterm minimumContrastRatio tuning (#7934, #9599, #10104). Light backgrounds keep WCAG-AA correction so
 // invisible white/bright-white ANSI body text stays readable. Dark backgrounds use a mild floor of 3
@@ -13,10 +20,17 @@ export const DARK_BG_MIN_CONTRAST = 3
 
 // Why gate by background luminance, not app mode (#7934): either theme slot can hold either kind of
 // theme (match-dark-mode, or a light theme in the dark slot), so follow the composed background.
+// `override` is the user's terminalMinimumContrastRatio; clamped here too so a hand-edited settings
+// file can't hand xterm an out-of-range or non-finite floor.
 export function resolveTerminalMinimumContrastRatio(
   background: string | undefined,
-  appSurface: 'dark' | 'light'
+  appSurface: 'dark' | 'light',
+  override?: number
 ): number {
+  const configured = normalizeTerminalMinimumContrastRatio(override)
+  if (configured !== undefined) {
+    return configured
+  }
   return isTerminalBackgroundLight(background, { appSurface })
     ? LIGHT_BG_MIN_CONTRAST
     : DARK_BG_MIN_CONTRAST

--- a/src/renderer/src/runtime/sync-runtime-graph/mobile-terminal-theme.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/mobile-terminal-theme.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '@/store/types'
+import { resolveMobileTerminalTheme } from './mobile-terminal-theme'
+
+function stateWith(settings: Record<string, unknown> | null): AppState {
+  return { settings } as unknown as AppState
+}
+
+const BASE = {
+  terminalThemeDark: 'Ghostty Default Style Dark',
+  terminalThemeLight: 'Builtin Tango Light',
+  terminalUseSeparateLightTheme: true,
+  theme: 'dark'
+}
+
+// #10754: mobile mirrors the desktop contrast gate, so an explicit floor has to travel with the
+// theme payload — otherwise the same session renders differently on the phone.
+describe('resolveMobileTerminalTheme contrast floor', () => {
+  it('omits the floor when the user has not set one', () => {
+    const theme = resolveMobileTerminalTheme(stateWith(BASE), true)
+    expect(theme?.minimumContrastRatio).toBeUndefined()
+  })
+
+  it('publishes the user floor so the phone stops lifting low-contrast output', () => {
+    const theme = resolveMobileTerminalTheme(
+      stateWith({ ...BASE, terminalMinimumContrastRatio: 1 }),
+      true
+    )
+    expect(theme?.minimumContrastRatio).toBe(1)
+  })
+
+  it('clamps before publishing so an old client can trust the value', () => {
+    expect(
+      resolveMobileTerminalTheme(stateWith({ ...BASE, terminalMinimumContrastRatio: 99 }), true)
+        ?.minimumContrastRatio
+    ).toBe(21)
+    expect(
+      resolveMobileTerminalTheme(
+        stateWith({ ...BASE, terminalMinimumContrastRatio: Number.NaN }),
+        true
+      )?.minimumContrastRatio
+    ).toBeUndefined()
+  })
+
+  it('returns nothing without settings', () => {
+    expect(resolveMobileTerminalTheme(stateWith(null), true)).toBeUndefined()
+  })
+})

--- a/src/renderer/src/runtime/sync-runtime-graph/mobile-terminal-theme.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/mobile-terminal-theme.ts
@@ -2,6 +2,7 @@ import { getSystemPrefersDark, resolveEffectiveTerminalAppearance } from '@/lib/
 import type { AppState } from '@/store/types'
 import type { RuntimeMobileTerminalTheme } from '../../../../shared/runtime-types'
 import { graphState } from './graph-state'
+import { normalizeTerminalMinimumContrastRatio } from '@/lib/terminal-contrast-correction'
 
 function hexToRgba(hex: string, alpha: number): string {
   let clean = hex.replace('#', '')
@@ -52,7 +53,15 @@ export function resolveMobileTerminalTheme(
       theme[key] = value
     }
   }
-  return { mode: appearance.mode, theme: theme as RuntimeMobileTerminalTheme['theme'] }
+  return {
+    mode: appearance.mode,
+    theme: theme as RuntimeMobileTerminalTheme['theme'],
+    // Why publish: mobile mirrors the desktop contrast gate, so an explicit floor has to travel with
+    // the theme or the same session would render differently on the phone (#10754).
+    minimumContrastRatio: normalizeTerminalMinimumContrastRatio(
+      settings.terminalMinimumContrastRatio
+    )
+  }
 }
 
 export function getMobileTerminalTheme(

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -144,6 +144,10 @@ export type GlobalSettings = {
   terminalPaneOpacityTransitionMs: number
   terminalDividerThicknessPx: number
   terminalBackgroundOpacity?: number
+  /** xterm minimumContrastRatio floor for terminal panes (#10754). Undefined keeps the automatic,
+   *  background-luminance-gated floor (3 dark / 4.5 light); 1 disables contrast correction so TUIs
+   *  that rely on deliberately low contrast (Powerline seams, dimmed secondary text) render as sent. */
+  terminalMinimumContrastRatio?: number
   terminalColorOverrides?: TerminalColorOverrides
   terminalPaddingX?: number
   terminalPaddingY?: number

--- a/src/shared/runtime-mobile-session-tab-contracts.ts
+++ b/src/shared/runtime-mobile-session-tab-contracts.ts
@@ -33,6 +33,9 @@ export type RuntimeMobileSessionTerminalTab = {
 export type RuntimeMobileTerminalTheme = {
   mode: 'dark' | 'light'
   theme: TerminalColorOverrides
+  /** Optional desktop terminalMinimumContrastRatio override (#10754). Absent means the client picks
+   *  its own background-luminance floor, which is what pre-#10754 clients always do. */
+  minimumContrastRatio?: number
 }
 
 export type RuntimeMobileSessionMarkdownTab = {

--- a/src/shared/terminal-minimum-contrast-settings.ts
+++ b/src/shared/terminal-minimum-contrast-settings.ts
@@ -1,0 +1,16 @@
+// xterm's minimumContrastRatio range: 1 disables contrast correction entirely, 21 is the maximum
+// WCAG ratio (black on white). Shared so main's persistence boundary and the renderer clamp alike.
+export const MIN_TERMINAL_CONTRAST_RATIO = 1
+export const MAX_TERMINAL_CONTRAST_RATIO = 21
+
+/**
+ * Clamps a user-supplied contrast floor (#10754). `undefined` means "unset", so callers fall back to
+ * Orca's automatic background-luminance floor; anything unusable is treated the same way rather than
+ * handed to xterm, which throws on a non-finite option.
+ */
+export function normalizeTerminalMinimumContrastRatio(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined
+  }
+  return Math.min(MAX_TERMINAL_CONTRAST_RATIO, Math.max(MIN_TERMINAL_CONTRAST_RATIO, value))
+}


### PR DESCRIPTION
Fixes #10754. Based on @Nanako0129’s #10760; their co-author credit is retained.

## Change

Orca’s automatic contrast correction brightens intentionally dim TUI text and Powerline styling. **Settings → Terminal → Rendering → Color Contrast** now offers three plain-language choices:

| Choice | Behavior |
| --- | --- |
| **Automatic** | Recommended default. Keeps the existing background-based correction: 3 dark / 4.5 light. |
| **Off** | Preserves program colors, including dim text and Powerline separators. No numeric input needed. |
| **Custom** | Reveals a Subtle → Strong slider and an optional precise contrast target. Starts at 4.5. |

Returning to Automatic removes the stored override in one click. Custom remembers its previous target while switching modes within the mounted settings control. Slider changes save on commit; arrow keys adjust the target. Exact input is bounded to 1–21, and entering 1 selects Off. The slider starts at 1.1 so reaching its lower end does not collapse the Custom controls.

The underlying optional `terminalMinimumContrastRatio` remains compatible: absent = Automatic, 1 = Off, other valid numbers = Custom. No new setting or wire field is introduced by this UX revision.

## Settings screenshots — current UI

Fresh hidden Electron/CDP captures from the implementation in `c997d35f96`. These replace the earlier blank-input screenshots. They show the full settings page and surrounding options, with no settings search filter unless explicitly labeled.

**Automatic — a recommended default, with no number to manage.**

![Automatic contrast mode](https://github.com/user-attachments/assets/ba169592-b912-48aa-9246-ff6c1910eefa)

**Off — preserve the colors chosen by the program in one click.**

![Off preserves program colors](https://github.com/user-attachments/assets/ccc56a6a-e902-4a8c-b9d1-45e92d96d33d)

**Custom — progressively reveals a slider and precise value field.**

![Custom contrast with slider and exact target](https://github.com/user-attachments/assets/db5fcb51-f3b4-4a2e-a07e-2211857b0e7f)

<details>
<summary>More settings proof: custom values, bounds, light mode, search, and narrow layout</summary>

**Custom target 7 — also verified to survive Off → Automatic → Custom.**

![Custom target 7](https://github.com/user-attachments/assets/7bb53a2f-20d9-44fd-a1db-4b2d85202f44)

**Entering 99 clamps to 21.**

![Custom target clamped to 21](https://github.com/user-attachments/assets/9b1cd2c3-05ca-4475-8bae-bc1307ffb7ea)

**Light mode, Automatic.**

![Automatic contrast in light mode](https://github.com/user-attachments/assets/0b6c35c1-4648-4a82-857d-be3d98830a9b)

**Light mode, Custom.**

![Custom contrast in light mode](https://github.com/user-attachments/assets/1aabf31b-ef2e-4471-b2db-e6bb006e2782)

**Search for “powerline” finds the control.**

![Powerline settings search](https://github.com/user-attachments/assets/60476717-ebcc-4428-9f9f-92fdf5a2ca63)

**Narrower window, Custom.**

![Custom contrast in a narrower window](https://github.com/user-attachments/assets/5a58e6c1-09e5-4350-b6a5-f982a89ae78a)

</details>

## Terminal rendering proof

The renderer behavior is unchanged by the UX revision. These existing captures used the same live PTY and terminal instance in a **folder workspace**, with the original issue’s ANSI foreground/background samples. “Auto” and “1” in the earlier measurements map to today’s Automatic and Off choices.

**Automatic: the seam sample becomes readable and deliberately dim text is brightened.**

![Automatic terminal rendering](https://github.com/user-attachments/assets/7ab6f0ec-bab4-4d2d-a00e-8ad8b7f4d7e7)

**Off: the seam sample becomes nearly invisible and secondary text stays dim.**

![Off terminal rendering](https://github.com/user-attachments/assets/c56cd51d-23f4-415c-a545-b9d75643be4e)

| Earlier live-buffer measurement | Changed pixels versus Automatic in the identical 1530 × 780 crop |
| --- | ---: |
| Off (1) | 16,383 |
| Custom 4.5 | 16,245 |
| Custom 21 | 16,822 |
| Restore Automatic | **0 — pixel-identical restoration** |

The 520 × 22 sample spanning all seven background swatches had **0 changed pixels** in every dark-mode state. Terminal identity and buffer text were preserved. These measurements establish foreground correction, not a palette/background change; they were captured before the new mode control.

<details>
<summary>Light theme and background-based defaults — 3 screenshots</summary>

The floor follows the composed terminal background, not the app’s light/dark mode. The capture script reads 4.5 for both light-background Auto cases and 1 for the disabled case.

**Light terminal background: automatic ratio is 4.5**

![Light terminal background: automatic ratio is 4.5](https://github.com/user-attachments/assets/2f265be3-3a47-4b01-9a21-15d0d4795262)

**Light terminal background: 1 disables correction here too**

![Light terminal background: 1 disables correction here too](https://github.com/user-attachments/assets/8424ef06-3408-4158-9f42-a940d0f7e844)

**Light theme in the dark theme slot: full app context**

![Light theme in the dark theme slot: full app context](https://github.com/user-attachments/assets/4617c626-5bb1-419e-b736-b9747bf10a64)


</details>

<details>
<summary>Appearance preview — 2 screenshots</summary>

Both values were entered in the Terminal setting before navigating to Appearance. The preview uses the same resolver as live panes.

**Appearance preview with the target set to 21**

![Appearance preview with the target set to 21](https://github.com/user-attachments/assets/b5fa6cb2-fc82-4b23-9b6f-541cbd330dad)

**Appearance preview with correction disabled at 1**

![Appearance preview with correction disabled at 1](https://github.com/user-attachments/assets/a9ce2f82-b2b2-4cc4-8533-7b4fefab8db2)

</details>

<details>
<summary>Mobile document rendering — 2 screenshots; not a phone test</summary>

The complete generated mobile WebView HTML was loaded in an iframe inside the hidden Electron renderer, initialized through its actual message handler, and updated with a `set-theme` message. It rendered the same ANSI sample with no captured engine/runtime errors. This exercises the document and its bundled xterm, **not** React Native pairing, an iPhone, or an Android device.

**Mobile WebView document: Auto**

![Mobile WebView document: Auto](https://github.com/user-attachments/assets/95f85440-ee80-4c9c-abd4-4e963264f2fe)

**Mobile WebView document: published override 1**

![Mobile WebView document: published override 1](https://github.com/user-attachments/assets/380735ad-20b6-4004-8ce4-6b4eb6457908)

</details>

<details>
<summary>Full desktop context — 2 uncropped screenshots</summary>



**Full Orca window: Auto**

![Full Orca window: Auto](https://github.com/user-attachments/assets/a291523d-81ae-421c-b97d-91fe8c2dc729)

**Full Orca window: correction off**

![Full Orca window: correction off](https://github.com/user-attachments/assets/5ca38d1a-17e9-4774-97ee-a6f50a85c5c8)

</details>

## Review map and comparison with #10760

- **Same core feature:** preserve existing defaults, allow correction to be disabled, clamp valid overrides, and feed the pane plus both desktop previews through the shared resolver.
- **This PR adds:** desktop persistence normalization and an optional mobile theme override with a safe fallback. The new UX presents Automatic / Off / Custom instead of exposing JSON conventions to users.
- **Contributor PR adds:** a committed pixel E2E (`terminal-minimum-contrast-setting.spec.ts`) and an explicit value-gated dashboard appearance helper. The E2E is not ported here; this PR’s dashboard constructor reads the override when the existing settings/theme effect reruns.
- **Credit:** @Nanako0129 authored both the issue and #10760 and is a recognized co-author on the original implementation commit.

Start with `TerminalContrastSetting.tsx` for mode selection and custom tuning, then `terminal-minimum-contrast-settings.ts` and `terminal-contrast-correction.ts` for numeric validation/defaults. Desktop consumers are `terminal-appearance.ts`, `TerminalSettingsPreview.tsx`, and `preview-terminal-options.ts`. Mobile publication and reading live in `mobile-terminal-theme.ts` and `terminal-webview-theme-injected.ts`.

## Verification

**Current UX revision:**

- `ORCA_BACKGROUND_LAUNCH=1 pnpm tc:web` — passed.
- Focused mode-control, NumberField, and resolver tests — **3 files / 21 tests passed**. Mode tests cover one-click Off/Automatic, custom-value memory, default custom target, bounds, and exact input 1 selecting Off.
- Real hidden Electron/CDP: Automatic and Off hide numeric controls; Custom reveals them; ArrowRight changes 4.5 → 4.6; exact 7 persists and survives mode changes; 99 clamps to 21; Automatic removes the override. Dark/light, narrow layout, and settings search captured above.
- Changed-file lint, React Doctor commit hook, formatting, localization extraction, and `git diff --check` — passed.

**Rebased rendering implementation:** full `pnpm tc`, 65 focused desktop tests, and 21 focused mobile tests passed on `ee33b92964`, rebased onto `main` at `c1e15c4008`. Earlier actual-source mobile VM validation covered 18 dark/light/invalid/clamp cases. The complete mobile document also rendered without captured engine errors in an Electron iframe (screenshots above); this is not phone/pairing validation.

The earlier mobile payload checksum CI failure was reproduced and fixed by updating the expected document length/hash after validating the intentional injected-JS change. CI must pass on the latest head before merge.

## Compatibility and limits

- Automatic preserves existing defaults and the pane’s value-gated option write. Invalid/non-finite overrides fall back safely.
- This is a client display preference: desktop IPC reaches persistence normalization; web preferences merge locally and are validated by the renderer resolver. It is not sent through the restricted host `settings.update` RPC.
- Mobile’s optional theme field is ignored by older clients; newer clients fall back to the background gate when older publishers omit it. No new opcode or required field.
- No execution, process-liveness, shell, Git, or provider behavior changes. SSH and folder/worktree panes use the same renderer preference. Actual remote pairing, Linux/Windows rendering, and physical phones were not exercised here.
- Ghostty `minimum-contrast` import remains out of scope.

New screenshots are GitHub attachments uploaded using `gh pr edit --attach` (CLI 2.100.0). The terminal and mobile galleries retain their earlier capture provenance; obsolete settings screenshots have been removed from this description.
