### PR TITLE
fix(editor): keep review note cards after an edit removes their lines

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-review-note-positioning.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-review-note-positioning.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import type { Editor } from '@tiptap/react'
+import type { DiffComment } from '../../../../shared/diff-comment-types'
+import { measureRichMarkdownReviewNotePositions } from './rich-markdown-review-note-positioning'
+
+// Paragraphs serialize with a blank separator line, like real markdown, so with
+// three paragraphs the blocks cover source lines 1, 3 and 5 and lines 2 and 4 are gaps.
+// Each block starts at document position (index * 10) + 1.
+function makeEditor(paragraphCount: number): Editor {
+  const content = Array.from({ length: paragraphCount }, (_value, index) => ({
+    type: 'paragraph',
+    content: [{ type: 'text', text: `paragraph ${index}` }]
+  }))
+  const doc = {
+    forEach(callback: (node: unknown, offset: number, index: number) => void): void {
+      content.forEach((_node, index) => callback({ nodeSize: 10 }, index * 10, index))
+    },
+    nodesBetween(): void {},
+    content: { size: paragraphCount * 10 }
+  }
+  return {
+    getJSON: () => ({ content }),
+    state: { doc },
+    markdown: {
+      serialize: (value: { content?: unknown[] }) =>
+        (value.content ?? []).map((_node, index) => `line ${index}`).join('\n\n')
+    },
+    // Why: the card top is the anchored position's y, so the top tells which block a
+    // note landed on: block 0 → 1, block 1 → 11, block 2 → 21.
+    view: { coordsAtPos: (pos: number) => ({ top: pos }) }
+  } as unknown as Editor
+}
+
+function makeComment(id: string, lineNumber: number): DiffComment {
+  return {
+    id,
+    worktreeId: 'wt1',
+    filePath: 'NOTES.md',
+    source: 'markdown',
+    lineNumber,
+    body: 'note',
+    createdAt: 1,
+    side: 'modified'
+  }
+}
+
+function topOf(lineNumber: number): number | undefined {
+  const positions = measureRichMarkdownReviewNotePositions({
+    container: document.createElement('div'),
+    editor: makeEditor(3),
+    markdownComments: [makeComment('note', lineNumber)],
+    markdownSourceLineOffset: 0
+  })
+  return positions[0]?.top
+}
+
+describe('measureRichMarkdownReviewNotePositions', () => {
+  it('anchors an in-range note to its own block', () => {
+    expect(topOf(1)).toBe(1)
+    expect(topOf(3)).toBe(11)
+    expect(topOf(5)).toBe(21)
+  })
+
+  it('anchors a note on a separator line to the block just above it', () => {
+    expect(topOf(2)).toBe(1)
+    expect(topOf(4)).toBe(11)
+  })
+
+  it('keeps a note whose line fell past the end after the document shrank', () => {
+    expect(topOf(9)).toBe(21)
+
+    const positions = measureRichMarkdownReviewNotePositions({
+      container: document.createElement('div'),
+      editor: makeEditor(3),
+      markdownComments: [makeComment('past-end', 9), makeComment('inside', 3)],
+      markdownSourceLineOffset: 0
+    })
+    expect(positions.map((position) => position.comment.id)).toEqual(['inside', 'past-end'])
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-review-note-positioning.ts
+++ b/src/renderer/src/components/editor/rich-markdown-review-note-positioning.ts
@@ -1,6 +1,9 @@
 import type { Editor } from '@tiptap/react'
 import type { DiffComment } from '../../../../shared/diff-comment-types'
-import { getRichMarkdownCommentAnchorTop } from './rich-markdown-review-annotations'
+import {
+  getRichMarkdownCommentAnchorTop,
+  type RichMarkdownCommentBlock
+} from './rich-markdown-review-annotations'
 import { getRichMarkdownReviewRailBlocks } from './rich-markdown-review-rail-blocks'
 import {
   stackRichMarkdownReviewNotePositions,
@@ -14,6 +17,17 @@ type MeasureRichMarkdownReviewNotePositionsOptions = {
   markdownSourceLineOffset: number
 }
 
+// Why: separator lines between blocks belong to no block and an edit can leave a note past
+// the last one; the badge and the source view still show such a note, so anchor it to the
+// nearest preceding block instead of dropping the card. Blocks are ascending, so the last
+// block starting at or before the line is also the containing one when there is one.
+function findReviewNoteBlock(
+  blocks: readonly RichMarkdownCommentBlock[],
+  bodyLineNumber: number
+): RichMarkdownCommentBlock | null {
+  return blocks.findLast((candidate) => candidate.startLine <= bodyLineNumber) ?? null
+}
+
 export function measureRichMarkdownReviewNotePositions({
   container,
   editor,
@@ -25,9 +39,7 @@ export function measureRichMarkdownReviewNotePositions({
   const nextPositions = markdownComments
     .map((comment): RichMarkdownReviewNotePosition | null => {
       const bodyLineNumber = Math.max(1, comment.lineNumber - markdownSourceLineOffset)
-      const block = blocks.find(
-        (candidate) => candidate.startLine <= bodyLineNumber && bodyLineNumber <= candidate.endLine
-      )
+      const block = findReviewNoteBlock(blocks, bodyLineNumber)
       if (!block) {
         return null
       }


### PR DESCRIPTION
## ELI5

When you leave review notes in the rich markdown editor and then the document gets shorter (you or an agent delete some lines), the note cards disappeared from the editor even though the count badge still said they exist and the source view still listed them. The editor was only willing to draw a card whose line still existed in the document; a note whose line is now past the end was silently skipped. Now such a note is drawn at the end of the document instead of vanishing.

## What Changed

`measureRichMarkdownReviewNotePositions` (`src/renderer/src/components/editor/rich-markdown-review-note-positioning.ts`) resolved each note's source line to a rendered block with a strict containment lookup and dropped the note when nothing matched. Two kinds of line miss every block: the blank separator lines `buildRichMarkdownCommentBlocks` skips between markdown blocks, and any line past the last block once the document shrank. A small local `findReviewNoteBlock` now takes the nearest preceding block (`findLast` over the ascending, non-overlapping blocks), which is the containing block when there is one, the block just above a separator line, and the last block past the end. The existing anchoring then places the card via the selected-text search (which already falls back to the whole document) or the block start.

Rebased onto current `main` on 2026-09-07. The block-table forwarding this PR originally added is now upstream: `getRichMarkdownCommentAnchorTop` already takes `prebuiltBlocks`, and the new `getRichMarkdownReviewRailBlocks` caches the table per editor document. That half is dropped from this branch, so the diff is now only the anchoring fix and its tests. The highlight-range lookup is unchanged: it already falls back to a whole-document text search, so it needed no clamp.

## Why

Fixes #16577

The count badge is computed from `markdownComments` while the cards come from the measured positions, so the two disagreed as soon as a note's line fell off the end of the document. The reporter's expectation, "notes remain visible and stay anchored to their lines as best as possible", is exactly what anchoring to the nearest preceding block gives: the note is still reachable in the rich editor next to the closest surviving content, its quote still shows what it referred to, and once the document grows back the normal containment lookup takes over again. Notes that are lost entirely (also from the source view) are a different, persistence-side problem tracked in #16581 and are out of scope here.

## Linked Issue

Fixes #16577

## Visual Proof

`pnpm dev` on macOS. A note added on the last paragraph, then the "Usage" section (a heading and two paragraphs) deleted in the rich editor.

**Before** — the badge still counts one note, but no card is rendered:

<img width="3390" height="2116" alt="2-before-fix-after-deleting-section-card-gone" src="https://github.com/user-attachments/assets/406a32aa-a6c8-48a1-b2f6-b11ed20e8c8c" />


**After** — the card stays, anchored to the last paragraph:

<img width="3390" height="2116" alt="3-after-fix-card-stays" src="https://github.com/user-attachments/assets/6f824214-93f2-43f1-a74b-6eb2e62f08e7" />


## Testing

- New `rich-markdown-review-note-positioning.test.ts` with a fake tiptap editor whose paragraphs serialize with blank separator lines (blocks on source lines 1, 3, 5) and whose anchor top reveals the block: in-range notes anchor to their own block; a note on a separator line anchors to the block just above it; a note past the end anchors to the last block and survives alongside an in-range note. Mutation-checked: the previous containment-only lookup fails the past-end case, and a naive "always the last block" fallback fails the in-range and separator cases.
- `pnpm test src/renderer/src/components/editor` (197 files), `pnpm tc:web`, `pnpm run check:code-quality:changed`, `oxlint`/`oxfmt --check` on the changed files.
- Manually in `pnpm dev` on macOS as shown above; the same edit with the previous code makes the card vanish while the badge stays at 1.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code (Claude Fable 5.1) under the author's direction; the author reviewed the diff, ran the checks, and captured the screenshots.

## Review

AI code review summary (Claude Code, independent review passes with adversarial verification):

- **Cross-platform (macOS / Linux / Windows)**: renderer-only, no platform code. The report came from Windows 11; the code path is identical.
- **SSH / remote / local**: the rich editor renders the same way for local and remote worktree files; no IPC change.
- **Agents / integrations / git providers**: not involved beyond agents being the usual cause of the document change.
- **Performance**: unchanged — the cached block build is upstream now; this branch adds one `findLast` per note that misses.
- **UI quality**: cards for in-range notes are positioned exactly as before; only notes that were previously dropped now appear, at the end of the document, stacked by the existing layout when several land there.
- **Security**: none.
- **Backwards compatibility**: no persisted data changes.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Mobile is untouched. A rescued note anchors at its block's start (or at its quoted text if that still exists anywhere in the document); if you would rather see it at the block's end, that is a one-line change in the anchor helper.

## Author

X: @gum79

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwSFoun5enrK3iiFrbFWRz


