### PR TITLE
fix(workspace): treat upstream slug as same project for create-worktree

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField-repo-slug-routing.test.ts
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField-repo-slug-routing.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import type * as RuntimeRpcClient from '@/runtime/runtime-rpc-client'
 import type { TaskSourceContext } from '../../../../shared/task-source-context'
-import { getRepoSlugCached } from './SmartWorkspaceNameField'
+import { getRepoSlugCached, getRepoUpstreamCached } from './smart-workspace-repo-slug'
 
 vi.mock('@/runtime/runtime-rpc-client', async (importOriginal) => ({
   ...(await importOriginal<typeof RuntimeRpcClient>()),
@@ -10,9 +10,10 @@ vi.mock('@/runtime/runtime-rpc-client', async (importOriginal) => ({
 }))
 
 const repoSlug = vi.fn()
+const repoUpstream = vi.fn()
 
 // @ts-expect-error focused preload mock
-globalThis.window = { api: { gh: { repoSlug } } }
+globalThis.window = { api: { gh: { repoSlug, repoUpstream } } }
 
 function runtimeSource(environmentId: string): TaskSourceContext {
   return {
@@ -28,6 +29,7 @@ describe('SmartWorkspaceNameField repository slug routing', () => {
   beforeEach(() => {
     vi.mocked(callRuntimeRpc).mockReset()
     repoSlug.mockReset()
+    repoUpstream.mockReset()
   })
 
   it('resolves runtime-owned repos on their runtime and scopes the cache by runtime', async () => {
@@ -71,5 +73,30 @@ describe('SmartWorkspaceNameField repository slug routing', () => {
       host: 'github.acme.test'
     })
     expect(callRuntimeRpc).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves runtime-owned upstream slugs on their runtime', async () => {
+    vi.mocked(callRuntimeRpc).mockResolvedValueOnce({
+      owner: 'stablyai',
+      repo: 'orca',
+      host: 'github.one.test'
+    })
+    const cache = new Map()
+    const repo = { id: 'repo-1', path: '/workspace/widgets' }
+
+    await expect(getRepoUpstreamCached(repo, runtimeSource('one'), cache)).resolves.toMatchObject({
+      host: 'github.one.test'
+    })
+    await expect(getRepoUpstreamCached(repo, runtimeSource('one'), cache)).resolves.toMatchObject({
+      host: 'github.one.test'
+    })
+
+    expect(callRuntimeRpc).toHaveBeenCalledExactlyOnceWith(
+      { kind: 'environment', environmentId: 'one' },
+      'github.repoUpstream',
+      { repo: 'repo-1' },
+      { timeoutMs: 30_000 }
+    )
+    expect(repoUpstream).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/new-workspace/smart-workspace-github-direct-link.test.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-github-direct-link.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { lookupSmartGitHubSubmitItem } from '@/lib/smart-github-submit'
+import type { GitHubWorkItem } from '../../../../shared/github/work-item-types'
+import { resolveSmartWorkspaceGithubDirectLink } from './smart-workspace-github-direct-link'
+import type { RepoOption } from './smart-workspace-name-field-model'
+
+vi.mock('@/lib/smart-github-submit', () => ({
+  lookupSmartGitHubSubmitItem: vi.fn()
+}))
+
+vi.mock('@/lib/github-work-item-source-lookup', () => ({
+  lookupGitHubWorkItemByOwnerRepoForSource: vi.fn(),
+  lookupGitHubWorkItemForSource: vi.fn()
+}))
+
+const repoSlug = vi.fn()
+const repoUpstream = vi.fn()
+
+// @ts-expect-error focused preload mock
+globalThis.window = { api: { gh: { repoSlug, repoUpstream } } }
+
+const workItem = {
+  id: 'item-1',
+  type: 'issue',
+  number: 14841,
+  title: 'Issue',
+  state: 'open',
+  url: 'https://github.com/quarto-dev/quarto-cli/issues/14841',
+  labels: [],
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  author: 'cderv',
+  repoId: 'repo-1'
+} satisfies GitHubWorkItem
+
+function makeRepo(overrides: Partial<RepoOption> = {}): RepoOption {
+  return {
+    id: 'repo-1',
+    path: '/workspace/quarto-cli',
+    displayName: 'quarto-cli',
+    badgeColor: '#000',
+    addedAt: 1,
+    executionHostId: 'local',
+    ...overrides
+  } as RepoOption
+}
+
+async function resolvePaste(args: {
+  owner: string
+  repo: string
+  host?: string
+  selectedRepo: RepoOption
+  repos?: readonly RepoOption[]
+}) {
+  const slug = {
+    owner: args.owner,
+    repo: args.repo,
+    ...(args.host ? { host: args.host } : {})
+  }
+  return resolveSmartWorkspaceGithubDirectLink({
+    directLink: { slug, number: 14841, type: 'issue' },
+    crossRepoSwitchTarget: 'project',
+    repoBackedSearchTargets: [],
+    selectedRepo: args.selectedRepo,
+    githubSourceContext: null,
+    repos: args.repos ?? [],
+    repoSlugCache: new Map(),
+    handledCrossRepoUrlRef: { current: null },
+    query: `https://github.com/${args.owner}/${args.repo}/issues/14841`
+  })
+}
+
+describe('resolveSmartWorkspaceGithubDirectLink fork upstream matching', () => {
+  beforeEach(() => {
+    repoSlug.mockReset()
+    repoUpstream.mockReset()
+    vi.mocked(lookupSmartGitHubSubmitItem).mockReset()
+    vi.mocked(lookupSmartGitHubSubmitItem).mockResolvedValue(workItem)
+  })
+
+  it("does not prompt to switch when the URL is the selected fork's upstream", async () => {
+    const selectedRepo = makeRepo({
+      upstream: { owner: 'quarto-dev', repo: 'quarto-cli' }
+    })
+    repoSlug.mockResolvedValue({ owner: 'cderv', repo: 'quarto-cli' })
+
+    await expect(
+      resolvePaste({ owner: 'quarto-dev', repo: 'quarto-cli', selectedRepo })
+    ).resolves.toEqual({ items: [workItem], prompt: null })
+    expect(lookupSmartGitHubSubmitItem).toHaveBeenCalledOnce()
+    expect(repoUpstream).not.toHaveBeenCalled()
+  })
+
+  it('still prompts when the URL is a genuinely different repo', async () => {
+    const selectedRepo = makeRepo({
+      upstream: { owner: 'quarto-dev', repo: 'quarto-cli' }
+    })
+    repoSlug.mockResolvedValue({ owner: 'cderv', repo: 'quarto-cli' })
+
+    await expect(resolvePaste({ owner: 'stablyai', repo: 'orca', selectedRepo })).resolves.toEqual({
+      items: [],
+      prompt: {
+        link: {
+          slug: { owner: 'stablyai', repo: 'orca' },
+          number: 14841,
+          type: 'issue'
+        },
+        matchingRepo: null
+      }
+    })
+    expect(lookupSmartGitHubSubmitItem).not.toHaveBeenCalled()
+  })
+
+  it('still matches an origin-only project against its origin slug', async () => {
+    const selectedRepo = makeRepo({ upstream: null })
+    repoSlug.mockResolvedValue({ owner: 'stablyai', repo: 'orca' })
+
+    await expect(resolvePaste({ owner: 'stablyai', repo: 'orca', selectedRepo })).resolves.toEqual({
+      items: [workItem],
+      prompt: null
+    })
+    expect(lookupSmartGitHubSubmitItem).toHaveBeenCalledOnce()
+    expect(repoUpstream).not.toHaveBeenCalled()
+  })
+
+  it('treats a live upstream slug as the same project when fork metadata is unresolved', async () => {
+    const selectedRepo = makeRepo()
+    repoSlug.mockResolvedValue({ owner: 'cderv', repo: 'quarto-cli' })
+    repoUpstream.mockResolvedValue({ owner: 'quarto-dev', repo: 'quarto-cli' })
+
+    await expect(
+      resolvePaste({ owner: 'quarto-dev', repo: 'quarto-cli', selectedRepo })
+    ).resolves.toEqual({ items: [workItem], prompt: null })
+    expect(repoUpstream).toHaveBeenCalledExactlyOnceWith({
+      repoPath: '/workspace/quarto-cli',
+      repoId: 'repo-1'
+    })
+  })
+
+  it('scopes a host-less persisted fork parent to the origin host', async () => {
+    const selectedRepo = makeRepo({
+      path: '/workspace/widgets',
+      upstream: { owner: 'acme', repo: 'widgets' }
+    })
+    repoSlug.mockResolvedValue({ owner: 'me', repo: 'widgets', host: 'ghe.example' })
+
+    await expect(
+      resolvePaste({
+        owner: 'acme',
+        repo: 'widgets',
+        host: 'ghe.example',
+        selectedRepo
+      })
+    ).resolves.toEqual({ items: [workItem], prompt: null })
+
+    await expect(
+      resolvePaste({ owner: 'acme', repo: 'widgets', selectedRepo })
+    ).resolves.toMatchObject({ prompt: { matchingRepo: null } })
+  })
+})

--- a/src/renderer/src/components/new-workspace/smart-workspace-github-direct-link.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-github-direct-link.ts
@@ -15,7 +15,7 @@ import type {
   RepoBackedSearchTarget,
   RepoOption
 } from './smart-workspace-name-field-model'
-import { findMatchingRepoForSlug, getRepoSlugCached, sameSlug } from './smart-workspace-repo-slug'
+import { findMatchingRepoForSlug, selectedRepoMatchesPastedSlug } from './smart-workspace-repo-slug'
 
 type DirectLink = NonNullable<ReturnType<typeof parseGitHubIssueOrPRLink>>
 
@@ -72,8 +72,16 @@ export async function resolveSmartWorkspaceGithubDirectLink({
   if (!selectedRepo?.path) {
     return { items: [], prompt: null }
   }
-  const selectedSlug = await getRepoSlugCached(selectedRepo, githubSourceContext, repoSlugCache)
-  if (!selectedSlug || sameSlug(selectedSlug, directLink.slug)) {
+  // Why: contributor clones keep the fork as origin, so upstream issue/PR URLs
+  // must count as the same project (#18168).
+  if (
+    await selectedRepoMatchesPastedSlug(
+      selectedRepo,
+      githubSourceContext,
+      repoSlugCache,
+      directLink.slug
+    )
+  ) {
     handledCrossRepoUrlRef.current = query
     const item = await lookupSmartGitHubSubmitItem({
       repoPath: selectedRepo.path,

--- a/src/renderer/src/components/new-workspace/smart-workspace-repo-slug.test.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-repo-slug.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RepoOption, RepoSlugTarget } from './smart-workspace-name-field-model'
+import { findMatchingRepoForSlug } from './smart-workspace-repo-slug'
+
+const repoSlug = vi.fn()
+const repoUpstream = vi.fn()
+
+// @ts-expect-error focused preload mock
+globalThis.window = { api: { gh: { repoSlug, repoUpstream } } }
+
+function makeRepo(overrides: Partial<RepoOption> = {}): RepoOption {
+  return {
+    id: 'repo-1',
+    path: '/workspace/repo-1',
+    displayName: 'repo-1',
+    badgeColor: '#000',
+    addedAt: 1,
+    executionHostId: 'local',
+    ...overrides
+  } as RepoOption
+}
+
+function makeTarget(id: string, overrides: Partial<RepoOption> = {}): RepoSlugTarget {
+  return {
+    repo: makeRepo({
+      id,
+      path: `/workspace/${id}`,
+      displayName: id,
+      ...overrides
+    }),
+    sourceContext: null
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+describe('findMatchingRepoForSlug', () => {
+  beforeEach(() => {
+    repoSlug.mockReset()
+    repoUpstream.mockReset()
+  })
+
+  it('probes unresolved upstream identities concurrently', async () => {
+    const gate = deferred<{ owner: string; repo: string } | null>()
+    const started: string[] = []
+    repoSlug.mockImplementation(async ({ repoId }: { repoId: string }) => ({
+      owner: `${repoId}-owner`,
+      repo: repoId
+    }))
+    repoUpstream.mockImplementation(async ({ repoId }: { repoId: string }) => {
+      started.push(repoId)
+      return gate.promise
+    })
+
+    const resultPromise = findMatchingRepoForSlug(
+      [makeTarget('a'), makeTarget('b'), makeTarget('c')],
+      { owner: 'acme', repo: 'widgets' },
+      new Map()
+    )
+
+    await vi.waitFor(() => expect(started).toEqual(['a', 'b', 'c']))
+    gate.resolve(null)
+    await expect(resultPromise).resolves.toBeNull()
+    expect(repoUpstream).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns the first exact origin match without probing upstream', async () => {
+    repoSlug.mockImplementation(async ({ repoId }: { repoId: string }) => {
+      if (repoId === 'later-origin') {
+        return { owner: 'acme', repo: 'widgets' }
+      }
+      return { owner: `${repoId}-owner`, repo: repoId }
+    })
+    repoUpstream.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+
+    await expect(
+      findMatchingRepoForSlug(
+        [makeTarget('early-fork'), makeTarget('later-origin')],
+        { owner: 'acme', repo: 'widgets' },
+        new Map()
+      )
+    ).resolves.toMatchObject({ repo: { id: 'later-origin' } })
+    expect(repoUpstream).not.toHaveBeenCalled()
+  })
+
+  it('selects the first matching upstream target in target order after concurrent probes', async () => {
+    const first = deferred<{ owner: string; repo: string } | null>()
+    const second = deferred<{ owner: string; repo: string } | null>()
+    repoSlug.mockImplementation(async ({ repoId }: { repoId: string }) => ({
+      owner: `${repoId}-owner`,
+      repo: repoId
+    }))
+    repoUpstream.mockImplementation(async ({ repoId }: { repoId: string }) =>
+      repoId === 'first' ? first.promise : second.promise
+    )
+
+    const resultPromise = findMatchingRepoForSlug(
+      [makeTarget('first'), makeTarget('second')],
+      { owner: 'acme', repo: 'widgets' },
+      new Map()
+    )
+    await vi.waitFor(() => expect(repoUpstream).toHaveBeenCalledTimes(2))
+    second.resolve({ owner: 'acme', repo: 'widgets' })
+    first.resolve({ owner: 'acme', repo: 'widgets' })
+
+    await expect(resultPromise).resolves.toMatchObject({ repo: { id: 'first' } })
+  })
+
+  it('does not live-probe a persisted non-fork while probing later unresolved targets', async () => {
+    const gate = deferred<{ owner: string; repo: string } | null>()
+    repoSlug.mockImplementation(async ({ repoId }: { repoId: string }) => ({
+      owner: `${repoId}-owner`,
+      repo: repoId
+    }))
+    repoUpstream.mockImplementation(async () => gate.promise)
+
+    const resultPromise = findMatchingRepoForSlug(
+      [makeTarget('resolved', { upstream: null }), makeTarget('unresolved')],
+      { owner: 'acme', repo: 'widgets' },
+      new Map()
+    )
+    await vi.waitFor(() => expect(repoUpstream).toHaveBeenCalledTimes(1))
+    expect(repoUpstream).toHaveBeenCalledExactlyOnceWith({
+      repoPath: '/workspace/unresolved',
+      repoId: 'unresolved'
+    })
+    gate.resolve(null)
+    await expect(resultPromise).resolves.toBeNull()
+  })
+})

--- a/src/renderer/src/components/new-workspace/smart-workspace-repo-slug.test.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-repo-slug.test.ts
@@ -133,4 +133,21 @@ describe('findMatchingRepoForSlug', () => {
     gate.resolve(null)
     await expect(resultPromise).resolves.toBeNull()
   })
+
+  it('uses an explicit persisted upstream when the origin slug is unavailable', async () => {
+    repoSlug.mockResolvedValue(null)
+
+    await expect(
+      findMatchingRepoForSlug(
+        [
+          makeTarget('fork', {
+            upstream: { owner: 'acme', repo: 'widgets', host: 'github.com' }
+          })
+        ],
+        { owner: 'acme', repo: 'widgets' },
+        new Map()
+      )
+    ).resolves.toMatchObject({ repo: { id: 'fork' } })
+    expect(repoUpstream).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/new-workspace/smart-workspace-repo-slug.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-repo-slug.ts
@@ -129,19 +129,44 @@ export async function findMatchingRepoForSlug(
   slug: RepoSlug,
   cache: Map<string, RepoSlug>
 ): Promise<RepoSlugTarget | null> {
-  let upstreamMatch: RepoSlugTarget | null = null
-  for (const target of targets) {
-    const origin = await getRepoSlugCached(target.repo, target.sourceContext, cache)
+  // Why: serial origin+upstream probes stacked 30s timeouts; start origins together
+  // and only then live-probe unresolved upstreams, still preferring origin hits.
+  const originPromises = targets.map((target) =>
+    getRepoSlugCached(target.repo, target.sourceContext, cache)
+  )
+  const origins: (RepoSlug | null)[] = []
+  for (const [index, originPromise] of originPromises.entries()) {
+    const origin = await originPromise
+    origins.push(origin)
     if (origin && sameSlug(origin, slug)) {
-      return target
-    }
-    if (
-      !upstreamMatch &&
-      origin &&
-      (await repoUpstreamMatchesPastedSlug(target.repo, origin, slug, target.sourceContext, cache))
-    ) {
-      upstreamMatch = target
+      return targets[index]
     }
   }
-  return upstreamMatch
+
+  const unresolved: { target: RepoSlugTarget; origin: RepoSlug }[] = []
+  let persistedMatch: RepoSlugTarget | null = null
+  for (const [index, target] of targets.entries()) {
+    const origin = origins[index]
+    if (!origin) {
+      continue
+    }
+    if (persistedUpstreamMatchesPasted(target.repo, origin, slug)) {
+      persistedMatch = target
+      break
+    }
+    if (target.repo.upstream === undefined) {
+      unresolved.push({ target, origin })
+    }
+  }
+  if (unresolved.length === 0) {
+    return persistedMatch
+  }
+
+  const hits = await Promise.all(
+    unresolved.map(({ target, origin }) =>
+      repoUpstreamMatchesPastedSlug(target.repo, origin, slug, target.sourceContext, cache)
+    )
+  )
+  const hit = hits.findIndex(Boolean)
+  return hit === -1 ? persistedMatch : unresolved[hit].target
 }

--- a/src/renderer/src/components/new-workspace/smart-workspace-repo-slug.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-repo-slug.ts
@@ -4,6 +4,7 @@ import {
   getGitHubRuntimeRepoId,
   getGitHubSourceRuntimeTarget
 } from '@/lib/github-source-runtime-context'
+import { repoUpstreamIdentityKey } from '@/lib/repo-slug-cache'
 import { githubRepoIdentityKey } from '../../../../shared/github/repository-identity-key'
 import {
   getTaskSourceCacheScope,
@@ -11,32 +12,49 @@ import {
 } from '../../../../shared/task-source-context'
 import type { RepoOption, RepoSlugTarget } from './smart-workspace-name-field-model'
 
+type RepoIdentityKind = 'origin' | 'upstream'
+type RepoIdentityTarget = Pick<RepoOption, 'id' | 'path' | 'upstream'>
+
 export function sameSlug(left: RepoSlug, right: RepoSlug): boolean {
   return githubRepoIdentityKey(left) === githubRepoIdentityKey(right)
 }
 
-export async function getRepoSlugCached(
+function repoIdentityCacheKey(
   repo: Pick<RepoOption, 'id' | 'path'>,
   sourceContext: TaskSourceContext | null | undefined,
-  cache: Map<string, RepoSlug>
-): Promise<RepoSlug | null> {
-  const cacheKey = sourceContext
+  kind: RepoIdentityKind
+): string {
+  const base = sourceContext
     ? `${getTaskSourceCacheScope(sourceContext)}\0${repo.path}`
     : `local:${repo.id}\0${repo.path}`
+  return kind === 'upstream' ? `upstream:${base}` : base
+}
+
+async function getRepoIdentityCached(
+  repo: Pick<RepoOption, 'id' | 'path'>,
+  sourceContext: TaskSourceContext | null | undefined,
+  cache: Map<string, RepoSlug>,
+  kind: RepoIdentityKind
+): Promise<RepoSlug | null> {
+  const cacheKey = repoIdentityCacheKey(repo, sourceContext, kind)
   if (cache.has(cacheKey)) {
     return cache.get(cacheKey) ?? null
   }
   try {
     const target = getGitHubSourceRuntimeTarget(sourceContext)
+    const method = kind === 'upstream' ? 'github.repoUpstream' : 'github.repoSlug'
     const slug =
       target.kind === 'environment'
         ? await callRuntimeRpc<RepoSlug | null>(
             target,
-            'github.repoSlug',
+            method,
             { repo: getGitHubRuntimeRepoId(sourceContext, repo.id) },
             { timeoutMs: 30_000 }
           )
-        : await window.api.gh.repoSlug({ repoPath: repo.path, repoId: repo.id })
+        : await (kind === 'upstream' ? window.api.gh.repoUpstream : window.api.gh.repoSlug)({
+            repoPath: repo.path,
+            repoId: repo.id
+          })
     if (slug) {
       cache.set(cacheKey, slug)
     }
@@ -46,16 +64,84 @@ export async function getRepoSlugCached(
   }
 }
 
+export async function getRepoSlugCached(
+  repo: Pick<RepoOption, 'id' | 'path'>,
+  sourceContext: TaskSourceContext | null | undefined,
+  cache: Map<string, RepoSlug>
+): Promise<RepoSlug | null> {
+  return getRepoIdentityCached(repo, sourceContext, cache, 'origin')
+}
+
+export async function getRepoUpstreamCached(
+  repo: Pick<RepoOption, 'id' | 'path'>,
+  sourceContext: TaskSourceContext | null | undefined,
+  cache: Map<string, RepoSlug>
+): Promise<RepoSlug | null> {
+  return getRepoIdentityCached(repo, sourceContext, cache, 'upstream')
+}
+
+function persistedUpstreamMatchesPasted(
+  repo: Pick<RepoOption, 'upstream'>,
+  origin: RepoSlug,
+  pasted: RepoSlug
+): boolean {
+  return (
+    repoUpstreamIdentityKey(repo, githubRepoIdentityKey(origin)) === githubRepoIdentityKey(pasted)
+  )
+}
+
+async function repoUpstreamMatchesPastedSlug(
+  repo: RepoIdentityTarget,
+  origin: RepoSlug,
+  pasted: RepoSlug,
+  sourceContext: TaskSourceContext | null | undefined,
+  cache: Map<string, RepoSlug>
+): Promise<boolean> {
+  if (persistedUpstreamMatchesPasted(repo, origin, pasted)) {
+    return true
+  }
+  // Why: `null` is a resolved non-fork; only unresolved forks need a live probe.
+  if (repo.upstream !== undefined) {
+    return false
+  }
+  const live = await getRepoUpstreamCached(repo, sourceContext, cache)
+  return (
+    repoUpstreamIdentityKey({ upstream: live }, githubRepoIdentityKey(origin)) ===
+    githubRepoIdentityKey(pasted)
+  )
+}
+
+export async function selectedRepoMatchesPastedSlug(
+  repo: RepoIdentityTarget,
+  sourceContext: TaskSourceContext | null | undefined,
+  cache: Map<string, RepoSlug>,
+  pasted: RepoSlug
+): Promise<boolean> {
+  const origin = await getRepoSlugCached(repo, sourceContext, cache)
+  if (!origin || sameSlug(origin, pasted)) {
+    return true
+  }
+  return repoUpstreamMatchesPastedSlug(repo, origin, pasted, sourceContext, cache)
+}
+
 export async function findMatchingRepoForSlug(
   targets: readonly RepoSlugTarget[],
   slug: RepoSlug,
   cache: Map<string, RepoSlug>
 ): Promise<RepoSlugTarget | null> {
+  let upstreamMatch: RepoSlugTarget | null = null
   for (const target of targets) {
-    const candidate = await getRepoSlugCached(target.repo, target.sourceContext, cache)
-    if (candidate && sameSlug(candidate, slug)) {
+    const origin = await getRepoSlugCached(target.repo, target.sourceContext, cache)
+    if (origin && sameSlug(origin, slug)) {
       return target
     }
+    if (
+      !upstreamMatch &&
+      origin &&
+      (await repoUpstreamMatchesPastedSlug(target.repo, origin, slug, target.sourceContext, cache))
+    ) {
+      upstreamMatch = target
+    }
   }
-  return null
+  return upstreamMatch
 }

--- a/src/renderer/src/components/new-workspace/smart-workspace-repo-slug.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-repo-slug.ts
@@ -82,9 +82,21 @@ export async function getRepoUpstreamCached(
 
 function persistedUpstreamMatchesPasted(
   repo: Pick<RepoOption, 'upstream'>,
-  origin: RepoSlug,
+  origin: RepoSlug | null,
   pasted: RepoSlug
 ): boolean {
+  const upstream = repo.upstream
+  if (!upstream) {
+    return false
+  }
+  // Why: an explicit host makes persisted upstream metadata authoritative even
+  // when the origin identity is currently unavailable.
+  if (!origin) {
+    return (
+      upstream.host !== undefined &&
+      githubRepoIdentityKey(upstream) === githubRepoIdentityKey(pasted)
+    )
+  }
   return (
     repoUpstreamIdentityKey(repo, githubRepoIdentityKey(origin)) === githubRepoIdentityKey(pasted)
   )
@@ -147,12 +159,12 @@ export async function findMatchingRepoForSlug(
   let persistedMatch: RepoSlugTarget | null = null
   for (const [index, target] of targets.entries()) {
     const origin = origins[index]
-    if (!origin) {
-      continue
-    }
     if (persistedUpstreamMatchesPasted(target.repo, origin, slug)) {
       persistedMatch = target
       break
+    }
+    if (!origin) {
+      continue
     }
     if (target.repo.upstream === undefined) {
       unresolved.push({ target, origin })

--- a/src/renderer/src/lib/repo-slug-cache.ts
+++ b/src/renderer/src/lib/repo-slug-cache.ts
@@ -26,7 +26,7 @@ export type RepoSlugMatches = { origin: Repo[]; upstream: Repo[] }
  *  persisted forks), the fork's origin host is the fallback so GHES parents do
  *  not collapse into github.com. Unresolved origins refuse the alias. */
 export function repoUpstreamIdentityKey(
-  repo: Repo,
+  repo: Pick<Repo, 'upstream'>,
   originIdentityKey: string | null | undefined
 ): string | null {
   const upstream = repo.upstream


### PR DESCRIPTION
## Description
Create-worktree no longer false-triggers "Switch project?" when pasting an upstream GitHub issue/PR URL into a project whose `origin` is a personal fork.

The smart-name cross-repo check now treats the selected project as matching if the pasted slug equals the origin slug **or** the upstream/parent slug (persisted `repo.upstream`, with a live `github.repoUpstream` probe only when fork metadata is still unresolved).

## Focused fix
- In scope: create-worktree GitHub URL matching against origin or upstream for the selected project, and the same identity when looking up a switch target.
- Out of scope (explicit): GitLab paste matching, mobile paste intent, Projects-board slug index, changing `gh:repoSlug` itself.

## Preserves
- Genuinely different-repo URLs still open "Switch project?".
- Origin-only (non-fork) projects still match origin.
- Unresolved origin slugs stay permissive (existing retry behavior).
- Host-less persisted fork parents stay scoped to the fork's origin host, so GHES parents do not collapse into github.com.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/new-workspace/smart-workspace-github-direct-link.test.ts src/renderer/src/components/new-workspace/SmartWorkspaceNameField-repo-slug-routing.test.ts`
- 8 passed (5 fork-match cases + 3 runtime slug-routing cases)
- Before: fork origin `cderv/quarto-cli` + URL `quarto-dev/quarto-cli/issues/N` opened Switch project.
- After: that paste stays on the current project; a URL to a different repo still prompts.

## User-regression-tradeoffs
- None. Matching is closed to the selected clone's origin and upstream identities.

Fixes #18168
