### PR TITLE
fix(native-chat): make structured Codex launches race-resistant

### DIFF
--- a/src/main/runtime/orca-runtime-apply-mobile-session-tab-navigation.ts
+++ b/src/main/runtime/orca-runtime-apply-mobile-session-tab-navigation.ts
@@ -142,7 +142,7 @@ export class OrcaRuntimeWithApplyMobileSessionTabNavigation extends OrcaRuntimeW
       tabs
     }
     this.persistHeadlessTerminalActiveLeaf(worktreeId, activeTab)
-    this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
+    this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     this.emitMobileSessionTabsSnapshot(nextSnapshot)
   }
 

--- a/src/main/runtime/orca-runtime-close-headless-mobile-terminal-tab.ts
+++ b/src/main/runtime/orca-runtime-close-headless-mobile-terminal-tab.ts
@@ -107,7 +107,7 @@ export class OrcaRuntimeWithCloseHeadlessMobileTerminalTab extends OrcaRuntimeWi
         : {}),
       tabs: nextTabs
     }
-    this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
+    this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     this.emitMobileSessionTabsSnapshot(nextSnapshot)
   }
 

--- a/src/main/runtime/orca-runtime-close-structured-agent-session-tab.ts
+++ b/src/main/runtime/orca-runtime-close-structured-agent-session-tab.ts
@@ -39,7 +39,7 @@ export class OrcaRuntimeWithCloseStructuredAgentSessionTab extends OrcaRuntimeWi
       })),
       tabs: nextTabs
     }
-    this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
+    this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     this.emitMobileSessionTabsSnapshot(nextSnapshot)
   }
 
@@ -49,7 +49,7 @@ export class OrcaRuntimeWithCloseStructuredAgentSessionTab extends OrcaRuntimeWi
   protected republishMobileSessionTabsSnapshot(worktreeId: string): void {
     const snapshot = this.mobileSessionTabsByWorktree.get(worktreeId)
     if (snapshot) {
-      this.mobileSessionTabsByWorktree.set(worktreeId, {
+      this.storeMobileSessionSnapshot(worktreeId, {
         ...snapshot,
         snapshotVersion: snapshot.snapshotVersion + 1
       })
@@ -161,7 +161,7 @@ export class OrcaRuntimeWithCloseStructuredAgentSessionTab extends OrcaRuntimeWi
       })),
       tabs: nextTabs
     }
-    this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
+    this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     this.emitMobileSessionTabsSnapshot(nextSnapshot)
     return true
   }
@@ -203,7 +203,7 @@ export class OrcaRuntimeWithCloseStructuredAgentSessionTab extends OrcaRuntimeWi
       focusesHost,
       publicationEpoch: `headless:${Date.now().toString(36)}`
     })
-    this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
+    this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     // Why: browser group membership is otherwise live-only; persist it so a
     // later rebuild keeps the browser in its group instead of coalescing left.
     if (placedInTargetGroup && nextSnapshot.tabGroupLayout) {

--- a/src/main/runtime/orca-runtime-create-runtime-owned-mobile-session-terminal.ts
+++ b/src/main/runtime/orca-runtime-create-runtime-owned-mobile-session-terminal.ts
@@ -139,7 +139,7 @@ export class OrcaRuntimeWithCreateRuntimeOwnedMobileSessionTerminal extends Orca
       ...(existing?.tabGroupLayout ? { tabGroupLayout: existing.tabGroupLayout } : {}),
       tabs
     }
-    this.mobileSessionTabsByWorktree.set(worktreeId, next)
+    this.storeMobileSessionSnapshot(worktreeId, next)
     const result = this.toMobileSessionTabsResult(next)
     const changeSequence = ++this.mobileSessionTabsChangeSequence
     for (const subscription of this.mobileSessionTabListeners) {

--- a/src/main/runtime/orca-runtime-has-exact-persisted-terminal-surface-identity.ts
+++ b/src/main/runtime/orca-runtime-has-exact-persisted-terminal-surface-identity.ts
@@ -65,7 +65,7 @@ export class OrcaRuntimeWithHasExactPersistedTerminalSurfaceIdentity extends Orc
         exactOnly: true
       })
       if (retired) {
-        this.mobileSessionTabsByWorktree.set(candidate.worktreeId, retired.snapshot)
+        this.storeMobileSessionSnapshot(candidate.worktreeId, retired.snapshot)
         this.notifyMobileSessionTabsChanged(candidate.worktreeId)
       }
     }

--- a/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
+++ b/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
@@ -236,7 +236,7 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
       if (existing && headlessMobileSnapshotContentUnchanged(existing, nextSnapshot)) {
         continue
       }
-      this.mobileSessionTabsByWorktree.set(entryWorktreeId, nextSnapshot)
+      this.storeMobileSessionSnapshot(entryWorktreeId, nextSnapshot)
     }
     return reconciledWorktreeIds
   }

--- a/src/main/runtime/orca-runtime-move-headless-mobile-session-tab.ts
+++ b/src/main/runtime/orca-runtime-move-headless-mobile-session-tab.ts
@@ -72,7 +72,7 @@ export class OrcaRuntimeWithMoveHeadlessMobileSessionTab extends OrcaRuntimeWith
     if (nextGroups.length > 1 && snapshot.tabGroupLayout) {
       this.persistHeadlessTabGroups(worktreeId, nextGroups, snapshot.tabGroupLayout)
     }
-    this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
+    this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     this.emitMobileSessionTabsSnapshot(nextSnapshot)
     return { moved: true }
   }
@@ -111,7 +111,7 @@ export class OrcaRuntimeWithMoveHeadlessMobileSessionTab extends OrcaRuntimeWith
       tabGroupLayout: split.layout
     }
     this.persistHeadlessTabGroups(worktreeId, split.groups, split.layout)
-    this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
+    this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     this.emitMobileSessionTabsSnapshot(nextSnapshot)
     return { moved: true }
   }
@@ -147,7 +147,7 @@ export class OrcaRuntimeWithMoveHeadlessMobileSessionTab extends OrcaRuntimeWith
       tabGroupLayout: layout
     }
     this.persistHeadlessTabGroups(worktreeId, moved.groups, layout)
-    this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
+    this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     this.emitMobileSessionTabsSnapshot(nextSnapshot)
     return { moved: true }
   }

--- a/src/main/runtime/orca-runtime-persist-headless-session-tab-props.ts
+++ b/src/main/runtime/orca-runtime-persist-headless-session-tab-props.ts
@@ -95,7 +95,7 @@ export class OrcaRuntimeWithPersistHeadlessSessionTabProps extends OrcaRuntimeWi
       snapshotVersion: snapshot.snapshotVersion + 1,
       tabs
     }
-    this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
+    this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     this.emitMobileSessionTabsSnapshot(nextSnapshot)
   }
 
@@ -181,7 +181,7 @@ export class OrcaRuntimeWithPersistHeadlessSessionTabProps extends OrcaRuntimeWi
       snapshotVersion: snapshot.snapshotVersion + 1,
       tabs
     }
-    this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
+    this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     this.emitMobileSessionTabsSnapshot(nextSnapshot)
   }
 }

--- a/src/main/runtime/orca-runtime-persist-terminal-surface-retirements.ts
+++ b/src/main/runtime/orca-runtime-persist-terminal-surface-retirements.ts
@@ -173,7 +173,7 @@ export class OrcaRuntimeWithPersistTerminalSurfaceRetirements extends OrcaRuntim
           : {})
       })
       if (retired) {
-        this.mobileSessionTabsByWorktree.set(worktreeId, retired.snapshot)
+        this.storeMobileSessionSnapshot(worktreeId, retired.snapshot)
         this.notifyMobileSessionTabsChanged(worktreeId)
       }
     }

--- a/src/main/runtime/orca-runtime-publish-pty-backed-mobile-session-terminal.ts
+++ b/src/main/runtime/orca-runtime-publish-pty-backed-mobile-session-terminal.ts
@@ -142,7 +142,7 @@ export class OrcaRuntimeWithPublishPtyBackedMobileSessionTerminal extends OrcaRu
       ...(existing?.tabGroupLayout ? { tabGroupLayout: existing.tabGroupLayout } : {}),
       tabs
     }
-    this.mobileSessionTabsByWorktree.set(worktreeId, next)
+    this.storeMobileSessionSnapshot(worktreeId, next)
     if (args.notify !== false) {
       this.notifyMobileSessionTabsChanged(worktreeId)
     }

--- a/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
+++ b/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
@@ -47,7 +47,7 @@ export class OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs extends Or
     const active = activeStillPresent
       ? null
       : (nextTabs.find((tab) => tab.isActive) ?? nextTabs[0] ?? null)
