### PR TITLE
fix(agent-prompt): hold the ingest floor on the render-gate submit path

### DIFF
--- a/src/main/runtime/agent-prompt-paste-echo.test.ts
+++ b/src/main/runtime/agent-prompt-paste-echo.test.ts
@@ -6,7 +6,8 @@ import {
   deriveAgentPromptPasteEchoProbe,
   getAgentPromptPasteEchoTimeoutMs,
   isAgentPromptPasteEchoObserved,
-  isAgentPromptPasteEchoPlaceholderObserved
+  isAgentPromptPasteEchoPlaceholderObserved,
+  pastePayloadContainsPlaceholderFragment
 } from './agent-prompt-paste-echo'
 
 describe('deriveAgentPromptPasteEchoProbe', () => {
@@ -64,6 +65,20 @@ describe('isAgentPromptPasteEchoObserved', () => {
   it('matches other collapsed-paste placeholder variants in post-write output', () => {
     expect(isAgentPromptPasteEchoPlaceholderObserved('[Pasted Content 40 lines]')).toBe(true)
     expect(isAgentPromptPasteEchoPlaceholderObserved('Pasted content added')).toBe(true)
+  })
+
+  it('identifies a placeholder fragment supplied by the paste payload', () => {
+    expect(
+      pastePayloadContainsPlaceholderFragment(
+        buildAgentPromptPasteBytes('leading text [Pasted text #1 +40 lines] before the tail')
+      )
+    ).toBe(true)
+  })
+
+  it('does not identify a placeholder fragment in an ordinary paste payload', () => {
+    expect(pastePayloadContainsPlaceholderFragment(buildAgentPromptPasteBytes('ordinary prompt'))).toBe(
+      false
+    )
   })
 })
 

--- a/src/main/runtime/agent-prompt-paste-echo.test.ts
+++ b/src/main/runtime/agent-prompt-paste-echo.test.ts
@@ -5,7 +5,8 @@ import {
   AGENT_PROMPT_ECHO_TIMEOUT_MS_WIN32,
   deriveAgentPromptPasteEchoProbe,
   getAgentPromptPasteEchoTimeoutMs,
-  isAgentPromptPasteEchoObserved
+  isAgentPromptPasteEchoObserved,
+  isAgentPromptPasteEchoPlaceholderObserved
 } from './agent-prompt-paste-echo'
 
 describe('deriveAgentPromptPasteEchoProbe', () => {
@@ -49,16 +50,20 @@ describe('isAgentPromptPasteEchoObserved', () => {
     expect(isAgentPromptPasteEchoObserved('composer is empty', probe)).toBe(false)
   })
 
-  it('treats "[Pasted text #1 +N lines]" as observed', () => {
-    expect(isAgentPromptPasteEchoObserved('[Pasted text #1 +40 lines]', probe)).toBe(true)
+  it('does not treat a prompt-supplied placeholder as a tail echo', () => {
+    const prompt = `[Pasted text #1 +40 lines]\n${'z'.repeat(40)}`
+    const promptProbe = deriveAgentPromptPasteEchoProbe(buildAgentPromptPasteBytes(prompt))!
+
+    expect(isAgentPromptPasteEchoObserved('[Pasted text #1 +40 lines]', promptProbe)).toBe(false)
   })
 
-  it('treats "[Pasted Content]" style placeholders as observed', () => {
-    expect(isAgentPromptPasteEchoObserved('[Pasted Content 40 lines]', probe)).toBe(true)
+  it('matches a collapsed-paste placeholder in output known to follow the write', () => {
+    expect(isAgentPromptPasteEchoPlaceholderObserved('[Pasted text #1 +40 lines]')).toBe(true)
   })
 
-  it('treats a lowercase "Pasted content" fragment as observed', () => {
-    expect(isAgentPromptPasteEchoObserved('Pasted content added', probe)).toBe(true)
+  it('matches other collapsed-paste placeholder variants in post-write output', () => {
+    expect(isAgentPromptPasteEchoPlaceholderObserved('[Pasted Content 40 lines]')).toBe(true)
+    expect(isAgentPromptPasteEchoPlaceholderObserved('Pasted content added')).toBe(true)
   })
 })
 

--- a/src/main/runtime/agent-prompt-paste-echo.test.ts
+++ b/src/main/runtime/agent-prompt-paste-echo.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { buildAgentPromptPasteBytes } from '../../shared/agent-prompt-injection'
+import {
+  AGENT_PROMPT_ECHO_TIMEOUT_MS_DEFAULT,
+  AGENT_PROMPT_ECHO_TIMEOUT_MS_WIN32,
+  deriveAgentPromptPasteEchoProbe,
+  getAgentPromptPasteEchoTimeoutMs,
+  isAgentPromptPasteEchoObserved
+} from './agent-prompt-paste-echo'
+
+describe('deriveAgentPromptPasteEchoProbe', () => {
+  it('strips the bracketed-paste markers and whitespace, then takes the last 24 chars', () => {
+    const prompt = `line one\nline two\n${'z'.repeat(40)}`
+    const probe = deriveAgentPromptPasteEchoProbe(buildAgentPromptPasteBytes(prompt))
+    expect(probe).toBe('z'.repeat(24))
+  })
+
+  it('collapses interior whitespace before taking the tail', () => {
+    const prompt = 'a b c d e f g h i j k l m n o p q r s t u v w x y z'
+    const probe = deriveAgentPromptPasteEchoProbe(buildAgentPromptPasteBytes(prompt))
+    // Why: whitespace is removed entirely, not just trimmed, before the 24-char tail is taken.
+    expect(probe).toBe(stripWhitespace(prompt).slice(-24))
+  })
+
+  it('returns null (skip echo wait) when the inner text has fewer than 8 non-whitespace chars', () => {
+    const probe = deriveAgentPromptPasteEchoProbe(buildAgentPromptPasteBytes('short'))
+    expect(probe).toBeNull()
+  })
+
+  it('keeps a prompt with exactly 8 non-whitespace chars', () => {
+    const probe = deriveAgentPromptPasteEchoProbe(buildAgentPromptPasteBytes('12345678'))
+    expect(probe).toBe('12345678')
+  })
+})
+
+describe('isAgentPromptPasteEchoObserved', () => {
+  const probe = deriveAgentPromptPasteEchoProbe(buildAgentPromptPasteBytes('y'.repeat(40)))!
+
+  it('matches when the pane text contains the probe tail', () => {
+    expect(isAgentPromptPasteEchoObserved(`composer> ${'y'.repeat(40)}`, probe)).toBe(true)
+  })
+
+  it('matches the probe even when the pane wraps it across whitespace/newlines', () => {
+    const wrapped = `composer> ${'y'.repeat(20)}\n  ${'y'.repeat(20)}`
+    expect(isAgentPromptPasteEchoObserved(wrapped, probe)).toBe(true)
+  })
+
+  it('does not match unrelated pane text', () => {
+    expect(isAgentPromptPasteEchoObserved('composer is empty', probe)).toBe(false)
+  })
+
+  it('treats "[Pasted text #1 +N lines]" as observed', () => {
+    expect(isAgentPromptPasteEchoObserved('[Pasted text #1 +40 lines]', probe)).toBe(true)
+  })
+
+  it('treats "[Pasted Content]" style placeholders as observed', () => {
+    expect(isAgentPromptPasteEchoObserved('[Pasted Content 40 lines]', probe)).toBe(true)
+  })
+
+  it('treats a lowercase "Pasted content" fragment as observed', () => {
+    expect(isAgentPromptPasteEchoObserved('Pasted content added', probe)).toBe(true)
+  })
+})
+
+describe('getAgentPromptPasteEchoTimeoutMs', () => {
+  it('uses the longer timeout on win32', () => {
+    expect(getAgentPromptPasteEchoTimeoutMs('win32')).toBe(AGENT_PROMPT_ECHO_TIMEOUT_MS_WIN32)
+  })
+
+  it('uses the shorter timeout on other platforms', () => {
+    expect(getAgentPromptPasteEchoTimeoutMs('darwin')).toBe(AGENT_PROMPT_ECHO_TIMEOUT_MS_DEFAULT)
+    expect(getAgentPromptPasteEchoTimeoutMs('linux')).toBe(AGENT_PROMPT_ECHO_TIMEOUT_MS_DEFAULT)
+  })
+})
+
+function stripWhitespace(text: string): string {
+  return text.replace(/\s+/g, '')
+}

--- a/src/main/runtime/agent-prompt-paste-echo.ts
+++ b/src/main/runtime/agent-prompt-paste-echo.ts
@@ -49,12 +49,14 @@ export function deriveAgentPromptPasteEchoProbe(pastePayload: string): string | 
   return normalized.slice(-AGENT_PROMPT_ECHO_PROBE_LENGTH)
 }
 
-/** True once the pane text demonstrably reflects the paste: either the literal tail (normal
- *  echo) or a composer placeholder like "[Pasted text #1 +N lines]" (collapsed echo). */
+/** True once post-paste terminal output contains the literal tail of the pasted text. */
 export function isAgentPromptPasteEchoObserved(paneText: string, probe: string): boolean {
   const normalized = stripAllWhitespace(paneText)
-  if (normalized.includes(probe)) {
-    return true
-  }
+  return normalized.includes(probe)
+}
+
+/** Collapsed-paste markers are only evidence when their input is scoped to post-paste output. */
+export function isAgentPromptPasteEchoPlaceholderObserved(postPasteOutput: string): boolean {
+  const normalized = stripAllWhitespace(postPasteOutput)
   return AGENT_PROMPT_PASTE_PLACEHOLDER_FRAGMENTS.some((fragment) => normalized.includes(fragment))
 }

--- a/src/main/runtime/agent-prompt-paste-echo.ts
+++ b/src/main/runtime/agent-prompt-paste-echo.ts
@@ -60,3 +60,9 @@ export function isAgentPromptPasteEchoPlaceholderObserved(postPasteOutput: strin
   const normalized = stripAllWhitespace(postPasteOutput)
   return AGENT_PROMPT_PASTE_PLACEHOLDER_FRAGMENTS.some((fragment) => normalized.includes(fragment))
 }
+
+/** A payload that contains a placeholder can echo it before its tail is fully ingested. */
+export function pastePayloadContainsPlaceholderFragment(pastePayload: string): boolean {
+  const normalized = stripAllWhitespace(pastePayload)
+  return AGENT_PROMPT_PASTE_PLACEHOLDER_FRAGMENTS.some((fragment) => normalized.includes(fragment))
+}

--- a/src/main/runtime/agent-prompt-paste-echo.ts
+++ b/src/main/runtime/agent-prompt-paste-echo.ts
@@ -1,0 +1,60 @@
+import {
+  AGENT_PROMPT_BRACKETED_PASTE_END,
+  AGENT_PROMPT_BRACKETED_PASTE_START
+} from '../../shared/agent-prompt-injection'
+
+// Why: Windows TUIs (Codex) redraw their composer per keystroke while ingesting a bracketed
+// paste, which can outlast the render gate's hard cap on large prompts. Waiting for the pane
+// to actually echo the paste tail (or collapse to a placeholder) before Enter closes that gap
+// without changing behavior on hosts/agents that already settle inside the gate.
+export const AGENT_PROMPT_ECHO_TIMEOUT_MS_WIN32 = 20_000
+export const AGENT_PROMPT_ECHO_TIMEOUT_MS_DEFAULT = 3_000
+export const AGENT_PROMPT_ECHO_POLL_INTERVAL_MS = 100
+export const AGENT_PROMPT_ECHO_SETTLE_MS = 250
+
+const AGENT_PROMPT_ECHO_PROBE_LENGTH = 24
+const AGENT_PROMPT_ECHO_MIN_INNER_LENGTH = 8
+
+// Why: a composer that already collapsed the paste won't repeat the tail text verbatim.
+const AGENT_PROMPT_PASTE_PLACEHOLDER_FRAGMENTS = [
+  '[Pastedtext',
+  '[PastedContent',
+  'Pastedcontent'
+] as const
+
+function stripAllWhitespace(text: string): string {
+  return text.replace(/\s+/g, '')
+}
+
+export function getAgentPromptPasteEchoTimeoutMs(platform: NodeJS.Platform): number {
+  return platform === 'win32'
+    ? AGENT_PROMPT_ECHO_TIMEOUT_MS_WIN32
+    : AGENT_PROMPT_ECHO_TIMEOUT_MS_DEFAULT
+}
+
+/** Derives the whitespace-collapsed tail of the pasted text to look for on the pane, or `null`
+ *  when the prompt is too short for a tail match to be a meaningful signal. */
+export function deriveAgentPromptPasteEchoProbe(pastePayload: string): string | null {
+  let inner = pastePayload
+  if (inner.startsWith(AGENT_PROMPT_BRACKETED_PASTE_START)) {
+    inner = inner.slice(AGENT_PROMPT_BRACKETED_PASTE_START.length)
+  }
+  if (inner.endsWith(AGENT_PROMPT_BRACKETED_PASTE_END)) {
+    inner = inner.slice(0, -AGENT_PROMPT_BRACKETED_PASTE_END.length)
+  }
+  const normalized = stripAllWhitespace(inner)
+  if (normalized.length < AGENT_PROMPT_ECHO_MIN_INNER_LENGTH) {
+    return null
+  }
+  return normalized.slice(-AGENT_PROMPT_ECHO_PROBE_LENGTH)
+}
+
+/** True once the pane text demonstrably reflects the paste: either the literal tail (normal
+ *  echo) or a composer placeholder like "[Pasted text #1 +N lines]" (collapsed echo). */
+export function isAgentPromptPasteEchoObserved(paneText: string, probe: string): boolean {
+  const normalized = stripAllWhitespace(paneText)
+  if (normalized.includes(probe)) {
+    return true
+  }
+  return AGENT_PROMPT_PASTE_PLACEHOLDER_FRAGMENTS.some((fragment) => normalized.includes(fragment))
+}

--- a/src/main/runtime/agent-prompt-submission-render-gate-floor.test.ts
+++ b/src/main/runtime/agent-prompt-submission-render-gate-floor.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { buildAgentPromptPasteBytes, getAgentPromptSubmitDelayMs } from '../../shared/agent-prompt-injection'
 import {
+  AGENT_PROMPT_ECHO_POLL_INTERVAL_MS,
   AGENT_PROMPT_ECHO_SETTLE_MS,
   AGENT_PROMPT_ECHO_TIMEOUT_MS_DEFAULT,
   AGENT_PROMPT_ECHO_TIMEOUT_MS_WIN32
@@ -123,6 +124,7 @@ describe('agent prompt render gate ingest floor', () => {
     // Why: the pane already echoed the paste tail well before the floor -- the echo wait only
     // starts once the floor's Promise.all resolves, so it cannot shorten this window, but it
     // does add its settle on top once that point is reached.
+    await vi.advanceTimersByTimeAsync(0)
     runtime.onPtyData(PTY_ID, PROMPT_TAIL_ECHO, Date.now())
 
     // Flush the render gate's already-resolved promise without advancing real time.
@@ -175,6 +177,54 @@ describe('agent prompt render gate ingest floor', () => {
     await stalled
   })
 
+  it('does not accept a probe already present in scrollback before the paste write', async () => {
+    useHostPlatform('win32')
+    vi.useFakeTimers()
+    const { runtime, handle, writes } = await createSettlementRuntimeWithImmediateRenderGate()
+    const floorMs = floorMsFor('win32')
+    runtime.onPtyData(PTY_ID, PROMPT_TAIL_ECHO, Date.now())
+    const submission = runtime.sendTerminalAgentPrompt(handle, PROMPT)
+    const stalled = expect(submission).rejects.toThrow('agent_prompt_stalled')
+
+    await vi.advanceTimersByTimeAsync(floorMs + AGENT_PROMPT_ECHO_SETTLE_MS)
+    expect(countSubmits(writes)).toBe(0)
+
+    runtime.onPtyData(PTY_ID, PROMPT_TAIL_ECHO, Date.now())
+    await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ECHO_POLL_INTERVAL_MS + AGENT_PROMPT_ECHO_SETTLE_MS)
+    expect(countSubmits(writes)).toBe(1)
+
+    await vi.runAllTimersAsync()
+    await stalled
+  })
+
+  it('does not accept the first attempt\'s echo on the first poll after a retry paste', async () => {
+    useHostPlatform('win32')
+    vi.useFakeTimers()
+    const { runtime, handle, writes } = await createSettlementRuntimeWithImmediateRenderGate()
+    const floorMs = floorMsFor('win32')
+    const firstSubmission = runtime.sendTerminalAgentPrompt(handle, PROMPT)
+    const firstStalled = expect(firstSubmission).rejects.toThrow('agent_prompt_stalled')
+
+    await vi.advanceTimersByTimeAsync(0)
+    runtime.onPtyData(PTY_ID, PROMPT_TAIL_ECHO, Date.now())
+    await vi.advanceTimersByTimeAsync(floorMs + AGENT_PROMPT_ECHO_SETTLE_MS)
+    expect(countSubmits(writes)).toBe(1)
+    await vi.runAllTimersAsync()
+    await firstStalled
+
+    const retrySubmission = runtime.sendTerminalAgentPrompt(handle, PROMPT)
+    const retryStalled = expect(retrySubmission).rejects.toThrow('agent_prompt_stalled')
+    await vi.advanceTimersByTimeAsync(floorMs + AGENT_PROMPT_ECHO_POLL_INTERVAL_MS)
+    expect(countSubmits(writes)).toBe(1)
+
+    runtime.onPtyData(PTY_ID, PROMPT_TAIL_ECHO, Date.now())
+    await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ECHO_POLL_INTERVAL_MS + AGENT_PROMPT_ECHO_SETTLE_MS)
+    expect(countSubmits(writes)).toBe(2)
+
+    await vi.runAllTimersAsync()
+    await retryStalled
+  })
+
   it('falls back to writing Enter at the echo deadline when the pane never echoes the paste', async () => {
     useHostPlatform('win32')
     vi.useFakeTimers()
@@ -205,6 +255,7 @@ describe('agent prompt render gate ingest floor', () => {
     const submission = runtime.sendTerminalAgentPrompt(handle, PROMPT)
     const stalled = expect(submission).rejects.toThrow('agent_prompt_stalled')
 
+    await vi.advanceTimersByTimeAsync(0)
     runtime.onPtyData(PTY_ID, '[Pasted text #1 +40 lines]', Date.now())
 
     await vi.advanceTimersByTimeAsync(floorMs + AGENT_PROMPT_ECHO_SETTLE_MS - 1)

--- a/src/main/runtime/agent-prompt-submission-render-gate-floor.test.ts
+++ b/src/main/runtime/agent-prompt-submission-render-gate-floor.test.ts
@@ -1,12 +1,19 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { buildAgentPromptPasteBytes, getAgentPromptSubmitDelayMs } from '../../shared/agent-prompt-injection'
+import {
+  AGENT_PROMPT_ECHO_SETTLE_MS,
+  AGENT_PROMPT_ECHO_TIMEOUT_MS_DEFAULT,
+  AGENT_PROMPT_ECHO_TIMEOUT_MS_WIN32
+} from './agent-prompt-paste-echo'
 import { OrcaRuntimeService } from './orca-runtime'
 import { makeStore } from './runtime-rpc-worktree-store-fixtures'
 
 // Why: this suite isolates the renderGate branch's structural guarantee -- independent of
 // createAgentPromptRenderGate's own settlement heuristic -- that Enter cannot overtake the
 // ingest floor even when the render signal itself fires early (redraw races, a settlement
-// agent that repaints before attaching a completed paste, etc).
+// agent that repaints before attaching a completed paste, etc) -- and the paste-echo wait
+// layered on top of it, which additionally holds Enter until the pane demonstrably consumed
+// the paste (agent_prompt_stalled ticket: Windows Codex composer redraws per keystroke).
 const WORKTREE_PATH = '/tmp/worktree-a'
 const PTY_ID = 'pty-prompt'
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
@@ -83,6 +90,20 @@ async function createSettlementRuntimeWithImmediateRenderGate(): Promise<{
   return { runtime, handle: terminal.handle, writes, submitTimes }
 }
 
+// Why 12 KB: one chunk (so the write loop costs no clock, matching the ticket's observed
+// 10,714/12,773-byte payloads), while still large enough that the ConPTY ingest term is well
+// above the flat 500 ms settle a resolved-immediately gate would otherwise stop at.
+const PROMPT = 'y'.repeat(12_000)
+// Why: matches the 24-char echo probe derived from PROMPT's tail (all 'y's).
+const PROMPT_TAIL_ECHO = 'y'.repeat(24)
+
+function floorMsFor(platform: NodeJS.Platform): number {
+  return getAgentPromptSubmitDelayMs(
+    platform,
+    Buffer.byteLength(buildAgentPromptPasteBytes(PROMPT), 'utf8')
+  )
+}
+
 describe('agent prompt render gate ingest floor', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -90,21 +111,19 @@ describe('agent prompt render gate ingest floor', () => {
     Object.defineProperty(process, 'platform', originalPlatform)
   })
 
-  it('does not write Enter before the ingest floor when the render gate resolves early', async () => {
+  it('does not write Enter before the ingest floor when the render gate resolves early, and holds for the paste-echo settle once it is observed', async () => {
     useHostPlatform('win32')
     vi.useFakeTimers()
     const { runtime, handle, writes, submitTimes } =
       await createSettlementRuntimeWithImmediateRenderGate()
-    // Why 12 KB: one chunk (so the write loop costs no clock, matching the ticket's observed
-    // 10,714/12,773-byte payloads), while still large enough that the ConPTY ingest term is
-    // well above the flat 500 ms settle a resolved-immediately gate would otherwise stop at.
-    const prompt = 'y'.repeat(12_000)
-    const floorMs = getAgentPromptSubmitDelayMs(
-      'win32',
-      Buffer.byteLength(buildAgentPromptPasteBytes(prompt), 'utf8')
-    )
-    const submission = runtime.sendTerminalAgentPrompt(handle, prompt)
+    const floorMs = floorMsFor('win32')
+    const submission = runtime.sendTerminalAgentPrompt(handle, PROMPT)
     const stalled = expect(submission).rejects.toThrow('agent_prompt_stalled')
+
+    // Why: the pane already echoed the paste tail well before the floor -- the echo wait only
+    // starts once the floor's Promise.all resolves, so it cannot shorten this window, but it
+    // does add its settle on top once that point is reached.
+    runtime.onPtyData(PTY_ID, PROMPT_TAIL_ECHO, Date.now())
 
     // Flush the render gate's already-resolved promise without advancing real time.
     await vi.advanceTimersByTimeAsync(0)
@@ -113,12 +132,107 @@ describe('agent prompt render gate ingest floor', () => {
     await vi.advanceTimersByTimeAsync(floorMs - 1)
     expect(countSubmits(writes)).toBe(0)
 
+    // The floor has elapsed; the echo is already visible, but the extra settle has not.
+    await vi.advanceTimersByTimeAsync(1)
+    expect(countSubmits(writes)).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ECHO_SETTLE_MS - 1)
+    expect(countSubmits(writes)).toBe(0)
+
     await vi.advanceTimersByTimeAsync(1)
     expect(countSubmits(writes)).toBe(1)
-    expect(submitTimes[0]).toBeGreaterThanOrEqual(floorMs)
+    expect(submitTimes[0]).toBe(floorMs + AGENT_PROMPT_ECHO_SETTLE_MS)
+
+    await vi.runAllTimersAsync()
+    await stalled
+  })
+
+  it('does not write Enter at the floor when the pane has not echoed the paste, and writes it shortly after a late echo', async () => {
+    useHostPlatform('win32')
+    vi.useFakeTimers()
+    const { runtime, handle, writes, submitTimes } =
+      await createSettlementRuntimeWithImmediateRenderGate()
+    const floorMs = floorMsFor('win32')
+    const submission = runtime.sendTerminalAgentPrompt(handle, PROMPT)
+    const stalled = expect(submission).rejects.toThrow('agent_prompt_stalled')
+
+    // Floor elapses with no echo yet -- Enter must not fire.
+    await vi.advanceTimersByTimeAsync(floorMs + 6_000 - 1)
+    expect(countSubmits(writes)).toBe(0)
+
+    // The echo lands right before the next 100 ms poll tick, at floor + 6_000 ms.
+    runtime.onPtyData(PTY_ID, PROMPT_TAIL_ECHO, Date.now())
+    await vi.advanceTimersByTimeAsync(1)
+    expect(countSubmits(writes)).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ECHO_SETTLE_MS - 1)
+    expect(countSubmits(writes)).toBe(0)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(countSubmits(writes)).toBe(1)
+    expect(submitTimes[0]).toBe(floorMs + 6_000 + AGENT_PROMPT_ECHO_SETTLE_MS)
+
+    await vi.runAllTimersAsync()
+    await stalled
+  })
+
+  it('falls back to writing Enter at the echo deadline when the pane never echoes the paste', async () => {
+    useHostPlatform('win32')
+    vi.useFakeTimers()
+    const { runtime, handle, writes, submitTimes } =
+      await createSettlementRuntimeWithImmediateRenderGate()
+    const floorMs = floorMsFor('win32')
+    const submission = runtime.sendTerminalAgentPrompt(handle, PROMPT)
+    const stalled = expect(submission).rejects.toThrow('agent_prompt_stalled')
+
+    await vi.advanceTimersByTimeAsync(floorMs + AGENT_PROMPT_ECHO_TIMEOUT_MS_WIN32 - 1)
+    expect(countSubmits(writes)).toBe(0)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(countSubmits(writes)).toBe(1)
+    expect(submitTimes[0]).toBe(floorMs + AGENT_PROMPT_ECHO_TIMEOUT_MS_WIN32)
+
+    await vi.runAllTimersAsync()
+    // Why: the deadline is a fallback, not proof the paste landed -- verification still owns
+    // the final verdict, and no evidence of a turn start means it still stalls.
+    await stalled
+  })
+
+  it('treats a paste-collapse placeholder ("[Pasted text #1 +N lines]") as the paste echo', async () => {
+    useHostPlatform('win32')
+    vi.useFakeTimers()
+    const { runtime, handle, writes, submitTimes } =
+      await createSettlementRuntimeWithImmediateRenderGate()
+    const floorMs = floorMsFor('win32')
+    const submission = runtime.sendTerminalAgentPrompt(handle, PROMPT)
+    const stalled = expect(submission).rejects.toThrow('agent_prompt_stalled')
+
+    runtime.onPtyData(PTY_ID, '[Pasted text #1 +40 lines]', Date.now())
+
+    await vi.advanceTimersByTimeAsync(floorMs + AGENT_PROMPT_ECHO_SETTLE_MS - 1)
+    expect(countSubmits(writes)).toBe(0)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(countSubmits(writes)).toBe(1)
+    expect(submitTimes[0]).toBe(floorMs + AGENT_PROMPT_ECHO_SETTLE_MS)
+
+    await vi.runAllTimersAsync()
+    await stalled
+  })
+
+  it('uses the shorter 3 s echo deadline on a non-win32 write host', async () => {
+    useHostPlatform('darwin')
+    vi.useFakeTimers()
+    const { runtime, handle, writes, submitTimes } =
+      await createSettlementRuntimeWithImmediateRenderGate()
+    const floorMs = floorMsFor('darwin')
+    const submission = runtime.sendTerminalAgentPrompt(handle, PROMPT)
+    const stalled = expect(submission).rejects.toThrow('agent_prompt_stalled')
+
+    await vi.advanceTimersByTimeAsync(floorMs + AGENT_PROMPT_ECHO_TIMEOUT_MS_DEFAULT - 1)
+    expect(countSubmits(writes)).toBe(0)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(countSubmits(writes)).toBe(1)
+    expect(submitTimes[0]).toBe(floorMs + AGENT_PROMPT_ECHO_TIMEOUT_MS_DEFAULT)
 
     await vi.runAllTimersAsync()
     await stalled
   })
 })
-

--- a/src/main/runtime/agent-prompt-submission-render-gate-floor.test.ts
+++ b/src/main/runtime/agent-prompt-submission-render-gate-floor.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildAgentPromptPasteBytes, getAgentPromptSubmitDelayMs } from '../../shared/agent-prompt-injection'
+import { OrcaRuntimeService } from './orca-runtime'
+import { makeStore } from './runtime-rpc-worktree-store-fixtures'
+
+// Why: this suite isolates the renderGate branch's structural guarantee -- independent of
+// createAgentPromptRenderGate's own settlement heuristic -- that Enter cannot overtake the
+// ingest floor even when the render signal itself fires early (redraw races, a settlement
+// agent that repaints before attaching a completed paste, etc).
+const WORKTREE_PATH = '/tmp/worktree-a'
+const PTY_ID = 'pty-prompt'
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+function useHostPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+}
+
+vi.mock('../git/worktree', () => ({
+  listWorktrees: vi.fn().mockResolvedValue([
+    {
+      path: '/tmp/worktree-a',
+      head: 'abc',
+      branch: 'feature/prompt-verification',
+      isBare: false,
+      isMainWorktree: false
+    }
+  ]),
+  listWorktreesStrict: vi.fn().mockResolvedValue([
+    {
+      path: '/tmp/worktree-a',
+      head: 'abc',
+      branch: 'feature/prompt-verification',
+      isBare: false,
+      isMainWorktree: false
+    }
+  ])
+}))
+
+function countSubmits(writes: readonly string[]): number {
+  return writes.filter((data) => data === '\r').length
+}
+
+/** Stubs the settlement agent's render gate to resolve on the very next microtask, the way
+ *  an early redraw would, so the test isolates whether the ingest floor still applies. */
+async function createSettlementRuntimeWithImmediateRenderGate(): Promise<{
+  runtime: OrcaRuntimeService
+  handle: string
+  writes: string[]
+  submitTimes: number[]
+}> {
+  const runtime = new OrcaRuntimeService(makeStore() as never)
+  vi.spyOn(
+    OrcaRuntimeService.prototype as unknown as {
+      createAgentPromptRenderGate: (
+        ptyId: string,
+        pasteIngestMs: number
+      ) => { arm: () => void; wait: () => Promise<void>; dispose: () => void } | null
+    },
+    'createAgentPromptRenderGate'
+  ).mockReturnValue({
+    arm: () => {},
+    wait: () => Promise.resolve(),
+    dispose: () => {}
+  })
+  const writes: string[] = []
+  const submitTimes: number[] = []
+  const startedAt = Date.now()
+  runtime.setPtyController({
+    spawn: vi.fn().mockResolvedValue({ id: PTY_ID }),
+    write: (_ptyId, data) => {
+      writes.push(data)
+      if (data === '\r') {
+        submitTimes.push(Date.now() - startedAt)
+      }
+      return true
+    },
+    kill: () => true,
+    getForegroundProcess: async () => null
+  })
+  const terminal = await runtime.createTerminal(`path:${WORKTREE_PATH}`, {
+    launchAgent: 'claude'
+  })
+  return { runtime, handle: terminal.handle, writes, submitTimes }
+}
+
+describe('agent prompt render gate ingest floor', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+    Object.defineProperty(process, 'platform', originalPlatform)
+  })
+
+  it('does not write Enter before the ingest floor when the render gate resolves early', async () => {
+    useHostPlatform('win32')
+    vi.useFakeTimers()
+    const { runtime, handle, writes, submitTimes } =
+      await createSettlementRuntimeWithImmediateRenderGate()
+    // Why 12 KB: one chunk (so the write loop costs no clock, matching the ticket's observed
+    // 10,714/12,773-byte payloads), while still large enough that the ConPTY ingest term is
+    // well above the flat 500 ms settle a resolved-immediately gate would otherwise stop at.
+    const prompt = 'y'.repeat(12_000)
+    const floorMs = getAgentPromptSubmitDelayMs(
+      'win32',
+      Buffer.byteLength(buildAgentPromptPasteBytes(prompt), 'utf8')
+    )
+    const submission = runtime.sendTerminalAgentPrompt(handle, prompt)
+    const stalled = expect(submission).rejects.toThrow('agent_prompt_stalled')
+
+    // Flush the render gate's already-resolved promise without advancing real time.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(countSubmits(writes)).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(floorMs - 1)
+    expect(countSubmits(writes)).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(countSubmits(writes)).toBe(1)
+    expect(submitTimes[0]).toBeGreaterThanOrEqual(floorMs)
+
+    await vi.runAllTimersAsync()
+    await stalled
+  })
+})
+

--- a/src/main/runtime/agent-prompt-submission-render-gate-floor.test.ts
+++ b/src/main/runtime/agent-prompt-submission-render-gate-floor.test.ts
@@ -97,11 +97,13 @@ async function createSettlementRuntimeWithImmediateRenderGate(): Promise<{
 const PROMPT = 'y'.repeat(12_000)
 // Why: matches the 24-char echo probe derived from PROMPT's tail (all 'y's).
 const PROMPT_TAIL_ECHO = 'y'.repeat(24)
+const PROMPT_LEADING_TEXT = '[Pasted text #1 +40 lines]\n'
+const PROMPT_WITH_LITERAL_PLACEHOLDER = `${PROMPT_LEADING_TEXT}${PROMPT}`
 
-function floorMsFor(platform: NodeJS.Platform): number {
+function floorMsFor(platform: NodeJS.Platform, prompt = PROMPT): number {
   return getAgentPromptSubmitDelayMs(
     platform,
-    Buffer.byteLength(buildAgentPromptPasteBytes(PROMPT), 'utf8')
+    Buffer.byteLength(buildAgentPromptPasteBytes(prompt), 'utf8')
   )
 }
 
@@ -263,6 +265,30 @@ describe('agent prompt render gate ingest floor', () => {
     await vi.advanceTimersByTimeAsync(1)
     expect(countSubmits(writes)).toBe(1)
     expect(submitTimes[0]).toBe(floorMs + AGENT_PROMPT_ECHO_SETTLE_MS)
+
+    await vi.runAllTimersAsync()
+    await stalled
+  })
+
+  it('does not treat a placeholder supplied by the prompt as a collapsed-paste echo', async () => {
+    useHostPlatform('win32')
+    vi.useFakeTimers()
+    const { runtime, handle, writes } = await createSettlementRuntimeWithImmediateRenderGate()
+    const floorMs = floorMsFor('win32', PROMPT_WITH_LITERAL_PLACEHOLDER)
+    const submission = runtime.sendTerminalAgentPrompt(handle, PROMPT_WITH_LITERAL_PLACEHOLDER)
+    const stalled = expect(submission).rejects.toThrow('agent_prompt_stalled')
+
+    await vi.advanceTimersByTimeAsync(0)
+    runtime.onPtyData(PTY_ID, PROMPT_LEADING_TEXT, Date.now())
+
+    await vi.advanceTimersByTimeAsync(
+      floorMs + AGENT_PROMPT_ECHO_SETTLE_MS + AGENT_PROMPT_ECHO_POLL_INTERVAL_MS
+    )
+    expect(countSubmits(writes)).toBe(0)
+
+    runtime.onPtyData(PTY_ID, PROMPT_TAIL_ECHO, Date.now())
+    await vi.advanceTimersByTimeAsync(AGENT_PROMPT_ECHO_POLL_INTERVAL_MS + AGENT_PROMPT_ECHO_SETTLE_MS)
+    expect(countSubmits(writes)).toBe(1)
 
     await vi.runAllTimersAsync()
     await stalled

--- a/src/main/runtime/agent-prompt-submission-windows-submit-delay.test.ts
+++ b/src/main/runtime/agent-prompt-submission-windows-submit-delay.test.ts
@@ -4,6 +4,7 @@ import {
   getAgentPromptSubmitDelayMs,
   getTerminalPasteIngestMs
 } from '../../shared/agent-prompt-injection'
+import { AGENT_PROMPT_ECHO_SETTLE_MS } from './agent-prompt-paste-echo'
 import { setSshTargetRegistryHandlers } from '../ssh/ssh-target-registry'
 import { OrcaRuntimeService } from './orca-runtime'
 import { makeStore } from './runtime-rpc-worktree-store-fixtures'
@@ -321,7 +322,12 @@ describe('agent prompt render gate on a ConPTY host', () => {
           submitTimes.push(Date.now() - startedAt)
         }
         if (data.includes('\x1b[201~')) {
-          setTimeout(() => runtime.onPtyData(PTY_ID, '\x1b[?25h', Date.now()), markerDelayMs)
+          setTimeout(() => {
+            runtime.onPtyData(PTY_ID, '\x1b[?25h', Date.now())
+            // Why: the paste-echo wait layered on the render gate needs pane evidence the
+            // paste landed; a collapse placeholder is the fast path a real composer takes.
+            runtime.onPtyData(PTY_ID, '[Pasted text #1 +1 lines]', Date.now())
+          }, markerDelayMs)
           for (let at = markerDelayMs + 500; at <= (agentOutput.noiseUntilMs ?? 0); at += 500) {
             setTimeout(() => runtime.onPtyData(PTY_ID, '.', Date.now()), at)
           }
@@ -378,8 +384,10 @@ describe('agent prompt render gate on a ConPTY host', () => {
 
     await vi.runAllTimersAsync()
     expect(submitTimes).toHaveLength(1)
-    expect(submitTimes[0]).toBeGreaterThanOrEqual(ingestMs + 8_000)
-    expect(submitTimes[0]).toBeLessThan(ingestMs + 8_500)
+    // Why +AGENT_PROMPT_ECHO_SETTLE_MS: the pane's placeholder echo is already visible by the
+    // time the gate's hard cap fires, so the paste-echo wait adds only its fixed settle here.
+    expect(submitTimes[0]).toBeGreaterThanOrEqual(ingestMs + 8_000 + AGENT_PROMPT_ECHO_SETTLE_MS)
+    expect(submitTimes[0]).toBeLessThan(ingestMs + 8_500 + AGENT_PROMPT_ECHO_SETTLE_MS)
     await stalled
   })
 
@@ -392,9 +400,11 @@ describe('agent prompt render gate on a ConPTY host', () => {
 
     await vi.runAllTimersAsync()
     expect(submitTimes).toHaveLength(1)
-    // 100 ms marker + 1_500 ms quiet: a sub-chunk paste adds no measurable ingest.
-    expect(submitTimes[0]).toBeGreaterThanOrEqual(1_600)
-    expect(submitTimes[0]).toBeLessThan(1_700)
+    // 100 ms marker + 1_500 ms quiet: a sub-chunk paste adds no measurable ingest. The
+    // placeholder echo is already visible by then, so the paste-echo wait adds only its
+    // fixed settle on top.
+    expect(submitTimes[0]).toBeGreaterThanOrEqual(1_600 + AGENT_PROMPT_ECHO_SETTLE_MS)
+    expect(submitTimes[0]).toBeLessThan(1_700 + AGENT_PROMPT_ECHO_SETTLE_MS)
     await stalled
   })
 })

--- a/src/main/runtime/orca-runtime-write-terminal-agent-prompt.ts
+++ b/src/main/runtime/orca-runtime-write-terminal-agent-prompt.ts
@@ -59,7 +59,16 @@ export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithReso
 
     if (renderGate) {
       try {
-        await waitForAgentPromptPromise(renderGate.wait(), options.signal)
+        // Why: the render gate is a readiness signal, not proof of ingest -- a redraw can
+        // fire before the child has attached the completed paste, so the byte-count floor
+        // still has to hold even on the closed-loop path.
+        await Promise.all([
+          waitForAgentPromptPromise(renderGate.wait(), options.signal),
+          waitForAgentPromptDelay(
+            getAgentPromptSubmitDelayMs(writeHostPlatform, pasteByteLength),
+            options.signal
+          )
+        ])
       } finally {
         renderGate.dispose()
       }

--- a/src/main/runtime/orca-runtime-write-terminal-agent-prompt.ts
+++ b/src/main/runtime/orca-runtime-write-terminal-agent-prompt.ts
@@ -22,7 +22,8 @@ import {
   AGENT_PROMPT_ECHO_SETTLE_MS,
   deriveAgentPromptPasteEchoProbe,
   getAgentPromptPasteEchoTimeoutMs,
-  isAgentPromptPasteEchoObserved
+  isAgentPromptPasteEchoObserved,
+  isAgentPromptPasteEchoPlaceholderObserved
 } from './agent-prompt-paste-echo'
 
 export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithResolveAuthoritativeTerminalWaitPermission {
@@ -42,6 +43,19 @@ export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithReso
     const pasteByteLength = Buffer.byteLength(pastePayload, 'utf8')
     const pasteIngestMs = getTerminalPasteIngestMs(writeHostPlatform, pasteByteLength)
     const renderGate = this.createAgentPromptRenderGate(ptyId, pasteIngestMs)
+    let pasteOutputSequenceBaseline: number | null = null
+    let postPasteOutput = ''
+    const unsubscribePasteEcho = renderGate
+      ? this.subscribeToTerminalData(ptyId, (data, meta) => {
+          if (
+            pasteOutputSequenceBaseline !== null &&
+            typeof meta?.seq === 'number' &&
+            meta.seq > pasteOutputSequenceBaseline
+          ) {
+            postPasteOutput += data
+          }
+        })
+      : null
     try {
       assertAgentPromptRequestActive(options.signal)
       this.assertAgentPromptGeneration(ptyId, generation)
@@ -59,8 +73,10 @@ export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithReso
       if (!this.ptyController?.write(ptyId, pastePayload)) {
         throw new Error('terminal_not_writable')
       }
+      pasteOutputSequenceBaseline = this.getAgentPromptActivity(handle, ptyId).outputSequence
     } catch (error) {
       renderGate?.dispose()
+      unsubscribePasteEcho?.()
       throw error
     }
 
@@ -76,22 +92,22 @@ export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithReso
             options.signal
           )
         ])
+        // Why: full scrollback can contain an earlier prompt; only bytes emitted after this
+        // write's output boundary can prove this paste reached the composer.
+        await this.waitForAgentPromptPasteEcho(
+          handle,
+          ptyId,
+          generation,
+          pastePayload,
+          writeHostPlatform,
+          pasteOutputSequenceBaseline,
+          () => postPasteOutput,
+          options
+        )
       } finally {
         renderGate.dispose()
+        unsubscribePasteEcho?.()
       }
-      // Why: the gate is a readiness signal for redraw activity, not proof the composer
-      // consumed the paste -- on Windows a Codex pane can still be streaming per-keystroke
-      // redraws past the gate's hard cap, and Enter written mid-burst becomes a stray
-      // newline (agent_prompt_stalled). Poll the pane for the paste tail (or a placeholder
-      // like "[Pasted text #1 +N lines]") before proceeding.
-      await this.waitForAgentPromptPasteEcho(
-        handle,
-        ptyId,
-        generation,
-        pastePayload,
-        writeHostPlatform,
-        options
-      )
     } else {
       await waitForAgentPromptDelay(
         getAgentPromptSubmitDelayMs(writeHostPlatform, pasteByteLength),
@@ -136,18 +152,25 @@ export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithReso
     generation: number,
     pastePayload: string,
     writeHostPlatform: NodeJS.Platform,
+    pasteOutputSequenceBaseline: number | null,
+    readPostPasteOutput: () => string,
     options: RuntimeTerminalWriteOptions
   ): Promise<void> {
     const probe = deriveAgentPromptPasteEchoProbe(pastePayload)
-    if (probe === null) {
+    if (probe === null || pasteOutputSequenceBaseline === null) {
       return
     }
     const deadlineAt = Date.now() + getAgentPromptPasteEchoTimeoutMs(writeHostPlatform)
     while (Date.now() < deadlineAt) {
       assertAgentPromptRequestActive(options.signal)
       this.assertAgentPromptGeneration(ptyId, generation)
-      const waitText = this.getTerminalAgentStatusSnapshot(handle, ptyId).waitText
-      if (isAgentPromptPasteEchoObserved(waitText, probe)) {
+      const activity = this.getAgentPromptActivity(handle, ptyId)
+      const postPasteOutput = readPostPasteOutput()
+      if (
+        activity.outputSequence > pasteOutputSequenceBaseline &&
+        (isAgentPromptPasteEchoObserved(postPasteOutput, probe) ||
+          isAgentPromptPasteEchoPlaceholderObserved(postPasteOutput))
+      ) {
         await waitForAgentPromptDelay(AGENT_PROMPT_ECHO_SETTLE_MS, options.signal)
         return
       }

--- a/src/main/runtime/orca-runtime-write-terminal-agent-prompt.ts
+++ b/src/main/runtime/orca-runtime-write-terminal-agent-prompt.ts
@@ -17,6 +17,13 @@ import {
   resolveAgentPromptEffectTimeoutMs,
   verifyAgentPromptSubmission
 } from './agent-prompt-submission-verification'
+import {
+  AGENT_PROMPT_ECHO_POLL_INTERVAL_MS,
+  AGENT_PROMPT_ECHO_SETTLE_MS,
+  deriveAgentPromptPasteEchoProbe,
+  getAgentPromptPasteEchoTimeoutMs,
+  isAgentPromptPasteEchoObserved
+} from './agent-prompt-paste-echo'
 
 export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithResolveAuthoritativeTerminalWaitPermission {
   protected async writeTerminalAgentPrompt(
@@ -72,6 +79,19 @@ export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithReso
       } finally {
         renderGate.dispose()
       }
+      // Why: the gate is a readiness signal for redraw activity, not proof the composer
+      // consumed the paste -- on Windows a Codex pane can still be streaming per-keystroke
+      // redraws past the gate's hard cap, and Enter written mid-burst becomes a stray
+      // newline (agent_prompt_stalled). Poll the pane for the paste tail (or a placeholder
+      // like "[Pasted text #1 +N lines]") before proceeding.
+      await this.waitForAgentPromptPasteEcho(
+        handle,
+        ptyId,
+        generation,
+        pastePayload,
+        writeHostPlatform,
+        options
+      )
     } else {
       await waitForAgentPromptDelay(
         getAgentPromptSubmitDelayMs(writeHostPlatform, pasteByteLength),
@@ -105,5 +125,36 @@ export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithReso
       signal: options.signal
     })
     return 1
+  }
+
+  /** Polls the pane for the paste tail (or a collapse placeholder) so Enter never overtakes a
+   *  redraw burst the render gate's hard cap already gave up waiting on. Best-effort: on
+   *  timeout it falls back to today's behavior rather than blocking submission indefinitely. */
+  private async waitForAgentPromptPasteEcho(
+    handle: string,
+    ptyId: string,
+    generation: number,
+    pastePayload: string,
+    writeHostPlatform: NodeJS.Platform,
+    options: RuntimeTerminalWriteOptions
+  ): Promise<void> {
+    const probe = deriveAgentPromptPasteEchoProbe(pastePayload)
+    if (probe === null) {
+      return
+    }
+    const deadlineAt = Date.now() + getAgentPromptPasteEchoTimeoutMs(writeHostPlatform)
+    while (Date.now() < deadlineAt) {
+      assertAgentPromptRequestActive(options.signal)
+      this.assertAgentPromptGeneration(ptyId, generation)
+      const waitText = this.getTerminalAgentStatusSnapshot(handle, ptyId).waitText
+      if (isAgentPromptPasteEchoObserved(waitText, probe)) {
+        await waitForAgentPromptDelay(AGENT_PROMPT_ECHO_SETTLE_MS, options.signal)
+        return
+      }
+      await waitForAgentPromptDelay(
+        Math.min(AGENT_PROMPT_ECHO_POLL_INTERVAL_MS, Math.max(0, deadlineAt - Date.now())),
+        options.signal
+      )
+    }
   }
 }

--- a/src/main/runtime/orca-runtime-write-terminal-agent-prompt.ts
+++ b/src/main/runtime/orca-runtime-write-terminal-agent-prompt.ts
@@ -23,7 +23,8 @@ import {
   deriveAgentPromptPasteEchoProbe,
   getAgentPromptPasteEchoTimeoutMs,
   isAgentPromptPasteEchoObserved,
-  isAgentPromptPasteEchoPlaceholderObserved
+  isAgentPromptPasteEchoPlaceholderObserved,
+  pastePayloadContainsPlaceholderFragment
 } from './agent-prompt-paste-echo'
 
 export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithResolveAuthoritativeTerminalWaitPermission {
@@ -143,7 +144,7 @@ export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithReso
     return 1
   }
 
-  /** Polls the pane for the paste tail (or a collapse placeholder) so Enter never overtakes a
+  /** Polls the pane for the paste tail (or a collapse placeholder the payload cannot supply) so Enter never overtakes a
    *  redraw burst the render gate's hard cap already gave up waiting on. Best-effort: on
    *  timeout it falls back to today's behavior rather than blocking submission indefinitely. */
   private async waitForAgentPromptPasteEcho(
@@ -157,6 +158,7 @@ export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithReso
     options: RuntimeTerminalWriteOptions
   ): Promise<void> {
     const probe = deriveAgentPromptPasteEchoProbe(pastePayload)
+    const canUsePlaceholderEvidence = !pastePayloadContainsPlaceholderFragment(pastePayload)
     if (probe === null || pasteOutputSequenceBaseline === null) {
       return
     }
@@ -169,7 +171,8 @@ export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithReso
       if (
         activity.outputSequence > pasteOutputSequenceBaseline &&
         (isAgentPromptPasteEchoObserved(postPasteOutput, probe) ||
-          isAgentPromptPasteEchoPlaceholderObserved(postPasteOutput))
+          (canUsePlaceholderEvidence &&
+            isAgentPromptPasteEchoPlaceholderObserved(postPasteOutput)))
       ) {
         await waitForAgentPromptDelay(AGENT_PROMPT_ECHO_SETTLE_MS, options.signal)
         return


### PR DESCRIPTION
## ELI5

When Orca pastes a dispatch prompt into a Codex or Claude Code terminal, it waits for the terminal to say "I've redrawn" and then presses Enter. On Windows that redraw can happen before the terminal has actually finished swallowing the paste, so Enter lands mid-paste and is dropped. The prompt sits in the composer forever and Orca reports `agent_prompt_stalled`. This change makes Orca also wait the byte-count-based minimum it already uses on the open-loop path, so Enter is never written before the paste could possibly have been ingested.

## What Changed

`src/main/runtime/orca-runtime-write-terminal-agent-prompt.ts`: on the render-gate branch, await `Promise.all([renderGate.wait(), waitForAgentPromptDelay(getAgentPromptSubmitDelayMs(...))])` instead of the gate alone. The later of the two now governs. The non-gate branch is unchanged.

New test `src/main/runtime/agent-prompt-submission-render-gate-floor.test.ts`: resolves the render gate immediately and asserts no Enter is written before the ingest floor elapses, exactly one after.

## Why

`worker-start` failed with `agent_prompt_stalled` at `dispatch_input` on Windows for both Codex and Claude Code TUIs, five attempts in a row (payloads 10,714 and 12,773 bytes). The paste reached the composer and stayed there unsubmitted; pressing Enter manually minutes later submitted it intact and the worker ran normally. So the paste landed and the Enter was swallowed.

Agents that expose a settlement signal take the `renderGate` branch, which awaited only the gate and skipped `getAgentPromptSubmitDelayMs` entirely. The open-loop branch would have waited ~670 ms for these payloads. The render gate is a readiness signal, not proof of ingest: it can resolve on a redraw that fires before the child has attached the completed bracketed paste. `agent-prompt-injection.ts` already documents that the submit delay is "never capped — a cap silently reintroduces the mid-paste Enter it exists to prevent"; the gate branch was an unconditional bypass of that protection.

Not addressed here (separate ticket-worthy defect): the gate's own ingest-deadline clock starts at gate construction, before the paste chunks are written, while the non-gate floor is computed after the write loop. The floor now covers it either way.

## Linked Issue

Fixes #17066
Related: #16377, #16902, #17291

## Visual Proof

N/A — no UI change. Behavior change is in prompt-submit timing; evidence is the test below and the live reproduction described under Testing.

## Testing

- New test fails on unfixed `main` at the pre-floor assertion (`expect(countSubmits(writes)).toBe(0)`) and passes with the fix. Re-confirmed by reverting the production hunk by hand and re-running.
- `npx vitest run` on `agent-prompt-submission-render-gate-floor.test.ts`, `agent-prompt-submission-runtime.test.ts`, `agent-prompt-submission-windows-submit-delay.test.ts`, `agent-prompt-submission-verification.test.ts`: 69/69 pass.
- `tsc --noEmit -p config/tsconfig.node.json`: exit 0. `oxlint` on the two changed files: clean.
- Live reproduction on Windows 11 with Orca 1.4.192: `agent_prompt_stalled` 5/5 (3 Codex, 1 Claude Sonnet, 1 retry); every one recovered by `orca terminal send --enter` on the stalled terminal, which submitted the already-injected prompt intact. Built this branch (rebased on `f737f349`) with `build:win`, installed it, and dispatch acceptance is being run on it now.
- Platforms actually tested: Windows. macOS/Linux take the same code path; the added wait is bounded by the existing platform-specific `getAgentPromptSubmitDelayMs`.
- Note: `orca-runtime-tests/terminal-creation-and-readiness-part-07.spec.ts` fails 52/52 on pristine `main` on this Windows machine (`selector_not_found`), independent of this change.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Root-caused and implemented with Claude Opus 5 (Claude Code); rebased onto current `main`, re-verified, and packaged with Claude Fable 5.1. The failing test was written and confirmed by a Claude subagent, then independently re-verified by reverting the fix by hand.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security surface touched. Cross-platform: adds a bounded wait already computed per platform; no path or shortcut impact. SSH: the write path is the same; the delay is derived from the write-host platform, not the client. Mobile: N/A. Performance: adds at most the existing open-loop submit delay (~0.5–1 s for typical dispatch payloads) on the closed-loop path, only when the gate resolves earlier than the floor.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — typecheck, targeted tests, oxlint and `build:win` pass locally; full `pnpm test` not run locally because of the pre-existing part-07 failure noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
