### PR TITLE
perf(terminal): cut per-pane store listeners from 48 to 17

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-timers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-timers.ts
@@ -1,0 +1,49 @@
+/**
+ * Pending cold-park recheck timers, keyed by tab and reconciled by deadline.
+ *
+ * Why reconcile instead of clear-and-re-arm: the cold-park effect must re-run on
+ * every tab-model write, because watcher coverage is re-derived from store and
+ * registry state the park key cannot encode (terminal-cold-park-verdict-loop
+ * pins what breaks when it stops). But every recheck deadline is absolute —
+ * hiddenSince plus a fixed policy window, a cool-down, or a pin expiry — so a
+ * re-run that recomputes the same deadline was cancelling a timer only to re-arm
+ * it for the same instant. A background title flood paid two timer syscalls per
+ * hidden tab per write for no scheduling change.
+ */
+
+export type TerminalTabColdParkRecheckTimer = { timerId: number; deadlineMs: number }
+export type TerminalTabColdParkRecheckTimers = Map<string, TerminalTabColdParkRecheckTimer>
+
+export function clearTerminalTabColdParkRecheckTimers(
+  timers: TerminalTabColdParkRecheckTimers
+): void {
+  for (const timer of timers.values()) {
+    window.clearTimeout(timer.timerId)
+  }
+  timers.clear()
+}
+
+/** Arms, holds, or cancels one timer per tab so only moved deadlines reschedule. */
+export function reconcileTerminalTabColdParkRecheckTimers(args: {
+  timers: TerminalTabColdParkRecheckTimers
+  deadlineMsByTabId: ReadonlyMap<string, number>
+  nowMs: number
+  onDeadline: () => void
+}): void {
+  for (const [tabId, timer] of args.timers) {
+    if (args.deadlineMsByTabId.get(tabId) !== timer.deadlineMs) {
+      window.clearTimeout(timer.timerId)
+      args.timers.delete(tabId)
+    }
+  }
+  for (const [tabId, deadlineMs] of args.deadlineMsByTabId) {
+    if (args.timers.has(tabId)) {
+      continue
+    }
+    const timerId = window.setTimeout(() => {
+      args.timers.delete(tabId)
+      args.onDeadline()
+    }, deadlineMs - args.nowMs)
+    args.timers.set(tabId, { timerId, deadlineMs })
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-timer-rearm.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-timer-rearm.test.tsx
@@ -1,0 +1,190 @@
+/** @vitest-environment happy-dom */
+/**
+ * The cold-park effect must keep re-running on every tab-model write — watcher
+ * coverage is re-derived from store and registry state the park key cannot
+ * encode, and terminal-cold-park-verdict-loop pins what happens when it stops.
+ *
+ * What it must NOT do is cancel and re-arm every pending recheck timer on each
+ * run. Recheck deadlines are absolute, so a title-only write recomputes the same
+ * instant and the re-arm changed nothing but the syscall count. This pins both
+ * halves: no timer churn under a title flood, and an unchanged park instant.
+ */
+import { act, useEffect, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const park = vi.hoisted(() => ({
+  worktreeId: 'repo::/wt-park-timers',
+  /** Counts cold-park effect runs; the effect reads the overrides exactly once. */
+  effectRuns: 0
+}))
+
+vi.mock('../../store', async () => {
+  const { create } = await import('zustand')
+  const useAppStore = create(() => ({
+    pendingStartupByTabId: {} as Record<string, unknown>,
+    ptyIdsByTabId: {} as Record<string, string[]>,
+    runtimeStatusByEnvironmentId: new Map<string, unknown>(),
+    settings: {} as Record<string, unknown>,
+    terminalLayoutsByTabId: {} as Record<string, unknown>,
+    runtimePaneTitlesByTabId: {} as Record<string, unknown>,
+    sleepingAgentSessionsByPaneKey: {} as Record<string, unknown>,
+    tabsByWorktree: {} as Record<string, TerminalTab[]>
+  }))
+  return { useAppStore }
+})
+
+vi.mock('./terminal-parked-tab-watchers', () => ({
+  canWatcherCoverParkedTerminalTab: () => true,
+  disposeParkedTerminalWatchersForWorktree: () => {},
+  resolveParkedTerminalPaneCandidates: () => [],
+  syncParkedTerminalTabWatchers: () => {}
+}))
+
+/** A 60s hysteresis keeps every hidden tab holding a pending recheck timer. */
+const COLD_PARK_DELAY_MS = 60_000
+
+vi.mock('./terminal-parking-e2e-overrides', () => ({
+  getTerminalParkingPolicyOverrides: () => {
+    park.effectRuns += 1
+    return { coldParkDelayMs: 60_000, hotRetainMs: 60_000 }
+  }
+}))
+
+import { useAppStore } from '../../store'
+import { useTerminalTabColdParking } from './use-terminal-tab-cold-parking'
+
+const TAB_IDS = ['tab-a', 'tab-b', 'tab-c', 'tab-d', 'tab-e'] as const
+const EMPTY_ASSIGNMENTS = new Map<string, { groupId: string; isActiveInGroup: boolean }>()
+const EMPTY_PORTALS: never[] = []
+const TITLE_FLOOD_WRITES = 40
+const TICK_MS = 10_000
+
+type ParkingStoreState = { tabsByWorktree: Record<string, TerminalTab[]> }
+
+const parkingStore = useAppStore as unknown as {
+  setState: (partial: (state: ParkingStoreState) => Partial<ParkingStoreState>) => void
+}
+
+function terminalTab(id: string): TerminalTab {
+  return { id, ptyId: `${park.worktreeId}@@session-${id}`, title: id } as TerminalTab
+}
+
+/** A runtime-title publication: re-mints tabsByWorktree, changes no park input. */
+function publishTitle(revision: number): void {
+  parkingStore.setState((state) => ({
+    tabsByWorktree: {
+      ...state.tabsByWorktree,
+      [park.worktreeId]: (state.tabsByWorktree[park.worktreeId] ?? []).map((tab) => ({
+        ...tab,
+        title: `${tab.id}-${revision}`
+      }))
+    }
+  }))
+}
+
+let latestParkedTabIds: ReadonlySet<string> = new Set()
+
+function ParkingHost({ writes }: { writes: number }): null {
+  const terminalTabs = useAppStore(
+    (state) => (state as ParkingStoreState).tabsByWorktree[park.worktreeId]
+  ) as TerminalTab[]
+  latestParkedTabIds = useTerminalTabColdParking({
+    worktreeId: park.worktreeId,
+    terminalTabs,
+    assignments: EMPTY_ASSIGNMENTS,
+    isWorktreeActive: false,
+    activeTerminalTabId: null,
+    coldParkTerminalPanes: false,
+    shouldMeasureHiddenWorktree: false,
+    activityTerminalPortals: EMPTY_PORTALS,
+    activationDeferredMountTabIds: null
+  })
+  const [written, setWritten] = useState(0)
+  useEffect(() => {
+    if (written >= writes) {
+      return
+    }
+    publishTitle(written)
+    setWritten((current) => current + 1)
+  }, [writes, written])
+  return null
+}
+
+let container: HTMLDivElement
+let root: Root | undefined
+
+beforeEach(() => {
+  park.effectRuns = 0
+  latestParkedTabIds = new Set()
+  parkingStore.setState(() => ({
+    tabsByWorktree: { [park.worktreeId]: TAB_IDS.map(terminalTab) }
+  }))
+  container = document.createElement('div')
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  root = undefined
+  container.remove()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+/** Advances the clock in fixed ticks and reports the first tick that parks. */
+function firstParkedElapsedMs(options: { publishTitles: boolean }): number {
+  vi.useFakeTimers()
+  vi.setSystemTime(0)
+  root = createRoot(container)
+  act(() => root?.render(<ParkingHost writes={0} />))
+  expect(latestParkedTabIds.size).toBe(0)
+
+  for (let tick = 1; tick <= 12; tick += 1) {
+    // advanceTimersByTime moves Date.now() and fires due timers together.
+    act(() => vi.advanceTimersByTime(TICK_MS))
+    // Both runs re-render every tick; only the flooded one publishes titles.
+    act(() => root?.render(<ParkingHost writes={options.publishTitles ? tick : 0} />))
+    if (latestParkedTabIds.size > 0) {
+      return tick * TICK_MS
+    }
+  }
+  throw new Error('never parked')
+}
+
+describe('cold-park recheck timers under a background title flood', () => {
+  it('re-arms no park timer for tab-model writes that move no deadline', () => {
+    root = createRoot(container)
+    act(() => root?.render(<ParkingHost writes={0} />))
+
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
+    act(() => root?.render(<ParkingHost writes={TITLE_FLOOD_WRITES} />))
+
+    // The effect still runs per write — that is the coverage wakeup, and dropping
+    // it regresses terminal-cold-park-verdict-loop.
+    expect(park.effectRuns).toBeGreaterThanOrEqual(TITLE_FLOOD_WRITES)
+    // Before: one clearTimeout and one setTimeout per hidden tab per run.
+    expect(setTimeoutSpy.mock.calls.length).toBe(0)
+    expect(clearTimeoutSpy.mock.calls.length).toBe(0)
+  })
+
+  it('parks at the same instant with and without a title flood', () => {
+    const quiet = firstParkedElapsedMs({ publishTitles: false })
+    act(() => root?.unmount())
+    root = undefined
+    vi.useRealTimers()
+    park.effectRuns = 0
+    latestParkedTabIds = new Set()
+    parkingStore.setState(() => ({
+      tabsByWorktree: { [park.worktreeId]: TAB_IDS.map(terminalTab) }
+    }))
+
+    const flooded = firstParkedElapsedMs({ publishTitles: true })
+
+    expect(flooded).toBe(quiet)
+    expect(quiet).toBe(COLD_PARK_DELAY_MS)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-pane-hook-order-parity.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-hook-order-parity.test.ts
@@ -6,11 +6,13 @@ import ts from 'typescript-api'
 import { describe, expect, it } from 'vitest'
 
 const TERMINAL_PANE_HOOK_SOURCE_PATTERN =
-  /^(?:TerminalPane\.tsx|use-terminal-pane-(?:chat-state|close-actions|context-actions|controller|foundation|global-listeners|layout-bindings|layout-persistence|lifecycle-stage|mobile-actions|paste-listeners|process-exit-actions|projection|reconciliation|startup-actions|store-bindings|title-effects|title-state)\.ts)$/
+  /^(?:TerminalPane\.tsx|use-terminal-pane-(?:chat-state|close-actions|context-actions|controller|foundation|global-listeners|layout-bindings|layout-persistence|lifecycle-stage|mobile-actions|paste-listeners|process-exit-actions|projection|reconciliation|startup-actions|store-actions|store-bindings|title-effects|title-state)\.ts)$/
 // Rebased onto main after the workbench surface-per-workspace and deferred
-// split-cwd changes; the pane session-ID projection adds one render hook (230 hooks).
+// split-cwd changes; the pane session-ID projection added one render hook (230 hooks).
+// Then 27 stable-action `useAppStore` subscriptions folded into four
+// `useTerminalPaneStoreActions()` calls, each one `useMemo` (204 hooks, 8 useMemo).
 const PRE_REFACTOR_HOOK_ORDER_SHA256 =
-  '77adcf8272ddc6f903920f12b2b652ec26c570987f452076ae6460c67d3741f3'
+  'b541d26ff66a1db0b7150ced2a4340c5cf025aba79a651a2ad8d2fa68d403ae3'
 
 const sourceFiles = readdirSync(__dirname)
   .filter((name) => TERMINAL_PANE_HOOK_SOURCE_PATTERN.test(name))
@@ -75,15 +77,15 @@ function readFlattenedHookOrder(): string[] {
 describe('TerminalPane refactor hook parity', () => {
   it('preserves the recursively flattened render hook order', () => {
     const hooks = readFlattenedHookOrder()
-    expect(hooks).toHaveLength(230)
-    expect(hooks.filter((hook) => hook === 'useMemo')).toHaveLength(4)
+    expect(hooks).toHaveLength(204)
+    expect(hooks.filter((hook) => hook === 'useMemo')).toHaveLength(8)
     expect(createHash('sha256').update(hooks.join('\n')).digest('hex')).toBe(
       PRE_REFACTOR_HOOK_ORDER_SHA256
     )
   })
 
   it('aggregates every extracted hook stage', () => {
-    expect(sourceFiles).toHaveLength(19)
+    expect(sourceFiles).toHaveLength(20)
     expect(sourceFiles).toContain('TerminalPane.tsx')
     expect(sourceFiles).toContain('use-terminal-pane-controller.ts')
   })

--- a/src/renderer/src/components/terminal-pane/terminal-pane-host-state-memo.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-host-state-memo.test.ts
@@ -1,0 +1,130 @@
+/**
+ * `useShallow` suppresses the render, not the selector: before the memo, every
+ * store publication re-resolved the execution host and allocated a fresh 7-key
+ * object for every mounted TerminalPane, then threw it away.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ConnectionContext from '@/lib/connection-context'
+import type { AppState } from '@/store/types'
+import {
+  resetTerminalPaneHostStateMemoForTests,
+  selectTerminalPaneHostState
+} from './terminal-pane-host-state'
+
+const connectionIdCalls = vi.hoisted(() => ({ count: 0 }))
+
+vi.mock('@/lib/connection-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof ConnectionContext>()
+  return {
+    ...actual,
+    getConnectionIdFromState: (state: AppState, worktreeId: string | null) => {
+      connectionIdCalls.count += 1
+      return actual.getConnectionIdFromState(state, worktreeId)
+    }
+  }
+})
+
+const LOCAL_WORKTREE = 'repo-1::/repo/worktrees/local'
+const OTHER_WORKTREE = 'repo-2::/repo/worktrees/other'
+
+/** Only the fields the resolver touches; the memo key is the whole object. */
+function makeState(overrides: Partial<Record<string, unknown>> = {}): AppState {
+  return {
+    repos: [],
+    worktreesByRepo: {},
+    detectedWorktreesByRepo: {},
+    folderWorkspaces: [],
+    activeWorktreeId: null,
+    activeWorkspaceExecutionHostId: null,
+    runtimeEnvironments: [],
+    runtimeStatusByEnvironmentId: new Map(),
+    sshConnectionStates: new Map(),
+    sshStateByEnvironment: new Map(),
+    sshTargetLabels: new Map(),
+    removedSshTargetLabels: new Map(),
+    sshTargetsHydrated: true,
+    sshTargets: [],
+    ...overrides
+  } as unknown as AppState
+}
+
+beforeEach(() => {
+  resetTerminalPaneHostStateMemoForTests()
+  connectionIdCalls.count = 0
+})
+
+describe('selectTerminalPaneHostState memo', () => {
+  it('returns the same object across an unrelated store write', () => {
+    const first = makeState()
+    const before = selectTerminalPaneHostState(first, LOCAL_WORKTREE)
+
+    // A new published state object with no host-relevant change.
+    const second = makeState({ rightSidebarOpen: true })
+    const after = selectTerminalPaneHostState(second, LOCAL_WORKTREE)
+
+    expect(after).toBe(before)
+  })
+
+  it('resolves the host once per published state, not once per mounted tab', () => {
+    const state = makeState()
+    selectTerminalPaneHostState(state, LOCAL_WORKTREE)
+    const afterFirstTab = connectionIdCalls.count
+    expect(afterFirstTab).toBe(1)
+
+    // Four more tabs of the same worktree, same publication.
+    for (let index = 0; index < 4; index += 1) {
+      selectTerminalPaneHostState(state, LOCAL_WORKTREE)
+    }
+    expect(connectionIdCalls.count).toBe(afterFirstTab)
+
+    // A different worktree in the same publication still resolves.
+    selectTerminalPaneHostState(state, OTHER_WORKTREE)
+    expect(connectionIdCalls.count).toBe(afterFirstTab + 1)
+  })
+
+  it('re-resolves when the published state changes, so a host change is never stale', () => {
+    const local = makeState()
+    const before = selectTerminalPaneHostState(local, LOCAL_WORKTREE)
+    expect(before.sshReconnectTargetId).toBeNull()
+
+    const remote = makeState({
+      repos: [{ id: 'repo-1', path: '/repo', connectionId: 'ssh-host-a' }],
+      worktreesByRepo: {
+        'repo-1': [{ id: LOCAL_WORKTREE, repoId: 'repo-1', path: '/repo/worktrees/local' }]
+      }
+    })
+    const after = selectTerminalPaneHostState(remote, LOCAL_WORKTREE)
+
+    expect(after).not.toBe(before)
+    expect(after.sshReconnectTargetId).toBe('ssh-host-a')
+  })
+
+  it('allocates nothing across 1,000 publications at 6 worktrees x 5 tabs', () => {
+    const worktreeIds = Array.from({ length: 6 }, (_, index) => `repo-${index}::/repo/wt-${index}`)
+    const firstState = makeState()
+    const firstByWorktree = new Map(
+      worktreeIds.map((worktreeId) => [
+        worktreeId,
+        selectTerminalPaneHostState(firstState, worktreeId)
+      ])
+    )
+    connectionIdCalls.count = 0
+    let allocations = 0
+
+    for (let publication = 0; publication < 1_000; publication += 1) {
+      // One published state object, then every mounted tab's selector run.
+      const state = makeState({ agentStatusEpoch: publication })
+      for (const worktreeId of worktreeIds) {
+        for (let tab = 0; tab < 5; tab += 1) {
+          if (selectTerminalPaneHostState(state, worktreeId) !== firstByWorktree.get(worktreeId)) {
+            allocations += 1
+          }
+        }
+      }
+    }
+
+    expect(allocations).toBe(0)
+    // One host resolve per worktree per publication instead of one per tab.
+    expect(connectionIdCalls.count).toBe(6 * 1_000)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-pane-host-state.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-host-state.ts
@@ -21,10 +21,7 @@ export type TerminalPaneHostState = {
   sshReconnectTargetRemoved: boolean
 }
 
-export function selectTerminalPaneHostState(
-  state: AppState,
-  worktreeId: string
-): TerminalPaneHostState {
+function computeTerminalPaneHostState(state: AppState, worktreeId: string): TerminalPaneHostState {
   const connectionId = getConnectionIdFromState(state, worktreeId)
   const nativeChatTranscriptIsLocalReadableResult =
     isNativeChatTranscriptLocalReadable(connectionId)
@@ -67,4 +64,61 @@ export function selectTerminalPaneHostState(
       sshReconnectTargetId
     )
   }
+}
+
+function isSameHostState(a: TerminalPaneHostState, b: TerminalPaneHostState): boolean {
+  return (
+    a.nativeChatTranscriptIsLocalReadable === b.nativeChatTranscriptIsLocalReadable &&
+    a.sshReconnectEnvironmentId === b.sshReconnectEnvironmentId &&
+    a.sshReconnectError === b.sshReconnectError &&
+    a.sshReconnectStatus === b.sshReconnectStatus &&
+    a.sshReconnectTargetId === b.sshReconnectTargetId &&
+    a.sshReconnectTargetLabel === b.sshReconnectTargetLabel &&
+    a.sshReconnectTargetRemoved === b.sshReconnectTargetRemoved
+  )
+}
+
+let cachedState: AppState | null = null
+let cachedByWorktreeId = new Map<string, TerminalPaneHostState>()
+let previousByWorktreeId = new Map<string, TerminalPaneHostState>()
+
+/**
+ * Per-worktree memo of the host state one TerminalPane needs.
+ *
+ * Why keyed on the whole `state` object and nothing narrower: resolving the
+ * execution host walks repos, worktree owners, folder-workspace routes, and the
+ * runtime/SSH slices, so no hand-written input list can be shown to be complete
+ * — and an incomplete one would hand an SSH pane a stale host. Zustand mints a
+ * new state object for every publication, so state identity is an exact,
+ * conservative key: a write can never be missed, and within one published state
+ * every mounted tab of a worktree resolves the host once instead of once each.
+ *
+ * The previous result is returned when nothing changed, so the shallow-equal
+ * subscriber compares by identity and the selector stops allocating per publication.
+ */
+export function selectTerminalPaneHostState(
+  state: AppState,
+  worktreeId: string
+): TerminalPaneHostState {
+  if (state !== cachedState) {
+    previousByWorktreeId = cachedByWorktreeId
+    cachedByWorktreeId = new Map()
+    cachedState = state
+  }
+  const cached = cachedByWorktreeId.get(worktreeId)
+  if (cached) {
+    return cached
+  }
+  const next = computeTerminalPaneHostState(state, worktreeId)
+  const previous = previousByWorktreeId.get(worktreeId)
+  const result = previous && isSameHostState(previous, next) ? previous : next
+  cachedByWorktreeId.set(worktreeId, result)
+  return result
+}
+
+/** Test seam: drops the memo so a suite can measure a cold resolve. */
+export function resetTerminalPaneHostStateMemoForTests(): void {
+  cachedState = null
+  cachedByWorktreeId = new Map()
+  previousByWorktreeId = new Map()
 }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-store-subscription-budget.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-store-subscription-budget.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment happy-dom
+/**
+ * TerminalPane mounts once per retained tab, and zustand visits every listener
+ * synchronously on every publication, so the per-pane subscription count is a
+ * direct multiplier on agent-status burn (docs/reference/renderer-agent-status-performance.md).
+ *
+ * On `main` one mounted pane opened 48 listeners; 31 of them selected values that
+ * can never change — 27 store actions and 4 duplicate reads of one unified tab.
+ */
+import { act, createRef, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+import { readStoreListenerCount } from '@/store/store-listener-census'
+import { LinkRoutingPreferenceDialogProvider } from '@/components/link-routing-preference-dialog'
+import { useTerminalPaneController } from './use-terminal-pane-controller'
+import {
+  TERMINAL_PANE_STORE_ACTION_KEYS,
+  useTerminalPaneStoreActions
+} from './use-terminal-pane-store-actions'
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+/**
+ * Pinned budget for one mounted TerminalPane. Raising it costs one extra listener
+ * visit per store publication for every retained tab in the app — read the doc
+ * above before you do.
+ */
+const TERMINAL_PANE_LISTENER_BUDGET = 17
+/** What the same mount cost before the stable-action and unified-tab folds. */
+const PRE_FOLD_LISTENERS_PER_PANE = 48
+
+const originalState = useAppStore.getState()
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function mount(node: ReactNode): void {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root?.render(node))
+}
+
+function rerender(node: ReactNode): void {
+  act(() => root?.render(node))
+}
+
+function unmount(): void {
+  if (root) {
+    act(() => root?.unmount())
+  }
+  root = null
+  container?.remove()
+  container = null
+}
+
+function listenerCount(): number {
+  const count = readStoreListenerCount()
+  if (count === null) {
+    throw new Error('store listener census unavailable')
+  }
+  return count
+}
+
+function PaneProbe({ tabId }: { tabId: string }): null {
+  useTerminalPaneController(
+    {
+      tabId,
+      worktreeId: 'repo-1::/repo/worktrees/budget',
+      cwd: '/repo/worktrees/budget',
+      isActive: false,
+      isVisible: false
+    } as never,
+    createRef()
+  )
+  return null
+}
+
+afterEach(() => {
+  unmount()
+  useAppStore.setState(originalState, true)
+})
+
+describe('TerminalPane store subscription budget', () => {
+  it('stays inside the pinned per-pane listener budget', () => {
+    const baseline = listenerCount()
+    mount(
+      <LinkRoutingPreferenceDialogProvider>
+        <PaneProbe tabId="tab-1" />
+      </LinkRoutingPreferenceDialogProvider>
+    )
+    const withOnePane = listenerCount()
+
+    // The provider itself subscribes, so the marginal cost of a pane is measured
+    // by adding a second one to the already-mounted tree.
+    rerender(
+      <LinkRoutingPreferenceDialogProvider>
+        <PaneProbe tabId="tab-1" />
+        <PaneProbe tabId="tab-2" />
+      </LinkRoutingPreferenceDialogProvider>
+    )
+    const perPane = listenerCount() - withOnePane
+
+    expect(perPane).toBe(TERMINAL_PANE_LISTENER_BUDGET)
+    expect(perPane).toBeLessThan(PRE_FOLD_LISTENERS_PER_PANE)
+    // 27 stable actions plus four duplicate unified-tab reads.
+    expect(PRE_FOLD_LISTENERS_PER_PANE - perPane).toBe(TERMINAL_PANE_STORE_ACTION_KEYS.length + 4)
+
+    unmount()
+    expect(listenerCount()).toBe(baseline)
+  })
+
+  it('scales linearly, so 20 retained tabs cost 20x the budget and not more', () => {
+    const baseline = listenerCount()
+    const tabIds = Array.from({ length: 20 }, (_, index) => `tab-${index}`)
+    mount(
+      <LinkRoutingPreferenceDialogProvider>
+        {tabIds.map((tabId) => (
+          <PaneProbe key={tabId} tabId={tabId} />
+        ))}
+      </LinkRoutingPreferenceDialogProvider>
+    )
+
+    const paneListeners = listenerCount() - baseline
+    // The provider's own subscriptions ride along; they do not scale with panes.
+    expect(paneListeners).toBeLessThanOrEqual(TERMINAL_PANE_LISTENER_BUDGET * 20 + 8)
+    expect(paneListeners).toBeLessThan(PRE_FOLD_LISTENERS_PER_PANE * 20)
+
+    unmount()
+    expect(listenerCount()).toBe(baseline)
+  })
+
+  it('binds the live store actions without opening a listener for any of them', () => {
+    let bound: Record<string, unknown> | null = null
+    function ActionsProbe(): null {
+      bound = useTerminalPaneStoreActions() as unknown as Record<string, unknown>
+      return null
+    }
+
+    const baseline = listenerCount()
+    mount(<ActionsProbe />)
+
+    expect(listenerCount()).toBe(baseline)
+    const state = useAppStore.getState() as unknown as Record<string, unknown>
+    const boundActions = bound as Record<string, unknown> | null
+    if (!boundActions) {
+      throw new Error('probe did not render')
+    }
+    expect(Object.keys(boundActions).sort()).toEqual([...TERMINAL_PANE_STORE_ACTION_KEYS].sort())
+    for (const key of TERMINAL_PANE_STORE_ACTION_KEYS) {
+      expect(boundActions[key]).toBe(state[key])
+    }
+  })
+
+  it('never reassigns one of the bound actions, which is what makes getState() safe', () => {
+    const before = useAppStore.getState() as unknown as Record<string, unknown>
+    const snapshot = new Map(TERMINAL_PANE_STORE_ACTION_KEYS.map((key) => [key, before[key]]))
+
+    act(() => {
+      useAppStore.getState().markWorktreeUnread('repo-1::/repo/worktrees/budget')
+      useAppStore.getState().clearWorktreeUnread('repo-1::/repo/worktrees/budget')
+      useAppStore.getState().setRuntimePaneTitle('tab-1', 1, 'title')
+      useAppStore.getState().clearRuntimePaneTitle('tab-1', 1)
+      useAppStore.getState().suppressPtyExit('pty-1')
+      useAppStore.getState().consumeSuppressedPtyExit('pty-1')
+      useAppStore.getState().setCacheTimerStartedAt('cache-1', Date.now())
+    })
+
+    const after = useAppStore.getState() as unknown as Record<string, unknown>
+    const moved = TERMINAL_PANE_STORE_ACTION_KEYS.filter((key) => after[key] !== snapshot.get(key))
+    expect(moved).toEqual([])
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.ts
@@ -1,4 +1,13 @@
 import type { Tab } from '../../../../shared/tab-types'
+import type { AgentType } from '../../../../shared/agent-status-types'
+
+export type UnifiedTerminalTabChatFields = {
+  unifiedTabId: string | undefined
+  structuredSessionAgent: AgentType | undefined
+  isChatViewMode: boolean
+  structuredSessionId: string | null
+  unifiedTabLabel: string | undefined
+}
 
 const terminalTabLookupByUnifiedTabs = new WeakMap<readonly Tab[], Map<string, Tab>>()
 
@@ -37,4 +46,29 @@ export function getCachedTerminalGroupIdForWorktree(
     getCachedUnifiedTerminalTabForWorktree(unifiedTabsByWorktree, worktreeId, terminalTabId)
       ?.groupId ?? null
   )
+}
+
+/**
+ * The five unified-tab fields TerminalPane's chat state reads.
+ *
+ * Why bundled: they used to be five `useAppStore` calls, so one publication paid
+ * the lookup five times and held five listener slots for every mounted tab.
+ */
+export function selectUnifiedTerminalTabChatFields(
+  unifiedTabsByWorktree: Record<string, Tab[]>,
+  worktreeId: string,
+  terminalTabId: string
+): UnifiedTerminalTabChatFields {
+  const tab = getCachedUnifiedTerminalTabForWorktree(
+    unifiedTabsByWorktree,
+    worktreeId,
+    terminalTabId
+  )
+  return {
+    unifiedTabId: tab?.id,
+    structuredSessionAgent: tab?.agentSessionAgent,
+    isChatViewMode: tab?.viewMode === 'chat',
+    structuredSessionId: tab?.structuredSessionId ?? null,
+    unifiedTabLabel: tab?.label
+  }
 }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-chat-state.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-chat-state.ts
@@ -2,13 +2,14 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { useAppStore } from '../../store'
-import { getCachedUnifiedTerminalTabForWorktree } from './terminal-unified-tab-lookup'
 import { getCachedTerminalTabForWorktree } from './terminal-tab-lookup'
 import { selectTerminalTabAgentTypesByLeaf } from './terminal-tab-agent-type-index'
 import { collectLeafIdsInOrder, EMPTY_LAYOUT } from './layout-serialization'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { sanitizeTerminalLayoutPaneTitles } from '@/lib/terminal-pane-title-sanitization'
 import { resolveNativeChatLeafTitleAgent } from './native-chat-leaf-title-agent'
+import { useTerminalPaneStoreActions } from './use-terminal-pane-store-actions'
+import { selectUnifiedTerminalTabChatFields } from './terminal-unified-tab-lookup'
 import { canToggleNativeChat } from '../native-chat/native-chat-availability'
 import {
   nativeChatLaunchAgentForLeaf,
@@ -30,32 +31,27 @@ export function useTerminalPaneChatState(controller: TerminalPaneTitleController
     tabWideAgentHintLeafId,
     worktreeId
   } = controller
-  const setTabPaneExpanded = useAppStore((store) => store.setTabPaneExpanded)
-  const setTabCanExpandPane = useAppStore((store) => store.setTabCanExpandPane)
-  const suppressPtyExit = useAppStore((store) => store.suppressPtyExit)
+  const {
+    clearCodexRestartNotice,
+    consumePendingCodexPaneRestart,
+    setTabCanExpandPane,
+    setTabPaneExpanded,
+    setTabViewMode,
+    suppressPtyExit
+  } = useTerminalPaneStoreActions()
   const pendingCodexPaneRestartIds = useAppStore((store) => store.pendingCodexPaneRestartIds)
-  const consumePendingCodexPaneRestart = useAppStore(
-    (store) => store.consumePendingCodexPaneRestart
-  )
-  const clearCodexRestartNotice = useAppStore((store) => store.clearCodexRestartNotice)
-  const unifiedTabId = useAppStore(
-    (store) =>
-      getCachedUnifiedTerminalTabForWorktree(store.unifiedTabsByWorktree, worktreeId, tabId)?.id
-  )
-  const structuredSessionAgent = useAppStore(
-    (store) =>
-      getCachedUnifiedTerminalTabForWorktree(store.unifiedTabsByWorktree, worktreeId, tabId)
-        ?.agentSessionAgent
-  )
-  const isChatViewMode = useAppStore(
-    (store) =>
-      getCachedUnifiedTerminalTabForWorktree(store.unifiedTabsByWorktree, worktreeId, tabId)
-        ?.viewMode === 'chat'
-  )
-  const structuredSessionId = useAppStore(
-    (store) =>
-      getCachedUnifiedTerminalTabForWorktree(store.unifiedTabsByWorktree, worktreeId, tabId)
-        ?.structuredSessionId ?? null
+  // Why one selector: five separate subscriptions each re-read the same unified
+  // tab, so one publication paid the lookup five times per mounted tab.
+  const {
+    unifiedTabId,
+    structuredSessionAgent,
+    isChatViewMode,
+    structuredSessionId,
+    unifiedTabLabel
+  } = useAppStore(
+    useShallow((store) =>
+      selectUnifiedTerminalTabChatFields(store.unifiedTabsByWorktree, worktreeId, tabId)
+    )
   )
   const nativeChatEnabled = useAppStore((store) => store.settings?.experimentalNativeChat === true)
   const effectiveChatViewMode = nativeChatEnabled && isChatViewMode
@@ -63,10 +59,6 @@ export function useTerminalPaneChatState(controller: TerminalPaneTitleController
     chatLeafId
       ? store.agentStatusByPaneKey[makePaneKey(tabId, chatLeafId)]?.orchestration?.dispatchStatus
       : undefined
-  )
-  const unifiedTabLabel = useAppStore(
-    (store) =>
-      getCachedUnifiedTerminalTabForWorktree(store.unifiedTabsByWorktree, worktreeId, tabId)?.label
   )
   const runtimePaneTitlesByPaneId = useAppStore(
     useShallow((store) => store.runtimePaneTitlesByTabId[tabId] ?? {})
@@ -78,7 +70,6 @@ export function useTerminalPaneChatState(controller: TerminalPaneTitleController
       store.paneForegroundAgentByPaneKey
     )
   )
-  const setTabViewMode = useAppStore((store) => store.setTabViewMode)
   const savedLayout = useAppStore((store) => store.terminalLayoutsByTabId[tabId] ?? EMPTY_LAYOUT)
   const terminalTab = useAppStore((store) =>
     getCachedTerminalTabForWorktree(store.tabsByWorktree, worktreeId, tabId)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle-stage.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle-stage.ts
@@ -1,4 +1,4 @@
-import { useAppStore } from '../../store'
+import { useTerminalPaneStoreActions } from './use-terminal-pane-store-actions'
 import { useTerminalPaneLifecycle } from './use-terminal-pane-lifecycle'
 import type { TerminalPaneCloseController } from './use-terminal-pane-close-actions'
 
@@ -72,6 +72,7 @@ export function useTerminalPaneLifecycleStage(controller: TerminalPaneCloseContr
     getTabWideAgentHintLeafIdRef,
     handlePaneProcessDied
   } = controller
+  const { consumeSuppressedPtyExit, isPtyShutdownPending } = useTerminalPaneStoreActions()
 
   useTerminalPaneLifecycle({
     tabId,
@@ -111,8 +112,8 @@ export function useTerminalPaneLifecycleStage(controller: TerminalPaneCloseContr
     onPaneProcessDied: handlePaneProcessDied,
     onPtyRecoveryStateRef,
     clearTabPtyId,
-    consumeSuppressedPtyExit: useAppStore((store) => store.consumeSuppressedPtyExit),
-    isPtyShutdownPending: useAppStore((store) => store.isPtyShutdownPending),
+    consumeSuppressedPtyExit,
+    isPtyShutdownPending,
     updateTabTitle,
     setRuntimePaneTitle,
     clearRuntimePaneTitle,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-startup-actions.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-startup-actions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 import { useAppStore } from '../../store'
+import { useTerminalPaneStoreActions } from './use-terminal-pane-store-actions'
 import { useProjectHostSetupProjection, useRepoById } from '@/store/selectors'
 import { useSessionRestoredBannerDismiss } from './useSessionRestoredBannerDismiss'
 import {
@@ -210,7 +211,7 @@ export function useTerminalPaneStartupActions(controller: TerminalPaneStoreContr
   onPtyExitRef.current = onPtyExit
   const systemPrefersDark = useSystemPrefersDark()
   const dispatchNotification = useNotificationDispatch(worktreeId)
-  const setCacheTimerStartedAt = useAppStore((store) => store.setCacheTimerStartedAt)
+  const { setCacheTimerStartedAt } = useTerminalPaneStoreActions()
 
   return {
     clearSessionRestoredBannerForPane,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-store-actions.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-store-actions.ts
@@ -1,0 +1,79 @@
+import { useMemo } from 'react'
+import { useAppStore } from '../../store'
+
+/**
+ * Every store action the TerminalPane controller dispatches, bound once.
+ *
+ * Why `getState()` and not one selector each: zustand action identities are fixed when the store
+ * is built and no slice ever puts one in a `set()` payload, so subscribing to them can never fire.
+ * TerminalPane mounts once per retained tab, so 27 action subscriptions cost 27 live listeners and
+ * 27 selector runs per store publication *per mounted tab*. Same pattern as
+ * `useSourceControlStoreActions`.
+ */
+export function useTerminalPaneStoreActions() {
+  return useMemo(() => {
+    const state = useAppStore.getState()
+    return {
+      clearCodexRestartNotice: state.clearCodexRestartNotice,
+      clearRuntimePaneTitle: state.clearRuntimePaneTitle,
+      clearTabPtyId: state.clearTabPtyId,
+      clearTerminalPaneUnread: state.clearTerminalPaneUnread,
+      clearTerminalTabUnread: state.clearTerminalTabUnread,
+      clearWorktreeUnread: state.clearWorktreeUnread,
+      consumePendingCodexPaneRestart: state.consumePendingCodexPaneRestart,
+      consumeSuppressedPtyExit: state.consumeSuppressedPtyExit,
+      consumeTabIssueCommandSplit: state.consumeTabIssueCommandSplit,
+      consumeTabSetupSplit: state.consumeTabSetupSplit,
+      consumeTabStartupCommand: state.consumeTabStartupCommand,
+      isPtyShutdownPending: state.isPtyShutdownPending,
+      markTerminalPaneUnread: state.markTerminalPaneUnread,
+      markTerminalTabUnread: state.markTerminalTabUnread,
+      markWorktreeUnread: state.markWorktreeUnread,
+      openSpacePage: state.openSpacePage,
+      refreshWorkspaceSpace: state.refreshWorkspaceSpace,
+      setCacheTimerStartedAt: state.setCacheTimerStartedAt,
+      setRuntimePaneTitle: state.setRuntimePaneTitle,
+      setTabCanExpandPane: state.setTabCanExpandPane,
+      setTabLayout: state.setTabLayout,
+      setTabPaneExpanded: state.setTabPaneExpanded,
+      setTabViewMode: state.setTabViewMode,
+      suppressPtyExit: state.suppressPtyExit,
+      updateSettings: state.updateSettings,
+      updateTabPtyId: state.updateTabPtyId,
+      updateTabTitle: state.updateTabTitle
+    }
+  }, [])
+}
+
+export type TerminalPaneStoreActions = ReturnType<typeof useTerminalPaneStoreActions>
+
+/** The action names bound above, for the listener-budget test. */
+export const TERMINAL_PANE_STORE_ACTION_KEYS = [
+  'clearCodexRestartNotice',
+  'clearRuntimePaneTitle',
+  'clearTabPtyId',
+  'clearTerminalPaneUnread',
+  'clearTerminalTabUnread',
+  'clearWorktreeUnread',
+  'consumePendingCodexPaneRestart',
+  'consumeSuppressedPtyExit',
+  'consumeTabIssueCommandSplit',
+  'consumeTabSetupSplit',
+  'consumeTabStartupCommand',
+  'isPtyShutdownPending',
+  'markTerminalPaneUnread',
+  'markTerminalTabUnread',
+  'markWorktreeUnread',
+  'openSpacePage',
+  'refreshWorkspaceSpace',
+  'setCacheTimerStartedAt',
+  'setRuntimePaneTitle',
+  'setTabCanExpandPane',
+  'setTabLayout',
+  'setTabPaneExpanded',
+  'setTabViewMode',
+  'suppressPtyExit',
+  'updateSettings',
+  'updateTabPtyId',
+  'updateTabTitle'
+] as const

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-store-bindings.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-store-bindings.ts
@@ -3,29 +3,35 @@ import { useAppStore } from '../../store'
 import { useLinkRoutingPreferenceDialog } from '@/components/link-routing-preference-dialog'
 import { isWindowsUserAgent } from './pane-helpers'
 import type { SessionRestoredBannerReason } from './session-restored-banner-pane-state'
+import { useTerminalPaneStoreActions } from './use-terminal-pane-store-actions'
 import type { TerminalPaneChatController } from './use-terminal-pane-chat-state'
 
 export function useTerminalPaneStoreBindings(controller: TerminalPaneChatController) {
   const { expectedLayoutLeafIds, isVisible, restoredLayout, tabId } = controller
-  const setTabLayout = useAppStore((store) => store.setTabLayout)
+  const {
+    clearRuntimePaneTitle,
+    clearTabPtyId,
+    clearTerminalPaneUnread,
+    clearTerminalTabUnread,
+    clearWorktreeUnread,
+    consumeTabIssueCommandSplit,
+    consumeTabSetupSplit,
+    consumeTabStartupCommand,
+    markTerminalPaneUnread,
+    markTerminalTabUnread,
+    markWorktreeUnread,
+    openSpacePage,
+    refreshWorkspaceSpace,
+    setRuntimePaneTitle,
+    setTabLayout,
+    updateSettings,
+    updateTabPtyId,
+    updateTabTitle
+  } = useTerminalPaneStoreActions()
   const expectedLayoutLeafIdsAttr =
     expectedLayoutLeafIds.length > 0 ? expectedLayoutLeafIds.join(' ') : undefined
   const initialLayoutRef = useRef(restoredLayout)
-  const updateTabTitle = useAppStore((store) => store.updateTabTitle)
-  const setRuntimePaneTitle = useAppStore((store) => store.setRuntimePaneTitle)
-  const clearRuntimePaneTitle = useAppStore((store) => store.clearRuntimePaneTitle)
-  const updateTabPtyId = useAppStore((store) => store.updateTabPtyId)
-  const clearTabPtyId = useAppStore((store) => store.clearTabPtyId)
-  const markWorktreeUnread = useAppStore((store) => store.markWorktreeUnread)
-  const markTerminalTabUnread = useAppStore((store) => store.markTerminalTabUnread)
-  const markTerminalPaneUnread = useAppStore((store) => store.markTerminalPaneUnread)
-  const clearWorktreeUnread = useAppStore((store) => store.clearWorktreeUnread)
-  const clearTerminalTabUnread = useAppStore((store) => store.clearTerminalTabUnread)
-  const clearTerminalPaneUnread = useAppStore((store) => store.clearTerminalPaneUnread)
-  const openSpacePage = useAppStore((store) => store.openSpacePage)
-  const refreshWorkspaceSpace = useAppStore((store) => store.refreshWorkspaceSpace)
   const settings = useAppStore((store) => store.settings)
-  const updateSettings = useAppStore((store) => store.updateSettings)
   const requestLinkRoutingPreference = useLinkRoutingPreferenceDialog()
   const keybindings = useAppStore((store) => store.keybindings)
   const rightClickToPaste = settings?.terminalRightClickToPaste ?? isWindowsUserAgent()
@@ -37,13 +43,10 @@ export function useTerminalPaneStoreBindings(controller: TerminalPaneChatControl
   const [sessionRestoredBannerPaneIds, setSessionRestoredBannerPaneIds] = useState<
     Map<number, SessionRestoredBannerReason>
   >(() => new Map())
-  const consumeTabStartupCommand = useAppStore((store) => store.consumeTabStartupCommand)
   const [setupSplit] = useState(() => useAppStore.getState().pendingSetupSplitByTabId[tabId])
-  const consumeTabSetupSplit = useAppStore((store) => store.consumeTabSetupSplit)
   const [issueCommandSplit] = useState(
     () => useAppStore.getState().pendingIssueCommandSplitByTabId[tabId]
   )
-  const consumeTabIssueCommandSplit = useAppStore((store) => store.consumeTabIssueCommandSplit)
 
   return {
     setTabLayout,

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -16,6 +16,11 @@ import {
 } from '../activity/activity-terminal-portal'
 import { getTerminalTabColdParkRecheckDelayMs } from './terminal-cold-park-recheck-deadlines'
 import {
+  clearTerminalTabColdParkRecheckTimers,
+  reconcileTerminalTabColdParkRecheckTimers,
+  type TerminalTabColdParkRecheckTimers
+} from './terminal-cold-park-recheck-timers'
+import {
   TERMINAL_TAB_COLD_PARK_DELAY_MS,
   selectPairedRuntimeParkingEnvironmentIdsFromState,
   selectColdParkedTerminalTabs
@@ -130,7 +135,7 @@ export function useTerminalTabColdParking(args: {
   // re-grants the hysteresis so measure end can't immediately re-park.
   const wasMeasuringHiddenWorktreeRef = useRef(false)
   const measureParkCooldownUntilRef = useRef<number | null>(null)
-  const terminalTabParkingTimersRef = useRef(new Map<string, number>())
+  const terminalTabParkingTimersRef = useRef<TerminalTabColdParkRecheckTimers>(new Map())
   const parkVerdictRecordsRef = useRef(new Map<string, ParkVerdictFlipRecord>())
   const [terminalTabParkingRevision, setTerminalTabParkingRevision] = useState(0)
   const [coldParkedTerminalTabIds, setColdParkedTerminalTabIds] = useState<ReadonlySet<string>>(
@@ -141,12 +146,7 @@ export function useTerminalTabColdParking(args: {
 
   useEffect(() => {
     const timers = terminalTabParkingTimersRef.current
-    return () => {
-      for (const timer of timers.values()) {
-        window.clearTimeout(timer)
-      }
-      timers.clear()
-    }
+    return () => clearTerminalTabColdParkRecheckTimers(timers)
   }, [])
 
   // Why: per-tab cold-park policy — hiddenSince bookkeeping, parked-set
@@ -154,11 +154,6 @@ export function useTerminalTabColdParking(args: {
   // re-renders exactly when the hysteresis elapses instead of polling.
   useEffect(() => {
     const timers = terminalTabParkingTimersRef.current
-    for (const timer of timers.values()) {
-      window.clearTimeout(timer)
-    }
-    timers.clear()
-
     const nowMs = Date.now()
     const overrides = getTerminalParkingPolicyOverrides()
     const currentTerminalTabIds = new Set(terminalTabs.map((tab) => tab.id))
@@ -235,6 +230,7 @@ export function useTerminalTabColdParking(args: {
       setColdParkedTerminalTabIds(parkedTabIds)
     }
 
+    const recheckDeadlineMsByTabId = new Map<string, number>()
     for (const candidate of candidates) {
       if (
         candidate.isVisible ||
@@ -253,14 +249,16 @@ export function useTerminalTabColdParking(args: {
         ...overrides
       })
       if (delayMs !== null && delayMs > 0) {
-        const tabId = candidate.id
-        const timer = window.setTimeout(() => {
-          timers.delete(tabId)
-          setTerminalTabParkingRevision((revision) => revision + 1)
-        }, delayMs)
-        timers.set(tabId, timer)
+        recheckDeadlineMsByTabId.set(candidate.id, nowMs + delayMs)
       }
     }
+
+    reconcileTerminalTabColdParkRecheckTimers({
+      timers,
+      deadlineMsByTabId: recheckDeadlineMsByTabId,
+      nowMs,
+      onDeadline: () => setTerminalTabParkingRevision((revision) => revision + 1)
+    })
     // eslint-disable-next-line react-hooks/exhaustive-deps -- semantic keys own the tab and assignment dependencies.
   }, [
     activityTerminalPortals,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​501 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​495 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​285 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​75 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​210 |

<!-- /orca-pr-loc -->

## ELI5

Every terminal tab you keep open quietly signs up for a pile of notifications from the app's shared state. Most of those signups were for things that can never change — the "do a thing" functions themselves — so the app woke up, checked them, and found nothing new, thousands of times a second. This PR cancels the pointless subscriptions, stops five parts of one pane from separately looking up the same tab, stops re-computing which machine a pane runs on when nothing moved, and stops cancelling-and-re-setting background timers that were already set for the right moment. Nothing looks or behaves differently.

## What was happening

`docs/reference/renderer-agent-status-performance.md` establishes the cost model: `burst work ≈ status events × store listeners × selector work`, with **9,279 live listeners** measured on the 100-worktree fixture. Prior work cut the sidebar cards (#18133, #18136). `TerminalPane` — mounted once per *retained* tab — was untouched.

**1. 31 of 48 subscriptions per mounted pane could never fire.**
`useAppStore` opens one `useSyncExternalStore` subscription per call, and zustand visits every listener synchronously on every publication.

- 27 of them selected **store actions**. Action identities are fixed when the store is built and no slice puts one in a `set()` payload, so those 27 listeners contributed 27 listener visits and 27 selector runs per publication, per retained tab, and could never produce a change. Same finding, same fix as `useSourceControlStoreActions` (`src/renderer/src/components/right-sidebar/source-control/listing/use-store-actions.ts`), which this reuses.
- 5 more read five fields of **one** unified tab through five separate subscriptions (`use-terminal-pane-chat-state.ts`), so each publication ran `getCachedUnifiedTerminalTabForWorktree` five times per pane.

**2. `selectTerminalPaneHostState` re-resolved and allocated per publication, per pane.**
`useShallow` suppresses the *render*, not the *selector*. On every publication, for every mounted pane, `use-terminal-pane-foundation.ts:77` ran `getConnectionIdFromState` (`parseWorkspaceKey` → indexed owner resolution → `resolveWorktreeExecutionHost`) plus `isNativeChatTranscriptLocalReadable`, then allocated a fresh 7-key object that was immediately discarded by the shallow comparison.

**3. The cold-park effect cleared and re-armed every pending timer on every tab-model write.**
`use-terminal-tab-cold-parking.ts` re-runs whenever `tabsByWorktree[worktreeId]` is recreated — a runtime title, an unread bump. Its first act was `clearTimeout` for every pending per-tab recheck timer, followed by one `setTimeout` per still-hidden tab. Every recheck deadline is *absolute* (hiddenSince + a fixed policy window, a cool-down, or a pin expiry), so a re-run under a title flood cancelled each timer only to re-arm it for the exact same instant.

## Measurement

Store subscriptions per mounted `TerminalPane`, measured by mounting the real `useTerminalPaneController` and reading `readStoreListenerCount()` (`terminal-pane-store-subscription-budget.test.tsx`), taking the marginal cost of a second pane so the shared provider's own listeners are excluded:

| Measure | Before | After |
| --- | ---: | ---: |
| Listeners per mounted terminal tab | **48** | **17** (−64.6%) |
| Listeners at 20 mounted tabs | **960** | **340** (−620) |
| Of which stable store actions | 27 | 0 |
| Of which duplicate unified-tab reads | 5 | 1 |

`selectTerminalPaneHostState` at 6 worktrees × 5 tabs over 1,000 publications (`terminal-pane-host-state-memo.test.ts`):

| Measure | Before | After |
| --- | ---: | ---: |
| Result objects allocated | 30,000 | **0** |
| `getConnectionIdFromState` host resolves | 30,000 | **6,000** (one per worktree per publication, not one per tab) |

Cold-park recheck timers under a background title flood — 40 title-only publications, 5 hidden tabs, real component mount (`terminal-cold-park-timer-rearm.test.tsx`):

| Measure | Before | After |
| --- | ---: | ---: |
| `setTimeout` calls | **200** (5/write) | **0** |
| `clearTimeout` calls | **200** (5/write) | **0** |
| Cold-park effect runs | ≥40 | ≥40 (unchanged — see below) |
| First park instant | 60,000 ms | 60,000 ms (identical) |

At the brief's 6 worktrees × 5 tabs, a flood touching every worktree therefore drops from 60 timer syscalls per title write to 0.

Not measured: the `bench:idle-cpu` fanout harness. It launches a full E2E Electron build and its fixture seeds worktree cards, not terminal panes, so it would not attribute a terminal-pane listener delta. The doc's own scaling constant (~0.18 CPU points per publication/s at 9,279 listeners) implies the −620 listeners at 20 retained tabs is a ~6.7% reduction in per-publication fanout work, but that is arithmetic from the doc, not a measurement, and is not claimed as one.

## Negative user-facing trade-offs

None. No terminal renders differently, no pane parks earlier or later, no SSH pane can resolve to a stale execution host, no status lags.

**One sub-fix from the brief was dropped, and one was replaced.**

- **Dropped — gating `getTerminalParkingInputsKey` / `getTerminalParkingAssignmentsKey` on `coldParkTerminalPanes`.** The premise that the keys are unused when cold-parking is off is wrong: both are passed unconditionally to `useParkedTerminalWatcherSynchronization` (`use-terminal-tab-cold-parking.ts:378-379`), which needs them whenever the committed park set is non-empty — and per-tab parks produce a non-empty set with `coldParkTerminalPanes === false`. Gating them would break watcher sync.

- **Replaced — narrowing the cold-park effect's tab dependency from `terminalTabs` identity to the semantic key.** I implemented this and it fails `terminal-cold-park-verdict-loop.test.tsx`: the verdict settles on `parked = true` while the byte watchers cannot cover the tab, which silently drops that pane's bells, titles, and completions. The array identity is load-bearing. `withholdUnparkableTerminalTabs` calls `canWatcherCoverParkedTerminalTab`, which re-reads `terminalLayoutsByTabId`, `runtimePaneTitlesByTabId`, and the out-of-React `capturedPanesByTabId` registry through `getState()` — none of which the park key encodes — and a coverage-withheld tab past all its deadlines gets **no** recheck timer (`nextColdParkDeadlineDelayMs` returns `null` once every deadline is in the past), so the tab-model write is its only remaining wakeup. Removing it is a correctness regression, not a perf win.

  Instead the effect keeps re-running, and the *timers* stop churning: recheck deadlines are absolute, so a re-run reconciles by deadline and only reschedules a tab whose deadline actually moved. That captures the measured cost (400 timer syscalls per 40 writes → 0) with the wakeup semantics untouched.

**On the host-state memo and the SSH boundary.** The memo key is the whole published `state` object plus `worktreeId`, and deliberately nothing narrower. Per `docs/reference/ssh-execution-boundary.md` the execution host owns everything that touches execution, and resolving it walks repos, indexed worktree owners, detected worktrees, folder-workspace routes, the active-workspace route, and the runtime/SSH slices. No hand-written input list can be shown to be complete, and an incomplete one would hand an SSH pane a stale host. Zustand mints a new state object for every `setState`, so state identity is an exact and conservative key: a write can never be missed. The win is real but narrower than an input-keyed memo would be — it dedupes across the tabs of one worktree within a publication and eliminates the allocation, rather than skipping the resolve entirely.

## Risk & verification

Renderer-local. No RPC field, stream opcode, persisted data, Git command, or provider-specific contract changes, so no remote wire-compatibility surface (`docs/reference/remote-wire-compatibility.md`). Native, WSL, SSH, relay, folder-workspace, and git-worktree panes all take the same paths. Nothing platform-dependent was added.

The `getState()` action binding rests on one invariant — action identities never move — which is asserted at runtime, not assumed: the budget test snapshots every bound action, drives real writes through several slices, and requires no identity moved.

- `pnpm tc` clean. `pnpm run check:code-quality:changed` clean (0 findings across 13 files, including the React Doctor and max-lines ratchets).
- All 154 test files matching `rg -l "terminal-pane|cold-parking|terminal-pane-host-state" src --glob '*.test.*'` pass — 1,552 tests. Two files in that set (`HtmlDocPreview.toolbar.test.tsx`, `useIpcEvents-terminal-create-surfacing.test.ts`) time out intermittently when the whole batch runs in parallel; I reverted `src/renderer/src/components/terminal-pane/` to the merge base and reproduced the identical 26 failures, so they are a pre-existing load flake and not from this change.
- `terminal-pane-hook-order-parity.test.ts` re-pinned: 230 → 204 render hooks, 4 → 8 `useMemo`, new SHA. The new `use-terminal-pane-store-actions.ts` was added to the guard's source pattern so the flattening still sees its real hook order rather than treating it as one opaque leaf.
- New tests: per-pane listener budget (pinned at 17, with mount/unmount balance and 20-pane linearity); host-state memo referential stability across an unrelated store write, per-publication resolve count, and re-resolution when the host actually changes; cold-park timer non-rearm under a title flood plus a park-instant comparison with and without the flood.
