### PR TITLE
perf(renderer): index worktree owner lookups instead of rescanning every workspace

### DIFF
--- a/src/renderer/src/lib/right-sidebar-visibility.ts
+++ b/src/renderer/src/lib/right-sidebar-visibility.ts
@@ -1,4 +1,5 @@
 import type { AppState } from '@/store/types'
+import { getIndexedRepoMap, getIndexedWorktreeMap } from '@/store/worktree-repo-index'
 import { isFolderRepo } from '../../../shared/repo-kind'
 
 type ActiveView = AppState['activeView']
@@ -37,11 +38,11 @@ export function rightSidebarShowsPullRequestData(
     return false
   }
 
-  const activeWorktree = Object.values(state.worktreesByRepo)
-    .flat()
-    .find((worktree) => worktree.id === state.activeWorktreeId)
+  const activeWorktree = state.activeWorktreeId
+    ? getIndexedWorktreeMap(state.worktreesByRepo).get(state.activeWorktreeId)
+    : undefined
   const activeRepo = activeWorktree
-    ? state.repos.find((repo) => repo.id === activeWorktree.repoId)
+    ? getIndexedRepoMap(state.repos).get(activeWorktree.repoId)
     : null
   if (!activeRepo || isFolderRepo(activeRepo)) {
     return false

--- a/src/renderer/src/store/terminals/terminal-workspace-routing.scale.test.ts
+++ b/src/renderer/src/store/terminals/terminal-workspace-routing.scale.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '../types'
+import {
+  getRemoteConnectionIdForWorktree,
+  worktreeUsesRemoteConnection,
+  worktreeUsesWslPath
+} from './terminal-workspace-routing'
+import { rightSidebarShowsPullRequestData } from '@/lib/right-sidebar-visibility'
+
+const REPO_COUNT = 10
+const WORKTREE_COUNT = 400
+
+/** Counts every `id` read so a rescan shows up as a multiple of the row count. */
+function buildCountingState(): {
+  state: AppState
+  reads: () => number
+  worktreeId: string
+} {
+  let idReads = 0
+  const repos = Array.from({ length: REPO_COUNT }, (_, index) => ({
+    id: `repo-${index}`,
+    name: `repo-${index}`,
+    path: `/repos/repo-${index}`,
+    connectionId: null
+  }))
+  const worktreesByRepo: Record<string, unknown[]> = {}
+  const perRepo = WORKTREE_COUNT / REPO_COUNT
+  for (let repoIndex = 0; repoIndex < REPO_COUNT; repoIndex++) {
+    worktreesByRepo[`repo-${repoIndex}`] = Array.from({ length: perRepo }, (_, index) => {
+      const id = `repo-${repoIndex}::/repos/repo-${repoIndex}/wt-${index}`
+      return {
+        get id() {
+          idReads++
+          return id
+        },
+        repoId: `repo-${repoIndex}`,
+        path: `/repos/repo-${repoIndex}/wt-${index}`,
+        branch: `branch-${index}`,
+        hostId: 'local'
+      }
+    })
+  }
+  return {
+    state: {
+      repos,
+      worktreesByRepo,
+      folderWorkspaces: [],
+      projectGroups: [],
+      activeView: 'worktrees',
+      activeWorktreeId: 'repo-9::/repos/repo-9/wt-39',
+      rightSidebarOpen: true,
+      rightSidebarTab: 'checks'
+    } as unknown as AppState,
+    reads: () => idReads,
+    worktreeId: 'repo-9::/repos/repo-9/wt-39'
+  }
+}
+
+describe('terminal workspace routing scales with tab count, not workspace count', () => {
+  it('answers repeated owner lookups without rescanning every worktree', () => {
+    const { state, reads, worktreeId } = buildCountingState()
+    const CALLS = 200
+
+    for (let call = 0; call < CALLS; call++) {
+      worktreeUsesRemoteConnection(state, worktreeId)
+      getRemoteConnectionIdForWorktree(state, worktreeId)
+      worktreeUsesWslPath(state, worktreeId)
+      rightSidebarShowsPullRequestData(state)
+    }
+
+    // One index build over every row, then O(1) map hits. A per-call scan would
+    // read at least CALLS x WORKTREE_COUNT ids.
+    expect(reads()).toBeLessThanOrEqual(WORKTREE_COUNT * 2)
+    expect(reads()).toBeLessThan(CALLS * WORKTREE_COUNT)
+  })
+
+  it('still resolves the owning repo and its connection', () => {
+    const { state, worktreeId } = buildCountingState()
+    const remoteState = {
+      ...state,
+      repos: state.repos.map((repo) =>
+        repo.id === 'repo-9' ? { ...repo, connectionId: 'ssh-host-1' } : repo
+      )
+    } as AppState
+
+    expect(worktreeUsesRemoteConnection(remoteState, worktreeId)).toBe(true)
+    expect(getRemoteConnectionIdForWorktree(remoteState, worktreeId)).toBe('ssh-host-1')
+    expect(worktreeUsesRemoteConnection(state, worktreeId)).toBe(false)
+    expect(getRemoteConnectionIdForWorktree(state, worktreeId)).toBeNull()
+    expect(worktreeUsesWslPath(state, worktreeId)).toBe(false)
+  })
+
+  it('returns null for a worktree id that no repo owns', () => {
+    const { state } = buildCountingState()
+    expect(getRemoteConnectionIdForWorktree(state, 'ghost::/nowhere')).toBeNull()
+    expect(worktreeUsesRemoteConnection(state, 'ghost::/nowhere')).toBe(false)
+  })
+})

--- a/src/renderer/src/store/terminals/terminal-workspace-routing.ts
+++ b/src/renderer/src/store/terminals/terminal-workspace-routing.ts
@@ -7,6 +7,7 @@ import { resolveLocalWindowsTerminalShellOverrideForTab } from '../../../../shar
 import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
 import { getFolderWorkspaceConnectionId } from '@/lib/folder-workspace-connection'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { getIndexedRepoMap, getIndexedWorktreeMap } from '../worktree-repo-index'
 
 export function isWindowsRendererRuntime(): boolean {
   return typeof navigator !== 'undefined' && navigator.userAgent.includes('Windows')
@@ -61,9 +62,7 @@ export function worktreeUsesWslPath(
     )
     return folderWorkspace ? isWslUncPath(folderWorkspace.folderPath) : false
   }
-  const worktree = Object.values(state.worktreesByRepo)
-    .flat()
-    .find((entry) => entry.id === worktreeId)
+  const worktree = getIndexedWorktreeMap(state.worktreesByRepo).get(worktreeId)
   return worktree ? isWslUncPath(worktree.path) : false
 }
 
