### PR TITLE
fix(cli): report host scope for worktree list and worktree ps

### DIFF
--- a/src/cli/index-worktree-list-host-scope.test.ts
+++ b/src/cli/index-worktree-list-host-scope.test.ts
@@ -88,7 +88,8 @@ describe('orca worktree list host scope', () => {
     expect(printed.result.worktrees[0].hostId).toBe('ssh:box-1')
     expect(printed.result.hostScope).toMatchObject({
       hostIds: ['ssh:box-1'],
-      omittedHostIds: ['local']
+      omittedHostIds: ['local'],
+      omittedHostSelectors: [{ hostId: 'local', selector: '--host local' }]
     })
   })
 

--- a/src/cli/index-worktree-list-host-scope.test.ts
+++ b/src/cli/index-worktree-list-host-scope.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const {
+  callMock,
+  runtimeClientConstructorMock,
+  serveOrcaAppMock,
+  getDefaultUserDataPathMock,
+  addEnvironmentFromPairingCodeMock,
+  listEnvironmentsMock,
+  spawnMock
+} = vi.hoisted(() => ({
+  callMock: vi.fn(),
+  runtimeClientConstructorMock: vi.fn(),
+  serveOrcaAppMock: vi.fn(),
+  getDefaultUserDataPathMock: vi.fn(() => '/tmp/orca-user-data'),
+  addEnvironmentFromPairingCodeMock: vi.fn(),
+  listEnvironmentsMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('./runtime-client', async () => {
+  const { createRuntimeClientModuleMock } = await import('./index-test-harness.js')
+  return createRuntimeClientModuleMock({
+    callMock,
+    runtimeClientConstructorMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock
+  })
+})
+
+vi.mock('./runtime/environments', () => ({
+  addEnvironmentFromPairingCode: addEnvironmentFromPairingCodeMock,
+  listEnvironments: listEnvironmentsMock,
+  removeEnvironment: vi.fn(),
+  resolveEnvironment: vi.fn()
+}))
+
+vi.mock('child_process', async () => {
+  const { createChildProcessModuleMock } = await import('./index-test-harness.js')
+  return createChildProcessModuleMock(spawnMock)
+})
+
+import { main } from './index'
+import { okFixture, queueFixtures } from './test-fixtures'
+import { useWorktreeAwarenessEnvironment } from './index-test-harness'
+
+const SSH_WORKTREE_ROW = {
+  id: 'repo-ssh::/remote/wt',
+  repoId: 'repo-ssh',
+  path: '/remote/wt',
+  branch: 'main',
+  displayName: 'remote',
+  isArchived: false,
+  isMainWorktree: true,
+  linkedIssue: null,
+  parentWorktreeId: null,
+  childWorktreeIds: [],
+  lineage: null,
+  hostId: 'ssh:box-1',
+  git: { isClean: true, ahead: 0, behind: 0 }
+}
+
+describe('orca worktree list host scope', () => {
+  useWorktreeAwarenessEnvironment({
+    callMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock,
+    addEnvironmentFromPairingCodeMock,
+    listEnvironmentsMock,
+    spawnMock
+  })
+
+  it('keeps the execution host and scope in --json output', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_worktree_list', {
+        worktrees: [SSH_WORKTREE_ROW],
+        totalCount: 1,
+        truncated: false,
+        hostScope: { hostIds: ['ssh:box-1'], omittedHostIds: ['local'] }
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['worktree', 'list', '--json'], '/tmp/repo')
+
+    const printed = JSON.parse(String(logSpy.mock.calls[0]?.[0]))
+    expect(printed.result.worktrees[0].hostId).toBe('ssh:box-1')
+    expect(printed.result.hostScope).toMatchObject({
+      hostIds: ['ssh:box-1'],
+      omittedHostIds: ['local']
+    })
+  })
+
+  it('prints the execution host and scope in human output', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_worktree_list', {
+        worktrees: [SSH_WORKTREE_ROW],
+        totalCount: 1,
+        truncated: false,
+        hostScope: { hostIds: ['ssh:box-1'], omittedHostIds: ['local'] }
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['worktree', 'list'], '/tmp/repo')
+
+    const printed = String(logSpy.mock.calls[0]?.[0])
+    expect(printed).toContain('host=ssh:box-1')
+    expect(printed).toContain('scope: ssh:box-1')
+    expect(printed).toContain('not covered: local')
+  })
+})
+
+describe('orca worktree ps host scope', () => {
+  useWorktreeAwarenessEnvironment({
+    callMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock,
+    addEnvironmentFromPairingCodeMock,
+    listEnvironmentsMock,
+    spawnMock
+  })
+
+  it('keeps the execution host and scope in --json output', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_worktree_ps', {
+        worktrees: [
+          {
+            worktreeId: SSH_WORKTREE_ROW.id,
+            repoId: SSH_WORKTREE_ROW.repoId,
+            hostId: 'ssh:box-1',
+            repo: 'ssh',
+            path: SSH_WORKTREE_ROW.path,
+            branch: SSH_WORKTREE_ROW.branch,
+            isArchived: false,
+            isMainWorktree: true,
+            hasHostSidebarActivity: false,
+            parentWorktreeId: null,
+            childWorktreeIds: [],
+            displayName: 'remote',
+            workspaceStatus: 'active',
+            sortOrder: 0,
+            linkedIssue: null,
+            linkedPR: null,
+            linkedLinearIssue: null,
+            linkedGitLabMR: null,
+            linkedGitLabIssue: null,
+            comment: '',
+            isPinned: false,
+            isActive: false,
+            unread: false,
+            liveTerminalCount: 0,
+            hasAttachedPty: false,
+            lastOutputAt: null,
+            preview: '',
+            status: 'inactive',
+            agents: []
+          }
+        ],
+        totalCount: 1,
+        truncated: false,
+        hostScope: { hostIds: ['ssh:box-1'], omittedHostIds: ['local'] }
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['worktree', 'ps', '--json'], '/tmp/repo')
+
+    const printed = JSON.parse(String(logSpy.mock.calls[0]?.[0]))
+    expect(printed.result.worktrees[0].hostId).toBe('ssh:box-1')
+    expect(printed.result.hostScope).toMatchObject({
+      hostIds: ['ssh:box-1'],
+      omittedHostIds: ['local'],
+      omittedHostSelectors: [{ hostId: 'local', selector: '--host local' }]
+    })
+  })
+})

