### PR TITLE
fix(process-table): fail a short `ps` capture loudly, and stop a resume spending 49 of them

### DIFF
--- a/src/main/runtime/structured-tui-process-identity.test.ts
+++ b/src/main/runtime/structured-tui-process-identity.test.ts
@@ -60,8 +60,18 @@ describe('structured TUI process identity', () => {
         platform: 'darwin',
         readPosixRows: async () => [
           { pid: 100, ppid: 1, stat: 'Ss', command: '/bin/zsh' },
-          { pid: 101, ppid: 100, stat: 'S+', command: 'node /opt/codex/bin/codex resume abc' },
-          { pid: 102, ppid: 101, stat: 'S+', command: '/opt/codex/vendor/codex' }
+          {
+            pid: 101,
+            ppid: 100,
+            stat: 'S+',
+            command: 'node /opt/codex/bin/codex resume abc'
+          },
+          {
+            pid: 102,
+            ppid: 101,
+            stat: 'S+',
+            command: '/opt/codex/vendor/codex'
+          }
         ],
         readStartTime
       })
@@ -83,9 +93,27 @@ describe('structured TUI process identity', () => {
         agent: 'codex',
         platform: 'win32',
         readWindowsRows: async () => [
-          { pid: 100, ppid: 1, name: 'pwsh.exe', command: 'pwsh.exe', executablePath: '' },
-          { pid: 101, ppid: 100, name: 'codex.exe', command: 'codex resume a', executablePath: '' },
-          { pid: 102, ppid: 100, name: 'codex.exe', command: 'codex resume b', executablePath: '' }
+          {
+            pid: 100,
+            ppid: 1,
+            name: 'pwsh.exe',
+            command: 'pwsh.exe',
+            executablePath: ''
+          },
+          {
+            pid: 101,
+            ppid: 100,
+            name: 'codex.exe',
+            command: 'codex resume a',
+            executablePath: ''
+          },
+          {
+            pid: 102,
+            ppid: 100,
+            name: 'codex.exe',
+            command: 'codex resume b',
+            executablePath: ''
+          }
         ],
         timeoutMs: 0
       })
