### PR TITLE
perf(renderer): reconcile hydrated workspaces in one store write

### DIFF
--- a/src/renderer/src/app-shell/reconcile-hydrated-workspace-tab-models.test.ts
+++ b/src/renderer/src/app-shell/reconcile-hydrated-workspace-tab-models.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it, vi } from 'vitest'
 import { reconcileHydratedWorkspaceTabModels } from './reconcile-hydrated-workspace-tab-models'
 
 describe('reconcileHydratedWorkspaceTabModels', () => {
-  it('reconciles every workspace the session hydrated, in session order', () => {
+  it('reconciles every workspace the session hydrated, in session order, in one call', () => {
     const reconcile = vi.fn()
     const reconciled = reconcileHydratedWorkspaceTabModels(
       { tabsByWorktree: { 'wt-a': [], 'wt-b': [], 'wt-c': [] } },
       reconcile
     )
-    expect(reconcile.mock.calls.map((call) => call[0])).toEqual(['wt-a', 'wt-b', 'wt-c'])
+    expect(reconcile).toHaveBeenCalledTimes(1)
+    expect(reconcile.mock.calls[0]?.[0]).toEqual(['wt-a', 'wt-b', 'wt-c'])
     expect(reconciled).toEqual(['wt-a', 'wt-b', 'wt-c'])
   })
 

--- a/src/renderer/src/app-shell/reconcile-hydrated-workspace-tab-models.ts
+++ b/src/renderer/src/app-shell/reconcile-hydrated-workspace-tab-models.ts
@@ -3,12 +3,13 @@ import type { WorkspaceSessionState } from '../../../shared/workspace-session-st
 /** Reconcile every workspace loaded during boot so stale unified-tab subsets converge. */
 export function reconcileHydratedWorkspaceTabModels(
   session: Pick<WorkspaceSessionState, 'tabsByWorktree'>,
-  reconcileWorktreeTabModel: (worktreeId: string) => unknown
+  // Why batched: one store write for the whole session instead of one per
+  // workspace, each fanning out to every non-React store subscriber.
+  reconcileWorktreeTabModels: (worktreeIds: readonly string[]) => void
 ): string[] {
-  const reconciled: string[] = []
-  for (const worktreeId of Object.keys(session.tabsByWorktree)) {
-    reconcileWorktreeTabModel(worktreeId)
-    reconciled.push(worktreeId)
+  const reconciled = Object.keys(session.tabsByWorktree)
+  if (reconciled.length > 0) {
+    reconcileWorktreeTabModels(reconciled)
   }
   return reconciled
 }

--- a/src/renderer/src/app-shell/use-app-startup-hydration.ts
+++ b/src/renderer/src/app-shell/use-app-startup-hydration.ts
@@ -198,7 +198,7 @@ export function useAppStartupHydration(onOnboardingLoaded: (state: OnboardingSta
             actions.hydrateBrowserSession(sessionRead.session, sessionHydrationOptions)
             reconcileHydratedWorkspaceTabModels(
               sessionRead.session,
-              useAppStore.getState().reconcileWorktreeTabModel
+              useAppStore.getState().reconcileWorktreeTabModels
             )
           })
           await timeRendererStartupStep('prepare-terminal-startup-restoration', () =>

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -21,6 +21,7 @@ import { disposeWebgl } from './pane-webgl-renderer'
 import { clearPendingSplitScrollRestore, scheduleSplitScrollRestore } from './pane-split-scroll'
 import { reattachWebglIfNeeded } from './pane-webgl-reattach'
 import { toPublicPane } from './pane-public-view'
+import { releaseTerminalScrollIntentKey } from './terminal-scroll-intent-key-store'
 
 type MovedPaneSplitState = {
   pane: ManagedPaneInternal
@@ -179,6 +180,12 @@ function teardownManagedPane(
   const closedLeafId = pane.leafId
   args.releasePaneIdentity(args.paneId)
   removePaneContainer(args, pane)
+  if (reason === 'close') {
+    // Leaf ids are minted UUIDs and never reused, so a closed leaf's scroll
+    // intent is unreachable. Detach/retire hand the leaf to a new host, which
+    // must still be able to restore it.
+    releaseTerminalScrollIntentKey(closedLeafId)
+  }
   const nextActivePaneId = activateReplacementPane(args)
   applyPaneOpacity(args.panes.values(), nextActivePaneId, args.styleOptions)
   for (const p of args.panes.values()) {

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent-dom-tracking.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent-dom-tracking.ts
@@ -8,7 +8,8 @@ import {
   syncTerminalScrollIntentFromViewport
 } from './terminal-scroll-intent'
 import { syncTerminalScrollIntentSoon } from './terminal-scroll-intent-settle'
-import type { TerminalScrollIntentKey, TerminalScrollIntentTarget } from './terminal-scroll-intent'
+import type { TerminalScrollIntentTarget } from './terminal-scroll-intent'
+import type { TerminalScrollIntentKey } from './terminal-scroll-intent-key-store'
 import {
   isTerminalScrollIntentRebuildInFlight,
   onTerminalScrollIntentBufferRebuildComplete

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent-key-retention.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent-key-retention.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
+
+const disposePane = vi.hoisted(() =>
+  vi.fn((pane: ManagedPaneInternal, panes: Map<number, ManagedPaneInternal>) => {
+    panes.delete(pane.id)
+  })
+)
+
+vi.mock('./pane-tree-ops', () => ({
+  captureScrollState: vi.fn(),
+  findPaneChildren: vi.fn(() => []),
+  promoteSibling: vi.fn(),
+  removeDividers: vi.fn(),
+  safeFit: vi.fn(),
+  wrapInSplit: vi.fn()
+}))
+vi.mock('./pane-lifecycle', () => ({ disposePane, openTerminal: vi.fn() }))
+vi.mock('./pane-webgl-renderer', () => ({ disposeWebgl: vi.fn() }))
+vi.mock('./pane-split-scroll', () => ({
+  clearPendingSplitScrollRestore: vi.fn(),
+  scheduleSplitScrollRestore: vi.fn()
+}))
+vi.mock('./pane-drag-reorder', () => ({ updateMultiPaneState: vi.fn() }))
+vi.mock('./pane-divider', () => ({ applyDividerStyles: vi.fn(), applyPaneOpacity: vi.fn() }))
+
+import {
+  closeManagedPane,
+  detachManagedPaneForExternalMove,
+  retireManagedPanePreservingPty
+} from './pane-split-close'
+import {
+  bindTerminalScrollIntentKey,
+  markTerminalPinnedViewport,
+  type TerminalScrollIntentTarget
+} from './terminal-scroll-intent'
+import {
+  readTerminalScrollIntentKeyRetention,
+  releaseTerminalScrollIntentKey
+} from './terminal-scroll-intent-key-store'
+
+function leafIdAt(index: number): TerminalLeafId {
+  return `11111111-1111-4111-8111-${String(index).padStart(12, '0')}` as TerminalLeafId
+}
+
+/** A pinned (non-bottom) viewport so a keyed intent is actually retained. */
+function createPinnedTerminal(): TerminalScrollIntentTarget {
+  return {
+    buffer: { active: { type: 'normal', viewportY: 3, baseY: 40 } } as never,
+    scrollToBottom: vi.fn(),
+    scrollToLine: vi.fn()
+  }
+}
+
+function createPane(id: number, leafId: TerminalLeafId): ManagedPaneInternal {
+  const container = {
+    classList: { contains: (className: string) => className === 'pane' },
+    dataset: { paneId: String(id), leafId },
+    parentElement: null,
+    remove: vi.fn()
+  }
+  return {
+    id,
+    leafId,
+    stablePaneId: leafId,
+    terminal: { focus: vi.fn() } as never,
+    container: container as unknown as HTMLElement,
+    xtermContainer: {} as never,
+    linkTooltip: {} as never,
+    terminalGpuAcceleration: 'auto',
+    gpuRenderingEnabled: false,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    hasComplexScriptOutput: false,
+    webglAddon: null,
+    ligaturesAddon: null,
+    fitResizeObserver: null,
+    pendingObservedFitRafId: null,
+    fitAddon: {} as never,
+    searchAddon: {} as never,
+    serializeAddon: {} as never,
+    unicode11Addon: {} as never,
+    webLinksAddon: {} as never,
+    compositionHandler: null,
+    pendingSplitScrollState: null,
+    debugLabel: null
+  }
+}
+
+function openPane(id: number, leafId: TerminalLeafId): ManagedPaneInternal {
+  const pane = createPane(id, leafId)
+  const terminal = createPinnedTerminal()
+  bindTerminalScrollIntentKey(terminal, leafId)
+  markTerminalPinnedViewport(terminal)
+  return pane
+}
+
+function closeArgs(pane: ManagedPaneInternal, panes: Map<number, ManagedPaneInternal>) {
+  return {
+    paneId: pane.id,
+    activePaneId: null,
+    panes,
+    root: {} as HTMLElement,
+    styleOptions: {},
+    managerOptions: { linkOpenHint: () => '' },
+    getDragCallbacks: () => ({}) as never,
+    releasePaneIdentity: vi.fn(),
+    setActivePaneId: vi.fn()
+  }
+}
+
+describe('terminal scroll intent key retention', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns both keyed maps to baseline after 200 pane open/close cycles', () => {
+    const baseline = readTerminalScrollIntentKeyRetention()
+
+    for (let index = 0; index < 200; index += 1) {
+      const leafId = leafIdAt(index)
+      const pane = openPane(index + 1, leafId)
+      const panes = new Map([[pane.id, pane]])
+      // A pinned pane must actually retain its keyed intent while it is open.
+      expect(readTerminalScrollIntentKeyRetention()).toEqual({
+        intents: baseline.intents + 1,
+        bindings: baseline.bindings + 1
+      })
+      // Keep a second pane so close is never the last-pane no-op path.
+      const survivor = createPane(10_000 + index, leafIdAt(10_000 + index))
+      panes.set(survivor.id, survivor)
+      closeManagedPane(closeArgs(pane, panes))
+    }
+
+    expect(readTerminalScrollIntentKeyRetention()).toEqual(baseline)
+  })
+
+  it('keeps the keyed intent when the leaf is handed to a new host', () => {
+    const baseline = readTerminalScrollIntentKeyRetention()
+
+    for (const teardown of [detachManagedPaneForExternalMove, retireManagedPanePreservingPty]) {
+      const leafId = leafIdAt(9000 + Number(teardown === retireManagedPanePreservingPty))
+      const pane = openPane(9000, leafId)
+      const survivor = createPane(9001, leafIdAt(9001))
+      const panes = new Map([
+        [pane.id, pane],
+        [survivor.id, survivor]
+      ])
+
+      expect(teardown(closeArgs(pane, panes))).toBe(true)
+      expect(readTerminalScrollIntentKeyRetention().intents).toBe(baseline.intents + 1)
+
+      releaseTerminalScrollIntentKey(leafId)
+    }
+
+    expect(readTerminalScrollIntentKeyRetention()).toEqual(baseline)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent-key-store.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent-key-store.ts
@@ -1,0 +1,63 @@
+import type { TerminalScrollBufferType } from './terminal-scroll-buffer-snapshot'
+
+export type TerminalScrollIntentKind = 'followOutput' | 'pinnedViewport'
+export type TerminalScrollIntentKey = string
+
+export type TerminalScrollIntent = {
+  kind: TerminalScrollIntentKind
+  bufferType: TerminalScrollBufferType
+  viewportY: number
+  baseY: number
+  revision: number
+}
+
+// Keyed by stable leaf id, so a pin outlives the xterm instance that recorded
+// it (workspace switch, keyed remount). Unlike the WeakMap-keyed siblings in
+// terminal-scroll-intent.ts these hold a strong string key, so a leaf that is
+// gone for good must be released explicitly — see releaseTerminalScrollIntentKey.
+const terminalScrollIntentByKey = new Map<TerminalScrollIntentKey, TerminalScrollIntent>()
+const terminalScrollIntentBindingByKey = new Map<TerminalScrollIntentKey, number>()
+
+export function readKeyedTerminalScrollIntent(
+  key: TerminalScrollIntentKey
+): TerminalScrollIntent | undefined {
+  return terminalScrollIntentByKey.get(key)
+}
+
+export function writeKeyedTerminalScrollIntent(
+  key: TerminalScrollIntentKey,
+  intent: TerminalScrollIntent
+): void {
+  terminalScrollIntentByKey.set(key, intent)
+}
+
+export function readKeyedTerminalScrollIntentBinding(
+  key: TerminalScrollIntentKey
+): number | undefined {
+  return terminalScrollIntentBindingByKey.get(key)
+}
+
+export function writeKeyedTerminalScrollIntentBinding(
+  key: TerminalScrollIntentKey,
+  binding: number
+): void {
+  terminalScrollIntentBindingByKey.set(key, binding)
+}
+
+/**
+ * Drops the keyed intent for a leaf that is gone for good. Only safe on a real
+ * close: plain disposal (workspace switch, keyed remount, manager destroy)
+ * relies on these entries to restore the pin when the leaf mounts again.
+ */
+export function releaseTerminalScrollIntentKey(key: TerminalScrollIntentKey): void {
+  terminalScrollIntentByKey.delete(key)
+  terminalScrollIntentBindingByKey.delete(key)
+}
+
+/** Retention probe for the leak tests. */
+export function readTerminalScrollIntentKeyRetention(): { intents: number; bindings: number } {
+  return {
+    intents: terminalScrollIntentByKey.size,
+    bindings: terminalScrollIntentBindingByKey.size
+  }
+}

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
@@ -4,6 +4,17 @@ import {
 } from './terminal-follow-output-waiters'
 import { isTerminalScrollIntentRebuildInFlight } from './terminal-scroll-intent-rebuild'
 import {
+  readKeyedTerminalScrollIntent,
+  readKeyedTerminalScrollIntentBinding,
+  writeKeyedTerminalScrollIntent,
+  writeKeyedTerminalScrollIntentBinding
+} from './terminal-scroll-intent-key-store'
+import type {
+  TerminalScrollIntent,
+  TerminalScrollIntentKey,
+  TerminalScrollIntentKind
+} from './terminal-scroll-intent-key-store'
+import {
   clampTerminalViewportY,
   isTerminalViewportAtBottom,
   readTerminalScrollBufferSnapshot,
@@ -11,22 +22,10 @@ import {
   type TerminalScrollBufferType
 } from './terminal-scroll-buffer-snapshot'
 
-type TerminalScrollIntentKind = 'followOutput' | 'pinnedViewport'
-
 export type TerminalScrollIntentTarget = {
   buffer?: Parameters<typeof readTerminalScrollBufferSnapshot>[0]['buffer']
   scrollToBottom?: () => void
   scrollToLine?: (line: number) => void
-}
-
-export type TerminalScrollIntentKey = string
-
-type TerminalScrollIntent = {
-  kind: TerminalScrollIntentKind
-  bufferType: TerminalScrollBufferType
-  viewportY: number
-  baseY: number
-  revision: number
 }
 
 export type TerminalStructuralScrollIntentSnapshot = {
@@ -53,8 +52,6 @@ const terminalScrollIntentKeyByTerminal = new WeakMap<
   TerminalScrollIntentKey
 >()
 const terminalScrollIntentKeyBindingByTerminal = new WeakMap<TerminalScrollIntentTarget, number>()
-const terminalScrollIntentByKey = new Map<TerminalScrollIntentKey, TerminalScrollIntent>()
-const terminalScrollIntentBindingByKey = new Map<TerminalScrollIntentKey, number>()
 
 let nextTerminalScrollIntentRevision = 1
 let nextTerminalScrollIntentKeyBinding = 1
@@ -92,7 +89,7 @@ function writeIntentSnapshot(
   terminalScrollIntentByTerminal.set(terminal, intent)
   const key = terminalScrollIntentKeyByTerminal.get(terminal)
   if (key) {
-    terminalScrollIntentByKey.set(key, intent)
+    writeKeyedTerminalScrollIntent(key, intent)
   }
   if (kind === 'followOutput') {
     notifyTerminalFollowOutputWaiters(terminal)
@@ -106,7 +103,7 @@ function readStoredIntent(terminal: TerminalScrollIntentTarget): TerminalScrollI
     return terminalIntent
   }
   const key = terminalScrollIntentKeyByTerminal.get(terminal)
-  return key ? terminalScrollIntentByKey.get(key) : undefined
+  return key ? readKeyedTerminalScrollIntent(key) : undefined
 }
 
 export function bindTerminalScrollIntentKey(
@@ -120,8 +117,8 @@ export function bindTerminalScrollIntentKey(
   const binding = nextTerminalScrollIntentKeyBinding
   nextTerminalScrollIntentKeyBinding += 1
   terminalScrollIntentKeyBindingByTerminal.set(terminal, binding)
-  terminalScrollIntentBindingByKey.set(key, binding)
-  const existing = terminalScrollIntentByKey.get(key)
+  writeKeyedTerminalScrollIntentBinding(key, binding)
+  const existing = readKeyedTerminalScrollIntent(key)
   if (existing) {
     terminalScrollIntentByTerminal.set(terminal, existing)
   }
@@ -137,7 +134,7 @@ export function isTerminalScrollIntentKeyBindingCurrent(
   }
   return (
     terminalScrollIntentKeyBindingByTerminal.get(terminal) ===
-    terminalScrollIntentBindingByKey.get(key)
+    readKeyedTerminalScrollIntentBinding(key)
   )
 }
 

--- a/src/renderer/src/store/slices/store-session-terminal-reconnect.test.ts
+++ b/src/renderer/src/store/slices/store-session-terminal-reconnect.test.ts
@@ -599,9 +599,12 @@ describe('reconnectPersistedTerminals', () => {
     }
     const sshConnectionStates = new Map([[targetId, currentAuthorityState]])
     const originalGet = sshConnectionStates.get.bind(sshConnectionStates)
+    // Rotate from the first read after the entry authority check, so the
+    // pre-publication check sees the new generation whatever number of
+    // intermediate reads the reconnect pass happens to make.
     sshConnectionStates.get = ((key: string) => {
       authorityReads += 1
-      return authorityReads >= 4 ? rotatedAuthorityState : originalGet(key)
+      return authorityReads >= 2 ? rotatedAuthorityState : originalGet(key)
     }) as typeof sshConnectionStates.get
     store.setState({
       repos: [
@@ -636,7 +639,7 @@ describe('reconnectPersistedTerminals', () => {
     })
 
     const after = store.getState()
-    expect(authorityReads).toBeGreaterThanOrEqual(4)
+    expect(authorityReads).toBeGreaterThanOrEqual(2)
     expect(after.tabsByWorktree).toBe(before.tabsByWorktree)
     expect(after.ptyIdsByTabId).toBe(before.ptyIdsByTabId)
     expect(after.pendingReconnectWorktreeIds).toBe(before.pendingReconnectWorktreeIds)

--- a/src/renderer/src/store/slices/tabs/hydrated-workspace-reconciliation-batch.test.ts
+++ b/src/renderer/src/store/slices/tabs/hydrated-workspace-reconciliation-batch.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+import { createTabsSliceMockApi } from '../tabs-slice-test-harness'
+import { createTestStore } from '../store-test-helpers'
+import {
+  buildHydratedWorkspaceFixture,
+  HYDRATED_TAB_COUNT,
+  HYDRATED_WORKSPACE_COUNT,
+  RECONCILIATION_WRITABLE_KEYS
+} from './hydrated-workspace-reconciliation-fixture'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return { ...actual, detectAgentStatusFromTitle: vi.fn().mockReturnValue(null) }
+})
+
+createTabsSliceMockApi()
+
+// Approximates the renderer's live non-React store-subscriber population.
+const SUBSCRIBER_COUNT = 1200
+
+type Store = ReturnType<typeof createTestStore>
+
+function hydrateFixtureStore(): { store: Store; workspaceIds: string[] } {
+  const fixture = buildHydratedWorkspaceFixture()
+  expect(fixture.workspaceIds).toHaveLength(HYDRATED_WORKSPACE_COUNT)
+  expect(fixture.tabCount).toBe(HYDRATED_TAB_COUNT)
+  const store = createTestStore()
+  store.setState(fixture.state)
+  return { store, workspaceIds: fixture.workspaceIds }
+}
+
+function countNotifications(store: Store, run: () => void): number {
+  let notifications = 0
+  const unsubscribes = Array.from({ length: SUBSCRIBER_COUNT }, () =>
+    store.subscribe(() => {
+      notifications += 1
+    })
+  )
+  try {
+    run()
+  } finally {
+    for (const unsubscribe of unsubscribes) {
+      unsubscribe()
+    }
+  }
+  return notifications
+}
+
+/** Group ids for restored legacy terminals are minted, so pin them to compare states. */
+function withDeterministicUuids<T>(run: () => T): T {
+  let counter = 0
+  const spy = vi.spyOn(globalThis.crypto, 'randomUUID').mockImplementation(() => {
+    counter += 1
+    return `00000000-0000-4000-8000-${String(counter).padStart(12, '0')}`
+  })
+  try {
+    return run()
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+function reconciliationSnapshot(store: Store): Record<string, unknown> {
+  const state = store.getState() as unknown as Record<string, unknown>
+  return Object.fromEntries(RECONCILIATION_WRITABLE_KEYS.map((key) => [key, state[key]]))
+}
+
+describe('whole-session workspace tab-model reconciliation', () => {
+  it('collapses a 193-workspace hydration to one store write', () => {
+    const perWorkspace = hydrateFixtureStore()
+    const perWorkspaceNotifications = countNotifications(perWorkspace.store, () => {
+      for (const worktreeId of perWorkspace.workspaceIds) {
+        perWorkspace.store.getState().reconcileWorktreeTabModel(worktreeId)
+      }
+    })
+
+    const batched = hydrateFixtureStore()
+    const batchedNotifications = countNotifications(batched.store, () => {
+      batched.store.getState().reconcileWorktreeTabModels(batched.workspaceIds)
+    })
+
+    // The fixture must actually be write-heavy, or the collapse proves nothing.
+    expect(perWorkspaceNotifications / SUBSCRIBER_COUNT).toBeGreaterThan(100)
+    expect(batchedNotifications).toBe(SUBSCRIBER_COUNT)
+  })
+
+  it('leaves the store byte-identical to the per-workspace path', () => {
+    const perWorkspace = hydrateFixtureStore()
+    withDeterministicUuids(() => {
+      for (const worktreeId of perWorkspace.workspaceIds) {
+        perWorkspace.store.getState().reconcileWorktreeTabModel(worktreeId)
+      }
+    })
+    const expected = reconciliationSnapshot(perWorkspace.store)
+
+    const batched = hydrateFixtureStore()
+    withDeterministicUuids(() => {
+      batched.store.getState().reconcileWorktreeTabModels(batched.workspaceIds)
+    })
+    const actual = reconciliationSnapshot(batched.store)
+
+    expect(actual).toEqual(expected)
+    // Object key order is observable through Object.keys/entries iteration in
+    // selectors and session serialization, so equal values are not enough.
+    for (const key of RECONCILIATION_WRITABLE_KEYS) {
+      const actualValue = actual[key]
+      const expectedValue = expected[key]
+      if (actualValue && typeof actualValue === 'object' && !Array.isArray(actualValue)) {
+        expect([key, Object.keys(actualValue)]).toEqual([key, Object.keys(expectedValue as object)])
+      }
+    }
+  })
+
+  it('re-reconciling the batched result is a no-op, as it is for the per-workspace path', () => {
+    const { store, workspaceIds } = hydrateFixtureStore()
+    store.getState().reconcileWorktreeTabModels(workspaceIds)
+    const settled = reconciliationSnapshot(store)
+
+    const notifications = countNotifications(store, () => {
+      store.getState().reconcileWorktreeTabModels(workspaceIds)
+    })
+
+    expect(notifications).toBe(0)
+    expect(reconciliationSnapshot(store)).toEqual(settled)
+  })
+
+  it('indexes openFiles once instead of rescanning it per workspace', () => {
+    const { store, workspaceIds } = hydrateFixtureStore()
+    const openFiles = store.getState().openFiles
+    let scans = 0
+    store.setState({
+      openFiles: new Proxy(openFiles, {
+        get(target, property, receiver) {
+          if (property === 'filter') {
+            scans += 1
+          }
+          return Reflect.get(target, property, receiver)
+        }
+      })
+    })
+
+    store.getState().reconcileWorktreeTabModels(workspaceIds)
+
+    expect(scans).toBe(0)
+  })
+})

--- a/src/renderer/src/store/slices/tabs/hydrated-workspace-reconciliation-fixture.ts
+++ b/src/renderer/src/store/slices/tabs/hydrated-workspace-reconciliation-fixture.ts
@@ -1,0 +1,242 @@
+import type { AppState } from '../../types'
+import type { Tab, TabGroup } from '../../../../../shared/tab-types'
+import type { TerminalTab } from '../../../../../shared/terminal-tab-types'
+import type { OpenFile } from '../editor'
+
+/**
+ * Session shape measured on a real heavy profile: 193 workspaces / 382 tabs,
+ * spread over every reconciliation outcome (no-op, dropped tab, restored legacy
+ * runtime terminal, orphan sweep, editor tab) so a whole-session fold exercises
+ * both the workspace-scoped maps and the store-global ones workspaces share.
+ */
+export const HYDRATED_WORKSPACE_COUNT = 193
+export const HYDRATED_TAB_COUNT = 382
+
+const BUCKETS = ['stable', 'stale', 'legacy', 'orphan', 'editor'] as const
+type Bucket = (typeof BUCKETS)[number]
+
+export type HydratedWorkspaceFixture = {
+  workspaceIds: string[]
+  tabCount: number
+  state: Partial<AppState>
+}
+
+type FixtureDraft = {
+  unifiedTabsByWorktree: Record<string, Tab[]>
+  groupsByWorktree: Record<string, TabGroup[]>
+  activeGroupIdByWorktree: Record<string, string>
+  tabsByWorktree: Record<string, TerminalTab[]>
+  activeTabIdByWorktree: Record<string, string | null>
+  tabBarOrderByWorktree: Record<string, string[]>
+  ptyIdsByTabId: Record<string, string[]>
+  pendingReconnectPtyIdByTabId: Record<string, string>
+  unreadTerminalTabs: Record<string, true>
+  cacheTimerByKey: Record<string, number>
+  openFiles: OpenFile[]
+}
+
+function unifiedTab(id: string, worktreeId: string, groupId: string, over: Partial<Tab>): Tab {
+  return {
+    id,
+    entityId: id,
+    groupId,
+    worktreeId,
+    contentType: 'terminal',
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    ...over
+  }
+}
+
+function runtimeTab(id: string, worktreeId: string, over: Partial<TerminalTab>): TerminalTab {
+  return {
+    id,
+    ptyId: `pty-${id}`,
+    worktreeId,
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    ...over
+  }
+}
+
+function setGroup(draft: FixtureDraft, worktreeId: string, groupId: string, tabs: Tab[]): void {
+  draft.unifiedTabsByWorktree[worktreeId] = tabs
+  draft.groupsByWorktree[worktreeId] = [
+    {
+      id: groupId,
+      worktreeId,
+      activeTabId: tabs[0]?.id ?? null,
+      tabOrder: tabs.map((tab) => tab.id)
+    }
+  ]
+}
+
+/** Live terminal rows that reconcile to a no-op patch. */
+function buildStableWorkspace(draft: FixtureDraft, worktreeId: string, groupId: string): number {
+  const live = `${worktreeId}#live`
+  setGroup(draft, worktreeId, groupId, [unifiedTab(live, worktreeId, groupId, {})])
+  draft.tabsByWorktree[worktreeId] = [runtimeTab(live, worktreeId, {})]
+  return 1
+}
+
+/** A unified row with no runtime backing: dropped, and its store-global unread flag with it. */
+function buildStaleWorkspace(draft: FixtureDraft, worktreeId: string, groupId: string): number {
+  const live = `${worktreeId}#live`
+  const stale = `${worktreeId}#stale`
+  setGroup(draft, worktreeId, groupId, [
+    unifiedTab(live, worktreeId, groupId, {}),
+    unifiedTab(stale, worktreeId, groupId, { sortOrder: 1 })
+  ])
+  draft.tabsByWorktree[worktreeId] = [runtimeTab(live, worktreeId, {})]
+  draft.unreadTerminalTabs[stale] = true
+  return 2
+}
+
+/** Live only in a reconnect map: restored into the unified model, minting a group and layout. */
+function buildLegacyWorkspace(draft: FixtureDraft, worktreeId: string): number {
+  const legacy = `${worktreeId}#legacy`
+  draft.tabsByWorktree[worktreeId] = [runtimeTab(legacy, worktreeId, { ptyId: null })]
+  draft.pendingReconnectPtyIdByTabId[legacy] = `session-${legacy}`
+  draft.ptyIdsByTabId[legacy] = []
+  draft.unifiedTabsByWorktree[worktreeId] = []
+  draft.groupsByWorktree[worktreeId] = []
+  draft.activeTabIdByWorktree[worktreeId] = legacy
+  return 1
+}
+
+/** No PTY and no unified row: swept, which writes the store-global per-tab maps. */
+function buildOrphanWorkspace(draft: FixtureDraft, worktreeId: string): number {
+  const orphan = `${worktreeId}#orphan`
+  draft.tabsByWorktree[worktreeId] = [runtimeTab(orphan, worktreeId, { ptyId: null })]
+  draft.tabBarOrderByWorktree[worktreeId] = [orphan]
+  draft.activeTabIdByWorktree[worktreeId] = orphan
+  draft.cacheTimerByKey[`${orphan}:git`] = 1
+  draft.unifiedTabsByWorktree[worktreeId] = []
+  draft.groupsByWorktree[worktreeId] = []
+  return 1
+}
+
+/** One editor tab backed by an open file, one that is not — the openFiles rescan path. */
+function buildEditorWorkspace(draft: FixtureDraft, worktreeId: string, groupId: string): number {
+  const fileId = `${worktreeId}#file`
+  const ghost = `${worktreeId}#ghost-file`
+  setGroup(draft, worktreeId, groupId, [
+    unifiedTab(fileId, worktreeId, groupId, { contentType: 'editor' }),
+    unifiedTab(ghost, worktreeId, groupId, { contentType: 'editor', sortOrder: 1 })
+  ])
+  draft.tabsByWorktree[worktreeId] = []
+  draft.openFiles.push({
+    id: fileId,
+    filePath: `/tmp/${worktreeId}/${fileId}`,
+    relativePath: fileId,
+    worktreeId,
+    language: 'typescript',
+    isDirty: false,
+    mode: 'edit'
+  })
+  return 2
+}
+
+function buildWorkspace(
+  draft: FixtureDraft,
+  bucket: Bucket,
+  worktreeId: string,
+  groupId: string
+): number {
+  switch (bucket) {
+    case 'stable':
+      return buildStableWorkspace(draft, worktreeId, groupId)
+    case 'stale':
+      return buildStaleWorkspace(draft, worktreeId, groupId)
+    case 'legacy':
+      return buildLegacyWorkspace(draft, worktreeId)
+    case 'orphan':
+      return buildOrphanWorkspace(draft, worktreeId)
+    default:
+      return buildEditorWorkspace(draft, worktreeId, groupId)
+  }
+}
+
+/** Tops the fixture up to the measured tab count with extra live rows. */
+function padToTabCount(draft: FixtureDraft, workspaceIds: string[], missing: number): number {
+  let added = 0
+  for (let slot = 0; added < missing; slot += 1) {
+    const worktreeId = workspaceIds[slot % workspaceIds.length]
+    const group = draft.groupsByWorktree[worktreeId]?.[0]
+    if (!group || draft.tabsByWorktree[worktreeId] == null) {
+      continue
+    }
+    const id = `${worktreeId}#extra-${slot}`
+    draft.unifiedTabsByWorktree[worktreeId].push(
+      unifiedTab(id, worktreeId, group.id, { sortOrder: 10 + slot })
+    )
+    draft.tabsByWorktree[worktreeId].push(runtimeTab(id, worktreeId, { sortOrder: 10 + slot }))
+    group.tabOrder.push(id)
+    added += 1
+  }
+  return added
+}
+
+export function buildHydratedWorkspaceFixture(
+  workspaceCount = HYDRATED_WORKSPACE_COUNT,
+  tabCountTarget = HYDRATED_TAB_COUNT
+): HydratedWorkspaceFixture {
+  const draft: FixtureDraft = {
+    unifiedTabsByWorktree: {},
+    groupsByWorktree: {},
+    activeGroupIdByWorktree: {},
+    tabsByWorktree: {},
+    activeTabIdByWorktree: {},
+    tabBarOrderByWorktree: {},
+    ptyIdsByTabId: {},
+    pendingReconnectPtyIdByTabId: {},
+    unreadTerminalTabs: {},
+    cacheTimerByKey: {},
+    openFiles: []
+  }
+  const workspaceIds: string[] = []
+  let tabCount = 0
+
+  for (let index = 0; index < workspaceCount; index += 1) {
+    const worktreeId = `repo1::/tmp/w${index}`
+    const groupId = `g-${index}`
+    workspaceIds.push(worktreeId)
+    draft.activeGroupIdByWorktree[worktreeId] = groupId
+    tabCount += buildWorkspace(draft, BUCKETS[index % BUCKETS.length], worktreeId, groupId)
+  }
+  tabCount += padToTabCount(draft, workspaceIds, Math.max(0, tabCountTarget - tabCount))
+
+  return { workspaceIds, tabCount, state: { ...draft } }
+}
+
+/** Every top-level key the two reconciliation patch producers can write. */
+export const RECONCILIATION_WRITABLE_KEYS = [
+  'unifiedTabsByWorktree',
+  'groupsByWorktree',
+  'activeGroupIdByWorktree',
+  'layoutByWorktree',
+  'unreadTerminalTabs',
+  'tabsByWorktree',
+  'ptyIdsByTabId',
+  'runtimePaneTitlesByTabId',
+  'expandedPaneByTabId',
+  'canExpandPaneByTabId',
+  'terminalLayoutsByTabId',
+  'pendingStartupByTabId',
+  'pendingInitialCwdByTabId',
+  'pendingSetupSplitByTabId',
+  'pendingIssueCommandSplitByTabId',
+  'automaticAgentResumeClaimsByTabId',
+  'nativeChatLaunchPromptByTabId',
+  'nativeChatLaunchDraftByTabId',
+  'tabBarOrderByWorktree',
+  'cacheTimerByKey',
+  'activeTabIdByWorktree',
+  'activeTabId'
+] as const satisfies readonly (keyof AppState)[]

--- a/src/renderer/src/store/slices/tabs/hydrated-workspace-reconciliation-fixture.ts
+++ b/src/renderer/src/store/slices/tabs/hydrated-workspace-reconciliation-fixture.ts
@@ -158,7 +158,7 @@ function buildWorkspace(
       return buildLegacyWorkspace(draft, worktreeId)
     case 'orphan':
       return buildOrphanWorkspace(draft, worktreeId)
-    default:
+    case 'editor':
       return buildEditorWorkspace(draft, worktreeId, groupId)
   }
 }

--- a/src/renderer/src/store/slices/tabs/tabs-reconciliation-batch.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-reconciliation-batch.ts
@@ -1,0 +1,55 @@
+import type { AppState } from '../../types'
+
+/**
+ * Scratch shared by one multi-workspace reconciliation fold.
+ *
+ * Reconciling N workspaces one `set()` at a time re-spreads the same
+ * workspace-keyed maps N times and rescans `openFiles` N times. A batch lets
+ * the fold clone each map once and then write into its own private draft, and
+ * index `openFiles` once — `openFiles` is never written by reconciliation, so
+ * the index stays valid for the whole fold.
+ */
+export type WorktreeTabModelReconciliationBatch = {
+  /** Top-level `AppState` keys this fold already cloned and therefore owns. */
+  readonly ownedStateKeys: Set<string>
+  readonly liveEditorIdsByWorktree: ReadonlyMap<string, Set<string>>
+}
+
+export const EMPTY_LIVE_EDITOR_IDS: ReadonlySet<string> = new Set<string>()
+
+export function createWorktreeTabModelReconciliationBatch(
+  state: Pick<AppState, 'openFiles'>
+): WorktreeTabModelReconciliationBatch {
+  const liveEditorIdsByWorktree = new Map<string, Set<string>>()
+  for (const file of state.openFiles) {
+    let ids = liveEditorIdsByWorktree.get(file.worktreeId)
+    if (!ids) {
+      ids = new Set<string>()
+      liveEditorIdsByWorktree.set(file.worktreeId, ids)
+    }
+    ids.add(file.id)
+  }
+  return { ownedStateKeys: new Set<string>(), liveEditorIdsByWorktree }
+}
+
+/**
+ * Sets one workspace entry, mutating the batch's own draft once it owns the
+ * map. Insertion order matches the spread it replaces: an existing key keeps
+ * its slot, a new key is appended.
+ */
+export function writeBatchedWorkspaceRecordEntry<T>(
+  current: Record<string, T>,
+  stateKey: string,
+  worktreeId: string,
+  // `undefined` is accepted because the spread this replaces also stored it.
+  value: T | undefined,
+  batch: WorktreeTabModelReconciliationBatch | undefined
+): Record<string, T> {
+  if (batch?.ownedStateKeys.has(stateKey)) {
+    ;(current as Record<string, T | undefined>)[worktreeId] = value
+    return current
+  }
+  const next = { ...current, [worktreeId]: value } as Record<string, T>
+  batch?.ownedStateKeys.add(stateKey)
+  return next
+}

--- a/src/renderer/src/store/slices/tabs/tabs-reconciliation.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-reconciliation.ts
@@ -7,6 +7,11 @@ import {
   getOrphanTerminalIds,
   terminalTabHasReconnectablePty
 } from '../terminal-orphan-helpers'
+import {
+  EMPTY_LIVE_EDITOR_IDS,
+  writeBatchedWorkspaceRecordEntry,
+  type WorktreeTabModelReconciliationBatch
+} from './tabs-reconciliation-batch'
 
 export type WorktreeTabModelReconciliation = {
   patch: Partial<AppState>
@@ -14,9 +19,15 @@ export type WorktreeTabModelReconciliation = {
   activeRenderableTabId: string | null
 }
 
+/**
+ * Pure projection of one workspace's reconciliation patch. Passing `batch`
+ * lets a multi-workspace fold reuse its own map drafts and `openFiles` index;
+ * the projected values are identical either way.
+ */
 export function projectWorktreeTabModelReconciliation(
   state: AppState,
-  worktreeId: string
+  worktreeId: string,
+  batch?: WorktreeTabModelReconciliationBatch
 ): WorktreeTabModelReconciliation {
   const unifiedTabs = state.unifiedTabsByWorktree[worktreeId] ?? []
   const groups = state.groupsByWorktree[worktreeId] ?? []
@@ -93,9 +104,13 @@ export function projectWorktreeTabModelReconciliation(
   const liveTerminalIds = new Set(
     runtimeTerminalTabs.filter((tab) => !orphanTerminalIds.has(tab.id)).map((tab) => tab.id)
   )
-  const liveEditorIds = new Set(
-    state.openFiles.filter((file) => file.worktreeId === worktreeId).map((file) => file.id)
-  )
+  // Why batched: the unbatched scan is O(openFiles) per workspace, so a
+  // whole-session reconcile is O(workspaces x openFiles).
+  const liveEditorIds: ReadonlySet<string> = batch
+    ? (batch.liveEditorIdsByWorktree.get(worktreeId) ?? EMPTY_LIVE_EDITOR_IDS)
+    : new Set(
+        state.openFiles.filter((file) => file.worktreeId === worktreeId).map((file) => file.id)
+      )
   const liveBrowserIds = new Set(
     (state.browserTabsByWorktree[worktreeId] ?? []).map((browserTab) => browserTab.id)
   )
@@ -177,7 +192,10 @@ export function projectWorktreeTabModelReconciliation(
     )
     let nextUnreadTerminalTabs = state.unreadTerminalTabs
     if (droppedTerminalEntityIds.length > 0) {
-      const copy = { ...state.unreadTerminalTabs }
+      // A batch that already owns this map published it in an earlier patch, so
+      // draining further entries in place needs no second patch entry.
+      const owned = batch?.ownedStateKeys.has('unreadTerminalTabs') === true
+      const copy = owned ? state.unreadTerminalTabs : { ...state.unreadTerminalTabs }
       let changed = false
       for (const entityId of droppedTerminalEntityIds) {
         if (copy[entityId]) {
@@ -187,25 +205,44 @@ export function projectWorktreeTabModelReconciliation(
       }
       if (changed) {
         nextUnreadTerminalTabs = copy
+        batch?.ownedStateKeys.add('unreadTerminalTabs')
       }
     }
     patch = {
-      unifiedTabsByWorktree: { ...state.unifiedTabsByWorktree, [worktreeId]: validTabs },
-      groupsByWorktree: { ...state.groupsByWorktree, [worktreeId]: nextGroups },
-      activeGroupIdByWorktree: {
-        ...state.activeGroupIdByWorktree,
-        [worktreeId]: nextActiveGroupId
-      },
+      unifiedTabsByWorktree: writeBatchedWorkspaceRecordEntry(
+        state.unifiedTabsByWorktree,
+        'unifiedTabsByWorktree',
+        worktreeId,
+        validTabs,
+        batch
+      ),
+      groupsByWorktree: writeBatchedWorkspaceRecordEntry(
+        state.groupsByWorktree,
+        'groupsByWorktree',
+        worktreeId,
+        nextGroups,
+        batch
+      ),
+      activeGroupIdByWorktree: writeBatchedWorkspaceRecordEntry(
+        state.activeGroupIdByWorktree,
+        'activeGroupIdByWorktree',
+        worktreeId,
+        nextActiveGroupId,
+        batch
+      ),
       ...(nextUnreadTerminalTabs !== state.unreadTerminalTabs
         ? { unreadTerminalTabs: nextUnreadTerminalTabs }
         : {}),
       ...(nextLayout && layoutChanged
         ? {
-            layoutByWorktree: {
-              ...state.layoutByWorktree,
-              // Why: restored runtime terminals need a concrete leaf before activation.
-              [worktreeId]: nextLayout
-            }
+            // Why: restored runtime terminals need a concrete leaf before activation.
+            layoutByWorktree: writeBatchedWorkspaceRecordEntry(
+              state.layoutByWorktree,
+              'layoutByWorktree',
+              worktreeId,
+              nextLayout,
+              batch
+            )
           }
         : {}),
       ...(orphanTerminalIds.size > 0

--- a/src/renderer/src/store/slices/tabs/tabs-session-actions.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-session-actions.ts
@@ -8,6 +8,8 @@ import {
 } from '../degraded-repo-worktree-validity'
 import { buildHydratedTabState } from '../tabs-hydration'
 import { projectWorktreeTabModelReconciliation } from './tabs-reconciliation'
+import { createWorktreeTabModelReconciliationBatch } from './tabs-reconciliation-batch'
+import type { AppState } from '../../types'
 
 function replaceWorkspaceRecordKeys<T>(
   current: Record<string, T>,
@@ -20,11 +22,49 @@ function replaceWorkspaceRecordKeys<T>(
   }
 }
 
+/**
+ * Folds every workspace's reconciliation into one patch. Equivalent to
+ * applying each patch with its own `set()`: each projection reads the state
+ * left by its predecessors (they share `unreadTerminalTabs` and the orphan
+ * cleanup maps), only the store write and subscriber fanout are deferred.
+ */
+function projectWorktreeTabModelReconciliations(
+  state: AppState,
+  worktreeIds: readonly string[]
+): Partial<AppState> {
+  const batch = createWorktreeTabModelReconciliationBatch(state)
+  // Private working copy so batch-owned maps can be written in place.
+  const working = { ...state }
+  const merged: Partial<AppState> = {}
+  for (const worktreeId of worktreeIds) {
+    const { patch } = projectWorktreeTabModelReconciliation(working, worktreeId, batch)
+    if (Object.keys(patch).length === 0) {
+      continue
+    }
+    Object.assign(merged, patch)
+    Object.assign(working, patch)
+  }
+  return merged
+}
+
 export function createTabsSessionActions(
   set: TabsSliceSet,
   get: TabsSliceGet
-): Pick<TabsSlice, 'reconcileWorktreeTabModel' | 'hydrateTabsSession'> {
+): Pick<
+  TabsSlice,
+  'reconcileWorktreeTabModel' | 'reconcileWorktreeTabModels' | 'hydrateTabsSession'
+> {
   return {
+    reconcileWorktreeTabModels: (worktreeIds) => {
+      if (worktreeIds.length === 0) {
+        return
+      }
+      const patch = projectWorktreeTabModelReconciliations(get(), worktreeIds)
+      if (Object.keys(patch).length > 0) {
+        set(patch)
+      }
+    },
+
     reconcileWorktreeTabModel: (worktreeId) => {
       const reconciliation = projectWorktreeTabModelReconciliation(get(), worktreeId)
       if (Object.keys(reconciliation.patch).length > 0) {

--- a/src/renderer/src/store/slices/tabs/tabs-slice-contract.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-slice-contract.ts
@@ -152,6 +152,8 @@ export type TabsSlice = {
     renderableTabCount: number
     activeRenderableTabId: string | null
   }
+  /** Reconciles many workspaces through one store write instead of one per workspace. */
+  reconcileWorktreeTabModels: (worktreeIds: readonly string[]) => void
   hydrateTabsSession: (
     session: WorkspaceSessionState,
     options?: WorkspaceSessionHydrationOptions

--- a/src/renderer/src/store/terminals/workspace-terminal-reconnect.ts
+++ b/src/renderer/src/store/terminals/workspace-terminal-reconnect.ts
@@ -50,18 +50,6 @@ export function createWorkspaceTerminalReconnectActions(
       const repoById = buildByIdIndex(get().repos)
       for (const worktreeId of ids) {
         const tabs = tabsByWorktree[worktreeId] ?? []
-        const worktree = worktreeById.get(worktreeId)
-        const repo = worktree ? (repoById.get(worktree.repoId) ?? null) : null
-        // Why: only allow deferred reattach when the SSH connection is active; reattaching to a not-yet-connected relay (deferred/passphrase targets) would fail.
-        const sshTargetId = options?.directSshAuthority.targetId ?? repo?.connectionId ?? null
-        const sshState = sshTargetId ? get().sshConnectionStates.get(sshTargetId) : null
-        const sshConnected = sshTargetId != null && sshState?.status === 'connected'
-        const supportsDeferredReattach = options
-          ? sshConnected
-          : !repo?.connectionId || sshConnected
-        console.debug(
-          `[reconnect-terminals] worktree=${worktreeId} connectionId=${repo?.connectionId} sshStatus=${sshState?.status} supportsDeferredReattach=${supportsDeferredReattach}`
-        )
         const targetTabIds = pendingReconnectTabByWorktree[worktreeId] ?? []
         const tabsToReconnect: TerminalTab[] =
           targetTabIds.length > 0
@@ -84,11 +72,8 @@ export function createWorkspaceTerminalReconnectActions(
               ? undefined
               : pendingPtyId
           const hasLeafMappings = Object.keys(leafPtyMap).length > 0
-          // Why: publish live PTY hints before mount; pty-connection reattaches later.
-          console.debug(
-            `[reconnect-terminals] tab=${tabId} tabLevelPtyId=${tabLevelPtyId} supportsDeferredReattach=${supportsDeferredReattach} hasLeafMappings=${hasLeafMappings}`
-          )
-          // Why: populate ptyIdsByTabId so the sessions status segment maps daemon IDs to tabs; otherwise all sessions look like orphans until the pane mounts.
+          // Why: publish live PTY hints before mount (pty-connection reattaches later) so the
+          // sessions status segment maps daemon IDs to tabs; otherwise all sessions look like orphans until the pane mounts.
           // A row whose tab.ptyId went to the canonical row has no tab-level id left, but its own leaf PTYs still need advertising.
           const allPtyIds = hasLeafMappings
             ? (Object.values(leafPtyMap).filter(Boolean) as string[])


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​315 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​311 |
| Prod | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​490 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​60 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​430 |

<!-- /orca-pr-loc -->

## ELI5

While restoring your session at startup, Orca told the rest of the app "something changed" **193 separate times** — once per saved workspace — and copied three whole lookup tables on every one of those announcements. Now it works out all 193 workspaces first and announces the result **once**, copying each table once instead of 193 times. Nothing about what you see changes; the app just stops doing the same bookkeeping 193 times over.

Two smaller items ride along: terminal scroll positions keyed by a pane's leaf id were never dropped when the pane closed (a slow, small leak), and startup emitted ~575 formatted debug strings nobody reads.

---

## Fix 1 — session hydration did 193 store writes, each spreading three whole maps

`reconcileHydratedWorkspaceTabModels` looped every key of `session.tabsByWorktree` and called `reconcileWorktreeTabModel`, which does one `set(patch)` per workspace. `projectWorktreeTabModelReconciliation` built that patch with three whole-map spreads (`unifiedTabsByWorktree`, `groupsByWorktree`, `activeGroupIdByWorktree`), plus `layoutByWorktree`/`unreadTerminalTabs` when they changed. React 18 batches the renders; the non-React Zustand subscriber fanout is not batched.

New `reconcileWorktreeTabModels(worktreeIds)` action folds the whole session into one patch and does one `set()`. `projectWorktreeTabModelReconciliation` stays a pure projection; it takes an optional batch context that (a) lets the fold clone each workspace-keyed map once and then write into its own private draft, and (b) supplies a prebuilt `openFiles` index.

The fold is a **sequential** fold, not a parallel projection — that is required for equivalence. Workspace patches are not independent: they share `unreadTerminalTabs` and, when the orphan sweep fires, the whole per-tab map family (`ptyIdsByTabId`, `terminalLayoutsByTabId`, `cacheTimerByKey`, `activeTabId`, …). Each projection therefore reads the state left by its predecessors; only the store write and the subscriber fanout are deferred.

Also fixed in the same pass: `state.openFiles.filter(...)` ran once per workspace (O(workspaces x openFiles)). The batch indexes `openFiles` by workspace once. `openFiles` is never written by reconciliation, so the index is valid for the whole fold.

### Corrections to the brief

- **Line/count details.** The described shape is accurate. Numbers below are measured, not the estimates in the brief: the map-key-copy total is **124,462**, not ~109,000, because `layoutByWorktree` and `unreadTerminalTabs` also get spread on the workspaces that change them, and the maps are 193 keys (not 188) once every hydrated workspace has an entry.
- **The 193 `set()` calls also cost a whole-`AppState` shallow copy each.** Zustand merges with `Object.assign({}, state, partial)`, so each write copied all ~1,136 top-level store keys. That is another **219,248** key copies the brief did not count, and it is larger than the map-spread cost.
- **`setHydrationSucceeded(true)` gating.** Confirmed at `use-app-startup-hydration.ts` — the disk writer is unlocked only after hydration, so this was pure CPU.

## Fix 2 — string-keyed terminal scroll-intent maps were never pruned

`terminalScrollIntentByKey` / `terminalScrollIntentBindingByKey` are keyed by a pane's leaf id (a minted UUID) and are written on every pinned terminal but never deleted. They now live in `terminal-scroll-intent-key-store.ts` (which also keeps `terminal-scroll-intent.ts` under the 300-line cap) and are released from `teardownManagedPane` — **only for `reason === 'close'`**.

That restriction is deliberate and load-bearing: these entries exist precisely so a pin survives disposal. Plain `disposePane` runs on workspace switch, keyed remount, and `PaneManager.destroy()`, and the entry must still be there when the leaf mounts again. `detach` and `retire` hand the same leaf to a new host, so they must keep it too. There is a covering test for both directions.

**Known remaining scope:** closing a whole terminal *tab* unmounts `TerminalPane`, which calls `manager.destroy()` rather than `closePane`, so those leaf entries are still retained. Releasing them needs a leaf-level hook at the point the store drops `terminalLayoutsByTabId`, which is a wider and riskier change than this PR; flagging rather than doing it blind.

## Fix 3 — ~575 formatted debug strings during `reconnect-terminals`

Both `[reconnect-terminals]` `console.debug` calls are removed. I checked: nothing in `src/`, `tests/`, or `docs/` consumes them — the startup benchmark reads the `renderer-reconnect-terminals-done` step event, not these lines. They are debug-only noise.

Removing them exposed that `supportsDeferredReattach` (and the `worktree` / `repo` / `sshTargetId` / `sshState` / `sshConnected` chain that feeds it) was **computed but only ever consumed by the log strings** — including a `sshConnectionStates.get()` per pending workspace. That dead block is deleted; the second loop still does the real deferred-SSH work and keeps its own lookups.

One consequence, called out explicitly: `store-session-terminal-reconnect.test.ts` simulated an SSH authority rotation by making the **4th** `sshConnectionStates.get()` return a rotated generation, and that count included the dead read. The trigger is now "from the first read after the entry authority check" instead of a hard-coded index, so the pre-publication authority check still sees the rotated generation and the test still proves the same thing without being pinned to an exact read count.

---

## Measurements

193 workspaces / 382 tabs, over a fixture spanning every reconciliation outcome (no-op, dropped tab, restored legacy runtime terminal, orphan sweep, editor tab). Subscriber count 1,200 approximates the renderer's live non-React store-subscriber population.

| | before | after |
|---|---:|---:|
| `set()` calls during hydration reconcile | **193** | **1** |
| Store-subscriber notifications | **231,600** | **1,200** |
| Workspace-map key copies | **124,462** | **618** |
| Whole-`AppState` key copies (Zustand merge) | **219,248** | **2,272** |
| `openFiles` rescans | **193** | **0** |
| Reconcile stage, 1,200 subscribers | 421 / 735 / 1,246 ms | 1.7 / 2.0 / 151 ms |
| Reconcile stage, no subscribers | 349 / 513 ms | 1.4 / 13.3 ms |

Counts are exact and reproduce identically run to run. Timings are three samples each from the Node/vitest harness and are noisy (GC and JIT ordering inside one worker); they are directional, not a packaged-app profile. The counts are the claim; the timings only show the order of magnitude.

Method: `set()` calls and notifications come from real Zustand subscribers counted during the run. Key copies are reconstructed from the same run by summing `Object.keys(map).length` for each map the observed patch actually replaced. Nothing here is estimated.

## Regression tests

- `hydrated-workspace-reconciliation-batch.test.ts`
  - `set()`/notification collapse: per-workspace path notifies 231,600 times, batched notifies exactly 1,200 (one write). Fails pre-fix with `expected 231600 to be 1200`.
  - **Byte-identical final state:** runs both paths over the same fixture and asserts deep equality of every top-level key either patch producer can write (22 keys), plus `Object.keys()` order equality for each of them. Minted group ids are pinned so the comparison is about state, not UUIDs. This test passes on both the old and new implementation — that is the point: it is the equivalence proof, not a change detector.
  - Re-reconciling the batched result is a no-op (0 notifications), matching the per-workspace path's settled behaviour.
  - `openFiles` is never `.filter()`ed during a batched reconcile. Fails pre-fix with `expected 193 to be +0`.
- `terminal-scroll-intent-key-retention.test.ts`
  - 200 open/close cycles return both map sizes to baseline; also asserts the entry *is* retained while the pane is open. Fails pre-fix (`bindings/intents: 2` vs `1` after one cycle).
  - `detach` / `retire` keep the keyed intent, so the leaf can be restored by its new host.
- `reconcile-hydrated-workspace-tab-models.test.ts` updated to assert one call with the full workspace list, in session order.

## Negative user-facing trade-offs

**None.**

- **Final store state is proven deep-equal, not asserted.** The equivalence test snapshots the entire writable surface after both paths and compares values *and* key insertion order. Insertion order matters here — `Object.keys`/`Object.entries` iteration order is observable through selectors and session serialization — and it is preserved by construction: the batch clones a map on first write and then assigns into that clone, which keeps an existing key in place and appends a new key, exactly like the spread it replaces.
- **The only behavioural difference is that subscribers no longer observe the 192 intermediate states.** Those states were partially-reconciled by construction (some workspaces converged, the rest not yet); nothing may depend on them, and the session disk writer is fenced off entirely during hydration by `hydrationSucceeded`.
- **`reconcileWorktreeTabModel` (single-workspace) is unchanged** — same signature, same return value, same behaviour. Every other call site is untouched.
- **Fix 2 cannot lose a scroll position**: the release runs only on a real pane close, after `disposePane` has already persisted the final geometry, and leaf ids are minted UUIDs that are never reused.
- **Fix 3** removes only debug output and code that existed solely to feed it.

## Verification

- `pnpm tc` — clean
- `npx oxlint <changed files>` — clean
- `npx vitest run --config config/vitest.config.ts src/renderer/src/app-shell src/renderer/src/store src/renderer/src/lib/pane-manager` — **409 files, 3,961 passed, 1 skipped**
