### PR TITLE
fix(claude): keep reauth after usage refresh failures

### DIFF
--- a/src/main/claude-accounts/claude-account-registration.ts
+++ b/src/main/claude-accounts/claude-account-registration.ts
@@ -121,6 +121,7 @@ export class ClaudeAccountRegistration {
         : entry
     )
     let wroteCredentials = false
+    const target = getClaudeSelectionTargetForAccount(account)
     try {
       await this.dependencies.writeOauth(accountId, managedAuthPath, captured.oauthAccount)
       await this.dependencies.writeCredentials(accountId, managedAuthPath, captured.credentialsJson)
@@ -128,10 +129,7 @@ export class ClaudeAccountRegistration {
       this.dependencies.store.updateSettings({ claudeManagedAccounts: nextAccounts })
       this.dependencies.runtimeAuth.clearLastWrittenCredentialsJson(accountId)
       this.dependencies.rateLimits.evictInactiveClaudeCache(accountId)
-      const target = getClaudeSelectionTargetForAccount(account)
       await this.dependencies.selection.syncRuntimeAuth(target)
-      await this.dependencies.rateLimits.refreshForClaudeAccountChange(undefined, target)
-      return this.dependencies.selection.snapshot()
     } catch (error) {
       await this.rollbackReauthentication(
         accountId,
@@ -143,6 +141,16 @@ export class ClaudeAccountRegistration {
       )
       throw error
     }
+    // Why: usage refresh is advisory and must not roll back durable OAuth reauthentication.
+    void this.dependencies.rateLimits
+      .refreshForClaudeAccountChange(undefined, target)
+      .catch((error: unknown) =>
+        console.warn(
+          '[claude-accounts] Failed to refresh Claude usage after reauthentication:',
+          error
+        )
+      )
+    return this.dependencies.selection.snapshot()
   }
 
   private async persist(

--- a/src/main/claude-accounts/claude-account-service-reauth-rollback.test.ts
+++ b/src/main/claude-accounts/claude-account-service-reauth-rollback.test.ts
@@ -417,4 +417,92 @@ describe('ClaudeAccountService credential capture', () => {
     })
     expect(settings.claudeManagedAccounts[0].email).toBe('new@example.com')
   })
+
+  it('keeps successful reauthentication when the follow-up usage refresh fails', async () => {
+    setPlatform('linux')
+    tempDir = CLAUDE_SERVICE_TEST_ROOT
+    rmSync(tempDir, { recursive: true, force: true })
+    const managedAuthPath = join(tempDir, 'claude-accounts', 'account-1', 'auth')
+    mkdirSync(managedAuthPath, { recursive: true })
+    writeFileSync(join(managedAuthPath, '.orca-managed-claude-auth'), 'account-1\n', 'utf-8')
+    writeFileSync(join(managedAuthPath, '.credentials.json'), '{"old":true}\n', 'utf-8')
+    writeFileSync(join(managedAuthPath, 'oauth-account.json'), '{"oldOauth":true}\n', 'utf-8')
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'old@example.com',
+          managedAuthPath,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      clearLastWrittenCredentialsJson: vi.fn(),
+      syncForCurrentSelection: vi.fn(async () => {}),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {})
+    }
+    const refreshError = new Error('Claude plan usage is unavailable for this Claude CLI session.')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const rateLimits = {
+      evictInactiveClaudeCache: vi.fn(),
+      refreshForClaudeAccountChange: vi.fn(async () => {
+        throw refreshError
+      })
+    }
+    const { ClaudeAccountService } = await import('./service')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+    ;(
+      service as unknown as {
+        runClaudeLoginAndCapture(): Promise<{
+          credentialsJson: string
+          oauthAccount: unknown
+          identity: { email: string; organizationUuid: null; organizationName: null }
+        }>
+      }
+    ).runClaudeLoginAndCapture = vi.fn(async () => ({
+      credentialsJson: '{"new":true}\n',
+      oauthAccount: { newOauth: true },
+      identity: { email: 'new@example.com', organizationUuid: null, organizationName: null }
+    }))
+
+    await expect(service.reauthenticateAccount('account-1')).resolves.toEqual(
+      expect.objectContaining({ activeAccountId: 'account-1' })
+    )
+
+    expect(readFileSync(join(managedAuthPath, '.credentials.json'), 'utf-8')).toBe('{"new":true}\n')
+    expect(JSON.parse(readFileSync(join(managedAuthPath, 'oauth-account.json'), 'utf-8'))).toEqual({
+      newOauth: true
+    })
+    expect(settings.claudeManagedAccounts[0]).toMatchObject({
+      email: 'new@example.com',
+      updatedAt: expect.any(Number),
+      lastAuthenticatedAt: expect.any(Number)
+    })
+    expect(settings.claudeManagedAccounts[0].updatedAt).toBeGreaterThan(1)
+    expect(settings.claudeManagedAccounts[0].lastAuthenticatedAt).toBeGreaterThan(1)
+    expect(runtimeAuth.forceMaterializeCurrentSelectionForRollback).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(
+      '[claude-accounts] Failed to refresh Claude usage after reauthentication:',
+      refreshError
+    )
+    warn.mockRestore()
+  })
 })

