### PR TITLE
perf(renderer): stop six timers from ticking behind a hidden window

### DIFF
--- a/src/main/git/worktree-base-divergence-real-git.test.ts
+++ b/src/main/git/worktree-base-divergence-real-git.test.ts
@@ -32,9 +32,17 @@ async function createRepo(): Promise<string> {
   return repoPath
 }
 
+// Why unique across calls: an empty commit's hash covers only parent, tree, message and a
+// one-second-granularity timestamp. On a fast runner the whole 100-commit build finishes inside
+// one second, so a post-reset `commit 0` off the same fork point hashed identically to the first
+// `commit 0` of the chain and Git handed back that same object — leaving the branch 99/0 apart
+// instead of 100/1.
+let emptyCommitSequence = 0
+
 function commitEmpty(repoPath: string, count: number): void {
   for (let index = 0; index < count; index += 1) {
-    git(repoPath, ['commit', '--quiet', '--allow-empty', '-m', `commit ${index}`])
+    emptyCommitSequence += 1
+    git(repoPath, ['commit', '--quiet', '--allow-empty', '-m', `commit ${emptyCommitSequence}`])
   }
 }
 

--- a/src/renderer/src/components/browser-pane/navigate/chromium-error-page-poll-visibility.test.ts
+++ b/src/renderer/src/components/browser-pane/navigate/chromium-error-page-poll-visibility.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BrowserTabPageState } from '../describe-page/browser-page-types'
+import { useBrowserPageWebviewUrlSync } from './use-browser-page-webview-url-sync'
+
+const CHROMIUM_ERROR_URL = 'chrome-error://chromewebdata/'
+
+function setDocumentVisibility(state: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => state })
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'))
+  })
+}
+
+function renderUrlSync(guestUrl: () => string): {
+  updates: [string, BrowserTabPageState][]
+  unmount: () => void
+} {
+  const updates: [string, BrowserTabPageState][] = []
+  const webview = { getURL: () => guestUrl(), src: '' } as unknown as Electron.WebviewTag
+  const view = renderHook(() =>
+    useBrowserPageWebviewUrlSync({
+      browserTabId: 'tab-1',
+      browserTabUrl: 'https://example.test/slow',
+      browserTabLoading: true,
+      isActive: true,
+      isPaintable: true,
+      slotViewport: null,
+      webviewRef: { current: webview },
+      chromeHeaderRef: { current: null },
+      lastKnownWebviewUrlRef: { current: 'https://example.test/slow' },
+      trackNextLoadingEventRef: { current: false },
+      keepAddressBarFocusRef: { current: false },
+      addressBarInputRef: { current: null },
+      browserTabUrlRef: { current: 'https://example.test/slow' },
+      addressBarValueRef: { current: 'https://example.test/slow' },
+      onUpdatePageStateRef: {
+        current: (tabId, patch) => {
+          updates.push([tabId, patch])
+        }
+      },
+      focusWebviewNow: () => false
+    })
+  )
+  return { updates, unmount: view.unmount }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  setDocumentVisibility('visible')
+})
+
+afterEach(() => {
+  cleanup()
+  setDocumentVisibility('visible')
+  vi.useRealTimers()
+})
+
+describe('chromium error page poll visibility gate', () => {
+  it('stops the 250ms poll while hidden and re-detects the error page on return', () => {
+    let guestUrl = 'https://example.test/slow'
+    const { updates, unmount } = renderUrlSync(() => guestUrl)
+
+    // Visible and still loading: the fallback poll is armed.
+    expect(vi.getTimerCount()).toBe(1)
+    act(() => vi.advanceTimersByTime(1_000))
+    expect(updates).toHaveLength(0)
+
+    setDocumentVisibility('hidden')
+    expect(vi.getTimerCount()).toBe(0)
+
+    // The guest lands on a chrome-error page while nobody can see the surface.
+    guestUrl = CHROMIUM_ERROR_URL
+    act(() => vi.advanceTimersByTime(10_000))
+    expect(updates).toHaveLength(0)
+
+    // Returning re-reads the durable guest URL, so the loadError is not lost.
+    setDocumentVisibility('visible')
+    expect(updates).toHaveLength(1)
+    expect(updates[0]?.[1].loadError?.validatedUrl).toBe('https://example.test/slow')
+    expect(updates[0]?.[1].loading).toBe(false)
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('polls unchanged while the window stays visible', () => {
+    let guestUrl = 'https://example.test/slow'
+    const { updates } = renderUrlSync(() => guestUrl)
+
+    guestUrl = CHROMIUM_ERROR_URL
+    act(() => vi.advanceTimersByTime(250))
+    expect(updates).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/components/browser-pane/navigate/use-browser-page-webview-url-sync.ts
+++ b/src/renderer/src/components/browser-pane/navigate/use-browser-page-webview-url-sync.ts
@@ -9,6 +9,7 @@ import {
   applyBrowserPageViewportLayout,
   syncBrowserPageChromeInset
 } from '../host-guest/browser-page-viewport'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import { shouldPollChromiumErrorPage } from './chromium-error-page-polling'
 import { isChromiumErrorPage } from '../describe-page/browser-page-url-display'
 import type { BrowserTabPageState } from '../describe-page/browser-page-types'
@@ -152,9 +153,11 @@ export function useBrowserPageWebviewUrlSync({
     }
 
     // Why: some Electron builds paint chrome-error pages without a did-fail-load event; poll only while the active tab loads as a fallback.
-    detectChromiumErrorPage()
-    const intervalId = window.setInterval(detectChromiumErrorPage, 250)
-    return () => window.clearInterval(intervalId)
+    // Why gated: a page stuck loading would otherwise poll 4x/sec forever behind a hidden window. The guest URL is durable state, so the becoming-visible run re-derives anything a hidden window skipped.
+    return installWindowVisibilityInterval({
+      run: detectChromiumErrorPage,
+      intervalMs: 250
+    })
   }, [
     addressBarValueRef,
     browserTabId,

--- a/src/renderer/src/components/contextual-tours/ContextualTourOverlay.tsx
+++ b/src/renderer/src/components/contextual-tours/ContextualTourOverlay.tsx
@@ -24,6 +24,7 @@ import {
   handleContextualTourOverlayKeyDown,
   type ActiveTourRenderState
 } from './ContextualTourOverlaySurface'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import { requestActiveTerminalPaneSplit } from '@/components/tab-bar/request-active-terminal-pane-split'
 import { performContextualTourStepAction } from './contextual-tour-step-actions'
 import { openWorkspaceCreationComposerWithTourHandoff } from './workspace-creation-tour-handoff'
@@ -228,14 +229,20 @@ export function ContextualTourOverlay(): JSX.Element | null {
     const scheduleFullMeasure = (): void => scheduleMeasure(true)
     window.addEventListener('resize', scheduleFullMeasure)
     window.addEventListener('scroll', scheduleTargetMeasure, true)
-    const interval = window.setInterval(scheduleFullMeasure, 500)
+    // Why gated: a hidden window paints no frames, so the queued rAF never runs
+    // and the pass is pure wakeup. The becoming-visible run re-queues it, and
+    // the layout effect measures on every render, so nothing is missed.
+    const stopFullPassInterval = installWindowVisibilityInterval({
+      run: scheduleFullMeasure,
+      intervalMs: 500
+    })
     return () => {
       if (frame !== null) {
         window.cancelAnimationFrame(frame)
       }
       window.removeEventListener('resize', scheduleFullMeasure)
       window.removeEventListener('scroll', scheduleTargetMeasure, true)
-      window.clearInterval(interval)
+      stopFullPassInterval()
     }
   }, [activeTourId, measureTourOverlay])
 

--- a/src/renderer/src/components/contextual-tours/ContextualTourOverlay.visibility.test.tsx
+++ b/src/renderer/src/components/contextual-tours/ContextualTourOverlay.visibility.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ContextualTourOverlay } from './ContextualTourOverlay'
+import { useAppStore } from '@/store'
+
+let container: HTMLDivElement
+let root: Root
+
+function tourTarget(name: string, top: number): { moveTo: (top: number) => void } {
+  let currentTop = top
+  const element = document.createElement('div')
+  element.setAttribute('data-contextual-tour-target', name)
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      left: 100,
+      right: 220,
+      top: currentTop,
+      bottom: currentTop + 40,
+      width: 120,
+      height: 40,
+      x: 100,
+      y: currentTop
+    })
+  })
+  document.body.appendChild(element)
+  return {
+    moveTo: (next) => {
+      currentTop = next
+    }
+  }
+}
+
+async function settle(ms: number): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms))
+  })
+}
+
+async function setDocumentVisibility(state: 'visible' | 'hidden'): Promise<void> {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => state })
+  await act(async () => {
+    document.dispatchEvent(new Event('visibilitychange'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+function ringsTop(): string | undefined {
+  return container.querySelector<HTMLElement>('[data-contextual-tour-target-rings]')?.style.top
+}
+
+beforeEach(async () => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  ;(window as unknown as { api: unknown }).api = { ui: { set: () => Promise.resolve() } }
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 })
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 960 })
+  await setDocumentVisibility('visible')
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  act(() => root.unmount())
+  container.remove()
+  document.querySelectorAll('[data-contextual-tour-target]').forEach((node) => node.remove())
+  await setDocumentVisibility('visible')
+  useAppStore.setState({ activeContextualTourId: null, activeContextualTourStepIndex: 0 })
+})
+
+describe('ContextualTourOverlay full-pass interval visibility gate', () => {
+  it('pauses the 500ms full pass while hidden and re-measures on return', async () => {
+    const target = tourTarget('workspace-create-control', 300)
+    useAppStore.setState({
+      activeContextualTourId: 'workspace-agent-sessions',
+      activeContextualTourStepIndex: 1,
+      activeModal: 'none',
+      contextualToursOnboardingVisible: false,
+      contextualToursBlockingSurfaceVisible: false,
+      activeContextualTourSuppressed: false
+    })
+    await act(async () => {
+      root.render(<ContextualTourOverlay />)
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+    expect(ringsTop()).toBe('300px')
+
+    // Baseline: while visible, the periodic full pass follows a silent move.
+    target.moveTo(640)
+    await settle(700)
+    expect(ringsTop()).toBe('640px')
+
+    await setDocumentVisibility('hidden')
+    target.moveTo(900)
+    await settle(1_500)
+    expect(ringsTop()).toBe('640px')
+
+    // Returning runs the pass immediately, so the overlay is never left stale.
+    await setDocumentVisibility('visible')
+    await settle(50)
+    expect(ringsTop()).toBe('900px')
+  })
+})

--- a/src/renderer/src/components/feature-wall/WorkspacesAnimatedVisual.tsx
+++ b/src/renderer/src/components/feature-wall/WorkspacesAnimatedVisual.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { JSX } from 'react'
 import { AgentStateDot } from '@/components/AgentStateDot'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import { ClaudeIcon, OpenCodeGoIcon } from '../status-bar/icons'
 
 type AgentKind = 'claude' | 'codex' | 'opencode'
@@ -87,18 +88,23 @@ export function WorkspacesAnimatedVisual(props: { reducedMotion: boolean }): JSX
     if (reducedMotion) {
       return
     }
-    const id = window.setInterval(() => {
-      setVisualState((current) => {
-        const next = current.order.slice()
-        const finishing = next.pop()
-        if (!finishing) {
-          return current
-        }
-        next.unshift(finishing)
-        return { order: next, promotedWorkspaceId: finishing.id }
-      })
-    }, STEP_MS)
-    return () => window.clearInterval(id)
+    // Why: nobody watches an animation in a hidden window. `runOnVisible` is a
+    // no-op so revealing the window resumes the cycle instead of skipping a card.
+    return installWindowVisibilityInterval({
+      run: () => {
+        setVisualState((current) => {
+          const next = current.order.slice()
+          const finishing = next.pop()
+          if (!finishing) {
+            return current
+          }
+          next.unshift(finishing)
+          return { order: next, promotedWorkspaceId: finishing.id }
+        })
+      },
+      runOnVisible: () => {},
+      intervalMs: STEP_MS
+    })
   }, [reducedMotion])
   // Why: reduced-motion mode should display the static stack without a
   // post-render repair; only the animated interval needs promoted z-order.

