### PR TITLE
fix(i18n): add the three activity keys #18245 left out of en.json

### DIFF
--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15962,7 +15962,8 @@
           "none": "None",
           "search": "Search",
           "showUnreadOnly": "Show unread only",
-          "showChildAgents": "Show child agents"
+          "showChildAgents": "Show child agents",
+          "activityOptions": "Activity options"
         },
         "clearCompleted": {
           "clearedOne": "Cleared 1 completed agent",
@@ -17259,7 +17260,9 @@
   "dashboard": {
     "sidebar": {
       "label": "Agents",
-      "dashboardLabel": "Agent Dashboard"
+      "dashboardLabel": "Agent Dashboard",
+      "openActivity": "View activity",
+      "closeActivity": "Turn off activity view"
     }
   },
   "runtimeRpc": {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## Problem

`verify:localization-catalog` and `verify:localization-extraction` both exit 1 on `main`. Three keys referenced from source are missing from `en.json`:

```
auto.components.activity.ActivityPrototypePage.activityOptions
dashboard.sidebar.closeActivity
dashboard.sidebar.openActivity
```

All three were introduced by c2fce802896 (#18245) and are absent at its parent.

### Why nobody saw it

`main` was also failing oxlint `max-lines` on `src/shared/process-table-snapshot.ts`. Because the `Lint` step fails first, every later step in `static analysis` — including both localization checks — was **skipped**. #18246 fixed the lint error and has now landed, so this localization failure is the next blocker for every open PR.

The break reached `main` because **#18245 was merged past a red required check**: its `static analysis` failed at 20:36:06 and it merged at 20:43:06. Separately, #18226 merged 8 seconds after its CI started (run created 20:42:07, merged 20:42:15, cancelled 20:42:39). Neither is in scope here, but they are the useful context for whoever owns CI merge policy — a green-required-check gate would have caught this before it reached `main`.

## Fix

`pnpm run sync:localization-catalog` resolves only the statically-analyzable key (`activityOptions`). The two `dashboard.sidebar.*` keys are selected through a ternary in `SidebarHeader.tsx`, so the catalog tool cannot see them; the extraction check does, and reports them with an empty default. Those two are added by hand.

Total diff: **3 keys, 5 insertions in `en.json`**, no churn elsewhere.

English strings match the inline `translate(key, fallback)` defaults at each call site exactly, which is also what `SidebarHeader.test.tsx` asserts as `aria-label`:

| key | string |
| --- | --- |
| `dashboard.sidebar.openActivity` | `View activity` |
| `dashboard.sidebar.closeActivity` | `Turn off activity view` |
| `auto.…ActivityPrototypePage.activityOptions` | `Activity options` |

## No #18245 UI follow-up needed

All three call sites use `translate(key, fallback)` with correct English fallbacks, so the UI has been rendering the right copy all along — no raw keys, no placeholder text were user-visible. The only breakage was CI. The keys still belong in the catalog: without them the strings are invisible to the translation pipeline and can never be localized (they were counted as missing in all four non-English locales).

## Verification

```
pnpm run verify:localization-catalog     # exit 0 (was 1)
pnpm run verify:localization-extraction  # exit 0 (was 1)
pnpm test src/renderer/src/components/sidebar/SidebarHeader.test.tsx  # 12 passed
```

Confirmed the three added keys introduce **zero** new inline-default drift (drift set is byte-identical before and after against a fixed extraction snapshot).