### PR TITLE
test(editor): isolate prefix bleed in the batched model sweep, drop a dead export

### DIFF
--- a/src/renderer/src/components/editor/closed-editor-tab-cache-sweep.test.ts
+++ b/src/renderer/src/components/editor/closed-editor-tab-cache-sweep.test.ts
@@ -1,8 +1,51 @@
 import { describe, expect, it } from 'vitest'
 import type { PdfViewPosition } from '@/lib/scroll-cache'
-import { sweepClosedPdfViewPositions } from './closed-editor-tab-cache-sweep'
+import {
+  deletePaneScopedCacheEntries,
+  sweepClosedPdfViewPositions
+} from './closed-editor-tab-cache-sweep'
 
 const position = (pageNumber: number): PdfViewPosition => ({ pageNumber, top: 0, left: 0 })
+
+describe('deletePaneScopedCacheEntries', () => {
+  it('does not delete an owner whose id merely extends a closed owner id', () => {
+    const cache = new Map([
+      ['tab-1::pane-1', 1],
+      ['tab-10::pane-1', 2],
+      ['tab-1x::pane-1', 3]
+    ])
+    deletePaneScopedCacheEntries(cache, ['tab-1'])
+    expect([...cache.keys()]).toEqual(['tab-10::pane-1', 'tab-1x::pane-1'])
+  })
+
+  it('matches an owner that ends at the second `::` of a `:::` run', () => {
+    // Locks the `boundary + 1` advance in hasPaneScopeOwner: `a:` ends at index 2, which only the
+    // second `::` of the run exposes. A `+ 2` advance would skip it and leak the entry.
+    const cache = new Map([
+      ['a:::b', 1],
+      ['a::b', 2],
+      ['ab:::c', 3]
+    ])
+    deletePaneScopedCacheEntries(cache, ['a:'])
+    expect([...cache.keys()]).toEqual(['a::b', 'ab:::c'])
+  })
+
+  it('sweeps every owner in the batch in one pass', () => {
+    const cache = new Map([
+      ['tab-1::pane-1', 1],
+      ['tab-2::pane-1', 2],
+      ['tab-3::pane-1', 3]
+    ])
+    deletePaneScopedCacheEntries(cache, ['tab-1', 'tab-3'])
+    expect([...cache.keys()]).toEqual(['tab-2::pane-1'])
+  })
+
+  it('is a no-op for an empty owner batch', () => {
+    const cache = new Map([['tab-1::pane-1', 1]])
+    deletePaneScopedCacheEntries(cache, [])
+    expect(cache.size).toBe(1)
+  })
+})
 
 describe('sweepClosedPdfViewPositions', () => {
   it('deletes the unscoped :pdf entry', () => {

--- a/src/renderer/src/components/editor/closed-editor-tab-cache-sweep.ts
+++ b/src/renderer/src/components/editor/closed-editor-tab-cache-sweep.ts
@@ -26,6 +26,9 @@ function hasPaneScopeOwner(key: string, owners: ReadonlySet<string>): boolean {
   for (
     let boundary = key.indexOf('::');
     boundary !== -1;
+    // `+ 1`, not `+ 2`: in a `:::` run the second `::` starts one char after the first, and it can
+    // be the only boundary an owner ends at (owner `a:` against key `a:::b`). Skipping to `+ 2`
+    // steps over it and silently leaks that entry.
     boundary = key.indexOf('::', boundary + 1)
   ) {
     if (owners.has(key.slice(0, boundary))) {

--- a/src/renderer/src/components/editor/closed-editor-tab-disposal.test.ts
+++ b/src/renderer/src/components/editor/closed-editor-tab-disposal.test.ts
@@ -226,6 +226,30 @@ describe('disposeClosedEditorTabs', () => {
     expect(scrollTopCache.size).toBe(0)
   })
 
+  // Why this is not covered by the parity test above: `buildScenario` closes tab-0..tab-99, so
+  // tab-10 is in the closed batch too. Prefix bleed from tab-1 would dispose tab-10's models, but
+  // the per-tab oracle disposes them as well via tab-10's own prefix, so the two agree and the
+  // assertion still passes. Isolating it needs a still-OPEN tab whose id extends a closed one.
+  it('does not dispose a still-open tab whose id extends a closed tab id', () => {
+    const closed = getDiffViewerMonacoModelPaths({ modelKey: 'tab-1', generationSuffix: '' })
+    const stillOpen = getDiffViewerMonacoModelPaths({ modelKey: 'tab-10', generationSuffix: '' })
+    const models = [
+      createModel(closed.originalModelPath),
+      createModel(closed.modifiedModelPath),
+      createModel(stillOpen.originalModelPath),
+      createModel(stillOpen.modifiedModelPath)
+    ]
+
+    // Batched entry point on purpose: the owned prefixes become a Set probed at the URI's own `:`
+    // boundaries, which is a different predicate from the pre-batch per-prefix `startsWith`.
+    disposeClosedEditorTabs(createRegistry(models), [diffTab('tab-1'), diffTab('tab-2')])
+
+    expect(models.filter((m) => m.disposed).map((m) => m.path)).toEqual([
+      closed.originalModelPath,
+      closed.modifiedModelPath
+    ])
+  })
+
   it('is a no-op when nothing closed', () => {
     const registry = createRegistry([createModel('diff:original:tab-1:tab-1')])
     disposeClosedEditorTabs(registry, [])

--- a/src/renderer/src/components/editor/diff-monaco-model-disposal.test.ts
+++ b/src/renderer/src/components/editor/diff-monaco-model-disposal.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   disposeUnattachedDiffViewerMonacoModels,
   disposeUnattachedMonacoModelPaths,
-  disposeUnattachedMonacoModelsByPathPrefix,
+  disposeUnattachedMonacoModelsByPathPrefixes,
   getDiffViewerMonacoModelPathPrefixes,
   getDiffViewerMonacoModelPaths
 } from './diff-monaco-model-disposal'
@@ -139,7 +139,7 @@ describe('diff Monaco model disposal', () => {
     const monacoRegistry = createRegistry(models)
     const { originalModelPathPrefix } = getDiffViewerMonacoModelPathPrefixes('tab-1')
 
-    disposeUnattachedMonacoModelsByPathPrefix(monacoRegistry, originalModelPathPrefix)
+    disposeUnattachedMonacoModelsByPathPrefixes(monacoRegistry, [originalModelPathPrefix])
 
     expect(baseDispose).toHaveBeenCalledOnce()
     expect(generatedDispose).toHaveBeenCalledOnce()
@@ -177,7 +177,7 @@ describe('diff Monaco model disposal', () => {
     const monacoRegistry = createRegistry(models)
     const { originalModelPathPrefix } = getDiffViewerMonacoModelPathPrefixes('foo')
 
-    disposeUnattachedMonacoModelsByPathPrefix(monacoRegistry, originalModelPathPrefix)
+    disposeUnattachedMonacoModelsByPathPrefixes(monacoRegistry, [originalModelPathPrefix])
 
     expect(ownedDispose).toHaveBeenCalledOnce()
     expect(siblingDispose).not.toHaveBeenCalled()

--- a/src/renderer/src/components/editor/diff-monaco-model-disposal.ts
+++ b/src/renderer/src/components/editor/diff-monaco-model-disposal.ts
@@ -79,13 +79,6 @@ export function disposeUnattachedMonacoModelPaths(
   }
 }
 
-export function disposeUnattachedMonacoModelsByPathPrefix(
-  monacoRegistry: MonacoModelRegistry,
-  modelPathPrefix: string
-): void {
-  disposeUnattachedMonacoModelsByPathPrefixes(monacoRegistry, [modelPathPrefix])
-}
-
 /**
  * Sweeps every owned prefix in a single scan of the global model registry.
  *

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -215,6 +215,12 @@ function buildTitleDerivedAgentRow(args: {
     agentType,
     rowSource: 'live',
     state: rowState,
+    // Load-bearing zero, not a placeholder: `dashboardRowBucketProjection` reads `startedAt === 0`
+    // as "title-derived" and short-circuits `unseen`. That is the ONLY reason the `args.now` stamps
+    // on `entry` above (updatedAt / stateStartedAt / observation) cannot move this row's bucket.
+    // Dashboard bucket caches key their invalidation on the freshness boundary in
+    // `isExplicitAgentStatusFresh` alone; give this a real timestamp and every one of them starts
+    // serving stale counts, with no test failing at the point of the change.
     startedAt: 0
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

A test that looked like it was guarding against a whole class of bug turned out to be structurally unable to see it. This adds a test that can, records two invariants that a future "cleanup" would silently break, and deletes an export #18144 left behind with a false justification attached.

Follow-up to #18144, found during readiness review. No production behaviour change except the removal of an unused export.

## 1. The parity test cannot see prefix bleed

`closed-editor-tab-disposal.test.ts` proves the batched sweep disposes exactly what the pre-batch per-tab sweep disposed, by running both over the same fixture. That is a good test, but it is blind to prefix bleed — the bug where closing `tab-1` also disposes `tab-10`'s models.

`buildScenario` closes `tab-0`…`tab-99`, so `tab-10` is in the closed batch too. A bleeding predicate would dispose `tab-10`'s models, but the per-tab oracle disposes them as well via `tab-10`'s *own* prefix. The two agree, and `disposedPaths(batched) === disposedPaths(perTab)` still passes.

Verified rather than assumed. Replacing the boundary probe in `isOwnedByPathPrefix` with a naive `startsWith` over the prefix set:

```
Tests  1 failed | 5 passed (6)   <- only the new test fails
```

All five pre-existing tests in that file stayed green under a predicate that disposes the wrong tab's models.

The new test closes `tab-1` while leaving `tab-10` **open**, and goes through the batched `disposeClosedEditorTabs` entry point on purpose — that is where the owned prefixes become a `Set` probed at the URI's own `:` boundaries against `shortestPrefixLength`/`longestPrefixLength`, which is a different predicate from the pre-batch per-prefix `startsWith`.

### Scope correction

`diff-monaco-model-disposal.test.ts` **does** already cover prefix bleed, for the encoded-colon sibling shape (`foo` vs `foo:bar`) — both of its prefix tests fail under the same mutation. So this was never entirely uncovered. What was missing is coverage at the batched entry point, with a multi-prefix `Set`, in the realistic `tab-1` vs `tab-10` shape.

## 2. `boundary + 1` is load-bearing

`hasPaneScopeOwner` advances by one character, not two. In a `:::` run the second `::` starts one character after the first, and it can be the only boundary an owner ends at — owner `a:` against key `a:::b`. Advancing by `+ 2` steps over it and silently leaks the entry.

That reads like an off-by-one waiting to be tidied up, so it now has both a comment and a test that fails under the `+ 2` version:

```
× matches an owner that ends at the second `::` of a `:::` run
AssertionError: expected [ 'a:::b', 'a::b', 'ab:::c' ] to deeply equal [ 'a::b', 'ab:::c' ]
```

This also gives `deletePaneScopedCacheEntries` direct unit coverage (owner-extension, batch sweep, empty batch), which it did not have — it was only exercised through `sweepClosedPdfViewPositions` and the disposal hook.

## 3. Dead export with a false justification

#18144's description says `disposeUnattachedMonacoModelsByPathPrefix` was "kept as a one-element wrapper for its other callers". It has no other callers — after that PR the only two call sites are in its own test file. Removed, and both call sites now use the plural form directly.

## 4. Why `startedAt: 0` is load-bearing

Not part of the #18144 change, but the same review turned up a landmine worth writing down where someone will actually see it.

`buildTitleDerivedAgentRow` stamps `updatedAt`, `stateStartedAt`, and `observation.revision`/`observedAt` from `args.now`. Those look freshness-dependent, and a reader could reasonably conclude a title-derived row's bucket decays with the clock. It does not — solely because the row carries `startedAt: 0`, which makes `dashboardRowBucketProjection` set `isTitleDerived` and short-circuit `unseen`.

Every dashboard bucket cache keys its invalidation on the freshness boundary in `isExplicitAgentStatusFresh` alone. Give title-derived rows a real timestamp and all of them start serving stale counts, with no test failing at the point of the change. That is now a comment on the line.

## Verification

- 504 test files / 3926 tests pass across `editor/`, `sidebar/`, `dashboard/`
- `pnpm tc` clean, `oxlint` clean, `oxfmt --check` clean
- Both new tests confirmed fail-first by mutating the implementation, then restored
