### PR TITLE
refactor(process-table): extract the correlation indexes into their own module

### DIFF
--- a/src/main/providers/agent-foreground-process-batch.test.ts
+++ b/src/main/providers/agent-foreground-process-batch.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { parseStrictProcessTableRows } from '../../shared/process-table-snapshot'
 import {
   buildProcessTableIndex,
-  parseStrictProcessTableRows,
   type ProcessTableIndexStats
-} from '../../shared/process-table-snapshot'
+} from '../../shared/process-table-index'
 import {
   resolveAgentForegroundProcessesBatch,
   resolveAgentForegroundProcessesFromIndex

--- a/src/main/providers/agent-foreground-process-batch.ts
+++ b/src/main/providers/agent-foreground-process-batch.ts
@@ -7,13 +7,15 @@ import { resolveOuterWrapperForegroundProcess } from '../../shared/foreground-wr
 import { selectForegroundProcessCandidate } from '../../shared/foreground-process-selection'
 import type { ForegroundProcessEvidence } from '../../shared/foreground-process-evidence'
 import {
-  buildProcessTableIndex,
   getStrictProcessTableSnapshot,
-  lookupProcessTableIndex,
   type ProcessTableIndex,
-  type ProcessTableIndexStats,
   type ProcessTableRow
 } from '../../shared/process-table-snapshot'
+import {
+  buildProcessTableIndex,
+  lookupProcessTableIndex,
+  type ProcessTableIndexStats
+} from '../../shared/process-table-index'
 
 export type BatchedForegroundProcessRequest = {
   rootPid: number

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -1,12 +1,11 @@
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
 import { resolveOuterWrapperForegroundProcess } from '../../shared/foreground-wrapper-agent'
 import {
-  collectDescendantsFromIndex,
   getFreshProcessTableSnapshot,
-  getProcessTableIndex,
   getProcessTableSnapshot,
   type ProcessTableRow
 } from '../../shared/process-table-snapshot'
+import { collectDescendantsFromIndex, getProcessTableIndex } from '../../shared/process-table-index'
 import {
   resolveWindowsAgentForegroundProcessWithAvailability,
   shouldInspectWindowsAgentForeground,

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -1,7 +1,4 @@
-import {
-  collectDescendantsFromIndex,
-  getProcessTableIndex
-} from '../../shared/process-table-snapshot'
+import { collectDescendantsFromIndex, getProcessTableIndex } from '../../shared/process-table-index'
 import {
   readWindowsProcessTable,
   readWindowsProcessTableFresh,

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -10,11 +10,11 @@ import {
 } from '../shared/agent-process-recognition'
 import { getFirstCommandToken } from '../shared/command-token-scanner'
 import {
-  getProcessTableIndex,
   getProcessTableSnapshot,
   type ProcessTableIndex,
   type ProcessTableRow
 } from '../shared/process-table-snapshot'
+import { getProcessTableIndex } from '../shared/process-table-index'
 import { selectForegroundProcessCandidate } from '../shared/foreground-process-selection'
 import {
   resolveOuterWrapperForegroundProcess,

--- a/src/shared/process-table-index.ts
+++ b/src/shared/process-table-index.ts
@@ -1,0 +1,117 @@
+/**
+ * Correlation indexes over a process-table capture, generic over the row shape so the POSIX
+ * `ps` snapshot and the Windows process table share one pass instead of parallel ones.
+ */
+
+export type ProcessTableIndexStats = {
+  captures?: number
+  indexBuilds: number
+  rowVisits: number
+  indexLookups: number
+}
+
+/** The parent/child fields every process-table row shape shares. */
+export type ProcessIdentityRow = { pid: number; ppid: number }
+
+export type ProcessTableIndexOf<Row extends ProcessIdentityRow> = {
+  rows: readonly Row[]
+  byPid: ReadonlyMap<number, Row>
+  childrenByPpid: ReadonlyMap<number, readonly Row[]>
+  stats?: ProcessTableIndexStats
+}
+
+/**
+ * Build the correlation indexes in one linear pass over a capture. Only the
+ * indexes a resolver actually reads are materialized: group indexes would cost
+ * two more maps plus a per-row array allocation on every capture, and foreground
+ * membership is derived from each row's own `pgid` against the root's `tpgid`.
+ *
+ * Generic over the row shape so the Windows snapshot (`pid`/`ppid`/`name`/
+ * `command`) shares this pass rather than carrying a parallel one.
+ */
+export function buildProcessTableIndex<Row extends ProcessIdentityRow>(
+  rows: readonly Row[],
+  stats?: ProcessTableIndexStats
+): ProcessTableIndexOf<Row> {
+  if (stats) {
+    stats.indexBuilds += 1
+  }
+  const byPid = new Map<number, Row>()
+  const childrenByPpid = new Map<number, Row[]>()
+  for (const row of rows) {
+    if (stats) {
+      stats.rowVisits += 1
+    }
+    // Preserve rows.find() semantics if a malformed table repeats a pid
+    if (!byPid.has(row.pid)) {
+      byPid.set(row.pid, row)
+    }
+    const children = childrenByPpid.get(row.ppid) ?? []
+    children.push(row)
+    childrenByPpid.set(row.ppid, children)
+  }
+  return { rows, byPid, childrenByPpid, stats }
+}
+
+/**
+ * Depth-first descendants of `rootPid`, deepest-last, off a prebuilt index.
+ *
+ * Each row is copied with its depth, so callers may not mutate the index's rows
+ * through the result. Ordering matches a per-call `childrenByPpid` walk exactly:
+ * children keep capture order and the stack pops last-pushed first.
+ */
+export function collectDescendantsFromIndex<Row extends ProcessIdentityRow>(
+  index: ProcessTableIndexOf<Row>,
+  rootPid: number
+): (Row & { depth: number })[] {
+  const descendants: (Row & { depth: number })[] = []
+  const stack = (index.childrenByPpid.get(rootPid) ?? []).map((row) => ({ row, depth: 1 }))
+  while (stack.length > 0) {
+    const { row, depth } = stack.pop()!
+    descendants.push({ ...row, depth })
+    for (const child of index.childrenByPpid.get(row.pid) ?? []) {
+      stack.push({ row: child, depth: depth + 1 })
+    }
+  }
+  return descendants
+}
+
+export function lookupProcessTableIndex<Row extends ProcessIdentityRow, T>(
+  index: ProcessTableIndexOf<Row>,
+  lookup: (index: ProcessTableIndexOf<Row>) => T,
+  stats = index.stats
+): T {
+  if (stats) {
+    stats.indexLookups += 1
+  }
+  return lookup(index)
+}
+
+// Keyed by array identity, which also pins the row shape the entry was built
+// for, so the one cast below cannot hand a caller another row type's index.
+const processTableIndexes = new WeakMap<readonly ProcessIdentityRow[], unknown>()
+
+/**
+ * Memoize one index per snapshot identity, so the panes that share a TTL-cached
+ * capture walk its rows once instead of once each. Keyed weakly by the rows
+ * array, so an index dies with the snapshot that produced it. The shared build
+ * materializes only `byPid` and `childrenByPpid`, so a one-pane relay pays for
+ * two maps per capture rather than four indexes no resolver queries.
+ *
+ * Deliberately stats-free: `buildProcessTableIndex` mutates the caller's counter
+ * bag and stores it on the index, so a shared index would hand one caller's bag
+ * to an unrelated later caller and let a cache hit satisfy an `indexBuilds`
+ * measurement without building anything. Measured callers keep calling
+ * `buildProcessTableIndex(rows, stats)` directly.
+ */
+export function getProcessTableIndex<Row extends ProcessIdentityRow>(
+  rows: readonly Row[]
+): ProcessTableIndexOf<Row> {
+  const cached = processTableIndexes.get(rows) as ProcessTableIndexOf<Row> | undefined
+  if (cached) {
+    return cached
+  }
+  const index = buildProcessTableIndex(rows)
+  processTableIndexes.set(rows, index)
+  return index
+}

--- a/src/shared/process-table-snapshot.test.ts
+++ b/src/shared/process-table-snapshot.test.ts
@@ -7,18 +7,20 @@ const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
 vi.mock('node:child_process', () => ({ execFile: execFileMock }))
 
 import {
-  buildProcessTableIndex,
   createProcessTableSnapshotReader,
-  getProcessTableIndex,
   getProcessTableSnapshot,
   getStrictProcessTableSnapshot,
   parseProcessTableRows,
   parseStrictProcessTableRows,
   ProcessTableCaptureError,
   PS_MAX_BUFFER_BYTES,
-  resetProcessTableSnapshotForTests,
-  type ProcessTableIndexStats
+  resetProcessTableSnapshotForTests
 } from './process-table-snapshot'
+import {
+  buildProcessTableIndex,
+  getProcessTableIndex,
+  type ProcessTableIndexStats
+} from './process-table-index'
 
 function deferred<T>(): {
   promise: Promise<T>

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -1,5 +1,6 @@
 import { execFile as execFileCb } from 'node:child_process'
 import { promisify } from 'node:util'
+import type { ProcessTableIndexOf } from './process-table-index'
 
 const execFile = promisify(execFileCb)
 
@@ -122,80 +123,7 @@ export function parseStrictProcessTableRows(stdout: string): ProcessTableRow[] {
   return rows
 }
 
-export type ProcessTableIndexStats = {
-  captures?: number
-  indexBuilds: number
-  rowVisits: number
-  indexLookups: number
-}
-
-/** The parent/child fields every process-table row shape shares. */
-export type ProcessIdentityRow = { pid: number; ppid: number }
-
-export type ProcessTableIndexOf<Row extends ProcessIdentityRow> = {
-  rows: readonly Row[]
-  byPid: ReadonlyMap<number, Row>
-  childrenByPpid: ReadonlyMap<number, readonly Row[]>
-  stats?: ProcessTableIndexStats
-}
-
 export type ProcessTableIndex = ProcessTableIndexOf<ProcessTableRow>
-
-/**
- * Build the correlation indexes in one linear pass over a capture. Only the
- * indexes a resolver actually reads are materialized: group indexes would cost
- * two more maps plus a per-row array allocation on every capture, and foreground
- * membership is derived from each row's own `pgid` against the root's `tpgid`.
- *
- * Generic over the row shape so the Windows snapshot (`pid`/`ppid`/`name`/
- * `command`) shares this pass rather than carrying a parallel one.
- */
-export function buildProcessTableIndex<Row extends ProcessIdentityRow>(
-  rows: readonly Row[],
-  stats?: ProcessTableIndexStats
-): ProcessTableIndexOf<Row> {
-  if (stats) {
-    stats.indexBuilds += 1
-  }
-  const byPid = new Map<number, Row>()
-  const childrenByPpid = new Map<number, Row[]>()
-  for (const row of rows) {
-    if (stats) {
-      stats.rowVisits += 1
-    }
-    // Preserve rows.find() semantics if a malformed table repeats a pid
-    if (!byPid.has(row.pid)) {
-      byPid.set(row.pid, row)
-    }
-    const children = childrenByPpid.get(row.ppid) ?? []
-    children.push(row)
-    childrenByPpid.set(row.ppid, children)
-  }
-  return { rows, byPid, childrenByPpid, stats }
-}
-
-/**
- * Depth-first descendants of `rootPid`, deepest-last, off a prebuilt index.
- *
- * Each row is copied with its depth, so callers may not mutate the index's rows
- * through the result. Ordering matches a per-call `childrenByPpid` walk exactly:
- * children keep capture order and the stack pops last-pushed first.
- */
-export function collectDescendantsFromIndex<Row extends ProcessIdentityRow>(
-  index: ProcessTableIndexOf<Row>,
-  rootPid: number
-): (Row & { depth: number })[] {
-  const descendants: (Row & { depth: number })[] = []
-  const stack = (index.childrenByPpid.get(rootPid) ?? []).map((row) => ({ row, depth: 1 }))
-  while (stack.length > 0) {
-    const { row, depth } = stack.pop()!
-    descendants.push({ ...row, depth })
-    for (const child of index.childrenByPpid.get(row.pid) ?? []) {
-      stack.push({ row: child, depth: depth + 1 })
-    }
-  }
-  return descendants
-}
 
 /**
  * Rank a descendant row as a foreground candidate: a `+` (foreground process
@@ -203,46 +131,6 @@ export function collectDescendantsFromIndex<Row extends ProcessIdentityRow>(
  */
 export function scoreForegroundCandidateRow(row: ProcessTableRow & { depth: number }): number {
   return (row.stat.includes('+') ? 10_000 : 0) + row.depth
-}
-
-export function lookupProcessTableIndex<Row extends ProcessIdentityRow, T>(
-  index: ProcessTableIndexOf<Row>,
-  lookup: (index: ProcessTableIndexOf<Row>) => T,
-  stats = index.stats
-): T {
-  if (stats) {
-    stats.indexLookups += 1
-  }
-  return lookup(index)
-}
-
-// Keyed by array identity, which also pins the row shape the entry was built
-// for, so the one cast below cannot hand a caller another row type's index.
-const processTableIndexes = new WeakMap<readonly ProcessIdentityRow[], unknown>()
-
-/**
- * Memoize one index per snapshot identity, so the panes that share a TTL-cached
- * capture walk its rows once instead of once each. Keyed weakly by the rows
- * array, so an index dies with the snapshot that produced it. The shared build
- * materializes only `byPid` and `childrenByPpid`, so a one-pane relay pays for
- * two maps per capture rather than four indexes no resolver queries.
- *
- * Deliberately stats-free: `buildProcessTableIndex` mutates the caller's counter
- * bag and stores it on the index, so a shared index would hand one caller's bag
- * to an unrelated later caller and let a cache hit satisfy an `indexBuilds`
- * measurement without building anything. Measured callers keep calling
- * `buildProcessTableIndex(rows, stats)` directly.
- */
-export function getProcessTableIndex<Row extends ProcessIdentityRow>(
-  rows: readonly Row[]
-): ProcessTableIndexOf<Row> {
-  const cached = processTableIndexes.get(rows) as ProcessTableIndexOf<Row> | undefined
-  if (cached) {
-    return cached
-  }
-  const index = buildProcessTableIndex(rows)
-  processTableIndexes.set(rows, index)
-  return index
 }
 
 type Snapshot<T> = { value: T; capturedAtMs: number }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​126 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​123 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

`main` is red. A lint rule caps a TypeScript file at 300 code lines, and `process-table-snapshot.ts` is at 308. Every open PR inherits the failure, so nobody can get a clean run.

Nobody did anything wrong to cause it — two separate PRs each grew the file a bit, and neither one crossed the line on its own. This moves one self-contained piece into its own file.

## Why `main` went red without anyone's CI catching it

This is the interesting part, and it will happen again if only the eight lines get fixed.

```
src/shared/process-table-snapshot.ts:463:2: File has too many lines (308).
```

Two PRs grew the same file, and **neither crossed the 300-line cap on its own**:

| | raw lines |
| --- | --- |
| before | 392 |
| after #18151 (`perf(windows): stop asking the process table for memory…`) | 427 |
| after #18166 (`fix(process-table): fail a short ps capture loudly…`) | 463 → **308 code lines**, over the cap |

**#18166's `static analysis` passed legitimately.** CI lints the *merge result*, but against the base as it stood **when CI ran** — and main moved in between:

| event | time |
| --- | --- |
| #18166's `static analysis` runs | `20:07:08Z` |
| **#18151 lands on `main`** (+35 lines to the same file) | `20:08:01Z` |
| #18166 merges | `20:22:25Z` |

**53 seconds.** #18166 was linted against a `main` that did not yet contain #18151, so the tree CI checked was ~428 raw lines and passed. #18151 landed just after, #18166 merged 14 minutes later, and the combined result is 463 → 308 code lines.

That this is a stale-base race rather than anything about PR-head-vs-merge-ref is confirmed by the PRs failing right now: one has the *427-line* file on its own head and still fails with the 463-line error, because it is being linted against today's `main`.

So: two green PRs, a base that moved between check and merge, and a red `main`. Nothing linted the sum until it existed. This is not specific to line counts — any repo-wide budget or cross-file invariant can break the same way, and the usual mitigation is requiring a branch to be current with its base before it can merge.

## Why the file grew, and why this is the seam

Not taste — the two PRs that grew it grew **two different responsibilities**, which is why neither author could see the other coming. Their hunks do not overlap at all:

| PR | hunks in `process-table-snapshot.ts` | concern |
| --- | --- | --- |
| **#18151** `perf(windows): stop asking the process table for memory…` | `@@ -124`, `-161`, `-169`, `-180`, `-195` — **all five inside the index block** | generalizing the index over the row shape so Windows shares one pass |
| **#18166** `fix(process-table): fail a short ps capture loudly…` | `@@ -10`, `@@ -388` | `ps` capture constants and capture validation |

Every line #18151 added is inside the block this PR extracts. Every line #18166 added is outside it. Two unrelated concerns, growing in parallel, sharing one budget — so each author was under the cap in the part of the file they were looking at, and the total crossed it.

After this split, #18151-shaped work lands in `process-table-index.ts` and #18166-shaped work in `process-table-snapshot.ts`, and they stop sharing a line budget. That is what makes this a fix rather than a deferral.

**Headroom, not a shave:** 308 → **237** code lines against the 300 cap, leaving 63 lines. Three PRs touched this file today, so getting it to 299 would have put it one small change from red again.

**One thing I deliberately did not do.** `createProcessTableSnapshotReader` is also generic (a TTL + in-flight-dedupe memoizer over `<T>`, ~100 lines) and is arguably a third responsibility. I left it: neither growth site touched it, so extracting it would be speculative rather than evidence-led, and this PR is unblocking a red `main`. Worth revisiting on its own merits, not here.

## The change

**A pure move. No behaviour change, no suppression.** No `max-lines` disable and no per-file budget bump — AGENTS.md forbids both, and suppressing here would hide exactly the signal that caught this.

The seam is a real one rather than an arbitrary cut. `process-table-index.ts` takes the correlation-index machinery, which is already fully generic over the row shape so POSIX `ps` and the Windows process table share one pass:

- `ProcessTableIndexStats`, `ProcessIdentityRow`, `ProcessTableIndexOf`
- `buildProcessTableIndex`, `collectDescendantsFromIndex`
- `lookupProcessTableIndex`, `getProcessTableIndex` and its `WeakMap`

`ProcessTableIndex` (the `ProcessTableRow` specialization) and `scoreForegroundCandidateRow` (reads `row.stat`) **stay** in `process-table-snapshot.ts`. That is deliberate: it leaves the new module with **no import back**, so the split introduces no cycle and the generic machinery stays free of `ps`-specific types.

Six consumers get their imports split rather than a barrel re-export, so the module boundary is real:

`agent-foreground-process-batch.ts` / `.test.ts`, `agent-foreground-process.ts`, `windows-foreground-process-rows.ts`, `relay/pty-shell-utils.ts`, `process-table-snapshot.test.ts`.

### Proof it is a pure move

Normalizing both sides (strip blank lines, comments, and import statements; sort), the pre-change file is byte-identical to the concatenation of the two post-change files:

```
diff <(norm before) <(norm after)   →   no output
```

## Verification

Run on my base and again on the **merged tree** (`git merge --no-commit --no-ff origin/main`, verify, abort), since a merge is what produced the problem in the first place:

| gate | before | after |
| --- | --- | --- |
| `oxlint --format github` (the failing CI step) | 5 warnings, **1 error** | 5 warnings, **0 errors** |
| `check:max-lines-ratchet` | — | OK, 12 grandfathered, no new bypasses |
| `pnpm tc` | — | clean |
| `check:code-quality:changed` | — | 0 new findings across 8 files |
| `check:react-doctor:changed` | — | clean |
| `check:reliability-gates` | — | 102 gates pass |
| `check:ts-nocheck-ratchet` / `check:runtime-electron-ratchet` / `check:zustand-selector-fanout` | — | pass |
| `gh-spawn-boundary` (new in #18239) | — | pass |

Tests over everything touching the moved code — `process-table-snapshot`, `foreground-process-selection`, `src/main/providers`, `relay/pty-shell-utils` — **83 files, 892 tests, all passing**, and again on the merged tree (889 tests; the delta is #18231 arriving in `main`, not a behaviour change here).

The 5 remaining `oxlint` warnings are pre-existing `exhaustive-deps` findings in the GitLab item dialog, untouched by this PR and present on `main` before it.

## Negative user-facing trade-offs

**None.** Pure module move on a hot path; the diff is mechanical. No runtime behaviour, wire format, persisted state, platform path, or public signature changes — the same functions with the same bodies are exported from a different file.