### PR TITLE
fix(terminal): stop a hidden pane's cursor blink deterministically

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -21,6 +21,7 @@ import {
   resolveTerminalCursorInactiveStyle
 } from '@/lib/pane-manager/pane-terminal-options'
 import { getFitOverrideForPty } from '@/lib/pane-manager/mobile-fit-overrides'
+import { setTerminalCursorBlinkOption } from '@/lib/pane-manager/pane-cursor-blink-suspension'
 import type { PtyTransport } from './pty-transport'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
 import { HEX_COLOR_RE } from '../../../../shared/color-validation'
@@ -180,7 +181,9 @@ export function applyTerminalAppearance(
     const cursorStyle = settings.terminalCursorStyle ?? 'block'
     pane.terminal.options.cursorStyle = cursorStyle
     pane.terminal.options.cursorInactiveStyle = resolveTerminalCursorInactiveStyle(cursorStyle)
-    pane.terminal.options.cursorBlink = settings.terminalCursorBlink
+    // Why not a direct write: a suspended (hidden) pane parks the value instead, so a
+    // settings change mid-hide cannot re-arm its blink timer behind the hidden surface.
+    setTerminalCursorBlinkOption(pane.terminal, settings.terminalCursorBlink)
     const paneSize = paneFontSizes.get(pane.id)
     const metricOptions = {
       fontSize: paneSize ?? settings.terminalFontSize,

--- a/src/renderer/src/lib/pane-manager/pane-cursor-blink-suspension.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-cursor-blink-suspension.test.ts
@@ -1,0 +1,300 @@
+// @vitest-environment happy-dom
+
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { resumePaneRendering, suspendPaneRendering } from './pane-rendering-control'
+import { resetHiddenWebglRetentionForTest } from './terminal-webgl-hidden-retention'
+import { isTerminalCursorBlinkSuspended } from './pane-cursor-blink-suspension'
+
+/**
+ * Invariant (`terminal-render.hidden-pane-idle-cost`): a hidden pane must not drive
+ * the cursor-blink redraw loop, and revealing it must put back exactly the blink
+ * state it had — never a frozen, missing, or unexpectedly blinking cursor.
+ *
+ * Oracle: the cursor xterm actually renders. The DOM renderer stamps
+ * `xterm-cursor` / `xterm-cursor-blink` on the cursor cell (DomRendererRowFactory),
+ * so these assertions read rendered output, not the option value — an assertion on
+ * `options.cursorBlink` alone would pass with the bug present.
+ *
+ * The hidden-side cost is proved separately by the redraw-count test at the bottom:
+ * the DOM renderer already gates its blink class on per-terminal focus, whereas the
+ * WebGL renderer's blink timer arms on `document.hasFocus()`, which is what leaks.
+ */
+
+const COLS = 80
+const ROWS = 24
+
+type TestPane = ManagedPaneInternal & { host: HTMLElement }
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()))
+}
+
+async function flushRender(): Promise<void> {
+  await nextFrame()
+  await nextFrame()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function write(terminal: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve))
+}
+
+function createTestPane(options: { cursorBlink?: boolean; webglAddon?: boolean } = {}): TestPane {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const terminal = new Terminal({
+    cols: COLS,
+    rows: ROWS,
+    cursorBlink: options.cursorBlink ?? true,
+    allowProposedApi: true
+  })
+  terminal.open(host)
+  terminal.focus()
+  const pane = {
+    id: 1,
+    terminal,
+    host,
+    container: host,
+    xtermContainer: host,
+    // Off so resume's reattachWebglIfNeeded leaves the DOM renderer in place;
+    // the rendered-cursor oracle needs a renderer that paints in happy-dom.
+    gpuRenderingEnabled: false,
+    terminalGpuAcceleration: 'off',
+    webglAddon: options.webglAddon ? ({ dispose: vi.fn() } as never) : null,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    webglAttachFailedSinceRecovery: false,
+    hasComplexScriptOutput: false,
+    pendingWebglRefreshRafId: null,
+    pendingObservedFitRafId: null
+  } as unknown as TestPane
+  return pane
+}
+
+/** The cursor cell as the renderer painted it, or null when no cursor is rendered. */
+function renderedCursor(pane: TestPane): HTMLElement | null {
+  return pane.host.querySelector('.xterm-cursor')
+}
+
+function rendersBlinkingCursor(pane: TestPane): boolean {
+  return renderedCursor(pane)?.classList.contains('xterm-cursor-blink') === true
+}
+
+function renderedText(pane: TestPane): string {
+  return pane.host.querySelector('.xterm-rows')?.textContent ?? ''
+}
+
+/** Reveal = the manager's resume pass, then the terminal regains real DOM focus. */
+async function reveal(panes: TestPane[], owner?: object): Promise<void> {
+  resumePaneRendering(panes, owner)
+  for (const pane of panes) {
+    pane.terminal.focus()
+  }
+}
+
+describe('hidden-pane cursor blink suspension', () => {
+  beforeEach(() => {
+    resetHiddenWebglRetentionForTest()
+    // happy-dom has no canvas text metrics; xterm measures glyphs on open().
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('renders a blinking cursor again one frame after reveal', async () => {
+    const pane = createTestPane()
+    await write(pane.terminal, 'ready$ ')
+    await flushRender()
+    expect(rendersBlinkingCursor(pane)).toBe(true)
+
+    suspendPaneRendering([pane])
+    expect(isTerminalCursorBlinkSuspended(pane.terminal)).toBe(true)
+
+    await reveal([pane])
+    await nextFrame()
+    expect(renderedCursor(pane), 'reveal must not leave the pane without a cursor').not.toBeNull()
+    expect(rendersBlinkingCursor(pane)).toBe(true)
+    expect(isTerminalCursorBlinkSuspended(pane.terminal)).toBe(false)
+  })
+
+  it('keeps a user who disabled cursor blink un-blinking across hide and reveal', async () => {
+    const pane = createTestPane({ cursorBlink: false })
+    await write(pane.terminal, 'ready$ ')
+    await flushRender()
+    expect(rendersBlinkingCursor(pane)).toBe(false)
+
+    suspendPaneRendering([pane])
+    await reveal([pane])
+    await flushRender()
+
+    expect(renderedCursor(pane), 'a steady cursor must still be rendered').not.toBeNull()
+    expect(rendersBlinkingCursor(pane), 'blink must stay off for this user').toBe(false)
+  })
+
+  it('does not drop output written while hidden, and echoes typing after reveal', async () => {
+    const pane = createTestPane()
+    await write(pane.terminal, 'before-hide\r\n')
+    await flushRender()
+
+    suspendPaneRendering([pane])
+    await write(pane.terminal, 'while-hidden\r\n')
+
+    await reveal([pane])
+    await flushRender()
+    expect(renderedText(pane)).toContain('before-hide')
+    expect(renderedText(pane)).toContain('while-hidden')
+
+    // Real key input through xterm's textarea must still route to the PTY.
+    const typed: string[] = []
+    pane.terminal.onData((data) => typed.push(data))
+    const keydown = new KeyboardEvent('keydown', {
+      key: 'x',
+      code: 'KeyX',
+      bubbles: true,
+      cancelable: true
+    })
+    Object.defineProperty(keydown, 'keyCode', { value: 88 })
+    pane.terminal.textarea?.dispatchEvent(keydown)
+    expect(typed, 'keystrokes must still reach the PTY after a hide/reveal').toEqual(['x'])
+
+    await write(pane.terminal, 'x')
+    await flushRender()
+    expect(renderedText(pane)).toContain('x')
+    expect(rendersBlinkingCursor(pane)).toBe(true)
+  })
+
+  it('restores blink on the retained-hidden-WebGL path, which skips dispose', async () => {
+    const owner = {}
+    const pane = createTestPane({ webglAddon: true })
+    const addon = pane.webglAddon
+    await write(pane.terminal, 'ready$ ')
+    await flushRender()
+
+    suspendPaneRendering([pane], { owner, livePanes: () => [pane] })
+    // The retention branch returns before disposeWebgl — this is the path where
+    // nothing else could have stopped the blink timer.
+    expect(addon?.dispose).not.toHaveBeenCalled()
+    expect(isTerminalCursorBlinkSuspended(pane.terminal)).toBe(true)
+
+    await reveal([pane], owner)
+    await nextFrame()
+    expect(rendersBlinkingCursor(pane)).toBe(true)
+  })
+
+  it('restores every pane of a split, including one revealed a second time', async () => {
+    const owner = {}
+    const left = createTestPane()
+    const right = createTestPane()
+    const panes = [left, right]
+    await write(left.terminal, 'left$ ')
+    await write(right.terminal, 'right$ ')
+    await flushRender()
+
+    for (let cycle = 0; cycle < 2; cycle++) {
+      suspendPaneRendering(panes, { owner, livePanes: () => panes })
+      resumePaneRendering(panes, owner)
+      // One at a time: the DOM renderer only paints a blinking cursor in the pane
+      // that currently holds real focus, so focus each split half in turn.
+      for (const [name, pane] of [
+        ['left', left],
+        ['right', right]
+      ] as const) {
+        pane.terminal.focus()
+        await nextFrame()
+        expect(renderedCursor(pane), `${name} cursor, cycle ${cycle}`).not.toBeNull()
+        expect(rendersBlinkingCursor(pane), `${name} blink, cycle ${cycle}`).toBe(true)
+      }
+    }
+    expect(renderedText(left)).toContain('left$')
+    expect(renderedText(right)).toContain('right$')
+  })
+
+  it('does not re-arm a hidden pane when the blink setting changes mid-hide', async () => {
+    const pane = createTestPane({ cursorBlink: false })
+    suspendPaneRendering([pane])
+
+    // What applyTerminalAppearance does when the user flips the setting.
+    const { setTerminalCursorBlinkOption } = await import('./pane-cursor-blink-suspension')
+    setTerminalCursorBlinkOption(pane.terminal, true)
+    expect(
+      pane.terminal.options.cursorBlink,
+      'a hidden pane must not start blinking behind the surface'
+    ).toBe(false)
+
+    await reveal([pane])
+    await nextFrame()
+    expect(rendersBlinkingCursor(pane), 'the new setting applies on reveal').toBe(true)
+  })
+
+  it('resume is a no-op for a pane that was never suspended', async () => {
+    const pane = createTestPane()
+    await flushRender()
+    await reveal([pane])
+    await nextFrame()
+    expect(rendersBlinkingCursor(pane)).toBe(true)
+  })
+})
+
+/**
+ * Deterministic cost gate for the hidden side.
+ *
+ * Model, taken from `@xterm/addon-webgl@0.20` sources: `CursorBlinkStateManager`
+ * runs a 600 ms interval whenever `ICoreBrowserService.isFocused` is true — a
+ * DOCUMENT-level fact — and every toggle calls `WebglRenderer._requestRedrawCursor()`,
+ * which redraws one full row (`_updateModel` loops `x < cols` per row).
+ * `WebglRenderer._updateCursorBlink()` decides whether the manager exists from
+ * `decPrivateModes.cursorBlink ?? terminal.options.cursorBlink`, which is read from
+ * the real Terminal below.
+ */
+const BLINK_INTERVAL_MS = 600
+
+function blinkCellsRedrawnPerWindow(terminal: Terminal, windowMs: number): number {
+  const decPrivateBlink = (
+    terminal as unknown as {
+      _core: { coreService: { decPrivateModes: { cursorBlink?: boolean } } }
+    }
+  )._core.coreService.decPrivateModes.cursorBlink
+  const blinking = decPrivateBlink ?? terminal.options.cursorBlink === true
+  if (!blinking) {
+    return 0
+  }
+  return Math.floor(windowMs / BLINK_INTERVAL_MS) * terminal.cols
+}
+
+describe('hidden-pane cursor blink redraw cost', () => {
+  beforeEach(() => {
+    resetHiddenWebglRetentionForTest()
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('drops retained hidden panes to zero blink redraws and restores them on reveal', async () => {
+    const owner = {}
+    // The retention cap: MAX_RETAINED_HIDDEN_WEBGL_CONTEXTS.
+    const panes = Array.from({ length: 6 }, () => createTestPane({ webglAddon: true }))
+    const windowMs = 30_000
+    const cells = () =>
+      panes.reduce((sum, pane) => sum + blinkCellsRedrawnPerWindow(pane.terminal, windowMs), 0)
+
+    expect(cells()).toBe(6 * 50 * COLS)
+
+    suspendPaneRendering(panes, { owner, livePanes: () => panes })
+    expect(cells(), 'hidden panes must cost nothing while the window is visible').toBe(0)
+
+    await reveal(panes, owner)
+    expect(cells()).toBe(6 * 50 * COLS)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-cursor-blink-suspension.ts
+++ b/src/renderer/src/lib/pane-manager/pane-cursor-blink-suspension.ts
@@ -1,0 +1,57 @@
+import type { Terminal } from '@xterm/xterm'
+
+/**
+ * Park `cursorBlink` while a pane is hidden.
+ *
+ * Why: a retained hidden pane (`terminal-webgl-hidden-retention.ts`) keeps a live
+ * WebglRenderer, and the only thing that stops its 600 ms blink timer is
+ * `WebglRenderer.handleBlur()` — reached only from a real DOM blur event. Today
+ * that arrives incidentally, because `display:none`/`visibility:hidden` move focus;
+ * under `opacity:0` without `inert` (TerminalOverlaySlot's startup probe) it never
+ * fires, `Terminal.blur()` is a no-op on a textarea that is not the active element,
+ * and the pane blinks — redrawing its whole cursor row through
+ * `WebglRenderer._updateModel` — until the 5-minute idle timeout.
+ *
+ * `cursorBlink` is the public option that tears the timer down deterministically
+ * (`RenderService.handleOptionsChanged` -> `WebglRenderer._updateCursorBlink`), so
+ * "a hidden pane does not blink" stops depending on which CSS hid it.
+ *
+ * Resume restores the parked value rather than the settings value, so a pane that
+ * was not blinking before the hide never comes back blinking.
+ */
+const parkedCursorBlink = new WeakMap<Terminal, boolean>()
+
+export function suspendTerminalCursorBlink(terminal: Terminal): void {
+  if (parkedCursorBlink.has(terminal)) {
+    return
+  }
+  parkedCursorBlink.set(terminal, terminal.options.cursorBlink === true)
+  terminal.options.cursorBlink = false
+}
+
+/** Restores the pre-suspend blink state. No-op on a terminal that was never suspended. */
+export function resumeTerminalCursorBlink(terminal: Terminal): void {
+  if (!parkedCursorBlink.has(terminal)) {
+    return
+  }
+  const restored = parkedCursorBlink.get(terminal) === true
+  parkedCursorBlink.delete(terminal)
+  terminal.options.cursorBlink = restored
+}
+
+/**
+ * Settings-driven blink writes land on the parked value while a pane is suspended;
+ * writing the option directly would re-arm the blink timer behind a hidden surface
+ * until the next reveal.
+ */
+export function setTerminalCursorBlinkOption(terminal: Terminal, enabled: boolean): void {
+  if (parkedCursorBlink.has(terminal)) {
+    parkedCursorBlink.set(terminal, enabled)
+    return
+  }
+  terminal.options.cursorBlink = enabled
+}
+
+export function isTerminalCursorBlinkSuspended(terminal: Terminal): boolean {
+  return parkedCursorBlink.has(terminal)
+}

--- a/src/renderer/src/lib/pane-manager/pane-manager-pane-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-pane-creation.ts
@@ -2,6 +2,7 @@ import type { ManagedPane, ManagedPaneInternal, PaneManagerOptions } from './pan
 import type { PaneManagerHost } from './pane-manager-host'
 import { applyPaneOpacity } from './pane-divider'
 import { createPaneDOM, openTerminal } from './pane-lifecycle'
+import { suspendTerminalCursorBlink } from './pane-cursor-blink-suspension'
 import { shouldFollowMouseFocus } from './focus-follows-mouse'
 import { toPublicPane } from './pane-public-view'
 
@@ -53,6 +54,10 @@ export function createManagedPaneInternal(
     }
   )
   pane.webglAttachmentDeferred = host.isRenderingSuspended()
+  if (host.isRenderingSuspended()) {
+    // A pane that mounts behind a hidden surface never sees suspendPaneRendering().
+    suspendTerminalCursorBlink(pane.terminal)
+  }
   host.panes.set(id, pane)
   host.identities.register(id, leafId)
   return pane

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -1,4 +1,8 @@
 import type { ManagedPaneInternal } from './pane-manager-types'
+import {
+  resumeTerminalCursorBlink,
+  suspendTerminalCursorBlink
+} from './pane-cursor-blink-suspension'
 import { safeFit } from './pane-tree-ops'
 import {
   attachWebgl,
@@ -66,6 +70,12 @@ export function suspendPaneRendering(
   for (const pane of suspended) {
     pane.webglAttachmentDeferred = true
     pane.terminal.blur()
+    // Why here, above the retention return: the retention branch keeps a live
+    // WebglRenderer, whose blink timer only stops on a real DOM blur event. blur()
+    // above is a no-op unless that pane's textarea held focus, so under a hide mode
+    // that keeps focus the pane would blink — redrawing its cursor row — until the
+    // 5-minute idle timeout. Parking the option makes it unconditional.
+    suspendTerminalCursorBlink(pane.terminal)
   }
   // Keep recent hidden worktrees on live WebGL so switch-back never presents
   // DOM-fallback frames; evicted/over-cap owners fall back to dispose.
@@ -86,6 +96,9 @@ export function resumePaneRendering(
   }
   for (const pane of panes) {
     clearTerminalWebglAttachBackoff(pane)
+    // Before the attach below so a freshly constructed WebglRenderer already samples
+    // the restored option and blinks on its first frame.
+    resumeTerminalCursorBlink(pane.terminal)
     const rebuildDeferred = pane.webglRebuildDeferred === true
     pane.webglAttachmentDeferred = false
     // Reveal can retry before the next resume, so both paths share the bounded loss policy.

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
@@ -14,6 +14,7 @@ function createPane(options: { loadAddon?: () => void } = {}): ManagedPaneIntern
     leafId,
     stablePaneId: leafId,
     terminal: {
+      options: { cursorBlink: true },
       cols: 80,
       rows: 24,
       refresh: vi.fn(),

--- a/src/renderer/src/lib/pane-manager/pane-webgl-refresh-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-refresh-lifecycle.test.ts
@@ -17,6 +17,7 @@ function createPane(
     leafId,
     stablePaneId: leafId,
     terminal: {
+      options: { cursorBlink: true },
       element: null,
       cols: 80,
       rows: 24,

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.test.ts
@@ -10,7 +10,8 @@ import {
 
 function createPane(withAddon = true): ManagedPaneInternal {
   return {
-    terminal: { blur: vi.fn() },
+    // options mirrors the real Terminal: suspend parks cursorBlink here.
+    terminal: { blur: vi.fn(), options: { cursorBlink: true } },
     webglAddon: withAddon
       ? ({ dispose: vi.fn() } as unknown as ManagedPaneInternal['webglAddon'])
       : null,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​304 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​303 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 |

<!-- /orca-pr-loc -->

## ELI5

Every terminal in Orca blinks its text cursor, and each blink makes the GPU renderer redraw the entire row of characters the cursor sits on. That is fine for the terminal you are looking at. The problem is that xterm decides *whether* to run that blink timer from a **document-level** fact ("is this window focused?") rather than "is this particular terminal on screen and focused?" — so the only thing that ever stops a hidden terminal from blinking is the browser happening to fire a focus-lost event when Orca hides it.

Today that event does arrive on the common paths, because `display: none` / `visibility: hidden` move keyboard focus. But Orca deliberately keeps up to 6 hidden panes on live WebGL (`MAX_RETAINED_HIDDEN_WEBGL_CONTEXTS`), and the suspend path's `terminal.blur()` is a **no-op that fires no event** when that pane's textarea was not the focused element. Under the one hide mode that keeps focus — `opacity: 0` without `inert`, which `TerminalOverlaySlot`'s startup probe uses, and which the existing comment in `pane-rendering-control.ts` already calls out — nothing stops the timer and the pane blinks for five minutes (xterm's idle timeout) while you are looking at a completely different tab.

This PR stops relying on that accident. Hiding a pane parks `terminal.options.cursorBlink`; revealing it puts the parked value back. "A hidden pane does not blink" becomes a property the code enforces instead of one CSS happens to give us.

## Measurements — and an important correction to the premise

**I could not reproduce the reported ~8,814/sec idle cost as cursor-blink work, and this change measures as a 0% delta on the default hide path.** Reporting that plainly rather than shipping an unsupported perf number.

### Controlled dev-build capture (this worktree, `Profiler.takePreciseCoverage`, 30 s)

Setup: 8 workspaces added, cycled through so terminals mount, ending with **1 visible pane and 6–7 hidden retained panes**. Focus condition, identical for both captures: `document.visibilityState === "visible"` and `document.hasFocus() === true`, with page focus supplied by CDP `Emulation.setFocusEmulationEnabled` so the capture never steals the developer's OS focus. Both values are asserted inside the capture script and recorded with every number. App idle (no PTY output).

| function | before (no fix) | after (fix) |
| --- | --- | --- |
| `forEachDecorationAtCell` | 15,900 (530/s) | 15,900 (530/s) |
| `getDecorationsOnLine` | 15,900 (530/s) | 15,900 (530/s) |
| `loadCell` | 7,950 (265/s) | 7,950 (265/s) |
| `isCellSelected` / `isBlink` | 7,950 (265/s) | 7,950 (265/s) |
| `_requestRedrawCursor` | 50 (1.67/s) | 50 (1.67/s) |
| `_updateModel` / `renderRows` / `refreshRows` | 50 each | 50 each |

530 cells/s ÷ 318 cols = exactly 1.67 row-redraws/sec = **one** blinking renderer at one toggle per 600 ms — the visible, focused pane, which is supposed to blink. The 6 hidden retained panes contributed **zero** before the fix, because Chromium's `display: none` blur had already paused them. So on this path the change is a no-op, exactly as the existing code comment predicted.

### Why the original ~8,814/sec figure is not cursor blink

Two `takePreciseCoverage` captures against the live packaged app (read-only, window visible + focused):

| | 3 xterms, capture A | 3 xterms, capture B |
| --- | --- | --- |
| `forEachDecorationAtCell` | 15,883/s | 141,968/s |
| `_requestRedrawCursor` | **0/s** (1 call in 15 s) | **0/s** |
| `restartBlinkAnimation` | 0/s | 0/s (2 calls) |
| `_clearModel` | 0 | 0 |
| `refreshRows` → `renderRows` | 5/s → 2/s | 37/s → 12/s |
| cells per `_updateModel` | ~6,807 | ~11,830 |

The cursor-blink entry points are flat at ~0/s while `forEachDecorationAtCell` runs at 15.9k–142k/s. The cost is `_updateModel` passes whose row span is effectively the **whole viewport**, driven by `refreshRows` — i.e. real terminal output and TUI repaints, not cursor blinking. Agent CLIs animate a spinner even when the *user* is idle, which plausibly accounts for the original "idle" figure at 11 xterms. **The next renderer-perf investigation should start at what drives full-viewport `refreshRows` spans on a nominally idle terminal, not at the blink timer.**

### Deterministic gate that does move

`pane-cursor-blink-suspension.test.ts` models the blink loop from the `@xterm/addon-webgl@0.20` sources (600 ms interval, `decPrivateModes.cursorBlink ?? options.cursorBlink`, one full row per toggle) and reads the effective state off real `Terminal` instances. Red without the fix / green with it:

```
AssertionError: hidden panes must cost nothing while the window is visible: expected 24000 to be +0
```

(6 retained hidden panes × 50 toggles × 80 cols over a 30 s window → 0.)

## Reliability contract

- **Invariant** (`terminal-render.hidden-pane-idle-cost`): a hidden pane must not drive the cursor-blink redraw loop, and revealing it must restore exactly the blink state it had — never a frozen, missing, or unexpectedly blinking cursor.
- **Failure source**: `suspendPaneRendering`'s retention branch returns before `disposeWebgl`, leaving `terminal.blur()` as the only blink stop; `Terminal.blur()` fires no event when the pane's textarea never held DOM focus.
- **Oracle**: the cursor xterm actually renders. Tests read `.xterm-cursor` / `.xterm-cursor-blink` off real opened `Terminal` instances (`DomRendererRowFactory` stamps them), plus real keydown-through-textarea input and rendered row text. An assertion on `options.cursorBlink` alone would pass with the bug present, so none of the behavioural tests use one as their oracle.
- **Gate**: no `config/reliability-gates.jsonc` entry exists for renderer idle cost; the new test file is the gate. Recorded as an accepted gap for promotion in a later PR.
- **Coverage**: local PTY / daemon / SSH / WSL / mobile-relay — **unaffected**; this is renderer-side xterm option state only, touches no PTY, provider, geometry, or wire contract. macOS/Linux/Windows — unaffected; no platform-conditional code.
- **Performance budget**: no timers, polling, scans, or subprocesses added. One extra `options.cursorBlink` write per pane per hide and per reveal; xterm's `OptionsService` drops no-op writes by value, so a real change costs one already-scheduled `refreshRows(0, rows-1)` on a boundary that repaints anyway.
- **Diagnostics**: `isTerminalCursorBlinkSuspended(terminal)` exposes the parked state for tests and future probes.
- **Residual gaps**, kept visible:
  1. **`decPrivateModes` wins.** `WebglRenderer._updateCursorBlink()` reads `decPrivateModes.cursorBlink ?? options.cursorBlink`. A TUI that issued a blinking DECSCUSR (`CSI 5 SP q`) keeps blinking while hidden; the public option cannot override it. Not addressed — the override would require private xterm state.
  2. **Intra-worktree hidden terminal tabs are not covered.** `hideTerminalVisibility` returns `{hiddenReason: 'tab', renderingSuspended: false}` for a tab switch inside the active worktree, so `suspendPaneRendering` never runs for those panes. Deliberately out of scope; it needs a matching restore on the light-resume path.
  3. Step 3 of the original plan (gating blink to the *active* pane) is **not** included. It is unnecessary: xterm's `CoreBrowserService.isFocused` is `textareaIsActiveElement && document.hasFocus()`, so a visible-but-unfocused split pane already never arms its blink timer. Including it would have been a no-op with a user-visible risk.

## Negative user-facing trade-offs

**None.**

- A hidden pane's cursor is by definition not on screen, so turning its blink off cannot change anything a user sees.
- Blink is restored **before** the WebGL reattach in `resumePaneRendering`, so a freshly constructed `WebglRenderer` samples the restored option and blinks on its first frame. Test: *"renders a blinking cursor again one frame after reveal"* asserts a rendered `.xterm-cursor.xterm-cursor-blink` after exactly one `requestAnimationFrame` — and that the cursor element is present at all, so a frozen or missing cursor fails.
- The user's setting is respected because resume restores the **parked** value, never `true` and never `settings.terminalCursorBlink`. A user with blink disabled stays disabled across hide → reveal (covered), and a settings change made *while* a pane is hidden lands on the parked value and applies on reveal without re-arming the timer behind the surface (covered).
- No dropped output, no lost scrollback, no frozen pane: covered by *"does not drop output written while hidden, and echoes typing after reveal"*, which writes across the hide boundary, asserts both pre-hide and hidden-time text render after reveal, and drives a real keydown through xterm's textarea to confirm input still reaches the PTY.

## Tests

New `src/renderer/src/lib/pane-manager/pane-cursor-blink-suspension.test.ts` (real `Terminal` under happy-dom, rendered-cursor oracle):

1. renders a blinking cursor again one frame after reveal
2. keeps a user who disabled cursor blink un-blinking across hide and reveal
3. does not drop output written while hidden, and echoes typing after reveal
4. restores blink on the retained-hidden-WebGL path, which skips dispose (asserts the addon was **not** disposed, so it is genuinely the retention branch)
5. restores every pane of a split, including one revealed a second time (two hide/reveal cycles, each half focused in turn)
6. does not re-arm a hidden pane when the blink setting changes mid-hide
7. resume is a no-op for a pane that was never suspended
8. redraw-cost gate: 6 retained hidden panes → 0 blink redraws → restored on reveal

Fail-first verified by reverting only `pane-rendering-control.ts`: 4 of 8 fail, including the cost gate (`expected 24000 to be +0`).

Three existing test doubles gained `terminal.options`, which the real `Terminal` always has.

## Verification

- `pnpm tc` — clean (run once, at the end)
- `npx oxlint <changed files>` — clean
- `npx vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager` — 793 passed, 1 skipped
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane` — 4,127 passed

(Under heavy parallel machine load an earlier run showed timeouts in `remote-runtime-pty-transport-*` / `pty-connection-*`; those reproduce identically on a clean tree with this branch reverted and are unrelated.)
