### PR TITLE
perf(diff): stop redrawing the whole combined-diff file tree on every section load

### DIFF
--- a/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-render.test.tsx
+++ b/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-render.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment happy-dom
+
+import React, { act, useCallback, useMemo, useState, type ReactElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitBranchChangeEntry } from '../../../../../../shared/git-diff-compare-types'
+import type { CombinedDiffFileTreeRow as CombinedDiffFileTreeRowComponent } from './combined-diff-file-tree-row'
+
+const rowRenders = vi.hoisted(() => ({ count: 0 }))
+const mountedRows = vi.hoisted(() => ({ count: 0 }))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ combinedDiffFileTreeWidth: 420, setCombinedDiffFileTreeWidth: () => {} })
+}))
+
+vi.mock('./combined-diff-file-tree-row', async (importOriginal) => {
+  const actual = (await importOriginal()) as {
+    CombinedDiffFileTreeRow: typeof CombinedDiffFileTreeRowComponent
+  }
+  const react = await import('react')
+  const Row = actual.CombinedDiffFileTreeRow
+  // Why: memo with React's default shallow compare, so this counts exactly the render commits
+  // the real memo'd row would have performed.
+  const CountingRow = react.memo((props: React.ComponentProps<typeof Row>) => {
+    rowRenders.count += 1
+    react.useEffect(() => {
+      mountedRows.count += 1
+      return () => {
+        mountedRows.count -= 1
+      }
+    }, [])
+    return react.createElement(Row, props)
+  })
+  return { ...actual, CombinedDiffFileTreeRow: CountingRow }
+})
+
+const { CombinedDiffFileTree } = await import('./combined-diff-file-tree')
+const { createCombinedDiffSectionIndexMap } =
+  await import('../resolve-changes/combined-diff-section-identity')
+const { useCombinedDiffSectionIndexMap } =
+  await import('../resolve-changes/use-combined-diff-section-index-map')
+const { getCombinedDiffBranchEntriesInTreeOrder } = await import('./combined-diff-file-tree-filter')
+
+const EMPTY_VIEWED_KEYS: ReadonlySet<string> = new Set()
+
+class NoopResizeObserver implements ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  rowRenders.count = 0
+  mountedRows.count = 0
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  vi.stubGlobal('ResizeObserver', NoopResizeObserver)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+type TestSection = { key: string; loading: boolean }
+
+/** `fileCount` files spread over `directoryCount` directories, in the viewer's own tree order. */
+function buildEntries(fileCount: number, directoryCount: number): GitBranchChangeEntry[] {
+  const raw: GitBranchChangeEntry[] = Array.from({ length: fileCount }, (_, index) => ({
+    path: `src/dir${String(index % directoryCount).padStart(2, '0')}/file-${String(index).padStart(4, '0')}.ts`,
+    status: 'modified'
+  }))
+  return getCombinedDiffBranchEntriesInTreeOrder('commit', raw)
+}
+
+function buildSections(entries: readonly GitBranchChangeEntry[]): TestSection[] {
+  return entries.map((entry) => ({ key: `combined-commit:${entry.path}`, loading: true }))
+}
+
+let loadSectionAt: (index: number) => void = () => {}
+
+/**
+ * Mirrors how both PR viewers feed the tree: an on-demand section load replaces the sections
+ * array, and the navigate callback closes over the section index map.
+ */
+function TreeHarness({
+  entries,
+  initialSections,
+  stableSectionIndexMap
+}: {
+  entries: readonly GitBranchChangeEntry[]
+  initialSections: TestSection[]
+  stableSectionIndexMap: boolean
+}): ReactElement {
+  const [sections, setSections] = useState(initialSections)
+  loadSectionAt = (index) => {
+    setSections((prev) =>
+      prev.map((section, sectionIndex) =>
+        sectionIndex === index ? { ...section, loading: false } : section
+      )
+    )
+  }
+  const rebuiltMap = useMemo(() => createCombinedDiffSectionIndexMap(sections), [sections])
+  const cachedMap = useCombinedDiffSectionIndexMap({ entrySignature: 'pr-1', sections })
+  const sectionIndexByKey = stableSectionIndexMap ? cachedMap : rebuiltMap
+  const onNavigate = useCallback(() => {
+    void sectionIndexByKey
+  }, [sectionIndexByKey])
+
+  return (
+    <CombinedDiffFileTree
+      mode="commit"
+      worktreePath="/repo"
+      entries={entries}
+      sectionIndexByKey={sectionIndexByKey}
+      activeSectionKey={null}
+      viewedSectionKeys={EMPTY_VIEWED_KEYS}
+      collapsed={false}
+      onCollapsedChange={() => {}}
+      onNavigate={onNavigate}
+    />
+  )
+}
+
+function mountedRowCount(): number {
+  return mountedRows.count
+}
+
+function renderHarness(
+  entries: readonly GitBranchChangeEntry[],
+  sections: TestSection[],
+  stableSectionIndexMap: boolean
+): void {
+  act(() => {
+    root.render(
+      <TreeHarness
+        entries={entries}
+        initialSections={sections}
+        stableSectionIndexMap={stableSectionIndexMap}
+      />
+    )
+  })
+}
+
+/** One section load per commit, the way lazy loads land while the user scrolls. */
+function runScrollPass(loadCount: number): number {
+  rowRenders.count = 0
+  for (let index = 0; index < loadCount; index += 1) {
+    act(() => loadSectionAt(index))
+  }
+  return rowRenders.count
+}
+
+describe('combined diff file tree re-renders on section loads', () => {
+  const SMALL_FILE_COUNT = 30
+  const SCROLL_PASS_LOADS = 10
+
+  it('re-renders every row per section load when the section index map is rebuilt', () => {
+    const entries = buildEntries(SMALL_FILE_COUNT, 3)
+    renderHarness(entries, buildSections(entries), false)
+    const rowCount = mountedRowCount()
+    expect(rowCount).toBeGreaterThan(SMALL_FILE_COUNT)
+
+    expect(runScrollPass(SCROLL_PASS_LOADS)).toBe(rowCount * SCROLL_PASS_LOADS)
+  })
+
+  it('re-renders no rows per section load when the section index map keeps its identity', () => {
+    const entries = buildEntries(SMALL_FILE_COUNT, 3)
+    renderHarness(entries, buildSections(entries), true)
+    expect(mountedRowCount()).toBeGreaterThan(SMALL_FILE_COUNT)
+
+    expect(runScrollPass(SCROLL_PASS_LOADS)).toBe(0)
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff/browse-files/use-combined-diff-tree-navigation.ts
+++ b/src/renderer/src/components/editor/combined-diff/browse-files/use-combined-diff-tree-navigation.ts
@@ -2,10 +2,8 @@ import React, { useCallback, useRef, useState } from 'react'
 import type { GitBranchChangeEntry } from '../../../../../../shared/git-diff-compare-types'
 import type { GitStatusEntry } from '../../../../../../shared/git-status-types'
 import type { DiffSection } from '../../diff-section-types'
-import {
-  createCombinedDiffSectionIndexMap,
-  type CombinedDiffFileTreeMode
-} from '../resolve-changes/combined-diff-section-identity'
+import type { CombinedDiffFileTreeMode } from '../resolve-changes/combined-diff-section-identity'
+import { useCombinedDiffSectionIndexMap } from '../resolve-changes/use-combined-diff-section-index-map'
 import { handleCombinedDiffFileTreeNavigation } from './combined-diff-file-tree-navigation'
 import { isCombinedDiffSectionViewed } from './combined-diff-file-tree-filter'
 
@@ -37,33 +35,7 @@ export function useCombinedDiffTreeNavigation({
   toggleSection: (index: number) => void
   treeMode: CombinedDiffFileTreeMode
 }): CombinedDiffTreeNavigation {
-  const sectionIndexCacheRef = useRef<{
-    entrySignature: string
-    sectionCount: number
-    map: Map<string, number>
-    keys: string[]
-  } | null>(null)
-  const sectionIndexByKey = React.useMemo(() => {
-    const previous = sectionIndexCacheRef.current
-    // Section content/loading updates preserve entry order and keys. The entry signature and
-    // count usually change when the navigable structure changes, but compare keys as a guard for
-    // same-sized/reused signatures (and to keep this cache correct if a caller rebuilds sections).
-    if (
-      previous?.entrySignature === entrySignature &&
-      previous.sectionCount === sections.length &&
-      sections.every((section, index) => previous.keys[index] === section.key)
-    ) {
-      return previous.map
-    }
-    const map = createCombinedDiffSectionIndexMap(sections)
-    sectionIndexCacheRef.current = {
-      entrySignature,
-      sectionCount: sections.length,
-      map,
-      keys: sections.map((section) => section.key)
-    }
-    return map
-  }, [entrySignature, sections])
+  const sectionIndexByKey = useCombinedDiffSectionIndexMap({ entrySignature, sections })
   const sectionIndexByKeyRef = useRef<ReadonlyMap<string, number>>(sectionIndexByKey)
   sectionIndexByKeyRef.current = sectionIndexByKey
 

--- a/src/renderer/src/components/editor/combined-diff/resolve-changes/use-combined-diff-section-index-map.test.tsx
+++ b/src/renderer/src/components/editor/combined-diff/resolve-changes/use-combined-diff-section-index-map.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useCombinedDiffSectionIndexMap } from './use-combined-diff-section-index-map'
+
+type Section = { key: string; loading: boolean }
+
+function sectionsFor(keys: readonly string[], loadedKeys: readonly string[] = []): Section[] {
+  return keys.map((key) => ({ key, loading: !loadedKeys.includes(key) }))
+}
+
+describe('useCombinedDiffSectionIndexMap', () => {
+  const keys = ['combined-commit:a.ts', 'combined-commit:b.ts', 'combined-commit:c.ts']
+
+  it('keeps the map identity across a section load that leaves the keys alone', () => {
+    const { result, rerender } = renderHook(
+      ({ sections }: { sections: Section[] }) =>
+        useCombinedDiffSectionIndexMap({ entrySignature: 'pr-1', sections }),
+      { initialProps: { sections: sectionsFor(keys) } }
+    )
+    const first = result.current
+
+    // An on-demand load replaces the array and one section object; keys are untouched.
+    rerender({ sections: sectionsFor(keys, ['combined-commit:b.ts']) })
+
+    expect(result.current).toBe(first)
+    expect([...result.current]).toEqual([
+      ['combined-commit:a.ts', 0],
+      ['combined-commit:b.ts', 1],
+      ['combined-commit:c.ts', 2]
+    ])
+  })
+
+  it('rebuilds when a section key changes in place', () => {
+    const { result, rerender } = renderHook(
+      ({ sections }: { sections: Section[] }) =>
+        useCombinedDiffSectionIndexMap({ entrySignature: 'pr-1', sections }),
+      { initialProps: { sections: sectionsFor(keys) } }
+    )
+    const first = result.current
+
+    rerender({ sections: sectionsFor(['combined-commit:a.ts', 'combined-commit:renamed.ts']) })
+
+    expect(result.current).not.toBe(first)
+    expect(result.current.get('combined-commit:renamed.ts')).toBe(1)
+    expect(result.current.has('combined-commit:b.ts')).toBe(false)
+  })
+
+  it('rebuilds when the entry set changes even if the keys happen to match', () => {
+    const { result, rerender } = renderHook(
+      ({ entrySignature }: { entrySignature: string }) =>
+        useCombinedDiffSectionIndexMap({ entrySignature, sections: sectionsFor(keys) }),
+      { initialProps: { entrySignature: 'pr-1' } }
+    )
+    const first = result.current
+
+    rerender({ entrySignature: 'pr-2' })
+
+    expect(result.current).not.toBe(first)
+    expect([...result.current]).toEqual([...first])
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff/resolve-changes/use-combined-diff-section-index-map.ts
+++ b/src/renderer/src/components/editor/combined-diff/resolve-changes/use-combined-diff-section-index-map.ts
@@ -1,0 +1,49 @@
+import { useLayoutEffect, useMemo, useRef } from 'react'
+import { createCombinedDiffSectionIndexMap } from './combined-diff-section-identity'
+
+type CombinedDiffSectionIndexCache = {
+  entrySignature: string
+  sections: readonly { key: string }[]
+  map: Map<string, number>
+}
+
+/**
+ * Section-key to section-index map that keeps its identity while the section keys do.
+ *
+ * On-demand section loads replace the sections array on every fetch, so a freshly built Map would
+ * be a memo miss for every consumer — the file tree would re-render all of its rows continuously
+ * while the user scrolls a large diff.
+ */
+export function useCombinedDiffSectionIndexMap({
+  entrySignature,
+  sections
+}: {
+  entrySignature: string
+  sections: readonly { key: string }[]
+}): Map<string, number> {
+  const cacheRef = useRef<CombinedDiffSectionIndexCache | null>(null)
+  const sectionIndexByKey = useMemo(() => {
+    const previous = cacheRef.current
+    // Section content/loading updates preserve entry order and keys. The entry signature usually
+    // changes when the navigable structure changes, but compare keys as a guard for reused
+    // signatures (and to keep this cache correct if a caller rebuilds sections).
+    if (
+      previous !== null &&
+      previous.entrySignature === entrySignature &&
+      previous.sections.length === sections.length &&
+      sections.every((section, index) => previous.sections[index]?.key === section.key)
+    ) {
+      return previous.map
+    }
+    return createCombinedDiffSectionIndexMap(sections)
+  }, [entrySignature, sections])
+
+  // Why a committed write and not a render-phase one: React can discard a render, and a cache
+  // seeded from abandoned work would hand a later render a map for sections that never existed.
+  // Layout, not passive, so a synchronous re-render inside the same commit still sees this cache.
+  useLayoutEffect(() => {
+    cacheRef.current = { entrySignature, sections, map: sectionIndexByKey }
+  }, [entrySignature, sectionIndexByKey, sections])
+
+  return sectionIndexByKey
+}

--- a/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-section-index.test.tsx
+++ b/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-section-index.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitHubPRFile } from '../../../../../shared/github/pull-request-types'
+import type { PRFilesCombinedDiffViewerProps } from '@/components/github/pr-file-diff-mapping'
+
+const capturedSectionIndexMaps = vi.hoisted(() => ({ list: [] as ReadonlyMap<string, number>[] }))
+const loaders = vi.hoisted(() => ({ loadSection: (_index: number) => {} }))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ settings: { theme: 'dark' } })
+}))
+
+vi.mock('./pr-files-combined-diff-body', () => ({
+  PRFilesCombinedDiffBody: (props: {
+    sectionIndexByKey: ReadonlyMap<string, number>
+    loadSection: (index: number) => void
+  }) => {
+    capturedSectionIndexMaps.list.push(props.sectionIndexByKey)
+    loaders.loadSection = props.loadSection
+    return null
+  }
+}))
+
+vi.mock('./pr-files-combined-diff-load', () => ({
+  addPRFilesCombinedDiffLineComment: () => Promise.resolve(),
+  // Why: stands in for the network fetch, keeping only the state shape a real load produces —
+  // a new sections array with one patched section and untouched keys.
+  loadPRFilesCombinedDiffSection: ({
+    index,
+    setSections
+  }: {
+    index: number
+    setSections: (updater: (prev: { key: string; loading: boolean }[]) => unknown) => void
+  }) => {
+    setSections((prev) =>
+      prev.map((section, sectionIndex) =>
+        sectionIndex === index ? { ...section, loading: false } : section
+      )
+    )
+  },
+  retryPRFilesCombinedDiffSection: () => {},
+  setAllPRFilesCombinedDiffSectionsCollapsed: () => {},
+  togglePRFilesCombinedDiffSection: () => {}
+}))
+
+const { PRFilesCombinedDiffViewer } = await import('./pr-files-combined-diff-viewer')
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  capturedSectionIndexMaps.list = []
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.restoreAllMocks()
+})
+
+function prFiles(count: number): GitHubPRFile[] {
+  return Array.from({ length: count }, (_, index) => ({
+    path: `src/file-${String(index).padStart(3, '0')}.ts`,
+    status: 'modified' as const,
+    additions: 1,
+    deletions: 1,
+    isBinary: false
+  }))
+}
+
+const viewerProps: PRFilesCombinedDiffViewerProps = {
+  files: prFiles(6),
+  comments: [],
+  repoPath: '/repo',
+  repoId: 'repo-1',
+  prNumber: 7,
+  prUrl: 'https://example.test/pr/7',
+  headSha: 'head',
+  baseSha: 'base',
+  pendingViewedPaths: new Set(),
+  onCommentAdded: () => {},
+  onViewedChange: () => Promise.resolve(true)
+}
+
+describe('inspect-pull-request combined diff section index map', () => {
+  it('keeps one map identity across on-demand section loads', () => {
+    act(() => {
+      root.render(<PRFilesCombinedDiffViewer {...viewerProps} />)
+    })
+    const initialMap = capturedSectionIndexMaps.list.at(-1)
+    expect(initialMap?.size).toBe(viewerProps.files.length)
+
+    for (let index = 0; index < viewerProps.files.length; index += 1) {
+      act(() => loaders.loadSection(index))
+    }
+
+    expect(capturedSectionIndexMaps.list.length).toBeGreaterThan(viewerProps.files.length)
+    expect(new Set(capturedSectionIndexMaps.list).size).toBe(1)
+  })
+})