--- a/src/cli/worktree-list-host-scope-format.test.ts
+++ b/src/cli/worktree-list-host-scope-format.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import { formatWorktreeList, formatWorktreePs } from './format'
+import type {
+  RuntimeWorktreeListResult,
+  RuntimeWorktreePsResult,
+  RuntimeWorktreePsSummary,
+  RuntimeWorktreeRecord
+} from '../shared/runtime-types'
+
+function worktreeRecord(overrides: Partial<RuntimeWorktreeRecord> = {}): RuntimeWorktreeRecord {
+  return {
+    id: 'repo::/repo',
+    repoId: 'repo',
+    path: '/repo',
+    branch: 'main',
+    displayName: 'main',
+    isArchived: false,
+    isMainWorktree: true,
+    linkedIssue: null,
+    parentWorktreeId: null,
+    childWorktreeIds: [],
+    lineage: null,
+    git: { isClean: true, ahead: 0, behind: 0 },
+    ...overrides
+  }
+}
+
+function worktreePsSummary(
+  overrides: Partial<RuntimeWorktreePsSummary> = {}
+): RuntimeWorktreePsSummary {
+  return {
+    worktreeId: 'repo::/repo',
+    repoId: 'repo',
+    repo: 'repo',
+    path: '/repo',
+    branch: 'main',
+    isArchived: false,
+    isMainWorktree: true,
+    hasHostSidebarActivity: false,
+    parentWorktreeId: null,
+    childWorktreeIds: [],
+    displayName: 'main',
+    workspaceStatus: 'active',
+    sortOrder: 0,
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    comment: '',
+    isPinned: false,
+    isActive: false,
+    unread: false,
+    liveTerminalCount: 0,
+    hasAttachedPty: false,
+    lastOutputAt: null,
+    preview: '',
+    status: 'inactive',
+    agents: [],
+    ...overrides
+  }
+}
+
+function listResult(overrides: Partial<RuntimeWorktreeListResult> = {}): RuntimeWorktreeListResult {
+  return { worktrees: [worktreeRecord()], totalCount: 1, truncated: false, ...overrides }
+}
+
+function psResult(overrides: Partial<RuntimeWorktreePsResult> = {}): RuntimeWorktreePsResult {
+  return { worktrees: [worktreePsSummary()], totalCount: 1, truncated: false, ...overrides }
+}
+
+describe('formatWorktreeList host identity', () => {
+  it('prints the execution host each worktree runs on', () => {
+    const output = formatWorktreeList(
+      listResult({ worktrees: [worktreeRecord({ hostId: 'ssh:box-1' })] })
+    )
+
+    expect(output).toContain('host=ssh:box-1')
+  })
+
+  it('prints unverifiable, not local, for a row whose host the runtime could not name', () => {
+    const output = formatWorktreeList(listResult())
+
+    expect(output).toContain('host=unverifiable')
+    expect(output).not.toContain('host=local')
+  })
+})
+
+describe('formatWorktreeList scope declaration', () => {
+  it('states the covered and omitted hosts', () => {
+    const output = formatWorktreeList(
+      listResult({
+        hostScope: { hostIds: ['local'], omittedHostIds: ['ssh:box-1'] }
+      })
+    )
+
+    expect(output).toContain('scope: local')
+    expect(output).toContain('not covered: ssh:box-1')
+  })
+
+  it('keeps an empty listing self-describing instead of reading as absolute', () => {
+    const output = formatWorktreeList(
+      listResult({
+        worktrees: [],
+        totalCount: 0,
+        hostScope: { hostIds: ['local'], omittedHostIds: ['ssh:box-1'] }
+      })
+    )
+
+    expect(output).toContain('No worktrees found')
+    expect(output).toContain('scope: local')
+    expect(output).toContain('not covered: ssh:box-1')
+  })
+
+  it('says the scope is unverifiable when the host predates the field', () => {
+    const output = formatWorktreeList(listResult())
+
+    expect(output).toContain('scope: unverifiable')
+    expect(output).not.toContain('scope: local')
+  })
+})
+
+describe('formatWorktreePs host identity', () => {
+  it('prints the execution host each worktree runs on', () => {
+    const output = formatWorktreePs(
+      psResult({ worktrees: [worktreePsSummary({ hostId: 'ssh:box-1' })] })
+    )
+
+    expect(output).toContain('host=ssh:box-1')
+  })
+})
+
+describe('formatWorktreePs scope declaration', () => {
+  it('states the covered and omitted hosts', () => {
+    const output = formatWorktreePs(
+      psResult({
+        hostScope: { hostIds: ['local'], omittedHostIds: ['ssh:box-1'] }
+      })
+    )
+
+    expect(output).toContain('scope: local')
+    expect(output).toContain('not covered: ssh:box-1')
+  })
+})

