### PR TITLE
perf(diff): window the combined-diff file tree rows on large reviews

### DIFF
--- a/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-row.tsx
+++ b/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-row.tsx
@@ -24,6 +24,9 @@ export type CombinedDiffTreeNode = SourceControlTreeNode<
   GitStagingArea | CombinedDiffBranchTreeArea
 >
 
+// Why: every row is a single `py-1 text-xs` line (16px line box + 8px padding); measureElement
+// still corrects, but a wrong estimate makes the virtualized tree's scrollbar jump on first paint.
+export const COMBINED_DIFF_TREE_ROW_HEIGHT_PX = 24
 const COMBINED_DIFF_TREE_INDENT_PX = 12
 const COMBINED_DIFF_TREE_DIRECTORY_PADDING_PX = 8
 const COMBINED_DIFF_TREE_FILE_PADDING_PX = 20

--- a/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-rows.tsx
+++ b/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-rows.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { SourceControlVirtualFileList } from '@/components/right-sidebar/source-control/listing/virtual-file-list'
+import type {
+  CombinedDiffFileTreeEntry,
+  CombinedDiffFileTreeMode
+} from '../resolve-changes/combined-diff-section-identity'
+import {
+  CombinedDiffFileTreeRow,
+  COMBINED_DIFF_TREE_ROW_HEIGHT_PX
+} from './combined-diff-file-tree-row'
+import type { CombinedDiffTreeNode } from './combined-diff-file-tree-model'
+
+/**
+ * One flattened tree section, windowed inside the file tree's scroller. A 900-file review flattens
+ * to over a thousand rows; below the virtualize threshold the rows stay in natural flow so small
+ * diffs keep byte-identical markup.
+ */
+export function CombinedDiffFileTreeRows({
+  rows,
+  mode,
+  worktreePath,
+  activeSectionKey,
+  sectionIndexByKey,
+  collapsedDirectoryKeys,
+  visibleFileCounts,
+  scrollElement,
+  onToggleDirectory,
+  onNavigate
+}: {
+  rows: readonly CombinedDiffTreeNode[]
+  mode: CombinedDiffFileTreeMode
+  worktreePath: string
+  activeSectionKey: string | null
+  sectionIndexByKey: ReadonlyMap<string, number>
+  collapsedDirectoryKeys: ReadonlySet<string>
+  visibleFileCounts: ReadonlyMap<string, number> | undefined
+  scrollElement: HTMLDivElement | null
+  onToggleDirectory: (key: string) => void
+  onNavigate: (entry: CombinedDiffFileTreeEntry) => void
+}): React.JSX.Element {
+  return (
+    <SourceControlVirtualFileList
+      rows={rows}
+      scrollElement={scrollElement}
+      estimateRowHeightPx={COMBINED_DIFF_TREE_ROW_HEIGHT_PX}
+      getRowKey={(node) => node.key}
+      renderRow={(node) => (
+        <CombinedDiffFileTreeRow
+          key={node.key}
+          node={node}
+          mode={mode}
+          worktreePath={worktreePath}
+          activeSectionKey={activeSectionKey}
+          sectionIndexByKey={sectionIndexByKey}
+          isCollapsed={collapsedDirectoryKeys.has(node.key)}
+          visibleFileCount={visibleFileCounts?.get(node.key)}
+          onToggleDirectory={onToggleDirectory}
+          onNavigate={onNavigate}
+        />
+      )}
+    />
+  )
+}

