### PR TITLE
test(e2e): pass testInfo to startDockerSshRelayTarget in the freeze repro

### DIFF
--- a/tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts
+++ b/tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts
@@ -55,11 +55,11 @@ test.describe('R2 Docker SSH bulk-open freeze', () => {
   test('bulk-open many flooding SSH terminals and measure renderer lag @freeze-repro', async ({
     orcaPage,
     registerPostElectronShutdownCleanup
-  }) => {
+  }, testInfo) => {
     test.setTimeout(420_000)
     let target: DockerSshRelayTarget | null = null
     try {
-      target = startDockerSshRelayTarget()
+      target = startDockerSshRelayTarget(testInfo)
       registerPostElectronShutdownCleanup(async () => {
         if (target) {
           cleanupDockerSshRelayTarget(target)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

`tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts:62` called `startDockerSshRelayTarget()` with no argument, while the helper signature is `startDockerSshRelayTarget(testInfo: TestInfo)` and dereferences `testInfo.workerIndex` (`tests/e2e/helpers/docker-ssh-relay-target.ts:236`).

It threw `TypeError: Cannot read properties of undefined (reading 'workerIndex')` **before any Orca code ran**, so the Docker SSH e2e lane has been red on every PR that touches SSH. `git grep 'startDockerSshRelayTarget()'` finds exactly this one zero-arg call site; every other spec passes `testInfo`.

Two independent reviews hit it while verifying unrelated SSH work, which is how it surfaced.

Fixes #16764