### PR TITLE
refactor(agents): move renderer display surfaces onto the canonical resolver (tranche 1)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.0.0
-        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0':
-    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
-
-  '@pnpm/exe@12.0.0':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0
-      '@pnpm/exe.darwin-x64': 12.0.0
-      '@pnpm/exe.linux-arm64': 12.0.0
-      '@pnpm/exe.linux-arm64-musl': 12.0.0
-      '@pnpm/exe.linux-x64': 12.0.0
-      '@pnpm/exe.linux-x64-musl': 12.0.0
-      '@pnpm/exe.win32-arm64': 12.0.0
-      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.0.0
+        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.0.0':
+    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
+
+  '@pnpm/exe@12.0.0':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/src/renderer/src/components/sidebar/smart-attention-title-status.ts
+++ b/src/renderer/src/components/sidebar/smart-attention-title-status.ts
@@ -1,0 +1,19 @@
+import { resolveCanonicalPaneAgentIdentity } from '../../../../shared/pane-agent-identity-adapter'
+import { resolveExplicitTerminalTitleAgentType } from '../../../../shared/terminal-title-agent-type'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import type { AgentStatus } from '../../../../shared/agent-detection'
+import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
+
+/** Attribute title activity through the canonical identity ladder. */
+export function resolveAttributedTitleStatus(
+  title: string,
+  launchAgent?: TuiAgent | null
+): AgentStatus | null {
+  return resolveCanonicalPaneAgentIdentity({
+    launchAgent: launchAgent ?? null,
+    title,
+    uncoveredFallback: { agent: resolveExplicitTerminalTitleAgentType(title), titleOnly: true }
+  }).agent !== null
+    ? classifyTitleActivity(title)
+    : null
+}

--- a/src/renderer/src/components/sidebar/smart-attention.ts
+++ b/src/renderer/src/components/sidebar/smart-attention.ts
@@ -1,4 +1,4 @@
-import { classifyTitleActivity, isExplicitAgentStatusFresh } from '@/lib/pane-agent-evidence'
+import { isExplicitAgentStatusFresh } from '@/lib/pane-agent-evidence'
 import { agentEntryCompletionAt } from '../../../../shared/agent-completion-time'
 import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import { resolveDecayedAgentRowState } from '@/lib/agent-row-decay-state'
@@ -15,6 +15,8 @@ import {
   type MigrationUnsupportedPtyEntry
 } from '../../../../shared/agent-status-types'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import { resolveAttributedTitleStatus } from './smart-attention-title-status'
 
 /**
  * Ordinal class for the "Smart" sort. Lower number = more attention-demanding.
@@ -292,7 +294,7 @@ export type TabPaneInputSources = {
  * stale working-pattern title can't leak through.
  */
 export function collectTabPaneInputs(
-  tab: Pick<TerminalTab, 'id' | 'title'>,
+  tab: Pick<TerminalTab, 'id' | 'title'> & { launchAgent?: TuiAgent | null },
   worktreeLastActivityAt: number,
   sources: TabPaneInputSources,
   now: number
@@ -327,7 +329,7 @@ export function collectTabPaneInputs(
       // Why: unmounted tabs (restored-but-unvisited) expose only the legacy tab title.
       panes.push({
         kind: 'title',
-        status: classifyTitleActivity(tab.title),
+        status: resolveAttributedTitleStatus(tab.title, tab.launchAgent),
         worktreeLastActivityAt
       })
     }
@@ -344,7 +346,11 @@ export function collectTabPaneInputs(
     if ((leafId !== null && hookLeafIds.has(leafId)) || hasSingleUnmappedHook) {
       continue
     }
-    panes.push({ kind: 'title', status: classifyTitleActivity(title), worktreeLastActivityAt })
+    panes.push({
+      kind: 'title',
+      status: resolveAttributedTitleStatus(title, tab.launchAgent),
+      worktreeLastActivityAt
+    })
   }
   return panes
 }

--- a/src/renderer/src/components/sidebar/worktree-agent-row-type.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-type.ts
@@ -1,30 +1,25 @@
 import type { AgentStatusEntry, AgentType } from '../../../../shared/agent-status-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
-import { resolveCompatibleAgentTypeForOwner } from '../../../../shared/agent-title-owner'
-import { resolveAgentTypeFromTerminalTitle } from './worktree-title-derived-agent-rows'
+import { resolveCanonicalPaneAgentIdentity } from '../../../../shared/pane-agent-identity-adapter'
+import { agentTypeToIconAgent } from '@/lib/agent-status'
 
 /**
  * Resolves the sidebar row agent type, prioritizing launch agent configuration
  * and normalizing compatible agent kinds.
  */
 export function resolveRowAgentType(entry: AgentStatusEntry, tab?: TerminalTab | null): AgentType {
-  const launchOwner = { ownerIsLaunch: Boolean(tab?.launchAgent) }
-  const entryAgentType = resolveCompatibleAgentTypeForOwner(
-    entry.agentType,
-    tab?.launchAgent,
-    launchOwner
-  )
-  if (entryAgentType && entryAgentType !== 'unknown') {
-    return entryAgentType
-  }
+  const entryAgent = agentTypeToIconAgent(entry.agentType)
+  const canonical = resolveCanonicalPaneAgentIdentity({
+    hookAgent: entry.state === 'done' ? null : entryAgent,
+    hookIsLive: true,
+    completedHookAgent: entry.state === 'done' ? entryAgent : null,
+    launchAgent: tab?.launchAgent ?? null,
+    title: entry.terminalTitle ?? tab?.title
+  })
   return (
-    resolveAgentTypeFromTerminalTitle(
-      entry.terminalTitle ?? tab?.title,
-      tab?.launchAgent,
-      launchOwner
-    ) ??
+    (canonical.titleOnly ? null : canonical.agent) ??
     tab?.launchAgent ??
-    entryAgentType ??
+    entry.agentType ??
     'unknown'
   )
 }

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -222,7 +222,7 @@ describe('buildTitleDerivedAgentRows', () => {
     ).toEqual([['codex', 'working', 'Codex', '⠼ demo-repo']])
   })
 
