### PR TITLE
perf(browser-pane): share one rAF loop across client-hosted page overlays

### DIFF
--- a/src/renderer/src/components/browser-pane/browser-client-page-position-driver.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-position-driver.test.ts
@@ -55,6 +55,12 @@ function moveContainer(container: HTMLElement, left: number, top: number): void 
     ({ left, top, width: 400, height: 300 }) as unknown as DOMRect
 }
 
+function breakContainer(container: HTMLElement): void {
+  container.getBoundingClientRect = () => {
+    throw new Error('rect read failed')
+  }
+}
+
 async function attachHost(
   browserPageId: string,
   left: number
@@ -165,6 +171,31 @@ describe('client-hosted page position driver', () => {
 
     expect(frames.pending()).toBe(0)
     expect(frames.cancelled()).toHaveLength(1)
+  })
+
+  // Why this is pinned: one loop now serves every overlay, so a host that throws must not take
+  // the others down with it — nothing would restart the loop, and a pane that merely moves fires
+  // no resize/scroll event to recover from.
+  it('keeps syncing the other hosts and reschedules when one host throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const broken = await attachHost('page-one', 10)
+    const healthy = await attachHost('page-two', 20)
+
+    breakContainer(broken.container)
+    moveContainer(healthy.container, 222, 12)
+    frames.runFrame()
+
+    expect(healthy.host().style.left).toBe('222px')
+    expect(healthy.host().style.top).toBe('12px')
+    expect(frames.pending()).toBe(1)
+
+    // Still running a frame later, and the repeat failure is not re-logged every frame.
+    moveContainer(healthy.container, 333, 24)
+    frames.runFrame()
+
+    expect(healthy.host().style.left).toBe('333px')
+    expect(frames.pending()).toBe(1)
+    expect(warn).toHaveBeenCalledTimes(1)
   })
 
   it('releases a disposed registry host from the shared loop without its pane detaching', async () => {

--- a/src/renderer/src/components/browser-pane/browser-client-page-position-driver.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-position-driver.test.ts
@@ -3,7 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createRetainedHostFixture,
   disposeRetainedHostFixtures,
-  RETAINED_FIXTURE_PAGE
+  RETAINED_FIXTURE_PAGE,
+  type RetainedHostFixture
 } from './browser-client-page-retained-host-fixture'
 import type { BrowserClientPageVisibleAttachment } from './browser-client-page-retained-registry'
 
@@ -57,7 +58,11 @@ function moveContainer(container: HTMLElement, left: number, top: number): void 
 async function attachHost(
   browserPageId: string,
   left: number
-): Promise<{ container: HTMLElement; host: () => HTMLDivElement }> {
+): Promise<{
+  container: HTMLElement
+  host: () => HTMLDivElement
+  registry: RetainedHostFixture['registry']
+}> {
   const identity = { ...RETAINED_FIXTURE_PAGE, browserPageId }
   const rig = createRetainedHostFixture()
   moveContainer(rig.container, left, 0)
@@ -65,6 +70,7 @@ async function attachHost(
   openAttachments.push(rig.attach(identity))
   return {
     container: rig.container,
+    registry: rig.registry,
     host: () =>
       document.querySelector<HTMLDivElement>(
         `[data-browser-client-page-id="${browserPageId}"]`
@@ -122,39 +128,57 @@ describe('client-hosted page position driver', () => {
     expect(pane.host().style.top).toBe('48px')
   })
 
-  it('stops the loop while hidden and resyncs every host before resuming', async () => {
+  // Why this is pinned: a `hidden` document is not proof the overlay is unobservable. Chromium's
+  // macOS occlusion tracker can wedge `visibilityState` at 'hidden' with no further
+  // visibilitychange while the window still paints, and Chromium already stops rAF itself in the
+  // states where the window really is unobservable. A visibility gate here would freeze every
+  // overlay on a window the user is looking at and save nothing.
+  it('keeps tracking pane moves while the document reports hidden', async () => {
     const first = await attachHost('page-one', 10)
     const second = await attachHost('page-two', 20)
 
     setVisibility('hidden')
 
-    expect(frames.pending()).toBe(0)
-    expect(frames.cancelled()).toHaveLength(1)
+    expect(frames.pending()).toBe(1)
+    expect(frames.cancelled()).toHaveLength(0)
 
-    // A pane moved while hidden must be corrected the instant the document is observable.
-    moveContainer(first.container, 300, 0)
-    moveContainer(second.container, 400, 0)
-    setVisibility('visible')
+    moveContainer(first.container, 300, 24)
+    moveContainer(second.container, 400, 36)
+    frames.runFrame()
 
     expect(first.host().style.left).toBe('300px')
+    expect(first.host().style.top).toBe('24px')
     expect(second.host().style.left).toBe('400px')
+    expect(second.host().style.top).toBe('36px')
     expect(frames.pending()).toBe(1)
   })
 
-  it('cancels the frame and drops the visibilitychange listener with the last host', async () => {
-    const removeListener = vi.spyOn(document, 'removeEventListener')
+  it('cancels the shared frame only when the last host detaches', async () => {
     await attachHost('page-one', 10)
     await attachHost('page-two', 20)
 
     openAttachments.shift()!.detach()
 
     expect(frames.pending()).toBe(1)
-    expect(removeListener.mock.calls.some(([type]) => type === 'visibilitychange')).toBe(false)
 
     openAttachments.shift()!.detach()
 
     expect(frames.pending()).toBe(0)
     expect(frames.cancelled()).toHaveLength(1)
-    expect(removeListener.mock.calls.some(([type]) => type === 'visibilitychange')).toBe(true)
+  })
+
+  it('releases a disposed registry host from the shared loop without its pane detaching', async () => {
+    const pane = await attachHost('page-one', 10)
+
+    pane.registry.dispose()
+
+    expect(frames.pending()).toBe(0)
+    expect(frames.cancelled()).toHaveLength(1)
+
+    // The stranded sync would otherwise keep re-reading a container whose host left the document.
+    moveContainer(pane.container, 999, 0)
+    frames.runFrame()
+
+    expect(pane.host()).toBeNull()
   })
 })

--- a/src/renderer/src/components/browser-pane/browser-client-page-position-driver.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-position-driver.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createRetainedHostFixture,
+  disposeRetainedHostFixtures,
+  RETAINED_FIXTURE_PAGE
+} from './browser-client-page-retained-host-fixture'
+import type { BrowserClientPageVisibleAttachment } from './browser-client-page-retained-registry'
+
+/** Drives the shared loop by hand so a "frame" is an explicit step, not wall-clock timing. */
+type FrameStub = {
+  pending: () => number
+  runFrame: () => void
+  cancelled: () => number[]
+}
+
+let frames: FrameStub
+let openAttachments: BrowserClientPageVisibleAttachment[]
+let visibilityState: DocumentVisibilityState
+
+function installFrameStub(): FrameStub {
+  const scheduled = new Map<number, FrameRequestCallback>()
+  const cancelled: number[] = []
+  let nextId = 0
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    nextId += 1
+    scheduled.set(nextId, callback)
+    return nextId
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+    cancelled.push(id)
+    scheduled.delete(id)
+  })
+  return {
+    pending: () => scheduled.size,
+    cancelled: () => cancelled,
+    runFrame: () => {
+      for (const [id, callback] of Array.from(scheduled)) {
+        scheduled.delete(id)
+        callback(0)
+      }
+    }
+  }
+}
+
+function setVisibility(next: DocumentVisibilityState): void {
+  visibilityState = next
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+/** Moves a pane the way a split resize or sidebar toggle does: new rect, no resize/scroll event. */
+function moveContainer(container: HTMLElement, left: number, top: number): void {
+  container.getBoundingClientRect = () =>
+    ({ left, top, width: 400, height: 300 }) as unknown as DOMRect
+}
+
+async function attachHost(
+  browserPageId: string,
+  left: number
+): Promise<{ container: HTMLElement; host: () => HTMLDivElement }> {
+  const identity = { ...RETAINED_FIXTURE_PAGE, browserPageId }
+  const rig = createRetainedHostFixture()
+  moveContainer(rig.container, left, 0)
+  await rig.mount(identity)
+  openAttachments.push(rig.attach(identity))
+  return {
+    container: rig.container,
+    host: () =>
+      document.querySelector<HTMLDivElement>(
+        `[data-browser-client-page-id="${browserPageId}"]`
+      ) as HTMLDivElement
+  }
+}
+
+beforeEach(() => {
+  openAttachments = []
+  visibilityState = 'visible'
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => visibilityState
+  })
+  frames = installFrameStub()
+})
+
+afterEach(() => {
+  for (const attachment of openAttachments.splice(0)) {
+    attachment.detach()
+  }
+  disposeRetainedHostFixtures()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('client-hosted page position driver', () => {
+  it('runs one shared frame for two attached hosts instead of one loop each', async () => {
+    const first = await attachHost('page-one', 10)
+    expect(frames.pending()).toBe(1)
+
+    const second = await attachHost('page-two', 20)
+
+    expect(frames.pending()).toBe(1)
+
+    // The single callback still repositions every registered host.
+    moveContainer(first.container, 111, 0)
+    moveContainer(second.container, 222, 0)
+    frames.runFrame()
+
+    expect(frames.pending()).toBe(1)
+    expect(first.host().style.left).toBe('111px')
+    expect(second.host().style.left).toBe('222px')
+  })
+
+  it('tracks a pane that moves with no resize or scroll event', async () => {
+    const pane = await attachHost('page-one', 10)
+    expect(pane.host().style.left).toBe('10px')
+
+    moveContainer(pane.container, 640, 48)
+    frames.runFrame()
+
+    expect(pane.host().style.left).toBe('640px')
+    expect(pane.host().style.top).toBe('48px')
+  })
+
+  it('stops the loop while hidden and resyncs every host before resuming', async () => {
+    const first = await attachHost('page-one', 10)
+    const second = await attachHost('page-two', 20)
+
+    setVisibility('hidden')
+
+    expect(frames.pending()).toBe(0)
+    expect(frames.cancelled()).toHaveLength(1)
+
+    // A pane moved while hidden must be corrected the instant the document is observable.
+    moveContainer(first.container, 300, 0)
+    moveContainer(second.container, 400, 0)
+    setVisibility('visible')
+
+    expect(first.host().style.left).toBe('300px')
+    expect(second.host().style.left).toBe('400px')
+    expect(frames.pending()).toBe(1)
+  })
+
+  it('cancels the frame and drops the visibilitychange listener with the last host', async () => {
+    const removeListener = vi.spyOn(document, 'removeEventListener')
+    await attachHost('page-one', 10)
+    await attachHost('page-two', 20)
+
+    openAttachments.shift()!.detach()
+
+    expect(frames.pending()).toBe(1)
+    expect(removeListener.mock.calls.some(([type]) => type === 'visibilitychange')).toBe(false)
+
+    openAttachments.shift()!.detach()
+
+    expect(frames.pending()).toBe(0)
+    expect(frames.cancelled()).toHaveLength(1)
+    expect(removeListener.mock.calls.some(([type]) => type === 'visibilitychange')).toBe(true)
+  })
+})

--- a/src/renderer/src/components/browser-pane/browser-client-page-position-driver.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-position-driver.ts
@@ -13,21 +13,37 @@
  * fires another `visibilitychange` (see `terminal-pane/stale-document-visibility.ts`) — and
  * there a gate would freeze every overlay on a window the user is looking at, with no
  * recovery. Zero upside, unrecoverable downside: let Chromium's own throttling do it.
+ *
+ * Sharing one loop would otherwise make a throwing host everyone's problem, so each sync is
+ * isolated and the reschedule is unconditional: one bad host is skipped, never one that
+ * wedges every other overlay at a stale rect with no event left to recover it.
  */
 
 /** Re-reads one host's container rect and repositions its overlay. */
 export type BrowserClientPagePositionSync = () => void
 
 const syncs = new Set<BrowserClientPagePositionSync>()
+/** Already-reported syncs, so a host failing every frame is one log line, not sixty a second. */
+const reportedFailures = new WeakSet<BrowserClientPagePositionSync>()
 let frame: number | null = null
 
 function runFrame(): void {
   frame = null
-  // Copied: a host may register or drop out while being synced.
-  for (const sync of Array.from(syncs)) {
-    sync()
+  try {
+    // Copied: a host may register or drop out while being synced.
+    for (const sync of Array.from(syncs)) {
+      try {
+        sync()
+      } catch (error) {
+        if (!reportedFailures.has(sync)) {
+          reportedFailures.add(sync)
+          console.warn('[browser-pane] client-hosted page position sync failed:', error)
+        }
+      }
+    }
+  } finally {
+    startFrame()
   }
-  startFrame()
 }
 
 function startFrame(): void {

--- a/src/renderer/src/components/browser-pane/browser-client-page-position-driver.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-position-driver.ts
@@ -1,0 +1,95 @@
+/** One rAF loop for every shown client-hosted page overlay.
+ *
+ * Each overlay has to re-read its container's rect every frame, because a pane can MOVE
+ * without resizing or scrolling and nothing fires an event for that. Per-host loops made
+ * that cost linear in shown hosts (N loops × N forced layouts per frame); one driver
+ * syncing N registered hosts keeps the loop count at one.
+ *
+ * The loop is gated on document visibility: a hidden document paints nothing, so no
+ * overlay can be observed at a stale rect, and every host is resynced the instant the
+ * document becomes visible again — before the loop resumes.
+ */
+
+/** Re-reads one host's container rect and repositions its overlay. */
+export type BrowserClientPagePositionSync = () => void
+
+const syncs = new Set<BrowserClientPagePositionSync>()
+let frame: number | null = null
+let listeningToVisibility = false
+
+function isDocumentVisible(): boolean {
+  return typeof document === 'undefined' || document.visibilityState === 'visible'
+}
+
+function syncRegisteredHosts(): void {
+  // Copied: a host may register or drop out while being synced.
+  for (const sync of Array.from(syncs)) {
+    sync()
+  }
+}
+
+function runFrame(): void {
+  frame = null
+  syncRegisteredHosts()
+  startFrame()
+}
+
+function startFrame(): void {
+  if (
+    frame !== null ||
+    syncs.size === 0 ||
+    !isDocumentVisible() ||
+    typeof requestAnimationFrame !== 'function'
+  ) {
+    return
+  }
+  frame = requestAnimationFrame(runFrame)
+}
+
+function stopFrame(): void {
+  if (frame === null) {
+    return
+  }
+  if (typeof cancelAnimationFrame === 'function') {
+    cancelAnimationFrame(frame)
+  }
+  frame = null
+}
+
+function handleVisibilityChange(): void {
+  if (!isDocumentVisible()) {
+    stopFrame()
+    return
+  }
+  // Resync before resuming so the first observable frame already has the current rects.
+  syncRegisteredHosts()
+  startFrame()
+}
+
+/** Registers a host with the shared loop; the returned release unregisters it. */
+export function registerBrowserClientPagePositionSync(
+  sync: BrowserClientPagePositionSync
+): () => void {
+  syncs.add(sync)
+  if (!listeningToVisibility && typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    listeningToVisibility = true
+  }
+  startFrame()
+  let released = false
+  return () => {
+    if (released) {
+      return
+    }
+    released = true
+    syncs.delete(sync)
+    if (syncs.size > 0) {
+      return
+    }
+    stopFrame()
+    if (listeningToVisibility && typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      listeningToVisibility = false
+    }
+  }
+}

--- a/src/renderer/src/components/browser-pane/browser-client-page-position-driver.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-position-driver.ts
@@ -5,9 +5,14 @@
  * that cost linear in shown hosts (N loops × N forced layouts per frame); one driver
  * syncing N registered hosts keeps the loop count at one.
  *
- * The loop is gated on document visibility: a hidden document paints nothing, so no
- * overlay can be observed at a stale rect, and every host is resynced the instant the
- * document becomes visible again — before the loop resumes.
+ * Deliberately NOT gated on document visibility. Measured on Electron 43 / macOS: when the
+ * window is hidden, minimized or fully occluded, `visibilityState` is 'hidden' AND Chromium
+ * already runs 0 rAF callbacks/s, so a gate saves nothing it does not already save. Its only
+ * effect would be in the state where `visibilityState` is wedged at 'hidden' while frames
+ * still flow — Chromium's macOS occlusion tracker does that after display sleep and never
+ * fires another `visibilitychange` (see `terminal-pane/stale-document-visibility.ts`) — and
+ * there a gate would freeze every overlay on a window the user is looking at, with no
+ * recovery. Zero upside, unrecoverable downside: let Chromium's own throttling do it.
  */
 
 /** Re-reads one host's container rect and repositions its overlay. */
@@ -15,32 +20,18 @@ export type BrowserClientPagePositionSync = () => void
 
 const syncs = new Set<BrowserClientPagePositionSync>()
 let frame: number | null = null
-let listeningToVisibility = false
 
-function isDocumentVisible(): boolean {
-  return typeof document === 'undefined' || document.visibilityState === 'visible'
-}
-
-function syncRegisteredHosts(): void {
+function runFrame(): void {
+  frame = null
   // Copied: a host may register or drop out while being synced.
   for (const sync of Array.from(syncs)) {
     sync()
   }
-}
-
-function runFrame(): void {
-  frame = null
-  syncRegisteredHosts()
   startFrame()
 }
 
 function startFrame(): void {
-  if (
-    frame !== null ||
-    syncs.size === 0 ||
-    !isDocumentVisible() ||
-    typeof requestAnimationFrame !== 'function'
-  ) {
+  if (frame !== null || syncs.size === 0 || typeof requestAnimationFrame !== 'function') {
     return
   }
   frame = requestAnimationFrame(runFrame)
@@ -56,25 +47,11 @@ function stopFrame(): void {
   frame = null
 }
 
-function handleVisibilityChange(): void {
-  if (!isDocumentVisible()) {
-    stopFrame()
-    return
-  }
-  // Resync before resuming so the first observable frame already has the current rects.
-  syncRegisteredHosts()
-  startFrame()
-}
-
 /** Registers a host with the shared loop; the returned release unregisters it. */
 export function registerBrowserClientPagePositionSync(
   sync: BrowserClientPagePositionSync
 ): () => void {
   syncs.add(sync)
-  if (!listeningToVisibility && typeof document !== 'undefined') {
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-    listeningToVisibility = true
-  }
   startFrame()
   let released = false
   return () => {
@@ -83,13 +60,8 @@ export function registerBrowserClientPagePositionSync(
     }
     released = true
     syncs.delete(sync)
-    if (syncs.size > 0) {
-      return
-    }
-    stopFrame()
-    if (listeningToVisibility && typeof document !== 'undefined') {
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
-      listeningToVisibility = false
+    if (syncs.size === 0) {
+      stopFrame()
     }
   }
 }

--- a/src/renderer/src/components/browser-pane/browser-client-page-retained-registry.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-retained-registry.ts
@@ -284,6 +284,7 @@ export class BrowserClientPageRetainedRegistry {
     }
     clearTimeout(page.attachTimer)
     page.releaseDragPassthroughSurface()
+    page.visibleAttachment?.stopTrackingViewport()
     page.webview.removeEventListener('did-attach', page.onAttached)
     page.webview.removeEventListener('dom-ready', page.onReady)
     page.webview.removeEventListener('destroyed', page.onDestroyed)
@@ -310,6 +311,9 @@ export class BrowserClientPageRetainedRegistry {
   }
 
   private disconnectPage(page: RetainedPage): void {
+    // Why: the pane's own detach may never run (registry dispose, guest loss), and the sync
+    // would otherwise keep re-reading a container for a host that is no longer in the document.
+    page.visibleAttachment?.stopTrackingViewport()
     page.visibleAttachment = null
     page.webview.remove()
     page.host.remove()

--- a/src/renderer/src/components/browser-pane/browser-client-page-retained-state.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-retained-state.ts
@@ -9,7 +9,7 @@ export type BrowserClientRetainedRendererPage = {
   webContentsId: number | null
   metadataRevision: number
   attachmentObserved: boolean
-  visibleAttachment: { container: HTMLElement } | null
+  visibleAttachment: { container: HTMLElement; stopTrackingViewport: () => void } | null
   mount: Promise<{ webContentsId: number }>
   resolveMount: (value: { webContentsId: number }) => void
   rejectMount: (error: Error) => void

--- a/src/renderer/src/components/browser-pane/browser-client-page-visible-attachment.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-visible-attachment.ts
@@ -2,6 +2,7 @@ import {
   isWebviewDragPassthroughActive,
   registerWebviewDragPassthroughSurface
 } from './host-guest/webview-drag-passthrough'
+import { registerBrowserClientPagePositionSync } from './browser-client-page-position-driver'
 import type { BrowserClientRetainedRendererPage as RetainedPage } from './browser-client-page-retained-state'
 
 export type BrowserClientPageVisibleAttachment = {
@@ -108,19 +109,11 @@ function showRetainedHost(host: HTMLDivElement, container: HTMLElement): () => v
   window.addEventListener('scroll', syncViewport, true)
   // Why: a pane can MOVE without resizing (tab dragged across an even split, sidebar toggles),
   // which fires no resize/scroll event — the overlay would keep painting at the old pane's rect.
-  let positionFrame: number | null = null
-  const trackPosition = (): void => {
-    syncViewport()
-    positionFrame = requestAnimationFrame(trackPosition)
-  }
-  if (typeof requestAnimationFrame === 'function') {
-    positionFrame = requestAnimationFrame(trackPosition)
-  }
+  // The per-frame re-read is shared with every other shown host by the position driver.
+  const releasePositionSync = registerBrowserClientPagePositionSync(syncViewport)
   syncViewport()
   return () => {
-    if (positionFrame !== null) {
-      cancelAnimationFrame(positionFrame)
-    }
+    releasePositionSync()
     observer?.disconnect()
     window.removeEventListener('resize', syncViewport)
     window.removeEventListener('scroll', syncViewport, true)

--- a/src/renderer/src/components/browser-pane/browser-client-page-visible-attachment.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-visible-attachment.ts
@@ -25,9 +25,9 @@ export function attachBrowserClientRetainedPage(
   if (!page.host.parentElement) {
     throw new Error('browser_client_page_renderer_retained_host_unavailable')
   }
-  const attachment = { container }
-  page.visibleAttachment = attachment
   const stopTrackingViewport = showRetainedHost(page.host, container)
+  const attachment = { container, stopTrackingViewport }
+  page.visibleAttachment = attachment
   let detached = false
   return {
     webview: page.webview,
@@ -112,7 +112,13 @@ function showRetainedHost(host: HTMLDivElement, container: HTMLElement): () => v
   // The per-frame re-read is shared with every other shown host by the position driver.
   const releasePositionSync = registerBrowserClientPagePositionSync(syncViewport)
   syncViewport()
+  // Idempotent: the registry releases a page it tears down, and the pane's own detach follows.
+  let stopped = false
   return () => {
+    if (stopped) {
+      return
+    }
+    stopped = true
     releasePositionSync()
     observer?.disconnect()
     window.removeEventListener('resize', syncViewport)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​184 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​184 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​70 |

<!-- /orca-pr-loc -->

## ELI5

Every time you opened a browser tab inside Orca, it started its own little timer that asked the app "where is this pane on screen?" sixty times a second, forever. Open eight browser tabs and you got eight separate timers all asking the same question at the same moment. This change replaces all of those with one timer that asks on behalf of every tab at once. The overlays still follow their panes exactly as before, in every window state — the app just stops running eight schedulers where one will do.

An earlier revision of this PR also switched the timer off while the window was hidden. That has been removed: measurement showed Chromium already does exactly that, so the gate saved nothing real and could only misfire (details below).

## What was happening

`src/renderer/src/components/browser-pane/browser-client-page-visible-attachment.ts:111-118` (pre-change) started a permanent `requestAnimationFrame` loop **per shown client-hosted page**:

```ts
let positionFrame: number | null = null
const trackPosition = (): void => {
  syncViewport()
  positionFrame = requestAnimationFrame(trackPosition)
}
if (typeof requestAnimationFrame === 'function') {
  positionFrame = requestAnimationFrame(trackPosition)
}
```

`syncViewport` (same file, line 92) calls `container.getBoundingClientRect()`, which forces a synchronous layout flush. The loop was **not shared** — N shown hosts meant N independent loops and N rAF callbacks per frame — and **never idle**: there is no "nothing moved, stop asking" exit; it self-reschedules unconditionally until detach.

The loop's *reason* is legitimate and unchanged: a pane can MOVE without resizing (tab dragged across an even split, sidebar toggled), which fires neither `resize` nor `scroll`, so the body-level fixed overlay would keep painting at the old rect.

The fix adds `src/renderer/src/components/browser-pane/browser-client-page-position-driver.ts`: a module-scoped set of per-host sync callbacks driven by **one** rAF loop. `showRetainedHost` registers `syncViewport` with the driver and releases it on teardown. The loop starts on the first registration and stops on the last.

## Measurement

Harness: a Node script simulating 10 seconds of 60 fps frames against a stubbed `requestAnimationFrame`/`cancelAnimationFrame`, mounting N fake hosts under the old per-host-loop code and the new shared-driver code, counting rAF callbacks scheduled and `getBoundingClientRect()` calls, minus the one-time attach-path work, divided by simulated seconds.

| hosts | rAF callbacks/s before | after | `getBoundingClientRect()`/s before | after |
| --- | --- | --- | --- | --- |
| 1 | 60 | 60 | 60 | 60 |
| 8 | 480 | **60** | 480 | 480 |

rAF callback scheduling drops from N per frame to 1 per frame — 8 hosts go from 480 to 60 scheduled callbacks per second (−87.5%). Rect reads stay at 60×N because each host genuinely needs its own container rect; they are now batched into a single callback rather than N scheduler entries.

**Correction to an earlier revision of this PR.** It also claimed a "hidden document: 60×N → 0" win from gating the loop on `document.visibilityState`. That row was an artifact of the stub: the harness's fake `requestAnimationFrame` keeps firing while hidden, and real Chromium does not. Measured against the real runtime (Electron 43.4.1, macOS 15, no `backgroundThrottling` override and no visibility-related Chromium switch in `src/main/startup/configure-process.ts` or `src/main/startup/disabled-chromium-features.ts`), counting rAF callbacks in a live `BrowserWindow`:

| window state | `document.visibilityState` | rAF callbacks/s |
| --- | --- | --- |
| shown, unfocused | `visible` | 60 |
| `hide()` | `hidden` | **0** |
| `minimize()` | `hidden` | **0** |
| fully occluded by another window | `hidden` | **0** |
| uncovered again | `visible` | 60 |

So the pre-change per-host loops were **already** costing 0 while hidden. The gate's measured saving in the real app is zero, and it has been removed.

## Negative user-facing trade-offs

**None.** Each preserved behavior:

- **Pane-move tracking (the reason the poll exists):** unchanged, in every window state. Every registered host's `syncViewport` still runs once per frame; the driver's callback iterates all of them. Covered by the test "tracks a pane that moves with no resize or scroll event" and by the two-host test asserting both overlays reposition from the single shared callback.
- **Hidden / occluded windows:** behavior is now identical to pre-change — the loop is never paused by this code, so whatever Chromium schedules is what runs. Pinned by the test "keeps tracking pane moves while the document reports hidden", which fires a `visibilitychange` to `hidden` and asserts both hosts still track a pane move on the next frame with no frame cancelled.
- **`ResizeObserver`, `resize`, capture-phase `scroll` listeners and the `appliedBounds` early-return:** untouched.
- **Cleanup:** every teardown path (detach, hide, error, last unregister) goes through the same release closure, which is now idempotent. The last host cancels the pending frame.
- **A host that throws does not take the others down:** each sync is isolated and the reschedule is unconditional, so the worst case is one overlay stalling, not all of them. See *Failure isolation* under Risk & verification.
- **No new failure mode when `requestAnimationFrame` is absent:** the same `typeof requestAnimationFrame === 'function'` guard is preserved (moved into the driver), and `cancelAnimationFrame` is guarded too.

### Why the visibility gate was removed rather than kept

Three findings, in order of weight:

1. **It saves nothing.** In every window state reproducible on macOS — hidden, minimized, fully occluded — `visibilityState` is `hidden` *and* Chromium is already running 0 rAF callbacks/s (table above). Windows behaves the same via `CalculateNativeWinOcclusion`; Linux has no occlusion tracking at all, so a covered window there stays `visible` and the gate would never engage.
2. **Its only live effect is a known-bad state.** `src/renderer/src/components/terminal-pane/stale-document-visibility.ts:1-9` documents a field-reported Chromium/macOS bug where the occlusion tracker wedges `visibilityState` at `hidden` after display sleep and never fires another `visibilitychange`, on a window the user is looking at and typing into. That is the one state where a gate would engage while frames still flow — and because no further `visibilitychange` arrives, a gated loop would never resume. The overlay would stop following pane moves permanently. Orca has already been bitten by this gate shape twice (terminal byte delivery, emulator streaming); both had to adopt `getWindowParkVisible()` from `src/renderer/src/lib/window-park-visibility.ts:10`, which layers a stale-input latch on top of `visibilityState`. Reaching for the raw signal here would have reintroduced the bug the latch exists to fix.
3. **The N→1 half is unconditionally safe and is where the win is.** Keeping only that half loses nothing measurable.

The test "keeps tracking pane moves while the document reports hidden" exists to stop the gate being reintroduced.

## Risk & verification

Verified:

- `pnpm tc` — clean.
- `pnpm run check:code-quality:changed` — 0 new findings across 5 changed files (oxlint, type-aware, React Doctor).
- `pnpm run check:react-doctor:changed` — 5 files scanned, 0 issues. Run **after committing on a clean tree**, since `lint:react-doctor:changed` only inspects uncommitted files and goes silent post-commit.
- Full `src/renderer/src/components/browser-pane` suite: 97 files / 781 tests passing.
- Unit test `src/renderer/src/components/browser-pane/browser-client-page-position-driver.test.ts`, 6 cases. It drives the **real** shipping path through `createRetainedHostFixture` (real registry, real body-level host, real visible attachment) with a hand-driven rAF stub, asserting: (a) two attached hosts share one rAF registration, not two; (b) a pane that moves with no resize/scroll event gets its rect updated on the next frame; (c) the loop keeps tracking both hosts across a `visibilitychange` to `hidden`, cancelling nothing; (d) the shared frame is cancelled only when the last host detaches; (e) `BrowserClientPageRetainedRegistry.dispose()` releases its host from the loop without the pane detaching; (f) when one host's sync throws, the other host still syncs on that same frame and the loop is still running on the next one. Case (f) was confirmed to fail against the driver without the isolation fix (the throw propagated out of `runFrame`), so it pins the guarantee rather than merely passing.
- Real-runtime rAF-vs-visibility measurement (table above) run against Electron 43.4.1 on macOS with a scratch `BrowserWindow`.
- **CLI/agent browser automation does not read this overlay rect.** Traced end to end: `orca browser screenshot` → `src/cli/handlers/browser-nav.ts:34` → RPC `browser.screenshot` (`src/main/runtime/rpc/methods/browser-core.ts:84`) → `src/main/runtime/runtime-browser-commands-browser-click.ts:130` → `AgentBrowserBridge` → `src/main/browser/cdp-screenshot.ts:180`, which issues CDP `Page.captureScreenshot` on the **guest** `webContents` (fallback `webContents.capturePage()` at line 261 is also the guest's own surface, never a window composite). Coordinate input takes the same shape: `orca mouse click` → `src/main/browser/agent-browser-bridge-mouse-commands.ts:36-88` resolves the guest `webContents` and dispatches CDP `Input.dispatchMouseEvent` in guest-local coordinates. The renderer-side host `left/top` written by `syncViewport` is never consulted on either path, so a stale overlay rect could not have produced a wrong-region screenshot or a mis-landed automated click. This PR therefore never carried an automation-correctness risk; the risk it did carry was to what a human sees.

**Failure isolation (the guarantee the N→1 change made load-bearing).** Sharing one loop changed the blast radius of a throwing host from 1 overlay to N. In the first revision `runFrame` called `startFrame()` *after* the sync loop with no `try`, so a single host's `syncViewport` throwing would escape before the reschedule and stop **every** overlay on the window tracking its pane — permanently, because the only things that call `startFrame()` again are a new `register` or a `ResizeObserver`/`resize`/`scroll` event, and none of those fire for a pane that merely moves. Low probability (`getBoundingClientRect()` on a detached node returns zeros rather than throwing, and `container`/`host` are non-null at registration) but unrecoverable and window-wide — the same "low probability, unrecoverable, affects everything" shape that argued the visibility gate out above. It is now fixed: each `sync()` runs inside its own `try`/`catch` so a failing host is skipped rather than fatal, the reschedule happens from a `finally` so it is unconditional, and each failing sync is reported once via a `WeakSet` rather than 60 times a second. A throwing host therefore degrades only itself, and only until whatever made it throw clears.

Also fixed here (flagged on the original revision): `BrowserClientPageRetainedRegistry` tore pages down — `dispose()`, `releasePage()`, `disconnectPage()` — without ever releasing the visible attachment's viewport tracking, so a torn-down page's `syncViewport` stayed registered and kept re-reading a container whose host had left the document. The attachment now carries its own idempotent `stopTrackingViewport`, and the registry runs it on both teardown paths.

Not verified:

- No manual run in the packaged Electron app; the overlay-follows-pane behavior was exercised in happy-dom, not against a real compositor.
- The rAF-vs-visibility table was measured on macOS only. Windows and Linux behavior is stated from Chromium's documented occlusion handling, not measured here.
- The wedged-occlusion state itself (display-sleep `visibilityState` wedge) could not be reproduced on demand, so whether frames keep flowing in it is inferred from the field report in `stale-document-visibility.ts`, not directly observed. The change is safe either way: without the gate this code behaves exactly as it did before the PR in that state.
- The driver is module-scoped renderer state shared across every retained registry in the renderer. That is intentional (one document, one rAF clock).
- No change to SSH/remote, main-process, or wire-format code paths; this is renderer-local overlay positioning only.