--- a/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-viewer.tsx
+++ b/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-viewer.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from '
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type { editor as monacoEditor } from 'monaco-editor'
 import type { DecoratedDiffComment } from '@/components/diff-comments/decorated-diff-comment'
-import { createCombinedDiffSectionIndexMap } from '../../editor/combined-diff/resolve-changes/combined-diff-section-identity'
+import { useCombinedDiffSectionIndexMap } from '../../editor/combined-diff/resolve-changes/use-combined-diff-section-index-map'
 import { handleCombinedDiffFileTreeNavigation } from '../../editor/combined-diff/browse-files/combined-diff-file-tree-navigation'
 import { getDiffSectionRowEstimatedHeight } from '@/components/editor/diff-section-layout'
 import type { DiffSection } from '@/components/editor/diff-section-types'
@@ -30,6 +30,7 @@ import {
 } from './pr-files-combined-diff-load'
 
 type PRFilesCombinedDiffSectionsProps = PRFilesCombinedDiffViewerProps & {
+  signature: string
   sideBySide: boolean
   setSideBySide: React.Dispatch<React.SetStateAction<boolean>>
   fileTreeCollapsed: boolean
@@ -61,6 +62,7 @@ export function PRFilesCombinedDiffViewer(
     <PRFilesCombinedDiffSections
       key={signature}
       {...props}
+      signature={signature}
       sideBySide={sideBySide}
       setSideBySide={setSideBySide}
       fileTreeCollapsed={fileTreeCollapsed}
@@ -83,6 +85,7 @@ function PRFilesCombinedDiffSections({
   pendingViewedPaths,
   onCommentAdded,
   onViewedChange,
+  signature,
   sideBySide,
   setSideBySide,
   fileTreeCollapsed,
@@ -222,7 +225,7 @@ function PRFilesCombinedDiffSections({
   )
 
   const allSectionsCollapsed = sections.length > 0 && sections.every((section) => section.collapsed)
-  const sectionIndexByKey = useMemo(() => createCombinedDiffSectionIndexMap(sections), [sections])
+  const sectionIndexByKey = useCombinedDiffSectionIndexMap({ entrySignature: signature, sections })
   const viewedSectionKeys = useMemo(
     () => new Set(files.filter(isPRFileViewed).map((file) => getPRFileSectionKey(file.path))),
     [files]

--- a/src/renderer/src/components/pull-request-page/files/combined-diff-section-index.test.tsx
+++ b/src/renderer/src/components/pull-request-page/files/combined-diff-section-index.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitHubPRFile } from '../../../../../shared/github/pull-request-types'
+import type { PRFilesCombinedDiffViewerProps } from '@/components/github/pr-file-diff-mapping'
+
+const capturedSectionIndexMaps = vi.hoisted(() => ({ list: [] as ReadonlyMap<string, number>[] }))
+const loaders = vi.hoisted(() => ({ loadSection: (_index: number) => {} }))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ settings: { theme: 'dark' } })
+}))
+
+vi.mock('../../editor/combined-diff/browse-files/combined-diff-file-tree', () => ({
+  CombinedDiffFileTree: (props: { sectionIndexByKey: ReadonlyMap<string, number> }) => {
+    capturedSectionIndexMaps.list.push(props.sectionIndexByKey)
+    return null
+  }
+}))
+
+vi.mock('@/components/editor/DiffSectionItem', () => ({ DiffSectionItem: () => null }))
+vi.mock('./toolbar', () => ({ PRFilesDiffToolbar: () => null }))
+vi.mock('./view-restore', () => ({ usePRFilesDiffViewPersistence: () => {} }))
+
+vi.mock('./section-loader', () => ({
+  usePRFileSectionLoader: ({
+    setSections
+  }: {
+    setSections: (updater: (prev: { key: string; loading: boolean }[]) => unknown) => void
+  }) => {
+    // Why: stands in for the network fetch, keeping only the state shape a real load produces —
+    // a new sections array with one patched section and untouched keys.
+    loaders.loadSection = (index: number) => {
+      setSections((prev) =>
+        prev.map((section, sectionIndex) =>
+          sectionIndex === index ? { ...section, loading: false } : section
+        )
+      )
+    }
+    return {
+      loadSection: loaders.loadSection,
+      retrySection: () => {},
+      toggleSection: () => {},
+      setAllSectionsCollapsed: () => {}
+    }
+  }
+}))
+
+const { PRFilesCombinedDiffViewer } = await import('./combined-diff-viewer')
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  capturedSectionIndexMaps.list = []
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.restoreAllMocks()
+})
+
+function prFiles(count: number): GitHubPRFile[] {
+  return Array.from({ length: count }, (_, index) => ({
+    path: `src/file-${String(index).padStart(3, '0')}.ts`,
+    status: 'modified' as const,
+    additions: 1,
+    deletions: 1,
+    isBinary: false
+  }))
+}
+
+const viewerProps: PRFilesCombinedDiffViewerProps = {
+  files: prFiles(6),
+  comments: [],
+  repoPath: '/repo',
+  repoId: 'repo-1',
+  prNumber: 7,
+  prUrl: 'https://example.test/pr/7',
+  headSha: 'head',
+  baseSha: 'base',
+  pendingViewedPaths: new Set(),
+  onCommentAdded: () => {},
+  onViewedChange: () => Promise.resolve(true)
+}
+
+describe('pull request page combined diff section index map', () => {
+  it('keeps one map identity across on-demand section loads', () => {
+    act(() => {
+      root.render(<PRFilesCombinedDiffViewer {...viewerProps} />)
+    })
+    capturedSectionIndexMaps.list = []
+
+    for (let index = 0; index < viewerProps.files.length; index += 1) {
+      act(() => loaders.loadSection(index))
+    }
+
+    expect(capturedSectionIndexMaps.list.length).toBe(viewerProps.files.length)
+    expect(capturedSectionIndexMaps.list[0]?.size).toBe(viewerProps.files.length)
+    expect(new Set(capturedSectionIndexMaps.list).size).toBe(1)
+  })
+})

