### PR TITLE
fix(agent-launch): preserve Codex session continuations

### DIFF
--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -886,14 +886,12 @@ describe('launchAgentInNewTab', () => {
       worktreeId: 'wt-1',
       prompt: 'large generated prompt',
       agentArgs: '--model gpt-5.5',
-      promptDelivery: 'submit-after-ready'
+      promptDelivery: 'submit-after-ready',
+      suppressStartupUpdatePrompt: true
     })
 
-    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
-      'tab-1',
-      expect.objectContaining({
-        command: "codex '--model' 'gpt-5.5'"
-      })
+    expect(mockQueueTabStartupCommand.mock.calls[0]?.[1]?.command).toBe(
+      "codex '--model' 'gpt-5.5' '-c' 'check_for_update_on_startup=false'"
     )
   })
 })

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -41,6 +41,8 @@ export type LaunchAgentInNewTabArgs = {
   prompt?: string
   /** Optional CLI arguments appended to the selected agent command. */
   agentArgs?: string | null
+  /** Prevent a startup update prompt from replacing a launch that carries generated context. */
+  suppressStartupUpdatePrompt?: boolean
   initialCwd?: string | null
   /** How to deliver the prompt: `draft` leaves it editable, `submit-after-ready` sends it once the TUI is ready. */
   promptDelivery?: 'auto-submit' | 'draft' | 'submit-after-ready'
@@ -86,6 +88,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     groupId,
     prompt,
     agentArgs,
+    suppressStartupUpdatePrompt = false,
     initialCwd,
     promptDelivery = 'auto-submit',
     launchSource,
@@ -139,6 +142,9 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     shell: queuedShell,
     isRemote,
     agentArgs: effectiveAgentArgs,
+    ...(agent === 'codex' && suppressStartupUpdatePrompt
+      ? { transientAgentArgs: ['-c', 'check_for_update_on_startup=false'] }
+      : {}),
     agentEnv,
     sessionOptions: resolveInitialNativeChatSessionOptions(store.settings, initialViewModeOptions)
   }

--- a/src/renderer/src/lib/launch-agent-session-continuation.test.ts
+++ b/src/renderer/src/lib/launch-agent-session-continuation.test.ts
@@ -72,7 +72,8 @@ describe('launchAgentSessionContinuation', () => {
         worktreeId: 'wt-1',
         groupId: 'group-1',
         initialCwd: '/repo/worktree/packages/app',
-        promptDelivery: 'submit-after-ready'
+        promptDelivery: 'submit-after-ready',
+        suppressStartupUpdatePrompt: true
       })
     )
   })

