### PR TITLE
feat(runtime,cli): bind creates to caller reservations

### DIFF
--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -32,6 +32,7 @@ import {
 } from '../omitted-host-scope-selectors'
 import { RuntimeClientError } from '../runtime-client'
 import {
+  assertResourceReservationEcho,
   assertResourceReservationSupported,
   getOptionalResourceReservation
 } from '../resource-reservation-flags'
@@ -179,11 +180,8 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
     })
     // Why: an older host drops the unknown `reservation` param and answers with an ordinary
     // create, which would leave the caller believing a binding it cannot see was persisted.
-    if (reservation && result.result.terminal.reservation === undefined) {
-      throw new RuntimeClientError(
-        'incompatible_runtime',
-        'This Orca host accepted the terminal create but returned no reservation binding, so the terminal cannot be attributed. Update Orca on the host.'
-      )
+    if (reservation) {
+      assertResourceReservationEcho(reservation, result.result.terminal.reservation, 'terminal')
     }
     printResult(result, json, formatTerminalCreate)
   },

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -32,6 +32,10 @@ import {
 } from '../omitted-host-scope-selectors'
 import { RuntimeClientError } from '../runtime-client'
 import {
+  assertResourceReservationSupported,
+  getOptionalResourceReservation
+} from '../resource-reservation-flags'
+import {
   getBrowserWorktreeSelector,
   getOptionalWorktreeSelector,
   getRequiredWorktreeSelector,
@@ -153,9 +157,18 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
     const useRendererBackedInteractiveTerminal =
       !client.isRemote && shouldUseRendererBackedInteractiveTerminal(command)
     const focus = flags.get('focus') === true
+    const reservation = getOptionalResourceReservation(flags, 'terminal')
+    if (reservation) {
+      await assertResourceReservationSupported(client)
+    }
     const result = await client.call<{ terminal: RuntimeTerminalCreate }>('terminal.create', {
       worktree: await getBrowserWorktreeSelector(flags, cwd, client),
       command,
+      ...(reservation
+        ? // Why reconcileExisting: a reserved retry must adopt the terminal the lost first attempt
+          // already spawned rather than spawn a second one at the same derived handle.
+          { reservation, reconcileExisting: true }
+        : {}),
       title: getOptionalStringFlag(flags, 'title'),
       // Why: interactive local agent TUIs need the renderer-backed terminal
       // path for browser-side features, but CLI creates must stay backgrounded
@@ -164,6 +177,14 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
       ...(focus ? { presentation: 'focused' } : {}),
       ...(useRendererBackedInteractiveTerminal ? { rendererBacked: true, activate: focus } : {})
     })
+    // Why: an older host drops the unknown `reservation` param and answers with an ordinary
+    // create, which would leave the caller believing a binding it cannot see was persisted.
+    if (reservation && result.result.terminal.reservation === undefined) {
+      throw new RuntimeClientError(
+        'incompatible_runtime',
+        'This Orca host accepted the terminal create but returned no reservation binding, so the terminal cannot be attributed. Update Orca on the host.'
+      )
+    }
     printResult(result, json, formatTerminalCreate)
   },
   // `focus` resolves to this canonical path via CommandSpec.aliases before dispatch.

--- a/src/cli/handlers/worktree-create-params.ts
+++ b/src/cli/handlers/worktree-create-params.ts
@@ -143,8 +143,12 @@ export async function buildWorktreeCreateParams(args: {
       // inside an Orca worktree. Cwd keeps CLI-created children nestable and
       // lets create infer the repo for the common current-workspace case.
       cwdParentWorktree = await resolveCurrentWorktreeSelector(cwd, client)
-    } catch {
-      cwdParentWorktree = undefined
+    } catch (error) {
+      if (error instanceof RuntimeClientError && error.code === 'selector_not_found') {
+        cwdParentWorktree = undefined
+      } else {
+        throw error
+      }
     }
   }
   const linearIssueLink = getOptionalLinearIssueLinkFlag(flags, 'linear-issue')

--- a/src/cli/handlers/worktree-create-params.ts
+++ b/src/cli/handlers/worktree-create-params.ts
@@ -1,0 +1,192 @@
+import type { CommandHandler } from '../dispatch'
+import { getOptionalNumberFlag, getOptionalStringFlag, getRequiredStringFlag } from '../flags'
+import { RuntimeClientError } from '../runtime-client'
+import { resolveCurrentWorktreeSelector } from '../selectors'
+import { isTuiAgent } from '../../shared/tui-agent-config'
+import { isWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
+import type { ResourceReservationRequest } from '../../shared/resource-reservation-binding'
+import {
+  assertResourceReservationSupported,
+  getOptionalResourceReservation
+} from '../resource-reservation-flags'
+import {
+  hasWorkspaceProjectTarget,
+  resolveProjectCreateRepoSelector
+} from '../worktree-project-target'
+import { resolveCreateParentSelector } from './worktree-create-parent-selector'
+import { getOptionalLinearIssueLinkFlag } from './worktree-linear-issue-link'
+
+type CliFlags = Map<string, string | boolean>
+type CliClient = Parameters<CommandHandler>[0]['client']
+
+function getEnvParentWorkspace(): string | undefined {
+  const workspaceId = process.env.ORCA_WORKSPACE_ID
+  if (typeof workspaceId === 'string' && isWorkspaceKey(workspaceId)) {
+    return workspaceId
+  }
+  const worktreeId = process.env.ORCA_WORKTREE_ID
+  if (typeof worktreeId === 'string' && worktreeId.length > 0) {
+    return isWorkspaceKey(worktreeId) ? worktreeId : worktreeWorkspaceKey(worktreeId)
+  }
+  return undefined
+}
+
+export function getPresentStringFlag(
+  flags: CliFlags,
+  name: string,
+  options: { allowEmpty?: boolean } = {}
+): string | undefined {
+  if (!flags.has(name)) {
+    return undefined
+  }
+  const value = flags.get(name)
+  if (typeof value === 'string' && (options.allowEmpty || value.length > 0)) {
+    return value
+  }
+  throw new RuntimeClientError('invalid_argument', `Missing value for --${name}`)
+}
+
+function getOptionalStartupAgent(flags: CliFlags): string | undefined {
+  const agent = getPresentStringFlag(flags, 'agent')
+  if (agent === undefined) {
+    if (flags.has('prompt')) {
+      throw new RuntimeClientError('invalid_argument', '--prompt requires --agent')
+    }
+    return undefined
+  }
+  if (!isTuiAgent(agent)) {
+    throw new RuntimeClientError('invalid_argument', `Unknown TUI agent "${agent}"`)
+  }
+  return agent
+}
+
+function getOptionalSetupDecision(flags: CliFlags): 'run' | 'skip' | 'inherit' | undefined {
+  const setup = getPresentStringFlag(flags, 'setup')
+  if (setup !== undefined && setup !== 'run' && setup !== 'skip' && setup !== 'inherit') {
+    throw new RuntimeClientError('invalid_argument', '--setup must be one of: run, skip, inherit')
+  }
+  if (flags.get('run-hooks') === true) {
+    if (setup !== undefined && setup !== 'run') {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        'Choose either --run-hooks or --setup run, not contradictory setup flags.'
+      )
+    }
+    return setup
+  }
+  return setup
+}
+
+function getRepoSelectorFromWorktreeSelector(selector: string | undefined): string | undefined {
+  if (!selector?.startsWith('id:')) {
+    return undefined
+  }
+  const worktreeId = selector.slice('id:'.length)
+  const separatorIndex = worktreeId.indexOf('::')
+  if (separatorIndex <= 0) {
+    return undefined
+  }
+  return `id:${worktreeId.slice(0, separatorIndex)}`
+}
+
+async function getCreateRepoSelector(
+  flags: CliFlags,
+  cwdParentWorktree: string | undefined,
+  client: CliClient
+): Promise<string> {
+  const projectRepoSelector = await resolveProjectCreateRepoSelector(flags, client)
+  if (projectRepoSelector) {
+    return projectRepoSelector
+  }
+  const explicitRepo = getPresentStringFlag(flags, 'repo')
+  if (explicitRepo) {
+    return explicitRepo
+  }
+  const inferredRepo = getRepoSelectorFromWorktreeSelector(cwdParentWorktree)
+  if (inferredRepo) {
+    return inferredRepo
+  }
+  throw new RuntimeClientError(
+    'invalid_argument',
+    'Missing repo selector. Pass --repo or run from inside an Orca-managed worktree.'
+  )
+}
+
+/** Assembles the `worktree.create` wire params, including the caller reservation when one was
+ *  passed. The reservation is reported back so the caller can verify the host echoed it. */
+export async function buildWorktreeCreateParams(args: {
+  flags: CliFlags
+  client: CliClient
+  cwd: string
+}): Promise<{ params: Record<string, unknown>; reservation?: ResourceReservationRequest }> {
+  const { flags, client, cwd } = args
+  const callerTerminalHandle =
+    typeof process.env.ORCA_TERMINAL_HANDLE === 'string' &&
+    process.env.ORCA_TERMINAL_HANDLE.length > 0
+      ? process.env.ORCA_TERMINAL_HANDLE
+      : undefined
+  const explicitParent = await resolveCreateParentSelector(flags, cwd, client)
+  const explicitParentWorktree = explicitParent.parentWorktree
+  const explicitParentWorkspace = explicitParent.parentWorkspace
+  const startupAgent = getOptionalStartupAgent(flags)
+  const setupDecision = getOptionalSetupDecision(flags)
+  const noParent = flags.get('no-parent') === true
+  const envParentWorkspace =
+    !noParent && !explicitParentWorkspace && !explicitParentWorktree
+      ? getEnvParentWorkspace()
+      : undefined
+  let cwdParentWorktree: string | undefined
+  const needsCwdRepoInference = !flags.has('repo') && !hasWorkspaceProjectTarget(flags)
+  if ((!explicitParentWorktree && !explicitParentWorkspace && !noParent) || needsCwdRepoInference) {
+    try {
+      // Why: agent shells can lose ORCA_TERMINAL_HANDLE while still running
+      // inside an Orca worktree. Cwd keeps CLI-created children nestable and
+      // lets create infer the repo for the common current-workspace case.
+      cwdParentWorktree = await resolveCurrentWorktreeSelector(cwd, client)
+    } catch {
+      cwdParentWorktree = undefined
+    }
+  }
+  const linearIssueLink = getOptionalLinearIssueLinkFlag(flags, 'linear-issue')
+  const activate = flags.get('activate') === true || flags.get('run-hooks') === true
+  const name = getRequiredStringFlag(flags, 'name')
+  const reservation = getOptionalResourceReservation(flags, 'worktree')
+  if (reservation) {
+    await assertResourceReservationSupported(client)
+  }
+  return {
+    ...(reservation ? { reservation } : {}),
+    params: {
+      repo: await getCreateRepoSelector(flags, cwdParentWorktree, client),
+      name,
+      displayName: name,
+      displayNameKind: 'user',
+      baseBranch: getOptionalStringFlag(flags, 'base-branch'),
+      linkedIssue: getOptionalNumberFlag(flags, 'issue'),
+      ...linearIssueLink,
+      comment: getOptionalStringFlag(flags, 'comment'),
+      runHooks: flags.get('run-hooks') === true,
+      activate,
+      // Why: the CLI pairs as a runtime device but is not a viewer, so caller-scoped
+      // delivery would make --activate a no-op against a remote runtime.
+      ...(activate ? { navigation: 'all' as const } : {}),
+      ...(setupDecision ? { setupDecision } : {}),
+      parentWorktree: explicitParentWorktree,
+      ...(explicitParentWorkspace ? { parentWorkspace: explicitParentWorkspace } : {}),
+      ...(envParentWorkspace ? { envParentWorkspace } : {}),
+      ...(cwdParentWorktree ? { cwdParentWorktree } : {}),
+      noParent,
+      callerTerminalHandle,
+      // Why: marks the workspace as CLI-created so the sidebar can badge and
+      // filter it. Sent on every `worktree create` — hand-typed or agent-run.
+      cliProvenanceRequest: callerTerminalHandle ? { callerTerminalHandle } : {},
+      ...(reservation ? { reservation } : {}),
+      ...(startupAgent
+        ? {
+            startupAgent,
+            startupPrompt: getPresentStringFlag(flags, 'prompt', { allowEmpty: true }) ?? ''
+          }
+        : {})
+    }
+  }
+}