--- a/src/renderer/src/components/pull-request-page/files/combined-diff-viewer.tsx
+++ b/src/renderer/src/components/pull-request-page/files/combined-diff-viewer.tsx
@@ -4,7 +4,7 @@ import type { editor as monacoEditor } from 'monaco-editor'
 import { useAppStore } from '@/store'
 import { DiffSectionItem } from '@/components/editor/DiffSectionItem'
 import { CombinedDiffFileTree } from '../../editor/combined-diff/browse-files/combined-diff-file-tree'
-import { createCombinedDiffSectionIndexMap } from '../../editor/combined-diff/resolve-changes/combined-diff-section-identity'
+import { useCombinedDiffSectionIndexMap } from '../../editor/combined-diff/resolve-changes/use-combined-diff-section-index-map'
 import { handleCombinedDiffFileTreeNavigation } from '../../editor/combined-diff/browse-files/combined-diff-file-tree-navigation'
 import { getDiffSectionRowEstimatedHeight } from '@/components/editor/diff-section-layout'
 import type { DiffSection } from '@/components/editor/diff-section-types'
@@ -180,7 +180,7 @@ export function PRFilesCombinedDiffViewer({
     })
 
   const allSectionsCollapsed = sections.length > 0 && sections.every((section) => section.collapsed)
