### PR TITLE
fix(terminal): confirm an unrecognized foreground before downgrading agent prompts

### DIFF
--- a/src/main/runtime/orca-runtime-get-pty-record-for-pane-key.ts
+++ b/src/main/runtime/orca-runtime-get-pty-record-for-pane-key.ts
@@ -112,13 +112,25 @@ export class OrcaRuntimeWithGetPtyRecordForPaneKey extends OrcaRuntimeWithPruneM
       if (!ptyId || !trackedPty || !this.ptyController) {
         return false
       }
-      const agent = recognizeAgentProcess(
-        await this.ptyController.getForegroundProcess(ptyId)
-      )?.agent
+      let foregroundProcess = await this.ptyController.getForegroundProcess(ptyId)
+      let agent = recognizeAgentProcess(foregroundProcess)?.agent
+      // Why: the cached foreground name can be an executable basename nothing recognizes
+      // (macOS p_comm reports the native Claude installer as `2.1.258`), and treating that
+      // as "no agent" silently downgrades the prompt to unframed chunks, which Claude's
+      // composer truncates. A fresh process-table scan reads the real command line.
+      if (agent === undefined && this.ptyController.confirmForegroundProcess) {
+        foregroundProcess = await this.ptyController.confirmForegroundProcess(ptyId)
+        agent = recognizeAgentProcess(foregroundProcess)?.agent
+      }
       if (agent !== 'claude' && agent !== 'codex') {
         return false
       }
-      if (!(await this.isTerminalRunningAgent(handle, { retryForegroundWrappers: false }))) {
+      if (
+        !(await this.isTerminalRunningAgent(handle, {
+          retryForegroundWrappers: false,
+          foregroundProcess
+        }))
+      ) {
         return false
       }
       trackedPty.foregroundAgent = agent

--- a/src/main/runtime/orca-runtime-tests/terminal-settled-prompt-foreground-confirmation.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-settled-prompt-foreground-confirmation.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../orca-runtime-test-mocks.spec'
+import { store, syncSinglePty } from '../orca-runtime-test-fixtures.spec'
+
+// Why: node-pty's cached foreground name is p_comm on macOS, which reports the native Claude
+// install as its version directory (`2.1.258`). Reading that as "no agent" silently downgraded
+// `terminal.send --enter` from the atomic bracketed-paste route to unframed 16 KiB chunks,
+// which Claude's composer truncates for large prompts (STA-4577).
+describe('isTerminalRunningSettledPromptAgent foreground confirmation', () => {
+  it('confirms an unrecognized foreground name before refusing the settled route', async () => {
+    const getForegroundProcess = vi.fn(async () => '2.1.258')
+    const confirmForegroundProcess = vi.fn(async () => 'claude')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess,
+      confirmForegroundProcess
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(true)
+    expect(confirmForegroundProcess).toHaveBeenCalledWith('pty-1')
+    // The confirmed identity is reused; the cached read must not be re-consulted and win.
+    expect(getForegroundProcess).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps legacy delivery when confirmation also finds no target agent', async () => {
+    const confirmForegroundProcess = vi.fn(async () => 'vim')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => '2.1.258',
+      confirmForegroundProcess
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(false)
+    expect(confirmForegroundProcess).toHaveBeenCalledOnce()
+  })
+
+  it('does not confirm when the cached foreground already names a target agent', async () => {
+    const confirmForegroundProcess = vi.fn(async () => 'claude')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'claude',
+      confirmForegroundProcess
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(true)
+    expect(confirmForegroundProcess).not.toHaveBeenCalled()
+  })
+
+  it('refuses the settled route when the provider cannot confirm', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => '2.1.258'
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(false)
+  })
+})

