### PR TITLE
fix(windows): mark PowerShell startup command boundaries

### DIFF
--- a/src/main/powershell-osc133-bootstrap.ts
+++ b/src/main/powershell-osc133-bootstrap.ts
@@ -103,6 +103,21 @@ export function getPowerShellOsc133Bootstrap(): string {
   return POWERSHELL_OSC133_BOOTSTRAP
 }
 
+/**
+ * Marks a startup command appended to the bootstrap as a real command.
+ *
+ * Why: that command runs before the first prompt, and the prompt wrapper
+ * suppresses `133;D` until it has printed once — so an agent launched this way
+ * exits leaving no command-finished boundary, and nothing ever retires its pane.
+ * bash gets both marks from its DEBUG trap; PowerShell has to be told.
+ */
+export function getPowerShellOsc133StartupCommandMark(): string {
+  return `if (Test-Path variable:global:__OrcaOsc133State) {
+    [Console]::Write("$($Global:__OrcaOsc133State.Esc)]133;C$($Global:__OrcaOsc133State.Bel)")
+    $Global:__OrcaOsc133State.HasSeenPrompt = $true
+}`
+}
+
 export function isPowerShellExecutableName(shellName: string): boolean {
   const normalized = shellName.toLowerCase()
   return (

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -26,6 +26,12 @@ function decodePowerShellCommand(result: ReturnType<typeof resolveWindowsShellLa
   return Buffer.from(result.shellArgs[3] ?? '', 'base64').toString('utf16le')
 }
 
+const OSC133_COMMAND_START_MARK = ']133;C$($Global:__OrcaOsc133State.Bel)'
+
+function countOsc133CommandStartMarks(command: string): number {
+  return command.split(OSC133_COMMAND_START_MARK).length - 1
+}
+
 function expectedPowerShellRestoreCwdCommand(cwdLiteral: string): string {
   return `try { Set-Location -LiteralPath ${cwdLiteral} -ErrorAction Stop } catch { Write-Warning "Failed to restore working directory: $_" }`
 }
@@ -201,6 +207,37 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(command).toContain('function Global:prompt')
     expect(command).toContain(expectedPowerShellRestoreCwdCommand("'C:\\Users\\alice'"))
     expect(command.trimEnd().endsWith("& 'codex' '--no-alt-screen'")).toBe(true)
+  })
+
+  it('marks an embedded PowerShell startup command as a command boundary', () => {
+    // Why: the prompt wrapper withholds 133;D until it has printed once, so a
+    // startup-launched agent would exit with no command-finished boundary and
+    // its pane row would never retire.
+    const result = resolveWindowsShellLaunchArgs(
+      'powershell.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      "& 'claude'"
+    )
+
+    const command = decodePowerShellCommand(result)
+    // One mark belongs to the readline hook; the second is this command's.
+    expect(countOsc133CommandStartMarks(command)).toBe(2)
+    const startupMarkIndex = command.lastIndexOf(OSC133_COMMAND_START_MARK)
+    const startupCommandIndex = command.indexOf("& 'claude'")
+    expect(startupMarkIndex).toBeLessThan(startupCommandIndex)
+    expect(command.slice(startupMarkIndex, startupCommandIndex)).toContain(
+      '$Global:__OrcaOsc133State.HasSeenPrompt = $true'
+    )
+  })
+
+  it('leaves a PowerShell shell with no startup command unmarked', () => {
+    const command = decodePowerShellCommand(
+      resolveWindowsShellLaunchArgs('powershell.exe', 'C:\\Users\\alice', 'C:\\Users\\alice')
+    )
+
+    expect(countOsc133CommandStartMarks(command)).toBe(1)
   })
 
   it('preserves complex PowerShell startup command text through EncodedCommand', () => {

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -10,7 +10,8 @@ import { getBashWrapperLaunchArgs } from './local-pty-shell-ready'
 import { ensureShellReadyWrappersAt } from './local-pty-shell-ready-wrapper-generation'
 import {
   encodePowerShellCommand,
-  getPowerShellOsc133Bootstrap
+  getPowerShellOsc133Bootstrap,
+  getPowerShellOsc133StartupCommandMark
 } from '../powershell-osc133-bootstrap'
 import { quoteStartupArg } from '../../shared/tui-agent-startup-shell'
 
@@ -121,7 +122,7 @@ function getPowerShellEncodedCommand(
     return { encodedCommand: encodePowerShellCommand(bootstrap) }
   }
 
-  const command = `${bootstrap}\n${startupCommand}`
+  const command = `${bootstrap}\n${getPowerShellOsc133StartupCommandMark()}\n${startupCommand}`
   const encodedCommand = encodePowerShellCommand(command)
   // Why: -EncodedCommand expands UTF-16 text into base64; keep a conservative
   // margin under Windows CreateProcess' 32,767-character command line limit.


### PR DESCRIPTION
## Summary

A native Windows PowerShell startup agent can exit cleanly and return to the shell while Orca
continues to retain its workspace row and per-pane lifecycle state. The startup command runs before
the first prompt, so the existing idle-shell guard suppresses the only OSC `133;D` that could begin
foreground confirmation and ended-process reconciliation.

This PR restores that missing lifecycle boundary by emitting OSC `133;C` and priming the existing
prompt latch immediately before an embedded startup command. It does not add a parallel cleanup
path or special-case an agent; it makes the existing C/D-driven cleanup path observable again.

## Why prompt review matters

- The failure occurs on a normal agent exit, not only after a crash or forced termination.
- The process table and Orca's workspace state can disagree until an unrelated lifecycle event,
  so users cannot trust the agent list to tell them what is actually running.
- The review surface is narrow: one guarded PowerShell fragment, two resolver call-site lines, and
  focused regression coverage; no protocol, process-tree, or non-PowerShell behavior changes.

## ELI5

PowerShell normally avoids saying "a command finished" when it displays a brand-new shell's
first prompt. Orca launches some commands before that prompt, so when one of those commands
finishes, PowerShell still treats the next prompt as the empty shell's first prompt and says
nothing. This PR marks the startup command as real work, allowing PowerShell to report its
completion and Orca to remove the finished agent row.

## What Changed

- Added `getPowerShellOsc133StartupCommandMark()` to emit OSC `133;C` and prime the existing
  `HasSeenPrompt` latch.
- Inserted that marker between the PowerShell bootstrap and every startup command embedded in
  `-EncodedCommand`.
- Added regression coverage proving that:
  - an embedded startup command gets exactly one additional `133;C` marker;
  - the marker and latch update occur before the startup command; and
  - a shell without a startup command receives no additional marker.

The implementation is command-generic. The test uses `claude` as the original reproduction
fixture, but production code does not inspect an agent name.

## Why

Agent-row teardown begins when the terminal consumer receives OSC `133;D`. It then confirms
that the foreground returned to the shell before sending `agentStatus:drop` and
`agentStatus:reconcileEndedProcess`.

On Windows, a short PowerShell startup command is appended to the bootstrap's
`-EncodedCommand` payload and therefore runs before the first prompt. The existing prompt
latch suppresses `133;D` at exactly that prompt, so the teardown chain never begins. Marking
the embedded startup command restores the missing C/D boundary while preserving the guard
for genuinely idle shells.

## Linked Issue

Fixes #18180

## Visual Proof

N/A — this is terminal lifecycle signaling rather than a visual layout change.

| Scenario | Before | After |
|---|---:|---:|
| Embedded PowerShell startup command | `133;D` × 0 | `133;D` × 1 |
| PowerShell with no startup command | `133;D` × 0 | `133;D` × 0 |

## Testing

- [x] Core payload suites (`windows-shell-args.test.ts` and
  `powershell-osc133-bootstrap.test.ts`) — 35 tests passed in this worktree.
- [x] Downstream OSC parsing, shell lifecycle, foreground tracking, cleanup, and PowerShell CLM
  suites — 101 tests passed; 4 Windows-only PowerShell/CLM tests were skipped on macOS.
- [x] `pnpm tc:node` — passed.
- [x] `pnpm run check:code-quality:changed` — passed with zero findings.
- [x] `oxlint` and `oxfmt --check` on all 3 changed files, plus `git diff --check` — passed.
- [x] Prior manual Windows 11 real-PowerShell measurement — the startup-command case emitted one
  `133;D`; the no-startup case emitted zero.
- [x] Final Orca UI check in a newly created PowerShell agent pane on Windows.

## AI Disclosure

Developed and reviewed with OpenAI Codex. The command-boundary behavior was also measured in
a real Windows PowerShell environment; all generated changes remain subject to maintainer
review.

## Review

- **Scope:** only `powershell.exe`/`pwsh.exe` startup commands embedded in Windows shell args.
- **No-startup behavior:** unchanged; the first-prompt false-D guard remains active.
- **Other Windows shells:** cmd.exe, Git Bash, and WSL paths are unchanged.
- **macOS/Linux:** the Windows resolver is gated by the execution host's `win32` platform.
  POSIX startup commands keep their existing wrapper/stdin delivery paths.
- **SSH/remote:** no RPC, stream opcode, or wire payload changes. The execution host remains
  responsible for shell integration.
- **PowerShell policy:** the new fragment is a no-op if the OSC state was not installed, such
  as under an unsupported language mode.
- **Command-line budget:** the marker is included before the existing 28,000-character encoded
  argument check; if it pushes a payload over the limit, the startup command keeps the stdin
  fallback and the bootstrap remains unmarked.
- **Security/EDR:** no new process, interpreter flag, execution-policy override, or encoded
  command mechanism is introduced; the existing payload only gains a bounded script fragment.
- **Performance:** one small OSC write and one state assignment per embedded startup command.

## Agent skill upstream boundary

- [x] Not applicable. This change copies or modifies no upstream agent-skill installer source,
  registry entry, fixture, path table, comment, or documentation.

## Notes

- Oversized startup commands continue to use the existing PTY stdin fallback and are not
  marked by this fragment.
- Foreground commands are the intended contract. A startup command that deliberately detaches
  a background process completes from the shell's perspective when its launcher returns.
- No user input, credentials, status-file contents, or command text is added to logs.

## Checklist

- [x] This PR is small and focused.
- [x] The problem, root cause, and chosen fix are documented.
- [x] Automated regression tests were added and self-reviewed.
- [x] Cross-platform, SSH/remote, security, and performance impact were considered.
- [x] No-startup and non-PowerShell behavior remain unchanged.
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
