### PR TITLE
revert(native-chat): drop the speculative Fable model-switch detections

### DIFF
--- a/src/main/rate-limits/claude-fetcher-fable-usage.test.ts
+++ b/src/main/rate-limits/claude-fetcher-fable-usage.test.ts
@@ -144,51 +144,6 @@ describe('fetchClaudeRateLimits', () => {
     expect(fetchViaPty).not.toHaveBeenCalled()
   })
 
-  it('maps a scoped Fable window whose display name carries a point release', async () => {
-    const configDir = '/Users/test/.claude'
-    const authPreparation: ClaudeRuntimeAuthPreparation = {
-      configDir,
-      envPatch: { CLAUDE_CONFIG_DIR: configDir },
-      stripAuthEnv: false,
-      provenance: 'managed:account-1'
-    }
-    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValueOnce(
-      JSON.stringify({ claudeAiOauth: { accessToken: 'oauth-token' } })
-    )
-    netFetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          five_hour: { utilization: 36 },
-          seven_day: { utilization: 73 },
-          // Discriminating: a passing scope match must beat this fallback.
-          fable_weekly: { utilization: 12 },
-          limits: [
-            {
-              kind: 'weekly_scoped',
-              percent: 64,
-              resets_at: '2026-07-17T20:00:00.099908+00:00',
-              is_active: true,
-              scope: { model: { display_name: 'Fable 5.1' } }
-            }
-          ]
-        }),
-        { status: 200 }
-      )
-    )
-
-    await expect(
-      fetchClaudeRateLimits({ authPreparation, allowUsagePanelSupplement: true })
-    ).resolves.toMatchObject({
-      provider: 'claude',
-      status: 'ok',
-      fableWeekly: {
-        usedPercent: 64,
-        resetsAt: Date.parse('2026-07-17T20:00:00.099908+00:00')
-      }
-    })
-    expect(fetchViaPty).not.toHaveBeenCalled()
-  })
-
   it('surfaces inactive scoped Fable usage over the legacy OAuth fallback', async () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {

--- a/src/main/rate-limits/claude-oauth-usage-request.ts
+++ b/src/main/rate-limits/claude-oauth-usage-request.ts
@@ -32,17 +32,13 @@ async function ensureProxyFromEnvironment(): Promise<void> {
   }).catch(() => {})
 }
 
