### PR TITLE
feat(status-bar): show tokens per second for the focused agent pane

### DIFF
--- a/src/main/agent-hooks/agent-throughput-source-profiles.ts
+++ b/src/main/agent-hooks/agent-throughput-source-profiles.ts
@@ -1,0 +1,145 @@
+import type { AgentHookSource } from '../../shared/agent-hook-relay'
+import { readLastClaudeMessageThroughput } from '../../shared/agent-hook-listener/claude-transcript-throughput'
+import { readLastCodexMessageThroughput } from '../../shared/agent-hook-listener/codex-transcript-throughput'
+import { readLastGeminiMessageThroughput } from '../../shared/agent-hook-listener/gemini-chat-throughput'
+import {
+  getGrokChatHistoryPath,
+  readGrokHomeEnvelope
+} from '../../shared/agent-hook-listener/grok-result-discovery'
+import { readLastGrokMessageThroughput } from '../../shared/agent-hook-listener/grok-session-throughput'
+import { readFirstString } from '../../shared/agent-hook-listener/interactive-tool'
+import { isGrokEvent } from '../../shared/agent-hook-listener/provider-event-names'
+import type { AgentMessageThroughput } from '../../shared/agent-throughput-types'
+import { readLastOpenCodeMessageThroughput } from '../opencode/opencode-message-throughput'
+
+export type ThroughputHookAction = 'reset' | 'new-turn' | 'measure' | 'measure-streaming' | 'ignore'
+
+/** How one hook source maps its events to throughput actions and where it reads the last call from. */
+export type AgentThroughputSourceProfile = {
+  classify: (hookEventName: string, payload: Record<string, unknown>) => ThroughputHookAction
+  read: (
+    payload: Record<string, unknown>,
+    /** The hook envelope around the payload (pane key, worktree, per-runtime home dirs). */
+    envelope: Record<string, unknown>
+  ) => AgentMessageThroughput | undefined | Promise<AgentMessageThroughput | undefined>
+  /** Floor between `measure-streaming` reads; those events fire while a message is still streaming. */
+  streamingReadIntervalMs?: number
+}
+
+// Why: each fires once a message is complete; the post-tool events double as a retry for a
+// transcript row that was still unflushed when the pre-tool event arrived.
+const CLAUDE_STYLE_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'PermissionRequest',
+  'Stop',
+  'StopFailure',
+  'SubagentStop',
+  'PostCompact'
+])
+const GEMINI_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
+  'BeforeTool',
+  'AfterTool',
+  'AfterAgent'
+])
+const OPENCODE_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
+  'SessionIdle',
+  'PermissionRequest',
+  'AskUserQuestion'
+])
+const OPENCODE_STREAMING_READ_INTERVAL_MS = 1_500
+
+function classifyClaudeStyleHook(hookEventName: string): ThroughputHookAction {
+  if (hookEventName === 'SessionStart') {
+    return 'reset'
+  }
+  if (hookEventName === 'UserPromptSubmit') {
+    return 'new-turn'
+  }
+  return CLAUDE_STYLE_COMPLETE_EVENTS.has(hookEventName) ? 'measure' : 'ignore'
+}
+
+function readWithTranscript(
+  read: (transcriptPath: string) => AgentMessageThroughput | undefined
+): AgentThroughputSourceProfile['read'] {
+  return (payload) => {
+    const transcriptPath = readFirstString(payload, ['transcript_path', 'transcriptPath'])
+    return transcriptPath ? read(transcriptPath) : undefined
+  }
+}
+
+const OPENCODE_PROFILE: AgentThroughputSourceProfile = {
+  classify: (hookEventName, payload) => {
+    if (hookEventName === 'SessionStart') {
+      return 'reset'
+    }
+    if (hookEventName === 'MessagePart') {
+      return payload.role === 'user'
+        ? 'new-turn'
+        : payload.role === 'assistant'
+          ? 'measure-streaming'
+          : 'ignore'
+    }
+    return OPENCODE_COMPLETE_EVENTS.has(hookEventName) ? 'measure' : 'ignore'
+  },
+  read: (payload) => {
+    const sessionId = readFirstString(payload, ['sessionID', 'sessionId', 'session_id'])
+    return sessionId ? readLastOpenCodeMessageThroughput(sessionId) : undefined
+  },
+  streamingReadIntervalMs: OPENCODE_STREAMING_READ_INTERVAL_MS
+}
+
+const GROK_PROFILE: AgentThroughputSourceProfile = {
+  classify: (hookEventName) => {
+    if (isGrokEvent(hookEventName, 'session_start')) {
+      return 'reset'
+    }
+    if (isGrokEvent(hookEventName, 'user_prompt_submit')) {
+      return 'new-turn'
+    }
+    return isGrokEvent(
+      hookEventName,
+      'pre_tool_use',
+      'post_tool_use',
+      'post_tool_use_failure',
+      'stop',
+      'stop_failure'
+    )
+      ? 'measure'
+      : 'ignore'
+  },
+  read: (payload, envelope) => {
+    const chatHistoryPath = getGrokChatHistoryPath(payload, readGrokHomeEnvelope(envelope))
+    return chatHistoryPath ? readLastGrokMessageThroughput(chatHistoryPath) : undefined
+  }
+}
+
+/** Sources with a per-message token record Orca can reach, plus Grok's text-length estimate. */
+export const AGENT_THROUGHPUT_SOURCE_PROFILES: Partial<
+  Record<AgentHookSource, AgentThroughputSourceProfile>
+> = {
+  claude: {
+    classify: classifyClaudeStyleHook,
+    read: readWithTranscript(readLastClaudeMessageThroughput)
+  },
+  codex: {
+    classify: classifyClaudeStyleHook,
+    read: readWithTranscript(readLastCodexMessageThroughput)
+  },
+  gemini: {
+    classify: (hookEventName) => {
+      if (hookEventName === 'SessionStart') {
+        return 'reset'
+      }
+      if (hookEventName === 'BeforeAgent') {
+        return 'new-turn'
+      }
+      return GEMINI_COMPLETE_EVENTS.has(hookEventName) ? 'measure' : 'ignore'
+    },
+    read: readWithTranscript(readLastGeminiMessageThroughput)
+  },
+  opencode: OPENCODE_PROFILE,
+  'mimo-code': OPENCODE_PROFILE,
+  grok: GROK_PROFILE
+}

--- a/src/main/agent-hooks/agent-throughput-source-profiles.ts
+++ b/src/main/agent-hooks/agent-throughput-source-profiles.ts
@@ -50,8 +50,11 @@ const OPENCODE_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
 ])
 const OPENCODE_STREAMING_READ_INTERVAL_MS = 1_500
 
