### PR TITLE
perf(remote): apply the no-evidence inspection cadence to remote panes (30 -> 4 host round trips/min/idle pane)

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -46,10 +46,10 @@ export type AgentCompletionCoordinatorOptions = {
   // this renderer CONSUMES that evidence and can tell "no evidence published"
   // from "host too old to publish it" — mixed-version hosts omit the field.
   shouldPollNoEvidenceProcessCadence?: () => boolean
-  // Why: on hosts where one inspection forks a whole-process-table scan (local
-  // Windows PowerShell/CIM), panes without agent evidence relax to a slow
-  // cadence; remote authorities can disable no-evidence polling entirely and
-  // re-arm from output/title activity instead.
+  // Why: where one inspection is a whole-process-table scan (local Windows
+  // PowerShell/CIM) or a host round trip plus a host-side scan (remote/SSH),
+  // panes without agent evidence relax to a slow cadence and re-arm from
+  // output/title/hook activity. See agent-process-inspection-cost.ts.
   isProcessInspectionCostly?: () => boolean
   shouldSuppressHookCompletion?: (payload: AgentCompletionStatusSnapshot) => boolean
 }

--- a/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
@@ -1,19 +1,26 @@
 // Regression guard: bound the volume of cadence process inspections a visible,
 // idle terminal with NO agent evidence drives on hosts where each inspection is
-// a whole-process-table scan (local Windows forks powershell.exe/CIM — the
-// scan-cost analogue of #6288). Pre-fix a single visible idle shell inspected
-// every 2s forever (~30 scans/min); with the no-evidence tier it inspects every
-// 15s, and pane activity (output/title/hook) or agent evidence re-arms the hot
-// cadence so agent-start detection stays event-driven and agent-finish
-// detection is unchanged.
+// expensive — local Windows forks a powershell.exe/CIM whole-process-table scan
+// (the scan-cost analogue of #6288), and a remote/SSH pane pays a host round
+// trip plus a host-side foreground scan. Pre-fix a single visible idle shell
+// inspected every 2s forever (~30 scans/min); with the no-evidence tier it
+// inspects every 15s, and pane activity (output/title/hook) or agent evidence
+// re-arms the hot cadence so agent-start detection stays event-driven and
+// agent-finish detection is unchanged.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createAgentCompletionCoordinator,
   resetAgentCompletionCoordinatorIdentitiesForTest
 } from './agent-completion-coordinator'
 import { resetAgentProcessInspectionQueueForTests } from './agent-process-inspection-queue'