--- a/src/renderer/src/lib/launch-agent-session-continuation.ts
+++ b/src/renderer/src/lib/launch-agent-session-continuation.ts
@@ -111,6 +111,7 @@ export async function launchAgentSessionContinuation({
     ...(groupId ? { groupId } : {}),
     prompt,
     promptDelivery: 'submit-after-ready',
+    suppressStartupUpdatePrompt: true,
     launchSource,
     ...(initialCwd ? { initialCwd } : {}),
     onPromptDelivered: () =>

--- a/src/shared/tui-agent-launch-command.ts
+++ b/src/shared/tui-agent-launch-command.ts
@@ -27,6 +27,8 @@ export function resolveAgentLaunchCommand(args: {
   platform: NodeJS.Platform
   shell: AgentStartupShell
   agentArgs?: string | null
+  /** Launch-only arguments omitted from persisted resume configuration. */
+  transientAgentArgs?: readonly string[]
   sessionOptions?: Record<string, SessionOptionValue>
   sessionOptionsOverrideAgentArgs?: boolean
   isRemote?: boolean
@@ -37,9 +39,9 @@ export function resolveAgentLaunchCommand(args: {
     getTuiAgentLaunchCommand(TUI_AGENT_CONFIG[args.agent], args.platform, {
       isRemote: args.isRemote
     })
-  const suffix = planAgentCliArgsSuffix(args.agentArgs, args.shell)
-  if (!suffix.ok) {
-    return suffix
+  const persistedSuffix = planAgentCliArgsSuffix(args.agentArgs, args.shell)
+  if (!persistedSuffix.ok) {
+    return persistedSuffix
   }
   const trailingTokens = args.agentArgs?.trim()
     ? tokenizeStartupCommand(args.agentArgs.trim(), args.shell)
@@ -47,6 +49,8 @@ export function resolveAgentLaunchCommand(args: {
   if (!trailingTokens.ok) {
     return { ok: false, error: `CLI arguments are invalid: ${trailingTokens.error}` }
   }
+  const launchTokens = insertBeforeTerminator(trailingTokens.tokens, args.transientAgentArgs ?? [])
+  const launchSuffix = launchTokens.map((token) => quoteStartupArg(token, args.shell)).join(' ')
   const resolvedOptions = resolveAgentSessionOptionLaunch(
     args.agent,
     args.sessionOptions,
@@ -77,12 +81,17 @@ export function resolveAgentLaunchCommand(args: {
     }
   }
   const optionSuffix = resolvedOptions.args.map((arg) => quoteStartupArg(arg, args.shell)).join(' ')
-  const commandWithoutSessionOptions = suffix.suffix ? `${command} ${suffix.suffix}` : command
+  const commandWithoutSessionOptions = persistedSuffix.suffix
+    ? `${command} ${persistedSuffix.suffix}`
+    : command
   const commandWithOptions = optionSuffix ? `${command} ${optionSuffix}` : command
   const overrideTokens = args.sessionOptionsOverrideAgentArgs
     ? insertBeforeTerminator(
-        removeOverriddenAgentSessionArgs(args.agent, args.sessionOptions, trailingTokens.tokens),
-        resolvedOptions.args
+        insertBeforeTerminator(
+          removeOverriddenAgentSessionArgs(args.agent, args.sessionOptions, trailingTokens.tokens),
+          resolvedOptions.args
+        ),
+        args.transientAgentArgs ?? []
       )
     : []
   const commandWithOverrides = overrideTokens.length
@@ -92,8 +101,8 @@ export function resolveAgentLaunchCommand(args: {
     ok: true,
     command: args.sessionOptionsOverrideAgentArgs
       ? commandWithOverrides
-      : suffix.suffix
-        ? `${commandWithOptions} ${suffix.suffix}`
+      : launchSuffix
+        ? `${commandWithOptions} ${launchSuffix}`
         : commandWithOptions,
     commandWithoutSessionOptions,
     appliedSessionOptions: resolvedOptions.appliedValues

--- a/src/shared/tui-agent-startup-session-options.test.ts
+++ b/src/shared/tui-agent-startup-session-options.test.ts
@@ -115,6 +115,25 @@ describe('tui agent startup session options', () => {
     )
   })
 
+  it('places transient arguments before the terminator without persisting them', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: '',
+      cmdOverrides: {},
+      platform: 'linux',
+      allowEmptyPromptLaunch: true,
+      agentArgs: '--dangerously-bypass-approvals-and-sandbox -- literal',
+      transientAgentArgs: ['-c', 'check_for_update_on_startup=false']
+    })
+
+    expect(plan?.launchCommand).toBe(
+      "codex '--dangerously-bypass-approvals-and-sandbox' '-c' 'check_for_update_on_startup=false' '--' 'literal'"
+    )
+    expect(plan?.launchConfig.agentCommand).toBe(
+      "codex '--dangerously-bypass-approvals-and-sandbox' '--' 'literal'"
+    )
+  })
+
   it('quotes option values for a remote POSIX launch', () => {
     const plan = buildAgentStartupPlan({
       agent: 'claude',

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -45,6 +45,8 @@ export function buildAgentStartupPlan(args: {
   shell?: AgentStartupShell
   allowEmptyPromptLaunch?: boolean
   agentArgs?: string | null
+  /** Launch-only arguments omitted from persisted resume configuration. */
+  transientAgentArgs?: readonly string[]
   agentEnv?: Record<string, string> | null
   sessionOptions?: Record<string, SessionOptionValue>
   sessionOptionsOverrideAgentArgs?: boolean
@@ -63,6 +65,7 @@ export function buildAgentStartupPlan(args: {
     platform,
     shell,
     agentArgs: usesQuery ? null : args.agentArgs,
+    transientAgentArgs: args.transientAgentArgs,
     sessionOptions: args.sessionOptions,
     sessionOptionsOverrideAgentArgs: args.sessionOptionsOverrideAgentArgs,
     isRemote: args.isRemote


### PR DESCRIPTION
## Summary

- suppress Codex's interactive startup update check only for context-bearing session continuations
- keep the launch-only config override out of persisted agent resume configuration
- preserve user arguments, session options, shell quoting, and `--` terminator ordering across local and remote hosts

## Why

Choosing Codex's **Update now** action exits the original process with a restart instruction. That consumes Orca's one-shot continuation launch before the Codex composer exists, so the generated handoff prompt is never delivered. Ordinary Codex launches remain eligible for update checks.

## Testing

- `vitest run --config config/vitest.config.ts src/renderer/src/lib/launch-agent-session-continuation.test.ts src/renderer/src/lib/launch-agent-in-new-tab.test.ts src/shared/tui-agent-startup-session-options.test.ts src/shared/tui-agent-startup.test.ts` (93 passed)
- full project typecheck
- changed-file oxlint + react-doctor pre-commit checks
- `codex -c check_for_update_on_startup=false --version`

Fixes #18153
