### PR TITLE
fix(agent-hooks): skip the branch auto-rename probe for folder projects

### DIFF
--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -556,4 +556,20 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
     expect(provider.renameCurrentBranch).toHaveBeenCalledWith('/repo/wt', 'you/fix-auth')
     expect(onRenamed).toHaveBeenCalledWith(REPO_ID)
   })
+
+  it('never runs git for a folder project, and settles so it stops re-probing', async () => {
+    // A folder project has no .git, so the branch probes below would all fail.
+    const folderRepo = { id: REPO_ID, path: '/folder', kind: 'folder' } as unknown as Repo
+    const getRepo = vi.fn(() => folderRepo)
+    const { deps, onRenamed, setRenameError } = makeDeps({ getRepo })
+
+    await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+    await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    // Settled, not retried: the second `working` event short-circuits before resolving the repo again.
+    expect(getRepo).toHaveBeenCalledTimes(1)
+    expect(onRenamed).not.toHaveBeenCalled()
+    expect(setRenameError).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/agent-hooks/first-work-branch-rename.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.ts
@@ -1,6 +1,7 @@
 // On first agent work in a fresh workspace, replace the auto-generated creature branch (e.g. `you/Nautilus`) with a short work-derived name.
 import type { GlobalSettings } from '../../shared/global-settings-types'
 import type { Repo } from '../../shared/repo-types'
+import { isFolderRepo } from '../../shared/repo-kind'
 import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree/id'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import { parsePaneKey } from '../../shared/stable-pane-id'
@@ -169,6 +170,10 @@ async function runAutoRename(
   const parsed = splitWorktreeIdForFilesystem(worktreeId)
   if (!repo || !parsed) {
     return stop('unresolved repo or worktree id')
+  }
+  // Why: a folder project is not a git repo, so every branch probe below fails; without a settled verdict it re-runs on each `working` event.
+  if (isFolderRepo(repo)) {
+    return stop('folder project has no branch to rename')
   }
   const worktreePath = parsed.worktreePath
 


### PR DESCRIPTION
## ELI5

If you add a plain folder (not a git repo) as a project, Orca still tries to rename its git branch every time an agent starts working. There is no branch, so the very first git command fails — and because the failure is never recorded as "done, stop asking", Orca tries again on the next agent event, and the next, forever. This adds one line that says "folder projects have no branch, stop here."

## What Changed

`src/main/agent-hooks/first-work-branch-rename.ts` now gates on `isFolderRepo(repo)` right after the repo/worktree id narrowing, and returns a **settled** verdict via `stop()`.

Placement matters: the check has to come after `if (!repo || !parsed)`, because before that `repo` is still `Repo | undefined`. Using `isFolderRepo` from `src/shared/repo-kind.ts` matches how the rest of the codebase tests this (`repos.ts`, `dashboard-card-context.ts`, `terminal-agent-session-fork.ts`).

## Why

`parseWorkspaceKey(worktreeId)?.type === 'folder'` at the top of `runAutoRename` only matches the synthetic `folder:<uuid>` workspace keys. A folder **project** has an ordinary `<repoId>::<path>` worktree id, so it returns `null` and execution falls straight through to the git path — even though the `Repo` it just resolved carries `kind: 'folder'`, which was never checked.

`exec(['rev-parse', '--abbrev-ref', 'HEAD'])` then throws in a directory with no `.git`. That rejection propagates out of `runAutoRename` and is swallowed by the catch in `maybeAutoRenameBranchOnFirstWork`. Since no settled verdict is returned, the worktree id never lands in `settledWorktreeIds`, so the entire attempt runs again on the next `working` event.

From my own trace logs on 1.4.195: **1,456 failing `git rev-parse --abbrev-ref HEAD` spawns in a folder project over 4 days, bursting to 75/minute** while an agent was working there.

`stop()` rather than `retry()` is the important half — a guard that returned `retry()` would remove the spawn but keep re-entering this path on every event.

## Linked Issue

Fixes #18311

## Visual Proof

`N/A` — no UI or interaction surface is touched. The change is an early return in a main-process agent hook; the only observable difference is the absence of failing git subprocesses.

## Testing

Added `never runs git for a folder project, and settles so it stops re-probing` to `first-work-branch-rename.test.ts`. It fires two `working` events and asserts:

- `gitExecFileAsyncMock` is never called — catches the missing guard
- `getRepo` is called exactly **once** — catches a guard that used `retry()` instead of `stop()`, since a non-settled verdict would re-resolve the repo on the second event

Verified the test genuinely fails on the pre-fix code: without the guard it reports 8 git calls and actually proceeds to `git branch -m` on the folder project.

Local runs (macOS, Apple Silicon, Node 22):

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm test` — 70,664 passed. One pre-existing failure in `tests/e2e/cross-version-wire/release-checkout.unit.test.ts` (`git rev-parse ~2^{commit}`) that reproduces identically on a clean `upstream/main` checkout with no changes applied, so it is unrelated to this PR.
- `pnpm build` — pass

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Opus 5 via Claude Code. The investigation started from Orca's own `main.trace.ndjson` telemetry; the model located the code path, and every file:line claim in this PR and in #18311 was verified against `upstream/main` before submitting.

## Review

Reviewed for cross-platform, remote, and provider impact:

- **Cross-platform (macOS/Linux/Windows):** the change is a pure early return with no platform branch, no path construction, no shell invocation, and no keyboard/accelerator surface. Behavior is identical on all three.
- **SSH / remote:** the gate sits *before* `repo.connectionId` is read, so the SSH provider path (`getSshGitProvider`, `provider.exec`) is untouched for git repos. A folder project has no git remote to reach in the first place.
- **Agents / integrations / git providers:** provider-neutral. Nothing here is GitHub- or GitLab-specific.
- **Performance:** strictly removes work — one failing subprocess spawn per agent `working` event in folder projects, plus the repeated re-entry.
- **Behavior risk:** the only reachable behavior change is for `kind: 'folder'` repos, which could never have completed a branch rename anyway. Git repos take the identical path as before.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: no input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. If anything the attack surface shrinks slightly, since it stops invoking git in a directory Orca does not control as a repo.

Out of scope, noted in #18311: folder projects get no first-work auto-naming at all today. Routing them to `runFolderWorkspaceTitleAutoRename` would not be enough on its own — `isPendingFirstAgentMessageRename` and `getFolderWorkspacePath` (`src/main/startup/branch-rename-hook.ts:46-58`) only resolve ids whose `parseWorkspaceKey` type is `folder`. Happy to follow up if that behavior is wanted.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