-  const sectionIndexByKey = useMemo(() => createCombinedDiffSectionIndexMap(sections), [sections])
+  const sectionIndexByKey = useCombinedDiffSectionIndexMap({ entrySignature, sections })
   const visibleActiveTreeSectionKey =
     activeTreeSectionKey && sectionIndexByKey.has(activeTreeSectionKey)
       ? activeTreeSectionKey


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​463 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​463 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |

<!-- /orca-pr-loc -->

## ELI5

Scrolling a big pull request made Orca redraw the entire file tree from scratch, over and over.

Every time one file's diff finished loading in the background (which happens constantly while you scroll a large PR), the sidebar file list threw away all ~900 rows and rebuilt them — even though nothing about the tree had changed. This makes that redraw not happen at all.

## The recurring cost

Both PR files viewers did:

```ts
const sectionIndexByKey = useMemo(() => createCombinedDiffSectionIndexMap(sections), [sections])
```

An on-demand section load does `setSections(prev => prev.map(...))`, so `sections` gets a new identity per load while the section **keys** stay identical. A new `Map` identity is a memo miss for every `CombinedDiffFileTreeRow` (and it also destabilized `handleTreeNavigate`, which closes over the map), so the whole tree re-rendered per load.

The local `CombinedDiffViewer` did not have this problem because `useCombinedDiffTreeNavigation` already cached the map behind an entry-signature + per-index key comparison. That cache is now extracted into `useCombinedDiffSectionIndexMap` and used by all three call sites — the navigation hook, `pull-request-page/files/combined-diff-viewer.tsx`, and `inspect-pull-request/pr-files-combined-diff-viewer.tsx`.