--- a/src/main/runtime/runtime-worktree-catalog-host-scope.test.ts
+++ b/src/main/runtime/runtime-worktree-catalog-host-scope.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
+import type { Repo } from '../../shared/repo-types'
+import type { RuntimeWorktreeRecord } from '../../shared/runtime-worktree-contracts'
+import {
+  buildWorktreeListCatalogResult,
+  buildWorktreeListHostScope
+} from './runtime-worktree-catalog-host-scope'
+
+const PLAIN_LOCAL_REPO: Repo = {
+  id: 'repo-plain-local',
+  path: '/tmp/plain-local',
+  displayName: 'plain-local',
+  badgeColor: '#000000',
+  addedAt: 0
+}
+
+function plainLocalWorktree(path: string): RuntimeWorktreeRecord {
+  const git = {
+    path,
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: true
+  }
+  return {
+    id: `${PLAIN_LOCAL_REPO.id}::${path}`,
+    repoId: PLAIN_LOCAL_REPO.id,
+    displayName: path,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    parentWorktreeId: null,
+    childWorktreeIds: [],
+    lineage: null,
+    ...git,
+    git
+  }
+}
+
+describe('buildWorktreeListHostScope', () => {
+  it('counts plain local rows under LOCAL_EXECUTION_HOST_ID', () => {
+    const repoById = new Map([[PLAIN_LOCAL_REPO.id, PLAIN_LOCAL_REPO]])
+    const rows = [
+      plainLocalWorktree('/tmp/plain-local/wt-a'),
+      plainLocalWorktree('/tmp/plain-local/wt-b')
+    ]
+
+    const hostScope = buildWorktreeListHostScope(rows, rows, repoById, new Set(), () => new Set())
+
+    expect(hostScope.hostIds).toEqual([LOCAL_EXECUTION_HOST_ID])
+    expect(hostScope.omittedHostIds).toEqual([])
+  })
+})
+
+describe('buildWorktreeListCatalogResult', () => {
+  it('keeps plain local rows in hostScope.hostIds', () => {
+    const rows = [plainLocalWorktree('/tmp/plain-local/wt-a')]
+
+    const result = buildWorktreeListCatalogResult(rows, 200, [PLAIN_LOCAL_REPO], () => new Set())
+
+    expect(result.hostScope?.hostIds).toEqual([LOCAL_EXECUTION_HOST_ID])
+    expect(result.hostScope?.omittedHostIds).toEqual([])
+  })
+})

--- a/src/main/runtime/runtime-worktree-ps-summaries.test.ts
+++ b/src/main/runtime/runtime-worktree-ps-summaries.test.ts
@@ -34,4 +34,40 @@ describe('buildRuntimeWorktreePsSummaries', () => {
 
     expect(summary?.hostId).toBe('ssh:persisted-host')
   })
+
+  it('stamps folder-workspace host ownership from the resolved worktree row', () => {
+    const folderWorkspace = {
+      id: 'folder-ssh',
+      projectGroupId: 'group-1',
+      name: 'SSH folder',
+      folderPath: '/remote/folder',
+      connectionId: 'box-2',
+      linkedTask: null,
+      comment: '',
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 0,
+      createdAt: 0,
+      updatedAt: 0
+    }
+    const store = {
+      getRepos: () => [],
+      getWorktreeMeta: () => undefined,
+      getAllWorktreeMeta: () => ({}),
+      getFolderWorkspaces: () => [folderWorkspace],
+      getProjectGroups: () => [{ id: 'group-1', name: 'Group', parentPath: '/remote' }]
+    } as unknown as RuntimeStore
+
+    const summary = [
+      ...buildRuntimeWorktreePsSummaries({
+        store,
+        resolvedWorktrees: [],
+        platformByRepoId: new Map()
+      }).values()
+    ][0]
+
+    expect(summary?.hostId).toBe('ssh:box-2')
+  })
 })

