### PR TITLE
fix(sidebar): include the newest agent in the project agent list

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -450,4 +450,30 @@ describe('buildTitleDerivedAgentRows', () => {
       ['tab-newest', makePaneKey('tab-newest', newestLeafId), 'claude', 'working']
     ])
   })
+
+  // Why: a rootless snapshot can bind split panes before the tree serializes;
+  // launchAgent must not stamp a spinner-only active sibling.
+  it('does not brand a spinner-only active pane with launchAgent when multiple rootless leaves are bound', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'claude' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: '⠼ demo-repo' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-a', 'pty-b'] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: null,
+          activeLeafId: LEAF_ID_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {
+            [LEAF_ID_1]: 'pty-a',
+            [LEAF_ID_2]: 'pty-b'
+          }
+        }
+      },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -381,4 +381,73 @@ describe('buildTitleDerivedAgentRows', () => {
 
     expect(rows).toHaveLength(0)
   })
+
+  // #18113: tab-bar + leaves the newest agent on a rootless layout until the pane
+  // tree serializes, so title-derived rows used to drop that tab (count = actual-1).
+  it('includes the newest live agent when its layout is still rootless', () => {
+    const newestLeafId = '99999999-9999-4999-8999-999999999999'
+    const tabs = [
+      makeTab('tab-1', { title: '⠋ Claude Code', sortOrder: 0, createdAt: 1 }),
+      makeTab('tab-2', { title: '⠋ Claude Code', sortOrder: 1, createdAt: 2 }),
+      makeTab('tab-newest', {
+        title: '⠋ Claude Code',
+        sortOrder: 2,
+        createdAt: 3,
+        launchAgent: 'claude'
+      })
+    ]
+    const rows = buildWorktreeAgentRows({
+      tabs,
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠋ Claude Code' },
+        'tab-2': { 1: '⠋ Claude Code' },
+        'tab-newest': { 1: '⠋ Claude Code' }
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-1'],
+        'tab-2': ['pty-2'],
+        'tab-newest': ['pty-newest']
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': makeSingleLayout(LEAF_ID_1),
+        'tab-2': makeSingleLayout(LEAF_ID_2),
+        'tab-newest': {
+          root: null,
+          activeLeafId: null,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [newestLeafId]: 'pty-newest' }
+        }
+      },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(3)
+    expect(rows.map((row) => row.tab.id)).toContain('tab-newest')
+    expect(rows.map((row) => row.paneKey)).toContain(makePaneKey('tab-newest', newestLeafId))
+  })
+
+  it('attributes a spinner-only newest tab to launchAgent on a rootless layout', () => {
+    const newestLeafId = '99999999-9999-4999-8999-999999999999'
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-newest', { launchAgent: 'claude', createdAt: 3, sortOrder: 2 })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-newest': { 1: '⠼ demo-repo' } },
+      ptyIdsByTabId: { 'tab-newest': ['pty-newest'] },
+      terminalLayoutsByTabId: {
+        'tab-newest': {
+          root: null,
+          activeLeafId: newestLeafId,
+          expandedLeafId: null
+        }
+      },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.tab.id, row.paneKey, row.agentType, row.state])).toEqual([
+      ['tab-newest', makePaneKey('tab-newest', newestLeafId), 'claude', 'working']
+    ])
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -1,4 +1,5 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import { resolveRootlessTerminalLayoutLeafId } from '@/components/terminal-pane/terminal-layout-leaf-ids'
 import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-status'
 import { isCursorAgentTitle } from '../../../../shared/agent-title-core'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
@@ -31,6 +32,11 @@ export const TITLE_DERIVED_AGENT_ROW_AUTHORITY_ID = 'renderer-title-projection'
 const EMPTY_RUNTIME_TITLES: Record<string, Record<number, string>> = {}
 const EMPTY_LIVE_PTY_IDS: Record<string, string[]> = {}
 const EMPTY_TERMINAL_LAYOUTS: Record<string, TerminalLayoutSnapshot | undefined> = {}
