### PR TITLE
fix(github): bound and coalesce the Orca star check so gh children cannot pile up

### DIFF
--- a/src/main/git/command-runner/gh-exec-file-deadline.test.ts
+++ b/src/main/git/command-runner/gh-exec-file-deadline.test.ts
@@ -1,0 +1,94 @@
+import { EventEmitter } from 'node:events'
+import type { ChildProcess } from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, spawnMock, killSpawnedCommandTreeMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  spawnMock: vi.fn(),
+  killSpawnedCommandTreeMock: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal()),
+  execFile: execFileMock,
+  spawn: spawnMock
+}))
+vi.mock('./spawned-command-tree-kill', () => ({
+  killSpawnedCommandTree: killSpawnedCommandTreeMock
+}))
+
+import { ghExecFileAsync } from './gh-exec-file'
+
+function mockChild(pid = 4321): ChildProcess {
+  const child = new EventEmitter() as EventEmitter & Record<string, unknown>
+  child.pid = pid
+  child.kill = vi.fn(() => true)
+  child.stdin = Object.assign(new EventEmitter(), { end: vi.fn() })
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  return child as unknown as ChildProcess
+}
+
+/**
+ * The contract the star check depends on after #18234: a `gh` that never exits
+ * is killed at the deadline, tree and all, rather than running forever.
+ */
+describe('gh exec deadline', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    execFileMock.mockReset()
+    spawnMock.mockReset()
+    killSpawnedCommandTreeMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('kills the process tree and rejects when gh never exits', async () => {
+    const child = mockChild()
+    // Why never invoking the callback: this is exactly the stuck child from
+    // #18234 — spawned, spinning, and never reporting an exit.
+    execFileMock.mockReturnValue(child)
+
+    const pending = ghExecFileAsync(['api', '--include', 'user/starred/stablyai/orca'], {
+      timeout: 15_000
+    })
+    const rejection = expect(pending).rejects.toThrow('timed out')
+    await vi.waitFor(() => expect(execFileMock).toHaveBeenCalledOnce())
+
+    // Not yet: the deadline has not elapsed.
+    expect(killSpawnedCommandTreeMock).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    await rejection
+
+    expect(killSpawnedCommandTreeMock).toHaveBeenCalledWith(child)
+  })
+
+  it('spawns with hidden console and captured stdio, never an inherited or shell stdio', async () => {
+    const child = mockChild()
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        callback(null, 'HTTP/2.0 204 No Content\r\n', '')
+        return child
+      }
+    )
+
+    await ghExecFileAsync(['api', '--include', 'user/starred/stablyai/orca'], { timeout: 15_000 })
+
+    const [command, args, options] = execFileMock.mock.calls[0]
+    expect(command).toBe('gh')
+    expect(args).toEqual(['api', '--include', 'user/starred/stablyai/orca'])
+    // `execFile` captures stdout/stderr over pipes and never inherits Orca's;
+    // `shell` is never set, and the console stays hidden on Windows.
+    expect(options.windowsHide).toBe(true)
+    expect(options.stdio).toBeUndefined()
+    expect(options.shell).toBeUndefined()
+  })
+})

