### PR TITLE
Report bytes written for stalled agent prompts

### DIFF
--- a/src/main/runtime/agent-prompt-submission-runtime.test.ts
+++ b/src/main/runtime/agent-prompt-submission-runtime.test.ts
@@ -80,7 +80,13 @@ describe('agent prompt submission runtime', () => {
       }
     })
     const submission = runtime.sendTerminalAgentPrompt(handle, 'review this')
-    const rejected = expect(submission).rejects.toThrow('agent_prompt_stalled')
+    const rejected = expect(submission).rejects.toMatchObject({
+      message: 'agent_prompt_stalled',
+      data: {
+        bytesWritten: Buffer.byteLength(buildAgentPromptPasteBytes('review this')) + 1,
+        submitted: true
+      }
+    })
 
     await vi.runAllTimersAsync()
 

--- a/src/main/runtime/orca-runtime-write-terminal-agent-prompt.ts
+++ b/src/main/runtime/orca-runtime-write-terminal-agent-prompt.ts
@@ -14,6 +14,7 @@ import {
 } from '../../shared/agent-prompt-injection'
 import type { AgentPromptWaitTextCache } from './agent-prompt-submission-verification'
 import {
+  isAgentPromptStalledError,
   resolveAgentPromptEffectTimeoutMs,
   verifyAgentPromptSubmission
 } from './agent-prompt-submission-verification'
@@ -89,12 +90,24 @@ export class OrcaRuntimeWithWriteTerminalAgentPrompt extends OrcaRuntimeWithReso
     if (!this.ptyController?.write(ptyId, AGENT_PROMPT_SUBMIT)) {
       throw new Error(options.suffixFailureError ?? 'terminal_not_writable')
     }
-    await verifyAgentPromptSubmission({
-      baseline,
-      readActivity: () => this.getAgentPromptActivity(handle, ptyId, waitTextCache),
-      timeoutMs: resolveAgentPromptEffectTimeoutMs(this.getPtyAgent(ptyId)),
-      signal: options.signal
-    })
+    try {
+      await verifyAgentPromptSubmission({
+        baseline,
+        readActivity: () => this.getAgentPromptActivity(handle, ptyId, waitTextCache),
+        timeoutMs: resolveAgentPromptEffectTimeoutMs(this.getPtyAgent(ptyId)),
+        signal: options.signal
+      })
+    } catch (error) {
+      if (error instanceof Error && isAgentPromptStalledError(error)) {
+        Object.assign(error, {
+          data: {
+            bytesWritten: pasteByteLength + Buffer.byteLength(AGENT_PROMPT_SUBMIT),
+            submitted: true
+          }
+        })
+      }
+      throw error
+    }
     return 1
   }
 }

--- a/src/main/runtime/rpc/errors.test.ts
+++ b/src/main/runtime/rpc/errors.test.ts
@@ -59,6 +59,21 @@ describe('mapRuntimeError', () => {
     }
   )
 
+  it('preserves the written receipt for an unobserved agent prompt submission', () => {
+    const error = Object.assign(new Error('agent_prompt_stalled'), {
+      data: { bytesWritten: 19, submitted: true }
+    })
+
+    expect(mapRuntimeError('req_1', { runtimeId: 'runtime-1' }, error)).toMatchObject({
+      ok: false,
+      error: {
+        code: 'agent_prompt_stalled',
+        message: 'agent_prompt_stalled',
+        data: { bytesWritten: 19, submitted: true }
+      }
+    })
+  })
+
   it.each([
     'remote_update_manual_required',
     'remote_update_not_available',

--- a/src/main/runtime/rpc/errors.ts
+++ b/src/main/runtime/rpc/errors.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../shared/skill-install-failure'
 import { GIT_DIFF_TOO_LARGE_CODE } from '../../../shared/git-diff-transport-budget'
 import { AUTOMATION_OWNER_CONFLICT_CODES } from '../../../shared/automation-owner-conflict'
+import { AGENT_PROMPT_STALLED_ERROR } from '../agent-prompt-submission-verification'
 
 export function successResponse(id: string, meta: RpcEnvelopeMeta, result: unknown): RpcSuccess {
   return {
@@ -63,7 +64,7 @@ const RUNTIME_PASSTHROUGH_CODES: ReadonlySet<string> = new Set([
   'terminal_tab_not_found',
   'terminal_tab_pinned',
   'agent_prompt_blocked',
-  'agent_prompt_stalled',
+  AGENT_PROMPT_STALLED_ERROR,
   'no_active_terminal',
   'repo_not_found',
   'timeout',
@@ -186,7 +187,11 @@ export function mapRuntimeError(id: string, meta: RpcEnvelopeMeta, error: unknow
     )
   }
   if (RUNTIME_PASSTHROUGH_CODES.has(message)) {
-    return errorResponse(id, meta, message, message)
+    const data =
+      message === AGENT_PROMPT_STALLED_ERROR && error instanceof Error && 'data' in error
+        ? (error as { data?: unknown }).data
+        : undefined
+    return errorResponse(id, meta, message, message, data)
   }
   const skillInstallFailure = classifySkillInstallFailureCode(message)
   if (skillInstallFailure) {


### PR DESCRIPTION
## ELI5

When Orca reports that an agent prompt stalled, the prompt and Enter key were already written. The error now says so, allowing callers to avoid submitting the same prompt twice.

## What Changed

- Attach `bytesWritten` and `submitted: true` to `agent_prompt_stalled` errors after the existing verification window expires.
- Preserve that receipt in the Runtime RPC error `data` payload.
- Cover both byte accounting and RPC error mapping with focused tests.

## Why

A stalled verdict means the submission effect was not observed; it does not mean the PTY write failed. Exposing the existing write evidence lets callers distinguish written-but-unobserved from not-written without changing the error code or 30-second verification behavior.

## Linked Issue

Refs #18206 (implements the `agent_prompt_stalled` addendum; the broader wake/subscription proposal remains open).

## Visual Proof

N/A — this changes a non-UI Runtime RPC error payload.

## Testing

- `pnpm test src/main/runtime/agent-prompt-submission-runtime.test.ts src/main/runtime/rpc/errors.test.ts` (70 tests passed)
- `pnpm tc:node`
- `pnpm tc:cli`
- `pnpm run check:code-quality:changed`
- Platforms manually exercised: none; the change uses platform-neutral byte accounting and the existing RPC envelope. SSH/remote compatibility follows the existing optional JSON `data` field behavior.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Codex (GPT-5).

## Review

Self-reviewed for exact byte accounting, unchanged timeout/error code, and additive mixed-version behavior.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No Runtime restart was performed. No platform-specific process, path, keyboard, UI, SSH execution-owner, or folder-workspace behavior changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