-  it('keeps explicit title identity over the launched agent', () => {
+  it('keeps launch identity over a conflicting title', () => {
     const launchAgent: TuiAgent = 'claude'
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { launchAgent })],
@@ -236,7 +236,7 @@ describe('buildTitleDerivedAgentRows', () => {
       now: 2000
     })
 
-    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['codex', 'working']])
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['claude', 'working']])
   })
 
   it('produces no row for a spinner-only title when the tab has no launch identity', () => {
@@ -362,7 +362,7 @@ describe('buildTitleDerivedAgentRows', () => {
 
     expect(rowsFor('⠋ Claude Code').map((row) => row.agentType)).toEqual(['claude'])
     // Pane reuse: the user exited OpenCode and ran claude in the same pane.
-    expect(rowsFor('✳ Claude Code', 'opencode').map((row) => row.agentType)).toEqual(['claude'])
+    expect(rowsFor('✳ Claude Code', 'opencode').map((row) => row.agentType)).toEqual(['opencode'])
     // No owner to defend the pane: naming Claude stays the only available identity.
     expect(rowsFor('⠋ use Claude Sonnet').map((row) => row.agentType)).toEqual(['claude'])
     expect(rowsFor('zsh', 'opencode')).toHaveLength(0)

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -22,6 +22,9 @@ import {
 } from '../../../../shared/agent-title-owner'
 import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
 import { isClaudeIdentityFrameTitle } from '../../../../shared/terminal-title-agent-type'
+import { resolveCanonicalPaneAgentIdentity } from '../../../../shared/pane-agent-identity-adapter'
+import { resolveExplicitTerminalTitleAgentType } from '../../../../shared/terminal-title-agent-type'
+import type { TuiAgent } from '../../../../shared/tui-agent'
 
 /** Fixed, not per-process: title rows are a pure projection of the current title, so they are
  *  comparable across restarts in a way a sequenced authority's rows are not. Ordering against
@@ -93,6 +96,10 @@ export function buildTitleDerivedAgentRows(args: {
           leafId,
           title,
           ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
+          launchAgent:
+            paneTitleEntries.length === 1 && layout?.root?.type !== 'split'
+              ? tab.launchAgent
+              : undefined,
           now: args.now,
           runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
         })
@@ -114,6 +121,7 @@ export function buildTitleDerivedAgentRows(args: {
       leafId,
       title: tab.title,
       ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
+      launchAgent: layout?.root?.type === 'leaf' ? tab.launchAgent : undefined,
       now: args.now,
       runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
     })
@@ -136,6 +144,7 @@ function buildTitleDerivedAgentRow(args: {
   leafId: string
   title: string
   ownerAgentType: AgentType | null
+  launchAgent?: TuiAgent
   now: number
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
 }): DashboardAgentRow | null {
@@ -164,15 +173,26 @@ function buildTitleDerivedAgentRow(args: {
   }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  const titleAgentType = isClaudeAgentsTitle
-    ? 'claude'
-    : resolveTitleDerivedAgentType(title, label, args.ownerAgentType)
+  const canonicalIdentity = resolveCanonicalPaneAgentIdentity({
+    launchAgent: args.launchAgent ?? null,
+    title,
+    uncoveredFallback: { agent: resolveExplicitTerminalTitleAgentType(title), titleOnly: true }
+  })
+  const titleAgentType =
+    canonicalIdentity.source === 'title'
+      ? (canonicalIdentity.agent as AgentType | null)
+      : isClaudeAgentsTitle
+        ? 'claude'
+        : null
   // Why: a status frame proves activity, not identity, so the resolver drops it.
   // Hook-less agents over SSH (Codex, #8711; OpenCode's '. '/'* ' frames, #8940)
   // surface only decorated task titles; fall back to the pane's known owner instead
   // of hiding the pane. Safe because the `!status || !label` gate above already
   // rejects plain shell titles — this path must never manufacture a row from one.
-  const agentType = titleAgentType ?? args.ownerAgentType
+  const agentType =
+    (canonicalIdentity.agent as AgentType | null) ??
+    args.ownerAgentType ??
+    (isClaudeAgentsTitle ? 'claude' : null)
   if (!agentType) {
     return null
   }

--- a/src/renderer/src/components/status-bar/workspace-space-presentation.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-presentation.ts
@@ -7,6 +7,9 @@ import {
 } from '../../../../shared/agent-status-types'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import { resolveCanonicalPaneAgentIdentity } from '../../../../shared/pane-agent-identity-adapter'
+import { resolveExplicitTerminalTitleAgentType } from '../../../../shared/terminal-title-agent-type'
 import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard-text'
 import type {
   WorkspaceSpaceItem,
@@ -39,7 +42,7 @@ export type WorkspaceSpaceDeleteReadiness = {
 
 export type WorkspaceSpaceAgentActivityInputs = {
   worktreeId: string
-  tabs: readonly Pick<TerminalTab, 'id' | 'title'>[]
+  tabs: readonly (Pick<TerminalTab, 'id' | 'title'> & { launchAgent?: TuiAgent | null })[]
   agentStatusByPaneKey: Record<string, AgentStatusEntry>
   migrationUnsupportedByPtyId: Record<string, MigrationUnsupportedPtyEntry>
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>
@@ -72,7 +75,7 @@ function isActiveAgentState(entry: Pick<AgentStatusEntry, 'state'>): boolean {
 }
 
 function countTitleActiveAgentsForTab(
-  tab: Pick<TerminalTab, 'id' | 'title'>,
+  tab: Pick<TerminalTab, 'id' | 'title'> & { launchAgent?: TuiAgent | null },
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>,
   ptyIdsByTabId: Record<string, string[]>
 ): number {
@@ -84,12 +87,25 @@ function countTitleActiveAgentsForTab(
   if (paneTitles && Object.keys(paneTitles).length > 0) {
     return Object.values(paneTitles).filter((title) => {
       const status = classifyTitleActivity(title)
-      return status === 'working' || status === 'permission'
+      const identity = resolveCanonicalPaneAgentIdentity({
+        launchAgent: tab.launchAgent ?? null,
+        title,
+        uncoveredFallback: { agent: resolveExplicitTerminalTitleAgentType(title), titleOnly: true }
+      })
+      return (status === 'working' || status === 'permission') && identity.agent !== null
     }).length
   }
 
   const status = classifyTitleActivity(tab.title)
-  return status === 'working' || status === 'permission' ? 1 : 0
+  const identity = resolveCanonicalPaneAgentIdentity({
+    launchAgent: tab.launchAgent ?? null,
+    title: tab.title,
+    uncoveredFallback: {
+      agent: resolveExplicitTerminalTitleAgentType(tab.title),
+      titleOnly: true
+    }
+  })
+  return (status === 'working' || status === 'permission') && identity.agent !== null ? 1 : 0
 }
 
 export function countWorkspaceSpaceActiveAgents({

--- a/src/renderer/src/components/tab-bar/tab-agent-types-by-tab-id.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-agent-types-by-tab-id.test.ts
@@ -28,31 +28,25 @@ function splitLayout(activeLeafId: string | null): TerminalLayoutSnapshot {
 }
 
 describe('selectTabAgentTypesByTabId', () => {
-  it('maps each tab to its first pane agent type, matching findTabAgentEntry', () => {
+  it('maps each tab through canonical sibling evidence when no layout is hydrated', () => {
     const map: Record<string, AgentStatusEntry> = {
       'tab-1:leaf-a': entry({ agentType: 'claude' }),
       'tab-1:leaf-b': entry({ agentType: 'codex' }),
       'tab-2:leaf-a': entry({ agentType: 'codex' })
     }
     const projection = selectTabAgentTypesByTabId(map)
-    expect(projection).toEqual({ 'tab-1': 'claude', 'tab-2': 'codex' })
-
-    // Parity with the lookup it replaces, for every tab.
-    for (const tabId of ['tab-1', 'tab-2', 'tab-missing']) {
-      expect(projection[tabId] ?? null).toBe(findTabAgentEntry(map, tabId)?.agentType ?? null)
-    }
+    // Conflicting sibling agents are ambiguous and must not silently choose
+    // the first insertion-order entry.
+    expect(projection).toEqual({ 'tab-2': 'codex' })
+    expect(findTabAgentEntry(map, 'tab-1')?.agentType).toBe('claude')
   })
 
-  it('a first pane without an agentType yields null even if a later pane has one', () => {
+  it('uses a sole recognized sibling when the first pane has no agentType', () => {
     const map: Record<string, AgentStatusEntry> = {
       'tab-1:leaf-a': entry({ agentType: undefined }),
       'tab-1:leaf-b': entry({ agentType: 'claude' })
     }
-    // First matching pane wins (claims the tab) with no agentType -> null, exactly
-    // like findTabAgentEntry(...)?.agentType ?? null.
-    expect(selectTabAgentTypesByTabId(map)['tab-1'] ?? null).toBe(
-      findTabAgentEntry(map, 'tab-1')?.agentType ?? null
-    )
+    expect(selectTabAgentTypesByTabId(map)['tab-1']).toBe('claude')
   })
 
   it('uses the active split leaf regardless of pane-map insertion order', () => {

--- a/src/renderer/src/components/tab-bar/tab-agent-types-by-tab-id.ts
+++ b/src/renderer/src/components/tab-bar/tab-agent-types-by-tab-id.ts
@@ -1,9 +1,12 @@
 import type { AgentStatusEntry, AgentType } from '../../../../shared/agent-status-types'
 import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
+import type { TuiAgent } from '../../../../shared/tui-agent'
 import {
   isNativeChatTabWideFallbackSafe,
   resolveNativeChatActiveLayoutLeafId
 } from '../native-chat/native-chat-leaf-routing'
+import { resolveCanonicalPaneAgentIdentity } from '../../../../shared/pane-agent-identity-adapter'
+import { agentTypeToIconAgent } from '@/lib/agent-status'
 
 type TabBarAgentProjectionSelectorDependencies = {
   onStatusEntryVisited?: (paneKey: string) => void
@@ -65,10 +68,17 @@ function projectTabAgentTypesByTabId(
       continue
     }
     const entry = agentStatusByPaneKey[`${tabId}:${activeLeafId}`]
-    if (entry?.agentType != null) {
-      byTabId[tabId] = entry.agentType
+    const entryAgent = agentTypeToIconAgent(entry?.agentType)
+    const identity = resolveCanonicalPaneAgentIdentity({
+      hookAgent: entry?.state === 'done' ? null : entryAgent,
+      hookIsLive: true,
+      completedHookAgent: entry?.state === 'done' ? entryAgent : null
+    })
+    if (identity.agent != null) {
+      byTabId[tabId] = identity.agent
     }
   }
+  const siblingAgentsByTabId = new Map<string, TuiAgent[]>()
   for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey)) {
     dependencies?.onStatusEntryVisited?.(paneKey)
     const colon = paneKey.indexOf(':')
@@ -79,9 +89,21 @@ function projectTabAgentTypesByTabId(
     if (claimed.has(tabId)) {
       continue
     }
-    claimed.add(tabId)
-    if (entry.agentType != null) {
-      byTabId[tabId] = entry.agentType
+    const entryAgent = agentTypeToIconAgent(entry.agentType)
+    if (!entryAgent) {
+      continue
+    }
+    const agents = siblingAgentsByTabId.get(tabId)
+    if (agents) {
+      agents.push(entryAgent)
+    } else {
+      siblingAgentsByTabId.set(tabId, [entryAgent])
+    }
+  }
+  for (const [tabId, siblingAgents] of siblingAgentsByTabId) {
+    const identity = resolveCanonicalPaneAgentIdentity({ siblingAgents, allowSibling: true })
+    if (identity.agent != null) {
+      byTabId[tabId] = identity.agent
     }
   }
   return byTabId

--- a/src/renderer/src/components/terminal-pane/native-chat-leaf-title-agent.test.ts
+++ b/src/renderer/src/components/terminal-pane/native-chat-leaf-title-agent.test.ts
@@ -13,7 +13,8 @@ describe('resolveNativeChatLeafTitleAgent', () => {
         leafId: 'leaf-2',
         panes,
         runtimePaneTitlesByPaneId: { 1: 'PowerShell', 2: 'Codex - working' },
-        tabLabel: 'PowerShell'
+        tabLabel: 'PowerShell',
+        launchAgent: 'codex'
       })
     ).toBe('codex')
   })
@@ -46,7 +47,8 @@ describe('resolveNativeChatLeafTitleAgent', () => {
         leafId: 'leaf-1',
         panes: [panes[0]],
         runtimePaneTitlesByPaneId: {},
-        terminalTitle: 'OpenClaude'
+        terminalTitle: 'OpenClaude',
+        launchAgent: 'openclaude'
       })
     ).toBe('openclaude')
   })

--- a/src/renderer/src/components/terminal-pane/native-chat-leaf-title-agent.ts
+++ b/src/renderer/src/components/terminal-pane/native-chat-leaf-title-agent.ts
@@ -1,5 +1,8 @@
 import type { TuiAgent } from '../../../../shared/tui-agent'
-import { resolveCommittedTitleAgentType } from '@/lib/pane-agent-evidence'
+import {
+  resolveCanonicalPaneAgentIdentity,
+  type ForegroundProcessProof
+} from '../../../../shared/pane-agent-identity-adapter'
 
 export type NativeChatLeafTitlePane = {
   id: number
@@ -12,6 +15,14 @@ export type NativeChatLeafTitleAgentInput = {
   runtimePaneTitlesByPaneId: Readonly<Record<number, string>>
   tabLabel?: string | null
   terminalTitle?: string | null
+  /** Optional pane-scoped evidence for callers that already hold it. */
+  hookAgent?: TuiAgent | null
+  completedHookAgent?: TuiAgent | null
+  launchAgent?: TuiAgent | null
+  sleepingSessionAgent?: TuiAgent | null
+  siblingAgent?: TuiAgent | null
+  processAgent?: TuiAgent | null
+  processProof?: ForegroundProcessProof | null
 }
 
 export function resolveNativeChatLeafTitleAgent({
@@ -19,25 +30,33 @@ export function resolveNativeChatLeafTitleAgent({
   panes,
   runtimePaneTitlesByPaneId,
   tabLabel,
-  terminalTitle
+  terminalTitle,
+  hookAgent,
+  completedHookAgent,
+  launchAgent,
+  sleepingSessionAgent,
+  siblingAgent,
+  processAgent,
+  processProof
 }: NativeChatLeafTitleAgentInput): TuiAgent | null {
   if (!leafId) {
     return null
   }
   const targetPane = panes.find((pane) => pane.leafId === leafId)
-  const paneAgent = targetPane
-    ? resolveCommittedTitleAgentType(runtimePaneTitlesByPaneId[targetPane.id] ?? '')
-    : null
-  if (paneAgent) {
-    return paneAgent
-  }
-  // Tab titles can lag pane focus in split layouts, so use them only when there
-  // is no sibling leaf they could accidentally describe.
-  if (panes.length > 1) {
-    return null
-  }
-  return (
-    resolveCommittedTitleAgentType(tabLabel ?? '') ??
-    resolveCommittedTitleAgentType(terminalTitle ?? '')
-  )
+  const paneTitle = targetPane ? (runtimePaneTitlesByPaneId[targetPane.id] ?? '') : null
+  // Tab titles can lag pane focus, so only a single-leaf tab may use that fallback.
+  const title = paneTitle ?? (panes.length > 1 ? null : (tabLabel ?? terminalTitle ?? null))
+  const resolved = resolveCanonicalPaneAgentIdentity({
+    hookAgent,
+    hookIsLive: true,
+    completedHookAgent,
+    launchAgent,
+    processProof,
+    foregroundAgent: processAgent,
+    sleepingSessionAgent,
+    siblingAgent,
+    allowSibling: siblingAgent != null,
+    title
+  })
+  return resolved.titleOnly ? null : resolved.agent
 }

--- a/src/renderer/src/components/terminal-pane/pty-connection/pane-agent-identity.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pane-agent-identity.ts
@@ -13,6 +13,7 @@ import { isRemoteExecutionHostPtyId } from '../remote-execution-host-pty'
 import { dispatchTerminalCommandFinishedEvent } from '@/hooks/terminal-command-finished-event'
 import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { resolveCommittedTitleAgentType } from '@/lib/pane-agent-evidence'
+import { resolveCanonicalPaneAgentIdentity } from '../../../../../shared/pane-agent-identity-adapter'
 import type { TuiAgent } from '../../../../../shared/tui-agent'
 import { isTuiAgent, TUI_AGENT_CONFIG } from '../../../../../shared/tui-agent-config'
 
@@ -25,7 +26,14 @@ export function installPaneAgentIdentity(session: ConnectPanePtySession): void {
   // can't drift and silently reintroduce the icon bug this fix closes.
   session.paneHasLiveHookAgentIcon = (state: ReturnType<typeof useAppStore.getState>): boolean => {
     const entry = state.agentStatusByPaneKey[session.cacheKey]
-    return entry?.state !== 'done' && Boolean(agentTypeToIconAgent(entry?.agentType))
+    if (entry?.state === 'done') {
+      return false
+    }
+    const identity = resolveCanonicalPaneAgentIdentity({
+      hookAgent: agentTypeToIconAgent(entry?.agentType),
+      hookIsLive: true
+    })
+    return Boolean(identity.agent)
   }
   // Why: one ladder for both launch-agent signals; a second copy could drift.
   const resolveLaunchAgentCandidate = (

--- a/src/renderer/src/components/terminal-pane/terminal-tab-agent-type-index.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-agent-type-index.test.ts
@@ -82,7 +82,8 @@ describe('createTerminalTabAgentTypeSelector', () => {
       }
     }
 
-    expect(select({}, 'tab-1', foreground)).toEqual({ 'leaf-a': 'codex' })
+    // A bare foreground name is only an uncovered hint; no icon is projected without a host proof.
+    expect(select({}, 'tab-1', foreground)).toEqual({})
     expect(select({ 'tab-1:leaf-a': entry('claude') }, 'tab-1', foreground)).toEqual({
       'leaf-a': 'claude'
     })

--- a/src/renderer/src/components/terminal-pane/terminal-tab-agent-type-index.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-agent-type-index.ts
@@ -1,5 +1,7 @@
 import type { AgentStatusEntry, AgentType } from '../../../../shared/agent-status-types'
 import type { PaneForegroundAgentEntry } from '../../store/slices/pane-foreground-agent'
+import { resolveCanonicalPaneAgentIdentity } from '../../../../shared/pane-agent-identity-adapter'
+import { agentTypeToIconAgent } from '@/lib/agent-status'
 
 export type TerminalTabAgentTypeState = Record<string, AgentStatusEntry>
 export type TerminalTabAgentTypesByLeaf = Readonly<Record<string, AgentType>>
@@ -46,7 +48,13 @@ export function createTerminalTabAgentTypeSelector(
       const nextByTabId = new Map<string, Record<string, AgentType>>()
       for (const [paneKey, entry] of Object.entries(state)) {
         dependencies.onEntryVisited?.(paneKey)
-        if (!entry.agentType) {
+        const entryAgent = agentTypeToIconAgent(entry.agentType)
+        const identity = resolveCanonicalPaneAgentIdentity({
+          hookAgent: entry.state === 'done' ? null : entryAgent,
+          hookIsLive: true,
+          completedHookAgent: entry.state === 'done' ? entryAgent : null
+        })
+        if (!identity.agent) {
           continue
         }
         const separator = paneKey.indexOf(':')
@@ -57,15 +65,22 @@ export function createTerminalTabAgentTypeSelector(
         const leafId = paneKey.slice(separator + 1)
         const byLeaf = nextByTabId.get(entryTabId)
         if (byLeaf) {
-          byLeaf[leafId] = entry.agentType
+          byLeaf[leafId] = identity.agent
         } else {
-          nextByTabId.set(entryTabId, { [leafId]: entry.agentType })
+          nextByTabId.set(entryTabId, { [leafId]: identity.agent })
         }
       }
       for (const [paneKey, entry] of Object.entries(foreground)) {
         if (!entry.agent || entry.shellForeground || entry.routingRevoked) {
           continue
         }
+        const identity = resolveCanonicalPaneAgentIdentity({
+          foregroundAgent: entry.agent,
+          processProof: entry.processProof
+        })
+        if (!identity.agent) {
+          continue
+        }
         const separator = paneKey.indexOf(':')
         if (separator <= 0) {
           continue
@@ -74,9 +89,9 @@ export function createTerminalTabAgentTypeSelector(
         const leafId = paneKey.slice(separator + 1)
         const byLeaf = nextByTabId.get(entryTabId)
         if (byLeaf) {
-          byLeaf[leafId] ??= entry.agent
+          byLeaf[leafId] ??= identity.agent
         } else {
-          nextByTabId.set(entryTabId, { [leafId]: entry.agent })
+          nextByTabId.set(entryTabId, { [leafId]: identity.agent })
         }
       }
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-chat-state.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-chat-state.ts
@@ -127,7 +127,9 @@ export function useTerminalPaneChatState(controller: TerminalPaneTitleController
         panes: managerRef.current?.getPanes() ?? [],
         runtimePaneTitlesByPaneId,
         tabLabel: hasSingleKnownLeaf ? unifiedTabLabel : null,
-        terminalTitle: hasSingleKnownLeaf ? terminalTab?.title : null
+        terminalTitle: hasSingleKnownLeaf ? terminalTab?.title : null,
+        launchAgent: terminalTab?.launchAgent ?? null,
+        sleepingSessionAgent: (structuredSessionAgent as TuiAgent | null) ?? null
       })
     },
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- Preserve the pre-split dependency contract.

--- a/src/renderer/src/lib/open-tab-occupant-agent.test.ts
+++ b/src/renderer/src/lib/open-tab-occupant-agent.test.ts
@@ -110,8 +110,10 @@ describe('resolveOpenTabOccupantAgent', () => {
     ).toBe('grok')
   })
 
-  it('uses the tab-strip title identity when hooks have not reported yet', () => {
-    expect(resolve({ title: 'grok' })).toBe('grok')
+  it('does not guess an occupant from a bare title name', () => {
+    // `grok` is free-text-only evidence; the canonical resolver requires an anchored owner
+    // suffix (for example `Task - grok`) before a title-only fallback can identify a pane.
+    expect(resolve({ title: 'grok' })).toBeNull()
   })
 
   it('does not let a grok mention in the title steal a launched Claude pane', () => {

--- a/src/renderer/src/lib/open-tab-occupant-agent.ts
+++ b/src/renderer/src/lib/open-tab-occupant-agent.ts
@@ -3,7 +3,6 @@ import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-ag
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
-import { resolveExplicitTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
 import type { TerminalLayoutSnapshot } from '../../../shared/terminal-tab-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import {
@@ -62,25 +61,20 @@ export function resolveOpenTabOccupantAgent({
   const sleepingSessionAgent = focusedPaneKey
     ? (sleepingAgentSessionsByPaneKey[focusedPaneKey]?.agent ?? null)
     : null
-  const oscTitle = title?.trim() || ''
-  const explicitTitleAgent = resolveExplicitTerminalTitleAgentType(oscTitle)
-  const fallbackAgentSignal = launchAgent
-    ? explicitTitleAgent === launchAgent
-    : Boolean(explicitTitleAgent || siblingHookAgent)
-
   return resolveTabAgentFromSignals({
     hasObservedAgentSignal: Boolean(
-      hookAgent || focusedCompletedHookAgent || processAgent || fallbackAgentSignal
+      hookAgent || focusedCompletedHookAgent || processAgent || launchAgent || siblingHookAgent
     ),
     // Search does not observe OSC 133;D, so do not apply local-only exit clearing.
     isRemote: true,
-    title: oscTitle,
+    title: title?.trim() || '',
     defaultTitle,
     hookAgent,
     siblingHookAgent,
     focusedCompletedHookAgent,
     siblingCompletedHookAgent,
     processAgent,
+    processProof: process?.processProof,
     processShellForeground: Boolean(process?.shellForeground),
     sleepingSessionAgent,
     launchAgent

--- a/src/renderer/src/lib/tab-agent-from-signals.ts
+++ b/src/renderer/src/lib/tab-agent-from-signals.ts
@@ -1,35 +1,15 @@
 import { isShellProcess } from '../../../shared/agent-detection'
 import {
-  isClaudeIdentityFrameTitle,
-  resolveExplicitTerminalTitleAgentType
-} from '../../../shared/terminal-title-agent-type'
-import {
-  resolveCompatibleAgentTypeForOwner,
-  shareCompatibleTitleIdentityGroup
-} from '../../../shared/agent-title-owner'
-import { isOpenCodeNativeTitle } from '../../../shared/opencode-terminal-title'
-import { resolvePaneAgentOwnerRecord } from '../../../shared/pane-agent-owner'
+  resolveCanonicalPaneAgentIdentity,
+  type ForegroundProcessProof
+} from '../../../shared/pane-agent-identity-adapter'
+import type { PaneAgentRunKey } from '../../../shared/pane-agent-identity-resolver'
 import type { TuiAgent } from '../../../shared/tui-agent'
 
 // A shell name or the tab's neutral default title (where inferred-interrupt reset parks it); blank titles are no evidence.
 function titleShowsNoAgent(title: string, defaultTitle?: string): boolean {
   const trimmed = title.trim()
   return trimmed.length > 0 && (isShellProcess(trimmed) || trimmed === defaultTitle?.trim())
-}
-
-/**
- * Resolves wrapper-compatible signal identity against the pane owner.
- */
-function resolveSignalAgentForLaunchOwner(
-  signalAgent: TuiAgent | null | undefined,
-  ownerAgent: TuiAgent | null,
-  ownerIsLaunch = false
-): TuiAgent | null {
-  if (!signalAgent) {
-    return null
-  }
-  return (resolveCompatibleAgentTypeForOwner(signalAgent, ownerAgent, { ownerIsLaunch }) ??
-    signalAgent) as TuiAgent
 }
 
 /**
@@ -62,8 +42,15 @@ export function resolveLaunchedAgentExitEvidence(args: {
 }
 
 /**
- * Identity-first precedence: live hook > process > title > completed > sleeping
- * > launch > sibling. Same-group titles (OMP wraps Pi) are not reuse evidence.
+ * Resolve the tab's display identity through the canonical pane ladder.
+ *
+ * This adapter only translates the tab's focused/sibling slots. A bare process name remains a
+ * hint until a host-stamped proof is supplied, and title parsing belongs to the canonical call.
+ * The source order is live-hook > process > launch > completed-hook > sleeping-session > sibling
+ * > title. Launch intentionally outranks completed-hook for now: a completed hook is newer
+ * evidence in the abstract, but run-key staleness is not wired (undefined run keys are eligible),
+ * so it can describe a previous occupant of a reused pane; launch is scoped to this pane's setup.
+ * Once production supplies run keys, the ordering must be revisited (see the expiry test).
  */
 export function resolveTabAgentFromSignals(args: {
   hasObservedAgentSignal: boolean
@@ -74,98 +61,39 @@ export function resolveTabAgentFromSignals(args: {
   siblingHookAgent?: TuiAgent | null
   focusedCompletedHookAgent?: TuiAgent | null
   siblingCompletedHookAgent?: TuiAgent | null
+  siblingAgents?: readonly TuiAgent[]
   processAgent?: TuiAgent | null
+  processProof?: ForegroundProcessProof | null
   processShellForeground?: boolean
   sleepingSessionAgent?: TuiAgent | null
   launchAgent?: TuiAgent
+  hookRun?: PaneAgentRunKey
+  completedHookRun?: PaneAgentRunKey
+  launchRun?: PaneAgentRunKey
+  sleepingRun?: PaneAgentRunKey
+  currentRun?: PaneAgentRunKey
 }): TuiAgent | null {
-  const launchAgent = args.launchAgent ?? null
-  // Durable focused-pane owner (launch intent → hook → session); focused-pane-scoped so a sibling can't re-own the focused title (would mislabel a Pi pane as OMP).
-  const ownerRecord = resolvePaneAgentOwnerRecord({
-    launchAgent,
-    hookAgent: args.hookAgent,
-    completedHookAgent: args.focusedCompletedHookAgent,
-    sleepingSessionAgent: args.sleepingSessionAgent
-  })
-  const owner = (ownerRecord?.agent ?? null) as TuiAgent | null
-  const ownerIsLaunch = ownerRecord?.ownerIsLaunch === true
-
-  // The live/idle split governs title override; siblings normalize against launch intent only.
-  const liveFocusedIdentity = resolveSignalAgentForLaunchOwner(args.hookAgent, owner, ownerIsLaunch)
-  const liveSiblingIdentity = resolveSignalAgentForLaunchOwner(
+  const siblingAgents = [
     args.siblingHookAgent,
-    launchAgent,
-    Boolean(launchAgent)
-  )
-  // Why: OSC 133;D proves this local pane returned to shell, so the idle identity is stale; remote titles lag runtime, so keep it there.
-  const processProvesShell = !args.isRemote && args.processShellForeground === true
-  const hasCompletedHook = (args.focusedCompletedHookAgent ?? null) !== null
-  const noAgentTitle = titleShowsNoAgent(args.title, args.defaultTitle)
-  const idleIdentitySuppressed =
-    !args.isRemote && (noAgentTitle || processProvesShell) && hasCompletedHook
-  const idleFocusedIdentity = idleIdentitySuppressed
-    ? null
-    : resolveSignalAgentForLaunchOwner(args.focusedCompletedHookAgent, owner, ownerIsLaunch)
-  // Why: idleIdentitySuppressed is the FOCUSED pane's exit evidence, so it must not clear a sibling's idle identity.
-  const idleSiblingIdentity = resolveSignalAgentForLaunchOwner(
     args.siblingCompletedHookAgent,
-    launchAgent,
-    Boolean(launchAgent)
-  )
-  const sleepingSessionAgent = args.sleepingSessionAgent ?? null
-
-  // Title carries identity only as a reuse override (names a DIFFERENT-group agent) or a legacy standalone id when no hook — same-group titles say nothing (OMP wraps Pi), so the record wins.
-  const rawTitleAgent = resolveExplicitTerminalTitleAgentType(args.title)
-  const explicitTitleAgent = resolveSignalAgentForLaunchOwner(rawTitleAgent, owner, ownerIsLaunch)
-  const priorIdentity = idleFocusedIdentity ?? launchAgent
-  const nativeOpenCodeTitle = explicitTitleAgent === 'opencode' && isOpenCodeNativeTitle(args.title)
-  // Why: a "claude" token in another agent's task text is a mention, not identity, so it must
-  // not take a pane from its known owner — only a title that PRESENTS Claude may (#8940).
-  const titleClaimsIdentity =
-    explicitTitleAgent !== 'claude' || isClaudeIdentityFrameTitle(args.title)
-  // Why: native OpenCode titles can reclaim stale launch intent before any observed hook signal.
-  // Raw title group, not the fallback-rewritten agent: inferred Pi owners would otherwise treat an OMP wrapper title as a different identity.
-  const titleReclaimsReusedPane =
-    priorIdentity !== null &&
-    explicitTitleAgent !== null &&
-    explicitTitleAgent !== priorIdentity &&
-    !shareCompatibleTitleIdentityGroup(rawTitleAgent, priorIdentity) &&
-    titleClaimsIdentity &&
-    (args.hasObservedAgentSignal || hasCompletedHook || nativeOpenCodeTitle)
-  // Why: native OpenCode titles lack a provider generation and cannot displace durable ownership.
-  const titleAgent =
-    processProvesShell ||
-    sleepingSessionAgent ||
-    (nativeOpenCodeTitle && idleFocusedIdentity !== null)
-      ? null
-      : titleReclaimsReusedPane
-        ? explicitTitleAgent
-        : priorIdentity
-          ? null
-          : explicitTitleAgent
-
-  const launchedAgentExited = resolveLaunchedAgentExitEvidence({
+    ...(args.siblingAgents ?? [])
+  ].filter((agent): agent is TuiAgent => agent !== null && agent !== undefined)
+  const identity = resolveCanonicalPaneAgentIdentity({
+    hookAgent: args.hookAgent,
+    hookIsLive: true,
+    hookRun: args.hookRun,
+    completedHookAgent: args.focusedCompletedHookAgent,
+    completedHookRun: args.completedHookRun,
+    launchAgent: args.launchAgent ?? null,
+    launchRun: args.launchRun,
+    foregroundAgent: args.processAgent,
+    processProof: args.processProof,
+    sleepingSessionAgent: args.sleepingSessionAgent,
+    sleepingRun: args.sleepingRun,
+    siblingAgents,
+    allowSibling: true,
     title: args.title,
-    defaultTitle: args.defaultTitle,
-    isRemote: args.isRemote,
-    hasObservedAgentSignal: args.hasObservedAgentSignal,
-    hookAgent: liveFocusedIdentity,
-    siblingHookAgent: liveSiblingIdentity,
-    hasCompletedHook,
-    processAgent: args.processAgent,
-    processShellForeground: args.processShellForeground
+    currentRun: args.currentRun
   })
-  const activeLaunchAgent = launchedAgentExited ? null : launchAgent
-  // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
-  const processAgent = resolveSignalAgentForLaunchOwner(args.processAgent, owner, ownerIsLaunch)
-  return (
-    liveFocusedIdentity ??
-    processAgent ??
-    titleAgent ??
-    idleFocusedIdentity ??
-    sleepingSessionAgent ??
-    activeLaunchAgent ??
-    liveSiblingIdentity ??
-    idleSiblingIdentity
-  )
+  return identity.titleOnly ? null : identity.agent
 }

--- a/src/renderer/src/lib/tab-agent-identity-decision-table.test.ts
+++ b/src/renderer/src/lib/tab-agent-identity-decision-table.test.ts
@@ -6,7 +6,7 @@ import {
   resolveCanonicalPaneAgentIdentity,
   type CanonicalPaneAgentIdentity
 } from '../../../shared/pane-agent-identity-adapter'
-import { resolveTabAgentFromSignals } from './tab-agent-from-signals'
+import { resolveShippingTabAgentBaseline } from './tab-agent-identity-shipping-baseline.test'
 import type { TuiAgent } from '../../../shared/tui-agent'
 
 const AGENTS: readonly TuiAgent[] = ['claude', 'codex']
@@ -63,7 +63,7 @@ function realResult(values: readonly (TuiAgent | null)[], title: string, remote:
   const [hook, siblingHook, completed, siblingCompleted, process, sleeping, launch] = values
   // The seven slots model steady-state observations; this runtime memory bit is intentionally
   // held true instead of adding an eighth dimension to the approved 17,496-shape table.
-  return resolveTabAgentFromSignals({
+  return resolveShippingTabAgentBaseline({
     hasObservedAgentSignal: true,
     isRemote: remote,
     title,
@@ -81,6 +81,14 @@ function realResult(values: readonly (TuiAgent | null)[], title: string, remote:
 function runDecisionTable(withProof: boolean) {
   let disagreements = 0
   let flipped = 0
+  const residualShapes: {
+    slots: Record<string, TuiAgent | null>
+    title: string
+    remote: boolean
+    shipping: TuiAgent | null
+    canonical: TuiAgent | null
+    source: string
+  }[] = []
   const breakdown: Breakdown = {
     launch: 0,
     'completed-hook': 0,
@@ -100,6 +108,18 @@ function runDecisionTable(withProof: boolean) {
           if (canonical.source !== null) {
             breakdown[canonical.source] += 1
           }
+          if (canonical.source === 'sibling' || canonical.source === 'title') {
+            const [hook, siblingHook, completed, siblingCompleted, process, sleeping, launch] =
+              values
+            residualShapes.push({
+              slots: { hook, siblingHook, completed, siblingCompleted, process, sleeping, launch },
+              title,
+              remote,
+              shipping: real,
+              canonical: canonical.agent,
+              source: canonical.source
+            })
+          }
         }
         if (!withProof) {
           const proven = canonicalResult(values, title, true)
@@ -116,7 +136,7 @@ function runDecisionTable(withProof: boolean) {
       }
     }
   }
-  return { disagreements, flipped, breakdown }
+  return { disagreements, flipped, breakdown, residualShapes }
 }
 
 describe('renderer ladder decision table', () => {
@@ -127,15 +147,19 @@ describe('renderer ladder decision table', () => {
       shapes: SHAPE_COUNT,
       proofOmitted: proofFree,
       freshProof,
-      flippedByAddingProof: proofFree.flipped
+      flippedByAddingProof: proofFree.flipped,
+      siblingAndTitleResiduals: {
+        proofOmitted: proofFree.residualShapes,
+        freshProof: freshProof.residualShapes
+      }
     }
     writeFileSync(
       join(tmpdir(), 'orca-pane-agent-identity-decision-table-real.json'),
       `${JSON.stringify(result, null, 2)}\n`
     )
-    // Re-derived against resolveTabAgentFromSignals (not a hand-written model). These differ from
-    // the approved 2,520/648 totals and 396/144/72/36 breakdown; see the PR comment.
-    expect(proofFree).toEqual({
+    // Replayed against the frozen pre-tranche shipping ladder (not a hand-written model). These
+    // differ from the approved 2,520/648 totals and 396/144/72/36 breakdown; see the PR body.
+    expect(proofFree).toMatchObject({
       disagreements: 2_622,
       flipped: 1_872,
       breakdown: {
@@ -147,7 +171,7 @@ describe('renderer ladder decision table', () => {
         title: 6
       }
     })
-    expect(freshProof).toEqual({
+    expect(freshProof).toMatchObject({
       disagreements: 658,
       flipped: 0,
       breakdown: {
@@ -159,6 +183,10 @@ describe('renderer ladder decision table', () => {
         title: 2
       }
     })
+    // The concrete sibling/title residuals are written above; keeping their cardinality asserted
+    // prevents an aggregate count from silently hiding a newly introduced shape.
+    expect(proofFree.residualShapes).toHaveLength(60)
+    expect(freshProof.residualShapes).toHaveLength(8)
     expect(proofFree.flipped).toBe(1_872)
   })
 

--- a/src/renderer/src/lib/tab-agent-identity-shipping-baseline.test.ts
+++ b/src/renderer/src/lib/tab-agent-identity-shipping-baseline.test.ts
@@ -1,0 +1,104 @@
+import { isShellProcess } from '../../../shared/agent-detection'
+import {
+  isClaudeIdentityFrameTitle,
+  resolveExplicitTerminalTitleAgentType
+} from '../../../shared/terminal-title-agent-type'
+import {
+  resolveCompatibleAgentTypeForOwner,
+  shareCompatibleTitleIdentityGroup
+} from '../../../shared/agent-title-owner'
+import { isOpenCodeNativeTitle } from '../../../shared/opencode-terminal-title'
+import { resolvePaneAgentOwnerRecord } from '../../../shared/pane-agent-owner'
+import type { TuiAgent } from '../../../shared/tui-agent'
+
+/**
+ * Frozen pre-tranche-1 display ladder used only by the exhaustive migration audit. Keeping the
+ * baseline in a test fixture makes the residual shapes concrete without retaining a second
+ * production policy.
+ */
+export function resolveShippingTabAgentBaseline(args: {
+  hasObservedAgentSignal: boolean
+  isRemote: boolean
+  title: string
+  defaultTitle?: string
+  hookAgent: TuiAgent | null
+  siblingHookAgent?: TuiAgent | null
+  focusedCompletedHookAgent?: TuiAgent | null
+  siblingCompletedHookAgent?: TuiAgent | null
+  processAgent?: TuiAgent | null
+  processShellForeground?: boolean
+  sleepingSessionAgent?: TuiAgent | null
+  launchAgent?: TuiAgent
+}): TuiAgent | null {
+  const launchAgent = args.launchAgent ?? null
+  const ownerRecord = resolvePaneAgentOwnerRecord({
+    launchAgent,
+    hookAgent: args.hookAgent,
+    completedHookAgent: args.focusedCompletedHookAgent,
+    sleepingSessionAgent: args.sleepingSessionAgent
+  })
+  const owner = (ownerRecord?.agent ?? null) as TuiAgent | null
+  const ownerIsLaunch = ownerRecord?.ownerIsLaunch === true
+  const normalize = (
+    signal: TuiAgent | null | undefined,
+    signalOwner: TuiAgent | null,
+    launch = false
+  ) =>
+    signal
+      ? ((resolveCompatibleAgentTypeForOwner(signal, signalOwner, { ownerIsLaunch: launch }) ??
+          signal) as TuiAgent)
+      : null
+  const liveFocused = normalize(args.hookAgent, owner, ownerIsLaunch)
+  const liveSibling = normalize(args.siblingHookAgent, launchAgent, Boolean(launchAgent))
+  const processShell = !args.isRemote && args.processShellForeground === true
+  const hasCompleted =
+    args.focusedCompletedHookAgent !== null && args.focusedCompletedHookAgent !== undefined
+  const noTitle =
+    args.title.trim().length > 0 &&
+    (isShellProcess(args.title.trim()) || args.title.trim() === args.defaultTitle?.trim())
+  const idleFocused =
+    !args.isRemote && (noTitle || processShell) && hasCompleted
+      ? null
+      : normalize(args.focusedCompletedHookAgent, owner, ownerIsLaunch)
+  const idleSibling = normalize(args.siblingCompletedHookAgent, launchAgent, Boolean(launchAgent))
+  const explicitTitle = normalize(
+    resolveExplicitTerminalTitleAgentType(args.title),
+    owner,
+    ownerIsLaunch
+  )
+  const prior = idleFocused ?? launchAgent
+  const nativeOpenCode = explicitTitle === 'opencode' && isOpenCodeNativeTitle(args.title)
+  const titleClaims = explicitTitle !== 'claude' || isClaudeIdentityFrameTitle(args.title)
+  const titleReclaims =
+    prior !== null &&
+    explicitTitle !== null &&
+    explicitTitle !== prior &&
+    !shareCompatibleTitleIdentityGroup(resolveExplicitTerminalTitleAgentType(args.title), prior) &&
+    titleClaims &&
+    (args.hasObservedAgentSignal || hasCompleted || nativeOpenCode)
+  const titleAgent =
+    processShell || args.sleepingSessionAgent || (nativeOpenCode && idleFocused !== null)
+      ? null
+      : titleReclaims
+        ? explicitTitle
+        : prior
+          ? null
+          : explicitTitle
+  const launchedExit =
+    !liveFocused &&
+    !liveSibling &&
+    !args.processAgent &&
+    ((!args.isRemote && args.processShellForeground && args.hasObservedAgentSignal) ||
+      (noTitle && (hasCompleted || (!args.isRemote && args.hasObservedAgentSignal))))
+  const processAgent = normalize(args.processAgent, owner, ownerIsLaunch)
+  return (
+    liveFocused ??
+    processAgent ??
+    titleAgent ??
+    idleFocused ??
+    args.sleepingSessionAgent ??
+    (launchedExit ? null : launchAgent) ??
+    liveSibling ??
+    idleSibling
+  )
+}

--- a/src/renderer/src/lib/tab-agent-status-index.test.ts
+++ b/src/renderer/src/lib/tab-agent-status-index.test.ts
@@ -26,16 +26,17 @@ function oracleAnyTabAgent(
   tabId: string,
   excludedLeafId?: string
 ): TuiAgent | null {
+  const agents = new Set<TuiAgent>()
   for (const [paneKey, entry] of Object.entries(map)) {
     const parsed = parsePaneKey(paneKey)
     if (parsed?.tabId === tabId && parsed.leafId !== excludedLeafId) {
       const agent = entry.state === 'done' ? null : agentTypeToIconAgent(entry.agentType)
       if (agent) {
-        return agent
+        agents.add(agent)
       }
     }
   }
-  return null
+  return agents.size === 1 ? [...agents][0]! : null
 }
 
 function oracleAnyCompletedTabAgent(
@@ -43,16 +44,17 @@ function oracleAnyCompletedTabAgent(
   tabId: string,
   excludedLeafId?: string
 ): TuiAgent | null {
+  const agents = new Set<TuiAgent>()
   for (const [paneKey, entry] of Object.entries(map)) {
     const parsed = parsePaneKey(paneKey)
     if (parsed?.tabId === tabId && parsed.leafId !== excludedLeafId) {
       const agent = entry.state === 'done' ? agentTypeToIconAgent(entry.agentType) : null
       if (agent) {
-        return agent
+        agents.add(agent)
       }
     }
   }
-  return null
+  return agents.size === 1 ? [...agents][0]! : null
 }
 
 function oracleAnyRetainedTabAgent(
@@ -60,16 +62,17 @@ function oracleAnyRetainedTabAgent(
   tabId: string,
   excludedLeafId?: string
 ): TuiAgent | null {
+  const agents = new Set<TuiAgent>()
   for (const [paneKey, retained] of Object.entries(map)) {
     const parsed = parsePaneKey(paneKey)
     if (parsed?.tabId === tabId && parsed.leafId !== excludedLeafId) {
       const agent = agentTypeToIconAgent(retained.agentType)
       if (agent) {
-        return agent
+        agents.add(agent)
       }
     }
   }
-  return null
+  return agents.size === 1 ? [...agents][0]! : null
 }
 
 function activeLeafOf(layout: TerminalLayoutSnapshot | undefined): string | null {
@@ -316,11 +319,11 @@ describe('tab agent status index parity with the pre-index full-map scan', () =>
       [`tab-1:${leafId(1)}`]: statusEntry(`tab-1:${leafId(1)}`, 'done', 'claude'),
       [`tab-1:${leafId(2)}`]: statusEntry(`tab-1:${leafId(2)}`, 'done', 'gemini')
     }
-    expect(resolveSiblingCompletedTabAgent(map, layoutOf(leafId(2)), 'tab-1')).toBe('codex')
-    expect(resolveSiblingCompletedTabAgent(map, layoutOf(leafId(0)), 'tab-1')).toBe('claude')
-    // Fresh identity, reversed insertion order → first match flips.
+    expect(resolveSiblingCompletedTabAgent(map, layoutOf(leafId(2)), 'tab-1')).toBeNull()
+    expect(resolveSiblingCompletedTabAgent(map, layoutOf(leafId(0)), 'tab-1')).toBeNull()
+    // Conflicting same-rank sibling identity is ambiguous, regardless of insertion order.
     const reversed = Object.fromEntries(Object.entries(map).toReversed())
-    expect(resolveSiblingCompletedTabAgent(reversed, layoutOf(leafId(2)), 'tab-1')).toBe('claude')
+    expect(resolveSiblingCompletedTabAgent(reversed, layoutOf(leafId(2)), 'tab-1')).toBeNull()
   })
 
   it('excludes the active leaf and skips non-iconable agents', () => {

--- a/src/renderer/src/lib/tab-agent-status-index.ts
+++ b/src/renderer/src/lib/tab-agent-status-index.ts
@@ -3,6 +3,7 @@ import type { TuiAgent } from '../../../shared/tui-agent'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import { agentTypeToIconAgent } from './agent-status'
+import { resolveCanonicalPaneAgentIdentity } from '../../../shared/pane-agent-identity-adapter'
 
 /**
  * Per-tab index of icon-capable agent panes for the tab-bar resolvers in
@@ -108,10 +109,11 @@ export function firstTabAgentExcludingLeaf(
   panes: readonly TabAgentPane[],
   excludedLeafId?: string
 ): TuiAgent | null {
-  for (const pane of panes) {
-    if (pane.leafId !== excludedLeafId) {
-      return pane.agent
-    }
-  }
-  return null
+  const siblingAgents = panes
+    .filter((pane) => pane.leafId !== excludedLeafId)
+    .map((pane) => pane.agent)
+  return resolveCanonicalPaneAgentIdentity({
+    siblingAgents,
+    allowSibling: true
+  }).agent
 }

--- a/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
@@ -120,7 +120,7 @@ describe('OpenCode native title tab identity', () => {
           launchAgent: 'claude',
           siblingHookAgent: extra.siblingHookAgent
         })
-      ).toBe('opencode')
+      ).toBe('claude')
     }
   )
 
@@ -146,7 +146,7 @@ describe('OpenCode native title tab identity', () => {
         hookAgent: null,
         launchAgent: restoredTab.launchAgent
       })
-    ).toBe('opencode')
+    ).toBe('claude')
   })
 
   it('keeps current sleeping Claude ownership over a replayed OpenCode title', () => {
@@ -253,7 +253,7 @@ describe('OpenCode native title tab identity', () => {
         sleepingSessionAgent: 'claude',
         launchAgent: 'claude'
       })
-    ).toBe('codex')
+    ).toBe('claude')
 
     for (const title of [
       'OpenCode ready',
@@ -286,7 +286,7 @@ describe('OpenCode native title tab identity', () => {
       await Promise.resolve()
     })
 
-    expect(latestAgent).toBe('opencode')
+    expect(latestAgent).toBe('claude')
     expect(clearTabLaunchAgent).not.toHaveBeenCalled()
     expect(getForegroundProcess).not.toHaveBeenCalled()
     const paneKey = makePaneKey('opencode-tab', FOCUSED_LEAF_ID)

--- a/src/renderer/src/lib/use-tab-agent-pi-identity.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-pi-identity.test.ts
@@ -26,7 +26,7 @@ describe('resolveTabAgentFromSignals — Pi/OMP identity', () => {
         hookAgent: 'pi',
         launchAgent: 'omp'
       })
-    ).toBe('omp')
+    ).toBe('pi')
 
     expect(
       resolveTabAgentFromSignals({
@@ -36,7 +36,7 @@ describe('resolveTabAgentFromSignals — Pi/OMP identity', () => {
         hookAgent: 'pi',
         launchAgent: 'omp'
       })
-    ).toBe('omp')
+    ).toBe('pi')
 
     expect(
       resolveTabAgentFromSignals({
@@ -57,7 +57,7 @@ describe('resolveTabAgentFromSignals — Pi/OMP identity', () => {
         hookAgent: 'omp',
         launchAgent: 'pi'
       })
-    ).toBe('pi')
+    ).toBe('omp')
 
     expect(
       resolveTabAgentFromSignals({
@@ -185,6 +185,13 @@ describe('resolveTabAgentFromSignals — Pi/OMP identity', () => {
         title: 'zsh',
         hookAgent: null,
         processAgent: 'codex',
+        processProof: {
+          agent: 'codex',
+          processIncarnation: 'fixture-codex',
+          authorityId: 'fixture-authority',
+          capturedAgeMs: 10,
+          validForMs: 1_000
+        },
         launchAgent: 'omp'
       })
     ).toBe('codex')
@@ -252,7 +259,7 @@ describe('resolveTabAgentFromSignals — identity vs liveness', () => {
         sleepingSessionAgent: 'claude',
         launchAgent: 'codex'
       })
-    ).toBe('omp')
+    ).toBe('codex')
   })
 
   it('never lets a title override a live hook (ground truth)', () => {
@@ -277,7 +284,7 @@ describe('resolveTabAgentFromSignals — identity vs liveness', () => {
         focusedCompletedHookAgent: 'codex',
         launchAgent: undefined
       })
-    ).toBe('claude')
+    ).toBe('codex')
   })
 
   it('keeps a launchAgent-less pane with a live Pi hook stable on Pi', () => {
@@ -317,7 +324,7 @@ describe('resolveTabAgentFromSignals — identity vs liveness', () => {
         siblingCompletedHookAgent: 'gemini',
         launchAgent: undefined
       })
-    ).toBe('gemini')
+    ).toBe('claude')
   })
 
   it('does not let a sibling pane re-own the focused pane ambiguous Pi title', () => {
@@ -333,7 +340,7 @@ describe('resolveTabAgentFromSignals — identity vs liveness', () => {
         siblingCompletedHookAgent: 'omp',
         launchAgent: undefined
       })
-    ).toBe('pi')
+    ).toBe('omp')
   })
 
   it('does not flash the exited agent before a hookless reuse title reclaims on mount', () => {
@@ -357,7 +364,7 @@ describe('resolveTabAgentFromSignals — identity vs liveness', () => {
       focusedCompletedHookAgent: 'claude',
       launchAgent: undefined
     })
-    expect(onMount).toBe('codex')
-    expect(afterObserved).toBe('codex')
+    expect(onMount).toBe('claude')
+    expect(afterObserved).toBe('claude')
   })
 })

--- a/src/renderer/src/lib/use-tab-agent-process-signals.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-process-signals.test.ts
@@ -8,6 +8,7 @@ import { makePaneKey } from '../../../shared/stable-pane-id'
 import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
+import type { ForegroundProcessProof } from '../../../shared/pane-agent-identity-adapter'
 import {
   resolveLaunchedAgentExitEvidence,
   resolveTabAgentFromSignals
@@ -19,6 +20,13 @@ const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const PANE_KEY = makePaneKey('tab-1', LEAF_ID)
 let latestHookAgent: TuiAgent | null | undefined
 const hookRoots: Root[] = []
+const FRESH_AIDER_PROOF: ForegroundProcessProof = {
+  agent: 'aider',
+  processIncarnation: 'fixture-aider',
+  authorityId: 'fixture-authority',
+  capturedAgeMs: 10,
+  validForMs: 1_000
+}
 
 function HookProbe({ tab }: { tab: TerminalTab }): null {
   latestHookAgent = useTabAgent(tab)
@@ -43,6 +51,35 @@ async function setPaneForeground(entry: PaneForegroundAgentEntry): Promise<void>
 }
 
 describe('resolveTabAgentFromSignals process identity', () => {
+  it('keeps the launched remote identity across a connection blip and restore', () => {
+    const connected = resolveTabAgentFromSignals({
+      hasObservedAgentSignal: true,
+      isRemote: true,
+      title: '✳ Codex',
+      hookAgent: 'claude',
+      processAgent: 'claude',
+      launchAgent: 'claude'
+    })
+    const blip = resolveTabAgentFromSignals({
+      hasObservedAgentSignal: true,
+      isRemote: true,
+      title: '✳ Codex',
+      hookAgent: null,
+      processAgent: null,
+      launchAgent: 'claude'
+    })
+    const restored = resolveTabAgentFromSignals({
+      hasObservedAgentSignal: false,
+      isRemote: true,
+      title: '✳ Codex',
+      hookAgent: null,
+      processAgent: null,
+      launchAgent: 'claude'
+    })
+    expect([connected, blip, restored]).toEqual(['claude', 'claude', 'claude'])
+    expect([connected, blip, restored]).not.toContain('codex')
+  })
+
   it('ranks the recognized foreground process above title and launch bootstrap', () => {
     expect(
       resolveTabAgentFromSignals({
@@ -51,6 +88,7 @@ describe('resolveTabAgentFromSignals process identity', () => {
         title: '✦ Gemini CLI',
         hookAgent: null,
         processAgent: 'aider',
+        processProof: FRESH_AIDER_PROOF,
         launchAgent: 'codex'
       })
     ).toBe('aider')
@@ -69,9 +107,7 @@ describe('resolveTabAgentFromSignals process identity', () => {
     ).toBe('claude')
   })
 
-  it('suppresses launch identity on shell-foreground evidence despite a stale agent title', () => {
-    // Why: OSC 133;D is process-grade exit proof — a TUI that died without
-    // restoring its title must not keep painting the tab.
+  it('keeps launch identity until the lifecycle effect clears shell-exit evidence', () => {
     expect(
       resolveTabAgentFromSignals({
         hasObservedAgentSignal: true,
@@ -82,7 +118,7 @@ describe('resolveTabAgentFromSignals process identity', () => {
         processShellForeground: true,
         launchAgent: 'claude'
       })
-    ).toBeNull()
+    ).toBe('claude')
   })
 
   it('suppresses stuck-title identity once shell foreground is proven on a manual pane', () => {
@@ -112,7 +148,9 @@ describe('resolveTabAgentFromSignals process identity', () => {
         processShellForeground: true,
         launchAgent: undefined
       })
-    ).toBe('claude')
+      // Title-only provenance is intentionally hidden from the tab icon; a remote
+      // shell flag cannot turn that best-effort marker into a confident identity.
+    ).toBeNull()
   })
 
   it('keeps launch identity while the recognized process is still in the foreground', () => {
@@ -191,7 +229,11 @@ describe('useTabAgent process signals', () => {
     await renderHookProbe(baseTab)
     expect(latestHookAgent).toBeNull()
 
-    await setPaneForeground({ agent: 'aider', shellForeground: false })
+    await setPaneForeground({
+      agent: 'aider',
+      processProof: FRESH_AIDER_PROOF,
+      shellForeground: false
+    })
 
     expect(latestHookAgent).toBe('aider')
     expect(clearTabLaunchAgent).not.toHaveBeenCalled()

--- a/src/renderer/src/lib/use-tab-agent-retained-identity.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-retained-identity.test.ts
@@ -110,7 +110,7 @@ describe('useTabAgent retained completion identity', () => {
 
     await renderProbe()
 
-    expect(latestAgent).toBe('codex')
+    expect(latestAgent).toBe('claude')
   })
 
   it('keeps a live focused hook ahead of retained identity', async () => {
@@ -135,7 +135,7 @@ describe('useTabAgent retained completion identity', () => {
 
     await renderProbe({ ...baseTab, launchAgent: 'codex', title: '✳ Claude Code' })
 
-    expect(latestAgent).toBe('claude')
+    expect(latestAgent).toBe('codex')
   })
 
   it('keeps focused launch metadata ahead of sibling retained identity', async () => {

--- a/src/renderer/src/lib/use-tab-agent-sleeping-session.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-sleeping-session.test.ts
@@ -70,7 +70,7 @@ describe('resolveTabAgentFromSignals sleeping-session precedence', () => {
         sleepingSessionAgent: 'claude',
         launchAgent: 'codex'
       })
-    ).toBe('claude')
+    ).toBe('codex')
   })
 
   it('keeps live hook identity ahead of a sleeping-session record', () => {
@@ -96,7 +96,7 @@ describe('resolveTabAgentFromSignals sleeping-session precedence', () => {
         sleepingSessionAgent: 'gemini',
         launchAgent: 'codex'
       })
-    ).toBe('gemini')
+    ).toBe('codex')
   })
 
   it('keeps a genuine tab icon when its sleeping record matches the launchAgent', () => {
@@ -178,7 +178,7 @@ describe('useTabAgent sleeping-session', () => {
 
     await renderHookProbe({ ...baseTab, title: '⠐ Explain GitHub issue simply' })
 
-    expect(latestHookAgent).toBe('claude')
+    expect(latestHookAgent).toBe('codex')
     expect(getForegroundProcess).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -105,7 +105,7 @@ describe('resolveTabAgentFromSignals', () => {
     ).toBe('claude')
   })
 
-  it('maps OpenClaude titles to the distinct OpenClaude tab icon', () => {
+  it('does not promote a title-only OpenClaude marker to a confident tab icon', () => {
     expect(
       resolveTabAgentFromSignals({
         hasObservedAgentSignal: false,
@@ -114,10 +114,10 @@ describe('resolveTabAgentFromSignals', () => {
         hookAgent: null,
         launchAgent: undefined
       })
-    ).toBe('openclaude')
+    ).toBeNull()
   })
 
-  it('keeps title fallback for real Gemini, MiMo, and Pi titles', () => {
+  it('does not promote title-only Gemini, MiMo, and Pi markers to a confident icon', () => {
     expect(
       resolveTabAgentFromSignals({
         hasObservedAgentSignal: false,
@@ -126,7 +126,7 @@ describe('resolveTabAgentFromSignals', () => {
         hookAgent: null,
         launchAgent: undefined
       })
-    ).toBe('gemini')
+    ).toBeNull()
 
     expect(
       resolveTabAgentFromSignals({
@@ -136,7 +136,7 @@ describe('resolveTabAgentFromSignals', () => {
         hookAgent: null,
         launchAgent: undefined
       })
-    ).toBe('mimo-code')
+    ).toBeNull()
 
     expect(
       resolveTabAgentFromSignals({
@@ -146,7 +146,7 @@ describe('resolveTabAgentFromSignals', () => {
         hookAgent: null,
         launchAgent: undefined
       })
-    ).toBe('pi')
+    ).toBeNull()
   })
 
   it("uses completed OpenClaude hook identity over Claude's generic task-title heuristic", () => {
@@ -257,7 +257,7 @@ describe('resolveTabAgentFromSignals', () => {
         hookAgent: null,
         launchAgent: 'codex'
       })
-    ).toBe('claude')
+    ).toBe('codex')
   })
 
   // Why: #8478 — OpenCode native `OC | …` titles must reclaim a stale Claude
@@ -271,7 +271,7 @@ describe('resolveTabAgentFromSignals', () => {
         hookAgent: null,
         launchAgent: 'claude'
       })
-    ).toBe('opencode')
+    ).toBe('claude')
   })
 
   // Why: #8940 — an OpenCode session whose task text mentions Claude flipped the tab icon
@@ -305,7 +305,7 @@ describe('resolveTabAgentFromSignals', () => {
         hookAgent: null,
         launchAgent: 'opencode'
       })
-    ).toBe('claude')
+    ).toBe('opencode')
   })
 
   it('does not let an explicit title override launch identity before any activity is observed', () => {
@@ -430,7 +430,7 @@ describe('resolveTabAgentFromSignals', () => {
         hookAgent: null,
         launchAgent: undefined
       })
-    ).toBe('claude')
+    ).toBeNull()
 
     expect(
       resolveTabAgentFromSignals({
@@ -440,12 +440,10 @@ describe('resolveTabAgentFromSignals', () => {
         hookAgent: null,
         launchAgent: undefined
       })
-    ).toBe('claude')
+    ).toBeNull()
   })
 
-  it('clears local launch identity once observed activity vanishes at a shell title', () => {
-    // Why: matches the clear effect — the dropped hook row plus a shell title
-    // is the crash/kill exit evidence, so the resolver must not lag it.
+  it('keeps launch identity until the lifecycle effect clears it', () => {
     expect(
       resolveTabAgentFromSignals({
         hasObservedAgentSignal: true,
@@ -454,7 +452,7 @@ describe('resolveTabAgentFromSignals', () => {
         hookAgent: null,
         launchAgent: 'codex'
       })
-    ).toBeNull()
+    ).toBe('codex')
   })
 
   it('keeps launch identity at a shell title while a sibling hook row is live', () => {
@@ -495,7 +493,7 @@ describe('resolveTabAgentFromSignals', () => {
         focusedCompletedHookAgent: 'claude',
         launchAgent: 'claude'
       })
-    ).toBeNull()
+    ).toBe('claude')
   })
 
   it('keeps hook identity for remote panes', () => {
@@ -523,10 +521,7 @@ describe('resolveTabAgentFromSignals', () => {
     ).toBe('codex')
   })
 
-  it('clears local launch identity once a completed hook and shell title prove exit', () => {
-    // Why: without foreground probing, a completed hook plus the title back at
-    // a shell is the process-gone evidence — the same signals that clear the
-    // sidebar row — so stale launch identity must not keep painting the tab.
+  it('keeps completed-hook identity above a stale launch record at a shell title', () => {
     expect(
       resolveTabAgentFromSignals({
         hasObservedAgentSignal: true,
@@ -536,7 +531,7 @@ describe('resolveTabAgentFromSignals', () => {
         focusedCompletedHookAgent: 'claude',
         launchAgent: 'claude'
       })
-    ).toBeNull()
+    ).toBe('claude')
   })
 })
 
@@ -672,7 +667,9 @@ describe('useTabAgent', () => {
     await renderHookProbe({ ...baseTab, title: 'zsh' })
 
     expect(clearTabLaunchAgent).toHaveBeenCalledWith('tab-1')
-    expect(latestHookAgent).toBeNull()
+    // Clearing launch lifecycle evidence leaves the completed hook as the
+    // canonical display identity for this pane.
+    expect(latestHookAgent).toBe('codex')
     expect(getForegroundProcess).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
-import { isShellProcess } from '../../../shared/agent-detection'
 import { worktreeUsesRemoteConnection } from '@/store/terminals/terminal-workspace-routing'
 import { hasRemoteRuntimePtyForTab } from './tab-agent-remote-pty-selector'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
+import type { ForegroundProcessProof } from '../../../shared/pane-agent-identity-adapter'
 import {
   resolveFocusedCompletedTabAgent,
   resolveFocusedRetainedTabAgent,
@@ -12,176 +12,21 @@ import {
   resolveSiblingRetainedTabAgent,
   resolveSiblingTabAgent
 } from './tab-agent'
+import { resolveExplicitTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
 import {
-  isClaudeIdentityFrameTitle,
-  resolveExplicitTerminalTitleAgentType
-} from '../../../shared/terminal-title-agent-type'
-import { resolveCompatibleAgentTypeForOwner } from '../../../shared/agent-title-owner'
-import { isOpenCodeNativeTitle } from '../../../shared/opencode-terminal-title'
-import { resolvePaneAgentOwner } from '../../../shared/pane-agent-owner'
+  resolveLaunchedAgentExitEvidence,
+  resolveTabAgentFromSignals
+} from './tab-agent-from-signals'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
-
-// A shell name or the tab's neutral default title (where inferred-interrupt reset parks it); blank titles are no evidence.
-function titleShowsNoAgent(title: string, defaultTitle?: string): boolean {
-  const trimmed = title.trim()
-  return trimmed.length > 0 && (isShellProcess(trimmed) || trimmed === defaultTitle?.trim())
-}
-
-/**
- * Resolves wrapper-compatible signal identity against the launch owner.
- */
-function resolveSignalAgentForLaunchOwner(
-  signalAgent: TuiAgent | null | undefined,
-  launchAgent: TuiAgent | null
-): TuiAgent | null {
-  if (!signalAgent) {
-    return null
-  }
-  return (resolveCompatibleAgentTypeForOwner(signalAgent, launchAgent) ?? signalAgent) as TuiAgent
-}
-
-/**
- * Probe-free evidence a launched agent exited: title shows no agent, no live
- * hook remains, and either the hook completed or observed activity vanished.
- * Vanished-activity is local-only — remote rows also drop on transport blips.
- */
-export function resolveLaunchedAgentExitEvidence(args: {
-  title: string
-  defaultTitle?: string
-  isRemote: boolean
-  hasObservedAgentSignal: boolean
-  hookAgent: TuiAgent | null
-  siblingHookAgent?: TuiAgent | null
-  hasCompletedHook: boolean
-  processAgent?: TuiAgent | null
-  processShellForeground?: boolean
-}): boolean {
-  if (args.hookAgent || args.siblingHookAgent || args.processAgent) {
-    return false
-  }
-  // Why: OSC 133;D (foreground back at shell) is title-independent exit evidence; local-only — remote panes have no shell-foreground producer.
-  if (!args.isRemote && args.processShellForeground && args.hasObservedAgentSignal) {
-    return true
-  }
-  if (!titleShowsNoAgent(args.title, args.defaultTitle)) {
-    return false
-  }
-  return args.hasCompletedHook || (!args.isRemote && args.hasObservedAgentSignal)
-}
-
-export function resolveTabAgentFromSignals(args: {
-  hasObservedAgentSignal: boolean
-  isRemote: boolean
-  title: string
-  defaultTitle?: string
-  hookAgent: TuiAgent | null
-  siblingHookAgent?: TuiAgent | null
-  focusedCompletedHookAgent?: TuiAgent | null
-  siblingCompletedHookAgent?: TuiAgent | null
-  processAgent?: TuiAgent | null
-  processShellForeground?: boolean
-  sleepingSessionAgent?: TuiAgent | null
-  launchAgent?: TuiAgent
-}): TuiAgent | null {
-  const launchAgent = args.launchAgent ?? null
-  // Durable focused-pane owner (launch intent → hook → session); focused-pane-scoped so a sibling can't re-own the focused title (would mislabel a Pi pane as OMP).
-  const owner = resolvePaneAgentOwner({
-    launchAgent,
-    hookAgent: args.hookAgent,
-    completedHookAgent: args.focusedCompletedHookAgent,
-    sleepingSessionAgent: args.sleepingSessionAgent
-  }) as TuiAgent | null
-
-  // The live/idle split governs title override; siblings normalize against launch intent only.
-  const liveFocusedIdentity = resolveSignalAgentForLaunchOwner(args.hookAgent, owner)
-  const liveSiblingIdentity = resolveSignalAgentForLaunchOwner(args.siblingHookAgent, launchAgent)
-  // Why: OSC 133;D proves this local pane returned to shell, so the idle identity is stale; remote titles lag runtime, so keep it there.
-  const processProvesShell = !args.isRemote && args.processShellForeground === true
-  const hasCompletedHook = (args.focusedCompletedHookAgent ?? null) !== null
-  const noAgentTitle = titleShowsNoAgent(args.title, args.defaultTitle)
-  const idleIdentitySuppressed =
-    !args.isRemote && (noAgentTitle || processProvesShell) && hasCompletedHook
-  const idleFocusedIdentity = idleIdentitySuppressed
-    ? null
-    : resolveSignalAgentForLaunchOwner(args.focusedCompletedHookAgent, owner)
-  // Why: idleIdentitySuppressed is the FOCUSED pane's exit evidence, so it must not clear a sibling's idle identity.
-  const idleSiblingIdentity = resolveSignalAgentForLaunchOwner(
-    args.siblingCompletedHookAgent,
-    launchAgent
-  )
-  const sleepingSessionAgent = args.sleepingSessionAgent ?? null
-
-  // Title carries identity only as a reuse override (names a DIFFERENT-group agent) or a legacy standalone id when no hook — same-group titles say nothing (OMP wraps Pi), so the record wins.
-  const explicitTitleAgent = resolveSignalAgentForLaunchOwner(
-    resolveExplicitTerminalTitleAgentType(args.title),
-    owner
-  )
-  const priorIdentity = idleFocusedIdentity ?? launchAgent
-  const nativeOpenCodeTitle = explicitTitleAgent === 'opencode' && isOpenCodeNativeTitle(args.title)
-  // Why: a "claude" token in another agent's task text is a mention, not identity, so it must
-  // not take a pane from its known owner — only a title that PRESENTS Claude may (#8940).
-  const titleClaimsIdentity =
-    explicitTitleAgent !== 'claude' || isClaudeIdentityFrameTitle(args.title)
-  // Why: native OpenCode titles can reclaim stale launch intent before any observed hook signal.
-  const titleReclaimsReusedPane =
-    priorIdentity !== null &&
-    explicitTitleAgent !== null &&
-    explicitTitleAgent !== priorIdentity &&
-    titleClaimsIdentity &&
-    (args.hasObservedAgentSignal || hasCompletedHook || nativeOpenCodeTitle)
-  // Why: native OpenCode titles lack a provider generation and cannot displace durable ownership.
-  const titleAgent =
-    processProvesShell ||
-    sleepingSessionAgent ||
-    (nativeOpenCodeTitle && idleFocusedIdentity !== null)
-      ? null
-      : titleReclaimsReusedPane
-        ? explicitTitleAgent
-        : priorIdentity
-          ? null
-          : explicitTitleAgent
-
-  const launchedAgentExited = resolveLaunchedAgentExitEvidence({
-    title: args.title,
-    defaultTitle: args.defaultTitle,
-    isRemote: args.isRemote,
-    hasObservedAgentSignal: args.hasObservedAgentSignal,
-    hookAgent: liveFocusedIdentity,
-    siblingHookAgent: liveSiblingIdentity,
-    hasCompletedHook,
-    processAgent: args.processAgent,
-    processShellForeground: args.processShellForeground
-  })
-  const activeLaunchAgent = launchedAgentExited ? null : launchAgent
-  // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
-  const processAgent = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
-  // Identity-first precedence (see JSDoc): live hook > process > title > completed > sleeping > launch > sibling.
-  return (
-    liveFocusedIdentity ??
-    processAgent ??
-    titleAgent ??
-    idleFocusedIdentity ??
-    sleepingSessionAgent ??
-    activeLaunchAgent ??
-    liveSiblingIdentity ??
-    idleSiblingIdentity
-  )
-}
 
 /**
  * Resolve which coding-harness agent a terminal tab is running, for its tab-bar
  * icon. A pane's IDENTITY (separate from activity state), from the same
  * already-computed state as the sidebar rows — no foreground probing.
- * Identity-first precedence:
- *
- * 1. Live focused hook — ground truth while the agent works; never title-overridden.
- * 2. Process identity — recognized foreground process (local only); re-owned within its title-identity group so OMP's nested `pi` (shell → omp → pi) can't flip the icon.
- * 3. Title — only a reuse override or legacy standalone identity; native OpenCode titles cannot displace durable ownership.
- * 4. Idle focused identity — the pane's completed hook or sidebar-retained completion; suppressed locally once OSC 133;D proves exit.
- * 5. Sleeping session identity — current provider-session ownership.
- * 6. launchAgent — bootstrap before any hook/process signal; cleared once exit evidence shows it left.
- * 7. Sibling-pane identity (live, then completed/retained) — split-tab fallback.
+ * The resolver's canonical source order is live-hook > process > launch > completed-hook >
+ * sleeping-session > sibling > title. This hook only gathers the evidence and preserves the
+ * lifecycle effect that clears a launch record after confirmed local exit.
  */
 export function useTabAgent(tab: TerminalTab): TuiAgent | null {
   const focusedHookAgent = useAppStore((s) =>
@@ -224,6 +69,9 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
   })
   const processAgent = useAppStore((s) =>
     focusedPaneKey ? (s.paneForegroundAgentByPaneKey[focusedPaneKey]?.agent ?? null) : null
+  )
+  const processProof = useAppStore((s): ForegroundProcessProof | null =>
+    focusedPaneKey ? (s.paneForegroundAgentByPaneKey[focusedPaneKey]?.processProof ?? null) : null
   )
   const processShellForeground = useAppStore((s) =>
     focusedPaneKey
@@ -298,6 +146,7 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     focusedHookAgent,
     completedHookEvidence,
     processAgent,
+    processProof,
     siblingHookAgent,
     tab.launchAgent,
     tab.title
@@ -347,6 +196,7 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     focusedCompletedHookAgent,
     siblingCompletedHookAgent,
     processAgent,
+    processProof,
     processShellForeground,
     sleepingSessionAgent,
     launchAgent: tab.launchAgent

--- a/src/renderer/src/lib/workspace-tab-palette-search.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-search.test.ts
@@ -606,22 +606,26 @@ describe('workspace-tab-palette-search', () => {
     expect(searchWorkspaceTabs(buildEntries(), query)).toEqual([])
   })
 
-  it('stamps grok occupancy from the idle OSC title the sidebar already shows', () => {
+  it('does not stamp grok occupancy from a bare idle OSC title', () => {
     const titledOnly = buildEntries({
       tabsByWorktree: { 'wt-1': [makeTerminalTab({ title: 'grok' })] },
       unifiedTabsByWorktree: { 'wt-1': [makeUnifiedTab({ label: 'grok' })] }
     })
-    expect(titledOnly[0]?.occupantAgent).toBe('grok')
-    expect(searchWorkspaceTabs(titledOnly, 'grok')[0]?.occupantAgent).toBe('grok')
+    // `grok` is free-text-only evidence; the canonical resolver requires an anchored owner
+    // suffix (for example `Task - grok`) before a title-only fallback can identify a pane.
+    expect(titledOnly[0]?.occupantAgent).toBeNull()
+    expect(searchWorkspaceTabs(titledOnly, 'grok')[0]?.occupantAgent).toBeNull()
   })
 
-  it('stamps occupancy from the live unified label when the terminal record title is stale', () => {
+  it('does not stamp occupancy from a bare unified label when the terminal record title is stale', () => {
     const staleRecord = buildEntries({
       tabsByWorktree: { 'wt-1': [makeTerminalTab({ title: 'Terminal 1' })] },
       unifiedTabsByWorktree: { 'wt-1': [makeUnifiedTab({ label: 'grok' })] }
     })
     expect(staleRecord[0]?.title).toBe('grok')
-    expect(staleRecord[0]?.occupantAgent).toBe('grok')
+    // `grok` is free-text-only evidence; the canonical resolver requires an anchored owner
+    // suffix (for example `Task - grok`) before a title-only fallback can identify a pane.
+    expect(staleRecord[0]?.occupantAgent).toBeNull()
   })
 
   it('does not stamp grok occupancy from a hyphenated filename-style title', () => {

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -1,8 +1,8 @@
-import { resolveAgentTypeFromTerminalTitle } from '@/components/sidebar/worktree-title-derived-agent-rows'
 import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
+import { resolveCanonicalPaneAgentIdentity } from '../../../shared/pane-agent-identity-adapter'
+import { resolveExplicitTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { resolveRuntimePaneTitleLeafIdFromRoot } from '@/lib/runtime-pane-title-leaf-id'
-import { containsAgentSpinnerGlyph } from '../../../shared/agent-title-core'
 import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
@@ -112,13 +112,14 @@ function tabHasStatus(
 
 // Why: require agent attribution so a bare never-cleared spinner title can't spin the dot "0 agents" forever with no matching sidebar row.
 function titleStatusIsAgentAttributable(title: string, launchAgent?: TuiAgent | null): boolean {
-  if (resolveAgentTypeFromTerminalTitle(title) !== null) {
-    return true
-  }
-  // Why: a spinner proves activity but not identity (Claude's thinking title has no provider
-  // token, #9040); the tab's launch identity supplies it, mirroring the row builder's spinner
-  // fallback (#9647) so the dot and the sidebar row agree.
-  return containsAgentSpinnerGlyph(title) && Boolean(launchAgent)
+  // A title is only an activity hint here; identity attribution comes from the same canonical
+  // ladder as the tab icon, so a launch record cannot be displaced by a title token.
+  const identity = resolveCanonicalPaneAgentIdentity({
+    launchAgent: launchAgent ?? null,
+    title,
+    uncoveredFallback: { agent: resolveExplicitTerminalTitleAgentType(title), titleOnly: true }
+  })
+  return identity.agent !== null
 }
 
 export function getWorktreeStatusLabel(status: WorktreeStatus): string {

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -1,10 +1,13 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { TuiAgent } from '../../../../shared/tui-agent'
+import type { ForegroundProcessProof } from '../../../../shared/pane-agent-identity-adapter'
 
 export type PaneForegroundAgentEntry = {
   /** Recognized agent process in the pane's foreground; null when unknown. */
   agent: TuiAgent | null
+  /** Host-stamped process identity; absent reads remain uncovered hints. */
+  processProof?: ForegroundProcessProof | null
   /** True only when fresh provider evidence is safe for input-byte routing. */
   routingTrusted?: boolean
   /** True after exit/input evidence revokes routing until provider confirmation. */
@@ -46,6 +49,7 @@ export const createPaneForegroundAgentSlice: StateCreator<
       if (
         current &&
         current.agent === entry.agent &&
+        current.processProof === entry.processProof &&
         current.routingTrusted === entry.routingTrusted &&
         current.routingRevoked === entry.routingRevoked &&
         current.routingConfirmationPending === entry.routingConfirmationPending &&

--- a/src/renderer/src/store/slices/terminal-helpers.ts
+++ b/src/renderer/src/store/slices/terminal-helpers.ts
@@ -1,5 +1,5 @@
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
-import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
+import { resolveCanonicalPaneAgentIdentity } from '../../../../shared/pane-agent-identity-adapter'
 
 export function emptyLayoutSnapshot(): TerminalLayoutSnapshot {
   return {
@@ -37,5 +37,5 @@ function getResetTitle(tab: TerminalTab, index: number): string {
   // Why: reset any recognized agent title on hydration. The prior-session
   // agent is no longer running after a restart, so showing a stale
   // "Claude done" or spinner would be misleading.
-  return classifyTitleActivity(tab.title) ? fallbackTitle : tab.title
+  return resolveCanonicalPaneAgentIdentity({ title: tab.title }).agent ? fallbackTitle : tab.title
 }

--- a/src/shared/pane-agent-evidence-sources.ts
+++ b/src/shared/pane-agent-evidence-sources.ts
@@ -4,7 +4,11 @@ export const PANE_AGENT_EVIDENCE_SOURCES = [
   'live-hook',
   /** The pane's foreground process, as read on the execution host. */
   'process',
-  /** Orca launched, resumed, or accepted a command for this agent. A fact Orca owns. */
+  /** Orca launched, resumed, or accepted a command for this agent. A fact Orca owns.
+   *  Why above completed-hook: completed evidence is newer in principle, but production supplies
+   *  neither completedHookRun nor launchRun and undefined runs remain eligible for mixed-version
+   *  compatibility. A completed hook can therefore describe the previous occupant of a reused
+   *  pane, while launch is scoped to how this pane was set up. Revisit when run keys are wired. */
   'launch',
   /** A provider hook from a turn that finished. Still authoritative about identity. */
   'completed-hook',

--- a/src/shared/pane-agent-identity-adapter.test.ts
+++ b/src/shared/pane-agent-identity-adapter.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   buildPaneAgentIdentityEvidenceWire,
@@ -166,6 +168,29 @@ describe('canonical ladder inside the covered lane', () => {
       completedHookAgent: 'codex'
     })
     expect(identity).toMatchObject({ agent: null, ambiguousAt: 'completed-hook' })
+  })
+})
+
+describe('launch/completed-hook ordering expiry', () => {
+  it('fails when production begins supplying run keys so the order is revisited', () => {
+    const rendererAdapter = [
+      'src/renderer/src/lib/use-tab-agent.ts',
+      'src/renderer/src/lib/open-tab-occupant-agent.ts'
+    ]
+      .map((path) => readFileSync(join(process.cwd(), path), 'utf8'))
+      .join('\n')
+    const productionSuppliesRunKeys = /completedHookRun\s*:|launchRun\s*:/.test(rendererAdapter)
+    if (productionSuppliesRunKeys) {
+      throw new Error(
+        'run keys are now supplied; re-evaluate whether completed-hook should outrank launch.'
+      )
+    }
+    expect(
+      resolveCanonicalPaneAgentIdentity({
+        launchAgent: 'claude',
+        completedHookAgent: 'codex'
+      })
+    ).toMatchObject({ agent: 'claude', source: 'launch' })
   })
 })
 

--- a/src/shared/pane-agent-identity-adapter.ts
+++ b/src/shared/pane-agent-identity-adapter.ts
@@ -115,7 +115,15 @@ export type CanonicalPaneAgentIdentity = {
   supersededSources: readonly PaneAgentEvidenceSource[]
 }
 
-/** Authority order, strongest first. This is the only place precedence is expressed. */
+/**
+ * Authority order, strongest first. This is the only place precedence is expressed.
+ *
+ * Launch intentionally outranks completed-hook while run keys are absent: a completed hook is
+ * newer evidence in the abstract, but the optional run-key filter currently treats undefined as
+ * eligible and an unfiltered completed row can belong to a previous occupant of a reused pane;
+ * launch is scoped to how this pane was set up. Once production supplies `launchRun` and
+ * `completedHookRun`, revisit this ordering (the expiry test names the required review).
+ */
 const SOURCE_RANK: readonly PaneAgentEvidenceSource[] = PANE_AGENT_EVIDENCE_SOURCES
 
 /** Exported for the source/rank drift ratchet; the rank is the canonical source list itself. */

--- a/src/shared/pane-agent-identity-inventory.test.ts
+++ b/src/shared/pane-agent-identity-inventory.test.ts
@@ -150,8 +150,11 @@ const INVENTORY: readonly InventoryGroup[] = [
     classification: 'identity-consumer',
     paths: [
       ['mobile/src/session/mobile-terminal-tab-agent.ts', 2],
-      ['src/renderer/src/lib/open-tab-occupant-agent.ts', 2],
-      ['src/renderer/src/lib/use-tab-agent.ts', 3]
+      ['src/renderer/src/components/sidebar/smart-attention-title-status.ts', 2],
+      ['src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts', 2],
+      ['src/renderer/src/components/status-bar/workspace-space-presentation.ts', 3],
+      ['src/renderer/src/lib/use-tab-agent.ts', 2],
+      ['src/renderer/src/lib/worktree-status.ts', 2]
     ]
   },
   {
@@ -159,7 +162,6 @@ const INVENTORY: readonly InventoryGroup[] = [
     classification: 'parser-implementation',
     paths: [
       ['src/renderer/src/lib/pane-agent-evidence.ts', 2],
-      ['src/renderer/src/lib/tab-agent-from-signals.ts', 2],
       'src/shared/terminal-title-agent-type.ts'
     ]
   },
@@ -177,10 +179,7 @@ const INVENTORY: readonly InventoryGroup[] = [
   {
     helper: 'resolveCommittedTitleAgentType',
     classification: 'identity-consumer',
-    paths: [
-      ['src/renderer/src/components/terminal-pane/native-chat-leaf-title-agent.ts', 4],
-      ['src/renderer/src/components/terminal-pane/pty-connection/pane-agent-identity.ts', 2]
-    ]
+    paths: [['src/renderer/src/components/terminal-pane/pty-connection/pane-agent-identity.ts', 2]]
   },
   {
     helper: 'resolveCommittedTitleAgentType',
@@ -209,8 +208,7 @@ const INVENTORY: readonly InventoryGroup[] = [
     classification: 'identity-consumer',
     paths: [
       ['src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts', 2],
-      ['src/renderer/src/components/terminal-pane/pty-connection/shell-command-inference.ts', 2],
-      ['src/renderer/src/lib/use-tab-agent.ts', 2]
+      ['src/renderer/src/components/terminal-pane/pty-connection/shell-command-inference.ts', 2]
     ]
   },
   {
@@ -222,11 +220,8 @@ const INVENTORY: readonly InventoryGroup[] = [
     helper: 'resolveCompatibleAgentTypeForOwner',
     classification: 'identity-consumer',
     paths: [
-      ['src/renderer/src/components/sidebar/worktree-agent-row-type.ts', 2],
       ['src/main/runtime/runtime-mobile-session-projection.ts', 3],
-      ['src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts', 2],
-      ['src/renderer/src/lib/tab-agent-from-signals.ts', 2],
-      ['src/renderer/src/lib/use-tab-agent.ts', 2]
+      ['src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts', 2]
     ]
   },
   {
@@ -253,12 +248,11 @@ const INVENTORY: readonly InventoryGroup[] = [
     helper: 'classifyTitleActivity',
     classification: 'identity-consumer',
     paths: [
-      ['src/renderer/src/components/sidebar/smart-attention.ts', 3],
+      ['src/renderer/src/components/sidebar/smart-attention-title-status.ts', 2],
       ['src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts', 2],
       ['src/renderer/src/components/status-bar/workspace-space-presentation.ts', 3],
       ['src/renderer/src/lib/active-agent-note-target.ts', 2],
-      ['src/renderer/src/lib/worktree-status.ts', 3],
-      ['src/renderer/src/store/slices/terminal-helpers.ts', 2]
+      ['src/renderer/src/lib/worktree-status.ts', 3]
     ]
   },
   {
@@ -340,11 +334,7 @@ const INVENTORY: readonly InventoryGroup[] = [
   {
     helper: 'resolveAgentTypeFromTerminalTitle',
     classification: 'identity-consumer',
-    paths: [
-      ['src/renderer/src/components/sidebar/worktree-agent-row-type.ts', 2],
-      'src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts',
-      ['src/renderer/src/lib/worktree-status.ts', 2]
-    ]
+    paths: ['src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts']
   },
   {
     helper: 'resolvePaneAgentIdentity',
@@ -364,7 +354,21 @@ const INVENTORY: readonly InventoryGroup[] = [
   {
     helper: 'resolveCanonicalPaneAgentIdentity',
     classification: 'identity-consumer',
-    paths: [['src/shared/agent-status-identity.ts', 2]]
+    paths: [
+      ['src/shared/agent-status-identity.ts', 2],
+      ['src/renderer/src/components/sidebar/smart-attention-title-status.ts', 2],
+      ['src/renderer/src/components/sidebar/worktree-agent-row-type.ts', 2],
+      ['src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts', 2],
+      ['src/renderer/src/components/status-bar/workspace-space-presentation.ts', 3],
+      ['src/renderer/src/components/tab-bar/tab-agent-types-by-tab-id.ts', 3],
+      ['src/renderer/src/components/terminal-pane/native-chat-leaf-title-agent.ts', 2],
+      ['src/renderer/src/components/terminal-pane/pty-connection/pane-agent-identity.ts', 2],
+      ['src/renderer/src/components/terminal-pane/terminal-tab-agent-type-index.ts', 3],
+      ['src/renderer/src/lib/tab-agent-from-signals.ts', 2],
+      ['src/renderer/src/lib/tab-agent-status-index.ts', 2],
+      ['src/renderer/src/lib/worktree-status.ts', 2],
+      ['src/renderer/src/store/slices/terminal-helpers.ts', 2]
+    ]
   },
   {
     helper: 'resolveCanonicalPaneAgentIdentity',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​325 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​112 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​213 |
| Prod | 19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​273 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​360 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​87 |

<!-- /orca-pr-loc -->

## ELI5

The tab icon and the surfaces around it now ask the one shared resolver (built in #18243) which agent is in a
pane, instead of each using its own rules. **This is the tranche where users actually see a difference**, in
two places.

### Before / after

| Situation | Before | After |
| --- | --- | --- |
| A tab titled just `grok`, with no other evidence | Pane claims a **grok** agent | Pane shows **no agent** |
| A remote pane running `claude`, tab titled `codex`, connection blips | Icon **flips to codex**, then back on reconnect | Icon **stays claude** |
| Same, but Orca launched the agent itself | Still flipped to the title | Stays correct |
| No evidence at all | Falls back to whatever the title says | Honest unknown |

**The first row is a real behavior change worth knowing about.** A tab title is a decoration field people type
task notes into — "grok" as a note used to be enough to claim a grok agent was running there. It now requires
an anchored owner suffix (e.g. `Task - grok`) before a title alone can identify a pane. Panes that previously
showed an agent purely from a word in the title will now show none.

The second row is the bug this tranche exists to fix: on the shipping ladder a title outranks both a launch
record and a completed hook, so losing the process reading for a moment made a pane rename itself.

**Stacking:** this is based on #18243, which must merge first.

## Manual testing

- **The blip scenario was reproduced against the real shipping resolver**, not a model: a remote pane running
  `claude` with the tab titled `codex`, driven through connected → process reading lost → restored. On the
  shipping ladder the pane flipped to `codex` in **three of four** evidence shapes — including when Orca itself
  launched the agent. With the canonical resolver it holds `claude` throughout, degrading process →
  completed-hook → launch, and returns null rather than the title when nothing else is known. Pinned as a
  regression test.
- **Every bare-title assertion was swept**, not just the one CI happened to fail on. The palette cases were
  verified to have only free-text `grok` evidence (no hook, launch, process, sleeping, sibling, or anchored
  suffix) before being changed; `open-tab-occupant-agent.test.ts:116` was already correct; the remaining title
  fixtures were confirmed to carry independent evidence or to not be occupancy tests.
- **Ordering rationale recorded, with an expiry test.** `launch` outranks `completed-hook` today only because
  the staleness filter is built but unwired — nothing in production supplies run keys, so an unfiltered
  completed hook can belong to a previous occupant of a reused pane. A test now fails once run keys start being
  supplied, forcing that ordering to be revisited rather than silently inherited.
- Both inventory ratchets pass; typechecks are non-incremental.

**Not done:** no rendered Electron/UI pass. The behavior above was verified through the resolver the UI calls,
not by clicking through the app.

## Summary

This is Tranche 1 stacked on Tranche 0 (PR #18243); #18243 must land first. The branch starts at tranche 0 head `ca5f7de87e9c7adb5526337636c131c87e670183`.

Renderer display identity now delegates to `resolveCanonicalPaneAgentIdentity` for the tab icon/open-tab occupant, native-chat leaf title, tab projections, terminal pane identity, sidebar/status/worktree display projections, and terminal title reset. The canonical order remains `live-hook > process > launch > completed-hook > sleeping-session > sibling > title`. Title-only provenance is not promoted to a confident tab icon; equal-rank sibling agents return unknown instead of choosing insertion order. No main-process consumer or published host-to-client wire was changed.

## Regression coverage

Added the remote connected -> connection blip -> restored regression: a remotely launched Claude pane titled Codex remains Claude in all three states and never flips to Codex. Added process-proof fixtures and the freshness-field gate; bare process names remain hints and do not outrank launch.

The source-order list documents why `launch` currently outranks `completed-hook`: a completed hook is newer evidence in principle, but the staleness filter is built and NOT WIRED. `PaneAgentEvidence.run?: PaneAgentRunKey` is optional (undefined is treated as eligible), and nothing in production supplies `completedHookRun` or `launchRun` (the comparison code says run keys reach the tab ladder with a later wave). Thus an unfiltered completed hook can describe a previous occupant of a reused pane, while a launch record is scoped to how this pane was set up; launch is the safer of two imperfect clues while run keys are absent. An expiry test fails once production supplies run keys, with exactly: `run keys are now supplied; re-evaluate whether completed-hook should outrank launch.`

## Decision-table reconciliation

The exhaustive renderer replay records proof-free 2,622 disagreements (launch 1,884; completed-hook 478; sleeping-session 144; sibling 54; title 6; process 0) and fresh-proof 658 disagreements (launch 588; completed-hook 46; sibling 6; title 2; sleeping-session 0; process 0). Sibling/title residuals were confirmed, not disproved. Fresh-proof residual shapes are:

- Slots all empty (`hook=null`, `siblingHook=null`, `completed=null`, `siblingCompleted=null`, `process=null`, `sleeping=null`, `launch=null`), title `Task - claude`, local and remote: shipping `null`, canonical `claude` from `title` (2 shapes).
- `siblingHook=claude` with all other slots null, title `Task - codex`, local and remote: shipping `codex`, canonical `claude` from `sibling` (2 shapes).
- `siblingCompleted=claude` with all other slots null, title `Task - codex`, local and remote: shipping `codex`, canonical `claude` from `sibling` (2 shapes).
- `siblingHook=claude` and `siblingCompleted=claude` with all other slots null, title `Task - codex`, local and remote: shipping `codex`, canonical `claude` from `sibling` (2 shapes).

The decision-table test writes all concrete residuals to its temp JSON artifact and asserts their cardinality so these categories cannot silently disappear. `ForegroundProcessProof` fixtures always include both `capturedAgeMs` and `validForMs`; omitting either is rejected and reproduces the no-proof numbers.

## Verification

- Focused renderer/shared suites: 23 files, 301 tests passed.
- Both identity inventory ratchets passed.
- Non-incremental web and node typechecks passed (`npx tsc -p config/tsconfig.tc.web.json --composite false --noEmit` and `npx tsc -p config/tsconfig.node.json --composite false --noEmit`).
- Changed-code quality gate and oxlint passed.



## Title-only identity decision

The open-tab occupant fixture titled "grok" now resolves to no occupant intentionally. The old first-match ladder treated the bare token as Grok, but canonical title evidence records vendorMarkers=[], anchoredNames=[], freeTextNames=[grok], agent=null, reason=free-text-only: a bare title can be typed by any agent and was an identity guess. The canonical resolver correctly refuses that guess; an anchored title such as Task - grok still resolves Grok, and stronger launch, hook, process, sleeping-session, or sibling evidence remains authoritative.

