### PR TITLE
fix(memory): close two per-id map reaper gaps and ratchet the pty-exit reaper

### DIFF
--- a/src/main/runtime/orca-runtime-on-pty-exit.ts
+++ b/src/main/runtime/orca-runtime-on-pty-exit.ts
@@ -140,6 +140,11 @@ export class OrcaRuntimeWithOnPtyExit extends OrcaRuntimeWithOnClientDisconnecte
     this.providerVisibleStateByPtyId.delete(ptyId)
     this.providerVisibleRetryAtByPtyId.delete(ptyId)
     this.agentPromptExplicitStatusFloorByPtyId.delete(ptyId)
+    // Safe against respawn: `getPtyLifecycleGeneration` lazily mints from the
+    // monotonic `nextPtyLifecycleGeneration`, so a re-read after this delete
+    // returns a strictly newer number — never a reused one. Every comparison a
+    // stale frame makes therefore still fails, exactly as the advance above intends.
+    this.ptyLifecycleGenerationById.delete(ptyId)
     this.agentStatusOscProcessorsByPtyId.delete(ptyId)
     this.terminalSpawnCommandsByPtyId.delete(ptyId)
     this.disposePtyTitleTracker(ptyId)

--- a/src/main/runtime/pty-exit-per-pty-map-reaper-ratchet.test.ts
+++ b/src/main/runtime/pty-exit-per-pty-map-reaper-ratchet.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Ratchet: `onPtyExit` is the reaper for per-PTY runtime state, and every
+ * per-PTY-keyed collection on the runtime must be accounted for there.
+ *
+ * `ptyLifecycleGenerationById` was added next to ~25 siblings the reaper already
+ * deleted — including `agentPromptExplicitStatusFloorByPtyId`, set two lines below
+ * it in `advancePtyLifecycleGeneration` — and was simply never added to the list.
+ * Nothing failed, so it accumulated one number per PTY for the life of the process.
+ * A hand-maintained delete list has no way to notice the next omission; this does.
+ *
+ * The field list is read off a real instance rather than parsed out of the source,
+ * so a map declared in any of the ~90 mixin files is covered the moment it exists.
+ * Every field must land in exactly one bucket, and the two "cleaned elsewhere"
+ * buckets are verified against real source rather than trusted as an allowlist.
+ */
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+
+const repoRoot = resolve(__dirname, '../../..')
+const REAPER_MODULE = 'src/main/runtime/orca-runtime-on-pty-exit.ts'
+
+/** `fooByPtyId`, plus the older `ById` spellings that are still keyed by pty id. */
+const PTY_KEYED_FIELD = /(?:ByPtyId|Pty[A-Za-z]*ById)$/i
+
+/** Cleared by a helper the reaper calls; the helper is verified below, not trusted. */
+const CLEARED_BY_REAPER_HELPER: Record<string, { helper: string; module: string }> = {
+  waitBlockedCheckStateByPtyId: {
+    helper: 'clearWaitBlockedCheckState',
+    module: 'src/main/runtime/orca-runtime-schedule-wait-blocked-check.ts'
+  },
+  ptyTitleTrackersByPtyId: {
+    helper: 'disposePtyTitleTracker',
+    module: 'src/main/runtime/orca-runtime-apply-tracked-pty-title.ts'
+  },
+  agentPromptLifecycleByPtyId: {
+    helper: 'advancePtyLifecycleGeneration',
+    module: 'src/main/runtime/orca-runtime-record-agent-prompt-lifecycle-state.ts'
+  },
+  agentPromptPermissionSequenceByPtyId: {
+    helper: 'advancePtyLifecycleGeneration',
+    module: 'src/main/runtime/orca-runtime-record-agent-prompt-lifecycle-state.ts'
+  }
+}
+
+/**
+ * One entry per in-flight operation, removed by that operation's own settle path.
+ * Bounded by concurrency, not by how many PTYs the session has ever had, so the
+ * reaper deleting them would race the settle rather than reclaim anything.
+ */
+const SELF_CLEARING_IN_FLIGHT = new Set([
+  'providerVisibleStateReadsByPtyId',
+  'agentPromptSubmissionTailByPtyId',
+  'interactiveWaitProbesByPtyId',
+  'orchestrationPointerAdmissionByPtyId',
+  'messageDeliveryFlightsByPtyId',
+  'parkedMessageRedeliveriesByPtyId'
+])
+
+/** Outlives the exit on purpose; each is reaped by its own later teardown. */
+const INTENTIONALLY_RETAINED: Record<string, string> = {
+  ptysById:
+    'the record carries lastExitCode/lastExitCause for `ps` and reconnect; pruneDisconnectedPtyRecords owns it',
+  leavesByPtyId:
+    'rebuilt from the renderer graph by rebuildLeafPtyIndex; the leaf shows the exit state until tab teardown',
+  handleByPtyId:
+    'the terminal handle stays addressable after exit; invalidateAllHandlesForPty retires it',
+  ptyLivenessVerdictByPtyId:
+    'an unverifiable SSH surface must keep its verdict across the exit; cleared on respawn and on a certified death'
+}
+
+function ptyKeyedFieldNames(): string[] {
+  const runtime = new OrcaRuntimeService() as unknown as Record<string, unknown>
+  return Object.keys(runtime).filter((key) => {
+    const value = runtime[key]
+    return PTY_KEYED_FIELD.test(key) && (value instanceof Map || value instanceof Set)
+  })
+}
+
+/** Comments are stripped so a commented-out delete cannot satisfy the ratchet. */
+function readModule(relativePath: string): string {
+  return readFileSync(join(repoRoot, relativePath), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1')
+}
+
+describe('onPtyExit per-PTY map reaper coverage', () => {
+  const fields = ptyKeyedFieldNames()
+  const reaperSource = readModule(REAPER_MODULE)
+
+  it('does not accept a commented-out delete as coverage', () => {
+    // The first draft of this ratchet passed against a tree where the fix was
+    // commented out, because the comment still contained the call text.
+    expect(readModule(REAPER_MODULE)).not.toContain('Safe against respawn')
+    expect(reaperSource).toContain('this.ptyLifecycleGenerationById.delete(ptyId)')
+  })
+
+  it('finds the per-PTY fields it claims to scan', () => {
+    // Guards the detector itself: a rename that breaks the regex would otherwise
+    // make this whole file pass by scanning nothing.
+    expect(fields.length).toBeGreaterThan(30)
+    expect(fields).toContain('ptyLifecycleGenerationById')
+    expect(fields).toContain('agentPromptExplicitStatusFloorByPtyId')
+  })
+
+  it('accounts for every per-PTY-keyed collection on the runtime', () => {
+    const unaccounted = fields.filter(
+      (field) =>
+        !reaperSource.includes(`this.${field}.delete(ptyId)`) &&
+        !(field in CLEARED_BY_REAPER_HELPER) &&
+        !SELF_CLEARING_IN_FLIGHT.has(field) &&
+        !(field in INTENTIONALLY_RETAINED)
+    )
+    expect(
+      unaccounted,
+      `${REAPER_MODULE} must delete these per-PTY entries, or they must be classified in this test`
+    ).toEqual([])
+  })
+
+  it('keeps every classification about a field that still exists', () => {
+    const known = new Set(fields)
+    const stale = [
+      ...Object.keys(CLEARED_BY_REAPER_HELPER),
+      ...SELF_CLEARING_IN_FLIGHT,
+      ...Object.keys(INTENTIONALLY_RETAINED)
+    ].filter((field) => !known.has(field))
+    expect(stale, 'classified fields that no longer exist').toEqual([])
+  })
+
+  it('verifies each helper is called by the reaper and deletes the field it is credited with', () => {
+    for (const [field, { helper, module }] of Object.entries(CLEARED_BY_REAPER_HELPER)) {
+      expect(reaperSource, `${REAPER_MODULE} must call ${helper}`).toContain(
+        `this.${helper}(ptyId)`
+      )
+      expect(readModule(module), `${helper} must delete ${field}`).toContain(
+        `this.${field}.delete(ptyId)`
+      )
+    }
+  })
+})
+
+describe('per-PTY lifecycle generation retention (leak regression)', () => {
+  type Internals = { ptyLifecycleGenerationById: Map<string, number> }
+
+  it('retains no lifecycle generation after a spawn/exit cycle', () => {
+    const runtime = new OrcaRuntimeService()
+    const internals = runtime as unknown as Internals
+    for (let index = 0; index < 50; index += 1) {
+      const ptyId = `pty-${index}`
+      runtime.onPtySpawned(ptyId)
+      runtime.onPtyExit(ptyId, 0)
+    }
+    expect(internals.ptyLifecycleGenerationById.size).toBe(0)
+  })
+
+  it('never hands a respawn a generation a pre-exit capture could still match', () => {
+    const runtime = new OrcaRuntimeService()
+    const internals = runtime as unknown as Internals & {
+      getPtyLifecycleGeneration: (ptyId: string) => number
+    }
+    runtime.onPtySpawned('pty-1')
+    const beforeExit = internals.getPtyLifecycleGeneration('pty-1')
+    runtime.onPtyExit('pty-1', 0)
+
+    runtime.onPtySpawned('pty-1')
+    const afterRespawn = internals.getPtyLifecycleGeneration('pty-1')
+
+    expect(afterRespawn).toBeGreaterThan(beforeExit)
+    // Stable once re-minted, so a post-respawn capture keeps matching itself.
+    expect(internals.getPtyLifecycleGeneration('pty-1')).toBe(afterRespawn)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer-warn-eviction.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer-warn-eviction.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Memory-leak regression: `warnedLostHandlerPtyIds` outlived the buffered data it
+ * describes when the LRU cap evicted that data.
+ *
+ * The set is cleaned in `drainPreHandlerPtyData` and `clearPreHandlerPtyState`,
+ * which both mean "a pane took this PTY's bytes". `evictOldestPtyIfAtCap` drops
+ * the oldest data entry without either, so a PTY that warned and was then evicted
+ * left its id behind for the life of the renderer — and, because the warn is
+ * once-per-id, silently suppressed the warning for a fresh accumulation on that
+ * same id, which is the exact signal the breadcrumb exists to emit.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { bufferPreHandlerPtyData, clearPreHandlerPtyState } from './pty-pre-handler-buffer'
+
+const PRE_HANDLER_PTY_DATA_MAX_PTYS = 64
+const WARN_BYTES = 64 * 1024
+const EVICTED_PTY_ID = 'pty-warn-evicted'
+/** One more than the cap, so the first id admitted is evicted. */
+const FILLER_PTY_IDS = Array.from(
+  { length: PRE_HANDLER_PTY_DATA_MAX_PTYS },
+  (_, index) => `pty-warn-filler-${index}`
+)
+
+function bufferPastWarnThreshold(ptyId: string): void {
+  bufferPreHandlerPtyData(ptyId, 'x'.repeat(WARN_BYTES + 1))
+}
+
+function lostHandlerWarnings(warn: ReturnType<typeof vi.spyOn>): string[] {
+  return warn.mock.calls
+    .map((call) => String(call[0]))
+    .filter((message) => message.includes('with no registered data handler'))
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  clearPreHandlerPtyState(EVICTED_PTY_ID)
+  for (const ptyId of FILLER_PTY_IDS) {
+    clearPreHandlerPtyState(ptyId)
+  }
+})
+
+describe('pre-handler lost-handler warning after LRU eviction', () => {
+  it('warns again once the evicted PTY re-accumulates past the threshold', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    bufferPastWarnThreshold(EVICTED_PTY_ID)
+    expect(lostHandlerWarnings(warn)).toHaveLength(1)
+
+    // Push the warned id out of the data map through the LRU cap.
+    for (const ptyId of FILLER_PTY_IDS) {
+      bufferPreHandlerPtyData(ptyId, 'y')
+    }
+
+    // Its buffered bytes are gone, so this is a brand-new accumulation episode.
+    bufferPastWarnThreshold(EVICTED_PTY_ID)
+
+    const messages = lostHandlerWarnings(warn)
+    expect(messages).toHaveLength(2)
+    expect(messages[1]).toContain(EVICTED_PTY_ID)
+  })
+
+  it('still warns only once while the buffered data is retained', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    bufferPastWarnThreshold(EVICTED_PTY_ID)
+    bufferPastWarnThreshold(EVICTED_PTY_ID)
+    bufferPastWarnThreshold(EVICTED_PTY_ID)
+
+    expect(lostHandlerWarnings(warn)).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
@@ -63,15 +63,18 @@ export function currentPreHandlerPtySequence(): number {
   return preHandlerPtySequence
 }
 
-/** Map preserves insertion order, so the first key is the least recently admitted id. */
-function evictOldestPtyIfAtCap<V>(map: Map<string, V>, ptyId: string, cap: number): void {
+/** Map preserves insertion order, so the first key is the least recently admitted id.
+ *  Returns the evicted id so the caller can drop state keyed alongside the entry. */
+function evictOldestPtyIfAtCap<V>(map: Map<string, V>, ptyId: string, cap: number): string | null {
   if (map.has(ptyId) || map.size < cap) {
-    return
+    return null
   }
   const oldestPtyId = map.keys().next().value
   if (typeof oldestPtyId === 'string') {
     map.delete(oldestPtyId)
+    return oldestPtyId
   }
+  return null
 }
 
 /** Drop a buffered exit proven to describe a different lifetime of `ptyId` than the one now
@@ -129,7 +132,15 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
   if (!chunk.data) {
     return
   }
-  evictOldestPtyIfAtCap(preHandlerPtyData, ptyId, PRE_HANDLER_PTY_DATA_MAX_PTYS)
+  const evictedPtyId = evictOldestPtyIfAtCap(
+    preHandlerPtyData,
+    ptyId,
+    PRE_HANDLER_PTY_DATA_MAX_PTYS
+  )
+  if (evictedPtyId !== null) {
+    // The warn breadcrumb describes buffered bytes that no longer exist.
+    warnedLostHandlerPtyIds.delete(evictedPtyId)
+  }
   const bufferedMeta =
     meta && chunk.data.length !== data.length && typeof meta.rawLength === 'number'
       ? { ...meta, rawLength: chunk.bytes }

--- a/src/renderer/src/store/slices/ambiguous-owner-warning-worktree-removal-leak.test.ts
+++ b/src/renderer/src/store/slices/ambiguous-owner-warning-worktree-removal-leak.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Memory-leak + correctness regression: `ambiguousOwnerWarnedWorktreeIds` is a
+ * module-scope Set that had no `delete` anywhere.
+ *
+ * `warnAmbiguousOwnerOnce` adds a worktree id so the "identity is ambiguous
+ * across hosts" warning is emitted once per workspace rather than on every PTY
+ * activity bump. Both removal paths prune ~20 other per-worktree collections and
+ * skipped this one, so ids accumulated for the life of the renderer — and, because
+ * membership is what suppresses the warning, a workspace whose id came back (paths
+ * are recreated, so worktree ids are recycled) could never warn again even when it
+ * was genuinely ambiguous a second time.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return { ...actual, detectAgentStatusFromTitle: vi.fn().mockReturnValue(null) }
+})
+
+const mockApi = {
+  worktrees: {
+    list: vi.fn().mockResolvedValue([]),
+    remove: vi.fn().mockResolvedValue(undefined),
+    forceDeletePreservedBranch: vi.fn().mockResolvedValue({ deleted: true }),
+    updateMeta: vi.fn().mockResolvedValue({})
+  },
+  pty: { kill: vi.fn().mockResolvedValue(undefined) },
+  runtimeEnvironments: { call: vi.fn().mockResolvedValue({ ok: true, result: {} }) }
+}
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: mockApi }
+
+import {
+  ambiguousOwnerWarnedWorktreeIds,
+  warnAmbiguousOwnerOnce
+} from './worktrees/listing/worktree-owner-settings'
+import { createTestStore, seedStore, makeWorktree } from './store-test-helpers'
+
+const WT1 = 'repo1::/path/wt1'
+const WT2 = 'repo1::/path/wt2'
+
+function seedWorktrees(store: ReturnType<typeof createTestStore>): void {
+  seedStore(store, {
+    worktreesByRepo: {
+      repo1: [
+        makeWorktree({ id: WT1, repoId: 'repo1', path: '/path/wt1' }),
+        makeWorktree({ id: WT2, repoId: 'repo1', path: '/path/wt2' })
+      ]
+    }
+  })
+}
+
+describe('ambiguous-owner warning set is pruned on worktree removal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ambiguousOwnerWarnedWorktreeIds.clear()
+    mockApi.worktrees.remove.mockResolvedValue(undefined)
+  })
+
+  it('drops the warned id on single removeWorktree, for the removed worktree only', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const store = createTestStore()
+    seedWorktrees(store)
+    warnAmbiguousOwnerOnce(WT1, 'persist worktree activity timestamp')
+    warnAmbiguousOwnerOnce(WT2, 'persist worktree activity timestamp')
+    expect(ambiguousOwnerWarnedWorktreeIds.size).toBe(2)
+
+    const result = await store.getState().removeWorktree({ id: WT1, executionHostId: null })
+    expect(result).toEqual({ ok: true })
+
+    expect(ambiguousOwnerWarnedWorktreeIds.has(WT1)).toBe(false)
+    expect(ambiguousOwnerWarnedWorktreeIds.has(WT2)).toBe(true)
+    expect(ambiguousOwnerWarnedWorktreeIds.size).toBe(1)
+    warn.mockRestore()
+  })
+
+  it('re-arms the once-per-workspace warning after remove and re-add', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const store = createTestStore()
+    seedWorktrees(store)
+
+    warnAmbiguousOwnerOnce(WT1, 'persist worktree activity timestamp')
+    warnAmbiguousOwnerOnce(WT1, 'persist worktree activity timestamp')
+    expect(warn).toHaveBeenCalledTimes(1)
+
+    await store.getState().removeWorktree({ id: WT1, executionHostId: null })
+    seedWorktrees(store)
+
+    warnAmbiguousOwnerOnce(WT1, 'persist worktree activity timestamp')
+
+    expect(warn).toHaveBeenCalledTimes(2)
+    warn.mockRestore()
+  })
+
+  it('drops warned ids on the bulk purge path too', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const store = createTestStore()
+    seedWorktrees(store)
+    warnAmbiguousOwnerOnce(WT1, 'persist worktree activity timestamp')
+    warnAmbiguousOwnerOnce(WT2, 'persist worktree activity timestamp')
+
+    store.getState().purgeWorktreeTerminalState([WT1])
+
+    expect(ambiguousOwnerWarnedWorktreeIds.has(WT1)).toBe(false)
+    expect(ambiguousOwnerWarnedWorktreeIds.has(WT2)).toBe(true)
+    warn.mockRestore()
+  })
+
+  it('does not accumulate across many remove cycles', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const store = createTestStore()
+    for (let index = 0; index < 100; index += 1) {
+      const worktreeId = `repo1::/path/cycle-${index}`
+      seedStore(store, {
+        worktreesByRepo: {
+          repo1: [makeWorktree({ id: worktreeId, repoId: 'repo1', path: `/path/cycle-${index}` })]
+        }
+      })
+      warnAmbiguousOwnerOnce(worktreeId, 'persist worktree activity timestamp')
+      await store.getState().removeWorktree({ id: worktreeId, executionHostId: null })
+    }
+
+    expect(ambiguousOwnerWarnedWorktreeIds.size).toBe(0)
+    warn.mockRestore()
+  })
+})

--- a/src/renderer/src/store/slices/worktrees/listing/worktree-owner-settings.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/worktree-owner-settings.ts
@@ -126,6 +126,13 @@ export function settingsForWorktreeOwner(
 // One line per workspace is enough to diagnose it (#10634).
 export const ambiguousOwnerWarnedWorktreeIds = new Set<string>()
 
+/** Re-arms the once-per-workspace warning; called from every worktree teardown path. */
+export function forgetAmbiguousOwnerWarnings(worktreeIds: Iterable<string>): void {
+  for (const worktreeId of worktreeIds) {
+    ambiguousOwnerWarnedWorktreeIds.delete(worktreeId)
+  }
+}
+
 export function warnAmbiguousOwnerOnce(worktreeId: string, errorLabel: string): void {
   if (ambiguousOwnerWarnedWorktreeIds.has(worktreeId)) {
     return

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-store-cleanup.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-store-cleanup.ts
@@ -3,6 +3,7 @@ import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import type { WorktreeSliceSet } from '../listing/worktree-slice-types'
 import { removeDeleteStatesForWorktreeIds } from './worktree-delete-state'
 import { removeWorktreeVisitEntries } from '@/lib/worktree-visit-recency'
+import { forgetAmbiguousOwnerWarnings } from '../listing/worktree-owner-settings'
 
 export function applyRemoveWorktreeSuccessState(
   set: WorktreeSliceSet,
@@ -10,6 +11,9 @@ export function applyRemoveWorktreeSuccessState(
   tabIds: Set<string>,
   executionHostId?: ExecutionHostId
 ): void {
+  // Why outside `set`: it is module-scope, not store state. Dropping it also
+  // re-arms the once-per-workspace warning if this id is ever added back.
+  forgetAmbiguousOwnerWarnings([worktreeId])
   set((s) => {
     const next = { ...s.worktreesByRepo }
     for (const repoId of Object.keys(next)) {

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
@@ -7,6 +7,7 @@ import { collectWorktreePurgeDoomedIds } from './worktree-purge-doomed-ids'
 import { createWorktreePurgeOmitters } from './worktree-purge-omitters'
 import { removeDeleteStatesForWorktreeIds } from './worktree-delete-state'
 import { removeWorktreeVisitEntriesForTargets } from '@/lib/worktree-visit-recency'
+import { forgetAmbiguousOwnerWarnings } from '../listing/worktree-owner-settings'
 
 export function buildWorktreePurgeState(
   s: AppState,
@@ -19,6 +20,7 @@ export function buildWorktreePurgeState(
   pruneHostedReviewLinkMutationGenerations(worktreeIdSet)
   // Why: every authoritative and explicit purge converges here, so a deleted path can't inherit stale UI state.
   forgetHugeRepoWarningDismissalsForWorktrees(worktreeIdSet)
+  forgetAmbiguousOwnerWarnings(worktreeIdSet)
 
   const doomed = collectWorktreePurgeDoomedIds(s, worktreeIdSet)
   const {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​381 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​381 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |

<!-- /orca-pr-loc -->

## ELI5

Orca keeps lots of little lookup tables keyed by "which terminal is this" or "which workspace is this". When a terminal dies or a workspace is deleted, a cleanup routine goes through and deletes that id from every table. Two tables were never added to their cleanup routine, and one was dropped by a cache eviction that forgot to take its companion entry with it. So those three tables just kept growing.

This adds the three missing deletes, plus a test that fails if anyone adds a per-terminal table and forgets to reap it.

## What was happening

**1. `ptyLifecycleGenerationById` — missing from the PTY-exit reaper**

- Allocated: `src/main/runtime/orca-runtime-fit-override-listeners.ts:77`; written by `advancePtyLifecycleGeneration` / `getPtyLifecycleGeneration` in `orca-runtime-record-agent-prompt-lifecycle-state.ts:79,84`.
- Reaper that forgot it: `orca-runtime-on-pty-exit.ts`, which deletes ~25 sibling per-PTY maps — including `agentPromptExplicitStatusFloorByPtyId`, set two lines below the leaking one in the same helper — but never this one.
- Every PTY that ever ran left one `Map<string, number>` entry behind for the life of the main process. PTY ids are not reused within a process, so this only ever grew.
- Respawn safety: `getPtyLifecycleGeneration` lazily mints from the monotonic, never-reset `nextPtyLifecycleGeneration` counter. A re-read after the delete returns a **strictly newer** number, never a reused one, so every `getPtyLifecycleGeneration(ptyId) !== captured` comparison a stale frame makes still fails. The delete can only make the fence more conservative, never less. The one window where a capture could observe the difference (between the `advancePtyLifecycleGeneration` at line 70 and the delete) is fully synchronous; its only re-entrant call is `notifyPtyExitListeners`, whose sole main-process subscriber (`rpc/methods/terminal/terminal-input-delivery.ts:73`) does not capture a generation.

**2. `warnedLostHandlerPtyIds` — survives LRU eviction of its own data entry**

- Allocated: `src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts:48`, added at `:159`.
- Cleaned only in `drainPreHandlerPtyData` and `clearPreHandlerPtyState`, which both mean "a pane took this PTY's bytes". The LRU path `evictOldestPtyIfAtCap` drops the data entry without either, so a PTY that warned and was then evicted left its id behind for the life of the renderer.
- This was also a small correctness bug: the warning is once-per-id, so a suppressed id could never re-warn on a genuinely new accumulation episode for that id — the exact signal the breadcrumb exists to emit.
- `evictOldestPtyIfAtCap` now returns the evicted id; only the `preHandlerPtyData` call site drops the warned entry (the `preHandlerPtyExit` call site is unaffected).

**3. `ambiguousOwnerWarnedWorktreeIds` — not pruned on worktree removal**

- Allocated: `src/renderer/src/store/slices/worktrees/listing/worktree-owner-settings.ts:127`, added at `:134`.
- No delete anywhere in the tree. `remove-worktree-store-cleanup.ts` and `worktree-purge-state.ts` prune ~20 other per-worktree collections between them and skipped this module-scope Set.
- Same correctness angle: membership is what suppresses the warning, so a workspace whose path-derived id came back could never warn again even when genuinely ambiguous a second time.
- Pruned on both paths. `buildWorktreePurgeState` (the convergence point for CLI/SSH/other-window removals discovered by a listing refresh) already performs two module-scope prunes at the top; this joins them.

**The ratchet** (`src/main/runtime/pty-exit-per-pty-map-reaper-ratchet.test.ts`)

Reads every per-PTY-keyed `Map`/`Set` off a **real `OrcaRuntimeService` instance** (not parsed out of source, so a map declared in any of the ~90 mixin files is covered the moment it exists) and requires each of the 35 to land in exactly one bucket:

- deleted directly by the reaper (21 fields);
- cleaned by a helper the reaper calls — and the test verifies both that the reaper calls the helper *and* that the helper's own source deletes the field, so this is not a trust-me allowlist (4 fields);
- self-clearing per in-flight operation, removed by that operation's own settle path (6 fields);
- explicitly justified as intentionally retained past the exit (4 fields).

Comments are stripped before scanning — the first draft of this ratchet passed against a tree where the fix was commented out, and there is now a test for that too.

## Measurement

| Map | Teardown loop | Entries retained before | after |
|---|---|---|---|
| `ptyLifecycleGenerationById` | 5,000 spawn/exit cycles | 5,000 | **0** |
| `ptyLifecycleGenerationById` | 50 spawn/exit cycles (unit test) | 50 | **0** |
| `warnedLostHandlerPtyIds` | 1 warn + 64 LRU-evicting buffers | 1 (and re-warn suppressed) | **0** (re-warn fires) |
| `ambiguousOwnerWarnedWorktreeIds` | 100 remove cycles | 100 | **0** |

Per-entry cost, measured on this Node/V8 (200k entries, heap delta): a `Map<string, number>` entry that also owns its key string costs **≈167 B**; the `Map` machinery alone (key already referenced elsewhere) is **≈37 B**, and a `Set<string>` slot alone is **≈16–18 B**. So 5,000 exited PTYs retained roughly **190 KB** in `ptyLifecycleGenerationById` alone before this change (the map is the last owner of the id string once its ~25 siblings have dropped it). The two renderer sets are far smaller in absolute terms — they matter because they are unbounded and because not pruning them suppressed a real diagnostic.

**This does not explain the reported 451 MB renderer RSS.** The audit concluded that figure is dominated by legitimately-retained xterm/Monaco/DOM state; nothing here moves it meaningfully. These are unbounded-growth fixes, not the answer to that report.

## Two audited items deliberately not shipped

The audit that produced this list flagged five maps. Two did not survive verification, and shipping them would have been either useless or actively harmful:

- **`pointedMessageIdsByHandle`** (`orca-runtime-runtime-id.ts:273`), described as the largest of the five, is **not a live leak — it is dead code.** `deliverPendingMessages` is `protected` and has exactly two callers: its own probe continuation, and `settlePendingMessageDelivery`, which is itself only called from `deliverPendingMessages`. That is a closed cycle with no external entry point; `deliverPendingMessagesForHandle` routes entirely through `OrchestrationMailboxPointerDelivery`, which supersedes it and whose `OrchestrationMailboxPointerState` *is* properly reaped (`retirePty` clears watermarks and flights). `lastPointedMessageSequenceByHandle`, `messageDeliveryFlightsByPtyId` and `parkedMessageRedeliveriesByPtyId` are in the same dead cluster. It retains zero bytes today, and modifying an unreachable path to "reclaim" nothing is diff risk for no gain. Worth a separate dead-code-removal PR; not this one.
- **`browserPageChromeInsetHeights`** (`browser-page-viewport.ts:29`). The audit assumed `removeBrowserPageViewport` is the page-*close* path. It is not — it is the page-*rebuild* path. `replacePersistentWebview(id)` (guest recovery, `browser-page-webview-guest-session.ts:162`) defaults to `preserveViewport: false` and reaches it, and `destroyPersistentWebview` is called for partition/profile switches (`browser-page-webview.ts:47`), SSH route gating, and runtime-environment handoff — all rebuilds. Deleting the inset there is exactly the case the map exists to survive; it would leave the webview overlapping the toolbar after a guest crash, and it breaks the existing test `restores the inset when guest recovery rebuilds the shell`, which documents that requirement. There is no call site in this module that means "closed and not coming back"; a correct fix belongs at the store's browser-tab-close level and is not a one-liner.

## Negative user-facing trade-offs

None.

- **A respawned PTY must not accept a stale frame.** Guaranteed, and strictly strengthened rather than weakened: the generation counter is monotonic and never reused, so the value re-minted after the delete is greater than every pre-exit capture. Covered by `never hands a respawn a generation a pre-exit capture could still match`, which asserts the post-respawn generation exceeds the pre-exit one and is stable thereafter.
- **Message-pointing dedupe behaves identically for still-unread ids.** Guaranteed by not touching that code at all (see above).
- **A remounted browser page keeps its chrome inset.** Guaranteed by not touching that code at all (see above).

The only observable behaviour change anywhere in this diff is that two `console.warn` breadcrumbs can now fire a second time — for a pre-handler PTY whose buffered bytes were evicted and then re-accumulated past 64 KB, and for a worktree id that is removed and comes back ambiguous. Both restore the once-per-*episode* semantics those warnings were written for. Neither is a user-facing surface.

## Risk & verification

Low. Three deletes and one changed private return type; no wire format, no IPC, no persisted schema, no SSH/remote surface, nothing platform-dependent.

- `pnpm tc` clean; `pnpm run check:code-quality:changed` clean (0 new findings across 8 files, including React Doctor).
- Every new test was verified to **fail** with its fix reverted, then pass with it restored — including the ratchet, which reports `[ 'ptyLifecycleGenerationById' ]` as unaccounted against the pre-fix tree.
- Existing suites in each touched area pass: `src/main/runtime` PTY-exit suites (24 tests), worktree-removal/purge leak suites (17), the full `src/renderer/src/components/terminal-pane` directory (4,162), and `src/renderer/src/store/slices/worktrees`. One pre-existing flake in `pty-connection-command-finished-cleanup.test.ts` (30 s timeout under full-directory parallel load, unrelated file) passes in isolation and did not reproduce on re-run.
