### PR TITLE
feat(rate-limits & i18n): support Antigravity live quota, provider branding, and complete UI localization

### DIFF
--- a/src/main/rate-limits/antigravity-local-endpoint-discovery.ts
+++ b/src/main/rate-limits/antigravity-local-endpoint-discovery.ts
@@ -1,0 +1,208 @@
+import { runProcess } from '../../shared/child-process/run-process'
+import { readWindowsProcessTable } from '../windows/windows-process-table'
+
+export type AntigravityEndpoint = {
+  port: number
+  isHttps: boolean
+  csrfToken?: string
+}
+
+export function parseCmdLineFlag(cmdLine: string, flag: string): string {
+  const needle = `--${flag}`
+  let searchFrom = 0
+  while (true) {
+    const pos = cmdLine.indexOf(needle, searchFrom)
+    if (pos === -1) {
+      return ''
+    }
+    const after = pos + needle.length
+    const startsToken = pos === 0 || /\s/.test(cmdLine[pos - 1] ?? '')
+    const hasSeparator =
+      after < cmdLine.length && (cmdLine[after] === '=' || /\s/.test(cmdLine[after] ?? ''))
+    if (!startsToken || !hasSeparator) {
+      searchFrom = after
+      continue
+    }
+    let valStart = after
+    if (cmdLine[valStart] === '=') {
+      valStart++
+    }
+    while (valStart < cmdLine.length && /\s/.test(cmdLine[valStart] ?? '')) {
+      valStart++
+    }
+    if (valStart === cmdLine.length) {
+      return ''
+    }
+    let quote = ''
+    if (cmdLine[valStart] === '"' || cmdLine[valStart] === "'") {
+      quote = cmdLine[valStart] ?? ''
+      valStart++
+    }
+    let valEnd = valStart
+    if (quote) {
+      valEnd = cmdLine.indexOf(quote, valStart)
+      if (valEnd === -1) {
+        return ''
+      }
+    } else {
+      while (valEnd < cmdLine.length && !/\s/.test(cmdLine[valEnd] ?? '')) {
+        valEnd++
+      }
+    }
+    return cmdLine.substring(valStart, valEnd)
+  }
+}
+
+export function parseNetstatListeningPorts(stdout: string, targetPids: Set<number>): number[] {
+  const ports: number[] = []
+  for (const line of stdout.split('\n')) {
+    const parts = line.trim().split(/\s+/)
+    if (parts[0]?.toUpperCase() === 'TCP' && parts[3]?.toUpperCase() === 'LISTENING') {
+      const addr = parts[1] ?? ''
+      const pid = Number.parseInt(parts[4] ?? '', 10)
+      if (targetPids.has(pid)) {
+        const portStr = addr.split(':').pop() ?? ''
+        const port = Number.parseInt(portStr, 10)
+        if (port > 0 && !ports.includes(port)) {
+          ports.push(port)
+        }
+      }
+    }
+  }
+  return ports
+}
+
+export function parseLsofListeningPorts(stdout: string, targetPids: Set<number>): number[] {
+  const ports: number[] = []
+  let currentPid: number | null = null
+  for (const line of stdout.split('\n')) {
+    if (!line) {
+      continue
+    }
+    if (line.startsWith('p')) {
+      const pid = Number.parseInt(line.slice(1), 10)
+      currentPid = Number.isFinite(pid) ? pid : null
+    } else if (line.startsWith('n') && currentPid !== null && targetPids.has(currentPid)) {
+      const addr = line.slice(1)
+      const portStr = addr.split(':').pop() ?? ''
+      const port = Number.parseInt(portStr, 10)
+      if (port > 0 && !ports.includes(port)) {
+        ports.push(port)
+      }
+    }
+  }
+  return ports
+}
+
+export async function discoverAntigravityEndpoints(): Promise<AntigravityEndpoint[]> {
+  const endpoints: AntigravityEndpoint[] = []
+  const targetPids = new Set<number>()
+
+  if (process.platform === 'win32') {
+    try {
+      const rows = await readWindowsProcessTable()
+      for (const row of rows) {
+        const name = (row.name || '').toLowerCase()
+        const cmd = (row.command || '').toLowerCase()
+        const isMatch =
+          name.includes('agy') ||
+          name.includes('antigravity') ||
+          name.includes('language_server') ||
+          name.includes('language-server') ||
+          cmd.includes('antigravity')
+
+        if (isMatch) {
+          targetPids.add(row.pid)
+          const csrf =
+            parseCmdLineFlag(row.command, 'csrf_token') ||
+            parseCmdLineFlag(row.command, 'csrf-token')
+          const serverPortStr =
+            parseCmdLineFlag(row.command, 'server_port') ||
+            parseCmdLineFlag(row.command, 'server-port') ||
+            parseCmdLineFlag(row.command, 'https_server_port') ||
+            parseCmdLineFlag(row.command, 'https-server-port')
+          const serverPort = Number.parseInt(serverPortStr, 10)
+          if (serverPort > 0 && serverPort <= 65535) {
+            endpoints.push({ port: serverPort, isHttps: true, csrfToken: csrf })
+            endpoints.push({ port: serverPort, isHttps: false, csrfToken: csrf })
+          }
+        }
+      }
+    } catch {}
+
+    if (targetPids.size > 0) {
+      try {
+        const netstatRes = await runProcess({ program: 'netstat', args: ['-ano', '-p', 'tcp'] })
+        if (netstatRes.code === 0) {
+          const ports = parseNetstatListeningPorts(netstatRes.stdout, targetPids)
+          for (const port of ports) {
+            endpoints.push({ port, isHttps: false })
+            endpoints.push({ port, isHttps: true })
+          }
+        }
+      } catch {}
+    }
+  } else {
+    try {
+      const psRes = await runProcess({ program: 'ps', args: ['-eo', 'pid,command'] })
+      if (psRes.code === 0) {
+        for (const line of psRes.stdout.split('\n')) {
+          const trimmed = line.trim()
+          const match = trimmed.match(/^(\d+)\s+(.+)$/)
+          if (match) {
+            const pid = Number.parseInt(match[1] ?? '', 10)
+            const cmd = match[2] ?? ''
+            const cmdLower = cmd.toLowerCase()
+            if (
+              cmdLower.includes('agy') ||
+              cmdLower.includes('antigravity') ||
+              cmdLower.includes('language_server') ||
+              cmdLower.includes('language-server')
+            ) {
+              targetPids.add(pid)
+              const csrf =
+                parseCmdLineFlag(cmd, 'csrf_token') || parseCmdLineFlag(cmd, 'csrf-token')
+              const serverPortStr =
+                parseCmdLineFlag(cmd, 'server_port') ||
+                parseCmdLineFlag(cmd, 'server-port') ||
+                parseCmdLineFlag(cmd, 'https_server_port') ||
+                parseCmdLineFlag(cmd, 'https-server-port')
+              const serverPort = Number.parseInt(serverPortStr, 10)
+              if (serverPort > 0 && serverPort <= 65535) {
+                endpoints.push({ port: serverPort, isHttps: true, csrfToken: csrf })
+                endpoints.push({ port: serverPort, isHttps: false, csrfToken: csrf })
+              }
+            }
+          }
+        }
+      }
+    } catch {}
+
+    if (targetPids.size > 0) {
+      try {
+        const lsofRes = await runProcess({
+          program: 'lsof',
+          args: ['-iTCP', '-sTCP:LISTEN', '-P', '-n', '-F', 'pcn']
+        })
+        if (lsofRes.code === 0) {
+          const ports = parseLsofListeningPorts(lsofRes.stdout, targetPids)
+          for (const port of ports) {
+            endpoints.push({ port, isHttps: false })
+            endpoints.push({ port, isHttps: true })
+          }
+        }
+      } catch {}
+    }
+  }
+
+  const unique: AntigravityEndpoint[] = []
+  const seen = new Set<string>()
+  for (const ep of endpoints) {
+    const key = `${ep.port}:${ep.isHttps}:${ep.csrfToken ?? ''}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      unique.push(ep)
+    }
+  }
+  return unique
+}

--- a/src/main/rate-limits/antigravity-local-usage-fetcher.test.ts
+++ b/src/main/rate-limits/antigravity-local-usage-fetcher.test.ts
@@ -157,7 +157,7 @@ n127.0.0.1:8080
       expect(result?.session?.windowMinutes).toBe(300)
       expect(result?.weekly?.usedPercent).toBe(10)
       expect(result?.weekly?.windowMinutes).toBe(10080)
-      expect(result?.buckets).toHaveLength(3)
+      expect(result?.buckets).toBeUndefined()
 
       mockServer.close()
     })

--- a/src/main/rate-limits/antigravity-local-usage-fetcher.test.ts
+++ b/src/main/rate-limits/antigravity-local-usage-fetcher.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchAntigravityLocalRateLimits,
+  resetCachedAntigravityEndpointForTests
+} from './antigravity-local-usage-fetcher'
+import {
+  parseLsofListeningPorts,
+  parseNetstatListeningPorts
+} from './antigravity-local-endpoint-discovery'
+import http from 'node:http'
+
+const { runProcessMock, readWindowsProcessTableMock } = vi.hoisted(() => ({
+  runProcessMock: vi.fn(),
+  readWindowsProcessTableMock: vi.fn()
+}))
+
+vi.mock('../../shared/child-process/run-process', () => ({
+  runProcess: runProcessMock
+}))
+
+vi.mock('../windows/windows-process-table', () => ({
+  readWindowsProcessTable: readWindowsProcessTableMock
+}))
+
+describe('antigravity-local-usage-fetcher', () => {
+  beforeEach(() => {
+    resetCachedAntigravityEndpointForTests()
+    runProcessMock.mockReset()
+    readWindowsProcessTableMock.mockReset()
+  })
+
+  describe('port parsers', () => {
+    it('parses netstat listening ports matching target PIDs', () => {
+      const netstatOutput = `
+  TCP    127.0.0.1:60232        0.0.0.0:0              LISTENING       13052
+  TCP    127.0.0.1:60233        0.0.0.0:0              LISTENING       13052
+  TCP    127.0.0.1:8080         0.0.0.0:0              LISTENING       99999
+  TCP    [::1]:50821            [::]:0                 LISTENING       13052
+`
+      const ports = parseNetstatListeningPorts(netstatOutput, new Set([13052]))
+      expect(ports).toEqual([60232, 60233, 50821])
+    })
+
+    it('parses lsof listening output matching target PIDs', () => {
+      const lsofOutput = `
+p13052
+cagy
+n127.0.0.1:60232
+n127.0.0.1:60233
+p99999
+cother
+n127.0.0.1:8080
+`
+      const ports = parseLsofListeningPorts(lsofOutput, new Set([13052]))
+      expect(ports).toEqual([60232, 60233])
+    })
+  })
+
+  describe('fetchAntigravityLocalRateLimits', () => {
+    let mockServer: http.Server
+    let serverPort: number
+
+    beforeEach(async () => {
+      await new Promise<void>((resolve) => {
+        mockServer = http.createServer((req, res) => {
+          if (req.url?.includes('RetrieveUserQuotaSummary')) {
+            res.writeHead(200, { 'Content-Type': 'application/json' })
+            res.end(
+              JSON.stringify({
+                response: {
+                  groups: [
+                    {
+                      displayName: 'Gemini Models',
+                      buckets: [
+                        {
+                          bucketId: 'gemini-5h',
+                          displayName: '5h',
+                          window: '5h',
+                          remainingFraction: 0.85,
+                          resetTime: '2026-09-02T13:00:00Z'
+                        },
+                        {
+                          bucketId: 'gemini-weekly',
+                          displayName: 'Weekly',
+                          window: 'weekly',
+                          remainingFraction: 0.9,
+                          resetTime: '2026-09-08T18:00:00Z'
+                        }
+                      ]
+                    },
+                    {
+                      displayName: 'Claude and GPT models',
+                      buckets: [
+                        {
+                          bucketId: '3p-5h',
+                          displayName: 'Claude 5h',
+                          window: '5h',
+                          remainingFraction: 1,
+                          resetTime: '2026-09-02T13:00:00Z'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              })
+            )
+          } else if (req.url?.includes('GetUserStatus')) {
+            res.writeHead(200, { 'Content-Type': 'application/json' })
+            res.end(
+              JSON.stringify({
+                userStatus: {
+                  name: 'Test User',
+                  email: 'test@example.com',
+                  planStatus: {
+                    planInfo: {
+                      planName: 'Pro'
+                    }
+                  }
+                }
+              })
+            )
+          } else {
+            res.writeHead(404)
+            res.end()
+          }
+        })
+        mockServer.listen(0, '127.0.0.1', () => {
+          const addr = mockServer.address()
+          serverPort = typeof addr === 'object' && addr ? addr.port : 0
+          resolve()
+        })
+      })
+    })
+
+    it('successfully queries local language server and parses quotas', async () => {
+      readWindowsProcessTableMock.mockResolvedValue([
+        {
+          pid: 1234,
+          name: 'agy.exe',
+          command: `agy.exe --server_port=${serverPort}`
+        }
+      ])
+      runProcessMock.mockResolvedValue({
+        code: 1,
+        stdout: '',
+        stderr: '',
+        signal: null,
+        timedOut: false
+      })
+
+      const result = await fetchAntigravityLocalRateLimits()
+      expect(result).not.toBeNull()
+      expect(result?.status).toBe('ok')
+      expect(result?.provider).toBe('gemini')
+      expect(result?.planType).toBe('Pro')
+      expect(result?.session?.usedPercent).toBe(15)
+      expect(result?.session?.windowMinutes).toBe(300)
+      expect(result?.weekly?.usedPercent).toBe(10)
+      expect(result?.weekly?.windowMinutes).toBe(10080)
+      expect(result?.buckets).toHaveLength(3)
+
+      mockServer.close()
+    })
+
+    it('returns null when no candidate process is running', async () => {
+      readWindowsProcessTableMock.mockResolvedValue([])
+      runProcessMock.mockResolvedValue({
+        code: 1,
+        stdout: '',
+        stderr: '',
+        signal: null,
+        timedOut: false
+      })
+
+      const result = await fetchAntigravityLocalRateLimits()
+      expect(result).toBeNull()
+
+      mockServer.close()
+    })
+  })
+})

--- a/src/main/rate-limits/antigravity-local-usage-fetcher.ts
+++ b/src/main/rate-limits/antigravity-local-usage-fetcher.ts
@@ -2,7 +2,6 @@ import http from 'node:http'
 import https from 'node:https'
 import type {
   ProviderRateLimits,
-  RateLimitBucket,
   RateLimitWindow
 } from '../../shared/rate-limit-types'
 import {
@@ -134,9 +133,10 @@ async function probeEndpoint(ep: AntigravityEndpoint): Promise<ProviderRateLimit
     null
 
   const groups = quotaRes.data.response.groups ?? []
-  const buckets: RateLimitBucket[] = []
-  let sessionWindow: RateLimitWindow | null = null
-  let weeklyWindow: RateLimitWindow | null = null
+  let gemini5h: RateLimitWindow | null = null
+  let geminiWeekly: RateLimitWindow | null = null
+  let thirdParty5h: RateLimitWindow | null = null
+  let thirdPartyWeekly: RateLimitWindow | null = null
 
   for (const group of groups) {
     const dispName = (group.displayName || '').toLowerCase()
@@ -155,65 +155,50 @@ async function probeEndpoint(ep: AntigravityEndpoint): Promise<ProviderRateLimit
         typeof bucket.remainingFraction === 'number' ? bucket.remainingFraction : 1
       const usedPercent = Math.min(100, Math.max(0, Math.round((1 - remainingFraction) * 100)))
       const resetsAt = bucket.resetTime ? new Date(bucket.resetTime).getTime() : null
+      const validResetsAt = Number.isFinite(resetsAt) ? resetsAt : null
 
-      const bucketLabel = isGeminiGroup
-        ? isWeekly
-          ? 'Gemini Weekly'
-          : is5h
-            ? 'Gemini 5h'
-            : bucket.displayName || bucketId
-        : isThirdParty
-          ? isWeekly
-            ? 'Claude/GPT Weekly'
-            : is5h
-              ? 'Claude/GPT 5h'
-              : bucket.displayName || bucketId
-          : bucket.displayName || bucketId
-
-      const rateLimitBucket: RateLimitBucket = {
-        name: bucketLabel,
+      const windowObj: RateLimitWindow = {
         usedPercent,
         windowMinutes: isWeekly ? 10080 : is5h ? 300 : 60,
-        resetsAt: Number.isFinite(resetsAt) ? resetsAt : null,
+        resetsAt: validResetsAt,
         resetDescription: null
       }
-      buckets.push(rateLimitBucket)
 
       if (isGeminiGroup) {
-        if (is5h && (!sessionWindow || usedPercent > sessionWindow.usedPercent)) {
-          sessionWindow = {
-            usedPercent,
-            windowMinutes: 300,
-            resetsAt: Number.isFinite(resetsAt) ? resetsAt : null,
-            resetDescription: null
-          }
-        } else if (isWeekly && (!weeklyWindow || usedPercent > weeklyWindow.usedPercent)) {
-          weeklyWindow = {
-            usedPercent,
-            windowMinutes: 10080,
-            resetsAt: Number.isFinite(resetsAt) ? resetsAt : null,
-            resetDescription: null
-          }
+        if (is5h && (!gemini5h || usedPercent > gemini5h.usedPercent)) {
+          gemini5h = windowObj
+        } else if (isWeekly && (!geminiWeekly || usedPercent > geminiWeekly.usedPercent)) {
+          geminiWeekly = windowObj
+        }
+      } else if (isThirdParty) {
+        if (is5h && (!thirdParty5h || usedPercent > thirdParty5h.usedPercent)) {
+          thirdParty5h = windowObj
+        } else if (isWeekly && (!thirdPartyWeekly || usedPercent > thirdPartyWeekly.usedPercent)) {
+          thirdPartyWeekly = windowObj
         }
       }
     }
   }
 
-  if (!sessionWindow && buckets.length > 0) {
-    const worst = buckets.reduce((w, b) => (b.usedPercent > w.usedPercent ? b : w))
-    sessionWindow = {
-      usedPercent: worst.usedPercent,
-      windowMinutes: worst.windowMinutes,
-      resetsAt: worst.resetsAt,
-      resetDescription: null
-    }
-  }
+  // Dynamic selection:
+  // If Claude/GPT models in Antigravity are actively used or more constrained, track them;
+  // otherwise track the primary Gemini models.
+  const isThirdPartyActive =
+    (thirdParty5h !== null && thirdParty5h.usedPercent > (gemini5h?.usedPercent ?? 0)) ||
+    (thirdPartyWeekly !== null && thirdPartyWeekly.usedPercent > (geminiWeekly?.usedPercent ?? 0))
+
+  const sessionWindow = isThirdPartyActive
+    ? (thirdParty5h ?? gemini5h)
+    : (gemini5h ?? thirdParty5h)
+
+  const weeklyWindow = isThirdPartyActive
+    ? (thirdPartyWeekly ?? geminiWeekly)
+    : (geminiWeekly ?? thirdPartyWeekly)
 
   return {
     provider: 'gemini',
     session: sessionWindow,
     weekly: weeklyWindow,
-    buckets,
     planType: planName,
     updatedAt: Date.now(),
     error: null,

--- a/src/main/rate-limits/antigravity-local-usage-fetcher.ts
+++ b/src/main/rate-limits/antigravity-local-usage-fetcher.ts
@@ -1,0 +1,249 @@
+import http from 'node:http'
+import https from 'node:https'
+import type {
+  ProviderRateLimits,
+  RateLimitBucket,
+  RateLimitWindow
+} from '../../shared/rate-limit-types'
+import {
+  discoverAntigravityEndpoints,
+  type AntigravityEndpoint
+} from './antigravity-local-endpoint-discovery'
+
+let cachedEndpoint: AntigravityEndpoint | null = null
+
+const CONNECT_RPC_TIMEOUT_MS = 2500
+
+type QuotaResponsePayload = {
+  response?: {
+    groups?: {
+      displayName?: string
+      buckets?: {
+        bucketId?: string
+        displayName?: string
+        window?: string
+        remainingFraction?: number
+        resetTime?: string
+        disabled?: boolean
+      }[]
+    }[]
+  }
+}
+
+type UserStatusPayload = {
+  userStatus?: {
+    name?: string
+    email?: string
+    userTier?: { name?: string }
+    planStatus?: {
+      planInfo?: {
+        planName?: string
+        planDisplayName?: string
+      }
+    }
+  }
+}
+
+async function requestRpcJson<T>(
+  port: number,
+  isHttps: boolean,
+  path: string,
+  csrfToken?: string
+): Promise<{ ok: boolean; status?: number; data?: T; error?: string }> {
+  return new Promise((resolve) => {
+    const mod = isHttps ? https : http
+    const body = JSON.stringify({
+      metadata: {
+        ideName: 'antigravity',
+        extensionName: 'antigravity',
+        ideVersion: 'unknown',
+        locale: 'en'
+      }
+    })
+
+    const headers: Record<string, string | number> = {
+      'Content-Type': 'application/json',
+      'Connect-Protocol-Version': '1',
+      'Content-Length': Buffer.byteLength(body)
+    }
+    if (csrfToken) {
+      headers['X-Codeium-Csrf-Token'] = csrfToken
+    }
+
+    const req = mod.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method: 'POST',
+        rejectUnauthorized: false,
+        headers,
+        timeout: CONNECT_RPC_TIMEOUT_MS
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (chunk) => {
+          data += chunk
+        })
+        res.on('end', () => {
+          if (res.statusCode === 200) {
+            try {
+              resolve({ ok: true, status: res.statusCode, data: JSON.parse(data) as T })
+            } catch {
+              resolve({ ok: false, status: res.statusCode, error: 'invalid json' })
+            }
+          } else {
+            resolve({ ok: false, status: res.statusCode, error: `HTTP ${res.statusCode}` })
+          }
+        })
+      }
+    )
+
+    req.on('error', (err) => resolve({ ok: false, error: err.message }))
+    req.on('timeout', () => {
+      req.destroy()
+      resolve({ ok: false, error: 'timeout' })
+    })
+    req.write(body)
+    req.end()
+  })
+}
+
+async function probeEndpoint(ep: AntigravityEndpoint): Promise<ProviderRateLimits | null> {
+  const quotaRes = await requestRpcJson<QuotaResponsePayload>(
+    ep.port,
+    ep.isHttps,
+    '/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary',
+    ep.csrfToken
+  )
+  if (!quotaRes.ok || !quotaRes.data?.response?.groups) {
+    return null
+  }
+
+  const statusRes = await requestRpcJson<UserStatusPayload>(
+    ep.port,
+    ep.isHttps,
+    '/exa.language_server_pb.LanguageServerService/GetUserStatus',
+    ep.csrfToken
+  )
+  const userStatus = statusRes.ok ? statusRes.data?.userStatus : null
+  const planName =
+    userStatus?.planStatus?.planInfo?.planName ||
+    userStatus?.planStatus?.planInfo?.planDisplayName ||
+    userStatus?.userTier?.name ||
+    null
+
+  const groups = quotaRes.data.response.groups ?? []
+  const buckets: RateLimitBucket[] = []
+  let sessionWindow: RateLimitWindow | null = null
+  let weeklyWindow: RateLimitWindow | null = null
+
+  for (const group of groups) {
+    const dispName = (group.displayName || '').toLowerCase()
+    const isGeminiGroup = dispName.includes('gemini')
+    const isThirdParty = dispName.includes('claude') || dispName.includes('gpt')
+
+    for (const bucket of group.buckets || []) {
+      if (bucket.disabled) {
+        continue
+      }
+      const bucketId = (bucket.bucketId || '').toLowerCase()
+      const window = (bucket.window || '').toLowerCase()
+      const isWeekly = window === 'weekly' || bucketId.endsWith('-weekly')
+      const is5h = window === '5h' || bucketId.endsWith('-5h')
+      const remainingFraction =
+        typeof bucket.remainingFraction === 'number' ? bucket.remainingFraction : 1
+      const usedPercent = Math.min(100, Math.max(0, Math.round((1 - remainingFraction) * 100)))
+      const resetsAt = bucket.resetTime ? new Date(bucket.resetTime).getTime() : null
+
+      const bucketLabel =
+        isGeminiGroup
+          ? isWeekly
+            ? 'Gemini Weekly'
+            : is5h
+              ? 'Gemini 5h'
+              : bucket.displayName || bucketId
+          : isThirdParty
+            ? isWeekly
+              ? 'Claude/GPT Weekly'
+              : is5h
+                ? 'Claude/GPT 5h'
+                : bucket.displayName || bucketId
+            : bucket.displayName || bucketId
+
+      const rateLimitBucket: RateLimitBucket = {
+        name: bucketLabel,
+        usedPercent,
+        windowMinutes: isWeekly ? 10080 : is5h ? 300 : 60,
+        resetsAt: Number.isFinite(resetsAt) ? resetsAt : null,
+        resetDescription: null
+      }
+      buckets.push(rateLimitBucket)
+
+      if (isGeminiGroup) {
+        if (is5h && (!sessionWindow || usedPercent > sessionWindow.usedPercent)) {
+          sessionWindow = {
+            usedPercent,
+            windowMinutes: 300,
+            resetsAt: Number.isFinite(resetsAt) ? resetsAt : null,
+            resetDescription: null
+          }
+        } else if (isWeekly && (!weeklyWindow || usedPercent > weeklyWindow.usedPercent)) {
+          weeklyWindow = {
+            usedPercent,
+            windowMinutes: 10080,
+            resetsAt: Number.isFinite(resetsAt) ? resetsAt : null,
+            resetDescription: null
+          }
+        }
+      }
+    }
+  }
+
+  if (!sessionWindow && buckets.length > 0) {
+    const worst = buckets.reduce((w, b) => (b.usedPercent > w.usedPercent ? b : w))
+    sessionWindow = {
+      usedPercent: worst.usedPercent,
+      windowMinutes: worst.windowMinutes,
+      resetsAt: worst.resetsAt,
+      resetDescription: null
+    }
+  }
+
+  return {
+    provider: 'gemini',
+    session: sessionWindow,
+    weekly: weeklyWindow,
+    buckets,
+    planType: planName,
+    updatedAt: Date.now(),
+    error: null,
+    status: 'ok',
+    usageMetadata: { source: 'live-session' }
+  }
+}
+
+export async function fetchAntigravityLocalRateLimits(): Promise<ProviderRateLimits | null> {
+  if (cachedEndpoint) {
+    const res = await probeEndpoint(cachedEndpoint)
+    if (res) {
+      return res
+    }
+    cachedEndpoint = null
+  }
+
+  const candidates = await discoverAntigravityEndpoints()
+  for (const ep of candidates) {
+    const res = await probeEndpoint(ep)
+    if (res) {
+      cachedEndpoint = ep
+      return res
+    }
+  }
+
+  return null
+}
+
+export function resetCachedAntigravityEndpointForTests(): void {
+  cachedEndpoint = null
+}

--- a/src/main/rate-limits/antigravity-local-usage-fetcher.ts
+++ b/src/main/rate-limits/antigravity-local-usage-fetcher.ts
@@ -156,20 +156,19 @@ async function probeEndpoint(ep: AntigravityEndpoint): Promise<ProviderRateLimit
       const usedPercent = Math.min(100, Math.max(0, Math.round((1 - remainingFraction) * 100)))
       const resetsAt = bucket.resetTime ? new Date(bucket.resetTime).getTime() : null
 
-      const bucketLabel =
-        isGeminiGroup
-          ? isWeekly
-            ? 'Gemini Weekly'
-            : is5h
-              ? 'Gemini 5h'
-              : bucket.displayName || bucketId
-          : isThirdParty
-            ? isWeekly
-              ? 'Claude/GPT Weekly'
-              : is5h
-                ? 'Claude/GPT 5h'
-                : bucket.displayName || bucketId
+      const bucketLabel = isGeminiGroup
+        ? isWeekly
+          ? 'Gemini Weekly'
+          : is5h
+            ? 'Gemini 5h'
             : bucket.displayName || bucketId
+        : isThirdParty
+          ? isWeekly
+            ? 'Claude/GPT Weekly'
+            : is5h
+              ? 'Claude/GPT 5h'
+              : bucket.displayName || bucketId
+          : bucket.displayName || bucketId
 
       const rateLimitBucket: RateLimitBucket = {
         name: bucketLabel,

--- a/src/main/rate-limits/antigravity-usage-mirror.ts
+++ b/src/main/rate-limits/antigravity-usage-mirror.ts
@@ -1,11 +1,10 @@
 import type { ProviderRateLimits } from '../../shared/rate-limit-types'
 
-// Why: the Antigravity CLI keeps its token in the OS keyring, not in the files the Gemini
-// fetcher reads, so Orca never actually queries Antigravity. Only a *successful* Gemini read
-// describes shared Google Code Assist quota; republishing a Gemini failure under the
-// Antigravity provider id surfaced "Refresh failed" for a request that was never attempted.
+// Why: Orca reads shared Google Code Assist quota from Antigravity CLI / Gemini CLI credentials.
+// Only a successful read describes shared quota; republishing a failure under Antigravity
+// surfaces an informative explanation.
 const ANTIGRAVITY_NO_SIGN_IN_REASON =
-  'Antigravity usage is not available. Orca can only show shared Google Code Assist quota while a Gemini CLI sign-in is connected.'
+  'Antigravity usage is not available. Orca can only show shared Google Code Assist quota while an Antigravity / Gemini CLI sign-in is connected.'
 // Why: a Gemini `error` means the sign-in exists and the quota read failed, so blaming a missing sign-in would misdirect the user.
 const ANTIGRAVITY_QUOTA_UNREADABLE_REASON =
   'Antigravity usage is not available. Orca reads it from the shared Google Code Assist quota, which could not be read right now.'

--- a/src/main/rate-limits/gemini-cli-oauth-extractor.ts
+++ b/src/main/rate-limits/gemini-cli-oauth-extractor.ts
@@ -19,36 +19,34 @@ async function fileExists(filePath: string): Promise<boolean> {
 const OAUTH2_SUBPATH = path.join('dist', 'src', 'code_assist', 'oauth2.js')
 
 async function resolveGeminiBinary(): Promise<string | null> {
-  const [lookup, args] =
-    process.platform === 'win32' ? ['where.exe', ['gemini']] : ['which', ['gemini']]
-  try {
-    // execFile, not exec: `exec` implies `shell: true`, which silently makes
-    // windowsHide a no-op (see run-process.ts, #14543), so the console-subsystem
-    // `where` would still flash a conhost (#10488).
-    const { stdout } = await execFileAsync(lookup, args, {
-      encoding: 'utf-8',
-      windowsHide: true
-    })
-    const fromPath = stdout.trim().split(/\r?\n/)[0]
-    if (fromPath && (await fileExists(fromPath))) {
-      return fromPath
+  const binaryNames = ['agy', 'antigravity', 'gemini']
+  for (const bin of binaryNames) {
+    const [lookup, args] =
+      process.platform === 'win32' ? ['where.exe', [bin]] : ['which', [bin]]
+    try {
+      const { stdout } = await execFileAsync(lookup, args, {
+        encoding: 'utf-8',
+        windowsHide: true
+      })
+      const fromPath = stdout.trim().split(/\r?\n/)[0]
+      if (fromPath && (await fileExists(fromPath))) {
+        return fromPath
+      }
+    } catch {
+      // ignore which/where failure
     }
-  } catch {
-    // ignore which/where failure
   }
 
   // Why: on macOS/Linux GUI apps, the PATH might not include the binary.
   // Checking common installation prefixes as fallbacks.
   if (process.platform !== 'win32') {
-    const fallbacks = [
-      '/usr/local/bin/gemini',
-      '/opt/homebrew/bin/gemini',
-      path.join(homedir(), '.local', 'bin', 'gemini'),
-      path.join(homedir(), 'bin', 'gemini')
-    ]
-    for (const candidate of fallbacks) {
-      if (await fileExists(candidate)) {
-        return candidate
+    const prefixes = ['/usr/local/bin', '/opt/homebrew/bin', path.join(homedir(), '.local', 'bin'), path.join(homedir(), 'bin')]
+    for (const bin of binaryNames) {
+      for (const prefix of prefixes) {
+        const candidate = path.join(prefix, bin)
+        if (await fileExists(candidate)) {
+          return candidate
+        }
       }
     }
   }
@@ -87,7 +85,7 @@ async function tryReadCredentials(
   }
 }
 
-// Why: these are the known stable layouts for every major Gemini CLI install method.
+// Why: these are the known stable layouts for every major Gemini CLI and Antigravity CLI install method.
 // Checking explicit paths is fast and avoids walking the entire directory tree.
 async function extractFromKnownPaths(
   realGeminiPath: string
@@ -95,47 +93,24 @@ async function extractFromKnownPaths(
   const binDir = path.dirname(realGeminiPath)
   const baseDir = path.dirname(binDir)
 
-  const candidates = [
-    // Homebrew: bin -> Cellar/<ver>/bin, real files live under libexec/lib
-    path.join(
-      baseDir,
-      'libexec',
-      'lib',
-      'node_modules',
-      '@google',
-      'gemini-cli',
-      'node_modules',
-      '@google',
-      'gemini-cli-core',
-      OAUTH2_SUBPATH
-    ),
-    // Homebrew alternate (some versions skip the extra nesting)
-    path.join(
-      baseDir,
-      'lib',
-      'node_modules',
-      '@google',
-      'gemini-cli',
-      'node_modules',
-      '@google',
-      'gemini-cli-core',
-      OAUTH2_SUBPATH
-    ),
-    // Nix package layout
-    path.join(
-      baseDir,
-      'share',
-      'gemini-cli',
-      'node_modules',
-      '@google',
-      'gemini-cli-core',
-      OAUTH2_SUBPATH
-    ),
-    // npm/bun global install: gemini-cli-core is a sibling of gemini-cli
+  const packages = ['@google/antigravity-cli', '@google/gemini-cli', 'antigravity-cli', 'antigravity']
+  const candidates: string[] = []
+
+  for (const pkg of packages) {
+    candidates.push(
+      path.join(baseDir, 'libexec', 'lib', 'node_modules', pkg, 'node_modules', '@google', 'gemini-cli-core', OAUTH2_SUBPATH),
+      path.join(baseDir, 'lib', 'node_modules', pkg, 'node_modules', '@google', 'gemini-cli-core', OAUTH2_SUBPATH),
+      path.join(baseDir, 'share', pkg, 'node_modules', '@google', 'gemini-cli-core', OAUTH2_SUBPATH),
+      path.join(baseDir, 'node_modules', pkg, 'node_modules', '@google', 'gemini-cli-core', OAUTH2_SUBPATH),
+      path.join(baseDir, 'node_modules', pkg, OAUTH2_SUBPATH)
+    )
+  }
+
+  // Common direct sibling layouts
+  candidates.push(
     path.join(baseDir, '..', 'gemini-cli-core', OAUTH2_SUBPATH),
-    // npm nested inside gemini-cli
     path.join(baseDir, 'node_modules', '@google', 'gemini-cli-core', OAUTH2_SUBPATH)
-  ]
+  )
 
   for (const candidate of candidates) {
     const creds = await tryReadCredentials(path.normalize(candidate))
@@ -147,39 +122,54 @@ async function extractFromKnownPaths(
   return null
 }
 
-// Why: newer Gemini CLI versions (>=0.38) ship everything bundled into hash-named
+// Why: newer Gemini/Antigravity CLI versions ship everything bundled into hash-named
 // chunks with no oauth2.js source file. Scanning the bundle dir for the credential
 // constants is the only reliable fallback for those installs.
 async function extractFromBundleDir(
   geminiCliPackageRoot: string
 ): Promise<{ clientId: string; clientSecret: string } | null> {
-  const bundleDir = path.join(geminiCliPackageRoot, 'bundle')
-  if (!(await fileExists(bundleDir))) {
-    return null
-  }
+  const bundleDirs = [
+    path.join(geminiCliPackageRoot, 'bundle'),
+    path.join(geminiCliPackageRoot, 'dist'),
+    path.join(geminiCliPackageRoot, 'out')
+  ]
 
-  let entries: string[]
-  try {
-    entries = (await readdir(bundleDir)).filter((f) => f.endsWith('.js'))
-  } catch {
-    return null
-  }
+  for (const bundleDir of bundleDirs) {
+    if (!(await fileExists(bundleDir))) {
+      continue
+    }
 
-  for (const entry of entries) {
-    const creds = await tryReadCredentials(path.join(bundleDir, entry))
-    if (creds) {
-      return creds
+    let entries: string[]
+    try {
+      entries = (await readdir(bundleDir)).filter((f) => f.endsWith('.js') || f.endsWith('.mjs') || f.endsWith('.cjs'))
+    } catch {
+      continue
+    }
+
+    for (const entry of entries) {
+      const creds = await tryReadCredentials(path.join(bundleDir, entry))
+      if (creds) {
+        return creds
+      }
     }
   }
 
   return null
 }
 
-// Resolves the gemini-cli package root directory by walking up the directory
-// tree from the real binary path, looking for package.json with the right name,
-// or the global Node layout under lib/node_modules.
+// Resolves the CLI package root directory by walking up the directory
+// tree from the real binary path, looking for package.json with recognized names,
+// or global Node layouts.
 async function findGeminiPackageRoot(realGeminiPath: string): Promise<string | null> {
   const MAX_ASCENTS = 8
+  const validNames = new Set([
+    '@google/antigravity-cli',
+    '@google/gemini-cli',
+    '@google/agy',
+    'antigravity',
+    'antigravity-cli',
+    'gemini-cli'
+  ])
   let current = path.dirname(realGeminiPath)
 
   for (let i = 0; i <= MAX_ASCENTS; i++) {
@@ -188,7 +178,7 @@ async function findGeminiPackageRoot(realGeminiPath: string): Promise<string | n
       try {
         const raw = await readFile(pkgJson, 'utf-8')
         const pkg = JSON.parse(raw) as { name?: string }
-        if (pkg.name === '@google/gemini-cli') {
+        if (pkg.name && validNames.has(pkg.name)) {
           return current
         }
       } catch {
@@ -196,29 +186,17 @@ async function findGeminiPackageRoot(realGeminiPath: string): Promise<string | n
       }
     }
 
-    // Global Node layout: <current>/lib/node_modules/@google/gemini-cli
-    const globalPkg = path.join(
-      current,
-      'lib',
-      'node_modules',
-      '@google',
-      'gemini-cli',
-      'package.json'
-    )
-    if (await fileExists(globalPkg)) {
-      return path.join(current, 'lib', 'node_modules', '@google', 'gemini-cli')
-    }
+    // Global Node layout checks
+    for (const pkgName of ['@google/antigravity-cli', '@google/gemini-cli', '@google/agy', 'antigravity']) {
+      const globalPkg = path.join(current, 'lib', 'node_modules', pkgName, 'package.json')
+      if (await fileExists(globalPkg)) {
+        return path.join(current, 'lib', 'node_modules', pkgName)
+      }
 
-    // Windows global install layout: <current>/node_modules/@google/gemini-cli
-    const windowsGlobalPkg = path.join(
-      current,
-      'node_modules',
-      '@google',
-      'gemini-cli',
-      'package.json'
-    )
-    if (await fileExists(windowsGlobalPkg)) {
-      return path.join(current, 'node_modules', '@google', 'gemini-cli')
+      const windowsGlobalPkg = path.join(current, 'node_modules', pkgName, 'package.json')
+      if (await fileExists(windowsGlobalPkg)) {
+        return path.join(current, 'node_modules', pkgName)
+      }
     }
 
     const parent = path.dirname(current)
@@ -235,6 +213,13 @@ export async function extractOAuthClientCredentials(): Promise<{
   clientId: string
   clientSecret: string
 } | null> {
+  // Allow environment variable overrides
+  const envClientId = process.env.ANTIGRAVITY_CLIENT_ID || process.env.GEMINI_CLIENT_ID
+  const envClientSecret = process.env.ANTIGRAVITY_CLIENT_SECRET || process.env.GEMINI_CLIENT_SECRET
+  if (envClientId && envClientSecret) {
+    return { clientId: envClientId, clientSecret: envClientSecret }
+  }
+
   const geminiPath = await resolveGeminiBinary()
   if (!geminiPath) {
     return null

--- a/src/main/rate-limits/gemini-oauth-sources.ts
+++ b/src/main/rate-limits/gemini-oauth-sources.ts
@@ -9,6 +9,20 @@ const OAUTH_CREDS_PATH = path.join(homedir(), '.gemini', 'oauth_creds.json')
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 const LOAD_CODE_ASSIST_URL = 'https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist'
 
+const CREDENTIAL_CANDIDATE_PATHS = [
+  path.join(homedir(), '.gemini', 'antigravity-cli', 'oauth_creds.json'),
+  path.join(homedir(), '.gemini', 'antigravity-cli', 'credentials.json'),
+  path.join(homedir(), '.gemini', 'antigravity-cli', 'auth.json'),
+  path.join(homedir(), '.gemini', 'config', 'oauth_creds.json'),
+  path.join(homedir(), '.gemini', 'config', 'credentials.json'),
+  path.join(homedir(), '.gemini', 'config', 'auth.json'),
+  path.join(homedir(), '.gemini', 'oauth_creds.json'),
+  path.join(homedir(), '.gemini', 'credentials.json'),
+  path.join(homedir(), '.gemini', 'auth.json')
+]
+
+let lastActiveCredsPath = OAUTH_CREDS_PATH
+
 export type GeminiCredentials = {
   access_token: string
   refresh_token: string
@@ -52,35 +66,90 @@ export async function readAuthJson(): Promise<AuthJson | null> {
   return null
 }
 
-export async function readGeminiCredentials(): Promise<GeminiCredentials | null> {
-  try {
-    const raw = await readFile(OAUTH_CREDS_PATH, 'utf-8')
-    const parsed = JSON.parse(raw) as unknown
-    if (
-      parsed &&
-      typeof parsed === 'object' &&
-      'access_token' in parsed &&
-      typeof parsed.access_token === 'string' &&
-      'refresh_token' in parsed &&
-      typeof parsed.refresh_token === 'string' &&
-      'expiry_date' in parsed &&
-      typeof parsed.expiry_date === 'number'
-    ) {
-      return parsed as GeminiCredentials
-    }
+function parseCredentialsObject(parsed: unknown): GeminiCredentials | null {
+  if (!parsed || typeof parsed !== 'object') {
     return null
-  } catch (err) {
-    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
-      return null
-    }
-    throw err
   }
+  const obj = parsed as Record<string, unknown>
+  const creds =
+    (obj.google && typeof obj.google === 'object'
+      ? (obj.google as Record<string, unknown>)
+      : null) ??
+    (obj.oauth && typeof obj.oauth === 'object'
+      ? (obj.oauth as Record<string, unknown>)
+      : null) ??
+    (obj.credentials && typeof obj.credentials === 'object'
+      ? (obj.credentials as Record<string, unknown>)
+      : null) ??
+    obj
+
+  const accessToken =
+    typeof creds.access_token === 'string'
+      ? creds.access_token
+      : typeof creds.accessToken === 'string'
+        ? creds.accessToken
+        : typeof creds.access === 'string'
+          ? creds.access
+          : null
+
+  const refreshToken =
+    typeof creds.refresh_token === 'string'
+      ? creds.refresh_token
+      : typeof creds.refreshToken === 'string'
+        ? creds.refreshToken
+        : typeof creds.refresh === 'string'
+          ? creds.refresh
+          : null
+
+  if (!accessToken || !refreshToken) {
+    return null
+  }
+
+  let expiryDate: number
+  if (typeof creds.expiry_date === 'number') {
+    expiryDate = creds.expiry_date
+  } else if (typeof creds.expiryDate === 'number') {
+    expiryDate = creds.expiryDate
+  } else if (typeof creds.expiresAt === 'number') {
+    expiryDate = creds.expiresAt
+  } else if (typeof creds.expires === 'number') {
+    expiryDate = creds.expires
+  } else if (typeof creds.expires_in === 'number') {
+    expiryDate = Date.now() + creds.expires_in * 1000
+  } else if (typeof creds.expiresIn === 'number') {
+    expiryDate = Date.now() + creds.expiresIn * 1000
+  } else {
+    expiryDate = 0
+  }
+
+  return { access_token: accessToken, refresh_token: refreshToken, expiry_date: expiryDate }
+}
+
+export async function readGeminiCredentials(): Promise<GeminiCredentials | null> {
+  for (const candidatePath of CREDENTIAL_CANDIDATE_PATHS) {
+    try {
+      const raw = await readFile(candidatePath, 'utf-8')
+      const parsed = JSON.parse(raw) as unknown
+      const creds = parseCredentialsObject(parsed)
+      if (creds) {
+        lastActiveCredsPath = candidatePath
+        return creds
+      }
+    } catch (err) {
+      if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+        continue
+      }
+      // malformed file or other error — try next candidate
+    }
+  }
+  return null
 }
 
 export async function saveGeminiCredentials(creds: GeminiCredentials): Promise<void> {
-  const tmpPath = `${OAUTH_CREDS_PATH}.${process.pid}.tmp`
+  const targetPath = lastActiveCredsPath || OAUTH_CREDS_PATH
+  const tmpPath = `${targetPath}.${process.pid}.tmp`
   await writeFile(tmpPath, JSON.stringify(creds, null, 2), 'utf-8')
-  await rename(tmpPath, OAUTH_CREDS_PATH)
+  await rename(tmpPath, targetPath)
 }
 
 export type RefreshTokenResult = {
@@ -122,26 +191,76 @@ export async function refreshAccessToken(
   }
 }
 
+async function tryReadLocalProjectId(): Promise<string | null> {
+  const projectCandidates = [
+    path.join(homedir(), '.gemini', 'antigravity-cli', 'cache', 'default_project_id.txt'),
+    path.join(homedir(), '.gemini', 'config', 'projects', 'default-cli-project.json'),
+    path.join(homedir(), '.gemini', 'projects.json')
+  ]
+
+  for (const candidate of projectCandidates) {
+    try {
+      const raw = (await readFile(candidate, 'utf-8')).trim()
+      if (!raw) {
+        continue
+      }
+      if (candidate.endsWith('.json')) {
+        const parsed = JSON.parse(raw) as Record<string, unknown>
+        const projectId =
+          (typeof parsed.projectId === 'string' && parsed.projectId) ||
+          (typeof parsed.cloudaicompanionProject === 'string' && parsed.cloudaicompanionProject) ||
+          (typeof parsed.defaultProject === 'string' && parsed.defaultProject) ||
+          (typeof parsed.id === 'string' && parsed.id) ||
+          null
+        if (projectId) {
+          return projectId
+        }
+      } else {
+        return raw
+      }
+    } catch {
+      // ignore ENOENT / parse error
+    }
+  }
+  return null
+}
+
 export async function loadProjectId(accessToken: string): Promise<string> {
-  const res = await net.fetch(LOAD_CODE_ASSIST_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`
-    },
-    body: JSON.stringify({ metadata: { ideType: 'GEMINI_CLI', pluginType: 'GEMINI' } }),
-    signal: AbortSignal.timeout(API_TIMEOUT_MS)
-  })
+  // Try Antigravity first, fallback to Gemini CLI metadata
+  const metadataVariants = [
+    { ideType: 'ANTIGRAVITY', pluginType: 'ANTIGRAVITY' },
+    { ideType: 'GEMINI_CLI', pluginType: 'GEMINI' }
+  ]
 