+// Why: a reading must not outlive the session that produced it, so SessionEnd clears it like
+// SessionStart does. Orca installs that hook for Grok only today; the others keep their last
+// reading until a new session starts in the pane.
 function classifyClaudeStyleHook(hookEventName: string): ThroughputHookAction {
-  if (hookEventName === 'SessionStart') {
+  if (hookEventName === 'SessionStart' || hookEventName === 'SessionEnd') {
     return 'reset'
   }
   if (hookEventName === 'UserPromptSubmit') {
@@ -92,7 +95,7 @@ const OPENCODE_PROFILE: AgentThroughputSourceProfile = {
 
 const GROK_PROFILE: AgentThroughputSourceProfile = {
   classify: (hookEventName) => {
-    if (isGrokEvent(hookEventName, 'session_start')) {
+    if (isGrokEvent(hookEventName, 'session_start', 'session_end')) {
       return 'reset'
     }
     if (isGrokEvent(hookEventName, 'user_prompt_submit')) {
@@ -129,7 +132,7 @@ export const AGENT_THROUGHPUT_SOURCE_PROFILES: Partial<
   },
   gemini: {
     classify: (hookEventName) => {
-      if (hookEventName === 'SessionStart') {
+      if (hookEventName === 'SessionStart' || hookEventName === 'SessionEnd') {
         return 'reset'
       }
       if (hookEventName === 'BeforeAgent') {

--- a/src/main/agent-hooks/agent-throughput-tracker.test.ts
+++ b/src/main/agent-hooks/agent-throughput-tracker.test.ts
@@ -251,7 +251,25 @@ describe('AgentThroughputTracker', () => {
     expect(gemini.classify('AfterTool', {})).toBe('measure')
     expect(gemini.classify('AfterAgent', {})).toBe('measure')
     expect(gemini.classify('SessionStart', {})).toBe('reset')
+    expect(gemini.classify('SessionEnd', {})).toBe('reset')
     expect(gemini.classify('Notification', {})).toBe('ignore')
+  })
+
+  it('clears the pane when the agent session ends', async () => {
+    const tracker = createTracker(() => message())
+    const clearListener = vi.fn()
+    tracker.setListener(vi.fn())
+    tracker.setClearListener(clearListener)
+
+    await observe(tracker, 'Stop')
+    expect(tracker.getSnapshot()).toHaveLength(1)
+    // Why: the last reading must not outlive the agent that produced it.
+    await observe(tracker, 'SessionEnd')
+    expect(clearListener).toHaveBeenCalledWith(PANE)
+    expect(tracker.getSnapshot()).toEqual([])
+
+    expect(AGENT_THROUGHPUT_SOURCE_PROFILES.grok!.classify('SessionEnd', {})).toBe('reset')
+    expect(AGENT_THROUGHPUT_SOURCE_PROFILES.codex!.classify('SessionEnd', {})).toBe('reset')
   })
 
   it('drops a read that resolves after the next prompt started a new turn', async () => {

--- a/src/main/agent-hooks/agent-throughput-tracker.test.ts
+++ b/src/main/agent-hooks/agent-throughput-tracker.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { AgentMessageThroughput } from '../../shared/agent-throughput-types'
+import {
+  AGENT_THROUGHPUT_MEASURED_AGENTS,
+  type AgentMessageThroughput
+} from '../../shared/agent-throughput-types'
 import {
   AGENT_THROUGHPUT_SOURCE_PROFILES,
   AgentThroughputTracker,
@@ -249,5 +252,12 @@ describe('AgentThroughputTracker', () => {
     expect(gemini.classify('AfterAgent', {})).toBe('measure')
     expect(gemini.classify('SessionStart', {})).toBe('reset')
     expect(gemini.classify('Notification', {})).toBe('ignore')
+  })
+
+  it('advertises exactly the sources it can read', () => {
+    // Why: the renderer's "not available for this agent" hint is driven by the shared list.
+    expect(Object.keys(AGENT_THROUGHPUT_SOURCE_PROFILES).sort()).toEqual(
+      [...AGENT_THROUGHPUT_MEASURED_AGENTS].sort()
+    )
   })
 })

--- a/src/main/agent-hooks/agent-throughput-tracker.test.ts
+++ b/src/main/agent-hooks/agent-throughput-tracker.test.ts
@@ -1,17 +1,18 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { ClaudeMessageThroughput } from '../../shared/agent-hook-listener/claude-transcript-throughput'
-import { AgentThroughputTracker, readClaudeHookTranscriptPath } from './agent-throughput-tracker'
+import type { AgentMessageThroughput } from '../../shared/agent-throughput-types'
+import {
+  AGENT_THROUGHPUT_SOURCE_PROFILES,
+  AgentThroughputTracker,
+  type AgentThroughputSourceProfile
+} from './agent-throughput-tracker'
 
 const PANE = 'tab-1:0f7c1b2e-3d4a-4c5b-8e6f-7a8b9c0d1e2f'
 
-function hookBody(hookEventName: string, transcriptPath = 'C:/transcripts/session.jsonl'): unknown {
-  return {
-    paneKey: PANE,
-    payload: JSON.stringify({ hook_event_name: hookEventName, transcript_path: transcriptPath })
-  }
+function hookBody(payload: Record<string, unknown>): unknown {
+  return { paneKey: PANE, payload: JSON.stringify(payload) }
 }
 
-function message(overrides: Partial<ClaudeMessageThroughput> = {}): ClaudeMessageThroughput {
+function message(overrides: Partial<AgentMessageThroughput> = {}): AgentMessageThroughput {
   return {
     messageId: 'msg_1',
     model: 'claude-fable-5-1',
@@ -22,25 +23,56 @@ function message(overrides: Partial<ClaudeMessageThroughput> = {}): ClaudeMessag
   }
 }
 
-function observe(tracker: AgentThroughputTracker, hookEventName: string): void {
-  tracker.observeClaudeHook({ paneKey: PANE, hookEventName, body: hookBody(hookEventName) })
+function createTracker(
+  read: AgentThroughputSourceProfile['read'],
+  options: { now?: () => number; streamingReadIntervalMs?: number } = {}
+): AgentThroughputTracker {
+  const claudeProfile = AGENT_THROUGHPUT_SOURCE_PROFILES.claude!
+  const opencodeProfile = AGENT_THROUGHPUT_SOURCE_PROFILES.opencode!
+  return new AgentThroughputTracker({
+    now: options.now ?? (() => 42),
+    profiles: {
+      claude: { classify: claudeProfile.classify, read },
+      codex: { classify: claudeProfile.classify, read },
+      opencode: {
+        classify: opencodeProfile.classify,
+        read,
+        streamingReadIntervalMs: options.streamingReadIntervalMs ?? 1_500
+      }
+    }
+  })
+}
+
+async function observe(
+  tracker: AgentThroughputTracker,
+  hookEventName: string,
+  source: 'claude' | 'codex' | 'opencode' | 'grok' = 'claude',
+  extra: Record<string, unknown> = {}
+): Promise<void> {
+  await tracker.observeHook({
+    source,
+    paneKey: PANE,
+    hookEventName,
+    body: hookBody({ hook_event_name: hookEventName, transcript_path: 'C:/t/s.jsonl', ...extra })
+  })
 }
 
 describe('AgentThroughputTracker', () => {
-  it('emits one sample per new message and dedupes repeated reads of the same message', () => {
-    const readTranscript = vi.fn().mockReturnValue(message())
-    const tracker = new AgentThroughputTracker({ now: () => 42, readTranscript })
+  it('emits one sample per new message and dedupes repeated reads of the same message', async () => {
+    const read = vi.fn().mockReturnValue(message())
+    const tracker = createTracker(read)
     const listener = vi.fn()
     tracker.setListener(listener)
 
-    observe(tracker, 'PreToolUse')
-    observe(tracker, 'PostToolUse')
+    await observe(tracker, 'PreToolUse')
+    await observe(tracker, 'PostToolUse')
 
-    expect(readTranscript).toHaveBeenCalledTimes(2)
-    expect(readTranscript).toHaveBeenCalledWith('C:/transcripts/session.jsonl')
+    expect(read).toHaveBeenCalledTimes(2)
+    expect(read.mock.calls[0][0]).toMatchObject({ transcript_path: 'C:/t/s.jsonl' })
     expect(listener).toHaveBeenCalledTimes(1)
     expect(listener.mock.calls[0][0]).toEqual({
       paneKey: PANE,
+      agentType: 'claude',
       messageId: 'msg_1',
       model: 'claude-fable-5-1',
       outputTokens: 500,
@@ -55,17 +87,17 @@ describe('AgentThroughputTracker', () => {
     expect(tracker.getSnapshot()).toHaveLength(1)
   })
 
-  it('accumulates the turn across messages and resets it on the next prompt', () => {
-    const readTranscript = vi
+  it('accumulates the turn across messages and resets it on the next prompt', async () => {
+    const read = vi
       .fn()
       .mockReturnValueOnce(message())
       .mockReturnValueOnce(message({ messageId: 'msg_2', outputTokens: 200, generationMs: 5_000 }))
-    const tracker = new AgentThroughputTracker({ now: () => 7, readTranscript })
+    const tracker = createTracker(read, { now: () => 7 })
     const listener = vi.fn()
     tracker.setListener(listener)
 
-    observe(tracker, 'PreToolUse')
-    observe(tracker, 'Stop')
+    await observe(tracker, 'PreToolUse')
+    await observe(tracker, 'Stop')
     expect(listener.mock.calls[1][0]).toMatchObject({
       messageId: 'msg_2',
       tokensPerSecond: 40,
@@ -74,8 +106,8 @@ describe('AgentThroughputTracker', () => {
       turnMessageCount: 2
     })
 
-    observe(tracker, 'UserPromptSubmit')
-    expect(readTranscript).toHaveBeenCalledTimes(2)
+    await observe(tracker, 'UserPromptSubmit')
+    expect(read).toHaveBeenCalledTimes(2)
     expect(listener).toHaveBeenCalledTimes(3)
     // Why: the last reading stays visible across the turn boundary; only the totals restart.
     expect(listener.mock.calls[2][0]).toMatchObject({
@@ -87,63 +119,135 @@ describe('AgentThroughputTracker', () => {
     })
   })
 
-  it('skips the transcript read without a listener or for non-completion events', () => {
-    const readTranscript = vi.fn().mockReturnValue(message())
-    const tracker = new AgentThroughputTracker({ readTranscript })
+  it('skips reads without a listener, for ignored events, and for sources without a profile', async () => {
+    const read = vi.fn().mockReturnValue(message())
+    const tracker = createTracker(read)
 
-    observe(tracker, 'Stop')
+    await observe(tracker, 'Stop')
     tracker.setListener(vi.fn())
-    observe(tracker, 'SubagentStart')
-    observe(tracker, 'Notification')
-    tracker.observeClaudeHook({ paneKey: PANE, hookEventName: undefined, body: hookBody('Stop') })
-    tracker.observeClaudeHook({ paneKey: PANE, hookEventName: 'Stop', body: { paneKey: PANE } })
+    await observe(tracker, 'SubagentStart')
+    await observe(tracker, 'Notification')
+    await observe(tracker, 'Stop', 'grok')
+    await tracker.observeHook({
+      source: 'claude',
+      paneKey: PANE,
+      hookEventName: undefined,
+      body: {}
+    })
 
-    expect(readTranscript).not.toHaveBeenCalled()
+    expect(read).not.toHaveBeenCalled()
     expect(tracker.getSnapshot()).toEqual([])
   })
 
-  it('clears a pane on SessionStart and on explicit clear', () => {
-    const tracker = new AgentThroughputTracker({ readTranscript: () => message() })
+  it('falls back to the hook payload model and labels the agent type', async () => {
+    const tracker = createTracker(() => message({ messageId: 'codex:1:2:3', model: null }))
+    const listener = vi.fn()
+    tracker.setListener(listener)
+
+    await observe(tracker, 'Stop', 'codex', { model: 'gpt-5.5' })
+
+    expect(listener.mock.calls[0][0]).toMatchObject({ agentType: 'codex', model: 'gpt-5.5' })
+  })
+
+  it('throttles streaming reads and awaits async readers', async () => {
+    let clock = 1_000
+    const read = vi.fn().mockImplementation(() => Promise.resolve(message({ messageId: 'oc-1' })))
+    const tracker = createTracker(read, { now: () => clock })
+    const listener = vi.fn()
+    tracker.setListener(listener)
+    const part = (role: string) =>
+      observe(tracker, 'MessagePart', 'opencode', { role, sessionID: 's1' })
+
+    await part('assistant')
+    clock += 200
+    await part('assistant')
+    clock += 2_000
+    await part('assistant')
+    await observe(tracker, 'SessionIdle', 'opencode', { sessionID: 's1' })
+
+    // Why: the second part lands inside the streaming floor; SessionIdle always reads.
+    expect(read).toHaveBeenCalledTimes(3)
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0][0]).toMatchObject({ agentType: 'opencode', messageId: 'oc-1' })
+
+    await part('user')
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(listener.mock.calls[1][0]).toMatchObject({ turnMessageCount: 0 })
+  })
+
+  it('drops a read that resolves after the pane was cleared or superseded', async () => {
+    let resolveSlow: (value: AgentMessageThroughput | undefined) => void = () => {}
+    const read = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<AgentMessageThroughput | undefined>((resolve) => {
+            resolveSlow = resolve
+          })
+      )
+      .mockImplementationOnce(() => message({ messageId: 'fast' }))
+    const tracker = createTracker(read)
+    const listener = vi.fn()
+    tracker.setListener(listener)
+
+    const slow = observe(tracker, 'PreToolUse')
+    await observe(tracker, 'Stop')
+    resolveSlow(message({ messageId: 'slow' }))
+    await slow
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0][0]).toMatchObject({ messageId: 'fast' })
+
+    const cleared = observe(tracker, 'PreToolUse')
+    tracker.clear(PANE)
+    await cleared
+    expect(tracker.getSnapshot()).toEqual([])
+  })
+
+  it('clears a pane on SessionStart and on explicit clear, and survives failing readers', async () => {
+    const tracker = createTracker(() => message())
     const clearListener = vi.fn()
     tracker.setListener(vi.fn())
     tracker.setClearListener(clearListener)
 
-    observe(tracker, 'Stop')
-    observe(tracker, 'SessionStart')
+    await observe(tracker, 'Stop')
+    await observe(tracker, 'SessionStart')
     expect(clearListener).toHaveBeenCalledWith(PANE)
     expect(tracker.getSnapshot()).toEqual([])
 
     tracker.clear(PANE)
     expect(clearListener).toHaveBeenCalledTimes(1)
 
-    observe(tracker, 'Stop')
+    await observe(tracker, 'Stop')
     tracker.clearAll()
     expect(clearListener).toHaveBeenCalledTimes(2)
-  })
 
-  it('survives a throwing listener', () => {
-    const tracker = new AgentThroughputTracker({ readTranscript: () => message() })
-    tracker.setListener(() => {
-      throw new Error('boom')
-    })
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     try {
-      expect(() => observe(tracker, 'Stop')).not.toThrow()
-      expect(tracker.getSnapshot()).toHaveLength(1)
+      const throwing = createTracker(() => {
+        throw new Error('boom')
+      })
+      throwing.setListener(() => {
+        throw new Error('listener boom')
+      })
+      await expect(observe(throwing, 'Stop')).resolves.toBe(undefined)
+      const listenerThrows = createTracker(() => message())
+      listenerThrows.setListener(() => {
+        throw new Error('listener boom')
+      })
+      await observe(listenerThrows, 'Stop')
+      expect(listenerThrows.getSnapshot()).toHaveLength(1)
     } finally {
       consoleError.mockRestore()
     }
   })
 
-  it('reads transcript_path from string and object payloads', () => {
-    expect(readClaudeHookTranscriptPath(hookBody('Stop', '/tmp/t.jsonl'))).toBe('/tmp/t.jsonl')
-    expect(
-      readClaudeHookTranscriptPath({ paneKey: PANE, payload: { transcript_path: '/tmp/o.jsonl' } })
-    ).toBe('/tmp/o.jsonl')
-    expect(readClaudeHookTranscriptPath({ paneKey: PANE, payload: '{not json' })).toBe(null)
-    expect(readClaudeHookTranscriptPath({ paneKey: PANE, payload: { transcript_path: '' } })).toBe(
-      null
-    )
-    expect(readClaudeHookTranscriptPath('nope')).toBe(null)
+  it('classifies gemini hooks', () => {
+    const gemini = AGENT_THROUGHPUT_SOURCE_PROFILES.gemini!
+    expect(gemini.classify('BeforeAgent', {})).toBe('new-turn')
+    expect(gemini.classify('AfterTool', {})).toBe('measure')
+    expect(gemini.classify('AfterAgent', {})).toBe('measure')
+    expect(gemini.classify('SessionStart', {})).toBe('reset')
+    expect(gemini.classify('Notification', {})).toBe('ignore')
   })
 })

--- a/src/main/agent-hooks/agent-throughput-tracker.test.ts
+++ b/src/main/agent-hooks/agent-throughput-tracker.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ClaudeMessageThroughput } from '../../shared/agent-hook-listener/claude-transcript-throughput'
+import { AgentThroughputTracker, readClaudeHookTranscriptPath } from './agent-throughput-tracker'
+
+const PANE = 'tab-1:0f7c1b2e-3d4a-4c5b-8e6f-7a8b9c0d1e2f'
+
+function hookBody(hookEventName: string, transcriptPath = 'C:/transcripts/session.jsonl'): unknown {
+  return {
+    paneKey: PANE,
+    payload: JSON.stringify({ hook_event_name: hookEventName, transcript_path: transcriptPath })
+  }
+}
+
+function message(overrides: Partial<ClaudeMessageThroughput> = {}): ClaudeMessageThroughput {
+  return {
+    messageId: 'msg_1',
+    model: 'claude-fable-5-1',
+    outputTokens: 500,
+    generationMs: 10_000,
+    completedAt: 1_000,
+    ...overrides
+  }
+}
+
+function observe(tracker: AgentThroughputTracker, hookEventName: string): void {
+  tracker.observeClaudeHook({ paneKey: PANE, hookEventName, body: hookBody(hookEventName) })
+}
+
+describe('AgentThroughputTracker', () => {
+  it('emits one sample per new message and dedupes repeated reads of the same message', () => {
+    const readTranscript = vi.fn().mockReturnValue(message())
+    const tracker = new AgentThroughputTracker({ now: () => 42, readTranscript })
+    const listener = vi.fn()
+    tracker.setListener(listener)
+
+    observe(tracker, 'PreToolUse')
+    observe(tracker, 'PostToolUse')
+
+    expect(readTranscript).toHaveBeenCalledTimes(2)
+    expect(readTranscript).toHaveBeenCalledWith('C:/transcripts/session.jsonl')
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0][0]).toEqual({
+      paneKey: PANE,
+      messageId: 'msg_1',
+      model: 'claude-fable-5-1',
+      outputTokens: 500,
+      generationMs: 10_000,
+      tokensPerSecond: 50,
+      completedAt: 1_000,
+      turnOutputTokens: 500,
+      turnGenerationMs: 10_000,
+      turnMessageCount: 1,
+      observedAt: 42
+    })
+    expect(tracker.getSnapshot()).toHaveLength(1)
+  })
+
+  it('accumulates the turn across messages and resets it on the next prompt', () => {
+    const readTranscript = vi
+      .fn()
+      .mockReturnValueOnce(message())
+      .mockReturnValueOnce(message({ messageId: 'msg_2', outputTokens: 200, generationMs: 5_000 }))
+    const tracker = new AgentThroughputTracker({ now: () => 7, readTranscript })
+    const listener = vi.fn()
+    tracker.setListener(listener)
+
+    observe(tracker, 'PreToolUse')
+    observe(tracker, 'Stop')
+    expect(listener.mock.calls[1][0]).toMatchObject({
+      messageId: 'msg_2',
+      tokensPerSecond: 40,
+      turnOutputTokens: 700,
+      turnGenerationMs: 15_000,
+      turnMessageCount: 2
+    })
+
+    observe(tracker, 'UserPromptSubmit')
+    expect(readTranscript).toHaveBeenCalledTimes(2)
+    expect(listener).toHaveBeenCalledTimes(3)
+    // Why: the last reading stays visible across the turn boundary; only the totals restart.
+    expect(listener.mock.calls[2][0]).toMatchObject({
+      messageId: 'msg_2',
+      tokensPerSecond: 40,
+      turnOutputTokens: 0,
+      turnGenerationMs: 0,
+      turnMessageCount: 0
+    })
+  })
+
+  it('skips the transcript read without a listener or for non-completion events', () => {
+    const readTranscript = vi.fn().mockReturnValue(message())
+    const tracker = new AgentThroughputTracker({ readTranscript })
+
+    observe(tracker, 'Stop')
+    tracker.setListener(vi.fn())
+    observe(tracker, 'SubagentStart')
+    observe(tracker, 'Notification')
+    tracker.observeClaudeHook({ paneKey: PANE, hookEventName: undefined, body: hookBody('Stop') })
+    tracker.observeClaudeHook({ paneKey: PANE, hookEventName: 'Stop', body: { paneKey: PANE } })
+
+    expect(readTranscript).not.toHaveBeenCalled()
+    expect(tracker.getSnapshot()).toEqual([])
+  })
+
+  it('clears a pane on SessionStart and on explicit clear', () => {
+    const tracker = new AgentThroughputTracker({ readTranscript: () => message() })
+    const clearListener = vi.fn()
+    tracker.setListener(vi.fn())
+    tracker.setClearListener(clearListener)
+
+    observe(tracker, 'Stop')
+    observe(tracker, 'SessionStart')
+    expect(clearListener).toHaveBeenCalledWith(PANE)
+    expect(tracker.getSnapshot()).toEqual([])
+
+    tracker.clear(PANE)
+    expect(clearListener).toHaveBeenCalledTimes(1)
+
+    observe(tracker, 'Stop')
+    tracker.clearAll()
+    expect(clearListener).toHaveBeenCalledTimes(2)
+  })
+
+  it('survives a throwing listener', () => {
+    const tracker = new AgentThroughputTracker({ readTranscript: () => message() })
+    tracker.setListener(() => {
+      throw new Error('boom')
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      expect(() => observe(tracker, 'Stop')).not.toThrow()
+      expect(tracker.getSnapshot()).toHaveLength(1)
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('reads transcript_path from string and object payloads', () => {
+    expect(readClaudeHookTranscriptPath(hookBody('Stop', '/tmp/t.jsonl'))).toBe('/tmp/t.jsonl')
+    expect(
+      readClaudeHookTranscriptPath({ paneKey: PANE, payload: { transcript_path: '/tmp/o.jsonl' } })
+    ).toBe('/tmp/o.jsonl')
+    expect(readClaudeHookTranscriptPath({ paneKey: PANE, payload: '{not json' })).toBe(null)
+    expect(readClaudeHookTranscriptPath({ paneKey: PANE, payload: { transcript_path: '' } })).toBe(
+      null
+    )
+    expect(readClaudeHookTranscriptPath('nope')).toBe(null)
+  })
+})

--- a/src/main/agent-hooks/agent-throughput-tracker.test.ts
+++ b/src/main/agent-hooks/agent-throughput-tracker.test.ts
@@ -254,6 +254,39 @@ describe('AgentThroughputTracker', () => {
     expect(gemini.classify('Notification', {})).toBe('ignore')
   })
 
+  it('drops a read that resolves after the next prompt started a new turn', async () => {
+    let resolveSlow: (value: AgentMessageThroughput | undefined) => void = () => {}
+    const read = vi
+      .fn()
+      .mockImplementationOnce(() => message({ messageId: 'first' }))
+      .mockImplementationOnce(
+        () =>
+          new Promise<AgentMessageThroughput | undefined>((resolve) => {
+            resolveSlow = resolve
+          })
+      )
+      .mockImplementationOnce(() => message({ messageId: 'next-turn', outputTokens: 100 }))
+    const tracker = createTracker(read)
+    const listener = vi.fn()
+    tracker.setListener(listener)
+
+    await observe(tracker, 'Stop')
+    const slow = observe(tracker, 'PostToolUse')
+    await observe(tracker, 'UserPromptSubmit')
+    resolveSlow(message({ messageId: 'stale', outputTokens: 900 }))
+    await slow
+    await observe(tracker, 'Stop')
+
+    // Why: the stale read would otherwise count 900 tokens into the new turn's totals.
+    const last = listener.mock.calls.at(-1)![0]
+    expect(last).toMatchObject({
+      messageId: 'next-turn',
+      turnOutputTokens: 100,
+      turnMessageCount: 1
+    })
+    expect(listener.mock.calls.some(([sample]) => sample.messageId === 'stale')).toBe(false)
+  })
+
   it('advertises exactly the sources it can read', () => {
     // Why: the renderer's "not available for this agent" hint is driven by the shared list.
     expect(Object.keys(AGENT_THROUGHPUT_SOURCE_PROFILES).sort()).toEqual(

--- a/src/main/agent-hooks/agent-throughput-tracker.ts
+++ b/src/main/agent-hooks/agent-throughput-tracker.ts
@@ -177,6 +177,9 @@ export class AgentThroughputTracker {
     if (!pane) {
       return
     }
+    // Why: a read still in flight belongs to the previous turn; it must not land in this one.
+    pane.readSequence += 1
+    pane.lastReadAt = null
     pane.turnOutputTokens = 0
     pane.turnGenerationMs = 0
     pane.turnMessageCount = 0

--- a/src/main/agent-hooks/agent-throughput-tracker.ts
+++ b/src/main/agent-hooks/agent-throughput-tracker.ts
@@ -1,0 +1,201 @@
+import {
+  readLastClaudeMessageThroughput,
+  type ClaudeMessageThroughput
+} from '../../shared/agent-hook-listener/claude-transcript-throughput'
+import { parseAgentHookJson } from '../../shared/agent-hook-listener/request-body'
+import {
+  computeTokensPerSecond,
+  type AgentThroughputSample
+} from '../../shared/agent-throughput-types'
+
+// Why: each fires once an assistant message is complete; the post-tool events double as a retry for
+// a transcript row that was still unflushed when PreToolUse arrived.
+const CLAUDE_MESSAGE_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'PermissionRequest',
+  'Stop',
+  'StopFailure',
+  'SubagentStop',
+  'PostCompact'
+])
+
+type PaneThroughputState = {
+  lastMessageId: string | null
+  turnOutputTokens: number
+  turnGenerationMs: number
+  turnMessageCount: number
+  sample: AgentThroughputSample | null
+}
+
+export type AgentThroughputListener = (sample: AgentThroughputSample) => void
+export type AgentThroughputClearListener = (paneKey: string) => void
+
+type AgentThroughputTrackerDependencies = {
+  now?: () => number
+  readTranscript?: (transcriptPath: string) => ClaudeMessageThroughput | undefined
+}
+
+/** `transcript_path` from a Claude hook envelope; the payload arrives as JSON text or an object. */
+export function readClaudeHookTranscriptPath(body: unknown): string | null {
+  if (typeof body !== 'object' || body === null) {
+    return null
+  }
+  const rawPayload = (body as Record<string, unknown>).payload
+  let payload: unknown = rawPayload
+  if (typeof rawPayload === 'string') {
+    try {
+      payload = parseAgentHookJson(rawPayload)
+    } catch {
+      return null
+    }
+  }
+  if (typeof payload !== 'object' || payload === null) {
+    return null
+  }
+  const transcriptPath = (payload as Record<string, unknown>).transcript_path
+  return typeof transcriptPath === 'string' && transcriptPath.length > 0 ? transcriptPath : null
+}
+
+function createPaneState(): PaneThroughputState {
+  return {
+    lastMessageId: null,
+    turnOutputTokens: 0,
+    turnGenerationMs: 0,
+    turnMessageCount: 0,
+    sample: null
+  }
+}
+
+/**
+ * Per-pane generation throughput derived from Claude Code transcripts on the local hook path.
+ * Remote panes (relay/SSH ingest) produce no samples: their transcripts live on the execution host.
+ */
+export class AgentThroughputTracker {
+  private readonly panes = new Map<string, PaneThroughputState>()
+  private listener: AgentThroughputListener | null = null
+  private clearListener: AgentThroughputClearListener | null = null
+  private readonly now: () => number
+  private readonly readTranscript: (transcriptPath: string) => ClaudeMessageThroughput | undefined
+
+  constructor(dependencies: AgentThroughputTrackerDependencies = {}) {
+    this.now = dependencies.now ?? Date.now
+    this.readTranscript = dependencies.readTranscript ?? readLastClaudeMessageThroughput
+  }
+
+  setListener(listener: AgentThroughputListener | null): void {
+    this.listener = listener
+  }
+
+  setClearListener(listener: AgentThroughputClearListener | null): void {
+    this.clearListener = listener
+  }
+
+  getSnapshot(): AgentThroughputSample[] {
+    const samples: AgentThroughputSample[] = []
+    for (const pane of this.panes.values()) {
+      if (pane.sample) {
+        samples.push(pane.sample)
+      }
+    }
+    return samples
+  }
+
+  observeClaudeHook(args: {
+    paneKey: string
+    hookEventName: string | undefined
+    body: unknown
+  }): void {
+    const { paneKey, hookEventName } = args
+    if (!hookEventName) {
+      return
+    }
+    if (hookEventName === 'SessionStart') {
+      this.clear(paneKey)
+      return
+    }
+    if (hookEventName === 'UserPromptSubmit') {
+      this.startTurn(paneKey)
+      return
+    }
+    // Why: with nothing listening (headless serve, window closed) skip the transcript read entirely.
+    if (!this.listener || !CLAUDE_MESSAGE_COMPLETE_EVENTS.has(hookEventName)) {
+      return
+    }
+    const transcriptPath = readClaudeHookTranscriptPath(args.body)
+    if (!transcriptPath) {
+      return
+    }
+    const message = this.readTranscript(transcriptPath)
+    if (!message) {
+      return
+    }
+    const pane = this.panes.get(paneKey) ?? createPaneState()
+    if (pane.lastMessageId === message.messageId) {
+      return
+    }
+    pane.lastMessageId = message.messageId
+    pane.turnOutputTokens += message.outputTokens
+    pane.turnGenerationMs += message.generationMs
+    pane.turnMessageCount += 1
+    pane.sample = {
+      paneKey,
+      messageId: message.messageId,
+      model: message.model,
+      outputTokens: message.outputTokens,
+      generationMs: message.generationMs,
+      tokensPerSecond: computeTokensPerSecond(message.outputTokens, message.generationMs),
+      completedAt: message.completedAt,
+      turnOutputTokens: pane.turnOutputTokens,
+      turnGenerationMs: pane.turnGenerationMs,
+      turnMessageCount: pane.turnMessageCount,
+      observedAt: this.now()
+    }
+    this.panes.set(paneKey, pane)
+    this.emit(pane.sample)
+  }
+
+  clear(paneKey: string): void {
+    if (this.panes.delete(paneKey)) {
+      this.clearListener?.(paneKey)
+    }
+  }
+
+  clearAll(): void {
+    for (const paneKey of Array.from(this.panes.keys())) {
+      this.clear(paneKey)
+    }
+  }
+
+  private startTurn(paneKey: string): void {
+    const pane = this.panes.get(paneKey)
+    if (!pane) {
+      return
+    }
+    pane.turnOutputTokens = 0
+    pane.turnGenerationMs = 0
+    pane.turnMessageCount = 0
+    if (pane.sample) {
+      // Why: keep the last reading visible across the turn boundary, but drop the previous turn's totals now.
+      pane.sample = {
+        ...pane.sample,
+        turnOutputTokens: 0,
+        turnGenerationMs: 0,
+        turnMessageCount: 0,
+        observedAt: this.now()
+      }
+      this.emit(pane.sample)
+    }
+  }
+
+  private emit(sample: AgentThroughputSample): void {
+    try {
+      this.listener?.(sample)
+    } catch (err) {
+      console.error('[agent-hooks] throughput listener threw', err)
+    }
+  }
+}
+
+export const agentThroughputTracker = new AgentThroughputTracker()

--- a/src/main/agent-hooks/agent-throughput-tracker.ts
+++ b/src/main/agent-hooks/agent-throughput-tracker.ts
@@ -1,7 +1,4 @@
 import type { AgentHookSource } from '../../shared/agent-hook-relay'
-import { readLastClaudeMessageThroughput } from '../../shared/agent-hook-listener/claude-transcript-throughput'
-import { readLastCodexMessageThroughput } from '../../shared/agent-hook-listener/codex-transcript-throughput'
-import { readLastGeminiMessageThroughput } from '../../shared/agent-hook-listener/gemini-chat-throughput'
 import { parseHookBodyPayloadRecord } from '../../shared/agent-hook-listener/grok-result-discovery'
 import { readFirstString } from '../../shared/agent-hook-listener/interactive-tool'
 import {
@@ -9,114 +6,16 @@ import {
   type AgentMessageThroughput,
   type AgentThroughputSample
 } from '../../shared/agent-throughput-types'
-import { readLastOpenCodeMessageThroughput } from '../opencode/opencode-message-throughput'
+import {
+  AGENT_THROUGHPUT_SOURCE_PROFILES,
+  type AgentThroughputSourceProfile
+} from './agent-throughput-source-profiles'
 
-export type ThroughputHookAction = 'reset' | 'new-turn' | 'measure' | 'measure-streaming' | 'ignore'
-
-export type AgentThroughputSourceProfile = {
-  classify: (hookEventName: string, payload: Record<string, unknown>) => ThroughputHookAction
-  read: (
-    payload: Record<string, unknown>
-  ) => AgentMessageThroughput | undefined | Promise<AgentMessageThroughput | undefined>
-  /** Floor between `measure-streaming` reads; those events fire while a message is still streaming. */
-  streamingReadIntervalMs?: number
-}
-
-// Why: each fires once a message is complete; the post-tool events double as a retry for a
-// transcript row that was still unflushed when the pre-tool event arrived.
-const CLAUDE_STYLE_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
-  'PreToolUse',
-  'PostToolUse',
-  'PostToolUseFailure',
-  'PermissionRequest',
-  'Stop',
-  'StopFailure',
-  'SubagentStop',
-  'PostCompact'
-])
-const GEMINI_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
-  'BeforeTool',
-  'AfterTool',
-  'AfterAgent'
-])
-const OPENCODE_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
-  'SessionIdle',
-  'PermissionRequest',
-  'AskUserQuestion'
-])
-const OPENCODE_STREAMING_READ_INTERVAL_MS = 1_500
-
-function classifyClaudeStyleHook(hookEventName: string): ThroughputHookAction {
-  if (hookEventName === 'SessionStart') {
-    return 'reset'
-  }
-  if (hookEventName === 'UserPromptSubmit') {
-    return 'new-turn'
-  }
-  return CLAUDE_STYLE_COMPLETE_EVENTS.has(hookEventName) ? 'measure' : 'ignore'
-}
-
-function readTranscriptPath(payload: Record<string, unknown>): string | null {
-  return readFirstString(payload, ['transcript_path', 'transcriptPath']) ?? null
-}
-
-function readWithTranscript(
-  read: (transcriptPath: string) => AgentMessageThroughput | undefined
-): AgentThroughputSourceProfile['read'] {
-  return (payload) => {
-    const transcriptPath = readTranscriptPath(payload)
-    return transcriptPath ? read(transcriptPath) : undefined
-  }
-}
-
-const OPENCODE_PROFILE: AgentThroughputSourceProfile = {
-  classify: (hookEventName, payload) => {
-    if (hookEventName === 'SessionStart') {
-      return 'reset'
-    }
-    if (hookEventName === 'MessagePart') {
-      return payload.role === 'user'
-        ? 'new-turn'
-        : payload.role === 'assistant'
-          ? 'measure-streaming'
-          : 'ignore'
-    }
-    return OPENCODE_COMPLETE_EVENTS.has(hookEventName) ? 'measure' : 'ignore'
-  },
-  read: (payload) => {
-    const sessionId = readFirstString(payload, ['sessionID', 'sessionId', 'session_id'])
-    return sessionId ? readLastOpenCodeMessageThroughput(sessionId) : undefined
-  },
-  streamingReadIntervalMs: OPENCODE_STREAMING_READ_INTERVAL_MS
-}
-
-/** Sources with a per-message token record Orca can reach; the rest expose no token counts. */
-export const AGENT_THROUGHPUT_SOURCE_PROFILES: Partial<
-  Record<AgentHookSource, AgentThroughputSourceProfile>
-> = {
-  claude: {
-    classify: classifyClaudeStyleHook,
-    read: readWithTranscript(readLastClaudeMessageThroughput)
-  },
-  codex: {
-    classify: classifyClaudeStyleHook,
-    read: readWithTranscript(readLastCodexMessageThroughput)
-  },
-  gemini: {
-    classify: (hookEventName) => {
-      if (hookEventName === 'SessionStart') {
-        return 'reset'
-      }
-      if (hookEventName === 'BeforeAgent') {
-        return 'new-turn'
-      }
-      return GEMINI_COMPLETE_EVENTS.has(hookEventName) ? 'measure' : 'ignore'
-    },
-    read: readWithTranscript(readLastGeminiMessageThroughput)
-  },
-  opencode: OPENCODE_PROFILE,
-  'mimo-code': OPENCODE_PROFILE
-}
+export {
+  AGENT_THROUGHPUT_SOURCE_PROFILES,
+  type AgentThroughputSourceProfile,
+  type ThroughputHookAction
+} from './agent-throughput-source-profiles'
 
 type PaneThroughputState = {
   lastMessageId: string | null
@@ -195,6 +94,10 @@ export class AgentThroughputTracker {
       return
     }
     const payload = parseHookBodyPayloadRecord(args.body) ?? {}
+    const envelope =
+      typeof args.body === 'object' && args.body !== null
+        ? (args.body as Record<string, unknown>)
+        : {}
     const action = profile.classify(hookEventName, payload)
     if (action === 'reset') {
       this.clear(paneKey)
@@ -223,7 +126,7 @@ export class AgentThroughputTracker {
     const readSequence = ++pane.readSequence
     let message: AgentMessageThroughput | undefined
     try {
-      message = await profile.read(payload)
+      message = await profile.read(payload, envelope)
     } catch (err) {
       console.error('[agent-hooks] throughput read failed', err)
       return
@@ -251,7 +154,8 @@ export class AgentThroughputTracker {
       turnOutputTokens: pane.turnOutputTokens,
       turnGenerationMs: pane.turnGenerationMs,
       turnMessageCount: pane.turnMessageCount,
-      observedAt: this.now()
+      observedAt: this.now(),
+      ...(message.estimated ? { estimated: true } : {})
     }
     this.emit(pane.sample)
   }

--- a/src/main/agent-hooks/agent-throughput-tracker.ts
+++ b/src/main/agent-hooks/agent-throughput-tracker.ts
@@ -1,16 +1,30 @@
-import {
-  readLastClaudeMessageThroughput,
-  type ClaudeMessageThroughput
-} from '../../shared/agent-hook-listener/claude-transcript-throughput'
-import { parseAgentHookJson } from '../../shared/agent-hook-listener/request-body'
+import type { AgentHookSource } from '../../shared/agent-hook-relay'
+import { readLastClaudeMessageThroughput } from '../../shared/agent-hook-listener/claude-transcript-throughput'
+import { readLastCodexMessageThroughput } from '../../shared/agent-hook-listener/codex-transcript-throughput'
+import { readLastGeminiMessageThroughput } from '../../shared/agent-hook-listener/gemini-chat-throughput'
+import { parseHookBodyPayloadRecord } from '../../shared/agent-hook-listener/grok-result-discovery'
+import { readFirstString } from '../../shared/agent-hook-listener/interactive-tool'
 import {
   computeTokensPerSecond,
+  type AgentMessageThroughput,
   type AgentThroughputSample
 } from '../../shared/agent-throughput-types'
+import { readLastOpenCodeMessageThroughput } from '../opencode/opencode-message-throughput'
 
-// Why: each fires once an assistant message is complete; the post-tool events double as a retry for
-// a transcript row that was still unflushed when PreToolUse arrived.
-const CLAUDE_MESSAGE_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
+export type ThroughputHookAction = 'reset' | 'new-turn' | 'measure' | 'measure-streaming' | 'ignore'
+
+export type AgentThroughputSourceProfile = {
+  classify: (hookEventName: string, payload: Record<string, unknown>) => ThroughputHookAction
+  read: (
+    payload: Record<string, unknown>
+  ) => AgentMessageThroughput | undefined | Promise<AgentMessageThroughput | undefined>
+  /** Floor between `measure-streaming` reads; those events fire while a message is still streaming. */
+  streamingReadIntervalMs?: number
+}
+
+// Why: each fires once a message is complete; the post-tool events double as a retry for a
+// transcript row that was still unflushed when the pre-tool event arrived.
+const CLAUDE_STYLE_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
   'PreToolUse',
   'PostToolUse',
   'PostToolUseFailure',
@@ -20,6 +34,89 @@ const CLAUDE_MESSAGE_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
   'SubagentStop',
   'PostCompact'
 ])
+const GEMINI_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
+  'BeforeTool',
+  'AfterTool',
+  'AfterAgent'
+])
+const OPENCODE_COMPLETE_EVENTS: ReadonlySet<string> = new Set([
+  'SessionIdle',
+  'PermissionRequest',
+  'AskUserQuestion'
+])
+const OPENCODE_STREAMING_READ_INTERVAL_MS = 1_500
+
+function classifyClaudeStyleHook(hookEventName: string): ThroughputHookAction {
+  if (hookEventName === 'SessionStart') {
+    return 'reset'
+  }
+  if (hookEventName === 'UserPromptSubmit') {
+    return 'new-turn'
+  }
+  return CLAUDE_STYLE_COMPLETE_EVENTS.has(hookEventName) ? 'measure' : 'ignore'
+}
+
+function readTranscriptPath(payload: Record<string, unknown>): string | null {
+  return readFirstString(payload, ['transcript_path', 'transcriptPath']) ?? null
+}
+
+function readWithTranscript(
+  read: (transcriptPath: string) => AgentMessageThroughput | undefined
+): AgentThroughputSourceProfile['read'] {
+  return (payload) => {
+    const transcriptPath = readTranscriptPath(payload)
+    return transcriptPath ? read(transcriptPath) : undefined
+  }
+}
+
+const OPENCODE_PROFILE: AgentThroughputSourceProfile = {
+  classify: (hookEventName, payload) => {
+    if (hookEventName === 'SessionStart') {
+      return 'reset'
+    }
+    if (hookEventName === 'MessagePart') {
+      return payload.role === 'user'
+        ? 'new-turn'
+        : payload.role === 'assistant'
+          ? 'measure-streaming'
+          : 'ignore'
+    }
+    return OPENCODE_COMPLETE_EVENTS.has(hookEventName) ? 'measure' : 'ignore'
+  },
+  read: (payload) => {
+    const sessionId = readFirstString(payload, ['sessionID', 'sessionId', 'session_id'])
+    return sessionId ? readLastOpenCodeMessageThroughput(sessionId) : undefined
+  },
+  streamingReadIntervalMs: OPENCODE_STREAMING_READ_INTERVAL_MS
+}
+
+/** Sources with a per-message token record Orca can reach; the rest expose no token counts. */
+export const AGENT_THROUGHPUT_SOURCE_PROFILES: Partial<
+  Record<AgentHookSource, AgentThroughputSourceProfile>
+> = {
+  claude: {
+    classify: classifyClaudeStyleHook,
+    read: readWithTranscript(readLastClaudeMessageThroughput)
+  },
+  codex: {
+    classify: classifyClaudeStyleHook,
+    read: readWithTranscript(readLastCodexMessageThroughput)
+  },
+  gemini: {
+    classify: (hookEventName) => {
+      if (hookEventName === 'SessionStart') {
+        return 'reset'
+      }
+      if (hookEventName === 'BeforeAgent') {
+        return 'new-turn'
+      }
+      return GEMINI_COMPLETE_EVENTS.has(hookEventName) ? 'measure' : 'ignore'
+    },
+    read: readWithTranscript(readLastGeminiMessageThroughput)
+  },
+  opencode: OPENCODE_PROFILE,
+  'mimo-code': OPENCODE_PROFILE
+}
 
 type PaneThroughputState = {
   lastMessageId: string | null
@@ -27,6 +124,9 @@ type PaneThroughputState = {
   turnGenerationMs: number
   turnMessageCount: number
   sample: AgentThroughputSample | null
+  /** Clock of the last record read; null until the first one so a young clock is not throttled. */
+  lastReadAt: number | null
+  readSequence: number
 }
 
 export type AgentThroughputListener = (sample: AgentThroughputSample) => void
@@ -34,28 +134,7 @@ export type AgentThroughputClearListener = (paneKey: string) => void
 
 type AgentThroughputTrackerDependencies = {
   now?: () => number
-  readTranscript?: (transcriptPath: string) => ClaudeMessageThroughput | undefined
-}
-
-/** `transcript_path` from a Claude hook envelope; the payload arrives as JSON text or an object. */
-export function readClaudeHookTranscriptPath(body: unknown): string | null {
-  if (typeof body !== 'object' || body === null) {
-    return null
-  }
-  const rawPayload = (body as Record<string, unknown>).payload
-  let payload: unknown = rawPayload
-  if (typeof rawPayload === 'string') {
-    try {
-      payload = parseAgentHookJson(rawPayload)
-    } catch {
-      return null
-    }
-  }
-  if (typeof payload !== 'object' || payload === null) {
-    return null
-  }
-  const transcriptPath = (payload as Record<string, unknown>).transcript_path
-  return typeof transcriptPath === 'string' && transcriptPath.length > 0 ? transcriptPath : null
+  profiles?: Partial<Record<AgentHookSource, AgentThroughputSourceProfile>>
 }
 
 function createPaneState(): PaneThroughputState {
@@ -64,24 +143,26 @@ function createPaneState(): PaneThroughputState {
     turnOutputTokens: 0,
     turnGenerationMs: 0,
     turnMessageCount: 0,
-    sample: null
+    sample: null,
+    lastReadAt: null,
+    readSequence: 0
   }
 }
 
 /**
- * Per-pane generation throughput derived from Claude Code transcripts on the local hook path.
- * Remote panes (relay/SSH ingest) produce no samples: their transcripts live on the execution host.
+ * Per-pane generation throughput derived from each agent's own session record on the local hook
+ * path. Remote panes (relay/SSH ingest) produce no samples: their records live on the execution host.
  */
 export class AgentThroughputTracker {
   private readonly panes = new Map<string, PaneThroughputState>()
   private listener: AgentThroughputListener | null = null
   private clearListener: AgentThroughputClearListener | null = null
   private readonly now: () => number
-  private readonly readTranscript: (transcriptPath: string) => ClaudeMessageThroughput | undefined
+  private readonly profiles: Partial<Record<AgentHookSource, AgentThroughputSourceProfile>>
 
   constructor(dependencies: AgentThroughputTrackerDependencies = {}) {
     this.now = dependencies.now ?? Date.now
-    this.readTranscript = dependencies.readTranscript ?? readLastClaudeMessageThroughput
+    this.profiles = dependencies.profiles ?? AGENT_THROUGHPUT_SOURCE_PROFILES
   }
 
   setListener(listener: AgentThroughputListener | null): void {
@@ -102,36 +183,55 @@ export class AgentThroughputTracker {
     return samples
   }
 
-  observeClaudeHook(args: {
+  async observeHook(args: {
+    source: AgentHookSource
     paneKey: string
     hookEventName: string | undefined
     body: unknown
-  }): void {
-    const { paneKey, hookEventName } = args
-    if (!hookEventName) {
+  }): Promise<void> {
+    const { source, paneKey, hookEventName } = args
+    const profile = this.profiles[source]
+    if (!profile || !hookEventName) {
       return
     }
-    if (hookEventName === 'SessionStart') {
+    const payload = parseHookBodyPayloadRecord(args.body) ?? {}
+    const action = profile.classify(hookEventName, payload)
+    if (action === 'reset') {
       this.clear(paneKey)
       return
     }
-    if (hookEventName === 'UserPromptSubmit') {
+    if (action === 'new-turn') {
       this.startTurn(paneKey)
       return
     }
-    // Why: with nothing listening (headless serve, window closed) skip the transcript read entirely.
-    if (!this.listener || !CLAUDE_MESSAGE_COMPLETE_EVENTS.has(hookEventName)) {
-      return
-    }
-    const transcriptPath = readClaudeHookTranscriptPath(args.body)
-    if (!transcriptPath) {
-      return
-    }
-    const message = this.readTranscript(transcriptPath)
-    if (!message) {
+    // Why: with nothing listening (headless serve, window closed) skip the record read entirely.
+    if (action === 'ignore' || !this.listener) {
       return
     }
     const pane = this.panes.get(paneKey) ?? createPaneState()
+    this.panes.set(paneKey, pane)
+    const now = this.now()
+    if (
+      action === 'measure-streaming' &&
+      profile.streamingReadIntervalMs !== undefined &&
+      pane.lastReadAt !== null &&
+      now - pane.lastReadAt < profile.streamingReadIntervalMs
+    ) {
+      return
+    }
+    pane.lastReadAt = now
+    const readSequence = ++pane.readSequence
+    let message: AgentMessageThroughput | undefined
+    try {
+      message = await profile.read(payload)
+    } catch (err) {
+      console.error('[agent-hooks] throughput read failed', err)
+      return
+    }
+    // Why: a slower read must not overwrite a newer one, and a cleared pane must stay cleared.
+    if (!message || this.panes.get(paneKey) !== pane || pane.readSequence !== readSequence) {
+      return
+    }
     if (pane.lastMessageId === message.messageId) {
       return
     }
@@ -141,8 +241,9 @@ export class AgentThroughputTracker {
     pane.turnMessageCount += 1
     pane.sample = {
       paneKey,
+      agentType: source,
       messageId: message.messageId,
-      model: message.model,
+      model: message.model ?? readFirstString(payload, ['model']) ?? null,
       outputTokens: message.outputTokens,
       generationMs: message.generationMs,
       tokensPerSecond: computeTokensPerSecond(message.outputTokens, message.generationMs),
@@ -152,7 +253,6 @@ export class AgentThroughputTracker {
       turnMessageCount: pane.turnMessageCount,
       observedAt: this.now()
     }
-    this.panes.set(paneKey, pane)
     this.emit(pane.sample)
   }
 

--- a/src/main/agent-hooks/server/server-lifecycle.ts
+++ b/src/main/agent-hooks/server/server-lifecycle.ts
@@ -116,14 +116,13 @@ export abstract class AgentHookServerLifecycle extends AgentHookServerRuntimeEnv
           const enriched = this.applyNormalizedStatus(event, normalized.onAccepted)
           this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
           this.scheduleCodexSubagentPoll(source, aliasedBody, enriched)
-          if (source === 'claude') {
-            // Why: local loopback only — the transcript this reads lives on the execution host.
-            agentThroughputTracker.observeClaudeHook({
-              paneKey: event.paneKey,
-              hookEventName: event.hookEventName,
-              body: aliasedBody
-            })
-          }
+          // Why: local loopback only — the session record this reads lives on the execution host.
+          void agentThroughputTracker.observeHook({
+            source,
+            paneKey: event.paneKey,
+            hookEventName: event.hookEventName,
+            body: aliasedBody
+          })
         }
         res.writeHead(204)
         res.end()

--- a/src/main/agent-hooks/server/server-lifecycle.ts
+++ b/src/main/agent-hooks/server/server-lifecycle.ts
@@ -12,6 +12,7 @@ import { HOOK_REQUEST_SLOWLORIS_MS } from '../../../shared/agent-hook-listener/l
 import { isHookRequestTruncatedError } from '../../../shared/agent-hook-transport-interference'
 import { drainAgentHookSpool, type SpoolRecord } from '../../../shared/agent-hook-spool'
 import { clearAllListenerCaches } from '../../../shared/agent-hook-listener/listener-state'
+import { agentThroughputTracker } from '../agent-throughput-tracker'
 import { trackEmptyPaneKeyHook } from './server-transport-rules'
 import { AgentHookServerRuntimeEnv } from './server-runtime-env'
 
@@ -115,6 +116,14 @@ export abstract class AgentHookServerLifecycle extends AgentHookServerRuntimeEnv
           const enriched = this.applyNormalizedStatus(event, normalized.onAccepted)
           this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
           this.scheduleCodexSubagentPoll(source, aliasedBody, enriched)
+          if (source === 'claude') {
+            // Why: local loopback only — the transcript this reads lives on the execution host.
+            agentThroughputTracker.observeClaudeHook({
+              paneKey: event.paneKey,
+              hookEventName: event.hookEventName,
+              body: aliasedBody
+            })
+          }
         }
         res.writeHead(204)
         res.end()

--- a/src/main/ipc/agent-hooks.ts
+++ b/src/main/ipc/agent-hooks.ts
@@ -6,6 +6,7 @@ import type {
 import type { AgentInterruptInferenceRequest } from '../../shared/agent-interrupt-intent'
 import type { AgentQuestionAnsweredInferenceRequest } from '../../shared/agent-question-answered-intent'
 import { agentHookServer } from '../agent-hooks/server'
+import { agentThroughputTracker } from '../agent-hooks/agent-throughput-tracker'
 import { getMigrationUnsupportedPtySnapshot } from '../agent-hooks/migration-unsupported-pty-state'
 import { registerAgentPaneAuthorityIpcHandlers } from './agent-pane-authority-ipc'
 import { registerAgentStatusRowTeardownIpcHandlers } from './agent-status-row-teardown-ipc'
@@ -37,6 +38,7 @@ export function registerAgentHookHandlers(
   ipcMain.removeHandler('agentStatus:inferInterrupt')
   ipcMain.removeHandler('agentStatus:inferQuestionAnswered')
   ipcMain.removeHandler('agentStatus:getMigrationUnsupportedSnapshot')
+  ipcMain.removeHandler('agentThroughput:getSnapshot')
   registerAgentStatusRowTeardownIpcHandlers()
   registerAgentPaneAuthorityIpcHandlers({
     ownsPty: createAgentPaneAuthorityOwnership({
@@ -53,6 +55,7 @@ export function registerAgentHookHandlers(
       .getStatusSnapshot()
       .map((entry) => enrichAgentStatusIpcPayload(entry, runtime))
   })
+  ipcMain.handle('agentThroughput:getSnapshot', () => agentThroughputTracker.getSnapshot())
   ipcMain.handle('agentStatus:inferInterrupt', (_event, request: unknown): boolean => {
     if (typeof request !== 'object' || request === null) {
       return false

--- a/src/main/opencode/opencode-message-throughput.test.ts
+++ b/src/main/opencode/opencode-message-throughput.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import SyncDatabase from '../sqlite/sync-database'
+import {
+  measureOpenCodeMessageRow,
+  readLastOpenCodeMessageThroughput
+} from './opencode-message-throughput'
+
+const CREATED = 1_777_777_700_000
+
+const tmpDirs: string[] = []
+
+function createDatabasePath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-opencode-throughput-'))
+  tmpDirs.push(dir)
+  return join(dir, 'opencode.db')
+}
+
+function assistantData(args: {
+  output: number
+  reasoning?: number
+  createdMs: number
+  completedMs?: number
+  role?: string
+}): string {
+  return JSON.stringify({
+    role: args.role ?? 'assistant',
+    providerID: 'openai',
+    modelID: 'gpt-5.5',
+    tokens: { input: 800, output: args.output, reasoning: args.reasoning ?? 0, cache: { read: 0 } },
+    time: {
+      created: args.createdMs,
+      ...(args.completedMs === undefined ? {} : { completed: args.completedMs })
+    }
+  })
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('opencode message throughput', () => {
+  it('measures a row from its own created → completed span, counting reasoning as output', () => {
+    expect(
+      measureOpenCodeMessageRow({
+        id: 'msg-1',
+        data: assistantData({
+          output: 200,
+          reasoning: 50,
+          createdMs: CREATED,
+          completedMs: CREATED + 5_000
+        }),
+        time_created: CREATED
+      })
+    ).toEqual({
+      messageId: 'msg-1',
+      model: 'openai/gpt-5.5',
+      outputTokens: 250,
+      generationMs: 5_000,
+      completedAt: CREATED + 5_000
+    })
+    // Why: OpenCode stores seconds in some generations; both must land on the same clock.
+    expect(
+      measureOpenCodeMessageRow({
+        id: 'msg-2',
+        data: assistantData({ output: 10, createdMs: 1_777_777_700, completedMs: 1_777_777_702 }),
+        time_created: null
+      })
+    ).toMatchObject({ generationMs: 2_000 })
+    expect(
+      measureOpenCodeMessageRow({
+        id: 'msg-3',
+        data: assistantData({ output: 10, createdMs: CREATED }),
+        time_created: CREATED
+      })
+    ).toBe(undefined)
+    expect(measureOpenCodeMessageRow({ id: 'msg-4', data: '{bad', time_created: null })).toBe(
+      undefined
+    )
+  })
+
+  it('reads the newest completed assistant message of a session from a message table', async () => {
+    const path = createDatabasePath()
+    const db = new SyncDatabase(path)
+    db.exec(`
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+    `)
+    const insert = db.prepare(
+      'INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)'
+    )
+    insert.run(
+      'm-user',
+      's1',
+      CREATED,
+      CREATED,
+      JSON.stringify({ role: 'user', time: { created: CREATED } })
+    )
+    insert.run(
+      'm-1',
+      's1',
+      CREATED + 1_000,
+      CREATED + 4_000,
+      assistantData({ output: 300, createdMs: CREATED + 1_000, completedMs: CREATED + 4_000 })
+    )
+    insert.run(
+      'm-2',
+      's1',
+      CREATED + 10_000,
+      CREATED + 10_000,
+      assistantData({ output: 40, createdMs: CREATED + 10_000 })
+    )
+    insert.run(
+      'm-other',
+      's2',
+      CREATED + 20_000,
+      CREATED + 21_000,
+      assistantData({ output: 999, createdMs: CREATED + 20_000, completedMs: CREATED + 21_000 })
+    )
+    db.close()
+
+    // Why: m-2 is still streaming (no completed stamp), so the last finished message wins.
+    await expect(
+      readLastOpenCodeMessageThroughput('s1', { databasePaths: [path] })
+    ).resolves.toMatchObject({ messageId: 'm-1', outputTokens: 300, generationMs: 3_000 })
+    await expect(
+      readLastOpenCodeMessageThroughput('missing', { databasePaths: [path] })
+    ).resolves.toBe(undefined)
+  })
+
+  it('reads typed session_message rows and tolerates unreadable databases', async () => {
+    const path = createDatabasePath()
+    const db = new SyncDatabase(path)
+    db.exec(`
+      CREATE TABLE session_message (id TEXT PRIMARY KEY, session_id TEXT, type TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+    `)
+    db.prepare(
+      'INSERT INTO session_message (id, session_id, type, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(
+      'sm-1',
+      's1',
+      'assistant',
+      CREATED,
+      CREATED + 2_500,
+      assistantData({ output: 100, createdMs: CREATED, completedMs: CREATED + 2_500 })
+    )
+    db.close()
+
+    await expect(
+      readLastOpenCodeMessageThroughput('s1', {
+        databasePaths: [join(tmpdir(), 'missing.db'), path]
+      })
+    ).resolves.toMatchObject({ messageId: 'sm-1', generationMs: 2_500 })
+  })
+})

--- a/src/main/opencode/opencode-message-throughput.ts
+++ b/src/main/opencode/opencode-message-throughput.ts
@@ -1,0 +1,133 @@
+import SyncDatabase from '../sqlite/sync-database'
+import { listOpenCodeDatabases } from '../opencode-usage/opencode-database-discovery'
+import { columnExists, tableExists } from '../opencode-usage/schema-helpers'
+import type { AgentMessageThroughput } from '../../shared/agent-throughput-types'
+
+export type OpenCodeMessageThroughputRow = {
+  id: string
+  data: string | null
+  time_created: number | null
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  if (typeof value !== 'string') {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+function readCount(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0
+}
+
+function normalizeMillis(value: unknown): number | null {
+  const numeric = readCount(value)
+  if (numeric <= 0) {
+    return null
+  }
+  return numeric < 10_000_000_000 ? numeric * 1000 : numeric
+}
+
+function readModelLabel(data: Record<string, unknown>): string | null {
+  const modelId =
+    typeof data.modelID === 'string'
+      ? data.modelID
+      : typeof data.modelId === 'string'
+        ? data.modelId
+        : null
+  const providerId =
+    typeof data.providerID === 'string'
+      ? data.providerID
+      : typeof data.providerId === 'string'
+        ? data.providerId
+        : null
+  if (!modelId) {
+    return null
+  }
+  return providerId ? `${providerId}/${modelId}` : modelId
+}
+
+/** One assistant message row measured from its own `time.created` → `time.completed` span. */
+export function measureOpenCodeMessageRow(
+  row: OpenCodeMessageThroughputRow
+): AgentMessageThroughput | undefined {
+  const data = parseJsonObject(row.data)
+  if (!data) {
+    return undefined
+  }
+  const tokens = parseJsonObject(data.tokens)
+  const time = parseJsonObject(data.time)
+  const outputTokens = readCount(tokens?.output) + readCount(tokens?.reasoning)
+  const startedAt = normalizeMillis(time?.created) ?? normalizeMillis(row.time_created)
+  // Why: `completed` is stamped when the provider stream ends, so the span is the model call itself.
+  const completedAt = normalizeMillis(time?.completed)
+  if (outputTokens <= 0 || startedAt === null || completedAt === null) {
+    return undefined
+  }
+  const generationMs = completedAt - startedAt
+  if (!(generationMs > 0)) {
+    return undefined
+  }
+  return { messageId: row.id, model: readModelLabel(data), outputTokens, generationMs, completedAt }
+}
+
+function selectNewestAssistantRows(
+  db: SyncDatabase.Database,
+  sessionId: string
+): OpenCodeMessageThroughputRow[] {
+  const table = tableExists(db, 'session_message')
+    ? 'session_message'
+    : tableExists(db, 'message')
+      ? 'message'
+      : null
+  if (!table) {
+    return []
+  }
+  const assistantPredicate = columnExists(db, table, 'type')
+    ? "type = 'assistant'"
+    : "json_extract(data, '$.role') = 'assistant'"
+  // Why: the newest row can still be streaming (no `completed` yet); a short window finds the last finished one.
+  return db
+    .prepare(
+      `SELECT id, data, time_created FROM ${table}
+       WHERE session_id = ? AND ${assistantPredicate}
+       ORDER BY time_created DESC, id DESC
+       LIMIT 3`
+    )
+    .all(sessionId) as OpenCodeMessageThroughputRow[]
+}
+
+/** Throughput of the newest completed assistant message of an OpenCode session, read from its DB. */
+export async function readLastOpenCodeMessageThroughput(
+  sessionId: string,
+  options: { databasePaths?: readonly string[] } = {}
+): Promise<AgentMessageThroughput | undefined> {
+  const databasePaths = options.databasePaths ?? (await listOpenCodeDatabases())
+  for (const databasePath of databasePaths) {
+    let db: SyncDatabase.Database | null = null
+    try {
+      db = new SyncDatabase(databasePath, { readonly: true, fileMustExist: true })
+      for (const row of selectNewestAssistantRows(db, sessionId)) {
+        const measured = measureOpenCodeMessageRow(row)
+        if (measured) {
+          return measured
+        }
+      }
+    } catch {
+      // Why: a DB mid-write or an older schema is not worth surfacing on every hook.
+    } finally {
+      db?.close()
+    }
+  }
+  return undefined
+}

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -62,7 +62,8 @@ const StatusBarItem = z.enum([
   'grok',
   'ssh',
   'resource-usage',
-  'ports'
+  'ports',
+  'throughput'
 ])
 const WorkspaceStatusDefinition = z.object({
   id: z.string(),

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -167,6 +167,7 @@ const UiUpdateFields = z
     _minimaxStatusBarDefaultAdded: z.boolean().optional(),
     _antigravityStatusBarDefaultAdded: z.boolean().optional(),
     _grokStatusBarDefaultAdded: z.boolean().optional(),
+    _throughputStatusBarDefaultAdded: z.boolean().optional(),
     statusBarVisible: z.boolean().optional(),
     usagePercentageDisplay: z.enum(['used', 'remaining']).optional(),
     statusBarUsageMode: z.enum(['verbose', 'compact']).optional(),

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -485,11 +485,12 @@ describe('client UI RPC methods', () => {
       ...getDefaultUIState(),
       worktreeCardProperties: ['status', 'branch', 'automation', 'inline-agents'],
       _worktreeCardModeDefaulted: true,
-      statusBarItems: ['codex', 'kimi', 'minimax', 'grok', 'antigravity', 'ports'],
+      statusBarItems: ['codex', 'kimi', 'minimax', 'grok', 'antigravity', 'ports', 'throughput'],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _grokStatusBarDefaultAdded: true,
+      _throughputStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
       taskResumeState: {
         githubMode: 'items',
@@ -536,11 +537,12 @@ describe('client UI RPC methods', () => {
     const payload = {
       worktreeCardProperties: ['status', 'branch', 'automation', 'inline-agents'],
       _worktreeCardModeDefaulted: true,
-      statusBarItems: ['codex', 'kimi', 'minimax', 'grok', 'antigravity', 'ports'],
+      statusBarItems: ['codex', 'kimi', 'minimax', 'grok', 'antigravity', 'ports', 'throughput'],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _grokStatusBarDefaultAdded: true,
+      _throughputStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
       taskResumeState: {
         githubMode: 'items',

--- a/src/main/startup/main-window-agent-status.ts
+++ b/src/main/startup/main-window-agent-status.ts
@@ -1,5 +1,6 @@
 import type { BrowserWindow } from 'electron'
 import { agentHookServer } from '../agent-hooks/server'
+import { agentThroughputTracker } from '../agent-hooks/agent-throughput-tracker'
 import { setMigrationUnsupportedPtyListener } from '../agent-hooks/migration-unsupported-pty-state'
 import { getDashboardPopoutWindow } from '../window/dashboard-popout-window'
 import { isAskUserQuestionTool } from '../../shared/agent-question-answered-intent'
@@ -115,11 +116,27 @@ export function installMainWindowAgentStatusListeners(options: MainWindowAgentSt
     }
   )
   agentHookServer.setPaneStatusClearListener((clear) => {
+    // Why: a torn-down pane's throughput sample must not outlive its status row.
+    if ('paneKey' in clear) {
+      agentThroughputTracker.clear(clear.paneKey)
+    }
     if (state.mainWindow?.isDestroyed()) {
       return
     }
     state.mainWindow?.webContents.send('agentStatus:clear', clear)
     getDashboardPopoutWindow()?.webContents.send('agentStatus:clear', clear)
+  })
+  agentThroughputTracker.setListener((sample) => {
+    if (state.mainWindow?.isDestroyed()) {
+      return
+    }
+    state.mainWindow?.webContents.send('agentThroughput:set', sample)
+  })
+  agentThroughputTracker.setClearListener((paneKey) => {
+    if (state.mainWindow?.isDestroyed()) {
+      return
+    }
+    state.mainWindow?.webContents.send('agentThroughput:clear', { paneKey })
   })
   setMigrationUnsupportedPtyListener((event) => {
     if (state.mainWindow?.isDestroyed()) {
@@ -139,6 +156,8 @@ export function clearMainWindowAgentStatusListeners(): void {
   // Why: detach the hook listener on close so the server never fires into destroyed webContents before reopen, and replay runs only on deliberate recreations.
   agentHookServer.setListener(null)
   agentHookServer.setPaneStatusClearListener(null)
+  agentThroughputTracker.setListener(null)
+  agentThroughputTracker.setClearListener(null)
   setMigrationUnsupportedPtyListener(null)
   // Why: stop the spinner timer here — it would fire into destroyed webContents, and per-pane teardown may never run for restored-but-untorn panes.
   stopAllSyntheticTitleSpinners()

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -9,6 +9,7 @@ import type {
 import type { HooksApi } from './api/agent-hook-api'
 import type { SkillsApi } from './api/agent-skill-api'
 import type { AgentAwakeApi, AgentStatusApi, AgentTrustApi } from './api/agent-status-api'
+import type { AgentThroughputApi } from './api/agent-throughput-api'
 import type {
   ClaudeUsageApi,
   CodexUsageApi,
@@ -148,10 +149,12 @@ export type PreloadApi = {
   gitBash: RuntimeApi['gitBash']
   plugins: PluginsApi
   agentStatus: AgentStatusApi
+  agentThroughput: AgentThroughputApi
   mobile: MobileApi
   speech: SpeechApi
 }
 
+export type { AgentThroughputApi } from './api/agent-throughput-api'
 export type { ClaudeUsageApi, CodexUsageApi, OpenCodeUsageApi } from './api/agent-usage-api'
 export type { AiVaultApi } from './api/ai-vault-api'
 export type { AutomationsApi, ExternalAutomationManagerResult } from './api/automation-api'

--- a/src/preload/api/agent-throughput-api.ts
+++ b/src/preload/api/agent-throughput-api.ts
@@ -1,0 +1,12 @@
+import type {
+  AgentThroughputClearIpcPayload,
+  AgentThroughputSample
+} from '../../shared/agent-throughput-types'
+
+export type AgentThroughputApi = {
+  /** Listen for per-pane generation throughput samples from the local hook server. */
+  onSet: (callback: (sample: AgentThroughputSample) => void) => () => void
+  onClear: (callback: (data: AgentThroughputClearIpcPayload) => void) => () => void
+  /** Pull cached samples after renderer hydration so startup pushes aren't lost. */
+  getSnapshot: () => Promise<AgentThroughputSample[]>
+}

--- a/src/preload/api/agent-throughput-bridge.ts
+++ b/src/preload/api/agent-throughput-bridge.ts
@@ -1,0 +1,22 @@
+import { ipcRenderer } from 'electron'
+import type {
+  AgentThroughputClearIpcPayload,
+  AgentThroughputSample
+} from '../../shared/agent-throughput-types'
+import type { AgentThroughputApi } from './agent-throughput-api'
+
+export const agentThroughputApi: AgentThroughputApi = {
+  onSet: (callback) => {
+    const listener = (_event: Electron.IpcRendererEvent, data: AgentThroughputSample) =>
+      callback(data)
+    ipcRenderer.on('agentThroughput:set', listener)
+    return () => ipcRenderer.removeListener('agentThroughput:set', listener)
+  },
+  onClear: (callback) => {
+    const listener = (_event: Electron.IpcRendererEvent, data: AgentThroughputClearIpcPayload) =>
+      callback(data)
+    ipcRenderer.on('agentThroughput:clear', listener)
+    return () => ipcRenderer.removeListener('agentThroughput:clear', listener)
+  },
+  getSnapshot: () => ipcRenderer.invoke('agentThroughput:getSnapshot')
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -83,6 +83,7 @@ import { automationsApi } from './api/automations-bridge'
 import { e2eApi } from './api/e2e-bridge'
 import { mobileApi } from './api/mobile-bridge'
 import { agentStatusApi } from './api/agent-status-bridge'
+import { agentThroughputApi } from './api/agent-throughput-bridge'
 import { speechApi } from './api/speech-bridge'
 
 installNativeFileDropHandlers()
@@ -181,6 +182,7 @@ const api = {
   e2e: e2eApi,
   mobile: mobileApi,
   agentStatus: agentStatusApi,
+  agentThroughput: agentThroughputApi,
   speech: speechApi
 } satisfies PreloadApi
 

--- a/src/renderer/src/components/settings/appearance-status-bar-ports-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-ports-toggle-search.ts
@@ -1,0 +1,40 @@
+import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getPortsStatusBarToggleSearchEntry(): {
+  id: StatusBarItem
+  title: string
+  description: string
+  keywords: string[]
+  toggleDescription: string
+} {
+  return {
+    id: 'ports',
+    title: translate('auto.components.settings.appearance.search.cf409b6c4d', 'Ports'),
+    description: translate(
+      'auto.components.settings.appearance.search.0ececfa190',
+      'Show live workspace ports in the status bar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.006e67b279', 'ports'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.46d21eef62',
+        'localhost'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.43cfba3b95', 'server'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.dc02c8759d',
+        'workspace'
+      )
+    ],
+    toggleDescription: translate(
+      'settings.appearance.statusBar.portsToggleDescription',
+      'Show live workspace ports. Click it for workspace-scoped ports and external listeners.'
+    )
+  }
+}

--- a/src/renderer/src/components/settings/appearance-status-bar-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-search.ts
@@ -4,6 +4,8 @@ import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { getAntigravityStatusBarToggleSearchEntry } from './appearance-status-bar-antigravity-toggle-search'
 import { getGrokStatusBarToggleSearchEntry } from './appearance-status-bar-grok-toggle-search'
+import { getPortsStatusBarToggleSearchEntry } from './appearance-status-bar-ports-toggle-search'
+import { getThroughputStatusBarToggleSearchEntry } from './appearance-status-bar-throughput-toggle-search'
 
 export const getStatusBarToggles = createLocalizedCatalog(
   (): readonly {
@@ -265,36 +267,7 @@ export const getStatusBarToggles = createLocalizedCatalog(
         'Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.'
       )
     },
-    {
-      id: 'ports',
-      title: translate('auto.components.settings.appearance.search.cf409b6c4d', 'Ports'),
-      description: translate(
-        'auto.components.settings.appearance.search.0ececfa190',
-        'Show live workspace ports in the status bar.'
-      ),
-      keywords: [
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.896eb53fd4',
-          'status bar'
-        ),
-        ...translateSearchKeyword('auto.components.settings.appearance.search.006e67b279', 'ports'),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.46d21eef62',
-          'localhost'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.43cfba3b95',
-          'server'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.dc02c8759d',
-          'workspace'
-        )
-      ],
-      toggleDescription: translate(
-        'settings.appearance.statusBar.portsToggleDescription',
-        'Show live workspace ports. Click it for workspace-scoped ports and external listeners.'
-      )
-    }
+    getPortsStatusBarToggleSearchEntry(),
+    getThroughputStatusBarToggleSearchEntry()
   ]
 )

--- a/src/renderer/src/components/settings/appearance-status-bar-throughput-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-throughput-toggle-search.ts
@@ -1,0 +1,43 @@
+import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getThroughputStatusBarToggleSearchEntry(): {
+  id: StatusBarItem
+  title: string
+  description: string
+  keywords: string[]
+  toggleDescription: string
+} {
+  return {
+    id: 'throughput',
+    title: translate(
+      'auto.components.settings.appearance.search.throughputTitle',
+      'Agent Tokens/sec'
+    ),
+    description: translate(
+      'auto.components.settings.appearance.search.throughputDescription',
+      'Show the focused agent’s generation speed in the status bar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.afbb6a3767', 'tokens'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.throughputKeyword',
+        'throughput'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.tokensPerSecondKeyword',
+        'tokens per second'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.speedKeyword', 'speed')
+    ],
+    toggleDescription: translate(
+      'settings.appearance.statusBar.throughputToggleDescription',
+      'Show tokens per second for the focused terminal’s agent, measured per completed assistant message.'
+    )
+  }
+}

--- a/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
@@ -140,7 +140,7 @@ export function AgentThroughputStatusSegment({
             {turnAverage !== null
               ? translate(
                   'auto.components.status.bar.AgentThroughputStatusSegment.barTurnAverage',
-                  'In the bar: {{value}} tok/s, this turn’s average over {{count}} message(s)',
+                  'In the bar: {{value}} tok/s, this turn’s average over {{count}} model response(s)',
                   { value: barValue, count: sample.turnMessageCount }
                 )
               : translate(

--- a/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { Gauge } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useAppStore } from '@/store'
+import { selectActiveTerminalPaneKey } from '@/store/active-terminal-pane-key'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { computeTokensPerSecond } from '../../../../shared/agent-throughput-types'
+import { formatTokens } from '../stats/usage-formatters'
+import { formatGenerationDuration, formatTokensPerSecondValue } from './agent-throughput-format'
+
+/** tok/s of the focused pane's agent; a sample only changes when an assistant message completes. */
+export function AgentThroughputStatusSegment({
+  iconOnly
+}: {
+  iconOnly: boolean
+}): React.JSX.Element | null {
+  const paneKey = useAppStore(selectActiveTerminalPaneKey)
+  const sample = useAppStore((s) => (paneKey ? s.agentThroughputByPaneKey[paneKey] : undefined))
+  const working = useAppStore(
+    (s) => paneKey !== null && s.agentStatusByPaneKey[paneKey]?.state === 'working'
+  )
+  if (!sample) {
+    return null
+  }
+  const readout = translate(
+    'auto.components.status.bar.AgentThroughputStatusSegment.tokensPerSecond',
+    '{{value}} tok/s',
+    { value: formatTokensPerSecondValue(sample.tokensPerSecond) }
+  )
+  const turnAverage =
+    sample.turnMessageCount > 0
+      ? computeTokensPerSecond(sample.turnOutputTokens, sample.turnGenerationMs)
+      : null
+  return (
+    <Tooltip delayDuration={150}>
+      <TooltipTrigger asChild>
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 rounded px-1 py-0.5 tabular-nums',
+            // Why: dim while idle so the last reading isn't mistaken for live generation.
+            working ? 'text-foreground' : 'text-muted-foreground'
+          )}
+          aria-label={translate(
+            'auto.components.status.bar.AgentThroughputStatusSegment.ariaLabel',
+            'Agent throughput, {{value}}',
+            { value: readout }
+          )}
+        >
+          <Gauge size={12} />
+          {iconOnly ? null : <span>{readout}</span>}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={6}>
+        <div className="space-y-0.5">
+          <div>
+            {translate(
+              'auto.components.status.bar.AgentThroughputStatusSegment.lastMessage',
+              'Last message: {{tokens}} tokens in {{duration}}',
+              {
+                tokens: formatTokens(sample.outputTokens),
+                duration: formatGenerationDuration(sample.generationMs)
+              }
+            )}
+          </div>
+          {turnAverage !== null ? (
+            <div>
+              {translate(
+                'auto.components.status.bar.AgentThroughputStatusSegment.turnAverage',
+                'This turn: {{value}} tok/s across {{count}} message(s)',
+                {
+                  value: formatTokensPerSecondValue(turnAverage),
+                  count: sample.turnMessageCount
+                }
+              )}
+            </div>
+          ) : null}
+          {sample.model ? <div className="text-muted-foreground">{sample.model}</div> : null}
+          <div className="text-muted-foreground">
+            {translate(
+              'auto.components.status.bar.AgentThroughputStatusSegment.updatesHint',
+              'Updates when an assistant message completes'
+            )}
+          </div>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
@@ -86,7 +86,7 @@ export function AgentThroughputStatusSegment({
   const working = paneAgent?.state === 'working'
   const measuredFor = translate(
     'auto.components.status.bar.AgentThroughputStatusSegment.measuredFor',
-    'Measured for Claude Code, Codex, Gemini CLI and OpenCode, per completed message.'
+    'Measured per completed message for Claude Code, Codex, Gemini CLI and OpenCode; estimated for Grok.'
   )
   if (!sample) {
     // Why: an enabled item must always render, or "nothing" is indistinguishable from "off".
@@ -108,7 +108,10 @@ export function AgentThroughputStatusSegment({
       </Tooltip>
     )
   }
-  const readout = readoutLabel(formatTokensPerSecondValue(sample.tokensPerSecond))
+  // Why: a leading "~" keeps an estimate from reading as a measured figure at a glance.
+  const readout = readoutLabel(
+    `${sample.estimated ? '~' : ''}${formatTokensPerSecondValue(sample.tokensPerSecond)}`
+  )
   const turnAverage =
     sample.turnMessageCount > 0
       ? computeTokensPerSecond(sample.turnOutputTokens, sample.turnGenerationMs)
@@ -145,6 +148,14 @@ export function AgentThroughputStatusSegment({
           <div className="text-muted-foreground">
             {[getAgentDisplayName(sample.agentType), sample.model].filter(Boolean).join(' · ')}
           </div>
+          {sample.estimated ? (
+            <div className="text-muted-foreground">
+              {translate(
+                'auto.components.status.bar.AgentThroughputStatusSegment.estimated',
+                'Estimated from text length: this agent records no token counts, so hidden reasoning is approximated.'
+              )}
+            </div>
+          ) : null}
           <div className="text-muted-foreground">{measuredFor}</div>
         </div>
       </TooltipContent>

--- a/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
@@ -6,8 +6,13 @@ import { selectActiveTerminalPaneKey } from '@/store/active-terminal-pane-key'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { computeTokensPerSecond } from '../../../../shared/agent-throughput-types'
+import { TUI_AGENT_DISPLAY_NAMES } from '../../../../shared/tui-agent-display-names'
 import { formatTokens } from '../stats/usage-formatters'
 import { formatGenerationDuration, formatTokensPerSecondValue } from './agent-throughput-format'
+
+function getAgentDisplayName(agentType: string): string {
+  return (TUI_AGENT_DISPLAY_NAMES as Record<string, string | undefined>)[agentType] ?? agentType
+}
 
 /** tok/s of the focused pane's agent; a sample only changes when an assistant message completes. */
 export function AgentThroughputStatusSegment({
@@ -75,7 +80,9 @@ export function AgentThroughputStatusSegment({
               )}
             </div>
           ) : null}
-          {sample.model ? <div className="text-muted-foreground">{sample.model}</div> : null}
+          <div className="text-muted-foreground">
+            {[getAgentDisplayName(sample.agentType), sample.model].filter(Boolean).join(' · ')}
+          </div>
           <div className="text-muted-foreground">
             {translate(
               'auto.components.status.bar.AgentThroughputStatusSegment.updatesHint',

--- a/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
@@ -30,19 +30,19 @@ function placeholderHint(reason: AgentThroughputPlaceholderReason, agentType?: s
   if (reason === 'no-pane') {
     return translate(
       'auto.components.status.bar.AgentThroughputStatusSegment.noPane',
-      'Focus a terminal pane running an agent.'
+      'Focus a terminal running an agent.'
     )
   }
   if (reason === 'unmeasured-agent') {
     return translate(
       'auto.components.status.bar.AgentThroughputStatusSegment.unmeasuredAgent',
-      'Not available for {{agent}}: it records no token counts per message.',
+      'Not available for {{agent}}: no token counts recorded.',
       { agent: getAgentDisplayName(agentType ?? '') }
     )
   }
   return translate(
     'auto.components.status.bar.AgentThroughputStatusSegment.waiting',
-    'Waiting for the focused agent to complete a message.'
+    'No completed message in this terminal yet.'
   )
 }
 
@@ -92,7 +92,7 @@ export function AgentThroughputStatusSegment({
   const working = paneAgent?.state === 'working'
   const measuredFor = translate(
     'auto.components.status.bar.AgentThroughputStatusSegment.measuredFor',
-    'Measured per completed message for Claude Code, Codex, Gemini CLI and OpenCode; estimated for Grok.'
+    'Measured for Claude Code, Codex, Gemini CLI, OpenCode. Estimated for Grok.'
   )
   if (!sample) {
     // Why: an enabled item must always render, or "nothing" is indistinguishable from "off".
@@ -136,12 +136,12 @@ export function AgentThroughputStatusSegment({
             {turnAverage !== null
               ? translate(
                   'auto.components.status.bar.AgentThroughputStatusSegment.barTurnAverage',
-                  'In the bar: {{value}} tok/s, the average of this turn across {{count}} message(s)',
+                  'In the bar: {{value}} tok/s, this turn’s average over {{count}} message(s)',
                   { value: barValue, count: sample.turnMessageCount }
                 )
               : translate(
                   'auto.components.status.bar.AgentThroughputStatusSegment.barLastRequest',
-                  'In the bar: {{value}} tok/s, the last request (nothing completed in this turn yet)',
+                  'In the bar: {{value}} tok/s, last request (no message completed this turn yet)',
                   { value: barValue }
                 )}
           </div>
@@ -163,7 +163,7 @@ export function AgentThroughputStatusSegment({
             <div className="text-muted-foreground">
               {translate(
                 'auto.components.status.bar.AgentThroughputStatusSegment.estimated',
-                'Estimated from text length: this agent records no token counts, so hidden reasoning is approximated.'
+                'Estimated from text length; Grok records no token counts.'
               )}
             </div>
           ) : null}

--- a/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
@@ -62,6 +62,8 @@ function Readout({
   return (
     <span
       {...triggerProps}
+      // Why: a span is not focusable, so keyboard users could never open the tooltip.
+      tabIndex={0}
       className={cn(
         'inline-flex items-center gap-1 rounded px-1 py-0.5 tabular-nums',
         // Why: dim while idle so the last reading isn't mistaken for live generation.
@@ -92,7 +94,7 @@ export function AgentThroughputStatusSegment({
   const working = paneAgent?.state === 'working'
   const measuredFor = translate(
     'auto.components.status.bar.AgentThroughputStatusSegment.measuredFor',
-    'Measured for Claude Code, Codex, Gemini CLI, OpenCode. Estimated for Grok.'
+    'Measured for Claude Code, Codex, Gemini CLI, OpenCode, MiMo Code. Estimated for Grok.'
   )
   if (!sample) {
     // Why: an enabled item must always render, or "nothing" is indistinguishable from "off".

--- a/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
@@ -46,21 +46,27 @@ function placeholderHint(reason: AgentThroughputPlaceholderReason, agentType?: s
   )
 }
 
+// Why: TooltipTrigger renders this as its child, so the ref and pointer handlers it injects must
+// land on the span or the tooltip never opens.
 function Readout({
   iconOnly,
   value,
-  emphasized
+  emphasized,
+  className,
+  ...triggerProps
 }: {
   iconOnly: boolean
   value: string
   emphasized: boolean
-}): React.JSX.Element {
+} & React.ComponentPropsWithRef<'span'>): React.JSX.Element {
   return (
     <span
+      {...triggerProps}
       className={cn(
         'inline-flex items-center gap-1 rounded px-1 py-0.5 tabular-nums',
         // Why: dim while idle so the last reading isn't mistaken for live generation.
-        emphasized ? 'text-foreground' : 'text-muted-foreground'
+        emphasized ? 'text-foreground' : 'text-muted-foreground',
+        className
       )}
       aria-label={translate(
         'auto.components.status.bar.AgentThroughputStatusSegment.ariaLabel',
@@ -109,13 +115,16 @@ export function AgentThroughputStatusSegment({
     )
   }
   // Why: a leading "~" keeps an estimate from reading as a measured figure at a glance.
-  const readout = readoutLabel(
-    `${sample.estimated ? '~' : ''}${formatTokensPerSecondValue(sample.tokensPerSecond)}`
-  )
   const turnAverage =
     sample.turnMessageCount > 0
       ? computeTokensPerSecond(sample.turnOutputTokens, sample.turnGenerationMs)
       : null
+  // Why: the bar shows the turn average — a single short message swings wildly — and keeps the
+  // previous reading across a turn boundary until the new turn's first message completes.
+  const prefix = sample.estimated ? '~' : ''
+  const barValue = `${prefix}${formatTokensPerSecondValue(turnAverage ?? sample.tokensPerSecond)}`
+  const lastValue = `${prefix}${formatTokensPerSecondValue(sample.tokensPerSecond)}`
+  const readout = readoutLabel(barValue)
   return (
     <Tooltip delayDuration={150}>
       <TooltipTrigger asChild>
@@ -124,27 +133,29 @@ export function AgentThroughputStatusSegment({
       <TooltipContent side="top" sideOffset={6}>
         <div className="space-y-0.5">
           <div>
+            {turnAverage !== null
+              ? translate(
+                  'auto.components.status.bar.AgentThroughputStatusSegment.barTurnAverage',
+                  'In the bar: {{value}} tok/s, the average of this turn across {{count}} message(s)',
+                  { value: barValue, count: sample.turnMessageCount }
+                )
+              : translate(
+                  'auto.components.status.bar.AgentThroughputStatusSegment.barLastRequest',
+                  'In the bar: {{value}} tok/s, the last request (nothing completed in this turn yet)',
+                  { value: barValue }
+                )}
+          </div>
+          <div>
             {translate(
-              'auto.components.status.bar.AgentThroughputStatusSegment.lastMessage',
-              'Last message: {{tokens}} tokens in {{duration}}',
+              'auto.components.status.bar.AgentThroughputStatusSegment.lastRequest',
+              'Last request: {{value}} tok/s ({{tokens}} tokens in {{duration}})',
               {
+                value: lastValue,
                 tokens: formatTokens(sample.outputTokens),
                 duration: formatGenerationDuration(sample.generationMs)
               }
             )}
           </div>
-          {turnAverage !== null ? (
-            <div>
-              {translate(
-                'auto.components.status.bar.AgentThroughputStatusSegment.turnAverage',
-                'This turn: {{value}} tok/s across {{count}} message(s)',
-                {
-                  value: formatTokensPerSecondValue(turnAverage),
-                  count: sample.turnMessageCount
-                }
-              )}
-            </div>
-          ) : null}
           <div className="text-muted-foreground">
             {[getAgentDisplayName(sample.agentType), sample.model].filter(Boolean).join(' · ')}
           </div>

--- a/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
@@ -47,7 +47,7 @@ function placeholderHint(reason: AgentThroughputPlaceholderReason, agentType?: s
 }
 
 // Why: TooltipTrigger renders this as its child, so the ref and pointer handlers it injects must
-// land on the span or the tooltip never opens.
+// land on the button or the tooltip never opens.
 function Readout({
   iconOnly,
   value,
@@ -58,14 +58,14 @@ function Readout({
   iconOnly: boolean
   value: string
   emphasized: boolean
-} & React.ComponentPropsWithRef<'span'>): React.JSX.Element {
+} & React.ComponentPropsWithRef<'button'>): React.JSX.Element {
   return (
-    <span
+    <button
+      type="button"
       {...triggerProps}
-      // Why: a span is not focusable, so keyboard users could never open the tooltip.
-      tabIndex={0}
+      // Why: a readout, not an action; the sibling segments' hover wash would promise a click.
       className={cn(
-        'inline-flex items-center gap-1 rounded px-1 py-0.5 tabular-nums',
+        'inline-flex cursor-default items-center gap-1 rounded px-1 py-0.5',
         // Why: dim while idle so the last reading isn't mistaken for live generation.
         emphasized ? 'text-foreground' : 'text-muted-foreground',
         className
@@ -76,9 +76,9 @@ function Readout({
         { value }
       )}
     >
-      <Gauge size={12} />
-      {iconOnly ? null : <span>{value}</span>}
-    </span>
+      <Gauge className="size-3" />
+      {iconOnly ? null : <span className="text-[11px] font-medium tabular-nums">{value}</span>}
+    </button>
   )
 }
 
@@ -92,11 +92,11 @@ export function AgentThroughputStatusSegment({
   const sample = useAppStore((s) => (paneKey ? s.agentThroughputByPaneKey[paneKey] : undefined))
   const paneAgent = useAppStore((s) => (paneKey ? s.agentStatusByPaneKey[paneKey] : undefined))
   const working = paneAgent?.state === 'working'
-  const measuredFor = translate(
-    'auto.components.status.bar.AgentThroughputStatusSegment.measuredFor',
-    'Measured for Claude Code, Codex, Gemini CLI, OpenCode, MiMo Code. Estimated for Grok.'
-  )
   if (!sample) {
+    const measuredFor = translate(
+      'auto.components.status.bar.AgentThroughputStatusSegment.measuredFor',
+      'Measured for Claude Code, Codex, Gemini CLI, OpenCode, MiMo Code. Estimated for Grok.'
+    )
     // Why: an enabled item must always render, or "nothing" is indistinguishable from "off".
     const reason = resolveAgentThroughputPlaceholderReason({
       paneKey,
@@ -110,7 +110,9 @@ export function AgentThroughputStatusSegment({
         <TooltipContent side="top" sideOffset={6}>
           <div className="space-y-0.5">
             <div>{placeholderHint(reason, paneAgent?.agentType)}</div>
-            <div className="text-muted-foreground">{measuredFor}</div>
+            {reason === 'unmeasured-agent' ? (
+              <div className="text-muted-foreground">{measuredFor}</div>
+            ) : null}
           </div>
         </TooltipContent>
       </Tooltip>
@@ -169,7 +171,6 @@ export function AgentThroughputStatusSegment({
               )}
             </div>
           ) : null}
-          <div className="text-muted-foreground">{measuredFor}</div>
         </div>
       </TooltipContent>
     </Tooltip>

--- a/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/AgentThroughputStatusSegment.tsx
@@ -9,30 +9,106 @@ import { computeTokensPerSecond } from '../../../../shared/agent-throughput-type
 import { TUI_AGENT_DISPLAY_NAMES } from '../../../../shared/tui-agent-display-names'
 import { formatTokens } from '../stats/usage-formatters'
 import { formatGenerationDuration, formatTokensPerSecondValue } from './agent-throughput-format'
+import {
+  resolveAgentThroughputPlaceholderReason,
+  type AgentThroughputPlaceholderReason
+} from './agent-throughput-placeholder'
 
 function getAgentDisplayName(agentType: string): string {
   return (TUI_AGENT_DISPLAY_NAMES as Record<string, string | undefined>)[agentType] ?? agentType
 }
 
-/** tok/s of the focused pane's agent; a sample only changes when an assistant message completes. */
+function readoutLabel(value: string): string {
+  return translate(
+    'auto.components.status.bar.AgentThroughputStatusSegment.tokensPerSecond',
+    '{{value}} tok/s',
+    { value }
+  )
+}
+
+function placeholderHint(reason: AgentThroughputPlaceholderReason, agentType?: string): string {
+  if (reason === 'no-pane') {
+    return translate(
+      'auto.components.status.bar.AgentThroughputStatusSegment.noPane',
+      'Focus a terminal pane running an agent.'
+    )
+  }
+  if (reason === 'unmeasured-agent') {
+    return translate(
+      'auto.components.status.bar.AgentThroughputStatusSegment.unmeasuredAgent',
+      'Not available for {{agent}}: it records no token counts per message.',
+      { agent: getAgentDisplayName(agentType ?? '') }
+    )
+  }
+  return translate(
+    'auto.components.status.bar.AgentThroughputStatusSegment.waiting',
+    'Waiting for the focused agent to complete a message.'
+  )
+}
+
+function Readout({
+  iconOnly,
+  value,
+  emphasized
+}: {
+  iconOnly: boolean
+  value: string
+  emphasized: boolean
+}): React.JSX.Element {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded px-1 py-0.5 tabular-nums',
+        // Why: dim while idle so the last reading isn't mistaken for live generation.
+        emphasized ? 'text-foreground' : 'text-muted-foreground'
+      )}
+      aria-label={translate(
+        'auto.components.status.bar.AgentThroughputStatusSegment.ariaLabel',
+        'Agent throughput, {{value}}',
+        { value }
+      )}
+    >
+      <Gauge size={12} />
+      {iconOnly ? null : <span>{value}</span>}
+    </span>
+  )
+}
+
+/** tok/s of the focused pane's agent; a sample only changes when a model call completes. */
 export function AgentThroughputStatusSegment({
   iconOnly
 }: {
   iconOnly: boolean
-}): React.JSX.Element | null {
+}): React.JSX.Element {
   const paneKey = useAppStore(selectActiveTerminalPaneKey)
   const sample = useAppStore((s) => (paneKey ? s.agentThroughputByPaneKey[paneKey] : undefined))
-  const working = useAppStore(
-    (s) => paneKey !== null && s.agentStatusByPaneKey[paneKey]?.state === 'working'
+  const paneAgent = useAppStore((s) => (paneKey ? s.agentStatusByPaneKey[paneKey] : undefined))
+  const working = paneAgent?.state === 'working'
+  const measuredFor = translate(
+    'auto.components.status.bar.AgentThroughputStatusSegment.measuredFor',
+    'Measured for Claude Code, Codex, Gemini CLI and OpenCode, per completed message.'
   )
   if (!sample) {
-    return null
+    // Why: an enabled item must always render, or "nothing" is indistinguishable from "off".
+    const reason = resolveAgentThroughputPlaceholderReason({
+      paneKey,
+      agentType: paneAgent?.agentType
+    })
+    return (
+      <Tooltip delayDuration={150}>
+        <TooltipTrigger asChild>
+          <Readout iconOnly={iconOnly} value={readoutLabel('n/a')} emphasized={false} />
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6}>
+          <div className="space-y-0.5">
+            <div>{placeholderHint(reason, paneAgent?.agentType)}</div>
+            <div className="text-muted-foreground">{measuredFor}</div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    )
   }
-  const readout = translate(
-    'auto.components.status.bar.AgentThroughputStatusSegment.tokensPerSecond',
-    '{{value}} tok/s',
-    { value: formatTokensPerSecondValue(sample.tokensPerSecond) }
-  )
+  const readout = readoutLabel(formatTokensPerSecondValue(sample.tokensPerSecond))
   const turnAverage =
     sample.turnMessageCount > 0
       ? computeTokensPerSecond(sample.turnOutputTokens, sample.turnGenerationMs)
@@ -40,21 +116,7 @@ export function AgentThroughputStatusSegment({
   return (
     <Tooltip delayDuration={150}>
       <TooltipTrigger asChild>
-        <span
-          className={cn(
-            'inline-flex items-center gap-1 rounded px-1 py-0.5 tabular-nums',
-            // Why: dim while idle so the last reading isn't mistaken for live generation.
-            working ? 'text-foreground' : 'text-muted-foreground'
-          )}
-          aria-label={translate(
-            'auto.components.status.bar.AgentThroughputStatusSegment.ariaLabel',
-            'Agent throughput, {{value}}',
-            { value: readout }
-          )}
-        >
-          <Gauge size={12} />
-          {iconOnly ? null : <span>{readout}</span>}
-        </span>
+        <Readout iconOnly={iconOnly} value={readout} emphasized={working} />
       </TooltipTrigger>
       <TooltipContent side="top" sideOffset={6}>
         <div className="space-y-0.5">
@@ -83,12 +145,7 @@ export function AgentThroughputStatusSegment({
           <div className="text-muted-foreground">
             {[getAgentDisplayName(sample.agentType), sample.model].filter(Boolean).join(' · ')}
           </div>
-          <div className="text-muted-foreground">
-            {translate(
-              'auto.components.status.bar.AgentThroughputStatusSegment.updatesHint',
-              'Updates when an assistant message completes'
-            )}
-          </div>
+          <div className="text-muted-foreground">{measuredFor}</div>
         </div>
       </TooltipContent>
     </Tooltip>

--- a/src/renderer/src/components/status-bar/StatusBarSurface.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarSurface.tsx
@@ -45,6 +45,11 @@ const PortsStatusSegment = lazyWithRetry(() =>
 const SshStatusSegment = lazyWithRetry(() =>
   import('./SshStatusSegment').then((module) => ({ default: module.SshStatusSegment }))
 )
+const AgentThroughputStatusSegment = lazyWithRetry(() =>
+  import('./AgentThroughputStatusSegment').then((module) => ({
+    default: module.AgentThroughputStatusSegment
+  }))
+)
 
 export type StatusBarProps = {
   floatingTerminalOpen: boolean
@@ -84,6 +89,7 @@ export function StatusBarSurface({
     showPorts,
     showResourceUsage,
     showSsh,
+    showThroughput,
     statusBarUsageMode,
     usageMenuFocusHandoff,
     usageMenuOpen,
@@ -249,6 +255,7 @@ export function StatusBarSurface({
         <UpdateStatusSegment compact={compact} iconOnly={iconOnly} />
         <React.Suspense fallback={null}>
           {petEnabled ? <PetStatusSegment /> : null}
+          {showThroughput ? <AgentThroughputStatusSegment iconOnly={iconOnly} /> : null}
           {showResourceUsage ? (
             <ResourceUsageStatusSegment compact={compact} iconOnly={iconOnly} />
           ) : null}

--- a/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
@@ -1,4 +1,4 @@
-import { Activity, Plug, Server } from 'lucide-react'
+import { Activity, Gauge, Plug, Server } from 'lucide-react'
 import React from 'react'
 import {
   DropdownMenu,
@@ -162,6 +162,15 @@ export function StatusBarVisibilityMenu({
         >
           <Plug className="size-3.5" />
           {translate('auto.components.status.bar.StatusBar.9659e38343', 'Ports')}
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={statusBarItems.includes('throughput')}
+          onCheckedChange={() => {
+            toggleStatusBarItem('throughput')
+          }}
+        >
+          <Gauge className="size-3.5" />
+          {translate('auto.components.status.bar.StatusBar.throughput', 'Agent Tokens/sec')}
         </DropdownMenuCheckboxItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/renderer/src/components/status-bar/agent-throughput-format.test.ts
+++ b/src/renderer/src/components/status-bar/agent-throughput-format.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { formatGenerationDuration, formatTokensPerSecondValue } from './agent-throughput-format'
+
+describe('agent throughput formatting', () => {
+  it('formats tokens per second by magnitude', () => {
+    expect(formatTokensPerSecondValue(0)).toBe('0')
+    expect(formatTokensPerSecondValue(Number.NaN)).toBe('0')
+    expect(formatTokensPerSecondValue(0.44)).toBe('0.4')
+    expect(formatTokensPerSecondValue(9.96)).toBe('10.0')
+    expect(formatTokensPerSecondValue(68.4)).toBe('68')
+    expect(formatTokensPerSecondValue(1234)).toBe('1.2k')
+  })
+
+  it('formats generation durations', () => {
+    expect(formatGenerationDuration(4_210)).toBe('4.2s')
+    expect(formatGenerationDuration(59_949)).toBe('59.9s')
+    expect(formatGenerationDuration(125_000)).toBe('2m 05s')
+    expect(formatGenerationDuration(-5)).toBe('0.0s')
+  })
+})

--- a/src/renderer/src/components/status-bar/agent-throughput-format.test.ts
+++ b/src/renderer/src/components/status-bar/agent-throughput-format.test.ts
@@ -15,6 +15,8 @@ describe('agent throughput formatting', () => {
     expect(formatGenerationDuration(4_210)).toBe('4.2s')
     expect(formatGenerationDuration(59_949)).toBe('59.9s')
     expect(formatGenerationDuration(125_000)).toBe('2m 05s')
+    expect(formatGenerationDuration(119_400)).toBe('1m 59s')
+    expect(formatGenerationDuration(119_999)).toBe('2m 00s')
     expect(formatGenerationDuration(-5)).toBe('0.0s')
   })
 })

--- a/src/renderer/src/components/status-bar/agent-throughput-format.ts
+++ b/src/renderer/src/components/status-bar/agent-throughput-format.ts
@@ -1,0 +1,24 @@
+/** Number part of a tok/s readout: whole numbers from 10 up, one decimal below, "k" from 1000. */
+export function formatTokensPerSecondValue(tokensPerSecond: number): string {
+  if (!(tokensPerSecond > 0)) {
+    return '0'
+  }
+  if (tokensPerSecond >= 1000) {
+    return `${(tokensPerSecond / 1000).toFixed(1)}k`
+  }
+  if (tokensPerSecond >= 10) {
+    return String(Math.round(tokensPerSecond))
+  }
+  return tokensPerSecond.toFixed(1)
+}
+
+/** Generation time as "4.2s" under a minute, else "2m 05s". */
+export function formatGenerationDuration(generationMs: number): string {
+  const totalSeconds = Math.max(0, generationMs) / 1000
+  if (totalSeconds < 60) {
+    return `${totalSeconds.toFixed(1)}s`
+  }
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = Math.round(totalSeconds - minutes * 60)
+  return `${minutes}m ${String(seconds).padStart(2, '0')}s`
+}

--- a/src/renderer/src/components/status-bar/agent-throughput-format.ts
+++ b/src/renderer/src/components/status-bar/agent-throughput-format.ts
@@ -18,7 +18,9 @@ export function formatGenerationDuration(generationMs: number): string {
   if (totalSeconds < 60) {
     return `${totalSeconds.toFixed(1)}s`
   }
-  const minutes = Math.floor(totalSeconds / 60)
-  const seconds = Math.round(totalSeconds - minutes * 60)
+  // Why: round the whole value first so a carry rolls into the minutes instead of printing "1m 60s".
+  const rounded = Math.round(totalSeconds)
+  const minutes = Math.floor(rounded / 60)
+  const seconds = rounded % 60
   return `${minutes}m ${String(seconds).padStart(2, '0')}s`
 }

--- a/src/renderer/src/components/status-bar/agent-throughput-placeholder.test.ts
+++ b/src/renderer/src/components/status-bar/agent-throughput-placeholder.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { resolveAgentThroughputPlaceholderReason } from './agent-throughput-placeholder'
+
+describe('resolveAgentThroughputPlaceholderReason', () => {
+  it('explains why no reading is shown', () => {
+    expect(resolveAgentThroughputPlaceholderReason({ paneKey: null, agentType: 'claude' })).toBe(
+      'no-pane'
+    )
+    expect(
+      resolveAgentThroughputPlaceholderReason({ paneKey: 'tab:leaf', agentType: 'grok' })
+    ).toBe('unmeasured-agent')
+    expect(
+      resolveAgentThroughputPlaceholderReason({ paneKey: 'tab:leaf', agentType: 'claude' })
+    ).toBe('waiting')
+    expect(
+      resolveAgentThroughputPlaceholderReason({ paneKey: 'tab:leaf', agentType: undefined })
+    ).toBe('waiting')
+  })
+})

--- a/src/renderer/src/components/status-bar/agent-throughput-placeholder.test.ts
+++ b/src/renderer/src/components/status-bar/agent-throughput-placeholder.test.ts
@@ -7,7 +7,7 @@ describe('resolveAgentThroughputPlaceholderReason', () => {
       'no-pane'
     )
     expect(
-      resolveAgentThroughputPlaceholderReason({ paneKey: 'tab:leaf', agentType: 'grok' })
+      resolveAgentThroughputPlaceholderReason({ paneKey: 'tab:leaf', agentType: 'kimi' })
     ).toBe('unmeasured-agent')
     expect(
       resolveAgentThroughputPlaceholderReason({ paneKey: 'tab:leaf', agentType: 'claude' })

--- a/src/renderer/src/components/status-bar/agent-throughput-placeholder.ts
+++ b/src/renderer/src/components/status-bar/agent-throughput-placeholder.ts
@@ -1,0 +1,22 @@
+import { isAgentThroughputMeasured } from '../../../../shared/agent-throughput-types'
+
+export type AgentThroughputPlaceholderReason =
+  /** No terminal pane is focused, so there is nothing to measure. */
+  | 'no-pane'
+  /** The focused pane's agent writes no per-message token counts Orca can read. */
+  | 'unmeasured-agent'
+  /** A measurable (or not yet identified) agent that has not completed a message. */
+  | 'waiting'
+
+export function resolveAgentThroughputPlaceholderReason(args: {
+  paneKey: string | null
+  agentType: string | undefined
+}): AgentThroughputPlaceholderReason {
+  if (!args.paneKey) {
+    return 'no-pane'
+  }
+  if (args.agentType && !isAgentThroughputMeasured(args.agentType)) {
+    return 'unmeasured-agent'
+  }
+  return 'waiting'
+}

--- a/src/renderer/src/components/status-bar/use-status-bar-controller.ts
+++ b/src/renderer/src/components/status-bar/use-status-bar-controller.ts
@@ -153,6 +153,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   const showSsh = statusBarItems.includes('ssh')
   const showResourceUsage = statusBarItems.includes('resource-usage')
   const showPorts = statusBarItems.includes('ports')
+  const showThroughput = statusBarItems.includes('throughput')
   const showFloatingTerminalToggle =
     floatingTerminalEnabled && floatingTerminalTriggerLocation === 'status-bar'
   // Why: meter-only children (excludes resource-usage) so the % display callout anchors to a real meter cluster.
@@ -261,6 +262,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     showPorts,
     showResourceUsage,
     showSsh,
+    showThroughput,
     statusBarItems,
     statusBarUsageMode,
     toggleStatusBarItem,

--- a/src/renderer/src/hooks/ipc-events/agent-throughput-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/agent-throughput-ipc-bridge.ts
@@ -1,0 +1,24 @@
+import { useAppStore } from '../../store'
+
+export function registerAgentThroughputIpcBridge(unsubs: (() => void)[]): void {
+  const api = window.api.agentThroughput
+  unsubs.push(
+    api.onSet((sample) => {
+      useAppStore.getState().setAgentThroughput(sample)
+    })
+  )
+  unsubs.push(
+    api.onClear(({ paneKey }) => {
+      useAppStore.getState().clearAgentThroughput(paneKey)
+    })
+  )
+  // Why: pushes that raced the startup pull win by observedAt inside the merge, so order here doesn't matter.
+  void api
+    .getSnapshot()
+    .then((samples) => {
+      useAppStore.getState().mergeAgentThroughputSnapshot(samples)
+    })
+    .catch((error: unknown) => {
+      console.warn('[agent-throughput] snapshot failed', error)
+    })
+}

--- a/src/renderer/src/hooks/ipc-events/app-lifetime-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/app-lifetime-ipc-bridge.ts
@@ -5,6 +5,7 @@ import { attachMobileMarkdownBridge } from '@/runtime/mobile-markdown-bridge'
 import { resetAgentHookCompletionNotificationCoordinators } from '../agent-hook-completion-notifications'
 import { useAppStore } from '../../store'
 import { registerAgentStatusIpcBridge } from './agent-status-ipc-bridge'
+import { registerAgentThroughputIpcBridge } from './agent-throughput-ipc-bridge'
 import { registerBrowserRequestIpcBridge } from './browser-request-ipc-bridge'
 import { registerBrowserStateIpcBridge } from './browser-state-ipc-bridge'
 import { registerContentCreationIpcBridge } from './content-creation-ipc-bridge'
@@ -110,6 +111,7 @@ export function installAppLifetimeIpcEvents(
   registerBrowserRequestIpcBridge(unsubs, isRuntimeEnvironmentActive)
   registerTabLifecycleIpcBridge(unsubs)
   registerRateLimitIpcBridge(unsubs)
+  registerAgentThroughputIpcBridge(unsubs)
   registerDirectSshStateIpcBridge(unsubs, directSshRuntime)
   registerRemoteWorkspaceIpcBridge(unsubs, directSshRuntime)
   registerZoomIpcBridge(unsubs)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -133,7 +133,8 @@
         "resourceUsageToggleDescription": "Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.",
         "portsToggleDescription": "Show live workspace ports. Click it for workspace-scoped ports and external listeners.",
         "antigravityToggleDescription": "Show Antigravity subscription usage for the active workspace.",
-        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI."
+        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI.",
+        "throughputToggleDescription": "Show tokens per second for the focused terminal’s agent, measured per completed assistant message."
       },
       "menuBarIcon": {
         "title": "Show Menu Bar Icon",
@@ -3690,7 +3691,8 @@
             "grokUsageMenu": "Grok Usage",
             "floatingTerminalNewActivity": "{{label}}, new activity",
             "codexSignInSuccess": "Signed in to Codex",
-            "codexSignInError": "Codex sign-in failed. Please try again."
+            "codexSignInError": "Codex sign-in failed. Please try again.",
+            "throughput": "Agent Tokens/sec"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -3953,6 +3955,13 @@
             "contact_note": "The host may still be running; only the Orca connection is unavailable.",
             "last_connected": "Last connected {{value0}}",
             "reconnect_attempt": "Attempt {{value0}}"
+          },
+          "AgentThroughputStatusSegment": {
+            "tokensPerSecond": "{{value}} tok/s",
+            "ariaLabel": "Agent throughput, {{value}}",
+            "lastMessage": "Last message: {{tokens}} tokens in {{duration}}",
+            "turnAverage": "This turn: {{value}} tok/s across {{count}} message(s)",
+            "updatesHint": "Updates when an assistant message completes"
           }
         }
       },
@@ -9054,7 +9063,9 @@
               "close": "close",
               "notification": "notification area",
               "background": "background"
-            }
+            },
+            "throughputTitle": "Agent Tokens/sec",
+            "throughputDescription": "Show the focused agent’s generation speed in the status bar."
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3959,13 +3959,13 @@
           "AgentThroughputStatusSegment": {
             "tokensPerSecond": "{{value}} tok/s",
             "ariaLabel": "Agent throughput, {{value}}",
-            "noPane": "Focus a terminal pane running an agent.",
-            "unmeasuredAgent": "Not available for {{agent}}: it records no token counts per message.",
-            "waiting": "Waiting for the focused agent to complete a message.",
-            "measuredFor": "Measured per completed message for Claude Code, Codex, Gemini CLI and OpenCode; estimated for Grok.",
-            "estimated": "Estimated from text length: this agent records no token counts, so hidden reasoning is approximated.",
-            "barTurnAverage": "In the bar: {{value}} tok/s, the average of this turn across {{count}} message(s)",
-            "barLastRequest": "In the bar: {{value}} tok/s, the last request (nothing completed in this turn yet)",
+            "noPane": "Focus a terminal running an agent.",
+            "unmeasuredAgent": "Not available for {{agent}}: no token counts recorded.",
+            "waiting": "No completed message in this terminal yet.",
+            "measuredFor": "Measured for Claude Code, Codex, Gemini CLI, OpenCode. Estimated for Grok.",
+            "estimated": "Estimated from text length; Grok records no token counts.",
+            "barTurnAverage": "In the bar: {{value}} tok/s, this turn’s average over {{count}} message(s)",
+            "barLastRequest": "In the bar: {{value}} tok/s, last request (no message completed this turn yet)",
             "lastRequest": "Last request: {{value}} tok/s ({{tokens}} tokens in {{duration}})"
           }
         }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9070,7 +9070,10 @@
               "background": "background"
             },
             "throughputTitle": "Agent Tokens/sec",
-            "throughputDescription": "Show the focused agent’s generation speed in the status bar."
+            "throughputDescription": "Show the focused agent’s generation speed in the status bar.",
+            "throughputKeyword": "throughput",
+            "tokensPerSecondKeyword": "tokens per second",
+            "speedKeyword": "speed"
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3961,7 +3961,11 @@
             "ariaLabel": "Agent throughput, {{value}}",
             "lastMessage": "Last message: {{tokens}} tokens in {{duration}}",
             "turnAverage": "This turn: {{value}} tok/s across {{count}} message(s)",
-            "updatesHint": "Updates when an assistant message completes"
+            "updatesHint": "Updates when an assistant message completes",
+            "noPane": "Focus a terminal pane running an agent.",
+            "unmeasuredAgent": "Not available for {{agent}}: it records no token counts per message.",
+            "waiting": "Waiting for the focused agent to complete a message.",
+            "measuredFor": "Measured for Claude Code, Codex, Gemini CLI and OpenCode, per completed message."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3964,7 +3964,7 @@
             "waiting": "No completed message in this terminal yet.",
             "measuredFor": "Measured for Claude Code, Codex, Gemini CLI, OpenCode, MiMo Code. Estimated for Grok.",
             "estimated": "Estimated from text length; Grok records no token counts.",
-            "barTurnAverage": "In the bar: {{value}} tok/s, this turn’s average over {{count}} message(s)",
+            "barTurnAverage": "In the bar: {{value}} tok/s, this turn’s average over {{count}} model response(s)",
             "barLastRequest": "In the bar: {{value}} tok/s, last request (no message completed this turn yet)",
             "lastRequest": "Last request: {{value}} tok/s ({{tokens}} tokens in {{duration}})"
           }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3962,7 +3962,7 @@
             "noPane": "Focus a terminal running an agent.",
             "unmeasuredAgent": "Not available for {{agent}}: no token counts recorded.",
             "waiting": "No completed message in this terminal yet.",
-            "measuredFor": "Measured for Claude Code, Codex, Gemini CLI, OpenCode. Estimated for Grok.",
+            "measuredFor": "Measured for Claude Code, Codex, Gemini CLI, OpenCode, MiMo Code. Estimated for Grok.",
             "estimated": "Estimated from text length; Grok records no token counts.",
             "barTurnAverage": "In the bar: {{value}} tok/s, this turn’s average over {{count}} message(s)",
             "barLastRequest": "In the bar: {{value}} tok/s, last request (no message completed this turn yet)",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3965,7 +3965,8 @@
             "noPane": "Focus a terminal pane running an agent.",
             "unmeasuredAgent": "Not available for {{agent}}: it records no token counts per message.",
             "waiting": "Waiting for the focused agent to complete a message.",
-            "measuredFor": "Measured for Claude Code, Codex, Gemini CLI and OpenCode, per completed message."
+            "measuredFor": "Measured for Claude Code, Codex, Gemini CLI and OpenCode, per completed message.",
+            "estimated": "Estimated from text length: this agent records no token counts, so hidden reasoning is approximated."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3959,14 +3959,14 @@
           "AgentThroughputStatusSegment": {
             "tokensPerSecond": "{{value}} tok/s",
             "ariaLabel": "Agent throughput, {{value}}",
-            "lastMessage": "Last message: {{tokens}} tokens in {{duration}}",
-            "turnAverage": "This turn: {{value}} tok/s across {{count}} message(s)",
-            "updatesHint": "Updates when an assistant message completes",
             "noPane": "Focus a terminal pane running an agent.",
             "unmeasuredAgent": "Not available for {{agent}}: it records no token counts per message.",
             "waiting": "Waiting for the focused agent to complete a message.",
-            "measuredFor": "Measured for Claude Code, Codex, Gemini CLI and OpenCode, per completed message.",
-            "estimated": "Estimated from text length: this agent records no token counts, so hidden reasoning is approximated."
+            "measuredFor": "Measured per completed message for Claude Code, Codex, Gemini CLI and OpenCode; estimated for Grok.",
+            "estimated": "Estimated from text length: this agent records no token counts, so hidden reasoning is approximated.",
+            "barTurnAverage": "In the bar: {{value}} tok/s, the average of this turn across {{count}} message(s)",
+            "barLastRequest": "In the bar: {{value}} tok/s, the last request (nothing completed in this turn yet)",
+            "lastRequest": "Last request: {{value}} tok/s ({{tokens}} tokens in {{duration}})"
           }
         }
       },

--- a/src/renderer/src/store/active-terminal-pane-key.test.ts
+++ b/src/renderer/src/store/active-terminal-pane-key.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  selectActiveTerminalPaneKey,
+  type ActiveTerminalPaneKeyState
+} from './active-terminal-pane-key'
+
+const LEAF = '0f7c1b2e-3d4a-4c5b-8e6f-7a8b9c0d1e2f'
+
+function state(overrides: Partial<Record<keyof ActiveTerminalPaneKeyState, unknown>> = {}) {
+  return {
+    activeTabType: 'terminal',
+    activeTabId: 'tab-1',
+    terminalLayoutsByTabId: { 'tab-1': { activeLeafId: LEAF } },
+    ...overrides
+  } as unknown as ActiveTerminalPaneKeyState
+}
+
+describe('selectActiveTerminalPaneKey', () => {
+  it('joins the active tab and its focused terminal leaf', () => {
+    expect(selectActiveTerminalPaneKey(state())).toBe(`tab-1:${LEAF}`)
+  })
+
+  it('returns null without a focused terminal leaf', () => {
+    expect(selectActiveTerminalPaneKey(state({ activeTabType: 'browser' }))).toBe(null)
+    expect(selectActiveTerminalPaneKey(state({ activeTabId: null }))).toBe(null)
+    expect(selectActiveTerminalPaneKey(state({ terminalLayoutsByTabId: {} }))).toBe(null)
+    expect(
+      selectActiveTerminalPaneKey(
+        state({ terminalLayoutsByTabId: { 'tab-1': { activeLeafId: 'legacy-3' } } })
+      )
+    ).toBe(null)
+  })
+})

--- a/src/renderer/src/store/active-terminal-pane-key.ts
+++ b/src/renderer/src/store/active-terminal-pane-key.ts
@@ -1,0 +1,19 @@
+import type { AppState } from './types'
+import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
+
+export type ActiveTerminalPaneKeyState = Pick<
+  AppState,
+  'activeTabType' | 'activeTabId' | 'terminalLayoutsByTabId'
+>
+
+/** Pane key of the focused terminal leaf, or null when no terminal tab is active. */
+export function selectActiveTerminalPaneKey(state: ActiveTerminalPaneKeyState): string | null {
+  if (state.activeTabType !== 'terminal' || !state.activeTabId) {
+    return null
+  }
+  const leafId = state.terminalLayoutsByTabId[state.activeTabId]?.activeLeafId
+  if (!leafId || !isTerminalLeafId(leafId)) {
+    return null
+  }
+  return makePaneKey(state.activeTabId, leafId)
+}

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -27,6 +27,7 @@ import { createRateLimitSlice } from './slices/rate-limits'
 import { createSshSlice } from './slices/ssh'
 import { createRuntimeEnvironmentSshSlice } from './slices/runtime-environment-ssh'
 import { createAgentStatusSlice } from './slices/agent-status'
+import { createAgentThroughputSlice } from './slices/agent-throughput'
 import { createPaneForegroundAgentSlice } from './slices/pane-foreground-agent'
 import { createDiffCommentsSlice } from './slices/diffComments'
 import { createDetectedAgentsSlice } from './slices/detected-agents'
@@ -89,6 +90,7 @@ export const useAppStore = create<AppState>()(
       ...createSshSlice(...a),
       ...createRuntimeEnvironmentSshSlice(...a),
       ...createAgentStatusSlice(...a),
+      ...createAgentThroughputSlice(...a),
       ...createPaneForegroundAgentSlice(...a),
       ...createDiffCommentsSlice(...a),
       ...createDetectedAgentsSlice(...a),

--- a/src/renderer/src/store/slices/agent-throughput.test.ts
+++ b/src/renderer/src/store/slices/agent-throughput.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentThroughputSample } from '../../../../shared/agent-throughput-types'
+import { createTestStore } from './store-test-helpers'
+
+const PANE = 'tab-1:0f7c1b2e-3d4a-4c5b-8e6f-7a8b9c0d1e2f'
+
+function sample(overrides: Partial<AgentThroughputSample> = {}): AgentThroughputSample {
+  return {
+    paneKey: PANE,
+    agentType: 'claude',
+    messageId: 'msg_1',
+    model: 'claude-fable-5-1',
+    outputTokens: 500,
+    generationMs: 10_000,
+    tokensPerSecond: 50,
+    completedAt: 1_000,
+    turnOutputTokens: 500,
+    turnGenerationMs: 10_000,
+    turnMessageCount: 1,
+    observedAt: 1_000,
+    ...overrides
+  }
+}
+
+describe('agent throughput slice', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(5_000)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps the newer of a push and a snapshot per pane', () => {
+    const store = createTestStore()
+    store.getState().setAgentThroughput(sample({ observedAt: 2_000, messageId: 'push' }))
+    store
+      .getState()
+      .mergeAgentThroughputSnapshot([sample({ observedAt: 1_000, messageId: 'older-snapshot' })])
+    expect(store.getState().agentThroughputByPaneKey[PANE]?.messageId).toBe('push')
+
+    store
+      .getState()
+      .mergeAgentThroughputSnapshot([sample({ observedAt: 3_000, messageId: 'newer-snapshot' })])
+    expect(store.getState().agentThroughputByPaneKey[PANE]?.messageId).toBe('newer-snapshot')
+  })
+
+  it('does not let a snapshot pulled before a clear resurrect the cleared pane', () => {
+    const store = createTestStore()
+    store.getState().setAgentThroughput(sample({ observedAt: 1_000 }))
+    store.getState().clearAgentThroughput(PANE)
+    expect(store.getState().agentThroughputByPaneKey[PANE]).toBeUndefined()
+
+    // Why: the snapshot request left before the clear (observedAt 1_000 < cleared at 5_000).
+    store.getState().mergeAgentThroughputSnapshot([sample({ observedAt: 1_000 })])
+    expect(store.getState().agentThroughputByPaneKey[PANE]).toBeUndefined()
+
+    // Why: a live push after the clear is a new reading and lifts the fence.
+    store.getState().setAgentThroughput(sample({ observedAt: 6_000, messageId: 'after-clear' }))
+    expect(store.getState().agentThroughputByPaneKey[PANE]?.messageId).toBe('after-clear')
+    expect(store.getState().agentThroughputClearedAt[PANE]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/agent-throughput.ts
+++ b/src/renderer/src/store/slices/agent-throughput.ts
@@ -1,0 +1,41 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+import type { AgentThroughputSample } from '../../../../shared/agent-throughput-types'
+
+export type AgentThroughputSlice = {
+  agentThroughputByPaneKey: Record<string, AgentThroughputSample>
+  setAgentThroughput: (sample: AgentThroughputSample) => void
+  clearAgentThroughput: (paneKey: string) => void
+  /** Startup catch-up: a pane keeps whichever of its push or snapshot sample was observed later. */
+  mergeAgentThroughputSnapshot: (samples: AgentThroughputSample[]) => void
+}
+
+export const createAgentThroughputSlice: StateCreator<AppState, [], [], AgentThroughputSlice> = (
+  set
+) => ({
+  agentThroughputByPaneKey: {},
+  setAgentThroughput: (sample) =>
+    set((s) => ({
+      agentThroughputByPaneKey: { ...s.agentThroughputByPaneKey, [sample.paneKey]: sample }
+    })),
+  clearAgentThroughput: (paneKey) =>
+    set((s) => {
+      if (!(paneKey in s.agentThroughputByPaneKey)) {
+        return {}
+      }
+      const next = { ...s.agentThroughputByPaneKey }
+      delete next[paneKey]
+      return { agentThroughputByPaneKey: next }
+    }),
+  mergeAgentThroughputSnapshot: (samples) =>
+    set((s) => {
+      const next = { ...s.agentThroughputByPaneKey }
+      for (const sample of samples) {
+        const current = next[sample.paneKey]
+        if (!current || current.observedAt <= sample.observedAt) {
+          next[sample.paneKey] = sample
+        }
+      }
+      return { agentThroughputByPaneKey: next }
+    })
+})

--- a/src/renderer/src/store/slices/agent-throughput.ts
+++ b/src/renderer/src/store/slices/agent-throughput.ts
@@ -4,6 +4,8 @@ import type { AgentThroughputSample } from '../../../../shared/agent-throughput-
 
 export type AgentThroughputSlice = {
   agentThroughputByPaneKey: Record<string, AgentThroughputSample>
+  /** Panes cleared since startup, by clear time; fences the startup snapshot merge. */
+  agentThroughputClearedAt: Record<string, number>
   setAgentThroughput: (sample: AgentThroughputSample) => void
   clearAgentThroughput: (paneKey: string) => void
   /** Startup catch-up: a pane keeps whichever of its push or snapshot sample was observed later. */
@@ -14,23 +16,33 @@ export const createAgentThroughputSlice: StateCreator<AppState, [], [], AgentThr
   set
 ) => ({
   agentThroughputByPaneKey: {},
+  agentThroughputClearedAt: {},
   setAgentThroughput: (sample) =>
-    set((s) => ({
-      agentThroughputByPaneKey: { ...s.agentThroughputByPaneKey, [sample.paneKey]: sample }
-    })),
+    set((s) => {
+      const { [sample.paneKey]: _cleared, ...clearedAt } = s.agentThroughputClearedAt
+      return {
+        agentThroughputByPaneKey: { ...s.agentThroughputByPaneKey, [sample.paneKey]: sample },
+        agentThroughputClearedAt: clearedAt
+      }
+    }),
   clearAgentThroughput: (paneKey) =>
     set((s) => {
-      if (!(paneKey in s.agentThroughputByPaneKey)) {
-        return {}
-      }
       const next = { ...s.agentThroughputByPaneKey }
       delete next[paneKey]
-      return { agentThroughputByPaneKey: next }
+      return {
+        agentThroughputByPaneKey: next,
+        agentThroughputClearedAt: { ...s.agentThroughputClearedAt, [paneKey]: Date.now() }
+      }
     }),
   mergeAgentThroughputSnapshot: (samples) =>
     set((s) => {
       const next = { ...s.agentThroughputByPaneKey }
       for (const sample of samples) {
+        // Why: a snapshot pulled before a clear must not resurrect the pane it cleared.
+        const clearedAt = s.agentThroughputClearedAt[sample.paneKey]
+        if (clearedAt !== undefined && sample.observedAt <= clearedAt) {
+          continue
+        }
         const current = next[sample.paneKey]
         if (!current || current.observedAt <= sample.observedAt) {
           next[sample.paneKey] = sample

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -31,6 +31,7 @@ import { createRateLimitSlice } from './rate-limits'
 import { createSshSlice } from './ssh'
 import { createRuntimeEnvironmentSshSlice } from './runtime-environment-ssh'
 import { createAgentStatusSlice } from './agent-status'
+import { createAgentThroughputSlice } from './agent-throughput'
 import { createPaneForegroundAgentSlice } from './pane-foreground-agent'
 import { createDiffCommentsSlice } from './diffComments'
 import { createDetectedAgentsSlice } from './detected-agents'
@@ -86,6 +87,7 @@ export function createTestStore() {
     ...createSshSlice(...a),
     ...createRuntimeEnvironmentSshSlice(...a),
     ...createAgentStatusSlice(...a),
+    ...createAgentThroughputSlice(...a),
     ...createPaneForegroundAgentSlice(...a),
     ...createDiffCommentsSlice(...a),
     ...createDetectedAgentsSlice(...a),

--- a/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
+++ b/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
@@ -139,7 +139,8 @@ describe('createUISlice hydratePersistedUI', () => {
       'kimi',
       'minimax',
       'antigravity',
-      'grok'
+      'grok',
+      'throughput'
     ])
     expect(setUI).toHaveBeenCalledWith({
       statusBarItems: [
@@ -149,13 +150,15 @@ describe('createUISlice hydratePersistedUI', () => {
         'kimi',
         'minimax',
         'antigravity',
-        'grok'
+        'grok',
+        'throughput'
       ],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
-      _grokStatusBarDefaultAdded: true
+      _grokStatusBarDefaultAdded: true,
+      _throughputStatusBarDefaultAdded: true
     })
   })
 
@@ -171,7 +174,8 @@ describe('createUISlice hydratePersistedUI', () => {
         _kimiStatusBarDefaultAdded: true,
         _minimaxStatusBarDefaultAdded: true,
         _antigravityStatusBarDefaultAdded: true,
-        _grokStatusBarDefaultAdded: true
+        _grokStatusBarDefaultAdded: true,
+        _throughputStatusBarDefaultAdded: true
       })
     )
 

--- a/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
@@ -72,6 +72,7 @@ const DEFAULT_ON_KIMI_STATUS_BAR_ITEM: StatusBarItem = 'kimi'
 const DEFAULT_ON_MINIMAX_STATUS_BAR_ITEM: StatusBarItem = 'minimax'
 const DEFAULT_ON_ANTIGRAVITY_STATUS_BAR_ITEM: StatusBarItem = 'antigravity'
 const DEFAULT_ON_GROK_STATUS_BAR_ITEM: StatusBarItem = 'grok'
+const DEFAULT_ON_THROUGHPUT_STATUS_BAR_ITEM: StatusBarItem = 'throughput'
 
 function hydrateStatusBarItems(ui: PersistedUIState): StatusBarItem[] {
   let items = migrateStatusBarItems(ui.statusBarItems)
@@ -80,7 +81,8 @@ function hydrateStatusBarItems(ui: PersistedUIState): StatusBarItem[] {
     ['_kimiStatusBarDefaultAdded', DEFAULT_ON_KIMI_STATUS_BAR_ITEM],
     ['_minimaxStatusBarDefaultAdded', DEFAULT_ON_MINIMAX_STATUS_BAR_ITEM],
     ['_antigravityStatusBarDefaultAdded', DEFAULT_ON_ANTIGRAVITY_STATUS_BAR_ITEM],
-    ['_grokStatusBarDefaultAdded', DEFAULT_ON_GROK_STATUS_BAR_ITEM]
+    ['_grokStatusBarDefaultAdded', DEFAULT_ON_GROK_STATUS_BAR_ITEM],
+    ['_throughputStatusBarDefaultAdded', DEFAULT_ON_THROUGHPUT_STATUS_BAR_ITEM]
   ] as const
   for (const [flag, item] of defaults) {
     if (!ui[flag] && !items.includes(item)) {

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -25,6 +25,7 @@ import type { RateLimitSlice } from './slices/rate-limits'
 import type { SshSlice } from './slices/ssh'
 import type { RuntimeEnvironmentSshSlice } from './slices/runtime-environment-ssh'
 import type { AgentStatusSlice } from './slices/agent-status'
+import type { AgentThroughputSlice } from './slices/agent-throughput'
 import type { PaneForegroundAgentSlice } from './slices/pane-foreground-agent'
 import type { DiffCommentsSlice } from './slices/diffComments'
 import type { DetectedAgentsSlice } from './slices/detected-agents'
@@ -69,6 +70,7 @@ export type AppState = RepoSlice &
   SshSlice &
   RuntimeEnvironmentSshSlice &
   AgentStatusSlice &
+  AgentThroughputSlice &
   PaneForegroundAgentSlice &
   DiffCommentsSlice &
   DetectedAgentsSlice &

--- a/src/renderer/src/web/preload-api/web-agent-status-api.ts
+++ b/src/renderer/src/web/preload-api/web-agent-status-api.ts
@@ -21,6 +21,12 @@ export function createWebAgentStatusApi(): Partial<PreloadApi> {
       retirePaneAuthority: () => {},
       restorePaneAuthority: () => {},
       transferPaneAuthority: () => {}
+    },
+    // Why: throughput samples come from the desktop's local hook server; the web client has none.
+    agentThroughput: {
+      onSet: () => noopUnsubscribe,
+      onClear: () => noopUnsubscribe,
+      getSnapshot: () => Promise.resolve([])
     }
   }
 }

--- a/src/renderer/src/web/web-preload-api-composition.test.ts
+++ b/src/renderer/src/web/web-preload-api-composition.test.ts
@@ -71,6 +71,7 @@ describe('web preload API composition', () => {
       'pwsh',
       'gitBash',
       'agentStatus',
+      'agentThroughput',
       'mobile',
       'telemetryTrack',
       'telemetrySetOptIn',

--- a/src/shared/agent-hook-listener-claude-transcript-throughput.test.ts
+++ b/src/shared/agent-hook-listener-claude-transcript-throughput.test.ts
@@ -8,7 +8,7 @@ import {
   readLastClaudeMessageThroughput
 } from './agent-hook-listener/claude-transcript-throughput'
 
-const BASE = Date.parse('2026-09-02T14:12:22.409Z')
+const BASE = Date.parse('2026-09-02T18:09:40.208Z')
 
 function at(offsetMs: number): string {
   return new Date(BASE + offsetMs).toISOString()
@@ -41,7 +41,12 @@ function assistantRow(args: {
   })
 }
 
-function plainRow(type: string, uuid: string, parentUuid: string | null, offsetMs: number): string {
+function row(
+  type: string,
+  uuid: string | null,
+  parentUuid: string | null,
+  offsetMs: number
+): string {
   return JSON.stringify({ type, uuid, parentUuid, timestamp: at(offsetMs) })
 }
 
@@ -62,52 +67,169 @@ afterEach(() => {
 })
 
 describe('claude transcript throughput', () => {
-  it('measures the newest message from its parent row to its last content-block row', () => {
+  it('starts at the first block’s parent row even when later-stamped rows were written mid-stream', () => {
+    // Why: the real shape — reminders are attached right before the request, queued input lands
+    // while the model streams, and the block rows are flushed together with their own timestamps.
     const transcriptPath = writeTranscript([
-      plainRow('user', 'u1', null, 0),
-      plainRow('attachment', 'att1', 'u1', 10),
       assistantRow({
-        uuid: 'a1',
+        uuid: 'p1',
+        parentUuid: null,
+        messageId: 'msg_prev',
+        offsetMs: -4_000,
+        outputTokens: 900,
+        block: 'tool_use'
+      }),
+      row('user', 'u0', 'p1', 0),
+      row('attachment', 'att0', 'u0', 17_821),
+      row('attachment', 'att1', 'att0', 17_823),
+      row('queue-operation', null, null, 37_087),
+      row('queue-operation', null, null, 77_803),
+      row('queue-operation', null, null, 115_171),
+      assistantRow({
+        uuid: 't1',
         parentUuid: 'att1',
         messageId: 'msg_1',
-        offsetMs: 32_000,
-        outputTokens: 2497,
+        offsetMs: 111_652,
+        outputTokens: 8393,
         block: 'thinking'
       }),
       assistantRow({
-        uuid: 'a2',
-        parentUuid: 'a1',
+        uuid: 't2',
+        parentUuid: 't1',
         messageId: 'msg_1',
-        offsetMs: 36_483,
-        outputTokens: 2497
+        offsetMs: 113_429,
+        outputTokens: 8393,
+        block: 'thinking'
       }),
-      plainRow('system', 's1', 'a2', 36_760)
+      assistantRow({
+        uuid: 'w1',
+        parentUuid: 't2',
+        messageId: 'msg_1',
+        offsetMs: 132_437,
+        outputTokens: 8393,
+        block: 'tool_use'
+      }),
+      assistantRow({
+        uuid: 'r1',
+        parentUuid: 'w1',
+        messageId: 'msg_1',
+        offsetMs: 132_685,
+        outputTokens: 8393,
+        block: 'tool_use'
+      }),
+      row('attachment', 'att2', 'r1', 132_662),
+      row('user', 'u1', 'w1', 132_902),
+      row('user', 'u2', 'r1', 133_394)
     ])
 
     expect(readLastClaudeMessageThroughput(transcriptPath)).toEqual({
       messageId: 'msg_1',
       model: 'claude-fable-5-1',
-      outputTokens: 2497,
-      generationMs: 36_473,
-      completedAt: BASE + 36_483
+      outputTokens: 8393,
+      generationMs: 132_685 - 17_823,
+      completedAt: BASE + 132_685
     })
+  })
+
+  it('spans a message whose tool results are interleaved with its blocks', () => {
+    const transcriptPath = writeTranscript([
+      row('user', 'u0', null, 0),
+      assistantRow({
+        uuid: 'a1',
+        parentUuid: 'u0',
+        messageId: 'msg_1',
+        offsetMs: 2_574,
+        outputTokens: 2108,
+        block: 'tool_use'
+      }),
+      row('user', 'r1', 'a1', 3_015),
+      assistantRow({
+        uuid: 'a2',
+        parentUuid: 'r1',
+        messageId: 'msg_1',
+        offsetMs: 5_557,
+        outputTokens: 2108,
+        block: 'tool_use'
+      }),
+      row('user', 'r2', 'a2', 6_033),
+      assistantRow({
+        uuid: 'a3',
+        parentUuid: 'r2',
+        messageId: 'msg_1',
+        offsetMs: 11_645,
+        outputTokens: 2108,
+        block: 'tool_use'
+      }),
+      row('user', 'r3', 'a3', 12_100)
+    ])
+
+    expect(readLastClaudeMessageThroughput(transcriptPath)).toMatchObject({
+      messageId: 'msg_1',
+      generationMs: 11_645,
+      completedAt: BASE + 11_645
+    })
+  })
+
+  it('prefers the last user row when the parent attachment carries a stale timestamp', () => {
+    const transcriptPath = writeTranscript([
+      row('user', 'u0', null, 10_000),
+      row('attachment', 'queued', 'u0', 2_000),
+      assistantRow({
+        uuid: 'a1',
+        parentUuid: 'queued',
+        messageId: 'msg_1',
+        offsetMs: 16_000,
+        outputTokens: 300
+      })
+    ])
+
+    expect(readLastClaudeMessageThroughput(transcriptPath)).toMatchObject({
+      generationMs: 6_000
+    })
+  })
+
+  it('falls back to the last user row, then to the previous message, when the parent is missing', () => {
+    const missingParent = writeTranscript([
+      row('user', 'u0', null, 0),
+      row('progress', 'pr', null, 500),
+      assistantRow({
+        uuid: 'a1',
+        parentUuid: 'missing',
+        messageId: 'msg_1',
+        offsetMs: 3_500,
+        outputTokens: 50
+      })
+    ])
+    expect(readLastClaudeMessageThroughput(missingParent)).toMatchObject({ generationMs: 3_500 })
+
+    const retryAfterError = writeTranscript([
+      assistantRow({ uuid: 'e1', parentUuid: null, messageId: 'msg_err', offsetMs: 0 }),
+      assistantRow({
+        uuid: 'a1',
+        parentUuid: 'missing',
+        messageId: 'msg_1',
+        offsetMs: 2_500,
+        outputTokens: 40
+      })
+    ])
+    expect(readLastClaudeMessageThroughput(retryAfterError)).toMatchObject({ generationMs: 2_500 })
   })
 
   it('skips sidechain rows and usage-less rows when picking the newest message', () => {
     const transcriptPath = writeTranscript([
-      plainRow('user', 'u1', null, 0),
+      row('user', 'u0', null, 0),
       assistantRow({
         uuid: 'a1',
-        parentUuid: 'u1',
+        parentUuid: 'u0',
         messageId: 'msg_1',
         offsetMs: 4_000,
         outputTokens: 120
       }),
-      plainRow('user', 'u2', 'a1', 5_000),
-      assistantRow({ uuid: 'a2', parentUuid: 'u2', messageId: 'msg_err', offsetMs: 6_000 }),
+      row('user', 'u1', 'a1', 5_000),
+      assistantRow({ uuid: 'e1', parentUuid: 'u1', messageId: 'msg_err', offsetMs: 6_000 }),
       assistantRow({
-        uuid: 'side',
-        parentUuid: 'elsewhere',
+        uuid: 's1',
+        parentUuid: 'x',
         messageId: 'msg_side',
         offsetMs: 7_000,
         outputTokens: 999,
@@ -122,44 +244,23 @@ describe('claude transcript throughput', () => {
     })
   })
 
-  it('falls back to the nearest earlier row when the parent row never appears', () => {
-    const transcriptPath = writeTranscript([
-      plainRow('progress', 'p1', null, 1_000),
-      assistantRow({
-        uuid: 'a1',
-        parentUuid: 'missing',
-        messageId: 'msg_1',
-        offsetMs: 3_500,
-        outputTokens: 50
-      })
-    ])
-
-    expect(readLastClaudeMessageThroughput(transcriptPath)).toMatchObject({
-      messageId: 'msg_1',
-      generationMs: 2_500
-    })
-  })
-
-  it('bounds the parent search and uses the nearest earlier row past the limit', () => {
-    const filler = Array.from({ length: 70 }, (_, index) =>
-      plainRow('progress', `p${index}`, 'u1', 100 + index)
+  it('bounds the walk once the start is known', () => {
+    const filler = Array.from({ length: 600 }, (_, index) =>
+      row('progress', `pr${index}`, null, 100 + index)
     )
     const transcriptPath = writeTranscript([
-      plainRow('user', 'u1', null, 0),
       ...filler,
+      row('user', 'u0', null, 1_000),
       assistantRow({
         uuid: 'a1',
-        parentUuid: 'u1',
+        parentUuid: 'u0',
         messageId: 'msg_1',
-        offsetMs: 2_000,
+        offsetMs: 3_000,
         outputTokens: 40
       })
     ])
 
-    expect(readLastClaudeMessageThroughput(transcriptPath)).toMatchObject({
-      messageId: 'msg_1',
-      generationMs: 2_000 - 169
-    })
+    expect(readLastClaudeMessageThroughput(transcriptPath)).toMatchObject({ generationMs: 2_000 })
   })
 
   it('returns undefined without a measurable message', () => {
@@ -167,21 +268,32 @@ describe('claude transcript throughput', () => {
       undefined
     )
     const noUsage = writeTranscript([
-      plainRow('user', 'u1', null, 0),
-      assistantRow({ uuid: 'a1', parentUuid: 'u1', messageId: 'msg_1', offsetMs: 500 })
+      row('user', 'u0', null, 0),
+      assistantRow({ uuid: 'a1', parentUuid: 'u0', messageId: 'msg_1', offsetMs: 500 })
     ])
     expect(readLastClaudeMessageThroughput(noUsage)).toBe(undefined)
     const sameInstant = writeTranscript([
-      plainRow('user', 'u1', null, 0),
+      row('user', 'u0', null, 0),
       assistantRow({
         uuid: 'a1',
-        parentUuid: 'u1',
+        parentUuid: 'u0',
         messageId: 'msg_1',
         offsetMs: 0,
         outputTokens: 5
       })
     ])
     expect(readLastClaudeMessageThroughput(sameInstant)).toBe(undefined)
+    const noStart = writeTranscript([
+      row('progress', 'pr', null, 0),
+      assistantRow({
+        uuid: 'a1',
+        parentUuid: 'missing',
+        messageId: 'msg_1',
+        offsetMs: 900,
+        outputTokens: 5
+      })
+    ])
+    expect(readLastClaudeMessageThroughput(noStart)).toBe(undefined)
     expect(createClaudeMessageThroughputExtractor().flush()).toBe(undefined)
   })
 

--- a/src/shared/agent-hook-listener-claude-transcript-throughput.test.ts
+++ b/src/shared/agent-hook-listener-claude-transcript-throughput.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createClaudeMessageThroughputExtractor,
+  parseClaudeTranscriptThroughputRow,
+  readLastClaudeMessageThroughput
+} from './agent-hook-listener/claude-transcript-throughput'
+
+const BASE = Date.parse('2026-09-02T14:12:22.409Z')
+
+function at(offsetMs: number): string {
+  return new Date(BASE + offsetMs).toISOString()
+}
+
+function assistantRow(args: {
+  uuid: string
+  parentUuid: string | null
+  messageId: string
+  offsetMs: number
+  outputTokens?: number
+  block?: string
+  isSidechain?: boolean
+}): string {
+  return JSON.stringify({
+    type: 'assistant',
+    uuid: args.uuid,
+    parentUuid: args.parentUuid,
+    timestamp: at(args.offsetMs),
+    isSidechain: args.isSidechain ?? false,
+    message: {
+      id: args.messageId,
+      model: 'claude-fable-5-1',
+      role: 'assistant',
+      content: [{ type: args.block ?? 'text', text: 'hi' }],
+      ...(args.outputTokens === undefined
+        ? {}
+        : { usage: { input_tokens: 101, output_tokens: args.outputTokens } })
+    }
+  })
+}
+
+function plainRow(type: string, uuid: string, parentUuid: string | null, offsetMs: number): string {
+  return JSON.stringify({ type, uuid, parentUuid, timestamp: at(offsetMs) })
+}
+
+const tmpDirs: string[] = []
+
+function writeTranscript(lines: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-claude-throughput-'))
+  tmpDirs.push(dir)
+  const transcriptPath = join(dir, 'transcript.jsonl')
+  writeFileSync(transcriptPath, `${lines.join('\n')}\n`)
+  return transcriptPath
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('claude transcript throughput', () => {
+  it('measures the newest message from its parent row to its last content-block row', () => {
+    const transcriptPath = writeTranscript([
+      plainRow('user', 'u1', null, 0),
+      plainRow('attachment', 'att1', 'u1', 10),
+      assistantRow({
+        uuid: 'a1',
+        parentUuid: 'att1',
+        messageId: 'msg_1',
+        offsetMs: 32_000,
+        outputTokens: 2497,
+        block: 'thinking'
+      }),
+      assistantRow({
+        uuid: 'a2',
+        parentUuid: 'a1',
+        messageId: 'msg_1',
+        offsetMs: 36_483,
+        outputTokens: 2497
+      }),
+      plainRow('system', 's1', 'a2', 36_760)
+    ])
+
+    expect(readLastClaudeMessageThroughput(transcriptPath)).toEqual({
+      messageId: 'msg_1',
+      model: 'claude-fable-5-1',
+      outputTokens: 2497,
+      generationMs: 36_473,
+      completedAt: BASE + 36_483
+    })
+  })
+
+  it('skips sidechain rows and usage-less rows when picking the newest message', () => {
+    const transcriptPath = writeTranscript([
+      plainRow('user', 'u1', null, 0),
+      assistantRow({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        messageId: 'msg_1',
+        offsetMs: 4_000,
+        outputTokens: 120
+      }),
+      plainRow('user', 'u2', 'a1', 5_000),
+      assistantRow({ uuid: 'a2', parentUuid: 'u2', messageId: 'msg_err', offsetMs: 6_000 }),
+      assistantRow({
+        uuid: 'side',
+        parentUuid: 'elsewhere',
+        messageId: 'msg_side',
+        offsetMs: 7_000,
+        outputTokens: 999,
+        isSidechain: true
+      })
+    ])
+
+    expect(readLastClaudeMessageThroughput(transcriptPath)).toMatchObject({
+      messageId: 'msg_1',
+      outputTokens: 120,
+      generationMs: 4_000
+    })
+  })
+
+  it('falls back to the nearest earlier row when the parent row never appears', () => {
+    const transcriptPath = writeTranscript([
+      plainRow('progress', 'p1', null, 1_000),
+      assistantRow({
+        uuid: 'a1',
+        parentUuid: 'missing',
+        messageId: 'msg_1',
+        offsetMs: 3_500,
+        outputTokens: 50
+      })
+    ])
+
+    expect(readLastClaudeMessageThroughput(transcriptPath)).toMatchObject({
+      messageId: 'msg_1',
+      generationMs: 2_500
+    })
+  })
+
+  it('bounds the parent search and uses the nearest earlier row past the limit', () => {
+    const filler = Array.from({ length: 70 }, (_, index) =>
+      plainRow('progress', `p${index}`, 'u1', 100 + index)
+    )
+    const transcriptPath = writeTranscript([
+      plainRow('user', 'u1', null, 0),
+      ...filler,
+      assistantRow({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        messageId: 'msg_1',
+        offsetMs: 2_000,
+        outputTokens: 40
+      })
+    ])
+
+    expect(readLastClaudeMessageThroughput(transcriptPath)).toMatchObject({
+      messageId: 'msg_1',
+      generationMs: 2_000 - 169
+    })
+  })
+
+  it('returns undefined without a measurable message', () => {
+    expect(readLastClaudeMessageThroughput(join(tmpdir(), 'orca-missing-transcript.jsonl'))).toBe(
+      undefined
+    )
+    const noUsage = writeTranscript([
+      plainRow('user', 'u1', null, 0),
+      assistantRow({ uuid: 'a1', parentUuid: 'u1', messageId: 'msg_1', offsetMs: 500 })
+    ])
+    expect(readLastClaudeMessageThroughput(noUsage)).toBe(undefined)
+    const sameInstant = writeTranscript([
+      plainRow('user', 'u1', null, 0),
+      assistantRow({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        messageId: 'msg_1',
+        offsetMs: 0,
+        outputTokens: 5
+      })
+    ])
+    expect(readLastClaudeMessageThroughput(sameInstant)).toBe(undefined)
+    expect(createClaudeMessageThroughputExtractor().flush()).toBe(undefined)
+  })
+
+  it('parses rows defensively', () => {
+    expect(parseClaudeTranscriptThroughputRow('not json')).toBe(null)
+    expect(parseClaudeTranscriptThroughputRow(JSON.stringify({ type: 'user' }))).toBe(null)
+    expect(
+      parseClaudeTranscriptThroughputRow(
+        JSON.stringify({
+          type: 'assistant',
+          timestamp: at(1_500),
+          message: { id: 'msg_1', usage: { output_tokens: 'many' } }
+        })
+      )
+    ).toEqual({
+      type: 'assistant',
+      uuid: null,
+      parentUuid: null,
+      timestamp: BASE + 1_500,
+      messageId: 'msg_1',
+      model: null,
+      outputTokens: 0
+    })
+  })
+})

--- a/src/shared/agent-hook-listener-codex-transcript-throughput.test.ts
+++ b/src/shared/agent-hook-listener-codex-transcript-throughput.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createCodexMessageThroughputExtractor,
+  parseCodexRolloutThroughputRow,
+  readLastCodexMessageThroughput
+} from './agent-hook-listener/codex-transcript-throughput'
+
+const BASE = Date.parse('2026-09-02T11:52:40.631Z')
+
+function at(offsetMs: number): string {
+  return new Date(BASE + offsetMs).toISOString()
+}
+
+function row(type: string, payload: Record<string, unknown>, offsetMs: number): string {
+  return JSON.stringify({ timestamp: at(offsetMs), type, payload })
+}
+
+function tokenCount(offsetMs: number, outputTokens: number, totalOutput: number): string {
+  return row(
+    'event_msg',
+    {
+      type: 'token_count',
+      info: {
+        total_token_usage: {
+          input_tokens: 1000,
+          output_tokens: totalOutput,
+          total_tokens: 1000 + totalOutput
+        },
+        last_token_usage: {
+          input_tokens: 500,
+          output_tokens: outputTokens,
+          total_tokens: 500 + outputTokens
+        }
+      },
+      rate_limits: null
+    },
+    offsetMs
+  )
+}
+
+/** The real rollout shape: model rows, then the tool output, then the call's token_count. */
+function realCallSequence(): string[] {
+  return [
+    row('response_item', { type: 'custom_tool_call_output', call_id: 'c1', output: 'ok' }, 0),
+    tokenCount(0, 184, 184),
+    row('event_msg', { type: 'agent_reasoning', text: 'thinking' }, 22_074),
+    row('response_item', { type: 'reasoning', summary: [] }, 22_087),
+    row('response_item', { type: 'reasoning', summary: [] }, 24_346),
+    row('response_item', { type: 'custom_tool_call', name: 'exec', input: 'ls' }, 29_293),
+    row(
+      'response_item',
+      { type: 'custom_tool_call_output', call_id: 'c2', output: 'files' },
+      32_443
+    ),
+    tokenCount(32_444, 696, 880),
+    tokenCount(33_213, 696, 880),
+    row('event_msg', { type: 'task_complete', last_agent_message: 'done' }, 33_226)
+  ]
+}
+
+const tmpDirs: string[] = []
+
+function writeRollout(lines: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-codex-throughput-'))
+  tmpDirs.push(dir)
+  const rolloutPath = join(dir, 'rollout.jsonl')
+  writeFileSync(rolloutPath, `${lines.join('\n')}\n`)
+  return rolloutPath
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('codex rollout throughput', () => {
+  it('measures the newest call from the previous snapshot to its last model row', () => {
+    expect(readLastCodexMessageThroughput(writeRollout(realCallSequence()))).toEqual({
+      messageId: 'codex:1000:880:1880',
+      model: null,
+      outputTokens: 696,
+      generationMs: 29_293,
+      completedAt: BASE + 29_293
+    })
+  })
+
+  it('ends a final assistant message at its message row and starts it at the tool output', () => {
+    const rolloutPath = writeRollout([
+      row('response_item', { type: 'function_call_output', call_id: 'c1', output: 'ok' }, 0),
+      tokenCount(1, 120, 120),
+      row('event_msg', { type: 'agent_message', message: 'All done.' }, 6_000),
+      row('response_item', { type: 'message', role: 'assistant', content: [] }, 6_000),
+      tokenCount(6_010, 40, 160),
+      row('event_msg', { type: 'task_complete' }, 6_020)
+    ])
+
+    expect(readLastCodexMessageThroughput(rolloutPath)).toMatchObject({
+      messageId: 'codex:1000:160:1160',
+      outputTokens: 40,
+      generationMs: 5_999,
+      completedAt: BASE + 6_000
+    })
+  })
+
+  it('starts the first call of a turn at the user message and ignores rate-limit snapshots', () => {
+    const rolloutPath = writeRollout([
+      row('turn_context', { cwd: 'C:/repo', model: 'gpt-5.5' }, 0),
+      row('event_msg', { type: 'user_message', message: 'go' }, 100),
+      row('response_item', { type: 'message', role: 'user', content: [] }, 100),
+      row('event_msg', { type: 'token_count', info: null, rate_limits: {} }, 150),
+      row('response_item', { type: 'reasoning', summary: [] }, 3_000),
+      row('response_item', { type: 'function_call', name: 'shell', arguments: '{}' }, 4_100),
+      row('response_item', { type: 'function_call_output', call_id: 'c1', output: 'ok' }, 4_500),
+      tokenCount(4_501, 90, 90)
+    ])
+
+    expect(readLastCodexMessageThroughput(rolloutPath)).toMatchObject({
+      outputTokens: 90,
+      generationMs: 4_000,
+      completedAt: BASE + 4_100
+    })
+  })
+
+  it('returns undefined without a measurable call', () => {
+    expect(readLastCodexMessageThroughput(join(tmpdir(), 'orca-missing-rollout.jsonl'))).toBe(
+      undefined
+    )
+    const snapshotOnly = writeRollout([tokenCount(0, 50, 50)])
+    expect(readLastCodexMessageThroughput(snapshotOnly)).toBe(undefined)
+    const noModelRows = writeRollout([
+      row('response_item', { type: 'function_call_output', call_id: 'c1', output: 'ok' }, 0),
+      tokenCount(5, 50, 50)
+    ])
+    expect(readLastCodexMessageThroughput(noModelRows)).toBe(undefined)
+    expect(createCodexMessageThroughputExtractor().flush()).toBe(undefined)
+  })
+
+  it('classifies rows defensively', () => {
+    expect(parseCodexRolloutThroughputRow('nope')).toBe(null)
+    expect(parseCodexRolloutThroughputRow(JSON.stringify({ type: 'event_msg' }))).toBe(null)
+    expect(parseCodexRolloutThroughputRow(tokenCount(10, 5, 5))).toEqual({
+      kind: 'boundary',
+      timestamp: BASE + 10,
+      lastOutputTokens: 5,
+      totalsKey: '1000:5:1005'
+    })
+    expect(
+      parseCodexRolloutThroughputRow(
+        row('response_item', { type: 'message', role: 'assistant' }, 1)
+      )
+    ).toMatchObject({ kind: 'model' })
+    expect(
+      parseCodexRolloutThroughputRow(row('response_item', { type: 'message', role: 'user' }, 1))
+    ).toMatchObject({ kind: 'boundary' })
+    expect(
+      parseCodexRolloutThroughputRow(row('event_msg', { type: 'token_count', info: null }, 1))
+    ).toMatchObject({ kind: 'skip' })
+  })
+})

--- a/src/shared/agent-hook-listener-gemini-chat-throughput.test.ts
+++ b/src/shared/agent-hook-listener-gemini-chat-throughput.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  GEMINI_CHAT_MAX_BYTES,
+  measureLastGeminiMessage,
+  readLastGeminiMessageThroughput
+} from './agent-hook-listener/gemini-chat-throughput'
+
+const BASE = Date.parse('2026-03-20T16:09:15.486Z')
+
+function at(offsetMs: number): string {
+  return new Date(BASE + offsetMs).toISOString()
+}
+
+function geminiMessage(args: {
+  id: string
+  offsetMs: number
+  output?: number
+  thoughts?: number
+  withTokens?: boolean
+}): Record<string, unknown> {
+  return {
+    id: args.id,
+    timestamp: at(args.offsetMs),
+    type: 'gemini',
+    content: 'reply',
+    thoughts: [],
+    model: 'gemini-3-pro',
+    ...(args.withTokens === false
+      ? {}
+      : {
+          tokens: {
+            input: 53_972,
+            output: args.output ?? 71,
+            cached: 33_890,
+            thoughts: args.thoughts ?? 53,
+            tool: 0,
+            total: 54_096
+          }
+        })
+  }
+}
+
+function userMessage(id: string, offsetMs: number): Record<string, unknown> {
+  return { id, timestamp: at(offsetMs), type: 'user', content: 'go' }
+}
+
+const tmpDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('gemini chat throughput', () => {
+  it('measures the newest gemini message from the message before it', () => {
+    const messages = [
+      userMessage('u1', 0),
+      geminiMessage({ id: 'g1', offsetMs: 8_241, output: 400, thoughts: 100 }),
+      geminiMessage({ id: 'g2', offsetMs: 11_617, output: 71, thoughts: 53 })
+    ]
+    expect(measureLastGeminiMessage(messages)).toEqual({
+      messageId: 'g2',
+      model: 'gemini-3-pro',
+      outputTokens: 124,
+      generationMs: 3_376,
+      completedAt: BASE + 11_617
+    })
+  })
+
+  it('skips gemini messages without usage and gives up without an earlier timestamp', () => {
+    expect(
+      measureLastGeminiMessage([
+        userMessage('u1', 0),
+        geminiMessage({ id: 'g1', offsetMs: 2_000, output: 10 }),
+        geminiMessage({ id: 'g2', offsetMs: 3_000, withTokens: false })
+      ])
+    ).toMatchObject({ messageId: 'g1', generationMs: 2_000 })
+    expect(measureLastGeminiMessage([geminiMessage({ id: 'g1', offsetMs: 2_000 })])).toBe(undefined)
+    expect(
+      measureLastGeminiMessage([
+        userMessage('u1', 5_000),
+        geminiMessage({ id: 'g1', offsetMs: 5_000 })
+      ])
+    ).toBe(undefined)
+    expect(measureLastGeminiMessage([null, 'text', { type: 'user' }])).toBe(undefined)
+  })
+
+  it('reads the chat file and refuses missing, malformed, or oversized files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-gemini-throughput-'))
+    tmpDirs.push(dir)
+    const chatPath = join(dir, 'session.json')
+    writeFileSync(
+      chatPath,
+      JSON.stringify({
+        sessionId: 's1',
+        messages: [
+          userMessage('u1', 0),
+          geminiMessage({ id: 'g1', offsetMs: 1_500, output: 30, thoughts: 0 })
+        ]
+      })
+    )
+    expect(readLastGeminiMessageThroughput(chatPath)).toMatchObject({
+      messageId: 'g1',
+      outputTokens: 30,
+      generationMs: 1_500
+    })
+
+    writeFileSync(chatPath, '{not json')
+    expect(readLastGeminiMessageThroughput(chatPath)).toBe(undefined)
+    expect(readLastGeminiMessageThroughput(join(dir, 'missing.json'))).toBe(undefined)
+    expect(GEMINI_CHAT_MAX_BYTES).toBeGreaterThan(1024 * 1024)
+  })
+})

--- a/src/shared/agent-hook-listener-grok-session-throughput.test.ts
+++ b/src/shared/agent-hook-listener-grok-session-throughput.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createGrokCallTextExtractor,
+  createGrokLoopTimingExtractor,
+  estimateGrokOutputTokens,
+  readLastGrokMessageThroughput
+} from './agent-hook-listener/grok-session-throughput'
+
+const BASE = Date.parse('2026-09-02T13:56:11.030Z')
+
+function at(offsetMs: number): string {
+  return new Date(BASE + offsetMs).toISOString()
+}
+
+function event(type: string, offsetMs: number, extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({ ts: at(offsetMs), type, ...extra })
+}
+
+function tick(phase: string, offsetMs: number): string {
+  return event('phase_changed', offsetMs, { phase })
+}
+
+function assistantRow(content: string, toolArguments: string[] = []): string {
+  return JSON.stringify({
+    type: 'assistant',
+    content,
+    model_id: 'grok-4.6',
+    tool_calls: toolArguments.map((args, index) => ({
+      id: `call-${index}`,
+      name: 'read_file',
+      arguments: args
+    }))
+  })
+}
+
+function reasoningRow(summaryText: string, encryptedLength: number): string {
+  return JSON.stringify({
+    type: 'reasoning',
+    id: 'rs_1',
+    summary: [{ type: 'summary_text', text: summaryText }],
+    encrypted_content: 'x'.repeat(encryptedLength)
+  })
+}
+
+const tmpDirs: string[] = []
+
+function writeSession(events: string[], chat: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-grok-throughput-'))
+  tmpDirs.push(dir)
+  writeFileSync(join(dir, 'events.jsonl'), `${events.join('\n')}\n`)
+  const chatPath = join(dir, 'chat_history.jsonl')
+  writeFileSync(chatPath, `${chat.join('\n')}\n`)
+  return chatPath
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('grok session throughput', () => {
+  it('estimates the newest completed call from its loop timing and text length', () => {
+    const chatPath = writeSession(
+      [
+        event('turn_started', -5_000, { model_id: 'grok-4.6' }),
+        event('loop_started', -4_000, { loop_index: 21 }),
+        tick('streaming_reasoning', -3_000),
+        event('permission_requested', -2_500),
+        event('permission_resolved', -1_000),
+        event('tool_started', -900, { tool: 'read_file' }),
+        event('tool_completed', -100),
+        event('loop_started', 0, { loop_index: 22 }),
+        tick('waiting_for_model', 1),
+        event('first_token', 1_513),
+        tick('streaming_reasoning', 1_513),
+        tick('streaming_text', 2_000),
+        tick('streaming_text', 15_000),
+        event('turn_ended', 15_608, { outcome: 'completed' })
+      ],
+      [
+        JSON.stringify({ type: 'user', content: 'go' }),
+        reasoningRow('short plan', 400),
+        assistantRow('', ['{"target_file":"a.cpp"}']),
+        JSON.stringify({ type: 'tool_result', tool_call_id: 'call-0', content: 'file body' }),
+        reasoningRow('final summary', 132),
+        assistantRow('x'.repeat(2121))
+      ]
+    )
+
+    const result = readLastGrokMessageThroughput(chatPath)
+    // Why: (2121 + 13 + 132 * 0.75) / 4 ≈ 558 tokens over the whole loop, permission waits excluded.
+    expect(result).toEqual({
+      messageId: `grok:${BASE}`,
+      model: 'grok-4.6',
+      outputTokens: 558,
+      generationMs: 15_608,
+      completedAt: BASE + 15_608,
+      estimated: true
+    })
+  })
+
+  it('ends a tool-calling loop at its permission prompt and skips a loop still streaming', () => {
+    const chatPath = writeSession(
+      [
+        event('loop_started', 0, { loop_index: 1 }),
+        tick('streaming_reasoning', 1_200),
+        event('permission_requested', 9_000),
+        event('permission_resolved', 40_000),
+        event('tool_started', 40_100),
+        event('tool_completed', 41_000),
+        event('loop_started', 41_050, { loop_index: 2 }),
+        tick('streaming_text', 42_000)
+      ],
+      [
+        JSON.stringify({ type: 'user', content: 'go' }),
+        reasoningRow('think', 800),
+        assistantRow('', ['{"path":"x"}']),
+        JSON.stringify({ type: 'tool_result', tool_call_id: 'call-0', content: 'ok' })
+      ]
+    )
+
+    expect(readLastGrokMessageThroughput(chatPath)).toMatchObject({
+      messageId: `grok:${BASE}`,
+      generationMs: 9_000,
+      // Why: (12 + 5 + 800 * 0.75) / 4 = 154.25 → 154
+      outputTokens: 154
+    })
+  })
+
+  it('returns undefined without a completed loop, without chat text, or without files', () => {
+    const streamingOnly = writeSession(
+      [event('loop_started', 0, { loop_index: 1 }), tick('streaming_text', 500)],
+      [assistantRow('hello')]
+    )
+    expect(readLastGrokMessageThroughput(streamingOnly)).toBe(undefined)
+
+    const noAssistant = writeSession(
+      [event('loop_started', 0, { loop_index: 1 }), event('turn_ended', 2_000)],
+      [JSON.stringify({ type: 'user', content: 'go' })]
+    )
+    expect(readLastGrokMessageThroughput(noAssistant)).toBe(undefined)
+
+    expect(
+      readLastGrokMessageThroughput(join(tmpdir(), 'orca-missing', 'chat_history.jsonl'))
+    ).toBe(undefined)
+  })
+
+  it('exposes its extractors and estimate for reuse', () => {
+    const timing = createGrokLoopTimingExtractor()
+    expect(timing.visit('not json')).toBe(undefined)
+    expect(timing.visit(event('turn_ended', 10))).toBe(undefined)
+    expect(timing.visit(event('loop_started', 0, { loop_index: 3 }))).toEqual({
+      loopIndex: 3,
+      startedAt: BASE,
+      endedAt: BASE + 10
+    })
+
+    const text = createGrokCallTextExtractor()
+    expect(text.visit(assistantRow('abcd', ['{}']))).toBe(undefined)
+    expect(text.visit(reasoningRow('ef', 8))).toBe(undefined)
+    expect(text.visit(JSON.stringify({ type: 'tool_result' }))).toEqual({
+      model: 'grok-4.6',
+      visibleChars: 8,
+      encryptedReasoningChars: 8
+    })
+    expect(text.flush()).toBe(undefined)
+    expect(
+      estimateGrokOutputTokens({ model: null, visibleChars: 10, encryptedReasoningChars: 8 })
+    ).toBe(4)
+  })
+})

--- a/src/shared/agent-hook-listener/claude-transcript-throughput.ts
+++ b/src/shared/agent-hook-listener/claude-transcript-throughput.ts
@@ -1,0 +1,159 @@
+import { parseAgentHookJson } from './request-body'
+import { readLastExtractedFromTranscriptOnce } from './transcript-reader'
+
+/** Fields of one Claude Code transcript row that throughput measurement reads. */
+export type ClaudeTranscriptThroughputRow = {
+  type: string
+  uuid: string | null
+  parentUuid: string | null
+  timestamp: number
+  messageId: string | null
+  model: string | null
+  outputTokens: number
+}
+
+export type ClaudeMessageThroughput = {
+  messageId: string
+  model: string | null
+  outputTokens: number
+  generationMs: number
+  completedAt: number
+}
+
+// Why: the parent row can sit behind unrelated rows (attachments, hook progress); bound the walk so
+// a broken chain falls back to the nearest earlier row instead of scanning to the file start.
+const PARENT_ROW_LOOKBACK_LIMIT = 64
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
+}
+
+function readTimestamp(value: unknown): number {
+  if (typeof value === 'number') {
+    return value
+  }
+  return typeof value === 'string' ? Date.parse(value) : Number.NaN
+}
+
+export function parseClaudeTranscriptThroughputRow(
+  line: string
+): ClaudeTranscriptThroughputRow | null {
+  let entry: unknown
+  try {
+    entry = parseAgentHookJson(line)
+  } catch {
+    return null
+  }
+  const record = readObject(entry)
+  if (!record) {
+    return null
+  }
+  const type = readString(record, 'type')
+  const timestamp = readTimestamp(record.timestamp)
+  // Why: sidechain rows belong to a subagent's own parent chain, so they are neither a sample nor a start row.
+  if (!type || !Number.isFinite(timestamp) || record.isSidechain === true) {
+    return null
+  }
+  const message = readObject(record.message)
+  const outputTokens = readObject(message?.usage)?.output_tokens
+  return {
+    type,
+    uuid: readString(record, 'uuid'),
+    parentUuid: readString(record, 'parentUuid'),
+    timestamp,
+    messageId: message ? readString(message, 'id') : null,
+    model: message ? readString(message, 'model') : null,
+    outputTokens:
+      typeof outputTokens === 'number' && Number.isFinite(outputTokens) && outputTokens > 0
+        ? outputTokens
+        : 0
+  }
+}
+
+type PendingMessage = {
+  messageId: string
+  model: string | null
+  outputTokens: number
+  completedAt: number
+  parentUuid: string | null
+}
+
+export type ClaudeMessageThroughputExtractor = {
+  /** Visits transcript lines newest-first; yields once the newest message's start row is known. */
+  visit: (line: string) => ClaudeMessageThroughput | undefined
+  /** Resolves against the nearest earlier row when the scan ended before the parent row was seen. */
+  flush: () => ClaudeMessageThroughput | undefined
+}
+
+export function createClaudeMessageThroughputExtractor(): ClaudeMessageThroughputExtractor {
+  let pending: PendingMessage | null = null
+  let nearestEarlierRowAt: number | null = null
+  let rowsPastMessage = 0
+
+  const finish = (startedAt: number | null): ClaudeMessageThroughput | undefined => {
+    if (!pending || startedAt === null) {
+      return undefined
+    }
+    const generationMs = pending.completedAt - startedAt
+    if (!(generationMs > 0)) {
+      return undefined
+    }
+    return {
+      messageId: pending.messageId,
+      model: pending.model,
+      outputTokens: pending.outputTokens,
+      generationMs,
+      completedAt: pending.completedAt
+    }
+  }
+
+  return {
+    visit: (line) => {
+      const row = parseClaudeTranscriptThroughputRow(line)
+      if (!row) {
+        return undefined
+      }
+      if (!pending) {
+        // Why: rows without usage (API-error placeholders) carry no generation to measure; keep scanning.
+        if (row.type !== 'assistant' || !row.messageId || row.outputTokens <= 0) {
+          return undefined
+        }
+        pending = {
+          messageId: row.messageId,
+          model: row.model,
+          outputTokens: row.outputTokens,
+          completedAt: row.timestamp,
+          parentUuid: row.parentUuid
+        }
+        return undefined
+      }
+      if (row.type === 'assistant' && row.messageId === pending.messageId) {
+        // Why: Claude Code writes one row per content block; the earliest row's parent is the message's start.
+        pending.parentUuid = row.parentUuid
+        pending.outputTokens = Math.max(pending.outputTokens, row.outputTokens)
+        pending.model ??= row.model
+        return undefined
+      }
+      rowsPastMessage += 1
+      if (row.uuid && row.uuid === pending.parentUuid) {
+        return finish(row.timestamp)
+      }
+      nearestEarlierRowAt ??= row.timestamp
+      return rowsPastMessage >= PARENT_ROW_LOOKBACK_LIMIT ? finish(nearestEarlierRowAt) : undefined
+    },
+    flush: () => finish(nearestEarlierRowAt)
+  }
+}
+
+/** Throughput of the newest completed assistant message in a Claude Code transcript. */
+export function readLastClaudeMessageThroughput(
+  transcriptPath: string
+): ClaudeMessageThroughput | undefined {
+  const extractor = createClaudeMessageThroughputExtractor()
+  return readLastExtractedFromTranscriptOnce(transcriptPath, extractor.visit) ?? extractor.flush()
+}

--- a/src/shared/agent-hook-listener/claude-transcript-throughput.ts
+++ b/src/shared/agent-hook-listener/claude-transcript-throughput.ts
@@ -15,9 +15,10 @@ export type ClaudeTranscriptThroughputRow = {
 
 export type ClaudeMessageThroughput = AgentMessageThroughput
 
-// Why: the parent row can sit behind unrelated rows (attachments, hook progress); bound the walk so
-// a broken chain falls back to the nearest earlier row instead of scanning to the file start.
-const PARENT_ROW_LOOKBACK_LIMIT = 64
+// Why: a message's blocks are interleaved with the results of the tools it calls, so the walk
+// back to the previous assistant message can cross many rows; bound it instead of scanning to
+// the file start.
+const ROW_LOOKBACK_LIMIT = 512
 
 function readString(record: Record<string, unknown>, key: string): string | null {
   const value = record[key]
@@ -50,7 +51,7 @@ export function parseClaudeTranscriptThroughputRow(
   }
   const type = readString(record, 'type')
   const timestamp = readTimestamp(record.timestamp)
-  // Why: sidechain rows belong to a subagent's own parent chain, so they are neither a sample nor a start row.
+  // Why: sidechain rows belong to a subagent's own conversation, so they neither end nor start a message here.
   if (!type || !Number.isFinite(timestamp) || record.isSidechain === true) {
     return null
   }
@@ -75,20 +76,36 @@ type PendingMessage = {
   model: string | null
   outputTokens: number
   completedAt: number
-  parentUuid: string | null
 }
 
 export type ClaudeMessageThroughputExtractor = {
-  /** Visits transcript lines newest-first; yields once the newest message's start row is known. */
+  /** Visits transcript lines newest-first; yields once the previous assistant message is reached. */
   visit: (line: string) => ClaudeMessageThroughput | undefined
-  /** Resolves against the nearest earlier row when the scan ended before the parent row was seen. */
+  /** Resolves against the rows seen so far when the scan ended before a previous message appeared. */
   flush: () => ClaudeMessageThroughput | undefined
 }
 
+/**
+ * Claude Code writes one row per content block, stamped with the block's completion time, and
+ * flushes rows in batches while tool calls already run, so a message's rows are interleaved with
+ * its own tool results and with rows written mid-stream (queued input, reminders) that can carry
+ * later timestamps. The message ends at its last block. It starts at the row its first block
+ * points to via `parentUuid` — the last row prepared before the API request — or, when that row
+ * carries a stale timestamp, at the last user row before the message, whichever is later.
+ */
 export function createClaudeMessageThroughputExtractor(): ClaudeMessageThroughputExtractor {
   let pending: PendingMessage | null = null
-  let nearestEarlierRowAt: number | null = null
+  let wantedParentUuid: string | null = null
+  let parentStartAt: number | null = null
+  let lastUserRowAt: number | null = null
   let rowsPastMessage = 0
+
+  const resolveStart = (fallback: number | null): number | null => {
+    if (parentStartAt !== null && lastUserRowAt !== null) {
+      return Math.max(parentStartAt, lastUserRowAt)
+    }
+    return parentStartAt ?? lastUserRowAt ?? fallback
+  }
 
   const finish = (startedAt: number | null): ClaudeMessageThroughput | undefined => {
     if (!pending || startedAt === null) {
@@ -122,26 +139,34 @@ export function createClaudeMessageThroughputExtractor(): ClaudeMessageThroughpu
           messageId: row.messageId,
           model: row.model,
           outputTokens: row.outputTokens,
-          completedAt: row.timestamp,
-          parentUuid: row.parentUuid
+          completedAt: row.timestamp
         }
+        wantedParentUuid = row.parentUuid
         return undefined
       }
-      if (row.type === 'assistant' && row.messageId === pending.messageId) {
-        // Why: Claude Code writes one row per content block; the earliest row's parent is the message's start.
-        pending.parentUuid = row.parentUuid
-        pending.outputTokens = Math.max(pending.outputTokens, row.outputTokens)
-        pending.model ??= row.model
-        return undefined
+      if (row.type === 'assistant') {
+        if (row.messageId === pending.messageId) {
+          // Why: an earlier block of the same message; everything seen since belonged inside it.
+          pending.outputTokens = Math.max(pending.outputTokens, row.outputTokens)
+          pending.model ??= row.model
+          wantedParentUuid = row.parentUuid
+          parentStartAt = null
+          lastUserRowAt = null
+          return undefined
+        }
+        // Why: the previous assistant message bounds this one; with nothing in between (API retry), its last row is the start.
+        return finish(resolveStart(row.timestamp))
+      }
+      if (row.uuid !== null && row.uuid === wantedParentUuid) {
+        parentStartAt = row.timestamp
+      }
+      if (row.type === 'user') {
+        lastUserRowAt = Math.max(lastUserRowAt ?? Number.NEGATIVE_INFINITY, row.timestamp)
       }
       rowsPastMessage += 1
-      if (row.uuid && row.uuid === pending.parentUuid) {
-        return finish(row.timestamp)
-      }
-      nearestEarlierRowAt ??= row.timestamp
-      return rowsPastMessage >= PARENT_ROW_LOOKBACK_LIMIT ? finish(nearestEarlierRowAt) : undefined
+      return rowsPastMessage >= ROW_LOOKBACK_LIMIT ? finish(resolveStart(null)) : undefined
     },
-    flush: () => finish(nearestEarlierRowAt)
+    flush: () => finish(resolveStart(null))
   }
 }
 

--- a/src/shared/agent-hook-listener/claude-transcript-throughput.ts
+++ b/src/shared/agent-hook-listener/claude-transcript-throughput.ts
@@ -1,3 +1,4 @@
+import type { AgentMessageThroughput } from '../agent-throughput-types'
 import { parseAgentHookJson } from './request-body'
 import { readLastExtractedFromTranscriptOnce } from './transcript-reader'
 
@@ -12,13 +13,7 @@ export type ClaudeTranscriptThroughputRow = {
   outputTokens: number
 }
 
-export type ClaudeMessageThroughput = {
-  messageId: string
-  model: string | null
-  outputTokens: number
-  generationMs: number
-  completedAt: number
-}
+export type ClaudeMessageThroughput = AgentMessageThroughput
 
 // Why: the parent row can sit behind unrelated rows (attachments, hook progress); bound the walk so
 // a broken chain falls back to the nearest earlier row instead of scanning to the file start.

--- a/src/shared/agent-hook-listener/codex-transcript-throughput.ts
+++ b/src/shared/agent-hook-listener/codex-transcript-throughput.ts
@@ -1,0 +1,196 @@
+import type { AgentMessageThroughput } from '../agent-throughput-types'
+import { parseAgentHookJson } from './request-body'
+import { readLastExtractedFromTranscriptOnce } from './transcript-reader'
+
+/**
+ * One Codex rollout row, classified for throughput measurement.
+ *
+ * Codex writes rows in this order per model call: the call's own rows (reasoning, message,
+ * function call), then the tool's output, then a `token_count` snapshot for that call. So the
+ * call ends at its last model row, not at the snapshot, and starts at the row before its first
+ * model row (the previous tool output, the user's message, or the previous snapshot).
+ */
+export type CodexRolloutThroughputRow = {
+  kind: 'model' | 'boundary' | 'skip'
+  timestamp: number
+  /** `last_token_usage.output_tokens` of a token_count row; 0 for every other row. */
+  lastOutputTokens: number
+  /** Cumulative totals of a token_count row; identical on Codex's duplicate emissions. */
+  totalsKey: string | null
+}
+
+// Why: a snapshot without a preceding boundary row is malformed; bound the walk instead of
+// scanning to the file start (rollouts grow past a gigabyte).
+const BOUNDARY_ROW_LOOKBACK_LIMIT = 64
+
+const MODEL_RESPONSE_ITEMS: ReadonlySet<string> = new Set([
+  'reasoning',
+  'function_call',
+  'custom_tool_call',
+  'local_shell_call',
+  'web_search_call'
+])
+const MODEL_EVENTS: ReadonlySet<string> = new Set([
+  'agent_reasoning',
+  'agent_reasoning_section_break',
+  'agent_reasoning_raw_content',
+  'agent_message'
+])
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function readCount(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0
+}
+
+function classifyRow(
+  type: string,
+  payloadType: string | null,
+  role: string | null
+): CodexRolloutThroughputRow['kind'] {
+  if (type === 'response_item') {
+    const isModel =
+      (payloadType !== null && MODEL_RESPONSE_ITEMS.has(payloadType)) ||
+      (payloadType === 'message' && role === 'assistant')
+    return isModel ? 'model' : 'boundary'
+  }
+  if (type === 'event_msg') {
+    return payloadType !== null && MODEL_EVENTS.has(payloadType) ? 'model' : 'boundary'
+  }
+  return 'boundary'
+}
+
+export function parseCodexRolloutThroughputRow(line: string): CodexRolloutThroughputRow | null {
+  let entry: unknown
+  try {
+    entry = parseAgentHookJson(line)
+  } catch {
+    return null
+  }
+  const record = readObject(entry)
+  const type = record ? readString(record, 'type') : null
+  const timestamp =
+    typeof record?.timestamp === 'string' ? Date.parse(record.timestamp) : Number.NaN
+  if (!record || !type || !Number.isFinite(timestamp)) {
+    return null
+  }
+  const payload = readObject(record.payload)
+  const payloadType = payload ? readString(payload, 'type') : null
+  if (type !== 'event_msg' || payloadType !== 'token_count') {
+    return {
+      kind: classifyRow(type, payloadType, payload ? readString(payload, 'role') : null),
+      timestamp,
+      lastOutputTokens: 0,
+      totalsKey: null
+    }
+  }
+  const info = readObject(payload?.info)
+  const totals = readObject(info?.total_token_usage)
+  const last = readObject(info?.last_token_usage)
+  if (!totals || !last) {
+    // Why: rate-limit refreshes reuse token_count with null info; they are not call boundaries.
+    return { kind: 'skip', timestamp, lastOutputTokens: 0, totalsKey: null }
+  }
+  return {
+    kind: 'boundary',
+    timestamp,
+    lastOutputTokens: readCount(last.output_tokens),
+    totalsKey: `${readCount(totals.input_tokens)}:${readCount(totals.output_tokens)}:${readCount(totals.total_tokens)}`
+  }
+}
+
+type PendingCall = {
+  totalsKey: string
+  outputTokens: number
+  /** Timestamp of the call's last model row once phase 2 begins; null while still in phase 1. */
+  completedAt: number | null
+}
+
+export type CodexMessageThroughputExtractor = {
+  /** Visits rollout lines newest-first; yields once the newest call's boundary row is known. */
+  visit: (line: string) => AgentMessageThroughput | undefined
+  /** Resolves against the nearest earlier row when the scan ended before a boundary was seen. */
+  flush: () => AgentMessageThroughput | undefined
+}
+
+export function createCodexMessageThroughputExtractor(): CodexMessageThroughputExtractor {
+  let pending: PendingCall | null = null
+  let nearestEarlierRowAt: number | null = null
+  let rowsPastCompletion = 0
+
+  const finish = (startedAt: number | null): AgentMessageThroughput | undefined => {
+    if (!pending || pending.completedAt === null || startedAt === null) {
+      return undefined
+    }
+    const generationMs = pending.completedAt - startedAt
+    if (!(generationMs > 0)) {
+      return undefined
+    }
+    return {
+      // Why: token_count rows carry no id; cumulative totals are unique per completed call.
+      messageId: `codex:${pending.totalsKey}`,
+      model: null,
+      outputTokens: pending.outputTokens,
+      generationMs,
+      completedAt: pending.completedAt
+    }
+  }
+
+  return {
+    visit: (line) => {
+      const row = parseCodexRolloutThroughputRow(line)
+      if (!row || row.kind === 'skip') {
+        return undefined
+      }
+      if (!pending) {
+        if (row.totalsKey && row.lastOutputTokens > 0) {
+          pending = {
+            totalsKey: row.totalsKey,
+            outputTokens: row.lastOutputTokens,
+            completedAt: null
+          }
+        }
+        return undefined
+      }
+      if (row.totalsKey === pending.totalsKey) {
+        // Why: Codex re-emits the same snapshot; both sit after the call's rows.
+        return undefined
+      }
+      if (pending.completedAt === null) {
+        // Phase 1: the tool output written after the call is not part of it; the first model row is.
+        if (row.kind === 'model') {
+          pending.completedAt = row.timestamp
+        }
+        return undefined
+      }
+      // Phase 2: the call's own rows continue until the previous boundary.
+      if (row.kind === 'model') {
+        return undefined
+      }
+      rowsPastCompletion += 1
+      nearestEarlierRowAt ??= row.timestamp
+      return (
+        finish(row.timestamp) ??
+        (rowsPastCompletion >= BOUNDARY_ROW_LOOKBACK_LIMIT
+          ? finish(nearestEarlierRowAt)
+          : undefined)
+      )
+    },
+    flush: () => finish(nearestEarlierRowAt)
+  }
+}
+
+/** Throughput of the newest completed model call in a Codex rollout transcript. */
+export function readLastCodexMessageThroughput(
+  transcriptPath: string
+): AgentMessageThroughput | undefined {
+  const extractor = createCodexMessageThroughputExtractor()
+  return readLastExtractedFromTranscriptOnce(transcriptPath, extractor.visit) ?? extractor.flush()
+}

--- a/src/shared/agent-hook-listener/gemini-chat-throughput.ts
+++ b/src/shared/agent-hook-listener/gemini-chat-throughput.ts
@@ -1,0 +1,75 @@
+import { readFileSync, statSync } from 'node:fs'
+import type { AgentMessageThroughput } from '../agent-throughput-types'
+
+// Why: a chat file is one JSON document, so it must be read whole; skip runaway sessions instead
+// of parsing tens of megabytes on every hook.
+export const GEMINI_CHAT_MAX_BYTES = 32 * 1024 * 1024
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
+}
+
+function readCount(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0
+}
+
+function readTimestamp(value: unknown): number {
+  return typeof value === 'string' ? Date.parse(value) : Number.NaN
+}
+
+/**
+ * Newest Gemini CLI message with token usage, timed from the message before it. Gemini writes
+ * one message per model call; tool calls run between consecutive `gemini` messages.
+ */
+export function measureLastGeminiMessage(
+  messages: readonly unknown[]
+): AgentMessageThroughput | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = readObject(messages[index])
+    if (!message || message.type !== 'gemini') {
+      continue
+    }
+    const tokens = readObject(message.tokens)
+    const outputTokens = readCount(tokens?.output) + readCount(tokens?.thoughts)
+    const completedAt = readTimestamp(message.timestamp)
+    if (!tokens || outputTokens <= 0 || !Number.isFinite(completedAt)) {
+      continue
+    }
+    for (let previous = index - 1; previous >= 0; previous -= 1) {
+      const startedAt = readTimestamp(readObject(messages[previous])?.timestamp)
+      if (!Number.isFinite(startedAt)) {
+        continue
+      }
+      const generationMs = completedAt - startedAt
+      if (!(generationMs > 0)) {
+        return undefined
+      }
+      return {
+        messageId:
+          typeof message.id === 'string' && message.id ? message.id : `gemini:${completedAt}`,
+        model: typeof message.model === 'string' && message.model ? message.model : null,
+        outputTokens,
+        generationMs,
+        completedAt
+      }
+    }
+    return undefined
+  }
+  return undefined
+}
+
+/** Throughput of the newest completed message in a Gemini CLI chat transcript (JSON). */
+export function readLastGeminiMessageThroughput(
+  transcriptPath: string
+): AgentMessageThroughput | undefined {
+  let messages: unknown
+  try {
+    if (statSync(transcriptPath).size > GEMINI_CHAT_MAX_BYTES) {
+      return undefined
+    }
+    messages = readObject(JSON.parse(readFileSync(transcriptPath, 'utf8')))?.messages
+  } catch {
+    return undefined
+  }
+  return Array.isArray(messages) ? measureLastGeminiMessage(messages) : undefined
+}

--- a/src/shared/agent-hook-listener/grok-session-throughput.ts
+++ b/src/shared/agent-hook-listener/grok-session-throughput.ts
@@ -1,0 +1,170 @@
+import { dirname, join } from 'node:path'
+import type { AgentMessageThroughput } from '../agent-throughput-types'
+import { parseAgentHookJson } from './request-body'
+import { readLastExtractedFromTranscriptOnce } from './transcript-reader'
+
+/**
+ * Grok CLI reports no token counts anywhere on disk. `events.jsonl` times each model call
+ * (`loop_started` → the first of permission_requested / tool_started / turn_ended) and
+ * `chat_history.jsonl` holds what it produced, so the call's tokens are ESTIMATED from text
+ * length: visible text and tool arguments plus the reasoning the CLI keeps only as an
+ * encrypted blob whose size tracks the hidden reasoning. Roughly four characters per token.
+ */
+export const GROK_EVENTS_FILE = 'events.jsonl'
+const CHARS_PER_TOKEN = 4
+// Why: the encrypted reasoning is base64; three quarters of its length is the ciphertext size,
+// which is the closest available proxy for the reasoning text the model generated.
+const BASE64_PAYLOAD_RATIO = 0.75
+const EVENT_ROW_LOOKBACK_LIMIT = 4096
+
+export type GrokModelCallTiming = {
+  loopIndex: number | null
+  startedAt: number
+  endedAt: number
+}
+
+export type GrokModelCallText = {
+  model: string | null
+  visibleChars: number
+  encryptedReasoningChars: number
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
+}
+
+function parseJsonObject(line: string): Record<string, unknown> | null {
+  try {
+    return readObject(parseAgentHookJson(line))
+  } catch {
+    return null
+  }
+}
+
+function stringLength(value: unknown): number {
+  return typeof value === 'string' ? value.length : 0
+}
+
+/** Backwards walk over events.jsonl that yields the newest model call which already ended. */
+export function createGrokLoopTimingExtractor(): {
+  visit: (line: string) => GrokModelCallTiming | undefined
+} {
+  let endedAt: number | null = null
+  let rowsSeen = 0
+  return {
+    visit: (line) => {
+      const record = parseJsonObject(line)
+      const type = typeof record?.type === 'string' ? record.type : null
+      const timestamp = typeof record?.ts === 'string' ? Date.parse(record.ts) : Number.NaN
+      if (!record || !type || !Number.isFinite(timestamp)) {
+        return undefined
+      }
+      rowsSeen += 1
+      if (rowsSeen > EVENT_ROW_LOOKBACK_LIMIT) {
+        // Why: bound the walk; a call this far back has no matching chat row worth reporting.
+        return undefined
+      }
+      if (type === 'loop_started') {
+        if (endedAt === null) {
+          // Why: the newest loop is still streaming; the call before it is the last completed one.
+          return undefined
+        }
+        const loopIndex = typeof record.loop_index === 'number' ? record.loop_index : null
+        const startedAt = timestamp
+        const ended = endedAt
+        endedAt = null
+        return ended > startedAt ? { loopIndex, startedAt, endedAt: ended } : undefined
+      }
+      // Why: walking backwards, the last of these seen before loop_started is the earliest one
+      // after the call — permission prompts and tool runs are not generation time.
+      if (type === 'permission_requested' || type === 'tool_started' || type === 'turn_ended') {
+        endedAt = timestamp
+      }
+      return undefined
+    }
+  }
+}
+
+/** Backwards walk over chat_history.jsonl that yields the newest assistant row plus the reasoning rows before it. */
+export function createGrokCallTextExtractor(): {
+  visit: (line: string) => GrokModelCallText | undefined
+  flush: () => GrokModelCallText | undefined
+} {
+  let pending: GrokModelCallText | null = null
+  const finish = (): GrokModelCallText | undefined => {
+    const result = pending ?? undefined
+    pending = null
+    return result
+  }
+  return {
+    visit: (line) => {
+      const record = parseJsonObject(line)
+      const type = typeof record?.type === 'string' ? record.type : null
+      if (!record || !type) {
+        return undefined
+      }
+      if (!pending) {
+        if (type !== 'assistant') {
+          return undefined
+        }
+        let visibleChars = stringLength(record.content)
+        if (Array.isArray(record.tool_calls)) {
+          for (const call of record.tool_calls) {
+            visibleChars += stringLength(readObject(call)?.arguments)
+          }
+        }
+        pending = {
+          model: typeof record.model_id === 'string' && record.model_id ? record.model_id : null,
+          visibleChars,
+          encryptedReasoningChars: 0
+        }
+        return undefined
+      }
+      if (type !== 'reasoning') {
+        return finish()
+      }
+      if (Array.isArray(record.summary)) {
+        for (const part of record.summary) {
+          pending.visibleChars += stringLength(readObject(part)?.text)
+        }
+      }
+      pending.encryptedReasoningChars += stringLength(record.encrypted_content)
+      return undefined
+    },
+    flush: finish
+  }
+}
+
+export function estimateGrokOutputTokens(text: GrokModelCallText): number {
+  const chars = text.visibleChars + text.encryptedReasoningChars * BASE64_PAYLOAD_RATIO
+  return Math.round(chars / CHARS_PER_TOKEN)
+}
+
+/** Estimated throughput of the newest completed Grok model call for a session's chat history file. */
+export function readLastGrokMessageThroughput(
+  chatHistoryPath: string
+): AgentMessageThroughput | undefined {
+  const timing = readLastExtractedFromTranscriptOnce(
+    join(dirname(chatHistoryPath), GROK_EVENTS_FILE),
+    createGrokLoopTimingExtractor().visit
+  )
+  if (!timing) {
+    return undefined
+  }
+  const textExtractor = createGrokCallTextExtractor()
+  const text =
+    readLastExtractedFromTranscriptOnce(chatHistoryPath, textExtractor.visit) ??
+    textExtractor.flush()
+  const outputTokens = text ? estimateGrokOutputTokens(text) : 0
+  if (!text || outputTokens <= 0) {
+    return undefined
+  }
+  return {
+    messageId: `grok:${timing.startedAt}`,
+    model: text.model,
+    outputTokens,
+    generationMs: timing.endedAt - timing.startedAt,
+    completedAt: timing.endedAt,
+    estimated: true
+  }
+}

--- a/src/shared/agent-hook-listener/transcript-reader.ts
+++ b/src/shared/agent-hook-listener/transcript-reader.ts
@@ -13,6 +13,14 @@ export function readLastTextFromTranscriptOnce(
   transcriptPath: string,
   extractLineText: (line: string) => string | undefined
 ): string | undefined {
+  return readLastExtractedFromTranscriptOnce(transcriptPath, extractLineText)
+}
+
+/** Scans the transcript newest-first in chunks and returns the first value `extractLine` yields. */
+export function readLastExtractedFromTranscriptOnce<T>(
+  transcriptPath: string,
+  extractLine: (line: string) => T | undefined
+): T | undefined {
   try {
     const stats = statSync(transcriptPath)
     const size = stats.size
@@ -66,7 +74,7 @@ export function readLastTextFromTranscriptOnce(
         if (completeRegion.length > 0) {
           const extracted = findLastExtractedTranscriptLineText(
             completeRegion.toString('utf8'),
-            extractLineText
+            extractLine
           )
           if (extracted !== undefined) {
             return extracted
@@ -82,10 +90,10 @@ export function readLastTextFromTranscriptOnce(
   }
 }
 
-export function findLastExtractedTranscriptLineText(
+export function findLastExtractedTranscriptLineText<T>(
   text: string,
-  extractLineText: (line: string) => string | undefined
-): string | undefined {
+  extractLineText: (line: string) => T | undefined
+): T | undefined {
   let lineEnd = text.length
 
   for (let index = text.length - 1; index >= -1; index--) {

--- a/src/shared/agent-throughput-types.ts
+++ b/src/shared/agent-throughput-types.ts
@@ -1,0 +1,33 @@
+/**
+ * Generation throughput of one pane's agent, measured per completed assistant
+ * message from the provider transcript. Claude Code writes token usage and a
+ * timestamp per message; no provider surface exposes intra-message counts, so a
+ * sample only changes when a message completes.
+ */
+export type AgentThroughputSample = {
+  paneKey: string
+  /** Provider-owned assistant message id the sample was measured on. */
+  messageId: string
+  model: string | null
+  outputTokens: number
+  /** Wall-clock ms from the transcript record preceding the message to its last row. */
+  generationMs: number
+  tokensPerSecond: number
+  /** Epoch ms of the message's last transcript row. */
+  completedAt: number
+  /** Output tokens, generation ms, and message count accumulated since the turn's prompt. */
+  turnOutputTokens: number
+  turnGenerationMs: number
+  turnMessageCount: number
+  /** Epoch ms when the hook server observed the sample; orders pushes against snapshots. */
+  observedAt: number
+}
+
+export type AgentThroughputClearIpcPayload = { paneKey: string }
+
+export function computeTokensPerSecond(outputTokens: number, generationMs: number): number {
+  if (!(outputTokens > 0) || !(generationMs > 0)) {
+    return 0
+  }
+  return (outputTokens * 1000) / generationMs
+}

--- a/src/shared/agent-throughput-types.ts
+++ b/src/shared/agent-throughput-types.ts
@@ -1,11 +1,13 @@
 /**
- * Generation throughput of one pane's agent, measured per completed assistant
- * message from the provider transcript. Claude Code writes token usage and a
- * timestamp per message; no provider surface exposes intra-message counts, so a
- * sample only changes when a message completes.
+ * Generation throughput of one pane's agent, measured per completed model call
+ * from the agent's own session record (Claude/Codex transcripts, Gemini chat
+ * files, OpenCode's database). No agent exposes intra-message counts, so a
+ * sample only changes when a call completes.
  */
 export type AgentThroughputSample = {
   paneKey: string
+  /** Hook source the record was read for (claude, codex, gemini, opencode, ...). */
+  agentType: string
   /** Provider-owned assistant message id the sample was measured on. */
   messageId: string
   model: string | null
@@ -24,6 +26,16 @@ export type AgentThroughputSample = {
 }
 
 export type AgentThroughputClearIpcPayload = { paneKey: string }
+
+/** One completed model call as read from a provider's on-disk session record. */
+export type AgentMessageThroughput = {
+  /** Provider-owned id when the record has one, else a synthetic key unique per call. */
+  messageId: string
+  model: string | null
+  outputTokens: number
+  generationMs: number
+  completedAt: number
+}
 
 export function computeTokensPerSecond(outputTokens: number, generationMs: number): number {
   if (!(outputTokens > 0) || !(generationMs > 0)) {

--- a/src/shared/agent-throughput-types.ts
+++ b/src/shared/agent-throughput-types.ts
@@ -23,6 +23,8 @@ export type AgentThroughputSample = {
   turnMessageCount: number
   /** Epoch ms when the hook server observed the sample; orders pushes against snapshots. */
   observedAt: number
+  /** True when the agent reports no token counts and `outputTokens` was estimated from text length. */
+  estimated?: boolean
 }
 
 export type AgentThroughputClearIpcPayload = { paneKey: string }
@@ -35,15 +37,18 @@ export type AgentMessageThroughput = {
   outputTokens: number
   generationMs: number
   completedAt: number
+  /** Set by readers that estimate tokens from text length because the agent records none. */
+  estimated?: true
 }
 
-/** Hook sources whose session record carries per-message token counts Orca can read. */
+/** Hook sources Orca can report for: per-message token counts on disk, or (Grok) a text-length estimate. */
 export const AGENT_THROUGHPUT_MEASURED_AGENTS = [
   'claude',
   'codex',
   'gemini',
   'opencode',
-  'mimo-code'
+  'mimo-code',
+  'grok'
 ] as const
 
 export function isAgentThroughputMeasured(agentType: string | undefined | null): boolean {

--- a/src/shared/agent-throughput-types.ts
+++ b/src/shared/agent-throughput-types.ts
@@ -37,6 +37,22 @@ export type AgentMessageThroughput = {
   completedAt: number
 }
 
+/** Hook sources whose session record carries per-message token counts Orca can read. */
+export const AGENT_THROUGHPUT_MEASURED_AGENTS = [
+  'claude',
+  'codex',
+  'gemini',
+  'opencode',
+  'mimo-code'
+] as const
+
+export function isAgentThroughputMeasured(agentType: string | undefined | null): boolean {
+  return (
+    typeof agentType === 'string' &&
+    (AGENT_THROUGHPUT_MEASURED_AGENTS as readonly string[]).includes(agentType)
+  )
+}
+
 export function computeTokensPerSecond(outputTokens: number, generationMs: number): number {
   if (!(outputTokens > 0) || !(generationMs > 0)) {
     return 0

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -116,6 +116,8 @@ export type PersistedUIState = {
   _antigravityStatusBarDefaultAdded?: boolean
   /** One-shot migration flag for adding the default-on Grok status item. */
   _grokStatusBarDefaultAdded?: boolean
+  /** One-shot migration flag for adding the default-on Agent Tokens/sec status item. */
+  _throughputStatusBarDefaultAdded?: boolean
   statusBarItems: StatusBarItem[]
   statusBarVisible: boolean
   /** Why: this is client-side presentation, not a provider/account or execution-host setting. */

--- a/src/shared/status-bar-defaults.ts
+++ b/src/shared/status-bar-defaults.ts
@@ -11,5 +11,6 @@ export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = [
   'grok',
   'ssh',
   'resource-usage',
-  'ports'
+  'ports',
+  'throughput'
 ]

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -65,6 +65,7 @@ export type StatusBarItem =
   | 'ssh'
   | 'resource-usage'
   | 'ports'
+  | 'throughput'
 export type FloatingTerminalTriggerLocation = 'floating-button' | 'status-bar'
 
 export type TaskResumeState = {

--- a/tests/e2e/status-bar-agent-throughput.spec.ts
+++ b/tests/e2e/status-bar-agent-throughput.spec.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import type { ElectronApplication } from '@stablyai/playwright-test'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import { expect, test } from './helpers/orca-app'
 import { readHookEndpoint } from './helpers/agent-hook-endpoint'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
@@ -10,18 +10,22 @@ import type { ActivePaneHookDescriptor } from './helpers/terminal-pane-identity'
 
 const BASE = Date.parse('2026-09-02T14:12:22.409Z')
 
-function transcriptRow(record: Record<string, unknown>, offsetMs: number): string {
-  return JSON.stringify({ ...record, timestamp: new Date(BASE + offsetMs).toISOString() })
+function at(offsetMs: number): string {
+  return new Date(BASE + offsetMs).toISOString()
 }
 
-function assistantRow(args: {
+function claudeRow(record: Record<string, unknown>, offsetMs: number): string {
+  return JSON.stringify({ ...record, timestamp: at(offsetMs) })
+}
+
+function claudeAssistantRow(args: {
   uuid: string
   parentUuid: string
   messageId: string
   outputTokens: number
   offsetMs: number
 }): string {
-  return transcriptRow(
+  return claudeRow(
     {
       type: 'assistant',
       uuid: args.uuid,
@@ -38,14 +42,41 @@ function assistantRow(args: {
   )
 }
 
-async function postClaudeHook(
+function codexRow(type: string, payload: Record<string, unknown>, offsetMs: number): string {
+  return JSON.stringify({ timestamp: at(offsetMs), type, payload })
+}
+
+function codexTokenCount(offsetMs: number, outputTokens: number, totalOutput: number): string {
+  return codexRow(
+    'event_msg',
+    {
+      type: 'token_count',
+      info: {
+        total_token_usage: {
+          input_tokens: 1000,
+          output_tokens: totalOutput,
+          total_tokens: 1000 + totalOutput
+        },
+        last_token_usage: {
+          input_tokens: 500,
+          output_tokens: outputTokens,
+          total_tokens: 500 + outputTokens
+        }
+      }
+    },
+    offsetMs
+  )
+}
+
+async function postHook(
   app: ElectronApplication,
+  source: 'claude' | 'codex',
   descriptor: ActivePaneHookDescriptor,
   payload: Record<string, unknown>
 ): Promise<void> {
   const endpoint = await readHookEndpoint(app)
   const [tabId] = descriptor.paneKey.split(':')
-  const response = await fetch(`http://127.0.0.1:${endpoint.port}/hook/claude`, {
+  const response = await fetch(`http://127.0.0.1:${endpoint.port}/hook/${source}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -63,15 +94,11 @@ async function postClaudeHook(
   expect(response.status).toBe(204)
 }
 
-test('shows tokens per second for the focused pane once a Claude message completes', async ({
-  electronApp,
-  orcaPage
-}) => {
+async function prepareFocusedPane(orcaPage: Page): Promise<ActivePaneHookDescriptor> {
   await waitForSessionReady(orcaPage)
   await waitForActiveWorktree(orcaPage)
   await ensureTerminalVisible(orcaPage)
   const descriptor = await waitForActivePaneHookDescriptor(orcaPage)
-
   // Why: the readout is opt-in; the store enables it (setup) and the DOM proves it (assertion).
   await orcaPage.evaluate(() => {
     const store = window.__store
@@ -82,15 +109,26 @@ test('shows tokens per second for the focused pane once a Claude message complet
       store.getState().toggleStatusBarItem('throughput')
     }
   })
+  return descriptor
+}
 
-  const transcriptDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-throughput-'))
+function createTranscriptDir(): string {
+  return mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-throughput-'))
+}
+
+test('shows tokens per second for the focused pane once a Claude message completes', async ({
+  electronApp,
+  orcaPage
+}) => {
+  const descriptor = await prepareFocusedPane(orcaPage)
+  const transcriptDir = createTranscriptDir()
   const transcriptPath = path.join(transcriptDir, 'session.jsonl')
   const lines = [
-    transcriptRow(
+    claudeRow(
       { type: 'user', uuid: 'u1', parentUuid: null, message: { role: 'user', content: 'go' } },
       0
     ),
-    assistantRow({
+    claudeAssistantRow({
       uuid: 'a1',
       parentUuid: 'u1',
       messageId: 'msg_1',
@@ -105,12 +143,12 @@ test('shows tokens per second for the focused pane once a Claude message complet
     cwd: transcriptDir
   }
 
-  await postClaudeHook(electronApp, descriptor, {
+  await postHook(electronApp, 'claude', descriptor, {
     ...session,
     hook_event_name: 'UserPromptSubmit',
     prompt: 'go'
   })
-  await postClaudeHook(electronApp, descriptor, {
+  await postHook(electronApp, 'claude', descriptor, {
     ...session,
     hook_event_name: 'Stop',
     last_assistant_message: 'done'
@@ -125,7 +163,7 @@ test('shows tokens per second for the focused pane once a Claude message complet
   }
 
   lines.push(
-    transcriptRow(
+    claudeRow(
       {
         type: 'user',
         uuid: 'u2',
@@ -134,7 +172,7 @@ test('shows tokens per second for the focused pane once a Claude message complet
       },
       40_000
     ),
-    assistantRow({
+    claudeAssistantRow({
       uuid: 'a2',
       parentUuid: 'u2',
       messageId: 'msg_2',
@@ -143,12 +181,12 @@ test('shows tokens per second for the focused pane once a Claude message complet
     })
   )
   writeFileSync(transcriptPath, `${lines.join('\n')}\n`)
-  await postClaudeHook(electronApp, descriptor, {
+  await postHook(electronApp, 'claude', descriptor, {
     ...session,
     hook_event_name: 'UserPromptSubmit',
     prompt: 'again'
   })
-  await postClaudeHook(electronApp, descriptor, {
+  await postHook(electronApp, 'claude', descriptor, {
     ...session,
     hook_event_name: 'Stop',
     last_assistant_message: 'done again'
@@ -157,4 +195,55 @@ test('shows tokens per second for the focused pane once a Claude message complet
   const secondReadout = orcaPage.getByLabel('Agent throughput, 40 tok/s')
   await expect(secondReadout).toBeVisible()
   await expect(secondReadout).toHaveText('40 tok/s')
+})
+
+test('shows tokens per second for a Codex pane from its rollout', async ({
+  electronApp,
+  orcaPage
+}) => {
+  const descriptor = await prepareFocusedPane(orcaPage)
+  const rolloutDir = createTranscriptDir()
+  const rolloutPath = path.join(rolloutDir, 'rollout.jsonl')
+  // Why: mirrors a real rollout — the call's rows, then the tool output, then its token_count.
+  writeFileSync(
+    rolloutPath,
+    `${[
+      codexRow(
+        'response_item',
+        { type: 'custom_tool_call_output', call_id: 'c1', output: 'ok' },
+        0
+      ),
+      codexTokenCount(0, 184, 184),
+      codexRow('response_item', { type: 'reasoning', summary: [] }, 22_087),
+      codexRow('response_item', { type: 'custom_tool_call', name: 'exec', input: 'ls' }, 29_293),
+      codexRow(
+        'response_item',
+        { type: 'custom_tool_call_output', call_id: 'c2', output: 'files' },
+        32_443
+      ),
+      codexTokenCount(32_444, 696, 880),
+      codexRow('event_msg', { type: 'task_complete', last_agent_message: 'done' }, 32_450)
+    ].join('\n')}\n`
+  )
+  const session = {
+    session_id: 'e2e-codex-throughput-session',
+    transcript_path: rolloutPath,
+    cwd: rolloutDir,
+    model: 'gpt-5.5'
+  }
+
+  await postHook(electronApp, 'codex', descriptor, {
+    ...session,
+    hook_event_name: 'UserPromptSubmit',
+    prompt: 'list files'
+  })
+  await postHook(electronApp, 'codex', descriptor, {
+    ...session,
+    hook_event_name: 'Stop',
+    last_assistant_message: 'done'
+  })
+
+  const readout = orcaPage.getByLabel('Agent throughput, 24 tok/s')
+  await expect(readout).toBeVisible()
+  await expect(readout).toHaveText('24 tok/s')
 })

--- a/tests/e2e/status-bar-agent-throughput.spec.ts
+++ b/tests/e2e/status-bar-agent-throughput.spec.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { grokEncodedCwdDirName } from '../../src/shared/grok-session-paths'
 import { expect, test } from './helpers/orca-app'
 import { readHookEndpoint } from './helpers/agent-hook-endpoint'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
@@ -70,9 +71,10 @@ function codexTokenCount(offsetMs: number, outputTokens: number, totalOutput: nu
 
 async function postHook(
   app: ElectronApplication,
-  source: 'claude' | 'codex',
+  source: 'claude' | 'codex' | 'grok',
   descriptor: ActivePaneHookDescriptor,
-  payload: Record<string, unknown>
+  payload: Record<string, unknown>,
+  envelope: Record<string, unknown> = {}
 ): Promise<void> {
   const endpoint = await readHookEndpoint(app)
   const [tabId] = descriptor.paneKey.split(':')
@@ -88,6 +90,7 @@ async function postHook(
       worktreeId: descriptor.worktreeId,
       env: endpoint.env,
       version: endpoint.version,
+      ...envelope,
       payload
     })
   })
@@ -248,4 +251,49 @@ test('shows tokens per second for a Codex pane from its rollout', async ({
   const readout = orcaPage.getByLabel('Agent throughput, 24 tok/s')
   await expect(readout).toBeVisible()
   await expect(readout).toHaveText('24 tok/s')
+})
+
+test('shows an estimated tokens per second for a Grok pane from its session files', async ({
+  electronApp,
+  orcaPage
+}) => {
+  const descriptor = await prepareFocusedPane(orcaPage)
+  const grokHome = createTranscriptDir()
+  const cwd = path.join(grokHome, 'workspace')
+  const sessionId = 'e2e-grok-throughput-session'
+  const sessionDir = path.join(grokHome, 'sessions', grokEncodedCwdDirName(cwd)!, sessionId)
+  mkdirSync(sessionDir, { recursive: true })
+  // Why: Grok records no token counts; 800 visible characters over a 5 s loop estimate to ~40 tok/s.
+  writeFileSync(
+    path.join(sessionDir, 'events.jsonl'),
+    `${[
+      JSON.stringify({ ts: at(0), type: 'turn_started', model_id: 'grok-4.6' }),
+      JSON.stringify({ ts: at(0), type: 'loop_started', loop_index: 1 }),
+      JSON.stringify({ ts: at(1_200), type: 'first_token' }),
+      JSON.stringify({ ts: at(1_200), type: 'phase_changed', phase: 'streaming_text' }),
+      JSON.stringify({ ts: at(5_000), type: 'turn_ended', outcome: 'completed' })
+    ].join('\n')}\n`
+  )
+  writeFileSync(
+    path.join(sessionDir, 'chat_history.jsonl'),
+    `${[
+      JSON.stringify({ type: 'user', content: 'go' }),
+      JSON.stringify({ type: 'assistant', content: 'x'.repeat(800), model_id: 'grok-4.6' })
+    ].join('\n')}\n`
+  )
+  const session = { sessionId, cwd }
+  const envelope = { grokHome }
+
+  await postHook(
+    electronApp,
+    'grok',
+    descriptor,
+    { ...session, hook_event_name: 'UserPromptSubmit', prompt: 'go' },
+    envelope
+  )
+  await postHook(electronApp, 'grok', descriptor, { ...session, hook_event_name: 'Stop' }, envelope)
+
+  const readout = orcaPage.getByLabel('Agent throughput, ~40 tok/s')
+  await expect(readout).toBeVisible()
+  await expect(readout).toHaveText('~40 tok/s')
 })

--- a/tests/e2e/status-bar-agent-throughput.spec.ts
+++ b/tests/e2e/status-bar-agent-throughput.spec.ts
@@ -323,7 +323,11 @@ test('shows tokens per second for a Codex pane from its rollout', async ({
   await expectTooltip(
     orcaPage,
     readout,
-    ['Last request: 24 tok/s (696 tokens in 29.3s)', 'Codex · gpt-5.5'],
+    [
+      'In the bar: 24 tok/s, this turn’s average over 1 message(s)',
+      'Last request: 24 tok/s (696 tokens in 29.3s)',
+      'Codex · gpt-5.5'
+    ],
     'after-codex-tooltip'
   )
 })
@@ -375,6 +379,7 @@ test('shows an estimated tokens per second for a Grok pane from its session file
     orcaPage,
     readout,
     [
+      'In the bar: ~40 tok/s, this turn’s average over 1 message(s)',
       'Last request: ~40 tok/s (200 tokens in 5.0s)',
       'Grok · grok-4.6',
       'Estimated from text length; Grok records no token counts.'
@@ -427,7 +432,11 @@ test('shows tokens per second for a Gemini CLI pane from its chat file', async (
   await expectTooltip(
     orcaPage,
     readout,
-    ['Last request: 50 tok/s (400 tokens in 8.0s)', 'Gemini · gemini-3-pro'],
+    [
+      'In the bar: 50 tok/s, this turn’s average over 1 message(s)',
+      'Last request: 50 tok/s (400 tokens in 8.0s)',
+      'Gemini · gemini-3-pro'
+    ],
     'after-gemini-tooltip'
   )
 })
@@ -475,7 +484,11 @@ test.describe('OpenCode', () => {
     await expectTooltip(
       orcaPage,
       readout,
-      ['Last request: 50 tok/s (400 tokens in 8.0s)', 'OpenCode · openai/gpt-5.5'],
+      [
+        'In the bar: 50 tok/s, this turn’s average over 1 message(s)',
+        'Last request: 50 tok/s (400 tokens in 8.0s)',
+        'OpenCode · openai/gpt-5.5'
+      ],
       'after-opencode-tooltip'
     )
   })

--- a/tests/e2e/status-bar-agent-throughput.spec.ts
+++ b/tests/e2e/status-bar-agent-throughput.spec.ts
@@ -1,0 +1,160 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { readHookEndpoint } from './helpers/agent-hook-endpoint'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { waitForActivePaneHookDescriptor } from './helpers/terminal'
+import type { ActivePaneHookDescriptor } from './helpers/terminal-pane-identity'
+
+const BASE = Date.parse('2026-09-02T14:12:22.409Z')
+
+function transcriptRow(record: Record<string, unknown>, offsetMs: number): string {
+  return JSON.stringify({ ...record, timestamp: new Date(BASE + offsetMs).toISOString() })
+}
+
+function assistantRow(args: {
+  uuid: string
+  parentUuid: string
+  messageId: string
+  outputTokens: number
+  offsetMs: number
+}): string {
+  return transcriptRow(
+    {
+      type: 'assistant',
+      uuid: args.uuid,
+      parentUuid: args.parentUuid,
+      message: {
+        id: args.messageId,
+        model: 'claude-e2e',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'done' }],
+        usage: { input_tokens: 10, output_tokens: args.outputTokens }
+      }
+    },
+    args.offsetMs
+  )
+}
+
+async function postClaudeHook(
+  app: ElectronApplication,
+  descriptor: ActivePaneHookDescriptor,
+  payload: Record<string, unknown>
+): Promise<void> {
+  const endpoint = await readHookEndpoint(app)
+  const [tabId] = descriptor.paneKey.split(':')
+  const response = await fetch(`http://127.0.0.1:${endpoint.port}/hook/claude`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Orca-Agent-Hook-Token': endpoint.token
+    },
+    body: JSON.stringify({
+      paneKey: descriptor.paneKey,
+      tabId,
+      worktreeId: descriptor.worktreeId,
+      env: endpoint.env,
+      version: endpoint.version,
+      payload
+    })
+  })
+  expect(response.status).toBe(204)
+}
+
+test('shows tokens per second for the focused pane once a Claude message completes', async ({
+  electronApp,
+  orcaPage
+}) => {
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  const descriptor = await waitForActivePaneHookDescriptor(orcaPage)
+
+  // Why: the readout is opt-in; the store enables it (setup) and the DOM proves it (assertion).
+  await orcaPage.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is unavailable')
+    }
+    if (!store.getState().statusBarItems.includes('throughput')) {
+      store.getState().toggleStatusBarItem('throughput')
+    }
+  })
+
+  const transcriptDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-throughput-'))
+  const transcriptPath = path.join(transcriptDir, 'session.jsonl')
+  const lines = [
+    transcriptRow(
+      { type: 'user', uuid: 'u1', parentUuid: null, message: { role: 'user', content: 'go' } },
+      0
+    ),
+    assistantRow({
+      uuid: 'a1',
+      parentUuid: 'u1',
+      messageId: 'msg_1',
+      outputTokens: 2497,
+      offsetMs: 36_473
+    })
+  ]
+  writeFileSync(transcriptPath, `${lines.join('\n')}\n`)
+  const session = {
+    session_id: 'e2e-throughput-session',
+    transcript_path: transcriptPath,
+    cwd: transcriptDir
+  }
+
+  await postClaudeHook(electronApp, descriptor, {
+    ...session,
+    hook_event_name: 'UserPromptSubmit',
+    prompt: 'go'
+  })
+  await postClaudeHook(electronApp, descriptor, {
+    ...session,
+    hook_event_name: 'Stop',
+    last_assistant_message: 'done'
+  })
+
+  const firstReadout = orcaPage.getByLabel('Agent throughput, 68 tok/s')
+  await expect(firstReadout).toBeVisible()
+  await expect(firstReadout).toHaveText('68 tok/s')
+  const proofPath = process.env.ORCA_THROUGHPUT_PROOF_PATH
+  if (proofPath) {
+    await orcaPage.screenshot({ path: proofPath })
+  }
+
+  lines.push(
+    transcriptRow(
+      {
+        type: 'user',
+        uuid: 'u2',
+        parentUuid: 'a1',
+        message: { role: 'user', content: [{ type: 'tool_result', content: 'ok' }] }
+      },
+      40_000
+    ),
+    assistantRow({
+      uuid: 'a2',
+      parentUuid: 'u2',
+      messageId: 'msg_2',
+      outputTokens: 200,
+      offsetMs: 45_000
+    })
+  )
+  writeFileSync(transcriptPath, `${lines.join('\n')}\n`)
+  await postClaudeHook(electronApp, descriptor, {
+    ...session,
+    hook_event_name: 'UserPromptSubmit',
+    prompt: 'again'
+  })
+  await postClaudeHook(electronApp, descriptor, {
+    ...session,
+    hook_event_name: 'Stop',
+    last_assistant_message: 'done again'
+  })
+
+  const secondReadout = orcaPage.getByLabel('Agent throughput, 40 tok/s')
+  await expect(secondReadout).toBeVisible()
+  await expect(secondReadout).toHaveText('40 tok/s')
+})

--- a/tests/e2e/status-bar-agent-throughput.spec.ts
+++ b/tests/e2e/status-bar-agent-throughput.spec.ts
@@ -386,6 +386,16 @@ test('shows an estimated tokens per second for a Grok pane from its session file
     ],
     'after-grok-tooltip'
   )
+
+  // Why: Grok's exit reaches Orca as a SessionEnd hook; the reading must not outlive the session.
+  await postHook(
+    electronApp,
+    'grok',
+    descriptor,
+    { ...session, hook_event_name: 'SessionEnd' },
+    envelope
+  )
+  await expect(orcaPage.getByLabel('Agent throughput, n/a tok/s')).toHaveText('n/a tok/s')
 })
 
 test('shows tokens per second for a Gemini CLI pane from its chat file', async ({

--- a/tests/e2e/status-bar-agent-throughput.spec.ts
+++ b/tests/e2e/status-bar-agent-throughput.spec.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import type { ElectronApplication, Locator, Page } from '@stablyai/playwright-test'
 import { grokEncodedCwdDirName } from '../../src/shared/grok-session-paths'
 import { expect, test } from './helpers/orca-app'
 import { readHookEndpoint } from './helpers/agent-hook-endpoint'
@@ -97,11 +97,59 @@ async function postHook(
   expect(response.status).toBe(204)
 }
 
-async function prepareFocusedPane(orcaPage: Page): Promise<ActivePaneHookDescriptor> {
+// Why: optional PR evidence. The status bar is a 24 px strip, so a bottom crop reads better than a full window.
+async function captureEvidence(
+  page: Page,
+  name: string,
+  options: { full?: boolean; stripHeight?: number } = {}
+): Promise<void> {
+  const dir = process.env.ORCA_THROUGHPUT_EVIDENCE_DIR
+  if (!dir) {
+    return
+  }
+  mkdirSync(dir, { recursive: true })
+  if (options.full) {
+    await page.screenshot({ path: path.join(dir, `${name}.png`) })
+  }
+  // Why: Electron pages report no Playwright viewport; the window's own size is the real one.
+  const viewport = await page.evaluate(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight
+  }))
+  // Why: the readout sits in the right-hand cluster; a full-width strip makes it unreadable.
+  const height = options.stripHeight ?? 40
+  const width = Math.min(viewport.width, 720)
+  await page.screenshot({
+    path: path.join(dir, `${name}-status-bar.png`),
+    clip: { x: viewport.width - width, y: viewport.height - height, width, height }
+  })
+}
+
+// Why: the tooltip is the only place the message size, duration and agent show, so hover must
+// open it; the star nag can cover that corner, so dismiss it first.
+async function expectTooltip(page: Page, trigger: Locator, expectedText: string): Promise<void> {
+  const later = page.getByRole('button', { name: 'Later' })
+  if (await later.isVisible().catch(() => false)) {
+    await later.click()
+  }
+  await trigger.hover()
+  // Why: Radix renders the content twice (visible popper + visually hidden a11y copy); the popper comes first.
+  await expect(page.getByText(expectedText).first()).toBeVisible()
+  await captureEvidence(page, 'after-tooltip', { stripHeight: 160 })
+  await page.mouse.move(0, 0)
+}
+
+async function prepareFocusedPane(
+  orcaPage: Page,
+  options: { captureBefore?: boolean } = {}
+): Promise<ActivePaneHookDescriptor> {
   await waitForSessionReady(orcaPage)
   await waitForActiveWorktree(orcaPage)
   await ensureTerminalVisible(orcaPage)
   const descriptor = await waitForActivePaneHookDescriptor(orcaPage)
+  if (options.captureBefore) {
+    await captureEvidence(orcaPage, 'before', { full: true })
+  }
   // Why: the readout is opt-in; the store enables it (setup) and the DOM proves it (assertion).
   await orcaPage.evaluate(() => {
     const store = window.__store
@@ -123,9 +171,10 @@ test('shows tokens per second for the focused pane once a Claude message complet
   electronApp,
   orcaPage
 }) => {
-  const descriptor = await prepareFocusedPane(orcaPage)
+  const descriptor = await prepareFocusedPane(orcaPage, { captureBefore: true })
   // Why: an enabled item must be visible before any message completes, not silently absent.
   await expect(orcaPage.getByLabel('Agent throughput, n/a tok/s')).toHaveText('n/a tok/s')
+  await captureEvidence(orcaPage, 'after-placeholder')
   const transcriptDir = createTranscriptDir()
   const transcriptPath = path.join(transcriptDir, 'session.jsonl')
   const lines = [
@@ -162,10 +211,8 @@ test('shows tokens per second for the focused pane once a Claude message complet
   const firstReadout = orcaPage.getByLabel('Agent throughput, 68 tok/s')
   await expect(firstReadout).toBeVisible()
   await expect(firstReadout).toHaveText('68 tok/s')
-  const proofPath = process.env.ORCA_THROUGHPUT_PROOF_PATH
-  if (proofPath) {
-    await orcaPage.screenshot({ path: proofPath })
-  }
+  await captureEvidence(orcaPage, 'after', { full: true })
+  await expectTooltip(orcaPage, firstReadout, 'Last request: 68 tok/s (2.5k tokens in 36.5s)')
 
   lines.push(
     claudeRow(

--- a/tests/e2e/status-bar-agent-throughput.spec.ts
+++ b/tests/e2e/status-bar-agent-throughput.spec.ts
@@ -101,6 +101,11 @@ async function postHook(
 }
 
 // Why: optional PR evidence. The status bar is a 24 px strip, so a bottom crop reads better than a full window.
+// Why: the style guide asks UI changes to be checked in both themes; an evidence run picks one.
+const evidenceTheme = process.env.ORCA_THROUGHPUT_EVIDENCE_THEME
+const EVIDENCE_THEME: 'dark' | 'light' | null =
+  evidenceTheme === 'dark' || evidenceTheme === 'light' ? evidenceTheme : null
+
 async function captureEvidence(
   page: Page,
   name: string,
@@ -111,8 +116,9 @@ async function captureEvidence(
     return
   }
   mkdirSync(dir, { recursive: true })
+  const fileName = EVIDENCE_THEME ? `${name}-${EVIDENCE_THEME}` : name
   if (options.full) {
-    await page.screenshot({ path: path.join(dir, `${name}.png`) })
+    await page.screenshot({ path: path.join(dir, `${fileName}.png`) })
   }
   // Why: Electron pages report no Playwright viewport; the window's own size is the real one.
   const viewport = await page.evaluate(() => ({
@@ -123,7 +129,7 @@ async function captureEvidence(
   const height = options.stripHeight ?? 40
   const width = Math.min(viewport.width, 720)
   await page.screenshot({
-    path: path.join(dir, `${name}-status-bar.png`),
+    path: path.join(dir, `${fileName}-status-bar.png`),
     clip: { x: viewport.width - width, y: viewport.height - height, width, height }
   })
 }
@@ -157,6 +163,11 @@ async function prepareFocusedPane(
   await waitForActiveWorktree(orcaPage)
   await ensureTerminalVisible(orcaPage)
   const descriptor = await waitForActivePaneHookDescriptor(orcaPage)
+  if (EVIDENCE_THEME) {
+    await orcaPage.evaluate((theme) => {
+      window.__store?.getState().updateSettings({ theme })
+    }, EVIDENCE_THEME)
+  }
   if (options.captureBefore) {
     await captureEvidence(orcaPage, 'before', { full: true })
   }

--- a/tests/e2e/status-bar-agent-throughput.spec.ts
+++ b/tests/e2e/status-bar-agent-throughput.spec.ts
@@ -121,6 +121,8 @@ test('shows tokens per second for the focused pane once a Claude message complet
   orcaPage
 }) => {
   const descriptor = await prepareFocusedPane(orcaPage)
+  // Why: an enabled item must be visible before any message completes, not silently absent.
+  await expect(orcaPage.getByLabel('Agent throughput, n/a tok/s')).toHaveText('n/a tok/s')
   const transcriptDir = createTranscriptDir()
   const transcriptPath = path.join(transcriptDir, 'session.jsonl')
   const lines = [

--- a/tests/e2e/status-bar-agent-throughput.spec.ts
+++ b/tests/e2e/status-bar-agent-throughput.spec.ts
@@ -234,7 +234,7 @@ test('shows tokens per second for the focused pane once a Claude message complet
   await expect(firstReadout).toHaveText('68 tok/s')
   await captureEvidence(orcaPage, 'after', { full: true })
   await expectTooltip(orcaPage, firstReadout, [
-    'In the bar: 68 tok/s, this turn’s average over 1 message(s)',
+    'In the bar: 68 tok/s, this turn’s average over 1 model response(s)',
     'Last request: 68 tok/s (2.5k tokens in 36.5s)',
     'Claude · claude-e2e'
   ])
@@ -335,7 +335,7 @@ test('shows tokens per second for a Codex pane from its rollout', async ({
     orcaPage,
     readout,
     [
-      'In the bar: 24 tok/s, this turn’s average over 1 message(s)',
+      'In the bar: 24 tok/s, this turn’s average over 1 model response(s)',
       'Last request: 24 tok/s (696 tokens in 29.3s)',
       'Codex · gpt-5.5'
     ],
@@ -390,7 +390,7 @@ test('shows an estimated tokens per second for a Grok pane from its session file
     orcaPage,
     readout,
     [
-      'In the bar: ~40 tok/s, this turn’s average over 1 message(s)',
+      'In the bar: ~40 tok/s, this turn’s average over 1 model response(s)',
       'Last request: ~40 tok/s (200 tokens in 5.0s)',
       'Grok · grok-4.6',
       'Estimated from text length; Grok records no token counts.'
@@ -454,7 +454,7 @@ test('shows tokens per second for a Gemini CLI pane from its chat file', async (
     orcaPage,
     readout,
     [
-      'In the bar: 50 tok/s, this turn’s average over 1 message(s)',
+      'In the bar: 50 tok/s, this turn’s average over 1 model response(s)',
       'Last request: 50 tok/s (400 tokens in 8.0s)',
       'Gemini · gemini-3-pro'
     ],
@@ -506,7 +506,7 @@ test.describe('OpenCode', () => {
       orcaPage,
       readout,
       [
-        'In the bar: 50 tok/s, this turn’s average over 1 message(s)',
+        'In the bar: 50 tok/s, this turn’s average over 1 model response(s)',
         'Last request: 50 tok/s (400 tokens in 8.0s)',
         'OpenCode · openai/gpt-5.5'
       ],

--- a/tests/e2e/status-bar-agent-throughput.spec.ts
+++ b/tests/e2e/status-bar-agent-throughput.spec.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import type { ElectronApplication, Locator, Page } from '@stablyai/playwright-test'
+import SyncDatabase from '../../src/main/sqlite/sync-database'
 import { grokEncodedCwdDirName } from '../../src/shared/grok-session-paths'
 import { expect, test } from './helpers/orca-app'
 import { readHookEndpoint } from './helpers/agent-hook-endpoint'
@@ -10,6 +11,8 @@ import { waitForActivePaneHookDescriptor } from './helpers/terminal'
 import type { ActivePaneHookDescriptor } from './helpers/terminal-pane-identity'
 
 const BASE = Date.parse('2026-09-02T14:12:22.409Z')
+// Why: the OpenCode reader locates opencode.db through XDG_DATA_HOME, which must be in the app's launch env.
+const OPENCODE_DATA_HOME = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-opencode-home-'))
 
 function at(offsetMs: number): string {
   return new Date(BASE + offsetMs).toISOString()
@@ -71,7 +74,7 @@ function codexTokenCount(offsetMs: number, outputTokens: number, totalOutput: nu
 
 async function postHook(
   app: ElectronApplication,
-  source: 'claude' | 'codex' | 'grok',
+  source: 'claude' | 'codex' | 'gemini' | 'opencode' | 'grok',
   descriptor: ActivePaneHookDescriptor,
   payload: Record<string, unknown>,
   envelope: Record<string, unknown> = {}
@@ -127,15 +130,22 @@ async function captureEvidence(
 
 // Why: the tooltip is the only place the message size, duration and agent show, so hover must
 // open it; the star nag can cover that corner, so dismiss it first.
-async function expectTooltip(page: Page, trigger: Locator, expectedText: string): Promise<void> {
+async function expectTooltip(
+  page: Page,
+  trigger: Locator,
+  expectedTexts: readonly string[],
+  evidenceName = 'after-tooltip'
+): Promise<void> {
   const later = page.getByRole('button', { name: 'Later' })
   if (await later.isVisible().catch(() => false)) {
     await later.click()
   }
   await trigger.hover()
-  // Why: Radix renders the content twice (visible popper + visually hidden a11y copy); the popper comes first.
-  await expect(page.getByText(expectedText).first()).toBeVisible()
-  await captureEvidence(page, 'after-tooltip', { stripHeight: 160 })
+  for (const expectedText of expectedTexts) {
+    // Why: Radix renders the content twice (visible popper + visually hidden a11y copy); the popper comes first.
+    await expect(page.getByText(expectedText).first()).toBeVisible()
+  }
+  await captureEvidence(page, evidenceName, { stripHeight: 160 })
   await page.mouse.move(0, 0)
 }
 
@@ -212,7 +222,11 @@ test('shows tokens per second for the focused pane once a Claude message complet
   await expect(firstReadout).toBeVisible()
   await expect(firstReadout).toHaveText('68 tok/s')
   await captureEvidence(orcaPage, 'after', { full: true })
-  await expectTooltip(orcaPage, firstReadout, 'Last request: 68 tok/s (2.5k tokens in 36.5s)')
+  await expectTooltip(orcaPage, firstReadout, [
+    'In the bar: 68 tok/s, this turn’s average over 1 message(s)',
+    'Last request: 68 tok/s (2.5k tokens in 36.5s)',
+    'Claude · claude-e2e'
+  ])
 
   lines.push(
     claudeRow(
@@ -238,6 +252,14 @@ test('shows tokens per second for the focused pane once a Claude message complet
     hook_event_name: 'UserPromptSubmit',
     prompt: 'again'
   })
+  // Why: a new turn must keep the previous reading until its first message completes.
+  await expect(orcaPage.getByLabel('Agent throughput, 68 tok/s')).toHaveText('68 tok/s')
+  await expectTooltip(
+    orcaPage,
+    orcaPage.getByLabel('Agent throughput, 68 tok/s'),
+    ['In the bar: 68 tok/s, last request (no message completed this turn yet)'],
+    'after-new-turn-tooltip'
+  )
   await postHook(electronApp, 'claude', descriptor, {
     ...session,
     hook_event_name: 'Stop',
@@ -298,6 +320,12 @@ test('shows tokens per second for a Codex pane from its rollout', async ({
   const readout = orcaPage.getByLabel('Agent throughput, 24 tok/s')
   await expect(readout).toBeVisible()
   await expect(readout).toHaveText('24 tok/s')
+  await expectTooltip(
+    orcaPage,
+    readout,
+    ['Last request: 24 tok/s (696 tokens in 29.3s)', 'Codex · gpt-5.5'],
+    'after-codex-tooltip'
+  )
 })
 
 test('shows an estimated tokens per second for a Grok pane from its session files', async ({
@@ -343,4 +371,112 @@ test('shows an estimated tokens per second for a Grok pane from its session file
   const readout = orcaPage.getByLabel('Agent throughput, ~40 tok/s')
   await expect(readout).toBeVisible()
   await expect(readout).toHaveText('~40 tok/s')
+  await expectTooltip(
+    orcaPage,
+    readout,
+    [
+      'Last request: ~40 tok/s (200 tokens in 5.0s)',
+      'Grok · grok-4.6',
+      'Estimated from text length; Grok records no token counts.'
+    ],
+    'after-grok-tooltip'
+  )
+})
+
+test('shows tokens per second for a Gemini CLI pane from its chat file', async ({
+  electronApp,
+  orcaPage
+}) => {
+  const descriptor = await prepareFocusedPane(orcaPage)
+  const chatDir = createTranscriptDir()
+  const chatPath = path.join(chatDir, 'session-e2e.json')
+  // Why: Gemini writes one message per model call with `tokens`; output + thoughts over the gap to the previous message.
+  writeFileSync(
+    chatPath,
+    JSON.stringify({
+      sessionId: 'e2e-gemini-session',
+      messages: [
+        { id: 'u1', timestamp: at(0), type: 'user', content: 'go' },
+        {
+          id: 'g1',
+          timestamp: at(8_000),
+          type: 'gemini',
+          content: 'done',
+          model: 'gemini-3-pro',
+          tokens: { input: 1_000, output: 300, cached: 0, thoughts: 100, tool: 0, total: 1_400 }
+        }
+      ]
+    })
+  )
+  const session = { session_id: 'e2e-gemini-session', transcript_path: chatPath, cwd: chatDir }
+
+  await postHook(electronApp, 'gemini', descriptor, {
+    ...session,
+    hook_event_name: 'BeforeAgent',
+    prompt: 'go'
+  })
+  await postHook(electronApp, 'gemini', descriptor, {
+    ...session,
+    hook_event_name: 'AfterAgent',
+    prompt_response: 'done'
+  })
+
+  const readout = orcaPage.getByLabel('Agent throughput, 50 tok/s')
+  await expect(readout).toBeVisible()
+  await expect(readout).toHaveText('50 tok/s')
+  await expectTooltip(
+    orcaPage,
+    readout,
+    ['Last request: 50 tok/s (400 tokens in 8.0s)', 'Gemini · gemini-3-pro'],
+    'after-gemini-tooltip'
+  )
+})
+
+test.describe('OpenCode', () => {
+  test.use({ orcaAppExtraEnv: { XDG_DATA_HOME: OPENCODE_DATA_HOME } })
+
+  test('shows tokens per second for an OpenCode pane from its database', async ({
+    electronApp,
+    orcaPage
+  }) => {
+    const descriptor = await prepareFocusedPane(orcaPage)
+    const dataDir = path.join(OPENCODE_DATA_HOME, 'opencode')
+    mkdirSync(dataDir, { recursive: true })
+    const db = new SyncDatabase(path.join(dataDir, 'opencode.db'))
+    db.exec(
+      'CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT)'
+    )
+    // Why: OpenCode stamps each assistant message with its own created → completed span.
+    db.prepare(
+      'INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)'
+    ).run(
+      'msg-e2e',
+      'e2e-opencode-session',
+      BASE,
+      BASE + 8_000,
+      JSON.stringify({
+        role: 'assistant',
+        providerID: 'openai',
+        modelID: 'gpt-5.5',
+        tokens: { input: 1_000, output: 400, reasoning: 0, cache: { read: 0 } },
+        time: { created: BASE, completed: BASE + 8_000 }
+      })
+    )
+    db.close()
+
+    await postHook(electronApp, 'opencode', descriptor, {
+      hook_event_name: 'SessionIdle',
+      sessionID: 'e2e-opencode-session'
+    })
+
+    const readout = orcaPage.getByLabel('Agent throughput, 50 tok/s')
+    await expect(readout).toBeVisible()
+    await expect(readout).toHaveText('50 tok/s')
+    await expectTooltip(
+      orcaPage,
+      readout,
+      ['Last request: 50 tok/s (400 tokens in 8.0s)', 'OpenCode · openai/gpt-5.5'],
+      'after-opencode-tooltip'
+    )
+  })
 })


### PR DESCRIPTION
## ELI5

The status bar gets an "Agent Tokens/sec" readout for the focused terminal, on by default like the other items: how fast the agent in that pane generated its last reply. Orca reads it from each agent's own session record, so it works without touching the agent's status line. Claude Code, Codex, Gemini CLI and OpenCode are measured from real token counts; Grok, which records no token counts anywhere, gets a clearly marked estimate; agents without any usable data show `n/a` with the reason in the tooltip.

## What Changed

- **Status bar item** `throughput`, on by default like every other item: it joins `DEFAULT_STATUS_BAR_ITEMS` and reaches existing users through the same one-shot flag (`_throughputStatusBarDefaultAdded`) the Ports, Kimi, MiniMax, Antigravity and Grok items used, so hiding it via the status bar context menu or Settings → Appearance → Status Bar sticks. It is one more `[flag, item]` pair in `hydrateStatusBarItems`. Shows `⏱ 68 tok/s` for the focused pane: this turn's average (a single short message swings wildly), keeping the previous reading across a turn boundary until the new turn's first message completes; dimmed while the agent is idle. Tooltip: which value the bar shows and why (turn average, or last request while a new turn has nothing completed), the last request's tok/s with tokens and duration, agent and model; the trigger is a button like the sibling segments, so keyboard focus opens it. With no sample yet it renders `n/a tok/s` and explains why (no terminal focused, agent without token records, or waiting for the first completed message).
- **Main process** `AgentThroughputTracker`, fed from the local hook server: on the hook events that follow a completed model call it reads the agent's record, dedupes by message id, tracks per-turn totals, and pushes per-pane samples over IPC (`agentThroughput:set/clear`, `agentThroughput:getSnapshot` for startup catch-up). Pane teardown and the agent's `SessionEnd` hook clear the sample (Orca installs that hook for Grok only; the other agents keep their last reading until a new session starts in the pane). Remote/SSH panes produce no samples: their records live on the execution host.
- **Per-source readers** (`agent-throughput-source-profiles.ts`):
  - Claude Code: newest assistant message in the transcript JSONL. Claude writes one row per content block stamped with the block's completion time but flushes them in batches while tool calls already run, and rows written mid-stream (queued input, reminders) can carry later timestamps. A message therefore spans from the row its first block points to via `parentUuid` (the last row prepared before the API request) to its last block; a stale parent timestamp falls back to the last user row.
  - Codex: newest `token_count` snapshot in the rollout. The snapshot is written after the tool output, so the call ends at its last model row and starts at the previous boundary (tool output, user message, or previous snapshot). Duplicate and rate-limit-only snapshots are skipped.
  - Gemini CLI: newest `gemini` message with `tokens` (output + thoughts) in the chat JSON, timed from the message before it; the hook payload carries `transcript_path`.
  - OpenCode / MiMo Code: newest completed assistant message of the hook's session in `opencode.db`, measured from its own `time.created` → `time.completed`; streaming `MessagePart` reads are floored at 1.5 s.
  - Grok: no token counts exist on disk. `events.jsonl` times each model call (`loop_started` → the first of `permission_requested` / `tool_started` / `turn_ended`) and `chat_history.jsonl` holds what it produced; tokens are estimated at ~4 characters each from visible text, tool arguments and the encrypted reasoning blob (base64 → ¾ length), the only trace of hidden reasoning. Samples carry `estimated: true`; the UI shows `~62 tok/s` and says so in the tooltip.
- Shared `transcript-reader` gained a generic `readLastExtractedFromTranscriptOnce<T>` so the readers reuse the chunked backwards scan (a 1.7 GB Codex rollout reads in ~2 ms).
- Preload bridge, web-client noop, store slice, IPC bridge, i18n keys.

## Why

Orca shows usage and rate limits but nothing about generation speed, and the plugin API has no status-bar contribution point or token data, so this cannot be a plugin. Reading the agent's own record needs no `statusLine` slot (users who run their own status line keep it), no extra process spawns, and no PTY output parsing. No agent exposes intra-message counts, so a sample changes when a call completes; that is stated in the tooltip.

## Linked Issue

Fixes #18233

## Visual Proof

Captured by the e2e spec on Windows 11 (`ORCA_THROUGHPUT_EVIDENCE_DIR`), status bar crops of the same window.

**Before** — no throughput item exists:

![before](https://github.com/CostacheAlin/orca/releases/download/gh-attach-assets/before-status-bar.png)

**After, no completed message yet** — `n/a tok/s`, the tooltip explains why:

![after placeholder](https://github.com/CostacheAlin/orca/releases/download/gh-attach-assets/after-placeholder-status-bar.png)

**After, Claude message completed** — `68 tok/s`:

![after](https://github.com/CostacheAlin/orca/releases/download/gh-attach-assets/after-status-bar.png)

**Tooltip** — what the bar shows and why, the last request, agent and model:

![tooltip](https://github.com/CostacheAlin/orca/releases/download/gh-attach-assets/after-tooltip-status-bar.png)

**Dark mode** — the same states with `theme: dark`, captured by the same spec with `ORCA_THROUGHPUT_EVIDENCE_THEME=dark`:

![after dark](https://github.com/CostacheAlin/orca/releases/download/gh-attach-assets/after-dark-status-bar.png)

![tooltip dark](https://github.com/CostacheAlin/orca/releases/download/gh-attach-assets/after-tooltip-dark-status-bar.png)

Full window after: https://github.com/CostacheAlin/orca/releases/download/gh-attach-assets/after.png (dark: https://github.com/CostacheAlin/orca/releases/download/gh-attach-assets/after-dark.png)

## Testing

- Unit tests for every reader against real-shaped fixtures (Claude interleaved tool results and mid-stream rows, Codex snapshot-after-tool-output ordering, Gemini messages, OpenCode `message` and `session_message` schemas, Grok loops with permission waits), the tracker (dedupe, turn totals, streaming throttle, stale async reads, cleared panes) and the status bar helpers.
- E2E (`tests/e2e/status-bar-agent-throughput.spec.ts`): launches the built app, keeps the item enabled, posts real hook events to the local hook server with on-disk fixtures (Claude transcript, Codex rollout, Gemini chat file, an `opencode.db` under a scoped `XDG_DATA_HOME`, Grok session files) and asserts the DOM for all five sources: the `n/a tok/s` placeholder, the bar value, the previous reading surviving a new prompt, and the tooltip fields (bar value and turn count, last request with tokens and duration, agent · model, the Grok estimate note).
- Default-on migration: the hydration tests cover adding the item once to an older persisted UI and preserving a user's removal after the flags are set; the RPC UI schema test accepts the new flag.
- Validated on real sessions on Windows: a Claude Code session (37–108 tok/s spread, 73 tok/s median across a session), a 1.7 GB Codex rollout (696 tokens over 29.3 s) and a grok-4.6 session (estimate lands in the 50–75 tok/s band of the observed streaming rate). Gemini and OpenCode were validated on fixtures shaped like real files plus the e2e above; no live CLI was available for those two.
- `pnpm lint` (all steps pass except `verify:skill-bundle-manifest`, which compares bytes and trips on CRLF checkouts on Windows with no content difference), `pnpm typecheck`, `pnpm build` (desktop + native), localization catalog/extraction/coverage, max-lines ratchet: clean. `pnpm test`: the new suites and every suite in the touched areas pass; the suites that fail locally (`src/main/ipc/*`, `spawn /bin/sh ENOENT`) fail identically on a clean checkout on Windows. Platform tested: Windows 11, light and dark mode. macOS/Linux: no platform-specific code (paths come from hook payloads and Orca's existing session-path helpers). The PR Checks workflow has not run on this PR yet (first-time contributor), so the local results above are the only CI-equivalent so far.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code (Claude Fable 5.1), including the transcript-format investigation and tests; reviewed and driven by the author.

## Review

Cross-platform: readers use `node:path` and Orca's existing session-path helpers (`getGrokChatHistoryPath`, `listOpenCodeDatabases`); no shell or platform branches. SSH/remote: the tracker only runs on the local loopback hook path, so remote panes show `n/a` (documented in the tooltip) rather than wrong numbers; no wire changes. Agents/integrations: per-source profiles, unknown sources are ignored; the shared `AGENT_THROUGHPUT_MEASURED_AGENTS` list keeps the UI hint and the tracker in sync (asserted by a test). Performance: one bounded tail read (64 KB chunks, 4 MB cap) per qualifying hook event, skipped entirely when no window is listening; OpenCode DB reads are read-only, opened per read and throttled while streaming; Gemini chat files above 32 MB are skipped. Security: reads only files the agent's own hook named or Orca already resolves; no new IPC that accepts renderer input beyond a snapshot getter. UI: follows `docs/STYLEGUIDE.md` and the sibling segments (button trigger, `size-3` lucide icon, 11px medium tabular numerals, `Tooltip` with `sideOffset={6}` like Ports/Caffeinate, tokens only, no hex), verified in light and dark mode; the tooltip names the reading and keeps the "measured for" line only where it is actionable. On by default through the existing one-shot default-on migration, hidden from paired web clients via the noop bridge.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Not covered: Antigravity (transcript has second-resolution timestamps and no token counts; its SQLite store is undocumented protobuf), Copilot (per-model totals only at session end), Kimi, Droid, Cursor, Amp, Pi and MiniMax-as-provider (measured through the hosting agent). These show `n/a` with the reason.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