-    this.mobileSessionTabsByWorktree.set(worktreeId, {
+    this.storeMobileSessionSnapshot(worktreeId, {
       ...existing,
       publicationEpoch: `headless-hydrated:${Date.now().toString(36)}`,
       snapshotVersion: existing.snapshotVersion + 1,

--- a/src/main/runtime/orca-runtime-restore-live-paired-renderer-session-owned-mobile-terminals.ts
+++ b/src/main/runtime/orca-runtime-restore-live-paired-renderer-session-owned-mobile-terminals.ts
@@ -39,7 +39,7 @@ export class OrcaRuntimeWithRestoreLivePairedRendererSessionOwnedMobileTerminals
         continue
       }
       if (!existing) {
-        this.mobileSessionTabsByWorktree.set(targetWorktreeId, {
+        this.storeMobileSessionSnapshot(targetWorktreeId, {
           worktree: targetWorktreeId,
           publicationEpoch: `renderer-rescue:${Date.now().toString(36)}`,
           snapshotVersion: 0,

--- a/src/main/runtime/orca-runtime-restore-structured-agent-session-tabs-once.ts
+++ b/src/main/runtime/orca-runtime-restore-structured-agent-session-tabs-once.ts
@@ -94,7 +94,7 @@ export class OrcaRuntimeWithRestoreStructuredAgentSessionTabsOnce extends OrcaRu
         ),
         tabs: existing.tabs.map((tab) => ({ ...tab, isActive: tab.id === id }))
       }
-      this.mobileSessionTabsByWorktree.set(input.workspaceId, snapshot)
+      this.storeMobileSessionSnapshot(input.workspaceId, snapshot)
       if (input.notify !== false) {
         this.emitMobileSessionTabsSnapshot(snapshot)
       }
@@ -143,7 +143,7 @@ export class OrcaRuntimeWithRestoreStructuredAgentSessionTabsOnce extends OrcaRu
       ...(existing?.tabGroupLayout ? { tabGroupLayout: existing.tabGroupLayout } : {}),
       tabs
     }
-    this.mobileSessionTabsByWorktree.set(input.workspaceId, snapshot)
+    this.storeMobileSessionSnapshot(input.workspaceId, snapshot)
     if (input.notify !== false) {
       this.emitMobileSessionTabsSnapshot(snapshot)
     }

--- a/src/main/runtime/orca-runtime-runtime-id.ts
+++ b/src/main/runtime/orca-runtime-runtime-id.ts
@@ -96,6 +96,21 @@ export class OrcaRuntimeWithRuntimeId {
 
   protected mobileSessionTabsByWorktree = new Map<string, RuntimeMobileSessionTabsSnapshot>()
 
+  /** Single host writer for mobile session snapshots; versions are total-order stamps. */
+  protected storeMobileSessionSnapshot(
+    worktreeId: string,
+    snapshot: RuntimeMobileSessionTabsSnapshot
+  ): RuntimeMobileSessionTabsSnapshot {
+    const existing = this.mobileSessionTabsByWorktree.get(worktreeId)
+    const snapshotVersion = existing
+      ? Math.max(snapshot.snapshotVersion, existing.snapshotVersion + 1)
+      : snapshot.snapshotVersion
+    const stamped =
+      snapshotVersion === snapshot.snapshotVersion ? snapshot : { ...snapshot, snapshotVersion }
+    this.mobileSessionTabsByWorktree.set(worktreeId, stamped)
+    return stamped
+  }
+
   protected structuredAgentSessionTabRestorePromise: Promise<void> | null = null
 
   protected structuredAgentSessionStartupRestorePromise: Promise<void> | null = null

--- a/src/main/runtime/orca-runtime-stop-requested-pty-ids.ts
+++ b/src/main/runtime/orca-runtime-stop-requested-pty-ids.ts
@@ -57,7 +57,7 @@ export class OrcaRuntimeWithStopRequestedPtyIds extends OrcaRuntimeWithRuntimeId
     resolveOwner: (handle) => this.resolveNativeChatLaunchDraftOwner(handle),
     listMobileSnapshots: () => this.mobileSessionTabsByWorktree,
     setMobileSnapshot: (worktreeId, snapshot) =>
-      this.mobileSessionTabsByWorktree.set(worktreeId, snapshot),
+      this.storeMobileSessionSnapshot(worktreeId, snapshot),
     scheduleMobileSnapshot: (worktreeId) => this.scheduleMobileSessionTabsChanged(worktreeId),
     notifyResolved: (tabId, resolution, event) => {
       this.notifier?.nativeChatLaunchDraftResolved?.(tabId, resolution)

--- a/src/main/runtime/orca-runtime-stored-mobile-snapshot-has-stale-preserved-tab.ts
+++ b/src/main/runtime/orca-runtime-stored-mobile-snapshot-has-stale-preserved-tab.ts
@@ -8,7 +8,6 @@ import type {
 import { getMobileSessionSnapshotTabIdentityKeys } from './mobile-session-tab-merge'
 import { getRuntimeBrowserPageRegistry } from './runtime-browser-page-registry'
 import { sameRuntimeBrowserPlacement } from '../../shared/runtime-browser-placement'
-import { createHash } from 'node:crypto'
 import type { ClientHostedBrowserRowsEvent } from '../../shared/client-hosted-browser-rows'
 
 export class OrcaRuntimeWithStoredMobileSnapshotHasStalePreservedTab extends OrcaRuntimeWithMergePreservedHeadlessMobileSessionTabs {
@@ -115,23 +114,14 @@ export class OrcaRuntimeWithStoredMobileSnapshotHasStalePreservedTab extends Orc
 
   protected getMergedMobileSessionPublicationEpoch(
     snapshot: RuntimeMobileSessionTabsSnapshot,
-    preservedTabs: readonly RuntimeMobileSessionSnapshotTab[]
+    _preservedTabs: readonly RuntimeMobileSessionSnapshotTab[]
   ): string {
     // Why: preserved snapshots can merge repeatedly; strip the prior merge suffix first so the publication epoch stays idempotent.
     const normalizedPublicationEpoch = snapshot.publicationEpoch.split(':headless-merge:')[0]
-    const signature = createHash('sha1')
-      .update(
-        preservedTabs
-          .map((tab) =>
-            tab.type === 'terminal'
-              ? `${tab.id}:${tab.parentTabId}:${tab.ptyId ?? ''}:${tab.leafId}`
-              : tab.id
-          )
-          .join('|')
-      )
-      .digest('hex')
-      .slice(0, 12)
-    return `${normalizedPublicationEpoch}:headless-merge:${signature}`
+    // The epoch identifies the publisher generation, not the merged content.
+    // Content changes are ordered by snapshotVersion, so encoding a merge hash
+    // here would make the identity oscillate and permanently fence later rows.
+    return normalizedPublicationEpoch
   }
 
   /** Serves a hydrating host renderer; the publisher counts this as a delivery, not a read. */

--- a/src/main/runtime/orca-runtime-sync-mobile-session-tabs.ts
+++ b/src/main/runtime/orca-runtime-sync-mobile-session-tabs.ts
@@ -167,7 +167,7 @@ export class OrcaRuntimeWithSyncMobileSessionTabs extends OrcaRuntimeWithWriteOr
       const storedVersion = existing
         ? Math.max(nextSnapshot.snapshotVersion, existing.snapshotVersion + 1)
         : nextSnapshot.snapshotVersion
-      this.mobileSessionTabsByWorktree.set(
+      this.storeMobileSessionSnapshot(
         snapshot.worktree,
         storedVersion === nextSnapshot.snapshotVersion
           ? nextSnapshot
@@ -195,7 +195,7 @@ export class OrcaRuntimeWithSyncMobileSessionTabs extends OrcaRuntimeWithWriteOr
             preserved.tabs.length === existing.tabs.length &&
             preserved.tabs.every((tab, index) => tab === existing.tabs[index])
           if (!preservedIsNoOp) {
-            this.mobileSessionTabsByWorktree.set(worktreeId, preserved)
+            this.storeMobileSessionSnapshot(worktreeId, preserved)
           }
           // Why: the stored entry is no longer the renderer's publication, so a
           // future renderer frame must be re-merged even if it reuses the pair.

--- a/src/main/runtime/orca-runtime-sync-window-graph.ts
+++ b/src/main/runtime/orca-runtime-sync-window-graph.ts
@@ -238,7 +238,7 @@ export class OrcaRuntimeWithSyncWindowGraph extends OrcaRuntimeWithAttachWindow 
       // the PTY touch path does) or the re-emitted payload — e.g. the
       // pending-handle → ready flip — is discarded and the client stays stale.
       // The accepted-renderer tracking is untouched: this is a main-local bump.
-      this.mobileSessionTabsByWorktree.set(worktreeId, {
+      this.storeMobileSessionSnapshot(worktreeId, {
         ...stored,
         snapshotVersion: stored.snapshotVersion + 1
       })

--- a/src/main/runtime/orca-runtime-tests/mobile-session-tabs-part-06.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/mobile-session-tabs-part-06.spec.ts
@@ -595,7 +595,7 @@ describe('OrcaRuntimeService', () => {
     const secondMerge = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
 
     expect(secondMerge.publicationEpoch).toBe(firstMerge.publicationEpoch)
-    expect(secondMerge.publicationEpoch.match(/:headless-merge:/g) ?? []).toHaveLength(1)
+    expect(secondMerge.publicationEpoch).toBe('headless:stable-epoch')
   })
 
   it('keeps the graph ready when a mobile snapshot references a removed folder workspace', () => {

--- a/src/main/runtime/orca-runtime-touch-mobile-session-tabs-for-worktree.ts
+++ b/src/main/runtime/orca-runtime-touch-mobile-session-tabs-for-worktree.ts
@@ -21,7 +21,7 @@ export class OrcaRuntimeWithTouchMobileSessionTabsForWorktree extends OrcaRuntim
     if (!snapshot) {
       return
     }
-    this.mobileSessionTabsByWorktree.set(worktreeId, {
+    this.storeMobileSessionSnapshot(worktreeId, {
       ...snapshot,
       snapshotVersion: snapshot.snapshotVersion + 1
     })

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { Settings as SettingsIcon } from 'lucide-react'
+import { Loader2, Settings as SettingsIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { DropdownMenuItem, DropdownMenuShortcut } from '@/components/ui/dropdown-menu'
 import { getAgentCatalog, AgentIcon } from '@/lib/agent-catalog'
@@ -15,6 +15,7 @@ import {
   filterEnabledTuiAgents
 } from '../../../../shared/tui-agent-selection'
 import { translate } from '@/i18n/i18n'
+import { useStructuredCodexLaunchStatus } from '@/lib/structured-agent-session-launch'
 
 export type QuickLaunchAgentMenuItemsProps = {
   worktreeId: string
@@ -116,6 +117,7 @@ function QuickLaunchAgentMenuItemsInner({
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const newAgentShortcut = useOptionalShortcutLabel('tab.newAgent')
+  const structuredCodexLaunchStatus = useStructuredCodexLaunchStatus(worktreeId)
 
   const openAgentSettings = useCallback(() => {
     openSettingsTarget({ pane: 'agents', repoId: null })
@@ -197,21 +199,31 @@ function QuickLaunchAgentMenuItemsInner({
       {agents.map((agent) => {
         const entry = getCatalogEntry(agent)
         const label = entry?.label ?? agent
+        const isStructuredCodexPending =
+          agent === 'codex' && structuredCodexLaunchStatus === 'pending'
+        const menuLabel = isStructuredCodexPending ? 'Starting Codex chat…' : label
         const showsDefaultAgentShortcut =
           newAgentShortcut !== null && defaultAgent !== 'blank' && agent === defaultAgent
         return (
           <DropdownMenuItem
             key={agent}
+            disabled={isStructuredCodexPending}
             onSelect={() => runLaunch(agent)}
             className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
             title={translate(
               'auto.components.tab.bar.QuickLaunchButton.ec2adf093e',
-              'Launch {{value0}} in a new terminal',
-              { value0: label }
+              isStructuredCodexPending
+                ? 'Starting Codex chat…'
+                : 'Launch {{value0}} in a new terminal',
+              isStructuredCodexPending ? undefined : { value0: label }
             )}
           >
-            <AgentIcon agent={agent} size={14} />
-            <span className="flex-1">{label}</span>
+            {isStructuredCodexPending ? (
+              <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden="true" />
+            ) : (
+              <AgentIcon agent={agent} size={14} />
+            )}
+            <span className="flex-1">{menuLabel}</span>
             {showsDefaultAgentShortcut ? (
               <DropdownMenuShortcut>{newAgentShortcut}</DropdownMenuShortcut>
             ) : null}

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.keyboard.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.keyboard.test.tsx
@@ -18,6 +18,9 @@ import type { AppState } from '@/store/types'
 // Why: the real entry-action module pulls in runtime IPC + the app store; the
 // keyboard behavior under test only needs a controllable option list.
 const entryOptionsMock = vi.hoisted(() => ({ options: [] as TabEntryOption[] }))
+const structuredLaunchMock = vi.hoisted(() => ({
+  status: 'idle' as 'idle' | 'pending' | 'unknown'
+}))
 vi.mock('./tab-create-entry-action', () => ({
   getTabEntryOptions: () => entryOptionsMock.options,
   createTabEntryAllowAbsolutePathsSelector: () => () => true,
@@ -34,6 +37,9 @@ vi.mock('../quick-open-file-list', () => ({
 vi.mock('@/lib/agent-catalog', () => ({
   getAgentCatalog: () => [],
   AgentIcon: () => null
+}))
+vi.mock('@/lib/structured-agent-session-launch', () => ({
+  useStructuredCodexLaunchStatus: () => structuredLaunchMock.status
 }))
 
 import TabBarCreateEntry from './TabBarCreateEntry'
@@ -170,6 +176,7 @@ afterEach(() => {
   act(() => root.unmount())
   container.remove()
   vi.clearAllMocks()
+  structuredLaunchMock.status = 'idle'
 })
 
 describe('TabBarCreateEntry keyboard navigation', () => {
@@ -258,6 +265,29 @@ describe('TabBarCreateEntry keyboard navigation', () => {
     submitForm()
 
     expect(onLaunchAgent).toHaveBeenCalledWith('gemini')
+  })
+
+  it('does not relaunch Codex when a structured launch is already pending', () => {
+    structuredLaunchMock.status = 'pending'
+    const agentOptions: TabAgentLaunchOption[] = [
+      { agent: 'codex', aliases: ['codex'], label: 'Codex' }
+    ]
+    const onLaunchAgent = vi.fn()
+    mount(
+      <TabBarCreateEntry
+        worktreeId="wt"
+        groupId="g"
+        menuOpen
+        agentOptions={agentOptions}
+        onOpenEntry={vi.fn().mockResolvedValue(undefined)}
+        onLaunchAgent={onLaunchAgent}
+      />
+    )
+
+    setQuery('cod')
+    submitForm()
+
+    expect(onLaunchAgent).not.toHaveBeenCalled()
   })
 
   it('exposes the highlighted row to assistive tech via aria-activedescendant', () => {

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
@@ -228,6 +228,9 @@ function TabBarCreateEntrySession({
       return
     }
     if (selectedOption.kind === 'agent') {
+      if (selectedOption.option.agent === 'codex' && structuredCodexLaunchStatus === 'pending') {
+        return
+      }
       onLaunchAgent?.(selectedOption.option.agent)
       onDidOpenEntry?.()
       return

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
@@ -33,6 +33,7 @@ import {
   getTabEntryOmniboxPlaceholder
 } from './tab-create-entry-copy'
 import { EMPTY_AGENT_OPTIONS, EMPTY_MENU_OPTIONS } from './tab-create-entry-empty-options'
+import { useStructuredCodexLaunchStatus } from '@/lib/structured-agent-session-launch'
 import type { TabEntryActionClassification } from './tab-create-entry-classifier'
 import type { TabBarCreateEntryProps } from './tab-create-entry-props'
 
@@ -59,6 +60,7 @@ function TabBarCreateEntrySession({
   const [error, setError] = useState<string | null>(null)
   const [switchError, setSwitchError] = useState<string | null>(null)
   const [selectionGuidance, setSelectionGuidance] = useState<string | null>(null)
+  const structuredCodexLaunchStatus = useStructuredCodexLaunchStatus(worktreeId)
   // null = follow ranking (deferred tabs can prepend); set on arrow keys only.
   const [pinnedOptionId, setPinnedOptionId] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -374,8 +376,26 @@ function TabBarCreateEntrySession({
                 id={resultOptionDomId(index)}
                 option={option}
                 selected={index === activeSelectedIndex}
-                disabled={disabled || pending}
-                loading={pending && index === activeSelectedIndex}
+                labelOverride={
+                  option.kind === 'agent' &&
+                  option.option.agent === 'codex' &&
+                  structuredCodexLaunchStatus === 'pending'
+                    ? 'Starting Codex chat…'
+                    : undefined
+                }
+                disabled={
+                  disabled ||
+                  pending ||
+                  (option.kind === 'agent' &&
+                    option.option.agent === 'codex' &&
+                    structuredCodexLaunchStatus === 'pending')
+                }
+                loading={
+                  (pending && index === activeSelectedIndex) ||
+                  (option.kind === 'agent' &&
+                    option.option.agent === 'codex' &&
+                    structuredCodexLaunchStatus === 'pending')
+                }
                 onClick={() => {
                   setSelectionGuidance(null)
                   submitOption(option)

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -44,6 +44,7 @@ export function EntryStatusRow({
 export function EntryActionRow({
   disabled = false,
   id,
+  labelOverride,
   loading = false,
   onClick,
   option,
@@ -51,12 +52,13 @@ export function EntryActionRow({
 }: {
   disabled?: boolean
   id: string
+  labelOverride?: string
   loading?: boolean
   onClick: () => void
   option: ActiveOption
   selected: boolean
 }): React.JSX.Element {
-  const presentation = getActionPresentation(option)
+  const presentation = getActionPresentation(option, labelOverride)
 
   const row = (
     <button
@@ -150,7 +152,10 @@ function getOpenTabIcon(option: Extract<ActiveOption, { kind: 'tab' }>['option']
   return <GitCompare className="size-3.5 shrink-0" aria-hidden="true" />
 }
 
-function getActionPresentation(option: ActiveOption): {
+function getActionPresentation(
+  option: ActiveOption,
+  labelOverride?: string
+): {
   detail: string
   icon: React.ReactNode
   label: string
@@ -201,7 +206,9 @@ function getActionPresentation(option: ActiveOption): {
     return {
       detail: option.option.label,
       icon: <AgentIcon agent={option.option.agent} size={14} />,
-      label: translate('auto.components.tab.bar.TabBarCreateEntry.b27864279e', 'Launch agent'),
+      label:
+        labelOverride ??
+        translate('auto.components.tab.bar.TabBarCreateEntry.b27864279e', 'Launch agent'),
       showDetail: true
     }
   }

--- a/src/renderer/src/components/tab-group/useTabGroupTabCloseCommands.structured-session.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupTabCloseCommands.structured-session.test.ts
@@ -3,6 +3,7 @@ import type * as ReactModule from 'react'
 
 const mocks = vi.hoisted(() => ({
   callRuntimeRpc: vi.fn(),
+  cancelStructuredCodexLaunch: vi.fn(),
   closeBrowserTab: vi.fn(),
   closeFile: vi.fn(),
   closeStructuredAgentSession: vi.fn(),
@@ -71,6 +72,10 @@ vi.mock('@/runtime/structured-agent-session-close', () => ({
   closeStructuredAgentSession: mocks.closeStructuredAgentSession
 }))
 
+vi.mock('@/lib/structured-agent-session-launch', () => ({
+  cancelStructuredCodexLaunch: mocks.cancelStructuredCodexLaunch
+}))
+
 vi.mock('@/runtime/runtime-worktree-selector', () => ({
   toRuntimeWorktreeSelector: (worktreeId: string) => `id:${worktreeId}`
 }))
@@ -124,6 +129,7 @@ describe('structured agent-session close ordering', () => {
     closeItem(AGENT_TAB.id)
 
     await vi.waitFor(() => expect(order).toEqual(['agent-close', 'tab-close', 'local-remove']))
+    expect(mocks.cancelStructuredCodexLaunch).toHaveBeenCalledWith('wt-1', 'session-1')
   })
 
   it('keeps the tab available when owner disposal fails, so close can be retried', async () => {

--- a/src/renderer/src/components/tab-group/useTabGroupTabCloseCommands.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupTabCloseCommands.ts
@@ -10,6 +10,7 @@ import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner
 import { closeBrowserWorkspaceTabOnHosts } from '@/runtime/browser-workspace-tab-close'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { closeStructuredAgentSession } from '@/runtime/structured-agent-session-close'
+import { cancelStructuredCodexLaunch } from '@/lib/structured-agent-session-launch'
 import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import { translate } from '@/i18n/i18n'
 
@@ -122,6 +123,9 @@ export function useTabGroupTabCloseCommands({
       if (item.contentType === 'agent-session') {
         // Why: the structured session lives on the host, so the local tab close must also
         // retire the host's canonical row or it reappears on the next sync.
+        // Cancel a still-reconciling create before closing its owner; otherwise a missing
+        // post-create snapshot is mistaken for an unknown outcome and retried after close.
+        cancelStructuredCodexLaunch(worktreeId, item.entityId)
         const target = getActiveRuntimeTarget({
           activeRuntimeEnvironmentId: runtimeEnvironmentId
         })
@@ -193,6 +197,7 @@ export function useTabGroupTabCloseCommands({
           worktreeId
         )
         if (item.contentType === 'agent-session') {
+          cancelStructuredCodexLaunch(worktreeId, item.entityId)
           const target = getActiveRuntimeTarget({
             activeRuntimeEnvironmentId: runtimeEnvironmentId
           })

--- a/src/renderer/src/lib/launch-agent-structured-chat-guard.test.ts
+++ b/src/renderer/src/lib/launch-agent-structured-chat-guard.test.ts
@@ -49,9 +49,10 @@ const store = {
   detectedWorktreesByRepo: {},
   allWorktrees: vi.fn(() => store.worktreesByRepo['repo-1']),
   tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
-  unifiedTabsByWorktree: {
-    'wt-1': [{ contentType: 'agent-session', entityId: 'codex-session-1', worktreeId: 'wt-1' }]
-  },
+  unifiedTabsByWorktree: {} as Record<
+    string,
+    { contentType: string; entityId: string; worktreeId: string }[]
+  >,
   openFiles: [] as { id: string; worktreeId: string }[],
   browserTabsByWorktree: {} as Record<string, { id: string }[]>,
   tabBarOrderByWorktree: {} as Record<string, string[]>,
@@ -105,6 +106,9 @@ vi.mock('@/runtime/local-structured-session-tabs-sync', () => ({
 describe('structured chat adoption guard on the launch path', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    store.unifiedTabsByWorktree = {
+      'wt-1': [{ contentType: 'agent-session', entityId: 'codex-session-1', worktreeId: 'wt-1' }]
+    }
     store.repos = [{ id: 'repo-1', connectionId: null, path: '/repo' }]
     store.projects = [{ id: 'repo-1', localWindowsRuntimePreference: { kind: 'inherit-global' } }]
     mockCreateTab.mockReturnValue({ id: 'tab-1' })
@@ -199,6 +203,7 @@ describe('structured chat adoption guard on the launch path', () => {
   })
 
   it('keeps the single-flight reservation until the published tab inventory is refreshed', async () => {
+    store.unifiedTabsByWorktree = {}
     let resolveRefresh!: (snapshots: unknown[]) => void
     mockRefreshLocalStructuredSessionTabs.mockImplementationOnce(
       () => new Promise<unknown[]>((resolve) => (resolveRefresh = resolve))
@@ -212,6 +217,9 @@ describe('structured chat adoption guard on the launch path', () => {
     launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1' })
 
     expect(mockLaunchStructuredCodexSession).toHaveBeenCalledTimes(1)
+    store.unifiedTabsByWorktree['wt-1'] = [
+      { contentType: 'agent-session', entityId: 'codex-session-1', worktreeId: 'wt-1' }
+    ]
     resolveRefresh([
       { worktree: 'wt-1', tabs: [{ type: 'agent-session', sessionId: 'codex-session-1' }] }
     ])
@@ -219,6 +227,7 @@ describe('structured chat adoption guard on the launch path', () => {
   })
 
   it('does not create a sibling when post-create visibility proof is unknown', async () => {
+    store.unifiedTabsByWorktree = {}
     const firstIntent = structuredLaunchIntent('wt-1', 'codex-session-1')
     const secondIntent = structuredLaunchIntent('wt-1', 'codex-session-2')
     mockCreateStructuredCodexSessionLaunchIntent
@@ -231,9 +240,15 @@ describe('structured chat adoption guard on the launch path', () => {
     mockRefreshLocalStructuredSessionTabs
       .mockRejectedValueOnce(new Error('inventory unavailable'))
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        { worktree: 'wt-1', tabs: [{ type: 'agent-session', sessionId: 'codex-session-1' }] }
-      ])
+      .mockImplementationOnce(() => {
+        // The inventory refresh also publishes the host snapshot into the renderer projection.
+        store.unifiedTabsByWorktree['wt-1'] = [
+          { contentType: 'agent-session', entityId: firstIntent.sessionId, worktreeId: 'wt-1' }
+        ]
+        return Promise.resolve([
+          { worktree: 'wt-1', tabs: [{ type: 'agent-session', sessionId: firstIntent.sessionId }] }
+        ])
+      })
       .mockResolvedValueOnce([
         { worktree: 'wt-1', tabs: [{ type: 'agent-session', sessionId: 'codex-session-2' }] }
       ])
@@ -256,7 +271,7 @@ describe('structured chat adoption guard on the launch path', () => {
       { contentType: 'agent-session', entityId: secondIntent.sessionId, worktreeId: 'wt-1' }
     ]
     launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1' })
-    await vi.waitFor(() => expect(mockRefreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(4))
+    await vi.waitFor(() => expect(mockLaunchStructuredCodexSession).toHaveBeenCalledTimes(3))
     expect(mockCreateStructuredCodexSessionLaunchIntent).toHaveBeenCalledTimes(2)
     expect(mockLaunchStructuredCodexSession).toHaveBeenCalledTimes(3)
     expect(mockLaunchStructuredCodexSession.mock.calls[2]?.[0]).toBe(secondIntent)

--- a/src/renderer/src/lib/launch-agent-structured-chat-guard.test.ts
+++ b/src/renderer/src/lib/launch-agent-structured-chat-guard.test.ts
@@ -49,6 +49,9 @@ const store = {
   detectedWorktreesByRepo: {},
   allWorktrees: vi.fn(() => store.worktreesByRepo['repo-1']),
   tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
+  unifiedTabsByWorktree: {
+    'wt-1': [{ contentType: 'agent-session', entityId: 'codex-session-1', worktreeId: 'wt-1' }]
+  },
   openFiles: [] as { id: string; worktreeId: string }[],
   browserTabsByWorktree: {} as Record<string, { id: string }[]>,
   tabBarOrderByWorktree: {} as Record<string, string[]>,
@@ -249,6 +252,9 @@ describe('structured chat adoption guard on the launch path', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     // A successful retry must release the reservation so a later launch can start normally.
+    store.unifiedTabsByWorktree['wt-1'] = [
+      { contentType: 'agent-session', entityId: secondIntent.sessionId, worktreeId: 'wt-1' }
+    ]
     launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1' })
     await vi.waitFor(() => expect(mockRefreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(4))
     expect(mockCreateStructuredCodexSessionLaunchIntent).toHaveBeenCalledTimes(2)

--- a/src/renderer/src/lib/structured-agent-session-launch.test.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.test.ts
@@ -129,6 +129,33 @@ describe('startStructuredCodexLaunch', () => {
     expect(mocks.abandonIntent).toHaveBeenCalledWith(intent)
   })
 
+  it('does not park or toast when close races the final verification retry', async () => {
+    const worktreeId = 'wt-close-final-verify'
+    const intent = launchIntent(worktreeId, 'session-close-final-verify')
+    let resolveFinalRefresh!: (snapshots: RuntimeMobileSessionTabsResult[]) => void
+    mocks.createIntent.mockReturnValueOnce(intent)
+    mocks.launch.mockResolvedValue(intent.sessionId)
+    vi.mocked(refreshLocalStructuredSessionTabs)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockImplementationOnce(
+        () =>
+          new Promise<RuntimeMobileSessionTabsResult[]>((resolve) => {
+            resolveFinalRefresh = resolve
+          })
+      )
+
+    startStructuredCodexLaunch(worktreeId)
+    await vi.waitFor(() => expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(3))
+    expect(cancelStructuredCodexLaunch(worktreeId, intent.sessionId)).toBe(true)
+    resolveFinalRefresh([])
+    await flushLaunchSettlement()
+
+    expect(mocks.launch).toHaveBeenCalledTimes(2)
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(mocks.abandonIntent).toHaveBeenCalledWith(intent)
+  })
+
   it('opens the chat without an informational progress toast', async () => {
     const worktreeId = 'wt-open-quiet'
     const intent = launchIntent(worktreeId, 'session-1')

--- a/src/renderer/src/lib/structured-agent-session-launch.test.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.test.ts
@@ -6,7 +6,8 @@ const mocks = vi.hoisted(() => ({
   createIntent: vi.fn(),
   launch: vi.fn(),
   abandonIntent: vi.fn(),
-  rendererTabs: {} as Record<string, unknown[]>
+  rendererTabs: {} as Record<string, unknown[]>,
+  listeners: new Set<(state: { unifiedTabsByWorktree: Record<string, unknown[]> }) => void>()
 }))
 
 vi.mock('sonner', () => ({
@@ -36,7 +37,13 @@ vi.mock('@/i18n/i18n', () => ({
 
 vi.mock('@/store', () => ({
   useAppStore: {
-    getState: () => ({ unifiedTabsByWorktree: mocks.rendererTabs })
+    getState: () => ({ unifiedTabsByWorktree: mocks.rendererTabs }),
+    subscribe: (
+      listener: (state: { unifiedTabsByWorktree: Record<string, unknown[]> }) => void
+    ) => {
+      mocks.listeners.add(listener)
+      return () => mocks.listeners.delete(listener)
+    }
   }
 }))
 
@@ -104,24 +111,18 @@ describe('startStructuredCodexLaunch', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.rendererTabs = {}
+    mocks.listeners.clear()
     mocks.createIntent.mockImplementation((worktreeId: string) => launchIntent(worktreeId))
   })
 
   it('cancels a close-racing launch without retrying an already-closed session', async () => {
     const worktreeId = 'wt-close-race'
     const intent = launchIntent(worktreeId, 'session-close-race')
-    let resolveRefresh!: (snapshots: RuntimeMobileSessionTabsResult[]) => void
     mocks.createIntent.mockReturnValueOnce(intent)
     mocks.launch.mockResolvedValueOnce(intent.sessionId)
-    vi.mocked(refreshLocalStructuredSessionTabs).mockImplementationOnce(
-      () => new Promise<RuntimeMobileSessionTabsResult[]>((resolve) => (resolveRefresh = resolve))
-    )
 
     startStructuredCodexLaunch(worktreeId)
-    await vi.waitFor(() => expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledOnce())
-
     expect(cancelStructuredCodexLaunch(worktreeId, intent.sessionId)).toBe(true)
-    resolveRefresh([])
     await flushLaunchSettlement()
 
     expect(mocks.launch).toHaveBeenCalledOnce()
@@ -129,29 +130,17 @@ describe('startStructuredCodexLaunch', () => {
     expect(mocks.abandonIntent).toHaveBeenCalledWith(intent)
   })
 
-  it('does not park or toast when close races the final verification retry', async () => {
+  it('does not retry creation when close races inventory recovery', async () => {
     const worktreeId = 'wt-close-final-verify'
     const intent = launchIntent(worktreeId, 'session-close-final-verify')
-    let resolveFinalRefresh!: (snapshots: RuntimeMobileSessionTabsResult[]) => void
     mocks.createIntent.mockReturnValueOnce(intent)
     mocks.launch.mockResolvedValue(intent.sessionId)
-    vi.mocked(refreshLocalStructuredSessionTabs)
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockImplementationOnce(
-        () =>
-          new Promise<RuntimeMobileSessionTabsResult[]>((resolve) => {
-            resolveFinalRefresh = resolve
-          })
-      )
 
     startStructuredCodexLaunch(worktreeId)
-    await vi.waitFor(() => expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(3))
     expect(cancelStructuredCodexLaunch(worktreeId, intent.sessionId)).toBe(true)
-    resolveFinalRefresh([])
     await flushLaunchSettlement()
 
-    expect(mocks.launch).toHaveBeenCalledTimes(2)
+    expect(mocks.launch).toHaveBeenCalledOnce()
     expect(toast.error).not.toHaveBeenCalled()
     expect(mocks.abandonIntent).toHaveBeenCalledWith(intent)
   })
@@ -171,6 +160,28 @@ describe('startStructuredCodexLaunch', () => {
     expect(mocks.launch).toHaveBeenCalledOnce()
     expect(mocks.launch).toHaveBeenCalledWith(intent)
     expect(toast.message).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('completes from the host-emitted projection without listing inventory', async () => {
+    const worktreeId = 'wt-host-frame'
+    const intent = launchIntent(worktreeId, 'session-host-frame')
+    mocks.createIntent.mockReturnValueOnce(intent)
+    mocks.launch.mockImplementationOnce(async () => {
+      mocks.rendererTabs[worktreeId] = [
+        { contentType: 'agent-session', entityId: intent.sessionId, worktreeId }
+      ]
+      for (const listener of mocks.listeners) {
+        listener({ unifiedTabsByWorktree: mocks.rendererTabs })
+      }
+      return intent.sessionId
+    })
+
+    startStructuredCodexLaunch(worktreeId)
+    await flushLaunchSettlement()
+
+    expect(mocks.launch).toHaveBeenCalledOnce()
+    expect(refreshLocalStructuredSessionTabs).not.toHaveBeenCalled()
     expect(toast.error).not.toHaveBeenCalled()
   })
 
@@ -213,13 +224,11 @@ describe('startStructuredCodexLaunch', () => {
     expect(toast.error).not.toHaveBeenCalled()
   })
 
-  it('retries an absent unknown outcome with the exact same intent', async () => {
+  it('keeps an absent unknown outcome tied to the original intent without recreating', async () => {
     const worktreeId = 'wt-same-envelope-retry'
     const intent = launchIntent(worktreeId)
     mocks.createIntent.mockReturnValueOnce(intent)
-    mocks.launch
-      .mockRejectedValueOnce(new Error('response lost'))
-      .mockResolvedValueOnce(intent.sessionId)
+    mocks.launch.mockRejectedValueOnce(new Error('response lost'))
     vi.mocked(refreshLocalStructuredSessionTabs)
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([publishedSnapshot(worktreeId, intent.sessionId)])
@@ -227,33 +236,39 @@ describe('startStructuredCodexLaunch', () => {
     startStructuredCodexLaunch(worktreeId)
     await flushLaunchSettlement()
 
-    expect(mocks.launch).toHaveBeenCalledTimes(2)
+    expect(mocks.launch).toHaveBeenCalledOnce()
     expect(mocks.launch.mock.calls[0]?.[0]).toBe(intent)
-    expect(mocks.launch.mock.calls[1]?.[0]).toBe(intent)
     expect(mocks.createIntent).toHaveBeenCalledOnce()
     expect(toast.error).not.toHaveBeenCalled()
   })
 
   it('keeps an unresolved identity reserved until inventory reconciles it', async () => {
-    const worktreeId = 'wt-still-unknown'
-    const intent = launchIntent(worktreeId)
-    mocks.createIntent.mockReturnValueOnce(intent)
-    mocks.launch.mockRejectedValue(new Error('offline'))
-    vi.mocked(refreshLocalStructuredSessionTabs).mockResolvedValue([])
+    vi.useFakeTimers()
+    try {
+      const worktreeId = 'wt-still-unknown'
+      const intent = launchIntent(worktreeId)
+      mocks.createIntent.mockReturnValueOnce(intent)
+      mocks.launch.mockRejectedValue(new Error('offline'))
+      vi.mocked(refreshLocalStructuredSessionTabs).mockResolvedValue([])
 
-    startStructuredCodexLaunch(worktreeId)
-    await flushLaunchSettlement()
-    expect(toast.error).toHaveBeenCalledOnce()
+      startStructuredCodexLaunch(worktreeId)
+      await vi.advanceTimersByTimeAsync(3000)
+      await flushLaunchSettlement()
+      expect(toast.error).toHaveBeenCalledOnce()
 
-    vi.mocked(refreshLocalStructuredSessionTabs).mockResolvedValue([
-      publishedSnapshot(worktreeId, intent.sessionId)
-    ])
-    startStructuredCodexLaunch(worktreeId)
-    await flushLaunchSettlement()
+      vi.mocked(refreshLocalStructuredSessionTabs).mockResolvedValue([
+        publishedSnapshot(worktreeId, intent.sessionId)
+      ])
+      startStructuredCodexLaunch(worktreeId)
+      await vi.advanceTimersByTimeAsync(1000)
+      await flushLaunchSettlement()
 
-    expect(mocks.createIntent).toHaveBeenCalledOnce()
-    expect(mocks.launch).toHaveBeenCalledTimes(2)
-    expect(toast.error).toHaveBeenCalledOnce()
+      expect(mocks.createIntent).toHaveBeenCalledOnce()
+      expect(mocks.launch).toHaveBeenCalledOnce()
+      expect(toast.error).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('releases a definitively refused intent so a new click can create a new identity', async () => {

--- a/src/renderer/src/lib/structured-agent-session-launch.test.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.test.ts
@@ -5,7 +5,8 @@ import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-ses
 const mocks = vi.hoisted(() => ({
   createIntent: vi.fn(),
   launch: vi.fn(),
-  abandonIntent: vi.fn()
+  abandonIntent: vi.fn(),
+  rendererTabs: {} as Record<string, unknown[]>
 }))
 
 vi.mock('sonner', () => ({
@@ -31,6 +32,12 @@ vi.mock('@/runtime/local-structured-session-tabs-sync', () => ({
 
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({ unifiedTabsByWorktree: mocks.rendererTabs })
+  }
 }))
 
 import {
@@ -64,6 +71,9 @@ function launchIntent(
 }
 
 function publishedSnapshot(worktreeId: string, sessionId: string): RuntimeMobileSessionTabsResult {
+  mocks.rendererTabs[worktreeId] = [
+    { contentType: 'agent-session', entityId: sessionId, worktreeId }
+  ]
   return {
     worktree: worktreeId,
     publicationEpoch: 'epoch-1',
@@ -93,6 +103,7 @@ async function flushLaunchSettlement(): Promise<void> {
 describe('startStructuredCodexLaunch', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.rendererTabs = {}
     mocks.createIntent.mockImplementation((worktreeId: string) => launchIntent(worktreeId))
   })
 

--- a/src/renderer/src/lib/structured-agent-session-launch.test.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.test.ts
@@ -4,7 +4,8 @@ import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-ses
 
 const mocks = vi.hoisted(() => ({
   createIntent: vi.fn(),
-  launch: vi.fn()
+  launch: vi.fn(),
+  abandonIntent: vi.fn()
 }))
 
 vi.mock('sonner', () => ({
@@ -19,6 +20,7 @@ vi.mock('@/lib/launch-structured-codex-session', () => {
   return {
     createStructuredCodexSessionLaunchIntent: mocks.createIntent,
     launchStructuredCodexSession: mocks.launch,
+    abandonStructuredAgentSessionLaunchIntent: mocks.abandonIntent,
     StructuredAgentSessionCreateRefusalError
   }
 })
@@ -36,7 +38,10 @@ import {
   type StructuredAgentSessionLaunchIntent
 } from '@/lib/launch-structured-codex-session'
 import { refreshLocalStructuredSessionTabs } from '@/runtime/local-structured-session-tabs-sync'
-import { startStructuredCodexLaunch } from './structured-agent-session-launch'
+import {
+  cancelStructuredCodexLaunch,
+  startStructuredCodexLaunch
+} from './structured-agent-session-launch'
 
 function launchIntent(
   worktreeId: string,
@@ -89,6 +94,28 @@ describe('startStructuredCodexLaunch', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.createIntent.mockImplementation((worktreeId: string) => launchIntent(worktreeId))
+  })
+
+  it('cancels a close-racing launch without retrying an already-closed session', async () => {
+    const worktreeId = 'wt-close-race'
+    const intent = launchIntent(worktreeId, 'session-close-race')
+    let resolveRefresh!: (snapshots: RuntimeMobileSessionTabsResult[]) => void
+    mocks.createIntent.mockReturnValueOnce(intent)
+    mocks.launch.mockResolvedValueOnce(intent.sessionId)
+    vi.mocked(refreshLocalStructuredSessionTabs).mockImplementationOnce(
+      () => new Promise<RuntimeMobileSessionTabsResult[]>((resolve) => (resolveRefresh = resolve))
+    )
+
+    startStructuredCodexLaunch(worktreeId)
+    await vi.waitFor(() => expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledOnce())
+
+    expect(cancelStructuredCodexLaunch(worktreeId, intent.sessionId)).toBe(true)
+    resolveRefresh([])
+    await flushLaunchSettlement()
+
+    expect(mocks.launch).toHaveBeenCalledOnce()
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(mocks.abandonIntent).toHaveBeenCalledWith(intent)
   })
 
   it('opens the chat without an informational progress toast', async () => {

--- a/src/renderer/src/lib/structured-agent-session-launch.test.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.test.ts
@@ -271,6 +271,40 @@ describe('startStructuredCodexLaunch', () => {
     }
   })
 
+  it('replays the same intent after an absent unknown outcome', async () => {
+    vi.useFakeTimers()
+    try {
+      const worktreeId = 'wt-replay-unknown'
+      const intent = launchIntent(worktreeId)
+      mocks.createIntent.mockReturnValueOnce(intent)
+      mocks.launch.mockRejectedValueOnce(new Error('offline')).mockImplementationOnce(async () => {
+        mocks.rendererTabs[worktreeId] = [
+          { contentType: 'agent-session', entityId: intent.sessionId, worktreeId }
+        ]
+        for (const listener of mocks.listeners) {
+          listener({ unifiedTabsByWorktree: mocks.rendererTabs })
+        }
+        return intent.sessionId
+      })
+      vi.mocked(refreshLocalStructuredSessionTabs).mockResolvedValue([])
+
+      startStructuredCodexLaunch(worktreeId)
+      await vi.advanceTimersByTimeAsync(3000)
+      await flushLaunchSettlement()
+
+      startStructuredCodexLaunch(worktreeId)
+      await vi.advanceTimersByTimeAsync(1000)
+      await flushLaunchSettlement()
+
+      expect(mocks.createIntent).toHaveBeenCalledOnce()
+      expect(mocks.launch).toHaveBeenCalledTimes(2)
+      expect(mocks.launch.mock.calls[1]?.[0]).toBe(intent)
+      expect(toast.error).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('releases a definitively refused intent so a new click can create a new identity', async () => {
     const worktreeId = 'wt-refused'
     const first = launchIntent(worktreeId, 'session-first')

--- a/src/renderer/src/lib/structured-agent-session-launch.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.ts
@@ -1,6 +1,7 @@
 import { toast } from 'sonner'
 import {
   createStructuredCodexSessionLaunchIntent,
+  abandonStructuredAgentSessionLaunchIntent,
   launchStructuredCodexSession,
   StructuredAgentSessionCreateRefusalError,
   type StructuredAgentSessionLaunchIntent
@@ -12,9 +13,23 @@ type StructuredLaunchState = {
   intent: StructuredAgentSessionLaunchIntent
   promise: Promise<string>
   visibilityUnknown: boolean
+  cancelled: boolean
 }
 
 const pendingStructuredLaunchesByWorktree = new Map<string, StructuredLaunchState>()
+
+class StructuredAgentSessionLaunchCancelledError extends Error {
+  constructor() {
+    super('structured session launch cancelled')
+    this.name = 'StructuredAgentSessionLaunchCancelledError'
+  }
+}
+
+function throwIfLaunchCancelled(state: StructuredLaunchState): void {
+  if (state.cancelled) {
+    throw new StructuredAgentSessionLaunchCancelledError()
+  }
+}
 
 function trackLaunchSettlement(
   worktreeId: string,
@@ -58,10 +73,15 @@ async function verifyPublishedSession(intent: StructuredAgentSessionLaunchIntent
 }
 
 async function retrySameIntent(state: StructuredLaunchState, priorError: unknown): Promise<string> {
+  throwIfLaunchCancelled(state)
   try {
     await launchStructuredCodexSession(state.intent)
+    throwIfLaunchCancelled(state)
     return await verifyPublishedSession(state.intent)
   } catch (error) {
+    if (state.cancelled) {
+      throw new StructuredAgentSessionLaunchCancelledError()
+    }
     if (error instanceof StructuredAgentSessionCreateRefusalError) {
       throw error
     }
@@ -75,9 +95,13 @@ async function retrySameIntent(state: StructuredLaunchState, priorError: unknown
 }
 
 async function launchAndReconcile(state: StructuredLaunchState): Promise<string> {
+  throwIfLaunchCancelled(state)
   try {
     await launchStructuredCodexSession(state.intent)
   } catch (error) {
+    if (state.cancelled) {
+      throw new StructuredAgentSessionLaunchCancelledError()
+    }
     if (error instanceof StructuredAgentSessionCreateRefusalError) {
       throw error
     }
@@ -88,13 +112,18 @@ async function launchAndReconcile(state: StructuredLaunchState): Promise<string>
     }
   }
   try {
+    throwIfLaunchCancelled(state)
     return await verifyPublishedSession(state.intent)
   } catch (error) {
+    if (state.cancelled) {
+      throw new StructuredAgentSessionLaunchCancelledError()
+    }
     return retrySameIntent(state, error)
   }
 }
 
 async function reconcileUnknownLaunch(state: StructuredLaunchState): Promise<string> {
+  throwIfLaunchCancelled(state)
   state.visibilityUnknown = false
   try {
     return await verifyPublishedSession(state.intent)
@@ -115,7 +144,8 @@ function launchStructuredCodexSessionOnce(worktreeId: string): Promise<string> {
   const state: StructuredLaunchState = {
     intent: createStructuredCodexSessionLaunchIntent(worktreeId),
     promise: Promise.resolve(''),
-    visibilityUnknown: false
+    visibilityUnknown: false,
+    cancelled: false
   }
   state.promise = launchAndReconcile(state)
   pendingStructuredLaunchesByWorktree.set(worktreeId, state)
@@ -123,8 +153,23 @@ function launchStructuredCodexSessionOnce(worktreeId: string): Promise<string> {
   return state.promise
 }
 
+/** Stop retries for a launch whose tab the user explicitly closed. */
+export function cancelStructuredCodexLaunch(worktreeId: string, sessionId: string): boolean {
+  const state = pendingStructuredLaunchesByWorktree.get(worktreeId)
+  if (!state || state.intent.sessionId !== sessionId) {
+    return false
+  }
+  state.cancelled = true
+  pendingStructuredLaunchesByWorktree.delete(worktreeId)
+  abandonStructuredAgentSessionLaunchIntent(state.intent)
+  return true
+}
+
 export function startStructuredCodexLaunch(worktreeId: string): void {
   void launchStructuredCodexSessionOnce(worktreeId).catch((error) => {
+    if (error instanceof StructuredAgentSessionLaunchCancelledError) {
+      return
+    }
     toast.error(
       translate(
         'components.native-chat.structuredSessionLaunchFailed',

--- a/src/renderer/src/lib/structured-agent-session-launch.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.ts
@@ -1,3 +1,4 @@
+import { useSyncExternalStore } from 'react'
 import { toast } from 'sonner'
 import {
   createStructuredCodexSessionLaunchIntent,
@@ -8,6 +9,7 @@ import {
 } from '@/lib/launch-structured-codex-session'
 import { refreshLocalStructuredSessionTabs } from '@/runtime/local-structured-session-tabs-sync'
 import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
 
 type StructuredLaunchState = {
   intent: StructuredAgentSessionLaunchIntent
@@ -16,7 +18,37 @@ type StructuredLaunchState = {
   cancelled: boolean
 }
 
+export type StructuredCodexLaunchStatus = 'idle' | 'pending' | 'unknown'
+
 const pendingStructuredLaunchesByWorktree = new Map<string, StructuredLaunchState>()
+const structuredLaunchListeners = new Set<() => void>()
+
+function notifyStructuredLaunchListeners(): void {
+  for (const listener of structuredLaunchListeners) {
+    listener()
+  }
+}
+
+export function subscribeStructuredCodexLaunchStatus(listener: () => void): () => void {
+  structuredLaunchListeners.add(listener)
+  return () => structuredLaunchListeners.delete(listener)
+}
+
+export function getStructuredCodexLaunchStatus(worktreeId: string): StructuredCodexLaunchStatus {
+  const state = pendingStructuredLaunchesByWorktree.get(worktreeId)
+  if (!state) {
+    return 'idle'
+  }
+  return state.visibilityUnknown ? 'unknown' : 'pending'
+}
+
+export function useStructuredCodexLaunchStatus(worktreeId: string): StructuredCodexLaunchStatus {
+  return useSyncExternalStore(
+    subscribeStructuredCodexLaunchStatus,
+    () => getStructuredCodexLaunchStatus(worktreeId),
+    () => 'idle'
+  )
+}
 
 class StructuredAgentSessionLaunchCancelledError extends Error {
   constructor() {
@@ -43,6 +75,7 @@ function trackLaunchSettlement(
         pendingStructuredLaunchesByWorktree.get(worktreeId) === state
       ) {
         pendingStructuredLaunchesByWorktree.delete(worktreeId)
+        notifyStructuredLaunchListeners()
       }
     },
     () => {
@@ -52,6 +85,7 @@ function trackLaunchSettlement(
         pendingStructuredLaunchesByWorktree.get(worktreeId) === state
       ) {
         pendingStructuredLaunchesByWorktree.delete(worktreeId)
+        notifyStructuredLaunchListeners()
       }
     }
   )
@@ -68,6 +102,17 @@ async function verifyPublishedSession(intent: StructuredAgentSessionLaunchIntent
   )
   if (!published) {
     throw new Error('structured session tab publication unavailable')
+  }
+  const adopted = useAppStore
+    .getState()
+    .unifiedTabsByWorktree[intent.worktreeId]?.some(
+      (tab) =>
+        tab.contentType === 'agent-session' &&
+        tab.entityId === intent.sessionId &&
+        tab.worktreeId === intent.worktreeId
+    )
+  if (!adopted) {
+    throw new Error('structured session tab adoption unavailable')
   }
   return intent.sessionId
 }
@@ -89,6 +134,7 @@ async function retrySameIntent(state: StructuredLaunchState, priorError: unknown
       return await verifyPublishedSession(state.intent)
     } catch {
       state.visibilityUnknown = true
+      notifyStructuredLaunchListeners()
       throw error ?? priorError
     }
   }
@@ -125,6 +171,7 @@ async function launchAndReconcile(state: StructuredLaunchState): Promise<string>
 async function reconcileUnknownLaunch(state: StructuredLaunchState): Promise<string> {
   throwIfLaunchCancelled(state)
   state.visibilityUnknown = false
+  notifyStructuredLaunchListeners()
   try {
     return await verifyPublishedSession(state.intent)
   } catch (error) {
@@ -149,6 +196,7 @@ function launchStructuredCodexSessionOnce(worktreeId: string): Promise<string> {
   }
   state.promise = launchAndReconcile(state)
   pendingStructuredLaunchesByWorktree.set(worktreeId, state)
+  notifyStructuredLaunchListeners()
   trackLaunchSettlement(worktreeId, state, state.promise)
   return state.promise
 }
@@ -161,6 +209,7 @@ export function cancelStructuredCodexLaunch(worktreeId: string, sessionId: strin
   }
   state.cancelled = true
   pendingStructuredLaunchesByWorktree.delete(worktreeId)
+  notifyStructuredLaunchListeners()
   abandonStructuredAgentSessionLaunchIntent(state.intent)
   return true
 }

--- a/src/renderer/src/lib/structured-agent-session-launch.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.ts
@@ -16,6 +16,8 @@ type StructuredLaunchState = {
   promise: Promise<string>
   visibilityUnknown: boolean
   cancelled: boolean
+  cancelWaiters: Set<() => void>
+  lastError: unknown
 }
 
 export type StructuredCodexLaunchStatus = 'idle' | 'pending' | 'unknown'
@@ -91,55 +93,114 @@ function trackLaunchSettlement(
   )
 }
 
-async function verifyPublishedSession(intent: StructuredAgentSessionLaunchIntent): Promise<string> {
-  const snapshots = await refreshLocalStructuredSessionTabs()
-  const published = snapshots.some(
-    (snapshot) =>
-      snapshot.worktree === intent.worktreeId &&
-      snapshot.tabs.some(
-        (tab) => tab.type === 'agent-session' && tab.sessionId === intent.sessionId
+function hasAdoptedStructuredSession(intent: StructuredAgentSessionLaunchIntent): boolean {
+  return Boolean(
+    useAppStore
+      .getState()
+      .unifiedTabsByWorktree[intent.worktreeId]?.some(
+        (tab) =>
+          tab.contentType === 'agent-session' &&
+          tab.entityId === intent.sessionId &&
+          tab.worktreeId === intent.worktreeId
       )
   )
-  if (!published) {
-    throw new Error('structured session tab publication unavailable')
-  }
-  const adopted = useAppStore
-    .getState()
-    .unifiedTabsByWorktree[intent.worktreeId]?.some(
-      (tab) =>
-        tab.contentType === 'agent-session' &&
-        tab.entityId === intent.sessionId &&
-        tab.worktreeId === intent.worktreeId
-    )
-  if (!adopted) {
-    throw new Error('structured session tab adoption unavailable')
-  }
-  return intent.sessionId
 }
 
-async function retrySameIntent(state: StructuredLaunchState, priorError: unknown): Promise<string> {
+/** Wait for the host-emitted projection; this is the normal launch completion path. */
+function waitForStructuredSessionAdoption(
+  state: StructuredLaunchState,
+  timeoutMs = 3000
+): Promise<string> {
+  if (hasAdoptedStructuredSession(state.intent)) {
+    return Promise.resolve(state.intent.sessionId)
+  }
+  // Keep unit-test and degraded harnesses deterministic when no store API is installed.
+  if (typeof useAppStore.subscribe !== 'function') {
+    return Promise.reject(new Error('structured session tab adoption unavailable'))
+  }
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const finish = (error?: Error): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      unsubscribe()
+      clearTimeout(timeout)
+      state.cancelWaiters.delete(cancel)
+      if (error) {
+        reject(error)
+      } else {
+        resolve(state.intent.sessionId)
+      }
+    }
+    const cancel = (): void => finish(new StructuredAgentSessionLaunchCancelledError())
+    const unsubscribe = useAppStore.subscribe((nextState) => {
+      if (
+        nextState.unifiedTabsByWorktree[state.intent.worktreeId]?.some(
+          (tab) =>
+            tab.contentType === 'agent-session' &&
+            tab.entityId === state.intent.sessionId &&
+            tab.worktreeId === state.intent.worktreeId
+        )
+      ) {
+        finish()
+      }
+    })
+    const timeout = setTimeout(
+      () => finish(new Error('structured session tab adoption timed out')),
+      timeoutMs
+    )
+    state.cancelWaiters.add(cancel)
+    if (state.cancelled) {
+      cancel()
+    }
+  })
+}
+
+async function recoverStructuredSessionFromInventory(
+  state: StructuredLaunchState,
+  priorError: unknown
+): Promise<string> {
+  state.lastError = priorError
   throwIfLaunchCancelled(state)
   try {
-    await launchStructuredCodexSession(state.intent)
+    const snapshots = await refreshLocalStructuredSessionTabs()
     throwIfLaunchCancelled(state)
-    return await verifyPublishedSession(state.intent)
-  } catch (error) {
-    if (state.cancelled) {
-      throw new StructuredAgentSessionLaunchCancelledError()
+    const published = snapshots.some(
+      (snapshot) =>
+        snapshot.worktree === state.intent.worktreeId &&
+        snapshot.tabs.some(
+          (tab) => tab.type === 'agent-session' && tab.sessionId === state.intent.sessionId
+        )
+    )
+    if (published && hasAdoptedStructuredSession(state.intent)) {
+      return state.intent.sessionId
     }
-    if (error instanceof StructuredAgentSessionCreateRefusalError) {
+  } catch (error) {
+    if (error instanceof StructuredAgentSessionLaunchCancelledError) {
       throw error
     }
-    try {
-      return await verifyPublishedSession(state.intent)
-    } catch {
-      if (state.cancelled) {
-        throw new StructuredAgentSessionLaunchCancelledError()
-      }
-      state.visibilityUnknown = true
-      notifyStructuredLaunchListeners()
-      throw error ?? priorError
+  }
+  state.visibilityUnknown = true
+  notifyStructuredLaunchListeners()
+  throw priorError instanceof Error ? priorError : new Error(String(priorError))
+}
+
+async function reconcileUnknownLaunch(state: StructuredLaunchState): Promise<string> {
+  throwIfLaunchCancelled(state)
+  state.visibilityUnknown = false
+  notifyStructuredLaunchListeners()
+  try {
+    return await waitForStructuredSessionAdoption(state, 1000)
+  } catch (error) {
+    if (error instanceof StructuredAgentSessionLaunchCancelledError) {
+      throw error
     }
+    return recoverStructuredSessionFromInventory(
+      state,
+      state.lastError instanceof Error ? state.lastError : error
+    )
   }
 }
 
@@ -155,30 +216,22 @@ async function launchAndReconcile(state: StructuredLaunchState): Promise<string>
       throw error
     }
     try {
-      return await verifyPublishedSession(state.intent)
-    } catch {
-      return retrySameIntent(state, error)
+      return await waitForStructuredSessionAdoption(state)
+    } catch (adoptionError) {
+      if (adoptionError instanceof StructuredAgentSessionLaunchCancelledError) {
+        throw adoptionError
+      }
+      return recoverStructuredSessionFromInventory(state, error)
     }
   }
   try {
     throwIfLaunchCancelled(state)
-    return await verifyPublishedSession(state.intent)
+    return await waitForStructuredSessionAdoption(state)
   } catch (error) {
-    if (state.cancelled) {
-      throw new StructuredAgentSessionLaunchCancelledError()
+    if (error instanceof StructuredAgentSessionLaunchCancelledError) {
+      throw error
     }
-    return retrySameIntent(state, error)
-  }
-}
-
-async function reconcileUnknownLaunch(state: StructuredLaunchState): Promise<string> {
-  throwIfLaunchCancelled(state)
-  state.visibilityUnknown = false
-  notifyStructuredLaunchListeners()
-  try {
-    return await verifyPublishedSession(state.intent)
-  } catch (error) {
-    return retrySameIntent(state, error)
+    return recoverStructuredSessionFromInventory(state, error)
   }
 }
 
@@ -195,7 +248,9 @@ function launchStructuredCodexSessionOnce(worktreeId: string): Promise<string> {
     intent: createStructuredCodexSessionLaunchIntent(worktreeId),
     promise: Promise.resolve(''),
     visibilityUnknown: false,
-    cancelled: false
+    cancelled: false,
+    cancelWaiters: new Set(),
+    lastError: null
   }
   state.promise = launchAndReconcile(state)
   pendingStructuredLaunchesByWorktree.set(worktreeId, state)
@@ -211,6 +266,10 @@ export function cancelStructuredCodexLaunch(worktreeId: string, sessionId: strin
     return false
   }
   state.cancelled = true
+  for (const cancel of state.cancelWaiters) {
+    cancel()
+  }
+  state.cancelWaiters.clear()
   pendingStructuredLaunchesByWorktree.delete(worktreeId)
   notifyStructuredLaunchListeners()
   abandonStructuredAgentSessionLaunchIntent(state.intent)

--- a/src/renderer/src/lib/structured-agent-session-launch.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.ts
@@ -10,6 +10,7 @@ import {
 import { refreshLocalStructuredSessionTabs } from '@/runtime/local-structured-session-tabs-sync'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
 
 type StructuredLaunchState = {
   intent: StructuredAgentSessionLaunchIntent
@@ -167,13 +168,7 @@ async function recoverStructuredSessionFromInventory(
   try {
     const snapshots = await refreshLocalStructuredSessionTabs()
     throwIfLaunchCancelled(state)
-    const published = snapshots.some(
-      (snapshot) =>
-        snapshot.worktree === state.intent.worktreeId &&
-        snapshot.tabs.some(
-          (tab) => tab.type === 'agent-session' && tab.sessionId === state.intent.sessionId
-        )
-    )
+    const published = inventoryContainsIntent(snapshots, state.intent)
     if (published && hasAdoptedStructuredSession(state.intent)) {
       return state.intent.sessionId
     }
@@ -187,6 +182,19 @@ async function recoverStructuredSessionFromInventory(
   throw priorError instanceof Error ? priorError : new Error(String(priorError))
 }
 
+function inventoryContainsIntent(
+  snapshots: readonly RuntimeMobileSessionTabsResult[],
+  intent: StructuredAgentSessionLaunchIntent
+): boolean {
+  return snapshots.some(
+    (snapshot) =>
+      snapshot.worktree === intent.worktreeId &&
+      snapshot.tabs.some(
+        (tab) => tab.type === 'agent-session' && tab.sessionId === intent.sessionId
+      )
+  )
+}
+
 async function reconcileUnknownLaunch(state: StructuredLaunchState): Promise<string> {
   throwIfLaunchCancelled(state)
   state.visibilityUnknown = false
@@ -197,10 +205,25 @@ async function reconcileUnknownLaunch(state: StructuredLaunchState): Promise<str
     if (error instanceof StructuredAgentSessionLaunchCancelledError) {
       throw error
     }
-    return recoverStructuredSessionFromInventory(
-      state,
-      state.lastError instanceof Error ? state.lastError : error
-    )
+    try {
+      const snapshots = await refreshLocalStructuredSessionTabs()
+      if (inventoryContainsIntent(snapshots, state.intent)) {
+        return await waitForStructuredSessionAdoption(state, 1000)
+      }
+      await launchStructuredCodexSession(state.intent)
+      return await waitForStructuredSessionAdoption(state)
+    } catch (retryError) {
+      if (retryError instanceof StructuredAgentSessionLaunchCancelledError) {
+        throw retryError
+      }
+      if (retryError instanceof StructuredAgentSessionCreateRefusalError) {
+        throw retryError
+      }
+      return recoverStructuredSessionFromInventory(
+        state,
+        state.lastError instanceof Error ? state.lastError : retryError
+      )
+    }
   }
 }
 

--- a/src/renderer/src/lib/structured-agent-session-launch.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.ts
@@ -133,6 +133,9 @@ async function retrySameIntent(state: StructuredLaunchState, priorError: unknown
     try {
       return await verifyPublishedSession(state.intent)
     } catch {
+      if (state.cancelled) {
+        throw new StructuredAgentSessionLaunchCancelledError()
+      }
       state.visibilityUnknown = true
       notifyStructuredLaunchListeners()
       throw error ?? priorError

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
 import type { Tab } from '../../../shared/tab-types'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import type { WorktreeRuntimeOwnerState } from '../lib/worktree-runtime-owner'
 import { buildPersistedUnifiedTabSessionData } from '../lib/workspace-session-unified-tabs'
 import { buildHydratedTabState } from '../store/slices/tabs-hydration'
 import {
@@ -210,6 +211,34 @@ describe('local structured session tab projection', () => {
         expect.arrayContaining([expect.objectContaining({ contentType: 'agent-session' })])
       )
     }
+  })
+
+  it('forgets publisher versions when a worktree is removed', () => {
+    type OwnerState = WebSessionTabsSyncState & WorktreeRuntimeOwnerState
+    const owner = {
+      id: WORKTREE_ID,
+      repoId: 'repo-1',
+      hostId: null,
+      runtimeOwnerEnvironmentId: null
+    }
+    let state = {
+      ...createSnapshot(),
+      worktreesByRepo: { 'repo-1': [owner] }
+    } as OwnerState
+    state = applyLocalStructuredSessionTabSnapshots(state, [
+      structuredInventory('epoch-1', 10, 'session-old')
+    ])
+    state = applyLocalStructuredSessionTabSnapshots(
+      { ...state, worktreesByRepo: {}, unifiedTabsByWorktree: {} },
+      []
+    )
+    state = applyLocalStructuredSessionTabSnapshots(
+      { ...state, worktreesByRepo: { 'repo-1': [owner] } },
+      [structuredInventory('epoch-1', 1, 'session-new')]
+    )
+    expect(state.unifiedTabsByWorktree[WORKTREE_ID]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ entityId: 'session-new' })])
+    )
   })
 
   it('drops terminal topology while retaining structured tabs', () => {

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
@@ -193,6 +193,25 @@ describe('local structured session tab projection', () => {
     )
   })
 
+  it('survives repeated create-close cycles under one publisher generation', () => {
+    let state = createSnapshot()
+    let version = 10
+    for (const sessionId of ['session-1', 'session-2', 'session-3']) {
+      state = applyLocalStructuredSessionTabSnapshots(state, [
+        structuredInventory('renderer:generation-1', version++, sessionId)
+      ])
+      expect(state.unifiedTabsByWorktree[WORKTREE_ID]).toEqual(
+        expect.arrayContaining([expect.objectContaining({ entityId: sessionId })])
+      )
+
+      const closed = structuredInventory('renderer:generation-1', version++, sessionId)
+      state = applyLocalStructuredSessionTabSnapshots(state, [{ ...closed, tabs: [] }])
+      expect(state.unifiedTabsByWorktree[WORKTREE_ID]).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ contentType: 'agent-session' })])
+      )
+    }
+  })
+
   it('drops terminal topology while retaining structured tabs', () => {
     const snapshot = {
       worktree: 'workspace-1',

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
 import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
 import type { Tab } from '../../../shared/tab-types'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
@@ -8,7 +11,8 @@ import { buildHydratedTabState } from '../store/slices/tabs-hydration'
 import {
   applyLocalStructuredSessionTabSnapshots,
   projectLocalStructuredSessionTabs,
-  resetLocalStructuredSessionVersionForTests
+  resetLocalStructuredSessionVersionForTests,
+  startLocalStructuredSessionTabsSync
 } from './local-structured-session-tabs-sync'
 import {
   applyWebSessionTabsSnapshot,
@@ -30,6 +34,11 @@ afterEach(() => {
   resetLocalStructuredSessionVersionForTests()
   resetWebSessionFocusIntentForTests()
   resetWebSessionTabsSnapshotFreshnessForTests()
+  vi.useRealTimers()
+})
+
+beforeEach(() => {
+  vi.restoreAllMocks()
 })
 
 function createSnapshot(): WebSessionTabsSyncState {
@@ -151,6 +160,63 @@ function expectExactSplit(state: {
 }
 
 describe('local structured session tab projection', () => {
+  it('reconnects after a streaming subscription reports an error', async () => {
+    vi.useFakeTimers()
+    const priorApi = window.api
+    const callbacks: ((response: {
+      ok: false
+      error: { code: string; message: string }
+    }) => void)[] = []
+    const unsubscribes: ReturnType<typeof vi.fn>[] = []
+    const subscribe = vi.fn(async (_args: unknown, callback: (response: unknown) => void) => {
+      callbacks.push(
+        callback as (response: { ok: false; error: { code: string; message: string } }) => void
+      )
+      const unsubscribe = vi.fn()
+      unsubscribes.push(unsubscribe)
+      return { unsubscribe, sendBinary: vi.fn() }
+    })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        runtime: {
+          getStatus: vi.fn().mockResolvedValue({
+            capabilities: [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]
+          }),
+          call: vi.fn().mockResolvedValue({
+            ok: true,
+            result: { snapshots: [] }
+          }),
+          subscribe
+        }
+      }
+    })
+    try {
+      await startLocalStructuredSessionTabsSync({
+        isDisposed: () => false,
+        setUnsubscribe: () => undefined
+      })
+      expect(subscribe).toHaveBeenCalledOnce()
+
+      callbacks[0]?.({ ok: false, error: { code: 'runtime_unavailable', message: 'offline' } })
+      await vi.advanceTimersByTimeAsync(249)
+      expect(subscribe).toHaveBeenCalledOnce()
+      await vi.advanceTimersByTimeAsync(1)
+      await Promise.resolve()
+
+      expect(subscribe).toHaveBeenCalledTimes(2)
+      expect(unsubscribes[0]).toHaveBeenCalledOnce()
+      expect(unsubscribes[1]).not.toHaveBeenCalled()
+
+      // A late error from the fenced generation must not start another retry.
+      callbacks[0]?.({ ok: false, error: { code: 'runtime_unavailable', message: 'late' } })
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(subscribe).toHaveBeenCalledTimes(2)
+    } finally {
+      Object.defineProperty(window, 'api', { configurable: true, value: priorApi })
+    }
+  })
+
   it('accepts a newer session after merged content returns to the base epoch', () => {
     const state = createSnapshot()
     const base = {

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
@@ -218,7 +218,7 @@ describe('local structured session tab projection', () => {
     const owner = {
       id: WORKTREE_ID,
       repoId: 'repo-1',
-      hostId: null,
+      hostId: undefined,
       runtimeOwnerEnvironmentId: null
     }
     let state = {

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
@@ -6,7 +6,8 @@ import { buildPersistedUnifiedTabSessionData } from '../lib/workspace-session-un
 import { buildHydratedTabState } from '../store/slices/tabs-hydration'
 import {
   applyLocalStructuredSessionTabSnapshots,
-  projectLocalStructuredSessionTabs
+  projectLocalStructuredSessionTabs,
+  resetLocalStructuredSessionVersionForTests
 } from './local-structured-session-tabs-sync'
 import {
   applyWebSessionTabsSnapshot,
@@ -25,6 +26,7 @@ const PRIMARY_GROUP = 'primary-group'
 const SECONDARY_GROUP = 'secondary-group'
 
 afterEach(() => {
+  resetLocalStructuredSessionVersionForTests()
   resetWebSessionFocusIntentForTests()
   resetWebSessionTabsSnapshotFreshnessForTests()
 })
@@ -148,6 +150,49 @@ function expectExactSplit(state: {
 }
 
 describe('local structured session tab projection', () => {
+  it('accepts a newer session after merged content returns to the base epoch', () => {
+    const state = createSnapshot()
+    const base = {
+      ...({
+        worktree: WORKTREE_ID,
+        publicationEpoch: 'renderer:generation-1',
+        snapshotVersion: 4,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: null,
+        tabs: []
+      } satisfies RuntimeMobileSessionTabsResult)
+    }
+    const withChat = {
+      ...base,
+      snapshotVersion: 5,
+      tabs: [
+        {
+          type: 'agent-session' as const,
+          id: STRUCTURED_ID,
+          title: 'Codex Chat',
+          sessionId: 'codex-1',
+          agent: 'codex' as const,
+          isActive: true
+        }
+      ]
+    }
+    const afterClose = { ...base, snapshotVersion: 6 }
+    const next = applyLocalStructuredSessionTabSnapshots(
+      state,
+      [
+        base,
+        withChat,
+        afterClose,
+        { ...base, snapshotVersion: 7, tabs: [{ ...withChat.tabs[0], isActive: true }] }
+      ],
+      'local-structured-session'
+    )
+    expect(next.unifiedTabsByWorktree[WORKTREE_ID]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ contentType: 'agent-session' })])
+    )
+  })
+
   it('drops terminal topology while retaining structured tabs', () => {
     const snapshot = {
       worktree: 'workspace-1',

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
@@ -219,7 +219,7 @@ describe('local structured session tab projection', () => {
       id: WORKTREE_ID,
       repoId: 'repo-1',
       hostId: undefined,
-      runtimeOwnerEnvironmentId: null
+      runtimeOwnerEnvironmentId: undefined
     }
     let state = {
       ...createSnapshot(),

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
@@ -516,6 +516,26 @@ describe('local structured session tab projection', () => {
       expect.arrayContaining([expect.objectContaining({ entityId: 'session-b' })])
     )
   })
+
+  it('rejects delayed frames from a retired predecessor epoch', () => {
+    const initial = applyLocalStructuredSessionTabSnapshots(createSnapshot(), [
+      structuredInventory('epoch-1', 5, 'session-one')
+    ])
+    const restarted = applyLocalStructuredSessionTabSnapshots(initial, [
+      structuredInventory('epoch-2', 1, 'session-two')
+    ])
+    const delayed = applyLocalStructuredSessionTabSnapshots(restarted, [
+      structuredInventory('epoch-1', 6, 'stale-session')
+    ])
+
+    expect(delayed).toBe(restarted)
+    expect(delayed.unifiedTabsByWorktree[WORKTREE_ID]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ entityId: 'session-two' })])
+    )
+    expect(delayed.unifiedTabsByWorktree[WORKTREE_ID]).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ entityId: 'stale-session' })])
+    )
+  })
 })
 
 function structuredInventory(

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
@@ -241,6 +241,34 @@ describe('local structured session tab projection', () => {
     )
   })
 
+  it('forgets publisher versions when a folder workspace is removed', () => {
+    type OwnerState = WebSessionTabsSyncState & WorktreeRuntimeOwnerState
+    const folderKey = 'folder:folder-1'
+    const folder = { id: 'folder-1' } as NonNullable<OwnerState['folderWorkspaces']>[number]
+    let state = {
+      ...createSnapshot(),
+      activeWorktreeId: folderKey,
+      unifiedTabsByWorktree: { [folderKey]: [] },
+      folderWorkspaces: [folder]
+    } as OwnerState
+    const folderSnapshot = (version: number, sessionId: string) => ({
+      ...structuredInventory('epoch-1', version, sessionId),
+      worktree: folderKey
+    })
+    state = applyLocalStructuredSessionTabSnapshots(state, [folderSnapshot(10, 'session-old')])
+    state = applyLocalStructuredSessionTabSnapshots(
+      { ...state, folderWorkspaces: [], unifiedTabsByWorktree: {} },
+      []
+    )
+    state = applyLocalStructuredSessionTabSnapshots(
+      { ...state, folderWorkspaces: [folder], unifiedTabsByWorktree: { [folderKey]: [] } },
+      [folderSnapshot(1, 'session-new')]
+    )
+    expect(state.unifiedTabsByWorktree[folderKey]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ entityId: 'session-new' })])
+    )
+  })
+
   it('drops terminal topology while retaining structured tabs', () => {
     const snapshot = {
       worktree: 'workspace-1',

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
@@ -169,6 +169,7 @@ async function startLocalStructuredSessionTabsSync(args: {
   }
   let subscriptionGeneration = 0
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let reconnectAttempt = 0
   const subscribeCurrent = async (): Promise<void> => {
     if (args.isDisposed()) {
       return
@@ -193,6 +194,8 @@ async function startLocalStructuredSessionTabsSync(args: {
           if (reconnectTimer !== null) {
             clearTimeout(reconnectTimer)
           }
+          const reconnectDelay = Math.min(250 * 2 ** reconnectAttempt, 5000)
+          reconnectAttempt += 1
           reconnectTimer = setTimeout(() => {
             reconnectTimer = null
             void refreshLocalStructuredSessionTabs()
@@ -204,10 +207,10 @@ async function startLocalStructuredSessionTabsSync(args: {
                     void subscribeCurrent().catch((error) =>
                       console.warn('[structured-session-tabs] resubscribe failed', error)
                     )
-                  }, 250)
+                  }, reconnectDelay)
                 }
               })
-          }, 250)
+          }, reconnectDelay)
         }
       }
     )

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
@@ -149,25 +149,45 @@ async function startLocalStructuredSessionTabsSync(args: {
   if (!supported) {
     return
   }
-  const handle = await window.api.runtime.subscribe(
-    { method: 'session.tabs.subscribeAll', params: {} },
-    (response) => {
-      if (args.isDisposed() || !response.ok) {
-        return
-      }
-      const event = response.result as SessionTabsEvent
-      if (event.type === 'snapshots') {
-        applyStructuredSessionTabSnapshots(event.snapshots)
-      } else if (event.type === 'snapshot' || event.type === 'updated') {
-        applyStructuredSessionTabSnapshots([event])
-      }
+  let subscriptionGeneration = 0
+  const subscribeCurrent = async (): Promise<void> => {
+    if (args.isDisposed()) {
+      return
     }
-  )
-  if (args.isDisposed()) {
-    handle.unsubscribe()
-  } else {
-    args.setUnsubscribe(handle.unsubscribe)
+    const generation = ++subscriptionGeneration
+    let handle: { unsubscribe: () => void } | null = null
+    handle = await window.api.runtime.subscribe(
+      { method: 'session.tabs.subscribeAll', params: {} },
+      (response) => {
+        if (args.isDisposed() || !response.ok) {
+          return
+        }
+        const event = response.result as SessionTabsEvent
+        if (event.type === 'snapshots') {
+          applyStructuredSessionTabSnapshots(event.snapshots)
+        } else if (event.type === 'snapshot' || event.type === 'updated') {
+          applyStructuredSessionTabSnapshots([event])
+        } else if (event.type === 'end' && generation === subscriptionGeneration) {
+          // Reattach with one refresh so a runtime-restart boundary cannot strand stale tabs.
+          subscriptionGeneration += 1
+          handle?.unsubscribe()
+          void refreshLocalStructuredSessionTabs()
+            .catch((error) => console.warn('[structured-session-tabs] resync failed', error))
+            .finally(() => {
+              if (!args.isDisposed()) {
+                void subscribeCurrent()
+              }
+            })
+        }
+      }
+    )
+    if (args.isDisposed() || generation !== subscriptionGeneration) {
+      handle.unsubscribe()
+    } else {
+      args.setUnsubscribe(handle.unsubscribe)
+    }
   }
+  await subscribeCurrent()
 }
 
 export function useLocalStructuredSessionTabsSync(): void {

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
@@ -105,6 +105,24 @@ export function applyLocalStructuredSessionTabSnapshots<
       snapshotVersion: snapshot.snapshotVersion
     })
   }
+  // Drop publisher cursors for worktrees that no longer exist. Without this,
+  // every deleted worktree leaves an entry for the lifetime of the renderer.
+  const knownWorktreeIds = new Set<string>(Object.keys(next.unifiedTabsByWorktree))
+  for (const worktrees of Object.values(next.worktreesByRepo ?? {})) {
+    for (const worktree of worktrees) {
+      knownWorktreeIds.add(worktree.id)
+    }
+  }
+  for (const detected of Object.values(next.detectedWorktreesByRepo ?? {})) {
+    for (const worktree of detected.worktrees) {
+      knownWorktreeIds.add(worktree.id)
+    }
+  }
+  for (const worktreeId of localStructuredSessionVersionByWorktree.keys()) {
+    if (!knownWorktreeIds.has(worktreeId)) {
+      localStructuredSessionVersionByWorktree.delete(worktreeId)
+    }
+  }
   return next
 }
 
@@ -150,6 +168,7 @@ async function startLocalStructuredSessionTabsSync(args: {
     return
   }
   let subscriptionGeneration = 0
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   const subscribeCurrent = async (): Promise<void> => {
     if (args.isDisposed()) {
       return
@@ -171,20 +190,37 @@ async function startLocalStructuredSessionTabsSync(args: {
           // Reattach with one refresh so a runtime-restart boundary cannot strand stale tabs.
           subscriptionGeneration += 1
           handle?.unsubscribe()
-          void refreshLocalStructuredSessionTabs()
-            .catch((error) => console.warn('[structured-session-tabs] resync failed', error))
-            .finally(() => {
-              if (!args.isDisposed()) {
-                void subscribeCurrent()
-              }
-            })
+          if (reconnectTimer !== null) {
+            clearTimeout(reconnectTimer)
+          }
+          reconnectTimer = setTimeout(() => {
+            reconnectTimer = null
+            void refreshLocalStructuredSessionTabs()
+              .catch((error) => console.warn('[structured-session-tabs] resync failed', error))
+              .finally(() => {
+                if (!args.isDisposed()) {
+                  reconnectTimer = setTimeout(() => {
+                    reconnectTimer = null
+                    void subscribeCurrent().catch((error) =>
+                      console.warn('[structured-session-tabs] resubscribe failed', error)
+                    )
+                  }, 250)
+                }
+              })
+          }, 250)
         }
       }
     )
     if (args.isDisposed() || generation !== subscriptionGeneration) {
       handle.unsubscribe()
     } else {
-      args.setUnsubscribe(handle.unsubscribe)
+      args.setUnsubscribe(() => {
+        if (reconnectTimer !== null) {
+          clearTimeout(reconnectTimer)
+          reconnectTimer = null
+        }
+        handle?.unsubscribe()
+      })
     }
   }
   await subscribeCurrent()

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
@@ -6,6 +6,11 @@ import type { WorktreeRuntimeOwnerState } from '../lib/worktree-runtime-owner'
 import { getExecutionHostIdForWorktree } from '../lib/worktree-runtime-owner'
 import { applyWebSessionTabsSnapshot, applyWebSessionTabsStorePatch } from './web-session-tabs-sync'
 import type { WebSessionTabsSyncState } from './web-session-tabs-sync'
+import {
+  noteRetiredValue,
+  sameSessionTabsPublicationLineage
+} from './web-session-tabs-sync/publisher-identity-fences'
+import type { SessionTabsPublicationEpochHistory } from './web-session-tabs-sync/state'
 
 export const LOCAL_STRUCTURED_SESSION_OWNER = 'local-structured-session'
 let localStructuredSessionTabsRestorePromise: Promise<void> | null = null
@@ -13,9 +18,14 @@ const localStructuredSessionVersionByWorktree = new Map<
   string,
   { publicationEpoch: string; snapshotVersion: number }
 >()
+const localStructuredSessionEpochHistoryByWorktree = new Map<
+  string,
+  SessionTabsPublicationEpochHistory
+>()
 
 export function resetLocalStructuredSessionVersionForTests(): void {
   localStructuredSessionVersionByWorktree.clear()
+  localStructuredSessionEpochHistoryByWorktree.clear()
 }
 
 type SessionTabsEvent =
@@ -84,8 +94,14 @@ export function applyLocalStructuredSessionTabSnapshots<
       continue
     }
     const prior = localStructuredSessionVersionByWorktree.get(snapshot.worktree)
-    const isNewerPublisher = prior?.publicationEpoch !== snapshot.publicationEpoch
-    if (prior && !isNewerPublisher && snapshot.snapshotVersion <= prior.snapshotVersion) {
+    const sharesLineage = Boolean(
+      prior && sameSessionTabsPublicationLineage(prior.publicationEpoch, snapshot.publicationEpoch)
+    )
+    const epochHistory = localStructuredSessionEpochHistoryByWorktree.get(snapshot.worktree)
+    if (epochHistory?.retired.includes(snapshot.publicationEpoch) && !sharesLineage) {
+      continue
+    }
+    if (prior && sharesLineage && snapshot.snapshotVersion <= prior.snapshotVersion) {
       continue
     }
     const patch = applyWebSessionTabsSnapshot(
@@ -104,6 +120,10 @@ export function applyLocalStructuredSessionTabSnapshots<
       publicationEpoch: snapshot.publicationEpoch,
       snapshotVersion: snapshot.snapshotVersion
     })
+    localStructuredSessionEpochHistoryByWorktree.set(
+      snapshot.worktree,
+      noteRetiredValue(epochHistory, snapshot.publicationEpoch, 8)
+    )
   }
   // Drop publisher cursors for worktrees that no longer exist. Without this,
   // every deleted worktree leaves an entry for the lifetime of the renderer.
@@ -121,6 +141,7 @@ export function applyLocalStructuredSessionTabSnapshots<
   for (const worktreeId of localStructuredSessionVersionByWorktree.keys()) {
     if (!knownWorktreeIds.has(worktreeId)) {
       localStructuredSessionVersionByWorktree.delete(worktreeId)
+      localStructuredSessionEpochHistoryByWorktree.delete(worktreeId)
     }
   }
   return next

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
@@ -4,15 +4,19 @@ import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-typ
 import { useAppStore } from '../store'
 import type { WorktreeRuntimeOwnerState } from '../lib/worktree-runtime-owner'
 import { getExecutionHostIdForWorktree } from '../lib/worktree-runtime-owner'
-import {
-  applyWebSessionTabsSnapshot,
-  applyWebSessionTabsStorePatch,
-  decideWebSessionTabsSnapshot
-} from './web-session-tabs-sync'
+import { applyWebSessionTabsSnapshot, applyWebSessionTabsStorePatch } from './web-session-tabs-sync'
 import type { WebSessionTabsSyncState } from './web-session-tabs-sync'
 
 export const LOCAL_STRUCTURED_SESSION_OWNER = 'local-structured-session'
 let localStructuredSessionTabsRestorePromise: Promise<void> | null = null
+const localStructuredSessionVersionByWorktree = new Map<
+  string,
+  { publicationEpoch: string; snapshotVersion: number }
+>()
+
+export function resetLocalStructuredSessionVersionForTests(): void {
+  localStructuredSessionVersionByWorktree.clear()
+}
 
 type SessionTabsEvent =
   | (RuntimeMobileSessionTabsResult & { type: 'snapshot' | 'updated' })
@@ -79,7 +83,9 @@ export function applyLocalStructuredSessionTabSnapshots<
     if (getExecutionHostIdForWorktree(next, snapshot.worktree) !== 'local') {
       continue
     }
-    if (!decideWebSessionTabsSnapshot(snapshot, owner).apply) {
+    const prior = localStructuredSessionVersionByWorktree.get(snapshot.worktree)
+    const isNewerPublisher = prior?.publicationEpoch !== snapshot.publicationEpoch
+    if (prior && !isNewerPublisher && snapshot.snapshotVersion <= prior.snapshotVersion) {
       continue
     }
     const patch = applyWebSessionTabsSnapshot(
@@ -94,6 +100,10 @@ export function applyLocalStructuredSessionTabSnapshots<
       }
     )
     next = patch === next ? next : ({ ...next, ...patch } as State)
+    localStructuredSessionVersionByWorktree.set(snapshot.worktree, {
+      publicationEpoch: snapshot.publicationEpoch,
+      snapshotVersion: snapshot.snapshotVersion
+    })
   }
   return next
 }

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
@@ -204,10 +204,16 @@ async function startLocalStructuredSessionTabsSync(args: {
     reconnectAttempt += 1
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null
-      void subscribeCurrent().catch((error) => {
-        console.warn('[structured-session-tabs] resubscribe failed', error)
-        scheduleSubscribeRetry()
-      })
+      void refreshLocalStructuredSessionTabs()
+        .catch((error) => console.warn('[structured-session-tabs] resync failed', error))
+        .finally(() => {
+          if (!args.isDisposed()) {
+            void subscribeCurrent().catch((error) => {
+              console.warn('[structured-session-tabs] resubscribe failed', error)
+              scheduleSubscribeRetry()
+            })
+          }
+        })
     }, reconnectDelay)
   }
   const subscribeCurrent = async (): Promise<void> => {

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
 import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import { useAppStore } from '../store'
 import type { WorktreeRuntimeOwnerState } from '../lib/worktree-runtime-owner'
 import { getExecutionHostIdForWorktree } from '../lib/worktree-runtime-owner'
@@ -138,6 +139,9 @@ export function applyLocalStructuredSessionTabSnapshots<
       knownWorktreeIds.add(worktree.id)
     }
   }
+  for (const workspace of next.folderWorkspaces ?? []) {
+    knownWorktreeIds.add(folderWorkspaceKey(workspace.id))
+  }
   for (const worktreeId of localStructuredSessionVersionByWorktree.keys()) {
     if (!knownWorktreeIds.has(worktreeId)) {
       localStructuredSessionVersionByWorktree.delete(worktreeId)
@@ -191,6 +195,21 @@ async function startLocalStructuredSessionTabsSync(args: {
   let subscriptionGeneration = 0
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   let reconnectAttempt = 0
+  let activeHandle: { unsubscribe: () => void } | null = null
+  const scheduleSubscribeRetry = (): void => {
+    if (args.isDisposed() || reconnectTimer !== null) {
+      return
+    }
+    const reconnectDelay = Math.min(250 * 2 ** reconnectAttempt, 5000)
+    reconnectAttempt += 1
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      void subscribeCurrent().catch((error) => {
+        console.warn('[structured-session-tabs] resubscribe failed', error)
+        scheduleSubscribeRetry()
+      })
+    }, reconnectDelay)
+  }
   const subscribeCurrent = async (): Promise<void> => {
     if (args.isDisposed()) {
       return
@@ -215,39 +234,28 @@ async function startLocalStructuredSessionTabsSync(args: {
           if (reconnectTimer !== null) {
             clearTimeout(reconnectTimer)
           }
-          const reconnectDelay = Math.min(250 * 2 ** reconnectAttempt, 5000)
-          reconnectAttempt += 1
-          reconnectTimer = setTimeout(() => {
-            reconnectTimer = null
-            void refreshLocalStructuredSessionTabs()
-              .catch((error) => console.warn('[structured-session-tabs] resync failed', error))
-              .finally(() => {
-                if (!args.isDisposed()) {
-                  reconnectTimer = setTimeout(() => {
-                    reconnectTimer = null
-                    void subscribeCurrent().catch((error) =>
-                      console.warn('[structured-session-tabs] resubscribe failed', error)
-                    )
-                  }, reconnectDelay)
-                }
-              })
-          }, reconnectDelay)
+          scheduleSubscribeRetry()
         }
       }
     )
     if (args.isDisposed() || generation !== subscriptionGeneration) {
       handle.unsubscribe()
     } else {
-      args.setUnsubscribe(() => {
-        if (reconnectTimer !== null) {
-          clearTimeout(reconnectTimer)
-          reconnectTimer = null
-        }
-        handle?.unsubscribe()
-      })
+      activeHandle = handle
     }
   }
-  await subscribeCurrent()
+  args.setUnsubscribe(() => {
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    activeHandle?.unsubscribe()
+    activeHandle = null
+  })
+  void subscribeCurrent().catch((error) => {
+    console.warn('[structured-session-tabs] subscribe failed', error)
+    scheduleSubscribeRetry()
+  })
 }
 
 export function useLocalStructuredSessionTabsSync(): void {

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.ts
@@ -176,7 +176,7 @@ export function refreshLocalStructuredSessionTabs(): Promise<RuntimeMobileSessio
     })
 }
 
-async function startLocalStructuredSessionTabsSync(args: {
+export async function startLocalStructuredSessionTabsSync(args: {
   isDisposed: () => boolean
   setUnsubscribe: (unsubscribe: () => void) => void
 }): Promise<void> {
@@ -225,7 +225,18 @@ async function startLocalStructuredSessionTabsSync(args: {
     handle = await window.api.runtime.subscribe(
       { method: 'session.tabs.subscribeAll', params: {} },
       (response) => {
-        if (args.isDisposed() || !response.ok) {
+        if (args.isDisposed() || generation !== subscriptionGeneration) {
+          return
+        }
+        if (!response.ok) {
+          // A streaming RPC can terminate with an error response before its
+          // handle resolves; fence that generation and retry the subscription.
+          subscriptionGeneration += 1
+          handle?.unsubscribe()
+          if (activeHandle === handle) {
+            activeHandle = null
+          }
+          scheduleSubscribeRetry()
           return
         }
         const event = response.result as SessionTabsEvent
@@ -237,6 +248,9 @@ async function startLocalStructuredSessionTabsSync(args: {
           // Reattach with one refresh so a runtime-restart boundary cannot strand stale tabs.
           subscriptionGeneration += 1
           handle?.unsubscribe()
+          if (activeHandle === handle) {
+            activeHandle = null
+          }
           if (reconnectTimer !== null) {
             clearTimeout(reconnectTimer)
           }

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -169,6 +169,40 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(shouldApplyWebSessionTabsSnapshot(sameEpochOlder, ENV)).toBe(false)
   })
 
+  it('keeps base and headless-merge publications in one freshness lineage', () => {
+    const renderer = makeSnapshot([], {
+      publicationEpoch: 'renderer:epoch-1',
+      snapshotVersion: 14,
+      activeTabType: null
+    })
+    const merged = makeSnapshot([], {
+      publicationEpoch: 'renderer:epoch-1:headless-merge:abc123',
+      snapshotVersion: 8,
+      activeTabType: null
+    })
+    const refreshedRenderer = makeSnapshot([], {
+      publicationEpoch: 'renderer:epoch-1',
+      snapshotVersion: 15,
+      activeTabType: null
+    })
+
+    expect(shouldApplyWebSessionTabsSnapshot(renderer, ENV)).toBe(true)
+    expect(shouldApplyWebSessionTabsSnapshot(merged, ENV)).toBe(true)
+    // listAll can return the renderer base after a host-side headless merge;
+    // the newer base revision must still be allowed to refresh the mirror.
+    expect(shouldApplyWebSessionTabsSnapshot(refreshedRenderer, ENV)).toBe(true)
+    expect(
+      shouldApplyWebSessionTabsSnapshot(
+        makeSnapshot([], {
+          publicationEpoch: 'renderer:epoch-1',
+          snapshotVersion: 7,
+          activeTabType: null
+        }),
+        ENV
+      )
+    ).toBe(false)
+  })
+
   it('rejects a delayed frame from an epoch superseded by a later restart', () => {
     const beforeRestart = makeSnapshot([], {
       publicationEpoch: 'epoch-before-restart',

--- a/src/renderer/src/runtime/web-session-tabs-sync/publisher-identity-fences.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/publisher-identity-fences.ts
@@ -125,6 +125,22 @@ export function isRetiredSessionTabsPublicationEpoch(
   return hasRetiredValue(sessionTabsPublicationEpochHistoryByWorktree.get(key), publicationEpoch)
 }
 
+/**
+ * A headless merge keeps the renderer publication as its base epoch while
+ * adding runtime-owned surfaces. Treat both forms as one ordering lineage.
+ */
+export function sameSessionTabsPublicationLineage(left: string, right: string): boolean {
+  return (
+    left === right ||
+    ((left.includes(':headless-merge:') || right.includes(':headless-merge:')) &&
+      left.split(':headless-merge:')[0] === right.split(':headless-merge:')[0])
+  )
+}
+
+export function isHeadlessMergeSessionTabsPublication(publicationEpoch: string): boolean {
+  return publicationEpoch.includes(':headless-merge:')
+}
+
 export function noteSessionTabsPublicationEpoch(
   key: string,
   publicationEpoch: string

--- a/src/renderer/src/runtime/web-session-tabs-sync/tracking-decisions.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/tracking-decisions.ts
@@ -9,7 +9,9 @@ import {
 import {
   acceptSessionTabsRuntimeId,
   isRetiredSessionTabsPublicationEpoch,
-  noteSessionTabsPublicationEpoch
+  isHeadlessMergeSessionTabsPublication,
+  noteSessionTabsPublicationEpoch,
+  sameSessionTabsPublicationLineage
 } from './publisher-identity-fences'
 import {
   sessionTabsFreshnessKey,
@@ -78,7 +80,20 @@ export function decideWebSessionTabsSnapshot(
     return WEB_SESSION_TABS_FRAME_UNMIRRORED
   }
   const current = latestSessionTabsSnapshotByWorktree.get(key)
-  if (isRetiredSessionTabsPublicationEpoch(key, snapshot.publicationEpoch)) {
+  const currentSharesPublicationLineage = Boolean(
+    current &&
+    sameSessionTabsPublicationLineage(current.publicationEpoch, snapshot.publicationEpoch)
+  )
+  const currentIsHeadlessMerge = current
+    ? isHeadlessMergeSessionTabsPublication(current.publicationEpoch)
+    : false
+  const comparePublicationVersions =
+    currentSharesPublicationLineage &&
+    (currentIsHeadlessMerge || !isHeadlessMergeSessionTabsPublication(snapshot.publicationEpoch))
+  if (
+    isRetiredSessionTabsPublicationEpoch(key, snapshot.publicationEpoch) &&
+    !currentSharesPublicationLineage
+  ) {
     return WEB_SESSION_TABS_FRAME_OUTRANKED
   }
   const replayable = replayableSessionTabsSnapshotByWorktree.get(key)
@@ -93,7 +108,8 @@ export function decideWebSessionTabsSnapshot(
   // Why: reject stale snapshots only within an epoch; host restarts create a new epoch.
   if (
     current &&
-    current.publicationEpoch === snapshot.publicationEpoch &&
+    comparePublicationVersions &&
+    sameSessionTabsPublicationLineage(current.publicationEpoch, snapshot.publicationEpoch) &&
     snapshot.snapshotVersion <= current.snapshotVersion &&
     !isExactCurrentReplay
   ) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​443 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​412 |
| Prod | 27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​487 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​106 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​381 |

<!-- /orca-pr-loc -->

## What changed

Codex native-chat launch now has one coordinated lifecycle from click to host publication to renderer adoption. The host owns one monotonically versioned snapshot per worktree; publisher identity is separate from snapshot content, so creating and closing chats cannot permanently poison the next launch. The renderer completes from the live host frame and uses inventory only as bounded recovery when a frame or response is lost.

## Before / after (user-facing)

**Before**

- Clicking New tab → Codex could appear to do nothing.
- Closing a chat and opening another could leave the workspace stuck or make old tabs appear later.
- Restart or reconnect timing could leave the local chat list stale.

**After**

- One click creates one chat identity; duplicate clicks are coalesced.
- The new chat appears as soon as the host publishes it, without waiting for a second inventory round trip.
- Closing a chat cannot be undone by a late launch response.
- Runtime stream termination triggers one inventory refresh and a clean resubscription.
- Repeated create → close → create cycles remain valid under the same publisher generation.

## Implementation

- Added a single host snapshot write funnel that stamps strictly increasing per-worktree versions.
- Removed merge/content hashes from `publicationEpoch`; it now represents publisher generation only.
- Replaced local structured-session adoption's shared retirement fence with a local `(publicationEpoch, snapshotVersion)` gate.
- Simplified the launch coordinator to wait for the host-emitted renderer projection, with one bounded inventory recovery path and same-intent unknown-state reconciliation.
- Added stream-end resubscription and focused regressions for host-frame completion, close races, repeated cycles, stale versions, and refusal handling.

## Validation

- 18 focused renderer tests passed (launch coordinator and local structured-session projection).
- `pnpm tc:web` passed.
- `pnpm tc:node` passed.
- `pnpm run check:code-quality:changed` passed.
- `git diff --check` passed.
- Electron CDP attached to the intended `taniwha @ brennanb2025/fix-codex-native-chat-race` instance; the rendered workspace showed the existing Terminal and Codex Chat tabs with zero console errors. Full click-through was not claimed because this profile did not expose the structured-chat creation menu.