### PR TITLE
perf(persistence): stop rewriting redundant bytes in the profile store

### DIFF
--- a/src/main/persistence/loading-store/persisted-state-redundancy.test.ts
+++ b/src/main/persistence/loading-store/persisted-state-redundancy.test.ts
@@ -1,0 +1,245 @@
+/**
+ * The store file re-serializes in full on a 1s debounce and re-parses in full at launch, so every
+ * byte it carries is paid for on both. Two kinds of byte were provably redundant on a 4.2 MB real
+ * install: `"linked*":null` slots that `mergeWorktreeMetaForWrite` materializes on every metadata
+ * row, and copies of local-owned global session fields inside non-local host partitions.
+ *
+ * These tests drive the real Store over a fixture sized like that install (10 hosts, 1,200 metadata
+ * rows, 200 browser history entries) and pin the only property that makes the omission safe: a file
+ * written by the OLD serializer and a file written by the NEW one load to the same in-memory state.
+ */
+import { mkdtempSync, readFileSync, realpathSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import type { BrowserHistoryEntry } from '../../../shared/browser-workspace-types'
+import { WORKTREE_META_PERSISTED_DEFAULTS } from '../../../shared/worktree/meta-persisted-defaults'
+import { HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS } from '../../../shared/workspace-session-host-field-ownership'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => tmpdir(),
+    getName: () => 'orca-test',
+    getVersion: () => '0.0.0-test',
+    isPackaged: false,
+    on: () => {},
+    whenReady: () => Promise.resolve()
+  },
+  safeStorage: { isEncryptionAvailable: () => false },
+  ipcMain: { on: () => {}, handle: () => {} },
+  BrowserWindow: { getAllWindows: () => [] }
+}))
+
+const { Store } = await import('./store')
+
+const META_ROWS = 1_200
+const IDENTITY_ROWS = 1_191
+const HISTORY_ENTRIES = 200
+/** local + 9 more, matching the reporting install. */
+const REMOTE_HOSTS = Array.from({ length: 9 }, (_, index) => `runtime:env-${index}`)
+/** The measured shape: 3 of the 9 held a byte-identical replica of local's history. */
+const HOSTS_WITH_REPLICA = REMOTE_HOSTS.slice(0, 3)
+/** 1 row in 40 carries a real link, so its slots must stay written. */
+const LINKED_ROW_STRIDE = 40
+/** Recent enough that the 30-day stale-metadata GC leaves the fixture alone. */
+const RECENTLY = Date.now()
+
+const stores: InstanceType<typeof Store>[] = []
+afterEach(() => {
+  for (const store of stores.splice(0)) {
+    store.freezeWrites()
+  }
+  vi.restoreAllMocks()
+})
+
+function openStore(dataFile: string): InstanceType<typeof Store> {
+  const store = new Store({ dataFile })
+  stores.push(store)
+  return store
+}
+
+function tempDataFile(): string {
+  return join(realpathSync(mkdtempSync(join(tmpdir(), 'orca-redundancy-'))), 'orca-data.json')
+}
+
+/** A row exactly as the OLD write path left it: every default slot materialized. */
+function legacyMeta(index: number): WorktreeMeta {
+  return {
+    ...WORKTREE_META_PERSISTED_DEFAULTS,
+    instanceId: `instance-${index}`,
+    hostId: 'local',
+    displayName: `workspace-${index}`,
+    comment: '',
+    isUnread: index % 7 === 0,
+    sortOrder: RECENTLY + index,
+    lastActivityAt: RECENTLY + index,
+    createdAt: RECENTLY,
+    workspaceStatus: 'none',
+    ...(index % LINKED_ROW_STRIDE === 0 ? { linkedPR: index + 1, isPinned: true } : {})
+  } as WorktreeMeta
+}
+
+function browserHistory(): BrowserHistoryEntry[] {
+  return Array.from({ length: HISTORY_ENTRIES }, (_, index) => ({
+    url: `https://example.test/page-${index}?q=${'x'.repeat(40)}`,
+    normalizedUrl: `https://example.test/page-${index}?q=${'x'.repeat(40)}`,
+    title: `A reasonably long page title number ${index}`,
+    lastVisitedAt: 1_700_000_000_000 - index,
+    visitCount: (index % 9) + 1
+  }))
+}
+
+function session(overrides: Partial<WorkspaceSessionState>): WorkspaceSessionState {
+  return {
+    activeRepoId: 'repo-1',
+    activeWorktreeId: null,
+    activeTabId: null,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    ...overrides
+  } as WorkspaceSessionState
+}
+
+/** A file in the pre-change shape: materialized metadata defaults, and local's global session
+ *  fields replicated into the host partitions the split used to seed from one shared template. */
+function writeLegacyFile(dataFile: string): void {
+  const worktreeMeta: Record<string, WorktreeMeta> = {}
+  for (let index = 0; index < META_ROWS; index++) {
+    worktreeMeta[`repo-1::/tmp/wt-${index}`] = legacyMeta(index)
+  }
+  const worktreeMetaByIdentity: Record<string, WorktreeMeta> = {}
+  for (let index = 0; index < IDENTITY_ROWS; index++) {
+    worktreeMetaByIdentity[`wt2:local:instance-${index}`] = legacyMeta(index)
+  }
+  const history = browserHistory()
+  const workspaceSessionsByHostId: Record<string, WorkspaceSessionState> = {}
+  for (const hostId of REMOTE_HOSTS) {
+    workspaceSessionsByHostId[hostId] = session({
+      activeTabId: `tab-${hostId}`,
+      ...(HOSTS_WITH_REPLICA.includes(hostId) ? { browserUrlHistory: history } : {})
+    })
+  }
+  const state = {
+    // Registered: the load-time deregistered-repo sweep drops residue rows for unknown repos.
+    repos: [{ id: 'repo-1', name: 'repo-1', path: '/tmp/repo-1', worktreesPath: '/tmp' }],
+    projects: [],
+    worktreeMeta,
+    worktreeMetaByIdentity,
+    worktreeLineageById: {},
+    workspaceLineageByChildKey: {},
+    workspaceSession: session({ activeTabId: 'local-tab', browserUrlHistory: history }),
+    workspaceSessionsByHostId
+  } as unknown as PersistedState
+  writeFileSync(dataFile, JSON.stringify(state), 'utf-8')
+}
+
+/** Inverse of everything this change does, applied to a compact file: what the old serializer
+ *  would have written for the same state. */
+function reexpandToLegacyShape(state: PersistedState): PersistedState {
+  const expanded = structuredClone(state)
+  for (const map of [expanded.worktreeMeta, expanded.worktreeMetaByIdentity]) {
+    for (const [key, meta] of Object.entries(map ?? {})) {
+      ;(map as Record<string, WorktreeMeta>)[key] = { ...WORKTREE_META_PERSISTED_DEFAULTS, ...meta }
+    }
+  }
+  for (const hostId of REMOTE_HOSTS) {
+    const slice = expanded.workspaceSessionsByHostId?.[hostId as never]
+    if (!slice) {
+      continue
+    }
+    slice.browserUrlHistory = HOSTS_WITH_REPLICA.includes(hostId)
+      ? expanded.workspaceSession.browserUrlHistory
+      : []
+    slice.workspaceDocHistory = []
+  }
+  return expanded
+}
+
+function defaultedSlotOccurrences(json: string): number {
+  let count = 0
+  for (const field of Object.keys(WORKTREE_META_PERSISTED_DEFAULTS)) {
+    count += json.split(`"${field}":`).length - 1
+  }
+  return count
+}
+
+describe('persisted-state redundancy', () => {
+  it('round-trips a legacy-shaped file to identical in-memory state and a smaller file', () => {
+    const dataFile = tempDataFile()
+    writeLegacyFile(dataFile)
+
+    // One load+flush first, so the baseline is not comparing against the one-time settings
+    // migrations a synthetic fixture triggers (same reason as state-write-round-trip.test.ts).
+    openStore(dataFile).flush()
+
+    const loaded = openStore(dataFile)
+    const before = {
+      meta: structuredClone(loaded.getAllWorktreeMeta()),
+      local: structuredClone(loaded.getWorkspaceSession()),
+      byHost: Object.fromEntries(
+        REMOTE_HOSTS.map((hostId) => [hostId, structuredClone(loaded.getWorkspaceSession(hostId))])
+      )
+    }
+    // The refill ran, so absence never reaches a consumer as `undefined`.
+    for (const meta of Object.values(before.meta)) {
+      for (const field of Object.keys(WORKTREE_META_PERSISTED_DEFAULTS)) {
+        expect(meta).toHaveProperty(field)
+      }
+    }
+
+    loaded.flush()
+    const rewritten = readFileSync(dataFile, 'utf-8')
+
+    // Only rows that actually hold a value still carry a slot: linkedPR + isPinned, 1 row in 40.
+    expect(defaultedSlotOccurrences(rewritten)).toBe(
+      (Math.ceil(META_ROWS / LINKED_ROW_STRIDE) + Math.ceil(IDENTITY_ROWS / LINKED_ROW_STRIDE)) * 2
+    )
+    // And no non-local partition carries a global the merge only ever reads off 'local'.
+    const onDisk = JSON.parse(rewritten) as PersistedState
+    for (const hostId of REMOTE_HOSTS) {
+      for (const field of HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS) {
+        expect(onDisk.workspaceSessionsByHostId?.[hostId]).not.toHaveProperty(field)
+      }
+    }
+    // Apples to apples: re-expand the file we just wrote back into the old shape and compare, so
+    // the number is the redundancy alone and not the settings defaults a synthetic fixture lacks.
+    expect(Buffer.byteLength(rewritten)).toBeLessThan(
+      Buffer.byteLength(JSON.stringify(reexpandToLegacyShape(onDisk))) * 0.6
+    )
+
+    // load(save(state)) deep-equals the pre-save state for every field touched.
+    const reloaded = openStore(dataFile)
+    expect(reloaded.getAllWorktreeMeta()).toEqual(before.meta)
+    expect(reloaded.getWorkspaceSession()).toEqual(before.local)
+    for (const hostId of REMOTE_HOSTS) {
+      expect(reloaded.getWorkspaceSession(hostId)).toEqual(before.byHost[hostId])
+    }
+
+    // A quiet app does not rewrite the file with new content on the next flush.
+    reloaded.flush()
+    expect(readFileSync(dataFile, 'utf-8')).toBe(rewritten)
+  })
+
+  it('loads an old-serializer file and a new-serializer file to the same state', () => {
+    const legacyFile = tempDataFile()
+    writeLegacyFile(legacyFile)
+    const fromLegacy = openStore(legacyFile)
+    // Writing it back produces the new, compact shape in place.
+    fromLegacy.flush()
+
+    const compactFile = tempDataFile()
+    writeFileSync(compactFile, readFileSync(legacyFile))
+    const fromCompact = openStore(compactFile)
+
+    expect(fromCompact.getAllWorktreeMeta()).toEqual(fromLegacy.getAllWorktreeMeta())
+    expect(fromCompact.getWorkspaceSession()).toEqual(fromLegacy.getWorkspaceSession())
+    for (const hostId of REMOTE_HOSTS) {
+      expect(fromCompact.getWorkspaceSession(hostId)).toEqual(
+        fromLegacy.getWorkspaceSession(hostId)
+      )
+    }
+  })
+})