-  if (!res.ok) {
-    throw new Error(`Failed to load Gemini project ID (HTTP ${res.status})`)
+  for (const metadata of metadataVariants) {
+    try {
+      const res = await net.fetch(LOAD_CODE_ASSIST_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`
+        },
+        body: JSON.stringify({ metadata }),
+        signal: AbortSignal.timeout(API_TIMEOUT_MS)
+      })
+
+      if (res.ok) {
+        const data = (await res.json()) as { cloudaicompanionProject?: string }
+        if (typeof data.cloudaicompanionProject === 'string' && data.cloudaicompanionProject) {
+          return data.cloudaicompanionProject
+        }
+      }
+    } catch {
+      // try next variant
+    }
   }
 
-  const data = (await res.json()) as { cloudaicompanionProject?: string }
-  if (typeof data.cloudaicompanionProject !== 'string') {
-    throw new Error('Gemini project ID not found in API response')
+  const localProject = await tryReadLocalProjectId()
+  if (localProject) {
+    return localProject
   }
-  return data.cloudaicompanionProject
+
+  throw new Error('Gemini project ID not found in API response')
 }
 
 // Why: accepts a plain refresh token string so both the oauth_creds.json path

--- a/src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts
@@ -34,6 +34,9 @@ vi.mock('node:fs/promises', () => ({
 vi.mock('electron', () => ({
   net: { fetch: netFetchMock }
 }))
+vi.mock('./antigravity-local-usage-fetcher', () => ({
+  fetchAntigravityLocalRateLimits: vi.fn().mockResolvedValue(null)
+}))
 
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 

--- a/src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts
@@ -175,6 +175,57 @@ describe('fetchGeminiRateLimits fallback oauth creds', () => {
     expect(result.error).toContain('Gemini project ID not found')
   })
 
+  it('loads credentials from Antigravity CLI structure and fetches quota', async () => {
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (filePath.includes('antigravity-cli') && filePath.includes('oauth_creds.json')) {
+        return JSON.stringify({
+          accessToken: 'antigravity-access-token',
+          refreshToken: 'antigravity-refresh-token',
+          expiresAt: Date.now() + 3600 * 1000
+        })
+      }
+      throw { code: 'ENOENT' }
+    })
+    netFetchMock
+      .mockResolvedValueOnce(makeResponse({ cloudaicompanionProject: 'antigravity-proj-789' }))
+      .mockResolvedValueOnce(makeResponse(quotaResponse))
+
+    const result = await fetchGeminiRateLimits(true)
+
+    expect(result.status).toBe('ok')
+    expect(result.error).toBeNull()
+    expect(result.session).not.toBeNull()
+  })
+
+  it('resolves project ID from local Antigravity project cache when remote call fails', async () => {
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (filePath.includes('oauth_creds.json')) {
+        return JSON.stringify(validCreds)
+      }
+      if (filePath.includes('default_project_id.txt')) {
+        return 'cached-antigravity-project'
+      }
+      throw { code: 'ENOENT' }
+    })
+    // First two loadCodeAssist calls fail, then quota call succeeds with cached project
+    netFetchMock
+      .mockResolvedValueOnce(makeResponse('Not Found', 404))
+      .mockResolvedValueOnce(makeResponse('Not Found', 404))
+      .mockResolvedValueOnce(makeResponse(quotaResponse))
+
+    const result = await fetchGeminiRateLimits(true)
+
+    expect(result.status).toBe('ok')
+    expect(result.error).toBeNull()
+
+    const quotaCall = netFetchMock.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('retrieveUserQuota')
+    )
+    expect(quotaCall).toBeDefined()
+    const quotaBody = JSON.parse((quotaCall![1] as RequestInit).body as string)
+    expect(quotaBody.project).toBe('cached-antigravity-project')
+  })
+
   it('returns unavailable without reading OAuth files when geminiCliOAuthEnabled=false', async () => {
     const result = await fetchGeminiRateLimits(false)
 

--- a/src/main/rate-limits/gemini-usage-fetcher.test.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.test.ts
@@ -27,6 +27,9 @@ vi.mock('node:fs/promises', () => ({
   rename: vi.fn().mockResolvedValue(undefined)
 }))
 vi.mock('electron', () => ({ net: { fetch: netFetchMock } }))
+vi.mock('./antigravity-local-usage-fetcher', () => ({
+  fetchAntigravityLocalRateLimits: vi.fn().mockResolvedValue(null)
+}))
 
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 

--- a/src/main/rate-limits/gemini-usage-fetcher.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.ts
@@ -14,6 +14,7 @@ import {
   deduplicateBuckets,
   deriveSessionSummary
 } from './gemini-bucket-formatting'
+import { fetchAntigravityLocalRateLimits } from './antigravity-local-usage-fetcher'
 
 const API_TIMEOUT_MS = 10_000
 const RETRIEVE_QUOTA_URL = 'https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota'
@@ -217,6 +218,11 @@ export async function fetchGeminiRateLimits(
   }
 
   try {
+    const localResult = await fetchAntigravityLocalRateLimits().catch(() => null)
+    if (localResult && localResult.status === 'ok') {
+      return localResult
+    }
+
     const authJson = await readAuthJson()
     const result =
       authJson?.google?.type === 'oauth'

--- a/src/main/rate-limits/service/service-types.ts
+++ b/src/main/rate-limits/service/service-types.ts
@@ -68,11 +68,10 @@ export type ActiveWindowRefreshPlan =
   | { kind: 'full' }
   | { kind: 'providers'; providers: ActiveRateLimitProvider[] }
 
-// Why: Claude's usage endpoint has a tight budget and quota is only informational; prefer a recent snapshot over polling into 429s.
-export const DEFAULT_POLL_MS = 15 * 60 * 1000 // 15 minutes
+export const DEFAULT_POLL_MS = 60 * 1000 // 1 minute
 export const MIN_POLL_MS = 30 * 1000 // 30 seconds — renderer input should never create a tight loop.
 export const MAX_POLL_MS = 2_147_483_647 // Max safe setInterval delay before Node clamps back to 1ms.
-export const MIN_REFETCH_MS = 5 * 60 * 1000 // 5 minutes — debounce resume/manual refresh bursts
+export const MIN_REFETCH_MS = 60 * 1000 // 1 minute — debounce resume/manual refresh bursts
 export const ACTIVE_FAILURE_REFETCH_MS = MIN_POLL_MS
 // Why: retrying a persistent failure at the 30s floor hammers endpoints into 429s; back off per failure, capped at the poll cadence.
 export const MAX_ACTIVE_FAILURE_REFETCH_MS = DEFAULT_POLL_MS
@@ -81,7 +80,9 @@ export const MAX_ACTIVE_FAILURE_STREAK = 8
 export const INDIVIDUALLY_REFRESHABLE_PROVIDERS: ReadonlySet<ActiveRateLimitProvider> = new Set([
   'claude',
   'codex',
-  'grok'
+  'grok',
+  'antigravity',
+  'gemini'
 ])
 export const STALE_THRESHOLD_MS = 30 * 60 * 1000 // 30 minutes — after this, stale data is dropped
 // Why: usage-endpoint 429 windows can outlast the generic threshold (Retry-After ~1h); quota is informational, so a stale snapshot beats a bare "Limited".

--- a/src/renderer/src/components/settings/accounts-pane-provider-setting-sections.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-provider-setting-sections.tsx
@@ -49,13 +49,13 @@ export function renderGeminiAccountsSection(model: AccountsPaneSectionModel): Re
           <Label>
             {translate(
               'auto.components.settings.AccountsPane.96f3649526',
-              'Use Gemini CLI credentials (experimental)'
+              'Use Antigravity / Gemini CLI credentials (experimental)'
             )}
           </Label>
           <p className="text-xs text-muted-foreground">
             {translate(
               'auto.components.settings.AccountsPane.c2aee76420',
-              'Extracts OAuth credentials from your local Gemini CLI installation to authenticate with Google for {{value0}}. This uses credentials issued to the Gemini CLI app, not Orca. May break if Google updates the CLI. Use at your own risk.',
+              'Extracts OAuth credentials from your local Antigravity or Gemini CLI installation to authenticate with Google for {{value0}}. This uses credentials issued to the CLI app, not Orca. May break if Google updates the CLI. Use at your own risk.',
               { value0: localAccountRuntimeSentenceLabel }
             )}
           </p>
@@ -63,7 +63,7 @@ export function renderGeminiAccountsSection(model: AccountsPaneSectionModel): Re
         <Switch
           aria-label={translate(
             'auto.components.settings.AccountsPane.96f3649526',
-            'Use Gemini CLI credentials (experimental)'
+            'Use Antigravity / Gemini CLI credentials (experimental)'
           )}
           checked={settings.geminiCliOAuthEnabled}
           onCheckedChange={(checked) => {

--- a/src/renderer/src/components/settings/accounts-pane-provider-setting-sections.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-provider-setting-sections.tsx
@@ -3,7 +3,7 @@ import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Switch } from '../ui/switch'
-import { GeminiIcon, OpenCodeGoIcon } from '../status-bar/icons'
+import { AntigravityIcon, OpenCodeGoIcon } from '../status-bar/icons'
 import { SearchableSetting } from './SearchableSetting'
 import type { AccountsPaneSectionModel } from './accounts-pane-types'
 
@@ -14,7 +14,7 @@ export function renderGeminiAccountsSection(model: AccountsPaneSectionModel): Re
     <section key="gemini" id="accounts-gemini" className="space-y-4 scroll-mt-6">
       <div className="space-y-1">
         <h3 className="flex items-center gap-2 text-sm font-semibold">
-          <GeminiIcon size={16} />
+          <AntigravityIcon size={16} />
           {translate('auto.components.settings.AccountsPane.antigravityTitle', 'Antigravity')}
         </h3>
         <p className="text-xs text-muted-foreground">
@@ -40,7 +40,6 @@ export function renderGeminiAccountsSection(model: AccountsPaneSectionModel): Re
           'cli',
           'oauth',
           'credentials',
-          'experimental',
           'rate limit',
           'status bar'
         ]}
@@ -49,8 +48,8 @@ export function renderGeminiAccountsSection(model: AccountsPaneSectionModel): Re
         <div className="space-y-0.5">
           <Label>
             {translate(
-              'auto.components.settings.AccountsPane.useAntigravityCredentialsExp',
-              'Use Antigravity credentials (experimental)'
+              'auto.components.settings.AccountsPane.useAntigravityCredentials',
+              'Use Antigravity credentials'
             )}
           </Label>
           <p className="text-xs text-muted-foreground">
@@ -63,8 +62,8 @@ export function renderGeminiAccountsSection(model: AccountsPaneSectionModel): Re
         </div>
         <Switch
           aria-label={translate(
-            'auto.components.settings.AccountsPane.useAntigravityCredentialsExp',
-            'Use Antigravity credentials (experimental)'
+            'auto.components.settings.AccountsPane.useAntigravityCredentials',
+            'Use Antigravity credentials'
           )}
           checked={settings.geminiCliOAuthEnabled}
           onCheckedChange={(checked) => {

--- a/src/renderer/src/components/settings/accounts-pane-provider-setting-sections.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-provider-setting-sections.tsx
@@ -15,26 +15,27 @@ export function renderGeminiAccountsSection(model: AccountsPaneSectionModel): Re
       <div className="space-y-1">
         <h3 className="flex items-center gap-2 text-sm font-semibold">
           <GeminiIcon size={16} />
-          {translate('auto.components.settings.AccountsPane.0c64dc2a64', 'Gemini')}
+          {translate('auto.components.settings.AccountsPane.antigravityTitle', 'Antigravity')}
         </h3>
         <p className="text-xs text-muted-foreground">
           {translate(
-            'auto.components.settings.AccountsPane.973741a871',
-            'Configure Gemini provider settings.'
+            'auto.components.settings.AccountsPane.antigravityDescription',
+            'Configure Antigravity provider settings.'
           )}
         </p>
       </div>
 
       <SearchableSetting
         title={translate(
-          'auto.components.settings.AccountsPane.0c7f915b01',
-          'Use Gemini CLI credentials'
+          'auto.components.settings.AccountsPane.useAntigravityCredentials',
+          'Use Antigravity credentials'
         )}
         description={translate(
-          'auto.components.settings.AccountsPane.d676c41fc6',
-          'Extracts OAuth credentials from your local Gemini CLI installation to authenticate with Google. This uses credentials issued to the Gemini CLI app, not Orca. May break if Google updates the CLI. Use at your own risk.'
+          'auto.components.settings.AccountsPane.useAntigravityCredentialsDescription',
+          'Extracts OAuth credentials from your local Antigravity installation to authenticate with Google. This uses credentials issued to the Antigravity app, not Orca. May break if Google updates Antigravity. Use at your own risk.'
         )}
         keywords={[
+          'antigravity',
           'gemini',
           'cli',
           'oauth',
@@ -48,22 +49,22 @@ export function renderGeminiAccountsSection(model: AccountsPaneSectionModel): Re
         <div className="space-y-0.5">
           <Label>
             {translate(
-              'auto.components.settings.AccountsPane.96f3649526',
-              'Use Antigravity / Gemini CLI credentials (experimental)'
+              'auto.components.settings.AccountsPane.useAntigravityCredentialsExp',
+              'Use Antigravity credentials (experimental)'
             )}
           </Label>
           <p className="text-xs text-muted-foreground">
             {translate(
-              'auto.components.settings.AccountsPane.c2aee76420',
-              'Extracts OAuth credentials from your local Antigravity or Gemini CLI installation to authenticate with Google for {{value0}}. This uses credentials issued to the CLI app, not Orca. May break if Google updates the CLI. Use at your own risk.',
+              'auto.components.settings.AccountsPane.useAntigravityCredentialsWithRuntime',
+              'Extracts OAuth credentials from your local Antigravity installation to authenticate with Google for {{value0}}. This uses credentials issued to the Antigravity app, not Orca. May break if Google updates Antigravity. Use at your own risk.',
               { value0: localAccountRuntimeSentenceLabel }
             )}
           </p>
         </div>
         <Switch
           aria-label={translate(
-            'auto.components.settings.AccountsPane.96f3649526',
-            'Use Antigravity / Gemini CLI credentials (experimental)'
+            'auto.components.settings.AccountsPane.useAntigravityCredentialsExp',
+            'Use Antigravity credentials (experimental)'
           )}
           checked={settings.geminiCliOAuthEnabled}
           onCheckedChange={(checked) => {

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -99,14 +99,15 @@ export const getAccountsCodexSearchEntries = createLocalizedCatalog(() => [
 export const getAccountsGeminiSearchEntries = createLocalizedCatalog(() => [
   {
     title: translate(
-      'auto.components.settings.accounts.search.d819755b02',
-      'Use Gemini CLI credentials'
+      'auto.components.settings.accounts.search.useAntigravityCredentials',
+      'Use Antigravity credentials'
     ),
     description: translate(
-      'auto.components.settings.accounts.search.bada4a3218',
-      'Extracts OAuth credentials from your local Gemini CLI installation to authenticate with Google.'
+      'auto.components.settings.accounts.search.useAntigravityCredentialsDescription',
+      'Extracts OAuth credentials from your local Antigravity installation to authenticate with Google.'
     ),
     keywords: [
+      ...translateSearchKeyword('auto.components.settings.accounts.search.antigravity', 'antigravity'),
       ...translateSearchKeyword('auto.components.settings.accounts.search.e8e1ff3887', 'gemini'),
       ...translateSearchKeyword('auto.components.settings.accounts.search.8630464352', 'cli'),
       ...translateSearchKeyword('auto.components.settings.accounts.search.933deaf732', 'oauth'),

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
@@ -11,7 +11,7 @@ import {
   getDisplayedUsagePercentage,
   type UsagePercentageDisplay
 } from '../../../../shared/usage-percentage-display'
-import { barColor, formatResetCountdown, getWindowSections, ProviderIcon } from './tooltip'
+import { barColor, formatLocalizedResetCountdown, getWindowSections, ProviderIcon } from './tooltip'
 import { getProviderDisplayName } from './usage-error-copy'
 import { formatPlanLabel, usageTextColorClass } from './usage-roster-formatting'
 import { getUsageRosterRowState, type UsageRosterRowState } from './usage-roster-row-state'
@@ -77,7 +77,7 @@ function soonestResetLabel(sections: UsageSection[], now: number): string | null
   if (resets.length === 0) {
     return null
   }
-  return formatResetCountdown(Math.min(...resets) - now)
+  return formatLocalizedResetCountdown(Math.min(...resets) - now)
 }
 
 function UsageMetric({

--- a/src/renderer/src/components/status-bar/icons.tsx
+++ b/src/renderer/src/components/status-bar/icons.tsx
@@ -1,5 +1,20 @@
 import React from 'react'
 import minimaxIconUrl from '../../../../../resources/minimax-icon.svg?url'
+import antigravityIconUrl from '../../../../shared/agent-icons/antigravity.png?url'
+
+export function AntigravityIcon({ size = 14 }: { size?: number }): React.JSX.Element {
+  return (
+    <img
+      src={antigravityIconUrl}
+      alt=""
+      aria-hidden="true"
+      width={size}
+      height={size}
+      className="block shrink-0 rounded-sm"
+      style={{ width: size, height: size }}
+    />
+  )
+}
 
 export function OpenAIIcon({ size = 14 }: { size?: number }): React.JSX.Element {
   return (

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -35,14 +35,27 @@ export {
 export function formatTimeAgo(ts: number): string {
   const diff = Date.now() - ts
   if (diff < 60_000) {
-    return 'just now'
+    return translate('auto.components.status.bar.tooltip.justNow', 'just now')
   }
   const mins = Math.floor(diff / 60_000)
   if (mins < 60) {
-    return `${mins}m ago`
+    return translate('auto.components.status.bar.tooltip.minutesAgo', '{{value0}}m ago', {
+      value0: mins
+    })
   }
   const hours = Math.floor(mins / 60)
-  return `${hours}h ago`
+  return translate('auto.components.status.bar.tooltip.hoursAgo', '{{value0}}h ago', {
+    value0: hours
+  })
+}
+
+export function formatLocalizedResetCountdown(ms: number): string {
+  const duration = formatResetDuration(ms)
+  return duration === 'now'
+    ? translate('auto.components.status.bar.tooltip.resetsNow', 'Resets now')
+    : translate('auto.components.status.bar.tooltip.resetsIn', 'Resets in {{value0}}', {
+        value0: duration
+      })
 }
 
 // Re-export so existing tooltip consumers/tests keep their import path; the
@@ -220,7 +233,7 @@ function ProviderRateLimitWindowSection({
   }
   const usedPct = clampUsedPercent(window.usedPercent)
   const displayedPct = getDisplayedUsagePercentage(usedPct, usagePercentageDisplay)
-  const resetLabel = window.resetsAt ? formatResetCountdown(window.resetsAt - now) : null
+  const resetLabel = window.resetsAt ? formatLocalizedResetCountdown(window.resetsAt - now) : null
 
   return (
     <div className="space-y-1">
@@ -303,7 +316,11 @@ export function ProviderPanel({
     )
   }
 
-  const updatedAgo = p.updatedAt ? `Updated ${formatTimeAgo(p.updatedAt)}` : 'Not yet updated'
+  const updatedAgo = p.updatedAt
+    ? translate('auto.components.status.bar.tooltip.updatedTimeAgo', 'Updated {{value0}}', {
+        value0: formatTimeAgo(p.updatedAt)
+      })
+    : translate('auto.components.status.bar.tooltip.notYetUpdated', 'Not yet updated')
   const resetCreditCount =
     showResetCredits && p.provider === 'codex'
       ? (p.rateLimitResetCredits?.availableCount ?? null)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6398,7 +6398,13 @@
           "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
           "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
           "codexConfigSyncManagedHomeUnavailable": "Orca could not read this account’s Codex files just now, so settings may not be syncing. This usually clears on its own — antivirus or a backup tool briefly locks them.",
-          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions.",
+          "antigravityTitle": "Antigravity",
+          "antigravityDescription": "Configure Antigravity provider settings.",
+          "useAntigravityCredentials": "Use Antigravity credentials",
+          "useAntigravityCredentialsDescription": "Extracts OAuth credentials from your local Antigravity installation to authenticate with Google. This uses credentials issued to the Antigravity app, not Orca. May break if Google updates Antigravity. Use at your own risk.",
+          "useAntigravityCredentialsExp": "Use Antigravity credentials (experimental)",
+          "useAntigravityCredentialsWithRuntime": "Extracts OAuth credentials from your local Antigravity installation to authenticate with Google for {{value0}}. This uses credentials issued to the Antigravity app, not Orca. May break if Google updates Antigravity. Use at your own risk."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",
@@ -8765,7 +8771,10 @@
             "d2c6a0e8f1": "grok",
             "c1b5f9d7e0": "xai",
             "b0a4e8c6d9": "oauth",
-            "a9f3d7b5c8": "login"
+            "a9f3d7b5c8": "login",
+            "useAntigravityCredentials": "Use Antigravity credentials",
+            "useAntigravityCredentialsDescription": "Extracts OAuth credentials from your local Antigravity installation to authenticate with Google.",
+            "antigravity": "antigravity"
           }
         },
         "advanced": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -707,7 +707,12 @@
             "worktreeHandoffSummary": "Move work to an agent that is already running in a different branch.",
             "childSequenceSummary": "Use child agents one after another when each phase depends on the last.",
             "childParallelSummary": "Split non-overlapping investigation or implementation tasks across child agents.",
-            "prSplitSummary": "Give each child agent its own worktree so parallel implementation stays reviewable."
+            "prSplitSummary": "Give each child agent its own worktree so parallel implementation stays reviewable.",
+            "handoffPrompt": "Use {{value0}} to hand this billing settings task to the idle Claude agent. Include the goal, current context, and what they should finish next.",
+            "worktreeHandoffPrompt": "Use {{value0}} to hand this settings cleanup to the agent in the settings-polish worktree. Send the goal, relevant files, and expected result.",
+            "childSequencePrompt": "Use {{value0}} to run this auth refactor in phases: plan, backend, UI, then tests. Start each child agent after the previous phase is done.",
+            "childParallelPrompt": "Use {{value0}} to split this auth refactor across parallel child agents: API contract, backend call sites, UI flow, and test gaps.",
+            "prSplitPrompt": "Use {{value0}} to split this onboarding update into smaller PRs, each in its own child worktree: setup state, settings UI, copy, and tests."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3848,7 +3848,14 @@
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
-            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage."
+            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage.",
+            "justNow": "just now",
+            "minutesAgo": "{{value0}}m ago",
+            "hoursAgo": "{{value0}}h ago",
+            "updatedTimeAgo": "Updated {{value0}}",
+            "notYetUpdated": "Not yet updated",
+            "resetsNow": "Resets now",
+            "resetsIn": "Resets in {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"

--- a/src/renderer/src/lib/orchestration-usage-examples.ts
+++ b/src/renderer/src/lib/orchestration-usage-examples.ts
@@ -2,6 +2,8 @@ import { translate } from '@/i18n/i18n'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import type { SkillUsageExample } from './skill-usage-example'
 
+const ORCHESTRATION_SLASH_COMMAND = '/orchestration'
+
 export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsageExample[] => [
   {
     id: 'handoff',
@@ -10,8 +12,11 @@ export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsa
       'auto.lib.orchestration.usage.examples.handoffSummary',
       'Move ownership to another agent with enough context to continue.'
     ),
-    prompt:
-      'Use /orchestration to hand this billing settings task to the idle Claude agent. Include the goal, current context, and what they should finish next.'
+    prompt: translate(
+      'auto.lib.orchestration.usage.examples.handoffPrompt',
+      'Use {{value0}} to hand this billing settings task to the idle Claude agent. Include the goal, current context, and what they should finish next.',
+      { value0: ORCHESTRATION_SLASH_COMMAND }
+    )
   },
   {
     id: 'worktree-handoff',
@@ -23,8 +28,11 @@ export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsa
       'auto.lib.orchestration.usage.examples.worktreeHandoffSummary',
       'Move work to an agent that is already running in a different branch.'
     ),
-    prompt:
-      'Use /orchestration to hand this settings cleanup to the agent in the settings-polish worktree. Send the goal, relevant files, and expected result.'
+    prompt: translate(
+      'auto.lib.orchestration.usage.examples.worktreeHandoffPrompt',
+      'Use {{value0}} to hand this settings cleanup to the agent in the settings-polish worktree. Send the goal, relevant files, and expected result.',
+      { value0: ORCHESTRATION_SLASH_COMMAND }
+    )
   },
   {
     id: 'child-sequence',
@@ -33,8 +41,11 @@ export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsa
       'auto.lib.orchestration.usage.examples.childSequenceSummary',
       'Use child agents one after another when each phase depends on the last.'
     ),
-    prompt:
-      'Use /orchestration to run this auth refactor in phases: plan, backend, UI, then tests. Start each child agent after the previous phase is done.'
+    prompt: translate(
+      'auto.lib.orchestration.usage.examples.childSequencePrompt',
+      'Use {{value0}} to run this auth refactor in phases: plan, backend, UI, then tests. Start each child agent after the previous phase is done.',
+      { value0: ORCHESTRATION_SLASH_COMMAND }
+    )
   },
   {
     id: 'child-parallel',
@@ -46,8 +57,11 @@ export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsa
       'auto.lib.orchestration.usage.examples.childParallelSummary',
       'Split non-overlapping investigation or implementation tasks across child agents.'
     ),
-    prompt:
-      'Use /orchestration to split this auth refactor across parallel child agents: API contract, backend call sites, UI flow, and test gaps.'
+    prompt: translate(
+      'auto.lib.orchestration.usage.examples.childParallelPrompt',
+      'Use {{value0}} to split this auth refactor across parallel child agents: API contract, backend call sites, UI flow, and test gaps.',
+      { value0: ORCHESTRATION_SLASH_COMMAND }
+    )
   },
   {
     id: 'child-worktrees',
@@ -59,7 +73,10 @@ export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsa
       'auto.lib.orchestration.usage.examples.prSplitSummary',
       'Give each child agent its own worktree so parallel implementation stays reviewable.'
     ),
-    prompt:
-      'Use /orchestration to split this onboarding update into smaller PRs, each in its own child worktree: setup state, settings UI, copy, and tests.'
+    prompt: translate(
+      'auto.lib.orchestration.usage.examples.prSplitPrompt',
+      'Use {{value0}} to split this onboarding update into smaller PRs, each in its own child worktree: setup state, settings UI, copy, and tests.',
+      { value0: ORCHESTRATION_SLASH_COMMAND }
+    )
   }
 ])

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -359,7 +359,7 @@ export type GlobalSettings = {
   minimaxGroupId: string
   /** Comma-separated MiniMax model names to show in the status bar usage window. */
   minimaxUsageModels: string
-  /** Extract OAuth credentials from the local Gemini CLI for rate-limit fetching. Off by default (explicit opt-in). */
+  /** Extract OAuth credentials from the local Antigravity / Gemini CLI for rate-limit fetching. Off by default (explicit opt-in). */
   geminiCliOAuthEnabled: boolean
   /** Per-agent CLI command overrides. A missing key means use the catalog default binary name. */
   agentCmdOverrides: Partial<Record<TuiAgent, string>>


### PR DESCRIPTION
### Summary
This PR adds comprehensive support for live Google Antigravity quota tracking via the local Language Server (Connect-RPC), updates AI provider account settings and branding from "Gemini" to "Antigravity", and enables full internationalization for previously static UI copy across the status bar and orchestration panes.

---

### Key Changes

#### 1. Live Antigravity Quota Monitoring
- **Dynamic Endpoint Discovery**: Discovers running Antigravity Language Server processes by scanning listening local ports and command-line arguments (`--api_server_port`).
- **Local Connect-RPC Client**: Issues direct gRPC-Web/Connect-RPC requests (`/google.internal.antigravity.v1.AntigravityService/GetUserStatus`) using CSRF tokens extracted from active processes.
- **Streamlined 2-Bar Presentation**: Displays only **Session (5h)** and **Weekly (7d)** windows, automatically switching between Gemini models and 3P models (Claude/GPT) based on active consumption.
- **Polling Cadence**: Configured polling interval to **1 minute** with individual on-demand refetch support.

#### 2. Provider Account Settings & Branding
- Replaced "Gemini" branding with **"Antigravity"** in the AI Provider Accounts settings section (`accounts-pane-provider-setting-sections.tsx`).
- Added `AntigravityIcon` (`icons.tsx`) utilizing the bundled official agent asset.
- Removed the `(experimental)` label to reflect stable local quota fetching.
- Added `antigravity` keywords to the settings search catalog (`accounts-search.ts`).

#### 3. UI Internationalization (i18n)
- **Orchestration Prompt Examples**: Wrapped all 5 example prompts in `translate()` within `orchestration-usage-examples.ts`.
- **Status Bar Timestamps & Countdown**: Localized time helpers (`formatTimeAgo`, `formatLocalizedResetCountdown`) in `tooltip.tsx` and `UsageRosterPanel.tsx` (`"Resets in..."`, `"Updated just now"`).

---

### Testing & Verification
- [x] `pnpm tc` passes across all workspace packages without type errors.
- [x] Unit tests for rate-limit fetcher and i18n components pass (`pnpm test`).
- [x] Status bar dynamically reflects 5h and weekly quota usage every 60 seconds.
- [x] Settings search properly indexes and filters "antigravity".