-// Why: the scope name carries the shipped version once a point release exists
-// ("Fable 5.1"), so exact equality would drop the window.
-const FABLE_SCOPE_RE = /^fable\b/
-
 function mapFableWeeklyWindow(data: OAuthUsageResponse): RateLimitWindow | null {
   const scoped = Array.isArray(data.limits)
     ? data.limits.find(
         (limit) =>
           limit?.kind === 'weekly_scoped' &&
           Number.isFinite(limit.percent) &&
-          FABLE_SCOPE_RE.test(limit.scope?.model?.display_name?.trim().toLowerCase() ?? '')
+          limit.scope?.model?.display_name?.trim().toLowerCase() === 'fable'
       )
     : undefined
   return (

--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -27,10 +27,10 @@ const mocks = vi.hoisted(() => ({
     sessionOptionsSnapshot?: SessionOptionDescriptor[]
     attachDisabled?: boolean
   } | null,
-  modelSwitchOutcome: 'applied' as 'applied' | 'rejected' | 'interaction-required' | 'unknown',
+  modelSwitchOutcome: 'applied' as 'applied' | 'rejected' | 'unknown',
   confirmationObserver: null as {
     ready: Promise<void>
-    result: Promise<'applied' | 'rejected' | 'interaction-required' | 'unknown'>
+    result: Promise<'applied' | 'rejected' | 'unknown'>
     arm: ReturnType<typeof vi.fn>
     startDetection: ReturnType<typeof vi.fn>
     dispose: ReturnType<typeof vi.fn>
@@ -729,33 +729,6 @@ describe('NativeChatComposer', () => {
     )
     expect(mocks.confirmationObserver?.dispose).toHaveBeenCalledOnce()
     expect(onSwitchToTerminal).not.toHaveBeenCalled()
-  })
-
-  it('reveals Claude interaction only when the model switch needs user input', async () => {
-    mocks.sendHandle.settleAfterMs = 0
-    mocks.modelSwitchOutcome = 'interaction-required'
-    const onSwitchToTerminal = vi.fn()
-    render(
-      <NativeChatComposer
-        terminalTabId="tab-1"
-        paneKey="tab-1:leaf-1"
-        targetPtyId="pty-1"
-        agent="claude"
-        onSwitchToTerminal={onSwitchToTerminal}
-      />
-    )
-
-    await act(async () => {
-      await mocks.fieldProps?.sessionOptionsSurface?.setOption('model', 'fable')
-    })
-
-    expect(mocks.sendNativeChatMessageVerified).toHaveBeenCalledWith(
-      {},
-      'pty-1',
-      '/model fable',
-      expect.any(AbortSignal)
-    )
-    expect(onSwitchToTerminal).toHaveBeenCalledOnce()
   })
 
   it('types the Codex picker command and switches to the terminal', async () => {

--- a/src/renderer/src/components/native-chat/claude-model-switch-confirmation.test.ts
+++ b/src/renderer/src/components/native-chat/claude-model-switch-confirmation.test.ts
@@ -138,69 +138,6 @@ describe('Claude model switch confirmation detection', () => {
     await expect(observer.result).resolves.toBe('rejected')
   })
 
-  it('requests interaction for Fable one-time usage-credit consent', async () => {
-    const dataObserver = { current: (_data: string): void => {} }
-    const observer = createClaudeModelSwitchConfirmationObserver({
-      ptyId: 'pty-1',
-      settings: {},
-      expectedModelLabel: 'Fable 5',
-      subscribeToData: (watcher) => {
-        dataObserver.current = watcher
-        return vi.fn(() => {})
-      },
-      timeoutMs: 100
-    })
-
-    await observer.ready
-    observer.arm()
-    dataObserver.current('Fable 5 uses usage credits and needs a one-time consent — ')
-    dataObserver.current('pick Fable from /model in an interactive session to set it up')
-
-    await expect(observer.result).resolves.toBe('interaction-required')
-  })
-
-  it('requests interaction for a Fable point-release consent prompt', async () => {
-    const dataObserver = { current: (_data: string): void => {} }
-    const observer = createClaudeModelSwitchConfirmationObserver({
-      ptyId: 'pty-1',
-      settings: {},
-      expectedModelLabel: 'Fable 5.1',
-      subscribeToData: (watcher) => {
-        dataObserver.current = watcher
-        return vi.fn(() => {})
-      },
-      timeoutMs: 100
-    })
-
-    await observer.ready
-    observer.arm()
-    // Only the versioned consent line: the generic "pick Fable from /model"
-    // sentence must not be what carries this case.
-    dataObserver.current('Fable 5.1 uses usage credits and needs a one-time consent')
-
-    await expect(observer.result).resolves.toBe('interaction-required')
-  })
-
-  it('requests interaction for a versioned Fable switch prompt', async () => {
-    const dataObserver = { current: (_data: string): void => {} }
-    const observer = createClaudeModelSwitchConfirmationObserver({
-      ptyId: 'pty-1',
-      settings: {},
-      expectedModelLabel: 'Fable 5.1',
-      subscribeToData: (watcher) => {
-        dataObserver.current = watcher
-        return vi.fn(() => {})
-      },
-      timeoutMs: 100
-    })
-
-    await observer.ready
-    observer.arm()
-    dataObserver.current('Switch to \u001b[1mFable 5.1\u001b[0m? This model uses usage credits.')
-
-    await expect(observer.result).resolves.toBe('interaction-required')
-  })
-
   it('reports unknown when the PTY observer cannot be established', async () => {
     const observer = createClaudeModelSwitchConfirmationObserver({
       ptyId: 'pty-1',

--- a/src/renderer/src/components/native-chat/claude-model-switch-confirmation.ts
+++ b/src/renderer/src/components/native-chat/claude-model-switch-confirmation.ts
@@ -10,7 +10,7 @@ const MAX_OBSERVED_BYTES = 64 * 1024
 
 type SubscribeToData = (watcher: (data: string) => void) => Promise<() => void> | (() => void)
 
-export type ClaudeModelSwitchOutcome = 'applied' | 'rejected' | 'interaction-required' | 'unknown'
+export type ClaudeModelSwitchOutcome = 'applied' | 'rejected' | 'unknown'
 
 export type ClaudeModelSwitchConfirmationObserver = {
   ready: Promise<void>
@@ -60,22 +60,6 @@ function hasClaudeModelSwitchSuccess(buffer: string, modelLabel: string): boolea
 
 function hasClaudeModelSwitchRejection(buffer: string): boolean {
   return compactTerminalText(buffer).includes('keptmodelas')
-}
-
-// Why: compactTerminalText only strips whitespace, so a point release keeps its
-// dot ("fable5.1uses..."). The version is optional because the CLI's own label
-// for the newest Fable carries no number at all.
-const FABLE_VERSION = String.raw`fable(?:\d+(?:\.\d+)*)?`
-const FABLE_CONSENT_RE = new RegExp(`${FABLE_VERSION}usesusagecreditsandneedsaone-timeconsent`)
-const FABLE_SWITCH_PROMPT_RE = new RegExp(`switchto${FABLE_VERSION}\\?`)
-
-function hasClaudeModelSwitchInteraction(buffer: string): boolean {
-  const text = compactTerminalText(buffer)
-  return (
-    FABLE_CONSENT_RE.test(text) ||
-    text.includes('pickfablefrom/modelinaninteractivesessiontosetitup') ||
-    (FABLE_SWITCH_PROMPT_RE.test(text) && text.includes('usagecredits'))
-  )
 }
 
 function subscribeToClaudeModelSwitchData(args: {
@@ -154,10 +138,6 @@ export function createClaudeModelSwitchConfirmationObserver(args: {
     }
     if (hasClaudeModelSwitchRejection(observed)) {
       finish('rejected')
-      return
-    }
-    if (hasClaudeModelSwitchInteraction(observed)) {
-      finish('interaction-required')
       return
     }
     if (!confirmationSubmitted && hasClaudeModelSwitchConfirmation(observed)) {

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -159,28 +159,6 @@ describe('native chat PTY session options', () => {
     })
   })
 
-  it('reveals the terminal only when Claude actually requires model-switch interaction', async () => {
-    seedNativeChatAppliedSessionOptions('pty-1', 'claude', { model: 'sonnet' })
-    const dispatch = vi.fn().mockResolvedValue({ outcome: 'interaction-required' })
-    const onAgentPicker = vi.fn()
-    const surface = createNativeChatPtySessionOptions({
-      agent: 'claude',
-      scopeKey: 'pty-1',
-      mode: 'live',
-      dispatchCommand: dispatch,
-      onAgentPicker
-    })!
-
-    const result = await surface.setOption('model', 'haiku')
-
-    expect(dispatch).toHaveBeenCalledWith('/model haiku', {
-      detectAgentInteraction: 'claude-model-switch-confirmation',
-      expectedChoiceLabel: 'Haiku'
-    })
-    expect(onAgentPicker).toHaveBeenCalledOnce()
-    expect(result.snapshot[0]).toMatchObject({ valueSource: 'unknown' })
-  })
-
   it('keeps the prior model and persistence when Claude rejects the switch', async () => {
     seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
       model: 'fable',

--- a/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
@@ -171,12 +171,6 @@ function applyDispatchOutcome(
     ctx.publish()
     throw new Error('Could not verify the model change; open the terminal to check.')
   }
-  if (dispatchResult?.outcome === 'interaction-required') {
-    ctx.clearModelTruth()
-    const snapshot = ctx.publish()
-    ctx.onAgentPicker?.()
-    return { snapshot }
-  }
   return null
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​159 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​157 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​32 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​30 |

<!-- /orca-pr-loc -->

Backs out the two speculative changes that shipped alongside the real fix in #18055. Neither addressed a reported problem, and both were written against strings never observed in a live session. The disabled-row filter from that PR is deliberately **untouched**.

## Why

#18055 landed three changes. Only one fixed something real — dropping the CLI's disabled placeholder row, which the picker had been rendering as a selectable model. Reproduced since:

> `Ran /model cc-update-required-1` → *"The `/model cc-update-required-1` command didn't match a known model name, so nothing changed. You're still on Fable 5.1."*

Note it does **not** error — it silently no-ops, so the CLI keeps the old model while the picker shows the new one. That is the bug worth having fixed, and it stays fixed.

The other two were guesses. Guessing at agent output we have not seen is how a row that silently no-ops got shipped in the first place.

## 1. Fable consent detection — removed

Watched session output for `"Fable N uses usage credits and needs a one-time consent"` and answered `interaction-required`, which reveals the terminal.

No consent prompt ever appeared during validation — the test account had already consented to Fable — so the wording being matched was never confirmed against a real prompt. This was flagged as the weakest part of #18055 when it merged.

With the detector gone, nothing produces `interaction-required`, so the outcome leaves `ClaudeModelSwitchOutcome` and its now-unreachable handler in `native-chat-session-option-apply.ts` goes with it. Leaving an unreachable state in a union is worse than removing it.

**Behavioural consequence, stated plainly:** if Claude does show a consent prompt mid-switch, Orca now reports *"Could not verify the model change; open the terminal to check"* instead of revealing the terminal. That is the correct answer for output we cannot recognize, and it is the same path any other unrecognized output already takes.

## 2. Weekly usage scope — reverted to exact match

`display_name === 'fable'` had been widened to `/^fable\b/` to survive Anthropic renaming their usage window to "Fable 5.1". The API still reports `"Fable"`, so this changed nothing today and defended a scenario with no evidence behind it.

## Tests

Deleted rather than rewritten — they covered behavior that no longer exists:

- 3 consent-detection cases in `claude-model-switch-confirmation.test.ts` (1 pre-existing, 2 from #18055)
- 1 usage-scope case in `claude-fetcher-fable-usage.test.ts`
- 2 pre-existing `interaction-required` cases asserting the terminal is revealed, in `native-chat-pty-session-options.test.ts` and `NativeChatComposer.test.tsx`

Net **+4 / −191**. `75/75` pass across the five affected files; `pnpm tc` green; oxlint and oxfmt clean.

## Not included

Surfacing disabled models as greyed-out, non-selectable rows so the CLI's own *"Update to 2.1.255+ to use Fable 5.1"* hint stays visible. That is the one change that would actually help an out-of-date user reach Fable 5.1, but it turns out to require threading a field through the shared commit-message model pipeline, its remote wire schema, and two unrelated settings UIs — roughly ten files. Held back deliberately rather than grown into this PR.

https://claude.ai/code/session_01SJy4XGrdre6YaU1wYNKak4