### PR TITLE
perf(platform): resolve the immutable platform payload once instead of ~19x/sec

### DIFF
--- a/src/preload/api/platform-bridge.test.ts
+++ b/src/preload/api/platform-bridge.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { platformApi } from './platform-bridge'
+
+const mocks = vi.hoisted(() => ({ getLinuxDisplayServer: vi.fn(() => null) }))
+
+vi.mock('../preload-runtime-support', () => ({
+  getLinuxDisplayServer: mocks.getLinuxDisplayServer
+}))
+
+// Electron declares getSystemVersion as required on NodeJS.Process; Node does not have it.
+const mutableProcess = process as unknown as { getSystemVersion?: () => string }
+
+async function loadPlatformApi(): Promise<typeof platformApi> {
+  vi.resetModules()
+  return (await import('./platform-bridge')).platformApi
+}
+
+describe('platformApi.get', () => {
+  beforeEach(() => {
+    mocks.getLinuxDisplayServer.mockClear()
+  })
+
+  afterEach(() => {
+    delete mutableProcess.getSystemVersion
+  })
+
+  it('resolves the immutable payload once and returns the identical object', async () => {
+    const platformApi = await loadPlatformApi()
+    const getSystemVersion = vi.fn(() => '25.3.0')
+    mutableProcess.getSystemVersion = getSystemVersion
+
+    const first = platformApi.get()
+    for (let index = 0; index < 100; index += 1) {
+      expect(platformApi.get()).toBe(first)
+    }
+
+    expect(getSystemVersion).toHaveBeenCalledTimes(1)
+    expect(mocks.getLinuxDisplayServer).toHaveBeenCalledTimes(1)
+    expect(first.platform).toBe(process.platform)
+    expect(first.arch).toBe(process.arch)
+    expect(first.osRelease).toBe('25.3.0')
+  })
+
+  it('freezes the payload so no consumer can corrupt the shared instance', async () => {
+    const platformApi = await loadPlatformApi()
+
+    expect(Object.isFrozen(platformApi.get())).toBe(true)
+  })
+
+  it('resolves nothing before the first get, keeping preload startup free', async () => {
+    await loadPlatformApi()
+
+    expect(mocks.getLinuxDisplayServer).not.toHaveBeenCalled()
+  })
+})

--- a/src/preload/api/platform-bridge.ts
+++ b/src/preload/api/platform-bridge.ts
@@ -1,8 +1,14 @@
 import { getLinuxDisplayServer } from '../preload-runtime-support'
 import type { PreloadApi } from '../api-types'
 