--- a/src/main/git/command-runner/gh-spawn-boundary.test.ts
+++ b/src/main/git/command-runner/gh-spawn-boundary.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guard the gh chokepoint the way `child-process-import-boundary` guards spawn.
+ *
+ * `ghExecFileAsync` is what gives a gh invocation a deadline, a process-tree
+ * kill, transient-error retry, the rate-limit breaker, and WSL/host routing.
+ * Two call sites quietly opted out of all of it by reaching for the legacy
+ * `execFileAsync('gh', …)`, and one of them left `gh` children spinning at 100%
+ * CPU forever while permanently exhausting the GitHub concurrency semaphore
+ * (#18234). Nothing about those call sites looked wrong locally — which is why
+ * this is a tree-level rule rather than a review habit.
+ *
+ * The allowlist is empty and may only stay empty.
+ */
+const GH_SPAWN_PATTERN =
+  /(?:execFileAsync|commandExecFileAsync|execFileCapture|runProcess|spawnProcess|execFile|spawnSync|spawn)\s*\(\s*(['"`])gh\1|program:\s*(['"`])gh\2/
+
+// Why trailing slash: a sibling like command-runner-extras.ts is scanned, not exempted.
+const OWNER_DIRECTORY = 'src/main/git/command-runner/'
+const SCANNED_EXTENSIONS = ['.ts', '.tsx']
+const IGNORED_DIRECTORIES = new Set([
+  'node_modules',
+  'dist',
+  'out',
+  'build',
+  '.git',
+  '__fixtures__'
+])
+
+function isTestFile(path: string): boolean {
+  return /\.(?:test|spec)\.tsx?$/.test(path) || path.includes('/__tests__/')
+}
+
+function collectSourceFiles(root: string): string[] {
+  let found: string[] = []
+  let entries: string[]
+  try {
+    entries = readdirSync(root)
+  } catch {
+    return found
+  }
+  for (const entry of entries) {
+    if (IGNORED_DIRECTORIES.has(entry)) {
+      continue
+    }
+    const full = join(root, entry)
+    if (statSync(full).isDirectory()) {
+      found = found.concat(collectSourceFiles(full))
+      continue
+    }
+    if (SCANNED_EXTENSIONS.some((extension) => full.endsWith(extension))) {
+      found.push(full)
+    }
+  }
+  return found
+}
+
+describe('gh spawn boundary', () => {
+  it('routes every gh invocation through ghExecFileAsync', () => {
+    const repoRoot = resolve(__dirname, '..', '..', '..', '..')
+    const offenders = collectSourceFiles(join(repoRoot, 'src'))
+      .map((path) => relative(repoRoot, path).split('\\').join('/'))
+      .filter((path) => !isTestFile(path) && !path.startsWith(OWNER_DIRECTORY))
+      .filter((path) => GH_SPAWN_PATTERN.test(readFileSync(join(repoRoot, path), 'utf8')))
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/main/github/client-starred.test.ts
+++ b/src/main/github/client-starred.test.ts
@@ -26,47 +26,146 @@ vi.mock('./github-api-repository', async (importOriginal) =>
   )
 )
 
-import { checkOrcaStarred } from './client'
+import { __resetOrcaStarCheckForTests, checkOrcaStarred, starOrca } from './client'
 import { resetOriginRepositoryCache } from './client-test-harness'
 
-const { execFileAsyncMock, acquireMock, releaseMock } = clientMocks
+const { execFileAsyncMock, ghExecFileAsyncMock, acquireMock, releaseMock } = clientMocks
+
+/** Let the coalesced check reach its `await acquire()` continuation and spawn gh. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    await Promise.resolve()
+  }
+}
 
 describe('checkOrcaStarred', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     resetOriginRepositoryCache()
     execFileAsyncMock.mockReset()
+    ghExecFileAsyncMock.mockReset()
     acquireMock.mockReset()
     releaseMock.mockReset()
     acquireMock.mockResolvedValue(undefined)
+    __resetOrcaStarCheckForTests()
   })
 
   it('returns true only for an included successful GitHub response', async () => {
-    execFileAsyncMock.mockResolvedValueOnce({ stdout: 'HTTP/2.0 204 No Content\r\n', stderr: '' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'HTTP/2.0 204 No Content\r\n', stderr: '' })
 
     await expect(checkOrcaStarred()).resolves.toBe(true)
 
-    expect(execFileAsyncMock).toHaveBeenCalledWith(
-      'gh',
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
       ['api', '--include', 'user/starred/stablyai/orca'],
-      { encoding: 'utf-8' }
+      expect.objectContaining({ encoding: 'utf-8' })
     )
   })
 
   it('returns true for an HTTP 200 starred response', async () => {
-    execFileAsyncMock.mockResolvedValueOnce({ stdout: 'HTTP/2.0 200 OK\r\n', stderr: '' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'HTTP/2.0 200 OK\r\n', stderr: '' })
 
     await expect(checkOrcaStarred()).resolves.toBe(true)
   })
 
   it('returns false for GitHub 404 not starred responses', async () => {
-    execFileAsyncMock.mockRejectedValueOnce(new Error('HTTP 404: Not Found'))
+    ghExecFileAsyncMock.mockRejectedValueOnce(new Error('HTTP 404: Not Found'))
 
     await expect(checkOrcaStarred()).resolves.toBe(false)
   })
 
   it('returns null when gh exits successfully without response headers', async () => {
-    execFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
 
     await expect(checkOrcaStarred()).resolves.toBe(null)
+  })
+
+  // ── #18234: an unbounded, unreaped, un-deduped star check ──────────────
+
+  it('never spawns gh directly, so the spawn carries a deadline and a tree kill', async () => {
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'HTTP/2.0 204 No Content\r\n', stderr: '' })
+
+    await checkOrcaStarred()
+
+    // Why: the raw execFileAsync has no timeout, so a `gh` that never exits ran
+    // forever at 100% CPU and was never reaped. ghExecFileAsync bounds the child
+    // and kills its process tree on the deadline.
+    expect(execFileAsyncMock).not.toHaveBeenCalled()
+    const [, options] = ghExecFileAsyncMock.mock.calls[0]
+    expect(typeof options.timeout).toBe('number')
+    expect(options.timeout).toBeGreaterThan(0)
+    expect(Number.isFinite(options.timeout)).toBe(true)
+  })
+
+  it('coalesces concurrent checks onto one gh child', async () => {
+    let resolveGh: (value: { stdout: string; stderr: string }) => void = () => {}
+    ghExecFileAsyncMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveGh = resolve
+      })
+    )
+
+    const first = checkOrcaStarred()
+    const second = checkOrcaStarred()
+    const third = checkOrcaStarred()
+    await flushMicrotasks()
+
+    // Why: five call sites can ask at once; without coalescing each forked its
+    // own `gh` and four stuck children exhausted the GitHub semaphore.
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(acquireMock).toHaveBeenCalledTimes(1)
+
+    resolveGh({ stdout: 'HTTP/2.0 204 No Content\r\n', stderr: '' })
+    await expect(Promise.all([first, second, third])).resolves.toEqual([true, true, true])
+  })
+
+  it('starts a fresh check once the previous one has settled', async () => {
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'HTTP/2.0 404 Not Found\r\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'HTTP/2.0 204 No Content\r\n', stderr: '' })
+
+    await checkOrcaStarred()
+    await expect(checkOrcaStarred()).resolves.toBe(true)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('releases its GitHub concurrency slot when gh fails or times out', async () => {
+    ghExecFileAsyncMock.mockRejectedValueOnce(new Error('gh timed out.'))
+
+    await expect(checkOrcaStarred()).resolves.toBe(null)
+
+    // Why: a leaked slot is permanent — four of them wedge every GitHub feature
+    // in the app for the rest of the session.
+    expect(releaseMock).toHaveBeenCalledTimes(1)
+    expect(acquireMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('starOrca', () => {
+  beforeEach(async () => {
+    resetOriginRepositoryCache()
+    execFileAsyncMock.mockReset()
+    ghExecFileAsyncMock.mockReset()
+    acquireMock.mockReset()
+    releaseMock.mockReset()
+    acquireMock.mockResolvedValue(undefined)
+    __resetOrcaStarCheckForTests()
+  })
+
+  it('stars through the bounded gh runner and releases its slot', async () => {
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await expect(starOrca()).resolves.toBe(true)
+
+    expect(execFileAsyncMock).not.toHaveBeenCalled()
+    const [args, options] = ghExecFileAsyncMock.mock.calls[0]
+    expect(args).toEqual(['api', '-X', 'PUT', 'user/starred/stablyai/orca'])
+    expect(options.timeout).toBeGreaterThan(0)
+    expect(releaseMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports failure and still releases its slot when gh times out', async () => {
+    ghExecFileAsyncMock.mockRejectedValueOnce(new Error('gh timed out.'))
+
+    await expect(starOrca()).resolves.toBe(false)
+    expect(releaseMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -8,7 +8,7 @@ export {
   __resetTrackedUpstreamBranchCacheForTests
 } from './client/lookup/tracked-upstream-cache'
 export { addPRReviewComment, addPRReviewCommentReply } from './client/create/add-pr-review-comment'
-export { checkOrcaStarred, starOrca } from './client/fetch/orca-star'
+export { __resetOrcaStarCheckForTests, checkOrcaStarred, starOrca } from './client/fetch/orca-star'
 export { countWorkItems } from './client/list/count-work-items'
 export { createGitHubPullRequest } from './client/create/create-github-pull-request'
 export { getAuthenticatedViewer } from './client/fetch/authenticated-viewer'

--- a/src/main/github/client/fetch/authenticated-viewer.ts
+++ b/src/main/github/client/fetch/authenticated-viewer.ts
@@ -1,14 +1,17 @@
 import type { GitHubViewer } from '../../../../shared/github/pull-request-types'
-import { execFileAsync, acquire, release } from '../../gh-utils'
+import { ghExecFileAsync, acquire, release } from '../../gh-utils'
 /**
  * Get the authenticated GitHub viewer when gh is available and logged in.
  * Returns null when gh is unavailable, unauthenticated, or the lookup fails.
+ *
+ * Runs through `ghExecFileAsync` for its deadline and tree kill: a `gh` that
+ * never exits would otherwise hold one of the four GitHub concurrency slots
+ * forever (#18234).
  */
 export async function getAuthenticatedViewer(): Promise<GitHubViewer | null> {
   await acquire()
   try {
-    const { stdout } = await execFileAsync(
-      'gh',
+    const { stdout } = await ghExecFileAsync(
       ['api', 'user', '--jq', '{login: .login, email: .email}'],
       { encoding: 'utf-8' }
     )

--- a/src/main/github/client/fetch/orca-star.ts
+++ b/src/main/github/client/fetch/orca-star.ts
@@ -1,17 +1,45 @@
-import { execFileAsync, acquire, release } from '../../gh-utils'
+import { ghExecFileAsync, acquire, release } from '../../gh-utils'
 export const ORCA_REPO = 'stablyai/orca'
+
+/**
+ * Deadline for the two star-nag gh calls.
+ *
+ * Why bounded at all: these are the only gh call sites that used the raw
+ * `execFileAsync`, so a `gh` that never exits blocked forever, never released
+ * its GitHub concurrency slot, and left the child running (#18234). Why shorter
+ * than the 30s gh default: nothing here is user-visible work — the nag falls
+ * back to the browser button — so a slow answer is worth less than a bounded one.
+ */
+const STAR_GH_TIMEOUT_MS = 15_000
+
+let inFlightStarCheck: Promise<boolean | null> | null = null
 
 /**
  * Check if the authenticated user has starred the Orca repo.
  * Returns true if starred, false if not, null if unable to determine (gh unavailable).
  */
-export async function checkOrcaStarred(): Promise<boolean | null> {
+export function checkOrcaStarred(): Promise<boolean | null> {
+  // Why: five independent callers (landing button, settings section, threshold
+  // nag, agent-value moment, force-show) can ask at once and none of them knows
+  // about the others. Without coalescing, each forks its own `gh`, and four
+  // stuck children exhaust the 4-wide GitHub semaphore for the app's lifetime.
+  inFlightStarCheck ??= runOrcaStarredCheck().finally(() => {
+    inFlightStarCheck = null
+  })
+  return inFlightStarCheck
+}
+
+/** @internal Drop any coalesced check so suites cannot inherit one another's. */
+export function __resetOrcaStarCheckForTests(): void {
+  inFlightStarCheck = null
+}
+
+async function runOrcaStarredCheck(): Promise<boolean | null> {
   await acquire()
   try {
-    const { stdout, stderr } = await execFileAsync(
-      'gh',
+    const { stdout, stderr } = await ghExecFileAsync(
       ['api', '--include', `user/starred/${ORCA_REPO}`],
-      { encoding: 'utf-8' }
+      { encoding: 'utf-8', timeout: STAR_GH_TIMEOUT_MS }
     )
     const response = `${stdout ?? ''}\n${stderr ?? ''}`
     if (/HTTP\/\S+\s+(?:200|204)\b/.test(response)) {
@@ -24,7 +52,7 @@ export async function checkOrcaStarred(): Promise<boolean | null> {
     if (message.includes('HTTP 404')) {
       return false
     }
-    // Anything else (gh not installed, not authenticated, network issue)
+    // Anything else (gh not installed, not authenticated, network issue, timeout)
     return null
   } finally {
     release()
@@ -37,8 +65,9 @@ export async function checkOrcaStarred(): Promise<boolean | null> {
 export async function starOrca(): Promise<boolean> {
   await acquire()
   try {
-    await execFileAsync('gh', ['api', '-X', 'PUT', `user/starred/${ORCA_REPO}`], {
-      encoding: 'utf-8'
+    await ghExecFileAsync(['api', '-X', 'PUT', `user/starred/${ORCA_REPO}`], {
+      encoding: 'utf-8',
+      timeout: STAR_GH_TIMEOUT_MS
     })
     return true
   } catch {

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -16,6 +16,7 @@ import logo from '../../../../resources/logo.svg'
 import { translate } from '@/i18n/i18n'
 import { hasGitHubBackedProject, type PreflightIssue } from './landing-preflight-issues'
 import { useLandingPreflightRuntime } from './landing-preflight-runtime'
+import { useLandingOrcaStarState, type LandingStarState } from './landing-github-star-state'
 
 type ShortcutItem = {
   id: string
@@ -26,30 +27,20 @@ type ShortcutItem = {
 // Do not deep-link to /stargazers: GitHub 404s that page for users without repo write access.
 const ORCA_GITHUB_URL = 'https://github.com/stablyai/orca'
 
-type StarState = 'loading' | 'starred' | 'not-starred' | 'web-fallback' | 'hidden'
+type StarButtonProps = {
+  hasRepos: boolean
+  state: LandingStarState
+  setState: React.Dispatch<React.SetStateAction<LandingStarState>>
+}
 
-function GitHubStarButton({ hasRepos }: { hasRepos: boolean }): React.JSX.Element | null {
-  const [state, setState] = useState<StarState>('loading')
+function GitHubStarButton({
+  hasRepos,
+  state,
+  setState
+}: StarButtonProps): React.JSX.Element | null {
   const [menuOpen, setMenuOpen] = useState(false)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const mountedRef = useMountedRef()
-
-  useEffect(() => {
-    let cancelled = false
-    void window.api.gh.checkOrcaStarred().then((result) => {
-      if (cancelled) {
-        return
-      }
-      if (result === null) {
-        setState('web-fallback')
-      } else {
-        setState(result ? 'starred' : 'not-starred')
-      }
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [])
 
   useEffect(() => {
     if (!menuOpen) {
@@ -237,6 +228,7 @@ export default function Landing(): React.JSX.Element {
 
   // Why: the runtime-aware slice probes the active remote host instead of the renderer host.
   const { preflightIssues } = useLandingPreflightRuntime()
+  const [starState, setStarState] = useLandingOrcaStarState()
 
   const createWorktreeShortcut = useShortcutKeyDetails('workspace.create')
   const previousWorktreeShortcut = useShortcutKeyDetails('worktree.navigateUp')
@@ -318,7 +310,7 @@ export default function Landing(): React.JSX.Element {
 
       {showGitHubSupportFooter && (
         <div className="absolute bottom-6 left-0 right-0 flex justify-center">
-          <GitHubStarButton hasRepos={repos.length > 0} />
+          <GitHubStarButton hasRepos={repos.length > 0} state={starState} setState={setStarState} />
         </div>
       )}
     </div>

--- a/src/renderer/src/components/landing-github-star-state.ts
+++ b/src/renderer/src/components/landing-github-star-state.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react'
+
+export type LandingStarState = 'loading' | 'starred' | 'not-starred' | 'web-fallback' | 'hidden'
+
+/**
+ * Resolve the viewer's Orca star state once per Landing mount.
+ *
+ * Why it lives here and not in the star button: the button renders inside a
+ * footer that is conditionally mounted on whether `repos` currently carries a
+ * GitHub provider identity, and `repos` is rewritten wholesale on every
+ * repo-catalog push. Every flicker of that condition re-ran the button's mount
+ * effect and forked another `gh api user/starred/...` (#18234). Landing itself
+ * only mounts when the user navigates, so the check runs once per visit.
+ */
+export function useLandingOrcaStarState(): [
+  LandingStarState,
+  Dispatch<SetStateAction<LandingStarState>>
+] {
+  const [state, setState] = useState<LandingStarState>('loading')
+
+  useEffect(() => {
+    let cancelled = false
+    void window.api.gh.checkOrcaStarred().then((result) => {
+      if (cancelled) {
+        return
+      }
+      if (result === null) {
+        setState('web-fallback')
+      } else {
+        setState(result ? 'starred' : 'not-starred')
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return [state, setState]
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​274 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​264 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​96 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​33 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 |

<!-- /orca-pr-loc -->

Fixes #18234

## ELI5

Orca asks GitHub "has this user starred the Orca repo?" by shelling out to `gh`. It asked that question with no time limit, no way to kill the helper if it wedged, and no memory that it had already asked. On the reporter's Linux box the `gh` helper never finished — it spun a CPU core at 100% — and Orca kept starting new ones without cleaning up the old ones. Four of them were still running after 1h48m each.

There is a second, quieter half the reporter did not see: every stuck helper also holds one of only **four** slots Orca has for talking to GitHub at all. Four stuck helpers means the user's entire GitHub integration — PR status, checks, issues, reviews — was silently dead for the rest of the session, not just burning CPU.

This PR does not fix whatever makes `gh` spin on that machine (see "What is still open"). It makes the spin survivable: the helper now gets a deadline and a kill, Orca only ever asks once at a time, and the UI stops re-asking every few seconds.

## Root cause

Three separate defects stack up. Only the first is speculative-free-standing; all three are proven below.

### 1. The star check was the only gh call site with no deadline and no kill

`src/main/github/client/fetch/orca-star.ts` used `execFileAsync`, i.e. `promisify(execFile)` from `src/main/github/gh-utils.ts:10`, with **no `timeout` option**:

```ts
const { stdout, stderr } = await execFileAsync(
  'gh',
  ['api', '--include', `user/starred/${ORCA_REPO}`],
  { encoding: 'utf-8' }        // ← no timeout, no kill, no tree termination
)
```

Every other gh call in the app goes through `ghExecFileAsync` (`src/main/git/command-runner/gh-exec-file.ts`), which supplies a 30s deadline and, on expiry, `killSpawnedCommandTree(child)` — a real process-**tree** kill, which matters here because the chain is `bash shim → mise x → gh` and killing only the direct child orphans the rest. That is precisely the reparenting to `systemd --user` the reporter observed.

`getAuthenticatedViewer` (`gh api user`) had the identical defect. After this PR a repo-wide sweep finds **zero** files outside the command runner naming `gh` as a spawned program, and a ratchet test keeps it that way.

### 2. A hung child permanently exhausts the GitHub concurrency semaphore

`acquire()` / `release()` in `src/main/github/gh-utils.ts:44` is a **4-wide semaphore over every GitHub operation in the app**. `checkOrcaStarred` acquires before the spawn and releases in `finally`. With no deadline, a `gh` that never exits means `finally` never runs and the slot is leaked forever.

This is what explains the reporter finding **exactly four** stuck children and no more. It is not a coincidence — it is `MAX_CONCURRENT = 4`. It also means their PR/checks/issues polling had been queued behind a permanently full semaphore.

### 3. The ~12s respawn is a remount, not a poll

There is no timer anywhere that calls `checkOrcaStarred`. I checked every `setInterval` and self-rescheduling `setTimeout` in `src/main` and `src/renderer/src`; none reaches it. There are only four callers, all event-driven.

The repeat comes from a **remount**. `Landing.tsx` computed:

```ts
const showGitHubSupportFooter = repos.length === 0 || hasGitHubProject
```

and rendered `<GitHubStarButton>` — whose mount effect fires the gh call — only inside that conditional footer. `repos` is rewritten wholesale on every `repos:changed` push, and `hasGitHubBackedProject` needs a resolved `providerIdentity.provider === 'github'`. Any push whose intermediate state lacks that identity unmounts the footer; the next one remounts it and forks another `gh`, with zero caching on the main side.

## Evidence

**Mechanism demo.** A `gh` that never exits (`while :; do :; done`), driven at the reporter's 12s cadence through both code shapes, with the real `gh-utils` semaphore:

```
=== BEFORE ===                              === AFTER ===
t= 0s  live gh children=0  sem=1/4          t= 0s  live gh children=0  sem=1/4
t= 5s  live gh children=1  sem=1/4          t= 5s  live gh children=1  sem=1/4
t=10s  live gh children=1  sem=1/4          t=10s  live gh children=1  sem=1/4
t=15s  live gh children=2  sem=2/4          t=15s  live gh children=1  sem=0/4
t=20s  live gh children=2  sem=2/4          t=20s  live gh children=0  sem=0/4
t=25s  live gh children=3  sem=3/4          t=25s  live gh children=1  sem=1/4
t=30s  live gh children=3  sem=3/4          t=30s  live gh children=1  sem=1/4
t=35s  live gh children=3  sem=3/4          t=35s  live gh children=1  sem=1/4
t=40s  live gh children=4  sem=4/4          t=40s  live gh children=0  sem=0/4
t=45s  live gh children=4  sem=4/4          t=45s  live gh children=0  sem=0/4
final: 4 live children, semaphore 4/4       final: 1 live child, semaphore 1/4
       — never recovers                            — drains every cycle
```

**Ruling out two of the reporter's structural clues**, so nobody else spends time on them:

- **stdin/stdout being sockets is normal, not a symptom.** libuv implements `stdio: 'pipe'` with `socketpair(AF_UNIX, SOCK_STREAM)`, not `pipe(2)`. Every Node and Electron child on Linux shows sockets on fd 0/1/2. It confirms a Node spawn; it is not evidence of a defect. The child's end is left blocking, so a parent that stopped reading would show state `S` at 0% CPU — consistent with the reporter's own observation that this is `R`, and with their conclusion that the child is not blocked on I/O.
- **`LD_LIBRARY_PATH` pollution is real but is not the cause.** I extracted the shipped `AppRun` from the real v1.4.195 AppImage. It exports `APPDIR`, `PATH="$APPDIR:$APPDIR/usr/sbin:$PATH"`, `LD_LIBRARY_PATH="$APPDIR/usr/lib"`, `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR` into every child Orca spawns, and defends against exactly this for its own helpers (`LD_LIBRARY_PATH="" zenity …`). But `$APPDIR/usr/lib` holds only `libappindicator.so.1`, `libgconf-2.so.4`, `libindicator.so.7`, `libnotify.so.4`, `libXss.so.1`, `libXtst.so.6` — no libc, libstdc++, libssl or libz to shadow. Driving the mise shim from Node's `execFile` on Ubuntu 24.04 with that exact directory on the loader path, 100 inherited descriptors and `ulimit -n 524288`, `gh` completed in 279–328ms on every attempt. Negative result, reported so the hypothesis can be retired.

## Measurements

| | before | after |
|---|---|---|
| Live `gh` children after 45s at the reporting cadence | 4 | 0–1 |
| Peak concurrent `gh` children | 4 (unbounded by time) | 1 |
| Max lifetime of a wedged child | unbounded (1h48m observed) | 15s, then `SIGKILL` to the tree |
| GitHub semaphore after 4 hangs | 4/4, permanent | 0/4, drains every cycle |
| CPU burned by wedged children | 4 cores, indefinitely | ≤1 core, ≤15s per cycle |
| gh spawns per star check, 3 concurrent callers | 3 | 1 |

## Changes

- `orca-star.ts` — route through `ghExecFileAsync` (15s deadline + tree kill); coalesce concurrent `checkOrcaStarred` calls onto one in-flight child, cleared on settle so the answer is never cached or stale.
- `authenticated-viewer.ts` — same routing for `gh api user`.
- `landing-github-star-state.ts` (new) + `Landing.tsx` — hoist the star-state effect above the conditionally rendered footer, so a repo-catalog rewrite no longer remounts it and re-forks gh. Landing itself only mounts on navigation, so the check runs once per visit.
- Tests — bounded spawn, kill-on-timeout, in-flight dedupe, semaphore release on failure, stdio/`windowsHide` intent, plus a `gh-spawn-boundary` ratchet with an empty allowlist.

## Negative user-facing trade-offs

**One, and it is small.** On a network where `gh api` takes longer than 15s the star check now reports `null` instead of eventually reporting the true answer. `null` is already a first-class outcome — it routes the prompt to the browser-star fallback, which is a working path, not a dead button. The previous behaviour was not "a correct answer later": the UI had long since resolved, so the late answer was discarded anyway while the child kept running. Everything else is unchanged: the same argv, the same 200/204 → starred, 404 → not starred, anything-else → null mapping, and the same prompt behaviour.

Nothing else regresses. `ghExecFileAsync` adds transient-5xx retry (2 attempts, 250ms/1s, bounded), the rate-limit breaker, and WSL/host fallback — all improvements. Windows `.cmd` argument encoding and `windowsHide` are untouched; `execFileCapture` already pins `windowsHide: true` and never uses `shell`. Nothing changes for SSH/remote: the star check is a local-host, main-process concern and is not exposed over runtime RPC.

## What is still open (not fixed here, deliberately)

1. **Why `gh` spins on that machine.** I could not reproduce it. I set up mise 2026.x + gh 2.98.0 + the same bash shim on Ubuntu 24.04 and drove it from Node's `execFile` with the AppImage environment, 100 inherited descriptors and the reporter's `RLIMIT_NOFILE` — 280–350ms every time. It needs the reporter's Arch/Omarchy toolchain. I have posted the exact `strace -c -p`, `ls -l /proc/<pid>/fd` and `cat /proc/<pid>/stack` commands on the issue; the reporter offered to run them.
2. **~100 descriptors inherited from Electron.** Real, and a genuine second defect, but not fixable at Orca's spawn layer: libuv relies on `O_CLOEXEC` rather than walking the fd table, and Chromium opens `DawnWebGPUCache`/`DawnGraphiteCache` entries without it. Needs an upstream fix or a closing exec shim.
3. **Updating does not terminate the previous instance.** The reporter had 1.4.190 and 1.4.195 running side by side with both squashfs mounts active, which doubles every background cost. Worth its own issue.
4. **`repos` being rewritten wholesale on every `repos:changed` push.** The hoist above makes the star check immune, but the remount storm itself is real churn for anything else mounted under a `repos`-derived condition. That is surgery on the publish path, so: follow-up, not this PR.
