### PR TITLE
diag(mobile/relay): name the phase and credential on relay dial failures

### DIFF
--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -112,7 +112,7 @@ export class MobileEndpointSupervisor {
       scheduleDirectProbe: () => this.directProbe.schedule(),
       onBookkeepingError: (error) =>
         this.logRelay('relay bookkeeping failed after migration', error.message.slice(0, 80)),
-      onDialFailure: (error) => logRelayDialFailure(this.logRelay, error)
+      onDialFailure: (error, context) => logRelayDialFailure(this.logRelay, error, 'dial', context)
     })
     this.directProbe = new DirectReturnProbe(dependencies, {
       hysteresis: this.hysteresis,

--- a/mobile/src/transport/mobile-relay-diagnostic-log.ts
+++ b/mobile/src/transport/mobile-relay-diagnostic-log.ts
@@ -17,6 +17,10 @@ export type RelayDialAttemptContext = {
   totalCredentials: number
 }
 
+/**
+ * Records a relay dial or active-session failure on the recovery log, appending the
+ * director's retry-after when present and the dialed credential when `context` is given.
+ */
 export function logRelayDialFailure(
   log: RelayRecoveryLog,
   error: Error | null,

--- a/mobile/src/transport/mobile-relay-diagnostic-log.ts
+++ b/mobile/src/transport/mobile-relay-diagnostic-log.ts
@@ -8,19 +8,32 @@ export function logRelayConnected(log: RelayRecoveryLog): void {
   })
 }
 
+// Which credential the dial used, so a log can show whether failures cluster on one
+// credential while a later attempt with another succeeds. The version is an integer
+// counter, never the token itself.
+export type RelayDialAttemptContext = {
+  credentialVersion: number
+  attempt: number
+  totalCredentials: number
+}
+
 export function logRelayDialFailure(
   log: RelayRecoveryLog,
   error: Error | null,
-  source: 'dial' | 'active-session' = 'dial'
+  source: 'dial' | 'active-session' = 'dial',
+  context?: RelayDialAttemptContext
 ): void {
   if (!error) {
     return
   }
   const base = `${error.name}: ${String(error.message).slice(0, 80)}`
-  const detail =
+  const withRetryAfter =
     error instanceof RelayDirectorHttpError && error.retryAfterMs != null
       ? `${base}; retry-after=${error.retryAfterMs}ms`
       : base
+  const detail = context
+    ? `${withRetryAfter}; credential=v${context.credentialVersion} (${context.attempt}/${context.totalCredentials})`
+    : withRetryAfter
   log(source === 'dial' ? 'relay dial failed' : 'active relay session failed', detail, {
     level: 'error',
     code: source === 'dial' ? 'relay-dial-failed' : 'relay-session-failed'

--- a/mobile/src/transport/mobile-relay-session-establisher.ts
+++ b/mobile/src/transport/mobile-relay-session-establisher.ts
@@ -48,8 +48,14 @@ export class MobileRelaySessionEstablisher {
     }
   ) {}
 
-  // Tries each eligible credential until one establishes. Only a grace-repairable
-  // failure (BAD_OUTER_CREDENTIAL) moves on to the next credential.
+  /**
+   * Tries each eligible credential until one establishes, resolving with the outcome of
+   * the run: 'established', 'aborted', or 'failed' with the last error.
+   *
+   * Only a grace-repairable failure (BAD_OUTER_CREDENTIAL) moves on to the next
+   * credential; each failure reports which credential was in play so a log can show
+   * whether failures cluster on one of them.
+   */
   async dialEligible(
     credentials: { token: string; version: number }[]
   ): Promise<

--- a/mobile/src/transport/mobile-relay-session-establisher.ts
+++ b/mobile/src/transport/mobile-relay-session-establisher.ts
@@ -7,6 +7,7 @@ import {
 } from './mobile-endpoint-supervisor-support'
 import { persistResumeConfirmation } from './mobile-relay-credential-rotation'
 import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import type { RelayDialAttemptContext } from './mobile-relay-diagnostic-log'
 import type { RelayReconnectController } from './mobile-relay-reconnect-controller'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
@@ -43,7 +44,7 @@ export class MobileRelaySessionEstablisher {
       scheduleLease: (expiry: number | null) => void
       scheduleDirectProbe: () => void
       onBookkeepingError: (error: Error) => void
-      onDialFailure: (error: Error) => void
+      onDialFailure: (error: Error, context: RelayDialAttemptContext) => void
     }
   ) {}
 
@@ -55,7 +56,9 @@ export class MobileRelaySessionEstablisher {
     { outcome: 'established' } | { outcome: 'aborted' } | { outcome: 'failed'; error: Error | null }
   > {
     let lastError: Error | null = null
+    let attempt = 0
     for (const credential of credentials) {
+      attempt += 1
       const result = await this.dial(credential)
       if (result.ok) {
         return { outcome: 'established' }
@@ -64,7 +67,11 @@ export class MobileRelaySessionEstablisher {
         return { outcome: 'aborted' }
       }
       lastError = result.error
-      this.args.onDialFailure(result.error)
+      this.args.onDialFailure(result.error, {
+        credentialVersion: credential.version,
+        attempt,
+        totalCredentials: credentials.length
+      })
       if (!this.args.controller.shouldTryGraceAfterRelayFailure(result.error)) {
         break
       }

--- a/mobile/src/transport/replacement-session-authentication.test.ts
+++ b/mobile/src/transport/replacement-session-authentication.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest'
+import { waitForAuthenticated } from './replacement-session-authentication'
+import type { RpcClient } from './rpc-client'
+import type { ConnectionState } from './types'
+
+type FakeSession = RpcClient & {
+  emit: (state: ConnectionState) => void
+  listenerCount: () => number
+}
+
+// Why: waitForAuthenticated only touches getState/onStateChange, so the fake keeps to
+// those two and tracks unsubscribe so the leak branches are observable.
+function fakeSession(
+  initial: ConnectionState,
+  options: { emitOnSubscribe?: ConnectionState } = {}
+) {
+  const listeners = new Set<(state: ConnectionState) => void>()
+  let state = initial
+  const session = {
+    getState: () => state,
+    onStateChange: (listener: (state: ConnectionState) => void) => {
+      listeners.add(listener)
+      if (options.emitOnSubscribe) {
+        state = options.emitOnSubscribe
+        listener(state)
+      }
+      return () => listeners.delete(listener)
+    },
+    emit: (next: ConnectionState) => {
+      state = next
+      // Why: snapshot the set — a listener that unsubscribes during notification
+      // must not mutate the collection being iterated.
+      const snapshot = Array.from(listeners)
+      for (const listener of snapshot) {
+        listener(next)
+      }
+    },
+    listenerCount: () => listeners.size
+  } as unknown as FakeSession
+  return session
+}
+
+describe('waitForAuthenticated', () => {
+  it('resolves without subscribing when the session is already connected', async () => {
+    const session = fakeSession('connected')
+    await expect(waitForAuthenticated(session, 1_000)).resolves.toBeUndefined()
+    expect(session.listenerCount()).toBe(0)
+  })
+
+  it('resolves once the session reaches connected', async () => {
+    const session = fakeSession('handshaking')
+    const wait = waitForAuthenticated(session, 1_000)
+    session.emit('connected')
+    await expect(wait).resolves.toBeUndefined()
+    expect(session.listenerCount()).toBe(0)
+  })
+
+  it.each(['auth-failed', 'disconnected'] as const)('rejects on %s', async (state) => {
+    const session = fakeSession('handshaking')
+    const wait = waitForAuthenticated(session, 1_000)
+    session.emit(state)
+    await expect(wait).rejects.toThrow(`replacement session ${state}`)
+    expect(session.listenerCount()).toBe(0)
+  })
+
+  it('ignores states that are neither success nor terminal', async () => {
+    const session = fakeSession('connecting')
+    const wait = waitForAuthenticated(session, 1_000)
+    session.emit('reconnecting')
+    session.emit('handshaking')
+    session.emit('connected')
+    await expect(wait).resolves.toBeUndefined()
+  })
+
+  it('names the phase it timed out in', async () => {
+    vi.useFakeTimers()
+    try {
+      const session = fakeSession('handshaking')
+      const wait = waitForAuthenticated(session, 12_000)
+      const assertion = expect(wait).rejects.toThrow(
+        'replacement session authentication timed out (phase: handshaking)'
+      )
+      vi.advanceTimersByTime(12_000)
+      await assertion
+      expect(session.listenerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reports connecting when the socket never opened', async () => {
+    vi.useFakeTimers()
+    try {
+      const session = fakeSession('connecting')
+      const wait = waitForAuthenticated(session, 12_000)
+      const assertion = expect(wait).rejects.toThrow('(phase: connecting)')
+      vi.advanceTimersByTime(12_000)
+      await assertion
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why: the file arms its timer before subscribing precisely so a synchronous
+  // notification during registration cannot leave a 12s timer running.
+  it('clears the timer when the notification fires during registration', async () => {
+    vi.useFakeTimers()
+    try {
+      const session = fakeSession('handshaking', { emitOnSubscribe: 'connected' })
+      await expect(waitForAuthenticated(session, 12_000)).resolves.toBeUndefined()
+      expect(vi.getTimerCount()).toBe(0)
+      expect(session.listenerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/mobile/src/transport/replacement-session-authentication.test.ts
+++ b/mobile/src/transport/replacement-session-authentication.test.ts
@@ -8,8 +8,14 @@ type FakeSession = RpcClient & {
   listenerCount: () => number
 }
 
-// Why: waitForAuthenticated only touches getState/onStateChange, so the fake keeps to
-// those two and tracks unsubscribe so the leak branches are observable.
+/**
+ * Builds a minimal RpcClient stand-in whose state can be driven from a test.
+ *
+ * Why: waitForAuthenticated only touches getState/onStateChange, so the fake keeps to
+ * those two and tracks unsubscribe so the leak branches are observable. Pass
+ * `emitOnSubscribe` to fire a state change synchronously during registration, which is
+ * the case the production file arms its timer before subscribing to survive.
+ */
 function fakeSession(
   initial: ConnectionState,
   options: { emitOnSubscribe?: ConnectionState } = {}

--- a/mobile/src/transport/replacement-session-authentication.ts
+++ b/mobile/src/transport/replacement-session-authentication.ts
@@ -13,8 +13,13 @@ export function waitForAuthenticated(session: RpcClient, timeoutMs: number): Pro
     // Why: armed before subscribing — a synchronous notification during registration
     // must find a timer to clear, or a settled wait leaves it running for 12s.
     const timer = setTimeout(() => {
+      // Why: the bare message cannot distinguish a cell socket that never opened
+      // ('connecting') from an E2EE handshake that stalled after it did
+      // ('handshaking'), and the inner HANDSHAKE_TIMEOUT_MS never surfaces when the
+      // socket is replaced before it fires — so name the phase we timed out in.
+      const phase = session.getState()
       finish()
-      reject(new Error('replacement session authentication timed out'))
+      reject(new Error(`replacement session authentication timed out (phase: ${phase})`))
     }, timeoutMs)
     unsubscribe = session.onStateChange((state) => {
       if (state === 'connected') {

--- a/mobile/src/transport/replacement-session-authentication.ts
+++ b/mobile/src/transport/replacement-session-authentication.ts
@@ -1,8 +1,15 @@
 import type { RpcClient } from './rpc-client'
 
-// Why: a migration must not cut over to a session that has only opened a socket — the
-// replacement has to reach 'connected' (E2EE authenticated) first, and a relay dial can
-// sit in handshaking for seconds, so the wait is bounded by the caller's timeout.
+/**
+ * Resolves once `session` reaches 'connected' (E2EE authenticated), rejecting if it
+ * lands on a terminal state or the timeout elapses first.
+ *
+ * Why: a migration must not cut over to a session that has only opened a socket — the
+ * replacement has to reach 'connected' first, and a relay dial can sit in handshaking
+ * for seconds, so the wait is bounded by the caller's timeout. The rejection names the
+ * phase it timed out in, because 'connecting' (socket never opened) and 'handshaking'
+ * (E2EE stalled after it did) need different investigation.
+ */
 export function waitForAuthenticated(session: RpcClient, timeoutMs: number): Promise<void> {
   if (session.getState() === 'connected') {
     return Promise.resolve()


### PR DESCRIPTION
## ELI5

When a phone fails to connect through the relay, the log says only "replacement session
authentication timed out" — it doesn't say whether the connection never opened or opened
and then stalled mid-handshake, and it doesn't say which of the available credentials it
tried. Those are the two things you need to know to tell these failures apart. This adds
them to the log, and adds the unit test the file never had. Nothing about how the app
connects changes.

## What Changed

Three things, all in `mobile/src/transport/`, all diagnostics:

1. **`replacement-session-authentication.ts`** — the timeout rejection now names the
   phase: `replacement session authentication timed out (phase: connecting)` vs
   `(phase: handshaking)`.
2. **`mobile-relay-diagnostic-log.ts`, `mobile-relay-session-establisher.ts`,
   `mobile-endpoint-supervisor.ts`** — `onDialFailure` now carries a
   `RelayDialAttemptContext` (`credentialVersion`, `attempt`, `totalCredentials`), and
   the dial-failure detail appends `credential=v3 (1/2)`. The version is the existing
   integer counter; the token is never logged.
3. **`replacement-session-authentication.test.ts`** — new, 8 cases.

## Why

Investigating a host where the direct endpoint is unavailable (dropped by corporate
firewall policy, so relay is the only path), relay dials failed with
`replacement session authentication timed out` — but roughly 1 dial in 12 succeeded with
no change to the environment, and the desktop host authenticated the device on *every*
attempt (`updateLastSeenDeferred` fires from inside `onReady`, and `lastSeenAt` advanced
every 10-15 s throughout the failures). Full write-up in #18228.

Neither fact is visible from the log today:

- **Phase.** A relay session that stalls hits its own `HANDSHAKE_TIMEOUT_MS = 5_000`,
  forces a close, and lands in `'reconnecting'` — a legitimate dial phase that
  `migrateTo` deliberately forwards and can still recover from (covered by
  `stable-logical-rpc-client.test.ts`, *"forwards a reconnecting phase published by the
  dialing session itself"*). So the outer 12 s wait is doing real work, and this PR does
  not change it. What is lost is only which phase the wait ended in:
  `session.getState()` in the rejection distinguishes a cell socket that never opened
  (`connecting`) from a handshake that stalled after it did (`handshaking`) — and, on a
  host where the pattern is ~1 successful dial in 12, that is the difference between
  investigating the transport and investigating the handshake.

- **Credential.** `dialEligible` already loops over every eligible credential and only
  advances on a grace-repairable failure, but `onDialFailure` drops which one was in
  play. That makes "failures cluster on one credential, a later attempt with another
  succeeds" — the leading hypothesis in #18228 — invisible. The file's own comment
  already flags the ambiguity: *"version comparison cannot tell fresh from stale."*

Why this shape rather than a fix: the step that actually fails is between the iOS client
and the relay service, which I can't reproduce or instrument from outside. Guessing at it
inside a race-sensitive supervisor seemed worse than making the next report conclusive.

## Linked Issue

Relates to #18228 — this PR **does not fix it**, so no closing keyword. It adds the
instrumentation needed to diagnose it. #18229 covers a separate direct-probe concern and
is deliberately untouched here.

## Visual Proof

`N/A` — no UI or interaction change. The only user-visible difference is extra detail in
the connection log text, shown here as before/after strings:

```
before   Relay: relay dial failed — Error: replacement session authentication timed out
after    Relay: relay dial failed — Error: replacement session authentication timed out
                (phase: handshaking); credential=v3 (1/2)
```

## Testing

Scoped to the `mobile` package:

```
pnpm exec vitest run src/transport/     88 files, 654 tests passed, 3 skipped
pnpm exec oxlint src/transport/         clean
pnpm exec oxfmt --check src/transport/  clean
pnpm exec tsc --noEmit                  no errors in the touched files
```

Honest caveats, so nothing here is oversold:

- Ran in a sparse checkout (`mobile src config`) with `--ignore-scripts`. That leaves two
  **pre-existing** typecheck errors on the `*.generated` webview bundles and one
  pre-existing failure in `src/mock-server-key-pair.test.ts`. Both reproduce identically
  on a clean baseline with these changes stashed.
- **I did not run `pnpm build`** — the sparse checkout has no Electron main/renderer
  tree, so the build is not meaningful from it. CI covers this.
- Not exercised on a device: the relay failure that motivated this is environment-bound
  (it needs a firewall that drops rather than rejects), so the new log lines were derived
  from the code path, not observed in a live app run. The unit test covers the phase
  string directly.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Author

X: [@vinicerqueira12](https://x.com/vinicerqueira12)

## AI Disclosure

This change was authored with **Claude Opus 5 via Claude Code**, driven by me. The model
read the published `mobile/src/transport/` sources to trace the handshake, wrote the
diff and the tests, and ran the checks above. I reviewed the result before opening this.

## Review

AI code review summary, per CONTRIBUTING:

- **Cross-platform (macOS / Linux / Windows):** no platform-specific code. No paths,
  shells, processes, or shortcuts touched. Two template literals and one optional
  parameter.
- **SSH / remote / local:** untouched. The change sits in the mobile transport's relay
  dial path and does not assume anything about where the host runs.
- **Agents / integrations / git providers:** provider-neutral; no integration-specific
  logic added.
- **Performance:** one extra `getState()` call on an already-failing path, and one string
  concat per dial failure. Nothing in a hot path; no new allocation while healthy.
- **UI quality:** no UI change; log text only.
- **Security:** the added field is the credential's integer `version`, never the token,
  and no key material or endpoint is newly logged. `RelayDirectorHttpError` handling is
  unchanged, and the existing 80-char truncation on the error message is preserved.
- **Backwards compatibility:** `RelayDialAttemptContext` is optional on
  `logRelayDialFailure`, so the `active-session` call site is unaffected. Error messages
  are diagnostic strings, not parsed anywhere in the repo (checked).

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry entries, path
  tables, comments, or documentation involved.

## Notes

No security, cross-platform, remote/SSH, mobile, backwards-compatibility, or performance
concerns identified. The behavioural surface is unchanged by construction: the only edits
are a string in a rejection that already happened, an optional log field, and a new test
file.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover;
      local preferred) — ran the `mobile`-scoped equivalents; `pnpm build` not run from a
      sparse checkout, see Testing