The extracted hook seeds its cache from a `useLayoutEffect` rather than writing the ref during render, which the original in-place version did. Render only reads the cache, so a render React discards cannot leave behind an entry for sections that never committed — and the hook does not need the `react-doctor/no-ref-current-in-render` allowance that `use-combined-diff-tree-navigation.ts` carries in `package.json`. Identity behaviour is unchanged and covered by the tests below.

## Measurements

Measured with `combined-diff-file-tree-render.test.tsx`, driving a real `CombinedDiffFileTree` in happy-dom. Re-taken against the current base (`3d67f2be2c5`) after `main` moved. "Section load" = one commit that replaces the sections array with one section patched, keys untouched — the exact shape both loaders produce.

| Tree | Row render commits per section load, before | after |
| --- | --- | --- |
| 900-file review (931 rows) | **931** | **0** |
| 30-file review (34 rows) | **34** | **0** |

The 34-row case is the one asserted in CI; the 931-row case is the same code path at review scale.

## Negative user-facing trade-offs

**None.** The map is a pure function of the section keys, and the cache rebuilds whenever a key, the section count, or the entry signature changes, so a stale map is not reachable. No markup, no ordering, no keyboard or mouse behaviour changes — this is a free change.

## Regression tests

- `use-combined-diff-section-index-map.test.tsx` — map identity survives a section load that leaves the keys alone; rebuilds on a key change and on an entry-signature change.
- `pull-request-page/files/combined-diff-section-index.test.tsx` and `inspect-pull-request/pr-files-combined-diff-section-index.test.tsx` — render the real viewers, capture what the tree receives across six simulated on-demand loads, assert exactly one map identity. Both **fail** without the fix (6 distinct maps instead of 1 — verified by reverting just the two viewer files).
- `combined-diff-file-tree-render.test.tsx` — row re-render counts across a simulated 10-load scroll pass over a real tree: `rowCount * 10` with the rebuilt map, `0` with the cached one.