--- a/src/main/claude-accounts/claude-account-service-reauth-rollback.test.ts
+++ b/src/main/claude-accounts/claude-account-service-reauth-rollback.test.ts
@@ -499,9 +499,11 @@ describe('ClaudeAccountService credential capture', () => {
     expect(settings.claudeManagedAccounts[0].updatedAt).toBeGreaterThan(1)
     expect(settings.claudeManagedAccounts[0].lastAuthenticatedAt).toBeGreaterThan(1)
     expect(runtimeAuth.forceMaterializeCurrentSelectionForRollback).not.toHaveBeenCalled()
-    expect(warn).toHaveBeenCalledWith(
-      '[claude-accounts] Failed to refresh Claude usage after reauthentication:',
-      refreshError
+    await vi.waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        '[claude-accounts] Failed to refresh Claude usage after reauthentication:',
+        refreshError
+      )
     )
     warn.mockRestore()
   })


### PR DESCRIPTION
## ELI5

Claude 로그인 자체는 성공했는데, 직후의 “사용량 확인”이 실패하면 Orca가 방금 성공한 로그인을 취소하고 예전 만료 인증으로 되돌리고 있었습니다. 이제 로그인 저장은 유지하고, 사용량 확인 오류만 별도로 기록합니다.

## What Changed

- Kept managed Claude OAuth writes, account metadata updates, and runtime-auth synchronization inside the rollback transaction.
- Moved advisory `refreshForClaudeAccountChange()` after the durable transaction.
- Attached a rejection handler so usage-refresh failures neither roll back authentication nor become unhandled rejections.
- Added a regression for `Claude plan usage is unavailable for this Claude CLI session.`
- Made the async warning assertion explicit with `vi.waitFor()` following Pullfrog review.

## Why

`ClaudeAccountRegistration.reauthenticate()` wrote fresh OAuth credentials and updated `updatedAt` / `lastAuthenticatedAt`, then awaited usage refresh inside the same rollback `try`. A usage-only failure restored the previous credential and metadata even though OAuth and runtime-auth synchronization had succeeded. The browser reported success, but a fresh Claude session still used expired auth.

Codex already treats quota refresh as a nonblocking post-auth operation. Claude now uses the same transaction boundary while runtime-auth synchronization remains fail-closed.

## Linked Issue

Related to #9582 — this PR addresses the confirmed post-auth usage-refresh rollback path only and intentionally does not auto-close the broader shared-credential race issue.

## Visual Proof

N/A — no UI or visual behavior changes. This changes the transaction boundary for managed Claude reauthentication.

## Testing

- [ ] I manually tested these changes locally — intentionally not run against live OAuth because that would require another user login before a fixed build is released.
- [x] Automated tests added/updated.

Automated verification:

- Final regression test against old source: RED with `Claude plan usage is unavailable for this Claude CLI session.`
- Final regression test with fix: GREEN.
- Reauthentication rollback file: 6/6 passed, including Node strict unhandled-rejection mode.
- Claude account subsystem: 190/190 passed.
- Rate-limit subsystem: 445/445 passed.
- Combined committed-tree affected scope: 635/635 passed.
- `pnpm run typecheck:node`: passed.
- `pnpm run check:code-quality:changed`: 0 new findings.
- `oxfmt --check` and `git diff --check`: passed.
- `pnpm run build:desktop`: passed.
- Tested locally on macOS. The transaction logic is platform-neutral; no SSH, remote-wire, mobile, path, or shortcut behavior changes.

## AI Disclosure

Implemented with Hermes Agent using OpenAI Codex GPT-5.6. The exact diff was independently reviewed by Codex and xAI Grok; both returned PASS. A fresh-context Hermes reviewer also returned PASS with no blocking or nonblocking findings. Claude review was unavailable because the installed managed Claude credential is the defect under repair; no additional login was requested.

## Review

- Pullfrog: no critical issues; its minor async-test robustness suggestion was incorporated in commit `7645323a89`.
- CodeRabbit: no actionable code comments; merge risk assessed as low.
- Final pre-push diff and commit SHA were read back from the fork.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: no credential payload logging or storage format change.
- Cross-platform: transaction ordering is shared; filesystem assertions use the existing Linux fixture for deterministic credential read-back.
- SSH/remote/mobile: no execution-host, wire, or UI changes.
- Backward compatibility: only usage-refresh failure handling changes. Usage may remain stale/error until a later refresh, but successful authentication remains durable.
- Scope: this does not claim to resolve the broader isolation/migration work in #17796.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why, including ELI5.
- [x] Visual proof is N/A because there is no UI change.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered.
- [ ] Full `pnpm lint`, unsharded `pnpm test`, and full native `pnpm build` were not run; focused quality gates, affected test suites, Node typecheck, and `build:desktop` passed as listed above.
