### PR TITLE
fix(sidebar): keep the agent name first on monitoring compact rows

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-card-agent-summary.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-agent-summary.test.ts
@@ -53,16 +53,27 @@ describe('worktree card agent summary', () => {
     expect(summarizeAgents([agent], 'Agent')).toBe('Agent monitoring')
   })
 
-  it('keeps monitoring visible before a compact row prompt', () => {
+  it('keeps the prompt first on a monitoring compact row', () => {
     const agent = monitoringAgent()
     agent.entry.prompt = 'Run background checks'
 
     const markup = renderCompactAgentRow({ agent, now: 2000, onActivate: vi.fn() })
 
-    expect(markup).toContain('title="Monitoring background tasks - Run background checks"')
+    expect(markup).toContain('title="Run background checks - Monitoring background tasks"')
     expect(markup).toMatch(
-      /Monitoring background tasks<\/span><span[^>]*> - Run background checks<\/span>/
+      /Run background checks<\/span><span[^>]*> - Monitoring background tasks<\/span>/
     )
+    // The trailing label is what truncates away, so the dot must still name the state.
+    expect(markup).toContain('aria-label="Monitoring background tasks"')
+  })
+
+  it('names the monitoring state once when the row has no prompt', () => {
+    const agent = monitoringAgent()
+
+    const markup = renderCompactAgentRow({ agent, now: 2000, onActivate: vi.fn() })
+
+    expect(markup).toContain('title="Monitoring background tasks"')
+    expect(markup).not.toContain(' - Monitoring background tasks')
   })
 
   it('hands the whole row to the send-target reason, and only then', () => {
@@ -84,7 +95,7 @@ describe('worktree card agent summary', () => {
 
     expect(orderedTitles(eligible)).toEqual([
       'Claude',
-      'Monitoring background tasks - Run background checks'
+      'Run background checks - Monitoring background tasks'
     ])
     expect(eligible).toContain('data-slot="tooltip-trigger"')
   })

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -138,11 +138,9 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
   const stableMessage =
     turnHoldable && !currentMessage && held?.turn === turn ? held.message : undefined
   const secondary = getCompactAgentSecondary(agent, now, stableMessage)
-  // Why: sidebar truncation must preserve the passive-vs-active distinction.
-  const leadingText = dotState === 'monitoring' ? secondary : primary
-  const trailingText =
-    dotState === 'monitoring' ? (primary === secondary ? '' : primary) : secondary
-  const rowTitle = `${leadingText}${trailingText ? ` - ${trailingText}` : ''}`
+  // Why: the name must survive default-width truncation; the state dot already names monitoring.
+  const trailingText = primary === secondary ? '' : secondary
+  const rowTitle = `${primary}${trailingText ? ` - ${trailingText}` : ''}`
   const model = agent.entry.model?.trim() ?? ''
   const shortTime = getCompactAgentTime(agent, now)
   const cacheTimer = usePromptCacheCountdownForPane(agent.paneKey, cacheTimerActive)
@@ -234,7 +232,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
         {/* Why: the selected-row fill is strong enough to wash out the dimmed
             prompt/secondary text, so lift both toward full foreground when focused. */}
         <span className={isFocusedPane ? 'text-foreground' : 'text-muted-foreground/90'}>
-          {leadingText}
+          {primary}
         </span>
         {trailingText && (
           <span className={isFocusedPane ? 'text-foreground/70' : 'text-muted-foreground/65'}>


### PR DESCRIPTION
## ELI5

In the sidebar's compact agent list, an agent that is "monitoring background tasks" showed its status label first and its name second. That label is 27 characters long, so at the default sidebar width the row read "Monitoring backgroun…" and the name never appeared. Every other state shows the name first. This PR makes the monitoring row do the same: name first, status after the dash. The yellow heartbeat icon on the row (and its tooltip) still says the agent is monitoring.

## What Changed

- `CompactAgentRow` (`src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx`): the leading/trailing text no longer swaps places for `dotState === 'monitoring'`. The row always renders `<primary> - <secondary>`.
- The guard that drops the trailing text when it equals the leading text used to live only inside the monitoring branch; it now applies to every state. It fires only when the two strings are identical, so it removes redundant `X - X` rows and loses no information. Interrupted and unverifiable rows are unaffected because their primary fallback (`Interrupted`, `No recent update`) and secondary labels (`Interrupted by user`, `No update in 34m`) never match. The no-prompt monitoring row, where both fall back to the state label, still reads `Monitoring background tasks` exactly once.
- Tests (`worktree-card-agent-summary.test.ts`): the existing monitoring-row assertions now expect name-first ordering, a new case checks that a monitoring row without a prompt names the state once, and the prompt-first case also pins that the state dot still carries `aria-label="Monitoring background tasks"`, since that dot is now what names the state when the trailing label truncates.

No change to `getCompactAgentSecondary`, the dot state, the tooltip, the full-size `DashboardAgentRow`, or mobile (both were already name-first). The review-notes send menu still lists the state label before the tab title in its secondary line; that is a dropdown, not a truncating sidebar row, and is out of scope here.

## Why

Fixes #17546. With two or more monitoring agents in one worktree (a coordinator plus a log monitor, say), their rows were visually identical at default width and could only be told apart by hovering each one.

The status-first ordering came from ec4687c434 (#16201), whose comment named the invariant it protected: sidebar truncation must preserve the passive-vs-active distinction. That was the right call under the conditions it shipped in. At that point `AgentStateDot` set only an aria-label on the monitoring glyph and rendered no hover tooltip, as #16981 later documented, so the leading text was the only place a mouse user could read the state from. #16981 changed that premise: every state glyph now carries a labelled tooltip, and monitoring moved from `Radio` to a static `Activity` heartbeat chosen because it reads as "still running". The distinction therefore now rides on a glyph that cannot be truncated, while the ordering that used to protect it costs the row the one piece of information nothing else on the row carries: the agent's name. Ordering the row like every other state keeps the distinction (yellow `Activity` glyph plus tooltip, and the label after the dash when there is room) and lets the name survive truncation.

Two edge cases worth naming rather than leaving for review to find:

- Under `prefers-reduced-motion` the working spinner freezes into a complete yellow ring, so for those users working and monitoring separate on glyph shape and size (6px ring vs 10px heartbeat) plus the tooltip and aria-label, not on motion. That was already the case before this PR.
- In send-target picker mode the row intentionally suppresses the dot's tooltip so the disabled reason wins on hover (pinned by the existing test). The glyph and aria-label remain.

## Linked Issue

Fixes #17546

## Visual Proof

`pnpm dev` on macOS, default sidebar width, two Claude sessions in one worktree that each left a `sleep 900` background shell running and ended their turn.

**Before** (status label first; the two rows are indistinguishable):
<img width="576" height="304" alt="before-sidebar-monitoring-rows" src="https://github.com/user-attachments/assets/2a340cf1-ad7f-4dd0-bfc3-7508bc5d286f" />

**After** (name first; the yellow heartbeat glyph and its tooltip still show the monitoring state):
<img width="576" height="304" alt="after-sidebar-monitoring-rows" src="https://github.com/user-attachments/assets/99e0eabe-6e67-475c-9019-d62e2ae18528" />


## Testing

- `pnpm test src/renderer/src/components/sidebar/worktree-card-agent-summary.test.ts`
- `pnpm test` (full suite: 7465 files passed, 48 skipped)
- `pnpm tc`
- `pnpm run check:code-quality:changed`, `oxlint`, `oxfmt --check` on the changed files
- Manually verified in `pnpm dev` on macOS (Apple Silicon): started a Claude Code session in a worktree terminal, had it leave a background shell task running and end its turn, and confirmed the sidebar row reads `<name> - Monitoring background tasks` with the yellow heartbeat glyph, then reverted the component to capture the before state from the same session.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code (Claude Fable 5.1) under the author's direction; the author reviewed the diff, ran the checks, and captured the screenshots.

## Review

AI code review summary (Claude Code, four independent review passes with adversarial verification of each finding):

- **Cross-platform (macOS / Linux / Windows)**: renderer-only string ordering; no platform APIs, paths, or shortcuts touched.
- **SSH / remote / local**: the row renders from the same `DashboardAgentRow` data regardless of execution host; no RPC or wire shape changes.
- **Agents / integrations / git providers**: `workingMode: 'monitoring'` is the only input and is unchanged; the change applies uniformly to whichever agent reports it.
- **Performance**: two ternaries replaced with one equality check inside an already-memoized component; no new work per render.
- **UI quality**: consistent with the other states in the same row and with `DashboardAgentRow` and mobile; the tooltip text follows the same order as the visible text because both derive from the same pair. No color or layout change, so light/dark are unaffected.
- **Security**: no user input handling, IPC, or filesystem involvement.
- **Backwards compatibility**: no persisted state or wire protocol involved.
- **Regression search**: no other production code, test, snapshot, or doc depends on the old ordering or the removed `leadingText`/`trailingText` names.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Mobile's worktree row already renders name-first and is untouched.

## Author

X: @gum79

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwSFoun5enrK3iiFrbFWRz
