### PR TITLE
fix(browser-pane): stop a dead client-hosted guest from killing the workbench

### DIFF
--- a/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.dead-guest.test.tsx
+++ b/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.dead-guest.test.tsx
@@ -231,6 +231,56 @@ describe('client-hosted browser pane over a dead guest', () => {
     expect(onUpdatePageState.mock.calls.at(-1)).toEqual(['page-a', { loading: false }])
   })
 
+  it('ignores queued load events after guest loss', () => {
+    const onUpdatePageState = vi.fn()
+    render(paneElement(true, { onUpdatePageState }))
+    act(() => webview.dispatchEvent(new Event('destroyed')))
+    onUpdatePageState.mockClear()
+
+    act(() => webview.dispatchEvent(new Event('did-start-loading')))
+
+    expect(onUpdatePageState).not.toHaveBeenCalled()
+    expect(screen.getByText('Client-hosted browser unavailable')).toBeTruthy()
+  })
+
+  it('uses the guarded title snapshot if the guest dies immediately afterward', () => {
+    render(paneElement(true))
+    webview.getTitle = vi.fn(() => {
+      webview.getTitle = vi.fn(() => {
+        throw invalidGuestInstanceId()
+      })
+      return 'Last live title'
+    })
+
+    expect(() => act(() => webview.dispatchEvent(new Event('did-navigate')))).not.toThrow()
+    expect(webview.getTitle).not.toHaveBeenCalled()
+  })
+
+  it('shows unavailability when a load-failure fallback finds the guest gone', () => {
+    const onUpdatePageState = vi.fn()
+    render(paneElement(true, { onUpdatePageState }))
+    webview.getURL.mockImplementation(() => {
+      throw invalidGuestInstanceId()
+    })
+
+    act(() => webview.dispatchEvent(new Event('did-fail-load')))
+
+    expect(screen.getByText('Client-hosted browser unavailable')).toBeTruthy()
+    expect(onUpdatePageState.mock.calls.at(-1)).toEqual(['page-a', { loading: false }])
+  })
+
+  it('removes loss listeners when the initial guest read fails', () => {
+    const removeListener = vi.spyOn(webview, 'removeEventListener')
+    webview.getURL.mockImplementation(() => {
+      throw invalidGuestInstanceId()
+    })
+
+    render(paneElement(true))
+
+    expect(removeListener).toHaveBeenCalledWith('destroyed', expect.any(Function))
+    expect(removeListener).toHaveBeenCalledWith('render-process-gone', expect.any(Function))
+  })
+
   it('stops listening for guest loss once the pane lets go of the tag', () => {
     const onUpdatePageState = vi.fn()
     const view = render(paneElement(true, { onUpdatePageState }))

--- a/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.dead-guest.test.tsx
+++ b/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.dead-guest.test.tsx
@@ -3,10 +3,17 @@ import { act, cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BrowserPage } from '../../../../shared/browser-workspace-types'
 
-const mocks = vi.hoisted(() => ({ attach: vi.fn(), detach: vi.fn() }))
+const mocks = vi.hoisted(() => ({
+  attach: vi.fn(),
+  detach: vi.fn(),
+  recordBreadcrumb: vi.fn()
+}))
 
 vi.mock('./browser-client-page-renderer-installation', () => ({
   attachBrowserClientPageToViewport: mocks.attach
+}))
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: mocks.recordBreadcrumb
 }))
 vi.mock('sonner', () => ({
   toast: { error: vi.fn(), success: vi.fn(), loading: vi.fn(), message: vi.fn() }
@@ -33,7 +40,7 @@ function nullContentWindowFocus(): TypeError {
   return new TypeError("Cannot read properties of null (reading 'focus')")
 }
 
-function page(): BrowserPage {
+function page(overrides?: Partial<BrowserPage>): BrowserPage {
   return {
     id: 'page-a',
     workspaceId: 'workspace-a',
@@ -45,7 +52,8 @@ function page(): BrowserPage {
     canGoBack: false,
     canGoForward: false,
     loadError: null,
-    createdAt: 1
+    createdAt: 1,
+    ...overrides
   }
 }
 
@@ -74,18 +82,21 @@ function createGuest(): Electron.WebviewTag & { getURL: ReturnType<typeof vi.fn>
   return webview
 }
 
-function paneElement(isActive: boolean): React.JSX.Element {
+function paneElement(
+  isActive: boolean,
+  options?: { browserTab?: BrowserPage; onUpdatePageState?: (id: string, state: unknown) => void }
+): React.JSX.Element {
   return (
     <TooltipProvider>
       <ClientHostedBrowserPagePane
-        browserTab={page()}
+        browserTab={options?.browserTab ?? page()}
         workspaceId="workspace-a"
         chromeShortcutScope="focused"
         runtimeEnvironmentId="environment-a"
         worktreeId="worktree-a"
         placement={PLACEMENT}
         isActive={isActive}
-        onUpdatePageState={vi.fn()}
+        onUpdatePageState={options?.onUpdatePageState ?? vi.fn()}
         onSetUrl={vi.fn()}
       />
     </TooltipProvider>
@@ -97,6 +108,7 @@ let webview: ReturnType<typeof createGuest>
 beforeEach(() => {
   mocks.attach.mockReset()
   mocks.detach.mockReset()
+  mocks.recordBreadcrumb.mockReset()
   installClientHostedPaneApi()
   webview = createGuest()
 })
@@ -115,6 +127,21 @@ describe('client-hosted browser pane over a dead guest', () => {
     expect(() => render(paneElement(true))).not.toThrow()
     expect(screen.getByText('Client-hosted browser unavailable')).toBeTruthy()
     expect(mocks.detach).toHaveBeenCalled()
+    expect(mocks.recordBreadcrumb).toHaveBeenCalledWith('browser_client_page_guest_unavailable', {
+      browserPageId: 'page-a',
+      pageHostGeneration: PLACEMENT.pageHostGeneration
+    })
+  })
+
+  it('stops the spinner it inherited from a page that died mid-load', () => {
+    webview.getURL.mockImplementation(() => {
+      throw invalidGuestInstanceId()
+    })
+    const onUpdatePageState = vi.fn()
+
+    render(paneElement(true, { browserTab: page({ loading: true }), onUpdatePageState }))
+
+    expect(onUpdatePageState).toHaveBeenCalledWith('page-a', { loading: false })
   })
 
   it('survives activation focus after the retained tag left the DOM', () => {

--- a/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.dead-guest.test.tsx
+++ b/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.dead-guest.test.tsx
@@ -57,9 +57,13 @@ function page(overrides?: Partial<BrowserPage>): BrowserPage {
   }
 }
 
-function createGuest(): Electron.WebviewTag & { getURL: ReturnType<typeof vi.fn> } {
+function createGuest(): Electron.WebviewTag & {
+  getURL: ReturnType<typeof vi.fn>
+  reload: ReturnType<typeof vi.fn>
+} {
   const webview = document.createElement('webview') as Electron.WebviewTag & {
     getURL: ReturnType<typeof vi.fn>
+    reload: ReturnType<typeof vi.fn>
   }
   Object.assign(webview, {
     getURL: vi.fn(() => 'https://example.internal/'),
@@ -129,7 +133,14 @@ describe('client-hosted browser pane over a dead guest', () => {
     expect(mocks.detach).toHaveBeenCalled()
     expect(mocks.recordBreadcrumb).toHaveBeenCalledWith('browser_client_page_guest_unavailable', {
       browserPageId: 'page-a',
-      pageHostGeneration: PLACEMENT.pageHostGeneration
+      pageHostGeneration: PLACEMENT.pageHostGeneration,
+      reason: 'unreadable',
+      tagConnected: false
+    })
+    // Why: the catch is total, so the swallowed error must stay visible to diagnostics.
+    expect(mocks.recordBreadcrumb).toHaveBeenCalledWith('browser_client_page_guest_read_failed', {
+      errorName: 'Error',
+      errorMessage: 'Invalid guestInstanceId: 7'
     })
   })
 
@@ -142,6 +153,95 @@ describe('client-hosted browser pane over a dead guest', () => {
     render(paneElement(true, { browserTab: page({ loading: true }), onUpdatePageState }))
 
     expect(onUpdatePageState).toHaveBeenCalledWith('page-a', { loading: false })
+  })
+
+  it('flips to the unavailable notice when the guest renderer goes away after attach', () => {
+    const onUpdatePageState = vi.fn()
+    render(paneElement(true, { browserTab: page({ loading: true }), onUpdatePageState }))
+    expect(screen.queryByText('Client-hosted browser unavailable')).toBeNull()
+    onUpdatePageState.mockClear()
+
+    // The registry pulls the tag out of the DOM on this event without telling the pane.
+    webview.remove()
+    act(() => {
+      webview.dispatchEvent(new Event('render-process-gone'))
+    })
+
+    expect(screen.getByText('Client-hosted browser unavailable')).toBeTruthy()
+    expect(mocks.detach).toHaveBeenCalled()
+    expect(onUpdatePageState).toHaveBeenCalledWith('page-a', { loading: false })
+    expect(mocks.recordBreadcrumb).toHaveBeenCalledWith('browser_client_page_guest_unavailable', {
+      browserPageId: 'page-a',
+      pageHostGeneration: PLACEMENT.pageHostGeneration,
+      reason: 'render-process-gone',
+      tagConnected: false
+    })
+  })
+
+  it('flips to the unavailable notice when main destroys the guest after attach', () => {
+    render(paneElement(true))
+
+    act(() => {
+      webview.dispatchEvent(new Event('destroyed'))
+    })
+
+    expect(screen.getByText('Client-hosted browser unavailable')).toBeTruthy()
+    expect(mocks.recordBreadcrumb).toHaveBeenCalledWith(
+      'browser_client_page_guest_unavailable',
+      expect.objectContaining({ reason: 'destroyed' })
+    )
+    // The chrome must not keep driving the dead tag: Reload routes to the notice, not a throw.
+    webview.reload.mockImplementation(() => {
+      throw invalidGuestInstanceId()
+    })
+    expect(() => act(() => screen.getByRole('button', { name: 'Reload' }).click())).not.toThrow()
+    expect(webview.reload).not.toHaveBeenCalled()
+  })
+
+  it('does not freeze silently when a navigation event finds the guest gone', () => {
+    const onUpdatePageState = vi.fn()
+    render(paneElement(true, { onUpdatePageState }))
+    onUpdatePageState.mockClear()
+    webview.getURL.mockImplementation(() => {
+      throw invalidGuestInstanceId()
+    })
+
+    act(() => {
+      webview.dispatchEvent(new Event('did-navigate'))
+    })
+
+    expect(screen.getByText('Client-hosted browser unavailable')).toBeTruthy()
+    expect(onUpdatePageState).toHaveBeenCalledWith('page-a', { loading: false })
+  })
+
+  it('stops the spinner when the guest dies as a load starts', () => {
+    const onUpdatePageState = vi.fn()
+    render(paneElement(true, { onUpdatePageState }))
+    onUpdatePageState.mockClear()
+    webview.getURL.mockImplementation(() => {
+      throw invalidGuestInstanceId()
+    })
+
+    act(() => {
+      webview.dispatchEvent(new Event('did-start-loading'))
+    })
+
+    expect(screen.getByText('Client-hosted browser unavailable')).toBeTruthy()
+    // did-start-loading writes loading:true first; the loss must be the last word.
+    expect(onUpdatePageState.mock.calls.at(-1)).toEqual(['page-a', { loading: false }])
+  })
+
+  it('stops listening for guest loss once the pane lets go of the tag', () => {
+    const onUpdatePageState = vi.fn()
+    const view = render(paneElement(true, { onUpdatePageState }))
+    view.unmount()
+    onUpdatePageState.mockClear()
+    mocks.recordBreadcrumb.mockClear()
+
+    webview.dispatchEvent(new Event('destroyed'))
+
+    expect(onUpdatePageState).not.toHaveBeenCalled()
+    expect(mocks.recordBreadcrumb).not.toHaveBeenCalled()
   })
 
   it('survives activation focus after the retained tag left the DOM', () => {

--- a/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.dead-guest.test.tsx
+++ b/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.dead-guest.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BrowserPage } from '../../../../shared/browser-workspace-types'
+
+const mocks = vi.hoisted(() => ({ attach: vi.fn(), detach: vi.fn() }))
+
+vi.mock('./browser-client-page-renderer-installation', () => ({
+  attachBrowserClientPageToViewport: mocks.attach
+}))
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), loading: vi.fn(), message: vi.fn() }
+}))
+
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { installClientHostedPaneApi } from './client-hosted-browser-pane-test-rig'
+import { ClientHostedBrowserPagePane } from './ClientHostedBrowserPagePane'
+
+const PLACEMENT = {
+  kind: 'client' as const,
+  browserHostClientId: 'host-a',
+  browserHostGeneration: 3,
+  pageHostGeneration: 7
+}
+
+/** Verbatim from Electron 43.4.1: main destroyed the guest, the tag still holds its id. */
+function invalidGuestInstanceId(): Error {
+  return new Error('Invalid guestInstanceId: 7')
+}
+
+/** Verbatim from Electron 43.4.1: focus() after the retained tag left the DOM. */
+function nullContentWindowFocus(): TypeError {
+  return new TypeError("Cannot read properties of null (reading 'focus')")
+}
+
+function page(): BrowserPage {
+  return {
+    id: 'page-a',
+    workspaceId: 'workspace-a',
+    worktreeId: 'worktree-a',
+    url: 'https://example.internal/',
+    title: 'Example',
+    loading: false,
+    faviconUrl: null,
+    canGoBack: false,
+    canGoForward: false,
+    loadError: null,
+    createdAt: 1
+  }
+}
+
+function createGuest(): Electron.WebviewTag & { getURL: ReturnType<typeof vi.fn> } {
+  const webview = document.createElement('webview') as Electron.WebviewTag & {
+    getURL: ReturnType<typeof vi.fn>
+  }
+  Object.assign(webview, {
+    getURL: vi.fn(() => 'https://example.internal/'),
+    getTitle: vi.fn(() => 'Example'),
+    isLoading: vi.fn(() => false),
+    canGoBack: vi.fn(() => false),
+    canGoForward: vi.fn(() => false),
+    focus: vi.fn(),
+    blur: vi.fn(),
+    goBack: vi.fn(),
+    goForward: vi.fn(),
+    reload: vi.fn(),
+    loadURL: vi.fn(async () => {})
+  })
+  mocks.attach.mockReturnValue({
+    webview,
+    detach: mocks.detach,
+    nextMetadataRevision: vi.fn(() => 1)
+  })
+  return webview
+}
+
+function paneElement(isActive: boolean): React.JSX.Element {
+  return (
+    <TooltipProvider>
+      <ClientHostedBrowserPagePane
+        browserTab={page()}
+        workspaceId="workspace-a"
+        chromeShortcutScope="focused"
+        runtimeEnvironmentId="environment-a"
+        worktreeId="worktree-a"
+        placement={PLACEMENT}
+        isActive={isActive}
+        onUpdatePageState={vi.fn()}
+        onSetUrl={vi.fn()}
+      />
+    </TooltipProvider>
+  )
+}
+
+let webview: ReturnType<typeof createGuest>
+
+beforeEach(() => {
+  mocks.attach.mockReset()
+  mocks.detach.mockReset()
+  installClientHostedPaneApi()
+  webview = createGuest()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('client-hosted browser pane over a dead guest', () => {
+  it('degrades to the unavailable notice when the guest was destroyed in main', () => {
+    webview.getURL.mockImplementation(() => {
+      throw invalidGuestInstanceId()
+    })
+
+    expect(() => render(paneElement(true))).not.toThrow()
+    expect(screen.getByText('Client-hosted browser unavailable')).toBeTruthy()
+    expect(mocks.detach).toHaveBeenCalled()
+  })
+
+  it('survives activation focus after the retained tag left the DOM', () => {
+    const view = render(paneElement(false))
+    webview.focus = vi.fn(() => {
+      throw nullContentWindowFocus()
+    })
+
+    expect(() =>
+      act(() => {
+        view.rerender(paneElement(true))
+      })
+    ).not.toThrow()
+    expect(webview.focus).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.tsx
+++ b/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.tsx
@@ -7,7 +7,10 @@ import type {
 } from '../../../../shared/browser-workspace-types'
 import { toHttpsRecoveryUrl } from '../../../../shared/browser-url'
 import type { RuntimeBrowserClientPlacement } from '../../../../shared/runtime-browser-placement'
-import { readBrowserClientPageGuestMetadataIfLive } from './browser-client-page-guest-metadata'
+import {
+  readBrowserClientPageGuestMetadataIfLive,
+  createBrowserClientPageLoadFailureHandler
+} from './browser-client-page-guest-metadata'
 import {
   forgetBrowserClientPageMetadataReports,
   startBrowserClientPageMetadataPublisher
@@ -37,7 +40,6 @@ import { BrowserLoadFailureOverlay } from './navigate/browser-load-failure-overl
 import { useClientHostedPageUrlSubmission } from './navigate/use-client-hosted-page-url-submission'
 import { convertBrowserPageToWorkspaceDoc } from '@/lib/file-preview'
 import { useBrowserPageReloadActions } from './navigate/use-browser-page-reload-actions'
-import { resolveBrowserWebviewLoadFailure } from './navigate/browser-webview-load-failure'
 import { resolveActiveBrowserLoadFailure } from './navigate/browser-load-failure-for-url'
 import { consumeBrowserPageDeferredNavigation } from './navigate/browser-page-deferred-navigation'
 import {
@@ -47,7 +49,6 @@ import {
 } from './describe-page/browser-page-url-display'
 import type {
   BrowserChromeShortcutScope,
-  BrowserPageFailLoadEvent,
   BrowserPageUrlSetter,
   BrowserTabPageState
 } from './describe-page/browser-page-types'
@@ -175,9 +176,7 @@ export function ClientHostedBrowserPagePane({
 
   useLayoutEffect(() => {
     const viewport = viewportRef.current
-    // Why: no placement means the host has not minted this page yet. Attaching would throw for an
-    // id the retained registry has never seen and strand the pane on the unavailable notice, whose
-    // only exit is reopening on the server — so mount quiet and wait for adoption to supply it.
+    // Wait for host adoption before attaching an optimistic page the registry has not seen.
     if (
       !viewport ||
       pageHostGeneration === null ||
@@ -201,24 +200,23 @@ export function ClientHostedBrowserPagePane({
       return
     }
     const webview = attachment.webview
-    // Why one route: a dead guest must always land on the unavailable notice — the pane's existing
-    // recovery state, with its reopen-on-server escape — never on a mute pane or an endless spinner.
+    // Guest loss uses the existing recovery notice and clears pending loading state.
+    let releaseGuest = (): void => attachment.detach()
     const guestLoss = watchBrowserClientPageGuestLoss({
       webview,
       webviewRef,
       browserPageId: browserTab.id,
       pageHostGeneration,
       onLost: () => {
-        attachment.detach()
+        releaseGuest()
         retryGuestRecoveryRef.current()
       }
     })
-    // Why: main can destroy the guest while the tag stays in the DOM holding its id, and every
-    // read below then throws — that is page unavailability, not a crash.
+    // Main can destroy the guest while its tag still holds the stale id.
     const attachedMetadata = readBrowserClientPageGuestMetadataIfLive(webview)
     if (!attachedMetadata) {
       guestLoss.lose('unreadable')
-      return
+      return guestLoss.dispose()
     }
     const publisher = startBrowserClientPageMetadataPublisher({
       browserPageId: browserTab.id,
@@ -233,10 +231,7 @@ export function ClientHostedBrowserPagePane({
     })
     webviewRef.current = webview
     setAttachmentError(null)
-    // Why: the failure carried in from the store is hearsay — this pane may be remounting over a
-    // guest that navigated on while nothing was listening — so it is checked once against where
-    // the guest actually is. Failures this session observes are trusted as they arrive, because a
-    // navigation that fails outright often never commits and leaves the guest on the old URL.
+    // Reconcile restored failures once; failed navigations this session may never commit a URL.
     activeLoadFailureRef.current = resolveActiveBrowserLoadFailure(
       activeLoadFailureRef.current,
       attachedMetadata.url
@@ -248,12 +243,9 @@ export function ClientHostedBrowserPagePane({
         guestLoss.lose('unreadable')
         return
       }
-      // Why: did-stop-loading fires after did-fail-load, so an unconditional null here would
-      // wipe the failure the overlay is about to show.
+      // did-stop-loading must preserve the preceding did-fail-load overlay.
       const activeLoadFailure = activeLoadFailureRef.current
-      // Why: a URL write drops the page's certificate challenge by design (challenges are
-      // transient across navigation), so a standing failure must not run through one — the
-      // local pane returns before its own setUrl for the same reason.
+      // URL writes clear certificate challenges, so preserve them while a failure stands.
       if (!activeLoadFailure) {
         setUrlFromGuest(browserTab.id, metadata.url, {
           preserveLoadError: true
@@ -267,9 +259,8 @@ export function ClientHostedBrowserPagePane({
         loadError: activeLoadFailure
       })
       publisher.publish(metadata)
-      // Why: the address bar's suggestions read the client's shared URL history, so a page
-      // hosted here has to file its navigations there like a local guest does.
-      recordHistoryFromGuest(metadata.url, getBrowserDisplayTitle(webview.getTitle(), metadata.url))
+      // Address-bar suggestions use the client's URL history, including client-hosted pages.
+      recordHistoryFromGuest(metadata.url, getBrowserDisplayTitle(metadata.title, metadata.url))
       setAddressBarValueFromPage(toDisplayUrl(metadata.url))
     }
     const onStart = (): void => {
@@ -282,32 +273,15 @@ export function ClientHostedBrowserPagePane({
       }
       publisher.publish(startMetadata)
     }
-    const onFailLoad = (event: Event): void => {
-      const loadError = resolveBrowserWebviewLoadFailure(event as BrowserPageFailLoadEvent, {
-        // Lazy: the guest read is five sync IPCs, and ERR_ABORTED/subframe events are discarded
-        // before any fallback is needed.
-        fallbackUrl: () => readBrowserClientPageGuestMetadataIfLive(webview)?.url ?? null
-      })
-      if (!loadError) {
-        return
+    const onFailLoad = createBrowserClientPageLoadFailureHandler(
+      webview,
+      () => guestLoss.lose('unreadable'),
+      (loadError) => {
+        activeLoadFailureRef.current = loadError
+        updatePageStateFromGuest(browserTab.id, { loading: false, loadError })
       }
-      activeLoadFailureRef.current = loadError
-      updatePageStateFromGuest(browserTab.id, { loading: false, loadError })
-    }
-    webview.addEventListener('did-start-loading', onStart)
-    webview.addEventListener('did-stop-loading', syncNavigation)
-    webview.addEventListener('did-navigate', syncNavigation)
-    webview.addEventListener('did-navigate-in-page', syncNavigation)
-    webview.addEventListener('page-title-updated', syncNavigation)
-    webview.addEventListener('did-fail-load', onFailLoad)
-    syncNavigation()
-    // Why: the user pressed Enter while this page was still an optimistic stage, so the navigation
-    // was parked rather than sent to a host page that did not exist yet. The guest exists now.
-    const deferredUrl = consumeBrowserPageDeferredNavigation(browserTab.id)
-    if (deferredUrl) {
-      runDeferredNavigation(deferredUrl)
-    }
-    return () => {
+    )
+    const cleanupGuest = (): void => {
       webview.removeEventListener('did-start-loading', onStart)
       webview.removeEventListener('did-stop-loading', syncNavigation)
       webview.removeEventListener('did-navigate', syncNavigation)
@@ -319,6 +293,20 @@ export function ClientHostedBrowserPagePane({
       forgetBrowserClientPageMetadataReports(browserTab.id)
       attachment.detach()
     }
+    releaseGuest = cleanupGuest
+    webview.addEventListener('did-start-loading', onStart)
+    webview.addEventListener('did-stop-loading', syncNavigation)
+    webview.addEventListener('did-navigate', syncNavigation)
+    webview.addEventListener('did-navigate-in-page', syncNavigation)
+    webview.addEventListener('page-title-updated', syncNavigation)
+    webview.addEventListener('did-fail-load', onFailLoad)
+    syncNavigation()
+    // Resume navigation submitted before host adoption.
+    const deferredUrl = consumeBrowserPageDeferredNavigation(browserTab.id)
+    if (deferredUrl) {
+      runDeferredNavigation(deferredUrl)
+    }
+    return cleanupGuest
   }, [
     browserTab.id,
     browserHostClientId,

--- a/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.tsx
+++ b/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useEffectEvent, useLayoutEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
-import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { useAppStore } from '@/store'
 import type {
   BrowserLoadError,
@@ -19,6 +18,7 @@ import { useBrowserClientHostedPopupNotices } from './browser-client-hosted-popu
 import { useBrowserClientHostedPermissionNotices } from './browser-client-hosted-permission-notices'
 import { useClientHostedBrowserIntroTour } from './use-client-hosted-browser-intro-tour'
 import { ClientHostedBrowserUnavailableNotice } from './client-hosted-browser-unavailable-notice'
+import { watchBrowserClientPageGuestLoss } from './host-guest/browser-client-page-guest-loss'
 import { useRestoredClientHostedRecoveryWindow } from './restored-client-hosted-recovery-window'
 import BrowserFind from './assemble-chrome/BrowserFind'
 import { BrowserNavigationControlRow } from './assemble-chrome/browser-navigation-control-row'
@@ -201,19 +201,23 @@ export function ClientHostedBrowserPagePane({
       return
     }
     const webview = attachment.webview
+    // Why one route: a dead guest must always land on the unavailable notice — the pane's existing
+    // recovery state, with its reopen-on-server escape — never on a mute pane or an endless spinner.
+    const guestLoss = watchBrowserClientPageGuestLoss({
+      webview,
+      webviewRef,
+      browserPageId: browserTab.id,
+      pageHostGeneration,
+      onLost: () => {
+        attachment.detach()
+        retryGuestRecoveryRef.current()
+      }
+    })
     // Why: main can destroy the guest while the tag stays in the DOM holding its id, and every
-    // read below then throws — that is page unavailability, which this pane already has a state for.
+    // read below then throws — that is page unavailability, not a crash.
     const attachedMetadata = readBrowserClientPageGuestMetadataIfLive(webview)
     if (!attachedMetadata) {
-      attachment.detach()
-      // Why the loading write: nothing is left to report progress, and a spinner beside the
-      // unavailable notice is the one state this pane must not sit in (as at retryGuestRecovery).
-      updatePageStateFromGuest(browserTab.id, { loading: false })
-      setAttachmentError('browser_client_page_guest_unavailable')
-      recordRendererCrashBreadcrumb('browser_client_page_guest_unavailable', {
-        browserPageId: browserTab.id,
-        pageHostGeneration
-      })
+      guestLoss.lose('unreadable')
       return
     }
     const publisher = startBrowserClientPageMetadataPublisher({
@@ -241,6 +245,7 @@ export function ClientHostedBrowserPagePane({
       const eventUrl = (event as (Event & { url?: string }) | undefined)?.url
       const metadata = readBrowserClientPageGuestMetadataIfLive(webview, eventUrl)
       if (!metadata) {
+        guestLoss.lose('unreadable')
         return
       }
       // Why: did-stop-loading fires after did-fail-load, so an unconditional null here would
@@ -271,9 +276,11 @@ export function ClientHostedBrowserPagePane({
       activeLoadFailureRef.current = null
       updatePageStateFromGuest(browserTab.id, { loading: true, loadError: null })
       const startMetadata = readBrowserClientPageGuestMetadataIfLive(webview, undefined, true)
-      if (startMetadata) {
-        publisher.publish(startMetadata)
+      if (!startMetadata) {
+        guestLoss.lose('unreadable')
+        return
       }
+      publisher.publish(startMetadata)
     }
     const onFailLoad = (event: Event): void => {
       const loadError = resolveBrowserWebviewLoadFailure(event as BrowserPageFailLoadEvent, {
@@ -307,9 +314,7 @@ export function ClientHostedBrowserPagePane({
       webview.removeEventListener('did-navigate-in-page', syncNavigation)
       webview.removeEventListener('page-title-updated', syncNavigation)
       webview.removeEventListener('did-fail-load', onFailLoad)
-      if (webviewRef.current === webview) {
-        webviewRef.current = null
-      }
+      guestLoss.dispose()
       publisher.dispose()
       forgetBrowserClientPageMetadataReports(browserTab.id)
       attachment.detach()

--- a/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.tsx
+++ b/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.tsx
@@ -7,7 +7,7 @@ import type {
 } from '../../../../shared/browser-workspace-types'
 import { toHttpsRecoveryUrl } from '../../../../shared/browser-url'
 import type { RuntimeBrowserClientPlacement } from '../../../../shared/runtime-browser-placement'
-import { readBrowserClientPageGuestMetadata } from './browser-client-page-guest-metadata'
+import { readBrowserClientPageGuestMetadataIfLive } from './browser-client-page-guest-metadata'
 import {
   forgetBrowserClientPageMetadataReports,
   startBrowserClientPageMetadataPublisher
@@ -200,6 +200,14 @@ export function ClientHostedBrowserPagePane({
       return
     }
     const webview = attachment.webview
+    // Why: main can destroy the guest while the tag stays in the DOM holding its id, and every
+    // read below then throws — that is page unavailability, which this pane already has a state for.
+    const attachedMetadata = readBrowserClientPageGuestMetadataIfLive(webview)
+    if (!attachedMetadata) {
+      attachment.detach()
+      setAttachmentError('browser_client_page_guest_unavailable')
+      return
+    }
     const publisher = startBrowserClientPageMetadataPublisher({
       browserPageId: browserTab.id,
       environmentId: runtimeEnvironmentId,
@@ -219,11 +227,14 @@ export function ClientHostedBrowserPagePane({
     // navigation that fails outright often never commits and leaves the guest on the old URL.
     activeLoadFailureRef.current = resolveActiveBrowserLoadFailure(
       activeLoadFailureRef.current,
-      readBrowserClientPageGuestMetadata(webview).url
+      attachedMetadata.url
     )
     const syncNavigation = (event?: Event): void => {
       const eventUrl = (event as (Event & { url?: string }) | undefined)?.url
-      const metadata = readBrowserClientPageGuestMetadata(webview, eventUrl)
+      const metadata = readBrowserClientPageGuestMetadataIfLive(webview, eventUrl)
+      if (!metadata) {
+        return
+      }
       // Why: did-stop-loading fires after did-fail-load, so an unconditional null here would
       // wipe the failure the overlay is about to show.
       const activeLoadFailure = activeLoadFailureRef.current
@@ -251,11 +262,14 @@ export function ClientHostedBrowserPagePane({
     const onStart = (): void => {
       activeLoadFailureRef.current = null
       updatePageStateFromGuest(browserTab.id, { loading: true, loadError: null })
-      publisher.publish(readBrowserClientPageGuestMetadata(webview, undefined, true))
+      const startMetadata = readBrowserClientPageGuestMetadataIfLive(webview, undefined, true)
+      if (startMetadata) {
+        publisher.publish(startMetadata)
+      }
     }
     const onFailLoad = (event: Event): void => {
       const loadError = resolveBrowserWebviewLoadFailure(event as BrowserPageFailLoadEvent, {
-        fallbackUrl: webview.getURL()
+        fallbackUrl: readBrowserClientPageGuestMetadataIfLive(webview)?.url ?? null
       })
       if (!loadError) {
         return
@@ -299,7 +313,7 @@ export function ClientHostedBrowserPagePane({
     setAddressBarValueFromPage
   ])
 
-  useClientHostedGuestActivationFocus({ isActive, webviewRef, keepAddressBarFocusRef })
+  useClientHostedGuestActivationFocus({ isActive, guestFocus, keepAddressBarFocusRef })
 
   const showFailureOverlay = !attachmentError && Boolean(browserTab.loadError)
   // Why: the failure is about the URL that failed, not whatever page is still loaded — feeding

--- a/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.tsx
+++ b/src/renderer/src/components/browser-pane/ClientHostedBrowserPagePane.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useEffectEvent, useLayoutEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { useAppStore } from '@/store'
 import type {
   BrowserLoadError,
@@ -205,7 +206,14 @@ export function ClientHostedBrowserPagePane({
     const attachedMetadata = readBrowserClientPageGuestMetadataIfLive(webview)
     if (!attachedMetadata) {
       attachment.detach()
+      // Why the loading write: nothing is left to report progress, and a spinner beside the
+      // unavailable notice is the one state this pane must not sit in (as at retryGuestRecovery).
+      updatePageStateFromGuest(browserTab.id, { loading: false })
       setAttachmentError('browser_client_page_guest_unavailable')
+      recordRendererCrashBreadcrumb('browser_client_page_guest_unavailable', {
+        browserPageId: browserTab.id,
+        pageHostGeneration
+      })
       return
     }
     const publisher = startBrowserClientPageMetadataPublisher({
@@ -269,7 +277,9 @@ export function ClientHostedBrowserPagePane({
     }
     const onFailLoad = (event: Event): void => {
       const loadError = resolveBrowserWebviewLoadFailure(event as BrowserPageFailLoadEvent, {
-        fallbackUrl: readBrowserClientPageGuestMetadataIfLive(webview)?.url ?? null
+        // Lazy: the guest read is five sync IPCs, and ERR_ABORTED/subframe events are discarded
+        // before any fallback is needed.
+        fallbackUrl: () => readBrowserClientPageGuestMetadataIfLive(webview)?.url ?? null
       })
       if (!loadError) {
         return

--- a/src/renderer/src/components/browser-pane/browser-client-page-guest-metadata.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-guest-metadata.ts
@@ -1,3 +1,4 @@
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { redactKagiSessionToken } from '../../../../shared/browser-url'
 import type { BrowserClientPageMetadataSnapshot } from './browser-client-page-metadata-publisher'
 
@@ -28,9 +29,13 @@ export function readBrowserClientPageGuestMetadataIfLive(
       canGoForward: webview.canGoForward()
     }
   } catch (error) {
-    // Why logged: the tag reporting a live guest id for a destroyed guest is an unfixed defect,
-    // and this is the only place the field can see it happen (or see a different read failure).
+    // Why recorded: the catch is total, so a read failure that is NOT guest death would otherwise
+    // be indistinguishable from one — the breadcrumb carries the error text the console cannot.
     console.warn('[browser-client-page] guest read failed, treating the page as gone:', error)
+    recordRendererCrashBreadcrumb('browser_client_page_guest_read_failed', {
+      errorName: error instanceof Error ? error.name : typeof error,
+      errorMessage: error instanceof Error ? error.message : String(error)
+    })
     return null
   }
 }

--- a/src/renderer/src/components/browser-pane/browser-client-page-guest-metadata.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-guest-metadata.ts
@@ -2,23 +2,32 @@ import { redactKagiSessionToken } from '../../../../shared/browser-url'
 import type { BrowserClientPageMetadataSnapshot } from './browser-client-page-metadata-publisher'
 
 /**
- * What a client-hosted guest currently is, read straight off the webview.
+ * What a client-hosted guest currently is, read straight off the webview, or null once the tag
+ * can no longer reach its guest.
  *
  * `eventUrl` wins when a navigation event carries one: the tag's own getURL() can still report the
  * previous page while the event is being delivered. `loading` is forced for did-start-loading,
  * which fires before isLoading() flips.
+ *
+ * Why total rather than throwing: a guest destroyed in main leaves the tag holding its id, so
+ * every method on it throws `Invalid guestInstanceId` from then on — and every caller reads from
+ * a React effect, where that unwinds the whole workbench error boundary.
  */
-export function readBrowserClientPageGuestMetadata(
+export function readBrowserClientPageGuestMetadataIfLive(
   webview: Electron.WebviewTag,
   eventUrl?: string,
   loading?: boolean
-): BrowserClientPageMetadataSnapshot {
-  const url = redactKagiSessionToken(eventUrl || webview.getURL() || 'about:blank')
-  return {
-    url,
-    title: webview.getTitle() || url || 'Browser',
-    loading: loading ?? webview.isLoading(),
-    canGoBack: webview.canGoBack(),
-    canGoForward: webview.canGoForward()
+): BrowserClientPageMetadataSnapshot | null {
+  try {
+    const url = redactKagiSessionToken(eventUrl || webview.getURL() || 'about:blank')
+    return {
+      url,
+      title: webview.getTitle() || url || 'Browser',
+      loading: loading ?? webview.isLoading(),
+      canGoBack: webview.canGoBack(),
+      canGoForward: webview.canGoForward()
+    }
+  } catch {
+    return null
   }
 }

--- a/src/renderer/src/components/browser-pane/browser-client-page-guest-metadata.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-guest-metadata.ts
@@ -1,3 +1,6 @@
+import type { BrowserLoadError } from '../../../../shared/browser-workspace-types'
+import type { BrowserPageFailLoadEvent } from './describe-page/browser-page-types'
+import { resolveBrowserWebviewLoadFailure } from './navigate/browser-webview-load-failure'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { redactKagiSessionToken } from '../../../../shared/browser-url'
 import type { BrowserClientPageMetadataSnapshot } from './browser-client-page-metadata-publisher'
@@ -37,5 +40,28 @@ export function readBrowserClientPageGuestMetadataIfLive(
       errorMessage: error instanceof Error ? error.message : String(error)
     })
     return null
+  }
+}
+
+export function createBrowserClientPageLoadFailureHandler(
+  webview: Electron.WebviewTag,
+  onUnavailable: () => void,
+  onFailure: (error: BrowserLoadError) => void
+): (event: Event) => void {
+  return (event) => {
+    let guestUnavailable = false
+    const loadError = resolveBrowserWebviewLoadFailure(event as BrowserPageFailLoadEvent, {
+      // Discarded ERR_ABORTED/subframe events must not read the guest.
+      fallbackUrl: () => {
+        const metadata = readBrowserClientPageGuestMetadataIfLive(webview)
+        guestUnavailable = metadata === null
+        return metadata?.url ?? null
+      }
+    })
+    if (guestUnavailable) {
+      onUnavailable()
+    } else if (loadError) {
+      onFailure(loadError)
+    }
   }
 }

--- a/src/renderer/src/components/browser-pane/browser-client-page-guest-metadata.ts
+++ b/src/renderer/src/components/browser-pane/browser-client-page-guest-metadata.ts
@@ -27,7 +27,10 @@ export function readBrowserClientPageGuestMetadataIfLive(
       canGoBack: webview.canGoBack(),
       canGoForward: webview.canGoForward()
     }
-  } catch {
+  } catch (error) {
+    // Why logged: the tag reporting a live guest id for a destroyed guest is an unfixed defect,
+    // and this is the only place the field can see it happen (or see a different read failure).
+    console.warn('[browser-client-page] guest read failed, treating the page as gone:', error)
     return null
   }
 }

--- a/src/renderer/src/components/browser-pane/host-guest/browser-client-page-guest-loss.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-client-page-guest-loss.ts
@@ -1,0 +1,54 @@
+import type { MutableRefObject } from 'react'
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
+
+export type BrowserClientPageGuestLossReason = 'unreadable' | 'destroyed' | 'render-process-gone'
+
+/**
+ * Tells a client-hosted pane, once, that its guest is gone. The retained registry fences the tag on
+ * `destroyed` / `render-process-gone` without telling the pane, which would otherwise sit mute or
+ * spinning over a tag whose every method throws; a failed guest read is the same verdict.
+ */
+export function watchBrowserClientPageGuestLoss(options: {
+  webview: Electron.WebviewTag
+  /** Released on loss and dispose: every chrome action null-checks it, so a dead tag is never driven. */
+  webviewRef: MutableRefObject<Electron.WebviewTag | null>
+  browserPageId: string
+  pageHostGeneration: number
+  onLost: () => void
+}): { lose(reason: BrowserClientPageGuestLossReason): void; dispose(): void } {
+  const { webview } = options
+  const releaseWebviewRef = (): void => {
+    if (options.webviewRef.current === webview) {
+      options.webviewRef.current = null
+    }
+  }
+  let lost = false
+  const lose = (reason: BrowserClientPageGuestLossReason): void => {
+    if (lost) {
+      return
+    }
+    lost = true
+    // Why the breadcrumb: the crash report this replaces was the only field signal for guest death.
+    recordRendererCrashBreadcrumb('browser_client_page_guest_unavailable', {
+      browserPageId: options.browserPageId,
+      pageHostGeneration: options.pageHostGeneration,
+      reason,
+      tagConnected: webview.isConnected
+    })
+    releaseWebviewRef()
+    options.onLost()
+  }
+  const onDestroyed = (): void => lose('destroyed')
+  const onRendererGone = (): void => lose('render-process-gone')
+  webview.addEventListener('destroyed', onDestroyed)
+  webview.addEventListener('render-process-gone', onRendererGone)
+  return {
+    lose,
+    dispose: () => {
+      lost = true
+      releaseWebviewRef()
+      webview.removeEventListener('destroyed', onDestroyed)
+      webview.removeEventListener('render-process-gone', onRendererGone)
+    }
+  }
+}

--- a/src/renderer/src/components/browser-pane/host-guest/use-client-hosted-guest-activation-focus.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/use-client-hosted-guest-activation-focus.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, type RefObject } from 'react'
+import type { BrowserPageGuestFocus } from '../assemble-chrome/browser-page-guest-focus'
 import { useWebviewDragPassthroughActive } from './use-webview-drag-passthrough-active'
 
 /**
@@ -11,11 +12,12 @@ import { useWebviewDragPassthroughActive } from './use-webview-drag-passthrough-
  */
 export function useClientHostedGuestActivationFocus({
   isActive,
-  webviewRef,
+  guestFocus,
   keepAddressBarFocusRef
 }: {
   isActive: boolean
-  webviewRef: RefObject<Electron.WebviewTag | null>
+  /** Not the raw tag: a retired page's <webview> is out of the DOM, where focus() throws (STA-3448). */
+  guestFocus: BrowserPageGuestFocus
   keepAddressBarFocusRef: RefObject<boolean>
 }): void {
   const dragPassthroughActive = useWebviewDragPassthroughActive()
@@ -41,6 +43,6 @@ export function useClientHostedGuestActivationFocus({
     if (keepAddressBarFocusRef.current) {
       return
     }
-    webviewRef.current?.focus()
-  }, [dragPassthroughActive, isActive, keepAddressBarFocusRef, webviewRef])
+    guestFocus.focus()
+  }, [dragPassthroughActive, guestFocus, isActive, keepAddressBarFocusRef])
 }

--- a/src/renderer/src/components/browser-pane/navigate/browser-webview-load-failure.test.ts
+++ b/src/renderer/src/components/browser-pane/navigate/browser-webview-load-failure.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { resolveBrowserWebviewLoadFailure } from './browser-webview-load-failure'
 
 describe('resolveBrowserWebviewLoadFailure', () => {
@@ -45,6 +45,18 @@ describe('resolveBrowserWebviewLoadFailure', () => {
       resolveBrowserWebviewLoadFailure(
         { errorCode: -105, errorDescription: 'ERR_NAME_NOT_RESOLVED', validatedURL: '' },
         { fallbackUrl: 'https://example.com/current' }
+      )
+    ).toMatchObject({ validatedUrl: 'https://example.com/current' })
+  })
+
+  it('never reads a lazy fallback URL for an event it discards', () => {
+    const fallbackUrl = vi.fn(() => 'https://example.com/current')
+    expect(resolveBrowserWebviewLoadFailure({ errorCode: -3 }, { fallbackUrl })).toBeNull()
+    expect(fallbackUrl).not.toHaveBeenCalled()
+    expect(
+      resolveBrowserWebviewLoadFailure(
+        { errorCode: -105, errorDescription: 'ERR_NAME_NOT_RESOLVED', validatedURL: '' },
+        { fallbackUrl }
       )
     ).toMatchObject({ validatedUrl: 'https://example.com/current' })
   })

--- a/src/renderer/src/components/browser-pane/navigate/browser-webview-load-failure.ts
+++ b/src/renderer/src/components/browser-pane/navigate/browser-webview-load-failure.ts
@@ -8,20 +8,23 @@ import type { BrowserPageFailLoadEvent } from '../describe-page/browser-page-typ
  * cannot forget the ignore rules or build a differently-shaped BrowserLoadError.
  *
  * `fallbackUrl` covers failures that arrive without a validatedURL — pass the webview's
- * current URL so the overlay names the page instead of about:blank.
+ * current URL so the overlay names the page instead of about:blank. Pass it as a function when
+ * reading it costs anything: discarded events never ask for it.
  */
 export function resolveBrowserWebviewLoadFailure(
   event: BrowserPageFailLoadEvent,
-  options: { fallbackUrl?: string | null } = {}
+  options: { fallbackUrl?: string | null | (() => string | null) } = {}
 ): BrowserLoadError | null {
   // Why: Chromium reports redirect/cancel races as ERR_ABORTED (-3) even when the
   // replacement navigation succeeds; subframe failures never blank the page.
   if (event.isMainFrame === false || event.errorCode === -3) {
     return null
   }
+  const fallbackUrl =
+    typeof options.fallbackUrl === 'function' ? options.fallbackUrl() : options.fallbackUrl
   return {
     code: event.errorCode ?? -1,
     description: event.errorDescription || 'Unknown load failure',
-    validatedUrl: redactKagiSessionToken(event.validatedURL || options.fallbackUrl || 'about:blank')
+    validatedUrl: redactKagiSessionToken(event.validatedURL || fallbackUrl || 'about:blank')
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​323 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​322 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​182 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​63 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 |

<!-- /orca-pr-loc -->

## What Changed

A destroyed client-hosted Electron guest could throw from metadata reads or activation focus during React effects, taking down the entire workbench. The pane now catches guest reads, reuses the guarded focus adapter, and shows its existing unavailable notice with the reopen-on-server action.

Guest destruction, renderer loss, and unreadable metadata all clear loading, release the webview reference, detach the attachment, and stop event listeners and metadata publishing. Failed initial reads also remove the loss listeners. Late loading events cannot restart the spinner after recovery.

Navigation history uses the guarded title snapshot, removing the last unguarded title read in this effect. Untitled nonblank pages consequently use their URL as the history title; blank pages still display “New Tab.” Load failures skip guest reads for discarded subframe/ERR_ABORTED events and reach the same recovery state if the remaining read fails.

## Why

Five field reports on Electron 43.4.1 showed `Invalid guestInstanceId` during metadata reads or a null `contentWindow` during focus. These operations run in renderer JavaScript on all desktop platforms. Guest read failures retain diagnostic breadcrumbs.

## ELI5

When an embedded browser dies, Orca now shows an unavailable message in that browser panel while keeping the rest of the workbench usable.

## Testing

- [x] Automated regressions: 12 dead-guest cases, including title-read races, failed-load recovery, initial listener cleanup, and loading events after destruction.
- [x] Browser-pane suite: 97 files / 788 tests passed locally on macOS.
- [x] `pnpm tc:web`, changed-code quality, focused oxlint, and formatting checks passed.
- [ ] Full rendered Orca workbench reproduction; the existing evidence below is a standalone Electron reproduction.

## Visual Proof

No before/after Orca recording is available. Regression tests exercise the unavailable notice and loading state; the prior standalone Electron run below establishes the native failure shapes, but does not prove end-to-end workbench behavior.

### 1. Live Electron 43.4.1 reproduction of both runtime conditions

Standalone Electron app (`/tmp/ct/repro-R1-R3`) on the exact Electron the field builds ship (`node_modules/electron` → `43.4.1`). Run first-hand for this PR, not quoted from an earlier session:

```
$ /…/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron .
[renderer] CASE0 attached guestInstanceId = 2 getURL = about:blank
[renderer] EVENT destroyed fired at 166.80000001192093
[renderer] CASE1 main says destroyed at 0.3 ms
[renderer] CASE1 firstThrow: "Invalid guestInstanceId: 2" after 2.1 ms; destroyed DOM event after 0.3 ms; iterations 1
[renderer] CASE1 getWebContentsId still = 2
[renderer] CASE1 focus ok
[renderer] CASE1 isLoading throws: Invalid guestInstanceId: 2
[renderer] CASE2 attached id 3
[renderer] CASE2 alive after remove? false
[renderer] CASE2 focus throws: TypeError: Cannot read properties of null (reading 'focus')
[renderer] CASE2 getURL throws: Error: The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.
[renderer] CASE2 getWebContentsId throws: The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.
DONE
```

CASE1 is the R3 field error verbatim. CASE2 is the R1 field error verbatim. `CASE1 getWebContentsId still = 2` is the evidence behind follow-up #1 below.


## Review

CodeRabbit's post-attachment recovery and unguarded-title findings are addressed. Review also added immediate listener/publisher cleanup and failed-load recovery. CodeRabbit and Pullfrog reviewed the final follow-up commit with no new actionable findings. All CI checks passed before merge.

## Notes

No RPC schema, platform-specific command, path, Git, or workspace-type behavior changes. Client-hosted guests still run on the client for SSH workspaces; network disconnection is not used as evidence of guest death.

Remaining pre-existing limitations: the retained registry can mistake a stale guest id for liveness; registry retirement without a DOM loss event can leave a pane quiet until the next read or placement update; separate attach-threw/renderer-unavailable branches may retain a loading state.

## Linked Issue

This PR addresses the five crash reports documented above; no GitHub issue is linked.

## Agent skill upstream boundary

- [x] Not applicable: no upstream skill-installer content is changed.

## Checklist

- [x] Self-reviewed for correctness, cleanup, and cross-platform/SSH behavior.
- [x] Focused production fix with regression coverage.
- [ ] Before/after rendered Orca capture attached.
- [x] Final CI checks complete; all passed before merge.