--- a/src/renderer/src/components/feature-wall/agents-orchestration/StatusesPage.tsx
+++ b/src/renderer/src/components/feature-wall/agents-orchestration/StatusesPage.tsx
@@ -5,6 +5,7 @@ import { Wrench } from 'lucide-react'
 import { AgentStateDot } from '@/components/AgentStateDot'
 import { getAgentCatalog, AgentIcon, type AgentCatalogEntry } from '@/lib/agent-catalog'
 import { ClaudeIcon, OpenAIIcon } from '../../status-bar/icons'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 
@@ -48,18 +49,25 @@ export function StatusesPage(props: { active: boolean; reducedMotion: boolean })
     schedule(() => setRevealed((r) => ({ ...r, codex: true })), 1900)
 
     let idx = 0
-    const cycleId = window.setInterval(() => {
-      setClaudeFading(true)
-      const swap = window.setTimeout(() => {
-        idx = (idx + 1) % CLAUDE_ACTIVITIES.length
-        setClaudeIdx(idx)
-        setClaudeFading(false)
-      }, 280)
-      timeouts.push(swap)
-    }, 2400)
+    // Why: nobody watches an animation in a hidden window. `runOnVisible` is a
+    // no-op so revealing the window resumes the cycle instead of skipping an
+    // activity; `idx` lives outside the timer, so the reveal picks up where it left off.
+    const stopCycle = installWindowVisibilityInterval({
+      run: () => {
+        setClaudeFading(true)
+        const swap = window.setTimeout(() => {
+          idx = (idx + 1) % CLAUDE_ACTIVITIES.length
+          setClaudeIdx(idx)
+          setClaudeFading(false)
+        }, 280)
+        timeouts.push(swap)
+      },
+      runOnVisible: () => {},
+      intervalMs: 2400
+    })
     return () => {
       timeouts.forEach((id) => window.clearTimeout(id))
-      window.clearInterval(cycleId)
+      stopCycle()
     }
   }, [active, reducedMotion])
 

