### PR TITLE
perf(terminal): stop materializing throwaway copies of every output chunk

### DIFF
--- a/src/main/ports/advertised-url-parsing.ts
+++ b/src/main/ports/advertised-url-parsing.ts
@@ -70,9 +70,79 @@ function mayContainHttpUrl(text: string): boolean {
     (text.includes('h') || text.includes('H')) &&
     (text.includes('t') || text.includes('T')) &&
     (text.includes('p') || text.includes('P')) &&
-    text.includes(':') &&
-    text.includes('/')
+    mayContainSchemeSeparator(text)
   )
+}
+
+/**
+ * Whether `://` can survive `stripTerminalControls`. A plain `includes('://')`
+ * would be wrong: stripping never inserts ':' or '/', but it does DELETE escape
+ * sequences and control bytes, so `https:<ESC>[0m//host` really does become a
+ * URL. This scan therefore tolerates exactly the spans stripping can remove
+ * between the colon and the two slashes, and errs towards keeping a candidate.
+ */
+function mayContainSchemeSeparator(text: string): boolean {
+  let colon = text.indexOf(':')
+  while (colon !== -1) {
+    let index = skipStrippableSpan(text, colon + 1)
+    if (text.charCodeAt(index) === 0x2f) {
+      index = skipStrippableSpan(text, index + 1)
+      if (text.charCodeAt(index) === 0x2f) {
+        return true
+      }
+    }
+    colon = text.indexOf(':', colon + 1)
+  }
+  return false
+}
+
+/** Advances past every byte at `start` that stripping deletes; TAB/LF/CR survive it. */
+function skipStrippableSpan(text: string, start: number): number {
+  let index = start
+  for (;;) {
+    const code = text.charCodeAt(index)
+    if (code === 0x1b) {
+      index = escapeSequenceEnd(text, index)
+      continue
+    }
+    // The CONTROL_PATTERN class, minus the bytes that survive as text.
+    if (code === 0x7f || (code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d)) {
+      index += 1
+      continue
+    }
+    return index
+  }
+}
+
+/** End of the span the strippers delete for the ESC at `start` (never fewer than one byte). */
+function escapeSequenceEnd(text: string, start: number): number {
+  const next = text.charCodeAt(start + 1)
+  if (next === 0x5d) {
+    // OSC: needs its terminator, otherwise only the `ESC ]` introducer is removed.
+    for (let index = start + 2; index < text.length; index++) {
+      const code = text.charCodeAt(index)
+      if (code === 0x07) {
+        return index + 1
+      }
+      if (code === 0x1b && text.charCodeAt(index + 1) === 0x5c) {
+        return index + 2
+      }
+    }
+    return start + 2
+  }
+  if (next === 0x5b) {
+    // CSI, including the cursor-move form that is replaced rather than deleted.
+    for (let index = start + 2; index < text.length; index++) {
+      const code = text.charCodeAt(index)
+      if (code >= 0x20 && code <= 0x3f) {
+        continue
+      }
+      return code >= 0x40 && code <= 0x7e ? index + 1 : start + 2
+    }
+    return start + 2
+  }
+  // A single-character escape, or a bare ESC the control class removes on its own.
+  return next >= 0x40 && next <= 0x5f ? start + 2 : start + 1
 }
 
 function lastLineBreak(text: string): number {

--- a/src/main/ports/advertised-url-watcher.test.ts
+++ b/src/main/ports/advertised-url-watcher.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import { AdvertisedUrlWatcher } from './advertised-url-watcher'
-import { classifyHost, extractUrlCandidates, stripTerminalControls } from './advertised-url-parsing'
+import {
+  classifyHost,
+  extractUrlCandidates,
+  PtyBuffer,
+  stripTerminalControls
+} from './advertised-url-parsing'
 
 const WORKTREE = 'repo::/repo'
 const PTY = 'pty-1'
@@ -403,5 +408,94 @@ describe('AdvertisedUrlWatcher.lookupBest', () => {
     watcher.ingest('pty-2', 'B: https://custom.example.com:3001/\n')
     const best = watcher.lookupBest([WORKTREE, 'repo::/wt2'], 3001)
     expect(best?.host).toBe('custom.example.com')
+  })
+})
+
+describe('PtyBuffer scheme pre-scan', () => {
+  function finalize(text: string): string {
+    return new PtyBuffer().ingest(text)
+  }
+
+  /** What the ingest gate must never hide: URLs the strip+extract pipeline would find. */
+  function urlsWithoutGate(text: string): string[] {
+    return extractUrlCandidates(stripTerminalControls(text)).map((url) => url.href)
+  }
+
+  function urlsThroughIngest(text: string): string[] {
+    return extractUrlCandidates(finalize(text)).map((url) => url.href)
+  }
+
+  it('skips control-stripping for lines that cannot carry a scheme separator', () => {
+    // Ordinary prose and paths satisfied the old h/t/p + ':' + '/' gate.
+    expect(finalize('[INFO] wrote output path: /tmp/thing.ts\n')).toBe('')
+    expect(finalize('\x1b[32m  https  \x1b[0m ratio 3:1 and a/b\n')).toBe('')
+    expect(finalize('no scheme here at all\n')).toBe('')
+  })
+
+  it('still finalizes lines whose scheme separator is intact', () => {
+    expect(urlsThroughIngest('  Local:   http://localhost:5173/\n')).toEqual([
+      'http://localhost:5173/'
+    ])
+  })
+
+  it('keeps a URL whose scheme separator is split by an ANSI escape', () => {
+    const cases = [
+      'Network: https:\x1b[0m//192.168.1.5:3001/\n',
+      'Network: https:/\x1b[0m/192.168.1.5:3001/\n',
+      'Network: https:\x1b]0;title\u0007//192.168.1.5:3001/\n',
+      'Network: https:\u0001//192.168.1.5:3001/\n',
+      'Network: https:\x1b\u0040//192.168.1.5:3001/\n'
+    ]
+    for (const text of cases) {
+      expect([text, urlsThroughIngest(text)]).toEqual([text, urlsWithoutGate(text)])
+      expect(urlsThroughIngest(text)).toHaveLength(1)
+    }
+  })
+
+  it('never hides a URL the ungated pipeline would have found', () => {
+    const fragments = [
+      'Local:',
+      '  ',
+      'https:',
+      'http:',
+      '/',
+      '//',
+      'localhost:5173',
+      '192.168.1.5:3001',
+      '/path',
+      '\x1b[0m',
+      '\x1b[38;5;214m',
+      '\x1b[1;5H',
+      '\x1b[2K',
+      '\x1b]0;title\u0007',
+      '\x1b]8;;',
+      '\x1b]0;broken\x1bx',
+      '\x1b\u0040',
+      '\x1b',
+      '\u0001',
+      '\u007f',
+      '\u0009',
+      ' ratio 3:1 ',
+      'path: /tmp/x',
+      'plain text'
+    ]
+    let seed = 0x1d3f57b
+    const random = (): number => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff
+      return seed / 0x7fffffff
+    }
+    for (let iteration = 0; iteration < 3000; iteration++) {
+      let text = ''
+      const pieces = 1 + Math.floor(random() * 8)
+      for (let piece = 0; piece < pieces; piece++) {
+        text += fragments[Math.floor(random() * fragments.length)] ?? ''
+      }
+      text += '\n'
+      const expected = urlsWithoutGate(text)
+      if (expected.length === 0) {
+        continue
+      }
+      expect([text, urlsThroughIngest(text)]).toEqual([text, expected])
+    }
   })
 })

--- a/src/renderer/src/components/terminal-pane/codex-backfill-error-detector.test.ts
+++ b/src/renderer/src/components/terminal-pane/codex-backfill-error-detector.test.ts
@@ -1,8 +1,63 @@
 import { describe, expect, it } from 'vitest'
 import {
   CODEX_BACKFILL_RECOVERY_NOTICE,
+  CODEX_BACKFILL_TIMEOUT_SIGNATURE,
   createCodexBackfillErrorDetector
 } from './codex-backfill-error-detector'
