### PR TITLE
perf(combined-diff): stop rebuilding whole-section derived state on every section load

### DIFF
--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.commentable-lines.test.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.commentable-lines.test.tsx
@@ -178,7 +178,55 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+function countingCommentableLines(length: number): {
+  lines: readonly number[]
+  joins: () => number
+} {
+  const lines = Array.from({ length }, (_, index) => index + 1)
+  let joins = 0
+  Object.defineProperty(lines, 'join', {
+    configurable: true,
+    value: (separator?: string) => {
+      joins += 1
+      return Array.prototype.join.call(lines, separator)
+    }
+  })
+  return { lines, joins: () => joins }
+}
+
 describe('useDiffCommentDecorator commentable-line churn', () => {
+  it('joins the commentable-line array once, not once per render, for a stable array', () => {
+    const fake = createFakeEditor()
+    const comments = [reviewNote(1)]
+    // reviewCommentLineNumbers carries every added and context line of the patch.
+    const { lines, joins } = countingCommentableLines(4_000)
+    const hook = renderDecorator(fake, { commentableLineNumbers: lines, comments })
+
+    for (let render = 1; render < 100; render += 1) {
+      hook.rerender({ commentableLineNumbers: lines, comments })
+    }
+
+    expect(joins()).toBe(1)
+  })
+
+  it('still re-keys on a fresh-but-equal array so the comment set survives a review refresh', () => {
+    const fake = createFakeEditor()
+    const comments = [reviewNote(1)]
+    const hook = renderDecorator(fake, {
+      commentableLineNumbers: freshCommentableLines(),
+      comments
+    })
+
+    fake.emitMouseMove(12)
+    expect(isAddButtonVisible(fake.domNode)).toBe(true)
+
+    hook.rerender({ commentableLineNumbers: freshCommentableLines(), comments })
+
+    fake.emitMouseMove(12)
+    expect(isAddButtonVisible(fake.domNode)).toBe(true)
+    expect(rootCounts.created).toBe(1)
+  })
+
   it('keeps every comment root and view zone alive across value-equal review refreshes', async () => {
     const fake = createFakeEditor()
     const comments = [reviewNote(1), reviewNote(2), reviewNote(3)]

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -82,7 +82,12 @@ export function useDiffCommentDecorator({
 
   // Key on the values, not the array identity: review surfaces re-fetch PR/MR file data on every
   // refresh and hand us a fresh-but-equal number[], which would otherwise churn every consumer.
-  const commentableLineKey = commentableLineNumbers?.join(',')
+  // Memoized on the array identity: the join walks every commentable line of the patch (thousands
+  // on a large file) and every mounted diff row runs this hook on every render.
+  const commentableLineKey = useMemo(
+    () => commentableLineNumbers?.join(','),
+    [commentableLineNumbers]
+  )
   const commentableLineSet = useMemo(
     () => (commentableLineNumbers ? new Set(commentableLineNumbers) : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/renderer/src/components/editor/combined-diff/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/combined-diff/CombinedDiffViewer.tsx
@@ -11,6 +11,8 @@ import {
   EMPTY_GIT_STATUS_ENTRIES,
   useCombinedDiffEntrySet
 } from './resolve-changes/use-combined-diff-entry-set'
+import { useCombinedDiffSectionIndexMap } from './resolve-changes/use-combined-diff-section-index-map'
+import { useCombinedDiffSectionRowKeys } from './resolve-changes/use-combined-diff-section-row-keys'
 import { useCombinedDiffSectionLoadRegistry } from './load-sections/combined-diff-section-load-registry'
 import { useCombinedDiffSectionLoader } from './load-sections/use-combined-diff-section-loader'
 import { useCombinedDiffSectionRetry } from './load-sections/use-combined-diff-section-retry'
@@ -120,6 +122,13 @@ export default function CombinedDiffViewer({
     setSections
   })
 
+  // Why: one incremental scan of `sections` feeds the virtualizer keys, the restore signal and the
+  // toolbar collapse state, instead of three independent full passes per loaded section.
+  const sectionRowKeys = useCombinedDiffSectionRowKeys({ generation, sections })
+  const sectionIndexByKey = useCombinedDiffSectionIndexMap({
+    entrySignature: entrySet.entrySignature,
+    sections
+  })
   const { hasDirectScrollInput, markDirectScrollInput } = useCombinedDiffDirectScrollInput()
   const { cleanupActiveScrollbarDrag, handleScrollbarPointerDown, scrollThumb, updateScrollbar } =
     useCombinedDiffScrollbar({ markDirectScrollInput, scrollContainerRef })
@@ -127,6 +136,7 @@ export default function CombinedDiffViewer({
     generation,
     programmaticScrollMarks,
     renderedIndicesRef: registry.renderedIndicesRef,
+    rowKeys: sectionRowKeys.rowKeys,
     scrollContainerRef,
     scrollOffsetRef: restore.scrollOffsetRef,
     sectionHeights,
@@ -142,9 +152,11 @@ export default function CombinedDiffViewer({
     scrollAnchorRef: restore.scrollAnchorRef,
     scrollContainerRef,
     scrollOffsetRef: restore.scrollOffsetRef,
+    sectionIndexByKey,
     sections,
     sectionsRef: registry.sectionsRef,
     sideBySide: preferences.sideBySide,
+    structureRevision: sectionRowKeys.structureRevision,
     totalSize: virtualizer.getTotalSize(),
     viewStateKey,
     virtualizer
@@ -168,6 +180,7 @@ export default function CombinedDiffViewer({
     entrySignature: entrySet.entrySignature,
     markDirectScrollInput,
     scrollToIndex: anchors.scrollToSectionIndex,
+    sectionIndexByKey,
     sections,
     sectionsRef: registry.sectionsRef,
     toggleSection,
@@ -297,7 +310,7 @@ export default function CombinedDiffViewer({
         skippedConflicts={skippedConflicts!}
       />
     ) : null
-  const allSectionsCollapsed = sections.every((section) => section.collapsed)
+  const allSectionsCollapsed = sectionRowKeys.allSectionsCollapsed
 
   return (
     <>

--- a/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-collapsed-work.test.tsx
+++ b/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-collapsed-work.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitBranchChangeEntry } from '../../../../../../shared/git-diff-compare-types'
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ combinedDiffFileTreeWidth: 420, setCombinedDiffFileTreeWidth: () => {} })
+}))
+
+const { CombinedDiffFileTree } = await import('./combined-diff-file-tree')
+
+class NoopResizeObserver implements ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  vi.stubGlobal('ResizeObserver', NoopResizeObserver)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+/**
+ * Entries whose `path` getter counts reads. Every filter/group/flatten step the tree runs reads
+ * `path`, so the count is a direct proxy for "did the tree get built".
+ */
+function countingEntries(count: number): {
+  entries: GitBranchChangeEntry[]
+  reads: () => number
+} {
+  let reads = 0
+  const entries = Array.from({ length: count }, (_, index) => {
+    const path = `src/dir${index % 5}/file-${index}.ts`
+    const entry = { status: 'modified' } as GitBranchChangeEntry
+    Object.defineProperty(entry, 'path', {
+      configurable: true,
+      enumerable: true,
+      get: () => {
+        reads += 1
+        return path
+      }
+    })
+    return entry
+  })
+  return { entries, reads: () => reads }
+}
+
+function renderTree(entries: GitBranchChangeEntry[], collapsed: boolean): void {
+  act(() => {
+    root.render(
+      <CombinedDiffFileTree
+        mode="branch"
+        worktreePath="/repo"
+        entries={entries}
+        sectionIndexByKey={new Map()}
+        activeSectionKey={null}
+        viewedSectionKeys={new Set()}
+        collapsed={collapsed}
+        onCollapsedChange={() => {}}
+        onNavigate={() => {}}
+      />
+    )
+  })
+}
+
+describe('CombinedDiffFileTree while collapsed', () => {
+  it('does not filter, build or flatten the tree behind a collapsed panel', () => {
+    const { entries, reads } = countingEntries(300)
+
+    renderTree(entries, true)
+
+    expect(host.childElementCount).toBe(0)
+    expect(reads()).toBe(0)
+  })
+
+  it('builds the same tree as soon as it is expanded', () => {
+    const { entries, reads } = countingEntries(300)
+
+    renderTree(entries, true)
+    renderTree(entries, false)
+
+    // Every entry is filtered and placed into the tree once the panel is visible.
+    expect(reads()).toBeGreaterThanOrEqual(entries.length)
+    expect(host.textContent).toContain('Files')
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree.tsx
+++ b/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree.tsx
@@ -20,8 +20,18 @@ import {
   buildCombinedDiffUncommittedTreeGroups,
   flattenCombinedDiffTreeRoots,
   getViewedCombinedDiffTreeVisibility,
+  type CombinedDiffTreeGroup,
   type CombinedDiffTreeNode
 } from './combined-diff-file-tree-model'
+
+// Why: a collapsed tree renders nothing, so every memo below short-circuits to one of these instead
+// of building and flattening the whole tree behind a hidden panel. Expanding rebuilds them, which
+// an expand already costs today.
+const EMPTY_TREE_ENTRIES: readonly CombinedDiffFileTreeEntry[] = Object.freeze([])
+const EMPTY_TREE_EXTENSIONS: readonly string[] = Object.freeze([])
+const EMPTY_UNCOMMITTED_TREE_GROUPS: CombinedDiffTreeGroup[] = []
+const EMPTY_TREE_ROOTS: CombinedDiffTreeNode[] = []
+const EMPTY_TREE_ROWS: CombinedDiffTreeNode[] = []
 
 export function CombinedDiffFileTree({
   mode,
@@ -67,19 +77,24 @@ export function CombinedDiffFileTree({
   }, [])
 
   const availableExtensions = React.useMemo(
-    () => Array.from(new Set(entries.map(getEntryExtension))).sort(),
-    [entries]
+    () =>
+      collapsed
+        ? EMPTY_TREE_EXTENSIONS
+        : Array.from(new Set(entries.map(getEntryExtension))).sort(),
+    [collapsed, entries]
   )
   // Why: viewed/loading state changes for one section must not invalidate the path filter or tree
   // construction. It is applied below as a visibility overlay.
   const structurallyFilteredEntries = React.useMemo(
     () =>
-      getCombinedDiffFileTreeEntriesMatchingStaticFilters({
-        entries,
-        query,
-        excludedExtensions
-      }),
-    [entries, excludedExtensions, query]
+      collapsed
+        ? EMPTY_TREE_ENTRIES
+        : getCombinedDiffFileTreeEntriesMatchingStaticFilters({
+            entries,
+            query,
+            excludedExtensions
+          }),
+    [collapsed, entries, excludedExtensions, query]
   )
   const toggleExtension = React.useCallback((extension: string) => {
     setExcludedExtensions((prev) => {
@@ -102,37 +117,39 @@ export function CombinedDiffFileTree({
 
   const uncommittedTreeGroups = React.useMemo(
     () =>
-      mode === 'all' || mode === 'uncommitted'
+      !collapsed && (mode === 'all' || mode === 'uncommitted')
         ? buildCombinedDiffUncommittedTreeGroups(structurallyFilteredEntries)
-        : [],
-    [mode, structurallyFilteredEntries]
+        : EMPTY_UNCOMMITTED_TREE_GROUPS,
+    [collapsed, mode, structurallyFilteredEntries]
   )
   const branchTreeRoots = React.useMemo(
     () =>
-      mode === 'all' || mode === 'branch' || mode === 'commit'
+      !collapsed && (mode === 'all' || mode === 'branch' || mode === 'commit')
         ? buildCombinedDiffBranchTreeRoots(mode, structurallyFilteredEntries)
-        : [],
-    [mode, structurallyFilteredEntries]
+        : EMPTY_TREE_ROOTS,
+    [collapsed, mode, structurallyFilteredEntries]
   )
   // Why: the viewed overlay below replaces these rows entirely when viewed files are hidden, so
   // flattening the unfiltered tree there is pure dead work.
   const uncommittedRowsByArea = React.useMemo(() => {
     const rowsByArea = new Map<string, CombinedDiffTreeNode[]>()
-    if (!includeViewed) {
+    if (collapsed || !includeViewed) {
       return rowsByArea
     }
     for (const group of uncommittedTreeGroups) {
       rowsByArea.set(group.area, flattenCombinedDiffTreeRoots(group.roots, collapsedDirectoryKeys))
     }
     return rowsByArea
-  }, [collapsedDirectoryKeys, includeViewed, uncommittedTreeGroups])
+  }, [collapsed, collapsedDirectoryKeys, includeViewed, uncommittedTreeGroups])
   const branchRows = React.useMemo(
     () =>
-      includeViewed ? flattenCombinedDiffTreeRoots(branchTreeRoots, collapsedDirectoryKeys) : [],
-    [branchTreeRoots, collapsedDirectoryKeys, includeViewed]
+      !collapsed && includeViewed
+        ? flattenCombinedDiffTreeRoots(branchTreeRoots, collapsedDirectoryKeys)
+        : EMPTY_TREE_ROWS,
+    [branchTreeRoots, collapsed, collapsedDirectoryKeys, includeViewed]
   )
   const uncommittedVisibleRowsByArea = React.useMemo(() => {
-    if (includeViewed) {
+    if (collapsed || includeViewed) {
       return null
     }
     const rowsByArea = new Map<string, ReturnType<typeof getViewedCombinedDiffTreeVisibility>>()
@@ -148,10 +165,17 @@ export function CombinedDiffFileTree({
       )
     }
     return rowsByArea
-  }, [collapsedDirectoryKeys, includeViewed, mode, uncommittedTreeGroups, viewedSectionKeys])
+  }, [
+    collapsed,
+    collapsedDirectoryKeys,
+    includeViewed,
+    mode,
+    uncommittedTreeGroups,
+    viewedSectionKeys
+  ])
   const branchVisibleRows = React.useMemo(
     () =>
-      includeViewed
+      collapsed || includeViewed
         ? null
         : getViewedCombinedDiffTreeVisibility({
             roots: branchTreeRoots,
@@ -159,7 +183,7 @@ export function CombinedDiffFileTree({
             mode,
             viewedSectionKeys
           }),
-    [branchTreeRoots, collapsedDirectoryKeys, includeViewed, mode, viewedSectionKeys]
+    [branchTreeRoots, collapsed, collapsedDirectoryKeys, includeViewed, mode, viewedSectionKeys]
   )
   const visibleEntryCount = includeViewed
     ? structurallyFilteredEntries.length

--- a/src/renderer/src/components/editor/combined-diff/browse-files/use-combined-diff-tree-navigation.test.ts
+++ b/src/renderer/src/components/editor/combined-diff/browse-files/use-combined-diff-tree-navigation.test.ts
@@ -32,6 +32,7 @@ function renderNavigation(sections: DiffSection[], entrySignature: string) {
         entrySignature: props.entrySignature,
         markDirectScrollInput: vi.fn(),
         scrollToIndex: vi.fn(),
+        sectionIndexByKey: new Map(props.sections.map((section, index) => [section.key, index])),
         sections: props.sections,
         sectionsRef,
         toggleSection: vi.fn(),

--- a/src/renderer/src/components/editor/combined-diff/browse-files/use-combined-diff-tree-navigation.ts
+++ b/src/renderer/src/components/editor/combined-diff/browse-files/use-combined-diff-tree-navigation.ts
@@ -3,14 +3,13 @@ import type { GitBranchChangeEntry } from '../../../../../../shared/git-diff-com
 import type { GitStatusEntry } from '../../../../../../shared/git-status-types'
 import type { DiffSection } from '../../diff-section-types'
 import type { CombinedDiffFileTreeMode } from '../resolve-changes/combined-diff-section-identity'
-import { useCombinedDiffSectionIndexMap } from '../resolve-changes/use-combined-diff-section-index-map'
 import { handleCombinedDiffFileTreeNavigation } from './combined-diff-file-tree-navigation'
 import { isCombinedDiffSectionViewed } from './combined-diff-file-tree-filter'
 
 export type CombinedDiffTreeNavigation = {
   activeTreeSectionKey: string | null
   handleTreeNavigate: (entry: GitStatusEntry | GitBranchChangeEntry) => void
-  sectionIndexByKey: Map<string, number>
+  sectionIndexByKey: ReadonlyMap<string, number>
   sectionIndexByKeyRef: React.RefObject<ReadonlyMap<string, number>>
   viewedSectionKeys: Set<string>
 }
@@ -21,6 +20,7 @@ export function useCombinedDiffTreeNavigation({
   entrySignature,
   markDirectScrollInput,
   scrollToIndex,
+  sectionIndexByKey,
   sections,
   sectionsRef,
   toggleSection,
@@ -30,12 +30,13 @@ export function useCombinedDiffTreeNavigation({
   entrySignature: string
   markDirectScrollInput: () => void
   scrollToIndex: (index: number) => void
+  // Why: hoisted to the viewer so the scroll anchor and the tree share one identity-stable map.
+  sectionIndexByKey: ReadonlyMap<string, number>
   sections: DiffSection[]
   sectionsRef: React.RefObject<DiffSection[]>
   toggleSection: (index: number) => void
   treeMode: CombinedDiffFileTreeMode
 }): CombinedDiffTreeNavigation {
-  const sectionIndexByKey = useCombinedDiffSectionIndexMap({ entrySignature, sections })
   const sectionIndexByKeyRef = useRef<ReadonlyMap<string, number>>(sectionIndexByKey)
   sectionIndexByKeyRef.current = sectionIndexByKey
 
@@ -79,6 +80,11 @@ export function useCombinedDiffTreeNavigation({
       const previousSection = previous.sections[index]
       const section = sections[index]
       if (!previousSection || !section) {
+        continue
+      }
+      // Why: a section load rewrites one element of a `prev.map(...)` copy, so identity settles
+      // every untouched row without re-deriving its viewed state.
+      if (previousSection === section) {
         continue
       }
       // Why: reordered keys can't be patched index by index — a later delete would drop an earlier add.

--- a/src/renderer/src/components/editor/combined-diff/remember-view/use-combined-diff-view-restore.test.tsx
+++ b/src/renderer/src/components/editor/combined-diff/remember-view/use-combined-diff-view-restore.test.tsx
@@ -9,6 +9,9 @@ import { useCombinedDiffSectionLoadRegistry } from '../load-sections/combined-di
 import type { CombinedDiffEntrySet } from '../resolve-changes/use-combined-diff-entry-set'
 import { combinedDiffViewStateCache } from './combined-diff-view-memory'
 import { useCombinedDiffViewRestore } from './use-combined-diff-view-restore'
+import { disposeClosedEditorTabs } from '../../closed-editor-tab-disposal'
+import type { MonacoModelRegistry } from '../../diff-monaco-model-disposal'
+import type { OpenFile } from '@/store/slices/editor'
 
 function buildAllModeEntrySet(
   uncommittedEntries: GitStatusEntry[],
@@ -73,6 +76,61 @@ describe('useCombinedDiffViewRestore deferral', () => {
       'mixed-pass-view'
     )
     expect(sections.map((section) => section.loadOnDemand)).toEqual([true, true, false])
+  })
+
+  it('restores a closed combined-diff tab from the view-state cache when it is reopened', () => {
+    // Why this test exists: combined-diff tab ids are deterministic
+    // (`<worktreeId>::all-diffs::uncommitted`), so closing and reopening the review hits the same
+    // viewStateKey and restores loaded bodies + scroll with no refetch. Sweeping the combined-diff
+    // view-state caches on tab close would therefore change what the user sees on reopen.
+    const entrySet = buildAllModeEntrySet(
+      [{ path: 'src/app.ts', status: 'modified', area: 'unstaged', added: 5 }],
+      []
+    )
+    const viewStateKey = 'wt-1::all-diffs::uncommitted'
+    const loadedSections: DiffSection[] = [
+      {
+        key: 'unstaged:src/app.ts',
+        path: 'src/app.ts',
+        status: 'modified',
+        area: 'unstaged',
+        added: 5,
+        originalContent: 'before',
+        modifiedContent: 'after',
+        collapsed: false,
+        loading: false,
+        dirty: false,
+        diffResult: null,
+        largeDiffRenderLimit: null
+      }
+    ]
+    combinedDiffViewStateCache.set(viewStateKey, {
+      entrySignature: entrySet.entrySignature,
+      gitStatusSignature: '',
+      sections: loadedSections,
+      sectionHeights: {},
+      loadedIndices: [0],
+      scrollTop: 0,
+      sideBySide: false
+    })
+    cleanup()
+
+    const closedTab = {
+      id: viewStateKey,
+      mode: 'diff',
+      diffSource: 'combined-uncommitted',
+      filePath: '/repo',
+      worktreeId: 'wt-1'
+    } as unknown as OpenFile
+    disposeClosedEditorTabs(
+      {
+        editor: { getModel: () => null, getModels: () => [] },
+        Uri: { parse: (v: string) => v }
+      } as unknown as MonacoModelRegistry,
+      [closedTab]
+    )
+
+    expect(restoreSections(entrySet, viewStateKey)).toEqual(loadedSections)
   })
 
   it('auto-loads an uncounted tracked row once its own pass counted something', () => {

--- a/src/renderer/src/components/editor/combined-diff/resolve-changes/combined-diff-section-scaling.test.tsx
+++ b/src/renderer/src/components/editor/combined-diff/resolve-changes/combined-diff-section-scaling.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment happy-dom
+
+import type React from 'react'
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { Virtualizer } from '@tanstack/react-virtual'
+import { createProgrammaticScrollMarks } from '@/hooks/programmatic-scroll-marks'
+import type { VirtualizedScrollAnchor } from '@/hooks/useVirtualizedScrollAnchor'
+import type { DiffSection } from '../../diff-section-types'
+import { useCombinedDiffScrollAnchors } from '../scroll-viewport/use-combined-diff-scroll-anchors'
+import { useCombinedDiffTreeNavigation } from '../browse-files/use-combined-diff-tree-navigation'
+import { useCombinedDiffSectionIndexMap } from './use-combined-diff-section-index-map'
+import { useCombinedDiffSectionRowKeys } from './use-combined-diff-section-row-keys'
+
+const SECTION_COUNT = 500
+
+type KeyReadCounter = { reads: number }
+
+/**
+ * Sections whose `key` getter counts reads. Every O(N)-per-load pass this PR targets derives from
+ * `section.key`, so the read count is a direct, deterministic proxy for the quadratic work.
+ */
+function makeCountingSection(
+  counter: KeyReadCounter,
+  key: string,
+  overrides: Partial<DiffSection> = {}
+): DiffSection {
+  const section: DiffSection = {
+    key: '',
+    path: key,
+    status: 'modified',
+    originalContent: '',
+    modifiedContent: '',
+    collapsed: false,
+    loading: true,
+    dirty: false,
+    diffResult: null,
+    largeDiffRenderLimit: null,
+    ...overrides
+  }
+  Object.defineProperty(section, 'key', {
+    configurable: true,
+    enumerable: true,
+    get: () => {
+      counter.reads += 1
+      return key
+    }
+  })
+  return section
+}
+
+function createFakeVirtualizer(): Virtualizer<HTMLDivElement, Element> {
+  return {
+    getTotalSize: () => 0,
+    getVirtualItems: () => [],
+    isScrolling: false,
+    measure: vi.fn(),
+    scrollToIndex: vi.fn()
+  } as unknown as Virtualizer<HTMLDivElement, Element>
+}
+
+function useCombinedDiffSectionPasses(sections: DiffSection[]): {
+  allSectionsCollapsed: boolean
+  rowKeys: readonly string[]
+  sectionIndexByKey: ReadonlyMap<string, number>
+  viewedSectionKeys: ReadonlySet<string>
+} {
+  const sectionsRef = { current: sections } as React.RefObject<DiffSection[]>
+  const scrollContainerRef = { current: null } as React.RefObject<HTMLDivElement | null>
+  const sectionRowKeys = useCombinedDiffSectionRowKeys({ generation: 1, sections })
+  const sectionIndexByKey = useCombinedDiffSectionIndexMap({ entrySignature: 'sig', sections })
+  const anchors = useCombinedDiffScrollAnchors({
+    clampRestoreCount: 0,
+    generation: 1,
+    hasDirectScrollInput: () => false,
+    latestDomScrollAnchorRef: { current: null } as React.RefObject<VirtualizedScrollAnchor>,
+    programmaticScrollMarks: createProgrammaticScrollMarks(),
+    scrollAnchorRef: { current: null } as React.RefObject<VirtualizedScrollAnchor>,
+    scrollContainerRef,
+    scrollOffsetRef: { current: 0 } as React.RefObject<number>,
+    sectionIndexByKey,
+    sections,
+    sectionsRef,
+    sideBySide: false,
+    structureRevision: sectionRowKeys.structureRevision,
+    totalSize: 0,
+    viewStateKey: 'scaling-test',
+    virtualizer: createFakeVirtualizer()
+  })
+  const treeNavigation = useCombinedDiffTreeNavigation({
+    ensureSectionLoaded: vi.fn(),
+    entrySignature: 'sig',
+    markDirectScrollInput: vi.fn(),
+    scrollToIndex: anchors.scrollToSectionIndex,
+    sectionIndexByKey,
+    sections,
+    sectionsRef,
+    toggleSection: vi.fn(),
+    treeMode: 'all'
+  })
+  return {
+    allSectionsCollapsed: sectionRowKeys.allSectionsCollapsed,
+    rowKeys: sectionRowKeys.rowKeys,
+    sectionIndexByKey,
+    viewedSectionKeys: treeNavigation.viewedSectionKeys
+  }
+}
+
+describe('combined diff section passes at scale', () => {
+  it('stays O(N) in section-key reads across a full progressive load of 500 sections', () => {
+    const counter: KeyReadCounter = { reads: 0 }
+    const initial = Array.from({ length: SECTION_COUNT }, (_, index) =>
+      makeCountingSection(counter, `combined-branch:file-${index}.ts`)
+    )
+    const view = renderHook(
+      ({ sections }: { sections: DiffSection[] }) => useCombinedDiffSectionPasses(sections),
+      { initialProps: { sections: initial } }
+    )
+    const firstRowKeys = view.result.current.rowKeys
+    const firstIndexMap = view.result.current.sectionIndexByKey
+    const readsAfterMount = counter.reads
+
+    let sections = initial
+    for (let index = 0; index < SECTION_COUNT; index += 1) {
+      // Mirrors loadSectionNow's `prev.map((s, i) => i === index ? {...s, ...} : s)`: one new
+      // section object, every other row keeps its identity.
+      const next = sections.slice()
+      next[index] = makeCountingSection(counter, `combined-branch:file-${index}.ts`, {
+        loading: false,
+        contentGeneration: 1
+      })
+      sections = next
+      view.rerender({ sections })
+    }
+
+    const loadReads = counter.reads - readsAfterMount
+    // O(N): a handful of reads per loaded section. The pre-fix passes (restore-signal join, a
+    // second key -> index Map, the viewed-key key compare) read every key on every load, which is
+    // ~3 * 500 * 500 reads here.
+    expect(loadReads).toBeLessThanOrEqual(8 * SECTION_COUNT)
+
+    // Outputs are still exactly right after the incremental patching.
+    expect(view.result.current.rowKeys).toHaveLength(SECTION_COUNT)
+    expect(view.result.current.rowKeys[0]).toBe('combined-branch:file-0.ts:expanded:1:1')
+    expect(view.result.current.rowKeys[499]).toBe('combined-branch:file-499.ts:expanded:1:1')
+    expect(view.result.current.rowKeys).not.toBe(firstRowKeys)
+    expect(view.result.current.sectionIndexByKey).toBe(firstIndexMap)
+    expect(view.result.current.sectionIndexByKey.get('combined-branch:file-250.ts')).toBe(250)
+    expect(view.result.current.viewedSectionKeys.size).toBe(SECTION_COUNT)
+    expect(view.result.current.allSectionsCollapsed).toBe(false)
+  })
+
+  it('reuses the row-key string of every section a load did not touch', () => {
+    const counter: KeyReadCounter = { reads: 0 }
+    const sections = Array.from({ length: 4 }, (_, index) =>
+      makeCountingSection(counter, `combined-branch:file-${index}.ts`)
+    )
+    const view = renderHook(
+      ({ rows }: { rows: DiffSection[] }) => useCombinedDiffSectionPasses(rows),
+      { initialProps: { rows: sections } }
+    )
+    const firstRowKeys = view.result.current.rowKeys
+
+    const next = sections.slice()
+    next[2] = makeCountingSection(counter, 'combined-branch:file-2.ts', {
+      loading: false,
+      contentGeneration: 1
+    })
+    view.rerender({ rows: next })
+
+    const rowKeys = view.result.current.rowKeys
+    for (const index of [0, 1, 3]) {
+      expect(rowKeys[index]).toBe(firstRowKeys[index])
+    }
+    expect(rowKeys[2]).toBe('combined-branch:file-2.ts:expanded:1:1')
+  })
+
+  it('returns the identical row-key result when a rerender changes nothing', () => {
+    const counter: KeyReadCounter = { reads: 0 }
+    const sections = Array.from({ length: 8 }, (_, index) =>
+      makeCountingSection(counter, `combined-branch:file-${index}.ts`)
+    )
+    const view = renderHook(
+      ({ rows }: { rows: DiffSection[] }) =>
+        useCombinedDiffSectionRowKeys({ generation: 1, sections: rows }),
+      { initialProps: { rows: sections } }
+    )
+    const first = view.result.current
+
+    // A fresh array whose elements are identical: the shape a no-op setSections produces.
+    view.rerender({ rows: sections.slice() })
+
+    expect(view.result.current).toBe(first)
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff/resolve-changes/combined-diff-section-scaling.test.tsx
+++ b/src/renderer/src/components/editor/combined-diff/resolve-changes/combined-diff-section-scaling.test.tsx
@@ -49,35 +49,46 @@ function makeCountingSection(
   return section
 }
 
-function createFakeVirtualizer(): Virtualizer<HTMLDivElement, Element> {
-  return {
-    getTotalSize: () => 0,
-    getVirtualItems: () => [],
-    isScrolling: false,
-    measure: vi.fn(),
-    scrollToIndex: vi.fn()
-  } as unknown as Virtualizer<HTMLDivElement, Element>
-}
+const FAKE_VIRTUALIZER = {
+  getTotalSize: () => 0,
+  getVirtualItems: () => [],
+  isScrolling: false,
+  measure: vi.fn(),
+  scrollToIndex: vi.fn()
+} as unknown as Virtualizer<HTMLDivElement, Element>
 
-function useCombinedDiffSectionPasses(sections: DiffSection[]): {
+// Stable across renders so the hooks under test see the same dependency identities the viewer gives them.
+const NO_DIRECT_SCROLL_INPUT = (): boolean => false
+const NOOP = vi.fn()
+const PROGRAMMATIC_SCROLL_MARKS = createProgrammaticScrollMarks()
+const SCROLL_CONTAINER_REF = { current: null } as React.RefObject<HTMLDivElement | null>
+const SCROLL_ANCHOR_REF = { current: null } as React.RefObject<VirtualizedScrollAnchor>
+const LATEST_DOM_SCROLL_ANCHOR_REF = { current: null } as React.RefObject<VirtualizedScrollAnchor>
+const SCROLL_OFFSET_REF = { current: 0 } as React.RefObject<number>
+
+function useCombinedDiffSectionPasses({
+  sections,
+  sectionsRef
+}: {
+  sections: DiffSection[]
+  sectionsRef: React.RefObject<DiffSection[]>
+}): {
   allSectionsCollapsed: boolean
   rowKeys: readonly string[]
   sectionIndexByKey: ReadonlyMap<string, number>
   viewedSectionKeys: ReadonlySet<string>
 } {
-  const sectionsRef = { current: sections } as React.RefObject<DiffSection[]>
-  const scrollContainerRef = { current: null } as React.RefObject<HTMLDivElement | null>
   const sectionRowKeys = useCombinedDiffSectionRowKeys({ generation: 1, sections })
   const sectionIndexByKey = useCombinedDiffSectionIndexMap({ entrySignature: 'sig', sections })
   const anchors = useCombinedDiffScrollAnchors({
     clampRestoreCount: 0,
     generation: 1,
-    hasDirectScrollInput: () => false,
-    latestDomScrollAnchorRef: { current: null } as React.RefObject<VirtualizedScrollAnchor>,
-    programmaticScrollMarks: createProgrammaticScrollMarks(),
-    scrollAnchorRef: { current: null } as React.RefObject<VirtualizedScrollAnchor>,
-    scrollContainerRef,
-    scrollOffsetRef: { current: 0 } as React.RefObject<number>,
+    hasDirectScrollInput: NO_DIRECT_SCROLL_INPUT,
+    latestDomScrollAnchorRef: LATEST_DOM_SCROLL_ANCHOR_REF,
+    programmaticScrollMarks: PROGRAMMATIC_SCROLL_MARKS,
+    scrollAnchorRef: SCROLL_ANCHOR_REF,
+    scrollContainerRef: SCROLL_CONTAINER_REF,
+    scrollOffsetRef: SCROLL_OFFSET_REF,
     sectionIndexByKey,
     sections,
     sectionsRef,
@@ -85,17 +96,17 @@ function useCombinedDiffSectionPasses(sections: DiffSection[]): {
     structureRevision: sectionRowKeys.structureRevision,
     totalSize: 0,
     viewStateKey: 'scaling-test',
-    virtualizer: createFakeVirtualizer()
+    virtualizer: FAKE_VIRTUALIZER
   })
   const treeNavigation = useCombinedDiffTreeNavigation({
-    ensureSectionLoaded: vi.fn(),
+    ensureSectionLoaded: NOOP,
     entrySignature: 'sig',
-    markDirectScrollInput: vi.fn(),
+    markDirectScrollInput: NOOP,
     scrollToIndex: anchors.scrollToSectionIndex,
     sectionIndexByKey,
     sections,
     sectionsRef,
-    toggleSection: vi.fn(),
+    toggleSection: NOOP,
     treeMode: 'all'
   })
   return {
@@ -112,8 +123,12 @@ describe('combined diff section passes at scale', () => {
     const initial = Array.from({ length: SECTION_COUNT }, (_, index) =>
       makeCountingSection(counter, `combined-branch:file-${index}.ts`)
     )
+    const sectionsRef = { current: initial } as React.RefObject<DiffSection[]>
     const view = renderHook(
-      ({ sections }: { sections: DiffSection[] }) => useCombinedDiffSectionPasses(sections),
+      ({ sections }: { sections: DiffSection[] }) => {
+        sectionsRef.current = sections
+        return useCombinedDiffSectionPasses({ sections, sectionsRef })
+      },
       { initialProps: { sections: initial } }
     )
     const firstRowKeys = view.result.current.rowKeys
@@ -155,8 +170,12 @@ describe('combined diff section passes at scale', () => {
     const sections = Array.from({ length: 4 }, (_, index) =>
       makeCountingSection(counter, `combined-branch:file-${index}.ts`)
     )
+    const sectionsRef = { current: sections } as React.RefObject<DiffSection[]>
     const view = renderHook(
-      ({ rows }: { rows: DiffSection[] }) => useCombinedDiffSectionPasses(rows),
+      ({ rows }: { rows: DiffSection[] }) => {
+        sectionsRef.current = rows
+        return useCombinedDiffSectionPasses({ sections: rows, sectionsRef })
+      },
       { initialProps: { rows: sections } }
     )
     const firstRowKeys = view.result.current.rowKeys

--- a/src/renderer/src/components/editor/combined-diff/resolve-changes/use-combined-diff-section-index-map.ts
+++ b/src/renderer/src/components/editor/combined-diff/resolve-changes/use-combined-diff-section-index-map.ts
@@ -31,7 +31,12 @@ export function useCombinedDiffSectionIndexMap({
       previous !== null &&
       previous.entrySignature === entrySignature &&
       previous.sections.length === sections.length &&
-      sections.every((section, index) => previous.sections[index]?.key === section.key)
+      // Why identity first: a section load rewrites one element of a `prev.map(...)` copy, so most
+      // rows settle on a pointer compare instead of a string compare.
+      sections.every(
+        (section, index) =>
+          previous.sections[index] === section || previous.sections[index]?.key === section.key
+      )
     ) {
       return previous.map
     }

--- a/src/renderer/src/components/editor/combined-diff/resolve-changes/use-combined-diff-section-row-keys.ts
+++ b/src/renderer/src/components/editor/combined-diff/resolve-changes/use-combined-diff-section-row-keys.ts
@@ -1,0 +1,102 @@
+import { useMemo, useRef } from 'react'
+import type { DiffSection } from '../../diff-section-types'
+
+export type CombinedDiffSectionRowKeys = {
+  allSectionsCollapsed: boolean
+  /** Virtualizer item key per section index, pre-built so `getItemKey` is an array read. */
+  rowKeys: readonly string[]
+  /**
+   * Bumps only when a row key actually changes. Scroll-anchor restore gates on this constant-size
+   * token instead of re-joining every section key on every section load.
+   */
+  structureRevision: number
+}
+
+type CombinedDiffSectionRowKeyCache = {
+  collapsedCount: number
+  generation: number
+  sections: readonly DiffSection[]
+  value: CombinedDiffSectionRowKeys
+}
+
+export function buildCombinedDiffSectionRowKey(section: DiffSection, generation: number): string {
+  // Why: contentGeneration is per-section, so a single row's reload remounts only that row.
+  return `${section.key}:${section.collapsed ? 'collapsed' : 'expanded'}:${generation}:${section.contentGeneration ?? 0}`
+}
+
+const EMPTY_ROW_KEYS: CombinedDiffSectionRowKeys = {
+  allSectionsCollapsed: true,
+  rowKeys: [],
+  structureRevision: 0
+}
+
+/**
+ * One incremental pass over `sections` feeding every consumer that needs per-row identity.
+ *
+ * On-demand section loads replace the sections array once per loaded file, so each independent
+ * `sections.map(...).join()` / `every(...)` consumer turns opening a review into O(N^2) work and
+ * O(N^2) transient strings. This scan patches index by index — an unchanged row costs one pointer
+ * compare and no property read — and returns the previous result unchanged when no row key moved.
+ */
+export function useCombinedDiffSectionRowKeys({
+  generation,
+  sections
+}: {
+  generation: number
+  sections: readonly DiffSection[]
+}): CombinedDiffSectionRowKeys {
+  const cacheRef = useRef<CombinedDiffSectionRowKeyCache | null>(null)
+
+  return useMemo(() => {
+    const previous = cacheRef.current
+    if (previous !== null && previous.sections === sections && previous.generation === generation) {
+      return previous.value
+    }
+    if (sections.length === 0) {
+      const value = previous?.value.rowKeys.length === 0 ? previous.value : EMPTY_ROW_KEYS
+      cacheRef.current = { collapsedCount: 0, generation, sections, value }
+      return value
+    }
+
+    // Why: a section load rewrites exactly one element of a `prev.map(...)` copy, so object
+    // identity is a sound (and allocation-free) test for "this row's key cannot have moved".
+    const patchable =
+      previous !== null &&
+      previous.generation === generation &&
+      previous.value.rowKeys.length === sections.length
+    const previousRowKeys = patchable ? previous!.value.rowKeys : null
+    const rowKeys: string[] = Array.from({ length: sections.length })
+    let collapsedCount = patchable ? previous!.collapsedCount : 0
+    let changed = !patchable
+    for (let index = 0; index < sections.length; index += 1) {
+      const section = sections[index]!
+      if (previousRowKeys !== null && previous!.sections[index] === section) {
+        rowKeys[index] = previousRowKeys[index]!
+        continue
+      }
+      if (previousRowKeys !== null && previous!.sections[index]?.collapsed === true) {
+        collapsedCount -= 1
+      }
+      if (section.collapsed) {
+        collapsedCount += 1
+      }
+      const rowKey = buildCombinedDiffSectionRowKey(section, generation)
+      rowKeys[index] = rowKey
+      if (rowKey !== previousRowKeys?.[index]) {
+        changed = true
+      }
+    }
+
+    if (!changed && previous !== null) {
+      cacheRef.current = { collapsedCount, generation, sections, value: previous.value }
+      return previous.value
+    }
+    const value: CombinedDiffSectionRowKeys = {
+      allSectionsCollapsed: collapsedCount === sections.length,
+      rowKeys,
+      structureRevision: (previous?.value.structureRevision ?? 0) + 1
+    }
+    cacheRef.current = { collapsedCount, generation, sections, value }
+    return value
+  }, [generation, sections])
+}

--- a/src/renderer/src/components/editor/combined-diff/resolve-changes/use-combined-diff-section-row-keys.ts
+++ b/src/renderer/src/components/editor/combined-diff/resolve-changes/use-combined-diff-section-row-keys.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react'
+import { useLayoutEffect, useMemo, useRef } from 'react'
 import type { DiffSection } from '../../diff-section-types'
 
 export type CombinedDiffSectionRowKeys = {
@@ -30,6 +30,64 @@ const EMPTY_ROW_KEYS: CombinedDiffSectionRowKeys = {
   structureRevision: 0
 }
 
+function scanCombinedDiffSectionRowKeys(
+  previous: CombinedDiffSectionRowKeyCache | null,
+  generation: number,
+  sections: readonly DiffSection[]
+): CombinedDiffSectionRowKeyCache {
+  if (previous !== null && previous.sections === sections && previous.generation === generation) {
+    return previous
+  }
+  if (sections.length === 0) {
+    const value = previous?.value.rowKeys.length === 0 ? previous.value : EMPTY_ROW_KEYS
+    return { collapsedCount: 0, generation, sections, value }
+  }
+
+  // Why: a section load rewrites exactly one element of a `prev.map(...)` copy, so object
+  // identity is a sound (and allocation-free) test for "this row's key cannot have moved".
+  const patchable =
+    previous !== null &&
+    previous.generation === generation &&
+    previous.value.rowKeys.length === sections.length
+  const previousCache = patchable ? previous! : null
+  const previousRowKeys = previousCache?.value.rowKeys ?? null
+  const rowKeys: string[] = Array.from({ length: sections.length })
+  let collapsedCount = previousCache?.collapsedCount ?? 0
+  let changed = previousCache === null
+  for (let index = 0; index < sections.length; index += 1) {
+    const section = sections[index]!
+    if (previousCache !== null && previousCache.sections[index] === section) {
+      rowKeys[index] = previousRowKeys![index]!
+      continue
+    }
+    if (previousCache?.sections[index]?.collapsed === true) {
+      collapsedCount -= 1
+    }
+    if (section.collapsed) {
+      collapsedCount += 1
+    }
+    const rowKey = buildCombinedDiffSectionRowKey(section, generation)
+    rowKeys[index] = rowKey
+    if (rowKey !== previousRowKeys?.[index]) {
+      changed = true
+    }
+  }
+
+  if (!changed && previousCache !== null) {
+    return { collapsedCount, generation, sections, value: previousCache.value }
+  }
+  return {
+    collapsedCount,
+    generation,
+    sections,
+    value: {
+      allSectionsCollapsed: collapsedCount === sections.length,
+      rowKeys,
+      structureRevision: (previous?.value.structureRevision ?? 0) + 1
+    }
+  }
+}
+
 /**
  * One incremental pass over `sections` feeding every consumer that needs per-row identity.
  *
@@ -46,57 +104,17 @@ export function useCombinedDiffSectionRowKeys({
   sections: readonly DiffSection[]
 }): CombinedDiffSectionRowKeys {
   const cacheRef = useRef<CombinedDiffSectionRowKeyCache | null>(null)
+  const cache = useMemo(
+    () => scanCombinedDiffSectionRowKeys(cacheRef.current, generation, sections),
+    [generation, sections]
+  )
 
-  return useMemo(() => {
-    const previous = cacheRef.current
-    if (previous !== null && previous.sections === sections && previous.generation === generation) {
-      return previous.value
-    }
-    if (sections.length === 0) {
-      const value = previous?.value.rowKeys.length === 0 ? previous.value : EMPTY_ROW_KEYS
-      cacheRef.current = { collapsedCount: 0, generation, sections, value }
-      return value
-    }
+  // Why a committed write and not a render-phase one: React can discard a render, and a cache
+  // seeded from abandoned work would let a later render patch against sections that never existed.
+  // Layout, not passive, so a synchronous re-render inside the same commit still sees this cache.
+  useLayoutEffect(() => {
+    cacheRef.current = cache
+  }, [cache])
 
-    // Why: a section load rewrites exactly one element of a `prev.map(...)` copy, so object
-    // identity is a sound (and allocation-free) test for "this row's key cannot have moved".
-    const patchable =
-      previous !== null &&
-      previous.generation === generation &&
-      previous.value.rowKeys.length === sections.length
-    const previousRowKeys = patchable ? previous!.value.rowKeys : null
-    const rowKeys: string[] = Array.from({ length: sections.length })
-    let collapsedCount = patchable ? previous!.collapsedCount : 0
-    let changed = !patchable
-    for (let index = 0; index < sections.length; index += 1) {
-      const section = sections[index]!
-      if (previousRowKeys !== null && previous!.sections[index] === section) {
-        rowKeys[index] = previousRowKeys[index]!
-        continue
-      }
-      if (previousRowKeys !== null && previous!.sections[index]?.collapsed === true) {
-        collapsedCount -= 1
-      }
-      if (section.collapsed) {
-        collapsedCount += 1
-      }
-      const rowKey = buildCombinedDiffSectionRowKey(section, generation)
-      rowKeys[index] = rowKey
-      if (rowKey !== previousRowKeys?.[index]) {
-        changed = true
-      }
-    }
-
-    if (!changed && previous !== null) {
-      cacheRef.current = { collapsedCount, generation, sections, value: previous.value }
-      return previous.value
-    }
-    const value: CombinedDiffSectionRowKeys = {
-      allSectionsCollapsed: collapsedCount === sections.length,
-      rowKeys,
-      structureRevision: (previous?.value.structureRevision ?? 0) + 1
-    }
-    cacheRef.current = { collapsedCount, generation, sections, value }
-    return value
-  }, [generation, sections])
+  return cache.value
 }

--- a/src/renderer/src/components/editor/combined-diff/scroll-viewport/combined-diff-restore-signal-equivalence.test.tsx
+++ b/src/renderer/src/components/editor/combined-diff/scroll-viewport/combined-diff-restore-signal-equivalence.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+
+import type React from 'react'
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { Virtualizer } from '@tanstack/react-virtual'
+import type { VirtualizedScrollAnchor } from '@/hooks/useVirtualizedScrollAnchor'
+import type { DiffSection } from '../../diff-section-types'
+
+const capturedRestoreSignals: (string | undefined)[] = []
+
+vi.mock('@/hooks/useVirtualizedScrollAnchor', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useVirtualizedScrollAnchor: (options: { restoreSignal?: string }) => {
+      capturedRestoreSignals.push(options.restoreSignal)
+    }
+  }
+})
+
+const { createProgrammaticScrollMarks } = await import('@/hooks/programmatic-scroll-marks')
+const { useCombinedDiffScrollAnchors } = await import('./use-combined-diff-scroll-anchors')
+const { useCombinedDiffSectionRowKeys } =
+  await import('../resolve-changes/use-combined-diff-section-row-keys')
+const { createCombinedDiffSectionIndexMap } =
+  await import('../resolve-changes/combined-diff-section-identity')
+
+/** The signal this PR replaces: one template string per section, joined, on every section load. */
+function legacyRestoreSignal(args: {
+  clampRestoreCount: number
+  generation: number
+  sections: readonly DiffSection[]
+  sideBySide: boolean
+}): string {
+  return `${args.generation}|${args.sideBySide ? 'sbs' : 'inline'}|${args.clampRestoreCount}|${args.sections
+    .map(
+      (section) =>
+        `${section.key}:${section.collapsed ? 'c' : 'e'}:${section.contentGeneration ?? 0}`
+    )
+    .join(',')}`
+}
+
+function section(key: string, overrides: Partial<DiffSection> = {}): DiffSection {
+  return {
+    key,
+    path: key,
+    status: 'modified',
+    originalContent: '',
+    modifiedContent: '',
+    collapsed: false,
+    loading: true,
+    dirty: false,
+    diffResult: null,
+    largeDiffRenderLimit: null,
+    ...overrides
+  }
+}
+
+type Step = {
+  clampRestoreCount: number
+  generation: number
+  sections: DiffSection[]
+  sideBySide: boolean
+}
+
+function changePoints(signals: readonly (string | undefined)[]): number[] {
+  const points: number[] = []
+  for (let index = 1; index < signals.length; index += 1) {
+    if (signals[index] !== signals[index - 1]) {
+      points.push(index)
+    }
+  }
+  return points
+}
+
+function renderSignals(steps: readonly Step[]): (string | undefined)[] {
+  capturedRestoreSignals.length = 0
+  const sectionsRef = { current: steps[0]!.sections } as React.RefObject<DiffSection[]>
+  const view = renderHook(
+    (step: Step) => {
+      sectionsRef.current = step.sections
+      const rowKeys = useCombinedDiffSectionRowKeys({
+        generation: step.generation,
+        sections: step.sections
+      })
+      useCombinedDiffScrollAnchors({
+        clampRestoreCount: step.clampRestoreCount,
+        generation: step.generation,
+        hasDirectScrollInput: () => false,
+        latestDomScrollAnchorRef: { current: null } as React.RefObject<VirtualizedScrollAnchor>,
+        programmaticScrollMarks: createProgrammaticScrollMarks(),
+        scrollAnchorRef: { current: null } as React.RefObject<VirtualizedScrollAnchor>,
+        scrollContainerRef: { current: null } as React.RefObject<HTMLDivElement | null>,
+        scrollOffsetRef: { current: 0 } as React.RefObject<number>,
+        sectionIndexByKey: createCombinedDiffSectionIndexMap(step.sections),
+        sections: step.sections,
+        sectionsRef,
+        sideBySide: step.sideBySide,
+        structureRevision: rowKeys.structureRevision,
+        totalSize: 0,
+        viewStateKey: 'equivalence-test',
+        virtualizer: {
+          getVirtualItems: () => [],
+          isScrolling: false,
+          scrollToIndex: vi.fn()
+        } as unknown as Virtualizer<HTMLDivElement, Element>
+      })
+    },
+    { initialProps: steps[0]! }
+  )
+  // Only the render-phase signal matters; drop React's duplicate renders of the same props.
+  const perStep: (string | undefined)[] = [capturedRestoreSignals.at(-1)]
+  for (const step of steps.slice(1)) {
+    capturedRestoreSignals.length = 0
+    view.rerender(step)
+    perStep.push(capturedRestoreSignals.at(-1))
+  }
+  return perStep
+}
+
+describe('combined diff restore signal', () => {
+  it('changes at exactly the same points as the per-section join it replaces', () => {
+    const base = [
+      section('a.ts'),
+      section('b.ts'),
+      section('c.ts'),
+      section('d.ts'),
+      section('e.ts')
+    ]
+    const loadedC = base.slice()
+    loadedC[2] = section('c.ts', { loading: false })
+    const collapsedB = loadedC.slice()
+    collapsedB[1] = section('b.ts', { collapsed: true })
+    const reloadedC = collapsedB.slice()
+    reloadedC[2] = section('c.ts', { loading: false, contentGeneration: 1 })
+    const reordered = [reloadedC[0]!, reloadedC[2]!, reloadedC[1]!, reloadedC[3]!, reloadedC[4]!]
+    const removed = reordered.slice(0, 4)
+
+    const steps: Step[] = [
+      { clampRestoreCount: 0, generation: 1, sections: base, sideBySide: false },
+      // A section load.
+      { clampRestoreCount: 0, generation: 1, sections: loadedC, sideBySide: false },
+      // A no-op commit: fresh array, identical elements.
+      { clampRestoreCount: 0, generation: 1, sections: loadedC.slice(), sideBySide: false },
+      // A collapse toggle.
+      { clampRestoreCount: 0, generation: 1, sections: collapsedB, sideBySide: false },
+      // A refetch that really changed content (contentGeneration bump).
+      { clampRestoreCount: 0, generation: 1, sections: reloadedC, sideBySide: false },
+      // A reorder that keeps every key.
+      { clampRestoreCount: 0, generation: 1, sections: reordered, sideBySide: false },
+      // A removal.
+      { clampRestoreCount: 0, generation: 1, sections: removed, sideBySide: false },
+      // Inline -> side-by-side.
+      { clampRestoreCount: 0, generation: 1, sections: removed, sideBySide: true },
+      // A browser clamp re-pin.
+      { clampRestoreCount: 1, generation: 1, sections: removed, sideBySide: true },
+      // A full entry-set rebuild.
+      { clampRestoreCount: 1, generation: 2, sections: removed, sideBySide: true }
+    ]
+
+    const legacy = steps.map((step) => legacyRestoreSignal(step))
+    expect(changePoints(renderSignals(steps))).toEqual(changePoints(legacy))
+  })
+
+  it('holds the signal steady through a 500-section progressive load and lands on the same rows', () => {
+    const count = 500
+    let sections = Array.from({ length: count }, (_, index) => section(`file-${index}.ts`))
+    const steps: Step[] = [{ clampRestoreCount: 0, generation: 1, sections, sideBySide: false }]
+    for (let index = 0; index < count; index += 1) {
+      const next = sections.slice()
+      next[index] = section(`file-${index}.ts`, { loading: false })
+      sections = next
+      steps.push({ clampRestoreCount: 0, generation: 1, sections, sideBySide: false })
+    }
+
+    const legacy = steps.map((step) => legacyRestoreSignal(step))
+    expect(changePoints(renderSignals(steps))).toEqual(changePoints(legacy))
+    // Every anchor key still resolves to the index a freshly built map would give it.
+    expect([...createCombinedDiffSectionIndexMap(sections)]).toEqual([
+      ...createCombinedDiffSectionIndexMap(steps.at(-1)!.sections)
+    ])
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff/scroll-viewport/use-combined-diff-scroll-anchors.ts
+++ b/src/renderer/src/components/editor/combined-diff/scroll-viewport/use-combined-diff-scroll-anchors.ts
@@ -29,9 +29,11 @@ export function useCombinedDiffScrollAnchors({
   scrollAnchorRef,
   scrollContainerRef,
   scrollOffsetRef,
+  sectionIndexByKey,
   sections,
   sectionsRef,
   sideBySide,
+  structureRevision,
   totalSize,
   viewStateKey,
   virtualizer
@@ -44,9 +46,11 @@ export function useCombinedDiffScrollAnchors({
   scrollAnchorRef: React.RefObject<VirtualizedScrollAnchor>
   scrollContainerRef: React.RefObject<HTMLDivElement | null>
   scrollOffsetRef: React.RefObject<number>
+  sectionIndexByKey: ReadonlyMap<string, number>
   sections: DiffSection[]
   sectionsRef: React.RefObject<DiffSection[]>
   sideBySide: boolean
+  structureRevision: number
   totalSize: number
   viewStateKey: string
   virtualizer: Virtualizer<HTMLDivElement, Element>
@@ -138,13 +142,10 @@ export function useCombinedDiffScrollAnchors({
     () =>
       // Why: a single-section reload drops that row's measured height, so it shifts rows
       // below it — still a structural change even though `generation` no longer moves.
-      `${generation}|${sideBySide ? 'sbs' : 'inline'}|${clampRestoreCount}|${sections
-        .map(
-          (section) =>
-            `${section.key}:${section.collapsed ? 'c' : 'e'}:${section.contentGeneration ?? 0}`
-        )
-        .join(',')}`,
-    [clampRestoreCount, generation, sections, sideBySide]
+      // structureRevision moves iff a section key/collapsed/contentGeneration moved, so this is
+      // the same signal the per-section join produced without rebuilding it once per load.
+      `${generation}|${sideBySide ? 'sbs' : 'inline'}|${clampRestoreCount}|${structureRevision}`,
+    [clampRestoreCount, generation, sideBySide, structureRevision]
   )
 
   useVirtualizedScrollAnchor({
@@ -157,6 +158,7 @@ export function useCombinedDiffScrollAnchors({
     recordAnchorOnCleanup: false,
     recordAnchorOnScroll: false,
     restoreSignal: combinedDiffRestoreSignal,
+    rowIndexByKey: sectionIndexByKey,
     rows: sections,
     scrollElementRef: scrollContainerRef,
     shouldSkipRestore: hasDirectScrollInput,

--- a/src/renderer/src/components/editor/combined-diff/scroll-viewport/use-combined-diff-virtualizer.ts
+++ b/src/renderer/src/components/editor/combined-diff/scroll-viewport/use-combined-diff-virtualizer.ts
@@ -11,6 +11,7 @@ export function useCombinedDiffVirtualizer({
   generation,
   programmaticScrollMarks,
   renderedIndicesRef,
+  rowKeys,
   scrollContainerRef,
   scrollOffsetRef,
   sectionHeights,
@@ -20,6 +21,7 @@ export function useCombinedDiffVirtualizer({
   generation: number
   programmaticScrollMarks: ProgrammaticScrollMarks
   renderedIndicesRef: React.RefObject<Set<number>>
+  rowKeys: readonly string[]
   scrollContainerRef: React.RefObject<HTMLDivElement | null>
   scrollOffsetRef: React.RefObject<number>
   sectionHeights: Record<number, number>
@@ -48,14 +50,9 @@ export function useCombinedDiffVirtualizer({
       }
       elementScroll(offset, options, instance)
     },
-    getItemKey: (index) => {
-      const section = sections[index]
-      if (!section) {
-        return `${index}:${generation}`
-      }
-      // Why: contentGeneration is per-section, so a single row's reload remounts only that row.
-      return `${section.key}:${section.collapsed ? 'collapsed' : 'expanded'}:${generation}:${section.contentGeneration ?? 0}`
-    }
+    // Why: TanStack re-runs getItemKey for every index on each measurement pass, so the key is
+    // pre-built once per section change instead of a template string per index per pass.
+    getItemKey: (index) => rowKeys[index] ?? `${index}:${generation}`
   })
 
   // Why: keep render pure (React Doctor); retrySection still needs the on-screen set without the virtualizer as a dep.

--- a/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-body.tsx
+++ b/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-body.tsx
@@ -41,11 +41,11 @@ export function PRFilesCombinedDiffBody({
   openFilesOnGitHub,
   renderViewedCheckbox,
   handleAddLineComment,
-  fileByPath,
   setSectionHeights,
   setSections,
   modifiedEditorsRef,
-  handleSectionSaveRef
+  handleSectionSaveRef,
+  getCommentableLineNumbers
 }: {
   files: GitHubPRFile[]
   repoPath: string
@@ -78,7 +78,8 @@ export function PRFilesCombinedDiffBody({
     section: DiffSection,
     args: { lineNumber: number; startLine?: number; body: string }
   ) => Promise<boolean>
-  fileByPath: Map<string, GitHubPRFile>
+  // Why: a stable callback, not an inline arrow — this re-keys every mounted row's comment decorator.
+  getCommentableLineNumbers: (section: DiffSection) => readonly number[] | undefined
   setSectionHeights: React.Dispatch<React.SetStateAction<Record<number, number>>>
   setSections: React.Dispatch<React.SetStateAction<DiffSection[]>>
   modifiedEditorsRef: React.RefObject<Map<number, monacoEditor.IStandaloneCodeEditor>>
@@ -150,9 +151,7 @@ export function PRFilesCombinedDiffBody({
                       'auto.components.GitHubItemDialog.86d84a17ca',
                       'Add a review comment'
                     )}
-                    getCommentableLineNumbers={(section) =>
-                      fileByPath.get(section.path)?.reviewCommentLineNumbers
-                    }
+                    getCommentableLineNumbers={getCommentableLineNumbers}
                     setSectionHeights={setSectionHeights}
                     setSections={setSections}
                     modifiedEditorsRef={modifiedEditorsRef}

--- a/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-viewer.tsx
+++ b/src/renderer/src/components/github-item-dialog/inspect-pull-request/pr-files-combined-diff-viewer.tsx
@@ -119,6 +119,12 @@ function PRFilesCombinedDiffSections({
     }))
   )
   const fileByPath = useMemo(() => new Map(files.map((file) => [file.path, file])), [files])
+  // Why: an inline arrow here re-keys every mounted row's comment decorator on every render.
+  const getCommentableLineNumbers = useCallback(
+    (section: DiffSection): readonly number[] | undefined =>
+      fileByPath.get(section.path)?.reviewCommentLineNumbers,
+    [fileByPath]
+  )
   const inlineReviewComments = useMemo<DecoratedDiffComment[]>(
     () =>
       comments.flatMap((comment): DecoratedDiffComment[] => {
@@ -356,7 +362,7 @@ function PRFilesCombinedDiffSections({
       openFilesOnGitHub={openFilesOnGitHub}
       renderViewedCheckbox={renderViewedCheckbox}
       handleAddLineComment={handleAddLineComment}
-      fileByPath={fileByPath}
+      getCommentableLineNumbers={getCommentableLineNumbers}
       setSectionHeights={setSectionHeights}
       setSections={setSections}
       modifiedEditorsRef={modifiedEditorsRef}

--- a/src/renderer/src/components/pull-request-page/files/combined-diff-viewer.tsx
+++ b/src/renderer/src/components/pull-request-page/files/combined-diff-viewer.tsx
@@ -71,6 +71,12 @@ export function PRFilesCombinedDiffViewer({
     [diffEntrySignature]
   )
   const fileByPath = useMemo(() => new Map(files.map((file) => [file.path, file])), [files])
+  // Why: an inline arrow here re-keys every mounted row's comment decorator on every render.
+  const getCommentableLineNumbers = useCallback(
+    (section: DiffSection): readonly number[] | undefined =>
+      fileByPath.get(section.path)?.reviewCommentLineNumbers,
+    [fileByPath]
+  )
   const inlineReviewComments = useMemo(
     () => buildInlineReviewComments(comments, repoId, prNumber),
     [comments, prNumber, repoId]
@@ -358,9 +364,7 @@ export function PRFilesCombinedDiffViewer({
                     onAddLineComment={handleAddLineComment}
                     addLineCommentLabel="Comment"
                     addLineCommentPlaceholder="Add a review comment"
-                    getCommentableLineNumbers={(current) =>
-                      fileByPath.get(current.path)?.reviewCommentLineNumbers
-                    }
+                    getCommentableLineNumbers={getCommentableLineNumbers}
                     setSectionHeights={setSectionHeights}
                     setSections={setSections}
                     modifiedEditorsRef={modifiedEditorsRef}

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.marks-restore-signal.test.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.marks-restore-signal.test.ts
@@ -536,4 +536,48 @@ describe('useVirtualizedScrollAnchor with marks + restoreSignal', () => {
     emitScroll(3_500)
     expect(el.scrollTop).toBe(4_000)
   })
+
+  it('lands a caller-supplied row index map on the same row as the internally built one', async () => {
+    const runRestore = async (rowIndexByKey?: ReadonlyMap<string, number>) => {
+      // Why: each run needs its own hook module, or the second run inherits the first harness's refs.
+      vi.resetModules()
+      const { harness, useVirtualizedScrollAnchor } = await loadHook()
+      const { el } = createScrollElement({ rowElements: [], scrollTop: 0 })
+      const anchorRef = { current: { key: 'row-1', offset: 40, scrollTop: 0 } }
+      let getRowKeyCalls = 0
+
+      harness.beginRender()
+      // oxlint-disable-next-line react-hooks/rules-of-hooks -- test harness mocks React's hook dispatcher directly.
+      useVirtualizedScrollAnchor({
+        anchorRef,
+        getRowKey: (row: string) => {
+          getRowKeyCalls += 1
+          return row
+        },
+        programmaticScrollMarks: createProgrammaticScrollMarks(),
+        recordAnchorOnScroll: false,
+        restoreSignal: 'signal-a',
+        rowIndexByKey,
+        rows: ['row-0', 'row-1'],
+        scrollElementRef: { current: el },
+        scrollOffsetRef: { current: 0 },
+        totalSize: 30_000,
+        virtualizer: virtualizerWithRow1()
+      } as never)
+      harness.effects[1]?.effect()
+      return { getRowKeyCalls, scrollTop: el.scrollTop }
+    }
+
+    const builtInternally = await runRestore()
+    const supplied = await runRestore(
+      new Map([
+        ['row-0', 0],
+        ['row-1', 1]
+      ])
+    )
+
+    expect(supplied.scrollTop).toBe(builtInternally.scrollTop)
+    expect(builtInternally.getRowKeyCalls).toBeGreaterThan(0)
+    expect(supplied.getRowKeyCalls).toBe(0)
+  })
 })

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
@@ -50,6 +50,10 @@ type UseVirtualizedScrollAnchorOptions<
   // anchor recorded under the old key follows its own row instead of pinning a
   // neighbour. Omitted by callers whose row keys are stable.
   rekeyedRowKeys?: ReadonlyMap<string, string>
+  // Why: callers that already maintain an identity-stable key -> index map (large diff reviews
+  // rebuild `rows` once per loaded file) pass it in so this hook does not rebuild a second Map
+  // on every one of those renders. Must agree with `getRowKey` over `rows`.
+  rowIndexByKey?: ReadonlyMap<string, number>
   // Why: when provided, anchor restore runs only when this value changes
   // (structural row changes) or while a prior restore is still converging —
   // not on every totalSize/isScrolling tick. Measurement-driven shifts are the
@@ -86,6 +90,7 @@ export function useVirtualizedScrollAnchor<
   recordAnchorOnScroll = true,
   rekeyedRowKeys,
   restoreSignal,
+  rowIndexByKey: providedRowIndexByKey,
   rows,
   scrollElementRef,
   scrollOffsetRef,
@@ -93,13 +98,16 @@ export function useVirtualizedScrollAnchor<
   totalSize,
   virtualizer
 }: UseVirtualizedScrollAnchorOptions<TRow, TScrollElement, TItemElement>): void {
-  const rowIndexByKey = useMemo(() => {
+  const rowIndexByKey = useMemo<ReadonlyMap<string, number>>(() => {
+    if (providedRowIndexByKey) {
+      return providedRowIndexByKey
+    }
     const indexByKey = new Map<string, number>()
     rows.forEach((row, index) => {
       indexByKey.set(getRowKey(row), index)
     })
     return indexByKey
-  }, [getRowKey, rows])
+  }, [getRowKey, providedRowIndexByKey, rows])
 
   const recordVirtualScrollAnchor = useCallback(
     (scrollTop: number) => {


### PR DESCRIPTION
## ELI5

Opening a big review loads files one at a time. Every time one file's diff arrived, six different parts of the screen threw away everything they knew about *all* the files and worked it out again from scratch — rebuilding a giant text label listing every file, rebuilding a lookup table, re-checking every row. With 500 files that is 500 files' worth of work, 500 times over. Now each of those parts only looks at the one row that actually changed and keeps the rest as-is. Separately, the file-tree panel was building its whole tree even while it was collapsed and invisible, and every mounted diff row was re-joining a list of thousands of line numbers into a string on every render. Same pixels, same scroll position, same comments — a lot less work.

## What was happening

`loadSectionNow` commits `setSections` with `prev.map(...)` per loaded file, so `sections` gets a new identity once per section load. Six consumers each did a full O(N) pass on that new identity:

1. `use-combined-diff-scroll-anchors.ts` — `combinedDiffRestoreSignal` built one template string per section and joined all N. On a first load `contentGeneration` does not move, so it recomputed to a **byte-identical** string every time.
2. `useVirtualizedScrollAnchor.ts` — `rowIndexByKey` rebuilt a full `Map`, duplicating the `sectionIndexByKey` the file tree already maintains.
3. `use-combined-diff-tree-navigation.ts` (`viewedSectionKeys`) — incremental already, but still did two `isCombinedDiffSectionViewed` calls plus a key compare per row per load.
4. `use-combined-diff-section-index-map.ts` — an N-long `sections.every(...)` key-string comparison guard.
5. `CombinedDiffViewer.tsx` — `allSectionsCollapsed = sections.every(...)`.
6. TanStack `getMeasurements` re-ran `getItemKey(i)` — a template string — for every index on each `itemSizeCache` bump.

Fixes:

- New `useCombinedDiffSectionRowKeys`: **one** incremental scan per `sections` identity producing the pre-built virtualizer row keys, a `structureRevision` token, and the all-collapsed flag. Unchanged rows settle on a pointer compare (no property read, no string build); the previous result object is returned unchanged when nothing moved. The scan is a pure function of `(previous cache, generation, sections)` and the cache is written in a **layout effect**, not during render — the same committed-write pattern `useCombinedDiffSectionIndexMap` uses, so a discarded render can never seed a cache a later render patches against.
- `getItemKey` is now an array read. The restore signal is `generation|mode|clamp|structureRevision` — constant size.
- `useVirtualizedScrollAnchor` takes an optional `rowIndexByKey`; the combined-diff viewer hoists `useCombinedDiffSectionIndexMap` and hands the same map to both the tree and the anchor, so the second `Map` is gone entirely.
- `viewedSectionKeys` and the index-map guard get an object-identity fast path.
- **C**: `commentableLineKey` is `useMemo`'d on `[commentableLineNumbers]`, and both PR call sites (`pull-request-page/files/combined-diff-viewer.tsx`, `github-item-dialog/.../pr-files-combined-diff-body.tsx`) now pass a stable `useCallback` instead of a fresh inline arrow.
- **D**: every memo in `combined-diff-file-tree.tsx` short-circuits to a shared empty constant while `collapsed`, so the tree is not filtered, grouped or flattened behind a hidden panel. Filter/query/collapsed-directory state stays in the component, so expanding restores exactly what it did before.

## Measurement

All at N=500 sections, one full progressive load (one `setSections` per file).

| Metric | Before | After |
| --- | --- | --- |
| `section.key` reads across the load (real hooks, counting getters) | 2,001,000 | 3,000 |
| `section.key` reads at mount | 2,500 | 1,000 |
| Transient row-key/signal strings allocated | 750,500 | 1,499 |
| Bytes of those transient strings | 118.9 MB | 0.18 MB |
| Wall clock for the derived-value work alone | 206.4 ms | 3.9 ms |
| `Map` entry insertions (key → index) | 250,000 | 500 |
| Collapsed file tree: entry-path reads per render (300 files) | 1,490 | 0 |
| `commentableLineKey` joins per 100 renders of one mounted row | 100 | 1 |
| Retained bytes in the two view-state caches after 10 open/close cycles (60 files, 30 KB/side) | 70.31 MB | 70.31 MB (unchanged — see below) |

The 2,001,000 → 3,000 figure is asserted by `combined-diff-section-scaling.test.tsx`, which fails at `expected 2001000 to be less than or equal to 4000` when the four consumer files are reverted to `main`. The collapsed-tree test fails at `expected 1490 to be +0` and the join test at `expected 100 to be 1` against their pre-fix files.

## Negative user-facing trade-offs

**None taken.** One sub-fix from the brief was **dropped** rather than shipped with a trade-off:

- **Sweeping `combinedDiffViewStateCache` / `prFilesDiffViewStateCache` in `disposeClosedEditorTabs`.** The premise ("reopening a closed tab already rebuilds sections") does not hold. Combined-diff tab ids are deterministic (`open-combined-diff.ts` builds `${worktreeId}::all-diffs::uncommitted`), so a close-then-reopen hits the **same** `viewStateKey`; `use-combined-diff-view-restore.ts` finds the cached entry, matches `entrySignature`, and restores the loaded bodies, section heights, `loadedIndices`, side-by-side mode and scroll offset with no refetch. The PR-page cache is keyed by repo + PR + source host and behaves the same. Deleting on close would make every reopened review re-fetch every diff — exactly the "diff appears later" the zero-trade-off bar forbids. The 70 MB is real, but reclaiming it is a product decision about restore-on-reopen, not a free win, so it is out of scope here. A new test in `use-combined-diff-view-restore.test.tsx` pins that reopen-restores behaviour (and runs `disposeClosedEditorTabs` first) so the constraint is explicit in CI. `combinedDiffScrollTopCache` / `combinedDiffScrollAnchorCache` were left alone for the same reason — deleting them loses the restored scroll position, and they hold a number and one anchor each.

Everything else is byte-identical output: same virtualizer item keys, same restore decisions, same `commentableLineSet` value-keying (a fresh-but-equal array on refresh still re-keys — covered by a test), same tree rows once expanded.

## Risk & verification

- `pnpm tc` clean; `pnpm run check:code-quality:changed` clean; `pnpm run check:react-doctor:changed` and `pnpm run lint:react-doctor:changed` clean (0 issues).
- Every existing test in the touched areas passes: `src/renderer/src/hooks/useVirtualizedScrollAnchor.*`, all of `src/renderer/src/components/editor`, `diff-comments`, `pull-request-page`, `github-item-dialog`, `sidebar` (the other `useVirtualizedScrollAnchor` caller) — 504 files, 3,874 tests.
- New tests:
  - `combined-diff-section-scaling.test.tsx` — N=500 progressive load through the real hooks, counting `section.key` reads; also asserts the index map keeps its identity, row-key strings are reused for untouched rows, and an unchanged rerender returns the identical result object.
  - `combined-diff-restore-signal-equivalence.test.tsx` — the new signal changes at **exactly** the same points as the per-section join it replaces, across load / no-op commit / collapse / content refetch / reorder / removal / side-by-side / clamp / generation bump, and across a 500-section progressive load; anchor keys still resolve to the same indices.
  - `useVirtualizedScrollAnchor.marks-restore-signal.test.ts` — a supplied `rowIndexByKey` lands the restore on the same `scrollTop` as the internally built map, with zero `getRowKey` calls.
  - `combined-diff-file-tree-collapsed-work.test.tsx` — zero entry reads while collapsed, full tree on expand.
  - `useDiffCommentDecorator.commentable-lines.test.tsx` — one join per 100 renders for a stable array; a fresh-but-equal array still re-keys and keeps the add-button overlay live.
  - `use-combined-diff-view-restore.test.tsx` — reopening a closed combined-diff tab restores from the view-state cache.
- Riskiest part is the restore-signal swap (a wrong signal would drop or double a scroll restore). It is guarded by the change-point equivalence test above; the signal is still a string compared only against its own previous value, and `structureRevision` moves iff a section's key / collapsed / contentGeneration / count moves — the exact inputs the old join encoded.
- `useVirtualizedScrollAnchor`'s new option is optional; the sidebar worktree list is unchanged.