--- a/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-windowing.test.tsx
+++ b/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-windowing.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SOURCE_CONTROL_VIRTUALIZE_MIN_ROWS } from '@/components/right-sidebar/source-control/listing/virtual-file-list'
+import type { GitBranchChangeEntry } from '../../../../../../shared/git-diff-compare-types'
+import type { CombinedDiffFileTreeRow as CombinedDiffFileTreeRowComponent } from './combined-diff-file-tree-row'
+
+const mountedRows = vi.hoisted(() => ({ count: 0 }))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ combinedDiffFileTreeWidth: 420, setCombinedDiffFileTreeWidth: () => {} })
+}))
+
+vi.mock('./combined-diff-file-tree-row', async (importOriginal) => {
+  const actual = (await importOriginal()) as {
+    CombinedDiffFileTreeRow: typeof CombinedDiffFileTreeRowComponent
+  }
+  const react = await import('react')
+  const Row = actual.CombinedDiffFileTreeRow
+  const CountingRow = react.memo((props: React.ComponentProps<typeof Row>) => {
+    react.useEffect(() => {
+      mountedRows.count += 1
+      return () => {
+        mountedRows.count -= 1
+      }
+    }, [])
+    return react.createElement(Row, props)
+  })
+  return { ...actual, CombinedDiffFileTreeRow: CountingRow }
+})
+
+const { CombinedDiffFileTree } = await import('./combined-diff-file-tree')
+const { createCombinedDiffSectionIndexMap } =
+  await import('../resolve-changes/combined-diff-section-identity')
+const { getCombinedDiffBranchEntriesInTreeOrder } = await import('./combined-diff-file-tree-filter')
+
+const VIEWPORT_HEIGHT_PX = 600
+const TREE_ROW_HEIGHT_PX = 24
+const EMPTY_VIEWED_KEYS: ReadonlySet<string> = new Set()
+
+class NoopResizeObserver implements ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  mountedRows.count = 0
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  vi.stubGlobal('ResizeObserver', NoopResizeObserver)
+  vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(
+    function (this: HTMLElement) {
+      return this.classList.contains('overflow-auto') ? VIEWPORT_HEIGHT_PX : TREE_ROW_HEIGHT_PX
+    }
+  )
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+    const height = this.classList.contains('overflow-auto')
+      ? VIEWPORT_HEIGHT_PX
+      : TREE_ROW_HEIGHT_PX
+    return {
+      top: 0,
+      bottom: height,
+      height,
+      left: 0,
+      right: 240,
+      width: 240,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    } as DOMRect
+  })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+/** `fileCount` files spread over `directoryCount` directories, in the viewer's own tree order. */
+function buildEntries(fileCount: number, directoryCount: number): GitBranchChangeEntry[] {
+  const raw: GitBranchChangeEntry[] = Array.from({ length: fileCount }, (_, index) => ({
+    path: `src/dir${String(index % directoryCount).padStart(2, '0')}/file-${String(index).padStart(4, '0')}.ts`,
+    status: 'modified'
+  }))
+  return getCombinedDiffBranchEntriesInTreeOrder('commit', raw)
+}
+
+function renderTree(entries: readonly GitBranchChangeEntry[]): void {
+  const sectionIndexByKey = createCombinedDiffSectionIndexMap(
+    entries.map((entry) => ({ key: `combined-commit:${entry.path}` }))
+  )
+  act(() => {
+    root.render(
+      <CombinedDiffFileTree
+        mode="commit"
+        worktreePath="/repo"
+        entries={entries}
+        sectionIndexByKey={sectionIndexByKey}
+        activeSectionKey={null}
+        viewedSectionKeys={EMPTY_VIEWED_KEYS}
+        collapsed={false}
+        onCollapsedChange={() => {}}
+        onNavigate={() => {}}
+      />
+    )
+  })
+}
+
+describe('combined diff file tree row windowing', () => {
+  it('mounts every row below the virtualize threshold', () => {
+    const fileCount = SOURCE_CONTROL_VIRTUALIZE_MIN_ROWS - 10
+    const directoryCount = 4
+    renderTree(buildEntries(fileCount, directoryCount))
+
+    // `src` plus one directory row per leaf directory, plus one row per file.
+    const totalRows = 1 + directoryCount + fileCount
+    expect(totalRows).toBeLessThan(SOURCE_CONTROL_VIRTUALIZE_MIN_ROWS)
+    expect(mountedRows.count).toBe(totalRows)
+    expect(host.querySelector('[data-testid="source-control-virtual-list"]')).toBeNull()
+    // Natural flow: no absolutely positioned wrappers, exactly the pre-virtualization markup.
+    expect(host.querySelectorAll('[data-index]').length).toBe(0)
+  })
+
+  it('mounts only a window of rows for a large review', () => {
+    const fileCount = 900
+    const directoryCount = 30
+    renderTree(buildEntries(fileCount, directoryCount))
+
+    const totalRows = 1 + directoryCount + fileCount
+    expect(host.querySelector('[data-testid="source-control-virtual-list"]')).not.toBeNull()
+    expect(mountedRows.count).toBeGreaterThan(0)
+    // A 600px viewport plus overscan: bounded by the window, not by the review size.
+    expect(mountedRows.count).toBeLessThan(totalRows / 10)
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree.tsx
+++ b/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree.tsx
@@ -12,7 +12,7 @@ import type {
   CombinedDiffFileTreeEntry,
   CombinedDiffFileTreeMode
 } from '../resolve-changes/combined-diff-section-identity'
-import { CombinedDiffFileTreeRow } from './combined-diff-file-tree-row'
+import { CombinedDiffFileTreeRows } from './combined-diff-file-tree-rows'
 import { useCombinedDiffFileTreeResize } from './use-combined-diff-file-tree-resize'
 import { translate } from '@/i18n/i18n'
 import {
@@ -50,6 +50,8 @@ export function CombinedDiffFileTree({
   const [query, setQuery] = React.useState('')
   const [excludedExtensions, setExcludedExtensions] = React.useState<Set<string>>(() => new Set())
   const [includeViewed, setIncludeViewed] = React.useState(true)
+  // Why: state, not a ref — the virtualized row lists need the scroller on their own mount pass.
+  const [listScrollElement, setListScrollElement] = React.useState<HTMLDivElement | null>(null)
   const { handleResizeKeyDown, handleResizeStart, maxWidth, minWidth, treeRef, width } =
     useCombinedDiffFileTreeResize(collapsed)
   const toggleDirectory = React.useCallback((key: string) => {
@@ -171,6 +173,17 @@ export function CombinedDiffFileTree({
     return null
   }
 
+  const sharedRowProps = {
+    mode,
+    worktreePath,
+    activeSectionKey,
+    sectionIndexByKey,
+    collapsedDirectoryKeys,
+    scrollElement: listScrollElement,
+    onToggleDirectory: toggleDirectory,
+    onNavigate
+  }
+
   return (
     // Why: this column must be height-bounded so the file list, not the page,
     // owns overflow when review diffs have more files than fit on screen.
@@ -283,7 +296,7 @@ export function CombinedDiffFileTree({
           </Popover>
         </div>
       </div>
-      <div className="min-h-0 flex-1 overflow-auto py-1 scrollbar-sleek">
+      <div ref={setListScrollElement} className="min-h-0 flex-1 overflow-auto py-1 scrollbar-sleek">
         {visibleEntryCount === 0 ? (
           <div className="px-3 py-6 text-center text-xs text-muted-foreground">
             {translate(
@@ -309,20 +322,11 @@ export function CombinedDiffFileTree({
                   <div className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
                     {group.label}
                   </div>
-                  {rows.map((node) => (
-                    <CombinedDiffFileTreeRow
-                      key={node.key}
-                      node={node}
-                      mode={mode}
-                      worktreePath={worktreePath}
-                      activeSectionKey={activeSectionKey}
-                      sectionIndexByKey={sectionIndexByKey}
-                      isCollapsed={collapsedDirectoryKeys.has(node.key)}
-                      visibleFileCount={visibleFileCounts?.get(node.key)}
-                      onToggleDirectory={toggleDirectory}
-                      onNavigate={onNavigate}
-                    />
-                  ))}
+                  <CombinedDiffFileTreeRows
+                    rows={rows}
+                    visibleFileCounts={visibleFileCounts}
+                    {...sharedRowProps}
+                  />
                 </div>
               )
             })}
@@ -334,38 +338,20 @@ export function CombinedDiffFileTree({
                     'Committed on Branch'
                   )}
                 </div>
-                {(branchVisibleRows?.rows ?? branchRows).map((node) => (
-                  <CombinedDiffFileTreeRow
-                    key={node.key}
-                    node={node}
-                    mode={mode}
-                    worktreePath={worktreePath}
-                    activeSectionKey={activeSectionKey}
-                    sectionIndexByKey={sectionIndexByKey}
-                    isCollapsed={collapsedDirectoryKeys.has(node.key)}
-                    visibleFileCount={branchVisibleRows?.visibleFileCounts.get(node.key)}
-                    onToggleDirectory={toggleDirectory}
-                    onNavigate={onNavigate}
-                  />
-                ))}
+                <CombinedDiffFileTreeRows
+                  rows={branchVisibleRows?.rows ?? branchRows}
+                  visibleFileCounts={branchVisibleRows?.visibleFileCounts}
+                  {...sharedRowProps}
+                />
               </div>
             ) : null}
           </>
         ) : (
-          (branchVisibleRows?.rows ?? branchRows).map((node) => (
-            <CombinedDiffFileTreeRow
-              key={node.key}
-              node={node}
-              mode={mode}
-              worktreePath={worktreePath}
-              activeSectionKey={activeSectionKey}
-              sectionIndexByKey={sectionIndexByKey}
-              isCollapsed={collapsedDirectoryKeys.has(node.key)}
-              visibleFileCount={branchVisibleRows?.visibleFileCounts.get(node.key)}
-              onToggleDirectory={toggleDirectory}
-              onNavigate={onNavigate}
-            />
-          ))
+          <CombinedDiffFileTreeRows
+            rows={branchVisibleRows?.rows ?? branchRows}
+            visibleFileCounts={branchVisibleRows?.visibleFileCounts}
+            {...sharedRowProps}
+          />
         )}
       </div>
       <div

--- a/src/renderer/src/components/right-sidebar/source-control/listing/virtual-file-list.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/virtual-file-list.tsx
@@ -83,7 +83,8 @@ export function SourceControlVirtualFileList<TRow>({
   rows,
   getRowKey,
   renderRow,
-  scrollElement
+  scrollElement,
+  estimateRowHeightPx = SOURCE_CONTROL_FILE_ROW_HEIGHT_PX
 }: {
   rows: readonly TRow[]
   getRowKey: (row: TRow) => string
@@ -92,6 +93,9 @@ export function SourceControlVirtualFileList<TRow>({
   // yet when this component's mount effects run, so a ref would leave the
   // virtualizer unobserved until some unrelated re-render.
   scrollElement: HTMLDivElement | null
+  // Why: callers outside source control have their own row paddings; measureElement
+  // still corrects, but a wrong estimate makes the initial scrollbar jump.
+  estimateRowHeightPx?: number
 }): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
   const [scrollMargin, setScrollMargin] = useState(0)
@@ -124,7 +128,7 @@ export function SourceControlVirtualFileList<TRow>({
     count: rows.length,
     enabled: virtualize && scrollElement !== null,
     getScrollElement: () => scrollElement,
-    estimateSize: () => SOURCE_CONTROL_FILE_ROW_HEIGHT_PX,
+    estimateSize: () => estimateRowHeightPx,
     overscan: SOURCE_CONTROL_FILE_ROW_OVERSCAN,
     scrollMargin,
     // Why: stable row keys let the virtualizer carry item identity across


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​46 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 |

<!-- /orca-pr-loc -->

## ELI5

A 900-file review put all ~931 file-tree rows into the page at once, even though only about 25 of them fit on screen. This keeps only the visible window mounted — the same windowing the source-control panel already uses.

Split out of #18140. That PR keeps the free half (a cached section-index map, no user-facing change); **this** PR is the half with real trade-offs, so it is reviewed on its own. The two are independent, touch disjoint files, and can merge in either order.

## What changed

`combined-diff-file-tree.tsx` had three unvirtualized `rows.map(...)` sites. The three now go through one `CombinedDiffFileTreeRows` wrapper over the existing `SourceControlVirtualFileList`, with the same `SOURCE_CONTROL_VIRTUALIZE_MIN_ROWS = 50` threshold, its own `COMBINED_DIFF_TREE_ROW_HEIGHT_PX = 24` estimate, and the existing `measureSourceControlScrollMargin` / `observeSourceControlScrollMargin` machinery unchanged (the file tree's scroller hosts several groups in "All changes" mode, which is exactly what the scroll-margin path already handles).

`SourceControlVirtualFileList` gained one optional `estimateRowHeightPx` prop, defaulting to its current `SOURCE_CONTROL_FILE_ROW_HEIGHT_PX`, so the source-control panel's behaviour is byte-identical.

## Measurements

Measured with `combined-diff-file-tree-windowing.test.tsx`, driving a real `CombinedDiffFileTree` in happy-dom with a 600px viewport.

900-file review (931 tree rows: 900 files + 30 directories + `src`):

| | before | after |
| --- | --- | --- |
| Mounted rows | **931** | **35** |

Both numbers are measured from the test harness on this branch against the current base `3d67f2be2c5` (before = the same test with the three prod files reverted to `main`).

Below the 50-row threshold the mounted row count is still exactly `rows.length` (asserted at 45 of 45), with no `data-index` wrappers — byte-identical markup to today.

## Negative user-facing trade-offs

Above the 50-row threshold, only the windowed rows exist in the DOM. Three things degrade as a direct result. All three are the same trade already accepted for the source-control panel this reuses, and **none of them apply below 50 rows**:

- **Browser find-in-page** (`Cmd/Ctrl+F`, Electron's find bar) over the file tree only matches rows currently in the window. On a 900-file review, searching the tree for a filename that is scrolled out of view will not find it. The tree's own filter box (`query`) is unaffected and still searches all entries — it filters the row set, not the DOM.
- **Select-all-copy over the tree** yields only the mounted rows, not all 900 paths. Anyone using the tree as a way to copy a full file list loses that.
- **Tab order** covers only mounted rows on large trees, so keyboard traversal cannot reach an unmounted row without scrolling to it first.

## What I verified stays identical

- Same rows and same order — rows come from the unchanged `flattenCombinedDiffTreeRoots` / `getViewedCombinedDiffTreeVisibility`.
- Expand/collapse — `collapsedDirectoryKeys` is untouched.
- The "viewed" visibility filter and its per-directory counts.
- Keyboard and mouse navigation into the diff.
- Scroll restoration: the tree has no `scrollIntoView` and no scroll persistence of its own — `activeSectionKey` only styles a row, and `onNavigate` scrolls the *diff* pane, not the tree — so there was no scroll-restoration behaviour here to change.
- Scrollbar length: row heights are uniform 24px and `measureElement` still corrects, so the estimate does not cause drift.

## Regression tests

`combined-diff-file-tree-windowing.test.tsx`:

- `mounts every row below the virtualize threshold` — 45 rows, all mounted, no virtual-list container, zero `data-index` wrappers.
- `mounts only a window of rows for a large review` — 931 rows, virtual-list container present, mounted rows under a tenth of the total. **Fails without this change** (verified by reverting the three prod files: `expected null not to be null`, 931 mounted).

## Provider coverage

The change is in the provider-agnostic `editor/combined-diff` module. The tree is used by the local worktree `CombinedDiffViewer` and the two GitHub PR surfaces; GitLab's MR files tab renders a plain list and does not use this viewer. No GitHub-specific naming was added.

## Verification

Rebased onto current `main` (`3d67f2be2c5`). `virtual-file-list.tsx` has not changed on `main` since this work started, so the `estimateRowHeightPx` addition still applies cleanly and both `SourceControlVirtualFileList` suites pass.

- `pnpm tc` — clean
- `npx oxlint` on all changed paths — clean
- `npx oxlint --config config/oxlint-react-doctor.json` on the changed paths — clean
- `pnpm run check:code-quality:changed` — 0 new findings across 5 changed files (code quality, type-aware, React Doctor)
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/editor/combined-diff src/renderer/src/components/pull-request-page src/renderer/src/components/github-item-dialog src/renderer/src/components/right-sidebar/source-control` — 60 files, 511 tests passed, including the two `SourceControlVirtualFileList` suites with the new optional prop

No lint rule was disabled and no per-file budget or ignore list was extended.