### PR TITLE
feat(worktrees): attach existing worktrees to folder workspaces and nest them in the sidebar and board

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -158,7 +158,7 @@ function formatCommandFlagHelp(flag: string, commandPath: string[]): string {
   if (command === 'linear create' && flag === 'parent-current') {
     return '--parent-current      Use the current linked issue as parent'
   }
-  if (command === 'worktree create' && flag === 'parent-worktree') {
+  if ((command === 'worktree create' || command === 'worktree set') && flag === 'parent-worktree') {
     return '--parent-worktree <selector> Parent selector such as identity:<identity>, active/current, id:<repo-id>::<path>, branch:<branch>, issue:<number>, path:<path>, folder:<id>, or worktree:<worktreeId>'
   }
   if (command === 'orchestration task-create' && flag === 'task-title') {

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -561,7 +561,15 @@ describe('orca root help', () => {
 
     const setHelp = String(logSpy.mock.calls[0][0])
     expect(setHelp).not.toContain('--parent-workspace')
-    expect(setHelp).not.toContain('folder:<id>')
+    // Why: `worktree set` now accepts a folder workspace as --parent-worktree, but
+    // --worktree itself still names a git worktree only.
+    const setHelpLines = setHelp.split('\n')
+    expect(setHelpLines.find((line) => line.trim().startsWith('--parent-worktree'))).toContain(
+      'folder:<id>'
+    )
+    expect(setHelpLines.find((line) => line.trim().startsWith('--worktree'))).not.toContain(
+      'folder:<id>'
+    )
     expect(formatFlagHelp('parent-worktree')).toContain('identity:<identity>')
     expect(setHelp).not.toContain('worktree:<id>')
     expect(callMock).not.toHaveBeenCalled()

--- a/src/main/runtime/orca-runtime-create-managed-remote-worktree.ts
+++ b/src/main/runtime/orca-runtime-create-managed-remote-worktree.ts
@@ -162,6 +162,7 @@ export class OrcaRuntimeWithCreateManagedRemoteWorktree extends OrcaRuntimeWithC
       store: this.store,
       ports: {
         resolveWorktree: (selector) => this.resolveWorktreeSelector(selector),
+        resolveParent: (selector) => this.worktreeLineage.resolveParent(selector),
         validateParent: (worktree, parent) => this.worktreeLineage.validateParent(worktree, parent),
         invalidateResolved: () => this.invalidateResolvedWorktreeCache(),
         invalidateScan: (repoId) => this.invalidateWorktreeScanCacheForRepo(repoId),

--- a/src/main/runtime/runtime-managed-worktree-metadata.folder-store.test.ts
+++ b/src/main/runtime/runtime-managed-worktree-metadata.folder-store.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { ExecutionHostId } from '../../shared/execution-host'
+import type { Store } from '../persistence'
+import { createStore, makeRepo, makeWorktreeLineage, testState } from '../persistence-test-harness'
+import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
+import { updateRuntimeManagedWorktreeMetadata } from './runtime-managed-worktree-metadata'
+import { RuntimeWorktreeLineageController } from './runtime-worktree-lineage-controller'
+import type { ResolvedWorktree } from './runtime-worktree-path-identity'
+
+vi.mock('../telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('../ssh/ssh-config-parser', () => ({
+  loadUserSshConfig: vi.fn(() => []),
+  sshConfigHostsToTargets: vi.fn(() => [])
+}))
+
+let root: string
+const stores: Store[] = []
+
+function openStore(name: string): Store {
+  testState.dir = join(root, name)
+  mkdirSync(testState.dir, { recursive: true })
+  const store = createStore()
+  stores.push(store)
+  return store
+}
+
+function createFolder(store: Store, name: string, connectionId: string | null = null) {
+  const group = store.createProjectGroup({
+    name,
+    parentPath: join(root, 'workspace'),
+    createdFrom: 'folder-scan',
+    connectionId
+  })
+  return store.createFolderWorkspace({ projectGroupId: group.id, name, connectionId })
+}
+
+function child(store: Store, hostId: ExecutionHostId = 'local'): ResolvedWorktree {
+  const repo = makeRepo({ path: join(root, 'repo') })
+  store.addRepo(repo)
+  const id = `${repo.id}::${join(repo.path, 'child')}`
+  store.setWorktreeMetaForHost(id, hostId, { instanceId: 'child-instance', comment: 'unchanged' })
+  return {
+    id,
+    repoId: repo.id,
+    path: join(repo.path, 'child'),
+    hostId,
+    instanceId: 'child-instance'
+  } as ResolvedWorktree
+}
+
+function metadataRuntime(store: Store, worktree: ResolvedWorktree) {
+  // Store lookup/persistence are real; transport, Git discovery and UI notifications are outside this fixture.
+  const resolveWorktree = vi.fn(async () => worktree)
+  const lineage = new RuntimeWorktreeLineageController({
+    getStore: () => store,
+    getCachedWorktrees: () => [worktree],
+    getDb: () => null,
+    resolveWorktree,
+    listResolvedWorktrees: async () => [worktree],
+    showTerminal: async () => {
+      throw new Error('No terminal in this fixture')
+    }
+  })
+  return {
+    lineage,
+    attach: (parent: string) =>
+      updateRuntimeManagedWorktreeMetadata({
+        selector: `id:${worktree.id}`,
+        updates: { comment: 'attached', lineage: { parentWorktree: parent } },
+        store,
+        ports: {
+          resolveWorktree,
+          resolveParent: (selector) => lineage.resolveParent(selector),
+          validateParent: (target, parentWorktree) =>
+            lineage.validateParent(target, parentWorktree),
+          invalidateResolved: vi.fn(),
+          invalidateScan: vi.fn(),
+          notifyChanged: vi.fn(),
+          showWorktree: async () => worktree
+        }
+      })
+  }
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'orca-folder-lineage-'))
+})
+afterEach(() => {
+  for (const store of stores.splice(0)) {
+    store.freezeWrites()
+  }
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('folder attachment through the runtime store', () => {
+  it.each(['local', 'runtime:env-a', 'ssh:build-box'] as const)(
+    'attaches a persisted folder for a %s child without a renderer host stamp',
+    async (hostId) => {
+      const store = openStore('owner')
+      const folder = createFolder(store, 'Owner', hostId === 'ssh:build-box' ? 'build-box' : null)
+      const worktree = child(store, hostId)
+      store.setWorktreeLineage(worktree.id, makeWorktreeLineage({ worktreeId: worktree.id }))
+      expect(folder).not.toHaveProperty('executionHostId')
+      store.flush()
+      store.freezeWrites()
+
+      const restored = openStore('owner')
+      const runtime = metadataRuntime(restored, worktree)
+      const parent = await runtime.lineage.resolveParent(folderWorkspaceKey(folder.id))
+      expect(parent).toMatchObject({ type: 'folder', folderWorkspace: { id: folder.id } })
+      expect(parent.type === 'folder' && parent.folderWorkspace).not.toHaveProperty(
+        'executionHostId'
+      )
+      expect(restored.getWorktreeLineage(worktree.id)).toMatchObject({ worktreeId: worktree.id })
+      await runtime.attach(folderWorkspaceKey(folder.id))
+      expect(restored.getWorktreeLineage(worktree.id)).toBeUndefined()
+      expect(restored.getWorkspaceLineage(worktreeWorkspaceKey(worktree.id))).toMatchObject({
+        childInstanceId: 'child-instance',
+        parentWorkspaceKey: folderWorkspaceKey(folder.id),
+        origin: 'manual'
+      })
+      restored.flush()
+      restored.freezeWrites()
+      expect(
+        openStore('owner').getWorkspaceLineage(worktreeWorkspaceKey(worktree.id))
+      ).toMatchObject({
+        parentWorkspaceKey: folderWorkspaceKey(folder.id)
+      })
+    }
+  )
+
+  it('discards a renderer runtime stamp on load instead of treating it as folder authority', async () => {
+    const store = openStore('owner')
+    const folder = createFolder(store, 'Owner')
+    const worktree = child(store, 'runtime:env-a')
+    store.flush()
+    store.freezeWrites()
+    const file = join(root, 'owner', 'orca-data.json')
+    const saved = JSON.parse(readFileSync(file, 'utf8'))
+    saved.folderWorkspaces[0].executionHostId = 'runtime:env-b'
+    writeFileSync(file, JSON.stringify(saved))
+
+    const restored = openStore('owner')
+    expect(restored.getFolderWorkspaces()[0]).not.toHaveProperty('executionHostId')
+    await metadataRuntime(restored, worktree).attach(folderWorkspaceKey(folder.id))
+    expect(restored.getWorkspaceLineage(worktreeWorkspaceKey(worktree.id))).toMatchObject({
+      parentWorkspaceKey: folderWorkspaceKey(folder.id)
+    })
+  })
+
+  it('cannot attach a folder that exists only in another runtime store', async () => {
+    const owner = openStore('owner')
+    const worktree = child(owner, 'runtime:env-a')
+    const previous = makeWorktreeLineage({ worktreeId: worktree.id })
+    owner.setWorktreeLineage(worktree.id, previous)
+    const other = openStore('other')
+    const foreignFolder = createFolder(other, 'Other runtime')
+    const otherReads = vi.spyOn(other, 'getFolderWorkspaces')
+    const before = structuredClone(owner.getWorktreeMeta(worktree.id))
+    expect(before).toMatchObject({ comment: 'unchanged' })
+
+    await expect(
+      metadataRuntime(owner, worktree).attach(folderWorkspaceKey(foreignFolder.id))
+    ).rejects.toThrow('selector_not_found')
+    expect(owner.getWorktreeLineage(worktree.id)).toEqual(previous)
+    expect(owner.getWorktreeMeta(worktree.id)).toEqual(before)
+    expect(owner.getAllWorkspaceLineage()).toEqual({})
+    expect(other.getAllWorkspaceLineage()).toEqual({})
+    expect(otherReads).not.toHaveBeenCalled()
+  })
+
+  it('resolves a colliding folder id only in the selected runtime store', async () => {
+    const owner = openStore('owner')
+    const folder = createFolder(owner, 'Owner folder')
+    const worktree = child(owner, 'runtime:env-a')
+    owner.flush()
+    mkdirSync(join(root, 'other'), { recursive: true })
+    writeFileSync(
+      join(root, 'other', 'orca-data.json'),
+      readFileSync(join(root, 'owner', 'orca-data.json'))
+    )
+    const other = openStore('other')
+    other.updateFolderWorkspace(folder.id, { name: 'Other folder' })
+    const runtime = metadataRuntime(owner, worktree)
+
+    expect(await runtime.lineage.resolveParent(folderWorkspaceKey(folder.id))).toMatchObject({
+      folderWorkspace: { name: 'Owner folder' }
+    })
+    await runtime.attach(folderWorkspaceKey(folder.id))
+    expect(owner.getWorkspaceLineage(worktreeWorkspaceKey(worktree.id))).toMatchObject({
+      parentWorkspaceKey: folderWorkspaceKey(folder.id)
+    })
+    expect(other.getAllWorkspaceLineage()).toEqual({})
+    expect(other.getFolderWorkspaces()[0].name).toBe('Other folder')
+  })
+
+  it('still rejects an SSH folder for a runtime-local child without changing metadata or lineage', async () => {
+    const store = openStore('owner')
+    const folder = createFolder(store, 'SSH folder', 'build-box')
+    const worktree = child(store, 'runtime:env-a')
+    const previous = makeWorktreeLineage({ worktreeId: worktree.id })
+    store.setWorktreeLineage(worktree.id, previous)
+    const before = structuredClone(store.getWorktreeMeta(worktree.id))
+    expect(before).toMatchObject({ comment: 'unchanged' })
+
+    await expect(
+      metadataRuntime(store, worktree).attach(folderWorkspaceKey(folder.id))
+    ).rejects.toMatchObject({ code: 'LINEAGE_PARENT_CONTEXT_CONFLICT' })
+    expect(store.getWorktreeLineage(worktree.id)).toEqual(previous)
+    expect(store.getWorktreeMeta(worktree.id)).toEqual(before)
+    expect(store.getAllWorkspaceLineage()).toEqual({})
+  })
+})

--- a/src/main/runtime/runtime-managed-worktree-metadata.test.ts
+++ b/src/main/runtime/runtime-managed-worktree-metadata.test.ts
@@ -1,40 +1,132 @@
 import { describe, expect, it, vi } from 'vitest'
+import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { Worktree } from '../../shared/worktree/types'
+import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import { updateRuntimeManagedWorktreeMetadata } from './runtime-managed-worktree-metadata'
+import type { ResolvedWorkspaceParent } from './runtime-worktree-lineage-resolution'
 import type { ResolvedWorktree } from './runtime-worktree-path-identity'
 import type { RuntimeStore } from './runtime-store-contract'
 
+function makeWorktree(overrides: Partial<ResolvedWorktree> = {}): ResolvedWorktree {
+  return {
+    id: 'repo-1::/workspace/app',
+    repoId: 'repo-1',
+    hostId: 'local',
+    path: '/workspace/app',
+    instanceId: 'instance-1',
+    ...overrides
+  } as unknown as ResolvedWorktree
+}
+
+function makeFolderParent(overrides: Partial<FolderWorkspace> = {}): ResolvedWorkspaceParent {
+  const folderWorkspace = {
+    id: 'fw-1',
+    projectGroupId: 'group-1',
+    name: 'Ticket workspace',
+    folderPath: '/workspace',
+    connectionId: null,
+    linkedTask: null,
+    ...overrides
+  } as unknown as FolderWorkspace
+  return {
+    type: 'folder',
+    workspaceKey: folderWorkspaceKey(folderWorkspace.id),
+    folderWorkspace,
+    instanceId: null
+  }
+}
+
+function makePorts(worktree: ResolvedWorktree, parent?: ResolvedWorkspaceParent) {
+  return {
+    resolveWorktree: vi.fn(async () => worktree),
+    resolveParent: vi.fn(async () => {
+      if (!parent) {
+        throw new Error('selector_not_found')
+      }
+      return parent
+    }),
+    validateParent: vi.fn(),
+    invalidateResolved: vi.fn(),
+    invalidateScan: vi.fn(),
+    notifyChanged: vi.fn(),
+    showWorktree: vi.fn(async () => worktree as unknown as Worktree)
+  }
+}
+
 describe('updateRuntimeManagedWorktreeMetadata', () => {
   it('writes metadata through the resolved worktree execution host', async () => {
-    const worktree = {
-      id: 'repo-1::/workspace/app',
-      repoId: 'repo-1',
-      hostId: 'ssh:build-box',
-      path: '/workspace/app',
-      instanceId: 'instance-1'
-    } as unknown as ResolvedWorktree
+    const worktree = makeWorktree({ hostId: 'ssh:build-box' })
     const setWorktreeMeta = vi.fn()
     const setWorktreeMetaForHost = vi.fn()
     const store = { setWorktreeMeta, setWorktreeMetaForHost } as unknown as RuntimeStore
-    const ports = {
-      resolveWorktree: vi.fn(async () => worktree),
-      validateParent: vi.fn(),
-      invalidateResolved: vi.fn(),
-      invalidateScan: vi.fn(),
-      notifyChanged: vi.fn(),
-      showWorktree: vi.fn(async () => worktree as unknown as Worktree)
-    }
 
     await updateRuntimeManagedWorktreeMetadata({
       selector: `id:${worktree.id}`,
       updates: { comment: 'remote row only' },
       store,
-      ports
+      ports: makePorts(worktree)
     })
 
     expect(setWorktreeMetaForHost).toHaveBeenCalledWith(worktree.id, 'ssh:build-box', {
       comment: 'remote row only'
     })
     expect(setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('attaches a worktree to a folder workspace parent through workspace lineage only', async () => {
+    const worktree = makeWorktree()
+    const store = {
+      setWorktreeMeta: vi.fn(),
+      setWorktreeLineage: vi.fn(),
+      removeWorktreeLineage: vi.fn(),
+      setWorkspaceLineage: vi.fn()
+    } as unknown as RuntimeStore
+    const ports = makePorts(worktree, makeFolderParent())
+
+    await updateRuntimeManagedWorktreeMetadata({
+      selector: `id:${worktree.id}`,
+      updates: { lineage: { parentWorktree: 'folder:fw-1' } },
+      store,
+      ports
+    })
+
+    expect(store.setWorkspaceLineage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childWorkspaceKey: worktreeWorkspaceKey(worktree.id),
+        childInstanceId: 'instance-1',
+        parentWorkspaceKey: 'folder:fw-1',
+        parentInstanceId: null,
+        origin: 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' }
+      })
+    )
+    // A folder parent replaces any worktree parent; no worktree-lineage row remains.
+    expect(store.removeWorktreeLineage).toHaveBeenCalledWith(worktree.id)
+    expect(store.setWorktreeLineage).not.toHaveBeenCalled()
+    expect(ports.validateParent).not.toHaveBeenCalled()
+    expect(ports.notifyChanged).toHaveBeenCalledWith('repo-1')
+  })
+
+  it('rejects a folder workspace parent on a different execution host', async () => {
+    const worktree = makeWorktree({ hostId: 'ssh:build-box' })
+    const store = {
+      setWorktreeMeta: vi.fn(),
+      setWorktreeMetaForHost: vi.fn(),
+      setWorktreeLineage: vi.fn(),
+      removeWorktreeLineage: vi.fn(),
+      setWorkspaceLineage: vi.fn()
+    } as unknown as RuntimeStore
+
+    await expect(
+      updateRuntimeManagedWorktreeMetadata({
+        selector: `id:${worktree.id}`,
+        updates: { lineage: { parentWorktree: 'folder:fw-1' } },
+        store,
+        ports: makePorts(worktree, makeFolderParent())
+      })
+    ).rejects.toMatchObject({ code: 'LINEAGE_PARENT_CONTEXT_CONFLICT' })
+
+    expect(store.setWorkspaceLineage).not.toHaveBeenCalled()
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
   })
 })

--- a/src/main/runtime/runtime-managed-worktree-metadata.test.ts
+++ b/src/main/runtime/runtime-managed-worktree-metadata.test.ts
@@ -130,22 +130,6 @@ describe('updateRuntimeManagedWorktreeMetadata', () => {
     )
   })
 
-  it('attaches a runtime-hosted worktree to a folder workspace in the same runtime environment', async () => {
-    const worktree = makeWorktree({ hostId: 'runtime:env-a' })
-    const store = makeStore()
-
-    await updateRuntimeManagedWorktreeMetadata({
-      selector: `id:${worktree.id}`,
-      updates: { lineage: { parentWorktree: 'folder:fw-1' } },
-      store,
-      ports: makePorts(worktree, makeFolderParent({ executionHostId: 'runtime:env-a' }))
-    })
-
-    expect(store.setWorkspaceLineage).toHaveBeenCalledWith(
-      expect.objectContaining({ parentWorkspaceKey: 'folder:fw-1' })
-    )
-  })
-
   it('attaches an ssh worktree to a folder workspace on the same ssh target', async () => {
     const worktree = makeWorktree({ hostId: 'ssh:build-box' })
     const store = makeStore()
@@ -189,22 +173,6 @@ describe('updateRuntimeManagedWorktreeMetadata', () => {
         updates: { lineage: { parentWorktree: 'folder:fw-1' } },
         store,
         ports: makePorts(worktree, makeFolderParent({ connectionId: 'other-box' }))
-      })
-    ).rejects.toMatchObject({ code: 'LINEAGE_PARENT_CONTEXT_CONFLICT' })
-
-    expect(store.setWorkspaceLineage).not.toHaveBeenCalled()
-  })
-
-  it('rejects a folder workspace parent in a different runtime environment', async () => {
-    const worktree = makeWorktree({ hostId: 'runtime:env-a' })
-    const store = makeStore()
-
-    await expect(
-      updateRuntimeManagedWorktreeMetadata({
-        selector: `id:${worktree.id}`,
-        updates: { lineage: { parentWorktree: 'folder:fw-1' } },
-        store,
-        ports: makePorts(worktree, makeFolderParent({ executionHostId: 'runtime:env-b' }))
       })
     ).rejects.toMatchObject({ code: 'LINEAGE_PARENT_CONTEXT_CONFLICT' })
 

--- a/src/main/runtime/runtime-managed-worktree-metadata.test.ts
+++ b/src/main/runtime/runtime-managed-worktree-metadata.test.ts
@@ -36,6 +36,18 @@ function makeFolderParent(overrides: Partial<FolderWorkspace> = {}): ResolvedWor
   }
 }
 
+function makeStore(): RuntimeStore {
+  return {
+    getRepos: vi.fn(() => []),
+    getProjectGroups: vi.fn(() => []),
+    setWorktreeMeta: vi.fn(),
+    setWorktreeMetaForHost: vi.fn(),
+    setWorktreeLineage: vi.fn(),
+    removeWorktreeLineage: vi.fn(),
+    setWorkspaceLineage: vi.fn()
+  } as unknown as RuntimeStore
+}
+
 function makePorts(worktree: ResolvedWorktree, parent?: ResolvedWorkspaceParent) {
   return {
     resolveWorktree: vi.fn(async () => worktree),
@@ -56,9 +68,7 @@ function makePorts(worktree: ResolvedWorktree, parent?: ResolvedWorkspaceParent)
 describe('updateRuntimeManagedWorktreeMetadata', () => {
   it('writes metadata through the resolved worktree execution host', async () => {
     const worktree = makeWorktree({ hostId: 'ssh:build-box' })
-    const setWorktreeMeta = vi.fn()
-    const setWorktreeMetaForHost = vi.fn()
-    const store = { setWorktreeMeta, setWorktreeMetaForHost } as unknown as RuntimeStore
+    const store = makeStore()
 
     await updateRuntimeManagedWorktreeMetadata({
       selector: `id:${worktree.id}`,
@@ -67,20 +77,15 @@ describe('updateRuntimeManagedWorktreeMetadata', () => {
       ports: makePorts(worktree)
     })
 
-    expect(setWorktreeMetaForHost).toHaveBeenCalledWith(worktree.id, 'ssh:build-box', {
+    expect(store.setWorktreeMetaForHost).toHaveBeenCalledWith(worktree.id, 'ssh:build-box', {
       comment: 'remote row only'
     })
-    expect(setWorktreeMeta).not.toHaveBeenCalled()
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
   })
 
   it('attaches a worktree to a folder workspace parent through workspace lineage only', async () => {
     const worktree = makeWorktree()
-    const store = {
-      setWorktreeMeta: vi.fn(),
-      setWorktreeLineage: vi.fn(),
-      removeWorktreeLineage: vi.fn(),
-      setWorkspaceLineage: vi.fn()
-    } as unknown as RuntimeStore
+    const store = makeStore()
     const ports = makePorts(worktree, makeFolderParent())
 
     await updateRuntimeManagedWorktreeMetadata({
@@ -107,15 +112,43 @@ describe('updateRuntimeManagedWorktreeMetadata', () => {
     expect(ports.notifyChanged).toHaveBeenCalledWith('repo-1')
   })
 
+  it('attaches a runtime-hosted worktree to a local folder workspace', async () => {
+    // A runtime environment's own server is local to the work it runs, so the
+    // folder's `local` answer is the same host the worktree reports.
+    const worktree = makeWorktree({ hostId: 'runtime:env-1' })
+    const store = makeStore()
+
+    await updateRuntimeManagedWorktreeMetadata({
+      selector: `id:${worktree.id}`,
+      updates: { lineage: { parentWorktree: 'folder:fw-1' } },
+      store,
+      ports: makePorts(worktree, makeFolderParent())
+    })
+
+    expect(store.setWorkspaceLineage).toHaveBeenCalledWith(
+      expect.objectContaining({ parentWorkspaceKey: 'folder:fw-1' })
+    )
+  })
+
+  it('attaches an ssh worktree to a folder workspace on the same ssh target', async () => {
+    const worktree = makeWorktree({ hostId: 'ssh:build-box' })
+    const store = makeStore()
+
+    await updateRuntimeManagedWorktreeMetadata({
+      selector: `id:${worktree.id}`,
+      updates: { lineage: { parentWorktree: 'folder:fw-1' } },
+      store,
+      ports: makePorts(worktree, makeFolderParent({ connectionId: 'build-box' }))
+    })
+
+    expect(store.setWorkspaceLineage).toHaveBeenCalledWith(
+      expect.objectContaining({ parentWorkspaceKey: 'folder:fw-1' })
+    )
+  })
+
   it('rejects a folder workspace parent on a different execution host', async () => {
     const worktree = makeWorktree({ hostId: 'ssh:build-box' })
-    const store = {
-      setWorktreeMeta: vi.fn(),
-      setWorktreeMetaForHost: vi.fn(),
-      setWorktreeLineage: vi.fn(),
-      removeWorktreeLineage: vi.fn(),
-      setWorkspaceLineage: vi.fn()
-    } as unknown as RuntimeStore
+    const store = makeStore()
 
     await expect(
       updateRuntimeManagedWorktreeMetadata({
@@ -128,5 +161,21 @@ describe('updateRuntimeManagedWorktreeMetadata', () => {
 
     expect(store.setWorkspaceLineage).not.toHaveBeenCalled()
     expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+  })
+
+  it('rejects a folder workspace parent on a different ssh target', async () => {
+    const worktree = makeWorktree({ hostId: 'ssh:build-box' })
+    const store = makeStore()
+
+    await expect(
+      updateRuntimeManagedWorktreeMetadata({
+        selector: `id:${worktree.id}`,
+        updates: { lineage: { parentWorktree: 'folder:fw-1' } },
+        store,
+        ports: makePorts(worktree, makeFolderParent({ connectionId: 'other-box' }))
+      })
+    ).rejects.toMatchObject({ code: 'LINEAGE_PARENT_CONTEXT_CONFLICT' })
+
+    expect(store.setWorkspaceLineage).not.toHaveBeenCalled()
   })
 })

--- a/src/main/runtime/runtime-managed-worktree-metadata.test.ts
+++ b/src/main/runtime/runtime-managed-worktree-metadata.test.ts
@@ -130,6 +130,22 @@ describe('updateRuntimeManagedWorktreeMetadata', () => {
     )
   })
 
+  it('attaches a runtime-hosted worktree to a folder workspace in the same runtime environment', async () => {
+    const worktree = makeWorktree({ hostId: 'runtime:env-a' })
+    const store = makeStore()
+
+    await updateRuntimeManagedWorktreeMetadata({
+      selector: `id:${worktree.id}`,
+      updates: { lineage: { parentWorktree: 'folder:fw-1' } },
+      store,
+      ports: makePorts(worktree, makeFolderParent({ executionHostId: 'runtime:env-a' }))
+    })
+
+    expect(store.setWorkspaceLineage).toHaveBeenCalledWith(
+      expect.objectContaining({ parentWorkspaceKey: 'folder:fw-1' })
+    )
+  })
+
   it('attaches an ssh worktree to a folder workspace on the same ssh target', async () => {
     const worktree = makeWorktree({ hostId: 'ssh:build-box' })
     const store = makeStore()
@@ -173,6 +189,38 @@ describe('updateRuntimeManagedWorktreeMetadata', () => {
         updates: { lineage: { parentWorktree: 'folder:fw-1' } },
         store,
         ports: makePorts(worktree, makeFolderParent({ connectionId: 'other-box' }))
+      })
+    ).rejects.toMatchObject({ code: 'LINEAGE_PARENT_CONTEXT_CONFLICT' })
+
+    expect(store.setWorkspaceLineage).not.toHaveBeenCalled()
+  })
+
+  it('rejects a folder workspace parent in a different runtime environment', async () => {
+    const worktree = makeWorktree({ hostId: 'runtime:env-a' })
+    const store = makeStore()
+
+    await expect(
+      updateRuntimeManagedWorktreeMetadata({
+        selector: `id:${worktree.id}`,
+        updates: { lineage: { parentWorktree: 'folder:fw-1' } },
+        store,
+        ports: makePorts(worktree, makeFolderParent({ executionHostId: 'runtime:env-b' }))
+      })
+    ).rejects.toMatchObject({ code: 'LINEAGE_PARENT_CONTEXT_CONFLICT' })
+
+    expect(store.setWorkspaceLineage).not.toHaveBeenCalled()
+  })
+
+  it('rejects an ssh folder workspace parent for a runtime-hosted worktree', async () => {
+    const worktree = makeWorktree({ hostId: 'runtime:env-a' })
+    const store = makeStore()
+
+    await expect(
+      updateRuntimeManagedWorktreeMetadata({
+        selector: `id:${worktree.id}`,
+        updates: { lineage: { parentWorktree: 'folder:fw-1' } },
+        store,
+        ports: makePorts(worktree, makeFolderParent({ connectionId: 'build-box' }))
       })
     ).rejects.toMatchObject({ code: 'LINEAGE_PARENT_CONTEXT_CONFLICT' })
 

--- a/src/main/runtime/runtime-managed-worktree-metadata.ts
+++ b/src/main/runtime/runtime-managed-worktree-metadata.ts
@@ -3,9 +3,14 @@ import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import { splitWorktreeId } from '../../shared/worktree/id'
 import { planWorktreeSortOrderUpdates } from '../../shared/worktree/sort-order-update'
+import { folderWorkspaceToWorktree } from '../../shared/folder-workspace-worktree'
+import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { stripOrcaProvenanceMetaUpdates } from '../worktree-removal-safety'
 import type { RuntimeStore } from './runtime-store-contract'
-import { RuntimeLineageError } from './runtime-worktree-lineage-resolution'
+import {
+  RuntimeLineageError,
+  type ResolvedWorkspaceParent
+} from './runtime-worktree-lineage-resolution'
 import type { ResolvedWorktree } from './runtime-worktree-path-identity'
 
 type Updates = Omit<Partial<WorktreeMeta>, 'pushTarget'> & {
@@ -15,6 +20,7 @@ type Updates = Omit<Partial<WorktreeMeta>, 'pushTarget'> & {
 
 type Ports = {
   resolveWorktree: (selector: string) => Promise<ResolvedWorktree>
+  resolveParent: (selector: string) => Promise<ResolvedWorkspaceParent>
   validateParent: (worktree: ResolvedWorktree, parent: ResolvedWorktree) => void
   invalidateResolved: () => void
   invalidateScan: (repoId: string) => void
@@ -55,39 +61,76 @@ export async function updateRuntimeManagedWorktreeMetadata(args: {
     args.store.removeWorktreeLineage?.(worktree.id)
     args.store.removeWorkspaceLineage?.(worktreeWorkspaceKey(worktree.id))
   } else if (lineage?.parentWorktree) {
-    const parent = await args.ports.resolveWorktree(lineage.parentWorktree)
-    args.ports.validateParent(worktree, parent)
-    if (!worktree.instanceId || !parent.instanceId) {
-      throw new RuntimeLineageError(
-        'LINEAGE_PARENT_CONTEXT_MISSING',
-        'Worktree instance identity was unavailable.'
-      )
+    const parent = await args.ports.resolveParent(lineage.parentWorktree)
+    if (parent.type === 'folder') {
+      // Why: a folder workspace has no repo or project, so the worktree boundary
+      // rules do not apply — but the hosts must match, or the folder view could
+      // never show the row it now claims.
+      const worktreeHostId =
+        worktree.identity?.executionHostId ?? worktree.hostId ?? LOCAL_EXECUTION_HOST_ID
+      if (worktreeHostId !== folderWorkspaceToWorktree(parent.folderWorkspace).hostId) {
+        throw new RuntimeLineageError(
+          'LINEAGE_PARENT_CONTEXT_CONFLICT',
+          'Parent folder workspace must belong to the same execution host.'
+        )
+      }
+      if (!worktree.instanceId) {
+        throw new RuntimeLineageError(
+          'LINEAGE_PARENT_CONTEXT_MISSING',
+          'Worktree instance identity was unavailable.'
+        )
+      }
+      if (!args.store.setWorkspaceLineage) {
+        throw new RuntimeLineageError(
+          'LINEAGE_PARENT_CONTEXT_MISSING',
+          'Workspace lineage storage was unavailable.'
+        )
+      }
+      // A folder parent replaces any worktree parent: workspace lineage is the only edge.
+      args.store.removeWorktreeLineage?.(worktree.id)
+      args.store.setWorkspaceLineage({
+        childWorkspaceKey: worktreeWorkspaceKey(worktree.id),
+        childInstanceId: worktree.instanceId,
+        parentWorkspaceKey: parent.workspaceKey,
+        parentInstanceId: parent.instanceId,
+        origin: 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' },
+        createdAt: Date.now()
+      })
+    } else {
+      args.ports.validateParent(worktree, parent.worktree)
+      if (!worktree.instanceId || !parent.instanceId) {
+        throw new RuntimeLineageError(
+          'LINEAGE_PARENT_CONTEXT_MISSING',
+          'Worktree instance identity was unavailable.'
+        )
+      }
+      if (!args.store.setWorktreeLineage) {
+        throw new RuntimeLineageError(
+          'LINEAGE_PARENT_CONTEXT_MISSING',
+          'Worktree lineage storage was unavailable.'
+        )
+      }
+      const createdAt = Date.now()
+      args.store.setWorktreeLineage(worktree.id, {
+        worktreeId: worktree.id,
+        worktreeInstanceId: worktree.instanceId,
+        parentWorktreeId: parent.worktree.id,
+        parentWorktreeInstanceId: parent.instanceId,
+        origin: 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' },
+        createdAt
+      })
+      args.store.setWorkspaceLineage?.({
+        childWorkspaceKey: worktreeWorkspaceKey(worktree.id),
+        childInstanceId: worktree.instanceId,
+        parentWorkspaceKey: parent.workspaceKey,
+        parentInstanceId: parent.instanceId,
+        origin: 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' },
+        createdAt
+      })
     }
-    if (!args.store.setWorktreeLineage) {
-      throw new RuntimeLineageError(
-        'LINEAGE_PARENT_CONTEXT_MISSING',
-        'Worktree lineage storage was unavailable.'
-      )
-    }
-    const createdAt = Date.now()
-    args.store.setWorktreeLineage(worktree.id, {
-      worktreeId: worktree.id,
-      worktreeInstanceId: worktree.instanceId,
-      parentWorktreeId: parent.id,
-      parentWorktreeInstanceId: parent.instanceId,
-      origin: 'manual',
-      capture: { source: 'manual-action', confidence: 'explicit' },
-      createdAt
-    })
-    args.store.setWorkspaceLineage?.({
-      childWorkspaceKey: worktreeWorkspaceKey(worktree.id),
-      childInstanceId: worktree.instanceId,
-      parentWorkspaceKey: worktreeWorkspaceKey(parent.id),
-      parentInstanceId: parent.instanceId,
-      origin: 'manual',
-      capture: { source: 'manual-action', confidence: 'explicit' },
-      createdAt
-    })
   }
   const metadataUpdates = stripOrcaProvenanceMetaUpdates(persisted)
   const executionHostId = worktree.identity?.executionHostId ?? worktree.hostId

--- a/src/main/runtime/runtime-managed-worktree-metadata.ts
+++ b/src/main/runtime/runtime-managed-worktree-metadata.ts
@@ -1,3 +1,4 @@
+import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { GitPushTarget, Worktree } from '../../shared/worktree/types'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
@@ -78,6 +79,7 @@ export async function updateRuntimeManagedWorktreeMetadata(args: {
           },
           parent.folderWorkspace.id
         ),
+        parent.folderWorkspace,
         worktree
       )
       if (hostConflict) {
@@ -162,9 +164,16 @@ export async function updateRuntimeManagedWorktreeMetadata(args: {
  * comparison rejects every worktree on a `runtime:` host. Both sides are therefore reduced to the
  * level `resolveFolderWorkspaceHost` answers at, where `local` and `runtime:` are the same answer
  * because a runtime environment's own server is local to the work it runs.
+ *
+ * A folder that does carry the stamp is what that reduction loses: it flattens every
+ * `runtime:<environment>` to `local`, so two different environments compared equal and a
+ * cross-runtime attach was persisted. Only `executionHostId` can name an environment — a
+ * `connectionId` beside it is an SSH target nested inside that environment, not a host this client
+ * addresses — so the stamp is read off the record itself, and a folder carrying none stays local.
  */
 function describeFolderParentHostConflict(
   folderHost: FolderWorkspaceHost,
+  folderWorkspace: FolderWorkspace,
   worktree: ResolvedWorktree
 ): string | null {
   if (folderHost.kind === 'missing') {
@@ -176,6 +185,12 @@ function describeFolderParentHostConflict(
   const worktreeHost = parseExecutionHostId(
     worktree.identity?.executionHostId ?? worktree.hostId ?? LOCAL_EXECUTION_HOST_ID
   )
+  const stampedFolderHost = parseExecutionHostId(folderWorkspace.executionHostId)
+  if (worktreeHost?.kind === 'runtime' && stampedFolderHost?.kind === 'runtime') {
+    return worktreeHost.environmentId === stampedFolderHost.environmentId
+      ? null
+      : 'Parent folder workspace must belong to the same runtime environment.'
+  }
   const worktreeTargetId = worktreeHost?.kind === 'ssh' ? worktreeHost.targetId : null
   const folderTargetId = folderHost.kind === 'ssh' ? folderHost.targetId : null
   return worktreeTargetId === folderTargetId

--- a/src/main/runtime/runtime-managed-worktree-metadata.ts
+++ b/src/main/runtime/runtime-managed-worktree-metadata.ts
@@ -1,4 +1,3 @@
-import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { GitPushTarget, Worktree } from '../../shared/worktree/types'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
@@ -79,7 +78,6 @@ export async function updateRuntimeManagedWorktreeMetadata(args: {
           },
           parent.folderWorkspace.id
         ),
-        parent.folderWorkspace,
         worktree
       )
       if (hostConflict) {
@@ -156,24 +154,10 @@ export async function updateRuntimeManagedWorktreeMetadata(args: {
   return args.ports.showWorktree(`id:${worktree.id}`)
 }
 
-/**
- * The reason a worktree may not hang off this folder workspace, or `null` when it may.
- *
- * Why resolve rather than compare projected host ids: a FolderWorkspace persists only its
- * `connectionId` on this side — `executionHostId` is a renderer-owned stamp — so a projected
- * comparison rejects every worktree on a `runtime:` host. Both sides are therefore reduced to the
- * level `resolveFolderWorkspaceHost` answers at, where `local` and `runtime:` are the same answer
- * because a runtime environment's own server is local to the work it runs.
- *
- * A folder that does carry the stamp is what that reduction loses: it flattens every
- * `runtime:<environment>` to `local`, so two different environments compared equal and a
- * cross-runtime attach was persisted. Only `executionHostId` can name an environment — a
- * `connectionId` beside it is an SSH target nested inside that environment, not a host this client
- * addresses — so the stamp is read off the record itself, and a folder carrying none stays local.
- */
+// Folder lookup is scoped to this runtime's store, which persists connectionId, not renderer
+// runtime stamps. Compare local/SSH ownership here; this runtime's local/runtime aliases agree.
 function describeFolderParentHostConflict(
   folderHost: FolderWorkspaceHost,
-  folderWorkspace: FolderWorkspace,
   worktree: ResolvedWorktree
 ): string | null {
   if (folderHost.kind === 'missing') {
@@ -185,12 +169,6 @@ function describeFolderParentHostConflict(
   const worktreeHost = parseExecutionHostId(
     worktree.identity?.executionHostId ?? worktree.hostId ?? LOCAL_EXECUTION_HOST_ID
   )
-  const stampedFolderHost = parseExecutionHostId(folderWorkspace.executionHostId)
-  if (worktreeHost?.kind === 'runtime' && stampedFolderHost?.kind === 'runtime') {
-    return worktreeHost.environmentId === stampedFolderHost.environmentId
-      ? null
-      : 'Parent folder workspace must belong to the same runtime environment.'
-  }
   const worktreeTargetId = worktreeHost?.kind === 'ssh' ? worktreeHost.targetId : null
   const folderTargetId = folderHost.kind === 'ssh' ? folderHost.targetId : null
   return worktreeTargetId === folderTargetId

--- a/src/main/runtime/runtime-managed-worktree-metadata.ts
+++ b/src/main/runtime/runtime-managed-worktree-metadata.ts
@@ -3,8 +3,11 @@ import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import { splitWorktreeId } from '../../shared/worktree/id'
 import { planWorktreeSortOrderUpdates } from '../../shared/worktree/sort-order-update'
-import { folderWorkspaceToWorktree } from '../../shared/folder-workspace-worktree'
-import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
+import {
+  resolveFolderWorkspaceHost,
+  type FolderWorkspaceHost
+} from '../../shared/folder-workspace-execution-host'
+import { LOCAL_EXECUTION_HOST_ID, parseExecutionHostId } from '../../shared/execution-host'
 import { stripOrcaProvenanceMetaUpdates } from '../worktree-removal-safety'
 import type { RuntimeStore } from './runtime-store-contract'
 import {
@@ -66,13 +69,19 @@ export async function updateRuntimeManagedWorktreeMetadata(args: {
       // Why: a folder workspace has no repo or project, so the worktree boundary
       // rules do not apply — but the hosts must match, or the folder view could
       // never show the row it now claims.
-      const worktreeHostId =
-        worktree.identity?.executionHostId ?? worktree.hostId ?? LOCAL_EXECUTION_HOST_ID
-      if (worktreeHostId !== folderWorkspaceToWorktree(parent.folderWorkspace).hostId) {
-        throw new RuntimeLineageError(
-          'LINEAGE_PARENT_CONTEXT_CONFLICT',
-          'Parent folder workspace must belong to the same execution host.'
-        )
+      const hostConflict = describeFolderParentHostConflict(
+        resolveFolderWorkspaceHost(
+          {
+            folderWorkspaces: [parent.folderWorkspace],
+            projectGroups: args.store.getProjectGroups?.() ?? [],
+            repos: args.store.getRepos()
+          },
+          parent.folderWorkspace.id
+        ),
+        worktree
+      )
+      if (hostConflict) {
+        throw new RuntimeLineageError('LINEAGE_PARENT_CONTEXT_CONFLICT', hostConflict)
       }
       if (!worktree.instanceId) {
         throw new RuntimeLineageError(
@@ -143,6 +152,35 @@ export async function updateRuntimeManagedWorktreeMetadata(args: {
   args.ports.invalidateResolved()
   args.ports.notifyChanged(worktree.repoId)
   return args.ports.showWorktree(`id:${worktree.id}`)
+}
+
+/**
+ * The reason a worktree may not hang off this folder workspace, or `null` when it may.
+ *
+ * Why resolve rather than compare projected host ids: a FolderWorkspace persists only its
+ * `connectionId` on this side — `executionHostId` is a renderer-owned stamp — so a projected
+ * comparison rejects every worktree on a `runtime:` host. Both sides are therefore reduced to the
+ * level `resolveFolderWorkspaceHost` answers at, where `local` and `runtime:` are the same answer
+ * because a runtime environment's own server is local to the work it runs.
+ */
+function describeFolderParentHostConflict(
+  folderHost: FolderWorkspaceHost,
+  worktree: ResolvedWorktree
+): string | null {
+  if (folderHost.kind === 'missing') {
+    return 'Parent folder workspace could not be resolved to an execution host.'
+  }
+  if (folderHost.kind === 'ambiguous') {
+    return 'Parent folder workspace spans more than one execution host.'
+  }
+  const worktreeHost = parseExecutionHostId(
+    worktree.identity?.executionHostId ?? worktree.hostId ?? LOCAL_EXECUTION_HOST_ID
+  )
+  const worktreeTargetId = worktreeHost?.kind === 'ssh' ? worktreeHost.targetId : null
+  const folderTargetId = folderHost.kind === 'ssh' ? folderHost.targetId : null
+  return worktreeTargetId === folderTargetId
+    ? null
+    : 'Parent folder workspace must belong to the same execution host.'
 }
 
 export function persistRuntimeManagedWorktreeSortOrder(args: {

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.search.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.search.test.tsx
@@ -10,6 +10,8 @@ import type { WorktreeMeta } from '../../../../shared/worktree/meta-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import type { WorktreeMetaBatchUpdate } from '../../store/slices/worktree-helpers'
 import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
+import type { WorkspaceLineage } from '../../../../shared/worktree/lineage-types'
+import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
 import WorkspaceKanbanDrawer from './WorkspaceKanbanDrawer'
 import type { WorkspaceKanbanLaneView } from './workspace-kanban-search'
 
@@ -252,7 +254,9 @@ beforeEach(() => {
     updateWorktreeMeta: vi.fn(),
     updateWorktreesMeta,
     getKnownWorktreeById: (id: string) => allWorktrees.find((item) => item.id === id),
-    recordFeatureInteraction: vi.fn()
+    recordFeatureInteraction: vi.fn(),
+    folderWorkspaces: [],
+    workspaceLineageByChildKey: {}
   })
 })
 
@@ -276,6 +280,44 @@ describe('WorkspaceKanbanDrawer search', () => {
     expect(gridState.current?.laneViews.get('todo')?.totalCount).toBe(4)
     expect(gridState.current?.laneViews.get('in-review')?.totalCount).toBe(1)
     expect(headerState.current).toMatchObject({ matchCount: 1, totalCount: 5 })
+  })
+
+  it('lays out folder workspaces as cards and folds their attached worktrees into them', () => {
+    useAppStore.setState({
+      folderWorkspaces: [
+        {
+          id: 'fw-1',
+          projectGroupId: 'group-1',
+          name: 'API-123 : Fix checkout',
+          folderPath: '/tickets/API-123',
+          linkedTask: null,
+          comment: '',
+          isArchived: false,
+          isUnread: false,
+          isPinned: false,
+          sortOrder: 1,
+          lastActivityAt: 1,
+          createdAt: 1,
+          updatedAt: 1,
+          workspaceStatus: 'in-review'
+        }
+      ],
+      workspaceLineageByChildKey: {
+        [worktreeWorkspaceKey(delta.id)]: {
+          childWorkspaceKey: worktreeWorkspaceKey(delta.id),
+          parentWorkspaceKey: folderWorkspaceKey('fw-1'),
+          origin: 'manual',
+          capture: { source: 'manual-action', confidence: 'explicit' },
+          createdAt: 1
+        } satisfies WorkspaceLineage
+      }
+    })
+    renderDrawer()
+
+    // Lanes sort by manual order descending; the folder card sorts by its own order.
+    expect(laneIds('in-review')).toEqual([omega.id, 'folder:fw-1'])
+    expect(laneIds('todo')).toEqual([gamma.id, beta.id, alpha.id])
+    expect(headerState.current?.totalCount).toBe(5)
   })
 
   it('restores every lane when the query is cleared', () => {

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useRef } from 'react'
+import { buildWorkspaceBoardWorktrees } from './workspace-kanban-folder-workspaces'
 import { useAppStore } from '@/store'
 import { useAllWorktrees, useRepoMap } from '@/store/selectors'
 import { useWorkspaceStatusDocumentDrop } from './use-workspace-status-drop'
@@ -79,6 +80,16 @@ function WorkspaceKanbanDrawerContent({
     () => buildWorktreeManualOrderCatalog({ worktrees: allWorktrees, folderWorkspaces }),
     [allWorktrees, folderWorkspaces]
   )
+  const workspaceLineageByChildKey = useAppStore((s) => s.workspaceLineageByChildKey)
+  const boardSourceWorktrees = useMemo(
+    () =>
+      buildWorkspaceBoardWorktrees({
+        worktrees: allWorktrees,
+        folderWorkspaces,
+        workspaceLineageByChildKey
+      }),
+    [allWorktrees, folderWorkspaces, workspaceLineageByChildKey]
+  )
   const {
     activeWorktreeIdentity,
     boardDragGroups,
@@ -92,7 +103,7 @@ function WorkspaceKanbanDrawerContent({
   } = useWorkspaceKanbanBoardProjection({
     activeWorktreeId,
     activeWorkspaceExecutionHostId,
-    allWorktrees,
+    allWorktrees: boardSourceWorktrees,
     open,
     repoMap,
     sortBy,
@@ -206,7 +217,7 @@ function WorkspaceKanbanDrawerContent({
     handleAddStatus,
     handleRemoveStatus
   } = useWorkspaceKanbanStatusActions({
-    allWorktrees,
+    allWorktrees: boardSourceWorktrees,
     workspaceStatuses,
     setWorkspaceStatuses,
     updateWorktreeMeta

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -160,6 +160,7 @@ const WorktreeList = React.memo(function WorktreeList({
     repoMap,
     worktreeMap,
     worktreeLineageById,
+    workspaceLineageByChildKey,
     prCache,
     settings,
     workspaceStatuses,

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
@@ -82,7 +82,8 @@ export function computeRenderedSidebarWorktrees(
     // Why no hostLabelById: it only feeds display-only host context labels, never row order.
     undefined,
     defaultHostId,
-    pinnedDisplayPolicy
+    pinnedDisplayPolicy,
+    state.workspaceLineageByChildKey
   )
 
   // Why lazy: with no host filter, addHostSectionRows is a pass-through, so skip building the whole host registry on a keystroke.

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-board-projection.test.tsx
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-board-projection.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, renderHook } from '@testing-library/react'
+import { useAppStore } from '@/store'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import { makeRepo } from '../worktree-jump-palette-test-fixtures'
+import { useWorkspaceKanbanBoardProjection } from './use-workspace-kanban-board-projection'
+
+const initialState = useAppStore.getInitialState()
+
+function folderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'fw-1',
+    projectGroupId: 'group-1',
+    name: 'API-123 : Fix checkout',
+    folderPath: '/tickets/API-123',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    workspaceStatus: 'in-review',
+    ...overrides
+  }
+}
+
+const LOCAL_FOLDER = folderWorkspace({ id: 'fw-local', name: 'Local ticket' })
+const SSH_FOLDER = folderWorkspace({
+  id: 'fw-ssh',
+  name: 'Remote ticket',
+  connectionId: 'build-box'
+})
+
+/** Board membership only — lane ordering is covered by the grouping suites. */
+function renderBoardWorktreeIds(): string[] {
+  const repo = makeRepo()
+  const { result } = renderHook(() =>
+    useWorkspaceKanbanBoardProjection({
+      activeWorktreeId: null,
+      activeWorkspaceExecutionHostId: null,
+      allWorktrees: [LOCAL_FOLDER, SSH_FOLDER].map(folderWorkspaceToWorktree),
+      open: false,
+      repoMap: new Map([[repo.id, repo]]),
+      sortBy: 'manual',
+      workspaceStatuses: useAppStore.getState().workspaceStatuses
+    })
+  )
+  return result.current.boardWorktrees.map((worktree) => worktree.id).sort()
+}
+
+describe('useWorkspaceKanbanBoardProjection folder workspace host filter', () => {
+  beforeEach(() => {
+    useAppStore.setState(initialState, true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    useAppStore.setState(initialState, true)
+  })
+
+  it('drops a folder workspace whose execution host is hidden', () => {
+    useAppStore.setState({ visibleWorkspaceHostIds: ['local'], workspaceHostScope: 'local' })
+
+    expect(renderBoardWorktreeIds()).toEqual(['folder:fw-local'])
+  })
+
+  it('keeps a folder workspace whose execution host is visible', () => {
+    useAppStore.setState({
+      visibleWorkspaceHostIds: ['ssh:build-box'],
+      workspaceHostScope: 'ssh:build-box'
+    })
+
+    expect(renderBoardWorktreeIds()).toEqual(['folder:fw-ssh'])
+  })
+
+  it('falls back to the single-host scope when no visible host ids are stored', () => {
+    useAppStore.setState({ visibleWorkspaceHostIds: null, workspaceHostScope: 'ssh:build-box' })
+
+    expect(renderBoardWorktreeIds()).toEqual(['folder:fw-ssh'])
+  })
+
+  it('keeps every folder workspace under the all-hosts scope', () => {
+    useAppStore.setState({ visibleWorkspaceHostIds: null, workspaceHostScope: 'all' })
+
+    expect(renderBoardWorktreeIds()).toEqual(['folder:fw-local', 'folder:fw-ssh'])
+  })
+})

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-board-projection.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-board-projection.ts
@@ -12,8 +12,13 @@ import {
 } from '../../../../shared/worktree/host-qualified-identity'
 import type { Worktree } from '../../../../shared/worktree/types'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import type { WorktreeDragGroup } from './worktree-manual-order'
 import type { useRepoMap } from '@/store/selectors'
+
+function isFolderWorkspaceEntry(worktree: Worktree): boolean {
+  return parseWorkspaceKey(worktree.id)?.type === 'folder'
+}
 
 export function useWorkspaceKanbanBoardProjection(args: {
   activeWorktreeId: string | null
@@ -24,10 +29,26 @@ export function useWorkspaceKanbanBoardProjection(args: {
   sortBy: ReturnType<typeof useAppStore.getState>['sortBy']
   workspaceStatuses: ReturnType<typeof useAppStore.getState>['workspaceStatuses']
 }) {
-  const visibleWorktreeIds = useVisibleWorkspaceKanbanWorktreeIds({
-    allWorktrees: args.allWorktrees,
+  // Why: the visibility filters (default branch, detached HEAD, other devices…)
+  // describe git checkouts. A folder workspace entry has no branch or repo, so
+  // it is on the board whenever it is in the list — archiving is the only
+  // thing that removes it, and the list builder already honours that.
+  const gitWorktrees = useMemo(
+    () => args.allWorktrees.filter((worktree) => !isFolderWorkspaceEntry(worktree)),
+    [args.allWorktrees]
+  )
+  const visibleGitWorktreeIds = useVisibleWorkspaceKanbanWorktreeIds({
+    allWorktrees: gitWorktrees,
     repoMap: args.repoMap
   })
+  const visibleWorktreeIds = useMemo(
+    () =>
+      new Set([
+        ...visibleGitWorktreeIds,
+        ...args.allWorktrees.filter(isFolderWorkspaceEntry).map(getWorktreeHostIdentity)
+      ]),
+    [args.allWorktrees, visibleGitWorktreeIds]
+  )
   const worktreesByStatus = useMemo(
     () =>
       groupWorkspaceKanbanWorktrees({

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-board-projection.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-board-projection.ts
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useMemo } from 'react'
-import type { useAppStore } from '@/store'
+import { useAppStore } from '@/store'
 import { useVisibleWorkspaceKanbanWorktreeIds } from './use-visible-workspace-kanban-worktree-ids'
 import { groupWorkspaceKanbanWorktrees } from './workspace-kanban-worktree-groups'
 import { buildWorkspaceKanbanLaneViews } from './workspace-kanban-search'
@@ -11,7 +11,11 @@ import {
   getWorktreeHostIdentity
 } from '../../../../shared/worktree/host-qualified-identity'
 import type { Worktree } from '../../../../shared/worktree/types'
-import type { ExecutionHostId } from '../../../../shared/execution-host'
+import {
+  ALL_EXECUTION_HOSTS_SCOPE,
+  LOCAL_EXECUTION_HOST_ID,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import type { WorktreeDragGroup } from './worktree-manual-order'
 import type { useRepoMap } from '@/store/selectors'
@@ -31,8 +35,8 @@ export function useWorkspaceKanbanBoardProjection(args: {
 }) {
   // Why: the visibility filters (default branch, detached HEAD, other devices…)
   // describe git checkouts. A folder workspace entry has no branch or repo, so
-  // it is on the board whenever it is in the list — archiving is the only
-  // thing that removes it, and the list builder already honours that.
+  // archiving — which the list builder already honours — and the host filter
+  // below are the only things that remove it.
   const gitWorktrees = useMemo(
     () => args.allWorktrees.filter((worktree) => !isFolderWorkspaceEntry(worktree)),
     [args.allWorktrees]
@@ -41,13 +45,26 @@ export function useWorkspaceKanbanBoardProjection(args: {
     allWorktrees: gitWorktrees,
     repoMap: args.repoMap
   })
+  const workspaceHostScope = useAppStore((s) => s.workspaceHostScope)
+  const visibleWorkspaceHostIds = useAppStore((s) => s.visibleWorkspaceHostIds)
+  // Why: a folder workspace does execute on one host, so it answers to the host
+  // filter exactly as computeVisibleWorktrees makes a git worktree answer to it.
+  const visibleFolderWorktreeIds = useMemo(() => {
+    const visibleHostIds =
+      visibleWorkspaceHostIds ??
+      (workspaceHostScope === ALL_EXECUTION_HOSTS_SCOPE ? null : [workspaceHostScope])
+    const visibleHostIdSet = visibleHostIds ? new Set(visibleHostIds) : null
+    return args.allWorktrees
+      .filter(
+        (worktree) =>
+          isFolderWorkspaceEntry(worktree) &&
+          (!visibleHostIdSet || visibleHostIdSet.has(worktree.hostId ?? LOCAL_EXECUTION_HOST_ID))
+      )
+      .map(getWorktreeHostIdentity)
+  }, [args.allWorktrees, visibleWorkspaceHostIds, workspaceHostScope])
   const visibleWorktreeIds = useMemo(
-    () =>
-      new Set([
-        ...visibleGitWorktreeIds,
-        ...args.allWorktrees.filter(isFolderWorkspaceEntry).map(getWorktreeHostIdentity)
-      ]),
-    [args.allWorktrees, visibleGitWorktreeIds]
+    () => new Set([...visibleGitWorktreeIds, ...visibleFolderWorktreeIds]),
+    [visibleFolderWorktreeIds, visibleGitWorktreeIds]
   )
   const worktreesByStatus = useMemo(
     () =>

--- a/src/renderer/src/components/sidebar/workspace-kanban-folder-workspaces.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-folder-workspaces.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { WorkspaceLineage } from '../../../../shared/worktree/lineage-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
+import { buildWorkspaceBoardWorktrees } from './workspace-kanban-folder-workspaces'
+
+function worktree(id: string): Worktree {
+  return {
+    id,
+    repoId: 'repo-a',
+    displayName: id,
+    path: `/${id}`,
+    branch: `feature/${id}`,
+    isPinned: false,
+    isArchived: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    workspaceStatus: 'todo'
+  } as unknown as Worktree
+}
+
+function folderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'fw-1',
+    projectGroupId: 'group-1',
+    name: 'API-123 : Fix checkout',
+    folderPath: '/tickets/API-123',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    workspaceStatus: 'in-review',
+    ...overrides
+  }
+}
+
+function attached(folderId: string, worktreeId: string): WorkspaceLineage {
+  return {
+    childWorkspaceKey: worktreeWorkspaceKey(worktreeId),
+    parentWorkspaceKey: folderWorkspaceKey(folderId),
+    origin: 'manual',
+    capture: { source: 'manual-action', confidence: 'explicit' },
+    createdAt: 1
+  }
+}
+
+describe('buildWorkspaceBoardWorktrees', () => {
+  it('adds each live folder workspace as a board row carrying its own status', () => {
+    const rows = buildWorkspaceBoardWorktrees({
+      worktrees: [worktree('repo-a::/alpha')],
+      folderWorkspaces: [folderWorkspace()],
+      workspaceLineageByChildKey: {}
+    })
+
+    expect(rows.map((row) => row.id)).toEqual(['repo-a::/alpha', 'folder:fw-1'])
+    expect(rows[1]).toMatchObject({
+      displayName: 'API-123 : Fix checkout',
+      workspaceStatus: 'in-review'
+    })
+  })
+
+  it('folds an attached worktree into its folder workspace card', () => {
+    const rows = buildWorkspaceBoardWorktrees({
+      worktrees: [worktree('repo-a::/alpha'), worktree('repo-a::/beta')],
+      folderWorkspaces: [folderWorkspace()],
+      workspaceLineageByChildKey: {
+        [worktreeWorkspaceKey('repo-a::/beta')]: attached('fw-1', 'repo-a::/beta')
+      }
+    })
+
+    expect(rows.map((row) => row.id)).toEqual(['repo-a::/alpha', 'folder:fw-1'])
+  })
+
+  it('keeps an attached worktree on the board when its folder workspace is archived', () => {
+    const rows = buildWorkspaceBoardWorktrees({
+      worktrees: [worktree('repo-a::/beta')],
+      folderWorkspaces: [folderWorkspace({ isArchived: true })],
+      workspaceLineageByChildKey: {
+        [worktreeWorkspaceKey('repo-a::/beta')]: attached('fw-1', 'repo-a::/beta')
+      }
+    })
+
+    expect(rows.map((row) => row.id)).toEqual(['repo-a::/beta'])
+  })
+})

--- a/src/renderer/src/components/sidebar/workspace-kanban-folder-workspaces.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-folder-workspaces.test.ts
@@ -5,7 +5,7 @@ import type { Worktree } from '../../../../shared/worktree/types'
 import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
 import { buildWorkspaceBoardWorktrees } from './workspace-kanban-folder-workspaces'
 
-function worktree(id: string): Worktree {
+function worktree(id: string, overrides: Partial<Worktree> = {}): Worktree {
   return {
     id,
     repoId: 'repo-a',
@@ -16,7 +16,8 @@ function worktree(id: string): Worktree {
     isArchived: false,
     sortOrder: 0,
     lastActivityAt: 1,
-    workspaceStatus: 'todo'
+    workspaceStatus: 'todo',
+    ...overrides
   } as unknown as Worktree
 }
 
@@ -40,9 +41,14 @@ function folderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorksp
   }
 }
 
-function attached(folderId: string, worktreeId: string): WorkspaceLineage {
+function attached(
+  folderId: string,
+  worktreeId: string,
+  childInstanceId?: string
+): WorkspaceLineage {
   return {
     childWorkspaceKey: worktreeWorkspaceKey(worktreeId),
+    ...(childInstanceId ? { childInstanceId } : {}),
     parentWorkspaceKey: folderWorkspaceKey(folderId),
     origin: 'manual',
     capture: { source: 'manual-action', confidence: 'explicit' },
@@ -75,6 +81,22 @@ describe('buildWorkspaceBoardWorktrees', () => {
     })
 
     expect(rows.map((row) => row.id)).toEqual(['repo-a::/alpha', 'folder:fw-1'])
+  })
+
+  it('keeps the other host row on the board when one of two same-id instances is attached', () => {
+    const rows = buildWorkspaceBoardWorktrees({
+      worktrees: [
+        worktree('repo-a::/alpha', { hostId: 'local', instanceId: 'local-1' }),
+        worktree('repo-a::/alpha', { hostId: 'ssh:build-box', instanceId: 'remote-1' })
+      ],
+      folderWorkspaces: [folderWorkspace()],
+      workspaceLineageByChildKey: {
+        [worktreeWorkspaceKey('repo-a::/alpha')]: attached('fw-1', 'repo-a::/alpha', 'remote-1')
+      }
+    })
+
+    expect(rows.map((row) => row.id)).toEqual(['repo-a::/alpha', 'folder:fw-1'])
+    expect(rows[0].hostId).toBe('local')
   })
 
   it('keeps an attached worktree on the board when its folder workspace is archived', () => {

--- a/src/renderer/src/components/sidebar/workspace-kanban-folder-workspaces.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-folder-workspaces.ts
@@ -1,0 +1,33 @@
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import type { WorkspaceLineage } from '../../../../shared/worktree/lineage-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { getAttachedWorktreesByFolderWorkspaceId } from './worktree-list/grouping/folder-workspace-attached'
+
+/**
+ * The worktree-shaped rows the Workspace Board lays out: every git worktree
+ * except those attached to a folder workspace on the board, plus each live
+ * folder workspace projected through the same adapter the sidebar uses. An
+ * attached worktree is part of its ticket's card, so the ticket — not the
+ * branch — is what moves between columns.
+ */
+export function buildWorkspaceBoardWorktrees(args: {
+  worktrees: readonly Worktree[]
+  folderWorkspaces: readonly FolderWorkspace[]
+  workspaceLineageByChildKey: Record<string, WorkspaceLineage>
+}): Worktree[] {
+  const folderWorkspaces = args.folderWorkspaces.filter((workspace) => !workspace.isArchived)
+  const attachedByFolderId = getAttachedWorktreesByFolderWorkspaceId(
+    args.worktrees,
+    args.workspaceLineageByChildKey
+  )
+  const attachedIds = new Set(
+    folderWorkspaces.flatMap((workspace) =>
+      (attachedByFolderId.get(workspace.id) ?? []).map((worktree) => worktree.id)
+    )
+  )
+  return [
+    ...args.worktrees.filter((worktree) => !attachedIds.has(worktree.id)),
+    ...folderWorkspaces.map(folderWorkspaceToWorktree)
+  ]
+}

--- a/src/renderer/src/components/sidebar/workspace-kanban-folder-workspaces.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-folder-workspaces.ts
@@ -1,5 +1,6 @@
 import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
 import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
 import type { WorkspaceLineage } from '../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { getAttachedWorktreesByFolderWorkspaceId } from './worktree-list/grouping/folder-workspace-attached'
@@ -21,13 +22,18 @@ export function buildWorkspaceBoardWorktrees(args: {
     args.worktrees,
     args.workspaceLineageByChildKey
   )
-  const attachedIds = new Set(
+  // Why: a worktree id is `repoId::path` with no host component, so two hosts can publish the same
+  // id for two different workspaces. Folding on the bare id dropped both rows when only one of them
+  // was attached; the grouping already returns the host-specific child, so key on its identity.
+  const attachedIdentities = new Set(
     folderWorkspaces.flatMap((workspace) =>
-      (attachedByFolderId.get(workspace.id) ?? []).map((worktree) => worktree.id)
+      (attachedByFolderId.get(workspace.id) ?? []).map(getWorktreeHostIdentity)
     )
   )
   return [
-    ...args.worktrees.filter((worktree) => !attachedIds.has(worktree.id)),
+    ...args.worktrees.filter(
+      (worktree) => !attachedIdentities.has(getWorktreeHostIdentity(worktree))
+    ),
     ...folderWorkspaces.map(folderWorkspaceToWorktree)
   ]
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.folder-workspace-lanes.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.folder-workspace-lanes.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from 'vitest'
 import { buildRows } from './build-rows'
 import { getFolderWorkspaceLaneKey } from './folder-workspace-lanes'
-import { getPRGroupKey, getPRLaneKey } from './group-keys'
+import {
+  getFolderWorkspaceAttachedGroupKey,
+  getPRGroupKey,
+  getPRLaneKey,
+  PINNED_GROUP_KEY
+} from './group-keys'
 import type { Row, WorktreeGroupBy } from './row-types'
 import { repo, worktree } from '../../worktree-list-groups-test-fixtures'
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import type { WorkspaceLineage } from '../../../../../../shared/worktree/lineage-types'
+import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../../../shared/workspace-scope'
 
 const GROUP: ProjectGroup = {
   id: 'group-1',
@@ -50,6 +57,7 @@ function buildSidebarRows(options: {
   projectGroups?: readonly ProjectGroup[]
   worktrees?: (typeof worktree)[]
   collapsedGroups?: Set<string>
+  workspaceLineageByChildKey?: Record<string, WorkspaceLineage>
 }): Row[] {
   const worktrees = options.worktrees ?? [worktree]
   return buildRows(
@@ -71,8 +79,26 @@ function buildSidebarRows(options: {
     new Map(),
     [],
     undefined,
-    options.folderWorkspaces ?? [makeFolderWorkspace()]
+    options.folderWorkspaces ?? [makeFolderWorkspace()],
+    undefined,
+    undefined,
+    undefined,
+    options.workspaceLineageByChildKey ?? {}
   )
+}
+
+function attachedTo(folderWorkspaceId: string, worktreeId: string): WorkspaceLineage {
+  return {
+    childWorkspaceKey: worktreeWorkspaceKey(worktreeId),
+    parentWorkspaceKey: folderWorkspaceKey(folderWorkspaceId),
+    origin: 'manual',
+    capture: { source: 'manual-action', confidence: 'explicit' },
+    createdAt: 1
+  }
+}
+
+function itemRows(rows: Row[]): Extract<Row, { type: 'item' }>[] {
+  return rows.filter((row): row is Extract<Row, { type: 'item' }> => row.type === 'item')
 }
 
 function folderRows(rows: Row[]): Extract<Row, { type: 'folder-workspace' }>[] {
@@ -95,6 +121,92 @@ describe('folder workspaces render under every Group by mode', () => {
   it('does not duplicate the row under repo grouping', () => {
     const rows = buildSidebarRows({ groupBy: 'repo' })
     expect(folderRows(rows).map((row) => row.key)).toEqual(['folder-workspace:fw-1'])
+  })
+})
+
+describe('worktrees attached to a folder workspace', () => {
+  // The child's own status would put it in the todo lane; attachment wins.
+  const attachedChild = { ...worktree, workspaceStatus: 'todo' as const }
+  const lineage = { [worktreeWorkspaceKey(worktree.id)]: attachedTo('fw-1', worktree.id) }
+
+  for (const groupBy of ALL_GROUP_BY) {
+    it(`nests the child beneath its folder workspace when groupBy is ${groupBy}`, () => {
+      const rows = buildSidebarRows({
+        groupBy,
+        worktrees: [attachedChild],
+        workspaceLineageByChildKey: lineage
+      })
+
+      const [folderRow] = folderRows(rows)
+      const [childRow, ...otherItems] = itemRows(rows)
+      expect(otherItems).toHaveLength(0)
+      expect(folderRow).toMatchObject({
+        attachedChildCount: 1,
+        attachedGroupKey: getFolderWorkspaceAttachedGroupKey('fw-1'),
+        attachedCollapsed: false
+      })
+      expect(rows.indexOf(childRow)).toBe(rows.indexOf(folderRow) + 1)
+      expect(childRow).toMatchObject({
+        worktree: attachedChild,
+        sectionKey: folderWorkspaceKey('fw-1'),
+        depth: 1
+      })
+      expect(rows.some((row) => row.type === 'header' && row.key === 'workspace-status:todo')).toBe(
+        false
+      )
+    })
+  }
+
+  it('hides the children while the attached group is collapsed', () => {
+    const rows = buildSidebarRows({
+      groupBy: 'workspace-status',
+      worktrees: [attachedChild],
+      workspaceLineageByChildKey: lineage,
+      collapsedGroups: new Set([getFolderWorkspaceAttachedGroupKey('fw-1')])
+    })
+
+    expect(itemRows(rows)).toHaveLength(0)
+    expect(folderRows(rows)[0]).toMatchObject({ attachedChildCount: 1, attachedCollapsed: true })
+  })
+
+  it('keeps a pinned child in the pinned section, matching worktree lineage', () => {
+    const rows = buildSidebarRows({
+      groupBy: 'workspace-status',
+      worktrees: [{ ...attachedChild, isPinned: true }],
+      workspaceLineageByChildKey: lineage
+    })
+
+    expect(itemRows(rows).map((row) => row.sectionKey)).toEqual([PINNED_GROUP_KEY])
+    expect(folderRows(rows)[0]).toMatchObject({ attachedChildCount: 0 })
+  })
+
+  it('leaves the child in its own lane when the folder workspace is not rendered', () => {
+    // Why: a host filter that hides the folder must not also hide its children.
+    const rows = buildSidebarRows({
+      groupBy: 'workspace-status',
+      worktrees: [attachedChild],
+      workspaceLineageByChildKey: lineage,
+      folderWorkspaces: []
+    })
+
+    expect(itemRows(rows).map((row) => row.sectionKey)).toEqual(['workspace-status:todo'])
+  })
+
+  it('ignores lineage whose child instance no longer matches', () => {
+    const staleLineage = {
+      [worktreeWorkspaceKey(worktree.id)]: {
+        ...attachedTo('fw-1', worktree.id),
+        childInstanceId: 'instance-from-a-previous-checkout'
+      }
+    }
+    const rows = buildSidebarRows({
+      groupBy: 'workspace-status',
+      worktrees: [{ ...attachedChild, instanceId: 'current-instance' }],
+      workspaceLineageByChildKey: staleLineage
+    })
+
+    expect(itemRows(rows).map((row) => row.sectionKey)).toEqual(['workspace-status:todo'])
+    expect(folderRows(rows)[0]).toMatchObject({ attachedChildCount: 0 })
   })
 })
 

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
@@ -27,12 +27,9 @@ import type { ProjectGroupingModel } from './project-grouping'
 import { appendProjectGroupSections } from './project-group-sections'
 import { getPinnedSectionWorktrees } from '../../pinned-section-worktrees'
 import { emitPinnedGroup } from './pinned-group-rows'
-import {
-  appendFolderWorkspaceRows,
-  appendWorktreeRows,
-  buildPendingCreationRow
-} from './row-builders'
+import { appendWorktreeRows, buildPendingCreationRow } from './row-builders'
 import { getAttachedWorktreesByFolderWorkspaceId } from './folder-workspace-attached'
+import { appendFolderWorkspaceRows } from './folder-workspace-rows'
 import {
   compareFolderWorkspacesForDisplay,
   getRenderableFolderWorkspaces

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
@@ -2,7 +2,10 @@ import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { ProjectOrderBy } from '../../../../../../shared/ui-chrome-types'
-import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-types'
+import type {
+  WorkspaceLineage,
+  WorktreeLineage
+} from '../../../../../../shared/worktree/lineage-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../../../shared/worktree/types'
 import { cloneDefaultWorkspaceStatuses } from '../../../../../../shared/workspace-statuses'
 import type { AppState } from '../../../../store/types'
@@ -25,10 +28,11 @@ import { appendProjectGroupSections } from './project-group-sections'
 import { getPinnedSectionWorktrees } from '../../pinned-section-worktrees'
 import { emitPinnedGroup } from './pinned-group-rows'
 import {
+  appendFolderWorkspaceRows,
   appendWorktreeRows,
-  buildFolderWorkspaceRow,
   buildPendingCreationRow
 } from './row-builders'
+import { getAttachedWorktreesByFolderWorkspaceId } from './folder-workspace-attached'
 import {
   compareFolderWorkspacesForDisplay,
   getRenderableFolderWorkspaces
@@ -70,7 +74,8 @@ export function buildRows(
   folderWorkspaces: readonly FolderWorkspace[] = [],
   hostLabelById?: ReadonlyMap<string, string>,
   defaultHostId: ExecutionHostId = LOCAL_EXECUTION_HOST_ID,
-  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy = getPinnedWorktreeDisplayPolicy(settings)
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy = getPinnedWorktreeDisplayPolicy(settings),
+  workspaceLineageByChildKey: Record<string, WorkspaceLineage> = {}
 ): Row[] {
   const result: Row[] = []
   const projectIndex = buildProjectGroupingIndex(projectGrouping)
@@ -101,10 +106,32 @@ export function buildRows(
     ? getPinnedSectionWorktrees(worktrees, lineageById, worktreeMap)
     : worktrees.filter((worktree) => worktree.isPinned)
   const pinnedSectionIds = new Set(pinnedSectionWorktrees.map(getWorktreeHostIdentity))
-  const naturalWorktrees =
+  const worktreesOutsidePinnedSection =
     pinnedDisplayPolicy === 'duplicate-in-groups'
       ? worktrees
       : worktrees.filter((worktree) => !pinnedSectionIds.has(getWorktreeHostIdentity(worktree)))
+  // Why: a worktree attached to a rendered folder workspace lives inside that
+  // card, whatever lane its own status would pick, so it must not also be a row
+  // of its own. Pinned attached worktrees keep their pinned placement, matching
+  // worktree lineage. A folder that is not rendered (host filter) keeps its
+  // children visible as ordinary rows rather than hiding them.
+  const renderableFolderIds = new Set(
+    renderableFolderWorkspaces.map((pair) => pair.folderWorkspace.id)
+  )
+  const attachedByFolderId = new Map(
+    [
+      ...getAttachedWorktreesByFolderWorkspaceId(
+        worktreesOutsidePinnedSection,
+        workspaceLineageByChildKey
+      )
+    ].filter(([folderId]) => renderableFolderIds.has(folderId))
+  )
+  const attachedIdentities = new Set(
+    [...attachedByFolderId.values()].flat().map(getWorktreeHostIdentity)
+  )
+  const naturalWorktrees = worktreesOutsidePinnedSection.filter(
+    (worktree) => !attachedIdentities.has(getWorktreeHostIdentity(worktree))
+  )
   // Why the full set: under the default pinned policy a pinned worktree exists
   // only in the Pinned section, and its host is part of whether the sidebar is
   // mixed at all. Scoping to naturalWorktrees left pinned remotes unlabelled.
@@ -185,11 +212,23 @@ export function buildRows(
           hostContextLabelByWorktreeIdentity: mixedWorktreeHostContextLabels,
           cyclicLineageIds
         })
-        for (const pair of [...renderableFolderWorkspaces].sort((left, right) =>
-          compareFolderWorkspacesForDisplay(left.folderWorkspace, right.folderWorkspace)
-        )) {
-          result.push(buildFolderWorkspaceRow(pair, 0))
-        }
+        appendFolderWorkspaceRows(
+          result,
+          [...renderableFolderWorkspaces].sort((left, right) =>
+            compareFolderWorkspacesForDisplay(left.folderWorkspace, right.folderWorkspace)
+          ),
+          0,
+          {
+            attachedByFolderId,
+            repoMap,
+            lineageById,
+            worktreeMap,
+            nestLineage,
+            collapsedGroups,
+            cyclicLineageIds,
+            hostContextLabelByWorktreeIdentity: mixedWorktreeHostContextLabels
+          }
+        )
       }
     }
     return result
@@ -229,7 +268,8 @@ export function buildRows(
     lineageById,
     worktreeMap,
     nestLineage,
-    cyclicLineageIds
+    cyclicLineageIds,
+    attachedByFolderId
   }
 
   if (groupBy !== 'repo' || projectGroups.length === 0) {

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-attached.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-attached.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkspaceLineage } from '../../../../../../shared/worktree/lineage-types'
+import type { Worktree } from '../../../../../../shared/worktree/types'
+import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { worktree } from '../../worktree-list-groups-test-fixtures'
+import { getAttachedWorktreesByFolderWorkspaceId } from './folder-workspace-attached'
+
+function attachedTo(
+  worktreeId: string,
+  overrides: Partial<WorkspaceLineage> = {}
+): WorkspaceLineage {
+  return {
+    childWorkspaceKey: worktreeWorkspaceKey(worktreeId),
+    parentWorkspaceKey: folderWorkspaceKey('fw-1'),
+    origin: 'manual',
+    capture: { source: 'manual-action', confidence: 'explicit' },
+    createdAt: 1,
+    ...overrides
+  }
+}
+
+function lineageFor(worktreeId: string, overrides: Partial<WorkspaceLineage> = {}) {
+  return { [worktreeWorkspaceKey(worktreeId)]: attachedTo(worktreeId, overrides) }
+}
+
+function attachedNames(worktrees: readonly Worktree[], lineage: Record<string, WorkspaceLineage>) {
+  const attached = getAttachedWorktreesByFolderWorkspaceId(worktrees, lineage)
+  return (attached.get('fw-1') ?? []).map((entry) => entry.displayName)
+}
+
+describe('getAttachedWorktreesByFolderWorkspaceId', () => {
+  it('nests the only worktree carrying the id on a single host', () => {
+    const names = attachedNames([worktree], lineageFor(worktree.id))
+
+    expect(names).toEqual([worktree.displayName])
+  })
+
+  it('nests only the instance the record names when two hosts share the id', () => {
+    const local: Worktree = {
+      ...worktree,
+      hostId: 'local',
+      instanceId: 'instance-local',
+      displayName: 'local row'
+    }
+    const remote: Worktree = {
+      ...worktree,
+      hostId: 'ssh:build-box',
+      instanceId: 'instance-remote',
+      displayName: 'remote row'
+    }
+
+    const names = attachedNames(
+      [local, remote],
+      lineageFor(worktree.id, { childInstanceId: 'instance-remote' })
+    )
+
+    expect(names).toEqual(['remote row'])
+  })
+
+  it('nests neither row when two hosts share the id and the record names no instance', () => {
+    const local: Worktree = { ...worktree, hostId: 'local', displayName: 'local row' }
+    const remote: Worktree = { ...worktree, hostId: 'ssh:build-box', displayName: 'remote row' }
+
+    expect(attachedNames([local, remote], lineageFor(worktree.id))).toEqual([])
+  })
+
+  it('ignores a record whose child instance no longer matches', () => {
+    const current: Worktree = { ...worktree, instanceId: 'current-instance' }
+
+    const names = attachedNames(
+      [current],
+      lineageFor(worktree.id, { childInstanceId: 'instance-from-a-previous-checkout' })
+    )
+
+    expect(names).toEqual([])
+  })
+
+  it('ignores an archived child', () => {
+    expect(attachedNames([{ ...worktree, isArchived: true }], lineageFor(worktree.id))).toEqual([])
+  })
+
+  it('ignores a record whose parent is another worktree', () => {
+    const lineage = lineageFor(worktree.id, {
+      parentWorkspaceKey: worktreeWorkspaceKey('wt-parent')
+    })
+
+    expect(getAttachedWorktreesByFolderWorkspaceId([worktree], lineage).size).toBe(0)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-attached.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-attached.ts
@@ -1,0 +1,34 @@
+import type { WorkspaceLineage } from '../../../../../../shared/worktree/lineage-types'
+import type { Worktree } from '../../../../../../shared/worktree/types'
+import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { getLineageChildWorktree } from '../../../right-sidebar/folder-workspace-attached-worktrees'
+
+/**
+ * Worktrees attached to a folder workspace by workspace lineage, keyed by folder
+ * workspace id. Children keep the order of `worktrees` so a folder's nested rows
+ * sort the same way the surrounding lane does.
+ */
+export function getAttachedWorktreesByFolderWorkspaceId(
+  worktrees: readonly Worktree[],
+  workspaceLineageByChildKey: Record<string, WorkspaceLineage>
+): Map<string, Worktree[]> {
+  const attached = new Map<string, Worktree[]>()
+  if (Object.keys(workspaceLineageByChildKey).length === 0) {
+    return attached
+  }
+  const worktreeById = new Map(worktrees.map((worktree) => [worktree.id, worktree]))
+  for (const worktree of worktrees) {
+    const lineage = workspaceLineageByChildKey[worktreeWorkspaceKey(worktree.id)]
+    if (!lineage) {
+      continue
+    }
+    const parentScope = parseWorkspaceKey(lineage.parentWorkspaceKey)
+    if (parentScope?.type !== 'folder' || !getLineageChildWorktree(lineage, worktreeById)) {
+      continue
+    }
+    const children = attached.get(parentScope.folderWorkspaceId) ?? []
+    children.push(worktree)
+    attached.set(parentScope.folderWorkspaceId, children)
+  }
+  return attached
+}

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-attached.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-attached.ts
@@ -1,7 +1,7 @@
 import type { WorkspaceLineage } from '../../../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../../../shared/worktree/types'
 import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../../../../../shared/workspace-scope'
-import { getLineageChildWorktree } from '../../../right-sidebar/folder-workspace-attached-worktrees'
+import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 
 /**
  * Worktrees attached to a folder workspace by workspace lineage, keyed by folder
@@ -16,14 +16,25 @@ export function getAttachedWorktreesByFolderWorkspaceId(
   if (Object.keys(workspaceLineageByChildKey).length === 0) {
     return attached
   }
-  const worktreeById = new Map(worktrees.map((worktree) => [worktree.id, worktree]))
+  // Why: a worktree id is `repoId::path` with no host component, so two hosts can
+  // publish the same id. Count the distinct host-qualified rows behind each id to
+  // tell a genuine cross-host collision from the same row listed twice.
+  const hostIdentitiesByWorktreeId = new Map<string, Set<string>>()
+  for (const worktree of worktrees) {
+    const identities = hostIdentitiesByWorktreeId.get(worktree.id) ?? new Set<string>()
+    identities.add(getWorktreeHostIdentity(worktree))
+    hostIdentitiesByWorktreeId.set(worktree.id, identities)
+  }
   for (const worktree of worktrees) {
     const lineage = workspaceLineageByChildKey[worktreeWorkspaceKey(worktree.id)]
     if (!lineage) {
       continue
     }
     const parentScope = parseWorkspaceKey(lineage.parentWorkspaceKey)
-    if (parentScope?.type !== 'folder' || !getLineageChildWorktree(lineage, worktreeById)) {
+    if (
+      parentScope?.type !== 'folder' ||
+      !isLineageChildWorktree(lineage, worktree, hostIdentitiesByWorktreeId)
+    ) {
       continue
     }
     const children = attached.get(parentScope.folderWorkspaceId) ?? []
@@ -31,4 +42,21 @@ export function getAttachedWorktreesByFolderWorkspaceId(
     attached.set(parentScope.folderWorkspaceId, children)
   }
   return attached
+}
+
+/** True only when this worktree is unambiguously the worktree the record was written for. */
+function isLineageChildWorktree(
+  lineage: WorkspaceLineage,
+  worktree: Worktree,
+  hostIdentitiesByWorktreeId: Map<string, Set<string>>
+): boolean {
+  if (worktree.isArchived) {
+    return false
+  }
+  if (lineage.childInstanceId) {
+    return lineage.childInstanceId === worktree.instanceId
+  }
+  // Why: with no instance id on the record, nothing separates two hosts' rows
+  // sharing this id, so nesting either one could claim the wrong workspace.
+  return (hostIdentitiesByWorktreeId.get(worktree.id)?.size ?? 0) <= 1
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-rows.ts
@@ -1,0 +1,82 @@
+import type { Repo } from '../../../../../../shared/repo-types'
+import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-types'
+import type { Worktree } from '../../../../../../shared/worktree/types'
+import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { getFolderWorkspaceAttachedGroupKey } from './group-keys'
+import type { RenderableFolderWorkspace } from './folder-workspace-lanes'
+import { appendWorktreeRows } from './row-builders'
+import type { FolderWorkspaceRow, Row } from './row-types'
+
+/** The one folder-workspace row constructor, shared by the project-group,
+ *  grouped-lane and flat emitters so their rows cannot diverge. */
+export function buildFolderWorkspaceRow(
+  pair: RenderableFolderWorkspace,
+  groupDepth: number,
+  attached: { childCount: number; collapsed: boolean } = { childCount: 0, collapsed: false }
+): FolderWorkspaceRow {
+  return {
+    type: 'folder-workspace',
+    key: `folder-workspace:${pair.folderWorkspace.id}`,
+    folderWorkspace: pair.folderWorkspace,
+    projectGroup: pair.projectGroup,
+    depth: 0,
+    groupDepth,
+    attachedChildCount: attached.childCount,
+    ...(attached.childCount > 0
+      ? {
+          attachedGroupKey: getFolderWorkspaceAttachedGroupKey(pair.folderWorkspace.id),
+          attachedCollapsed: attached.collapsed
+        }
+      : {})
+  }
+}
+
+/**
+ * Emits each folder workspace row followed by its attached worktrees, nested one
+ * level deep (cross-status nesting: a child renders under its folder whatever
+ * lane the child's own status would have put it in).
+ */
+export function appendFolderWorkspaceRows(
+  result: Row[],
+  pairs: readonly RenderableFolderWorkspace[],
+  groupDepth: number,
+  options: {
+    attachedByFolderId: ReadonlyMap<string, Worktree[]>
+    repoMap: Map<string, Repo>
+    lineageById: Record<string, WorktreeLineage>
+    worktreeMap: Map<string, Worktree>
+    nestLineage: boolean
+    collapsedGroups: Set<string>
+    cyclicLineageIds: ReadonlySet<string>
+    hostContextLabelByWorktreeIdentity?: ReadonlyMap<string, string>
+  }
+): void {
+  for (const pair of pairs) {
+    const attached = options.attachedByFolderId.get(pair.folderWorkspace.id) ?? []
+    const collapsed = options.collapsedGroups.has(
+      getFolderWorkspaceAttachedGroupKey(pair.folderWorkspace.id)
+    )
+    result.push(
+      buildFolderWorkspaceRow(pair, groupDepth, { childCount: attached.length, collapsed })
+    )
+    if (attached.length === 0 || collapsed) {
+      continue
+    }
+    appendWorktreeRows(
+      result,
+      attached,
+      options.repoMap,
+      options.lineageById,
+      options.worktreeMap,
+      {
+        nestLineage: options.nestLineage,
+        collapsedGroups: options.collapsedGroups,
+        groupDepth,
+        sectionKey: folderWorkspaceKey(pair.folderWorkspace.id),
+        hostContextLabelByWorktreeIdentity: options.hostContextLabelByWorktreeIdentity,
+        cyclicLineageIds: options.cyclicLineageIds,
+        baseDepth: 1
+      }
+    )
+  }
+}

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/group-keys.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/group-keys.ts
@@ -101,6 +101,11 @@ export function getLineageGroupKey(worktreeId: string): string {
   return `${LINEAGE_GROUP_PREFIX}${worktreeId}`
 }
 
+/** Collapse key for the worktrees attached to a folder workspace. */
+export function getFolderWorkspaceAttachedGroupKey(folderWorkspaceId: string): string {
+  return `folder-attached:${folderWorkspaceId}`
+}
+
 export function getWorktreeLineageGroupKey(worktree: Pick<Worktree, 'id' | 'hostId'>): string {
   return getLineageGroupKey(worktree.hostId ? getWorktreeHostIdentity(worktree) : worktree.id)
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
@@ -16,8 +16,8 @@ import {
 } from './host-labels'
 import type { OrderedGroupEntry, ProjectGroupingIndex } from './project-grouping'
 import {
+  appendFolderWorkspaceRows,
   appendWorktreeRows,
-  buildFolderWorkspaceRow,
   buildImportedWorktreesCardRow,
   buildNewExternalWorktreesInboxRow,
   buildPendingCreationRow
@@ -50,6 +50,8 @@ export type SectionAppendContext = {
   worktreeMap: Map<string, Worktree>
   nestLineage: boolean
   cyclicLineageIds: ReadonlySet<string>
+  /** Worktrees nested beneath each folder workspace row, keyed by folder id. */
+  attachedByFolderId: ReadonlyMap<string, Worktree[]>
 }
 
 export function appendOrderedGroups(
@@ -210,9 +212,16 @@ export function appendOrderedGroups(
         hostContextLabelByWorktreeIdentity,
         cyclicLineageIds
       })
-      for (const pair of folderPairs) {
-        result.push(buildFolderWorkspaceRow(pair, projectGroupDepth))
-      }
+      appendFolderWorkspaceRows(result, folderPairs, projectGroupDepth, {
+        attachedByFolderId: ctx.attachedByFolderId,
+        repoMap,
+        lineageById,
+        worktreeMap,
+        nestLineage,
+        collapsedGroups,
+        cyclicLineageIds,
+        hostContextLabelByWorktreeIdentity
+      })
     }
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
@@ -15,8 +15,8 @@ import {
   getMixedHostContextLabels
 } from './host-labels'
 import type { OrderedGroupEntry, ProjectGroupingIndex } from './project-grouping'
+import { appendFolderWorkspaceRows } from './folder-workspace-rows'
 import {
-  appendFolderWorkspaceRows,
   appendWorktreeRows,
   buildImportedWorktreesCardRow,
   buildNewExternalWorktreesInboxRow,

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/project-group-sections.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/project-group-sections.ts
@@ -14,7 +14,7 @@ import {
   recentRankForEntry,
   withRepoSectionDisplayLabels
 } from './section-order'
-import { buildFolderWorkspaceRow } from './row-builders'
+import { appendFolderWorkspaceRows } from './row-builders'
 
 export function appendProjectGroupSections(
   ctx: SectionAppendContext,
@@ -108,9 +108,21 @@ export function appendProjectGroupSections(
       projectGroupDepth: depth
     })
     if (!collapsedGroups.has(key)) {
-      for (const pair of folderWorkspacesByProjectGroupId.get(projectGroup.id) ?? []) {
-        result.push(buildFolderWorkspaceRow(pair, depth + 1))
-      }
+      appendFolderWorkspaceRows(
+        result,
+        folderWorkspacesByProjectGroupId.get(projectGroup.id) ?? [],
+        depth + 1,
+        {
+          attachedByFolderId: ctx.attachedByFolderId,
+          repoMap: ctx.repoMap,
+          lineageById: ctx.lineageById,
+          worktreeMap: ctx.worktreeMap,
+          nestLineage: ctx.nestLineage,
+          collapsedGroups,
+          cyclicLineageIds: ctx.cyclicLineageIds,
+          hostContextLabelByWorktreeIdentity: ctx.mixedWorktreeHostContextLabels
+        }
+      )
       appendOrderedGroups(ctx, withRepoSectionDisplayLabels(repoEntries), depth + 1)
       for (const childGroup of childGroups) {
         appendProjectGroup(childGroup, depth + 1)

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/project-group-sections.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/project-group-sections.ts
@@ -14,7 +14,7 @@ import {
   recentRankForEntry,
   withRepoSectionDisplayLabels
 } from './section-order'
-import { appendFolderWorkspaceRows } from './row-builders'
+import { appendFolderWorkspaceRows } from './folder-workspace-rows'
 
 export function appendProjectGroupSections(
   ctx: SectionAppendContext,

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
@@ -3,8 +3,9 @@ import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-
 import type { Worktree } from '../../../../../../shared/worktree/types'
 import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import { isValidResolvedWorktreeLineageEdge } from '../../../../../../shared/resolved-worktree-lineage'
+import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import { getProjectedWorktreeLineage } from '../../worktree-lineage-projection'
-import { getWorktreeLineageGroupKey } from './group-keys'
+import { getFolderWorkspaceAttachedGroupKey, getWorktreeLineageGroupKey } from './group-keys'
 import type { NoticeHostContext } from './host-labels'
 import type { RenderableFolderWorkspace } from './folder-workspace-lanes'
 import type {
@@ -111,6 +112,8 @@ export function appendWorktreeRows(
     hostContextLabelByRepoId?: ReadonlyMap<string, string>
     hostContextLabelByWorktreeIdentity?: ReadonlyMap<string, string>
     cyclicLineageIds: ReadonlySet<string>
+    /** Depth the roots start at — 1 when they render beneath a folder workspace row. */
+    baseDepth?: number
   }
 ): void {
   const {
@@ -120,18 +123,19 @@ export function appendWorktreeRows(
     sectionKey,
     hostContextLabelByRepoId,
     hostContextLabelByWorktreeIdentity,
-    cyclicLineageIds
+    cyclicLineageIds,
+    baseDepth = 0
   } = options
   if (!nestLineage) {
-    for (const worktree of worktrees) {
+    for (const [index, worktree] of worktrees.entries()) {
       result.push(
         buildWorktreeRow(worktree, repoMap, {
           rowKey: `${sectionKey}:${getWorktreeHostIdentity(worktree)}`,
           sectionKey,
-          depth: 0,
+          depth: baseDepth,
           groupDepth,
-          lineageTrail: [],
-          isLastLineageChild: false,
+          lineageTrail: baseDepth > 0 ? [index < worktrees.length - 1] : [],
+          isLastLineageChild: baseDepth > 0 && index === worktrees.length - 1,
           lineageChildCount: 0,
           lineageCollapsed: false,
           hostContextLabel:
@@ -239,14 +243,19 @@ export function appendWorktreeRows(
     (worktree) => !childIdentities.has(getWorktreeHostIdentity(worktree))
   )
   for (const [index, worktree] of roots.entries()) {
-    emit(worktree, 0, [], index === roots.length - 1)
+    emit(
+      worktree,
+      baseDepth,
+      baseDepth > 0 ? [index < roots.length - 1] : [],
+      index === roots.length - 1
+    )
   }
   if (roots.length === 0) {
     for (const worktree of worktrees) {
       if (!emitted.has(getWorktreeHostIdentity(worktree))) {
         // Why: malformed cyclic lineage should not hide every participant.
         // Render any leftovers as roots rather than recursing forever.
-        emit(worktree, 0, [], true)
+        emit(worktree, baseDepth, [], true)
       }
     }
   }
@@ -256,7 +265,8 @@ export function appendWorktreeRows(
  *  grouped-lane and flat emitters so their rows cannot diverge. */
 export function buildFolderWorkspaceRow(
   pair: RenderableFolderWorkspace,
-  groupDepth: number
+  groupDepth: number,
+  attached: { childCount: number; collapsed: boolean } = { childCount: 0, collapsed: false }
 ): FolderWorkspaceRow {
   return {
     type: 'folder-workspace',
@@ -264,6 +274,63 @@ export function buildFolderWorkspaceRow(
     folderWorkspace: pair.folderWorkspace,
     projectGroup: pair.projectGroup,
     depth: 0,
-    groupDepth
+    groupDepth,
+    attachedChildCount: attached.childCount,
+    ...(attached.childCount > 0
+      ? {
+          attachedGroupKey: getFolderWorkspaceAttachedGroupKey(pair.folderWorkspace.id),
+          attachedCollapsed: attached.collapsed
+        }
+      : {})
+  }
+}
+
+/**
+ * Emits each folder workspace row followed by its attached worktrees, nested one
+ * level deep (cross-status nesting: a child renders under its folder whatever
+ * lane the child's own status would have put it in).
+ */
+export function appendFolderWorkspaceRows(
+  result: Row[],
+  pairs: readonly RenderableFolderWorkspace[],
+  groupDepth: number,
+  options: {
+    attachedByFolderId: ReadonlyMap<string, Worktree[]>
+    repoMap: Map<string, Repo>
+    lineageById: Record<string, WorktreeLineage>
+    worktreeMap: Map<string, Worktree>
+    nestLineage: boolean
+    collapsedGroups: Set<string>
+    cyclicLineageIds: ReadonlySet<string>
+    hostContextLabelByWorktreeIdentity?: ReadonlyMap<string, string>
+  }
+): void {
+  for (const pair of pairs) {
+    const attached = options.attachedByFolderId.get(pair.folderWorkspace.id) ?? []
+    const collapsed = options.collapsedGroups.has(
+      getFolderWorkspaceAttachedGroupKey(pair.folderWorkspace.id)
+    )
+    result.push(
+      buildFolderWorkspaceRow(pair, groupDepth, { childCount: attached.length, collapsed })
+    )
+    if (attached.length === 0 || collapsed) {
+      continue
+    }
+    appendWorktreeRows(
+      result,
+      attached,
+      options.repoMap,
+      options.lineageById,
+      options.worktreeMap,
+      {
+        nestLineage: options.nestLineage,
+        collapsedGroups: options.collapsedGroups,
+        groupDepth,
+        sectionKey: folderWorkspaceKey(pair.folderWorkspace.id),
+        hostContextLabelByWorktreeIdentity: options.hostContextLabelByWorktreeIdentity,
+        cyclicLineageIds: options.cyclicLineageIds,
+        baseDepth: 1
+      }
+    )
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
@@ -3,13 +3,10 @@ import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-
 import type { Worktree } from '../../../../../../shared/worktree/types'
 import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import { isValidResolvedWorktreeLineageEdge } from '../../../../../../shared/resolved-worktree-lineage'
-import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import { getProjectedWorktreeLineage } from '../../worktree-lineage-projection'
-import { getFolderWorkspaceAttachedGroupKey, getWorktreeLineageGroupKey } from './group-keys'
+import { getWorktreeLineageGroupKey } from './group-keys'
 import type { NoticeHostContext } from './host-labels'
-import type { RenderableFolderWorkspace } from './folder-workspace-lanes'
 import type {
-  FolderWorkspaceRow,
   ImportedWorktreesCardCandidate,
   ImportedWorktreesCardRow,
   NewExternalWorktreesInboxCandidate,
@@ -258,79 +255,5 @@ export function appendWorktreeRows(
         emit(worktree, baseDepth, [], true)
       }
     }
-  }
-}
-
-/** The one folder-workspace row constructor, shared by the project-group,
- *  grouped-lane and flat emitters so their rows cannot diverge. */
-export function buildFolderWorkspaceRow(
-  pair: RenderableFolderWorkspace,
-  groupDepth: number,
-  attached: { childCount: number; collapsed: boolean } = { childCount: 0, collapsed: false }
-): FolderWorkspaceRow {
-  return {
-    type: 'folder-workspace',
-    key: `folder-workspace:${pair.folderWorkspace.id}`,
-    folderWorkspace: pair.folderWorkspace,
-    projectGroup: pair.projectGroup,
-    depth: 0,
-    groupDepth,
-    attachedChildCount: attached.childCount,
-    ...(attached.childCount > 0
-      ? {
-          attachedGroupKey: getFolderWorkspaceAttachedGroupKey(pair.folderWorkspace.id),
-          attachedCollapsed: attached.collapsed
-        }
-      : {})
-  }
-}
-
-/**
- * Emits each folder workspace row followed by its attached worktrees, nested one
- * level deep (cross-status nesting: a child renders under its folder whatever
- * lane the child's own status would have put it in).
- */
-export function appendFolderWorkspaceRows(
-  result: Row[],
-  pairs: readonly RenderableFolderWorkspace[],
-  groupDepth: number,
-  options: {
-    attachedByFolderId: ReadonlyMap<string, Worktree[]>
-    repoMap: Map<string, Repo>
-    lineageById: Record<string, WorktreeLineage>
-    worktreeMap: Map<string, Worktree>
-    nestLineage: boolean
-    collapsedGroups: Set<string>
-    cyclicLineageIds: ReadonlySet<string>
-    hostContextLabelByWorktreeIdentity?: ReadonlyMap<string, string>
-  }
-): void {
-  for (const pair of pairs) {
-    const attached = options.attachedByFolderId.get(pair.folderWorkspace.id) ?? []
-    const collapsed = options.collapsedGroups.has(
-      getFolderWorkspaceAttachedGroupKey(pair.folderWorkspace.id)
-    )
-    result.push(
-      buildFolderWorkspaceRow(pair, groupDepth, { childCount: attached.length, collapsed })
-    )
-    if (attached.length === 0 || collapsed) {
-      continue
-    }
-    appendWorktreeRows(
-      result,
-      attached,
-      options.repoMap,
-      options.lineageById,
-      options.worktreeMap,
-      {
-        nestLineage: options.nestLineage,
-        collapsedGroups: options.collapsedGroups,
-        groupDepth,
-        sectionKey: folderWorkspaceKey(pair.folderWorkspace.id),
-        hostContextLabelByWorktreeIdentity: options.hostContextLabelByWorktreeIdentity,
-        cyclicLineageIds: options.cyclicLineageIds,
-        baseDepth: 1
-      }
-    )
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/row-types.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/row-types.ts
@@ -91,6 +91,11 @@ export type FolderWorkspaceRow = {
   projectGroup: ProjectGroup
   depth: number
   groupDepth: number
+  /** Worktrees whose workspace lineage names this folder workspace as parent;
+   *  they render nested beneath the row instead of as rows of their own. */
+  attachedChildCount?: number
+  attachedGroupKey?: string
+  attachedCollapsed?: boolean
 }
 
 /** Minimal shape buildRows needs for an in-flight create. Deliberately not the

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
@@ -7,7 +7,10 @@ import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { ProjectOrderBy } from '../../../../../../shared/ui-chrome-types'
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../../../shared/worktree/types'
-import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-types'
+import type {
+  WorkspaceLineage,
+  WorktreeLineage
+} from '../../../../../../shared/worktree/lineage-types'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import { getHostDisplayLabelOverrides } from '../../../../../../shared/host-setting-overrides'
@@ -31,6 +34,7 @@ type SectionRowsArgs = {
   repoMap: Map<string, Repo>
   worktreeMap: Map<string, Worktree>
   worktreeLineageById: Record<string, WorktreeLineage>
+  workspaceLineageByChildKey: Record<string, WorkspaceLineage>
   prCache: AppState['prCache'] | null
   settings: AppState['settings']
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
@@ -165,7 +169,8 @@ export function useSidebarSectionRows(args: SectionRowsArgs) {
         args.visibleFolderWorkspacesForRows,
         hostLabelById,
         defaultHostId,
-        args.pinnedDisplayPolicy
+        args.pinnedDisplayPolicy,
+        args.workspaceLineageByChildKey
       ),
     [
       args.groupBy,
@@ -188,7 +193,8 @@ export function useSidebarSectionRows(args: SectionRowsArgs) {
       args.newExternalWorktreesInboxByRepo,
       pendingCreations,
       hostLabelById,
-      args.pinnedDisplayPolicy
+      args.pinnedDisplayPolicy,
+      args.workspaceLineageByChildKey
     ]
   )
   const orderedHostOptions = useMemo(

--- a/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
@@ -12,6 +12,7 @@ import type { FolderWorkspacePathStatus } from '../../../../../../shared/folder-
 import { isConfirmedStaleFolderPathStatus } from '../../../../../../shared/folder-workspace-path-status'
 import { folderWorkspaceToWorktree } from '../../../../../../shared/folder-workspace-worktree'
 import WorktreeCard from '../../WorktreeCard'
+import type { LineageToggleHandler } from '../../worktree-lineage-toggle-handler-cache'
 import type { WorktreeGroupBy } from '../grouping/row-types'
 import { getVirtualRowTransform } from '../viewport/virtual-rows'
 import { getFolderWorkspaceRowGeometry } from './indentation'
@@ -49,6 +50,7 @@ export type FolderWorkspaceRowContext = {
     worktree: Worktree,
     rowKey: string
   ) => void
+  getLineageToggleHandler: (groupKey: string) => LineageToggleHandler
 }
 
 export function renderFolderWorkspaceVirtualRow(args: {
@@ -122,6 +124,11 @@ export function renderFolderWorkspaceVirtualRow(args: {
           onSelectionGesture={(event) => ctx.onSelectionGesture(event, folderWorktree)}
           onContextMenuSelect={ctx.onContextMenuSelect}
           statusPrDisplay={folderPrDisplay}
+          lineageChildCount={row.attachedChildCount ?? 0}
+          lineageCollapsed={row.attachedCollapsed ?? false}
+          onLineageToggle={
+            row.attachedGroupKey ? ctx.getLineageToggleHandler(row.attachedGroupKey) : undefined
+          }
         />
         <div className="pointer-events-auto absolute right-3 top-1.5">
           <FolderPathStatusIndicator status={pathStatus} />

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
@@ -153,7 +153,8 @@ export function buildWorktreeVirtualRowContext(args: BuildArgs): WorktreeVirtual
       onContextMenuSelect: props.onContextMenuSelect,
       onImmediateActivate: primaryActive.handleImmediateWorktreeRowActivate,
       onRowClickCapture: args.onRowClickCapture,
-      onRowPointerDown: args.onRowPointerDown
+      onRowPointerDown: args.onRowPointerDown,
+      getLineageToggleHandler: args.getLineageToggleHandler
     }
   }
 }


### PR DESCRIPTION
### ELI5

A ticket's folder workspace and its repo branches now behave as one thing: you can attach existing branches to the workspace, the sidebar tucks them under the ticket's card (in every grouping, including status lanes), and the ticket itself gets a card on the Workspace Board.

### What Changed

Three feature slices, with follow-up review corrections:

1. **`worktree set` accepts a folder workspace parent.** `updateRuntimeManagedWorktreeMetadata` resolves `--parent-worktree` through the lineage controller's workspace-aware `resolveParent` (the same routing `create` gained in #5743). A folder parent writes workspace lineage only and clears any worktree-lineage row; the folder must share the worktree's execution host (`LINEAGE_PARENT_CONTEXT_CONFLICT` otherwise). The folder side is resolved with `resolveFolderWorkspaceHost`, so `local` and `runtime:` compare as the same host and SSH compares by target id; a folder that resolves as `ambiguous` or `missing` is rejected. Folder selectors are resolved only in the selected runtime's own Store, before lineage is written. The local/runtime alias is intentional within that store: folder `executionHostId` is a renderer-only stamp, not persisted authority. No runtime-environment comparison is made against that absent field. Worktree parents are unchanged. Help text for `worktree set` now lists the folder/worktree selector forms.
2. **Sidebar nesting.** `getAttachedWorktreesByFolderWorkspaceId` derives each rendered folder's attached children from `workspaceLineageByChildKey`, matching each lineage record to its child by host-qualified identity and `childInstanceId`, so two hosts sharing a bare worktree id cannot nest the wrong row (a record that cannot be pinned to exactly one row is skipped); the board folds attached children by the same host-qualified identity; `appendFolderWorkspaceRows` emits the folder row followed by its children at depth 1, in every Group by mode and lane. `FolderWorkspaceRow` carries `attachedChildCount` / `attachedGroupKey` / `attachedCollapsed`, and the folder card gets the existing lineage chip and collapse toggle. Attached children are removed from their ordinary lanes; pinned children keep their pinned placement; children of an unrendered folder stay visible as ordinary rows.
3. **Workspace Board.** `buildWorkspaceBoardWorktrees` feeds the board git worktrees minus attached children plus each live folder workspace via `folderWorkspaceToWorktree`. Folder entries bypass the git-only visibility filters (default branch, detached HEAD, other devices) in the projection but honour the workspace host filter, matching the sidebar. Status moves on a folder card persist through the existing folder-aware `updateWorktreeMeta` path.

### Why

These are the items the folder-workspace design deferred after its first slice: *manual attach/detach* and *nesting under the folder workspace within each status lane*. Without them a multi-repo ticket reads as one card in one place and several loose rows in others, and any workspace not created by Orca itself can never be linked at all.

### Tests

- `runtime-managed-worktree-metadata.test.ts`: folder parent writes workspace lineage only and clears worktree lineage; runtime-host worktree attaches to a local folder; same-target SSH attaches; cross-host and cross-target folder parents rejected.
- `folder-workspace-attached.test.ts`: same id on two hosts nests only the instance the record names, or neither when no instance is recorded; stale instance and archived child ignored.
- `use-workspace-kanban-board-projection.test.tsx`: folder card hidden when its host is filtered out, shown when visible or under the all-hosts scope.
- `workspace-kanban-folder-workspaces.test.ts`: with the same worktree id on two hosts and only one instance attached, the other host's row stays on the board.
- `runtime-managed-worktree-metadata.folder-store.test.ts`: seven cases exercise real Store creation/reload and the production folder-parent resolver: persisted local/runtime/SSH attachments, discarded renderer stamps, foreign-store folder rejection, colliding folder IDs staying store-local, and SSH-parent rejection without metadata or lineage changes. Git discovery is stubbed; these are store/resolver integration tests, not multi-runtime transport E2E tests.
- `runtime-managed-worktree-metadata.test.ts`: retains runtime-local/SSH host rejection; removes the two artificial stamped-folder fixtures.
- `build-rows.folder-workspace-lanes.test.ts`: nesting in all four Group by modes, collapse, pinned child, unrendered folder, stale child instance.
- `workspace-kanban-folder-workspaces.test.ts` + `WorkspaceKanbanDrawer.search.test.tsx`: folder cards on the board, attached child folded in, archived folder releases its child.
- Original feature validation: sidebar suite plus runtime metadata tests (304 files / 2,554 tests), typecheck and lint/format checks passed. The current correction validation is listed below.

### Notes

The right sidebar's existing `getLineageChildWorktree` still resolves lineage children by bare worktree id, so it has the same cross-host ambiguity this PR closes in the new sidebar lookup. Left untouched here; it is a separate change to that view.

Fixes #18198.



### Review follow-up validation

- 31 focused test files: 311 passed, 0 failed, 0 skipped (runtime metadata/lineage, persistence, CLI/RPC routing, folder-host resolution, and affected sidebar/board/catalog tests).
- `pnpm run typecheck`
- `pnpm exec oxlint <three changed files>` plus the React Doctor and type-aware configurations on those files.
- `pnpm exec oxfmt --write <three changed files>`
- `pnpm run check:max-lines-ratchet`
- `git diff --cached --check`
