### PR TITLE
fix(runtime): expose detached terminal topology and scrub stale pane identity

### DIFF
--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -26,7 +26,7 @@ export function formatTerminalList(result: RuntimeTerminalListResult): string {
   const body = result.terminals
     .map(
       (terminal) =>
-        `${terminal.handle}  ${terminal.title ?? '(untitled)'}  ${terminal.connected ? 'connected' : 'disconnected'}  host=${terminal.executionHostId ?? 'unverifiable'}  ${terminal.worktreePath}\n${terminal.preview ? `preview: ${terminal.preview}` : 'preview: <empty>'}`
+        `${terminal.handle}  ${terminal.title ?? '(untitled)'}  ${terminal.connected ? 'connected' : 'disconnected'}  visual=${terminal.visualTopologyState ?? 'unverifiable'}  host=${terminal.executionHostId ?? 'unverifiable'}  ${terminal.worktreePath}\n${terminal.preview ? `preview: ${terminal.preview}` : 'preview: <empty>'}`
     )
     .join('\n\n')
   const visualLayout = formatTerminalVisualLayouts(result.visualLayouts)
@@ -114,6 +114,7 @@ export function formatTerminalShow(result: { terminal: RuntimeTerminalShow }): s
     `ptyId: ${terminal.ptyId ?? 'none'}`,
     `connected: ${terminal.connected}`,
     `writable: ${terminal.writable}`,
+    `visualTopologyState: ${terminal.visualTopologyState ?? 'unverifiable'}`,
     // Why listed above the preview: the preview is where a reader would otherwise have to
     // spot the prompt by eye, which is the work this line exists to remove.
     `agentWait: ${formatAgentWait(terminal.agentWait)}`,

--- a/src/main/daemon/pty-subprocess-env-inheritance.test.ts
+++ b/src/main/daemon/pty-subprocess-env-inheritance.test.ts
@@ -126,12 +126,14 @@ describe('createPtySubprocess', () => {
       ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
       ORCA_TAB_ID: process.env.ORCA_TAB_ID,
       ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
-      ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE
+      ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE,
+      ORCA_AGENT_LAUNCH_TOKEN: process.env.ORCA_AGENT_LAUNCH_TOKEN
     }
     process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
     process.env.ORCA_TAB_ID = 'parent-tab'
     process.env.ORCA_WORKTREE_ID = 'parent-worktree'
     process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
+    process.env.ORCA_AGENT_LAUNCH_TOKEN = 'parent-launch-token'
 
     try {
       await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
@@ -150,6 +152,7 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_TAB_ID).toBeUndefined()
     expect(env.ORCA_WORKTREE_ID).toBeUndefined()
     expect(env.ORCA_TERMINAL_HANDLE).toBeUndefined()
+    expect(env.ORCA_AGENT_LAUNCH_TOKEN).toBeUndefined()
   })
 
   it('preserves explicit child Orca pane identity over parent env', async () => {
@@ -159,12 +162,14 @@ describe('createPtySubprocess', () => {
       ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
       ORCA_TAB_ID: process.env.ORCA_TAB_ID,
       ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
-      ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE
+      ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE,
+      ORCA_AGENT_LAUNCH_TOKEN: process.env.ORCA_AGENT_LAUNCH_TOKEN
     }
     process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
     process.env.ORCA_TAB_ID = 'parent-tab'
     process.env.ORCA_WORKTREE_ID = 'parent-worktree'
     process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
+    process.env.ORCA_AGENT_LAUNCH_TOKEN = 'parent-launch-token'
 
     try {
       await createPtySubprocess({
@@ -175,7 +180,8 @@ describe('createPtySubprocess', () => {
           ORCA_PANE_KEY: 'child-tab:child-leaf',
           ORCA_TAB_ID: 'child-tab',
           ORCA_WORKTREE_ID: 'child-worktree',
-          ORCA_TERMINAL_HANDLE: 'term_child'
+          ORCA_TERMINAL_HANDLE: 'term_child',
+          ORCA_AGENT_LAUNCH_TOKEN: 'child-launch-token'
         }
       })
     } finally {
@@ -193,6 +199,7 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_TAB_ID).toBe('child-tab')
     expect(env.ORCA_WORKTREE_ID).toBe('child-worktree')
     expect(env.ORCA_TERMINAL_HANDLE).toBe('term_child')
+    expect(env.ORCA_AGENT_LAUNCH_TOKEN).toBe('child-launch-token')
   })
 
   it.each([

--- a/src/main/daemon/pty-subprocess-env-inheritance.test.ts
+++ b/src/main/daemon/pty-subprocess-env-inheritance.test.ts
@@ -125,11 +125,13 @@ describe('createPtySubprocess', () => {
     const saved = {
       ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
       ORCA_TAB_ID: process.env.ORCA_TAB_ID,
-      ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID
+      ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
+      ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE
     }
     process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
     process.env.ORCA_TAB_ID = 'parent-tab'
     process.env.ORCA_WORKTREE_ID = 'parent-worktree'
+    process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
 
     try {
       await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
@@ -147,6 +149,7 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_PANE_KEY).toBeUndefined()
     expect(env.ORCA_TAB_ID).toBeUndefined()
     expect(env.ORCA_WORKTREE_ID).toBeUndefined()
+    expect(env.ORCA_TERMINAL_HANDLE).toBeUndefined()
   })
 
   it('preserves explicit child Orca pane identity over parent env', async () => {
@@ -155,11 +158,13 @@ describe('createPtySubprocess', () => {
     const saved = {
       ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
       ORCA_TAB_ID: process.env.ORCA_TAB_ID,
-      ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID
+      ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
+      ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE
     }
     process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
     process.env.ORCA_TAB_ID = 'parent-tab'
     process.env.ORCA_WORKTREE_ID = 'parent-worktree'
+    process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
 
     try {
       await createPtySubprocess({
@@ -169,7 +174,8 @@ describe('createPtySubprocess', () => {
         env: {
           ORCA_PANE_KEY: 'child-tab:child-leaf',
           ORCA_TAB_ID: 'child-tab',
-          ORCA_WORKTREE_ID: 'child-worktree'
+          ORCA_WORKTREE_ID: 'child-worktree',
+          ORCA_TERMINAL_HANDLE: 'term_child'
         }
       })
     } finally {
@@ -186,6 +192,7 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_PANE_KEY).toBe('child-tab:child-leaf')
     expect(env.ORCA_TAB_ID).toBe('child-tab')
     expect(env.ORCA_WORKTREE_ID).toBe('child-worktree')
+    expect(env.ORCA_TERMINAL_HANDLE).toBe('term_child')
   })
 
   it.each([

--- a/src/main/daemon/pty-subprocess/spawn-environment.ts
+++ b/src/main/daemon/pty-subprocess/spawn-environment.ts
@@ -16,15 +16,10 @@ import {
   expandWindowsEnvironmentVariables,
   expandWindowsPathEnvironmentVariables
 } from '../../../shared/windows-environment-expansion'
+import { removeUnspecifiedPaneIdentityEnv } from '../../../shared/pane-identity-env'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import type { PtySubprocessOptions } from '../pty-subprocess'
 
-const PANE_IDENTITY_ENV_KEYS = [
-  'ORCA_PANE_KEY',
-  'ORCA_TAB_ID',
-  'ORCA_WORKTREE_ID',
-  'ORCA_AGENT_LAUNCH_TOKEN'
-] as const
 const WINDOWS_PATH_ENV_KEY_RE = /^path$/i
 
 function composeGuardedDaemonGitConfigEnv(
@@ -55,17 +50,6 @@ function deleteRequestedDaemonEnvKeys(
   }
   if (deleteOrcaOwnedCodexHome) {
     delete env.CODEX_HOME
-  }
-}
-
-function removeUnspecifiedPaneIdentityEnv(
-  env: Record<string, string>,
-  explicitEnv: Record<string, string> | undefined
-): void {
-  for (const key of PANE_IDENTITY_ENV_KEYS) {
-    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
-      delete env[key]
-    }
   }
 }
 

--- a/src/main/providers/local-pty-launch-helpers.ts
+++ b/src/main/providers/local-pty-launch-helpers.ts
@@ -4,27 +4,10 @@ import { parseWslPath } from '../wsl'
 import { resolvePathEnvKey } from '../pty/windows-environment-path'
 import { expandWindowsEnvironmentVariables } from '../../shared/windows-environment-expansion'
 import { resolveSafePtyDefaultCwd } from './pty-default-cwd'
-
-const PANE_IDENTITY_ENV_KEYS = [
-  'ORCA_PANE_KEY',
-  'ORCA_TAB_ID',
-  'ORCA_WORKTREE_ID',
-  'ORCA_AGENT_LAUNCH_TOKEN'
-] as const
+export { removeUnspecifiedPaneIdentityEnv } from '../../shared/pane-identity-env'
 
 export function getDefaultCwd(): string {
   return resolveSafePtyDefaultCwd()
-}
-
-export function removeUnspecifiedPaneIdentityEnv(
-  env: Record<string, string>,
-  explicitEnv: Record<string, string> | undefined
-): void {
-  for (const key of PANE_IDENTITY_ENV_KEYS) {
-    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
-      delete env[key]
-    }
-  }
 }
 
 export function promoteAgentTeamsShimPath(

--- a/src/main/providers/local-pty-provider-spawn-env.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-env.test.ts
@@ -563,11 +563,13 @@ describe('LocalPtyProvider', () => {
       const saved = {
         ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
         ORCA_TAB_ID: process.env.ORCA_TAB_ID,
-        ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID
+        ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
+        ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE
       }
       process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
       process.env.ORCA_TAB_ID = 'parent-tab'
       process.env.ORCA_WORKTREE_ID = 'parent-worktree'
+      process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
 
       try {
         await provider.spawn({ cols: 80, rows: 24 })
@@ -585,17 +587,20 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.ORCA_PANE_KEY).toBeUndefined()
       expect(spawnCall[2].env.ORCA_TAB_ID).toBeUndefined()
       expect(spawnCall[2].env.ORCA_WORKTREE_ID).toBeUndefined()
+      expect(spawnCall[2].env.ORCA_TERMINAL_HANDLE).not.toBe('term_parent')
     })
 
     it('preserves explicit child Orca pane identity over parent env', async () => {
       const saved = {
         ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
         ORCA_TAB_ID: process.env.ORCA_TAB_ID,
-        ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID
+        ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
+        ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE
       }
       process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
       process.env.ORCA_TAB_ID = 'parent-tab'
       process.env.ORCA_WORKTREE_ID = 'parent-worktree'
+      process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
 
       try {
         await provider.spawn({
@@ -604,7 +609,8 @@ describe('LocalPtyProvider', () => {
           env: {
             ORCA_PANE_KEY: 'child-tab:child-leaf',
             ORCA_TAB_ID: 'child-tab',
-            ORCA_WORKTREE_ID: 'child-worktree'
+            ORCA_WORKTREE_ID: 'child-worktree',
+            ORCA_TERMINAL_HANDLE: 'term_child'
           }
         })
       } finally {
@@ -621,6 +627,7 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.ORCA_PANE_KEY).toBe('child-tab:child-leaf')
       expect(spawnCall[2].env.ORCA_TAB_ID).toBe('child-tab')
       expect(spawnCall[2].env.ORCA_WORKTREE_ID).toBe('child-worktree')
+      expect(spawnCall[2].env.ORCA_TERMINAL_HANDLE).toBe('term_child')
     })
   })
 })

--- a/src/main/providers/local-pty-provider-spawn-env.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-env.test.ts
@@ -564,12 +564,14 @@ describe('LocalPtyProvider', () => {
         ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
         ORCA_TAB_ID: process.env.ORCA_TAB_ID,
         ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
-        ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE
+        ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE,
+        ORCA_AGENT_LAUNCH_TOKEN: process.env.ORCA_AGENT_LAUNCH_TOKEN
       }
       process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
       process.env.ORCA_TAB_ID = 'parent-tab'
       process.env.ORCA_WORKTREE_ID = 'parent-worktree'
       process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
+      process.env.ORCA_AGENT_LAUNCH_TOKEN = 'parent-launch-token'
 
       try {
         await provider.spawn({ cols: 80, rows: 24 })
@@ -588,6 +590,7 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.ORCA_TAB_ID).toBeUndefined()
       expect(spawnCall[2].env.ORCA_WORKTREE_ID).toBeUndefined()
       expect(spawnCall[2].env.ORCA_TERMINAL_HANDLE).not.toBe('term_parent')
+      expect(spawnCall[2].env.ORCA_AGENT_LAUNCH_TOKEN).toBeUndefined()
     })
 
     it('preserves explicit child Orca pane identity over parent env', async () => {
@@ -595,12 +598,14 @@ describe('LocalPtyProvider', () => {
         ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
         ORCA_TAB_ID: process.env.ORCA_TAB_ID,
         ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
-        ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE
+        ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE,
+        ORCA_AGENT_LAUNCH_TOKEN: process.env.ORCA_AGENT_LAUNCH_TOKEN
       }
       process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
       process.env.ORCA_TAB_ID = 'parent-tab'
       process.env.ORCA_WORKTREE_ID = 'parent-worktree'
       process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
+      process.env.ORCA_AGENT_LAUNCH_TOKEN = 'parent-launch-token'
 
       try {
         await provider.spawn({
@@ -610,7 +615,8 @@ describe('LocalPtyProvider', () => {
             ORCA_PANE_KEY: 'child-tab:child-leaf',
             ORCA_TAB_ID: 'child-tab',
             ORCA_WORKTREE_ID: 'child-worktree',
-            ORCA_TERMINAL_HANDLE: 'term_child'
+            ORCA_TERMINAL_HANDLE: 'term_child',
+            ORCA_AGENT_LAUNCH_TOKEN: 'child-launch-token'
           }
         })
       } finally {
@@ -628,6 +634,7 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.ORCA_TAB_ID).toBe('child-tab')
       expect(spawnCall[2].env.ORCA_WORKTREE_ID).toBe('child-worktree')
       expect(spawnCall[2].env.ORCA_TERMINAL_HANDLE).toBe('term_child')
+      expect(spawnCall[2].env.ORCA_AGENT_LAUNCH_TOKEN).toBe('child-launch-token')
     })
   })
 })

--- a/src/main/runtime/mobile-session-terminal-projection.ts
+++ b/src/main/runtime/mobile-session-terminal-projection.ts
@@ -23,6 +23,7 @@ export function buildHeadlessMobileSessionTerminalTabs(
       }
       return leafIds.flatMap((leafId) => {
         const ptyId = layout?.ptyIdsByLeafId?.[leafId] ?? (leafIds.length === 1 ? tab.ptyId : null)
+        const incarnationId = session.terminalPtyIncarnationsByPaneKey?.[`${tab.id}:${leafId}`]
         const title =
           tab.customTitle?.trim() ||
           tab.generatedTitle?.trim() ||
@@ -37,6 +38,7 @@ export function buildHeadlessMobileSessionTerminalTabs(
             leafId,
             title,
             ...(ptyId ? { ptyId } : {}),
+            ...(incarnationId ? { incarnationId } : {}),
             ...(tab.startupCwd ? { startupCwd: tab.startupCwd } : {}),
             ...(tab.launchAgent ? { launchAgent: tab.launchAgent } : {}),
             ...(layout ? { parentLayout: cloneTerminalLayoutSnapshot(layout) } : {}),

--- a/src/main/runtime/orca-runtime-resolve-terminal-pane.ts
+++ b/src/main/runtime/orca-runtime-resolve-terminal-pane.ts
@@ -13,6 +13,8 @@ import {
   readTerminalTail
 } from './terminal-tail-read'
 import { getTerminalState } from './terminal-wait-results'
+import { buildRuntimeTerminalVisualLayouts } from './runtime-terminal-visual-layout'
+import { annotateRuntimeTerminalVisualTopology } from './runtime-terminal-visual-topology-state'
 
 export class OrcaRuntimeWithResolveTerminalPane extends OrcaRuntimeWithGetTerminalInteractiveWait {
   resolveTerminalPane(paneKey: string, expectedWorktreeId?: string): RuntimeTerminalResolvePane {
@@ -113,16 +115,19 @@ export class OrcaRuntimeWithResolveTerminalPane extends OrcaRuntimeWithGetTermin
       const preview = await this.visibleSnapshotPreview(pty.pty.ptyId, summary.preview)
       this.assertLiveTerminalHandleTargetsPty(handle, pty.pty.ptyId)
       const agentWait = await this.getTerminalInteractiveWait(handle)
-      return {
-        ...summary,
-        preview,
-        tabId: pty.pty.tabId ?? pty.record.tabId,
-        leafId: parsePaneKey(pty.pty.paneKey ?? '')?.leafId ?? pty.record.leafId,
-        paneRuntimeId: -1,
-        ptyId: pty.pty.ptyId,
-        rendererGraphEpoch: this.rendererGraphEpoch,
-        ...(agentWait !== undefined ? { agentWait } : {})
-      }
+      return this.withVisualTopologyState(
+        {
+          ...summary,
+          preview,
+          tabId: pty.pty.tabId ?? pty.record.tabId,
+          leafId: parsePaneKey(pty.pty.paneKey ?? '')?.leafId ?? pty.record.leafId,
+          paneRuntimeId: -1,
+          ptyId: pty.pty.ptyId,
+          rendererGraphEpoch: this.rendererGraphEpoch,
+          ...(agentWait !== undefined ? { agentWait } : {})
+        },
+        worktreesById
+      )
     }
     const graphEpoch = this.captureReadyGraphEpoch()
     const worktreesById = await this.getResolvedWorktreeMap()
@@ -137,14 +142,32 @@ export class OrcaRuntimeWithResolveTerminalPane extends OrcaRuntimeWithGetTermin
       this.assertLiveTerminalHandleTargetsPty(handle, leaf.ptyId)
     }
     const agentWait = await this.getTerminalInteractiveWait(handle)
-    return {
-      ...summary,
-      preview,
-      paneRuntimeId: leaf.paneRuntimeId,
-      ptyId: leaf.ptyId,
-      rendererGraphEpoch: this.rendererGraphEpoch,
-      ...(agentWait !== undefined ? { agentWait } : {})
-    }
+    return this.withVisualTopologyState(
+      {
+        ...summary,
+        preview,
+        paneRuntimeId: leaf.paneRuntimeId,
+        ptyId: leaf.ptyId,
+        rendererGraphEpoch: this.rendererGraphEpoch,
+        ...(agentWait !== undefined ? { agentWait } : {})
+      },
+      worktreesById
+    )
+  }
+
+  protected withVisualTopologyState(
+    terminal: RuntimeTerminalShow,
+    worktreesById: Map<string, { path: string }>
+  ): RuntimeTerminalShow {
+    const snapshot = this.mobileSessionTabsByWorktree.get(terminal.worktreeId)
+    const snapshots = snapshot ? [snapshot] : []
+    const layouts = buildRuntimeTerminalVisualLayouts({
+      terminals: [terminal],
+      worktreesById,
+      snapshots,
+      getTabTitle: (tabId) => this.tabs.get(tabId)?.title ?? null
+    })
+    return annotateRuntimeTerminalVisualTopology([terminal], layouts, snapshots)[0]
   }
 
   async readTerminal(

--- a/src/main/runtime/orca-runtime-tests/terminal-listing.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-listing.spec.ts
@@ -6,14 +6,20 @@ import {
   listWorktrees
 } from '../orca-runtime-test-mocks.spec'
 import {
+  HEADLESS_LEAF_ID,
+  HEADLESS_SECOND_LEAF_ID,
+  HEADLESS_THIRD_LEAF_ID,
   TEST_FOLDER_WORKSPACE_PATH,
   TEST_REPO_ID,
   TEST_WORKTREE_ID,
   TEST_WORKTREE_PATH,
   createRuntime,
+  makeRuntimeStoreWithWorkspaceSession,
+  makeWorkspaceSessionWithHeadlessTerminal,
   makeWorktreeMeta,
   store
 } from '../orca-runtime-test-fixtures.spec'
+import { makePaneKey } from '../../../shared/stable-pane-id'
 
 describe('OrcaRuntimeService', () => {
   it('emits one mobile session terminal tab per live PTY even if two tabs resolve to it', () => {
@@ -70,6 +76,184 @@ describe('OrcaRuntimeService', () => {
     })
     const split = internals.getMobileSessionTabsForWorktree(TEST_WORKTREE_ID)
     expect(split.tabs.filter((tab) => tab.type === 'terminal')).toHaveLength(2)
+  })
+
+  it('marks a live persisted terminal detached when its visual tab is missing', async () => {
+    const runtime = createRuntime()
+    const internals = runtime as unknown as {
+      recordPtyWorktree: (
+        ptyId: string,
+        worktreeId: string,
+        state?: Record<string, unknown>
+      ) => void
+      mobileSessionTabsByWorktree: Map<string, unknown>
+    }
+    internals.recordPtyWorktree('pty-visible', TEST_WORKTREE_ID, {
+      connected: true,
+      incarnationId: 'visible-incarnation',
+      tabId: 'tab-visible',
+      paneKey: makePaneKey('tab-visible', HEADLESS_LEAF_ID)
+    })
+    internals.recordPtyWorktree('pty-detached', TEST_WORKTREE_ID, {
+      connected: true,
+      incarnationId: 'detached-incarnation',
+      tabId: 'tab-detached',
+      paneKey: makePaneKey('tab-detached', HEADLESS_SECOND_LEAF_ID)
+    })
+    internals.recordPtyWorktree('pty-unverified', TEST_WORKTREE_ID, {
+      connected: true,
+      incarnationId: 'unverified-incarnation',
+      tabId: 'tab-unverified',
+      paneKey: makePaneKey('tab-unverified', HEADLESS_THIRD_LEAF_ID)
+    })
+    internals.mobileSessionTabsByWorktree.set(TEST_WORKTREE_ID, {
+      worktree: TEST_WORKTREE_ID,
+      publicationEpoch: 'renderer:after-restart:1',
+      snapshotVersion: 1,
+      activeGroupId: 'group-1',
+      activeTabId: `tab-visible::${HEADLESS_LEAF_ID}`,
+      activeTabType: 'terminal',
+      tabGroups: [
+        {
+          id: 'group-1',
+          activeTabId: 'tab-visible',
+          tabOrder: ['tab-visible', 'tab-unverified']
+        }
+      ],
+      tabs: [
+        {
+          type: 'terminal',
+          id: `tab-visible::${HEADLESS_LEAF_ID}`,
+          parentTabId: 'tab-visible',
+          leafId: HEADLESS_LEAF_ID,
+          ptyId: 'pty-visible',
+          incarnationId: 'visible-incarnation',
+          title: 'Visible',
+          isActive: true
+        },
+        {
+          type: 'terminal',
+          id: `tab-unverified::${HEADLESS_THIRD_LEAF_ID}`,
+          parentTabId: 'tab-unverified',
+          leafId: HEADLESS_THIRD_LEAF_ID,
+          ptyId: 'pty-unverified',
+          title: 'Old publisher without incarnation',
+          isActive: false
+        }
+      ]
+    })
+
+    const listed = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`, 100, {
+      includeVisualLayouts: true
+    })
+    const visible = listed.terminals.find((terminal) => terminal.ptyId === 'pty-visible')
+    const detached = listed.terminals.find((terminal) => terminal.ptyId === 'pty-detached')
+    const unverified = listed.terminals.find((terminal) => terminal.ptyId === 'pty-unverified')
+
+    expect(visible).toMatchObject({ visualTopologyState: 'projected' })
+    expect(detached).toMatchObject({
+      connected: true,
+      writable: true,
+      orphaned: false,
+      tabId: 'tab-detached',
+      leafId: HEADLESS_SECOND_LEAF_ID,
+      visualTopologyState: 'detached'
+    })
+    expect(unverified).toMatchObject({ connected: true })
+    expect(unverified).not.toHaveProperty('visualTopologyState')
+    await expect(runtime.showTerminal(detached!.handle)).resolves.toMatchObject({
+      visualTopologyState: 'detached'
+    })
+    await expect(runtime.showTerminal(visible!.handle)).resolves.toMatchObject({
+      visualTopologyState: 'projected'
+    })
+
+    const withoutLayouts = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`, 100, {
+      includeVisualLayouts: false
+    })
+    expect(withoutLayouts.visualLayouts).toBeUndefined()
+    expect(withoutLayouts.terminals[0]).not.toHaveProperty('visualTopologyState')
+  })
+
+  it('does not project a replacement PTY through a stale persisted restart binding', async () => {
+    const paneKey = makePaneKey('host-tab', HEADLESS_LEAF_ID)
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        terminalPtyIncarnationsByPaneKey: { [paneKey]: 'incarnation-old' }
+      })
+    )
+    type RestartInternals = {
+      recordPtyWorktree: (
+        ptyId: string,
+        worktreeId: string,
+        state?: Record<string, unknown>
+      ) => void
+      hydrateHeadlessMobileSessionTabsFromWorkspaceSession: (worktreeId: string) => Set<string>
+    }
+
+    const beforeRestart = new OrcaRuntimeService(runtimeStore as never)
+    const beforeInternals = beforeRestart as unknown as RestartInternals
+    beforeInternals.recordPtyWorktree('persisted-pty', TEST_WORKTREE_ID, {
+      connected: true,
+      incarnationId: 'incarnation-old',
+      tabId: 'host-tab',
+      paneKey
+    })
+    beforeInternals.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(TEST_WORKTREE_ID)
+
+    const before = await beforeRestart.listTerminals(`id:${TEST_WORKTREE_ID}`, 100, {
+      includeVisualLayouts: true
+    })
+    expect(before.terminals).toEqual([
+      expect.objectContaining({
+        ptyId: 'persisted-pty',
+        visualTopologyState: 'projected'
+      })
+    ])
+
+    const afterRestart = new OrcaRuntimeService(runtimeStore as never)
+    const afterInternals = afterRestart as unknown as RestartInternals
+    afterInternals.recordPtyWorktree('replacement-pty', TEST_WORKTREE_ID, {
+      connected: true,
+      incarnationId: 'incarnation-new',
+      tabId: 'host-tab',
+      paneKey
+    })
+    afterInternals.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(TEST_WORKTREE_ID)
+
+    const after = await afterRestart.listTerminals(`id:${TEST_WORKTREE_ID}`, 100, {
+      includeVisualLayouts: true
+    })
+    expect(after.visualLayouts).toBeUndefined()
+    expect(after.terminals).toEqual([
+      expect.objectContaining({
+        ptyId: 'replacement-pty',
+        incarnationId: 'incarnation-new',
+        connected: true,
+        visualTopologyState: 'detached'
+      })
+    ])
+
+    const reusedPtyIdAfterRestart = new OrcaRuntimeService(runtimeStore as never)
+    const reusedInternals = reusedPtyIdAfterRestart as unknown as RestartInternals
+    reusedInternals.recordPtyWorktree('persisted-pty', TEST_WORKTREE_ID, {
+      connected: true,
+      incarnationId: 'incarnation-new',
+      tabId: 'host-tab',
+      paneKey
+    })
+    reusedInternals.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(TEST_WORKTREE_ID)
+
+    const reused = await reusedPtyIdAfterRestart.listTerminals(`id:${TEST_WORKTREE_ID}`, 100, {
+      includeVisualLayouts: true
+    })
+    expect(reused.terminals).toEqual([
+      expect.objectContaining({
+        ptyId: 'persisted-pty',
+        incarnationId: 'incarnation-new',
+        visualTopologyState: 'detached'
+      })
+    ])
   })
 
   it('resolves projected split authority from the parent layout PTY binding', () => {

--- a/src/main/runtime/runtime-terminal-list.ts
+++ b/src/main/runtime/runtime-terminal-list.ts
@@ -8,6 +8,7 @@ import type { PtyControllerInventory } from './runtime-pty-controller-contract'
 import type { ResolvedWorktreeSnapshot } from './runtime-resolved-worktree-cache'
 import type { RuntimeLeafRecord, RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
 import { buildRuntimeTerminalVisualLayouts } from './runtime-terminal-visual-layout'
+import { annotateRuntimeTerminalVisualTopology } from './runtime-terminal-visual-topology-state'
 import {
   includeTargetResolvedWorktree,
   type ResolvedWorktree
@@ -163,8 +164,12 @@ export class RuntimeTerminalList {
               : snapshots.values(),
             getTabTitle: (tabId) => this.deps.getTabTitle(tabId)
           })
+    const listedWithVisualState =
+      opts.includeVisualLayouts === false
+        ? listed
+        : annotateRuntimeTerminalVisualTopology(listed, visualLayouts, snapshots.values())
     return {
-      terminals: listed,
+      terminals: listedWithVisualState,
       hostScope: this.deps.buildHostScope(
         targetId,
         matching,

--- a/src/main/runtime/runtime-terminal-visual-layout.ts
+++ b/src/main/runtime/runtime-terminal-visual-layout.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../shared/runtime-types'
 import type { TabGroupLayoutNode } from '../../shared/tab-types'
 import type { TerminalPaneLayoutNode } from '../../shared/terminal-tab-types'
+import { getPtyBindings } from './runtime-terminal-visual-topology-state'
 
 type RuntimeTerminalVisualLayoutArgs = {
   terminals: RuntimeTerminalSummary[]
@@ -138,7 +139,13 @@ function buildTab(
     type: 'leaf' as const,
     leafId: firstSurface.leafId
   }
-  const visibleLeafIds = collectVisibleLeafIds(root, parentTabId, summariesByLeafKey)
+  const visibleLeafIds = collectVisibleLeafIds(
+    root,
+    parentTabId,
+    surfaces,
+    firstSurface.parentLayout,
+    summariesByLeafKey
+  )
   if (visibleLeafIds.length === 0) {
     return null
   }
@@ -147,7 +154,14 @@ function buildTab(
       ? requestedActiveLeafId
       : surfaces.find((surface) => surface.isActive && visibleLeafIds.includes(surface.leafId))
           ?.leafId) ?? visibleLeafIds[0]!
-  const panes = buildPane(root, parentTabId, activeLeafId, summariesByLeafKey)
+  const panes = buildPane(
+    root,
+    parentTabId,
+    activeLeafId,
+    surfaces,
+    firstSurface.parentLayout,
+    summariesByLeafKey
+  )
   if (!panes) {
     return null
   }
@@ -162,14 +176,18 @@ function buildTab(
 function collectVisibleLeafIds(
   node: TerminalPaneLayoutNode,
   tabId: string,
+  surfaces: readonly RuntimeMobileSessionTerminalTab[],
+  parentLayout: RuntimeMobileSessionTerminalTab['parentLayout'],
   summariesByLeafKey: ReadonlyMap<string, RuntimeTerminalSummary>
 ): string[] {
   if (node.type === 'leaf') {
-    return summariesByLeafKey.has(leafKey(tabId, node.leafId)) ? [node.leafId] : []
+    return getVisuallyBoundSummary(tabId, node.leafId, surfaces, parentLayout, summariesByLeafKey)
+      ? [node.leafId]
+      : []
   }
   return [
-    ...collectVisibleLeafIds(node.first, tabId, summariesByLeafKey),
-    ...collectVisibleLeafIds(node.second, tabId, summariesByLeafKey)
+    ...collectVisibleLeafIds(node.first, tabId, surfaces, parentLayout, summariesByLeafKey),
+    ...collectVisibleLeafIds(node.second, tabId, surfaces, parentLayout, summariesByLeafKey)
   ]
 }
 
@@ -177,10 +195,18 @@ function buildPane(
   node: TerminalPaneLayoutNode,
   tabId: string,
   activeLeafId: string | null,
+  surfaces: readonly RuntimeMobileSessionTerminalTab[],
+  parentLayout: RuntimeMobileSessionTerminalTab['parentLayout'],
   summariesByLeafKey: ReadonlyMap<string, RuntimeTerminalSummary>
 ): RuntimeTerminalVisualPaneNode | null {
   if (node.type === 'leaf') {
-    const summary = summariesByLeafKey.get(leafKey(tabId, node.leafId))
+    const summary = getVisuallyBoundSummary(
+      tabId,
+      node.leafId,
+      surfaces,
+      parentLayout,
+      summariesByLeafKey
+    )
     if (!summary) {
       return null
     }
@@ -194,12 +220,52 @@ function buildPane(
       active: summary.leafId === activeLeafId
     }
   }
-  const first = buildPane(node.first, tabId, activeLeafId, summariesByLeafKey)
-  const second = buildPane(node.second, tabId, activeLeafId, summariesByLeafKey)
+  const first = buildPane(
+    node.first,
+    tabId,
+    activeLeafId,
+    surfaces,
+    parentLayout,
+    summariesByLeafKey
+  )
+  const second = buildPane(
+    node.second,
+    tabId,
+    activeLeafId,
+    surfaces,
+    parentLayout,
+    summariesByLeafKey
+  )
   if (first && second) {
     return { type: 'pane-split', direction: node.direction, first, second }
   }
   return first ?? second
+}
+
+function getVisuallyBoundSummary(
+  tabId: string,
+  leafId: string,
+  surfaces: readonly RuntimeMobileSessionTerminalTab[],
+  parentLayout: RuntimeMobileSessionTerminalTab['parentLayout'],
+  summariesByLeafKey: ReadonlyMap<string, RuntimeTerminalSummary>
+): RuntimeTerminalSummary | null {
+  const summary = summariesByLeafKey.get(leafKey(tabId, leafId))
+  const surface = surfaces.find((candidate) => candidate.leafId === leafId)
+  if (!summary || !surface) {
+    return null
+  }
+  const ptyBindings = getPtyBindings(surface, parentLayout)
+  if (
+    !summary.ptyId ||
+    ptyBindings.length === 0 ||
+    ptyBindings.some((ptyId) => ptyId !== summary.ptyId)
+  ) {
+    return null
+  }
+  if (surface.incarnationId && surface.incarnationId !== summary.incarnationId) {
+    return null
+  }
+  return summary
 }
 
 function buildGroupLayout(

--- a/src/main/runtime/runtime-terminal-visual-topology-state.ts
+++ b/src/main/runtime/runtime-terminal-visual-topology-state.ts
@@ -1,0 +1,94 @@
+import type {
+  RuntimeMobileSessionTabsSnapshot,
+  RuntimeMobileSessionTerminalTab,
+  RuntimeTerminalSummary,
+  RuntimeTerminalVisualLayout,
+  RuntimeTerminalVisualLayoutNode,
+  RuntimeTerminalVisualPaneNode
+} from '../../shared/runtime-types'
+import { UNPUBLISHED_WORKTREE_PUBLICATION_EPOCH } from '../../shared/runtime-types'
+
+export function annotateRuntimeTerminalVisualTopology(
+  terminals: readonly RuntimeTerminalSummary[],
+  layouts: readonly RuntimeTerminalVisualLayout[],
+  snapshots: Iterable<RuntimeMobileSessionTabsSnapshot>
+): RuntimeTerminalSummary[] {
+  const projectedHandles = new Set<string>()
+  for (const layout of layouts) {
+    collectProjectedHandles(layout.root, projectedHandles)
+  }
+  const snapshotsByWorktree = new Map(
+    [...snapshots].map((snapshot) => [snapshot.worktree, snapshot])
+  )
+  return terminals.map((terminal) => {
+    const snapshot = snapshotsByWorktree.get(terminal.worktreeId)
+    if (!snapshot) {
+      return terminal
+    }
+    const surface = snapshot.tabs.find(
+      (candidate): candidate is RuntimeMobileSessionTerminalTab =>
+        candidate.type === 'terminal' &&
+        candidate.parentTabId === terminal.tabId &&
+        candidate.leafId === terminal.leafId
+    )
+    if (!surface) {
+      if (
+        snapshot.publicationEpoch === UNPUBLISHED_WORKTREE_PUBLICATION_EPOCH &&
+        snapshot.snapshotVersion === 0
+      ) {
+        return terminal
+      }
+      return { ...terminal, visualTopologyState: 'detached' }
+    }
+    const firstParentSurface = snapshot.tabs.find(
+      (candidate): candidate is RuntimeMobileSessionTerminalTab =>
+        candidate.type === 'terminal' && candidate.parentTabId === terminal.tabId
+    )
+    const ptyBindings = getPtyBindings(surface, firstParentSurface?.parentLayout)
+    if (ptyBindings.length === 0 || !terminal.ptyId) {
+      return terminal
+    }
+    if (ptyBindings.some((ptyId) => ptyId !== terminal.ptyId)) {
+      return { ...terminal, visualTopologyState: 'detached' }
+    }
+    if (!surface.incarnationId || !terminal.incarnationId) {
+      return terminal
+    }
+    if (surface.incarnationId !== terminal.incarnationId) {
+      return { ...terminal, visualTopologyState: 'detached' }
+    }
+    return {
+      ...terminal,
+      visualTopologyState: projectedHandles.has(terminal.handle) ? 'projected' : 'detached'
+    }
+  })
+}
+
+export function getPtyBindings(
+  surface: RuntimeMobileSessionTerminalTab,
+  parentLayout: RuntimeMobileSessionTerminalTab['parentLayout'] = surface.parentLayout
+): string[] {
+  return [
+    surface.ptyId,
+    surface.parentLayout?.ptyIdsByLeafId?.[surface.leafId],
+    parentLayout?.ptyIdsByLeafId?.[surface.leafId]
+  ].filter((ptyId): ptyId is string => typeof ptyId === 'string' && ptyId.length > 0)
+}
+
+function collectProjectedHandles(
+  node: RuntimeTerminalVisualLayoutNode | RuntimeTerminalVisualPaneNode,
+  handles: Set<string>
+): void {
+  if (node.type === 'terminal') {
+    handles.add(node.handle)
+    return
+  }
+  if (node.type === 'group') {
+    for (const tab of node.tabs) {
+      collectProjectedHandles(tab.panes, handles)
+    }
+    return
+  }
+  collectProjectedHandles(node.first, handles)
+  collectProjectedHandles(node.second, handles)
+}

--- a/src/main/runtime/terminal-list-payload-size.test.ts
+++ b/src/main/runtime/terminal-list-payload-size.test.ts
@@ -200,11 +200,18 @@ describe('terminal.list payload size', () => {
     const withoutLayouts = await runtime.listTerminals(`id:${WORKTREE_ID}`, 10_000, {
       includeVisualLayouts: false
     })
-    const { visualLayouts, ...expectedWithoutLayouts } = withLayouts
+    const { visualLayouts, ...withLayoutPayload } = withLayouts
+    const expectedWithoutLayouts = {
+      ...withLayoutPayload,
+      terminals: withLayoutPayload.terminals.map(
+        ({ visualTopologyState: _state, ...terminal }) => terminal
+      )
+    }
 
     expect(withLayouts.terminals).toHaveLength(TERMINAL_COUNT)
     expect(visualLayouts).toHaveLength(1)
     expect(withoutLayouts).toEqual(expectedWithoutLayouts)
+    expect(withoutLayouts.terminals.every((terminal) => !terminal.visualTopologyState)).toBe(true)
     expect(layoutBuilder).not.toHaveBeenCalled()
 
     const beforeBytes = Buffer.byteLength(JSON.stringify(withLayouts), 'utf8')

--- a/src/relay/pty-handler-revive.test.ts
+++ b/src/relay/pty-handler-revive.test.ts
@@ -72,7 +72,8 @@ describe('PtyHandler', () => {
       env: {
         ORCA_PANE_KEY: 'tab-5:1',
         ORCA_TAB_ID: 'tab-5',
-        ORCA_WORKTREE_ID: 'wt-5'
+        ORCA_WORKTREE_ID: 'wt-5',
+        ORCA_TERMINAL_HANDLE: 'term_5'
       }
     })
     const state = (await dispatcher.callRequest('pty.serialize', { ids: [PTY_1] })) as string
@@ -106,6 +107,7 @@ describe('PtyHandler', () => {
     expect(callArgs.env.ORCA_PANE_KEY).toBe('tab-5:1')
     expect(callArgs.env.ORCA_TAB_ID).toBe('tab-5')
     expect(callArgs.env.ORCA_WORKTREE_ID).toBe('wt-5')
+    expect(callArgs.env.ORCA_TERMINAL_HANDLE).toBe('term_5')
     expect(callArgs.env.ORCA_AGENT_HOOK_PORT).toBe('12345')
     expect(callArgs.env.ORCA_AGENT_HOOK_TOKEN).toBe('abc-uuid')
     expect(callArgs.env.TERM).toBe('xterm-256color')

--- a/src/relay/pty-handler-revive.test.ts
+++ b/src/relay/pty-handler-revive.test.ts
@@ -90,7 +90,9 @@ describe('PtyHandler', () => {
     // Why seeded: a revived pane must not inherit a feature selection from the
     // relay process's own environment.
     const oldShellFeatures = process.env.ORCA_SHELL_FEATURES
+    const oldLaunchToken = process.env.ORCA_AGENT_LAUNCH_TOKEN
     process.env.ORCA_SHELL_FEATURES = 'ready,identity,markers,overlay'
+    process.env.ORCA_AGENT_LAUNCH_TOKEN = 'parent-launch-token'
     try {
       await dispatcher.callRequest('pty.revive', { state })
     } finally {
@@ -98,6 +100,11 @@ describe('PtyHandler', () => {
         delete process.env.ORCA_SHELL_FEATURES
       } else {
         process.env.ORCA_SHELL_FEATURES = oldShellFeatures
+      }
+      if (oldLaunchToken === undefined) {
+        delete process.env.ORCA_AGENT_LAUNCH_TOKEN
+      } else {
+        process.env.ORCA_AGENT_LAUNCH_TOKEN = oldLaunchToken
       }
       killSpy.mockRestore()
     }
@@ -108,6 +115,7 @@ describe('PtyHandler', () => {
     expect(callArgs.env.ORCA_TAB_ID).toBe('tab-5')
     expect(callArgs.env.ORCA_WORKTREE_ID).toBe('wt-5')
     expect(callArgs.env.ORCA_TERMINAL_HANDLE).toBe('term_5')
+    expect(callArgs.env.ORCA_AGENT_LAUNCH_TOKEN).toBeUndefined()
     expect(callArgs.env.ORCA_AGENT_HOOK_PORT).toBe('12345')
     expect(callArgs.env.ORCA_AGENT_HOOK_TOKEN).toBe('abc-uuid')
     expect(callArgs.env.TERM).toBe('xterm-256color')

--- a/src/relay/pty-handler-spawn-environment.test.ts
+++ b/src/relay/pty-handler-spawn-environment.test.ts
@@ -543,13 +543,15 @@ describe('PtyHandler', () => {
       'ORCA_PANE_KEY',
       'ORCA_TAB_ID',
       'ORCA_WORKTREE_ID',
-      'ORCA_TERMINAL_HANDLE'
+      'ORCA_TERMINAL_HANDLE',
+      'ORCA_AGENT_LAUNCH_TOKEN'
     ] as const
     const saved = new Map(keys.map((key) => [key, process.env[key]]))
     process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
     process.env.ORCA_TAB_ID = 'parent-tab'
     process.env.ORCA_WORKTREE_ID = 'parent-worktree'
     process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
+    process.env.ORCA_AGENT_LAUNCH_TOKEN = 'parent-launch-token'
 
     try {
       await dispatcher.callRequest('pty.spawn', {})
@@ -568,6 +570,7 @@ describe('PtyHandler', () => {
     expect(env.ORCA_TAB_ID).toBeUndefined()
     expect(env.ORCA_WORKTREE_ID).toBeUndefined()
     expect(env.ORCA_TERMINAL_HANDLE).toBeUndefined()
+    expect(env.ORCA_AGENT_LAUNCH_TOKEN).toBeUndefined()
   })
 
   it('preserves the exact pane identity explicitly supplied for a spawn', async () => {
@@ -576,7 +579,8 @@ describe('PtyHandler', () => {
         ORCA_PANE_KEY: 'child-tab:child-leaf',
         ORCA_TAB_ID: 'child-tab',
         ORCA_WORKTREE_ID: 'child-worktree',
-        ORCA_TERMINAL_HANDLE: 'term_child'
+        ORCA_TERMINAL_HANDLE: 'term_child',
+        ORCA_AGENT_LAUNCH_TOKEN: 'child-launch-token'
       }
     })
 
@@ -585,6 +589,7 @@ describe('PtyHandler', () => {
     expect(env.ORCA_TAB_ID).toBe('child-tab')
     expect(env.ORCA_WORKTREE_ID).toBe('child-worktree')
     expect(env.ORCA_TERMINAL_HANDLE).toBe('term_child')
+    expect(env.ORCA_AGENT_LAUNCH_TOKEN).toBe('child-launch-token')
   })
 
   it('passes PTY and explicit launch identity to env augmenters', async () => {

--- a/src/relay/pty-handler-spawn-environment.test.ts
+++ b/src/relay/pty-handler-spawn-environment.test.ts
@@ -538,6 +538,55 @@ describe('PtyHandler', () => {
     expect(callArgs.env.ORCA_TAB_ID).toBe('tab-1')
   })
 
+  it('does not inherit another pane identity into a spawn that omits it', async () => {
+    const keys = [
+      'ORCA_PANE_KEY',
+      'ORCA_TAB_ID',
+      'ORCA_WORKTREE_ID',
+      'ORCA_TERMINAL_HANDLE'
+    ] as const
+    const saved = new Map(keys.map((key) => [key, process.env[key]]))
+    process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
+    process.env.ORCA_TAB_ID = 'parent-tab'
+    process.env.ORCA_WORKTREE_ID = 'parent-worktree'
+    process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
+
+    try {
+      await dispatcher.callRequest('pty.spawn', {})
+    } finally {
+      for (const [key, value] of saved) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
+
+    const env = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+    expect(env.ORCA_PANE_KEY).toBeUndefined()
+    expect(env.ORCA_TAB_ID).toBeUndefined()
+    expect(env.ORCA_WORKTREE_ID).toBeUndefined()
+    expect(env.ORCA_TERMINAL_HANDLE).toBeUndefined()
+  })
+
+  it('preserves the exact pane identity explicitly supplied for a spawn', async () => {
+    await dispatcher.callRequest('pty.spawn', {
+      env: {
+        ORCA_PANE_KEY: 'child-tab:child-leaf',
+        ORCA_TAB_ID: 'child-tab',
+        ORCA_WORKTREE_ID: 'child-worktree',
+        ORCA_TERMINAL_HANDLE: 'term_child'
+      }
+    })
+
+    const env = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+    expect(env.ORCA_PANE_KEY).toBe('child-tab:child-leaf')
+    expect(env.ORCA_TAB_ID).toBe('child-tab')
+    expect(env.ORCA_WORKTREE_ID).toBe('child-worktree')
+    expect(env.ORCA_TERMINAL_HANDLE).toBe('term_child')
+  })
+
   it('passes PTY and explicit launch identity to env augmenters', async () => {
     const seenContexts: {
       id: string

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -4,6 +4,7 @@ import type * as NodePty from 'node-pty'
 import { existsSync } from 'node:fs'
 import { basename, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
+import { removeUnspecifiedPaneIdentityEnv } from '../shared/pane-identity-env'
 import { resolveWindowsGitBashShellPath } from '../main/git-bash'
 import { WINDOWS_GIT_BASH_SHELL } from '../shared/windows-terminal-shell'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
@@ -754,6 +755,9 @@ export class PtyHandler {
     // on, yet an inherited Orca HISTFILE must not scope a pane to someone else's
     // worktree on the disabled and revive paths either.
     dropInheritedOrcaHistFile(result)
+    // Why: relay processes are often launched from an Orca pane; inherited identity names the
+    // relay's parent pane, never this spawn. Explicit child identity remains authoritative.
+    removeUnspecifiedPaneIdentityEnv(result, rendererEnv)
     // Why unconditionally: ORCA_HISTFILE is Orca-owned and minted below by
     // injectRelayHistoryEnv, which also runs only with isolation on. An
     // inherited one (the relay can be launched from an Orca pane) would

--- a/src/shared/pane-identity-env.ts
+++ b/src/shared/pane-identity-env.ts
@@ -1,0 +1,20 @@
+/** Identity Orca stamps into one PTY. Inherited values always name the host process's pane. */
+export const PANE_IDENTITY_ENV_KEYS = [
+  'ORCA_PANE_KEY',
+  'ORCA_TAB_ID',
+  'ORCA_WORKTREE_ID',
+  'ORCA_TERMINAL_HANDLE',
+  'ORCA_AGENT_LAUNCH_TOKEN'
+] as const
+
+/** Drops pane identity not explicitly supplied for this spawn. */
+export function removeUnspecifiedPaneIdentityEnv(
+  env: Record<string, string>,
+  explicitEnv: Record<string, string> | undefined
+): void {
+  for (const key of PANE_IDENTITY_ENV_KEYS) {
+    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
+      delete env[key]
+    }
+  }
+}

--- a/src/shared/runtime-mobile-session-tab-contracts.ts
+++ b/src/shared/runtime-mobile-session-tab-contracts.ts
@@ -13,6 +13,8 @@ export type RuntimeMobileSessionTerminalTab = {
   parentTabId: string
   leafId: string
   ptyId?: string | null
+  /** Persisted PTY generation when the snapshot can prove it; absent on older publishers. */
+  incarnationId?: string
   terminalTheme?: RuntimeMobileTerminalTheme
   agentStatus?: AgentStatusEntry | null
   /** Event-only lead-turn end time for paired clients; never persisted in AgentStatusEntry. */

--- a/src/shared/runtime-terminal-contracts.ts
+++ b/src/shared/runtime-terminal-contracts.ts
@@ -33,6 +33,8 @@ export type RuntimeTerminalSummary = {
   exitCause?: TerminalExitCause
   /** Absent when the host predates the field or could not name the execution host. */
   executionHostId?: ExecutionHostId
+  /** Current visual-layout membership; absent on old hosts/list opt-out, detached never means stopped. */
+  visualTopologyState?: 'projected' | 'detached'
 }
 
 export type RuntimeTerminalVisualTerminalNode = {


### PR DESCRIPTION
## ELI5

A terminal can still be alive even when Orca no longer has a current visual pane for it, and a resumed Agent can inherit pane identity from the terminal that launched it. Orca now reports that detached state explicitly and removes inherited pane identity unless the child launch supplies its own binding.

## What Changed

- Expose optional `visualTopologyState` on terminal list/show so a live terminal missing from the published visual layout is explicitly detached.
- Fence visual projection by persisted PTY/incarnation identity so a restarted replacement is not projected through a stale layout binding.
- Scrub inherited `ORCA_*` pane/worktree/tab/terminal/launch-token identity unless child spawn explicitly supplies the target binding, including relay revive.
- Add focused coverage for terminal inventory, projection identity, local/daemon spawn, relay spawn, and relay revive.

## Why

Without an explicit detached state, consumers can mistake a live but unprojected PTY for a healthy visible terminal. Inherited parent/source-pane identity can also misattribute a resumed child Agent. The change makes the topology gap observable and treats spawn boundaries as identity boundaries without declaring detached terminals stopped or safe to delete.

## Linked Issue

Closes #18201

## Visual Proof

N/A — this changes Runtime/CLI state reporting and spawn identity hygiene; it does not change renderer layout or styling.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Verified on macOS:

- 99 targeted Vitest tests passed across terminal listing, payload size, daemon/local provider spawn environment, relay spawn, and relay revive.
- `pnpm tc:node` passed.
- `pnpm tc:cli` passed.
- `pnpm run check:code-quality:changed` passed with 0 new findings across 18 files.

A full `pnpm test` run was attempted from an Orca dev terminal but became resource-starved and was stopped after more than 15 minutes. It produced unrelated timing/environment failures across orchestration devMode expectations, cross-version checkout locks, relay timeouts, fuzz timing, dashboard UI timing, and other unchanged files. The affected task-specific suites above pass serially. No application build was run for this follow-up.

## AI Disclosure

OpenAI Codex was used for implementation, review, and focused verification.

## Review

Please focus on the distinction between detached and stopped terminals, the persisted PTY/incarnation projection fence, and whether every child spawn/revive boundary scrubs inherited pane identity without removing an explicitly supplied target binding.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no Agent Skill source, registry, fixture, path table, comment, or documentation.

## Notes

- Detached remains a live state; this PR does not authorize terminal or worktree deletion.
- `visualTopologyState` is optional for mixed-version compatibility. Older/insufficient publishers remain explicitly unverifiable instead of being guessed projected.
- The new state and identity filtering are platform-neutral; local daemon and relay paths have focused coverage. No path separator, shortcut, mobile-only, Git-provider, or filesystem behavior changes.
- The change adds no credential, privilege, HTML, command execution, or new transport capability surface.
- The compatibility questions in #18191 are broader than this PR and are not closed here.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` were not all run; targeted tests, node/CLI typechecks, and changed-code quality passed as documented above
