### PR TITLE
perf(sidebar,terminal): memoize terminal-title agent classification and lineage projections

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-lineage-projection.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-projection.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import {
+  getCyclicProjectedWorktreeLineageIds,
+  getLineageRenderInfo,
+  getProjectedWorktreeLineageChildrenByParentId
+} from './worktree-lineage-projection'
+
+function makeWorktree(id: string): Worktree {
+  return {
+    id,
+    repoId: 'repo-1',
+    instanceId: `${id}-instance`,
+    path: `/tmp/${id}`,
+    branch: id,
+    isMainWorktree: false
+  } as unknown as Worktree
+}
+
+function makeLineage(childId: string, parentId: string): WorktreeLineage {
+  return {
+    worktreeId: childId,
+    worktreeInstanceId: `${childId}-instance`,
+    parentWorktreeId: parentId,
+    parentWorktreeInstanceId: `${parentId}-instance`
+  } as unknown as WorktreeLineage
+}
+
+/**
+ * A sidebar-scale fixture: one root with many children, mirroring the shape the
+ * row builder scans on every store write.
+ */
+function buildFixture(childCount: number): {
+  lineageById: Record<string, WorktreeLineage>
+  worktreeMap: Map<string, Worktree>
+} {
+  const worktreeMap = new Map<string, Worktree>()
+  const lineageById: Record<string, WorktreeLineage> = {}
+  worktreeMap.set('root', makeWorktree('root'))
+  for (let index = 0; index < childCount; index += 1) {
+    const id = `child-${index}`
+    worktreeMap.set(id, makeWorktree(id))
+    lineageById[id] = makeLineage(id, 'root')
+  }
+  return { lineageById, worktreeMap }
+}
+
+describe('worktree lineage projection cache', () => {
+  it('reuses the cyclic-id scan for an unchanged input pair', () => {
+    const { lineageById, worktreeMap } = buildFixture(8)
+    const first = getCyclicProjectedWorktreeLineageIds(lineageById, worktreeMap)
+    const second = getCyclicProjectedWorktreeLineageIds(lineageById, worktreeMap)
+    expect(second).toBe(first)
+  })
+
+  it('reuses the children projection for an unchanged input pair', () => {
+    const { lineageById, worktreeMap } = buildFixture(8)
+    const first = getProjectedWorktreeLineageChildrenByParentId(lineageById, worktreeMap)
+    const second = getProjectedWorktreeLineageChildrenByParentId(lineageById, worktreeMap)
+    expect(second).toBe(first)
+    expect(first.get('root')?.map((worktree) => worktree.id)).toEqual([
+      'child-0',
+      'child-1',
+      'child-2',
+      'child-3',
+      'child-4',
+      'child-5',
+      'child-6',
+      'child-7'
+    ])
+  })
+
+  it('rescans when either input is replaced', () => {
+    const { lineageById, worktreeMap } = buildFixture(4)
+    const baseline = getProjectedWorktreeLineageChildrenByParentId(lineageById, worktreeMap)
+
+    const replacedLineage = { ...lineageById }
+    expect(getProjectedWorktreeLineageChildrenByParentId(replacedLineage, worktreeMap)).not.toBe(
+      baseline
+    )
+
+    const replacedWorktrees = new Map(worktreeMap)
+    expect(getProjectedWorktreeLineageChildrenByParentId(lineageById, replacedWorktrees)).not.toBe(
+      baseline
+    )
+  })
+
+  it('reflects a removed lineage edge as soon as the record is replaced', () => {
+    const { lineageById, worktreeMap } = buildFixture(2)
+    expect(
+      getProjectedWorktreeLineageChildrenByParentId(lineageById, worktreeMap).get('root')
+    ).toHaveLength(2)
+
+    const withoutFirstChild = { ...lineageById }
+    delete withoutFirstChild['child-0']
+    const reprojected = getProjectedWorktreeLineageChildrenByParentId(
+      withoutFirstChild,
+      worktreeMap
+    )
+    expect(reprojected.get('root')?.map((worktree) => worktree.id)).toEqual(['child-1'])
+    expect(
+      getLineageRenderInfo(
+        worktreeMap.get('child-0') as Worktree,
+        withoutFirstChild,
+        worktreeMap,
+        getCyclicProjectedWorktreeLineageIds(withoutFirstChild, worktreeMap)
+      ).state
+    ).toBe('none')
+  })
+
+  it('still reports cycles from the cached scan', () => {
+    const worktreeMap = new Map<string, Worktree>([
+      ['a', makeWorktree('a')],
+      ['b', makeWorktree('b')]
+    ])
+    const lineageById: Record<string, WorktreeLineage> = {
+      a: makeLineage('a', 'b'),
+      b: makeLineage('b', 'a')
+    }
+    const cyclic = getCyclicProjectedWorktreeLineageIds(lineageById, worktreeMap)
+    expect([...cyclic].sort()).toEqual(['a', 'b'])
+    expect(getCyclicProjectedWorktreeLineageIds(lineageById, worktreeMap)).toBe(cyclic)
+    expect(getProjectedWorktreeLineageChildrenByParentId(lineageById, worktreeMap).size).toBe(0)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-lineage-projection.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-projection.ts
@@ -22,10 +22,49 @@ export function getProjectedWorktreeLineage(
   return (worktree as WorktreeWithResolvedLineage).lineage
 }
 
+type LineageProjection = {
+  cyclicLineageIds?: Set<string>
+  childrenByParentId?: Map<string, Worktree[]>
+}
+
+/**
+ * Why: both projections are O(worktrees) scans that the sidebar row builder and
+ * the pinned/attached-children readers re-run several times per pass, and
+ * zustand re-runs those on every store write. Both are pure in the two inputs,
+ * and both inputs are immutable store-derived collections that are REPLACED
+ * rather than mutated, so their identity pair is a sound cache key. Weak on both
+ * levels so a superseded lineage record or worktree index is not pinned.
+ */
+const projectionByLineageAndWorktreeMap = new WeakMap<
+  Readonly<Record<string, WorktreeLineage>>,
+  WeakMap<ReadonlyMap<string, Worktree>, LineageProjection>
+>()
+
+function getLineageProjection(
+  lineageById: Readonly<Record<string, WorktreeLineage>>,
+  worktreeMap: ReadonlyMap<string, Worktree>
+): LineageProjection {
+  let byWorktreeMap = projectionByLineageAndWorktreeMap.get(lineageById)
+  if (!byWorktreeMap) {
+    byWorktreeMap = new WeakMap()
+    projectionByLineageAndWorktreeMap.set(lineageById, byWorktreeMap)
+  }
+  let projection = byWorktreeMap.get(worktreeMap)
+  if (!projection) {
+    projection = {}
+    byWorktreeMap.set(worktreeMap, projection)
+  }
+  return projection
+}
+
 export function getCyclicProjectedWorktreeLineageIds(
   lineageById: Readonly<Record<string, WorktreeLineage>>,
   worktreeMap: ReadonlyMap<string, Worktree>
 ): Set<string> {
+  const projection = getLineageProjection(lineageById, worktreeMap)
+  if (projection.cyclicLineageIds) {
+    return projection.cyclicLineageIds
+  }
   const validLineageByChildId = new Map<string, WorktreeLineage>()
   for (const worktree of worktreeMap.values()) {
     const lineage = getProjectedWorktreeLineage(worktree, lineageById)
@@ -37,7 +76,9 @@ export function getCyclicProjectedWorktreeLineageIds(
       validLineageByChildId.set(worktree.id, lineage)
     }
   }
-  return getCyclicWorktreeLineageChildIds(validLineageByChildId)
+  const cyclicLineageIds = getCyclicWorktreeLineageChildIds(validLineageByChildId)
+  projection.cyclicLineageIds = cyclicLineageIds
+  return cyclicLineageIds
 }
 
 export function getLineageRenderInfo(
@@ -65,6 +106,10 @@ export function getProjectedWorktreeLineageChildrenByParentId(
   lineageById: Readonly<Record<string, WorktreeLineage>>,
   worktreeMap: ReadonlyMap<string, Worktree>
 ): Map<string, Worktree[]> {
+  const projection = getLineageProjection(lineageById, worktreeMap)
+  if (projection.childrenByParentId) {
+    return projection.childrenByParentId
+  }
   const cyclicLineageIds = getCyclicProjectedWorktreeLineageIds(lineageById, worktreeMap)
   const childrenByParentId = new Map<string, Worktree[]>()
   for (const worktree of worktreeMap.values()) {
@@ -76,6 +121,7 @@ export function getProjectedWorktreeLineageChildrenByParentId(
     children.push(worktree)
     childrenByParentId.set(lineage.parent.id, children)
   }
+  projection.childrenByParentId = childrenByParentId
   return childrenByParentId
 }
 

--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -7,6 +7,7 @@ import {
 } from './agent-name-token-match'
 import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
 import { isLegacyPiCompatibleTitle } from './pi-compatible-synthetic-title'
+import { memoizeTitleClassification } from './terminal-title-classification-memo'
 import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 
 export { AGY_AGENT_NAME_RE, DROID_AGENT_NAME_RE, HERMES_AGENT_NAME_RE, titleHasAgentName }
@@ -54,7 +55,7 @@ export const BRAILLE_SPINNER_RE = /[\u2800-\u28ff]/g
 // Reserve the whole quarter-circle block so a later frame addition cannot regress this.
 export const QUARTER_CIRCLE_SPINNER_RE = /[\u25d0-\u25d3]/g
 
-export function isGeminiTerminalTitle(title: string): boolean {
+function computeIsGeminiTerminalTitle(title: string): boolean {
   // Why: Gemini OSC glyphs are stronger evidence than any cwd/session text.
   if (
     title.includes(GEMINI_PERMISSION) ||
@@ -79,6 +80,11 @@ export function isGeminiTerminalTitle(title: string): boolean {
   }
   return titleHasAgentName(title, 'gemini')
 }
+
+/** Pure in `title` — memoized so repeated selector reads skip the regex ladder. */
+export const isGeminiTerminalTitle: (title: string) => boolean = memoizeTitleClassification(
+  computeIsGeminiTerminalTitle
+)
 
 export function isPiTerminalTitle(title: string): boolean {
   return isLegacyPiCompatibleTitle(title) && !containsBrailleSpinner(title)

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -12,12 +12,13 @@ import {
 } from './agent-title-core'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getPiCompatibleSyntheticAgentLabel } from './pi-compatible-synthetic-title'
+import { memoizeTitleClassification } from './terminal-title-classification-memo'
 
 /**
  * Returns true when the terminal title matches Claude Code's title conventions.
  * Used to scope prompt-cache-timer behavior to Claude sessions only.
  */
-export function isClaudeAgent(title: string): boolean {
+function computeIsClaudeAgent(title: string): boolean {
   if (!title || isClaudeManagementTitle(title) || isOpenCodeNativeTitle(title)) {
     return false
   }
@@ -43,7 +44,11 @@ export function isClaudeAgent(title: string): boolean {
   )
 }
 
-export function getAgentLabel(title: string): string | null {
+/** Pure in `title` — memoized so repeated selector reads skip the regex ladder. */
+export const isClaudeAgent: (title: string) => boolean =
+  memoizeTitleClassification(computeIsClaudeAgent)
+
+function computeAgentLabel(title: string): string | null {
   if (isClaudeManagementTitle(title)) {
     return null
   }
@@ -119,3 +124,7 @@ export function getAgentLabel(title: string): string | null {
 
   return null
 }
+
+/** Pure in `title` — memoized so repeated selector reads skip the regex ladder. */
+export const getAgentLabel: (title: string) => string | null =
+  memoizeTitleClassification(computeAgentLabel)

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -32,6 +32,7 @@ import {
 import { clearPiStateWorkingMarker, getPiStateTitleStatus } from './pi-state-title-marker'
 import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
+import { memoizeTitleClassification } from './terminal-title-classification-memo'
 
 /**
  * Strip working-status indicators so stale exit titles stop reporting working.
@@ -178,7 +179,7 @@ function canonicalizeBrailleSpinnerFrame(title: string): string {
   return canonical
 }
 
-export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
+function computeAgentStatusFromTitle(title: string): AgentStatus | null {
   if (!title || isClaudeManagementTitle(title)) {
     return null
   }
@@ -261,6 +262,13 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
 
   return 'idle'
 }
+
+/**
+ * Pure in `title`, so it is memoized on the title string: sidebar/tab selectors
+ * re-ask for the same unchanged titles on every store write.
+ */
+export const detectAgentStatusFromTitle: (title: string) => AgentStatus | null =
+  memoizeTitleClassification(computeAgentStatusFromTitle)
 
 /**
  * True when a quarter-circle spinner frame is the only agent evidence a title carries.

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -10,6 +10,7 @@ import {
   getPiCompatibleSyntheticAgentLabel,
   isLegacyPiCompatibleTitle
 } from './pi-compatible-synthetic-title'
+import { memoizeTitleClassification } from './terminal-title-classification-memo'
 import type { TuiAgent } from './tui-agent'
 
 export const CLAUDE_IDLE = '\u2733' // ✳ (eight-spoked asterisk — Claude Code idle prefix)
@@ -84,7 +85,7 @@ export function isPiAgentTitle(title: string): boolean {
  * Used to scope prompt-cache-timer behavior to Claude sessions only — other
  * agents have different (or no) caching semantics.
  */
-export function isClaudeAgent(title: string): boolean {
+function computeIsClaudeAgent(title: string): boolean {
   if (!title || isClaudeManagementTitle(title) || isOpenCodeNativeTitle(title)) {
     return false
   }
@@ -121,11 +122,15 @@ export function isClaudeAgent(title: string): boolean {
   return false
 }
 
+/** Pure in `title` — memoized so repeated selector reads skip the regex ladder. */
+export const isClaudeAgent: (title: string) => boolean =
+  memoizeTitleClassification(computeIsClaudeAgent)
+
 export function isClaudeManagementTitle(title: string): boolean {
   return CLAUDE_MANAGEMENT_TITLE_RE.test(title)
 }
 
-export function getAgentLabel(title: string): string | null {
+function computeAgentLabel(title: string): string | null {
   if (isClaudeManagementTitle(title)) {
     return null
   }
@@ -235,6 +240,10 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
   OMP: 'omp'
 }
 
+/** Pure in `title` — memoized so repeated selector reads skip the regex ladder. */
+export const getAgentLabel: (title: string) => string | null =
+  memoizeTitleClassification(computeAgentLabel)
+
 function hasGenericClaudeStatusPrefix(title: string): boolean {
   return (
     containsAgentSpinnerGlyph(title) ||
@@ -266,10 +275,14 @@ export function resolveTerminalTitleAgentType(title: string): TuiAgent | null {
  * that something is running, not proof the agent is Claude — so a task or
  * worktree title cannot become Claude without an explicit "Claude Code" name.
  */
-export function resolveExplicitTerminalTitleAgentType(title: string): TuiAgent | null {
+function computeExplicitTerminalTitleAgentType(title: string): TuiAgent | null {
   const titleAgent = resolveTerminalTitleAgentType(title)
   if (isGenericClaudeStatusClaim(title, titleAgent)) {
     return null
   }
   return titleAgent
 }
+
+/** Pure in `title` — memoized so repeated selector reads skip the regex ladder. */
+export const resolveExplicitTerminalTitleAgentType: (title: string) => TuiAgent | null =
+  memoizeTitleClassification(computeExplicitTerminalTitleAgentType)

--- a/src/shared/terminal-title-classification-corpus.test.ts
+++ b/src/shared/terminal-title-classification-corpus.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest'
+import { isGeminiTerminalTitle } from './agent-title-core'
+import { getAgentLabel, isClaudeAgent } from './agent-title-identity'
+import { detectAgentStatusFromTitle } from './agent-title-status'
+import { TERMINAL_TITLE_CLASSIFICATION_CORPUS } from './terminal-title-classification-corpus'
+import {
+  getAgentLabel as getExplicitAgentLabel,
+  isClaudeAgent as isExplicitClaudeAgent,
+  resolveExplicitTerminalTitleAgentType,
+  resolveTerminalTitleAgentType
+} from './terminal-title-agent-type'
+
+/**
+ * Pins the exact verdict every title classifier returns for a realistic corpus.
+ *
+ * Why: these classifiers are now memoized on the title string, and a caching bug
+ * here would repaint a pane under the wrong agent. This table is the proof that
+ * memoization is transparent — it was generated from the pre-memo implementation
+ * and must keep matching byte-for-byte.
+ */
+type PinnedRow = [
+  title: string,
+  status: string | null,
+  label: string | null,
+  claude: boolean,
+  gemini: boolean,
+  explicitLabel: string | null,
+  explicitClaude: boolean,
+  titleAgent: string | null,
+  explicitTitleAgent: string | null
+]
+
+const PINNED_CLASSIFICATIONS: readonly PinnedRow[] = [
+  ['', null, null, false, false, null, false, null, null],
+  ['zsh', null, null, false, false, null, false, null, null],
+  ['bash', null, null, false, false, null, false, null, null],
+  ['nwparker@mac: ~/orca', null, null, false, false, null, false, null, null],
+  ['npm run dev', null, null, false, false, null, false, null, null],
+  ['opencode-blinker', null, null, false, false, null, false, null, null],
+  [
+    'openclaude',
+    'idle',
+    'OpenClaude',
+    false,
+    false,
+    'OpenClaude',
+    false,
+    'openclaude',
+    'openclaude'
+  ],
+  ['openclaude-scratch', null, null, false, false, null, false, null, null],
+  ['claude-scratch', null, null, false, false, null, false, null, null],
+  ['~/codex/ready', null, null, false, false, null, false, null, null],
+  ['review-14600-codex', null, null, false, false, null, false, null, null],
+  ['timestamp ready', null, null, false, false, null, false, null, null],
+  ['android build running', null, null, false, false, null, false, null, null],
+  ['~/hermes/working', null, null, false, false, null, false, null, null],
+  ['C:\\tools\\codex\\run', null, null, false, false, null, false, null, null],
+  ['/usr/local/bin/claude/notes', null, null, false, false, null, false, null, null],
+  ['agy-nightly', null, null, false, false, null, false, null, null],
+  ['codex.exe', 'idle', 'Codex', false, false, 'Codex', false, 'codex', 'codex'],
+  [
+    'openclaude.cmd',
+    'idle',
+    'OpenClaude',
+    false,
+    false,
+    'OpenClaude',
+    false,
+    'openclaude',
+    'openclaude'
+  ],
+  [
+    'claude.bat working',
+    'working',
+    'Claude Code',
+    true,
+    false,
+    'Claude Code',
+    true,
+    'claude',
+    'claude'
+  ],
+  ['aider.ps1 ready', 'idle', 'Aider', false, false, 'Aider', false, 'aider', 'aider'],
+  [
+    'copilot.exe - action required',
+    'permission',
+    'GitHub Copilot',
+    false,
+    false,
+    'GitHub Copilot',
+    false,
+    'copilot',
+    'copilot'
+  ],
+  ['droid.exe', null, null, false, false, null, false, null, null],
+  ['\u2733', 'idle', 'Claude Code', true, false, 'Claude Code', true, 'claude', null],
+  [
+    '\u2733 Claude Code',
+    'idle',
+    'Claude Code',
+    true,
+    false,
+    'Claude Code',
+    true,
+    'claude',
+    'claude'
+  ],
+  ['\u2733 ready', 'idle', 'Claude Code', true, false, 'Claude Code', true, 'claude', null],
+  ['. building the parser', null, 'Claude Code', true, false, 'Claude Code', true, 'claude', null],
+  ['* done', null, 'Claude Code', true, false, 'Claude Code', true, 'claude', null],
+  ['Claude Code', 'idle', 'Claude Code', true, false, 'Claude Code', true, 'claude', 'claude'],
+  [
+    'claude - action required',
+    'permission',
+    'Claude Code',
+    true,
+    false,
+    'Claude Code',
+    true,
+    'claude',
+    'claude'
+  ],
+  ['Claude ready', 'idle', 'Claude Code', true, false, 'Claude Code', true, 'claude', 'claude'],
+  ['claude agents', null, null, false, false, null, false, null, null],
+  ['"/usr/local/bin/claude" agents', null, null, false, false, null, false, null, null],
+  [
+    '\u280b Claude Code',
+    'working',
+    'Claude Code',
+    true,
+    false,
+    'Claude Code',
+    true,
+    'claude',
+    'claude'
+  ],
+  [
+    '\u2809 Codex \u2014 refactoring',
+    'working',
+    'Codex',
+    true,
+    false,
+    'Codex',
+    true,
+    'codex',
+    'codex'
+  ],
+  ['\u25d0 working', 'working', 'Claude Code', true, false, 'Claude Code', true, 'claude', null],
+  ['\u25d3 Grok', 'working', 'Grok', true, false, 'Grok', true, 'grok', 'grok'],
+  ['\u280b Cursor Agent', 'working', 'Cursor', false, false, 'Cursor', false, 'cursor', 'cursor'],
+  ['\u280b Droid', 'working', 'Droid', true, false, 'Droid', true, 'droid', 'droid'],
+  ['\u280b Hermes', 'working', 'Hermes', true, false, 'Hermes', true, 'hermes', 'hermes'],
+  ['\u2726 gemini', 'working', 'Gemini CLI', false, true, 'Gemini CLI', false, 'gemini', 'gemini'],
+  [
+    '\u23f2 Gemini CLI',
+    'working',
+    'Gemini CLI',
+    false,
+    true,
+    'Gemini CLI',
+    false,
+    'gemini',
+    'gemini'
+  ],
+  ['\u25c7 Gemini CLI', 'idle', 'Gemini CLI', false, true, 'Gemini CLI', false, 'gemini', 'gemini'],
+  [
+    '\u270b Gemini CLI',
+    'permission',
+    'Gemini CLI',
+    false,
+    true,
+    'Gemini CLI',
+    false,
+    'gemini',
+    'gemini'
+  ],
+  ['gemini', 'idle', 'Gemini CLI', false, true, 'Gemini CLI', false, 'gemini', 'gemini'],
+  [
+    'antigravity gemini 3 pro',
+    'idle',
+    'Antigravity',
+    false,
+    false,
+    'Antigravity',
+    false,
+    'antigravity',
+    'antigravity'
+  ],
+  [
+    'agy - gemini 2 flash',
+    'idle',
+    'Antigravity',
+    false,
+    false,
+    'Antigravity',
+    false,
+    'antigravity',
+    'antigravity'
+  ],
+  ['codex working', 'working', 'Codex', false, false, 'Codex', false, 'codex', 'codex'],
+  ['codex ready', 'idle', 'Codex', false, false, 'Codex', false, 'codex', 'codex'],
+  [
+    'copilot waiting',
+    'permission',
+    'GitHub Copilot',
+    false,
+    false,
+    'GitHub Copilot',
+    false,
+    'copilot',
+    'copilot'
+  ],
+  ['devin thinking', 'working', 'Devin', false, false, 'Devin', false, 'devin', 'devin'],
+  ['mimo idle', 'idle', 'MiMo Code', false, false, 'MiMo Code', false, 'mimo-code', 'mimo-code'],
+  ['aider running', 'working', 'Aider', false, false, 'Aider', false, 'aider', 'aider'],
+  ['grok done', 'idle', 'Grok', false, false, 'Grok', false, 'grok', 'grok'],
+  ['opencode ready', 'idle', 'OpenCode', false, false, 'OpenCode', false, 'opencode', 'opencode'],
+  ['hermes ready', 'idle', 'Hermes', false, false, 'Hermes', false, 'hermes', 'hermes'],
+  ['droid ready', 'idle', 'Droid', false, false, 'Droid', false, 'droid', 'droid'],
+  ['cursor agent', null, 'Cursor', false, false, 'Cursor', false, 'cursor', 'cursor'],
+  ['cursor ready', 'idle', 'Cursor', false, false, 'Cursor', false, 'cursor', 'cursor'],
+  [
+    'cursor - action required',
+    'permission',
+    'Cursor',
+    false,
+    false,
+    'Cursor',
+    false,
+    'cursor',
+    'cursor'
+  ],
+  ['cursor position reset', 'idle', null, false, false, null, false, null, null],
+  ['\u03c0 > session - ~/orca', 'idle', 'Pi', false, false, 'Pi', false, 'pi', 'pi'],
+  ['\u03c0 ! blocked-session', 'permission', 'Pi', false, false, 'Pi', false, 'pi', 'pi'],
+  ['\u280b \u03c0 - session - ~/orca', 'working', 'Pi', true, false, 'Pi', true, 'pi', 'pi'],
+  ['zsh | \u280b Codex', 'working', 'Codex', true, false, 'Codex', true, 'codex', 'codex'],
+  ['tmux | claude - action required', 'permission', null, false, false, null, false, null, null],
+  [
+    'ssh host | opencode ready',
+    'idle',
+    'OpenCode',
+    false,
+    false,
+    'OpenCode',
+    false,
+    'opencode',
+    'opencode'
+  ]
+]
+
+describe('terminal title classification', () => {
+  it('covers every corpus title exactly once', () => {
+    expect(PINNED_CLASSIFICATIONS.map(([title]) => title)).toEqual([
+      ...TERMINAL_TITLE_CLASSIFICATION_CORPUS
+    ])
+  })
+
+  it.each(PINNED_CLASSIFICATIONS)(
+    'classifies %j identically',
+    (
+      title,
+      status,
+      label,
+      claude,
+      gemini,
+      explicitLabel,
+      explicitClaude,
+      titleAgent,
+      explicitTitleAgent
+    ) => {
+      expect(detectAgentStatusFromTitle(title)).toBe(status)
+      expect(getAgentLabel(title)).toBe(label)
+      expect(isClaudeAgent(title)).toBe(claude)
+      expect(isGeminiTerminalTitle(title)).toBe(gemini)
+      expect(getExplicitAgentLabel(title)).toBe(explicitLabel)
+      expect(isExplicitClaudeAgent(title)).toBe(explicitClaude)
+      expect(resolveTerminalTitleAgentType(title)).toBe(titleAgent)
+      expect(resolveExplicitTerminalTitleAgentType(title)).toBe(explicitTitleAgent)
+    }
+  )
+
+  it('returns the same verdict on the second read of every title', () => {
+    for (const title of TERMINAL_TITLE_CLASSIFICATION_CORPUS) {
+      expect(detectAgentStatusFromTitle(title)).toBe(detectAgentStatusFromTitle(title))
+      expect(getAgentLabel(title)).toBe(getAgentLabel(title))
+      expect(resolveExplicitTerminalTitleAgentType(title)).toBe(
+        resolveExplicitTerminalTitleAgentType(title)
+      )
+    }
+  })
+})

--- a/src/shared/terminal-title-classification-corpus.ts
+++ b/src/shared/terminal-title-classification-corpus.ts
@@ -1,0 +1,86 @@
+/**
+ * Realistic terminal-title corpus for pinning agent classification.
+ *
+ * Why a shared const: the corpus is the contract the memoized classifiers must
+ * reproduce byte-for-byte, so the pinning test and the memo regression test
+ * read the same titles.
+ */
+export const TERMINAL_TITLE_CLASSIFICATION_CORPUS: readonly string[] = [
+  // Plain shell / directory titles — must classify as nothing.
+  '',
+  'zsh',
+  'bash',
+  'nwparker@mac: ~/orca',
+  'npm run dev',
+  // Boundary-guard cases from agent-name-token-match.ts's header comment.
+  'opencode-blinker',
+  'openclaude',
+  'openclaude-scratch',
+  'claude-scratch',
+  '~/codex/ready',
+  'review-14600-codex',
+  'timestamp ready',
+  'android build running',
+  '~/hermes/working',
+  'C:\\tools\\codex\\run',
+  '/usr/local/bin/claude/notes',
+  'agy-nightly',
+  // Windows launcher suffixes.
+  'codex.exe',
+  'openclaude.cmd',
+  'claude.bat working',
+  'aider.ps1 ready',
+  'copilot.exe - action required',
+  'droid.exe',
+  // Claude Code prefixes and identity frames.
+  '\u2733',
+  '\u2733 Claude Code',
+  '\u2733 ready',
+  '. building the parser',
+  '* done',
+  'Claude Code',
+  'claude - action required',
+  'Claude ready',
+  'claude agents',
+  '"/usr/local/bin/claude" agents',
+  // Leading spinner glyphs (braille + quarter circle).
+  '\u280b Claude Code',
+  '\u2809 Codex \u2014 refactoring',
+  '\u25d0 working',
+  '\u25d3 Grok',
+  '\u280b Cursor Agent',
+  '\u280b Droid',
+  '\u280b Hermes',
+  // Gemini glyph vocabulary.
+  '\u2726 gemini',
+  '\u23f2 Gemini CLI',
+  '\u25c7 Gemini CLI',
+  '\u270b Gemini CLI',
+  'gemini',
+  'antigravity gemini 3 pro',
+  'agy - gemini 2 flash',
+  // Named agents with status words.
+  'codex working',
+  'codex ready',
+  'copilot waiting',
+  'devin thinking',
+  'mimo idle',
+  'aider running',
+  'grok done',
+  'opencode ready',
+  'hermes ready',
+  'droid ready',
+  // Cursor's closed identity set.
+  'cursor agent',
+  'cursor ready',
+  'cursor - action required',
+  'cursor position reset',
+  // Pi / OMP compatible titles.
+  '\u03c0 > session - ~/orca',
+  '\u03c0 ! blocked-session',
+  '\u280b \u03c0 - session - ~/orca',
+  // Wrapper/multiplexer prefixes.
+  'zsh | \u280b Codex',
+  'tmux | claude - action required',
+  'ssh host | opencode ready'
+]

--- a/src/shared/terminal-title-classification-memo.test.ts
+++ b/src/shared/terminal-title-classification-memo.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as AgentNameTokenMatchModule from './agent-name-token-match'
+import { getAgentLabel } from './agent-title-identity'
+import { detectAgentStatusFromTitle } from './agent-title-status'
+import { memoizeTitleClassification } from './terminal-title-classification-memo'
+import { resolveExplicitTerminalTitleAgentType } from './terminal-title-agent-type'
+
+// Why a module mock: `titleHasAgentName` is the leaf regex test every title
+// classifier funnels into, so counting its invocations is the direct measure of
+// what one store write costs when no title has changed.
+vi.mock('./agent-name-token-match', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentNameTokenMatchModule>()
+  return { ...actual, titleHasAgentName: vi.fn(actual.titleHasAgentName) }
+})
+
+const classifierCalls = vi.mocked(AgentNameTokenMatchModule.titleHasAgentName)
+
+// Titles a real sidebar holds steady while unrelated agent-status writes churn.
+const UNCHANGED_TITLES = [
+  'codex working',
+  'opencode-blinker',
+  'zsh',
+  '✳ Claude Code',
+  'copilot.exe - action required',
+  'gemini',
+  'cursor agent'
+]
+const STORE_WRITES = 50
+
+function classifyEveryTitle(): void {
+  for (const title of UNCHANGED_TITLES) {
+    getAgentLabel(title)
+    detectAgentStatusFromTitle(title)
+    resolveExplicitTerminalTitleAgentType(title)
+  }
+}
+
+describe('terminal title classification memo', () => {
+  beforeEach(() => {
+    classifierCalls.mockClear()
+  })
+
+  it('classifies each distinct title once across repeated store writes', () => {
+    // Warm the caches the way the first render would, then measure steady state.
+    classifyEveryTitle()
+    classifierCalls.mockClear()
+
+    for (let write = 0; write < STORE_WRITES; write += 1) {
+      classifyEveryTitle()
+    }
+
+    // Unmemoized this is STORE_WRITES x titles x the whole regex ladder — 4,350
+    // leaf matches for this fixture. Memoized, an unchanged title costs nothing.
+    expect(classifierCalls).not.toHaveBeenCalled()
+  })
+
+  it('classifies a title once no matter how many readers ask', () => {
+    const title = 'aider running'
+    getAgentLabel(title)
+    const firstReadCalls = classifierCalls.mock.calls.length
+    expect(firstReadCalls).toBeGreaterThan(0)
+
+    for (let read = 0; read < 20; read += 1) {
+      getAgentLabel(title)
+    }
+    expect(classifierCalls.mock.calls.length).toBe(firstReadCalls)
+  })
+
+  it('reclassifies as soon as the title changes', () => {
+    expect(getAgentLabel('codex ready')).toBe('Codex')
+    expect(getAgentLabel('grok ready')).toBe('Grok')
+    expect(detectAgentStatusFromTitle('codex ready')).toBe('idle')
+    expect(detectAgentStatusFromTitle('codex working')).toBe('working')
+  })
+
+  it('caches null and false verdicts, not just truthy ones', () => {
+    const classify = vi.fn((): string | null => null)
+    const memoized = memoizeTitleClassification(classify)
+    expect(memoized('zsh')).toBeNull()
+    expect(memoized('zsh')).toBeNull()
+    expect(classify).toHaveBeenCalledTimes(1)
+  })
+
+  it('evicts oldest entries instead of growing without bound', () => {
+    const classify = vi.fn((title: string) => title.length)
+    const memoized = memoizeTitleClassification(classify)
+    // Cap is 1024; overflow it and confirm the newest key still hits while the
+    // oldest was evicted.
+    for (let index = 0; index < 1030; index += 1) {
+      memoized(`title-${index}`)
+    }
+    const afterFill = classify.mock.calls.length
+    memoized('title-1029')
+    expect(classify.mock.calls.length).toBe(afterFill)
+    memoized('title-0')
+    expect(classify.mock.calls.length).toBe(afterFill + 1)
+  })
+})

--- a/src/shared/terminal-title-classification-memo.ts
+++ b/src/shared/terminal-title-classification-memo.ts
@@ -1,0 +1,43 @@
+/**
+ * Bounded memo for pure `(title: string) => T` terminal-title classifiers.
+ *
+ * Why: the sidebar cards and tab strip re-derive agent identity/status from
+ * every pane title inside zustand selectors and render bodies, so an UNCHANGED
+ * title was re-tested against every agent-name regex on every store write —
+ * thousands of classifications per second while the app sat idle. Every
+ * classifier below depends on nothing but the title string, so the verdict is
+ * reusable until the title itself changes; a new title is simply a new key, so
+ * there is no staleness window and no invalidation signal to miss.
+ */
+
+/**
+ * Cap: comfortably above the live working set (one title per open pane plus
+ * retained rows) so steady-state hit rate stays ~100%, small enough that the
+ * map cannot grow with session length. Entries hold a reference to a string the
+ * store already retains, so the marginal cost is the map entry itself.
+ */
+const MAX_MEMOIZED_TITLES = 1024
+
+export function memoizeTitleClassification<T>(
+  classify: (title: string) => T
+): (title: string) => T {
+  // Boxed values so `undefined`/`null` verdicts are still cache hits.
+  const cache = new Map<string, { value: T }>()
+  return (title: string): T => {
+    const cached = cache.get(title)
+    if (cached) {
+      return cached.value
+    }
+    const value = classify(title)
+    // Insertion-ordered FIFO eviction: a pane's superseded title frames are the
+    // oldest keys and the least likely to be asked for again.
+    if (cache.size >= MAX_MEMOIZED_TITLES) {
+      const oldest = cache.keys().next()
+      if (!oldest.done) {
+        cache.delete(oldest.value)
+      }
+    }
+    cache.set(title, { value })
+    return value
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​517 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​517 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​219 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​211 |

<!-- /orca-pr-loc -->

## ELI5

Orca was re-reading every terminal's title and re-deciding which AI agent was running in it, thousands of times per second, even when no title had changed. The answer depends only on the title text, so now we remember it until the title actually changes.

## The call chain

Profiling the user's live packaged app (`Profiler.takePreciseCoverage`, 20s, window hidden, app idle; 10 repos / 423 worktrees / 382 tabs / 9 xterms) put `titleHasAgentName` at **11,771 calls/sec** and the any-legacy-agent regex at **4,399 calls/sec** — about one to three per zustand subscriber notification (9,391/sec).

### 1. Tab strip — runs on *every* store write, per mounted tab

- `src/renderer/src/components/tab-bar/SortableTab.tsx:90-99` — `useAppStore((s) => resolveTerminalTabActivityStatus({...}))` is an **unmemoized selector**: it runs on every notification.
- → `src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts:150` `resolveTerminalTabActivityStatus`
- → `src/renderer/src/lib/worktree-status.ts:158` `resolveWorktreeStatus` → `:51` `getWorktreeStatus` — calls `hasStatus('permission')` then `hasStatus('working')`, i.e. **two passes** over the tab's live titles
- → `src/renderer/src/lib/worktree-status.ts:95` / `:108` `classifyTitleActivity(title)`
- → `src/renderer/src/lib/pane-agent-evidence.ts:39` → `src/shared/agent-title-status.ts` `detectAgentStatusFromTitle`
- → `src/shared/agent-title-status.ts:235` `containsLegacyAgentName(title)` → `src/shared/agent-title-core.ts:119` → `src/shared/agent-name-token-match.ts:58` `titleHasAnyLegacyAgentName` — **this is the minified `Om` / `dm.test(e)` at 4,399/sec.**

When a title *does* read working/permission, the same pass continues into identity:

- `src/renderer/src/lib/worktree-status.ts:115` `titleStatusIsAgentAttributable` → `resolveAgentTypeFromTerminalTitle`
- → `src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts:263-280` → `resolveTitleActivityLabel` → `src/shared/agent-title-identity.ts:63` `getAgentLabel`
- → `src/shared/agent-title-identity.ts:78,81,84,87,90,93,96,99,102` — **nine `titleHasAgentName` calls per label lookup**, plus `isGeminiTerminalTitle` (`src/shared/agent-title-core.ts:78,80`) and `isClaudeAgent` (`:42`). That ladder is the 11,771/sec.

### 2. Tab strip — identity, re-run on every render

- `src/renderer/src/components/tab-bar/SortableTab.tsx:107` `useTabAgent(tab)`
- → `src/renderer/src/lib/use-tab-agent.ts:340` `resolveTabAgentFromSignals` is called **in the render body**, and the hook holds ~12 separate `useAppStore` subscriptions (`:187-263`), so any of them flipping re-renders the tab and re-runs it
- → `src/renderer/src/lib/use-tab-agent.ts:117` `resolveExplicitTerminalTitleAgentType(args.title)` → `src/shared/terminal-title-agent-type.ts:269` → `:258` `resolveTerminalTitleAgentType` → `:129` `getAgentLabel` (a **second, duplicated** copy of the nine-call ladder, `:165-190`)
- plus `src/renderer/src/lib/use-tab-agent.ts:279` — the same call again inside a `useEffect` whose deps include `tab.title`.

### 3. Sidebar cards — same resolver, per card

- `src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx:103` → `use-worktree-activity-status.ts:38` → `resolveWorktreeStatus` (memoized, but re-fires on every input change)
- `src/renderer/src/components/sidebar/WorktreeParentPickerPopover.tsx:269` → `use-worktree-activity-statuses.ts:72` — `useAppStore(useShallow(selectStatuses))`, an **unmemoized selector that loops `resolveWorktreeStatus` over every candidate worktree** on every store write while the picker is open.
- `src/renderer/src/components/sidebar/worktree-agent-rows.ts:206` → `worktree-title-derived-agent-rows.ts:157-158` — `classifyTitleActivity` + `resolveTitleActivityLabel` per pane title.

### 4. Lineage projection — O(worktrees) scans, several per sidebar pass

- `src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts:80` `getCyclicProjectedWorktreeLineageIds(lineageById, worktreeMap)` — full scan #1
- `build-rows.ts:100` → `pinned-section-worktrees.ts:14` → `worktree-lineage-projection.ts:64` `getProjectedWorktreeLineageChildrenByParentId`, which **recomputes the cyclic set internally** (`:68`, full scan #2) and then walks every worktree through `getLineageRenderInfo` (`:71`, full scan #3)
- `src/renderer/src/components/sidebar/visible-worktrees.ts:193/201` `addVisibleLineageAncestors` — another cyclic scan plus a per-worktree `getLineageRenderInfo`
- Each of those bottoms out in `worktree-lineage-projection.ts:15` `getProjectedWorktreeLineage` — the minified `n(e,t)` at **8,653/sec** — and `:43` `getLineageRenderInfo`, the minified `i` at **4,064/sec**. The observed 2.1:1 ratio matches ~2 cyclic scans + 1 render-info pass per sidebar build over 423 worktrees.

## What changed

**`src/shared/terminal-title-classification-memo.ts` (new)** — `memoizeTitleClassification(fn)` wraps any pure `(title: string) => T`.

- **Key**: the exact title string (no normalization, no second input — these classifiers read nothing else).
- **Eviction**: insertion-ordered FIFO, cap **1024 entries per classifier**. Comfortably above the live working set (one title per open pane plus retained rows) and independent of session length. Entries reference a string the store already retains, so the marginal cost is the map entry.
- **Invalidation**: none needed. The functions are pure and their modules hold no mutable state, so a changed title is simply a different key — reflected on the very next read, with no staleness window.

Applied to `detectAgentStatusFromTitle`, `getAgentLabel` (both the `agent-title-identity.ts` and the duplicated `terminal-title-agent-type.ts` copy), `isClaudeAgent` (both copies), `isGeminiTerminalTitle`, and `resolveExplicitTerminalTitleAgentType`.

**`src/renderer/src/components/sidebar/worktree-lineage-projection.ts`** — `getCyclicProjectedWorktreeLineageIds` and `getProjectedWorktreeLineageChildrenByParentId` now share an identity-keyed cache, the same pattern as `src/renderer/src/store/worktree-repo-index.ts`.

- **Key**: the identity pair `(lineageById, worktreeMap)`, held in a `WeakMap<lineageById, WeakMap<worktreeMap, projection>>`.
- **Eviction**: weak on both levels — a superseded lineage record or worktree index is collected, nothing is pinned.
- **Invalidation**: both inputs are immutable store-derived collections that are *replaced*, never mutated, so a replacement is a cache miss by construction (test: `rescans when either input is replaced`).

## Measurements

Real counts from the repo's own test harness, measured before and after on the same fixtures.

**Title classification** — 50 store writes over 7 unchanged titles, three classifiers each, counting invocations of the leaf `titleHasAgentName`:

| | leaf regex matches |
| --- | --- |
| before | **4,350** |
| after | **0** |

Single-title read amplification: one `getAgentLabel('aider running')` costs 11 leaf matches; 20 further reads of the same title cost **231 before → 11 after** (i.e. once, then free).

**Lineage projection** — one sidebar pass over 423 worktrees (`getCyclicProjectedWorktreeLineageIds` + `getPinnedSectionWorktrees`, mirroring `buildRows`), counting `isValidResolvedWorktreeLineageEdge`:

| pass | before | after |
| --- | --- | --- |
| 1 | 1,266 | **844** |
| 2 | 1,266 | **0** |
| 3 | 1,266 | **0** |

Projected against the captured profile: the 11,771/sec `titleHasAgentName` and 4,399/sec legacy-regex rates collapse to roughly the rate at which titles actually change (a handful per second on an idle app), and the 8,653 + 4,064/sec lineage helpers drop to one scan per lineage/worktree-index replacement.

## `translate` at 8,444/sec — deliberately not fixed

Investigated and **deprioritized, honestly**. It is not on the selector path: `src/renderer/src/i18n/no-top-level-translate.test.ts` is an AST gate that *requires* every one of the ~12.7k `translate(` call sites to sit inside a function, so they are render bodies and event callbacks, not zustand selectors. The body (`src/renderer/src/i18n/i18n.ts:76-79`) is one `i18next.t` against the eagerly-bundled English catalog — a key lookup plus an options-object spread. The 8,444/sec is a symptom of render frequency, not of an expensive lookup, and caching it would introduce a language-switch invalidation hazard for no measured win. Fixing render frequency is the right lever, and it belongs to whoever owns those components.

## Tests

- `src/shared/terminal-title-classification-corpus.ts` + `.test.ts` — a 67-title corpus (Windows `.exe`/`.cmd`/`.bat`/`.ps1` suffixes, every boundary-guard case the comment at `agent-name-token-match.ts:8` describes — `opencode-blinker`, `openclaude`, `~/codex/ready`, `review-14600-codex`, `timestamp ready`, `android build running`, `C:\tools\codex\run` — leading braille and quarter-circle spinner glyphs, Gemini glyphs, Claude `✳`/`. `/`* ` prefixes, Cursor's closed set, Pi/OMP titles, and multiplexer-wrapped titles) pinned against **8 classifiers each**. The table was generated from the pre-memo implementation and verified to pass unchanged on both sides — the full JSON dump of all 67 × 8 verdicts is byte-identical before and after.
- `src/shared/terminal-title-classification-memo.test.ts` — the regression test. Fails without the fix (4,350 leaf calls / 231 per-title calls); passes with it (0 / 11). Also covers null-verdict caching, immediate reclassification on title change, and FIFO eviction at the 1024 cap.
- `src/renderer/src/components/sidebar/worktree-lineage-projection.test.ts` — identity reuse, rescan on either input being replaced, a removed lineage edge reflected immediately, and cycle detection surviving the cache. 3 of its 5 cases fail without the fix.

## Verification

- `pnpm tc` — clean.
- `npx oxlint <changed files>` — clean; `pnpm run check:code-quality:changed` — 0 new findings (incl. React Doctor, type-aware).
- `npx vitest run --config config/vitest.config.ts src/shared src/renderer/src/components/sidebar src/renderer/src/components/terminal-pane` — 13,146 passing. 7 files fail, **identically on `main` without this change** (`WorktreeCard.compact-hover`, `WorktreeCard.hosted-review-refresh`, `WorktreeList.lineage-agent-expansion-coupling`, `pty-connection-command-finished-cleanup`, `remote-runtime-pty-transport-{input-coalescing,stream-reconnect}`, `feature-interactions`) — pre-existing timeouts under this machine's parallel load, unrelated to this PR. The baseline actually failed 9 tests where this branch fails 7.

## Negative user-facing trade-offs

**None.**

- **Agent classification is byte-identical.** The pinned 67-title corpus was generated from the pre-memo implementation and passes unchanged against the memoized one across all 8 classifiers; the raw dump diffs clean. No classifier's logic was edited — the bodies were renamed to `compute*` and re-exported through the memo, nothing more.
- **No staleness window.** The cache key *is* the title. A pane that emits a new OSC title produces a new key on the very next read, so a title change is reflected immediately — there is no TTL, no epoch, and no invalidation signal that can be missed. The `reclassifies as soon as the title changes` test pins this.
- **Bounded memory.** 1024 entries per classifier, FIFO, holding references to strings the store already retains. Cannot grow with session length. The lineage cache is weak on both levels and pins nothing.
- **No wire, IPC, or persisted-state surface is touched**, so there is no remote-compatibility or migration exposure. The change is renderer- and main-local computation only.

## Scope

Touches nothing owned by other agents. `worktree-card-status-inputs.ts`, `useWorktreeAgentRows.ts`, `store/selectors.ts`, `terminal-workspace-routing.ts`, the dashboard bucket-count files, and everything under `terminal-pane/pty-connection/` were read for the call chain but not edited.
