### PR TITLE
feat(dashboard): open the worktree straight from a card click

### DIFF
--- a/src/main/ipc/dashboard-payload-validation.test.ts
+++ b/src/main/ipc/dashboard-payload-validation.test.ts
@@ -437,6 +437,11 @@ describe('dashboard payload validation', () => {
       // Why: showIdle and filterOptions describe the frame, not one card, so a
       // bad value there has no card to drop and must fail the whole snapshot.
       expect(admitDashboardSnapshot({ ...SNAPSHOT, showIdle: 'yes' })).toBeNull()
+      expect(admitDashboardSnapshot({ ...SNAPSHOT, cardClickOpensWorktree: 'yes' })).toBeNull()
+      expect(
+        admitDashboardSnapshot({ ...SNAPSHOT, cardClickOpensWorktree: true })?.snapshot
+          .cardClickOpensWorktree
+      ).toBe(true)
       expect(
         admitDashboardSnapshot({
           ...SNAPSHOT,
@@ -451,6 +456,7 @@ describe('dashboard payload validation', () => {
         { ...SNAPSHOT, cards: 'nope' },
         { ...SNAPSHOT, repoIconsByRepoId: [] },
         { ...SNAPSHOT, showIdle: 'yes' },
+        { ...SNAPSHOT, cardClickOpensWorktree: 'yes' },
         { ...SNAPSHOT, filterOptions: { projects: [], workspaceStatuses: 'nope' } },
         null,
         []

--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -108,6 +108,8 @@ export function isDashboardSnapshot(value: unknown): value is DashboardSnapshot 
     snapshot.cards.every(isDashboardCard) &&
     isDashboardWorkspaceList(snapshot.workspaces) &&
     (snapshot.showIdle === undefined || typeof snapshot.showIdle === 'boolean') &&
+    (snapshot.cardClickOpensWorktree === undefined ||
+      typeof snapshot.cardClickOpensWorktree === 'boolean') &&
     isDashboardFilterOptions(snapshot.filterOptions) &&
     isDashboardLaunchOptions(snapshot.launchableAgentsByWorktreeId) &&
     isDashboardRepoIcons(snapshot.repoIconsByRepoId)
@@ -139,6 +141,8 @@ export function admitDashboardSnapshot(value: unknown): DashboardSnapshotAdmissi
     snapshot.cards.length > MAX_DASHBOARD_CARDS ||
     workspaces === null ||
     (snapshot.showIdle !== undefined && typeof snapshot.showIdle !== 'boolean') ||
+    (snapshot.cardClickOpensWorktree !== undefined &&
+      typeof snapshot.cardClickOpensWorktree !== 'boolean') ||
     !isDashboardFilterOptions(snapshot.filterOptions) ||
     !isDashboardLaunchOptions(snapshot.launchableAgentsByWorktreeId) ||
     !isDashboardRepoIcons(snapshot.repoIconsByRepoId)

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.test.tsx
@@ -19,12 +19,14 @@ vi.mock('./AgentKanbanCard', () => ({
     card,
     repoIcon,
     now,
-    onOpenTerminal
+    clickOpensWorktree,
+    onActivate
   }: {
     card: DashboardCard
     repoIcon?: RepoIcon | null
     now: number
-    onOpenTerminal: (card: DashboardCard) => void
+    clickOpensWorktree: boolean
+    onActivate: (card: DashboardCard, event: React.MouseEvent<HTMLButtonElement>) => void
   }) => (
     <div
       data-testid="card"
@@ -32,7 +34,8 @@ vi.mock('./AgentKanbanCard', () => ({
       data-unseen={card.unseen}
       data-now={now}
       data-repo-icon={repoIcon === null ? 'none' : JSON.stringify(repoIcon)}
-      onClick={() => onOpenTerminal(card)}
+      data-click-opens-worktree={clickOpensWorktree}
+      onClick={(event) => onActivate(card, event as unknown as React.MouseEvent<HTMLButtonElement>)}
     >
       {card.worktreeName}
     </div>
@@ -92,6 +95,12 @@ function renderBoard(
 }
 
 const ackAgent = vi.fn(async () => {})
+const revealAgent = vi.fn(async () => {})
+const originalUserAgent = navigator.userAgent
+
+function stubUserAgent(userAgent: string): void {
+  Object.defineProperty(navigator, 'userAgent', { configurable: true, value: userAgent })
+}
 
 describe('AgentKanbanBoard', () => {
   beforeEach(async () => {
@@ -101,8 +110,8 @@ describe('AgentKanbanBoard', () => {
       'matchMedia',
       vi.fn(() => ({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() }))
     )
-    // The board relays seen-acks through the dashboard preload API.
-    ;(window as unknown as { api: unknown }).api = { dashboard: { ackAgent } }
+    // The board relays seen-acks and reveals through the dashboard preload API.
+    ;(window as unknown as { api: unknown }).api = { dashboard: { ackAgent, revealAgent } }
   })
   afterEach(() => {
     cleanup()
@@ -110,6 +119,7 @@ describe('AgentKanbanBoard', () => {
     vi.clearAllMocks()
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
+    stubUserAgent(originalUserAgent)
   })
 
   it('renders the three default columns in order', () => {
@@ -310,6 +320,61 @@ describe('AgentKanbanBoard', () => {
     rerender(<AgentKanbanBoard snapshot={{ generatedAt: 3, cards: [] }} />)
     expect(screen.getByTestId('terminal-dialog').dataset.open).toBe('true')
     expect(screen.getByTestId('terminal-dialog').dataset.ptyId).toBeUndefined()
+  })
+
+  it('previews on click and opens the worktree on modifier-click by default', () => {
+    stubUserAgent('Macintosh')
+    const agent = card({ paneKey: 'pk-open', tabId: 'tab-9', leafId: 'leaf-9' })
+    render(<AgentKanbanBoard snapshot={{ generatedAt: 1, cards: [agent] }} />)
+    expect(screen.getByTestId('card').dataset.clickOpensWorktree).toBe('false')
+
+    fireEvent.click(screen.getByTestId('card'), { metaKey: true })
+    expect(revealAgent).toHaveBeenCalledWith({
+      repoId: 'r1',
+      worktreeId: 'w1',
+      executionHostId: undefined,
+      tabId: 'tab-9',
+      leafId: 'leaf-9'
+    })
+    // Going to the agent counts as seeing it, exactly like opening its preview.
+    expect(ackAgent).toHaveBeenCalledWith('pk-open')
+    expect(screen.getByTestId('terminal-dialog').dataset.open).toBe('false')
+
+    fireEvent.click(screen.getByTestId('card'))
+    expect(revealAgent).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('terminal-dialog').dataset.open).toBe('true')
+  })
+
+  it('reads the platform modifier: Ctrl on non-Mac hosts, never Cmd', () => {
+    stubUserAgent('Windows NT 10.0')
+    render(<AgentKanbanBoard snapshot={{ generatedAt: 1, cards: [card({})] }} />)
+
+    fireEvent.click(screen.getByTestId('card'), { metaKey: true })
+    expect(revealAgent).not.toHaveBeenCalled()
+    expect(screen.getByTestId('terminal-dialog').dataset.open).toBe('true')
+    fireEvent.click(screen.getByTestId('terminal-dialog-close'))
+
+    fireEvent.click(screen.getByTestId('card'), { ctrlKey: true })
+    expect(revealAgent).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('terminal-dialog').dataset.open).toBe('false')
+  })
+
+  it('swaps the two actions when the snapshot says click opens the worktree', () => {
+    stubUserAgent('Macintosh')
+    render(
+      <AgentKanbanBoard
+        snapshot={{ generatedAt: 1, cards: [card({})], cardClickOpensWorktree: true }}
+      />
+    )
+    expect(screen.getByTestId('card').dataset.clickOpensWorktree).toBe('true')
+
+    fireEvent.click(screen.getByTestId('card'))
+    expect(revealAgent).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('terminal-dialog').dataset.open).toBe('false')
+
+    fireEvent.click(screen.getByTestId('card'), { metaKey: true })
+    expect(revealAgent).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('terminal-dialog').dataset.open).toBe('true')
   })
 
   it('relays a seen-ack when a dialog opens and when the open agent changes state', () => {

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.tsx
@@ -13,6 +13,7 @@ import { installWindowVisibilityInterval } from '@/lib/window-visibility-interva
 import { AgentKanbanCard } from './AgentKanbanCard'
 import { AgentDashboardToolbar } from './AgentDashboardToolbar'
 import { AgentTerminalDialog, type AgentRevealArgs } from './AgentTerminalDialog'
+import { agentCardClickOpensWorktree } from './agent-card-activation'
 import {
   EMPTY_DASHBOARD_FILTERS,
   filterDashboardCards,
@@ -71,13 +72,15 @@ function KanbanColumn({
   cards,
   repoIconsByRepoId,
   now,
-  onOpenTerminal
+  clickOpensWorktree,
+  onActivate
 }: {
   bucket: DashboardBucket
   cards: DashboardCard[]
   repoIconsByRepoId: Record<string, RepoIcon | null> | undefined
   now: number
-  onOpenTerminal: (card: DashboardCard) => void
+  clickOpensWorktree: boolean
+  onActivate: (card: DashboardCard, event: React.MouseEvent<HTMLButtonElement>) => void
 }): React.JSX.Element {
   return (
     // Why: attention no longer tints the whole column — the cards inside carry
@@ -103,7 +106,8 @@ function KanbanColumn({
               card={card}
               repoIcon={repoIconsByRepoId?.[card.repoId] ?? null}
               now={now}
-              onOpenTerminal={onOpenTerminal}
+              clickOpensWorktree={clickOpensWorktree}
+              onActivate={onActivate}
             />
           ))
         )}
@@ -229,6 +233,26 @@ export function AgentKanbanBoard({
     },
     [onAckAgent]
   )
+  // Why: the setting chooses what a plain click does and the platform modifier
+  // does the other thing, so the two actions are always one click away.
+  const clickOpensWorktree = snapshot.cardClickOpensWorktree === true
+  const handleCardActivate = useCallback(
+    (card: DashboardCard, event: React.MouseEvent<HTMLButtonElement>) => {
+      if (!agentCardClickOpensWorktree(event, clickOpensWorktree)) {
+        handleOpenTerminal(card)
+        return
+      }
+      onAckAgent(card.paneKey)
+      onRevealAgent({
+        repoId: card.repoId,
+        worktreeId: card.worktreeId,
+        executionHostId: card.executionHostId,
+        tabId: card.tabId,
+        leafId: card.leafId
+      })
+    },
+    [clickOpensWorktree, handleOpenTerminal, onAckAgent, onRevealAgent]
+  )
   // Watching the open dialog counts as seeing state changes as they happen —
   // without this, an agent finishing while you watch would re-flag its card.
   useEffect(() => {
@@ -290,7 +314,8 @@ export function AgentKanbanBoard({
                 cards={grouped[bucket]}
                 repoIconsByRepoId={snapshot.repoIconsByRepoId}
                 now={now}
-                onOpenTerminal={handleOpenTerminal}
+                clickOpensWorktree={clickOpensWorktree}
+                onActivate={handleCardActivate}
               />
             ))}
           </div>

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
@@ -52,7 +52,8 @@ function renderCard(props: {
   card: DashboardCard
   now: number
   repoIcon?: RepoIcon | null
-  onOpenTerminal?: () => void
+  clickOpensWorktree?: boolean
+  onActivate?: (card: DashboardCard, event: React.MouseEvent<HTMLButtonElement>) => void
 }): ReturnType<typeof render> {
   return render(
     <TooltipProvider>
@@ -60,10 +61,17 @@ function renderCard(props: {
         card={props.card}
         repoIcon={props.repoIcon}
         now={props.now}
-        onOpenTerminal={props.onOpenTerminal ?? vi.fn()}
+        clickOpensWorktree={props.clickOpensWorktree ?? false}
+        onActivate={props.onActivate ?? vi.fn()}
       />
     </TooltipProvider>
   )
+}
+
+const originalUserAgent = navigator.userAgent
+
+function stubUserAgent(userAgent: string): void {
+  Object.defineProperty(navigator, 'userAgent', { configurable: true, value: userAgent })
 }
 
 describe('AgentKanbanCard', () => {
@@ -74,6 +82,35 @@ describe('AgentKanbanCard', () => {
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
+    stubUserAgent(originalUserAgent)
+  })
+
+  it('hands the click event to the host so it can read the modifier', () => {
+    const onActivate = vi.fn()
+    renderCard({ card: card(), now: 1_000, onActivate })
+
+    fireEvent.click(screen.getByText('dashboard-review'), { metaKey: true })
+
+    expect(onActivate).toHaveBeenCalledTimes(1)
+    expect(onActivate.mock.calls[0][0]).toMatchObject({ paneKey: 'tab:leaf' })
+    expect(onActivate.mock.calls[0][1]).toMatchObject({ metaKey: true })
+  })
+
+  it('hints both actions with the platform modifier, following the swap', () => {
+    stubUserAgent('Macintosh')
+    const { unmount } = renderCard({ card: card(), now: 1_000 })
+    expect(screen.getByText('dashboard-review').closest('button')).toHaveAttribute(
+      'title',
+      'Click for a live preview · ⌘-click to open the worktree'
+    )
+    unmount()
+
+    stubUserAgent('Windows NT 10.0')
+    renderCard({ card: card(), now: 1_000, clickOpensWorktree: true })
+    expect(screen.getByText('dashboard-review').closest('button')).toHaveAttribute(
+      'title',
+      'Click to open the worktree · Ctrl+click for a live preview'
+    )
   })
 
   it('does not render an invented age when the start time is unknown', () => {
@@ -98,7 +135,8 @@ describe('AgentKanbanCard', () => {
         <AgentKanbanCard
           card={{ ...attentionCard, askSummary: undefined }}
           now={2_000}
-          onOpenTerminal={vi.fn()}
+          clickOpensWorktree={false}
+          onActivate={vi.fn()}
         />
       </TooltipProvider>
     )
@@ -124,7 +162,7 @@ describe('AgentKanbanCard', () => {
   })
 
   it('shows review metadata and expands grouped subagents without opening the terminal', () => {
-    const onOpenTerminal = vi.fn()
+    const onActivate = vi.fn()
     renderCard({
       card: card({
         review: { number: 11012, state: 'open' },
@@ -134,7 +172,7 @@ describe('AgentKanbanCard', () => {
         ]
       }),
       now: 2_000,
-      onOpenTerminal
+      onActivate
     })
 
     expect(screen.getByText('#11012')).toBeInTheDocument()
@@ -143,11 +181,11 @@ describe('AgentKanbanCard', () => {
     fireEvent.click(screen.getByRole('button', { name: '2 subagents' }))
     expect(screen.getByText('Review loop')).toBeInTheDocument()
     expect(screen.getByText('Smoke tests')).toBeInTheDocument()
-    expect(onOpenTerminal).not.toHaveBeenCalled()
+    expect(onActivate).not.toHaveBeenCalled()
   })
 
-  it('opens the terminal from the footer while keeping subagent disclosure isolated', () => {
-    const onOpenTerminal = vi.fn()
+  it('activates from the footer while keeping subagent disclosure isolated', () => {
+    const onActivate = vi.fn()
     renderCard({
       card: card({
         conversationName: 'Dashboard review',
@@ -155,14 +193,14 @@ describe('AgentKanbanCard', () => {
         subagents: [{ id: 'child-1', name: 'Review loop', dotState: 'working' }]
       }),
       now: 61_000,
-      onOpenTerminal
+      onActivate
     })
 
     fireEvent.click(screen.getByText('#11042'))
-    expect(onOpenTerminal).toHaveBeenCalledTimes(1)
+    expect(onActivate).toHaveBeenCalledTimes(1)
 
     fireEvent.click(screen.getByRole('button', { name: '1 subagent' }))
-    expect(onOpenTerminal).toHaveBeenCalledTimes(1)
+    expect(onActivate).toHaveBeenCalledTimes(1)
   })
 
   it('labels one subagent accessibly and never renders a workspace-status dot', () => {
@@ -242,7 +280,7 @@ describe('AgentKanbanCard', () => {
   })
 
   it('skips structured-clone rerenders until visible card data or its age changes', () => {
-    const onOpenTerminal = vi.fn()
+    const onActivate = vi.fn()
     const initial = card({
       startedAt: 1_000,
       subagents: [{ id: 'child-1', name: 'Review loop', dotState: 'working' }]
@@ -254,7 +292,8 @@ describe('AgentKanbanCard', () => {
           card={initial}
           repoIcon={repoIcon}
           now={61_500}
-          onOpenTerminal={onOpenTerminal}
+          clickOpensWorktree={false}
+          onActivate={onActivate}
         />
       </TooltipProvider>
     )
@@ -268,7 +307,8 @@ describe('AgentKanbanCard', () => {
           card={{ ...initial, subagents: initial.subagents?.map((subagent) => ({ ...subagent })) }}
           repoIcon={{ ...repoIcon }}
           now={62_000}
-          onOpenTerminal={onOpenTerminal}
+          clickOpensWorktree={false}
+          onActivate={onActivate}
         />
       </TooltipProvider>
     )
@@ -280,7 +320,8 @@ describe('AgentKanbanCard', () => {
           card={{ ...initial, subagents: initial.subagents?.map((subagent) => ({ ...subagent })) }}
           repoIcon={{ ...repoIcon }}
           now={121_500}
-          onOpenTerminal={onOpenTerminal}
+          clickOpensWorktree={false}
+          onActivate={onActivate}
         />
       </TooltipProvider>
     )
@@ -298,7 +339,8 @@ describe('AgentKanbanCard', () => {
         <AgentKanbanCard
           card={{ ...initial, workingMode: 'monitoring' }}
           now={2_000}
-          onOpenTerminal={vi.fn()}
+          clickOpensWorktree={false}
+          onActivate={vi.fn()}
         />
       </TooltipProvider>
     )
@@ -307,7 +349,7 @@ describe('AgentKanbanCard', () => {
   })
 
   it('rerenders when the repo icon changes', () => {
-    const onOpenTerminal = vi.fn()
+    const onActivate = vi.fn()
     const initial = card({ startedAt: 1_000 })
     const { rerender } = render(
       <TooltipProvider>
@@ -315,7 +357,8 @@ describe('AgentKanbanCard', () => {
           card={initial}
           repoIcon={{ type: 'lucide', name: 'Rocket' }}
           now={61_500}
-          onOpenTerminal={onOpenTerminal}
+          clickOpensWorktree={false}
+          onActivate={onActivate}
         />
       </TooltipProvider>
     )
@@ -327,7 +370,8 @@ describe('AgentKanbanCard', () => {
           card={{ ...initial }}
           repoIcon={{ type: 'lucide', name: 'Database' }}
           now={61_500}
-          onOpenTerminal={onOpenTerminal}
+          clickOpensWorktree={false}
+          onActivate={onActivate}
         />
       </TooltipProvider>
     )

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -21,6 +21,7 @@ import {
 import type { RepoIcon } from '../../../../shared/repo-icon'
 import { translate } from '@/i18n/i18n'
 import { DashboardHostBadge } from './DashboardHostBadge'
+import { agentCardActivationHint } from './agent-card-activation'
 
 /** Compact "started N ago" (the card is glanceable — coarse units are fine). */
 function formatStartedAgo(startedAt: number, now: number): string {
@@ -188,19 +189,25 @@ type AgentKanbanCardProps = {
   /** The card repo's icon. null renders the default folder glyph. */
   repoIcon?: RepoIcon | null
   now: number
-  /** Opens the board-level terminal dialog. The dialog is NOT owned by the
-   *  card: bucket moves remount the card, and an embedded dialog would close
-   *  the chat mid-conversation. */
-  onOpenTerminal: (card: DashboardCard) => void
+  /** Whether a plain click opens the worktree (modifier-click previews) rather
+   *  than the reverse; only the hover hint depends on it here. */
+  clickOpensWorktree: boolean
+  /** Hands the click to the board, which opens the board-level terminal dialog
+   *  or reveals the worktree. The dialog is NOT owned by the card: bucket moves
+   *  remount the card, and an embedded dialog would close the chat
+   *  mid-conversation. */
+  onActivate: (card: DashboardCard, event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-/** One agent on the kanban board. Clicking opens the board's live terminal dialog. */
+/** One agent on the kanban board. Clicking opens the board's live terminal
+ *  dialog or the worktree, depending on the modifier and the board setting. */
 export const AgentKanbanCard = memo(
   function AgentKanbanCard({
     card,
     repoIcon = null,
     now,
-    onOpenTerminal
+    clickOpensWorktree,
+    onActivate
   }: AgentKanbanCardProps): React.JSX.Element {
     useTranslation()
     const [subagentsOpen, setSubagentsOpen] = useState(false)
@@ -233,7 +240,8 @@ export const AgentKanbanCard = memo(
       >
         <button
           type="button"
-          onClick={() => onOpenTerminal(card)}
+          onClick={(event) => onActivate(card, event)}
+          title={agentCardActivationHint(clickOpensWorktree)}
           className="flex w-full flex-col gap-1.5 text-left focus-visible:rounded-md focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
         >
           <div className="flex w-full items-center gap-1.5">
@@ -316,7 +324,7 @@ export const AgentKanbanCard = memo(
 
         <button
           type="button"
-          onClick={() => onOpenTerminal(card)}
+          onClick={(event) => onActivate(card, event)}
           className="flex w-full items-center gap-2 rounded-md text-left text-[11px] text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
         >
           <Tooltip>
@@ -350,7 +358,8 @@ export const AgentKanbanCard = memo(
     )
   },
   (previous, next) =>
-    previous.onOpenTerminal === next.onOpenTerminal &&
+    previous.onActivate === next.onActivate &&
+    previous.clickOpensWorktree === next.clickOpensWorktree &&
     sameCard(previous.card, next.card) &&
     sameRepoIcon(previous.repoIcon, next.repoIcon) &&
     (displayTimestamp(previous.card) <= 0 ||

--- a/src/renderer/src/components/dashboard-popout/agent-card-activation.test.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-card-activation.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { i18n } from '@/i18n/i18n'
+import {
+  agentCardActivationHint,
+  agentCardClickOpensWorktree,
+  isPlatformModifierClick,
+  platformModifierClickLabel
+} from './agent-card-activation'
+
+const originalUserAgent = navigator.userAgent
+
+function stubUserAgent(userAgent: string): void {
+  Object.defineProperty(navigator, 'userAgent', { configurable: true, value: userAgent })
+}
+
+const META = { metaKey: true, ctrlKey: false }
+const CTRL = { metaKey: false, ctrlKey: true }
+const PLAIN = { metaKey: false, ctrlKey: false }
+
+describe('agent card activation', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en')
+  })
+
+  afterEach(() => {
+    stubUserAgent(originalUserAgent)
+  })
+
+  it('reads ⌘ on macOS and ignores Ctrl there', () => {
+    stubUserAgent('Macintosh')
+    expect(isPlatformModifierClick(META)).toBe(true)
+    expect(isPlatformModifierClick(CTRL)).toBe(false)
+    expect(platformModifierClickLabel()).toBe('⌘-click')
+  })
+
+  it('reads Ctrl elsewhere and ignores the meta key there', () => {
+    stubUserAgent('Windows NT 10.0')
+    expect(isPlatformModifierClick(CTRL)).toBe(true)
+    expect(isPlatformModifierClick(META)).toBe(false)
+    expect(platformModifierClickLabel()).toBe('Ctrl+click')
+  })
+
+  it('lets the setting choose the plain-click action and the modifier flip it', () => {
+    stubUserAgent('Macintosh')
+    expect(agentCardClickOpensWorktree(PLAIN, false)).toBe(false)
+    expect(agentCardClickOpensWorktree(META, false)).toBe(true)
+    expect(agentCardClickOpensWorktree(PLAIN, true)).toBe(true)
+    expect(agentCardClickOpensWorktree(META, true)).toBe(false)
+  })
+
+  it('names both actions in their current assignment with the platform chord', () => {
+    stubUserAgent('Linux x86_64')
+    expect(agentCardActivationHint(false)).toBe(
+      'Click for a live preview · Ctrl+click to open the worktree'
+    )
+    expect(agentCardActivationHint(true)).toBe(
+      'Click to open the worktree · Ctrl+click for a live preview'
+    )
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/agent-card-activation.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-card-activation.ts
@@ -1,0 +1,38 @@
+import { translate } from '@/i18n/i18n'
+import { getShortcutPlatform } from '@/lib/shortcut-platform'
+
+/** The modifier-click chord as the UI names it: ⌘-click on macOS, Ctrl+click elsewhere. */
+export function platformModifierClickLabel(): string {
+  return getShortcutPlatform() === 'darwin' ? '⌘-click' : 'Ctrl+click'
+}
+
+export function isPlatformModifierClick(
+  event: Pick<React.MouseEvent, 'metaKey' | 'ctrlKey'>
+): boolean {
+  return getShortcutPlatform() === 'darwin' ? event.metaKey : event.ctrlKey
+}
+
+/** Which card action a click asks for: the setting picks the plain-click
+ *  default and the platform modifier flips to the other one. */
+export function agentCardClickOpensWorktree(
+  event: Pick<React.MouseEvent, 'metaKey' | 'ctrlKey'>,
+  clickOpensWorktree: boolean
+): boolean {
+  return clickOpensWorktree !== isPlatformModifierClick(event)
+}
+
+/** Hover hint naming both actions in their current assignment. */
+export function agentCardActivationHint(clickOpensWorktree: boolean): string {
+  const modifierClick = platformModifierClickLabel()
+  return clickOpensWorktree
+    ? translate(
+        'dashboardPopout.card.clickHint.openWorktree',
+        'Click to open the worktree · {{modifierClick}} for a live preview',
+        { modifierClick }
+      )
+    : translate(
+        'dashboardPopout.card.clickHint.preview',
+        'Click for a live preview · {{modifierClick}} to open the worktree',
+        { modifierClick }
+      )
+}

--- a/src/renderer/src/components/dashboard/AgentDashboardSettingsMenu.test.tsx
+++ b/src/renderer/src/components/dashboard/AgentDashboardSettingsMenu.test.tsx
@@ -11,6 +11,7 @@ vi.mock('@/store', () => ({
       settings: {
         experimentalAgentDashboardMode: 'in-window'
         experimentalAgentDashboardShowIdle: boolean
+        experimentalAgentDashboardCardClickOpensWorktree: boolean
       }
       updateSettings: typeof updateSettings
     }) => unknown
@@ -18,7 +19,8 @@ vi.mock('@/store', () => ({
     selector({
       settings: {
         experimentalAgentDashboardMode: 'in-window',
-        experimentalAgentDashboardShowIdle: false
+        experimentalAgentDashboardShowIdle: false,
+        experimentalAgentDashboardCardClickOpensWorktree: false
       },
       updateSettings
     })
@@ -67,5 +69,25 @@ describe('AgentDashboardSettingsMenu', () => {
     act(() => toggle?.click())
 
     expect(updateSettings).toHaveBeenCalledWith({ experimentalAgentDashboardShowIdle: true })
+  })
+
+  it('owns the card-click action setting', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => {
+      root?.render(<AgentDashboardSettingsMenu onSwitchToPopout={vi.fn()} onOpenChange={vi.fn()} />)
+    })
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[role="switch"][aria-label="Open the worktree on click"]'
+    )
+    expect(toggle).not.toBeNull()
+
+    act(() => toggle?.click())
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      experimentalAgentDashboardCardClickOpensWorktree: true
+    })
   })
 })

--- a/src/renderer/src/components/dashboard/AgentDashboardSettingsMenu.tsx
+++ b/src/renderer/src/components/dashboard/AgentDashboardSettingsMenu.tsx
@@ -11,6 +11,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { SettingsSegmentedControl, SettingsSwitch } from '../settings/SettingsFormControls'
 import type { AgentDashboardMode } from '../../../../shared/ui-chrome-types'
 import { translate } from '@/i18n/i18n'
+import { platformModifierClickLabel } from '../dashboard-popout/agent-card-activation'
 
 type AgentDashboardSettingsMenuProps = {
   /** Called after the mode switches to pop-out so the host can hand the board
@@ -30,6 +31,9 @@ export function AgentDashboardSettingsMenu({
 }: AgentDashboardSettingsMenuProps): React.JSX.Element {
   const mode = useAppStore((s) => s.settings?.experimentalAgentDashboardMode ?? 'in-window')
   const showIdle = useAppStore((s) => s.settings?.experimentalAgentDashboardShowIdle === true)
+  const clickOpensWorktree = useAppStore(
+    (s) => s.settings?.experimentalAgentDashboardCardClickOpensWorktree === true
+  )
   const updateSettings = useAppStore((s) => s.updateSettings)
 
   const handleModeChange = (next: AgentDashboardMode): void => {
@@ -125,6 +129,35 @@ export function AgentDashboardSettingsMenu({
               void updateSettings({ experimentalAgentDashboardShowIdle: !showIdle })
             }}
             ariaLabel={translate('dashboardPopout.settings.showIdle', 'Show idle agents')}
+          />
+        </div>
+        <div className="flex items-start justify-between gap-3 rounded-md px-1.5 py-1.5">
+          <span className="min-w-0 space-y-0.5">
+            <span className="block text-[12px] font-medium leading-4 text-foreground">
+              {translate(
+                'dashboardPopout.settings.cardClickOpensWorktree',
+                'Open the worktree on click'
+              )}
+            </span>
+            <span className="block text-[11px] leading-4 text-muted-foreground">
+              {translate(
+                'dashboardPopout.settings.cardClickOpensWorktreeCopy',
+                'Clicking a card opens the worktree and {{modifierClick}} shows the live preview. Off: click previews, {{modifierClick}} opens the worktree.',
+                { modifierClick: platformModifierClickLabel() }
+              )}
+            </span>
+          </span>
+          <SettingsSwitch
+            checked={clickOpensWorktree}
+            onChange={() => {
+              void updateSettings({
+                experimentalAgentDashboardCardClickOpensWorktree: !clickOpensWorktree
+              })
+            }}
+            ariaLabel={translate(
+              'dashboardPopout.settings.cardClickOpensWorktree',
+              'Open the worktree on click'
+            )}
           />
         </div>
       </DropdownMenuContent>

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -727,6 +727,18 @@ describe('buildDashboardSnapshot', () => {
     expect(snapshot.showIdle).toBe(true)
   })
 
+  it('relays the card-click action setting in the serialized snapshot', () => {
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        settings: { experimentalAgentDashboardCardClickOpensWorktree: true } as never
+      }),
+      NOW
+    )
+
+    expect(snapshot.cardClickOpensWorktree).toBe(true)
+    expect(buildDashboardSnapshot(baseState({}), NOW).cardClickOpensWorktree).toBe(false)
+  })
+
   it('attaches batched runtime orchestration metadata to dashboard rows', () => {
     const snapshot = buildDashboardSnapshot(
       baseState({

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -99,6 +99,8 @@ export function buildDashboardSnapshot(
   const includeCardDetails = options.includeCardDetails !== false
   const generatedTitlesEnabled = state.settings?.tabAutoGenerateTitle === true
   const showIdle = state.settings?.experimentalAgentDashboardShowIdle === true
+  const cardClickOpensWorktree =
+    state.settings?.experimentalAgentDashboardCardClickOpensWorktree === true
   const activeWorktrees = collectActiveDashboardWorkspaces(state, includeCardDetails)
   const filterOptions =
     options.includeFilterOptions === false
@@ -270,6 +272,7 @@ export function buildDashboardSnapshot(
     cards,
     ...(workspaces ? { workspaces } : {}),
     showIdle,
+    cardClickOpensWorktree,
     filterOptions,
     // Only the dashboard surfaces offer a launcher; the count-only rebuild that
     // feeds the sidebar must not pay for host-detection lookups.

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17199,7 +17199,9 @@
     "close": "Close dashboard",
     "settings": {
       "showIdle": "Show idle agents",
-      "showIdleCopy": "Include agents that have gone quiet for 30 minutes without reporting completion. Hidden by default."
+      "showIdleCopy": "Include agents that have gone quiet for 30 minutes without reporting completion. Hidden by default.",
+      "cardClickOpensWorktree": "Open the worktree on click",
+      "cardClickOpensWorktreeCopy": "Clicking a card opens the worktree and {{modifierClick}} shows the live preview. Off: click previews, {{modifierClick}} opens the worktree."
     },
     "settingsTooltip": "Board settings",
     "card": {
@@ -17217,7 +17219,11 @@
         "closed": "Closed review"
       },
       "subagents_one": "{{count}} subagent",
-      "subagents_other": "{{count}} subagents"
+      "subagents_other": "{{count}} subagents",
+      "clickHint": {
+        "openWorktree": "Click to open the worktree · {{modifierClick}} for a live preview",
+        "preview": "Click for a live preview · {{modifierClick}} to open the worktree"
+      }
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -114,6 +114,9 @@ describe('getDefaultSettings', () => {
   it('keeps the agent dashboard popout disabled by default', () => {
     expect(getDefaultSettings('/tmp').experimentalAgentDashboardPopout).toBeUndefined()
     expect(getDefaultSettings('/tmp').experimentalAgentDashboardShowIdle).toBeUndefined()
+    expect(
+      getDefaultSettings('/tmp').experimentalAgentDashboardCardClickOpensWorktree
+    ).toBeUndefined()
   })
 
   it('routes fresh Codex profiles through the real-home rollout by default', () => {})

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -192,6 +192,9 @@ export type DashboardSnapshot = {
    *  optional for preload compatibility with older snapshot producers. */
   workspaces?: DashboardWorkspace[]
   showIdle?: boolean
+  /** Plain card click opens the worktree (modifier-click previews) instead of
+   *  the reverse. Carried in the snapshot because the pop-out has no store. */
+  cardClickOpensWorktree?: boolean
   /** Available filter dimensions are store-derived so zero-card projects and
    *  statuses remain selectable. Optional for preload-version compatibility. */
   filterOptions?: DashboardFilterOptions

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -435,6 +435,9 @@ export type GlobalSettings = {
   experimentalAgentDashboardMode?: AgentDashboardMode
   /** Includes stale quiet agents as a fourth Agent Dashboard column. */
   experimentalAgentDashboardShowIdle?: boolean
+  /** Dashboard cards jump to the agent's worktree on plain click; the platform
+   *  modifier then opens the live preview instead of the other way round. */
+  experimentalAgentDashboardCardClickOpensWorktree?: boolean
   /** One-shot migration guard for defaulting the Agents view off; later explicit opt-ins persist normally. */
   experimentalActivityDefaultedOffForAllUsers?: boolean
   /** Experimental: persistent terminal-pane attention ring for bell + agent-completion events. Opt-in while tuning signal/noise. */


### PR DESCRIPTION
## ELI5

Clicking a card on the Agent Dashboard always opened a preview dialog of that agent's terminal, and getting to the real terminal meant a second click on the dialog's "Open worktree" button. Now ⌘-click (Ctrl+click on Windows/Linux) on a card takes you straight to the agent's terminal. If you mostly use the dashboard to navigate, a new board setting swaps the two: a plain click jumps to the terminal and ⌘-click shows the preview. Hovering a card tells you which is which.

## What Changed

- `AgentKanbanBoard` decides what a card click does: `agentCardClickOpensWorktree(event, setting)` (new `agent-card-activation.ts`, with its own unit test covering the ⌘/Ctrl × setting matrix) reads the platform modifier at runtime through the existing `getShortcutPlatform()` helper (⌘ on macOS, otherwise Ctrl) and XORs it with the setting. Reveal reuses the exact payload and relay the dialog's "Open worktree" button already used (`onRevealAgent` → pop-out IPC or in-window activation), and acks the agent as seen the same way opening the dialog does.
- `AgentKanbanCard` hands the click event to the board (`onActivate(card, event)`, replacing `onOpenTerminal(card)`) and carries a `title` hint on the card body naming both actions with the platform chord ("⌘-click" / "Ctrl+click", matching the labels used elsewhere in the app).
- New setting `experimentalAgentDashboardCardClickOpensWorktree` (off by default) next to `experimentalAgentDashboardShowIdle`, toggled from the in-window board's settings menu. It is copied into `DashboardSnapshot.cardClickOpensWorktree` by `buildDashboardSnapshot` because the pop-out renderer has no store; the snapshot validators accept the optional boolean and reject anything else, mirroring `showIdle`.
- Four English strings added to `en.json` via `pnpm run sync:localization-catalog` (other locales untouched, like most recent additions).

Plain click with the setting off behaves exactly as before, so nobody's muscle memory changes unless they opt in.

## Why

Fixes #11411
Fixes #12511

#11411 asked for modifier-click to skip the dialog (a maintainer replied "makes sense. can improve the UX there"), and #12511 asked for an option to open the terminal tab on click so the dashboard can stay visible on a second screen. Both come from the same friction: the dashboard is often used to *go to* an agent, and the preview dialog is an extra stop on that path. Making the setting a swap rather than a third mode keeps both actions one click away in either configuration, which is what #11411's "setting to swap the two" suggested.

## Linked Issue

Fixes #11411
Fixes #12511

## Visual Proof

`pnpm dev` on macOS (Apple Silicon), two finished Claude sessions in one worktree.

**Before** — every click opens the preview dialog; the terminal is a second click away (bottom-right "Open worktree"):

<img width="3390" height="2116" alt="before-click-opens-preview-dialog" src="https://github.com/user-attachments/assets/a59ac83a-eedc-46af-b3f9-29fa27e2090d" />


**After** — ⌘-click on a card jumps straight to the agent's terminal (drawer closes, tab switches):

<img width="1400" height="874" alt="after-cmd-click-jumps-to-terminal" src="https://github.com/user-attachments/assets/ece572c7-6d14-4aa0-b1fd-e7e48d3897d1" />


**After** — the new board setting, and the pop-out window receiving it through the snapshot (card hint flipped to "Click to open the worktree · ⌘-click for a live preview"):

<img width="3390" height="2116" alt="after-board-settings-toggle" src="https://github.com/user-attachments/assets/3bd778f4-a94a-4b94-b3ae-bbabea393394" />
<img width="1920" height="1376" alt="after-popout-cards-hint" src="https://github.com/user-attachments/assets/ce59129b-dcf0-4260-9db8-78f855fc973e" />


## Testing

- `pnpm test src/renderer/src/components/dashboard-popout src/renderer/src/components/dashboard src/main/ipc/dashboard-payload-validation.test.ts` (69 files) — new cases: modifier-click reveals and acks without opening the dialog; Ctrl on non-Mac hosts and never Cmd; the snapshot flag swaps both actions; the card forwards the click event and renders the platform-specific hint in both modes; the settings menu owns the new toggle; the snapshot builder relays the setting; the validators reject a non-boolean flag and admit a boolean one.
- `pnpm tc`, `pnpm run check:code-quality:changed`, `oxlint`/`oxfmt --check` on the changed files, `pnpm run verify:localization-extraction`, `pnpm run verify:localization-coverage`.
- Manually in `pnpm dev` on macOS: in-window drawer — plain click opens the preview, ⌘-click closes the drawer and focuses the agent's tab; toggling the setting flips both; pop-out window — hint reflects the setting, ⌘-click opens the preview inside the pop-out, plain click (setting on) switches the main window's tab via the IPC relay.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code (Claude Fable 5.1) under the author's direction; the author reviewed the diff, ran the checks, and captured the screenshots.

## Review

AI code review summary (Claude Code, four independent review passes with adversarial verification of each finding):

- **Cross-platform (macOS / Linux / Windows)**: modifier and label are runtime platform checks per AGENTS.md; no paths or shell involved.
- **SSH / remote / local**: reveal uses the same `DashboardRevealAgentArgs` (including `executionHostId`) and the same relay as the existing dialog button, so remote worktrees take the path that already works. The new snapshot field is optional, so an older pop-out preload or producer still validates.
- **Agents / integrations / git providers**: agent-agnostic; the card only forwards the click.
- **Performance**: one boolean per snapshot and one extra comparison per click; the card's memo comparator covers the new props.
- **UI quality**: default behaviour unchanged; hint text follows the ⌘/Ctrl label convention used by the board's search shortcut; the toggle mirrors "Show idle agents" in placement and copy.
- **Security**: no new IPC channels; the snapshot validator gates the new field.
- **Backwards compatibility**: new optional setting and optional snapshot field; nothing persisted changes shape.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Mobile has no kanban dashboard and is untouched. #11411 is assigned to @AmethystLiang; happy to close this in favour of an in-house change if one is already in flight.

Deliberate choices worth a second look:

- The hint is a native `title` on the card's main button rather than a Radix tooltip: `AgentStateDot` and the repo icon inside the card already use tooltips, and a second floating tooltip over the whole card would fight them. The footer button activates too but carries no hint, because the repo icon inside it already owns a tooltip and stacking a `title` on top would show two at once.
- The toggle lives in the in-window board's settings menu next to "Show idle agents"; the pop-out has no settings menu (no store), exactly as for the idle toggle, so pop-out users flip it from the in-window board or wait for a pane entry if the maintainers want one.
- Keyboard activation (Enter/Space) always takes the plain-click path; the modifier action is mouse-only, same as the search shortcut's platform handling in this board.

## Author

X: @gum79

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwSFoun5enrK3iiFrbFWRz

