### PR TITLE
perf(keybindings): stop recomputing shortcut labels on every render

### DIFF
--- a/src/renderer/src/hooks/shortcut-label-cache.test.tsx
+++ b/src/renderer/src/hooks/shortcut-label-cache.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import type * as KeybindingsModule from '../../../shared/keybindings'
+import type { KeybindingOverrides } from '../../../shared/keybindings'
+
+const counters = vi.hoisted(() => ({ effective: 0, formatList: 0, formatBinding: 0 }))
+const platformRef = vi.hoisted(() => ({ current: 'darwin' as NodeJS.Platform }))
+
+vi.mock('../lib/shortcut-platform', () => ({
+  getShortcutPlatform: () => platformRef.current
+}))
+
+vi.mock('../../../shared/keybindings', async (importOriginal) => {
+  const actual = await importOriginal<typeof KeybindingsModule>()
+  return {
+    ...actual,
+    getEffectiveKeybindingsForAction: (
+      ...args: Parameters<typeof actual.getEffectiveKeybindingsForAction>
+    ) => {
+      counters.effective++
+      return actual.getEffectiveKeybindingsForAction(...args)
+    },
+    formatKeybindingList: (...args: Parameters<typeof actual.formatKeybindingList>) => {
+      counters.formatList++
+      return actual.formatKeybindingList(...args)
+    },
+    formatKeybinding: (...args: Parameters<typeof actual.formatKeybinding>) => {
+      counters.formatBinding++
+      return actual.formatKeybinding(...args)
+    }
+  }
+})
+
+const {
+  formatOptionalShortcutLabel,
+  formatPrimaryShortcutLabel,
+  formatShortcutKeyComboDetails,
+  formatShortcutLabel,
+  useShortcutLabel
+} = await import('./useShortcutLabel')
+const { useAppStore } = await import('@/store')
+
+function resetCounters(): void {
+  counters.effective = 0
+  counters.formatList = 0
+  counters.formatBinding = 0
+}
+
+// A fresh overrides object per test keeps each case on its own cache entry, exactly as a real edit does.
+function overridesFor(binding: string): KeybindingOverrides {
+  return { 'tab.close': [binding] }
+}
+
+describe('shortcut label memoization', () => {
+  beforeEach(() => {
+    platformRef.current = 'darwin'
+    resetCounters()
+  })
+
+  it('computes a label once no matter how many times it is asked for', () => {
+    const overrides = overridesFor('Mod+Shift+K')
+    const first = formatShortcutLabel('tab.close', overrides)
+    resetCounters()
+    for (let index = 0; index < 200; index++) {
+      expect(formatShortcutLabel('tab.close', overrides)).toBe(first)
+    }
+    expect(counters.effective).toBe(0)
+    expect(counters.formatList).toBe(0)
+  })
+
+  it('memoizes each label shape separately and keeps their values correct', () => {
+    const overrides = overridesFor('Mod+Shift+K')
+    expect(formatShortcutLabel('tab.close', overrides)).toBe(
+      formatShortcutLabel('tab.close', overrides)
+    )
+    expect(formatPrimaryShortcutLabel('tab.close', overrides)).toBe(
+      formatPrimaryShortcutLabel('tab.close', overrides)
+    )
+    expect(formatOptionalShortcutLabel('tab.close', overrides)).toBe(
+      formatOptionalShortcutLabel('tab.close', overrides)
+    )
+    expect(formatShortcutKeyComboDetails('tab.close', overrides)).toBe(
+      formatShortcutKeyComboDetails('tab.close', overrides)
+    )
+    expect(formatShortcutKeyComboDetails('tab.close', overrides)[0]?.keys).toEqual(['⌘', '⇧', 'K'])
+    expect(formatShortcutLabel('tab.close', overrides)).toBe('⌘⇧K')
+  })
+
+  it('returns null rather than a cached sentinel for a disabled action', () => {
+    const overrides: KeybindingOverrides = { 'tab.close': [] }
+    expect(formatOptionalShortcutLabel('tab.close', overrides)).toBe(null)
+    expect(formatOptionalShortcutLabel('tab.close', overrides)).toBe(null)
+    expect(formatShortcutLabel('tab.close', overrides)).toBe('Unassigned')
+    expect(formatPrimaryShortcutLabel('tab.close', overrides)).toBe('Unassigned')
+  })
+
+  it('recomputes as soon as a different overrides object arrives', () => {
+    expect(formatShortcutLabel('tab.close', overridesFor('Mod+Shift+K'))).toBe('⌘⇧K')
+    expect(formatShortcutLabel('tab.close', overridesFor('Mod+Shift+L'))).toBe('⌘⇧L')
+    expect(formatShortcutLabel('tab.close', overridesFor('Mod+Shift+K'))).toBe('⌘⇧K')
+  })
+
+  it('does not let one action id serve another', () => {
+    const overrides = overridesFor('Mod+Shift+K')
+    expect(formatShortcutLabel('tab.close', overrides)).toBe('⌘⇧K')
+    expect(formatShortcutLabel('tab.rename', overrides)).not.toBe('⌘⇧K')
+  })
+
+  it('keys the cache by platform so Mac and Windows glyphs never cross', () => {
+    const overrides = overridesFor('Mod+Shift+K')
+    expect(formatShortcutLabel('tab.close', overrides)).toBe('⌘⇧K')
+    platformRef.current = 'win32'
+    expect(formatShortcutLabel('tab.close', overrides)).toBe('Ctrl+Shift+K')
+    platformRef.current = 'darwin'
+    expect(formatShortcutLabel('tab.close', overrides)).toBe('⌘⇧K')
+  })
+
+  it('caches the undefined-overrides case without leaking into the override case', () => {
+    const defaultLabel = formatShortcutLabel('tab.close')
+    expect(formatShortcutLabel('tab.close')).toBe(defaultLabel)
+    expect(formatShortcutLabel('tab.close', overridesFor('Mod+Shift+K'))).toBe('⌘⇧K')
+    expect(formatShortcutLabel('tab.close')).toBe(defaultLabel)
+  })
+})
+
+function CloseLabel(): React.JSX.Element {
+  return <span data-testid="close-label">{useShortcutLabel('tab.close')}</span>
+}
+
+describe('useShortcutLabel', () => {
+  beforeEach(() => {
+    platformRef.current = 'darwin'
+    resetCounters()
+  })
+
+  afterEach(() => {
+    cleanup()
+    useAppStore.setState({ keybindings: {} })
+  })
+
+  it('does not recompute the label on re-render', () => {
+    useAppStore.setState({ keybindings: overridesFor('Mod+Shift+K') })
+    const { rerender } = render(<CloseLabel />)
+    expect(screen.getByTestId('close-label').textContent).toBe('⌘⇧K')
+    resetCounters()
+    for (let index = 0; index < 25; index++) {
+      rerender(<CloseLabel />)
+    }
+    expect(screen.getByTestId('close-label').textContent).toBe('⌘⇧K')
+    expect(counters.effective).toBe(0)
+    expect(counters.formatList).toBe(0)
+  })
+
+  it('shows an edited keybinding immediately, with no stale-cache window', () => {
+    useAppStore.setState({ keybindings: overridesFor('Mod+Shift+K') })
+    render(<CloseLabel />)
+    expect(screen.getByTestId('close-label').textContent).toBe('⌘⇧K')
+
+    // Mirrors the store update a Settings edit performs: a brand new overrides object.
+    act(() => useAppStore.setState({ keybindings: overridesFor('Mod+Shift+L') }))
+    expect(screen.getByTestId('close-label').textContent).toBe('⌘⇧L')
+
+    act(() => useAppStore.setState({ keybindings: { 'tab.close': ['Mod+Alt+Backspace'] } }))
+    expect(screen.getByTestId('close-label').textContent).toBe('⌘⌥⌫')
+
+    act(() => useAppStore.setState({ keybindings: { 'tab.close': [] } }))
+    expect(screen.getByTestId('close-label').textContent).toBe('Unassigned')
+
+    // Back to the first binding: a revert must not resurrect the entry cached for the old object.
+    act(() => useAppStore.setState({ keybindings: overridesFor('Mod+Shift+K') }))
+    expect(screen.getByTestId('close-label').textContent).toBe('⌘⇧K')
+  })
+})

