### PR TITLE
perf(remote): replace the perpetual idle inspection timer with a 45s post-activity schedule

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -40,9 +40,10 @@ export type AgentCompletionCoordinatorOptions = {
   shouldSuppressConfirmedProcessExitCompletion?: (exited: RecognizedAgentProcess) => boolean
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean
-  // Why: returning false disarms the idle no-evidence timer so the pane arms
-  // inspections only from pane activity (output/replay/title/hook). Remote
-  // panes use this — see shouldPollNoEvidenceProcessCadenceForPty.
+  // Why: returning false disarms the perpetual no-evidence timer so the pane
+  // inspects only inside the bounded window after pane activity
+  // (output/replay/title/hook). Remote panes use this — see
+  // shouldPollNoEvidenceProcessCadenceForPty.
   shouldPollNoEvidenceProcessCadence?: () => boolean
   // Why: where one inspection is a whole-process-table scan (local Windows
   // PowerShell/CIM) or a host round trip plus a host-side scan (remote/SSH),

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -40,11 +40,9 @@ export type AgentCompletionCoordinatorOptions = {
   shouldSuppressConfirmedProcessExitCompletion?: (exited: RecognizedAgentProcess) => boolean
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean
-  // Why: a host that publishes foreground evidence with its inventory lets a
-  // pane without agent evidence stay push-driven instead of scheduling
-  // redundant host process-table reads while idle. Wire a producer only once
-  // this renderer CONSUMES that evidence and can tell "no evidence published"
-  // from "host too old to publish it" — mixed-version hosts omit the field.
+  // Why: returning false disarms the idle no-evidence timer so the pane arms
+  // inspections only from pane activity (output/replay/title/hook). Remote
+  // panes use this — see shouldPollNoEvidenceProcessCadenceForPty.
   shouldPollNoEvidenceProcessCadence?: () => boolean
   // Why: where one inspection is a whole-process-table scan (local Windows
   // PowerShell/CIM) or a host round trip plus a host-side scan (remote/SSH),

--- a/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
@@ -13,7 +13,10 @@ import {
   resetAgentCompletionCoordinatorIdentitiesForTest
 } from './agent-completion-coordinator'
 import { resetAgentProcessInspectionQueueForTests } from './agent-process-inspection-queue'
-import { isAgentProcessInspectionCostly } from './agent-process-inspection-cost'
+import {
+  isAgentProcessInspectionCostly,
+  shouldPollNoEvidenceProcessCadenceForPty
+} from './agent-process-inspection-cost'
 import { toRemoteRuntimePtyId } from '../../../../shared/remote-runtime-pty-id'
 import { toAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
@@ -109,6 +112,96 @@ describe('agent completion no-evidence inspection cadence', () => {
     coordinator.observeOutputActivity()
     await vi.advanceTimersByTimeAsync(2_000)
     expect(inspectProcess).toHaveBeenCalledTimes(1)
+  })
+
+  describe('remote pane in the shipped option shape (push-driven, no idle timer)', () => {
+    // Why: mirror terminal-keydown-fit.ts exactly — both predicates fed from the
+    // same pty id — so these counts are what production remote panes pay.
+    function createRemoteCoordinator(
+      ptyId: string,
+      inspectProcess: AgentCompletionCoordinatorOptions['inspectProcess']
+    ) {
+      return createCoordinator(inspectProcess, {
+        getPtyId: () => ptyId,
+        isProcessInspectionCostly: () => isAgentProcessInspectionCostly(MAC_UA, ptyId),
+        shouldPollNoEvidenceProcessCadence: () => shouldPollNoEvidenceProcessCadenceForPty(ptyId)
+      })
+    }
+
+    it('costs zero idle host round trips for a silent remote pane with no evidence', async () => {
+      for (const ptyId of [
+        toAppSshPtyId('target-1', 'pty-1'),
+        toRemoteRuntimePtyId('term_1', 'env-a')
+      ]) {
+        const inspectProcess = vi.fn(async () => processResult(null, false))
+        const { coordinator } = createRemoteCoordinator(ptyId, inspectProcess)
+
+        coordinator.startProcessTracking()
+        await vi.advanceTimersByTimeAsync(60_000)
+
+        // Was 30 (2s idle), then 4 (15s no-evidence tier); now nothing is armed.
+        expect(inspectProcess).not.toHaveBeenCalled()
+        coordinator.dispose()
+      }
+    })
+
+    it('runs a bounded 2s hot window after a reattach paint, then disarms again', async () => {
+      // Why: a reattach paint routes through writeReplayData, which now records
+      // pane activity exactly like a live byte — so a restart onto a running
+      // remote agent gets the same 4 inspections (2s/4s/6s/8s inside the strict
+      // 10s window) a fresh output burst would.
+      const ptyId = toAppSshPtyId('target-1', 'pty-1')
+      const inspectProcess = vi.fn(async () => processResult(null, false))
+      const { coordinator } = createRemoteCoordinator(ptyId, inspectProcess)
+
+      coordinator.startProcessTracking()
+      coordinator.observeOutputActivity()
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(inspectProcess).toHaveBeenCalledTimes(4)
+
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(inspectProcess).toHaveBeenCalledTimes(4)
+    })
+
+    it('escalates a running agent found in the hot window to the active cadence', async () => {
+      // Why: the reattach hot window must be enough to establish process evidence,
+      // after which the pane is on the ordinary active/idle tiers and exit
+      // detection is unchanged from every other host.
+      const ptyId = toRemoteRuntimePtyId('term_1', 'env-a')
+      let foreground: string | null = 'claude'
+      const inspectProcess = vi.fn(async () => processResult(foreground, foreground !== null))
+      const { coordinator, dispatchCompletion } = createRemoteCoordinator(ptyId, inspectProcess)
+
+      coordinator.startProcessTracking()
+      coordinator.observeOutputActivity()
+      await vi.advanceTimersByTimeAsync(2_000)
+      expect(inspectProcess).toHaveBeenCalledTimes(1)
+
+      // Active tier is 750ms: well past the 10s hot window it must keep polling.
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(inspectProcess.mock.calls.length).toBeGreaterThan(30)
+
+      foreground = null
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(dispatchCompletion).toHaveBeenCalledWith(
+        'claude',
+        expect.objectContaining({ terminalIdleConfirmed: true })
+      )
+    })
+
+    it('re-arms the hot window from a title change or hook status with no output', async () => {
+      const ptyId = toAppSshPtyId('target-1', 'pty-1')
+      const inspectProcess = vi.fn(async () => processResult(null, false))
+      const { coordinator } = createRemoteCoordinator(ptyId, inspectProcess)
+
+      coordinator.startProcessTracking()
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(inspectProcess).not.toHaveBeenCalled()
+
+      coordinator.observeTitle('vim')
+      await vi.advanceTimersByTimeAsync(2_000)
+      expect(inspectProcess).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('looks within 2s, not 15s, when a reattach paint marks activity at tracking start', async () => {
@@ -362,5 +455,21 @@ describe('isAgentProcessInspectionCostly', () => {
   // inspection crosses a link (see remote-execution-host-pty.test.ts).
   it('does not relax a POSIX pane for an ssh-prefixed id carrying no relay pty id', () => {
     expect(isAgentProcessInspectionCostly(MAC_UA, 'ssh:target-1')).toBe(false)
+  })
+})
+
+describe('shouldPollNoEvidenceProcessCadenceForPty', () => {
+  it('disarms the idle timer only for remote-execution-host ptys', () => {
+    expect(shouldPollNoEvidenceProcessCadenceForPty(toAppSshPtyId('target-1', 'pty-1'))).toBe(false)
+    expect(shouldPollNoEvidenceProcessCadenceForPty(toRemoteRuntimePtyId('term_1', 'env-a'))).toBe(
+      false
+    )
+    expect(shouldPollNoEvidenceProcessCadenceForPty(toRemoteRuntimePtyId('term_1'))).toBe(false)
+  })
+
+  it('keeps the timer for local, daemon-shaped, null and bare-ssh ids', () => {
+    expect(shouldPollNoEvidenceProcessCadenceForPty('worktree-1|pane-1')).toBe(true)
+    expect(shouldPollNoEvidenceProcessCadenceForPty(null)).toBe(true)
+    expect(shouldPollNoEvidenceProcessCadenceForPty('ssh:target-1')).toBe(true)
   })
 })

--- a/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
@@ -145,22 +145,43 @@ describe('agent completion no-evidence inspection cadence', () => {
       }
     })
 
-    it('runs a bounded 2s hot window after a reattach paint, then disarms again', async () => {
-      // Why: a reattach paint routes through writeReplayData, which now records
-      // pane activity exactly like a live byte — so a restart onto a running
-      // remote agent gets the same 4 inspections (2s/4s/6s/8s inside the strict
-      // 10s window) a fresh output burst would.
+    it('runs the exact 2/4/6/8/10/25/40s schedule after activity, then disarms at 45s', async () => {
+      // Why: a reattach paint routes through writeReplayData, which records
+      // pane activity exactly like a live byte. The 2s hot burst catches the
+      // common case; three more looks 15s apart give a slow host up to 45s to
+      // show a foreground agent before the pane goes fully quiet.
       const ptyId = toAppSshPtyId('target-1', 'pty-1')
+      const inspectedAt: number[] = []
+      const inspectProcess = vi.fn(async () => {
+        inspectedAt.push(vi.getMockedSystemTime()?.getTime() ?? Date.now())
+        return processResult(null, false)
+      })
+      const { coordinator } = createRemoteCoordinator(ptyId, inspectProcess)
+      const start = Date.now()
+
+      coordinator.startProcessTracking()
+      coordinator.observeOutputActivity()
+      await vi.advanceTimersByTimeAsync(120_000)
+
+      expect(inspectedAt.map((at) => (at - start) / 1000)).toEqual([2, 4, 6, 8, 10, 25, 40])
+      // Nothing after 45s: the next tick (55s) finds the armed window closed.
+      expect(inspectProcess).toHaveBeenCalledTimes(7)
+    })
+
+    it('re-arms the full schedule from activity late in the armed window', async () => {
+      const ptyId = toRemoteRuntimePtyId('term_1', 'env-a')
       const inspectProcess = vi.fn(async () => processResult(null, false))
       const { coordinator } = createRemoteCoordinator(ptyId, inspectProcess)
 
       coordinator.startProcessTracking()
       coordinator.observeOutputActivity()
-      await vi.advanceTimersByTimeAsync(10_000)
-      expect(inspectProcess).toHaveBeenCalledTimes(4)
+      await vi.advanceTimersByTimeAsync(41_000)
+      expect(inspectProcess).toHaveBeenCalledTimes(7)
 
-      await vi.advanceTimersByTimeAsync(60_000)
-      expect(inspectProcess).toHaveBeenCalledTimes(4)
+      // A byte at 41s (a slow agent's first output) restarts the 2s hot burst.
+      coordinator.observeOutputActivity()
+      await vi.advanceTimersByTimeAsync(2_000)
+      expect(inspectProcess).toHaveBeenCalledTimes(8)
     })
 
     it('escalates a running agent found in the hot window to the active cadence', async () => {
@@ -201,6 +222,26 @@ describe('agent completion no-evidence inspection cadence', () => {
       coordinator.observeTitle('vim')
       await vi.advanceTimersByTimeAsync(2_000)
       expect(inspectProcess).toHaveBeenCalledTimes(1)
+    })
+
+    it('finds an agent that only appears on the third slow look', async () => {
+      // Why: the whole point of the 45s armed window — a box that is slow to
+      // exec the agent still gets caught before the pane disarms.
+      const ptyId = toAppSshPtyId('target-1', 'pty-1')
+      let foreground: string | null = null
+      const inspectProcess = vi.fn(async () => processResult(foreground, foreground !== null))
+      const { coordinator } = createRemoteCoordinator(ptyId, inspectProcess)
+
+      coordinator.startProcessTracking()
+      coordinator.observeOutputActivity()
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(inspectProcess).toHaveBeenCalledTimes(6)
+
+      foreground = 'codex'
+      await vi.advanceTimersByTimeAsync(15_000)
+      // The 40s look saw codex: the pane is on the 750ms active tier, well past
+      // the 45s point where a still-empty pane would have disarmed.
+      expect(inspectProcess.mock.calls.length).toBeGreaterThan(10)
     })
   })
 
@@ -272,11 +313,12 @@ describe('agent completion no-evidence inspection cadence', () => {
     coordinator.observeOutputActivity()
     await vi.advanceTimersByTimeAsync(12_000)
 
-    // Output arms 2s polls only for the 10s activity window; silence then
-    // disarms the host reads again instead of falling back to a slow timer.
-    expect(inspectProcess).toHaveBeenCalledTimes(4)
+    // Output arms 2s polls for the 10s hot window (2/4/6/8s, and the 10s tick
+    // armed at 8s still runs), then the no-evidence tier keeps three slower
+    // looks alive (10/25/40s) until the 45s armed window closes.
+    expect(inspectProcess).toHaveBeenCalledTimes(5)
     await vi.advanceTimersByTimeAsync(60_000)
-    expect(inspectProcess).toHaveBeenCalledTimes(4)
+    expect(inspectProcess).toHaveBeenCalledTimes(7)
   })
 
   it('does not re-arm no-evidence scans for output from hidden panes', async () => {

--- a/src/renderer/src/components/terminal-pane/agent-completion-poll-cadence.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-poll-cadence.ts
@@ -7,4 +7,11 @@ export const POLL_TIER_INTERVAL_MS: Record<PollCadenceTier, number> = {
   'no-evidence': 15_000
 }
 
+// Pane activity (output/replay/title/hook) on a pane with no agent evidence
+// runs the 2s idle cadence for this long...
 export const NO_EVIDENCE_ACTIVITY_HOT_WINDOW_MS = 10_000
+// ...and, where the idle no-evidence timer is disarmed (remote panes), keeps
+// cadence inspections armed at the no-evidence tier until this long after the
+// activity, so a slow host gets three more looks (~10s/25s/40s) before the pane
+// goes fully quiet. Panes that keep the idle timer never reach this gate.
+export const NO_EVIDENCE_ACTIVITY_ARMED_WINDOW_MS = 45_000

--- a/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
@@ -6,6 +6,7 @@ import type { RecognizedAgentProcess } from '../../../../shared/agent-process-re
 import { recognizeAgentProcess } from '../../../../shared/agent-process-recognition'
 import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
 import {
+  NO_EVIDENCE_ACTIVITY_ARMED_WINDOW_MS,
   NO_EVIDENCE_ACTIVITY_HOT_WINDOW_MS,
   POLL_TIER_INTERVAL_MS,
   type PollCadenceTier
@@ -204,7 +205,7 @@ export function createAgentCompletionProcessMonitor({
         options.shouldPollNoEvidenceProcessCadence?.() !== false) ||
       (options.shouldPollProcessCadence?.() !== false &&
         state.lastPaneActivityAt !== null &&
-        Date.now() - state.lastPaneActivityAt < NO_EVIDENCE_ACTIVITY_HOT_WINDOW_MS)
+        Date.now() - state.lastPaneActivityAt < NO_EVIDENCE_ACTIVITY_ARMED_WINDOW_MS)
     )
   }
 

--- a/src/renderer/src/components/terminal-pane/agent-process-inspection-cost.ts
+++ b/src/renderer/src/components/terminal-pane/agent-process-inspection-cost.ts
@@ -10,11 +10,6 @@ import { isRemoteExecutionHostPtyId } from './remote-execution-host-pty'
  * platform. Local Windows is costly for a different reason: it forks a
  * powershell.exe whole-process-table CIM scan per poll (~10-40x POSIX `ps`).
  * Local POSIX (and daemon/WSL panes on it) stays on the full cadence.
- *
- * Relaxing is the interim measure: once this renderer consumes the batched
- * foreground evidence direct-SSH/remote authorities already publish with their
- * PTY inventory (#17525), those panes can drop to `shouldPollNoEvidenceProcessCadence`
- * and stop scheduling idle host reads altogether.
  */
 export function isAgentProcessInspectionCostly(userAgent: string, ptyId: string | null): boolean {
   if (ptyId !== null && isRemoteExecutionHostPtyId(ptyId)) {
@@ -24,4 +19,20 @@ export function isAgentProcessInspectionCostly(userAgent: string, ptyId: string 
     return false
   }
   return ptyId !== null
+}
+
+/**
+ * Whether a pane with no agent evidence should keep a slow idle inspection
+ * timer at all, or rely purely on pane activity (output/replay/title/hook) to
+ * arm the hot cadence.
+ *
+ * Why remote is push-driven: an idle no-evidence timer can only discover an
+ * agent that started without printing a byte, changing the title, or firing a
+ * hook — and every one of those signals already re-arms the 2s cadence. On a
+ * remote pane that timer buys nothing and costs a host round trip plus two host
+ * forks per tick, so it is disarmed outright. Local hosts keep the timer: local
+ * inspection is cheap enough that the floor is worth its price.
+ */
+export function shouldPollNoEvidenceProcessCadenceForPty(ptyId: string | null): boolean {
+  return ptyId === null || !isRemoteExecutionHostPtyId(ptyId)
 }

--- a/src/renderer/src/components/terminal-pane/agent-process-inspection-cost.ts
+++ b/src/renderer/src/components/terminal-pane/agent-process-inspection-cost.ts
@@ -22,16 +22,17 @@ export function isAgentProcessInspectionCostly(userAgent: string, ptyId: string 
 }
 
 /**
- * Whether a pane with no agent evidence should keep a slow idle inspection
- * timer at all, or rely purely on pane activity (output/replay/title/hook) to
- * arm the hot cadence.
+ * Whether a pane with no agent evidence should keep a perpetual idle inspection
+ * timer, or rely on pane activity (output/replay/title/hook) to arm a bounded
+ * inspection schedule (2/4/6/8s, then 10/25/40s — see
+ * NO_EVIDENCE_ACTIVITY_ARMED_WINDOW_MS) and go quiet after it.
  *
- * Why remote is push-driven: an idle no-evidence timer can only discover an
- * agent that started without printing a byte, changing the title, or firing a
- * hook — and every one of those signals already re-arms the 2s cadence. On a
- * remote pane that timer buys nothing and costs a host round trip plus two host
- * forks per tick, so it is disarmed outright. Local hosts keep the timer: local
- * inspection is cheap enough that the floor is worth its price.
+ * Why remote is activity-driven: a perpetual timer can only discover an agent
+ * that started without printing a byte, changing the title, or firing a hook —
+ * and every one of those signals already arms the schedule. On a remote pane
+ * that timer costs a host round trip plus two host forks per tick, forever, so
+ * it is disarmed. Local hosts keep the timer: local inspection is cheap enough
+ * that the floor is worth its price.
  */
 export function shouldPollNoEvidenceProcessCadenceForPty(ptyId: string | null): boolean {
   return ptyId === null || !isRemoteExecutionHostPtyId(ptyId)

--- a/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
@@ -11,7 +11,10 @@ import { resolveCompatibleAgentTypeForOwner } from '../../../../../shared/agent-
 import { registerTerminalSideEffectFactConsumer } from '../terminal-side-effect-facts-handler'
 
 import { isAgentTaskCompleteTrackingEnabled } from './agent-task-complete-settings'
-import { isAgentProcessInspectionCostly } from '../agent-process-inspection-cost'
+import {
+  isAgentProcessInspectionCostly,
+  shouldPollNoEvidenceProcessCadenceForPty
+} from '../agent-process-inspection-cost'
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
@@ -231,6 +234,8 @@ export function installTerminalKeydownFit(session: ConnectPanePtySession): void 
       isAgentTaskCompleteTrackingEnabled() && session.deps.isVisibleRef.current,
     isProcessInspectionCostly: () =>
       isAgentProcessInspectionCostly(navigator.userAgent, session.transport.getPtyId()),
+    shouldPollNoEvidenceProcessCadence: () =>
+      shouldPollNoEvidenceProcessCadenceForPty(session.transport.getPtyId()),
     isLive: () => {
       if (session.disposed) {
         return false


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​156 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |

<!-- /orca-pr-loc -->

## ELI5

After #18146 and #18254, an idle SSH / paired-runtime terminal that has never run an agent still asks the far machine "what are you running?" every 15 seconds, forever, and always hears "nothing". This PR stops asking on a perpetual timer. Instead, whenever *something happens in the pane* — bytes, a repaint after reconnect/restart, a title change, or a hook — Orca looks quickly a few times, then a few more times slowly over the next 45 seconds in case the box is slow, and then goes quiet until the next thing happens. Once an agent is found, everything is as before.

## The exact schedule after any pane activity

| t (s) | tier | why |
| --- | --- | --- |
| 2, 4, 6, 8 | `idle` (2s) | hot burst inside the strict 10s `NO_EVIDENCE_ACTIVITY_HOT_WINDOW_MS`; catches the common case |
| 10 | `no-evidence` (15s) | timer armed at 8s inside the hot window still fires |
| 25, 40 | `no-evidence` (15s) | two more slow looks for a box that is slow to exec the agent |
| 55 | — | not fired: the 45s `NO_EVIDENCE_ACTIVITY_ARMED_WINDOW_MS` has closed, so no timer is armed |

**Seven inspections per activity event, up to 45s, then zero.** Any new byte/title/hook restarts the schedule from the top. Deterministic with jitter pinned; the test `runs the exact 2/4/6/8/10/25/40s schedule after activity, then disarms at 45s` asserts these exact timestamps.

This is the review request ("15 seconds 3 times — up to 45 seconds in case something on that box is oddly slow"), implemented as: keep the existing 10s hot window, and add a 45s armed window that keeps the no-evidence tier alive after it. Panes that keep the perpetual timer (local) never reach the new gate.

## The trade-off (narrowed, but not zero)

An agent on a remote pane with **zero prior agent evidence** that is launched **by hand, by a script, or by another client**, with **stdout and stderr both redirected**, **no TUI**, **no hook**, and that produces **nothing at all for 45 seconds** after the last thing that happened in the pane, will not be found while it runs. Today (#18146) it would be found within 15s of any point during its run.

**What the user would experience:** no task-complete or process-exit notification for that specific agent. Badge and title are unaffected (they come from hooks and titles). When it exits, the returned shell prompt is a byte and restarts the schedule, but the process is gone by then.

**What keeps that surface small — each point verified in code:**

- Applies only to a pane with **no agent evidence at all**. Once any agent has been seen (inspection, title, or hook), `hasAgentRunEvidence` puts the pane on the normal `active`/`idle` tiers and this PR changes nothing.
- **An Orca-launched agent always produces a byte.** Re-verified after the change: `schedulePendingStartupCommandDelivery` (`pty-connection/deferred-cold-restore-and-snapshot.ts:119`) delivers the launch via `transport.sendInput(`${command}\r`)` or terminal paste; the shell echoes the command and the agent prints its UI. Both are bytes through `live-data-callback.ts` → `observeOutputActivity()`. So the gap is confined to agents Orca did not launch.
- Hook-instrumented agents (Claude, Codex, etc.) fire a hook regardless of redirection.
- Any byte, title change, or hook at any time — including at second 44 — restarts the full 45s schedule (test: `re-arms the full schedule from activity late in the armed window`).
- Local POSIX / Windows / daemon / WSL panes are untouched.

## The change

Renderer-only. No wire change, no new RPC field, no capability negotiation.

1. `shouldPollNoEvidenceProcessCadenceForPty(ptyId)` in `src/renderer/src/components/terminal-pane/agent-process-inspection-cost.ts`, wired as `shouldPollNoEvidenceProcessCadence` in `pty-connection/terminal-keydown-fit.ts`. Returns `false` for any `isRemoteExecutionHostPtyId` (`ssh:<target>@@<id>`, `remote:` with or without an environment id), `true` for everything else (`null`, local, daemon, WSL, bare `ssh:target`). That makes the perpetual branch of `shouldRunCadenceInspection()` (`agent-completion-process-monitor.ts`) false for remote panes.
2. New `NO_EVIDENCE_ACTIVITY_ARMED_WINDOW_MS = 45_000` in `agent-completion-poll-cadence.ts`. `shouldRunCadenceInspection()`'s activity branch now uses it instead of the 10s hot window, so the `no-evidence` tier stays armed for 45s after activity. `currentPollTier()` still uses the 10s hot window to pick `idle` vs `no-evidence`, which is what produces the 2/4/6/8 then 10/25/40 shape.

Stacked on #18254 (reattach paints record pane activity), which is what makes the post-restart case safe: a restore onto a running-but-quiet remote agent gets the full schedule, not silence.

## Measurements

Deterministic under fake timers with jitter pinned (`Math.random = 0.5`), one inspection = one host round trip (`inspectProcess` RPC + `ps` + `pgrep` on the host).

| Remote pane state | #18146 + #18254 | this PR |
| --- | ---: | ---: |
| Visible, no evidence, silent — steady state | **4/min, forever** | **0/min** |
| Visible, no evidence — the 45s after any activity | 4 (2/4/6/8) + 15s tier | **7** (2/4/6/8/10/25/40), then 0 |
| Visible, agent found on any of those looks | active 750ms (~78/min) | same |
| Visible, agent evidence, no foreground agent | idle 2s (30/min) | same |
| Hidden | 0 | 0 |
| Local POSIX / Windows / daemon / WSL | unchanged | unchanged |

Honest headline: **an idle remote pane pays at most 7 round trips in the 45s after each activity event, then 0**, versus 4/min indefinitely today. A pane that sees one output burst per hour goes from ~240 round trips/hour to 7.

## Correctness argument

The perpetual timer's only job is to discover an agent that started with no observable pane event. Every observable event starts the same schedule the timer would have escalated to, so the timer only matters for the residual above.

**Start detection.** `recordActivity()` sets `lastPaneActivityAt` and calls `scheduleNextPoll()`, which with no timer armed schedules the 2s `idle` tier immediately. Callers: every live PTY chunk with length > 0 (`live-data-callback.ts`, including deferred reattach chunks); every replay/restore paint (#18254); every title observation (`agent-completion-title-observer.ts`); every hook status (`agent-completion-hook-observer.ts`).

**Finish detection is unchanged.** `currentPollTier()` returns `active` when `lastForegroundAgent` is set and `idle` when `hasAgentRunEvidence` is set, before consulting the no-evidence branch; `shouldRunCadenceInspection()` returns true on either evidence flag. The two-consecutive-idle-sample exit confirmation, `pendingProcessExitAgent`, and both suppression hooks are untouched. Tests `escalates a running agent found in the hot window to the active cadence` and `finds an agent that only appears on the third slow look` pin this on remote ids, including exit confirmation.

**Hook-driven completion is not on this path.** `hasPendingHookDone()` short-circuits `handleInspectionResult`, and hook-only coordinators never start process tracking.

**Enumeration of "agent started with no byte, no title, no hook, for 45s":**

| Case | Observable? |
| --- | --- |
| Agent typed into the shell | shell echo + agent output. Byte. |
| Agent launched by Orca | `sendInput` / paste of the command, echoed; agent prints. Byte. |
| Agent already running at Orca restart / reconnect / reveal | replay or snapshot paint (#18254). Byte. |
| Agent started by another client on the same relay PTY | its bytes are broadcast to this pane. Byte. |
| Hook-instrumented agent, however launched | hook status. |
| Agent that is slow to exec (up to ~40s) after a visible launch | caught by the 10/25/40s looks. |
| **Non-hook agent launched by a silent script with stdout+stderr redirected, on a pane with no prior evidence, silent for >45s** | **not observable — the residual.** |

## Wire compatibility

None involved. Nothing new is sent or received; `inspectProcess` and the inventory shape are untouched. Mixed client/host versions are unaffected.

## Context for the push-driven endgame (the alternative with no residual)

The endgame #17525 built toward — the host publishes foreground evidence and the renderer never polls — is a separate, larger piece of work. Recorded so it is not lost:

- `foregroundProcessEvidence` is produced by the direct-SSH relay in `pty.listProcesses` only (`src/relay/pty-handler.ts`, POSIX only). `listProcesses` is on-demand (teardown, resize-subscribe, worktree reconciliation, unstopped-PTY verification); nothing periodic drives it, and the relay pushes only `pty.data` / `pty.exit` / `pty.replay`.
- The field enters main through `src/main/providers/pty-process-list-admission.ts` (validated and cloned) and is **dropped on the floor there: zero consumers** in `src/main/runtime`, `src/main/ipc`, `src/main/ssh`, or `src/renderer`.
- **Paired runtime has no producer at all**; `terminal.inspectProcess` (`src/main/runtime/rpc/methods/terminal/terminal-query-methods.ts`) is a separate transport that publishes no evidence.
- Getting there needs a host-side periodic or change-driven publish (a new stream opcode, capability-negotiated per `docs/reference/remote-wire-compatibility.md`), a main-side consumer with `authorityGeneration`/`observationEpoch` freshness handling, a renderer feed into `establishAgentEvidence`, the same for paired runtime, and a mixed-version fallback that keeps polling until the host proves it publishes.

Once that lands, `shouldPollNoEvidenceProcessCadence` is already the hook it drives, and the residual disappears because the host reports the foreground.

## Tests

`agent-completion-no-evidence-cadence.test.ts` (extended, `remote pane in the shipped option shape` block feeds both predicates from one pty id exactly as `terminal-keydown-fit.ts` does):
- zero round trips over 60s for a silent remote pane on both id shapes;
- the exact `[2, 4, 6, 8, 10, 25, 40]` second schedule after activity, and nothing at 55s;
- activity at 41s restarts the 2s burst;
- an agent found on the first look escalates to active and its exit is confirmed;
- an agent that appears only on the 40s look is found and escalates to active;
- a title change alone re-arms with no output;
- `shouldPollNoEvidenceProcessCadenceForPty` unit block over all remote and local id shapes.

The pre-existing `starts a bounded hot cadence after output on an evidence-publishing host` test moved from 4 to 5/7 with the 45s window; the new counts are pinned there too.

## Verification

- `pnpm tc` — clean.
- `npx oxlint` / `npx oxfmt --check` on the changed files — clean.
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane` — 427 files, 4165 tests, all green.
