### PR TITLE
fix(path): stop seeded user bin dirs from outranking the inherited PATH

### DIFF
--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -137,6 +137,66 @@ describe('patchPackagedProcessPath', () => {
     expect(segments).toContain('/usr/local/bin')
   })
 
+  // Why this ordering is load-bearing (#18234): a seed exists so a GUI-launched
+  // Electron can *find* a tool, not to re-rank tools the user already has.
+  // `~/.local/bin` is user-writable and can hold a wrapper for any system tool.
+  // The reporter's `~/.local/bin/gh` wrapped `mise x gh -- gh`; seeded ahead of
+  // /usr/bin it ran instead of the real gh, and the wrapper's inner bare `gh`
+  // resolved back to itself. Measured in a container: with the login shell's
+  // ordering that chain exits in 22ms, with the seeded ordering it never
+  // terminates and creates ~1,300 processes/second.
+  it('never lets a seeded user dir overtake a system dir already on PATH', async () => {
+    const { app } = await import('electron')
+    const { patchPackagedProcessPath } = await import('./configure-process')
+
+    setPlatform('linux')
+    Object.defineProperty(app, 'isPackaged', { configurable: true, value: true })
+    process.env.HOME = '/home/tester'
+    process.env.PATH = '/usr/local/bin:/usr/bin:/bin'
+
+    patchPackagedProcessPath()
+
+    const segments = (process.env.PATH ?? '').split(':')
+    const localBin = segments.indexOf(join('/home/tester', '.local/bin'))
+    // Still reachable — that is what the seeding is for (#829).
+    expect(localBin).toBeGreaterThan(-1)
+    for (const systemDir of ['/usr/bin', '/bin', '/usr/local/bin']) {
+      expect(segments.indexOf(systemDir)).toBeLessThan(localBin)
+    }
+    expect(segments.indexOf(join('/home/tester', 'bin'))).toBeGreaterThan(
+      segments.indexOf('/usr/bin')
+    )
+  })
+
+  it('keeps version-manager shims ahead of the inherited PATH', async () => {
+    const { app } = await import('electron')
+    const { patchPackagedProcessPath } = await import('./configure-process')
+    const { getVersionManagerBinPaths } = await import('../../shared/node-cli-command-resolution')
+
+    setPlatform('linux')
+    Object.defineProperty(app, 'isPackaged', { configurable: true, value: true })
+    process.env.HOME = '/home/tester'
+    process.env.PATH = '/usr/bin:/bin'
+
+    patchPackagedProcessPath()
+
+    const segments = (process.env.PATH ?? '').split(':')
+    const genericUserBinDirs = [join('/home/tester', 'bin'), join('/home/tester', '.local/bin')]
+    const seeded = getVersionManagerBinPaths({ platform: 'linux', homePath: '/home/tester' })
+    const shimDirs = seeded.filter((dir) => !genericUserBinDirs.includes(dir))
+    expect(shimDirs).not.toHaveLength(0)
+    // Why these keep leading: an nvm/mise/asdf user's runtime must beat a
+    // system install, which is the reason this seeding is ordered at all.
+    for (const dir of shimDirs) {
+      expect(segments.indexOf(dir)).toBeLessThan(segments.indexOf('/usr/bin'))
+    }
+    // Why these do not: the same list carries the generic user bin dirs, which
+    // hold whatever was last installed there rather than a managed toolchain.
+    for (const dir of genericUserBinDirs) {
+      expect(segments.indexOf(dir)).toBeGreaterThan(segments.indexOf('/usr/bin'))
+    }
+  })
+
   it('leaves PATH untouched when the app is not packaged', async () => {
     const { app } = await import('electron')
     const { patchPackagedProcessPath } = await import('./configure-process')

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -117,20 +117,37 @@ export function patchPackagedProcessPath(): void {
   }
 
   const home = process.env.HOME ?? ''
-  const extraPaths: string[] = []
+  // Why two lists: a seed exists so a GUI-launched Electron can *find* a tool
+  // its minimal PATH omits. Putting one ahead of the inherited PATH does more
+  // than that — it re-ranks binaries the user already has, and `~/bin` and
+  // `~/.local/bin` are arbitrary user-writable directories that can shadow any
+  // system tool. On the #18234 reporter's box `~/.local/bin/gh` is a wrapper
+  // around `mise x gh -- gh`; hoisting it over /usr/bin/gh made us run the
+  // wrapper where their own shell ran the real binary, and the inner bare `gh`
+  // then resolved back to the wrapper. So: append these, and let a real
+  // ordering opinion come from the login shell via mergePathSegments.
+  const isGenericUserBinDir = (path: string): boolean =>
+    process.platform !== 'win32' &&
+    home !== '' &&
+    (path === join(home, 'bin') || path === join(home, '.local/bin'))
+  const appendPaths: string[] = []
+  // Why these still lead: version-manager shims must beat a system install or
+  // an nvm/mise/asdf user gets the wrong runtime, which is the whole reason
+  // this seeding is ordered rather than appended (see hydrate-shell-path.ts).
+  const prependPaths: string[] = []
 
   if (process.platform !== 'win32') {
-    extraPaths.push('/opt/homebrew/bin', '/opt/homebrew/sbin', '/usr/local/bin', '/usr/local/sbin')
+    appendPaths.push('/opt/homebrew/bin', '/opt/homebrew/sbin', '/usr/local/bin', '/usr/local/sbin')
 
     if (process.platform === 'linux') {
       // Why: snap and Linuxbrew ship on Linux only, so seeding them elsewhere adds phantom PATH entries every spawn must stat.
-      extraPaths.push('/snap/bin', '/home/linuxbrew/.linuxbrew/bin')
+      appendPaths.push('/snap/bin', '/home/linuxbrew/.linuxbrew/bin')
     }
 
-    extraPaths.push('/nix/var/nix/profiles/default/bin')
+    appendPaths.push('/nix/var/nix/profiles/default/bin')
 
     if (home) {
-      extraPaths.push(
+      appendPaths.push(
         join(home, 'bin'),
         join(home, '.local/bin'),
         join(home, '.nix-profile/bin'),
@@ -142,18 +159,24 @@ export function patchPackagedProcessPath(): void {
   }
 
   // Why: version-manager CLIs use env-node shebangs, so node must be on PATH or spawns fail (also seeds Windows user-local dirs).
-  extraPaths.push(...getVersionManagerBinPaths())
+  // Why the filter: that list carries `~/bin` and `~/.local/bin` too, because
+  // bun/pnpm/npm --user also install there. Those two are generic user bin
+  // directories, not a version manager's own shim directory, so they hold
+  // whatever the user last dropped in them and must not outrank a system dir.
+  // The specific dirs (.volta/bin, .asdf/shims, mise shims, .bun/bin, …) keep
+  // leading, which is what the ordering was actually for.
+  prependPaths.push(...getVersionManagerBinPaths().filter((path) => !isGenericUserBinDir(path)))
 
   const pathKey = process.platform === 'win32' && process.env.Path !== undefined ? 'Path' : 'PATH'
   const currentPath = process.env[pathKey] ?? ''
   const pathDelimiter = getProcessPathDelimiter()
-  const existing = new Set(currentPath.split(pathDelimiter))
-  const missing = extraPaths.filter((path) => !existing.has(path))
+  const currentSegments = currentPath.split(pathDelimiter).filter(Boolean)
+  const existing = new Set(currentSegments)
+  const prepend = prependPaths.filter((path) => !existing.has(path))
+  const append = appendPaths.filter((path) => !existing.has(path) && !prepend.includes(path))
 
-  if (missing.length > 0) {
-    process.env[pathKey] = [...missing, ...currentPath.split(pathDelimiter).filter(Boolean)].join(
-      pathDelimiter
-    )
+  if (prepend.length > 0 || append.length > 0) {
+    process.env[pathKey] = [...prepend, ...currentSegments, ...append].join(pathDelimiter)
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

Follow-up to #18234 / #18258. This one is ours.

## What establishes causation

Ubuntu 24.04 container, mise 2026.9.1, a real `gh` in a system dir, and a `~/.local/bin/gh` wrapper of the shape the #18234 reporter's `ps` output implies (`mise x gh -- gh "$@"`), driven exactly the way Orca drives it — Node `execFile`, bare name, PATH-resolved:

| | login-shell order | Orca seeded order |
|---|---|---|
| `gh` installed + pinned in mise | 37ms | 28ms |
| mise resolution fails | **26ms** | **never terminates, 10,037 tasks/6s** |

Neither factor alone does anything. Orca's ordering on its own is harmless. A mise resolution failure on its own exits cleanly in 26ms. **Only the combination loops — and the combination exists only because we changed which `gh` runs.**

So this is a necessary co-factor we own, not the whole trigger. See "What this does not explain" below.

## The defect

`patchPackagedProcessPath` prepends *every* seeded directory:

```ts
process.env[pathKey] = [...missing, ...currentPath.split(pathDelimiter).filter(Boolean)].join(…)
```

Seeding exists so a GUI-launched Electron can **find** a tool its minimal PATH omits (#829). Prepending does more than that: it re-ranks binaries the user already has. `~/bin` and `~/.local/bin` are arbitrary user-writable directories that can hold a wrapper for any system tool, and we were putting them ahead of `/usr/bin`.

The window is startup until the login-shell probe completes (up to 10s), and **permanent if that probe fails or times out** — which a heavy rc file will do.

We already had the right rule written down, in the WSL twin of this list:

> **Append, never prepend:** when the login PATH did resolve it is authoritative, and a prepended fallback could shadow the binary the user actually runs with an older one from a stale nvm version directory.
>
> — `src/shared/posix-version-manager-bin-dirs.ts`

The native path just didn't follow it.

## The fix

Prepending is load-bearing only for **version-manager shim dirs** — an nvm/mise/asdf user's runtime must beat a system install, which is the documented intent in `hydrate-shell-path.ts`. Those keep leading. The generic dirs (`~/bin`, `~/.local/bin`, homebrew, snap, nix, the agent-CLI dirs) move behind the inherited PATH, where they are still found.

One wrinkle worth knowing: `getVersionManagerBinPaths()` carries `~/bin` and `~/.local/bin` too, because bun and pnpm install there. So they are filtered out of the leading group **by name**, not by which list produced them. Merely reordering the two seed lists against each other does *not* fix this — I tried it first and the wrapper still beat `/usr/bin`, because `~/.local/bin` arrived via the version-manager list.

Windows is unchanged: the generic block is POSIX-only and the demotion is gated on `platform !== 'win32'`.

### Resulting order

```
~/.volta/bin  ~/.asdf/shims  ~/.fnm/…  ~/.local/share/mise/shims  ~/.local/share/pnpm  ~/.yarn/bin  ~/.bun/bin
  ← inherited PATH (/usr/local/sbin /usr/local/bin /usr/bin …) →
/opt/homebrew/bin  …  ~/bin  ~/.local/bin  ~/.nix-profile/bin  ~/.opencode/bin  ~/.vite-plus/bin
```

### Measured, clean container each run, using the exact PATH strings this code emits

| | resolves `gh` to | result |
|---|---|---|
| user's login shell, no seeding | real `gh` | 22ms |
| **before this PR** | `~/.local/bin/gh` wrapper | **never terminates, 9,363 tasks/6s** |
| **after this PR** | real `gh` | **36ms, 14 tasks/6s** |

## What this does not explain

I am not claiming this explains the reporter's symptom, and the PR should not be read that way.

My reproduction needs mise to resolve `gh` to *nothing* — I forced that with `MISE_OFFLINE=1` plus the tool uninstalled and unpinned, and I have no evidence the reporter is in that state. Their CPU signature also still differs: their processes were `R` at 99.6% for 1h48m, while my ladder members sleep at 0% and exhaust PIDs instead. Same structural fault, different cost.

What is established is narrower and enough to justify this change on its own: **we were changing which binary runs**, and that is what turns a benign upstream failure into an unbounded one.

## Known consequence

During the pre-hydration window a macOS user with, say, a Homebrew `git` alongside Apple's `/usr/bin/git` now gets Apple's until hydration lands. That is a real change, and it is the conservative direction — the alternative is what this PR is fixing, where an arbitrary user-writable directory wins. Hydration restores the user's own ordering seconds later, and version-manager runtimes are unaffected.

## Noted separately, not fixed here

Several seeded directories never exist on a given machine (`/opt/homebrew/*` and `/home/linuxbrew/*` on most boxes, `~/.nix-profile/bin`, `~/.opencode/bin`, `~/.vite-plus/bin`, `~/.volta/bin`, `~/.asdf/shims`). Every PATH lookup in every child process pays a `statx` for each, which is a plausible contributor to the `statx`/`readlink` ENOENT volume in the #18234 histogram. Filtering by existence at seed time is a snapshot, so a directory created after startup would be missed until re-hydration — a perf nicety with a correctness edge, so it wants its own change rather than riding along here.

## Verification

- `pnpm tc` clean; `pnpm run check:code-quality:changed` — 0 new findings.
- `pnpm test src/main/startup src/main/preflight src/cli/handlers` — 783 passed, 6 skipped.
- Two new regression tests: a seeded user dir can never overtake a system dir already on PATH, and version-manager shim dirs still lead it. The second asserts both halves — the shim dirs ahead, the generic user dirs behind — so a future change that folds them back together fails.