### PR TITLE
fix(relay): stop counting the probe's TLS handshake as region jitter

### DIFF
--- a/src/main/runtime/relay/relay-region-preference.test.ts
+++ b/src/main/runtime/relay/relay-region-preference.test.ts
@@ -170,6 +170,103 @@ describe('Relay region preference', () => {
     ).resolves.toBeUndefined()
   })
 
+  it('forgives a first probe that paid the TLS handshake instead of pinning the far region', async () => {
+    const path = userDataPath()
+    // Why: the cold round carries DNS+TCP+TLS on top of the RTT; the two warm rounds are the
+    // comparable pair. Reading the spread across all three disqualified every healthy region.
+    const { probe } = sampledProbe({ [US]: [200, 40, 42], [ASIA]: [780, 792, 800] })
+
+    await expect(
+      new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: path,
+        fetch: catalogFetch([
+          { region: 'us-central1', probeOrigins: [US] },
+          { region: 'asia-east2', probeOrigins: [ASIA] }
+        ]),
+        probe,
+        now: () => 1_000
+      }).resolve()
+    ).resolves.toBe('us-central1')
+    expect(JSON.parse(readFileSync(cachePath(path), 'utf8'))).toMatchObject({
+      region: 'us-central1',
+      latencyMs: 42
+    })
+  })
+
+  it('still rejects a region whose warm rounds disagree, whatever the cold one did', async () => {
+    const path = userDataPath()
+    // Why: 260 ms between the comparable rounds trips only the warm gate; the 900 ms tail
+    // sits under the cold ceiling, so this cannot pass through the other check.
+    const jittery = sampledProbe({ [US]: [40, 300, 900] })
+
+    await expect(
+      new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: path,
+        fetch: catalogFetch([{ region: 'us-central1', probeOrigins: [US] }]),
+        probe: jittery.probe,
+        now: () => 1_000
+      }).resolve()
+    ).resolves.toBeUndefined()
+  })
+
+  it('judges jitter on the warm rounds even when the cold sample sits between or below them', async () => {
+    const path = userDataPath()
+    const jitteryWarmRounds = sampledProbe({ [US]: [150, 100, 300] })
+    await expect(
+      new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: path,
+        fetch: catalogFetch([{ region: 'us-central1', probeOrigins: [US] }]),
+        probe: jitteryWarmRounds.probe,
+        now: () => 1_000
+      }).resolve()
+    ).resolves.toBeUndefined()
+
+    const fastColdRound = sampledProbe({ [US]: [30, 100, 102] })
+    await expect(
+      new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: path,
+        fetch: catalogFetch([{ region: 'us-central1', probeOrigins: [US] }]),
+        probe: fastColdRound.probe,
+        now: () => 1_000
+      }).resolve()
+    ).resolves.toBe('us-central1')
+    expect(JSON.parse(readFileSync(cachePath(path), 'utf8'))).toMatchObject({ latencyMs: 100 })
+  })
+
+  it('still rejects a first round that stalls far beyond any handshake', async () => {
+    const path = userDataPath()
+    const stalledColdRound = sampledProbe({ [US]: [1400, 95, 100] })
+
+    await expect(
+      new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: path,
+        fetch: catalogFetch([{ region: 'us-central1', probeOrigins: [US] }]),
+        probe: stalledColdRound.probe,
+        now: () => 1_000
+      }).resolve()
+    ).resolves.toBeUndefined()
+  })
+
+  it('still rejects a region that stalls one round in three', async () => {
+    const path = userDataPath()
+    const stalling = sampledProbe({ [US]: [95, 100, 1400] })
+
+    await expect(
+      new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: path,
+        fetch: catalogFetch([{ region: 'us-central1', probeOrigins: [US] }]),
+        probe: stalling.probe,
+        now: () => 1_000
+      }).resolve()
+    ).resolves.toBeUndefined()
+  })
+
   it('recovers from corrupt cache and cancels an old directors error response', async () => {
     const path = userDataPath()
     writeFileSync(cachePath(path), '{not-json')

--- a/src/main/runtime/relay/relay-region-preference.ts
+++ b/src/main/runtime/relay/relay-region-preference.ts
@@ -243,10 +243,13 @@ async function measureRegion(
     }
     samples.push(Math.min(...latencies))
   }
-  samples.sort((left, right) => left - right)
-  const median = samples[1]!
-  const spread = samples[2]! - samples[0]!
-  if (spread > Math.max(20, median * 0.5)) {
+  // Why: the first probe pays DNS+TCP+TLS on top of the RTT, so jitter is judged on the two
+  // warm rounds and the cold one only has to stay within a handshake-sized ceiling of them.
+  const [cold, firstWarm, secondWarm] = samples
+  const median = [...samples].sort((left, right) => left - right)[1]!
+  const warmSpread = Math.abs(firstWarm! - secondWarm!)
+  const coldSpread = cold! - Math.min(firstWarm!, secondWarm!)
+  if (warmSpread > Math.max(20, median * 0.5) || coldSpread > Math.max(150, median * 5)) {
     return null
   }
   return { region: entry.region, latencyMs: median }


### PR DESCRIPTION
## ELI5

Orca picks the closest relay region by pinging each one three times and throwing away any region whose three timings disagree too much. But the very first ping always includes the cost of opening the connection (DNS, TCP, TLS), so it is naturally much slower than the two that follow. The check read that as "unstable" and threw away perfectly healthy regions, sometimes leaving only the far one, which then got remembered for a day. Now the stability check compares the two comparable pings and only asks the first one to be within a generous handshake budget.

## What Changed

`measureRegion` in `src/main/runtime/relay/relay-region-preference.ts` replaces the single `max - min > max(20, median * 0.5)` gate, computed over the sorted samples, with two gates over the samples in probe order:

- warm gate: `|second - third| > max(20, median * 0.5)` rejects a region whose two kept-alive rounds disagree, exactly the jitter the old gate meant to catch;
- cold gate: `first - min(second, third) > max(150, median * 5)` keeps a ceiling on the first round so a region that stalls there far beyond any handshake (`[1400, 95, 100]`) still loses instead of winning at `latencyMs: 100`.

Judging in probe order matters: sorted, a stall in round three (`[95, 100, 1400]`) looks the same as a slow handshake in round one, and a fast cold sample below two disagreeing warm ones (`[150, 100, 300]`) hides the disagreement. The cached value stays the median of the three, the region order tie-break stays the same, and the existing `[10, 20, 200]` "unstable probes" fixture still rejects, now via the warm gate. Numbers stay inline as before because the file sits at the 300-line lint ceiling.

## Why

Fixes #18212

The first probe of a region pays DNS + TCP + TLS (about three RTTs) while rounds two and three ride the kept-alive connection (about one RTT), so `samples[2] - samples[0]` was dominated by the handshake and `spread ≈ 2·RTT > 0.5·RTT` held for any RTT. The issue measured this against three real HTTPS endpoints and all three healthy destinations were rejected by their own handshake. With only two regions in the catalog, disqualifying one leaves the other winning unopposed with no absolute floor, and `selectRegionMeasurement` caches it for 24 hours: that is the reported `asia-east2` at 792 ms from Mexico. The two-gate shape and thresholds follow the issue's proposal, including the reasons an absolute latency ceiling was rejected (it measures main-process event-loop delay as much as network).

## Linked Issue

Fixes #18212

## Visual Proof

N/A: no UI or interaction change. The observable effect is which region the resolver caches in `orca-relay-region-preference.json`, which the two new unit tests pin.

## Testing

- `pnpm test src/main/runtime/relay/relay-region-preference.test.ts`: five new cases. `forgives a first probe that paid the TLS handshake instead of pinning the far region` fails before the change with `expected 'asia-east2' to be 'us-central1'` (the reported symptom); `still rejects a region whose warm rounds disagree, whatever the cold one did` (`[40, 300, 900]`) and `still rejects a region that stalls one round in three` (`[95, 100, 1400]`) pin the warm gate; `still rejects a first round that stalls far beyond any handshake` (`[1400, 95, 100]`) pins the cold ceiling; `judges jitter on the warm rounds even when the cold sample sits between or below them` (`[150, 100, 300]` rejected, `[30, 100, 102]` accepted at `latencyMs: 100`) pins the probe-order reading that CodeRabbit's review asked for. The pre-existing `[10, 20, 200]` fixture is untouched and still passes.
- `pnpm test src/main/runtime/relay`, `pnpm tc:node`, `pnpm run check:code-quality:changed`, `oxlint` and `oxfmt --check` on the changed files.
- Platforms: pure arithmetic in the main process, exercised by unit tests on macOS; no platform-specific path.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code (Claude Fable 5.1) under the author's direction; the author reviewed the diff and ran the checks. The analysis and proposed thresholds come from the issue reporter's measurements.

## Review

AI code review summary (Claude Code, independent review passes with adversarial verification):

- **Cross-platform (macOS / Linux / Windows)**: arithmetic only; no platform code.
- **SSH / remote / local**: relay region selection runs in the desktop main process before a relay session is requested; the fix only changes which measured region survives, not how the relay is used. Remote wire compatibility is unaffected (no payloads change; the cache file schema is unchanged).
- **Agents / integrations / git providers**: not involved.
- **Performance**: same three probes per region; one extra subtraction.
- **Security**: none; the probe origin validation and cache hardening are untouched.
- **Backwards compatibility**: cache schema unchanged; an existing cached region keeps being honoured until its TTL.
- **Conflict note**: open PR #16487 touches the same file for recovery behaviour but not this gate.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

The issue also notes that a "no preference" verdict is never cached, so every reconnect attempt re-probes; that is a separate change (cache schema) and is deliberately not part of this PR.

One property of the proposed thresholds worth knowing: the cold ceiling `max(150, median * 5)` exceeds `PROBE_TIMEOUT_MS` (1500 ms) once the median passes 300 ms, so for a far region the first sample can never trip it and only the warm gate applies. That matches the issue's intent (the ceiling exists to catch a stall on a *near* region, and a far region is already losing on latency), but if you would rather cap it at the probe timeout, that is a one-token change.

## Author

X: @gum79

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwSFoun5enrK3iiFrbFWRz