+const EMPTY_LAYOUT: TerminalLayoutSnapshot = {
+  root: null,
+  activeLeafId: null,
+  expandedLeafId: null
+}
 
 const TITLE_AGENT_LABEL_TO_TYPE: Record<string, AgentType> = {
   'Claude Code': 'claude',
@@ -105,7 +111,7 @@ export function buildTitleDerivedAgentRows(args: {
       continue
     }
 
-    const leafId = layout?.activeLeafId ?? collectLeafIds(layout?.root ?? null)[0]
+    const leafId = resolveTitleDerivedTabLeafId(layout)
     if (!leafId) {
       continue
     }
@@ -256,10 +262,30 @@ function resolveTitleDerivedPaneOwner(
 ): AgentType | null {
   // Why: launchAgent is tab-scoped, so it is pane ownership only while the tab has one
   // leaf; applying it inside a split would let one pane brand its sibling.
-  if (layout?.root?.type !== 'leaf' || layout.root.leafId !== leafId) {
+  if (!isTitleDerivedLaunchOwnerLeaf(layout, leafId)) {
     return null
   }
   return resolvePaneAgentOwner({ launchAgent: tab.launchAgent })
+}
+
+function isTitleDerivedLaunchOwnerLeaf(
+  layout: TerminalLayoutSnapshot | undefined,
+  leafId: string
+): boolean {
+  if (layout?.root?.type === 'leaf' && layout.root.leafId === leafId) {
+    return true
+  }
+  // Why: tab-bar + creates the newest agent with a rootless snapshot until the
+  // pane tree serializes; the unique bound/active leaf is still that tab's owner.
+  return !layout?.root && resolveRootlessTerminalLayoutLeafId(layout ?? EMPTY_LAYOUT) === leafId
+}
+
+function resolveTitleDerivedTabLeafId(layout: TerminalLayoutSnapshot | undefined): string | null {
+  const rootedLeafId = layout?.activeLeafId ?? collectLeafIds(layout?.root ?? null)[0]
+  if (rootedLeafId) {
+    return rootedLeafId
+  }
+  return layout ? resolveRootlessTerminalLayoutLeafId(layout) : null
 }
 
 /**
@@ -313,6 +339,15 @@ function resolveLeafIdForTitleFallback(args: {
   const leafIds = collectLeafIds(args.layout?.root ?? null)
   if (leafIds.length === 1) {
     return leafIds[0]
+  }
+
+  // Why: a just-created + tab can already have a pane title and live PTY while
+  // layout.root is still null; the unique bound leaf is that pane (#18113).
+  if (!args.layout?.root && args.paneTitleEntries.length === 1) {
+    const rootlessLeafId = args.layout ? resolveRootlessTerminalLayoutLeafId(args.layout) : null
+    if (rootlessLeafId) {
+      return rootlessLeafId
+    }
   }
 
   const paneIndex = args.paneTitleEntries.findIndex(([paneId]) => Number(paneId) === args.paneId)

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -275,6 +275,12 @@ function isTitleDerivedLaunchOwnerLeaf(
   if (layout?.root?.type === 'leaf' && layout.root.leafId === leafId) {
     return true
   }
+  const boundLeafIds = Object.keys(layout?.ptyIdsByLeafId ?? {}).filter(isTerminalLeafId)
+  // Why: a rootless snapshot can bind split panes before the tree serializes;
+  // launchAgent is tab-scoped and must not stamp a spinner-only sibling.
+  if (!layout?.root && boundLeafIds.length > 1) {
+    return false
+  }
   // Why: tab-bar + creates the newest agent with a rootless snapshot until the
   // pane tree serializes; the unique bound/active leaf is still that tab's owner.
   return !layout?.root && resolveRootlessTerminalLayoutLeafId(layout ?? EMPTY_LAYOUT) === leafId

--- a/src/renderer/src/store/slices/store-create-tab-id-hint.test.ts
+++ b/src/renderer/src/store/slices/store-create-tab-id-hint.test.ts
@@ -149,3 +149,29 @@ describe('createTab tabId hint', () => {
     }
   })
 })
+
+describe('createTab launchAgent layout', () => {
+  it('pins a single-pane layout leaf when creating a launchAgent tab', () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt-agent'
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt-agent' })]
+      },
+      groupsByWorktree: {},
+      activeGroupIdByWorktree: {},
+      unifiedTabsByWorktree: {}
+    })
+
+    const tab = store.getState().createTab(wt, undefined, undefined, { launchAgent: 'claude' })
+    const layout = store.getState().terminalLayoutsByTabId[tab.id]
+
+    expect(layout?.root).toEqual({
+      type: 'leaf',
+      leafId: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+      )
+    })
+    expect(layout?.activeLeafId).toBe(layout?.root?.type === 'leaf' ? layout.root.leafId : null)
+  })
+})

--- a/src/renderer/src/store/terminals/terminal-tab-creation.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-creation.ts
@@ -84,9 +84,11 @@ export function createTerminalTabCreationActions(
           options?.initialLeafId && isTerminalLeafId(options.initialLeafId)
             ? options.initialLeafId
             : undefined
-        // Why: startup delivery is pane-owned; pin its first leaf so an aborted/remounted renderer retries against the same spawn reservation.
+        // Why: pin the first leaf for startup delivery and for tab-bar + launchAgent
+        // tabs — + queues startup after createTab, so a missing leaf drops the newest
+        // sidebar agent row (#18113).
         const initialLeafId =
-          options?.initialPtyId || options?.pendingStartup
+          options?.initialPtyId || options?.pendingStartup || options?.launchAgent
             ? (requestedInitialLeafId ?? createBrowserUuid())
             : undefined
         const shouldActivate = options?.activate !== false


### PR DESCRIPTION
## Description
The project sidebar "N agents" list was always missing the most recently created agent tab (count = actual − 1), even though the tab bar showed it immediately after "+".

Title-derived sidebar rows require a UUID leaf to key a pane. Tab-bar `+` queues `launchAgent` startup *after* `createTab`, so the newest tab was stored with a rootless `emptyLayoutSnapshot`. Until that pane tree serialized, `buildTitleDerivedAgentRows` skipped the tab.

## Focused fix
- In scope: pin a single-pane layout leaf when creating a `launchAgent` tab, and resolve a unique rootless bound/active leaf in the title-derived row builder.
- Out of scope (explicit): SSH Codex idle-row `launchAgent` fallback (#10130 / #10178); hook routing; tab-bar chrome; other projects' lists.

## Preserves
- Tab bar, other projects, SSH, and idle vs running semantics for older agents with hydrated layouts.
- Split-pane launchAgent ownership (still not applied to sibling shells).
- No row is invented for a live PTY that has no classifiable title and no resolvable leaf.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts src/renderer/src/store/slices/store-create-tab-id-hint.test.ts`
- Before: 3 live Claude tabs, newest still rootless → sidebar length 2, newest pane/tab id missing.
- After: length 3 and includes the newest pane key; `createTab({ launchAgent })` stores a single-pane leaf.

## User-regression-tradeoffs
- None expected. The new leaf is the same single-pane snapshot already used for `pendingStartup` / `initialPtyId` tabs. Existing older agent rows still come from hook entries or rooted layouts.

Fixes #18113