@@ -107,7 +135,14 @@ describe('structured TUI process identity', () => {
           return [
             { pid: 100, ppid: 1, stat: 'Ss', command: '/bin/zsh' },
             ...(snapshots >= 3
-              ? [{ pid: 101, ppid: 100, stat: 'S+', command: 'codex resume session-1' }]
+              ? [
+                  {
+                    pid: 101,
+                    ppid: 100,
+                    stat: 'S+',
+                    command: 'codex resume session-1'
+                  }
+                ]
               : [])
           ]
         },
@@ -126,6 +161,81 @@ describe('structured TUI process identity', () => {
       spawnToken: 'spawn-2'
     })
     expect(delays).toEqual([25, 25])
+  })
+
+  // Each poll forks a whole-machine `ps` (~0.065 CPU-s at 1,460 processes), so the
+  // capture COUNT per identification is the cost, not the 5s wall ceiling.
+  function countCapturesForIdentification(input: {
+    captureCostMs: number
+    childAppearsAtMs: number | null
+  }): Promise<{
+    captures: number
+    identifiedAtMs: number | null
+    elapsedMs: number
+  }> {
+    let clockMs = 0
+    let captures = 0
+    return readStructuredTuiProcessIdentity({
+      hostId: 'local',
+      rootPid: 100,
+      spawnToken: 'spawn-cost',
+      agent: 'codex',
+      platform: 'darwin',
+      readPosixRows: async () => {
+        captures += 1
+        clockMs += input.captureCostMs
+        return [
+          { pid: 100, ppid: 1, stat: 'Ss', command: '/bin/zsh' },
+          ...(input.childAppearsAtMs !== null && clockMs >= input.childAppearsAtMs
+            ? [
+                {
+                  pid: 101,
+                  ppid: 100,
+                  stat: 'S+',
+                  command: 'codex resume session-1'
+                }
+              ]
+            : [])
+        ]
+      },
+      readStartTime: async () => 1_700_000_000_000,
+      now: () => clockMs,
+      sleep: async (delayMs) => {
+        clockMs += delayMs
+      }
+    }).then(
+      () => ({ captures, identifiedAtMs: clockMs, elapsedMs: clockMs }),
+      () => ({ captures, identifiedAtMs: null, elapsedMs: clockMs })
+    )
+  }
+
+  it('does not spend a hundred ps captures on an identification that never resolves', async () => {
+    const { captures, identifiedAtMs, elapsedMs } = await countCapturesForIdentification({
+      captureCostMs: 55,
+      childAppearsAtMs: null
+    })
+
+    expect(identifiedAtMs).toBeNull()
+    // The 5s ceiling is unchanged; only the captures inside it are.
+    expect(elapsedMs).toBeGreaterThanOrEqual(5_000)
+    // A flat 50ms poll spends ~48 captures here.
+    expect(captures).toBeLessThanOrEqual(20)
+  })
+
+  it('keeps identification latency identical while a child can still plausibly appear', async () => {
+    // The backoff must not touch the window a real spawn lands in: same capture
+    // count and same detection time as the flat 50ms poll.
+    for (const childAppearsAtMs of [0, 200, 500, 900]) {
+      const flatPollCaptures = Math.max(1, Math.ceil(childAppearsAtMs / (55 + 50)) + 1)
+      const { captures, identifiedAtMs } = await countCapturesForIdentification({
+        captureCostMs: 55,
+        childAppearsAtMs
+      })
+
+      expect(identifiedAtMs).not.toBeNull()
+      expect(captures).toBeLessThanOrEqual(flatPollCaptures)
+      expect(identifiedAtMs!).toBeLessThanOrEqual(childAppearsAtMs + 55 + 50)
+    }
   })
 
   it('fails closed when the process snapshot omitted the PTY root', async () => {

--- a/src/main/runtime/structured-tui-process-identity.ts
+++ b/src/main/runtime/structured-tui-process-identity.ts
@@ -15,6 +15,13 @@ type ProcessRow = { pid: number; ppid: number; command: string; foreground: bool
 
 const STRUCTURED_TUI_PROCESS_WAIT_MS = 5_000
 const STRUCTURED_TUI_PROCESS_POLL_MS = 50
+// Why: every poll forks a whole-machine `ps` (~0.065 CPU-s at 1,460 processes),
+// and the 5s ceiling is only reached when the child never appears at all — so the
+// tight interval buys nothing there. Hold it for the window in which a spawning
+// child plausibly lands (detection latency byte-identical), then widen. Past the
+// window the added latency is bounded by one interval.
+const STRUCTURED_TUI_PROCESS_FAST_POLL_WINDOW_MS = 1_000
+const STRUCTURED_TUI_PROCESS_MAX_POLL_MS = 500
 
 function descendants(rows: ProcessRow[], rootPid: number): (ProcessRow & { depth: number })[] {
   const children = new Map<number, ProcessRow[]>()
@@ -153,7 +160,9 @@ export async function readStructuredTuiProcessIdentity(input: {
   const platform = input.platform ?? process.platform
   const now = input.now ?? Date.now
   const sleep = input.sleep ?? ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)))
-  const deadline = now() + (input.timeoutMs ?? STRUCTURED_TUI_PROCESS_WAIT_MS)
+  const startedAtMs = now()
+  const deadline = startedAtMs + (input.timeoutMs ?? STRUCTURED_TUI_PROCESS_WAIT_MS)
+  let pollDelayMs = input.pollIntervalMs ?? STRUCTURED_TUI_PROCESS_POLL_MS
 
   while (true) {
     const rows: ProcessRow[] =
@@ -194,6 +203,13 @@ export async function readStructuredTuiProcessIdentity(input: {
       const label = input.agent === 'codex' ? 'Codex' : 'Claude'
       throw new Error(`The resumed terminal did not expose one exact ${label} child process.`)
     }
-    await sleep(Math.min(input.pollIntervalMs ?? STRUCTURED_TUI_PROCESS_POLL_MS, remainingMs))
+    await sleep(Math.min(pollDelayMs, remainingMs))
+    if (now() - startedAtMs >= STRUCTURED_TUI_PROCESS_FAST_POLL_WINDOW_MS) {
+      // Never below the caller's interval, so an explicitly slow poll stays slow.
+      pollDelayMs = Math.max(
+        pollDelayMs,
+        Math.min(pollDelayMs * 2, STRUCTURED_TUI_PROCESS_MAX_POLL_MS)
+      )
+    }
   }
 }

--- a/src/shared/process-table-snapshot.test.ts
+++ b/src/shared/process-table-snapshot.test.ts
@@ -15,6 +15,7 @@ import {
   parseProcessTableRows,
   parseStrictProcessTableRows,
   ProcessTableCaptureError,
+  PS_MAX_BUFFER_BYTES,
   resetProcessTableSnapshotForTests,
   type ProcessTableIndexStats
 } from './process-table-snapshot'
@@ -261,7 +262,14 @@ describe('shared process-table capture', () => {
 
     expect(forks()).toBe(1)
     expect(strict).toEqual([
-      { pid: 100, ppid: 1, pgid: 100, tpgid: 100, stat: 'Ss+', command: '/bin/zsh' }
+      {
+        pid: 100,
+        ppid: 1,
+        pgid: 100,
+        tpgid: 100,
+        stat: 'Ss+',
+        command: '/bin/zsh'
+      }
     ])
   })
 
@@ -293,7 +301,12 @@ describe('parseProcessTableRows', () => {
     )
     expect(rows).toEqual([
       { pid: 501, ppid: 1, stat: 'S', command: '/bin/zsh' },
-      { pid: 600, ppid: 501, stat: 'S+', command: 'node /path/bin/codex --flag' }
+      {
+        pid: 600,
+        ppid: 501,
+        stat: 'S+',
+        command: 'node /path/bin/codex --flag'
+      }
     ])
   })
 
@@ -320,11 +333,46 @@ describe('parseStrictProcessTableRows', () => {
         stat: 'I',
         command: '[pool_workqueue_release]'
       },
-      { pid: 4, ppid: 2, pgid: 0, tpgid: -1, stat: 'I', command: '[kworker/R-rcu_g]' },
-      { pid: 5, ppid: 2, pgid: 0, tpgid: -1, stat: 'I', command: '[kworker/R-sync_wq]' },
-      { pid: 6, ppid: 2, pgid: 0, tpgid: -1, stat: 'I', command: '[kworker/R-slub_]' },
-      { pid: 100, ppid: 1, pgid: 100, tpgid: 100, stat: 'Ss+', command: '/bin/bash -l' },
-      { pid: 101, ppid: 100, pgid: 101, tpgid: 101, stat: 'S+', command: 'node /opt/codex' }
+      {
+        pid: 4,
+        ppid: 2,
+        pgid: 0,
+        tpgid: -1,
+        stat: 'I',
+        command: '[kworker/R-rcu_g]'
+      },
+      {
+        pid: 5,
+        ppid: 2,
+        pgid: 0,
+        tpgid: -1,
+        stat: 'I',
+        command: '[kworker/R-sync_wq]'
+      },
+      {
+        pid: 6,
+        ppid: 2,
+        pgid: 0,
+        tpgid: -1,
+        stat: 'I',
+        command: '[kworker/R-slub_]'
+      },
+      {
+        pid: 100,
+        ppid: 1,
+        pgid: 100,
+        tpgid: 100,
+        stat: 'Ss+',
+        command: '/bin/bash -l'
+      },
+      {
+        pid: 101,
+        ppid: 100,
+        pgid: 101,
+        tpgid: 101,
+        stat: 'S+',
+        command: 'node /opt/codex'
+      }
     ])
   })
 
