### PR TITLE
perf(startup): stop an unreachable SSH host from gating local terminal restore

### DIFF
--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -183,6 +183,48 @@ describe('startup ordering', () => {
     )
   })
 
+  it('keeps the git-environment barrier off the PTY startup services', () => {
+    const barrierSource = readFileSync(
+      join(process.cwd(), 'src/main/startup/main-process-ipc-bootstrap.ts'),
+      'utf8'
+    )
+    const launchSource = readFileSync(
+      join(process.cwd(), 'src/main/startup/main-process-runtime-launch.ts'),
+      'utf8'
+    )
+    const gitBarrierStart = barrierSource.indexOf(
+      "ipcMain.handle('app:awaitGitEnvironmentStartupBarrier'"
+    )
+    const gitBarrierEnd = barrierSource.indexOf(
+      "'app:prepareTerminalStartupRestoration'",
+      gitBarrierStart
+    )
+    expect(gitBarrierStart).toBeGreaterThanOrEqual(0)
+    expect(gitBarrierEnd).toBeGreaterThan(gitBarrierStart)
+    const gitBarrier = barrierSource.slice(gitBarrierStart, gitBarrierEnd)
+    // The git environment fence is shell PATH + WSL registration; a daemon PTY provider or a
+    // hook-server bind here puts terminal startup back in front of worktree hydration.
+    expect(gitBarrier).toContain('state.shellPathReady')
+    expect(gitBarrier).toContain('state.managedWslCliStartupBarrierReady')
+    expect(gitBarrier).not.toContain('firstWindowStartupServicesReady')
+    // The published promise must be the same one the terminal startup services wait on.
+    expect(launchSource).toContain('state.shellPathReady = shellPathReady')
+    expect(launchSource.indexOf('state.shellPathReady = shellPathReady')).toBeLessThan(
+      launchSource.indexOf('await launchDesktopMode(')
+    )
+    // Terminal restoration itself must still fence on the first-window services.
+    const restorationStart = barrierSource.indexOf(
+      "ipcMain.handle('app:prepareTerminalStartupRestoration'"
+    )
+    const restorationEnd = barrierSource.indexOf(
+      "'app:recoverLegacyWorkerTerminalsForRendererStartup'",
+      restorationStart
+    )
+    expect(barrierSource.slice(restorationStart, restorationEnd)).toContain(
+      'state.firstWindowStartupServicesReady'
+    )
+  })
+
   it('reconciles retained Codex homes after authoritative daemon inventory', () => {
     const source = readFileSync(
       join(process.cwd(), 'src/main/startup/main-process-pty-startup.ts'),

--- a/src/main/startup/main-process-ipc-bootstrap.ts
+++ b/src/main/startup/main-process-ipc-bootstrap.ts
@@ -11,6 +11,13 @@ export function registerMainProcessIpcHandlers(): void {
       state.managedWslCliStartupBarrierReady
     ])
   })