--- a/src/renderer/src/components/feature-wall/feature-wall-animation-visibility.test.tsx
+++ b/src/renderer/src/components/feature-wall/feature-wall-animation-visibility.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { StatusesPage } from './agents-orchestration/StatusesPage'
+import { useWorkbenchTerminalStoryboard } from './use-workbench-terminal-storyboard'
+import { WorkspacesAnimatedVisual } from './WorkspacesAnimatedVisual'
+
+let container: HTMLDivElement
+let root: Root
+
+function setDocumentVisibility(state: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => state })
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'))
+  })
+}
+
+function cardOrder(): string[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[data-ws-id]'))
+    .map((node) => ({
+      id: node.dataset.wsId ?? '',
+      top: Number.parseFloat(node.style.transform.replace(/[^\d.-]/g, '')) || 0
+    }))
+    .sort((left, right) => left.top - right.top)
+    .map((card) => card.id)
+}
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  vi.useFakeTimers()
+  setDocumentVisibility('visible')
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  setDocumentVisibility('visible')
+  vi.useRealTimers()
+})
+
+describe('feature wall animation timers', () => {
+  it('pauses the workspaces card rotation while hidden and resumes without skipping', () => {
+    act(() =>
+      root.render(
+        <TooltipProvider>
+          <WorkspacesAnimatedVisual reducedMotion={false} />
+        </TooltipProvider>
+      )
+    )
+    const initialOrder = cardOrder()
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => vi.advanceTimersByTime(3_600))
+    const afterOneStep = cardOrder()
+    expect(afterOneStep).not.toEqual(initialOrder)
+
+    setDocumentVisibility('hidden')
+    expect(vi.getTimerCount()).toBe(0)
+    act(() => vi.advanceTimersByTime(3_600 * 10))
+    expect(cardOrder()).toEqual(afterOneStep)
+
+    // Revealing resumes the cycle rather than jumping a card forward.
+    setDocumentVisibility('visible')
+    expect(cardOrder()).toEqual(afterOneStep)
+    expect(vi.getTimerCount()).toBe(1)
+    act(() => vi.advanceTimersByTime(3_600))
+    expect(cardOrder()).not.toEqual(afterOneStep)
+  })
+
+  it('pauses the workbench run queue while hidden and resumes from the same entry', () => {
+    const view = renderHook(() => useWorkbenchTerminalStoryboard('tour', false))
+    const first = view.result.current.running
+    act(() => vi.advanceTimersByTime(2_400))
+    const second = view.result.current.running
+    expect(second).not.toBe(first)
+
+    setDocumentVisibility('hidden')
+    act(() => vi.advanceTimersByTime(2_400 * 10))
+    expect(view.result.current.running).toBe(second)
+
+    setDocumentVisibility('visible')
+    expect(view.result.current.running).toBe(second)
+    act(() => vi.advanceTimersByTime(2_400))
+    expect(view.result.current.running).not.toBe(second)
+    view.unmount()
+  })
+
+  it('pauses the agent-status activity cycle while hidden and resumes in place', () => {
+    act(() =>
+      root.render(
+        <TooltipProvider>
+          <StatusesPage active reducedMotion={false} />
+        </TooltipProvider>
+      )
+    )
+    act(() => vi.advanceTimersByTime(2_400 + 280))
+    const afterOneCycle = container.textContent ?? ''
+
+    setDocumentVisibility('hidden')
+    act(() => vi.advanceTimersByTime((2_400 + 280) * 10))
+    expect(container.textContent).toBe(afterOneCycle)
+
+    setDocumentVisibility('visible')
+    expect(container.textContent).toBe(afterOneCycle)
+    act(() => vi.advanceTimersByTime(2_400 + 280))
+    expect(container.textContent).not.toBe(afterOneCycle)
+  })
+})

