### PR TITLE
perf(sidebar): stop rebuilding per-card selector records on every store write

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1956,7 +1956,9 @@ html.native-shell .app-layout {
     transform 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
     width 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
     opacity 80ms ease-out;
-  will-change: transform, width, opacity;
+  /* Why no `width`: it is not compositable, so hinting it only pins a layer that
+     has to be re-rastered every frame of the transition anyway. */
+  will-change: transform, opacity;
 }
 
 [data-workspace-board-card-drop-indicator='true']::before,

--- a/src/renderer/src/components/sidebar/truncated-sidebar-label.test.tsx
+++ b/src/renderer/src/components/sidebar/truncated-sidebar-label.test.tsx
@@ -105,4 +105,40 @@ describe('TruncatedSidebarLabel', () => {
     expect(container.textContent).toContain('feature/really-long-branch-name')
     expect(container.querySelector('[data-tooltip-content]')).toBeNull()
   })
+
+  // Why: worktree titles change on the hot store-write path. Remounting the
+  // span per text change tore down and rebuilt its ResizeObserver every time.
+  it('keeps one ResizeObserver across a label text change', async () => {
+    const originalResizeObserver = globalThis.ResizeObserver
+    let constructed = 0
+    let disconnected = 0
+    class CountingResizeObserver {
+      constructor(_callback: ResizeObserverCallback) {
+        constructed += 1
+      }
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {
+        disconnected += 1
+      }
+    }
+    globalThis.ResizeObserver = CountingResizeObserver as unknown as typeof ResizeObserver
+
+    try {
+      await act(async () => {
+        root.render(<TruncatedSidebarLabel text="feature/short" />)
+      })
+      expect(constructed).toBe(1)
+
+      await act(async () => {
+        root.render(<TruncatedSidebarLabel text="fix/short" />)
+      })
+
+      expect(container.textContent).toBe('fix/short')
+      expect(constructed).toBe(1)
+      expect(disconnected).toBe(0)
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver
+    }
+  })
 })