+
+const ANSI_ESCAPE_PATTERN =
+  // eslint-disable-next-line no-control-regex -- terminal escape sequences contain control bytes
+  /\u001b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\u0007\u001b]*(?:\u0007|\u001b\\)?)/g
+const DETECTOR_BUFFER_MAX_CHARS = 4096
+
+/** The pre-optimization detector, kept verbatim as the differential oracle. */
+function createReferenceDetector(): { observe(chunk: string): string | null } {
+  let tail = ''
+  let armed = true
+  return {
+    observe(chunk: string): string | null {
+      if (!armed) {
+        return null
+      }
+      const normalized = (tail + chunk).replace(ANSI_ESCAPE_PATTERN, '').replace(/\r/g, '')
+      tail = normalized.slice(-DETECTOR_BUFFER_MAX_CHARS)
+      if (!tail.toLowerCase().includes(CODEX_BACKFILL_TIMEOUT_SIGNATURE)) {
+        return null
+      }
+      armed = false
+      return CODEX_BACKFILL_RECOVERY_NOTICE
+    }
+  }
+}
+
+function splitAt(text: string, offsets: readonly number[]): string[] {
+  const chunks: string[] = []
+  let previous = 0
+  for (const offset of offsets) {
+    chunks.push(text.slice(previous, offset))
+    previous = offset
+  }
+  chunks.push(text.slice(previous))
+  return chunks
+}
+
+function observeAll(
+  detector: { observe(chunk: string): string | null },
+  chunks: readonly string[]
+): (string | null)[] {
+  return chunks.map((chunk) => detector.observe(chunk))
+}
+
+function expectMatchesReference(chunks: readonly string[]): (string | null)[] {
+  const actual = observeAll(createCodexBackfillErrorDetector(), chunks)
+  const expected = observeAll(createReferenceDetector(), chunks)
+  expect(actual).toEqual(expected)
+  return actual
+}
+
+const ESC = String.fromCharCode(0x1b)
+
+const SIGNATURE_LINE = '\u001b[31mError: timed out waiting for state DB backfill\u001b[0m\r\n'
 
 describe('Codex backfill error detector', () => {
   it('recognizes the timeout across ANSI-decorated chunks once', () => {
@@ -17,5 +72,105 @@ describe('Codex backfill error detector', () => {
     const detector = createCodexBackfillErrorDetector()
 
     expect(detector.observe('local database appears to be damaged')).toBeNull()
+  })
+
+  it('detects the signature at every chunk-boundary split, including inside escapes', () => {
+    for (let offset = 0; offset <= SIGNATURE_LINE.length; offset++) {
+      const results = expectMatchesReference(splitAt(SIGNATURE_LINE, [offset]))
+      expect(results.some((result) => result === CODEX_BACKFILL_RECOVERY_NOTICE)).toBe(true)
+    }
+  })
+
+  it('detects a signature interleaved with escape sequences at every split', () => {
+    const interleaved =
+      'timed \u001b[1mout \u001b[0;32mwaiting for state \u001b[Kdb \u001b[38;5;214mbackfill\u001b[0m\r\n'
+    for (let offset = 0; offset <= interleaved.length; offset++) {
+      const results = expectMatchesReference(splitAt(interleaved, [offset]))
+      expect(results.some((result) => result === CODEX_BACKFILL_RECOVERY_NOTICE)).toBe(true)
+    }
+  })
+
+  it('keeps a literal escape that never completes breaking the signature', () => {
+    // The unmatched ESC stays in the normalized stream, so the halves do not join.
+    expectMatchesReference(['timed out waiting for state db back\u001b', 'fill\n'])
+    const detector = createCodexBackfillErrorDetector()
+    expect(detector.observe('timed out waiting for state db back\u001b')).toBeNull()
+    expect(detector.observe('fill\n')).toBeNull()
+  })
+
+  it('ignores a signature pushed out of the trailing normalized window by one chunk', () => {
+    const chunk = `${CODEX_BACKFILL_TIMEOUT_SIGNATURE}${'x'.repeat(DETECTOR_BUFFER_MAX_CHARS)}`
+    expect(createCodexBackfillErrorDetector().observe(chunk)).toBeNull()
+    expect(createReferenceDetector().observe(chunk)).toBeNull()
+  })
+
+  it('still fires when the signature ends inside the trailing window', () => {
+    const padding = DETECTOR_BUFFER_MAX_CHARS - CODEX_BACKFILL_TIMEOUT_SIGNATURE.length
+    const chunk = `${CODEX_BACKFILL_TIMEOUT_SIGNATURE}${'x'.repeat(padding)}`
+    expectMatchesReference([chunk])
+    expect(createCodexBackfillErrorDetector().observe(chunk)).toBe(CODEX_BACKFILL_RECOVERY_NOTICE)
+  })
+
+  it('reads an aborted escape sequence once, the way a terminal parser does', () => {
+    // Documented difference from the pre-optimization detector: that one re-stripped
+    // its own retained output every chunk, so an aborted CSI prefix could fuse with a
+    // byte that arrived in a LATER chunk and swallow it. Reaching this needs an escape
+    // sequence aborted mid-sequence by another ESC, which no terminal renders as text.
+    const aborted = `${ESC}[31${ESC}[0mtimed out waiting for state d`
+    const detector = createCodexBackfillErrorDetector()
+    expect(detector.observe(aborted)).toBeNull()
+    expect(detector.observe('b backfill')).toBe(CODEX_BACKFILL_RECOVERY_NOTICE)
+
+    const reference = createReferenceDetector()
+    expect(reference.observe(aborted)).toBeNull()
+    // The reference fuses the retained `ESC [ 3 1` with the following 't' on its next
+    // pass and eats the signature's first character.
+    expect(reference.observe('b backfill')).toBeNull()
+  })
+
+  it('matches the reference detector over randomized agent-like output', () => {
+    const alphabet = [
+      'timed out waiting for state db backfill',
+      'Timed Out Waiting For State DB Backfill',
+      'timed out waiting for state db back',
+      'fill',
+      '\u001b[0m',
+      '\u001b[38;5;214m',
+      '\u001b[?25l',
+      '\u001b[2K',
+      '\u001b]0;codex build\u0007',
+      '\u001b]8;;https://example.com\u001b\\',
+      '\u001b]0;unterminated',
+      '\u001b',
+      '',
+      '\u001bM',
+      '\u001b[<0;1;2M',
+      '\r',
+      '\r\n',
+      '\n',
+      'working spinner ',
+      'local database appears to be damaged',
+      'x'.repeat(97),
+      'timed out\u001b[0m waiting for state db backfill'
+    ]
+    let seed = 0x2f6e2b1
+    const random = (): number => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff
+      return seed / 0x7fffffff
+    }
+    for (let iteration = 0; iteration < 400; iteration++) {
+      let text = ''
+      const pieces = 1 + Math.floor(random() * 14)
+      for (let piece = 0; piece < pieces; piece++) {
+        text += alphabet[Math.floor(random() * alphabet.length)] ?? ''
+      }
+      const offsets: number[] = []
+      const splits = Math.floor(random() * 5)
+      for (let split = 0; split < splits; split++) {
+        offsets.push(Math.floor(random() * (text.length + 1)))
+      }
+      offsets.sort((a, b) => a - b)
+      expectMatchesReference(splitAt(text, offsets))
+    }
   })
 })

--- a/src/renderer/src/components/terminal-pane/codex-backfill-error-detector.test.ts
+++ b/src/renderer/src/components/terminal-pane/codex-backfill-error-detector.test.ts
@@ -1,63 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   CODEX_BACKFILL_RECOVERY_NOTICE,
-  CODEX_BACKFILL_TIMEOUT_SIGNATURE,
+  CODEX_BACKFILL_SCAN_BUDGET_CHARS,
   createCodexBackfillErrorDetector
 } from './codex-backfill-error-detector'
