### PR TITLE
fix(quit): reap owned helpers before app exit

### DIFF
--- a/src/main/emulator/emulator-bridge-shutdown.ts
+++ b/src/main/emulator/emulator-bridge-shutdown.ts
@@ -1,0 +1,75 @@
+import { EmulatorError } from './emulator-errors'
+import type { EmulatorSessionRegistry } from './emulator-session-registry'
+import type {
+  EmulatorStartLeaseRegistry,
+  EmulatorStartLease
+} from './emulator-start-lease-registry'
+import type { EmulatorBackend } from './backends/emulator-backend'
+
+type EmulatorBridgeShutdownOptions = {
+  sessionRegistry: EmulatorSessionRegistry
+  startLeases: EmulatorStartLeaseRegistry
+  backends: EmulatorBackend[]
+}
+
+export class EmulatorBridgeShutdown {
+  private readonly pendingHelperAcquires = new Set<Promise<EmulatorStartLease>>()
+  private shutdownStarted = false
+  private shutdownPromise: Promise<void> | undefined
+
+  constructor(private readonly options: EmulatorBridgeShutdownOptions) {}
+
+  assertNotShuttingDown(): void {
+    if (this.shutdownStarted) {
+      throw new EmulatorError('emulator_no_active', 'Emulator runtime is shutting down')
+    }
+  }
+
+  async trackHelperAcquire(acquisition: Promise<EmulatorStartLease>): Promise<EmulatorStartLease> {
+    this.pendingHelperAcquires.add(acquisition)
+    try {
+      return await acquisition
+    } finally {
+      this.pendingHelperAcquires.delete(acquisition)
+    }
+  }
+
+  destroyAllSessions(): Promise<void> {
+    if (this.shutdownPromise) {
+      return this.shutdownPromise
+    }
+    this.shutdownStarted = true
+    this.shutdownPromise = this.destroyAllSessionsInternal()
+    return this.shutdownPromise
+  }
+
+  private async destroyAllSessionsInternal(): Promise<void> {
+    const promises: Promise<unknown>[] = []
+    for (const session of this.options.sessionRegistry.listSessions()) {
+      if (!session.managed) {
+        continue
+      }
+      const backend = this.backendForKind(session.backend)
+      if (!backend) {
+        continue
+      }
+      promises.push(
+        backend
+          .stopHelperForDevice(session.deviceUdid, { helperPid: session.pid })
+          .catch(() => {})
+          .then(() => backend.shutdownDevice(session.deviceUdid).catch(() => {}))
+      )
+    }
+    const pendingHelperAcquires = Promise.allSettled(this.pendingHelperAcquires)
+    await Promise.allSettled([
+      this.options.startLeases.shutdown(),
+      pendingHelperAcquires,
+      ...promises
+    ])
+    this.options.sessionRegistry.clear()
+  }
+
+  private backendForKind(kind: EmulatorBackend['kind']): EmulatorBackend | null {
+    return this.options.backends.find((backend) => backend.kind === kind) ?? null
+  }
+}

--- a/src/main/emulator/emulator-bridge-shutdown.ts
+++ b/src/main/emulator/emulator-bridge-shutdown.ts
@@ -55,7 +55,7 @@ export class EmulatorBridgeShutdown {
       }
       promises.push(
         backend
-          .stopHelperForDevice(session.deviceUdid, { helperPid: session.pid })
+          .stopHelperForDevice(session.deviceUdid, { helperPid: session.pid, includeOrphaned: true })
           .catch(() => {})
           .then(() => backend.shutdownDevice(session.deviceUdid).catch(() => {}))
       )

--- a/src/main/emulator/emulator-bridge.test.ts
+++ b/src/main/emulator/emulator-bridge.test.ts
@@ -188,6 +188,37 @@ describe('EmulatorBridge helper ownership', () => {
     expect(bridge.getActiveForWorktree('wt-external')).toBeNull()
   })
 
