### PR TITLE
perf(sidebar): memoize the lineage ancestor index and precompute sort labels

### DIFF
--- a/src/renderer/src/components/sidebar/smart-sort.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.ts
@@ -48,7 +48,7 @@ export function effectiveRecentActivity(worktree: Worktree, now: number): number
   return Math.max(lastActivityAt, createdAt + CREATE_GRACE_MS)
 }
 
-type WorktreeSortLabelInput = Pick<Worktree, 'displayName' | 'path' | 'id'>
+export type WorktreeSortLabelInput = Pick<Worktree, 'displayName' | 'path' | 'id'>
 
 export function getWorktreeSortLabel(worktree: WorktreeSortLabelInput): string {
   const displayName = typeof worktree.displayName === 'string' ? worktree.displayName.trim() : ''
@@ -62,11 +62,34 @@ export function getWorktreeSortLabel(worktree: WorktreeSortLabelInput): string {
   return pathLabel || worktree.id
 }
 
+/**
+ * Sort labels precomputed once per sort, so the O(N log N) comparator does O(1)
+ * lookups instead of re-deriving both labels on every comparison.
+ *
+ * Why keyed on the row and not its id: a two-host id collision (STA-4343) puts
+ * two rows with different paths under one id, and an id key would hand one of
+ * them the other's label.
+ */
+export type WorktreeSortLabels = ReadonlyMap<WorktreeSortLabelInput, string>
+
+export function buildWorktreeSortLabels<T extends WorktreeSortLabelInput>(
+  worktrees: readonly T[]
+): Map<WorktreeSortLabelInput, string> {
+  const labels = new Map<WorktreeSortLabelInput, string>()
+  for (const worktree of worktrees) {
+    labels.set(worktree, getWorktreeSortLabel(worktree))
+  }
+  return labels
+}
+
 export function compareWorktreeSortLabel(
   a: WorktreeSortLabelInput,
-  b: WorktreeSortLabelInput
+  b: WorktreeSortLabelInput,
+  labels?: WorktreeSortLabels
 ): number {
-  return getWorktreeSortLabel(a).localeCompare(getWorktreeSortLabel(b))
+  return (labels?.get(a) ?? getWorktreeSortLabel(a)).localeCompare(
+    labels?.get(b) ?? getWorktreeSortLabel(b)
+  )
 }
 
 /**
@@ -82,12 +105,13 @@ export function buildWorktreeComparator(
   sortBy: SortBy,
   repoMap: Map<string, Repo>,
   now: number,
-  attentionByWorktree: Map<string, WorktreeAttention>
+  attentionByWorktree: Map<string, WorktreeAttention>,
+  labels?: WorktreeSortLabels
 ): (a: Worktree, b: Worktree) => number {
   return (a, b) => {
     switch (sortBy) {
       case 'name':
-        return compareWorktreeSortLabel(a, b)
+        return compareWorktreeSortLabel(a, b, labels)
       case 'smart': {
         const aw = attentionByWorktree.get(a.id) ?? IDLE
         const bw = attentionByWorktree.get(b.id) ?? IDLE
@@ -99,7 +123,7 @@ export function buildWorktreeComparator(
           // Why: idle worktrees fall through to recency (and the create-grace
           // floor for brand-new worktrees) before alphabetical.
           effectiveRecentActivity(b, now) - effectiveRecentActivity(a, now) ||
-          compareWorktreeSortLabel(a, b)
+          compareWorktreeSortLabel(a, b, labels)
         )
       }
       case 'recent':
@@ -116,13 +140,13 @@ export function buildWorktreeComparator(
         // events) and by meaningful meta edits (comment, isUnread).
         return (
           effectiveRecentActivity(b, now) - effectiveRecentActivity(a, now) ||
-          compareWorktreeSortLabel(a, b)
+          compareWorktreeSortLabel(a, b, labels)
         )
       case 'repo': {
         const ra = repoMap.get(a.repoId)?.displayName ?? ''
         const rb = repoMap.get(b.repoId)?.displayName ?? ''
         const cmp = ra.localeCompare(rb)
-        return cmp !== 0 ? cmp : compareWorktreeSortLabel(a, b)
+        return cmp !== 0 ? cmp : compareWorktreeSortLabel(a, b, labels)
       }
       case 'manual':
         // Why fallback to sortOrder: existing users have a persisted smart-sort
@@ -130,7 +154,7 @@ export function buildWorktreeComparator(
         // restored order instead of alphabetizing every legacy workspace.
         return (
           (b.manualOrder ?? b.sortOrder) - (a.manualOrder ?? a.sortOrder) ||
-          compareWorktreeSortLabel(a, b)
+          compareWorktreeSortLabel(a, b, labels)
         )
     }
   }
@@ -169,11 +193,12 @@ export function sortWorktreesSmart(
     .some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id))
 
   const now = Date.now()
+  const labels = buildWorktreeSortLabels(worktrees)
   if (!hasAnyLivePty && !hasFreshAttributedAgentStatus(agentStatusByPaneKey, now, tabsByWorktree)) {
     // Cold start: use persisted sortOrder snapshot until the agent-status
     // snapshot lands and a warm sort runs.
     return [...worktrees].sort(
-      (a, b) => b.sortOrder - a.sortOrder || compareWorktreeSortLabel(a, b)
+      (a, b) => b.sortOrder - a.sortOrder || compareWorktreeSortLabel(a, b, labels)
     )
   }
 
@@ -188,5 +213,7 @@ export function sortWorktreesSmart(
     terminalLayoutsByTabId
   )
 
-  return [...worktrees].sort(buildWorktreeComparator('smart', repoMap, now, attentionByWorktree))
+  return [...worktrees].sort(
+    buildWorktreeComparator('smart', repoMap, now, attentionByWorktree, labels)
+  )
 }

--- a/src/renderer/src/components/sidebar/visible-worktree-indexes.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktree-indexes.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest'
+import type * as ResolvedWorktreeLineage from '../../../../shared/resolved-worktree-lineage'
+import type { Repo } from '../../../../shared/repo-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+
+const counters = vi.hoisted(() => ({ cycleDetections: 0 }))
+
+vi.mock('../../../../shared/resolved-worktree-lineage', async (importOriginal) => {
+  const actual = await importOriginal<typeof ResolvedWorktreeLineage>()
+  return {
+    ...actual,
+    getCyclicWorktreeLineageChildIds: (
+      ...args: Parameters<typeof actual.getCyclicWorktreeLineageChildIds>
+    ) => {
+      counters.cycleDetections += 1
+      return actual.getCyclicWorktreeLineageChildIds(...args)
+    }
+  }
+})
+
+import { computeVisibleWorktreeIds } from './visible-worktrees'
+import type { computeVisibleWorktrees } from './visible-worktrees'
+import { getCyclicProjectedWorktreeLineageIds } from './worktree-lineage-projection'
+import { getLineageAncestorIndex, getSortedWorktreeRankIndex } from './visible-worktree-indexes'
+
+type IdentifiedWorktree = Worktree & { instanceId: string }
+
+function makeWorktree(id: string, repoId = 'repo1'): IdentifiedWorktree {
+  return {
+    id,
+    instanceId: `${id}-instance`,
+    repoId,
+    path: `/tmp/${id}`,
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+function makeLineage(child: IdentifiedWorktree, parent: IdentifiedWorktree): WorktreeLineage {
+  return {
+    worktreeId: child.id,
+    worktreeInstanceId: child.instanceId,
+    parentWorktreeId: parent.id,
+    parentWorktreeInstanceId: parent.instanceId,
+    origin: 'cli',
+    capture: { source: 'terminal-context', confidence: 'inferred' },
+    createdAt: 1
+  }
+}
+
+function makeTab(id: string, worktreeId: string, ptyId: string): TerminalTab {
+  return {
+    id,
+    ptyId,
+    worktreeId,
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+const repoMap = new Map<string, Repo>([
+  ['repo1', { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }]
+])
+
+function visibleOptions(
+  overrides: Partial<Parameters<typeof computeVisibleWorktrees>[2]> = {}
+): Parameters<typeof computeVisibleWorktrees>[2] {
+  return {
+    filterRepoIds: [],
+    showSleepingWorkspaces: true,
+    tabsByWorktree: null,
+    ptyIdsByTabId: null,
+    browserTabsByWorktree: null,
+    worktreeIdsWithLiveAgent: new Set<string>(),
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    hideCliCreatedWorkspaces: false,
+    hideDetachedHeadWorkspaces: false,
+    hideWorkspacesFromOtherDevices: false,
+    pairedDeviceIdsByEnvironment: new Map<string, string>(),
+    repoMap,
+    workspaceHostScope: 'all',
+    defaultHostId: LOCAL_EXECUTION_HOST_ID,
+    worktreeLineageById: {},
+    ...overrides
+  }
+}
+
+describe('visible worktree indexes', () => {
+  it('reuses the lineage projection instead of rebuilding it on every store write', () => {
+    const parent = makeWorktree('parent')
+    const child = makeWorktree('child')
+    const worktreesByRepo = { repo1: [parent, child] }
+    const sortedIds = [parent.id, child.id]
+    const worktreeLineageById = { [child.id]: makeLineage(child, parent) }
+
+    counters.cycleDetections = 0
+    // Each call stands for one store write that re-fires the sidebar memo
+    // (PTY spawn/exit, tab open/close, agent status transition) without
+    // changing `worktreesByRepo`.
+    for (let write = 0; write < 10; write += 1) {
+      computeVisibleWorktreeIds(worktreesByRepo, sortedIds, visibleOptions({ worktreeLineageById }))
+    }
+
+    expect(counters.cycleDetections).toBe(1)
+  })
+
+  it('returns identity-stable index maps for unchanged store inputs', () => {
+    const parent = makeWorktree('parent')
+    const child = makeWorktree('child')
+    const worktreesByRepo = { repo1: [parent, child] }
+    const sortedIds = [parent.id, child.id]
+    const lineageById = { [child.id]: makeLineage(child, parent) }
+
+    const firstAncestors = getLineageAncestorIndex(worktreesByRepo)
+    const secondAncestors = getLineageAncestorIndex(worktreesByRepo)
+    expect(secondAncestors).toBe(firstAncestors)
+    expect(getSortedWorktreeRankIndex(sortedIds)).toBe(getSortedWorktreeRankIndex(sortedIds))
+    expect([...getSortedWorktreeRankIndex(sortedIds)]).toEqual([
+      [parent.id, 0],
+      [child.id, 1]
+    ])
+
+    expect(getCyclicProjectedWorktreeLineageIds(lineageById, secondAncestors)).toBe(
+      getCyclicProjectedWorktreeLineageIds(lineageById, firstAncestors)
+    )
+  })
+
+  it('keeps archived parents out of the cached ancestor index', () => {
+    const parent = makeWorktree('parent')
+    parent.isArchived = true
+    const child = makeWorktree('child')
+    const worktreesByRepo = { repo1: [parent, child] }
+    const sortedIds = [child.id, parent.id]
+    const worktreeLineageById = { [child.id]: makeLineage(child, parent) }
+    const opts = visibleOptions({
+      showSleepingWorkspaces: false,
+      tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
+      ptyIdsByTabId: { 't-child': ['p-child'] },
+      worktreeLineageById
+    })
+
+    // Twice: the second call reads the warm cache, which is where an index
+    // built from the store's own (archive-inclusive) worktree map would leak a
+    // phantom ancestor row.
+    expect(computeVisibleWorktreeIds(worktreesByRepo, sortedIds, opts)).toEqual([child.id])
+    expect(computeVisibleWorktreeIds(worktreesByRepo, sortedIds, opts)).toEqual([child.id])
+    expect(getLineageAncestorIndex(worktreesByRepo).has(parent.id)).toBe(false)
+  })
+
+  it('keeps the last row for a two-host id collision, as the per-call map did', () => {
+    const local: Worktree = {
+      ...makeWorktree('shared'),
+      hostId: LOCAL_EXECUTION_HOST_ID,
+      path: '/tmp/local'
+    }
+    const remote: Worktree = { ...makeWorktree('shared'), hostId: 'ssh:box', path: '/tmp/remote' }
+    const worktreesByRepo = { repo1: [local, remote] }
+
+    expect(getLineageAncestorIndex(worktreesByRepo).get('shared')?.path).toBe('/tmp/remote')
+  })
+})

--- a/src/renderer/src/components/sidebar/visible-worktree-indexes.ts
+++ b/src/renderer/src/components/sidebar/visible-worktree-indexes.ts
@@ -1,0 +1,49 @@
+import { getIndexedAllWorktrees } from '@/store/worktree-repo-index'
+import type { Worktree } from '../../../../shared/worktree/types'
+
+type WorktreesByRepo = Record<string, Worktree[]>
+
+/**
+ * Non-archived rows by id — the map `computeVisibleWorktrees` hands to the
+ * lineage projection.
+ *
+ * Why cached: `getCyclicProjectedWorktreeLineageIds` keys its memo on this map's
+ * identity, so a per-call Map is a guaranteed miss that re-walks every workspace
+ * and re-runs cycle detection on each PTY, tab and agent-status write.
+ *
+ * Why not the store's `getIndexedWorktreeMap`: this index excludes archived rows
+ * (an archived parent resolving as a valid ancestor would inject a phantom row),
+ * and it keeps the last row for a two-host id collision rather than the first.
+ */
+const lineageAncestorIndexCache = new WeakMap<WorktreesByRepo, Map<string, Worktree>>()
+
+export function getLineageAncestorIndex(worktreesByRepo: WorktreesByRepo): Map<string, Worktree> {
+  const cached = lineageAncestorIndexCache.get(worktreesByRepo)
+  if (cached) {
+    return cached
+  }
+  const index = new Map<string, Worktree>()
+  for (const worktree of getIndexedAllWorktrees(worktreesByRepo)) {
+    if (!worktree.isArchived) {
+      index.set(worktree.id, worktree)
+    }
+  }
+  lineageAncestorIndexCache.set(worktreesByRepo, index)
+  return index
+}
+
+/**
+ * Rank of each id in the frozen sidebar sort order. Keyed on the array the sort
+ * hook already holds identity-stable across unrelated store writes.
+ */
+const sortedWorktreeRankIndexCache = new WeakMap<readonly string[], Map<string, number>>()
+
+export function getSortedWorktreeRankIndex(sortedIds: readonly string[]): Map<string, number> {
+  const cached = sortedWorktreeRankIndexCache.get(sortedIds)
+  if (cached) {
+    return cached
+  }
+  const index = new Map(sortedIds.map((id, rank) => [id, rank]))
+  sortedWorktreeRankIndexCache.set(sortedIds, index)
+  return index
+}

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -47,6 +47,7 @@ import {
   isWorkspaceFromOtherDevice
 } from './workspace-creator-visibility'
 import { isDefaultBranchWorkspace } from './default-branch-workspace'
+import { getLineageAncestorIndex, getSortedWorktreeRankIndex } from './visible-worktree-indexes'
 import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
 
 /**
@@ -96,7 +97,7 @@ export function computeVisibleWorktrees(
 
   // Why: sidebar lineage is structural. Archived workspaces stay hidden, but
   // every other valid ancestor can bypass filters so children never orphan.
-  const lineageAncestorById = new Map(all.map((w) => [w.id, w]))
+  const lineageAncestorById = getLineageAncestorIndex(worktreesByRepo)
 
   if (opts.hideWorkspacesFromOtherDevices) {
     all = all.filter(
@@ -170,7 +171,7 @@ export function computeVisibleWorktrees(
 
   // Apply cached sort order. Items not yet in the cache (e.g. brand-new
   // worktrees before the next sortEpoch bump) are appended at the end.
-  const orderIndex = new Map(sortedIds.map((id, i) => [id, i]))
+  const orderIndex = getSortedWorktreeRankIndex(sortedIds)
   all.sort((a, b) => {
     const ai = orderIndex.get(a.id) ?? Infinity
     const bi = orderIndex.get(b.id) ?? Infinity

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-sort-order.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-sort-order.ts
@@ -6,7 +6,12 @@ import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { persistWorktreeSortOrderByHost } from '@/lib/worktree-sort-order-persistence'
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { Worktree } from '../../../../../../shared/worktree/types'
-import { buildWorktreeComparator, compareWorktreeSortLabel, type SortBy } from '../../smart-sort'
+import {
+  buildWorktreeComparator,
+  buildWorktreeSortLabels,
+  compareWorktreeSortLabel,
+  type SortBy
+} from '../../smart-sort'
 import {
   buildAttentionByWorktree,
   hasFreshAttributedAgentStatus,
@@ -103,6 +108,8 @@ export function useSidebarWorktreeSortOrder(args: {
       (worktree) => !worktree.isArchived
     )
     const now = Date.now()
+    // Why precompute: the label tiebreaker runs on every comparison in every mode.
+    const labels = buildWorktreeSortLabels(nonArchivedWorktrees)
     let detectedLiveSmartSignal = false
 
     // Why cold-start detection: agent-status hydrates async, so the warm comparator would collapse all to Class 4; keep the persisted order until a live signal appears.
@@ -118,7 +125,7 @@ export function useSidebarWorktreeSortOrder(args: {
         detectedLiveSmartSignal = true
       } else {
         nonArchivedWorktrees.sort(
-          (a, b) => b.sortOrder - a.sortOrder || compareWorktreeSortLabel(a, b)
+          (a, b) => b.sortOrder - a.sortOrder || compareWorktreeSortLabel(a, b, labels)
         )
         return {
           sortedIds: nonArchivedWorktrees.map((w) => w.id),
@@ -142,7 +149,9 @@ export function useSidebarWorktreeSortOrder(args: {
             state.terminalLayoutsByTabId
           )
         : new Map<string, WorktreeAttention>()
-    nonArchivedWorktrees.sort(buildWorktreeComparator(sortBy, repoMap, now, attentionByWorktree))
+    nonArchivedWorktrees.sort(
+      buildWorktreeComparator(sortBy, repoMap, now, attentionByWorktree, labels)
+    )
     return {
       sortedIds: nonArchivedWorktrees.map((w) => w.id),
       attentionByWorktree: sortBy === 'smart' ? attentionByWorktree : null,

--- a/src/renderer/src/components/sidebar/worktree-manual-order-catalog.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order-catalog.ts
@@ -1,7 +1,7 @@
 import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
 import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
 import type { Worktree } from '../../../../shared/worktree/types'
-import { compareWorktreeSortLabel } from './smart-sort'
+import { buildWorktreeSortLabels, compareWorktreeSortLabel } from './smart-sort'
 
 export type WorktreeManualOrderCatalog = {
   orderedIds: readonly string[]
@@ -15,13 +15,13 @@ export function buildWorktreeManualOrderCatalog(args: {
   const rows = [
     ...args.worktrees,
     ...args.folderWorkspaces.map((workspace) => folderWorkspaceToWorktree(workspace))
-  ]
-    .filter((row) => !row.isArchived)
-    .sort(
-      (left, right) =>
-        (right.manualOrder ?? right.sortOrder) - (left.manualOrder ?? left.sortOrder) ||
-        compareWorktreeSortLabel(left, right)
-    )
+  ].filter((row) => !row.isArchived)
+  const labels = buildWorktreeSortLabels(rows)
+  rows.sort(
+    (left, right) =>
+      (right.manualOrder ?? right.sortOrder) - (left.manualOrder ?? left.sortOrder) ||
+      compareWorktreeSortLabel(left, right, labels)
+  )
   const rowsById = new Map<string, Worktree[]>()
   for (const row of rows) {
     const matches = rowsById.get(row.id)

--- a/src/renderer/src/components/sidebar/worktree-sort-label-ordering.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sort-label-ordering.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import {
+  buildWorktreeComparator,
+  buildWorktreeSortLabels,
+  compareWorktreeSortLabel,
+  getWorktreeSortLabel,
+  type SortBy
+} from './smart-sort'
+
+/** The comparator as it read before labels were precomputed. */
+function legacyCompareWorktreeSortLabel(a: Worktree, b: Worktree): number {
+  return getWorktreeSortLabel(a).localeCompare(getWorktreeSortLabel(b))
+}
+
+const TRICKY_LABELS: readonly (string | null)[] = [
+  'alpha',
+  'Alpha',
+  'ALPHA',
+  'álpha',
+  'Álpha',
+  'ångström',
+  'Ångström',
+  'béta',
+  'Beta',
+  'straße',
+  'strasse',
+  '🎉 party',
+  '🍎 apple',
+  'apple',
+  '日本語',
+  'にほんご',
+  '한국어',
+  'Ω omega',
+  'ω omega',
+  'task-2',
+  'task-10',
+  'task-02',
+  'TASK-2',
+  'task_2',
+  'task 2',
+  '  leading space',
+  'trailing space  ',
+  '',
+  '   ',
+  null,
+  '-dash',
+  '_underscore',
+  '.dotfile',
+  '#hash',
+  'ﬁle',
+  'file',
+  'ＡＢＣ',
+  'ABC'
+]
+
+function makeWorktree(index: number, displayName: string | null): Worktree {
+  // Trailing separators and Windows separators exercise `basename()`'s
+  // normalisation on the rows whose displayName is blank.
+  const suffixes = ['', '/', '//', '\\']
+  return {
+    id: `w${index}`,
+    repoId: index % 2 === 0 ? 'repo1' : 'repo2',
+    path: `/tmp/${TRICKY_LABELS[index % TRICKY_LABELS.length] ?? 'unnamed'}-${index}${suffixes[index % suffixes.length]}`,
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    // Cast: persisted/remote rows can arrive with a null displayName, which is
+    // exactly the fallback path `getWorktreeSortLabel` guards.
+    displayName: displayName as string,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    // Heavy tie density so the label tiebreaker actually decides the order.
+    sortOrder: index % 3,
+    manualOrder: index % 3,
+    lastActivityAt: 1_700_000_000_000 - (index % 3)
+  }
+}
+
+const corpus: Worktree[] = TRICKY_LABELS.flatMap((label, index) => [
+  makeWorktree(index * 2, label),
+  // Second row per label with a blank displayName, so `basename(path)` decides.
+  makeWorktree(index * 2 + 1, index % 2 === 0 ? '' : null)
+])
+
+const repoMap = new Map<string, Repo>([
+  [
+    'repo1',
+    { id: 'repo1', path: '/repo1', displayName: 'Ångström', badgeColor: '#000', addedAt: 0 }
+  ],
+  [
+    'repo2',
+    { id: 'repo2', path: '/repo2', displayName: 'angstrom', badgeColor: '#111', addedAt: 0 }
+  ]
+])
+
+const SORT_MODES: readonly SortBy[] = ['name', 'smart', 'recent', 'repo', 'manual']
+const NOW = 1_700_000_000_000
+
+describe('worktree sort label ordering', () => {
+  it('matches the pre-precompute comparator on every pair', () => {
+    const labels = buildWorktreeSortLabels(corpus)
+    for (const a of corpus) {
+      for (const b of corpus) {
+        expect(Math.sign(compareWorktreeSortLabel(a, b, labels))).toBe(
+          Math.sign(legacyCompareWorktreeSortLabel(a, b))
+        )
+      }
+    }
+  })
+
+  it('produces byte-for-byte identical sort output in every mode', () => {
+    for (const sortBy of SORT_MODES) {
+      const attention = new Map()
+      const withLabels = [...corpus].sort(
+        buildWorktreeComparator(sortBy, repoMap, NOW, attention, buildWorktreeSortLabels(corpus))
+      )
+      const withoutLabels = [...corpus].sort(
+        buildWorktreeComparator(sortBy, repoMap, NOW, attention)
+      )
+      expect(withLabels.map((w) => w.id)).toEqual(withoutLabels.map((w) => w.id))
+    }
+  })
+
+  it('falls back to deriving labels for rows missing from the precomputed map', () => {
+    const [first, second] = corpus
+    const partial = buildWorktreeSortLabels([first])
+    expect(Math.sign(compareWorktreeSortLabel(first, second, partial))).toBe(
+      Math.sign(legacyCompareWorktreeSortLabel(first, second))
+    )
+  })
+
+  it('keys labels by row so a two-host id collision keeps each row its own label', () => {
+    const local: Worktree = { ...makeWorktree(0, null), id: 'shared', path: '/tmp/aaa' }
+    const remote: Worktree = { ...makeWorktree(1, null), id: 'shared', path: '/tmp/zzz' }
+    const labels = buildWorktreeSortLabels([local, remote])
+
+    expect(labels.get(local)).toBe('aaa')
+    expect(labels.get(remote)).toBe('zzz')
+    expect(Math.sign(compareWorktreeSortLabel(local, remote, labels))).toBe(
+      Math.sign(legacyCompareWorktreeSortLabel(local, remote))
+    )
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​331 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​331 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 |

<!-- /orca-pr-loc -->

## ELI5

The sidebar keeps a little "who is whose parent" lookup so nested workspaces can draw under their parent. It was throwing that lookup away and rebuilding it from scratch on *every* store write — every terminal spawn, every tab open, every agent status blip — even though the answer had not changed. Separately, the sort that orders your workspace cards re-derived each card's display name twice for every single comparison it made. Both are now computed once and reused. Nothing about what you see changes: same cards, same order, same status dots, same update speed — the sidebar just does a lot less bookkeeping to get there.

## What was happening

**Defect 1 — a throwaway `Map` guaranteed a 100% cache miss on the lineage projection.**

`src/renderer/src/components/sidebar/visible-worktrees.ts:99` built

```ts
const lineageAncestorById = new Map(all.map((w) => [w.id, w]))
```

fresh on every call and passed it as the second key to `getCyclicProjectedWorktreeLineageIds`, whose memo is `WeakMap<lineageById, WeakMap<worktreeMap, projection>>` (`worktree-lineage-projection.ts:38-57`). A brand-new `Map` can never hit that inner `WeakMap`, so every call re-walked all workspaces rebuilding `validLineageByChildId` and re-ran cycle detection — while the store already held an identity-stable answer every other sidebar reader shares (`getIndexedAllWorktrees`, `src/renderer/src/store/worktree-repo-index.ts:67`).

A second throwaway 400-entry `Map` for `orderIndex` was built at `visible-worktrees.ts:173`.

`useVisibleSidebarWorktrees`'s memo deps include `tabsByWorktree`, `ptyIdsByTabId`, `browserTabsByWorktree` and `agentStatusEpoch` (`worktree-list/listing/use-visible-worktrees.ts:107-131`), so this fired on every PTY spawn/exit, tab open/close and agent state transition.

Both maps now come from module-level `WeakMap`s in the new `visible-worktree-indexes.ts` — the ancestor index keyed on `worktreesByRepo`, the rank index keyed on the already identity-stable `sortedIds`.

**Defect 2 — sort labels recomputed inside the comparator.**

`smart-sort.ts:65-69`: `compareWorktreeSortLabel` is the final tiebreaker in all five sort modes (`:90, :102, :119, :125, :133, :176`). Per comparison it called `getWorktreeSortLabel()` twice, each doing a `typeof` + `.trim()` and, when `displayName` is blank, a `basename()` that allocates via `path.replace(/[\\/]+$/, '')`. At 400 workspaces a `name` sort is ~3,400 comparisons, so ~6,800 label derivations.

Labels are now precomputed once per sort into a `Map`, mirroring what `buildAttentionByWorktree` already does for attention, and threaded through `buildWorktreeComparator` as an optional last parameter. Wired up at the two hot producers: `useSidebarWorktreeSortOrder` (both the cold-start and warm branches) and `sortWorktreesSmart`, plus `buildWorktreeManualOrderCatalog`.

The map is keyed on the **row object**, not on `worktree.id`. A two-host id collision (STA-4343) puts two rows with different paths under one id, and an id-keyed map would hand one of them the other's label — a real ordering change. Row-keying makes that impossible and is covered by a test.

## Measurement

Bench at the repo's own reference scale — 400 workspaces, matching `build-dashboard-bucket-counts.allocation.test.ts:51` — with one lineage edge per 4 workspaces and a label corpus mixing ASCII, accents, emoji, digits and blank display names. Before/after measured by stashing only the changed source and re-running the identical bench in the same harness. Reported as min-of-25 batches (the box was under heavy parallel load; min is the robust estimator, and the medians from an idle run agree).

**Lineage projection**

| | full rebuilds per 100 store writes | `computeVisibleWorktrees` |
|---|---|---|
| before | **100** (100% miss) | 0.114 ms/call (idle-run median 0.131) |
| after | **0** in steady state (1 on the first write after `worktreesByRepo` changes) | 0.069 ms/call (idle-run median 0.077) |

About **40% less time per call**, and cycle detection plus `validLineageByChildId` reconstruction is gone from every PTY/tab/agent-status write.

**400-workspace sort** (`name` mode, where the label tiebreaker decides every comparison)

| | ms per sort |
|---|---|
| before | **0.258** (idle-run median 0.273) |
| after | **0.177** (idle-run median 0.189) |

About **31% faster**.

### Dropped: the `Intl.Collator` swap

The audit also proposed replacing bare `localeCompare` with one module-level `const collator = new Intl.Collator()`, on the theory that V8 resolves a collator per call. I implemented it, measured it, and **reverted it — it is slower, not faster.**

Ordering equivalence held exactly as claimed (2,916 pairs over a tricky corpus, 0 sign mismatches, identical sort output; ECMA-402 defines `localeCompare(that)` as `Intl.Collator(undefined, undefined).compare`). But V8 has a dedicated fast path for `String.prototype.localeCompare` with no arguments — it caches the default collator *and* short-circuits one-byte strings — which a user-land `Intl.Collator` instance does not get:

400-label sort, same V8 as the Electron runtime:

| corpus | `localeCompare` | shared `Intl.Collator().compare` |
|---|---|---|
| ASCII | **0.038 ms** | 0.138 ms (3.6x slower) |
| accents/emoji/CJK | **0.280 ms** | 0.438 ms (1.6x slower) |

So `localeCompare` stays everywhere, and the three related call sites the audit flagged (`worktree-list/grouping/section-order.ts:195,207`, `project-group-sections.ts:82`, `folder-workspace-lanes.ts:76`) are left untouched. The remaining sort win above is entirely from precomputing labels.

Also skipped: the non-smart branch of `getVisibleWorktreeIds` (`visible-worktrees.ts:328`). It is a cold fallback that only runs on a Cmd+1-9 press while `WorktreeList` is unmounted, and `visible-worktrees.ts` has no room under the 300-line `max-lines` budget. No disable was added.

## Negative user-facing trade-offs

**None.**

- **Ordering** — the label map is a pure memo of `getWorktreeSortLabel`, and `compareWorktreeSortLabel` falls back to deriving the label for any row missing from it. No collator or locale change: `localeCompare` with no arguments is still what runs. `worktree-sort-label-ordering.test.ts` asserts sign-equality against the pre-change comparator on every pair of a 76-row tricky corpus (emoji, accents, ß/ss, ligatures, fullwidth, CJK, Hangul, digits vs zero-padded digits, mixed case, blank/whitespace/null display names, trailing `/`, `//` and `\`), plus identical full sort output in all five modes.
- **Membership** — the cached ancestor index is built from exactly the same source the per-call `Map` was: `getIndexedAllWorktrees(worktreesByRepo)` filtered to non-archived, in the same order, with the same last-wins resolution for a two-host id collision. Not the store's `getIndexedWorktreeMap`, which is archive-inclusive and first-wins.
- **Archived-parent handling** — preserved deliberately and tested twice: `computeVisibleWorktreeIds` still returns only the child when the lineage parent is archived, *including on the second call when the cache is warm*, and `getLineageAncestorIndex(...).has(archivedParentId)` is asserted `false`. This was the one way this change could have injected a phantom row, and it does not.
- **Update latency** — the caches are `WeakMap`s keyed on the store collections themselves. `worktreesByRepo` is replaced (never mutated) on every worktree write, so any real change misses the cache and recomputes on the same tick as before. `sortedIds` is always freshly `.map()`-produced. Nothing is time- or epoch-gated.
- **Memory** — `WeakMap` on both, so a superseded store snapshot is not pinned.

## Risk & verification

Risk is low and concentrated in cache-key soundness, which is the part the tests target directly.

- `pnpm tc` — clean.
- `pnpm run check:code-quality:changed` — clean (0 findings across 7 files, including type-aware and React Doctor). No `max-lines` disable anywhere.
- Existing suites: all 293 files / 2,473 tests under `src/renderer/src/components/sidebar` plus `worktree-jump-*` and `locale-text-collators` pass, as do `src/renderer/src/store` and `src/renderer/src/components/dashboard` (397 files / 3,680 tests). Six `WorktreeCard` hover/port render tests time out under heavy parallel machine load; they were confirmed to fail identically on `origin/main` with the change reverted, so they are pre-existing flakes, not a regression.
- New `visible-worktree-indexes.test.ts`:
  - **cache-hit / referential stability** — 10 simulated store writes trigger exactly **1** cycle detection. Verified to fail without the fix (`expected 10 to be 1`).
  - identity stability of both index maps and of the resulting `getCyclicProjectedWorktreeLineageIds` `Set`.
  - **archived parent** produces no phantom row, on a warm cache.
  - two-host id collision keeps the same row the per-call `Map` kept.
- New `worktree-sort-label-ordering.test.ts`: full pairwise and full sort-output equivalence against the pre-change comparator, the missing-row fallback path, and per-row labels under an id collision.
