### PR TITLE
fix(codex): serialize session restart after PTY shutdown

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-transport-detach-attach-handoff.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-detach-attach-handoff.test.ts
@@ -84,6 +84,49 @@ describe('createIpcPtyTransport', () => {
     expect(collectRendererMemoryProfileCounts()['ptySideEffects.processors']).toBe(0)
   })
 
+  it('settles destroy only after the PTY shutdown completes', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const kill = window.api.pty.kill as unknown as ReturnType<typeof vi.fn>
+    let finishKill!: () => void
+    const killFinished = new Promise<void>((resolve) => {
+      finishKill = resolve
+    })
+    kill.mockReturnValueOnce(killFinished)
+    const transport = createIpcPtyTransport({})
+    await transport.connect({ url: '', callbacks: {} })
+
+    const destroyed = transport.destroy?.()
+    let settled = false
+    void Promise.resolve(destroyed).then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+
+    expect(settled).toBe(false)
+    expect(kill).toHaveBeenCalledOnce()
+    finishKill()
+    await destroyed
+    expect(settled).toBe(true)
+  })
+
+  it('retains a failed shutdown identity so destroy can retry it', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const kill = window.api.pty.kill as unknown as ReturnType<typeof vi.fn>
+    kill.mockRejectedValueOnce(new Error('provider unavailable')).mockResolvedValueOnce(undefined)
+    const transport = createIpcPtyTransport({})
+    await transport.connect({ url: '', callbacks: {} })
+    const ptyId = transport.getPtyId()
+
+    await expect(transport.destroy?.()).rejects.toThrow('provider unavailable')
+    expect(transport.getPtyId()).toBeNull()
+    expect(transport.getPendingShutdownPtyId?.()).toBe(ptyId)
+
+    await transport.destroy?.()
+    expect(kill).toHaveBeenCalledTimes(2)
+    expect(kill).toHaveBeenLastCalledWith(ptyId)
+    expect(transport.getPendingShutdownPtyId?.()).toBeNull()
+  })
+
   it('keeps the live handler when detach() runs after a newer transport attached to the same PTY', async () => {
     // Why: a new pane can attach the same ptyId before the old detaches; unconditional unregister deletes the live handler (frozen-pane bug).
     const { createIpcPtyTransport } = await import('./pty-transport')

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -171,7 +171,7 @@ export type PtyTransport = {
     isAlternateScreen?: boolean
     callbacks: PtyCallbacks
   }) => void
-  disconnect: () => void
+  disconnect: () => void | Promise<void>
   sendInput: (data: string) => boolean
   // Why: latency-critical terminal query replies (CPR/DSR/DA/OSC color/pixel
   // size) must skip input coalescing — a querying program reads them in raw
@@ -204,6 +204,8 @@ export type PtyTransport = {
   /** The user dismissed the error surface; the next occurrence of the same message must surface again. */
   notifyErrorSurfaceDismissed?: () => void
   getPtyId: () => string | null
+  /** Retained owner identity when shutdown failed and can be retried. */
+  getPendingShutdownPtyId?: () => string | null
   getConnectionId?: () => string | null | undefined
   /** The runtime captured by this transport; legacy remote PTY ids do not
    * encode their owner, and current worktree settings may have changed. */

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -45,6 +45,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   let connected = false
   let destroyed = false
   let ptyId: string | null = null
+  let pendingShutdownPtyId: string | null = null
   let lifecycleGeneration = 0
   let lastExitGeneration: number | null = null
   let suppressAttentionEvents = false
@@ -179,18 +180,36 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     disconnect() {
       advancePtyLifecycle()
       preconnectInputBuffer?.clear()
-      const id = ptyId
+      const disconnectsLivePty = ptyId !== null
+      const id = ptyId ?? pendingShutdownPtyId
       connected = false
       ptyId = null
       handlers.clearAccumulatedState()
       if (id) {
         try {
-          window.api.pty.kill(id)
+          const killPromise = Promise.resolve(window.api.pty.kill(id))
+          return killPromise.then(
+            () => {
+              if (pendingShutdownPtyId === id) {
+                pendingShutdownPtyId = null
+              }
+            },
+            (error: unknown) => {
+              pendingShutdownPtyId = id
+              throw error
+            }
+          )
+        } catch (error) {
+          pendingShutdownPtyId = id
+          throw error
         } finally {
-          handlers.unregisterAll(id)
-          storedCallbacks.onDisconnect?.()
+          if (disconnectsLivePty) {
+            handlers.unregisterAll(id)
+            storedCallbacks.onDisconnect?.()
+          }
         }
       }
+      return undefined
     },
 
     detach(options) {
@@ -261,6 +280,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
 
     isConnected: () => connected,
     getPtyId: () => ptyId,
+    getPendingShutdownPtyId: () => pendingShutdownPtyId,
     getConnectionId: () => connectionId ?? null,
     getLocalSessionMetadata: () =>
       connectionId
@@ -271,7 +291,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     destroy() {
       destroyed = true
       try {
-        this.disconnect()
+        return this.disconnect()
       } finally {
         outputProcessor.disposePendingSideEffectGauge()
       }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-codex-restart-order.test.tsx
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-codex-restart-order.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '../../store'
+
+const { connectPanePty } = vi.hoisted(() => ({
+  connectPanePty: vi.fn(() => ({ dispose: vi.fn() }))
+}))
+
+vi.mock('./pty-connection', () => ({ connectPanePty }))
+
+import { useTerminalPaneProcessExitActions } from './use-terminal-pane-process-exit-actions'
+
+function deferred(): {
+  promise: Promise<void>
+  reject: (error: Error) => void
+  resolve: () => void
+} {
+  let reject!: (error: Error) => void
+  let resolve!: () => void
+  const promise = new Promise<void>((settle, fail) => {
+    resolve = settle
+    reject = fail
+  })
+  return { promise, reject, resolve }
+}
+
+function renderRestartHarness(destroy: () => void | Promise<void>) {
+  const pane = {
+    id: 1,
+    leafId: '11111111-1111-4111-8111-111111111111',
+    container: document.createElement('div')
+  }
+  const manager = {
+    getPanes: () => [pane],
+    setActivePane: vi.fn()
+  }
+  let shutdownStarted = false
+  const oldTransport = {
+    getPtyId: () => (shutdownStarted ? null : 'pty-old'),
+    getPendingShutdownPtyId: () => (shutdownStarted ? 'pty-old' : null),
+    destroy: vi.fn(() => {
+      shutdownStarted = true
+      return destroy()
+    })
+  }
+  const paneTransports = new Map<
+    number,
+    typeof oldTransport | { getPtyId: () => string; getPendingShutdownPtyId?: () => null }
+  >([[pane.id, oldTransport]])
+  const clearExitedPanePtyLayoutBinding = vi.fn()
+  const clearExitedPanePtyLayoutBindingForLeaf = vi.fn()
+  const clearCodexRestartNotice = vi.fn()
+  const clearTabPtyId = vi.fn()
+  const syncPanePtyLayoutBinding = vi.fn()
+
+  const { rerender } = renderHook(() =>
+    useTerminalPaneProcessExitActions({
+      clearCodexRestartNotice,
+      clearExitedPanePtyLayoutBinding,
+      clearExitedPanePtyLayoutBindingForLeaf,
+      clearRuntimePaneTitle: vi.fn(),
+      clearTabPtyId,
+      clearTerminalPaneUnread: vi.fn(),
+      clearTerminalTabUnread: vi.fn(),
+      clearWorktreeUnread: vi.fn(),
+      consumePendingCodexPaneRestart: vi.fn(() => true),
+      cwd: 'C:\\repo',
+      dispatchNotification: vi.fn(),
+      executeClosePane: vi.fn(),
+      handlePaneProcessDied: vi.fn(),
+      isActiveRef: { current: true },
+      isVisibleRef: { current: true },
+      managerRef: { current: manager },
+      markTerminalPaneUnread: vi.fn(),
+      markTerminalTabUnread: vi.fn(),
+      markWorktreeUnread: vi.fn(),
+      onAgentExitedRef: { current: null },
+      onPtyErrorClearedRef: { current: null },
+      onPtyErrorRef: { current: null },
+      onPtyExitRef: { current: null },
+      onPtyRecoveryStateRef: { current: null },
+      paneKittyKeyboardModesRef: { current: new Map() },
+      paneLastThemeModeRef: { current: new Map() },
+      paneMode2031Ref: { current: new Map() },
+      panePtyBindingsRef: { current: new Map() },
+      paneTransportsRef: { current: paneTransports },
+      pendingCodexPaneRestartIds: { 'pty-old': true },
+      replayingPanesRef: { current: new Set() },
+      savedLayout: { ptyIdsByLeafId: { [pane.leafId]: 'pty-old' } },
+      setCacheTimerStartedAt: vi.fn(),
+      setPaneProcessExitsByPaneId: vi.fn(),
+      setRuntimePaneTitle: vi.fn(),
+      setTerminalError: vi.fn(),
+      setTerminalErrorsByPaneId: vi.fn(),
+      showRestoredSessionBanner: vi.fn(),
+      suppressPtyExit: vi.fn(),
+      syncPanePtyLayoutBinding,
+      tabId: 'tab-1',
+      updateTabPtyId: vi.fn(),
+      updateTabTitle: vi.fn(),
+      worktreeId: 'worktree-1'
+    } as never)
+  )
+
+  return {
+    clearCodexRestartNotice,
+    clearExitedPanePtyLayoutBinding,
+    clearExitedPanePtyLayoutBindingForLeaf,
+    clearTabPtyId,
+    oldTransport,
+    pane,
+    paneTransports,
+    rerender,
+    syncPanePtyLayoutBinding
+  }
+}
+
+describe('mounted Codex account restart ordering', () => {
+  beforeEach(() => {
+    connectPanePty.mockClear()
+  })
+
+  it('waits for the outdated PTY to stop before launching its replacement', async () => {
+    const stopped = deferred()
+    const harness = renderRestartHarness(() => stopped.promise)
+
+    await waitFor(() => expect(harness.oldTransport.destroy).toHaveBeenCalledOnce())
+    expect(connectPanePty).not.toHaveBeenCalled()
+    harness.rerender()
+    await Promise.resolve()
+    expect(harness.oldTransport.destroy).toHaveBeenCalledOnce()
+
+    stopped.resolve()
+    await waitFor(() => expect(connectPanePty).toHaveBeenCalledOnce())
+    expect(harness.clearExitedPanePtyLayoutBindingForLeaf).toHaveBeenCalledWith(
+      harness.pane.leafId,
+      'pty-old'
+    )
+    expect(harness.clearExitedPanePtyLayoutBinding).not.toHaveBeenCalled()
+    expect(harness.syncPanePtyLayoutBinding).not.toHaveBeenCalled()
+  })
+
+  it('does not clear or replace a newer transport that wins during shutdown', async () => {
+    const stopped = deferred()
+    const harness = renderRestartHarness(() => stopped.promise)
+    await waitFor(() => expect(harness.oldTransport.destroy).toHaveBeenCalledOnce())
+    const replacementTransport = { getPtyId: () => 'pty-new' }
+    harness.paneTransports.set(harness.pane.id, replacementTransport)
+
+    stopped.resolve()
+
+    await waitFor(() =>
+      expect(harness.clearExitedPanePtyLayoutBindingForLeaf).toHaveBeenCalledWith(
+        harness.pane.leafId,
+        'pty-old'
+      )
+    )
+    expect(harness.paneTransports.get(harness.pane.id)).toBe(replacementTransport)
+    expect(harness.syncPanePtyLayoutBinding).not.toHaveBeenCalled()
+    expect(connectPanePty).not.toHaveBeenCalled()
+  })
+
+  it('reopens the prompt when the outdated PTY cannot be stopped', async () => {
+    const stopped = deferred()
+    let shutdownAttempts = 0
+    const reopenCodexRestartPrompt = vi
+      .spyOn(useAppStore.getState(), 'reopenCodexRestartPrompt')
+      .mockImplementation(() => {})
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const harness = renderRestartHarness(() => {
+      shutdownAttempts += 1
+      return shutdownAttempts === 1 ? stopped.promise : Promise.resolve()
+    })
+    await waitFor(() => expect(harness.oldTransport.destroy).toHaveBeenCalledOnce())
+
+    stopped.reject(new Error('shutdown failed'))
+
+    await waitFor(() => expect(reopenCodexRestartPrompt).toHaveBeenCalledWith('pty-old'))
+    expect(harness.clearCodexRestartNotice).not.toHaveBeenCalled()
+    expect(harness.clearTabPtyId).not.toHaveBeenCalled()
+    expect(harness.clearExitedPanePtyLayoutBindingForLeaf).not.toHaveBeenCalled()
+    expect(connectPanePty).not.toHaveBeenCalled()
+
+    harness.rerender()
+    await waitFor(() => expect(harness.oldTransport.destroy).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(connectPanePty).toHaveBeenCalledOnce())
+    warn.mockRestore()
+    reopenCodexRestartPrompt.mockRestore()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-process-exit-actions.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-process-exit-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 import { useAppStore } from '../../store'
 import { CODEX_ACCOUNT_RESTART_STARTUP } from '@/lib/codex-session-restart'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
@@ -14,6 +14,7 @@ export function useTerminalPaneProcessExitActions(controller: TerminalPaneCloseC
   const {
     clearCodexRestartNotice,
     clearExitedPanePtyLayoutBinding,
+    clearExitedPanePtyLayoutBindingForLeaf,
     clearRuntimePaneTitle,
     clearTabPtyId,
     clearTerminalPaneUnread,
@@ -56,12 +57,13 @@ export function useTerminalPaneProcessExitActions(controller: TerminalPaneCloseC
     updateTabTitle,
     worktreeId
   } = controller
+  const codexPaneRestartsRef = useRef(new Map<number, Promise<void>>())
 
-  const handleRestartCodexPane = useCallback(
-    (
+  const runRestartCodexPane = useCallback(
+    async (
       paneId: number,
       restartStartup: PtyConnectionDeps['startup'] = CODEX_ACCOUNT_RESTART_STARTUP
-    ) => {
+    ): Promise<void> => {
       const manager = managerRef.current
       const pane = manager?.getPanes().find((candidate) => candidate.id === paneId)
       if (!manager || !pane) {
@@ -69,17 +71,42 @@ export function useTerminalPaneProcessExitActions(controller: TerminalPaneCloseC
       }
       const transport = paneTransportsRef.current.get(paneId)
       const panePtyBinding = panePtyBindingsRef.current.get(paneId)
-      const existingPtyId = transport?.getPtyId()
+      const existingPtyId = transport?.getPtyId() ?? transport?.getPendingShutdownPtyId?.()
       if (existingPtyId) {
         suppressPtyExit(existingPtyId)
-        clearCodexRestartNotice(existingPtyId)
-        clearTabPtyId(tabId, existingPtyId)
       }
       panePtyBinding?.dispose()
       panePtyBindingsRef.current.delete(paneId)
-      syncPanePtyLayoutBinding(paneId, null)
-      transport?.destroy?.()
-      paneTransportsRef.current.delete(paneId)
+      try {
+        await transport?.destroy?.()
+      } catch (error) {
+        if (existingPtyId) {
+          useAppStore.getState().reopenCodexRestartPrompt(existingPtyId)
+        }
+        console.warn('[codex-restart] mounted pane shutdown failed:', error)
+        return
+      }
+      if (existingPtyId) {
+        clearCodexRestartNotice(existingPtyId)
+        clearTabPtyId(tabId, existingPtyId)
+        if (clearExitedPanePtyLayoutBindingForLeaf) {
+          clearExitedPanePtyLayoutBindingForLeaf(pane.leafId, existingPtyId)
+        } else {
+          clearExitedPanePtyLayoutBinding(paneId, existingPtyId)
+        }
+      } else {
+        syncPanePtyLayoutBinding(paneId, null)
+      }
+      if (paneTransportsRef.current.get(paneId) === transport) {
+        paneTransportsRef.current.delete(paneId)
+      }
+      if (
+        managerRef.current !== manager ||
+        paneTransportsRef.current.has(paneId) ||
+        !manager.getPanes().some((candidate) => candidate.id === paneId)
+      ) {
+        return
+      }
       setCacheTimerStartedAt(makePaneKey(tabId, pane.leafId), null)
       setTerminalError(null)
       setTerminalErrorsByPaneId((current) => clearPaneTerminalError(current, paneId))
@@ -128,6 +155,7 @@ export function useTerminalPaneProcessExitActions(controller: TerminalPaneCloseC
     [
       clearCodexRestartNotice,
       clearExitedPanePtyLayoutBinding,
+      clearExitedPanePtyLayoutBindingForLeaf,
       clearRuntimePaneTitle,
       clearTabPtyId,
       clearTerminalPaneUnread,
@@ -166,6 +194,34 @@ export function useTerminalPaneProcessExitActions(controller: TerminalPaneCloseC
     ]
   )
 
+  const handleRestartCodexPane = useCallback(
+    (
+      paneId: number,
+      restartStartup: PtyConnectionDeps['startup'] = CODEX_ACCOUNT_RESTART_STARTUP
+    ): Promise<void> => {
+      const pendingRestart = codexPaneRestartsRef.current.get(paneId)
+      if (pendingRestart) {
+        return pendingRestart
+      }
+      const restart = runRestartCodexPane(paneId, restartStartup)
+      codexPaneRestartsRef.current.set(paneId, restart)
+      void restart.then(
+        () => {
+          if (codexPaneRestartsRef.current.get(paneId) === restart) {
+            codexPaneRestartsRef.current.delete(paneId)
+          }
+        },
+        () => {
+          if (codexPaneRestartsRef.current.get(paneId) === restart) {
+            codexPaneRestartsRef.current.delete(paneId)
+          }
+        }
+      )
+      return restart
+    },
+    [runRestartCodexPane]
+  )
+
   const clearPaneProcessExit = useCallback(
     (paneId: number) => {
       setPaneProcessExitsByPaneId((current) => {
@@ -183,7 +239,7 @@ export function useTerminalPaneProcessExitActions(controller: TerminalPaneCloseC
   const handleRestartExitedPane = useCallback(
     (processExit: PaneProcessExit) => {
       clearPaneProcessExit(processExit.paneId)
-      handleRestartCodexPane(
+      void handleRestartCodexPane(
         processExit.paneId,
         resolveTerminalProcessExitRestartStartup(processExit)
       )
@@ -232,12 +288,13 @@ export function useTerminalPaneProcessExitActions(controller: TerminalPaneCloseC
       return
     }
     for (const pane of manager.getPanes()) {
-      const ptyId = paneTransportsRef.current.get(pane.id)?.getPtyId()
+      const transport = paneTransportsRef.current.get(pane.id)
+      const ptyId = transport?.getPtyId() ?? transport?.getPendingShutdownPtyId?.()
       if (!ptyId || !pendingCodexPaneRestartIds[ptyId]) {
         continue
       }
       if (consumePendingCodexPaneRestart(ptyId)) {
-        handleRestartCodexPane(pane.id)
+        void handleRestartCodexPane(pane.id)
       }
     }
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- Preserve the pre-split dependency contract.


### PR DESCRIPTION
## ELI5

Restart now waits for the old Codex terminal process to finish shutting down before Orca starts its replacement. This prevents the replacement from accidentally reconnecting to the same outdated process and showing the setup-change dialog again.

## What Changed

- Make local PTY transport shutdown awaitable and retain the PTY identity when shutdown fails so a retry can target the same process.
- Serialize the full mounted-pane restart transaction, clear only the captured old layout binding, and recheck pane ownership before reconnecting.
- Reopen the restart prompt after a failed shutdown instead of clearing state as though the restart succeeded.
- Add regression coverage for shutdown ordering, concurrent ownership changes, duplicate restart suppression, and failed-shutdown retries.

## Why

Mounted Codex restarts previously launched the replacement immediately after requesting shutdown of the old PTY. Because shutdown is asynchronous, the replacement could reclaim the stable pane while the old PTY was still available, reattach the stale session, and trigger the same setup-change notice again.

## Linked Issue

Fixes #18174

## Visual Proof

N/A. This changes PTY lifecycle ordering and failure recovery; it does not change dialog layout or styling.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated on Windows:

- 7 focused Vitest files: 124 tests passed
- Renderer typecheck: `tsc --noEmit -p config/tsconfig.tc.web.json`
- Targeted `oxlint` and React Doctor lint passed on all 5 changed files
- `oxfmt --write` completed with no remaining changes
- Electron Vite production build passed (existing CSS highlight and chunk-size warnings only)
- `git diff upstream/main...HEAD --check` passed

Full cross-platform coverage is left to CI. The behavior is transport-agnostic and preserves the existing SSH/remote transport contract; only the local IPC transport exposes the optional failed-shutdown identity.

## AI Disclosure

OpenAI Codex was used to diagnose, implement, review, and verify this change.

## Review

Pre-landing and adversarial review found no concrete issues. The main residual test limitation is that the failure retry is triggered through a hook rerender rather than a literal dialog click; the store prompt lifecycle is covered separately.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: no new trust boundary or external input handling.
- Cross-platform: no platform-specific commands, paths, or shortcuts added.
- Remote SSH: no remote wire or execution-host contract changes.
- Mobile: no mobile code paths changed.
- Backwards compatibility: the new transport method is optional and the disconnect return type still accepts synchronous implementations.
- Performance: restart work is serialized per pane only while shutdown is in flight.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