--- a/src/renderer/src/components/sidebar/truncated-sidebar-label.tsx
+++ b/src/renderer/src/components/sidebar/truncated-sidebar-label.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useLayoutEffect, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
@@ -23,6 +23,7 @@ export function TruncatedSidebarLabel({
   tooltipSide = 'right',
   tooltipSideOffset = 8
 }: TruncatedSidebarLabelProps): React.JSX.Element {
+  const nodeRef = React.useRef<HTMLSpanElement | null>(null)
   const resizeObserverRef = React.useRef<ResizeObserver | null>(null)
   const removeResizeListenerRef = React.useRef<(() => void) | null>(null)
   const [truncated, setTruncated] = useState(false)
@@ -39,6 +40,7 @@ export function TruncatedSidebarLabel({
       removeResizeListenerRef.current?.()
       removeResizeListenerRef.current = null
 
+      nodeRef.current = node
       if (!node) {
         measureTruncated(null)
         return
@@ -60,14 +62,15 @@ export function TruncatedSidebarLabel({
     [measureTruncated]
   )
 
+  // Why: ResizeObserver does not fire when only the rendered text changes, but
+  // scrollWidth can. Remeasure in place rather than remounting the span, which
+  // would tear down and rebuild the observer on every title update.
+  useLayoutEffect(() => {
+    measureTruncated(nodeRef.current)
+  }, [measureTruncated, text])
+
   const label = (
-    <span
-      // Why: ResizeObserver does not fire when only the rendered text changes,
-      // but scrollWidth can; remount so branch reuse remeasures immediately.
-      key={text}
-      ref={handleRef}
-      className={cn('block min-w-0 truncate', className)}
-    >
+    <span ref={handleRef} className={cn('block min-w-0 truncate', className)}>
       {text}
     </span>
   )

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -5,21 +5,32 @@ import { applyAgentRowLineage } from '@/components/dashboard/agent-row-lineage'
 import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import { useAppStore } from '@/store'
 import {
+  EMPTY_LIVE_PTY_IDS,
+  EMPTY_RUNTIME_PANE_TITLES,
   selectLivePtyIdsForWorktree,
   selectRuntimePaneTitlesForWorktree
 } from './worktree-card-status-inputs'
 import { buildWorktreeAgentRows } from './worktree-agent-rows'
 import {
+  EMPTY_LIVE_ENTRIES,
+  EMPTY_MIGRATION_UNSUPPORTED_ENTRIES,
+  EMPTY_RETAINED,
+  EMPTY_TERMINAL_LAYOUTS,
   selectLiveAgentStatusEntriesForWorktree,
   selectMigrationUnsupportedEntriesForWorktree,
   selectRuntimeAgentOrchestrationForWorktree,
   selectRetainedAgentEntriesForWorktree,
   selectTerminalLayoutsForWorktree
 } from './worktree-agent-row-selectors'
+import { EMPTY_WORKTREE_AGENT_ORCHESTRATION } from './worktree-agent-orchestration-index'
+import { EMPTY_TABS } from './WorktreeCardHelpers'
 import {
   createWorktreeAgentFreshnessSelector,
   EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
 } from './worktree-agent-freshness-selector'
+
+// Why frozen: shared by every inactive card, and callers only read these rows.
+const EMPTY_AGENT_ROWS = Object.freeze([]) as unknown as DashboardAgentRow[]
 
 export { buildWorktreeAgentRows } from './worktree-agent-rows'
 export {
@@ -44,35 +55,51 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     () => createWorktreeAgentFreshnessSelector(worktreeId),
     [worktreeId]
   )
-  const tabs = useAppStore((s) => (active ? s.tabsByWorktree[worktreeId] : undefined))
+  const tabs = useAppStore((s) => (active ? s.tabsByWorktree[worktreeId] : EMPTY_TABS))
   // Why: narrow the subscriptions to only THIS worktree's entries via
   // useShallow. Subscribing to the whole agentStatusByPaneKey map would make
   // every on-screen card re-render on any agent-status update anywhere —
   // O(worktrees²) render amplification. Pre-filtering here means the card
   // only re-renders when something relevant to THIS worktree changes.
   const liveEntries = useAppStore(
-    useShallow((s) => (active ? selectLiveAgentStatusEntriesForWorktree(s, worktreeId) : []))
+    useShallow((s) =>
+      active ? selectLiveAgentStatusEntriesForWorktree(s, worktreeId) : EMPTY_LIVE_ENTRIES
+    )
   )
   // Why: keep the store selector limited to stable raw records. Converting
   // migration entries creates fresh objects with Date.now(), which breaks
   // useSyncExternalStore's cached-snapshot contract and can blank Electron.
   const migrationUnsupported = useAppStore(
-    useShallow((s) => (active ? selectMigrationUnsupportedEntriesForWorktree(s, worktreeId) : []))
+    useShallow((s) =>
+      active
+        ? selectMigrationUnsupportedEntriesForWorktree(s, worktreeId)
+        : EMPTY_MIGRATION_UNSUPPORTED_ENTRIES
+    )
   )
   const retained = useAppStore(
-    useShallow((s) => (active ? selectRetainedAgentEntriesForWorktree(s, worktreeId) : []))
+    useShallow((s) =>
+      active ? selectRetainedAgentEntriesForWorktree(s, worktreeId) : EMPTY_RETAINED
+    )
   )
   const runtimePaneTitlesByTabId = useAppStore(
-    useShallow((s) => (active ? selectRuntimePaneTitlesForWorktree(s, worktreeId) : {}))
+    useShallow((s) =>
+      active ? selectRuntimePaneTitlesForWorktree(s, worktreeId) : EMPTY_RUNTIME_PANE_TITLES
+    )
   )
   const ptyIdsByTabId = useAppStore(
-    useShallow((s) => (active ? selectLivePtyIdsForWorktree(s, worktreeId) : {}))
+    useShallow((s) => (active ? selectLivePtyIdsForWorktree(s, worktreeId) : EMPTY_LIVE_PTY_IDS))
   )
   const terminalLayoutsByTabId = useAppStore(
-    useShallow((s) => (active ? selectTerminalLayoutsForWorktree(s, worktreeId) : {}))
+    useShallow((s) =>
+      active ? selectTerminalLayoutsForWorktree(s, worktreeId) : EMPTY_TERMINAL_LAYOUTS
+    )
   )
   const runtimeAgentOrchestrationByPaneKey = useAppStore(
-    useShallow((s) => (active ? selectRuntimeAgentOrchestrationForWorktree(s, worktreeId) : {}))
+    useShallow((s) =>
+      active
+        ? selectRuntimeAgentOrchestrationForWorktree(s, worktreeId)
+        : EMPTY_WORKTREE_AGENT_ORCHESTRATION
+    )
   )
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
@@ -80,7 +107,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
 
   return useMemo<DashboardAgentRow[]>(() => {
     if (!active) {
-      return []
+      return EMPTY_AGENT_ROWS
     }
     // Why: Date.now() is read inside the memo so stale-decay recalculates when
     // this worktree's freshness signature changes, even without new PTY data.
@@ -97,7 +124,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
         : liveEntries
     return applyAgentRowLineage(
       buildWorktreeAgentRows({
-        tabs: tabs ?? [],
+        tabs: tabs ?? EMPTY_TABS,
         entries,
         retained,
         runtimePaneTitlesByTabId,

--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts
@@ -9,10 +9,15 @@ import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { getLiveEntriesFullRebuildCountForTests } from './worktree-agent-live-index-patch'
 import {
+  EMPTY_LIVE_ENTRIES,
+  EMPTY_MIGRATION_UNSUPPORTED_ENTRIES,
+  EMPTY_RETAINED,
+  EMPTY_TERMINAL_LAYOUTS,
   selectLiveAgentStatusEntriesForWorktree,
   selectMigrationUnsupportedEntriesForWorktree,
   selectRuntimeAgentOrchestrationForWorktree,
-  selectRetainedAgentEntriesForWorktree
+  selectRetainedAgentEntriesForWorktree,
+  selectTerminalLayoutsForWorktree
 } from './worktree-agent-row-selectors'
 
 const PANE_KEY_1 = makePaneKey('tab-1', '22222222-2222-4222-8222-222222222222')
@@ -94,8 +99,14 @@ describe('selectMigrationUnsupportedEntriesForWorktree', () => {
 
 describe('selectLiveAgentStatusEntriesForWorktree', () => {
   it('reuses unaffected worktree arrays when another worktree receives a same-state ping', () => {
-    const wt1Entry = makeEntry(PANE_KEY_1, 1000, { state: 'working', prompt: 'first' })
-    const wt2Entry = makeEntry(PANE_KEY_2, 1000, { state: 'working', prompt: 'first' })
+    const wt1Entry = makeEntry(PANE_KEY_1, 1000, {
+      state: 'working',
+      prompt: 'first'
+    })
+    const wt2Entry = makeEntry(PANE_KEY_2, 1000, {
+      state: 'working',
+      prompt: 'first'
+    })
     const state = {
       tabsByWorktree: {
         'wt-1': [makeTab('tab-1')],
@@ -192,8 +203,14 @@ describe('selectLiveAgentStatusEntriesForWorktree', () => {
   })
 
   it('patches instead of full-rebuilding across within-state pings, and stays correct on transitions', () => {
-    const wt1Entry = makeEntry(PANE_KEY_1, 1000, { state: 'working', prompt: 'wt1 prompt' })
-    const wt2Entry = makeEntry(PANE_KEY_2, 1000, { state: 'working', prompt: 'wt2 prompt' })
+    const wt1Entry = makeEntry(PANE_KEY_1, 1000, {
+      state: 'working',
+      prompt: 'wt1 prompt'
+    })
+    const wt2Entry = makeEntry(PANE_KEY_2, 1000, {
+      state: 'working',
+      prompt: 'wt2 prompt'
+    })
     const baseState = {
       tabsByWorktree: {
         'wt-1': [makeTab('tab-1')],
@@ -256,7 +273,10 @@ describe('selectLiveAgentStatusEntriesForWorktree', () => {
   })
 
   it('falls back to a full rebuild when a within-map update changes worktree attribution', () => {
-    const entry = makeEntry(PANE_KEY_1, 1000, { state: 'working', worktreeId: 'wt-1' })
+    const entry = makeEntry(PANE_KEY_1, 1000, {
+      state: 'working',
+      worktreeId: 'wt-1'
+    })
     const state = {
       // No tab membership: bucketing comes from entry.worktreeId attribution.
       tabsByWorktree: { 'wt-1': [], 'wt-2': [] },
@@ -276,7 +296,10 @@ describe('selectLiveAgentStatusEntriesForWorktree', () => {
   })
 
   it('falls back to a full rebuild when a live entry completes with its tab gone', () => {
-    const entry = makeEntry(PANE_KEY_1, 1000, { state: 'working', worktreeId: 'wt-1' })
+    const entry = makeEntry(PANE_KEY_1, 1000, {
+      state: 'working',
+      worktreeId: 'wt-1'
+    })
     const state = {
       tabsByWorktree: { 'wt-1': [] },
       agentStatusByPaneKey: { [PANE_KEY_1]: entry },
@@ -425,5 +448,81 @@ describe('selectRetainedAgentEntriesForWorktree', () => {
     expect(secondWt1).toBe(firstWt1)
     expect(secondWt2).not.toBe(firstWt2)
     expect(secondWt2[0]?.startedAt).toBe(1100)
+  })
+})
+
+describe('selectTerminalLayoutsForWorktree', () => {
+  const layout = {
+    root: { type: 'leaf', leafId: '44444444-4444-4444-8444-444444444444' },
+    activeLeafId: '44444444-4444-4444-8444-444444444444',
+    expandedLeafId: null,
+    ptyIdsByLeafId: {}
+  } as const
+
+  // Why: every visible card re-runs this selector on every store write; a fresh
+  // record per call is an allocation per card per write.
+  it('returns one identity per store generation', () => {
+    const state = {
+      tabsByWorktree: { 'wt-1': [makeTab('tab-1')] },
+      terminalLayoutsByTabId: { 'tab-1': layout }
+    }
+
+    expect(selectTerminalLayoutsForWorktree(state, 'wt-1')).toBe(
+      selectTerminalLayoutsForWorktree(state, 'wt-1')
+    )
+  })
+
+  it('returns the shared frozen empty for a worktree with no tabs', () => {
+    const state = { tabsByWorktree: {}, terminalLayoutsByTabId: {} }
+
+    expect(selectTerminalLayoutsForWorktree(state, 'missing')).toBe(EMPTY_TERMINAL_LAYOUTS)
+  })
+})
+
+// Why: the inline-agents hook short-circuits on `active`; the off branch has to
+// hand back a shared identity or the gate allocates on every store write.
+describe('inactive-card empty constants', () => {
+  it('are frozen and shared', () => {
+    for (const empty of [
+      EMPTY_LIVE_ENTRIES,
+      EMPTY_MIGRATION_UNSUPPORTED_ENTRIES,
+      EMPTY_RETAINED,
+      EMPTY_TERMINAL_LAYOUTS
+    ]) {
+      expect(Object.isFrozen(empty)).toBe(true)
+    }
+    expect(
+      selectLiveAgentStatusEntriesForWorktree(
+        {
+          agentStatusByPaneKey: {},
+          migrationUnsupportedByPtyId: {},
+          retainedAgentsByPaneKey: {},
+          tabsByWorktree: {}
+        },
+        'missing'
+      )
+    ).toBe(EMPTY_LIVE_ENTRIES)
+    expect(
+      selectMigrationUnsupportedEntriesForWorktree(
+        {
+          agentStatusByPaneKey: {},
+          migrationUnsupportedByPtyId: {},
+          retainedAgentsByPaneKey: {},
+          tabsByWorktree: {}
+        },
+        'missing'
+      )
+    ).toBe(EMPTY_MIGRATION_UNSUPPORTED_ENTRIES)
+    expect(
+      selectRetainedAgentEntriesForWorktree(
+        {
+          agentStatusByPaneKey: {},
+          migrationUnsupportedByPtyId: {},
+          retainedAgentsByPaneKey: {},
+          tabsByWorktree: {}
+        },
+        'missing'
+      )
+    ).toBe(EMPTY_RETAINED)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
@@ -13,11 +13,18 @@ import {
   recordLiveEntriesFullRebuild
 } from './worktree-agent-live-index-patch'
 import { selectWorktreeAgentOrchestration } from './worktree-agent-orchestration-index'
+import { createWorktreeRecordSelector } from './worktree-record-selector-cache'
 import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
 
-const EMPTY_LIVE_ENTRIES: AgentStatusEntry[] = []
-const EMPTY_MIGRATION_UNSUPPORTED_ENTRIES: MigrationUnsupportedPtyEntry[] = []
-const EMPTY_RETAINED: RetainedAgentEntry[] = []
+// Why frozen and exported: card hooks return these from their inactive branch,
+// so the identity has to be shared app-wide and safe from stray writes.
+export const EMPTY_LIVE_ENTRIES = Object.freeze([]) as unknown as AgentStatusEntry[]
+export const EMPTY_MIGRATION_UNSUPPORTED_ENTRIES = Object.freeze(
+  []
+) as unknown as MigrationUnsupportedPtyEntry[]
+export const EMPTY_RETAINED = Object.freeze([]) as unknown as RetainedAgentEntry[]
+export const EMPTY_TERMINAL_LAYOUTS: Record<string, TerminalLayoutSnapshot | undefined> =
+  Object.freeze({})
 // Why: selector unit tests often pass partial store mocks; production state
 // owns these maps, but missing mock maps should behave like empty slices.
 const EMPTY_RECORD = {}
@@ -268,13 +275,20 @@ export function selectRuntimeAgentOrchestrationForWorktree(
   return selectWorktreeAgentOrchestration(state, worktreeId)
 }
 
-export function selectTerminalLayoutsForWorktree(
-  state: Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId'>,
-  worktreeId: string
-): Record<string, TerminalLayoutSnapshot | undefined> {
-  const out: Record<string, TerminalLayoutSnapshot | undefined> = {}
-  for (const tab of (state.tabsByWorktree ?? EMPTY_RECORD)[worktreeId] ?? []) {
-    out[tab.id] = (state.terminalLayoutsByTabId ?? EMPTY_RECORD)[tab.id]
+export const selectTerminalLayoutsForWorktree = createWorktreeRecordSelector<
+  Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId'>,
+  Record<string, TerminalLayoutSnapshot | undefined>
+>({
+  readSources: (state) => [
+    state.tabsByWorktree ?? EMPTY_RECORD,
+    state.terminalLayoutsByTabId ?? EMPTY_RECORD
+  ],
+  empty: EMPTY_TERMINAL_LAYOUTS,
+  build: (state, worktreeId) => {
+    const out: Record<string, TerminalLayoutSnapshot | undefined> = {}
+    for (const tab of (state.tabsByWorktree ?? EMPTY_RECORD)[worktreeId] ?? []) {
+      out[tab.id] = (state.terminalLayoutsByTabId ?? EMPTY_RECORD)[tab.id]
+    }
+    return out
   }
-  return out
-}
+})

--- a/src/renderer/src/components/sidebar/worktree-card-status-inputs.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-status-inputs.test.ts
@@ -6,6 +6,9 @@ import type {
   TerminalTab
 } from '../../../../shared/terminal-tab-types'
 import {
+  EMPTY_LIVE_PTY_IDS,
+  EMPTY_RUNTIME_PANE_TITLES,
+  EMPTY_TERMINAL_LAYOUT_ROOTS,
   selectLivePtyIdsForWorktree,
   selectTerminalLayoutRootsForWorktree,
   selectTerminalLayoutRootsForWorktrees,
@@ -144,5 +147,76 @@ describe('worktree card status input selectors', () => {
         selectTerminalLayoutRootsForWorktrees(wakeBindingUpdate, [worktreeId])
       )
     ).toBe(true)
+  })
+
+  // Why: zustand re-runs every mounted card's selector on every store write, so
+  // a fresh record per call multiplies by (visible cards x writes/sec).
+  it('returns one identity per store generation instead of rebuilding per call', () => {
+    const worktreeId = 'repo1::/path/wt1'
+    const state: SelectorState & LayoutRootSelectorState = {
+      tabsByWorktree: {
+        [worktreeId]: [makeTab('tab-1', worktreeId)]
+      },
+      runtimePaneTitlesByTabId: { 'tab-1': { 0: 'codex [working]' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      terminalLayoutsByTabId: {
+        'tab-1': makeLayout(
+          { type: 'leaf', leafId: '11111111-1111-4111-8111-111111111111' },
+          'pty-1'
+        )
+      }
+    }
+
+    expect(selectRuntimePaneTitlesForWorktree(state, worktreeId)).toBe(
+      selectRuntimePaneTitlesForWorktree(state, worktreeId)
+    )
+    expect(selectLivePtyIdsForWorktree(state, worktreeId)).toBe(
+      selectLivePtyIdsForWorktree(state, worktreeId)
+    )
+    expect(selectTerminalLayoutRootsForWorktree(state, worktreeId)).toBe(
+      selectTerminalLayoutRootsForWorktree(state, worktreeId)
+    )
+  })
+
+  it('carries the same identity across unrelated pane-title and PTY churn', () => {
+    const worktreeId = 'repo1::/path/wt1'
+    const state: SelectorState = {
+      tabsByWorktree: {
+        [worktreeId]: [makeTab('tab-1', worktreeId)]
+      },
+      runtimePaneTitlesByTabId: { 'tab-1': { 0: 'codex [working]' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+    }
+    const unrelatedUpdate: SelectorState = {
+      ...state,
+      runtimePaneTitlesByTabId: {
+        ...state.runtimePaneTitlesByTabId,
+        'other-tab': { 0: 'claude [permission]' }
+      },
+      ptyIdsByTabId: { ...state.ptyIdsByTabId, 'other-tab': ['pty-other'] }
+    }
+
+    expect(selectRuntimePaneTitlesForWorktree(state, worktreeId)).toBe(
+      selectRuntimePaneTitlesForWorktree(unrelatedUpdate, worktreeId)
+    )
+    expect(selectLivePtyIdsForWorktree(state, worktreeId)).toBe(
+      selectLivePtyIdsForWorktree(unrelatedUpdate, worktreeId)
+    )
+  })
+
+  it('returns the shared frozen empty for a worktree with no tabs', () => {
+    const state: SelectorState & LayoutRootSelectorState = {
+      tabsByWorktree: {},
+      runtimePaneTitlesByTabId: {},
+      ptyIdsByTabId: {},
+      terminalLayoutsByTabId: {}
+    }
+
+    expect(selectRuntimePaneTitlesForWorktree(state, 'missing')).toBe(EMPTY_RUNTIME_PANE_TITLES)
+    expect(selectLivePtyIdsForWorktree(state, 'missing')).toBe(EMPTY_LIVE_PTY_IDS)
+    expect(selectTerminalLayoutRootsForWorktree(state, 'missing')).toBe(EMPTY_TERMINAL_LAYOUT_ROOTS)
+    expect(Object.isFrozen(EMPTY_RUNTIME_PANE_TITLES)).toBe(true)
+    expect(Object.isFrozen(EMPTY_LIVE_PTY_IDS)).toBe(true)
+    expect(Object.isFrozen(EMPTY_TERMINAL_LAYOUT_ROOTS)).toBe(true)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-card-status-inputs.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-status-inputs.ts
@@ -1,8 +1,18 @@
 import type { AppState } from '@/store/types'
 import type { TerminalPaneLayoutNode } from '../../../../shared/terminal-tab-types'
+import { createWorktreeRecordSelector } from './worktree-record-selector-cache'
 
 // Why: these selectors return fresh maps whose top-level values preserve
 // underlying per-tab references, so callers must compare them shallowly.
+
+// Why frozen: one instance is shared by every card, so a stray write would leak
+// across worktrees instead of failing locally.
+export const EMPTY_RUNTIME_PANE_TITLES: Record<string, Record<number, string>> = Object.freeze({})
+export const EMPTY_LIVE_PTY_IDS: Record<string, string[]> = Object.freeze({})
+export const EMPTY_TERMINAL_LAYOUT_ROOTS: Record<
+  string,
+  TerminalPaneLayoutNode | null | undefined
+> = Object.freeze({})
 
 type WorktreeCardStatusInputState = Pick<AppState, 'runtimePaneTitlesByTabId' | 'ptyIdsByTabId'> & {
   tabsByWorktree: Record<string, readonly { id: string }[]>
@@ -12,44 +22,56 @@ type WorktreeCardLayoutRootInputState = Pick<AppState, 'terminalLayoutsByTabId'>
   tabsByWorktree: Record<string, readonly { id: string }[]>
 }
 
-export function selectRuntimePaneTitlesForWorktree(
-  state: WorktreeCardStatusInputState,
-  worktreeId: string
-): Record<string, Record<number, string>> {
-  const out: Record<string, Record<number, string>> = {}
-  for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
-    const paneTitles = state.runtimePaneTitlesByTabId[tab.id]
-    if (paneTitles) {
-      out[tab.id] = paneTitles
+export const selectRuntimePaneTitlesForWorktree = createWorktreeRecordSelector<
+  WorktreeCardStatusInputState,
+  Record<string, Record<number, string>>
+>({
+  readSources: (state) => [state.tabsByWorktree, state.runtimePaneTitlesByTabId],
+  empty: EMPTY_RUNTIME_PANE_TITLES,
+  build: (state, worktreeId) => {
+    const out: Record<string, Record<number, string>> = {}
+    for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
+      const paneTitles = state.runtimePaneTitlesByTabId[tab.id]
+      if (paneTitles) {
+        out[tab.id] = paneTitles
+      }
     }
+    return out
   }
-  return out
-}
+})
 
-export function selectLivePtyIdsForWorktree(
-  state: WorktreeCardStatusInputState,
-  worktreeId: string
-): Record<string, string[]> {
-  const out: Record<string, string[]> = {}
-  for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
-    const ids = state.ptyIdsByTabId[tab.id]
-    if (ids && ids.length > 0) {
-      out[tab.id] = ids
+export const selectLivePtyIdsForWorktree = createWorktreeRecordSelector<
+  WorktreeCardStatusInputState,
+  Record<string, string[]>
+>({
+  readSources: (state) => [state.tabsByWorktree, state.ptyIdsByTabId],
+  empty: EMPTY_LIVE_PTY_IDS,
+  build: (state, worktreeId) => {
+    const out: Record<string, string[]> = {}
+    for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
+      const ids = state.ptyIdsByTabId[tab.id]
+      if (ids && ids.length > 0) {
+        out[tab.id] = ids
+      }
     }
+    return out
   }
-  return out
-}
+})
 
-export function selectTerminalLayoutRootsForWorktree(
-  state: WorktreeCardLayoutRootInputState,
-  worktreeId: string
-): Record<string, TerminalPaneLayoutNode | null | undefined> {
-  const out: Record<string, TerminalPaneLayoutNode | null | undefined> = {}
-  for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
-    out[tab.id] = state.terminalLayoutsByTabId[tab.id]?.root
+export const selectTerminalLayoutRootsForWorktree = createWorktreeRecordSelector<
+  WorktreeCardLayoutRootInputState,
+  Record<string, TerminalPaneLayoutNode | null | undefined>
+>({
+  readSources: (state) => [state.tabsByWorktree, state.terminalLayoutsByTabId],
+  empty: EMPTY_TERMINAL_LAYOUT_ROOTS,
+  build: (state, worktreeId) => {
+    const out: Record<string, TerminalPaneLayoutNode | null | undefined> = {}
+    for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
+      out[tab.id] = state.terminalLayoutsByTabId[tab.id]?.root
+    }
+    return out
   }
-  return out
-}
+})
 
 export function selectTerminalLayoutRootsForWorktrees(
   state: WorktreeCardLayoutRootInputState,

--- a/src/renderer/src/components/sidebar/worktree-list/listing/pending-worktree-creation-keys.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/pending-worktree-creation-keys.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '@/store/types'
+import {
+  EMPTY_PENDING_WORKTREE_CREATION_KEYS,
+  selectPendingWorktreeCreationKeys
+} from './pending-worktree-creation-keys'
+
+type PendingCreations = AppState['pendingWorktreeCreations']
+
+function makePending(creationId: string, repoId: string): PendingCreations[string] {
+  return {
+    creationId,
+    request: { repoId }
+  } as unknown as PendingCreations[string]
+}
+
+describe('selectPendingWorktreeCreationKeys', () => {
+  // Why: this runs inside an always-mounted sidebar subscriber, so zustand
+  // re-evaluates it on every store write in the app.
+  it('returns the shared frozen empty when nothing is pending', () => {
+    const empty: PendingCreations = {}
+
+    expect(selectPendingWorktreeCreationKeys(empty)).toBe(EMPTY_PENDING_WORKTREE_CREATION_KEYS)
+    expect(selectPendingWorktreeCreationKeys({})).toBe(EMPTY_PENDING_WORKTREE_CREATION_KEYS)
+    expect(selectPendingWorktreeCreationKeys(undefined)).toBe(EMPTY_PENDING_WORKTREE_CREATION_KEYS)
+    expect(Object.isFrozen(EMPTY_PENDING_WORKTREE_CREATION_KEYS)).toBe(true)
+  })
+
+  it('builds the key list once per slice identity', () => {
+    const pending: PendingCreations = {
+      'creation-1': makePending('creation-1', 'repo with space')
+    }
+
+    const first = selectPendingWorktreeCreationKeys(pending)
+    expect(first).toEqual(['creation-1 repo with space'])
+    expect(selectPendingWorktreeCreationKeys(pending)).toBe(first)
+  })
+
+  it('rebuilds when the slice is replaced', () => {
+    const before: PendingCreations = {
+      'creation-1': makePending('creation-1', 'repo-1')
+    }
+    const after: PendingCreations = {
+      ...before,
+      'creation-2': makePending('creation-2', 'repo-2')
+    }
+
+    expect(selectPendingWorktreeCreationKeys(after)).toEqual([
+      'creation-1 repo-1',
+      'creation-2 repo-2'
+    ])
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/listing/pending-worktree-creation-keys.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/pending-worktree-creation-keys.ts
@@ -1,0 +1,39 @@
+import type { AppState } from '@/store/types'
+
+// Why frozen: the sidebar row model is always mounted and this list is empty
+// almost always, so one shared identity serves every read.
+export const EMPTY_PENDING_WORKTREE_CREATION_KEYS: string[] = Object.freeze(
+  []
+) as unknown as string[]
+
+const keysBySource = new WeakMap<object, string[]>()
+
+/**
+ * Flat `"<creationId> <repoId>"` keys for the pending-creation sidebar rows.
+ *
+ * Why identity-cached: this runs inside an always-mounted subscriber, so an
+ * unmemoized `Object.values(...).map(...)` allocated an array plus one template
+ * string per pending creation on every store write in the app. Keyed on the
+ * slice reference, so it only rebuilds when the slice itself is replaced.
+ *
+ * Split on the first space — creationId is a UUID (no space) so a
+ * space-containing repoId stays intact.
+ */
+export function selectPendingWorktreeCreationKeys(
+  pendingWorktreeCreations: AppState['pendingWorktreeCreations'] | undefined
+): string[] {
+  if (!pendingWorktreeCreations) {
+    return EMPTY_PENDING_WORKTREE_CREATION_KEYS
+  }
+  const cached = keysBySource.get(pendingWorktreeCreations)
+  if (cached) {
+    return cached
+  }
+  const creations = Object.values(pendingWorktreeCreations)
+  const keys =
+    creations.length === 0
+      ? EMPTY_PENDING_WORKTREE_CREATION_KEYS
+      : creations.map((creation) => `${creation.creationId} ${creation.request.repoId}`)
+  keysBySource.set(pendingWorktreeCreations, keys)
+  return keys
+}

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
@@ -19,6 +19,7 @@ import { getEmptyProjectPlaceholderRepoIds } from '../../empty-project-placehold
 import { addHostSectionRows } from '../../host-section-rows'
 import { orderHostSectionOptions } from '../../host-section-order'
 import { buildSidebarHostOptions } from '../../sidebar-host-options'
+import { selectPendingWorktreeCreationKeys } from './pending-worktree-creation-keys'
 
 type SectionRowsArgs = {
   groupBy: WorktreeGroupBy
@@ -96,19 +97,17 @@ export function useSidebarSectionRows(args: SectionRowsArgs) {
   )
 
   // Why: subscribe on a flat key array (useShallow) so progress ticks don't rebuild the whole row model.
-  // Split on first space — creationId is a UUID (no space) so a space-containing repoId stays intact.
   const pendingCreationKeys = useAppStore(
-    useShallow((s) =>
-      Object.values(s.pendingWorktreeCreations ?? {}).map(
-        (creation) => `${creation.creationId} ${creation.request.repoId}`
-      )
-    )
+    useShallow((s) => selectPendingWorktreeCreationKeys(s.pendingWorktreeCreations))
   )
   const pendingCreations = useMemo(
     () =>
       pendingCreationKeys.map((key) => {
         const separator = key.indexOf(' ')
-        return { creationId: key.slice(0, separator), repoId: key.slice(separator + 1) }
+        return {
+          creationId: key.slice(0, separator),
+          repoId: key.slice(separator + 1)
+        }
       }),
     [pendingCreationKeys]
   )

--- a/src/renderer/src/components/sidebar/worktree-record-selector-cache.ts
+++ b/src/renderer/src/components/sidebar/worktree-record-selector-cache.ts
@@ -1,0 +1,63 @@
+import { shallow } from 'zustand/shallow'
+
+type WorktreeRecordGeneration<TValue> = {
+  sources: readonly unknown[]
+  carried: ReadonlyMap<string, TValue> | null
+  byWorktreeId: Map<string, TValue>
+}
+
+function sameSources(previous: readonly unknown[], next: readonly unknown[]): boolean {
+  if (previous.length !== next.length) {
+    return false
+  }
+  for (let index = 0; index < next.length; index += 1) {
+    if (previous[index] !== next[index]) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Wraps a per-worktree record selector in a store-identity-keyed cache.
+ *
+ * Zustand re-runs every mounted subscriber's selector on every store write, so
+ * an unmemoized build allocates one record per visible card per write even when
+ * nothing it reads changed. Gating on the source slice identities collapses that
+ * to one build per worktree per generation; carrying the previous generation
+ * forward keeps the reference stable when a rebuild produces equal contents, so
+ * downstream `useShallow`/`useMemo` gates short-circuit on identity.
+ *
+ * The returned records are shared by every caller and must never be mutated.
+ */
+export function createWorktreeRecordSelector<TState, TValue extends object>(options: {
+  readSources: (state: TState) => readonly unknown[]
+  build: (state: TState, worktreeId: string) => TValue
+  empty: TValue
+}): (state: TState, worktreeId: string) => TValue {
+  let generation: WorktreeRecordGeneration<TValue> | null = null
+  return (state, worktreeId) => {
+    const sources = options.readSources(state)
+    if (!generation || !sameSources(generation.sources, sources)) {
+      generation = {
+        sources,
+        carried: generation?.byWorktreeId ?? null,
+        byWorktreeId: new Map()
+      }
+    }
+    const cached = generation.byWorktreeId.get(worktreeId)
+    if (cached !== undefined) {
+      return cached
+    }
+    const built = options.build(state, worktreeId)
+    const carried = generation.carried?.get(worktreeId)
+    let value = built
+    if (Object.keys(built).length === 0) {
+      value = options.empty
+    } else if (carried && shallow(carried, built)) {
+      value = carried
+    }
+    generation.byWorktreeId.set(worktreeId, value)
+    return value
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​269 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​262 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​238 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​69 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​169 |

<!-- /orca-pr-loc -->

## ELI5

Zustand re-runs **every** mounted subscriber's selector on **every** store write. Several sidebar selectors answered "what are this worktree's pane titles / PTYs / layouts?" by building a **brand new object from scratch every single time they were asked** — even when nothing they read had changed since the last answer. With ~15 visible cards each asking ~6 of these questions, ~20 writes/sec meant thousands of throwaway objects per second whose contents were byte-for-byte identical to the ones just discarded.

Same story in three other places:

- The inline-agents hook already had an "if this card is inactive, don't do the work" gate — but the off branch returned a **fresh** `[]` / `{}` literal each time, so the gate produced a new identity on every write and never actually short-circuited anything downstream.
- The sidebar's pending-worktree-creation list rebuilt an array (plus one template string per entry) on every store write from an always-mounted component, to report "nothing is pending" 99.9% of the time.
- A truncation label used `key={text}`, which tells React to **throw the DOM node away and build a new one** whenever the text changes — taking its `ResizeObserver` down with it and constructing a fresh one.

The fix is the same idea everywhere: if the inputs haven't changed, hand back the answer you already have.

---

## What changed

**1. `createWorktreeRecordSelector`** (new, `worktree-record-selector-cache.ts`) — gates the build on the source slice identities, memoizes lazily per worktree id, and carries the previous generation forward so a rebuild that produces shallow-equal contents keeps its old reference. `selectRuntimePaneTitlesForWorktree`, `selectLivePtyIdsForWorktree`, `selectTerminalLayoutRootsForWorktree` and `selectTerminalLayoutsForWorktree` now route through it and return a shared frozen empty when a worktree has no tabs.

The existing contract comment at `worktree-card-status-inputs.ts:4-5` ("these selectors return fresh maps whose top-level values preserve underlying per-tab references, so callers must compare them shallowly") is respected and strengthened: the cross-generation reuse uses zustand's own `shallow`, which is exactly the comparison every caller already applies. Callers that were shallow-equal before are now `Object.is`-equal.

**2. `useWorktreeAgentRows`** — all seven inactive-branch literals (`[]`, `{}`, and the memo's `return []`) swapped for shared frozen constants, plus `tabs ?? EMPTY_TABS`.

**3. `selectPendingWorktreeCreationKeys`** (new, `pending-worktree-creation-keys.ts`) — WeakMap identity cache on the slice reference, shared frozen `[]` for the empty case. This is the same in-repo pattern as `countRecordKeysByReference`.

**4. `TruncatedSidebarLabel`** — `key={text}` dropped; the span keeps one observer for its lifetime and remeasures via `useLayoutEffect` on `text` calling the existing `measureTruncated` on the current node. `useLayoutEffect` (not `useEffect`) so the measurement still lands in the commit phase exactly like the old ref-callback did — no paint with a stale tooltip.

**5. `main.css`** — removed non-compositable `width` from the board drop indicator's `will-change`. Left in `transition`.

`AgentWorkingSpinner` was not touched.

---

## Corrections to the brief

Three details in the request did not match the code. Flagging rather than silently working around them:

- **Item 3 (`use-row-measurement.ts:53`) needed no change and was left alone.** `countRecordKeysByReference` does not contain a `.map(` — it is `Object.keys(record).length` behind a `WeakMap<Record, number>` identity cache (lines 19-29), i.e. already O(1) amortized. `issueCache`/`prCache` identities only change on a GitHub cache write, so on the hot path this is a single WeakMap hit. Touching it would have been churn for zero gain.
- **`TruncatedSidebarLabel` is mounted once per worktree card, not twice.** `worktree-card-meta-row.tsx:68` and `:81` are two arms of the same ternary (`showIdentityInNewCard ? … : isFolder ? … : showBranch ? …`), so at most one renders.
- **Its `text` is the branch name or identity display, not the worktree title**, so it does not change on every agent status update. The remount-per-text-change is still real observer churn worth removing (branch renames, identity resolution, folder-workspace label resolution), just not as hot as described.

---

## Measurements

All numbers are real, produced by a throwaway harness run against this branch and then against the same files reverted via `git apply -R` (harness not committed). Synthetic state at the stated scale: 423 worktrees, 382 terminal tabs, 15 visible cards, 200 store writes that change the root state object but touch none of the slices these selectors read (the common idle case).

### Selector records allocated — 200 store writes x 15 cards = 18,000 selector calls

| Selector | Before | After |
|---|---:|---:|
| `selectRuntimePaneTitlesForWorktree` (2 call sites/card) | 6,000 | **15** |
| `selectLivePtyIdsForWorktree` (2 call sites/card) | 6,000 | **15** |
| `selectTerminalLayoutRootsForWorktree` | 3,000 | **15** |
| `selectTerminalLayoutsForWorktree` | 3,000 | **15** |
| **Total distinct records** | **18,000** | **60** |

18,000 calls previously produced 18,000 distinct object identities — a 1:1 allocation-to-call ratio, i.e. every call was an identity miss. Now 60 (one per worktree per selector, built once and reused), a **99.7% reduction**. Extrapolated to the reported ~20 writes/sec: ~1,800 records/sec → ~0.

### Pending-worktree-creation keys — 200 store writes, empty pending map

| | Before | After |
|---|---:|---:|
| Distinct arrays returned | 200 (1 per call, by construction — `Object.values({}).map(f)` cannot return a cached array) | **1** (measured) |

The `200` is arithmetic from the removed expression, not a harness run; the `1` is measured.

### ResizeObserver constructions across one label text change

Measured by the new test in `truncated-sidebar-label.test.tsx`, which swaps a counting `ResizeObserver` onto `globalThis`:

| | Before | After |
|---|---:|---:|
| `new ResizeObserver(...)` calls | **2** | **1** |
| `disconnect()` calls | 1 | **0** |

Reverted-code run: `AssertionError: expected 2 to be 1`.

### Inactive-card empty literals (arithmetic, not measured)

`useWorktreeAgentRows(id, false)` allocated 6 empty literals per store write per inactive card (four `[]`, three `{}` across seven `useShallow` off-branches plus the memo's `return []`). Now 0 — all seven return shared frozen module constants.

---

## Fail-first verification

Confirmed by reverting `worktree-card-status-inputs.ts`, `worktree-agent-row-selectors.ts` and `truncated-sidebar-label.tsx` (via saved patch — no `git stash`) and re-running:

```
Tests  4 failed | 7 passed (11)
```

Failing without the fix:
- `returns one identity per store generation instead of rebuilding per call`
- `carries the same identity across unrelated pane-title and PTY churn`
- `returns the shared frozen empty for a worktree with no tabs`
- `keeps one ResizeObserver across a label text change`

(`pending-worktree-creation-keys.test.ts` covers a newly extracted module — the old code was an inline expression inside a hook with no seam to assert against, so it is a new-module test, not a fail-first one. Being straight about that.)

---

## Negative user-facing trade-offs

**None.** Point by point:

1. **Do the shared frozen constants get mutated by anyone?** Searched every consumer of all five selectors and of `useWorktreeAgentRows`' return value. They are read-only:
   - `resolveWorktreeStatus` — `filter` / index reads only.
   - `buildWorktreeAgentRows` — the one `rows.sort(...)` at `worktree-agent-rows.ts:272` sorts a **locally built** array; `args.entries` / `args.retained` / `args.terminalLayoutsByTabId` / `args.ptyIdsByTabId` / `args.runtimePaneTitlesByTabId` are only iterated or indexed.
   - `WorktreeCardAgents`, `use-worktree-card-secondary-details`, `ReviewNotesSendMenuContent`, `build-dashboard-snapshot`, `build-dashboard-bucket-counts` — iterate/read only. `selectSummaryGroupIconAgents` pushes into `Map` values it creates itself, never into the input.
   - Empirically: freezing them and running 4,244 tests across sidebar + dashboard + editor + the three runtime consumers produced zero `TypeError: Cannot add property` — ESM is strict mode, so any write would have thrown.
2. **Stale data from the identity gate?** The gate is over *reference* identity of the exact slices each selector reads. The store is immutable (every write replaces the slice), so a content change necessarily changes the reference and forces a rebuild. `changes when this worktree receives a new live PTY id list` still passes.
3. **Memory growth from the cache?** Bounded by worktree count, and the per-worktree map is discarded wholesale on every source-identity change (only the immediately-prior generation is retained for reference reuse). No per-write growth.
4. **Truncation/tooltip behavior?** Rendered output is byte-identical — only the `key` prop is gone. Measurement still runs in the commit phase (`useLayoutEffect`, not `useEffect`), so there is no frame where the ellipsis and the tooltip disagree. The pre-existing `remeasures when the branch text changes without a resize event` test passes unchanged, including both truncated→untruncated directions.
5. **CSS?** `will-change: width` is a no-op hint on a non-compositable property; the `width` transition itself is untouched and still animates identically. Zero visual change.

## Verification

- `pnpm tc` — clean (run once, at the end)
- `npx oxlint <changed files>` and `npx oxlint src/renderer/src/components/sidebar/` — clean
- `npx oxfmt --check` — clean
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar` — 283 files, 2,425 tests passed
- Plus `dashboard`, `editor`, `worktree-creation` and the three `runtime/*` selector consumers — 541 files, 4,244 tests passed