## Split from the original PR

This PR originally also virtualized the file tree's row lists. That half has real user-facing trade-offs (find-in-page, select-all-copy and Tab order see only the mounted window above 50 rows), so it now lives in #18236 and is reviewed separately. The two are independent and touch disjoint files; neither depends on the other.

## Provider coverage

The fix is in the provider-agnostic `editor/combined-diff` module plus the shared hook. Today the tree is used by the local worktree `CombinedDiffViewer` and the two GitHub PR surfaces; GitLab's MR files tab renders a plain list and does not use this viewer, so it inherits the fix if it ever adopts it. No GitHub-specific naming was added.

## Verification

Rebased onto current `main` (`3d67f2be2c5`); nothing in `editor/combined-diff` or the PR surfaces changed on `main` since this PR opened, and `use-combined-diff-tree-navigation.ts` is still the only section-index cache in the area, so there is no competing implementation to reconcile.

- `pnpm tc` — clean
- `npx oxlint` on all changed paths — clean
- `npx oxlint --config config/oxlint-react-doctor.json` on the changed paths — clean
- `pnpm run check:code-quality:changed` — 0 new findings across 8 changed files (code quality, type-aware, React Doctor)
- `check:max-lines-ratchet` — OK, no new bypasses
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/editor/combined-diff src/renderer/src/components/pull-request-page src/renderer/src/components/github-item-dialog` — 23 files, 128 tests passed

No lint rule was disabled and no per-file budget or ignore list was extended.