### PR TITLE
fix(cli): reject selectors for local host lists

### DIFF
--- a/src/cli/handlers/environment.ts
+++ b/src/cli/handlers/environment.ts
@@ -1,4 +1,4 @@
-import type { CommandHandler } from '../dispatch'
+import type { CommandHandler, HandlerContext } from '../dispatch'
 import { formatEnvironment, formatEnvironmentList, formatHostList, printResult } from '../format'
 import { listSshTargets } from '../host-selector-alternatives'
 import { getDefaultUserDataPath, RuntimeClientError } from '../runtime-client'
@@ -33,7 +33,9 @@ export const ENVIRONMENT_HANDLERS: Record<string, CommandHandler> = {
   // Why: an agent told "run it on <name>" had nowhere to look. `orca environment list` showed
   // paired servers only, and nothing in the CLI listed SSH targets at all, so the wrong-axis
   // guess was the only move available. This is the one place that answers both.
-  'host list': async ({ client, json }) => {
+  'host list': async (ctx) => {
+    rejectRemoteSelectionFlags(ctx, 'orca host list')
+    const { client, json } = ctx
     const environments = listEnvironments(getDefaultUserDataPath()).map((environment) => ({
       kind: 'environment' as const,
       name: environment.name,
@@ -53,7 +55,9 @@ export const ENVIRONMENT_HANDLERS: Record<string, CommandHandler> = {
     ]
     printResult(localSuccess({ hosts }), json, formatHostList)
   },
-  'environment list': async ({ json }) => {
+  'environment list': async (ctx) => {
+    rejectRemoteSelectionFlags(ctx, 'orca environment list')
+    const { json } = ctx
     const environments = listEnvironments(getDefaultUserDataPath()).map(redactRuntimeEnvironment)
     printResult(localSuccess({ environments }), json, formatEnvironmentList)
   },
@@ -75,6 +79,17 @@ export const ENVIRONMENT_HANDLERS: Record<string, CommandHandler> = {
       (result: EnvironmentRemoveResult) =>
         `Removed environment ${result.removed.name} (${result.removed.id}).`
     )
+  }
+}
+
+function rejectRemoteSelectionFlags(ctx: HandlerContext, command: string): void {
+  for (const flag of ['environment', 'pairing-code']) {
+    if (ctx.flags.has(flag)) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        `\`--${flag}\` does not retarget \`${command}\`. Run it on the host whose environments and hosts you want to inspect.`
+      )
+    }
   }
 }
 

--- a/src/cli/index-environment-commands.test.ts
+++ b/src/cli/index-environment-commands.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   callMock,
@@ -43,7 +43,16 @@ vi.mock('child_process', async () => {
 import { main } from './index'
 import { useWorktreeAwarenessEnvironment } from './index-test-harness'
 
+const localOnlyCommands = [
+  ['environment list', ['environment', 'list']],
+  ['host list', ['host', 'list']]
+] as const
+
 describe('orca cli worktree awareness', () => {
+  beforeEach(() => {
+    process.exitCode = 0
+  })
+
   useWorktreeAwarenessEnvironment({
     callMock,
     serveOrcaAppMock,
@@ -55,15 +64,52 @@ describe('orca cli worktree awareness', () => {
 
   it('lists saved environments even when ORCA_ENVIRONMENT is set', async () => {
     process.env.ORCA_ENVIRONMENT = 'stale-env'
+    process.env.ORCA_PAIRING_CODE = 'stale-pairing-code'
     listEnvironmentsMock.mockReturnValue([addEnvironmentFromPairingCodeMock()])
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
     await main(['environment', 'list', '--json'], '/tmp/repo')
 
     expect(listEnvironmentsMock).toHaveBeenCalledWith('/tmp/orca-user-data')
+    expect(runtimeClientConstructorMock).not.toHaveBeenCalled()
     expect(callMock).not.toHaveBeenCalled()
     expect(logSpy.mock.calls[0]?.[0]).not.toContain('token')
     expect(logSpy.mock.calls[0]?.[0]).not.toContain('publicKeyB64')
+  })
+
+  it.each(
+    localOnlyCommands.flatMap(([command, argv]) =>
+      ['environment', 'pairing-code'].map((flag) => [command, argv, flag] as const)
+    )
+  )('rejects explicit --%s for %s before runtime access', async (command, argv, flag) => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main([...argv, `--${flag}`, 'remote-host'], '/tmp/repo')
+
+    expect(process.exitCode).toBe(1)
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain(
+      `\`--${flag}\` does not retarget \`orca ${command}\``
+    )
+    expect(runtimeClientConstructorMock).not.toHaveBeenCalled()
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps host list local when ambient remote selectors are set', async () => {
+    process.env.ORCA_ENVIRONMENT = 'stale-environment'
+    process.env.ORCA_PAIRING_CODE = 'stale-pairing-code'
+    callMock.mockResolvedValue({
+      id: 'local',
+      ok: true,
+      result: { targets: [] },
+      _meta: { runtimeId: 'local' }
+    })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['host', 'list', '--json'], '/tmp/repo')
+
+    expect(process.exitCode).not.toBe(1)
+    expect(runtimeClientConstructorMock).toHaveBeenCalledWith(null, null)
+    expect(callMock).toHaveBeenCalledWith('ssh.listTargetSummaries')
   })
 
   it('adds saved environments even when ORCA_ENVIRONMENT is set', async () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ function shouldIgnoreRemoteSelection(commandPath: string[]): boolean {
     commandPath[0] === 'account' ||
     commandPath[0] === 'artifacts' ||
     commandPath[0] === 'environment' ||
+    commandPath[0] === 'host' ||
     commandPath[0] === 'serve' ||
     commandPath[0] === 'agent' ||
     commandPath[0] === 'vm' ||


### PR DESCRIPTION
Fixes #18105. Reject explicit remote selectors for local-only environment and host list commands while preserving ambient selector suppression and local behavior.