### PR TITLE
fix(relay): refuse worktree remove when the listing is unavailable

### DIFF
--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import * as path from 'node:path'
 import { GitCapabilityCache } from '../shared/git-capability-cache'
+import { isWorktreeCatalogUnavailableError } from '../shared/worktree/worktree-catalog-availability'
 import type { GitExec } from './git-handler-ops'
 import { addWorktreeOp, removeWorktreeOp } from './git-handler-worktree-ops'
 
@@ -25,6 +26,12 @@ function worktreeList(...entries: { path: string; branch?: string }[]): string {
 
 function resolvedRepoPath(): string {
   return path.posix.resolve('/repo-feature', '/repo/.git', '..')
+}
+
+function expectWorktreeRemoveNotInvoked(git: ReturnType<typeof vi.fn<GitExec>>) {
+  expect(
+    git.mock.calls.filter(([args]) => args[0] === 'worktree' && args[1] === 'remove')
+  ).toHaveLength(0)
 }
 
 describe('addWorktreeOp', () => {
@@ -222,6 +229,60 @@ describe('addWorktreeOp', () => {
 })
 
 describe('removeWorktreeOp', () => {
+  it('refuses SSH worktree removal when the worktree listing fails', async () => {
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        throw new Error('git worktree list failed')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+    ).rejects.toThrow('git worktree list failed')
+    expectWorktreeRemoveNotInvoked(git)
+  })
+
+  it('refuses SSH worktree removal when a successful listing is empty', async () => {
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { stdout: '', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+    ).rejects.toSatisfy(isWorktreeCatalogUnavailableError)
+    expectWorktreeRemoveNotInvoked(git)
+  })
+
+  it('refuses SSH worktree removal when the target is absent from the catalog', async () => {
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          stdout: worktreeList({ path: '/repo', branch: 'main' }),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+    ).rejects.toThrow('Refusing to delete unregistered worktree path: /repo-feature')
+    expectWorktreeRemoveNotInvoked(git)
+  })
+
   it('rejects a locked SSH worktree before invoking remove', async () => {
     const git = vi.fn<GitExec>(async (args) => {
       if (args[0] === 'rev-parse') {

--- a/src/relay/git-handler-worktree-remove.ts
+++ b/src/relay/git-handler-worktree-remove.ts
@@ -1,11 +1,12 @@
 import * as path from 'node:path'
+import type { GitCapabilityCache } from '../shared/git-capability-cache'
 import type { RemoveWorktreeResult } from '../shared/worktree/create-types'
 import { assertWorktreeUnlockedForRemoval } from '../shared/worktree/removal'
 import { isSubmoduleWorktreeRemovalRefusal } from '../shared/worktree/submodule-removal'
+import { assertAuthoritativeWorktreeCatalog } from '../shared/worktree/worktree-catalog-availability'
 import { deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure } from './git-handler-branch-cleanup'
 import type { GitExec } from './git-handler-ops'
-import type { GitCapabilityCache } from '../shared/git-capability-cache'
-import { readRelayWorktreeList } from './git-handler-worktree-list'
+import { readRelayWorktreeList, type RelayWorktreeInfo } from './git-handler-worktree-list'
 
 function getErrorText(error: unknown): string {
   if (typeof error === 'object' && error !== null) {
@@ -76,11 +77,9 @@ async function listRelayWorktreesForRemoval(
   repoPath: string,
   capabilities: GitCapabilityCache
 ) {
-  try {
-    return await readRelayWorktreeList(git, repoPath, capabilities)
-  } catch {
-    return []
-  }
+  const worktrees = await readRelayWorktreeList(git, repoPath, capabilities)
+  // Why: Git still lists the repo checkout; a successful [] is "could not ask", not "target gone".
+  return assertAuthoritativeWorktreeCatalog<RelayWorktreeInfo>(worktrees, repoPath)
 }
 
 async function deleteRelayBranchAfterWorktreeRemoval(
@@ -147,8 +146,11 @@ export async function removeWorktreeOp(
   const removedWorktree = worktreesBeforeRemoval.find((worktree) =>
     areRelayWorktreePathsEqual(worktree.path, worktreePath)
   )
-  const branchName = normalizeLocalBranchRef(removedWorktree?.branch ?? '')
-  const branchHead = removedWorktree?.head ?? ''
+  if (!removedWorktree) {
+    throw new Error(`Refusing to delete unregistered worktree path: ${worktreePath}`)
+  }
+  const branchName = normalizeLocalBranchRef(removedWorktree.branch ?? '')
+  const branchHead = removedWorktree.head ?? ''
 
   assertWorktreeUnlockedForRemoval(removedWorktree)
 


### PR DESCRIPTION
## ELI5

If Orca cannot see the SSH Git worktree catalog, it must not pretend the worktree is unlocked and delete it. A missing listing is “I could not ask,” not “go ahead and remove.”

## What Changed

Relay `git.worktree.remove` no longer swallows a failed `git worktree list` as `[]`. The listing error now fails the removal. A successful empty catalog is treated as unavailable (Git always lists the repo checkout). A successful listing that does not contain the target path is refused as unregistered. Locked rows still fail before `git worktree remove`.

## Why

A swallowed list failure left `removedWorktree` undefined. `assertWorktreeUnlockedForRemoval(undefined)` is a no-op (`if (worktree?.locked)`), so Orca skipped the locked-worktree contract and branch-preservation identity, then still ran `git worktree remove`. Git might refuse a lock; Orca must refuse too.

## Focused fix

- In scope: relay worktree-remove listing fail-closed + regression tests
- Out of scope: local `listWorktreeGraph` lenient `[]` (#14003), missing SSH provider (Plan 005), `--force` Git semantics, new opcodes

## Preserves

- Locked worktrees still block removal, including when the caller passed `force`
- Branch-preservation identity (`branchName` / `branchHead`) is taken only from a catalog row
- SSH host still owns `git worktree remove`; there is no client-side fallback
- Mixed-version wire: existing `git.removeWorktree` RPC only; no new opcode

## Evidence

- Test: `pnpm test src/relay/git-handler-worktree-ops.test.ts src/relay/git-handler-worktree-paths.test.ts src/relay/git-handler-branch-cleanup.test.ts`
- 35 passed (3 new fail-closed cases: list throw, empty catalog, missing row; existing locked case still blocks remove)
- `pnpm tc:node`
- `ORCA_CODE_QUALITY_BASE=upstream/main pnpm run check:code-quality:changed` — 0 findings
- Before: `catch { return [] }` → undefined row → unlock no-op → `git worktree remove`
- After: list errors and empty catalogs throw; missing rows throw; remove argv is not issued

## User-regression-tradeoffs

SSH delete now fails closed when the host cannot list worktrees. Users must retry once listing works instead of deleting blindly. That is the intended safety tradeoff.

## Linked Issue

Fixes #18274

## Visual Proof

N/A — SSH relay git-handler behavior; no UI change.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally

Relay unit tests with a fake `git` function cover list failure, empty catalog, missing row, and the existing locked-row path. Happy-path remove + branch cleanup tests still pass.

## AI Disclosure

Assisted by Grok (xAI) for implementation against the issue plan. Human-reviewed before opening.

## Review

Fail-closed listing on SSH remove. Please check that empty `[]` is catalog-unavailable rather than “not found,” and that locked rows still reject before `git worktree remove`.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
