### PR TITLE
fix(terminals): add equality bailouts to the tab pane-expansion actions

### DIFF
--- a/src/renderer/src/store/terminals/terminal-layout-state.ts
+++ b/src/renderer/src/store/terminals/terminal-layout-state.ts
@@ -43,15 +43,20 @@ export function createTerminalLayoutActions(
         }
       })
     },
+    // Why: pane mount/unmount re-asserts the same booleans; bailing like setTabLayout keeps map subscribers asleep.
     setTabPaneExpanded: (tabId, expanded) => {
-      set((s) => ({
-        expandedPaneByTabId: { ...s.expandedPaneByTabId, [tabId]: expanded }
-      }))
+      set((s) =>
+        s.expandedPaneByTabId[tabId] === expanded
+          ? s
+          : { expandedPaneByTabId: { ...s.expandedPaneByTabId, [tabId]: expanded } }
+      )
     },
     setTabCanExpandPane: (tabId, canExpand) => {
-      set((s) => ({
-        canExpandPaneByTabId: { ...s.canExpandPaneByTabId, [tabId]: canExpand }
-      }))
+      set((s) =>
+        s.canExpandPaneByTabId[tabId] === canExpand
+          ? s
+          : { canExpandPaneByTabId: { ...s.canExpandPaneByTabId, [tabId]: canExpand } }
+      )
     },
     setTabLayout: (tabId, layout) => {
       let ownershipTransfers: ReturnType<typeof resolveTerminalLayoutPtyOwnershipTransfers> = []

--- a/src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx
+++ b/src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+
+import { Profiler } from 'react'
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createTestStore } from '../slices/store-test-helpers'
+
+afterEach(cleanup)
+
+type TestStore = ReturnType<typeof createTestStore>
+
+const TAB_ID = 'tab-1'
+const NO_OP_WRITES = 25
+
+function recordPublishedMapKeys(store: TestStore): string[] {
+  const published: string[] = []
+  store.subscribe((next, previous) => {
+    if (next.expandedPaneByTabId !== previous.expandedPaneByTabId) {
+      published.push('expandedPaneByTabId')
+    }
+    if (next.canExpandPaneByTabId !== previous.canExpandPaneByTabId) {
+      published.push('canExpandPaneByTabId')
+    }
+  })
+  return published
+}
+
+// Mirrors use-terminal-workspace-store-bindings.ts:17, which subscribes to the raw map.
+function ExpandedPaneSubscriber({ store }: { store: TestStore }): React.JSX.Element {
+  const expandedPaneByTabId = store((s) => s.expandedPaneByTabId)
+  return <span>{String(expandedPaneByTabId[TAB_ID] === true)}</span>
+}
+
+function CanExpandPaneSubscriber({ store }: { store: TestStore }): React.JSX.Element {
+  const canExpandPaneByTabId = store((s) => s.canExpandPaneByTabId)
+  return <span>{String(canExpandPaneByTabId[TAB_ID] === true)}</span>
+}
+
+function renderCommitCounter(subscriber: React.JSX.Element): () => number {
+  let commits = 0
+  render(
+    <Profiler
+      id="terminal-pane-expansion"
+      onRender={() => {
+        commits += 1
+      }}
+    >
+      {subscriber}
+    </Profiler>
+  )
+  const mountCommits = commits
+  return () => commits - mountCommits
+}
+
+describe('setTabPaneExpanded', () => {
+  it('publishes the first write for an unseen tab and a real toggle', () => {
+    const store = createTestStore()
+    const published = recordPublishedMapKeys(store)
+
+    store.getState().setTabPaneExpanded(TAB_ID, false)
+    expect(published).toEqual(['expandedPaneByTabId'])
+    expect(store.getState().expandedPaneByTabId[TAB_ID]).toBe(false)
+
+    store.getState().setTabPaneExpanded(TAB_ID, true)
+    expect(published).toEqual(['expandedPaneByTabId', 'expandedPaneByTabId'])
+    expect(store.getState().expandedPaneByTabId[TAB_ID]).toBe(true)
+  })
+
+  it('bails out when the value is unchanged', () => {
+    const store = createTestStore()
+    store.getState().setTabPaneExpanded(TAB_ID, false)
+    const before = store.getState().expandedPaneByTabId
+    const published = recordPublishedMapKeys(store)
+
+    for (let i = 0; i < NO_OP_WRITES; i += 1) {
+      store.getState().setTabPaneExpanded(TAB_ID, false)
+    }
+
+    expect(published).toEqual([])
+    expect(store.getState().expandedPaneByTabId).toBe(before)
+  })
+
+  it('costs no React commit in a map subscriber when the value is unchanged', () => {
+    const store = createTestStore()
+    store.getState().setTabPaneExpanded(TAB_ID, false)
+    const commitsSinceMount = renderCommitCounter(<ExpandedPaneSubscriber store={store} />)
+
+    for (let i = 0; i < NO_OP_WRITES; i += 1) {
+      act(() => {
+        store.getState().setTabPaneExpanded(TAB_ID, false)
+      })
+    }
+    expect(commitsSinceMount()).toBe(0)
+
+    act(() => {
+      store.getState().setTabPaneExpanded(TAB_ID, true)
+    })
+    expect(commitsSinceMount()).toBe(1)
+  })
+})
+
+describe('setTabCanExpandPane', () => {
+  it('publishes the first write for an unseen tab and a real toggle', () => {
+    const store = createTestStore()
+    const published = recordPublishedMapKeys(store)
+
+    store.getState().setTabCanExpandPane(TAB_ID, false)
+    expect(published).toEqual(['canExpandPaneByTabId'])
+    expect(store.getState().canExpandPaneByTabId[TAB_ID]).toBe(false)
+
+    store.getState().setTabCanExpandPane(TAB_ID, true)
+    expect(published).toEqual(['canExpandPaneByTabId', 'canExpandPaneByTabId'])
+    expect(store.getState().canExpandPaneByTabId[TAB_ID]).toBe(true)
+  })
+
+  it('bails out when the value is unchanged', () => {
+    const store = createTestStore()
+    store.getState().setTabCanExpandPane(TAB_ID, false)
+    const before = store.getState().canExpandPaneByTabId
+    const published = recordPublishedMapKeys(store)
+
+    for (let i = 0; i < NO_OP_WRITES; i += 1) {
+      store.getState().setTabCanExpandPane(TAB_ID, false)
+    }
+
+    expect(published).toEqual([])
+    expect(store.getState().canExpandPaneByTabId).toBe(before)
+  })
+
+  it('costs no React commit in a map subscriber when the value is unchanged', () => {
+    const store = createTestStore()
+    store.getState().setTabCanExpandPane(TAB_ID, false)
+    const commitsSinceMount = renderCommitCounter(<CanExpandPaneSubscriber store={store} />)
+
+    for (let i = 0; i < NO_OP_WRITES; i += 1) {
+      act(() => {
+        store.getState().setTabCanExpandPane(TAB_ID, false)
+      })
+    }
+    expect(commitsSinceMount()).toBe(0)
+
+    act(() => {
+      store.getState().setTabCanExpandPane(TAB_ID, true)
+    })
+    expect(commitsSinceMount()).toBe(1)
+  })
+})

