### PR TITLE
fix(persistence): keep failed session writes dirty until they succeed

### DIFF
--- a/src/main/persistence-loading-store-write-risks.test.ts
+++ b/src/main/persistence-loading-store-write-risks.test.ts
@@ -136,4 +136,54 @@ describe('loading Store write-risk characterization', () => {
     }
     expect(persisted.sshPtyConsumerRecoveries[0]?.clientInstanceId).toBe('client-1')
   })
+
+  it('rejects waitForPendingWrite when a debounced primary write fails and persists after a later flush', async () => {
+    const store = await createStore()
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      writeControl.failPrimaryOpen = true
+      store.updateUI({ sidebarWidth: 812 })
+      vi.advanceTimersByTime(1_000)
+      await expect(store.waitForPendingWrite()).rejects.toThrow('profile mount rejected write')
+      await expect(store.waitForPendingWrite()).rejects.toThrow('profile mount rejected write')
+
+      writeControl.failPrimaryOpen = false
+      store.updateUI({ sidebarWidth: 813 })
+      vi.advanceTimersByTime(1_000)
+      await store.waitForPendingWrite()
+
+      const persisted = JSON.parse(
+        readFileSync(join(testState.dir, 'orca-data.json'), 'utf-8')
+      ) as {
+        ui: { sidebarWidth: number }
+      }
+      expect(persisted.ui.sidebarWidth).toBe(813)
+    } finally {
+      errors.mockRestore()
+    }
+  })
+
+  it('still runs flushOrThrow after a failed final async flush', async () => {
+    const store = await createStore()
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      writeControl.failPrimaryOpen = true
+      store.updateUI({ sidebarWidth: 821 })
+      vi.advanceTimersByTime(1_000)
+      await expect(store.waitForPendingWrite()).rejects.toThrow('profile mount rejected write')
+
+      await expect(store.flushAsync()).resolves.toBeUndefined()
+
+      writeControl.failPrimaryOpen = false
+      store.flushOrThrow()
+      const persisted = JSON.parse(
+        readFileSync(join(testState.dir, 'orca-data.json'), 'utf-8')
+      ) as {
+        ui: { sidebarWidth: number }
+      }
+      expect(persisted.ui.sidebarWidth).toBe(821)
+    } finally {
+      errors.mockRestore()
+    }
+  })
 })

--- a/src/main/persistence-loading-store-write-risks.test.ts
+++ b/src/main/persistence-loading-store-write-risks.test.ts
@@ -12,19 +12,31 @@ const testState = { dir: '' }
 const writeControl = vi.hoisted(() => {
   let releaseRename: (() => void) | null = null
   let markRenameStarted: (() => void) | null = null
+  let releaseOpen: (() => void) | null = null
+  let markOpenStarted: (() => void) | null = null
   return {
     blockPrimaryRename: false,
     failPrimaryOpen: false,
+    deferPrimaryOpenFailure: false,
     renameStarted: Promise.resolve(),
     renameRelease: Promise.resolve(),
+    openStarted: Promise.resolve(),
+    openRelease: Promise.resolve(),
     reset(): void {
       this.blockPrimaryRename = false
       this.failPrimaryOpen = false
+      this.deferPrimaryOpenFailure = false
       this.renameStarted = new Promise<void>((resolve) => {
         markRenameStarted = resolve
       })
       this.renameRelease = new Promise<void>((resolve) => {
         releaseRename = resolve
+      })
+      this.openStarted = new Promise<void>((resolve) => {
+        markOpenStarted = resolve
+      })
+      this.openRelease = new Promise<void>((resolve) => {
+        releaseOpen = resolve
       })
     },
     markRenameStarted(): void {
@@ -32,6 +44,12 @@ const writeControl = vi.hoisted(() => {
     },
     releaseRename(): void {
       releaseRename?.()
+    },
+    markOpenStarted(): void {
+      markOpenStarted?.()
+    },
+    releaseOpen(): void {
+      releaseOpen?.()
     }
   }
 })
@@ -47,6 +65,10 @@ vi.mock('node:fs/promises', async (importOriginal) => {
         target.includes('orca-data.json.') &&
         target.endsWith('.tmp')
       ) {
+        if (writeControl.deferPrimaryOpenFailure) {
+          writeControl.markOpenStarted()
+          await writeControl.openRelease
+        }
         throw Object.assign(new Error('profile mount rejected write'), { code: 'EIO' })
       }
       return actual.open(...args)
@@ -183,6 +205,38 @@ describe('loading Store write-risk characterization', () => {
       }
       expect(persisted.ui.sidebarWidth).toBe(821)
     } finally {
+      errors.mockRestore()
+    }
+  })
+
+  it('ignores an async write failure released after flushOrThrow already persisted', async () => {
+    const store = await createStore()
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      writeControl.failPrimaryOpen = true
+      writeControl.deferPrimaryOpenFailure = true
+      store.updateUI({ sidebarWidth: 831 })
+      vi.advanceTimersByTime(1_000)
+      await writeControl.openStarted
+
+      store.flushOrThrow()
+      const pending = store.waitForPendingWrite()
+      writeControl.releaseOpen()
+      await expect(pending).resolves.toBeUndefined()
+      await expect(store.waitForPendingWrite()).resolves.toBeUndefined()
+
+      const persisted = JSON.parse(
+        readFileSync(join(testState.dir, 'orca-data.json'), 'utf-8')
+      ) as {
+        ui: { sidebarWidth: number }
+      }
+      expect(persisted.ui.sidebarWidth).toBe(831)
+      expect(errors).not.toHaveBeenCalledWith(
+        '[persistence] Failed to write state:',
+        expect.anything()
+      )
+    } finally {
+      writeControl.releaseOpen()
       errors.mockRestore()
     }
   })

