### PR TITLE
fix(runtime): prevent SSH worktree list starvation

### DIFF
--- a/src/main/runtime/runtime-managed-worktree-queries.test.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.test.ts
@@ -3,6 +3,7 @@ import type { Repo } from '../../shared/repo-types'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import { RuntimeManagedWorktreeQueries } from './runtime-managed-worktree-queries'
 import type { RuntimeStore } from './runtime-store-contract'
+import type { ResolvedWorktree } from './runtime-worktree-path-identity'
 
 const settings = {
   workspaceDir: '/worktrees',
@@ -40,10 +41,47 @@ function metadata(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
   }
 }
 
-function queries(store: RuntimeStore): RuntimeManagedWorktreeQueries {
+function resolvedWorktree(overrides: Partial<ResolvedWorktree> = {}): ResolvedWorktree {
+  const path = overrides.path ?? '/workspace/app'
+  return {
+    id: `repo-1::${path}`,
+    repoId: 'repo-1',
+    path,
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: true,
+    displayName: 'Local app',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    parentWorktreeId: null,
+    childWorktreeIds: [],
+    lineage: null,
+    git: {
+      path,
+      head: 'abc123',
+      branch: 'refs/heads/main',
+      isBare: false,
+      isMainWorktree: true
+    },
+    ...overrides
+  }
+}
+
+function queries(
+  store: RuntimeStore,
+  resolved: ResolvedWorktree[] = []
+): RuntimeManagedWorktreeQueries {
   return new RuntimeManagedWorktreeQueries({
     getStore: () => store,
-    listResolved: async () => [],
+    listResolved: async () => resolved,
     resolveRepo: async () => store.getRepos()[0]!,
     selectRepos: () => store.getRepos(),
     scanRepo: async () => ({ ok: true, worktrees: [] })
@@ -102,5 +140,38 @@ describe('RuntimeManagedWorktreeQueries.listDetected', () => {
       visibilitySource: { kind: 'custom', id: 'host-source' }
     })
     expect(legacy.worktrees[0]).not.toHaveProperty('visibilitySource')
+  })
+})
+
+describe('RuntimeManagedWorktreeQueries.list', () => {
+  it('keeps the first visible row from each host before filling the limit', async () => {
+    const local = folderRepo()
+    const ssh = folderRepo({ id: 'repo-ssh', connectionId: 'box-1', path: '/remote/app' })
+    const store = {
+      getRepos: () => [local, ssh],
+      getRepo: (id: string) => [local, ssh].find((repo) => repo.id === id),
+      getAllWorktreeMeta: () => ({}),
+      getWorktreeMeta: () => undefined,
+      getSettings: () => settings
+    } as unknown as RuntimeStore
+    const rows = [
+      resolvedWorktree({ hostId: 'local', path: '/workspace/local-1' }),
+      resolvedWorktree({ hostId: 'local', path: '/workspace/local-2' }),
+      resolvedWorktree({
+        id: 'repo-ssh::/remote/app',
+        repoId: 'repo-ssh',
+        path: '/remote/app',
+        hostId: 'ssh:box-1'
+      })
+    ]
+
+    const result = await queries(store, rows).list(undefined, 2)
+
+    expect(result.worktrees.map((worktree) => worktree.path)).toEqual([
+      '/workspace/local-1',
+      '/remote/app'
+    ])
+    expect(result.totalCount).toBe(3)
+    expect(result.truncated).toBe(true)
   })
 })

--- a/src/main/runtime/runtime-managed-worktree-queries.test.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.test.ts
@@ -156,13 +156,13 @@ describe('RuntimeManagedWorktreeQueries.list', () => {
     } as unknown as RuntimeStore
     const rows = [
       resolvedWorktree({ hostId: 'local', path: '/workspace/local-1' }),
-      resolvedWorktree({ hostId: 'local', path: '/workspace/local-2' }),
       resolvedWorktree({
         id: 'repo-ssh::/remote/app',
         repoId: 'repo-ssh',
         path: '/remote/app',
         hostId: 'ssh:box-1'
-      })
+      }),
+      resolvedWorktree({ hostId: 'local', path: '/workspace/local-2' })
     ]
 
     const result = await queries(store, rows).list(undefined, 2)
@@ -173,5 +173,15 @@ describe('RuntimeManagedWorktreeQueries.list', () => {
     ])
     expect(result.totalCount).toBe(3)
     expect(result.truncated).toBe(true)
+
+    const complete = await queries(store, rows).list(undefined, 3)
+
+    expect(complete.worktrees.map((worktree) => worktree.path)).toEqual([
+      '/workspace/local-1',
+      '/remote/app',
+      '/workspace/local-2'
+    ])
+    expect(complete.totalCount).toBe(3)
+    expect(complete.truncated).toBe(false)
   })
 })