+  it('reaps a helper when app shutdown wins a concurrent attach', async () => {
+    let finishStart:
+      | ((info: Awaited<ReturnType<typeof execServeSimCommandMock>>) => void)
+      | undefined
+    execServeSimCommandMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishStart = resolve
+        })
+    )
+    const bridge = new EmulatorBridge({ waitForEndpointReady: vi.fn(async () => true) })
+    const acquire = bridge.acquireHelperForDevice('device-1')
+
+    await vi.waitFor(() => expect(execServeSimCommandMock).toHaveBeenCalledOnce())
+    const shutdown = bridge.destroyAllSessions()
+    finishStart?.({
+      device: 'device-1',
+      streamUrl: 'http://127.0.0.1:3102/stream.mjpeg',
+      wsUrl: 'ws://127.0.0.1:3102'
+    })
+
+    await expect(acquire).rejects.toMatchObject({ code: 'emulator_no_active' })
+    await shutdown
+
+    expect(killServeSimHelperProcessesForDeviceMock).toHaveBeenCalledWith('device-1', {
+      helperPid: undefined,
+      includeOrphaned: true
+    })
+    expect(shutdownSimulatorDeviceMock).toHaveBeenCalledWith('device-1')
+  })
+
   it('rejects a capability the resolved backend does not support', async () => {
     const bridge = new EmulatorBridge()
     // device-1 resolves to the iOS backend, which advertises no explicit-verb caps.

--- a/src/main/emulator/emulator-bridge.test.ts
+++ b/src/main/emulator/emulator-bridge.test.ts
@@ -181,7 +181,8 @@ describe('EmulatorBridge helper ownership', () => {
     )
     expect(killServeSimHelperProcessesForDeviceMock).toHaveBeenCalledTimes(1)
     expect(killServeSimHelperProcessesForDeviceMock).toHaveBeenCalledWith('device-managed', {
-      helperPid: 1234
+      helperPid: 1234,
+      includeOrphaned: true
     })
     expect(shutdownSimulatorDeviceMock).toHaveBeenCalledWith('device-managed')
     expect(bridge.getActiveForWorktree('wt-managed')).toBeNull()

--- a/src/main/emulator/emulator-bridge.ts
+++ b/src/main/emulator/emulator-bridge.ts
@@ -20,6 +20,7 @@ import type {
   EmulatorDevice,
   EmulatorTargetOpts
 } from './backends/emulator-backend'
+import { EmulatorBridgeShutdown } from './emulator-bridge-shutdown'
 
 // Routes emulator commands to the backend that owns the target device while
 // owning the per-worktree active-session registry and lifecycle orchestration.
@@ -31,6 +32,7 @@ export class EmulatorBridge {
   private readonly backends: EmulatorBackend[]
   private readonly iosBackend: IosEmulatorBackend
   private readonly androidBackend: AndroidEmulatorBackend
+  private readonly shutdownCoordinator: EmulatorBridgeShutdown
 
   constructor(options: EmulatorBridgeOptions = {}) {
     this.iosBackend = new IosEmulatorBackend(options)
@@ -38,6 +40,11 @@ export class EmulatorBridge {
     // Why: backends are always registered (not host-gated) so explicitly targeted
     // commands still reach them; availability reporting handles host support.
     this.backends = [this.iosBackend, this.androidBackend]
+    this.shutdownCoordinator = new EmulatorBridgeShutdown({
+      sessionRegistry: this.sessionRegistry,
+      startLeases: this.startLeases,
+      backends: this.backends
+    })
   }
 
   listBackends(): EmulatorBackend[] {
@@ -68,6 +75,7 @@ export class EmulatorBridge {
     info: EmulatorSessionInfo,
     options: { managed?: boolean; backend?: EmulatorBackendKind } = {}
   ): void {
+    this.shutdownCoordinator.assertNotShuttingDown()
     this.sessionRegistry.registerActive(worktreeId, info, options)
   }
 
@@ -242,6 +250,11 @@ export class EmulatorBridge {
   }
 
   async acquireHelperForDevice(device: string): Promise<EmulatorStartLease> {
+    this.shutdownCoordinator.assertNotShuttingDown()
+    return this.shutdownCoordinator.trackHelperAcquire(this.acquireHelperForDeviceInternal(device))
+  }
+
+  private async acquireHelperForDeviceInternal(device: string): Promise<EmulatorStartLease> {
     const backend = await this.backendForDevice(device)
     return this.startLeases.acquire(backend, device, (info) =>
       this.sessionRegistry.hasActiveWorktreeForSession(info.deviceUdid)
@@ -269,29 +282,12 @@ export class EmulatorBridge {
     return udid
   }
 
-  async destroyAllSessions(): Promise<void> {
-    const promises: Promise<unknown>[] = []
-    for (const session of this.sessionRegistry.listSessions()) {
-      if (!session.managed) {
-        continue
-      }
-      const backend = this.backendForKind(session.backend)
-      if (!backend) {
-        continue
-      }
-      promises.push(
-        backend
-          .stopHelperForDevice(session.deviceUdid, { helperPid: session.pid })
-          .catch(() => {})
-          .then(() => backend.shutdownDevice(session.deviceUdid).catch(() => {}))
-      )
-    }
-    await Promise.allSettled(promises)
-    this.sessionRegistry.clear()
+  destroyAllSessions(): Promise<void> {
+    return this.shutdownCoordinator.destroyAllSessions()
   }
 
   async onAppQuit(): Promise<void> {
-    await this.destroyAllSessions()
+    await this.shutdownCoordinator.destroyAllSessions()
   }
 
   private async resolveTarget(

--- a/src/main/emulator/emulator-start-lease-registry.test.ts
+++ b/src/main/emulator/emulator-start-lease-registry.test.ts
@@ -106,4 +106,51 @@ describe('EmulatorStartLeaseRegistry', () => {
     expect(stopHelperForDevice).toHaveBeenCalledOnce()
     expect(shutdownDevice).toHaveBeenCalledOnce()
   })
+
+  it('cleans up an unreleased lease when shutdown begins', async () => {
+    const { backend, stopHelperForDevice, shutdownDevice } = makeBackend()
+    const registry = new EmulatorStartLeaseRegistry()
+    const lease = await registry.acquire(backend, 'Pixel_Tablet', () => false)
+
+    await registry.shutdown()
+
+    expect(stopHelperForDevice).toHaveBeenCalledWith('emulator-5554', {
+      helperPid: undefined,
+      includeOrphaned: true
+    })
+    expect(shutdownDevice).toHaveBeenCalledWith('emulator-5554')
+    await lease.release()
+    expect(stopHelperForDevice).toHaveBeenCalledOnce()
+  })
+
+  it('cleans up a helper that finishes starting after shutdown begins', async () => {
+    const { backend, startSession, stopHelperForDevice, shutdownDevice } = makeBackend()
+    let finishStart: ((info: EmulatorSessionInfo) => void) | undefined
+    startSession.mockImplementation(
+      () =>
+        new Promise<EmulatorSessionInfo>((resolve) => {
+          finishStart = resolve
+        })
+    )
+    const registry = new EmulatorStartLeaseRegistry()
+    const acquire = registry.acquire(backend, 'Pixel_Tablet', () => false)
+
+    await vi.waitFor(() => expect(startSession).toHaveBeenCalledOnce())
+    const shutdown = registry.shutdown()
+    finishStart?.({
+      deviceUdid: 'emulator-5554',
+      streamUrl: 'scrcpy://emulator-5554',
+      wsUrl: '',
+      streamCodec: 'h264',
+      backend: 'android'
+    })
+
+    await expect(acquire).rejects.toMatchObject({ code: 'emulator_no_active' })
+    await shutdown
+    expect(stopHelperForDevice).toHaveBeenCalledWith('emulator-5554', {
+      helperPid: undefined,
+      includeOrphaned: true
+    })
+    expect(shutdownDevice).toHaveBeenCalledWith('emulator-5554')
+  })
 })

--- a/src/main/emulator/emulator-start-lease-registry.ts
+++ b/src/main/emulator/emulator-start-lease-registry.ts
@@ -1,3 +1,4 @@
+import { EmulatorError } from './emulator-errors'
 import type { EmulatorBackend } from './backends/emulator-backend'
 import type { EmulatorSessionInfo } from './emulator-types'
 
@@ -13,12 +14,40 @@ type PendingCleanup = {
   shutdownDevice: boolean
 }
 
+type ActiveLease = {
+  backend: EmulatorBackend
+  info: EmulatorSessionInfo
+  isRegistered: (info: EmulatorSessionInfo) => boolean
+  released: boolean
+}
+
 export class EmulatorStartLeaseRegistry {
   private readonly claimsByBackend = new Map<EmulatorBackend, number>()
   private readonly cleanupByBackend = new Map<EmulatorBackend, Promise<void>>()
   private readonly pendingCleanupByBackend = new Map<EmulatorBackend, Map<string, PendingCleanup>>()
+  private readonly activeLeases = new Set<ActiveLease>()
+  private readonly inFlightAcquires = new Set<Promise<EmulatorStartLease>>()
+  private shutdownStarted = false
+  private shutdownPromise: Promise<void> | undefined
 
-  async acquire(
+  acquire(
+    backend: EmulatorBackend,
+    device: string,
+    isRegistered: (info: EmulatorSessionInfo) => boolean
+  ): Promise<EmulatorStartLease> {
+    if (this.shutdownStarted) {
+      return Promise.reject(createShutdownError())
+    }
+    const operation = this.acquireInternal(backend, device, isRegistered)
+    this.inFlightAcquires.add(operation)
+    void operation.then(
+      () => this.inFlightAcquires.delete(operation),
+      () => this.inFlightAcquires.delete(operation)
+    )
+    return operation
+  }
+
+  private async acquireInternal(
     backend: EmulatorBackend,
     device: string,
     isRegistered: (info: EmulatorSessionInfo) => boolean
@@ -26,28 +55,51 @@ export class EmulatorStartLeaseRegistry {
     this.claimsByBackend.set(backend, (this.claimsByBackend.get(backend) ?? 0) + 1)
     try {
       await this.cleanupByBackend.get(backend)
+      if (this.shutdownStarted) {
+        throw createShutdownError()
+      }
       const info = await backend.startSession(device)
-      let released = false
+      if (this.shutdownStarted) {
+        await this.cleanupStartedSession(backend, info)
+        throw createShutdownError()
+      }
+      const activeLease: ActiveLease = {
+        backend,
+        info,
+        isRegistered,
+        released: false
+      }
+      this.activeLeases.add(activeLease)
       return {
         info,
-        release: async (options = {}) => {
-          if (released) {
-            return
-          }
-          released = true
-          if (options.cleanupIfUnused) {
-            this.addPendingCleanup(backend, info, isRegistered, {
-              includeOrphaned: true,
-              shutdownDevice: true
-            })
-          }
-          await this.release(backend)
-        }
+        release: (options = {}) => this.releaseActiveLease(activeLease, options)
       }
     } catch (error) {
       await this.release(backend)
       throw error
     }
+  }
+
+  shutdown(): Promise<void> {
+    if (this.shutdownPromise) {
+      return this.shutdownPromise
+    }
+    this.shutdownStarted = true
+    this.shutdownPromise = this.shutdownActiveLeases()
+    return this.shutdownPromise
+  }
+
+  private async shutdownActiveLeases(): Promise<void> {
+    await Promise.allSettled(this.inFlightAcquires)
+    const leases = [...this.activeLeases]
+    await Promise.allSettled(
+      leases.map((lease) =>
+        this.releaseActiveLease(lease, {
+          cleanupIfUnused: !lease.isRegistered(lease.info)
+        })
+      )
+    )
+    await Promise.allSettled(this.cleanupByBackend.values())
   }
 
   async cleanupWhenIdle(
@@ -66,6 +118,37 @@ export class EmulatorStartLeaseRegistry {
       return
     }
     await this.drainCleanup(backend)
+  }
+
+  private async releaseActiveLease(
+    lease: ActiveLease,
+    options: { cleanupIfUnused?: boolean } = {}
+  ): Promise<void> {
+    if (lease.released) {
+      return
+    }
+    lease.released = true
+    this.activeLeases.delete(lease)
+    if (options.cleanupIfUnused) {
+      this.addPendingCleanup(lease.backend, lease.info, lease.isRegistered, {
+        includeOrphaned: true,
+        shutdownDevice: true
+      })
+    }
+    await this.release(lease.backend)
+  }
+
+  private async cleanupStartedSession(
+    backend: EmulatorBackend,
+    info: EmulatorSessionInfo
+  ): Promise<void> {
+    await backend
+      .stopHelperForDevice(info.deviceUdid, {
+        helperPid: info.helperPid,
+        includeOrphaned: true
+      })
+      .catch(() => {})
+    await backend.shutdownDevice(info.deviceUdid).catch(() => {})
   }
 
   private async drainCleanup(backend: EmulatorBackend): Promise<void> {
@@ -124,4 +207,8 @@ export class EmulatorStartLeaseRegistry {
     }
     return next
   }
+}
+
+function createShutdownError(): EmulatorError {
+  return new EmulatorError('emulator_no_active', 'Emulator runtime is shutting down')
 }

--- a/src/main/ipc/pty/kill-all.ts
+++ b/src/main/ipc/pty/kill-all.ts
@@ -4,8 +4,9 @@ import { localProvider } from './provider/registry'
 /**
  * Kill in-process local PTYs. Daemon-backed PTYs are preserved by daemon disconnect.
  */
-export function killAllPty(): void {
+export function killAllPty(): Promise<void> {
   if (localProvider instanceof LocalPtyProvider) {
-    localProvider.killAll()
+    return localProvider.killAll()
   }
+  return Promise.resolve()
 }

--- a/src/main/providers/local-pty-provider-shutdown.test.ts
+++ b/src/main/providers/local-pty-provider-shutdown.test.ts
@@ -555,10 +555,11 @@ describe('LocalPtyProvider', () => {
       await provider.spawn({ cols: 80, rows: 24 })
       await provider.spawn({ cols: 80, rows: 24 })
 
-      provider.killAll()
+      await provider.killAll()
 
       expect(mock1Kill).toHaveBeenCalled()
       expect(mock2Kill).toHaveBeenCalled()
+      expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
       const list = await provider.listProcesses()
       expect(list).toHaveLength(0)
     })
@@ -575,10 +576,29 @@ describe('LocalPtyProvider', () => {
 
       await provider.spawn({ cols: 80, rows: 24 })
 
-      provider.killAll()
+      await provider.killAll()
 
       expect(killSpy).toHaveBeenCalledTimes(1)
       expect(destroySpy).not.toHaveBeenCalled()
+    })
+
+    it('sweeps agent descendants before taking final exit ownership', async () => {
+      const onExit = vi.fn()
+      provider.configure({ onExit })
+      const { id } = await provider.spawn({ cols: 80, rows: 24, launchAgent: 'claude' })
+
+      await provider.killAll()
+
+      expect(killWithDescendantSweepMock).toHaveBeenCalledWith(
+        mockProc.pid,
+        expect.any(Function),
+        expect.objectContaining({
+          ownsRoot: expect.any(Function),
+          terminateOwnedTree: expect.any(Function)
+        })
+      )
+      expect(onExit).not.toHaveBeenCalled()
+      expect(provider.hasPty(id)).toBe(false)
     })
 
     it('settles an overlapping shutdown when app quit takes final ownership', async () => {
@@ -592,7 +612,7 @@ describe('LocalPtyProvider', () => {
       await Promise.resolve()
       expect(settled).toBe(false)
 
-      provider.killAll()
+      await provider.killAll()
 
       await expect(shutdown).resolves.toBeUndefined()
     })

--- a/src/main/providers/local-pty-provider-state.ts
+++ b/src/main/providers/local-pty-provider-state.ts
@@ -37,6 +37,9 @@ export const ptyIncarnations = new Map<string, string>()
 export const ptyAgentSessionIds = new Set<string>()
 // Why: descendant capture is async, so reattach/duplicate shutdown must wait for the original owner, not return a dying PTY.
 export const ptyShutdownOperations = new Map<string, PtyShutdownOperation>()
+// Why: app quit owns PTY cleanup directly; suppress a late node-pty callback from
+// re-entering runtime teardown after stats and renderer services have stopped.
+export const ptyExitCallbacksSuppressed = new Set<string>()
 export const pendingLocalPtySpawns = new Map<string, Set<PendingLocalPtySpawn>>()
 export const ptyShellName = new Map<string, string>()
 export const ptyAgentForegroundContextPaths = new Map<string, string[]>()
@@ -116,6 +119,7 @@ export function clearPtyState(id: string): void {
   ptyProcesses.delete(id)
   ptyIncarnations.delete(id)
   ptyAgentSessionIds.delete(id)
+  ptyExitCallbacksSuppressed.delete(id)
   ptyShellName.delete(id)
   ptyAgentForegroundContextPaths.delete(id)
   ptyLastRecognizedForeground.delete(id)

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -178,9 +178,9 @@ export class LocalPtyProvider implements IPtyProvider {
     return getLocalPtyProcess(id)
   }
 
-  /** Kill all in-process local PTYs. Call on app quit. */
-  killAll(): void {
-    killAllLocalPtys()
+  /** Kill all in-process local PTYs and their owned descendants. Call on app quit. */
+  killAll(): Promise<void> {
+    return killAllLocalPtys()
   }
 }
 

--- a/src/main/providers/local-pty-session-activation.ts
+++ b/src/main/providers/local-pty-session-activation.ts
@@ -17,6 +17,7 @@ import {
   ptyAgentSessionIds,
   ptyDisposables,
   ptyExitDisposables,
+  ptyExitCallbacksSuppressed,
   ptyIncarnations,
   ptyInitialCwd,
   ptyLoadGeneration,
@@ -133,6 +134,7 @@ export function activateLocalPtySession(args: {
       hostReportsChildExitStatus: ptyReportsChildExitStatus.get(id)
     })
     const wasTerminationRequested = ptyTerminationMode.has(id)
+    const suppressExitCallbacks = ptyExitCallbacksSuppressed.has(id)
     ptyPhysicalExits.get(id)?.markExited()
     // Why: neutralize proc.kill before destroy — node-pty SIGHUPs on socket 'close', which can race here and signal a reaped/recycled pid.
     if (process.platform !== 'win32') {
@@ -145,9 +147,11 @@ export function activateLocalPtySession(args: {
     // Why: release the master ptmx fd on natural exit, else a clean exit leaks the fd until GC. See docs/fix-pty-fd-leak.md.
     destroyPtyProcess(proc, { alreadyKilled: wasTerminationRequested })
     ptyReportsChildExitStatus.delete(id)
-    getOptions().onExit?.(id, exitCode, incarnationId, cause)
-    for (const cb of exitListeners) {
-      cb({ id, code: exitCode, incarnationId, cause })
+    if (!suppressExitCallbacks) {
+      getOptions().onExit?.(id, exitCode, incarnationId, cause)
+      for (const cb of exitListeners) {
+        cb({ id, code: exitCode, incarnationId, cause })
+      }
     }
   })
   if (onExitDisposable) {

--- a/src/main/providers/local-pty-termination.ts
+++ b/src/main/providers/local-pty-termination.ts
@@ -9,6 +9,7 @@ import {
   disposePtyExitListener,
   disposePtyListeners,
   ptyAgentSessionIds,
+  ptyExitCallbacksSuppressed,
   ptyForceKillTimers,
   ptyPhysicalExits,
   ptyProcesses,
@@ -135,6 +136,18 @@ function requestPtyTermination(id: string, proc: pty.IPty): void {
   destroyPtyProcess(proc, { alreadyKilled: true })
 }
 
+function requestPlainPosixAppQuitTermination(id: string, proc: pty.IPty): void {
+  runPtyCleanup(id)
+  disposePtyListeners(id)
+  disposePtyExitListener(id)
+  try {
+    proc.kill()
+  } catch {
+    /* Process may already be dead. */
+  }
+  destroyPtyProcess(proc, { alreadyKilled: true })
+}
+
 function requestTrackedPtyShutdown(id: string, proc: pty.IPty, immediate: boolean): void {
   const previousMode = ptyTerminationMode.get(id)
   // Why: ConPTY has no graceful signal — its first bare kill closes the pseudoconsole, so treat it as a final force request.
@@ -246,23 +259,46 @@ export function killOrphanedLocalPtys(currentGeneration: number): { id: string }
   return killed
 }
 
-export function killAllLocalPtys(): void {
-  cancelAllPendingLocalPtySpawns()
-  for (const [id, proc] of ptyProcesses) {
-    runPtyCleanup(id)
-    disposePtyListeners(id)
-    disposePtyExitListener(id)
-    if (!(process.platform === 'win32' && ptyTerminationMode.has(id))) {
-      try {
-        proc.kill()
-      } catch {
-        /* Process may already be dead. */
-      }
+async function shutdownPtyForAppQuit(id: string, proc: pty.IPty): Promise<void> {
+  if (ptyProcesses.get(id) !== proc) {
+    return
+  }
+  const killRoot = (): void => {
+    // A natural exit can win while the descendant snapshot is in flight.
+    if (ptyProcesses.get(id) === proc) {
+      requestPtyTermination(id, proc)
     }
-    // Why: app quit can't retain NAPI callbacks into FreeEnvironment; process exit is the final handle boundary here.
-    destroyPtyProcess(proc, { alreadyKilled: true })
-    // Why: app quit replaces node-pty's onExit as final owner; overlapping shutdown waiters must join this boundary.
-    ptyPhysicalExits.get(id)?.markExited()
-    clearPtyState(id)
+  }
+  try {
+    if (ptyAgentSessionIds.has(id) || process.platform === 'win32') {
+      await killWithDescendantSweep(proc.pid, killRoot, {
+        ownsRoot: () => ptyProcesses.get(id) === proc,
+        terminateOwnedTree: () => terminatePtyJob(proc)
+      })
+    } else {
+      requestPlainPosixAppQuitTermination(id, proc)
+    }
+  } finally {
+    if (ptyProcesses.get(id) === proc) {
+      disposePtyExitListener(id)
+      ptyPhysicalExits.get(id)?.markExited()
+      clearPtyState(id)
+    }
+  }
+}
+
+export async function killAllLocalPtys(): Promise<void> {
+  cancelAllPendingLocalPtySpawns()
+  const entries = [...ptyProcesses.entries()]
+  for (const [id] of entries) {
+    ptyExitCallbacksSuppressed.add(id)
+  }
+  const results = await Promise.allSettled(
+    entries.map(([id, proc]) => shutdownPtyForAppQuit(id, proc))
+  )
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.error('[pty] failed to terminate a local PTY during app quit', result.reason)
+    }
   }
 }

--- a/src/main/runtime/orca-runtime-emulator-folder-workspace.test.ts
+++ b/src/main/runtime/orca-runtime-emulator-folder-workspace.test.ts
@@ -158,4 +158,39 @@ describe('RuntimeEmulatorCommands folder workspace routing', () => {
     expect(bridge.shutdownActiveManagedForWorktree).toHaveBeenCalledWith(FOLDER_WORKSPACE_KEY)
     expect(release).toHaveBeenCalledWith({ cleanupIfUnused: true })
   })
+
+  it('releases a helper when registration is refused during app shutdown', async () => {
+    const release = vi.fn(async () => {})
+    const bridge = {
+      acquireHelperForDevice: vi.fn(async () => ({ info: EMULATOR_INFO, release })),
+      getReusableActiveForWorktree: vi.fn(async () => null),
+      registerActiveEmulator: vi.fn(() => {
+        throw new Error('Emulator runtime is shutting down')
+      }),
+      stopActiveForSwitch: vi.fn(async () => null)
+    }
+    const runtime = new OrcaRuntimeService({
+      getFolderWorkspaces: () => [makeFolderWorkspace()],
+      getAllWorktreeMeta: () => new Map(),
+      getRepo: () => null,
+      getRepos: () => [],
+      getSettings: () => ({
+        mobileEmulatorEnabled: true,
+        mobileEmulatorDefaultDeviceUdid: null,
+        androidSdkPath: null
+      })
+    } as never)
+    runtime.setEmulatorBridge(bridge as never)
+    Object.assign(runtime, {
+      getAuthoritativeWindow: () => ({ webContents: { send: vi.fn() } })
+    })
+
+    await expect(
+      runtime.emulatorAttach({
+        device: EMULATOR_INFO.deviceUdid,
+        worktree: FOLDER_WORKSPACE_KEY
+      })
+    ).rejects.toThrow('Emulator runtime is shutting down')
+    expect(release).toHaveBeenCalledWith({ cleanupIfUnused: true })
+  })
 })

--- a/src/main/runtime/orca-runtime-emulator.ts
+++ b/src/main/runtime/orca-runtime-emulator.ts
@@ -169,8 +169,9 @@ export class RuntimeEmulatorCommands {
             'The workspace changed while the emulator was starting. Reattach the emulator.'
           )
         }
+        bridge.registerActiveEmulator(worktreeId, info, { managed: true })
       } catch (error) {
-        // Why: the workspace can disappear while a slow Android device boots.
+        // Why: the workspace or app can disappear while a slow Android device boots.
         await lease.release({ cleanupIfUnused: true }).catch(() => {})
         if (error instanceof Error && error.message === 'selector_not_found') {
           throw new EmulatorError(
@@ -180,7 +181,6 @@ export class RuntimeEmulatorCommands {
         }
         throw error
       }
-      bridge.registerActiveEmulator(worktreeId, info, { managed: true })
       await lease.release()
       this.notifyRendererEmulatorAutoAttach(worktreeId, info)
       if (params.focus) {

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -389,6 +389,22 @@ describe('startup ordering', () => {
     expect(willQuit.slice(barrierStart)).toContain("{ name: 'browser', promise: browserShutdown }")
   })
 
+  it('joins local PTY descendant cleanup before the committed quit exits', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/main/startup/main-process-quit.ts'),
+      'utf8'
+    )
+    const willQuitStart = source.indexOf("app.on('will-quit'")
+    const windowAllClosedStart = source.indexOf("app.on('window-all-closed'", willQuitStart)
+    const willQuit = source.slice(willQuitStart, windowAllClosedStart)
+    const cleanupStart = willQuit.indexOf('const ptyShutdown = killAllPty()')
+    const barrierStart = willQuit.indexOf('settleTeardownWithinDeadline([')
+
+    expect(cleanupStart).toBeGreaterThanOrEqual(0)
+    expect(barrierStart).toBeGreaterThan(cleanupStart)
+    expect(willQuit.slice(barrierStart)).toContain("{ name: 'local-ptys', promise: ptyShutdown }")
+  })
+
   it('registers repeatable serve signal handling before headless startup completes', () => {
     const source = readFileSync(
       join(process.cwd(), 'src/main/startup/main-process-runtime-launch.ts'),

--- a/src/main/startup/main-process-quit.ts
+++ b/src/main/startup/main-process-quit.ts
@@ -188,7 +188,7 @@ function installWillQuitHandler(): void {
     // Why immediately before store.flushAsync() with no await in between: beginSshShutdown() marks every
     // active SSH lease detached in memory synchronously, and that flush is what persists it.
     const sshShutdown = beginSshShutdown()
-    killAllPty()
+    const ptyShutdown = killAllPty()
     const watcherShutdown = shutdownWatchersOnce()
     const storeFlush = state.store?.flushAsync() ?? Promise.resolve()
     // Why: usage-cache writes are queued off the main thread, so a quit right after setEnabled or a
@@ -233,6 +233,7 @@ function installWillQuitHandler(): void {
       { name: 'browser-client-hosts', promise: browserClientHostShutdown },
       { name: 'local-ssh-browser-routes', promise: localSshRouteShutdown },
       { name: 'ssh', promise: sshShutdown },
+      { name: 'local-ptys', promise: ptyShutdown },
       { name: 'plugin-hosts', promise: pluginHostShutdown },
       { name: 'skill-uploads', promise: skillUploadShutdown },
       { name: 'grok-hooks', promise: grokHookCleanup },


### PR DESCRIPTION
## ELI5

When Orca quit while a terminal or emulator helper was still starting, the app could stop waiting for that owned child process. This change keeps shutdown connected to the quit barrier and cleans up helpers that finish starting during shutdown, so closing Orca does not leave its work running in the background.

## What Changed

- Join local PTY cleanup to the app-quit teardown barrier.
- Sweep descendants for agent PTYs and Windows PTYs during app quit, while preserving the existing ordinary POSIX `nohup` behavior.
- Suppress late PTY exit callbacks after app-quit teardown has begun.
- Gate iOS and Android emulator helper acquisition/registration during shutdown and clean up helpers that finish after the session snapshot.
- Add regression coverage for local PTY descendants, shutdown ordering, emulator lease cleanup, late helper completion, and refused late registration.

## Why

The quit path previously started local PTY cleanup without joining its asynchronous completion to the app teardown barrier. It also took a session snapshot before an in-flight emulator helper could register, allowing owned descendants to outlive the process that launched them. The new shutdown coordination closes both races without broad process-table reaping.

## Linked Issue

Related to #11342 and #16714. This change covers local app-quit cleanup; daemon tab-close and cross-launch daemon ownership remain out of scope.

## Visual Proof

N/A — no UI or interaction surface changed.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Automated verification:

- `pnpm tc`
- `pnpm run check:code-quality:changed`
- `pnpm test src/main/emulator/emulator-start-lease-registry.test.ts src/main/emulator/emulator-bridge.test.ts src/main/runtime/orca-runtime-emulator-folder-workspace.test.ts src/main/providers/local-pty-provider-shutdown.test.ts src/main/startup/desktop-startup-ordering.test.ts` — 5 files, 80 tests passed on Windows.
- Pre-commit hooks passed: oxlint, React Doctor lint, and oxfmt.
- `pnpm test` was attempted, but the full suite was not clean in this Windows environment because of unrelated WSL/App Control/native-module/symlink-dependent failures and timeouts; it is not claimed as passing here.

## AI Disclosure

OpenAI Codex (GPT-5) implemented the change. Claude performed an independent review of the shutdown paths.

## Review

- Cross-platform: uses the existing platform-specific PTY/process termination paths, preserves ordinary POSIX `nohup` semantics, and adds no shell or interpreter spawning.
- SSH/remote/local: the change is scoped to local PTY and local emulator shutdown; remote/SSH execution remains owned by the execution host and is not reaped by the local quit path.
- Agent/integration compatibility: agent PTY tracking uses the existing session identity, and the emulator gate covers both iOS and Android backends without changing their wire contract.
- Performance: additional work runs only during shutdown; tracked acquisitions and cleanup are joined with bounded `Promise.allSettled` coordination rather than adding hot-path polling.
- UI quality: no visual or interaction changes.
- Security: cleanup is limited to owned/tracked sessions and existing descendant/job termination mechanisms; no broad process scan or new command-shell path was introduced.
- Claude review confirmed the local PTY root-only termination survivor path. The cross-check also covered the emulator late-registration race and its cleanup-on-refusal behavior.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No UI, SSH wire, Git provider, or shortcut behavior changed. The implementation keeps remote process ownership on the execution host and limits app-quit cleanup to locally owned resources.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
