### PR TITLE
fix(diff-comments): stop review refreshes from blanking inline comment cards

### DIFF
--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.commentable-lines.test.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.commentable-lines.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { editor as MonacoEditor, IDisposable } from 'monaco-editor'
+import type { DecoratedDiffComment } from './decorated-diff-comment'
+import type * as ReactDomClientModule from 'react-dom/client'
+import type * as DiffCommentZoneCardModule from './diff-comment-zone-card'
+
+const storeFixture = vi.hoisted(() => ({
+  activeGroupIdByWorktree: {},
+  clearDeliveredDiffComments: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: typeof storeFixture) => unknown) => selector(storeFixture)
+}))
+
+// Stub only the card render: this suite is about zone/root lifecycle, not card markup.
+vi.mock('./diff-comment-zone-card', async (importOriginal) => ({
+  ...(await importOriginal<typeof DiffCommentZoneCardModule>()),
+  renderDiffCommentZoneCard: vi.fn()
+}))
+
+const rootCounts = vi.hoisted(() => ({ created: 0, unmounted: 0 }))
+
+// Count only roots the decorator creates for its zones — @testing-library/react creates its own.
+vi.mock('react-dom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactDomClientModule>()
+  return {
+    ...actual,
+    createRoot: (container: Element, options?: Parameters<typeof actual.createRoot>[1]) => {
+      const isZoneRoot = container.classList?.contains('orca-diff-comment-inline') ?? false
+      if (isZoneRoot) {
+        rootCounts.created += 1
+      }
+      const root = actual.createRoot(container, options)
+      return {
+        render: (node: Parameters<typeof root.render>[0]) => root.render(node),
+        unmount: () => {
+          if (isZoneRoot) {
+            rootCounts.unmounted += 1
+          }
+          root.unmount()
+        }
+      }
+    }
+  }
+})
+
+import { useDiffCommentDecorator } from './useDiffCommentDecorator'
+
+type FakeEditor = {
+  editor: MonacoEditor.ICodeEditor
+  domNode: HTMLElement
+  zones: Map<string, MonacoEditor.IViewZone>
+  emitMouseMove: (lineNumber: number) => void
+}
+
+function createFakeEditor(): FakeEditor {
+  const domNode = document.createElement('div')
+  document.body.appendChild(domNode)
+  const zones = new Map<string, MonacoEditor.IViewZone>()
+  let nextZoneId = 0
+  const mouseMoveListeners: ((e: { target: { position: { lineNumber: number } } }) => void)[] = []
+  const noopDisposable: IDisposable = { dispose: () => {} }
+
+  const editor = {
+    getDomNode: () => domNode,
+    getModel: () => ({}),
+    getOption: () => 19,
+    getTopForLineNumber: () => 0,
+    getScrollTop: () => 0,
+    getLayoutInfo: () => ({ height: 400 }),
+    setScrollTop: () => {},
+    deltaDecorations: () => [],
+    getTargetAtClientPoint: () => null,
+    onMouseMove: (listener: (e: { target: { position: { lineNumber: number } } }) => void) => {
+      mouseMoveListeners.push(listener)
+      return noopDisposable
+    },
+    onMouseLeave: () => noopDisposable,
+    onDidScrollChange: () => noopDisposable,
+    changeViewZones: (callback: (accessor: MonacoEditor.IViewZoneChangeAccessor) => void) =>
+      callback({
+        addZone: (zone: MonacoEditor.IViewZone) => {
+          const id = `zone-${(nextZoneId += 1)}`
+          zones.set(id, zone)
+          return id
+        },
+        removeZone: (id: string) => {
+          zones.delete(id)
+        },
+        layoutZone: () => {}
+      } as unknown as MonacoEditor.IViewZoneChangeAccessor)
+  } as unknown as MonacoEditor.ICodeEditor
+
+  return {
+    editor,
+    domNode,
+    zones,
+    emitMouseMove: (lineNumber) => {
+      for (const listener of mouseMoveListeners) {
+        listener({ target: { position: { lineNumber } } })
+      }
+    }
+  }
+}
+
+const FILE_PATH = 'src/index.ts'
+const REVIEW_SURFACE_ID = 'pr:acme/widgets:42'
+
+function reviewNote(index: number): DecoratedDiffComment {
+  return {
+    id: `review-note-${index}`,
+    worktreeId: REVIEW_SURFACE_ID,
+    filePath: FILE_PATH,
+    lineNumber: 10 + index,
+    body: `Please rename this (${index}).`,
+    createdAt: index,
+    side: 'modified',
+    author: 'octocat'
+  }
+}
+
+// Every refresh of remote review data yields a fresh-but-equal array, exactly as the main process ships it.
+function freshCommentableLines(): readonly number[] {
+  return [10, 11, 12, 13, 14, 15, 16]
+}
+
+// Root teardown is deferred through queueMicrotask, so drain before asserting on unmount counts.
+async function flushDeferredUnmounts(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+// Asserted as one object so a failure reports every lifecycle number at once.
+function lifecycleTotals(fake: FakeEditor): Record<string, number> {
+  return {
+    createRootCalls: rootCounts.created,
+    rootUnmounts: rootCounts.unmounted,
+    monacoViewZones: fake.zones.size
+  }
+}
+
+function isAddButtonVisible(domNode: HTMLElement): boolean {
+  const button = domNode.querySelector<HTMLElement>('.orca-diff-comment-add-btn')
+  return button != null && button.style.display !== 'none'
+}
+
+type DecoratorProps = {
+  commentableLineNumbers: readonly number[]
+  comments: readonly DecoratedDiffComment[]
+}
+
+function renderDecorator(fake: FakeEditor, initialProps: DecoratorProps) {
+  return renderHook(
+    ({ commentableLineNumbers, comments }: DecoratorProps) =>
+      useDiffCommentDecorator({
+        editor: fake.editor,
+        filePath: FILE_PATH,
+        worktreeId: REVIEW_SURFACE_ID,
+        comments,
+        commentableLineNumbers,
+        onAddCommentClick: vi.fn(),
+        onDeleteComment: vi.fn()
+      }),
+    { initialProps }
+  )
+}
+
+beforeEach(() => {
+  rootCounts.created = 0
+  rootCounts.unmounted = 0
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+  vi.clearAllMocks()
+})
+
+describe('useDiffCommentDecorator commentable-line churn', () => {
+  it('keeps every comment root and view zone alive across value-equal review refreshes', async () => {
+    const fake = createFakeEditor()
+    const comments = [reviewNote(1), reviewNote(2), reviewNote(3)]
+    const hook = renderDecorator(fake, {
+      commentableLineNumbers: freshCommentableLines(),
+      comments
+    })
+
+    expect(rootCounts.created).toBe(3)
+    expect(fake.zones.size).toBe(3)
+
+    for (let refresh = 0; refresh < 5; refresh += 1) {
+      hook.rerender({ commentableLineNumbers: freshCommentableLines(), comments })
+    }
+    await flushDeferredUnmounts()
+
+    expect(lifecycleTotals(fake)).toEqual({
+      createRootCalls: 3,
+      rootUnmounts: 0,
+      monacoViewZones: 3
+    })
+
+    // Still tracked, so dropping a note reclaims its vertical space instead of leaving a blank gap.
+    hook.rerender({ commentableLineNumbers: freshCommentableLines(), comments: comments.slice(1) })
+    expect(fake.zones.size).toBe(2)
+  })
+
+  it('does not accumulate orphan zones when refreshes interleave with new review comments', async () => {
+    const fake = createFakeEditor()
+    let comments = [reviewNote(1)]
+    const hook = renderDecorator(fake, {
+      commentableLineNumbers: freshCommentableLines(),
+      comments
+    })
+
+    for (let refresh = 2; refresh <= 6; refresh += 1) {
+      comments = [...comments, reviewNote(refresh)]
+      hook.rerender({ commentableLineNumbers: freshCommentableLines(), comments })
+    }
+    await flushDeferredUnmounts()
+
+    // 6 live notes => 6 roots, 6 zones, nothing stranded.
+    expect(lifecycleTotals(fake)).toEqual({
+      createRootCalls: 6,
+      rootUnmounts: 0,
+      monacoViewZones: 6
+    })
+  })
+
+  it('rebuilds the add-button overlay when the commentable lines really change', async () => {
+    const fake = createFakeEditor()
+    const comments = [reviewNote(1)]
+    const hook = renderDecorator(fake, {
+      commentableLineNumbers: [10, 11, 12] as readonly number[],
+      comments
+    })
+
+    fake.emitMouseMove(40)
+    expect(isAddButtonVisible(fake.domNode)).toBe(false)
+
+    hook.rerender({ commentableLineNumbers: [10, 11, 12, 40], comments })
+    await flushDeferredUnmounts()
+
+    // Decorator is not stale: the widened set is live...
+    fake.emitMouseMove(40)
+    expect(isAddButtonVisible(fake.domNode)).toBe(true)
+    // ...and the existing note's zone/root was neither orphaned nor rebuilt.
+    expect(lifecycleTotals(fake)).toEqual({
+      createRootCalls: 1,
+      rootUnmounts: 0,
+      monacoViewZones: 1
+    })
+  })
+
+  it('removes its zones from Monaco when the model swaps under a retained editor', async () => {
+    const fake = createFakeEditor()
+    const comments = [reviewNote(1)]
+    const hook = renderHook(
+      ({ monacoModelIdentity }) =>
+        useDiffCommentDecorator({
+          editor: fake.editor,
+          monacoModelIdentity,
+          filePath: FILE_PATH,
+          worktreeId: REVIEW_SURFACE_ID,
+          comments,
+          commentableLineNumbers: freshCommentableLines(),
+          onAddCommentClick: vi.fn(),
+          onDeleteComment: vi.fn()
+        }),
+      { initialProps: { monacoModelIdentity: 'modified-v1' } }
+    )
+    const firstZoneIds = [...fake.zones.keys()]
+
+    hook.rerender({ monacoModelIdentity: 'modified-v2' })
+    await flushDeferredUnmounts()
+
+    // Stale zone ids are gone rather than left as untracked blank gaps, and the note was rebuilt.
+    expect(fake.zones.size).toBe(1)
+    expect([...fake.zones.keys()]).not.toEqual(firstZoneIds)
+    expect(rootCounts.created).toBe(2)
+    expect(rootCounts.unmounted).toBe(1)
+  })
+})

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -80,11 +80,17 @@ export function useDiffCommentDecorator({
     scrollToZoneFrameRef.current = null
   }, [])
 
+  // Key on the values, not the array identity: review surfaces re-fetch PR/MR file data on every
+  // refresh and hand us a fresh-but-equal number[], which would otherwise churn every consumer.
+  const commentableLineKey = commentableLineNumbers?.join(',')
   const commentableLineSet = useMemo(
     () => (commentableLineNumbers ? new Set(commentableLineNumbers) : null),
-    [commentableLineNumbers]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [commentableLineKey]
   )
 
+  // Add-button overlay only: it captures commentableLineSet/addButtonLabel, so it must be rebuilt when
+  // either changes. Kept apart from the zone teardown below, whose deps must mirror the zone-creating effect.
   useEffect(() => {
     if (!editor) {
       return
@@ -95,8 +101,7 @@ export function useDiffCommentDecorator({
       return
     }
 
-    const zones = zonesRef.current
-    const disposeAddButtonOverlay = installDiffCommentAddButtonOverlay({
+    return installDiffCommentAddButtonOverlay({
       editor,
       editorDomNode,
       addButtonLabel,
@@ -105,15 +110,33 @@ export function useDiffCommentDecorator({
       disposablesRef,
       onAddCommentClickRef
     })
+  }, [addButtonLabel, commentableLineSet, editor, monacoModelIdentity])
+
+  // Deps must stay a subset of the zone-creating effect's, or a teardown here is never followed by a rebuild.
+  useEffect(() => {
+    if (!editor) {
+      return
+    }
+
+    const zones = zonesRef.current
 
     return () => {
-      disposeAddButtonOverlay()
       // Editor swapped/torn down: unmount roots and clear tracking so the next mount starts known-empty.
       // Defer unmount via queueMicrotask: a sync unmount during React's commit triggers React 19's "unmount while rendering" warning; clear zones synchronously.
       const rootsToUnmount = Array.from(zones.values(), (z) => {
         z.disposeMouseDownStopper()
         return z.root
       })
+      // Drop the zones from Monaco too: clearing our map alone would strand them as untracked blank gaps
+      // in a still-live editor. No-op when the model already swapped (Monaco dropped them) or the editor is disposed.
+      if (zones.size > 0) {
+        const zoneIds = Array.from(zones.values(), (z) => z.zoneId)
+        editor.changeViewZones((accessor) => {
+          for (const zoneId of zoneIds) {
+            accessor.removeZone(zoneId)
+          }
+        })
+      }
       zones.clear()
       if (rootsToUnmount.length > 0) {
         queueMicrotask(() => {
@@ -127,7 +150,7 @@ export function useDiffCommentDecorator({
       pendingScrollRef.current = null
       scrollToZoneRef.current = null
     }
-  }, [addButtonLabel, cancelScrollToZoneFrame, commentableLineSet, editor, monacoModelIdentity])
+  }, [cancelScrollToZoneFrame, editor, monacoModelIdentity])
 
   useEffect(() => {
     if (!editor) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​284 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​284 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## ELI5

Every time Orca refreshed a pull request, it deleted the contents of every inline comment box in the diff but left the empty boxes behind — so you got blank gaps where your review comments used to be. Then it did it again on the next refresh, stacking up more blank gaps.

## What was wrong

`useDiffCommentDecorator` memoized `commentableLineSet` on the **identity** of the `commentableLineNumbers` array:

```ts
const commentableLineSet = useMemo(
  () => (commentableLineNumbers ? new Set(commentableLineNumbers) : null),
  [commentableLineNumbers]
)
```

On review surfaces that array is `fileByPath.get(path)?.reviewCommentLineNumbers` (`pull-request-page/files/combined-diff-viewer.tsx:362`, `github-item-dialog/inspect-pull-request/pr-files-combined-diff-body.tsx:154`). It is rebuilt fresh in the main process on every fetch (`src/main/github/pull-request-file-data.ts:148`) and shipped over IPC, and the renderer never value-compares it. So an identical set of line numbers still produced a new array -> new `Set` -> new dep.

That dep sat on the effect that owns **both** the add-button overlay **and** the view-zone teardown. Its cleanup unmounted every comment card's React root and emptied `zonesRef`, but never called `accessor.removeZone`. The effect that actually *creates* zones does not depend on `commentableLineSet`, so it never re-ran. Net result per refresh: Monaco still holds the view zones (still consuming vertical space), they are now blank, untracked, unremovable, and never re-rendered. If new review comments arrived between refreshes, the now-empty map made the create-effect rebuild zones for *every* comment on top of the stranded ones — quadratic accumulation.

Local worktree diffs were unaffected: `CombinedDiffViewer.tsx` does not pass `getCommentableLineNumbers`, so the set is `null` and stable.

## The fix

1. **Memoize on the values, not the array identity** (`commentableLineNumbers?.join(',')`). This kills the churn at the root and follows the existing house pattern in `combined-diff-viewer.tsx` (`diffEntrySignature`).
2. **Split the effect.** `commentableLineSet` does **not** belong on the zone-teardown effect — but it cannot simply be dropped, because `installDiffCommentAddButtonOverlay` closes over the set by value and would go stale (the "+" button would keep offering the old commentable lines). So the overlay moved into its own effect (`[addButtonLabel, commentableLineSet, editor, monacoModelIdentity]`) and the teardown kept only `[cancelScrollToZoneFrame, editor, monacoModelIdentity]`. The teardown's deps are now a strict **subset** of the zone-creating effect's, which is the invariant that was missing: a teardown is now always followed by a rebuild.
3. **The missing `accessor.removeZone` was a second, real bug**, latent even after the memo fix. The cleanup clears `zonesRef`, so anything left in Monaco is unreachable by definition. It still fires on a genuine model swap under a retained editor, and on any future dep added to that effect. Verified safe in `monaco-editor`: `ViewZones._removeZone` is guarded by `hasOwnProperty` (no-op for an id Monaco already dropped on model swap), and `CodeEditorWidget.changeViewZones` early-returns when `_modelData` is null (no-op on a disposed editor).

## Measurements

Real numbers from the new regression suite (`useDiffCommentDecorator.commentable-lines.test.tsx`), same test run against unmodified `main` and against this branch.

**Scenario A — 5 refreshes shipping value-equal line numbers, fixed set of 3 review notes:**

| | `createRoot` calls | root unmounts | Monaco view zones | orphaned (blank) zones |
|---|---|---|---|---|
| before | 3 | **3** | 3 | **3** |
| after | 3 | 0 | 3 | 0 |

All three cards were destroyed; all three zones survived as blank gaps.

**Scenario B — 5 refreshes, each also bringing one new review comment (6 notes live at the end):**

| | `createRoot` calls | root unmounts | Monaco view zones | orphaned (blank) zones |
|---|---|---|---|---|
| before | **21** | **15** | **21** | **15** |
| after | 6 | 0 | 6 | 0 |

**Scenario C — model swap under a retained editor:** before, 2 view zones for 1 comment (1 stranded); after, 1.

### Failing assertions on unmodified code

```
× keeps every comment root and view zone alive across value-equal review refreshes
AssertionError: expected { createRootCalls: 3, …(2) } to deeply equal { createRootCalls: 3, …(2) }
    "createRootCalls": 3,
    "monacoViewZones": 3,
-   "rootUnmounts": 0,
+   "rootUnmounts": 3,

× does not accumulate orphan zones when refreshes interleave with new review comments
AssertionError: expected { createRootCalls: 21, …(2) } to deeply equal { createRootCalls: 6, …(2) }
-   "createRootCalls": 6,
-   "monacoViewZones": 6,
-   "rootUnmounts": 0,
+   "createRootCalls": 21,
+   "monacoViewZones": 21,
+   "rootUnmounts": 15,

× rebuilds the add-button overlay when the commentable lines really change
AssertionError: expected { createRootCalls: 1, …(2) } to deeply equal { createRootCalls: 1, …(2) }
    "createRootCalls": 1,
    "monacoViewZones": 1,
-   "rootUnmounts": 0,
+   "rootUnmounts": 1,

× removes its zones from Monaco when the model swaps under a retained editor
AssertionError: expected 2 to be 1 // Object.is equality
```

All 4 fail on `main`, all 4 pass on this branch.

## Tests

New `src/renderer/src/components/diff-comments/useDiffCommentDecorator.commentable-lines.test.tsx` drives the hook against a fake Monaco editor with a real view-zone registry and a `createRoot` counter scoped to zone containers:

- value-equal refreshes: no extra `createRoot`, no unmounts, constant zone count, and a subsequent comment deletion still reclaims the zone (proving the zones stayed *tracked*, not just present)
- refreshes interleaved with new comments: no orphan accumulation
- **a genuine change to the commentable line set is not made stale** — widening `[10,11,12]` to `[10,11,12,40]` makes the "+" button appear on line 40, while the existing note's zone and React root are neither rebuilt nor orphaned
- model swap under a retained editor removes the stale zone ids

## Provider coverage

The fix lives in the provider-generic decorator hook, so any review surface inherits it. Today only the GitHub path populates `reviewCommentLineNumbers` (`src/main/github/pull-request-file-data.ts`); GitLab / Bitbucket / Azure DevOps MR views do not pass `getCommentableLineNumbers` yet, so they cannot hit the bug today and will be safe when they do. Naming and comments in the changed code say "PR/MR" rather than GitHub-specific terms.

## Negative user-facing trade-offs

**None.** This is a strict improvement: it fixes visible blank gaps in the reviewed diff and stops inline comment cards from being wiped on every PR refresh. It also does strictly less work — fewer React root teardowns and, in the interleaved case, 21 -> 6 `createRoot` calls. The only behavior that can now differ is a genuine model swap, where stale view zones are removed instead of being left behind; the zone-creating effect re-runs on the same dep and rebuilds them, which the model-swap test asserts.

## Verification

- `pnpm tc` — clean
- `npx oxlint <changed files>` — clean
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/diff-comments src/renderer/src/components/pull-request-page src/renderer/src/components/github-item-dialog` — 12 files, 64 tests passed
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/editor` — 192 files, 1295 tests passed (the hook's two consumers live there)