--- a/src/main/runtime/orca-runtime-tests/terminal-settled-prompt-foreground-confirmation.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-settled-prompt-foreground-confirmation.spec.ts
@@ -7,24 +7,29 @@ import { store, syncSinglePty } from '../orca-runtime-test-fixtures.spec'
 // `terminal.send --enter` from the atomic bracketed-paste route to unframed 16 KiB chunks,
 // which Claude's composer truncates for large prompts (STA-4577).
 describe('isTerminalRunningSettledPromptAgent foreground confirmation', () => {
-  it('confirms an unrecognized foreground name before refusing the settled route', async () => {
-    const getForegroundProcess = vi.fn(async () => '2.1.258')
-    const confirmForegroundProcess = vi.fn(async () => 'claude')
-    const runtime = new OrcaRuntimeService(store)
-    runtime.setPtyController({
-      write: () => true,
-      kill: () => true,
-      getForegroundProcess,
-      confirmForegroundProcess
-    })
-    syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
-    const [terminal] = (await runtime.listTerminals()).terminals
+  // `2.1.258`: macOS p_comm for the native Claude install. `bash.exe`: the Windows daemon
+  // tracker answers with the shell fallback until its async scan lands.
+  it.each(['2.1.258', 'bash.exe'])(
+    'confirms an unrecognized foreground (%s) before refusing the settled route',
+    async (cachedForeground) => {
+      const getForegroundProcess = vi.fn(async () => cachedForeground)
+      const confirmForegroundProcess = vi.fn(async () => 'claude')
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess,
+        confirmForegroundProcess
+      })
+      syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
+      const [terminal] = (await runtime.listTerminals()).terminals
 
-    await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(true)
-    expect(confirmForegroundProcess).toHaveBeenCalledWith('pty-1')
-    // The confirmed identity is reused; the cached read must not be re-consulted and win.
-    expect(getForegroundProcess).toHaveBeenCalledTimes(1)
-  })
+      await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(true)
+      expect(confirmForegroundProcess).toHaveBeenCalledWith('pty-1')
+      // The confirmed identity is reused; the cached read must not be re-consulted and win.
+      expect(getForegroundProcess).toHaveBeenCalledTimes(1)
+    }
+  )
 
   it('keeps legacy delivery when confirmation also finds no target agent', async () => {
     const confirmForegroundProcess = vi.fn(async () => 'vim')

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -56,6 +56,7 @@ await import('./orca-runtime-tests/terminal-output-and-worker-recovery-part-06.s
 await import('./orca-runtime-tests/terminal-output-and-worker-recovery-part-07.spec')
 await import('./orca-runtime-tests/terminal-handles-and-agent-status.spec')
 await import('./orca-runtime-tests/terminal-handles-and-agent-status-part-02.spec')
+await import('./orca-runtime-tests/terminal-settled-prompt-foreground-confirmation.spec')
 await import('./orca-runtime-tests/terminal-handles-and-agent-status-part-03.spec')
 await import('./orca-runtime-tests/terminal-handles-and-agent-status-part-04.spec')
 await import('./orca-runtime-tests/terminal-handles-and-agent-status-part-05.spec')

--- a/src/main/runtime/runtime-terminal-agent-presence.ts
+++ b/src/main/runtime/runtime-terminal-agent-presence.ts
@@ -30,6 +30,8 @@ type RuntimeTerminalAgentPresenceDependencies = {
 
 export type RuntimeTerminalAgentPresenceOptions = {
   retryForegroundWrappers?: boolean
+  /** Foreground identity the caller already confirmed; skips the provider's cached read. */
+  foregroundProcess?: string | null
 }
 
 export class RuntimeTerminalAgentPresence {
@@ -75,7 +77,7 @@ export class RuntimeTerminalAgentPresence {
       if (!leaf.ptyId) {
         return false
       }
-      const foreground = await this.deps.getForegroundProcess(leaf.ptyId)
+      const foreground = await this.readForegroundProcess(leaf.ptyId, options)
       if (!foreground) {
         return false
       }
@@ -138,7 +140,7 @@ export class RuntimeTerminalAgentPresence {
     ) {
       return true
     }
-    const foreground = await this.deps.getForegroundProcess(pty.ptyId)
+    const foreground = await this.readForegroundProcess(pty.ptyId, options)
     if (!foreground) {
       return false
     }
@@ -155,6 +157,16 @@ export class RuntimeTerminalAgentPresence {
       suppressClaude,
       options.retryForegroundWrappers !== false
     )
+  }
+
+  private async readForegroundProcess(
+    ptyId: string,
+    options: RuntimeTerminalAgentPresenceOptions
+  ): Promise<string | null> {
+    if (options.foregroundProcess !== undefined) {
+      return options.foregroundProcess
+    }
+    return await this.deps.getForegroundProcess(ptyId)
   }
 
   private async isRecognizedForegroundAgentProcess(

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -299,10 +299,34 @@ describe('resolveDefaultCwd', () => {
 })
 
 describe('getForegroundProcessName', () => {
-  it('returns clear non-wrapper foregrounds without process-table enrichment', async () => {
-    await expect(getForegroundProcessName(100, 'vim')).resolves.toBe('vim')
+  it('keeps a non-agent foreground name when the process table shows no agent', async () => {
+    await withProcessPlatform('darwin', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return { stdout: ['100 99 Ss   zsh -l', '101 100 S+   vim notes.md'].join('\n') }
+        }
+        return new Error('unexpected command')
+      })
 
-    expect(execFileMock).not.toHaveBeenCalled()
+      await expect(getForegroundProcessName(100, 'vim')).resolves.toBe('vim')
+    })
+  })
+
+  it('resolves a macOS p_comm basename to the agent that owns the foreground', async () => {
+    // Why: node-pty reports the native Claude binary as its version directory (`2.1.258`);
+    // answering with that name downgrades agent prompts to unframed chunks (STA-4577).
+    await withProcessPlatform('darwin', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return {
+            stdout: ['100 99 Ss   zsh -l', '101 100 S+   claude --model haiku'].join('\n')
+          }
+        }
+        return new Error('unexpected command')
+      })
+
+      await expect(getForegroundProcessName(100, '2.1.258')).resolves.toBe('claude')
+    })
   })
 
   it('recognizes SSH relay node-wrapped agents from descendant command lines', async () => {

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -21,7 +21,6 @@ import {
   resolveOuterWrapperForegroundProcess,
   shouldInspectOuterWrapperForegroundProcess
 } from '../shared/foreground-wrapper-agent'
-import { isShellProcess } from '../shared/shell-process-detection'
 import {
   resolveWindowsAgentForegroundProcess,
   shouldInspectWindowsAgentForeground
@@ -309,10 +308,11 @@ export async function getForegroundProcessName(
         (await resolveWindowsAgentForegroundProcess(pid, fallbackProcess, {})) ?? fallbackProcess
       )
     }
-    if (!isShellProcess(fallbackProcess) && !isAgentForegroundWrapperProcess(fallbackProcess)) {
-      return fallbackProcess
-    }
   }
+  // Why: an unrecognized name is not proof of a non-agent foreground -- macOS p_comm truncates
+  // to the executable basename, which for the native Claude install is its version directory
+  // (`2.1.258`). The TTL-cached table read resolves the real command line; a foreground that
+  // is genuinely not an agent still answers with its own name below.
   const recognized = await getRecognizedForegroundDescendant(pid, fallbackProcess)
   if (recognized) {
     return recognized


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​106 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |

<!-- /orca-pr-loc -->

## Summary

Large prompts sent to Claude through `orca terminal send --text --enter` were still truncated after #17718 shipped in v1.4.194 (STA-4577). The atomic bracketed-paste route #17718 repaired was never taken.

`isTerminalRunningSettledPromptAgent` reads the provider's cached foreground name. On macOS that is node-pty's `p_comm`, which reports the native Claude install as its version directory (`2.1.258`, not `claude`). `recognizeAgentProcess()` returned nothing, the predicate answered "not a settled agent", and every send fell back to the generic 16 KiB chunked write with no bracketed-paste frame. Claude's composer truncates unframed multi-chunk input (`MISSING_BEGIN` / `MISSING_MIDDLE`). Codex (a `node` wrapper) was never affected.

Live diagnostic from the predicate on the unfixed build:

```
[paste-lab] settled=false foreground="2.1.258" agent=undefined osc="✳ Claude Code"
```

## Fix

- When the cached foreground is unrecognized, call `confirmForegroundProcess` (fresh process-table scan of the real command line) before refusing the settled route, and pass the confirmed identity into the presence check so the cached read cannot win it back.
- SSH relay: `getForegroundProcessName` no longer returns an unrecognized non-shell basename verbatim; it consults the TTL-cached process table first.
- Windows falls back for a different reason (the daemon tracker answers `bash.exe` until its async scan lands); the same confirm-first path covers it.

## Tests

- `terminal-settled-prompt-foreground-confirmation.spec.ts`: 4 cases (`2.1.258` and `bash.exe` cached names confirm to `claude`; confirmation finding no agent keeps legacy delivery; recognized cache skips confirmation; no confirm hook refuses).
- Relay: p_comm basename resolves to `claude`; non-agent foreground name is kept.
- All red on the unfixed predicate, green after. `tc:node`, `check:code-quality:changed`, `check:react-doctor:changed`, and the 1226-case runtime suite pass.

## Live evidence

Real Claude Code (Haiku), isolated `orca-dev serve` profiles, fresh session per run. Oracle: exact JSONL user content equals the fixture, plus the visible reply. Route discriminated by `bytesWritten` (text+13 = atomic, text+1 = chunked).

| Build | Route | Result |
|---|---|---|
| candidate before fix | generic-chunked | truncated, 3 of 3 |
| v1.4.193 | generic-chunked | truncated (prompt-1, prompt-3) |
| v1.4.194 (has #17718) | generic-chunked | truncated (prompt-1, prompt-3) |
| candidate after fix | atomic-agentPrompt | FULL on 65 KB / 101 KB / 119 KB fixtures, repeated, and at 0 / 1500 / 3000 ms after launch |
| Windows relay host (v1.4.195, unfixed) | generic-chunked | remote JSONL truncated: 2239/65711 and 4256/118944 bytes |

A standalone node-pty control showed the renderer clipboard framing (START, 16 KiB chunks, END as separate writes) arrives intact, so the paste executor is fine; the defect is purely route selection.

Not proven: the fixed build on the Windows host (needs a build there).
