### PR TITLE
fix(native-chat): show images in Codex structured chat

### DIFF
--- a/src/renderer/src/components/editor/local-image-src-cache.ts
+++ b/src/renderer/src/components/editor/local-image-src-cache.ts
@@ -1,0 +1,234 @@
+import {
+  clearLocalImageCachePins,
+  isLocalImageCacheKeyPinned,
+  pinLocalImageCacheKey,
+  prunePinnedLocalImageCache,
+  unpinLocalImageCacheKey
+} from './local-image-cache-pinning'
+
+const BLOB_URL_CACHE_MAX_SIZE = 100
+// Keep retained decoded image data bounded as well as entry count.
+const BLOB_URL_CACHE_MAX_BYTES = 128 * 1024 * 1024
+
+export const blobUrlCache = new Map<string, string>()
+const blobUrlCacheBytes = new Map<string, number>()
+export const inFlightBlobUrlLoads = new Map<string, Promise<string | null>>()
+// Incremented on lease transitions so a read resolving after release cannot
+// repopulate the cache. A later lease gets a new version and may cache safely.
+const cacheKeyVersions = new Map<string, number>()
+
+export function getLocalImageCacheKeyVersion(key: string): number {
+  return cacheKeyVersions.get(key) ?? 0
+}
+
+export function cleanupLocalImageCacheKeyVersion(key: string): void {
+  if (
+    !blobUrlCache.has(key) &&
+    !inFlightBlobUrlLoads.has(key) &&
+    !isLocalImageCacheKeyPinned(key)
+  ) {
+    cacheKeyVersions.delete(key)
+  }
+}
+
+let cacheGeneration = 0
+const cacheListeners = new Set<() => void>()
+const pendingBlobUrlRevocations = new Set<string>()
+let pendingBlobUrlRevocationTimer: ReturnType<typeof setTimeout> | null = null
+
+function pruneImageCache(): void {
+  prunePinnedLocalImageCache(blobUrlCache, BLOB_URL_CACHE_MAX_SIZE, (url) => {
+    URL.revokeObjectURL(url)
+  })
+  for (const key of blobUrlCacheBytes.keys()) {
+    if (!blobUrlCache.has(key)) {
+      blobUrlCacheBytes.delete(key)
+      cleanupLocalImageCacheKeyVersion(key)
+    }
+  }
+  let retainedBytes = 0
+  for (const byteLength of blobUrlCacheBytes.values()) {
+    retainedBytes += byteLength
+  }
+  while (retainedBytes > BLOB_URL_CACHE_MAX_BYTES) {
+    const key = Array.from(blobUrlCache.keys()).find(
+      (candidate) => !isLocalImageCacheKeyPinned(candidate)
+    )
+    if (key === undefined) {
+      return
+    }
+    const url = blobUrlCache.get(key)
+    blobUrlCache.delete(key)
+    retainedBytes -= blobUrlCacheBytes.get(key) ?? 0
+    blobUrlCacheBytes.delete(key)
+    if (url) {
+      URL.revokeObjectURL(url)
+    }
+    cleanupLocalImageCacheKeyVersion(key)
+  }
+}
+
+export function cacheLocalImageBlob(
+  key: string,
+  url: string,
+  byteLength: number,
+  expectedVersion?: number
+): boolean {
+  if (
+    (expectedVersion !== undefined && getLocalImageCacheKeyVersion(key) !== expectedVersion) ||
+    byteLength > BLOB_URL_CACHE_MAX_BYTES
+  ) {
+    URL.revokeObjectURL(url)
+    cleanupLocalImageCacheKeyVersion(key)
+    return false
+  }
+  const previousUrl = blobUrlCache.get(key)
+  const previousBytes = blobUrlCacheBytes.get(key) ?? 0
+  let retainedBytes = 0
+  for (const bytes of blobUrlCacheBytes.values()) {
+    retainedBytes += bytes
+  }
+  let projectedEntries = blobUrlCache.size + (previousUrl === undefined ? 1 : 0)
+  let projectedBytes = retainedBytes - previousBytes + byteLength
+
+  // Evict only unpinned entries. If visible leases consume the budget, fail
+  // closed so a late/non-visible decode cannot make retention unbounded.
+  while (projectedEntries > BLOB_URL_CACHE_MAX_SIZE || projectedBytes > BLOB_URL_CACHE_MAX_BYTES) {
+    const candidate = Array.from(blobUrlCache.keys()).find(
+      (candidateKey) => candidateKey !== key && !isLocalImageCacheKeyPinned(candidateKey)
+    )
+    if (candidate === undefined) {
+      URL.revokeObjectURL(url)
+      cleanupLocalImageCacheKeyVersion(key)
+      return false
+    }
+    const candidateUrl = blobUrlCache.get(candidate)
+    const candidateBytes = blobUrlCacheBytes.get(candidate) ?? 0
+    blobUrlCache.delete(candidate)
+    blobUrlCacheBytes.delete(candidate)
+    projectedEntries -= 1
+    projectedBytes -= candidateBytes
+    if (candidateUrl) {
+      URL.revokeObjectURL(candidateUrl)
+    }
+    cleanupLocalImageCacheKeyVersion(candidate)
+  }
+  if (previousUrl !== undefined && previousUrl !== url) {
+    URL.revokeObjectURL(previousUrl)
+  }
+  blobUrlCacheBytes.delete(key)
+  blobUrlCacheBytes.set(key, byteLength)
+  blobUrlCache.set(key, url)
+  return true
+}
+
+export function getLocalImageCacheGeneration(): number {
+  return cacheGeneration
+}
+
+export function pinLocalImageCache(key: string): void {
+  if (!isLocalImageCacheKeyPinned(key)) {
+    cacheKeyVersions.set(key, getLocalImageCacheKeyVersion(key) + 1)
+  }
+  pinLocalImageCacheKey(key)
+}
+
+export function unpinLocalImageCache(key: string): void {
+  unpinLocalImageCacheKey(key)
+  pruneImageCache()
+  cleanupLocalImageCacheKeyVersion(key)
+}
+
+export function subscribeToLocalImageCacheInvalidation(listener: () => void): () => void {
+  cacheListeners.add(listener)
+  return () => cacheListeners.delete(listener)
+}
+
+function revokePendingBlobUrls(): void {
+  pendingBlobUrlRevocationTimer = null
+  for (const url of pendingBlobUrlRevocations) {
+    URL.revokeObjectURL(url)
+  }
+  pendingBlobUrlRevocations.clear()
+}
+
+function scheduleBlobUrlRevocation(urls: string[]): void {
+  for (const url of urls) {
+    pendingBlobUrlRevocations.add(url)
+  }
+  if (pendingBlobUrlRevocationTimer !== null || pendingBlobUrlRevocations.size === 0) {
+    return
+  }
+  pendingBlobUrlRevocationTimer = setTimeout(revokePendingBlobUrls, 30_000)
+}
+
+export function invalidateLocalImageCache(): void {
+  const staleUrls = Array.from(blobUrlCache.values())
+  blobUrlCache.clear()
+  blobUrlCacheBytes.clear()
+  inFlightBlobUrlLoads.clear()
+  cacheKeyVersions.clear()
+  cacheGeneration += 1
+  for (const listener of cacheListeners) {
+    listener()
+  }
+  if (staleUrls.length > 0) {
+    scheduleBlobUrlRevocation(staleUrls)
+  }
+}
+
+export function releaseLocalImageBlob(key: string): void {
+  if (isLocalImageCacheKeyPinned(key)) {
+    return
+  }
+  cacheKeyVersions.set(key, getLocalImageCacheKeyVersion(key) + 1)
+  const inFlight = inFlightBlobUrlLoads.get(key)
+  if (inFlight) {
+    // A released lease must not be reused by a later visible lease: the
+    // released read may resolve null or be stale for the next owner.
+    inFlightBlobUrlLoads.delete(key)
+  }
+  const url = blobUrlCache.get(key)
+  if (url) {
+    blobUrlCache.delete(key)
+    blobUrlCacheBytes.delete(key)
+    URL.revokeObjectURL(url)
+  }
+  if (!inFlight) {
+    cleanupLocalImageCacheKeyVersion(key)
+  }
+}
+
+export function resetLocalImageCacheState(): void {
+  if (pendingBlobUrlRevocationTimer !== null) {
+    clearTimeout(pendingBlobUrlRevocationTimer)
+    pendingBlobUrlRevocationTimer = null
+  }
+  revokePendingBlobUrls()
+  for (const url of blobUrlCache.values()) {
+    URL.revokeObjectURL(url)
+  }
+  blobUrlCache.clear()
+  blobUrlCacheBytes.clear()
+  clearLocalImageCachePins()
+  inFlightBlobUrlLoads.clear()
+  cacheKeyVersions.clear()
+  cacheGeneration = 0
+  pendingBlobUrlRevocations.clear()
+  cacheListeners.clear()
+}
+
+export function disposeLocalImageCacheState(): void {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('focus', invalidateLocalImageCache)
+  }
+  resetLocalImageCacheState()
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('focus', invalidateLocalImageCache)
+}
+
+if (import.meta !== undefined && import.meta.hot) {
+  import.meta.hot.dispose(disposeLocalImageCacheState)
+}

--- a/src/renderer/src/components/editor/local-image-src-cache.ts
+++ b/src/renderer/src/components/editor/local-image-src-cache.ts
@@ -13,8 +13,8 @@ const BLOB_URL_CACHE_MAX_BYTES = 128 * 1024 * 1024
 export const blobUrlCache = new Map<string, string>()
 const blobUrlCacheBytes = new Map<string, number>()
 export const inFlightBlobUrlLoads = new Map<string, Promise<string | null>>()