+import { isAgentProcessInspectionCostly } from './agent-process-inspection-cost'
+import { toRemoteRuntimePtyId } from '../../../../shared/remote-runtime-pty-id'
+import { toAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
 import type { AgentCompletionCoordinatorOptions } from './agent-completion-coordinator-types'
+
+const MAC_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+const WINDOWS_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
 
 function processResult(
   foregroundProcess: string | null,
@@ -67,6 +74,43 @@ describe('agent completion no-evidence inspection cadence', () => {
     expect(inspectProcess).toHaveBeenCalledTimes(4)
   })
 
+  it('bounds a visible idle remote pane through the shipped cost predicate', async () => {
+    // Why: a remote inspection is an RPC round trip to the execution host plus a
+    // host-side foreground scan — the costliest inspection shape here — yet it
+    // was excluded from the no-evidence tier on every client platform.
+    const sshPtyId = toAppSshPtyId('target-1', 'pty-1')
+    const inspectProcess = vi.fn(async () => processResult(null, false))
+    const { coordinator } = createCoordinator(inspectProcess, {
+      getPtyId: () => sshPtyId,
+      isProcessInspectionCostly: () => isAgentProcessInspectionCostly(MAC_UA, sshPtyId)
+    })
+
+    coordinator.startProcessTracking()
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    // 60s / 15s = 4 host round trips. Pre-fix (2s idle cadence) this was 30.
+    expect(inspectProcess).toHaveBeenCalledTimes(4)
+  })
+
+  it('re-arms the remote pane to the 2s cadence on the first byte of PTY output', async () => {
+    // Why: agent-start detection on a remote pane must stay event-driven, not
+    // wait out the relaxed interval.
+    const runtimePtyId = toRemoteRuntimePtyId('term_1', 'env-a')
+    const inspectProcess = vi.fn(async () => processResult(null, false))
+    const { coordinator } = createCoordinator(inspectProcess, {
+      getPtyId: () => runtimePtyId,
+      isProcessInspectionCostly: () => isAgentProcessInspectionCostly(MAC_UA, runtimePtyId)
+    })
+
+    coordinator.startProcessTracking()
+    await vi.advanceTimersByTimeAsync(14_000)
+    expect(inspectProcess).not.toHaveBeenCalled()
+
+    coordinator.observeOutputActivity()
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(inspectProcess).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps the full 2s idle cadence on hosts where inspection is cheap', async () => {
     const inspectProcess = vi.fn(async () => processResult(null, false))
     const { coordinator } = createCoordinator(inspectProcess, {
@@ -76,7 +120,7 @@ describe('agent completion no-evidence inspection cadence', () => {
     coordinator.startProcessTracking()
     await vi.advanceTimersByTimeAsync(60_000)
 
-    // 60s / 2s = 30: POSIX/SSH/remote panes must not be relaxed.
+    // 60s / 2s = 30: local POSIX panes (cheap `ps`) must not be relaxed.
     expect(inspectProcess).toHaveBeenCalledTimes(30)
   })
 
@@ -273,5 +317,32 @@ describe('agent completion no-evidence inspection cadence', () => {
       quietedHookDone: false,
       terminalIdleConfirmed: true
     })
+  })
+})
+
+describe('isAgentProcessInspectionCostly', () => {
+  it('treats remote-execution-host ptys as costly on every client platform', () => {
+    for (const userAgent of [MAC_UA, WINDOWS_UA]) {
+      expect(isAgentProcessInspectionCostly(userAgent, toAppSshPtyId('target-1', 'pty-1'))).toBe(
+        true
+      )
+      expect(
+        isAgentProcessInspectionCostly(userAgent, toRemoteRuntimePtyId('term_1', 'env-a'))
+      ).toBe(true)
+      expect(isAgentProcessInspectionCostly(userAgent, toRemoteRuntimePtyId('term_1'))).toBe(true)
+    }
+  })
+
+  it('leaves the local branch unchanged: Windows costly, POSIX cheap', () => {
+    expect(isAgentProcessInspectionCostly(WINDOWS_UA, 'worktree-1|pane-1')).toBe(true)
+    expect(isAgentProcessInspectionCostly(WINDOWS_UA, null)).toBe(false)
+    expect(isAgentProcessInspectionCostly(MAC_UA, 'worktree-1|pane-1')).toBe(false)
+    expect(isAgentProcessInspectionCostly(MAC_UA, null)).toBe(false)
+  })
+
+  // Why: a bare "ssh:" id names no connection, so it is not evidence the
+  // inspection crosses a link (see remote-execution-host-pty.test.ts).
+  it('does not relax a POSIX pane for an ssh-prefixed id carrying no relay pty id', () => {
+    expect(isAgentProcessInspectionCostly(MAC_UA, 'ssh:target-1')).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/agent-process-inspection-cost.ts
+++ b/src/renderer/src/components/terminal-pane/agent-process-inspection-cost.ts
@@ -1,0 +1,27 @@
+import { isRemoteExecutionHostPtyId } from './remote-execution-host-pty'
+
+/**
+ * Whether one cadence process inspection for this pane is expensive enough that
+ * a pane with no agent evidence should relax to the `no-evidence` tier.
+ *
+ * Why remote first: a remote inspection is a `terminal.inspectProcess` /
+ * `pty.inspectProcess` round trip to the execution host plus a host-side
+ * foreground scan there — the costliest shape in this codebase, on every client
+ * platform. Local Windows is costly for a different reason: it forks a
+ * powershell.exe whole-process-table CIM scan per poll (~10-40x POSIX `ps`).
+ * Local POSIX (and daemon/WSL panes on it) stays on the full cadence.
+ *
+ * Relaxing is the interim measure: once this renderer consumes the batched
+ * foreground evidence direct-SSH/remote authorities already publish with their
+ * PTY inventory (#17525), those panes can drop to `shouldPollNoEvidenceProcessCadence`
+ * and stop scheduling idle host reads altogether.
+ */
+export function isAgentProcessInspectionCostly(userAgent: string, ptyId: string | null): boolean {
+  if (ptyId !== null && isRemoteExecutionHostPtyId(ptyId)) {
+    return true
+  }
+  if (!userAgent.includes('Windows')) {
+    return false
+  }
+  return ptyId !== null
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
@@ -11,7 +11,7 @@ import { resolveCompatibleAgentTypeForOwner } from '../../../../../shared/agent-
 import { registerTerminalSideEffectFactConsumer } from '../terminal-side-effect-facts-handler'
 
 import { isAgentTaskCompleteTrackingEnabled } from './agent-task-complete-settings'
-import { isRemoteExecutionHostPtyId } from '../remote-execution-host-pty'
+import { isAgentProcessInspectionCostly } from '../agent-process-inspection-cost'
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
@@ -229,17 +229,8 @@ export function installTerminalKeydownFit(session: ConnectPanePtySession): void 
       }),
     shouldPollProcessCadence: () =>
       isAgentTaskCompleteTrackingEnabled() && session.deps.isVisibleRef.current,
-    isProcessInspectionCostly: () => {
-      // Why: local Windows inspection forks a powershell.exe whole-process-table
-      // CIM scan per poll (~10-40x heavier than POSIX `ps`). Keep the no-evidence
-      // cadence enabled until inventory evidence is consumed by this renderer;
-      // mixed-version relays may omit the optional field.
-      if (!navigator.userAgent.includes('Windows')) {
-        return false
-      }
-      const ptyId = session.transport.getPtyId()
-      return ptyId !== null && !isRemoteExecutionHostPtyId(ptyId)
-    },
+    isProcessInspectionCostly: () =>
+      isAgentProcessInspectionCostly(navigator.userAgent, session.transport.getPtyId()),
     isLive: () => {
       if (session.disposed) {
         return false


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

## ELI5

If you have a terminal open on a remote machine (SSH or a paired runtime) and you have never run an agent in it, Orca was asking that machine **"what are you running right now?" every 2 seconds, forever** — and getting **"nothing"** every single time. That question is a network round trip plus a process scan on the far end. This PR makes Orca ask every 15 seconds instead, and go straight back to every 2 seconds the instant the terminal does anything at all.

## The finding

`currentPollTier()` (`agent-completion-process-monitor.ts:211-229`) only returns the `no-evidence` tier when `options.isProcessInspectionCostly?.() === true`. That callback was, effectively:

```ts
if (!navigator.userAgent.includes('Windows')) return false
const ptyId = session.transport.getPtyId()
return ptyId !== null && !isRemoteExecutionHostPtyId(ptyId)   // remote explicitly EXCLUDED
```

So "costly" meant *local Windows only*, and a remote-execution-host PTY was the one shape deliberately excluded — even though a remote inspection is the most expensive inspection in the codebase:

- paired runtime: `inspectRuntimeTerminalProcess` -> `terminal.inspectProcess` RPC, `timeoutMs: 15_000` (`src/renderer/src/runtime/runtime-terminal-inspection.ts:115-142`)
- direct SSH: `window.api.pty.inspectProcess` -> main -> SSH-mux `pty.inspectProcess` (`src/main/providers/ssh-pty-provider.ts:282-283`), which on the relay runs `getForegroundProcessName(pid)` + `processHasChildren(pid)` per call (`src/relay/pty-handler.ts:2378-2395`)

There is no cache anywhere on that path (`inspectPtyProviderProcess` calls straight through).

The intent is stated verbatim at the top of `agent-completion-no-evidence-cadence.test.ts`: *"bound the volume of cadence process inspections a visible, idle terminal with NO agent evidence drives on hosts where each inspection is a whole-process-table scan."* Remote hosts fit that description; the predicate just did not cover them.

### Why the exclusion existed, and why it can go now

`#17525` (`feat(ssh): batch process evidence in PTY inventory`) built the host side of the real endgame — direct-SSH/remote authorities now publish batched foreground evidence with their PTY inventory — and added `shouldPollNoEvidenceProcessCadence` so those panes can eventually go fully **push-driven (zero idle host reads)**. That producer is intentionally not wired yet, because this renderer does not consume the inventory evidence and cannot tell "no evidence published" from "host too old to publish it". The comment that shipped with it (`Keep the no-evidence cadence enabled until inventory evidence is consumed by this renderer`) was about *that* pending work, and left remote panes at the full 2s cadence in the meantime.

This PR is the interim measure that does not depend on the inventory work: **2s -> 15s now**, and `shouldPollNoEvidenceProcessCadence` still lands later for **15s -> 0**. The two compose: when a producer is wired, `shouldRunCadenceInspection()` returns false and no timer is armed at all, so `isProcessInspectionCostly` becomes moot in that state.

## The change

`isProcessInspectionCostly` moves to `src/renderer/src/components/terminal-pane/agent-process-inspection-cost.ts` (so it is unit-testable without a full pane session) and gains one leading branch:

```ts
if (ptyId !== null && isRemoteExecutionHostPtyId(ptyId)) return true
if (!userAgent.includes('Windows')) return false
return ptyId !== null
```

The local branch is byte-identical. Nothing else in the monitor, the cadence table, or the wire changed.

## Measurements

Deterministic counts from `agent-completion-no-evidence-cadence.test.ts` with `Math.random` pinned to `0.5` (which makes the ±10% jitter factor exactly 1.0), over a 60s window. On a remote pane **one inspection == one RPC round trip to the execution host**.

| Pane state | Tier before | Tier after | Inspections/min before | after |
| --- | --- | --- | --- | --- |
| **Visible remote, no agent evidence, no activity for >10s** | `idle` 2000ms | **`no-evidence` 15000ms** | **30** | **4** |
| Visible remote, within 10s of output/title/hook activity | `idle` 2000ms | `idle` 2000ms | 30 | 30 |
| Visible remote, agent evidence, no foreground agent | `idle` 2000ms | `idle` 2000ms | 30 | 30 |
| Visible remote, recognized agent in foreground | `active` 750ms | `active` 750ms | ~78 | ~78 |
| Visible remote, inspections erroring | error backoff (>=10s, capped at tier) | same, floor 15s | 4 | 4 |
| Hidden remote, no agent evidence | not armed at all | not armed at all | 0 | 0 |
| Local POSIX (any PTY) | `idle` 2000ms | `idle` 2000ms | 30 | 30 |
| Local Windows, no evidence, idle | `no-evidence` 15000ms | `no-evidence` 15000ms | 4 | 4 |

**Net: 30 -> 4 host round trips per minute per idle remote pane (-26/min, -87%).** Decay is measured too: after one output byte a remote pane runs 5 inspections in the 10s hot window, then only 3 more over the following 45s.

For scale, the global inspection queue caps at `MAX_INSPECTION_STARTS_PER_SECOND = 8` / `MAX_CONCURRENT_INSPECTIONS = 4` (`agent-process-inspection-queue.ts`), so before this change ~16 visible idle remote panes were enough to start contending for that budget with the inspections that actually matter.

## Negative user-facing trade-offs

This is **not** a strictly zero-behavior-change fix, and it should not be sold as one. It applies to remote hosts the same trade already shipped for local Windows.

**The change:** a remote pane with `hasAgentRunEvidence === false` **AND** `lastForegroundAgent === null` **AND** no pane activity in the last `NO_EVIDENCE_ACTIVITY_HOT_WINDOW_MS` (10s) polls every 15s instead of every 2s. That is the entire blast radius — every other state keeps its previous tier (see the table above).

Point by point, why no user-observable detection is delayed:

1. **Agent *start* stays event-driven, not 15s-delayed.** `recordActivity()` (`agent-completion-process-monitor.ts:265-270`) re-arms immediately and specifically clears a `no-evidence` timer mid-interval (`state.pollTimerTier === 'no-evidence'` -> `clearPollTimer` in `scheduleNextPoll`). Every live PTY byte calls it (`live-data-callback.ts:38`), as does every title change (`title-spawn-bell.ts:55`) and every hook status (`agent-completion-hook-observer.ts:76`). A starting agent always prints; the covering test asserts that at t=14s of a 15s interval, one output byte produces an inspection 2s later. Deferred reattach chunks re-enter the same `dataCallback`, so they re-arm too.
2. **Agent *finish* detection and completion notifications are bit-for-bit unchanged.** Once `establishAgentEvidence()` runs, `currentPollTier()` returns `active` (750ms, foreground agent present) or `idle` (2000ms, evidence without a foreground agent) and never reaches the `no-evidence` branch. The two-consecutive-idle-samples process-exit confirmation, `pendingProcessExitAgent`, and both suppression hooks are untouched. Covered by the existing "keeps a recognized agent on the full active cadence" and "still detects an unannounced agent exit promptly after escalating from the relaxed tier" tests.
3. **Hook-driven completion never touches this path.** `hasPendingHookDone()` short-circuits `handleInspectionResult` before any tier decision, and hook-only coordinators never call `startProcessTracking()` at all — the existing "keeps cadence disarmed and the done quiet window intact when tracking never starts" test pins that.
4. **Transport failure behaves exactly as before.** The `result.unavailable === true` branch (`agent-completion-process-monitor.ts:71-76`) and the `consecutiveInspectionErrors` backoff are unmodified: an unreachable host still yields the same non-committal outcome and never an exit claim. The backoff ceiling (`Math.min(Math.max(10_000, base), base * 2 ** n)`) already cannot undercut the 15s tier, so erroring remote scans do not start polling *more* often than healthy ones.
5. **`live` / `unverifiable` / `exited` is not involved.** Nothing here produces or consumes an `UnstoppedPtyVerdict`. Confirmed: this path's only outputs are internal coordinator state and `dispatchCompletion(...)` (a notification), and a failed/absent inspection results in *no* claim rather than a downgraded one. Per `docs/reference/ssh-execution-boundary.md`, loss of contact remains `unverifiable` by construction — this PR does not add a new way to infer death from silence, it only asks a live host less often.
6. **No wire change.** No new RPC param, no new field, no new stream opcode, nothing capability-negotiated. Purely a client-side timer choice, so mixed client/host versions are unaffected.

**The one honest residual, stated plainly:** the very first cadence inspection after a *silent* reattach moves from ~2s to ~15s. Reattach replay/snapshot is painted through the connect result, not through `dataCallback`, so `lastPaneActivityAt` can still be `null` right after a restore. Consequence: on an Orca restart with a remote agent that is running but printing nothing, the coordinator arms its process-exit detector up to ~13s later. Nothing user-visible is fed by that inspection (`establishAgentEvidence()` sets internal state only — the pane's agent badge comes from hooks and titles, and the foreground-agent *tracker* is disabled for remote PTYs anyway at `pane-agent-identity.ts:129-131`). To actually lose a notification you would need that agent to also exit inside the same 15s window with no output, no title change, and no done hook — and its exit returns a shell prompt, which is output. Local Windows has shipped with this identical window since the tier was introduced.

If a follow-up wants that window closed too, the clean fix is to record pane activity on reattach paint, not to keep the 2s cadence.

## Reliability contract

- **Invariant:** relaxing the no-evidence cadence must not change any completion outcome — only the timing of inspections that return no agent.
- **Failure source:** `#6288`-shaped inspection volume, applied to the remote round-trip shape that `#17525` documented but left on the full cadence.
- **Oracle:** deterministic inspection counts per state under fake timers with jitter pinned, plus the existing exit/notification assertions that must remain unchanged.
- **Gate:** extends the incumbent `agent-completion-no-evidence-cadence.test.ts` regression guard. That file is not referenced by `config/reliability-gates.jsonc` today (pre-existing gap, unchanged here); the adjacent `agent-session.remote-host-authority` gate's cadence tests were run and pass.
- **Provider/platform coverage:** direct SSH + paired runtime **covered** (both id shapes asserted); local POSIX, local Windows, daemon, WSL **unaffected** (predicate asserted byte-identical); mobile/relay **unaffected** (no wire change).
- **Performance budget:** no polling, timers, listeners, subprocesses, or scans added; one timer interval increased. Counts above.
- **Diagnostics:** none added — the tier is already inferable from `state.pollTimerTier`.

## Tests

Added to `agent-completion-no-evidence-cadence.test.ts` (extended, not a new file):

- `bounds a visible idle remote pane through the shipped cost predicate` — SSH pty id through the real predicate: 4 round trips in 60s (was 30).
- `re-arms the remote pane to the 2s cadence on the first byte of PTY output` — paired-runtime pty id, output at t=14s produces an inspection at t=16s.
- `isAgentProcessInspectionCostly` unit block — remote costly on both Mac and Windows UAs across all three remote id shapes; local branch unchanged (Windows costly, POSIX cheap, null cheap); a bare `ssh:target-1` with no relay pty id does **not** relax a POSIX pane.

## Verification

- `pnpm tc` — clean.
- `npx oxlint <changed files>` — clean. `npx oxfmt --check` — clean.
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane` — the target file is 19/19 green. The suite has pre-existing load-related timeout flake on this machine (~10 agents running vitest concurrently): a clean-tree baseline run of the same directory failed 19 tests across 12 files, all `Test timed out in 30000ms` in `remote-runtime-pty-transport-*` / `remote-runtime-outage-*` / `pty-connection-*`. Every file that failed in the with-change run and not in the baseline was re-run in isolation and passes.
- Also green: `agent-completion-coordinator-process-cadence`, `agent-completion-coordinator-pending-title-inspection`, `remote-execution-host-pty`, `pty-connection-task-complete-dispatch`.