-export const platformApi = {
-  get: () => ({
+type PlatformInfo = ReturnType<PreloadApi['platform']['get']>
+
+// Why: the renderer reads this on its render cadence, and every field below is fixed
+// for the process lifetime, so resolve once and hand back the same frozen payload.
+let platformInfo: PlatformInfo | undefined
+
+function resolvePlatformInfo(): PlatformInfo {
+  return Object.freeze({
     platform: process.platform,
     // Why: sandboxed preload cannot require node:os; Electron exposes the OS
     // version on process.getSystemVersion when available.
@@ -14,4 +20,9 @@ export const platformApi = {
     shell: process.env.SHELL?.trim() || process.env.ComSpec?.trim() || '',
     displayServer: getLinuxDisplayServer()
   })
+}
+
+export const platformApi = {
+  // Why: resolved lazily so preload startup keeps paying nothing for it.
+  get: () => (platformInfo ??= resolvePlatformInfo())
 } satisfies PreloadApi['platform']

--- a/src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx
@@ -11,6 +11,7 @@ import {
   RIGHT_SIDEBAR_WINDOWS_TOP_ACTIVITY_STRIP_CLASS_NAME
 } from './right-sidebar-titlebar-drag-regions'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
+import { resetRendererAppPlatformCacheForTests } from '@/lib/renderer-app-platform'
 
 const mockAppState = vi.hoisted(() => ({
   rightSidebarOpen: true,
@@ -198,6 +199,7 @@ function expectNoDrag(tag: string): void {
 }
 
 function setRendererPlatform(platform: NodeJS.Platform): void {
+  resetRendererAppPlatformCacheForTests()
   Object.defineProperty(window, 'api', {
     configurable: true,
     value: {

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { I18nextProvider } from 'react-i18next'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { i18n } from '@/i18n/i18n'
+import { resetRendererAppPlatformCacheForTests } from '@/lib/renderer-app-platform'
 import { getDefaultSettings } from '../../../../shared/constants'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
@@ -216,6 +217,7 @@ describe('AppearancePane', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    resetRendererAppPlatformCacheForTests()
     mocks.state.availableStatusBarToggles = []
     mocks.state.appPlatform = 'linux'
     mocks.state.settingsSearchQuery = 'automations'

--- a/src/renderer/src/lib/renderer-app-platform.test.ts
+++ b/src/renderer/src/lib/renderer-app-platform.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getRendererAppPlatform,
+  resetRendererAppPlatformCacheForTests
+} from './renderer-app-platform'
+
+function stubPlatformApi(get: () => { platform: NodeJS.Platform }): void {
+  ;(window as unknown as { api: unknown }).api = { platform: { get } }
+}
+
+describe('getRendererAppPlatform', () => {
+  beforeEach(() => {
+    resetRendererAppPlatformCacheForTests()
+  })
+
+  afterEach(() => {
+    delete (window as unknown as { api?: unknown }).api
+    resetRendererAppPlatformCacheForTests()
+  })
+
+  it('crosses the preload bridge once no matter how many renders ask', () => {
+    const get = vi.fn(() => ({ platform: 'darwin' as NodeJS.Platform }))
+    stubPlatformApi(get)
+
+    for (let index = 0; index < 500; index += 1) {
+      expect(getRendererAppPlatform()).toBe('darwin')
+    }
+
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['darwin', 'win32', 'linux'] as const)(
+    'reports the preload platform verbatim on %s',
+    (platform) => {
+      stubPlatformApi(() => ({ platform }))
+
+      expect(getRendererAppPlatform()).toBe(platform)
+    }
+  )
+
+  // Why: the web client injects its platform API after boot, so an early caller must
+  // not pin the user-agent guess for the rest of the session.
+  it('does not cache the user-agent fallback', () => {
+    // 'freebsd' is never a user-agent fallback answer, so the swap is unambiguous.
+    expect(getRendererAppPlatform()).not.toBe('freebsd')
+
+    stubPlatformApi(() => ({ platform: 'freebsd' }))
+
+    expect(getRendererAppPlatform()).toBe('freebsd')
+  })
+})

--- a/src/renderer/src/lib/renderer-app-platform.ts
+++ b/src/renderer/src/lib/renderer-app-platform.ts
@@ -1,7 +1,16 @@
+// Why: hot render paths call this per render; the preload answer never changes, so
+// cache it. The user-agent fallback stays uncached because window.api can still be
+// installing (the web client injects its own platform API after boot).
+let cachedAppPlatform: NodeJS.Platform | undefined
+
 export function getRendererAppPlatform(): NodeJS.Platform {
+  if (cachedAppPlatform) {
+    return cachedAppPlatform
+  }
   const preloadPlatform =
     typeof window === 'undefined' ? undefined : window.api?.platform?.get?.()?.platform
   if (preloadPlatform) {
+    cachedAppPlatform = preloadPlatform
     return preloadPlatform
   }
   const userAgent = typeof navigator === 'undefined' ? '' : navigator.userAgent
@@ -15,4 +24,9 @@ export function getRendererAppPlatform(): NodeJS.Platform {
     return 'linux'
   }
   return 'win32'
+}
+
+/** Tests swap the window.api platform stub between cases; the real value never changes. */
+export function resetRendererAppPlatformCacheForTests(): void {
+  cachedAppPlatform = undefined
 }

--- a/src/renderer/src/store/slices/preflight.test.ts
+++ b/src/renderer/src/store/slices/preflight.test.ts
@@ -6,6 +6,7 @@ import type { Worktree } from '../../../../shared/worktree/types'
 import type { AppState } from '../types'
 import { createPreflightSlice } from './preflight'
 import { createRuntimeStatusSlice } from './runtime-status'
+import { resetRendererAppPlatformCacheForTests } from '@/lib/renderer-app-platform'
 
 const preflightCheck = vi.fn()
 const callRuntimeRpc = vi.fn()
@@ -62,6 +63,7 @@ function resetPreflightMocks(): void {
   preflightCheck.mockReset()
   callRuntimeRpc.mockReset()
   platformGet.mockReset().mockReturnValue({ platform: 'linux' })
+  resetRendererAppPlatformCacheForTests()
 }
 
 function makeStatus(glabInstalled: boolean): PreflightStatus {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |

<!-- /orca-pr-loc -->

## ELI5

Every time any part of the UI wanted to know "are we on a Mac?", the app asked the operating system all over again — what platform is this, what OS version, what CPU, what shell, what Linux display server — and packed the answers into a brand-new box. Then it handed that box across the wall between the sandboxed preload and the UI, which means Chromium has to build a fresh wrapper for it every single time.

None of those answers can ever change while the app is running. You don't switch from macOS to Windows mid-session.

So now the app asks once, puts the answers in a box, locks the box, and hands out the same box forever. And the UI keeps its own sticky note with the platform on it, so most of the time it doesn't even have to walk over to the wall.

## What changed

- `src/preload/api/platform-bridge.ts` — `platformApi.get()` resolves the payload lazily on first call, then returns the same frozen object for the rest of the process. Every field is fixed for the process lifetime: `process.platform`, `process.getSystemVersion()`, `process.arch`, `process.env.SHELL` / `ComSpec`, and `getLinuxDisplayServer()` (which reads `WAYLAND_DISPLAY` / `XDG_SESSION_TYPE` / `ELECTRON_OZONE_PLATFORM_HINT` / `DISPLAY` — all fixed at process spawn).
- `src/renderer/src/lib/renderer-app-platform.ts` — `getRendererAppPlatform()` caches the preload answer, so its 20 call sites stop crossing the context bridge on every render.

### Corrections to the original report

Two details in the problem description were slightly off, and a third thing I assumed turned out to be the most important fact in the whole PR:

1. **It is 20 call expressions, not 32.** `rg getRendererAppPlatform src/` returns 33 lines, but that counts the definition, the imports and the test mocks. There are **20 actual call expressions** in non-test renderer source, and **7 of those are default parameter values** (`local-preflight-context.ts` x5, `typing-latency/diagnostic-summary.ts`, `status-bar-runtime-targets.ts`) that only evaluate when the caller omits the argument. Separately, there are **9 direct `window.api.platform.get()` call sites** that bypass `getRendererAppPlatform` entirely (`terminal-pane-manager-options.ts`, `dashboard-client-host.ts`, `file-explorer-row-file-transfer.ts`, `useActiveProjectSkillRuntime.ts`, `useMacTccAttributionSeveredNotice.ts`, `client-login-shell.ts`, `terminal-webgl-auto-policy.ts`, `CliSkillRuntimeSetup.tsx`, `client-environment-info.ts`). Those get the preload half of the win but not the renderer memo.

2. **`RightSidebarInner` has 7 `useAppStore` subscriptions in its own body**, plus more inside `useRightSidebarActivityItems` and `useRightSidebarTabRouting`. Otherwise exactly as described: `getRendererAppPlatform()` is called unguarded in the render body (`src/renderer/src/components/right-sidebar/index.tsx:33-36`), and `AppearancePane.tsx:85-86` does call it twice in one render.

3. **`contextBridge` does *not* cache proxies across calls.** I assumed returning the same source object would let Electron hand back the same renderer-side proxy. It does not — I measured `window.api.platform.get() === window.api.platform.get()` as `false` even with a memoized, frozen source object. That means the preload memo alone only removes the *recompute*, not the bridge marshalling. **The renderer-side memo is doing the heavy lifting here** (1.7x vs 300x below). If you only take one half of this PR, take the renderer half.

## Measurements

### Real Electron, real context bridge

A minimal Electron 43 app (`sandbox: true`, `contextIsolation: true`) exposing verbatim copies of the pre- and post-change `platformApi.get` bodies, called from a renderer. 200,000 calls per case, 20,000 warmup calls, two independent runs:

| case | run 1 | run 2 |
|---|---|---|
| before: recompute + bridge crossing | **1295 ns/call** | **1254 ns/call** |
| preload memo only, still crossing the bridge | 736 ns/call | 785 ns/call |
| after: renderer memo (no bridge crossing) | **4 ns/call** | **4 ns/call** |

- Preload memo alone: **1.6–1.8x**, saving ~470–560 ns per call.
- Preload + renderer memo: **~300x**, saving ~1250–1290 ns per call.
- `contextBridge` proxy identity across calls with an identical frozen source object: `false` (this is why the renderer memo matters).

### Preload payload computation in isolation (Node, `getSystemVersion` stubbed to a constant-returning function)

Node has no `process.getSystemVersion`, so it is stubbed with a plain JS function. Real Electron pays a native binding call there, so this is a **lower bound** on the saving. 5,000,000 calls:

```
old (recompute)   5000000 calls  total 717.22 ms  per-call 143.4 ns
new (memoized)    5000000 calls  total  25.38 ms  per-call   5.1 ns
speedup 28.3x  saved 138.4 ns/call
```

Second run: 149.7 ns → 5.2 ns, 29.0x.

### Allocation churn (Node, `PerformanceObserver` on `gc`)

1,000,000 calls:

```
old (recompute)   gc events 39  gc time 2.20 ms
new (memoized)    gc events  0  gc time 0.00 ms
```

39 minor collections per million payloads, down to zero.

### Invocation counts (from the new regression tests)

- `src/preload/api/platform-bridge.test.ts` — 101 `platformApi.get()` calls produce **1** `getSystemVersion()` call and **1** `getLinuxDisplayServer()` call (was 101 and 101), and all 101 return the identical object.
- `src/renderer/src/lib/renderer-app-platform.test.ts` — 500 `getRendererAppPlatform()` calls produce **1** `window.api.platform.get()` bridge crossing (was 500).

### Regression tests fail without the fix

Reverting only the two source files (test resets stubbed out) and re-running:

```
FAIL platform-bridge.test.ts > resolves the immutable payload once and returns the identical object
FAIL platform-bridge.test.ts > freezes the payload so no consumer can corrupt the shared instance
     AssertionError: expected false to be true
FAIL renderer-app-platform.test.ts > crosses the preload bridge once no matter how many renders ask
     AssertionError: expected "vi.fn()" to be called 1 times, but got 500 times
```

## Safety audit

**Does anything need a fresh object?** No. I checked all 9 direct `platform.get()` consumers plus the 20 `getRendererAppPlatform` sites — every one reads a field (`.platform`, `.osRelease`, `.arch`, `.shell`, `.displayServer`) or spreads. Nothing mutates the returned object. The freeze is safe. No test mutates it either; the tests that touch this substitute their *own* stub object, which is untouched by this change.

**Can any field legitimately change at runtime?** No.
- `process.platform` / `process.arch` — compile-time constants.
- `process.getSystemVersion()` — the OS version of the running kernel; changing it requires a reboot, which ends the process.
- `process.env.SHELL` / `ComSpec` — inherited at spawn. Nothing in the codebase writes them in the preload context.
- `getLinuxDisplayServer()` — reads `WAYLAND_DISPLAY`, `XDG_SESSION_TYPE`, `ELECTRON_OZONE_PLATFORM_HINT`, `DISPLAY`, all inherited at spawn. Ozone's platform choice is fixed before the first window exists, so it cannot flip after preload loads. Nothing needed to be excluded from the memo.

**Is the renderer memo safe?** The user-agent fallback branch is deliberately **not** cached. The web client installs its platform API via `createWebPlatformApi()` after boot (`src/renderer/src/web/web-preload-api.ts:67`), and `getBrowserPlatform()` and the UA fallback disagree for unusual user agents (the fallback returns `linux` for a non-Windows/non-Mac UA and `win32` for an empty one; `getBrowserPlatform` returns `darwin` by default). Caching a pre-boot guess could have pinned the wrong platform for the session. Only a real preload answer is cached, so there is no staleness window. There is a test for exactly this.

**Cross-platform:** the resolution logic is byte-for-byte unchanged — same expressions, same order, same fallbacks. Only *when* they run changed. Windows, Linux and macOS all get the identical value they got before.

**Test churn:** three existing test files swap `window.api.platform` between cases in the same file (`AppearancePane.test.tsx`, `right-sidebar-titlebar-drag-regions.render.test.tsx`, `preflight.test.ts`). They now call the exported `resetRendererAppPlatformCacheForTests()` where they change the stub. I found these by running the whole thing, not by guessing.

## Negative user-facing trade-offs

**None.** Point by point:

- **No behavior change.** Every field is computed by the exact same expression as before and can never change during the process lifetime, so every consumer sees the same value it saw before. Full `src/renderer` + `src/preload` suite: **3417 files, 28563 tests, 0 failures**.
- **No staleness window.** There is nothing to go stale — the inputs are fixed at process spawn. The one input that could theoretically arrive late (the web client's injected platform API) is explicitly excluded from the cache.
- **No added memory.** This *reduces* memory: one frozen 5-field object for the process lifetime replaces one fresh object per call (~19/sec idle), and one `NodeJS.Platform` string reference in the renderer. Measured 39 minor GCs per million calls down to 0.
- **No deferral.** Nothing was moved off the critical path or made async. `get()` is still fully synchronous and still returns on the same call. Resolution is *lazy*, so preload startup pays strictly less than before (previously zero at load, still zero at load; the first caller pays what every caller used to pay).
- **No new surface.** One added export, `resetRendererAppPlatformCacheForTests()`, which is inert in production — it only clears a cache that gets refilled on the next call with the identical value.
