### PR TITLE
fix(source-control): fix Antigravity commit message generation args and prompt delivery

### DIFF
--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -401,11 +401,28 @@ describe('model discovery parsers', () => {
     ])
   })
 
-  it('parses Antigravity model output', () => {
+  it('parses Antigravity model output with tab-separated slug and display name', () => {
     const output = [
-      'Gemini 3.5 Flash (Medium)',
-      'Gemini 3.5 Flash (High)',
-      'Gemini 3.5 Flash (Low)',
+      'Fetching available models...',
+      'gemini-3.8-flash-medium\tGemini 3.8 Flash (Medium)',
+      'gemini-3.8-flash-high\tGemini 3.8 Flash (High)',
+      'gemini-3.8-flash-low\tGemini 3.8 Flash (Low)',
+      'claude-sonnet-4-6\tClaude Sonnet 4.6 (Thinking)'
+    ].join('\n')
+
+    expect(parseAntigravityModels(output)).toEqual([
+      { id: 'Gemini 3.8 Flash (Medium)', label: 'Gemini 3.8 Flash (Medium)' },
+      { id: 'Gemini 3.8 Flash (High)', label: 'Gemini 3.8 Flash (High)' },
+      { id: 'Gemini 3.8 Flash (Low)', label: 'Gemini 3.8 Flash (Low)' },
+      { id: 'Claude Sonnet 4.6 (Thinking)', label: 'Claude Sonnet 4.6 (Thinking)' }
+    ])
+  })
+
+  it('parses legacy Antigravity single-column model output', () => {
+    const output = [
+      'Gemini 3.8 Flash (Medium)',
+      'Gemini 3.8 Flash (High)',
+      'Gemini 3.8 Flash (Low)',
       'Gemini 3.1 Pro (Low)',
       'Gemini 3.1 Pro (High)',
       'Claude Sonnet 4.6 (Thinking)',
@@ -414,9 +431,9 @@ describe('model discovery parsers', () => {
     ].join('\n')
 
     expect(parseAntigravityModels(output)).toEqual([
-      { id: 'Gemini 3.5 Flash (Medium)', label: 'Gemini 3.5 Flash (Medium)' },
-      { id: 'Gemini 3.5 Flash (High)', label: 'Gemini 3.5 Flash (High)' },
-      { id: 'Gemini 3.5 Flash (Low)', label: 'Gemini 3.5 Flash (Low)' },
+      { id: 'Gemini 3.8 Flash (Medium)', label: 'Gemini 3.8 Flash (Medium)' },
+      { id: 'Gemini 3.8 Flash (High)', label: 'Gemini 3.8 Flash (High)' },
+      { id: 'Gemini 3.8 Flash (Low)', label: 'Gemini 3.8 Flash (Low)' },
       { id: 'Gemini 3.1 Pro (Low)', label: 'Gemini 3.1 Pro (Low)' },
       { id: 'Gemini 3.1 Pro (High)', label: 'Gemini 3.1 Pro (High)' },
       { id: 'Claude Sonnet 4.6 (Thinking)', label: 'Claude Sonnet 4.6 (Thinking)' },
@@ -574,8 +591,8 @@ describe('buildArgs (Antigravity)', () => {
   const spec = getCommitMessageAgentSpec('antigravity')!
 
   it('runs agy with --print, --sandbox, and --model flags', () => {
-    const args = spec.buildArgs({ prompt: 'PROMPT', model: 'Gemini 3.7 Flash (Medium)' })
-    expect(args).toEqual(['--print', 'PROMPT', '--sandbox', '--model', 'Gemini 3.7 Flash (Medium)'])
+    const args = spec.buildArgs({ prompt: 'PROMPT', model: 'Gemini 3.8 Flash (Medium)' })
+    expect(args).toEqual(['--print', 'PROMPT', '--sandbox', '--model', 'Gemini 3.8 Flash (Medium)'])
     expect(spec.promptDelivery).toBe('argv')
   })
 
@@ -585,7 +602,7 @@ describe('buildArgs (Antigravity)', () => {
     expect(spec.modelDiscovery?.args).toEqual(['models'])
   })
 
-  it('uses Gemini 3.7 Flash (Medium) as default model', () => {
-    expect(COMMIT_MESSAGE_AGENT_SPECS.antigravity?.defaultModelId).toBe('Gemini 3.7 Flash (Medium)')
+  it('uses Gemini 3.8 Flash (Medium) as default model', () => {
+    expect(COMMIT_MESSAGE_AGENT_SPECS.antigravity?.defaultModelId).toBe('Gemini 3.8 Flash (Medium)')
   })
 })

--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -574,9 +574,9 @@ describe('buildArgs (Antigravity)', () => {
   const spec = getCommitMessageAgentSpec('antigravity')!
 
   it('runs agy with --print, --sandbox, and --model flags', () => {
-    const args = spec.buildArgs({ prompt: '', model: 'Gemini 3.5 Flash (Medium)' })
-    expect(args).toEqual(['--print', '--sandbox', '--model', 'Gemini 3.5 Flash (Medium)'])
-    expect(spec.promptDelivery).toBe('stdin')
+    const args = spec.buildArgs({ prompt: 'PROMPT', model: 'Gemini 3.7 Flash (Medium)' })
+    expect(args).toEqual(['--print', 'PROMPT', '--sandbox', '--model', 'Gemini 3.7 Flash (Medium)'])
+    expect(spec.promptDelivery).toBe('argv')
   })
 
   it('uses dynamic model discovery via agy models', () => {
@@ -585,7 +585,7 @@ describe('buildArgs (Antigravity)', () => {
     expect(spec.modelDiscovery?.args).toEqual(['models'])
   })
 
-  it('uses Gemini 3.5 Flash (Medium) as default model', () => {
-    expect(COMMIT_MESSAGE_AGENT_SPECS.antigravity?.defaultModelId).toBe('Gemini 3.5 Flash (Medium)')
+  it('uses Gemini 3.7 Flash (Medium) as default model', () => {
+    expect(COMMIT_MESSAGE_AGENT_SPECS.antigravity?.defaultModelId).toBe('Gemini 3.7 Flash (Medium)')
   })
 })

--- a/src/shared/commit-message-agent-specs-secondary.ts
+++ b/src/shared/commit-message-agent-specs-secondary.ts
@@ -212,16 +212,26 @@ export function buildSecondaryCommitMessageAgentSpecs({
       id: 'antigravity',
       label: 'Antigravity',
       binary: 'agy',
-      promptDelivery: 'stdin',
-      buildArgs: ({ model }) => ['--print', '--sandbox', '--model', model],
+      // Why: agy expects prompt delivery via `--print <prompt>` on argv. Passing
+      // `--print` followed by other flags without a prompt argument causes agy to
+      // parse the next flag (e.g. `--sandbox`) as the prompt value.
+      promptDelivery: 'argv',
+      buildArgs: ({ prompt, model }) => [
+        '--print',
+        prompt,
+        '--sandbox',
+        '--model',
+        model
+      ],
+      singletonOptions: [['--model', '-m']],
       modelSource: 'dynamic',
       modelDiscovery: { binary: 'agy', args: ['models'], parse: parseAntigravityModels },
       models: [
-        { id: 'Gemini 3.5 Flash (Medium)', label: 'Gemini 3.5 Flash (Medium)' },
-        { id: 'Gemini 3.5 Flash (High)', label: 'Gemini 3.5 Flash (High)' },
-        { id: 'Gemini 3.5 Flash (Low)', label: 'Gemini 3.5 Flash (Low)' }
+        { id: 'Gemini 3.7 Flash (High)', label: 'Gemini 3.7 Flash (High)' },
+        { id: 'Gemini 3.7 Flash (Medium)', label: 'Gemini 3.7 Flash (Medium)' },
+        { id: 'Gemini 3.7 Flash (Low)', label: 'Gemini 3.7 Flash (Low)' }
       ],
-      defaultModelId: 'Gemini 3.5 Flash (Medium)'
+      defaultModelId: 'Gemini 3.7 Flash (Medium)'
     }
   }
 }

--- a/src/shared/commit-message-agent-specs-secondary.ts
+++ b/src/shared/commit-message-agent-specs-secondary.ts
@@ -227,11 +227,11 @@ export function buildSecondaryCommitMessageAgentSpecs({
       modelSource: 'dynamic',
       modelDiscovery: { binary: 'agy', args: ['models'], parse: parseAntigravityModels },
       models: [
-        { id: 'Gemini 3.7 Flash (High)', label: 'Gemini 3.7 Flash (High)' },
-        { id: 'Gemini 3.7 Flash (Medium)', label: 'Gemini 3.7 Flash (Medium)' },
-        { id: 'Gemini 3.7 Flash (Low)', label: 'Gemini 3.7 Flash (Low)' }
+        { id: 'Gemini 3.8 Flash (High)', label: 'Gemini 3.8 Flash (High)' },
+        { id: 'Gemini 3.8 Flash (Medium)', label: 'Gemini 3.8 Flash (Medium)' },
+        { id: 'Gemini 3.8 Flash (Low)', label: 'Gemini 3.8 Flash (Low)' }
       ],
-      defaultModelId: 'Gemini 3.7 Flash (Medium)'
+      defaultModelId: 'Gemini 3.8 Flash (Medium)'
     }
   }
 }

--- a/src/shared/commit-message-agent-specs-secondary.ts
+++ b/src/shared/commit-message-agent-specs-secondary.ts
@@ -12,6 +12,12 @@ type SecondaryAgentSpecDeps = {
   parseAntigravityModels: (stdout: string) => CommitMessageModel[]
 }
 
+/**
+ * Builds specs for secondary commit-message generation agents.
+ *
+ * @param deps - Shared thinking levels and parser functions.
+ * @returns Map of secondary agent IDs to their commit-message specifications.
+ */
 export function buildSecondaryCommitMessageAgentSpecs({
   BASIC_THINKING_LEVELS,
   OPENAI_THINKING_LEVELS,
@@ -212,9 +218,12 @@ export function buildSecondaryCommitMessageAgentSpecs({
       id: 'antigravity',
       label: 'Antigravity',
       binary: 'agy',
-      // Why: agy expects prompt delivery via `--print <prompt>` on argv. Passing
-      // `--print` followed by other flags without a prompt argument causes agy to
-      // parse the next flag (e.g. `--sandbox`) as the prompt value.
+      // Why: agy expects prompt delivery via `--print <prompt>` on argv. In text
+      // print mode, `--print` strictly requires an argument in the CLI flag parser
+      // and does not accept prompts via stdin (stdin is supported only for NDJSON
+      // streaming with `--input-format stream-json`). Passing `--print` without an
+      // argument caused agy to consume the subsequent `--sandbox` flag as its prompt
+      // and exit code 2. Prompt delivery on argv mirrors Cursor, Kimi, and Copilot.
       promptDelivery: 'argv',
       buildArgs: ({ prompt, model }) => [
         '--print',

--- a/src/shared/commit-message-model-parsers.ts
+++ b/src/shared/commit-message-model-parsers.ts
@@ -235,13 +235,21 @@ export function parseCursorModels(stdout: string): CommitMessageModel[] {
 export function parseAntigravityModels(stdout: string): CommitMessageModel[] {
   const models: CommitMessageModel[] = []
   for (const rawLine of iterateModelOutputLines(stdout)) {
-    const id = rawLine.trim()
-    if (id.length === 0) {
+    const trimmed = rawLine.trim()
+    if (trimmed.length === 0 || trimmed.toLowerCase().startsWith('fetching')) {
+      continue
+    }
+    const tabIndex = trimmed.indexOf('\t')
+    const modelName =
+      tabIndex === -1
+        ? trimmed
+        : trimmed.slice(tabIndex + 1).trim() || trimmed.slice(0, tabIndex).trim()
+    if (modelName.length === 0) {
       continue
     }
     models.push({
-      id,
-      label: id
+      id: modelName,
+      label: modelName
     })
   }
   return uniqueModels(models)

--- a/src/shared/commit-message-model-parsers.ts
+++ b/src/shared/commit-message-model-parsers.ts
@@ -232,6 +232,15 @@ export function parseCursorModels(stdout: string): CommitMessageModel[] {
   return uniqueModels(models)
 }
 
+/**
+ * Parses stdout output from `agy models`.
+ *
+ * Handles optional status headers (such as "Fetching available models..."), skips
+ * blank lines, and parses tab-separated `<slug>\t<Display Name>` or single-token lines.
+ *
+ * @param stdout - Output from the `agy models` CLI command.
+ * @returns Deduplicated list of models available for Antigravity.
+ */
 export function parseAntigravityModels(stdout: string): CommitMessageModel[] {
   const models: CommitMessageModel[] = []
   for (const rawLine of iterateModelOutputLines(stdout)) {

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -155,6 +155,32 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
+  it('plans Antigravity non-interactive generation with prompt on argv and sandbox mode', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'antigravity',
+        model: 'Gemini 3.7 Flash (High)'
+      },
+      'PROMPT'
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      plan: {
+        binary: 'agy',
+        args: [
+          '--print',
+          'PROMPT',
+          '--sandbox',
+          '--model',
+          'Gemini 3.7 Flash (High)'
+        ],
+        stdinPayload: null,
+        label: 'Antigravity'
+      }
+    })
+  })
+
   it('plans Codex exec as non-interactive read-only generation with the prompt on stdin only', () => {
     const result = planCommitMessageGeneration(
       {

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -159,7 +159,7 @@ describe('planCommitMessageGeneration', () => {
     const result = planCommitMessageGeneration(
       {
         agentId: 'antigravity',
-        model: 'Gemini 3.7 Flash (High)'
+        model: 'Gemini 3.8 Flash (High)'
       },
       'PROMPT'
     )
@@ -173,7 +173,7 @@ describe('planCommitMessageGeneration', () => {
           'PROMPT',
           '--sandbox',
           '--model',
-          'Gemini 3.7 Flash (High)'
+          'Gemini 3.8 Flash (High)'
         ],
         stdinPayload: null,
         label: 'Antigravity'


### PR DESCRIPTION
## ELI5

Fix Antigravity (`agy`) commit message generation so prompts are correctly passed on the command line, dynamic models from `agy models` are properly parsed, and the default fallback model is updated to Gemini 3.8 Flash.

## What Changed

- Changed Antigravity spec `promptDelivery` from `'stdin'` to `'argv'`.
- Updated `buildArgs` to pass `['--print', prompt, '--sandbox', '--model', model]`.
- Added `singletonOptions: [['--model', '-m']]` to avoid duplicate model flags when recipe or user args are provided.
- Updated `parseAntigravityModels` to parse tab-separated `<slug>\t<Display Name>` output and skip status/header lines such as `Fetching available models...`. Added TSDoc comments.
- Updated static fallback models to Gemini 3.8 Flash (`gemini-3.8-flash-medium` as default).
- Added and updated unit tests covering spec, model parser, and commit-message planning.

## Why

1. `agy`'s text print mode strictly expects the prompt via `--print <prompt>` on argv. The CLI's flag parser requires an explicit argument for `--print` and does not accept prompts via stdin in text mode (streaming stdin is only supported for NDJSON via `--input-format stream-json`). Passing `--print` without an inline prompt caused agy to consume the subsequent `--sandbox` flag as its prompt value and exit code 2.
2. `agy models` outputs `Fetching available models...` followed by tab-separated model entries (`<slug>\t<Display Name>`). The previous line parser did not handle headers or tab separation.
3. Fallback Gemini 3.5 models are deprecated and rejected by current Antigravity CLI releases.

## Linked Issue

Fixes #

## Visual Proof

N/A (Backend argument construction and CLI stdout parsing logic; no UI layout changes)

## Testing

- [x] I manually tested these changes locally (verified `agy` 1.1.x flag parsing, `--print <prompt>` behavior, and `agy models` output parsing)
- [x] Automated tests added/updated (`commit-message-agent-spec.test.ts`, `commit-message-plan.test.ts`)

## AI Disclosure

Developed with the assistance of an AI coding assistant.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Antigravity prompt delivery on argv mirrors existing secondary agents (Cursor, Kimi, Copilot) in `src/shared/commit-message-agent-specs-secondary.ts`.
- Text mode in `agy` requires `--print <prompt>` on argv because `agy`'s CLI flag parser requires a prompt argument and fails with exit code 2 if omitted.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
