### PR TITLE
fix(native-chat): show images in terminal optimistic echoes

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -23,6 +23,7 @@ import {
   ProviderFrameRow
 } from './NativeChatTranscriptChrome'
 import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
+import { isPendingMessageId } from './native-chat-pending'
 
 export { ProviderFrameRow } from './NativeChatTranscriptChrome'
 
@@ -45,7 +46,8 @@ function MessageRow({
   deliveryFailed = false,
   activityExpandOverride,
   structuredActivityUi = true,
-  runtimeContext
+  runtimeContext,
+  imagePreviewEnabled = false
 }: {
   message: NativeChatMessage
   expandSignal: boolean
@@ -58,11 +60,17 @@ function MessageRow({
   activityExpandOverride?: boolean
   structuredActivityUi?: boolean
   runtimeContext?: RuntimeFileOperationArgs | null
+  imagePreviewEnabled?: boolean
 }): React.JSX.Element | null {
   const rowRef = useRef<HTMLDivElement | null>(null)
   const { prose, tools } = useMemo(() => splitNativeChatBlocks(message.blocks), [message.blocks])
   const markdown = nativeChatProseToMarkdown(prose)
   const hasImages = prose.some((block) => block.type === 'image-ref')
+  const imageAttachmentProps = {
+    blocks: prose,
+    runtimeContext,
+    enablePreview: imagePreviewEnabled
+  }
   const isUser = message.role === 'user'
   const isReasoning = message.role === 'reasoning'
   const isSystem = message.role === 'system'
@@ -97,11 +105,7 @@ function MessageRow({
         <div className="max-w-[85%] rounded-lg rounded-tr-sm bg-muted px-3.5 py-2.5 text-sm text-foreground">
           {markdown ? (
             <>
-              <NativeChatImageAttachments
-                blocks={prose}
-                runtimeContext={runtimeContext}
-                enablePreview={runtimeContext !== undefined}
-              />
+              <NativeChatImageAttachments {...imageAttachmentProps} />
               <CommentMarkdown
                 content={markdown}
                 variant="document"
@@ -111,11 +115,7 @@ function MessageRow({
               />
             </>
           ) : (
-            <NativeChatImageAttachments
-              blocks={prose}
-              runtimeContext={runtimeContext}
-              enablePreview={runtimeContext !== undefined}
-            />
+            <NativeChatImageAttachments {...imageAttachmentProps} />
           )}
         </div>
         {deliveryFailed ? (
@@ -144,11 +144,7 @@ function MessageRow({
         isSystem && 'text-xs text-muted-foreground'
       )}
     >
-      <NativeChatImageAttachments
-        blocks={prose}
-        runtimeContext={runtimeContext}
-        enablePreview={runtimeContext !== undefined}
-      />
+      <NativeChatImageAttachments {...imageAttachmentProps} />
       {markdown ? (
         <CommentMarkdown
           content={markdown}
@@ -188,7 +184,8 @@ export function NativeChatMessageList({
   workingStartedAt,
   failedDeliveryMessageIds,
   showTurnStatus = true,
-  runtimeContext
+  runtimeContext,
+  imagePreviewMode = 'none'
 }: {
   session: NativeChatLiveSession
   isWorking: boolean
@@ -203,6 +200,7 @@ export function NativeChatMessageList({
   /** Turn timing/disclosure is available only on the structured Codex lane. */
   showTurnStatus?: boolean
   runtimeContext?: RuntimeFileOperationArgs | null
+  imagePreviewMode?: 'none' | 'pending' | 'all'
 }): React.JSX.Element {
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
@@ -399,6 +397,10 @@ export function NativeChatMessageList({
                   structuredActivityUi={showTurnStatus}
                   activityExpandOverride={turnKey ? expandedTurnIds.has(turnKey) : undefined}
                   runtimeContext={runtimeContext}
+                  imagePreviewEnabled={
+                    imagePreviewMode === 'all' ||
+                    (imagePreviewMode === 'pending' && isPendingMessageId(message.id))
+                  }
                 />
                 {showTurnStatus &&
                 status &&

--- a/src/renderer/src/components/native-chat/NativeChatResolvedView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatResolvedView.tsx
@@ -52,6 +52,7 @@ import { useNativeChatFileLinkClick } from './use-native-chat-file-link-click'
 import type { NativeChatResolvedViewProps } from './native-chat-view-types'
 import { useNativeChatFileLinkContext } from './use-native-chat-file-link-context'
 import { NativeChatOrchestrationPausedNotice } from './NativeChatOrchestrationPausedNotice'
+import { useNativeChatImageRuntimeContext } from './native-chat-image-runtime-context'
 
 /** Renders the bridge UI after NativeChatSessionGate resolves its agent session. */
 export function NativeChatResolvedView({
@@ -123,6 +124,7 @@ export function NativeChatResolvedView({
   // replaces the composer.
   const questionAnswerInputRef = useRef<HTMLInputElement>(null)
   const fileLinkContext = useNativeChatFileLinkContext(terminalTabId)
+  const imageRuntimeContext = useNativeChatImageRuntimeContext(terminalTabId)
   const pasteClipboardIntoComposer = useNativeChatPasteBridge({
     rootRef,
     composerRef,
@@ -375,6 +377,8 @@ export function NativeChatResolvedView({
             onLinkClick={nativeChatFileLinkClick}
             allowFileUriLinks={fileLinkContext !== null}
             failedDeliveryMessageIds={failedLaunchPromptMessageIds}
+            runtimeContext={imageRuntimeContext}
+            imagePreviewMode="pending"
           />
         )}
       </div>

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -148,6 +148,7 @@ export function NativeChatStructuredSession(props: {
             onLinkClick={fileLinkClick}
             allowFileUriLinks={fileLinkClick !== undefined}
             runtimeContext={props.agent === 'codex' ? imageRuntimeContext : undefined}
+            imagePreviewMode={props.agent === 'codex' ? 'all' : 'none'}
           />
         )}
       </div>

--- a/src/renderer/src/components/native-chat/native-chat-attachment-cache.ts
+++ b/src/renderer/src/components/native-chat/native-chat-attachment-cache.ts
@@ -1,0 +1,30 @@
+import type { NativeChatComposerImageAttachment } from './NativeChatComposerField'
+import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
+
+const attachmentCache = new Map<string, NativeChatComposerImageAttachment[]>()
+
+export function readNativeChatAttachmentCache(
+  scopeKey: string
+): NativeChatComposerImageAttachment[] {
+  return [...(attachmentCache.get(scopeKey) ?? [])]
+}
+
+export function writeNativeChatAttachmentCache(
+  scopeKey: string,
+  cacheable: readonly NativeChatComposerImageAttachment[]
+): void {
+  // Pending chips resolve into the current hook; only settled paths survive remounts.
+  const attachments = cacheable
+    .filter((attachment) => !attachment.pending)
+    // Settled attachments reload from their authorized path, so don't retain transient previews.
+    .map(({ previewUrl: _previewUrl, ...attachment }) => attachment)
+  if (attachments.length === 0) {
+    attachmentCache.delete(scopeKey)
+    return
+  }
+  setBoundedScopeCacheEntry(attachmentCache, scopeKey, [...attachments])
+}
+
+export function clearNativeChatAttachmentCacheForTests(): void {
+  attachmentCache.clear()
+}

--- a/src/renderer/src/components/native-chat/native-chat-preview-url-lifecycle.ts
+++ b/src/renderer/src/components/native-chat/native-chat-preview-url-lifecycle.ts
@@ -1,0 +1,39 @@
+import type { NativeChatComposerImageAttachment } from './NativeChatComposerField'
+
+/** Track object URLs owned by one composer so cleanup is idempotent. */
+export function createPreviewUrlRegistry(
+  attachments: readonly NativeChatComposerImageAttachment[]
+): Set<string> {
+  return new Set(
+    attachments.flatMap((attachment) =>
+      attachment.previewUrl?.startsWith('blob:') ? [attachment.previewUrl] : []
+    )
+  )
+}
+
+export function trackPreviewUrl(url: string | undefined, registry: Set<string>): void {
+  if (url?.startsWith('blob:')) {
+    registry.add(url)
+  }
+}
+
+export function releaseAttachmentPreview(
+  attachment: NativeChatComposerImageAttachment,
+  registry: Set<string>
+): void {
+  if (attachment.previewUrl?.startsWith('blob:') && registry.delete(attachment.previewUrl)) {
+    URL.revokeObjectURL(attachment.previewUrl)
+  }
+}
+
+export function removeAttachmentById(
+  attachments: readonly NativeChatComposerImageAttachment[],
+  id: string,
+  registry: Set<string>
+): NativeChatComposerImageAttachment[] {
+  const removed = attachments.find((attachment) => attachment.id === id)
+  if (removed) {
+    releaseAttachmentPreview(removed, registry)
+  }
+  return attachments.filter((attachment) => attachment.id !== id)
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.test.tsx
@@ -131,6 +131,39 @@ describe('useNativeChatComposerAttachments', () => {
   afterEach(() => {
     clearNativeChatAttachmentCacheForTests()
     document.body.replaceChildren()
+    vi.restoreAllMocks()
+  })
+
+  it('revokes clipboard preview URLs once when a composer unmounts', async () => {
+    const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+    const probe = await renderProbe('preview-cleanup')
+
+    await act(async () => {
+      expect(probe.latest().beginPendingImageAttachment('blob:clipboard-preview')).toBeTruthy()
+    })
+    act(() => probe.root.unmount())
+
+    expect(revoke).toHaveBeenCalledTimes(1)
+    expect(revoke).toHaveBeenCalledWith('blob:clipboard-preview')
+  })
+
+  it('does not double-revoke a preview removed before unmount', async () => {
+    const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+    const probe = await renderProbe('preview-remove-cleanup')
+
+    let id: string | null = null
+    await act(async () => {
+      id = probe.latest().beginPendingImageAttachment('blob:clipboard-preview-removed')
+    })
+    await act(async () => {
+      if (id) {
+        probe.latest().removeImageAttachment(id)
+      }
+    })
+    act(() => probe.root.unmount())
+
+    expect(revoke).toHaveBeenCalledTimes(1)
+    expect(revoke).toHaveBeenCalledWith('blob:clipboard-preview-removed')
   })
 
   it('holds attached images as chips (deferred to submit) and restores them on remount', async () => {

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef, useState, type RefObject } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react'
 import { translate } from '@/i18n/i18n'
 import { NATIVE_FILE_DROP_MAX_PATHS } from '../../../../shared/native-file-drop'
 import { isNativeChatImageAttachmentPath } from './native-chat-image-paste'
@@ -8,8 +8,17 @@ import {
   type NativeChatResolvedTarget
 } from './native-chat-composer-target'
 import type { NativeChatComposerImageAttachment } from './NativeChatComposerField'
-import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
-
+import {
+  clearNativeChatAttachmentCacheForTests,
+  readNativeChatAttachmentCache,
+  writeNativeChatAttachmentCache
+} from './native-chat-attachment-cache'
+import {
+  createPreviewUrlRegistry,
+  releaseAttachmentPreview,
+  removeAttachmentById,
+  trackPreviewUrl
+} from './native-chat-preview-url-lifecycle'
 export type UseNativeChatComposerAttachmentsArgs = {
   attachmentScopeKey: string
   allowWithoutTarget?: boolean
@@ -47,6 +56,10 @@ export function useNativeChatComposerAttachments({
   const [imageAttachments, setImageAttachments] = useState<NativeChatComposerImageAttachment[]>(
     () => readNativeChatAttachmentCache(attachmentScopeKey)
   )
+  // Scope URL ownership so cleanup is idempotent without global history.
+  const livePreviewUrlsRef = useRef(createPreviewUrlRegistry(imageAttachments))
+  const imageAttachmentsRef = useRef(imageAttachments)
+  imageAttachmentsRef.current = imageAttachments
   const imageAttachmentCounter = useRef(0)
   const pendingResolvedPathsRef = useRef<{ path: string; connectionId?: string | null }[]>([])
   const pendingPathLimitRejectedRef = useRef(false)
@@ -59,6 +72,16 @@ export function useNativeChatComposerAttachments({
       pendingPathLimitRejectedRef.current = false
     }
   }, [disabled])
+
+  useEffect(() => {
+    const attachments = imageAttachmentsRef
+    const livePreviewUrls = livePreviewUrlsRef
+    return () => {
+      for (const attachment of attachments.current) {
+        releaseAttachmentPreview(attachment, livePreviewUrls.current)
+      }
+    }
+  }, [])
 
   const updateImageAttachments = useCallback(
     (
@@ -80,8 +103,7 @@ export function useNativeChatComposerAttachments({
     return `${Date.now()}-${imageAttachmentCounter.current}`
   }, [])
 
-  // Local paths are only attachable when the composer's target runs locally;
-  // remote-runtime panes read a different filesystem than the one we resolved.
+  // Remote-runtime panes read a different filesystem than local paths.
   const attachmentTargetBlocked = useCallback((): boolean => {
     const target = resolveTarget()
     return (
@@ -127,6 +149,7 @@ export function useNativeChatComposerAttachments({
         noteAttachmentTargetBlocked()
         return null
       }
+      trackPreviewUrl(previewUrl, livePreviewUrlsRef.current)
       const id = nextAttachmentId()
       updateImageAttachments((prev) => [...prev, { id, path: '', previewUrl, pending: true }])
       return id
@@ -154,7 +177,7 @@ export function useNativeChatComposerAttachments({
 
   const dropPendingImageAttachment = useCallback(
     (id: string) => {
-      updateImageAttachments((prev) => removeAttachmentById(prev, id))
+      updateImageAttachments((prev) => removeAttachmentById(prev, id, livePreviewUrlsRef.current))
     },
     [updateImageAttachments]
   )
@@ -255,69 +278,23 @@ export function useNativeChatComposerAttachments({
     }
     applyResolvedPaths(paths, false, preserveNotice)
   }, [applyResolvedPaths])
-
   return {
     imageAttachments,
     attachResolvedPaths,
     clearImageAttachments: () =>
       updateImageAttachments((prev) => {
-        prev.forEach(releaseAttachmentPreview)
+        prev.forEach((attachment) =>
+          releaseAttachmentPreview(attachment, livePreviewUrlsRef.current)
+        )
         return []
       }),
     flushPendingAttachments,
-    removeImageAttachment: (id) => updateImageAttachments((prev) => removeAttachmentById(prev, id)),
+    removeImageAttachment: (id) =>
+      updateImageAttachments((prev) => removeAttachmentById(prev, id, livePreviewUrlsRef.current)),
     beginPendingImageAttachment,
     resolvePendingImageAttachment,
     dropPendingImageAttachment
   }
 }
 
-/** Object URLs minted from a clipboard blob leak until revoked; data URLs don't. */
-function releaseAttachmentPreview(attachment: NativeChatComposerImageAttachment): void {
-  if (attachment.previewUrl?.startsWith('blob:')) {
-    URL.revokeObjectURL(attachment.previewUrl)
-  }
-}
-
-function removeAttachmentById(
-  attachments: readonly NativeChatComposerImageAttachment[],
-  id: string
-): NativeChatComposerImageAttachment[] {
-  const removed = attachments.find((attachment) => attachment.id === id)
-  if (removed) {
-    releaseAttachmentPreview(removed)
-  }
-  return attachments.filter((attachment) => attachment.id !== id)
-}
-
-const attachmentCache = new Map<string, NativeChatComposerImageAttachment[]>()
-
-export function readNativeChatAttachmentCache(
-  scopeKey: string
-): NativeChatComposerImageAttachment[] {
-  return [...(attachmentCache.get(scopeKey) ?? [])]
-}
-
-function writeNativeChatAttachmentCache(
-  scopeKey: string,
-  cacheable: readonly NativeChatComposerImageAttachment[]
-): void {
-  // A pending chip's save resolves into THIS hook instance; restoring one into a
-  // remount would strand it pending forever, so only settled chips are cached.
-  const attachments = cacheable
-    .filter((attachment) => !attachment.pending)
-    // Preview URLs can retain the full clipboard Blob (or a large data URL) for
-    // the lifetime of the scope cache. Settled attachments reload from their
-    // authorized path after a remount, so never retain the transient preview.
-    .map(({ previewUrl: _previewUrl, ...attachment }) => attachment)
-  if (attachments.length === 0) {
-    attachmentCache.delete(scopeKey)
-    return
-  }
-  // LRU-bounded so pending attachments for permanently-removed panes can't accumulate.
-  setBoundedScopeCacheEntry(attachmentCache, scopeKey, [...attachments])
-}
-
-export function clearNativeChatAttachmentCacheForTests(): void {
-  attachmentCache.clear()
-}
+export { clearNativeChatAttachmentCacheForTests, readNativeChatAttachmentCache }

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-paste.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-paste.test.tsx
@@ -25,6 +25,7 @@ vi.mock('./native-chat-attachment-upload', () => ({
 }))
 
 vi.stubGlobal('window', {
+  location: { pathname: '' },
   api: {
     ui: {
       saveClipboardImageAsTempFile: mocks.saveClipboardImageAsTempFile,
@@ -170,6 +171,7 @@ const sshOwner: NativeChatAttachmentOwner = {
 afterEach(() => {
   root?.unmount()
   root = null
+  delete (window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
   vi.clearAllMocks()
 })
 
@@ -294,6 +296,37 @@ describe('useNativeChatComposerPaste', () => {
     expect(setNotice).toHaveBeenCalledWith('Worktree not ready — try again in a moment.')
   })
 
+  it('does not settle an SSH path after the connection generation changes', async () => {
+    let resolveSave: (path: string) => void = () => {}
+    let owner: NativeChatAttachmentOwner = sshOwner
+    mocks.saveClipboardImageAsTempFile.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveSave = resolve
+      })
+    )
+    const store = createChipStore()
+    const setNotice = vi.fn()
+    const probe = await renderProbe({
+      resolveAttachmentOwner: () => owner,
+      store,
+      setNotice
+    })
+
+    await act(async () => {
+      probe.latest().handlePaste(imagePasteEvent())
+    })
+    expect(store.chips).toHaveLength(1)
+
+    // A reconnect can reuse the connection ID while changing the session generation.
+    owner = { ...sshOwner, expectedSshConnectionGeneration: 5 }
+    await act(async () => {
+      resolveSave('/remote/tmp/stale-session.png')
+    })
+
+    expect(store.chips).toHaveLength(0)
+    expect(setNotice).toHaveBeenCalledWith('Worktree not ready — try again in a moment.')
+  })
+
   it('shows a pending chip for menu paste from the clipboard thumbnail probe', async () => {
     mocks.readClipboardImageThumbnail.mockResolvedValue({
       dataUrl: 'data:image/png;base64,AAA',
@@ -321,6 +354,26 @@ describe('useNativeChatComposerPaste', () => {
       resolveSave('/tmp/orca-paste-2.png')
     })
     expect(store.chips[0]).toMatchObject({ path: '/tmp/orca-paste-2.png', pending: false })
+  })
+
+  it('keeps the thumbnail probe available for paired web', async () => {
+    ;(window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+    mocks.readClipboardImageThumbnail.mockResolvedValue({
+      dataUrl: 'data:image/png;base64,AAA',
+      width: 1200,
+      height: 800
+    })
+    mocks.saveClipboardImageAsTempFile.mockResolvedValue('/runtime/tmp/orca-paste-web.png')
+    const probe = await renderProbe({
+      resolveAttachmentOwner: () => ({ kind: 'local' })
+    })
+
+    await act(async () => {
+      probe.latest().pasteFromClipboard()
+    })
+
+    expect(mocks.readClipboardImageThumbnail).toHaveBeenCalledOnce()
+    expect(mocks.saveClipboardImageAsTempFile).toHaveBeenCalledOnce()
   })
 
   it('attaches directly when no clipboard preview was available', async () => {

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-paste.ts
@@ -68,7 +68,14 @@ function attachmentOwnerStillMatches(
   if (original.kind !== 'ssh') {
     return true
   }
-  return current.kind === 'ssh' && original.connectionId === current.connectionId
+  return (
+    current.kind === 'ssh' &&
+    original.connectionId === current.connectionId &&
+    original.worktreePath === current.worktreePath &&
+    original.expectedExecutionHostId === current.expectedExecutionHostId &&
+    original.expectedSshTargetId === current.expectedSshTargetId &&
+    original.expectedSshConnectionGeneration === current.expectedSshConnectionGeneration
+  )
 }
 
 /**
@@ -106,6 +113,8 @@ export function useNativeChatComposerPaste({
   const disabledRef = useRef(disabled)
   disabledRef.current = disabled
   const acceptsImages = getAgentImageHandling(agent) === 'attachment'
+  const canReadClipboardImageThumbnail =
+    typeof window.api.ui.readClipboardImageThumbnail === 'function'
 
   // Distinguishes 'empty' (no image on the clipboard — text may fall through)
   // from 'failed' (save errored — the flow must stop and say why).
@@ -256,9 +265,10 @@ export function useNativeChatComposerPaste({
       // The in-memory thumbnail probe runs alongside the save rather than before
       // it: it answers first (it never touches disk or the network), so the chip
       // appears while the save is still in flight and text paste stays as fast.
-      const wantsPlaceholder = acceptsImages && ownerAcceptsClipboardImage(owner)
+      const wantsPlaceholder =
+        canReadClipboardImageThumbnail && acceptsImages && ownerAcceptsClipboardImage(owner)
       const thumbnailPromise = wantsPlaceholder
-        ? window.api.ui.readClipboardImageThumbnail().catch(() => null)
+        ? window.api.ui.readClipboardImageThumbnail?.().catch(() => null)
         : Promise.resolve(null)
       const savePromise = saveClipboardImageForOwner(owner)
       const thumbnail = await thumbnailPromise
@@ -300,6 +310,7 @@ export function useNativeChatComposerPaste({
   }, [
     acceptsImages,
     beginPendingImageAttachment,
+    canReadClipboardImageThumbnail,
     dropPendingImageAttachment,
     insertTypedText,
     noteImagesUnsupported,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​142 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​78 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​64 |

<!-- /orca-pr-loc -->

## Summary
- opt legacy terminal chat's pending user echoes into image previews, matching the established mobile interaction
- keep authoritative PTY transcript rows on their existing textual image chips
- preserve paired-web clipboard thumbnail behavior while tightening preview URL cleanup and SSH reconnect fencing

## ELI5: Before / After

**Before:** When you pasted an image into a terminal chat, Orca showed a small text label while the image was still being saved. It could look like your paste had disappeared or failed.

**After:** Orca immediately shows a small image preview while the paste finishes saving. Once it is ready, the preview stays tied to the correct chat and remote connection, and the existing text-only transcript behavior remains unchanged.

## Validation
- focused composer, transcript, runtime-owner, and local-image tests
- `pnpm tc:web`
- changed-code quality, React Doctor, formatting, and diff checks

Stacked on #18266 so the structured Codex renderer and its bounded runtime preview machinery are reviewed independently.
