### PR TITLE
ci: checkout PR head for reusable E2E

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -897,6 +897,9 @@ jobs:
       contents: read
     uses: ./.github/workflows/e2e.yml
     with:
+      # The synthetic pull-request merge ref can disappear while this reusable
+      # workflow is queued. The head SHA is immutable and works for every PR.
+      ref: ${{ github.event.pull_request.head.sha }}
       test_files: ${{ needs.e2e-paths.outputs.test_files }}
       ssh_source_changed: ${{ needs.e2e-paths.outputs.ssh_source_changed }}
 

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -114,6 +114,7 @@ describe('PR E2E gate contract', () => {
     expect(prWorkflow.jobs['e2e-paths'].outputs.test_files).toBe(
       '${{ steps.filter.outputs.test_files }}'
     )
+    expect(prWorkflow.jobs.e2e.with.ref).toBe('${{ github.event.pull_request.head.sha }}')
     expect(prWorkflow.jobs.e2e.with.test_files).toBe('${{ needs.e2e-paths.outputs.test_files }}')
   })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## Summary
- checkout the immutable PR head SHA in the reusable E2E workflow
- avoid failures when GitHub's synthetic pull-request merge ref is unavailable
- add a contract assertion to prevent regression

## Validation
- pnpm exec vitest run config/scripts/pr-e2e-gate-contract.test.mjs config/scripts/release-e2e-dispatch-contract.test.mjs
- 49 tests passed
- git diff --check