### PR TITLE
feat(serve): give headless Linux serve an observable update contract

### DIFF
--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -478,6 +478,16 @@ Orca prints those commands and never runs them. The service runs unprivileged
 with no authentication agent available, so the privileged install and the
 restart stay the operator's action.
 
+The check is a single outbound request to the GitHub releases feed plus a small
+number of probes confirming the newest release is fully published, once every 24
+hours. It never downloads a build. On an air-gapped or egress-audited host, set
+`ORCA_SERVE_DISABLE_UPDATE_CHECK=1` to switch it off. Add it as one more
+`Environment=` line in the `[Service]` section of the `orca-serve.service` unit
+built in [Systemd Service](#systemd-service), beside the `DISPLAY` and
+`LIBGL_ALWAYS_SOFTWARE` entries already there — do not create a second unit
+file. `orca status` then reports `updateCheck: disabled` and still names the
+install method, so the contract stays readable with no network traffic at all.
+
 ### Record the version you deploy
 
 The bundled CLI launcher prints the Orca build with `orca-ide --version`, and

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -469,9 +469,13 @@ updateDocs: ...
 `orca status --json` carries the same contract under
 `result.runtime.remoteUpdateSupport.manualUpdate`, so a monitoring job can read
 `check` and `latestVersion` instead of scraping the releases API. `check` is
-`pending` before the first check completes and `unavailable` when the feed could
-not be reached or the newest release is still publishing — neither means the
-server is current. A paired desktop client sees the same fields on the runtime
+`pending` before the first check completes, `unavailable` when the feed could
+not be reached or the newest release is still publishing, and `disabled` when the
+operator opted out — none of the three means the server is current.
+`updateMethod` reports `externally-managed` when a repackaged install (AUR, Nix,
+a container rebuild) carries Orca's `package-type` marker but the host has no
+package manager that could apply an Orca package; the steps then point at the
+package manager that installed Orca rather than the release page. A paired desktop client sees the same fields on the runtime
 status it already polls.
 
 Orca prints those commands and never runs them. The service runs unprivileged

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -405,7 +405,9 @@ depend on an interactive shell profile.
 `orca serve` never updates itself. In headless mode Orca wires up no auto-updater
 at all — the built-in updater only runs in the desktop GUI, and no paired mobile
 or web client can trigger it remotely. Upgrading is always a deliberate step:
-replace the AppImage and restart the service.
+replace the AppImage and restart the service. Orca does report when a newer
+release exists and exactly what to run — see
+[Find out an upgrade is due](#find-out-an-upgrade-is-due).
 
 Two facts make the persisted-state transition predictable:
 
@@ -441,9 +443,45 @@ and the stop; Orca does not yet provide an atomic census-and-stop fence.
 
 Rolling back is the case that needs care — see [Roll back](#roll-back).
 
+### Find out an upgrade is due
+
+The server will not update itself, but it does tell you when it is behind. It
+checks the release feed once a day and reports the result through `orca status`:
+
+```console
+$ orca status
+...
+appVersion: 1.4.159
+updateAutomatic: false
+updateInstallMode: unsupported-headless-serve
+updateReason: manual-service-update-required
+updateMethod: appimage
+updateCheck: update-available
+updateLatestVersion: 1.4.200
+updateRelease: https://github.com/stablyai/orca/releases/tag/v1.4.200
+updateSteps:
+  1. Download the Linux AppImage for this machine's architecture from https://github.com/stablyai/orca/releases/tag/v1.4.200 to /opt/orca/orca-linux.AppImage.new
+  2. /usr/bin/sudo /usr/bin/mv -- '/opt/orca/orca-linux.AppImage.new' '/opt/orca/orca-linux.AppImage'
+  3. Restart the service unit that runs `orca serve`. ...
+updateDocs: ...
+```
+
+`orca status --json` carries the same contract under
+`result.runtime.remoteUpdateSupport.manualUpdate`, so a monitoring job can read
+`check` and `latestVersion` instead of scraping the releases API. `check` is
+`pending` before the first check completes and `unavailable` when the feed could
+not be reached or the newest release is still publishing — neither means the
+server is current. A paired desktop client sees the same fields on the runtime
+status it already polls.
+
+Orca prints those commands and never runs them. The service runs unprivileged
+with no authentication agent available, so the privileged install and the
+restart stay the operator's action.
+
 ### Record the version you deploy
 
-The bundled CLI launcher prints the Orca build with `orca-ide --version`. For an
+The bundled CLI launcher prints the Orca build with `orca-ide --version`, and
+`orca status` reports the same build as `appVersion`. For an
 extracted deployment, that launcher is
 `squashfs-root/resources/bin/orca-ide`; deb/rpm installs and CLI registration put
 it on `PATH`. Do not use `orca-linux.AppImage --version` for this audit because

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -6,6 +6,7 @@ import {
 } from '../shared/automation-owner-conflict'
 import { automationOwnerConflictRecovery } from './automation-owner-conflict-recovery'
 import { prepareComputerCliJsonResult } from './computer-format'
+import { formatRemoteUpdateSupportLines } from './serve-manual-update-format'
 import type { RuntimeRpcFailure, RuntimeRpcSuccess } from './runtime-client'
 import { RuntimeClientError, RuntimeRpcFailureError } from './runtime/types'
 
@@ -247,7 +248,9 @@ export function formatCliStatus(status: CliStatusResult): string {
     `runtimeReachable: ${status.runtime.reachable}`,
     `runtimeConnectionState: ${status.runtime.connectionState ?? 'unknown'}`,
     `runtimeId: ${status.runtime.runtimeId ?? 'none'}`,
-    `graphState: ${status.graph.state}`
+    `graphState: ${status.graph.state}`,
+    ...(status.runtime.appVersion ? [`appVersion: ${status.runtime.appVersion}`] : []),
+    ...formatRemoteUpdateSupportLines(status.runtime.remoteUpdateSupport)
   ].join('\n')
 }
 

--- a/src/cli/serve-manual-update-format.test.ts
+++ b/src/cli/serve-manual-update-format.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import type { CliStatusResult } from '../shared/runtime-types'
+import type { RemoteServerUpdateSupport } from '../shared/remote-server-update'
+import { formatRemoteUpdateSupportLines } from './serve-manual-update-format'
+import { formatCliStatus } from './format'
+
+const MANUAL_SUPPORT: RemoteServerUpdateSupport = {
+  installMode: 'unsupported-headless-serve',
+  automatic: false,
+  reason: 'manual-service-update-required',
+  manualUpdate: {
+    method: 'deb',
+    check: 'update-available',
+    currentVersion: '1.4.159',
+    latestVersion: '1.4.200',
+    releaseUrl: 'https://github.com/stablyai/orca/releases/tag/v1.4.200',
+    steps: ["sudo /usr/bin/apt install -- '/tmp/orca-1.4.200.deb'", 'Restart the service unit'],
+    documentationUrl: 'https://docs.example/upgrade'
+  }
+}
+
+function statusWith(support?: RemoteServerUpdateSupport): CliStatusResult {
+  return {
+    app: { running: true, pid: 42 },
+    runtime: {
+      state: 'ready',
+      reachable: true,
+      runtimeId: 'runtime-1',
+      appVersion: '1.4.159',
+      ...(support ? { remoteUpdateSupport: support } : {})
+    },
+    graph: { state: 'ready' }
+  }
+}
+
+describe('formatRemoteUpdateSupportLines', () => {
+  it('adds nothing for a host that reports no update support', () => {
+    expect(formatRemoteUpdateSupportLines(undefined)).toEqual([])
+  })
+
+  it('names the version that is out and the exact numbered commands', () => {
+    expect(formatRemoteUpdateSupportLines(MANUAL_SUPPORT)).toEqual([
+      'updateAutomatic: false',
+      'updateInstallMode: unsupported-headless-serve',
+      'updateReason: manual-service-update-required',
+      'updateMethod: deb',
+      'updateCheck: update-available',
+      'updateLatestVersion: 1.4.200',
+      'updateRelease: https://github.com/stablyai/orca/releases/tag/v1.4.200',
+      'updateSteps:',
+      "  1. sudo /usr/bin/apt install -- '/tmp/orca-1.4.200.deb'",
+      '  2. Restart the service unit',
+      'updateDocs: https://docs.example/upgrade'
+    ])
+  })
+
+  it('reports an unknown latest version rather than implying the host is current', () => {
+    const lines = formatRemoteUpdateSupportLines({
+      ...MANUAL_SUPPORT,
+      manualUpdate: {
+        ...MANUAL_SUPPORT.manualUpdate!,
+        check: 'pending',
+        latestVersion: null,
+        releaseUrl: null,
+        steps: []
+      }
+    })
+
+    expect(lines).toContain('updateCheck: pending')
+    expect(lines).toContain('updateLatestVersion: unknown')
+    expect(lines.some((line) => line.startsWith('updateSteps'))).toBe(false)
+  })
+
+  it('leaves an automatic-update host with support lines but no manual block', () => {
+    const lines = formatRemoteUpdateSupportLines({
+      installMode: 'interactive',
+      automatic: true,
+      reason: 'available'
+    })
+
+    expect(lines).toEqual([
+      'updateAutomatic: true',
+      'updateInstallMode: interactive',
+      'updateReason: available'
+    ])
+  })
+})
+
+describe('formatCliStatus', () => {
+  it('surfaces the update contract through `orca status`', () => {
+    const output = formatCliStatus(statusWith(MANUAL_SUPPORT))
+
+    expect(output).toContain('appVersion: 1.4.159')
+    expect(output).toContain('updateLatestVersion: 1.4.200')
+    expect(output).toContain("  1. sudo /usr/bin/apt install -- '/tmp/orca-1.4.200.deb'")
+  })
+
+  it('keeps the original status lines for a host that reports no update support', () => {
+    expect(formatCliStatus(statusWith())).toBe(
+      [
+        'appRunning: true',
+        'pid: 42',
+        'desktopWindowStatus: unknown',
+        'runtimeState: ready',
+        'runtimeReachable: true',
+        'runtimeConnectionState: unknown',
+        'runtimeId: runtime-1',
+        'graphState: ready',
+        'appVersion: 1.4.159'
+      ].join('\n')
+    )
+  })
+})

--- a/src/cli/serve-manual-update-format.ts
+++ b/src/cli/serve-manual-update-format.ts
@@ -1,0 +1,35 @@
+import type { RemoteServerUpdateSupport } from '../shared/remote-server-update'
+
+/**
+ * The human `orca status` rendering of a host's update contract. Kept out of the JSON path on
+ * purpose: `--json` callers read `runtime.remoteUpdateSupport` directly.
+ */
+export function formatRemoteUpdateSupportLines(
+  support: RemoteServerUpdateSupport | undefined
+): string[] {
+  if (!support) {
+    return []
+  }
+  const lines = [
+    `updateAutomatic: ${support.automatic}`,
+    `updateInstallMode: ${support.installMode}`,
+    `updateReason: ${support.reason}`
+  ]
+  const manual = support.manualUpdate
+  if (!manual) {
+    return lines
+  }
+  lines.push(`updateMethod: ${manual.method}`)
+  lines.push(`updateCheck: ${manual.check}`)
+  lines.push(`updateLatestVersion: ${manual.latestVersion ?? 'unknown'}`)
+  if (manual.releaseUrl) {
+    lines.push(`updateRelease: ${manual.releaseUrl}`)
+  }
+  if (manual.steps.length > 0) {
+    lines.push('updateSteps:')
+    // Why: Orca prints these; it never runs them. The serve process is unprivileged by design.
+    lines.push(...manual.steps.map((step, index) => `  ${index + 1}. ${step}`))
+  }
+  lines.push(`updateDocs: ${manual.documentationUrl}`)
+  return lines
+}

--- a/src/main/runtime/remote-server-updater.test.ts
+++ b/src/main/runtime/remote-server-updater.test.ts
@@ -18,6 +18,17 @@ describe('remote server updater adapter', () => {
     expect(() => installRemoteServerUpdater('runtime-1')).toThrow('remote_update_manual_required')
   })
 
+  // Why: an unconfigured adapter proves the updater is unwired, not that the host is a headless
+  // serve install. Claiming that mode alongside `updater-unavailable` reproduced the exact
+  // mismatched pairing #14068 reported.
+  it('claims no install mode it never detected', () => {
+    expect(getRemoteServerUpdaterSnapshot('runtime-1').support).toEqual({
+      installMode: 'interactive',
+      automatic: false,
+      reason: 'updater-unavailable'
+    })
+  })
+
   it('passes the runtime identity through every configured operation', () => {
     const snapshot = {
       appVersion: '1.5.0',

--- a/src/main/runtime/remote-server-updater.ts
+++ b/src/main/runtime/remote-server-updater.ts
@@ -15,7 +15,11 @@ const unavailableSnapshot = (runtimeId: string): RemoteServerUpdaterSnapshot => 
   appVersion: process.env.ORCA_APP_VERSION ?? '0.0.0-dev',
   runtimeId,
   support: {
-    installMode: 'unsupported-headless-serve',
+    // Why: reached only when nothing configured an adapter, which proves the updater is unwired but
+    // proves nothing about the host. Claiming `unsupported-headless-serve` here asserted a serve
+    // install that was never detected, and paired it with the very reason #14068 showed is wrong
+    // for that mode. `interactive` matches the updater's own uninitialized default.
+    installMode: 'interactive',
     automatic: false,
     reason: 'updater-unavailable'
   },

--- a/src/main/serve-manual-update-report.test.ts
+++ b/src/main/serve-manual-update-report.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  appMock,
+  fetchNewerReleaseTagsWithReadinessMock,
+  getLinuxRootPackageTypeMock,
+  recordUpdaterLifecycleMock
+} = vi.hoisted(() => ({
+  appMock: { isPackaged: true, getVersion: vi.fn(() => '1.4.159') },
+  fetchNewerReleaseTagsWithReadinessMock: vi.fn(),
+  getLinuxRootPackageTypeMock: vi.fn<() => 'deb' | 'rpm' | null>(() => null),
+  recordUpdaterLifecycleMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({ app: appMock }))
+vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }))
+vi.mock('./linux-update-package-type', () => ({
+  getLinuxRootPackageType: getLinuxRootPackageTypeMock
+}))
+vi.mock('./updater-prerelease-feed', () => ({
+  fetchNewerReleaseTagsWithReadiness: fetchNewerReleaseTagsWithReadinessMock,
+  getReleaseTagUrl: (tag: string) => `https://github.com/stablyai/orca/releases/tag/${tag}`,
+  normalizeTagToVersion: (tag: string) => tag.replace(/^v/i, '')
+}))
+vi.mock('./updater-lifecycle-diagnostics', () => ({
+  recordUpdaterLifecycle: recordUpdaterLifecycleMock
+}))
+vi.mock('./serve-manual-update-steps', () => ({
+  SERVE_UPGRADE_DOC_URL: 'https://docs.example/upgrade',
+  buildServeManualUpdateSteps: (input: { method: string; latestVersion: string }) => [
+    `install ${input.method} ${input.latestVersion}`
+  ]
+}))
+
+const {
+  detectServeUpdateMethod,
+  getServeManualUpdateReport,
+  startServeManualUpdateReporting,
+  stopServeManualUpdateReporting
+} = await import('./serve-manual-update-report')
+
+const originalPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
+describe('serve manual update report', () => {
+  beforeEach(() => {
+    appMock.isPackaged = true
+    appMock.getVersion.mockReturnValue('1.4.159')
+    getLinuxRootPackageTypeMock.mockReset().mockReturnValue(null)
+    recordUpdaterLifecycleMock.mockReset()
+    fetchNewerReleaseTagsWithReadinessMock
+      .mockReset()
+      .mockResolvedValue({ tags: ['v1.4.200'], state: 'ready' })
+    setPlatform('linux')
+    delete process.env.APPIMAGE
+    delete process.env.APPDIR
+  })
+
+  afterEach(() => {
+    stopServeManualUpdateReporting()
+    setPlatform(originalPlatform)
+    delete process.env.APPIMAGE
+    delete process.env.APPDIR
+  })
+
+  it('reports nothing until a host starts the contract', () => {
+    expect(getServeManualUpdateReport()).toBeNull()
+  })
+
+  it('detects the install method from evidence the install carries', () => {
+    getLinuxRootPackageTypeMock.mockReturnValue('deb')
+    expect(detectServeUpdateMethod()).toBe('deb')
+
+    getLinuxRootPackageTypeMock.mockReturnValue(null)
+    process.env.APPIMAGE = '/opt/orca/orca-linux.AppImage'
+    expect(detectServeUpdateMethod()).toBe('appimage')
+
+    delete process.env.APPIMAGE
+    process.env.APPDIR = '/opt/orca/squashfs-root'
+    expect(detectServeUpdateMethod()).toBe('extracted-appimage')
+
+    delete process.env.APPDIR
+    expect(detectServeUpdateMethod()).toBe('unknown')
+  })
+
+  it('names the newer version and the exact steps once a check succeeds', async () => {
+    getLinuxRootPackageTypeMock.mockReturnValue('deb')
+
+    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+
+    expect(getServeManualUpdateReport()).toEqual({
+      method: 'deb',
+      check: 'update-available',
+      currentVersion: '1.4.159',
+      latestVersion: '1.4.200',
+      releaseUrl: 'https://github.com/stablyai/orca/releases/tag/v1.4.200',
+      steps: ['install deb 1.4.200'],
+      documentationUrl: 'https://docs.example/upgrade'
+    })
+  })
+
+  it('logs an available update once per version, not once per check', async () => {
+    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+    stopServeManualUpdateReporting()
+    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+
+    const announcements = recordUpdaterLifecycleMock.mock.calls.filter(
+      ([event]) => event === 'headless_serve_update_available'
+    )
+    expect(announcements).toHaveLength(2)
+    expect(announcements[0]?.[1]).toMatchObject({
+      currentVersion: '1.4.159',
+      latestVersion: '1.4.200'
+    })
+  })
+
+  it('reports `current` with no steps when nothing newer is published', async () => {
+    fetchNewerReleaseTagsWithReadinessMock.mockResolvedValue({ tags: [], state: 'no-newer' })
+
+    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+
+    expect(getServeManualUpdateReport()).toMatchObject({
+      check: 'current',
+      latestVersion: null,
+      steps: []
+    })
+    expect(recordUpdaterLifecycleMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['unavailable' as const, { tags: [], state: 'unavailable', unavailableReason: 'feed' }],
+    ['not-ready' as const, { tags: ['v1.4.200'], state: 'not-ready' }]
+  ])('never advertises a version it could not prove (%s)', async (_label, feedResult) => {
+    fetchNewerReleaseTagsWithReadinessMock.mockResolvedValue(feedResult)
+
+    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+
+    expect(getServeManualUpdateReport()).toMatchObject({
+      check: 'unavailable',
+      latestVersion: null,
+      steps: []
+    })
+  })
+
+  it('reports the method but skips the release check on an unpackaged host', async () => {
+    appMock.isPackaged = false
+
+    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+
+    expect(fetchNewerReleaseTagsWithReadinessMock).not.toHaveBeenCalled()
+    expect(getServeManualUpdateReport()).toMatchObject({ check: 'unavailable', steps: [] })
+  })
+
+  it('follows the running version for the prerelease channel', async () => {
+    appMock.getVersion.mockReturnValue('1.4.159-rc.1')
+
+    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+
+    expect(fetchNewerReleaseTagsWithReadinessMock).toHaveBeenCalledWith('1.4.159-rc.1', 1, {
+      includePrerelease: true
+    })
+  })
+})

--- a/src/main/serve-manual-update-report.test.ts
+++ b/src/main/serve-manual-update-report.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   appMock,
+  buildServeManualUpdateStepsMock,
   fetchNewerReleaseTagsWithReadinessMock,
   getLinuxRootPackageTypeMock,
   recordUpdaterLifecycleMock
@@ -9,7 +10,10 @@ const {
   appMock: { isPackaged: true, getVersion: vi.fn(() => '1.4.159') },
   fetchNewerReleaseTagsWithReadinessMock: vi.fn(),
   getLinuxRootPackageTypeMock: vi.fn<() => 'deb' | 'rpm' | null>(() => null),
-  recordUpdaterLifecycleMock: vi.fn()
+  recordUpdaterLifecycleMock: vi.fn(),
+  buildServeManualUpdateStepsMock: vi.fn((input: { method: string; latestVersion: string }) => [
+    `install ${input.method} ${input.latestVersion}`
+  ])
 }))
 
 vi.mock('electron', () => ({ app: appMock }))
@@ -26,15 +30,14 @@ vi.mock('./updater-lifecycle-diagnostics', () => ({
   recordUpdaterLifecycle: recordUpdaterLifecycleMock
 }))
 vi.mock('./serve-manual-update-steps', () => ({
-  SERVE_UPGRADE_DOC_URL: 'https://docs.example/upgrade',
-  buildServeManualUpdateSteps: (input: { method: string; latestVersion: string }) => [
-    `install ${input.method} ${input.latestVersion}`
-  ]
+  getServeUpgradeDocUrl: () => 'https://docs.example/upgrade',
+  buildServeManualUpdateSteps: buildServeManualUpdateStepsMock
 }))
 
 const {
   detectServeUpdateMethod,
   getServeManualUpdateReport,
+  SERVE_DISABLE_UPDATE_CHECK_ENV,
   startServeManualUpdateReporting,
   stopServeManualUpdateReporting
 } = await import('./serve-manual-update-report')
@@ -51,12 +54,14 @@ describe('serve manual update report', () => {
     appMock.getVersion.mockReturnValue('1.4.159')
     getLinuxRootPackageTypeMock.mockReset().mockReturnValue(null)
     recordUpdaterLifecycleMock.mockReset()
+    buildServeManualUpdateStepsMock.mockClear()
     fetchNewerReleaseTagsWithReadinessMock
       .mockReset()
       .mockResolvedValue({ tags: ['v1.4.200'], state: 'ready' })
     setPlatform('linux')
     delete process.env.APPIMAGE
     delete process.env.APPDIR
+    delete process.env[SERVE_DISABLE_UPDATE_CHECK_ENV]
   })
 
   afterEach(() => {
@@ -64,6 +69,7 @@ describe('serve manual update report', () => {
     setPlatform(originalPlatform)
     delete process.env.APPIMAGE
     delete process.env.APPDIR
+    delete process.env[SERVE_DISABLE_UPDATE_CHECK_ENV]
   })
 
   it('reports nothing until a host starts the contract', () => {
@@ -89,7 +95,10 @@ describe('serve manual update report', () => {
   it('names the newer version and the exact steps once a check succeeds', async () => {
     getLinuxRootPackageTypeMock.mockReturnValue('deb')
 
-    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+    await startServeManualUpdateReporting({
+      installMode: 'unsupported-headless-serve',
+      intervalMs: 60_000
+    })
 
     expect(getServeManualUpdateReport()).toEqual({
       method: 'deb',
@@ -103,9 +112,15 @@ describe('serve manual update report', () => {
   })
 
   it('logs an available update once per version, not once per check', async () => {
-    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+    await startServeManualUpdateReporting({
+      installMode: 'unsupported-headless-serve',
+      intervalMs: 60_000
+    })
     stopServeManualUpdateReporting()
-    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+    await startServeManualUpdateReporting({
+      installMode: 'unsupported-headless-serve',
+      intervalMs: 60_000
+    })
 
     const announcements = recordUpdaterLifecycleMock.mock.calls.filter(
       ([event]) => event === 'headless_serve_update_available'
@@ -120,7 +135,10 @@ describe('serve manual update report', () => {
   it('reports `current` with no steps when nothing newer is published', async () => {
     fetchNewerReleaseTagsWithReadinessMock.mockResolvedValue({ tags: [], state: 'no-newer' })
 
-    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+    await startServeManualUpdateReporting({
+      installMode: 'unsupported-headless-serve',
+      intervalMs: 60_000
+    })
 
     expect(getServeManualUpdateReport()).toMatchObject({
       check: 'current',
@@ -136,7 +154,10 @@ describe('serve manual update report', () => {
   ])('never advertises a version it could not prove (%s)', async (_label, feedResult) => {
     fetchNewerReleaseTagsWithReadinessMock.mockResolvedValue(feedResult)
 
-    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+    await startServeManualUpdateReporting({
+      installMode: 'unsupported-headless-serve',
+      intervalMs: 60_000
+    })
 
     expect(getServeManualUpdateReport()).toMatchObject({
       check: 'unavailable',
@@ -148,16 +169,64 @@ describe('serve manual update report', () => {
   it('reports the method but skips the release check on an unpackaged host', async () => {
     appMock.isPackaged = false
 
-    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+    await startServeManualUpdateReporting({
+      installMode: 'unsupported-headless-serve',
+      intervalMs: 60_000
+    })
 
     expect(fetchNewerReleaseTagsWithReadinessMock).not.toHaveBeenCalled()
     expect(getServeManualUpdateReport()).toMatchObject({ check: 'unavailable', steps: [] })
   })
 
+  it.each(['interactive', 'supervised-headless-serve'] as const)(
+    'makes no network call and publishes nothing on a %s host',
+    async (installMode) => {
+      await startServeManualUpdateReporting({ installMode, intervalMs: 60_000 })
+
+      expect(fetchNewerReleaseTagsWithReadinessMock).not.toHaveBeenCalled()
+      expect(recordUpdaterLifecycleMock).not.toHaveBeenCalled()
+      expect(getServeManualUpdateReport()).toBeNull()
+    }
+  )
+
+  it('makes no outbound call when the operator opts out', async () => {
+    process.env[SERVE_DISABLE_UPDATE_CHECK_ENV] = '1'
+    getLinuxRootPackageTypeMock.mockReturnValue('deb')
+
+    await startServeManualUpdateReporting({
+      installMode: 'unsupported-headless-serve',
+      intervalMs: 60_000
+    })
+
+    expect(fetchNewerReleaseTagsWithReadinessMock).not.toHaveBeenCalled()
+    expect(getServeManualUpdateReport()).toMatchObject({
+      method: 'deb',
+      check: 'disabled',
+      latestVersion: null,
+      steps: []
+    })
+  })
+
+  it('builds the steps once per tag, not once per status poll', async () => {
+    await startServeManualUpdateReporting({
+      installMode: 'unsupported-headless-serve',
+      intervalMs: 60_000
+    })
+
+    const first = getServeManualUpdateReport()
+    const second = getServeManualUpdateReport()
+
+    expect(buildServeManualUpdateStepsMock).toHaveBeenCalledTimes(1)
+    expect(second?.steps).toBe(first?.steps)
+  })
+
   it('follows the running version for the prerelease channel', async () => {
     appMock.getVersion.mockReturnValue('1.4.159-rc.1')
 
-    await startServeManualUpdateReporting({ intervalMs: 60_000 })
+    await startServeManualUpdateReporting({
+      installMode: 'unsupported-headless-serve',
+      intervalMs: 60_000
+    })
 
     expect(fetchNewerReleaseTagsWithReadinessMock).toHaveBeenCalledWith('1.4.159-rc.1', 1, {
       includePrerelease: true

--- a/src/main/serve-manual-update-report.test.ts
+++ b/src/main/serve-manual-update-report.test.ts
@@ -5,11 +5,13 @@ const {
   buildServeManualUpdateStepsMock,
   fetchNewerReleaseTagsWithReadinessMock,
   getLinuxRootPackageTypeMock,
+  isExternallyManagedLinuxInstallMock,
   recordUpdaterLifecycleMock
 } = vi.hoisted(() => ({
   appMock: { isPackaged: true, getVersion: vi.fn(() => '1.4.159') },
   fetchNewerReleaseTagsWithReadinessMock: vi.fn(),
   getLinuxRootPackageTypeMock: vi.fn<() => 'deb' | 'rpm' | null>(() => null),
+  isExternallyManagedLinuxInstallMock: vi.fn<() => boolean>(() => false),
   recordUpdaterLifecycleMock: vi.fn(),
   buildServeManualUpdateStepsMock: vi.fn((input: { method: string; latestVersion: string }) => [
     `install ${input.method} ${input.latestVersion}`
@@ -19,7 +21,8 @@ const {
 vi.mock('electron', () => ({ app: appMock }))
 vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }))
 vi.mock('./linux-update-package-type', () => ({
-  getLinuxRootPackageType: getLinuxRootPackageTypeMock
+  getLinuxRootPackageType: getLinuxRootPackageTypeMock,
+  isExternallyManagedLinuxInstall: isExternallyManagedLinuxInstallMock
 }))
 vi.mock('./updater-prerelease-feed', () => ({
   fetchNewerReleaseTagsWithReadiness: fetchNewerReleaseTagsWithReadinessMock,
@@ -53,6 +56,7 @@ describe('serve manual update report', () => {
     appMock.isPackaged = true
     appMock.getVersion.mockReturnValue('1.4.159')
     getLinuxRootPackageTypeMock.mockReset().mockReturnValue(null)
+    isExternallyManagedLinuxInstallMock.mockReset().mockReturnValue(false)
     recordUpdaterLifecycleMock.mockReset()
     buildServeManualUpdateStepsMock.mockClear()
     fetchNewerReleaseTagsWithReadinessMock
@@ -79,6 +83,12 @@ describe('serve manual update report', () => {
   it('detects the install method from evidence the install carries', () => {
     getLinuxRootPackageTypeMock.mockReturnValue('deb')
     expect(detectServeUpdateMethod()).toBe('deb')
+
+    // Why: the same marker on a host with no matching package manager describes the artifact Orca
+    // was built as, not the system that owns the install.
+    isExternallyManagedLinuxInstallMock.mockReturnValue(true)
+    expect(detectServeUpdateMethod()).toBe('externally-managed')
+    isExternallyManagedLinuxInstallMock.mockReturnValue(false)
 
     getLinuxRootPackageTypeMock.mockReturnValue(null)
     process.env.APPIMAGE = '/opt/orca/orca-linux.AppImage'

--- a/src/main/serve-manual-update-report.ts
+++ b/src/main/serve-manual-update-report.ts
@@ -1,0 +1,172 @@
+import { app } from 'electron'
+import { is } from '@electron-toolkit/utils'
+import type {
+  ServeManualUpdateCheckState,
+  ServeManualUpdateMethod,
+  ServeManualUpdateReport
+} from '../shared/remote-server-update'
+import { getLinuxRootPackageType } from './linux-update-package-type'
+import {
+  fetchNewerReleaseTagsWithReadiness,
+  getReleaseTagUrl,
+  normalizeTagToVersion
+} from './updater-prerelease-feed'
+import { isPrereleaseVersion } from './updater-fallback'
+import { recordUpdaterLifecycle } from './updater-lifecycle-diagnostics'
+import { AUTO_UPDATE_CHECK_INTERVAL_MS } from './updater/updater-state'
+import { SERVE_UPGRADE_DOC_URL, buildServeManualUpdateSteps } from './serve-manual-update-steps'
+
+type ReportState = {
+  method: ServeManualUpdateMethod
+  appImagePath: string | null
+  check: ServeManualUpdateCheckState
+  latestVersion: string | null
+  latestTag: string | null
+  lastAnnouncedVersion: string | null
+}
+
+let reportState: ReportState | null = null
+let checkTimer: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * The active update method, read only from evidence the running install carries: the packaged
+ * package-type marker `electron-updater` itself uses, and the AppImage runtime's own environment.
+ * Nothing else is consulted, so an install that proves nothing reports `unknown`.
+ */
+export function detectServeUpdateMethod(): ServeManualUpdateMethod {
+  const packageType = getLinuxRootPackageType()
+  if (packageType) {
+    return packageType
+  }
+  if (process.platform !== 'linux') {
+    return 'unknown'
+  }
+  if (process.env.APPIMAGE) {
+    return 'appimage'
+  }
+  // Why: AppRun exports APPDIR for an extracted tree, where no single binary swap applies.
+  return process.env.APPDIR ? 'extracted-appimage' : 'unknown'
+}
+
+/**
+ * The manual update contract for this host, or null when nothing started reporting one.
+ *
+ * Null is not "up to date" — it means this process never entered a mode that owns the contract,
+ * so callers must keep treating an absent report as unknown.
+ */
+export function getServeManualUpdateReport(): ServeManualUpdateReport | null {
+  if (!reportState) {
+    return null
+  }
+  const releaseUrl = reportState.latestTag ? getReleaseTagUrl(reportState.latestTag) : null
+  const steps =
+    reportState.latestVersion && releaseUrl
+      ? buildServeManualUpdateSteps({
+          method: reportState.method,
+          latestVersion: reportState.latestVersion,
+          releaseUrl,
+          appImagePath: reportState.appImagePath
+        })
+      : []
+  return {
+    method: reportState.method,
+    check: reportState.check,
+    currentVersion: app.getVersion(),
+    latestVersion: reportState.latestVersion,
+    releaseUrl,
+    steps,
+    documentationUrl: SERVE_UPGRADE_DOC_URL
+  }
+}
+
+async function runServeUpdateCheck(): Promise<void> {
+  const state = reportState
+  if (!state) {
+    return
+  }
+  const currentVersion = app.getVersion()
+  const result = await fetchNewerReleaseTagsWithReadiness(currentVersion, 1, {
+    includePrerelease: isPrereleaseVersion(currentVersion)
+  })
+  if (state !== reportState) {
+    return
+  }
+  if (result.state === 'no-newer') {
+    state.check = 'current'
+    state.latestVersion = null
+    state.latestTag = null
+    return
+  }
+  const tag = result.state === 'ready' ? (result.tags[0] ?? null) : null
+  if (!tag) {
+    // Why: a feed failure and a mid-publish release both mean "not proven", so keep the last
+    // known target rather than inventing a version the operator could not download yet.
+    state.check = 'unavailable'
+    return
+  }
+  state.check = 'update-available'
+  state.latestTag = tag
+  state.latestVersion = normalizeTagToVersion(tag)
+  if (state.lastAnnouncedVersion === state.latestVersion) {
+    return
+  }
+  // Bounded by construction: one record per newly observed version, not per check.
+  state.lastAnnouncedVersion = state.latestVersion
+  recordUpdaterLifecycle(
+    'headless_serve_update_available',
+    { method: state.method, currentVersion, latestVersion: state.latestVersion },
+    {
+      level: 'warn',
+      message: `Orca ${state.latestVersion} is available; this install updates manually — run \`orca status\` for the exact commands`
+    }
+  )
+}
+
+function scheduleNextCheck(intervalMs: number): void {
+  checkTimer = setTimeout(() => {
+    void runCheckThenSchedule(intervalMs)
+  }, intervalMs)
+  checkTimer.unref?.()
+}
+
+async function runCheckThenSchedule(intervalMs: number): Promise<void> {
+  await runServeUpdateCheck()
+  if (reportState) {
+    scheduleNextCheck(intervalMs)
+  }
+}
+
+/**
+ * Starts the status-only update contract for a headless serve host: detect the install method,
+ * then poll the release feed on the same daily cadence the desktop updater uses. This never
+ * downloads, installs, or restarts anything — it only makes the gap observable.
+ */
+export function startServeManualUpdateReporting(
+  options: { intervalMs?: number } = {}
+): Promise<void> {
+  if (reportState) {
+    return Promise.resolve()
+  }
+  reportState = {
+    method: detectServeUpdateMethod(),
+    appImagePath: process.env.APPIMAGE ?? null,
+    check: 'pending',
+    latestVersion: null,
+    latestTag: null,
+    lastAnnouncedVersion: null
+  }
+  if (!app.isPackaged || is.dev) {
+    // Why: an unpackaged host has no release to compare against; report the method and stop.
+    reportState.check = 'unavailable'
+    return Promise.resolve()
+  }
+  return runCheckThenSchedule(options.intervalMs ?? AUTO_UPDATE_CHECK_INTERVAL_MS)
+}
+
+export function stopServeManualUpdateReporting(): void {
+  if (checkTimer) {
+    clearTimeout(checkTimer)
+    checkTimer = null
+  }
+  reportState = null
+}

--- a/src/main/serve-manual-update-report.ts
+++ b/src/main/serve-manual-update-report.ts
@@ -6,7 +6,10 @@ import type {
   ServeManualUpdateMethod,
   ServeManualUpdateReport
 } from '../shared/remote-server-update'
-import { getLinuxRootPackageType } from './linux-update-package-type'
+import {
+  getLinuxRootPackageType,
+  isExternallyManagedLinuxInstall
+} from './linux-update-package-type'
 import {
   fetchNewerReleaseTagsWithReadiness,
   getReleaseTagUrl,
@@ -44,6 +47,12 @@ let checkTimer: ReturnType<typeof setTimeout> | null = null
  * Nothing else is consulted, so an install that proves nothing reports `unknown`.
  */
 export function detectServeUpdateMethod(): ServeManualUpdateMethod {
+  // Why: repackagers (AUR, Nix, container rebuilds) inherit Orca's `package-type` marker verbatim,
+  // so a `deb` marker on a host with no dpkg/apt describes the artifact, not the system that owns
+  // the install (#18100). Reporting `deb` there would advise a download it could never apply.
+  if (isExternallyManagedLinuxInstall()) {
+    return 'externally-managed'
+  }
   const packageType = getLinuxRootPackageType()
   if (packageType) {
     return packageType

--- a/src/main/serve-manual-update-report.ts
+++ b/src/main/serve-manual-update-report.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import type {
+  RemoteServerUpdateInstallMode,
   ServeManualUpdateCheckState,
   ServeManualUpdateMethod,
   ServeManualUpdateReport
@@ -14,7 +15,14 @@ import {
 import { isPrereleaseVersion } from './updater-fallback'
 import { recordUpdaterLifecycle } from './updater-lifecycle-diagnostics'
 import { AUTO_UPDATE_CHECK_INTERVAL_MS } from './updater/updater-state'
-import { SERVE_UPGRADE_DOC_URL, buildServeManualUpdateSteps } from './serve-manual-update-steps'
+import { buildServeManualUpdateSteps, getServeUpgradeDocUrl } from './serve-manual-update-steps'
+
+/**
+ * Opts a host out of the daily release check. Named for exactly what it disables: an air-gapped or
+ * egress-audited server makes no outbound call, and `check: 'disabled'` says so rather than
+ * masquerading as a check that failed.
+ */
+export const SERVE_DISABLE_UPDATE_CHECK_ENV = 'ORCA_SERVE_DISABLE_UPDATE_CHECK'
 
 type ReportState = {
   method: ServeManualUpdateMethod
@@ -23,6 +31,8 @@ type ReportState = {
   latestVersion: string | null
   latestTag: string | null
   lastAnnouncedVersion: string | null
+  /** Memoized on the tag: `status.get` is client-polled and step building stats the filesystem. */
+  cachedSteps: { tag: string; steps: string[] } | null
 }
 
 let reportState: ReportState | null = null
@@ -58,24 +68,28 @@ export function getServeManualUpdateReport(): ServeManualUpdateReport | null {
   if (!reportState) {
     return null
   }
-  const releaseUrl = reportState.latestTag ? getReleaseTagUrl(reportState.latestTag) : null
-  const steps =
-    reportState.latestVersion && releaseUrl
-      ? buildServeManualUpdateSteps({
-          method: reportState.method,
-          latestVersion: reportState.latestVersion,
-          releaseUrl,
-          appImagePath: reportState.appImagePath
-        })
-      : []
+  const { latestTag, latestVersion } = reportState
+  const releaseUrl = latestTag ? getReleaseTagUrl(latestTag) : null
+  if (latestTag && latestVersion && releaseUrl && reportState.cachedSteps?.tag !== latestTag) {
+    reportState.cachedSteps = {
+      tag: latestTag,
+      steps: buildServeManualUpdateSteps({
+        method: reportState.method,
+        latestVersion,
+        releaseUrl,
+        appImagePath: reportState.appImagePath
+      })
+    }
+  }
+  const cached = latestTag ? reportState.cachedSteps : null
   return {
     method: reportState.method,
     check: reportState.check,
     currentVersion: app.getVersion(),
-    latestVersion: reportState.latestVersion,
+    latestVersion,
     releaseUrl,
-    steps,
-    documentationUrl: SERVE_UPGRADE_DOC_URL
+    steps: cached?.tag === latestTag ? cached.steps : [],
+    documentationUrl: getServeUpgradeDocUrl()
   }
 }
 
@@ -95,6 +109,7 @@ async function runServeUpdateCheck(): Promise<void> {
     state.check = 'current'
     state.latestVersion = null
     state.latestTag = null
+    state.cachedSteps = null
     return
   }
   const tag = result.state === 'ready' ? (result.tags[0] ?? null) : null
@@ -141,10 +156,14 @@ async function runCheckThenSchedule(intervalMs: number): Promise<void> {
  * then poll the release feed on the same daily cadence the desktop updater uses. This never
  * downloads, installs, or restarts anything — it only makes the gap observable.
  */
-export function startServeManualUpdateReporting(
-  options: { intervalMs?: number } = {}
-): Promise<void> {
-  if (reportState) {
+export function startServeManualUpdateReporting(options: {
+  installMode: RemoteServerUpdateInstallMode
+  intervalMs?: number
+}): Promise<void> {
+  // Why: only the mode whose status branch publishes this report may pay for the check. A
+  // supervised or interactive host would otherwise fetch the feed and log advice pointing at a
+  // status surface that never carries it.
+  if (reportState || options.installMode !== 'unsupported-headless-serve') {
     return Promise.resolve()
   }
   reportState = {
@@ -153,7 +172,12 @@ export function startServeManualUpdateReporting(
     check: 'pending',
     latestVersion: null,
     latestTag: null,
-    lastAnnouncedVersion: null
+    lastAnnouncedVersion: null,
+    cachedSteps: null
+  }
+  if (process.env[SERVE_DISABLE_UPDATE_CHECK_ENV]) {
+    reportState.check = 'disabled'
+    return Promise.resolve()
   }
   if (!app.isPackaged || is.dev) {
     // Why: an unpackaged host has no release to compare against; report the method and stop.

--- a/src/main/serve-manual-update-steps.test.ts
+++ b/src/main/serve-manual-update-steps.test.ts
@@ -17,7 +17,7 @@ const { buildServeManualUpdateSteps, getServeUpgradeDocUrl, SERVE_UPGRADE_DOC_UR
 const RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/v1.4.200'
 
 function stepsFor(overrides: {
-  method: 'deb' | 'rpm' | 'appimage' | 'extracted-appimage' | 'unknown'
+  method: 'deb' | 'rpm' | 'appimage' | 'extracted-appimage' | 'externally-managed' | 'unknown'
   appImagePath?: string | null
   latestVersion?: string
   platform?: NodeJS.Platform
@@ -114,6 +114,15 @@ describe('buildServeManualUpdateSteps', () => {
     expect(getServeUpgradeDocUrl('linux')).toBe(SERVE_UPGRADE_DOC_URL)
     expect(getServeUpgradeDocUrl('win32')).toBe('https://www.onorca.dev/docs/remote-servers')
     expect(getServeUpgradeDocUrl('darwin')).toBe('https://www.onorca.dev/docs/remote-servers')
+  })
+
+  it('sends a repackaged install to its own package manager, not the release page', () => {
+    const steps = stepsFor({ method: 'externally-managed' })
+
+    expect(steps.join('\n')).not.toContain(RELEASE_URL)
+    expect(steps[0]).toContain('1.4.200')
+    expect(steps[1]).toContain('Update through whichever package manager installed Orca')
+    expect(buildLinuxPackageInstallCommandMock).not.toHaveBeenCalled()
   })
 
   it('never emits a step Orca could run for the operator', () => {

--- a/src/main/serve-manual-update-steps.test.ts
+++ b/src/main/serve-manual-update-steps.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { buildLinuxPackageInstallCommandMock, resolveTrustedExecutableMock } = vi.hoisted(() => ({
+  buildLinuxPackageInstallCommandMock: vi.fn(),
+  resolveTrustedExecutableMock: vi.fn()
+}))
+
+vi.mock('./linux-package-install-command', () => ({
+  buildLinuxPackageInstallCommand: buildLinuxPackageInstallCommandMock,
+  resolveTrustedExecutable: resolveTrustedExecutableMock,
+  quoteForPosixShell: (value: string) => `'${value.split("'").join(`'"'"'`)}'`
+}))
+
+const { buildServeManualUpdateSteps, SERVE_UPGRADE_DOC_URL } =
+  await import('./serve-manual-update-steps')
+
+const RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/v1.4.200'
+
+function stepsFor(overrides: {
+  method: 'deb' | 'rpm' | 'appimage' | 'extracted-appimage' | 'unknown'
+  appImagePath?: string | null
+  latestVersion?: string
+}): string[] {
+  return buildServeManualUpdateSteps({
+    method: overrides.method,
+    latestVersion: overrides.latestVersion ?? '1.4.200',
+    releaseUrl: RELEASE_URL,
+    appImagePath: overrides.appImagePath ?? null
+  })
+}
+
+describe('buildServeManualUpdateSteps', () => {
+  beforeEach(() => {
+    buildLinuxPackageInstallCommandMock.mockReset().mockImplementation((_type, packagePath) => ({
+      ok: true,
+      command: `/usr/bin/sudo /usr/bin/apt install -- '${packagePath}'`
+    }))
+    resolveTrustedExecutableMock
+      .mockReset()
+      .mockImplementation((name: string) => `/usr/bin/${name}`)
+  })
+
+  it('names the exact package-manager command for a deb install', () => {
+    const steps = stepsFor({ method: 'deb' })
+
+    expect(buildLinuxPackageInstallCommandMock).toHaveBeenCalledWith(
+      'deb',
+      expect.stringMatching(/^\/.*orca-1\.4\.200\.deb$/)
+    )
+    expect(steps[0]).toContain(RELEASE_URL)
+    expect(steps[1]).toMatch(
+      /^\/usr\/bin\/sudo \/usr\/bin\/apt install -- '\/.*orca-1\.4\.200\.deb'$/
+    )
+    expect(steps[2]).toContain('Restart the service unit that runs `orca serve`')
+  })
+
+  it('routes an rpm install through the same builder', () => {
+    stepsFor({ method: 'rpm' })
+
+    expect(buildLinuxPackageInstallCommandMock).toHaveBeenCalledWith(
+      'rpm',
+      expect.stringMatching(/orca-1\.4\.200\.rpm$/)
+    )
+  })
+
+  it('swaps an AppImage through a staged name rather than writing it in place', () => {
+    const steps = stepsFor({ method: 'appimage', appImagePath: '/opt/orca/orca-linux.AppImage' })
+
+    expect(steps[0]).toContain('/opt/orca/orca-linux.AppImage.new')
+    expect(steps[1]).toBe(
+      "/usr/bin/sudo /usr/bin/mv -- '/opt/orca/orca-linux.AppImage.new' '/opt/orca/orca-linux.AppImage'"
+    )
+  })
+
+  it('falls back to the documented procedure when no package manager is resolvable', () => {
+    buildLinuxPackageInstallCommandMock.mockReturnValue({ ok: false, reason: 'no-sudo' })
+
+    expect(stepsFor({ method: 'deb' })[0]).toContain(SERVE_UPGRADE_DOC_URL)
+  })
+
+  it('refuses to embed a version that is not filename-safe', () => {
+    expect(stepsFor({ method: 'deb', latestVersion: '1.4.200; rm -rf /' })[0]).toContain(
+      SERVE_UPGRADE_DOC_URL
+    )
+    expect(buildLinuxPackageInstallCommandMock).not.toHaveBeenCalled()
+  })
+
+  it('points an extracted tree and an unproven install at the documented procedure', () => {
+    for (const method of ['extracted-appimage', 'unknown'] as const) {
+      const steps = stepsFor({ method })
+      expect(steps[0]).toContain(RELEASE_URL)
+      expect(steps[1]).toContain(SERVE_UPGRADE_DOC_URL)
+    }
+  })
+
+  it('never emits a step Orca could run for the operator', () => {
+    const allSteps = [
+      ...stepsFor({ method: 'deb' }),
+      ...stepsFor({ method: 'appimage', appImagePath: '/opt/orca/orca-linux.AppImage' })
+    ]
+
+    expect(allSteps.filter((step) => step.includes('sudo'))).toHaveLength(2)
+    expect(allSteps.some((step) => step.includes('systemctl restart'))).toBe(false)
+  })
+})

--- a/src/main/serve-manual-update-steps.test.ts
+++ b/src/main/serve-manual-update-steps.test.ts
@@ -11,7 +11,7 @@ vi.mock('./linux-package-install-command', () => ({
   quoteForPosixShell: (value: string) => `'${value.split("'").join(`'"'"'`)}'`
 }))
 
-const { buildServeManualUpdateSteps, SERVE_UPGRADE_DOC_URL } =
+const { buildServeManualUpdateSteps, getServeUpgradeDocUrl, SERVE_UPGRADE_DOC_URL } =
   await import('./serve-manual-update-steps')
 
 const RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/v1.4.200'
@@ -20,12 +20,14 @@ function stepsFor(overrides: {
   method: 'deb' | 'rpm' | 'appimage' | 'extracted-appimage' | 'unknown'
   appImagePath?: string | null
   latestVersion?: string
+  platform?: NodeJS.Platform
 }): string[] {
   return buildServeManualUpdateSteps({
     method: overrides.method,
     latestVersion: overrides.latestVersion ?? '1.4.200',
     releaseUrl: RELEASE_URL,
-    appImagePath: overrides.appImagePath ?? null
+    appImagePath: overrides.appImagePath ?? null,
+    platform: overrides.platform ?? 'linux'
   })
 }
 
@@ -91,6 +93,27 @@ describe('buildServeManualUpdateSteps', () => {
       expect(steps[0]).toContain(RELEASE_URL)
       expect(steps[1]).toContain(SERVE_UPGRADE_DOC_URL)
     }
+  })
+
+  it('keeps systemd vocabulary and the Linux guide off a non-Linux serve host', () => {
+    expect(stepsFor({ method: 'unknown', platform: 'linux' }).join('\n')).toContain(
+      'Restart the service unit that runs `orca serve`'
+    )
+
+    const windowsSteps = stepsFor({ method: 'unknown', platform: 'win32' }).join('\n')
+    expect(windowsSteps).toContain('Windows service or scheduled task')
+    expect(windowsSteps).not.toContain('service unit')
+    expect(windowsSteps).not.toContain('headless-linux-server')
+
+    const macSteps = stepsFor({ method: 'unknown', platform: 'darwin' }).join('\n')
+    expect(macSteps).toContain('launchd job or supervisor')
+    expect(macSteps).not.toContain('headless-linux-server')
+  })
+
+  it('links the Linux guide only on Linux', () => {
+    expect(getServeUpgradeDocUrl('linux')).toBe(SERVE_UPGRADE_DOC_URL)
+    expect(getServeUpgradeDocUrl('win32')).toBe('https://www.onorca.dev/docs/remote-servers')
+    expect(getServeUpgradeDocUrl('darwin')).toBe('https://www.onorca.dev/docs/remote-servers')
   })
 
   it('never emits a step Orca could run for the operator', () => {

--- a/src/main/serve-manual-update-steps.ts
+++ b/src/main/serve-manual-update-steps.ts
@@ -1,0 +1,94 @@
+import os from 'node:os'
+import path from 'node:path'
+import type { ServeManualUpdateMethod } from '../shared/remote-server-update'
+import {
+  buildLinuxPackageInstallCommand,
+  quoteForPosixShell,
+  resolveTrustedExecutable
+} from './linux-package-install-command'
+
+export const SERVE_UPGRADE_DOC_URL =
+  'https://github.com/stablyai/orca/blob/main/docs/reference/headless-linux-server.md#upgrade'
+
+// Why: no service unit name is knowable from inside the runtime, and #14068 forbids guessing one.
+const RESTART_STEP =
+  'Restart the service unit that runs `orca serve`. Orca does not restart itself: nothing here can prove exactly one replacement would start.'
+
+function documentedProcedureStep(documentationUrl: string): string {
+  return `Follow the documented upgrade procedure for this install: ${documentationUrl}`
+}
+
+/** Rejects anything a release tag should never contain before it reaches a shell-quoted path. */
+function sanitizeVersionForFileName(version: string): string | null {
+  return /^[0-9A-Za-z][0-9A-Za-z.+-]*$/.test(version) ? version : null
+}
+
+function buildPackageSteps(
+  method: 'deb' | 'rpm',
+  latestVersion: string,
+  releaseUrl: string,
+  documentationUrl: string
+): string[] {
+  const safeVersion = sanitizeVersionForFileName(latestVersion)
+  if (!safeVersion) {
+    return [documentedProcedureStep(documentationUrl), RESTART_STEP]
+  }
+  // posix.join: this advice only ever describes a Linux host.
+  const stagedPath = path.posix.join(os.tmpdir(), `orca-${safeVersion}.${method}`)
+  const install = buildLinuxPackageInstallCommand(method, stagedPath)
+  if (!install.ok) {
+    return [documentedProcedureStep(documentationUrl), RESTART_STEP]
+  }
+  return [
+    `Download the .${method} for this machine's architecture from ${releaseUrl} to ${stagedPath}`,
+    install.command,
+    RESTART_STEP
+  ]
+}
+
+function buildAppImageSteps(
+  appImagePath: string,
+  releaseUrl: string,
+  documentationUrl: string
+): string[] {
+  const sudoPath = resolveTrustedExecutable('sudo')
+  const movePath = resolveTrustedExecutable('mv')
+  if (!sudoPath || !movePath) {
+    return [documentedProcedureStep(documentationUrl), RESTART_STEP]
+  }
+  const stagedPath = `${appImagePath}.new`
+  return [
+    // Why: the running AppImage is FUSE-mounted, so it must never be written in place.
+    `Download the Linux AppImage for this machine's architecture from ${releaseUrl} to ${stagedPath}`,
+    `${sudoPath} ${movePath} -- ${quoteForPosixShell(stagedPath)} ${quoteForPosixShell(appImagePath)}`,
+    RESTART_STEP
+  ]
+}
+
+/**
+ * The exact operator steps for a host Orca refuses to update itself. Every command is a fixed
+ * literal plus POSIX-single-quoted paths, and none of them is ever executed — the serve process
+ * runs unprivileged with no authentication agent, so the privileged install stays the operator's
+ * action by design.
+ */
+export function buildServeManualUpdateSteps(input: {
+  method: ServeManualUpdateMethod
+  latestVersion: string
+  releaseUrl: string
+  /** Absolute path of the running AppImage, when the method is `appimage`. */
+  appImagePath: string | null
+  documentationUrl?: string
+}): string[] {
+  const documentationUrl = input.documentationUrl ?? SERVE_UPGRADE_DOC_URL
+  if (input.method === 'deb' || input.method === 'rpm') {
+    return buildPackageSteps(input.method, input.latestVersion, input.releaseUrl, documentationUrl)
+  }
+  if (input.method === 'appimage' && input.appImagePath && path.isAbsolute(input.appImagePath)) {
+    return buildAppImageSteps(input.appImagePath, input.releaseUrl, documentationUrl)
+  }
+  return [
+    `Download the release for this machine's architecture from ${input.releaseUrl}`,
+    documentedProcedureStep(documentationUrl),
+    RESTART_STEP
+  ]
+}

--- a/src/main/serve-manual-update-steps.ts
+++ b/src/main/serve-manual-update-steps.ts
@@ -9,10 +9,25 @@ import {
 
 export const SERVE_UPGRADE_DOC_URL =
   'https://github.com/stablyai/orca/blob/main/docs/reference/headless-linux-server.md#upgrade'
+// Why: that guide is systemd-specific, but a Windows or macOS serve host resolves to the same
+// install mode — it must not be handed systemd vocabulary or a Linux-only link.
+const SERVE_REMOTE_DOC_URL = 'https://www.onorca.dev/docs/remote-servers'
 
-// Why: no service unit name is knowable from inside the runtime, and #14068 forbids guessing one.
-const RESTART_STEP =
-  'Restart the service unit that runs `orca serve`. Orca does not restart itself: nothing here can prove exactly one replacement would start.'
+export function getServeUpgradeDocUrl(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'linux' ? SERVE_UPGRADE_DOC_URL : SERVE_REMOTE_DOC_URL
+}
+
+// Why: no unit/service name is knowable from inside the runtime, and #14068 forbids guessing one.
+// Only the vocabulary for "the thing that supervises this process" varies by platform.
+function restartStep(platform: NodeJS.Platform): string {
+  const supervisor =
+    platform === 'linux'
+      ? 'service unit'
+      : platform === 'win32'
+        ? 'Windows service or scheduled task'
+        : 'launchd job or supervisor'
+  return `Restart the ${supervisor} that runs \`orca serve\`. Orca does not restart itself: nothing here can prove exactly one replacement would start.`
+}
 
 function documentedProcedureStep(documentationUrl: string): string {
   return `Follow the documented upgrade procedure for this install: ${documentationUrl}`
@@ -27,41 +42,43 @@ function buildPackageSteps(
   method: 'deb' | 'rpm',
   latestVersion: string,
   releaseUrl: string,
-  documentationUrl: string
+  documentationUrl: string,
+  restart: string
 ): string[] {
   const safeVersion = sanitizeVersionForFileName(latestVersion)
   if (!safeVersion) {
-    return [documentedProcedureStep(documentationUrl), RESTART_STEP]
+    return [documentedProcedureStep(documentationUrl), restart]
   }
   // posix.join: this advice only ever describes a Linux host.
   const stagedPath = path.posix.join(os.tmpdir(), `orca-${safeVersion}.${method}`)
   const install = buildLinuxPackageInstallCommand(method, stagedPath)
   if (!install.ok) {
-    return [documentedProcedureStep(documentationUrl), RESTART_STEP]
+    return [documentedProcedureStep(documentationUrl), restart]
   }
   return [
     `Download the .${method} for this machine's architecture from ${releaseUrl} to ${stagedPath}`,
     install.command,
-    RESTART_STEP
+    restart
   ]
 }
 
 function buildAppImageSteps(
   appImagePath: string,
   releaseUrl: string,
-  documentationUrl: string
+  documentationUrl: string,
+  restart: string
 ): string[] {
   const sudoPath = resolveTrustedExecutable('sudo')
   const movePath = resolveTrustedExecutable('mv')
   if (!sudoPath || !movePath) {
-    return [documentedProcedureStep(documentationUrl), RESTART_STEP]
+    return [documentedProcedureStep(documentationUrl), restart]
   }
   const stagedPath = `${appImagePath}.new`
   return [
     // Why: the running AppImage is FUSE-mounted, so it must never be written in place.
     `Download the Linux AppImage for this machine's architecture from ${releaseUrl} to ${stagedPath}`,
     `${sudoPath} ${movePath} -- ${quoteForPosixShell(stagedPath)} ${quoteForPosixShell(appImagePath)}`,
-    RESTART_STEP
+    restart
   ]
 }
 
@@ -77,18 +94,27 @@ export function buildServeManualUpdateSteps(input: {
   releaseUrl: string
   /** Absolute path of the running AppImage, when the method is `appimage`. */
   appImagePath: string | null
+  platform?: NodeJS.Platform
   documentationUrl?: string
 }): string[] {
-  const documentationUrl = input.documentationUrl ?? SERVE_UPGRADE_DOC_URL
+  const platform = input.platform ?? process.platform
+  const documentationUrl = input.documentationUrl ?? getServeUpgradeDocUrl(platform)
+  const restart = restartStep(platform)
   if (input.method === 'deb' || input.method === 'rpm') {
-    return buildPackageSteps(input.method, input.latestVersion, input.releaseUrl, documentationUrl)
+    return buildPackageSteps(
+      input.method,
+      input.latestVersion,
+      input.releaseUrl,
+      documentationUrl,
+      restart
+    )
   }
   if (input.method === 'appimage' && input.appImagePath && path.isAbsolute(input.appImagePath)) {
-    return buildAppImageSteps(input.appImagePath, input.releaseUrl, documentationUrl)
+    return buildAppImageSteps(input.appImagePath, input.releaseUrl, documentationUrl, restart)
   }
   return [
     `Download the release for this machine's architecture from ${input.releaseUrl}`,
     documentedProcedureStep(documentationUrl),
-    RESTART_STEP
+    restart
   ]
 }

--- a/src/main/serve-manual-update-steps.ts
+++ b/src/main/serve-manual-update-steps.ts
@@ -112,6 +112,15 @@ export function buildServeManualUpdateSteps(input: {
   if (input.method === 'appimage' && input.appImagePath && path.isAbsolute(input.appImagePath)) {
     return buildAppImageSteps(input.appImagePath, input.releaseUrl, documentationUrl, restart)
   }
+  if (input.method === 'externally-managed') {
+    // Why: a GitHub download is useless here — no package manager on this host could apply it.
+    // The distribution or repackager that installed Orca owns the upgrade.
+    return [
+      `Orca ${input.latestVersion} is published, but this install came from a repackager or distribution rather than an Orca release artifact.`,
+      'Update through whichever package manager installed Orca; a package downloaded from the Orca release page cannot be applied on this host.',
+      restart
+    ]
+  }
   return [
     `Download the release for this machine's architecture from ${input.releaseUrl}`,
     documentedProcedureStep(documentationUrl),

--- a/src/main/startup/main-process-runtime-launch.ts
+++ b/src/main/startup/main-process-runtime-launch.ts
@@ -124,7 +124,8 @@ async function launchServeMode(
 ): Promise<void> {
   // Why: serve opens no window, so nothing else records the install mode; set it before the RPC
   // transport starts or the first status.get describes a desktop install with a broken updater.
-  setUpdateInstallMode(resolveUpdateInstallMode(true))
+  const serveInstallMode = resolveUpdateInstallMode(true)
+  setUpdateInstallMode(serveInstallMode)
   // Why: give managed WSL launchers a brief chance to migrate before headless PTYs go live, without slow repairs withholding all RPC readiness.
   logStartupMilestone('wsl-cli-barrier-start')
   await state.managedWslCliStartupBarrierReady
@@ -205,7 +206,8 @@ async function launchServeMode(
   scheduleAllPendingHistoryTreeRemovals()
   await printServeReady(serveOptions)
   // Why: after readiness, because stdout is the serve readiness API and this check is network-bound.
-  void startServeManualUpdateReporting()
+  // Gated on the mode so only a host that actually publishes the contract pays for the egress.
+  void startServeManualUpdateReporting({ installMode: serveInstallMode })
 }
 
 async function launchDesktopMode(

--- a/src/main/startup/main-process-runtime-launch.ts
+++ b/src/main/startup/main-process-runtime-launch.ts
@@ -33,6 +33,8 @@ import {
 import { CliInstaller } from '../cli/cli-installer'
 import { installLinuxBareOrcaDispatcher } from '../cli/linux-bare-orca-dispatcher'
 import { scheduleAllPendingHistoryTreeRemovals } from '../terminal-history-deletion'
+import { resolveUpdateInstallMode, setUpdateInstallMode } from '../updater'
+import { startServeManualUpdateReporting } from '../serve-manual-update-report'
 import { triggerStartupNotificationRegistration } from '../ipc/startup-notification-registration'
 import { mainProcessState as state } from './main-process-state'
 import { logStartupMilestone } from './startup-diagnostics'
@@ -120,6 +122,9 @@ async function launchServeMode(
   runtimeRpc: OrcaRuntimeRpcServer,
   serveOptions: NonNullable<ReturnType<typeof getServeOptions>>
 ): Promise<void> {
+  // Why: serve opens no window, so nothing else records the install mode; set it before the RPC
+  // transport starts or the first status.get describes a desktop install with a broken updater.
+  setUpdateInstallMode(resolveUpdateInstallMode(true))
   // Why: give managed WSL launchers a brief chance to migrate before headless PTYs go live, without slow repairs withholding all RPC readiness.
   logStartupMilestone('wsl-cli-barrier-start')
   await state.managedWslCliStartupBarrierReady
@@ -199,6 +204,8 @@ async function launchServeMode(
   // armed from the main window — without this, a quit mid-removal leaks the tree until a desktop launch.
   scheduleAllPendingHistoryTreeRemovals()
   await printServeReady(serveOptions)
+  // Why: after readiness, because stdout is the serve readiness API and this check is network-bound.
+  void startServeManualUpdateReporting()
 }
 
 async function launchDesktopMode(

--- a/src/main/startup/serve-update-contract-wiring.test.ts
+++ b/src/main/startup/serve-update-contract-wiring.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `launchServeMode` has no unit-testable seam — it pulls the whole main-process graph — so the
+ * ordering the update contract depends on is asserted against the source, matching
+ * serve-desktop-activation-wiring.test.ts.
+ */
+describe('serve update contract wiring', () => {
+  const runtimeSource = readFileSync(
+    join(process.cwd(), 'src/main/startup/main-process-runtime-launch.ts'),
+    'utf8'
+  )
+  const serveLaunchIndex = runtimeSource.indexOf('async function launchServeMode(')
+  const desktopLaunchIndex = runtimeSource.indexOf('async function launchDesktopMode(')
+
+  it('records the serve install mode before any client can read status', () => {
+    const installModeIndex = runtimeSource.indexOf(
+      'setUpdateInstallMode(resolveUpdateInstallMode(true))',
+      serveLaunchIndex
+    )
+    const rpcStartIndex = runtimeSource.indexOf('await runtimeRpc.start()', serveLaunchIndex)
+
+    expect(serveLaunchIndex).toBeGreaterThanOrEqual(0)
+    expect(installModeIndex).toBeGreaterThan(serveLaunchIndex)
+    expect(installModeIndex).toBeLessThan(rpcStartIndex)
+    expect(installModeIndex).toBeLessThan(desktopLaunchIndex)
+  })
+
+  it('starts the release check after readiness so stdout stays the readiness API', () => {
+    const readinessIndex = runtimeSource.indexOf('await printServeReady(serveOptions)')
+    const reportIndex = runtimeSource.indexOf('startServeManualUpdateReporting()', serveLaunchIndex)
+
+    expect(readinessIndex).toBeGreaterThan(serveLaunchIndex)
+    expect(reportIndex).toBeGreaterThan(readinessIndex)
+    expect(reportIndex).toBeLessThan(desktopLaunchIndex)
+  })
+
+  it('never gives serve an install or restart path', () => {
+    const serveBody = runtimeSource.slice(serveLaunchIndex, desktopLaunchIndex)
+
+    for (const forbidden of ['quitAndInstall', 'downloadRemoteServerUpdate', 'sudo', 'systemctl']) {
+      expect(serveBody).not.toContain(forbidden)
+    }
+  })
+})

--- a/src/main/startup/serve-update-contract-wiring.test.ts
+++ b/src/main/startup/serve-update-contract-wiring.test.ts
@@ -17,7 +17,7 @@ describe('serve update contract wiring', () => {
 
   it('records the serve install mode before any client can read status', () => {
     const installModeIndex = runtimeSource.indexOf(
-      'setUpdateInstallMode(resolveUpdateInstallMode(true))',
+      'setUpdateInstallMode(serveInstallMode)',
       serveLaunchIndex
     )
     const rpcStartIndex = runtimeSource.indexOf('await runtimeRpc.start()', serveLaunchIndex)
@@ -30,11 +30,22 @@ describe('serve update contract wiring', () => {
 
   it('starts the release check after readiness so stdout stays the readiness API', () => {
     const readinessIndex = runtimeSource.indexOf('await printServeReady(serveOptions)')
-    const reportIndex = runtimeSource.indexOf('startServeManualUpdateReporting()', serveLaunchIndex)
+    const reportIndex = runtimeSource.indexOf(
+      'startServeManualUpdateReporting({ installMode: serveInstallMode })',
+      serveLaunchIndex
+    )
 
     expect(readinessIndex).toBeGreaterThan(serveLaunchIndex)
     expect(reportIndex).toBeGreaterThan(readinessIndex)
     expect(reportIndex).toBeLessThan(desktopLaunchIndex)
+  })
+
+  // Why: the reporter is only consulted inside the unsupported-headless-serve status branch, so an
+  // ungated start would fetch the release feed and log update advice on a supervised host whose own
+  // status surface never carries it.
+  it('pays for the release check only on the mode that publishes the contract', () => {
+    expect(runtimeSource).toContain('const serveInstallMode = resolveUpdateInstallMode(true)')
+    expect(runtimeSource).not.toContain('startServeManualUpdateReporting()')
   })
 
   it('never gives serve an install or restart path', () => {

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -4,6 +4,7 @@ import { compareVersions, isPrereleaseVersion, isValidVersion } from './updater-
 
 const ATOM_FEED_URL = 'https://github.com/stablyai/orca/releases.atom'
 const RELEASES_DOWNLOAD_BASE = 'https://github.com/stablyai/orca/releases/download'
+const RELEASES_TAG_BASE = 'https://github.com/stablyai/orca/releases/tag'
 const FETCH_TIMEOUT_MS = 5000
 const MAX_MANIFEST_PROBE_CANDIDATES = 6
 
@@ -14,6 +15,11 @@ const TAG_HREF_RE = /href="https:\/\/github\.com\/stablyai\/orca\/releases\/tag\
 
 export function getReleaseDownloadUrl(tag: string): string {
   return `${RELEASES_DOWNLOAD_BASE}/${encodeURIComponent(tag)}`
+}
+
+/** The browsable release page, where an operator picks the asset for their architecture. */
+export function getReleaseTagUrl(tag: string): string {
+  return `${RELEASES_TAG_BASE}/${encodeURIComponent(tag)}`
 }
 
 function getPlatformManifestName(): string {

--- a/src/main/updater.headless-serve-install.test.ts
+++ b/src/main/updater.headless-serve-install.test.ts
@@ -549,7 +549,10 @@ describe('headless serve update install handoff', () => {
         reason: 'manual-service-update-required'
       })
 
-      await startServeManualUpdateReporting({ intervalMs: 60_000 })
+      await startServeManualUpdateReporting({
+        installMode: 'unsupported-headless-serve',
+        intervalMs: 60_000
+      })
       const support = getRemoteServerUpdateSupport()
 
       expect(support.reason).toBe('manual-service-update-required')

--- a/src/main/updater.headless-serve-install.test.ts
+++ b/src/main/updater.headless-serve-install.test.ts
@@ -94,7 +94,9 @@ vi.mock('./updater-prerelease-feed', () => ({
     tags: ['v1.0.61'],
     state: 'ready'
   }),
-  getReleaseDownloadUrl: vi.fn()
+  getReleaseDownloadUrl: vi.fn(),
+  getReleaseTagUrl: (tag: string) => `https://github.com/stablyai/orca/releases/tag/${tag}`,
+  normalizeTagToVersion: (tag: string) => tag.replace(/^v/i, '')
 }))
 vi.mock('./update-install-exit-watchdog', () => ({
   armUpdateInstallExitWatchdog: vi.fn(),
@@ -528,5 +530,40 @@ describe('headless serve update install handoff', () => {
       reason: 'manual-service-update-required'
     })
     expect(() => checkForRemoteServerUpdate('runtime-1')).toThrow('remote_update_manual_required')
+  })
+
+  // Why: headless serve opens no window, so setupAutoUpdater never runs. Before #14068 the status
+  // surface reported `interactive` / `updater-unavailable` there — a desktop install with a broken
+  // updater — instead of a server that is correctly refusing to update itself.
+  it('reports the manual update contract on a serve host that never initialized an updater', async () => {
+    const { getRemoteServerUpdateSupport, setUpdateInstallMode } = await loadUpdaterModule()
+    const { startServeManualUpdateReporting, stopServeManualUpdateReporting } =
+      await import('./serve-manual-update-report')
+
+    // Standing in for launchServeMode: no setupAutoUpdater call, so nothing else records the mode.
+    setUpdateInstallMode('unsupported-headless-serve')
+    try {
+      expect(getRemoteServerUpdateSupport()).toEqual({
+        installMode: 'unsupported-headless-serve',
+        automatic: false,
+        reason: 'manual-service-update-required'
+      })
+
+      await startServeManualUpdateReporting({ intervalMs: 60_000 })
+      const support = getRemoteServerUpdateSupport()
+
+      expect(support.reason).toBe('manual-service-update-required')
+      expect(support.manualUpdate).toMatchObject({
+        check: 'update-available',
+        currentVersion: '1.0.51',
+        latestVersion: '1.0.61',
+        releaseUrl: 'https://github.com/stablyai/orca/releases/tag/v1.0.61'
+      })
+      expect(support.manualUpdate?.steps.length).toBeGreaterThan(0)
+      expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled()
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
+    } finally {
+      stopServeManualUpdateReporting()
+    }
   })
 })

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -22,6 +22,10 @@ export function resolveUpdateInstallMode(isServeMode: boolean): UpdateInstallMod
   return updater.resolveUpdateInstallMode(isServeMode)
 }
 
+export function setUpdateInstallMode(mode: UpdateInstallMode): void {
+  updater.setUpdateInstallMode(mode)
+}
+
 export function getUpdateStatus(): UpdateStatus {
   return updater.getUpdateStatus()
 }

--- a/src/main/updater/updater-remote-status.ts
+++ b/src/main/updater/updater-remote-status.ts
@@ -7,6 +7,7 @@ import type {
   RemoteServerUpdateSupport
 } from '../../shared/remote-server-update'
 import { hasServeUpdateSupervisor } from '../serve-update-handoff'
+import { getServeManualUpdateReport } from '../serve-manual-update-report'
 import { getLinuxPackageType } from '../linux-update-package-type'
 import { UpdaterNudge } from './updater-nudge'
 import type { UpdateInstallMode } from './updater-state'
@@ -25,6 +26,18 @@ export abstract class UpdaterRemoteStatus extends UpdaterNudge {
         reason: 'unpackaged-build'
       }
     }
+    // Why: checked before the initialization gate — a headless serve host never wires an updater,
+    // so reporting `updater-unavailable` there described a broken desktop install rather than a
+    // server that is correctly refusing to update itself (#14068).
+    if (this.updateInstallMode === 'unsupported-headless-serve') {
+      const manualUpdate = getServeManualUpdateReport()
+      return {
+        installMode: this.updateInstallMode,
+        automatic: false,
+        reason: 'manual-service-update-required',
+        ...(manualUpdate ? { manualUpdate } : {})
+      }
+    }
     if (!this.autoUpdaterInitialized) {
       return {
         installMode: this.updateInstallMode,
@@ -32,9 +45,10 @@ export abstract class UpdaterRemoteStatus extends UpdaterNudge {
         reason: 'updater-unavailable'
       }
     }
+    // Why: the headless-serve case already returned above, so this clause is purely about a
+    // distro-managed install whose updater did initialize (#18100).
     const linuxPackageType = getLinuxPackageType()
     if (
-      this.updateInstallMode === 'unsupported-headless-serve' ||
       linuxPackageType === 'deb' ||
       linuxPackageType === 'rpm' ||
       linuxPackageType === 'unusable'

--- a/src/main/updater/updater-setup.ts
+++ b/src/main/updater/updater-setup.ts
@@ -86,6 +86,15 @@ export class UpdaterSetup extends UpdaterDownloadInstall {
     return super.resolveUpdateInstallMode(isServeMode)
   }
 
+  /**
+   * Records the install mode for a host that never calls `setupAutoUpdater`. Headless serve opens
+   * no window, so without this the mode stayed at its `interactive` default and status reporting
+   * described a desktop install (#14068).
+   */
+  setUpdateInstallMode(mode: UpdateInstallMode): void {
+    this.updateInstallMode = mode
+  }
+
   async getLinuxPackageInstallInstructions(): Promise<LinuxPackageInstallInstructions> {
     return super.getLinuxPackageInstallInstructions()
   }

--- a/src/shared/remote-server-update.ts
+++ b/src/shared/remote-server-update.ts
@@ -7,6 +7,38 @@ export type RemoteServerUpdateInstallMode =
   | 'supervised-headless-serve'
   | 'unsupported-headless-serve'
 
+/**
+ * How a headless `orca serve` host receives new versions. Detected from the running install —
+ * `unknown` is reported rather than guessed when nothing proves the method.
+ */
+export type ServeManualUpdateMethod = 'deb' | 'rpm' | 'appimage' | 'extracted-appimage' | 'unknown'
+
+/**
+ * Outcome of the host's own release check. `pending` means no check has completed yet and
+ * `unavailable` means the last one could not reach a fully published release — neither is
+ * evidence that the host is current.
+ */
+export type ServeManualUpdateCheckState = 'pending' | 'current' | 'update-available' | 'unavailable'
+
+/**
+ * The operator-facing update contract for a host that cannot update itself.
+ *
+ * Optional on the wire: absence means the host predates this contract or does not update
+ * manually, never that it is up to date. Additive per Rule 1 of
+ * docs/reference/remote-wire-compatibility.md.
+ */
+export type ServeManualUpdateReport = {
+  method: ServeManualUpdateMethod
+  check: ServeManualUpdateCheckState
+  currentVersion: string
+  /** Newest fully published release, or null when no check has proven one. */
+  latestVersion: string | null
+  releaseUrl: string | null
+  /** Ordered operator steps. Orca prints these and never runs any of them. */
+  steps: string[]
+  documentationUrl: string
+}
+
 export type RemoteServerUpdateSupport = {
   installMode: RemoteServerUpdateInstallMode
   automatic: boolean
@@ -15,6 +47,8 @@ export type RemoteServerUpdateSupport = {
     | 'manual-service-update-required'
     | 'unpackaged-build'
     | 'updater-unavailable'
+  /** Present only on a host that reports a manual update contract. */
+  manualUpdate?: ServeManualUpdateReport
 }
 
 export type RemoteServerUpdaterSnapshot = {

--- a/src/shared/remote-server-update.ts
+++ b/src/shared/remote-server-update.ts
@@ -11,7 +11,14 @@ export type RemoteServerUpdateInstallMode =
  * How a headless `orca serve` host receives new versions. Detected from the running install —
  * `unknown` is reported rather than guessed when nothing proves the method.
  */
-export type ServeManualUpdateMethod = 'deb' | 'rpm' | 'appimage' | 'extracted-appimage' | 'unknown'
+export type ServeManualUpdateMethod =
+  | 'deb'
+  | 'rpm'
+  | 'appimage'
+  | 'extracted-appimage'
+  /** A repackaged root install whose host has no package manager that could apply Orca's package. */
+  | 'externally-managed'
+  | 'unknown'
 
 /**
  * Outcome of the host's own release check. `pending` means no check has completed yet,

--- a/src/shared/remote-server-update.ts
+++ b/src/shared/remote-server-update.ts
@@ -14,11 +14,16 @@ export type RemoteServerUpdateInstallMode =
 export type ServeManualUpdateMethod = 'deb' | 'rpm' | 'appimage' | 'extracted-appimage' | 'unknown'
 
 /**
- * Outcome of the host's own release check. `pending` means no check has completed yet and
- * `unavailable` means the last one could not reach a fully published release — neither is
- * evidence that the host is current.
+ * Outcome of the host's own release check. `pending` means no check has completed yet,
+ * `unavailable` means the last one could not reach a fully published release, and `disabled` means
+ * the operator opted out — none of the three is evidence that the host is current.
  */
-export type ServeManualUpdateCheckState = 'pending' | 'current' | 'update-available' | 'unavailable'
+export type ServeManualUpdateCheckState =
+  | 'pending'
+  | 'current'
+  | 'update-available'
+  | 'unavailable'
+  | 'disabled'
 
 /**
  * The operator-facing update contract for a host that cannot update itself.


### PR DESCRIPTION
Closes #14068.

## ELI5

An admin runs Orca on a headless Linux server. Today, if they ask that server about updates, it says "automatic updates unavailable" and stops there — it never mentions that version 1.4.200 shipped two months ago, and it never says what to type. The admin has to go build their own release-watching cron job.

Now `orca status` on that box says which version is out and the exact command to install it:

```console
$ orca status
...
appVersion: 1.4.159
updateAutomatic: false
updateInstallMode: unsupported-headless-serve
updateReason: manual-service-update-required
updateMethod: deb
updateCheck: update-available
updateLatestVersion: 1.4.200
updateRelease: https://github.com/stablyai/orca/releases/tag/v1.4.200
updateSteps:
  1. Download the .deb for this machine's architecture from https://github.com/stablyai/orca/releases/tag/v1.4.200 to /tmp/orca-1.4.200.deb
  2. /usr/bin/sudo /usr/bin/apt install -- '/tmp/orca-1.4.200.deb'
  3. Restart the service unit that runs `orca serve`. Orca does not restart itself: nothing here can prove exactly one replacement would start.
updateDocs: https://github.com/stablyai/orca/blob/main/docs/reference/headless-linux-server.md#upgrade
```

Orca **prints** that command. It never runs it. The service runs unprivileged with no authentication agent on a headless box, so the privileged install and the restart stay the operator's action — that is deliberate, not a gap.

## What was actually broken

Two independent gates, both named in @oliver-mee's comment on #14068:

1. `resolveUpdateInstallMode(state.isServeMode)` was only ever called from `main-window-core-services.ts`. Headless serve opens no window, so `updateInstallMode` stayed at its `'interactive'` default.
2. `getRemoteServerUpdateSupport()` checked `!this.autoUpdaterInitialized` **before** the headless-serve branch. Serve never wires an updater, so it always fell into `updater-unavailable`.

Together those made a correctly-fail-closed Linux server report as `{ installMode: 'interactive', reason: 'updater-unavailable' }` — a desktop install with a broken updater. Fixed by recording the mode at serve launch and checking the headless branch first: the updater's absence there is a *consequence* of the install mode, not the cause.

## Which surface, and why

**`orca status` / the `status.get` RPC**, extending the existing `remoteUpdateSupport` object.

- It is already the operator's polling surface, already carries `appVersion` and `remoteUpdateSupport`, and already reaches paired desktop clients over a channel they poll. #14068's comment describes external tooling *already built* on `orca status --json`; this makes that tooling unnecessary rather than adding a second thing to watch.
- **Serve readiness output was rejected**: it is printed once at process start, so a release published a week later would never appear in it. Readiness is also a machine-parsed stdout contract (`renderServeReadiness`, recipe JSON), and a network round-trip must not sit in front of it.
- **The startup log alone was rejected**: it is write-only, so no paired client or CLI can query it.

The startup log does get a **secondary**, bounded record: `recordUpdaterLifecycle('headless_serve_update_available', …)` at `warn` fires once per newly observed version, so `journalctl` carries the transition without becoming a per-check spam loop.

## Wire compatibility

Read `docs/reference/remote-wire-compatibility.md` first. This is **Rule 1 only** — one new optional field, `manualUpdate`, on an existing frame:

- No new RPC method, no new stream opcode, no capability negotiation needed.
- No required field and no new enum value on an existing field. `RemoteServerUpdateInstallMode` and `reason` are unchanged; the new `ServeManualUpdateMethod` / `ServeManualUpdateCheckState` unions live *only* inside the new optional object, so an old client never decodes them.
- Every reader treats it as optional. The renderer coordinator (`remote-server-update-coordinator.ts`) reads only `automatic` / `reason` / `installMode` and is untouched.
- Rule 3 (content change with no wire change) **does** apply to `reason`: a Linux serve host that used to publish `updater-unavailable` now publishes `manual-service-update-required`. Old clients already handle that value — it is the string the supervised-macOS path has published since #9634, and both route to the same non-automatic branch. Nothing new appears in an old client's decoder.

Absence is documented as "the host predates this contract or does not update manually", explicitly *not* "the host is up to date".

## Reuse

No parallel path built. This wires together what already existed:

| Reused | For |
| --- | --- |
| `getLinuxRootPackageType()` (`linux-update-package-type.ts`) | detecting deb/rpm from the packaged marker `electron-updater` itself reads |
| `buildLinuxPackageInstallCommand()` (`linux-package-install-command.ts`) | the exact `sudo apt install …` line, POSIX-quoted, trusted-directory executables only |
| `quoteForPosixShell` / `resolveTrustedExecutable` | the AppImage staged-rename command |
| `fetchNewerReleaseTagsWithReadiness()` (`updater-prerelease-feed.ts`) | the release check, including its manifest-readiness probe |
| `AUTO_UPDATE_CHECK_INTERVAL_MS` | the same 24h cadence the desktop updater uses |
| `recordUpdaterLifecycle()` | the durable breadcrumb + log lane |
| `remoteUpdateSupport` on `status.get` | the transport |

Only `getReleaseTagUrl()` is new in `updater-prerelease-feed.ts` (six lines beside the existing `getReleaseDownloadUrl`), because the operator needs the *browsable* release page to pick an architecture asset, and the existing helper returns the non-browsable `/download/<tag>` prefix.

## Honesty about what is detected vs. guessed

#14068 requires reporting the method "without guessing". So:

- Method comes only from evidence the running install carries: the packaged package-type marker, then `$APPIMAGE`, then `$APPDIR` (AppRun's extracted tree). Anything else reports `unknown`, not a best guess.
- The systemd **unit name is never guessed** — step 3 says "the service unit that runs `orca serve`". Inventing `systemctl restart orca-serve` would be wrong on most deployments.
- The **asset filename is never guessed**. Step 1 points at the release page and names the architecture choice, because `latest-linux.yml` contents are not a stable enough basis to print a `curl` line an admin would paste blind.
- `check` distinguishes `pending` / `current` / `update-available` / `unavailable`. A feed failure or a mid-publish release reports `unavailable` and advertises **no** version — the operator is never told to download something that is not fully published yet.
- The extracted-tree and `unknown` methods get the documented procedure link rather than a fabricated one-liner, since no single binary swap applies there.
- A release version that is not filename-safe never reaches a shell-quoted path; it falls back to the documented procedure. (Belt-and-braces: the tag already passed `isValidVersion` upstream.)

## Review round 2 (P2s)

Both P2s shared one root cause and one fix: **`startServeManualUpdateReporting()` is now gated on `resolveUpdateInstallMode(true) === 'unsupported-headless-serve'`.** The gate lives inside the function (which takes `installMode` as a required argument) rather than only at the call site, so a future caller cannot bypass it, and the call site can't drift from the status branch it feeds.

- **P2-2, the lying log** — fixed by the gate. A supervised macOS serve host no longer runs the check or emits advice its own status surface does not carry. The two inaccurate sentences in this description are corrected above.
- **P2-1, unconsented egress** — narrowed by the gate, and additionally given a documented opt-out.

### On the opt-out env var

I added one rather than relying on gating alone: **`ORCA_SERVE_DISABLE_UPDATE_CHECK=1`**, documented in the headless guide with a `check: 'disabled'` state so the status surface distinguishes "operator turned it off" from "the check failed".

Gating alone was not enough. The strongest argument for it was that a desktop install already polls more aggressively (a 30-minute nudge poll plus the daily check), so a gated serve host is a strict subset of shipped behavior. But that argument does not survive the actual deployment: a desktop user can quit the app, whereas a serve host is an unattended 24/7 process on a machine whose egress may be audited or absent — and there is no pre-existing opt-out anywhere in the updater to inherit, so an operator who does not want the traffic had no way to say so. The check is also the entire feature; a host that cannot use it should not pay for it. The env var is scoped and named for exactly what it disables rather than implying a global updater switch, so it does not over-promise about the desktop updater it does not control.

### Three smaller ones

- **Platform vocabulary** — `getServeUpgradeDocUrl()` and the restart step now branch on platform. Windows gets "Windows service or scheduled task", macOS "launchd job or supervisor", and both get `https://www.onorca.dev/docs/remote-servers` instead of the systemd-specific Linux guide. `platform` is an injectable input, so the test asserts all three without mutating `process.platform`.
- **Fallback adapter** — described under User-facing regressions above.
- **`statSync` on a polled path** — install steps are memoized on the release tag. `getServeManualUpdateReport()` now builds them once per tag; the test asserts the builder is called once across two `status.get`-shaped reads and that the returned array is referentially identical.

Unchanged, as instructed: the refusal to guess a systemd unit name or an asset filename.

## Red/green transcript

Every suite was proven red by injecting the pre-change behavior, then green after restoring. Full transcript:

<details>
<summary>1. <code>updater.headless-serve-install.test.ts</code> — restore the old gate order in <code>updater-remote-status.ts</code></summary>

```
--- INJECTED (pre-change gate order) ---
 ❯ src/main/updater.headless-serve-install.test.ts (10 tests | 1 failed)
   × reports the manual update contract on a serve host that never initialized an updater

AssertionError: expected { …(3) } to deeply equal { …(3) }
- Expected
+ Received
  {
    "automatic": false,
    "installMode": "unsupported-headless-serve",
-   "reason": "manual-service-update-required",
+   "reason": "updater-unavailable",
  }

 Tests  1 failed | 9 passed (10)

--- RESTORED ---
 Tests  10 passed (10)
```

That `+ "reason": "updater-unavailable"` is verbatim the payload reported in #14068.
</details>

<details>
<summary>2. <code>serve-manual-update-report.test.ts</code> — accept a tag from a non-<code>ready</code> feed result</summary>

```
--- INJECTED (advertise an unproven release) ---
   × never advertises a version it could not prove (not-ready)
AssertionError: expected { method: 'unknown', …(6) } to match object { check: 'unavailable', …(2) }
 Tests  1 failed | 8 passed (9)
```
</details>

<details>
<summary>3. <code>serve-manual-update-steps.test.ts</code> — drop the filename sanitizer</summary>

```
--- INJECTED (unsanitized version into a shell-quoted path) ---
   × refuses to embed a version that is not filename-safe
AssertionError: expected 'Download the .deb for this machine\'s…' to contain 'https://github.com/stablyai/orca/blob…'
 Tests  1 failed | 6 passed (7)
```
</details>

<details>
<summary>4. <code>serve-manual-update-format.test.ts</code> — revert the <code>formatCliStatus</code> lines</summary>

```
--- INJECTED (status format without update contract) ---
   × surfaces the update contract through `orca status`
   × keeps the original status lines for a host that reports no update support
AssertionError: expected 'appRunning: true\npid: 42\ndesktopWin…' to contain 'appVersion: 1.4.159'
 Tests  2 failed | 4 passed (6)
```
</details>

<details>
<summary>5. <code>serve-update-contract-wiring.test.ts</code> — remove both serve call sites</summary>

```
--- INJECTED (serve launch never wires the contract) ---
   × records the serve install mode before any client can read status
   × starts the release check after readiness so stdout stays the readiness API
AssertionError: expected -1 to be greater than 5929
AssertionError: expected -1 to be greater than 10074
 Tests  2 failed | 1 passed (3)
```
</details>

**Green after restore:**

```
 Test Files  5 passed (5)
      Tests  35 passed (35)
```

### Round 2 injections

<details>
<summary>A. ungate the reporter (P2-2)</summary>

```
=== INJECTED A: ungated reporter (P2-2) ===
 × makes no network call and publishes nothing on a interactive host
 × makes no network call and publishes nothing on a supervised-headless-serve host
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 Tests  2 failed | 11 passed (13)
```
</details>

<details>
<summary>B. stop honoring the opt-out (P2-1)</summary>

```
=== INJECTED B: no opt-out honored (P2-1) ===
 × makes no outbound call when the operator opts out
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 Tests  1 failed | 12 passed (13)
```
</details>

<details>
<summary>C. rebuild steps on every poll</summary>

```
=== INJECTED C: rebuild steps every poll ===
 × builds the steps once per tag, not once per status poll
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
 Tests  1 failed | 12 passed (13)
```
</details>

<details>
<summary>D. systemd vocabulary on every platform</summary>

```
=== INJECTED D: systemd vocabulary everywhere ===
 × keeps systemd vocabulary and the Linux guide off a non-Linux serve host
 × links the Linux guide only on Linux
AssertionError: expected 'Download the release for this machine…' to contain 'Windows service or scheduled task'
AssertionError: expected 'https://github.com/stablyai/orca/blob…' to be 'https://www.onorca.dev/docs/remote-se…'
 Tests  2 failed | 7 passed (9)
```
</details>

<details>
<summary>E. fallback re-asserts the undetected mode</summary>

```
=== INJECTED E: fallback re-asserts the wrong pairing ===
 × claims no install mode it never detected
-   "installMode": "interactive",
+   "installMode": "unsupported-headless-serve",
 Tests  1 failed | 2 passed (3)
```
</details>

**Green after restore (round 2):**

```
 Test Files  7 passed (7)
      Tests  50 passed (50)
```

One genuine catch from the existing ratchet in `single-instance-lock-headless-exit.test.ts`: my first draft of the opt-out documentation showed a fenced `# /etc/systemd/system/orca-serve.service` block containing only the `Environment=` line, and the ratchet correctly failed it for lacking `RestartPreventExitStatus=`/`StartLimitIntervalSec=`. The guide now tells the operator to add the line to the existing unit's `[Service]` section rather than presenting a copyable partial unit.

## Verification

- `pnpm tc` — clean.
- `pnpm test src/main/updater` — 24 files, 272 tests passed.
- `pnpm test src/cli` — 113 files, 1069 tests passed.
- `pnpm test src/renderer/src/runtime/remote-server src/main/startup …` — 55 files, 438 passed.
- `pnpm run check:code-quality:changed` — 0 new findings across 22 changed files (incl. React Doctor and type-aware passes).
- Round 2 re-ran the touched suites plus `single-instance-lock-headless-exit` — 7 files, 50 tests passed.
- Four failures seen in a broad, heavily-oversubscribed run are **pre-existing and environmental**, each re-confirmed against a clean tree: `cross-version-wire/release-checkout.unit.test.ts` (`ECOMPROMISED` on a temp-dir lockfile), `terminal-output-frame-chunks-equivalence` (800-trial fuzz), and two `automation-change-publication` cases that hit the 30s `testTimeout`. Two `FAIL src/main/updater.*` entries in that same run were file-level import timeouts, exactly the oversubscription case `updater-test-module-loader.ts` documents ("~1.4s idle but 45s+ on an oversubscribed machine"); both pass in isolation. None is touched by this change.

## User-facing regressions

- **A Linux/headless-serve host's `reason` changes from `updater-unavailable` to `manual-service-update-required`.** This is the fix, but it is a value an operator or script may have matched on. Both are `automatic: false` and both route to the identical non-automatic branch in the renderer coordinator and in `assertRemoteServerUpdateAvailable()`, so no behavior changes — only the label an operator reads. `installMode` likewise moves from `interactive` to `unsupported-headless-serve` on those hosts, which is the accurate value.
- **`orca status` (non-`--json`) gains lines.** `appVersion` plus the `update*` block are appended when the host reports them. Anything parsing that human output positionally, or asserting an exact line count, sees more lines. `--json` shape is purely additive. Existing lines and their order are byte-identical; covered by a test.
- **A serve host in `unsupported-headless-serve` mode makes a daily outbound call it did not make before.** Correcting an earlier understatement in this description: it is **not** one request. `fetchNewerReleaseTagsWithReadiness` issues an atom-feed `net.fetch`, then up to 6 manifest probes, then a `HEAD` per asset named in each manifest (`updater-prerelease-feed.ts:294-300, 201-208`). That runs once every 24h. **`ORCA_SERVE_DISABLE_UPDATE_CHECK=1` opts a host out entirely** — no outbound call at all, and `check: 'disabled'` says the operator turned it off rather than pretending a check failed; the install method is still reported. Only `unsupported-headless-serve` hosts run it at all (see the note below). Without the env var, an unreachable feed yields `check: 'unavailable'` and no steps — no retry storm, no error status, no failed-startup path. It runs strictly *after* readiness publishes, so it cannot delay or corrupt the serve stdout contract, and it is skipped on unpackaged builds.
- **No status-payload change for desktop, supervised-macOS-serve, or any automatic-update host.** The new branch is reachable only when `updateInstallMode === 'unsupported-headless-serve'`, and `manualUpdate` is omitted unless a serve process started the contract, so the `interactive` and `supervised-headless-serve` payloads are byte-identical. An earlier revision of this description claimed "no change" outright, which was wrong: the reporter used to start on *every* serve host, so a supervised macOS host also made the network call and logged `headless_serve_update_available` — "run `orca status` for the exact commands" — pointing at a status surface that returns `updater-unavailable` with no steps. `startServeManualUpdateReporting()` is now gated on the resolved install mode, so those hosts make no call and emit no log, and the claim holds for the network and the log as well as the payload.
- **The no-adapter fallback snapshot changes `installMode` from `unsupported-headless-serve` to `interactive`** (`remote-server-updater.ts`). It is reached only when nothing configured an adapter — unreachable in the shipping app, since `configureRemoteServerUpdater` runs unconditionally in preflight. It previously asserted a serve install it had never detected, paired with the very reason this PR argues is wrong for that mode. `automatic: false` and `reason: 'updater-unavailable'` are unchanged, so every consumer branches identically.

## Deliberately out of scope

Per the issue's own scope boundary and #15956, this PR is the **status slice only**. From #14068's acceptance criteria, these are *not* implemented and are left to the restart-owner work:

- "Never replace binaries or stop a runtime unless a supervisor can start exactly one replacement" — nothing is replaced or stopped, so this holds vacuously. No systemd handoff, no restart mechanism.
- "Verify the target version and runtime readiness before declaring success" — there is no install to declare success for.
- "Preserve daemon-backed PTYs and verify they reconnect" — no restart happens. Worth flagging for whoever builds that: @oliver-mee's warning that a single `terminal list --json` sample can report zero terminals while two are live means idleness must be confirmed across multiple readings.
- "Persist failure state and stop after a bounded attempt" — partially met in spirit: a failed release check is bounded (one per 24h, no retry backoff loop, no watchdog) and reports `check: 'unavailable'` rather than escalating. But there is no *install* failure state to persist, and nothing is written to disk.
- `replacement pending` / `replacement ready` / `replacement failed` are **not** exposed, because no replacement is ever staged. The `check` field covers the states that exist today: `pending` / `current` / `update-available` / `unavailable`. Adding the replacement states is additive on the same optional object when #15956 lands.

Also left out: the two policy questions raised in the issue thread (CLI-parent supervisor vs. handing restart authority to systemd; and whether a root-owned install directory is compatible with a self-updating server). Both are maintainer calls, and neither is needed for the status slice.

## Rebase onto the landed Linux packaging stack

Rebased onto `e5a1e79e8e4` after #18100, #18122, #18123 and #18125 merged. Two conflicts, both in files the packaging stack also edited.

### `src/main/updater/updater-remote-status.ts` — both changes kept

This is the one that mattered. `main` had added a root-package clause to the same branch this PR reorders:

```ts
if (!this.autoUpdaterInitialized) { return { ...,  reason: 'updater-unavailable' } }
const linuxPackageType = getLinuxPackageType()
if (
  this.updateInstallMode === 'unsupported-headless-serve' ||   // <- overlaps this PR
  linuxPackageType === 'deb' || linuxPackageType === 'rpm' || linuxPackageType === 'unusable'
) { return { ..., reason: 'manual-service-update-required' } }
```

Resolved so both survive, in this order:

1. **From this PR** — the headless-serve branch runs *before* the `autoUpdaterInitialized` gate and attaches `manualUpdate`. Serve never wires an updater, so the gate has to come second or the headless host reports `updater-unavailable` again.
2. **From `main`** — the `autoUpdaterInitialized` gate, unchanged.
3. **From `main`** — the `deb`/`rpm`/`unusable` clause, unchanged except that the now-unreachable `unsupported-headless-serve ||` term is dropped, since case 1 has already returned. A comment records why the clause is purely about a distro-managed install whose updater *did* initialize.

Ordering note: pulling the headless case ahead of the gate does not weaken the root-package clause, because a distro-managed *desktop* host does initialize its updater and still reaches step 3. A host that is both headless-serve and deb/rpm now returns at step 1 with the same `manual-service-update-required` reason plus the install steps, which is strictly more information for the same verdict.

**Both directions are proven by injection, not by inspection** — see the transcript below.

### `docs/reference/headless-linux-server.md` — kept `main`'s text, folded in one clause

#18123 replaced the "Orca has no headless version command" paragraph (which this PR had also been correcting) with a better one documenting `orca-ide --version`. Kept `main`'s paragraph wholesale and added only that `orca status` reports the same build as `appVersion`. This PR's "Find out an upgrade is due" section merged cleanly and its cross-reference from the Upgrade preamble survived; I re-read the merged section to confirm it does not contradict #18123's new census and packaging text.

`src/main/startup/main-process-runtime-launch.ts` and `src/main/updater/updater-setup.ts` auto-merged — `main`'s edits there (`getServeOptions(process.argv)`, the `non-root` `autoInstallOnAppQuit` gate) are in different hunks from this PR's.

### One thing composed rather than merely resolved

`isExternallyManagedLinuxInstall()` landed with #18100. An earlier revision of this description said it "would compose cleanly here" as a follow-up; it does, and the third commit does it, because leaving it out was a live wrong-advice bug rather than a missing nicety.

Repackagers unpack Orca's `.deb` and inherit its `package-type` marker verbatim, so a `deb` marker on an AUR/Nix/container host describes the artifact Orca was *built* as, not the system that owns the install. This PR would have reported `updateMethod: deb` there and pointed the operator at the Orca release page for a package their host can never apply. It now reports `externally-managed` and names the package manager that installed Orca as the upgrade owner, emitting no command at all — none of ours applies.

The command was never unsafe: `buildLinuxPackageInstallCommand` already returns `no-package-manager` on such a host and fell through to the documented-procedure step. What was wrong was the reported method and the download advice.

Say the word if you would rather ship the rebase alone and take `19aac7ea3c9` as a follow-up PR; it is a clean single commit on top.

### Rebase re-verification

Re-ran the red/green from scratch rather than assuming it survived, as asked. Eight prior injections plus two new ones, all red, then green:

| # | Injection | Result |
| --- | --- | --- |
| 1 | Restore the pre-#14068 gate order **on top of** the landed #18100 clause | `× reports the manual update contract on a serve host that never initialized an updater` — `- "manual-service-update-required"` / `+ "updater-unavailable"`. 1 failed, 9 passed |
| 2 | Delete the landed #18100 root-package clause | `× disables install-on-quit and remote automatic control for deb builds`, `× … rpm builds`, `× fails closed for an unusable packaged marker`. 3 failed, 289 passed |
| 3 | Ungate the reporter | 2 failed, 11 passed |
| 4 | Ignore the opt-out env var | 1 failed, 12 passed |
| 5 | Rebuild steps on every poll | 1 failed, 12 passed |
| 6 | Platform-blind wording + unsanitized version | 3 failed, 6 passed |
| 7 | Revert the `formatCliStatus` lines | 2 failed, 4 passed |
| 8 | Fallback re-asserts the undetected mode | 1 failed, 2 passed |
| 9 | Report an externally-managed host as plain `deb` | `AssertionError: expected 'deb' to be 'externally-managed'`. 1 failed, 12 passed |
| 10 | Send a repackaged host to the release page | `AssertionError: expected 'Download the release…' not to contain 'https://github.com/stablyai/orca/rele…'`. 1 failed, 9 passed |

Injection 2 is the one that proves the merge in the other direction: `main`'s clause is not decoration, and this PR's reorder did not strand it.

**Green after restore:** touched suites 7 files / 50 tests; `src/main/updater` 25 files / 292 tests (up from 24/272 — the stack added a suite); full affected-area run 76 files / 751 tests passed, 1 file / 6 tests skipped. `pnpm tc` clean. `check:code-quality:changed` 0 new findings across 17 changed files.
