### PR TITLE
perf(renderer): drop react-markdown and the emoji catalog off the boot path (-371 KB eager JS)

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardAgentRowMessage.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRowMessage.tsx
@@ -1,5 +1,9 @@
+import { useEffect } from 'react'
 import { cn } from '@/lib/utils'
-import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import {
+  CommentMarkdownAsync,
+  preloadCommentMarkdown
+} from '@/components/sidebar/comment-markdown-lazy'
 import { translate } from '@/i18n/i18n'
 
 type DashboardAgentRowMessageProps = {
@@ -13,6 +17,9 @@ export function DashboardAgentRowMessage({
   isInterrupted,
   lastAssistantMessage
 }: DashboardAgentRowMessageProps): React.JSX.Element | null {
+  // These rows are the sidebar's only boot-visible markdown, so warm the chunk as
+  // soon as one mounts rather than waiting for text to arrive.
+  useEffect(preloadCommentMarkdown, [])
   // Why: message slot is always reserved in collapsed view so the row height
   // stays fixed as assistant text arrives or clears.
   if (!isInterrupted && !lastAssistantMessage) {
@@ -38,7 +45,7 @@ export function DashboardAgentRowMessage({
         </span>
       ) : null}
       {lastAssistantMessage ? (
-        <CommentMarkdown
+        <CommentMarkdownAsync
           content={lastAssistantMessage}
           // Why: animate between a clipped preview and natural height without
           // measuring markdown content in JS.

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -6,7 +6,6 @@ import { toast } from 'sonner'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import { JiraIcon } from '@/components/icons/JiraIcon'
 import { SelectedTextCopyMenu } from '@/components/SelectedTextCopyMenu'
-import CommentMarkdown from './CommentMarkdown'
 import { WORKTREE_NATIVE_CONTEXT_MENU_ATTR } from './WorktreeContextMenu'
 import {
   WorktreeCardDetailSection,
@@ -31,6 +30,10 @@ import { WorktreeCardAutomationDetailSection } from './WorktreeCardAutomationDet
 import { WorktreeCardCliDetailSection } from './WorktreeCardCliDetailSection'
 import { WorktreeCardIssueDetailSection } from './WorktreeCardIssueDetailSection'
 import { WorktreeCardHoverIdentityHeader } from './WorktreeCardHoverIdentityHeader'
+import { CommentMarkdownAsync, preloadCommentMarkdown } from './comment-markdown-lazy'
+
+const COMMENT_MARKDOWN_CLASS_NAME =
+  'text-[11.5px] text-foreground break-words leading-normal [&_.comment-md-p]:block [&_.comment-md-p+.comment-md-p]:mt-1'
 
 export type {
   WorktreeCardIssueDisplay,
@@ -183,7 +186,12 @@ export function WorktreeCardDetailsHover({
       openDelay={openDelay}
       closeDelay={closeDelay}
     >
-      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardTrigger
+        asChild
+        onPointerEnter={hasComment(comment) ? preloadCommentMarkdown : undefined}
+      >
+        {children}
+      </HoverCardTrigger>
       <HoverCardContent
         side="right"
         align="start"
@@ -355,9 +363,11 @@ export function WorktreeCardDetailsHover({
                 }
               />
               <WorktreeCardDetailSectionContent className="space-y-2">
-                <CommentMarkdown
+                <CommentMarkdownAsync
                   content={comment ?? ''}
-                  className="text-[11.5px] text-foreground break-words leading-normal [&_.comment-md-p]:block [&_.comment-md-p+.comment-md-p]:mt-1"
+                  className={COMMENT_MARKDOWN_CLASS_NAME}
+                  // Mirrors remark-breaks so the fallback keeps the note's line count.
+                  fallbackClassName="whitespace-pre-wrap"
                 />
               </WorktreeCardDetailSectionContent>
             </WorktreeCardDetailSection>

--- a/src/renderer/src/components/sidebar/comment-markdown-lazy.tsx
+++ b/src/renderer/src/components/sidebar/comment-markdown-lazy.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { cn } from '@/lib/utils'
+import { lazyWithRetry } from '@/lib/lazy-with-retry'
+
+// Boot-path split: react-markdown + remark/rehype/DOMPurify is ~356 KB of JS that
+// only the sidebar's two markdown surfaces pull onto the eager graph. One lazy()
+// identity for both, so they share a component type and a single chunk fetch.
+const LazyCommentMarkdown = lazyWithRetry(() => import('./CommentMarkdown'), {
+  reloadKey: 'comment-markdown'
+})
+
+/** Warms the chunk ahead of render so the fallback is never actually shown. */
+export function preloadCommentMarkdown(): void {
+  void import('./CommentMarkdown')
+}
+
+type CommentMarkdownAsyncProps = React.ComponentProps<typeof LazyCommentMarkdown> & {
+  /** Extra classes for the pre-load fallback only, e.g. to mirror remark-breaks. */
+  fallbackClassName?: string
+}
+
+/**
+ * Renders the markdown body, falling back to the raw text in an identically
+ * classed box while the chunk loads — same width and wrapping constraints, so a
+ * paint before the chunk lands cannot shift layout.
+ */
+export function CommentMarkdownAsync({
+  fallbackClassName,
+  ...props
+}: CommentMarkdownAsyncProps): React.JSX.Element {
+  return (
+    <React.Suspense
+      fallback={
+        <div
+          className={cn(
+            'min-w-0 max-w-full [overflow-wrap:anywhere]',
+            props.className,
+            fallbackClassName
+          )}
+          title={props.title}
+        >
+          {props.content}
+        </div>
+      }
+    >
+      <LazyCommentMarkdown {...props} />
+    </React.Suspense>
+  )
+}

--- a/src/renderer/src/components/sidebar/worktree-card-markdown-isolation.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-markdown-isolation.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync, existsSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const rendererSrc = join(__dirname, '../..')
+const entry = join(rendererSrc, 'main.tsx')
+const COMMENT_MARKDOWN = join(rendererSrc, 'components/sidebar/CommentMarkdown.tsx')
+
+function source(relativePath: string): string {
+  return readFileSync(join(rendererSrc, relativePath), 'utf8')
+}
+
+const MODULE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx']
+
+function resolveImport(specifier: string, fromFile: string): string | null {
+  const base = specifier.startsWith('@/')
+    ? join(rendererSrc, specifier.slice(2))
+    : specifier.startsWith('.')
+      ? resolve(dirname(fromFile), specifier)
+      : null
+  if (base === null) {
+    return null
+  }
+  for (const extension of ['', ...MODULE_EXTENSIONS]) {
+    const candidate = base + extension
+    if (existsSync(candidate) && statSync(candidate).isFile()) {
+      return candidate
+    }
+  }
+  for (const extension of MODULE_EXTENSIONS) {
+    const candidate = join(base, `index${extension}`)
+    if (existsSync(candidate) && statSync(candidate).isFile()) {
+      return candidate
+    }
+  }
+  return null
+}
+
+// Static `from '...'` edges only; `import('...')` and `import type` do not ship
+// code onto the eager graph.
+const STATIC_IMPORT =
+  /(?:^|[\n;])\s*(?:import|export)(?:(?!\bfrom\b)[\s\S])*?\bfrom\s*['"]([^'"]+)['"]/g
+
+/** Walks the renderer entry's static import graph, recording how each module was reached. */
+function eagerModuleGraph(): Map<string, string | null> {
+  const parents = new Map<string, string | null>([[entry, null]])
+  const queue = [entry]
+  while (queue.length > 0) {
+    const current = queue.shift() as string
+    const contents = readFileSync(current, 'utf8')
+    for (const match of contents.matchAll(STATIC_IMPORT)) {
+      if (/^\s*(?:import|export)\s+type\b/.test(match[0].replace(/^[\n;]/, ''))) {
+        continue
+      }
+      const resolved = resolveImport(match[1], current)
+      if (resolved === null || parents.has(resolved)) {
+        continue
+      }
+      parents.set(resolved, current)
+      queue.push(resolved)
+    }
+  }
+  return parents
+}
+
+function importChain(parents: Map<string, string | null>, module: string): string[] {
+  const chain: string[] = []
+  let cursor: string | null | undefined = module
+  while (cursor) {
+    chain.push(cursor.slice(rendererSrc.length + 1))
+    cursor = parents.get(cursor)
+  }
+  return chain.toReversed()
+}
+
+describe('worktree card markdown performance isolation', () => {
+  it('keeps CommentMarkdown off the renderer boot graph entirely', () => {
+    const parents = eagerModuleGraph()
+
+    // Names the offending chain when this regresses, instead of a bare boolean.
+    const chain = parents.has(COMMENT_MARKDOWN) ? importChain(parents, COMMENT_MARKDOWN) : []
+    expect(chain).toEqual([])
+    expect(parents.size).toBeGreaterThan(1000)
+  })
+
+  it('routes both sidebar markdown surfaces through the shared lazy boundary', () => {
+    const lazyBoundary = source('components/sidebar/comment-markdown-lazy.tsx')
+    expect(lazyBoundary).toContain("import('./CommentMarkdown')")
+    // A fallback in the same box keeps first paint from shifting layout.
+    expect(lazyBoundary).toContain('React.Suspense')
+
+    for (const file of [
+      'components/sidebar/WorktreeCardMeta.tsx',
+      'components/dashboard/DashboardAgentRowMessage.tsx'
+    ]) {
+      const contents = source(file)
+      expect(contents).not.toMatch(/^import CommentMarkdown from/m)
+      expect(contents).toContain('CommentMarkdownAsync')
+      // The chunk must be warmed before the surface renders, not on demand.
+      expect(contents).toContain('preloadCommentMarkdown')
+    }
+  })
+})

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.lazy.test.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.lazy.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('workspace emoji shortcode index laziness', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('does not build the shared catalog when the renderer index is imported', async () => {
+    const shortcodeIndex = await import('./workspace-emoji-shortcodes')
+    const catalog = await import('../../../shared/emoji-shortcode-catalog')
+
+    expect(catalog.isEmojiShortcodeCatalogBuiltForTest()).toBe(false)
+
+    // Cursor/regex-only paths must stay off the catalog too.
+    expect(shortcodeIndex.getActiveWorkspaceEmojiShortcode('hi :tad', 7)).not.toBeNull()
+    expect(catalog.isEmojiShortcodeCatalogBuiltForTest()).toBe(false)
+
+    expect(shortcodeIndex.searchWorkspaceEmojiShortcodes('tada')[0]?.emoji).toBe('🎉')
+    expect(catalog.isEmojiShortcodeCatalogBuiltForTest()).toBe(true)
+  })
+
+  it('keeps the exact-shortcode index out of module scope', () => {
+    const indexSource = readFileSync(join(__dirname, 'workspace-emoji-shortcodes.ts'), 'utf8')
+
+    expect(indexSource).not.toMatch(/^const \w+ = new Map\(/m)
+    expect(indexSource).not.toContain('STANDARD_EMOJI_SHORTCODE_ENTRIES')
+  })
+})

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.ts
@@ -1,5 +1,5 @@
 import {
-  STANDARD_EMOJI_SHORTCODE_ENTRIES,
+  getStandardEmojiShortcodeEntries,
   type StandardEmojiShortcodeEntry
 } from '../../../shared/emoji-shortcode-catalog'
 
@@ -16,9 +16,19 @@ export type WorkspaceEmojiReplacement = {
   value: string
 }
 
-const EXACT_SHORTCODE = new Map(
-  STANDARD_EMOJI_SHORTCODE_ENTRIES.map(({ emoji, shortcode }) => [shortcode, { emoji, shortcode }])
-)
+// Lazy for the same reason as the shared catalog it indexes: nothing needs it
+// until a `:` shortcode is completed.
+let exactShortcode: ReadonlyMap<string, WorkspaceEmojiSuggestion> | null = null
+
+function exactShortcodeIndex(): ReadonlyMap<string, WorkspaceEmojiSuggestion> {
+  exactShortcode ??= new Map(
+    getStandardEmojiShortcodeEntries().map(({ emoji, shortcode }) => [
+      shortcode,
+      { emoji, shortcode }
+    ])
+  )
+  return exactShortcode
+}
 
 // Lower tiers rank first, so `korea` surfaces `south_korea` above `dishwasher`-style incidental hits.
 const MATCH_TIER = { exact: 0, prefix: 1, wordStart: 2, substring: 3 } as const
@@ -43,15 +53,17 @@ export function searchWorkspaceEmojiShortcodes(
     return []
   }
 
-  const matches = STANDARD_EMOJI_SHORTCODE_ENTRIES.flatMap((entry) => {
-    const tier = matchTier(entry.shortcode, normalizedQuery)
-    return tier === null ? [] : [{ ...entry, tier }]
-  }).sort(
-    (left, right) =>
-      left.tier - right.tier ||
-      left.shortcode.length - right.shortcode.length ||
-      left.shortcode.localeCompare(right.shortcode)
-  )
+  const matches = getStandardEmojiShortcodeEntries()
+    .flatMap((entry) => {
+      const tier = matchTier(entry.shortcode, normalizedQuery)
+      return tier === null ? [] : [{ ...entry, tier }]
+    })
+    .sort(
+      (left, right) =>
+        left.tier - right.tier ||
+        left.shortcode.length - right.shortcode.length ||
+        left.shortcode.localeCompare(right.shortcode)
+    )
   const seenEmoji = new Set<string>()
   const suggestions: WorkspaceEmojiSuggestion[] = []
   for (const { emoji, shortcode } of matches) {
@@ -96,7 +108,7 @@ export function replaceCompletedWorkspaceEmojiShortcode(
   if (!match) {
     return null
   }
-  const suggestion = EXACT_SHORTCODE.get(match[2].toLowerCase())
+  const suggestion = exactShortcodeIndex().get(match[2].toLowerCase())
   if (!suggestion) {
     return null
   }

--- a/src/shared/emoji-shortcode-catalog.lazy.test.ts
+++ b/src/shared/emoji-shortcode-catalog.lazy.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('emoji shortcode catalog laziness', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('does not build the catalog when the shared module is imported', async () => {
+    const catalog = await import('./emoji-shortcode-catalog.js')
+
+    expect(catalog.isEmojiShortcodeCatalogBuiltForTest()).toBe(false)
+
+    expect(catalog.getStandardEmojiShortcodeEntries().length).toBeGreaterThan(1000)
+    expect(catalog.isEmojiShortcodeCatalogBuiltForTest()).toBe(true)
+  })
+
+  it('builds on first use and keeps the main process off the eager path', async () => {
+    const catalog = await import('./emoji-shortcode-catalog.js')
+
+    expect(catalog.replaceKnownEmojiWithShortcodes('ship \u{1F389}')).toBe('ship  party ')
+    expect(catalog.isEmojiShortcodeCatalogBuiltForTest()).toBe(true)
+  })
+
+  it('leaves the main-process worktree namer importing only the deferred entry point', () => {
+    // A cross-project import would drag src/main into the shared tsconfig, so assert on source.
+    const worktreeLogic = readFileSync(join(__dirname, '../main/ipc/worktree-logic.ts'), 'utf8')
+    const catalogImport = worktreeLogic.match(
+      /import \{([^}]*)\} from '[^']*emoji-shortcode-catalog'/
+    )
+
+    expect(catalogImport?.[1].trim()).toBe('replaceKnownEmojiWithShortcodes')
+  })
+
+  it('keeps the catalog build out of module scope', () => {
+    const sharedSource = readFileSync(join(__dirname, 'emoji-shortcode-catalog.ts'), 'utf8')
+
+    // A module-scope `const X = <expression over the dataset>` is the regression this guards.
+    expect(sharedSource).not.toMatch(/^const \w+ = Object\.entries\(/m)
+    expect(sharedSource).not.toMatch(/^const \w+ = new (?:Map|Intl\.Segmenter)\(/m)
+    expect(sharedSource).toContain('function loadCatalog()')
+  })
+})

--- a/src/shared/emoji-shortcode-catalog.ts
+++ b/src/shared/emoji-shortcode-catalog.ts
@@ -8,22 +8,50 @@ export type StandardEmojiShortcodeEntry = {
 // Skin-tone aliases (`wave_tone3`) are ~40% of the dataset and would drown the suggestion list.
 const SKIN_TONE_SHORTCODE = /_tone\d(?:-\d)?$/
 
-const CATALOG = Object.entries(emojiShortcodes).flatMap(([hexcode, value]) => {
-  const shortcodes = (typeof value === 'string' ? [value] : value).filter(
-    (shortcode) => !SKIN_TONE_SHORTCODE.test(shortcode)
-  )
-  return shortcodes.length > 0 ? [{ emoji: hexcodeToEmoji(hexcode), shortcodes }] : []
-})
+type EmojiShortcodeCatalog = {
+  entries: readonly StandardEmojiShortcodeEntry[]
+  primaryShortcodeByEmoji: ReadonlyMap<string, string>
+  segmenter: Intl.Segmenter
+}
 
-export const STANDARD_EMOJI_SHORTCODE_ENTRIES: readonly StandardEmojiShortcodeEntry[] =
-  CATALOG.flatMap(({ emoji, shortcodes }) => shortcodes.map((shortcode) => ({ emoji, shortcode })))
+let catalog: EmojiShortcodeCatalog | null = null
 
-const PRIMARY_SHORTCODE_BY_EMOJI = new Map(
-  CATALOG.map(({ emoji, shortcodes }) => [
-    normalizeEmojiLookup(emoji),
-    primaryShortcode(shortcodes)
-  ])
-)
+// Why lazy: this walks ~3,900 shortcodes and is only needed once a `:` is typed
+// or a worktree name is sanitized, but at module scope every renderer and main
+// boot paid for it. Memoized so the first caller builds it exactly once.
+function loadCatalog(): EmojiShortcodeCatalog {
+  if (catalog) {
+    return catalog
+  }
+  const grouped = Object.entries(emojiShortcodes).flatMap(([hexcode, value]) => {
+    const shortcodes = (typeof value === 'string' ? [value] : value).filter(
+      (shortcode) => !SKIN_TONE_SHORTCODE.test(shortcode)
+    )
+    return shortcodes.length > 0 ? [{ emoji: hexcodeToEmoji(hexcode), shortcodes }] : []
+  })
+  catalog = {
+    entries: grouped.flatMap(({ emoji, shortcodes }) =>
+      shortcodes.map((shortcode) => ({ emoji, shortcode }))
+    ),
+    primaryShortcodeByEmoji: new Map(
+      grouped.map(({ emoji, shortcodes }) => [
+        normalizeEmojiLookup(emoji),
+        primaryShortcode(shortcodes)
+      ])
+    ),
+    segmenter: new Intl.Segmenter('en', { granularity: 'grapheme' })
+  }
+  return catalog
+}
+
+export function getStandardEmojiShortcodeEntries(): readonly StandardEmojiShortcodeEntry[] {
+  return loadCatalog().entries
+}
+
+/** Test-only probe for the lazy-boundary guard; never branch on this in product code. */
+export function isEmojiShortcodeCatalogBuiltForTest(): boolean {
+  return catalog !== null
+}
 
 /**
  * Pick the alias that reads best as a branch or directory name: skip `+1`/`-1` so the name
@@ -40,11 +68,10 @@ function primaryShortcode(shortcodes: readonly string[]): string {
   )
 }
 
-const EMOJI_SEGMENTER = new Intl.Segmenter('en', { granularity: 'grapheme' })
-
 export function replaceKnownEmojiWithShortcodes(input: string): string {
-  return Array.from(EMOJI_SEGMENTER.segment(input), ({ segment }) => {
-    const shortcode = PRIMARY_SHORTCODE_BY_EMOJI.get(normalizeEmojiLookup(segment))
+  const { primaryShortcodeByEmoji, segmenter } = loadCatalog()
+  return Array.from(segmenter.segment(input), ({ segment }) => {
+    const shortcode = primaryShortcodeByEmoji.get(normalizeEmojiLookup(segment))
     return shortcode ? ` ${shortcode.replaceAll('_', '-')} ` : segment
   }).join('')
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​177 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​177 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​143 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​105 |

<!-- /orca-pr-loc -->

## ELI5

Before Orca could show you anything, it was loading a full Markdown rendering engine (react-markdown + remark + rehype + DOMPurify) and building a 4,000-entry emoji dictionary. You don't need either one until you hover a worktree card or type a `:` in a rename box. This moves both off the boot path: the Markdown engine now loads in its own chunk the moment your cursor touches a card, and the emoji dictionary is built the first time something actually asks for a shortcode.

## Measurements

Real numbers from an `electron-vite` renderer build on this branch vs. the same build on its merge base, measured off `out/renderer/index.html` (entry script + `modulepreload` links — the JS the renderer parses before first paint).

### Eager renderer bundle

| | Before | After | Delta |
|---|---|---|---|
| Eager JS bytes | 5,569,446 | 5,198,787 | **−370,659 (−6.7%)** |
| Eager chunks (entry + modulepreload) | 331 | 325 | **−6** |
| Eager CSS | 571,829 | 571,829 | 0 |

For reference, the same script against the currently shipped `.asar` reports 5,561,678 B / 331 chunks, so the local baseline reproduces the shipped bundle to within 8 KB.

Chunks that left the eager set:

| Chunk | Bytes |
|---|---|
| `lib-*` (react-markdown + micromark/hast) | 220,546 |
| `lib-*` (mdast / unified / remark-gfm) | 108,865 |
| `purify.es-*` (DOMPurify, via `MermaidBlock`) | 27,124 |
| `CommentMarkdown-*` | 12,293 |
| `MermaidBlock-*` | 2,336 |
| `lib-*` (remark-breaks) | 160 |
| **Total** | **371,324** |

(Net is 665 B less than the sum, because the remaining eager chunks grew slightly for the dynamic-import glue.)

### Emoji shortcode catalog

Cold, single-shot measurement across 15 fresh Node processes — no JIT warm-up, which is what a boot actually pays:

| Phase | Median | Min | Max |
|---|---|---|---|
| `JSON.parse` of the dataset | 0.85 ms | 0.79 ms | 4.12 ms |
| Catalog build (`Object.entries` → `flatMap` → regex filter → `Map` + `Intl.Segmenter`) | **19.32 ms** | 10.66 ms | 59.65 ms |
| Renderer exact-shortcode `Map` | 0.30 ms | 0.27 ms | 1.22 ms |
| **Total removed from module eval** | **~19.6 ms** | ~11 ms | — |

Dataset: 3,979 hexcodes → 2,590 non-skin-tone entries → 1,945 primary shortcodes.

That ~19.6 ms was paid **twice** on every launch — once on renderer boot and once on main-process boot, since `src/main/ipc/worktree-logic.ts` imports the same module for worktree naming. Both now pay 0 ms at import.

## Corrections to the brief

1. **`CommentMarkdown` had two eager static importers, not one.** Fixing only `WorktreeCardMeta` moved **zero** bytes — measured 5,569,446 → 5,570,185, i.e. **+739 B**. The second path is the sidebar card's inline agent rows:
   `App → Sidebar → WorktreeList → WorktreeCard → worktree-card-secondary-rows → WorktreeCardAgents → dashboard/DashboardAgentRow → DashboardAgentRowMessage → CommentMarkdown`.
   Both surfaces now share one `lazy()` identity in `comment-markdown-lazy.tsx`, so they share a component type, a chunk, and a single fetch.
2. **The emoji fix buys time, not bytes.** `useWorkspaceEmojiShortcodeInput-*.js` (175,909 B in the shipped bundle) stays eagerly preloaded, because `WorktreeTitleInlineRename` — which renders on every card — statically imports the hook, and the bundler inlines the dataset as a JS object literal in that chunk. Removing those bytes needs an *async* data boundary, which would make the synchronous `searchWorkspaceEmojiShortcodes` return `[]` on the very first `:` keystroke. That trades a guaranteed behavior change for ~3% of the bundle, so it is deliberately not done here. Net: (a) + (b) is ~371 KB, not the estimated 535 KB.
3. **The measured "21.9 ms JSON parse" does not reproduce.** `JSON.parse` of `emojibase.json` is ~0.9 ms; essentially the entire ~20 ms is the transform — which is exactly what this defers.
4. **Path nit:** the jump-palette call site is `src/renderer/src/components/use-worktree-jump-palette-controller.ts`, not `src/renderer/src/lib/…`.

## Negative user-facing trade-offs

**None observed, with one honest caveat below.**

- **First hover over a card with notes.** `onPointerEnter` on the `HoverCardTrigger` starts `import('./CommentMarkdown')` immediately; the hover card's `openDelay` is 250 ms, so the chunk gets a quarter-second head start on the content mounting. The fetch is a local `app://` read of ~371 KB — an order of magnitude inside that budget. **No visible delay and no layout shift**: if the chunk somehow has not landed, the Suspense fallback is the raw note text in a `<div>` carrying the *same* `className` plus the same `min-w-0 max-w-full [overflow-wrap:anywhere]` box constraints, and `whitespace-pre-wrap` to mirror `remark-breaks`' line count. Same box, same line count; only Markdown punctuation would read literally for that instant. `WorktreeCard.compact-hover.test.tsx`, which opens the hover and asserts the notes body renders, passes unchanged.
- **Sidebar agent rows are the one boot-visible Markdown surface**, so `DashboardAgentRowMessage` warms the chunk from a mount `useEffect` rather than waiting for text to arrive. Its collapsed row height is fixed by CSS (`h-[1lh]`, `truncate`), so the height is identical whether the fallback or the real renderer is mounted — no reflow either way. **The caveat:** on a cold boot where agent rows already carry an assistant message in the first paint, that one-line preview can briefly show raw text before the chunk lands. It occupies exactly the same clipped single line, so nothing shifts; a message containing Markdown punctuation would show that punctuation for the length of one local disk read.
- **Emoji completion is unchanged.** The API stayed synchronous — `STANDARD_EMOJI_SHORTCODE_ENTRIES` became `getStandardEmojiShortcodeEntries()`, memoized behind `loadCatalog()`. The first `:` builds the catalog inline (the ~20 ms this used to spend at boot) on a keystroke where the user has already committed to typing a shortcode; every keystroke after is free. `replaceKnownEmojiWithShortcodes` output is byte-identical (asserted).
- **Chunk-load resilience is not weakened**: the boundary uses the repo's existing `lazyWithRetry`, so a stale or truncated chunk gets the same retry-then-reload recovery as every other lazy surface.

## Guard tests

`src/renderer/src/components/sidebar/worktree-card-markdown-isolation.test.ts`
- Walks the renderer's **actual static import graph** from `main.tsx` and asserts `CommentMarkdown.tsx` is unreachable. This is what catches the class of regression the brief's trace missed — a second importer *anywhere* in the graph, not just in `components/sidebar/`. On failure it prints the offending import chain.
- Asserts both surfaces route through the shared lazy boundary, and that both preload.

`src/shared/emoji-shortcode-catalog.lazy.test.ts`
- Asserts importing the shared module leaves the catalog **unbuilt**, and that it becomes built only once a lookup runs.
- Asserts the main-process worktree namer imports only the deferred entry point (`replaceKnownEmojiWithShortcodes`), by source — a real cross-project import would drag `src/main` into the shared tsconfig.
- Source guard against a module-scope `Object.entries(...)` / `new Map(...)` / `new Intl.Segmenter(...)` creeping back.

`src/renderer/src/lib/workspace-emoji-shortcodes.lazy.test.ts`
- Asserts importing the renderer index leaves the shared catalog unbuilt, that the cursor/regex-only path stays off it, and that the first search builds it.

All of these fail with the fix reverted and the tests kept.

## Verification

- `pnpm tc` — clean.
- `npx oxlint <changed files>` — clean.
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar src/shared` — 8,934+ passing. A handful of files time out under the CI-less local machine's load (load average ~100 from parallel agents); every one of them, including `WorktreeCard.pr-display.test.tsx`, reproduces the identical timeout on unmodified `HEAD` and passes when run in isolation on this branch.

## Explicitly not attempted

`store-*.js` (1.23 MB), `App-*.js` (986 KB), and `i18n-*.js` (702 KB) are untouched — splitting the first two is a design change, and non-English locales are already lazy.
