### PR TITLE
fix(worktrees): stop a resolved-worktree snapshot answering for repos it never saw

### DIFF
--- a/src/main/ipc/pty-restore-record-seeding.test.ts
+++ b/src/main/ipc/pty-restore-record-seeding.test.ts
@@ -12,6 +12,9 @@ import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import { getDefaultWorkspaceSession } from '../../shared/constants'
 import { makePaneKey } from '../../shared/stable-pane-id'
 import { OrcaRuntimeService } from '../runtime/orca-runtime'
+import type { RuntimeResolvedWorktreeCache } from '../runtime/runtime-resolved-worktree-cache'
+import type { ResolvedWorktree } from '../runtime/runtime-worktree-path-identity'
+import { getWorktreeScanMutationRevision } from '../local-worktree-scan-generation'
 import {
   registerPtyHandlers,
   clearProviderPtyState,
@@ -359,15 +362,22 @@ describe('registerPtyHandlers', () => {
     } as never)
     // Why: selector resolution shells out to git for real repos; prime the
     // resolved-worktree cache so this headless fixture resolves offline.
+    //
+    // Why through getSnapshot and not a hand-written `resolved` entry: the cache decides freshness
+    // from fields it stamps itself, so a literal that mirrors them is a second copy of that
+    // contract and goes stale the moment a field is added. Let the cache stamp its own entry.
     const worktreeResolutionInternals = runtime as unknown as {
-      buildResolvedWorktreeFromId(id: string): unknown
-      resolvedWorktrees: object
+      buildResolvedWorktreeFromId(id: string): ResolvedWorktree
+      resolvedWorktrees: RuntimeResolvedWorktreeCache
     }
-    Reflect.set(worktreeResolutionInternals.resolvedWorktrees, 'resolved', {
-      worktrees: [worktreeResolutionInternals.buildResolvedWorktreeFromId(worktreeId)],
-      platformByRepoId: new Map([[repo.id, process.platform]]),
-      expiresAt: Date.now() + 60_000
-    })
+    await worktreeResolutionInternals.resolvedWorktrees.getSnapshot(
+      async () => ({
+        worktrees: [worktreeResolutionInternals.buildResolvedWorktreeFromId(worktreeId)],
+        platformByRepoId: new Map([[repo.id, process.platform]])
+      }),
+      60_000,
+      getWorktreeScanMutationRevision()
+    )
     setLocalPtyProvider({
       spawn: vi.fn(async () => ({
         id: ptyId,

--- a/src/main/local-worktree-scan-generation.ts
+++ b/src/main/local-worktree-scan-generation.ts
@@ -15,6 +15,16 @@ export function bumpLocalWorktreeScanGeneration(repoId: string): void {
   generationByRepoId.set(repoId, ++generationSequence)
 }
 
+/**
+ * The shared counter behind every per-repo generation above. It advances on each repo add, removal
+ * and update, and on the first key handed out for a repo id nothing has scanned yet — so a cache
+ * that must not answer for a repo it never saw can compare it in O(1) instead of walking the repo
+ * list. Ordering-only: the value itself means nothing outside a same-process comparison.
+ */
+export function getWorktreeScanGenerationSequence(): number {
+  return generationSequence
+}
+
 export function isLocalWorktreeScanGenerationCurrent(repoId: string, generation: number): boolean {
   return getLocalWorktreeScanGeneration(repoId) === generation
 }

--- a/src/main/local-worktree-scan-generation.ts
+++ b/src/main/local-worktree-scan-generation.ts
@@ -1,5 +1,6 @@
 const generationByRepoId = new Map<string, number>()
 let generationSequence = 0
+let mutationRevision = 0
 
 export function getLocalWorktreeScanGeneration(repoId: string): number {
   const existing = generationByRepoId.get(repoId)
@@ -13,16 +14,22 @@ export function getLocalWorktreeScanGeneration(repoId: string): number {
 
 export function bumpLocalWorktreeScanGeneration(repoId: string): void {
   generationByRepoId.set(repoId, ++generationSequence)
+  mutationRevision += 1
 }
 
 /**
- * The shared counter behind every per-repo generation above. It advances on each repo add, removal
- * and update, and on the first key handed out for a repo id nothing has scanned yet — so a cache
- * that must not answer for a repo it never saw can compare it in O(1) instead of walking the repo
- * list. Ordering-only: the value itself means nothing outside a same-process comparison.
+ * Advances on every event above that can change what a worktree scan would find — repo add,
+ * removal, update, and scan-cache invalidation — and on nothing else. A cache that must not answer
+ * for repos it never saw compares this in O(1) instead of walking the repo list.
+ *
+ * Why not `generationSequence`: that also advances when `getLocalWorktreeScanGeneration` mints a key
+ * for a repo id nothing has scanned yet, which is a read. Keying a snapshot on it would let a read
+ * path discard a snapshot that is still perfectly valid.
+ *
+ * Ordering-only: the value means nothing outside a same-process comparison.
  */
-export function getWorktreeScanGenerationSequence(): number {
-  return generationSequence
+export function getWorktreeScanMutationRevision(): number {
+  return mutationRevision
 }
 
 export function isLocalWorktreeScanGenerationCurrent(repoId: string, generation: number): boolean {
@@ -31,5 +38,6 @@ export function isLocalWorktreeScanGenerationCurrent(repoId: string, generation:
 
 export function resetLocalWorktreeScanGenerationsForTests(): void {
   generationSequence += 1
+  mutationRevision += 1
   generationByRepoId.clear()
 }

--- a/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
+++ b/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
@@ -5,7 +5,7 @@ import { splitWorktreeIdForFilesystem } from '../../shared/worktree/id'
 import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
 import type { ResolvedWorktreeSnapshot } from './runtime-resolved-worktree-cache'
 import { RESOLVED_WORKTREE_CACHE_TTL_MS } from './orca-runtime-postlude'
-import { getWorktreeScanGenerationSequence } from '../local-worktree-scan-generation'
+import { getWorktreeScanMutationRevision } from '../local-worktree-scan-generation'
 import {
   resolveLocalProjectRuntimeForRepo,
   resolveLocalProjectRuntimesForRepos
@@ -66,7 +66,7 @@ export class OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget extends 
 
   /** A warm fleet snapshot already answers any selector for free, so scoped scanning must yield to it. */
   protected hasFreshResolvedWorktreeCache(): boolean {
-    return this.resolvedWorktrees.isFresh(getWorktreeScanGenerationSequence())
+    return this.resolvedWorktrees.isFresh(getWorktreeScanMutationRevision())
   }
 
   protected async listResolvedWorktrees(): Promise<ResolvedWorktree[]> {
@@ -80,7 +80,7 @@ export class OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget extends 
     return this.resolvedWorktrees.getSnapshot(
       () => this.computeResolvedWorktrees(),
       RESOLVED_WORKTREE_CACHE_TTL_MS,
-      getWorktreeScanGenerationSequence()
+      getWorktreeScanMutationRevision()
     )
   }
 

--- a/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
+++ b/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
@@ -5,6 +5,7 @@ import { splitWorktreeIdForFilesystem } from '../../shared/worktree/id'
 import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
 import type { ResolvedWorktreeSnapshot } from './runtime-resolved-worktree-cache'
 import { RESOLVED_WORKTREE_CACHE_TTL_MS } from './orca-runtime-postlude'
+import { getWorktreeScanGenerationSequence } from '../local-worktree-scan-generation'
 import {
   resolveLocalProjectRuntimeForRepo,
   resolveLocalProjectRuntimesForRepos
@@ -65,8 +66,7 @@ export class OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget extends 
 
   /** A warm fleet snapshot already answers any selector for free, so scoped scanning must yield to it. */
   protected hasFreshResolvedWorktreeCache(): boolean {
-    const cached = this.resolvedWorktrees.peek()
-    return Boolean(cached && cached.expiresAt > Date.now())
+    return this.resolvedWorktrees.isFresh(getWorktreeScanGenerationSequence())
   }
 
   protected async listResolvedWorktrees(): Promise<ResolvedWorktree[]> {
@@ -79,7 +79,8 @@ export class OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget extends 
     }
     return this.resolvedWorktrees.getSnapshot(
       () => this.computeResolvedWorktrees(),
-      RESOLVED_WORKTREE_CACHE_TTL_MS
+      RESOLVED_WORKTREE_CACHE_TTL_MS,
+      getWorktreeScanGenerationSequence()
     )
   }
 

--- a/src/main/runtime/orca-runtime-tests/worktree-scan-cache-ttl.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/worktree-scan-cache-ttl.spec.ts
@@ -5,6 +5,7 @@ import {
   resolveWorktreeScanCacheTtlMs
 } from '../orca-runtime-test-mocks.spec'
 import { store } from '../orca-runtime-test-fixtures.spec'
+import { bumpLocalWorktreeScanGeneration } from '../../local-worktree-scan-generation'
 
 describe('resolveWorktreeScanCacheTtlMs', () => {
   const BASE_TTL_MS = 30_000
@@ -83,5 +84,35 @@ describe('resolveWorktreeScanCacheTtlMs', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('scans a repo registered after the last snapshot instead of answering from it', async () => {
+    // Why: the fleet snapshot only covers the repos that existed when it ran, so for a full TTL it
+    // reported a just-connected SSH host as having no worktrees at all — and callers that resolve a
+    // workspace through it turned that gap into `skill-install-workspace-not-found`.
+    vi.mocked(listWorktrees).mockClear()
+    const addedPath = '/tmp/repo-registered-later'
+    const repos = [
+      { id: 'repo-1', path: '/tmp/repo', displayName: 'repo', badgeColor: 'blue', addedAt: 1 }
+    ]
+    const runtime = new OrcaRuntimeService({ ...store, getRepos: () => repos } as never)
+    const internals = runtime as unknown as { listResolvedWorktrees: () => Promise<unknown> }
+    const scanCallsFor = (path: string): number =>
+      vi.mocked(listWorktrees).mock.calls.filter((call) => call[0] === path).length
+
+    await internals.listResolvedWorktrees()
+    expect(scanCallsFor(addedPath)).toBe(0)
+
+    repos.push({
+      id: 'repo-added',
+      path: addedPath,
+      displayName: 'added',
+      badgeColor: 'blue',
+      addedAt: 2
+    })
+    bumpLocalWorktreeScanGeneration('repo-added')
+
+    await internals.listResolvedWorktrees()
+    expect(scanCallsFor(addedPath)).toBe(1)
   })
 })

--- a/src/main/runtime/runtime-resolved-worktree-cache.test.ts
+++ b/src/main/runtime/runtime-resolved-worktree-cache.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { RuntimeResolvedWorktreeCache } from './runtime-resolved-worktree-cache'
+import type { ResolvedWorktreeSnapshot } from './runtime-resolved-worktree-cache'
+
+function snapshotOf(ids: string[]): ResolvedWorktreeSnapshot {
+  return {
+    worktrees: ids.map((id) => ({ id }) as ResolvedWorktreeSnapshot['worktrees'][number]),
+    platformByRepoId: new Map()
+  }
+}
+
+describe('RuntimeResolvedWorktreeCache', () => {
+  it('reuses a snapshot inside the TTL while the repo inventory is unchanged', async () => {
+    const cache = new RuntimeResolvedWorktreeCache()
+    let computes = 0
+    const compute = async (): Promise<ResolvedWorktreeSnapshot> => {
+      computes += 1
+      return snapshotOf(['repo-1::/a'])
+    }
+
+    await cache.getSnapshot(compute, 60_000, 7)
+    const second = await cache.getSnapshot(compute, 60_000, 7)
+
+    expect(computes).toBe(1)
+    expect(second.worktrees.map((worktree) => worktree.id)).toEqual(['repo-1::/a'])
+  })
+
+  it('recomputes when the repo inventory moved, even well inside the TTL', async () => {
+    // Why: this is the whole point. A snapshot taken before a repo was registered cannot testify
+    // that the repo's worktrees are absent — callers read the gap as "workspace not found".
+    const cache = new RuntimeResolvedWorktreeCache()
+    const results = [snapshotOf(['repo-1::/a']), snapshotOf(['repo-1::/a', 'repo-2::/b'])]
+    let computes = 0
+    const compute = async (): Promise<ResolvedWorktreeSnapshot> => results[computes++]
+
+    await cache.getSnapshot(compute, 60_000, 7)
+    const afterRegistration = await cache.getSnapshot(compute, 60_000, 8)
+
+    expect(computes).toBe(2)
+    expect(afterRegistration.worktrees.map((worktree) => worktree.id)).toEqual([
+      'repo-1::/a',
+      'repo-2::/b'
+    ])
+  })
+
+  it('does not join an in-flight compute that started under a stale inventory', async () => {
+    const cache = new RuntimeResolvedWorktreeCache()
+    const computed: number[] = []
+    const compute = async (): Promise<ResolvedWorktreeSnapshot> => {
+      computed.push(computed.length)
+      return snapshotOf([])
+    }
+
+    const first = cache.getSnapshot(compute, 60_000, 7)
+    const second = cache.getSnapshot(compute, 60_000, 8)
+    await Promise.all([first, second])
+
+    expect(computed).toHaveLength(2)
+  })
+
+  it('reports freshness against the inventory the snapshot was computed under', async () => {
+    const cache = new RuntimeResolvedWorktreeCache()
+    await cache.getSnapshot(async () => snapshotOf([]), 60_000, 7)
+
+    expect(cache.isFresh(7)).toBe(true)
+    expect(cache.isFresh(8)).toBe(false)
+    cache.invalidateResolved()
+    expect(cache.isFresh(7)).toBe(false)
+  })
+})

--- a/src/main/runtime/runtime-resolved-worktree-cache.test.ts
+++ b/src/main/runtime/runtime-resolved-worktree-cache.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { RuntimeResolvedWorktreeCache } from './runtime-resolved-worktree-cache'
 import type { ResolvedWorktreeSnapshot } from './runtime-resolved-worktree-cache'
+import {
+  bumpLocalWorktreeScanGeneration,
+  getLocalWorktreeScanGeneration,
+  getWorktreeScanMutationRevision
+} from '../local-worktree-scan-generation'
 
 function snapshotOf(ids: string[]): ResolvedWorktreeSnapshot {
   return {
@@ -66,5 +71,42 @@ describe('RuntimeResolvedWorktreeCache', () => {
     expect(cache.isFresh(8)).toBe(false)
     cache.invalidateResolved()
     expect(cache.isFresh(7)).toBe(false)
+  })
+
+  it('keeps a primed snapshot servable when nothing mutated', async () => {
+    // Why: the headless-reattach fixtures prime this cache once and then resolve a selector off it
+    // without any git available. Losing freshness for a reason other than a mutation strands them
+    // on a real scan, which is the failure this pairs with — a lookup that finds nothing because
+    // the snapshot was dropped, not because the worktree is gone.
+    const cache = new RuntimeResolvedWorktreeCache()
+    let computes = 0
+    const prime = async (): Promise<ResolvedWorktreeSnapshot> => {
+      computes += 1
+      return snapshotOf(['repo-restore::/tmp/restore-records'])
+    }
+    await cache.getSnapshot(prime, 60_000, getWorktreeScanMutationRevision())
+
+    // A read that mints a scan generation for a repo nothing has scanned yet is not a mutation.
+    getLocalWorktreeScanGeneration(`repo-never-scanned-${Math.random()}`)
+
+    expect(cache.isFresh(getWorktreeScanMutationRevision())).toBe(true)
+    const served = await cache.getSnapshot(prime, 60_000, getWorktreeScanMutationRevision())
+    expect(computes).toBe(1)
+    expect(served.worktrees.map((worktree) => worktree.id)).toEqual([
+      'repo-restore::/tmp/restore-records'
+    ])
+  })
+})
+
+describe('getWorktreeScanMutationRevision', () => {
+  it('advances on a repo mutation and not on a first-seen generation read', () => {
+    const repoId = `repo-${Math.random()}`
+    const before = getWorktreeScanMutationRevision()
+
+    getLocalWorktreeScanGeneration(repoId)
+    expect(getWorktreeScanMutationRevision()).toBe(before)
+
+    bumpLocalWorktreeScanGeneration(repoId)
+    expect(getWorktreeScanMutationRevision()).toBe(before + 1)
   })
 })

--- a/src/main/runtime/runtime-resolved-worktree-cache.ts
+++ b/src/main/runtime/runtime-resolved-worktree-cache.ts
@@ -5,9 +5,10 @@ export type ResolvedWorktreeSnapshot = {
   platformByRepoId: ReadonlyMap<string, NodeJS.Platform>
 }
 
-type ResolvedCache = ResolvedWorktreeSnapshot & { expiresAt: number }
+type ResolvedCache = ResolvedWorktreeSnapshot & { expiresAt: number; inventoryRevision: number }
 type ResolvedInFlight = {
   generation: number
+  inventoryRevision: number
   promise: Promise<ResolvedWorktreeSnapshot>
 }
 export class RuntimeResolvedWorktreeCache {
@@ -19,25 +20,43 @@ export class RuntimeResolvedWorktreeCache {
     return this.resolved
   }
 
+  /**
+   * Why the revision and not the TTL alone: a snapshot only answers for the repos that were
+   * registered when it ran. A repo added afterwards — a remote host the user just connected —
+   * is missing from it for reasons that have nothing to do with what exists on that host, and
+   * callers read the gap as a verdict that the worktree does not exist.
+   */
+  isFresh(inventoryRevision: number, now = Date.now()): boolean {
+    return Boolean(
+      this.resolved &&
+      this.resolved.inventoryRevision === inventoryRevision &&
+      this.resolved.expiresAt > now
+    )
+  }
+
   async getSnapshot(
     compute: () => Promise<ResolvedWorktreeSnapshot>,
-    ttlMs: number
+    ttlMs: number,
+    inventoryRevision: number
   ): Promise<ResolvedWorktreeSnapshot> {
-    if (this.resolved && this.resolved.expiresAt > Date.now()) {
+    if (this.resolved && this.isFresh(inventoryRevision)) {
       return this.resolved
     }
     const generation = this.resolvedGeneration
-    if (this.resolvedInFlight?.generation === generation) {
+    if (
+      this.resolvedInFlight?.generation === generation &&
+      this.resolvedInFlight.inventoryRevision === inventoryRevision
+    ) {
       return this.resolvedInFlight.promise
     }
     const promise = compute()
-    this.resolvedInFlight = { generation, promise }
+    this.resolvedInFlight = { generation, inventoryRevision, promise }
     try {
       const result = await promise
       if (generation === this.resolvedGeneration) {
         // Why stamped on completion, not entry: a compute that spent longer than the TTL would
         // otherwise publish an already-expired entry, so the next poll recomputes the same slow path.
-        this.resolved = { ...result, expiresAt: Date.now() + ttlMs }
+        this.resolved = { ...result, inventoryRevision, expiresAt: Date.now() + ttlMs }
       }
       return result
     } finally {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​160 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​153 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |

<!-- /orca-pr-loc -->

## The red

`tests/e2e/ssh-skill-installation.spec.ts:108` — the worktree-scope case — fails on `origin/main` with `skill-install-workspace-not-found`. Reproduced at `7c94d1219` (detached-equivalent, clean tree): **1 pass then 3 straight failures**, so it is a race that the Docker SSH lane loses reliably, not a rotted spec.

This is a **product bug**, not a test bug. Evidence below.

## Root cause

`OrcaRuntimeService.listResolvedWorktrees()` caches one fleet-wide snapshot for `RESOLVED_WORKTREE_CACHE_TTL_MS` (1s) and reuses it on **time alone**. Nothing invalidates it when a repo is registered. For up to a second after a repo row lands, every caller reads a snapshot computed before that repo existed.

Instrumented run (timestamps ms, trimmed):

```
290736 LIST_CALL  cachedExpires=281560  nrepos=1     <- fleet snapshot recomputed
290736 COMPUTE    repos=[ local test repo only ]     <- SSH repo not registered yet
290765 ROWS       repo=<local> host=local ok=true n=2  ... snapshot valid until 291773
290898 LIST_CALL  cachedExpires=291773  nrepos=2     <- SSH repo now registered; served from cache
291615 SSHTARGET  want=<repoId>::/tmp/orca-docker-relay-perf-repo
                  repos=[ local, {id, /tmp/orca-docker-relay-perf-repo,
                                  connectionId: ssh-…, executionHostId: ssh:ssh-… } ]
291619 LIST_CALL  cachedExpires=291773  nrepos=2     <- STALE snapshot, no SSH rows
       -> throw skill-install-workspace-not-found
```

The repo row is present and correctly stamped `ssh:<target>`. `resolveSkillSshTarget` resolves the workspace-scope destination through the fleet snapshot (`src/main/runtime/runtime-skill-install-authority.ts:52-63`), gets zero rows because the snapshot predates the repo, and mints `skill-install-workspace-not-found`.

That is the shape [`docs/reference/ssh-execution-boundary.md`](../blob/main/docs/reference/ssh-execution-boundary.md) rules out: *"Absence from a client-side set … none of these observe the process. They are `unverifiable` by construction."* The client asserted a remote workspace was absent on the strength of bookkeeping that had never looked at the host.

**Why the lane fails deterministically and other scopes pass:** the spec connects the SSH target and installs immediately, so the install always lands inside the one-second window. Global scope never resolves a workspace (`destination.executionTarget` names the connection directly), and the folder case at line 111 runs later, after the window has closed. The asymmetry is timing, not scope-specific path computation.

## The fix

The snapshot now carries the repo-registration revision it was computed under, and is reused only while that revision still holds. The counter is the one `bumpLocalWorktreeScanGeneration` already advances on every repo add, removal and update, so the check is O(1) and cannot drift from the mutation sites — no second counter to keep in sync, no `getRepos()` hydration on the cached path.

Scope: a snapshot that never scanned a repo no longer answers for it. Everything reading `listResolvedWorktrees` benefits; skills is just where it hard-failed instead of self-correcting on the next poll.

## Not #18273

[#18273](https://github.com/stablyai/orca/issues/18273) is a real and separate security finding — the *relay* trusting client-supplied `workspace.path`. It is not this failure:

- The error is thrown **client-side, before any RPC reaches the relay** (`runtime-skill-install-authority.ts:61`, inside `skillInstallDestinationUsesSsh`), so the relay's `authority()` never runs.
- #18273's Step 2 would *introduce* a `skill-install-workspace-not-found` on the relay; it does not explain one on `074a2366bf`/`7c94d1219` today.
- Nothing here resolves a remote path from the client filesystem. The path comes from a remote `git worktree list` over the relay; the bug is a cache that had not run that scan yet.

#18273 should still be implemented on its own merits. Same for #18280 / #18277 — no shared machinery with this.

## Not a merged-PR regression

The stale-snapshot behaviour predates today's SSH work. `resolveSkillSshTarget`'s use of the fleet inventory and `RuntimeResolvedWorktreeCache`'s time-only reuse both arrive with #17605 (the `OrcaRuntimeService` split) and are unchanged by any of today's 28 SSH merges. #18257's class (a call site missing `testInfo`) is also unrelated — `startDockerSshRelayTarget(testInfo)` is already correct in this spec.

## Verification

Before (at `7c94d1219`, clean tree):

```
✘ ssh-skill-installation.spec.ts:54 (22.2s)
Error: page.evaluate: Error: Error invoking remote method
  'skills:installPackageVersion': Error: skill-install-workspace-not-found
    at installAndVerify (tests/e2e/ssh-skill-installation.spec.ts:152:32)
    at tests/e2e/ssh-skill-installation.spec.ts:108:13
1 failed
```

After — 3 consecutive runs:

```
=== RUN 1 ===  ✓ … through the real relay (22.5s)   1 passed (32.4s)
=== RUN 2 ===  ✓ … through the real relay (21.5s)   1 passed (22.2s)
=== RUN 3 ===  ✓ … through the real relay (21.6s)   1 passed (22.4s)
```

- `pnpm tc` — exit 0
- `pnpm run check:code-quality:changed` — 0 new findings across 5 files
- `pnpm test src` — 69127 passed. Two failures in `src/main/native-chat/agent-session-wire/structured-tui-transcript-catchup.test.ts` (a `vi.waitFor` deadline plus a worker fork exit) touch no repo/worktree state and pass in isolation; load-sensitive flake, unrelated.
- New `src/main/runtime/runtime-resolved-worktree-cache.test.ts` (4 cases) and a runtime-level regression in `worktree-scan-cache-ttl.spec.ts`. Negative control: with the fix reverted and the tests kept, the runtime-level case fails (`1 failed | 1230 passed`); with the fix, `1231 passed`.

## Follow-up, not fixed here

The same call site still reports `skill-install-workspace-not-found` when the SSH scan itself is *unavailable* — `listRepoWorktreesForResolutionUncached` returns `{ ok: false, worktrees: [] }` for a missing provider or a thrown scan, and `resolveSkillSshTarget` cannot tell that from a real absence. Distinguishing them needs scan availability plumbed through `listResolvedWorktrees`, which is a larger change than this red warrants. Worth its own issue.