--- a/src/main/persistence/loading-store/session-host-partitions.ts
+++ b/src/main/persistence/loading-store/session-host-partitions.ts
@@ -9,6 +9,7 @@ import {
 import { getDefaultWorkspaceSession } from '../../../shared/constants'
 import { pruneLocalTerminalScrollbackBuffers } from '../../../shared/workspace-session-terminal-buffers'
 import { pruneWorkspaceSessionBrowserHistory } from '../../../shared/workspace-session-browser-history'
+import { withoutRedundantGlobalFields } from '../../../shared/workspace-session-host-field-ownership'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 import { readTerminalScrollbackSnapshotSync } from '../../terminal-scrollback-snapshots'
 import { preserveRuntimeAuthoredWorkspaceSessionFields } from '../runtime-authored-workspace-session-fields'
@@ -190,11 +191,16 @@ export function setHostWorkspaceSession(
       executionHostId: hostId
     }
   )
-  const pruned = pruneWorkspaceSessionBrowserHistory(
-    pruneLocalTerminalScrollbackBuffers(
-      session,
-      owner[sessionHostPartitionOperationsContext].runtime.state.repos
-    )
+  // Why here too: the load-side drop only survives until the next full snapshot write. A renderer
+  // or runtime payload that still carries local's globals would re-inject them into this partition.
+  const pruned = withoutRedundantGlobalFields(
+    pruneWorkspaceSessionBrowserHistory(
+      pruneLocalTerminalScrollbackBuffers(
+        session,
+        owner[sessionHostPartitionOperationsContext].runtime.state.repos
+      )
+    ),
+    owner[sessionHostPartitionOperationsContext].runtime.state.workspaceSession
   )
   owner[sessionHostPartitionOperationsContext].runtime.state.workspaceSessionsByHostId = {
     ...owner[sessionHostPartitionOperationsContext].runtime.state.workspaceSessionsByHostId,

--- a/src/main/persistence/loading-store/state-serialization-secret-handling.ts
+++ b/src/main/persistence/loading-store/state-serialization-secret-handling.ts
@@ -7,6 +7,8 @@ import {
   type ProtectedSecretRetentionUpdate
 } from '../../protected-secret-persistence'
 import { stripRetiredGlobalSettings } from '../applying-settings/terminal-settings-migrations'
+import { omitDefaultWorktreeMetaFieldsInMap } from '../../../shared/worktree/meta-persisted-defaults'
+import { withoutRedundantPartitionGlobals } from '../../../shared/workspace-session-host-field-ownership'
 
 import {
   applySecretSentinelSubstitutions,
@@ -69,6 +71,26 @@ export class StateSerializationSecretHandlingOperations {
     // Why: clone before encrypting secrets so in-memory this.state stays plaintext.
     const stateToSave = {
       ...this.getDurableState(),
+      // Default-valued metadata slots are re-filled at load (normalizeWorktreeLinkedItemMetadata),
+      // so omitting them here is lossless and drops ~12% of the file on a heavy install.
+      worktreeMeta: omitDefaultWorktreeMetaFieldsInMap(this.runtime.state.worktreeMeta),
+      ...(this.runtime.state.worktreeMetaByIdentity !== undefined
+        ? {
+            worktreeMetaByIdentity: omitDefaultWorktreeMetaFieldsInMap(
+              this.runtime.state.worktreeMetaByIdentity
+            )
+          }
+        : {}),
+      // 'local' owns these globals and is the only slice any read takes them from; the load path
+      // re-seeds each partition's default, so writing them per host is pure file weight.
+      ...(this.runtime.state.workspaceSessionsByHostId !== undefined
+        ? {
+            workspaceSessionsByHostId: withoutRedundantPartitionGlobals(
+              this.runtime.state.workspaceSessionsByHostId,
+              this.runtime.state.workspaceSession
+            )
+          }
+        : {}),
       // Why both keys unconditionally: the explicit keys always win over the spread, and
       // JSON.stringify drops the `undefined` value so a note-free profile gains no key on disk.
       // The strip builds a new array here only; this.state records keep their notes in memory.

--- a/src/main/persistence/loading-store/workspace-session-partitions.test.ts
+++ b/src/main/persistence/loading-store/workspace-session-partitions.test.ts
@@ -10,12 +10,12 @@ import { getDefaultWorkspaceSession } from '../../../shared/constants'
 import type { BrowserHistoryEntry } from '../../../shared/browser-workspace-types'
 import type { WorkspaceDocHistoryEntry } from '../../../shared/workspace-doc-history'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
-import { WORKSPACE_SESSION_FIELD_OWNERSHIP } from '../../../shared/workspace-session-host-field-ownership'
-import { WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND } from '../restoring-sessions/session-worktree-ownership'
 import {
   HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS,
-  parseWorkspaceSessionsByHostId
-} from './workspace-session-partitions'
+  WORKSPACE_SESSION_FIELD_OWNERSHIP
+} from '../../../shared/workspace-session-host-field-ownership'
+import { WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND } from '../restoring-sessions/session-worktree-ownership'
+import { parseWorkspaceSessionsByHostId } from './workspace-session-partitions'
 
 const HOST = 'ssh:target-1'
 

--- a/src/main/persistence/loading-store/workspace-session-partitions.ts
+++ b/src/main/persistence/loading-store/workspace-session-partitions.ts
@@ -5,6 +5,7 @@ import {
   type ExecutionHostId
 } from '../../../shared/execution-host'
 import { parseWorkspaceSessionSalvaging } from '../../../shared/workspace-session-salvage'
+import { withoutRedundantGlobalFields } from '../../../shared/workspace-session-host-field-ownership'
 
 export function workspaceSessionSalvageLogDetails(result: {
   droppedCount: number
@@ -14,43 +15,6 @@ export function workspaceSessionSalvageLogDetails(result: {
     count: result.droppedCount,
     fields: [...new Set(result.droppedPaths.map((path) => path.split('.', 1)[0]))],
     detailsTruncated: result.droppedCount > result.droppedPaths.length
-  }
-}
-
-/**
- * Global fields belong to the 'local' slice: the split writes them only there and the merge reads
- * them only from there. A copy inside a non-local partition is legacy residue no read can reach —
- * stale `browserUrlHistory` replicas alone were 589 KB, 12.7% of a 4.65 MB store, rewritten on
- * every save and reparsed on every launch.
- *
- * Deliberately NOT every field in `GLOBAL_WORKSPACE_SESSION_FIELDS`. Two separate gates disqualify
- * the rest, and both are load-bearing:
- *  - `activeWorktreeId` and `activeWorkspaceKey` are `'direct'` in
- *    `WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND`, and both `collectPersistedSessionWorktreeOwners`
- *    and the deregistered-repo residue sweep read them out of EVERY partition. Dropping one
- *    un-owns a worktree, and an un-owned worktree gets its metadata pruned.
- *  - `activeTabId`, `activeConnectionIdsAtShutdown` and `activeRepoId` have live main-side readers
- *    on a partition: `isPersistedTerminalLeafActive` falls back to `activeTabId` for the mobile
- *    projection, and the runtime attach-window handoff unions `activeConnectionIdsAtShutdown`.
- *
- * `workspace-session-partitions.test.ts` re-checks both gates for every field listed here.
- */
-export const HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS = [
-  'browserUrlHistory',
-  'workspaceDocHistory'
-] as const satisfies readonly (keyof WorkspaceSessionState)[]
-
-/** Dropped only where local already holds the field — exactly when the merge's fallback to another
- *  slice cannot fire. Runs before the defaults spread, so a field the type requires comes back at
- *  its default rather than going missing. */
-function dropRedundantGlobalFields(
-  slice: Partial<WorkspaceSessionState>,
-  local: WorkspaceSessionState | undefined
-): void {
-  for (const field of HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS) {
-    if (local?.[field] !== undefined) {
-      delete slice[field]
-    }
   }
 }
 
@@ -88,8 +52,12 @@ export function parseWorkspaceSessionsByHostId(
       )
       repaired = true
     }
-    dropRedundantGlobalFields(result.value, localSession)
-    partitions[hostId] = { ...defaults, ...result.value }
+    // Runs before the defaults spread, so a field the type requires comes back at its default
+    // rather than going missing.
+    partitions[hostId] = {
+      ...defaults,
+      ...withoutRedundantGlobalFields(result.value, localSession)
+    }
   }
   return { partitions, repaired }
 }

--- a/src/main/persistence/loading-store/worktree-meta-write-normalization.ts
+++ b/src/main/persistence/loading-store/worktree-meta-write-normalization.ts
@@ -5,6 +5,7 @@ import { normalizeWorkspaceLinkedItem } from '../../../shared/workspace-linked-i
 import { isWorkspaceLinkedItemSourceContextMatch } from '../../../shared/workspace-linked-item-source-context'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../../shared/workspace-statuses'
 import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import { WORKTREE_META_PERSISTED_DEFAULTS } from '../../../shared/worktree/meta-persisted-defaults'
 import { normalizeGitHubPRSuppressionUpdate } from '../../../shared/worktree/github-pr-suppression'
 
 type WorktreeMetaIdentity = {
@@ -12,24 +13,15 @@ type WorktreeMetaIdentity = {
   hostId: ExecutionHostId
 }
 
+// Why spread the shared table: it is what the serializer omits and the loader re-fills, so the two
+// must never drift.
 function createDefaultWorktreeMeta(): WorktreeMeta {
   return {
+    ...WORKTREE_META_PERSISTED_DEFAULTS,
     instanceId: randomUUID(),
     displayName: '',
     comment: '',
-    linkedIssue: null,
-    linkedPR: null,
-    linkedLinearIssue: null,
-    linkedGitLabMR: null,
-    linkedGitLabIssue: null,
-    linkedBitbucketPR: null,
-    linkedAzureDevOpsPR: null,
-    linkedGiteaPR: null,
-    linkedWorkItem: null,
-    linkedTaskSourceContext: null,
-    isArchived: false,
     isUnread: false,
-    isPinned: false,
     sortOrder: Date.now(),
     lastActivityAt: 0,
     workspaceStatus: DEFAULT_WORKSPACE_STATUS_ID

--- a/src/main/persistence/tracking-repos/worktree-metadata-normalization.test.ts
+++ b/src/main/persistence/tracking-repos/worktree-metadata-normalization.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import { WORKTREE_META_PERSISTED_DEFAULTS } from '../../../shared/worktree/meta-persisted-defaults'
 import type { PersistedState } from '../../../shared/persisted-state-types'
 import {
   gcStaleWorktreeMeta,
@@ -7,9 +8,10 @@ import {
   WORKTREE_META_GC_GRACE_MS
 } from './worktree-metadata-normalization'
 
-// Only the presence of an entry matters here; the normalizer never reads its linked-item fields.
+// Only the presence of an entry matters to the alias/lineage passes, but the normalizer is also
+// the load-side inverse of the serializer's default omission, so a surviving row carries them back.
 function makeMeta(): WorktreeMeta {
-  return { createdAt: 1 } as WorktreeMeta
+  return { createdAt: 1, ...WORKTREE_META_PERSISTED_DEFAULTS } as WorktreeMeta
 }
 
 function makeState(overrides: Partial<PersistedState>): PersistedState {

--- a/src/main/persistence/tracking-repos/worktree-metadata-normalization.ts
+++ b/src/main/persistence/tracking-repos/worktree-metadata-normalization.ts
@@ -20,6 +20,7 @@ import {
   removeWorktreeMetadataForHost
 } from '../loading-store/worktree-identity-metadata'
 import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import { fillDefaultWorktreeMetaFields } from '../../../shared/worktree/meta-persisted-defaults'
 
 // Why: worktrees deleted outside Orca orphan their worktreeMeta, so the map grew monotonically (63% dead on a heavy install).
 // GC stays narrow: local-host entries only (a local existsSync would falsely condemn SSH/WSL remote paths) and only after a 30-day idle grace.
@@ -143,6 +144,9 @@ export function normalizeWorktreeLinkedItemMetadata(state: PersistedState): bool
       changed = true
       continue
     }
+    // Not `changed`: the serializer omits these slots deliberately, so re-filling them is how the
+    // on-disk shape is already canonical -- flagging it would force a full rewrite on every launch.
+    fillDefaultWorktreeMetaFields(meta)
     changed = normalizeLinkedMetadata(meta) || changed
   }
   const rawIdentityMetadata = state.worktreeMetaByIdentity as unknown
@@ -161,6 +165,7 @@ export function normalizeWorktreeLinkedItemMetadata(state: PersistedState): bool
       changed = true
       continue
     }
+    fillDefaultWorktreeMetaFields(meta)
     changed = normalizeLinkedMetadata(meta) || changed
   }
 

--- a/src/renderer/src/lib/workspace-session-host-split.test.ts
+++ b/src/renderer/src/lib/workspace-session-host-split.test.ts
@@ -6,6 +6,7 @@ import {
 } from './workspace-session-host-split'
 import { getDefaultWorkspaceSession } from '../../../shared/constants'
 import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../shared/execution-host'
+import { HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS } from '../../../shared/workspace-session-host-field-ownership'
 import type { BrowserPage } from '../../../shared/browser-workspace-types'
 import type { Tab } from '../../../shared/tab-types'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
@@ -94,6 +95,46 @@ describe('splitWorkspaceSessionByHost', () => {
     expect(slices[LOCAL_EXECUTION_HOST_ID]?.activeConnectionIdsAtShutdown).toEqual(['ssh-target'])
     // No runtime slice is created when nothing is worktree-owned by it.
     expect(slices[RUNTIME_A]).toBeUndefined()
+  })
+
+  it('never replicates a local-owned global onto a non-local slice', () => {
+    // The regression this pins: one template handed to every host put a byte-identical copy of
+    // local's browserUrlHistory in each runtime partition, undoing #18161's load-time drop on the
+    // very next full snapshot write. 66 KB per host at 200 entries, growing with host count.
+    const state: WorkspaceSessionState = {
+      ...getDefaultWorkspaceSession(),
+      browserUrlHistory: [
+        { url: 'u', normalizedUrl: 'u', title: 't', lastVisitedAt: 1, visitCount: 1 }
+      ],
+      workspaceDocHistory: [
+        {
+          docLocation: { kind: 'workspace-doc', worktreeId: 'local-wt', filePath: 'a.md' },
+          title: 'a.md',
+          lastVisitedAt: 2,
+          visitCount: 1
+        }
+      ],
+      tabsByWorktree: {
+        'local-wt': [makeTab('t-local', 'local-wt')],
+        'a-wt': [makeTab('t-a', 'a-wt')],
+        'b-wt': [makeTab('t-b', 'b-wt')]
+      }
+    }
+
+    const slices = splitWorkspaceSessionByHost(state, ownerByPrefix())
+
+    expect(Object.keys(slices).sort()).toEqual([LOCAL_EXECUTION_HOST_ID, RUNTIME_A, RUNTIME_B])
+    for (const field of HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS) {
+      expect(slices[LOCAL_EXECUTION_HOST_ID]?.[field]).toEqual(state[field])
+      expect(Object.hasOwn(slices[RUNTIME_A] ?? {}, field)).toBe(false)
+      expect(Object.hasOwn(slices[RUNTIME_B] ?? {}, field)).toBe(false)
+    }
+    // The read path is unaffected: local always carries them, so the merge never reaches its
+    // fallback to another slice.
+    const merged = mergeWorkspaceSessionsFromHosts(slices)
+    for (const field of HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS) {
+      expect(merged[field]).toEqual(state[field])
+    }
   })
 
   it('routes worktree-keyed maps to their owner host', () => {

--- a/src/renderer/src/lib/workspace-session-host-split.ts
+++ b/src/renderer/src/lib/workspace-session-host-split.ts
@@ -7,6 +7,7 @@ import {
 import { isWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
 import {
   GLOBAL_WORKSPACE_SESSION_FIELDS,
+  hostPartitionSliceTemplate,
   WORKSPACE_SESSION_FIELD_OWNERSHIP
 } from '../../../shared/workspace-session-host-field-ownership'
 import {
@@ -58,16 +59,24 @@ type SplitContext = {
   worktreeIdByFileId: Map<string, string>
 }
 
+/** 'local' owns the full global set; every other host gets the subset the merge can still read
+ *  back off it. Handing one template to both is what re-injected local's browserUrlHistory into
+ *  every runtime partition and undid the load-time drop on the next full snapshot write (#18161). */
+type SliceTemplates = {
+  local: WorkspaceSessionState
+  nonLocal: WorkspaceSessionState
+}
+
 function ensureSlice(
   slices: HostSessionSlices,
   hostId: ExecutionHostId,
-  template: WorkspaceSessionState
+  templates: SliceTemplates
 ): WorkspaceSessionState {
   let slice = slices[hostId]
   if (!slice) {
     // Why: clone the global fields onto every slice so a partition read in
     // isolation still carries the active pointers; merge later prefers 'local'.
-    slice = { ...template }
+    slice = { ...(hostId === LOCAL_EXECUTION_HOST_ID ? templates.local : templates.nonLocal) }
     slices[hostId] = slice
   }
   return slice
@@ -75,7 +84,7 @@ function ensureSlice(
 
 function assignWorktreeKeyed(
   slices: HostSessionSlices,
-  template: WorkspaceSessionState,
+  templates: SliceTemplates,
   field: keyof WorkspaceSessionState,
   value: unknown,
   ctx: SplitContext
@@ -85,7 +94,7 @@ function assignWorktreeKeyed(
   }
   for (const [worktreeId, entry] of Object.entries(value)) {
     const host = ctx.hostIdByWorktreeId(worktreeId)
-    const slice = ensureSlice(slices, host, template) as WorkspaceSessionRecord
+    const slice = ensureSlice(slices, host, templates) as WorkspaceSessionRecord
     const target = (slice[field] ??= {}) as WorkspaceSessionRecord
     target[worktreeId] = entry
   }
@@ -93,7 +102,7 @@ function assignWorktreeKeyed(
 
 function assignVisitRecencyByHost(
   slices: HostSessionSlices,
-  template: WorkspaceSessionState,
+  templates: SliceTemplates,
   value: unknown,
   ctx: SplitContext
 ): void {
@@ -112,7 +121,7 @@ function assignVisitRecencyByHost(
         ? qualifiedHost.id
         : LOCAL_EXECUTION_HOST_ID
       : ctx.hostIdByWorktreeId(key)
-    const slice = ensureSlice(slices, host, template) as WorkspaceSessionRecord
+    const slice = ensureSlice(slices, host, templates) as WorkspaceSessionRecord
     const target = (slice.lastVisitedAtByWorktreeId ??= {}) as WorkspaceSessionRecord
     target[key] = entry
   }
@@ -120,7 +129,7 @@ function assignVisitRecencyByHost(
 
 function assignKeyedByResolvedWorktree(
   slices: HostSessionSlices,
-  template: WorkspaceSessionState,
+  templates: SliceTemplates,
   field: keyof WorkspaceSessionState,
   value: unknown,
   resolveWorktreeId: (key: string, entry: unknown) => string | undefined,
@@ -132,7 +141,7 @@ function assignKeyedByResolvedWorktree(
   for (const [key, entry] of Object.entries(value)) {
     const worktreeId = resolveWorktreeId(key, entry)
     const host = worktreeId ? ctx.hostIdByWorktreeId(worktreeId) : LOCAL_EXECUTION_HOST_ID
-    const slice = ensureSlice(slices, host, template) as WorkspaceSessionRecord
+    const slice = ensureSlice(slices, host, templates) as WorkspaceSessionRecord
     const target = (slice[field] ??= {}) as WorkspaceSessionRecord
     target[key] = entry
   }
@@ -157,10 +166,15 @@ export function splitWorkspaceSessionByHost(
     }
   }
 
+  const templates: SliceTemplates = {
+    local: template,
+    nonLocal: hostPartitionSliceTemplate(template)
+  }
+
   const slices: HostSessionSlices = {}
   // Why: 'local' must always exist — it owns the global fields and is the
   // hydration anchor even when every worktree belongs to a runtime host.
-  ensureSlice(slices, LOCAL_EXECUTION_HOST_ID, template)
+  ensureSlice(slices, LOCAL_EXECUTION_HOST_ID, templates)
 
   const ctx: SplitContext = {
     hostIdByWorktreeId,
@@ -192,9 +206,9 @@ export function splitWorkspaceSessionByHost(
         break
       case 'worktreeKeyed':
         if (field === 'lastVisitedAtByWorktreeId') {
-          assignVisitRecencyByHost(slices, template, value, ctx)
+          assignVisitRecencyByHost(slices, templates, value, ctx)
         } else {
-          assignWorktreeKeyed(slices, template, field, value, ctx)
+          assignWorktreeKeyed(slices, templates, field, value, ctx)
         }
         break
       case 'worktreeArray': {
@@ -203,7 +217,7 @@ export function splitWorkspaceSessionByHost(
         }
         for (const worktreeId of value as string[]) {
           const host = ctx.hostIdByWorktreeId(worktreeId)
-          const slice = ensureSlice(slices, host, template) as WorkspaceSessionRecord
+          const slice = ensureSlice(slices, host, templates) as WorkspaceSessionRecord
           const target = (slice[field] ??= []) as string[]
           target.push(worktreeId)
         }
@@ -212,7 +226,7 @@ export function splitWorkspaceSessionByHost(
       case 'tabKeyed':
         assignKeyedByResolvedWorktree(
           slices,
-          template,
+          templates,
           field,
           value,
           (tabId) => ctx.worktreeIdByTabId.get(tabId),
@@ -222,7 +236,7 @@ export function splitWorkspaceSessionByHost(
       case 'fileKeyed':
         assignKeyedByResolvedWorktree(
           slices,
-          template,
+          templates,
           field,
           value,
           (fileId) => ctx.worktreeIdByFileId.get(fileId),
@@ -232,7 +246,7 @@ export function splitWorkspaceSessionByHost(
       case 'browserWorkspaceKeyed':
         assignKeyedByResolvedWorktree(
           slices,
-          template,
+          templates,
           field,
           value,
           (_workspaceId, pages) => {
@@ -247,7 +261,7 @@ export function splitWorkspaceSessionByHost(
       case 'sleepingAgentKeyed':
         assignKeyedByResolvedWorktree(
           slices,
-          template,
+          templates,
           field,
           value,
           (_paneKey, record) =>
@@ -260,7 +274,7 @@ export function splitWorkspaceSessionByHost(
       case 'paneKeyed':
         assignKeyedByResolvedWorktree(
           slices,
-          template,
+          templates,
           field,
           value,
           (paneKey) => {
@@ -275,7 +289,7 @@ export function splitWorkspaceSessionByHost(
       case 'surfaceTombstoneKeyed':
         assignKeyedByResolvedWorktree(
           slices,
-          template,
+          templates,
           field,
           value,
           (_paneKey, record) =>

--- a/src/shared/workspace-session-host-field-ownership.ts
+++ b/src/shared/workspace-session-host-field-ownership.ts
@@ -67,3 +67,74 @@ void exhaustive
 export const GLOBAL_WORKSPACE_SESSION_FIELDS = (
   Object.keys(WORKSPACE_SESSION_FIELD_OWNERSHIP) as (keyof WorkspaceSessionState)[]
 ).filter((field) => WORKSPACE_SESSION_FIELD_OWNERSHIP[field] === 'global')
+
+/**
+ * Global session fields that belong to the 'local' slice alone: `splitWorkspaceSessionByHost`
+ * writes them only there and `mergeWorkspaceSessionsFromHosts` reads them only from there. A copy
+ * inside a non-local partition is residue no read can reach — stale `browserUrlHistory` replicas
+ * alone were 589 KB, 12.7% of a 4.65 MB store, rewritten on every save and reparsed on every
+ * launch.
+ *
+ * Deliberately NOT every field in `GLOBAL_WORKSPACE_SESSION_FIELDS`. Two separate gates disqualify
+ * the rest, and both are load-bearing:
+ *  - `activeWorktreeId` and `activeWorkspaceKey` are `'direct'` in
+ *    `WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND`, and both `collectPersistedSessionWorktreeOwners`
+ *    and the deregistered-repo residue sweep read them out of EVERY partition. Dropping one
+ *    un-owns a worktree, and an un-owned worktree gets its metadata pruned.
+ *  - `activeTabId`, `activeConnectionIdsAtShutdown` and `activeRepoId` have live main-side readers
+ *    on a partition: `isPersistedTerminalLeafActive` falls back to `activeTabId` for the mobile
+ *    projection, and the runtime attach-window handoff unions `activeConnectionIdsAtShutdown`.
+ *
+ * `workspace-session-partitions.test.ts` re-checks both gates for every field listed here.
+ */
+export const HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS = [
+  'browserUrlHistory',
+  'workspaceDocHistory'
+] as const satisfies readonly (keyof WorkspaceSessionState)[]
+
+/** Serialize-side sweep over every non-local partition. The load path re-seeds these fields at
+ *  their default from the session defaults spread, so a partition that holds only that default
+ *  still costs bytes on every save; this is where those go. Returns the input when nothing drops. */
+export function withoutRedundantPartitionGlobals<
+  T extends Partial<Record<string, WorkspaceSessionState>>
+>(partitions: T, local: Partial<WorkspaceSessionState> | undefined): T {
+  let pruned: Record<string, WorkspaceSessionState | undefined> | undefined
+  for (const [hostId, slice] of Object.entries(partitions) as [
+    string,
+    WorkspaceSessionState | undefined
+  ][]) {
+    if (!slice) {
+      continue
+    }
+    const next = withoutRedundantGlobalFields(slice, local)
+    if (next === slice) {
+      continue
+    }
+    pruned ||= { ...partitions }
+    pruned[hostId] = next
+  }
+  return (pruned as T | undefined) ?? partitions
+}
+
+/** Non-local slice template: the same globals minus the ones only 'local' is ever read for. */
+export function hostPartitionSliceTemplate(template: WorkspaceSessionState): WorkspaceSessionState {
+  return withoutRedundantGlobalFields(template, template)
+}
+
+/** Drop redundant globals only where `local` already holds the field — exactly when the merge's
+ *  fallback to another slice cannot fire. Returns `slice` untouched when nothing is dropped, so
+ *  callers that rely on identity keep it. */
+export function withoutRedundantGlobalFields<T extends Partial<WorkspaceSessionState>>(
+  slice: T,
+  local: Partial<WorkspaceSessionState> | undefined
+): T {
+  let pruned: T | undefined
+  for (const field of HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS) {
+    if (local?.[field] === undefined || !Object.hasOwn(slice, field)) {
+      continue
+    }
+    pruned ??= { ...slice }
+    delete pruned[field]
+  }
+  return pruned ?? slice
+}

--- a/src/shared/worktree/meta-persisted-defaults.ts
+++ b/src/shared/worktree/meta-persisted-defaults.ts
@@ -1,0 +1,73 @@
+import type { WorktreeMeta } from './meta-types'
+
+/**
+ * WorktreeMeta slots whose persisted value is a fixed default on almost every row.
+ *
+ * `mergeWorktreeMetaForWrite` materializes all of them on creation, so a store with ~1,200
+ * workspaces carried ~534 KB of `"field":null` / `"field":false` pairs — 12.6% of the whole file —
+ * re-serialized on every debounced save and re-parsed on every launch. They are omitted on
+ * serialize and re-filled on load, so in-memory state is byte-identical either way.
+ *
+ * Only genuinely constant defaults belong here: `instanceId` and `sortOrder` are minted per row
+ * and must stay written. Absence is safe for an older build too — every projection out of
+ * WorktreeMeta into the `Worktree` the app reads (`mergeWorktree`, `getLinkedWorkItemMetadata`,
+ * `folder-workspace-model`, `runtime-folder-workspace`, `runtime-worktree-ps-summaries`) already
+ * coerces each of these with `?? null` / `?? false`.
+ */
+export const WORKTREE_META_PERSISTED_DEFAULTS = {
+  linkedIssue: null,
+  linkedPR: null,
+  linkedLinearIssue: null,
+  linkedGitLabMR: null,
+  linkedGitLabIssue: null,
+  linkedBitbucketPR: null,
+  linkedAzureDevOpsPR: null,
+  linkedGiteaPR: null,
+  linkedWorkItem: null,
+  linkedTaskSourceContext: null,
+  isArchived: false,
+  isPinned: false
+} as const satisfies Partial<WorktreeMeta>
+
+type DefaultedField = keyof typeof WORKTREE_META_PERSISTED_DEFAULTS
+
+const DEFAULTED_FIELDS = Object.keys(WORKTREE_META_PERSISTED_DEFAULTS) as DefaultedField[]
+
+/** Serialize-side: drop slots still at their default. Returns the input when nothing is dropped. */
+export function omitDefaultWorktreeMetaFields(meta: WorktreeMeta): WorktreeMeta {
+  let compacted: WorktreeMeta | undefined
+  for (const field of DEFAULTED_FIELDS) {
+    if (meta[field] !== WORKTREE_META_PERSISTED_DEFAULTS[field]) {
+      continue
+    }
+    compacted ??= { ...meta }
+    delete (compacted as Record<string, unknown>)[field]
+  }
+  return compacted ?? meta
+}
+
+/** Same, across a whole metadata map. Returns the input map when no row changed. */
+export function omitDefaultWorktreeMetaFieldsInMap<T extends Record<string, WorktreeMeta>>(
+  metaById: T
+): T {
+  let compacted: Record<string, WorktreeMeta> | undefined
+  for (const [key, meta] of Object.entries(metaById)) {
+    const next = omitDefaultWorktreeMetaFields(meta)
+    if (next === meta) {
+      continue
+    }
+    compacted ??= { ...metaById }
+    compacted[key] = next
+  }
+  return (compacted as T | undefined) ?? metaById
+}
+
+/** Load-side inverse, in place. Without it `null` silently becomes `undefined` for any consumer
+ *  doing `=== null`, so it must land in the same change as the omission. */
+export function fillDefaultWorktreeMetaFields(meta: WorktreeMeta): void {
+  for (const field of DEFAULTED_FIELDS) {
+    if (meta[field] === undefined) {
+      ;(meta as Record<string, unknown>)[field] = WORKTREE_META_PERSISTED_DEFAULTS[field]
+    }
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​294 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​288 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​225 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​74 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 |

<!-- /orca-pr-loc -->

## ELI5

Orca writes its whole `orca-data.json` from scratch every time anything changes (1 s debounce, 5 s max wait) and reads the whole thing back at launch. On a heavy install that file is 4.2 MB. A big slice of those bytes said nothing: metadata rows spelled out `"linkedGitLabMR":null` twelve times over for ~1,200 workspaces, and three of ten per-host session partitions carried a byte-identical photocopy of the browser history that only the `local` partition is ever read for.

This deletes those bytes on write and reconstructs them on read, so nothing in memory changes — the app just stops paying to write and re-read the same nulls a hundred times a session.

## What was happening

**A — the renderer split was re-injecting global session fields into every non-local partition. This is a write-side regression that undid #18161's load-side fix.**

`splitWorkspaceSessionByHost` built one `template` holding all `GLOBAL_WORKSPACE_SESSION_FIELDS` and handed that same template to `ensureSlice` for *every* host, not just `local`. `setHostWorkspaceSession` stored it verbatim.

`mergeWorkspaceSessionsFromHosts` reads globals from `local` first and only falls back to another slice when local lacks them — which cannot happen, because the template always fills `local`. So every non-local copy was bytes no read could reach.

#18161 added a load-time drop in `parseWorkspaceSessionsByHostId` that removed the replicas on the way in. But the very next full snapshot write put them straight back, because the split still seeded them. On the reporting install that was 3 of 10 partitions each holding a byte-identical 66,178 B replica of local's `browserUrlHistory` (verified `===`), 198,534 B / 4.7% of the file, re-serialized on every save, re-parsed on every launch, and structured-cloned over IPC once per host on every `persistWorkspaceSessionByHost` and quit snapshot. It grows linearly with the number of runtime hosts ever used.

Fixed in three places so the drop cannot be undone again: the split gives non-local slices a template without `HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS`, `setHostWorkspaceSession` strips them from any payload that still carries them, and the serializer sweeps the partition map as a backstop (the load path re-seeds each partition's `[]` default, which was itself being written back per host).

**C — ~11,450 `"field":null` pairs across the two metadata maps.**

`mergeWorktreeMetaForWrite` materializes all ten `linked*` slots plus `isPinned`/`isArchived` on every row at creation, even when null. Measured on the real file: 266,977 B in `worktreeMeta` + 266,810 B in `worktreeMetaByIdentity` = **533,787 B, 12.6% of the whole file**, per save and per launch parse.

The serializer now omits any slot still equal to its default; `normalizeWorktreeLinkedItemMetadata` — which already walks every row of both maps at load — re-fills them. The default table (`WORKTREE_META_PERSISTED_DEFAULTS`) is now the single source `createDefaultWorktreeMeta` spreads, so the omit set and the fill set cannot drift. Only genuinely constant defaults are in it: `instanceId` and `sortOrder` are minted per row and stay written.

**B — `normalizedUrl` duplicating `url` in `browserUrlHistory` — dropped, deliberately.**

19,641 B of `browserUrlHistory`'s 66,569 B are `normalizedUrl` values byte-identical to `url`, and the load path already recomputes `normalizedUrl` from `url` unconditionally (`browserHistoryEntriesSchema` → `normalizeBrowserHistoryEntries`), so omitting it would be lossless *for this build*. It fails the downgrade half of the hard constraint: the entry schema is `salvagingArray(browserHistoryEntrySchema)` with `normalizedUrl: z.string()` required, so an **older build silently drops every history entry that omits the field** and then rewrites the file without them — real, unrecoverable user data loss, and there is no coercion layer to save it the way `mergeWorktree` saves C. 0.46% of the file is not worth that. Not shipped.

## Measurement

Realistic fixture built to the reported install's shape: 10 hosts (local + 9 runtime, 3 carrying the history replica), 1,200 `worktreeMeta` rows, 1,191 `worktreeMetaByIdentity` rows, 200 browser history entries. Driven through the real `Store`; "before" is the same loaded state re-expanded to the old on-disk shape, so the delta is the redundancy alone and not fixture noise.

**Serialized bytes per save**

| | before | after | delta |
|---|---|---|---|
| **total** | 1,445,276 | 643,238 | **−802,038 (−55.5%)** |
| `worktreeMeta` | 607,256 | 285,446 | −321,810 (−53.0%) |
| `worktreeMetaByIdentity` | 606,259 | 286,870 | −319,389 (−52.7%) |
| `workspaceSessionsByHostId` | 164,433 | 3,594 | −160,839 (−97.8%) |

**Bytes structured-cloned per `persistWorkspaceSessionByHost`, 9 non-local hosts:** 164,250 → **3,411** (−97.9%).

**Launch `JSON.parse`, median of 25:** 2.00 ms → **1.37 ms** (−31%), plus the same proportion off the `readFileSync` and off every `writeFile` + `fsync` on the save path.

Projected onto the reporting user's 4,243,739-byte file using its own per-field measurements: 533,787 B (C) + ~198,948 B (A) ≈ **733 KB, 17.3%** removed from every save and every launch parse. The fixture removes 268 B/row from metadata versus the 224 B/row measured on the real file, so the projection uses the real number and is conservative.

## Negative user-facing trade-offs

None found. The specific claims:

**Round trip.** `load(save(state))` deep-equals the pre-save state for every field touched, asserted directly in `persisted-state-redundancy.test.ts` over the full fixture: `getAllWorktreeMeta()`, the local session, and all nine host sessions. The load-side fill lands in the same change as the omission, so `null` never becomes `undefined` for a consumer doing `=== null`. A second flush is byte-identical, so a quiet app does not churn the file.

**Forward compatibility.** A file written by the OLD serializer and a file written by the NEW one load to identical in-memory state — its own test. Absence and the default carry the same meaning, and no non-default value is ever omitted.

**Downgrade.** A file this build writes, read by an older build with no fill:
- *A:* the older build's `parseWorkspaceSessionsByHostId` already drops these fields at load (#18161) and re-seeds each partition's default from its own defaults spread. It never reads them off a non-local partition — that is the gate `workspace-session-partitions.test.ts` enforces per field. Nothing to lose.
- *C:* every projection from `WorktreeMeta` into the `Worktree` the app actually reads already coerces each omitted slot, in code that is on `main` today and unchanged here — `mergeWorktree` (`meta?.linkedIssue ?? null`, `isArchived ?? false`, `isPinned ?? false`), `getLinkedWorkItemMetadata` (`?? null` for all seven optional linked fields), `folder-workspace-model`, `runtime-folder-workspace`, `runtime-worktree-ps-summaries`. Every raw-meta reader in main goes through `?.field ?? null`, a truthiness check, or a `isLinkedIssueNumber`-style type guard. An older build therefore builds the same `Worktree` objects. Then it rewrites the file with the fields still absent (`JSON.stringify` drops `undefined`), and re-upgrading re-fills them — no data lost either direction.
- *B* fails this test, which is exactly why it is not in this PR.

**Not touched, deliberately:**
- `SAVE_DEBOUNCE_MS` / `SAVE_MAX_WAIT_MS` are unchanged — raising them trades crash-window state loss for bytes.
- Backup rotation is already hourly-gated at 4 renames + 1 `copyFile`; left alone.

## Risk & verification

`pnpm tc` clean. `pnpm run check:code-quality:changed` clean (0 new findings across 12 files).

Every test in the touched areas runs green, plus the whole of `src/main/persistence`, `src/renderer/src/lib`, and the session schema suites: **582 files / 5,726 tests passing**. (`persistence-async-write-syscalls.test.ts` timed out once at 30 s under full-suite parallelism and passes in 27.6 s standalone — pre-existing headroom, unrelated.)

New tests, each verified to fail without its fix:
- `workspace-session-host-split.test.ts` → *never replicates a local-owned global onto a non-local slice*: no non-local slice carries any `HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS` after a split, **and** the merge still returns local's value. **Fails on `main`.**
- `persisted-state-redundancy.test.ts` → *round-trips a legacy-shaped file to identical in-memory state and a smaller file*: full-size fixture; asserts the refill ran, that only rows holding a real value keep a slot, that no partition on disk carries a redundant global, an apples-to-apples size drop, deep equality across `load(save(…))`, and byte-stability of the next flush. **Fails without either the serializer omission or the load-side fill.**
- `persisted-state-redundancy.test.ts` → *loads an old-serializer file and a new-serializer file to the same state*. **Fails without the load-side fill.**

Existing `workspace-session-partitions.test.ts` still re-checks both safety gates for every field in `HOST_PARTITION_REDUNDANT_GLOBAL_FIELDS` (must be `'global'`, must be `'none'` in `WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND`); the constant just moved to `src/shared/` so the renderer split can share it.

**Separately-scoped follow-up, not done here:** 1,191 of the 1,193 `worktreeMeta` rows are byte-identical duplicates of `worktreeMetaByIdentity` rows, another ~20% of the file. Dropping the legacy map is a persisted-schema change with a downgrade hazard that this PR's constraints do not permit: an older build reads only `worktreeMeta` and would show **zero workspace metadata**. It needs its own migration and a deprecation window.
