### PR TITLE
test(daemon): stop assuming POSIX endpoints and cwds

### DIFF
--- a/src/main/daemon/daemon-preflight-client-replacement.test.ts
+++ b/src/main/daemon/daemon-preflight-client-replacement.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { DaemonClient } from './client'
 import { DaemonServer } from './daemon-server'
+import { getDaemonSocketPath } from './daemon-spawner'
 import { encodeNdjson } from './ndjson'
 import { PROTOCOL_VERSION } from './types'
 import type { SubprocessHandle } from './session-subprocess-handle'
@@ -72,7 +73,7 @@ describe('daemon preflight client replacement', () => {
     })
     const preparePtySpawn = vi.fn(() => preparation)
     const spawnSubprocess = vi.fn(() => createMockSubprocess())
-    const socketPath = join(dir, 'daemon.sock')
+    const socketPath = getDaemonSocketPath(dir)
     const tokenPath = join(dir, 'daemon.token')
     server = new DaemonServer({ socketPath, tokenPath, preparePtySpawn, spawnSubprocess })
     await server.start()
@@ -111,7 +112,7 @@ describe('daemon preflight client replacement', () => {
     })
     const preparePtySpawn = vi.fn(() => preparation)
     const spawnSubprocess = vi.fn(() => createMockSubprocess())
-    const socketPath = join(dir, 'daemon.sock')
+    const socketPath = getDaemonSocketPath(dir)
     const tokenPath = join(dir, 'daemon.token')
     server = new DaemonServer({ socketPath, tokenPath, preparePtySpawn, spawnSubprocess })
     await server.start()