-// Incremented on lease transitions so a read resolving after release cannot
-// repopulate the cache. A later lease gets a new version and may cache safely.
+// Incremented on release so a read resolving after its last consumer left
+// cannot repopulate the cache.
 const cacheKeyVersions = new Map<string, number>()
 
 export function getLocalImageCacheKeyVersion(key: string): number {
@@ -127,9 +127,6 @@ export function getLocalImageCacheGeneration(): number {
 }
 
 export function pinLocalImageCache(key: string): void {
-  if (!isLocalImageCacheKeyPinned(key)) {
-    cacheKeyVersions.set(key, getLocalImageCacheKeyVersion(key) + 1)
-  }
   pinLocalImageCacheKey(key)
 }
 

--- a/src/renderer/src/components/editor/local-image-src-reader.ts
+++ b/src/renderer/src/components/editor/local-image-src-reader.ts
@@ -1,0 +1,23 @@
+import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
+import { readRuntimeFilePreview } from '@/runtime/runtime-file-client'
+
+export function readLocalImagePreview(
+  absolutePath: string,
+  connectionId?: string | null,
+  runtimeContext?: Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null }
+) {
+  try {
+    if (!runtimeContext) {
+      return window.api.fs.readFile({
+        filePath: absolutePath,
+        connectionId: connectionId ?? undefined
+      })
+    }
+    return readRuntimeFilePreview(
+      { ...runtimeContext, connectionId: runtimeContext.connectionId ?? connectionId ?? undefined },
+      absolutePath
+    )
+  } catch (error) {
+    return Promise.reject(error)
+  }
+}

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -12,7 +12,11 @@ import { TableRow } from '@tiptap/extension-table-row'
 import { BlockMath, InlineMath } from '@tiptap/extension-mathematics'
 import { Markdown } from '@tiptap/markdown'
 import { createLowlight, common } from 'lowlight'
