### PR TITLE
feat: fully migrate xterm to libghostty

### DIFF
--- a/mobile/src/mock-server-key-pair.test.ts
+++ b/mobile/src/mock-server-key-pair.test.ts
@@ -29,7 +29,9 @@ function runConcurrentCreator(keyFile: string): ConcurrentCreator {
     join(import.meta.dirname, '../scripts/mock-server-key-pair.ts')
   ).href
   const script = `
-    const { loadOrCreateMockServerKeyPair } = await import(process.argv[1])
+    const module = await import(process.argv[1])
+    const loadOrCreateMockServerKeyPair =
+      module.loadOrCreateMockServerKeyPair ?? module.default?.loadOrCreateMockServerKeyPair
     process.stdout.write('READY\\n')
     await new Promise((resolve) => process.stdin.once('data', resolve))
     process.stdout.write('CALLING\\n')

--- a/mobile/src/session/mobile-session-route-parity.test.ts
+++ b/mobile/src/session/mobile-session-route-parity.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import ts from 'typescript-api'
+import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { MOBILE_SESSION_ROUTE_SOURCE_FILES } from './mobile-session-route-source-family.test-support'
 


### PR DESCRIPTION
## ELI5

Orca still draws the terminal with xterm. This work replaces that engine with libghostty on mobile, then desktop/web, then daemon snapshots, so vim/tmux/zellij get a real Ghostty pointer and restore does not split xterm vs Ghostty geometry.

## What Changed

Work in progress against #18127. First slice:

- Mobile tests no longer depend on the desktop `typescript-api` alias, and the mock-server key child accepts tsx CJS default exports.
- Native mouse + host APIs land on `rudironsoni/expo-libghostty` (`feat/mouse-input`): Android `ghostty_mouse_encoder` (press/release/motion/wheel/hover/stylus), `keyboardEnabled`, `onTap`, `resetWithText`, `pasteText`.
- Next commits on this PR: depend on that module from Expo 55, replace `TerminalWebView` with `TerminalView`, keep live input, then desktop WASM + daemon VT.

## Why

The xterm WebView has poor mobile touch, a heavy JS bridge, and a hand-rolled SGR mouse encoder. Desktop xterm internals (IME, WebGL, wheel) do not match Ghostty VT. One engine is the point of #18127.

## Linked Issue

Fixes #18127

## Visual Proof

N/A until the native terminal view is wired in this PR. Follow-up commits will attach iOS/Android captures.

## Testing

- `pnpm --dir mobile test` (490 files, 3985 passed, 3 skipped)
- expo-libghostty: vitest 5/5, Android JUnit 25/25, JNI `nativeEncodeMouse` / `nativeMouseTracking` in `libexpolibghostty.so`, `:app:assembleRelease` R8, iOS `xcodebuild` simulator **BUILD SUCCEEDED**
- Platforms: macOS. Android emulator / device mouse still to run after the Orca view swap.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No Expo 55 → 57 bump. Desktop stays in the pane DOM (no NSView overlay). Cross-platform, SSH, and mixed-version `terminal.updateViewport` fallback stay in scope for later commits on this PR.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
