### PR TITLE
perf(editor): stop reclassifying the whole markdown document on every render

### DIFF
--- a/src/renderer/src/components/editor/EditorContent.markdown-classification.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.markdown-classification.test.tsx
@@ -9,8 +9,11 @@ const classifiers = vi.hoisted(() => ({
   exceedsSizeLimit: vi.fn<(content: string) => boolean>()
 }))
 
+// Why: the decision is what gets cached; the message is resolved from it per
+// read so it can follow the active UI language. The stub uses the message text
+// itself as the reason token so both seams stay observable.
 vi.mock('./markdown-rich-mode', () => ({
-  getMarkdownRichModeEligibility: ({
+  getMarkdownRichModeEligibilityDecision: ({
     content,
     sizeOverridden
   }: {
@@ -18,8 +21,9 @@ vi.mock('./markdown-rich-mode', () => ({
     sizeOverridden: boolean
   }) => ({
     exceedsSizeLimit: !sizeOverridden && classifiers.exceedsSizeLimit(content),
-    unsupportedMessage: classifiers.getUnsupportedMessage(content)
-  })
+    unsupportedReason: classifiers.getUnsupportedMessage(content)
+  }),
+  resolveMarkdownRichModeUnsupportedMessage: (reason: string | null) => reason
 }))
 
 vi.mock('./editor-lazy-views', () => {

--- a/src/renderer/src/components/editor/EditorContent.markdown-classification.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.markdown-classification.test.tsx
@@ -71,6 +71,7 @@ vi.mock('@/store', () => {
 
 import { EditorContent } from './EditorContent'
 import { getEditorPanelRenderModel } from './editor-panel-render-model'
+import { resetMarkdownRichModeEligibilityCache } from './markdown-rich-mode-eligibility-cache'
 
 function openFile(
   language: 'markdown' | 'typescript' = 'markdown',
@@ -172,6 +173,7 @@ function getGuardedRenderModel({
 }
 
 beforeEach(() => {
+  resetMarkdownRichModeEligibilityCache()
   classifiers.getUnsupportedMessage.mockImplementation((content) =>
     content.includes('[reference]:') ? 'Reference links require source mode.' : null
   )
@@ -181,6 +183,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  resetMarkdownRichModeEligibilityCache()
 })
 
 describe('inline Markdown render classification', () => {

--- a/src/renderer/src/components/editor/EditorPanel.markdown-classification-memoization.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.markdown-classification-memoization.test.tsx
@@ -226,11 +226,15 @@ describe('EditorPanel markdown classification memoization', () => {
 
     expect(probe.lastShellProps?.onContentChangeForFile).toBe(initialCallback)
 
-    // …and the stable callback still compares against the freshly loaded content.
+    // …and the stable callback compares against the newly committed baseline,
+    // not the one captured when it was created.
     const file = useAppStore.getState().openFiles[0]
     await act(async () =>
       probe.lastShellProps?.onContentChangeForFile(file, `${MARKDOWN_WITH_HTML}\nReloaded.\n`)
     )
     expect(useAppStore.getState().openFiles[0]?.isDirty).toBe(false)
+
+    await act(async () => probe.lastShellProps?.onContentChangeForFile(file, MARKDOWN_WITH_HTML))
+    expect(useAppStore.getState().openFiles[0]?.isDirty).toBe(true)
   })
 })

--- a/src/renderer/src/components/editor/EditorPanel.markdown-classification-memoization.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.markdown-classification-memoization.test.tsx
@@ -10,6 +10,7 @@ import type * as MarkdownRoundTripModule from './markdown-round-trip'
 
 type ShellProps = {
   onContentChangeForFile: (file: OpenFile | null, content: string) => void
+  model: { inlineMarkdownRenderState: { richModeUnsupportedMessage: string | null } | null }
 }
 
 const probe = vi.hoisted(() => ({
@@ -27,9 +28,12 @@ vi.mock('./markdown-rich-mode', async (importActual) => {
   const actual = await importActual<typeof MarkdownRichModeModule>()
   return {
     ...actual,
-    getMarkdownRichModeEligibility: (params: { content: string; sizeOverridden: boolean }) => {
+    getMarkdownRichModeEligibilityDecision: (params: {
+      content: string
+      sizeOverridden: boolean
+    }) => {
       probe.eligibility(params.content)
-      return actual.getMarkdownRichModeEligibility(params)
+      return actual.getMarkdownRichModeEligibilityDecision(params)
     }
   }
 })
@@ -49,7 +53,16 @@ vi.mock('./EditorPanelShell', () => ({
   EditorPanelShell: (props: ShellProps) => {
     probe.shellRender()
     probe.lastShellProps = props
-    return <div data-editor-panel-shell="true" />
+    // Why: `richModeUnsupportedMessage` is exactly what EditorMarkdownFileSurface
+    // renders as the rich-mode fallback banner, so rendering it here asserts on
+    // the banner text without mounting the whole editor surface.
+    return (
+      <div data-editor-panel-shell="true">
+        <span data-rich-fallback-banner="true">
+          {props.model.inlineMarkdownRenderState?.richModeUnsupportedMessage ?? ''}
+        </span>
+      </div>
+    )
   }
 }))
 
@@ -61,6 +74,7 @@ vi.mock('./useEditorPanelContentState', () => ({
   })
 }))
 
+import { i18n } from '@/i18n/i18n'
 import EditorPanel from './EditorPanel'
 import { resetMarkdownRichModeEligibilityCache } from './markdown-rich-mode-eligibility-cache'
 
@@ -81,6 +95,17 @@ const MARKDOWN_WITH_HTML = [
   '<!-- a comment -->',
   '',
   'Body text.',
+  ''
+].join('\n')
+
+// Why: reference-style links are the cheapest branch that produces a fallback
+// banner without paying for a TipTap round trip.
+const MARKDOWN_WITH_REFERENCE_LINKS = [
+  '# Notes',
+  '',
+  'See [the docs][ref].',
+  '',
+  '[ref]: https://example.com',
   ''
 ].join('\n')
 
@@ -207,6 +232,50 @@ describe('EditorPanel markdown classification memoization', () => {
 
     await change(MARKDOWN_WITH_HTML)
     expect(isDirty()).toBe(false)
+  })
+
+  it('re-localizes the rich-mode fallback banner after a UI language switch', async () => {
+    contentState.fileContents = {
+      [FILE_PATH]: { content: MARKDOWN_WITH_REFERENCE_LINKS, isBinary: false }
+    }
+    await act(async () => root.render(<EditorPanel />))
+    await flushEffects()
+
+    const banner = (): string | null =>
+      container.querySelector('[data-rich-fallback-banner="true"]')?.textContent ?? null
+
+    expect(banner()).toBe(
+      'Editable only in code mode because this file contains reference-style links.'
+    )
+    expect(probe.eligibility).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await i18n.changeLanguage('ja')
+    })
+    try {
+      // An ordinary idle re-render, the same shape as a git-status poll tick.
+      await act(async () => {
+        useAppStore.setState({ gitStatusByWorktree: { [WORKTREE_ID]: [] } })
+      })
+
+      expect(banner()).toBe(
+        'このファイルには参照形式のリンクが含まれているため、コードモードでのみ編集できます。'
+      )
+      // The decision is still cached — only the string was re-resolved.
+      expect(probe.eligibility).toHaveBeenCalledTimes(1)
+    } finally {
+      await act(async () => {
+        await i18n.changeLanguage('en')
+      })
+    }
+
+    await act(async () => {
+      useAppStore.setState({ gitStatusByWorktree: { [WORKTREE_ID]: [] } })
+    })
+    expect(banner()).toBe(
+      'Editable only in code mode because this file contains reference-style links.'
+    )
+    expect(probe.eligibility).toHaveBeenCalledTimes(1)
   })
 
   it('keeps the content-change callback identity stable across content loads', async () => {

--- a/src/renderer/src/components/editor/EditorPanel.markdown-classification-memoization.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.markdown-classification-memoization.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import type { OpenFile } from '@/store/slices/editor'
+import type { FileContent } from './editor-panel-content-types'
+import type * as MarkdownRichModeModule from './markdown-rich-mode'
+import type * as MarkdownRoundTripModule from './markdown-round-trip'
+
+type ShellProps = {
+  onContentChangeForFile: (file: OpenFile | null, content: string) => void
+}
+
+const probe = vi.hoisted(() => ({
+  eligibility: vi.fn(),
+  roundTrip: vi.fn(),
+  shellRender: vi.fn(),
+  lastShellProps: null as ShellProps | null
+}))
+
+const contentState = vi.hoisted(() => ({
+  fileContents: {} as Record<string, FileContent>
+}))
+
+vi.mock('./markdown-rich-mode', async (importActual) => {
+  const actual = await importActual<typeof MarkdownRichModeModule>()
+  return {
+    ...actual,
+    getMarkdownRichModeEligibility: (params: { content: string; sizeOverridden: boolean }) => {
+      probe.eligibility(params.content)
+      return actual.getMarkdownRichModeEligibility(params)
+    }
+  }
+})
+
+vi.mock('./markdown-round-trip', async (importActual) => {
+  const actual = await importActual<typeof MarkdownRoundTripModule>()
+  return {
+    ...actual,
+    getRichMarkdownRoundTripOutput: (content: string) => {
+      probe.roundTrip(content)
+      return actual.getRichMarkdownRoundTripOutput(content)
+    }
+  }
+})
+
+vi.mock('./EditorPanelShell', () => ({
+  EditorPanelShell: (props: ShellProps) => {
+    probe.shellRender()
+    probe.lastShellProps = props
+    return <div data-editor-panel-shell="true" />
+  }
+}))
+
+vi.mock('./useEditorPanelContentState', () => ({
+  useEditorPanelContentState: () => ({
+    fileContents: contentState.fileContents,
+    diffContents: {},
+    reloadContent: () => {}
+  })
+}))
+
+import EditorPanel from './EditorPanel'
+import { resetMarkdownRichModeEligibilityCache } from './markdown-rich-mode-eligibility-cache'
+
+const WORKTREE_ID = 'wt-memo'
+const FILE_PATH = '/repo/notes.md'
+
+// Why: HTML in the body is the branch that reaches the TipTap round trip, and
+// staying under 50 KB keeps the round trip eligible rather than size-blocked.
+const MARKDOWN_WITH_HTML = [
+  '---',
+  'title: Notes',
+  '---',
+  '',
+  '# Notes',
+  '',
+  '<div class="callout">Heads up</div>',
+  '',
+  '<!-- a comment -->',
+  '',
+  'Body text.',
+  ''
+].join('\n')
+
+function makeOpenFile(): OpenFile {
+  return {
+    id: FILE_PATH,
+    filePath: FILE_PATH,
+    relativePath: 'notes.md',
+    worktreeId: WORKTREE_ID,
+    language: 'markdown',
+    mode: 'edit',
+    isDirty: false
+  }
+}
+
+const initialAppState = useAppStore.getInitialState()
+let container: HTMLDivElement
+let root: Root
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+describe('EditorPanel markdown classification memoization', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    probe.eligibility.mockClear()
+    probe.roundTrip.mockClear()
+    probe.shellRender.mockClear()
+    probe.lastShellProps = null
+    resetMarkdownRichModeEligibilityCache()
+    const file = makeOpenFile()
+    contentState.fileContents = { [file.id]: { content: MARKDOWN_WITH_HTML, isBinary: false } }
+    useAppStore.setState(initialAppState, true)
+    useAppStore.setState({
+      openFiles: [file],
+      activeFileId: file.id,
+      markdownViewMode: { [file.id]: 'rich' },
+      gitStatusByWorktree: { [WORKTREE_ID]: [] }
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+    resetMarkdownRichModeEligibilityCache()
+  })
+
+  it('classifies once per content change, not once per unrelated store write', async () => {
+    await act(async () => root.render(<EditorPanel />))
+    await flushEffects()
+
+    expect(container.querySelector('[data-editor-panel-shell="true"]')).not.toBeNull()
+    expect(probe.eligibility).toHaveBeenCalledTimes(1)
+    expect(probe.roundTrip).toHaveBeenCalledTimes(1)
+
+    const rendersAfterMount = probe.shellRender.mock.calls.length
+
+    // An idle git-status poll: same data, fresh array identity, exactly what the
+    // worktree poller writes on every tick.
+    for (let tick = 0; tick < 20; tick += 1) {
+      await act(async () => {
+        useAppStore.setState({ gitStatusByWorktree: { [WORKTREE_ID]: [] } })
+      })
+    }
+
+    expect(probe.shellRender.mock.calls.length).toBeGreaterThan(rendersAfterMount)
+    expect(probe.eligibility).toHaveBeenCalledTimes(1)
+    expect(probe.roundTrip).toHaveBeenCalledTimes(1)
+  })
+
+  it('reclassifies when the document content actually changes', async () => {
+    await act(async () => root.render(<EditorPanel />))
+    await flushEffects()
+    expect(probe.eligibility).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      useAppStore.getState().setEditorDraft(FILE_PATH, `${MARKDOWN_WITH_HTML}\nMore text.\n`)
+    })
+
+    expect(probe.eligibility).toHaveBeenCalledTimes(2)
+    expect(probe.eligibility).toHaveBeenLastCalledWith(`${MARKDOWN_WITH_HTML}\nMore text.\n`)
+  })
+
+  it('flips the dirty flag on edit and back on undo to the original', async () => {
+    await act(async () => root.render(<EditorPanel />))
+    await flushEffects()
+
+    const file = useAppStore.getState().openFiles[0]
+    const change = (content: string): Promise<void> =>
+      act(async () => probe.lastShellProps?.onContentChangeForFile(file, content))
+    const isDirty = (): boolean | undefined =>
+      useAppStore.getState().openFiles.find((entry) => entry.id === FILE_PATH)?.isDirty
+
+    expect(isDirty()).toBe(false)
+
+    await change(`${MARKDOWN_WITH_HTML}a`)
+    expect(isDirty()).toBe(true)
+
+    await change(`${MARKDOWN_WITH_HTML}ab`)
+    expect(isDirty()).toBe(true)
+
+    await change(`${MARKDOWN_WITH_HTML}a`)
+    expect(isDirty()).toBe(true)
+
+    // Undo back to the loaded content.
+    await change(MARKDOWN_WITH_HTML)
+    expect(isDirty()).toBe(false)
+
+    // Markdown ignores trailing whitespace, exactly as before.
+    await change(`${MARKDOWN_WITH_HTML}\n\n`)
+    expect(isDirty()).toBe(false)
+
+    // A same-length edit is still detected.
+    await change(`${MARKDOWN_WITH_HTML.slice(0, -1)}X`)
+    expect(isDirty()).toBe(true)
+
+    await change(MARKDOWN_WITH_HTML)
+    expect(isDirty()).toBe(false)
+  })
+
+  it('keeps the content-change callback identity stable across content loads', async () => {
+    await act(async () => root.render(<EditorPanel />))
+    await flushEffects()
+
+    const initialCallback = probe.lastShellProps?.onContentChangeForFile
+    expect(initialCallback).toBeTypeOf('function')
+
+    // A background file read replaces the loaded-content maps.
+    contentState.fileContents = {
+      [FILE_PATH]: { content: `${MARKDOWN_WITH_HTML}\nReloaded.\n`, isBinary: false }
+    }
+    await act(async () => {
+      useAppStore.setState({ gitStatusByWorktree: { [WORKTREE_ID]: [] } })
+    })
+
+    expect(probe.lastShellProps?.onContentChangeForFile).toBe(initialCallback)
+
+    // …and the stable callback still compares against the freshly loaded content.
+    const file = useAppStore.getState().openFiles[0]
+    await act(async () =>
+      probe.lastShellProps?.onContentChangeForFile(file, `${MARKDOWN_WITH_HTML}\nReloaded.\n`)
+    )
+    expect(useAppStore.getState().openFiles[0]?.isDirty).toBe(false)
+  })
+})

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -18,6 +18,7 @@ import { useEditorPanelContentState } from './useEditorPanelContentState'
 import { useMarkdownPreviewShortcut } from './useMarkdownPreviewShortcut'
 import { useUntitledFileRename } from './useUntitledFileRename'
 import { extractFrontMatter } from './markdown-frontmatter'
+import { isEditorContentUnchanged } from './editor-content-dirty-state'
 import {
   selectEditorPanelGitBranchEntries,
   selectEditorPanelGitStatusEntries
@@ -145,28 +146,33 @@ function EditorPanelInner({
   useClosedEditorTabCleanup(openFiles)
   useMarkdownPreviewShortcut({ activeFile, panelRef, openMarkdownPreview })
 
+  // Why: reading loaded content through refs keeps this callback identity stable
+  // across content loads, so a background file read stops pushing fresh props
+  // through the whole memoized editor subtree.
+  const fileContentsRef = useRef(fileContents)
+  fileContentsRef.current = fileContents
+  const diffContentsRef = useRef(diffContents)
+  diffContentsRef.current = diffContents
   const handleContentChangeForFile = useCallback(
     (file: typeof activeFile, content: string) => {
       if (!file) {
         return
       }
       setEditorDraft(file.id, content)
-      const normalize =
-        file.language === 'markdown'
-          ? (value: string): string => value.trimEnd()
-          : (value: string): string => value
+      const ignoreTrailingWhitespace = file.language === 'markdown'
       if (file.mode === 'edit') {
+        const original = fileContentsRef.current[file.id]?.content ?? ''
         markFileDirty(
           file.id,
-          normalize(content) !== normalize(fileContents[file.id]?.content ?? '')
+          !isEditorContentUnchanged(content, original, ignoreTrailingWhitespace)
         )
         return
       }
-      const diffContent = diffContents[file.id]
+      const diffContent = diffContentsRef.current[file.id]
       const original = diffContent?.kind === 'text' ? diffContent.modifiedContent : ''
-      markFileDirty(file.id, normalize(content) !== normalize(original))
+      markFileDirty(file.id, !isEditorContentUnchanged(content, original, ignoreTrailingWhitespace))
     },
-    [diffContents, fileContents, markFileDirty, setEditorDraft]
+    [markFileDirty, setEditorDraft]
   )
 
   const handleContentChange = useCallback(

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -18,7 +18,7 @@ import { useEditorPanelContentState } from './useEditorPanelContentState'
 import { useMarkdownPreviewShortcut } from './useMarkdownPreviewShortcut'
 import { useUntitledFileRename } from './useUntitledFileRename'
 import { extractFrontMatter } from './markdown-frontmatter'
-import { isEditorContentUnchanged } from './editor-content-dirty-state'
+import { useEditorContentChangeHandler } from './use-editor-content-change-handler'
 import {
   selectEditorPanelGitBranchEntries,
   selectEditorPanelGitStatusEntries
@@ -80,7 +80,6 @@ function EditorPanelInner({
     [activeFile]
   )
   const editorDrafts = useAppStore(editorDraftSelector)
-  const setEditorDraft = useAppStore((s) => s.setEditorDraft)
   const settings = useAppStore((s) => s.settings)
   const panelRef = useRef<HTMLDivElement>(null)
   const [copiedPathToast, setCopiedPathToast] = useState<{ fileId: string; token: number } | null>(
@@ -146,34 +145,7 @@ function EditorPanelInner({
   useClosedEditorTabCleanup(openFiles)
   useMarkdownPreviewShortcut({ activeFile, panelRef, openMarkdownPreview })
 
-  // Why: reading loaded content through refs keeps this callback identity stable
-  // across content loads, so a background file read stops pushing fresh props
-  // through the whole memoized editor subtree.
-  const fileContentsRef = useRef(fileContents)
-  fileContentsRef.current = fileContents
-  const diffContentsRef = useRef(diffContents)
-  diffContentsRef.current = diffContents
-  const handleContentChangeForFile = useCallback(
-    (file: typeof activeFile, content: string) => {
-      if (!file) {
-        return
-      }
-      setEditorDraft(file.id, content)
-      const ignoreTrailingWhitespace = file.language === 'markdown'
-      if (file.mode === 'edit') {
-        const original = fileContentsRef.current[file.id]?.content ?? ''
-        markFileDirty(
-          file.id,
-          !isEditorContentUnchanged(content, original, ignoreTrailingWhitespace)
-        )
-        return
-      }
-      const diffContent = diffContentsRef.current[file.id]
-      const original = diffContent?.kind === 'text' ? diffContent.modifiedContent : ''
-      markFileDirty(file.id, !isEditorContentUnchanged(content, original, ignoreTrailingWhitespace))
-    },
-    [markFileDirty, setEditorDraft]
-  )
+  const handleContentChangeForFile = useEditorContentChangeHandler({ fileContents, diffContents })
 
   const handleContentChange = useCallback(
     (content: string) => {

--- a/src/renderer/src/components/editor/editor-content-dirty-state.test.ts
+++ b/src/renderer/src/components/editor/editor-content-dirty-state.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { isEditorContentUnchanged } from './editor-content-dirty-state'
+
+// Why: the exact expression the editor used before, kept as the equivalence oracle.
+function referenceUnchanged(
+  content: string,
+  original: string,
+  ignoreTrailingWhitespace: boolean
+): boolean {
+  const normalize = ignoreTrailingWhitespace
+    ? (value: string): string => value.trimEnd()
+    : (value: string): string => value
+  return normalize(content) === normalize(original)
+}
+
+const SAMPLES = [
+  '',
+  ' ',
+  '\n',
+  '\n\n',
+  '  \t\n',
+  '# Title',
+  '# Title\n',
+  '# Title\n\n',
+  '# Title \n',
+  '# Titl',
+  '# Titles',
+  '# Title\r\n',
+  '# Title\r\n\r\n',
+  '# Title ',
+  '# Title ',
+  '# Title　',
+  'a'.repeat(2_000),
+  `${'a'.repeat(2_000)}\n`,
+  `${'a'.repeat(1_999)}b`
+]
+
+describe('isEditorContentUnchanged', () => {
+  it('matches the trimEnd comparison for every pair in the corpus', () => {
+    for (const content of SAMPLES) {
+      for (const original of SAMPLES) {
+        for (const ignoreTrailingWhitespace of [false, true]) {
+          expect({
+            content,
+            original,
+            ignoreTrailingWhitespace,
+            result: isEditorContentUnchanged(content, original, ignoreTrailingWhitespace)
+          }).toEqual({
+            content,
+            original,
+            ignoreTrailingWhitespace,
+            result: referenceUnchanged(content, original, ignoreTrailingWhitespace)
+          })
+        }
+      }
+    }
+  })
+
+  it('treats markdown trailing whitespace as insignificant', () => {
+    expect(isEditorContentUnchanged('# Title\n\n\n', '# Title\n', true)).toBe(true)
+    expect(isEditorContentUnchanged('# Title\n\n\n', '# Title\n', false)).toBe(false)
+  })
+
+  it('detects a same-length edit', () => {
+    expect(isEditorContentUnchanged('# Titlf\n', '# Title\n', true)).toBe(false)
+  })
+
+  it('reports unchanged again after an edit is undone back to the original', () => {
+    const original = '# Notes\n\nBody text.\n'
+    expect(isEditorContentUnchanged(original, original, true)).toBe(true)
+    expect(isEditorContentUnchanged(`${original}x`, original, true)).toBe(false)
+    expect(isEditorContentUnchanged(original, original, true)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/editor/editor-content-dirty-state.ts
+++ b/src/renderer/src/components/editor/editor-content-dirty-state.ts
@@ -1,0 +1,39 @@
+const TRAILING_WHITESPACE_CHAR_RE = /\s/
+
+// Why: `String.prototype.trimEnd` and the regex `\s` class cover the same
+// WhiteSpace + LineTerminator set, so this reports `value.trimEnd().length`
+// without allocating a trimmed copy.
+function getTrimEndLength(value: string): number {
+  let end = value.length
+  while (end > 0 && TRAILING_WHITESPACE_CHAR_RE.test(value[end - 1])) {
+    end -= 1
+  }
+  return end
+}
+
+/**
+ * Whether an editor buffer still matches the content it was loaded from, using
+ * the same comparison the dirty indicator has always used: exact for most
+ * languages, trailing-whitespace-insensitive for markdown.
+ *
+ * Why not `normalize(a) !== normalize(b)`: that allocated two full copies of the
+ * document on every keystroke. The trimmed lengths differ for almost every edit,
+ * which settles the answer before any character comparison happens; the
+ * remaining same-length case falls back to one native prefix compare.
+ */
+export function isEditorContentUnchanged(
+  content: string,
+  original: string,
+  ignoreTrailingWhitespace: boolean
+): boolean {
+  if (!ignoreTrailingWhitespace) {
+    return content === original
+  }
+  const originalEnd = getTrimEndLength(original)
+  if (getTrimEndLength(content) !== originalEnd) {
+    return false
+  }
+  return content.startsWith(
+    originalEnd === original.length ? original : original.slice(0, originalEnd)
+  )
+}

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -13,7 +13,7 @@ import type { EditorToggleValue } from './EditorViewToggle'
 import type { FileContent } from './editor-panel-content-types'
 import { canUseChangesModeForFile } from './editor-panel-file-mode'
 import { getMarkdownRenderMode, type MarkdownRenderState } from './markdown-render-mode'
-import { getMarkdownRichModeEligibility } from './markdown-rich-mode'
+import { getCachedMarkdownRichModeEligibility } from './markdown-rich-mode-eligibility-cache'
 
 type StoreState = ReturnType<typeof useAppStore.getState>
 
@@ -143,7 +143,7 @@ export function getEditorPanelRenderModel({
   if (canRenderInlineMarkdown) {
     const shouldClassifyRichMode = mdViewMode === 'rich'
     const richModeEligibility = shouldClassifyRichMode
-      ? getMarkdownRichModeEligibility({
+      ? getCachedMarkdownRichModeEligibility({
           content: inlineMarkdownContent,
           sizeOverridden: markdownRichModeSizeOverridden
         })

--- a/src/renderer/src/components/editor/markdown-rich-mode-eligibility-cache.test.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode-eligibility-cache.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { i18n } from '@/i18n/i18n'
 import { getMarkdownRichModeEligibility } from './markdown-rich-mode'
 import {
   getCachedMarkdownRichModeEligibility,
@@ -86,9 +87,27 @@ describe('getCachedMarkdownRichModeEligibility', () => {
     }
   })
 
-  it('returns the retained result for a repeated content string', () => {
-    const content = '# Title\n\n<div>Hi</div>\n'
-    const first = getCachedMarkdownRichModeEligibility({ content, sizeOverridden: false })
-    expect(getCachedMarkdownRichModeEligibility({ content, sizeOverridden: false })).toBe(first)
+  it('re-resolves the unsupported message per read instead of caching the string', async () => {
+    const content = '# Title\n\n[ref]: https://example.com\n\nSee [ref].\n'
+    const english = getCachedMarkdownRichModeEligibility({ content, sizeOverridden: false })
+    expect(english.unsupportedMessage).toBe(
+      'Editable only in code mode because this file contains reference-style links.'
+    )
+
+    await i18n.changeLanguage('ja')
+    try {
+      const japanese = getCachedMarkdownRichModeEligibility({ content, sizeOverridden: false })
+      expect(japanese.unsupportedMessage).not.toBeNull()
+      // Why: the decision is cached but the localized string is not, so a cache
+      // hit still follows the language active at read time.
+      expect(japanese.unsupportedMessage).not.toBe(english.unsupportedMessage)
+      expect(japanese.exceedsSizeLimit).toBe(english.exceedsSizeLimit)
+    } finally {
+      await i18n.changeLanguage('en')
+    }
+
+    expect(
+      getCachedMarkdownRichModeEligibility({ content, sizeOverridden: false }).unsupportedMessage
+    ).toBe(english.unsupportedMessage)
   })
 })

--- a/src/renderer/src/components/editor/markdown-rich-mode-eligibility-cache.test.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode-eligibility-cache.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getMarkdownRichModeEligibility } from './markdown-rich-mode'
+import {
+  getCachedMarkdownRichModeEligibility,
+  resetMarkdownRichModeEligibilityCache
+} from './markdown-rich-mode-eligibility-cache'
+
+const OVERSIZED_BODY = `${'lorem ipsum dolor sit amet '.repeat(2_500)}\n<span>tail</span>\n`
+
+const CORPUS: { name: string; content: string }[] = [
+  { name: 'empty', content: '' },
+  { name: 'whitespace only', content: '   \n\n\t\n' },
+  { name: 'plain markdown', content: '# Title\n\nA paragraph with **bold** text.\n' },
+  {
+    name: 'front matter only',
+    content: '---\ntitle: Notes\ntags: [a, b]\n---\n\n# Body\n\nText.\n'
+  },
+  {
+    name: 'front matter with embedded html',
+    content: '---\ntitle: Notes\n---\n\n<div class="callout">Hi</div>\n\nText.\n'
+  },
+  { name: 'embedded html', content: '# Title\n\n<div class="callout">Hi</div>\n\nText.\n' },
+  { name: 'html comment', content: '# Title\n\n<!-- hidden note -->\n\nText.\n' },
+  {
+    name: 'html inside a fenced code block',
+    content: '# Title\n\n```html\n<div>not real markup</div>\n```\n\nText.\n'
+  },
+  { name: 'html inside inline code', content: '# Title\n\nUse `<div>` here.\n' },
+  { name: 'reference links', content: '# Title\n\n[ref]: https://example.com\n\nSee [ref].\n' },
+  { name: 'footnotes', content: '# Title\n\nText[^1]\n\n[^1]: A footnote.\n' },
+  { name: 'jsx-ish tag', content: '# Title\n\n<MyComponent prop="1" />\n' },
+  { name: 'CRLF plain', content: '# Title\r\n\r\nA paragraph.\r\n' },
+  { name: 'CRLF with html', content: '# Title\r\n\r\n<div>Hi</div>\r\n\r\nText.\r\n' },
+  {
+    name: 'CRLF with front matter',
+    content: '---\r\ntitle: Notes\r\n---\r\n\r\n<!-- note -->\r\n\r\nText.\r\n'
+  },
+  { name: 'over the 50 KB round-trip threshold, with html', content: OVERSIZED_BODY },
+  {
+    name: 'over the 50 KB round-trip threshold, with front matter and html',
+    content: `---\ntitle: Big\n---\n\n${OVERSIZED_BODY}`
+  }
+]
+
+describe('getCachedMarkdownRichModeEligibility', () => {
+  beforeEach(() => {
+    resetMarkdownRichModeEligibilityCache()
+  })
+
+  afterEach(() => {
+    resetMarkdownRichModeEligibilityCache()
+  })
+
+  it.each(CORPUS)('matches the unmemoized classifier for $name', ({ content }) => {
+    for (const sizeOverridden of [false, true]) {
+      const expected = getMarkdownRichModeEligibility({ content, sizeOverridden })
+      resetMarkdownRichModeEligibilityCache()
+      // Cold, then warm — both must equal the uncached classifier.
+      expect(getCachedMarkdownRichModeEligibility({ content, sizeOverridden })).toEqual(expected)
+      expect(getCachedMarkdownRichModeEligibility({ content, sizeOverridden })).toEqual(expected)
+    }
+  })
+
+  it('keys on the sizeOverridden flag as well as the content', () => {
+    const content = OVERSIZED_BODY
+    expect(getCachedMarkdownRichModeEligibility({ content, sizeOverridden: false })).toEqual(
+      getMarkdownRichModeEligibility({ content, sizeOverridden: false })
+    )
+    expect(getCachedMarkdownRichModeEligibility({ content, sizeOverridden: true })).toEqual(
+      getMarkdownRichModeEligibility({ content, sizeOverridden: true })
+    )
+  })
+
+  it('stays correct once the corpus exceeds the cache capacity', () => {
+    const expected = CORPUS.map(({ content }) =>
+      getMarkdownRichModeEligibility({ content, sizeOverridden: false })
+    )
+    resetMarkdownRichModeEligibilityCache()
+    for (let pass = 0; pass < 3; pass += 1) {
+      CORPUS.forEach(({ content }, index) => {
+        expect(getCachedMarkdownRichModeEligibility({ content, sizeOverridden: false })).toEqual(
+          expected[index]
+        )
+      })
+    }
+  })
+
+  it('returns the retained result for a repeated content string', () => {
+    const content = '# Title\n\n<div>Hi</div>\n'
+    const first = getCachedMarkdownRichModeEligibility({ content, sizeOverridden: false })
+    expect(getCachedMarkdownRichModeEligibility({ content, sizeOverridden: false })).toBe(first)
+  })
+})

--- a/src/renderer/src/components/editor/markdown-rich-mode-eligibility-cache.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode-eligibility-cache.ts
@@ -1,12 +1,14 @@
 import {
-  getMarkdownRichModeEligibility,
-  type MarkdownRichModeEligibility
+  getMarkdownRichModeEligibilityDecision,
+  resolveMarkdownRichModeUnsupportedMessage,
+  type MarkdownRichModeEligibility,
+  type MarkdownRichModeEligibilityDecision
 } from './markdown-rich-mode'
 
 type EligibilityCacheEntry = {
   content: string
   sizeOverridden: boolean
-  result: MarkdownRichModeEligibility
+  decision: MarkdownRichModeEligibilityDecision
 }
 
 // Why: one entry per visible markdown surface (active tab plus split panes),
@@ -16,18 +18,36 @@ const MAX_ENTRIES = 4
 const entries: EligibilityCacheEntry[] = []
 
 /**
- * Memoized `getMarkdownRichModeEligibility`.
+ * Memoized rich-mode eligibility.
  *
- * Why: the classifier is pure but scans the whole document (and can build a
+ * Why: classifying is pure but scans the whole document (and can build a
  * throwaway TipTap editor to round-trip it), while `EditorPanel` re-renders
- * from ~18 store subscriptions — including idle git-status polls. Keying on
- * the content string keeps classification at once per content change instead
- * of once per render, with byte-identical output.
+ * from ~18 store subscriptions — including idle git-status polls. Keying on the
+ * content string keeps classification at once per content change instead of
+ * once per render.
+ *
+ * Only the *decision* is cached. `unsupportedMessage` is resolved per read
+ * because the matcher messages are late-bound `translate()` getters: caching
+ * the string would freeze the fallback banner in whatever UI language happened
+ * to be active when the document was first classified, which is wrong both on
+ * a language switch and at startup (the persisted language is applied from an
+ * effect, after the first render).
  */
 export function getCachedMarkdownRichModeEligibility(params: {
   content: string
   sizeOverridden: boolean
 }): MarkdownRichModeEligibility {
+  const decision = getCachedMarkdownRichModeEligibilityDecision(params)
+  return {
+    exceedsSizeLimit: decision.exceedsSizeLimit,
+    unsupportedMessage: resolveMarkdownRichModeUnsupportedMessage(decision.unsupportedReason)
+  }
+}
+
+function getCachedMarkdownRichModeEligibilityDecision(params: {
+  content: string
+  sizeOverridden: boolean
+}): MarkdownRichModeEligibilityDecision {
   const { content, sizeOverridden } = params
   for (let index = 0; index < entries.length; index += 1) {
     const entry = entries[index]
@@ -38,15 +58,15 @@ export function getCachedMarkdownRichModeEligibility(params: {
       entries.splice(index, 1)
       entries.unshift(entry)
     }
-    return entry.result
+    return entry.decision
   }
 
-  const result = getMarkdownRichModeEligibility({ content, sizeOverridden })
-  entries.unshift({ content, sizeOverridden, result })
+  const decision = getMarkdownRichModeEligibilityDecision({ content, sizeOverridden })
+  entries.unshift({ content, sizeOverridden, decision })
   if (entries.length > MAX_ENTRIES) {
     entries.length = MAX_ENTRIES
   }
-  return result
+  return decision
 }
 
 export function resetMarkdownRichModeEligibilityCache(): void {

--- a/src/renderer/src/components/editor/markdown-rich-mode-eligibility-cache.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode-eligibility-cache.ts
@@ -1,0 +1,54 @@
+import {
+  getMarkdownRichModeEligibility,
+  type MarkdownRichModeEligibility
+} from './markdown-rich-mode'
+
+type EligibilityCacheEntry = {
+  content: string
+  sizeOverridden: boolean
+  result: MarkdownRichModeEligibility
+}
+
+// Why: one entry per visible markdown surface (active tab plus split panes),
+// so a split view does not evict its own siblings on every render.
+const MAX_ENTRIES = 4
+
+const entries: EligibilityCacheEntry[] = []
+
+/**
+ * Memoized `getMarkdownRichModeEligibility`.
+ *
+ * Why: the classifier is pure but scans the whole document (and can build a
+ * throwaway TipTap editor to round-trip it), while `EditorPanel` re-renders
+ * from ~18 store subscriptions — including idle git-status polls. Keying on
+ * the content string keeps classification at once per content change instead
+ * of once per render, with byte-identical output.
+ */
+export function getCachedMarkdownRichModeEligibility(params: {
+  content: string
+  sizeOverridden: boolean
+}): MarkdownRichModeEligibility {
+  const { content, sizeOverridden } = params
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index]
+    if (entry.sizeOverridden !== sizeOverridden || entry.content !== content) {
+      continue
+    }
+    if (index > 0) {
+      entries.splice(index, 1)
+      entries.unshift(entry)
+    }
+    return entry.result
+  }
+
+  const result = getMarkdownRichModeEligibility({ content, sizeOverridden })
+  entries.unshift({ content, sizeOverridden, result })
+  if (entries.length > MAX_ENTRIES) {
+    entries.length = MAX_ENTRIES
+  }
+  return result
+}
+
+export function resetMarkdownRichModeEligibilityCache(): void {
+  entries.length = 0
+}

--- a/src/renderer/src/components/editor/markdown-rich-mode.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.ts
@@ -21,6 +21,19 @@ export type MarkdownRichModeEligibility = {
   unsupportedMessage: string | null
 }
 
+/**
+ * The part of rich-mode eligibility that is a pure function of the document.
+ *
+ * Why this is split out: `unsupportedMessage` is deliberately late-bound — the
+ * matcher messages are `get message()` accessors that call `translate()` at
+ * access time, so they follow the active UI language. Anything that caches
+ * eligibility must cache this decision and re-resolve the message per read.
+ */
+export type MarkdownRichModeEligibilityDecision = {
+  exceedsSizeLimit: boolean
+  unsupportedReason: MarkdownRichModeUnsupportedReason | null
+}
+
 const KNOWN_MARKDOWN_HTML_TAG_NAMES = new Set(defaultSchema.tagNames ?? [])
 
 const UNSUPPORTED_PATTERNS: UnsupportedMatch[] = [
@@ -60,6 +73,25 @@ const UNSUPPORTED_PATTERNS: UnsupportedMatch[] = [
 ]
 
 export function getMarkdownRichModeUnsupportedMessage(content: string): string | null {
+  return resolveMarkdownRichModeUnsupportedMessage(getMarkdownRichModeUnsupportedReason(content))
+}
+
+/**
+ * Reads the matcher's localized message through its getter, so the string
+ * always reflects the language active at call time.
+ */
+export function resolveMarkdownRichModeUnsupportedMessage(
+  reason: MarkdownRichModeUnsupportedReason | null
+): string | null {
+  if (reason === null) {
+    return null
+  }
+  return UNSUPPORTED_PATTERNS.find((matcher) => matcher.reason === reason)?.message ?? null
+}
+
+export function getMarkdownRichModeUnsupportedReason(
+  content: string
+): MarkdownRichModeUnsupportedReason | null {
   // Why: front-matter is handled externally — stripped before the rich editor
   // sees the content and displayed as a read-only block. Only the body needs
   // to pass the unsupported-content checks.
@@ -82,7 +114,7 @@ export function getMarkdownRichModeUnsupportedMessage(content: string): string |
       continue
     }
     if (matcher.pattern.test(contentWithoutCode)) {
-      return matcher.message
+      return matcher.reason
     }
   }
 
@@ -94,23 +126,33 @@ export function getMarkdownRichModeUnsupportedMessage(content: string): string |
     if (roundTripOutput && preservesEmbeddedHtml(contentWithoutCode, roundTripOutput)) {
       return null
     }
-    return htmlMatcher!.message
+    return htmlMatcher!.reason
   }
 
   return null
 }
 
-export function getMarkdownRichModeEligibility({
+export function getMarkdownRichModeEligibilityDecision({
   content,
   sizeOverridden
 }: {
   content: string
   sizeOverridden: boolean
-}): MarkdownRichModeEligibility {
-  const exceedsSizeLimit = !sizeOverridden && exceedsMarkdownRichModeSizeLimit(content)
+}): MarkdownRichModeEligibilityDecision {
   return {
-    exceedsSizeLimit,
-    unsupportedMessage: getMarkdownRichModeUnsupportedMessage(content)
+    exceedsSizeLimit: !sizeOverridden && exceedsMarkdownRichModeSizeLimit(content),
+    unsupportedReason: getMarkdownRichModeUnsupportedReason(content)
+  }
+}
+
+export function getMarkdownRichModeEligibility(params: {
+  content: string
+  sizeOverridden: boolean
+}): MarkdownRichModeEligibility {
+  const decision = getMarkdownRichModeEligibilityDecision(params)
+  return {
+    exceedsSizeLimit: decision.exceedsSizeLimit,
+    unsupportedMessage: resolveMarkdownRichModeUnsupportedMessage(decision.unsupportedReason)
   }
 }
 

--- a/src/renderer/src/components/editor/monaco-conflict-decorations.ts
+++ b/src/renderer/src/components/editor/monaco-conflict-decorations.ts
@@ -1,4 +1,5 @@
 import type { editor, IRange } from 'monaco-editor'
+import { forEachLine } from './text-line-offsets'
 
 type ConflictBlock = {
   startLine: number
@@ -197,25 +198,6 @@ export function buildGitConflictDecorations(content: string): editor.IModelDelta
   }
 
   return decorations
-}
-
-function forEachLine(
-  content: string,
-  visit: (lineStart: number, lineEnd: number, lineNumber: number) => boolean | void
-): void {
-  let lineStart = 0
-  let lineNumber = 1
-  for (let index = 0; index <= content.length; index += 1) {
-    if (index < content.length && content.charCodeAt(index) !== 10) {
-      continue
-    }
-    const lineEnd = index > lineStart && content.charCodeAt(index - 1) === 13 ? index - 1 : index
-    if (visit(lineStart, lineEnd, lineNumber) === false) {
-      return
-    }
-    lineStart = index + 1
-    lineNumber += 1
-  }
 }
 
 function lineStartsWith(

--- a/src/renderer/src/components/editor/monaco-markdown-doc-link-decorations.offset-scan.test.ts
+++ b/src/renderer/src/components/editor/monaco-markdown-doc-link-decorations.offset-scan.test.ts
@@ -1,0 +1,159 @@
+import type { IRange } from 'monaco-editor'
+import { describe, expect, it } from 'vitest'
+import { getMarkdownDocLinkTarget } from './markdown-doc-links'
+import { getMarkdownDocLinkDecorationRanges } from './monaco-markdown-doc-link-decorations'
+
+// Why: the pre-offset implementation, kept verbatim as the equivalence oracle
+// for the allocation-free scan that replaced it.
+function referenceDecorationRanges(content: string): IRange[] {
+  const getInlineCodeSpans = (line: string): { start: number; end: number }[] => {
+    const spans: { start: number; end: number }[] = []
+    let start = -1
+    for (let index = 0; index < line.length; index += 1) {
+      if (line[index] !== '`' || (index > 0 && line[index - 1] === '\\')) {
+        continue
+      }
+      if (start === -1) {
+        start = index
+      } else {
+        spans.push({ start, end: index + 1 })
+        start = -1
+      }
+    }
+    return spans
+  }
+  const isInsideSpan = (index: number, spans: { start: number; end: number }[]): boolean =>
+    spans.some((span) => index >= span.start && index < span.end)
+
+  const ranges: IRange[] = []
+  let insideFence = false
+  let lineStart = 0
+  let lineNumber = 1
+  for (let index = 0; index <= content.length; index += 1) {
+    if (index < content.length && content.charCodeAt(index) !== 10) {
+      continue
+    }
+    const lineEnd = index > lineStart && content.charCodeAt(index - 1) === 13 ? index - 1 : index
+    const line = content.slice(lineStart, lineEnd)
+    lineStart = index + 1
+    const currentLineNumber = lineNumber
+    lineNumber += 1
+
+    if (/^\s*(```|~~~)/.test(line)) {
+      insideFence = !insideFence
+      continue
+    }
+    if (insideFence) {
+      continue
+    }
+    const inlineCodeSpans = getInlineCodeSpans(line)
+    let searchFrom = 0
+    while (searchFrom < line.length) {
+      const start = line.indexOf('[[', searchFrom)
+      if (start === -1) {
+        break
+      }
+      const end = line.indexOf(']]', start + 2)
+      if (end === -1) {
+        break
+      }
+      if (!isInsideSpan(start, inlineCodeSpans)) {
+        const target = getMarkdownDocLinkTarget(line.slice(start + 2, end))
+        if (target) {
+          ranges.push({
+            startLineNumber: currentLineNumber,
+            startColumn: start + 1,
+            endLineNumber: currentLineNumber,
+            endColumn: end + 3
+          })
+        }
+      }
+      searchFrom = end + 2
+    }
+  }
+  return ranges
+}
+
+const CORPUS: { name: string; content: string }[] = [
+  { name: 'empty', content: '' },
+  { name: 'no links', content: '# Title\n\nJust prose.\n' },
+  { name: 'single link', content: '# Title\n\nSee [[notes.md]] for details.\n' },
+  { name: 'two links on one line', content: 'See [[a.md]] and [[b.md]].\n' },
+  { name: 'link with an anchor', content: 'See [[a.md#heading]].\n' },
+  { name: 'link with a display alias', content: 'See [[a.md|Alias]].\n' },
+  { name: 'link inside inline code', content: 'Type `[[a.md]]` to link.\n' },
+  { name: 'link after inline code', content: 'Type `code` then [[a.md]].\n' },
+  { name: 'escaped backtick before a link', content: 'A \\` then [[a.md]] here.\n' },
+  {
+    name: 'link inside a backtick fence',
+    content: '```\n[[a.md]]\n```\n\n[[b.md]]\n'
+  },
+  {
+    name: 'link inside a tilde fence',
+    content: '~~~\n[[a.md]]\n~~~\n\n[[b.md]]\n'
+  },
+  { name: 'indented fence', content: '   ```\n[[a.md]]\n   ```\n[[b.md]]\n' },
+  { name: 'unterminated fence', content: '```\n[[a.md]]\n' },
+  { name: 'blank line before a fence', content: '\n```\n[[a.md]]\n```\n[[b.md]]\n' },
+  { name: 'whitespace-only line then a fence', content: '   \n```js\n[[a.md]]\n```\n[[b.md]]\n' },
+  { name: 'open bracket without a close', content: 'See [[a.md and nothing else.\n' },
+  { name: 'close on the next line', content: 'See [[a.md\n]] later.\n' },
+  { name: 'many unterminated opens', content: '[[a\n[[b\n[[c\n[[d\n' },
+  { name: 'empty link body', content: 'See [[]] here.\n' },
+  { name: 'no trailing newline', content: 'See [[a.md]]' },
+  { name: 'CRLF single link', content: 'See [[a.md]] here.\r\n' },
+  { name: 'CRLF link at end of line', content: 'See [[a.md]]\r\nNext [[b.md]]\r\n' },
+  { name: 'CRLF fence', content: '```\r\n[[a.md]]\r\n```\r\n[[b.md]]\r\n' },
+  { name: 'link split across a CRLF boundary', content: 'See [[a.md\r\n]] here.\r\n' },
+  { name: 'consecutive newlines', content: '\n\n[[a.md]]\n\n\n[[b.md]]\n\n' },
+  { name: 'nested brackets', content: 'See [[[a.md]]] here.\n' },
+  { name: 'unmatched inline code fence', content: 'A ` then [[a.md]] here.\n' }
+]
+
+const BIG_DOCUMENT = Array.from({ length: 4_000 }, (_, index) =>
+  index % 5 === 0
+    ? `Line ${index} links [[doc-${index}.md]] and \`[[skipped-${index}.md]]\`.`
+    : `Line ${index} is ordinary prose with no link at all.`
+).join('\n')
+
+describe('getMarkdownDocLinkDecorationRanges offset scan', () => {
+  it.each(CORPUS)('matches the substring implementation for $name', ({ content }) => {
+    expect(getMarkdownDocLinkDecorationRanges(content)).toEqual(referenceDecorationRanges(content))
+  })
+
+  it('matches the substring implementation on a large document', () => {
+    expect(getMarkdownDocLinkDecorationRanges(BIG_DOCUMENT)).toEqual(
+      referenceDecorationRanges(BIG_DOCUMENT)
+    )
+    expect(getMarkdownDocLinkDecorationRanges(BIG_DOCUMENT).length).toBeGreaterThan(0)
+  })
+
+  it('matches the substring implementation on a document with no links at all', () => {
+    const noLinks = Array.from({ length: 4_000 }, (_, index) => `Line ${index} prose.`).join('\n')
+    expect(getMarkdownDocLinkDecorationRanges(noLinks)).toEqual(referenceDecorationRanges(noLinks))
+  })
+
+  it('does not rescan the document tail once per line', () => {
+    const linkFree = Array.from(
+      { length: 20_000 },
+      (_, index) => `Line ${index} prose with no wiki link.`
+    ).join('\n')
+
+    const realIndexOf = String.prototype.indexOf
+    let indexOfCalls = 0
+    String.prototype.indexOf = function (this: string, ...args: unknown[]) {
+      indexOfCalls += 1
+      return (realIndexOf as (...a: unknown[]) => number).apply(this, args)
+    } as typeof String.prototype.indexOf
+    try {
+      getMarkdownDocLinkDecorationRanges(linkFree)
+    } finally {
+      String.prototype.indexOf = realIndexOf
+    }
+
+    // Why: the delimiter cursors are seeded once and never re-armed while they
+    // hold -1, so a link-free document costs a fixed number of searches rather
+    // than one tail scan per line.
+    expect(indexOfCalls).toBeLessThanOrEqual(8)
+  })
+})

--- a/src/renderer/src/components/editor/monaco-markdown-doc-link-decorations.ts
+++ b/src/renderer/src/components/editor/monaco-markdown-doc-link-decorations.ts
@@ -1,35 +1,67 @@
 import type { editor, IDisposable, IRange } from 'monaco-editor'
 import { getMarkdownDocLinkTarget } from './markdown-doc-links'
+import { forEachLine } from './text-line-offsets'
 
-function getInlineCodeSpans(line: string): { start: number; end: number }[] {
-  const spans: { start: number; end: number }[] = []
+const BACKTICK = 96
+const BACKSLASH = 92
+
+// Why: spans are stored as flat [start, end, start, end, …] absolute offsets so
+// a full-document scan allocates one reusable array instead of an object per span.
+function collectInlineCodeSpans(
+  content: string,
+  lineStart: number,
+  lineEnd: number,
+  spans: number[]
+): void {
+  spans.length = 0
   let start = -1
 
-  for (let index = 0; index < line.length; index += 1) {
-    if (line[index] !== '`' || (index > 0 && line[index - 1] === '\\')) {
+  for (let index = lineStart; index < lineEnd; index += 1) {
+    if (
+      content.charCodeAt(index) !== BACKTICK ||
+      (index > lineStart && content.charCodeAt(index - 1) === BACKSLASH)
+    ) {
       continue
     }
     if (start === -1) {
       start = index
     } else {
-      spans.push({ start, end: index + 1 })
+      spans.push(start, index + 1)
       start = -1
     }
   }
-
-  return spans
 }
 
-function isInsideSpan(index: number, spans: { start: number; end: number }[]): boolean {
-  return spans.some((span) => index >= span.start && index < span.end)
+function isInsideSpan(index: number, spans: number[]): boolean {
+  for (let cursor = 0; cursor < spans.length; cursor += 2) {
+    if (index >= spans[cursor] && index < spans[cursor + 1]) {
+      return true
+    }
+  }
+  return false
+}
+
+const FENCE_PREFIX_RE = /\s*(?:```|~~~)/y
+
+function startsCodeFence(content: string, lineStart: number, lineEnd: number): boolean {
+  FENCE_PREFIX_RE.lastIndex = lineStart
+  // Why: a sticky `\s*` run can cross the newline into the next line, so an
+  // out-of-line match is rejected to stay identical to the old per-line regex.
+  return FENCE_PREFIX_RE.test(content) && FENCE_PREFIX_RE.lastIndex <= lineEnd
 }
 
 export function getMarkdownDocLinkDecorationRanges(content: string): IRange[] {
   const ranges: IRange[] = []
+  const inlineCodeSpans: number[] = []
   let insideFence = false
+  // Why: `indexOf` on the whole document would rescan the tail once per line.
+  // Both cursors only ever move forward, and every probe position is
+  // monotonic, so the delimiter search stays linear in document length.
+  let nextOpen = content.indexOf('[[')
+  let nextClose = content.indexOf(']]')
 
-  forEachMarkdownLine(content, (line, lineNumber) => {
-    if (/^\s*(```|~~~)/.test(line)) {
+  forEachLine(content, (lineStart, lineEnd, lineNumber) => {
+    if (startsCodeFence(content, lineStart, lineEnd)) {
       insideFence = !insideFence
       return
     }
@@ -37,25 +69,37 @@ export function getMarkdownDocLinkDecorationRanges(content: string): IRange[] {
       return
     }
 
-    const inlineCodeSpans = getInlineCodeSpans(line)
-    let searchFrom = 0
-    while (searchFrom < line.length) {
-      const start = line.indexOf('[[', searchFrom)
-      if (start === -1) {
+    let spansCollected = false
+    let searchFrom = lineStart
+    while (searchFrom < lineEnd) {
+      if (nextOpen !== -1 && nextOpen < searchFrom) {
+        nextOpen = content.indexOf('[[', searchFrom)
+      }
+      const start = nextOpen
+      if (start === -1 || start + 2 > lineEnd) {
         break
       }
-      const end = line.indexOf(']]', start + 2)
-      if (end === -1) {
+      if (nextClose !== -1 && nextClose < start + 2) {
+        nextClose = content.indexOf(']]', start + 2)
+      }
+      const end = nextClose
+      if (end === -1 || end + 2 > lineEnd) {
         break
+      }
+      // Why: most lines hold no wiki link, so the inline-code scan is deferred
+      // until one is actually found.
+      if (!spansCollected) {
+        collectInlineCodeSpans(content, lineStart, lineEnd, inlineCodeSpans)
+        spansCollected = true
       }
       if (!isInsideSpan(start, inlineCodeSpans)) {
-        const target = getMarkdownDocLinkTarget(line.slice(start + 2, end))
+        const target = getMarkdownDocLinkTarget(content.slice(start + 2, end))
         if (target) {
           ranges.push({
             startLineNumber: lineNumber,
-            startColumn: start + 1,
+            startColumn: start - lineStart + 1,
             endLineNumber: lineNumber,
-            endColumn: end + 3
+            endColumn: end - lineStart + 3
           })
         }
       }
@@ -64,23 +108,6 @@ export function getMarkdownDocLinkDecorationRanges(content: string): IRange[] {
   })
 
   return ranges
-}
-
-function forEachMarkdownLine(
-  content: string,
-  visit: (line: string, lineNumber: number) => void
-): void {
-  let lineStart = 0
-  let lineNumber = 1
-  for (let index = 0; index <= content.length; index += 1) {
-    if (index < content.length && content.charCodeAt(index) !== 10) {
-      continue
-    }
-    const lineEnd = index > lineStart && content.charCodeAt(index - 1) === 13 ? index - 1 : index
-    visit(content.slice(lineStart, lineEnd), lineNumber)
-    lineStart = index + 1
-    lineNumber += 1
-  }
 }
 
 export type MarkdownDocLinkDecorationController = {

--- a/src/renderer/src/components/editor/text-line-offsets.ts
+++ b/src/renderer/src/components/editor/text-line-offsets.ts
@@ -1,0 +1,26 @@
+/**
+ * Visits every line of `content` as `[lineStart, lineEnd)` offsets, excluding a
+ * trailing `\r`. Return `false` from `visit` to stop early.
+ *
+ * Why offsets instead of substrings: these scans run over whole editor
+ * documents on every content change, and a 600 KB markdown file has ~43k lines
+ * — one substring per line was the bulk of their allocation cost.
+ */
+export function forEachLine(
+  content: string,
+  visit: (lineStart: number, lineEnd: number, lineNumber: number) => boolean | void
+): void {
+  let lineStart = 0
+  let lineNumber = 1
+  for (let index = 0; index <= content.length; index += 1) {
+    if (index < content.length && content.charCodeAt(index) !== 10) {
+      continue
+    }
+    const lineEnd = index > lineStart && content.charCodeAt(index - 1) === 13 ? index - 1 : index
+    if (visit(lineStart, lineEnd, lineNumber) === false) {
+      return
+    }
+    lineStart = index + 1
+    lineNumber += 1
+  }
+}

--- a/src/renderer/src/components/editor/use-editor-content-change-handler.ts
+++ b/src/renderer/src/components/editor/use-editor-content-change-handler.ts
@@ -1,0 +1,55 @@
+import { useCallback, useLayoutEffect, useRef } from 'react'
+import { useAppStore } from '@/store'
+import type { OpenFile } from '@/store/slices/editor'
+import type { DiffContent, FileContent } from './editor-panel-content-types'
+import { isEditorContentUnchanged } from './editor-content-dirty-state'
+
+/**
+ * Builds the editor's content-change handler: record the draft, then reconcile
+ * the dirty flag against the content the file was loaded with.
+ *
+ * Why the refs: depending on the loaded-content maps directly churned the
+ * callback identity on every content load, pushing fresh props through the
+ * whole memoized editor subtree. They are written in a layout effect rather
+ * than during render because a render React discards must not move the
+ * dirty-check baseline, and a committed one lands before any input event can
+ * reach the handler.
+ */
+export function useEditorContentChangeHandler({
+  fileContents,
+  diffContents
+}: {
+  fileContents: Record<string, FileContent>
+  diffContents: Record<string, DiffContent>
+}): (file: OpenFile | null, content: string) => void {
+  const markFileDirty = useAppStore((s) => s.markFileDirty)
+  const setEditorDraft = useAppStore((s) => s.setEditorDraft)
+  const fileContentsRef = useRef(fileContents)
+  const diffContentsRef = useRef(diffContents)
+  useLayoutEffect(() => {
+    fileContentsRef.current = fileContents
+    diffContentsRef.current = diffContents
+  }, [diffContents, fileContents])
+
+  return useCallback(
+    (file: OpenFile | null, content: string) => {
+      if (!file) {
+        return
+      }
+      setEditorDraft(file.id, content)
+      const ignoreTrailingWhitespace = file.language === 'markdown'
+      if (file.mode === 'edit') {
+        const original = fileContentsRef.current[file.id]?.content ?? ''
+        markFileDirty(
+          file.id,
+          !isEditorContentUnchanged(content, original, ignoreTrailingWhitespace)
+        )
+        return
+      }
+      const diffContent = diffContentsRef.current[file.id]
+      const original = diffContent?.kind === 'text' ? diffContent.modifiedContent : ''
+      markFileDirty(file.id, !isEditorContentUnchanged(content, original, ignoreTrailingWhitespace))
+    },
+    [markFileDirty, setEditorDraft]
+  )
+}

--- a/src/renderer/src/components/editor/use-monaco-editor-decorations.doc-link-refresh.test.tsx
+++ b/src/renderer/src/components/editor/use-monaco-editor-decorations.doc-link-refresh.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import { act, useRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { editor } from 'monaco-editor'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useMonacoEditorDecorations } from './use-monaco-editor-decorations'
+import type { MarkdownDocLinkDecorationController } from './monaco-markdown-doc-link-decorations'
+
+vi.mock('./monaco-markdown-doc-completions', () => ({
+  clearMarkdownDocCompletionDocuments: () => {},
+  setMarkdownDocCompletionDocuments: () => {}
+}))
+
+const refresh = vi.fn()
+const controller: MarkdownDocLinkDecorationController = { refresh, dispose: () => {} }
+
+function Harness({ content, language }: { content: string; language: string }): null {
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
+  const decorations = useMonacoEditorDecorations({
+    editorRef,
+    mountedEditor: null,
+    content,
+    language,
+    markdownDocuments: undefined,
+    conflictDecorationsEnabled: false
+  })
+  decorations.markdownDocLinkDecorationsRef.current = controller
+  return null
+}
+
+let container: HTMLDivElement
+let root: Root
+
+describe('useMonacoEditorDecorations doc-link refresh', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    refresh.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    document.body.replaceChildren()
+  })
+
+  it('does not refresh doc-link decorations on content changes', async () => {
+    await act(async () => root.render(<Harness content="# a" language="markdown" />))
+    refresh.mockClear()
+
+    for (let keystroke = 0; keystroke < 200; keystroke += 1) {
+      await act(async () =>
+        root.render(<Harness content={`# a${'x'.repeat(keystroke)}`} language="markdown" />)
+      )
+    }
+
+    // Why: `createMarkdownDocLinkDecorationController` already subscribes to
+    // `onDidChangeModelContent`, so the React mirror was pure duplicate work.
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('still refreshes when the language of a retained model changes', async () => {
+    await act(async () => root.render(<Harness content="# a" language="markdown" />))
+    refresh.mockClear()
+
+    await act(async () => root.render(<Harness content="# a" language="plaintext" />))
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/editor/use-monaco-editor-decorations.ts
+++ b/src/renderer/src/components/editor/use-monaco-editor-decorations.ts
@@ -52,9 +52,14 @@ export function useMonacoEditorDecorations(params: {
     }
   }, [editorRef, language, markdownDocuments])
 
+  // Why: content changes are already covered by the controller's own
+  // `onDidChangeModelContent` subscription (which also catches programmatic
+  // edits this effect never saw), so mirroring `content` here only doubled the
+  // debounce timer churn per keystroke. A language swap on a retained model has
+  // no content event, so that trigger stays.
   useEffect(() => {
     markdownDocLinkDecorationsRef.current?.refresh()
-  }, [content, language])
+  }, [language])
 
   useEffect(() => {
     const ed = mountedEditor


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​736 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​733 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​318 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​90 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 |

<!-- /orca-pr-loc -->

## ELI5

Every time anything in the app changed — a background Git status poll, a settings write, a keystroke — the editor re-read your entire open markdown file and re-decided "can this be edited in rich mode or not?" from scratch. That decision involves scanning the whole document several times and, for documents with HTML in them, building a throwaway rich-text editor and parsing the whole file just to check the answer. It only needs to happen when the document actually changes. Now it does. Same answer, same UI, just computed once instead of dozens of times a minute.

Two smaller versions of the same problem also got fixed: the wiki-link highlighter was being told to refresh twice per keystroke (once by React, once by Monaco — Monaco's is the accurate one), and the "is this file dirty?" check was allocating two full copies of the document on every keystroke to compare them.

## What was happening

**A — the whole document was reclassified on every `EditorPanel` render.**
`getEditorPanelRenderModel` (`editor-panel-render-model.ts:143-150`) called `getMarkdownRichModeEligibility` unmemoized, straight from `EditorPanel`'s render body (`EditorPanel.tsx:233`). `EditorPanel` subscribes to ~18 store slices — `settings`, `openFiles`, the active worktree's Git status, four view-mode maps, `pendingEditorReveal` — plus every `fileContents`/`diffContents` update. So for any markdown tab in rich mode (the default), every one of those writes re-ran `extractFrontMatter`, `stripMarkdownCode` (which builds a second full copy of the document via `sanitized +=`, two regex executions per line), and 2-3 whole-document regex scans. If the body contained an HTML tag or `<!-- -->` and was under 50 KB, it also called `getRichMarkdownRoundTripOutput`, whose own comment notes it "blocks for seconds on large files".

That module has a 20-entry content-keyed cache, so the *TipTap construction* usually did not repeat — but everything upstream of it did, on a completely idle app.

Fix: memoize the classifier in `markdown-rich-mode-eligibility-cache.ts` (4 entries, LRU, one per visible markdown surface).

Only the *decision* is cached, not the whole result. `unsupportedMessage` comes from a matcher `get message()` accessor that calls `translate()` at access time — the accessors are late-bound on purpose — so the active UI language is an ambient third input that a `(content, sizeOverridden)` key does not cover. `markdown-rich-mode.ts` now splits into `getMarkdownRichModeEligibilityDecision` (genuinely pure: `exceedsSizeLimit` plus which matcher fired) and `resolveMarkdownRichModeUnsupportedMessage` (reads the getter per read); `getMarkdownRichModeEligibility` keeps its old signature as a composition of the two. Adding the language to the key would have worked only until the next ambient input got added to the classifier.

**B — doc-link decoration refresh fired twice per keystroke.**
`use-monaco-editor-decorations.ts:55-58` fired `markdownDocLinkDecorationsRef.refresh()` from a React effect on every `content` change, while `createMarkdownDocLinkDecorationController` (`monaco-markdown-doc-link-decorations.ts:137`) already subscribes `onDidChangeModelContent(refresh)`. Both hit the same 120 ms coalescing timer, so every keystroke did a redundant `clearTimeout`/`setTimeout` pair. The React mirror is also strictly less accurate — it never sees programmatic edits that do not flow back through the `content` prop.

The effect's `language` dependency *is* load-bearing (a language swap on a retained Monaco model produces no content event), so the effect stays with `[language]` and loses `content`.

Separately, `forEachMarkdownLine` allocated one string per line for the whole document on every refresh. It now scans by `(lineStart, lineEnd)` offsets, matching the allocation-free `forEachLine` that already existed in `monaco-conflict-decorations.ts` — which is now the shared `text-line-offsets.ts` used by both. Two extra allocation cuts fell out: the inline-code-span scan is deferred until a line actually contains `[[`, and spans are stored as flat offset pairs instead of objects. The `[[`/`]]` searches use forward-only cursors so a document-wide `indexOf` can never rescan the tail per line.

**C — the dirty check allocated and compared the full document twice per keystroke.**
`EditorPanel.tsx:150-170` applied `value.trimEnd()` to both the new content and the stored original before comparing — two full document copies per keystroke, on a path where `markFileDirty` bails immediately from keystroke 2 onward. `isEditorContentUnchanged` now compares trimmed *lengths* first (a backward scan over trailing whitespace only, which settles almost every keystroke with zero allocation) and falls back to one native `startsWith` for the same-length case.

Separately, `handleContentChangeForFile` depended on `[diffContents, fileContents, …]`, so its identity churned on every content load and pushed fresh props through the whole editor subtree. The handler and the loaded-content maps it reads now live in `use-editor-content-change-handler.ts`, with the maps behind refs that are written in a `useLayoutEffect` rather than during render (the same latest-value pattern `useIpynbDocumentEditing` already uses). Writing them in render would let a render React discards move the dirty-check baseline; a layout effect only runs for committed renders and lands before any input event can reach the handler. Extracting the hook also keeps `EditorPanel.tsx` under the 400-line cap without a `max-lines` bump.

## Measurement

Measured in-process with a Vitest harness driving the real Zustand store and a real `EditorPanel` mount, run against `origin/main` and against this branch on the same machine and the same generated documents.

**Classifier + round-trip invocations per 60 s of idle** (one markdown tab open in rich mode, git-status poll writing a fresh entries array every 2 s = 30 ticks; `EditorPanel` re-rendered 31 times in both runs, so nothing is being hidden by fewer renders):

| Document | `getMarkdownRichModeEligibility` calls | `getRichMarkdownRoundTripOutput` calls | Wall time for the 30 idle ticks |
| --- | --- | --- | --- |
| 8 KB `.md` with HTML | 31 → **1** | 31 → **1** | 187.2 ms → 186.1 ms |
| 100 KB `.md` with HTML | 31 → **1** | 0 → 0 (over 50 KB, round trip already skipped) | 437.6 ms → **25-71 ms** (run-to-run noise; 3 post-fix runs) |

**`EditorPanel` render-model self time** (`getEditorPanelRenderModel`, 50 calls, average per render):

| Document | Before | After |
| --- | --- | --- |
| 100 KB `.md` with HTML | 6.485 ms | **0.011 ms** |
| 40 KB `.md` with HTML (round-trip eligible) | 0.574 ms | **0.004 ms** |

The 100 KB figure includes re-resolving the banner string through `translate()` on every read, since that document trips the HTML matcher. Documents that produce no banner short-circuit on a null reason and pay nothing. Worst case measured directly — 1,000 consecutive cached reads of a document that always shows a banner — is **0.034 ms** per read at 100 KB and **0.007 ms** at document sizes typical of a note.

**String allocations in the doc-link line scan**, 600 KB markdown / 46,230 lines, 200 simulated keystrokes (each triggering a full scan), counted by instrumenting `String.prototype.slice`:

| | Before | After |
| --- | --- | --- |
| Allocations per scan | 50,853 | **4,623** (only the matched links themselves) |
| Allocations per 200 keystrokes | 10,170,600 | **924,600** |
| Scan time per pass | 34.06 ms | **20.25 ms** |

**Doc-link `refreshNow` invocations per 200 keystrokes** (30 ms apart, 120 ms coalescing window):

| | refreshNow runs | debounce timer ops |
| --- | --- | --- |
| Before (React effect + model listener) | 1 | 800 |
| After (model listener only) | 1 | **400** |

`refreshNow` count is unchanged by design — the 120 ms coalesce already collapsed the duplicate into one run. What is removed is the duplicate effect invocation and its `clearTimeout`/`setTimeout` pair per keystroke. (Decorations actually land marginally *sooner* now: the React effect used to re-arm the timer a tick after the model listener already had.)

**Dirty-check allocation per 200 keystrokes**, 100 KB markdown document:

| | Full-document copies allocated | Bytes copied | Wall time |
| --- | --- | --- | --- |
| Before (`trimEnd()` on both sides) | 400 | 40.0 MB | 7.0 ms |
| After (length probe + prefix compare) | **0** | **0** | 0.5 ms |

## Negative user-facing trade-offs

None.

- Rich-mode vs source-mode selection is byte-identical: `markdown-rich-mode-eligibility-cache.test.ts` runs the memoized path against the unmemoized one over a corpus (empty, whitespace-only, front matter, embedded HTML, HTML comments, HTML in fenced/inline code, reference links, footnotes, JSX-ish tags, CRLF variants, and documents over the 50 KB round-trip threshold), cold and warm, at both `sizeOverridden` values, and across cache eviction.
- The rich-mode fallback banner still follows the UI language. Caching the resolved string would have frozen it — visible on a Settings language switch, and at startup for non-English users since `I18nProvider` applies the persisted language from an effect that runs after the first classification. Two tests cover it, both confirmed to fail against a string-caching cache: a unit test asserting a cache hit follows `i18n.changeLanguage('ja')`, and an `EditorPanel` test that renders the banner from a reference-link document, switches the language, forces an idle store write, and asserts the Japanese string while the cached decision is not recomputed.
- Decorations are identical: `monaco-markdown-doc-link-decorations.offset-scan.test.ts` keeps the previous substring implementation verbatim as an oracle and asserts range-for-range equality over 27 edge cases (fences, indented fences, unterminated fences, inline code, escaped backticks, CRLF, links split across line boundaries, nested brackets, no trailing newline) plus a 4,000-line document.
- The dirty dot behaves identically, including edit-then-undo-to-original: `editor-content-dirty-state.test.ts` cross-checks the new comparison against `trimEnd()`-based equality for all 361 ordered pairs of a whitespace-heavy corpus at both normalization settings, and `EditorPanel.markdown-classification-memoization.test.tsx` drives the real store through type → type → backspace → undo-to-original → trailing-whitespace-only → same-length edit → undo, asserting `isDirty` at every step.
- Nothing was debounced or deferred that runs synchronously today; connect-time mobile sync-key semantics and the draft hash are untouched.
- Retention: the eligibility cache holds at most 4 document strings, which the store already retains for open tabs; it is bounded and LRU-evicted.

## Risk & verification

The stabilized change handler is the piece that touches correctness most directly, so its refs are written in a `useLayoutEffect`, never in render — a discarded render must not be able to move the dirty-check baseline. `EditorPanel.markdown-classification-memoization.test.tsx` pins both directions after a background content reload: the stable handler reports clean for the newly committed content and dirty for the pre-reload content, and a probe confirms the handler keeps a single identity across 30 idle re-renders.

The offset-based doc-link scan is the other risk area, since it replaces per-line substrings with absolute-offset arithmetic. Two behaviours needed care and are covered:

1. The fence check `^\s*(```|~~~)` became a sticky regex over the full document, which can run `\s*` past the newline into the next line. Matches whose `lastIndex` exceeds `lineEnd` are rejected, so a blank line followed by a fence is not misread as a fence (covered by the "blank line before a fence" and "whitespace-only line then a fence" cases).
2. A naive `content.indexOf('[[', …)` per line would rescan the document tail on every line — quadratic. Both delimiter searches use forward-only cursors; a test instruments `String.prototype.indexOf` and asserts a 20,000-line link-free document costs a fixed number of searches.

Verification:

- `pnpm tc` clean.
- `pnpm run check:code-quality:changed` clean (0 findings across 16 changed files).
- `pnpm run lint:react-doctor:changed` and `pnpm run check:react-doctor:changed` clean (0 issues). These are a separate gate from `check:code-quality:changed`; an earlier revision of this PR tripped `no-ref-current-in-render` here and has been fixed properly rather than suppressed.
- `src/renderer/src/components/editor` + `src/renderer/src/components/floating-terminal` + `remote-host-file-open-repro.test.ts`: 218 files / 1,517 tests pass, re-run after both follow-up fixes. `src/renderer/src/store` also re-run green (546 files / 4,665 tests together with the editor suites).
- The memoization test fails on `origin/main` (21 classifier and 21 round-trip calls instead of 1 across 20 idle git-status ticks), and the callback-stability test fails without the refs — both confirmed by reverting each fix in place.
- Note: `src/renderer/src/components/right-sidebar/ai-vault-session-worktree-map.test.tsx` has a pre-existing timing flake — it fails intermittently on a clean `origin/main` checkout (verified 1 failure in 3 runs with this branch stashed). Unrelated to this change.
