### PR TITLE
Make terminal error overlays opaque

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -206,8 +206,8 @@ export function TerminalErrorToast({
         background: paneOwnerUnverified
           ? 'var(--popover)'
           : ssh
-            ? 'rgba(234, 179, 8, 0.12)'
-            : 'rgba(220, 38, 38, 0.15)',
+            ? 'color-mix(in srgb, var(--color-amber-500) 20%, var(--popover))'
+            : 'color-mix(in srgb, var(--destructive) 20%, var(--popover))',
         border: paneOwnerUnverified
           ? '1px solid var(--color-amber-500)'
           : ssh

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -151,6 +151,11 @@ export function TerminalErrorToast({
   const showIssueLink =
     !ssh && !paneOwnerUnverified && !showDaemonRestart && !isExplainedTerminalError(error)
   const displayError = humanizeTerminalError(error)
+  const messageColor = paneOwnerUnverified
+    ? 'var(--popover-foreground)'
+    : ssh
+      ? 'color-mix(in srgb, var(--popover-foreground) 70%, var(--color-amber-500))'
+      : 'color-mix(in srgb, var(--popover-foreground) 70%, var(--destructive))'
   const [retrying, setRetrying] = useState(false)
   const [retryFailed, setRetryFailed] = useState(false)
   const [environmentFooter, setEnvironmentFooter] = useState<{
@@ -213,7 +218,7 @@ export function TerminalErrorToast({
           : ssh
             ? '1px solid rgba(234, 179, 8, 0.35)'
             : '1px solid rgba(220, 38, 38, 0.4)',
-        color: paneOwnerUnverified ? 'var(--popover-foreground)' : ssh ? '#fde68a' : '#fca5a5',
+        color: messageColor,
         fontSize: 12,
         fontFamily: 'monospace',
         whiteSpace: 'pre-wrap',
@@ -240,7 +245,7 @@ export function TerminalErrorToast({
               )}{' '}
               <a
                 href="https://github.com/stablyai/orca/issues"
-                style={{ color: '#fca5a5', textDecoration: 'underline' }}
+                style={{ color: messageColor, textDecoration: 'underline' }}
               >
                 {translate(
                   'auto.components.terminal.pane.TerminalErrorToast.a7e2fd2699',
@@ -298,7 +303,7 @@ export function TerminalErrorToast({
           style={{
             background: 'none',
             border: 'none',
-            color: paneOwnerUnverified ? 'var(--popover-foreground)' : ssh ? '#fde68a' : '#fca5a5',
+            color: messageColor,
             cursor: 'pointer',
             fontSize: 14,
             padding: '0 0 0 8px',

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -151,11 +151,11 @@ export function TerminalErrorToast({
   const showIssueLink =
     !ssh && !paneOwnerUnverified && !showDaemonRestart && !isExplainedTerminalError(error)
   const displayError = humanizeTerminalError(error)
-  const messageColor = paneOwnerUnverified
-    ? 'var(--popover-foreground)'
+  const tint = paneOwnerUnverified
+    ? null
     : ssh
-      ? 'color-mix(in srgb, var(--popover-foreground) 70%, var(--color-amber-500))'
-      : 'color-mix(in srgb, var(--popover-foreground) 70%, var(--destructive))'
+      ? 'color-mix(in srgb, var(--color-amber-500) 20%, var(--popover))'
+      : 'color-mix(in srgb, var(--destructive) 20%, var(--popover))'
   const [retrying, setRetrying] = useState(false)
   const [retryFailed, setRetryFailed] = useState(false)
   const [environmentFooter, setEnvironmentFooter] = useState<{
@@ -208,17 +208,14 @@ export function TerminalErrorToast({
         zIndex: 50,
         padding: '10px 14px',
         borderRadius: 6,
-        background: paneOwnerUnverified
-          ? 'var(--popover)'
-          : ssh
-            ? 'color-mix(in srgb, var(--color-amber-500) 20%, var(--popover))'
-            : 'color-mix(in srgb, var(--destructive) 20%, var(--popover))',
+        background: 'var(--popover)',
+        backgroundImage: tint ? `linear-gradient(${tint}, ${tint})` : undefined,
         border: paneOwnerUnverified
           ? '1px solid var(--color-amber-500)'
           : ssh
             ? '1px solid rgba(234, 179, 8, 0.35)'
             : '1px solid rgba(220, 38, 38, 0.4)',
-        color: messageColor,
+        color: 'var(--popover-foreground)',
         fontSize: 12,
         fontFamily: 'monospace',
         whiteSpace: 'pre-wrap',
@@ -245,7 +242,7 @@ export function TerminalErrorToast({
               )}{' '}
               <a
                 href="https://github.com/stablyai/orca/issues"
-                style={{ color: messageColor, textDecoration: 'underline' }}
+                style={{ color: 'inherit', textDecoration: 'underline' }}
               >
                 {translate(
                   'auto.components.terminal.pane.TerminalErrorToast.a7e2fd2699',
@@ -303,7 +300,7 @@ export function TerminalErrorToast({
           style={{
             background: 'none',
             border: 'none',
-            color: messageColor,
+            color: 'inherit',
             cursor: 'pointer',
             fontSize: 14,
             padding: '0 0 0 8px',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## Summary

- Make yellow SSH and red terminal error overlays fully opaque.
- Preserve theme-aware tinted surfaces so terminal output remains readable.

## Validation

- `pnpm test src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts` (39 passed)
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx`
- `pnpm tc` is currently blocked by an existing `staleCleanupInFlight` type error in `src/main/worktree-create-preparation.ts:66`.

## Visual proof

Yellow SSH reconnect overlay:

| Before | After |
| --- | --- |
| ![Before: yellow SSH overlay](https://github.com/user-attachments/assets/df698631-36d6-4833-85f0-db7916d2dbf4) | ![After: yellow SSH overlay](https://github.com/user-attachments/assets/9d4d7eff-d945-4bfa-b0e6-5a1ffbbe1525) |

Red terminal error overlay:

| Before | After |
| --- | --- |
| ![Before: red terminal overlay](https://github.com/user-attachments/assets/2d1883cb-c3e4-42ec-9dda-389411c891aa) | ![After: red terminal overlay](https://github.com/user-attachments/assets/ede0c8cb-e717-40ba-88c9-9ecdd64aa7b8) |