@@ -334,7 +382,14 @@ describe('parseStrictProcessTableRows', () => {
         ' PID PPID PGID TPGID STAT COMMAND\r\n 100 1 100 101 Ss /bin/zsh -l\r\n 101 100 101 101 S+ node /opt/codex --flag  value\r\n'
       )
     ).toEqual([
-      { pid: 100, ppid: 1, pgid: 100, tpgid: 101, stat: 'Ss', command: '/bin/zsh -l' },
+      {
+        pid: 100,
+        ppid: 1,
+        pgid: 100,
+        tpgid: 101,
+        stat: 'Ss',
+        command: '/bin/zsh -l'
+      },
       {
         pid: 101,
         ppid: 100,
@@ -348,10 +403,24 @@ describe('parseStrictProcessTableRows', () => {
 
   it('accepts no-controlling-tty sentinels for later unverifiable classification', () => {
     expect(parseStrictProcessTableRows('100 1 100 0 Ss /bin/zsh')).toEqual([
-      { pid: 100, ppid: 1, pgid: 100, tpgid: 0, stat: 'Ss', command: '/bin/zsh' }
+      {
+        pid: 100,
+        ppid: 1,
+        pgid: 100,
+        tpgid: 0,
+        stat: 'Ss',
+        command: '/bin/zsh'
+      }
     ])
     expect(parseStrictProcessTableRows('100 1 100 -1 Ss /bin/zsh')).toEqual([
-      { pid: 100, ppid: 1, pgid: 100, tpgid: -1, stat: 'Ss', command: '/bin/zsh' }
+      {
+        pid: 100,
+        ppid: 1,
+        pgid: 100,
+        tpgid: -1,
+        stat: 'Ss',
+        command: '/bin/zsh'
+      }
     ])
   })
 
@@ -416,7 +485,11 @@ describe('getProcessTableIndex', () => {
 
   it('keeps the memo out of measured builds so a cache hit cannot satisfy a perf gate', () => {
     const rows = parseProcessTableRows('100 1 Ss bash')
-    const stats: ProcessTableIndexStats = { indexBuilds: 0, rowVisits: 0, indexLookups: 0 }
+    const stats: ProcessTableIndexStats = {
+      indexBuilds: 0,
+      rowVisits: 0,
+      indexLookups: 0
+    }
 
     const memoized = getProcessTableIndex(rows)
     const measured = buildProcessTableIndex(rows, stats)
@@ -426,5 +499,100 @@ describe('getProcessTableIndex', () => {
     expect(stats).toEqual({ indexBuilds: 1, rowVisits: 1, indexLookups: 0 })
     // The measured build must not evict or replace the shared memo.
     expect(getProcessTableIndex(rows)).toBe(memoized)
+  })
+})
+
+describe('process-table capture completeness', () => {
+  const NODE_DEFAULT_MAX_BUFFER_BYTES = 1024 * 1024
+
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetProcessTableSnapshotForTests()
+  })
+
+  /**
+   * Emulate Node's own execFile buffering: over `maxBuffer` it kills the child and
+   * calls back with ERR_CHILD_PROCESS_STDIO_MAXBUFFER plus the truncated bytes. A
+   * mock that always resolves would hide the very ceiling under test.
+   */
+  function mockPsWithNodeBufferSemantics(stdout: string): void {
+    execFileMock.mockImplementation(
+      (_command: string, _args: string[], options: unknown, callback: unknown) => {
+        const done = callback as (err: unknown, result: { stdout: string; stderr: string }) => void
+        const maxBuffer =
+          (options as { maxBuffer?: number })?.maxBuffer ?? NODE_DEFAULT_MAX_BUFFER_BYTES
+        if (Buffer.byteLength(stdout, 'utf-8') > maxBuffer) {
+          const error = Object.assign(new Error('stdout maxBuffer length exceeded'), {
+            code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'
+          })
+          done(error, { stdout: stdout.slice(0, maxBuffer), stderr: '' })
+          return
+        }
+        done(null, { stdout, stderr: '' })
+      }
+    )
+  }
+
+  function busyHostTable(processCount: number): string {
+    // ~285 bytes/row, so 4k processes clears 1MB the way a real busy host does.
+    const argv = `/usr/bin/node ${'--inspect-brk-and-a-long-flag '.repeat(8)}server.js`
+    return `${Array.from(
+      { length: processCount },
+      (_, index) => `${1000 + index} 1 ${1000 + index} ${1000 + index} S+ ${argv}`
+    ).join('\n')}\n`
+  }
+
+  it('reads a busy host whose table overflows execFile 1MB default', async () => {
+    const table = busyHostTable(4_000)
+    expect(Buffer.byteLength(table, 'utf-8')).toBeGreaterThan(NODE_DEFAULT_MAX_BUFFER_BYTES)
+    mockPsWithNodeBufferSemantics(table)
+
+    // Without an explicit maxBuffer this rejects, so the whole subsystem degrades
+    // to "unverifiable" on every capture for as long as the host stays busy.
+    await expect(getProcessTableSnapshot()).resolves.toHaveLength(4_000)
+  })
+
+  it('reports a truncated capture as unreadable rather than a silently short table', async () => {
+    const table = busyHostTable(200)
+    const truncated = table + 'x'.repeat(PS_MAX_BUFFER_BYTES - table.length)
+    // A capture that stopped at the ceiling but still resolved: the lenient parser
+    // drops the cut tail without complaint, so 200 of N processes would read as
+    // the complete list — a false "no agent" the execution boundary forbids.
+    expect(parseProcessTableRows(truncated)).toHaveLength(200)
+    execFileMock.mockImplementation(
+      (_command: string, _args: string[], _options: unknown, callback: unknown) => {
+        ;(callback as (err: unknown, result: { stdout: string; stderr: string }) => void)(null, {
+          stdout: truncated,
+          stderr: ''
+        })
+      }
+    )
+
+    await expect(getProcessTableSnapshot()).rejects.toThrow(ProcessTableCaptureError)
+    await expect(getProcessTableSnapshot()).rejects.toThrow('capture_truncated')
+  })
+
+  it('names a buffer-ceiling rejection as truncation on both views', async () => {
+    mockPsWithNodeBufferSemantics('x'.repeat(PS_MAX_BUFFER_BYTES + 1))
+
+    await expect(getProcessTableSnapshot()).rejects.toThrow('capture_truncated')
+    resetProcessTableSnapshotForTests()
+    await expect(getStrictProcessTableSnapshot()).rejects.toThrow('capture_truncated')
+  })
+
+  it('reports an empty capture as unreadable rather than an empty process table', async () => {
+    // The lenient view used to answer [] here: zero processes on a machine that is
+    // by definition running at least `ps` itself.
+    execFileMock.mockImplementation(
+      (_command: string, _args: string[], _options: unknown, callback: unknown) => {
+        ;(callback as (err: unknown, result: { stdout: string; stderr: string }) => void)(null, {
+          stdout: '   \n',
+          stderr: ''
+        })
+      }
+    )
+
+    await expect(getProcessTableSnapshot()).rejects.toThrow(ProcessTableCaptureError)
+    await expect(getProcessTableSnapshot()).rejects.toThrow('empty_capture')
   })
 })

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -10,6 +10,11 @@ const execFile = promisify(execFileCb)
 /** Columns used by the evidence reader. Keep command last so its spaces survive parsing. */
 export const PS_ARGS = ['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=,command='] as const
 const PS_TIMEOUT_MS = 3000
+// Why: execFile's 1MB default leaves ~3x headroom (326KB / 1,460 processes, and
+// a single 5KB argv row is ordinary), so a busy host overflows it and then EVERY
+// capture fails — a readable process table degrading into permanent
+// "unverifiable". Matches the sibling reader in pty-descendant-termination.ts.
+export const PS_MAX_BUFFER_BYTES = 32 * 1024 * 1024
 
 // Why: 500ms is below the active cadence poll's minimum inter-poll gap (~675ms
 // = 750ms less jitter), so a cadence-driven pane never reuses a snapshot older
@@ -353,13 +358,44 @@ function createProcessTableCapture(stdout: string): ProcessTableCapture {
   }
 }
 
+/**
+ * Reject a capture that cannot be a whole process table.
+ *
+ * Why this is not redundant with the buffer ceiling: `parseProcessTableRows`
+ * drops unparseable lines, so a short capture reads as a *complete* table whose
+ * missing processes simply are not running — a false "no agent"/"no children",
+ * i.e. the `unverifiable` -> `exited` collapse the execution boundary forbids.
+ * Only the strict view would notice today; the lenient view would not. A capture
+ * that stopped at the ceiling, or that carries no rows at all, is unreadable
+ * evidence and must fail loudly on both views.
+ */
+function assertWholeCapture(stdout: string): string {
+  if (Buffer.byteLength(stdout, 'utf-8') >= PS_MAX_BUFFER_BYTES) {
+    throw new ProcessTableCaptureError('capture_truncated')
+  }
+  if (!/\S/.test(stdout)) {
+    throw new ProcessTableCaptureError('empty_capture')
+  }
+  return stdout
+}
+
 const processTableReader = createProcessTableSnapshotReader<ProcessTableCapture>({
   runPs: async () => {
-    const { stdout } = await execFile('ps', [...PS_ARGS], {
-      encoding: 'utf-8',
-      timeout: PS_TIMEOUT_MS
-    })
-    return createProcessTableCapture(stdout)
+    let stdout: string
+    try {
+      ;({ stdout } = await execFile('ps', [...PS_ARGS], {
+        encoding: 'utf-8',
+        timeout: PS_TIMEOUT_MS,
+        maxBuffer: PS_MAX_BUFFER_BYTES
+      }))
+    } catch (error) {
+      // A ceiling hit is truncation, not absence: name it in the domain vocabulary.
+      if ((error as { code?: unknown } | null)?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+        throw new ProcessTableCaptureError('capture_truncated')
+      }
+      throw error
+    }
+    return createProcessTableCapture(assertWholeCapture(stdout))
   },
   now: () => Date.now()
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​295 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​278 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |

<!-- /orca-pr-loc -->

## ELI5

To answer "is the agent still running in this terminal?", Orca asks the OS for the list of every running program and reads it into a buffer. That buffer had no size set, so it got the default 1 MB — and on my machine the list is already 326 KB. On a busier machine it overflows. When it overflows, Orca does not say "I couldn't read the list"; it quietly acts as if the programs it never read simply are not running. That is how "I can't tell" turns into "nothing is there" — the one conversion the execution-boundary rule forbids.

Separately, resuming an agent terminal reads that entire program list over and over — up to **49 times in five seconds** — waiting for the agent's process to show up. The first second of that is doing real work. The remaining four seconds are re-asking a question that has already answered "no" forty times.

## What changed

**Fix 1 — `src/shared/process-table-snapshot.ts`**

- Sets an explicit `maxBuffer` of 32 MB, matching the sibling reader in `src/main/pty-descendant-termination.ts` and its stated reasoning ("truncation would silently drop descendants from the snapshot").
- Adds a capture-integrity guard: a capture that reaches the buffer ceiling, or that carries no rows at all, now rejects with `ProcessTableCaptureError` (`capture_truncated` / `empty_capture`) instead of being parsed. A `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` rejection is renamed into the same domain vocabulary.

**Fix 2 — `src/main/runtime/structured-tui-process-identity.ts`**

- The poll interval holds at the caller's interval (default 50 ms) for the first **1 s**, then doubles per poll to a **500 ms** cap. `getFreshProcessTableSnapshot()` is retained — the freshness guarantee is what makes "root absent ⇒ root gone" sound, so it was not weakened to the TTL-cached reader.

### Correcting the reported premise for Fix 1

The investigation that motivated this said overflow produces "a partial process table presented as a complete one". **Measured, that is not what `execFile` does.** Promisified `execFile` *rejects* on overflow (`ERR_CHILD_PROCESS_STDIO_MAXBUFFER`), and every consumer already handles a rejection correctly as unavailable. So the reported false-negative is not reachable through the buffer ceiling today.

The real defects are the two adjacent ones, and both are demonstrated by failing tests:

- **The reader has no integrity guard of its own.** Verified by measurement: a capture cut at 4 KB parses to **59 of 1,463 rows** with no error, and an empty capture parses to `[]` with no error. `resolveAgentForegroundProcessWithAvailability` then answers `available: true` on that empty table. So the "silently short table" shape is genuinely present — it just needed a non-`execFile` route to reach it. This PR closes it at the capture boundary so no future exec wrapper can reopen it.
- **The 1 MB ceiling is an availability bug, not a correctness one.** At ~3x headroom a busy host fails *every* capture, so foreground inspection and structured-TUI identification degrade to permanently `unverifiable`.

Both are fixed; the verdict vocabulary (`live` / `unverifiable` / `exited`) is unchanged and no new synonym was introduced.

## Measurements

All on macOS, **1,460 processes**, Orca's exact `PS_ARGS`.

### Output size vs buffer limit

| | value |
| --- | --- |
| `ps` stdout | **326,180 bytes** |
| longest single row | **5,116 chars** |
| old limit (Node default) | 1,048,576 bytes — **3.2x headroom** |
| new limit | 33,554,432 bytes — **103x headroom** |
| cost of a capture | **0.065 CPU-s** (50 captures = 3.25 CPU-s user+sys, incl. the `ps` child) |

A 4,000-process host with ordinary argv produces ~1.14 MB and fails outright on the old limit; the regression test uses exactly that table.

### Captures per identification attempt (Fix 2)

Simulated clock, 55 ms measured capture cost, 5 s ceiling:

| child appears at | captures before | captures after | settled before | settled after |
| --- | --- | --- | --- | --- |
| 0 ms | 1 | **1** | 55 ms | 55 ms |
| 200 ms | 3 | **3** | 265 ms | 265 ms |
| 500 ms | 6 | **6** | 580 ms | 580 ms |
| 900 ms | 10 | **10** | 1000 ms | 1000 ms |
| 2000 ms | 20 | **15** | 2050 ms | 2525 ms |
| never (worst case) | **49** | **20** | 5055 ms | 5055 ms |

### CPU saved per resume

| case | before | after | saved |
| --- | --- | --- | --- |
| failed identification (worst case) | 49 x 0.065 = **3.19 CPU-s** | 20 x 0.065 = **1.30 CPU-s** | **1.89 CPU-s (59%)** |
| slow success (child at 2 s) | 1.30 CPU-s | 0.98 CPU-s | 0.33 CPU-s |
| normal success (child < 1 s) | unchanged | unchanged | **0** |

Note the corrected worst case is 49 captures, not 100: each capture costs ~55 ms of wall time on top of the 50 ms sleep, so a 5 s window fits ~48 iterations, not 100.

## Negative user-facing trade-offs

**None.**

- **Structured-TUI identification is not delayed in any user-visible case.** The table above is the evidence: for a child appearing at 0 / 200 / 500 / 900 ms, both the capture count and the settle time are *identical* before and after — the backoff does not begin until 1 s has elapsed. A real shell publishes its `codex`/`claude` child in well under that, and the capture itself already imposes a ~105 ms effective granularity, so the first second was never finer-grained than the fix leaves it.
- Past 1 s the added latency is bounded by one interval (**≤ 500 ms**), reached only by a child already 20x slower than normal, on a background resume proof whose own caller then waits up to 30 s for `tui-idle`. There is no interactive surface on this path.
- The 5 s ceiling, `PS_ARGS`, the 500 ms TTL, and every cadence tier are untouched.
- Fix 1 strictly *widens* availability: a capture that used to fail on a busy host now succeeds. The only new rejections are for captures that were already unusable, and they turn a false "no agent" into an honest `unavailable`.

## Reliability contract

- **Invariant:** `process-table.capture-completeness` — a process-table snapshot is either whole or unreadable; it is never partially delivered as complete. And `agent-session.foreground-availability` — an unreadable capture yields `available: false`, never a positive claim about what is running.
- **Failure source:** 3.2x buffer headroom at 1,460 processes; a lenient parser that discards unparseable rows silently.
- **Oracle:** consumer-observable. `getProcessTableSnapshot()` rejects rather than resolving with a short array; the busy-host table parses to all 4,000 rows. Both fail on `main`.
- **Provider/platform coverage:** macOS/Linux **covered** (this is the POSIX reader). **Windows unaffected** — `src/main/windows/windows-process-table.ts` supplies its own `runPs` to `createProcessTableSnapshotReader` via a Toolhelp32 snapshot, forks no child and has no buffer ceiling; `readStructuredTuiProcessIdentity`'s `win32` branch uses `queryWindowsProcessRowsFresh` and shares only the poll cadence, which changes identically on all three platforms. SSH/relay **covered** — the relay imports the same shared reader, and `pty-handler.listProcesses` already maps a capture failure to `table_unreadable` evidence.
- **Performance budget:** capture counts per identification are asserted deterministically in the test, not benchmarked. No timer, listener, subprocess or scan was added; one subprocess-per-poll was removed 29 times over.
- **Residual gaps:** the 1 MB ceiling is not reachable on the machine measured here, so the busy-host case is proved by an `execFile` mock that reproduces Node's exact buffering semantics rather than by a genuinely 4,000-process host.

## Tests

Six new regression tests, all verified red on `main`:

`src/shared/process-table-snapshot.test.ts`
- `reads a busy host whose table overflows execFile 1MB default` — red: *"promise rejected 'stdout maxBuffer length exceeded' instead of resolving"*
- `reports a truncated capture as unreadable rather than a silently short table` — red: *"promise resolved [200 rows] instead of rejecting"*
- `names a buffer-ceiling rejection as truncation on both views` — red
- `reports an empty capture as unreadable rather than an empty process table` — red: *"promise resolved [] instead of rejecting"*

`src/main/runtime/structured-tui-process-identity.test.ts`
- `does not spend a hundred ps captures on an identification that never resolves` — red: *"expected 49 to be less than or equal to 20"*
- `keeps identification latency identical while a child can still plausibly appear` — passes both before and after **by design**: it is the guard proving the fast path did not move.

## Verification

- `pnpm tc` — clean
- `npx oxlint <changed files>` — clean
- `npx vitest run --config config/vitest.config.ts src/shared src/main/runtime src/main/providers` — **13,478 passed**, plus the relay snapshot consumers (`pty-shell-utils`, `pty-handler-inventory-process-evidence`) for **13,511 passed** total
