### PR TITLE
perf(renderer): stop three always-mounted selectors rescanning the store on every write

### DIFF
--- a/src/renderer/src/components/settings/repository-runtime-session-summary.ts
+++ b/src/renderer/src/components/settings/repository-runtime-session-summary.ts
@@ -1,5 +1,6 @@
 import type { AppState } from '../../store/types'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree/id'
+import { getTabIdToWorktreeId } from '../sidebar/worktree-agent-row-selectors'
 
 export type ProjectRuntimeSessionSummary = {
   liveTerminalCount: number
@@ -11,16 +12,26 @@ type RuntimeSessionSummaryState = Pick<
   'tabsByWorktree' | 'ptyIdsByTabId' | 'agentStatusByPaneKey'
 >
 
+type SessionSummaryCache = {
+  ptyIdsByTabId: AppState['ptyIdsByTabId']
+  agentStatusByPaneKey: AppState['agentStatusByPaneKey']
+  byRepoId: Map<string, ProjectRuntimeSessionSummary>
+}
+
+// Why: one RepositoryPane per project reruns this on every store write, and each
+// run walked every worktree bucket plus every agent-status pane. Key on the three
+// input slices so unrelated writes reuse the answer instead of rescanning.
+const sessionSummaryCache = new WeakMap<AppState['tabsByWorktree'], SessionSummaryCache>()
+
 function getTabIdFromPaneKey(paneKey: string): string | null {
   const separator = paneKey.indexOf(':')
   return separator > 0 ? paneKey.slice(0, separator) : null
 }
 
-export function getProjectRuntimeSessionSummary(
+function computeProjectRuntimeSessionSummary(
   state: RuntimeSessionSummaryState,
   repoId: string
 ): ProjectRuntimeSessionSummary {
-  const tabWorktreeIds = new Map<string, string>()
   const projectWorktreeIds = new Set<string>()
   let liveTerminalCount = 0
 
@@ -31,7 +42,6 @@ export function getProjectRuntimeSessionSummary(
     projectWorktreeIds.add(worktreeId)
 
     for (const tab of tabs) {
-      tabWorktreeIds.set(tab.id, worktreeId)
       const livePtyIds = new Set(state.ptyIdsByTabId[tab.id] ?? [])
       if (tab.ptyId) {
         livePtyIds.add(tab.ptyId)
@@ -40,6 +50,9 @@ export function getProjectRuntimeSessionSummary(
     }
   }
 
+  // Rows outside this project resolve to a worktree the checks below reject, so
+  // the shared index answers the same question the repo-scoped map used to.
+  const tabWorktreeIds = getTabIdToWorktreeId(state.tabsByWorktree)
   let activeTaskCount = 0
   for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey)) {
     if (entry.state === 'done') {
@@ -56,4 +69,30 @@ export function getProjectRuntimeSessionSummary(
   }
 
   return { liveTerminalCount, activeTaskCount }
+}
+
+export function getProjectRuntimeSessionSummary(
+  state: RuntimeSessionSummaryState,
+  repoId: string
+): ProjectRuntimeSessionSummary {
+  let cache = sessionSummaryCache.get(state.tabsByWorktree)
+  if (
+    !cache ||
+    cache.ptyIdsByTabId !== state.ptyIdsByTabId ||
+    cache.agentStatusByPaneKey !== state.agentStatusByPaneKey
+  ) {
+    cache = {
+      ptyIdsByTabId: state.ptyIdsByTabId,
+      agentStatusByPaneKey: state.agentStatusByPaneKey,
+      byRepoId: new Map()
+    }
+    sessionSummaryCache.set(state.tabsByWorktree, cache)
+  }
+  const cached = cache.byRepoId.get(repoId)
+  if (cached) {
+    return cached
+  }
+  const summary = computeProjectRuntimeSessionSummary(state, repoId)
+  cache.byRepoId.set(repoId, summary)
+  return summary
 }

--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
@@ -68,7 +68,10 @@ export function reuseArrayIfEqual<T>(previous: T[] | undefined, next: T[]): T[] 
   return previous
 }
 
-function getTabIdToWorktreeId(
+// Why exported: the Settings -> Repositories runtime summary needs the same
+// tab -> worktree index, and rebuilding it there would re-walk every tab bucket
+// on each store write.
+export function getTabIdToWorktreeId(
   tabsByWorktree: WorktreeAgentRowsState['tabsByWorktree']
 ): Map<string, string> {
   if (tabWorktreeIndexCache?.tabsByWorktree === tabsByWorktree) {

--- a/src/renderer/src/lib/local-preflight-context.ts
+++ b/src/renderer/src/lib/local-preflight-context.ts
@@ -9,6 +9,7 @@ import {
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
 import type { Repo } from '../../../shared/repo-types'
 import type { Worktree } from '../../../shared/worktree/types'
+import { getIndexedRepoMap, getIndexedWorktreeById } from '@/store/worktree-repo-index'
 import { getProviderRuntimeContextKey } from './provider-runtime-context'
 import { getRendererAppPlatform } from './renderer-app-platform'
 import {
@@ -35,6 +36,11 @@ type LocalProjectRuntimeState = Pick<
   AppState,
   'activeRepoId' | 'activeWorktreeId' | 'projects' | 'repos' | 'settings' | 'worktreesByRepo'
 >
+
+// Why: the shared indexes are WeakMap-keyed on slice identity, so a fresh `{}`
+// or `[]` fallback would miss the cache on every read.
+const EMPTY_WORKTREES_BY_REPO: AppState['worktreesByRepo'] = {}
+const EMPTY_REPOS: AppState['repos'] = []
 
 type LocalProjectRuntimeWslContext = {
   wslAvailable?: boolean
@@ -120,7 +126,7 @@ export function getLocalRepoProjectExecutionRuntimeContext(
     return undefined
   }
 
-  const repo = (state.repos ?? []).find((entry) => entry.id === repoId)
+  const repo = getIndexedRepoMap(state.repos ?? EMPTY_REPOS).get(repoId)
   if (!isLocalRuntimeRepo(repo)) {
     return undefined
   }
@@ -270,7 +276,7 @@ function getLocalRuntimeRepoForWorktree(
   worktree?: Pick<Worktree, 'repoId'> | null
 ): Pick<Repo, 'id' | 'path' | 'connectionId' | 'executionHostId'> | undefined {
   const repoId = worktree?.repoId ?? state.activeRepoId
-  return repoId ? (state.repos ?? []).find((repo) => repo.id === repoId) : undefined
+  return repoId ? getIndexedRepoMap(state.repos ?? EMPTY_REPOS).get(repoId) : undefined
 }
 
 function isLocalRuntimeRepo(
@@ -302,11 +308,13 @@ function getLocalWorktree(
   worktreeId?: string | null
 ): Pick<Worktree, 'id' | 'repoId' | 'projectId' | 'path' | 'hostId'> | null {
   const targetWorktreeId = worktreeId ?? state.activeWorktreeId
-  return targetWorktreeId
-    ? (Object.values(state.worktreesByRepo ?? {})
-        .flat()
-        .find((worktree) => worktree.id === targetWorktreeId) ?? null)
-    : null
+  if (!targetWorktreeId) {
+    return null
+  }
+  return (
+    getIndexedWorktreeById(state.worktreesByRepo ?? EMPTY_WORKTREES_BY_REPO, targetWorktreeId) ??
+    null
+  )
 }
 
 function getLocalPreflightProjectId(

--- a/src/renderer/src/store/always-mounted-selector-scan-cost.test.ts
+++ b/src/renderer/src/store/always-mounted-selector-scan-cost.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Zustand reruns every subscriber's selector on every store write, so an O(N)
+ * scan inside an always-mounted selector is paid thousands of times per second
+ * while the app is idle. These tests count property reads on the store rows to
+ * prove each selector builds its index once per snapshot instead of per read.
+ */
+import { describe, expect, it } from 'vitest'
+import type { Repo } from '../../../shared/repo-types'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import type { Worktree } from '../../../shared/worktree/types'
+import { WORKTREE_ID_SEPARATOR } from '../../../shared/worktree/id'
+import { getLocalPreflightContext } from '../lib/local-preflight-context'
+import { getProjectRuntimeSessionSummary } from '../components/settings/repository-runtime-session-summary'
+import type { AppState } from './types'
+import { selectRepoByIdForActiveWorkspace } from './selectors'
+
+// The user scale that motivated this: 10 repos, 423 worktrees, 382 open tabs.
+const REPO_COUNT = 10
+const WORKTREES_PER_REPO = 42
+const TABS_PER_WORKTREE = 1
+const STORE_WRITES = 200
+
+type ReadCounter = { count: number }
+
+function makeRepoRows(counter: ReadCounter): Repo[] {
+  return Array.from({ length: REPO_COUNT }, (_unused, index) => {
+    const id = `repo-${index}`
+    return {
+      get id() {
+        counter.count += 1
+        return id
+      },
+      path: `/tmp/repo-${index}`,
+      displayName: `repo-${index}`,
+      badgeColor: '#737373',
+      addedAt: 100,
+      kind: 'git'
+    } as Repo
+  })
+}
+
+function makeWorktreesByRepo(counter: ReadCounter): AppState['worktreesByRepo'] {
+  const worktreesByRepo: Record<string, Worktree[]> = {}
+  for (let repoIndex = 0; repoIndex < REPO_COUNT; repoIndex += 1) {
+    const repoId = `repo-${repoIndex}`
+    worktreesByRepo[repoId] = Array.from({ length: WORKTREES_PER_REPO }, (_unused, index) => {
+      const path = String.raw`\\wsl.localhost\Ubuntu\home\alice\wt-${repoIndex}-${index}`
+      const id = `${repoId}${WORKTREE_ID_SEPARATOR}${path}`
+      return {
+        get id() {
+          counter.count += 1
+          return id
+        },
+        repoId,
+        path
+      } as Worktree
+    })
+  }
+  return worktreesByRepo
+}
+
+/** The worst case for a first-wins linear scan: the last row of the last repo. */
+function lastWorktreeId(worktreesByRepo: AppState['worktreesByRepo']): string {
+  const lastBucket = Object.values(worktreesByRepo).at(-1) ?? []
+  return (lastBucket.at(-1) as Worktree).id
+}
+
+describe('local preflight context worktree lookup', () => {
+  it('builds the worktree index once instead of rescanning per store write', () => {
+    const worktreeReads: ReadCounter = { count: 0 }
+    const repoReads: ReadCounter = { count: 0 }
+    const worktreesByRepo = makeWorktreesByRepo(worktreeReads)
+    const activeWorktreeId = lastWorktreeId(worktreesByRepo)
+    const state = {
+      activeRepoId: `repo-${REPO_COUNT - 1}`,
+      activeWorktreeId,
+      repos: makeRepoRows(repoReads),
+      worktreesByRepo,
+      projects: []
+    } as unknown as AppState
+    const rowCount = REPO_COUNT * WORKTREES_PER_REPO
+    worktreeReads.count = 0
+    repoReads.count = 0
+
+    for (let write = 0; write < STORE_WRITES; write += 1) {
+      expect(getLocalPreflightContext(state, 'darwin')).toEqual({
+        wslDistro: 'Ubuntu'
+      })
+    }
+
+    // One index build per snapshot, not one scan per store write.
+    expect(worktreeReads.count).toBeLessThanOrEqual(rowCount)
+    expect(repoReads.count).toBeLessThanOrEqual(REPO_COUNT)
+  })
+
+  it('rebuilds against a replacement snapshot', () => {
+    const counter: ReadCounter = { count: 0 }
+    const worktreesByRepo = makeWorktreesByRepo(counter)
+    const repos = makeRepoRows({ count: 0 })
+    const activeWorktreeId = lastWorktreeId(worktreesByRepo)
+    const before = getLocalPreflightContext(
+      {
+        activeRepoId: 'repo-0',
+        activeWorktreeId,
+        repos,
+        worktreesByRepo
+      } as unknown as AppState,
+      'darwin'
+    )
+    expect(before).toEqual({ wslDistro: 'Ubuntu' })
+
+    const movedWorktree = {
+      id: activeWorktreeId,
+      repoId: `repo-${REPO_COUNT - 1}`,
+      path: String.raw`\\wsl.localhost\Debian\home\alice\moved`
+    } as Worktree
+    const after = getLocalPreflightContext(
+      {
+        activeRepoId: 'repo-0',
+        activeWorktreeId,
+        repos,
+        worktreesByRepo: { [`repo-${REPO_COUNT - 1}`]: [movedWorktree] }
+      } as unknown as AppState,
+      'darwin'
+    )
+
+    expect(after).toEqual({ wslDistro: 'Debian' })
+  })
+})
+
+describe('selectRepoByIdForActiveWorkspace', () => {
+  function makeActiveWorkspaceState(counter: ReadCounter): AppState {
+    return {
+      repos: makeRepoRows(counter),
+      activeRepoId: 'repo-0',
+      // No repo row carries this host, so the fallback branch runs every time.
+      activeWorkspaceExecutionHostId: 'ssh:host-a'
+    } as unknown as AppState
+  }
+
+  it('resolves the active-workspace host once per repos snapshot', () => {
+    const counter: ReadCounter = { count: 0 }
+    const state = makeActiveWorkspaceState(counter)
+    counter.count = 0
+
+    for (let write = 0; write < STORE_WRITES; write += 1) {
+      expect(selectRepoByIdForActiveWorkspace(state, 'repo-0')).toBeNull()
+    }
+
+    // Worst case: the id-keyed map build plus one host-filter pass.
+    expect(counter.count).toBeLessThanOrEqual(REPO_COUNT * 3)
+  })
+
+  it('still prefers the row that carries the active workspace host', () => {
+    const localRepo = {
+      id: 'repo-0',
+      path: '/tmp/a',
+      displayName: 'a'
+    } as Repo
+    const sshRepo = {
+      id: 'repo-0',
+      path: '/tmp/a',
+      displayName: 'a',
+      connectionId: 'host-a'
+    } as Repo
+    const state = {
+      repos: [localRepo, sshRepo],
+      activeRepoId: 'repo-0',
+      activeWorkspaceExecutionHostId: 'ssh:host-a'
+    } as unknown as AppState
+
+    expect(selectRepoByIdForActiveWorkspace(state, 'repo-0')).toBe(sshRepo)
+    expect(selectRepoByIdForActiveWorkspace(state, 'repo-0')).toBe(sshRepo)
+  })
+
+  it('returns an identical result for repeated reads of one snapshot', () => {
+    const state = makeActiveWorkspaceState({ count: 0 })
+    expect(selectRepoByIdForActiveWorkspace(state, 'repo-0')).toBe(
+      selectRepoByIdForActiveWorkspace(state, 'repo-0')
+    )
+    expect(selectRepoByIdForActiveWorkspace(state, 'repo-1')).toBe(
+      selectRepoByIdForActiveWorkspace(state, 'repo-1')
+    )
+  })
+})
+
+describe('project runtime session summary', () => {
+  function makeRuntimeSessionState(counter: ReadCounter): AppState {
+    const tabsByWorktree: Record<string, TerminalTab[]> = {}
+    for (let repoIndex = 0; repoIndex < REPO_COUNT; repoIndex += 1) {
+      for (let index = 0; index < WORKTREES_PER_REPO; index += 1) {
+        const worktreeId = `repo-${repoIndex}${WORKTREE_ID_SEPARATOR}/tmp/wt-${repoIndex}-${index}`
+        tabsByWorktree[worktreeId] = Array.from(
+          { length: TABS_PER_WORKTREE },
+          (_unused, tabIndex) => {
+            const id = `tab-${repoIndex}-${index}-${tabIndex}`
+            return {
+              get id() {
+                counter.count += 1
+                return id
+              },
+              ptyId: `pty-${id}`,
+              worktreeId
+            } as TerminalTab
+          }
+        )
+      }
+    }
+    return {
+      tabsByWorktree,
+      ptyIdsByTabId: {},
+      agentStatusByPaneKey: {}
+    } as unknown as AppState
+  }
+
+  it('reuses the tab index across repos and store writes', () => {
+    const counter: ReadCounter = { count: 0 }
+    const state = makeRuntimeSessionState(counter)
+    const tabCount = REPO_COUNT * WORKTREES_PER_REPO * TABS_PER_WORKTREE
+    counter.count = 0
+
+    // One RepositoryPane per project, all re-running on every store write.
+    for (let write = 0; write < STORE_WRITES; write += 1) {
+      for (let repoIndex = 0; repoIndex < REPO_COUNT; repoIndex += 1) {
+        expect(getProjectRuntimeSessionSummary(state, `repo-${repoIndex}`)).toEqual({
+          liveTerminalCount: WORKTREES_PER_REPO * TABS_PER_WORKTREE,
+          activeTaskCount: 0
+        })
+      }
+    }
+
+    // The shared tab index plus one pass over each repo's own tabs.
+    expect(counter.count).toBeLessThanOrEqual(tabCount * 3)
+  })
+
+  it('returns an identical summary for repeated reads of one snapshot', () => {
+    const state = makeRuntimeSessionState({ count: 0 })
+    expect(getProjectRuntimeSessionSummary(state, 'repo-0')).toBe(
+      getProjectRuntimeSessionSummary(state, 'repo-0')
+    )
+  })
+
+  it('recomputes when a tab slice is replaced', () => {
+    const state = makeRuntimeSessionState({ count: 0 })
+    const first = getProjectRuntimeSessionSummary(state, 'repo-0')
+    const worktreeId = `repo-0${WORKTREE_ID_SEPARATOR}/tmp/wt-0-0`
+    const next = getProjectRuntimeSessionSummary(
+      {
+        ...state,
+        tabsByWorktree: {
+          [worktreeId]: [{ id: 'tab-new', ptyId: 'pty-new', worktreeId } as TerminalTab]
+        }
+      } as unknown as AppState,
+      'repo-0'
+    )
+
+    expect(first.liveTerminalCount).toBe(WORKTREES_PER_REPO * TABS_PER_WORKTREE)
+    expect(next.liveTerminalCount).toBe(1)
+  })
+
+  it('counts running agents against the owning project only', () => {
+    const state = makeRuntimeSessionState({ count: 0 })
+    const summary = getProjectRuntimeSessionSummary(
+      {
+        ...state,
+        agentStatusByPaneKey: {
+          'tab-0-0-0:leaf': { state: 'working', tabId: 'tab-0-0-0' },
+          'tab-1-0-0:leaf': { state: 'working', tabId: 'tab-1-0-0' },
+          'tab-0-1-0:leaf': { state: 'done', tabId: 'tab-0-1-0' }
+        }
+      } as unknown as AppState,
+      'repo-0'
+    )
+
+    expect(summary.activeTaskCount).toBe(1)
+  })
+})

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -228,33 +228,65 @@ export const useActiveRepo = () =>
   useAppStore(useShallow((s) => selectRepoByIdForActiveWorkspace(s, s.activeRepoId)))
 export const useRepoMap = () => useAppStore((s) => getCachedRepoMap(s.repos))
 
+type ActiveWorkspaceRepoState = Pick<
+  AppState,
+  'repos' | 'activeRepoId' | 'activeWorkspaceExecutionHostId'
+>
+
+// Why: mirrors getIndexedRepoMap above — the host-scoped branch re-filtered every
+// repo on each store write even though its answer only moves when `repos` or the
+// active workspace host does.
+const activeWorkspaceRepoCache = new WeakMap<AppState['repos'], Map<string, Repo | null>>()
+
+function resolveRepoOnActiveWorkspaceHost(
+  state: ActiveWorkspaceRepoState,
+  repoId: string,
+  activeWorkspaceExecutionHostId: ExecutionHostId
+): Repo | null {
+  const repoCandidates = state.repos.filter((candidate) => candidate.id === repoId)
+  const hostMatch = repoCandidates.find(
+    (candidate) => getRepoExecutionHostId(candidate) === activeWorkspaceExecutionHostId
+  )
+  if (hostMatch) {
+    return hostMatch
+  }
+  // Why: withRepoHostOwnership keeps a paired-hub worktree on its own SSH host while the repo
+  // stays hub-owned, so that one mismatch still names the right repo; every other stays closed.
+  if (parseExecutionHostId(activeWorkspaceExecutionHostId)?.kind !== 'ssh') {
+    return null
+  }
+  const pairedHubRepos = repoCandidates.filter(
+    (candidate) => parseExecutionHostId(getRepoExecutionHostId(candidate))?.kind === 'runtime'
+  )
+  return pairedHubRepos.length === 1 ? pairedHubRepos[0] : null
+}
+
 export function selectRepoByIdForActiveWorkspace(
-  state: Pick<AppState, 'repos' | 'activeRepoId' | 'activeWorkspaceExecutionHostId'>,
+  state: ActiveWorkspaceRepoState,
   repoId: string | null
 ): Repo | null {
   if (!repoId) {
     return null
   }
   const repo = getCachedRepoMap(state.repos).get(repoId) ?? null
-  if (repoId === state.activeRepoId && state.activeWorkspaceExecutionHostId) {
-    const repoCandidates = state.repos.filter((candidate) => candidate.id === repoId)
-    const hostMatch = repoCandidates.find(
-      (candidate) => getRepoExecutionHostId(candidate) === state.activeWorkspaceExecutionHostId
-    )
-    if (hostMatch) {
-      return hostMatch
-    }
-    // Why: withRepoHostOwnership keeps a paired-hub worktree on its own SSH host while the repo
-    // stays hub-owned, so that one mismatch still names the right repo; every other stays closed.
-    if (parseExecutionHostId(state.activeWorkspaceExecutionHostId)?.kind !== 'ssh') {
-      return null
-    }
-    const pairedHubRepos = repoCandidates.filter(
-      (candidate) => parseExecutionHostId(getRepoExecutionHostId(candidate))?.kind === 'runtime'
-    )
-    return pairedHubRepos.length === 1 ? pairedHubRepos[0] : null
+  const activeWorkspaceExecutionHostId = state.activeWorkspaceExecutionHostId
+  if (repoId !== state.activeRepoId || !activeWorkspaceExecutionHostId) {
+    return repo
   }
-  return repo
+  // The branch below only fires for the active repo, so the host id fully keys it.
+  let byHost = activeWorkspaceRepoCache.get(state.repos)
+  if (!byHost) {
+    byHost = new Map()
+    activeWorkspaceRepoCache.set(state.repos, byHost)
+  }
+  const cacheKey = `${activeWorkspaceExecutionHostId}\u0000${repoId}`
+  const cached = byHost.get(cacheKey)
+  if (cached !== undefined) {
+    return cached
+  }
+  const resolved = resolveRepoOnActiveWorkspaceHost(state, repoId, activeWorkspaceExecutionHostId)
+  byHost.set(cacheKey, resolved)
+  return resolved
 }
 
 export const useRepoById = (repoId: string | null) =>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​277 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​277 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​112 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​30 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 |

<!-- /orca-pr-loc -->

## ELI5

Zustand calls **every** subscriber's selector function on **every** store write. So a selector that says "walk all 423 worktrees and find the one with this id" isn't doing that once — it's doing it thousands of times a second, while the app is idle, because some other unrelated part of the store ticked.

Three selectors were doing exactly that, recounting from scratch what never changed:

1. The **sidebar Tasks button** (always mounted, never unmounts for the whole session) resolved the active worktree by flattening every repo bucket and linear-scanning 423 rows, then linear-scanning the repo list.
2. **`useActiveRepo` / `useRepoById`** re-filtered the whole repo array to pick the row on the active workspace's execution host — and then threw the arrays away, because the answer was already identity-stable.
3. The **Settings -> Repositories** pane rebuilt a tab->worktree map from all 382 tabs, once per open project pane, on every write.

The fix is the pattern this repo already uses (`src/renderer/src/store/worktree-repo-index.ts`, and `connection-owner-resolution.ts:63-65` as the exemplar): build the lookup **once per store snapshot** and hang it off a `WeakMap` keyed on the slice object itself. A new snapshot object is a new key, so a rebuild happens exactly when the data actually changed, and the old index is collectable.

---

## What changed

| File | Change |
|---|---|
| `src/renderer/src/lib/local-preflight-context.ts` | `getLocalWorktree` -> `getIndexedWorktreeById`; `getLocalRuntimeRepoForWorktree` and `getLocalRepoProjectExecutionRuntimeContext` -> `getIndexedRepoMap(...).get(repoId)` |
| `src/renderer/src/store/selectors.ts` | `selectRepoByIdForActiveWorkspace` host-scoped branch extracted to `resolveRepoOnActiveWorkspaceHost` and memoized in a `WeakMap<repos, Map<key, Repo \| null>>`, mirroring `getIndexedRepoMap` directly above it |
| `src/renderer/src/components/settings/repository-runtime-session-summary.ts` | memoized per `(tabsByWorktree, ptyIdsByTabId, agentStatusByPaneKey, repoId)`; the duplicated tab->worktree map build replaced with the already-identity-cached `getTabIdToWorktreeId` |
| `src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts` | export `getTabIdToWorktreeId` (no logic change) |
| `src/renderer/src/store/always-mounted-selector-scan-cost.test.ts` | new regression tests |

Note: two `EMPTY_WORKTREES_BY_REPO` / `EMPTY_REPOS` constants were needed in `local-preflight-context.ts`, because the pre-existing `?? {}` / `?? []` defensive fallbacks would allocate a **fresh** object on each call and miss the WeakMap every single time.

### Corrections to the original report

- The claim that `getLocalWorktree` runs **twice** per `getLocalPreflightContext` call is only true on **Windows**. On macOS/Linux `getLocalProjectExecutionRuntimeContext` returns at its `appPlatform !== 'win32'` guard before touching the store, so it is **one** scan per call there — still one 423-row scan on every store write for the whole session.
- `RepositoryPane` -> `getProjectRuntimeSessionSummary` did **not** walk "193 worktrees x 382 tabs". The inner tab loop is guarded by `getRepoIdFromWorktreeId(worktreeId) !== repoId` -> `continue`, so per call it was ~382 bucket-key `Object.entries` allocations + `indexOf`/`slice` per key, plus only *that* repo's own tabs. Still expensive (measured below) because it repeats per open project pane, but the shape is O(buckets) + O(own tabs), not O(worktrees x tabs).

---

## Measurements

### (a) Microbenchmark at the real scale

10 repos / 423 worktrees / 382 tabs (382 tab buckets), 5,000 iterations per case, median of 3 runs, run under the project's vitest node environment on the same machine. "BEFORE" is a verbatim copy of the replaced code, benchmarked in the same process as the new code, so JIT state and allocator pressure are shared. The benchmark harness was temporary and is not committed.

| Selector (cost per store write) | Before | After | Delta |
|---|---:|---:|---|
| 1. `getLocalPreflightContext` (one `SidebarTaskNavButton` subscriber) | **6.61 us** | **0.49 us** | 13.5x faster |
| 2. `selectRepoByIdForActiveWorkspace` (one `useActiveRepo` subscriber) | **0.36 us** | **0.13 us** | 2.8x faster |
| 3. `getProjectRuntimeSessionSummary` x 10 open project panes | **456 us** | **0.40 us** | ~1140x faster |

Run-to-run spread across the 3 runs: case 1 `6.43-7.01 -> 0.486-0.493`, case 2 `0.354-0.394 -> 0.126-0.142`, case 3 `418-570 -> 0.385-0.407`.

Reading case 3 honestly: 456 us per store write is only paid while Settings -> Repositories is open with all 10 project panes rendered — but at that point it alone is ~46% of a 60fps frame budget spent on every single store write. Case 1's 6.6 us is paid **always**, for the entire session, and at the ~24,700 selector-evaluations/sec figure from the idle profile that is real, continuous, idle CPU.

### (b) Row-read counts from the regression tests

`src/renderer/src/store/always-mounted-selector-scan-cost.test.ts` builds 10 repos / 420 worktrees / 420 tabs where each row's `id` is a **getter that increments a counter**, then drives 200 simulated store writes and asserts the total number of `id` reads stays near the row count (one index build) rather than 200x it.

Confirmed failing on unmodified code (source reverted, test kept). Verbatim assertion output:

```
FAIL  src/renderer/src/store/always-mounted-selector-scan-cost.test.ts > local preflight context worktree lookup > builds the worktree index once instead of rescanning per store write
AssertionError: expected 84000 to be less than or equal to 420

FAIL  src/renderer/src/store/always-mounted-selector-scan-cost.test.ts > selectRepoByIdForActiveWorkspace > resolves the active-workspace host once per repos snapshot
AssertionError: expected 2010 to be less than or equal to 30

FAIL  src/renderer/src/store/always-mounted-selector-scan-cost.test.ts > project runtime session summary > reuses the tab index across repos and store writes
AssertionError: expected 168000 to be less than or equal to 1260

FAIL  src/renderer/src/store/always-mounted-selector-scan-cost.test.ts > project runtime session summary > returns an identical summary for repeated reads of one snapshot
AssertionError: expected { liveTerminalCount: 42, ...(1) } to be { liveTerminalCount: 42, ...(1) } // Object.is equality

Tests  4 failed | 5 passed (9)
```

| Test | Reads before | Reads after |
|---|---:|---:|
| worktree `id` reads, 200 writes, 420 worktrees | **84,000** | **420** (one index build) |
| repo `id` reads, 200 writes, 10 repos | **2,010** | **20** |
| tab `id` reads, 200 writes x 10 project panes, 420 tabs | **168,000** | **840** |

The file also carries the identity guard the audit asked for: each pure selector is called twice against the same state object and the result is asserted with `Object.is` (`toBe`). That guard is what the 4th failure above is — the old `getProjectRuntimeSessionSummary` returned a freshly allocated object literal on every single call, which is a wasted allocation per subscriber per store write even when nothing moved.

Alongside those, correctness tests cover: rebuilding against a replacement snapshot (a worktree whose path moves distro), still preferring the repo row that carries the active workspace host, recomputing when the tab slice is replaced, and counting running agents against the owning project only.

---

## Negative user-facing trade-offs

**None**, with one honest semantics delta called out under its own heading below.

Point by point:

- **No behavior change.** Every replaced lookup answers the same question with the same inputs. The one place the answer *can* differ is duplicate rows, documented below. The full `src/renderer/src/store` + `src/renderer/src/components/settings` suites pass (4,225 tests; the single failure was `agent-skill-installed-command-callers.test.ts` timing out at 30s under parallel load, and it passes in 10.6s run alone — it is a filesystem-scanning test unrelated to these files).
- **No staleness.** Every cache is keyed on the **object identity** of a store slice (`worktreesByRepo`, `repos`, `tabsByWorktree`, plus explicit identity checks on `ptyIdsByTabId` / `agentStatusByPaneKey`). Zustand replaces slice objects on write, so a changed slice is a new key and the index is rebuilt on the next read. There is no time-based invalidation and no manual invalidation to forget.
- **No added retained memory.** All three caches are `WeakMap`s keyed on the store slice, so an index dies with the snapshot that produced it. `selectRepoByIdForActiveWorkspace`'s inner `Map` is bounded by (active host id x active repo id) for one `repos` array — in practice one or two entries — and it is dropped wholesale when `repos` is replaced. `getProjectRuntimeSessionSummary`'s inner `Map` is bounded by repo count (10).
- **Nothing deferred.** No `setTimeout`, no `requestIdleCallback`, no debounce, no microtask. Every selector still returns a fully correct value synchronously on the same call. The only change is that it stops recomputing an answer it already has.
- **No new subscriptions or renders.** These are read-path changes only; no component's subscription set changes. If anything, `getProjectRuntimeSessionSummary` now returns a stable identity, so its `useShallow` comparison gets cheaper.
- **No SSH / remote-wire / folder-workspace impact.** Nothing here touches IPC, RPC params, stream frames, or anything a paired host publishes. `getIndexedWorktreeMap` is explicitly host-aware (see below); folder workspaces are unaffected because `worktreesByRepo` bucket contents are read the same way.

### Duplicate-row semantics delta (read this one)

Two lookups change their tie-break when a **duplicate id** is present. Both are strictly-speaking behavior changes and neither is silent:

**1. Worktrees — `.flat().find()` (raw-iteration, first-wins) -> `getIndexedWorktreeMap` (same-host duplicates collapse last-wins, then first-wins across hosts).**

Per the comments at `worktree-repo-index.ts:26-62` (STA-4343), the index keys on `(hostId, worktreeId)`: a same-host duplicate is *the same workspace listed twice* and collapses **last-wins**, because `fetchWorktrees` replaces while `createWorktree` appends, so the later row is the current one. Genuine two-host collisions (a `worktreeId` is `repoId::path` with no host component, so local and SSH can publish the same id for different workspaces) stay **first-wins**, matching the `.find()` being replaced.

`getLocalWorktree` reads `path`, `projectId`, `repoId` and `hostId`. So during the narrow `createWorktree`-appends-while-`fetchWorktrees`-replaces race, this now returns the **fresher** row rather than the stale one. In practice that means the WSL-distro preflight key is derived from the current path instead of a superseded one. I believe this is a fix, not a regression — but it is a change, and it should not ride in silently under a perf PR.

**2. Repos — `.find()` (first-wins) -> `getIndexedRepoMap` (`new Map(repos.map(...))`, last-wins).**

Duplicate repo ids across execution hosts are real in this codebase (see `delete-worktree-flow.ts:74`, `open-tab-search-entries.ts:79`, and `selectRepoByIdForActiveWorkspace` itself, all of which `filter` rather than `find` for exactly this reason). For a repo id present on two hosts, `getLocalRuntimeRepoForWorktree` now resolves to the **last** matching row instead of the first.

Both orderings were arbitrary — neither the old `.find()` nor the new map consults `hostId`, so neither was ever *correct* for a two-host collision; this is a bare-id lookup that structurally cannot resolve one. What this change buys is **consistency**: `connection-owner-resolution.ts:65`, `right-sidebar-visibility.ts` and `terminal-workspace-routing.ts` already resolve repos through `getIndexedRepoMap`, so the local-preflight path now agrees with them instead of quietly disagreeing. The correct long-term fix for a genuine collision is to take an explicit host (the `WorktreeRemovalTarget` pattern), which is out of scope here.

**3. Tab ids.** `getProjectRuntimeSessionSummary` now resolves `tabId -> worktreeId` through the global `getTabIdToWorktreeId` index rather than a repo-scoped map. Rows resolving to another project's worktree are still rejected by the unchanged `projectWorktreeIds.has(...) || getRepoIdFromWorktreeId(...) === repoId` check, so the count is identical. The only way to diverge would be the *same tab id appearing in two different worktree buckets*, which tab ids being globally unique rules out.

---

## Verification

- `pnpm tc` — clean (exit 0)
- `npx oxlint <changed files>` — clean
- `npx vitest run --config config/vitest.config.ts src/renderer/src/store src/renderer/src/components/settings` — 4,225 passed (1 unrelated load-induced timeout, passes in isolation)
- Regression tests confirmed **failing** on unmodified source before landing (assertion text quoted above)

## Related

Same class of fix as #18130, which moved `terminal-workspace-routing.ts` and `right-sidebar-visibility.ts` onto the same indexes. Those two files are deliberately untouched here.