--- a/src/main/runtime/runtime-managed-worktree-queries.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.ts
@@ -31,6 +31,7 @@ import { listRuntimeFolderWorkspaces } from './runtime-worktree-filesystem'
 import type { ResolvedWorktree } from './runtime-worktree-path-identity'
 import { resolveConfiguredWorktreeBasePaths } from '../../shared/worktree/configured-worktree-base-path'
 import { getRetiredNameRegistryForRepo } from '../worktree-name-retirement'
+import { selectHostFairWorktrees } from './runtime-worktree-host-selection'
 
 type Dependencies = {
   getStore(): RuntimeStore | null
@@ -42,11 +43,8 @@ type Dependencies = {
 
 /**
  * The destructive scan expectation for one repo, or undefined when this repo must not carry one.
- *
- * WSL-routed repos are excluded for the same reason the desktop listing excludes them: the listing
- * runs in the distro and reports Linux paths while metadata can hold UNC ones, and v1 cannot prove
- * those aliases equivalent. A runtime that needs repair throws rather than resolving routing, which
- * is likewise no basis for deleting rows.
+ * WSL-routed repos are excluded for the same reason the desktop listing excludes them: the listing runs in the distro and reports Linux paths while metadata can hold UNC ones, and v1 cannot prove
+ * those aliases equivalent. A runtime that needs repair throws rather than resolving routing, which is likewise no basis for deleting rows.
  */
 function captureLocalMetadataPruneExpectation(
   store: RuntimeStore,
@@ -100,18 +98,8 @@ export class RuntimeManagedWorktreeQueries {
         (!repoId || worktree.repoId === repoId) &&
         this.isVisible(worktree, matchers.get(worktree.repoId), sourceDefaultsSupported)
     )
-    const firstIndexByHost = worktrees.reduce(
-      (first, worktree, index) =>
-        first.has(worktree.hostId ?? 'legacy')
-          ? first
-          : first.set(worktree.hostId ?? 'legacy', index),
-      new Map<string, number>()
-    )
-    const selectedIndexes = new Set(
-      [...firstIndexByHost.values(), ...worktrees.map((_, index) => index)].slice(0, limit)
-    )
     return {
-      worktrees: worktrees.filter((_worktree, index) => selectedIndexes.has(index)),
+      worktrees: selectHostFairWorktrees(worktrees, limit),
       totalCount: worktrees.length,
       truncated: worktrees.length > limit
     }

--- a/src/main/runtime/runtime-managed-worktree-queries.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.ts
@@ -100,8 +100,18 @@ export class RuntimeManagedWorktreeQueries {
         (!repoId || worktree.repoId === repoId) &&
         this.isVisible(worktree, matchers.get(worktree.repoId), sourceDefaultsSupported)
     )
+    const firstIndexByHost = worktrees.reduce(
+      (first, worktree, index) =>
+        first.has(worktree.hostId ?? 'legacy')
+          ? first
+          : first.set(worktree.hostId ?? 'legacy', index),
+      new Map<string, number>()
+    )
+    const selectedIndexes = new Set(
+      [...firstIndexByHost.values(), ...worktrees.map((_, index) => index)].slice(0, limit)
+    )
     return {
-      worktrees: worktrees.slice(0, limit),
+      worktrees: worktrees.filter((_worktree, index) => selectedIndexes.has(index)),
       totalCount: worktrees.length,
       truncated: worktrees.length > limit
     }

--- a/src/main/runtime/runtime-worktree-host-selection.ts
+++ b/src/main/runtime/runtime-worktree-host-selection.ts
@@ -1,0 +1,23 @@
+type HostOwnedWorktree = {
+  hostId?: string
+}
+
+export function selectHostFairWorktrees<T extends HostOwnedWorktree>(
+  worktrees: readonly T[],
+  limit: number
+): T[] {
+  const firstIndexByHost = worktrees.reduce(
+    (first, worktree, index) =>
+      first.has(worktree.hostId ?? 'legacy')
+        ? first
+        : first.set(worktree.hostId ?? 'legacy', index),
+    new Map<string, number>()
+  )
+  const selectedIndexes = new Set(
+    [...new Set([...firstIndexByHost.values(), ...worktrees.map((_, index) => index)])].slice(
+      0,
+      limit
+    )
+  )
+  return worktrees.filter((_worktree, index) => selectedIndexes.has(index))
+}


### PR DESCRIPTION
Fixes #18104. Preserve worktree ordering and response shape while ensuring host-fair selection does not let local rows consume the entire limit and SSH rows disappear. Includes regression coverage and index deduplication.