### PR TITLE
fix(automations): wait for startup hydration before dispatch

### DIFF
--- a/src/renderer/src/app-shell/use-app-shell-services.ts
+++ b/src/renderer/src/app-shell/use-app-shell-services.ts
@@ -36,7 +36,7 @@ export function useAppShellServices(options: { floatingPanelVisible: boolean }):
   // Subscribe to IPC push events
   useIpcEvents()
   useRemoteRuntimeRecoveryTriggers()
-  useAutomationDispatchEvents()
+  useAutomationDispatchEvents(workspaceSessionReady)
   // Why: git polling lives at App level (RightSidebar unmounts when closed, stranding stale Rebasing/Merging badges); gate on workspaceSessionReady so it doesn't compete with first paint.
   useGitStatusPolling({ enabled: workspaceSessionReady })
   // Why: wire file-change watching at App level so the editor keeps hearing FS changes when Explorer unmounts (right-sidebar switches to Source Control/Checks).

--- a/src/renderer/src/hooks/automation-dispatch-handler.ts
+++ b/src/renderer/src/hooks/automation-dispatch-handler.ts
@@ -13,6 +13,7 @@ import type {
 import { createAutomationDispatchCompletion } from './automation-dispatch-completion'
 import {
   prepareAutomationDispatchWorkspace,
+  refreshLocalAutomationDispatchWorkspace,
   resolveAutomationDispatchWorkspace
 } from './automation-dispatch-workspace'
 
@@ -37,14 +38,14 @@ export async function handleAutomationDispatchRequest({
     // here would arrive second and invalidate every host in the catalog.
     await window.api.automations.markDispatchResult(result)
   }
-  const state = useAppStore.getState()
+  let state = useAppStore.getState()
   const focusBeforeDispatch = {
     activeView: state.activeView,
     activeWorktreeId: state.activeWorktreeId,
     activeTabId: state.activeTabId,
     activeTabType: state.activeTabType
   }
-  const resolved = resolveAutomationDispatchWorkspace(state, automation, run)
+  let resolved = resolveAutomationDispatchWorkspace(state, automation, run)
   let terminalOwnership: AutomationTerminalOwnership | null = null
   const releaseTerminalOwnership = (): void => {
     const ownership = terminalOwnership
@@ -57,21 +58,29 @@ export async function handleAutomationDispatchRequest({
     return ownership?.finalize() ?? false
   }
 
-  if (!resolved.repo) {
-    await markDispatchResult({
-      runId: run.id,
-      status: 'skipped_unavailable',
-      workspaceId: run.workspaceId,
-      workspaceDisplayName: run.workspaceDisplayName ?? null,
-      error: translate(
-        'auto.hooks.useAutomationDispatchEvents.386db94f3e',
-        'The target project is no longer available.'
-      )
-    })
-    return
-  }
-
   try {
+    if (!resolved.repo) {
+      const refreshed = await refreshLocalAutomationDispatchWorkspace(
+        useAppStore.getState,
+        automation,
+        run
+      )
+      state = refreshed.state
+      resolved = refreshed.resolved
+    }
+    if (!resolved.repo) {
+      await markDispatchResult({
+        runId: run.id,
+        status: 'skipped_unavailable',
+        workspaceId: run.workspaceId,
+        workspaceDisplayName: run.workspaceDisplayName ?? null,
+        error: translate(
+          'auto.hooks.useAutomationDispatchEvents.386db94f3e',
+          'The target project is no longer available.'
+        )
+      })
+      return
+    }
     const worktree = await prepareAutomationDispatchWorkspace({
       state,
       automation,

--- a/src/renderer/src/hooks/automation-dispatch-workspace-refresh.test.ts
+++ b/src/renderer/src/hooks/automation-dispatch-workspace-refresh.test.ts
@@ -18,7 +18,7 @@ function makeState(repos: { id: string }[]) {
     repos,
     allWorktrees: () => [],
     getKnownWorktreeById: () => undefined,
-    fetchReposForAllHosts: vi.fn<() => Promise<void>>(),
+    fetchRepos: vi.fn<() => Promise<void>>(),
     awaitLocalRepoCatalogSettlement: vi.fn<() => Promise<void>>()
   }
 }
@@ -28,7 +28,7 @@ describe('refreshLocalAutomationDispatchWorkspace', () => {
     const refreshed = makeState([{ id: 'repo-1' }])
     const initial = makeState([])
     let current = initial
-    initial.fetchReposForAllHosts.mockImplementation(async () => {
+    initial.fetchRepos.mockImplementation(async () => {
       current = refreshed
     })
     refreshed.awaitLocalRepoCatalogSettlement.mockResolvedValue(undefined)
@@ -39,7 +39,7 @@ describe('refreshLocalAutomationDispatchWorkspace', () => {
       run
     )
 
-    expect(initial.fetchReposForAllHosts).toHaveBeenCalledWith({ remoteHosts: 'skip' })
+    expect(initial.fetchRepos).toHaveBeenCalledWith({ runtimeEnvironmentId: null })
     expect(refreshed.awaitLocalRepoCatalogSettlement).toHaveBeenCalledOnce()
     expect(result.state).toBe(refreshed)
     expect(result.resolved.repo?.id).toBe('repo-1')
@@ -47,7 +47,7 @@ describe('refreshLocalAutomationDispatchWorkspace', () => {
 
   it('keeps the target unavailable when the refreshed catalog is still empty', async () => {
     const state = makeState([])
-    state.fetchReposForAllHosts.mockResolvedValue(undefined)
+    state.fetchRepos.mockResolvedValue(undefined)
     state.awaitLocalRepoCatalogSettlement.mockResolvedValue(undefined)
 
     const result = await refreshLocalAutomationDispatchWorkspace(
@@ -56,7 +56,7 @@ describe('refreshLocalAutomationDispatchWorkspace', () => {
       run
     )
 
-    expect(state.fetchReposForAllHosts).toHaveBeenCalledOnce()
+    expect(state.fetchRepos).toHaveBeenCalledWith({ runtimeEnvironmentId: null })
     expect(state.awaitLocalRepoCatalogSettlement).toHaveBeenCalledOnce()
     expect(result.resolved.repo).toBeUndefined()
   })

--- a/src/renderer/src/hooks/automation-dispatch-workspace-refresh.test.ts
+++ b/src/renderer/src/hooks/automation-dispatch-workspace-refresh.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Automation, AutomationRun } from '../../../shared/automations-types'
+import { refreshLocalAutomationDispatchWorkspace } from './automation-dispatch-workspace'
+
+const automation = {
+  id: 'automation-1',
+  projectId: 'repo-1',
+  workspaceId: null
+} as Automation
+
+const run = {
+  id: 'run-1',
+  workspaceDisplayName: null
+} as AutomationRun
+
+function makeState(repos: { id: string }[]) {
+  return {
+    repos,
+    allWorktrees: () => [],
+    getKnownWorktreeById: () => undefined,
+    fetchReposForAllHosts: vi.fn<() => Promise<void>>(),
+    awaitLocalRepoCatalogSettlement: vi.fn<() => Promise<void>>()
+  }
+}
+
+describe('refreshLocalAutomationDispatchWorkspace', () => {
+  it('rereads the store after the local catalog refresh', async () => {
+    const refreshed = makeState([{ id: 'repo-1' }])
+    const initial = makeState([])
+    let current = initial
+    initial.fetchReposForAllHosts.mockImplementation(async () => {
+      current = refreshed
+    })
+    refreshed.awaitLocalRepoCatalogSettlement.mockResolvedValue(undefined)
+
+    const result = await refreshLocalAutomationDispatchWorkspace(
+      () => current as never,
+      automation,
+      run
+    )
+
+    expect(initial.fetchReposForAllHosts).toHaveBeenCalledWith({ remoteHosts: 'skip' })
+    expect(refreshed.awaitLocalRepoCatalogSettlement).toHaveBeenCalledOnce()
+    expect(result.state).toBe(refreshed)
+    expect(result.resolved.repo?.id).toBe('repo-1')
+  })
+
+  it('keeps the target unavailable when the refreshed catalog is still empty', async () => {
+    const state = makeState([])
+    state.fetchReposForAllHosts.mockResolvedValue(undefined)
+    state.awaitLocalRepoCatalogSettlement.mockResolvedValue(undefined)
+
+    const result = await refreshLocalAutomationDispatchWorkspace(
+      () => state as never,
+      automation,
+      run
+    )
+
+    expect(state.fetchReposForAllHosts).toHaveBeenCalledOnce()
+    expect(state.awaitLocalRepoCatalogSettlement).toHaveBeenCalledOnce()
+    expect(result.resolved.repo).toBeUndefined()
+  })
+})

--- a/src/renderer/src/hooks/automation-dispatch-workspace.ts
+++ b/src/renderer/src/hooks/automation-dispatch-workspace.ts
@@ -64,7 +64,9 @@ export async function refreshLocalAutomationDispatchWorkspace(
   state: AutomationDispatchStoreState
   resolved: ResolvedAutomationDispatchWorkspace
 }> {
-  await getState().fetchReposForAllHosts({ remoteHosts: 'skip' })
+  // Refresh only the local host. An all-host refresh claims the store-wide
+  // generation and can cancel startup's in-flight remote catalog load.
+  await getState().fetchRepos({ runtimeEnvironmentId: null })
   await getState().awaitLocalRepoCatalogSettlement()
   const state = getState()
   return {

--- a/src/renderer/src/hooks/automation-dispatch-workspace.ts
+++ b/src/renderer/src/hooks/automation-dispatch-workspace.ts
@@ -55,6 +55,24 @@ export function resolveAutomationDispatchWorkspace(
 
 type ResolvedAutomationDispatchWorkspace = ReturnType<typeof resolveAutomationDispatchWorkspace>
 
+/** Refreshes the local catalog once before treating a missing automation project as unavailable. */
+export async function refreshLocalAutomationDispatchWorkspace(
+  getState: () => AutomationDispatchStoreState,
+  automation: Automation,
+  run: AutomationRun
+): Promise<{
+  state: AutomationDispatchStoreState
+  resolved: ResolvedAutomationDispatchWorkspace
+}> {
+  await getState().fetchReposForAllHosts({ remoteHosts: 'skip' })
+  await getState().awaitLocalRepoCatalogSettlement()
+  const state = getState()
+  return {
+    state,
+    resolved: resolveAutomationDispatchWorkspace(state, automation, run)
+  }
+}
+
 export async function prepareAutomationDispatchWorkspace(args: {
   state: AutomationDispatchStoreState
   automation: Automation

--- a/src/renderer/src/hooks/useAutomationDispatchEvents-hydration.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents-hydration.test.ts
@@ -1,0 +1,53 @@
+import type * as ReactModule from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockOnDispatchRequested = vi.fn(() => () => {})
+const mockRendererReady = vi.fn()
+
+vi.mock('./automation-dispatch-handler', () => ({
+  handleAutomationDispatchRequest: vi.fn()
+}))
+
+describe('useAutomationDispatchEvents hydration gate', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.stubGlobal('window', {
+      api: {
+        automations: {
+          onDispatchRequested: mockOnDispatchRequested,
+          rendererReady: mockRendererReady
+        }
+      }
+    })
+  })
+
+  async function mount(rendererReady: boolean): Promise<void> {
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof ReactModule>('react')
+      return {
+        ...actual,
+        useEffect: (effect: () => void | (() => void)) => {
+          effect()
+        }
+      }
+    })
+    const { useAutomationDispatchEvents: registerAutomationDispatchEvents } =
+      await import('./useAutomationDispatchEvents')
+    registerAutomationDispatchEvents(rendererReady)
+  }
+
+  it('subscribes without releasing scheduled runs before startup hydration', async () => {
+    await mount(false)
+
+    expect(mockOnDispatchRequested).toHaveBeenCalledOnce()
+    expect(mockRendererReady).not.toHaveBeenCalled()
+  })
+
+  it('releases scheduled runs after startup hydration', async () => {
+    await mount(true)
+
+    expect(mockOnDispatchRequested).toHaveBeenCalledOnce()
+    expect(mockRendererReady).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/hooks/useAutomationDispatchEvents-hydration.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents-hydration.test.ts
@@ -1,7 +1,10 @@
-import type * as ReactModule from 'react'
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAutomationDispatchEvents } from './useAutomationDispatchEvents'
 
-const mockOnDispatchRequested = vi.fn(() => () => {})
+const mockUnsubscribe = vi.fn()
+const mockOnDispatchRequested = vi.fn(() => mockUnsubscribe)
 const mockRendererReady = vi.fn()
 
 vi.mock('./automation-dispatch-handler', () => ({
@@ -10,10 +13,10 @@ vi.mock('./automation-dispatch-handler', () => ({
 
 describe('useAutomationDispatchEvents hydration gate', () => {
   beforeEach(() => {
-    vi.resetModules()
     vi.clearAllMocks()
-    vi.stubGlobal('window', {
-      api: {
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
         automations: {
           onDispatchRequested: mockOnDispatchRequested,
           rendererReady: mockRendererReady
@@ -22,32 +25,23 @@ describe('useAutomationDispatchEvents hydration gate', () => {
     })
   })
 
-  async function mount(rendererReady: boolean): Promise<void> {
-    vi.doMock('react', async () => {
-      const actual = await vi.importActual<typeof ReactModule>('react')
-      return {
-        ...actual,
-        useEffect: (effect: () => void | (() => void)) => {
-          effect()
-        }
-      }
-    })
-    const { useAutomationDispatchEvents: registerAutomationDispatchEvents } =
-      await import('./useAutomationDispatchEvents')
-    registerAutomationDispatchEvents(rendererReady)
-  }
-
-  it('subscribes without releasing scheduled runs before startup hydration', async () => {
-    await mount(false)
+  it('releases scheduled runs once when startup hydration becomes ready', () => {
+    const hook = renderHook(
+      ({ rendererReady }: { rendererReady: boolean }) => useAutomationDispatchEvents(rendererReady),
+      { initialProps: { rendererReady: false } }
+    )
 
     expect(mockOnDispatchRequested).toHaveBeenCalledOnce()
     expect(mockRendererReady).not.toHaveBeenCalled()
-  })
 
-  it('releases scheduled runs after startup hydration', async () => {
-    await mount(true)
-
+    hook.rerender({ rendererReady: true })
     expect(mockOnDispatchRequested).toHaveBeenCalledOnce()
     expect(mockRendererReady).toHaveBeenCalledOnce()
+
+    hook.rerender({ rendererReady: true })
+    expect(mockRendererReady).toHaveBeenCalledOnce()
+
+    hook.unmount()
+    expect(mockUnsubscribe).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -114,7 +114,7 @@ async function registerAndDispatch(automation = makeAutomation()): Promise<void>
   })
   const { useAutomationDispatchEvents: registerAutomationDispatchEvents } =
     await import('./useAutomationDispatchEvents')
-  registerAutomationDispatchEvents()
+  registerAutomationDispatchEvents(true)
   const handler = mockOnDispatchRequested.mock.calls[0]?.[0]
   if (!handler) {
     throw new Error('dispatch handler was not registered')

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -1,6 +1,10 @@
 import { useEffect } from 'react'
 import { handleAutomationDispatchRequest } from './automation-dispatch-handler'
 
+/**
+ * Keeps the dispatch listener attached while withholding main's readiness
+ * handshake until the renderer has hydrated its workspace catalog.
+ */
 export function useAutomationDispatchEvents(rendererReady: boolean): void {
   useEffect(() => {
     const unsubscribe = window.api.automations.onDispatchRequested(handleAutomationDispatchRequest)

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -1,10 +1,19 @@
 import { useEffect } from 'react'
 import { handleAutomationDispatchRequest } from './automation-dispatch-handler'
 
-export function useAutomationDispatchEvents(): void {
+export function useAutomationDispatchEvents(rendererReady: boolean): void {
   useEffect(() => {
     const unsubscribe = window.api.automations.onDispatchRequested(handleAutomationDispatchRequest)
-    void window.api.automations.rendererReady()
     return unsubscribe
   }, [])
+
+  useEffect(() => {
+    if (!rendererReady) {
+      return
+    }
+    // Why: main evaluates overdue scheduled runs as soon as this signal arrives.
+    // Wait until startup has hydrated the local repo catalog and workspace session,
+    // or a valid project can be permanently recorded as skipped_unavailable (#12318).
+    void window.api.automations.rendererReady()
+  }, [rendererReady])
 }


### PR DESCRIPTION
## ELI5

Orca could release scheduled automations before the local project list was usable. A real project then looked deleted and the run was permanently skipped. This waits for startup hydration and, if lookup still misses, refreshes the local catalog once before deciding the project is unavailable.

## What Changed

- keep the automation dispatch listener subscribed during startup
- defer the renderer-ready handshake until `workspaceSessionReady`
- retry a missing local project after a local-only catalog refresh and latest-refresh settlement
- keep that local retry from superseding the concurrent startup remote-catalog load
- cover the readiness transition plus successful and unsuccessful recovery

## Why

Main evaluates overdue scheduled runs as soon as the renderer reports ready. The startup barrier prevents the initial race. The one-shot refresh covers a later transient empty catalog without arbitrary sleeps or remote-host delays.

## Linked Issue

Fixes #12318

## Visual Proof

N/A. This changes background startup and dispatch behavior without a visual surface.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS:
- isolated Electron cold-start smoke: an overdue local `new_per_run` automation advanced to `dispatched`, created its workspace, attached its terminal, and retained `error: null`
- `pnpm test src/renderer/src/hooks/automation-dispatch-workspace-refresh.test.ts src/renderer/src/store/slices/repos-all-hosts-generation.test.ts src/renderer/src/hooks/useAutomationDispatchEvents.test.ts` (35 tests)
- `pnpm tc`
- `pnpm run check:code-quality:changed`
- `git diff --check`
- Earlier full validation on this PR: `pnpm lint` and `pnpm build` passed
- Earlier full `pnpm test`: 70,644 passed; three release-checkout timeouts and one orchestration performance threshold passed on isolated rerun; the two unchanged `structured-tui-transcript-catchup` tests still fail when isolated

The changed paths introduce no filesystem, shell, path, SSH, remote runtime, or platform-specific behavior. Remote project hydration remains outside this local-project fix; the local recovery path now preserves the concurrent startup remote-catalog load.

## AI Disclosure

OpenAI Codex was used to diagnose the live failure, implement the change, and add tests.

## Review

Please focus on the startup readiness boundary and whether the one-shot local refresh correctly prevents false `skipped_unavailable` results without cancelling the concurrent remote catalog load.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The listener attaches immediately. Degraded startup still sets `workspaceSessionReady`, so automation dispatch is not gated forever if session restoration fails. A refresh failure becomes `dispatch_failed`; a settled catalog that still lacks the project retains `skipped_unavailable`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