--- a/src/renderer/src/components/feature-wall/use-workbench-terminal-storyboard.ts
+++ b/src/renderer/src/components/feature-wall/use-workbench-terminal-storyboard.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import {
   WORKBENCH_RUN_QUEUE,
   WORKBENCH_RUN_TICK_MS,
@@ -38,10 +39,13 @@ export function useWorkbenchTerminalStoryboard(
     if (reducedMotion || isTwoAgentsChecklist) {
       return
     }
-    const id = window.setInterval(() => {
-      setRunIdx((index) => (index + 1) % WORKBENCH_RUN_QUEUE.length)
-    }, WORKBENCH_RUN_TICK_MS)
-    return () => window.clearInterval(id)
+    // Why: nobody watches an animation in a hidden window. `runOnVisible` is a
+    // no-op so revealing the window resumes the queue instead of skipping an entry.
+    return installWindowVisibilityInterval({
+      run: () => setRunIdx((index) => (index + 1) % WORKBENCH_RUN_QUEUE.length),
+      runOnVisible: () => {},
+      intervalMs: WORKBENCH_RUN_TICK_MS
+    })
   }, [isTwoAgentsChecklist, reducedMotion])
 
   useEffect(() => {

--- a/src/renderer/src/components/landing-preflight-runtime-boundary.test.ts
+++ b/src/renderer/src/components/landing-preflight-runtime-boundary.test.ts
@@ -15,6 +15,11 @@ const status = (overrides: Partial<PreflightStatus> = {}): PreflightStatus => ({
   ...overrides
 })
 
+function setDocumentVisibility(state: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => state })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
 const githubRepo: Repo = {
   id: 'github',
   path: '/repos/github',
@@ -27,6 +32,7 @@ const githubRepo: Repo = {
 
 beforeEach(() => {
   vi.useFakeTimers()
+  setDocumentVisibility('visible')
   refresh.mockClear()
   invalidate.mockClear()
   useAppStore.setState(useAppStore.getInitialState(), true)
@@ -35,6 +41,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  setDocumentVisibility('visible')
   vi.useRealTimers()
   useAppStore.setState(useAppStore.getInitialState(), true)
 })
@@ -105,6 +112,29 @@ describe('landing preflight runtime boundary', () => {
 
     expect(invalidate).toHaveBeenCalledTimes(1)
     expect(refresh).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
+  it('stops the 30s preflight poll while hidden and lets the reveal refresh instead', () => {
+    useAppStore.setState({ repos: [githubRepo], preflightStatus: status() })
+    const view = renderHook(() => useLandingPreflightRuntime())
+    refresh.mockClear()
+
+    expect(vi.getTimerCount()).toBe(1)
+    act(() => setDocumentVisibility('hidden'))
+    expect(vi.getTimerCount()).toBe(0)
+
+    // Five poll windows pass behind a hidden window with no IPC at all.
+    act(() => vi.advanceTimersByTime(150_000))
+    expect(refresh).not.toHaveBeenCalled()
+
+    // The sibling visibilitychange handler force-refreshes on reveal, so the
+    // banner is current the moment it can be seen; the poll re-arms behind it.
+    act(() => setDocumentVisibility('visible'))
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(refresh).toHaveBeenCalledWith({ force: true })
+    expect(vi.getTimerCount()).toBe(1)
+
     view.unmount()
   })
 

--- a/src/renderer/src/components/landing-preflight-runtime.ts
+++ b/src/renderer/src/components/landing-preflight-runtime.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import { useAppStore } from '../store'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import {
   getLandingPreflightIssues,
   hasGitHubBackedProject,
@@ -60,10 +61,16 @@ export function useLandingPreflightRuntime(): { preflightIssues: PreflightIssue[
     if (preflightIssues.length === 0) {
       return
     }
-    const intervalId = window.setInterval(() => {
-      void refreshPreflightStatus({ force: true })
-    }, 30000)
-    return () => window.clearInterval(intervalId)
+    // Why gated: the effect above already force-refreshes on visibilitychange
+    // and focus, so a revealed window has fresh data without this poll firing
+    // while hidden — hence the no-op `runOnVisible`.
+    return installWindowVisibilityInterval({
+      run: () => {
+        void refreshPreflightStatus({ force: true })
+      },
+      runOnVisible: () => {},
+      intervalMs: 30000
+    })
   }, [preflightIssues.length, refreshPreflightStatus])
 
   return { preflightIssues }

--- a/src/renderer/src/components/native-chat/NativeChatWorkingStatus.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatWorkingStatus.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { ChevronRight } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
+import { useNow } from '@/hooks/use-now'
 
 export function NativeChatWorkingStatus({
   startedAt,
@@ -15,18 +16,17 @@ export function NativeChatWorkingStatus({
   expanded?: boolean
   onToggleExpanded?: () => void
 }): React.JSX.Element {
-  const [elapsedSeconds, setElapsedSeconds] = useState(0)
-
-  useEffect(() => {
-    if (thinking || workedSeconds != null) {
-      return
-    }
-    const epoch = startedAt ?? Date.now()
-    setElapsedSeconds(Math.max(0, Math.floor((Date.now() - epoch) / 1000)))
-    const update = () => setElapsedSeconds(Math.max(0, Math.floor((Date.now() - epoch) / 1000)))
-    const timer = window.setInterval(update, 1000)
-    return () => window.clearInterval(timer)
-  }, [startedAt, thinking, workedSeconds])
+  // Why: elapsed seconds is ordinary render dataflow, not an external system.
+  // The shared 1s clock is visibility-gated and collapses every in-flight turn
+  // onto one tick, instead of one interval plus one commit per turn.
+  const counting = !thinking && workedSeconds == null
+  const now = useNow(1_000, counting)
+  // Why: preserves the old effect's `startedAt ?? Date.now()` epoch for the
+  // single frame before the turn's startedAt lands.
+  const [mountedAt] = useState(() => Date.now())
+  const elapsedSeconds = counting
+    ? Math.max(0, Math.floor((now - (startedAt ?? mountedAt)) / 1000))
+    : 0
 
   const label =
     workedSeconds != null

--- a/src/renderer/src/components/native-chat/native-chat-working-status-shared-clock.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-working-status-shared-clock.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NativeChatWorkingStatus } from './NativeChatWorkingStatus'
+
+let container: HTMLDivElement
+let root: Root
+
+function setDocumentVisibility(state: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => state })
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'))
+  })
+}
+
+function renderTurns(count: number, startedAt: number): void {
+  act(() => {
+    root.render(
+      <>
+        {Array.from({ length: count }, (_, index) => (
+          <NativeChatWorkingStatus key={index} startedAt={startedAt} thinking={false} />
+        ))}
+      </>
+    )
+  })
+}
+
+function elapsedLabels(): string[] {
+  return Array.from(container.querySelectorAll('[aria-label]'), (node) => node.textContent ?? '')
+}
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  vi.useFakeTimers()
+  vi.setSystemTime(1_000_000)
+  setDocumentVisibility('visible')
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  setDocumentVisibility('visible')
+  vi.useRealTimers()
+})
+
+describe('native chat working status elapsed clock', () => {
+  it('collapses every in-flight turn onto one shared visibility-gated timer', () => {
+    renderTurns(3, 1_000_000)
+
+    // One shared 1s clock for all three turns, not one interval per turn.
+    expect(vi.getTimerCount()).toBe(1)
+    act(() => vi.advanceTimersByTime(3_000))
+    expect(elapsedLabels()).toEqual([
+      'Working for 3 seconds',
+      'Working for 3 seconds',
+      'Working for 3 seconds'
+    ])
+  })
+
+  it('stops ticking while hidden and re-syncs the elapsed value on return', () => {
+    renderTurns(1, 1_000_000)
+    act(() => vi.advanceTimersByTime(3_000))
+    expect(elapsedLabels()).toEqual(['Working for 3 seconds'])
+
+    setDocumentVisibility('hidden')
+    expect(vi.getTimerCount()).toBe(0)
+
+    // A minute of hidden wall-clock: no callbacks, no commits, label frozen.
+    act(() => vi.advanceTimersByTime(60_000))
+    expect(elapsedLabels()).toEqual(['Working for 3 seconds'])
+
+    // Returning re-derives elapsed from startedAt, so nothing was lost.
+    setDocumentVisibility('visible')
+    expect(elapsedLabels()).toEqual(['Working for 63 seconds'])
+    expect(vi.getTimerCount()).toBe(1)
+  })
+
+  it('holds no timer for a thinking turn or a completed turn', () => {
+    act(() => {
+      root.render(
+        <>
+          <NativeChatWorkingStatus startedAt={1_000_000} thinking />
+          <NativeChatWorkingStatus startedAt={1_000_000} thinking={false} workedSeconds={12} />
+        </>
+      )
+    })
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​451 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​450 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​48 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 |

<!-- /orca-pr-loc -->

## ELI5

Orca launches Chromium with `IntensiveWakeUpThrottling` disabled, so the platform does **not** slow background timers down. A `setInterval(fn, 250)` in the renderer really does fire four times a second forever — even when the window is hidden behind another app.

Six renderer timers were doing exactly that with nobody able to see the result:

- A chat turn's "Working for N seconds" counter ticked once a second **per in-flight turn**, each tick a `setState` and a full React commit, just to bump a number on a screen that wasn't on screen.
- A browser tab stuck loading polled its guest 4x/sec forever, to write an error into state for a surface nobody could look at.
- An active product tour woke up twice a second to re-measure where its highlight ring should go.
- Three onboarding animations kept animating.
- The landing screen kept firing IPC preflight refreshes every 30s.

This PR pauses all six while the window is hidden and resumes them on return, using the primitive the repo already has for this (`installWindowVisibilityInterval`, already behind 14 call sites) plus the already-shared `useNow` clock.

## Measurements

Deterministic harness (temporary, not committed): fake timers, `document.hidden` toggled via `visibilitychange`, `globalThis.setInterval` wrapped to count callback invocations, React commits counted with a `<Profiler>`. Timers advanced in 100 ms slices inside separate `act()` calls so React commits once per tick rather than batching a whole window into one commit. Window = **60 simulated seconds** (300 s for the 30 s preflight poll), same harness run against `main` and against this branch.

| Scenario | Visible before | Visible after | **Hidden before** | **Hidden after** |
|---|---|---|---|---|
| Native chat, 3 in-flight turns, intervals staggered 333 ms apart | 180 ticks / 180 commits | **60 / 60** | 180 / 180 | **0 / 0** |
| Native chat, 3 turns mounted together (React coalesces) | 180 / 60 | **60 / 60** | 180 / 60 | **0 / 0** |
| Browser tab stuck loading (250 ms chromium-error poll) | 240 / 0 | 240 / 0 | 240 / 0 | **0 / 0** |
| Contextual tour active (500 ms full pass) | 120 / 0 | 120 / 0 | 120 / 0 | **0 / 0** |
| Feature wall: workspaces + storyboard + statuses (3600/2400/2400 ms) | 67 / 58 | 67 / 58 | 66 / 58 | **0 / 1** |
| Landing preflight with issues, 300 s window (30 s poll) | 10 / 0 | 10 / 0 | 10 / 0 | **0 / 0** |

Notes on the numbers:

- **Aggregate wakeups/sec removed while hidden**, if all these surfaces are live at once: `3.0 (3 chat turns) + 4.0 (browser) + 2.0 (tour) + 1.1 (feature wall) + 0.03 (preflight) = 10.1 wakeups/sec`, plus **238 React commits/minute → 1**. Per-surface: 3.0/s scales linearly with concurrent chat turns; 4.0/s per stuck-loading active browser tab.
- **Visible-window win (chat only)**: three concurrent turns went from 3 interval callbacks/sec to 1, and in the realistic staggered case from 180 to 60 React commits/minute. The commit *content* is identical — same label, same DOM.
- The `feature-wall-hidden after` column shows `1` commit: the in-flight 280 ms cross-fade timeout that was already scheduled when the window hid still lands, so the text is not left stuck mid-fade. It does not repeat.
- The contextual-tour row shows `0 commits` both before and after, because the rect never changed in the harness. That is the honest framing of that item: in a real hidden Electron window the queued `requestAnimationFrame` does not run either, so the *rect pass* was already mostly not happening — what this removes is the 2 wakeups/sec themselves, not a DOM read.

## Negative user-facing trade-offs, item by item

**1. `NativeChatWorkingStatus` — none.**
The counter is now `Math.floor((now - startedAt) / 1000)` derived during render from the shared 1s clock. `startedAt` is durable state owned by `useNativeChatTurnStatus`, so on reveal the label jumps straight to the true elapsed time. A user could theoretically notice the counter frozen at the pre-hide value — but only by watching a window they cannot see. Regression test asserts a 60 s hidden gap produces `Working for 63 seconds` immediately on return, not `3`. The one behavioural nuance: `useNow` re-derives from a shared snapshot, so with the window visible the three turns now update on the *same* second boundary instead of on three staggered ones. Same value, just no longer skewed by mount time.

**2. Chromium-error fallback poll — none.**
The poll's only job is to notice the guest sitting on a `chrome-error://` URL. That URL is durable guest state, not an event, so it cannot be "missed" — `installWindowVisibilityInterval` runs the detector immediately on becoming visible and re-derives it. Test: the guest transitions to a chrome-error page *while hidden*, no `onUpdatePageState` fires, and the correct `loadError` (with the right `validatedUrl`) is written the instant the window returns. Real trade-off, stated plainly: the `loadError` write is delayed until reveal. Since the only consumer is the load-failure overlay in that tab's chrome, there is no window in which a user sees a wrong state.

**3. Contextual tour overlay — none.**
The 500 ms pass exists to catch a step target appearing, vanishing, or moving without a scroll/resize event. On reveal the pass runs immediately, and the `useLayoutEffect` re-measures on every render anyway. The measure pass can also call `advanceContextualTour()`/`cancelContextualTour()` — those are *deferred*, not lost, and they fire before the first painted frame after reveal, so the user never sees the stale step. Test: target moves twice while hidden, ring is still at the old position during the hidden window, and snaps to the new one on return.

**4. Feature-wall animations (3 timers) — none.**
Purely decorative. `runOnVisible` is an explicit no-op so revealing the window *resumes* the cycle rather than immediately advancing it — without that, a user tabbing back would see a card jump. `idx` in `StatusesPage` lives outside the timer closure, so the activity list picks up where it left off rather than restarting at entry 0. All three tests assert: pause while hidden, no jump on reveal, normal advance one period later.

**5. Landing preflight 30 s poll — none, provably.**
The sibling effect ~15 lines above already calls `refreshPreflightStatus({ force: true })` on both `visibilitychange` and `focus`. So a revealed window gets *fresher* data than the poll would have given it (immediately, vs. up to 30 s later). Test asserts 150 s of hidden time produces zero IPC calls and that reveal produces exactly one forced refresh with the poll re-armed behind it.

## Explicitly out of scope

Left alone on purpose, because gating them would trade a real signal for ~0.2 wakeups/sec or break a feature:

- `agent-completion-process-monitor.ts` — gating the process-exit completion lane on window visibility would break desktop notifications for agents that finish while Orca is backgrounded. That is a product decision, not a mechanical gate.
- `plugin-panel-watchdog.ts`, `remote-runtime-socket-liveness.ts` — liveness watchdogs.
- The 60 s singletons (`agent-hibernation-coordinator`, `use-app-session-persistence`, `crash-diagnostics`) and the 15 s `terminal-delivery-watchdog` — two of these exist specifically to survive a hard kill, so pausing them defeats their purpose.

## Verification

- `pnpm tc` — clean
- `npx oxlint <12 changed files>` — clean; `node config/scripts/check-changed-code-quality.mjs` — 0 new findings (incl. React Doctor)
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/{native-chat,browser-pane/navigate,contextual-tours,feature-wall}/ src/renderer/src/components/landing-preflight-runtime-boundary.test.ts src/renderer/src/hooks/use-now.test.ts` — **133 files / 1205 tests passed**
- Every new assertion was confirmed to **fail on `main`**: 8 failures across the 5 test files (`expected 1 to be +0` for each timer that kept running, `expected 3 to be 1` for the per-turn intervals, `expected '900px' to be '640px'` for the tour re-measuring while hidden).

## Corrections to the original brief

Three details in the audit that this PR verified against the real code and found slightly off — none change the conclusion:

1. **`NativeChatWorkingStatus:27` is not "gated on nothing".** The effect early-returns on `if (thinking || workedSeconds != null)`, so it only ran for an actively-working turn that had already produced a response. The perf claim still holds — that is precisely the state a long agent turn sits in for minutes — but it did not tick for "thinking" or completed turns. The new code preserves that gate exactly via `useNow(1_000, counting)`.
2. **`useDocumentVisible` at `PetOverlay.tsx:216` is at line 218 and is a file-local, non-exported helper.** Rather than export it, every gated timer here uses `installWindowVisibilityInterval`, which is strictly better for this job: it pauses/resumes the interval without re-running the React effect or forcing a re-render on each visibility flip. No new primitive, no extraction.
3. **The contextual-tour item is a wakeup fix, not a rect-pass fix.** A hidden window paints no frames, so the `requestAnimationFrame` the 500 ms tick queues never runs, and every subsequent tick early-returns on `frame !== null`. The DOM rect pass was therefore already not happening while hidden. What this removes is the 2 wakeups/sec. Measured and reported as such above.


## Unrelated CI flake fixed in passing (second commit)

The first CI run failed on `test / tests node 24 3/8` with:

```
FAIL src/main/git/worktree-base-divergence-real-git.test.ts > measureRetargetDivergence with real Git > counts drift in both directions
AssertionError: expected 'within' to be 'exceeded'
```

**This is not caused by this PR.** That file is byte-identical to `main` (`git diff --name-only main...HEAD` does not list it), it is a main-process real-Git test, and it imports only `node:child_process`, `node:fs/promises`, `node:os`, `node:path` and `./worktree-base-divergence` — nothing this PR touches, no renderer code, no timers, no `document`.

**Root cause.** The fixture builds 100 empty commits, resets to the fork point, then adds one more, expecting `100 ahead + 1 behind = 101 > 100` to read `exceeded`. But `commitEmpty` restarts its message counter at `0` on every call, and an empty commit's hash covers only parent, tree, message and a **one-second-granularity** timestamp. When the whole build finishes inside a single wall-clock second, the post-reset `commit 0` — same fork-point parent, same tree, same message, same second — hashes identically to the *first* `commit 0` of the chain, so Git returns that existing object instead of a new one. The branch ends up 99 ahead / 0 behind, which is `within`. The CI log shows the case took **1059 ms** and its sibling built 101 commits in 714 ms (~7 ms/commit), so the loop lands inside one second whenever it does not straddle a second boundary — hence intermittent.

**Proof, not a re-roll.** Pinning `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` forces the timestamp collision the fast runner hits by chance:

- unmodified file + pinned dates → fails with the **exact** CI assertion, same line 69, `expected 'within' to be 'exceeded'`
- with the fix + pinned dates → 5/5 pass

Standalone shell repro also confirms the object identity directly: `first_of_chain == final commit`, `ahead=99 behind=0`.

**Fix.** Number the empty commits across calls so the fixture builds the 101 *distinct* commits it already claimed to. No assertion was weakened — the assertion was always right; the fixture just wasn't producing the history it described.

Re-verified after the fix: `pnpm tc` clean, `oxlint`/`oxfmt` clean, `check-changed-code-quality.mjs` 0 new findings across 13 files, `src/main/git/` suite 126 files / 1310 tests passed.


## Verified against `orca-cli` browser automation

The one item with an automation-facing question was the chromium-error fallback poll, since `orca-cli` drives the browser embedded in Orca and often runs against a window nobody is looking at. Verified two ways:

**1. The gate does not engage for background-launched automation at all.** `ORCA_BACKGROUND_LAUNCH=1` reveals the window through `showWindowWithoutStealingFocus`, which calls `showInactive()` (`src/main/window/foreground-activation-policy.ts`). An unfocused-but-shown window reports `document.visibilityState === "visible"`, confirmed by reading it out of a live background-launched dev instance. The poll has to be reached through an actually hidden window — minimized, occluded, or app-hidden.

**2. Even with the window genuinely hidden, no `orca-cli` command changes behaviour.** The gated poll writes only into the renderer's zustand store via `updateBrowserPageState`; there is no IPC path back to the main process. Every `orca-cli` browser command reads main-process state or the guest directly:

- `tab list` / `tab current` / `tab show` → `AgentBrowserBridge.tabList`, whose `loadError` comes from `browserManager.getBrowserPageLoadError()` (`src/main/browser/agent-browser-bridge-tabs.ts`), populated by the main-process `did-fail-load` handler in `browser-manager-guest-navigation-policy.ts`. Client-hosted pages report `loadError: null` unconditionally.
- `goto` → the same main-process `getBrowserPageLoadError` (`agent-browser-bridge-core-commands.ts`).
- `wait` / `snapshot` / `screenshot` / `eval` / input commands → CDP against the guest `WebContents`, which never reads renderer React state.

A/B probe on this branch and on `main`, window minimized via `window.api.ui.minimize()` with `document.visibilityState` confirmed `"hidden"`: `goto` to a good URL, `tab list`, `wait --url`, `snapshot`, `goto` to an unresolvable host, `tab list` again, and `eval location.href` produced identical results on both branches, including the `ERR_NAME_NOT_RESOLVED (-105)` error and the `loadError.description` in `tab list`.

So the delayed `loadError` write is confined to the in-app failure overlay, as stated above — it is not on any automation-visible surface.
