### PR TITLE
perf(terminal): one registry sweep per watcher pass, not one per workspace

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -116,7 +116,7 @@ const WorktreeList = React.memo(function WorktreeList({
     sortedIds,
     repoMap,
     worktreeLineageById,
-    settings,
+    defaultHostId,
     agentSendTargetWorktreeId
   })
   const effectiveCollapsedGroups = useEffectiveCollapsedGroups({

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.test.tsx
@@ -1,11 +1,27 @@
 // @vitest-environment happy-dom
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, renderHook } from '@testing-library/react'
 import { useAppStore } from '@/store'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../../../shared/execution-host'
 import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import { makeRepo, makeWorktree } from '../../../worktree-jump-palette-test-fixtures'
 import { useVisibleSidebarWorktrees } from './use-visible-worktrees'
+import type * as visibleWorktreesModule from '../../visible-worktrees'
+
+const computeVisibleWorktreesCalls = { count: 0 }
+vi.mock('../../visible-worktrees', async (importOriginal) => {
+  const actual = await importOriginal<typeof visibleWorktreesModule>()
+  return {
+    ...actual,
+    computeVisibleWorktrees: (
+      ...args: Parameters<typeof actual.computeVisibleWorktrees>
+    ): ReturnType<typeof actual.computeVisibleWorktrees> => {
+      computeVisibleWorktreesCalls.count += 1
+      return actual.computeVisibleWorktrees(...args)
+    }
+  }
+})
 
 const initialState = useAppStore.getInitialState()
 
@@ -43,7 +59,7 @@ describe('useVisibleSidebarWorktrees', () => {
         sortedIds: [local.id, ssh.id],
         repoMap: new Map([[repo.id, repo]]),
         worktreeLineageById: {},
-        settings: useAppStore.getState().settings,
+        defaultHostId: LOCAL_EXECUTION_HOST_ID,
         agentSendTargetWorktreeId: null
       })
     )
@@ -78,7 +94,7 @@ describe('useVisibleSidebarWorktrees', () => {
         sortedIds: [local.id, ssh.id],
         repoMap: new Map([[repo.id, repo]]),
         worktreeLineageById: {},
-        settings: useAppStore.getState().settings,
+        defaultHostId: LOCAL_EXECUTION_HOST_ID,
         agentSendTargetWorktreeId: null
       })
     )