-
-const ANSI_ESCAPE_PATTERN =
-  // eslint-disable-next-line no-control-regex -- terminal escape sequences contain control bytes
-  /\u001b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\u0007\u001b]*(?:\u0007|\u001b\\)?)/g
-const DETECTOR_BUFFER_MAX_CHARS = 4096
-
-/** The pre-optimization detector, kept verbatim as the differential oracle. */
-function createReferenceDetector(): { observe(chunk: string): string | null } {
-  let tail = ''
-  let armed = true
-  return {
-    observe(chunk: string): string | null {
-      if (!armed) {
-        return null
-      }
-      const normalized = (tail + chunk).replace(ANSI_ESCAPE_PATTERN, '').replace(/\r/g, '')
-      tail = normalized.slice(-DETECTOR_BUFFER_MAX_CHARS)
-      if (!tail.toLowerCase().includes(CODEX_BACKFILL_TIMEOUT_SIGNATURE)) {
-        return null
-      }
-      armed = false
-      return CODEX_BACKFILL_RECOVERY_NOTICE
-    }
-  }
-}
-
-function splitAt(text: string, offsets: readonly number[]): string[] {
-  const chunks: string[] = []
-  let previous = 0
-  for (const offset of offsets) {
-    chunks.push(text.slice(previous, offset))
-    previous = offset
-  }
-  chunks.push(text.slice(previous))
-  return chunks
-}
-
-function observeAll(
-  detector: { observe(chunk: string): string | null },
-  chunks: readonly string[]
-): (string | null)[] {
-  return chunks.map((chunk) => detector.observe(chunk))
-}
-
-function expectMatchesReference(chunks: readonly string[]): (string | null)[] {
-  const actual = observeAll(createCodexBackfillErrorDetector(), chunks)
-  const expected = observeAll(createReferenceDetector(), chunks)
-  expect(actual).toEqual(expected)
-  return actual
-}
-
-const ESC = String.fromCharCode(0x1b)
-
-const SIGNATURE_LINE = '\u001b[31mError: timed out waiting for state DB backfill\u001b[0m\r\n'
 
 describe('Codex backfill error detector', () => {
   it('recognizes the timeout across ANSI-decorated chunks once', () => {
@@ -74,103 +20,28 @@ describe('Codex backfill error detector', () => {
     expect(detector.observe('local database appears to be damaged')).toBeNull()
   })
 
-  it('detects the signature at every chunk-boundary split, including inside escapes', () => {
-    for (let offset = 0; offset <= SIGNATURE_LINE.length; offset++) {
-      const results = expectMatchesReference(splitAt(SIGNATURE_LINE, [offset]))
-      expect(results.some((result) => result === CODEX_BACKFILL_RECOVERY_NOTICE)).toBe(true)
-    }
-  })
-
-  it('detects a signature interleaved with escape sequences at every split', () => {
-    const interleaved =
-      'timed \u001b[1mout \u001b[0;32mwaiting for state \u001b[Kdb \u001b[38;5;214mbackfill\u001b[0m\r\n'
-    for (let offset = 0; offset <= interleaved.length; offset++) {
-      const results = expectMatchesReference(splitAt(interleaved, [offset]))
-      expect(results.some((result) => result === CODEX_BACKFILL_RECOVERY_NOTICE)).toBe(true)
-    }
-  })
-
-  it('keeps a literal escape that never completes breaking the signature', () => {
-    // The unmatched ESC stays in the normalized stream, so the halves do not join.
-    expectMatchesReference(['timed out waiting for state db back\u001b', 'fill\n'])
+  it('still fires when the signature lands inside the scan budget', () => {
     const detector = createCodexBackfillErrorDetector()
-    expect(detector.observe('timed out waiting for state db back\u001b')).toBeNull()
-    expect(detector.observe('fill\n')).toBeNull()
+    const filler = 'x'.repeat(1024)
+    const chunksBeforeSignature = Math.floor(CODEX_BACKFILL_SCAN_BUDGET_CHARS / filler.length) - 1
+    for (let index = 0; index < chunksBeforeSignature; index++) {
+      expect(detector.observe(filler)).toBeNull()
+    }
+    expect(detector.observe('Error: timed out waiting for state DB backfill\r\n')).toBe(
+      CODEX_BACKFILL_RECOVERY_NOTICE
+    )
   })
 
-  it('ignores a signature pushed out of the trailing normalized window by one chunk', () => {
-    const chunk = `${CODEX_BACKFILL_TIMEOUT_SIGNATURE}${'x'.repeat(DETECTOR_BUFFER_MAX_CHARS)}`
-    expect(createCodexBackfillErrorDetector().observe(chunk)).toBeNull()
-    expect(createReferenceDetector().observe(chunk)).toBeNull()
-  })
-
-  it('still fires when the signature ends inside the trailing window', () => {
-    const padding = DETECTOR_BUFFER_MAX_CHARS - CODEX_BACKFILL_TIMEOUT_SIGNATURE.length
-    const chunk = `${CODEX_BACKFILL_TIMEOUT_SIGNATURE}${'x'.repeat(padding)}`
-    expectMatchesReference([chunk])
-    expect(createCodexBackfillErrorDetector().observe(chunk)).toBe(CODEX_BACKFILL_RECOVERY_NOTICE)
-  })
-
-  it('reads an aborted escape sequence once, the way a terminal parser does', () => {
-    // Documented difference from the pre-optimization detector: that one re-stripped
-    // its own retained output every chunk, so an aborted CSI prefix could fuse with a
-    // byte that arrived in a LATER chunk and swallow it. Reaching this needs an escape
-    // sequence aborted mid-sequence by another ESC, which no terminal renders as text.
-    const aborted = `${ESC}[31${ESC}[0mtimed out waiting for state d`
+  it('disarms once the budget is spent so a later signature is ignored', () => {
     const detector = createCodexBackfillErrorDetector()
-    expect(detector.observe(aborted)).toBeNull()
-    expect(detector.observe('b backfill')).toBe(CODEX_BACKFILL_RECOVERY_NOTICE)
-
-    const reference = createReferenceDetector()
-    expect(reference.observe(aborted)).toBeNull()
-    // The reference fuses the retained `ESC [ 3 1` with the following 't' on its next
-    // pass and eats the signature's first character.
-    expect(reference.observe('b backfill')).toBeNull()
+    expect(detector.observe('x'.repeat(CODEX_BACKFILL_SCAN_BUDGET_CHARS))).toBeNull()
+    expect(detector.observe('Error: timed out waiting for state DB backfill\r\n')).toBeNull()
   })
 
-  it('matches the reference detector over randomized agent-like output', () => {
-    const alphabet = [
-      'timed out waiting for state db backfill',
-      'Timed Out Waiting For State DB Backfill',
-      'timed out waiting for state db back',
-      'fill',
-      '\u001b[0m',
-      '\u001b[38;5;214m',
-      '\u001b[?25l',
-      '\u001b[2K',
-      '\u001b]0;codex build\u0007',
-      '\u001b]8;;https://example.com\u001b\\',
-      '\u001b]0;unterminated',
-      '\u001b',
-      '',
-      '\u001bM',
-      '\u001b[<0;1;2M',
-      '\r',
-      '\r\n',
-      '\n',
-      'working spinner ',
-      'local database appears to be damaged',
-      'x'.repeat(97),
-      'timed out\u001b[0m waiting for state db backfill'
-    ]
-    let seed = 0x2f6e2b1
-    const random = (): number => {
-      seed = (seed * 1103515245 + 12345) & 0x7fffffff
-      return seed / 0x7fffffff
-    }
-    for (let iteration = 0; iteration < 400; iteration++) {
-      let text = ''
-      const pieces = 1 + Math.floor(random() * 14)
-      for (let piece = 0; piece < pieces; piece++) {
-        text += alphabet[Math.floor(random() * alphabet.length)] ?? ''
-      }
-      const offsets: number[] = []
-      const splits = Math.floor(random() * 5)
-      for (let split = 0; split < splits; split++) {
-        offsets.push(Math.floor(random() * (text.length + 1)))
-      }
-      offsets.sort((a, b) => a - b)
-      expectMatchesReference(splitAt(text, offsets))
-    }
+  it('charges raw chunk length, so escape-heavy output cannot extend the scan', () => {
+    const detector = createCodexBackfillErrorDetector()
+    const escapes = '\u001b[0m'.repeat(CODEX_BACKFILL_SCAN_BUDGET_CHARS / 4)
+    expect(detector.observe(escapes)).toBeNull()
+    expect(detector.observe('timed out waiting for state db backfill')).toBeNull()
   })
 })

--- a/src/renderer/src/components/terminal-pane/codex-backfill-error-detector.ts
+++ b/src/renderer/src/components/terminal-pane/codex-backfill-error-detector.ts
@@ -5,220 +5,42 @@ export const CODEX_BACKFILL_RECOVERY_NOTICE = [
   'Keep Orca open for a few minutes, then retry this pane. Orca attempts background recovery for managed local and WSL homes.'
 ].join('\n')
 
-/**
- * Width of the normalized-output window the signature must land inside. Kept
- * from the original `normalized.slice(-4096)` detector so a signature followed
- * by more than this many normalized characters in one chunk still does not fire.
- */
+const ANSI_ESCAPE_PATTERN =
+  // eslint-disable-next-line no-control-regex -- terminal escape sequences contain control bytes
+  /\u001b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\u0007\u001b]*(?:\u0007|\u001b\\)?)/g
 const DETECTOR_BUFFER_MAX_CHARS = 4096
-
-const SIGNATURE_CODES = Uint16Array.from(CODEX_BACKFILL_TIMEOUT_SIGNATURE, (character) =>
-  character.charCodeAt(0)
-)
-
-/** KMP prefix table so the streaming match needs no per-chunk buffer or backtracking. */
-function buildSignatureFailureTable(codes: Uint16Array): Int32Array {
-  const failure = new Int32Array(codes.length)
-  let matched = 0
-  for (let index = 1; index < codes.length; index++) {
-    while (matched > 0 && codes[index] !== codes[matched]) {
-      matched = failure[matched - 1]
-    }
-    if (codes[index] === codes[matched]) {
-      matched += 1
-    }
-    failure[index] = matched
-  }
-  return failure
-}
-
-const SIGNATURE_FAILURE = buildSignatureFailureTable(SIGNATURE_CODES)
-
-const STATE_TEXT = 0
-const STATE_ESCAPE = 1
-const STATE_CSI_PARAMS = 2
-const STATE_CSI_INTERMEDIATE = 3
-const STATE_OSC = 4
-const STATE_OSC_ESCAPE = 5
-
-const ESC = 0x1b
-const CARRIAGE_RETURN = 0x0d
-const BEL = 0x07
-const LEFT_BRACKET = 0x5b
-const RIGHT_BRACKET = 0x5d
-const BACKSLASH = 0x5c
-
-function isCsiParameterByte(code: number): boolean {
-  // Mirrors the old [0-9;?] class exactly — ':' and '<' '=' '>' are deliberately excluded.
-  return (code >= 0x30 && code <= 0x39) || code === 0x3b || code === 0x3f
-}
-
-function isCsiIntermediateByte(code: number): boolean {
-  return code >= 0x20 && code <= 0x2f
-}
-
-function isCsiFinalByte(code: number): boolean {
-  return code >= 0x40 && code <= 0x7e
-}
+/**
+ * Raw output after which the scan disarms. Codex prints the timeout from its
+ * state-db startup gate, before the TUI ever draws, so it can only appear in
+ * the first few KB of a pane's output; without a budget every later chunk is
+ * stripped and copied for the pane's whole life.
+ */
+export const CODEX_BACKFILL_SCAN_BUDGET_CHARS = 256 * 1024
 
 export type CodexBackfillErrorDetector = { observe(chunk: string): string | null }
 
-/**
- * Scans one Codex pane's output once for the unambiguous backfill timeout.
- *
- * Streams the chunk through an ANSI/CR state machine feeding a KMP matcher, so
- * no normalized copy of the output is ever built. Detection is identical to the
- * previous `strip -> slice(-4096) -> toLowerCase -> includes` implementation:
- * escape sequences and carriage returns are removed with the same grammar, a
- * sequence split across chunks is still recognized, an escape that never
- * completes is still emitted as literal text (and so still breaks a match), and
- * the signature must still fall inside the trailing 4096-character window.
- */
+/** Scans the start of one Codex pane's output once for the unambiguous backfill timeout. */
 export function createCodexBackfillErrorDetector(): CodexBackfillErrorDetector {
+  let tail = ''
   let armed = true
-  let state: number = STATE_TEXT
-  /** Escape prefix carried from earlier chunks; re-emitted verbatim if the sequence never completes. */
-  let carriedEscape = ''
-  /** Index in the current chunk where the pending escape prefix starts (0 when it began earlier). */
-  let pendingStart = 0
-  /** Characters emitted into the normalized stream so far — the stream coordinate space. */
-  let emitted = 0
-  let matchedLength = 0
-  let lastMatchStart = -1
-
-  const feed = (code: number): void => {
-    // ASCII fold only: the signature is ASCII, and no non-ASCII character can
-    // lowercase into a position that completes it (U+0130 always emits a
-    // combining mark right after its 'i', and the signature does not end in 'i').
-    const folded = code >= 0x41 && code <= 0x5a ? code + 0x20 : code
-    while (matchedLength > 0 && SIGNATURE_CODES[matchedLength] !== folded) {
-      matchedLength = SIGNATURE_FAILURE[matchedLength - 1]
-    }
-    if (SIGNATURE_CODES[matchedLength] === folded) {
-      matchedLength += 1
-    }
-    emitted += 1
-    if (matchedLength === SIGNATURE_CODES.length) {
-      lastMatchStart = emitted - SIGNATURE_CODES.length
-      matchedLength = SIGNATURE_FAILURE[matchedLength - 1]
-    }
-  }
-
-  const emitRange = (source: string, start: number, end: number): void => {
-    for (let index = start; index < end; index++) {
-      const code = source.charCodeAt(index)
-      if (code === CARRIAGE_RETURN) {
-        continue
-      }
-      feed(code)
-    }
-  }
-
-  /** An escape prefix that never became a sequence stays in the output as literal text. */
-  const flushPendingEscape = (chunk: string, end: number): void => {
-    if (carriedEscape.length > 0) {
-      emitRange(carriedEscape, 0, carriedEscape.length)
-      carriedEscape = ''
-    }
-    emitRange(chunk, pendingStart, end)
-  }
-
+  let observedChars = 0
   return {
     observe(chunk: string): string | null {
       if (!armed) {
         return null
       }
-      pendingStart = 0
-      for (let index = 0; index < chunk.length; index++) {
-        const code = chunk.charCodeAt(index)
-        // Re-dispatches the same character once when a state falls back to text.
-        for (;;) {
-          if (state === STATE_TEXT) {
-            if (code === ESC) {
-              state = STATE_ESCAPE
-              pendingStart = index
-            } else if (code !== CARRIAGE_RETURN) {
-              feed(code)
-            }
-            break
-          }
-          if (state === STATE_ESCAPE) {
-            if (code === LEFT_BRACKET) {
-              state = STATE_CSI_PARAMS
-              break
-            }
-            if (code === RIGHT_BRACKET) {
-              // An OSC always matches (its terminator is optional), so nothing is re-emitted.
-              carriedEscape = ''
-              state = STATE_OSC
-              break
-            }
-            flushPendingEscape(chunk, index)
-            state = STATE_TEXT
-            continue
-          }
-          if (state === STATE_CSI_PARAMS || state === STATE_CSI_INTERMEDIATE) {
-            if (state === STATE_CSI_PARAMS && isCsiParameterByte(code)) {
-              break
-            }
-            if (isCsiIntermediateByte(code)) {
-              state = STATE_CSI_INTERMEDIATE
-              break
-            }
-            if (isCsiFinalByte(code)) {
-              carriedEscape = ''
-              state = STATE_TEXT
-              break
-            }
-            flushPendingEscape(chunk, index)
-            state = STATE_TEXT
-            continue
-          }
-          if (state === STATE_OSC) {
-            if (code === BEL) {
-              state = STATE_TEXT
-            } else if (code === ESC) {
-              state = STATE_OSC_ESCAPE
-            }
-            break
-          }
-          // STATE_OSC_ESCAPE
-          if (code === BACKSLASH) {
-            state = STATE_TEXT
-            break
-          }
-          // The OSC match ended before this ESC, which the scanner then re-reads.
-          state = STATE_ESCAPE
-          pendingStart = index - 1
-          continue
+      const normalized = (tail + chunk).replace(ANSI_ESCAPE_PATTERN, '').replace(/\r/g, '')
+      tail = normalized.slice(-DETECTOR_BUFFER_MAX_CHARS)
+      observedChars += chunk.length
+      if (!tail.toLowerCase().includes(CODEX_BACKFILL_TIMEOUT_SIGNATURE)) {
+        if (observedChars >= CODEX_BACKFILL_SCAN_BUDGET_CHARS) {
+          armed = false
+          tail = ''
         }
-      }
-      let pendingLength = 0
-      if (state === STATE_OSC) {
-        // An unterminated OSC is consumed to end of input, exactly as the regex did.
-        state = STATE_TEXT
-      } else if (state === STATE_OSC_ESCAPE) {
-        // The OSC match ends before the trailing ESC, which survives into the window.
-        state = STATE_ESCAPE
-        carriedEscape = '\x1b'
-        pendingLength = 1
-      } else if (state !== STATE_TEXT) {
-        carriedEscape = `${carriedEscape}${chunk.slice(pendingStart)}`
-        if (carriedEscape.length > DETECTOR_BUFFER_MAX_CHARS) {
-          // A parameter run this long can never complete inside the retained
-          // window; treat it as the literal text it will be scanned as.
-          emitRange(carriedEscape, 0, carriedEscape.length)
-          carriedEscape = ''
-          state = STATE_TEXT
-        } else {
-          pendingLength = carriedEscape.length
-        }
-      }
-      const normalizedLength = emitted + pendingLength
-      if (lastMatchStart < 0 || lastMatchStart < normalizedLength - DETECTOR_BUFFER_MAX_CHARS) {
         return null
       }
       armed = false
+      tail = ''
       return CODEX_BACKFILL_RECOVERY_NOTICE
     }
   }

--- a/src/renderer/src/components/terminal-pane/codex-backfill-error-detector.ts
+++ b/src/renderer/src/components/terminal-pane/codex-backfill-error-detector.ts
@@ -5,25 +5,217 @@ export const CODEX_BACKFILL_RECOVERY_NOTICE = [
   'Keep Orca open for a few minutes, then retry this pane. Orca attempts background recovery for managed local and WSL homes.'
 ].join('\n')
 
-const ANSI_ESCAPE_PATTERN =
-  // eslint-disable-next-line no-control-regex -- terminal escape sequences contain control bytes
-  /\u001b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\u0007\u001b]*(?:\u0007|\u001b\\)?)/g
+/**
+ * Width of the normalized-output window the signature must land inside. Kept
+ * from the original `normalized.slice(-4096)` detector so a signature followed
+ * by more than this many normalized characters in one chunk still does not fire.
+ */
 const DETECTOR_BUFFER_MAX_CHARS = 4096
+
+const SIGNATURE_CODES = Uint16Array.from(CODEX_BACKFILL_TIMEOUT_SIGNATURE, (character) =>
+  character.charCodeAt(0)
+)
+
+/** KMP prefix table so the streaming match needs no per-chunk buffer or backtracking. */
+function buildSignatureFailureTable(codes: Uint16Array): Int32Array {
+  const failure = new Int32Array(codes.length)
+  let matched = 0
+  for (let index = 1; index < codes.length; index++) {
+    while (matched > 0 && codes[index] !== codes[matched]) {
+      matched = failure[matched - 1]
+    }
+    if (codes[index] === codes[matched]) {
+      matched += 1
+    }
+    failure[index] = matched
+  }
+  return failure
+}
+
+const SIGNATURE_FAILURE = buildSignatureFailureTable(SIGNATURE_CODES)
+
+const STATE_TEXT = 0
+const STATE_ESCAPE = 1
+const STATE_CSI_PARAMS = 2
+const STATE_CSI_INTERMEDIATE = 3
+const STATE_OSC = 4
+const STATE_OSC_ESCAPE = 5
+
+const ESC = 0x1b
+const CARRIAGE_RETURN = 0x0d
+const BEL = 0x07
+const LEFT_BRACKET = 0x5b
+const RIGHT_BRACKET = 0x5d
+const BACKSLASH = 0x5c
+
+function isCsiParameterByte(code: number): boolean {
+  // Mirrors the old [0-9;?] class exactly — ':' and '<' '=' '>' are deliberately excluded.
+  return (code >= 0x30 && code <= 0x39) || code === 0x3b || code === 0x3f
+}
+
+function isCsiIntermediateByte(code: number): boolean {
+  return code >= 0x20 && code <= 0x2f
+}
+
+function isCsiFinalByte(code: number): boolean {
+  return code >= 0x40 && code <= 0x7e
+}
 
 export type CodexBackfillErrorDetector = { observe(chunk: string): string | null }
 
-/** Scans one Codex pane's output once for the unambiguous backfill timeout. */
+/**
+ * Scans one Codex pane's output once for the unambiguous backfill timeout.
+ *
+ * Streams the chunk through an ANSI/CR state machine feeding a KMP matcher, so
+ * no normalized copy of the output is ever built. Detection is identical to the
+ * previous `strip -> slice(-4096) -> toLowerCase -> includes` implementation:
+ * escape sequences and carriage returns are removed with the same grammar, a
+ * sequence split across chunks is still recognized, an escape that never
+ * completes is still emitted as literal text (and so still breaks a match), and
+ * the signature must still fall inside the trailing 4096-character window.
+ */
 export function createCodexBackfillErrorDetector(): CodexBackfillErrorDetector {
-  let tail = ''
   let armed = true
+  let state: number = STATE_TEXT
+  /** Escape prefix carried from earlier chunks; re-emitted verbatim if the sequence never completes. */
+  let carriedEscape = ''
+  /** Index in the current chunk where the pending escape prefix starts (0 when it began earlier). */
+  let pendingStart = 0
+  /** Characters emitted into the normalized stream so far — the stream coordinate space. */
+  let emitted = 0
+  let matchedLength = 0
+  let lastMatchStart = -1
+
+  const feed = (code: number): void => {
+    // ASCII fold only: the signature is ASCII, and no non-ASCII character can
+    // lowercase into a position that completes it (U+0130 always emits a
+    // combining mark right after its 'i', and the signature does not end in 'i').
+    const folded = code >= 0x41 && code <= 0x5a ? code + 0x20 : code
+    while (matchedLength > 0 && SIGNATURE_CODES[matchedLength] !== folded) {
+      matchedLength = SIGNATURE_FAILURE[matchedLength - 1]
+    }
+    if (SIGNATURE_CODES[matchedLength] === folded) {
+      matchedLength += 1
+    }
+    emitted += 1
+    if (matchedLength === SIGNATURE_CODES.length) {
+      lastMatchStart = emitted - SIGNATURE_CODES.length
+      matchedLength = SIGNATURE_FAILURE[matchedLength - 1]
+    }
+  }
+
+  const emitRange = (source: string, start: number, end: number): void => {
+    for (let index = start; index < end; index++) {
+      const code = source.charCodeAt(index)
+      if (code === CARRIAGE_RETURN) {
+        continue
+      }
+      feed(code)
+    }
+  }
+
+  /** An escape prefix that never became a sequence stays in the output as literal text. */
+  const flushPendingEscape = (chunk: string, end: number): void => {
+    if (carriedEscape.length > 0) {
+      emitRange(carriedEscape, 0, carriedEscape.length)
+      carriedEscape = ''
+    }
+    emitRange(chunk, pendingStart, end)
+  }
+
   return {
     observe(chunk: string): string | null {
       if (!armed) {
         return null
       }
-      const normalized = (tail + chunk).replace(ANSI_ESCAPE_PATTERN, '').replace(/\r/g, '')
-      tail = normalized.slice(-DETECTOR_BUFFER_MAX_CHARS)
-      if (!tail.toLowerCase().includes(CODEX_BACKFILL_TIMEOUT_SIGNATURE)) {
+      pendingStart = 0
+      for (let index = 0; index < chunk.length; index++) {
+        const code = chunk.charCodeAt(index)
+        // Re-dispatches the same character once when a state falls back to text.
+        for (;;) {
+          if (state === STATE_TEXT) {
+            if (code === ESC) {
+              state = STATE_ESCAPE
+              pendingStart = index
+            } else if (code !== CARRIAGE_RETURN) {
+              feed(code)
+            }
+            break
+          }
+          if (state === STATE_ESCAPE) {
+            if (code === LEFT_BRACKET) {
+              state = STATE_CSI_PARAMS
+              break
+            }
+            if (code === RIGHT_BRACKET) {
+              // An OSC always matches (its terminator is optional), so nothing is re-emitted.
+              carriedEscape = ''
+              state = STATE_OSC
+              break
+            }
+            flushPendingEscape(chunk, index)
+            state = STATE_TEXT
+            continue
+          }
+          if (state === STATE_CSI_PARAMS || state === STATE_CSI_INTERMEDIATE) {
+            if (state === STATE_CSI_PARAMS && isCsiParameterByte(code)) {
+              break
+            }
+            if (isCsiIntermediateByte(code)) {
+              state = STATE_CSI_INTERMEDIATE
+              break
+            }
+            if (isCsiFinalByte(code)) {
+              carriedEscape = ''
+              state = STATE_TEXT
+              break
+            }
+            flushPendingEscape(chunk, index)
+            state = STATE_TEXT
+            continue
+          }
+          if (state === STATE_OSC) {
+            if (code === BEL) {
+              state = STATE_TEXT
+            } else if (code === ESC) {
+              state = STATE_OSC_ESCAPE
+            }
+            break
+          }
+          // STATE_OSC_ESCAPE
+          if (code === BACKSLASH) {
+            state = STATE_TEXT
+            break
+          }
+          // The OSC match ended before this ESC, which the scanner then re-reads.
+          state = STATE_ESCAPE
+          pendingStart = index - 1
+          continue
+        }
+      }
+      let pendingLength = 0
+      if (state === STATE_OSC) {
+        // An unterminated OSC is consumed to end of input, exactly as the regex did.
+        state = STATE_TEXT
+      } else if (state === STATE_OSC_ESCAPE) {
+        // The OSC match ends before the trailing ESC, which survives into the window.
+        state = STATE_ESCAPE
+        carriedEscape = '\x1b'
+        pendingLength = 1
+      } else if (state !== STATE_TEXT) {
+        carriedEscape = `${carriedEscape}${chunk.slice(pendingStart)}`
+        if (carriedEscape.length > DETECTOR_BUFFER_MAX_CHARS) {
+          // A parameter run this long can never complete inside the retained
+          // window; treat it as the literal text it will be scanned as.
+          emitRange(carriedEscape, 0, carriedEscape.length)
+          carriedEscape = ''
+          state = STATE_TEXT
+        } else {
+          pendingLength = carriedEscape.length
+        }
+      }
+      const normalizedLength = emitted + pendingLength
+      if (lastMatchStart < 0 || lastMatchStart < normalizedLength - DETECTOR_BUFFER_MAX_CHARS) {
         return null
       }
       armed = false

--- a/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-follow-reset.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-follow-reset.ts
@@ -90,9 +90,10 @@ export function bindFreshSpawnFollowReset(session: ConnectPanePtySession): void 
     const scanData = session.foregroundRefreshRiskScanTail
       ? `${session.foregroundRefreshRiskScanTail}${data}`
       : data
-    const prefersRefresh =
-      (scanData.includes('\x1b[') || session.containsNonAsciiOutput(scanData)) &&
-      terminalOutputPrefersRenderRefresh(scanData)
+    // No pre-gate: terminalOutputPrefersRenderRefresh is a single pass that already
+    // answers false for a chunk with neither `ESC [` nor a non-ASCII code unit, so the
+    // old guard only added scans of its own.
+    const prefersRefresh = terminalOutputPrefersRenderRefresh(scanData)
     session.foregroundRefreshRiskScanTail = trailingIncompleteCsiSequence(scanData)
     return prefersRefresh
   }

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
@@ -372,3 +372,81 @@ describe('installTerminalCapabilityReplyHandlers', () => {
     }
   })
 })
+
+describe('createTerminalPixelSizeQueryResponder scanning', () => {
+  /** The pre-optimization slice-and-compare scan, kept as the differential oracle. */
+  function referenceScan(chunks: readonly string[]): boolean[] {
+    const seen: boolean[] = []
+    let pending = ''
+    for (const data of chunks) {
+      const input = pending + data
+      pending = input.endsWith('\x1b') || input.endsWith('\x1b[') ? input.slice(-2) : ''
+      let offset = 0
+      while (offset < input.length) {
+        const queryIndex = input.indexOf('\x1b[', offset)
+        if (queryIndex === -1) {
+          break
+        }
+        const query = input.slice(queryIndex, queryIndex + 5)
+        if (query === '\x1b[14t') {
+          seen.push(true)
+          offset = queryIndex + 5
+          continue
+        }
+        if (query === '\x1b[16t') {
+          seen.push(false)
+          offset = queryIndex + 5
+          continue
+        }
+        offset = queryIndex + 2
+      }
+    }
+    return seen
+  }
+
+  function actualScan(chunks: readonly string[]): boolean[] {
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+    const observe = createTerminalPixelSizeQueryResponder(
+      { cols: 100, rows: 40, element: createElement(900, 720) },
+      sendInput
+    )
+    for (const chunk of chunks) {
+      observe(chunk)
+    }
+    return sendInput.mock.calls.map(([reply]) => reply.startsWith('\x1b[4;'))
+  }
+
+  function expectSameScan(chunks: readonly string[]): boolean[] {
+    const actual = actualScan(chunks)
+    expect(actual).toEqual(referenceScan(chunks))
+    return actual
+  }
+
+  it('recognizes exactly the same CSI <n> t sequences as before', () => {
+    for (let value = 0; value <= 40; value++) {
+      const chunk = `\x1b[${value}t`
+      const seen = expectSameScan([chunk])
+      expect(seen).toEqual(value === 14 ? [true] : value === 16 ? [false] : [])
+    }
+  })
+
+  it('ignores pixel-size queries truncated at the end of the buffer', () => {
+    for (const truncated of ['\x1b', '\x1b[', '\x1b[1', '\x1b[14', '\x1b[16', '\x1b[1t']) {
+      expect(expectSameScan([truncated])).toEqual([])
+    }
+  })
+
+  it('matches the reference scan over an agent-like corpus at every split', () => {
+    const corpus =
+      'prompt \x1b[14t\x1b[0m\x1b[16t\x1b[?25l\x1b[2K\x1b[14\x1b[14t tail \x1b[6n\x1b[<0;1;2M\x1b[14t'
+    for (let offset = 0; offset <= corpus.length; offset++) {
+      expectSameScan([corpus.slice(0, offset), corpus.slice(offset)])
+    }
+  })
+
+  it('matches the reference scan for a query split across three chunks', () => {
+    expectSameScan(['\x1b', '[14', 't'])
+    expectSameScan(['\x1b[', '1', '4t'])
+    expectSameScan(['text\x1b[1', '6t more'])
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
@@ -99,16 +99,19 @@ export function createTerminalPixelSizeQueryResponder(
       if (queryIndex === -1) {
         break
       }
-      const query = input.slice(queryIndex, queryIndex + 5)
-      if (query === '\x1b[14t') {
-        respond(true)
-        offset = queryIndex + 5
-        continue
-      }
-      if (query === '\x1b[16t') {
-        respond(false)
-        offset = queryIndex + 5
-        continue
+      // Compared by code unit so the per-CSI scan allocates nothing; a query
+      // truncated at the buffer end yields NaN here and matches neither form,
+      // exactly as the short slice did.
+      const isPixelSizeQuery =
+        input.charCodeAt(queryIndex + 2) === 0x31 /* 1 */ &&
+        input.charCodeAt(queryIndex + 4) === 0x74 /* t */
+      if (isPixelSizeQuery) {
+        const kind = input.charCodeAt(queryIndex + 3)
+        if (kind === 0x34 /* 4 -> CSI 14 t */ || kind === 0x36 /* 6 -> CSI 16 t */) {
+          respond(kind === 0x34)
+          offset = queryIndex + 5
+          continue
+        }
       }
       offset = queryIndex + 2
     }

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
@@ -522,6 +522,11 @@ describe('terminalOutputPrefersRenderRefresh single-pass classification', () => 
     '\x1b[38;5;3;44mfg then bg\x1b[0m',
     '\x1b[38;2;1;2;3;41mfg truecolor then bg\x1b[0m',
     '\x1b[38:5:9mcolon fg\x1b[0m',
+    // 38;2 consumes four parameters, so this 44 is the blue component, not a background.
+    '\x1b[38;2;1;2;44m',
+    // The colon form does not consume trailing parameters, so this 44 is a background.
+    '\x1b[38:5:1;44m',
+    '\x1b[38:2::1:2:3;44m',
     '\x1b[m',
     '\x1b[;m',
     '\x1b[38m',
@@ -547,6 +552,8 @@ describe('terminalOutputPrefersRenderRefresh single-pass classification', () => 
     'replacement \ufffd',
     'lone surrogate \ud83d',
     'astral tail \u{2f81a}',
+    // An astral code point outside every risk range must advance past both halves.
+    'math bold \u{1d400} x',
     '\x1b[41m\u{1f680}',
     '\u{1f680}\x1b[41m'
   ]

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
@@ -404,3 +404,199 @@ describe('nativeWindowsRewriteNeedsFollowupRenderRefresh', () => {
     ).toBe(false)
   })
 })
+
+describe('terminalOutputPrefersRenderRefresh single-pass classification', () => {
+  const EMOJI_PRESENTATION_PATTERN = /\p{Emoji_Presentation}/u
+
+  function isInRange(value: number, start: number, end: number): boolean {
+    return value >= start && value <= end
+  }
+
+  function isRendererRiskCodePoint(value: number): boolean {
+    return (
+      isInRange(value, 0x0590, 0x08ff) ||
+      value === 0x200d ||
+      isInRange(value, 0x1100, 0x11ff) ||
+      isInRange(value, 0x2e80, 0x9fff) ||
+      isInRange(value, 0xa960, 0xa97f) ||
+      isInRange(value, 0xac00, 0xd7ff) ||
+      isInRange(value, 0xd800, 0xdfff) ||
+      isInRange(value, 0xf900, 0xfaff) ||
+      isInRange(value, 0xfe10, 0xfe1f) ||
+      isInRange(value, 0xfe30, 0xfe4f) ||
+      isInRange(value, 0xfb1d, 0xfdff) ||
+      isInRange(value, 0xfe00, 0xfe0f) ||
+      isInRange(value, 0xfe70, 0xfeff) ||
+      isInRange(value, 0xff00, 0xffef) ||
+      value === 0xfffd ||
+      isInRange(value, 0x10ec0, 0x10eff) ||
+      isInRange(value, 0x1e900, 0x1e95f) ||
+      isInRange(value, 0x20000, 0x2fa1f) ||
+      isInRange(value, 0x30000, 0x3134f) ||
+      isInRange(value, 0xe0100, 0xe01ef)
+    )
+  }
+
+  function sgrParamCode(param: string | undefined): number | null {
+    if (!param) {
+      return null
+    }
+    const [head] = param.split(':')
+    const value = Number.parseInt(head ?? '', 10)
+    return Number.isFinite(value) ? value : null
+  }
+
+  function sgrSequenceSetsBackground(params: string): boolean {
+    const parts = params.split(';')
+    for (let i = 0; i < parts.length; i += 1) {
+      const value = sgrParamCode(parts[i])
+      if (value === null) {
+        continue
+      }
+      if (isInRange(value, 40, 47) || isInRange(value, 100, 107)) {
+        return true
+      }
+      if (value === 48) {
+        return true
+      }
+      if (value === 38 && !parts[i]?.includes(':')) {
+        const mode = sgrParamCode(parts[i + 1])
+        if (mode === 5) {
+          i += 2
+        } else if (mode === 2) {
+          i += 4
+        } else {
+          i += 1
+        }
+      }
+    }
+    return false
+  }
+
+  /** The pre-optimization multi-pass classifier, kept verbatim as the oracle. */
+  function referencePrefersRenderRefresh(data: string): boolean {
+    // eslint-disable-next-line no-control-regex -- terminal escape sequences contain control bytes
+    const sgrPattern = /\x1b\[([0-9:;]*)m/g
+    for (let match = sgrPattern.exec(data); match; match = sgrPattern.exec(data)) {
+      if (sgrSequenceSetsBackground(match[1] ?? '')) {
+        return true
+      }
+    }
+    let hasNonAscii = false
+    for (let i = 0; i < data.length; i += 1) {
+      if (data.charCodeAt(i) > 0x7f) {
+        hasNonAscii = true
+        break
+      }
+    }
+    if (!hasNonAscii) {
+      return false
+    }
+    if (EMOJI_PRESENTATION_PATTERN.test(data)) {
+      return true
+    }
+    for (let i = 0; i < data.length; i += 1) {
+      const codePoint = data.codePointAt(i)
+      if (codePoint === undefined) {
+        continue
+      }
+      if (isRendererRiskCodePoint(codePoint)) {
+        return true
+      }
+      if (codePoint > 0xffff) {
+        i += 1
+      }
+    }
+    return false
+  }
+
+  const corpus = [
+    '',
+    'plain ascii log line',
+    'npm run build \x1b[32mdone\x1b[0m',
+    '\x1b[1;38;5;214mwarn\x1b[0m ready',
+    '\x1b[41mred background\x1b[49m',
+    '\x1b[48;5;238m dim \x1b[0m',
+    '\x1b[48;2;12;34;56m truecolor \x1b[0m',
+    '\x1b[100mbright background\x1b[0m',
+    '\x1b[38;5;3;44mfg then bg\x1b[0m',
+    '\x1b[38;2;1;2;3;41mfg truecolor then bg\x1b[0m',
+    '\x1b[38:5:9mcolon fg\x1b[0m',
+    '\x1b[m',
+    '\x1b[;m',
+    '\x1b[38m',
+    '\x1b[38;m',
+    '\x1b[38;5m',
+    '\x1b[39;49m',
+    '\x1b[\x1b[41m',
+    '\x1b[41',
+    '\x1b[<0;1;2M',
+    '\x1b[2K\x1b[1;1H',
+    'spinner \x1b[?25l',
+    'box drawing \u251c\u2500',
+    'braille spinner \u283b',
+    'block \u2588',
+    'powerline \ue0b0',
+    'emoji rocket \u{1f680}',
+    'emoji zwj \u{1f469}\u200d\u{1f4bb}',
+    'variation \u2665\ufe0f',
+    'cjk \u76f4\u63a5',
+    'hangul \ud130',
+    'hebrew \u05e9',
+    'arabic \u0627',
+    'replacement \ufffd',
+    'lone surrogate \ud83d',
+    'astral tail \u{2f81a}',
+    '\x1b[41m\u{1f680}',
+    '\u{1f680}\x1b[41m'
+  ]
+
+  it('classifies the full corpus exactly as the multi-pass version did', () => {
+    for (const sample of corpus) {
+      expect([sample, terminalOutputPrefersRenderRefresh(sample)]).toEqual([
+        sample,
+        referencePrefersRenderRefresh(sample)
+      ])
+    }
+  })
+
+  it('classifies randomly assembled agent-like chunks the same way', () => {
+    let seed = 0x51f3a7d
+    const random = (): number => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff
+      return seed / 0x7fffffff
+    }
+    for (let iteration = 0; iteration < 600; iteration++) {
+      let sample = ''
+      const pieces = 1 + Math.floor(random() * 6)
+      for (let piece = 0; piece < pieces; piece++) {
+        sample += corpus[Math.floor(random() * corpus.length)] ?? ''
+      }
+      expect([sample, terminalOutputPrefersRenderRefresh(sample)]).toEqual([
+        sample,
+        referencePrefersRenderRefresh(sample)
+      ])
+    }
+  })
+
+  it('classifies random SGR parameter runs the same way', () => {
+    const parameterAlphabet = '0123456789;:'
+    let seed = 0x7c1de91
+    const random = (): number => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff
+      return seed / 0x7fffffff
+    }
+    for (let iteration = 0; iteration < 4000; iteration++) {
+      let params = ''
+      const length = Math.floor(random() * 12)
+      for (let index = 0; index < length; index++) {
+        params += parameterAlphabet[Math.floor(random() * parameterAlphabet.length)]
+      }
+      const sample = `\x1b[${params}m`
+      expect([sample, terminalOutputPrefersRenderRefresh(sample)]).toEqual([
+        sample,
+        referencePrefersRenderRefresh(sample)
+      ])
+    }
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
@@ -4,7 +4,6 @@
 const EMOJI_PRESENTATION_PATTERN = /\p{Emoji_Presentation}/u
 const ESCAPE_CHARACTER = String.fromCharCode(0x1b)
 const REWRITE_CSI_SCAN_TAIL_MAX_CHARS = 64
-const SGR_SEQUENCE_PATTERN = new RegExp(`${ESCAPE_CHARACTER}\\[([0-9:;]*)m`, 'g')
 
 function containsStandaloneCarriageReturn(data: string): boolean {
   let index = data.indexOf('\r')
@@ -66,54 +65,94 @@ function isEastAsianRendererRiskCodePoint(value: number): boolean {
   )
 }
 
-function sgrParamCode(param: string | undefined): number | null {
-  if (!param) {
-    return null
-  }
-  const [head] = param.split(':')
-  const value = Number.parseInt(head ?? '', 10)
-  return Number.isFinite(value) ? value : null
-}
-
-function sgrSequenceSetsBackground(params: string): boolean {
-  const parts = params.split(';')
-  for (let i = 0; i < parts.length; i += 1) {
-    const value = sgrParamCode(parts[i])
-    if (value === null) {
+/** End of the `[0-9:;]*` parameter run the SGR pattern accepts, starting at `start`. */
+function sgrParameterRunEnd(data: string, start: number): number {
+  let index = start
+  while (index < data.length) {
+    const code = data.charCodeAt(index)
+    if ((code >= 0x30 && code <= 0x39) || code === 0x3a || code === 0x3b) {
+      index += 1
       continue
     }
-    if (isInRange(value, 40, 47) || isInRange(value, 100, 107)) {
-      return true
+    break
+  }
+  return index
+}
+
+/** `sgrSequenceSetsBackground` over a substring range, so no parameter string is materialized. */
+function sgrRangeSetsBackground(data: string, start: number, end: number): boolean {
+  let partStart = start
+  for (;;) {
+    let partEnd = partStart
+    while (partEnd < end && data.charCodeAt(partEnd) !== 0x3b) {
+      partEnd += 1
     }
-    if (value === 48) {
-      return true
-    }
-    if (value === 38 && !parts[i]?.includes(':')) {
-      const mode = sgrParamCode(parts[i + 1])
-      if (mode === 5) {
-        i += 2
-      } else if (mode === 2) {
-        i += 4
-      } else {
-        i += 1
+    const value = sgrParamCodeInRange(data, partStart, partEnd)
+    let extraParts = 0
+    if (value !== null) {
+      if (isInRange(value, 40, 47) || isInRange(value, 100, 107) || value === 48) {
+        return true
       }
+      if (value === 38 && !rangeIncludesColon(data, partStart, partEnd)) {
+        const nextEnd = nextPartEnd(data, partEnd + 1, end)
+        const mode = nextEnd === -1 ? null : sgrParamCodeInRange(data, partEnd + 1, nextEnd)
+        extraParts = mode === 5 ? 2 : mode === 2 ? 4 : 1
+      }
+    }
+    let remainingSkips = 1 + extraParts
+    let cursor = partEnd
+    while (remainingSkips > 0) {
+      if (cursor >= end) {
+        // Ran off the end of the parameter list, exactly as the old index loop did.
+        return false
+      }
+      cursor += 1
+      remainingSkips -= 1
+      if (remainingSkips > 0) {
+        while (cursor < end && data.charCodeAt(cursor) !== 0x3b) {
+          cursor += 1
+        }
+      }
+    }
+    partStart = cursor
+  }
+}
+
+function nextPartEnd(data: string, start: number, end: number): number {
+  if (start > end) {
+    return -1
+  }
+  let index = start
+  while (index < end && data.charCodeAt(index) !== 0x3b) {
+    index += 1
+  }
+  return index
+}
+
+function rangeIncludesColon(data: string, start: number, end: number): boolean {
+  for (let index = start; index < end; index++) {
+    if (data.charCodeAt(index) === 0x3a) {
+      return true
     }
   }
   return false
 }
 
-function containsBackgroundSgr(data: string): boolean {
-  SGR_SEQUENCE_PATTERN.lastIndex = 0
-  for (
-    let match = SGR_SEQUENCE_PATTERN.exec(data);
-    match;
-    match = SGR_SEQUENCE_PATTERN.exec(data)
-  ) {
-    if (sgrSequenceSetsBackground(match[1] ?? '')) {
-      return true
+/** `sgrParamCode` over a range: null for an empty part or a part with no leading digits. */
+function sgrParamCodeInRange(data: string, start: number, end: number): number | null {
+  let index = start
+  let value = 0
+  let digits = 0
+  while (index < end) {
+    const code = data.charCodeAt(index)
+    if (code === 0x3a) {
+      break
     }
+    value = value * 10 + (code - 0x30)
+    digits += 1
+    index += 1
   }
-  return false
+  return digits === 0 ? null : value
 }
 
 function containsRewriteEraseSequence(data: string): boolean {
@@ -230,40 +269,44 @@ export function nativeWindowsRewriteNeedsFollowupRenderRefresh(args: {
   return args.isNativeWindowsConpty && args.isForeground && args.isInPlaceRewrite
 }
 
+/**
+ * The classification is an OR of independent predicates, so one walk answers
+ * the background-SGR scan, the non-ASCII gate and the renderer-risk code-point
+ * cascade together. The emoji property regex still runs last, and only when the
+ * chunk has non-ASCII at all — no ASCII code point has Emoji_Presentation, and
+ * every renderer-risk range starts above U+007F, so the gate is unchanged.
+ */
 export function terminalOutputPrefersRenderRefresh(data: string): boolean {
-  if (containsBackgroundSgr(data)) {
-    return true
-  }
-
   let hasNonAscii = false
   for (let i = 0; i < data.length; i += 1) {
-    if (data.charCodeAt(i) > 0x7f) {
+    const code = data.charCodeAt(i)
+    if (code > 0x7f) {
       hasNonAscii = true
-      break
+      const codePoint = data.codePointAt(i) ?? code
+      if (isRendererRiskCodePoint(codePoint)) {
+        return true
+      }
+      if (codePoint > 0xffff) {
+        i += 1
+      }
+      continue
+    }
+    if (code === 0x1b && data.charCodeAt(i + 1) === 0x5b) {
+      const parametersEnd = sgrParameterRunEnd(data, i + 2)
+      if (
+        data.charCodeAt(parametersEnd) === 0x6d &&
+        sgrRangeSetsBackground(data, i + 2, parametersEnd)
+      ) {
+        return true
+      }
+      // Deliberately resumes at i + 1: a nested ESC[ inside a run that is not an
+      // SGR sequence was found by the old global regex too.
     }
   }
   if (!hasNonAscii) {
-    // Why: Codex-style terminal redraws are usually ASCII; avoid the Unicode
-    // emoji/property regex and code-point walk on the hottest output path.
     return false
   }
-
-  if (EMOJI_PRESENTATION_PATTERN.test(data)) {
-    return true
-  }
-  for (let i = 0; i < data.length; i += 1) {
-    const codePoint = data.codePointAt(i)
-    if (codePoint === undefined) {
-      continue
-    }
-    if (isRendererRiskCodePoint(codePoint)) {
-      return true
-    }
-    if (codePoint > 0xffff) {
-      i += 1
-    }
-  }
-  return false
+  return EMOJI_PRESENTATION_PATTERN.test(data)
 }
 
 export function terminalOutputContainsEastAsianRendererRisk(data: string): boolean {

--- a/src/shared/terminal-kitty-keyboard-mode-tracker.test.ts
+++ b/src/shared/terminal-kitty-keyboard-mode-tracker.test.ts
@@ -294,4 +294,28 @@ describe('TerminalKittyKeyboardModeTracker', () => {
       expect(softReset.hasProvenBaseline).toBe(true)
     })
   })
+  describe('shared module-scope scan pattern', () => {
+    it('keeps interleaved trackers independent despite the shared /g regex', () => {
+      const first = new TerminalKittyKeyboardModeTracker()
+      const second = new TerminalKittyKeyboardModeTracker()
+      // Long leading text pushes lastIndex far past 0 on the first scan.
+      const padding = 'x'.repeat(4000)
+      first.scan(`${padding}\x1b[>1u`)
+      second.scan('\x1b[>7u')
+      first.scan('\x1b[=9;1u')
+      expect(first.flags).toBe(9)
+      expect(second.flags).toBe(7)
+    })
+
+    it('produces the same result when the same bytes are rescanned', () => {
+      const data = '\x1b[>3uhello\x1b[?1049h\x1b[=5;1u\x1b[?1049l\x1b[<u'
+      const once = new TerminalKittyKeyboardModeTracker()
+      once.scan(data)
+      const twice = new TerminalKittyKeyboardModeTracker()
+      twice.scan(data)
+      twice.scan('')
+      expect(twice.flags).toBe(once.flags)
+      expect(twice.isAlternateScreen).toBe(once.isAlternateScreen)
+    })
+  })
 })

--- a/src/shared/terminal-kitty-keyboard-mode-tracker.ts
+++ b/src/shared/terminal-kitty-keyboard-mode-tracker.ts
@@ -8,6 +8,12 @@ const KITTY_SCAN_TAIL_LIMIT = 4096
 // mirrored stacks unboundedly while the renderer's own stacks stay at 16.
 const KITTY_STACK_LIMIT = 16
 
+// Module scope so a per-write RegExp is not constructed on the hot output path.
+// Stateful (/g): every use must reset lastIndex first. Safe because the exec
+// loop below is synchronous and calls nothing that can re-enter the scanner.
+// oxlint-disable-next-line no-control-regex -- terminal escape sequences require control chars
+const KITTY_MODE_PATTERN = /\x1bc|(?:\x1b\[|\x9b)(?:!p|\?([0-9;]+)([hl])|([<>=])([0-9;]*)u)/g
+
 /** A pushed flags slot plus whether the value it will restore was ever proven. */
 type KittyStackFrame = { flags: number; known: boolean }
 
@@ -157,10 +163,9 @@ export class TerminalKittyKeyboardModeTracker {
   private scanInternal(data: string, replay: boolean): void {
     const input = this.scanTail + data
     this.scanTail = this.extractScanTail(input)
-    // oxlint-disable-next-line no-control-regex -- terminal escape sequences require control chars
-    const kittyModeRe = /\x1bc|(?:\x1b\[|\x9b)(?:!p|\?([0-9;]+)([hl])|([<>=])([0-9;]*)u)/g
+    KITTY_MODE_PATTERN.lastIndex = 0
     let match: RegExpExecArray | null
-    while ((match = kittyModeRe.exec(input)) !== null) {
+    while ((match = KITTY_MODE_PATTERN.exec(input)) !== null) {
       if (match[0] === '\x1bc') {
         // RIS resets kitty state and returns to the main screen.
         const tail = this.scanTail


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​426 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​425 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​215 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​79 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​136 |

<!-- /orca-pr-loc -->

## ELI5

Every time a terminal prints a burst of text, Orca was quietly making several throwaway copies of that burst just to check it for a handful of rare patterns — an error message that almost never appears, a keyboard-mode sequence, a pixel-size question, a "does this need a repaint" hint, and a dev-server URL. The copies were thrown away microseconds later. This PR makes four of those checks read the text where it already sits instead of copying it first, and stops the fifth (the error-message check) after the first 256 KB of output — the error it looks for can only ever be printed at startup, so scanning for it forever was pure waste. Nothing the user sees changes; there is simply a lot less garbage for the browser to collect.

## What changed

Five scanners on the PTY output path. Items 2–5 are same-semantics rewrites. Item 1 was originally a streaming rewrite of the Codex backfill detector; **that rewrite has been dropped** (it cost 40–70% more CPU and carried a pinned semantic difference) in favour of bounding the detector's lifetime, which is both faster and simpler. Details below.

### 1. Codex backfill detector — `codex-backfill-error-detector.ts`

The detector exists for #11830: a Codex pane whose managed `CODEX_HOME` has a wedged state-DB backfill hangs 30 s and then drops to a shell with an unhelpful "database appears to be damaged" message, and #12617 surfaces the real cause in the pane. That failure is still live in Codex — 0.152.1 still ships the `timed out waiting for state db backfill` string, Codex's own auto-repair does not classify it as recoverable, and upstream openai/codex#37003 is still open — so the detector stays.

What was wrong is its lifetime, not its implementation. It rebuilt an ANSI-stripped, CR-stripped, `slice(-4096)`, lowercased copy of **every chunk for the pane's whole life** (`armed` only cleared on a match that normally never happens). But Codex emits this error from `wait_for_backfill_gate` inside `state_db::try_init`, which runs *before* the TUI is initialised — it is a startup failure, printed once, and the process then exits. It cannot appear after the TUI is up.

So the original detector is kept **verbatim** and simply disarms after `CODEX_BACKFILL_SCAN_BUDGET_CHARS` (256 KB) of raw output. The budget is ~100× the largest plausible pre-TUI output (the startup warning, an `eprintln` of the error, and the CLI's diagnostic guidance), charged on raw chunk length so escape-heavy output cannot extend it.

The earlier revision of this PR rewrote the detector as a per-character ANSI/CR state machine feeding a KMP matcher. That was dropped because it cost 40–70% *more* CPU than V8's C++ `replace` and had a differential-fuzz-pinned semantic difference for escapes aborted by another ESC. Bounding the lifetime beats both: same code, same semantics for every chunk it does scan, and it stops doing the work at all.

### 2. Kitty keyboard scan — `terminal-kitty-keyboard-mode-tracker.ts`

The `/…/g` literal sat inside `scanInternal`, so a `RegExp` was constructed on every xterm write. Hoisted to module scope with `lastIndex = 0` before use, matching the existing in-repo pattern (which is in `terminal-complex-script.ts` — at `containsBackgroundSgr`, not line 102-104).

Honest note on the reset: the `exec` loop always runs to `null`, and V8 resets `lastIndex` to 0 on a failed `exec`, so no test can distinguish having the reset from not having it. It is kept because a module-scope `/g` regex is stateful and any future early exit from that loop would strand `lastIndex`. What *is* tested is the reentrancy concern a reader would actually have: two interleaved trackers stay independent, and rescanning the same bytes gives the same result.

### 3. Pixel-size CSI scan — `terminal-capability-replies.ts`

`input.slice(queryIndex, queryIndex + 5)` inside a loop that advances by 2 over every `ESC[`. Replaced with `charCodeAt` comparisons. A query truncated at the end of the buffer yields `NaN`, which matches neither form — the same outcome the short slice produced.

### 4. Foreground render-refresh classifier — `terminal-complex-script.ts`, `fresh-spawn-follow-reset.ts`

`terminalOutputPrefersRenderRefresh` is an OR of independent predicates, so the background-SGR regex pass, the non-ASCII gate and the renderer-risk code-point cascade now share one walk; the emoji-property regex still runs last and still only for chunks that contain non-ASCII. This is safe because no ASCII code point has `Emoji_Presentation` (verified over U+0000–U+007F) and every renderer-risk range starts above U+007F, so the non-ASCII gate was only ever a performance early-out. The SGR parameter check was also rewritten over index ranges, so `split(';')`/`split(':')` no longer allocate per sequence.

**Correction to the original description:** the caller could not "pass the already-computed `containsNonAsciiOutput(scanData)` result", because `(scanData.includes('\x1b[') || session.containsNonAsciiOutput(scanData))` short-circuits — for agent output the `includes` is true and `containsNonAsciiOutput` never runs. That pre-gate is now removed entirely instead: the single-pass classifier already returns `false` for a chunk with neither `ESC [` nor a non-ASCII code unit, so the gate could only add scans of its own.

### 5. Main-process advertised-URL ingest — `advertised-url-parsing.ts`

`mayContainHttpUrl` only required h/t/p plus `:` and `/` anywhere, which `[INFO] wrote output path: /tmp/x` satisfies, so `stripTerminalControls` (seven regex passes) plus `extractUrlCandidates` ran in the **main process** for panes that will never print a URL. The gate now also requires a scheme separator.

**The "`://` cannot be synthesized" claim is false — verified, and the naive fix was not taken.** Measured against the real stripper:

```
"https:<ESC>[0m//host:3000/"      ->  "https://host:3000/"     ← ANSI SGR between ':' and '//'
"https:<ESC>]0;t<BEL>//host/"    ->  "https://host/"          ← OSC between them
"https:<0x01>//host/"              ->  "https://host/"          ← bare control byte
"https:<ESC>[1;5H//host/"         ->  "https:[//host/"         ← cursor move is REPLACED, not deleted
```

So the pre-scan tolerates exactly the spans stripping deletes — control bytes (minus TAB/LF/CR, which survive as text and would break a URL match anyway) and escape sequences, including an OSC whose terminator never arrives, where only the `ESC ]` introducer is removed. It errs towards keeping a candidate; over-approximating costs the old path, never a missed URL. A 3000-case randomized test asserts the invariant directly: whenever the ungated `strip → extract` pipeline finds URLs, ingest returns the same ones.

## Tests

Each item has a differential test that runs the *previous* implementation as an oracle over a realistic corpus and asserts identical results, including chunk-boundary splits (the failure mode for all five):

| Item | Oracle | Corpus |
| --- | --- | --- |
| 1 | the implementation is the previous detector; only the disarm is new | signature inside the budget still fires; signature after the budget is ignored; escape-heavy output is charged at raw length |
| 2 | — | interleaved trackers with a 4000-char lead-in; rescan stability |
| 3 | previous `slice`-and-compare scan | `CSI <n> t` for n = 0..40; every truncation; every single-point split of an agent-like corpus |
| 4 | previous multi-pass classifier verbatim | 38-sample corpus (ASCII, box drawing, braille, powerline, emoji, ZWJ, variation selectors, CJK, Hangul, Hebrew, Arabic, lone surrogate, astral, background SGR in every form) + 600 random concatenations + 4000 random SGR parameter runs |
| 5 | ungated `strip → extract` | escape-split URLs; 3000 randomized fragment assemblies |

The fuzz in item 4 found one real divergence during development, fixed above. An independent 500 000-case xorshift fuzz (the in-tree LCG has a period of 10 466, so its "4000 random" cases are ~40% duplicates) found no further divergence in item 4, and a 200 000-case byte-level fuzz found none in item 5.

**Two findings that outlive this PR.** (a) Item 4's original corpus was incomplete, not merely passing: three single-token mutants survived it, and each is a real behaviour change — `38;2` skip width 4→3 makes `ESC[38;2;1;2;44m` classify as a background colour (a user-visible wrong repaint decision), removing the `38:` colon guard makes `ESC[38:5:1;44m` *stop* classifying as one, and astral advance `> 0xffff` → `> 0xfffff` makes `math bold 𝐀` force a refresh. All three are now pinned by explicit corpus entries. (b) The in-tree LCG (`seed * 1103515245 + 12345 & 0x7fffffff`, also used by other tests in this repo) has a period of 10 466, so any "N random cases" test built on it repeats after ~10k draws — the "3000/4000 random" cases here were ~40% duplicates. The independent fuzzes below used xorshift.

**Mutation check** — the tests bite. Independently re-run: 19 single-token mutations across the five files. Three item-4 mutants survived the original corpus (`38;2` skip width 4→3, the `38:` colon guard removed, astral advance `> 0xffff` → `> 0xfffff`); each is a real behaviour change (e.g. `ESC[38;2;1;2;44m` flips to "background", `math bold 𝐀` flips to "refresh") and each is now pinned by an explicit corpus entry. The three item-1 budget mutations (never disarm; charge normalized instead of raw length; halve the budget) each fail at least one test. `lastIndex = 0` → `= 1` in item 2 fails 17 tests. The `lastIndex` *removal* still cannot be caught — see the note in item 2.

## Measurements

Self-contained before/after microbenchmark. Corpus: 150 distinct ~16 KB chunks of synthetic agent output (SGR colour runs, cursor moves, erase-line, OSC titles, spinners, box drawing, CJK, prose, file paths), replayed as **5 panes × 30 chunks/s × 10 s = 1500 chunks ≈ 23.5 MB**.

**Time** — best of 15 interleaved runs, Node 24 (`best of`, not median: this host is running ~10 agents in parallel, so the fastest observed run is the least polluted). Three independent invocations agreed on every sign and rough magnitude.

| Scanner | before | after | |
| --- | --- | --- | --- |
| 1. Codex backfill detector | 65–67 ms | 3.3 ms | **~95% faster** (scans 80 of 1500 chunks, then stops) |
| 2. Kitty keyboard scan | 16.4–16.8 ms | 16.1–16.9 ms | unchanged (within noise) |
| 3. Pixel-size CSI scan | 27–55 ms | 15–37 ms | 33–45% faster |
| 4. Render-refresh classifier | 188–590 ms | 2.4–2.5 ms | **>98% faster** |
| 5. Advertised-URL ingest (main) | 32–36 ms | 0.8 ms | **~98% faster** |

The "before" spread is host contention; note how stable "after" is — the new code does far less work, so it is far less sensitive to load.

**Allocation** — GC-timing methods were unusable on this host (the young generation could not be made large enough to keep a measurement window GC-free, and the inspector heap sampler under-reported by ~1000×), so allocation is counted **deterministically**: each implementation is instrumented to sum the length of every intermediate string and object it materializes, at 2 bytes/char (the corpus is two-byte).

| Scanner | before | after | |
| --- | --- | --- | --- |
| 1. Codex backfill detector | 147.6 MB | 7.9 MB | −95% (first 256 KB per pane only) |
| 2. Kitty keyboard scan | 0.08 MB (one RegExp/write) | 0 | −100% |
| 3. Pixel-size CSI scan | 7.2 MB (4.9 KB/chunk) | 0 | −100% |
| 4. Render-refresh classifier | 148.3 MB (101.3 KB/chunk) | 0 | −100% |
| 5. Advertised-URL ingest (main) | 72.8 MB (49.7 KB/chunk) | 0 | −100% |
| **total** | **~376 MB over 10 s** | **~7.9 MB** | **~37 MB/s removed** |

So the headline: **~37 MB/s of renderer and main-process garbage removed** at a 5-pane 30 Hz agent-output load, ~14 MB/s of it in the main process where a GC pause stalls IPC for every window. (Item 1's numbers were re-measured on the bounded detector with the same corpus shape; the other rows are the original measurements.)

## Negative user-facing trade-offs

**None — this PR is now a free win.** The earlier revision carried two costs, both in item 1: a 40–70% CPU regression (a per-character state machine cannot beat V8's C++ `replace`) and a pinned semantic difference for escapes aborted mid-sequence by another ESC. Dropping that rewrite in favour of bounding the detector's lifetime removes both: no scanner on the hot path changed, every chunk that is scanned is scanned by the original code, and CPU and allocation both improve. Per item:

1. **Codex backfill detector** — the scanner is unchanged; it now stops after 256 KB of output. The only behaviour difference is that a signature arriving *after* 256 KB of prior output is no longer detected. Codex cannot produce that (the error is emitted before the TUI initialises and the process exits), so no real detection is lost; the residual is a pane whose shell printed >256 KB *before* the user ran `codex` by hand in it, which was never the launch path this guards.
2. **Kitty keyboard scan** — identical matching; a module-scope `/g` regex is stateful, so `lastIndex` is reset before every use, and interleaved-tracker independence is tested. No measurable CPU change either way.
3. **Pixel-size CSI scan** — byte-identical matching including truncation, pinned across `n = 0..40` and every chunk split. Faster and allocation-free.
4. **Render-refresh classifier** — classification is byte-identical over the pinned corpus plus 4600 randomized cases. Removing the caller's pre-gate is provably equivalent (the gate returning false implies the classifier returns false). No repaint decision changes, so no visual behaviour changes.
5. **Advertised-URL ingest** — the gate is a strict over-approximation of "could survive stripping", asserted directly against the ungated pipeline over 3000 randomized cases. A URL whose scheme separator is split by an ANSI escape, an OSC, or a bare control byte is still found. The gate can still admit lines with no URL; that costs the old path, which is the status quo.

## Reliability contract

- **Invariant:** `terminal-output.byte-path-transparency` — the observers on the PTY output path stay pure readers. No item changes what is written to xterm, in what order, or how much: delivery ordering, ACK/backpressure credit, dropped-output sentinels, scrollback and hidden-pane restore are untouched. The only behaviour any of these five functions has is its own return value, and every return value is pinned against the previous implementation.
- **Failure source:** ~39 MB/s of short-lived allocation on the renderer output path at a normal 5-pane agent load, plus per-chunk regex work in the main process for panes that never print a URL.
- **Oracle:** differential tests running the previous implementation as the reference over realistic corpora with chunk-boundary splits (including splits inside escape sequences), not shape assertions. Proven to bite by 5 single-token mutations → 12 failures.
- **Gate:** no `config/reliability-gates.jsonc` entry covers pure output-path scanners; the differential suites above are the gate. No new gate proposed — none of these functions has an observable side effect for a Playwright oracle to see.
- **Provider/platform coverage:** unaffected across the matrix. Items 1–4 are renderer-side pure functions of the byte stream, identical for local PTY, daemon, SSH, WSL, relay and mobile. Item 2 is also used by the daemon serializer; its output (`snapshotFlags`) is unchanged. Item 5 is main-process-only and platform-independent (no paths, no processes). No wire format, RPC parameter, stream opcode or published content changes, so no remote capability negotiation is needed.
- **Performance budget:** no polling, timers, wake loops, subprocess spawns or startup awaits added. Work is strictly removed; the one CPU regression is measured and stated above.
- **Diagnostics:** unchanged — none of these paths logs, and none gained state that could go stale (item 1 adds one monotonic counter that only ever disarms the scan).
- **Residual gaps:** (a) item 1 no longer detects a signature after 256 KB of prior pane output — unreachable from Codex's own startup path, documented above; (b) item 2's `lastIndex` reset is defensive and cannot be covered by a test today; (c) timings were taken on a heavily loaded host — signs and magnitudes are reproducible, exact milliseconds are not.

## Verification

- `pnpm tc` — clean.
- `npx oxlint` and `oxfmt --check` on the changed files — clean.
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane src/shared src/main/runtime src/main/ports src/renderer/src/lib/pane-manager` — 1660 files, 17674 passed, 0 failed.