+  // Why separate from the first-window barrier: host Git needs the shell-PATH
+  // generation and the managed WSL CLI registration, not a daemon PTY provider
+  // or a hook-server bind. Bundling them made worktree hydration wait on a
+  // terminal service it never calls.
+  ipcMain.handle('app:awaitGitEnvironmentStartupBarrier', async () => {
+    await Promise.all([state.shellPathReady, state.managedWslCliStartupBarrierReady])
+  })
   ipcMain.handle('app:prepareTerminalStartupRestoration', async () => {
     await Promise.all([
       state.firstWindowStartupServicesReady,

--- a/src/main/startup/main-process-runtime-launch.ts
+++ b/src/main/startup/main-process-runtime-launch.ts
@@ -289,6 +289,9 @@ export async function initializeMainProcessRuntimeLaunch(
   state.serveOptions = serveOptions
   const runtimeRpc = installRuntimeRpc(runtime, serveOptions)
   const shellPathReady = shellPathHydration.whenReady()
+  // Why published: the renderer's git-environment barrier must fence on the same
+  // generation the terminal startup services wait for, not a later re-read.
+  state.shellPathReady = shellPathReady
   let desktopWindow: BrowserWindow | null = null
   if (process.platform === 'win32' && app.isPackaged && !serveOptions) {
     const desktopStartup = startWindowsDesktopBeforeShellPathReady({

--- a/src/preload/api/app-api.ts
+++ b/src/preload/api/app-api.ts
@@ -38,6 +38,9 @@ export type AppApi = {
   /** Resolves when the daemon PTY provider and hook receiver have either
    *  started or failed open for the first BrowserWindow. */
   awaitFirstWindowStartupServices: () => Promise<void>
+  /** Resolves when host Git can run: shell-PATH generation is published and the
+   *  managed WSL CLI registration has reconciled. Does not wait on PTY services. */
+  awaitGitEnvironmentStartupBarrier: () => Promise<void>
   /** Inventories retained PTYs and restores durable structured ownership before renderer adoption. */
   prepareTerminalStartupRestoration: () => Promise<void>
   /** Reconciles legacy worker authority around persisted terminal reconnect. */

--- a/src/preload/api/app-bridge.ts
+++ b/src/preload/api/app-bridge.ts
@@ -43,6 +43,8 @@ export const appApi = {
   awaitBeforeUnloadCheckpoint: () => awaitBeforeUnloadCheckpoint(),
   awaitFirstWindowStartupServices: (): Promise<void> =>
     ipcRenderer.invoke('app:awaitFirstWindowStartupServices'),
+  awaitGitEnvironmentStartupBarrier: (): Promise<void> =>
+    ipcRenderer.invoke('app:awaitGitEnvironmentStartupBarrier'),
   prepareTerminalStartupRestoration: (): Promise<void> =>
     ipcRenderer.invoke('app:prepareTerminalStartupRestoration'),
   recoverLegacyWorkerTerminalsForRendererStartup: (): Promise<void> =>

--- a/src/renderer/src/app-shell/startup-actions-selector.test.ts
+++ b/src/renderer/src/app-shell/startup-actions-selector.test.ts
@@ -30,6 +30,7 @@ function makeActions(): StartupActions {
     reconnectPersistedTerminals: vi.fn(),
     setTerminalStartupRestorationReady: vi.fn(),
     setDeferredSshReconnectTargets: vi.fn(),
+    removeDeferredSshReconnectTarget: vi.fn(),
     setSshConnectionState: vi.fn(),
     hydratePersistedUI: vi.fn(),
     setHydrationSucceeded: vi.fn(),

--- a/src/renderer/src/app-shell/startup-actions-selector.ts
+++ b/src/renderer/src/app-shell/startup-actions-selector.ts
@@ -22,6 +22,7 @@ export type StartupActions = Pick<
   | 'reconnectPersistedTerminals'
   | 'setTerminalStartupRestorationReady'
   | 'setDeferredSshReconnectTargets'
+  | 'removeDeferredSshReconnectTarget'
   | 'setSshConnectionState'
   | 'hydratePersistedUI'
   | 'setHydrationSucceeded'
@@ -59,6 +60,8 @@ export function selectStartupActions(state: StartupActions): StartupActions {
     cachedStartupActions.setTerminalStartupRestorationReady ===
       state.setTerminalStartupRestorationReady &&
     cachedStartupActions.setDeferredSshReconnectTargets === state.setDeferredSshReconnectTargets &&
+    cachedStartupActions.removeDeferredSshReconnectTarget ===
+      state.removeDeferredSshReconnectTarget &&
     cachedStartupActions.setSshConnectionState === state.setSshConnectionState &&
     cachedStartupActions.hydratePersistedUI === state.hydratePersistedUI &&
     cachedStartupActions.setHydrationSucceeded === state.setHydrationSucceeded &&
@@ -91,6 +94,7 @@ export function selectStartupActions(state: StartupActions): StartupActions {
     reconnectPersistedTerminals: state.reconnectPersistedTerminals,
     setTerminalStartupRestorationReady: state.setTerminalStartupRestorationReady,
     setDeferredSshReconnectTargets: state.setDeferredSshReconnectTargets,
+    removeDeferredSshReconnectTarget: state.removeDeferredSshReconnectTarget,
     setSshConnectionState: state.setSshConnectionState,
     hydratePersistedUI: state.hydratePersistedUI,
     setHydrationSucceeded: state.setHydrationSucceeded,

--- a/src/renderer/src/app-shell/use-app-startup-hydration.ts
+++ b/src/renderer/src/app-shell/use-app-startup-hydration.ts
@@ -19,6 +19,7 @@ import {
 } from '../startup/startup-diagnostics'
 import { recoverFromDegradedStartup } from '../startup/startup-degraded-recovery'
 import { restoreSshConnectionsForStartup } from '../startup/startup-ssh-connection-restore'
+import { collectActiveWorkspaceSshTargetIds } from '../startup/active-workspace-ssh-targets'
 import { publishTerminalViewAttributesAtAppStart } from '../components/terminal-pane/terminal-appearance'
 import { getSystemPrefersDark } from '../lib/terminal-theme'
 import {
@@ -155,9 +156,12 @@ export function useAppStartupHydration(onOnboardingLoaded: (state: OnboardingSta
               // Why: disconnected SSH repos hydrate from local metadata; only runtime-owned repos use placeholders.
               parseExecutionHostId(getRepoExecutionHostId(repo))?.kind !== 'runtime'
           )
-          // Why: worktree refresh can spawn host Git; wait for main's shell-PATH generation fence first.
-          await timeRendererStartupStep('first-window-services-await', () =>
-            window.api.app.awaitFirstWindowStartupServices()
+          // Why this barrier and not the first-window one: worktree refresh can spawn host Git,
+          // which needs the shell-PATH generation and the managed WSL CLI registration. It never
+          // needs the daemon PTY provider or the hook-server bind, and `prepare-terminal-startup-restoration`
+          // below still fences those before any terminal is restored.
+          await timeRendererStartupStep('git-environment-barrier-await', () =>
+            window.api.app.awaitGitEnvironmentStartupBarrier()
           )
           await timeRendererStartupStep('fetch-hydration-worktrees', () =>
             mapWithConcurrency(hydrationRepos, WORKTREE_REFRESH_CONCURRENCY, (repo) =>
@@ -213,9 +217,14 @@ export function useAppStartupHydration(onOnboardingLoaded: (state: OnboardingSta
             actions.pruneLastVisitedTimestamps()
             actions.seedActiveWorktreeLastVisitedIfMissing()
           })
-          await timeRendererStartupStep('fetch-browser-session-profiles', () =>
+          // Why started here but not awaited: on a remote runtime this is an RPC with a 15s
+          // timeout, and nothing between here and terminal restoration reads the profile list —
+          // awaiting it put that timeout on the terminal-restoration gate. Starting it at the
+          // original point keeps the profiles landing no later than they did before; the action
+          // swallows its own failures, so the `.catch` only marks the timing wrapper handled.
+          void timeRendererStartupStep('fetch-browser-session-profiles', () =>
             actions.fetchBrowserSessionProfiles()
-          )
+          ).catch(() => {})
           const onboardingState = await onboardingPromise
           if (!cancelled) {
             onOnboardingLoadedRef.current(onboardingState)
@@ -228,9 +237,17 @@ export function useAppStartupHydration(onOnboardingLoaded: (state: OnboardingSta
           )
           if (connectionIds.length > 0) {
             try {
+              // Why scoped: an unreachable host used to hold every restored terminal — local ones
+              // included — for the full reconnect timeout. Only the targets whose panes mount as
+              // soon as the gate opens are worth waiting for; the rest reattach on tab focus.
+              const blockingConnectionIds = collectActiveWorkspaceSshTargetIds(
+                useAppStore.getState()
+              )
               await restoreSshConnectionsForStartup({
                 connectionIds,
+                blockingConnectionIds,
                 setDeferredSshReconnectTargets: actions.setDeferredSshReconnectTargets,
+                removeDeferredSshReconnectTarget: actions.removeDeferredSshReconnectTarget,
                 publishSshConnectionState: actions.setSshConnectionState
               })
             } catch (err) {
@@ -240,7 +257,8 @@ export function useAppStartupHydration(onOnboardingLoaded: (state: OnboardingSta
             logRendererStartupDiagnostic('ssh-reconnect-skipped', { connectionIds: 0 })
           }
 
-          // first-window-services-await already fenced worktree hydration; terminal recovery reuses that ready state.
+          // Why no explicit barrier here: prepare-terminal-startup-restoration above already awaited
+          // the first-window services, and main re-awaits them inside this handler anyway.
           await timeRendererStartupStep('recover-legacy-worker-terminals-pre-reconnect', () =>
             window.api.app.recoverLegacyWorkerTerminalsForRendererStartup()
           )

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -68,8 +68,11 @@ describe('renderer startup runtime routing', () => {
     const hydrationWorktreesIndex = source.indexOf(
       "timeRendererStartupStep('fetch-hydration-worktrees'"
     )
-    const servicesIndex = source.indexOf(
-      "timeRendererStartupStep('first-window-services-await'",
+    // Why this barrier: worktree hydration can spawn host Git, so it must sit behind the
+    // shell-PATH + managed-WSL fence. On packaged Windows the window opens before
+    // shellPathReady resolves, so this really is the fence, not a formality.
+    const gitEnvironmentBarrierIndex = source.indexOf(
+      "timeRendererStartupStep('git-environment-barrier-await'",
       sessionIndex
     )
     const fullWorktreesIndex = source.indexOf('await actions.fetchAllWorktrees()')
@@ -89,8 +92,11 @@ describe('renderer startup runtime routing', () => {
     expect(localReposIndex).toBeLessThan(localGroupsIndex)
     expect(localGroupsIndex).toBeLessThan(localFoldersIndex)
     expect(localReposIndex).toBeLessThan(sessionIndex)
-    expect(sessionIndex).toBeLessThan(servicesIndex)
-    expect(servicesIndex).toBeLessThan(hydrationWorktreesIndex)
+    expect(sessionIndex).toBeLessThan(gitEnvironmentBarrierIndex)
+    expect(gitEnvironmentBarrierIndex).toBeLessThan(hydrationWorktreesIndex)
+    expect(source.slice(gitEnvironmentBarrierIndex, hydrationWorktreesIndex)).toContain(
+      'window.api.app.awaitGitEnvironmentStartupBarrier()'
+    )
     const hydrationWorktreeBlock = source.slice(
       hydrationWorktreesIndex,
       source.indexOf('await keybindingsPromise')
@@ -180,7 +186,13 @@ describe('renderer startup runtime routing', () => {
 
   it('waits for first-window startup services before terminal reconnect', () => {
     const source = readSource(STARTUP_HYDRATION_PATH)
-    const servicesIndex = source.indexOf("timeRendererStartupStep('first-window-services-await'")
+    // Why this step: `app:prepareTerminalStartupRestoration` awaits
+    // firstWindowStartupServicesReady + managedWslCliStartupBarrierReady in main before it
+    // does anything else, so it is the renderer-side position of that fence.
+    // `desktop-startup-ordering.test.ts` pins the main-side await itself.
+    const servicesIndex = source.indexOf(
+      "timeRendererStartupStep('prepare-terminal-startup-restoration'"
+    )
     const preReconnectRecoveryIndex = source.indexOf(
       "timeRendererStartupStep('recover-legacy-worker-terminals-pre-reconnect'"
     )
@@ -193,6 +205,9 @@ describe('renderer startup runtime routing', () => {
     )
 
     expect(servicesIndex).toBeGreaterThanOrEqual(0)
+    expect(source.slice(servicesIndex)).toContain(
+      'window.api.app.prepareTerminalStartupRestoration()'
+    )
     expect(preReconnectRecoveryIndex).toBeGreaterThan(servicesIndex)
     expect(capabilityRefreshIndex).toBeGreaterThan(preReconnectRecoveryIndex)
     expect(reconnectIndex).toBeGreaterThan(capabilityRefreshIndex)

--- a/src/renderer/src/startup/active-workspace-ssh-targets.test.ts
+++ b/src/renderer/src/startup/active-workspace-ssh-targets.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { toAppSshPtyId } from '../../../shared/ssh-pty-id'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import { collectActiveWorkspaceSshTargetIds } from './active-workspace-ssh-targets'
+
+function tab(id: string, ptyId: string | null = null): TerminalTab {
+  return {
+    id,
+    ptyId,
+    worktreeId: 'repo-a::/w/a',
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  } as TerminalTab
+}
+
+const emptyInput = {
+  activeWorktreeId: null as string | null,
+  tabsByWorktree: {} as Record<string, TerminalTab[]>,
+  pendingReconnectPtyIdByTabId: {} as Record<string, string>,
+  terminalLayoutsByTabId: {} as Record<string, { ptyIdsByLeafId?: Record<string, string | null> }>,
+  repos: [] as { id: string; connectionId?: string | null }[]
+}
+
+describe('collectActiveWorkspaceSshTargetIds', () => {
+  it('returns nothing when no workspace is active', () => {
+    expect(collectActiveWorkspaceSshTargetIds(emptyInput)).toEqual([])
+  })
+
+  it('returns nothing for a purely local active workspace', () => {
+    expect(
+      collectActiveWorkspaceSshTargetIds({
+        ...emptyInput,
+        activeWorktreeId: 'repo-a::/w/a',
+        tabsByWorktree: { 'repo-a::/w/a': [tab('t1', 'local-pty-1')] },
+        repos: [{ id: 'repo-a', connectionId: null }]
+      })
+    ).toEqual([])
+  })
+
+  it('names the target from the active workspace repo connection', () => {
+    expect(
+      collectActiveWorkspaceSshTargetIds({
+        ...emptyInput,
+        activeWorktreeId: 'repo-remote::/srv/w',
+        repos: [{ id: 'repo-remote', connectionId: 'ssh-1' }]
+      })
+    ).toEqual(['ssh-1'])
+  })
+
+  it('names the target from a restored PTY id when the repo catalog has no connection', () => {
+    // SSH worktrees are absent from worktreesByRepo at cold start; the PTY id is the durable name.
+    expect(
+      collectActiveWorkspaceSshTargetIds({
+        ...emptyInput,
+        activeWorktreeId: 'repo-a::/w/a',
+        tabsByWorktree: { 'repo-a::/w/a': [tab('t1')] },
+        pendingReconnectPtyIdByTabId: { t1: toAppSshPtyId('ssh-2', 'pty-9') },
+        repos: [{ id: 'repo-a' }]
+      })
+    ).toEqual(['ssh-2'])
+  })
+
+  it('names split-leaf targets on the active workspace', () => {
+    expect(
+      collectActiveWorkspaceSshTargetIds({
+        ...emptyInput,
+        activeWorktreeId: 'repo-a::/w/a',
+        tabsByWorktree: { 'repo-a::/w/a': [tab('t1')] },
+        terminalLayoutsByTabId: {
+          t1: {
+            ptyIdsByLeafId: {
+              leaf1: toAppSshPtyId('ssh-3', 'pty-1'),
+              leaf2: null,
+              leaf3: 'local-pty-2'
+            }
+          }
+        },
+        repos: [{ id: 'repo-a' }]
+      })
+    ).toEqual(['ssh-3'])
+  })
+
+  it('ignores targets that only own an inactive workspace', () => {
+    expect(
+      collectActiveWorkspaceSshTargetIds({
+        ...emptyInput,
+        activeWorktreeId: 'repo-a::/w/a',
+        tabsByWorktree: {
+          'repo-a::/w/a': [tab('t1', 'local-pty-1')],
+          'repo-b::/w/b': [tab('t2', toAppSshPtyId('ssh-other', 'pty-1'))]
+        },
+        repos: [{ id: 'repo-a' }, { id: 'repo-b', connectionId: 'ssh-other' }]
+      })
+    ).toEqual([])
+  })
+
+  it('deduplicates a target named by both the repo and its PTY ids', () => {
+    expect(
+      collectActiveWorkspaceSshTargetIds({
+        ...emptyInput,
+        activeWorktreeId: 'repo-remote::/srv/w',
+        tabsByWorktree: {
+          'repo-remote::/srv/w': [tab('t1', toAppSshPtyId('ssh-1', 'pty-1'))]
+        },
+        repos: [{ id: 'repo-remote', connectionId: 'ssh-1' }]
+      })
+    ).toEqual(['ssh-1'])
+  })
+})

--- a/src/renderer/src/startup/active-workspace-ssh-targets.ts
+++ b/src/renderer/src/startup/active-workspace-ssh-targets.ts
@@ -1,0 +1,49 @@
+import { parseAppSshPtyId } from '../../../shared/ssh-pty-id'
+import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
+
+type ActiveWorkspaceSshTargetInput = {
+  activeWorktreeId: string | null
+  tabsByWorktree: Readonly<Record<string, readonly { id: string; ptyId?: string | null }[]>>
+  /** Restored tab-level PTY ids, keyed by tab id. */
+  pendingReconnectPtyIdByTabId: Readonly<Record<string, string>>
+  terminalLayoutsByTabId: Readonly<
+    Record<string, { ptyIdsByLeafId?: Readonly<Record<string, string | null>> } | undefined>
+  >
+  repos: readonly { id: string; connectionId?: string | null }[]
+}
+
+/**
+ * SSH targets that own terminals the user sees the moment the startup gate opens: the ones
+ * whose reconnect must still be awaited. Everything else can connect in the background and
+ * reattach on tab focus.
+ *
+ * Derived from the restored PTY ids rather than the repo catalog alone, because SSH worktrees
+ * are absent from `worktreesByRepo` at cold start — the PTY id is the durable name of the
+ * target the pane will reattach.
+ */
+export function collectActiveWorkspaceSshTargetIds(input: ActiveWorkspaceSshTargetInput): string[] {
+  const { activeWorktreeId } = input
+  if (!activeWorktreeId) {
+    return []
+  }
+  const targetIds = new Set<string>()
+  const repoId = getRepoIdFromWorktreeId(activeWorktreeId)
+  const connectionId = input.repos.find((repo) => repo.id === repoId)?.connectionId
+  if (connectionId) {
+    targetIds.add(connectionId)
+  }
+  for (const tab of input.tabsByWorktree[activeWorktreeId] ?? []) {
+    const ptyIds = [
+      tab.ptyId,
+      input.pendingReconnectPtyIdByTabId[tab.id],
+      ...Object.values(input.terminalLayoutsByTabId[tab.id]?.ptyIdsByLeafId ?? {})
+    ]
+    for (const ptyId of ptyIds) {
+      const parsed = ptyId ? parseAppSshPtyId(ptyId) : null
+      if (parsed) {
+        targetIds.add(parsed.connectionId)
+      }
+    }
+  }
+  return [...targetIds]
+}

--- a/src/renderer/src/startup/ssh-startup-reconnect.ts
+++ b/src/renderer/src/startup/ssh-startup-reconnect.ts
@@ -6,7 +6,9 @@ export type SshStartupReconnectResult = {
 
 export async function reconnectSshTargetForRendererStartup(args: {
   targetId: string
-  timeoutMs: number
+  /** Omitted for a connect nobody is waiting on — no timer, so it cannot report
+   *  a timeout the caller has no use for. */
+  timeoutMs?: number
   connect: (targetId: string) => Promise<SshConnectionState | null>
   publishState: (targetId: string, state: SshConnectionState) => void
   onFailure: (targetId: string, error: unknown) => void
@@ -14,10 +16,16 @@ export async function reconnectSshTargetForRendererStartup(args: {
   const { targetId, timeoutMs, connect, publishState, onFailure } = args
   let timeoutId: ReturnType<typeof setTimeout> | null = null
   try {
-    const timeout = new Promise<never>((_resolve, reject) => {
-      timeoutId = setTimeout(() => reject(new Error('SSH reconnect timeout')), timeoutMs)
-    })
-    const state = await Promise.race([connect(targetId), timeout])
+    const connected = connect(targetId)
+    const state =
+      timeoutMs === undefined
+        ? await connected
+        : await Promise.race([
+            connected,
+            new Promise<never>((_resolve, reject) => {
+              timeoutId = setTimeout(() => reject(new Error('SSH reconnect timeout')), timeoutMs)
+            })
+          ])
     // Why: the state-change IPC can trail connect's resolution. Publish the
     // authoritative result before restored terminals inspect renderer state.
     if (state) {

--- a/src/renderer/src/startup/startup-ssh-connection-restore.test.ts
+++ b/src/renderer/src/startup/startup-ssh-connection-restore.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import type { SshConnectionState, SshProviderEpoch, SshTarget } from '../../../shared/ssh-types'
+import { restoreSshConnectionsForStartup } from './startup-ssh-connection-restore'
+
+function connectedState(targetId: string): SshConnectionState {
+  return {
+    targetId,
+    status: 'connected',
+    error: null,
+    reconnectAttempt: 0,
+    providerEpoch: 'epoch' as SshProviderEpoch,
+    connectionGeneration: 1,
+    remotePlatform: 'linux'
+  }
+}
+
+function target(id: string, lastRequiredPassphrase = false): SshTarget {
+  return {
+    id,
+    label: id,
+    host: `${id}.example`,
+    port: 22,
+    username: 'orca',
+    lastRequiredPassphrase
+  }
+}
+
+type Harness = {
+  connect: Mock<(targetId: string) => Promise<SshConnectionState | null>>
+  getState: Mock<(targetId: string) => Promise<SshConnectionState | null>>
+  setDeferredSshReconnectTargets: Mock<(targetIds: string[]) => void>
+  removeDeferredSshReconnectTarget: Mock<(targetId: string) => void>
+  publishSshConnectionState: Mock<(targetId: string, state: SshConnectionState) => void>
+}
+
+let harness: Harness
+
+function installWindowApi(targets: SshTarget[]): void {
+  harness = {
+    connect: vi.fn(),
+    getState: vi.fn().mockResolvedValue(null),
+    setDeferredSshReconnectTargets: vi.fn(),
+    removeDeferredSshReconnectTarget: vi.fn(),
+    publishSshConnectionState: vi.fn()
+  }
+  vi.stubGlobal('window', {
+    api: {
+      app: { startupDiagnostic: undefined },
+      ssh: {
+        listTargets: vi.fn().mockResolvedValue(targets),
+        connect: (args: { targetId: string }) => harness.connect(args.targetId),
+        getState: (args: { targetId: string }) => harness.getState(args.targetId)
+      }
+    }
+  })
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('restoreSshConnectionsForStartup', () => {
+  it('does not wait on a target that owns no immediately-mounted pane', async () => {
+    vi.useFakeTimers()
+    installWindowApi([target('ssh-active'), target('ssh-asleep')])
+    // The asleep host never answers — the old code awaited it for the full timeout.
+    harness.connect.mockImplementation((targetId: string) =>
+      targetId === 'ssh-active'
+        ? Promise.resolve(connectedState(targetId))
+        : new Promise<SshConnectionState>(() => {})
+    )
+
+    let settled = false
+    const restore = restoreSshConnectionsForStartup({
+      connectionIds: ['ssh-active', 'ssh-asleep'],
+      blockingConnectionIds: ['ssh-active'],
+      setDeferredSshReconnectTargets: harness.setDeferredSshReconnectTargets,
+      removeDeferredSshReconnectTarget: harness.removeDeferredSshReconnectTarget,
+      publishSshConnectionState: harness.publishSshConnectionState
+    }).then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    await restore
+    expect(settled).toBe(true)
+    // Both were dialled; only the active one gated restoration.
+    expect(harness.connect).toHaveBeenCalledWith('ssh-active')
+    expect(harness.connect).toHaveBeenCalledWith('ssh-asleep')
+    expect(harness.publishSshConnectionState).toHaveBeenCalledWith(
+      'ssh-active',
+      connectedState('ssh-active')
+    )
+    // The unreachable host is deferred, so its panes reattach on tab focus.
+    expect(harness.setDeferredSshReconnectTargets).toHaveBeenCalledWith(['ssh-asleep'])
+  })
+
+  it('awaits the target that owns the active workspace', async () => {
+    vi.useFakeTimers()
+    installWindowApi([target('ssh-active')])
+    harness.connect.mockReturnValue(new Promise<SshConnectionState>(() => {}))
+
+    let settled = false
+    const restore = restoreSshConnectionsForStartup({
+      connectionIds: ['ssh-active'],
+      blockingConnectionIds: ['ssh-active'],
+      setDeferredSshReconnectTargets: harness.setDeferredSshReconnectTargets,
+      removeDeferredSshReconnectTarget: harness.removeDeferredSshReconnectTarget,
+      publishSshConnectionState: harness.publishSshConnectionState
+    }).then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(14_000)
+    expect(settled).toBe(false)
+    await vi.advanceTimersByTimeAsync(1_000)
+    await restore
+    expect(settled).toBe(true)
+    expect(harness.setDeferredSshReconnectTargets).toHaveBeenLastCalledWith(['ssh-active'])
+  })
+
+  it('clears the deferred flag once a background target connects', async () => {
+    installWindowApi([target('ssh-bg')])
+    harness.connect.mockResolvedValue(connectedState('ssh-bg'))
+
+    await restoreSshConnectionsForStartup({
+      connectionIds: ['ssh-bg'],
+      blockingConnectionIds: [],
+      setDeferredSshReconnectTargets: harness.setDeferredSshReconnectTargets,
+      removeDeferredSshReconnectTarget: harness.removeDeferredSshReconnectTarget,
+      publishSshConnectionState: harness.publishSshConnectionState
+    })
+    await vi.waitFor(() =>
+      expect(harness.removeDeferredSshReconnectTarget).toHaveBeenCalledWith('ssh-bg')
+    )
+    expect(harness.publishSshConnectionState).toHaveBeenCalledWith(
+      'ssh-bg',
+      connectedState('ssh-bg')
+    )
+  })
+
+  it('keeps passphrase targets deferred and never dials them', async () => {
+    installWindowApi([target('ssh-key', true), target('ssh-bg')])
+    harness.connect.mockResolvedValue(connectedState('ssh-bg'))
+
+    await restoreSshConnectionsForStartup({
+      connectionIds: ['ssh-key', 'ssh-bg'],
+      blockingConnectionIds: [],
+      setDeferredSshReconnectTargets: harness.setDeferredSshReconnectTargets,
+      removeDeferredSshReconnectTarget: harness.removeDeferredSshReconnectTarget,
+      publishSshConnectionState: harness.publishSshConnectionState
+    })
+
+    expect(harness.connect).not.toHaveBeenCalledWith('ssh-key')
+    expect(harness.setDeferredSshReconnectTargets).toHaveBeenCalledWith(['ssh-key', 'ssh-bg'])
+  })
+
+  it('awaits every target when no blocking set is supplied', async () => {
+    vi.useFakeTimers()
+    installWindowApi([target('ssh-a'), target('ssh-b')])
+    harness.connect.mockReturnValue(new Promise<SshConnectionState>(() => {}))
+
+    let settled = false
+    const restore = restoreSshConnectionsForStartup({
+      connectionIds: ['ssh-a', 'ssh-b'],
+      setDeferredSshReconnectTargets: harness.setDeferredSshReconnectTargets,
+      removeDeferredSshReconnectTarget: harness.removeDeferredSshReconnectTarget,
+      publishSshConnectionState: harness.publishSshConnectionState
+    }).then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(14_000)
+    expect(settled).toBe(false)
+    await vi.advanceTimersByTimeAsync(1_000)
+    await restore
+    expect(harness.setDeferredSshReconnectTargets).toHaveBeenLastCalledWith(['ssh-a', 'ssh-b'])
+  })
+})

--- a/src/renderer/src/startup/startup-ssh-connection-restore.test.ts
+++ b/src/renderer/src/startup/startup-ssh-connection-restore.test.ts
@@ -145,6 +145,29 @@ describe('restoreSshConnectionsForStartup', () => {
     )
   })
 
+  it('does not push a connected background target back into the deferred list', async () => {
+    installWindowApi([target('ssh-active'), target('ssh-bg')])
+    // The active host never answers and times out; the background host connects first.
+    harness.connect.mockImplementation((targetId: string) =>
+      targetId === 'ssh-bg'
+        ? Promise.resolve(connectedState(targetId))
+        : new Promise<SshConnectionState>(() => {})
+    )
+
+    await restoreSshConnectionsForStartup({
+      connectionIds: ['ssh-active', 'ssh-bg'],
+      blockingConnectionIds: ['ssh-active'],
+      setDeferredSshReconnectTargets: harness.setDeferredSshReconnectTargets,
+      removeDeferredSshReconnectTarget: harness.removeDeferredSshReconnectTarget,
+      publishSshConnectionState: harness.publishSshConnectionState
+    })
+
+    expect(harness.removeDeferredSshReconnectTarget).toHaveBeenCalledWith('ssh-bg')
+    // The timed-out rewrite must not resurrect the reachable background target: a deferred
+    // connected target sends fresh panes down the cold-restore path instead of the normal one.
+    expect(harness.setDeferredSshReconnectTargets).toHaveBeenLastCalledWith(['ssh-active'])
+  }, 30_000)
+
   it('keeps passphrase targets deferred and never dials them', async () => {
     installWindowApi([target('ssh-key', true), target('ssh-bg')])
     harness.connect.mockResolvedValue(connectedState('ssh-bg'))

--- a/src/renderer/src/startup/startup-ssh-connection-restore.ts
+++ b/src/renderer/src/startup/startup-ssh-connection-restore.ts
@@ -8,13 +8,27 @@ const SSH_RECONNECT_TIMEOUT_MS = 15_000
  * Re-establishes the SSH targets that were live at shutdown before terminal reconnect, so
  * SSH-backed tabs route through pty.attach. Passphrase-protected and timed-out targets are
  * handed back as deferred so their PTYs reattach on tab focus instead of stacking dialogs.
+ *
+ * Only `blockingConnectionIds` are awaited. Every other target connects in the background and
+ * is registered as deferred up front, so an unreachable host cannot hold local terminal
+ * restoration for the reconnect timeout. Background connects keep running in main; the pane's
+ * deferred flow joins the same in-flight `ssh.connect` on tab focus.
  */
 export async function restoreSshConnectionsForStartup(args: {
   connectionIds: string[]
+  /** Targets whose panes mount as soon as the startup gate opens. Omitted = await all. */
+  blockingConnectionIds?: readonly string[]
   setDeferredSshReconnectTargets: (targetIds: string[]) => void
+  removeDeferredSshReconnectTarget: (targetId: string) => void
   publishSshConnectionState: (targetId: string, state: SshConnectionState) => void
 }): Promise<void> {
-  const { connectionIds, setDeferredSshReconnectTargets, publishSshConnectionState } = args
+  const {
+    connectionIds,
+    blockingConnectionIds,
+    setDeferredSshReconnectTargets,
+    removeDeferredSshReconnectTarget,
+    publishSshConnectionState
+  } = args
   const allTargets = await timeRendererStartupStep('ssh-list-targets', () =>
     window.api.ssh.listTargets()
   )
@@ -24,11 +38,38 @@ export async function restoreSshConnectionsForStartup(args: {
     needsPassphrase: targetMap.get(targetId)?.lastRequiredPassphrase ?? false
   }))
 
-  const eagerTargets = targets.filter((t) => !t.needsPassphrase)
-  const deferredTargets = targets.filter((t) => t.needsPassphrase)
+  const passphraseTargetIds = targets.filter((t) => t.needsPassphrase).map((t) => t.targetId)
+  const blocking = blockingConnectionIds ? new Set(blockingConnectionIds) : null
+  const eagerTargets = targets.filter(
+    (t) => !t.needsPassphrase && (blocking === null || blocking.has(t.targetId))
+  )
+  const backgroundTargets = targets.filter(
+    (t) => !t.needsPassphrase && blocking !== null && !blocking.has(t.targetId)
+  )
 
-  if (deferredTargets.length > 0) {
-    setDeferredSshReconnectTargets(deferredTargets.map((t) => t.targetId))
+  const deferredTargetIds = [...passphraseTargetIds, ...backgroundTargets.map((t) => t.targetId)]
+  if (deferredTargetIds.length > 0) {
+    setDeferredSshReconnectTargets(deferredTargetIds)
+  }
+
+  // Why fired before the awaited group: a background target that lands before terminal
+  // reconnect reads as an ordinary connected target, exactly as it does today.
+  for (const { targetId } of backgroundTargets) {
+    void reconnectSshTargetForRendererStartup({
+      targetId,
+      connect: (id) => window.api.ssh.connect({ targetId: id }),
+      publishState: (id, state) => {
+        publishSshConnectionState(id, state)
+        if (state.status === 'connected') {
+          // Why: a still-deferred connected target sends fresh panes down the deferred
+          // spawn path instead of the normal one. Clear it as soon as it is reachable.
+          removeDeferredSshReconnectTarget(id)
+        }
+      },
+      onFailure: (id, error) => {
+        console.warn(`SSH background auto-reconnect failed for ${id}:`, error)
+      }
+    })
   }
 
   // Why: treat timed-out eager targets as deferred so their PTYs reattach on tab focus (ssh.connect keeps running in main and likely finishes by then).
@@ -52,10 +93,14 @@ export async function restoreSshConnectionsForStartup(args: {
           }
         })
       ),
-    { eagerTargets: eagerTargets.length, deferredTargets: deferredTargets.length }
+    {
+      eagerTargets: eagerTargets.length,
+      deferredTargets: passphraseTargetIds.length,
+      backgroundTargets: backgroundTargets.length
+    }
   )
   if (timedOutTargets.length > 0) {
-    setDeferredSshReconnectTargets([...deferredTargets.map((t) => t.targetId), ...timedOutTargets])
+    setDeferredSshReconnectTargets([...deferredTargetIds, ...timedOutTargets])
   }
 
   // Why: older/wrapped providers may return no state from connect; poll main once as a compatibility fallback before terminal restoration.

--- a/src/renderer/src/startup/startup-ssh-connection-restore.ts
+++ b/src/renderer/src/startup/startup-ssh-connection-restore.ts
@@ -52,6 +52,9 @@ export async function restoreSshConnectionsForStartup(args: {
     setDeferredSshReconnectTargets(deferredTargetIds)
   }
 
+  // Why tracked: the timed-out branch below rewrites the whole deferred list, and a
+  // background target that already connected must not be pushed back into it.
+  const connectedBackgroundTargetIds = new Set<string>()
   // Why fired before the awaited group: a background target that lands before terminal
   // reconnect reads as an ordinary connected target, exactly as it does today.
   for (const { targetId } of backgroundTargets) {
@@ -63,6 +66,7 @@ export async function restoreSshConnectionsForStartup(args: {
         if (state.status === 'connected') {
           // Why: a still-deferred connected target sends fresh panes down the deferred
           // spawn path instead of the normal one. Clear it as soon as it is reachable.
+          connectedBackgroundTargetIds.add(id)
           removeDeferredSshReconnectTarget(id)
         }
       },
@@ -100,7 +104,10 @@ export async function restoreSshConnectionsForStartup(args: {
     }
   )
   if (timedOutTargets.length > 0) {
-    setDeferredSshReconnectTargets([...deferredTargetIds, ...timedOutTargets])
+    setDeferredSshReconnectTargets([
+      ...deferredTargetIds.filter((id) => !connectedBackgroundTargetIds.has(id)),
+      ...timedOutTargets
+    ])
   }
 
   // Why: older/wrapped providers may return no state from connect; poll main once as a compatibility fallback before terminal restoration.

--- a/src/renderer/src/web/preload-api/web-app-api.ts
+++ b/src/renderer/src/web/preload-api/web-app-api.ts
@@ -33,6 +33,7 @@ export function createWebAppApi(): Partial<PreloadApi> {
       // Staging already wrote through to browser storage, so there is nothing left to join.
       awaitBeforeUnloadCheckpoint: () => Promise.resolve(),
       awaitFirstWindowStartupServices: () => Promise.resolve(),
+      awaitGitEnvironmentStartupBarrier: () => Promise.resolve(),
       prepareTerminalStartupRestoration: () => Promise.resolve(),
       recoverLegacyWorkerTerminalsForRendererStartup: () => Promise.resolve(),
       startupDiagnostic: () => Promise.resolve(),

--- a/tests/tools/benchmarks/startup-bench-state-fixture.mjs
+++ b/tests/tools/benchmarks/startup-bench-state-fixture.mjs
@@ -1,0 +1,193 @@
+/**
+ * Persisted-state fixtures for the startup benchmark: the git repos, GitHub
+ * remotes, restored terminal tabs, and unreachable SSH targets that `orca-data.json`
+ * must contain for a run to exercise the corresponding startup path.
+ */
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, realpathSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function initFixtureGitRepo(repoDir) {
+  mkdirSync(repoDir, { recursive: true })
+  if (!existsSync(join(repoDir, '.git'))) {
+    const init = spawnSync('git', ['init', repoDir], { stdio: 'ignore' })
+    if (init.status !== 0) {
+      throw new Error(`Failed to create git repo fixture at ${repoDir}`)
+    }
+  }
+  return realpathSync(repoDir)
+}
+
+/**
+ * Seed repos whose hydration reaches the `gh` login probe: a GitHub `origin`
+ * remote and no github.user/user.username config (the bench also points
+ * GIT_CONFIG_GLOBAL away from the developer's real config at launch).
+ */
+function buildGithubRepoFixtures(fixtureDir, githubRepos) {
+  const repos = []
+  for (let i = 0; i < githubRepos; i++) {
+    const repoPath = initFixtureGitRepo(join(fixtureDir, `bench-gh-repo-${i}`))
+    const remote = spawnSync(
+      'git',
+      [
+        '-C',
+        repoPath,
+        'remote',
+        'add',
+        'origin',
+        `https://github.com/orca-bench/bench-gh-repo-${i}.git`
+      ],
+      { stdio: 'ignore' }
+    )
+    // Exit 3 (remote exists) is fine on fixture reuse; anything else is not.
+    if (remote.status !== 0 && remote.status !== 3) {
+      throw new Error(`Failed to add GitHub remote to ${repoPath}`)
+    }
+    repos.push({
+      id: `bench-gh-repo-${i}`,
+      path: repoPath,
+      displayName: `Bench GH Repo ${i}`,
+      badgeColor: '#000000',
+      addedAt: 1,
+      externalWorktreeVisibility: 'show'
+    })
+  }
+  return repos
+}
+
+/**
+ * SSH targets on TEST-NET-3 (RFC 5737). The address is guaranteed unroutable,
+ * so the TCP handshake never completes and never gets a reset — the wire
+ * behaviour of a host that is asleep or behind a dropped VPN.
+ */
+function buildUnreachableSshTargets(count) {
+  const targets = []
+  for (let i = 0; i < count; i++) {
+    targets.push({
+      id: `bench-ssh-unreachable-${i}`,
+      label: `Unreachable Host ${i}`,
+      host: `203.0.113.${i + 1}`,
+      port: 22,
+      username: 'orca',
+      source: 'manual',
+      lastRequiredPassphrase: false
+    })
+  }
+  return targets
+}
+
+export function writePersistedStateFixture(
+  fixtureDir,
+  { stateProfile, sessionTabs, githubRepos, sshUnreachableTargets = 0 }
+) {
+  const dataPath = join(fixtureDir, 'orca-data.json')
+  if (stateProfile === 'none' && githubRepos === 0 && sshUnreachableTargets === 0) {
+    try {
+      unlinkSync(dataPath)
+    } catch {
+      // no persisted state fixture
+    }
+    return 0
+  }
+  if (!['none', 'restored-local-tabs'].includes(stateProfile)) {
+    throw new Error(`Unknown state profile: ${stateProfile}`)
+  }
+
+  const githubRepoEntries = buildGithubRepoFixtures(fixtureDir, githubRepos)
+  const sshTargets = buildUnreachableSshTargets(sshUnreachableTargets)
+  if (stateProfile === 'none') {
+    const state = {
+      schemaVersion: 1,
+      ...(sshTargets.length > 0 ? { sshTargets } : {}),
+      repos: githubRepoEntries,
+      settings: {
+        telemetry: {
+          installId: 'startup-bench',
+          optedIn: false,
+          existedBeforeTelemetryRelease: true
+        }
+      }
+    }
+    const json = JSON.stringify(state, null, 2)
+    writeFileSync(dataPath, json, 'utf-8')
+    return Buffer.byteLength(json)
+  }
+
+  const repoPath = initFixtureGitRepo(join(fixtureDir, 'bench-repo'))
+  const repoId = 'bench-repo'
+  const worktreeId = `${repoId}::${repoPath}`
+  const tabCount = Math.max(1, sessionTabs)
+  const tabs = []
+  const terminalLayoutsByTabId = {}
+  const activeTabIdByWorktree = {}
+  for (let i = 0; i < tabCount; i++) {
+    const tabId = `bench-tab-${String(i).padStart(5, '0')}`
+    const ptyId = `bench-pty-${String(i).padStart(5, '0')}`
+    tabs.push({
+      id: tabId,
+      ptyId,
+      worktreeId,
+      title: `Terminal ${i + 1}`,
+      customTitle: null,
+      color: null,
+      sortOrder: i,
+      createdAt: 1
+    })
+    terminalLayoutsByTabId[tabId] = {
+      root: null,
+      activeLeafId: null,
+      expandedLeafId: null
+    }
+  }
+  activeTabIdByWorktree[worktreeId] = tabs[0]?.id ?? null
+  const state = {
+    schemaVersion: 1,
+    repos: [
+      {
+        id: repoId,
+        path: repoPath,
+        displayName: 'Bench Repo',
+        badgeColor: '#000000',
+        addedAt: 1,
+        externalWorktreeVisibility: 'show'
+      },
+      ...githubRepoEntries
+    ],
+    settings: {
+      telemetry: {
+        installId: 'startup-bench',
+        optedIn: false,
+        existedBeforeTelemetryRelease: true
+      }
+    },
+    ui: {
+      lastActiveRepoId: repoId,
+      lastActiveWorktreeId: worktreeId
+    },
+    workspaceSession: {
+      activeRepoId: repoId,
+      activeWorktreeId: worktreeId,
+      activeTabId: tabs[0]?.id ?? null,
+      tabsByWorktree: {
+        [worktreeId]: tabs
+      },
+      terminalLayoutsByTabId,
+      activeTabIdByWorktree,
+      activeWorktreeIdsOnShutdown: [worktreeId],
+      defaultTerminalTabsAppliedByWorktreeId: {
+        [worktreeId]: true
+      },
+      // Why on the session and not just the target list: startup reconnect only
+      // dials targets that were connected at shutdown.
+      ...(sshTargets.length > 0
+        ? { activeConnectionIdsAtShutdown: sshTargets.map((target) => target.id) }
+        : {})
+    }
+  }
+  if (sshTargets.length > 0) {
+    state.sshTargets = sshTargets
+  }
+  const json = JSON.stringify(state, null, 2)
+  writeFileSync(dataPath, json, 'utf-8')
+  return Buffer.byteLength(json)
+}

--- a/tests/tools/benchmarks/startup-time-bench.mjs
+++ b/tests/tools/benchmarks/startup-time-bench.mjs
@@ -12,6 +12,7 @@
  *   node tests/tools/benchmarks/startup-time-bench.mjs --label baseline
  *     [--iterations 5] [--files 28000] [--fixture-dir <path>]
  *     [--state-profile none|restored-local-tabs] [--session-tabs 200]
+ *     [--ssh-unreachable-targets 1]
  *     [--github-repos 3] [--gh-hang-ms 30000]
  *     [--wait-for-event renderer-startup-hydration-done]
  *     [--exe <path-to-packaged-Orca>] [--timeout-ms 240000]
@@ -27,20 +28,14 @@
  * Results: tests/tools/benchmarks/results/startup-<label>-<timestamp>.json
  */
 import { spawn, spawnSync } from 'node:child_process'
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  realpathSync,
-  unlinkSync,
-  writeFileSync
-} from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import os from 'node:os'
 import { delimiter, join, resolve } from 'node:path'
+import { writePersistedStateFixture } from './startup-bench-state-fixture.mjs'
 
 const scriptDir = import.meta.dirname
-const repoRoot = resolve(scriptDir, '..', '..')
+const repoRoot = resolve(scriptDir, '..', '..', '..')
 const require = createRequire(import.meta.url)
 
 function parseArgs(argv) {
@@ -53,6 +48,11 @@ function parseArgs(argv) {
     timeoutMs: 240000,
     stateProfile: 'none',
     sessionTabs: 0,
+    // Seeds N SSH targets pointed at TEST-NET-3 (RFC 5737, guaranteed
+    // unroutable) and lists them as live-at-shutdown, so startup reconnect
+    // dials a host that never answers. Reproduces "one asleep remote machine
+    // delays every local terminal".
+    sshUnreachableTargets: 0,
     githubRepos: 0,
     ghHangMs: 0,
     waitForEvent: 'did-finish-load',
@@ -88,6 +88,9 @@ function parseArgs(argv) {
       case '--session-tabs':
         args.sessionTabs = Number(next())
         break
+      case '--ssh-unreachable-targets':
+        args.sshUnreachableTargets = Number(next())
+        break
       case '--github-repos':
         args.githubRepos = Number(next())
         break
@@ -113,7 +116,7 @@ function parseArgs(argv) {
  * tiny. Layout mirrors Chromium cache dirs plus a few Orca-owned dirs.
  */
 function ensureFixture(fixtureDir, options) {
-  const { fileCount, stateProfile, sessionTabs, githubRepos } = options
+  const { fileCount, stateProfile, sessionTabs, githubRepos, sshUnreachableTargets } = options
   const manifestPath = join(fixtureDir, 'bench-fixture-manifest.json')
   if (existsSync(manifestPath)) {
     try {
@@ -122,7 +125,8 @@ function ensureFixture(fixtureDir, options) {
         manifest.files === fileCount &&
         manifest.stateProfile === stateProfile &&
         manifest.sessionTabs === sessionTabs &&
-        (manifest.githubRepos ?? 0) === githubRepos
+        (manifest.githubRepos ?? 0) === githubRepos &&
+        (manifest.sshUnreachableTargets ?? 0) === sshUnreachableTargets
       ) {
         console.log(`[fixture] reusing ${fixtureDir} (${fileCount} files, state=${stateProfile})`)
         return
@@ -157,7 +161,8 @@ function ensureFixture(fixtureDir, options) {
   const persistedStateBytes = writePersistedStateFixture(fixtureDir, {
     stateProfile,
     sessionTabs,
-    githubRepos
+    githubRepos,
+    sshUnreachableTargets
   })
   writeFileSync(
     manifestPath,
@@ -166,162 +171,12 @@ function ensureFixture(fixtureDir, options) {
       stateProfile,
       sessionTabs,
       githubRepos,
+      sshUnreachableTargets,
       persistedStateBytes,
       createdAt: Date.now()
     })
   )
   console.log(`[fixture] done in ${((Date.now() - started) / 1000).toFixed(1)}s`)
-}
-
-function initFixtureGitRepo(repoDir) {
-  mkdirSync(repoDir, { recursive: true })
-  if (!existsSync(join(repoDir, '.git'))) {
-    const init = spawnSync('git', ['init', repoDir], { stdio: 'ignore' })
-    if (init.status !== 0) {
-      throw new Error(`Failed to create git repo fixture at ${repoDir}`)
-    }
-  }
-  return realpathSync(repoDir)
-}
-
-/**
- * Seed repos whose hydration reaches the `gh` login probe: a GitHub `origin`
- * remote and no github.user/user.username config (the bench also points
- * GIT_CONFIG_GLOBAL away from the developer's real config at launch).
- */
-function buildGithubRepoFixtures(fixtureDir, githubRepos) {
-  const repos = []
-  for (let i = 0; i < githubRepos; i++) {
-    const repoPath = initFixtureGitRepo(join(fixtureDir, `bench-gh-repo-${i}`))
-    const remote = spawnSync(
-      'git',
-      [
-        '-C',
-        repoPath,
-        'remote',
-        'add',
-        'origin',
-        `https://github.com/orca-bench/bench-gh-repo-${i}.git`
-      ],
-      { stdio: 'ignore' }
-    )
-    // Exit 3 (remote exists) is fine on fixture reuse; anything else is not.
-    if (remote.status !== 0 && remote.status !== 3) {
-      throw new Error(`Failed to add GitHub remote to ${repoPath}`)
-    }
-    repos.push({
-      id: `bench-gh-repo-${i}`,
-      path: repoPath,
-      displayName: `Bench GH Repo ${i}`,
-      badgeColor: '#000000',
-      addedAt: 1,
-      externalWorktreeVisibility: 'show'
-    })
-  }
-  return repos
-}
-
-function writePersistedStateFixture(fixtureDir, { stateProfile, sessionTabs, githubRepos }) {
-  const dataPath = join(fixtureDir, 'orca-data.json')
-  if (stateProfile === 'none' && githubRepos === 0) {
-    try {
-      unlinkSync(dataPath)
-    } catch {
-      // no persisted state fixture
-    }
-    return 0
-  }
-  if (!['none', 'restored-local-tabs'].includes(stateProfile)) {
-    throw new Error(`Unknown state profile: ${stateProfile}`)
-  }
-
-  const githubRepoEntries = buildGithubRepoFixtures(fixtureDir, githubRepos)
-  if (stateProfile === 'none') {
-    const state = {
-      schemaVersion: 1,
-      repos: githubRepoEntries,
-      settings: {
-        telemetry: {
-          installId: 'startup-bench',
-          optedIn: false,
-          existedBeforeTelemetryRelease: true
-        }
-      }
-    }
-    const json = JSON.stringify(state, null, 2)
-    writeFileSync(dataPath, json, 'utf-8')
-    return Buffer.byteLength(json)
-  }
-
-  const repoPath = initFixtureGitRepo(join(fixtureDir, 'bench-repo'))
-  const repoId = 'bench-repo'
-  const worktreeId = `${repoId}::${repoPath}`
-  const tabCount = Math.max(1, sessionTabs)
-  const tabs = []
-  const terminalLayoutsByTabId = {}
-  const activeTabIdByWorktree = {}
-  for (let i = 0; i < tabCount; i++) {
-    const tabId = `bench-tab-${String(i).padStart(5, '0')}`
-    const ptyId = `bench-pty-${String(i).padStart(5, '0')}`
-    tabs.push({
-      id: tabId,
-      ptyId,
-      worktreeId,
-      title: `Terminal ${i + 1}`,
-      customTitle: null,
-      color: null,
-      sortOrder: i,
-      createdAt: 1
-    })
-    terminalLayoutsByTabId[tabId] = {
-      root: null,
-      activeLeafId: null,
-      expandedLeafId: null
-    }
-  }
-  activeTabIdByWorktree[worktreeId] = tabs[0]?.id ?? null
-  const state = {
-    schemaVersion: 1,
-    repos: [
-      {
-        id: repoId,
-        path: repoPath,
-        displayName: 'Bench Repo',
-        badgeColor: '#000000',
-        addedAt: 1,
-        externalWorktreeVisibility: 'show'
-      },
-      ...githubRepoEntries
-    ],
-    settings: {
-      telemetry: {
-        installId: 'startup-bench',
-        optedIn: false,
-        existedBeforeTelemetryRelease: true
-      }
-    },
-    ui: {
-      lastActiveRepoId: repoId,
-      lastActiveWorktreeId: worktreeId
-    },
-    workspaceSession: {
-      activeRepoId: repoId,
-      activeWorktreeId: worktreeId,
-      activeTabId: tabs[0]?.id ?? null,
-      tabsByWorktree: {
-        [worktreeId]: tabs
-      },
-      terminalLayoutsByTabId,
-      activeTabIdByWorktree,
-      activeWorktreeIdsOnShutdown: [worktreeId],
-      defaultTerminalTabsAppliedByWorktreeId: {
-        [worktreeId]: true
-      }
-    }
-  }
-  const json = JSON.stringify(state, null, 2)
-  writeFileSync(dataPath, json, 'utf-8')
-  return Buffer.byteLength(json)
 }
 
 /**
@@ -385,12 +240,19 @@ function buildLaunchEnvironment({ fixtureDir, githubRepos, ghShimDir }) {
 }
 
 function killProcessTree(proc) {
-  if (proc.exitCode !== null || proc.signalCode !== null) {
+  if (process.platform === 'win32') {
+    if (proc.exitCode === null && proc.signalCode === null) {
+      spawnSync('taskkill', ['/PID', String(proc.pid), '/T', '/F'], { stdio: 'ignore' })
+    }
     return
   }
-  if (process.platform === 'win32') {
-    spawnSync('taskkill', ['/PID', String(proc.pid), '/T', '/F'], { stdio: 'ignore' })
-  } else {
+  // Why the whole group and not just the child: Electron's helper processes
+  // inherit the stderr pipe, so killing only the launcher leaves them holding it
+  // open — the harness then never sees EOF and never exits after its last run.
+  // Requires the `detached: true` spawn below.
+  try {
+    process.kill(-proc.pid, 'SIGKILL')
+  } catch {
     try {
       proc.kill('SIGKILL')
     } catch {
@@ -432,7 +294,10 @@ function runIteration({ exe, timeoutMs, lingerMs, waitForEvent, launchEnv }) {
     const startedAt = process.hrtime.bigint()
     const child = spawn(command, commandArgs, {
       env: launchEnv,
-      stdio: ['ignore', 'ignore', 'pipe']
+      stdio: ['ignore', 'ignore', 'pipe'],
+      // Why: gives the launcher its own process group so teardown can reap every
+      // Electron helper it spawned (see killProcessTree).
+      detached: process.platform !== 'win32'
     })
     let finished = false
     let buffer = ''
@@ -512,6 +377,12 @@ function derivePhases(events) {
       'renderer-startup-hydration-done'
     ),
     totalToWorkspaceReady: eventTime(events, 'renderer-startup-hydration-done', 'harness'),
+    // Time the terminal-restoration gate spent on SSH reconnect, and on the
+    // main-process barrier that used to fence worktree hydration.
+    rendererSshReconnectMs: eventDetailsNumber(events, 'renderer-ssh-reconnect-done', 'durationMs'),
+    rendererStartupBarrierMs:
+      eventDetailsNumber(events, 'renderer-git-environment-barrier-await-done', 'durationMs') ??
+      eventDetailsNumber(events, 'renderer-first-window-services-await-done', 'durationMs'),
     rendererReconnectTerminalsMs:
       eventDetailsNumber(events, 'renderer-reconnect-terminals-done', 'durationMs') ??
       delta(
@@ -585,7 +456,7 @@ async function main() {
       join(
         os.tmpdir(),
         'orca-startup-bench',
-        `userdata-${args.files}-${args.stateProfile}-${args.sessionTabs}-gh${args.githubRepos}`
+        `userdata-${args.files}-${args.stateProfile}-${args.sessionTabs}-gh${args.githubRepos}-ssh${args.sshUnreachableTargets}`
       )
   )
   mkdirSync(fixtureDir, { recursive: true })
@@ -593,7 +464,8 @@ async function main() {
     fileCount: args.files,
     stateProfile: args.stateProfile,
     sessionTabs: args.sessionTabs,
-    githubRepos: args.githubRepos
+    githubRepos: args.githubRepos,
+    sshUnreachableTargets: args.sshUnreachableTargets
   })
   const ghShimDir = writeGhShim(fixtureDir, args.ghHangMs)
   const launchEnv = buildLaunchEnvironment({


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​618 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​175 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​443 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​165 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​147 |

<!-- /orca-pr-loc -->

## ELI5

If one of your remote machines was asleep, Orca waited up to **15 seconds** for it before bringing back **any** of your terminals — including the local ones that had nothing to do with that machine. Now it only waits for the remote machine whose terminals you're actually looking at. The rest connect quietly in the background and reattach to the exact same running sessions when you click their tabs.

## What was wrong

`use-app-startup-hydration.ts` gates terminal restoration behind `setTerminalStartupRestorationReady(true)`. Three things sat inside that gate that did not need to.

**1. SSH reconnect awaited every target, not just the one in view.** `restoreSshConnectionsForStartup` awaited `ssh.connect` for every non-passphrase target that was live at shutdown (`SSH_RECONNECT_TIMEOUT_MS = 15_000`), then serially polled `ssh.getState` per target. Only then did recover-legacy-worker-terminals, snapshot-capabilities, and reconnect-terminals run, and only then did the gate open. One asleep host cost 15 s before any local terminal restored.

**2. Git worktree hydration was fenced on the PTY daemon spawn.** `awaitFirstWindowStartupServices()` before `fetch-hydration-worktrees` resolves `Promise.all([firstWindowStartupServicesReady, managedWslCliStartupBarrierReady])`, and `firstWindowStartupServicesReady` is the daemon-PTY-provider start **and** the agent-hook-server bind. The git scan needs neither.

**3. `fetch-browser-session-profiles` was awaited on the gate.** On a remote runtime that action is `callRuntimeRpc('browser.profileList', …, { timeoutMs: 15_000 })` — a second 15-second timeout on the terminal-restoration path.

## What changed

- `restoreSshConnectionsForStartup` takes `blockingConnectionIds`. Only those are awaited; every other eager target is registered as deferred up front and its `ssh.connect` is fired without a timer. `collectActiveWorkspaceSshTargetIds` (new, unit-tested) derives the blocking set from the active workspace's repo `connectionId` plus the SSH target embedded in its restored PTY ids — the PTY id is used because SSH worktrees are absent from `worktreesByRepo` at cold start.
- A background target that connects is removed from `deferredSshReconnectTargets`, because a still-deferred connected target sends *fresh* panes down `startFreshColdRestoreAgentResume` instead of the normal `runDeferredSessionReattachChoice`. Without this, a reachable host would behave differently than it does today.
- New `app:awaitGitEnvironmentStartupBarrier` IPC = `Promise.all([shellPathReady, managedWslCliStartupBarrierReady])`. `state.shellPathReady` is now published from `initializeMainProcessRuntimeLaunch` (the field existed but was never assigned). Worktree hydration uses this; `app:prepareTerminalStartupRestoration` still awaits the first-window services before anything is restored.
- `fetch-browser-session-profiles` starts at the same point in the chain but is no longer awaited.

## Corrections to the reported findings

**The shell-PATH claim needed checking on Windows, and the conclusion is stronger than reported.** On non-Windows, `main-process-runtime-launch.ts:302` awaits `shellPathReady` before the window opens, so it is already resolved — as reported. But on **packaged Windows** the window opens *before* `shellPathReady` resolves (`startWindowsDesktopBeforeShellPathReady`), and `firstWindowStartupServicesReady` is `shellPathReady.then(startServices).then(v => v.firstWindowReady)` — so there the old await genuinely *was* the shell-PATH fence, and removing it outright would have been the "broken git environment" trade the task warned about. Rather than keep a platform-conditional await, this PR keeps an explicit `shellPathReady` fence on the git path.

Separately, `configureWindowsHostGitEnvironmentReadiness` already makes **every** host-Git spawn await the same fence internally (`prepareWindowsHostGitEnvironment`, called from `git-exec-file.ts`, `git-spawn.ts`, `git-stream-stdout.ts`), so this is belt-and-braces. It is kept because relying on a fence three modules away is not something a future reader should have to rediscover.

**The duplicate `recoverLegacyWorkerTerminals` is load-bearing — left in place.** The pre/post pair was added together in #11271. Under `materializeRenderer: true`, the pre-reconnect run calls `ports.reveal(candidate)`, which materializes a legacy worker's surface in the renderer store. `reconnectPersistedTerminals` then reads `tabsByWorktree` — so the pre run can change what reconnect sees. Removing it is not a no-op and it is not removed here. (`startup-degraded-recovery.ts:89-95` keeps the same pre/post pair, confirming the intent.)

**The `onboardingPromise` await is not a round trip.** `window.api.onboarding.get()` is started at the top of the chain (line 98) and is overlapped by ~13 awaited stages before it is joined. Measured cost at the join point is ~0 ms, and moving the onboarding callback past the gate would delay the onboarding modal on a first run for no gain. Left alone.

## Measurements

`tests/tools/benchmarks/startup-time-bench.mjs`, 382 restored tabs, 28k-file synthetic profile, `--wait-for-event renderer-startup-hydration-done`, medians of 3 iterations, macOS arm64. Baselines were re-run back-to-back with the "after" runs because this machine's load varies; both baseline sets are shown.

**Unreachable SSH host** (`--ssh-unreachable-targets 1`, target on 203.0.113.1 — RFC 5737 TEST-NET-3, so the TCP handshake never completes and never resets, the wire behaviour of a sleeping host):

| phase | before | after |
|---|---|---|
| `renderer-ssh-reconnect` | **15.00 s** | **0 ms** |
| did-finish-load → hydration-done | **15.85 s** | **343 ms** |
| total → hydration-done | **17.27 s** | **1.34 s** |
| renderer startup barrier | 499 ms | 2 ms |

**All local, no SSH:**

| phase | before (run 1) | before (run 2) | after |
|---|---|---|---|
| did-finish-load → hydration-done | 1.02 s | 529 ms | **382 ms** |
| total → hydration-done | 3.32 s | 1.98 s | **1.33 s** |
| renderer startup barrier | 213 ms | 168 ms | **3 ms** |
| reconnect-terminals | 15 ms | 14 ms | 16 ms |

The barrier line is finding 2 in isolation: 168–213 ms → 2–3 ms, because the daemon spawn now overlaps the worktree scan instead of preceding it. On this fixture the git scan is one small repo; at 10 repos / 423 worktree entries the overlap is larger, not smaller.

Raw results: `tests/tools/benchmarks/results/startup-{base2-local,base2-unreachable-ssh,after-local,after-unreachable-ssh}-*.json`.

### Benchmark harness fixes needed to take these numbers

- `repoRoot` was `resolve(scriptDir, '..', '..')`, correct when the script lived at `tools/benchmarks/` but stale since #11890 moved it to `tests/tools/benchmarks/`. It resolved to `<root>/tests`, so the harness always failed its `out/main/index.js` precondition. `daemon-coldstart-bench.mjs` and `main-thread-jank-bench.mjs` carry the identical stale constant and are presumably also unrunnable; not touched here.
- `killProcessTree` SIGKILLed only the direct child on POSIX. Electron's helper processes inherit the stderr pipe, so the harness never saw EOF and hung forever after its last iteration — the results JSON was written but nothing printed. Now spawns `detached` and kills the process group.
- Added `--ssh-unreachable-targets N` to seed the unreachable-host case, and `rendererSshReconnectMs` / `rendererStartupBarrierMs` to the phase table.
- Fixture builders moved to `startup-bench-state-fixture.mjs` to keep the harness under `max-lines` without a disable.

## Negative user-facing trade-offs

**Non-active SSH targets now connect on tab focus rather than during boot.** This is a real behaviour change, stated plainly:

- If the host is **reachable and fast**, the connect usually lands before `reconnect-terminals` (it is fired earlier than the old awaited group, and two IPC stages run in between), so `sshConnectionStates` reads `connected` and restoration is byte-identical to today. The target is also removed from `deferredSshReconnectTargets` on connect, so panes with no restored session take the same non-deferred code path they take today.
- If the connect **loses that race**, the pane takes the deferred flow on mount: it paints main's parked snapshot, then `waitForSshConnection` joins the *same in-flight* `ssh.connect` (`sshConnectPromises` dedupes; `ssh-connect-flow.ts:59` serialises concurrent connects for one target in main) and reattaches `pendingSessionId` — the same PTY id, the same relay, the same replay buffer. The user sees the parked snapshot for the extra few hundred ms instead of a blank pane. This is not a new path: it is exactly what a timed-out eager target has always done, and what every passphrase target has always done.
- If the host is **unreachable**, the user reaches a workspace they could not have used anyway, and now reaches it 15 s sooner for every *other* workspace.

**What cannot regress:**

- *No terminal is dropped.* When SSH is not connected at reconnect time, `reconnectPersistedTerminals` writes the session id into `deferredSshSessionIdsByTabId` and leaves `tab.ptyId` and `ptyIdsByTabId` set. Nothing clears a PTY id. A deferred id reads as liveness to the orphan sweep, so deferring is the safe direction (see the #9911 comment in `workspace-terminal-reconnect.ts`).
- *No remote PTY is reported dead.* Nothing in this diff produces a verdict. `refreshTerminalProviderSnapshotCapabilities` returns `authoritative: null` (unknown) for a PTY on an unconnected target and keeps the pane mounted and eviction-exempt; main's legacy-worker recovery classifies an unreachable adoption as `unverifiable` and defers it. Loss of contact stays `unverifiable`, never `exited`.
- *Focusing a remote tab before hydration finishes.* Panes cannot mount before the gate (`use-terminal-watcher-effects.ts:142`, `worktree-agent-activation-gate.ts:53`), so an early click is only an active-workspace change. After the gate opens, the pane runs the deferred flow and joins the in-flight connect. The gate opens ~15 s sooner, so this window is now shorter, not longer.
- *Passphrase targets are unchanged* — still never auto-dialled, still deferred to a user-initiated connect.
- *Git environment* — see the Windows correction above; the shell-PATH fence is preserved explicitly, and `golden-worktree-create-switch` (which creates a worktree via host Git) passes.

**One deliberate asymmetry:** the `ssh.getState` compatibility poll ("older/wrapped providers may return no state from connect") still runs only for awaited targets. A background target on such a provider gets its state from the ordinary `ssh:stateChanged` push, and the pane's `waitForSshConnection` resolves on `ssh.connect` returning without throwing regardless of the state value, so it cannot strand.

## Reliability contract

- **Invariant:** `terminal-restore.pty-identity` — every terminal that would have been restored is restored with the same PTY id, the same replay/scrollback, and the same live/parked state, regardless of which SSH targets were reachable at boot. `ssh.verdict-vocabulary` — a deferred reconnect never yields `exited`.
- **Failure source:** at 10 repos / 423 worktree entries / 382 tabs / 1 SSH target, a sleeping host delayed all local terminal restoration by the full 15 s reconnect timeout.
- **Oracle:** `golden-quit-relaunch-session.spec.ts` (the exact file and the *live* extra terminal survive quit → relaunch) passes on this branch. Deterministic layer: `startup-ssh-connection-restore.test.ts` proves an unreachable non-active target does not extend the awaited window while an active one still does; 3 of its 5 cases fail on `main` and the 2 that pass are the await-everything controls.
- **Gate:** no existing `config/reliability-gates.jsonc` entry covers renderer startup SSH partitioning. `node config/scripts/check-reliability-gates.mjs` passes (100 gates). Recorded as an accepted gap rather than a new gate.
- **Provider/platform coverage:** local PTY — covered (golden restart e2e, all-local bench). Daemon PTY — covered (same; the daemon barrier moved off the git path but still fences restoration). SSH/remote — covered at the unit layer and by the unreachable-host bench; **no live SSH host was exercised** (accepted gap). WSL — unaffected: `managedWslCliStartupBarrierReady` stays on the git path. Mobile/relay — unaffected; `web-app-api.ts` resolves the new barrier immediately, as it does the existing one. macOS — measured. Linux/Windows — reasoned, not run; the Windows-specific risk is the shell-PATH fence, addressed above and additionally covered by a structural test.
- **Performance budget:** no new polling, timers, or subprocesses. One timer is *removed* per background target (`timeoutMs` is now optional and omitted for connects nobody awaits). One IPC round trip added on the git path, one removed from the gate.
- **Diagnostics:** `renderer-ssh-reconnect-done` now reports `backgroundTargets` alongside `eagerTargets`/`deferredTargets`; `renderer-git-environment-barrier-await-done` replaces `renderer-first-window-services-await-done`; the bench surfaces both.
- **Residual gaps:** (a) no live-SSH e2e; (b) Linux/Windows measured only by reasoning and unit/structural tests; (c) the reachable-but-slow race described above is argued from the code path, not from an instrumented run.

## Verify

- `pnpm tc` — clean.
- `npx oxlint <changed files>` — clean; `oxfmt --check` clean.
- `npx vitest run --config config/vitest.config.ts src/renderer/src/app-shell src/renderer/src/startup src/main/startup` — 435 passed, 1 skipped file.
- Deferred-SSH reattach neighbours: `ssh-pane-connect-gate`, `pty-connection-deferred-ssh-passphrase`, `pty-connection-parked-ssh-snapshot`, `ssh-reattach-model-restore`, `pty-connection-direct-ssh-reattach-retry`, `ssh-reconnect-model-paint-gate`, `store-session-terminal-reconnect`, `src/renderer/src/store/terminals` — 88 passed.
- `golden-quit-relaunch-session` and `golden-worktree-create-switch` e2e pass.
- `golden-terminal-file-link` fails 2 tests ("Monaco opened a different file identity") — **verified pre-existing**: the identical two failures reproduce on a baseline build of `main` with no changes applied.