--- a/src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx
+++ b/src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx
@@ -70,6 +70,8 @@ describe('setTabPaneExpanded', () => {
     const store = createTestStore()
     store.getState().setTabPaneExpanded(TAB_ID, false)
     const before = store.getState().expandedPaneByTabId
+    // Root identity too: returning `{}` keeps the map but allocates a new root, so zustand still walks every listener.
+    const rootBefore = store.getState()
     const published = recordPublishedMapKeys(store)
 
     for (let i = 0; i < NO_OP_WRITES; i += 1) {
@@ -78,6 +80,7 @@ describe('setTabPaneExpanded', () => {
 
     expect(published).toEqual([])
     expect(store.getState().expandedPaneByTabId).toBe(before)
+    expect(store.getState()).toBe(rootBefore)
   })
 
   it('costs no React commit in a map subscriber when the value is unchanged', () => {
@@ -117,6 +120,7 @@ describe('setTabCanExpandPane', () => {
     const store = createTestStore()
     store.getState().setTabCanExpandPane(TAB_ID, false)
     const before = store.getState().canExpandPaneByTabId
+    const rootBefore = store.getState()
     const published = recordPublishedMapKeys(store)
 
     for (let i = 0; i < NO_OP_WRITES; i += 1) {
@@ -125,6 +129,7 @@ describe('setTabCanExpandPane', () => {
 
     expect(published).toEqual([])
     expect(store.getState().canExpandPaneByTabId).toBe(before)
+    expect(store.getState()).toBe(rootBefore)
   })
 
   it('costs no React commit in a map subscriber when the value is unchanged', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## What

`setTabPaneExpanded` and `setTabCanExpandPane` in
[`src/renderer/src/store/terminals/terminal-layout-state.ts:47-61`](https://github.com/stablyai/orca/blob/main/src/renderer/src/store/terminals/terminal-layout-state.ts#L47-L61)
allocated a brand-new `expandedPaneByTabId` / `canExpandPaneByTabId` map on **every** call, including calls that
wrote the value already stored. Their sibling in the same factory, `setTabLayout`, has had an equality bailout
all along (`terminal-layout-state.ts:81-83`). This PR gives the two pane-expansion actions the same one.

Both actions are called unconditionally from the pane mount/unmount path, so they re-assert the same booleans
on every remount:

- `src/renderer/src/components/terminal-pane/terminal-pane-mount-cleanup.ts:130-131` — teardown writes `false, false`
- `src/renderer/src/components/terminal-pane/terminal-pane-mount-preparation.ts:192-193` — `syncCanExpandState()` writes `panes.length > 1`
- `src/renderer/src/components/terminal-pane/expand-collapse.ts:117-121` — `setExpandedPane()` writes `paneId !== null`

Because the map identity changed on each of those no-op writes, every subscriber to the raw map re-rendered
(`use-terminal-workspace-store-bindings.ts:17` subscribes to `expandedPaneByTabId` wholesale), and zustand walked
its full listener list on each write.

**Field crashes.** Cluster **R2-react-185** — **5 reports**, all `Minified React error #185`
("Maximum update depth exceeded") escaping into `boundary_id: terminal.workbench`:

| Report | Version | OS |
|---|---|---|
| `1.4.194_eb166b63_andypeters` | 1.4.194 | darwin 25.6.0 arm64 |
| `1.4.194_bc319598_andypeters` | 1.4.194 | darwin 25.6.0 arm64 |
| `1.4.194_65b2217e_andypeters` | 1.4.194 | darwin 25.6.0 arm64 |
| `1.4.195_3002ec1f_AndrewS-TS` | 1.4.195 | darwin 24.6.0 arm64 |
| `1.4.195_26461769_NoGitHubidentity` | 1.4.195 | win32 10.0.26200 x64 |

macOS (arm64) and Windows (x64); Electron 43.4.1 on all five.

v1.4.194 shipped with function names preserved in the renderer bundle, so the `react_commit_cascade` breadcrumb
names the driver **by symbol**, not by bundle offset. In 4 of the 5 crumbs (3 distinct cascades) the `driverFrame`
is literally `Object.setTabPaneExpanded`, and every symbol in the `driverStack` resolves to a real source symbol
in this repo. Verbatim from `1.4.194_bc319598_andypeters.diag.ndjson`:

```json
{
  "commits": 40, "commitBudget": 50, "elapsedMs": 2178,
  "pendingLanes": 2, "storeWrites": 420, "storeWriteSites": 3,
  "driverFrame": "store-Cxfo0ng3.js:35991:4 Object.setTabPaneExpanded",
  "driverStack": "store-Cxfo0ng3.js:35991:4 Object.setTabPaneExpanded
OnboardingInlineCommandTerminal-B8yUeuYo.js:923:9 setExpandedPane
OnboardingInlineCommandTerminal-B8yUeuYo.js:29806:10
store-Cxfo0ng3.js:36004:4 setTabLayout
OnboardingInlineCommandTerminal-B8yUeuYo.js:32712:3 Object.persistLayoutSnapshot
OnboardingInlineCommandTerminal-B8yUeuYo.js:924:9 setExpandedPane
store-Cxfo0ng3.js:35997:4 setTabCanExpandPane
OnboardingInlineCommandTerminal-B8yUeuYo.js:29193:4 syncCanExpandState
OnboardingInlineCommandTerminal-B8yUeuYo.js:29831:3",
  "storeListeners": 34515, "rendererSurface": "main"
}
```

Symbol → source mapping (each name is unique in `src/`):

| Bundle symbol | Source |
|---|---|
| `Object.setTabPaneExpanded` | `src/renderer/src/store/terminals/terminal-layout-state.ts:47` |
| `setTabCanExpandPane` | `src/renderer/src/store/terminals/terminal-layout-state.ts:54` |
| `setTabLayout` | `src/renderer/src/store/terminals/terminal-layout-state.ts:58` |
| `setExpandedPane` | `src/renderer/src/components/terminal-pane/expand-collapse.ts:117` |
| `syncCanExpandState` | `src/renderer/src/components/terminal-pane/terminal-pane-mount-preparation.ts:192` |
| `persistLayoutSnapshot` | `src/renderer/src/components/terminal-pane/terminal-pane-mount-events.ts:110` |

420 store writes from 3 sites, driving 40 React commits against a budget of 50, with 34,515 live store listeners.
The other two cascades in the cluster show the same `driverFrame` at `storeWrites` 80 (`storeListeners` 10,599)
and a `focusGroup`-rooted variant at `storeWrites` 100 (`storeListeners` 8,387).

**This PR removes the write amplifier. It does not claim to be the whole of React #185** — see *Fix evidence* and
*Follow-ups* for exactly where the proof stops.

## Fix evidence

All commands run from `/tmp/fix-terminal-layout-bailouts` against branch `nwparker/crash-terminal-layout-bailouts`.

### 1. GREEN as shipped

```
$ ./node_modules/.bin/vitest run --config config/vitest.config.ts \
    src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx

 RUN  v4.1.11 /private/tmp/fix-terminal-layout-bailouts

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  21:31:02
   Duration  2.63s
```

### 2. RED with the production hunk reverted to `origin/main`

```
$ git show origin/main:src/renderer/src/store/terminals/terminal-layout-state.ts \
    > src/renderer/src/store/terminals/terminal-layout-state.ts
$ ./node_modules/.bin/vitest run --config config/vitest.config.ts \
    src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx

 ❯ src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx (6 tests | 4 failed) 48ms
     × bails out when the value is unchanged 8ms
     × costs no React commit in a map subscriber when the value is unchanged 13ms
     × bails out when the value is unchanged 5ms
     × costs no React commit in a map subscriber when the value is unchanged 6ms
AssertionError: expected [ 'expandedPaneByTabId', …(24) ] to deeply equal []
 ❯ src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx:81:23
AssertionError: expected 25 to be +0 // Object.is equality
 ❯ src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx:96:33
AssertionError: expected [ 'canExpandPaneByTabId', …(24) ] to deeply equal []
 ❯ src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx:130:23
AssertionError: expected 25 to be +0 // Object.is equality
 ❯ src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx:145:33
 Test Files  1 failed (1)
      Tests  4 failed | 2 passed (6)
```

`expected 25 to be +0` is a React `Profiler` commit counter, not a store-write counter. **25 no-op store writes
produced 25 React commits** in a component subscribing to the raw map (mirroring
`use-terminal-workspace-store-bindings.ts:17`); after the fix it produces 0. That is commit-level evidence.

### 3. RED with a *weaker* `return {}` bailout — locks the listener walk, not just the re-render

The first review round showed the test passed with `? {} :` instead of `? s :`. Per
`node_modules/zustand/esm/vanilla.mjs:4-10`, `{}` is not `Object.is`-equal to state, so zustand allocates a new
root state and invokes **every** listener — the 34,515-listener walk this PR is meant to eliminate. The test now
asserts root-state identity, and the weaker bailout fails:

```
$ # scratch mutation: `? s` -> `? {}` in both actions
$ ./node_modules/.bin/vitest run --config config/vitest.config.ts \
    src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx

 ❯ src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx (6 tests | 2 failed) 77ms
     × bails out when the value is unchanged 20ms
     × bails out when the value is unchanged 15ms
AssertionError: expected { repos: [], projects: [], …(1151) } to be { repos: [], projects: [], …(1151) } // Object.is equality
 ❯ src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx:83:30
AssertionError: expected { repos: [], projects: [], …(1151) } to be { repos: [], projects: [], …(1151) } // Object.is equality
 ❯ src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx:132:30
 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)
```

The working tree was restored to the committed hunk afterwards (`git status` clean, verified below).

### 4. Behaviour preservation, typecheck, lint, format, suites

Two of the six cases assert that real writes still publish: the first write for an unseen tab
(`undefined !== false`) and a genuine toggle both land, both maps end with identical key sets to before.

```
$ ./node_modules/.bin/tsc --noEmit -p config/tsconfig.tc.web.json
tsc exit: 0

$ ./node_modules/.bin/oxlint src/renderer/src/store/terminals/terminal-layout-state.ts \
    src/renderer/src/store/terminals/terminal-pane-expansion-write-bailout.test.tsx
oxlint exit: 0

$ ./node_modules/.bin/oxfmt --check <both files>
All matched files use the correct format.

$ ./node_modules/.bin/vitest run --config config/vitest.config.ts src/renderer/src/store/terminals
 Test Files  4 passed (4)
      Tests  18 passed (18)
```

Wider suites (terminals store, terminal-pane, floating-terminal, tab-bar, terminal slices) were run during
implementation: **508 files / 4817 tests passed**, including the three pre-existing tests that exercise these
actions (`expand-collapse-render-stability.test.ts`, `expand-collapse.test.ts`, `keyboard-handlers-ime.test.tsx`).
The reviewer additionally ran `store/slices/tabs`, `store/slices/worktrees`, tab-group and the workspace bindings
(55 files / 573 tests, green). Repo quality gate:

```
$ pnpm run check:code-quality:changed
code quality: 0 new finding(s) across 2 changed file(s).
type-aware code quality: 0 new finding(s) across 2 changed file(s).
React Doctor: 0 new finding(s) across 2 changed file(s).
Changed-code quality gate passed since 76836b30ea6c.
```

### What is NOT proven

Stated plainly rather than padded:

1. **Not proven that this alone drops `commits=40` under `commitBudget=50`.** The cascade budget is a global
   counter; this PR removes one of three contributing write sites. No live #185 reproduction was produced.
2. **No live #185 repro was attempted, deliberately.** Getting a self-sustaining loop in jsdom requires injecting
   the remount driver by hand, which would only prove the harness loops. Tracing every consumer of these two maps
   (`tab-bar-item-model.ts:257`, `tab-bar-item-surface.tsx:107`, `active-terminal-chrome-selector.ts:34/37`,
   `floating-terminal-panel-inputs.ts:86`, `use-tab-bar-item-projection.ts:143`) shows the map identity fans out
   into re-renders but never back into a pane remount — there is no provable feedback edge here.
3. **The two 1.4.195 reports carry zero `react_commit_cascade` crumbs** (`3002ec1f`: 6,988 of 7,377 spans are
   `git.exec`; `26461769`: 2,639 of 4,233), so their cluster membership rests on `boundary_id` + error identity,
   not on a driver stack. See follow-up 1.
4. **Multi-pane tabs get less relief.** A 2+ pane tab still publishes on `canExpandPaneByTabId` across a remount
   (cleanup writes `false`, mount writes `true`). The bailout neutralises the single-pane/collapsed case — which is
   what the field bundles actually show (`livePanes == livePaneManagers == 271`, one pane each) — but this is not
   "the amplifier is gone in general".

## ELI5

Orca keeps a tiny note for each terminal tab: is one of its panes currently blown up to fill the whole
tab, and is blowing one up even allowed right now. You never see the note itself — it's what tells the tab
strip which little expand arrow to draw.

Every time a terminal pane was rebuilt on screen, Orca rewrote that note, even when the new answer was
identical to the old one — scribbling "not blown up" over a note that already said "not blown up".

Rewriting the note wakes up every part of the screen that is watching it. In a busy window there were tens
of thousands of watchers, so a burst of pane rebuilds turned into a burst of pointless redraws. The toolkit
Orca's screen is built on refuses to chain more than a set number of redraws back-to-back; once a burst
crossed that line the toolkit gave up, and the whole terminal area was replaced by an error screen. Five
people hit that, on both Mac and Windows.

This change makes Orca read the note before rewriting it. If it already says the right thing, leave it
alone. That exact check was already in place for the neighbouring note that records a tab's pane layout;
this just extends it to the other two.

What this does **not** do is prove the crash is gone. It removes one of three things that were piling
redraws onto those bursts, and nobody has managed to reproduce the crash on demand, before or after. Treat
it as "one contributor removed, and a lot of wasted work removed for certain", not as "fixed".

Nothing about what the app does changes: same panes, same arrows, same layout. Only the amount of pointless
work happening behind them.

## Trade-offs

**None user-facing.**

- **Behaviour:** the only semantic difference is that a write whose value already equals the stored value no longer
  notifies subscribers. Since the stored value is already what the caller is writing, no observable state differs.
  First write for an unseen tab still lands (`undefined !== false`, and `expanded` is typed `boolean` so a missing
  key can never `===` it), and a genuine toggle still publishes. Both are asserted in the test, so the key sets of
  both maps are provably identical to before — no orphan-cleanup or `Object.keys` regression.
- **No newly-swallowed errors.** Nothing is caught, logged-and-dropped, or suppressed. No telemetry is removed.
- **Identity churn:** these two map references now change strictly less often. The only place identity is compared
  is `src/renderer/src/components/floating-terminal/floating-terminal-panel-inputs.ts:82`, where it is a memo-cache invalidation key — fewer identity changes
  means more cache hits, which is the intended direction. Every other consumer reads a boolean by `tabId`.
- **Latency:** one property lookup and one `===` per call, on a path that previously always allocated a new object.
  Strictly cheaper.
- **Cross-platform / SSH / folder-workspace / remote-wire / Git:** no surface. This is renderer-local zustand
  state; neither map name appears anywhere in `src/main` or `src/shared`. No IPC, no wire format, no filesystem,
  no process interaction, no git-worktree assumption.
- **One diagnostic consideration, disclosed:** `src/renderer/src/lib/react-commit-cascade-telemetry.ts:41-42` only emits the
  `react_commit_cascade` crumb at `commits >= REACT_NESTED_UPDATE_LIMIT - 10` (= 40). If this fix drops cascades under that threshold while the
  underlying remount/manager-accumulation problem persists, successor crashes could land in other clusters with no
  pointer back here. That is a reason to file follow-up 2, not a reason to keep the amplifier.

## Adversarial review

**1 round(s) until clean.**

**Round 1 — verdict: ship.** The reviewer reproduced the full evidence chain independently: reverted the
production hunk on a scratch copy and got the identical 4-failed/2-passed with the same `expected 25 to be +0`
Profiler assertions (so the test is not theatre), reproduced `tsc` exit 0, `oxlint` exit 0, and the 508 files /
4817 tests, and additionally ran `store/slices/tabs`, `store/slices/worktrees`, tab-group and the workspace
bindings (55 files / 573 tests, green) because those touch the two maps and were outside the original run. No
blocking findings. Six non-blocking findings, resolved as follows:

1. **"Test under-locks the mechanism."** The reviewer patched a scratch copy to bail with `? {} :` instead of
   `? s :` and the test still passed 6/6 — but `{}` still allocates a new root state and walks all 34,515
   listeners. **FIXED** in commit `cd6f900`: both bailout tests now assert `expect(store.getState()).toBe(rootBefore)`.
   Section 3 of *Fix evidence* shows the weaker `{}` implementation now failing.
2. **"`replaceTerminalLayoutPanePtyId` has the same `{}` gap 15 lines up"** (`terminal-layout-state.ts:32-34`),
   called once per adopted pane from `src/renderer/src/lib/worktree-agent-live-surface-adoption.ts:61` during worktree activation.
   **NOT FIXED — deferred deliberately.** It is a real instance of the same class, but it is a different action on
   a different map with a different call path, and changing it would put unreviewed production code in a diff that
   has already converged. Filed as follow-up 3.
3. **"Multi-pane tabs get no relief."** **ACCEPTED, not a code change** — the PR text was corrected instead. It is
   now stated in *Fix evidence → What is NOT proven*, item 4.
4. **"Diagnostic-erosion risk: the cascade crumb may go quiet while the mount storm persists."** **ACCEPTED as a
   companion ticket, not a hold** — disclosed in *Trade-offs* and filed as follow-up 2.
5. **"Shared `node_modules` mutation."** The reviewer reproduced, from their own run, that vitest in
   `/tmp/fix-terminal-layout-bailouts` rewrites `node_modules/.modules.yaml` and rebuilds
   `node-pty/build/Release/pty.node` in the shared symlinked tree. **REBUTTED as out of scope for this PR** — it is
   a property of the symlinked-worktree dev setup, not of this change. Verified benign: `require('node-pty')` still
   loads, the suite still runs, and the main worktree is clean. Filed as follow-up 4.
6. **"Test uses `createTestStore`, so it does not exercise `withReactCommitCascadeWriteProbe`."** **REBUTTED as
   benign, no action** — the reviewer read `store/react-commit-cascade-write-probe.ts:22-36` and confirmed it
   forwards verbatim and passes the updater *function*, so `noteReactCommitCascadeStoreWrite` skips `changedKeys`
   collection and behaviour is identical. Bailed-out calls still increment `storeWrites`, so the crumb's
   `storeWrites`/`driverFrame` attribution survives the fix.

## Follow-ups

**1. PaneManager accumulation — the memory half of this crash, and the higher-value fix.**
Mounted `PaneManager` instances are not being reclaimed. `cleanupTerminalPaneMount` does call `manager.destroy()`
(`src/renderer/src/lib/pane-manager/pane-manager.ts:343` → `unregisterLivePaneManager`), so a balanced mount/unmount loop should keep the count flat,
but the bundles show it climbing monotonically. Verified directly from the corpus:

- `1.4.194_bc319598_andypeters` and `1.4.194_65b2217e_andypeters`: `mountedManagers` peaks at **271**, with
  `terminal_safe_fit_retry_exhausted {"paneId":1,"livePanes":271,"livePaneManagers":271}` — 271 managers holding
  one pane each.
- `G2-killed/1.4.194_b8b142ec_hybridapp323`: `{"managers":1,"mountedManagers":223,"reason":"settled-reveal",
  "kind":"webgl-atlas-reset"}` — 223 mounted against 1 live manager, alongside `domNodes=25333`,
  `processMetricsPreGoneRendererPeakWorkingSetMB: 2281`. That is the highest-memory renderer in the
  55-bundle corpus; exactly three bundles corpus-wide exceed a 900 MB renderer peak (2281, 1249, 917), all in G2.
- `1.4.195_3002ec1f`: `usedHeapMB` across 309 renderer-memory samples ranges 152 → 674 MB.

This is entirely untouched by this PR, and it is corroborated in a second cluster (G2) where nobody was looking at
React, so it is not an R2 artefact. **This should also carry the mount-storm / manager-accumulation alarm** that
round-1 finding 4 asks for, so attribution survives if the cascade crumb goes quiet.

**2. Crash-bundle sampler starves the renderer evidence.** `git.exec` dominates every bundle in this cluster —
6,970 of 7,799 spans; 7,060 of 7,826; 6,988 of 7,377; 2,639 of 4,233 — and the bundles truncate at the 4 MB cap
(`Bytes: 4193942`). Both 1.4.195 reports consequently carry **zero** `react_commit_cascade` spans, which is why
their driver is unknown. Cap or downsample `git.exec` in the crash bundle.

**3. `replaceTerminalLayoutPanePtyId` no-op path returns `{}`** (`terminal-layout-state.ts:32-34`). Same amplifier
class as this PR, 15 lines above the hunk: `{}` is not `Object.is`-equal to state, so zustand allocates a new root
and walks every listener even though nothing changed. Called once per adopted pane from
`src/renderer/src/lib/worktree-agent-live-surface-adoption.ts:61` during worktree activation — the storm initiator the investigation
names as most likely. One-line change (`return {}` → `return s`) plus a root-identity test, deliberately kept out
of this converged diff.

**4. Renderer sourcemaps.** v1.4.194 shipped with function names preserved; v1.4.195 is fully minified. That
accident is the only reason this driver stack was attributable at all. Ship renderer sourcemaps or a
name-preserving minify so future #185 stacks stay readable — which would also let someone settle the causal
question this PR leaves open.

**5. Re-cluster `1.4.195_26461769_NoGitHubidentity` out of R2.** It carries no `react_commit_cascade` crumb at
all, and 26 `terminal_replay_guard_wedged_release` breadcrumbs — the second-highest count in the 55-bundle corpus
(only `G6-no-capture/1.4.195_..._murlock1000` is higher, at 62; third place is 11). It looks like it belongs with
the replay-guard wedge family rather than with #185, which currently inflates this cluster's count from 4 to 5.

**6. Remaining cheap no-op emitters** (now neutralised at the store, so optional):
`src/renderer/src/components/terminal-pane/terminal-pane-layout-restore.ts:81` calls `deps.setExpandedPane(null)` on every mount even when
`expandedPaneIdRef.current` is already `null`, which still pays a `persistLayoutSnapshot()` round trip.

**7. Shared `node_modules` is mutated by vitest runs from a `/tmp` worktree** whose `node_modules` symlinks into
the main checkout: pnpm's auto-install rewrites `.modules.yaml` and rebuilds `node-pty` from source in the shared
tree. Reproduced independently by both the implementer and the reviewer. Dev-environment hygiene, unrelated to this
change.