--- a/src/main/daemon/pty-subprocess-cwd-cancel-identity.test.ts
+++ b/src/main/daemon/pty-subprocess-cwd-cancel-identity.test.ts
@@ -50,7 +50,7 @@ vi.mock('../providers/windows-pty-job-membership', () => ({
 import { createPtySubprocess } from './pty-subprocess'
 import { TerminalAttachCanceledError } from './daemon-errors'
 import { WorkingDirectoryValidationAbortedError } from '../providers/working-directory-validation'
-import { useDaemonPtySubprocessEnv } from './pty-subprocess-test-harness'
+import { platformNativePtyCwd, useDaemonPtySubprocessEnv } from './pty-subprocess-test-harness'
 
 describe('createPtySubprocess cwd cancellation identity', () => {
   useDaemonPtySubprocessEnv({
@@ -62,8 +62,9 @@ describe('createPtySubprocess cwd cancellation identity', () => {
   })
 
   it('reports a canceled cwd probe as an attach cancellation, not a spawn failure', async () => {
+    const cwd = platformNativePtyCwd('/Volumes/dead/repo', 'C:\\Volumes\\dead\\repo')
     validateWorkingDirectoryAsyncMock.mockRejectedValue(
-      new WorkingDirectoryValidationAbortedError('/Volumes/dead/repo')
+      new WorkingDirectoryValidationAbortedError(cwd)
     )
     const abort = new AbortController()
     abort.abort()
@@ -73,7 +74,7 @@ describe('createPtySubprocess cwd cancellation identity', () => {
         sessionId: 'canceled-cwd-session',
         cols: 80,
         rows: 24,
-        cwd: '/Volumes/dead/repo',
+        cwd,
         cancelSignal: abort.signal
       })
     ).rejects.toThrow(TerminalAttachCanceledError)
@@ -81,8 +82,9 @@ describe('createPtySubprocess cwd cancellation identity', () => {
   })
 
   it('leaves a genuine missing-directory failure alone', async () => {
+    const cwd = platformNativePtyCwd('/gone', 'C:\\gone')
     validateWorkingDirectoryAsyncMock.mockRejectedValue(
-      new Error('Working directory "/gone" does not exist. It may have been deleted.')
+      new Error(`Working directory "${cwd}" does not exist. It may have been deleted.`)
     )
 
     await expect(
@@ -90,7 +92,7 @@ describe('createPtySubprocess cwd cancellation identity', () => {
         sessionId: 'missing-cwd-session',
         cols: 80,
         rows: 24,
-        cwd: '/gone'
+        cwd
       })
     ).rejects.toThrow(/does not exist/)
   })

--- a/src/main/daemon/pty-subprocess-env-inheritance.test.ts
+++ b/src/main/daemon/pty-subprocess-env-inheritance.test.ts
@@ -286,9 +286,10 @@ describe('createPtySubprocess', () => {
 
     const env = spawnMock.mock.calls.at(-1)?.[2].env
     expect(env.ORCA_HISTFILE).toBe(expected)
-    // The wrapping consequence: no inherited value may point a pane at Orca's
-    // ZDOTDIR that the client scoped no history for.
-    expect(env.ORCA_SHELL_FEATURES).toBe(expected === undefined ? undefined : 'history')
+    // Why: history wrapping writes ORCA_SHELL_FEATURES only on the POSIX launch path.
+    expect(env.ORCA_SHELL_FEATURES).toBe(
+      process.platform === 'win32' || expected === undefined ? undefined : 'history'
+    )
   })
 
   it('does not inherit ELECTRON_RUN_AS_NODE from the daemon process env', async () => {

--- a/src/main/daemon/pty-subprocess-test-harness.ts
+++ b/src/main/daemon/pty-subprocess-test-harness.ts
@@ -18,6 +18,11 @@ const ORCA_SHELL_WRAPPER_ENV = [
 ] as const
 export const POWERLEVEL10K_WIZARD_DISABLE_ENV = 'POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD'
 
+/** Win32 preflight only validates explicit native Windows paths (`C:\` or UNC). */
+export function platformNativePtyCwd(posixCwd: string, windowsCwd: string): string {
+  return process.platform === 'win32' ? windowsCwd : posixCwd
+}
+
 /**
  * Makes the daemon look like it is sitting in a deleted cwd, without moving the
  * test process there.

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -81,6 +81,7 @@ import { createPtySubprocess, checkPtySpawnHealth } from './pty-subprocess'
 import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS, PROTOCOL_VERSION } from './types'
 import {
   mockPtyProcess,
+  platformNativePtyCwd,
   POWERLEVEL10K_WIZARD_DISABLE_ENV,
   stubMissingDaemonCwd,
   useDaemonPtySubprocessEnv
@@ -145,6 +146,7 @@ describe('createPtySubprocess', () => {
       sessionId: 'canceled-validation',
       cols: 80,
       rows: 24,
+      cwd: platformNativePtyCwd('/tmp/orca-cwd-fixture', 'C:\\orca-cwd-fixture'),
       isCanceled: () => canceled
     })
     await vi.waitFor(() => expect(validateWorkingDirectoryMock).toHaveBeenCalled())
@@ -170,6 +172,7 @@ describe('createPtySubprocess', () => {
           sessionId: 'test',
           cols: 80,
           rows: 24,
+          cwd: platformNativePtyCwd('/tmp/orca-cwd-fixture', 'C:\\orca-cwd-fixture'),
           env: { SHELL: '/bin/bash' },
           onMacosTccSpawnStrategy
         })


### PR DESCRIPTION
## Description
Daemon vitest suites no longer assume POSIX socket files and POSIX cwds, so the same tests can bind and validate on Windows.

Production already uses named pipes (`getDaemonSocketPath`) and only validates explicit native Windows paths. The tests were still handing `daemon.sock` and `/gone` into those branches.

## Focused fix
- In scope:
  - Build preflight-replacement endpoints with `getDaemonSocketPath(dir)` instead of `join(dir, 'daemon.sock')`.
  - Give cwd-validation fixtures a platform-native path (`C:\…` on win32) so `isNativeWindowsPath` is actually entered.
  - Gate the `ORCA_SHELL_FEATURES` wrapping assertion on platform (POSIX-only launch path).
- Out of scope (explicit):
  - Adding an `os` matrix to `unit-tests.yml`.
  - Product reconnect retries for dead named-pipe respawn (`daemon-pty-adapter-daemon-recovery` §2). That failure is lifecycle, not a POSIX-shaped fixture, and a test-only delay does not help — the single `connect` has already rejected with `ENOENT`.

## Preserves
- Product spawn, endpoint, and reconnect code is unchanged.
- Linux/macOS behavior of these suites is unchanged: Darwin still uses unix sockets and POSIX cwds, and still expects `ORCA_SHELL_FEATURES=history` on the zsh wrapping path.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-preflight-client-replacement.test.ts src/main/daemon/daemon-pty-adapter-daemon-recovery.test.ts src/main/daemon/pty-subprocess.test.ts src/main/daemon/pty-subprocess-cwd-cancel-identity.test.ts src/main/daemon/pty-subprocess-env-inheritance.test.ts`
- Darwin: **73 passed** (5 files).
- Before (Windows): `listen EACCES …\daemon.sock`; cwd-cancel/`validateWorkingDirectoryMock` skipped for `/gone`; `ORCA_SHELL_FEATURES` asserted `'history'` on win32 where the POSIX launch path never writes it.
- After: endpoint matches production named-pipe/unix-socket helper; win32 cwd fixtures are `C:\`-rooted so preflight runs; `ORCA_SHELL_FEATURES` is unset on win32 and `'history'` on POSIX when `ORCA_HISTFILE` is injected.

## User-regression-tradeoffs
- None. Tests only. Windows CI is still Ubuntu-only, so this unblocks local Windows checkouts without claiming a new runner.

## Remaining (issue §2)
`joins a request-path respawn instead of forking a second daemon` still needs product reconnect retry on Windows named-pipe `ENOENT` after server close. Left untouched here.

Fixes #18261