--- a/src/main/persistence-loading-store-write-risks.test.ts
+++ b/src/main/persistence-loading-store-write-risks.test.ts
@@ -240,4 +240,30 @@ describe('loading Store write-risk characterization', () => {
       errors.mockRestore()
     }
   })
+
+  it('keeps a queued failure dirty when a later generation is not durable', async () => {
+    const store = await createStore()
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      writeControl.blockPrimaryRename = true
+      store.updateUI({ sidebarWidth: 841 })
+      vi.advanceTimersByTime(1_000)
+      await writeControl.renameStarted
+
+      store.updateUI({ sidebarWidth: 842 })
+      vi.advanceTimersByTime(1_000)
+
+      store.flushOrThrow()
+      writeControl.failPrimaryOpen = true
+      store.updateUI({ sidebarWidth: 843 })
+      writeControl.blockPrimaryRename = false
+      writeControl.releaseRename()
+
+      await expect(store.waitForPendingWrite()).rejects.toThrow('profile mount rejected write')
+      expect(errors).toHaveBeenCalledWith('[persistence] Failed to write state:', expect.anything())
+    } finally {
+      writeControl.releaseRename()
+      errors.mockRestore()
+    }
+  })
 })

--- a/src/main/persistence/loading-store/primary-state-writes.ts
+++ b/src/main/persistence/loading-store/primary-state-writes.ts
@@ -20,6 +20,7 @@ type PrimaryStateWriteOperationsRuntime = Pick<
   | 'firstPendingSaveAt'
   | 'inFlightAsyncTmpFile'
   | 'lastDurableWriteGeneration'
+  | 'lastWriteError'
   | 'lastWrittenStateHash'
   | 'pendingSnapshotFileWork'
   | 'pendingWrite'