--- a/src/cli/handlers/worktree-create-params.ts
+++ b/src/cli/handlers/worktree-create-params.ts
@@ -144,7 +144,15 @@ export async function buildWorktreeCreateParams(args: {
       // lets create infer the repo for the common current-workspace case.
       cwdParentWorktree = await resolveCurrentWorktreeSelector(cwd, client)
     } catch (error) {
-      if (error instanceof RuntimeClientError && error.code === 'selector_not_found') {
+      const optionalRemoteCwd =
+        !needsCwdRepoInference &&
+        client.isRemote &&
+        error instanceof RuntimeClientError &&
+        error.code === 'invalid_argument'
+      if (
+        optionalRemoteCwd ||
+        (error instanceof RuntimeClientError && error.code === 'selector_not_found')
+      ) {
         cwdParentWorktree = undefined
       } else {
         throw error

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -17,6 +17,7 @@ import {
   getOptionalPositiveIntegerFlag,
   getOptionalStringFlag
 } from '../flags'
+import { assertResourceReservationEcho } from '../resource-reservation-flags'
 import {
   getOptionalWorktreeSelector,
   getRequiredWorktreeSelector,
@@ -107,11 +108,8 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
     const result = await client.call<RuntimeWorktreeCreateResult>('worktree.create', params)
     // Why: an older host drops the unknown `reservation` param and answers with an ordinary
     // create, leaving the caller believing a binding it cannot see was persisted.
-    if (reservation && result.result.worktree.reservation === undefined) {
-      throw new RuntimeClientError(
-        'incompatible_runtime',
-        'This Orca host accepted the workspace create but returned no reservation binding, so the workspace cannot be attributed. Update Orca on the host.'
-      )
+    if (reservation) {
+      assertResourceReservationEcho(reservation, result.result.worktree.reservation, 'workspace')
     }
     printHookWarning(result.result, json)
     printLineageSummary(result.result, json)

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -14,29 +14,19 @@ import {
 import { RuntimeClientError } from '../runtime-client'
 import {
   getOptionalNullableNumberFlag,
-  getOptionalNumberFlag,
   getOptionalPositiveIntegerFlag,
-  getOptionalStringFlag,
-  getRequiredStringFlag
+  getOptionalStringFlag
 } from '../flags'
 import {
   getOptionalWorktreeSelector,
   getRequiredWorktreeSelector,
   resolveCurrentWorktreeSelector
 } from '../selectors'
-import { isTuiAgent } from '../../shared/tui-agent-config'
-import { isWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import { printLineageSummary } from './worktree-lineage-summary'
-import {
-  assertWorkspaceTargetFlagsCompatible,
-  hasWorkspaceProjectTarget,
-  resolveProjectCreateRepoSelector
-} from '../worktree-project-target'
-import {
-  assertCreateParentFlagsCompatible,
-  resolveCreateParentSelector
-} from './worktree-create-parent-selector'
+import { assertWorkspaceTargetFlagsCompatible } from '../worktree-project-target'
+import { assertCreateParentFlagsCompatible } from './worktree-create-parent-selector'
 import { getOptionalLinearIssueLinkFlag } from './worktree-linear-issue-link'
+import { buildWorktreeCreateParams } from './worktree-create-params'
 
 type HookWarningResult = {
   warning?: string
@@ -78,101 +68,6 @@ function assertParentWorktreeFlagsCompatible(flags: Map<string, string | boolean
   }
 }
 
-function getEnvParentWorkspace(): string | undefined {
-  const workspaceId = process.env.ORCA_WORKSPACE_ID
-  if (typeof workspaceId === 'string' && isWorkspaceKey(workspaceId)) {
-    return workspaceId
-  }
-  const worktreeId = process.env.ORCA_WORKTREE_ID
-  if (typeof worktreeId === 'string' && worktreeId.length > 0) {
-    return isWorkspaceKey(worktreeId) ? worktreeId : worktreeWorkspaceKey(worktreeId)
-  }
-  return undefined
-}
-
-function getPresentStringFlag(
-  flags: Map<string, string | boolean>,
-  name: string,
-  options: { allowEmpty?: boolean } = {}
-): string | undefined {
-  if (!flags.has(name)) {
-    return undefined
-  }
-  const value = flags.get(name)
-  if (typeof value === 'string' && (options.allowEmpty || value.length > 0)) {
-    return value
-  }
-  throw new RuntimeClientError('invalid_argument', `Missing value for --${name}`)
-}
-
-function getOptionalStartupAgent(flags: Map<string, string | boolean>): string | undefined {
-  const agent = getPresentStringFlag(flags, 'agent')
-  if (agent === undefined) {
-    if (flags.has('prompt')) {
-      throw new RuntimeClientError('invalid_argument', '--prompt requires --agent')
-    }
-    return undefined
-  }
-  if (!isTuiAgent(agent)) {
-    throw new RuntimeClientError('invalid_argument', `Unknown TUI agent "${agent}"`)
-  }
-  return agent
-}
-
-function getOptionalSetupDecision(
-  flags: Map<string, string | boolean>
-): 'run' | 'skip' | 'inherit' | undefined {
-  const setup = getPresentStringFlag(flags, 'setup')
-  if (setup !== undefined && setup !== 'run' && setup !== 'skip' && setup !== 'inherit') {
-    throw new RuntimeClientError('invalid_argument', '--setup must be one of: run, skip, inherit')
-  }
-  if (flags.get('run-hooks') === true) {
-    if (setup !== undefined && setup !== 'run') {
-      throw new RuntimeClientError(
-        'invalid_argument',
-        'Choose either --run-hooks or --setup run, not contradictory setup flags.'
-      )
-    }
-    return setup
-  }
-  return setup
-}
-
-function getRepoSelectorFromWorktreeSelector(selector: string | undefined): string | undefined {
-  if (!selector?.startsWith('id:')) {
-    return undefined
-  }
-  const worktreeId = selector.slice('id:'.length)
-  const separatorIndex = worktreeId.indexOf('::')
-  if (separatorIndex <= 0) {
-    return undefined
-  }
-  return `id:${worktreeId.slice(0, separatorIndex)}`
-}
-
-async function getCreateRepoSelector(
-  flags: Map<string, string | boolean>,
-  cwdParentWorktree: string | undefined,
-  client: Parameters<CommandHandler>[0]['client']
-): Promise<string> {
-  const projectRepoSelector = await resolveProjectCreateRepoSelector(flags, client)
-  if (projectRepoSelector) {
-    return projectRepoSelector
-  }
-  const explicitRepo = getPresentStringFlag(flags, 'repo')
-  if (explicitRepo) {
-    return explicitRepo
-  }
-  const inferredRepo = getRepoSelectorFromWorktreeSelector(cwdParentWorktree)
-  if (inferredRepo) {
-    return inferredRepo
-  }
-  throw new RuntimeClientError(
-    'invalid_argument',
-    'Missing repo selector. Pass --repo or run from inside an Orca-managed worktree.'
-  )
-}
-
 export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
   'worktree ps': async ({ flags, client, json }) => {
     const result = await client.call<WithAnnotatedHostScope<RuntimeWorktreePsResult>>(
@@ -208,70 +103,16 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
   'worktree create': async ({ flags, client, cwd, json }) => {
     assertCreateParentFlagsCompatible(flags)
     assertWorkspaceTargetFlagsCompatible(flags)
-    const callerTerminalHandle =
-      typeof process.env.ORCA_TERMINAL_HANDLE === 'string' &&
-      process.env.ORCA_TERMINAL_HANDLE.length > 0
-        ? process.env.ORCA_TERMINAL_HANDLE
-        : undefined
-    const explicitParent = await resolveCreateParentSelector(flags, cwd, client)
-    const explicitParentWorktree = explicitParent.parentWorktree
-    const explicitParentWorkspace = explicitParent.parentWorkspace
-    const startupAgent = getOptionalStartupAgent(flags)
-    const setupDecision = getOptionalSetupDecision(flags)
-    const noParent = flags.get('no-parent') === true
-    const envParentWorkspace =
-      !noParent && !explicitParentWorkspace && !explicitParentWorktree
-        ? getEnvParentWorkspace()
-        : undefined
-    let cwdParentWorktree: string | undefined
-    const needsCwdRepoInference = !flags.has('repo') && !hasWorkspaceProjectTarget(flags)
-    if (
-      (!explicitParentWorktree && !explicitParentWorkspace && !noParent) ||
-      needsCwdRepoInference
-    ) {
-      try {
-        // Why: agent shells can lose ORCA_TERMINAL_HANDLE while still running
-        // inside an Orca worktree. Cwd keeps CLI-created children nestable and
-        // lets create infer the repo for the common current-workspace case.
-        cwdParentWorktree = await resolveCurrentWorktreeSelector(cwd, client)
-      } catch {
-        cwdParentWorktree = undefined
-      }
+    const { params, reservation } = await buildWorktreeCreateParams({ flags, client, cwd })
+    const result = await client.call<RuntimeWorktreeCreateResult>('worktree.create', params)
+    // Why: an older host drops the unknown `reservation` param and answers with an ordinary
+    // create, leaving the caller believing a binding it cannot see was persisted.
+    if (reservation && result.result.worktree.reservation === undefined) {
+      throw new RuntimeClientError(
+        'incompatible_runtime',
+        'This Orca host accepted the workspace create but returned no reservation binding, so the workspace cannot be attributed. Update Orca on the host.'
+      )
     }
-    const linearIssueLink = getOptionalLinearIssueLinkFlag(flags, 'linear-issue')
-    const activate = flags.get('activate') === true || flags.get('run-hooks') === true
-    const name = getRequiredStringFlag(flags, 'name')
-    const result = await client.call<RuntimeWorktreeCreateResult>('worktree.create', {
-      repo: await getCreateRepoSelector(flags, cwdParentWorktree, client),
-      name,
-      displayName: name,
-      displayNameKind: 'user',
-      baseBranch: getOptionalStringFlag(flags, 'base-branch'),
-      linkedIssue: getOptionalNumberFlag(flags, 'issue'),
-      ...linearIssueLink,
-      comment: getOptionalStringFlag(flags, 'comment'),
-      runHooks: flags.get('run-hooks') === true,
-      activate,
-      // Why: the CLI pairs as a runtime device but is not a viewer, so caller-scoped
-      // delivery would make --activate a no-op against a remote runtime.
-      ...(activate ? { navigation: 'all' as const } : {}),
-      ...(setupDecision ? { setupDecision } : {}),
-      parentWorktree: explicitParentWorktree,
-      ...(explicitParentWorkspace ? { parentWorkspace: explicitParentWorkspace } : {}),
-      ...(envParentWorkspace ? { envParentWorkspace } : {}),
-      ...(cwdParentWorktree ? { cwdParentWorktree } : {}),
-      noParent,
-      callerTerminalHandle,
-      // Why: marks the workspace as CLI-created so the sidebar can badge and
-      // filter it. Sent on every `worktree create` — hand-typed or agent-run.
-      cliProvenanceRequest: callerTerminalHandle ? { callerTerminalHandle } : {},
-      ...(startupAgent
-        ? {
-            startupAgent,
-            startupPrompt: getPresentStringFlag(flags, 'prompt', { allowEmpty: true }) ?? ''
-          }
-        : {})
-    })
     printHookWarning(result.result, json)
     printLineageSummary(result.result, json)
     printResult(result, json, formatWorktreeShow)

--- a/src/cli/index-terminal-create-reservation.test.ts
+++ b/src/cli/index-terminal-create-reservation.test.ts
@@ -138,6 +138,19 @@ describe('orca terminal create reservation binding', () => {
     expect(process.exitCode).toBe(1)
   })
 
+  it('refuses a create whose reply changes an immutable binding field', async () => {
+    queueFixtures(
+      callMock,
+      statusFixture([RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY]),
+      createdTerminalFixture({ ...RESERVATION_PARAM, ownershipGeneration: 1, boundAt: 42 })
+    )
+    silenceOutput()
+
+    await main([...CREATE_ARGS, ...RESERVATION_ARGS, '--json'], '/tmp/elsewhere')
+
+    expect(process.exitCode).toBe(1)
+  })
+
   it('leaves an unreserved create untouched', async () => {
     queueFixtures(callMock, createdTerminalFixture(undefined))
     silenceOutput()

--- a/src/cli/index-terminal-create-reservation.test.ts
+++ b/src/cli/index-terminal-create-reservation.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const {
+  callMock,
+  runtimeClientConstructorMock,
+  serveOrcaAppMock,
+  getDefaultUserDataPathMock,
+  addEnvironmentFromPairingCodeMock,
+  listEnvironmentsMock,
+  spawnMock
+} = vi.hoisted(() => ({
+  callMock: vi.fn(),
+  runtimeClientConstructorMock: vi.fn(),
+  serveOrcaAppMock: vi.fn(),
+  getDefaultUserDataPathMock: vi.fn(() => '/tmp/orca-user-data'),
+  addEnvironmentFromPairingCodeMock: vi.fn(),
+  listEnvironmentsMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('./runtime-client', async () => {
+  const { createRuntimeClientModuleMock } = await import('./index-test-harness.js')
+  return createRuntimeClientModuleMock({
+    callMock,
+    runtimeClientConstructorMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock
+  })
+})
+
+vi.mock('./runtime/environments', () => ({
+  addEnvironmentFromPairingCode: addEnvironmentFromPairingCodeMock,
+  listEnvironments: listEnvironmentsMock,
+  removeEnvironment: vi.fn(),
+  resolveEnvironment: vi.fn()
+}))
+
+vi.mock('child_process', async () => {
+  const { createChildProcessModuleMock } = await import('./index-test-harness.js')
+  return createChildProcessModuleMock(spawnMock)
+})
+
+import { main } from './index'
+import { RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY } from '../shared/protocol-version'
+import { okFixture, queueFixtures } from './test-fixtures'
+import { useWorktreeAwarenessEnvironment } from './index-test-harness'
+
+const RESERVATION_ARGS = [
+  '--idempotency-key',
+  'key-1',
+  '--reservation-id',
+  'res-1',
+  '--reservation-session',
+  'session-1',
+  '--ownership-generation',
+  '0'
+]
+
+const RESERVATION_PARAM = {
+  key: 'key-1',
+  reservationId: 'res-1',
+  sessionId: 'session-1',
+  resourceKind: 'terminal',
+  ownershipGeneration: 0
+}
+
+const CREATE_ARGS = ['terminal', 'create', '--worktree', 'id:repo-1::/tmp/repo/child']
+
+function statusFixture(capabilities: string[]) {
+  return okFixture('req_status', { runtimeId: 'runtime-1', capabilities })
+}
+
+function createdTerminalFixture(reservation: unknown) {
+  return okFixture('req_create', {
+    terminal: {
+      handle: 'term_abc',
+      worktreeId: 'repo-1::/tmp/repo/child',
+      title: null,
+      ...(reservation === undefined ? {} : { reservation })
+    }
+  })
+}
+
+function silenceOutput(): void {
+  process.exitCode = undefined
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+}
+
+describe('orca terminal create reservation binding', () => {
+  useWorktreeAwarenessEnvironment({
+    callMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock,
+    addEnvironmentFromPairingCodeMock,
+    listEnvironmentsMock,
+    spawnMock
+  })
+
+  it('sends the binding and asks the host to reconcile an existing reserved terminal', async () => {
+    queueFixtures(
+      callMock,
+      statusFixture([RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY]),
+      createdTerminalFixture({ ...RESERVATION_PARAM, boundAt: 42 })
+    )
+    silenceOutput()
+
+    await main([...CREATE_ARGS, ...RESERVATION_ARGS, '--json'], '/tmp/elsewhere')
+
+    expect(callMock).toHaveBeenCalledWith(
+      'terminal.create',
+      expect.objectContaining({ reservation: RESERVATION_PARAM, reconcileExisting: true })
+    )
+    expect(process.exitCode).toBeFalsy()
+  })
+
+  it('refuses before creating anything when the host does not advertise the capability', async () => {
+    queueFixtures(callMock, statusFixture(['terminal.create-idempotency.v2']))
+    silenceOutput()
+
+    await main([...CREATE_ARGS, ...RESERVATION_ARGS, '--json'], '/tmp/elsewhere')
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).not.toHaveBeenCalledWith('terminal.create', expect.anything())
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('refuses a create whose reply carries no binding back', async () => {
+    queueFixtures(
+      callMock,
+      statusFixture([RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY]),
+      createdTerminalFixture(undefined)
+    )
+    silenceOutput()
+
+    await main([...CREATE_ARGS, ...RESERVATION_ARGS, '--json'], '/tmp/elsewhere')
+
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('leaves an unreserved create untouched', async () => {
+    queueFixtures(callMock, createdTerminalFixture(undefined))
+    silenceOutput()
+
+    await main([...CREATE_ARGS, '--json'], '/tmp/elsewhere')
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith(
+      'terminal.create',
+      expect.not.objectContaining({ reservation: expect.anything() })
+    )
+  })
+})

--- a/src/cli/index-worktree-create-reservation.test.ts
+++ b/src/cli/index-worktree-create-reservation.test.ts
@@ -41,7 +41,7 @@ vi.mock('child_process', async () => {
 })
 
 import { main } from './index'
-import { RuntimeRpcFailureError } from './runtime-client'
+import { RuntimeClientError, RuntimeRpcFailureError } from './runtime-client'
 import { RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY } from '../shared/protocol-version'
 import { buildWorktree, okFixture, queueFixtures } from './test-fixtures'
 import { useWorktreeAwarenessEnvironment } from './index-test-harness'
@@ -222,6 +222,23 @@ describe('orca worktree create reservation binding', () => {
     await main([...CREATE_ARGS, ...unsafe, '--json'], '/tmp/elsewhere')
 
     expect(callMock).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('propagates cwd selector infrastructure failures instead of reporting a missing repo', async () => {
+    callMock.mockRejectedValueOnce(
+      new RuntimeClientError('runtime_unavailable', 'runtime transport exploded')
+    )
+    silenceOutput()
+
+    await main(['worktree', 'create', '--name', 'child', '--json'], '/tmp/managed-or-not')
+
+    const output = JSON.parse(String(vi.mocked(console.log).mock.calls.at(-1)?.[0]))
+    expect(output).toMatchObject({
+      ok: false,
+      error: { code: 'runtime_unavailable', message: 'runtime transport exploded' }
+    })
+    expect(output.error.message).not.toContain('Missing repo selector')
     expect(process.exitCode).toBe(1)
   })
 })

--- a/src/cli/index-worktree-create-reservation.test.ts
+++ b/src/cli/index-worktree-create-reservation.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const {
+  callMock,
+  runtimeClientConstructorMock,
+  serveOrcaAppMock,
+  getDefaultUserDataPathMock,
+  addEnvironmentFromPairingCodeMock,
+  listEnvironmentsMock,
+  spawnMock
+} = vi.hoisted(() => ({
+  callMock: vi.fn(),
+  runtimeClientConstructorMock: vi.fn(),
+  serveOrcaAppMock: vi.fn(),
+  getDefaultUserDataPathMock: vi.fn(() => '/tmp/orca-user-data'),
+  addEnvironmentFromPairingCodeMock: vi.fn(),
+  listEnvironmentsMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('./runtime-client', async () => {
+  const { createRuntimeClientModuleMock } = await import('./index-test-harness.js')
+  return createRuntimeClientModuleMock({
+    callMock,
+    runtimeClientConstructorMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock
+  })
+})
+
+vi.mock('./runtime/environments', () => ({
+  addEnvironmentFromPairingCode: addEnvironmentFromPairingCodeMock,
+  listEnvironments: listEnvironmentsMock,
+  removeEnvironment: vi.fn(),
+  resolveEnvironment: vi.fn()
+}))
+
+vi.mock('child_process', async () => {
+  const { createChildProcessModuleMock } = await import('./index-test-harness.js')
+  return createChildProcessModuleMock(spawnMock)
+})
+
+import { main } from './index'
+import { RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY } from '../shared/protocol-version'
+import { buildWorktree, okFixture, queueFixtures } from './test-fixtures'
+import { useWorktreeAwarenessEnvironment } from './index-test-harness'
+
+const RESERVATION_ARGS = [
+  '--idempotency-key',
+  'key-1',
+  '--reservation-id',
+  'res-1',
+  '--reservation-session',
+  'session-1',
+  '--ownership-generation',
+  '7',
+  '--reservation-issuer',
+  'openloop'
+]
+
+const RESERVATION_PARAM = {
+  key: 'key-1',
+  reservationId: 'res-1',
+  sessionId: 'session-1',
+  resourceKind: 'worktree',
+  ownershipGeneration: 7,
+  issuer: 'openloop'
+}
+
+function statusFixture(capabilities: string[]) {
+  return okFixture('req_status', { runtimeId: 'runtime-1', capabilities })
+}
+
+function createdWorktreeFixture(reservation: unknown) {
+  return okFixture('req_create', {
+    worktree: {
+      ...buildWorktree('/tmp/repo/child', 'child', 'abc', 'repo-1'),
+      ...(reservation === undefined ? {} : { reservation })
+    },
+    lineage: null,
+    warnings: []
+  })
+}
+
+function silenceOutput(): void {
+  process.exitCode = undefined
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+}
+
+/** --no-parent with an explicit --repo keeps the run free of cwd-inference RPCs, so every
+ *  assertion below is about the reservation calls and nothing else. */
+const CREATE_ARGS = ['worktree', 'create', '--repo', 'id:repo-1', '--name', 'child', '--no-parent']
+
+describe('orca worktree create reservation binding', () => {
+  useWorktreeAwarenessEnvironment({
+    callMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock,
+    addEnvironmentFromPairingCodeMock,
+    listEnvironmentsMock,
+    spawnMock
+  })
+
+  it('sends the caller-generated binding after the host advertises support', async () => {
+    queueFixtures(
+      callMock,
+      statusFixture([RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY]),
+      createdWorktreeFixture({ ...RESERVATION_PARAM, boundAt: 42 })
+    )
+    silenceOutput()
+
+    await main([...CREATE_ARGS, ...RESERVATION_ARGS, '--json'], '/tmp/elsewhere')
+
+    expect(callMock).toHaveBeenCalledWith(
+      'worktree.create',
+      expect.objectContaining({ reservation: RESERVATION_PARAM })
+    )
+    expect(process.exitCode).toBeFalsy()
+  })
+
+  it('refuses before creating anything when the host does not advertise the capability', async () => {
+    queueFixtures(callMock, statusFixture(['worktree.create-idempotency.v1']))
+    silenceOutput()
+
+    await main([...CREATE_ARGS, ...RESERVATION_ARGS, '--json'], '/tmp/elsewhere')
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).not.toHaveBeenCalledWith('worktree.create', expect.anything())
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('refuses a create whose reply carries no binding back', async () => {
+    queueFixtures(
+      callMock,
+      statusFixture([RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY]),
+      createdWorktreeFixture(undefined)
+    )
+    silenceOutput()
+
+    await main([...CREATE_ARGS, ...RESERVATION_ARGS, '--json'], '/tmp/elsewhere')
+
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('sends no reservation and probes no capability without the flags', async () => {
+    queueFixtures(callMock, createdWorktreeFixture(undefined))
+    silenceOutput()
+
+    await main([...CREATE_ARGS, '--json'], '/tmp/elsewhere')
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith(
+      'worktree.create',
+      expect.not.objectContaining({ reservation: expect.anything() })
+    )
+  })
+
+  it('refuses a partial binding rather than creating an unattributable workspace', async () => {
+    silenceOutput()
+
+    await main([...CREATE_ARGS, '--idempotency-key', 'key-1', '--json'], '/tmp/elsewhere')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/src/cli/index-worktree-create-reservation.test.ts
+++ b/src/cli/index-worktree-create-reservation.test.ts
@@ -41,6 +41,7 @@ vi.mock('child_process', async () => {
 })
 
 import { main } from './index'
+import { RuntimeRpcFailureError } from './runtime-client'
 import { RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY } from '../shared/protocol-version'
 import { buildWorktree, okFixture, queueFixtures } from './test-fixtures'
 import { useWorktreeAwarenessEnvironment } from './index-test-harness'
@@ -153,6 +154,40 @@ describe('orca worktree create reservation binding', () => {
 
     await main([...CREATE_ARGS, ...RESERVATION_ARGS, '--json'], '/tmp/elsewhere')
 
+    expect(JSON.parse(String(vi.mocked(console.log).mock.calls.at(-1)?.[0]))).toMatchObject({
+      ok: false,
+      error: { code: 'incompatible_runtime' }
+    })
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('preserves a provider reservation conflict through the public JSON contract', async () => {
+    callMock.mockResolvedValueOnce(
+      statusFixture([RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY])
+    )
+    callMock.mockRejectedValueOnce(
+      new RuntimeRpcFailureError({
+        id: 'req_create',
+        ok: false,
+        error: {
+          code: 'reservation_conflict',
+          message: 'Reservation keys are single-use.',
+          data: { resourceKind: 'worktree', resourceId: 'worktree-1' }
+        },
+        _meta: { runtimeId: 'runtime-1' }
+      })
+    )
+    silenceOutput()
+
+    await main([...CREATE_ARGS, ...RESERVATION_ARGS, '--json'], '/tmp/elsewhere')
+
+    expect(JSON.parse(String(vi.mocked(console.log).mock.calls.at(-1)?.[0]))).toMatchObject({
+      ok: false,
+      error: {
+        code: 'reservation_conflict',
+        data: { resourceKind: 'worktree', resourceId: 'worktree-1' }
+      }
+    })
     expect(process.exitCode).toBe(1)
   })
 

--- a/src/cli/index-worktree-create-reservation.test.ts
+++ b/src/cli/index-worktree-create-reservation.test.ts
@@ -143,6 +143,19 @@ describe('orca worktree create reservation binding', () => {
     expect(process.exitCode).toBe(1)
   })
 
+  it('refuses a create whose reply changes an immutable binding field', async () => {
+    queueFixtures(
+      callMock,
+      statusFixture([RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY]),
+      createdWorktreeFixture({ ...RESERVATION_PARAM, sessionId: 'wrong-session', boundAt: 42 })
+    )
+    silenceOutput()
+
+    await main([...CREATE_ARGS, ...RESERVATION_ARGS, '--json'], '/tmp/elsewhere')
+
+    expect(process.exitCode).toBe(1)
+  })
+
   it('sends no reservation and probes no capability without the flags', async () => {
     queueFixtures(callMock, createdWorktreeFixture(undefined))
     silenceOutput()
@@ -160,6 +173,18 @@ describe('orca worktree create reservation binding', () => {
     silenceOutput()
 
     await main([...CREATE_ARGS, '--idempotency-key', 'key-1', '--json'], '/tmp/elsewhere')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('refuses an ownership generation that cannot round-trip as a safe integer', async () => {
+    silenceOutput()
+    const unsafe = RESERVATION_ARGS.map((value, index) =>
+      RESERVATION_ARGS[index - 1] === '--ownership-generation' ? '9007199254740993' : value
+    )
+
+    await main([...CREATE_ARGS, ...unsafe, '--json'], '/tmp/elsewhere')
 
     expect(callMock).not.toHaveBeenCalled()
     expect(process.exitCode).toBe(1)

--- a/src/cli/index-worktree-create-reservation.test.ts
+++ b/src/cli/index-worktree-create-reservation.test.ts
@@ -241,4 +241,48 @@ describe('orca worktree create reservation binding', () => {
     expect(output.error.message).not.toContain('Missing repo selector')
     expect(process.exitCode).toBe(1)
   })
+
+  it('does not require remote cwd lineage when an explicit repo supplies the create target', async () => {
+    process.env.ORCA_PAIRING_CODE = 'remote-runtime'
+    callMock.mockResolvedValueOnce(createdWorktreeFixture(undefined))
+    silenceOutput()
+
+    await main(
+      ['worktree', 'create', '--repo', 'id:repo-1', '--name', 'child', '--json'],
+      '/remote-only/path'
+    )
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'worktree.create', {
+      repo: 'id:repo-1',
+      name: 'child',
+      displayName: 'child',
+      displayNameKind: 'user',
+      baseBranch: undefined,
+      linkedIssue: undefined,
+      comment: undefined,
+      runHooks: false,
+      activate: false,
+      parentWorktree: undefined,
+      noParent: false,
+      callerTerminalHandle: undefined,
+      cliProvenanceRequest: {}
+    })
+    expect(process.exitCode).toBeFalsy()
+  })
+
+  it('does not hide infrastructure failures during optional cwd lineage lookup', async () => {
+    callMock.mockRejectedValueOnce(
+      new RuntimeClientError('runtime_unavailable', 'runtime transport exploded')
+    )
+    silenceOutput()
+
+    await main(
+      ['worktree', 'create', '--repo', 'id:repo-1', '--name', 'child', '--json'],
+      '/tmp/managed-or-not'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).not.toHaveBeenCalledWith('worktree.create', expect.anything())
+    expect(process.exitCode).toBe(1)
+  })
 })

--- a/src/cli/resource-reservation-flags.ts
+++ b/src/cli/resource-reservation-flags.ts
@@ -1,0 +1,77 @@
+import {
+  RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY,
+  RESOURCE_RESERVATION_ATTRIBUTION_UPDATE_REQUIRED_MESSAGE
+} from '../shared/protocol-version'
+import type {
+  ResourceReservationKind,
+  ResourceReservationRequest
+} from '../shared/resource-reservation-binding'
+import type { RuntimeStatus } from '../shared/runtime-types'
+import { RuntimeClientError } from './runtime-client'
+import type { CommandHandler } from './dispatch'
+
+export const RESOURCE_RESERVATION_FLAGS = [
+  'idempotency-key',
+  'reservation-id',
+  'reservation-session',
+  'ownership-generation',
+  'reservation-issuer'
+] as const
+
+const REQUIRED_COMPANION_FLAGS = ['reservation-id', 'reservation-session', 'ownership-generation']
+
+function requireStringFlag(flags: Map<string, string | boolean>, name: string): string {
+  const value = flags.get(name)
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new RuntimeClientError('invalid_argument', `Missing value for --${name}`)
+  }
+  return value
+}
+
+/** Parses the caller-generated reservation binding, or returns undefined when none was passed.
+ *  Partial bindings are refused: an unbound create is exactly the ambiguity these flags remove. */
+export function getOptionalResourceReservation(
+  flags: Map<string, string | boolean>,
+  resourceKind: ResourceReservationKind
+): ResourceReservationRequest | undefined {
+  if (!flags.has('idempotency-key')) {
+    const stray = REQUIRED_COMPANION_FLAGS.filter((name) => flags.has(name))
+    if (stray.length > 0 || flags.has('reservation-issuer')) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        `--${stray[0] ?? 'reservation-issuer'} requires --idempotency-key`
+      )
+    }
+    return undefined
+  }
+  const generationText = requireStringFlag(flags, 'ownership-generation')
+  if (!/^\d+$/.test(generationText)) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      '--ownership-generation must be a non-negative integer'
+    )
+  }
+  const issuer = flags.get('reservation-issuer')
+  return {
+    key: requireStringFlag(flags, 'idempotency-key'),
+    reservationId: requireStringFlag(flags, 'reservation-id'),
+    sessionId: requireStringFlag(flags, 'reservation-session'),
+    resourceKind,
+    ownershipGeneration: Number.parseInt(generationText, 10),
+    ...(issuer !== undefined ? { issuer: requireStringFlag(flags, 'reservation-issuer') } : {})
+  }
+}
+
+/** Refuses rather than creating an unattributable resource: an older host drops the unknown
+ *  `reservation` param and answers with an ordinary create the caller cannot bind to its ledger. */
+export async function assertResourceReservationSupported(
+  client: Parameters<CommandHandler>[0]['client']
+): Promise<void> {
+  const status = await client.call<RuntimeStatus>('status.get', undefined)
+  if (!status.result.capabilities?.includes(RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY)) {
+    throw new RuntimeClientError(
+      'incompatible_runtime',
+      `${RESOURCE_RESERVATION_ATTRIBUTION_UPDATE_REQUIRED_MESSAGE} No resource was created.`
+    )
+  }
+}

--- a/src/cli/resource-reservation-flags.ts
+++ b/src/cli/resource-reservation-flags.ts
@@ -3,6 +3,7 @@ import {
   RESOURCE_RESERVATION_ATTRIBUTION_UPDATE_REQUIRED_MESSAGE
 } from '../shared/protocol-version'
 import type {
+  ResourceReservationBinding,
   ResourceReservationKind,
   ResourceReservationRequest
 } from '../shared/resource-reservation-binding'
@@ -51,14 +52,43 @@ export function getOptionalResourceReservation(
       '--ownership-generation must be a non-negative integer'
     )
   }
+  const ownershipGeneration = Number(generationText)
+  if (!Number.isSafeInteger(ownershipGeneration)) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      '--ownership-generation must be a safe non-negative integer'
+    )
+  }
   const issuer = flags.get('reservation-issuer')
   return {
     key: requireStringFlag(flags, 'idempotency-key'),
     reservationId: requireStringFlag(flags, 'reservation-id'),
     sessionId: requireStringFlag(flags, 'reservation-session'),
     resourceKind,
-    ownershipGeneration: Number.parseInt(generationText, 10),
+    ownershipGeneration,
     ...(issuer !== undefined ? { issuer: requireStringFlag(flags, 'reservation-issuer') } : {})
+  }
+}
+
+/** A create response is trustworthy only when the host echoes every immutable request field. */
+export function assertResourceReservationEcho(
+  requested: ResourceReservationRequest,
+  returned: ResourceReservationBinding | undefined,
+  resourceLabel: string
+): void {
+  const matches =
+    returned !== undefined &&
+    returned.key === requested.key &&
+    returned.reservationId === requested.reservationId &&
+    returned.sessionId === requested.sessionId &&
+    returned.resourceKind === requested.resourceKind &&
+    returned.ownershipGeneration === requested.ownershipGeneration &&
+    (returned.issuer ?? '') === (requested.issuer ?? '')
+  if (!matches) {
+    throw new RuntimeClientError(
+      'incompatible_runtime',
+      `This Orca host returned a mismatched ${resourceLabel} reservation binding, so the resource cannot be attributed. Update Orca on the host.`
+    )
   }
 }
 

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -4,6 +4,7 @@ import { WORKTREE_LISTING_SCOPE_NOTES } from './worktree-listing-scope-notes'
 import { SERVE_COMMAND_SPECS } from './serve'
 import { TERMINAL_SEND_COMMAND_SPEC } from './terminal-send'
 import { TERMINAL_CLOSE_COMMAND_SPEC } from './terminal-close'
+import { RESOURCE_RESERVATION_FLAGS } from '../resource-reservation-flags'
 
 export const CORE_COMMAND_SPECS: CommandSpec[] = [
   {
@@ -90,7 +91,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['worktree', 'create'],
     summary: 'Create a new Orca-managed worktree',
     usage:
-      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
+      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--idempotency-key <key> --reservation-id <id> --reservation-session <id> --ownership-generation <n> [--reservation-issuer <name>]] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'repo',
@@ -108,7 +109,8 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'parent-worktree',
       'no-parent',
       'run-hooks',
-      'activate'
+      'activate',
+      ...RESOURCE_RESERVATION_FLAGS
     ],
     notes: [
       'This creates a new checkout. For a fresh agent in an existing worktree, use `orca terminal create --worktree active --command "codex"` instead.',
@@ -124,7 +126,9 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'With --agent --json, read the new agent handle from result.agentTerminalHandle; older runtimes return only result.startupTerminal.handle, and may return neither for folder-based repos.',
       'Repo-defined setup hooks follow the repository setup policy; pass --setup run to force them.',
       'Pass --activate when the CLI caller intentionally wants to reveal the new worktree in the app.',
-      'Passing --run-hooks is kept as a legacy alias for --setup run and reveals the worktree.'
+      'Passing --run-hooks is kept as a legacy alias for --setup run and reveals the worktree.',
+      'Pass --idempotency-key with --reservation-id, --reservation-session and --ownership-generation to bind this create to a caller ledger reservation. The key is single-use: a retry returns the same resource, and reusing it with a different binding is refused.',
+      'The exact binding is readable back through `orca worktree show --json` and `orca worktree list --json` as `reservation`.'
     ],
     examples: [
       'orca worktree create --name agent-task --agent codex --prompt "hi" --json',
@@ -247,11 +251,20 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['terminal', 'create'],
     summary: 'Create a terminal session in the current worktree',
     usage:
-      'orca terminal create [--worktree <selector>] [--title <name>] [--command <text>] [--focus] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'command', 'title', 'focus'],
+      'orca terminal create [--worktree <selector>] [--title <name>] [--command <text>] [--focus] [--idempotency-key <key> --reservation-id <id> --reservation-session <id> --ownership-generation <n> [--reservation-issuer <name>]] [--json]',
+    allowedFlags: [
+      ...GLOBAL_FLAGS,
+      'worktree',
+      'command',
+      'title',
+      'focus',
+      ...RESOURCE_RESERVATION_FLAGS
+    ],
     notes: [
       'Creates a visible terminal tab without switching focus when possible; falls back to a background handle if the UI cannot adopt it. Pass --focus to switch to it.',
-      'Use this, not worktree create, for a fresh agent in the current checkout.'
+      'Use this, not worktree create, for a fresh agent in the current checkout.',
+      'Pass --idempotency-key with --reservation-id, --reservation-session and --ownership-generation to bind this create to a caller ledger reservation. The key is single-use: a retry returns the same resource, and reusing it with a different binding is refused.',
+      'The exact binding is readable back through `orca terminal show --json` and `orca terminal list --json` as `reservation`.'
     ],
     examples: [
       'orca terminal create --json',

--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -21,7 +21,7 @@ import type {
 export function formatTerminalList(
   result: WithAnnotatedHostScope<RuntimeTerminalListResult>
 ): string {
-  const scope = formatListingHostScope(result.hostScope)
+  const scope = `${formatListingHostScope(result.hostScope)}\n${formatTerminalInventoryCompleteness(result.hostScope)}`
   if (result.terminals.length === 0) {
     return `No terminals listed.\n${scope}`
   }
@@ -37,6 +37,21 @@ export function formatTerminalList(
   return result.truncated
     ? `${bodyWithScope}\ntruncated: showing ${result.terminals.length} of ${result.totalCount}`
     : bodyWithScope
+}
+
+// Pagination and cross-host inventory completeness are independent. Missing host support is
+// unverifiable, never evidence that an empty or untruncated page covered every host.
+function formatTerminalInventoryCompleteness(
+  scope: WithAnnotatedHostScope<RuntimeTerminalListResult>['hostScope']
+): string {
+  if (scope?.complete === undefined) {
+    return 'inventory: unverifiable — this host does not report inventory completeness'
+  }
+  const observed =
+    scope.observedAt === undefined
+      ? ''
+      : ` (observed at ${new Date(scope.observedAt).toISOString()})`
+  return `inventory: ${scope.complete ? 'complete' : 'incomplete'}${observed}`
 }
 
 function formatTerminalVisualLayouts(

--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -28,7 +28,7 @@ export function formatTerminalList(
   const body = result.terminals
     .map(
       (terminal) =>
-        `${terminal.handle}  ${terminal.title ?? '(untitled)'}  ${terminal.connected ? 'connected' : 'disconnected'}  host=${terminal.executionHostId ?? 'unverifiable'}  ${terminal.worktreePath}\n${terminal.preview ? `preview: ${terminal.preview}` : 'preview: <empty>'}`
+        `${terminal.handle}  ${terminal.title ?? '(untitled)'}  ${terminal.connected ? 'connected' : 'disconnected'}  host=${terminal.executionHostId ?? 'unverifiable'}  ${terminal.worktreePath}${terminal.reservation ? `\nreservation: ${JSON.stringify(terminal.reservation)}` : ''}\n${terminal.preview ? `preview: ${terminal.preview}` : 'preview: <empty>'}`
     )
     .join('\n\n')
   const visualLayout = formatTerminalVisualLayouts(result.visualLayouts)
@@ -107,6 +107,7 @@ export function formatTerminalShow(result: { terminal: RuntimeTerminalShow }): s
     // Why listed above the preview: the preview is where a reader would otherwise have to
     // spot the prompt by eye, which is the work this line exists to remove.
     `agentWait: ${formatAgentWait(terminal.agentWait)}`,
+    `reservation: ${terminal.reservation ? JSON.stringify(terminal.reservation) : 'none'}`,
     `preview: ${terminal.preview || '<empty>'}`
   ].join('\n')
 }
@@ -234,7 +235,10 @@ export function formatTerminalCreate(result: { terminal: RuntimeTerminalCreate }
   const titleNote = result.terminal.title ? ` (title: "${result.terminal.title}")` : ''
   const surfaceNote = result.terminal.surface ? ` [${result.terminal.surface}]` : ''
   const warningNote = result.terminal.warning ? `\nwarning: ${result.terminal.warning}` : ''
-  return `Created terminal ${result.terminal.handle}${titleNote}${surfaceNote}${warningNote}`
+  const reservationNote = result.terminal.reservation
+    ? `\nreservation: ${JSON.stringify(result.terminal.reservation)}`
+    : ''
+  return `Created terminal ${result.terminal.handle}${titleNote}${surfaceNote}${reservationNote}${warningNote}`
 }
 
 export function formatTerminalSplit(result: { split: RuntimeTerminalSplit }): string {

--- a/src/cli/terminal-list-inventory-completeness.test.ts
+++ b/src/cli/terminal-list-inventory-completeness.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { formatTerminalList } from './format'
+import type { RuntimeTerminalListResult, RuntimeTerminalSummary } from '../shared/runtime-types'
+
+function terminal(overrides: Partial<RuntimeTerminalSummary> = {}): RuntimeTerminalSummary {
+  return {
+    handle: 'term_1',
+    ptyId: 'pty-1',
+    worktreeId: 'repo::/repo',
+    worktreePath: '/repo',
+    branch: 'main',
+    tabId: 'tab-1',
+    leafId: 'leaf-1',
+    title: 'worker',
+    connected: true,
+    writable: true,
+    lastOutputAt: null,
+    preview: '',
+    ...overrides
+  }
+}
+
+function listResult(overrides: Partial<RuntimeTerminalListResult> = {}): RuntimeTerminalListResult {
+  return { terminals: [terminal()], totalCount: 1, truncated: false, ...overrides }
+}
+
+describe('formatTerminalList inventory completeness', () => {
+  it('reports an incomplete inventory when a host was omitted, even with truncated false', () => {
+    const output = formatTerminalList(
+      listResult({
+        truncated: false,
+        hostScope: {
+          hostIds: ['local'],
+          omittedHostIds: ['ssh:box-1'],
+          complete: false,
+          observedAt: 0
+        }
+      })
+    )
+
+    expect(output).toContain('inventory: incomplete')
+  })
+
+  it('reports a complete inventory with the observation time that bounds it', () => {
+    const output = formatTerminalList(
+      listResult({
+        hostScope: { hostIds: ['local'], omittedHostIds: [], complete: true, observedAt: 0 }
+      })
+    )
+
+    expect(output).toContain('inventory: complete')
+    expect(output).toContain('1970-01-01T00:00:00.000Z')
+  })
+
+  it('reads an absent verdict as unverifiable rather than complete', () => {
+    const output = formatTerminalList(
+      listResult({ hostScope: { hostIds: ['local'], omittedHostIds: [] } })
+    )
+
+    expect(output).toContain('inventory: unverifiable')
+    expect(output).not.toContain('inventory: complete')
+  })
+
+  it('keeps an empty listing from reading as a complete absence', () => {
+    const output = formatTerminalList(listResult({ terminals: [], totalCount: 0 }))
+
+    expect(output).toContain('inventory: unverifiable')
+  })
+
+  it('surfaces the exact reservation binding on a terminal row', () => {
+    const output = formatTerminalList(
+      listResult({
+        terminals: [
+          terminal({
+            reservation: {
+              key: 'key-1',
+              reservationId: 'res-1',
+              sessionId: 'session-1',
+              resourceKind: 'terminal',
+              ownershipGeneration: 4,
+              issuer: 'openloop',
+              boundAt: 7
+            }
+          })
+        ]
+      })
+    )
+
+    expect(output).toContain('"reservationId":"res-1"')
+    expect(output).toContain('"ownershipGeneration":4')
+  })
+})

--- a/src/main/ipc/worktree-base-directory-watcher.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.ts
@@ -1,4 +1,5 @@
 import type { BrowserWindow } from 'electron'
+import { registerMainWindowCloseDisposer } from '../window/main-window-close-disposers'
 import type { Store } from '../persistence'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
@@ -219,7 +220,7 @@ export function setWorktreeBaseDirectoryWatcherSyncContext(
   // Why: older integration tests use lean BrowserWindow stubs; real windows still
   // clear this context on close so stale watcher syncs cannot target dead chrome.
   if (typeof mainWindow.once === 'function') {
-    mainWindow.once('closed', () => {
+    registerMainWindowCloseDisposer(mainWindow, () => {
       if (latestSyncContext?.mainWindow === mainWindow) {
         latestSyncContext = null
       }

--- a/src/main/ipc/worktree-metadata-merge.test.ts
+++ b/src/main/ipc/worktree-metadata-merge.test.ts
@@ -104,3 +104,50 @@ describe('mergeWorktree identity projection', () => {
     expect(worktree.suppressedGitHubPR).toBe(42)
   })
 })
+
+describe('mergeWorktree reservation projection', () => {
+  it('projects the persisted reservation binding so show and list expose it verbatim', () => {
+    const reservation = {
+      key: 'key-1',
+      reservationId: 'res-1',
+      sessionId: 'session-1',
+      resourceKind: 'worktree' as const,
+      ownershipGeneration: 4,
+      issuer: 'openloop',
+      boundAt: 9
+    }
+
+    const worktree = mergeWorktree('repo-1', git, {
+      displayName: 'feature',
+      reservation,
+      comment: '',
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 0
+    })
+
+    expect(worktree.reservation).toEqual(reservation)
+  })
+
+  it('leaves an unreserved workspace with no binding to misread', () => {
+    const worktree = mergeWorktree('repo-1', git, {
+      displayName: 'feature',
+      comment: '',
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 0
+    })
+
+    expect(worktree.reservation).toBeUndefined()
+  })
+})

--- a/src/main/ipc/worktree-metadata-merge.ts
+++ b/src/main/ipc/worktree-metadata-merge.ts
@@ -85,6 +85,7 @@ export function mergeWorktree(
       ? { automationProvenance: meta.automationProvenance }
       : {}),
     ...(meta?.cliProvenance !== undefined ? { cliProvenance: meta.cliProvenance } : {}),
+    ...(meta?.reservation !== undefined ? { reservation: meta.reservation } : {}),
     ...(meta?.pendingFirstAgentMessageRename !== undefined
       ? { pendingFirstAgentMessageRename: meta.pendingFirstAgentMessageRename }
       : {}),

--- a/src/main/ipc/worktree-metadata-merge.ts
+++ b/src/main/ipc/worktree-metadata-merge.ts
@@ -86,6 +86,9 @@ export function mergeWorktree(
       : {}),
     ...(meta?.cliProvenance !== undefined ? { cliProvenance: meta.cliProvenance } : {}),
     ...(meta?.reservation !== undefined ? { reservation: meta.reservation } : {}),
+    ...(meta?.reservationCreateReceipt !== undefined
+      ? { reservationCreateReceipt: meta.reservationCreateReceipt }
+      : {}),
     ...(meta?.pendingFirstAgentMessageRename !== undefined
       ? { pendingFirstAgentMessageRename: meta.pendingFirstAgentMessageRename }
       : {}),

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -28,7 +28,7 @@ import type {
   WorktreeHeadIdentity
 } from '../../shared/worktree/types'
 import { getPRForBranch } from '../github/client'
-import { listWorktrees, addWorktree, addSparseWorktree } from '../git/worktree'
+import { listWorktrees, addWorktree, addSparseWorktree, removeWorktree } from '../git/worktree'
 import type { AddWorktreeOptions, AddWorktreeResult } from '../git/worktree'
 import { consumePreparedWorktreeCreate } from '../worktree-create-preparation'
 import {
@@ -139,6 +139,7 @@ import { formatWorktreeIncludeCopyWarning } from './worktree-include-copy-budget
 import { resolveWorktreeIncludePaths } from '../git/worktree-include-file'
 import { resolveWorktreeSharedDirectories } from '../git/worktree-shared-directories'
 import { normalizeSparseDirectories } from './sparse-checkout-directories'
+import { persistCreatedWorktreeOrRollback } from './worktree-reservation-persistence'
 import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
 import type { IFilesystemProvider } from '../providers/types'
 import {
@@ -2226,9 +2227,18 @@ export async function createRemoteWorktree(
       : {}),
     ...(args.workspaceStatus !== undefined ? { workspaceStatus: args.workspaceStatus } : {})
   }
-  const { worktree } = timing.timeSync('persist_metadata', () => {
-    const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
-    return { worktree: mergeWorktree(repo.id, created, meta) }
+  const worktree = await persistCreatedWorktreeOrRollback({
+    resourcePath: created.path,
+    persist: () =>
+      timing.timeSync('persist_metadata', () => {
+      const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
+      return mergeWorktree(repo.id, created, meta)
+      }),
+    rollback: () =>
+      provider.removeWorktree(created.path, true, {
+        deleteBranch: !checkoutExistingBranch,
+        forceBranchDelete: !checkoutExistingBranch
+      })
   })
   const { lineage: worktreeLineage, workspaceLineage } = recordWorkspaceLineageForCreatedWorktree(
     store,
@@ -2920,9 +2930,18 @@ export async function createLocalWorktree(
       : {}),
     ...(args.workspaceStatus !== undefined ? { workspaceStatus: args.workspaceStatus } : {})
   }
-  const { worktree } = timing.timeSync('persist_metadata', () => {
-    const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
-    return { worktree: mergeWorktree(repo.id, created, meta) }
+  const worktree = await persistCreatedWorktreeOrRollback({
+    resourcePath: created.path,
+    persist: () =>
+      timing.timeSync('persist_metadata', () => {
+      const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
+      return mergeWorktree(repo.id, created, meta)
+      }),
+    rollback: () =>
+      removeWorktree(repo.path, created.path, true, {
+        deleteBranch: !checkoutExistingBranch,
+        forceBranchDelete: !checkoutExistingBranch
+      })
   })
   const { lineage: worktreeLineage, workspaceLineage } = recordWorkspaceLineageForCreatedWorktree(
     store,

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -70,6 +70,7 @@ import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import type { SshGitProvider } from '../providers/ssh-git-provider'
 import { TUI_AGENT_CONFIG, isTuiAgent } from '../../shared/tui-agent-config'
 import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
+import type { ResourceReservationBinding } from '../../shared/resource-reservation-binding'
 import { runWorktreeChangeInvalidators } from './worktree-change-invalidators'
 import {
   registerOptionalSshWorktreeCreateRoots,
@@ -79,6 +80,7 @@ import {
 type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
   cliProvenance?: CliWorkspaceProvenance
+  reservation?: ResourceReservationBinding
 }
 import {
   sanitizeWorktreeName,
@@ -2180,6 +2182,7 @@ export async function createRemoteWorktree(
     orcaCreationWorkspaceLayout: getWorktreeCreationLayout(repo, settings),
     ...(args.automationProvenance ? { automationProvenance: args.automationProvenance } : {}),
     ...(args.cliProvenance ? { cliProvenance: args.cliProvenance } : {}),
+    ...(args.reservation ? { reservation: args.reservation } : {}),
     baseRef: metadataBaseRef,
     ...(checkoutExistingBranch ? { preserveBranchOnDelete: true } : {}),
     ...(configuredPushTarget ? { pushTarget: configuredPushTarget } : {}),
@@ -2873,6 +2876,7 @@ export async function createLocalWorktree(
     orcaCreationWorkspaceLayout: getWorktreeCreationLayout(repo, settings),
     ...(args.automationProvenance ? { automationProvenance: args.automationProvenance } : {}),
     ...(args.cliProvenance ? { cliProvenance: args.cliProvenance } : {}),
+    ...(args.reservation ? { reservation: args.reservation } : {}),
     baseRef: metadataBaseRef,
     ...(checkoutExistingBranch ? { preserveBranchOnDelete: true } : {}),
     ...(configuredPushTarget ? { pushTarget: configuredPushTarget } : {}),

--- a/src/main/ipc/worktree-reservation-persistence.test.ts
+++ b/src/main/ipc/worktree-reservation-persistence.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+import { persistCreatedWorktreeOrRollback } from './worktree-reservation-persistence'
+
+describe('reservation-bearing worktree metadata persistence', () => {
+  it('does not touch the provider when metadata commits', async () => {
+    const rollback = vi.fn(async () => undefined)
+    await expect(
+      persistCreatedWorktreeOrRollback({
+        resourcePath: '/repo/worktree',
+        persist: () => 'committed',
+        rollback
+      })
+    ).resolves.toBe('committed')
+    expect(rollback).not.toHaveBeenCalled()
+  })
+
+  it('rolls back the provider resource before reporting persistence failure', async () => {
+    const rollback = vi.fn(async () => undefined)
+    await expect(
+      persistCreatedWorktreeOrRollback({
+        resourcePath: '/repo/worktree',
+        persist: () => {
+          throw new Error('metadata_failed')
+        },
+        rollback
+      })
+    ).rejects.toThrow('metadata_failed')
+    expect(rollback).toHaveBeenCalledOnce()
+  })
+
+  it('reports both failures when rollback cannot prove the resource was removed', async () => {
+    await expect(
+      persistCreatedWorktreeOrRollback({
+        resourcePath: '/repo/worktree',
+        persist: () => {
+          throw new Error('metadata_failed')
+        },
+        rollback: async () => {
+          throw new Error('rollback_failed')
+        }
+      })
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('rollback failed'),
+      errors: [expect.any(Error), expect.any(Error)]
+    })
+  })
+})

--- a/src/main/ipc/worktree-reservation-persistence.ts
+++ b/src/main/ipc/worktree-reservation-persistence.ts
@@ -1,0 +1,24 @@
+/**
+ * Commits reservation-bearing metadata or removes the just-created provider resource. A rollback
+ * failure is preserved beside the persistence error so callers never mistake the orphan for a
+ * clean failure that is safe to retry.
+ */
+export async function persistCreatedWorktreeOrRollback<T>(args: {
+  resourcePath: string
+  persist: () => T
+  rollback: () => Promise<unknown>
+}): Promise<T> {
+  try {
+    return args.persist()
+  } catch (persistenceError) {
+    try {
+      await args.rollback()
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [persistenceError, rollbackError],
+        `Worktree metadata persistence failed and rollback failed for ${args.resourcePath}`
+      )
+    }
+    throw persistenceError
+  }
+}

--- a/src/main/ipc/worktrees/create/folder-workspace-creation.ts
+++ b/src/main/ipc/worktrees/create/folder-workspace-creation.ts
@@ -38,6 +38,7 @@ export function createFolderWorkspace(
     creatorProvenance: { kind: 'host' },
     ...(args.automationProvenance ? { automationProvenance: args.automationProvenance } : {}),
     ...(args.cliProvenance ? { cliProvenance: args.cliProvenance } : {}),
+    ...(args.reservation ? { reservation: args.reservation } : {}),
     ...(args.createdWithAgent ? { createdWithAgent: args.createdWithAgent } : {}),
     ...(args.linkedIssue !== undefined ? { linkedIssue: args.linkedIssue } : {}),
     ...(args.linkedPR !== undefined ? { linkedPR: args.linkedPR } : {}),

--- a/src/main/ipc/worktrees/folder-workspace-model.ts
+++ b/src/main/ipc/worktrees/folder-workspace-model.ts
@@ -67,6 +67,7 @@ export function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: Workt
       ? { automationProvenance: meta.automationProvenance }
       : {}),
     ...(meta.cliProvenance !== undefined ? { cliProvenance: meta.cliProvenance } : {}),
+    ...(meta.reservation !== undefined ? { reservation: meta.reservation } : {}),
     ...(meta.priorWorktreeIds !== undefined ? { priorWorktreeIds: meta.priorWorktreeIds } : {}),
     workspaceStatus: meta.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
     diffComments: meta.diffComments,

--- a/src/main/ipc/worktrees/ipc-context-schemas.ts
+++ b/src/main/ipc/worktrees/ipc-context-schemas.ts
@@ -4,6 +4,7 @@ import type {
   CliWorkspaceProvenance
 } from '../../../shared/worktree/types'
 import type { ExecutionHostId } from '../../../shared/execution-host'
+import type { ResourceReservationBinding } from '../../../shared/resource-reservation-binding'
 import type { ListDetectedWorktreesArgs } from '../../../shared/detected-worktree-provider-contract'
 import { WorkspaceLinkedItemSchema } from '../../../shared/workspace-linked-item-schema'
 import { TaskSourceContextSchema } from '../../../shared/task-source-context-schema'
@@ -12,6 +13,7 @@ import { isWorkspaceLinkedItemSourceContextMatch } from '../../../shared/workspa
 export type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
   cliProvenance?: CliWorkspaceProvenance
+  reservation?: ResourceReservationBinding
 }
 
 export type RemoveWorktreeArgs = {

--- a/src/main/macos-tcc-prompt-notice.ts
+++ b/src/main/macos-tcc-prompt-notice.ts
@@ -4,6 +4,7 @@ import type { BrowserWindow } from 'electron'
 import { writeFileAtomically } from './codex-accounts/fs-utils'
 import { getCanonicalUserDataPath } from './persistence'
 import { MacosTccPromptWatch } from './macos-tcc-prompt-watch'
+import { registerMainWindowCloseDisposer } from './window/main-window-close-disposers'
 
 /**
  * Surfaces Full Disk Access guidance only to users macOS is actually prompting
@@ -162,7 +163,7 @@ export function dismissTccPromptNotice(): void {
 
 function trackMainWindow(mainWindow: BrowserWindow): void {
   mainWindowRef = mainWindow
-  mainWindow.once('closed', () => {
+  registerMainWindowCloseDisposer(mainWindow, () => {
     if (mainWindowRef === mainWindow) {
       mainWindowRef = null
     }

--- a/src/main/rate-limits/service/service-configuration.ts
+++ b/src/main/rate-limits/service/service-configuration.ts
@@ -1,4 +1,5 @@
 import type { BrowserWindow } from 'electron'
+import { registerMainWindowCloseDisposer } from '../../window/main-window-close-disposers'
 import { hasMiniMaxSessionCookie } from '../../minimax/minimax-cookie-store'
 import { hasMiniMaxApiKey } from '../../minimax/minimax-api-key-store'
 import { RateLimitServiceAccountRefresh } from './service-account-refresh'
@@ -72,12 +73,13 @@ export abstract class RateLimitServiceConfiguration extends RateLimitServiceAcco
     const refreshOnResume = (): void => {
       void this.refreshIfWindowActive()
     }
+    let unregisterWindowClose = (): void => {}
     // Why: attach() can replace windows; remove the previous closed listener too, not only the focus listeners.
     const detachWindowListeners = (): void => {
       mainWindow.removeListener('focus', refreshOnResume)
       mainWindow.removeListener('show', refreshOnResume)
       mainWindow.removeListener('restore', refreshOnResume)
-      mainWindow.removeListener('closed', onClosed)
+      unregisterWindowClose()
     }
     const onClosed = (): void => {
       detachWindowListeners()
@@ -91,7 +93,7 @@ export abstract class RateLimitServiceConfiguration extends RateLimitServiceAcco
     mainWindow.on('focus', refreshOnResume)
     mainWindow.on('show', refreshOnResume)
     mainWindow.on('restore', refreshOnResume)
-    mainWindow.on('closed', onClosed)
+    unregisterWindowClose = registerMainWindowCloseDisposer(mainWindow, onClosed)
     this.detachWindowListeners = detachWindowListeners
   }
 

--- a/src/main/runtime/claude-agent-teams-pty-exit-leak.test.ts
+++ b/src/main/runtime/claude-agent-teams-pty-exit-leak.test.ts
@@ -10,7 +10,7 @@
  * `team-${randomUUID()}`, so when a leader shell exits on its own (agent finishes,
  * process dies, renderer reload) the team + nested panes Map leaked permanently.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { OrcaRuntimeService } from './orca-runtime'
 import type { ClaudeAgentTeamsService } from './claude-agent-teams-service'
 import { buildResourceReservationBinding } from '../../shared/resource-reservation-binding'
@@ -21,6 +21,7 @@ type RuntimeInternals = {
   handleByPtyId: Map<string, string>
   dropDisconnectedPtyRecord: (ptyId: string) => void
   terminalReservations: TerminalReservationBindings
+  ptysById: Map<string, unknown>
 }
 
 function internals(runtime: OrcaRuntimeService): RuntimeInternals {
@@ -72,6 +73,23 @@ describe('ClaudeAgentTeams eviction on natural PTY exit (leak regression)', () =
     runtime.onPtyExit('pty-reserved', 0)
 
     expect(terminalReservations.get(handle)).toBeUndefined()
+  })
+
+  it('finishes PTY death cleanup before surfacing reservation persistence failure', () => {
+    const runtime = new OrcaRuntimeService()
+    const { handleByPtyId, terminalReservations, ptysById } = internals(runtime)
+    const handle = 'handle-retire-failure'
+    runtime.registerPty('pty-retire-failure', 'worktree-1', null)
+    handleByPtyId.set('pty-retire-failure', handle)
+    const retirementError = new Error('reservation_retirement_persist_failed')
+    const retire = vi.spyOn(terminalReservations, 'retire').mockImplementation(() => {
+      throw retirementError
+    })
+
+    expect(() => runtime.onPtyExit('pty-retire-failure', 0)).toThrow(retirementError)
+
+    expect(retire).toHaveBeenCalledWith(handle)
+    expect(ptysById.get('pty-retire-failure')).toMatchObject({ connected: false })
   })
 
   it('evicts the team when the disconnected PTY record is pruned', () => {

--- a/src/main/runtime/claude-agent-teams-pty-exit-leak.test.ts
+++ b/src/main/runtime/claude-agent-teams-pty-exit-leak.test.ts
@@ -13,11 +13,14 @@
 import { describe, it, expect } from 'vitest'
 import { OrcaRuntimeService } from './orca-runtime'
 import type { ClaudeAgentTeamsService } from './claude-agent-teams-service'
+import { buildResourceReservationBinding } from '../../shared/resource-reservation-binding'
+import type { TerminalReservationBindings } from './terminal-reservation-bindings'
 
 type RuntimeInternals = {
   claudeAgentTeams: ClaudeAgentTeamsService
   handleByPtyId: Map<string, string>
   dropDisconnectedPtyRecord: (ptyId: string) => void
+  terminalReservations: TerminalReservationBindings
 }
 
 function internals(runtime: OrcaRuntimeService): RuntimeInternals {
@@ -45,6 +48,30 @@ describe('ClaudeAgentTeams eviction on natural PTY exit (leak regression)', () =
     runtime.onPtyExit('pty-leader', 0)
 
     expect(internals(runtime).claudeAgentTeams.getActiveTeamCount()).toBe(0)
+  })
+
+  it('retires the terminal reservation when its PTY exits naturally', () => {
+    const runtime = new OrcaRuntimeService()
+    const { handleByPtyId, terminalReservations } = internals(runtime)
+    const handle = 'handle-reserved'
+    handleByPtyId.set('pty-reserved', handle)
+    terminalReservations.claim(
+      handle,
+      buildResourceReservationBinding(
+        {
+          key: 'key-natural-exit',
+          reservationId: 'reservation-natural-exit',
+          sessionId: 'session-natural-exit',
+          resourceKind: 'terminal',
+          ownershipGeneration: 1
+        },
+        { boundAt: 1 }
+      )
+    )
+
+    runtime.onPtyExit('pty-reserved', 0)
+
+    expect(terminalReservations.get(handle)).toBeUndefined()
   })
 
   it('evicts the team when the disconnected PTY record is pruned', () => {

--- a/src/main/runtime/claude-agent-teams-pty-exit-leak.test.ts
+++ b/src/main/runtime/claude-agent-teams-pty-exit-leak.test.ts
@@ -22,6 +22,8 @@ type RuntimeInternals = {
   dropDisconnectedPtyRecord: (ptyId: string) => void
   terminalReservations: TerminalReservationBindings
   ptysById: Map<string, unknown>
+  retireMobileSessionSurfacesForPty: (...args: unknown[]) => void
+  pruneDisconnectedPtyRecords: () => void
 }
 
 function internals(runtime: OrcaRuntimeService): RuntimeInternals {
@@ -85,10 +87,14 @@ describe('ClaudeAgentTeams eviction on natural PTY exit (leak regression)', () =
     const retire = vi.spyOn(terminalReservations, 'retire').mockImplementation(() => {
       throw retirementError
     })
+    const retireSurfaces = vi.spyOn(internals(runtime), 'retireMobileSessionSurfacesForPty')
+    const pruneDisconnected = vi.spyOn(internals(runtime), 'pruneDisconnectedPtyRecords')
 
     expect(() => runtime.onPtyExit('pty-retire-failure', 0)).toThrow(retirementError)
 
     expect(retire).toHaveBeenCalledWith(handle)
+    expect(retireSurfaces).toHaveBeenCalled()
+    expect(pruneDisconnected).toHaveBeenCalledOnce()
     expect(ptysById.get('pty-retire-failure')).toMatchObject({ connected: false })
   })
 

--- a/src/main/runtime/orca-runtime-build-pty-terminal-summary.ts
+++ b/src/main/runtime/orca-runtime-build-pty-terminal-summary.ts
@@ -20,8 +20,9 @@ export class OrcaRuntimeWithBuildPtyTerminalSummary extends OrcaRuntimeWithGetPt
     const title = getLatestPtyTitle(pty)
     const pane = parsePaneKey(pty.paneKey ?? '')
     const orphaned = !pty.tabId || !pane || pane.tabId !== pty.tabId
+    const handle = this.issuePtyHandle(pty)
     return {
-      handle: this.issuePtyHandle(pty),
+      handle,
       ptyId: pty.ptyId,
       incarnationId: pty.incarnationId,
       orphaned,
@@ -37,6 +38,7 @@ export class OrcaRuntimeWithBuildPtyTerminalSummary extends OrcaRuntimeWithGetPt
       preview: pty.preview,
       ...(pty.lastExitCause ? { exitCause: pty.lastExitCause } : {}),
       ...this.terminalExecutionHostField(pty.ptyId, pty.worktreeId),
+      ...this.terminalReservationField(handle),
       ...this.resolvePaneAgentIdentityField(
         pty.launchAgent,
         pty.foregroundAgent,

--- a/src/main/runtime/orca-runtime-create-managed-remote-worktree.ts
+++ b/src/main/runtime/orca-runtime-create-managed-remote-worktree.ts
@@ -9,6 +9,7 @@ import type { WorktreeBaseStatusEvent } from '../../shared/worktree/base-ref-dri
 import { probeRuntimeWorktreeDrift } from './runtime-worktree-drift-probe'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import type { GitHubPrStartPoint, GitPushTarget } from '../../shared/worktree/types'
+import type { WorktreeReservationCreateReceipt } from '../../shared/worktree/reservation-create-receipt'
 import {
   persistRuntimeManagedWorktreeSortOrder,
   updateRuntimeManagedWorktreeMetadata
@@ -17,6 +18,22 @@ import { resolveRuntimeGitHubWorktreeBase } from './runtime-github-worktree-base
 import { resolveRuntimeGitLabWorktreeBase } from './runtime-gitlab-worktree-base'
 
 export class OrcaRuntimeWithCreateManagedRemoteWorktree extends OrcaRuntimeWithCreateManagedWorktree {
+  recordWorktreeReservationCreateReceipt(
+    worktreeId: string,
+    hostId: string | undefined,
+    receipt: WorktreeReservationCreateReceipt
+  ): void {
+    if (!this.store) {
+      throw new Error('runtime_unavailable')
+    }
+    if (hostId && this.store.setWorktreeMetaForHost) {
+      this.store.setWorktreeMetaForHost(worktreeId, hostId, { reservationCreateReceipt: receipt })
+    } else {
+      this.store.setWorktreeMeta(worktreeId, { reservationCreateReceipt: receipt })
+    }
+    this.invalidateResolvedWorktreeCache()
+  }
+
   protected createManagedRemoteWorktree(
     repo: Repo,
     args: RuntimeRemoteWorktreeCreateArgs

--- a/src/main/runtime/orca-runtime-get-runtime-id.ts
+++ b/src/main/runtime/orca-runtime-get-runtime-id.ts
@@ -166,9 +166,14 @@ export class OrcaRuntimeWithGetRuntimeId extends OrcaRuntimeWithHasExactPersiste
         (id) => queriedHostIds.has(id) && parseExecutionHostId(id)?.kind !== 'runtime'
       )
     )
+    const omittedHostIds = [...known].filter((id) => !covered.has(id)).sort()
     return {
       hostIds: [...covered].sort(),
-      omittedHostIds: [...known].filter((id) => !covered.has(id)).sort()
+      omittedHostIds,
+      // Why explicit: `truncated` answers page size, not cross-host coverage. Callers were reading
+      // `truncated: false` as a complete inventory while hosts were being omitted.
+      complete: omittedHostIds.length === 0,
+      observedAt: Date.now()
     }
   }
 

--- a/src/main/runtime/orca-runtime-list-managed-worktrees.ts
+++ b/src/main/runtime/orca-runtime-list-managed-worktrees.ts
@@ -129,6 +129,15 @@ export class OrcaRuntimeWithListManagedWorktrees extends OrcaRuntimeWithRestoreS
     return await this.resolveWorktreeSelector(worktreeSelector)
   }
 
+  /** Resolve a reservation replay to its exact persisted host and occupant identity. */
+  async showReservedManagedWorktree(worktreeId: string, hostId: string, instanceId: string) {
+    const worktree = await this.resolveExplicitWorktreeIdScoped(worktreeId, hostId)
+    if (!worktree || worktree.instanceId !== instanceId) {
+      throw new Error('reservation_resource_missing')
+    }
+    return worktree
+  }
+
   async showManagedTerminalWorkspace(worktreeSelector: string) {
     const target = await this.resolveTerminalWorkspaceLaunchTarget(worktreeSelector)
     if (!target.managedWorktree) {

--- a/src/main/runtime/orca-runtime-list-managed-worktrees.ts
+++ b/src/main/runtime/orca-runtime-list-managed-worktrees.ts
@@ -5,6 +5,11 @@ import type { RuntimeWorktreeListResult } from '../../shared/runtime-types'
 import type { DetectedWorktreeListResult, Worktree } from '../../shared/worktree/types'
 import type { Repo } from '../../shared/repo-types'
 import { stopMissingWorktreeTerminals } from './missing-worktree-terminal-reconciliation'
+import {
+  findWorktreeReservation,
+  type WorktreeReservationLookup
+} from './worktree-reservation-replay'
+import type { ResourceReservationRequest } from '../../shared/resource-reservation-binding'
 import type { RuntimeCommandSurfaceHost } from './orca-runtime-core'
 import type { WorktreeVisibilitySourceMatcher } from '../../shared/worktree/visibility-sources'
 import type { RuntimeStore } from './runtime-store-contract'
@@ -27,6 +32,12 @@ export class OrcaRuntimeWithListManagedWorktrees extends OrcaRuntimeWithRestoreS
     sourceDefaultsSupported = true
   ): Promise<RuntimeWorktreeListResult> {
     return this.managedWorktreeQueries.list(repoSelector, limit, sourceDefaultsSupported)
+  }
+
+  /** Durable reservation replay over persisted workspace metadata — no git scan, so a create
+   *  retry resolves without paying for a full worktree listing. */
+  findManagedWorktreeReservation(request: ResourceReservationRequest): WorktreeReservationLookup {
+    return findWorktreeReservation(this.store?.getAllWorktreeMeta?.() ?? {}, request)
   }
 
   listRetiredWorktreeNames(repoSelector: string) {

--- a/src/main/runtime/orca-runtime-on-pty-exit.ts
+++ b/src/main/runtime/orca-runtime-on-pty-exit.ts
@@ -226,6 +226,9 @@ export class OrcaRuntimeWithOnPtyExit extends OrcaRuntimeWithOnClientDisconnecte
     } else {
       // Why: permanent process exit is absence, not a starting/sleeping tab.
       // Retire before publishing so paired clients never persist a ghost.
+      if (exitedTeamLeaderHandle) {
+        this.terminalReservations.retire(exitedTeamLeaderHandle)
+      }
       this.retireMobileSessionSurfacesForPty(ptyId, incarnationId, exactSurfaces)
     }
 

--- a/src/main/runtime/orca-runtime-on-pty-exit.ts
+++ b/src/main/runtime/orca-runtime-on-pty-exit.ts
@@ -220,6 +220,7 @@ export class OrcaRuntimeWithOnPtyExit extends OrcaRuntimeWithOnClientDisconnecte
       this.resolvePtyExitWaiters(pty, ptyId)
       this.pruneDisconnectedPtyTranscript(pty)
     }
+    let reservationRetirementError: unknown
     if (preservesIntentionalHandlelessSurface || preservesAbnormalSshSurface) {
       // Why: relay loss is recoverable; keep the HUB-owned pane addressable through the bounded reconnect grace.
       this.touchMobileSessionSnapshotsForPty(ptyId, { immediate: true })
@@ -227,7 +228,13 @@ export class OrcaRuntimeWithOnPtyExit extends OrcaRuntimeWithOnClientDisconnecte
       // Why: permanent process exit is absence, not a starting/sleeping tab.
       // Retire before publishing so paired clients never persist a ghost.
       if (exitedTeamLeaderHandle) {
-        this.terminalReservations.retire(exitedTeamLeaderHandle)
+        try {
+          this.terminalReservations.retire(exitedTeamLeaderHandle)
+        } catch (error) {
+          // Process death cannot be rolled back. Preserve the durable-store failure, but finish
+          // independent in-memory teardown before surfacing it to the caller.
+          reservationRetirementError = error
+        }
       }
       this.retireMobileSessionSurfacesForPty(ptyId, incarnationId, exactSurfaces)
     }
@@ -260,6 +267,9 @@ export class OrcaRuntimeWithOnPtyExit extends OrcaRuntimeWithOnClientDisconnecte
       }
     }
     this.pruneDisconnectedPtyRecords()
+    if (reservationRetirementError !== undefined) {
+      throw reservationRetirementError
+    }
   }
 
   private notifyPtyExitListeners(ptyId: string): void {

--- a/src/main/runtime/orca-runtime-runtime-id.ts
+++ b/src/main/runtime/orca-runtime-runtime-id.ts
@@ -30,6 +30,7 @@ import { WorktreeTerminalMutationLock } from './worktree-terminal-mutation-lock'
 import { RemoteRuntimeTerminalCreateIdempotency } from './remote-runtime-terminal-create-idempotency'
 import { TerminalReservationBindings } from './terminal-reservation-bindings'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
+import type { ResourceReservationRequest } from '../../shared/resource-reservation-binding'
 import type { MobileSessionTabsNotifyCoalescer } from './mobile-session-tabs-notify-coalescer'
 import { createMobileSessionTabsNotifyCoalescer } from './mobile-session-tabs-notify-coalescer'
 import type { MobileSessionTabsAgentStatusHeartbeat } from './mobile-session-tabs-agent-status-heartbeat'
@@ -202,7 +203,10 @@ export class OrcaRuntimeWithRuntimeId {
   // Why: idempotency map for worktree.create — a create interrupted by a mobile
   // connection migration is retried with the same clientMutationId and returns
   // the in-flight (or just-finished) operation instead of a duplicate worktree.
-  protected worktreeCreateByMutationId = new Map<string, Promise<unknown>>()
+  protected worktreeCreateByMutationId = new Map<
+    string,
+    { promise: Promise<unknown>; reservation?: ResourceReservationRequest }
+  >()
 
   // Why: a mobile create waits for the renderer to publish the new tab's surface
   // via graph-sync, but a throttled/hidden renderer can park that past the surface

--- a/src/main/runtime/orca-runtime-runtime-id.ts
+++ b/src/main/runtime/orca-runtime-runtime-id.ts
@@ -28,6 +28,7 @@ import { ClientHostedPageReconciliationWindow } from './client-hosted-page-recon
 import { ClientSessionTabSelectionStore } from './client-session-tab-selection'
 import { WorktreeTerminalMutationLock } from './worktree-terminal-mutation-lock'
 import { RemoteRuntimeTerminalCreateIdempotency } from './remote-runtime-terminal-create-idempotency'
+import { TerminalReservationBindings } from './terminal-reservation-bindings'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
 import type { MobileSessionTabsNotifyCoalescer } from './mobile-session-tabs-notify-coalescer'
 import { createMobileSessionTabsNotifyCoalescer } from './mobile-session-tabs-notify-coalescer'
@@ -172,6 +173,7 @@ export class OrcaRuntimeWithRuntimeId {
   >()
 
   protected readonly terminalCreateIdempotency = new RemoteRuntimeTerminalCreateIdempotency()
+  protected readonly terminalReservations = new TerminalReservationBindings()
 
   // Why: concurrent clients sleeping one host workspace must share one physical teardown.
   protected terminalSleepByWorktreeId = new Map<

--- a/src/main/runtime/orca-runtime-state-fields.ts
+++ b/src/main/runtime/orca-runtime-state-fields.ts
@@ -96,6 +96,10 @@ export class OrcaRuntimeWithStateFields extends OrcaRuntimeWithLinearCommands {
         this.notifyMobileSessionTabsChanged()
       }
     })
+    const profileStorageDirectory = store?.getProfileStorageDirectory?.()
+    if (profileStorageDirectory) {
+      this.terminalReservations.configurePersistence(profileStorageDirectory)
+    }
     const runtime = this as RuntimeCommandSurfaceHost<this>
     installRuntimeFileCommandSurface(runtime, this.fileCommands)
     installRuntimeGitCommandSurface(runtime, this.gitCommands)

--- a/src/main/runtime/orca-runtime-stop-explicitly-closed-tab-ptys.ts
+++ b/src/main/runtime/orca-runtime-stop-explicitly-closed-tab-ptys.ts
@@ -76,10 +76,6 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
   }
 
   async closeTerminal(handle: string): Promise<RuntimeTerminalClose> {
-    const retire = (result: RuntimeTerminalClose): RuntimeTerminalClose => {
-      this.terminalReservations.retire(handle)
-      return result
-    }
     const pty = this.getLivePtyForHandle(handle)
     this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
     if (pty) {
@@ -117,7 +113,7 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
           this.notifier.closeTerminal?.(tabId)
         }
         const ptyKilled = await this.stopExplicitlyClosedTabPtys(ptyIdsToKill, pty.pty.ptyId)
-        return retire(this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled))
+        return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
       }
       if (
         siblingCount <= 1 &&
@@ -137,16 +133,16 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
           }
           const ptyKilled = await this.stopExplicitlyClosedTabPtys([pty.pty.ptyId], pty.pty.ptyId)
           this.notifier?.closeTerminal(tabId)
-          return retire(this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled))
+          return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
         }
         const ptyKilled = await this.stopExplicitlyClosedTabPtys([pty.pty.ptyId], pty.pty.ptyId)
-        return retire(this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled))
+        return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
       }
       if (siblingCount <= 1 && !surface && pty.pty.tabId && this.notifier?.closeTerminalTab) {
         const ptyIdsToKill = this.getPtyIdsForExplicitTabClose(pty.pty.worktreeId, tabId)
         await this.notifier.closeTerminalTab(tabId, { localPtyTeardownOwnedExternally: true })
         const ptyKilled = await this.stopExplicitlyClosedTabPtys(ptyIdsToKill, pty.pty.ptyId)
-        return retire(this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled))
+        return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
       }
       const ptyKilled = await this.stopExplicitlyClosedTabPtys([pty.pty.ptyId], pty.pty.ptyId)
       if (!ptyKilled || siblingCount <= 1) {
@@ -166,7 +162,7 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
           this.notifier?.closeTerminal(tabId)
         }
       }
-      return retire(this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled))
+      return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
     }
     this.assertGraphReady()
     const { leaf } = this.getLiveLeafForHandle(handle)
@@ -187,14 +183,10 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
     if (siblingCount > 1 ? !ptyKilled : !this.notifier?.closeTerminalTab) {
       this.notifier?.closeTerminal(leaf.tabId, leaf.paneRuntimeId)
     }
-    return retire(this.describeTerminalClose(handle, leaf.tabId, leaf.ptyId ?? null, ptyKilled))
+    return this.describeTerminalClose(handle, leaf.tabId, leaf.ptyId ?? null, ptyKilled)
   }
 
   async closeTerminalTab(handle: string): Promise<RuntimeTerminalClose> {
-    const retire = (result: RuntimeTerminalClose): RuntimeTerminalClose => {
-      this.terminalReservations.retire(handle)
-      return result
-    }
     const pty = this.getLivePtyForHandle(handle)
     if (pty) {
       const closeAuthority: RuntimePtyTabCloseAuthority = {
@@ -216,12 +208,12 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
         expectedPtyCloseAuthority: closeAuthority
       })
       this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
-      return retire({ handle, tabId, closeMode: 'tab', ptyKilled: false })
+      return { handle, tabId, closeMode: 'tab', ptyKilled: false }
     }
     this.assertGraphReady()
     const { leaf } = this.getLiveLeafForHandle(handle)
     await this.closeMobileSessionTab(`id:${leaf.worktreeId}`, leaf.tabId, { reason: 'user' })
     this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
-    return retire({ handle, tabId: leaf.tabId, closeMode: 'tab', ptyKilled: false })
+    return { handle, tabId: leaf.tabId, closeMode: 'tab', ptyKilled: false }
   }
 }

--- a/src/main/runtime/orca-runtime-stop-explicitly-closed-tab-ptys.ts
+++ b/src/main/runtime/orca-runtime-stop-explicitly-closed-tab-ptys.ts
@@ -76,6 +76,10 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
   }
 
   async closeTerminal(handle: string): Promise<RuntimeTerminalClose> {
+    const retire = (result: RuntimeTerminalClose): RuntimeTerminalClose => {
+      this.terminalReservations.retire(handle)
+      return result
+    }
     const pty = this.getLivePtyForHandle(handle)
     this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
     if (pty) {
@@ -113,7 +117,7 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
           this.notifier.closeTerminal?.(tabId)
         }
         const ptyKilled = await this.stopExplicitlyClosedTabPtys(ptyIdsToKill, pty.pty.ptyId)
-        return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
+        return retire(this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled))
       }
       if (
         siblingCount <= 1 &&
@@ -133,16 +137,16 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
           }
           const ptyKilled = await this.stopExplicitlyClosedTabPtys([pty.pty.ptyId], pty.pty.ptyId)
           this.notifier?.closeTerminal(tabId)
-          return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
+          return retire(this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled))
         }
         const ptyKilled = await this.stopExplicitlyClosedTabPtys([pty.pty.ptyId], pty.pty.ptyId)
-        return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
+        return retire(this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled))
       }
       if (siblingCount <= 1 && !surface && pty.pty.tabId && this.notifier?.closeTerminalTab) {
         const ptyIdsToKill = this.getPtyIdsForExplicitTabClose(pty.pty.worktreeId, tabId)
         await this.notifier.closeTerminalTab(tabId, { localPtyTeardownOwnedExternally: true })
         const ptyKilled = await this.stopExplicitlyClosedTabPtys(ptyIdsToKill, pty.pty.ptyId)
-        return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
+        return retire(this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled))
       }
       const ptyKilled = await this.stopExplicitlyClosedTabPtys([pty.pty.ptyId], pty.pty.ptyId)
       if (!ptyKilled || siblingCount <= 1) {
@@ -162,7 +166,7 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
           this.notifier?.closeTerminal(tabId)
         }
       }
-      return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
+      return retire(this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled))
     }
     this.assertGraphReady()
     const { leaf } = this.getLiveLeafForHandle(handle)
@@ -183,10 +187,14 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
     if (siblingCount > 1 ? !ptyKilled : !this.notifier?.closeTerminalTab) {
       this.notifier?.closeTerminal(leaf.tabId, leaf.paneRuntimeId)
     }
-    return this.describeTerminalClose(handle, leaf.tabId, leaf.ptyId ?? null, ptyKilled)
+    return retire(this.describeTerminalClose(handle, leaf.tabId, leaf.ptyId ?? null, ptyKilled))
   }
 
   async closeTerminalTab(handle: string): Promise<RuntimeTerminalClose> {
+    const retire = (result: RuntimeTerminalClose): RuntimeTerminalClose => {
+      this.terminalReservations.retire(handle)
+      return result
+    }
     const pty = this.getLivePtyForHandle(handle)
     if (pty) {
       const closeAuthority: RuntimePtyTabCloseAuthority = {
@@ -208,12 +216,12 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
         expectedPtyCloseAuthority: closeAuthority
       })
       this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
-      return { handle, tabId, closeMode: 'tab', ptyKilled: false }
+      return retire({ handle, tabId, closeMode: 'tab', ptyKilled: false })
     }
     this.assertGraphReady()
     const { leaf } = this.getLiveLeafForHandle(handle)
     await this.closeMobileSessionTab(`id:${leaf.worktreeId}`, leaf.tabId, { reason: 'user' })
     this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
-    return { handle, tabId: leaf.tabId, closeMode: 'tab', ptyKilled: false }
+    return retire({ handle, tabId: leaf.tabId, closeMode: 'tab', ptyKilled: false })
   }
 }

--- a/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
+++ b/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
@@ -10,6 +10,11 @@ import { getRegisteredSshState } from '../ssh/ssh-target-registry'
 import { LOCAL_EXECUTION_HOST_ID, toSshExecutionHostId } from '../../shared/execution-host'
 import { resolveWorktreeLaunchHost } from './worktree-launch-host-repo'
 import type { TuiAgent } from '../../shared/tui-agent'
+import {
+  buildResourceReservationBinding,
+  type ResourceReservationRequest
+} from '../../shared/resource-reservation-binding'
+import { ResourceReservationConflictError } from './resource-reservation-conflict'
 
 export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithCreateAgentSession {
   async dedupeTerminalCreate(
@@ -20,11 +25,19 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
     run: (
       canonicalWorktreeSelector: string | undefined,
       preAllocatedHandle: string | undefined
-    ) => Promise<RuntimeTerminalCreate>
+    ) => Promise<RuntimeTerminalCreate>,
+    reservation?: ResourceReservationRequest
   ): Promise<RuntimeTerminalCreate> {
-    if (!clientMutationId || !worktreeSelector) {
+    // Why the reservation key wins: it is the caller's durable single-use identity, so deriving
+    // the handle from it makes the returned handle itself the binding — a retry re-derives the
+    // same address even if the caller minted a fresh transport mutation id.
+    const identityKey = reservation?.key ?? clientMutationId
+    if (!identityKey || !worktreeSelector) {
       if (reconcileExisting) {
         throw new Error('runtime_unavailable')
+      }
+      if (reservation) {
+        throw new Error('invalid_argument')
       }
       return await run(worktreeSelector, undefined)
     }
@@ -33,12 +46,24 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
     const preAllocatedHandle = deriveRemoteRuntimeTerminalCreateHandle(
       clientIdentity,
       workspace.id,
-      clientMutationId
+      identityKey
     )
-    return this.terminalCreateIdempotency.run(
+    const binding = reservation
+      ? buildResourceReservationBinding(reservation, { boundAt: Date.now() })
+      : null
+    if (binding) {
+      const conflict = this.terminalReservations.assertBindable(preAllocatedHandle, binding)
+      if (conflict) {
+        throw new ResourceReservationConflictError(conflict, {
+          resourceKind: 'terminal',
+          resourceId: preAllocatedHandle
+        })
+      }
+    }
+    const created = await this.terminalCreateIdempotency.run(
       clientIdentity,
       workspace.id,
-      clientMutationId,
+      identityKey,
       async () => {
         if (reconcileExisting) {
           const adopted = await this.reconcileRemoteTerminalCreate(
@@ -56,6 +81,22 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
         return await run(canonicalWorktreeSelector, preAllocatedHandle)
       }
     )
+    if (!binding) {
+      return created
+    }
+    // Why bound after the create resolves: a failed create must leave the key unused so a genuine
+    // retry can start fresh, exactly as the automation provenance reservation does.
+    const bindResult = this.terminalReservations.bind(created.handle, binding)
+    if (bindResult.outcome === 'conflict') {
+      throw new ResourceReservationConflictError(bindResult.message, {
+        resourceKind: 'terminal',
+        resourceId: created.handle
+      })
+    }
+    return {
+      ...created,
+      reservation: bindResult.outcome === 'replay' ? bindResult.binding : binding
+    }
   }
 
   protected async reconcileRemoteTerminalCreate(

--- a/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
+++ b/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
@@ -12,6 +12,8 @@ import { resolveWorktreeLaunchHost } from './worktree-launch-host-repo'
 import type { TuiAgent } from '../../shared/tui-agent'
 import {
   buildResourceReservationBinding,
+  describeResourceReservationConflict,
+  resourceReservationBindingMatchesRequest,
   type ResourceReservationRequest
 } from '../../shared/resource-reservation-binding'
 import { ResourceReservationConflictError } from './resource-reservation-conflict'
@@ -43,7 +45,9 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
     }
     const workspace = await this.resolveTerminalWorkspaceLaunchScope(worktreeSelector)
     const canonicalWorktreeSelector = `id:${workspace.id}`
-    const reservationIdentity = reservation ? `reservation:${reservation.issuer ?? ''}` : clientIdentity
+    const reservationIdentity = reservation
+      ? `reservation:${reservation.issuer ?? ''}`
+      : clientIdentity
     const preAllocatedHandle = deriveRemoteRuntimeTerminalCreateHandle(
       reservationIdentity,
       workspace.id,
@@ -54,10 +58,10 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
       : null
     const claim = binding ? this.terminalReservations.claim(preAllocatedHandle, binding) : null
     if (claim?.outcome === 'conflict') {
-        throw new ResourceReservationConflictError(claim.message, {
-          resourceKind: 'terminal',
-          resourceId: preAllocatedHandle
-        })
+      throw new ResourceReservationConflictError(claim.message, {
+        resourceKind: 'terminal',
+        resourceId: preAllocatedHandle
+      })
     }
     let created: RuntimeTerminalCreate
     try {
@@ -66,20 +70,20 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
         workspace.id,
         identityKey,
         async () => {
-        if (reconcileExisting) {
-          const adopted = await this.reconcileRemoteTerminalCreate(
-            workspace.id,
-            preAllocatedHandle,
-            // Why: an unreachable SSH host vanishes from the aggregate listing, which would read
-            // as absence and respawn over live remote work. Local/folder workspaces have no
-            // connection and keep the aggregate listing.
-            workspace.connectionId ?? null
-          )
-          if (adopted) {
-            return adopted
+          if (reconcileExisting) {
+            const adopted = await this.reconcileRemoteTerminalCreate(
+              workspace.id,
+              preAllocatedHandle,
+              // Why: an unreachable SSH host vanishes from the aggregate listing, which would read
+              // as absence and respawn over live remote work. Local/folder workspaces have no
+              // connection and keep the aggregate listing.
+              workspace.connectionId ?? null
+            )
+            if (adopted) {
+              return adopted
+            }
           }
-        }
-        return await run(canonicalWorktreeSelector, preAllocatedHandle)
+          return await run(canonicalWorktreeSelector, preAllocatedHandle)
         }
       )
     } catch (error) {
@@ -219,20 +223,35 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
   dedupeWorktreeCreate<T>(
     repoSelector: string,
     clientMutationId: string | undefined,
-    run: () => Promise<T>
+    run: () => Promise<T>,
+    reservation?: ResourceReservationRequest
   ): Promise<T> {
     if (!clientMutationId) {
       return run()
     }
-    const key = `${repoSelector}\0${clientMutationId}`
+    // Reservation keys and transport mutation ids are separate namespaces. A caller-chosen
+    // mutation id must never intercept a durable reservation retry that happens to share text.
+    const key = `${repoSelector}\0${reservation ? 'reservation' : 'mutation'}\0${clientMutationId}`
     const inflight = this.worktreeCreateByMutationId.get(key)
     if (inflight) {
-      return inflight as Promise<T>
+      if (reservation && inflight.reservation) {
+        const prior = buildResourceReservationBinding(inflight.reservation, { boundAt: 0 })
+        if (!resourceReservationBindingMatchesRequest(prior, reservation)) {
+          return Promise.reject(
+            new ResourceReservationConflictError(
+              describeResourceReservationConflict(prior, reservation, 'pending-worktree-create'),
+              { resourceKind: 'worktree', resourceId: 'pending-worktree-create' }
+            )
+          )
+        }
+      }
+      return inflight.promise as Promise<T>
     }
     const created = run()
-    this.worktreeCreateByMutationId.set(key, created)
+    const entry = { promise: created as Promise<unknown>, ...(reservation ? { reservation } : {}) }
+    this.worktreeCreateByMutationId.set(key, entry)
     const drop = (): void => {
-      if (this.worktreeCreateByMutationId.get(key) === created) {
+      if (this.worktreeCreateByMutationId.get(key) === entry) {
         this.worktreeCreateByMutationId.delete(key)
       }
     }

--- a/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
+++ b/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
@@ -43,28 +43,29 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
     }
     const workspace = await this.resolveTerminalWorkspaceLaunchScope(worktreeSelector)
     const canonicalWorktreeSelector = `id:${workspace.id}`
+    const reservationIdentity = reservation ? `reservation:${reservation.issuer ?? ''}` : clientIdentity
     const preAllocatedHandle = deriveRemoteRuntimeTerminalCreateHandle(
-      clientIdentity,
+      reservationIdentity,
       workspace.id,
       identityKey
     )
     const binding = reservation
       ? buildResourceReservationBinding(reservation, { boundAt: Date.now() })
       : null
-    if (binding) {
-      const conflict = this.terminalReservations.assertBindable(preAllocatedHandle, binding)
-      if (conflict) {
-        throw new ResourceReservationConflictError(conflict, {
+    const claim = binding ? this.terminalReservations.claim(preAllocatedHandle, binding) : null
+    if (claim?.outcome === 'conflict') {
+        throw new ResourceReservationConflictError(claim.message, {
           resourceKind: 'terminal',
           resourceId: preAllocatedHandle
         })
-      }
     }
-    const created = await this.terminalCreateIdempotency.run(
-      clientIdentity,
-      workspace.id,
-      identityKey,
-      async () => {
+    let created: RuntimeTerminalCreate
+    try {
+      created = await this.terminalCreateIdempotency.run(
+        reservationIdentity,
+        workspace.id,
+        identityKey,
+        async () => {
         if (reconcileExisting) {
           const adopted = await this.reconcileRemoteTerminalCreate(
             workspace.id,
@@ -79,23 +80,20 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
           }
         }
         return await run(canonicalWorktreeSelector, preAllocatedHandle)
+        }
+      )
+    } catch (error) {
+      if (binding && claim?.outcome === 'bound') {
+        this.terminalReservations.release(preAllocatedHandle, binding)
       }
-    )
+      throw error
+    }
     if (!binding) {
       return created
     }
-    // Why bound after the create resolves: a failed create must leave the key unused so a genuine
-    // retry can start fresh, exactly as the automation provenance reservation does.
-    const bindResult = this.terminalReservations.bind(created.handle, binding)
-    if (bindResult.outcome === 'conflict') {
-      throw new ResourceReservationConflictError(bindResult.message, {
-        resourceKind: 'terminal',
-        resourceId: created.handle
-      })
-    }
     return {
       ...created,
-      reservation: bindResult.outcome === 'replay' ? bindResult.binding : binding
+      reservation: claim?.outcome === 'replay' ? claim.binding : binding
     }
   }
 

--- a/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
+++ b/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
@@ -88,7 +88,14 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
       )
     } catch (error) {
       if (binding && claim?.outcome === 'bound') {
-        this.terminalReservations.release(preAllocatedHandle, binding)
+        try {
+          this.terminalReservations.release(preAllocatedHandle, binding)
+        } catch (releaseError) {
+          throw new AggregateError(
+            [error, releaseError],
+            'Terminal creation failed and its reservation claim could not be released.'
+          )
+        }
       }
       throw error
     }

--- a/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
+++ b/src/main/runtime/orca-runtime-terminal-create-deduplication.ts
@@ -70,7 +70,9 @@ export class OrcaRuntimeWithTerminalCreateDeduplication extends OrcaRuntimeWithC
         workspace.id,
         identityKey,
         async () => {
-          if (reconcileExisting) {
+          // A reservation is the durable replay contract. Enforce reconciliation here so a
+          // schema-valid caller cannot accidentally weaken it by omitting the transport hint.
+          if (reservation || reconcileExisting) {
             const adopted = await this.reconcileRemoteTerminalCreate(
               workspace.id,
               preAllocatedHandle,

--- a/src/main/runtime/orca-runtime-terminal-create-reservation.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-create-reservation.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PtyProcessInfo } from '../providers/types'
+import type { RuntimeTerminalCreate } from '../../shared/runtime-types'
+import type { ResourceReservationRequest } from '../../shared/resource-reservation-binding'
+import { OrcaRuntimeService } from './orca-runtime'
+import { deriveRemoteRuntimeTerminalCreateHandle } from './remote-runtime-terminal-create-identity'
+import { RemoteRuntimeTerminalCreateIdempotency } from './remote-runtime-terminal-create-idempotency'
+import { TerminalReservationBindings } from './terminal-reservation-bindings'
+
+type CreateRun = (
+  canonicalWorktreeSelector: string | undefined,
+  preAllocatedHandle: string | undefined
+) => Promise<RuntimeTerminalCreate>
+
+const RESERVATION: ResourceReservationRequest = {
+  key: 'key-1',
+  reservationId: 'res-1',
+  sessionId: 'session-1',
+  resourceKind: 'terminal',
+  ownershipGeneration: 2,
+  issuer: 'openloop'
+}
+
+function createRuntimeForDedupe(listProcesses = vi.fn(async (): Promise<PtyProcessInfo[]> => [])) {
+  const runtime = Object.create(OrcaRuntimeService.prototype) as OrcaRuntimeService
+  Object.assign(runtime, {
+    terminalCreateIdempotency: new RemoteRuntimeTerminalCreateIdempotency(),
+    terminalReservations: new TerminalReservationBindings(),
+    ptyController: { listProcesses },
+    resolveTerminalWorkspaceLaunchScope: vi.fn(async (selector: string) => ({
+      id: selector.startsWith('id:') ? selector.slice(3) : selector
+    }))
+  })
+  return runtime
+}
+
+function createdTerminal(handle: string, worktreeId = 'worktree-1'): RuntimeTerminalCreate {
+  return { handle, worktreeId, title: null }
+}
+
+describe('terminal create reservation binding', () => {
+  it('addresses the terminal by the reservation key so a retry re-derives one handle', async () => {
+    const runtime = createRuntimeForDedupe()
+    const create = vi.fn<CreateRun>(async (_selector, handle) =>
+      createdTerminal(handle ?? 'missing')
+    )
+
+    const first = await runtime.dedupeTerminalCreate(
+      'device-a',
+      'id:worktree-1',
+      undefined,
+      false,
+      create,
+      RESERVATION
+    )
+
+    expect(first.handle).toBe(
+      deriveRemoteRuntimeTerminalCreateHandle('device-a', 'worktree-1', 'key-1')
+    )
+    expect(first.reservation).toMatchObject(RESERVATION)
+    expect(typeof first.reservation?.boundAt).toBe('number')
+  })
+
+  it('ignores a fresh transport mutation id so a reserved retry is not a second terminal', async () => {
+    const runtime = createRuntimeForDedupe()
+    const create = vi.fn<CreateRun>(async (_selector, handle) =>
+      createdTerminal(handle ?? 'missing')
+    )
+
+    const first = await runtime.dedupeTerminalCreate(
+      'device-a',
+      'id:worktree-1',
+      'mutation-1',
+      false,
+      create,
+      RESERVATION
+    )
+    const retry = await runtime.dedupeTerminalCreate(
+      'device-a',
+      'id:worktree-1',
+      'mutation-2',
+      false,
+      create,
+      RESERVATION
+    )
+
+    expect(retry.handle).toBe(first.handle)
+    expect(retry.reservation).toEqual(first.reservation)
+  })
+
+  it('refuses a reused key whose ownership generation moved on', async () => {
+    const runtime = createRuntimeForDedupe()
+    const create = vi.fn<CreateRun>(async (_selector, handle) =>
+      createdTerminal(handle ?? 'missing')
+    )
+    await runtime.dedupeTerminalCreate(
+      'device-a',
+      'id:worktree-1',
+      undefined,
+      false,
+      create,
+      RESERVATION
+    )
+
+    await expect(
+      runtime.dedupeTerminalCreate('device-a', 'id:worktree-1', undefined, false, create, {
+        ...RESERVATION,
+        ownershipGeneration: 3
+      })
+    ).rejects.toMatchObject({ code: 'reservation_conflict' })
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses the same key aimed at a second workspace instead of binding twice', async () => {
+    const runtime = createRuntimeForDedupe()
+    const create = vi.fn<CreateRun>(async (_selector, handle) =>
+      createdTerminal(handle ?? 'missing')
+    )
+    await runtime.dedupeTerminalCreate(
+      'device-a',
+      'id:worktree-1',
+      undefined,
+      false,
+      create,
+      RESERVATION
+    )
+
+    await expect(
+      runtime.dedupeTerminalCreate(
+        'device-a',
+        'id:worktree-2',
+        undefined,
+        false,
+        create,
+        RESERVATION
+      )
+    ).rejects.toMatchObject({ code: 'reservation_conflict' })
+  })
+
+  it('leaves the key unused after a failed create so a genuine retry starts fresh', async () => {
+    const runtime = createRuntimeForDedupe()
+    const failing = vi.fn<CreateRun>(async () => {
+      throw new Error('spawn_failed')
+    })
+    const succeeding = vi.fn<CreateRun>(async (_selector, handle) =>
+      createdTerminal(handle ?? 'missing')
+    )
+
+    await expect(
+      runtime.dedupeTerminalCreate(
+        'device-a',
+        'id:worktree-1',
+        undefined,
+        false,
+        failing,
+        RESERVATION
+      )
+    ).rejects.toThrow('spawn_failed')
+
+    const retry = await runtime.dedupeTerminalCreate(
+      'device-a',
+      'id:worktree-1',
+      undefined,
+      false,
+      succeeding,
+      RESERVATION
+    )
+
+    expect(retry.reservation).toMatchObject(RESERVATION)
+  })
+
+  it('refuses a reserved create with no workspace rather than creating an unbound terminal', async () => {
+    const runtime = createRuntimeForDedupe()
+    const create = vi.fn<CreateRun>(async () => createdTerminal('term_x'))
+
+    await expect(
+      runtime.dedupeTerminalCreate('device-a', undefined, undefined, false, create, RESERVATION)
+    ).rejects.toThrow('invalid_argument')
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('leaves an unreserved create with no binding on the result', async () => {
+    const runtime = createRuntimeForDedupe()
+    const create = vi.fn<CreateRun>(async (_selector, handle) =>
+      createdTerminal(handle ?? 'missing')
+    )
+
+    const created = await runtime.dedupeTerminalCreate(
+      'device-a',
+      'id:worktree-1',
+      'mutation-1',
+      false,
+      create
+    )
+
+    expect(created.reservation).toBeUndefined()
+  })
+})

--- a/src/main/runtime/orca-runtime-terminal-create-reservation.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-create-reservation.test.ts
@@ -73,10 +73,20 @@ describe('terminal create reservation binding', () => {
     })
 
     const first = runtime.dedupeTerminalCreate(
-      'device-a', 'id:worktree-1', 'mutation-1', false, create, RESERVATION
+      'device-a',
+      'id:worktree-1',
+      'mutation-1',
+      false,
+      create,
+      RESERVATION
     )
     const reconnect = runtime.dedupeTerminalCreate(
-      'device-b', 'id:worktree-1', 'mutation-2', false, create, RESERVATION
+      'device-b',
+      'id:worktree-1',
+      'mutation-2',
+      false,
+      create,
+      RESERVATION
     )
     releaseCreate()
 
@@ -191,6 +201,32 @@ describe('terminal create reservation binding', () => {
     )
 
     expect(retry.reservation).toMatchObject(RESERVATION)
+  })
+
+  it('preserves both the create and reservation-release errors when cleanup also fails', async () => {
+    const runtime = createRuntimeForDedupe()
+    const createError = new Error('spawn_failed')
+    const releaseError = new Error('reservation_release_persist_failed')
+    const failing = vi.fn<CreateRun>(async () => {
+      throw createError
+    })
+    const release = vi
+      .spyOn(
+        (runtime as unknown as { terminalReservations: TerminalReservationBindings })
+          .terminalReservations,
+        'release'
+      )
+      .mockImplementation(() => {
+        throw releaseError
+      })
+
+    const rejected = await runtime
+      .dedupeTerminalCreate('device-a', 'id:worktree-1', undefined, false, failing, RESERVATION)
+      .catch((error: unknown) => error)
+
+    expect(release).toHaveBeenCalledOnce()
+    expect(rejected).toBeInstanceOf(AggregateError)
+    expect((rejected as AggregateError).errors).toEqual([createError, releaseError])
   })
 
   it('refuses a reserved create with no workspace rather than creating an unbound terminal', async () => {

--- a/src/main/runtime/orca-runtime-terminal-create-reservation.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-create-reservation.test.ts
@@ -55,10 +55,34 @@ describe('terminal create reservation binding', () => {
     )
 
     expect(first.handle).toBe(
-      deriveRemoteRuntimeTerminalCreateHandle('device-a', 'worktree-1', 'key-1')
+      deriveRemoteRuntimeTerminalCreateHandle('reservation:openloop', 'worktree-1', 'key-1')
     )
     expect(first.reservation).toMatchObject(RESERVATION)
     expect(typeof first.reservation?.boundAt).toBe('number')
+  })
+
+  it('uses the same reservation address and one create across changed transports', async () => {
+    const runtime = createRuntimeForDedupe()
+    let releaseCreate!: () => void
+    const gate = new Promise<void>((resolve) => {
+      releaseCreate = resolve
+    })
+    const create = vi.fn<CreateRun>(async (_selector, handle) => {
+      await gate
+      return createdTerminal(handle ?? 'missing')
+    })
+
+    const first = runtime.dedupeTerminalCreate(
+      'device-a', 'id:worktree-1', 'mutation-1', false, create, RESERVATION
+    )
+    const reconnect = runtime.dedupeTerminalCreate(
+      'device-b', 'id:worktree-1', 'mutation-2', false, create, RESERVATION
+    )
+    releaseCreate()
+
+    const [created, replayed] = await Promise.all([first, reconnect])
+    expect(replayed.handle).toBe(created.handle)
+    expect(create).toHaveBeenCalledTimes(1)
   })
 
   it('ignores a fresh transport mutation id so a reserved retry is not a second terminal', async () => {

--- a/src/main/runtime/orca-runtime-terminal-create-reservation.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-create-reservation.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import type { PtyProcessInfo } from '../providers/types'
 import type { RuntimeTerminalCreate } from '../../shared/runtime-types'
 import type { ResourceReservationRequest } from '../../shared/resource-reservation-binding'
@@ -21,15 +24,28 @@ const RESERVATION: ResourceReservationRequest = {
   issuer: 'openloop'
 }
 
-function createRuntimeForDedupe(listProcesses = vi.fn(async (): Promise<PtyProcessInfo[]> => [])) {
+function createRuntimeForDedupe(
+  listProcesses = vi.fn(async (): Promise<PtyProcessInfo[]> => []),
+  terminalReservations = new TerminalReservationBindings()
+) {
+  const handleByPtyId = new Map<string, string>()
   const runtime = Object.create(OrcaRuntimeService.prototype) as OrcaRuntimeService
   Object.assign(runtime, {
     terminalCreateIdempotency: new RemoteRuntimeTerminalCreateIdempotency(),
-    terminalReservations: new TerminalReservationBindings(),
+    terminalReservations,
     ptyController: { listProcesses },
     resolveTerminalWorkspaceLaunchScope: vi.fn(async (selector: string) => ({
       id: selector.startsWith('id:') ? selector.slice(3) : selector
-    }))
+    })),
+    adoptControllerTerminalHandle: vi.fn((ptyId: string, handle: string) => {
+      handleByPtyId.set(ptyId, handle)
+    }),
+    recordPtyWorktree: vi.fn((ptyId: string, worktreeId: string, state: { title?: string }) => ({
+      ptyId,
+      worktreeId,
+      title: state.title ?? null
+    })),
+    issuePtyHandle: vi.fn((pty: { ptyId: string }) => handleByPtyId.get(pty.ptyId))
   })
   return runtime
 }
@@ -93,6 +109,61 @@ describe('terminal create reservation binding', () => {
     const [created, replayed] = await Promise.all([first, reconnect])
     expect(replayed.handle).toBe(created.handle)
     expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  it('reconciles a persisted reservation after restart even when the caller omits the hint', async () => {
+    const profile = mkdtempSync(join(tmpdir(), 'orca-terminal-reservation-'))
+    try {
+      const liveSessions: PtyProcessInfo[] = []
+      const firstRuntime = createRuntimeForDedupe(
+        vi.fn(async () => liveSessions),
+        new TerminalReservationBindings(profile)
+      )
+      const create = vi.fn<CreateRun>(async (_selector, handle) => {
+        liveSessions.push({
+          id: 'worktree-1@@session-a',
+          cwd: '/workspace',
+          title: 'pwsh',
+          worktreeId: 'worktree-1',
+          terminalHandle: handle
+        })
+        return createdTerminal(handle ?? 'missing')
+      })
+      const first = await firstRuntime.dedupeTerminalCreate(
+        'device-a',
+        'id:worktree-1',
+        'mutation-1',
+        false,
+        create,
+        RESERVATION
+      )
+
+      const retryInventory = vi.fn(async () => liveSessions)
+      const restartedRuntime = createRuntimeForDedupe(
+        retryInventory,
+        new TerminalReservationBindings(profile)
+      )
+      const retrySpawn = vi.fn<CreateRun>()
+      const replayed = await restartedRuntime.dedupeTerminalCreate(
+        'device-b',
+        'id:worktree-1',
+        'mutation-2',
+        false,
+        retrySpawn,
+        RESERVATION
+      )
+
+      expect(replayed).toMatchObject({
+        handle: first.handle,
+        ptyId: 'worktree-1@@session-a',
+        reservation: first.reservation
+      })
+      expect(retryInventory).toHaveBeenCalledTimes(1)
+      expect(retrySpawn).not.toHaveBeenCalled()
+      expect(create).toHaveBeenCalledTimes(1)
+    } finally {
+      rmSync(profile, { recursive: true, force: true })
+    }
   })
 
   it('ignores a fresh transport mutation id so a reserved retry is not a second terminal', async () => {

--- a/src/main/runtime/orca-runtime-tests/dedupe-worktree-create.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/dedupe-worktree-create.spec.ts
@@ -3,6 +3,15 @@ import { OrcaRuntimeService } from '../orca-runtime-test-mocks.spec'
 import { store } from '../orca-runtime-test-fixtures.spec'
 
 describe('OrcaRuntimeService.dedupeWorktreeCreate', () => {
+  const reservation = {
+    key: 'key-1',
+    reservationId: 'reservation-1',
+    sessionId: 'session-1',
+    resourceKind: 'worktree' as const,
+    ownershipGeneration: 1,
+    issuer: 'openloop'
+  }
+
   it('coalesces concurrent creates that share a clientMutationId', async () => {
     const runtime = new OrcaRuntimeService(store)
     let calls = 0
@@ -29,6 +38,28 @@ describe('OrcaRuntimeService.dedupeWorktreeCreate', () => {
     const retried = await runtime.dedupeWorktreeCreate('id:r', 'key-1', factory)
     expect(calls).toBe(1)
     expect(retried).toEqual(first)
+  })
+
+  it('rejects a conflicting binding while the reservation result is cached', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const factory = vi.fn(async () => ({ worktree: { id: 'wt' } }))
+    await runtime.dedupeWorktreeCreate('id:r', reservation.key, factory, reservation)
+
+    await expect(
+      runtime.dedupeWorktreeCreate('id:r', reservation.key, factory, {
+        ...reservation,
+        reservationId: 'reservation-2'
+      })
+    ).rejects.toMatchObject({ code: 'reservation_conflict' })
+    expect(factory).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps reservation keys separate from transport mutation ids', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const factory = vi.fn(async () => ({ worktree: { id: `wt-${factory.mock.calls.length}` } }))
+    await runtime.dedupeWorktreeCreate('id:r', reservation.key, factory)
+    await runtime.dedupeWorktreeCreate('id:r', reservation.key, factory, reservation)
+    expect(factory).toHaveBeenCalledTimes(2)
   })
 
   it('expires settled successes after the reconnect window', async () => {

--- a/src/main/runtime/orca-runtime-tests/runtime-availability.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/runtime-availability.spec.ts
@@ -43,6 +43,7 @@ describe('OrcaRuntimeService', () => {
     expect(status.capabilities).toContain('mobile.tasks.v1')
     expect(status.capabilities).toContain('terminal.quick-commands.v1')
     expect(status.capabilities).toContain('worktree.create-idempotency.v1')
+    expect(status.capabilities).toContain('resource.reservation-attribution.v1')
     expect(status.worktreeCreateIdempotency).toEqual({ dedupeTtlMs: 60_000 })
     expect(status.capabilities).toContain('files.mutation-ownership.v1')
     expect(status.capabilities).toContain('project-host-setup.v1')

--- a/src/main/runtime/orca-runtime-write-orchestration-pointer-pty.ts
+++ b/src/main/runtime/orca-runtime-write-orchestration-pointer-pty.ts
@@ -76,6 +76,13 @@ export class OrcaRuntimeWithWriteOrchestrationPointerPty extends OrcaRuntimeWith
     return this.getLeavesForPty(ptyId)[0] ?? null
   }
 
+  /** Projects the create-time reservation onto every show/list row so a caller can read the exact
+   *  binding back from inventory instead of re-deriving attribution. */
+  protected terminalReservationField(handle: string): Pick<RuntimeTerminalSummary, 'reservation'> {
+    const reservation = this.terminalReservations.get(handle)
+    return reservation ? { reservation } : {}
+  }
+
   protected terminalExecutionHostField(
     ptyId: string | null,
     worktreeId: string
@@ -165,8 +172,9 @@ export class OrcaRuntimeWithWriteOrchestrationPointerPty extends OrcaRuntimeWith
       !leaf.ptyId.startsWith('remote:') &&
       parseAppSshPtyId(leaf.ptyId) === null &&
       this.ptyController?.hasPty?.(leaf.ptyId) !== true
+    const handle = this.issueHandle(leaf)
     return {
-      handle: this.issueHandle(leaf),
+      handle,
       ptyId: leaf.ptyId,
       incarnationId: pty?.incarnationId ?? null,
       orphaned: false,
@@ -182,6 +190,7 @@ export class OrcaRuntimeWithWriteOrchestrationPointerPty extends OrcaRuntimeWith
       preview: leaf.preview,
       ...(leaf.lastExitCause ? { exitCause: leaf.lastExitCause } : {}),
       ...this.terminalExecutionHostField(leaf.ptyId, leaf.worktreeId),
+      ...this.terminalReservationField(handle),
       ...this.resolvePaneAgentIdentityField(
         pty?.launchAgent,
         pty?.foregroundAgent,

--- a/src/main/runtime/resource-reservation-conflict.ts
+++ b/src/main/runtime/resource-reservation-conflict.ts
@@ -1,0 +1,17 @@
+import {
+  RESOURCE_RESERVATION_CONFLICT_ERROR,
+  type ResourceReservationKind
+} from '../../shared/resource-reservation-binding'
+
+/** Reusing a single-use reservation key against a different binding. Distinct from a retryable
+ *  transport failure: the caller's ledger, not the connection, is what disagrees. */
+export class ResourceReservationConflictError extends Error {
+  readonly code = RESOURCE_RESERVATION_CONFLICT_ERROR
+  constructor(
+    message: string,
+    readonly data: { resourceKind: ResourceReservationKind; resourceId: string }
+  ) {
+    super(message)
+    this.name = 'ResourceReservationConflictError'
+  }
+}

--- a/src/main/runtime/rpc/errors.ts
+++ b/src/main/runtime/rpc/errors.ts
@@ -23,6 +23,7 @@ import {
 import { GIT_DIFF_TOO_LARGE_CODE } from '../../../shared/git-diff-transport-budget'
 import { AUTOMATION_OWNER_CONFLICT_CODES } from '../../../shared/automation-owner-conflict'
 import { NESTED_WORKER_DEPTH_EXCEEDED_CODE } from '../../../shared/nested-worker-depth'
+import { RESOURCE_RESERVATION_CONFLICT_ERROR } from '../../../shared/resource-reservation-binding'
 
 export function successResponse(id: string, meta: RpcEnvelopeMeta, result: unknown): RpcSuccess {
   return {
@@ -137,7 +138,9 @@ const STRUCTURED_RUNTIME_PASSTHROUGH_CODES: ReadonlySet<string> = new Set([
   SKILL_INSTALL_RPC_ERROR_CODE,
   // Why: an owner conflict is a distinct client decision (reload the host, re-adopt,
   // stop offering the action) — flattened to runtime_error it can only be guessed at.
-  ...Object.values(AUTOMATION_OWNER_CONFLICT_CODES)
+  ...Object.values(AUTOMATION_OWNER_CONFLICT_CODES),
+  // A conflicting durable reservation is a caller-ledger error, not a retryable runtime failure.
+  RESOURCE_RESERVATION_CONFLICT_ERROR
 ])
 
 export function mapRuntimeError(id: string, meta: RpcEnvelopeMeta, error: unknown): RpcFailure {

--- a/src/main/runtime/rpc/methods/agent-session.test.ts
+++ b/src/main/runtime/rpc/methods/agent-session.test.ts
@@ -227,7 +227,8 @@ describe('agent session RPC methods', () => {
       'id:worktree-1',
       undefined,
       false,
-      expect.any(Function)
+      expect.any(Function),
+      undefined
     )
     expect(createTerminal).toHaveBeenCalledWith('id:worktree-1', {
       command: 'codex resume provider-session-1',

--- a/src/main/runtime/rpc/methods/terminal-create-idempotency.test.ts
+++ b/src/main/runtime/rpc/methods/terminal-create-idempotency.test.ts
@@ -44,7 +44,8 @@ describe('terminal.create RPC idempotency', () => {
       'id:worktree-1',
       'mutation-1',
       false,
-      expect.any(Function)
+      expect.any(Function),
+      undefined
     )
     expect(createTerminal).toHaveBeenCalledWith(
       'id:worktree-1',

--- a/src/main/runtime/rpc/methods/terminal-create-idempotency.test.ts
+++ b/src/main/runtime/rpc/methods/terminal-create-idempotency.test.ts
@@ -3,6 +3,43 @@ import type { RpcContext } from '../core'
 import { TERMINAL_METHODS } from './terminal'
 
 describe('terminal.create RPC idempotency', () => {
+  it('accepts a reservation without requiring the reconciliation hint', async () => {
+    const terminal = { handle: 'terminal-1', worktreeId: 'worktree-1', title: null }
+    const createTerminal = vi.fn(async () => terminal)
+    const dedupeTerminalCreate = vi.fn(async () => terminal)
+    const reservation = {
+      key: 'reservation-key',
+      reservationId: 'reservation-1',
+      sessionId: 'session-1',
+      resourceKind: 'terminal' as const,
+      ownershipGeneration: 1,
+      issuer: 'openloop'
+    }
+    const method = TERMINAL_METHODS.find((candidate) => candidate.name === 'terminal.create')
+    if (!method) {
+      throw new Error('terminal.create method missing')
+    }
+
+    const result = await method.handler(
+      { worktree: 'id:worktree-1', reservation },
+      {
+        runtime: { createTerminal, dedupeTerminalCreate },
+        pairedDeviceId: 'device-a'
+      } as unknown as RpcContext,
+      vi.fn()
+    )
+
+    expect(dedupeTerminalCreate).toHaveBeenCalledWith(
+      'device-a',
+      'id:worktree-1',
+      undefined,
+      false,
+      expect.any(Function),
+      reservation
+    )
+    expect(result).toEqual({ terminal })
+  })
+
   it('scopes the mutation key to the authenticated paired device and worktree', async () => {
     const terminal = { handle: 'terminal-1', worktreeId: 'worktree-1', title: null }
     const createTerminal = vi.fn(async () => terminal)

--- a/src/main/runtime/rpc/methods/terminal/terminal-lifecycle-methods.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-lifecycle-methods.ts
@@ -73,7 +73,8 @@ export const TERMINAL_LIFECYCLE_METHODS: RpcAnyMethod[] = [
               tabId: params.tabId,
               leafId: params.leafId,
               ...(preAllocatedHandle ? { preAllocatedHandle } : {})
-            })
+            }),
+          params.reservation
         )
       }
     }

--- a/src/main/runtime/rpc/methods/terminal/unary-schemas.ts
+++ b/src/main/runtime/rpc/methods/terminal/unary-schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { OptionalFiniteNumber, OptionalString, requiredString } from '../../schemas'
 import { TERMINAL_PANE_SPLIT_SOURCES } from '../../../../../shared/feature-education-telemetry'
 import { isTuiAgent } from '../../../../../shared/tui-agent-config'
+import { ResourceReservationRequestSchema } from '../../../../../shared/resource-reservation-binding'
 
 export const TerminalHandle = z.object({
   terminal: requiredString('Missing terminal handle'),
@@ -142,6 +143,13 @@ export const TerminalWait = TerminalHandle.extend({
 export const TerminalCreateParams = z.object({
   worktree: OptionalString,
   clientMutationId: z.string().min(1).max(128).optional(),
+  // Why: a caller-generated single-use key plus its ledger binding. Gated by
+  // RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY because an older host drops this object
+  // and answers with a terminal the caller cannot attribute.
+  reservation: ResourceReservationRequestSchema.refine(
+    (value) => value.resourceKind === 'terminal',
+    { message: 'reservation.resourceKind must be "terminal" on terminal.create' }
+  ).optional(),
   reconcileExisting: z.boolean().optional(),
   command: OptionalString,
   startupCommandDelivery: z.enum(['fast', 'shell-ready']).optional(),

--- a/src/main/runtime/rpc/methods/worktree-create-args.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-args.ts
@@ -7,7 +7,7 @@ type WorktreeCreateParams = z.infer<typeof WorktreeCreate>
 type ManagedWorktreeCreateArgs = Parameters<OrcaRuntimeService['createManagedWorktree']>[0]
 type CreateProvenance = Pick<
   ManagedWorktreeCreateArgs,
-  'automationProvenance' | 'cliProvenance' | 'creatorProvenance'
+  'automationProvenance' | 'cliProvenance' | 'creatorProvenance' | 'reservation'
 >
 
 /** Wire params → runtime create args. Kept out of the method table so the mapping can grow with

--- a/src/main/runtime/rpc/methods/worktree-create-replay-receipt.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-replay-receipt.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RpcDispatcher } from '../dispatcher'
+import type { RpcRequest } from '../core'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { WORKTREE_METHODS } from './worktree'
+
+const makeRequest = (params: unknown): RpcRequest => ({
+  id: 'req-1',
+  authToken: 'tok',
+  method: 'worktree.create',
+  params
+})
+
+describe('worktree.create reservation replay receipt', () => {
+  it('persists non-derivable response metadata before returning success', async () => {
+    const recordReceipt = vi.fn()
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      dedupeWorktreeCreate: <T>(_repo: string, _id: string, run: () => Promise<T>) => run(),
+      findManagedWorktreeReservation: vi.fn(() => ({ outcome: 'unbound' })),
+      showRepo: vi.fn().mockResolvedValue({
+        id: 'repo-1',
+        path: '/workspace/repo',
+        displayName: 'repo',
+        badgeColor: '#000',
+        addedAt: 1,
+        kind: 'git',
+        executionHostId: 'local'
+      }),
+      createManagedWorktree: vi.fn().mockResolvedValue({
+        worktree: { id: 'wt-1', hostId: 'local' },
+        warnings: [],
+        startupTerminal: { spawned: true, handle: 'term_agent', surface: 'background' }
+      }),
+      recordWorktreeReservationCreateReceipt: recordReceipt
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest({
+        repo: 'repo-1',
+        name: 'reserved-agent-startup',
+        startupAgent: 'codex',
+        reservation: {
+          key: 'key-1',
+          reservationId: 'res-1',
+          sessionId: 'session-1',
+          resourceKind: 'worktree',
+          ownershipGeneration: 1
+        }
+      })
+    )
+
+    expect(recordReceipt).toHaveBeenCalledWith('wt-1', 'local', {
+      version: 1,
+      warnings: [],
+      startupTerminal: { spawned: true, handle: 'term_agent', surface: 'background' },
+      agentTerminalHandle: 'term_agent'
+    })
+    expect(response).toMatchObject({ ok: true, result: { agentTerminalHandle: 'term_agent' } })
+  })
+})

--- a/src/main/runtime/rpc/methods/worktree-create-reservation.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-reservation.test.ts
@@ -3,7 +3,10 @@ import { buildResourceReservationBinding } from '../../../../shared/resource-res
 import type { ResourceReservationRequest } from '../../../../shared/resource-reservation-binding'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import { WorktreeCreate } from './worktree-create-schemas'
-import { replayReservedManagedWorktree } from './worktree-create-reservation'
+import {
+  recordWorktreeReservationCreateReceiptOrRollback,
+  replayReservedManagedWorktree
+} from './worktree-create-reservation'
 
 const REQUEST: ResourceReservationRequest = {
   key: 'key-1',
@@ -151,5 +154,45 @@ describe('worktree.create reservation schema', () => {
     })
 
     expect(parsed.success).toBe(false)
+  })
+})
+
+describe('worktree.create reservation receipt persistence', () => {
+  it('rolls back a created worktree when receipt persistence fails', async () => {
+    const persistenceError = new Error('receipt disk full')
+    const removeManagedWorktree = vi.fn().mockResolvedValue({ removed: true })
+
+    await expect(
+      recordWorktreeReservationCreateReceiptOrRollback(
+        {
+          recordWorktreeReservationCreateReceipt: vi.fn(() => {
+            throw persistenceError
+          }),
+          removeManagedWorktree
+        } as never,
+        { worktreeId: 'repo-1::/tmp/wt', hostId: 'local', receipt: { version: 1, warnings: [] } }
+      )
+    ).rejects.toBe(persistenceError)
+    expect(removeManagedWorktree).toHaveBeenCalledWith(
+      'id:repo-1::/tmp/wt',
+      true,
+      false,
+      true,
+      'local'
+    )
+  })
+
+  it('preserves both receipt and rollback failures', async () => {
+    await expect(
+      recordWorktreeReservationCreateReceiptOrRollback(
+        {
+          recordWorktreeReservationCreateReceipt: vi.fn(() => {
+            throw new Error('receipt disk full')
+          }),
+          removeManagedWorktree: vi.fn().mockRejectedValue(new Error('rollback failed'))
+        } as never,
+        { worktreeId: 'repo-1::/tmp/wt', receipt: { version: 1, warnings: [] } }
+      )
+    ).rejects.toBeInstanceOf(AggregateError)
   })
 })

--- a/src/main/runtime/rpc/methods/worktree-create-reservation.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-reservation.test.ts
@@ -17,7 +17,12 @@ const BINDING = buildResourceReservationBinding(REQUEST, { boundAt: 5 })
 
 function runtimeWith(
   lookup: ReturnType<OrcaRuntimeService['findManagedWorktreeReservation']>,
-  worktree: unknown = { id: 'repo-1::/tmp/wt', reservation: BINDING, lineage: null }
+  worktree: unknown = {
+    id: 'repo-1::/tmp/wt',
+    reservation: BINDING,
+    lineage: null,
+    reservationCreateReceipt: { version: 1, warnings: [] }
+  }
 ) {
   return {
     findManagedWorktreeReservation: vi.fn(() => lookup),
@@ -54,6 +59,52 @@ describe('worktree.create reservation replay', () => {
     )
     expect(result?.worktree.reservation).toEqual(BINDING)
     expect(result?.warnings).toEqual([])
+  })
+
+  it('replays durable startup-terminal and agent-handle response metadata', async () => {
+    const startupTerminal = { spawned: true, handle: 'term_agent', surface: 'background' as const }
+    const runtime = runtimeWith(
+      {
+        outcome: 'replay',
+        worktreeId: 'repo-1::/tmp/wt',
+        hostId: 'local',
+        instanceId: 'instance-1',
+        binding: BINDING
+      },
+      {
+        id: 'repo-1::/tmp/wt',
+        reservation: BINDING,
+        lineage: null,
+        reservationCreateReceipt: {
+          version: 1,
+          warnings: [],
+          startupTerminal,
+          agentTerminalHandle: 'term_agent'
+        }
+      }
+    )
+
+    await expect(replayReservedManagedWorktree(runtime, REQUEST)).resolves.toMatchObject({
+      startupTerminal,
+      agentTerminalHandle: 'term_agent'
+    })
+  })
+
+  it('fails loudly when a bound worktree lacks its durable replay receipt', async () => {
+    const runtime = runtimeWith(
+      {
+        outcome: 'replay',
+        worktreeId: 'repo-1::/tmp/wt',
+        hostId: 'local',
+        instanceId: 'instance-1',
+        binding: BINDING
+      },
+      { id: 'repo-1::/tmp/wt', reservation: BINDING, lineage: null }
+    )
+
+    await expect(replayReservedManagedWorktree(runtime, REQUEST)).rejects.toThrow(
+      'no valid durable create receipt'
+    )
   })
 
   it('refuses a reused key whose binding disagrees rather than replaying it', async () => {

--- a/src/main/runtime/rpc/methods/worktree-create-reservation.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-reservation.test.ts
@@ -21,8 +21,11 @@ function runtimeWith(
 ) {
   return {
     findManagedWorktreeReservation: vi.fn(() => lookup),
-    showManagedWorktree: vi.fn(async () => worktree)
-  } as unknown as Pick<OrcaRuntimeService, 'findManagedWorktreeReservation' | 'showManagedWorktree'>
+    showReservedManagedWorktree: vi.fn(async () => worktree)
+  } as unknown as Pick<
+    OrcaRuntimeService,
+    'findManagedWorktreeReservation' | 'showReservedManagedWorktree'
+  >
 }
 
 describe('worktree.create reservation replay', () => {
@@ -30,19 +33,25 @@ describe('worktree.create reservation replay', () => {
     const runtime = runtimeWith({ outcome: 'unbound' })
 
     await expect(replayReservedManagedWorktree(runtime, REQUEST)).resolves.toBeNull()
-    expect(runtime.showManagedWorktree).not.toHaveBeenCalled()
+    expect(runtime.showReservedManagedWorktree).not.toHaveBeenCalled()
   })
 
   it('returns the already-bound workspace instead of creating a second one', async () => {
     const runtime = runtimeWith({
       outcome: 'replay',
       worktreeId: 'repo-1::/tmp/wt',
+      hostId: 'local',
+      instanceId: 'instance-1',
       binding: BINDING
     })
 
     const result = await replayReservedManagedWorktree(runtime, REQUEST)
 
-    expect(runtime.showManagedWorktree).toHaveBeenCalledWith('id:repo-1::/tmp/wt')
+    expect(runtime.showReservedManagedWorktree).toHaveBeenCalledWith(
+      'repo-1::/tmp/wt',
+      'local',
+      'instance-1'
+    )
     expect(result?.worktree.reservation).toEqual(BINDING)
     expect(result?.warnings).toEqual([])
   })
@@ -58,7 +67,7 @@ describe('worktree.create reservation replay', () => {
       code: 'reservation_conflict',
       data: { resourceKind: 'worktree', resourceId: 'repo-1::/tmp/wt' }
     })
-    expect(runtime.showManagedWorktree).not.toHaveBeenCalled()
+    expect(runtime.showReservedManagedWorktree).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/runtime/rpc/methods/worktree-create-reservation.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-reservation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildResourceReservationBinding } from '../../../../shared/resource-reservation-binding'
+import type { ResourceReservationRequest } from '../../../../shared/resource-reservation-binding'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { WorktreeCreate } from './worktree-create-schemas'
+import { replayReservedManagedWorktree } from './worktree-create-reservation'
+
+const REQUEST: ResourceReservationRequest = {
+  key: 'key-1',
+  reservationId: 'res-1',
+  sessionId: 'session-1',
+  resourceKind: 'worktree',
+  ownershipGeneration: 2
+}
+
+const BINDING = buildResourceReservationBinding(REQUEST, { boundAt: 5 })
+
+function runtimeWith(
+  lookup: ReturnType<OrcaRuntimeService['findManagedWorktreeReservation']>,
+  worktree: unknown = { id: 'repo-1::/tmp/wt', reservation: BINDING, lineage: null }
+) {
+  return {
+    findManagedWorktreeReservation: vi.fn(() => lookup),
+    showManagedWorktree: vi.fn(async () => worktree)
+  } as unknown as Pick<OrcaRuntimeService, 'findManagedWorktreeReservation' | 'showManagedWorktree'>
+}
+
+describe('worktree.create reservation replay', () => {
+  it('lets an unused key fall through to a real create', async () => {
+    const runtime = runtimeWith({ outcome: 'unbound' })
+
+    await expect(replayReservedManagedWorktree(runtime, REQUEST)).resolves.toBeNull()
+    expect(runtime.showManagedWorktree).not.toHaveBeenCalled()
+  })
+
+  it('returns the already-bound workspace instead of creating a second one', async () => {
+    const runtime = runtimeWith({
+      outcome: 'replay',
+      worktreeId: 'repo-1::/tmp/wt',
+      binding: BINDING
+    })
+
+    const result = await replayReservedManagedWorktree(runtime, REQUEST)
+
+    expect(runtime.showManagedWorktree).toHaveBeenCalledWith('id:repo-1::/tmp/wt')
+    expect(result?.worktree.reservation).toEqual(BINDING)
+    expect(result?.warnings).toEqual([])
+  })
+
+  it('refuses a reused key whose binding disagrees rather than replaying it', async () => {
+    const runtime = runtimeWith({
+      outcome: 'conflict',
+      worktreeId: 'repo-1::/tmp/wt',
+      message: 'Reservation key "key-1" is already bound'
+    })
+
+    await expect(replayReservedManagedWorktree(runtime, REQUEST)).rejects.toMatchObject({
+      code: 'reservation_conflict',
+      data: { resourceKind: 'worktree', resourceId: 'repo-1::/tmp/wt' }
+    })
+    expect(runtime.showManagedWorktree).not.toHaveBeenCalled()
+  })
+})
+
+describe('worktree.create reservation schema', () => {
+  it('refuses a terminal reservation aimed at the workspace create surface', () => {
+    const parsed = WorktreeCreate.safeParse({
+      repo: 'id:repo-1',
+      name: 'child',
+      reservation: { ...REQUEST, resourceKind: 'terminal' }
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it('accepts a workspace reservation', () => {
+    const parsed = WorktreeCreate.safeParse({
+      repo: 'id:repo-1',
+      name: 'child',
+      reservation: REQUEST
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+
+  it('refuses a reservation missing its ledger fields', () => {
+    const parsed = WorktreeCreate.safeParse({
+      repo: 'id:repo-1',
+      name: 'child',
+      reservation: { key: 'key-1', resourceKind: 'worktree', ownershipGeneration: 1 }
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+})

--- a/src/main/runtime/rpc/methods/worktree-create-reservation.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-reservation.ts
@@ -1,0 +1,31 @@
+import type { ResourceReservationRequest } from '../../../../shared/resource-reservation-binding'
+import type { RuntimeWorktreeCreateResult } from '../../../../shared/runtime-types'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { ResourceReservationConflictError } from '../../resource-reservation-conflict'
+
+/** Returns the workspace an earlier create already bound to this key, or null when the key is
+ *  unused. Throws on a reused key whose binding disagrees — a conflict is never a silent replay. */
+export async function replayReservedManagedWorktree(
+  runtime: Pick<OrcaRuntimeService, 'findManagedWorktreeReservation' | 'showManagedWorktree'>,
+  request: ResourceReservationRequest
+): Promise<RuntimeWorktreeCreateResult | null> {
+  const lookup = runtime.findManagedWorktreeReservation(request)
+  if (lookup.outcome === 'conflict') {
+    throw new ResourceReservationConflictError(lookup.message, {
+      resourceKind: 'worktree',
+      resourceId: lookup.worktreeId
+    })
+  }
+  if (lookup.outcome === 'unbound') {
+    return null
+  }
+  const worktree = await runtime.showManagedWorktree(`id:${lookup.worktreeId}`)
+  return {
+    worktree,
+    lineage: worktree.lineage ?? null,
+    ...(worktree.workspaceLineage !== undefined
+      ? { workspaceLineage: worktree.workspaceLineage }
+      : {}),
+    warnings: []
+  }
+}

--- a/src/main/runtime/rpc/methods/worktree-create-reservation.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-reservation.ts
@@ -2,6 +2,8 @@ import type { ResourceReservationRequest } from '../../../../shared/resource-res
 import type { RuntimeWorktreeCreateResult } from '../../../../shared/runtime-types'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import { ResourceReservationConflictError } from '../../resource-reservation-conflict'
+import { WorktreeReservationCreateReceiptSchema } from '../../../../shared/worktree/reservation-create-receipt'
+import type { WorktreeReservationCreateReceipt } from '../../../../shared/worktree/reservation-create-receipt'
 
 /** Returns the workspace an earlier create already bound to this key, or null when the key is
  *  unused. Throws on a reused key whose binding disagrees — a conflict is never a silent replay. */
@@ -27,12 +29,15 @@ export async function replayReservedManagedWorktree(
     lookup.hostId,
     lookup.instanceId
   )
-  const receipt = worktree.reservationCreateReceipt
-  if (!receipt || receipt.version !== 1) {
+  const receiptResult = WorktreeReservationCreateReceiptSchema.safeParse(
+    worktree.reservationCreateReceipt
+  )
+  if (!receiptResult.success) {
     throw new Error(
-      `Reserved worktree ${lookup.worktreeId} has no valid durable create receipt for reservation replay`
+      `Reserved worktree ${lookup.worktreeId} has no valid durable create receipt for reservation replay: ${receiptResult.error.message}`
     )
   }
+  const receipt = receiptResult.data
   return {
     worktree,
     lineage: worktree.lineage ?? null,
@@ -43,5 +48,32 @@ export async function replayReservedManagedWorktree(
     ...(receipt.warning !== undefined ? { warning: receipt.warning } : {}),
     ...(receipt.startupTerminal ? { startupTerminal: receipt.startupTerminal } : {}),
     ...(receipt.agentTerminalHandle ? { agentTerminalHandle: receipt.agentTerminalHandle } : {})
+  }
+}
+
+/** Makes a receipt-write failure recoverable by removing the just-created bound worktree. */
+export async function recordWorktreeReservationCreateReceiptOrRollback(
+  runtime: Pick<
+    OrcaRuntimeService,
+    'recordWorktreeReservationCreateReceipt' | 'removeManagedWorktree'
+  >,
+  args: {
+    worktreeId: string
+    hostId?: string
+    receipt: WorktreeReservationCreateReceipt
+  }
+): Promise<void> {
+  try {
+    runtime.recordWorktreeReservationCreateReceipt(args.worktreeId, args.hostId, args.receipt)
+  } catch (receiptError) {
+    try {
+      await runtime.removeManagedWorktree(`id:${args.worktreeId}`, true, false, true, args.hostId)
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [receiptError, rollbackError],
+        `Worktree reservation receipt persistence and rollback failed for ${args.worktreeId}`
+      )
+    }
+    throw receiptError
   }
 }

--- a/src/main/runtime/rpc/methods/worktree-create-reservation.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-reservation.ts
@@ -6,7 +6,10 @@ import { ResourceReservationConflictError } from '../../resource-reservation-con
 /** Returns the workspace an earlier create already bound to this key, or null when the key is
  *  unused. Throws on a reused key whose binding disagrees — a conflict is never a silent replay. */
 export async function replayReservedManagedWorktree(
-  runtime: Pick<OrcaRuntimeService, 'findManagedWorktreeReservation' | 'showReservedManagedWorktree'>,
+  runtime: Pick<
+    OrcaRuntimeService,
+    'findManagedWorktreeReservation' | 'showReservedManagedWorktree'
+  >,
   request: ResourceReservationRequest
 ): Promise<RuntimeWorktreeCreateResult | null> {
   const lookup = runtime.findManagedWorktreeReservation(request)
@@ -24,12 +27,21 @@ export async function replayReservedManagedWorktree(
     lookup.hostId,
     lookup.instanceId
   )
+  const receipt = worktree.reservationCreateReceipt
+  if (!receipt || receipt.version !== 1) {
+    throw new Error(
+      `Reserved worktree ${lookup.worktreeId} has no valid durable create receipt for reservation replay`
+    )
+  }
   return {
     worktree,
     lineage: worktree.lineage ?? null,
     ...(worktree.workspaceLineage !== undefined
       ? { workspaceLineage: worktree.workspaceLineage }
       : {}),
-    warnings: []
+    warnings: receipt.warnings,
+    ...(receipt.warning !== undefined ? { warning: receipt.warning } : {}),
+    ...(receipt.startupTerminal ? { startupTerminal: receipt.startupTerminal } : {}),
+    ...(receipt.agentTerminalHandle ? { agentTerminalHandle: receipt.agentTerminalHandle } : {})
   }
 }

--- a/src/main/runtime/rpc/methods/worktree-create-reservation.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-reservation.ts
@@ -6,7 +6,7 @@ import { ResourceReservationConflictError } from '../../resource-reservation-con
 /** Returns the workspace an earlier create already bound to this key, or null when the key is
  *  unused. Throws on a reused key whose binding disagrees — a conflict is never a silent replay. */
 export async function replayReservedManagedWorktree(
-  runtime: Pick<OrcaRuntimeService, 'findManagedWorktreeReservation' | 'showManagedWorktree'>,
+  runtime: Pick<OrcaRuntimeService, 'findManagedWorktreeReservation' | 'showReservedManagedWorktree'>,
   request: ResourceReservationRequest
 ): Promise<RuntimeWorktreeCreateResult | null> {
   const lookup = runtime.findManagedWorktreeReservation(request)
@@ -19,7 +19,11 @@ export async function replayReservedManagedWorktree(
   if (lookup.outcome === 'unbound') {
     return null
   }
-  const worktree = await runtime.showManagedWorktree(`id:${lookup.worktreeId}`)
+  const worktree = await runtime.showReservedManagedWorktree(
+    lookup.worktreeId,
+    lookup.hostId,
+    lookup.instanceId
+  )
   return {
     worktree,
     lineage: worktree.lineage ?? null,

--- a/src/main/runtime/rpc/methods/worktree-create-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-schemas.ts
@@ -11,6 +11,7 @@ import {
   OptionalString,
   TriStateLinkedIssue
 } from '../schemas'
+import { ResourceReservationRequestSchema } from '../../../../shared/resource-reservation-binding'
 import {
   assertLinkedWorkItemSourceContextMatch,
   AutomationWorkspaceProvenanceRequest,
@@ -120,6 +121,10 @@ export const WorktreeCreate = z
     // Why: mobile retries a create interrupted by a connection migration with the
     // same key so the host dedupes instead of spawning a duplicate worktree.
     clientMutationId: z.string().min(1).max(128).optional(),
+    // Why: a caller-generated single-use key plus its ledger binding, persisted atomically with
+    // the workspace. Gated by RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY because an
+    // older host silently drops this object and answers with an unattributable workspace.
+    reservation: ResourceReservationRequestSchema.optional(),
     automationProvenanceRequest: AutomationWorkspaceProvenanceRequest.optional(),
     cliProvenanceRequest: CliWorkspaceProvenanceRequest.optional()
   })
@@ -135,6 +140,12 @@ export const WorktreeCreate = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Choose either one parent selector or --no-parent.'
+      })
+    }
+    if (params.reservation && params.reservation.resourceKind !== 'worktree') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'reservation.resourceKind must be "worktree" on worktree.create'
       })
     }
     if (params.startupPrompt !== undefined && params.startupAgent === undefined) {

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -128,9 +128,32 @@ export const WORKTREE_METHODS: RpcMethod[] = [
             finishAutomationWorkspaceProvenanceRequest(params.automationProvenanceRequest)
             // Why: agent callers need a stable dispatch target without traversing
             // terminal-list layout duplicates after creating the worktree.
-            return params.startupAgent && result.startupTerminal?.handle
-              ? { ...result, agentTerminalHandle: result.startupTerminal.handle }
-              : result
+            const response = {
+              ...result,
+              warnings: result.warnings ?? [],
+              agentTerminalHandle:
+                params.startupAgent && result.startupTerminal?.handle
+                  ? result.startupTerminal.handle
+                  : undefined
+            }
+            if (params.reservation) {
+              runtime.recordWorktreeReservationCreateReceipt(
+                result.worktree.id,
+                result.worktree.identity?.executionHostId ?? result.worktree.hostId,
+                {
+                  version: 1,
+                  warnings: response.warnings,
+                  ...(response.warning !== undefined ? { warning: response.warning } : {}),
+                  ...(response.startupTerminal
+                    ? { startupTerminal: response.startupTerminal }
+                    : {}),
+                  ...(response.agentTerminalHandle
+                    ? { agentTerminalHandle: response.agentTerminalHandle }
+                    : {})
+                }
+              )
+            }
+            return response
           } catch (error) {
             releaseAutomationWorkspaceProvenanceRequest(params.automationProvenanceRequest)
             throw error

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -85,7 +85,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
       // one in-flight create, not race past the durable replay lookup below and both create.
       context.runtime.dedupeWorktreeCreate(
         params.repo,
-        params.clientMutationId ?? params.reservation?.key,
+        params.reservation?.key ?? params.clientMutationId,
         async () => {
           const { runtime } = context
           const replay = params.reservation

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -135,7 +135,8 @@ export const WORKTREE_METHODS: RpcMethod[] = [
             releaseAutomationWorkspaceProvenanceRequest(params.automationProvenanceRequest)
             throw error
           }
-        }
+        },
+        params.reservation
       )
   }),
   defineMethod({

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -23,6 +23,8 @@ import {
   WorktreeTeardownMissingTerminalsParams
 } from './worktree-schemas'
 import { WORKTREE_CATALOG_METHODS } from './worktree-catalog-methods'
+import { replayReservedManagedWorktree } from './worktree-create-reservation'
+import { buildResourceReservationBinding } from '../../../../shared/resource-reservation-binding'
 
 export const WORKTREE_METHODS: RpcMethod[] = [
   ...WORKTREE_CATALOG_METHODS,
@@ -79,43 +81,62 @@ export const WORKTREE_METHODS: RpcMethod[] = [
       // Why: a mobile create interrupted by a connection migration is retried with
       // the same clientMutationId; dedupe so the host returns the in-flight/created
       // worktree instead of spawning a duplicate. No key (desktop/CLI) runs plainly.
-      context.runtime.dedupeWorktreeCreate(params.repo, params.clientMutationId, async () => {
-        const { runtime } = context
-        const repo = await runtime.showRepo(params.repo)
-        const automationProvenance = resolveAutomationWorkspaceProvenance({
-          authority: runtime,
-          repoSelector: params.repo,
-          repo,
-          request: params.automationProvenanceRequest
-        })
-        // Why: provenance tokens are reserved before creation so retries can recover,
-        // but failed create attempts must release the reservation for a safe retry.
-        try {
-          const result = await runtime.createManagedWorktree(
-            buildManagedWorktreeCreateArgs(
-              params,
-              {
-                automationProvenance,
-                cliProvenance: buildCliWorkspaceProvenance(params.cliProvenanceRequest, {
-                  startupAgent: params.startupAgent ?? params.createdWithAgent,
-                  createdAt: Date.now()
-                }),
-                creatorProvenance: resolveRpcWorkspaceCreatorProvenance(context)
-              },
-              context.clientKind ? { clientKind: context.clientKind } : {}
+      // Why the reservation key also feeds the dedupe: two concurrent retries must collapse onto
+      // one in-flight create, not race past the durable replay lookup below and both create.
+      context.runtime.dedupeWorktreeCreate(
+        params.repo,
+        params.clientMutationId ?? params.reservation?.key,
+        async () => {
+          const { runtime } = context
+          const replay = params.reservation
+            ? await replayReservedManagedWorktree(runtime, params.reservation)
+            : null
+          if (replay) {
+            return replay
+          }
+          const repo = await runtime.showRepo(params.repo)
+          const automationProvenance = resolveAutomationWorkspaceProvenance({
+            authority: runtime,
+            repoSelector: params.repo,
+            repo,
+            request: params.automationProvenanceRequest
+          })
+          // Why: provenance tokens are reserved before creation so retries can recover,
+          // but failed create attempts must release the reservation for a safe retry.
+          try {
+            const result = await runtime.createManagedWorktree(
+              buildManagedWorktreeCreateArgs(
+                params,
+                {
+                  automationProvenance,
+                  cliProvenance: buildCliWorkspaceProvenance(params.cliProvenanceRequest, {
+                    startupAgent: params.startupAgent ?? params.createdWithAgent,
+                    createdAt: Date.now()
+                  }),
+                  creatorProvenance: resolveRpcWorkspaceCreatorProvenance(context),
+                  ...(params.reservation
+                    ? {
+                        reservation: buildResourceReservationBinding(params.reservation, {
+                          boundAt: Date.now()
+                        })
+                      }
+                    : {})
+                },
+                context.clientKind ? { clientKind: context.clientKind } : {}
+              )
             )
-          )
-          finishAutomationWorkspaceProvenanceRequest(params.automationProvenanceRequest)
-          // Why: agent callers need a stable dispatch target without traversing
-          // terminal-list layout duplicates after creating the worktree.
-          return params.startupAgent && result.startupTerminal?.handle
-            ? { ...result, agentTerminalHandle: result.startupTerminal.handle }
-            : result
-        } catch (error) {
-          releaseAutomationWorkspaceProvenanceRequest(params.automationProvenanceRequest)
-          throw error
+            finishAutomationWorkspaceProvenanceRequest(params.automationProvenanceRequest)
+            // Why: agent callers need a stable dispatch target without traversing
+            // terminal-list layout duplicates after creating the worktree.
+            return params.startupAgent && result.startupTerminal?.handle
+              ? { ...result, agentTerminalHandle: result.startupTerminal.handle }
+              : result
+          } catch (error) {
+            releaseAutomationWorkspaceProvenanceRequest(params.automationProvenanceRequest)
+            throw error
+          }
         }
-      })
+      )
   }),
   defineMethod({
     name: 'worktree.prefetchCreateBase',

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -23,7 +23,10 @@ import {
   WorktreeTeardownMissingTerminalsParams
 } from './worktree-schemas'
 import { WORKTREE_CATALOG_METHODS } from './worktree-catalog-methods'
-import { replayReservedManagedWorktree } from './worktree-create-reservation'
+import {
+  recordWorktreeReservationCreateReceiptOrRollback,
+  replayReservedManagedWorktree
+} from './worktree-create-reservation'
 import { buildResourceReservationBinding } from '../../../../shared/resource-reservation-binding'
 
 export const WORKTREE_METHODS: RpcMethod[] = [
@@ -137,10 +140,10 @@ export const WORKTREE_METHODS: RpcMethod[] = [
                   : undefined
             }
             if (params.reservation) {
-              runtime.recordWorktreeReservationCreateReceipt(
-                result.worktree.id,
-                result.worktree.identity?.executionHostId ?? result.worktree.hostId,
-                {
+              await recordWorktreeReservationCreateReceiptOrRollback(runtime, {
+                worktreeId: result.worktree.id,
+                hostId: result.worktree.identity?.executionHostId ?? result.worktree.hostId,
+                receipt: {
                   version: 1,
                   warnings: response.warnings,
                   ...(response.warning !== undefined ? { warning: response.warning } : {}),
@@ -151,7 +154,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
                     ? { agentTerminalHandle: response.agentTerminalHandle }
                     : {})
                 }
-              )
+              })
             }
             return response
           } catch (error) {

--- a/src/main/runtime/runtime-folder-workspace.ts
+++ b/src/main/runtime/runtime-folder-workspace.ts
@@ -68,6 +68,7 @@ export function mergeRuntimeFolderWorkspace(
       ? { automationProvenance: meta.automationProvenance }
       : {}),
     ...(meta.cliProvenance !== undefined ? { cliProvenance: meta.cliProvenance } : {}),
+    ...(meta.reservation !== undefined ? { reservation: meta.reservation } : {}),
     ...(meta.priorWorktreeIds !== undefined ? { priorWorktreeIds: meta.priorWorktreeIds } : {}),
     workspaceStatus: meta.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
     diffComments: meta.diffComments,

--- a/src/main/runtime/runtime-folder-worktree-create.ts
+++ b/src/main/runtime/runtime-folder-worktree-create.ts
@@ -83,6 +83,7 @@ export async function createRuntimeFolderWorktree(args: {
     },
     ...(request.automationProvenance ? { automationProvenance: request.automationProvenance } : {}),
     ...(request.cliProvenance ? { cliProvenance: request.cliProvenance } : {}),
+    ...(request.reservation ? { reservation: request.reservation } : {}),
     creatorProvenance: request.creatorProvenance ?? { kind: 'host' },
     ...(request.linkedIssue !== undefined ? { linkedIssue: request.linkedIssue } : {}),
     ...(request.linkedPR !== undefined ? { linkedPR: request.linkedPR } : {}),

--- a/src/main/runtime/runtime-local-worktree-materialization.ts
+++ b/src/main/runtime/runtime-local-worktree-materialization.ts
@@ -121,6 +121,7 @@ export async function materializeRuntimeLocalWorktree<T>(args: {
       : {}),
     ...(request.automationProvenance ? { automationProvenance: request.automationProvenance } : {}),
     ...(request.cliProvenance ? { cliProvenance: request.cliProvenance } : {}),
+    ...(request.reservation ? { reservation: request.reservation } : {}),
     creatorProvenance: request.creatorProvenance ?? { kind: 'host' },
     ...(request.comment !== undefined ? { comment: request.comment } : {}),
     ...(request.manualOrder !== undefined ? { manualOrder: request.manualOrder } : {}),

--- a/src/main/runtime/runtime-managed-worktree-create-types.ts
+++ b/src/main/runtime/runtime-managed-worktree-create-types.ts
@@ -13,6 +13,7 @@ import type { WorktreeStartupLaunch } from '../../shared/worktree/launch-types'
 import type { TaskSourceContext } from '../../shared/task-source-context'
 import type { WorktreeStartupDraftPaste } from './runtime-worktree-agent-startup'
 import type { RuntimeNavigationTarget } from '../../shared/runtime-navigation'
+import type { ResourceReservationBinding } from '../../shared/resource-reservation-binding'
 
 export type RuntimeManagedWorktreeCreateArgs = {
   repoSelector: string
@@ -55,6 +56,8 @@ export type RuntimeManagedWorktreeCreateArgs = {
   automationProvenance?: AutomationWorkspaceProvenance
   cliProvenance?: CliWorkspaceProvenance
   creatorProvenance?: Worktree['creatorProvenance']
+  /** Caller-bound reservation persisted atomically with the workspace metadata. */
+  reservation?: ResourceReservationBinding
   startup?: WorktreeStartupLaunch
   startupDraft?: string
   startupDraftPaste?: WorktreeStartupDraftPaste

--- a/src/main/runtime/runtime-remote-worktree-create-request.ts
+++ b/src/main/runtime/runtime-remote-worktree-create-request.ts
@@ -62,7 +62,8 @@ export async function requestRuntimeRemoteWorktree(
       ...(args.pendingFirstAgentMessageRename ? { pendingFirstAgentMessageRename: true } : {}),
       ...(args.nameWasGenerated === true ? { nameWasGenerated: true } : {}),
       ...(args.automationProvenance ? { automationProvenance: args.automationProvenance } : {}),
-      ...(args.cliProvenance ? { cliProvenance: args.cliProvenance } : {})
+      ...(args.cliProvenance ? { cliProvenance: args.cliProvenance } : {}),
+      ...(args.reservation ? { reservation: args.reservation } : {})
     },
     repo,
     store as unknown as Store,

--- a/src/main/runtime/runtime-terminal-list.ts
+++ b/src/main/runtime/runtime-terminal-list.ts
@@ -1,5 +1,6 @@
 import type {
   RuntimeMobileSessionTabsSnapshot,
+  RuntimeTerminalListHostScope,
   RuntimeTerminalListResult,
   RuntimeTerminalSummary
 } from '../../shared/runtime-types'
@@ -45,7 +46,7 @@ type RuntimeTerminalListDependencies = {
     terminals: readonly RuntimeTerminalSummary[],
     worktrees: Iterable<ResolvedWorktree>,
     queriedHostIds: ReadonlySet<ExecutionHostId>
-  ): { hostIds: ExecutionHostId[]; omittedHostIds: ExecutionHostId[] }
+  ): RuntimeTerminalListHostScope
 }
 
 export class RuntimeTerminalList {
@@ -163,14 +164,22 @@ export class RuntimeTerminalList {
               : snapshots.values(),
             getTabTitle: (tabId) => this.deps.getTabTitle(tabId)
           })
+    const hostScope = this.deps.buildHostScope(
+      targetId,
+      matching,
+      worktreesById.values(),
+      (inventory?.queriedHostIds ?? new Set()) as ReadonlySet<ExecutionHostId>
+    )
     return {
       terminals: listed,
-      hostScope: this.deps.buildHostScope(
-        targetId,
-        matching,
-        worktreesById.values(),
-        (inventory?.queriedHostIds ?? new Set()) as ReadonlySet<ExecutionHostId>
-      ),
+      // Why the listing's own page limit folds into completeness: a truncated page is not a
+      // complete inventory either, and callers must not have to combine two flags to learn that.
+      hostScope: {
+        ...hostScope,
+        ...(hostScope.complete !== undefined
+          ? { complete: hostScope.complete && matching.length <= limit }
+          : {})
+      },
       ...(visualLayouts.length > 0 ? { visualLayouts } : {}),
       topologyRevisions: Object.fromEntries(
         [...new Set(matching.map((terminal) => terminal.worktreeId))].map((worktreeId) => [

--- a/src/main/runtime/terminal-list-inventory-completeness.test.ts
+++ b/src/main/runtime/terminal-list-inventory-completeness.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import { getDefaultWorkspaceSession } from '../../shared/constants'
+import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
+import type { FolderWorkspace } from '../../shared/folder-workspace-types'
+
+// An agent read `truncated: false` as a complete inventory while the same response was naming
+// omitted remote hosts. Completeness must be its own verdict, not inferred from the page flag.
+
+const LOCAL_WORKTREE_ID = 'repo-local::/tmp/local-worktree'
+const LOCAL_LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const SECOND_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+
+const REPOS = [
+  {
+    id: 'repo-local',
+    path: '/tmp/local-worktree',
+    displayName: 'local',
+    badgeColor: '#000000',
+    addedAt: 0
+  }
+]
+
+function makeStore(hostIds: string[]) {
+  const session: WorkspaceSessionState = getDefaultWorkspaceSession()
+  return {
+    getWorkspaceSession: vi.fn(() => session),
+    getWorkspaceSessionHostIds: vi.fn(() => hostIds),
+    getFolderWorkspaces: vi.fn((): FolderWorkspace[] => []),
+    getProjectGroups: vi.fn(() => []),
+    setWorkspaceSession: vi.fn(),
+    getRepos: vi.fn(() => REPOS),
+    getRepo: vi.fn((id: string) => REPOS.find((repo) => repo.id === id)),
+    getAllWorktreeMeta: vi.fn(() => ({})),
+    getWorktreeMeta: vi.fn(() => undefined),
+    setWorktreeMeta: vi.fn(),
+    removeWorktreeMeta: vi.fn(),
+    getSettings: vi.fn(() => ({ workspaceDir: '/tmp/workspaces' })),
+    getProjects: vi.fn(() => [])
+  }
+}
+
+function makeRuntime(hostIds: string[], leafCount = 1): OrcaRuntimeService {
+  const leafIds = [LOCAL_LEAF_ID, SECOND_LEAF_ID].slice(0, leafCount)
+  const runtime = new OrcaRuntimeService(makeStore(hostIds) as never)
+  runtime.setPtyController({
+    spawn: vi.fn(async () => ({ id: 'never' })),
+    write: () => true,
+    kill: () => true,
+    listProcesses: vi.fn(async () =>
+      leafIds.map((_leafId, index) => ({ id: `pty-local-${index + 1}`, cwd: '/tmp' }))
+    )
+  } as never)
+  runtime.attachWindow(1)
+  runtime.syncWindowGraph(1, {
+    tabs: leafIds.map((leafId, index) => ({
+      tabId: `tab-${index + 1}`,
+      worktreeId: LOCAL_WORKTREE_ID,
+      title: '',
+      activeLeafId: leafId,
+      layout: null
+    })),
+    leaves: leafIds.map((leafId, index) => ({
+      tabId: `tab-${index + 1}`,
+      worktreeId: LOCAL_WORKTREE_ID,
+      leafId,
+      paneRuntimeId: index + 1,
+      ptyId: `pty-local-${index + 1}`,
+      paneTitle: null,
+      title: ''
+    }))
+  })
+  return runtime
+}
+
+describe('listTerminals inventory completeness', () => {
+  it('declares the inventory incomplete when a host is omitted, even untruncated', async () => {
+    const result = await makeRuntime(['local', 'ssh:box-1']).listTerminals()
+
+    expect(result.truncated).toBe(false)
+    expect(result.hostScope?.omittedHostIds).toEqual(['ssh:box-1'])
+    expect(result.hostScope?.complete).toBe(false)
+  })
+
+  it('declares the inventory complete only when every known host was covered', async () => {
+    const result = await makeRuntime(['local']).listTerminals()
+
+    expect(result.hostScope?.omittedHostIds).toEqual([])
+    expect(result.hostScope?.complete).toBe(true)
+  })
+
+  it('bounds the verdict with the host clock it was observed at', async () => {
+    const before = Date.now()
+
+    const result = await makeRuntime(['local']).listTerminals()
+
+    expect(result.hostScope?.observedAt).toBeGreaterThanOrEqual(before)
+  })
+
+  it('does not call a truncated page complete even when every host was covered', async () => {
+    const result = await makeRuntime(['local'], 2).listTerminals(undefined, 1)
+
+    expect(result.truncated).toBe(true)
+    expect(result.hostScope?.omittedHostIds).toEqual([])
+    expect(result.hostScope?.complete).toBe(false)
+  })
+})

--- a/src/main/runtime/terminal-reservation-bindings.test.ts
+++ b/src/main/runtime/terminal-reservation-bindings.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, readFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -61,6 +61,55 @@ describe('terminal reservation bindings', () => {
       outcome: 'replay',
       binding
     })
+  })
+
+  it('rejects malformed persisted bindings instead of laundering them into runtime state', () => {
+    const profile = mkdtempSync(join(tmpdir(), 'orca-terminal-reservations-'))
+    writeFileSync(
+      join(profile, 'terminal-reservations.json'),
+      JSON.stringify([{ handle: 'term_a', binding: { ...REQUEST, boundAt: -1 } }])
+    )
+
+    expect(() => new TerminalReservationBindings(profile)).toThrow(
+      'Invalid terminal reservation store at entry 0'
+    )
+  })
+
+  it.each([
+    [
+      'handle',
+      [
+        { handle: 'term_a', binding: { ...REQUEST, boundAt: 1 } },
+        { handle: 'term_a', binding: { ...REQUEST, key: 'key-2', boundAt: 2 } }
+      ]
+    ],
+    [
+      'key',
+      [
+        { handle: 'term_a', binding: { ...REQUEST, boundAt: 1 } },
+        { handle: 'term_b', binding: { ...REQUEST, boundAt: 2 } }
+      ]
+    ]
+  ])('rejects a duplicate persisted %s', (kind, entries) => {
+    const profile = mkdtempSync(join(tmpdir(), 'orca-terminal-reservations-'))
+    writeFileSync(join(profile, 'terminal-reservations.json'), JSON.stringify(entries))
+
+    expect(() => new TerminalReservationBindings(profile)).toThrow(`duplicate ${kind}`)
+  })
+
+  it('keeps existing state and persistence target when reconfiguration hydration fails', () => {
+    const originalProfile = mkdtempSync(join(tmpdir(), 'orca-terminal-reservations-'))
+    const corruptProfile = mkdtempSync(join(tmpdir(), 'orca-terminal-reservations-'))
+    const registry = new TerminalReservationBindings(originalProfile)
+    const binding = buildResourceReservationBinding(REQUEST, { boundAt: 1 })
+    registry.claim('term_a', binding)
+    writeFileSync(join(corruptProfile, 'terminal-reservations.json'), JSON.stringify([null]))
+
+    expect(() => registry.configurePersistence(corruptProfile)).toThrow()
+    expect(registry.get('term_a')).toEqual(binding)
+
+    registry.retire('term_a')
+    expect(new TerminalReservationBindings(originalProfile).get('term_a')).toBeUndefined()
   })
 
   it('retires an explicitly destroyed terminal claim durably', () => {

--- a/src/main/runtime/terminal-reservation-bindings.test.ts
+++ b/src/main/runtime/terminal-reservation-bindings.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { buildResourceReservationBinding } from '../../shared/resource-reservation-binding'
 import type { ResourceReservationRequest } from '../../shared/resource-reservation-binding'
@@ -46,19 +49,17 @@ describe('terminal reservation bindings', () => {
     expect(registry.assertBindable('term_a', REQUEST)).toBeNull()
   })
 
-  it('drops the oldest entry rather than growing without bound', () => {
-    const registry = new TerminalReservationBindings(2)
-    registry.bind('term_a', buildResourceReservationBinding(REQUEST, { boundAt: 1 }))
-    registry.bind(
-      'term_b',
-      buildResourceReservationBinding({ ...REQUEST, key: 'key-2' }, { boundAt: 2 })
-    )
-    registry.bind(
-      'term_c',
-      buildResourceReservationBinding({ ...REQUEST, key: 'key-3' }, { boundAt: 3 })
-    )
+  it('reloads an immutable claim after runtime restart', () => {
+    const profile = mkdtempSync(join(tmpdir(), 'orca-terminal-reservations-'))
+    const first = new TerminalReservationBindings(profile)
+    const binding = buildResourceReservationBinding(REQUEST, { boundAt: 1 })
+    first.claim('term_a', binding)
 
-    expect(registry.get('term_a')).toBeUndefined()
-    expect(registry.get('term_c')).toBeDefined()
+    const restarted = new TerminalReservationBindings(profile)
+    expect(restarted.get('term_a')).toEqual(binding)
+    expect(restarted.claim('term_a', { ...binding, boundAt: 2 })).toEqual({
+      outcome: 'replay',
+      binding
+    })
   })
 })

--- a/src/main/runtime/terminal-reservation-bindings.test.ts
+++ b/src/main/runtime/terminal-reservation-bindings.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'node:fs'
+import { chmodSync, mkdtempSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -61,5 +61,35 @@ describe('terminal reservation bindings', () => {
       outcome: 'replay',
       binding
     })
+  })
+
+  it('retires an explicitly destroyed terminal claim durably', () => {
+    const profile = mkdtempSync(join(tmpdir(), 'orca-terminal-reservations-'))
+    const registry = new TerminalReservationBindings(profile)
+    const binding = buildResourceReservationBinding(REQUEST, { boundAt: 1 })
+    registry.claim('term_a', binding)
+
+    registry.retire('term_a')
+
+    expect(registry.get('term_a')).toBeUndefined()
+    expect(new TerminalReservationBindings(profile).get('term_a')).toBeUndefined()
+  })
+
+  it('keeps memory and disk unchanged when release persistence fails', () => {
+    const profile = mkdtempSync(join(tmpdir(), 'orca-terminal-reservations-'))
+    const registry = new TerminalReservationBindings(profile)
+    const binding = buildResourceReservationBinding(REQUEST, { boundAt: 1 })
+    registry.claim('term_a', binding)
+    const storagePath = join(profile, 'terminal-reservations.json')
+    const persisted = readFileSync(storagePath, 'utf8')
+    chmodSync(profile, 0o500)
+
+    try {
+      expect(() => registry.release('term_a', binding)).toThrow()
+      expect(registry.get('term_a')).toEqual(binding)
+      expect(readFileSync(storagePath, 'utf8')).toBe(persisted)
+    } finally {
+      chmodSync(profile, 0o700)
+    }
   })
 })

--- a/src/main/runtime/terminal-reservation-bindings.test.ts
+++ b/src/main/runtime/terminal-reservation-bindings.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { buildResourceReservationBinding } from '../../shared/resource-reservation-binding'
+import type { ResourceReservationRequest } from '../../shared/resource-reservation-binding'
+import { TerminalReservationBindings } from './terminal-reservation-bindings'
+
+const REQUEST: ResourceReservationRequest = {
+  key: 'key-1',
+  reservationId: 'res-1',
+  sessionId: 'session-1',
+  resourceKind: 'terminal',
+  ownershipGeneration: 1
+}
+
+describe('terminal reservation bindings', () => {
+  it('binds once and replays the first binding for an identical retry', () => {
+    const registry = new TerminalReservationBindings()
+    const first = buildResourceReservationBinding(REQUEST, { boundAt: 1 })
+    const second = buildResourceReservationBinding(REQUEST, { boundAt: 2 })
+
+    expect(registry.bind('term_a', first)).toEqual({ outcome: 'bound' })
+    expect(registry.bind('term_a', second)).toEqual({ outcome: 'replay', binding: first })
+    expect(registry.get('term_a')).toEqual(first)
+  })
+
+  it('refuses the same key against a second terminal handle', () => {
+    const registry = new TerminalReservationBindings()
+    registry.bind('term_a', buildResourceReservationBinding(REQUEST, { boundAt: 1 }))
+
+    const result = registry.bind('term_b', buildResourceReservationBinding(REQUEST, { boundAt: 2 }))
+
+    expect(result.outcome).toBe('conflict')
+  })
+
+  it('refuses a reused key whose session changed before anything is created', () => {
+    const registry = new TerminalReservationBindings()
+    registry.bind('term_a', buildResourceReservationBinding(REQUEST, { boundAt: 1 }))
+
+    expect(registry.assertBindable('term_a', { ...REQUEST, sessionId: 'session-2' })).toContain(
+      'single-use'
+    )
+  })
+
+  it('lets an untouched key bind', () => {
+    const registry = new TerminalReservationBindings()
+
+    expect(registry.assertBindable('term_a', REQUEST)).toBeNull()
+  })
+
+  it('drops the oldest entry rather than growing without bound', () => {
+    const registry = new TerminalReservationBindings(2)
+    registry.bind('term_a', buildResourceReservationBinding(REQUEST, { boundAt: 1 }))
+    registry.bind(
+      'term_b',
+      buildResourceReservationBinding({ ...REQUEST, key: 'key-2' }, { boundAt: 2 })
+    )
+    registry.bind(
+      'term_c',
+      buildResourceReservationBinding({ ...REQUEST, key: 'key-3' }, { boundAt: 3 })
+    )
+
+    expect(registry.get('term_a')).toBeUndefined()
+    expect(registry.get('term_c')).toBeDefined()
+  })
+})

--- a/src/main/runtime/terminal-reservation-bindings.test.ts
+++ b/src/main/runtime/terminal-reservation-bindings.test.ts
@@ -75,6 +75,30 @@ describe('terminal reservation bindings', () => {
     )
   })
 
+  it('rejects a worktree binding persisted in the terminal-only store', () => {
+    const profile = mkdtempSync(join(tmpdir(), 'orca-terminal-reservations-'))
+    writeFileSync(
+      join(profile, 'terminal-reservations.json'),
+      JSON.stringify([
+        { handle: 'term_a', binding: { ...REQUEST, resourceKind: 'worktree', boundAt: 1 } }
+      ])
+    )
+
+    expect(() => new TerminalReservationBindings(profile)).toThrow(
+      'Invalid terminal reservation store at entry 0'
+    )
+  })
+
+  it('rejects a worktree binding at the live terminal authority boundary', () => {
+    const registry = new TerminalReservationBindings()
+    const wrongKind = { ...REQUEST, resourceKind: 'worktree' as const, boundAt: 1 }
+
+    expect(() => registry.claim('term_a', wrongKind)).toThrow(
+      'Invalid terminal reservation binding'
+    )
+    expect(registry.get('term_a')).toBeUndefined()
+  })
+
   it.each([
     [
       'handle',

--- a/src/main/runtime/terminal-reservation-bindings.ts
+++ b/src/main/runtime/terminal-reservation-bindings.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import {
   describeResourceReservationConflict,
   resourceReservationBindingMatchesRequest,
@@ -5,78 +7,126 @@ import {
   type ResourceReservationRequest
 } from '../../shared/resource-reservation-binding'
 
-const DEFAULT_MAX_TERMINAL_RESERVATIONS = 4_096
+const TERMINAL_RESERVATIONS_FILE = 'terminal-reservations.json'
 
 export type TerminalReservationBindResult =
   | { outcome: 'bound' }
   | { outcome: 'replay'; binding: ResourceReservationBinding }
   | { outcome: 'conflict'; message: string }
 
-/**
- * Handle → reservation binding for terminals. The handle a reserved create returns is derived
- * from the reservation key itself, so this registry is a projection cache, not the source of
- * identity: an evicted entry still re-derives to the same handle on retry.
- */
+/** Durable reservation authority. Claims are persisted before provider mutation. */
 export class TerminalReservationBindings {
   private readonly byHandle = new Map<string, ResourceReservationBinding>()
   private readonly handleByKey = new Map<string, string>()
+  private storagePath: string | null = null
 
-  constructor(private readonly maxEntries = DEFAULT_MAX_TERMINAL_RESERVATIONS) {}
-
-  /** Records the binding, or reports why this key cannot bind to this handle. */
-  bind(handle: string, binding: ResourceReservationBinding): TerminalReservationBindResult {
-    const existingHandle = this.handleByKey.get(binding.key)
-    const existing = existingHandle ? this.byHandle.get(existingHandle) : undefined
-    if (existing && existingHandle) {
-      if (
-        existingHandle !== handle ||
-        !resourceReservationBindingMatchesRequest(existing, binding)
-      ) {
-        return {
-          outcome: 'conflict',
-          message: describeResourceReservationConflict(existing, binding, existingHandle)
-        }
-      }
-      return { outcome: 'replay', binding: existing }
+  constructor(profileStorageDirectory?: string) {
+    if (profileStorageDirectory) {
+      this.configurePersistence(profileStorageDirectory)
     }
-    this.evictOldestIfFull()
+  }
+
+  configurePersistence(profileStorageDirectory: string): void {
+    this.storagePath = join(profileStorageDirectory, TERMINAL_RESERVATIONS_FILE)
+    this.hydrate()
+  }
+
+  /** Atomically claims a key before creation, or returns its immutable prior binding. */
+  claim(handle: string, binding: ResourceReservationBinding): TerminalReservationBindResult {
+    const existing = this.inspect(handle, binding)
+    if (existing) {
+      return existing
+    }
     this.byHandle.set(handle, binding)
     this.handleByKey.set(binding.key, handle)
+    try {
+      this.persist()
+    } catch (error) {
+      this.byHandle.delete(handle)
+      this.handleByKey.delete(binding.key)
+      throw error
+    }
     return { outcome: 'bound' }
   }
 
-  /** Refuses a request whose key is already bound elsewhere, before any resource is created. */
+  bind(handle: string, binding: ResourceReservationBinding): TerminalReservationBindResult {
+    return this.claim(handle, binding)
+  }
+
+  /** Releases only the exact claim owned by a failed create attempt. */
+  release(handle: string, binding: ResourceReservationBinding): void {
+    if (this.byHandle.get(handle) !== binding || this.handleByKey.get(binding.key) !== handle) {
+      return
+    }
+    this.byHandle.delete(handle)
+    this.handleByKey.delete(binding.key)
+    this.persist()
+  }
+
   assertBindable(handle: string, request: ResourceReservationRequest): string | null {
-    const existingHandle = this.handleByKey.get(request.key)
-    if (!existingHandle) {
-      return null
-    }
-    const existing = this.byHandle.get(existingHandle)
-    if (!existing) {
-      return null
-    }
-    if (existingHandle === handle && resourceReservationBindingMatchesRequest(existing, request)) {
-      return null
-    }
-    return describeResourceReservationConflict(existing, request, existingHandle)
+    const result = this.inspect(handle, request)
+    return result?.outcome === 'conflict' ? result.message : null
   }
 
   get(handle: string): ResourceReservationBinding | undefined {
     return this.byHandle.get(handle)
   }
 
-  private evictOldestIfFull(): void {
-    if (this.byHandle.size < this.maxEntries) {
+  private inspect(
+    handle: string,
+    request: ResourceReservationRequest
+  ): Exclude<TerminalReservationBindResult, { outcome: 'bound' }> | null {
+    const existingHandle = this.handleByKey.get(request.key)
+    const existing = existingHandle ? this.byHandle.get(existingHandle) : undefined
+    if (!existing || !existingHandle) {
+      return null
+    }
+    if (existingHandle !== handle || !resourceReservationBindingMatchesRequest(existing, request)) {
+      return {
+        outcome: 'conflict',
+        message: describeResourceReservationConflict(existing, request, existingHandle)
+      }
+    }
+    return { outcome: 'replay', binding: existing }
+  }
+
+  private hydrate(): void {
+    if (!this.storagePath) {
       return
     }
-    const oldest = this.byHandle.keys().next()
-    if (oldest.done) {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(readFileSync(this.storagePath, 'utf8'))
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return
+      }
+      throw error
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error(`Invalid terminal reservation store: ${this.storagePath}`)
+    }
+    for (const entry of parsed) {
+      const { handle, binding } = (entry ?? {}) as {
+        handle?: unknown
+        binding?: ResourceReservationBinding
+      }
+      if (typeof handle !== 'string' || !binding || typeof binding.key !== 'string') {
+        throw new Error(`Invalid terminal reservation entry: ${this.storagePath}`)
+      }
+      this.byHandle.set(handle, binding)
+      this.handleByKey.set(binding.key, handle)
+    }
+  }
+
+  private persist(): void {
+    if (!this.storagePath) {
       return
     }
-    const evicted = this.byHandle.get(oldest.value)
-    this.byHandle.delete(oldest.value)
-    if (evicted && this.handleByKey.get(evicted.key) === oldest.value) {
-      this.handleByKey.delete(evicted.key)
-    }
+    mkdirSync(dirname(this.storagePath), { recursive: true })
+    const temporaryPath = `${this.storagePath}.tmp`
+    const entries = [...this.byHandle].map(([handle, binding]) => ({ handle, binding }))
+    writeFileSync(temporaryPath, `${JSON.stringify(entries)}\n`, { mode: 0o600 })
+    renameSync(temporaryPath, this.storagePath)
   }
 }

--- a/src/main/runtime/terminal-reservation-bindings.ts
+++ b/src/main/runtime/terminal-reservation-bindings.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import {
   describeResourceReservationConflict,
-  ResourceReservationBindingSchema,
+  TerminalReservationBindingSchema,
   resourceReservationBindingMatchesRequest,
   type ResourceReservationBinding,
   type ResourceReservationRequest
@@ -12,7 +12,7 @@ import { z } from 'zod'
 const TERMINAL_RESERVATIONS_FILE = 'terminal-reservations.json'
 const TerminalReservationEntrySchema = z.object({
   handle: z.string().min(1).max(256),
-  binding: ResourceReservationBindingSchema
+  binding: TerminalReservationBindingSchema
 })
 
 export type TerminalReservationBindResult =
@@ -41,6 +41,10 @@ export class TerminalReservationBindings {
 
   /** Atomically claims a key before creation, or returns its immutable prior binding. */
   claim(handle: string, binding: ResourceReservationBinding): TerminalReservationBindResult {
+    const validation = TerminalReservationBindingSchema.safeParse(binding)
+    if (!validation.success) {
+      throw new Error(`Invalid terminal reservation binding: ${validation.error.message}`)
+    }
     const existing = this.inspect(handle, binding)
     if (existing) {
       return existing

--- a/src/main/runtime/terminal-reservation-bindings.ts
+++ b/src/main/runtime/terminal-reservation-bindings.ts
@@ -37,15 +37,10 @@ export class TerminalReservationBindings {
     if (existing) {
       return existing
     }
-    this.byHandle.set(handle, binding)
-    this.handleByKey.set(binding.key, handle)
-    try {
-      this.persist()
-    } catch (error) {
-      this.byHandle.delete(handle)
-      this.handleByKey.delete(binding.key)
-      throw error
-    }
+    const nextByHandle = new Map(this.byHandle).set(handle, binding)
+    const nextHandleByKey = new Map(this.handleByKey).set(binding.key, handle)
+    this.persist(nextByHandle)
+    this.replaceState(nextByHandle, nextHandleByKey)
     return { outcome: 'bound' }
   }
 
@@ -58,9 +53,15 @@ export class TerminalReservationBindings {
     if (this.byHandle.get(handle) !== binding || this.handleByKey.get(binding.key) !== handle) {
       return
     }
-    this.byHandle.delete(handle)
-    this.handleByKey.delete(binding.key)
-    this.persist()
+    this.remove(handle, binding.key)
+  }
+
+  /** Permanently retires the claim when its terminal is explicitly destroyed. */
+  retire(handle: string): void {
+    const binding = this.byHandle.get(handle)
+    if (binding) {
+      this.remove(handle, binding.key)
+    }
   }
 
   assertBindable(handle: string, request: ResourceReservationRequest): string | null {
@@ -119,13 +120,32 @@ export class TerminalReservationBindings {
     }
   }
 
-  private persist(): void {
+  private remove(handle: string, key: string): void {
+    const nextByHandle = new Map(this.byHandle)
+    const nextHandleByKey = new Map(this.handleByKey)
+    nextByHandle.delete(handle)
+    nextHandleByKey.delete(key)
+    this.persist(nextByHandle)
+    this.replaceState(nextByHandle, nextHandleByKey)
+  }
+
+  private replaceState(
+    byHandle: ReadonlyMap<string, ResourceReservationBinding>,
+    handleByKey: ReadonlyMap<string, string>
+  ): void {
+    this.byHandle.clear()
+    this.handleByKey.clear()
+    for (const [handle, binding] of byHandle) this.byHandle.set(handle, binding)
+    for (const [key, handle] of handleByKey) this.handleByKey.set(key, handle)
+  }
+
+  private persist(entriesByHandle: ReadonlyMap<string, ResourceReservationBinding>): void {
     if (!this.storagePath) {
       return
     }
     mkdirSync(dirname(this.storagePath), { recursive: true })
     const temporaryPath = `${this.storagePath}.tmp`
-    const entries = [...this.byHandle].map(([handle, binding]) => ({ handle, binding }))
+    const entries = [...entriesByHandle].map(([handle, binding]) => ({ handle, binding }))
     writeFileSync(temporaryPath, `${JSON.stringify(entries)}\n`, { mode: 0o600 })
     renameSync(temporaryPath, this.storagePath)
   }

--- a/src/main/runtime/terminal-reservation-bindings.ts
+++ b/src/main/runtime/terminal-reservation-bindings.ts
@@ -1,0 +1,82 @@
+import {
+  describeResourceReservationConflict,
+  resourceReservationBindingMatchesRequest,
+  type ResourceReservationBinding,
+  type ResourceReservationRequest
+} from '../../shared/resource-reservation-binding'
+
+const DEFAULT_MAX_TERMINAL_RESERVATIONS = 4_096
+
+export type TerminalReservationBindResult =
+  | { outcome: 'bound' }
+  | { outcome: 'replay'; binding: ResourceReservationBinding }
+  | { outcome: 'conflict'; message: string }
+
+/**
+ * Handle → reservation binding for terminals. The handle a reserved create returns is derived
+ * from the reservation key itself, so this registry is a projection cache, not the source of
+ * identity: an evicted entry still re-derives to the same handle on retry.
+ */
+export class TerminalReservationBindings {
+  private readonly byHandle = new Map<string, ResourceReservationBinding>()
+  private readonly handleByKey = new Map<string, string>()
+
+  constructor(private readonly maxEntries = DEFAULT_MAX_TERMINAL_RESERVATIONS) {}
+
+  /** Records the binding, or reports why this key cannot bind to this handle. */
+  bind(handle: string, binding: ResourceReservationBinding): TerminalReservationBindResult {
+    const existingHandle = this.handleByKey.get(binding.key)
+    const existing = existingHandle ? this.byHandle.get(existingHandle) : undefined
+    if (existing && existingHandle) {
+      if (
+        existingHandle !== handle ||
+        !resourceReservationBindingMatchesRequest(existing, binding)
+      ) {
+        return {
+          outcome: 'conflict',
+          message: describeResourceReservationConflict(existing, binding, existingHandle)
+        }
+      }
+      return { outcome: 'replay', binding: existing }
+    }
+    this.evictOldestIfFull()
+    this.byHandle.set(handle, binding)
+    this.handleByKey.set(binding.key, handle)
+    return { outcome: 'bound' }
+  }
+
+  /** Refuses a request whose key is already bound elsewhere, before any resource is created. */
+  assertBindable(handle: string, request: ResourceReservationRequest): string | null {
+    const existingHandle = this.handleByKey.get(request.key)
+    if (!existingHandle) {
+      return null
+    }
+    const existing = this.byHandle.get(existingHandle)
+    if (!existing) {
+      return null
+    }
+    if (existingHandle === handle && resourceReservationBindingMatchesRequest(existing, request)) {
+      return null
+    }
+    return describeResourceReservationConflict(existing, request, existingHandle)
+  }
+
+  get(handle: string): ResourceReservationBinding | undefined {
+    return this.byHandle.get(handle)
+  }
+
+  private evictOldestIfFull(): void {
+    if (this.byHandle.size < this.maxEntries) {
+      return
+    }
+    const oldest = this.byHandle.keys().next()
+    if (oldest.done) {
+      return
+    }
+    const evicted = this.byHandle.get(oldest.value)
+    this.byHandle.delete(oldest.value)
+    if (evicted && this.handleByKey.get(evicted.key) === oldest.value) {
+      this.handleByKey.delete(evicted.key)
+    }
+  }
+}

--- a/src/main/runtime/terminal-reservation-bindings.ts
+++ b/src/main/runtime/terminal-reservation-bindings.ts
@@ -2,12 +2,18 @@ import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import {
   describeResourceReservationConflict,
+  ResourceReservationBindingSchema,
   resourceReservationBindingMatchesRequest,
   type ResourceReservationBinding,
   type ResourceReservationRequest
 } from '../../shared/resource-reservation-binding'
+import { z } from 'zod'
 
 const TERMINAL_RESERVATIONS_FILE = 'terminal-reservations.json'
+const TerminalReservationEntrySchema = z.object({
+  handle: z.string().min(1).max(256),
+  binding: ResourceReservationBindingSchema
+})
 
 export type TerminalReservationBindResult =
   | { outcome: 'bound' }
@@ -27,8 +33,10 @@ export class TerminalReservationBindings {
   }
 
   configurePersistence(profileStorageDirectory: string): void {
-    this.storagePath = join(profileStorageDirectory, TERMINAL_RESERVATIONS_FILE)
-    this.hydrate()
+    const storagePath = join(profileStorageDirectory, TERMINAL_RESERVATIONS_FILE)
+    const [byHandle, handleByKey] = this.hydrate(storagePath)
+    this.storagePath = storagePath
+    this.replaceState(byHandle, handleByKey)
   }
 
   /** Atomically claims a key before creation, or returns its immutable prior binding. */
@@ -91,33 +99,45 @@ export class TerminalReservationBindings {
     return { outcome: 'replay', binding: existing }
   }
 
-  private hydrate(): void {
-    if (!this.storagePath) {
-      return
-    }
+  private hydrate(
+    storagePath: string
+  ): [Map<string, ResourceReservationBinding>, Map<string, string>] {
     let parsed: unknown
     try {
-      parsed = JSON.parse(readFileSync(this.storagePath, 'utf8'))
+      parsed = JSON.parse(readFileSync(storagePath, 'utf8'))
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        return
+        return [new Map(), new Map()]
       }
       throw error
     }
     if (!Array.isArray(parsed)) {
-      throw new Error(`Invalid terminal reservation store: ${this.storagePath}`)
+      throw new Error(`Invalid terminal reservation store: ${storagePath}`)
     }
-    for (const entry of parsed) {
-      const { handle, binding } = (entry ?? {}) as {
-        handle?: unknown
-        binding?: ResourceReservationBinding
+    const byHandle = new Map<string, ResourceReservationBinding>()
+    const handleByKey = new Map<string, string>()
+    for (const [index, entry] of parsed.entries()) {
+      const result = TerminalReservationEntrySchema.safeParse(entry)
+      if (!result.success) {
+        throw new Error(
+          `Invalid terminal reservation store at entry ${index}: ${storagePath}: ${result.error.message}`
+        )
       }
-      if (typeof handle !== 'string' || !binding || typeof binding.key !== 'string') {
-        throw new Error(`Invalid terminal reservation entry: ${this.storagePath}`)
+      const { handle, binding } = result.data
+      if (byHandle.has(handle)) {
+        throw new Error(
+          `Invalid terminal reservation store at entry ${index}: duplicate handle "${handle}": ${storagePath}`
+        )
       }
-      this.byHandle.set(handle, binding)
-      this.handleByKey.set(binding.key, handle)
+      if (handleByKey.has(binding.key)) {
+        throw new Error(
+          `Invalid terminal reservation store at entry ${index}: duplicate key "${binding.key}": ${storagePath}`
+        )
+      }
+      byHandle.set(handle, binding)
+      handleByKey.set(binding.key, handle)
     }
+    return [byHandle, handleByKey]
   }
 
   private remove(handle: string, key: string): void {
@@ -135,8 +155,12 @@ export class TerminalReservationBindings {
   ): void {
     this.byHandle.clear()
     this.handleByKey.clear()
-    for (const [handle, binding] of byHandle) this.byHandle.set(handle, binding)
-    for (const [key, handle] of handleByKey) this.handleByKey.set(key, handle)
+    for (const [handle, binding] of byHandle) {
+      this.byHandle.set(handle, binding)
+    }
+    for (const [key, handle] of handleByKey) {
+      this.handleByKey.set(key, handle)
+    }
   }
 
   private persist(entriesByHandle: ReadonlyMap<string, ResourceReservationBinding>): void {

--- a/src/main/runtime/worktree-reservation-replay.test.ts
+++ b/src/main/runtime/worktree-reservation-replay.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { buildResourceReservationBinding } from '../../shared/resource-reservation-binding'
+import type { ResourceReservationRequest } from '../../shared/resource-reservation-binding'
+import type { WorktreeMeta } from '../../shared/worktree/meta-types'
+import { findWorktreeReservation } from './worktree-reservation-replay'
+
+const REQUEST: ResourceReservationRequest = {
+  key: 'key-1',
+  reservationId: 'res-1',
+  sessionId: 'session-1',
+  resourceKind: 'worktree',
+  ownershipGeneration: 2
+}
+
+function meta(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
+  return {
+    displayName: 'wt',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+describe('worktree reservation replay', () => {
+  it('reports an unused key as unbound so the create proceeds', () => {
+    expect(findWorktreeReservation({ 'repo::/a': meta() }, REQUEST)).toEqual({
+      outcome: 'unbound'
+    })
+  })
+
+  it('replays the same workspace for a retry with an identical binding', () => {
+    const binding = buildResourceReservationBinding(REQUEST, { boundAt: 5 })
+
+    const lookup = findWorktreeReservation(
+      { 'repo::/a': meta(), 'repo::/b': meta({ reservation: binding }) },
+      REQUEST
+    )
+
+    expect(lookup).toEqual({ outcome: 'replay', worktreeId: 'repo::/b', binding })
+  })
+
+  it('refuses a reused key whose ownership generation moved on', () => {
+    const binding = buildResourceReservationBinding(REQUEST, { boundAt: 5 })
+
+    const lookup = findWorktreeReservation(
+      { 'repo::/b': meta({ reservation: binding }) },
+      {
+        ...REQUEST,
+        ownershipGeneration: 3
+      }
+    )
+
+    expect(lookup.outcome).toBe('conflict')
+    expect(lookup).toMatchObject({ worktreeId: 'repo::/b' })
+  })
+
+  it('does not replay a different key that happens to share a reservation id', () => {
+    const binding = buildResourceReservationBinding(REQUEST, { boundAt: 5 })
+
+    expect(
+      findWorktreeReservation(
+        { 'repo::/b': meta({ reservation: binding }) },
+        {
+          ...REQUEST,
+          key: 'key-2'
+        }
+      )
+    ).toEqual({ outcome: 'unbound' })
+  })
+
+  it('tolerates an empty or absent metadata map', () => {
+    expect(findWorktreeReservation(undefined, REQUEST)).toEqual({ outcome: 'unbound' })
+  })
+})

--- a/src/main/runtime/worktree-reservation-replay.test.ts
+++ b/src/main/runtime/worktree-reservation-replay.test.ts
@@ -39,11 +39,20 @@ describe('worktree reservation replay', () => {
     const binding = buildResourceReservationBinding(REQUEST, { boundAt: 5 })
 
     const lookup = findWorktreeReservation(
-      { 'repo::/a': meta(), 'repo::/b': meta({ reservation: binding }) },
+      {
+        'repo::/a': meta(),
+        'repo::/b': meta({ reservation: binding, hostId: 'local', instanceId: 'instance-1' })
+      },
       REQUEST
     )
 
-    expect(lookup).toEqual({ outcome: 'replay', worktreeId: 'repo::/b', binding })
+    expect(lookup).toEqual({
+      outcome: 'replay',
+      worktreeId: 'repo::/b',
+      hostId: 'local',
+      instanceId: 'instance-1',
+      binding
+    })
   })
 
   it('refuses a reused key whose ownership generation moved on', () => {

--- a/src/main/runtime/worktree-reservation-replay.ts
+++ b/src/main/runtime/worktree-reservation-replay.ts
@@ -1,0 +1,34 @@
+import {
+  describeResourceReservationConflict,
+  resourceReservationBindingMatchesRequest,
+  type ResourceReservationBinding,
+  type ResourceReservationRequest
+} from '../../shared/resource-reservation-binding'
+import type { WorktreeMeta } from '../../shared/worktree/meta-types'
+
+export type WorktreeReservationLookup =
+  | { outcome: 'unbound' }
+  | { outcome: 'replay'; worktreeId: string; binding: ResourceReservationBinding }
+  | { outcome: 'conflict'; worktreeId: string; message: string }
+
+/** Durable replay lookup: the binding lives in persisted workspace metadata, so a retry after a
+ *  lost reply — or after a host restart — resolves to the same workspace instead of a duplicate. */
+export function findWorktreeReservation(
+  allMeta: Readonly<Record<string, WorktreeMeta | undefined>> | undefined,
+  request: ResourceReservationRequest
+): WorktreeReservationLookup {
+  for (const [worktreeId, meta] of Object.entries(allMeta ?? {})) {
+    const binding = meta?.reservation
+    if (!binding || binding.key !== request.key) {
+      continue
+    }
+    return resourceReservationBindingMatchesRequest(binding, request)
+      ? { outcome: 'replay', worktreeId, binding }
+      : {
+          outcome: 'conflict',
+          worktreeId,
+          message: describeResourceReservationConflict(binding, request, worktreeId)
+        }
+  }
+  return { outcome: 'unbound' }
+}

--- a/src/main/runtime/worktree-reservation-replay.ts
+++ b/src/main/runtime/worktree-reservation-replay.ts
@@ -8,8 +8,8 @@ import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 
 export type WorktreeReservationLookup =
   | { outcome: 'unbound' }
-  | { outcome: 'replay'; worktreeId: string; binding: ResourceReservationBinding }
-  | { outcome: 'conflict'; worktreeId: string; message: string }
+  | { outcome: 'replay'; worktreeId: string; hostId: string; instanceId: string; binding: ResourceReservationBinding }
+  | { outcome: 'conflict'; worktreeId: string; hostId?: string; instanceId?: string; message: string }
 
 /** Durable replay lookup: the binding lives in persisted workspace metadata, so a retry after a
  *  lost reply — or after a host restart — resolves to the same workspace instead of a duplicate. */
@@ -22,11 +22,13 @@ export function findWorktreeReservation(
     if (!binding || binding.key !== request.key) {
       continue
     }
-    return resourceReservationBindingMatchesRequest(binding, request)
-      ? { outcome: 'replay', worktreeId, binding }
+    return resourceReservationBindingMatchesRequest(binding, request) && meta.hostId && meta.instanceId
+      ? { outcome: 'replay', worktreeId, hostId: meta.hostId, instanceId: meta.instanceId, binding }
       : {
           outcome: 'conflict',
           worktreeId,
+          ...(meta.hostId ? { hostId: meta.hostId } : {}),
+          ...(meta.instanceId ? { instanceId: meta.instanceId } : {}),
           message: describeResourceReservationConflict(binding, request, worktreeId)
         }
   }

--- a/src/main/startup/main-window-controller.ts
+++ b/src/main/startup/main-window-controller.ts
@@ -44,6 +44,7 @@ import {
   stopSyntheticTitleSpinnerTimer
 } from './synthetic-title-runtime'
 import { requireMainWindowServices } from './main-window-service-readiness'
+import { registerMainWindowCloseDisposer } from '../window/main-window-close-disposers'
 
 const TRAY_CREATE_FALLBACK_MS = 12_000
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
@@ -201,7 +202,7 @@ export function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}
         minIntervalMs: AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS
       })
   })
-  window.on('closed', () => {
+  registerMainWindowCloseDisposer(window, () => {
     if (state.mainWindow === window) {
       state.mainWindow = null
     }

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -38,6 +38,7 @@ import {
 import { startFolderRepoGitUpgradeWatch } from '../ipc/folder-repo-git-upgrade'
 import { scheduleMainWindowAutoUpdaterSetup } from './main-window-updater'
 import { registerRuntimeWindowLifecycle } from './runtime-window-lifecycle'
+import { registerMainWindowCloseDisposer } from './main-window-close-disposers'
 
 export { ensureAutoUpdaterConfigured, registerUpdaterHandlers } from './main-window-updater'
 
@@ -147,7 +148,7 @@ export function attachMainWindowServices(
     }
   )
 
-  mainWindow.on('closed', () => {
+  registerMainWindowCloseDisposer(mainWindow, () => {
     // Why: clear main-owned guest registrations on close so stale tab→webContents ids don't leak across relaunch/hot-reload.
     browserManager.unregisterAll()
   })
@@ -197,7 +198,7 @@ function registerTccPromptNoticeHandlers(mainWindow: BrowserWindow): void {
     }
   })
   // Why: macOS can stay windowless; drop stale closures without letting an old close clear newer handlers.
-  mainWindow.on('closed', () => {
+  registerMainWindowCloseDisposer(mainWindow, () => {
     if (activeTccPromptHandlerToken !== handlerToken) {
       return
     }
@@ -230,7 +231,7 @@ function registerAppReloadHandler(
     onBeforeRendererReload?.({ webContentsId: mainWebContents.id, ignoreCache: false })
     mainWebContents.reload()
   })
-  mainWindow.on('closed', () => {
+  registerMainWindowCloseDisposer(mainWindow, () => {
     if (activeAppReloadHandlerToken !== handlerToken) {
       return
     }
@@ -260,7 +261,7 @@ function registerFileDropRelay(mainWindow: BrowserWindow): void {
     mainWindow.webContents.send('terminal:file-drop', args)
   }
   ipcMain.on(channel, relayFileDrop)
-  mainWindow.on('closed', () => {
+  registerMainWindowCloseDisposer(mainWindow, () => {
     // Why: macOS keeps the process alive after window close; drop the closure so the destroyed window isn't retained.
     ipcMain.removeListener(channel, relayFileDrop)
   })

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -29,6 +29,7 @@ import {
   TRAFFIC_LIGHT_X
 } from './main-window-visual-lifecycle'
 import { installMainWindowWebviewSecurity } from './main-window-webview-security'
+import { registerMainWindowCloseDisposer } from './main-window-close-disposers'
 import { rectHasVisibleAreaOnAnyDisplay } from './window-bounds-validation'
 import { installWindowsPathRegistryChangeListener } from '../pty/windows-path-registry-change'
 
@@ -202,7 +203,7 @@ export function createMainWindow(
     store
   })
 
-  mainWindow.on('closed', () => {
+  registerMainWindowCloseDisposer(mainWindow, () => {
     closeDashboardPopout()
     state.clearInitialRevealFallbackTimer()
     closeLifecycle.dispose()

--- a/src/main/window/main-window-close-disposers.test.ts
+++ b/src/main/window/main-window-close-disposers.test.ts
@@ -1,0 +1,34 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+import type { BrowserWindow } from 'electron'
+import {
+  getMainWindowNativeCloseListenerBudget,
+  registerMainWindowCloseDisposer
+} from './main-window-close-disposers'
+
+describe('main-window close disposers', () => {
+  it('composes subsystem cleanup behind one native closed listener', () => {
+    const window = new EventEmitter() as BrowserWindow
+    const first = vi.fn()
+    const second = vi.fn()
+
+    registerMainWindowCloseDisposer(window, first)
+    registerMainWindowCloseDisposer(window, second)
+
+    expect(getMainWindowNativeCloseListenerBudget(window)).toBe(1)
+    window.emit('closed')
+    expect(first).toHaveBeenCalledOnce()
+    expect(second).toHaveBeenCalledOnce()
+  })
+
+  it('allows a subsystem to unregister before close', () => {
+    const window = new EventEmitter() as BrowserWindow
+    const dispose = vi.fn()
+    const unregister = registerMainWindowCloseDisposer(window, dispose)
+
+    unregister()
+    window.emit('closed')
+
+    expect(dispose).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window/main-window-close-disposers.ts
+++ b/src/main/window/main-window-close-disposers.ts
@@ -1,0 +1,53 @@
+import type { BrowserWindow } from 'electron'
+
+type MainWindowDisposer = () => void
+
+interface MainWindowCloseState {
+  closed: boolean
+  disposers: Set<MainWindowDisposer>
+}
+
+const closeStates = new WeakMap<BrowserWindow, MainWindowCloseState>()
+
+function getCloseState(mainWindow: BrowserWindow): MainWindowCloseState {
+  const existing = closeStates.get(mainWindow)
+  if (existing) {
+    return existing
+  }
+
+  const state: MainWindowCloseState = { closed: false, disposers: new Set() }
+  closeStates.set(mainWindow, state)
+  // One native listener owns the close fan-out. Subsystems register plain disposers below.
+  mainWindow.once('closed', () => {
+    state.closed = true
+    const disposers = [...state.disposers]
+    state.disposers.clear()
+    for (const dispose of disposers) {
+      try {
+        dispose()
+      } catch (error) {
+        console.error('[window] Main-window close disposer failed', error)
+      }
+    }
+  })
+  return state
+}
+
+/** Register cleanup without adding another native BrowserWindow `closed` listener. */
+export function registerMainWindowCloseDisposer(
+  mainWindow: BrowserWindow,
+  dispose: MainWindowDisposer
+): () => void {
+  const state = getCloseState(mainWindow)
+  if (state.closed) {
+    dispose()
+    return () => {}
+  }
+  state.disposers.add(dispose)
+  return () => state.disposers.delete(dispose)
+}
+
+export function getMainWindowNativeCloseListenerBudget(mainWindow: BrowserWindow): number {
+  getCloseState(mainWindow)
+  return mainWindow.listenerCount('closed')
+}

--- a/src/main/window/main-window-visual-lifecycle.ts
+++ b/src/main/window/main-window-visual-lifecycle.ts
@@ -1,5 +1,6 @@
 import { ipcMain, type BrowserWindow } from 'electron'
 import { isMacosTahoeOrNewer } from './macos-tahoe-release'
+import { registerMainWindowCloseDisposer } from './main-window-close-disposers'
 
 const activeRepaintJiggles = new WeakSet<BrowserWindow>()
 export function forceRepaint(window: BrowserWindow): void {
@@ -89,7 +90,7 @@ export function installMacosVisibilityRepaint(window: BrowserWindow): void {
       window.webContents.invalidate()
     }
   })
-  window.on('closed', () => {
+  registerMainWindowCloseDisposer(window, () => {
     clearDelayedRepaint()
     ipcMain.removeListener('ui:window-revealed', onRendererRevealed)
   })

--- a/src/main/window/runtime-window-lifecycle.ts
+++ b/src/main/window/runtime-window-lifecycle.ts
@@ -17,6 +17,7 @@ import { registerRendererDocumentNavigation } from './renderer-document-navigati
 import { createRuntimeRendererNotificationSender } from './runtime-renderer-notification-sender'
 import { requestSessionTabCloseFromRenderer } from './session-tab-close-request-relay'
 import { requestTerminalTabCloseFromRenderer } from './terminal-tab-close-request-relay'
+import { registerMainWindowCloseDisposer } from './main-window-close-disposers'
 
 let runtimeNotifierTokenCounter = 0
 let activeRuntimeNotifierToken: number | null = null
@@ -230,7 +231,7 @@ export function registerRuntimeWindowLifecycle(
   mainWebContents.on('render-process-gone', () => {
     rendererNotifications.onRendererProcessGone()
   })
-  mainWindow.on('closed', () => {
+  registerMainWindowCloseDisposer(mainWindow, () => {
     rendererNotifications.close()
     runtime.markGraphUnavailable(mainWindow.id)
     if (activeRuntimeNotifierToken === notifierToken) {

--- a/src/main/window/session-tab-close-request-relay.ts
+++ b/src/main/window/session-tab-close-request-relay.ts
@@ -7,6 +7,7 @@ import type {
   SessionTabCloseResponse
 } from '../../shared/session-tab-close'
 import { SESSION_TAB_CLOSE_TIMEOUT_ERROR } from '../../shared/session-tab-close'
+import { registerMainWindowCloseDisposer } from './main-window-close-disposers'
 
 const SESSION_TAB_CLOSE_CONFIRMATION_MS = 5 * 60_000
 const SESSION_TAB_CLOSE_RESPONSE_GRACE_MS = 5_000
@@ -30,7 +31,7 @@ export async function requestSessionTabCloseFromRenderer(
       settled = true
       clearTimeout(timeout)
       ipcMain.removeListener('ui:sessionTabCloseResponse', onResponse)
-      mainWindow.removeListener('closed', onRendererUnavailable)
+      unregisterWindowClose()
       webContents.removeListener('destroyed', onRendererUnavailable)
       webContents.removeListener('render-process-gone', onRendererUnavailable)
       webContents.removeListener('did-start-loading', onRendererUnavailable)
@@ -54,7 +55,10 @@ export async function requestSessionTabCloseFromRenderer(
     )
     timeout.unref?.()
     ipcMain.on('ui:sessionTabCloseResponse', onResponse)
-    mainWindow.once('closed', onRendererUnavailable)
+    const unregisterWindowClose = registerMainWindowCloseDisposer(
+      mainWindow,
+      onRendererUnavailable
+    )
     webContents.once('destroyed', onRendererUnavailable)
     webContents.once('render-process-gone', onRendererUnavailable)
     webContents.once('did-start-loading', onRendererUnavailable)

--- a/src/main/worktree-removal-safety.ts
+++ b/src/main/worktree-removal-safety.ts
@@ -26,7 +26,8 @@ const ORCA_OWNED_PROVENANCE_META_KEYS = [
   'orcaCreationWorkspaceLayout',
   'automationProvenance',
   'cliProvenance',
-  'creatorProvenance'
+  'creatorProvenance',
+  'reservation'
 ] as const
 type UnregisteredOrcaCleanupMeta = Pick<
   WorktreeMeta,

--- a/src/main/worktree-removal-safety.ts
+++ b/src/main/worktree-removal-safety.ts
@@ -27,7 +27,8 @@ const ORCA_OWNED_PROVENANCE_META_KEYS = [
   'automationProvenance',
   'cliProvenance',
   'creatorProvenance',
-  'reservation'
+  'reservation',
+  'reservationCreateReceipt'
 ] as const
 type UnregisteredOrcaCleanupMeta = Pick<
   WorktreeMeta,

--- a/src/main/worktree-reservation-immutability.test.ts
+++ b/src/main/worktree-reservation-immutability.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { buildResourceReservationBinding } from '../shared/resource-reservation-binding'
+import { stripOrcaProvenanceMetaUpdates } from './worktree-removal-safety'
+
+const BINDING = buildResourceReservationBinding(
+  {
+    key: 'key-1',
+    reservationId: 'res-1',
+    sessionId: 'session-1',
+    resourceKind: 'worktree',
+    ownershipGeneration: 1
+  },
+  { boundAt: 10 }
+)
+
+describe('worktree reservation immutability', () => {
+  it('drops a reservation from a metadata update so worktree.set cannot rewrite the binding', () => {
+    expect(stripOrcaProvenanceMetaUpdates({ comment: 'keep me', reservation: BINDING })).toEqual({
+      comment: 'keep me'
+    })
+  })
+
+  it('drops a reservation even when it is the only field offered', () => {
+    expect(stripOrcaProvenanceMetaUpdates({ reservation: BINDING })).toEqual({})
+  })
+})

--- a/src/main/worktree-trash.test.ts
+++ b/src/main/worktree-trash.test.ts
@@ -2,13 +2,14 @@ import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../shared/repo-types'
 import {
   collectWorktreeTrashSweepRoots,
   getWorktreeTrashRoot,
   isWorktreeTrashEntryName,
   moveWorktreeDirectoryToTrash,
+  removeStaleWorktreeTrashEntry,
   restoreWorktreeDirectoryFromTrash,
   scheduleWorktreeTrashDeletion,
   sweepStaleWorktreeTrash,
@@ -119,6 +120,38 @@ describe('scheduleWorktreeTrashDeletion', () => {
 })
 
 describe('sweepStaleWorktreeTrash', () => {
+  it('recovers from a one-shot POSIX ENOTEMPTY removal race', async () => {
+    const removeTree = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('directory not empty'), { code: 'ENOTEMPTY' }))
+      .mockResolvedValueOnce(undefined)
+    const delay = vi.fn().mockResolvedValue(undefined)
+
+    await removeStaleWorktreeTrashEntry('/workspace/.orca-worktree-trash/wt-1-abcdef01', {
+      removeTree,
+      delay
+    })
+
+    expect(removeTree).toHaveBeenCalledTimes(2)
+    expect(delay).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds persistent ENOTEMPTY retries with actionable diagnostics', async () => {
+    const removeTree = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('directory not empty'), { code: 'ENOTEMPTY' }))
+
+    await expect(
+      removeStaleWorktreeTrashEntry('/workspace/.orca-worktree-trash/wt-1-abcdef01', {
+        removeTree,
+        delay: vi.fn().mockResolvedValue(undefined)
+      })
+    ).rejects.toThrow(
+      'Failed to remove stale worktree trash entry /workspace/.orca-worktree-trash/wt-1-abcdef01 after 3 attempt(s)'
+    )
+    expect(removeTree).toHaveBeenCalledTimes(3)
+  })
+
   it('removes leftover entries from both workspace layouts and nothing else', async () => {
     const nestedTrashRoot = join(scratchDir, 'repo', WORKTREE_TRASH_DIR_NAME)
     const flatTrashRoot = join(scratchDir, WORKTREE_TRASH_DIR_NAME)

--- a/src/main/worktree-trash.ts
+++ b/src/main/worktree-trash.ts
@@ -19,6 +19,44 @@ const TRASH_ENTRY_PATTERN = /^wt-\d+-[0-9a-f]{8}$/
 
 // Why: the sweep must stay cheap on a workspace root holding many repo containers.
 const TRASH_SWEEP_MAX_CONTAINERS = 200
+export const TRASH_SWEEP_REMOVE_MAX_ATTEMPTS = 3
+const TRASH_SWEEP_RETRY_DELAY_MS = 25
+
+type RemoveTree = (path: string) => Promise<void>
+
+function isDirectoryNotEmpty(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOTEMPTY'
+  )
+}
+
+export async function removeStaleWorktreeTrashEntry(
+  target: string,
+  options: { removeTree?: RemoveTree; delay?: (milliseconds: number) => Promise<void> } = {}
+): Promise<void> {
+  const removeTree = options.removeTree ?? removeHostTree
+  const delay =
+    options.delay ??
+    ((milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)))
+  for (let attempt = 1; attempt <= TRASH_SWEEP_REMOVE_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await removeTree(target)
+      return
+    } catch (error) {
+      if (!isDirectoryNotEmpty(error) || attempt === TRASH_SWEEP_REMOVE_MAX_ATTEMPTS) {
+        throw new Error(
+          `Failed to remove stale worktree trash entry ${target} after ${attempt} attempt(s)`,
+          { cause: error }
+        )
+      }
+      // POSIX recursive removal may observe a directory recreated by a writer between scan and rmdir.
+      await delay(TRASH_SWEEP_RETRY_DELAY_MS * attempt)
+    }
+  }
+}
 
 /** Trash root for a worktree: a hidden sibling, so the rename always stays on one volume. */
 export function getWorktreeTrashRoot(worktreePath: string): string {
@@ -116,7 +154,7 @@ export async function sweepStaleWorktreeTrash(
         continue
       }
       try {
-        await removeHostTree(join(trashRoot, entry))
+        await removeStaleWorktreeTrashEntry(join(trashRoot, entry))
         removed += 1
       } catch (error) {
         console.warn(

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -196,6 +196,14 @@ export const AUTOMATION_OWNER_FENCING_UPDATE_REQUIRED_MESSAGE =
   'Editing automations on this host requires a newer Orca server. Update the HUB and try again.'
 export const AUTOMATION_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY =
   'automation.create-idempotency.v1' as const
+// Why: older hosts strip the create-time `reservation` param (zod drops unknown keys) and answer
+// with an unbound resource, so a caller that needs a ledger-bound create must refuse rather than
+// create something it cannot attribute. Also gates the explicit terminal-inventory completeness
+// verdict, whose absence must read as unverifiable rather than complete.
+export const RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY =
+  'resource.reservation-attribution.v1' as const
+export const RESOURCE_RESERVATION_ATTRIBUTION_UPDATE_REQUIRED_MESSAGE =
+  'Reservation-bound create requires a newer Orca server. Update the host and try again.'
 
 // Generic native clients include the CLI and must not claim Electron-only page
 // placement support.
@@ -292,7 +300,8 @@ export const RUNTIME_CAPABILITIES = [
   SKILL_DELETE_CAPABILITY,
   AUTOMATION_LIST_HOST_SCOPE_RUNTIME_CAPABILITY,
   AUTOMATION_OWNER_FENCING_RUNTIME_CAPABILITY,
-  AUTOMATION_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY
+  AUTOMATION_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
+  RESOURCE_RESERVATION_ATTRIBUTION_RUNTIME_CAPABILITY
 ] as const
 
 export type RuntimeCapability = (typeof RUNTIME_CAPABILITIES)[number] | (string & {})

--- a/src/shared/resource-reservation-binding.test.ts
+++ b/src/shared/resource-reservation-binding.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ResourceReservationRequestSchema,
+  buildResourceReservationBinding,
+  describeResourceReservationConflict,
+  resourceReservationBindingMatchesRequest,
+  type ResourceReservationRequest
+} from './resource-reservation-binding'
+
+function request(overrides: Partial<ResourceReservationRequest> = {}): ResourceReservationRequest {
+  return {
+    key: 'key-1',
+    reservationId: 'res-1',
+    sessionId: 'session-1',
+    resourceKind: 'worktree',
+    ownershipGeneration: 3,
+    issuer: 'openloop',
+    ...overrides
+  }
+}
+
+describe('resource reservation binding identity', () => {
+  it('treats a byte-identical repeat as the same request, not a second use', () => {
+    const binding = buildResourceReservationBinding(request(), { boundAt: 100 })
+
+    expect(resourceReservationBindingMatchesRequest(binding, request())).toBe(true)
+  })
+
+  it.each([
+    ['reservationId', { reservationId: 'res-2' }],
+    ['sessionId', { sessionId: 'session-2' }],
+    ['ownershipGeneration', { ownershipGeneration: 4 }],
+    ['issuer', { issuer: 'other' }]
+  ])('refuses a repeat whose %s disagrees', (_field, overrides) => {
+    const binding = buildResourceReservationBinding(request(), { boundAt: 100 })
+
+    expect(resourceReservationBindingMatchesRequest(binding, request(overrides))).toBe(false)
+  })
+
+  it('never lets a client clock set the bind time', () => {
+    const binding = buildResourceReservationBinding(
+      { ...request(), boundAt: 1 } as ResourceReservationRequest,
+      { boundAt: 999 }
+    )
+
+    expect(binding.boundAt).toBe(999)
+  })
+
+  it('names the resource and the disagreeing fields in the conflict text', () => {
+    const binding = buildResourceReservationBinding(request(), { boundAt: 100 })
+
+    const message = describeResourceReservationConflict(
+      binding,
+      request({ sessionId: 'session-2' }),
+      'repo-1::/tmp/wt'
+    )
+
+    expect(message).toContain('repo-1::/tmp/wt')
+    expect(message).toContain('sessionId session-1 != session-2')
+    expect(message).toContain('single-use')
+  })
+})
+
+describe('resource reservation request schema', () => {
+  it('rejects a fractional ownership generation', () => {
+    expect(
+      ResourceReservationRequestSchema.safeParse(request({ ownershipGeneration: 1.5 })).success
+    ).toBe(false)
+  })
+
+  it('rejects an unknown resource kind', () => {
+    expect(
+      ResourceReservationRequestSchema.safeParse({
+        ...request(),
+        resourceKind: 'automation'
+      }).success
+    ).toBe(false)
+  })
+
+  it('accepts a binding with no issuer', () => {
+    const parsed = ResourceReservationRequestSchema.safeParse({
+      key: 'k',
+      reservationId: 'r',
+      sessionId: 's',
+      resourceKind: 'terminal',
+      ownershipGeneration: 0
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+})

--- a/src/shared/resource-reservation-binding.ts
+++ b/src/shared/resource-reservation-binding.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod'
+
+export const RESOURCE_RESERVATION_KINDS = ['worktree', 'terminal'] as const
+export type ResourceReservationKind = (typeof RESOURCE_RESERVATION_KINDS)[number]
+
+/** Caller-generated single-use create key plus the external ledger binding it commits to.
+ *  Every field is chosen by the caller before the resource exists, so a create whose reply was
+ *  lost can still be attributed without heuristics. */
+export type ResourceReservationRequest = {
+  /** Single-use idempotency key. Also the durable replay lookup key. */
+  key: string
+  /** Ledger reservation nonce this create is bound to. */
+  reservationId: string
+  /** Caller session/instance that owns the reservation. */
+  sessionId: string
+  /** Resource the caller intends to create; must match the create surface it is sent to. */
+  resourceKind: ResourceReservationKind
+  /** Caller ownership generation. A later generation must never adopt an earlier binding. */
+  ownershipGeneration: number
+  /** Namespace of the issuing ledger, e.g. `openloop`. */
+  issuer?: string
+}
+
+/** A request the host committed atomically with one provider resource. Immutable after create.
+ *  No resource id is carried inside: the binding is stored on the resource record itself, so the
+ *  stable id sits beside it in every show/list projection and cannot drift from it. */
+export type ResourceReservationBinding = ResourceReservationRequest & {
+  /** Host-stamped bind time; a client clock never sets it. */
+  boundAt: number
+}
+
+export const RESOURCE_RESERVATION_CONFLICT_ERROR = 'reservation_conflict' as const
+
+export const ResourceReservationRequestSchema = z.object({
+  key: z.string().min(1).max(128),
+  reservationId: z.string().min(1).max(256),
+  sessionId: z.string().min(1).max(256),
+  resourceKind: z.enum(RESOURCE_RESERVATION_KINDS),
+  // Why int: a generation is a counter, and a fractional value would make the
+  // "never adopt an earlier generation" comparison ambiguous across encoders.
+  ownershipGeneration: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  issuer: z.string().min(1).max(128).optional()
+})
+
+export function buildResourceReservationBinding(
+  request: ResourceReservationRequest,
+  options: { boundAt: number }
+): ResourceReservationBinding {
+  return {
+    key: request.key,
+    reservationId: request.reservationId,
+    sessionId: request.sessionId,
+    resourceKind: request.resourceKind,
+    ownershipGeneration: request.ownershipGeneration,
+    ...(request.issuer ? { issuer: request.issuer } : {}),
+    boundAt: options.boundAt
+  }
+}
+
+/** Fields whose disagreement makes a repeat of the same key a different request, not a retry. */
+function reservationBindingMismatches(
+  binding: ResourceReservationBinding,
+  request: ResourceReservationRequest
+): string[] {
+  const mismatches: string[] = []
+  if (binding.reservationId !== request.reservationId) {
+    mismatches.push(`reservationId ${binding.reservationId} != ${request.reservationId}`)
+  }
+  if (binding.sessionId !== request.sessionId) {
+    mismatches.push(`sessionId ${binding.sessionId} != ${request.sessionId}`)
+  }
+  if (binding.resourceKind !== request.resourceKind) {
+    mismatches.push(`resourceKind ${binding.resourceKind} != ${request.resourceKind}`)
+  }
+  if (binding.ownershipGeneration !== request.ownershipGeneration) {
+    mismatches.push(
+      `ownershipGeneration ${binding.ownershipGeneration} != ${request.ownershipGeneration}`
+    )
+  }
+  if ((binding.issuer ?? '') !== (request.issuer ?? '')) {
+    mismatches.push(`issuer ${binding.issuer ?? '(none)'} != ${request.issuer ?? '(none)'}`)
+  }
+  return mismatches
+}
+
+export function resourceReservationBindingMatchesRequest(
+  binding: ResourceReservationBinding,
+  request: ResourceReservationRequest
+): boolean {
+  return binding.key === request.key && reservationBindingMismatches(binding, request).length === 0
+}
+
+/** Refusal text for a reused key whose binding disagrees — never returned as a successful replay. */
+export function describeResourceReservationConflict(
+  binding: ResourceReservationBinding,
+  request: ResourceReservationRequest,
+  resourceId: string
+): string {
+  const mismatches = reservationBindingMismatches(binding, request)
+  return `Reservation key "${request.key}" is already bound to ${binding.resourceKind} ${resourceId} with a different binding (${mismatches.join('; ')}). Reservation keys are single-use.`
+}

--- a/src/shared/resource-reservation-binding.ts
+++ b/src/shared/resource-reservation-binding.ts
@@ -42,6 +42,11 @@ export const ResourceReservationRequestSchema = z.object({
   issuer: z.string().min(1).max(128).optional()
 })
 
+/** Complete host-stamped binding schema used at durable trust boundaries. */
+export const ResourceReservationBindingSchema = ResourceReservationRequestSchema.extend({
+  boundAt: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER)
+})
+
 export function buildResourceReservationBinding(
   request: ResourceReservationRequest,
   options: { boundAt: number }

--- a/src/shared/resource-reservation-binding.ts
+++ b/src/shared/resource-reservation-binding.ts
@@ -47,6 +47,12 @@ export const ResourceReservationBindingSchema = ResourceReservationRequestSchema
   boundAt: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER)
 })
 
+/** Binding accepted by terminal-only authority stores. Keep the generic schema broad because
+ * worktree reservation persistence legitimately uses the other discriminator. */
+export const TerminalReservationBindingSchema = ResourceReservationBindingSchema.extend({
+  resourceKind: z.literal('terminal')
+})
+
 export function buildResourceReservationBinding(
   request: ResourceReservationRequest,
   options: { boundAt: number }

--- a/src/shared/runtime-listing-host-scope.ts
+++ b/src/shared/runtime-listing-host-scope.ts
@@ -9,6 +9,11 @@ import { parseExecutionHostId, type ExecutionHostId } from './execution-host'
 export type RuntimeListingHostScope = {
   hostIds: ExecutionHostId[]
   omittedHostIds: ExecutionHostId[]
+  /** Explicit completeness verdict. Absent on hosts that predate the field, which means the
+   * inventory is unverifiable rather than complete. Pagination truncation is independent. */
+  complete?: boolean
+  /** Host clock at which completeness was observed, allowing callers to bound staleness. */
+  observedAt?: number
 }
 
 /**

--- a/src/shared/runtime-terminal-contracts.ts
+++ b/src/shared/runtime-terminal-contracts.ts
@@ -7,6 +7,7 @@ import type { StartupCommandDelivery } from './codex-startup-delivery'
 import type { ExecutionHostId } from './execution-host'
 import type { PtyIncarnationId } from './pty-incarnation'
 import type { RuntimeListingHostScope } from './runtime-listing-host-scope'
+import type { ResourceReservationBinding } from './resource-reservation-binding'
 import type { RuntimeMobileSessionTabsResult } from './runtime-session-contracts'
 import type { TabGroupLayoutNode } from './tab-types'
 import type { TerminalExitCause } from './terminal-exit-cause'
@@ -34,6 +35,9 @@ export type RuntimeTerminalSummary = {
   exitCause?: TerminalExitCause
   /** Absent when the host predates the field or could not name the execution host. */
   executionHostId?: ExecutionHostId
+  /** Immutable caller-supplied reservation this terminal was created under; absent means the
+   *  terminal has no ledger binding. Never infer one from the handle alone. */
+  reservation?: ResourceReservationBinding
 }
 
 export type RuntimeTerminalVisualTerminalNode = {
@@ -283,6 +287,9 @@ export type RuntimeTerminalCreate = {
   title: string | null
   executionHostId?: ExecutionHostId
   hostPlatform?: NodeJS.Platform
+  /** Echo of the reservation this create was bound to, so a caller can confirm the host honored
+   *  it rather than silently dropping the param. */
+  reservation?: ResourceReservationBinding
   surface?: 'background' | 'visible'
   warning?: string
   agentSessionDisposition?: 'created' | 'adopted'

--- a/src/shared/worktree/meta-types.ts
+++ b/src/shared/worktree/meta-types.ts
@@ -13,6 +13,7 @@ import type { TuiAgent } from '../tui-agent'
 import type { OrcaWorkspaceLayout } from '../global-settings-types'
 import type { DiffComment, MobileDiffReviewState } from '../diff-comment-types'
 import type { ResourceReservationBinding } from '../resource-reservation-binding'
+import type { WorktreeReservationCreateReceipt } from './reservation-create-receipt'
 
 // ─── Worktree metadata (persisted user-authored fields only) ─────────
 export type WorktreeMeta = {
@@ -95,4 +96,6 @@ export type WorktreeMeta = {
   cliProvenance?: CliWorkspaceProvenance
   /** See {@link Worktree.reservation}. System-owned; meta updates can never change it. */
   reservation?: ResourceReservationBinding
+  /** Durable non-derivable response metadata for exact reservation replay. */
+  reservationCreateReceipt?: WorktreeReservationCreateReceipt
 }

--- a/src/shared/worktree/meta-types.ts
+++ b/src/shared/worktree/meta-types.ts
@@ -12,6 +12,7 @@ import type {
 import type { TuiAgent } from '../tui-agent'
 import type { OrcaWorkspaceLayout } from '../global-settings-types'
 import type { DiffComment, MobileDiffReviewState } from '../diff-comment-types'
+import type { ResourceReservationBinding } from '../resource-reservation-binding'
 
 // ─── Worktree metadata (persisted user-authored fields only) ─────────
 export type WorktreeMeta = {
@@ -92,4 +93,6 @@ export type WorktreeMeta = {
   automationProvenance?: AutomationWorkspaceProvenance
   /** System-owned provenance for workspaces created via `orca worktree create`. */
   cliProvenance?: CliWorkspaceProvenance
+  /** See {@link Worktree.reservation}. System-owned; meta updates can never change it. */
+  reservation?: ResourceReservationBinding
 }

--- a/src/shared/worktree/reservation-create-receipt.ts
+++ b/src/shared/worktree/reservation-create-receipt.ts
@@ -1,0 +1,17 @@
+import type { WorktreeLineageWarning } from './lineage-types'
+
+/** Immutable, non-derivable parts of a reservation-bearing worktree create response. */
+export type WorktreeReservationCreateReceipt = {
+  version: 1
+  warnings: WorktreeLineageWarning[]
+  warning?: string
+  startupTerminal?: {
+    spawned: boolean
+    handle?: string
+    tabId?: string
+    paneKey?: string | null
+    ptyId?: string | null
+    surface?: 'visible' | 'background'
+  }
+  agentTerminalHandle?: string
+}

--- a/src/shared/worktree/reservation-create-receipt.ts
+++ b/src/shared/worktree/reservation-create-receipt.ts
@@ -1,17 +1,46 @@
-import type { WorktreeLineageWarning } from './lineage-types'
+import { z } from 'zod'
 
 /** Immutable, non-derivable parts of a reservation-bearing worktree create response. */
-export type WorktreeReservationCreateReceipt = {
-  version: 1
-  warnings: WorktreeLineageWarning[]
-  warning?: string
-  startupTerminal?: {
-    spawned: boolean
-    handle?: string
-    tabId?: string
-    paneKey?: string | null
-    ptyId?: string | null
-    surface?: 'visible' | 'background'
-  }
-  agentTerminalHandle?: string
-}
+export const WorktreeReservationCreateReceiptSchema = z
+  .object({
+    version: z.literal(1),
+    warnings: z.array(
+      z.object({
+        code: z.enum([
+          'LINEAGE_PARENT_CONTEXT_MISSING',
+          'LINEAGE_PARENT_CONTEXT_CONFLICT',
+          'LINEAGE_PARENT_INSTANCE_STALE'
+        ]),
+        message: z.string(),
+        details: z.record(z.string(), z.unknown()).optional()
+      })
+    ),
+    warning: z.string().optional(),
+    startupTerminal: z
+      .object({
+        spawned: z.boolean(),
+        handle: z.string().min(1).optional(),
+        tabId: z.string().min(1).optional(),
+        paneKey: z.string().min(1).nullable().optional(),
+        ptyId: z.string().min(1).nullable().optional(),
+        surface: z.enum(['visible', 'background']).optional()
+      })
+      .optional(),
+    agentTerminalHandle: z.string().min(1).optional()
+  })
+  .superRefine((receipt, context) => {
+    if (
+      receipt.agentTerminalHandle !== undefined &&
+      receipt.agentTerminalHandle !== receipt.startupTerminal?.handle
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['agentTerminalHandle'],
+        message: 'agentTerminalHandle must match startupTerminal.handle'
+      })
+    }
+  })
+
+export type WorktreeReservationCreateReceipt = z.infer<
+  typeof WorktreeReservationCreateReceiptSchema
+>

--- a/src/shared/worktree/types.ts
+++ b/src/shared/worktree/types.ts
@@ -6,6 +6,7 @@ import type { DiffComment, MobileDiffReviewState } from '../diff-comment-types'
 import type { EphemeralVmCheckoutMode } from '../orca-yaml-hook-types'
 import type { BuiltInWorktreeVisibilitySourceId } from '../repo-types'
 import type { WorktreeIdentity } from './identity'
+import type { ResourceReservationBinding } from '../resource-reservation-binding'
 
 export type WorkspaceLinkedItem = {
   provider: 'github' | 'gitlab' | 'linear' | 'jira'
@@ -141,6 +142,9 @@ export type Worktree = {
   mobileDiffReview?: MobileDiffReviewState
   automationProvenance?: AutomationWorkspaceProvenance
   cliProvenance?: CliWorkspaceProvenance
+  /** Immutable caller-supplied reservation this workspace was created under. Absent means the
+   *  workspace has no ledger binding — never infer one from other provenance. */
+  reservation?: ResourceReservationBinding
 } & GitWorktreeInfo
 
 /** Provenance for workspaces created through `orca worktree create`. Absent on

--- a/src/shared/worktree/types.ts
+++ b/src/shared/worktree/types.ts
@@ -7,6 +7,7 @@ import type { EphemeralVmCheckoutMode } from '../orca-yaml-hook-types'
 import type { BuiltInWorktreeVisibilitySourceId } from '../repo-types'
 import type { WorktreeIdentity } from './identity'
 import type { ResourceReservationBinding } from '../resource-reservation-binding'
+import type { WorktreeReservationCreateReceipt } from './reservation-create-receipt'
 
 export type WorkspaceLinkedItem = {
   provider: 'github' | 'gitlab' | 'linear' | 'jira'
@@ -145,6 +146,8 @@ export type Worktree = {
   /** Immutable caller-supplied reservation this workspace was created under. Absent means the
    *  workspace has no ledger binding — never infer one from other provenance. */
   reservation?: ResourceReservationBinding
+  /** Durable non-derivable response metadata for exact reservation replay. */
+  reservationCreateReceipt?: WorktreeReservationCreateReceipt
 } & GitWorktreeInfo
 
 /** Provenance for workspaces created through `orca worktree create`. Absent on


### PR DESCRIPTION
Adds a public, capability-gated reservation contract for worktree and terminal creation. Caller-generated idempotency keys are bound to immutable reservation metadata, replay to the same resource, and conflict on mismatched reuse. Worktree and terminal inventory expose the binding, and terminal list reports explicit host-scope completeness so an incomplete federated inventory cannot be mistaken for absence.

The dogfood branch also fixes two startup lifecycle defects: all main-window close cleanup now composes behind one native `BrowserWindow` listener, and stale worktree-trash cleanup gives transient POSIX `ENOTEMPTY` races a bounded three-attempt retry with actionable terminal diagnostics.

Validation:
- all Node, CLI, and web TypeScript checks pass
- changed-code quality gate: 0 findings across the original reservation change
- affected reservation suite: 3,567 passed, 1 skipped across 251 files
- startup lifecycle regression suite: 19 passed across 2 files
- TypeScript project verification passes after the startup fixes

One pre-existing terminal stream fuzz test exceeds its 30s timeout in this checkout; the test and all imported implementation/config files are byte-identical to upstream HEAD and are not changed by this PR.

OpenLoop tracking: openloop-i0lrpa.3057.3000.3000

Closes: openloop-i0lrpa.3057.3005, openloop-i0lrpa.3057.3006
