### PR TITLE
feat(tab-bar): add an Open-in apps launcher beside the quick command button

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeOpenInMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeOpenInMenu.test.tsx
@@ -185,6 +185,19 @@ describe('WorktreeOpenInMenu', () => {
     ).toEqual(['VS Code', 'Cursor', 'Zed', 'File Manager'])
   })
 
+  it('omits the file manager entry when a caller lists only configured apps', () => {
+    expect(
+      getWorktreeOpenInEntries(
+        [
+          { id: 'vscode', label: 'VS Code', command: 'code' },
+          { id: 'cursor', label: 'Cursor', command: 'cursor' }
+        ],
+        'File Manager',
+        { includeFileManager: false }
+      ).map((entry) => entry.label)
+    ).toEqual(['VS Code', 'Cursor'])
+  })
+
   it('opens settings at the Open In Apps section', () => {
     openOpenInAppsSettings()
 

--- a/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
@@ -26,6 +26,9 @@ type WorktreeOpenInMenuItemsProps = {
   connectionId?: string | null
   disabled?: boolean
   labelPrefix?: string
+  /** Default true; the tab-strip launcher lists only the configured apps. */
+  includeFileManager?: boolean
+  onOpenEntry?: (entry: OpenInMenuEntry) => void
 }
 
 export type OpenInMenuEntry = {
@@ -37,15 +40,20 @@ export type OpenInMenuEntry = {
 
 export function getWorktreeOpenInEntries(
   openInApplications: readonly OpenInApplication[],
-  fileManagerLabel: string
+  fileManagerLabel: string,
+  options: { includeFileManager?: boolean } = {}
 ): OpenInMenuEntry[] {
+  const applicationEntries = openInApplications.map((application) => ({
+    id: application.id,
+    label: application.label,
+    target: 'external-editor' as const,
+    command: application.command
+  }))
+  if (options.includeFileManager === false) {
+    return applicationEntries
+  }
   return [
-    ...openInApplications.map((application) => ({
-      id: application.id,
-      label: application.label,
-      target: 'external-editor' as const,
-      command: application.command
-    })),
+    ...applicationEntries,
     { id: 'file-manager', label: fileManagerLabel, target: 'file-manager' }
   ]
 }
@@ -301,7 +309,9 @@ export function WorktreeOpenInMenuItems({
   worktreePath,
   connectionId,
   disabled,
-  labelPrefix = ''
+  labelPrefix = '',
+  includeFileManager = true,
+  onOpenEntry
 }: WorktreeOpenInMenuItemsProps): React.JSX.Element {
   const openInWorktreePath = useOpenInWorktreePath({ worktreePath, connectionId })
   const openInApplications = useAppStore(
@@ -309,7 +319,9 @@ export function WorktreeOpenInMenuItems({
   )
   const settings = useAppStore((s) => s.settings)
   const fileManagerLabel = getLocalFileManagerLabel()
-  const entries = getWorktreeOpenInEntries(openInApplications, fileManagerLabel)
+  const entries = getWorktreeOpenInEntries(openInApplications, fileManagerLabel, {
+    includeFileManager
+  })
 
   return (
     <>
@@ -320,6 +332,7 @@ export function WorktreeOpenInMenuItems({
             key={entry.id}
             onClick={stopMenuPropagation}
             onSelect={() => {
+              onOpenEntry?.(entry)
               void openInWorktreePath(entry.target, entry.command)
             }}
             disabled={disabled || availability.disabled}

--- a/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.test.tsx
@@ -8,6 +8,12 @@ import type { OpenInApplication } from '../../../../shared/ui-chrome-types'
 import { resolvePrimaryOpenInApplication, TabBarOpenInAppsButton } from './TabBarOpenInAppsButton'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+// Why: Radix popper measures the trigger with ResizeObserver, which happy-dom lacks.
+globalThis.ResizeObserver ??= class {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
 
 const {
   mockState,
@@ -111,6 +117,14 @@ describe('resolvePrimaryOpenInApplication', () => {
     expect(resolvePrimaryOpenInApplication([vscode, cursor], null)).toBe(vscode)
     expect(resolvePrimaryOpenInApplication([], 'vscode')).toBeNull()
   })
+
+  it('skips an unavailable recent app for the first available one, else keeps it', () => {
+    const onlyCursor = (application: OpenInApplication): boolean => application.id === 'cursor'
+    expect(resolvePrimaryOpenInApplication([vscode, cursor], 'vscode', onlyCursor)).toBe(cursor)
+    expect(resolvePrimaryOpenInApplication([vscode, cursor], null, onlyCursor)).toBe(cursor)
+    expect(resolvePrimaryOpenInApplication([vscode, cursor], 'vscode', () => false)).toBe(vscode)
+    expect(resolvePrimaryOpenInApplication([vscode, cursor], null, () => false)).toBe(vscode)
+  })
 })
 
 describe('TabBarOpenInAppsButton', () => {
@@ -145,12 +159,53 @@ describe('TabBarOpenInAppsButton', () => {
     expect(primaryButton().textContent).toBe('Cursor')
   })
 
-  it('disables the primary action when the app cannot open the workspace here', () => {
+  it('prefers an app that can open an SSH workspace over a local-only recent one', () => {
     mockState.repos = [{ id: 'repo-1', connectionId: 'ssh-1' }]
     mockState.recentOpenInApplicationId = 'cursor'
     render()
     // Why: only VS Code supports SSH workspaces, so Cursor is "Local only" on a remote repo.
+    expect(primaryButton().textContent).toBe('VS Code')
+    expect(primaryButton().disabled).toBe(false)
+  })
+
+  it('disables the primary action when no configured app can open the workspace here', () => {
+    mockState.repos = [{ id: 'repo-1', connectionId: 'ssh-1' }]
+    mockState.settings = { activeRuntimeEnvironmentId: null, openInApplications: [cursor] }
+    render()
+    expect(primaryButton().textContent).toBe('Cursor')
     expect(primaryButton().disabled).toBe(true)
+  })
+
+  it('lists every configured app in the dropdown and remembers the one launched from it', async () => {
+    render()
+    const chevron = container.querySelector('button[aria-label="More apps"]')
+    if (!(chevron instanceof HTMLButtonElement)) {
+      throw new Error('chevron not found')
+    }
+
+    await act(async () => {
+      chevron.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      await Promise.resolve()
+    })
+
+    const items = Array.from(document.querySelectorAll('[data-slot="dropdown-menu-item"]'))
+    expect(items.map((item) => item.textContent)).toEqual([
+      'VS Code',
+      'Cursor',
+      'Customize apps...'
+    ])
+
+    await act(async () => {
+      ;(items[1] as HTMLElement).click()
+      await Promise.resolve()
+    })
+
+    expect(setRecentOpenInApplicationIdMock).toHaveBeenCalledWith('cursor')
+    expect(openInExternalEditorMock).toHaveBeenCalledWith({
+      path: '/tmp/ws',
+      command: 'cursor',
+      connectionId: null
+    })
   })
 
   it('falls back to a settings shortcut when no apps are configured', () => {

--- a/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import type { OpenInApplication } from '../../../../shared/ui-chrome-types'
+import { resolvePrimaryOpenInApplication, TabBarOpenInAppsButton } from './TabBarOpenInAppsButton'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const {
+  mockState,
+  openInExternalEditorMock,
+  openSettingsPageMock,
+  openSettingsTargetMock,
+  setRecentOpenInApplicationIdMock
+} = vi.hoisted(() => ({
+  mockState: {
+    worktreesByRepo: {} as Record<string, { id: string; repoId: string; path: string }[]>,
+    repos: [] as { id: string; connectionId?: string | null }[],
+    settings: {
+      activeRuntimeEnvironmentId: null as string | null,
+      openInApplications: [] as { id: string; label: string; command: string }[]
+    },
+    recentOpenInApplicationId: null as string | null
+  },
+  openInExternalEditorMock: vi.fn(),
+  openSettingsPageMock: vi.fn(),
+  openSettingsTargetMock: vi.fn(),
+  setRecentOpenInApplicationIdMock: vi.fn()
+}))
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
+
+vi.mock('@/i18n/i18n', () => ({
+  i18n: { language: 'en' },
+  translate: (_key: string, fallback: string, values?: Record<string, string>) => {
+    if (!values) {
+      return fallback
+    }
+    return Object.entries(values).reduce(
+      (text, [key, value]) => text.replace(`{{${key}}}`, value),
+      fallback
+    )
+  }
+}))
+
+vi.mock('@/store', () => {
+  const getState = (): Record<string, unknown> => ({
+    ...mockState,
+    openSettingsPage: openSettingsPageMock,
+    openSettingsTarget: openSettingsTargetMock,
+    setRecentOpenInApplicationId: setRecentOpenInApplicationIdMock
+  })
+  const useAppStore = Object.assign(
+    (selector: (state: Record<string, unknown>) => unknown) => selector(getState()),
+    { getState }
+  )
+  return { useAppStore }
+})
+
+const vscode: OpenInApplication = { id: 'vscode', label: 'VS Code', command: 'code' }
+const cursor: OpenInApplication = { id: 'cursor', label: 'Cursor', command: 'cursor' }
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  mockState.worktreesByRepo = {
+    'repo-1': [{ id: 'repo-1::/tmp/ws', repoId: 'repo-1', path: '/tmp/ws' }]
+  }
+  mockState.repos = [{ id: 'repo-1', connectionId: null }]
+  mockState.settings = { activeRuntimeEnvironmentId: null, openInApplications: [vscode, cursor] }
+  mockState.recentOpenInApplicationId = null
+  openInExternalEditorMock.mockReset().mockResolvedValue({ ok: true })
+  openSettingsPageMock.mockReset()
+  openSettingsTargetMock.mockReset()
+  setRecentOpenInApplicationIdMock.mockReset()
+  Object.assign(window, { api: { shell: { openInExternalEditor: openInExternalEditorMock } } })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+function render(worktreeId = 'repo-1::/tmp/ws'): void {
+  act(() => {
+    root.render(
+      createElement(TooltipProvider, null, createElement(TabBarOpenInAppsButton, { worktreeId }))
+    )
+  })
+}
+
+function primaryButton(): HTMLButtonElement {
+  const button = container.querySelector('button[aria-label^="Open in"]')
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error('primary button not found')
+  }
+  return button
+}
+
+describe('resolvePrimaryOpenInApplication', () => {
+  it('prefers the most recently launched app and falls back to the first one', () => {
+    expect(resolvePrimaryOpenInApplication([vscode, cursor], 'cursor')).toBe(cursor)
+    expect(resolvePrimaryOpenInApplication([vscode, cursor], 'missing')).toBe(vscode)
+    expect(resolvePrimaryOpenInApplication([vscode, cursor], null)).toBe(vscode)
+    expect(resolvePrimaryOpenInApplication([], 'vscode')).toBeNull()
+  })
+})
+
+describe('TabBarOpenInAppsButton', () => {
+  it('renders nothing when the worktree is unknown (floating terminals)', () => {
+    render('global-floating-terminal')
+    expect(container.querySelector('button')).toBeNull()
+  })
+
+  it('opens the workspace in the first configured app and remembers it', async () => {
+    render()
+    const button = primaryButton()
+    expect(button.textContent).toBe('VS Code')
+    expect(button.getAttribute('aria-label')).toBe('Open in VS Code')
+    expect(container.querySelector('button[aria-label="More apps"]')).not.toBeNull()
+
+    await act(async () => {
+      button.click()
+      await Promise.resolve()
+    })
+
+    expect(setRecentOpenInApplicationIdMock).toHaveBeenCalledWith('vscode')
+    expect(openInExternalEditorMock).toHaveBeenCalledWith({
+      path: '/tmp/ws',
+      command: 'code',
+      connectionId: null
+    })
+  })
+
+  it('promotes the most recently launched app to the primary action', () => {
+    mockState.recentOpenInApplicationId = 'cursor'
+    render()
+    expect(primaryButton().textContent).toBe('Cursor')
+  })
+
+  it('disables the primary action when the app cannot open the workspace here', () => {
+    mockState.repos = [{ id: 'repo-1', connectionId: 'ssh-1' }]
+    mockState.recentOpenInApplicationId = 'cursor'
+    render()
+    // Why: only VS Code supports SSH workspaces, so Cursor is "Local only" on a remote repo.
+    expect(primaryButton().disabled).toBe(true)
+  })
+
+  it('falls back to a settings shortcut when no apps are configured', () => {
+    mockState.settings = { activeRuntimeEnvironmentId: null, openInApplications: [] }
+    render()
+    const button = container.querySelector(
+      'button[aria-label="Add apps to open this workspace in"]'
+    )
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error('empty-state button not found')
+    }
+    expect(button.textContent).toBe('Open in')
+
+    act(() => {
+      button.click()
+    })
+
+    expect(openSettingsTargetMock).toHaveBeenCalledWith({
+      pane: 'general',
+      repoId: null,
+      sectionId: 'general-open-in-apps'
+    })
+    expect(openSettingsPageMock).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.test.tsx
@@ -168,12 +168,34 @@ describe('TabBarOpenInAppsButton', () => {
     expect(primaryButton().disabled).toBe(false)
   })
 
-  it('disables the primary action when no configured app can open the workspace here', () => {
+  it('disables the primary action and keeps its tooltip reachable when no app can open the workspace here', async () => {
     mockState.repos = [{ id: 'repo-1', connectionId: 'ssh-1' }]
     mockState.settings = { activeRuntimeEnvironmentId: null, openInApplications: [cursor] }
     render()
     expect(primaryButton().textContent).toBe('Cursor')
     expect(primaryButton().disabled).toBe(true)
+
+    // Why: a disabled button gets no focus or pointer events, so the wrapper must be the focusable tooltip trigger.
+    const trigger = primaryButton().parentElement
+    if (!(trigger instanceof HTMLElement)) {
+      throw new Error('tooltip trigger not found')
+    }
+    expect(trigger.getAttribute('data-slot')).toBe('tooltip-trigger')
+    expect(trigger.tabIndex).toBe(0)
+
+    await act(async () => {
+      trigger.focus()
+      await Promise.resolve()
+    })
+
+    const tooltip = document.querySelector('[data-slot="tooltip-content"]')
+    expect(tooltip?.textContent).toContain('Open in Cursor')
+    expect(tooltip?.textContent).toContain('Local only')
+  })
+
+  it('does not make the wrapper focusable while the primary button is enabled', () => {
+    render()
+    expect(primaryButton().parentElement?.hasAttribute('tabindex')).toBe(false)
   })
 
   it('lists every configured app in the dropdown and remembers the one launched from it', async () => {

--- a/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.test.tsx
@@ -226,6 +226,11 @@ describe('TabBarOpenInAppsButton', () => {
     }
     expect(trigger.getAttribute('data-slot')).toBe('tooltip-trigger')
     expect(trigger.tabIndex).toBe(0)
+    // Why: the stop must announce what it is; the inert inner button is hidden so its name is not read twice.
+    expect(trigger.getAttribute('role')).toBe('button')
+    expect(trigger.getAttribute('aria-disabled')).toBe('true')
+    expect(trigger.getAttribute('aria-label')).toBe('Open in Cursor')
+    expect(primaryButton().getAttribute('aria-hidden')).toBe('true')
 
     await act(async () => {
       trigger.focus()
@@ -237,9 +242,13 @@ describe('TabBarOpenInAppsButton', () => {
     expect(tooltip?.textContent).toContain('Local only')
   })
 
-  it('does not make the wrapper focusable while the primary button is enabled', () => {
+  it('leaves the wrapper inert and unnamed while the primary button is enabled', () => {
     render()
-    expect(primaryButton().parentElement?.hasAttribute('tabindex')).toBe(false)
+    const wrapper = primaryButton().parentElement
+    expect(wrapper?.hasAttribute('tabindex')).toBe(false)
+    expect(wrapper?.hasAttribute('role')).toBe(false)
+    expect(wrapper?.hasAttribute('aria-label')).toBe(false)
+    expect(primaryButton().hasAttribute('aria-hidden')).toBe(false)
   })
 
   it('lists every configured app in the dropdown and remembers the one launched from it', async () => {

--- a/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.test.tsx
@@ -24,7 +24,14 @@ const {
 } = vi.hoisted(() => ({
   mockState: {
     worktreesByRepo: {} as Record<string, { id: string; repoId: string; path: string }[]>,
-    repos: [] as { id: string; connectionId?: string | null }[],
+    repos: [] as { id: string; path: string; connectionId?: string | null }[],
+    folderWorkspaces: [] as {
+      id: string
+      projectGroupId: string
+      folderPath: string
+      connectionId?: string | null
+    }[],
+    projectGroups: [] as { id: string; connectionId?: string | null }[],
     settings: {
       activeRuntimeEnvironmentId: null as string | null,
       openInApplications: [] as { id: string; label: string; command: string }[]
@@ -76,7 +83,9 @@ beforeEach(() => {
   mockState.worktreesByRepo = {
     'repo-1': [{ id: 'repo-1::/tmp/ws', repoId: 'repo-1', path: '/tmp/ws' }]
   }
-  mockState.repos = [{ id: 'repo-1', connectionId: null }]
+  mockState.repos = [{ id: 'repo-1', path: '/tmp/repo-1', connectionId: null }]
+  mockState.folderWorkspaces = []
+  mockState.projectGroups = []
   mockState.settings = { activeRuntimeEnvironmentId: null, openInApplications: [vscode, cursor] }
   mockState.recentOpenInApplicationId = null
   openInExternalEditorMock.mockReset().mockResolvedValue({ ok: true })
@@ -133,6 +142,41 @@ describe('TabBarOpenInAppsButton', () => {
     expect(container.querySelector('button')).toBeNull()
   })
 
+  it('renders for folder workspaces, which live outside worktreesByRepo', async () => {
+    mockState.folderWorkspaces = [
+      { id: 'folder-1', projectGroupId: 'group-1', folderPath: '/tmp/plain-folder' }
+    ]
+    render('folder:folder-1')
+    const button = primaryButton()
+    expect(button.textContent).toBe('VS Code')
+
+    await act(async () => {
+      button.click()
+      await Promise.resolve()
+    })
+
+    expect(openInExternalEditorMock).toHaveBeenCalledWith({
+      path: '/tmp/plain-folder',
+      command: 'code',
+      connectionId: null
+    })
+  })
+
+  it('resolves the SSH connection of a remote folder workspace', () => {
+    mockState.folderWorkspaces = [
+      {
+        id: 'folder-1',
+        projectGroupId: 'group-1',
+        folderPath: '/srv/remote-folder',
+        connectionId: 'ssh-1'
+      }
+    ]
+    mockState.recentOpenInApplicationId = 'cursor'
+    render('folder:folder-1')
+    // Why: Cursor is local only, so an SSH folder must fall back to VS Code like an SSH worktree does.
+    expect(primaryButton().textContent).toBe('VS Code')
+  })
+
   it('opens the workspace in the first configured app and remembers it', async () => {
     render()
     const button = primaryButton()
@@ -160,7 +204,7 @@ describe('TabBarOpenInAppsButton', () => {
   })
 
   it('prefers an app that can open an SSH workspace over a local-only recent one', () => {
-    mockState.repos = [{ id: 'repo-1', connectionId: 'ssh-1' }]
+    mockState.repos = [{ id: 'repo-1', path: '/tmp/repo-1', connectionId: 'ssh-1' }]
     mockState.recentOpenInApplicationId = 'cursor'
     render()
     // Why: only VS Code supports SSH workspaces, so Cursor is "Local only" on a remote repo.
@@ -169,7 +213,7 @@ describe('TabBarOpenInAppsButton', () => {
   })
 
   it('disables the primary action and keeps its tooltip reachable when no app can open the workspace here', async () => {
-    mockState.repos = [{ id: 'repo-1', connectionId: 'ssh-1' }]
+    mockState.repos = [{ id: 'repo-1', path: '/tmp/repo-1', connectionId: 'ssh-1' }]
     mockState.settings = { activeRuntimeEnvironmentId: null, openInApplications: [cursor] }
     render()
     expect(primaryButton().textContent).toBe('Cursor')

--- a/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.tsx
@@ -179,15 +179,19 @@ export function TabBarOpenInAppsButton({
     <div className={TAB_BAR_SPLIT_BUTTON_CLASS}>
       <Tooltip>
         <TooltipTrigger asChild>
-          {/* Why: a disabled button gets no pointer or focus events, so the wrapper carries the tooltip that says why. */}
+          {/* Why: a disabled button gets no pointer or focus events, so while disabled the wrapper is the focusable, named stop that carries the tooltip saying why. */}
           <span
             className="flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             tabIndex={primaryAvailability.disabled ? 0 : undefined}
+            role={primaryAvailability.disabled ? 'button' : undefined}
+            aria-disabled={primaryAvailability.disabled || undefined}
+            aria-label={primaryAvailability.disabled ? openPrimaryLabel : undefined}
           >
             <button
               type="button"
               onClick={openPrimary}
               disabled={primaryAvailability.disabled}
+              aria-hidden={primaryAvailability.disabled || undefined}
               className={TAB_BAR_SPLIT_BUTTON_PRIMARY_CLASS}
               aria-label={openPrimaryLabel}
             >

--- a/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.tsx
@@ -18,9 +18,11 @@ import {
 import { OpenInApplicationIcon } from '@/lib/open-in-app-catalog'
 import { NO_OPEN_IN_APPLICATIONS } from '@/lib/open-in-application-selection'
 import { useAppStore } from '@/store'
-import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { getIndexedWorktreeById } from '@/store/worktree-repo-index'
+import { getConnectionIdFromState } from '@/lib/connection-owner-resolution'
 import { translate } from '@/i18n/i18n'
 import type { OpenInApplication } from '../../../../shared/ui-chrome-types'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import {
   TAB_BAR_ACTION_BUTTON_CLASS,
   TAB_BAR_SPLIT_BUTTON_CHEVRON_CLASS,
@@ -63,8 +65,18 @@ export function resolvePrimaryOpenInApplication(
 export function TabBarOpenInAppsButton({
   worktreeId
 }: TabBarOpenInAppsButtonProps): React.JSX.Element | null {
-  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
-  const repos = useAppStore((s) => s.repos)
+  // Why: folder workspaces live in `folderWorkspaces`, not `worktreesByRepo`, and the selectors return primitives so store writes elsewhere don't re-render the strip.
+  const worktreePath = useAppStore((s) => {
+    const scope = parseWorkspaceKey(worktreeId)
+    if (scope?.type === 'folder') {
+      return (
+        s.folderWorkspaces.find((workspace) => workspace.id === scope.folderWorkspaceId)
+          ?.folderPath ?? null
+      )
+    }
+    return getIndexedWorktreeById(s.worktreesByRepo, worktreeId)?.path ?? null
+  })
+  const connectionId = useAppStore((s) => getConnectionIdFromState(s, worktreeId) ?? null)
   const settings = useAppStore((s) => s.settings)
   const openInApplications = useAppStore(
     (s) => s.settings?.openInApplications ?? NO_OPEN_IN_APPLICATIONS
@@ -75,16 +87,6 @@ export function TabBarOpenInAppsButton({
   // Why: closing the menu restores focus to the chevron, which must not immediately reopen its tooltip.
   const suppressMoreAppsTooltipRef = useRef(false)
 
-  // Why: floating terminals use a synthetic worktree id with no workspace behind it, so there is nothing to open.
-  const worktree = useMemo(
-    () => findWorktreeById(worktreesByRepo, worktreeId) ?? null,
-    [worktreesByRepo, worktreeId]
-  )
-  const connectionId = useMemo(
-    () =>
-      worktree ? (repos.find((repo) => repo.id === worktree.repoId)?.connectionId ?? null) : null,
-    [repos, worktree]
-  )
   const availabilityOf = useCallback(
     (application: OpenInApplication) =>
       getOpenInEntryAvailability(toOpenInEntry(application), settings, connectionId),
@@ -119,19 +121,20 @@ export function TabBarOpenInAppsButton({
     suppressMoreAppsTooltipRef.current = false
   }, [])
   const openPrimary = useCallback((): void => {
-    if (!primary || !worktree) {
+    if (!primary || !worktreePath) {
       return
     }
     useAppStore.getState().setRecentOpenInApplicationId(primary.id)
     void openWorktreePath({
       target: 'external-editor',
-      worktreePath: worktree.path,
+      worktreePath,
       connectionId,
       command: primary.command
     })
-  }, [connectionId, primary, worktree])
+  }, [connectionId, primary, worktreePath])
 
-  if (!worktree) {
+  // Why: floating terminals use a synthetic worktree id with no workspace behind it, so there is nothing to open.
+  if (!worktreePath) {
     return null
   }
 
@@ -221,7 +224,7 @@ export function TabBarOpenInAppsButton({
         </Tooltip>
         <DropdownMenuContent align="end" side="bottom" sideOffset={6} className="w-52">
           <WorktreeOpenInMenuItems
-            worktreePath={worktree.path}
+            worktreePath={worktreePath}
             connectionId={connectionId}
             includeFileManager={false}
             onOpenEntry={(entry) => useAppStore.getState().setRecentOpenInApplicationId(entry.id)}

--- a/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.tsx
@@ -12,7 +12,8 @@ import {
   getOpenInEntryAvailability,
   openOpenInAppsSettings,
   openWorktreePath,
-  WorktreeOpenInMenuItems
+  WorktreeOpenInMenuItems,
+  type OpenInMenuEntry
 } from '@/components/sidebar/WorktreeOpenInMenu'
 import { OpenInApplicationIcon } from '@/lib/open-in-app-catalog'
 import { NO_OPEN_IN_APPLICATIONS } from '@/lib/open-in-application-selection'
@@ -32,18 +33,29 @@ type TabBarOpenInAppsButtonProps = {
   worktreeId: string
 }
 
+function toOpenInEntry(application: OpenInApplication): OpenInMenuEntry {
+  return {
+    id: application.id,
+    label: application.label,
+    target: 'external-editor',
+    command: application.command
+  }
+}
+
 /** Split-button primary: the most recently launched app, else the first configured one (mirrors the quick-commands button). */
 export function resolvePrimaryOpenInApplication(
   applications: readonly OpenInApplication[],
-  recentId: string | null
+  recentId: string | null,
+  isAvailable: (application: OpenInApplication) => boolean = () => true
 ): OpenInApplication | null {
-  if (recentId) {
-    const match = applications.find((application) => application.id === recentId)
-    if (match) {
-      return match
-    }
+  const recent = recentId
+    ? applications.find((application) => application.id === recentId)
+    : undefined
+  if (recent && isAvailable(recent)) {
+    return recent
   }
-  return applications[0] ?? null
+  // Why: on an SSH workspace the last-used app may be local-only, so prefer one that can open here.
+  return applications.find(isAvailable) ?? recent ?? applications[0] ?? null
 }
 
 export function TabBarOpenInAppsButton({
@@ -71,25 +83,23 @@ export function TabBarOpenInAppsButton({
       worktree ? (repos.find((repo) => repo.id === worktree.repoId)?.connectionId ?? null) : null,
     [repos, worktree]
   )
+  const availabilityOf = useCallback(
+    (application: OpenInApplication) =>
+      getOpenInEntryAvailability(toOpenInEntry(application), settings, connectionId),
+    [connectionId, settings]
+  )
   const primary = useMemo(
-    () => resolvePrimaryOpenInApplication(openInApplications, recentId),
-    [openInApplications, recentId]
+    () =>
+      resolvePrimaryOpenInApplication(
+        openInApplications,
+        recentId,
+        (application) => !availabilityOf(application).disabled
+      ),
+    [availabilityOf, openInApplications, recentId]
   )
   const primaryAvailability = useMemo(
-    () =>
-      primary
-        ? getOpenInEntryAvailability(
-            {
-              id: primary.id,
-              label: primary.label,
-              target: 'external-editor',
-              command: primary.command
-            },
-            settings,
-            connectionId
-          )
-        : { disabled: true },
-    [connectionId, primary, settings]
+    () => (primary ? availabilityOf(primary) : { disabled: true }),
+    [availabilityOf, primary]
   )
 
   const handleOpenChange = useCallback((next: boolean): void => {

--- a/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.tsx
@@ -33,6 +33,7 @@ type TabBarOpenInAppsButtonProps = {
   worktreeId: string
 }
 
+/** Availability checks take menu entries, so adapt a configured app. */
 function toOpenInEntry(application: OpenInApplication): OpenInMenuEntry {
   return {
     id: application.id,
@@ -58,6 +59,7 @@ export function resolvePrimaryOpenInApplication(
   return applications.find(isAvailable) ?? recent ?? applications[0] ?? null
 }
 
+/** Tab-strip split button that opens the workspace in a configured Open In app. Hidden when the id has no workspace (floating terminals). */
 export function TabBarOpenInAppsButton({
   worktreeId
 }: TabBarOpenInAppsButtonProps): React.JSX.Element | null {
@@ -174,16 +176,22 @@ export function TabBarOpenInAppsButton({
     <div className={TAB_BAR_SPLIT_BUTTON_CLASS}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={openPrimary}
-            disabled={primaryAvailability.disabled}
-            className={TAB_BAR_SPLIT_BUTTON_PRIMARY_CLASS}
-            aria-label={openPrimaryLabel}
+          {/* Why: a disabled button gets no pointer or focus events, so the wrapper carries the tooltip that says why. */}
+          <span
+            className="flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            tabIndex={primaryAvailability.disabled ? 0 : undefined}
           >
-            <OpenInApplicationIcon application={primary} size={12} />
-            <span className={TAB_BAR_SPLIT_BUTTON_LABEL_CLASS}>{primary.label}</span>
-          </button>
+            <button
+              type="button"
+              onClick={openPrimary}
+              disabled={primaryAvailability.disabled}
+              className={TAB_BAR_SPLIT_BUTTON_PRIMARY_CLASS}
+              aria-label={openPrimaryLabel}
+            >
+              <OpenInApplicationIcon application={primary} size={12} />
+              <span className={TAB_BAR_SPLIT_BUTTON_LABEL_CLASS}>{primary.label}</span>
+            </button>
+          </span>
         </TooltipTrigger>
         <TooltipContent side="bottom" sideOffset={6}>
           {openPrimaryLabel}

--- a/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarOpenInAppsButton.tsx
@@ -1,0 +1,222 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { AppWindow, ChevronDown } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import {
+  getOpenInEntryAvailability,
+  openOpenInAppsSettings,
+  openWorktreePath,
+  WorktreeOpenInMenuItems
+} from '@/components/sidebar/WorktreeOpenInMenu'
+import { OpenInApplicationIcon } from '@/lib/open-in-app-catalog'
+import { NO_OPEN_IN_APPLICATIONS } from '@/lib/open-in-application-selection'
+import { useAppStore } from '@/store'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { translate } from '@/i18n/i18n'
+import type { OpenInApplication } from '../../../../shared/ui-chrome-types'
+import {
+  TAB_BAR_ACTION_BUTTON_CLASS,
+  TAB_BAR_SPLIT_BUTTON_CHEVRON_CLASS,
+  TAB_BAR_SPLIT_BUTTON_CLASS,
+  TAB_BAR_SPLIT_BUTTON_LABEL_CLASS,
+  TAB_BAR_SPLIT_BUTTON_PRIMARY_CLASS
+} from './tab-bar-split-button-chrome'
+
+type TabBarOpenInAppsButtonProps = {
+  worktreeId: string
+}
+
+/** Split-button primary: the most recently launched app, else the first configured one (mirrors the quick-commands button). */
+export function resolvePrimaryOpenInApplication(
+  applications: readonly OpenInApplication[],
+  recentId: string | null
+): OpenInApplication | null {
+  if (recentId) {
+    const match = applications.find((application) => application.id === recentId)
+    if (match) {
+      return match
+    }
+  }
+  return applications[0] ?? null
+}
+
+export function TabBarOpenInAppsButton({
+  worktreeId
+}: TabBarOpenInAppsButtonProps): React.JSX.Element | null {
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const repos = useAppStore((s) => s.repos)
+  const settings = useAppStore((s) => s.settings)
+  const openInApplications = useAppStore(
+    (s) => s.settings?.openInApplications ?? NO_OPEN_IN_APPLICATIONS
+  )
+  const recentId = useAppStore((s) => s.recentOpenInApplicationId)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [moreAppsTooltipOpen, setMoreAppsTooltipOpen] = useState(false)
+  // Why: closing the menu restores focus to the chevron, which must not immediately reopen its tooltip.
+  const suppressMoreAppsTooltipRef = useRef(false)
+
+  // Why: floating terminals use a synthetic worktree id with no workspace behind it, so there is nothing to open.
+  const worktree = useMemo(
+    () => findWorktreeById(worktreesByRepo, worktreeId) ?? null,
+    [worktreesByRepo, worktreeId]
+  )
+  const connectionId = useMemo(
+    () =>
+      worktree ? (repos.find((repo) => repo.id === worktree.repoId)?.connectionId ?? null) : null,
+    [repos, worktree]
+  )
+  const primary = useMemo(
+    () => resolvePrimaryOpenInApplication(openInApplications, recentId),
+    [openInApplications, recentId]
+  )
+  const primaryAvailability = useMemo(
+    () =>
+      primary
+        ? getOpenInEntryAvailability(
+            {
+              id: primary.id,
+              label: primary.label,
+              target: 'external-editor',
+              command: primary.command
+            },
+            settings,
+            connectionId
+          )
+        : { disabled: true },
+    [connectionId, primary, settings]
+  )
+
+  const handleOpenChange = useCallback((next: boolean): void => {
+    setMenuOpen(next)
+    suppressMoreAppsTooltipRef.current = !next
+    setMoreAppsTooltipOpen(false)
+  }, [])
+  const handleMoreAppsTooltipOpenChange = useCallback((next: boolean): void => {
+    if (next && suppressMoreAppsTooltipRef.current) {
+      return
+    }
+    setMoreAppsTooltipOpen(next)
+  }, [])
+  const allowMoreAppsTooltip = useCallback((): void => {
+    suppressMoreAppsTooltipRef.current = false
+  }, [])
+  const openPrimary = useCallback((): void => {
+    if (!primary || !worktree) {
+      return
+    }
+    useAppStore.getState().setRecentOpenInApplicationId(primary.id)
+    void openWorktreePath({
+      target: 'external-editor',
+      worktreePath: worktree.path,
+      connectionId,
+      command: primary.command
+    })
+  }, [connectionId, primary, worktree])
+
+  if (!worktree) {
+    return null
+  }
+
+  const addAppsLabel = translate(
+    'auto.components.tab.bar.TabBarOpenInAppsButton.addApps',
+    'Add apps to open this workspace in'
+  )
+  // Empty state: single button that jumps to the Open In Apps setting.
+  if (!primary) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={openOpenInAppsSettings}
+            className={TAB_BAR_ACTION_BUTTON_CLASS}
+            aria-label={addAppsLabel}
+          >
+            <AppWindow className="size-3.5" />
+            <span className="text-[12px] font-medium">
+              {translate('auto.components.tab.bar.TabBarOpenInAppsButton.openIn', 'Open in')}
+            </span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6}>
+          {addAppsLabel}
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  const openPrimaryLabel = translate(
+    'auto.components.tab.bar.TabBarOpenInAppsButton.openInApp',
+    'Open in {{value0}}',
+    { value0: primary.label }
+  )
+  const moreAppsLabel = translate(
+    'auto.components.tab.bar.TabBarOpenInAppsButton.moreApps',
+    'More apps'
+  )
+  return (
+    <div className={TAB_BAR_SPLIT_BUTTON_CLASS}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={openPrimary}
+            disabled={primaryAvailability.disabled}
+            className={TAB_BAR_SPLIT_BUTTON_PRIMARY_CLASS}
+            aria-label={openPrimaryLabel}
+          >
+            <OpenInApplicationIcon application={primary} size={12} />
+            <span className={TAB_BAR_SPLIT_BUTTON_LABEL_CLASS}>{primary.label}</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6}>
+          {openPrimaryLabel}
+          {primaryAvailability.metadata ? (
+            <span className="text-background/70"> · {primaryAvailability.metadata}</span>
+          ) : null}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenu modal={false} open={menuOpen} onOpenChange={handleOpenChange}>
+        <Tooltip open={moreAppsTooltipOpen} onOpenChange={handleMoreAppsTooltipOpenChange}>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className={TAB_BAR_SPLIT_BUTTON_CHEVRON_CLASS}
+                aria-label={moreAppsLabel}
+                onPointerEnter={allowMoreAppsTooltip}
+                onBlur={allowMoreAppsTooltip}
+              >
+                <ChevronDown className="size-3" strokeWidth={2.5} />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {moreAppsLabel}
+          </TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end" side="bottom" sideOffset={6} className="w-52">
+          <WorktreeOpenInMenuItems
+            worktreePath={worktree.path}
+            connectionId={connectionId}
+            includeFileManager={false}
+            onOpenEntry={(entry) => useAppStore.getState().setRecentOpenInApplicationId(entry.id)}
+          />
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={openOpenInAppsSettings}>
+            {translate(
+              'auto.components.sidebar.WorktreeOpenInMenu.1417fd8380',
+              'Customize apps...'
+            )}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
@@ -25,6 +25,7 @@ import {
 import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 import { useProjectHostSetupProjection } from '@/store/selectors'
 import { terminalQuickCommandMatchesWorkspaceProject } from '@/lib/terminal-quick-command-project-scope'
+import { TAB_BAR_ACTION_BUTTON_CLASS } from './tab-bar-split-button-chrome'
 
 type TabBarQuickCommandsButtonProps = {
   worktreeId: string
@@ -177,7 +178,7 @@ export function TabBarQuickCommandsButton({
             <button
               type="button"
               onClick={() => addRepoCommand(defaultHostId)}
-              className="my-auto flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className={TAB_BAR_ACTION_BUTTON_CLASS}
               aria-label={translate(
                 'auto.components.tab.bar.TabBarQuickCommandsButton.8f1e971966',
                 'Add quick command'

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
@@ -20,7 +20,6 @@ import {
 } from '../../../../shared/terminal-quick-commands'
 import { getAgentLabel } from '@/lib/agent-catalog'
 import { TabBarQuickCommandItem } from './TabBarQuickCommandItem'
-import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { useImeEnterGestureOwnership } from '@/lib/ime-composition-keyboard-event'
 import { useShortcutKeyComboDetails } from '@/hooks/useShortcutLabel'
@@ -29,6 +28,12 @@ import { TabBarQuickCommandAddActions } from './TabBarQuickCommandAddActions'
 import { TabBarQuickCommandHostLoadStatus } from './TabBarQuickCommandHostLoadStatus'
 import { searchHostedTerminalQuickCommands } from './hosted-terminal-quick-command-search'
 import { useTabBarQuickCommandSearchInput } from './use-tab-bar-quick-command-search-input'
+import {
+  TAB_BAR_SPLIT_BUTTON_CHEVRON_CLASS,
+  TAB_BAR_SPLIT_BUTTON_CLASS,
+  TAB_BAR_SPLIT_BUTTON_LABEL_CLASS,
+  TAB_BAR_SPLIT_BUTTON_PRIMARY_CLASS
+} from './tab-bar-split-button-chrome'
 import type {
   HostedTerminalQuickCommand,
   TerminalQuickCommandHost
@@ -183,19 +188,15 @@ export function TabBarQuickCommandsMenu({
     'auto.components.tab.bar.TabBarQuickCommandsButton.b82e237a4b',
     'More quick commands'
   )
-  const splitButtonClass =
-    'my-auto flex h-7 shrink-0 items-stretch overflow-hidden rounded-md border border-border/60 text-muted-foreground'
-  const innerButtonBase =
-    'flex items-center bg-transparent leading-none text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
   return (
-    <div className={splitButtonClass}>
+    <div className={TAB_BAR_SPLIT_BUTTON_CLASS}>
       <Tooltip>
         <TooltipTrigger asChild>
           <button
             type="button"
             onClick={() => mostRecent && runAndClose(mostRecent)}
             disabled={!mostRecent}
-            className={cn(innerButtonBase, 'gap-1.5 rounded-l-md rounded-r-none px-1.5')}
+            className={TAB_BAR_SPLIT_BUTTON_PRIMARY_CLASS}
             aria-label={
               mostRecent
                 ? translate(
@@ -210,7 +211,7 @@ export function TabBarQuickCommandsMenu({
             }
           >
             <Play className="size-3 shrink-0" fill="currentColor" strokeWidth={0} />
-            <span className="max-w-[160px] truncate text-[12px] font-medium">
+            <span className={TAB_BAR_SPLIT_BUTTON_LABEL_CLASS}>
               {mostRecent?.command.label ??
                 translate('auto.components.tab.bar.TabBarQuickCommandsButton.7b1c9d6ae1', 'Run')}
             </span>
@@ -244,10 +245,7 @@ export function TabBarQuickCommandsMenu({
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                className={cn(
-                  innerButtonBase,
-                  'justify-center rounded-l-none rounded-r-md border-l border-border/60 px-1'
-                )}
+                className={TAB_BAR_SPLIT_BUTTON_CHEVRON_CLASS}
                 aria-label={moreCommandsLabel}
                 onPointerEnter={allowMoreCommandsTooltip}
                 onBlur={allowMoreCommandsTooltip}

--- a/src/renderer/src/components/tab-bar/tab-bar-split-button-chrome.ts
+++ b/src/renderer/src/components/tab-bar/tab-bar-split-button-chrome.ts
@@ -8,7 +8,7 @@ export const TAB_BAR_SPLIT_BUTTON_CLASS =
   'my-auto flex h-7 shrink-0 items-stretch overflow-hidden rounded-md border border-border/60 text-muted-foreground'
 
 const TAB_BAR_SPLIT_BUTTON_INNER_CLASS =
-  'flex items-center bg-transparent leading-none text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+  'flex items-center bg-transparent leading-none text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:pointer-events-none disabled:opacity-50'
 
 export const TAB_BAR_SPLIT_BUTTON_PRIMARY_CLASS = cn(
   TAB_BAR_SPLIT_BUTTON_INNER_CLASS,

--- a/src/renderer/src/components/tab-bar/tab-bar-split-button-chrome.ts
+++ b/src/renderer/src/components/tab-bar/tab-bar-split-button-chrome.ts
@@ -1,0 +1,23 @@
+import { cn } from '@/lib/utils'
+
+/** Chrome shared by the tab-strip action buttons (quick commands, open-in apps) so they stay visually identical. */
+export const TAB_BAR_ACTION_BUTTON_CLASS =
+  'my-auto flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+
+export const TAB_BAR_SPLIT_BUTTON_CLASS =
+  'my-auto flex h-7 shrink-0 items-stretch overflow-hidden rounded-md border border-border/60 text-muted-foreground'
+
+const TAB_BAR_SPLIT_BUTTON_INNER_CLASS =
+  'flex items-center bg-transparent leading-none text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+
+export const TAB_BAR_SPLIT_BUTTON_PRIMARY_CLASS = cn(
+  TAB_BAR_SPLIT_BUTTON_INNER_CLASS,
+  'gap-1.5 rounded-l-md rounded-r-none px-1.5'
+)
+
+export const TAB_BAR_SPLIT_BUTTON_CHEVRON_CLASS = cn(
+  TAB_BAR_SPLIT_BUTTON_INNER_CLASS,
+  'justify-center rounded-l-none rounded-r-md border-l border-border/60 px-1'
+)
+
+export const TAB_BAR_SPLIT_BUTTON_LABEL_CLASS = 'max-w-[160px] truncate text-[12px] font-medium'

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -12,6 +12,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import TabBar from '../tab-bar/TabBar'
 
+import { TabBarOpenInAppsButton } from '../tab-bar/TabBarOpenInAppsButton'
 import { TabBarQuickCommandsButton } from '../tab-bar/TabBarQuickCommandsButton'
 import { useTabGroupWorkspaceModel } from './useTabGroupWorkspaceModel'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
@@ -220,7 +221,8 @@ export default function TabGroupPanel({
   const menuButtonClassName =
     'my-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
   // Why: focused-only so quick commands and Close split pane stay with the active pane and unfocused strips stay compact.
-  const focusedActionChromeClassName = `flex shrink-0 items-center gap-0.5 overflow-hidden transition-[opacity] duration-150 ${
+  // Why: gap-1.5 keeps the bordered Open-in and Command split buttons from reading as one segmented control.
+  const focusedActionChromeClassName = `flex shrink-0 items-center gap-1.5 overflow-hidden transition-[opacity] duration-150 ${
     isFocused ? 'ml-1.5 pointer-events-auto opacity-100' : 'pointer-events-none opacity-0 w-0'
   }`
   return (
@@ -271,7 +273,10 @@ export default function TabGroupPanel({
           >
             <div className={focusedActionChromeClassName}>
               {isFocused ? (
-                <TabBarQuickCommandsButton worktreeId={worktreeId} groupId={groupId} />
+                <>
+                  <TabBarOpenInAppsButton worktreeId={worktreeId} />
+                  <TabBarQuickCommandsButton worktreeId={worktreeId} groupId={groupId} />
+                </>
               ) : null}
               {isFocused && hasSplitGroups ? (
                 <Tooltip>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3489,6 +3489,12 @@
           "TabBarQuickCommandHostLoadStatus": {
             "82e294f3ca": "Host unavailable",
             "7c129b08ff": "Loading host…"
+          },
+          "TabBarOpenInAppsButton": {
+            "addApps": "Add apps to open this workspace in",
+            "openIn": "Open in",
+            "openInApp": "Open in {{value0}}",
+            "moreApps": "More apps"
           }
         }
       },

--- a/src/renderer/src/store/slices/ui/ui-slice-contract-preferences.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-contract-preferences.ts
@@ -124,6 +124,9 @@ export type UISliceSurfaces = {
   // Why: cleared by the diff decorator after it reveals the line, so the same id can be requested again without a stale value.
   scrollToDiffCommentId: string | null
   setScrollToDiffCommentId: (id: string | null) => void
+  /** Transient: last app launched from the tab-strip Open-in button, so its primary action follows usage. */
+  recentOpenInApplicationId: string | null
+  setRecentOpenInApplicationId: (id: string | null) => void
 }
 
 export type UISlicePersistence = {

--- a/src/renderer/src/store/slices/ui/ui-slice-surface-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-surface-actions.ts
@@ -164,6 +164,8 @@ export function createUiSurfaceActions(set: UISliceSet, _get: UISliceGet): Parti
     clearPendingRevealWorktreeId: () => set({ pendingRevealWorktree: null }),
     clearPendingRevealSidebarRow: () => set({ pendingRevealSidebarRow: null }),
     scrollToDiffCommentId: null,
-    setScrollToDiffCommentId: (id) => set({ scrollToDiffCommentId: id })
+    setScrollToDiffCommentId: (id) => set({ scrollToDiffCommentId: id }),
+    recentOpenInApplicationId: null,
+    setRecentOpenInApplicationId: (id) => set({ recentOpenInApplicationId: id })
   }
 }


### PR DESCRIPTION
## ELI5

The pane's tab strip gets a second button next to "Command". One click opens the current workspace in one of the apps you set up under Settings > Open In Apps (VS Code, Cursor, Zed, and so on). The dropdown lists all of them.

## What Changed

- New `TabBarOpenInAppsButton` in the focused pane's tab strip, left of the quick command button, with the same split-button chrome. The left half shows the app's icon and name and launches it. The chevron lists every configured app plus "Customize apps...".
- The left half launches the app you used last this session, or the first configured one before that. On an SSH workspace it picks an app that can open the workspace there (today only VS Code can), so the button still works when your usual app is local only.
- With no apps configured it shows a single "Open in" button that jumps to the Open In Apps setting, like the quick command button's empty state.
- The split-button classes move into `tab-bar-split-button-chrome.ts`, shared by both buttons, and get a disabled state.
- `WorktreeOpenInMenuItems` takes `includeFileManager` and `onOpenEntry` props, so the dropdown reuses the existing menu items and their "Local only" / "Remote SSH" hints.
- The gap in the pane-action cluster grows from 2px to 6px, so two bordered split buttons no longer look like one segmented control.
- Adds a transient `recentOpenInApplicationId` to the ui slice and four keys to `en.json`.

## Why

Opening the workspace in an editor is a frequent action, and right now it sits two levels deep in the workspace card's context menu or the explorer's "..." menu. The tab strip already has a launcher-shaped split button for quick commands. Putting the app launcher next to it, in the same shape, makes it one click without adding a new kind of control to the strip.

## Linked Issue

Fixes #18189

## Visual Proof

Before and after of the focused pane's tab strip, with a saved quick command so both buttons are in their bordered state:

| Before | After |
| --- | --- |
| ![open-in-before.png](https://github.com/user-attachments/assets/a2211663-00e3-479f-aa28-11f1f41b7992) | ![open-in-after.png](https://github.com/user-attachments/assets/69b80f61-74b9-42fe-a7d8-9eced5a8e6db) |

## Testing

- `pnpm tc:web`, `pnpm run check:code-quality:changed`, `pnpm verify:localization-catalog`
- `pnpm test` for the tab-bar, tab-group, sidebar open-in menu, and ui slice suites. Eight new tests cover the floating-terminal hide, launch and recency, dropdown listing and selection, the SSH fallback, the all-unavailable disabled state, the empty state, and the entry list without the file manager.
- Rendered check through the Playwright e2e Electron build on macOS: placement, dropdown content, tooltip, disabled state, spacing.
- Tested on macOS. There is no platform-specific code. Unit tests cover the SSH path (VS Code allowed, other apps "Local only").

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Fable 5.1). I reviewed and verified the result.

## Review

- Cross-platform: no platform branches. Labels, paths, and launching go through existing helpers.
- SSH / remote / local: availability uses `getOpenInEntryAvailability`, the same check as the sidebar menu. Paired remote runtimes disable every entry, as before.
- Agents and integrations: untouched.
- Performance: one memoized `findWorktreeById` lookup per focused strip. The icon is the same favicon `<img>` the menus already render.
- UI: both split buttons share one set of class constants, so they cannot drift. The 6px gap follows the styleguide's "keep toolbar groups visually distinct".
- Security: no new IPC or user input. Launches reuse `openWorktreePath`.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Folder workspaces get the button too. Floating terminals hide it because they have no workspace path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYfus31rCKUck9GwSXibNj