@@ -75,15 +74,13 @@ export function worktreeUsesRemoteConnection(
   if (parsedWorkspaceKey?.type === 'folder') {
     return Boolean(getFolderWorkspaceConnectionId(state, parsedWorkspaceKey.folderWorkspaceId))
   }
-  const directRepoId = getRepoIdFromWorktreeId(worktreeId)
-  const directRepo = state.repos.find((repo) => repo.id === directRepoId)
+  const repoMap = getIndexedRepoMap(state.repos)
+  const directRepo = repoMap.get(getRepoIdFromWorktreeId(worktreeId))
   if (directRepo) {
     return Boolean(directRepo.connectionId)
   }
-  const worktree = Object.values(state.worktreesByRepo)
-    .flat()
-    .find((entry) => entry.id === worktreeId)
-  const repo = worktree ? state.repos.find((entry) => entry.id === worktree.repoId) : null
+  const worktree = getIndexedWorktreeMap(state.worktreesByRepo).get(worktreeId)
+  const repo = worktree ? repoMap.get(worktree.repoId) : null
   return Boolean(repo?.connectionId)
 }
 
@@ -95,15 +92,13 @@ export function getRemoteConnectionIdForWorktree(
   if (parsedWorkspaceKey?.type === 'folder') {
     return getFolderWorkspaceConnectionId(state, parsedWorkspaceKey.folderWorkspaceId) ?? null
   }
-  const directRepoId = getRepoIdFromWorktreeId(worktreeId)
-  const directRepo = state.repos.find((repo) => repo.id === directRepoId)
+  const repoMap = getIndexedRepoMap(state.repos)
+  const directRepo = repoMap.get(getRepoIdFromWorktreeId(worktreeId))
   if (directRepo) {
     return directRepo.connectionId?.trim() || null
   }
-  const worktree = Object.values(state.worktreesByRepo)
-    .flat()
-    .find((entry) => entry.id === worktreeId)
-  const repo = worktree ? state.repos.find((entry) => entry.id === worktree.repoId) : null
+  const worktree = getIndexedWorktreeMap(state.worktreesByRepo).get(worktreeId)
+  const repo = worktree ? repoMap.get(worktree.repoId) : null
   return repo?.connectionId?.trim() || null
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​98 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​98 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

Orca keeps a list of every workspace you have. Some code needed to answer a tiny question — "is this tab's workspace on a remote machine?" — and to answer it, it walked the **entire** list of all 423 workspaces, every single time.

Worse, that question gets re-asked once per open tab (382 of them) every time *anything at all* changes in the app's state. So Orca was walking a 423-item list, 382 times over, dozens of times per second, while sitting completely idle.

This PR builds the lookup table once and then just looks the answer up. Same answer, ~17x less work.

## What was measured

Profiled the **live packaged app** (v1.4.195-hourly) by driving `webContents.debugger` from the main process's Node inspector — no restart, no dev build, real user state.

`Profiler.takePreciseCoverage` over 30 seconds, window focused, app idle:

| Function | Calls in 30s | Rate |
| --- | --- | --- |
| `.find()` predicate inside `worktreeUsesRemoteConnection` | **1,320,424** | 44,000 worktree visits/sec |

Real workload scale, read from the user's persisted store (not an estimate): **10 repos, 423 worktrees, 382 open tabs, 11 live terminals.**

Context for why this multiplies: the same profile showed ~1,200 Zustand subscribers and ~24,700 selector evaluations/sec, with only **2.4 React commits/sec and zero long tasks**. Almost none of that work produced a render — the cost was purely re-evaluating selectors that then correctly bailed out. Making each selector cheap is therefore a pure win.

## The fix

Four functions did `Object.values(state.worktreesByRepo).flat().find(...)` plus a linear `state.repos.find(...)`:

- `store/terminals/terminal-workspace-routing.ts` — `worktreeUsesWslPath`, `worktreeUsesRemoteConnection`, `getRemoteConnectionIdForWorktree`
- `lib/right-sidebar-visibility.ts` — `rightSidebarShowsPullRequestData`

They are reached from unmemoized Zustand selectors, so they ran on every store write:
- `lib/use-tab-agent.ts:263` — `useAppStore((s) => worktreeUsesRemoteConnection(s, tab.worktreeId))`, once per tab
- `components/sidebar/worktree-list/viewport/use-visible-review-refresh.ts:45`

All four now use the **already-existing** WeakMap-cached `getIndexedWorktreeMap` / `getIndexedRepoMap` in `store/worktree-repo-index.ts`. This is not a new mechanism — `lib/connection-owner-resolution.ts:63` already made exactly this swap, with a comment explaining why. This PR finishes the job.

## Measured improvement

Benchmark at the real scale above (200 store writes x 382 tabs x 3 lookups):

| | Per store write | At ~20 store writes/sec |
| --- | --- | --- |
| Before | 2.762 ms | 55.2 ms/sec (~5.5% of a core) |
| After | **0.167 ms** | **3.3 ms/sec (~0.3% of a core)** |

**16.6x faster.**

New regression test `terminal-workspace-routing.scale.test.ts` counts worktree `id` reads across 200 calls:

- Before the fix: **160,000** reads — test fails with `expected 160000 to be less than or equal to 800`
- After the fix: **800** reads (one index build, then O(1) hits)

Verified the test fails on `main` and passes on this branch.

## Correctness

The index has the *same* collision semantics as the code it replaces, and this is load-bearing (STA-4343):

- Duplicate `host+id` within one repo array collapses to the later entry — documented as intended in `worktree-repo-index.ts:26-33` (same workspace, later is current).
- Two different hosts publishing the same bare id: **first wins**, matching the `.find()` being replaced.
- `getIndexedRepoMap` is last-wins on duplicate repo ids vs `.find()`'s first-wins; repo ids are unique, and `connection-owner-resolution.ts` already relies on this.

## Negative user-facing trade-offs

**None.** This is a pure indexing change:

- No behavior change, no API change, no visual change.
- No new caching semantics — reuses an existing WeakMap keyed on the `worktreesByRepo` / `repos` object identity, so a new store snapshot rebuilds the index. No staleness window.
- No added memory beyond one `Map` per live store snapshot, released with it (WeakMap).
- No deferral, debounce, or throttle — nothing is made lazier or less responsive.
- Cross-platform, SSH, folder-workspace and remote paths untouched; the folder-workspace and remote-connection branches keep their exact prior order and precedence.

## Verification

- `pnpm tc` clean
- `oxlint` clean on changed files
- `pnpm test src/renderer/src/store/terminals src/renderer/src/lib/right-sidebar-visibility` — 4 files, 17 tests passed
