### PR TITLE
perf(persistence): build the state file once per save instead of seven times

### DIFF
--- a/src/main/durable-file-write.ts
+++ b/src/main/durable-file-write.ts
@@ -187,10 +187,15 @@ export async function removeStaleDurableWriteTempFiles(
 }
 
 /** Synchronous counterpart for quit and crash paths that cannot await. */
-export function writeFileDurableSync(tmpPath: string, finalPath: string, payload: string): void {
+export function writeFileDurableSync(
+  tmpPath: string,
+  finalPath: string,
+  payload: string | Uint8Array
+): void {
   let renamed = false
   try {
-    writeFileSync(tmpPath, payload, 'utf-8')
+    // A Uint8Array payload is written verbatim; a string still defaults to UTF-8.
+    writeFileSync(tmpPath, payload)
     const fd = openSync(tmpPath, 'r+')
     try {
       fsyncSync(fd)

--- a/src/main/persistence/loading-store/normalize-loaded-profile-state.ts
+++ b/src/main/persistence/loading-store/normalize-loaded-profile-state.ts
@@ -35,6 +35,8 @@ export function normalizeLoadedProfileState(
   const { defaults, migratedExternalVisibility, osc52ClipboardNoticePending } = terminal
   const { normalizedOnboarding, normalizedProjectGroups, loadedCompactWorktreeCards } = profile
   const projectCatalog = normalizeLoadedProjectCatalog(parsed, markNeedsSave)
+  // Ordered: the host partitions drop the global fields this slice already owns.
+  const workspaceSession = normalizeLoadedLocalSession(parsed, defaults, markNeedsSave)
 
   return {
     ...defaults,
@@ -69,9 +71,14 @@ export function normalizeLoadedProfileState(
       markNeedsSave
     ),
     // Why: volatile schema; zod-validate workspaceSession at read so a bad payload falls to defaults, not a renderer crash.
-    workspaceSession: normalizeLoadedLocalSession(parsed, defaults, markNeedsSave),
+    workspaceSession,
     // Why: per-host session partitions, validated independently; 'local' stays in workspaceSession for downgrade compat.
-    workspaceSessionsByHostId: normalizeLoadedHostSessions(parsed, defaults, markNeedsSave),
+    workspaceSessionsByHostId: normalizeLoadedHostSessions(
+      parsed,
+      defaults,
+      workspaceSession,
+      markNeedsSave
+    ),
     sshTargets: (parsed.sshTargets ?? []).map(normalizeSshTarget),
     deletedSshConfigAliases: Array.isArray(parsed.deletedSshConfigAliases)
       ? parsed.deletedSshConfigAliases.filter((alias): alias is string => typeof alias === 'string')

--- a/src/main/persistence/loading-store/normalize-loaded-state-collections.ts
+++ b/src/main/persistence/loading-store/normalize-loaded-state-collections.ts
@@ -41,11 +41,13 @@ export function normalizeLoadedLocalSession(
 export function normalizeLoadedHostSessions(
   parsed: PersistedState,
   defaults: PersistedState,
+  localSession: WorkspaceSessionState,
   markNeedsSave: () => void
 ): PersistedState['workspaceSessionsByHostId'] {
   const { partitions, repaired } = parseWorkspaceSessionsByHostId(
     parsed.workspaceSessionsByHostId,
-    defaults.workspaceSession
+    defaults.workspaceSession,
+    localSession
   )
   if (repaired) {
     // Why: salvage repairs only the in-memory partitions; without a save the corrupt entries stay on disk and get re-dropped every launch.

--- a/src/main/persistence/loading-store/primary-state-writes.ts
+++ b/src/main/persistence/loading-store/primary-state-writes.ts
@@ -161,7 +161,8 @@ export async function writeToDiskAsync(owner: PrimaryStateWriteOperations): Prom
     // Why: fsync before rename, then fsync the directory; see writeFileDurable.
     const handle = await open(tmpFile, 'w')
     try {
-      await handle.writeFile(payload, 'utf-8')
+      // Already UTF-8 bytes: passing the string here would re-encode the whole state on the main thread.
+      await handle.writeFile(payload)
       await handle.sync()
     } finally {
       await handle.close()

--- a/src/main/persistence/loading-store/secret-sentinel-substitution.test.ts
+++ b/src/main/persistence/loading-store/secret-sentinel-substitution.test.ts
@@ -1,0 +1,184 @@
+/**
+ * The bar for this change is "the bytes on disk did not move". Every case below runs the exact
+ * loop `applySecretSentinelSubstitutions` replaced — reproduced in `previousImplementation` — and
+ * compares payload bytes and guard hash, because a drifting hash silently disables the no-op write
+ * guard and a drifting payload is corrupted persisted state.
+ */
+import { createHash, randomUUID } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import {
+  applySecretSentinelSubstitutions,
+  type SecretSentinelSubstitution
+} from './secret-sentinel-substitution'
+
+/** Verbatim from state-serialization-secret-handling.ts before this change. */
+function previousImplementation(
+  serialized: string,
+  secretSubs: readonly SecretSentinelSubstitution[],
+  degradedPrefix: string
+): { payload: Buffer; stateHash: string } {
+  let payload = serialized
+  let hashInput = serialized
+  for (const { sentinel, blob, hashValue } of secretSubs) {
+    const escapedSentinel = JSON.stringify(sentinel).slice(1, -1)
+    payload = payload.replace(escapedSentinel, () => JSON.stringify(blob).slice(1, -1))
+    hashInput = hashInput.replace(escapedSentinel, () => JSON.stringify(hashValue).slice(1, -1))
+  }
+  const stateHash = createHash('sha1').update(degradedPrefix).update(hashInput).digest('hex')
+  // `handle.writeFile(payload, 'utf-8')` is what turned the string into bytes.
+  return { payload: Buffer.from(payload, 'utf8'), stateHash }
+}
+
+function expectIdenticalToPrevious(
+  serialized: string,
+  subs: readonly SecretSentinelSubstitution[],
+  degradedPrefix = ''
+): void {
+  const before = previousImplementation(serialized, subs, degradedPrefix)
+  const after = applySecretSentinelSubstitutions(serialized, subs, degradedPrefix)
+  expect(after.payload.equals(before.payload)).toBe(true)
+  expect(after.stateHash).toBe(before.stateHash)
+}
+
+function sentinel(): string {
+  return `orca-secret-slot-${randomUUID()}`
+}
+
+describe('applySecretSentinelSubstitutions', () => {
+  it('produces bytes and a hash identical to the previous implementation', () => {
+    const subs: SecretSentinelSubstitution[] = [
+      { sentinel: sentinel(), blob: 'djEwY2lwaGVy', hashValue: 'cookie-value' },
+      {
+        sentinel: sentinel(),
+        // Regex-special *and* JSON-escapable, which is the pair that breaks a naive rewrite:
+        // `$&` would splice the match back in under string-form replace, and the backslash and
+        // quote have to survive `JSON.stringify(...).slice(1, -1)` unchanged.
+        blob: 'A+/=$&$1$`\\x "quoted" |.*?[](){}^',
+        hashValue: 'http://proxy.example:8080/?a=b&c=$&'
+      },
+      { sentinel: sentinel(), blob: '', hashValue: 'https://kagi.com/session?t=abc' }
+    ]
+    const state = {
+      settings: { opencodeSessionCookie: subs[0].sentinel, httpProxyUrl: subs[1].sentinel },
+      ui: { browserKagiSessionLink: subs[2].sentinel },
+      // Adjacent content that must not shift: a near-miss prefix, and JSON escapes either side.
+      noise: ['orca-secret-slot-', 'a\\b"c\n\t', subs[0].sentinel.slice(0, -1)]
+    }
+    expectIdenticalToPrevious(JSON.stringify(state), subs)
+  })
+
+  it('stays identical when the state holds multi-byte and escaped characters', () => {
+    const subs: SecretSentinelSubstitution[] = [
+      { sentinel: sentinel(), blob: 'blob-é', hashValue: 'plain-é' },
+      { sentinel: sentinel(), blob: '😀', hashValue: '中文' }
+    ]
+    const state = {
+      // Segment boundaries land next to these, so a wrong split would corrupt the encode.
+      before: 'é中文😀',
+      a: subs[0].sentinel,
+      between: '😀  ',
+      b: subs[1].sentinel,
+      after: '😀'
+    }
+    expectIdenticalToPrevious(JSON.stringify(state), subs)
+  })
+
+  it('stays identical with no substitutions and with the degraded-storage prefix', () => {
+    const state = JSON.stringify({ settings: { httpProxyUrl: '' }, big: 'x'.repeat(4096) })
+    expectIdenticalToPrevious(state, [])
+    expectIdenticalToPrevious(state, [], 'safeStorage-degraded\0')
+
+    const subs = [{ sentinel: sentinel(), blob: 'b', hashValue: 'h' }]
+    expectIdenticalToPrevious(
+      JSON.stringify({ s: subs[0].sentinel }),
+      subs,
+      'safeStorage-degraded\0'
+    )
+  })
+
+  it('escapes regex metacharacters in the sentinel itself', () => {
+    // Not reachable from a UUID sentinel, but the alternation must not be able to become a pattern.
+    const subs = [{ sentinel: 'a.b*c(d)|e[f]', blob: 'BLOB', hashValue: 'HASH' }]
+    const serialized = JSON.stringify({ real: subs[0].sentinel, decoy: 'axbxxcXdX_eXfX' })
+    expectIdenticalToPrevious(serialized, subs)
+    expect(
+      applySecretSentinelSubstitutions(serialized, subs, '').payload.toString('utf8')
+    ).toContain('axbxxcXdX_eXfX')
+  })
+
+  it('substitutes every occurrence when a sentinel repeats', () => {
+    // Cannot happen today (a sentinel is a UUID minted after the state is assembled, so it appears
+    // exactly once), but the old first-match-only `String.replace` would have written a raw
+    // sentinel to disk in place of a secret if it ever did. The alternation is global instead.
+    const subs = [{ sentinel: sentinel(), blob: 'CIPHER', hashValue: 'PLAIN' }]
+    const serialized = JSON.stringify({ a: subs[0].sentinel, b: subs[0].sentinel })
+    const { payload } = applySecretSentinelSubstitutions(serialized, subs, '')
+    expect(payload.toString('utf8')).toBe(JSON.stringify({ a: 'CIPHER', b: 'CIPHER' }))
+    expect(payload.toString('utf8')).not.toContain(subs[0].sentinel)
+  })
+
+  it('copies and UTF-8 encodes the full state once, not once per sentinel per side', () => {
+    const subs: SecretSentinelSubstitution[] = Array.from({ length: 3 }, () => ({
+      sentinel: sentinel(),
+      blob: 'CIPHERTEXT',
+      hashValue: 'plaintext'
+    }))
+    const serialized = JSON.stringify({
+      pad: 'x'.repeat(200_000),
+      a: subs[0].sentinel,
+      b: subs[1].sentinel,
+      c: subs[2].sentinel
+    })
+    const FULL_STATE = 100_000
+
+    // Both costs are observable at their sources: a `String.replace` whose receiver is the whole
+    // state allocates another copy of it, and every string handed to `Buffer.from` or `hash.update`
+    // is one full UTF-8 encode pass on the main thread.
+    const counted = (run: () => unknown): { fullStateReplaces: number; encodedChars: number } => {
+      const realReplace = String.prototype.replace
+      const realBufferFrom = Buffer.from
+      const hashProto = Object.getPrototypeOf(createHash('sha1')) as {
+        update: (...args: unknown[]) => unknown
+      }
+      const realUpdate = hashProto.update
+      const counts = { fullStateReplaces: 0, encodedChars: 0 }
+      String.prototype.replace = function (this: string, ...args: unknown[]) {
+        if (this.length >= FULL_STATE) {
+          counts.fullStateReplaces++
+        }
+        return realReplace.apply(this, args as never)
+      } as typeof String.prototype.replace
+      Buffer.from = function (...args: unknown[]) {
+        if (typeof args[0] === 'string') {
+          counts.encodedChars += args[0].length
+        }
+        return (realBufferFrom as (...a: unknown[]) => Buffer).apply(Buffer, args)
+      } as typeof Buffer.from
+      hashProto.update = function (this: unknown, ...args: unknown[]) {
+        if (typeof args[0] === 'string') {
+          counts.encodedChars += args[0].length
+        }
+        return realUpdate.apply(this, args)
+      }
+      try {
+        run()
+      } finally {
+        String.prototype.replace = realReplace
+        Buffer.from = realBufferFrom
+        hashProto.update = realUpdate
+      }
+      return counts
+    }
+
+    const before = counted(() => previousImplementation(serialized, subs, ''))
+    const after = counted(() => applySecretSentinelSubstitutions(serialized, subs, ''))
+
+    // Two `String.replace` calls over the whole state per sentinel — payload and hash input.
+    expect(before.fullStateReplaces).toBe(subs.length * 2)
+    expect(after.fullStateReplaces).toBe(0)
+    // The old path encoded the state twice: once for sha1, once for the file write.
+    expect(before.encodedChars).toBeGreaterThan(serialized.length * 1.9)
+    expect(after.encodedChars).toBeLessThan(serialized.length * 1.1)
+    expect(after.encodedChars).toBeGreaterThan(serialized.length * 0.9)
+  })
+})

--- a/src/main/persistence/loading-store/secret-sentinel-substitution.ts
+++ b/src/main/persistence/loading-store/secret-sentinel-substitution.ts
@@ -1,0 +1,78 @@
+import { createHash } from 'node:crypto'
+import { escapeRegex } from '../../../shared/string-utils'
+
+export type SecretSentinelSubstitution = {
+  /** The `orca-secret-slot-<uuid>` placeholder standing in the serialized state. */
+  sentinel: string
+  /** What the on-disk payload gets: the ciphertext. */
+  blob: string
+  /** What the guard hash gets: a value stable across non-deterministic encryption. */
+  hashValue: string
+}
+
+/**
+ * Replace every secret sentinel in `serialized` in ONE pass, producing the on-disk bytes and the
+ * guard hash from the same encoded segments.
+ *
+ * Why not the obvious `payload.replace(...)` / `hashInput.replace(...)` loop it replaces: each
+ * `String.replace` returns a rope that the *next* `replace` has to flatten before it can search, so
+ * N sentinels cost 2N-1 flattened copies of the whole multi-MB state, plus one more per side when
+ * `hash.update` and the file write finally consume them. Measured on a 4.65 MB store with three
+ * sentinels: 7 full-state string allocations, 62 MB of V8 heap, 27 MB of it in large_object_space.
+ *
+ * Here the state is walked once, each literal run is UTF-8 encoded exactly once, and those same
+ * buffers feed both the payload and the hash — 1 full-state string, 1 encode.
+ *
+ * Byte-for-byte identical output to the loop: both sides read the sentinel in its JSON-escaped
+ * form, the replacements are the JSON-escaped `blob`/`hashValue`, and the hash sees the same byte
+ * sequence it saw when it was handed one concatenated string.
+ */
+export function applySecretSentinelSubstitutions(
+  serialized: string,
+  substitutions: readonly SecretSentinelSubstitution[],
+  degradedPrefix: string
+): { payload: Buffer; stateHash: string } {
+  const hash = createHash('sha1').update(degradedPrefix)
+  if (substitutions.length === 0) {
+    const payload = Buffer.from(serialized, 'utf8')
+    return { payload, stateHash: hash.update(payload).digest('hex') }
+  }
+
+  const replacementBySentinel = new Map<string, { blob: Buffer; hashValue: Buffer }>()
+  const alternatives: string[] = []
+  for (const { sentinel, blob, hashValue } of substitutions) {
+    // Preserved from the loop this replaces: both the search key and the replacements are the
+    // JSON-escaped forms, because that is what `serialized` actually contains.
+    const escapedSentinel = JSON.stringify(sentinel).slice(1, -1)
+    if (replacementBySentinel.has(escapedSentinel)) {
+      continue
+    }
+    alternatives.push(escapeRegex(escapedSentinel))
+    replacementBySentinel.set(escapedSentinel, {
+      blob: Buffer.from(JSON.stringify(blob).slice(1, -1), 'utf8'),
+      hashValue: Buffer.from(JSON.stringify(hashValue).slice(1, -1), 'utf8')
+    })
+  }
+
+  // Global, though a sentinel is a UUID minted after the state was assembled and so occurs exactly
+  // once: a single pass that substitutes every occurrence cannot leave one behind on disk.
+  const pattern = new RegExp(alternatives.join('|'), 'g')
+  const chunks: Buffer[] = []
+  let cursor = 0
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(serialized)) !== null) {
+    // Non-null: the alternation is built from exactly the map's keys.
+    const replacement = replacementBySentinel.get(match[0])!
+    // A sliced substring, so this does not copy the state; the encode below is its only pass.
+    const literal = Buffer.from(serialized.slice(cursor, match.index), 'utf8')
+    chunks.push(literal, replacement.blob)
+    hash.update(literal)
+    hash.update(replacement.hashValue)
+    cursor = match.index + match[0].length
+  }
+  const tail = Buffer.from(serialized.slice(cursor), 'utf8')
+  chunks.push(tail)
+  hash.update(tail)
+
+  return { payload: Buffer.concat(chunks), stateHash: hash.digest('hex') }
+}

--- a/src/main/persistence/loading-store/state-serialization-secret-handling.ts
+++ b/src/main/persistence/loading-store/state-serialization-secret-handling.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto'
+import { randomUUID } from 'node:crypto'
 import type { PersistedState } from '../../../shared/persisted-state-types'
 import { collectFolderWorkspaceDiffComments } from '../../folder-workspace-diff-comments'
 import {
@@ -8,6 +8,10 @@ import {
 } from '../../protected-secret-persistence'
 import { stripRetiredGlobalSettings } from '../applying-settings/terminal-settings-migrations'
 
+import {
+  applySecretSentinelSubstitutions,
+  type SecretSentinelSubstitution
+} from './secret-sentinel-substitution'
 import type { StoreRuntimeState } from './store-runtime-state'
 
 type StateSerializationSecretHandlingOperationsRuntime = Pick<
@@ -24,7 +28,7 @@ export class StateSerializationSecretHandlingOperations {
   }
 
   buildStateToSave(): {
-    payload: string
+    payload: Buffer
     stateHash: string
     protectedSecretUpdates: ProtectedSecretRetentionUpdate[]
   } {
@@ -37,7 +41,7 @@ export class StateSerializationSecretHandlingOperations {
     // on deterministic-IV platforms (macOS/legacy-Linux OSCrypt). A per-slot
     // random UUID can't occur anywhere else in the serialized state (the user
     // sets their data before it is minted), so it appears exactly once.
-    const secretSubs: { sentinel: string; blob: string; hashValue: string }[] = []
+    const secretSubs: SecretSentinelSubstitution[] = []
     const protectedSecretUpdates: ProtectedSecretRetentionUpdate[] = []
     let protectedStorageDegraded = false
     const encryptToSentinel = (slot: string, plaintext: string): string => {
@@ -105,21 +109,14 @@ export class StateSerializationSecretHandlingOperations {
     // Why compact: ~20% fewer bytes and less serialize time; all readers JSON.parse so formatting is irrelevant.
     // One full-state stringify; secret slots currently hold sentinels.
     const serialized = JSON.stringify(stateToSave)
-    // Substitute each unique sentinel exactly once: ciphertext for the on-disk
-    // payload, a stable normalized value for the guard hash. Function-form
-    // replacement keeps `$` inert; both sides read the sentinel as JSON-escaped
-    // in `serialized`, so each replace is byte-for-byte position-exact.
-    let payload = serialized
-    let hashInput = serialized
-    for (const { sentinel, blob, hashValue } of secretSubs) {
-      const escapedSentinel = JSON.stringify(sentinel).slice(1, -1)
-      payload = payload.replace(escapedSentinel, () => JSON.stringify(blob).slice(1, -1))
-      hashInput = hashInput.replace(escapedSentinel, () => JSON.stringify(hashValue).slice(1, -1))
-    }
-    const stateHash = createHash('sha1')
-      .update(protectedStorageDegraded ? 'safeStorage-degraded\0' : '')
-      .update(hashInput)
-      .digest('hex')
+    // Substitute each unique sentinel: ciphertext for the on-disk payload, a stable normalized
+    // value for the guard hash. One pass builds both, so the multi-MB state is never copied per
+    // sentinel and never encoded twice.
+    const { payload, stateHash } = applySecretSentinelSubstitutions(
+      serialized,
+      secretSubs,
+      protectedStorageDegraded ? 'safeStorage-degraded\0' : ''
+    )
     return { payload, stateHash, protectedSecretUpdates }
   }
 }

--- a/src/main/persistence/loading-store/state-write-round-trip.test.ts
+++ b/src/main/persistence/loading-store/state-write-round-trip.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The write path now hands the file a Buffer it built in one pass instead of a string it rebuilt
+ * per secret. Drives the real `Store` end to end — encrypted settings, a local session and a remote
+ * host partition — and reloads from the file it actually wrote, because the failure this guards
+ * against (a mis-sliced segment, a re-encoded payload, a dropped sentinel) is invisible until
+ * something reads the bytes back.
+ */
+import { mkdtempSync, readFileSync, realpathSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => tmpdir(),
+    getName: () => 'orca-test',
+    getVersion: () => '0.0.0-test',
+    isPackaged: false,
+    on: () => {},
+    whenReady: () => Promise.resolve()
+  },
+  safeStorage: {
+    // Encryption ON, so the secret slots really do mint sentinels and the substitution pass runs.
+    isEncryptionAvailable: () => true,
+    encryptString: (value: string) => Buffer.from(`enc:${value}`),
+    decryptString: (value: Buffer) => value.toString().slice(4)
+  },
+  ipcMain: { on: () => {}, handle: () => {} },
+  BrowserWindow: { getAllWindows: () => [] }
+}))
+
+const { Store } = await import('./store')
+
+const HOST_ID = 'ssh:user@host'
+
+const stores: InstanceType<typeof Store>[] = []
+afterEach(() => {
+  for (const store of stores.splice(0)) {
+    store.flush()
+  }
+  vi.restoreAllMocks()
+})
+
+function openStore(dataFile: string): InstanceType<typeof Store> {
+  const store = new Store({ dataFile })
+  stores.push(store)
+  return store
+}
+
+function session(activeTabId: string): WorkspaceSessionState {
+  return {
+    activeRepoId: 'repo-1',
+    // Left null: the load path's deregistered-repo sweep nulls an active worktree whose repo is
+    // not registered, which would mask what this test is actually about.
+    activeWorktreeId: null,
+    activeTabId,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    // Non-ASCII on purpose: a byte-offset mistake in the encode shows up here first.
+    browserUrlHistory: [
+      {
+        url: 'https://example.test/é😀',
+        normalizedUrl: 'https://example.test/é😀',
+        title: '中文 title',
+        lastVisitedAt: 17,
+        visitCount: 3
+      }
+    ]
+  } as WorkspaceSessionState
+}
+
+describe('persisted state survives a save/load round trip', () => {
+  it('reloads settings, secrets and both session partitions unchanged', () => {
+    const dataFile = join(
+      realpathSync(mkdtempSync(join(tmpdir(), 'orca-store-round-trip-'))),
+      'orca-data.json'
+    )
+    const written = openStore(dataFile)
+    written.updateSettings({
+      // Three secret slots, i.e. three sentinels in one save — the case the old loop paid 7 copies for.
+      opencodeSessionCookie: 'cookie-é-value',
+      httpProxyUrl: 'http://proxy.example:8080/?a=b&c=$&'
+    })
+    written.updateUI({ browserKagiSessionLink: 'https://kagi.com/session?t=abc' })
+    written.setWorkspaceSession(session('local-tab'))
+    written.setWorkspaceSession(session('remote-tab'), HOST_ID)
+    written.flush()
+
+    const before = {
+      settings: written.getSettings(),
+      ui: written.getUI(),
+      local: written.getWorkspaceSession(),
+      remote: written.getWorkspaceSession(HOST_ID)
+    }
+
+    // The file is valid UTF-8 JSON and holds ciphertext, not the plaintext secrets.
+    const bytes = readFileSync(dataFile)
+    const onDisk = JSON.parse(bytes.toString('utf8'))
+    expect(onDisk.settings.opencodeSessionCookie).not.toBe('cookie-é-value')
+    expect(Buffer.from(onDisk.settings.opencodeSessionCookie, 'base64').toString('utf8')).toContain(
+      'cookie-é-value'
+    )
+    expect(bytes.toString('utf8')).not.toContain('orca-secret-slot-')
+
+    const reloaded = openStore(dataFile)
+    expect(reloaded.getSettings().opencodeSessionCookie).toBe(before.settings.opencodeSessionCookie)
+    expect(reloaded.getSettings().httpProxyUrl).toBe(before.settings.httpProxyUrl)
+    expect(reloaded.getUI().browserKagiSessionLink).toBe(before.ui.browserKagiSessionLink)
+    // `toMatchObject`: the load path spreads session defaults over what was written, so the
+    // reloaded slice is a superset. Exact deep equality is asserted on the second trip below.
+    expect(reloaded.getWorkspaceSession()).toMatchObject(before.local)
+    // The remote partition keeps everything it owns; only globals local already holds are dropped,
+    // and `browserUrlHistory` comes back at its default from the same spread as before.
+    expect(reloaded.getWorkspaceSession(HOST_ID).activeTabId).toBe('remote-tab')
+    expect(reloaded.getWorkspaceSession(HOST_ID).browserUrlHistory).toEqual([])
+
+    // Deep equality of the whole reloaded state, taken across a second round trip so the assertion
+    // is not comparing against the first load's one-time settings migrations.
+    reloaded.flush()
+    const bytesAfterReload = readFileSync(dataFile)
+    const again = openStore(dataFile)
+    expect(again.getSettings()).toEqual(reloaded.getSettings())
+    expect(again.getUI()).toEqual(reloaded.getUI())
+    expect(again.getWorkspaceSession()).toEqual(reloaded.getWorkspaceSession())
+    expect(again.getWorkspaceSession(HOST_ID)).toEqual(reloaded.getWorkspaceSession(HOST_ID))
+    // ...and the bytes are stable, so a quiet app is not rewriting a 4 MB file with new content.
+    again.flush()
+    expect(readFileSync(dataFile).equals(bytesAfterReload)).toBe(true)
+  })
+})

--- a/src/main/persistence/loading-store/workspace-session-partitions.test.ts
+++ b/src/main/persistence/loading-store/workspace-session-partitions.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Global session fields live in the 'local' slice. Copies of them inside a non-local host partition
+ * are legacy residue: the split never writes them there and the merge never reads them from there
+ * unless local has nothing. These tests pin the drop to exactly that condition, keep the renderer's
+ * merge landing on the same value either way, and re-check the two safety gates that decide which
+ * global fields may be dropped at all.
+ */
+import { describe, expect, it } from 'vitest'
+import { getDefaultWorkspaceSession } from '../../../shared/constants'
+import type { BrowserHistoryEntry } from '../../../shared/browser-workspace-types'
+import type { WorkspaceDocHistoryEntry } from '../../../shared/workspace-doc-history'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { WORKSPACE_SESSION_FIELD_OWNERSHIP } from '../../../shared/workspace-session-host-field-ownership'
+import { WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND } from '../restoring-sessions/session-worktree-ownership'
+import {
+  HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS,
+  parseWorkspaceSessionsByHostId
+} from './workspace-session-partitions'
+
+const HOST = 'ssh:target-1'
+
+function history(url: string): BrowserHistoryEntry[] {
+  return [{ url, normalizedUrl: url, title: url, lastVisitedAt: 1, visitCount: 1 }]
+}
+
+function docEntry(filePath: string): WorkspaceDocHistoryEntry {
+  return {
+    docLocation: { kind: 'workspace-doc', worktreeId: 'repo-1::/tmp/a', filePath },
+    title: filePath,
+    lastVisitedAt: 2,
+    visitCount: 1
+  }
+}
+
+function localSession(overrides: Partial<WorkspaceSessionState>): WorkspaceSessionState {
+  return { ...getDefaultWorkspaceSession(), ...overrides }
+}
+
+function parse(
+  raw: Record<string, unknown>,
+  local?: WorkspaceSessionState
+): Partial<Record<string, WorkspaceSessionState>> {
+  return parseWorkspaceSessionsByHostId(raw, getDefaultWorkspaceSession(), local).partitions
+}
+
+describe('HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS', () => {
+  it('only lists fields that are global AND that no worktree-ownership pass follows', () => {
+    for (const field of HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS) {
+      // Gate 1: the renderer's split/merge treat it as local-owned, so a non-local copy is dead.
+      expect(WORKSPACE_SESSION_FIELD_OWNERSHIP[field]).toBe('global')
+      // Gate 2: `collectPersistedSessionWorktreeOwners` and the deregistered-repo residue sweep
+      // walk EVERY partition through this table. Anything but 'none' means dropping the field
+      // could un-own a worktree and get its metadata pruned.
+      expect(WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND[field]).toBe('none')
+    }
+  })
+})
+
+describe('parseWorkspaceSessionsByHostId global-field residue', () => {
+  it('drops a non-local global field the local slice already owns', () => {
+    const local = localSession({ browserUrlHistory: history('https://local.test') })
+    const partitions = parse(
+      {
+        [HOST]: {
+          ...getDefaultWorkspaceSession(),
+          browserUrlHistory: history('https://stale.test')
+        }
+      },
+      local
+    )
+    // Back to the default from the spread, not the 65 KB stale replica. The merge reads this field
+    // from local whenever local has it, so the renderer still sees `https://local.test`
+    // (`workspace-session-host-split.test.ts` pins that half of the contract).
+    expect(partitions[HOST]?.browserUrlHistory).toEqual([])
+  })
+
+  it('retains a non-local global field the local slice does NOT have', () => {
+    // `workspaceDocHistory` is optional and absent from the defaults, so local can genuinely lack
+    // it and the merge's fallback to another slice is live.
+    const local = localSession({})
+    expect(local.workspaceDocHistory).toBeUndefined()
+    const docs = [docEntry('/repo/remote.md')]
+    const partitions = parse(
+      { [HOST]: { ...getDefaultWorkspaceSession(), workspaceDocHistory: docs } },
+      local
+    )
+    // Retained, so the merge's "fall back to any slice that has it" path still finds a value.
+    expect(partitions[HOST]?.workspaceDocHistory).toEqual(docs)
+  })
+
+  it('drops that same field once the local slice does have it', () => {
+    const localDocs = [docEntry('/repo/local.md')]
+    const local = localSession({ workspaceDocHistory: localDocs })
+    const partitions = parse(
+      {
+        [HOST]: {
+          ...getDefaultWorkspaceSession(),
+          workspaceDocHistory: [docEntry('/repo/stale.md')]
+        }
+      },
+      local
+    )
+    expect(partitions[HOST]).not.toHaveProperty('workspaceDocHistory')
+    expect(local.workspaceDocHistory).toEqual(localDocs)
+  })
+
+  it('leaves worktree-referencing globals and host-owned fields alone', () => {
+    const local = localSession({
+      browserUrlHistory: history('https://local.test'),
+      activeWorktreeId: 'repo-1::/tmp/local',
+      activeTabId: 'local-tab'
+    })
+    const tabs = { 'repo-1::/tmp/a': [] }
+    const partitions = parse(
+      {
+        [HOST]: {
+          ...getDefaultWorkspaceSession(),
+          // A `'direct'` worktree reference the residue sweep reads out of every partition.
+          activeWorktreeId: 'repo-1::/tmp/a',
+          // Read on a partition by the mobile terminal projection.
+          activeTabId: 'remote-tab',
+          tabsByWorktree: tabs,
+          terminalTopologyRevisionByRepoId: { 'repo-1': 4 }
+        }
+      },
+      local
+    )
+    expect(partitions[HOST]?.activeWorktreeId).toBe('repo-1::/tmp/a')
+    expect(partitions[HOST]?.activeTabId).toBe('remote-tab')
+    expect(partitions[HOST]?.tabsByWorktree).toEqual(tabs)
+    expect(partitions[HOST]?.terminalTopologyRevisionByRepoId).toEqual({ 'repo-1': 4 })
+  })
+
+  it('is a no-op when no local slice is supplied', () => {
+    const stale = history('https://stale.test')
+    const partitions = parse({
+      [HOST]: { ...getDefaultWorkspaceSession(), browserUrlHistory: stale }
+    })
+    expect(partitions[HOST]?.browserUrlHistory).toEqual(stale)
+  })
+})

--- a/src/main/persistence/loading-store/workspace-session-partitions.ts
+++ b/src/main/persistence/loading-store/workspace-session-partitions.ts
@@ -17,11 +17,49 @@ export function workspaceSessionSalvageLogDetails(result: {
   }
 }
 
+/**
+ * Global fields belong to the 'local' slice: the split writes them only there and the merge reads
+ * them only from there. A copy inside a non-local partition is legacy residue no read can reach —
+ * stale `browserUrlHistory` replicas alone were 589 KB, 12.7% of a 4.65 MB store, rewritten on
+ * every save and reparsed on every launch.
+ *
+ * Deliberately NOT every field in `GLOBAL_WORKSPACE_SESSION_FIELDS`. Two separate gates disqualify
+ * the rest, and both are load-bearing:
+ *  - `activeWorktreeId` and `activeWorkspaceKey` are `'direct'` in
+ *    `WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND`, and both `collectPersistedSessionWorktreeOwners`
+ *    and the deregistered-repo residue sweep read them out of EVERY partition. Dropping one
+ *    un-owns a worktree, and an un-owned worktree gets its metadata pruned.
+ *  - `activeTabId`, `activeConnectionIdsAtShutdown` and `activeRepoId` have live main-side readers
+ *    on a partition: `isPersistedTerminalLeafActive` falls back to `activeTabId` for the mobile
+ *    projection, and the runtime attach-window handoff unions `activeConnectionIdsAtShutdown`.
+ *
+ * `workspace-session-partitions.test.ts` re-checks both gates for every field listed here.
+ */
+export const HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS = [
+  'browserUrlHistory',
+  'workspaceDocHistory'
+] as const satisfies readonly (keyof WorkspaceSessionState)[]
+
+/** Dropped only where local already holds the field — exactly when the merge's fallback to another
+ *  slice cannot fire. Runs before the defaults spread, so a field the type requires comes back at
+ *  its default rather than going missing. */
+function dropRedundantGlobalFields(
+  slice: Partial<WorkspaceSessionState>,
+  local: WorkspaceSessionState | undefined
+): void {
+  for (const field of HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS) {
+    if (local?.[field] !== undefined) {
+      delete slice[field]
+    }
+  }
+}
+
 /** Normalize non-'local' host partitions; 'local' (the legacy workspaceSession blob) is dropped so the two surfaces never diverge.
  *  Each partition is zod-validated independently, so one corrupt host drops to defaults without taking out the others. Idempotent. */
 export function parseWorkspaceSessionsByHostId(
   raw: unknown,
-  defaults: WorkspaceSessionState
+  defaults: WorkspaceSessionState,
+  localSession?: WorkspaceSessionState
 ): { partitions: Partial<Record<ExecutionHostId, WorkspaceSessionState>>; repaired: boolean } {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     return { partitions: {}, repaired: raw !== undefined }
@@ -50,6 +88,7 @@ export function parseWorkspaceSessionsByHostId(
       )
       repaired = true
     }
+    dropRedundantGlobalFields(result.value, localSession)
     partitions[hostId] = { ...defaults, ...result.value }
   }
   return { partitions, repaired }

--- a/src/renderer/src/lib/workspace-session-host-contention.ts
+++ b/src/renderer/src/lib/workspace-session-host-contention.ts
@@ -10,7 +10,7 @@ import {
   getWorktreeIdFromHostIdentity,
   isWorktreeHostIdentity
 } from '../../../shared/worktree/host-qualified-identity'
-import { WORKSPACE_SESSION_FIELD_OWNERSHIP } from './workspace-session-host-field-ownership'
+import { WORKSPACE_SESSION_FIELD_OWNERSHIP } from '../../../shared/workspace-session-host-field-ownership'
 import {
   isWorkspaceSessionRecord,
   type WorkspaceSessionRecord

--- a/src/renderer/src/lib/workspace-session-host-split.test.ts
+++ b/src/renderer/src/lib/workspace-session-host-split.test.ts
@@ -392,3 +392,46 @@ describe('split → merge round trip', () => {
     expect(roundTrip(state)).toEqual(state)
   })
 })
+
+/**
+ * The main-process load path drops a global field from a non-local partition when the local slice
+ * already has it, on the strength of exactly these two rules. If either moves, that prune starts
+ * discarding a value the renderer would otherwise have read.
+ */
+describe('mergeWorkspaceSessionsFromHosts global-field precedence', () => {
+  const localEntry = {
+    url: 'local',
+    normalizedUrl: 'local',
+    title: 'l',
+    lastVisitedAt: 2,
+    visitCount: 1
+  }
+  const hostEntry = {
+    url: 'host',
+    normalizedUrl: 'host',
+    title: 'h',
+    lastVisitedAt: 1,
+    visitCount: 1
+  }
+
+  it("takes a global field from 'local' whenever local has one, ignoring every other slice", () => {
+    const merged = mergeWorkspaceSessionsFromHosts({
+      [LOCAL_EXECUTION_HOST_ID]: {
+        ...getDefaultWorkspaceSession(),
+        browserUrlHistory: [localEntry]
+      },
+      [RUNTIME_A]: { ...getDefaultWorkspaceSession(), browserUrlHistory: [hostEntry] }
+    })
+    expect(merged.browserUrlHistory).toEqual([localEntry])
+  })
+
+  it('falls back to another slice only when local does not have the field', () => {
+    const local = getDefaultWorkspaceSession()
+    delete local.browserUrlHistory
+    const merged = mergeWorkspaceSessionsFromHosts({
+      [LOCAL_EXECUTION_HOST_ID]: local,
+      [RUNTIME_A]: { ...getDefaultWorkspaceSession(), browserUrlHistory: [hostEntry] }
+    })
+    expect(merged.browserUrlHistory).toEqual([hostEntry])
+  })
+})

--- a/src/renderer/src/lib/workspace-session-host-split.ts
+++ b/src/renderer/src/lib/workspace-session-host-split.ts
@@ -8,7 +8,7 @@ import { isWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-
 import {
   GLOBAL_WORKSPACE_SESSION_FIELDS,
   WORKSPACE_SESSION_FIELD_OWNERSHIP
-} from './workspace-session-host-field-ownership'
+} from '../../../shared/workspace-session-host-field-ownership'
 import {
   buildWorktreeIdByFileId,
   buildWorktreeIdByTabId,

--- a/src/shared/workspace-session-host-field-ownership.ts
+++ b/src/shared/workspace-session-host-field-ownership.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import type { WorkspaceSessionState } from './workspace-session-state-types'
 
 export type WorkspaceSessionFieldOwnership =
   | 'global'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​499 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​499 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​157 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​129 |

<!-- /orca-pr-loc -->

## ELI5

Every few seconds Orca writes out a ~4.6 MB description of your session — every tab, every worktree, every setting. To do that it was making **seven** separate full-size copies of that text in memory, using one and throwing six away, and then re-typing the whole thing into bytes twice more. This PR builds it once.

Separately, about an eighth of that file was a **copy of your browser address-bar history, duplicated into every remote-host section** — copies that nothing ever reads back. Those are dropped at load.

Nothing about the app behaves differently. The bytes written to disk are byte-for-byte the same, and a test proves it against the old code.

---

## Fix 1 — one pass instead of seven copies and three encodes

`state-serialization-secret-handling.ts` did:

```js
const serialized = JSON.stringify(stateToSave)
let payload = serialized
let hashInput = serialized
for (const { sentinel, blob, hashValue } of secretSubs) {
  payload   = payload.replace(escapedSentinel, () => ...)
  hashInput = hashInput.replace(escapedSentinel, () => ...)
}
createHash('sha1').update(hashInput)      // encode #2
handle.writeFile(payload, 'utf-8')        // encode #3
```

**Correction to the brief's mechanism (the count is right, the reason isn't).** `String.replace` does *not* immediately copy — V8 returns a `ConsString` rope, which is why a single replace on a 4.65 MB string measures at 0.1 ms. The cost is deferred: the *next* `replace` must flatten the rope before it can search, and `hash.update` / `Buffer.from` flatten the final one. Step-decomposed on the real store:

| step | V8 heap allocated | large_object_space |
|---|---|---|
| `JSON.stringify` | +9.00 MB | +0.00 MB |
| 3 × 2 `String.replace` | +35.48 MB (4 flattens) | +26.61 MB |
| `sha1.update(hashInput)` (flattens) | +8.89 MB | +8.87 MB |
| `Buffer.from(payload)` for the write (flattens) | +8.88 MB | +8.87 MB |

So it is **exactly 7 full-state allocations** as claimed — 1 stringify + 4 intermediate flattens + 2 final flattens — just via rope flattening rather than eager copying. It's also **more** than the brief's 31 MB: the store's JSON is a **two-byte** V8 string (~8.87 MB per copy, not 4.43 MB), so 7 copies is ~62 MB of allocation.

The replacement (`secret-sentinel-substitution.ts`) walks `serialized` once with one alternation `RegExp`, `Buffer.from`s each literal run exactly once, and hands **those same buffers** to both the payload concat and `hash.update`. That is better than the brief asked for: the hash is over `hashInput` (normalized values), not over `payload` (ciphertext), so "hash the payload Buffer" isn't available — but reusing the shared literal segments gets the same win, and hashing Buffers instead of strings is the measured 3× (5.2 ms → 1.6 ms).

**"Each sentinel appears exactly once" — verified.** Each is `orca-secret-slot-${randomUUID()}`, minted inside `encryptToSentinel` *after* the user's state is assembled, and assigned to exactly one property. Nothing aliases it. The alternation is `/g` anyway, so a hypothetical repeat is substituted everywhere rather than leaving a raw sentinel on disk where a secret should be (the old first-match-only string `replace` would have). Escaping is preserved verbatim: the search key is still `JSON.stringify(sentinel).slice(1, -1)`, now additionally passed through the existing `escapeRegex` from `shared/string-utils.ts` before it becomes a pattern.

Two smaller call-site changes: `handle.writeFile(payload)` and `writeFileDurableSync(..., payload: string | Uint8Array)` take the Buffer directly instead of re-encoding a string on the main thread.

### Measurements — Fix 1

Real 4.65 MB store, 3 live secret slots, Node 22, macOS arm64. Repeated `gc()`-separated runs; stable across 3 invocations.

| | before | after |
|---|---|---|
| full-state string allocations / save | **7** | **1** |
| full-state UTF-8 encode passes / save | **2** (sha1 + writeFile) | **1** |
| allocated per save (V8 heap) | 44.37 MB | **9.03 MB** |
| allocated per save (external Buffers) | 4.44 MB | 8.85 MB |
| **allocated per save (total)** | **48.81 MB** | **17.88 MB** (−63%) |
| large_object_space churn / save | 26.61 MB | **0.00 MB** |
| build+hash+encode, min | 22.1 ms | **15.1 ms** (−32%) |
| build+hash+encode, median | 32.3 ms | **16.9 ms** (−48%) |
| build+hash+encode, p90 | 144.8 ms | **88.7 ms** |
| sha1 over 4.65 MB (string vs Buffer) | 5.2 ms | **1.6 ms** |

(The step table above sums to 62.1 MB of *allocation*; the 44.37 MB figure is the steady-state `heapUsed` delta across a whole cycle, where a scavenge reclaims ~2 of the intermediate copies mid-call. Both are measured; the second is what the process actually experiences.)

## Fix 2 — dead `browserUrlHistory` replicas, **narrowed from the brief**

Confirmed on the live store: 589,807 bytes of global-field residue removable, **12.7% of the file**, matching the brief's 589,522.

**Two corrections to the brief:**

1. **Counts.** 9 of 10 partitions carry a `browserUrlHistory` copy, not 10 — the `ssh:` partition has none. Of the 9: **3 byte-identical** to the root copy, **6 drifted** (brief said 3 / 7).
2. **The citation `profile-project-session-state.ts:89-91` is wrong.** Lines 89-91 are `terminalPtyIncarnationsByPaneKey`. The residue is preserved by the bare `...base` spread at **line 46** of `mergeWorkspaceSessions`.

**The important correction: dropping *every* `GLOBAL_WORKSPACE_SESSION_FIELDS` entry is NOT a zero-behavior-change edit, and I did not do it.** Two independent main-side gates disqualify five of the eight:

- `activeWorktreeId` and `activeWorkspaceKey` are classified `'direct'` in `WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND`, and **both** `collectPersistedSessionWorktreeOwners` (`session-worktree-ownership.ts:227-237`) and the deregistered-repo residue sweep (`deregistered-repo-residue.ts:86-95`, which reads `session.activeWorktreeId` / `session.activeWorkspaceKey` explicitly) walk **every** partition. Dropping either un-owns a worktree, and an un-owned worktree gets its metadata pruned — that is data loss, exactly the class of bug this PR must not introduce.
- `activeTabId`, `activeConnectionIdsAtShutdown` and `activeRepoId` have live main-side readers *on a partition*: `isPersistedTerminalLeafActive` falls back to `session.activeTabId` for the mobile terminal projection, and `orca-runtime-attach-window.ts:64-95` unions `session.activeConnectionIdsAtShutdown` from `store.getWorkspaceSession(hostId)` for SSH auto-reconnect.

So the prune is scoped to the two pure-history globals — `browserUrlHistory` and `workspaceDocHistory` — which are `'global'` in the ownership table **and** `'none'` in the reference-kind table. That is 589,807 of the 593,758 total residue bytes: **99.3% of the win, none of the risk.** A ratchet test re-checks both gates for every field in the list, so the list cannot grow into an unsafe field silently.

The drop runs before the defaults spread, so a field the type requires comes back at its default rather than going missing, and it only fires when the local slice already holds the field — exactly the condition under which `mergeWorkspaceSessionsFromHosts`' fallback-to-another-slice branch cannot fire (pinned by two new tests in `workspace-session-host-split.test.ts`).

`workspace-session-host-field-ownership.ts` moves `src/renderer/src/lib/` → `src/shared/` so the main-process ratchet can import it (`tsconfig.node.json` correctly refuses a main → renderer import). Pure data module, no behavior change; 2 import lines updated.

### Measurements — Fix 2

| | before | after |
|---|---|---|
| store file size | 4,653,760 B | **4,060,805 B** (−592,955 B, −12.7%) |
| dead residue removed | — | 589,807 B |
| startup decode+parse, warm min | 7.7 ms | **7.1 ms** |
| startup decode+parse, fresh process | 12.9–21.7 ms | **11.7–14.9 ms** |
| `JSON.stringify` of the state, min | 12.9 ms | **5.0 ms** |

**I could not reproduce the brief's 157 ms parse.** On this machine (Node 22, macOS arm64, outside Electron) the same file decodes+parses in **7.7 ms warm** and 12.9–21.7 ms in a cold process. I'm reporting what I measured rather than the briefed figure. The relative shrink is real either way, and the `JSON.stringify` win (12.9 → 5.0 ms) is the larger and more reproducible one, since it lands on every save rather than once at launch.

## Optional no-op-save skip: **NOT done**, deliberately

The brief allowed caching serialization on `writeGeneration`. I could not prove every mutation path bumps it, so per the brief's own instruction I did not add it. Concretely: there are 48 direct `state.<field> = ...` assignments across `src/main/persistence` and `src/main/runtime` against 86 `scheduleSave` call sites, plus in-place nested mutation (`state.worktreeMeta[key] = ...`, `delete state.worktreeMeta[key]`, and the `src/main/orca-profiles/` helpers that mutate a state object reached by reference). A generation-keyed cache cannot observe an in-place nested mutation that skipped `scheduleSave`, and a stale cache there is silent data loss, not a perf regression. The current `lastWrittenStateHash` guard still skips the disk write; it just pays the (now 48% cheaper) serialization to compute the hash.

## Out of scope, as instructed

- Omitting default-valued keys: **−681 KB** available, not attempted (needs a per-field absent-vs-default audit; `linked*: null` vs absent is the risk).
- `worktreeMetaByIdentity` dedup: **−953 KB** available, schema change, separate design pass. (Measured here: `worktreeMeta` 835,444 B + `worktreeMetaByIdentity` 773,324 B.)
- `gcStaleWorktreeMeta`, `session-write-subscriber.ts`, startup migration passes: untouched.

## Tests

New, all failing without the corresponding fix:

- `secret-sentinel-substitution.test.ts` — six cases, each comparing against `previousImplementation`, a verbatim copy of the loop this PR deletes:
  - payload bytes **and** guard hash byte-identical for a fixture with **three** sentinels, one whose replacement blob is `A+/=$&$1$` + backtick + `\x "quoted" |.*?[](){}^` (regex-special **and** JSON-escapable), plus adjacent near-miss decoys;
  - identical across multi-byte content (`é`, `中文`, `😀`) placed on both sides of every segment boundary;
  - identical with zero substitutions and with the `safeStorage-degraded\0` prefix;
  - regex metacharacters in the sentinel itself are escaped, not interpreted;
  - a repeated sentinel is substituted at **every** occurrence;
  - **allocation/encode counting**: patches `String.prototype.replace`, `Buffer.from` and `Hash.prototype.update` and asserts the old path does `3 × 2 = 6` full-state replaces and ≈2× full-state encoded chars, while the new path does **0** replaces and ≈1× encoded chars.
- `workspace-session-partitions.test.ts` — dropped only when local has the field; **retained** when local does not (`workspaceDocHistory`, which is absent from the defaults so the case is reachable); untouched when no local slice is supplied; `activeWorktreeId` / `activeTabId` / host-owned fields explicitly left alone; plus the two-gate ratchet on the drop list.
- `state-write-round-trip.test.ts` — drives the real `Store`: three encrypted secret slots, a local session and a remote partition with non-ASCII history, `flush()`, reads the file back, asserts it holds ciphertext and no leaked `orca-secret-slot-` sentinel, reloads, then asserts **deep equality of settings / UI / both session partitions across a second round trip** and that a third flush produces **byte-identical** file contents.

Fail-first verified by reverting the three Fix-2 files (unique patch path, not the shared `/tmp/mywip.patch`): 3 of 6 partition tests fail. The allocation-count test fails if the substitution is reverted to the loop (it would report 6 replaces, not 0).

## Verification

- `pnpm tc` — clean (run once, at the end)
- `npx oxlint <changed files>` — clean; `oxfmt` applied
- `npx vitest run --config config/vitest.config.ts src/main/persistence src/renderer/src/lib` — **569 files, 5613 tests passed**, 1 skipped

## Negative user-facing trade-offs

**None.**

- **Fix 1 writes provably identical bytes.** `secret-sentinel-substitution.test.ts` compares `payload.equals(...)` and the sha1 against the deleted implementation across regex-special, JSON-escapable and multi-byte fixtures. The guard hash is unchanged, so the no-op-write skip keeps behaving exactly as it did. The only intentional divergence is a case that cannot occur today: a repeated sentinel is now fully substituted instead of leaving a raw UUID on disk where a secret belongs — strictly safer.
- **Fix 2 removes only data that no code path can read**, and only under the condition that makes it unreadable (local owns the field). Both disqualifying gates are enforced by a ratchet test rather than by a comment. `browserUrlHistory` returns from the defaults spread as `[]`, so no consumer sees an unexpected `undefined`.
- The remote/SSH boundary is untouched: nothing here changes what a host publishes, what an RPC carries, or what a paired client decodes — this is local main-process serialization and local load-time normalization only.
