### PR TITLE
fix(activity): persist the agents unread filter and grouping

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui-pairing-local-fields.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui-pairing-local-fields.test.ts
@@ -49,6 +49,8 @@ describe('client UI RPC pairing-local field seams', () => {
     agentsFilterRepoIds: ['repo-a'],
     agentsShowChildAgents: true,
     agentsCompactMode: false,
+    agentsReadFilter: 'unread',
+    agentsGroupBy: 'project',
     activityClearedAtByPaneKey: { 'tab-1:leaf-1': 123 },
     manuallyUnreadTurnsByPaneKey: { 'tab-1:leaf-1': 321 }
   }

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -126,6 +126,8 @@ const UiUpdateFields = z
     agentsFilterRepoIds: StringArray.optional(),
     agentsShowChildAgents: z.boolean().optional(),
     agentsCompactMode: z.boolean().optional(),
+    agentsReadFilter: z.enum(['all', 'unread']).optional(),
+    agentsGroupBy: z.enum(['none', 'status', 'project', 'worktree', 'agent']).optional(),
     workspaceHostOrder: z.array(z.string()).optional(),
     automationHostFilter: z
       .union([

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -3,6 +3,10 @@ import {
   isFeatureInteractionId,
   type FeatureInteractionId
 } from '../../../../shared/feature-interactions'
+import {
+  ACTIVITY_GROUP_BY_VALUES,
+  THREAD_READ_FILTER_VALUES
+} from '../../../../shared/agents-view-thread-filters'
 import { isFeatureTipId } from '../../../../shared/feature-tips'
 import { isReleaseChannel, type ReleaseChannel } from '../../../../shared/release-channel'
 import {
@@ -126,8 +130,8 @@ const UiUpdateFields = z
     agentsFilterRepoIds: StringArray.optional(),
     agentsShowChildAgents: z.boolean().optional(),
     agentsCompactMode: z.boolean().optional(),
-    agentsReadFilter: z.enum(['all', 'unread']).optional(),
-    agentsGroupBy: z.enum(['none', 'status', 'project', 'worktree', 'agent']).optional(),
+    agentsReadFilter: z.enum(THREAD_READ_FILTER_VALUES).optional(),
+    agentsGroupBy: z.enum(ACTIVITY_GROUP_BY_VALUES).optional(),
     workspaceHostOrder: z.array(z.string()).optional(),
     automationHostFilter: z
       .union([

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -21,22 +21,20 @@ import {
   useActivityTerminalLoadingLabel,
   useActivityTerminalPortalStatus
 } from './activity-terminal-portal-status'
-import type {
-  ActivityGroupBy,
-  ActivityTerminalPortalSlotId,
-  ThreadReadFilter
-} from './activity-thread-types'
+import type { ActivityTerminalPortalSlotId } from './activity-thread-types'
 
 export * from './activity-prototype-page-exports'
 
 export default function ActivityPrototypePage(): React.JSX.Element {
-  const [readFilter, setReadFilter] = useState<ThreadReadFilter>('all')
-  const [groupBy, setGroupBy] = useState<ActivityGroupBy>('status')
   const [query, setQuery] = useState('')
   const activityFilterInputRef = useRef<HTMLInputElement | null>(null)
   // Why: bounds auto mark-read to one acknowledgement per selected thread turn.
   const autoAcknowledgedTurnRef = useRef<string | null>(null)
   // Why store-backed: persisted preferences shared with the sidebar agents list.
+  const readFilter = useAppStore((s) => s.agentsReadFilter)
+  const setReadFilter = useAppStore((s) => s.setAgentsReadFilter)
+  const groupBy = useAppStore((s) => s.agentsGroupBy)
+  const setGroupBy = useAppStore((s) => s.setAgentsGroupBy)
   const compactMode = useAppStore((s) => s.agentsCompactMode)
   const setCompactMode = useAppStore((s) => s.setAgentsCompactMode)
   const showChildAgents = useAppStore((s) => s.agentsShowChildAgents)

--- a/src/renderer/src/components/activity/activity-thread-types.ts
+++ b/src/renderer/src/components/activity/activity-thread-types.ts
@@ -9,8 +9,8 @@ import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import type { ActivityPortalReadinessStatus } from './activity-portal-readiness-oscillation'
 
-export type ThreadReadFilter = 'all' | 'unread'
-export type ActivityGroupBy = 'none' | 'status' | 'project' | 'worktree' | 'agent'
+export type { ActivityGroupBy, ThreadReadFilter } from '../../../../shared/ui-chrome-types'
+
 export type ActivityEventState = Extract<AgentStatusState, 'done' | 'blocked' | 'waiting'>
 export type ActivityHookLiveAgentState = Extract<
   AgentStatusState,

--- a/src/renderer/src/components/sidebar/SidebarAgentsList.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsList.tsx
@@ -41,7 +41,7 @@ export default function SidebarAgentsList({
 }: SidebarAgentsListProps): React.JSX.Element {
   // The search row is owned here and mounts conditionally, so subscribe this host to locale changes.
   useTranslation()
-  // Why store-backed: these are persisted preferences (agents* UI fields), unlike the momentary read filter/search.
+  // Why store-backed: these are persisted preferences (agents* UI fields), unlike the momentary search.
   const compactMode = useAppStore((s) => s.agentsCompactMode)
   const setCompactMode = useAppStore((s) => s.setAgentsCompactMode)
   const showChildAgents = useAppStore((s) => s.agentsShowChildAgents)

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -11,7 +11,6 @@ import WorkspaceKanbanDrawer from './WorkspaceKanbanDrawer'
 import type { VirtualizedScrollAnchor } from '@/hooks/useVirtualizedScrollAnchor'
 import { cn } from '@/lib/utils'
 import { FolderPlus, Loader2 } from 'lucide-react'
-import type { ActivityGroupBy, ThreadReadFilter } from '@/components/activity/activity-thread-types'
 import { ActivityThreadCollapseContext } from '@/components/activity/activity-thread-collapse-context'
 import { useSidebarProjectDrop } from './useSidebarProjectDrop'
 import { useWorkspaceBoardPanel } from './useWorkspaceBoardPanel'
@@ -59,8 +58,10 @@ function Sidebar({
   const showAgentDashboard = settings?.experimentalAgentDashboardPopout === true
   const agentDashboardDrawerOpen = useAppStore((s) => s.agentDashboardDrawerOpen)
   const setAgentDashboardDrawerOpen = useAppStore((s) => s.setAgentDashboardDrawerOpen)
-  const [agentReadFilter, setAgentReadFilter] = React.useState<ThreadReadFilter>('all')
-  const [agentGroupBy, setAgentGroupBy] = React.useState<ActivityGroupBy>('status')
+  const agentReadFilter = useAppStore((s) => s.agentsReadFilter)
+  const setAgentReadFilter = useAppStore((s) => s.setAgentsReadFilter)
+  const agentGroupBy = useAppStore((s) => s.agentsGroupBy)
+  const setAgentGroupBy = useAppStore((s) => s.setAgentsGroupBy)
   const [agentQuery, setAgentQuery] = React.useState('')
   const [agentOptionsTarget, setAgentOptionsTarget] = React.useState<HTMLDivElement | null>(null)
   const agentsScrollTopRef = React.useRef(0)

--- a/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
+++ b/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
@@ -551,6 +551,27 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().agentsFilterRepoIds).toEqual([])
     expect(store.getState().agentsShowChildAgents).toBe(false)
     expect(store.getState().agentsCompactMode).toBe(true)
+    expect(store.getState().agentsReadFilter).toBe('all')
+    expect(store.getState().agentsGroupBy).toBe('status')
+  })
+
+  it('restores the persisted agents read filter and grouping, rejecting unknown values', () => {
+    const store = createUIStore()
+
+    store
+      .getState()
+      .hydratePersistedUI(makePersistedUI({ agentsReadFilter: 'unread', agentsGroupBy: 'project' }))
+    expect(store.getState().agentsReadFilter).toBe('unread')
+    expect(store.getState().agentsGroupBy).toBe('project')
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        agentsReadFilter: 'bogus' as unknown as PersistedUIState['agentsReadFilter'],
+        agentsGroupBy: 'bogus' as unknown as PersistedUIState['agentsGroupBy']
+      })
+    )
+    expect(store.getState().agentsReadFilter).toBe('all')
+    expect(store.getState().agentsGroupBy).toBe('status')
   })
 
   it('sanitizes malformed agents repo filters before the repo catalog loads', () => {

--- a/src/renderer/src/store/slices/ui/ui-slice-contract-preferences.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-contract-preferences.ts
@@ -1,9 +1,11 @@
 import type { PersistedUIState } from '../../../../../shared/persisted-ui-state-types'
 import type {
+  ActivityGroupBy,
   AgentActivityDisplayMode,
   ManualRepoOrderEntry,
   ProjectOrderBy,
   StatusBarItem,
+  ThreadReadFilter,
   WorktreeCardMode,
   WorktreeCardProperty,
   WorkspaceHostOrder,
@@ -71,6 +73,10 @@ export type UISlicePreferences = {
   setAgentsShowChildAgents: (v: boolean) => void
   agentsCompactMode: boolean
   setAgentsCompactMode: (v: boolean) => void
+  agentsReadFilter: ThreadReadFilter
+  setAgentsReadFilter: (v: ThreadReadFilter) => void
+  agentsGroupBy: ActivityGroupBy
+  setAgentsGroupBy: (v: ActivityGroupBy) => void
   collapsedGroups: Set<string>
   toggleCollapsedGroup: (key: string) => void
   worktreeCardProperties: WorktreeCardProperty[]

--- a/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
@@ -21,6 +21,10 @@ import {
   normalizeAgentActivityDisplayMode
 } from '../../../../../shared/constants'
 import {
+  normalizeActivityGroupBy,
+  normalizeThreadReadFilter
+} from '../../../../../shared/agents-view-thread-filters'
+import {
   clampWorkspaceBoardColumnWidth,
   clampWorkspaceBoardOpacity,
   normalizeWorkspaceStatuses
@@ -182,6 +186,8 @@ export function createUiHydrationActions(set: UISliceSet, _get: UISliceGet): Par
           ),
           agentsShowChildAgents: ui.agentsShowChildAgents === true,
           agentsCompactMode: ui.agentsCompactMode !== false,
+          agentsReadFilter: normalizeThreadReadFilter(ui.agentsReadFilter),
+          agentsGroupBy: normalizeActivityGroupBy(ui.agentsGroupBy),
           collapsedGroups: new Set(ui.collapsedGroups ?? []),
           uiZoomLevel: ui.uiZoomLevel ?? 0,
           editorFontZoomLevel: ui.editorFontZoomLevel ?? 0,

--- a/src/renderer/src/store/slices/ui/ui-slice-preference-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-preference-actions.ts
@@ -1,5 +1,9 @@
 import type { UISlice, UISliceGet, UISliceSet } from './ui-slice-contract'
 import {
+  DEFAULT_AGENTS_GROUP_BY,
+  DEFAULT_AGENTS_READ_FILTER
+} from '../../../../../shared/agents-view-thread-filters'
+import {
   DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE,
   DEFAULT_SHOW_SLEEPING_WORKSPACES,
   DEFAULT_STATUS_BAR_ITEMS,
@@ -169,6 +173,16 @@ export function createUiPreferenceActions(set: UISliceSet, get: UISliceGet): Par
     setAgentsCompactMode: (v) => {
       set({ agentsCompactMode: v })
       window.api.ui.set({ agentsCompactMode: v }).catch(console.error)
+    },
+    agentsReadFilter: DEFAULT_AGENTS_READ_FILTER,
+    setAgentsReadFilter: (v) => {
+      set({ agentsReadFilter: v })
+      window.api.ui.set({ agentsReadFilter: v }).catch(console.error)
+    },
+    agentsGroupBy: DEFAULT_AGENTS_GROUP_BY,
+    setAgentsGroupBy: (v) => {
+      set({ agentsGroupBy: v })
+      window.api.ui.set({ agentsGroupBy: v }).catch(console.error)
     },
 
     collapsedGroups: new Set<string>(),

--- a/src/renderer/src/web/preload-api/web-preference-normalization.ts
+++ b/src/renderer/src/web/preload-api/web-preference-normalization.ts
@@ -73,6 +73,8 @@ export function mergeHostWebUIState(
     agentsFilterRepoIds: local.agentsFilterRepoIds,
     agentsShowChildAgents: local.agentsShowChildAgents,
     agentsCompactMode: local.agentsCompactMode,
+    agentsReadFilter: local.agentsReadFilter,
+    agentsGroupBy: local.agentsGroupBy,
     activityClearedAtByPaneKey: local.activityClearedAtByPaneKey,
     manuallyUnreadTurnsByPaneKey: local.manuallyUnreadTurnsByPaneKey
   } satisfies Record<PairingLocalUiField, unknown> & Partial<PersistedUIState>

--- a/src/renderer/src/web/web-preload-api-ui.test.ts
+++ b/src/renderer/src/web/web-preload-api-ui.test.ts
@@ -469,6 +469,8 @@ describe('web UI preload API', () => {
     agentsFilterRepoIds: ['repo-b'],
     agentsShowChildAgents: true,
     agentsCompactMode: false,
+    agentsReadFilter: 'unread',
+    agentsGroupBy: 'project',
     activityClearedAtByPaneKey: { 'tab-1:leaf-1': 123 },
     manuallyUnreadTurnsByPaneKey: { 'tab-1:leaf-1': 321 }
   }
@@ -481,6 +483,8 @@ describe('web UI preload API', () => {
     agentsFilterRepoIds: ['repo-a'],
     agentsShowChildAgents: false,
     agentsCompactMode: true,
+    agentsReadFilter: 'all',
+    agentsGroupBy: 'status',
     activityClearedAtByPaneKey: { 'tab-2:leaf-2': 456 },
     manuallyUnreadTurnsByPaneKey: { 'tab-2:leaf-2': 654 }
   }

--- a/src/shared/agents-view-thread-filters.ts
+++ b/src/shared/agents-view-thread-filters.ts
@@ -1,22 +1,23 @@
-import type { ActivityGroupBy, ThreadReadFilter } from './ui-chrome-types'
+/** The two filter value domains, in menu order. The types below, the client
+ *  schema's `z.enum`s and the normalizers all derive from these, so a new value
+ *  cannot drift out of any of them. */
+export const THREAD_READ_FILTER_VALUES = ['all', 'unread'] as const
+export const ACTIVITY_GROUP_BY_VALUES = ['none', 'status', 'project', 'worktree', 'agent'] as const
+
+export type ThreadReadFilter = (typeof THREAD_READ_FILTER_VALUES)[number]
+export type ActivityGroupBy = (typeof ACTIVITY_GROUP_BY_VALUES)[number]
 
 export const DEFAULT_AGENTS_READ_FILTER: ThreadReadFilter = 'all'
 export const DEFAULT_AGENTS_GROUP_BY: ActivityGroupBy = 'status'
 
-const ACTIVITY_GROUP_BY_VALUES: ReadonlySet<string> = new Set<ActivityGroupBy>([
-  'none',
-  'status',
-  'project',
-  'worktree',
-  'agent'
-])
-
 export function normalizeThreadReadFilter(value: unknown): ThreadReadFilter {
-  return value === 'unread' || value === 'all' ? value : DEFAULT_AGENTS_READ_FILTER
+  return isMember(THREAD_READ_FILTER_VALUES, value) ? value : DEFAULT_AGENTS_READ_FILTER
 }
 
 export function normalizeActivityGroupBy(value: unknown): ActivityGroupBy {
-  return typeof value === 'string' && ACTIVITY_GROUP_BY_VALUES.has(value)
-    ? (value as ActivityGroupBy)
-    : DEFAULT_AGENTS_GROUP_BY
+  return isMember(ACTIVITY_GROUP_BY_VALUES, value) ? value : DEFAULT_AGENTS_GROUP_BY
+}
+
+function isMember<T extends string>(catalog: readonly T[], value: unknown): value is T {
+  return typeof value === 'string' && (catalog as readonly string[]).includes(value)
 }

--- a/src/shared/agents-view-thread-filters.ts
+++ b/src/shared/agents-view-thread-filters.ts
@@ -1,0 +1,22 @@
+import type { ActivityGroupBy, ThreadReadFilter } from './ui-chrome-types'
+
+export const DEFAULT_AGENTS_READ_FILTER: ThreadReadFilter = 'all'
+export const DEFAULT_AGENTS_GROUP_BY: ActivityGroupBy = 'status'
+
+const ACTIVITY_GROUP_BY_VALUES: ReadonlySet<string> = new Set<ActivityGroupBy>([
+  'none',
+  'status',
+  'project',
+  'worktree',
+  'agent'
+])
+
+export function normalizeThreadReadFilter(value: unknown): ThreadReadFilter {
+  return value === 'unread' || value === 'all' ? value : DEFAULT_AGENTS_READ_FILTER
+}
+
+export function normalizeActivityGroupBy(value: unknown): ActivityGroupBy {
+  return typeof value === 'string' && ACTIVITY_GROUP_BY_VALUES.has(value)
+    ? (value as ActivityGroupBy)
+    : DEFAULT_AGENTS_GROUP_BY
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -11,6 +11,7 @@ import { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 import type { VoiceSettings } from './speech-types'
 import { cloneDefaultWorkspaceStatuses } from './workspace-statuses'
 import { DEFAULT_WORKTREE_CARD_PROPERTIES } from './worktree/card-properties'
+import { DEFAULT_AGENTS_GROUP_BY, DEFAULT_AGENTS_READ_FILTER } from './agents-view-thread-filters'
 import { DEFAULT_USAGE_PERCENTAGE_DISPLAY } from './usage-percentage-display'
 import { DEFAULT_STATUS_BAR_USAGE_MODE } from './status-bar-usage-mode'
 import { buildDefaultSettings } from './default-global-settings'
@@ -273,6 +274,8 @@ export function getDefaultUIState(): PersistedUIState {
     agentsFilterRepoIds: [],
     agentsShowChildAgents: false,
     agentsCompactMode: true,
+    agentsReadFilter: DEFAULT_AGENTS_READ_FILTER,
+    agentsGroupBy: DEFAULT_AGENTS_GROUP_BY,
     collapsedGroups: [],
     uiZoomLevel: 0,
     editorFontZoomLevel: 0,

--- a/src/shared/pairing-local-ui-fields.test.ts
+++ b/src/shared/pairing-local-ui-fields.test.ts
@@ -14,6 +14,8 @@ describe('pairing-local UI fields', () => {
       'agentsFilterRepoIds',
       'agentsShowChildAgents',
       'agentsCompactMode',
+      'agentsReadFilter',
+      'agentsGroupBy',
       'activityClearedAtByPaneKey',
       'manuallyUnreadTurnsByPaneKey'
     ])

--- a/src/shared/pairing-local-ui-fields.ts
+++ b/src/shared/pairing-local-ui-fields.ts
@@ -17,6 +17,8 @@ export const PAIRING_LOCAL_UI_FIELDS = [
   'agentsFilterRepoIds',
   'agentsShowChildAgents',
   'agentsCompactMode',
+  'agentsReadFilter',
+  'agentsGroupBy',
   'activityClearedAtByPaneKey',
   'manuallyUnreadTurnsByPaneKey'
 ] as const satisfies readonly (keyof PersistedUIState)[]

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -8,6 +8,7 @@ import type { StatusBarUsageMode } from './status-bar-usage-mode'
 import type { PersistedTrustedOrcaHooks } from './orca-yaml-hook-types'
 import type { CustomPet } from './pet-types'
 import type {
+  ActivityGroupBy,
   AgentActivityDisplayMode,
   ManualRepoOrderEntry,
   ProjectOrderBy,
@@ -15,6 +16,7 @@ import type {
   RightSidebarTab,
   StatusBarItem,
   TaskResumeState,
+  ThreadReadFilter,
   TopLevelView,
   VisibleWorkspaceHostIds,
   WorkspaceHostOrder,
@@ -81,6 +83,10 @@ export type PersistedUIState = {
   agentsShowChildAgents?: boolean
   /** Agents-view compact thread rows. Absent means on. */
   agentsCompactMode?: boolean
+  /** Agents-view unread-only thread filter. Absent means 'all'. */
+  agentsReadFilter?: ThreadReadFilter
+  /** Agents-view thread grouping. Absent means 'status'. */
+  agentsGroupBy?: ActivityGroupBy
   collapsedGroups: string[]
   uiZoomLevel: number
   editorFontZoomLevel: number

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -49,8 +49,9 @@ export type WorktreeCardMode = 'Default' | 'Compact'
 
 export type AgentActivityDisplayMode = 'compact' | 'full'
 
-export type ThreadReadFilter = 'all' | 'unread'
-export type ActivityGroupBy = 'none' | 'status' | 'project' | 'worktree' | 'agent'
+// Re-exported so existing importers keep one home for UI chrome types; the
+// value domain lives with the normalizers that police it.
+export type { ActivityGroupBy, ThreadReadFilter } from './agents-view-thread-filters'
 
 export type StatusBarItem =
   | 'claude'

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -49,6 +49,9 @@ export type WorktreeCardMode = 'Default' | 'Compact'
 
 export type AgentActivityDisplayMode = 'compact' | 'full'
 
+export type ThreadReadFilter = 'all' | 'unread'
+export type ActivityGroupBy = 'none' | 'status' | 'project' | 'worktree' | 'agent'
+
 export type StatusBarItem =
   | 'claude'
   | 'codex'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |
| Prod | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​84 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |

<!-- /orca-pr-loc -->

## Problem

The Agents view's **Show unread threads only** toggle does not survive an app restart — it silently snaps back to showing everything.

Same for the **Group by** select next to it.

## Cause

Both were plain component-local React state:

```ts
// src/renderer/src/components/sidebar/index.tsx
const [agentReadFilter, setAgentReadFilter] = React.useState<ThreadReadFilter>('all')
const [agentGroupBy, setAgentGroupBy] = React.useState<ActivityGroupBy>('status')
```

Their neighbours in the very same toolbar and options menu — compact rows, show child agents — *do* persist, because they are backed by the UI store (`agentsCompactMode`, `agentsShowChildAgents`). The read filter was never wired into any of those seams, so it reset on every mount, restart included.

`ActivityPrototypePage` had the same bug independently, which also meant the sidebar and the standalone Activity page did not share the filter with each other.

## Fix

Promote both to persisted UI preferences (`agentsReadFilter`, `agentsGroupBy`), following `agentsCompactMode` through every seam:

- `ThreadReadFilter` / `ActivityGroupBy` moved to `shared/ui-chrome-types.ts` (re-exported from `activity-thread-types.ts`, so existing imports are unchanged)
- defaults in `getDefaultUIState()`; normalizers in a new `shared/agents-view-thread-filters.ts`
- strict client RPC schema entries, so paired web/mobile/relay clients don't reject the whole `ui.set` payload
- added to `PAIRING_LOCAL_UI_FIELDS` — this is each client's own view state, like compact mode, so a paired host must not overwrite it — plus the web read pin
- store contract, actions, and hydration (unknown persisted values fall back to `'all'` / `'status'`)
- both consumers now read the store, so the sidebar and the Activity page share one filter

The normalizers live in their own module rather than `shared/constants.ts` because adding them there tripped the `max-lines` cap.

## Notes

- **Remote wire**: the new fields are optional and pairing-local — stripped on the way to a host, pinned to the local value on the way back — so nothing new crosses the boundary and old hosts are unaffected.
- The repo's census tests (`pairing-local-ui-fields`, the two seam tests, and the `AssertNoMissingKeys`/`AssertNoMissingValues` parity guards) all caught the new fields before this was wired, which is how each seam above was found.

## Verification

- `pnpm tc` clean
- `pnpm exec oxlint` clean; `pnpm run check:code-quality:changed` — 0 new findings
- `pnpm test` over `components/activity`, `components/sidebar`, `store`, `shared`, `main/runtime/rpc`, `web`: **14489 passed**, 76 skipped
- New coverage in `ui-hydration-workspace-preferences.test.ts` for restore + malformed-value rejection