### PR TITLE
fix(sidebar): keep the project filter when adding a project

### DIFF
--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.test.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.test.ts
@@ -61,9 +61,24 @@ describe('finalizeImportedRepoAfterSkip', () => {
     finalizeImportedRepoAfterSkip(state, 'repo-new')
 
     expect(state.setActiveRepo).toHaveBeenCalledWith('repo-new')
-    expect(state.setFilterRepoIds).toHaveBeenCalledWith([])
+    expect(state.setFilterRepoIds).toHaveBeenCalledWith(['repo-old', 'repo-new'])
     expect(state.setShowActiveOnly).toHaveBeenCalledWith(false)
     expect(state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('leaves the filter untouched when it already includes the imported repo', () => {
+    const state = makeState({
+      activeRepoId: 'repo-new',
+      filterRepoIds: ['repo-new'],
+      showActiveOnly: false,
+      worktreesByRepo: {
+        'repo-new': [makeWorktree({ id: 'repo-new::/repo/feature', repoId: 'repo-new' })]
+      }
+    })
+
+    finalizeImportedRepoAfterSkip(state, 'repo-new')
+
+    expect(state.setFilterRepoIds).not.toHaveBeenCalled()
   })
 
   it('clears default-branch hiding when it would hide every imported worktree', () => {
@@ -140,7 +155,7 @@ describe('finalizeImportedRepoAfterSkip', () => {
     finalizeImportedRepoAfterSkip(state, 'repo-new')
 
     expect(state.setActiveRepo).toHaveBeenCalledWith('repo-new')
-    expect(state.setFilterRepoIds).toHaveBeenCalledWith([])
+    expect(state.setFilterRepoIds).toHaveBeenCalledWith(['repo-old', 'repo-new'])
     expect(state.setShowActiveOnly).toHaveBeenCalledWith(false)
     expect(state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
@@ -1,5 +1,6 @@
 import type { Worktree } from '../../../../shared/worktree/types'
 import { isDefaultBranchWorkspace } from './default-branch-workspace'
+import { widenFilterRepoIds } from '@/store/slices/repo-filter-selection'
 
 export type AddRepoSkipFinalizationState = {
   activeRepoId: string | null
@@ -27,8 +28,10 @@ export function finalizeImportedRepoAfterSkip(
   if (state.activeRepoId !== importedRepoId) {
     state.setActiveRepo(importedRepoId)
   }
-  if (state.filterRepoIds.length > 0 && !state.filterRepoIds.includes(importedRepoId)) {
-    state.setFilterRepoIds([])
+  // Why: widen the filter rather than clear it, so an active project selection survives adding a project.
+  const widenedFilterRepoIds = widenFilterRepoIds(state.filterRepoIds, [importedRepoId])
+  if (widenedFilterRepoIds) {
+    state.setFilterRepoIds(widenedFilterRepoIds)
   }
   if (state.showActiveOnly) {
     state.setShowActiveOnly(false)

--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
@@ -1,6 +1,6 @@
 import type { Worktree } from '../../../../shared/worktree/types'
 import { isDefaultBranchWorkspace } from './default-branch-workspace'
-import { widenFilterRepoIds } from '@/store/slices/repo-filter-selection'
+import { includeReposInFilter } from '@/store/slices/repo-filter-selection'
 
 export type AddRepoSkipFinalizationState = {
   activeRepoId: string | null
@@ -29,10 +29,7 @@ export function finalizeImportedRepoAfterSkip(
     state.setActiveRepo(importedRepoId)
   }
   // Why: widen the filter rather than clear it, so an active project selection survives adding a project.
-  const widenedFilterRepoIds = widenFilterRepoIds(state.filterRepoIds, [importedRepoId])
-  if (widenedFilterRepoIds) {
-    state.setFilterRepoIds(widenedFilterRepoIds)
-  }
+  includeReposInFilter(state, [importedRepoId])
   if (state.showActiveOnly) {
     state.setShowActiveOnly(false)
   }

--- a/src/renderer/src/components/sidebar/project-added-default-checkout.test.ts
+++ b/src/renderer/src/components/sidebar/project-added-default-checkout.test.ts
@@ -529,7 +529,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
       reason: 'no_authoritative_detection'
     })
     expect(mocks.state.setActiveRepo).toHaveBeenCalledWith('repo-1')
-    expect(mocks.state.setFilterRepoIds).toHaveBeenCalledWith([])
+    expect(mocks.state.setFilterRepoIds).toHaveBeenCalledWith(['repo-2', 'repo-1'])
     expect(mocks.state.setShowActiveOnly).toHaveBeenCalledWith(false)
   })
 })

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts
@@ -27,9 +27,11 @@ const folderRepo: Repo = {
 const mocks = vi.hoisted(() => ({
   state: {
     repos: [] as Repo[],
+    filterRepoIds: [] as string[],
     addNonGitFolder: vi.fn(),
     closeModal: vi.fn(),
-    openModal: vi.fn()
+    openModal: vi.fn(),
+    setFilterRepoIds: vi.fn()
   }
 }))
 
@@ -96,6 +98,7 @@ describe('useAddRepoNestedImportFlow open folder fallback', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.state.repos = []
+    mocks.state.filterRepoIds = []
     mocks.state.addNonGitFolder.mockResolvedValue(folderRepo)
   })
 
@@ -245,5 +248,31 @@ describe('useAddRepoNestedImportFlow open folder fallback', () => {
       executionHostId: 'ssh:ssh-builder'
     })
     expect(onGitRepoReady).not.toHaveBeenCalled()
+  })
+
+  it('widens an active sidebar filter to include every repo imported via separate mode', async () => {
+    const importedA: Repo = { ...folderRepo, id: 'repo-a', path: '/workspace/platform/a' }
+    const importedB: Repo = { ...folderRepo, id: 'repo-b', path: '/workspace/platform/b' }
+    const importNestedRepos = vi.fn().mockResolvedValue({
+      projects: [
+        { path: importedA.path, projectId: importedA.id, status: 'imported' as const },
+        { path: importedB.path, projectId: importedB.id, status: 'imported' as const }
+      ],
+      importedCount: 2,
+      alreadyKnownCount: 0,
+      failedCount: 0
+    })
+    mocks.state.repos = [importedA, importedB]
+    mocks.state.filterRepoIds = ['repo-other']
+    const { handleImportNestedRepos } = useTestAddRepoNestedImportFlow({
+      nestedSelectedPaths: new Set([importedA.path, importedB.path]),
+      importNestedRepos,
+      fetchWorktrees: vi.fn(),
+      onGitRepoReady: vi.fn()
+    })
+
+    await handleImportNestedRepos('separate')
+
+    expect(mocks.state.setFilterRepoIds).toHaveBeenCalledWith(['repo-other', 'repo-a', 'repo-b'])
   })
 })

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
@@ -20,6 +20,7 @@ import { worktreeRefreshOptions, type CapturedRuntimeOwner } from './add-repo-ru
 import { completeNestedFolderOpen } from './complete-nested-folder-open'
 import { defaultProjectGroupNameForPath } from './add-repo-dialog-types'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { widenFilterRepoIds } from '@/store/slices/repo-filter-selection'
 
 export function useAddRepoNestedImportFlow({
   nestedAttemptId,
@@ -200,6 +201,11 @@ export function useAddRepoNestedImportFlow({
               )
             }
           )
+        }
+        // Why: 'separate' mode can import several repos, but only the first is revealed below.
+        const widened = widenFilterRepoIds(useAppStore.getState().filterRepoIds, importedRepoIds)
+        if (widened) {
+          useAppStore.getState().setFilterRepoIds(widened)
         }
         const repo = useAppStore.getState().repos.find((entry) => entry.id === firstRepoId)
         if (repo) {

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
@@ -20,7 +20,7 @@ import { worktreeRefreshOptions, type CapturedRuntimeOwner } from './add-repo-ru
 import { completeNestedFolderOpen } from './complete-nested-folder-open'
 import { defaultProjectGroupNameForPath } from './add-repo-dialog-types'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
-import { widenFilterRepoIds } from '@/store/slices/repo-filter-selection'
+import { includeReposInFilter } from '@/store/slices/repo-filter-selection'
 
 export function useAddRepoNestedImportFlow({
   nestedAttemptId,
@@ -203,10 +203,7 @@ export function useAddRepoNestedImportFlow({
           )
         }
         // Why: 'separate' mode can import several repos, but only the first is revealed below.
-        const widened = widenFilterRepoIds(useAppStore.getState().filterRepoIds, importedRepoIds)
-        if (widened) {
-          useAppStore.getState().setFilterRepoIds(widened)
-        }
+        includeReposInFilter(useAppStore.getState(), importedRepoIds)
         const repo = useAppStore.getState().repos.find((entry) => entry.id === firstRepoId)
         if (repo) {
           const source: AddRepoExistingWorkspaceSource = nestedConnectionId

--- a/src/renderer/src/lib/worktree-activation-reveal.test.ts
+++ b/src/renderer/src/lib/worktree-activation-reveal.test.ts
@@ -5,6 +5,57 @@ import { useAppStore } from '@/store'
 
 registerWorktreeActivationReset()
 
+const worktreeOne = {
+  id: 'wt-1',
+  repoId: 'repo-1',
+  path: '/repo',
+  displayName: 'main',
+  branch: 'main',
+  head: 'abc',
+  isBare: false,
+  isMainWorktree: true
+}
+
+function setupActivationState(overrides: Record<string, unknown> = {}): {
+  queueTabInitialCwd: ReturnType<typeof vi.fn>
+  revealWorktreeInSidebar: ReturnType<typeof vi.fn>
+  setFilterRepoIds: ReturnType<typeof vi.fn>
+} {
+  const queueTabInitialCwd = vi.fn()
+  const revealWorktreeInSidebar = vi.fn()
+  const setFilterRepoIds = vi.fn()
+  useAppStore.setState({
+    activeRepoId: null,
+    activeWorktreeId: null,
+    activeView: 'settings',
+    filterRepoIds: [],
+    isNavigatingHistory: false,
+    repos: [{ id: 'repo-1', connectionId: null }],
+    worktreesByRepo: { 'repo-1': [worktreeOne] },
+    getKnownWorktreeById: (worktreeId: string) =>
+      worktreeId === 'wt-1' ? (worktreeOne as never) : null,
+    setActiveRepo: vi.fn(),
+    setActiveView: vi.fn(),
+    setActiveWorktree: vi.fn(),
+    markWorktreeVisited: vi.fn(),
+    recordWorktreeVisit: vi.fn(),
+    reconcileWorktreeTabModel: vi.fn(() => ({ renderableTabCount: 0 })),
+    createTab: vi.fn(() => ({ id: 'tab-1' })),
+    setActiveTab: vi.fn(),
+    setTabCustomTitle: vi.fn(),
+    setTabColor: vi.fn(),
+    markDefaultTerminalTabsApplied: vi.fn(),
+    queueTabStartupCommand: vi.fn(),
+    queueTabInitialCwd,
+    queueTabSetupSplit: vi.fn(),
+    queueTabIssueCommandSplit: vi.fn(),
+    setFilterRepoIds,
+    revealWorktreeInSidebar,
+    ...overrides
+  } as never)
+  return { queueTabInitialCwd, revealWorktreeInSidebar, setFilterRepoIds }
+}
+
 describe('activateAndRevealWorktree', () => {
   afterEach(() => {
     useAppStore.setState({
@@ -17,59 +68,7 @@ describe('activateAndRevealWorktree', () => {
   })
 
   it('queues a one-shot initial cwd for the primary activation-created tab', () => {
-    const queueTabInitialCwd = vi.fn()
-    const revealWorktreeInSidebar = vi.fn()
-    useAppStore.setState({
-      activeRepoId: null,
-      activeWorktreeId: null,
-      activeView: 'settings',
-      filterRepoIds: [],
-      isNavigatingHistory: false,
-      repos: [{ id: 'repo-1', connectionId: null }],
-      worktreesByRepo: {
-        'repo-1': [
-          {
-            id: 'wt-1',
-            repoId: 'repo-1',
-            path: '/repo',
-            displayName: 'main',
-            branch: 'main',
-            head: 'abc',
-            isBare: false,
-            isMainWorktree: true
-          }
-        ]
-      },
-      getKnownWorktreeById: (worktreeId: string) =>
-        worktreeId === 'wt-1'
-          ? ({
-              id: 'wt-1',
-              repoId: 'repo-1',
-              path: '/repo',
-              displayName: 'main',
-              branch: 'main',
-              head: 'abc',
-              isBare: false,
-              isMainWorktree: true
-            } as never)
-          : null,
-      setActiveRepo: vi.fn(),
-      setActiveView: vi.fn(),
-      setActiveWorktree: vi.fn(),
-      markWorktreeVisited: vi.fn(),
-      recordWorktreeVisit: vi.fn(),
-      reconcileWorktreeTabModel: vi.fn(() => ({ renderableTabCount: 0 })),
-      createTab: vi.fn(() => ({ id: 'tab-1' })),
-      setActiveTab: vi.fn(),
-      setTabCustomTitle: vi.fn(),
-      setTabColor: vi.fn(),
-      markDefaultTerminalTabsApplied: vi.fn(),
-      queueTabStartupCommand: vi.fn(),
-      queueTabInitialCwd,
-      queueTabSetupSplit: vi.fn(),
-      queueTabIssueCommandSplit: vi.fn(),
-      revealWorktreeInSidebar
-    } as never)
+    const { queueTabInitialCwd, revealWorktreeInSidebar } = setupActivationState()
 
     const result = activateAndRevealWorktree('wt-1', {
       initialCwd: '/repo/packages/web',
@@ -81,5 +80,21 @@ describe('activateAndRevealWorktree', () => {
     expect(revealWorktreeInSidebar).toHaveBeenCalledWith('wt-1', {
       executionHostId: 'ssh:box'
     })
+  })
+
+  it('widens (not clears) an active sidebar filter to include the revealed worktree', () => {
+    const { setFilterRepoIds } = setupActivationState({ filterRepoIds: ['repo-other'] })
+
+    activateAndRevealWorktree('wt-1', {})
+
+    expect(setFilterRepoIds).toHaveBeenCalledWith(['repo-other', 'repo-1'])
+  })
+
+  it('leaves the filter untouched when it already includes the revealed worktree', () => {
+    const { setFilterRepoIds } = setupActivationState({ filterRepoIds: ['repo-1'] })
+
+    activateAndRevealWorktree('wt-1', {})
+
+    expect(setFilterRepoIds).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -15,6 +15,7 @@ import {
   gateWorktreeAgentActivation,
   workspaceHasSleepingAgentSessions
 } from '@/lib/worktree-agent-activation-gate'
+import { widenFilterRepoIds } from '@/store/slices/repo-filter-selection'
 import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-agent-session'
 import { shouldAutoCreateInitialTerminal } from '@/components/terminal/initial-terminal'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -297,10 +298,12 @@ export function activateAndRevealWorktree(
     useAppStore.getState().queueTabInitialCwd(primaryTabId, opts.initialCwd)
   }
 
-  // 5. Clear sidebar filters hiding the target — reveal needs the card rendered, else it silently no-ops.
+  // 5. Widen (not clear) filters hiding the target so reveal renders the card without dropping the user's project selection.
   if (opts?.clearSidebarFilters !== false) {
-    if (state.filterRepoIds.length > 0 && !state.filterRepoIds.includes(wt.repoId)) {
-      state.setFilterRepoIds([])
+    const currentState = useAppStore.getState()
+    const widenedFilterRepoIds = widenFilterRepoIds(currentState.filterRepoIds, [wt.repoId])
+    if (widenedFilterRepoIds) {
+      currentState.setFilterRepoIds(widenedFilterRepoIds)
     }
     if (
       state.hideAutomationGeneratedWorkspaces &&

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -15,7 +15,7 @@ import {
   gateWorktreeAgentActivation,
   workspaceHasSleepingAgentSessions
 } from '@/lib/worktree-agent-activation-gate'
-import { widenFilterRepoIds } from '@/store/slices/repo-filter-selection'
+import { includeReposInFilter } from '@/store/slices/repo-filter-selection'
 import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-agent-session'
 import { shouldAutoCreateInitialTerminal } from '@/components/terminal/initial-terminal'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -300,11 +300,7 @@ export function activateAndRevealWorktree(
 
   // 5. Widen (not clear) filters hiding the target so reveal renders the card without dropping the user's project selection.
   if (opts?.clearSidebarFilters !== false) {
-    const currentState = useAppStore.getState()
-    const widenedFilterRepoIds = widenFilterRepoIds(currentState.filterRepoIds, [wt.repoId])
-    if (widenedFilterRepoIds) {
-      currentState.setFilterRepoIds(widenedFilterRepoIds)
-    }
+    includeReposInFilter(useAppStore.getState(), [wt.repoId])
     if (
       state.hideAutomationGeneratedWorkspaces &&
       wt.automationProvenance?.kind === 'created-by-automation'

--- a/src/renderer/src/store/slices/repo-filter-selection.test.ts
+++ b/src/renderer/src/store/slices/repo-filter-selection.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { widenFilterRepoIds } from './repo-filter-selection'
+
+describe('widenFilterRepoIds', () => {
+  it('returns null when the filter is empty (no filter to widen)', () => {
+    expect(widenFilterRepoIds([], ['repo-1'])).toBeNull()
+  })
+
+  it('returns null when all repoIds are already included', () => {
+    expect(widenFilterRepoIds(['repo-1', 'repo-2'], ['repo-1'])).toBeNull()
+  })
+
+  it('appends only the missing repoIds, preserving order and without duplicates', () => {
+    expect(widenFilterRepoIds(['repo-1'], ['repo-1', 'repo-2', 'repo-3'])).toEqual([
+      'repo-1',
+      'repo-2',
+      'repo-3'
+    ])
+  })
+})

--- a/src/renderer/src/store/slices/repo-filter-selection.test.ts
+++ b/src/renderer/src/store/slices/repo-filter-selection.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { widenFilterRepoIds } from './repo-filter-selection'
+import { describe, expect, it, vi } from 'vitest'
+import { includeReposInFilter, widenFilterRepoIds } from './repo-filter-selection'
 
 describe('widenFilterRepoIds', () => {
   it('returns null when the filter is empty (no filter to widen)', () => {
@@ -20,5 +20,20 @@ describe('widenFilterRepoIds', () => {
 
   it('appends a repeated missing id only once', () => {
     expect(widenFilterRepoIds(['repo-1'], ['repo-2', 'repo-2'])).toEqual(['repo-1', 'repo-2'])
+  })
+})
+
+describe('includeReposInFilter', () => {
+  it('sets the widened filter only when something is missing', () => {
+    const setFilterRepoIds = vi.fn()
+    includeReposInFilter({ filterRepoIds: ['repo-1'], setFilterRepoIds }, ['repo-2'])
+    expect(setFilterRepoIds).toHaveBeenCalledWith(['repo-1', 'repo-2'])
+  })
+
+  it('does nothing when the filter is inactive or already covers the ids', () => {
+    const setFilterRepoIds = vi.fn()
+    includeReposInFilter({ filterRepoIds: [], setFilterRepoIds }, ['repo-2'])
+    includeReposInFilter({ filterRepoIds: ['repo-2'], setFilterRepoIds }, ['repo-2'])
+    expect(setFilterRepoIds).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/store/slices/repo-filter-selection.test.ts
+++ b/src/renderer/src/store/slices/repo-filter-selection.test.ts
@@ -17,4 +17,8 @@ describe('widenFilterRepoIds', () => {
       'repo-3'
     ])
   })
+
+  it('appends a repeated missing id only once', () => {
+    expect(widenFilterRepoIds(['repo-1'], ['repo-2', 'repo-2'])).toEqual(['repo-1', 'repo-2'])
+  })
 })

--- a/src/renderer/src/store/slices/repo-filter-selection.ts
+++ b/src/renderer/src/store/slices/repo-filter-selection.ts
@@ -17,6 +17,14 @@ export function widenFilterRepoIds(
   if (filterRepoIds.length === 0) {
     return null
   }
-  const missing = repoIds.filter((id) => !filterRepoIds.includes(id))
+  // Why: callers may pass the same id twice (batched imports), so dedupe against the running set.
+  const selected = new Set(filterRepoIds)
+  const missing: string[] = []
+  for (const id of repoIds) {
+    if (!selected.has(id)) {
+      selected.add(id)
+      missing.push(id)
+    }
+  }
   return missing.length > 0 ? [...filterRepoIds, ...missing] : null
 }

--- a/src/renderer/src/store/slices/repo-filter-selection.ts
+++ b/src/renderer/src/store/slices/repo-filter-selection.ts
@@ -8,3 +8,15 @@ export function retainValidFilterRepoIds(
     ? filterRepoIds
     : filterRepoIds.filter((repoId) => validRepoIds.has(repoId))
 }
+
+// Why: reveal/import must make the target visible without dropping the user's project selection, so widen the filter instead of clearing it.
+export function widenFilterRepoIds(
+  filterRepoIds: readonly string[],
+  repoIds: readonly string[]
+): string[] | null {
+  if (filterRepoIds.length === 0) {
+    return null
+  }
+  const missing = repoIds.filter((id) => !filterRepoIds.includes(id))
+  return missing.length > 0 ? [...filterRepoIds, ...missing] : null
+}

--- a/src/renderer/src/store/slices/repo-filter-selection.ts
+++ b/src/renderer/src/store/slices/repo-filter-selection.ts
@@ -28,3 +28,14 @@ export function widenFilterRepoIds(
   }
   return missing.length > 0 ? [...filterRepoIds, ...missing] : null
 }
+
+// Why: reveal and import paths share one no-op-safe entry point instead of repeating the widen-then-set dance.
+export function includeReposInFilter(
+  state: { filterRepoIds: readonly string[]; setFilterRepoIds: (ids: string[]) => void },
+  repoIds: readonly string[]
+): void {
+  const widened = widenFilterRepoIds(state.filterRepoIds, repoIds)
+  if (widened) {
+    state.setFilterRepoIds(widened)
+  }
+}


### PR DESCRIPTION
## ELI5

If you had the sidebar filtered down to a few projects and then added a new project, Orca threw your filter away. Now it keeps your selection and just adds the new project to it.

## What Changed

- Added `widenFilterRepoIds(filterRepoIds, repoIds)` in `src/renderer/src/store/slices/repo-filter-selection.ts` (next to `retainValidFilterRepoIds`). It returns the filter with the missing ids appended, or `null` when no change is needed (filter inactive, or ids already present).
- `activateAndRevealWorktree` (`src/renderer/src/lib/worktree-activation.ts`, step 5): widen the filter to include the target repo instead of `setFilterRepoIds([])`. Reads fresh store state right before the read-modify-write.
- `finalizeImportedRepoAfterSkip` (`add-repo-skip-finalization.ts`): same change.
- Nested repo import (`useAddRepoNestedImportFlow.ts`): in `separate` mode all imported repo ids are added to the filter, not only the first one that gets revealed.
- Tests: updated expectations in `add-repo-skip-finalization.test.ts` and `project-added-default-checkout.test.ts`; new cases in `worktree-activation-reveal.test.ts` (setup deduplicated into a local helper), `useAddRepoNestedImportFlow.test.ts`, and a new `repo-filter-selection.test.ts`.

## Why

Both add paths (git repo and non-git folder) end in `activateAndRevealWorktree`, whose step 5 cleared the whole project filter whenever the target repo was not in it. The reveal only needs the target card rendered, which widening achieves without discarding the user's selection. The same clearing lived in `finalizeImportedRepoAfterSkip`, so both now share one helper.

Trade-off worth noting: `activateAndRevealWorktree` is also reached from background activations (automation runs, CLI, work-item launch). Those will now append to an active filter instead of resetting it to "all projects". That seems like the better default (the user's explicit selection survives), and the filter's Clear action remains one click away.

## Linked Issue

Fixes #18176

## Visual Proof

**Before** (current release): two projects selected in the sidebar filter, Add Project → Browse folder → the filter badge disappears and every project is listed again.

https://github.com/user-attachments/assets/cc950838-f264-4faa-960f-56024c52d7a3

**After** (this branch): the selected projects stay selected and the new project is added to the selection; only those projects are listed.

https://github.com/user-attachments/assets/d448170d-7545-4185-ba9b-203069da9abf

## Testing

Tested on macOS (arm64) with a local `build:mac` build: filter two projects, add a local git repo via Browse folder, filter is kept and widened. Same for a non-git folder.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`pnpm tc` passes; `vitest run` over `src/renderer/src/components/sidebar`, `src/renderer/src/lib`, `src/renderer/src/store` passes (1108 files / 10303 tests); `oxlint` clean on changed files.

## AI Disclosure

Root-cause analysis, implementation, and review were done with Claude Code (Claude Fable 5.1). I reviewed the diff and verified the behaviour manually on a local build.

## Review

AI code review summary (Claude Code, independent review pass over the diff):

- **Cross-platform (macOS / Linux / Windows)**: renderer store logic only; no paths, shortcuts, or process spawning touched. No platform-specific risk.
- **SSH / remote / local**: the remote add path (`useRemoteRepo` → `completeGitRepoAdd`), the runtime-host add path, the non-git folder path (`addNonGitFolder`), the hosted composer path, and the nested import path were all grepped for `setFilterRepoIds`; none call it directly, so every add path funnels through the two fixed functions. Remote hosts get the same behaviour.
- **Agents / integrations / git providers**: not involved. `filterRepoIds` holds opaque repo ids, so GitHub / GitLab identity is irrelevant here.
- **Persistence**: `filterRepoIds` is a writer-owned persisted UI field. `persisted-ui-write-baseline.ts` compares string arrays element-wise, so a widened array is detected as a change and flushed through the debounced `ui.set` writer as before.
- **Performance**: `widenFilterRepoIds` is O(n) over the current filter plus the added ids and runs once per activation/import; no hot-path impact.
- **Security**: no new IPC, no file or network access.
- **Behaviour trade-off flagged by the reviewer**: `activateAndRevealWorktree` is also reached from background activations (automation runs, CLI, work-item launch). Those now append to an active filter instead of resetting it to "all projects". The reviewer judged this the better default (the user's explicit selection survives) and noted the filter's Clear action stays one click away. Callers that pass `revealInSidebar: false` (post-delete focus) still run this step, as they did before; left unchanged to keep the PR scoped.
- **Findings fixed before opening / during review**: nested `separate` import only widened for the first repo (fixed to widen for all imported ids); duplicate ids in the input could be appended twice (fixed with a running `Set`, flagged by CodeRabbit and Pullfrog).

Author: no X handle.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Renderer-only change to store/UI state; no IPC, wire, path, or shortcut impact. SSH/remote add paths funnel through the same two functions, so they get the same behaviour.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