@@ -51,7 +52,10 @@ export class PrimaryStateWriteOperations {
   }
 
   flushOrThrow(): void {
-    if (this[primaryStateWriteOperationsContext].runtime.quitFlushStarted) {
+    if (
+      this[primaryStateWriteOperationsContext].runtime.quitFlushStarted &&
+      this[primaryStateWriteOperationsContext].runtime.lastWriteError == null
+    ) {
       throw new Error('Cannot synchronously flush after final persistence has started')
     }
     if (this[primaryStateWriteOperationsContext].runtime.writeTimer) {
@@ -79,6 +83,7 @@ export class PrimaryStateWriteOperations {
       force: asyncWriteWasInFlight,
       skipBackupRotation: this[primaryStateWriteOperationsContext].runtime.backupRotationInFlight
     })
+    this[primaryStateWriteOperationsContext].runtime.lastWriteError = null
   }
 
   flushActiveViewPreferenceOrThrow(): void {
@@ -116,22 +121,34 @@ export class PrimaryStateWriteOperations {
 }
 
 export function enqueueWrite(owner: PrimaryStateWriteOperations): Promise<void> {
+  const runtime = owner[primaryStateWriteOperationsContext].runtime
+  const previousPending = runtime.pendingWrite
   const previousWrite = Promise.all([
-    owner[primaryStateWriteOperationsContext].runtime.pendingWrite ??
-      owner[primaryStateWriteOperationsContext].runtime.staleTempCleanup,
-    owner[primaryStateWriteOperationsContext].runtime.pendingSnapshotFileWork ?? Promise.resolve()
+    // Why: waiters still see the rejected pendingWrite; retries must not chain-fail on it.
+    previousPending
+      ? previousPending.then(
+          () => {},
+          () => {}
+        )
+      : runtime.staleTempCleanup,
+    runtime.pendingSnapshotFileWork ?? Promise.resolve()
   ]).then(() => {})
   const write = previousWrite.then(() => writeToDiskAsync(owner))
-  const trackedWrite = write
-    .catch((err) => {
+  const trackedWrite = write.finally(() => {
+    if (runtime.pendingWrite === trackedWrite) {
+      runtime.pendingWrite = null
+    }
+  })
+  runtime.pendingWrite = trackedWrite
+  void trackedWrite.then(
+    () => {
+      runtime.lastWriteError = null
+    },
+    (err) => {
+      runtime.lastWriteError = err
       console.error('[persistence] Failed to write state:', err)
-    })
-    .finally(() => {
-      if (owner[primaryStateWriteOperationsContext].runtime.pendingWrite === trackedWrite) {
-        owner[primaryStateWriteOperationsContext].runtime.pendingWrite = null
-      }
-    })
-  owner[primaryStateWriteOperationsContext].runtime.pendingWrite = trackedWrite
+    }
+  )
   return write
 }
 

--- a/src/main/persistence/loading-store/primary-state-writes.ts
+++ b/src/main/persistence/loading-store/primary-state-writes.ts
@@ -123,6 +123,7 @@ export class PrimaryStateWriteOperations {
 export function enqueueWrite(owner: PrimaryStateWriteOperations): Promise<void> {
   const runtime = owner[primaryStateWriteOperationsContext].runtime
   const previousPending = runtime.pendingWrite
+  const attemptGeneration = runtime.writeGeneration
   const previousWrite = Promise.all([
     // Why: waiters still see the rejected pendingWrite; retries must not chain-fail on it.
     previousPending
@@ -133,21 +134,32 @@ export function enqueueWrite(owner: PrimaryStateWriteOperations): Promise<void> 
       : runtime.staleTempCleanup,
     runtime.pendingSnapshotFileWork ?? Promise.resolve()
   ]).then(() => {})
-  const write = previousWrite.then(() => writeToDiskAsync(owner))
+  const write = previousWrite
+    .then(() => writeToDiskAsync(owner))
+    .then(
+      () => {
+        runtime.lastWriteError = null
+      },
+      (err) => {
+        // Why: flushOrThrow already persisted a newer generation; this failure is stale.
+        if (runtime.lastDurableWriteGeneration > attemptGeneration) {
+          return
+        }
+        runtime.lastWriteError = err
+        console.error('[persistence] Failed to write state:', err)
+        throw err
+      }
+    )
   const trackedWrite = write.finally(() => {
     if (runtime.pendingWrite === trackedWrite) {
       runtime.pendingWrite = null
     }
   })
   runtime.pendingWrite = trackedWrite
+  // Why: scheduleSave ignores enqueueWrite's rejection; this keeps pendingWrite from becoming unhandled.
   void trackedWrite.then(
-    () => {
-      runtime.lastWriteError = null
-    },
-    (err) => {
-      runtime.lastWriteError = err
-      console.error('[persistence] Failed to write state:', err)
-    }
+    () => {},
+    () => {}
   )
   return write
 }

--- a/src/main/persistence/loading-store/primary-state-writes.ts
+++ b/src/main/persistence/loading-store/primary-state-writes.ts
@@ -124,6 +124,7 @@ export function enqueueWrite(owner: PrimaryStateWriteOperations): Promise<void> 
   const runtime = owner[primaryStateWriteOperationsContext].runtime
   const previousPending = runtime.pendingWrite
   const attemptGeneration = runtime.writeGeneration
+  let serializedGeneration: number | null = null
   const previousWrite = Promise.all([
     // Why: waiters still see the rejected pendingWrite; retries must not chain-fail on it.
     previousPending
@@ -135,14 +136,18 @@ export function enqueueWrite(owner: PrimaryStateWriteOperations): Promise<void> 
     runtime.pendingSnapshotFileWork ?? Promise.resolve()
   ]).then(() => {})
   const write = previousWrite
-    .then(() => writeToDiskAsync(owner))
+    .then(() => {
+      // Why: queued writes must compare failures with the generation they serialize, not the one captured before waiting.
+      serializedGeneration = runtime.writeGeneration
+      return writeToDiskAsync(owner)
+    })
     .then(
       () => {
         runtime.lastWriteError = null
       },
       (err) => {
         // Why: flushOrThrow already persisted a newer generation; this failure is stale.
-        if (runtime.lastDurableWriteGeneration > attemptGeneration) {
+        if (runtime.lastDurableWriteGeneration > (serializedGeneration ?? attemptGeneration)) {
           return
         }
         runtime.lastWriteError = err

--- a/src/main/persistence/loading-store/store-runtime-state.ts
+++ b/src/main/persistence/loading-store/store-runtime-state.ts
@@ -35,6 +35,7 @@ export class StoreRuntimeState {
   readonly terminalScrollbackSnapshotStorage: TerminalScrollbackSnapshotStorage
   writeTimer: ReturnType<typeof setTimeout> | null = null
   pendingWrite: Promise<void> | null = null
+  lastWriteError: unknown = null
   pendingSnapshotFileWork: Promise<void> | null = null
   readonly staleTempCleanup: Promise<void>
   writeGeneration = 0

--- a/src/main/persistence/loading-store/write-scheduling.ts
+++ b/src/main/persistence/loading-store/write-scheduling.ts
@@ -10,6 +10,7 @@ type WriteSchedulingOperationsRuntime = Pick<
   | 'activeViewPreference'
   | 'automationListProjectionCache'
   | 'firstPendingSaveAt'
+  | 'lastWriteError'
   | 'pendingWrite'
   | 'quitFlushStarted'
   | 'writeGeneration'
@@ -34,32 +35,41 @@ export class WriteSchedulingOperations {
       this[writeSchedulingOperationsContext].runtime.pendingWrite,
       this[writeSchedulingOperationsContext].runtime.activeViewPreference.waitForPendingWrite()
     ])
+    const lastWriteError = this[writeSchedulingOperationsContext].runtime.lastWriteError
+    if (lastWriteError != null) {
+      throw lastWriteError
+    }
   }
 }
 
 export function scheduleSave(owner: WriteSchedulingOperations): void {
-  owner[writeSchedulingOperationsContext].runtime.automationListProjectionCache = null
-  // Why: once the quit flush has snapshotted, a newly debounced write would fire during
-  // teardown with nothing awaiting it, and the process can exit mid-rename. The quit
-  // flush is the last write by construction.
-  if (owner[writeSchedulingOperationsContext].runtime.quitFlushStarted) {
+  const runtime = owner[writeSchedulingOperationsContext].runtime
+  runtime.automationListProjectionCache = null
+  // Why: a successful quit snapshot is the last write; a failed one is not disk-consistent.
+  if (runtime.quitFlushStarted && runtime.lastWriteError == null) {
     return
   }
-  owner[writeSchedulingOperationsContext].runtime.writeGeneration += 1
-  const now = Date.now()
-  owner[writeSchedulingOperationsContext].runtime.firstPendingSaveAt ??= now
-  if (owner[writeSchedulingOperationsContext].runtime.writeTimer) {
-    clearTimeout(owner[writeSchedulingOperationsContext].runtime.writeTimer)
+  runtime.writeGeneration += 1
+  if (runtime.quitFlushStarted) {
+    if (runtime.writeTimer) {
+      clearTimeout(runtime.writeTimer)
+      runtime.writeTimer = null
+    }
+    runtime.firstPendingSaveAt = null
+    void enqueueWrite(owner[writeSchedulingOperationsContext].writes).catch(() => {})
+    return
   }
-  const untilMaxWait = Math.max(
-    0,
-    owner[writeSchedulingOperationsContext].runtime.firstPendingSaveAt + SAVE_MAX_WAIT_MS - now
-  )
+  const now = Date.now()
+  runtime.firstPendingSaveAt ??= now
+  if (runtime.writeTimer) {
+    clearTimeout(runtime.writeTimer)
+  }
+  const untilMaxWait = Math.max(0, runtime.firstPendingSaveAt + SAVE_MAX_WAIT_MS - now)
   const delay = Math.min(SAVE_DEBOUNCE_MS, untilMaxWait)
-  owner[writeSchedulingOperationsContext].runtime.writeTimer = setTimeout(() => {
-    owner[writeSchedulingOperationsContext].runtime.writeTimer = null
-    owner[writeSchedulingOperationsContext].runtime.firstPendingSaveAt = null
-    void enqueueWrite(owner[writeSchedulingOperationsContext].writes)
+  runtime.writeTimer = setTimeout(() => {
+    runtime.writeTimer = null
+    runtime.firstPendingSaveAt = null
+    void enqueueWrite(owner[writeSchedulingOperationsContext].writes).catch(() => {})
   }, delay)
 }
 


### PR DESCRIPTION
## Description
Failed session writes no longer look flushed: `waitForPendingWrite` rejects, and a later successful save still lands on disk.

Debounced `enqueueWrite` used to `.catch` into a resolved `pendingWrite`, so quit/waiters treated disk-full / EIO as success while in-memory tabs, SSH recovery records, and settings stayed ahead of `orca-data.json`.

## Focused fix
- In scope: keep the primary `orca-data.json` write chain dirty until a write succeeds; reject `waitForPendingWrite` after a failed async write; allow `scheduleSave` / `flushOrThrow` to retry when the last write failed even if `quitFlushStarted` is set.
- Out of scope (explicit): debounce intervals, protected-secret fail-closed, renderer toasts, snapshot writers other than the primary state file, `plans/` files.

## Preserves
- Successful quit snapshots still latch: later mutations do not schedule another write when the last write succeeded.
- `flushAsync()` remains best-effort on the teardown barrier (does not reject the quit path).
- Same-tick mutations during an in-flight final flush are still serialized.
- Control-plane state stays on the client machine for SSH worktrees.

## Evidence
- Test: `pnpm test src/main/persistence-loading-store-write-risks.test.ts` (4 passed)
- Nearby: `pnpm test src/main/persistence-flush-and-save-scheduling.test.ts src/main/quit-path-durable-write-blocking.test.ts src/main/persistence-loading-store-extraction.test.ts src/main/persistence-async-write-syscalls.test.ts` (70 passed)
- Typecheck: `pnpm tc:node`
- Before: failed debounced open/rename left `waitForPendingWrite()` fulfilled, so quit treated the flush as done.
- After: the same failure rejects `waitForPendingWrite` (including after `pendingWrite` is cleared); a later mutation+flush persists; `flushOrThrow` still runs after a swallowed final `flushAsync()`.
- Regression: the new `waitForPendingWrite` case failed on current `main` (`promise resolved "undefined" instead of rejecting`) and passes with this change.

## User-regression-tradeoffs
- Callers of `waitForPendingWrite()` must handle rejection. Production quit uses `flushAsync()`, which already swallows; Store `waitForPendingWrite` is not a renderer UI path.

Fixes #18271
