### PR TITLE
perf(history-gc): drop 12,259 startup syscalls by using dirents and deleting a log-only size scan

### DIFF
--- a/src/main/terminal-history-gc-fs-call-count.test.ts
+++ b/src/main/terminal-history-gc-fs-call-count.test.ts
@@ -1,0 +1,215 @@
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import type * as FsPromises from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installFakeAppEnvironment } from '../../config/scripts/vitest-host-ports-setup'
+
+const { fsCalls, removeHostTreeMock } = vi.hoisted(() => ({
+  fsCalls: { readdir: [] as string[], stat: [] as string[] },
+  removeHostTreeMock: vi.fn<(dir: string) => Promise<void>>()
+}))
+
+vi.mock('./host-tree-removal', () => ({ removeHostTree: removeHostTreeMock }))
+
+// Why wrap the real module rather than stub it: this suite measures how many filesystem
+// requests one GC pass issues, so every call has to still hit the disk it is counting.
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof FsPromises>('node:fs/promises')
+  const call = (name: 'readdir' | 'stat', fn: unknown) => {
+    return (...args: unknown[]): unknown => {
+      fsCalls[name].push(String(args[0]))
+      return (fn as (...a: unknown[]) => unknown)(...args)
+    }
+  }
+  return { ...actual, readdir: call('readdir', actual.readdir), stat: call('stat', actual.stat) }
+})
+
+import { readHistoryMeta } from './terminal-history'
+import {
+  cancelPendingHistoryTreeRemovalRetries,
+  flushPendingWorktreeHistoryDeletions
+} from './terminal-history-deletion'
+import { cancelHistoryGc, runHistoryGc } from './terminal-history-gc'
+
+const GC_MIN_AGE_MS = 5 * 60 * 1000
+const PENDING_DELETE_DIR_NAME = '.pending-delete'
+const LIVE_WORKTREE_ID = 'repo-1::/path/live-wt'
+const DEAD_WORKTREE_ID = 'repo-1::/path/dead-wt'
+const DIR_COUNT = 50
+const ORPHAN_EVERY = 5
+
+let userDataDir: string
+let historyRoot: string
+let originalXdgDataHome: string | undefined
+
+/** The pre-dirent decision logic, verbatim apart from reporting names instead of deleting. */
+function referencePruneDecisions(root: string, liveWorktreeIds: Set<string>): string[] {
+  const decisions: string[] = []
+  const now = Date.now()
+  for (const entry of readdirSync(root)) {
+    if (entry === PENDING_DELETE_DIR_NAME) {
+      continue
+    }
+    const entryPath = join(root, entry)
+    try {
+      if (!statSync(entryPath).isDirectory()) {
+        continue
+      }
+      const meta = readHistoryMeta(entryPath)
+      if (!meta?.worktreeId || liveWorktreeIds.has(meta.worktreeId)) {
+        continue
+      }
+      if (meta.createdAt && now - new Date(meta.createdAt).getTime() < GC_MIN_AGE_MS) {
+        continue
+      }
+      decisions.push(entry)
+    } catch {
+      // Skip individual entries that fail, as the walk under test does.
+    }
+  }
+  return decisions
+}
+
+function seedDir(name: string, files: Record<string, string>): string {
+  const dir = join(historyRoot, name)
+  mkdirSync(dir, { recursive: true })
+  for (const [file, contents] of Object.entries(files)) {
+    writeFileSync(join(dir, file), contents)
+  }
+  return dir
+}
+
+function meta(worktreeId: string): string {
+  return JSON.stringify({
+    worktreeId,
+    createdAt: new Date(Date.now() - GC_MIN_AGE_MS * 2).toISOString()
+  })
+}
+
+/** DIR_COUNT directories of three files each: meta.json plus two shell history files. */
+function seedFixture(): void {
+  for (let i = 0; i < DIR_COUNT; i++) {
+    const orphan = i % ORPHAN_EVERY === 0
+    seedDir(`wt-${i}`, {
+      'meta.json': meta(orphan ? `${DEAD_WORKTREE_ID}-${i}` : LIVE_WORKTREE_ID),
+      zsh_history: `entry-${i}`,
+      bash_history: `entry-${i}`
+    })
+  }
+}
+
+/** Symlinks included, and tolerant of a broken one, which `statSync` cannot be. */
+function survivingDirs(): Set<string> {
+  return new Set(
+    readdirSync(historyRoot).filter(
+      (entry) => entry !== PENDING_DELETE_DIR_NAME && !lstatSync(join(historyRoot, entry)).isFile()
+    )
+  )
+}
+
+/** Stats on the root's own entries — the `isDirectory()` probe the dirent now answers. */
+function statsOnEntries(): string[] {
+  return fsCalls.stat.filter((path) => dirname(path) === historyRoot)
+}
+
+/** Stats on files inside a history directory — the per-file size estimation this pass dropped. */
+function statsInsideEntries(): string[] {
+  return fsCalls.stat.filter((path) => dirname(dirname(path)) === historyRoot)
+}
+
+beforeEach(() => {
+  userDataDir = mkdtempSync(join(tmpdir(), 'orca-history-gc-calls-'))
+  historyRoot = join(userDataDir, 'terminal-history')
+  mkdirSync(historyRoot, { recursive: true })
+  installFakeAppEnvironment({ getPath: () => userDataDir })
+  // Why: the fish sweep resolves a real user data dir otherwise, and would delete the
+  // developer's own orca fish history files while this suite runs.
+  originalXdgDataHome = process.env.XDG_DATA_HOME
+  process.env.XDG_DATA_HOME = userDataDir
+  fsCalls.readdir.length = 0
+  fsCalls.stat.length = 0
+  removeHostTreeMock.mockReset()
+  removeHostTreeMock.mockImplementation(async (dir) => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+})
+
+afterEach(async () => {
+  cancelHistoryGc()
+  await flushPendingWorktreeHistoryDeletions()
+  cancelPendingHistoryTreeRemovalRetries()
+  if (originalXdgDataHome === undefined) {
+    delete process.env.XDG_DATA_HOME
+  } else {
+    process.env.XDG_DATA_HOME = originalXdgDataHome
+  }
+  rmSync(userDataDir, { recursive: true, force: true })
+})
+
+describe('history GC filesystem request count', () => {
+  it('issues no per-file stat and one readdir for the whole root', async () => {
+    seedFixture()
+    const live = new Set([LIVE_WORKTREE_ID])
+    const expected = new Set(referencePruneDecisions(historyRoot, live))
+    const before = survivingDirs()
+    fsCalls.readdir.length = 0
+    fsCalls.stat.length = 0
+
+    await runHistoryGc(live)
+
+    // The size estimation walked into every directory; the pass now only lists the root.
+    expect(fsCalls.readdir).toEqual([historyRoot])
+    // No stat on the entries themselves: the root dirent already carries the type.
+    expect(statsOnEntries()).toEqual([])
+    // The one surviving stat per directory is readHistoryMetaAsync enforcing its size cap.
+    expect(statsInsideEntries().sort()).toEqual(
+      Array.from({ length: DIR_COUNT }, (_, i) => join(historyRoot, `wt-${i}`, 'meta.json')).sort()
+    )
+    expect(fsCalls.readdir.length + fsCalls.stat.length).toBe(1 + DIR_COUNT)
+
+    const after = survivingDirs()
+    expect(expected.size).toBe(DIR_COUNT / ORPHAN_EVERY)
+    expect([...before].filter((entry) => !after.has(entry)).sort()).toEqual([...expected].sort())
+  })
+
+  it('still resolves a symlinked history directory through its target', async () => {
+    const orphanTarget = join(userDataDir, 'linked-orphan')
+    mkdirSync(orphanTarget, { recursive: true })
+    writeFileSync(join(orphanTarget, 'meta.json'), meta(`${DEAD_WORKTREE_ID}-linked`))
+    const liveTarget = join(userDataDir, 'linked-live')
+    mkdirSync(liveTarget, { recursive: true })
+    writeFileSync(join(liveTarget, 'meta.json'), meta(LIVE_WORKTREE_ID))
+    try {
+      symlinkSync(orphanTarget, join(historyRoot, 'link-orphan'), 'dir')
+      symlinkSync(liveTarget, join(historyRoot, 'link-live'), 'dir')
+      symlinkSync(join(userDataDir, 'nowhere'), join(historyRoot, 'link-broken'), 'dir')
+    } catch {
+      // Unprivileged Windows cannot create symlinks; the dirent path is covered above.
+      return
+    }
+    seedDir('plain-orphan', { 'meta.json': meta(`${DEAD_WORKTREE_ID}-plain`) })
+
+    await runHistoryGc(new Set([LIVE_WORKTREE_ID]))
+
+    const after = survivingDirs()
+    expect(after.has('link-orphan')).toBe(false)
+    expect(after.has('plain-orphan')).toBe(false)
+    expect(after.has('link-live')).toBe(true)
+    // A dangling link fails its stat and is skipped, exactly as the pre-dirent walk skipped it.
+    expect(after.has('link-broken')).toBe(true)
+    // Only the links cost a stat on the entry itself; plain-orphan costs none.
+    expect(statsOnEntries().sort()).toEqual(
+      ['link-broken', 'link-live', 'link-orphan'].map((name) => join(historyRoot, name))
+    )
+  })
+})

--- a/src/main/terminal-history-gc.ts
+++ b/src/main/terminal-history-gc.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path'
+import type { Dirent } from 'node:fs'
 import { readdir, stat } from 'node:fs/promises'
 import {
   getHistoryRoot,
@@ -41,7 +42,6 @@ type GcRootScan = {
   totalDirs: number
   orphaned: number
   pruned: number
-  totalSizeKB: number
   /** Every fish data dir a meta.json in this root names, for the orphan sweep. */
   fishHistoryDirs: Set<string>
 }
@@ -49,31 +49,22 @@ type GcRootScan = {
 /** Inspect one history directory, tombstoning it when its worktree is gone. */
 async function gcScanEntry(
   root: string,
-  entry: string,
+  entry: Dirent,
   liveWorktreeIds: Set<string>,
   now: number,
   result: GcRootScan
 ): Promise<void> {
-  const entryPath = join(root, entry)
+  const entryPath = join(root, entry.name)
   try {
-    const stats = await stat(entryPath)
-    if (!stats.isDirectory()) {
+    // Why stat only for links: a dirent describes the link itself, and the pre-dirent walk
+    // stat'd every entry, so a symlink to a history directory was and stays a directory here.
+    const isDirectory = entry.isSymbolicLink()
+      ? (await stat(entryPath)).isDirectory()
+      : entry.isDirectory()
+    if (!isDirectory) {
       return
     }
     result.totalDirs++
-
-    // Estimate directory size from meta.json + history files.
-    // Why a local accumulator: `result.totalSizeKB += <expression containing await>`
-    // reads the field before suspending and writes back a stale sum once workers interleave.
-    let dirSizeKB = 0
-    try {
-      for (const file of await readdir(entryPath)) {
-        dirSizeKB += Math.ceil((await stat(join(entryPath, file))).size / 1024)
-      }
-    } catch {
-      // Skip size estimation on error, keeping whatever was measured first.
-    }
-    result.totalSizeKB += dirSizeKB
 
     // A missing, truncated, oversized or malformed meta.json reads back as null, and a
     // null meta is never pruned — an entry whose ownership we cannot establish is kept.
@@ -119,13 +110,14 @@ async function gcScanRoot(
     totalDirs: 0,
     orphaned: 0,
     pruned: 0,
-    totalSizeKB: 0,
     fishHistoryDirs: new Set<string>()
   }
 
-  let entries: string[]
+  let entries: Dirent[]
   try {
-    entries = await readdir(root)
+    // Why withFileTypes: the root listing already carries each entry's type, so asking for it
+    // here removes one stat per history directory from the startup pass.
+    entries = await readdir(root, { withFileTypes: true })
   } catch {
     // Absent or unreadable root: nothing to collect.
     return result
@@ -133,7 +125,7 @@ async function gcScanRoot(
 
   const now = Date.now()
   // Why: pending-delete is a tombstone queue drained asynchronously, not a live worktree hash.
-  const frontier = entries.filter((entry) => entry !== PENDING_DELETE_DIR_NAME)
+  const frontier = entries.filter((entry) => entry.name !== PENDING_DELETE_DIR_NAME)
 
   await forEachWithConcurrency(
     frontier,
@@ -171,7 +163,7 @@ async function executeHistoryGc(liveWorktreeIds: Set<string>, signal: AbortSigna
     const main = await gcScanRoot(getHistoryRoot(), liveWorktreeIds, signal)
 
     // Also scan WSL history directories (each distro has its own subdirectory).
-    const wslTotals = { totalDirs: 0, orphaned: 0, pruned: 0, totalSizeKB: 0 }
+    const wslTotals = { totalDirs: 0, orphaned: 0, pruned: 0 }
     const liveFishHistoryDirs = new Set(main.fishHistoryDirs)
     for (const distroRoot of listWslHistoryRoots()) {
       if (signal.aborted) {
@@ -182,7 +174,6 @@ async function executeHistoryGc(liveWorktreeIds: Set<string>, signal: AbortSigna
       wslTotals.totalDirs += r.totalDirs
       wslTotals.orphaned += r.orphaned
       wslTotals.pruned += r.pruned
-      wslTotals.totalSizeKB += r.totalSizeKB
       for (const dir of r.fishHistoryDirs) {
         liveFishHistoryDirs.add(dir)
       }
@@ -214,11 +205,8 @@ async function executeHistoryGc(liveWorktreeIds: Set<string>, signal: AbortSigna
     const totalDirs = main.totalDirs + wslTotals.totalDirs
     const orphaned = main.orphaned + wslTotals.orphaned
     const pruned = main.pruned + wslTotals.pruned
-    const totalSizeKB = main.totalSizeKB + wslTotals.totalSizeKB
 
-    console.log(
-      `[pty:history:gc] totalDirs=${totalDirs} orphaned=${orphaned} pruned=${pruned} totalSizeKB=${totalSizeKB}`
-    )
+    console.log(`[pty:history:gc] totalDirs=${totalDirs} orphaned=${orphaned} pruned=${pruned}`)
   } catch (err) {
     console.warn(`[pty:history:gc] GC failed: ${err instanceof Error ? err.message : String(err)}`)
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​215 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​215 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

About ten seconds after Orca launches, a background job tidies up shell-history folders belonging to worktrees you deleted. To decide "is this a folder?", it was asking the disk about every single entry — even though the folder listing it had *just* received already answers that. Then, for every one of those folders, it opened it and measured the size of every file inside, purely so it could print one number into a developer log line nobody reads. This PR takes the answer from the listing it already had, and deletes the size measurement and the log field. Same folders get cleaned up, same folders get kept — the app just stops making thousands of disk requests during startup to produce a number it threw away.

## What was happening

`src/main/terminal-history-gc.ts` schedules one GC pass 10s after launch (`scheduleHistoryGc`, line 259 on `main`). For every entry in `~/Library/Application Support/orca/terminal-history`, `gcScanEntry` did:

- **`src/main/terminal-history-gc.ts:59`** — `const stats = await stat(entryPath)`, used only for `stats.isDirectory()` on line 60.
- **`src/main/terminal-history-gc.ts:66-76`** — `readdir(entryPath)` plus one `stat()` per file inside, accumulating `dirSizeKB` into `result.totalSizeKB`.

`readdir(root)` (line 128) was already being called without `withFileTypes`, so the type information the kernel returns with the directory listing was discarded and then re-fetched one `stat` at a time.

**Proof that `totalSizeKB` had exactly one consumer.** `rg -n "totalSizeKB" .` on `main` returns 8 hits, all inside `src/main/terminal-history-gc.ts` — nothing in any other `src` file, no test, no config, no doc:

```
src/main/terminal-history-gc.ts:44:  totalSizeKB: number                      # type field
src/main/terminal-history-gc.ts:66:  // Why a local accumulator: `result...`   # comment
src/main/terminal-history-gc.ts:68:    let dirSizeKB = 0                       # producer
src/main/terminal-history-gc.ts:71:    dirSizeKB += Math.ceil(...)             # producer
src/main/terminal-history-gc.ts:76:    result.totalSizeKB += dirSizeKB         # producer
src/main/terminal-history-gc.ts:122:    totalSizeKB: 0,                        # init
src/main/terminal-history-gc.ts:174:    ... totalSizeKB: 0 }                   # WSL init
src/main/terminal-history-gc.ts:185:    wslTotals.totalSizeKB += r.totalSizeKB # aggregate
src/main/terminal-history-gc.ts:217:    const totalSizeKB = ...                # aggregate
src/main/terminal-history-gc.ts:220:    `[pty:history:gc] ... totalSizeKB=${totalSizeKB}` # ONLY consumer
```

`GcRootScan` is a module-private type and `gcScanRoot`/`gcScanEntry` are module-private functions, so no external reader is possible. The value never crosses an IPC boundary, is never persisted, and is never asserted on. The only place it is read is the `console.log` on line 220.

There is no existing debug/diagnostics env flag in this codebase that would be an appropriate home for a re-gated version of the number, so the size estimation is removed outright rather than hidden behind a new setting.

## The change

1. `gcScanRoot` lists with `readdir(root, { withFileTypes: true })` and passes the `Dirent` to `gcScanEntry`, which reads `entry.isDirectory()` instead of calling `stat`.
2. Symlinked entries fall back to `stat(entryPath)` for that entry only, so a symlink pointing at a history directory is still treated as a directory (a `Dirent` describes the link, not the target) and a dangling link still throws into the existing skip path — byte-for-byte the pre-change verdict.
3. The per-file size loop and the `totalSizeKB` field are deleted, and the summary log drops the field.

`PENDING_DELETE_DIR_NAME` filtering, the `GC_MIN_AGE_MS` TOCTOU guard, the null-meta "never prune" rule, `readHistoryMetaAsync`, fish-history collection, the WSL roots loop, `HISTORY_GC_SCAN_CONCURRENCY`, and `HISTORY_GC_YIELD_EVERY` are untouched.

## Measurement

**Deterministic call counts** — new test `src/main/terminal-history-gc-fs-call-count.test.ts` wraps `node:fs/promises` and counts real `readdir`/`stat` requests over a fixture of **50 directories x 3 files each** (`meta.json`, `zsh_history`, `bash_history`):

| | `readdir` | `stat` | total |
| --- | --- | --- | --- |
| before | 51 | 250 | **301** |
| after | 1 | 50 | **51** |

The 50 surviving `stat` calls are `readHistoryMetaAsync` enforcing its `MAX_HISTORY_META_BYTES` cap, which this PR does not touch. **83% fewer filesystem requests.**

**Extrapolated to the reported real corpus (2,781 dirs / 6,697 files):**

| | before | after |
| --- | --- | --- |
| root `readdir` | 1 | 1 |
| per-entry `isDirectory` `stat` | 2,781 | 0 |
| per-entry `readdir` | 2,781 | 0 |
| per-file size `stat` | 6,697 | 0 |
| `readHistoryMetaAsync` `stat` | 2,781 | 2,781 |
| **total** | **15,041** | **2,782** |

**12,259 filesystem requests removed per launch** — exactly the count in the original report — an 81% reduction.

**Wall clock on a synthetic 2,781-dir / 6,697-file fixture** (macOS APFS, warm page cache, both variants run interleaved 15x so machine-load drift hits both equally, `UV_THREADPOOL_SIZE` default):

| | median | min |
| --- | --- | --- |
| before | 828.0 ms | 281.7 ms |
| after | 370.0 ms | 105.1 ms |

**~2.2x faster at the median, ~2.7x at the floor.** Absolute numbers are noisy because the measuring machine was under heavy parallel load; the ratio held across every run. Isolating just the removed work (per-entry `stat` + per-entry `readdir` + per-file `stat`, no meta reads) measured 218 ms median on its own — that is disk time competing with startup I/O for zero output.

## Negative user-facing trade-offs

- **The `[pty:history:gc]` summary log loses its `totalSizeKB=` field.** It now reads `[pty:history:gc] totalDirs=N orphaned=N pruned=N`. This is a `console.log` in the main process, visible only in a dev console or a packaged-app log file — it is not surfaced in any UI, IPC payload, settings screen, or diagnostics bundle, and nothing parses it. It is a developer log field, not user-facing.
- **No pruning decision changes.** No history directory that was kept becomes prunable, and none that was prunable becomes kept. `totalDirs`, `orphaned`, and `pruned` are all unchanged, as is the per-prune `Pruned orphaned history:` line.
- Nothing else. There is no new setting, no new behavior to opt into, and no case where a user waits longer for anything.

## Risk & verification

**Symlinked entries.** This is the only place `Dirent` semantics differ from `stat`: `stat` follows links, a `Dirent` describes the link itself. Handled explicitly — `entry.isSymbolicLink()` falls back to `await stat(entryPath)` for that entry alone, so:

- symlink -> orphaned history dir: still classified as a directory, still pruned (the rename moves the link, not the target — identical to before);
- symlink -> live history dir: still kept;
- dangling symlink: `stat` throws, the existing `catch` skips the entry — identical to before.

A dedicated test asserts all three and that exactly the three link entries (and no plain directory) cost an entry-level `stat`.

**Filesystems that do not report `d_type`.** Node's `readdir(..., { withFileTypes: true })` falls back to an internal `lstat` per `UV_DIRENT_UNKNOWN` entry, so classification stays correct there; the win simply shrinks to the removed per-file work on those volumes.

**Directory that vanishes mid-walk.** Previously the `stat` threw `ENOENT` and the entry was skipped. Now the entry proceeds to `readHistoryMetaAsync`, which returns `null` on the same `ENOENT`, and a null meta is never pruned — same outcome, no prune either way. Covered by the existing "survives a directory removed while the walk is in flight" test.

**Verification run:**

- `pnpm tc` — clean.
- `pnpm run check:code-quality:changed` — clean (0 findings across 2 changed files, including React Doctor and type-aware passes).
- `pnpm test src/main/terminal-history-gc.test.ts` — green, unchanged. Its `referenceSyncPruneDecisions` control still replays the original synchronous walk (including its per-file `statSync` loop) and the async pass still reaches an identical prune set over the full decision matrix plus 200 bulk directories.
- `pnpm test src/main/window/history-gc-worktree-ids.test.ts` — green, unchanged.
- `pnpm test src/main/terminal-history` — 6 files, 81 tests, all green.
- New `src/main/terminal-history-gc-fs-call-count.test.ts` — **both cases fail on `main`** (`expected [ …(51) ] to deeply equal [ Array(1) ]` for the count assertion, `expected [ …(4) ] to deeply equal [ …(3) ]` for the symlink one), pass with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
