### PR TITLE
fix(terminal): record pane activity on reattach and restore paints

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-no-evidence-cadence.test.ts
@@ -111,6 +111,24 @@ describe('agent completion no-evidence inspection cadence', () => {
     expect(inspectProcess).toHaveBeenCalledTimes(1)
   })
 
+  it('looks within 2s, not 15s, when a reattach paint marks activity at tracking start', async () => {
+    // Why: a reattach/restore paint goes through writeReplayData, which now
+    // records pane activity (see fresh-spawn-follow-reset-replay-activity.test.ts).
+    // On a remote pane that turns the first post-restart inspection from a
+    // 15s wait into a 2s one, so a running-but-quiet agent is found promptly.
+    const sshPtyId = toAppSshPtyId('target-1', 'pty-1')
+    const inspectProcess = vi.fn(async () => processResult('claude', true))
+    const { coordinator } = createCoordinator(inspectProcess, {
+      getPtyId: () => sshPtyId,
+      isProcessInspectionCostly: () => isAgentProcessInspectionCostly(MAC_UA, sshPtyId)
+    })
+
+    coordinator.startProcessTracking()
+    coordinator.observeOutputActivity()
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(inspectProcess).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps the full 2s idle cadence on hosts where inspection is cheap', async () => {
     const inspectProcess = vi.fn(async () => processResult(null, false))
     const { coordinator } = createCoordinator(inspectProcess, {

--- a/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-follow-reset-replay-activity.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-follow-reset-replay-activity.test.ts
@@ -1,0 +1,58 @@
+// Regression guard: a reattach/restore paint goes through writeReplayData, not
+// dataCallback, so it must itself mark pane activity — otherwise a remote pane
+// whose no-evidence timer is disarmed would never inspect a silently-running
+// agent after a restart until that agent's next byte.
+import { describe, expect, it, vi } from 'vitest'
+import { bindFreshSpawnFollowReset } from './fresh-spawn-follow-reset'
+import type { ConnectPanePtySession } from './connect-pane-pty-session'
+
+vi.mock('../replay-guard', () => ({
+  replayIntoTerminal: vi.fn(),
+  replayIntoTerminalAsync: vi.fn(async () => {})
+}))
+vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
+  flushTerminalOutput: vi.fn()
+}))
+
+function createSession(): ConnectPanePtySession & {
+  agentCompletionCoordinator: { observeOutputActivity: ReturnType<typeof vi.fn> }
+} {
+  const session = {
+    pane: { id: 'pane-1', terminal: {} },
+    manager: {},
+    deps: {
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      replayingPanesRef: { current: new Map() },
+      isVisibleRef: { current: true }
+    },
+    transport: { getPtyId: () => 'ssh:target-1@@pty-1' },
+    agentCompletionCoordinator: { observeOutputActivity: vi.fn() },
+    shouldRefreshForegroundSynchronously: () => false
+  } as unknown as ConnectPanePtySession & {
+    agentCompletionCoordinator: { observeOutputActivity: ReturnType<typeof vi.fn> }
+  }
+  bindFreshSpawnFollowReset(session)
+  return session
+}
+
+describe('replay paint records pane activity', () => {
+  it('marks activity for a sync replay write', () => {
+    const session = createSession()
+    session.writeReplayData('\x1b[2J$ claude\r\n')
+    expect(session.agentCompletionCoordinator.observeOutputActivity).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks activity for an async replay write', async () => {
+    const session = createSession()
+    await session.writeReplayDataAsync('restored frame')
+    expect(session.agentCompletionCoordinator.observeOutputActivity).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores an empty write, which paints nothing', async () => {
+    const session = createSession()
+    session.writeReplayData('')
+    await session.writeReplayDataAsync('')
+    expect(session.agentCompletionCoordinator.observeOutputActivity).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-follow-reset.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-follow-reset.ts
@@ -101,7 +101,18 @@ export function bindFreshSpawnFollowReset(session: ConnectPanePtySession): void 
   // sequences don't leak into the shell. xterm.write() buffers internally
   // regardless of DOM visibility and the guard stays engaged via the
   // write-completion callback until xterm finishes parsing.
+  // Why: a reattach/restore paint bypasses dataCallback, so it never marked
+  // pane activity and a silently-running agent stayed on the relaxed (or
+  // disarmed) no-evidence cadence until its next byte. Replay bytes are the
+  // same "something may be running here" signal as live output.
+  const recordReplayPaintActivity = (data: string): void => {
+    if (data.length > 0) {
+      session.agentCompletionCoordinator?.observeOutputActivity()
+    }
+  }
+
   session.writeReplayData = (data: string): void => {
+    recordReplayPaintActivity(data)
     // Why: drain any queued background bytes BEFORE the replay paint, so the
     // scheduler's deferred drain cannot land older bytes on top of the replay.
     flushTerminalOutput(session.pane.terminal)
@@ -117,6 +128,7 @@ export function bindFreshSpawnFollowReset(session: ConnectPanePtySession): void 
   }
 
   session.writeReplayDataAsync = (data: string): Promise<void> => {
+    recordReplayPaintActivity(data)
     // Why: WebGL must be rebuilt after xterm has parsed replay bytes, not
     // merely after the write was queued.
     flushTerminalOutput(session.pane.terminal)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

When Orca restarts (or reconnects, or re-shows a hidden tab) onto a terminal where an agent is already running quietly, it repaints the old screen but did not count that repaint as "something happened here". So the pane's agent detector waited a full idle interval — 15 seconds on remote and local-Windows panes after #18146 — before taking its first look. Now the repaint counts, and the first look happens within 2 seconds, the same as if the agent had printed a byte.

This closes the one gap #18146 explicitly left open ("the very first cadence inspection after a *silent* reattach moves from ~2s to ~15s ... the clean fix is to record pane activity on reattach paint"). Nothing gets slower or less accurate.

## The change

`writeReplayData` and `writeReplayDataAsync` (`src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-follow-reset.ts`) call `agentCompletionCoordinator.observeOutputActivity()` for any non-empty write. Every reattach, reconnect, park-reveal, cold-restore, and hidden-output-restore paint goes through these two functions (`apply-reattach-payload.ts`, `replay-data-drain.ts`, `hidden-output-restore-snapshot.ts`, `ssh-snapshot-prepaint.ts`, and the fresh-shell viewport blanking). None of them pass through `dataCallback`, so `lastPaneActivityAt` stayed `null` after a silent restore. Empty writes paint nothing and are ignored.

`observeOutputActivity` → `recordActivity()` (`agent-completion-process-monitor.ts`) sets `lastPaneActivityAt` and re-arms `scheduleNextPoll()`; when a `no-evidence` timer is pending it is cleared and replaced with the 2s `idle` tier. That is the same path a live PTY byte takes.

## Measurements

Deterministic under fake timers with jitter pinned (`Math.random = 0.5`).

| Pane state after a restore paint | before | after |
| --- | ---: | ---: |
| Remote (SSH / paired runtime), no prior evidence, agent running quietly — first inspection | ~15s | **2s** |
| Local Windows, same | ~15s | **2s** |
| Local POSIX, same | 2s | 2s (unchanged) |
| Any pane, restore onto an empty shell — inspections in the next 10s | 0 (remote/Windows) or 4 (POSIX) | 4 (2/4/6/8s), then back to the pane's normal tier |

Total inspection volume on an idle pane is unchanged after the 10s post-restore window: remote and Windows panes return to the 15s `no-evidence` tier, POSIX to 2s. No new timers, listeners, RPCs, or wire fields.

## Negative user-facing trade-offs

None that reach the user. The only behavior change is that a restore onto an *empty* remote or local-Windows shell now runs 4 inspections over 10s that it previously did not — one bounded burst per restore, then the existing slow tier. On a remote pane that is 4 round trips once per restore; on local Windows, 4 CIM scans once per restore. The restore itself already costs far more than that.

## Tests

- `pty-connection/fresh-spawn-follow-reset-replay-activity.test.ts` (new, small): sync and async replay writes call `observeOutputActivity`; empty writes do not.
- `agent-completion-no-evidence-cadence.test.ts` (extended): a remote pane that records activity at tracking start inspects at 2s, not 15s.

## Verification

- `pnpm tc` — clean.
- `npx oxlint` / `npx oxfmt --check` on the changed files — clean.
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane` — 427 files, 4157 tests, all green.
