### PR TITLE
perf(main): share one process-table index per capture across agent panes

### DIFF
--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -1,7 +1,9 @@
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
 import { resolveOuterWrapperForegroundProcess } from '../../shared/foreground-wrapper-agent'
 import {
+  collectProcessTreeDescendants,
   getFreshProcessTableSnapshot,
+  getProcessTableIndex,
   getProcessTableSnapshot,
   type ProcessTableRow
 } from '../../shared/process-table-snapshot'
@@ -43,29 +45,6 @@ type ShellForegroundConfirmationOptions = {
     | Promise<ReadonlySet<number> | null>
 }
 
-function collectDescendants<Row extends { pid: number; ppid: number }>(
-  rows: Row[],
-  rootPid: number
-): (Row & { depth: number })[] {
-  const childrenByParent = new Map<number, Row[]>()
-  for (const row of rows) {
-    const children = childrenByParent.get(row.ppid) ?? []
-    children.push(row)
-    childrenByParent.set(row.ppid, children)
-  }
-
-  const descendants: (Row & { depth: number })[] = []
-  const stack = (childrenByParent.get(rootPid) ?? []).map((row) => ({ row, depth: 1 }))
-  while (stack.length > 0) {
-    const { row, depth } = stack.pop()!
-    descendants.push({ ...row, depth })
-    for (const child of childrenByParent.get(row.pid) ?? []) {
-      stack.push({ row: child, depth: depth + 1 })
-    }
-  }
-  return descendants
-}
-
 function commandExecutable(command: string): string {
   const trimmed = command.trim().replace(/^[-]/, '')
   if (trimmed.startsWith('"') || trimmed.startsWith("'")) {
@@ -97,12 +76,12 @@ export async function confirmShellForegroundProcess(
     }
   }
   try {
-    const rows = await getFreshProcessTableSnapshot()
-    if (!rows.some((row) => row.pid === shellPid)) {
+    const index = getProcessTableIndex(await getFreshProcessTableSnapshot())
+    const root = index.byPid.get(shellPid)
+    if (!root) {
       return false
     }
-    const root = rows.find((row) => row.pid === shellPid)!
-    const tree = [{ ...root, depth: 0 }, ...collectDescendants(rows, shellPid)]
+    const tree = [{ ...root, depth: 0 }, ...collectProcessTreeDescendants(index, shellPid)]
     const spawnedShellBasename = executableBasename(spawnedShellProcess)
     const foregroundShell = tree
       .filter(
@@ -172,7 +151,7 @@ export async function resolveAgentForegroundProcessWithAvailability(
     const rows = options.fresh
       ? await getFreshProcessTableSnapshot()
       : await getProcessTableSnapshot()
-    if (options.fresh && !rows.some((row) => row.pid === shellPid)) {
+    if (options.fresh && !getProcessTableIndex(rows).byPid.has(shellPid)) {
       return { available: false, processName: fallbackProcess }
     }
     return {
@@ -189,8 +168,9 @@ export function resolveAgentForegroundProcessFromPs(
   rows: ProcessTableRow[],
   shellPid: number
 ): string | null {
-  const shellRow = rows.find((row) => row.pid === shellPid)
-  const candidates = collectDescendants(rows, shellPid)
+  const index = getProcessTableIndex(rows)
+  const shellRow = index.byPid.get(shellPid)
+  const candidates = collectProcessTreeDescendants(index, shellPid)
   // Why: `+` in `ps stat` marks the process holding the terminal foreground.
   // The root shell can hold it after Ctrl-Z, so use the whole PTY tree as the
   // foreground gate; otherwise a stopped agent child still masquerades as live.

--- a/src/main/providers/agent-foreground-shared-process-table-index.test.ts
+++ b/src/main/providers/agent-foreground-shared-process-table-index.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+
+vi.mock('child_process', () => ({ execFile: execFileMock }))
+
+import {
+  collectProcessTreeDescendants,
+  getProcessTableIndex,
+  getProcessTableSnapshot,
+  parseProcessTableRows,
+  resetProcessTableSnapshotForTests,
+  type ProcessTableRow
+} from '../../shared/process-table-snapshot'
+import { resolveAgentForegroundProcess } from './agent-foreground-process'
+
+/**
+ * The shape this change replaced: every pane rebuilt a parent map over the
+ * whole table and linearly scanned it for its own root. Kept as the oracle so
+ * the new index has to return byte-identical rows, in the same order.
+ */
+function collectDescendantsPerCall(
+  rows: readonly ProcessTableRow[],
+  rootPid: number
+): (ProcessTableRow & { depth: number })[] {
+  const childrenByParent = new Map<number, ProcessTableRow[]>()
+  for (const row of rows) {
+    const children = childrenByParent.get(row.ppid) ?? []
+    children.push(row)
+    childrenByParent.set(row.ppid, children)
+  }
+  const descendants: (ProcessTableRow & { depth: number })[] = []
+  const stack = (childrenByParent.get(rootPid) ?? []).map((row) => ({
+    row,
+    depth: 1
+  }))
+  while (stack.length > 0) {
+    const { row, depth } = stack.pop()!
+    descendants.push({ ...row, depth })
+    for (const child of childrenByParent.get(row.pid) ?? []) {
+      stack.push({ row: child, depth: depth + 1 })
+    }
+  }
+  return descendants
+}
+
+/** Counts every whole-table traversal, however it is spelled. */
+const WHOLE_TABLE_WALKS = new Set<string | symbol>([
+  Symbol.iterator,
+  'find',
+  'some',
+  'filter',
+  'map',
+  'forEach',
+  'reduce'
+])
+
+function countingTable(rows: ProcessTableRow[]): {
+  rows: ProcessTableRow[]
+  walks: () => number
+} {
+  let walks = 0
+  const proxy = new Proxy(rows, {
+    get(target, property, receiver) {
+      if (WHOLE_TABLE_WALKS.has(property)) {
+        walks += 1
+      }
+      return Reflect.get(target, property, receiver) as unknown
+    }
+  })
+  return { rows: proxy, walks: () => walks }
+}
+
+/** 15 shell panes, each with an agent child, plus unrelated system processes. */
+function buildFleetTable(paneCount: number): string {
+  const lines = ['1 0 Ss /sbin/launchd', '50 1 Ss /usr/libexec/loginwindow']
+  for (let pane = 0; pane < paneCount; pane += 1) {
+    const shellPid = 1000 + pane * 10
+    lines.push(`${shellPid} 1 Ss /bin/zsh`)
+    lines.push(`${shellPid + 1} ${shellPid} S+ node /Users/dev/.local/bin/claude`)
+    lines.push(`${shellPid + 2} ${shellPid + 1} S+ /usr/bin/rg --files`)
+  }
+  for (let filler = 0; filler < 200; filler += 1) {
+    lines.push(`${90000 + filler} 1 S /usr/sbin/filler${filler}`)
+  }
+  return lines.join('\n')
+}
+
+const PANE_COUNT = 15
+const PANE_PIDS = Array.from({ length: PANE_COUNT }, (_, pane) => 1000 + pane * 10)
+
+describe('shared process-table index across agent panes', () => {
+  it('walks one capture once for a whole fleet instead of once per pane', () => {
+    const parsed = parseProcessTableRows(buildFleetTable(PANE_COUNT))
+
+    const perCall = countingTable(parsed.slice())
+    for (const shellPid of PANE_PIDS) {
+      perCall.rows.find((row) => row.pid === shellPid)
+      collectDescendantsPerCall(perCall.rows, shellPid)
+    }
+
+    const shared = countingTable(parsed.slice())
+    for (const shellPid of PANE_PIDS) {
+      const index = getProcessTableIndex(shared.rows)
+      index.byPid.get(shellPid)
+      collectProcessTreeDescendants(index, shellPid)
+    }
+
+    // Two walks per pane before (the `find` plus the parent-map build), one for
+    // the whole capture after, no matter how many panes share it.
+    expect(perCall.walks()).toBe(PANE_COUNT * 2)
+    expect(shared.walks()).toBe(1)
+  })
+
+  it('returns the same descendants, in the same order, as the per-call walk', () => {
+    const rows = parseProcessTableRows(
+      [
+        buildFleetTable(3),
+        // An orphan and a repeated pid: malformed shapes a real table can carry.
+        // (A ppid cycle hangs both walks identically and is out of scope here.)
+        '7000 6999 S orphaned-child',
+        '1001 1000 S duplicate-pid-row'
+      ].join('\n')
+    )
+    const index = getProcessTableIndex(rows)
+
+    for (const rootPid of [...PANE_PIDS.slice(0, 3), 1, 1001, 6999, 424242]) {
+      expect(collectProcessTreeDescendants(index, rootPid)).toEqual(
+        collectDescendantsPerCall(rows, rootPid)
+      )
+    }
+  })
+})
+
+describe('agent foreground resolution over a shared capture', () => {
+  let platform: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetProcessTableSnapshotForTests()
+    platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'darwin'
+    })
+  })
+
+  afterEach(() => {
+    if (platform) {
+      Object.defineProperty(process, 'platform', platform)
+    }
+  })
+
+  it('answers every pane identically off a single ps capture', async () => {
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, callback: unknown) => {
+        ;(callback as (err: unknown, out: { stdout: string; stderr: string }) => void)(null, {
+          stdout: buildFleetTable(PANE_COUNT),
+          stderr: ''
+        })
+      }
+    )
+
+    const resolved = await Promise.all(
+      PANE_PIDS.map((shellPid) => resolveAgentForegroundProcess(shellPid, 'zsh'))
+    )
+
+    expect(resolved).toEqual(Array.from({ length: PANE_COUNT }, () => 'claude'))
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+  })
+
+  // Red/green for the wiring itself: poison the capture's shared index and the
+  // resolver must see the poisoned view. A resolver that rebuilt its own parent
+  // map per pane would still answer 'claude' here.
+  it('resolves off the capture-scoped index rather than rebuilding one per pane', async () => {
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, callback: unknown) => {
+        ;(callback as (err: unknown, out: { stdout: string; stderr: string }) => void)(null, {
+          stdout: buildFleetTable(1),
+          stderr: ''
+        })
+      }
+    )
+
+    const rows = await getProcessTableSnapshot()
+    const index = getProcessTableIndex(rows)
+    expect(await resolveAgentForegroundProcess(1000, 'zsh')).toBe('claude')
+    ;(index.childrenByPpid as Map<number, ProcessTableRow[]>).delete(1000)
+
+    expect(await resolveAgentForegroundProcess(1000, 'zsh')).toBe('zsh')
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -14,6 +14,7 @@ const getAllProcessesMock = vi.fn()
 
 import { __setWindowsProcessTreeLoaderForTests } from '../windows/windows-process-table'
 import {
+  queryWindowsPaneProcessInventory,
   queryWindowsProcessDescendants,
   queryWindowsProcessRowsFresh,
   resetWindowsProcessRowsSnapshotForTests
@@ -107,6 +108,38 @@ describe('windows process rows', () => {
 
     expect(scanCount()).toBe(1)
     expect(rows[31]?.map((row) => row.pid)).toEqual([process.pid, 100, 200])
+  })
+
+  it('projects and indexes a capture once, however many panes inspect it', async () => {
+    // Every agent pane inspects on its own cadence but shares the TTL-cached
+    // table underneath. Identical row objects prove the projection ran once;
+    // before, each pane re-allocated the whole table plus its own parent map.
+    resetWindowsProcessRowsSnapshotForTests()
+
+    const first = await queryWindowsPaneProcessInventory(100, { anchorPid: 200 })
+    const second = await queryWindowsPaneProcessInventory(100, { anchorPid: 200 })
+
+    expect(scanCount()).toBe(1)
+    expect(second?.anchorRow).toBe(first?.anchorRow)
+    expect(first?.anchorRow).toEqual({
+      pid: 200,
+      ppid: 100,
+      name: 'node.exe',
+      command: NATIVE_ROWS[1]!.commandLine
+    })
+    expect(second?.candidates).toEqual(first?.candidates)
+    expect(second?.candidates).toEqual([
+      { pid: 200, ppid: 100, name: 'node.exe', command: NATIVE_ROWS[1]!.commandLine, depth: 1 }
+    ])
+  })
+
+  it('re-projects a fresh capture instead of serving the memoized one', async () => {
+    const cached = await queryWindowsPaneProcessInventory(100, { anchorPid: 200 })
+    resetWindowsProcessRowsSnapshotForTests()
+    const refreshed = await queryWindowsPaneProcessInventory(100, { anchorPid: 200 })
+
+    expect(refreshed?.anchorRow).not.toBe(cached?.anchorRow)
+    expect(refreshed?.anchorRow).toEqual(cached?.anchorRow)
   })
 
   it('never answers from the TTL cache, which can predate the recycle it detects', async () => {

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -1,3 +1,4 @@
+import { collectProcessTreeDescendants } from '../../shared/process-table-snapshot'
 import {
   readWindowsProcessTable,
   readWindowsProcessTableFresh,
@@ -25,6 +26,51 @@ function toProcessRow(row: NativeWindowsProcessRow): WindowsProcessRow {
   }
 }
 
+type WindowsProcessTableIndex = {
+  rows: readonly WindowsProcessRow[]
+  byPid: ReadonlyMap<number, WindowsProcessRow>
+  childrenByPpid: ReadonlyMap<number, readonly WindowsProcessRow[]>
+}
+
+const windowsProcessTableIndexes = new WeakMap<
+  readonly NativeWindowsProcessRow[],
+  WindowsProcessTableIndex
+>()
+
+/**
+ * Project and index one native capture once, keyed weakly by the capture so the
+ * index dies with it. Every agent pane inspects on its own cadence but shares
+ * the TTL-cached table underneath, and each used to re-allocate the whole
+ * projection plus a parent map before finding its own root.
+ *
+ * Rows are shared, so treat them as read-only.
+ */
+function indexWindowsProcessTable(
+  native: readonly NativeWindowsProcessRow[]
+): WindowsProcessTableIndex {
+  const cached = windowsProcessTableIndexes.get(native)
+  if (cached) {
+    return cached
+  }
+  const rows: WindowsProcessRow[] = []
+  const byPid = new Map<number, WindowsProcessRow>()
+  const childrenByPpid = new Map<number, WindowsProcessRow[]>()
+  for (const nativeRow of native) {
+    const row = toProcessRow(nativeRow)
+    rows.push(row)
+    // Preserve rows.find() semantics if a malformed table repeats a pid.
+    if (!byPid.has(row.pid)) {
+      byPid.set(row.pid, row)
+    }
+    const children = childrenByPpid.get(row.ppid) ?? []
+    children.push(row)
+    childrenByPpid.set(row.ppid, children)
+  }
+  const index: WindowsProcessTableIndex = { rows, byPid, childrenByPpid }
+  windowsProcessTableIndexes.set(native, index)
+  return index
+}
+
 /**
  * Rows from a scan that starts after this call.
  *
@@ -32,8 +78,8 @@ function toProcessRow(row: NativeWindowsProcessRow): WindowsProcessRow {
  * the very recycle it is meant to detect. Rejects when the table is unreadable,
  * so "unavailable" stays distinguishable from "nothing is running".
  */
-export async function queryWindowsProcessRowsFresh(): Promise<WindowsProcessRow[]> {
-  return (await readWindowsProcessTableFresh()).map(toProcessRow)
+export async function queryWindowsProcessRowsFresh(): Promise<readonly WindowsProcessRow[]> {
+  return indexWindowsProcessTable(await readWindowsProcessTableFresh()).rows
 }
 
 export async function queryWindowsProcessDescendants(
@@ -57,54 +103,28 @@ export async function queryWindowsPaneProcessInventory(
   rootPid: number,
   options: { fresh?: boolean; anchorPid?: number } = {}
 ): Promise<WindowsPaneProcessInventory | null> {
-  let rows: WindowsProcessRow[]
+  let index: WindowsProcessTableIndex
   try {
-    const native =
+    index = indexWindowsProcessTable(
       options.fresh === true
         ? await readWindowsProcessTableFresh()
         : await readWindowsProcessTable()
-    rows = native.map(toProcessRow)
+    )
   } catch {
     return null
   }
   // Why: a snapshot that omitted the PTY root may be stale or permission-
   // filtered; only an observed root can authoritatively have no descendants.
-  if (!rows.some((row) => row.pid === rootPid)) {
+  if (!index.byPid.has(rootPid)) {
     return null
   }
   return {
-    candidates: collectDescendants(rows, rootPid).sort((a, b) => b.depth - a.depth),
-    anchorRow:
-      options.anchorPid !== undefined
-        ? (rows.find((row) => row.pid === options.anchorPid) ?? null)
-        : null
+    candidates: collectProcessTreeDescendants(index, rootPid).sort((a, b) => b.depth - a.depth),
+    anchorRow: options.anchorPid !== undefined ? (index.byPid.get(options.anchorPid) ?? null) : null
   }
 }
 
 /** Test-only: clear the shared snapshot so one case's rows never serve the next. */
 export function resetWindowsProcessRowsSnapshotForTests(): void {
   resetWindowsProcessTableForTests()
-}
-
-function collectDescendants<Row extends { pid: number; ppid: number }>(
-  rows: Row[],
-  rootPid: number
-): (Row & { depth: number })[] {
-  const childrenByParent = new Map<number, Row[]>()
-  for (const row of rows) {
-    const children = childrenByParent.get(row.ppid) ?? []
-    children.push(row)
-    childrenByParent.set(row.ppid, children)
-  }
-
-  const descendants: (Row & { depth: number })[] = []
-  const stack = (childrenByParent.get(rootPid) ?? []).map((row) => ({ row, depth: 1 }))
-  while (stack.length > 0) {
-    const { row, depth } = stack.pop()!
-    descendants.push({ ...row, depth })
-    for (const child of childrenByParent.get(row.pid) ?? []) {
-      stack.push({ row: child, depth: depth + 1 })
-    }
-  }
-  return descendants
 }

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -10,9 +10,9 @@ import {
 } from '../shared/agent-process-recognition'
 import { getFirstCommandToken } from '../shared/command-token-scanner'
 import {
+  collectProcessTreeDescendants,
   getProcessTableIndex,
   getProcessTableSnapshot,
-  type ProcessTableIndex,
   type ProcessTableRow
 } from '../shared/process-table-snapshot'
 import { selectForegroundProcessCandidate } from '../shared/foreground-process-selection'
@@ -198,22 +198,6 @@ export function isProcessAlive(pid: number): boolean {
   }
 }
 
-function collectDescendants(
-  index: ProcessTableIndex,
-  rootPid: number
-): (ProcessTableRow & { depth: number })[] {
-  const descendants: (ProcessTableRow & { depth: number })[] = []
-  const stack = (index.childrenByPpid.get(rootPid) ?? []).map((row) => ({ row, depth: 1 }))
-  while (stack.length > 0) {
-    const { row, depth } = stack.pop()!
-    descendants.push({ ...row, depth })
-    for (const child of index.childrenByPpid.get(row.pid) ?? []) {
-      stack.push({ row: child, depth: depth + 1 })
-    }
-  }
-  return descendants
-}
-
 async function getRecognizedForegroundDescendant(
   pid: number,
   fallbackProcess?: string | null
@@ -239,7 +223,7 @@ function getForegroundProcessNameFromProcessTable(
   // snapshot no longer each rebuild the parent/child map over every row.
   const index = getProcessTableIndex(rows)
   const root = index.byPid.get(pid)
-  const candidates = collectDescendants(index, pid)
+  const candidates = collectProcessTreeDescendants(index, pid)
   // Why: SSH relays do not have the daemon's async wrapper cache. Inspect the
   // remote process tree so node/python agent entrypoints become real agents.
   const foregroundIsKnown =

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -169,6 +169,32 @@ export function scoreForegroundCandidateRow(row: ProcessTableRow & { depth: numb
   return (row.stat.includes('+') ? 10_000 : 0) + row.depth
 }
 
+/** The parent/child projection a descendant walk needs, and nothing else. */
+export type ProcessTreeChildIndex<Row> = {
+  childrenByPpid: ReadonlyMap<number, readonly Row[]>
+}
+
+/**
+ * Depth-first walk of a root's descendants off a prebuilt index, children in
+ * table order. Same rows, same order as building a parent map per call — but
+ * the map is built once per capture instead of once per pane per inspection.
+ */
+export function collectProcessTreeDescendants<Row extends { pid: number }>(
+  index: ProcessTreeChildIndex<Row>,
+  rootPid: number
+): (Row & { depth: number })[] {
+  const descendants: (Row & { depth: number })[] = []
+  const stack = (index.childrenByPpid.get(rootPid) ?? []).map((row) => ({ row, depth: 1 }))
+  while (stack.length > 0) {
+    const { row, depth } = stack.pop()!
+    descendants.push({ ...row, depth })
+    for (const child of index.childrenByPpid.get(row.pid) ?? []) {
+      stack.push({ row: child, depth: depth + 1 })
+    }
+  }
+  return descendants
+}
+
 export function lookupProcessTableIndex<T>(
   index: ProcessTableIndex,
   lookup: (index: ProcessTableIndex) => T,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​226 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​226 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​82 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## ELI5

Orca watches your agent panes so it can tell you the moment an agent finishes — including when the window is in the background. To do that it reads the computer's list of running programs a couple of times a second and then asks, for each pane, "what is running under this terminal?"

The reading part was already shared: one read, every pane uses it. The **understanding** part was not. Every pane took that one shared list and rebuilt its own index of the entire list — every process on the machine — just to find its own handful of processes. Fifteen panes meant fifteen rebuilds of the same thing off the same list. On Windows it was worse: each pane also re-copied all ~1000 rows into fresh objects first.

Now the list is indexed once, when it is captured, and every pane reads that one index. Same answers, same timing, same notifications — just built once instead of once per pane.

## What I verified, and what was wrong in the original report

The finding I was handed said `pty:inspectProcess` performs **two process-table reads per inspection** (`getForegroundProcess` + `hasChildProcesses`) and that implementing the optional `inspectProcess` hook on the local provider would halve it. I checked every provider and **that is not what the code does.** Correcting it:

| Claim | Reality |
| --- | --- |
| `inspectProcess` does two process-table reads on the local provider | `hasLocalPtyChildProcesses` (`local-pty-foreground-inspection.ts:20-36`) reads **no** process table. It compares node-pty's `proc.process` against the pane's shell name, in memory. There is no second read to merge. |
| `inspectProcess` is unimplemented on the providers that matter | It is implemented on `SshPtyProvider`, `DaemonPtyProcessInspection`, `DaemonPtyRouter` and `DegradedDaemonPtyProvider`. The local provider is the only one without it — and it is the one that needs it least, per the row above. |
| ~16 process-table reads/sec | `getProcessTableSnapshot()` has a 500 ms TTL plus single-flight (`process-table-snapshot.ts`), so the whole app is capped at **~2 `ps` captures/sec** regardless of pane count. That dedupe landed in #6288. |
| The daemon path reads the table per inspection | It does not. `TerminalHost.inspectProcess` answers from `session.getForegroundProcess()`, which is a synchronous read of a 1 s cache maintained by a rate-limited background refresh (`foreground-process-tracker.ts`). |

So I did **not** implement the local `inspectProcess` hook: it would be a parallel copy of the default two-call path that saves nothing, which `AGENTS.md` ("Reuse Before Reimplementing") tells me not to add.

What *is* genuinely duplicated per pane in this lane is the step after the read. `src/relay/pty-shell-utils.ts` was already fixed for it ("one memoized index per capture, so N panes sharing the TTL-cached snapshot no longer each rebuild the parent/child map over every row"). The two main-process resolvers were not:

- `agent-foreground-process.ts` built its own `childrenByParent` map over the **whole** table and ran `rows.find`/`rows.some` linear scans — once per pane, per inspection.
- `windows-foreground-process-rows.ts` did the same **and** re-projected every native row into a fresh object first (`native.map(toProcessRow)`), also once per pane, per inspection, even though `readWindowsProcessTable()` hands back the same cached array.

## The change

One capture is indexed once and shared, exactly as the relay already does.

- `process-table-snapshot.ts`: new `collectProcessTreeDescendants(index, rootPid)` — the descendant walk, generic over the row shape. Three copies of this walk existed; now there is one.
- `agent-foreground-process.ts`: `getProcessTableIndex(rows)` (the existing per-capture `WeakMap` memo) replaces the per-call parent map and both linear scans, in `resolveAgentForegroundProcessFromPs`, `confirmShellForegroundProcess` and the `fresh` root-presence check.
- `windows-foreground-process-rows.ts`: `indexWindowsProcessTable()` memoizes the projection *and* the index per native capture, keyed weakly by the capture so it dies with it.
- `relay/pty-shell-utils.ts`: drops its now-duplicate local walker.

No cadence change, no visibility gating, no skipped inspections, no wire change, no new subprocess, no PowerShell, no new `child_process` import.

## Measurements

Machine: macOS, 1604-process table (a real 15-pane Orca session). CPU is `process.cpuUsage()`, mean over 400 iterations after warmup. "Capture-round" = every pane resolving its foreground off one shared capture.

**Whole-table walks per inspection** (deterministic, asserted in `agent-foreground-shared-process-table-index.test.ts`):

| | before | after |
| --- | --- | --- |
| per pane, per inspection | 2 (`find` + parent-map build) | 0 |
| per capture, all panes | 2 x panes (30 at 15 panes) | **1** |

**CPU per capture-round:**

| | 11 panes | 15 panes |
| --- | --- | --- |
| POSIX before | 0.377 ms | 0.500 ms |
| POSIX after | 0.103 ms | 0.099 ms |
| | **3.7x** | **5.1x** |
| Windows-shaped (1050 rows) before | 0.348 ms | 0.426 ms |
| Windows-shaped after | 0.077 ms | 0.085 ms |
| | **4.5x** | **5.0x** |

**Per second.** `MAX_INSPECTION_STARTS_PER_SECOND = 8` and the queue is saturated at both scales (11 panes on the 750 ms active tier demand 14.7 starts/s, 15 panes demand 20/s), so both run at the same 8 inspections/sec:

| | before | after |
| --- | --- | --- |
| whole-table index builds/sec | 8 | **<= 2** (bounded by the 500 ms capture TTL) |
| CPU in that step | ~0.27 ms/s | ~0.18 ms/s |
| garbage from it, POSIX (136 KiB/build measured) | ~1.1 MiB/s | **<= 0.27 MiB/s** |
| garbage from it, Windows (260 KiB/build measured) | ~2.1 MiB/s | **<= 0.52 MiB/s** |

**Rebased onto a newer `main`; numbers re-baselined.** This branch was rebased after `1d94ebee3f6` (#18062, *stop a deeper vendor helper from stealing a pane's agent identity*) landed, which touches both files this PR touches. What that means for the figures above:

- **The structural claim is unchanged and re-verified on the new base.** Current `main` still performs exactly 2 whole-table walks per pane per inspection — `rows.find((row) => row.pid === shellPid)` plus the `childrenByParent` build over every row inside `collectDescendants`. #18062 removed only a `.sort()` over *per-pane descendants* (a handful of rows), not either whole-table walk. `2 x panes -> 1 per capture` still holds, and is asserted deterministically in `agent-foreground-shared-process-table-index.test.ts`.
- **The allocation-churn figures are unaffected** — they come from the index build itself, which #18062 did not touch.
- **The wall-clock ratios (3.7x/5.1x POSIX, 4.5x/5.0x Windows-shaped) were measured on the pre-#18062 base** and are therefore marginally optimistic, since the baseline lost that small sort. The whole-table walks over a 1604-row table dominate both sides so the effect is immaterial, but these ratios are *not* freshly re-measured and should be read as approximate.
- **#18062's behaviour is preserved verbatim.** `git diff origin/main HEAD` over the two shared files is *only* the index reuse; `selectForegroundProcessCandidate`, `foregroundCandidates` and `ancestryCandidates` are byte-identical to `main`. Its regression tests (`src/shared/foreground-process-selection.test.ts`, `src/main/providers/agent-foreground-process-real-rows.test.ts`) pass on this branch.

**Be clear about the size of this.** In absolute CPU it is small — ~0.09 ms/sec — because the inspection queue's 8/sec rate cap already bounds total work no matter how many panes exist. The wins that matter are the ~4-5x drop in allocation churn and that per-pane cost is now O(its own subtree) instead of O(the whole machine), so it stays flat as pane count grows.

**The dominant cost in this lane is untouched, and it is worth naming.** The `ps -axo` capture itself, measured on the same 1604-process box: **0.11 s wall and 0.07 CPU-seconds** per capture (`/usr/bin/time`: 0.01 user + 0.06 sys). At the <=2 captures/sec the TTL permits, that is roughly **14% of one core, continuously**, while any agent pane is on the active tier. That is the number to attack next, and attacking it means changing cadence, TTL or the `ps` field set — all explicitly out of scope here.

## Negative user-facing trade-offs

**None.**

- **Detection sensitivity: unchanged.** The rows returned, their order, and their depths are identical — asserted against the previous per-call implementation, kept in the test file as the oracle, over the fleet plus orphan and duplicate-pid rows.
- **Cadence: unchanged.** `agent-completion-poll-cadence.ts` and `agent-process-inspection-queue.ts` are not touched. No tier, interval, concurrency limit or rate cap moved.
- **Backgrounded-window notifications: unchanged.** This PR does not go near `shouldRunCadenceInspection()`; the `process-exit` lane still short-circuits before consulting visibility, so a backgrounded window still fires the desktop notification.
- **Capture freshness: unchanged.** The index is keyed to the capture that produced it, so a fresh capture (`getFreshProcessTableSnapshot`, `readWindowsProcessTableFresh`) always gets a fresh index. Teardown identity never reads a memo from an older capture — covered by "re-projects a fresh capture instead of serving the memoized one".
- **SSH / remote: unaffected or improved.** No RPC, opcode or published field changes, so mixed client/host versions are unaffected. `src/relay/pty-shell-utils.ts` already had the memoized index; it only loses a duplicate walker. `live` / `unverifiable` / `exited` is untouched — an unreadable table still rejects, an absent root still returns `null`, and neither degrades into "nothing is running".
- **Windows: improved, and the posture rules hold.** Enumeration still goes through `src/main/windows/windows-process-table.ts`. No `powershell.exe` fork, no `-ExecutionPolicy Bypass`, no `-EncodedCommand`, no `cmd.exe /c`, no `Add-Type`, no per-operation interpreter. The change *reduces* work behind the same native snapshot.
- **Linux:** same POSIX path as macOS, same improvement.
- **One thing a reviewer should check:** `queryWindowsProcessRowsFresh` now returns `readonly WindowsProcessRow[]` and the rows are shared between callers of one capture rather than freshly copied per call. Both consumers (`windows-pty-root-identity.ts`, `structured-tui-process-identity.ts`) only read them, and the type change makes accidental mutation a compile error.

## Tests

`src/main/providers/agent-foreground-shared-process-table-index.test.ts` (new):
- whole-table walks per capture: 30 before (2 x 15 panes) -> 1 after, counted through a `Proxy` that traps every traversal;
- descendants identical to the previous per-call walk — same rows, same order, same depths — across the fleet, an orphan, a duplicate pid and an absent root;
- 15 panes resolve identically off a single `ps` capture (`execFile` called once);
- red/green on the wiring: poisoning the capture's shared index changes the resolver's answer, proving it reads the shared index rather than rebuilding one. Reverting `agent-foreground-process.ts` makes this fail (`expected 'claude' to be 'zsh'`).

`src/main/providers/windows-foreground-process-rows.test.ts`:
- one capture is projected and indexed once — two pane inspections get the *identical* row objects, not copies (fails on revert);
- a fresh capture re-projects instead of serving the memo.

Green: `src/main/providers` (80 files, 828 tests), `src/shared/process-table-snapshot.test.ts`, `src/relay`. `pnpm tc` clean.

`src/renderer/src/components/terminal-pane` has pre-existing failures in the
`remote-runtime-pty-transport-*` suites that are **not** from this branch: the
same three files fail identically (2 files / 4 tests) with the branch checked out
and with the tree reverted to `main`, and the failure count varies run to run
(30 / 14 / 8) under load. Nothing under `src/renderer` imports any module this PR
touches (`rg 'process-table-snapshot|agent-foreground-process|windows-foreground-process-rows|pty-shell-utils' src/renderer` is empty).

## Reliability contract

- **Invariant:** `agent-completion.process-exit-evidence` — the foreground-process and has-children answers a pane receives, and the order of the candidate rows they are derived from, do not change.
- **Failure source:** per-pane whole-table index rebuilds in the completion-detection lane at 11-15 agent panes.
- **Oracle:** answer-equality against the previous implementation as the reference, plus a walk count; not the shape of the index.
- **Gate:** no existing entry covers per-capture index sharing; the two count tests above are the record until one exists.
- **Provider/platform coverage:** local PTY covered; daemon PTY unaffected (answers from its own foreground cache); SSH/relay unaffected (already shared, loses a duplicate); WSL follows the POSIX path; mobile/relay unaffected (no wire change); macOS/Linux covered, Windows covered by the projection tests.
- **Diagnostics:** none added; the counts live in the tests.
- **Residual gaps:** the Windows tests run on POSIX with an injected native loader, so they prove the projection and index contract but not the real addon. The dominant `ps` capture cost is unaddressed by design.

