### PR TITLE
fix(automations): isolate Codex state per run

### DIFF
--- a/src/main/automations/headless-workspace-create.test.ts
+++ b/src/main/automations/headless-workspace-create.test.ts
@@ -72,6 +72,7 @@ describe('headless automation workspace create args', () => {
       activate: false,
       createdWithAgent: 'codex',
       startupAgent: 'codex',
+      codexAutomationStateId: 'run-1',
       startupPrompt: 'Review changes',
       telemetrySource: 'unknown',
       automationProvenance: {
@@ -88,6 +89,20 @@ describe('headless automation workspace create args', () => {
         hostId: 'ssh:ssh-target-1'
       }
     })
+  })
+
+  it('does not add Codex state isolation to non-Codex automation agents', () => {
+    const args = buildHeadlessAutomationWorktreeCreateArgs({
+      automation: { ...automation, agentId: 'claude' },
+      run: {
+        id: 'run-1',
+        title: 'Nightly review run',
+        scheduledFor: Date.UTC(2026, 0, 2, 3, 4, 5)
+      },
+      repo
+    })
+
+    expect(args).not.toHaveProperty('codexAutomationStateId')
   })
 
   it('falls back to skip for legacy automations without a saved setup decision', () => {

--- a/src/main/automations/headless-workspace-create.ts
+++ b/src/main/automations/headless-workspace-create.ts
@@ -40,6 +40,7 @@ export function buildHeadlessAutomationWorktreeCreateArgs({
     activate: false,
     createdWithAgent: automation.agentId,
     startupAgent: automation.agentId,
+    ...(automation.agentId === 'codex' ? { codexAutomationStateId: run.id } : {}),
     startupPrompt: automation.prompt,
     telemetrySource: 'unknown',
     automationProvenance: buildAutomationWorkspaceProvenance(automation, run, repo, createdAt)

--- a/src/main/runtime/orca-runtime-activate-managed-worktree.ts
+++ b/src/main/runtime/orca-runtime-activate-managed-worktree.ts
@@ -139,7 +139,8 @@ export class OrcaRuntimeWithActivateManagedWorktree extends OrcaRuntimeWithListM
     repo: Repo,
     agent: TuiAgent,
     prompt: string | undefined,
-    launchPreferences?: AgentLaunchPreferences
+    launchPreferences?: AgentLaunchPreferences,
+    codexAutomationStateId?: string
   ): { agent: TuiAgent; startup: WorktreeStartupLaunch; followup?: WorktreeStartupFollowup } {
     if (!this.store) {
       throw new Error('runtime_unavailable')
@@ -149,6 +150,7 @@ export class OrcaRuntimeWithActivateManagedWorktree extends OrcaRuntimeWithListM
       agent,
       ...(prompt !== undefined ? { prompt } : {}),
       ...(launchPreferences ? { launchPreferences } : {}),
+      ...(codexAutomationStateId ? { codexAutomationStateId } : {}),
       settings: this.store.getSettings(),
       getLaunchPlatform: () => this.getAgentLaunchPlatformForRepo(repo),
       toSessionOptions: (preferences) => this.toAgentSessionOptions(preferences)

--- a/src/main/runtime/orca-runtime-create-managed-worktree.ts
+++ b/src/main/runtime/orca-runtime-create-managed-worktree.ts
@@ -41,7 +41,8 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
             repo,
             args.startupAgent,
             args.startupPrompt,
-            args.startupLaunchPreferences
+            args.startupLaunchPreferences,
+            args.codexAutomationStateId
           )
         : null
     const draftStartup =

--- a/src/main/runtime/orca-runtime-tests/worktree-setup-and-startup-part-04.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/worktree-setup-and-startup-part-04.spec.ts
@@ -16,6 +16,52 @@ import type { WorktreeMeta } from '../orca-runtime-test-mocks.spec'
 import { TEST_REPO_ID, makeWorktreeMeta, store } from '../orca-runtime-test-fixtures.spec'
 
 describe('OrcaRuntimeService', () => {
+  it('isolates headless Codex automation state outside the worktree', async () => {
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        agentCmdOverrides: {},
+        agentDefaultArgs: { codex: '--dangerously-bypass-approvals-and-sandbox' }
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-codex-automation' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'codex'
+    })
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-codex-automation')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-codex-automation')
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-codex-automation',
+        head: 'def',
+        branch: 'runtime-codex-automation',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await runtime.createManagedWorktree({
+      repoSelector: TEST_REPO_ID,
+      name: 'runtime-codex-automation',
+      startupAgent: 'codex',
+      startupPrompt: 'run automation',
+      codexAutomationStateId: 'run-1'
+    })
+
+    const command = (spawn.mock.calls[0]?.[0] as { command?: string } | undefined)?.command
+    expect(command).toContain("'--dangerously-bypass-approvals-and-sandbox'")
+    expect(command).toMatch(
+      /'-c' 'sqlite_home=~\/.orca\/tmp\/codex-automation\/run-1-[a-f0-9]{32}'/
+    )
+    expect(command).toContain("'run automation'")
+  })
+
   it('sends follow-up prompts for CLI-created stdin-after-start startup agents', async () => {
     const metaById: Record<string, WorktreeMeta> = {}
     const runtimeStore = {

--- a/src/main/runtime/runtime-managed-worktree-create-types.ts
+++ b/src/main/runtime/runtime-managed-worktree-create-types.ts
@@ -49,6 +49,7 @@ export type RuntimeManagedWorktreeCreateArgs = {
   observeSetupCompletion?: boolean
   createdWithAgent?: TuiAgent
   startupAgent?: TuiAgent
+  codexAutomationStateId?: string
   startupLaunchPreferences?: AgentLaunchPreferences
   startupPrompt?: string
   pendingFirstAgentMessageRename?: boolean

--- a/src/main/runtime/runtime-worktree-agent-startup.ts
+++ b/src/main/runtime/runtime-worktree-agent-startup.ts
@@ -6,6 +6,7 @@ import { repoIsRemote } from '../../shared/agent-launch-remote'
 import { isTuiAgent, TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
 import { isTuiAgentEnabled, pickTuiAgent } from '../../shared/tui-agent-selection'
 import {
+  resolveAutomationAgentArgs,
   resolveTuiAgentLaunchArgs,
   resolveTuiAgentLaunchEnv
 } from '../../shared/tui-agent-launch-defaults'
@@ -126,6 +127,7 @@ export function buildWorktreeStartupForAgent(
     agent: TuiAgent
     prompt?: string
     launchPreferences?: AgentLaunchPreferences
+    codexAutomationStateId?: string
     toSessionOptions: (
       preferences?: AgentLaunchPreferences
     ) => Parameters<typeof buildAgentStartupPlan>[0]['sessionOptions'] | undefined
@@ -138,11 +140,16 @@ export function buildWorktreeStartupForAgent(
   const platform = environment.getLaunchPlatform()
   const isRemote = repoIsRemote(repo)
   const sessionOptions = environment.toSessionOptions(environment.launchPreferences)
+  const agentArgs = resolveAutomationAgentArgs(
+    agent,
+    settings.agentDefaultArgs,
+    environment.codexAutomationStateId
+  )
   const startupPlan = buildAgentStartupPlan({
     agent,
     prompt: environment.prompt ?? '',
     cmdOverrides: settings.agentCmdOverrides ?? {},
-    agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
+    agentArgs,
     agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv),
     sessionOptions,
     sessionOptionsOverrideAgentArgs: Boolean(sessionOptions),

--- a/src/renderer/src/hooks/automation-dispatch-completion.ts
+++ b/src/renderer/src/hooks/automation-dispatch-completion.ts
@@ -253,7 +253,9 @@ export function createAutomationDispatchCompletion(args: {
     },
     settlePendingAfterDispatch: async () => {
       dispatchMarked = true
-      if (pendingDone) {
+      if (pendingExitCode !== null && isProvenProcessExit(pendingExitCode)) {
+        await markExitResult(pendingExitCode)
+      } else if (pendingDone) {
         await markCompletionResult()
       } else if (pendingExitCode !== null) {
         await markExitResult(pendingExitCode)

--- a/src/renderer/src/hooks/automation-dispatch-handler.ts
+++ b/src/renderer/src/hooks/automation-dispatch-handler.ts
@@ -11,6 +11,7 @@ import type {
   AutomationDispatchResult
 } from '../../../shared/automations-types'
 import { createAutomationDispatchCompletion } from './automation-dispatch-completion'
+import { resolveAutomationAgentArgs } from '../../../shared/tui-agent-launch-defaults'
 import {
   prepareAutomationDispatchWorkspace,
   resolveAutomationDispatchWorkspace
@@ -170,6 +171,15 @@ export async function handleAutomationDispatchRequest({
       prompt: automation.prompt,
       launchSource: 'unknown',
       title: run.title,
+      ...(automation.agentId === 'codex'
+        ? {
+            agentArgsOverride: resolveAutomationAgentArgs(
+              'codex',
+              state.settings?.agentDefaultArgs,
+              run.id
+            )
+          }
+        : {}),
       onData: completion.appendOutput,
       onAgentStatus: (payload) => {
         completion.captureAssistantMessage(payload.lastAssistantMessage)

--- a/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
+++ b/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
@@ -102,4 +102,47 @@ describe('automation dispatch completion on an unverifiable loss', () => {
     )
     warnSpy.mockRestore()
   })
+
+  it('prefers pending done over simultaneous unverifiable loss', async () => {
+    const { createAutomationDispatchCompletion } = await import('./automation-dispatch-completion')
+    const completion = createAutomationDispatchCompletion({
+      run: { id: 'run-1' } as never,
+      worktree: { id: 'wt-1', displayName: 'Automation worktree' } as never,
+      precheckResult: null,
+      markDispatchResult,
+      releaseTerminalOwnership,
+      finalizeTerminalOwnership
+    })
+
+    completion.handleAgentDone()
+    completion.handleExit(-1)
+    await completion.settlePendingAfterDispatch()
+
+    expect(markDispatchResult).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: 'completed', error: null })
+    )
+  })
+
+  it('prefers a pending process failure over a simultaneous done signal', async () => {
+    const { createAutomationDispatchCompletion } = await import('./automation-dispatch-completion')
+    const completion = createAutomationDispatchCompletion({
+      run: { id: 'run-1' } as never,
+      worktree: { id: 'wt-1', displayName: 'Automation worktree' } as never,
+      precheckResult: null,
+      markDispatchResult,
+      releaseTerminalOwnership,
+      finalizeTerminalOwnership
+    })
+
+    completion.handleAgentDone()
+    completion.handleExit(1)
+    await completion.settlePendingAfterDispatch()
+
+    expect(markDispatchResult).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        status: 'dispatch_failed',
+        error: 'Automation process exited with code 1.'
+      })
+    )
+  })
 })

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -334,12 +334,13 @@ describe('useAutomationDispatchEvents setup launch', () => {
   })
 
   it('does not stamp the created workspace with an empty agent-launch fallback', async () => {
-    await registerAndDispatch()
+    await registerAndDispatch(makeAutomation({ agentId: 'codex' }))
 
     expect(mockCreateWorktree.mock.calls[0][10]).toBeUndefined()
+    expect(mockLaunchAgentBackgroundSession.mock.calls[0]?.[0]?.agentArgsOverride).toContain('run-1')
     expect(mockLaunchAgentBackgroundSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        agent: 'claude',
+        agent: 'codex',
         prompt: 'run this',
         worktreeId: 'wt-created'
       })

--- a/src/renderer/src/lib/agent-background-session-contract.ts
+++ b/src/renderer/src/lib/agent-background-session-contract.ts
@@ -10,6 +10,7 @@ export type LaunchAgentBackgroundSessionArgs = {
   prompt?: string
   launchSource?: LaunchSource
   title?: string
+  agentArgsOverride?: string
   onData?: (chunk: string) => void
   onExit?: (ptyId: string, code: number) => void
   onAgentStatus?: (payload: ParsedAgentStatusPayload) => void

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -90,6 +90,25 @@ describe('launchAgentBackgroundSession', () => {
     })
   })
 
+  it('routes isolated Codex state to the worktree without replacing its authenticated home', async () => {
+    const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
+    mockSpawn.mockResolvedValue({ id: 'pty-1', incarnationId: 'inc-fresh' })
+
+    await launchAgentBackgroundSession({
+      agent: 'codex',
+      worktreeId: 'wt-1',
+      prompt: 'run the automation',
+      agentArgsOverride:
+        "--dangerously-bypass-approvals-and-sandbox -c sqlite_home='~/.orca/tmp/codex-automation/run-1-proof'"
+    })
+
+    const spawnArgs = mockSpawn.mock.calls.at(-1)?.[0]
+    expect(spawnArgs?.command).toContain(
+      "'-c' 'sqlite_home=~/.orca/tmp/codex-automation/run-1-proof'"
+    )
+    expect(spawnArgs?.env?.CODEX_HOME).toBeUndefined()
+  })
+
   it('spawns a PTY first and creates the inactive tab already bound to it', async () => {
     const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
     mockSpawn.mockResolvedValue({ id: 'pty-1', incarnationId: 'inc-fresh' })

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -54,7 +54,7 @@ export async function launchAgentBackgroundSession(
     throw new Error('The target workspace is no longer available.')
   }
   const cmdOverrides = store.settings?.agentCmdOverrides ?? {}
-  const agentArgs = resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs)
+  const agentArgs = args.agentArgsOverride ?? resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs)
   const agentEnv = resolveTuiAgentLaunchEnv(agent, store.settings?.agentDefaultEnv)
   // Folder launch ownership cannot be derived from a repo row (#2989).
   const launchHost = resolveAgentBackgroundLaunchHost({

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -1,3 +1,4 @@
+import { resolveAutomationAgentArgs } from './tui-agent-launch-defaults'
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_TERMINAL_INACTIVE_PANE_OPACITY,
@@ -180,5 +181,28 @@ describe('MiniMax defaults', () => {
     // MiniMax usage endpoint exposes by default.
     expect(settings.minimaxGroupId).toBe('')
     expect(settings.minimaxUsageModels).toBe('general')
+  })
+})
+
+describe('resolveAutomationAgentArgs', () => {
+  it('appends a run-scoped Codex sqlite home without replacing configured args', () => {
+    expect(
+      resolveAutomationAgentArgs('codex', { codex: '--profile work' }, 'run:1/unsafe')
+    ).toMatch(
+      /^--profile work -c sqlite_home='~\/.orca\/tmp\/codex-automation\/run-1-unsafe-[a-f0-9]{32}'$/
+    )
+  })
+
+  it('keeps lossy, truncated, and case-only run ids in separate directories', () => {
+    const resolve = (id: string) => resolveAutomationAgentArgs('codex', {}, id)
+    expect(new Set([resolve('run:1'), resolve('run/1')]).size).toBe(2)
+    expect(new Set([resolve(`${'a'.repeat(128)}x`), resolve(`${'a'.repeat(128)}y`)]).size).toBe(2)
+    expect(new Set([resolve('RUN-1'), resolve('run-1')]).size).toBe(2)
+  })
+
+  it('leaves non-Codex agent arguments unchanged', () => {
+    expect(resolveAutomationAgentArgs('claude', { claude: '--model opus' }, 'run-1')).toBe(
+      '--model opus'
+    )
   })
 })

--- a/src/shared/tui-agent-launch-defaults.ts
+++ b/src/shared/tui-agent-launch-defaults.ts
@@ -1,6 +1,7 @@
 import { isTuiAgent } from './tui-agent-config'
 import { YOLO_TUI_AGENT_ARGS, YOLO_TUI_AGENT_ENV } from './tui-agent-permissions'
 import type { TuiAgent } from './tui-agent'
+import { sha256 } from './sha256'
 
 const UNSUPPORTED_TUI_AGENT_ARGS: Partial<Record<TuiAgent, readonly string[]>> = {
   opencode: ['--dangerously-skip-permissions'],
@@ -101,4 +102,27 @@ export function resolveTuiAgentLaunchEnv(
     return { ...configuredEnv[agent] }
   }
   return getTuiAgentDefaultEnv(agent)
+}
+
+const CODEX_AUTOMATION_STATE_ROOT = '~/.orca/tmp/codex-automation'
+
+function normalizeCodexAutomationStateId(runId: string): string {
+  const readable = runId.replace(/[^a-zA-Z0-9_-]/g, '-').slice(0, 64) || 'run'
+  const digest = Array.from(sha256(new TextEncoder().encode(runId)).slice(0, 16), (byte) =>
+    byte.toString(16).padStart(2, '0')
+  ).join('')
+  return `${readable}-${digest}`
+}
+
+export function resolveAutomationAgentArgs(
+  agent: TuiAgent,
+  configuredArgs: Partial<Record<TuiAgent, string>> | null | undefined,
+  codexAutomationStateId?: string
+): string {
+  const defaultArgs = resolveTuiAgentLaunchArgs(agent, configuredArgs)
+  if (agent !== 'codex' || !codexAutomationStateId) {
+    return defaultArgs
+  }
+  const statePath = `${CODEX_AUTOMATION_STATE_ROOT}/${normalizeCodexAutomationStateId(codexAutomationStateId)}`
+  return `${defaultArgs} -c sqlite_home='${statePath}'`.trim()
 }


### PR DESCRIPTION
## ELI5

Codex keeps active-session bookkeeping in SQLite files. Orca now gives every scheduled Codex run its own bookkeeping directory, so another live Codex session cannot lock it out, while login and user configuration continue to come from the normal Codex home.

## What Changed

- isolate Codex automation SQLite files under `~/.orca/tmp/codex-automation/<readable-run-id>-<digest>`
- apply the same state override in desktop and headless/remote automation launch paths without replacing `CODEX_HOME`
- make the derived directory collision-resistant across lossy characters, truncation, and case-insensitive filesystems
- prefer a proven nonzero process exit over a simultaneous agent `done` signal, while preserving `done` over an unverifiable contact-loss sentinel

## Why

A scheduled Codex automation failed at startup because another Codex process held shared `state_5.sqlite` / `logs_2.sqlite` files. The failed startup could also be recorded as completed if status and exit callbacks raced before the dispatch record was persisted. Isolating only SQLite state fixes the lock without copying credentials or forking refresh-token state.

## Linked Issue

No existing issue; reproduced from a manually triggered scheduled automation run.

## Visual Proof

N/A — this changes automation process launch/state handling, not UI rendering.

## Testing

- [x] I manually tested these changes locally on macOS
- [x] Automated tests added/updated
- [x] `pnpm lint`
- [x] `pnpm tc`
- [x] focused Vitest set: 1,306 passed, 1 skipped
- [x] `pnpm run check:code-quality:changed`
- [x] `pnpm run build:desktop`
- [x] concurrent `codex doctor --json` launches resolved distinct run-scoped SQLite homes while retaining the configured `CODEX_HOME`
- [ ] Linux / Windows / SSH execution tested live; path and shell quoting are covered by existing cross-platform startup builders and tests

## AI Disclosure

OpenAI Codex was used to investigate, implement, test, and self-review this change.

## Review

Self-reviewed the exact current head. Addressed both external review findings: collision-resistant state paths and correct proven-exit/unverifiable-loss precedence.

## Agent skill upstream boundary

- [x] Not applicable; no skill-installer source or upstream skill content is copied or translated.

## Notes

- Security: credentials remain in the configured `CODEX_HOME`; only SQLite state is redirected.
- Cross-platform/SSH: `~` expansion is performed by Codex, and Orca's existing host-specific argument tokenizer/quoting remains authoritative.
- Compatibility: the new runtime create field is optional and internal; non-Codex launches are unchanged.
- Performance: one small per-run SQLite directory; no hot-path I/O added by Orca.
- Known limitation: age-based cleanup of temporary run-state directories is not included and can be added independently.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [x] Local lint, typecheck, focused tests, and desktop build pass; full-suite infrastructure failures were unrelated and pre-existing under resource pressure