-import { loadLocalImageSrc, onImageCacheInvalidated } from './useLocalImageSrc'
+import {
+  acquireLocalImageSrcLease,
+  loadLocalImageSrc,
+  onImageCacheInvalidated
+} from './useLocalImageSrc'
 import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
 import {
   createRawMarkdownHtmlBlock,
@@ -126,14 +130,18 @@ export function createRichMarkdownExtensions({
 
           let currentSrc = node.attrs.src as string | undefined
           let currentContextVersion = getImageContextVersion(this.storage)
+          let releaseImageLease: (() => void) | undefined
 
           const loadImage = (src: string | undefined): void => {
+            releaseImageLease?.()
+            releaseImageLease = undefined
             const fp = this.storage.filePath as string
             const runtimeContext = this.storage.runtimeContext as
               | RuntimeFileOperationArgs
               | undefined
             const contextVersionAtLoad = getImageContextVersion(this.storage)
             if (src && fp) {
+              releaseImageLease = acquireLocalImageSrcLease(src, fp, undefined, runtimeContext)
               void loadLocalImageSrc(src, fp, undefined, runtimeContext).then((resolved) => {
                 if (currentSrc !== src || currentContextVersion !== contextVersionAtLoad) {
                   return
@@ -187,6 +195,7 @@ export function createRichMarkdownExtensions({
               return true
             },
             destroy: () => {
+              releaseImageLease?.()
               if (reloadListeners instanceof Set) {
                 reloadListeners.delete(reloadForContextChange)
               }

--- a/src/renderer/src/components/editor/rich-markdown-local-image.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-local-image.test.ts
@@ -4,7 +4,7 @@ import { Editor } from '@tiptap/core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRichMarkdownExtensions } from './rich-markdown-extensions'
 import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
-import { resetLocalImageSrcStateForTests } from './useLocalImageSrc'
+import { releaseLocalImageSrc, resetLocalImageSrcStateForTests } from './useLocalImageSrc'
 import { setRichMarkdownImageResolverContext } from './rich-markdown-image-context'
 
 async function flushPromises(): Promise<void> {
@@ -18,6 +18,7 @@ describe('rich markdown local images', () => {
   beforeEach(() => {
     resetLocalImageSrcStateForTests()
     vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:rich-local-image')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
     globalThis.window.api = {
       ...globalThis.window.api,
       fs: {
@@ -59,6 +60,29 @@ describe('rich markdown local images', () => {
         filePath: '/repo/docs/diagram.png',
         connectionId: undefined
       })
+      expect(host.querySelector('img')?.src).toBe('blob:rich-local-image')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('keeps a displayed image leased when another surface releases the same cache entry', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const editor = new Editor({
+      element: host,
+      extensions: createRichMarkdownExtensions({ codec: createRichMarkdownEditorCodec() }),
+      content: '![](diagram.png)',
+      contentType: 'markdown'
+    })
+
+    try {
+      setRichMarkdownImageResolverContext(editor, { filePath: '/repo/docs/readme.md' })
+      await flushPromises()
+
+      releaseLocalImageSrc('diagram.png', '/repo/docs/readme.md')
+
+      expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('blob:rich-local-image')
       expect(host.querySelector('img')?.src).toBe('blob:rich-local-image')
     } finally {
       editor.destroy()

--- a/src/renderer/src/components/editor/useLocalImageSrc.test.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.test.ts
@@ -7,9 +7,16 @@ import {
   getLocalImageCacheKey,
   invalidateLocalImageSrcCacheForTests,
   loadLocalImageSrc,
+  releaseLocalImageSrc,
   resetLocalImageSrcStateForTests,
   useLocalImageSrc
 } from './useLocalImageSrc'
+import {
+  blobUrlCache,
+  cacheLocalImageBlob,
+  getLocalImageCacheKeyVersion,
+  pinLocalImageCache
+} from './local-image-src-cache'
 
 type PreviewResult = {
   content: string
@@ -228,6 +235,84 @@ describe('loadLocalImageSrc', () => {
     )
     expect(readFile).toHaveBeenCalledTimes(2)
     expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('blob:newer')
+  })
+
+  it('does not retain a read that resolves after its preview lease is released', async () => {
+    const read = deferred<PreviewResult>()
+    const readFile = vi.fn().mockReturnValue(read.promise)
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:released')
+    setReadFile(readFile)
+
+    const pending = loadLocalImageSrc('diagram.png', '/repo/docs/readme.md')
+    releaseLocalImageSrc('diagram.png', '/repo/docs/readme.md')
+    read.resolve(binaryPreview())
+
+    await expect(pending).resolves.toBeNull()
+    expect(blobUrlCache.size).toBe(0)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:released')
+  })
+
+  it('starts a fresh read when a released lease becomes visible again', async () => {
+    const firstRead = deferred<PreviewResult>()
+    const secondRead = deferred<PreviewResult>()
+    const readFile = vi
+      .fn()
+      .mockReturnValueOnce(firstRead.promise)
+      .mockReturnValueOnce(secondRead.promise)
+    vi.spyOn(URL, 'createObjectURL')
+      .mockReturnValueOnce('blob:fresh')
+      .mockReturnValueOnce('blob:stale')
+    setReadFile(readFile)
+
+    const stale = loadLocalImageSrc('diagram.png', '/repo/docs/readme.md')
+    releaseLocalImageSrc('diagram.png', '/repo/docs/readme.md')
+    const fresh = loadLocalImageSrc('diagram.png', '/repo/docs/readme.md')
+    expect(readFile).toHaveBeenCalledTimes(2)
+
+    secondRead.resolve(binaryPreview('AQ=='))
+    await expect(fresh).resolves.toBe('blob:fresh')
+    firstRead.resolve(binaryPreview())
+    await expect(stale).resolves.toBeNull()
+    expect(blobUrlCache.size).toBe(1)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:stale')
+  })
+
+  it('cleans version metadata for released unique paths', () => {
+    for (let index = 0; index < 500; index += 1) {
+      const path = `/repo/docs/image-${index}.png`
+      releaseLocalImageSrc(path, '/repo/docs/readme.md')
+      expect(getLocalImageCacheKeyVersion(getLocalImageCacheKey(path, undefined, undefined))).toBe(
+        0
+      )
+    }
+  })
+
+  it('fails closed when pinned previews already consume the entry or byte budget', () => {
+    for (let index = 0; index < 100; index += 1) {
+      const key = `pinned-${index}`
+      pinLocalImageCache(key)
+      expect(cacheLocalImageBlob(key, `blob:${index}`, 1)).toBe(true)
+    }
+
+    expect(cacheLocalImageBlob('pinned-overflow', 'blob:overflow', 1)).toBe(false)
+    expect(blobUrlCache.size).toBe(100)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:overflow')
+
+    expect(
+      cacheLocalImageBlob('large-overflow', 'blob:large-overflow', 128 * 1024 * 1024 + 1)
+    ).toBe(false)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:large-overflow')
+  })
+
+  it('does not exceed the decoded-byte budget when all retained entries are pinned', () => {
+    const retainedBytes = 80 * 1024 * 1024
+    pinLocalImageCache('large-pinned-1')
+    pinLocalImageCache('large-pinned-2')
+    expect(cacheLocalImageBlob('large-pinned-1', 'blob:large-1', retainedBytes)).toBe(true)
+    expect(cacheLocalImageBlob('large-pinned-2', 'blob:large-2', retainedBytes)).toBe(false)
+
+    expect(blobUrlCache.size).toBe(1)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:large-2')
   })
 
   it('keeps runtime owners in separate image cache entries', async () => {

--- a/src/renderer/src/components/editor/useLocalImageSrc.test.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.test.ts
@@ -135,6 +135,37 @@ describe('loadLocalImageSrc', () => {
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
   })
 
+  it('lets a mounted preview adopt an in-flight prewarm read', async () => {
+    const read = deferred<PreviewResult>()
+    const readFile = vi.fn().mockReturnValue(read.promise)
+    const renders: (string | undefined)[] = []
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:prewarmed')
+    setReadFile(readFile)
+
+    const prewarm = loadLocalImageSrc('diagram.png', '/repo/docs/readme.md')
+    const container = document.createElement('div')
+    const root: Root = createRoot(container)
+    await act(async () => {
+      root.render(
+        createElement(HookProbe, {
+          filePath: '/repo/docs/readme.md',
+          onRender: (displaySrc) => renders.push(displaySrc),
+          src: 'diagram.png'
+        })
+      )
+    })
+    expect(readFile).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      read.resolve(binaryPreview())
+      await flushPromises()
+    })
+
+    await expect(prewarm).resolves.toBe('blob:prewarmed')
+    expect(renders.at(-1)).toBe('blob:prewarmed')
+    root.unmount()
+  })
+
   it('does not revoke blob URLs still used by mounted previews during eviction', async () => {
     const readFile = vi.fn().mockResolvedValue(binaryPreview())
     let nextUrl = 0

--- a/src/renderer/src/components/editor/useLocalImageSrc.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.ts
@@ -72,18 +72,7 @@ export function useLocalImageSrc(
   const [generation, setGeneration] = useState(getLocalImageCacheGeneration())
 
   useEffect(() => {
-    if (!rawSrc || isExternalUrl(rawSrc) || runtimeContext === null) {
-      return
-    }
-    const absolutePath = resolveImageAbsolutePath(rawSrc, filePath)
-    if (!absolutePath) {
-      return
-    }
-    const cacheKey = getLocalImageCacheKey(absolutePath, connectionId, runtimeContext)
-    pinLocalImageCache(cacheKey)
-    return () => {
-      unpinLocalImageCache(cacheKey)
-    }
+    return acquireLocalImageSrcLease(rawSrc, filePath, connectionId, runtimeContext)
   }, [rawSrc, filePath, connectionId, runtimeContext])
 
   useEffect(() => {
@@ -243,6 +232,26 @@ export function resetLocalImageSrcStateForTests(): void {
 
 export function invalidateLocalImageSrcCacheForTests(): void {
   invalidateLocalImageCache()
+}
+
+export function acquireLocalImageSrcLease(
+  rawSrc: string | undefined,
+  filePath: string,
+  connectionId?: string | null,
+  runtimeContext?:
+    | (Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null })
+    | null
+): (() => void) | undefined {
+  if (!rawSrc || isExternalUrl(rawSrc) || runtimeContext === null) {
+    return undefined
+  }
+  const absolutePath = resolveImageAbsolutePath(rawSrc, filePath)
+  if (!absolutePath) {
+    return undefined
+  }
+  const key = getLocalImageCacheKey(absolutePath, connectionId, runtimeContext)
+  pinLocalImageCache(key)
+  return () => unpinLocalImageCache(key)
 }
 
 /** Evict one no-longer-visible transcript preview immediately. */

--- a/src/renderer/src/components/editor/useLocalImageSrc.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.ts
@@ -1,22 +1,21 @@
 import { useEffect, useState } from 'react'
 import { resolveImageAbsolutePath } from './markdown-preview-links'
 import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
-import { readRuntimeFilePreview } from '@/runtime/runtime-file-client'
+import { readLocalImagePreview } from './local-image-src-reader'
 import {
-  clearLocalImageCachePins,
-  pinLocalImageCacheKey,
-  prunePinnedLocalImageCache,
-  unpinLocalImageCacheKey
-} from './local-image-cache-pinning'
-
-// Why: the renderer is served from http://localhost in dev mode, so file://
-// URLs in <img> tags are blocked by cross-origin restrictions. Loading images
-// via the existing fs.readFile IPC and converting to blob URLs bypasses this
-// limitation and works identically in both dev and production modes.
-
-const BLOB_URL_CACHE_MAX_SIZE = 100
-const blobUrlCache = new Map<string, string>()
-const inFlightBlobUrlLoads = new Map<string, Promise<string | null>>()
+  blobUrlCache,
+  cacheLocalImageBlob,
+  cleanupLocalImageCacheKeyVersion,
+  getLocalImageCacheGeneration,
+  getLocalImageCacheKeyVersion,
+  inFlightBlobUrlLoads,
+  invalidateLocalImageCache,
+  pinLocalImageCache,
+  releaseLocalImageBlob,
+  resetLocalImageCacheState,
+  subscribeToLocalImageCacheInvalidation,
+  unpinLocalImageCache
+} from './local-image-src-cache'
 
 export function getLocalImageCacheKey(
   absolutePath: string,
@@ -28,131 +27,32 @@ export function getLocalImageCacheKey(
   return [
     runtimeEnvironmentId,
     runtimeContext?.connectionId ?? connectionId ?? 'local',
+    runtimeContext?.expectedExecutionHostId ?? 'unknown-host',
+    runtimeContext?.expectedSshTargetId ?? '',
+    runtimeContext?.expectedSshConnectionGeneration?.toString() ?? '',
     runtimeContext?.expectedExternalSshTargetId ?? '',
     runtimeContext?.worktreeId ?? 'unknown-worktree',
+    runtimeContext?.worktreePath ?? '',
     absolutePath
   ].join('\0')
 }
 
-// Why: blob URLs hold references to in-memory Blob objects; without eviction
-// the cache grows without bound and leaks memory. We evict the oldest entry
-// (Map iteration order is insertion order) and revoke its blob URL so the
-// browser can free the underlying data.
-function cacheBlobUrl(key: string, url: string): void {
-  const previousUrl = blobUrlCache.get(key)
-  if (previousUrl !== undefined) {
-    blobUrlCache.delete(key)
-    if (previousUrl !== url) {
-      // Why: cache replacements must release the superseded Blob even when
-      // they come from rare stale state or future loader changes.
-      URL.revokeObjectURL(previousUrl)
-    }
-  }
-  blobUrlCache.set(key, url)
-  prunePinnedLocalImageCache(blobUrlCache, BLOB_URL_CACHE_MAX_SIZE, URL.revokeObjectURL)
-}
-
-const cacheListeners = new Set<() => void>()
-let cacheGeneration = 0
-const pendingBlobUrlRevocations = new Set<string>()
-let pendingBlobUrlRevocationTimer: ReturnType<typeof setTimeout> | null = null
-
-function base64ToBlobUrl(base64: string, mimeType: string): string {
+function base64ToBlobUrl(base64: string, mimeType: string): { url: string; byteLength: number } {
   const binary = atob(base64.replace(/\s/g, ''))
   const bytes = new Uint8Array(binary.length)
   for (let i = 0; i < binary.length; i += 1) {
     bytes[i] = binary.charCodeAt(i)
   }
-  return URL.createObjectURL(new Blob([bytes], { type: mimeType }))
-}
-
-function revokePendingBlobUrls(): void {
-  pendingBlobUrlRevocationTimer = null
-  for (const url of pendingBlobUrlRevocations) {
-    URL.revokeObjectURL(url)
-  }
-  pendingBlobUrlRevocations.clear()
-}
-
-function scheduleBlobUrlRevocation(urls: string[]): void {
-  for (const url of urls) {
-    pendingBlobUrlRevocations.add(url)
-  }
-  if (pendingBlobUrlRevocationTimer !== null || pendingBlobUrlRevocations.size === 0) {
-    return
-  }
-  pendingBlobUrlRevocationTimer = setTimeout(revokePendingBlobUrls, 30_000)
-}
-
-// Why: when the user switches back to the app after deleting or replacing
-// image files externally, clearing the cache forces the preview to pick up
-// the current filesystem state instead of showing stale in-memory blob URLs.
-// Old blob URLs are revoked after a short delay so that <img> elements still
-// display the old data while the fresh IPC load completes, avoiding a visible
-// flash. The 30-second window is generous enough for even slow IPC reads.
-function invalidateImageCache(): void {
-  const staleUrls = Array.from(blobUrlCache.values())
-  blobUrlCache.clear()
-  inFlightBlobUrlLoads.clear()
-  cacheGeneration += 1
-  for (const listener of cacheListeners) {
-    listener()
-  }
-  // Why: defer revocation so the browser keeps the old blob data readable
-  // until replacement IPC loads complete, then free the underlying memory.
-  // 30 seconds is generous enough to cover slow machines or large images
-  // without risking a visible broken-image flash.
-  if (staleUrls.length > 0) {
-    scheduleBlobUrlRevocation(staleUrls)
+  return {
+    url: URL.createObjectURL(new Blob([bytes], { type: mimeType })),
+    byteLength: bytes.byteLength
   }
 }
 
-function disposeImageCacheModuleState(): void {
-  if (typeof window !== 'undefined') {
-    window.removeEventListener('focus', invalidateImageCache)
-  }
-  if (pendingBlobUrlRevocationTimer !== null) {
-    clearTimeout(pendingBlobUrlRevocationTimer)
-    pendingBlobUrlRevocationTimer = null
-  }
-  revokePendingBlobUrls()
-  for (const url of blobUrlCache.values()) {
-    URL.revokeObjectURL(url)
-  }
-  blobUrlCache.clear()
-  clearLocalImageCachePins()
-  inFlightBlobUrlLoads.clear()
-  cacheListeners.clear()
-}
-
-if (typeof window !== 'undefined') {
-  window.addEventListener('focus', invalidateImageCache)
-}
-
-if (import.meta !== undefined && import.meta.hot) {
-  // Why: Vite can re-evaluate this module without a full renderer reload.
-  // Disposing the module-level listener and blob URLs prevents dev-session leaks.
-  import.meta.hot.dispose(disposeImageCacheModuleState)
-}
-
-/**
- * Subscribe to cache invalidation events (fired on window re-focus).
- * Returns an unsubscribe function.
- */
-export function onImageCacheInvalidated(listener: () => void): () => void {
-  cacheListeners.add(listener)
-  return () => {
-    cacheListeners.delete(listener)
-  }
-}
+export const onImageCacheInvalidated = subscribeToLocalImageCacheInvalidation
 
 function isExternalUrl(src: string): boolean {
-  return (
-    src.startsWith('http://') ||
-    src.startsWith('https://') ||
-    src.startsWith('data:') ||
-    src.startsWith('blob:')
-  )
+  return /^(?:https?|data|blob):/i.test(src)
 }
 
 /**
@@ -165,12 +65,14 @@ export function useLocalImageSrc(
   rawSrc: string | undefined,
   filePath: string,
   connectionId?: string | null,
-  runtimeContext?: Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null }
+  runtimeContext?:
+    | (Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null })
+    | null
 ): string | undefined {
-  const [generation, setGeneration] = useState(cacheGeneration)
+  const [generation, setGeneration] = useState(getLocalImageCacheGeneration())
 
   useEffect(() => {
-    if (!rawSrc || isExternalUrl(rawSrc)) {
+    if (!rawSrc || isExternalUrl(rawSrc) || runtimeContext === null) {
       return
     }
     const absolutePath = resolveImageAbsolutePath(rawSrc, filePath)
@@ -178,19 +80,18 @@ export function useLocalImageSrc(
       return
     }
     const cacheKey = getLocalImageCacheKey(absolutePath, connectionId, runtimeContext)
-    pinLocalImageCacheKey(cacheKey)
+    pinLocalImageCache(cacheKey)
     return () => {
-      unpinLocalImageCacheKey(cacheKey)
-      prunePinnedLocalImageCache(blobUrlCache, BLOB_URL_CACHE_MAX_SIZE, URL.revokeObjectURL)
+      unpinLocalImageCache(cacheKey)
     }
   }, [rawSrc, filePath, connectionId, runtimeContext])
 
   useEffect(() => {
-    return onImageCacheInvalidated(() => setGeneration(cacheGeneration))
+    return onImageCacheInvalidated(() => setGeneration(getLocalImageCacheGeneration()))
   }, [])
 
   const [displaySrc, setDisplaySrc] = useState<string | undefined>(() => {
-    if (!rawSrc) {
+    if (!rawSrc || runtimeContext === null) {
       return undefined
     }
     if (isExternalUrl(rawSrc)) {
@@ -207,7 +108,7 @@ export function useLocalImageSrc(
   })
 
   useEffect(() => {
-    if (!rawSrc) {
+    if (!rawSrc || runtimeContext === null) {
       setDisplaySrc(undefined)
       return
     }
@@ -236,7 +137,7 @@ export function useLocalImageSrc(
         if (cancelled) {
           return
         }
-        setDisplaySrc(cacheGeneration === effectGeneration && url ? url : undefined)
+        setDisplaySrc(getLocalImageCacheGeneration() === effectGeneration && url ? url : undefined)
       })
       .catch(() => {
         if (!cancelled) {
@@ -261,15 +162,15 @@ export async function loadLocalImageSrc(
   rawSrc: string,
   filePath: string,
   connectionId?: string | null,
-  runtimeContext?: Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null }
+  runtimeContext?:
+    | (Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null })
+    | null
 ): Promise<string | null> {
-  if (
-    rawSrc.startsWith('http://') ||
-    rawSrc.startsWith('https://') ||
-    rawSrc.startsWith('data:') ||
-    rawSrc.startsWith('blob:')
-  ) {
+  if (isExternalUrl(rawSrc)) {
     return rawSrc
+  }
+  if (runtimeContext === null) {
+    return null
   }
 
   const absolutePath = resolveImageAbsolutePath(rawSrc, filePath)
@@ -289,8 +190,13 @@ export async function loadLocalImageSrc(
 export function loadLocalImageAbsolutePath(
   absolutePath: string,
   connectionId?: string | null,
-  runtimeContext?: Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null }
+  runtimeContext?:
+    | (Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null })
+    | null
 ): Promise<string | null> {
+  if (runtimeContext === null) {
+    return Promise.resolve(null)
+  }
   const cacheKey = getLocalImageCacheKey(absolutePath, connectionId, runtimeContext)
   const cached = blobUrlCache.get(cacheKey)
   if (cached) {
@@ -302,73 +208,59 @@ export function loadLocalImageAbsolutePath(
     return inFlight
   }
 
-  const readGeneration = cacheGeneration
-  const loadPromise = readImagePreview(absolutePath, connectionId, runtimeContext)
+  const readGeneration = getLocalImageCacheGeneration()
+  const readLeaseVersion = getLocalImageCacheKeyVersion(cacheKey)
+  const loadPromise = readLocalImagePreview(absolutePath, connectionId, runtimeContext)
     .then((result) => {
-      if (!result.isBinary || !result.content || cacheGeneration !== readGeneration) {
-        // Why: local image paths must stay behind IPC/runtime authorization;
-        // handing raw file: or relative paths back to Chromium can escape it.
+      if (
+        !result.isBinary ||
+        !result.content ||
+        getLocalImageCacheGeneration() !== readGeneration
+      ) {
         return null
       }
-      const url = base64ToBlobUrl(result.content, result.mimeType ?? 'image/png')
-      if (cacheGeneration !== readGeneration) {
+      const { url, byteLength } = base64ToBlobUrl(result.content, result.mimeType ?? 'image/png')
+      if (getLocalImageCacheGeneration() !== readGeneration) {
         URL.revokeObjectURL(url)
         return null
       }
-      cacheBlobUrl(cacheKey, url)
-      return url
+      return cacheLocalImageBlob(cacheKey, url, byteLength, readLeaseVersion) ? url : null
     })
     .catch(() => null)
     .finally(() => {
       if (inFlightBlobUrlLoads.get(cacheKey) === loadPromise) {
         inFlightBlobUrlLoads.delete(cacheKey)
       }
+      cleanupLocalImageCacheKeyVersion(cacheKey)
     })
   inFlightBlobUrlLoads.set(cacheKey, loadPromise)
   return loadPromise
 }
 
 export function resetLocalImageSrcStateForTests(): void {
-  if (pendingBlobUrlRevocationTimer !== null) {
-    clearTimeout(pendingBlobUrlRevocationTimer)
-    pendingBlobUrlRevocationTimer = null
-  }
-  revokePendingBlobUrls()
-  for (const url of blobUrlCache.values()) {
-    URL.revokeObjectURL(url)
-  }
-  blobUrlCache.clear()
-  clearLocalImageCachePins()
-  inFlightBlobUrlLoads.clear()
-  cacheGeneration = 0
-  pendingBlobUrlRevocations.clear()
-  cacheListeners.clear()
+  resetLocalImageCacheState()
 }
 
 export function invalidateLocalImageSrcCacheForTests(): void {
-  invalidateImageCache()
+  invalidateLocalImageCache()
 }
 
-function readImagePreview(
-  absolutePath: string,
+/** Evict one no-longer-visible transcript preview immediately. */
+export function releaseLocalImageSrc(
+  rawSrc: string,
+  filePath: string,
   connectionId?: string | null,
-  runtimeContext?: Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null }
-) {
-  try {
-    if (!runtimeContext) {
-      return window.api.fs.readFile({
-        filePath: absolutePath,
-        connectionId: connectionId ?? undefined
-      })
-    }
-    return readRuntimeFilePreview(
-      {
-        ...runtimeContext,
-        connectionId: runtimeContext.connectionId ?? connectionId ?? undefined
-      },
-      absolutePath
-    )
-  } catch (error) {
-    return Promise.reject(error)
+  runtimeContext?:
+    | (Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null })
+    | null
+): void {
+  if (!rawSrc || isExternalUrl(rawSrc) || runtimeContext === null) {
+    return
   }
+  const absolutePath = resolveImageAbsolutePath(rawSrc, filePath)
+  if (!absolutePath) {
+    return
+  }
+  const key = getLocalImageCacheKey(absolutePath, connectionId, runtimeContext)
+  releaseLocalImageBlob(key)
 }

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -16,33 +16,15 @@ import { shouldShowNativeChatTypingIndicator } from './native-chat-typing-indica
 import { NativeChatWorkingStatus } from './NativeChatWorkingStatus'
 import { useNativeChatTurnStatus } from './use-native-chat-turn-status'
 import { nativeChatProseToMarkdown } from './native-chat-prose'
+import { NativeChatTypingIndicatorRow } from './NativeChatTypingIndicatorRow'
 import {
   NativeChatAgentControls,
   NativeChatImageAttachments,
   ProviderFrameRow
 } from './NativeChatTranscriptChrome'
+import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
 
 export { ProviderFrameRow } from './NativeChatTranscriptChrome'
-
-function TypingIndicatorRow(): React.JSX.Element {
-  return (
-    <div
-      className="flex items-center justify-start"
-      aria-label={translate('components.native-chat.status.responding', 'Agent is responding')}
-      aria-live="polite"
-    >
-      <div className="flex h-8 items-center gap-1.5 text-muted-foreground">
-        {[0, 1, 2].map((i) => (
-          <span
-            key={i}
-            className="size-1.5 animate-bounce rounded-full bg-muted-foreground/70"
-            style={{ animationDelay: `${i * 160}ms` }}
-          />
-        ))}
-      </div>
-    </div>
-  )
-}
 
 function geometryOf(el: HTMLElement): ScrollGeometry {
   return { scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight }
@@ -62,7 +44,8 @@ function MessageRow({
   allowFileUriLinks = false,
   deliveryFailed = false,
   activityExpandOverride,
-  structuredActivityUi = true
+  structuredActivityUi = true,
+  runtimeContext
 }: {
   message: NativeChatMessage
   expandSignal: boolean
@@ -74,6 +57,7 @@ function MessageRow({
   deliveryFailed?: boolean
   activityExpandOverride?: boolean
   structuredActivityUi?: boolean
+  runtimeContext?: RuntimeFileOperationArgs | null
 }): React.JSX.Element | null {
   const rowRef = useRef<HTMLDivElement | null>(null)
   const { prose, tools } = useMemo(() => splitNativeChatBlocks(message.blocks), [message.blocks])
@@ -113,7 +97,11 @@ function MessageRow({
         <div className="max-w-[85%] rounded-lg rounded-tr-sm bg-muted px-3.5 py-2.5 text-sm text-foreground">
           {markdown ? (
             <>
-              <NativeChatImageAttachments blocks={prose} />
+              <NativeChatImageAttachments
+                blocks={prose}
+                runtimeContext={runtimeContext}
+                enablePreview={runtimeContext !== undefined}
+              />
               <CommentMarkdown
                 content={markdown}
                 variant="document"
@@ -123,7 +111,11 @@ function MessageRow({
               />
             </>
           ) : (
-            <NativeChatImageAttachments blocks={prose} />
+            <NativeChatImageAttachments
+              blocks={prose}
+              runtimeContext={runtimeContext}
+              enablePreview={runtimeContext !== undefined}
+            />
           )}
         </div>
         {deliveryFailed ? (
@@ -152,7 +144,11 @@ function MessageRow({
         isSystem && 'text-xs text-muted-foreground'
       )}
     >
-      <NativeChatImageAttachments blocks={prose} />
+      <NativeChatImageAttachments
+        blocks={prose}
+        runtimeContext={runtimeContext}
+        enablePreview={runtimeContext !== undefined}
+      />
       {markdown ? (
         <CommentMarkdown
           content={markdown}
@@ -191,7 +187,8 @@ export function NativeChatMessageList({
   allowFileUriLinks = false,
   workingStartedAt,
   failedDeliveryMessageIds,
-  showTurnStatus = true
+  showTurnStatus = true,
+  runtimeContext
 }: {
   session: NativeChatLiveSession
   isWorking: boolean
@@ -205,6 +202,7 @@ export function NativeChatMessageList({
   failedDeliveryMessageIds?: ReadonlySet<string>
   /** Turn timing/disclosure is available only on the structured Codex lane. */
   showTurnStatus?: boolean
+  runtimeContext?: RuntimeFileOperationArgs | null
 }): React.JSX.Element {
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
@@ -231,7 +229,6 @@ export function NativeChatMessageList({
 
   const stuckToBottomRef = useRef(stuckToBottom)
   stuckToBottomRef.current = stuckToBottom
-
   const { hasMore, loadingEarlier, loadEarlier } = session
 
   // Keep hidden harness turns as fold boundaries, then strip them before render.
@@ -401,6 +398,7 @@ export function NativeChatMessageList({
                   deliveryFailed={failedDeliveryMessageIds?.has(message.id) === true}
                   structuredActivityUi={showTurnStatus}
                   activityExpandOverride={turnKey ? expandedTurnIds.has(turnKey) : undefined}
+                  runtimeContext={runtimeContext}
                 />
                 {showTurnStatus &&
                 status &&
@@ -430,7 +428,7 @@ export function NativeChatMessageList({
               workedSeconds={turnStatuses.active.workedSeconds}
             />
           ) : null}
-          {!showTurnStatus && showTypingIndicator ? <TypingIndicatorRow /> : null}
+          {!showTurnStatus && showTypingIndicator ? <NativeChatTypingIndicatorRow /> : null}
         </div>
       </div>
       {showJump ? (

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -22,6 +22,7 @@ import { useStructuredAgentSession } from './use-structured-agent-session'
 import { translate } from '@/i18n/i18n'
 import { NativeChatOrchestrationPausedNotice } from './NativeChatOrchestrationPausedNotice'
 import { useNativeChatPasteBridge } from './use-native-chat-paste-bridge'
+import { useNativeChatImageRuntimeContext } from './native-chat-image-runtime-context'
 
 function encodeQuestionAnswer(questionId: string, answer: string): string {
   return `${encodeURIComponent(questionId)}:${encodeURIComponent(answer)}`
@@ -80,6 +81,7 @@ export function NativeChatStructuredSession(props: {
   const viewState = selectNativeChatViewState(session)
   const fontScale = useNativeChatFontScale(viewState.kind === 'ready')
   const fileLinkContext = useNativeChatFileLinkContext(props.tabId)
+  const imageRuntimeContext = useNativeChatImageRuntimeContext(props.tabId)
   const fileLinkClick = useNativeChatFileLinkClick(props.allowFileUriLinks ? fileLinkContext : null)
   const prompt = controller.prompts[0] ?? null
   const questionBody = prompt?.body.kind === 'question' ? prompt.body : null
@@ -145,6 +147,7 @@ export function NativeChatStructuredSession(props: {
             showTurnStatus={props.agent === 'codex'}
             onLinkClick={fileLinkClick}
             allowFileUriLinks={fileLinkClick !== undefined}
+            runtimeContext={imageRuntimeContext}
           />
         )}
       </div>

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -147,7 +147,7 @@ export function NativeChatStructuredSession(props: {
             showTurnStatus={props.agent === 'codex'}
             onLinkClick={fileLinkClick}
             allowFileUriLinks={fileLinkClick !== undefined}
-            runtimeContext={imageRuntimeContext}
+            runtimeContext={props.agent === 'codex' ? imageRuntimeContext : undefined}
           />
         )}
       </div>

--- a/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.test.tsx
@@ -4,7 +4,10 @@ import { act, createElement } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
-import { resetLocalImageSrcStateForTests } from '@/components/editor/useLocalImageSrc'
+import {
+  invalidateLocalImageSrcCacheForTests,
+  resetLocalImageSrcStateForTests
+} from '@/components/editor/useLocalImageSrc'
 import { NativeChatImageAttachments } from './NativeChatTranscriptChrome'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
@@ -130,6 +133,34 @@ describe('NativeChatImageAttachments', () => {
     expect(container.querySelector('img')?.getAttribute('src')).not.toBe(firstOwnerSrc)
     expect(window.api.fs.readFile).toHaveBeenCalledTimes(2)
 
+    root.unmount()
+  })
+
+  it('retries a failed thumbnail after the image cache refreshes', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const props = {
+      blocks: [{ type: 'image-ref' as const, path: '/repo/image.png' }],
+      runtimeContext: runtimeContext('wt-1')
+    }
+
+    await act(async () => {
+      root.render(createElement(NativeChatImageAttachments, props))
+      await flushPromises()
+    })
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('blob:owner-1')
+
+    await act(async () => {
+      container.querySelector('img')?.dispatchEvent(new Event('error'))
+    })
+    expect(container.querySelector('img')).toBeNull()
+
+    await act(async () => {
+      invalidateLocalImageSrcCacheForTests()
+      await flushPromises()
+    })
+
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('blob:owner-2')
     root.unmount()
   })
 

--- a/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.test.tsx
@@ -132,4 +132,47 @@ describe('NativeChatImageAttachments', () => {
 
     root.unmount()
   })
+
+  it('keeps the observed element stable while a preview is materialized', async () => {
+    let callback: IntersectionObserverCallback | undefined
+    class FakeIntersectionObserver {
+      readonly observe = vi.fn()
+      readonly unobserve = vi.fn()
+      readonly disconnect = vi.fn()
+
+      constructor(nextCallback: IntersectionObserverCallback) {
+        callback = nextCallback
+      }
+    }
+    vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver)
+
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    await act(async () => {
+      root.render(
+        createElement(NativeChatImageAttachments, {
+          blocks: [{ type: 'image-ref' as const, path: '/repo/image.png' }],
+          runtimeContext: runtimeContext('wt-1')
+        })
+      )
+      await flushPromises()
+    })
+
+    const observedElement = container.firstElementChild
+    expect(observedElement).not.toBeNull()
+    if (!observedElement || !callback) {
+      throw new Error('image preview did not register visibility observation')
+    }
+    const notifyVisibility = callback
+    await act(async () => {
+      notifyVisibility(
+        [{ target: observedElement, isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+      await flushPromises()
+    })
+
+    expect(container.firstElementChild).toBe(observedElement)
+    root.unmount()
+  })
 })

--- a/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
+import { resetLocalImageSrcStateForTests } from '@/components/editor/useLocalImageSrc'
+import { NativeChatImageAttachments } from './NativeChatTranscriptChrome'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+function runtimeContext(worktreeId: string): RuntimeFileOperationArgs {
+  return {
+    settings: { activeRuntimeEnvironmentId: null },
+    worktreeId,
+    worktreePath: `/repo/${worktreeId}`,
+    expectedExecutionHostId: 'local'
+  }
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+beforeEach(() => {
+  resetLocalImageSrcStateForTests()
+  vi.stubGlobal('IntersectionObserver', undefined)
+  let urlSequence = 0
+  vi.spyOn(URL, 'createObjectURL').mockImplementation(() => `blob:owner-${++urlSequence}`)
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+  window.api = {
+    fs: {
+      readFile: vi.fn().mockResolvedValue({
+        content: 'AA==',
+        isBinary: true,
+        mimeType: 'image/png'
+      })
+    }
+  } as unknown as Window['api']
+})
+
+afterEach(() => {
+  resetLocalImageSrcStateForTests()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('NativeChatImageAttachments', () => {
+  it('pools visibility observation across image refs', async () => {
+    class FakeIntersectionObserver {
+      static instances: FakeIntersectionObserver[] = []
+      readonly observe = vi.fn()
+      readonly unobserve = vi.fn()
+      readonly disconnect = vi.fn()
+
+      constructor(_callback: IntersectionObserverCallback) {
+        FakeIntersectionObserver.instances.push(this)
+      }
+    }
+    vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver)
+
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    await act(async () => {
+      root.render(
+        createElement(NativeChatImageAttachments, {
+          blocks: [
+            { type: 'image-ref' as const, path: '/repo/one.png' },
+            { type: 'image-ref' as const, path: '/repo/two.png' },
+            { type: 'image-ref' as const, path: '/repo/three.png' }
+          ],
+          runtimeContext: runtimeContext('wt-1')
+        })
+      )
+      await flushPromises()
+    })
+
+    expect(FakeIntersectionObserver.instances).toHaveLength(1)
+    expect(FakeIntersectionObserver.instances[0]?.observe).toHaveBeenCalledTimes(3)
+
+    root.unmount()
+    expect(FakeIntersectionObserver.instances[0]?.unobserve).toHaveBeenCalledTimes(3)
+    expect(FakeIntersectionObserver.instances[0]?.disconnect).toHaveBeenCalledOnce()
+  })
+
+  it('preserves same-image errors but retries when the runtime owner changes', async () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const blocks = [{ type: 'image-ref' as const, path: '/repo/image.png' }]
+    const ownerOne = runtimeContext('wt-1')
+
+    await act(async () => {
+      root.render(
+        createElement(NativeChatImageAttachments, {
+          blocks,
+          runtimeContext: ownerOne
+        })
+      )
+      await flushPromises()
+    })
+    const firstOwnerSrc = container.querySelector('img')?.getAttribute('src')
+    expect(firstOwnerSrc).toBe('blob:owner-1')
+
+    await act(async () => {
+      container.querySelector('img')?.dispatchEvent(new Event('error'))
+    })
+    expect(container.querySelector('img')).toBeNull()
+
+    await act(async () => {
+      root.render(
+        createElement(NativeChatImageAttachments, {
+          blocks,
+          runtimeContext: ownerOne
+        })
+      )
+      await flushPromises()
+    })
+    expect(container.querySelector('img')).toBeNull()
+
+    await act(async () => {
+      root.render(
+        createElement(NativeChatImageAttachments, {
+          blocks,
+          runtimeContext: runtimeContext('wt-2')
+        })
+      )
+      await flushPromises()
+    })
+    expect(container.querySelector('img')?.getAttribute('src')).not.toBe(firstOwnerSrc)
+    expect(window.api.fs.readFile).toHaveBeenCalledTimes(2)
+
+    root.unmount()
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.tsx
@@ -78,8 +78,8 @@ function TranscriptImagePreview({
 }): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [near, setNear] = useState(false)
-  const [thumbnailError, setThumbnailError] = useState(false)
-  const [dialogError, setDialogError] = useState(false)
+  const [thumbnailErrorSrc, setThumbnailErrorSrc] = useState<string | null>(null)
+  const [dialogErrorSrc, setDialogErrorSrc] = useState<string | null>(null)
   const ref = useRef<HTMLDivElement>(null)
   const source = block.url?.trim() || block.path
   const filePath = block.path ?? source ?? ''
@@ -131,7 +131,7 @@ function TranscriptImagePreview({
   const showPreview =
     leaseActive &&
     Boolean(displaySrc) &&
-    !thumbnailError &&
+    displaySrc !== thumbnailErrorSrc &&
     Boolean(source) &&
     (external || runtimeContext !== null)
 
@@ -151,7 +151,7 @@ function TranscriptImagePreview({
           src={displaySrc}
           alt={label}
           loading="lazy"
-          onError={() => setThumbnailError(true)}
+          onError={() => setThumbnailErrorSrc(displaySrc ?? null)}
           className="size-full object-cover"
         />
       </button>
@@ -162,11 +162,11 @@ function TranscriptImagePreview({
             {translate('components.native-chat.composer.imagePreview', 'Full-size image preview')}
           </DialogDescription>
           <div className="scrollbar-sleek flex min-h-0 items-center justify-center overflow-auto rounded-md bg-muted/20 p-2">
-            {displaySrc && !dialogError ? (
+            {displaySrc && displaySrc !== dialogErrorSrc ? (
               <img
                 src={displaySrc}
                 alt={label}
-                onError={() => setDialogError(true)}
+                onError={() => setDialogErrorSrc(displaySrc)}
                 className="max-h-[75vh] max-w-full object-contain"
               />
             ) : (

--- a/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.tsx
@@ -194,11 +194,15 @@ export function NativeChatImageAttachments({
   if (images.length === 0) {
     return null
   }
+  const imageKeyCounts = new Map<string, number>()
   if (!enablePreview) {
     return (
       <div className="mb-2 flex flex-wrap gap-1.5">
-        {images.map((image, index) => {
+        {images.map((image) => {
           const label = image.alt ?? image.path ?? image.url ?? 'Image'
+          const imageKeyBase = `${label}-${image.url ?? ''}-${image.path ?? ''}`
+          const occurrence = imageKeyCounts.get(imageKeyBase) ?? 0
+          imageKeyCounts.set(imageKeyBase, occurrence + 1)
           const name =
             image.path && isNativeChatPastedImagePath(image.path)
               ? translate('components.native-chat.composer.pastedImageLabel', 'Pasted image')
@@ -207,7 +211,7 @@ export function NativeChatImageAttachments({
                 : label
           return (
             <div
-              key={`${label}-${image.url ?? ''}-${image.path ?? ''}-${index}`}
+              key={`${imageKeyBase}-${occurrence}`}
               className="flex max-w-full items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs text-muted-foreground"
               title={label}
             >
@@ -219,7 +223,6 @@ export function NativeChatImageAttachments({
       </div>
     )
   }
-  const imageKeyCounts = new Map<string, number>()
   return (
     <div className="mb-2 flex flex-wrap gap-1.5">
       {images.map((image) => {

--- a/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.tsx
@@ -128,34 +128,33 @@ function TranscriptImagePreview({
     return () => releaseLocalImageSrc(source, filePath, context.connectionId, context)
   }, [external, filePath, leaseActive, runtimeContext, source])
 
-  if (
-    !leaseActive ||
-    !displaySrc ||
-    thumbnailError ||
-    !source ||
-    (!external && runtimeContext === null)
-  ) {
+  const showPreview =
+    leaseActive &&
+    Boolean(displaySrc) &&
+    !thumbnailError &&
+    Boolean(source) &&
+    (external || runtimeContext !== null)
+
+  if (!showPreview) {
     return <div ref={ref}>{fallback}</div>
   }
   return (
-    <>
-      <div ref={ref} className="relative size-20 shrink-0">
-        <button
-          type="button"
-          aria-label={`${viewImageLabel}: ${label}`}
-          title={label}
-          onClick={() => setOpen(true)}
-          className="flex size-full items-center justify-center overflow-hidden rounded-md border border-border bg-background transition-colors hover:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          <img
-            src={displaySrc}
-            alt={label}
-            loading="lazy"
-            onError={() => setThumbnailError(true)}
-            className="size-full object-cover"
-          />
-        </button>
-      </div>
+    <div ref={ref} className="relative size-20 shrink-0">
+      <button
+        type="button"
+        aria-label={`${viewImageLabel}: ${label}`}
+        title={label}
+        onClick={() => setOpen(true)}
+        className="flex size-full items-center justify-center overflow-hidden rounded-md border border-border bg-background transition-colors hover:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <img
+          src={displaySrc}
+          alt={label}
+          loading="lazy"
+          onError={() => setThumbnailError(true)}
+          className="size-full object-cover"
+        />
+      </button>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="flex max-h-[90vh] max-w-[90vw] flex-col gap-3 border-border bg-background p-3 sm:max-w-4xl">
           <DialogTitle className="truncate text-sm">{label}</DialogTitle>
@@ -176,7 +175,7 @@ function TranscriptImagePreview({
           </div>
         </DialogContent>
       </Dialog>
-    </>
+    </div>
   )
 }
 

--- a/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.tsx
@@ -1,40 +1,239 @@
+import { useEffect, useRef, useState } from 'react'
 import { ArrowUp, Image as ImageIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { basename } from '@/lib/path'
 import type { NativeChatBlock } from '../../../../shared/native-chat-types'
-import { isNativeChatPastedImagePath } from './native-chat-image-paste'
 import { NativeChatCopyButton } from './NativeChatCopyButton'
 import { nativeChatProviderFrameSummary } from '../../../../shared/native-chat-provider-frame-summary'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
+import {
+  getLocalImageCacheKey,
+  useLocalImageSrc,
+  releaseLocalImageSrc
+} from '@/components/editor/useLocalImageSrc'
+import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
+import { isNativeChatPastedImagePath } from './native-chat-image-paste'
+
+type VisibilityListener = (isVisible: boolean) => void
+
+const visibilityListeners = new Map<Element, VisibilityListener>()
+let visibilityObserver: IntersectionObserver | null = null
+
+function observeTranscriptVisibility(element: Element, listener: VisibilityListener): () => void {
+  if (typeof IntersectionObserver === 'undefined') {
+    listener(true)
+    return () => {}
+  }
+
+  visibilityObserver ??= new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        visibilityListeners.get(entry.target)?.(entry.isIntersecting)
+      }
+    },
+    { rootMargin: '128px' }
+  )
+  visibilityListeners.set(element, listener)
+  visibilityObserver.observe(element)
+
+  return () => {
+    visibilityListeners.delete(element)
+    visibilityObserver?.unobserve(element)
+    if (visibilityListeners.size === 0) {
+      visibilityObserver?.disconnect()
+      visibilityObserver = null
+    }
+  }
+}
+
+function renderableImageSource(source: string | undefined): boolean {
+  return Boolean(source && /^(?:https?|data|blob):/i.test(source))
+}
+
+function transcriptImageIdentity(
+  block: Extract<NativeChatBlock, { type: 'image-ref' }>,
+  runtimeContext: RuntimeFileOperationArgs | null | undefined
+): string {
+  const source = block.url?.trim() || block.path
+  const filePath = block.path ?? source ?? ''
+  if (renderableImageSource(source)) {
+    return `external\0${source ?? ''}`
+  }
+  return `${source ?? ''}\0${filePath}\0${
+    runtimeContext === null
+      ? 'unresolved'
+      : runtimeContext === undefined
+        ? 'pending'
+        : getLocalImageCacheKey(source ?? '', runtimeContext.connectionId, runtimeContext)
+  }`
+}
+
+function TranscriptImagePreview({
+  block,
+  runtimeContext
+}: {
+  block: Extract<NativeChatBlock, { type: 'image-ref' }>
+  runtimeContext: RuntimeFileOperationArgs | null | undefined
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [near, setNear] = useState(false)
+  const [thumbnailError, setThumbnailError] = useState(false)
+  const [dialogError, setDialogError] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const source = block.url?.trim() || block.path
+  const filePath = block.path ?? source ?? ''
+  const external = renderableImageSource(source)
+  const leaseActive = near || open
+  const localSrc = useLocalImageSrc(
+    leaseActive && !external && runtimeContext !== undefined ? source : undefined,
+    filePath,
+    runtimeContext?.connectionId,
+    runtimeContext
+  )
+  const displaySrc = external && leaseActive ? source : localSrc
+  const label =
+    block.alt?.trim() ||
+    (block.path && isNativeChatPastedImagePath(block.path)
+      ? translate('components.native-chat.composer.pastedImageLabel', 'Pasted image')
+      : block.path
+        ? basename(block.path)
+        : 'Image')
+  const viewImageLabel = translate('components.native-chat.composer.viewAttachment', 'View image')
+  const fallback = (
+    <div
+      className="flex max-w-full items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs text-muted-foreground"
+      title={label}
+    >
+      <ImageIcon className="size-3.5 shrink-0" />
+      <span className="truncate">{label}</span>
+    </div>
+  )
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) {
+      return
+    }
+    return observeTranscriptVisibility(element, setNear)
+  }, [])
+  useEffect(() => {
+    const context = runtimeContext
+    if (!source || external || context === undefined || context === null) {
+      return
+    }
+    if (!leaseActive) {
+      releaseLocalImageSrc(source, filePath, context.connectionId, context)
+    }
+    return () => releaseLocalImageSrc(source, filePath, context.connectionId, context)
+  }, [external, filePath, leaseActive, runtimeContext, source])
+
+  if (
+    !leaseActive ||
+    !displaySrc ||
+    thumbnailError ||
+    !source ||
+    (!external && runtimeContext === null)
+  ) {
+    return <div ref={ref}>{fallback}</div>
+  }
+  return (
+    <>
+      <div ref={ref} className="relative size-20 shrink-0">
+        <button
+          type="button"
+          aria-label={`${viewImageLabel}: ${label}`}
+          title={label}
+          onClick={() => setOpen(true)}
+          className="flex size-full items-center justify-center overflow-hidden rounded-md border border-border bg-background transition-colors hover:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <img
+            src={displaySrc}
+            alt={label}
+            loading="lazy"
+            onError={() => setThumbnailError(true)}
+            className="size-full object-cover"
+          />
+        </button>
+      </div>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="flex max-h-[90vh] max-w-[90vw] flex-col gap-3 border-border bg-background p-3 sm:max-w-4xl">
+          <DialogTitle className="truncate text-sm">{label}</DialogTitle>
+          <DialogDescription className="sr-only">
+            {translate('components.native-chat.composer.imagePreview', 'Full-size image preview')}
+          </DialogDescription>
+          <div className="scrollbar-sleek flex min-h-0 items-center justify-center overflow-auto rounded-md bg-muted/20 p-2">
+            {displaySrc && !dialogError ? (
+              <img
+                src={displaySrc}
+                alt={label}
+                onError={() => setDialogError(true)}
+                className="max-h-[75vh] max-w-full object-contain"
+              />
+            ) : (
+              fallback
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
 
 export function NativeChatImageAttachments({
-  blocks
+  blocks,
+  runtimeContext,
+  enablePreview = runtimeContext !== undefined
 }: {
   blocks: NativeChatBlock[]
+  runtimeContext?: RuntimeFileOperationArgs | null
+  /** Keep legacy terminal chips unchanged until that lane opts into previews. */
+  enablePreview?: boolean
 }): React.JSX.Element | null {
   const images = blocks.filter((block) => block.type === 'image-ref')
   if (images.length === 0) {
     return null
   }
+  if (!enablePreview) {
+    return (
+      <div className="mb-2 flex flex-wrap gap-1.5">
+        {images.map((image, index) => {
+          const label = image.alt ?? image.path ?? image.url ?? 'Image'
+          const name =
+            image.path && isNativeChatPastedImagePath(image.path)
+              ? translate('components.native-chat.composer.pastedImageLabel', 'Pasted image')
+              : image.path
+                ? basename(image.path)
+                : label
+          return (
+            <div
+              key={`${label}-${image.url ?? ''}-${image.path ?? ''}-${index}`}
+              className="flex max-w-full items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs text-muted-foreground"
+              title={label}
+            >
+              <ImageIcon className="size-3.5 shrink-0" />
+              <span className="truncate">{name}</span>
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+  const imageKeyCounts = new Map<string, number>()
   return (
     <div className="mb-2 flex flex-wrap gap-1.5">
-      {images.map((image, index) => {
+      {images.map((image) => {
         const label = image.alt ?? image.path ?? image.url ?? 'Image'
-        const name =
-          image.path && isNativeChatPastedImagePath(image.path)
-            ? translate('components.native-chat.composer.pastedImageLabel', 'Pasted image')
-            : image.path
-              ? basename(image.path)
-              : label
+        const imageKeyBase = `${label}-${image.url ?? ''}-${image.path ?? ''}`
+        const occurrence = imageKeyCounts.get(imageKeyBase) ?? 0
+        imageKeyCounts.set(imageKeyBase, occurrence + 1)
+        const identity = transcriptImageIdentity(image, runtimeContext)
         return (
-          <div
-            key={`${label}-${index}`}
-            className="flex max-w-full items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs text-muted-foreground"
-            title={label}
-          >
-            <ImageIcon className="size-3.5 shrink-0" />
-            <span className="truncate">{name}</span>
-          </div>
+          <TranscriptImagePreview
+            key={`${imageKeyBase}-${identity}-${occurrence}`}
+            block={image}
+            runtimeContext={runtimeContext}
+          />
         )
       })}
     </div>

--- a/src/renderer/src/components/native-chat/NativeChatTypingIndicatorRow.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTypingIndicatorRow.tsx
@@ -1,0 +1,21 @@
+import { translate } from '@/i18n/i18n'
+
+export function NativeChatTypingIndicatorRow(): React.JSX.Element {
+  return (
+    <div
+      className="flex items-center justify-start"
+      aria-label={translate('components.native-chat.status.responding', 'Agent is responding')}
+      aria-live="polite"
+    >
+      <div className="flex h-8 items-center gap-1.5 text-muted-foreground">
+        {[0, 1, 2].map((i) => (
+          <span
+            key={i}
+            className="size-1.5 animate-bounce rounded-full bg-muted-foreground/70"
+            style={{ animationDelay: `${i * 160}ms` }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/native-chat/native-chat-file-link.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-file-link.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { Tab } from '../../../../shared/tab-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { AppState } from '@/store/types'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 import {
   resolveNativeChatFileLink,
   resolveNativeChatFileLinkContext,
@@ -108,6 +109,27 @@ describe('resolveNativeChatFileLinkContext', () => {
     ).toEqual({
       worktreeId: 'wt-1',
       worktreePath: '/repo/fallback',
+      runtimeEnvironmentId: null
+    })
+  })
+
+  it('resolves a folder workspace tab from its folder path when no projected worktree path exists', () => {
+    const folderId = 'folder-1'
+    const folderKey = folderWorkspaceKey(folderId)
+    const folderTab = terminalTab({ worktreeId: folderKey })
+    expect(
+      resolveNativeChatFileLinkContext(
+        state({
+          tabsByWorktree: { [folderKey]: [folderTab] },
+          getKnownWorktreeById: () => undefined,
+          folderWorkspaces: [{ id: folderId, folderPath: '/workspace/platform' } as never],
+          worktreesByRepo: {}
+        }),
+        folderTab.id
+      )
+    ).toEqual({
+      worktreeId: folderKey,
+      worktreePath: '/workspace/platform',
       runtimeEnvironmentId: null
     })
   })

--- a/src/renderer/src/components/native-chat/native-chat-file-link.ts
+++ b/src/renderer/src/components/native-chat/native-chat-file-link.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/explicit-file-link-target'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import type { AppState } from '@/store/types'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 
 export type NativeChatFileLinkContext = {
   worktreeId: string
@@ -86,13 +87,21 @@ export function resolveNativeChatFileLinkContext(
   const worktree = knownWorktree?.path
     ? knownWorktree
     : findWorktreeFallback(state.worktreesByRepo, worktreeId)
-  if (!worktree?.path) {
+  const workspaceScope = parseWorkspaceKey(worktreeId)
+  const worktreePath =
+    worktree?.path ??
+    (workspaceScope?.type === 'folder'
+      ? (state.folderWorkspaces.find(
+          (workspace) => workspace.id === workspaceScope.folderWorkspaceId
+        )?.folderPath ?? null)
+      : null)
+  if (!worktreePath) {
     return null
   }
 
   return {
     worktreeId,
-    worktreePath: worktree.path,
+    worktreePath,
     runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(state, worktreeId)
   }
 }

--- a/src/renderer/src/components/native-chat/native-chat-image-runtime-context.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-runtime-context.test.ts
@@ -66,4 +66,31 @@ describe('resolveNativeChatImageRuntimeContext', () => {
     expect(second?.settings).toBe(first?.settings)
     expect(shallow(second, first)).toBe(true)
   })
+
+  it('derives a runtime host from an owner-only route during paired hydration', () => {
+    const storeState = state()
+    const ownerOnlyWorktree = {
+      id: 'wt-1',
+      repoId: 'repo',
+      path: '/repo/worktree',
+      runtimeOwnerEnvironmentId: 'owner-a'
+    }
+    const ownerState = {
+      ...storeState,
+      activeWorktreeId: null,
+      activeWorkspaceExecutionHostId: null,
+      getKnownWorktreeById: () => ownerOnlyWorktree,
+      worktreesByRepo: { repo: [ownerOnlyWorktree] },
+      runtimeEnvironments: [{ id: 'owner-a' }]
+    } as unknown as AppState
+
+    const context = resolveNativeChatImageRuntimeContext(ownerState, 'tab-1')
+
+    expect(context).toMatchObject({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo/worktree',
+      expectedExecutionHostId: 'local',
+      settings: { activeRuntimeEnvironmentId: 'owner-a' }
+    })
+  })
 })

--- a/src/renderer/src/components/native-chat/native-chat-image-runtime-context.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-runtime-context.test.ts
@@ -57,13 +57,12 @@ describe('resolveNativeChatImageRuntimeContext', () => {
     expect(shallow(second, first)).toBe(true)
   })
 
-  it('keeps shallow selector identity stable when owner inputs are unchanged', () => {
+  it('reuses derived settings when owner inputs are unchanged', () => {
     const storeState = state()
     const first = resolveNativeChatImageRuntimeContext(storeState, 'tab-1')
     const second = resolveNativeChatImageRuntimeContext(storeState, 'tab-1')
 
     expect(first).not.toBeNull()
-    expect(second).not.toBe(first)
     expect(second?.settings).toBe(first?.settings)
     expect(shallow(second, first)).toBe(true)
   })

--- a/src/renderer/src/components/native-chat/native-chat-image-runtime-context.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-runtime-context.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { shallow } from 'zustand/shallow'
+import type { AppState } from '@/store/types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import {
+  resolveNativeChatImageRuntimeContext,
+  selectNativeChatImageOwnerState
+} from './native-chat-image-runtime-context'
+
+function state(): AppState {
+  const tab: TerminalTab = {
+    id: 'tab-1',
+    ptyId: null,
+    worktreeId: 'wt-1',
+    title: 'Terminal 1',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+  const worktree = {
+    id: 'wt-1',
+    repoId: 'repo',
+    path: '/repo/worktree',
+    hostId: 'local'
+  }
+  return {
+    activeWorkspaceExecutionHostId: 'local',
+    activeWorktreeId: 'wt-1',
+    detectedWorktreesByRepo: {},
+    folderWorkspaces: [],
+    getKnownWorktreeById: () => worktree,
+    projectGroups: [],
+    removedRuntimeEnvironmentIds: new Set(),
+    repos: [{ id: 'repo', path: '/repo' }],
+    restoredRuntimeHostIdByWorkspaceSessionKey: {},
+    runtimeEnvironmentCatalogHydrated: true,
+    runtimeEnvironments: [],
+    settings: { activeRuntimeEnvironmentId: null },
+    sshConnectionStates: {},
+    sshStateByEnvironment: {},
+    tabsByWorktree: { 'wt-1': [tab] },
+    unifiedTabsByWorktree: {},
+    worktreesByRepo: { repo: [worktree] }
+  } as unknown as AppState
+}
+
+describe('resolveNativeChatImageRuntimeContext', () => {
+  it('keeps unrelated store writes out of the image-owner selector', () => {
+    const storeState = state()
+    const first = selectNativeChatImageOwnerState(storeState)
+    const second = selectNativeChatImageOwnerState({
+      ...storeState,
+      agentStatusByPaneKey: {} as AppState['agentStatusByPaneKey']
+    })
+
+    expect(shallow(second, first)).toBe(true)
+  })
+
+  it('keeps shallow selector identity stable when owner inputs are unchanged', () => {
+    const storeState = state()
+    const first = resolveNativeChatImageRuntimeContext(storeState, 'tab-1')
+    const second = resolveNativeChatImageRuntimeContext(storeState, 'tab-1')
+
+    expect(first).not.toBeNull()
+    expect(second).not.toBe(first)
+    expect(second?.settings).toBe(first?.settings)
+    expect(shallow(second, first)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-image-runtime-context.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-runtime-context.ts
@@ -1,0 +1,173 @@
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
+import {
+  settingsForWorktreeOperationRoute,
+  resolveWorktreeOperationRouteResult
+} from '@/lib/worktree-operation-route'
+import { resolveNativeChatFileLinkContext } from './native-chat-file-link'
+import { captureDirectSshMutationExpectation } from '@/lib/ssh-mutation-expectation'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import { useShallow } from 'zustand/react/shallow'
+
+/** The transcript must not read until ownership and its path are both known. */
+export type NativeChatImageRuntimeContext = RuntimeFileOperationArgs | null
+
+type OwnerState = Pick<
+  AppState,
+  | 'settings'
+  | 'repos'
+  | 'worktreesByRepo'
+  | 'detectedWorktreesByRepo'
+  | 'folderWorkspaces'
+  | 'projectGroups'
+  | 'runtimeEnvironments'
+  | 'runtimeEnvironmentCatalogHydrated'
+  | 'removedRuntimeEnvironmentIds'
+  | 'sshConnectionStates'
+  | 'sshStateByEnvironment'
+  | 'activeWorktreeId'
+  | 'activeWorkspaceExecutionHostId'
+  | 'restoredRuntimeHostIdByWorkspaceSessionKey'
+  | 'getKnownWorktreeById'
+  | 'tabsByWorktree'
+  | 'unifiedTabsByWorktree'
+>
+
+// Keep the subscription limited to fields that can change image ownership. The
+// derived context is computed during render, after Zustand has filtered updates.
+export function selectNativeChatImageOwnerState(state: AppState): OwnerState {
+  return {
+    settings: state.settings,
+    repos: state.repos,
+    worktreesByRepo: state.worktreesByRepo,
+    detectedWorktreesByRepo: state.detectedWorktreesByRepo,
+    folderWorkspaces: state.folderWorkspaces,
+    projectGroups: state.projectGroups,
+    runtimeEnvironments: state.runtimeEnvironments,
+    runtimeEnvironmentCatalogHydrated: state.runtimeEnvironmentCatalogHydrated,
+    removedRuntimeEnvironmentIds: state.removedRuntimeEnvironmentIds,
+    sshConnectionStates: state.sshConnectionStates,
+    sshStateByEnvironment: state.sshStateByEnvironment,
+    activeWorktreeId: state.activeWorktreeId,
+    activeWorkspaceExecutionHostId: state.activeWorkspaceExecutionHostId,
+    restoredRuntimeHostIdByWorkspaceSessionKey: state.restoredRuntimeHostIdByWorkspaceSessionKey,
+    getKnownWorktreeById: state.getKnownWorktreeById,
+    tabsByWorktree: state.tabsByWorktree,
+    unifiedTabsByWorktree: state.unifiedTabsByWorktree
+  }
+}
+
+// Route settings are cloned for the runtime operation contract. Reuse that
+// clone while the store's source settings and selected runtime are unchanged so
+// consumers do not treat an unrelated store update as a new image owner.
+const settingsBySource = new WeakMap<object, Map<string, AppState['settings']>>()
+
+function stableSettingsForRoute(
+  settings: AppState['settings'],
+  runtimeEnvironmentId: string | null
+): AppState['settings'] {
+  if (!settings) {
+    return settingsForWorktreeOperationRoute(settings, {
+      executionHostId: null,
+      runtimeEnvironmentId
+    })
+  }
+  const source = settings as object
+  let byRuntime = settingsBySource.get(source)
+  if (!byRuntime) {
+    byRuntime = new Map()
+    settingsBySource.set(source, byRuntime)
+  }
+  const cacheKey = runtimeEnvironmentId ?? ''
+  const cached = byRuntime.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+  const resolved = settingsForWorktreeOperationRoute(settings, {
+    executionHostId: null,
+    runtimeEnvironmentId
+  })
+  byRuntime.set(cacheKey, resolved)
+  return resolved
+}
+
+function resolvePath(
+  state: OwnerState,
+  worktreeId: string,
+  hostId: ExecutionHostId | null
+): string | null {
+  const known = state.getKnownWorktreeById(worktreeId, hostId ?? undefined)
+  if (known?.path) {
+    return known.path
+  }
+  const workspace = parseWorkspaceKey(worktreeId)
+  if (workspace?.type === 'folder') {
+    return (
+      state.folderWorkspaces.find((entry) => entry.id === workspace.folderWorkspaceId)
+        ?.folderPath ?? null
+    )
+  }
+  for (const worktrees of Object.values(state.worktreesByRepo ?? {})) {
+    const match = worktrees.find(
+      (entry) => entry.id === worktreeId && (!hostId || entry.hostId === hostId)
+    )
+    if (match?.path) {
+      return match.path
+    }
+  }
+  return null
+}
+
+export function resolveNativeChatImageRuntimeContext(
+  state: OwnerState,
+  tabId: string
+): NativeChatImageRuntimeContext {
+  const linkContext = resolveNativeChatFileLinkContext(state, tabId)
+  if (!linkContext) {
+    return null
+  }
+  const routeResolution = resolveWorktreeOperationRouteResult(state, linkContext.worktreeId)
+  if (routeResolution.kind !== 'resolved' || !routeResolution.route.executionHostId) {
+    return null
+  }
+  const route = routeResolution.route
+  const worktreePath = resolvePath(state, linkContext.worktreeId, route.executionHostId)
+  if (!worktreePath) {
+    return null
+  }
+  const host = parseExecutionHostId(route.executionHostId)
+  if (!host) {
+    return null
+  }
+  const context: RuntimeFileOperationArgs = {
+    settings: stableSettingsForRoute(state.settings, route.runtimeEnvironmentId),
+    worktreeId: linkContext.worktreeId,
+    worktreePath,
+    expectedExecutionHostId: host.kind === 'ssh' ? host.id : 'local'
+  }
+  if (host.kind === 'ssh') {
+    try {
+      const expectation = captureDirectSshMutationExpectation(
+        state,
+        host.targetId,
+        route.runtimeEnvironmentId
+      )
+      context.expectedSshTargetId = expectation.expectedSshTargetId
+      context.expectedSshConnectionGeneration = expectation.expectedSshConnectionGeneration
+      if (!route.runtimeEnvironmentId) {
+        context.connectionId = host.targetId
+        context.expectedExternalSshTargetId = host.targetId
+      }
+    } catch {
+      return null
+    }
+  }
+  return context
+}
+
+export function useNativeChatImageRuntimeContext(tabId: string): NativeChatImageRuntimeContext {
+  const ownerState = useAppStore(useShallow(selectNativeChatImageOwnerState))
+  return resolveNativeChatImageRuntimeContext(ownerState, tabId)
+}

--- a/src/renderer/src/components/native-chat/native-chat-image-runtime-context.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-runtime-context.ts
@@ -7,7 +7,11 @@ import {
 } from '@/lib/worktree-operation-route'
 import { resolveNativeChatFileLinkContext } from './native-chat-file-link'
 import { captureDirectSshMutationExpectation } from '@/lib/ssh-mutation-expectation'
-import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import {
+  parseExecutionHostId,
+  toRuntimeExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
@@ -130,15 +134,21 @@ export function resolveNativeChatImageRuntimeContext(
     return null
   }
   const routeResolution = resolveWorktreeOperationRouteResult(state, linkContext.worktreeId)
-  if (routeResolution.kind !== 'resolved' || !routeResolution.route.executionHostId) {
+  if (routeResolution.kind !== 'resolved') {
     return null
   }
   const route = routeResolution.route
-  const worktreePath = resolvePath(state, linkContext.worktreeId, route.executionHostId)
+  const executionHostId =
+    route.executionHostId ??
+    (route.runtimeEnvironmentId ? toRuntimeExecutionHostId(route.runtimeEnvironmentId) : null)
+  if (!executionHostId) {
+    return null
+  }
+  const worktreePath = resolvePath(state, linkContext.worktreeId, executionHostId)
   if (!worktreePath) {
     return null
   }
-  const host = parseExecutionHostId(route.executionHostId)
+  const host = parseExecutionHostId(executionHostId)
   if (!host) {
     return null
   }

--- a/src/renderer/src/components/native-chat/native-chat-image-runtime-context.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-runtime-context.ts
@@ -9,6 +9,7 @@ import { resolveNativeChatFileLinkContext } from './native-chat-file-link'
 import { captureDirectSshMutationExpectation } from '@/lib/ssh-mutation-expectation'
 import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import { useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 
 /** The transcript must not read until ownership and its path are both known. */
@@ -169,5 +170,5 @@ export function resolveNativeChatImageRuntimeContext(
 
 export function useNativeChatImageRuntimeContext(tabId: string): NativeChatImageRuntimeContext {
   const ownerState = useAppStore(useShallow(selectNativeChatImageOwnerState))
-  return resolveNativeChatImageRuntimeContext(ownerState, tabId)
+  return useMemo(() => resolveNativeChatImageRuntimeContext(ownerState, tabId), [ownerState, tabId])
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​468 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​467 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​822 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​242 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​580 |

<!-- /orca-pr-loc -->

## Summary
- render typed `image-ref` blocks in Codex structured-session transcripts as accessible thumbnails
- resolve image bytes through the owning local, folder, runtime, or SSH execution host, failing closed while ownership is unresolved
- reuse bounded, lease-aware preview caching and the existing full-size dialog with textual fallback

## Validation
- focused transcript, runtime-owner, file-link, and local-image tests
- `pnpm tc:web`
- changed-code quality, React Doctor, formatting, and diff checks

This PR intentionally leaves legacy terminal transcript rows on their existing chip behavior; the terminal optimistic-echo lane is in the stacked follow-up PR.
