### PR TITLE
fix(ssh): treat a missing git provider as an unavailable worktree graph

### DIFF
--- a/src/main/ipc/hosted-review.test.ts
+++ b/src/main/ipc/hosted-review.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolve } from 'node:path'
+import {
+  isWorktreeCatalogUnavailableError,
+  WorktreeCatalogUnavailableError
+} from '../../shared/worktree/worktree-catalog-availability'
 
 const ORIGINAL_PLATFORM = process.platform
 
@@ -474,6 +478,30 @@ describe('registerHostedReviewHandlers', () => {
       'ssh-1',
       { localGitExecOptions: { admissionTier: 'interactive' } }
     )
+    expect(createHostedReviewMock).not.toHaveBeenCalled()
+  })
+
+  it('does not treat an unavailable SSH worktree catalog as a missing worktree', async () => {
+    listRepoWorktreeGraphMock.mockRejectedValue(
+      new WorktreeCatalogUnavailableError(
+        `Worktree catalog unavailable for ${repoPath}: SSH connection "ssh-1" is not connected.`
+      )
+    )
+
+    registerHostedReviewHandlers(store as never, stats as never)
+
+    await expect(
+      handlers['hostedReview:create'](null, {
+        repoPath,
+        repoId: repo.id,
+        worktreePath,
+        provider: 'github',
+        base: 'main',
+        head: 'feature/pr',
+        title: 'Feature PR'
+      })
+    ).rejects.toSatisfy(isWorktreeCatalogUnavailableError)
+
     expect(createHostedReviewMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/repo-worktrees.test.ts
+++ b/src/main/repo-worktrees.test.ts
@@ -1,15 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { isWorktreeCatalogUnavailableError } from '../shared/worktree/worktree-catalog-availability'
 
-const { listWorktreeGraphMock, listWorktreesMock, listWorktreesStrictMock } = vi.hoisted(() => ({
-  listWorktreeGraphMock: vi.fn(),
-  listWorktreesMock: vi.fn(),
-  listWorktreesStrictMock: vi.fn()
-}))
+const { getSshGitProviderMock, listWorktreeGraphMock, listWorktreesMock, listWorktreesStrictMock } =
+  vi.hoisted(() => ({
+    getSshGitProviderMock: vi.fn(),
+    listWorktreeGraphMock: vi.fn(),
+    listWorktreesMock: vi.fn(),
+    listWorktreesStrictMock: vi.fn()
+  }))
 
 vi.mock('./git/worktree', () => ({
   listWorktreeGraph: listWorktreeGraphMock,
   listWorktrees: listWorktreesMock,
   listWorktreesStrict: listWorktreesStrictMock
+}))
+
+vi.mock('./providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
 }))
 
 import {
@@ -22,6 +29,7 @@ import {
 
 describe('repo-worktrees', () => {
   beforeEach(() => {
+    getSshGitProviderMock.mockReset()
     listWorktreeGraphMock.mockReset()
     listWorktreesMock.mockReset()
     listWorktreesStrictMock.mockReset()
@@ -154,6 +162,57 @@ describe('repo-worktrees', () => {
         kind: 'folder'
       })
     ])
+  })
+
+  it('throws when the SSH git provider is missing from the graph listing', async () => {
+    getSshGitProviderMock.mockReturnValue(undefined)
+    const repo = {
+      id: 'repo-1',
+      path: '/remote/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'ssh-1',
+      kind: 'git' as const
+    }
+
+    await expect(listRepoWorktreeGraph(repo)).rejects.toSatisfy((error: unknown) => {
+      return (
+        isWorktreeCatalogUnavailableError(error) &&
+        error instanceof Error &&
+        error.message ===
+          'Worktree catalog unavailable for /remote/workspace/repo: SSH connection "ssh-1" is not connected.'
+      )
+    })
+    expect(listWorktreeGraphMock).not.toHaveBeenCalled()
+  })
+
+  it('delegates the SSH graph listing to the connected git provider', async () => {
+    const worktrees = [
+      {
+        path: '/remote/workspace/feature',
+        head: 'abc',
+        branch: 'feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ]
+    const listWorktrees = vi.fn().mockResolvedValue(worktrees)
+    getSshGitProviderMock.mockReturnValue({ listWorktrees })
+
+    const result = await listRepoWorktreeGraph({
+      id: 'repo-1',
+      path: '/remote/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'ssh-1',
+      kind: 'git'
+    })
+
+    expect(listWorktrees).toHaveBeenCalledWith('/remote/workspace/repo')
+    expect(listWorktreeGraphMock).not.toHaveBeenCalled()
+    expect(result).toEqual(worktrees)
   })
 
   it('delegates strict local listing with the signal and WSL options', async () => {

--- a/src/main/repo-worktrees.ts
+++ b/src/main/repo-worktrees.ts
@@ -74,7 +74,14 @@ export async function listRepoWorktreeGraph(
   }
   if (repo.connectionId) {
     const provider = getSshGitProvider(repo.connectionId)
-    return provider ? await provider.listWorktrees(repo.path) : []
+    // Why: path-only callers treat [] as "not a member". An unreachable host is not
+    // an empty catalog (#14004) — never fall back to local git against a server path.
+    if (!provider) {
+      throw new WorktreeCatalogUnavailableError(
+        `Worktree catalog unavailable for ${repo.path}: SSH connection "${repo.connectionId}" is not connected.`
+      )
+    }
+    return await provider.listWorktrees(repo.path)
   }
   return hasLocalRepoWorktreeListOptions(options)
     ? await listWorktreeGraph(repo.path, options)


### PR DESCRIPTION
## Description

A disconnected SSH repo no longer looks like an empty worktree catalog to path-only callers. Hosted-review membership reports the host as unavailable instead of `Access denied: worktree does not belong to repository`.

`listRepoWorktrees` already throws `WorktreeCatalogUnavailableError` when `repo.connectionId` is set and `getSshGitProvider` is missing. `listRepoWorktreeGraph` returned `[]` on that same miss, so membership treated “could not ask” as “not a member” and blocked PR/review on live remote worktrees until reconnect.

## Focused fix

- In scope: `listRepoWorktreeGraph` SSH miss path; regression tests for the graph function and hosted-review membership.
- Out of scope: local/WSL detected-scan empty catalog (#14003); relay remove list-fail-open; host-qualified worktree ids; changing `assertAuthoritativeWorktreeCatalog`.

## Preserves

- Same `WorktreeCatalogUnavailableError` message as `listRepoWorktrees`. An unreachable host is still not an empty catalog (#14004 / `docs/reference/ssh-execution-boundary.md`).
- Folder repos still return one synthetic worktree. Local git repos still use probe-free `listWorktreeGraph`.
- Hosted-review still denies a path that is absent from an authoritative listing. This does not fold into #14003.

## Evidence

- Test: `pnpm test src/main/repo-worktrees.test.ts` (11 passed)
- Test: `pnpm test src/main/ipc/hosted-review.test.ts` (13 passed)
- Related: `pnpm test src/main/providers/ssh-worktree-catalog-authority.test.ts` (6 passed)
- `pnpm tc:node` exit 0; changed-code quality 0
- Missing provider rejects with `isWorktreeCatalogUnavailableError` and does not call local `listWorktreeGraph`. Hosted-review create surfaces that error, not “does not belong”.

## User-regression-tradeoffs

- Review/PR actions on an SSH worktree while the git provider is missing now fail as catalog-unavailable instead of access-denied. Loss of contact is not evidence that the worktree does not belong.

Fixes #18272