@@ -86,5 +102,61 @@ describe('useVisibleSidebarWorktrees', () => {
     expect(result.current.visibleWorktrees.map(getWorktreeHostIdentity)).toEqual([
       getWorktreeHostIdentity(ssh)
     ])
+  })
+  it('does not rescan every worktree when a settings write leaves the focused host unchanged', () => {
+    const repo = makeRepo()
+    const worktree = makeWorktree('alpha', 'Alpha workspace', { hostId: 'local' })
+    useAppStore.setState({ worktreesByRepo: { [repo.id]: [worktree] } })
+
+    const baseArgs = {
+      filterState: {
+        showSleepingWorkspaces: true,
+        filterRepoIds: [],
+        hideDefaultBranchWorkspace: false,
+        hideAutomationGeneratedWorkspaces: false,
+        hideCliCreatedWorkspaces: false,
+        hideDetachedHeadWorkspaces: false,
+        hideWorkspacesFromOtherDevices: false,
+        alwaysShowDefaultBranchWorkspace: true,
+        visibleWorkspaceHostIds: null,
+        workspaceHostScope: 'all'
+      },
+      sortBy: 'recent',
+      sortedIds: [worktree.id],
+      repoMap: new Map([[repo.id, repo]]),
+      worktreeLineageById: {},
+      defaultHostId: LOCAL_EXECUTION_HOST_ID,
+      agentSendTargetWorktreeId: null
+    } as Parameters<typeof useVisibleSidebarWorktrees>[0]
+    // Why the extra `settings`: it is the pre-fix memo key. Passing it keeps
+    // this test red against the old hook, which re-keyed the whole scan on the
+    // settings object identity.
+    const withSettings = (
+      settings: ReturnType<typeof useAppStore.getState>['settings']
+    ): Parameters<typeof useVisibleSidebarWorktrees>[0] => Object.assign({}, baseArgs, { settings })
+
+    computeVisibleWorktreesCalls.count = 0
+    const { result, rerender } = renderHook(
+      (args: Parameters<typeof useVisibleSidebarWorktrees>[0]) => useVisibleSidebarWorktrees(args),
+      { initialProps: withSettings(useAppStore.getState().settings) }
+    )
+    const initialVisible = result.current.visibleWorktrees
+    const callsAfterFirstRender = computeVisibleWorktreesCalls.count
+    expect(callsAfterFirstRender).toBe(1)
+
+    // A settings write that does not move the focused execution host.
+    const nextSettings = {
+      ...useAppStore.getState().settings,
+      sidebarWidth: 321
+    } as ReturnType<typeof useAppStore.getState>['settings']
+    useAppStore.setState({ settings: nextSettings })
+    rerender(withSettings(nextSettings))
+
+    expect(computeVisibleWorktreesCalls.count).toBe(callsAfterFirstRender)
+    expect(result.current.visibleWorktrees).toBe(initialVisible)
+
+    // A write that does move it still recomputes.
+    rerender(Object.assign({}, withSettings(nextSettings), { defaultHostId: 'runtime:other' }))
+    expect(computeVisibleWorktreesCalls.count).toBe(callsAfterFirstRender + 1)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
@@ -2,10 +2,9 @@ import { useMemo } from 'react'
 import { useAppStore } from '@/store'
 import { getAgentStatusEpochNow } from '@/lib/agent-status-epoch-clock'
 import { getWorktreeIdsWithLiveAgent } from '@/lib/worktree-activity-state'
-import type { AppState } from '@/store/types'
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-types'
-import { getSettingsFocusedExecutionHostId } from '../../../../../../shared/execution-host'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { computeVisibleWorktrees } from '../../visible-worktrees'
 import {
   EMPTY_PAIRED_DEVICE_IDS_BY_ENVIRONMENT,
@@ -29,10 +28,12 @@ export function useVisibleSidebarWorktrees(args: {
   sortedIds: string[]
   repoMap: Map<string, Repo>
   worktreeLineageById: Record<string, WorktreeLineage>
-  settings: AppState['settings']
+  /** Pre-derived focused host; the whole `settings` object would re-key this
+   *  423-workspace scan on every unrelated settings write. */
+  defaultHostId: ExecutionHostId
   agentSendTargetWorktreeId: string | null
 }) {
-  const { filterState, sortBy, sortedIds, repoMap, worktreeLineageById, settings } = args
+  const { filterState, sortBy, sortedIds, repoMap, worktreeLineageById, defaultHostId } = args
   const {
     showSleepingWorkspaces,
     filterRepoIds,
@@ -98,7 +99,7 @@ export function useVisibleSidebarWorktrees(args: {
       repoMap,
       workspaceHostScope,
       visibleWorkspaceHostIds,
-      defaultHostId: getSettingsFocusedExecutionHostId(settings),
+      defaultHostId,
       worktreeLineageById,
       forcedVisibleWorktreeIds: args.agentSendTargetWorktreeId
         ? [args.agentSendTargetWorktreeId]
@@ -118,7 +119,7 @@ export function useVisibleSidebarWorktrees(args: {
     alwaysShowDefaultBranchWorkspace,
     workspaceHostScope,
     visibleWorkspaceHostIds,
-    settings,
+    defaultHostId,
     repoMap,
     tabsByWorktree,
     ptyIdsByTabId,

--- a/src/renderer/src/components/terminal-cold-activation.ts
+++ b/src/renderer/src/components/terminal-cold-activation.ts
@@ -36,7 +36,8 @@ export function applyTerminalColdActivation(controller: TerminalParkingFoundatio
     terminalParkingEnabled,
     terminalTitleSnapshotAuthorityEnabled,
     workspaceSessionReady,
-    workspaceSurfaces
+    workspaceSurfaceIds,
+    workspaceSurfaceIdSet
   } = controller
   if (
     renderedActiveWorktreeId &&
@@ -150,16 +151,15 @@ export function applyTerminalColdActivation(controller: TerminalParkingFoundatio
     tabsByWorktree,
     activationDeferredMountTabIdsByWorktreeRef.current
   )
-  const allWorktreeIds = new Set(workspaceSurfaces.map((workspace) => workspace.id))
   for (const id of mountedWorktreeIdsRef.current) {
-    if (!allWorktreeIds.has(id)) {
+    if (!workspaceSurfaceIdSet.has(id)) {
       mountedWorktreeIdsRef.current.delete(id)
       backgroundMountTabIdsByWorktreeRef.current.delete(id)
       activationDeferredMountTabIdsByWorktreeRef.current.delete(id)
     }
   }
   const anyMountedWorktreeHasLayout = computeAnyMountedWorktreeHasLayout(
-    workspaceSurfaces.map((workspace) => workspace.id),
+    workspaceSurfaceIds,
     mountedWorktreeIdsRef.current,
     layoutByWorktree,
     groupsByWorktree,

--- a/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers-batch-sync.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers-batch-sync.test.ts
@@ -1,0 +1,540 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ParkedTerminalByteWatcherOptions } from './parked-terminal-byte-watcher'
+
+type StartEvent = {
+  kind: 'start'
+  worktreeId: string
+  tabId: string
+  ptyId: string
+  paneId: number
+  leafId: string
+  drivesTabTitle: boolean
+  restoreTitleOnRegister: boolean
+}
+type DisposeEvent = { kind: 'dispose'; worktreeId: string; tabId: string; ptyId: string }
+type ClearTitleEvent = { kind: 'clearTitle'; tabId: string; paneId: number }
+type DiscardEvent = { kind: 'discard'; ptyId: string }
+type WatcherEvent = StartEvent | DisposeEvent | ClearTitleEvent | DiscardEvent
+
+let events: WatcherEvent[] = []
+
+const startParkedTerminalByteWatcher = vi.fn((options: ParkedTerminalByteWatcherOptions) => {
+  events.push({
+    kind: 'start',
+    worktreeId: options.worktreeId,
+    tabId: options.tabId,
+    ptyId: options.ptyId,
+    paneId: options.paneId,
+    leafId: options.leafId,
+    drivesTabTitle: options.drivesTabTitle === true,
+    restoreTitleOnRegister: options.restoreTitleOnRegister === true
+  })
+  return () => {
+    events.push({
+      kind: 'dispose',
+      worktreeId: options.worktreeId,
+      tabId: options.tabId,
+      ptyId: options.ptyId
+    })
+  }
+})
+
+vi.mock('./parked-terminal-byte-watcher', () => ({
+  startParkedTerminalByteWatcher: (options: ParkedTerminalByteWatcherOptions) =>
+    startParkedTerminalByteWatcher(options)
+}))
+
+vi.mock('./pty-dispatcher', () => ({
+  subscribeToPtyExit: () => () => {}
+}))
+
+vi.mock('./pty-pre-handler-buffer', () => ({
+  discardPreHandlerPtyState: (ptyId: string) => {
+    events.push({ kind: 'discard', ptyId })
+  },
+  hasPreHandlerPtyExit: () => false
+}))
+
+vi.mock('../terminal/terminal-tab-actions', () => ({
+  closeTerminalTab: () => {}
+}))
+
+type TabModel = { id: string; ptyId: string | null }
+type MockStoreState = {
+  tabsByWorktree: Record<string, TabModel[]>
+  terminalLayoutsByTabId: Record<
+    string,
+    {
+      root: unknown
+      activeLeafId: string | null
+      expandedLeafId: string | null
+      ptyIdsByLeafId?: Record<string, string>
+    }
+  >
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+  settings: { terminalSshViewParking?: boolean } | null
+  runtimeStatusByEnvironmentId: Map<string, { status: null; checkedAt: number }>
+  clearRuntimePaneTitle: (tabId: string, paneId: number) => void
+  setRuntimePaneTitle: () => void
+  clearTabLaunchAgent: () => void
+  setTabLayout: () => void
+  updateTabTitle: () => void
+  markUnverifiedPtyLoss: () => void
+  isPtyShutdownPending: () => boolean
+  suppressedPtyExitIds: Record<string, true>
+}
+
+let mockStoreState: MockStoreState
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => mockStoreState }
+}))
+
+import {
+  clearTerminalProviderSnapshotCapabilities,
+  synchronizeTerminalProviderSnapshotCapabilities
+} from '../terminal/terminal-provider-snapshot-capability'
+import {
+  captureParkedTerminalPaneCandidates,
+  pruneParkedTerminalWatchers,
+  syncParkedTerminalTabWatchers,
+  syncParkedTerminalTabWatchersForWorkspaces,
+  type ParkedTerminalTabWatcherSyncEntry
+} from './terminal-parked-tab-watchers'
+import { capturedPanesByTabId, parkedWatchersByTabId } from './terminal-parked-watcher-registry'
+
+const leafId = (index: number): string =>
+  `${index.toString(16).padStart(8, '0')}-1111-4111-8111-111111111111`
+
+function makeStore(): MockStoreState {
+  return {
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    runtimePaneTitlesByTabId: {},
+    settings: null,
+    runtimeStatusByEnvironmentId: new Map(),
+    clearRuntimePaneTitle: (tabId: string, paneId: number) => {
+      events.push({ kind: 'clearTitle', tabId, paneId })
+    },
+    setRuntimePaneTitle: () => {},
+    clearTabLaunchAgent: () => {},
+    setTabLayout: () => {},
+    updateTabTitle: () => {},
+    markUnverifiedPtyLoss: () => {},
+    isPtyShutdownPending: () => false,
+    suppressedPtyExitIds: {}
+  }
+}
+
+/** Counts entries visited by `for...of` over the module-level registries. */
+function instrumentRegistryIteration(): { count: number; restore: () => void } {
+  const counter = { count: 0, restore: () => {} }
+  const patched: Map<unknown, unknown>[] = [
+    parkedWatchersByTabId as Map<unknown, unknown>,
+    capturedPanesByTabId as Map<unknown, unknown>
+  ]
+  for (const map of patched) {
+    Object.defineProperty(map, Symbol.iterator, {
+      configurable: true,
+      writable: true,
+      value: function* (this: Map<unknown, unknown>) {
+        for (const entry of Map.prototype.entries.call(this)) {
+          counter.count += 1
+          yield entry
+        }
+      }
+    })
+  }
+  counter.restore = () => {
+    for (const map of patched) {
+      Reflect.deleteProperty(map, Symbol.iterator)
+    }
+  }
+  return counter
+}
+
+describe('parked terminal watcher batch synchronization', () => {
+  beforeEach(() => {
+    events = []
+    mockStoreState = makeStore()
+    clearTerminalProviderSnapshotCapabilities()
+  })
+
+  afterEach(() => {
+    pruneParkedTerminalWatchers(new Set())
+    capturedPanesByTabId.clear()
+    events = []
+    vi.clearAllMocks()
+    clearTerminalProviderSnapshotCapabilities()
+  })
+
+  describe('registry scan cost at the real-profile scale', () => {
+    // The user's profile: 423 workspace surfaces, 382 terminal tabs.
+    const WORKSPACE_COUNT = 423
+    const TAB_COUNT = 382
+
+    function seedRegistries(): {
+      workspaceIds: string[]
+      tabsByWorktreeId: Map<string, TabModel[]>
+    } {
+      const workspaceIds = Array.from(
+        { length: WORKSPACE_COUNT },
+        (_, index) => `repo::/worktree-${index}`
+      )
+      const tabsByWorktreeId = new Map<string, TabModel[]>(
+        workspaceIds.map((workspaceId) => [workspaceId, [] as TabModel[]])
+      )
+      for (let index = 0; index < TAB_COUNT; index += 1) {
+        const worktreeId = workspaceIds[index % WORKSPACE_COUNT]
+        const tabId = `tab-${index}`
+        const ptyId = `${worktreeId}@@session-${index}`
+        tabsByWorktreeId.get(worktreeId)!.push({ id: tabId, ptyId })
+        // A live, already-parked tab: present in both registries, nothing to
+        // dispose and nothing to start, so the pass is a pure registry scan.
+        parkedWatchersByTabId.set(tabId, {
+          worktreeId,
+          tabPtyId: ptyId,
+          paneIdByPtyId: new Map([[ptyId, 1]]),
+          disposersByPtyId: new Map()
+        })
+        captureParkedTerminalPaneCandidates(tabId, worktreeId, [
+          { ptyId, paneId: 1, leafId: leafId(index), drivesTabTitle: true }
+        ])
+      }
+      return { workspaceIds, tabsByWorktreeId }
+    }
+
+    it('collapses surfaces x registry scans into one scan of each registry', () => {
+      const { workspaceIds, tabsByWorktreeId } = seedRegistries()
+      const registryRows = parkedWatchersByTabId.size + capturedPanesByTabId.size
+      expect(registryRows).toBe(TAB_COUNT * 2)
+
+      const perSurface = instrumentRegistryIteration()
+      for (const workspaceId of workspaceIds) {
+        syncParkedTerminalTabWatchers({
+          worktreeId: workspaceId,
+          tabs: tabsByWorktreeId.get(workspaceId)!,
+          parkedTabIds: new Set()
+        })
+      }
+      const perSurfaceVisits = perSurface.count
+      perSurface.restore()
+
+      const batched = instrumentRegistryIteration()
+      const entries = new Map<string, ParkedTerminalTabWatcherSyncEntry>(
+        workspaceIds.map((workspaceId) => [
+          workspaceId,
+          { tabs: tabsByWorktreeId.get(workspaceId)!, parkedTabIds: new Set<string>() }
+        ])
+      )
+      syncParkedTerminalTabWatchersForWorkspaces(entries)
+      const batchedVisits = batched.count
+      batched.restore()
+
+      // Old shape: every surface re-walks both registries in full.
+      expect(perSurfaceVisits).toBe(WORKSPACE_COUNT * registryRows)
+      // New shape: each registry is walked exactly once for the whole pass.
+      expect(batchedVisits).toBe(registryRows)
+      expect(perSurfaceVisits / batchedVisits).toBeGreaterThan(400)
+    })
+  })
+
+  describe('start/dispose decisions match the per-surface path', () => {
+    type Scenario = {
+      name: string
+      workspaces: {
+        worktreeId: string
+        tabs: TabModel[]
+        parkedTabIds: string[]
+        restoreTitleOnStartTabIds?: string[]
+      }[]
+      /** Watcher rows already in the registry when the pass runs. */
+      preParkedTabs: { worktreeId: string; tabId: string; ptyId: string; withDisposer: boolean }[]
+      /** Captures for tabs that may or may not still be live. */
+      preCapturedTabs: { worktreeId: string; tabId: string; ptyId: string | null }[]
+    }
+
+    const WORKTREE_A = 'repo::/alpha'
+    const WORKTREE_B = 'repo::/beta'
+    const WORKTREE_C = 'repo::/gamma'
+
+    const pty = (worktreeId: string, index: number): string => `${worktreeId}@@session-${index}`
+
+    const scenarios: Scenario[] = [
+      {
+        name: 'cold start: nothing parked yet, two workspaces park every tab',
+        workspaces: [
+          {
+            worktreeId: WORKTREE_A,
+            tabs: [
+              { id: 'a1', ptyId: pty(WORKTREE_A, 1) },
+              { id: 'a2', ptyId: pty(WORKTREE_A, 2) }
+            ],
+            parkedTabIds: ['a1', 'a2']
+          },
+          {
+            worktreeId: WORKTREE_B,
+            tabs: [{ id: 'b1', ptyId: pty(WORKTREE_B, 1) }],
+            parkedTabIds: ['b1']
+          },
+          { worktreeId: WORKTREE_C, tabs: [], parkedTabIds: [] }
+        ],
+        preParkedTabs: [],
+        preCapturedTabs: []
+      },
+      {
+        name: 'reveal: a parked workspace drops out of the parked set',
+        workspaces: [
+          {
+            worktreeId: WORKTREE_A,
+            tabs: [
+              { id: 'a1', ptyId: pty(WORKTREE_A, 1) },
+              { id: 'a2', ptyId: pty(WORKTREE_A, 2) }
+            ],
+            parkedTabIds: []
+          },
+          {
+            worktreeId: WORKTREE_B,
+            tabs: [{ id: 'b1', ptyId: pty(WORKTREE_B, 1) }],
+            parkedTabIds: ['b1']
+          }
+        ],
+        preParkedTabs: [
+          { worktreeId: WORKTREE_A, tabId: 'a1', ptyId: pty(WORKTREE_A, 1), withDisposer: true },
+          { worktreeId: WORKTREE_A, tabId: 'a2', ptyId: pty(WORKTREE_A, 2), withDisposer: true }
+        ],
+        preCapturedTabs: [
+          { worktreeId: WORKTREE_A, tabId: 'a1', ptyId: pty(WORKTREE_A, 1) },
+          { worktreeId: WORKTREE_A, tabId: 'a2', ptyId: pty(WORKTREE_A, 2) }
+        ]
+      },
+      {
+        name: 'closed tabs: registry rows and captures outlive their tabs',
+        workspaces: [
+          {
+            worktreeId: WORKTREE_A,
+            tabs: [{ id: 'a1', ptyId: pty(WORKTREE_A, 1) }],
+            parkedTabIds: ['a1']
+          },
+          { worktreeId: WORKTREE_B, tabs: [], parkedTabIds: [] }
+        ],
+        preParkedTabs: [
+          {
+            worktreeId: WORKTREE_A,
+            tabId: 'a-closed',
+            ptyId: pty(WORKTREE_A, 9),
+            withDisposer: true
+          },
+          {
+            worktreeId: WORKTREE_B,
+            tabId: 'b-closed',
+            ptyId: pty(WORKTREE_B, 9),
+            withDisposer: true
+          }
+        ],
+        preCapturedTabs: [
+          { worktreeId: WORKTREE_A, tabId: 'a-closed', ptyId: pty(WORKTREE_A, 9) },
+          { worktreeId: WORKTREE_B, tabId: 'b-closed', ptyId: pty(WORKTREE_B, 9) },
+          { worktreeId: WORKTREE_A, tabId: 'a1', ptyId: pty(WORKTREE_A, 1) }
+        ]
+      },
+      {
+        name: 're-minted pty: a parked tab wakes with a fresh pty id',
+        workspaces: [
+          {
+            worktreeId: WORKTREE_A,
+            tabs: [{ id: 'a1', ptyId: pty(WORKTREE_A, 2) }],
+            parkedTabIds: ['a1'],
+            restoreTitleOnStartTabIds: ['a1']
+          },
+          {
+            worktreeId: WORKTREE_B,
+            tabs: [{ id: 'b1', ptyId: pty(WORKTREE_B, 1) }],
+            parkedTabIds: ['b1']
+          }
+        ],
+        preParkedTabs: [
+          { worktreeId: WORKTREE_A, tabId: 'a1', ptyId: pty(WORKTREE_A, 1), withDisposer: true }
+        ],
+        preCapturedTabs: [{ worktreeId: WORKTREE_A, tabId: 'a1', ptyId: pty(WORKTREE_A, 2) }]
+      },
+      {
+        name: 'unknown worktree rows: registry holds a workspace absent from this pass',
+        workspaces: [
+          {
+            worktreeId: WORKTREE_A,
+            tabs: [{ id: 'a1', ptyId: pty(WORKTREE_A, 1) }],
+            parkedTabIds: ['a1']
+          }
+        ],
+        preParkedTabs: [
+          { worktreeId: WORKTREE_C, tabId: 'c1', ptyId: pty(WORKTREE_C, 1), withDisposer: true }
+        ],
+        preCapturedTabs: [{ worktreeId: WORKTREE_C, tabId: 'c1', ptyId: pty(WORKTREE_C, 1) }]
+      },
+      {
+        name: 'tombstone rows: a pinned-close entry with no live disposers',
+        workspaces: [
+          {
+            worktreeId: WORKTREE_A,
+            tabs: [{ id: 'a1', ptyId: pty(WORKTREE_A, 1) }],
+            parkedTabIds: []
+          },
+          {
+            worktreeId: WORKTREE_B,
+            tabs: [{ id: 'b1', ptyId: pty(WORKTREE_B, 1) }],
+            parkedTabIds: ['b1']
+          }
+        ],
+        preParkedTabs: [
+          { worktreeId: WORKTREE_A, tabId: 'a1', ptyId: pty(WORKTREE_A, 1), withDisposer: false }
+        ],
+        preCapturedTabs: [{ worktreeId: WORKTREE_B, tabId: 'b1', ptyId: pty(WORKTREE_B, 1) }]
+      }
+    ]
+
+    type Outcome = {
+      eventsByWorktree: Record<string, WatcherEvent[]>
+      registry: readonly (readonly [
+        string,
+        { worktreeId: string; tabPtyId: string | null; ptyIds: string[] }
+      ])[]
+      captures: string[]
+    }
+
+    async function seedAndRun(
+      scenario: Scenario,
+      run: (scenario: Scenario) => void
+    ): Promise<Outcome> {
+      pruneParkedTerminalWatchers(new Set())
+      capturedPanesByTabId.clear()
+      clearTerminalProviderSnapshotCapabilities()
+      mockStoreState = makeStore()
+      const allPtyIds = new Set<string>()
+      for (const workspace of scenario.workspaces) {
+        for (const tab of workspace.tabs) {
+          if (tab.ptyId) {
+            allPtyIds.add(tab.ptyId)
+          }
+        }
+      }
+      for (const row of [...scenario.preParkedTabs, ...scenario.preCapturedTabs]) {
+        if (row.ptyId) {
+          allPtyIds.add(row.ptyId)
+        }
+      }
+      await synchronizeTerminalProviderSnapshotCapabilities(Array.from(allPtyIds), async (ids) =>
+        ids.map((id) => ({ id, authoritative: true }))
+      )
+      let paneOrdinal = 0
+      for (const row of scenario.preParkedTabs) {
+        paneOrdinal += 1
+        parkedWatchersByTabId.set(row.tabId, {
+          worktreeId: row.worktreeId,
+          tabPtyId: row.ptyId,
+          paneIdByPtyId: new Map([[row.ptyId, paneOrdinal]]),
+          disposersByPtyId: row.withDisposer
+            ? new Map([
+                [
+                  row.ptyId,
+                  () => {
+                    events.push({
+                      kind: 'dispose',
+                      worktreeId: row.worktreeId,
+                      tabId: row.tabId,
+                      ptyId: row.ptyId
+                    })
+                  }
+                ]
+              ])
+            : new Map()
+        })
+      }
+      for (const [index, row] of scenario.preCapturedTabs.entries()) {
+        captureParkedTerminalPaneCandidates(row.tabId, row.worktreeId, [
+          { ptyId: row.ptyId, paneId: 100 + index, leafId: leafId(index + 1), drivesTabTitle: true }
+        ])
+      }
+      events = []
+      run(scenario)
+
+      const eventsByWorktree: Record<string, WatcherEvent[]> = {}
+      for (const event of events) {
+        const key = 'worktreeId' in event ? event.worktreeId : 'shared'
+        ;(eventsByWorktree[key] ??= []).push(event)
+      }
+      // Why per-worktree, not one global sequence: batching deliberately hoists
+      // every workspace's dispose sweep ahead of every workspace's start pass.
+      // Registry rows are tab-id keyed and a tab belongs to exactly one
+      // worktree, so that reorder crosses only disjoint tab sets. `shared`
+      // events (pane-title clears, pre-handler discards) are compared as a
+      // multiset for the same reason.
+      for (const key of Object.keys(eventsByWorktree)) {
+        if (key === 'shared') {
+          eventsByWorktree[key] = [...eventsByWorktree[key]].sort((left, right) =>
+            JSON.stringify(left).localeCompare(JSON.stringify(right))
+          )
+        }
+      }
+      return {
+        eventsByWorktree,
+        registry: Array.from(
+          parkedWatchersByTabId,
+          ([tabId, entry]) =>
+            [
+              tabId,
+              {
+                worktreeId: entry.worktreeId,
+                tabPtyId: entry.tabPtyId,
+                ptyIds: Array.from(entry.disposersByPtyId.keys()).sort()
+              }
+            ] as const
+        ).sort((left, right) => left[0].localeCompare(right[0])),
+        captures: Array.from(capturedPanesByTabId.keys()).sort()
+      }
+    }
+
+    const runPerSurface = (scenario: Scenario): void => {
+      for (const workspace of scenario.workspaces) {
+        syncParkedTerminalTabWatchers({
+          worktreeId: workspace.worktreeId,
+          tabs: workspace.tabs,
+          parkedTabIds: new Set(workspace.parkedTabIds),
+          ...(workspace.restoreTitleOnStartTabIds
+            ? { restoreTitleOnStartTabIds: new Set(workspace.restoreTitleOnStartTabIds) }
+            : {})
+        })
+      }
+    }
+
+    const runBatched = (scenario: Scenario): void => {
+      syncParkedTerminalTabWatchersForWorkspaces(
+        new Map(
+          scenario.workspaces.map((workspace) => [
+            workspace.worktreeId,
+            {
+              tabs: workspace.tabs,
+              parkedTabIds: new Set(workspace.parkedTabIds),
+              ...(workspace.restoreTitleOnStartTabIds
+                ? { restoreTitleOnStartTabIds: new Set(workspace.restoreTitleOnStartTabIds) }
+                : {})
+            }
+          ])
+        )
+      )
+    }
+
+    for (const scenario of scenarios) {
+      it(`decides identically — ${scenario.name}`, async () => {
+        const perSurface = await seedAndRun(scenario, runPerSurface)
+        const batched = await seedAndRun(scenario, runBatched)
+        expect(batched).toEqual(perSurface)
+        // Guard against a vacuous comparison of two empty outcomes.
+        expect(
+          Object.values(perSurface.eventsByWorktree).some((list) => list.length > 0) ||
+            perSurface.registry.length > 0
+        ).toBe(true)
+      })
+    }
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.ts
@@ -244,6 +244,93 @@ function disposeClosedParkedTabWatchers(
   disposeParkedTabWatchers(tabId)
 }
 
+/** One workspace's rendered parked verdict, as the batch pass consumes it. */
+export type ParkedTerminalTabWatcherSyncEntry = {
+  tabs: readonly ParkableTerminalTabModel[]
+  parkedTabIds: ReadonlySet<string>
+  /** Parked-equivalent tabs whose pane has not restored the current title. */
+  restoreTitleOnStartTabIds?: ReadonlySet<string>
+}
+
+function startOrReconcileParkedTabWatchers(
+  worktreeId: string,
+  entry: ParkedTerminalTabWatcherSyncEntry
+): void {
+  for (const tab of entry.tabs) {
+    if (!entry.parkedTabIds.has(tab.id)) {
+      continue
+    }
+    const watcherEntry = parkedWatchersByTabId.get(tab.id)
+    const restoreTitleOnRegister = entry.restoreTitleOnStartTabIds?.has(tab.id) === true
+    if (watcherEntry) {
+      reconcileParkedTabWatchers(worktreeId, tab, watcherEntry, restoreTitleOnRegister)
+    } else {
+      startParkedTabWatchers(worktreeId, tab, restoreTitleOnRegister)
+    }
+  }
+}
+
+/**
+ * Reconciles watchers for every rendered workspace in one pass.
+ *
+ * Why batched: the per-worktree entry point scans both registries in full, so
+ * the terminal host calling it once per workspace made a single effect fire
+ * cost surfaces x registry map iterations. Walking each registry once and then
+ * doing the per-tab start/reconcile pass is O(registry + tabs) instead.
+ *
+ * The dispose/start decisions are identical: registry entries are keyed by tab
+ * id and every tab belongs to exactly one worktree, so hoisting the dispose and
+ * capture-cleanup sweeps ahead of every start only reorders work across
+ * disjoint tab sets.
+ */
+export function syncParkedTerminalTabWatchersForWorkspaces(
+  entriesByWorktreeId: ReadonlyMap<string, ParkedTerminalTabWatcherSyncEntry>
+): void {
+  if (entriesByWorktreeId.size === 0) {
+    return
+  }
+  // Why lazy: only worktrees that actually own a registry row need the id set,
+  // so an idle profile allocates none of them.
+  const liveTabIdsByWorktreeId = new Map<string, ReadonlySet<string>>()
+  const liveTabIdsFor = (worktreeId: string): ReadonlySet<string> | null => {
+    const cached = liveTabIdsByWorktreeId.get(worktreeId)
+    if (cached) {
+      return cached
+    }
+    const entry = entriesByWorktreeId.get(worktreeId)
+    if (!entry) {
+      return null
+    }
+    const liveTabIds = new Set(entry.tabs.map((tab) => tab.id))
+    liveTabIdsByWorktreeId.set(worktreeId, liveTabIds)
+    return liveTabIds
+  }
+  for (const [tabId, watcherEntry] of parkedWatchersByTabId) {
+    const entry = entriesByWorktreeId.get(watcherEntry.worktreeId)
+    if (!entry) {
+      continue
+    }
+    const liveTabIds = liveTabIdsFor(watcherEntry.worktreeId)
+    if (!liveTabIds?.has(tabId)) {
+      disposeClosedParkedTabWatchers(tabId, watcherEntry)
+      continue
+    }
+    if (!entry.parkedTabIds.has(tabId) && watcherEntry.disposersByPtyId.size > 0) {
+      disposeParkedTabWatchers(tabId)
+    }
+  }
+  // Why: closed tabs never park/reveal again; drop captures to keep the registry bounded.
+  for (const [tabId, capture] of capturedPanesByTabId) {
+    const liveTabIds = liveTabIdsFor(capture.worktreeId)
+    if (liveTabIds && !liveTabIds.has(tabId)) {
+      capturedPanesByTabId.delete(tabId)
+    }
+  }
+  for (const [worktreeId, entry] of entriesByWorktreeId) {
+    startOrReconcileParkedTabWatchers(worktreeId, entry)
+  }
+}
+
 /**
  * Reconciles watchers for one worktree against its rendered parked set.
  * Run from an effect keyed on committed render state so disposal shares the
@@ -256,35 +343,18 @@ export function syncParkedTerminalTabWatchers(args: {
   /** Parked-equivalent tabs whose pane has not restored the current title. */
   restoreTitleOnStartTabIds?: ReadonlySet<string>
 }): void {
-  const liveTabIds = new Set(args.tabs.map((tab) => tab.id))
-  for (const [tabId, entry] of parkedWatchersByTabId) {
-    if (entry.worktreeId !== args.worktreeId) {
-      continue
-    }
-    if (!liveTabIds.has(tabId)) {
-      disposeClosedParkedTabWatchers(tabId, entry)
-      continue
-    }
-    if (!args.parkedTabIds.has(tabId) && entry.disposersByPtyId.size > 0) {
-      disposeParkedTabWatchers(tabId)
-    }
-  }
-  // Why: closed tabs never park/reveal again; drop captures to keep the registry bounded.
-  for (const [tabId, capture] of capturedPanesByTabId) {
-    if (capture.worktreeId === args.worktreeId && !liveTabIds.has(tabId)) {
-      capturedPanesByTabId.delete(tabId)
-    }
-  }
-  for (const tab of args.tabs) {
-    if (!args.parkedTabIds.has(tab.id)) {
-      continue
-    }
-    const entry = parkedWatchersByTabId.get(tab.id)
-    const restoreTitleOnRegister = args.restoreTitleOnStartTabIds?.has(tab.id) === true
-    if (entry) {
-      reconcileParkedTabWatchers(args.worktreeId, tab, entry, restoreTitleOnRegister)
-    } else {
-      startParkedTabWatchers(args.worktreeId, tab, restoreTitleOnRegister)
-    }
-  }
+  syncParkedTerminalTabWatchersForWorkspaces(
+    new Map([
+      [
+        args.worktreeId,
+        {
+          tabs: args.tabs,
+          parkedTabIds: args.parkedTabIds,
+          ...(args.restoreTitleOnStartTabIds
+            ? { restoreTitleOnStartTabIds: args.restoreTitleOnStartTabIds }
+            : {})
+        }
+      ]
+    ])
+  )
 }

--- a/src/renderer/src/components/terminal-parking-pass-candidates.ts
+++ b/src/renderer/src/components/terminal-parking-pass-candidates.ts
@@ -27,7 +27,8 @@ export function collectTerminalParkingPassCandidates(controller: TerminalParking
     terminalWorktreeHiddenSinceRef,
     terminalWorktreeParkCooldownUntilRef,
     terminalWorktreeParkingTimersRef,
-    workspaceSurfaces
+    workspaceSurfaceIds,
+    workspaceSurfaceIdSet
   } = controller
   const parkingTimers = terminalWorktreeParkingTimersRef.current
   for (const timer of parkingTimers.values()) {
@@ -38,9 +39,8 @@ export function collectTerminalParkingPassCandidates(controller: TerminalParking
   const nowMs = Date.now()
   const overrides = getTerminalParkingPolicyOverrides()
   const portalWorktreeIds = new Set(activityTerminalPortals.map((portal) => portal.worktreeId))
-  const currentWorktreeIds = new Set(workspaceSurfaces.map((workspace) => workspace.id))
   for (const worktreeId of Array.from(terminalWorktreeHiddenSinceRef.current.keys())) {
-    if (!currentWorktreeIds.has(worktreeId) || !mountedWorktreeIdsRef.current.has(worktreeId)) {
+    if (!workspaceSurfaceIdSet.has(worktreeId) || !mountedWorktreeIdsRef.current.has(worktreeId)) {
       terminalWorktreeHiddenSinceRef.current.delete(worktreeId)
       measuringTerminalWorktreeIdsRef.current.delete(worktreeId)
       terminalWorktreeParkCooldownUntilRef.current.delete(worktreeId)
@@ -48,8 +48,7 @@ export function collectTerminalParkingPassCandidates(controller: TerminalParking
   }
 
   const retentionCandidates: TerminalWorktreeColdParkCandidate[] = []
-  for (const workspace of workspaceSurfaces) {
-    const worktreeId = workspace.id
+  for (const worktreeId of workspaceSurfaceIds) {
     if (!mountedWorktreeIdsRef.current.has(worktreeId)) {
       terminalWorktreeHiddenSinceRef.current.delete(worktreeId)
       measuringTerminalWorktreeIdsRef.current.delete(worktreeId)

--- a/src/renderer/src/components/terminal-workspace-surface-ids.test.tsx
+++ b/src/renderer/src/components/terminal-workspace-surface-ids.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { useEffect } from 'react'
+import { useAppStore } from '@/store'
+import { makeRepo, makeWorktree } from './worktree-jump-palette-test-fixtures'
+import { useTerminalWorkspaceFoundation } from './use-terminal-workspace-foundation'
+import { applyTerminalColdActivation } from './terminal-cold-activation'
+import { collectTerminalParkingPassCandidates } from './terminal-parking-pass-candidates'
+import type { WorkspaceSurface } from './workspace-surface-projection'
+import type { TerminalParkingFoundation } from './use-terminal-parking-foundation'
+
+const initialState = useAppStore.getInitialState()
+
+/** An id-only surface array that reports how often a caller re-derived its ids. */
+function countingSurfaces(ids: string[]): { surfaces: WorkspaceSurface[]; mapCalls: () => number } {
+  let mapCalls = 0
+  const surfaces = ids.map((id) => ({ id, path: `/tmp/${id}` }))
+  Object.defineProperty(surfaces, 'map', {
+    configurable: true,
+    value(this: WorkspaceSurface[], ...args: Parameters<WorkspaceSurface[]['map']>) {
+      mapCalls += 1
+      return Array.prototype.map.apply(this, args)
+    }
+  })
+  return { surfaces, mapCalls: () => mapCalls }
+}
+
+describe('workspace surface ids', () => {
+  beforeEach(() => {
+    useAppStore.setState(initialState, true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    useAppStore.setState(initialState, true)
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the id array and id set stable when a worktree write re-identifies the surfaces', () => {
+    const repo = makeRepo()
+    const first = makeWorktree('alpha', 'Alpha')
+    const second = makeWorktree('beta', 'Beta')
+    useAppStore.setState({ worktreesByRepo: { [repo.id]: [first, second] } })
+
+    const { result, rerender } = renderHook(() => useTerminalWorkspaceFoundation())
+    const initialSurfaces = result.current.workspaceSurfaces
+    const initialIds = result.current.workspaceSurfaceIds
+    const initialIdSet = result.current.workspaceSurfaceIdSet
+    expect(initialIds).toEqual([first.id, second.id])
+
+    // A worktree write that changes no id: fresh row objects, fresh array.
+    useAppStore.setState({
+      worktreesByRepo: {
+        [repo.id]: [
+          { ...first, lastActivityAt: Date.now() },
+          { ...second, lastActivityAt: Date.now() }
+        ]
+      }
+    })
+    rerender()
+
+    expect(result.current.workspaceSurfaces).not.toBe(initialSurfaces)
+    expect(result.current.workspaceSurfaceIds).toBe(initialIds)
+    expect(result.current.workspaceSurfaceIdSet).toBe(initialIdSet)
+
+    // A real membership change still re-identifies both.
+    useAppStore.setState({ worktreesByRepo: { [repo.id]: [first] } })
+    rerender()
+    expect(result.current.workspaceSurfaceIds).not.toBe(initialIds)
+    expect(result.current.workspaceSurfaceIdSet).not.toBe(initialIdSet)
+    expect(result.current.workspaceSurfaceIds).toEqual([first.id])
+  })
+
+  it('does not rebuild a surface-id array or set on a cold-activation render', () => {
+    const ids = Array.from({ length: 423 }, (_, index) => `repo::/worktree-${index}`)
+    const { surfaces, mapCalls } = countingSurfaces(ids)
+    const controller = {
+      activationDeferredMountTabIdsByWorktreeRef: { current: new Map() },
+      activeGroupIdByWorktree: {},
+      activeTabId: null,
+      activeTabIdByWorktree: {},
+      activeWorktreeDeferralHostId: null,
+      activityTerminalPortals: [],
+      backgroundMountTabIdsByWorktreeRef: { current: new Map() },
+      groupsByWorktree: {},
+      hydrationSucceeded: false,
+      lastActivationWorktreeIdRef: { current: null },
+      layoutByWorktree: {},
+      mountedWorktreeIdsRef: { current: new Set(['repo::/worktree-0', 'repo::/gone']) },
+      pairedRuntimeParkingEnvironmentIds: new Set(),
+      pendingStartupByTabId: {},
+      renderedActiveWorktreeId: null,
+      startupWorktreeRefreshCompleted: false,
+      tabsByWorktree: {},
+      terminalParkingEnabled: true,
+      terminalTitleSnapshotAuthorityEnabled: true,
+      workspaceSessionReady: false,
+      workspaceSurfaces: surfaces,
+      workspaceSurfaceIds: ids,
+      workspaceSurfaceIdSet: new Set(ids)
+    } as unknown as TerminalParkingFoundation
+
+    applyTerminalColdActivation(controller)
+    applyTerminalColdActivation(controller)
+
+    // Pre-fix this was two 423-element id arrays (plus a 423-entry Set) per render.
+    expect(mapCalls()).toBe(0)
+    expect(controller.mountedWorktreeIdsRef.current.has('repo::/gone')).toBe(false)
+    expect(controller.mountedWorktreeIdsRef.current.has('repo::/worktree-0')).toBe(true)
+  })
+
+  it('does not rebuild a surface-id array or set on a parking pass', () => {
+    const ids = Array.from({ length: 423 }, (_, index) => `repo::/worktree-${index}`)
+    const { surfaces, mapCalls } = countingSurfaces(ids)
+    const hiddenSince = new Map<string, number>([
+      ['repo::/worktree-0', 1],
+      ['repo::/stale', 2]
+    ])
+    const controller = {
+      activeView: 'terminal',
+      activityTerminalPortals: [],
+      measurableBackgroundWorktreeIdsRef: { current: new Set() },
+      measuringTerminalWorktreeIdsRef: { current: new Set() },
+      mountedWorktreeIdsRef: { current: new Set(['repo::/worktree-0']) },
+      pairedRuntimeParkingEnvironmentIds: new Set(),
+      pendingStartupByTabId: {},
+      renderedActiveWorktreeId: 'repo::/worktree-0',
+      tabsByWorktree: {},
+      terminalParkingEnabled: true,
+      terminalSshParkingEnabled: true,
+      terminalWorktreeHiddenSinceRef: { current: hiddenSince },
+      terminalWorktreeParkCooldownUntilRef: { current: new Map() },
+      terminalWorktreeParkingTimersRef: { current: new Map() },
+      workspaceSurfaces: surfaces,
+      workspaceSurfaceIds: ids,
+      workspaceSurfaceIdSet: new Set(ids)
+    } as unknown as TerminalParkingFoundation
+
+    const pass = collectTerminalParkingPassCandidates(controller)
+
+    // Pre-fix this allocated a 423-element id array and a 423-entry Set per fire.
+    expect(mapCalls()).toBe(0)
+    expect(pass.retentionCandidates.map((candidate) => candidate.worktreeId)).toEqual([
+      'repo::/worktree-0'
+    ])
+    expect(hiddenSince.has('repo::/stale')).toBe(false)
+  })
+  it('stops idle worktree writes from re-firing surface-keyed terminal effects', () => {
+    const repo = makeRepo()
+    const worktrees = Array.from({ length: 20 }, (_, index) =>
+      makeWorktree(`wt-${index}`, `Workspace ${index}`)
+    )
+    useAppStore.setState({ worktreesByRepo: { [repo.id]: worktrees } })
+
+    const fires = { surfaceKeyed: 0, idKeyed: 0 }
+    renderHook(() => {
+      const foundation = useTerminalWorkspaceFoundation()
+      useEffect(() => {
+        fires.surfaceKeyed += 1
+      }, [foundation.workspaceSurfaces])
+      useEffect(() => {
+        fires.idKeyed += 1
+      }, [foundation.workspaceSurfaceIds])
+    })
+    expect(fires).toEqual({ surfaceKeyed: 1, idKeyed: 1 })
+
+    // 100 worktree writes that touch no workspace id — the idle shape (activity
+    // timestamps, status refreshes) that dominates a large profile.
+    for (let write = 0; write < 100; write += 1) {
+      act(() => {
+        useAppStore.setState({
+          worktreesByRepo: {
+            [repo.id]: worktrees.map((worktree) => ({ ...worktree, lastActivityAt: write }))
+          }
+        })
+      })
+    }
+
+    expect(fires.surfaceKeyed).toBe(101)
+    expect(fires.idKeyed).toBe(1)
+  })
+})

--- a/src/renderer/src/components/use-terminal-browser-retention.ts
+++ b/src/renderer/src/components/use-terminal-browser-retention.ts
@@ -20,7 +20,8 @@ export function useTerminalBrowserRetention(controller: TerminalParkingFoundatio
     mountedWorktreeIdsRef,
     renderedActiveWorktreeId,
     setBrowserGuestRetentionRevision,
-    workspaceSurfaces
+    workspaceSurfaceIds,
+    workspaceSurfaceIdSet
   } = controller
 
   useEffect(() => {
@@ -42,9 +43,8 @@ export function useTerminalBrowserRetention(controller: TerminalParkingFoundatio
     }
     const recency = browserGuestWorktreeRecencyRef.current
     touchBrowserGuestWorktreeRecency(recency, renderedActiveWorktreeId)
-    const surfaceIds = new Set(workspaceSurfaces.map((workspace) => workspace.id))
     for (let index = recency.length - 1; index >= 0; index--) {
-      if (!surfaceIds.has(recency[index])) {
+      if (!workspaceSurfaceIdSet.has(recency[index])) {
         recency.splice(index, 1)
       }
     }
@@ -55,7 +55,7 @@ export function useTerminalBrowserRetention(controller: TerminalParkingFoundatio
     const recencyIds = new Set(recency)
     const orderedWorktreeIds = [
       ...recency,
-      ...workspaceSurfaces.map((workspace) => workspace.id).filter((id) => !recencyIds.has(id))
+      ...workspaceSurfaceIds.filter((id) => !recencyIds.has(id))
     ]
     const evictedWorktreeIds = selectBrowserGuestEvictionWorktreeIds({
       orderedWorktreeIds,
@@ -82,7 +82,7 @@ export function useTerminalBrowserRetention(controller: TerminalParkingFoundatio
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- controller refs preserve their original stable identities.
   }, [
     renderedActiveWorktreeId,
-    workspaceSurfaces,
+    workspaceSurfaceIds,
     browserGuestRetentionBudgetEnabled,
     browserGuestRetentionRevision
   ])

--- a/src/renderer/src/components/use-terminal-parking-pass.ts
+++ b/src/renderer/src/components/use-terminal-parking-pass.ts
@@ -41,7 +41,7 @@ export function useTerminalParkingPass(controller: TerminalParkingFoundation): v
     terminalProviderSnapshotCapabilityRevision,
     terminalRetentionBudgetEnabled,
     terminalSshParkingEnabled,
-    workspaceSurfaces
+    workspaceSurfaceIds
   } = controller
 
   useEffect(() => {
@@ -182,6 +182,6 @@ export function useTerminalParkingPass(controller: TerminalParkingFoundation): v
     terminalProviderSnapshotCapabilityRevision,
     terminalRetentionBudgetEnabled,
     terminalSshParkingEnabled,
-    workspaceSurfaces
+    workspaceSurfaceIds
   ])
 }

--- a/src/renderer/src/components/use-terminal-watcher-effects.ts
+++ b/src/renderer/src/components/use-terminal-watcher-effects.ts
@@ -5,8 +5,9 @@ import {
   canWatcherCoverParkedTerminalTab,
   disposeAllParkedTerminalWatchers,
   pruneParkedTerminalWatchers,
-  syncParkedTerminalTabWatchers,
-  terminalWatcherLiveWorkspaceIds
+  syncParkedTerminalTabWatchersForWorkspaces,
+  terminalWatcherLiveWorkspaceIds,
+  type ParkedTerminalTabWatcherSyncEntry
 } from './terminal-pane/terminal-parked-tab-watchers'
 import { useAppStore } from '@/store'
 import { gateWorktreeAgentActivation } from '@/lib/worktree-agent-activation-gate'
@@ -40,36 +41,35 @@ export function useTerminalWatcherEffects(controller: TerminalColdActivationCont
     terminalStartupRestorationReady,
     terminalTitleSnapshotAuthorityEnabled,
     workspaceSessionReady,
-    workspaceSurfaces
+    workspaceSurfaceIds
   } = controller
 
   useEffect(() => {
-    pruneParkedTerminalWatchers(
-      terminalWatcherLiveWorkspaceIds(workspaceSurfaces.map((workspace) => workspace.id))
-    )
-    for (const workspace of workspaceSurfaces) {
+    pruneParkedTerminalWatchers(terminalWatcherLiveWorkspaceIds(workspaceSurfaceIds))
+    const syncEntriesByWorktreeId = new Map<string, ParkedTerminalTabWatcherSyncEntry>()
+    for (const workspaceId of workspaceSurfaceIds) {
       if (
         anyMountedWorktreeHasLayout &&
-        mountedWorktreeIdsRef.current.has(workspace.id) &&
-        getEffectiveLayoutForWorktree(workspace.id)
+        mountedWorktreeIdsRef.current.has(workspaceId) &&
+        getEffectiveLayoutForWorktree(workspaceId)
       ) {
         continue
       }
-      const tabs = tabsByWorktree[workspace.id] ?? []
+      const tabs = tabsByWorktree[workspaceId] ?? []
       const parkedTabIds = new Set<string>()
       let deferredTabIds: ReadonlySet<string> | null = null
-      if (!anyMountedWorktreeHasLayout && mountedWorktreeIdsRef.current.has(workspace.id)) {
-        const isVisible = activeView === 'terminal' && workspace.id === renderedActiveWorktreeId
+      if (!anyMountedWorktreeHasLayout && mountedWorktreeIdsRef.current.has(workspaceId)) {
+        const isVisible = activeView === 'terminal' && workspaceId === renderedActiveWorktreeId
         const shouldMeasureHiddenWorktree =
-          !isVisible && measurableBackgroundWorktreeIdsRef.current.has(workspace.id)
+          !isVisible && measurableBackgroundWorktreeIdsRef.current.has(workspaceId)
         const parked =
           !isVisible &&
           !shouldMeasureHiddenWorktree &&
-          effectiveParkedTerminalWorktreeIds.has(workspace.id)
+          effectiveParkedTerminalWorktreeIds.has(workspaceId)
         if (parked) {
           for (const tab of tabs) {
             const activityTerminalPortal = findActivityTerminalPortal(activityTerminalPortals, {
-              worktreeId: workspace.id,
+              worktreeId: workspaceId,
               tabId: tab.id
             })
             if (!activityTerminalPortal && !evictionExemptTerminalTabIds.has(tab.id)) {
@@ -77,15 +77,14 @@ export function useTerminalWatcherEffects(controller: TerminalColdActivationCont
             }
           }
         }
-        deferredTabIds =
-          activationDeferredMountTabIdsByWorktreeRef.current.get(workspace.id) ?? null
+        deferredTabIds = activationDeferredMountTabIdsByWorktreeRef.current.get(workspaceId) ?? null
         for (const tab of tabs) {
           if (
             deferredTabIds?.has(tab.id) &&
             !parkedTabIds.has(tab.id) &&
-            canWatcherCoverParkedTerminalTab(workspace.id, tab) &&
+            canWatcherCoverParkedTerminalTab(workspaceId, tab) &&
             !findActivityTerminalPortal(activityTerminalPortals, {
-              worktreeId: workspace.id,
+              worktreeId: workspaceId,
               tabId: tab.id
             })
           ) {
@@ -93,13 +92,13 @@ export function useTerminalWatcherEffects(controller: TerminalColdActivationCont
           }
         }
       }
-      syncParkedTerminalTabWatchers({
-        worktreeId: workspace.id,
+      syncEntriesByWorktreeId.set(workspaceId, {
         tabs,
         parkedTabIds,
         ...(deferredTabIds ? { restoreTitleOnStartTabIds: deferredTabIds } : {})
       })
     }
+    syncParkedTerminalTabWatchersForWorkspaces(syncEntriesByWorktreeId)
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- controller refs preserve their original stable identities.
   }, [
     activeTabId,
@@ -118,7 +117,7 @@ export function useTerminalWatcherEffects(controller: TerminalColdActivationCont
     terminalParkingEnabled,
     terminalTitleSnapshotAuthorityEnabled,
     workspaceSessionReady,
-    workspaceSurfaces
+    workspaceSurfaceIds
   ])
   useEffect(() => () => disposeAllParkedTerminalWatchers(), [])
 

--- a/src/renderer/src/components/use-terminal-workspace-foundation.ts
+++ b/src/renderer/src/components/use-terminal-workspace-foundation.ts
@@ -6,6 +6,7 @@ import { useWorktreeMap } from '../store/selectors'
 import { getResolvedExecutionHostIdForWorktree } from '@/lib/resolved-worktree-execution-host'
 import type { WorktreeTabBucketProjection } from '@/lib/worktree-tab-bucket-projection'
 import { projectWorkspaceSurfaces } from './workspace-surface-projection'
+import { useReusedArrayIdentity } from './sidebar/worktree-list/listing/use-reused-array-identity'
 import { selectPairedRuntimeParkingEnvironmentIds } from './terminal-pane/terminal-hidden-view-parking'
 import { createTerminalWorktreeTopologyProjection } from './terminal-pane/terminal-hidden-worktree-retention'
 import { isMainTerminalSideEffectAuthorityForPty } from './terminal-pane/terminal-side-effect-facts-handler'
@@ -45,6 +46,17 @@ export function useTerminalWorkspaceFoundation() {
         activeWorkspaceResolvedHostId: activeFolderSurfaceHostId
       }),
     [worktreesById, folderWorkspaces, renderedActiveWorktreeId, activeFolderSurfaceHostId]
+  )
+  // Why split the ids out: every mount/park/activation pass reads only `.id`, but
+  // the surface array is re-identified on any worktree write. Reusing the previous
+  // id-array identity keeps those effects and their per-fire Sets from re-firing
+  // when the workspace set itself did not change.
+  const workspaceSurfaceIds = useReusedArrayIdentity(
+    useMemo(() => workspaceSurfaces.map((workspace) => workspace.id), [workspaceSurfaces])
+  )
+  const workspaceSurfaceIdSet = useMemo<ReadonlySet<string>>(
+    () => new Set(workspaceSurfaceIds),
+    [workspaceSurfaceIds]
   )
   const activeView = useAppStore((state) => state.activeView)
   // Why: terminal titles are leaf chrome. The root host only subscribes to
@@ -88,6 +100,8 @@ export function useTerminalWorkspaceFoundation() {
     terminalWorktreeParkingTimersRef,
     folderWorkspaces,
     workspaceSurfaces,
+    workspaceSurfaceIds,
+    workspaceSurfaceIdSet,
     activeWorktreeId,
     renderedActiveWorktreeId,
     activeWorktreeDeferralHostId,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​799 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​796 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​154 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​71 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 |

<!-- /orca-pr-loc -->

## ELI5

Every time anything about your terminals changed, Orca walked all 423 of your workspaces and, for **each one**, re-scanned its entire terminal bookkeeping table from the top. With 382 tabs in that table that is ~323,000 map steps to answer a question that only ever needed one pass. The same effects also rebuilt a fresh 423-item list of workspace ids several times per render, purely to look ids up.

This PR makes the bookkeeping sweep happen **once per pass instead of once per workspace**, and gives the workspace-id list a stable identity so the passes stop re-running when nothing about your workspaces actually changed.

No behaviour changes: the same watchers start, the same watchers get disposed.

## What changed

### 1. `syncParkedTerminalTabWatchersForWorkspaces` — one registry sweep per pass

`use-terminal-watcher-effects.ts` looped all ~423 `workspaceSurfaces` and called `syncParkedTerminalTabWatchers` once per surface. That function walks **both** module-level registries (`parkedWatchersByTabId`, `capturedPanesByTabId`) in full on every call, filtering by `entry.worktreeId`. One effect fire therefore cost `surfaces x registry`.

The new batch entry point takes `ReadonlyMap<worktreeId, {tabs, parkedTabIds, restoreTitleOnStartTabIds?}>`, walks each registry exactly once, then does the per-tab start/reconcile pass. `syncParkedTerminalTabWatchers` (still used by the per-pane `useParkedTerminalWatcherSynchronization` path) now delegates to it with a single-entry map, so there is one implementation.

**Why the decisions are identical:** registry rows are keyed by tab id and a tab belongs to exactly one worktree, so hoisting every workspace's dispose + capture-cleanup sweep ahead of every workspace's start pass only reorders work across *disjoint* tab sets. Within a worktree, order is unchanged. Workspaces skipped by the `anyMountedWorktreeHasLayout` guard are simply absent from the map, which reproduces the old "never called for that worktree" behaviour exactly.

### 2/3. `workspaceSurfaceIds` / `workspaceSurfaceIdSet` on the foundation

Verified: **no** consumer of `workspaceSurfaces` in the mount/park/activation path reads a field other than `.id` — `use-terminal-watcher-effects.ts`, `terminal-parking-pass-candidates.ts`, `terminal-cold-activation.ts`, and `use-terminal-browser-retention.ts` all read only `.id`. `.path` is read only by the three rendering components (`TerminalLegacyTerminalPanes`, `TerminalSplitWorkspaceSurfaces`, `TerminalLegacyBrowserPanes`), which keep taking `workspaceSurfaces`.

`useTerminalWorkspaceFoundation` now derives the id array once alongside `workspaceSurfaces`, runs it through the existing `useReusedArrayIdentity`, and hoists the `currentWorktreeIds` / `allWorktreeIds` Set into a memo keyed on that stable array. Both consumers use them instead of building their own; both effects are keyed on the id array instead of the surface-object array.

### 4. `useVisibleSidebarWorktrees` takes `defaultHostId`, not `settings`

The 423-worktree `computeVisibleWorktrees` memo listed the whole `settings` object as a dep but only used `getSettingsFocusedExecutionHostId(settings)`. `WorktreeList.tsx:96` already computes that value for sibling hooks, so it is passed in. Any settings write (including the `usePersistedUIWriter` round-trip) no longer re-runs the full scan.

## Measurements

All numbers are measured by the tests in this PR, at the reported profile scale (423 workspace surfaces, 382 terminal tabs). They are deterministic counts, not wall-clock samples.

| Metric | Before | After |
| --- | --- | --- |
| Registry rows visited per watcher-effect fire (382 watcher rows + 382 capture rows = 764) | **323,172** (423 x 764) | **764** (423x less) |
| `workspaceSurfaces` id-array/Set builds per `Terminal` render (`applyTerminalColdActivation`) | 2 arrays of 423 + 1 Set of 423 = **1,269 element writes** | **0** |
| Same, per parking-pass fire (`collectTerminalParkingPassCandidates`) | 1 array of 423 + 1 Set of 423 = **846 element writes** | **0** |
| Same, per browser-retention fire | 1 array of 423 + 1 Set of 423 = **846 element writes** | **0** (bonus, same pattern) |
| Terminal effect fires for 100 idle worktree writes that change no workspace id | **101** (1 mount + 100) | **1** (mount only) |
| `computeVisibleWorktrees` runs per settings write that leaves the focused host unchanged | **1 extra full 423-worktree scan** | **0** |

**Effect fires/sec over a 60s idle window: not measured.** I could not run the packaged app against the real 423-workspace profile from this worktree, and I am not going to invent that number. The idle-window equivalent measured here is deterministic and stronger for review purposes: with the real `useTerminalWorkspaceFoundation` mounted, 100 consecutive worktree writes that touch only `lastActivityAt` produced 101 fires of a `workspaceSurfaces`-keyed effect and 1 fire of a `workspaceSurfaceIds`-keyed one. Idle CPU on that profile is dominated by exactly that write shape (status/activity refreshes), so the per-write elimination is the mechanism; the per-second rate depends on the user's refresh cadence.

## Corrections to the brief

- The `use-terminal-watcher-effects.ts` dep list is **17** entries, not 16.
- `collectTerminalParkingPassCandidates` also allocates `new Set(activityTerminalPortals.map(...))`, but that one is sized by *portal* count (typically 0-2), not by workspaces. It is left alone; only the two 423-sized allocations (`currentWorktreeIds`, and the surface loop's per-surface `.id` derivation) are removed.
- Everything else in the brief checked out: `projectWorkspaceSurfaces` does push one surface per `worktreesById` entry plus folder workspaces; `syncParkedTerminalTabWatchers` did scan both registries in full per call; `use-visible-worktrees.ts` used `settings` only at line 101 for the focused host id; `terminal-cold-activation.ts:153`/`:162` were the two 423-element allocations per render.

## Tests

New: `src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers-batch-sync.test.ts`

- **Scan-cost test** at 423 workspaces / 382 tabs. Instruments `Symbol.iterator` on both registries and asserts the exact visit counts for the per-surface loop (323,172) and the batch pass (764).
- **Decision-equality matrix** (6 scenarios: cold start, reveal, closed tabs with stale registry rows and captures, re-minted PTY / `restartAll`, registry rows for a worktree absent from the pass, pinned-close tombstone rows). Each scenario is seeded and run twice from a clean registry — once through the per-surface loop, once through the batch pass — and the two runs are compared on the started / disposed / pane-title-cleared / pre-handler-discarded event streams (per worktree, order preserved within a worktree) **and** the resulting `parkedWatchersByTabId` / `capturedPanesByTabId` state. Includes a guard against a vacuously-empty comparison.

New: `src/renderer/src/components/terminal-workspace-surface-ids.test.tsx`

- Identity reuse of `workspaceSurfaceIds` / `workspaceSurfaceIdSet` across a worktree write that re-identifies `workspaceSurfaces`, and re-identification on a real membership change.
- Allocation counts: `applyTerminalColdActivation` and `collectTerminalParkingPassCandidates` no longer call `workspaceSurfaces.map` at all.
- The 100-idle-writes effect-fire count above.

Extended: `use-visible-worktrees.test.tsx` — asserts `computeVisibleWorktrees` does not re-run on a settings write that leaves the focused execution host unchanged, and still re-runs when it changes. The test deliberately also passes the pre-fix `settings` arg so it stays red against the old hook.

**Red/green verified.** With the source changes reverted (test files kept), all 10 tests in the two new files fail and the new `use-visible-worktrees` test fails (`expected 2 to be 1`).

## Reliability contract (per `terminal-session-reliability`)

- **Invariant:** `terminal-parking.watcher-coverage` — the set of parked byte watchers started and disposed for a given rendered state is unchanged. A wrong dispose drops a parked tab's bell/title/completion side effects; a wrong start pins a dead PTY as a live parked owner.
- **Failure source:** this batch refactor reorders dispose/start across workspaces.
- **Oracle:** the decision-equality matrix above compares observable watcher lifecycle events and final registry state between the old per-surface loop and the new batch pass, not implementation shape.
- **Provider/platform coverage:** unaffected. Nothing in this diff touches PTY identity, provider selection, host authority, SSH/WSL/remote/relay paths, geometry, or the wire. The batch pass is pure renderer-side bookkeeping over the same inputs; `canWatcherCoverParkedTerminalTab` and `isParkRestorableTerminalPty` (which own the SSH/paired/local policy) are called with identical arguments.
- **Performance budget:** deterministic count tests for registry iterations, id-array allocations, and effect fires (table above). No new polling, timers, subprocesses, or startup awaits.
- **Residual gap:** no packaged-app 60s idle CPU sample (see above).

## Negative user-facing trade-offs

**None.**

- Watcher start/dispose decisions are proven identical by the equality matrix, which compares real lifecycle events and final registry state across a 6-scenario matrix rather than asserting on internals. The one behavioural difference the batch introduces — dispose sweeps for *all* workspaces run before start passes for *all* workspaces — is safe because registry rows are tab-id keyed and every tab belongs to exactly one worktree, so the reorder never puts two operations on the same tab out of order.
- `useReusedArrayIdentity` only reuses the previous array when it is element-wise equal, so a real workspace add / remove / reorder still re-identifies the ids and re-fires every dependent effect on the same render as before. It is safe on `string[]` for the same reason it is safe on the sidebar's `Worktree[]`: elements are replaced, never mutated in place.
- Fix 4 narrows a dep from `settings` to a value derived from it. `computeVisibleWorktrees` read nothing else off `settings`, so no filter, sort, or visibility decision loses an input.
