### PR TITLE
fix(cli): reject remote selectors on local host listings

### DIFF
--- a/config/scripts/cli-runtime-client-deferral-equivalence.mjs
+++ b/config/scripts/cli-runtime-client-deferral-equivalence.mjs
@@ -131,10 +131,7 @@ function run(entry, argv, env) {
   }
 }
 
-// Every case must produce identical bytes on both arms. The runtime-dependent
-// ones (status/worktree list) are pointed at an empty user-data dir so the
-// answer is deterministic "not running" rather than whatever the dev machine
-// happens to be doing.
+/** Builds deterministic and seeded-fuzz invocations whose outputs must remain byte-equivalent. */
 function buildCases(isolatedUserData) {
   const isolated = { ORCA_USER_DATA_PATH: isolatedUserData }
   const cases = [

--- a/config/scripts/cli-runtime-client-deferral-equivalence.mjs
+++ b/config/scripts/cli-runtime-client-deferral-equivalence.mjs
@@ -170,13 +170,12 @@ function buildCases(isolatedUserData) {
     [['status', '--json'], { ...isolated, ORCA_ENVIRONMENT: 'no-such-environment' }],
     // ...and must stay suppressed for the local-only command groups.
     //
-    // NOTE: the only commands that both live in a suppressed group AND touch
-    // ctx.client are `agent hooks on|off`, which rewrite the user's real agent
-    // hook configuration in ~/.claude and friends — far outside
-    // ORCA_USER_DATA_PATH. They are deliberately NOT invoked here. The
-    // null-vs-undefined suppression they would exercise is covered
-    // side-effect-free by the constructor-argument assertions in
-    // src/cli/runtime-client-deferral.test.ts instead.
+    // NOTE: the commands that both live in a suppressed group AND touch
+    // ctx.client are `agent hooks on|off` and `host list`. The former rewrites
+    // the user's real agent hook configuration in ~/.claude and friends — far
+    // outside ORCA_USER_DATA_PATH — so it is deliberately NOT invoked here.
+    // Both commands' null-vs-undefined suppression is covered side-effect-free
+    // by constructor-argument assertions in runtime-client-deferral.test.ts.
     [['environment', 'list', '--json'], { ...isolated, ORCA_ENVIRONMENT: 'no-such-environment' }],
     [['environment', 'list', '--json'], { ...isolated, ORCA_PAIRING_CODE: 'not-a-pairing-code' }],
     [['agent-context', '--json'], { ...isolated, ORCA_PAIRING_CODE: 'not-a-pairing-code' }],

--- a/src/cli/handlers/environment.ts
+++ b/src/cli/handlers/environment.ts
@@ -82,6 +82,7 @@ export const ENVIRONMENT_HANDLERS: Record<string, CommandHandler> = {
   }
 }
 
+/** Rejects selectors that would otherwise make local connection metadata appear remotely scoped. */
 function rejectRemoteSelectionFlags(ctx: HandlerContext, command: string): void {
   for (const flag of ['environment', 'pairing-code']) {
     if (ctx.flags.has(flag)) {

--- a/src/cli/handlers/environment.ts
+++ b/src/cli/handlers/environment.ts
@@ -1,4 +1,4 @@
-import type { CommandHandler } from '../dispatch'
+import type { CommandHandler, HandlerContext } from '../dispatch'
 import { formatEnvironment, formatEnvironmentList, formatHostList, printResult } from '../format'
 import { listSshTargets } from '../host-selector-alternatives'
 import { getDefaultUserDataPath, RuntimeClientError } from '../runtime-client'
@@ -33,7 +33,9 @@ export const ENVIRONMENT_HANDLERS: Record<string, CommandHandler> = {
   // Why: an agent told "run it on <name>" had nowhere to look. `orca environment list` showed
   // paired servers only, and nothing in the CLI listed SSH targets at all, so the wrong-axis
   // guess was the only move available. This is the one place that answers both.
-  'host list': async ({ client, json }) => {
+  'host list': async (ctx) => {
+    rejectRemoteSelectionFlags(ctx, 'orca host list')
+    const { client, json } = ctx
     const environments = listEnvironments(getDefaultUserDataPath()).map((environment) => ({
       kind: 'environment' as const,
       name: environment.name,
@@ -53,7 +55,9 @@ export const ENVIRONMENT_HANDLERS: Record<string, CommandHandler> = {
     ]
     printResult(localSuccess({ hosts }), json, formatHostList)
   },
-  'environment list': async ({ json }) => {
+  'environment list': async (ctx) => {
+    rejectRemoteSelectionFlags(ctx, 'orca environment list')
+    const { json } = ctx
     const environments = listEnvironments(getDefaultUserDataPath()).map(redactRuntimeEnvironment)
     printResult(localSuccess({ environments }), json, formatEnvironmentList)
   },
@@ -75,6 +79,17 @@ export const ENVIRONMENT_HANDLERS: Record<string, CommandHandler> = {
       (result: EnvironmentRemoveResult) =>
         `Removed environment ${result.removed.name} (${result.removed.id}).`
     )
+  }
+}
+
+function rejectRemoteSelectionFlags(ctx: HandlerContext, command: string): void {
+  for (const flag of ['environment', 'pairing-code']) {
+    if (ctx.flags.has(flag)) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        `\`--${flag}\` does not retarget \`${command}\`. Run it on the Orca host whose connections you want to inspect.`
+      )
+    }
   }
 }
 

--- a/src/cli/index-environment-commands.test.ts
+++ b/src/cli/index-environment-commands.test.ts
@@ -41,10 +41,14 @@ vi.mock('child_process', async () => {
 })
 
 import { main } from './index'
-import { pairRuntimeEnvironment, useWorktreeAwarenessEnvironment } from './index-test-harness'
+import {
+  pairRuntimeEnvironment,
+  useWorktreeAwarenessEnvironment as installWorktreeAwarenessEnvironment
+} from './index-test-harness'
 
-describe('orca cli worktree awareness', () => {
-  useWorktreeAwarenessEnvironment({
+/** Registers CLI routing regressions for local metadata commands and remote selectors. */
+function registerWorktreeAwarenessTests(): void {
+  installWorktreeAwarenessEnvironment({
     callMock,
     serveOrcaAppMock,
     getDefaultUserDataPathMock,
@@ -141,4 +145,6 @@ describe('orca cli worktree awareness', () => {
       process.exitCode = priorExitCode
     }
   })
-})
+}
+
+describe('orca cli worktree awareness', registerWorktreeAwarenessTests)

--- a/src/cli/index-environment-commands.test.ts
+++ b/src/cli/index-environment-commands.test.ts
@@ -41,7 +41,7 @@ vi.mock('child_process', async () => {
 })
 
 import { main } from './index'
-import { useWorktreeAwarenessEnvironment } from './index-test-harness'
+import { pairRuntimeEnvironment, useWorktreeAwarenessEnvironment } from './index-test-harness'
 
 describe('orca cli worktree awareness', () => {
   useWorktreeAwarenessEnvironment({
@@ -83,4 +83,38 @@ describe('orca cli worktree awareness', () => {
     expect(logSpy.mock.calls[0]?.[0]).not.toContain('token')
     expect(logSpy.mock.calls[0]?.[0]).not.toContain('publicKeyB64')
   })
+
+  it.each([
+    [['environment', 'list'], 'environment'],
+    [['environment', 'list'], 'pairing-code'],
+    [['host', 'list'], 'environment'],
+    [['host', 'list'], 'pairing-code']
+  ] as const)(
+    '%s rejects --%s instead of answering for the local machine',
+    async (command, flag) => {
+      const priorExitCode = process.exitCode
+      process.exitCode = undefined
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      try {
+        if (flag === 'environment') {
+          pairRuntimeEnvironment(listEnvironmentsMock, 'env-homelab', 'homelab')
+        }
+        await main([...command, `--${flag}`, 'homelab', '--json'], '/tmp/repo')
+
+        const response = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))
+        expect(response).toMatchObject({
+          ok: false,
+          error: {
+            code: 'invalid_argument'
+          }
+        })
+        expect(response.error.message).toContain(`\`--${flag}\` does not retarget`)
+        expect(process.exitCode).toBe(1)
+        expect(callMock).not.toHaveBeenCalled()
+      } finally {
+        process.exitCode = priorExitCode
+      }
+    }
+  )
 })

--- a/src/cli/index-environment-commands.test.ts
+++ b/src/cli/index-environment-commands.test.ts
@@ -117,4 +117,28 @@ describe('orca cli worktree awareness', () => {
       }
     }
   )
+
+  it('rejects an unknown --environment on host list before selector resolution', async () => {
+    const priorExitCode = process.exitCode
+    process.exitCode = undefined
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    try {
+      await main(['host', 'list', '--environment', 'missing-host', '--json'], '/tmp/repo')
+
+      const response = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))
+      expect(response).toMatchObject({
+        ok: false,
+        error: {
+          code: 'invalid_argument'
+        }
+      })
+      expect(response.error.message).toContain('`--environment` does not retarget `orca host list`')
+      expect(runtimeClientConstructorMock).not.toHaveBeenCalled()
+      expect(callMock).not.toHaveBeenCalled()
+      expect(process.exitCode).toBe(1)
+    } finally {
+      process.exitCode = priorExitCode
+    }
+  })
 })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,7 @@ export { buildCurrentWorktreeSelector, normalizeWorktreeSelector } from './selec
 
 const COMMAND_PATHS = COMMAND_SPECS.flatMap((spec) => specPaths(spec))
 
+/** Returns whether a command family must suppress remote selection before selector resolution. */
 function shouldIgnoreRemoteSelection(commandPath: string[]): boolean {
   return (
     commandPath[0] === 'account' ||

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,6 +31,7 @@ function shouldIgnoreRemoteSelection(commandPath: string[]): boolean {
     commandPath[0] === 'account' ||
     commandPath[0] === 'artifacts' ||
     commandPath[0] === 'environment' ||
+    commandPath[0] === 'host' ||
     commandPath[0] === 'serve' ||
     commandPath[0] === 'agent' ||
     commandPath[0] === 'vm' ||
@@ -145,7 +146,7 @@ export async function main(
     // Why: pass `null` (not `undefined`) when remote selection is suppressed
     // so the RuntimeClient default parameter does not re-activate the
     // ORCA_PAIRING_CODE / ORCA_ENVIRONMENT env-var fallback for commands
-    // that must run locally (environment / serve).
+    // that must run locally (environment / host / serve).
     const suppressed = ignoreRemoteSelection ? null : undefined
     // An explicit --host runtime:<id> outranks an ambient pairing code or environment.
     const remotePairingCode =

--- a/src/cli/runtime-client-deferral.test.ts
+++ b/src/cli/runtime-client-deferral.test.ts
@@ -62,7 +62,8 @@ import * as dispatchModule from './dispatch'
 
 const CLI_DIR = __dirname
 
-describe('RuntimeClient module-graph deferral', () => {
+/** Registers checks that local-only CLI paths defer or suppress RuntimeClient construction. */
+function registerRuntimeClientDeferralTests(): void {
   let logSpy: ReturnType<typeof vi.spyOn>
   let errorSpy: ReturnType<typeof vi.spyOn>
 
@@ -257,4 +258,6 @@ describe('RuntimeClient module-graph deferral', () => {
 
     expect(constructorArgsMock).toHaveBeenCalledTimes(1)
   })
-})
+}
+
+describe('RuntimeClient module-graph deferral', registerRuntimeClientDeferralTests)

--- a/src/cli/runtime-client-deferral.test.ts
+++ b/src/cli/runtime-client-deferral.test.ts
@@ -123,21 +123,22 @@ describe('RuntimeClient module-graph deferral', () => {
     expect(constructorArgsMock).not.toHaveBeenCalled()
   })
 
-  // Why: `agent hooks on|off` are the only commands that both sit in a
-  // suppressed group and touch ctx.client, and they rewrite the real ~/.claude
-  // hook config — so the byte-for-byte equivalence script cannot invoke them.
-  // Assert the constructor arguments directly instead: `null` (not `undefined`)
-  // is what stops the ORCA_* env fallback re-activating for local-only groups.
+  // Why: `agent hooks on|off` and `host list` sit in suppressed groups but still
+  // touch ctx.client. The former rewrites the real ~/.claude hook config, so the
+  // byte-for-byte equivalence script cannot invoke it. Assert the constructor
+  // arguments directly instead: `null` (not `undefined`) is what stops the
+  // ORCA_* env fallback re-activating for local-only groups.
   //
   // `constructs` is declared per case and asserted BEFORE the args, because
-  // only `agent hooks off` reads ctx.client. Looping over `mock.calls` alone
-  // would pass vacuously for the other four, and would keep passing if the one
-  // case that carries the null-vs-undefined coverage stopped constructing at
-  // all. The zero rows are not filler: they assert the deferral itself — a
-  // local-only group must reach its handler without building a client.
+  // only `agent hooks off` and `host list` read ctx.client. Looping over
+  // `mock.calls` alone would pass vacuously for the other four, and would keep
+  // passing if the cases that carry the null-vs-undefined coverage stopped
+  // constructing at all. The zero rows are not filler: they assert the deferral
+  // itself — a local-only group must reach its handler without building a client.
   const SUPPRESSED_GROUPS: [name: string, argv: string[], constructs: number][] = [
     ['agent', ['agent', 'hooks', 'off'], 1],
     ['environment', ['environment', 'list'], 0],
+    ['host', ['host', 'list'], 1],
     ['serve', ['serve'], 0],
     ['vm', ['vm', 'recipe', 'doctor'], 0],
     ['agent-context', ['agent-context'], 0]
@@ -175,7 +176,7 @@ describe('RuntimeClient module-graph deferral', () => {
     }
   )
 
-  // Why: four of the five groups above never read ctx.client, so they can only
+  // Why: four of the six groups above never read ctx.client, so they can only
   // assert that no client is built — not that suppression forwards `null`.
   // Stub dispatch and read the getter directly so every group asserts the
   // constructor arguments unconditionally, exactly once.


### PR DESCRIPTION
## ELI5

Two listing commands accepted a remote-machine flag but quietly returned this machine's data. They now stop with a clear error instead of giving a believable answer about the wrong host.

## What Changed

- Reject explicit `--environment` and `--pairing-code` on `orca environment list` and `orca host list`.
- Pin the `host` command family to local remote-selection suppression so rejection happens before eager selector resolution.
- Return `invalid_argument` before constructing or calling a runtime client.
- Add parameterized CLI boundary coverage for both commands and both remote selectors while retaining the existing no-selector positive controls.

## Why

These commands inspect connection metadata owned by the current Orca host; the flags cannot retarget that local store. Explicit rejection follows the existing `account` and `artifacts` pattern and prevents operators from acting on plausible local data when they named a remote runtime.

## Linked Issue

Fixes #18105

## Visual Proof

N/A

No visual change: this is CLI JSON/error behavior. Before the fix, all four routed cases returned `ok: true` local data. After the fix, they return `invalid_argument`, set exit code 1, and make no runtime RPC.

## Testing

Platform tested locally: Windows. The changed logic is platform-neutral TypeScript and does not touch paths, shells, UI, mobile, or transport code.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verification run from commit `ce12819560b32e8949f3e54e42737031e899549d`:

- Two focused Vitest suites: 32/32 passed, including an unresolvable `--environment` case that asserts no client construction.
- Full CLI `tsc --noEmit`: passed.
- Oxlint and React Doctor on both changed files: passed.
- `oxfmt --check`, `git diff --check`, and staged-secret scan: passed.
- JSDoc coverage remediation: documented the five touched functions across the five analyzed files; CodeRabbit re-check pending.

The changed-code wrapper reported zero ordinary findings, but its type-aware helper could not produce JSON because `oxlint-tsgolint` crashed on this Windows host with `0xc0000005`. Full CLI TypeScript checking passed; Linux CI remains authoritative for that native gate.

## AI Disclosure

OpenAI Codex (GPT-5 family; the exact serving deployment ID is not exposed) assisted with issue triage, implementation, regression tests, verification, and review. The submitted diff and evidence were inspected before publication.

## Review

- Cross-platform: no OS-specific API, path, shell, or line-ending behavior was added; Windows local checks passed and macOS/Linux remain covered by CI.
- SSH/remote/local: explicit unsupported selectors fail before client construction; no-selector local behavior and `--host` routing are unchanged.
- Agents/integrations/providers: provider-neutral CLI validation only; no agent or integration contract changed.
- Performance: at most two `Map.has` checks before local listing work; no hot-loop, I/O, or network cost added.
- Security: fails closed on ambiguous routing, performs no new input interpolation or logging, and adds no secret-bearing data flow.
- UI/mobile: not applicable.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No dependencies, lockfiles, generated files, release metadata, or unrelated refactors are included. Full repository `pnpm lint`, `pnpm test`, and `pnpm build` were not run locally; the focused gates above cover this CLI-only patch and the full suite is left to upstream CI.

## Author

- GitHub: @boyam01
- X: not provided

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