--- a/src/main/runtime/runtime-worktree-ps-summaries.ts
+++ b/src/main/runtime/runtime-worktree-ps-summaries.ts
@@ -88,6 +88,7 @@ export function buildRuntimeWorktreePsSummaries(args: {
       workspaceKind: 'folder-workspace',
       worktreeId: worktree.id,
       repoId: worktree.repoId,
+      ...(worktree.hostId ? { hostId: worktree.hostId } : {}),
       repo: projectGroup.name,
       path: worktree.path,
       branch: worktree.branch,

--- a/src/main/runtime/worktree-list-execution-host-scope.test.ts
+++ b/src/main/runtime/worktree-list-execution-host-scope.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import { getDefaultWorkspaceSession } from '../../shared/constants'
+import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
+import type { GitWorktreeInfo } from '../../shared/worktree/types'
+
+const LOCAL_REPO_ID = 'repo-local'
+const SSH_REPO_ID = 'repo-ssh'
+const DEFAULT_LIST_LIMIT = 200
+
+const REPOS = [
+  {
+    id: LOCAL_REPO_ID,
+    path: '/tmp/local-worktree',
+    displayName: 'local',
+    badgeColor: '#000000',
+    addedAt: 0
+  },
+  {
+    id: SSH_REPO_ID,
+    path: '/remote/ssh-worktree',
+    displayName: 'ssh',
+    badgeColor: '#000000',
+    addedAt: 0,
+    connectionId: 'box-1'
+  }
+]
+
+type TestResolvedWorktree = {
+  id: string
+  repoId: string
+  path: string
+  branch: string
+  displayName: string
+  hostId: 'local' | 'ssh:box-1'
+  isArchived: boolean
+  isMainWorktree: boolean
+  linkedIssue: null
+  parentWorktreeId: null
+  childWorktreeIds: []
+  lineage: null
+  git: GitWorktreeInfo
+}
+
+function makeStore() {
+  const session: WorkspaceSessionState = getDefaultWorkspaceSession()
+  return {
+    getWorkspaceSession: vi.fn(() => session),
+    getWorkspaceSessionHostIds: vi.fn(() => ['local', 'ssh:box-1']),
+    getFolderWorkspaces: vi.fn(() => []),
+    getProjectGroups: vi.fn(() => []),
+    setWorkspaceSession: vi.fn(),
+    getRepos: vi.fn(() => REPOS),
+    getRepo: vi.fn((id: string) => REPOS.find((repo) => repo.id === id)),
+    getAllWorktreeMeta: vi.fn(() => ({})),
+    getWorktreeMeta: vi.fn(() => undefined),
+    setWorktreeMeta: vi.fn(),
+    removeWorktreeMeta: vi.fn(),
+    getSettings: vi.fn(() => ({ workspaceDir: '/tmp/workspaces' })),
+    getProjects: vi.fn(() => []),
+    getAllWorktreeLineage: vi.fn(() => ({}))
+  }
+}
+
+function resolvedWorktree(
+  repoId: string,
+  path: string,
+  hostId: 'local' | 'ssh:box-1'
+): TestResolvedWorktree {
+  const id = `${repoId}::${path}`
+  return {
+    id,
+    repoId,
+    path,
+    branch: 'main',
+    displayName: path,
+    hostId,
+    isArchived: false,
+    isMainWorktree: true,
+    linkedIssue: null,
+    parentWorktreeId: null,
+    childWorktreeIds: [],
+    lineage: null,
+    git: { path, head: 'abc123', branch: 'refs/heads/main', isBare: false, isMainWorktree: true }
+  }
+}
+
+function qaReproCatalog(): TestResolvedWorktree[] {
+  const localRows = Array.from({ length: 434 }, (_, index) =>
+    resolvedWorktree(LOCAL_REPO_ID, `/aaa/local-${index}`, 'local')
+  )
+  const sshRows = Array.from({ length: 23 }, (_, index) =>
+    resolvedWorktree(SSH_REPO_ID, `/zzz/ssh-${index}`, 'ssh:box-1')
+  )
+  return [...localRows, ...sshRows]
+}
+
+describe('listManagedWorktrees host scope', () => {
+  it('includes SSH rows at the default limit when local worktrees dominate', async () => {
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+    vi.spyOn(
+      runtime as unknown as { listResolvedWorktrees: () => Promise<TestResolvedWorktree[]> },
+      'listResolvedWorktrees'
+    ).mockResolvedValue(qaReproCatalog())
+
+    const result = await runtime.listManagedWorktrees(undefined, DEFAULT_LIST_LIMIT)
+
+    expect(result.truncated).toBe(true)
+    expect(result.totalCount).toBe(457)
+    expect(result.worktrees.length).toBe(DEFAULT_LIST_LIMIT)
+    expect(result.worktrees.some((worktree) => worktree.hostId === 'ssh:box-1')).toBe(true)
+    expect(result.worktrees.filter((worktree) => worktree.hostId === 'ssh:box-1').length).toBe(23)
+    expect(result.hostScope?.hostIds).toEqual(expect.arrayContaining(['local', 'ssh:box-1']))
+    expect(result.hostScope?.omittedHostIds).toEqual([])
+  })
+})
+
+describe('getWorktreePs host scope', () => {
+  it('includes SSH rows at the default limit when local worktrees dominate', async () => {
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+    vi.spyOn(
+      runtime as unknown as {
+        listResolvedWorktreeSnapshot: () => Promise<{
+          worktrees: TestResolvedWorktree[]
+          platformByRepoId: Map<string, 'linux'>
+        }>
+      },
+      'listResolvedWorktreeSnapshot'
+    ).mockResolvedValue({
+      worktrees: qaReproCatalog(),
+      platformByRepoId: new Map([
+        [LOCAL_REPO_ID, 'linux'],
+        [SSH_REPO_ID, 'linux']
+      ])
+    })
+    runtime.setPtyController({
+      spawn: vi.fn(async () => ({ id: 'never' })),
+      write: () => true,
+      kill: () => true,
+      listProcesses: vi.fn(async () => []),
+      listProcessesWithHostScope: vi.fn(async () => ({
+        processes: [],
+        hostIds: ['local', 'ssh:box-1']
+      }))
+    } as never)
+
+    const result = await runtime.getWorktreePs(DEFAULT_LIST_LIMIT)
+
+    expect(result.truncated).toBe(true)
+    expect(result.totalCount).toBe(457)
+    expect(result.worktrees.length).toBe(DEFAULT_LIST_LIMIT)
+    expect(result.worktrees.some((worktree) => worktree.hostId === 'ssh:box-1')).toBe(true)
+    expect(result.worktrees.filter((worktree) => worktree.hostId === 'ssh:box-1').length).toBe(23)
+    expect(result.hostScope?.hostIds).toEqual(expect.arrayContaining(['local', 'ssh:box-1']))
+    expect(result.hostScope?.omittedHostIds).toEqual([])
+  })
+})

--- a/src/main/runtime/worktree-list-execution-host-scope.test.ts
+++ b/src/main/runtime/worktree-list-execution-host-scope.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
 import { OrcaRuntimeService } from './orca-runtime'
+import { DEFAULT_WORKTREE_LIST_LIMIT, DEFAULT_WORKTREE_PS_LIMIT } from './orca-runtime-postlude'
 import { getDefaultWorkspaceSession } from '../../shared/constants'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import type { GitWorktreeInfo } from '../../shared/worktree/types'
 
 const LOCAL_REPO_ID = 'repo-local'
 const SSH_REPO_ID = 'repo-ssh'
-const DEFAULT_LIST_LIMIT = 200
+const SSH_HOST_ID = 'ssh:box-1'
+// Round-robin with local-first host order leaves SSH with zero rows at this cap.
+const LIMIT_EXCLUDING_SSH_HOST = 1
 
 const REPOS = [
   {
@@ -46,7 +49,7 @@ function makeStore() {
   const session: WorkspaceSessionState = getDefaultWorkspaceSession()
   return {
     getWorkspaceSession: vi.fn(() => session),
-    getWorkspaceSessionHostIds: vi.fn(() => ['local', 'ssh:box-1']),
+    getWorkspaceSessionHostIds: vi.fn(() => ['local', SSH_HOST_ID]),
     getFolderWorkspaces: vi.fn(() => []),
     getProjectGroups: vi.fn(() => []),
     setWorkspaceSession: vi.fn(),
@@ -90,68 +93,112 @@ function qaReproCatalog(): TestResolvedWorktree[] {
     resolvedWorktree(LOCAL_REPO_ID, `/aaa/local-${index}`, 'local')
   )
   const sshRows = Array.from({ length: 23 }, (_, index) =>
-    resolvedWorktree(SSH_REPO_ID, `/zzz/ssh-${index}`, 'ssh:box-1')
+    resolvedWorktree(SSH_REPO_ID, `/zzz/ssh-${index}`, SSH_HOST_ID)
   )
   return [...localRows, ...sshRows]
+}
+
+function mockListResolvedWorktrees(runtime: OrcaRuntimeService, worktrees: TestResolvedWorktree[]) {
+  vi.spyOn(
+    runtime as unknown as { listResolvedWorktrees: () => Promise<TestResolvedWorktree[]> },
+    'listResolvedWorktrees'
+  ).mockResolvedValue(worktrees)
+}
+
+function mockListResolvedWorktreeSnapshot(
+  runtime: OrcaRuntimeService,
+  worktrees: TestResolvedWorktree[]
+) {
+  vi.spyOn(
+    runtime as unknown as {
+      listResolvedWorktreeSnapshot: () => Promise<{
+        worktrees: TestResolvedWorktree[]
+        platformByRepoId: Map<string, 'linux'>
+      }>
+    },
+    'listResolvedWorktreeSnapshot'
+  ).mockResolvedValue({
+    worktrees,
+    platformByRepoId: new Map([
+      [LOCAL_REPO_ID, 'linux'],
+      [SSH_REPO_ID, 'linux']
+    ])
+  })
+}
+
+function mockPtyControllerWithHostScope(runtime: OrcaRuntimeService) {
+  runtime.setPtyController({
+    spawn: vi.fn(async () => ({ id: 'never' })),
+    write: () => true,
+    kill: () => true,
+    listProcesses: vi.fn(async () => []),
+    listProcessesWithHostScope: vi.fn(async () => ({
+      processes: [],
+      hostIds: ['local', SSH_HOST_ID]
+    }))
+  } as never)
 }
 
 describe('listManagedWorktrees host scope', () => {
   it('includes SSH rows at the default limit when local worktrees dominate', async () => {
     const runtime = new OrcaRuntimeService(makeStore() as never)
-    vi.spyOn(
-      runtime as unknown as { listResolvedWorktrees: () => Promise<TestResolvedWorktree[]> },
-      'listResolvedWorktrees'
-    ).mockResolvedValue(qaReproCatalog())
+    mockListResolvedWorktrees(runtime, qaReproCatalog())
 
-    const result = await runtime.listManagedWorktrees(undefined, DEFAULT_LIST_LIMIT)
+    const result = await runtime.listManagedWorktrees()
 
     expect(result.truncated).toBe(true)
     expect(result.totalCount).toBe(457)
-    expect(result.worktrees.length).toBe(DEFAULT_LIST_LIMIT)
-    expect(result.worktrees.some((worktree) => worktree.hostId === 'ssh:box-1')).toBe(true)
-    expect(result.worktrees.filter((worktree) => worktree.hostId === 'ssh:box-1').length).toBe(23)
-    expect(result.hostScope?.hostIds).toEqual(expect.arrayContaining(['local', 'ssh:box-1']))
+    expect(result.worktrees.length).toBe(DEFAULT_WORKTREE_LIST_LIMIT)
+    expect(result.worktrees.some((worktree) => worktree.hostId === SSH_HOST_ID)).toBe(true)
+    expect(result.worktrees.filter((worktree) => worktree.hostId === SSH_HOST_ID).length).toBe(23)
+    expect(result.hostScope?.hostIds).toEqual(expect.arrayContaining(['local', SSH_HOST_ID]))
     expect(result.hostScope?.omittedHostIds).toEqual([])
+  })
+
+  it('names SSH in omittedHostIds when the cap fully excludes that host', async () => {
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+    mockListResolvedWorktrees(runtime, qaReproCatalog())
+
+    const result = await runtime.listManagedWorktrees(undefined, LIMIT_EXCLUDING_SSH_HOST)
+
+    expect(result.truncated).toBe(true)
+    expect(result.totalCount).toBe(457)
+    expect(result.worktrees.length).toBe(LIMIT_EXCLUDING_SSH_HOST)
+    expect(result.worktrees.every((worktree) => worktree.hostId === 'local')).toBe(true)
+    expect(result.hostScope?.hostIds).toEqual(['local'])
+    expect(result.hostScope?.omittedHostIds).toEqual([SSH_HOST_ID])
   })
 })
 
 describe('getWorktreePs host scope', () => {
   it('includes SSH rows at the default limit when local worktrees dominate', async () => {
     const runtime = new OrcaRuntimeService(makeStore() as never)
-    vi.spyOn(
-      runtime as unknown as {
-        listResolvedWorktreeSnapshot: () => Promise<{
-          worktrees: TestResolvedWorktree[]
-          platformByRepoId: Map<string, 'linux'>
-        }>
-      },
-      'listResolvedWorktreeSnapshot'
-    ).mockResolvedValue({
-      worktrees: qaReproCatalog(),
-      platformByRepoId: new Map([
-        [LOCAL_REPO_ID, 'linux'],
-        [SSH_REPO_ID, 'linux']
-      ])
-    })
-    runtime.setPtyController({
-      spawn: vi.fn(async () => ({ id: 'never' })),
-      write: () => true,
-      kill: () => true,
-      listProcesses: vi.fn(async () => []),
-      listProcessesWithHostScope: vi.fn(async () => ({
-        processes: [],
-        hostIds: ['local', 'ssh:box-1']
-      }))
-    } as never)
+    mockListResolvedWorktreeSnapshot(runtime, qaReproCatalog())
+    mockPtyControllerWithHostScope(runtime)
 
-    const result = await runtime.getWorktreePs(DEFAULT_LIST_LIMIT)
+    const result = await runtime.getWorktreePs()
 
     expect(result.truncated).toBe(true)
     expect(result.totalCount).toBe(457)
-    expect(result.worktrees.length).toBe(DEFAULT_LIST_LIMIT)
-    expect(result.worktrees.some((worktree) => worktree.hostId === 'ssh:box-1')).toBe(true)
-    expect(result.worktrees.filter((worktree) => worktree.hostId === 'ssh:box-1').length).toBe(23)
-    expect(result.hostScope?.hostIds).toEqual(expect.arrayContaining(['local', 'ssh:box-1']))
+    expect(result.worktrees.length).toBe(DEFAULT_WORKTREE_PS_LIMIT)
+    expect(result.worktrees.some((worktree) => worktree.hostId === SSH_HOST_ID)).toBe(true)
+    expect(result.worktrees.filter((worktree) => worktree.hostId === SSH_HOST_ID).length).toBe(23)
+    expect(result.hostScope?.hostIds).toEqual(expect.arrayContaining(['local', SSH_HOST_ID]))
     expect(result.hostScope?.omittedHostIds).toEqual([])
+  })
+
+  it('names SSH in omittedHostIds when the cap fully excludes that host', async () => {
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+    mockListResolvedWorktreeSnapshot(runtime, qaReproCatalog())
+    mockPtyControllerWithHostScope(runtime)
+
+    const result = await runtime.getWorktreePs(LIMIT_EXCLUDING_SSH_HOST)
+
+    expect(result.truncated).toBe(true)
+    expect(result.totalCount).toBe(457)
+    expect(result.worktrees.length).toBe(LIMIT_EXCLUDING_SSH_HOST)
+    expect(result.worktrees.every((worktree) => worktree.hostId === 'local')).toBe(true)
+    expect(result.hostScope?.hostIds).toEqual(['local'])
+    expect(result.hostScope?.omittedHostIds).toEqual([SSH_HOST_ID])
   })
 })

--- a/src/main/runtime/worktree-listing-host-scope-local-fallback.test.ts
+++ b/src/main/runtime/worktree-listing-host-scope-local-fallback.test.ts
@@ -3,9 +3,9 @@ import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import type { Repo } from '../../shared/repo-types'
 import type { RuntimeWorktreeRecord } from '../../shared/runtime-worktree-contracts'
 import {
-  buildWorktreeListCatalogResult,
-  buildWorktreeListHostScope
-} from './runtime-worktree-catalog-host-scope'
+  buildWorktreeListingHostScope,
+  buildWorktreeListingPage
+} from './worktree-listing-host-scope'
 
 const PLAIN_LOCAL_REPO: Repo = {
   id: 'repo-plain-local',
@@ -44,28 +44,31 @@ function plainLocalWorktree(path: string): RuntimeWorktreeRecord {
   }
 }
 
-describe('buildWorktreeListHostScope', () => {
+describe('buildWorktreeListingHostScope', () => {
   it('counts plain local rows under LOCAL_EXECUTION_HOST_ID', () => {
-    const repoById = new Map([[PLAIN_LOCAL_REPO.id, PLAIN_LOCAL_REPO]])
     const rows = [
       plainLocalWorktree('/tmp/plain-local/wt-a'),
       plainLocalWorktree('/tmp/plain-local/wt-b')
     ]
 
-    const hostScope = buildWorktreeListHostScope(rows, rows, repoById, new Set(), () => new Set())
+    const hostScope = buildWorktreeListingHostScope({
+      pageHostIds: rows.map((row) => row.hostId),
+      matchedHostIds: rows.map((row) => row.hostId),
+      knownHostIds: []
+    })
 
     expect(hostScope.hostIds).toEqual([LOCAL_EXECUTION_HOST_ID])
     expect(hostScope.omittedHostIds).toEqual([])
   })
 })
 
-describe('buildWorktreeListCatalogResult', () => {
+describe('buildWorktreeListingPage', () => {
   it('keeps plain local rows in hostScope.hostIds', () => {
     const rows = [plainLocalWorktree('/tmp/plain-local/wt-a')]
 
-    const result = buildWorktreeListCatalogResult(rows, 200, [PLAIN_LOCAL_REPO], () => new Set())
+    const result = buildWorktreeListingPage(rows, 200, [])
 
-    expect(result.hostScope?.hostIds).toEqual([LOCAL_EXECUTION_HOST_ID])
-    expect(result.hostScope?.omittedHostIds).toEqual([])
+    expect(result.hostScope.hostIds).toEqual([LOCAL_EXECUTION_HOST_ID])
+    expect(result.hostScope.omittedHostIds).toEqual([])
   })
 })

--- a/src/main/runtime/worktree-listing-host-scope.ts
+++ b/src/main/runtime/worktree-listing-host-scope.ts
@@ -1,5 +1,9 @@
 import type { Repo } from '../../shared/repo-types'
-import { getRepoExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  type ExecutionHostId
+} from '../../shared/execution-host'
 import { selectHostBalancedPage } from '../../shared/host-balanced-listing-page'
 import type { RuntimeListingHostScope } from '../../shared/runtime-listing-host-scope'
 
@@ -23,7 +27,7 @@ export function buildWorktreeListingPage<TRow extends { hostId?: ExecutionHostId
   totalCount: number
   truncated: boolean
 } {
-  const page = selectHostBalancedPage(rows, limit, (row) => row.hostId)
+  const page = selectHostBalancedPage(rows, limit, (row) => row.hostId ?? LOCAL_EXECUTION_HOST_ID)
   return {
     worktrees: page,
     hostScope: buildWorktreeListingHostScope({
@@ -49,16 +53,16 @@ export function buildWorktreeListingHostScope(args: {
   /** Hosts this runtime has configured repos or workspaces on, even if they contributed no rows. */
   knownHostIds: Iterable<ExecutionHostId>
 }): RuntimeListingHostScope {
+  const normalizeHostId = (hostId: ExecutionHostId | undefined) => hostId ?? LOCAL_EXECUTION_HOST_ID
   const covered = new Set<ExecutionHostId>()
   for (const hostId of args.pageHostIds) {
-    if (hostId) {
-      covered.add(hostId)
-    }
+    covered.add(normalizeHostId(hostId))
   }
   const omitted = new Set<ExecutionHostId>()
   for (const hostId of [...args.matchedHostIds, ...args.knownHostIds]) {
-    if (hostId && !covered.has(hostId)) {
-      omitted.add(hostId)
+    const normalized = normalizeHostId(hostId)
+    if (!covered.has(normalized)) {
+      omitted.add(normalized)
     }
   }
   return { hostIds: [...covered].sort(), omittedHostIds: [...omitted].sort() }

--- a/src/main/runtime/worktree-ps-host-scope.test.ts
+++ b/src/main/runtime/worktree-ps-host-scope.test.ts
@@ -128,4 +128,39 @@ describe('worktree.ps host coverage', () => {
     )
     expect(result.hostScope?.hostIds).toEqual(['local', `ssh:${SSH_CONNECTION_ID}`])
   })
+
+  it('attributes an SSH folder workspace to its execution host in hostScope', async () => {
+    const folderWorkspace = {
+      id: 'folder-ssh',
+      projectGroupId: 'group-1',
+      name: 'SSH folder',
+      folderPath: '/remote/folder',
+      connectionId: 'box-2',
+      linkedTask: null,
+      comment: '',
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 0,
+      createdAt: 0,
+      updatedAt: 0
+    }
+    const runtime = new OrcaRuntimeService({
+      ...makeStore(),
+      getFolderWorkspaces: () => [folderWorkspace],
+      getProjectGroups: () => [{ id: 'group-1', name: 'Group', parentPath: '/remote' }]
+    } as never)
+
+    const result = await runtime.getWorktreePs(10_000)
+
+    const folderRow = result.worktrees.find(
+      (worktree) => worktree.workspaceKind === 'folder-workspace'
+    )
+    expect(folderRow?.hostId).toBe('ssh:box-2')
+    expect(result.hostScope?.hostIds).toEqual(
+      expect.arrayContaining(['local', 'ssh:box-1', 'ssh:box-2'])
+    )
+    expect(result.hostScope?.omittedHostIds).not.toContain('ssh:box-2')
+  })
 })

--- a/src/shared/runtime-client-export-parity.test.ts
+++ b/src/shared/runtime-client-export-parity.test.ts
@@ -170,6 +170,7 @@ type RuntimeTypeInventory = [
   Runtime.RuntimeTerminalWaitCondition,
   Runtime.RuntimeWorktreeAgentRow,
   Runtime.RuntimeWorktreeCreateResult,
+  Runtime.RuntimeWorktreeListHostScope,
   Runtime.RuntimeWorktreeListResult,
   Runtime.RuntimeWorktreePsConditionalResult,
   Runtime.RuntimeWorktreePsResult,

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -189,6 +189,7 @@ export type {
   RuntimeSpeechSetupState,
   RuntimeWorktreeAgentRow,
   RuntimeWorktreeCreateResult,
+  RuntimeWorktreeListHostScope,
   RuntimeWorktreeListResult,
   RuntimeWorktreePsConditionalResult,
   RuntimeWorktreePsResult,

--- a/src/shared/runtime-worktree-contracts.ts
+++ b/src/shared/runtime-worktree-contracts.ts
@@ -1,5 +1,4 @@
 import type { AgentStatusState, AgentType, AgentWorkingMode } from './agent-status-types'
-import type { ExecutionHostId } from './execution-host'
 import type { BaseRefSearchResult, Repo } from './repo-types'
 import type { CreateWorktreeResult, RemoveWorktreeResult } from './worktree/create-types'
 import type {

--- a/src/shared/runtime-worktree-contracts.ts
+++ b/src/shared/runtime-worktree-contracts.ts
@@ -1,4 +1,5 @@
 import type { AgentStatusState, AgentType, AgentWorkingMode } from './agent-status-types'
+import type { ExecutionHostId } from './execution-host'
 import type { BaseRefSearchResult, Repo } from './repo-types'
 import type { CreateWorktreeResult, RemoveWorktreeResult } from './worktree/create-types'
 import type {
@@ -121,6 +122,8 @@ export type RuntimeWorktreeRemoveResult = RemoveWorktreeResult & {
   removed: boolean
   warning?: string
 }
+
+export type RuntimeWorktreeListHostScope = RuntimeListingHostScope
 
 export type RuntimeWorktreePsResult = {
   worktrees: RuntimeWorktreePsSummary[]


### PR DESCRIPTION
## ELI5

If you have worktrees on your laptop and on a remote SSH machine, `orca worktree list` used to show only the first 200 rows and never say that a whole remote machine was left out. That made it look like SSH worktrees disappeared. This change labels each row with `host=…` and adds a footer that says which hosts were included vs skipped — the same pattern `terminal list` already uses.

## What changed

- Add optional `hostScope` (`hostIds` + `omittedHostIds`) to `worktree.list` and `worktree.ps` RPC results.
- Runtime builds scope from which execution hosts appear in the truncated listing vs which hosts are known but absent.
- Human text output prints `host=…` per row and a `scope:` footer (or `scope: unverifiable` on older hosts).
- Export shared `formatRuntimeListHostScope` from terminal formatting for reuse.

Fixes #18104