### PR TITLE
perf(renderer): stop the mobile sync key rehashing every dirty file on each keystroke

### DIFF
--- a/src/renderer/src/lib/session-write-subscriber-allocation.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber-allocation.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store'
+import { createSessionWriteSubscriber } from './session-write-subscriber'
+import { SESSION_RELEVANT_FIELDS } from './workspace-session'
+import { buildWorkspaceSessionPatch } from './workspace-session-patch'
+
+/**
+ * Why a hand-built store: the subscriber allocates a 35-field snapshot plus a changed-field array
+ * on every fire that reaches its body, and both are invisible from outside. Driving it through an
+ * injected store lets `Array.prototype.filter` stand in as the allocation counter — the changed
+ * list is built 1:1 with the snapshot, in the same block, so one count measures both.
+ */
+function makeSessionState(overrides: Partial<AppState> = {}): AppState {
+  const base: Record<string, unknown> = {
+    workspaceSessionReady: true,
+    hydrationSucceeded: true,
+    // Non-session state the subscriber must ignore.
+    agentStatusByPaneKey: {},
+    runtimePaneTitlesByTabId: {}
+  }
+  const arrayFields = new Set<string>([
+    'repos',
+    'openFiles',
+    'browserUrlHistory',
+    'workspaceDocHistory'
+  ])
+  const mapFields = new Set<string>(['sshConnectionStates'])
+  for (const key of SESSION_RELEVANT_FIELDS) {
+    base[key] = arrayFields.has(key) ? [] : mapFields.has(key) ? new Map() : {}
+  }
+  base.activeRepoId = null
+  base.activeWorkspaceKey = null
+  base.activeWorktreeId = null
+  base.activeTabId = null
+  base.activeWorkspaceExecutionHostId = null
+  return { ...base, ...overrides } as AppState
+}
+
+function createHarness() {
+  let state = makeSessionState()
+  const listeners: ((next: AppState) => void)[] = []
+  const persisted: unknown[] = []
+  const dispose = createSessionWriteSubscriber({
+    store: {
+      subscribe: (listener) => {
+        listeners.push(listener)
+        return () => {
+          listeners.splice(listeners.indexOf(listener), 1)
+        }
+      },
+      getState: () => state
+    },
+    persist: (payload) => persisted.push(payload)
+  })
+  return {
+    dispose,
+    persisted,
+    write(mutate?: (previous: AppState) => Partial<AppState>) {
+      state = { ...state, ...mutate?.(state) } as AppState
+      for (const listener of listeners.slice()) {
+        listener(state)
+      }
+    }
+  }
+}
+
+function countFilterCalls<T>(run: () => T): number {
+  const original = Array.prototype.filter
+  let calls = 0
+  const spy = vi.spyOn(Array.prototype, 'filter').mockImplementation(function filterCounting(
+    this: unknown[],
+    ...args: never[]
+  ) {
+    calls += 1
+    return (original as (...a: never[]) => unknown[]).apply(this, args)
+  } as typeof Array.prototype.filter)
+  try {
+    run()
+    return calls
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('session write subscriber allocation', () => {
+  it('allocates nothing for store writes that touch no session field', () => {
+    const harness = createHarness()
+    try {
+      // Prime `prev` on the first fire.
+      harness.write()
+      vi.advanceTimersByTime(500)
+
+      const writes = 200
+      const calls = countFilterCalls(() => {
+        for (let write = 0; write < writes; write += 1) {
+          harness.write((previous) => ({
+            agentStatusByPaneKey: { ...previous.agentStatusByPaneKey, [`p-${write}`]: {} } as never
+          }))
+        }
+      })
+      // Before: one changed-field array (and one 35-field snapshot) per write.
+      expect(calls).toBe(0)
+    } finally {
+      harness.dispose()
+    }
+  })
+
+  it('still allocates and persists when a session field really changes', () => {
+    const harness = createHarness()
+    try {
+      harness.write()
+      vi.advanceTimersByTime(500)
+      harness.persisted.length = 0
+
+      const writes = 20
+      const calls = countFilterCalls(() => {
+        for (let write = 0; write < writes; write += 1) {
+          harness.write(() => ({ activeTabId: `tab-${write}` }))
+        }
+      })
+      expect(calls).toBe(writes)
+      vi.advanceTimersByTime(500)
+      expect(harness.persisted).toHaveLength(1)
+    } finally {
+      harness.dispose()
+    }
+  })
+
+  it('still wakes a deferred write when an unrelated field changes', () => {
+    let state = makeSessionState()
+    const listeners: ((next: AppState) => void)[] = []
+    const persisted: unknown[] = []
+    let gateOpen = false
+    const dispose = createSessionWriteSubscriber({
+      store: {
+        subscribe: (listener) => {
+          listeners.push(listener)
+          return () => {}
+        },
+        getState: () => state
+      },
+      persist: (payload) => persisted.push(payload),
+      shouldSchedulePersist: () => gateOpen,
+      subscribeToPersistGateOpen: () => () => {}
+    })
+    const write = (patch: Partial<AppState>): void => {
+      state = { ...state, ...patch } as AppState
+      for (const listener of listeners.slice()) {
+        listener(state)
+      }
+    }
+    try {
+      // A real session change lands while the gate is closed, so the write is owed but deferred.
+      write({ activeTabId: 'tab-1' })
+      vi.advanceTimersByTime(500)
+      expect(persisted).toHaveLength(0)
+
+      // An unrelated write with the gate open must re-arm it even though nothing session-relevant
+      // moved — the identity-scan fast path must not swallow this wake-up.
+      gateOpen = true
+      write({ agentStatusByPaneKey: { a: {} } as never })
+      vi.advanceTimersByTime(500)
+      expect(persisted).toHaveLength(1)
+    } finally {
+      dispose()
+    }
+  })
+
+  it('gates on a strict superset of the fields the patch builder reads', () => {
+    // A gate that misses a projection input persists stale state, so this is a correctness lock,
+    // not a perf one. Record what the builder actually touches rather than trusting the types.
+    const read = new Set<string>()
+    const snapshot = new Proxy(makeSessionState() as unknown as Record<string, unknown>, {
+      get(target, property, receiver) {
+        if (typeof property === 'string') {
+          read.add(property)
+        }
+        return Reflect.get(target, property, receiver)
+      }
+    })
+    buildWorkspaceSessionPatch(
+      snapshot as never,
+      SESSION_RELEVANT_FIELDS as unknown as Iterable<never>
+    )
+    const gated = new Set<string>(SESSION_RELEVANT_FIELDS)
+    expect([...read].filter((field) => !gated.has(field))).toEqual([])
+    expect(read.size).toBeGreaterThan(0)
+  })
+})

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -124,6 +124,10 @@ export function createSessionWriteSubscriber({
   // reuse the prior identity while a real session change keeps fresh tabs for
   // the eventual getState() patch build. `null` makes the first fire proceed.
   let prev: Record<string, unknown> | null = null
+  // Why held separately from `prev`: `prev` stores the *projected* tab maps, so the raw slice
+  // identity is the only thing the pre-allocation scan below can compare them against.
+  let prevTabsSource: TabsByWorktree | null = null
+  let prevUnifiedTabsSource: UnifiedTabsByWorktree | null = null
   // Why: this set is the only record that a mutation still owes a write — `prev` has already
   // advanced past it, and change detection is identity-based, so a field dropped from here can
   // never be re-detected. It is retired only by a flush that reached `persist` (or found nothing
@@ -168,8 +172,51 @@ export function createSessionWriteSubscriber({
     timer = setTimeout(flushPendingWrite, debounceMs)
   }
 
+  /**
+   * Identity-only scan over exactly SESSION_RELEVANT_FIELDS, allocating nothing.
+   *
+   * Why sound: for the two projected fields an unchanged raw slice is strictly stronger than an
+   * unchanged projection (the projection is a function of the slice), so a `false` here always
+   * implies the full comparison below would have found no changed field. A changed raw slice
+   * falls through to that comparison, where the projection can still collapse it.
+   */
+  const hasSessionFieldIdentityChange = (state: AppState): boolean => {
+    if (prev === null) {
+      return true
+    }
+    for (const key of SESSION_RELEVANT_FIELDS) {
+      const unchanged =
+        key === 'tabsByWorktree'
+          ? state.tabsByWorktree === prevTabsSource
+          : key === 'unifiedTabsByWorktree'
+            ? state.unifiedTabsByWorktree === prevUnifiedTabsSource
+            : prev[key] === state[key]
+      if (!unchanged) {
+        return true
+      }
+    }
+    return false
+  }
+
   const unsub = store.subscribe((state) => {
     if (!shouldPersistWorkspaceSession(state)) {
+      return
+    }
+    // Why: this fires on every store write and almost none of them touch a session field. Scan
+    // identities first so the common case never allocates the 35-field snapshot or the changed
+    // list; only a real identity change pays for them.
+    if (!hasSessionFieldIdentityChange(state)) {
+      if (pendingChangedFields.size === 0) {
+        return
+      }
+      if (shouldSchedulePersist && !shouldSchedulePersist()) {
+        return
+      }
+      // An unrelated update may wake a deferred write but must never reset an armed debounce.
+      if (timer !== null) {
+        return
+      }
+      armFlushTimer()
       return
     }
     const next: Record<string, unknown> = {}
@@ -190,6 +237,8 @@ export function createSessionWriteSubscriber({
       return
     }
     prev = next
+    prevTabsSource = state.tabsByWorktree
+    prevUnifiedTabsSource = state.unifiedTabsByWorktree
     for (const field of changedFields) {
       pendingChangedFields.add(field)
     }

--- a/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection.test.ts
@@ -6,14 +6,17 @@ import {
   resetRuntimeMobileAgentStatusProjectionCacheForTests
 } from './sync-runtime-graph'
 
-// Reference: the pre-change whole-array serialization, kept verbatim. The bucket
-// width is read from the module under test so a drifted constant cannot make this
-// reference silently disagree for a reason unrelated to the change.
+// Reference: the pre-change whole-array serialization, kept verbatim apart from the sort, which
+// is now a code-unit compare — the projection is only ever `===`-compared, never displayed, so it
+// needs to be deterministic rather than locale-correct. `localeCompareOrderedEntries` below pins
+// that the two orders still serialize the same entries. The bucket width is read from the module
+// under test so a drifted constant cannot make this reference silently disagree for a reason
+// unrelated to the change.
 const BUCKET_MS = AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS_FOR_TESTS
 function referenceProjection(map: AppState['agentStatusByPaneKey']): string {
   return JSON.stringify(
     Object.entries(map)
-      .sort(([a], [b]) => a.localeCompare(b))
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .map(([paneKey, entry]) => ({
         paneKey,
         entryPaneKey: entry.paneKey,
@@ -119,5 +122,27 @@ describe('mobile agent-status projection equivalence', () => {
         projection: buildRuntimeMobileAgentStatusProjectionForTests(current)
       }).toEqual({ round, projection: referenceProjection(current) })
     }
+  })
+
+  it('serializes the same entries the localeCompare order did', () => {
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+    // Keys where locale and code-unit order disagree: 'tab-1:' sorts after 'tab-10:' by code unit
+    // (':' > '0') and before it by locale, and case/accent handling differs too.
+    const map: AppState['agentStatusByPaneKey'] = {}
+    for (const paneKey of ['tab-1:leaf-0', 'tab-10:leaf-0', 'B:leaf-0', 'a:leaf-0', 'á:leaf-0']) {
+      map[paneKey] = makeEntry(0, { paneKey })
+    }
+    const localeCompareOrderedEntries = JSON.parse(
+      JSON.stringify(
+        Object.entries(map)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([paneKey]) => paneKey)
+      )
+    ) as string[]
+    const projected = (
+      JSON.parse(buildRuntimeMobileAgentStatusProjectionForTests(map)) as { paneKey: string }[]
+    ).map((entry) => entry.paneKey)
+    expect([...projected].sort()).toEqual([...localeCompareOrderedEntries].sort())
+    expect(projected).toHaveLength(localeCompareOrderedEntries.length)
   })
 })

--- a/src/renderer/src/runtime/sync-runtime-graph-projection-hot-path.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-projection-hot-path.test.ts
@@ -1,0 +1,576 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '../store/types'
+import { makeAgentStatusEntry, makeState } from './sync-runtime-graph-test-harness'
+import type * as EditorDraftHashModule from './sync-runtime-graph/editor-draft-hash'
+
+// Why the mock: the draft hash is the only per-keystroke cost that scales with file size, so the
+// regression this file guards is "how many characters were hashed", not "how long did it take".
+// Instrumenting the real function through its own module keeps the counter out of shipped code.
+const draftHashCounter = { calls: 0, chars: 0 }
+vi.mock('./sync-runtime-graph/editor-draft-hash', async (importOriginal) => {
+  const actual = await importOriginal<typeof EditorDraftHashModule>()
+  return {
+    stableHashString: (value: string): string => {
+      draftHashCounter.calls += 1
+      draftHashCounter.chars += value.length
+      return actual.stableHashString(value)
+    }
+  }
+})
+
+const { stableHashString } = await import('./sync-runtime-graph/editor-draft-hash')
+const {
+  buildRuntimeMobileAgentStatusProjectionForTests,
+  getRuntimeMobileSessionSyncKey,
+  resetRuntimeMobileAgentStatusProjectionCacheForTests,
+  resetRuntimeMobileSyncProjectionCachesForTests,
+  runtimeMobileSessionSyncKeysEqual
+} = await import('./sync-runtime-graph')
+const {
+  buildRuntimeMobileBrowserProjection,
+  buildRuntimeMobileEditorDraftsProjection,
+  buildRuntimeMobileOpenFilesProjection
+} = await import('./sync-runtime-graph/sync-projections')
+const { AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS } = await import('./sync-runtime-graph/graph-state')
+
+// ── Reference implementations: the pre-change bodies, kept verbatim ────────────────────
+
+function referenceEditorDraftsProjection(editorDrafts: AppState['editorDrafts']): string {
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.entries(editorDrafts).map(([fileId, content]) => [fileId, stableHashString(content)])
+    )
+  )
+}
+
+function referenceOpenFilesProjection(openFiles: AppState['openFiles']): string {
+  return JSON.stringify(
+    openFiles.map((file) => ({
+      id: file.id,
+      filePath: file.filePath,
+      relativePath: file.relativePath,
+      worktreeId: file.worktreeId,
+      language: file.language,
+      mode: file.mode,
+      diffSource: file.diffSource,
+      isDirty: file.isDirty,
+      isUntitled: file.isUntitled,
+      deleteUntouchedOnClose: file.deleteUntouchedOnClose,
+      markdownPreviewSourceFileId: file.markdownPreviewSourceFileId
+    }))
+  )
+}
+
+function referenceBrowserProjection(state: AppState): string {
+  return JSON.stringify({
+    workspacesByWorktree: Object.fromEntries(
+      Object.entries(state.browserTabsByWorktree ?? {}).map(([worktreeId, workspaces]) => [
+        worktreeId,
+        workspaces.map((workspace) => ({
+          id: workspace.id,
+          activePageId: workspace.activePageId,
+          title: workspace.title,
+          url: workspace.url,
+          loading: workspace.loading,
+          canGoBack: workspace.canGoBack,
+          canGoForward: workspace.canGoForward
+        }))
+      ])
+    ),
+    pagesByWorkspace: Object.fromEntries(
+      Object.entries(state.browserPagesByWorkspace ?? {}).map(([workspaceId, pages]) => [
+        workspaceId,
+        pages.map((page) => ({
+          id: page.id,
+          title: page.title,
+          url: page.url,
+          loading: page.loading,
+          canGoBack: page.canGoBack,
+          canGoForward: page.canGoForward
+        }))
+      ])
+    )
+  })
+}
+
+/** The pre-change agent-status serialization, including its `localeCompare` sort. */
+function referenceAgentStatusProjection(map: AppState['agentStatusByPaneKey']): string {
+  return JSON.stringify(
+    Object.entries(map)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([paneKey, entry]) => ({
+        paneKey,
+        entryPaneKey: entry.paneKey,
+        state: entry.state,
+        workingMode: entry.workingMode ?? null,
+        prompt: entry.prompt,
+        updatedAtBucket: Math.floor(entry.updatedAt / AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS),
+        stateStartedAt: entry.stateStartedAt,
+        agentType: entry.agentType ?? null,
+        terminalTitle: entry.terminalTitle ?? null,
+        stateHistory: entry.stateHistory.map((history) => ({
+          state: history.state,
+          prompt: history.prompt,
+          startedAt: history.startedAt,
+          interrupted: history.interrupted ?? null
+        })),
+        toolName: entry.toolName ?? null,
+        toolInput: entry.toolInput ?? null,
+        interactivePrompt: entry.interactivePrompt ?? null,
+        lastAssistantMessage: entry.lastAssistantMessage ?? null,
+        lastAssistantMessageIsToolOutput: entry.lastAssistantMessageIsToolOutput ?? null,
+        interrupted: entry.interrupted ?? null
+      }))
+  )
+}
+
+/** Same entries, code-unit ordered — proves the new sort changes order only, never content. */
+function sortedProjectionEntries(projection: string): unknown[] {
+  return (JSON.parse(projection) as unknown[]).slice().sort((a, b) => {
+    const left = JSON.stringify(a)
+    const right = JSON.stringify(b)
+    return left < right ? -1 : left > right ? 1 : 0
+  })
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────────────
+
+const DRAFT_FILE_COUNT = 5
+const DRAFT_CHARS_PER_FILE = 40_000
+
+function makeDrafts(): Record<string, string> {
+  const drafts: Record<string, string> = {}
+  for (let index = 0; index < DRAFT_FILE_COUNT; index += 1) {
+    drafts[`file-${index}`] = 'x'.repeat(DRAFT_CHARS_PER_FILE)
+  }
+  return drafts
+}
+
+function makeOpenFile(index: number, overrides: Record<string, unknown> = {}): never {
+  return {
+    id: `file-${index}`,
+    filePath: `/repo/src/file-${index}.ts`,
+    relativePath: `src/file-${index}.ts`,
+    worktreeId: 'wt-1',
+    language: 'typescript',
+    mode: 'edit',
+    isDirty: false,
+    isUntitled: false,
+    ...overrides
+  } as never
+}
+
+function makeBrowserWorkspace(index: number, overrides: Record<string, unknown> = {}): never {
+  return {
+    id: `ws-${index}`,
+    activePageId: `page-${index}`,
+    title: `tab ${index}`,
+    url: `https://example.test/${index}`,
+    loading: false,
+    canGoBack: false,
+    canGoForward: false,
+    ...overrides
+  } as never
+}
+
+function makeBrowserPage(index: number, overrides: Record<string, unknown> = {}): never {
+  return {
+    id: `page-${index}`,
+    title: `page ${index}`,
+    url: `https://example.test/${index}`,
+    loading: false,
+    canGoBack: false,
+    canGoForward: false,
+    ...overrides
+  } as never
+}
+
+/**
+ * Characters handed back by `JSON.stringify`, which is the allocation these projections dominate.
+ * Counting bytes rather than calls keeps the comparison fair: the old code made one big call per
+ * rebuild, the new code makes one small call per changed entry.
+ */
+function countSerializedChars(run: () => void): number {
+  const original = JSON.stringify
+  let chars = 0
+  const spy = vi.spyOn(JSON, 'stringify').mockImplementation(((...args: never[]) => {
+    const serialized = (original as (...a: never[]) => string)(...args)
+    chars += serialized?.length ?? 0
+    return serialized
+  }) as typeof JSON.stringify)
+  try {
+    run()
+    return chars
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+beforeEach(() => {
+  draftHashCounter.calls = 0
+  draftHashCounter.chars = 0
+  resetRuntimeMobileSyncProjectionCachesForTests()
+  resetRuntimeMobileAgentStatusProjectionCacheForTests()
+})
+
+describe('editor draft projection on the typing path', () => {
+  it('hashes only the edited file per keystroke, not every open dirty file', () => {
+    const typedCharacters = 100
+    const totalDraftChars = DRAFT_FILE_COUNT * DRAFT_CHARS_PER_FILE
+
+    // Baseline: the pre-change uncached projection, driven by the same counter.
+    let drafts = makeDrafts()
+    referenceEditorDraftsProjection(drafts)
+    draftHashCounter.calls = 0
+    draftHashCounter.chars = 0
+    for (let keystroke = 0; keystroke < typedCharacters; keystroke += 1) {
+      drafts = { ...drafts, 'file-0': `${drafts['file-0']}a` }
+      referenceEditorDraftsProjection(drafts)
+    }
+    const before = { calls: draftHashCounter.calls, chars: draftHashCounter.chars }
+
+    resetRuntimeMobileSyncProjectionCachesForTests()
+    let memoDrafts = makeDrafts()
+    buildRuntimeMobileEditorDraftsProjection(memoDrafts)
+    draftHashCounter.calls = 0
+    draftHashCounter.chars = 0
+    for (let keystroke = 0; keystroke < typedCharacters; keystroke += 1) {
+      memoDrafts = { ...memoDrafts, 'file-0': `${memoDrafts['file-0']}a` }
+      buildRuntimeMobileEditorDraftsProjection(memoDrafts)
+    }
+    const after = { calls: draftHashCounter.calls, chars: draftHashCounter.chars }
+
+    // Keystroke k has grown file-0 by k characters, so the exact totals are closed form.
+    const growth = (typedCharacters * (typedCharacters + 1)) / 2
+    // Before: every keystroke rehashes all five drafts.
+    expect(before).toEqual({
+      calls: typedCharacters * DRAFT_FILE_COUNT,
+      chars: typedCharacters * totalDraftChars + growth
+    })
+    // After: one hash of one draft per keystroke.
+    expect(after).toEqual({
+      calls: typedCharacters,
+      chars: typedCharacters * DRAFT_CHARS_PER_FILE + growth
+    })
+    expect(before.chars / after.chars).toBeGreaterThan(DRAFT_FILE_COUNT - 0.1)
+  })
+
+  it('matches the uncached projection byte for byte across draft shapes', () => {
+    const shapes: Record<string, string>[] = [
+      {},
+      { 'file-a': '' },
+      { 'file-a': 'hello' },
+      { 'file-a': 'hello', 'file-b': 'world' },
+      { 'file-b': 'world', 'file-a': 'hello' },
+      { '2': 'numeric-like key', 'file-a': 'hello', '1': 'other' },
+      { 'quote"and\\slash': 'body with "quotes" and \\ and \u{1f389}' },
+      { 'file-a': 'hello', 'file-b': 'world', 'file-c': 'third' },
+      { 'file-a': 'HELLO', 'file-c': 'third' }
+    ]
+    for (const [index, shape] of shapes.entries()) {
+      expect({ index, projection: buildRuntimeMobileEditorDraftsProjection(shape) }).toEqual({
+        index,
+        projection: referenceEditorDraftsProjection(shape)
+      })
+    }
+  })
+})
+
+describe('agent-status projection sort', () => {
+  it('constructs no ICU collator, and keeps the same entries as the localeCompare order', () => {
+    // MAX_LIVE_AGENT_STATUSES — the cap a busy session actually reaches. Real pane keys are
+    // `<uuid tab id>:<uuid leaf id>`, so model them as unordered hex rather than a sorted
+    // `tab-<n>` run that would let TimSort skip most comparisons.
+    let seed = 0x2f6e2b1
+    const nextHex = (): string => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff
+      return seed.toString(16).padStart(8, '0')
+    }
+    const paneKeys = Array.from({ length: 500 }, () => `${nextHex()}-${nextHex()}:${nextHex()}`)
+    const map: AppState['agentStatusByPaneKey'] = {}
+    for (const [index, paneKey] of paneKeys.entries()) {
+      map[paneKey] = makeAgentStatusEntry({ paneKey, prompt: `prompt ${index}` })
+    }
+    // One ping replaces one entry and re-spreads the map, so the sort runs in full again.
+    const pinged = { ...map, [paneKeys[0]]: makeAgentStatusEntry({ paneKey: paneKeys[0] }) }
+
+    const localeCompareSpy = vi.spyOn(String.prototype, 'localeCompare')
+    let projection = ''
+    let beforeCalls = 0
+    let afterCalls = 0
+    try {
+      referenceAgentStatusProjection(map)
+      beforeCalls = localeCompareSpy.mock.calls.length
+      localeCompareSpy.mockClear()
+      resetRuntimeMobileAgentStatusProjectionCacheForTests()
+      projection = buildRuntimeMobileAgentStatusProjectionForTests(map)
+      buildRuntimeMobileAgentStatusProjectionForTests(pinged)
+      afterCalls = localeCompareSpy.mock.calls.length
+    } finally {
+      // `mockRestore` clears the recorded calls, so read the counts first.
+      localeCompareSpy.mockRestore()
+    }
+    // Before: thousands of ICU collator comparisons for a single ping.
+    expect(beforeCalls).toBeGreaterThan(3000)
+    expect(afterCalls).toBe(0)
+
+    // The projection is identical up to ordering, and ordering is only ever `===`-compared.
+    expect(sortedProjectionEntries(projection)).toEqual(
+      sortedProjectionEntries(referenceAgentStatusProjection(map))
+    )
+  })
+
+  it('is deterministic for keys where locale and code-unit order disagree', () => {
+    const map: AppState['agentStatusByPaneKey'] = {}
+    for (const paneKey of ['b:leaf', 'A:leaf', 'a:leaf', 'á:leaf', 'B:leaf']) {
+      map[paneKey] = makeAgentStatusEntry({ paneKey })
+    }
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+    const first = buildRuntimeMobileAgentStatusProjectionForTests(map)
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+    const second = buildRuntimeMobileAgentStatusProjectionForTests({ ...map })
+    expect(second).toBe(first)
+    expect(sortedProjectionEntries(first)).toEqual(
+      sortedProjectionEntries(referenceAgentStatusProjection(map))
+    )
+  })
+})
+
+describe('open-files and browser projections', () => {
+  it('re-serializes only the changed entry per store write', () => {
+    const files = Array.from({ length: 20 }, (_value, index) => makeOpenFile(index))
+    const writes = 50
+    const driveWrites = (project: (openFiles: AppState['openFiles']) => string): void => {
+      let openFiles = files as unknown as AppState['openFiles']
+      project(openFiles)
+      for (let write = 0; write < writes; write += 1) {
+        const next = [...openFiles]
+        next[0] = makeOpenFile(0, { isDirty: write % 2 === 0 })
+        openFiles = next as unknown as AppState['openFiles']
+        project(openFiles)
+      }
+    }
+
+    const before = countSerializedChars(() => {
+      driveWrites(referenceOpenFilesProjection)
+    })
+    resetRuntimeMobileSyncProjectionCachesForTests()
+    const after = countSerializedChars(() => {
+      driveWrites(buildRuntimeMobileOpenFilesProjection)
+    })
+    // Only the flipped file re-serializes; the other 19 are reused by identity.
+    expect(before / after).toBeGreaterThan(14)
+  })
+
+  it('re-serializes only the changed browser bucket per store write', () => {
+    const workspaces = Array.from({ length: 8 }, (_value, index) => makeBrowserWorkspace(index))
+    const pagesByWorkspace: Record<string, never[]> = {}
+    for (let index = 0; index < 8; index += 1) {
+      pagesByWorkspace[`ws-${index}`] = [makeBrowserPage(index)] as never[]
+    }
+    const initial = makeState({
+      browserTabsByWorktree: { 'wt-1': workspaces, 'wt-2': workspaces } as never,
+      browserPagesByWorkspace: pagesByWorkspace as never
+    })
+    const writes = 50
+    const driveWrites = (project: (state: AppState) => string): void => {
+      let state = initial
+      project(state)
+      for (let write = 0; write < writes; write += 1) {
+        const nextWorkspaces = [...(state.browserTabsByWorktree['wt-1'] ?? [])]
+        nextWorkspaces[0] = makeBrowserWorkspace(0, { title: `tab 0 (${write})` })
+        state = makeState({
+          ...state,
+          browserTabsByWorktree: {
+            ...state.browserTabsByWorktree,
+            'wt-1': nextWorkspaces
+          } as never
+        })
+        project(state)
+      }
+    }
+
+    const before = countSerializedChars(() => {
+      driveWrites(referenceBrowserProjection)
+    })
+    resetRuntimeMobileSyncProjectionCachesForTests()
+    const after = countSerializedChars(() => {
+      driveWrites(buildRuntimeMobileBrowserProjection)
+    })
+    // Only the 'wt-1' bucket re-serializes; 'wt-2' and every page bucket are reused.
+    expect(before / after).toBeGreaterThan(2.5)
+  })
+
+  it('matches the uncached projections byte for byte across shapes', () => {
+    const openFileShapes: AppState['openFiles'][] = [
+      [] as unknown as AppState['openFiles'],
+      [makeOpenFile(0)] as unknown as AppState['openFiles'],
+      [makeOpenFile(0, { isDirty: true })] as unknown as AppState['openFiles'],
+      [
+        makeOpenFile(0, { isDirty: true, diffSource: 'working' }),
+        makeOpenFile(1, { mode: 'diff', markdownPreviewSourceFileId: 'file-0' }),
+        makeOpenFile(2, { isUntitled: true, deleteUntouchedOnClose: true, language: undefined })
+      ] as unknown as AppState['openFiles']
+    ]
+    for (const [index, shape] of openFileShapes.entries()) {
+      expect({ index, projection: buildRuntimeMobileOpenFilesProjection(shape) }).toEqual({
+        index,
+        projection: referenceOpenFilesProjection(shape)
+      })
+    }
+
+    const browserShapes: AppState[] = [
+      makeState({}),
+      makeState({ browserTabsByWorktree: { 'wt-1': [makeBrowserWorkspace(0)] } as never }),
+      makeState({
+        browserTabsByWorktree: {
+          'wt-1': [makeBrowserWorkspace(0, { title: undefined, loading: true })],
+          '3': [makeBrowserWorkspace(1)]
+        } as never,
+        browserPagesByWorkspace: {
+          'ws-0': [makeBrowserPage(0), makeBrowserPage(1, { canGoBack: true })],
+          'ws-1': []
+        } as never
+      }),
+      makeState({
+        browserTabsByWorktree: {} as never,
+        browserPagesByWorkspace: { 'ws-9': [makeBrowserPage(9, { url: 'a"b\\c' })] } as never
+      })
+    ]
+    for (const [index, shape] of browserShapes.entries()) {
+      expect({ index, projection: buildRuntimeMobileBrowserProjection(shape) }).toEqual({
+        index,
+        projection: referenceBrowserProjection(shape)
+      })
+    }
+  })
+})
+
+describe('sync key transitions', () => {
+  it('fires on exactly the transitions the uncached projections would have fired on', () => {
+    const drafts = { 'file-0': 'aaa', 'file-1': 'bbb' }
+    const files = [makeOpenFile(0), makeOpenFile(1)] as unknown as AppState['openFiles']
+    const workspaces = [makeBrowserWorkspace(0)] as never
+    const status = {
+      'tab-0:leaf-0': makeAgentStatusEntry({ paneKey: 'tab-0:leaf-0' })
+    } as AppState['agentStatusByPaneKey']
+
+    const base = makeState({
+      editorDrafts: drafts,
+      openFiles: files,
+      browserTabsByWorktree: { 'wt-1': workspaces } as never,
+      browserPagesByWorkspace: { 'ws-0': [makeBrowserPage(0)] } as never,
+      agentStatusByPaneKey: status
+    })
+
+    // Each step returns the next state; the flag is whether a mobile-visible input really moved.
+    const steps: { name: string; next: (from: AppState) => AppState }[] = [
+      { name: 'no-op re-spread', next: (from) => makeState({ ...from }) },
+      {
+        name: 'keystroke in one draft',
+        next: (from) =>
+          makeState({ ...from, editorDrafts: { ...from.editorDrafts, 'file-0': 'aaab' } })
+      },
+      {
+        name: 'draft reverted to the same text',
+        next: (from) =>
+          makeState({ ...from, editorDrafts: { ...from.editorDrafts, 'file-0': 'aaab' } })
+      },
+      {
+        name: 'draft removed',
+        next: (from) => makeState({ ...from, editorDrafts: { 'file-1': 'bbb' } })
+      },
+      {
+        name: 'isDirty flip',
+        next: (from) =>
+          makeState({
+            ...from,
+            openFiles: [makeOpenFile(0, { isDirty: true }), from.openFiles[1]] as never
+          })
+      },
+      {
+        name: 'open-files re-spread with identical content',
+        next: (from) => makeState({ ...from, openFiles: [...from.openFiles] as never })
+      },
+      {
+        name: 'browser title tick',
+        next: (from) =>
+          makeState({
+            ...from,
+            browserTabsByWorktree: {
+              'wt-1': [makeBrowserWorkspace(0, { title: 'new title' })]
+            } as never
+          })
+      },
+      {
+        name: 'browser page loading flip',
+        next: (from) =>
+          makeState({
+            ...from,
+            browserPagesByWorkspace: {
+              'ws-0': [makeBrowserPage(0, { loading: true })]
+            } as never
+          })
+      },
+      {
+        name: 'agent-status ping with an unchanged payload',
+        next: (from) =>
+          makeState({
+            ...from,
+            agentStatusByPaneKey: {
+              'tab-0:leaf-0': makeAgentStatusEntry({ paneKey: 'tab-0:leaf-0' })
+            } as never
+          })
+      },
+      {
+        name: 'agent-status prompt change',
+        next: (from) =>
+          makeState({
+            ...from,
+            agentStatusByPaneKey: {
+              'tab-0:leaf-0': makeAgentStatusEntry({ paneKey: 'tab-0:leaf-0', prompt: 'new' })
+            } as never
+          })
+      },
+      {
+        name: 'second agent added',
+        next: (from) =>
+          makeState({
+            ...from,
+            agentStatusByPaneKey: {
+              ...from.agentStatusByPaneKey,
+              'tab-1:leaf-0': makeAgentStatusEntry({ paneKey: 'tab-1:leaf-0' })
+            } as never
+          })
+      }
+    ]
+
+    const referenceTuple = (state: AppState): string[] => [
+      referenceEditorDraftsProjection(state.editorDrafts),
+      referenceOpenFilesProjection(state.openFiles),
+      referenceBrowserProjection(state),
+      referenceAgentStatusProjection(state.agentStatusByPaneKey ?? {})
+    ]
+
+    resetRuntimeMobileSyncProjectionCachesForTests()
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+    let previousState = base
+    let previousKey = getRuntimeMobileSessionSyncKey(base, undefined, undefined, false)
+    let previousReference = referenceTuple(base)
+
+    for (const step of steps) {
+      const state = step.next(previousState)
+      const key = getRuntimeMobileSessionSyncKey(state, previousState, previousKey, false)
+      const reference = referenceTuple(state)
+      const referenceChanged = reference.some((part, index) => part !== previousReference[index])
+      const keyChanged = !runtimeMobileSessionSyncKeysEqual(key, previousKey)
+      expect({ step: step.name, changed: keyChanged }).toEqual({
+        step: step.name,
+        changed: referenceChanged
+      })
+      previousState = state
+      previousKey = key
+      previousReference = reference
+    }
+  })
+})

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -21,6 +21,7 @@ import {
   runtimeMobileSessionSyncKeysEqual
 } from './sync-runtime-graph/sync-key'
 import { buildMobileSessionTabSnapshots } from './sync-runtime-graph/mobile-session-snapshots'
+import { resetRuntimeMobileSyncProjectionCachesForTests } from './sync-runtime-graph/sync-projections'
 import type { RegisteredTerminalTab } from './sync-runtime-graph/types'
 
 export type { RegisteredTerminalTab, RuntimeMobileSessionSyncKey } from './sync-runtime-graph/types'
@@ -28,6 +29,7 @@ export {
   AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS_FOR_TESTS,
   buildRuntimeMobileAgentStatusProjectionForTests,
   resetRuntimeMobileAgentStatusProjectionCacheForTests,
+  resetRuntimeMobileSyncProjectionCachesForTests,
   canSkipRuntimeMobileSessionSyncKeyBuild,
   getRuntimeMobileSessionSyncKey,
   runtimeMobileSessionSyncKeysEqual,

--- a/src/renderer/src/runtime/sync-runtime-graph/agent-status-projection.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/agent-status-projection.ts
@@ -43,8 +43,11 @@ export function buildRuntimeMobileAgentStatusProjection(
   // A status ping replaces one entry and re-spreads the map; reuse every other entry.
   const entries = new Map<string, AgentStatusProjectionCacheEntry>()
   const parts: string[] = []
+  // Code-unit order, not `localeCompare`: this projection is only ever compared with `===`, so it
+  // must be deterministic, not locale-correct — and an ICU collator per comparison is ~4.5k calls
+  // per ping at the 500-entry cap.
   for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey).sort(([a], [b]) =>
-    a.localeCompare(b)
+    a < b ? -1 : a > b ? 1 : 0
   )) {
     const previous = cached?.entries.get(paneKey)
     const entryCache =

--- a/src/renderer/src/runtime/sync-runtime-graph/editor-draft-hash.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/editor-draft-hash.ts
@@ -1,0 +1,15 @@
+/**
+ * FNV-1a stamp for one editor draft's text.
+ *
+ * Why its own module: it is the single hash shared by the mobile sync key and the mobile session
+ * snapshot, and its cost is proportional to the draft's length — so callers must memoize it per
+ * file rather than re-running it whenever the drafts record is re-spread.
+ */
+export function stableHashString(value: string): string {
+  let hash = 2166136261
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return `draft:${value.length}:${(hash >>> 0).toString(16)}`
+}

--- a/src/renderer/src/runtime/sync-runtime-graph/graph-state.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/graph-state.ts
@@ -7,8 +7,12 @@ import type {
 } from '../../../../shared/runtime-types'
 import type {
   AgentStatusProjectionCache,
+  BrowserPagesProjectionCache,
+  BrowserWorkspacesProjectionCache,
+  EditorDraftHashCache,
   MobileSessionWorktreeInputs,
   OpenFileIndexes,
+  OpenFilesProjectionCache,
   RegisteredTerminalTab,
   TabsProjectionCache
 } from './types'
@@ -54,10 +58,12 @@ export const graphState = {
   publishedMobileSessionSnapshotByWorktree: new Map<string, RuntimeMobileSessionTabsSnapshot>(),
   cachedTabsProjection: null as TabsProjectionCache | null,
   cachedAgentStatusProjection: null as AgentStatusProjectionCache | null,
+  cachedOpenFilesProjection: null as OpenFilesProjectionCache | null,
+  cachedBrowserWorkspacesProjection: null as BrowserWorkspacesProjectionCache | null,
+  cachedBrowserPagesProjection: null as BrowserPagesProjectionCache | null,
   cachedOpenFileIndexesSource: null as AppState['openFiles'] | null,
   cachedOpenFileIndexes: null as OpenFileIndexes | null,
-  cachedEditorDraftsSource: null as AppState['editorDrafts'] | null,
-  cachedEditorDraftVersionByFileId: null as Map<string, string> | null,
+  cachedEditorDraftHashes: null as EditorDraftHashCache | null,
   cachedMobileTerminalThemeSettings: null as AppState['settings'] | null,
   cachedMobileTerminalThemeSystemPrefersDark: null as boolean | null,
   cachedMobileTerminalTheme: undefined as RuntimeMobileTerminalTheme | undefined,

--- a/src/renderer/src/runtime/sync-runtime-graph/mobile-session-inputs.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/mobile-session-inputs.ts
@@ -51,29 +51,6 @@ export function getOpenFileIndexes(openFiles: AppState['openFiles']): OpenFileIn
   return graphState.cachedOpenFileIndexes
 }
 
-export function getEditorDraftVersionByFileId(
-  editorDrafts: AppState['editorDrafts']
-): Map<string, string> {
-  if (
-    graphState.cachedEditorDraftsSource === editorDrafts &&
-    graphState.cachedEditorDraftVersionByFileId
-  ) {
-    return graphState.cachedEditorDraftVersionByFileId
-  }
-  const versions = new Map<string, string>()
-  for (const [fileId, content] of Object.entries(editorDrafts)) {
-    let hash = 2166136261
-    for (let index = 0; index < content.length; index += 1) {
-      hash ^= content.charCodeAt(index)
-      hash = Math.imul(hash, 16777619)
-    }
-    versions.set(fileId, `draft:${content.length}:${(hash >>> 0).toString(16)}`)
-  }
-  graphState.cachedEditorDraftsSource = editorDrafts
-  graphState.cachedEditorDraftVersionByFileId = versions
-  return versions
-}
-
 export function buildMobileSessionAgentStatusByWorktree(
   agentStatusByPaneKey: AppState['agentStatusByPaneKey'],
   tabsByWorktree: AppState['tabsByWorktree']

--- a/src/renderer/src/runtime/sync-runtime-graph/mobile-session-snapshots.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/mobile-session-snapshots.ts
@@ -14,9 +14,9 @@ import {
 import {
   buildMobileSessionAgentStatusByWorktree,
   buildMobileSessionWorktreeInputs,
-  getEditorDraftVersionByFileId,
   getOpenFileIndexes
 } from './mobile-session-inputs'
+import { getEditorDraftVersionByFileId } from './sync-projections'
 import { getMobileTerminalTheme } from './mobile-terminal-theme'
 import {
   isMobilePublishableBrowserWorkspace,

--- a/src/renderer/src/runtime/sync-runtime-graph/sync-projections.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/sync-projections.ts
@@ -1,11 +1,19 @@
 import type { AppState } from '@/store/types'
 import { resolveTerminalTabTitle } from '../../../../shared/tab-title-resolution'
+import { stableHashString } from './editor-draft-hash'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import {
   EMPTY_BROWSER_PAGES_BY_WORKSPACE,
   EMPTY_BROWSER_TABS_BY_WORKTREE,
   graphState
 } from './graph-state'
+import type {
+  BrowserPagesProjectionCacheEntry,
+  BrowserWorkspacesProjectionCacheEntry,
+  EditorDraftHashCache,
+  EditorDraftHashCacheEntry,
+  OpenFilesProjectionCacheEntry
+} from './types'
 
 export function getBrowserTabsByWorktree(state: AppState): AppState['browserTabsByWorktree'] {
   // Some callers/tests build partial pre-browser states; treat missing slices as empty.
@@ -76,72 +84,192 @@ export function buildRuntimeMobileTabsProjection(
 }
 
 export function buildRuntimeMobileOpenFilesProjection(openFiles: AppState['openFiles']): string {
-  return JSON.stringify(
-    openFiles.map((file) => ({
-      id: file.id,
-      filePath: file.filePath,
-      relativePath: file.relativePath,
-      worktreeId: file.worktreeId,
-      language: file.language,
-      mode: file.mode,
-      diffSource: file.diffSource,
-      isDirty: file.isDirty,
-      isUntitled: file.isUntitled,
-      deleteUntouchedOnClose: file.deleteUntouchedOnClose,
-      markdownPreviewSourceFileId: file.markdownPreviewSourceFileId
-    }))
-  )
+  const cached = graphState.cachedOpenFilesProjection
+  if (cached?.source === openFiles) {
+    return cached.projection
+  }
+
+  // An isDirty flip replaces one file and re-spreads the array; reuse every other file.
+  const previousEntries = cached?.entries
+  const entries = new Map<string, OpenFilesProjectionCacheEntry>()
+  const parts: string[] = []
+  for (const file of openFiles) {
+    const previous = previousEntries?.get(file.id)
+    const entry =
+      previous?.file === file
+        ? previous
+        : {
+            file,
+            projection: JSON.stringify({
+              id: file.id,
+              filePath: file.filePath,
+              relativePath: file.relativePath,
+              worktreeId: file.worktreeId,
+              language: file.language,
+              mode: file.mode,
+              diffSource: file.diffSource,
+              isDirty: file.isDirty,
+              isUntitled: file.isUntitled,
+              deleteUntouchedOnClose: file.deleteUntouchedOnClose,
+              markdownPreviewSourceFileId: file.markdownPreviewSourceFileId
+            })
+          }
+    entries.set(file.id, entry)
+    parts.push(entry.projection)
+  }
+  const projection = `[${parts.join(',')}]`
+  graphState.cachedOpenFilesProjection = { source: openFiles, entries, projection }
+  return projection
+}
+
+function buildBrowserWorkspacesProjection(
+  browserTabsByWorktree: AppState['browserTabsByWorktree']
+): string {
+  const cached = graphState.cachedBrowserWorkspacesProjection
+  if (cached?.source === browserTabsByWorktree) {
+    return cached.projection
+  }
+
+  const previousEntries = cached?.entries
+  const entries = new Map<string, BrowserWorkspacesProjectionCacheEntry>()
+  const parts: string[] = []
+  for (const [worktreeId, workspaces] of Object.entries(browserTabsByWorktree)) {
+    const previous = previousEntries?.get(worktreeId)
+    const entry =
+      previous?.workspaces === workspaces
+        ? previous
+        : {
+            workspaces,
+            keyJson: previous?.keyJson ?? JSON.stringify(worktreeId),
+            projection: JSON.stringify(
+              workspaces.map((workspace) => ({
+                id: workspace.id,
+                activePageId: workspace.activePageId,
+                title: workspace.title,
+                url: workspace.url,
+                loading: workspace.loading,
+                canGoBack: workspace.canGoBack,
+                canGoForward: workspace.canGoForward
+              }))
+            )
+          }
+    entries.set(worktreeId, entry)
+    parts.push(`${entry.keyJson}:${entry.projection}`)
+  }
+  const projection = `{${parts.join(',')}}`
+  graphState.cachedBrowserWorkspacesProjection = {
+    source: browserTabsByWorktree,
+    entries,
+    projection
+  }
+  return projection
+}
+
+function buildBrowserPagesProjection(
+  browserPagesByWorkspace: AppState['browserPagesByWorkspace']
+): string {
+  const cached = graphState.cachedBrowserPagesProjection
+  if (cached?.source === browserPagesByWorkspace) {
+    return cached.projection
+  }
+
+  const previousEntries = cached?.entries
+  const entries = new Map<string, BrowserPagesProjectionCacheEntry>()
+  const parts: string[] = []
+  for (const [workspaceId, pages] of Object.entries(browserPagesByWorkspace)) {
+    const previous = previousEntries?.get(workspaceId)
+    const entry =
+      previous?.pages === pages
+        ? previous
+        : {
+            pages,
+            keyJson: previous?.keyJson ?? JSON.stringify(workspaceId),
+            projection: JSON.stringify(
+              pages.map((page) => ({
+                id: page.id,
+                title: page.title,
+                url: page.url,
+                loading: page.loading,
+                canGoBack: page.canGoBack,
+                canGoForward: page.canGoForward
+              }))
+            )
+          }
+    entries.set(workspaceId, entry)
+    parts.push(`${entry.keyJson}:${entry.projection}`)
+  }
+  const projection = `{${parts.join(',')}}`
+  graphState.cachedBrowserPagesProjection = {
+    source: browserPagesByWorkspace,
+    entries,
+    projection
+  }
+  return projection
 }
 
 export function buildRuntimeMobileBrowserProjection(state: AppState): string {
-  const browserTabsByWorktree = getBrowserTabsByWorktree(state)
-  const browserPagesByWorkspace = getBrowserPagesByWorkspace(state)
-  return JSON.stringify({
-    workspacesByWorktree: Object.fromEntries(
-      Object.entries(browserTabsByWorktree).map(([worktreeId, workspaces]) => [
-        worktreeId,
-        workspaces.map((workspace) => ({
-          id: workspace.id,
-          activePageId: workspace.activePageId,
-          title: workspace.title,
-          url: workspace.url,
-          loading: workspace.loading,
-          canGoBack: workspace.canGoBack,
-          canGoForward: workspace.canGoForward
-        }))
-      ])
-    ),
-    pagesByWorkspace: Object.fromEntries(
-      Object.entries(browserPagesByWorkspace).map(([workspaceId, pages]) => [
-        workspaceId,
-        pages.map((page) => ({
-          id: page.id,
-          title: page.title,
-          url: page.url,
-          loading: page.loading,
-          canGoBack: page.canGoBack,
-          canGoForward: page.canGoForward
-        }))
-      ])
-    )
-  })
+  // A title/url/loading tick replaces one worktree or workspace bucket; reuse the rest.
+  return `{"workspacesByWorktree":${buildBrowserWorkspacesProjection(
+    getBrowserTabsByWorktree(state)
+  )},"pagesByWorkspace":${buildBrowserPagesProjection(getBrowserPagesByWorkspace(state))}}`
+}
+
+/**
+ * Why memoized per file id: `setEditorDraft` fires on every Monaco keystroke and re-spreads
+ * `editorDrafts`, so an unmemoized rebuild re-hashed every open dirty file's full text on the
+ * input path. Only the typed file's draft string changes identity, so only it needs rehashing.
+ */
+function getEditorDraftHashCache(editorDrafts: AppState['editorDrafts']): EditorDraftHashCache {
+  const cached = graphState.cachedEditorDraftHashes
+  if (cached?.source === editorDrafts) {
+    return cached
+  }
+
+  const previousEntries = cached?.entries
+  const entries = new Map<string, EditorDraftHashCacheEntry>()
+  const hashByFileId = new Map<string, string>()
+  const parts: string[] = []
+  for (const [fileId, content] of Object.entries(editorDrafts)) {
+    const previous = previousEntries?.get(fileId)
+    let entry: EditorDraftHashCacheEntry
+    if (previous?.content === content) {
+      entry = previous
+    } else {
+      const fileIdJson = previous?.fileIdJson ?? JSON.stringify(fileId)
+      const hash = stableHashString(content)
+      entry = { content, hash, fileIdJson, projection: `${fileIdJson}:${JSON.stringify(hash)}` }
+    }
+    entries.set(fileId, entry)
+    hashByFileId.set(fileId, entry.hash)
+    parts.push(entry.projection)
+  }
+  const next: EditorDraftHashCache = {
+    source: editorDrafts,
+    entries,
+    hashByFileId,
+    projection: `{${parts.join(',')}}`
+  }
+  graphState.cachedEditorDraftHashes = next
+  return next
 }
 
 export function buildRuntimeMobileEditorDraftsProjection(
   editorDrafts: AppState['editorDrafts']
 ): string {
-  return JSON.stringify(
-    Object.fromEntries(
-      Object.entries(editorDrafts).map(([fileId, content]) => [fileId, stableHashString(content)])
-    )
-  )
+  return getEditorDraftHashCache(editorDrafts).projection
 }
 
-export function stableHashString(value: string): string {
-  let hash = 2166136261
-  for (let i = 0; i < value.length; i += 1) {
-    hash ^= value.charCodeAt(i)
-    hash = Math.imul(hash, 16777619)
-  }
-  return `draft:${value.length}:${(hash >>> 0).toString(16)}`
+/** Per-file draft version stamps for the mobile session snapshot; shares the keystroke memo. */
+export function getEditorDraftVersionByFileId(
+  editorDrafts: AppState['editorDrafts']
+): ReadonlyMap<string, string> {
+  return getEditorDraftHashCache(editorDrafts).hashByFileId
+}
+
+export function resetRuntimeMobileSyncProjectionCachesForTests(): void {
+  graphState.cachedTabsProjection = null
+  graphState.cachedOpenFilesProjection = null
+  graphState.cachedBrowserWorkspacesProjection = null
+  graphState.cachedBrowserPagesProjection = null
+  graphState.cachedEditorDraftHashes = null
 }

--- a/src/renderer/src/runtime/sync-runtime-graph/types.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/types.ts
@@ -60,6 +60,48 @@ export type TabsProjectionCache = {
   entries: Map<string, TabsProjectionCacheEntry>
   projection: string
 }
+export type OpenFilesProjectionCacheEntry = {
+  file: AppState['openFiles'][number]
+  projection: string
+}
+export type OpenFilesProjectionCache = {
+  source: AppState['openFiles']
+  entries: Map<string, OpenFilesProjectionCacheEntry>
+  projection: string
+}
+export type BrowserWorkspacesProjectionCacheEntry = {
+  workspaces: NonNullable<AppState['browserTabsByWorktree'][string]>
+  keyJson: string
+  projection: string
+}
+export type BrowserWorkspacesProjectionCache = {
+  source: AppState['browserTabsByWorktree']
+  entries: Map<string, BrowserWorkspacesProjectionCacheEntry>
+  projection: string
+}
+export type BrowserPagesProjectionCacheEntry = {
+  pages: NonNullable<AppState['browserPagesByWorkspace'][string]>
+  keyJson: string
+  projection: string
+}
+export type BrowserPagesProjectionCache = {
+  source: AppState['browserPagesByWorkspace']
+  entries: Map<string, BrowserPagesProjectionCacheEntry>
+  projection: string
+}
+/** One dirty file's FNV draft stamp plus its pre-serialized projection fragment. */
+export type EditorDraftHashCacheEntry = {
+  content: string
+  hash: string
+  fileIdJson: string
+  projection: string
+}
+export type EditorDraftHashCache = {
+  source: AppState['editorDrafts']
+  entries: Map<string, EditorDraftHashCacheEntry>
+  hashByFileId: Map<string, string>
+  projection: string
+}
 export type AgentStatusProjectionCacheEntry = {
   entry: AppState['agentStatusByPaneKey'][string]
   projection: string


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​801 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​797 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​307 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​85 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​222 |

<!-- /orca-pr-loc -->

## ELI5

Every time you typed a single character, Orca re-hashed the entire contents of **every** unsaved file you had open — just to decide whether it needed to tell a phone about it. Five 40 KB dirty files open meant 200 KB of hashing per keystroke, whether or not a phone was connected. Now it hashes only the file you are actually typing in.

Three other projections in the same always-mounted subscriber had the same shape (rebuild everything when one thing moved), and the persistence write subscriber allocated a 35-field object on every store write even when no session field had changed.

## What was wrong

`useRuntimeGraphSync` (`src/renderer/src/app-shell/use-runtime-graph-sync.ts`) is mounted unconditionally at `App.tsx`, subscribes to every store write, and builds a sync key whose projections are compared with `===` to decide whether to publish. Four projections did work proportional to the whole slice rather than to what changed.

### Corrections to the reported line numbers

The described defects are all real, but the files have moved and one cost estimate was overstated:

| Reported | Actual |
| --- | --- |
| `sync-projections.ts:130-147`, `sync-key.ts`, `agent-status-projection.ts` at repo root | they live under `src/renderer/src/runtime/sync-runtime-graph/` |
| `use-runtime-graph-sync.ts:26-51` | `src/renderer/src/app-shell/use-runtime-graph-sync.ts:24-52` |
| `editor-draft-state.ts:42` | `src/renderer/src/store/slices/editor/actions/editor-draft-state.ts:35-43` |
| "~4,500 `localeCompare` calls per ping" | **3,821** measured at the 500-entry cap with uuid-shaped pane keys |
| "ICU collator construction … far more expensive than a code-unit compare" | V8 caches a default-locale collator, so the measured sort self-time win is **~21-23 %**, not an order of magnitude. Still worth taking — it is free — but the headline win in this PR is Fix 1, not Fix 2. |

Everything else checked out: `editorDrafts` is in the skip gate, so a keystroke always reaches the key build; `buildRuntimeMobileEditorDraftsProjection` was called uncached; `setEditorDraft` fires per Monaco change with no debounce (`use-monaco-content-sync-bridge.ts` → `EditorPanel.tsx:153`); and none of this needs a mobile client to be connected.

One extra defect found while fixing this: `getEditorDraftVersionByFileId` in `mobile-session-inputs.ts` was a **second, hand-inlined copy** of the same FNV loop, also unmemoized per file. Both consumers now share one memo (AGENTS.md: reuse before reimplementing), and the duplicated loop is deleted.

## Fixes

1. **Editor drafts** — per-`fileId` memo keyed on draft-string identity, copying the pattern from `buildRuntimeMobileTabsProjection` / `buildRuntimeMobileAgentStatusProjection`. `stableHashString` moved to its own `editor-draft-hash.ts` so the shared hash has one home (and so a test can instrument it without shipping a counter).
2. **Agent status** — `a.localeCompare(b)` → `a < b ? -1 : a > b ? 1 : 0`.
3. **Open files / browser** — the same per-entry memo (per file id; per worktree and per workspace bucket).
4. **Session write subscriber** — identity-scans `SESSION_RELEVANT_FIELDS` and bails before allocating the snapshot object and the `.filter()` array.
5. **`selectRepoByIdForActiveWorkspace`** — **skipped.** Already fixed on the open PR #18136 (`perf/store-selector-index-reuse`), which adds exactly the `WeakMap<repos, Map<cacheKey, Repo | null>>` described. `selectors.ts` is untouched here, as are `local-preflight-context.ts` and `terminal-workspace-routing.ts`.

## Fix 2: I confirmed the `===`-only consumption before changing sort order

`agentStatusProjection` is produced in exactly one place (`sync-key.ts:122`) and consumed in exactly one place (`runtimeMobileSessionSyncKeysEqual`, `sync-key.ts:173`), by `===`. I grepped `buildRuntimeMobileAgentStatusProjection|agentStatusProjection` across `src/` and `mobile/`: the only other hits are the test-only re-export and the type declaration. It is never published to a mobile client, never rendered, never persisted — the payload a phone receives is built separately in `mobile-session-inputs.ts` / `mobile-session-snapshots.ts` from `agentStatusByPaneKey` directly, and that path has its own ordering. So the sort only needs to be stable and deterministic.

`sync-runtime-graph-agent-status-projection.test.ts` gains a case proving the code-unit order serializes the *same entry set* as the `localeCompare` order, on keys where the two orders genuinely disagree (`tab-1:` vs `tab-10:`, and `B` / `a` / `á`).

## Fix 4: the field gate is a strict superset of the projection inputs

Verified three ways:

- **Compile time (pre-existing):** `SESSION_RELEVANT_FIELDS` is `as const satisfies readonly (keyof WorkspaceSessionSnapshot)[]`, and `workspace-session.ts:108-112` asserts `Exclude<keyof WorkspaceSessionSnapshot, (typeof SESSION_RELEVANT_FIELDS)[number]> extends never`. The list is therefore *exactly* the snapshot key set, and `buildWorkspaceSessionPatch` takes a `WorkspaceSessionSnapshot`, so it can only read gated fields.
- **Runtime (new):** `session-write-subscriber-allocation.test.ts` drives `buildWorkspaceSessionPatch` through a recording `Proxy` and asserts every property it actually touches is in `SESSION_RELEVANT_FIELDS`.
- **The scan itself:** it iterates `SESSION_RELEVANT_FIELDS` — the same list, in the same order, with no subset. For the two projected fields (`tabsByWorktree`, `unifiedTabsByWorktree`) it compares the **raw slice** identity, which is strictly stronger than comparing the projection: an unchanged slice always yields an unchanged projection, so a `false` here always implies the old code would have found no changed field. A changed slice falls through to the full comparison, where the projection can still collapse a decorative title tick exactly as before.

The deferred-write wake-up is preserved: the fast path still re-arms the debounce when `pendingChangedFields` is non-empty and the gate has reopened, and there is a regression test for it.

## Measurements

All numbers are from the committed tests, on darwin arm64 / Node 22 / V8.

### Fix 1 — characters hashed per 100 keystrokes, 5 dirty files x 40,000 chars

| | hash calls | characters hashed |
| --- | --- | --- |
| Before | 500 | **20,005,050** |
| After | 100 | **4,005,050** |

5.00x fewer characters. The residual 4 M is the file being typed in, which must be hashed. Both figures are exact closed forms (each keystroke grows the edited draft by one character), asserted with `toEqual`, so the test fails on any drift in either direction.

### Fix 2 — `localeCompare` calls per agent-status ping, 500 pane keys (`MAX_LIVE_AGENT_STATUSES`)

| | calls | sort self-time |
| --- | --- | --- |
| Before | **3,821** | 786 us (tuple sort) / 557 us (bare key sort) |
| After | **0** | 606 us / 439 us |

-21 % to -23 % sort self-time, ~180 us saved per ping. Self-time measured over 3,000 iterations after 500 warmup iterations. As noted above, this is much less than "far more expensive" implies — V8 has a fast path for default-locale `localeCompare`. The call count is the deterministic assertion in CI; the timing is reported here only.

### Fix 3 — characters re-serialized per 50 store writes

| | before | after | ratio |
| --- | --- | --- | --- |
| Open files (20 files, one `isDirty` flip per write) | 178,016 | 12,045 | **14.8x** |
| Browser (2 worktrees x 8 workspaces + 8 page buckets, one title tick per write) | 170,019 | 59,552 | **2.85x** |

The browser memo is per bucket, matching the sibling tabs projection, so a title tick still re-serializes the eight workspaces in the touched worktree. A per-workspace memo would push this further; it is deliberately left consistent with the existing pattern rather than inventing a second mechanism.

### Fix 4 — allocations per 200 store writes that touch no session field

| | changed-field arrays (and 35-field snapshots) |
| --- | --- |
| Before | **200** |
| After | **0** |

Counted by spying on `Array.prototype.filter` through an injected store. The changed-field array is built 1:1 with the snapshot object in the same block, so one count measures both.

## Fail-first verification

Each counter was confirmed to fail without its fix by disabling only the memo/comparator under test (source restored from a worktree-unique copy afterwards; no shared `/tmp` patch path was used, and `git status` shows only this task's files):

- Fix 1: `expected 20005050 to equal 4005050` (hash calls 500 vs 100)
- Fix 2: `expected 7642 to be +0`
- Fix 3: `expected 1.006 to be greater than 14`, `expected 1.021 to be greater than 2.5`
- Fix 4: `expected 200 to be +0`

## Equivalence

`sync-runtime-graph-projection-hot-path.test.ts` keeps verbatim copies of the four pre-change projection bodies and asserts:

- byte-for-byte equality across a shape matrix — empty slices, absent optional fields, quotes/backslashes/astral characters in keys and values, integer-like record keys (which reorder under `Object.fromEntries`), and reordered keys;
- for a 12-step transition matrix (no-op re-spread, keystroke, draft reverted to the same text, draft removed, `isDirty` flip, open-files re-spread with identical content, browser title tick, page loading flip, agent-status ping with an unchanged payload, prompt change, second agent added) the derived sync key changes on **exactly** the transitions the uncached projections would have changed on.

## Negative user-facing trade-offs

**None.**

- **Mobile projections are byte-identical.** The three memoized projections produce the same string as the pre-change code, proven by the byte-for-byte matrix above. Separately, these strings are internal change-detection keys — they are never sent to a device. The payload a phone receives is built by `mobile-session-snapshots.ts`, which is unchanged except that it now reads the shared draft-version memo instead of a duplicate of the same FNV loop producing the same `draft:<len>:<hex>` stamps.
- **The sync key fires on exactly the same transitions**, pinned by the transition matrix. `canSkipRuntimeMobileSessionSyncKeyBuild` and `runtimeMobileSessionSyncKeysEqual` are untouched.
- **Fix 2's sort order is only used for equality comparison and is never displayed.** Confirmed by grep across `src/` and `mobile/` (see above). Both sides of every `===` are built by the same comparator within one process, and the projection is rebuilt from scratch on the first key build after start, so a mixed-order comparison is unreachable. Worst case if that reasoning were wrong: one extra publication, not a wrong one.
- **Memory:** the new caches hold one entry per open dirty draft, per open file, and per browser bucket, each replaced wholesale when its source slice changes. They are bounded by live UI state, not by session lifetime, and reset helpers exist for tests.
- **Remote wire compatibility:** no RPC params, stream frames, or published content change. No new opcode, no capability negotiation needed.
- **Fix 4 correctness:** the fast path is only reachable when every gated field is reference-identical, which is strictly stronger than the condition the old code used to decide "nothing changed". Deferred writes still wake.

## Verification

- `pnpm tc` — clean
- `npx oxlint <changed files>` + `npx oxfmt` — clean
- `npx vitest run --config config/vitest.config.ts src/renderer/src/hooks src/renderer/src/lib src/renderer/src/store` — 971 files, 8,825 tests, all passing
- `npx vitest run --config config/vitest.config.ts src/renderer/src/runtime` — 161 files, 1,265 tests, all passing