--- a/src/renderer/src/hooks/useShortcutLabel.ts
+++ b/src/renderer/src/hooks/useShortcutLabel.ts
@@ -16,14 +16,48 @@ export type ShortcutKeyComboDetails = {
   doubleTap: boolean
 }
 
+// Why: these run in render bodies of components that re-render constantly, and every call is two full keybinding parses.
+// The store hands out a new overrides object on every keybinding edit, so keying the cache on that object gives exact
+// invalidation: an edit can never be served from a stale entry, and the old entry is dropped with the old object.
+const cachesByOverrides = new WeakMap<KeybindingOverrides, Map<string, unknown>>()
+const defaultOverridesCache = new Map<string, unknown>()
+
+function labelCache(overrides: KeybindingOverrides | undefined): Map<string, unknown> {
+  if (!overrides) {
+    return defaultOverridesCache
+  }
+  let cache = cachesByOverrides.get(overrides)
+  if (!cache) {
+    cache = new Map()
+    cachesByOverrides.set(overrides, cache)
+  }
+  return cache
+}
+
+function memoizeShortcut<T>(
+  kind: string,
+  actionId: KeybindingActionId,
+  platform: NodeJS.Platform,
+  overrides: KeybindingOverrides | undefined,
+  compute: () => T
+): T {
+  const cache = labelCache(overrides)
+  const key = `${platform}\u0000${kind}\u0000${actionId}`
+  if (cache.has(key)) {
+    return cache.get(key) as T
+  }
+  const value = compute()
+  cache.set(key, value)
+  return value
+}
+
 export function formatShortcutLabel(
   actionId: KeybindingActionId,
   overrides?: KeybindingOverrides
 ): string {
   const platform = getShortcutPlatform()
-  return formatKeybindingList(
-    getEffectiveKeybindingsForAction(actionId, platform, overrides),
-    platform
+  return memoizeShortcut('label', actionId, platform, overrides, () =>
+    formatKeybindingList(getEffectiveKeybindingsForAction(actionId, platform, overrides), platform)
   )
 }
 
@@ -32,8 +66,10 @@ export function formatPrimaryShortcutLabel(
   overrides?: KeybindingOverrides
 ): string {
   const platform = getShortcutPlatform()
-  const [binding] = getEffectiveKeybindingsForAction(actionId, platform, overrides)
-  return binding ? formatKeybindingList([binding], platform) : 'Unassigned'
+  return memoizeShortcut('primary', actionId, platform, overrides, () => {
+    const [binding] = getEffectiveKeybindingsForAction(actionId, platform, overrides)
+    return binding ? formatKeybindingList([binding], platform) : 'Unassigned'
+  })
 }
 
 export function useShortcutLabel(actionId: KeybindingActionId): string {
@@ -49,11 +85,13 @@ export function formatOptionalShortcutLabel(
   overrides?: KeybindingOverrides
 ): string | null {
   const platform = getShortcutPlatform()
-  const bindings = getEffectiveKeybindingsForAction(actionId, platform, overrides)
-  if (bindings.length === 0) {
-    return null
-  }
-  return formatKeybindingList(bindings, platform)
+  return memoizeShortcut('optional', actionId, platform, overrides, () => {
+    const bindings = getEffectiveKeybindingsForAction(actionId, platform, overrides)
+    if (bindings.length === 0) {
+      return null
+    }
+    return formatKeybindingList(bindings, platform)
+  })
 }
 
 export function useOptionalShortcutLabel(actionId: KeybindingActionId): string | null {
@@ -66,10 +104,13 @@ export function formatShortcutKeyComboDetails(
   overrides?: KeybindingOverrides
 ): ShortcutKeyComboDetails[] {
   const platform = getShortcutPlatform()
-  return getEffectiveKeybindingsForAction(actionId, platform, overrides).map((binding) => ({
-    keys: formatKeybinding(binding, platform),
-    doubleTap: isDoubleTapBinding(binding)
-  }))
+  // The returned array is shared across callers now, so treat it as read-only (every current caller does).
+  return memoizeShortcut('combo', actionId, platform, overrides, () =>
+    getEffectiveKeybindingsForAction(actionId, platform, overrides).map((binding) => ({
+      keys: formatKeybinding(binding, platform),
+      doubleTap: isDoubleTapBinding(binding)
+    }))
+  )
 }
 
 export function useShortcutKeyComboDetails(

--- a/src/shared/keybindings-parse-cache.test.ts
+++ b/src/shared/keybindings-parse-cache.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { KEYBINDING_DEFINITIONS } from './keybindings/definitions'
+import { getDefaultBindings } from './keybindings/effective'
+import { formatKeybindingList } from './keybindings/formatting'
+import { normalizeKeyToken, parseKeybinding } from './keybindings/parser'
+
+describe('parseKeybinding memoization', () => {
+  it('reuses the parsed result for a repeated binding string', () => {
+    const first = parseKeybinding('Mod+Shift+K')
+    const second = parseKeybinding('Mod+Shift+K')
+    expect(first).not.toBeNull()
+    expect(second).toBe(first)
+  })
+
+  it('caches rejections without re-parsing', () => {
+    expect(parseKeybinding('K+J')).toBeNull()
+    expect(parseKeybinding('K+J')).toBeNull()
+  })
+
+  it('never hands out an entry a caller can corrupt', () => {
+    const parsed = parseKeybinding('Mod+P')
+    expect(Object.isFrozen(parsed)).toBe(true)
+    expect(parseKeybinding('Mod+P')?.key).toBe('P')
+  })
+
+  it('stays bounded and correct when fed far more strings than the cache holds', () => {
+    for (let index = 0; index < 2000; index++) {
+      expect(parseKeybinding(`Mod+Alt+F${(index % 24) + 1}`)?.key).toBe(`F${(index % 24) + 1}`)
+    }
+    // A cleared cache must still return the right answer, not a stale neighbour.
+    expect(parseKeybinding('Mod+Shift+K')?.key).toBe('K')
+    expect(parseKeybinding('DoubleTap+Shift')?.doubleTapModifier).toBe('Shift')
+  })
+
+  it('parses every distinct token form identically across repeat calls', () => {
+    const tokens = [
+      ' ',
+      'a',
+      '7',
+      'f7',
+      '[',
+      '}',
+      '-',
+      '_',
+      '=',
+      '+',
+      ',',
+      '.',
+      '/',
+      '\\',
+      ';',
+      "'",
+      '`',
+      'return',
+      'esc',
+      'spacebar',
+      'pgup',
+      'pgdn',
+      'arrowleft',
+      'left',
+      'down',
+      'backspace',
+      'del',
+      'ins',
+      'numpadadd',
+      'subtract',
+      'nonsense',
+      ''
+    ]
+    for (const token of tokens) {
+      expect(normalizeKeyToken(token)).toBe(normalizeKeyToken(token))
+    }
+    expect(normalizeKeyToken(' ')).toBe('Space')
+    expect(normalizeKeyToken('pgdn')).toBe('PageDown')
+    expect(normalizeKeyToken('subtract')).toBe('NumpadSubtract')
+    expect(normalizeKeyToken('nonsense')).toBe(null)
+    expect(normalizeKeyToken('')).toBe(null)
+    // Object.prototype keys must not leak through the token table.
+    expect(normalizeKeyToken('constructor')).toBe(null)
+    expect(normalizeKeyToken('__proto__')).toBe(null)
+  })
+})
+
+describe('shortcut label output', () => {
+  it('formats every default binding identically on repeat calls, on both glyph platforms', () => {
+    for (const platform of ['darwin', 'win32'] as const) {
+      for (const definition of KEYBINDING_DEFINITIONS) {
+        const bindings = getDefaultBindings(definition, platform)
+        const label = formatKeybindingList(bindings, platform)
+        expect(formatKeybindingList(bindings, platform)).toBe(label)
+        expect(label.length).toBeGreaterThan(0)
+      }
+    }
+  })
+})

--- a/src/shared/keybindings/formatting.ts
+++ b/src/shared/keybindings/formatting.ts
@@ -90,38 +90,41 @@ export function findKeybindingActionsForBinding(
   ).map((definition) => definition.id)
 }
 
+const KEY_TOKEN_LABELS: Record<string, string> = {
+  BracketLeft: '[',
+  BracketRight: ']',
+  Minus: '-',
+  Underscore: '_',
+  Equal: '=',
+  Plus: '+',
+  ArrowLeft: '←',
+  ArrowRight: '→',
+  ArrowUp: '↑',
+  ArrowDown: '↓',
+  PageUp: 'PageUp',
+  PageDown: 'PageDown',
+  NumpadAdd: 'Numpad +',
+  NumpadSubtract: 'Numpad -',
+  Comma: ',',
+  Period: '.',
+  Slash: '/',
+  Backslash: '\\',
+  Semicolon: ';',
+  Quote: "'",
+  Backquote: '`',
+  Enter: 'Enter',
+  Backspace: 'Backspace',
+  Delete: 'Delete',
+  Insert: 'Insert',
+  Tab: 'Tab',
+  Escape: 'Esc',
+  Space: 'Space'
+}
+
+const MAC_KEY_TOKEN_LABELS: Record<string, string> = { ...KEY_TOKEN_LABELS, Backspace: '⌫' }
+
 function formatKeyToken(token: string, isMac: boolean): string {
-  const labels: Record<string, string> = {
-    BracketLeft: '[',
-    BracketRight: ']',
-    Minus: '-',
-    Underscore: '_',
-    Equal: '=',
-    Plus: '+',
-    ArrowLeft: '←',
-    ArrowRight: '→',
-    ArrowUp: '↑',
-    ArrowDown: '↓',
-    PageUp: 'PageUp',
-    PageDown: 'PageDown',
-    NumpadAdd: 'Numpad +',
-    NumpadSubtract: 'Numpad -',
-    Comma: ',',
-    Period: '.',
-    Slash: '/',
-    Backslash: '\\',
-    Semicolon: ';',
-    Quote: "'",
-    Backquote: '`',
-    Enter: 'Enter',
-    Backspace: isMac ? '⌫' : 'Backspace',
-    Delete: 'Delete',
-    Insert: 'Insert',
-    Tab: 'Tab',
-    Escape: 'Esc',
-    Space: 'Space'
-  }
-  return labels[token] ?? token
+  return (isMac ? MAC_KEY_TOKEN_LABELS : KEY_TOKEN_LABELS)[token] ?? token
 }
 
 export function findKeybindingConflicts(

--- a/src/shared/keybindings/parser.ts
+++ b/src/shared/keybindings/parser.ts
@@ -16,31 +16,8 @@ export function hasModifier(
   return Boolean(input.shift ?? input.shiftKey)
 }
 
-function isFunctionKeyToken(key: string): boolean {
-  return /^F([1-9]|1[0-9]|2[0-4])$/.test(key)
-}
-
-export function normalizeKeyToken(token: string): string | null {
-  if (token === ' ') {
-    return 'Space'
-  }
-  const trimmed = token.trim()
-  if (!trimmed) {
-    return null
-  }
-  const upper = trimmed.toUpperCase()
-  if (upper.length === 1 && upper >= 'A' && upper <= 'Z') {
-    return upper
-  }
-  if (upper.length === 1 && upper >= '0' && upper <= '9') {
-    return upper
-  }
-  // Function keys F1–F24 (event.key/event.code report them verbatim, e.g. F7).
-  if (isFunctionKeyToken(upper)) {
-    return upper
-  }
-
-  const simple: Record<string, string> = {
+const SIMPLE_KEY_TOKENS = new Map<string, string>(
+  Object.entries({
     '[': 'BracketLeft',
     ']': 'BracketRight',
     '{': 'BracketLeft',
@@ -97,9 +74,34 @@ export function normalizeKeyToken(token: string): string | null {
     SEMICOLON: 'Semicolon',
     QUOTE: 'Quote',
     BACKQUOTE: 'Backquote'
+  })
+)
+
+function isFunctionKeyToken(key: string): boolean {
+  return /^F([1-9]|1[0-9]|2[0-4])$/.test(key)
+}
+
+export function normalizeKeyToken(token: string): string | null {
+  if (token === ' ') {
+    return 'Space'
+  }
+  const trimmed = token.trim()
+  if (!trimmed) {
+    return null
+  }
+  const upper = trimmed.toUpperCase()
+  if (upper.length === 1 && upper >= 'A' && upper <= 'Z') {
+    return upper
+  }
+  if (upper.length === 1 && upper >= '0' && upper <= '9') {
+    return upper
+  }
+  // Function keys F1–F24 (event.key/event.code report them verbatim, e.g. F7).
+  if (isFunctionKeyToken(upper)) {
+    return upper
   }
 
-  return simple[upper] ?? null
+  return SIMPLE_KEY_TOKENS.get(upper) ?? null
 }
 
 export function parseModifierToken(rawPart: string): ModifierToken | null {
@@ -177,7 +179,24 @@ export function parseDoubleTapKeybinding(rawParts: string[]): ParsedKeybinding |
   return parsed
 }
 
+// Binding strings come from a fixed definition set plus user overrides, so the live set is tiny; the cap only guards a caller feeding arbitrary strings.
+const PARSE_CACHE_LIMIT = 512
+const parseCache = new Map<string, ParsedKeybinding | null>()
+
 export function parseKeybinding(binding: string): ParsedKeybinding | null {
+  if (parseCache.has(binding)) {
+    return parseCache.get(binding) ?? null
+  }
+  const parsed = parseKeybindingUncached(binding)
+  if (parseCache.size >= PARSE_CACHE_LIMIT) {
+    parseCache.clear()
+  }
+  // Frozen so a caller can never corrupt the shared entry; every current caller spread-copies before changing a field.
+  parseCache.set(binding, parsed ? Object.freeze(parsed) : null)
+  return parsed
+}
+
+function parseKeybindingUncached(binding: string): ParsedKeybinding | null {
   const rawParts = binding
     .split('+')
     .map((part) => part.trim())


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​269 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​269 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​134 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​71 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 |

<!-- /orca-pr-loc -->

## ELI5

Every keyboard-shortcut hint in the UI (`⌘W` next to "Close", `⌘D` next to "Split terminal right", and so on) was being **re-derived from its raw text form on every single React render**. Turning the string `"Mod+Shift+K"` into the label `"⌘⇧K"` means splitting it, uppercasing each piece, matching modifiers, and looking up the key name — and each label did that work **twice** (once to resolve which binding is in effect, once to format it). Nothing cached the answer, even though the answer only changes when the user actually edits a keybinding.

Worse, two of those lookup tables were being **rebuilt from scratch on each call**: `normalizeKeyToken` allocated a 57-entry object literal just to do one lookup, and `formatKeybinding`'s key-label table allocated a 28-entry object literal per key token.

The result: on the packaged app, idle, with zero keystrokes, `parseKeybinding` was running ~120 times/sec and `parseModifierToken` ~294 times/sec.

This PR caches the answers:

1. **Label layer** — results are memoized in a module-level `WeakMap` keyed by the keybindings-overrides object, plus a plain `Map` for the no-overrides case.
2. **`parseKeybinding`** — memoized behind a bounded (512-entry) cache, keyed by the binding string. Since it is a pure string→struct function, there is nothing to invalidate.
3. **Lookup tables** — hoisted to module constants.

## Verification of the reported root cause

Each claim was checked against the code before being acted on.

| Claim | Verdict |
|---|---|
| `useShortcutLabel` (L39), `useOptionalShortcutLabel` (L59), `useShortcutKeyComboDetails` (L75) recompute on every render, no `useMemo`, no cache | **Confirmed**, at exactly those lines |
| One label costs two full `parseKeybinding` passes | **Confirmed, and it is more than two.** Measured: one pass over all 124 shortcut labels issues **243 `parseKeybinding` calls** — the effective-bindings pass runs `normalizeKeybindingWithOptions` per binding and the format pass runs `formatKeybinding` per binding, so it is 2 per *binding*, not per action, and actions with two default bindings cost 4 |
| `normalizeKeyToken` allocates a 44-entry object literal per call | **Confirmed, but it is 57 entries**, not 44 |
| `normalizeKeyToken` is on the real keydown path via `src/shared/keybindings/input.ts` | **Confirmed** |
| `SortableTabContextMenu` computes split labels unconditionally in its body, and is rendered for every tab | **Confirmed, and it is 4 labels, not 2** — `terminal.splitRight` and `terminal.splitDown` via `formatShortcutLabel`, plus `tab.close` and `tab.rename` via `useOptionalShortcutLabel` |
| `state.keybindings` is only ever *reassigned*, never mutated in place | **Confirmed.** `applySnapshot` in `src/renderer/src/store/slices/keybindings.ts` sets `keybindings: snapshot.overrides`. On desktop that object crosses an `ipcRenderer.invoke` boundary, so it is a freshly structured-cloned object every time. On web, `getWebKeybindingSnapshot()` builds `overrides` as a fresh object literal per call. No code path mutates an existing overrides object, so a `WeakMap` key can never go stale |

**Additional finding not in the original report:** `formatKeyToken` in `src/shared/keybindings/formatting.ts` had the same per-call object-literal allocation as `normalizeKeyToken` (28 entries), on the same label path. Hoisted here too, as two module constants so the Mac `⌫` vs non-Mac `Backspace` split stays byte-identical.

## Measurements

All numbers produced locally on this branch. The "before" side is the real pre-change code (the original `parser.ts` and `formatting.ts` from `main`, copied into a scratch module tree and imported side-by-side with the new one), not an estimate. Timings are min-of-7 to suppress noise from a heavily loaded machine; the invocation counts are exact and deterministic.

**Invocation counts** — computing every shortcut label in the app (124 actions, 81 distinct binding strings):

| | before | after |
|---|---|---|
| `parseKeybinding` calls, first (cold) pass | 243 | 243 |
| `parseKeybinding` calls, next 25 passes | **6,075** | **0** |

25 passes stands in for a component re-rendering 25 times, which is what was happening continuously in the idle app.

**Throughput:**

| benchmark | before | after | speedup |
|---|---|---|---|
| `parseKeybinding`, 162,000 calls | 28.6 ms | 3.1 ms | **9.2x** |
| full label computation, 248,000 labels | 135.2 ms | 33.6 ms | **4.0x** |

Per label that is 0.545 µs → 0.135 µs; per parse, 0.177 µs → 0.019 µs. The residual cost on the "after" label path is the cache key construction and lookup, not any parsing.

**Regression-test evidence.** Both new test files were confirmed to fail on the unmodified code:

- Reverting the three source files: **5 failures** — `reuses the parsed result for a repeated binding string`, `never hands out an entry a caller can corrupt`, `computes a label once no matter how many times it is asked for`, `memoizes each label shape separately…`, `does not recompute the label on re-render`.
- Deliberately breaking *only* the invalidation key (making the cache ignore the overrides object): **3 failures**, including `shows an edited keybinding immediately, with no stale-cache window`. This is the specific check that a stale-cache bug cannot pass.

## Negative user-facing trade-offs

**None.** Point by point:

- **Is there a staleness window when a keybinding is edited?** No. The cache is keyed on the identity of the overrides object itself. A Settings edit calls `setKeybindingOverride`, which sets `keybindings` to a brand-new object from the IPC response, so the very first label lookup after the edit hits a cache that has never existed and computes fresh. There is no TTL, no revision counter, and no "clear the cache" step that could be forgotten — invalidation is structural. The test `shows an edited keybinding immediately, with no stale-cache window` drives a real render through four consecutive edits (rebind, rebind again, disable, then revert to the original binding) and asserts the DOM text after each. The revert step specifically proves an old object's entry cannot be resurrected.
- **Do labels render identically?** Yes. No formatting logic changed; the object literals were moved, not edited. The Mac vs Windows/Linux glyph branch is untouched, and existing coverage in `keybindings-parsing.test.ts` already pins `⌘⇧⌫` vs `Ctrl+Shift+Backspace`. A new test formats every default binding of all 124 actions on both `darwin` and `win32`.
- **Can the cache grow without bound?** No. The label cache is a `WeakMap` keyed on overrides objects — entries die with the object they belong to, and each holds at most (4 label shapes × 124 actions). The parse cache is capped at 512 entries and clears wholesale on overflow, with a test that feeds it 2,000 distinct strings and asserts correct results afterwards.
- **Can a caller corrupt a shared cached value?** For `parseKeybinding`, no: results are frozen, and I audited every consumer — the only writes to `ParsedKeybinding` fields are inside `parser.ts` on locally-constructed objects, and every external caller spread-copies (`{ ...parsed, key: digit }`) before changing anything. For `formatShortcutKeyComboDetails` the returned array is now shared rather than rebuilt per render; all six call sites are read-only (`.map`, `.slice`, `.length`), which is noted in a comment.
- **Does stable array identity change any behavior?** Only for the better. `formatShortcutKeyComboDetails` previously returned a new array on every render, so any downstream `useMemo`/`useEffect` depending on it re-ran every render. It is now stable, which strictly reduces work; no consumer depends on the identity changing.
- **Does anything change on the keydown path?** Only favorably. `keybindingMatchesInput` parses the binding string for every candidate on every keystroke; those parses are now cache hits. Behavior is identical.

## Skipped

Item 5 of the brief — hoisting the two `SortableTabContextMenu` split labels up to the tab-strip parent — is **deliberately skipped**. It would mean threading two new props through `SortableTab` (which does not otherwise care about shortcut labels) purely as a pass-through to `SortableTabContextMenu`, widening a component API for no remaining gain: with the label cache in place, the per-tab cost is now a `WeakMap` + `Map` lookup rather than two keybinding parses. The amplifier is removed by the cache, not by the plumbing.

## Test plan

- `pnpm tc` — clean
- `npx oxlint` on all 5 changed files — clean
- `npx vitest run --config config/vitest.config.ts src/shared/keybindings src/renderer/src/hooks src/renderer/src/components/settings` — 323 files / 2132 tests passed
- `npx vitest run --config config/vitest.config.ts src/shared/keybindings src/renderer/src/components/settings src/renderer/src/hooks/shortcut-label-cache.test.tsx` — 178 files / 1192 tests passed
- Downstream consumers (`tab-bar`, `terminal-pane`, `feature-tips`, `sidebar`) also run. A handful of `useIpcEvents`/`automations`/`BrowserTab` tests intermittently hit the 30s timeout on this machine; those were confirmed to fail identically on a clean checkout of `main` with this branch's changes reverted, and are unrelated to keybindings.
