### PR TITLE
fix(ssh): preserve linked native deps on unverifiable probe

### DIFF
--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -1091,6 +1091,12 @@ async function installNativeDeps(
     if (linkedProbe.available) {
       return
     }
+    if (linkedProbe.missing.length === 0) {
+      console.warn(
+        `[ssh-relay][NATIVE-CACHE-PROBE-UNVERIFIABLE] shared entry ${cache.key} could not be verified at ${remoteDir} (${platform}); preserving the linked cache and launching as-is. stderr=${linkedProbe.stderr.trim().slice(-500)}`
+      )
+      return
+    }
     // Why fall through rather than repair the entry: it is shared, and something else on this
     // host may be running out of it right now. This directory installs its own copy instead.
     console.warn(

--- a/src/main/ssh/ssh-relay-native-deps-cache-deploy.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache-deploy.test.ts
@@ -181,6 +181,29 @@ describe('relay native-deps cache on the deploy path', () => {
     expect(commands.some((c) => /\.orca-remote\/native\/linux-x64-[0-9a-f]{16}/.test(c))).toBe(true)
   })
 
+  it('installs per-directory when a linked probe names node-pty as missing', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      firstInstall(RELAY_NATIVE_CACHE_LINKED, [
+        '', // chmod prebuilds, through the symlink
+        'ORCA-NATIVE-DEPS-MISSING:node-pty\nMISSING', // explicit evidence about the broken dep
+        '', // cat probe stderr
+        '', // rm probe stderr
+        '', // npm install, privately, after the prefix detaches the symlink
+        '', // chmod prebuilds
+        'ORCA-NPTY-PROBE-OK\n',
+        '', // rm probe stderr
+        '', // promotion attempt (the entry already exists, so it is declined)
+        ...LAUNCH_TAIL
+      ])
+    )
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+
+    const install = execCommands().find((c) => c.includes('npm install')) ?? ''
+    expect(install).toContain('if [ -L node_modules ]; then rm -f node_modules; fi;')
+  })
+
   it('still installs on the first deploy, then publishes the tree the probe loaded', async () => {
     const conn = makeMockConnection(sftpCapture)
     feed(

--- a/src/main/ssh/ssh-relay-native-deps-cache-deploy.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-cache-deploy.test.ts
@@ -75,6 +75,7 @@ import { isRelayAlreadyInstalled, gcOldRelayVersions } from './ssh-relay-version
 import {
   makeMockConnection,
   makeStagedFirstInstallExecPrefix,
+  BOTH_NATIVE_DEPS_MISSING_PROBE,
   type ExecResponse,
   type SftpWriteCapture
 } from './ssh-relay-native-deps-install-fixture'
@@ -157,6 +158,29 @@ describe('relay native-deps cache on the deploy path', () => {
     expect(commands.some((c) => /\.orca-remote\/native\/linux-x64-[0-9a-f]{16}/.test(c))).toBe(true)
   })
 
+  it('preserves a linked entry when its probe answer names no missing dependency', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      firstInstall(RELAY_NATIVE_CACHE_LINKED, [
+        '', // chmod prebuilds, through the symlink
+        'MISSING\n', // the linked probe is markerless and therefore unverifiable
+        '', // cat probe stderr
+        '', // rm probe stderr
+        ...LAUNCH_TAIL
+      ])
+    )
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+
+    const commands = execCommands()
+    expect(commands.some((c) => c.includes('npm install'))).toBe(false)
+    expect(commands.some((c) => c.includes('npm rebuild'))).toBe(false)
+    expect(
+      commands.some((c) => c.includes('if [ -L node_modules ]; then rm -f node_modules; fi;'))
+    ).toBe(false)
+    expect(commands.some((c) => /\.orca-remote\/native\/linux-x64-[0-9a-f]{16}/.test(c))).toBe(true)
+  })
+
   it('still installs on the first deploy, then publishes the tree the probe loaded', async () => {
     const conn = makeMockConnection(sftpCapture)
     feed(
@@ -228,7 +252,7 @@ describe('relay native-deps cache on the deploy path', () => {
     feed(
       firstInstall(RELAY_NATIVE_CACHE_LINKED, [
         '', // chmod prebuilds
-        'MISSING\n', // the shared tree does not load here
+        BOTH_NATIVE_DEPS_MISSING_PROBE, // the shared tree explicitly names broken deps
         '', // cat probe stderr
         '', // rm probe stderr
         '', // npm install, privately, after the prefix detaches the symlink


### PR DESCRIPTION
## ELI5

When Orca cannot confirm whether a linked native-dependency cache is available on an SSH host, it now keeps the last known-good shared link instead of discarding it. An explicit missing-dependency marker still triggers the existing per-directory recovery path.

## What Changed

- Preserve markerless linked native-dependency cache results when the remote probe is `unverifiable`.
- Keep per-directory recovery for explicit `ORCA-NATIVE-DEPS-MISSING` markers.
- Add focused SSH regression coverage for both outcomes.

## Why

An unavailable SSH probe is not evidence that a previously valid shared dependency link is bad. Treating it as missing could replace a good cache result and break relay startup during a transient or unclassifiable remote failure.

## Linked Issue

Fixes #18083

## Visual Proof

N/A — this changes SSH relay deployment and cache recovery behavior; it has no visual or interaction change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Focused regression coverage is in `src/main/ssh/ssh-relay-native-deps-cache-deploy.test.ts`. Current GitHub `PR Checks` and `PR test LoC` runs require maintainer approval and have not executed, so this description does not claim CI passed.

## AI Disclosure

Codex assisted with review and this PR description update.

## Review

No unresolved review threads or requested changes remain. Pullfrog completed successfully on the current head.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security, SSH execution ownership, loss-of-contact semantics, folder workspaces, cross-platform behavior, and backward compatibility were considered. No renderer or mobile impact.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
