### PR TITLE
fix(editor): stop an unparseable file path from taking down the workbench

### DIFF
--- a/src/renderer/src/components/editor/MonacoEditor.model-path.test.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.model-path.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Uri } from 'monaco-editor'
+
+const editorProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }))
+
+vi.mock('@monaco-editor/react', () => ({
+  default: (props: Record<string, unknown>) => {
+    // Why: @monaco-editor/react resolves `path` with this exact call before creating the model.
+    Uri.parse(String(props.path))
+    editorProps.current = props
+    return null
+  },
+  loader: { config: vi.fn() }
+}))
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      settings: { theme: 'dark', terminalFontSize: 13 },
+      editorFontZoomLevel: 0,
+      setPendingEditorReveal: vi.fn(),
+      setEditorCursorLine: vi.fn(),
+      addDiffComment: vi.fn(),
+      deleteDiffComment: vi.fn(),
+      updateDiffComment: vi.fn(),
+      scrollToDiffCommentId: null,
+      setScrollToDiffCommentId: vi.fn(),
+      worktreeDiffComments: {}
+    })
+}))
+vi.mock('../diff-comments/useDiffCommentDecorator', () => ({
+  useDiffCommentDecorator: vi.fn()
+}))
+vi.mock('./useContextualCopySetup', () => ({
+  useContextualCopySetup: () => ({ setupCopy: vi.fn(), toastNode: null })
+}))
+
+import MonacoEditor from './MonacoEditor'
+
+const WSL_COLON_PATH =
+  '\\\\wsl.localhost\\Ubuntu-26.04\\home\\mj\\projects\\acp-client\\notes:2026.md'
+
+function renderEditor(filePath: string): void {
+  render(
+    <MonacoEditor
+      fileId="file"
+      filePath={filePath}
+      viewStateKey="pane:file"
+      relativePath="notes:2026.md"
+      content="# notes"
+      language="markdown"
+      onContentChange={vi.fn()}
+      onSave={vi.fn()}
+      readOnly
+    />
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  editorProps.current = null
+})
+
+describe('MonacoEditor model path', () => {
+  it('passes ordinary paths through unchanged', () => {
+    renderEditor('/repo/file.py')
+    expect(editorProps.current?.path).toBe('/repo/file.py')
+  })
+
+  it('hands Monaco a parseable path for a WSL/UNC file name carrying a colon', () => {
+    expect(() => renderEditor(WSL_COLON_PATH)).not.toThrow()
+    expect(() => Uri.parse(String(editorProps.current?.path))).not.toThrow()
+  })
+})

--- a/src/renderer/src/components/editor/MonacoEditor.model-path.test.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.model-path.test.tsx
@@ -2,6 +2,9 @@
 import { cleanup, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Uri } from 'monaco-editor'
+import type { OpenFile } from '@/store/slices/editor'
+import { disposeClosedEditorTabs } from './closed-editor-tab-disposal'
+import { createMonacoModelRegistryWithRealUri } from './monaco-model-registry-test-fixture'
 
 const editorProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }))
 
@@ -71,5 +74,19 @@ describe('MonacoEditor model path', () => {
   it('hands Monaco a parseable path for a WSL/UNC file name carrying a colon', () => {
     expect(() => renderEditor(WSL_COLON_PATH)).not.toThrow()
     expect(() => Uri.parse(String(editorProps.current?.path))).not.toThrow()
+  })
+
+  // Why through the rendered prop, not the helper: this is the only assertion that fails if
+  // MonacoEditor stops routing `path` through the helper and the close-all key drifts.
+  it('keys the model on a path close-all can still dispose', () => {
+    renderEditor(WSL_COLON_PATH)
+    const renderedPath = String(editorProps.current?.path)
+    const registry = createMonacoModelRegistryWithRealUri([renderedPath])
+
+    disposeClosedEditorTabs(registry, [
+      { id: 'poisoned', mode: 'edit', filePath: WSL_COLON_PATH } as OpenFile
+    ])
+
+    expect(registry.disposed).toEqual([renderedPath])
   })
 })

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -1,7 +1,7 @@
 /* oxlint-disable react-doctor/no-adjust-state-on-prop-change -- Why: selection annotations are synchronized from Monaco editor selection and layout APIs, not derived React props. */
 import React, { useRef, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import Editor from '@monaco-editor/react'
-import type { editor } from 'monaco-editor'
+import { Uri, type editor } from 'monaco-editor'
 import type { MarkdownDocument } from '../../../../shared/filesystem-entry-types'
 import { useAppStore } from '@/store'
 import '@/lib/monaco-setup'
@@ -21,6 +21,7 @@ import { useMonacoEditorDecorations } from './use-monaco-editor-decorations'
 import { useMonacoEditorMount } from './use-monaco-editor-mount'
 import { snapshotMonacoViewState } from './monaco-view-state-persistence'
 import { MonacoMarkdownAnnotationOverlay } from './MonacoMarkdownAnnotationOverlay'
+import { toMonacoEditModelPath } from './monaco-edit-model-path'
 
 type MonacoEditorProps = {
   fileId: string
@@ -110,6 +111,8 @@ export default function MonacoEditor({
   // Invariant: the mount path must read `contentRef.current` (guaranteed latest), never `lastSyncedContentRef.current` (may be stale pre-mount).
   const contentRef = useRef(content)
   contentRef.current = content
+  // Why: @monaco-editor/react resolves `path` with Uri.parse inside its mount effect, which throws on a drive-less backslash path carrying a ':' and takes the workbench down.
+  const monacoModelPath = useMemo(() => toMonacoEditModelPath(Uri, filePath), [filePath])
   // Gutter context menu state
   const [gutterMenuOpen, setGutterMenuOpen] = useState(false)
   const [gutterMenuPoint, setGutterMenuPoint] = useState({ x: 0, y: 0 })
@@ -259,7 +262,7 @@ export default function MonacoEditor({
           // Why: Monaco owns its rendered line surface, so align its selection-clipboard with the app opt-out (the global DOM hook can't).
           selectionClipboard: settings?.primarySelectionMiddleClickPaste ?? isLinuxUserAgent()
         }}
-        path={filePath}
+        path={monacoModelPath}
         // Why: Orca owns cursor/scroll restoration, so disable @monaco-editor/react's competing view-state Map.
         saveViewState={false}
         keepCurrentModel

--- a/src/renderer/src/components/editor/closed-editor-tab-disposal.test.ts
+++ b/src/renderer/src/components/editor/closed-editor-tab-disposal.test.ts
@@ -12,6 +12,7 @@ import {
   getDiffViewerMonacoModelPathPrefixes,
   type MonacoModelRegistry
 } from './diff-monaco-model-disposal'
+import type { MonacoUriNamespace } from './monaco-edit-model-path'
 
 const CLOSED_DIFF_TAB_COUNT = 100
 const RETAINED_MODEL_COUNT = 320
@@ -26,6 +27,7 @@ type FakeModel = {
 }
 
 type FakeRegistry = MonacoModelRegistry & {
+  Uri: MonacoUriNamespace
   models: FakeModel[]
   counters: { getModelsCalls: number; uriToStringCalls: number }
 }
@@ -42,7 +44,7 @@ function createRegistry(models: FakeModel[]): FakeRegistry {
   return {
     models,
     counters,
-    Uri: { parse: (value: string) => value },
+    Uri: { parse: (value: string) => value, file: (value: string) => ({ toString: () => value }) },
     editor: {
       getModel: (uri: unknown) => byPath.get(String(uri)) ?? null,
       getModels: () => {

--- a/src/renderer/src/components/editor/closed-editor-tab-disposal.test.ts
+++ b/src/renderer/src/components/editor/closed-editor-tab-disposal.test.ts
@@ -6,13 +6,14 @@ import {
   scrollTopCache
 } from '@/lib/scroll-cache'
 import type { OpenFile } from '@/store/slices/editor'
-import { disposeClosedEditorTabs } from './closed-editor-tab-disposal'
+import {
+  disposeClosedEditorTabs,
+  type ClosedEditorTabMonacoRegistry
+} from './closed-editor-tab-disposal'
 import {
   getDiffViewerMonacoModelPaths,
-  getDiffViewerMonacoModelPathPrefixes,
-  type MonacoModelRegistry
+  getDiffViewerMonacoModelPathPrefixes
 } from './diff-monaco-model-disposal'
-import type { MonacoUriNamespace } from './monaco-edit-model-path'
 
 const CLOSED_DIFF_TAB_COUNT = 100
 const RETAINED_MODEL_COUNT = 320
@@ -26,8 +27,7 @@ type FakeModel = {
   uri: { toString: (skipEncoding?: boolean) => string }
 }
 
-type FakeRegistry = MonacoModelRegistry & {
-  Uri: MonacoUriNamespace
+type FakeRegistry = ClosedEditorTabMonacoRegistry & {
   models: FakeModel[]
   counters: { getModelsCalls: number; uriToStringCalls: number }
 }

--- a/src/renderer/src/components/editor/closed-editor-tab-disposal.ts
+++ b/src/renderer/src/components/editor/closed-editor-tab-disposal.ts
@@ -14,6 +14,23 @@ import {
   deletePaneScopedCacheEntries,
   sweepClosedPdfViewPositions
 } from './closed-editor-tab-cache-sweep'
+import { toMonacoEditModelPath, type MonacoUriNamespace } from './monaco-edit-model-path'
+
+type ClosedEditorTabMonacoRegistry = MonacoModelRegistry & { Uri: MonacoUriNamespace }
+
+function disposeEditTabModel(
+  monacoRegistry: ClosedEditorTabMonacoRegistry,
+  filePath: string
+): void {
+  let modelUri: unknown
+  try {
+    modelUri = monacoRegistry.Uri.parse(toMonacoEditModelPath(monacoRegistry.Uri, filePath))
+  } catch {
+    // Why safe: @monaco-editor/react keys the model with this identical parse, so a path that throws here never produced a model to leak.
+    return
+  }
+  monacoRegistry.editor.getModel(modelUri)?.dispose()
+}
 
 /**
  * Releases the Monaco models and view-state cache entries owned by a batch of closed tabs.
@@ -23,7 +40,7 @@ import {
  * the monaco namespace as an argument so it stays testable without importing `monaco-editor`.
  */
 export function disposeClosedEditorTabs(
-  monacoRegistry: MonacoModelRegistry,
+  monacoRegistry: ClosedEditorTabMonacoRegistry,
   closedFiles: readonly OpenFile[]
 ): void {
   if (closedFiles.length === 0) {
@@ -39,9 +56,9 @@ export function disposeClosedEditorTabs(
   for (const closedFile of closedFiles) {
     switch (closedFile.mode) {
       case 'edit':
-        // Why: the edit model URI is constructed via monaco.Uri.parse(filePath)
-        // to match @monaco-editor/react's `path` prop convention.
-        monacoRegistry.editor.getModel(monacoRegistry.Uri.parse(closedFile.filePath))?.dispose()
+        // Why: the edit model URI is keyed by the same path @monaco-editor/react
+        // hands Monaco, so create and dispose stay on one key.
+        disposeEditTabModel(monacoRegistry, closedFile.filePath)
         scrollTopCache.delete(closedFile.filePath)
         // Why: markdown and mermaid surfaces keep mode-scoped scroll positions.
         scrollTopCache.delete(`${closedFile.filePath}:rich`)

--- a/src/renderer/src/components/editor/closed-editor-tab-disposal.ts
+++ b/src/renderer/src/components/editor/closed-editor-tab-disposal.ts
@@ -14,9 +14,15 @@ import {
   deletePaneScopedCacheEntries,
   sweepClosedPdfViewPositions
 } from './closed-editor-tab-cache-sweep'
-import { toMonacoEditModelPath, type MonacoUriNamespace } from './monaco-edit-model-path'
+import {
+  recordUnparseableModelPathShape,
+  toMonacoEditModelPath,
+  type MonacoUriNamespace
+} from './monaco-edit-model-path'
 
-type ClosedEditorTabMonacoRegistry = MonacoModelRegistry & { Uri: MonacoUriNamespace }
+export type ClosedEditorTabMonacoRegistry = Omit<MonacoModelRegistry, 'Uri'> & {
+  Uri: MonacoUriNamespace
+}
 
 function disposeEditTabModel(
   monacoRegistry: ClosedEditorTabMonacoRegistry,
@@ -26,7 +32,8 @@ function disposeEditTabModel(
   try {
     modelUri = monacoRegistry.Uri.parse(toMonacoEditModelPath(monacoRegistry.Uri, filePath))
   } catch {
-    // Why safe: @monaco-editor/react keys the model with this identical parse, so a path that throws here never produced a model to leak.
+    // Reached only if Uri.file() itself rejects the path: no key exists, so nothing to dispose.
+    recordUnparseableModelPathShape('editor_model_dispose_path_unkeyable', filePath)
     return
   }
   monacoRegistry.editor.getModel(modelUri)?.dispose()

--- a/src/renderer/src/components/editor/monaco-edit-model-path.test.ts
+++ b/src/renderer/src/components/editor/monaco-edit-model-path.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { Uri } from 'monaco-editor'
+import type { OpenFile } from '@/store/slices/editor'
+import { disposeClosedEditorTabs } from './closed-editor-tab-disposal'
+import { toMonacoEditModelPath } from './monaco-edit-model-path'
+import type { MonacoModelRegistry } from './diff-monaco-model-disposal'
+import type { MonacoUriNamespace } from './monaco-edit-model-path'
+
+// Why this exact shape: the field crash (`[UriError]: Scheme contains illegal characters.`) came
+// from a Windows/WSL workspace. `Uri.parse` reads `\\wsl.localhost\...\notes` as the scheme
+// because nothing before the first `:` is a `/`, `?` or `#`.
+const WSL_COLON_PATH =
+  '\\\\wsl.localhost\\Ubuntu-26.04\\home\\mj\\projects\\acp-client\\notes:2026.md'
+
+type RecordingRegistry = MonacoModelRegistry & {
+  Uri: MonacoUriNamespace
+  disposed: string[]
+}
+
+function createRegistryWithRealUri(modelPaths: readonly string[]): RecordingRegistry {
+  const disposed: string[] = []
+  const modelsByUri = new Map<string, ReturnType<typeof createModel>>()
+
+  function createModel(modelPath: string): {
+    dispose: () => void
+    isAttachedToEditor: () => boolean
+    uri: { toString: (skipEncoding?: boolean) => string }
+  } {
+    const key = Uri.parse(modelPath).toString()
+    return {
+      dispose: () => disposed.push(modelPath),
+      isAttachedToEditor: () => false,
+      uri: { toString: () => key }
+    }
+  }
+
+  for (const modelPath of modelPaths) {
+    modelsByUri.set(Uri.parse(modelPath).toString(), createModel(modelPath))
+  }
+
+  return {
+    disposed,
+    Uri,
+    editor: {
+      getModel: (uri: unknown) => modelsByUri.get(String(uri)) ?? null,
+      getModels: () => [...modelsByUri.values()]
+    }
+  }
+}
+
+function editTab(id: string, filePath: string): OpenFile {
+  return { id, mode: 'edit', filePath } as OpenFile
+}
+
+describe('toMonacoEditModelPath', () => {
+  it('leaves every path Monaco already accepts untouched', () => {
+    for (const filePath of [
+      '/home/mj/projects/acp-client/notes:2026.md',
+      'C:\\Users\\mj\\notes:2026.md',
+      '\\\\wsl.localhost\\Ubuntu-26.04\\home\\mj\\projects\\acp-client\\src\\index.ts'
+    ]) {
+      expect(toMonacoEditModelPath(Uri, filePath)).toBe(filePath)
+    }
+  })
+
+  it('rewrites the path class that makes Monaco throw into a parseable one', () => {
+    expect(() => Uri.parse(WSL_COLON_PATH)).toThrow(/Scheme contains illegal characters/)
+
+    const modelPath = toMonacoEditModelPath(Uri, WSL_COLON_PATH)
+    expect(modelPath).not.toBe(WSL_COLON_PATH)
+    expect(() => Uri.parse(modelPath)).not.toThrow()
+  })
+})
+
+describe('disposeClosedEditorTabs with the real Monaco URI parser', () => {
+  it('does not throw the workbench down on the unparseable path class', () => {
+    const registry = createRegistryWithRealUri([])
+
+    expect(() =>
+      disposeClosedEditorTabs(registry, [editTab('poisoned', WSL_COLON_PATH)])
+    ).not.toThrow()
+  })
+
+  it('keeps disposing the rest of the close-all batch behind a poisoned tab', () => {
+    const beforePath = '/repo/before.ts'
+    const afterPath = '/repo/after.ts'
+    const registry = createRegistryWithRealUri([
+      beforePath,
+      toMonacoEditModelPath(Uri, WSL_COLON_PATH),
+      afterPath
+    ])
+
+    disposeClosedEditorTabs(registry, [
+      editTab('before', beforePath),
+      editTab('poisoned', WSL_COLON_PATH),
+      editTab('after', afterPath)
+    ])
+
+    expect(registry.disposed).toContain(beforePath)
+    expect(registry.disposed).toContain(afterPath)
+    // Why: the poisoned tab's model is reachable too, because open and close now key it the same way.
+    expect(registry.disposed).toContain(toMonacoEditModelPath(Uri, WSL_COLON_PATH))
+  })
+})

--- a/src/renderer/src/components/editor/monaco-edit-model-path.test.ts
+++ b/src/renderer/src/components/editor/monaco-edit-model-path.test.ts
@@ -1,53 +1,28 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Uri } from 'monaco-editor'
 import type { OpenFile } from '@/store/slices/editor'
 import { disposeClosedEditorTabs } from './closed-editor-tab-disposal'
 import { toMonacoEditModelPath } from './monaco-edit-model-path'
-import type { MonacoModelRegistry } from './diff-monaco-model-disposal'
-import type { MonacoUriNamespace } from './monaco-edit-model-path'
+import {
+  createMonacoModelRegistryWithRealUri,
+  type RecordingMonacoModelRegistry
+} from './monaco-model-registry-test-fixture'
+
+const crashBreadcrumbs = vi.hoisted(() => ({ record: vi.fn() }))
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: crashBreadcrumbs.record
+}))
+
+beforeEach(() => {
+  crashBreadcrumbs.record.mockClear()
+})
 
 // Why this exact shape: the field crash (`[UriError]: Scheme contains illegal characters.`) came
 // from a Windows/WSL workspace. `Uri.parse` reads `\\wsl.localhost\...\notes` as the scheme
 // because nothing before the first `:` is a `/`, `?` or `#`.
 const WSL_COLON_PATH =
   '\\\\wsl.localhost\\Ubuntu-26.04\\home\\mj\\projects\\acp-client\\notes:2026.md'
-
-type RecordingRegistry = MonacoModelRegistry & {
-  Uri: MonacoUriNamespace
-  disposed: string[]
-}
-
-function createRegistryWithRealUri(modelPaths: readonly string[]): RecordingRegistry {
-  const disposed: string[] = []
-  const modelsByUri = new Map<string, ReturnType<typeof createModel>>()
-
-  function createModel(modelPath: string): {
-    dispose: () => void
-    isAttachedToEditor: () => boolean
-    uri: { toString: (skipEncoding?: boolean) => string }
-  } {
-    const key = Uri.parse(modelPath).toString()
-    return {
-      dispose: () => disposed.push(modelPath),
-      isAttachedToEditor: () => false,
-      uri: { toString: () => key }
-    }
-  }
-
-  for (const modelPath of modelPaths) {
-    modelsByUri.set(Uri.parse(modelPath).toString(), createModel(modelPath))
-  }
-
-  return {
-    disposed,
-    Uri,
-    editor: {
-      getModel: (uri: unknown) => modelsByUri.get(String(uri)) ?? null,
-      getModels: () => [...modelsByUri.values()]
-    }
-  }
-}
 
 function editTab(id: string, filePath: string): OpenFile {
   return { id, mode: 'edit', filePath } as OpenFile
@@ -71,11 +46,32 @@ describe('toMonacoEditModelPath', () => {
     expect(modelPath).not.toBe(WSL_COLON_PATH)
     expect(() => Uri.parse(modelPath)).not.toThrow()
   })
+
+  // Why: the rewrite is now the only trace of an input class whose producer is unidentified.
+  it('leaves a shape-only crumb describing the rejected path', () => {
+    toMonacoEditModelPath(Uri, WSL_COLON_PATH)
+
+    expect(crashBreadcrumbs.record).toHaveBeenCalledWith('editor_model_path_uri_rejected', {
+      length: WSL_COLON_PATH.length,
+      colons: 1,
+      hasBackslash: true,
+      schemePrefixLength: WSL_COLON_PATH.indexOf(':'),
+      schemePrefixCharset: 'alpha|backslash|digit|schemeSafePunct'
+    })
+    const [, data] = crashBreadcrumbs.record.mock.calls[0] as [string, Record<string, unknown>]
+    expect(JSON.stringify(data)).not.toContain('wsl.localhost')
+  })
+
+  it('records nothing for a path Monaco already accepts', () => {
+    toMonacoEditModelPath(Uri, '/repo/file.py')
+
+    expect(crashBreadcrumbs.record).not.toHaveBeenCalled()
+  })
 })
 
 describe('disposeClosedEditorTabs with the real Monaco URI parser', () => {
   it('does not throw the workbench down on the unparseable path class', () => {
-    const registry = createRegistryWithRealUri([])
+    const registry = createMonacoModelRegistryWithRealUri([])
 
     expect(() =>
       disposeClosedEditorTabs(registry, [editTab('poisoned', WSL_COLON_PATH)])
@@ -85,7 +81,7 @@ describe('disposeClosedEditorTabs with the real Monaco URI parser', () => {
   it('keeps disposing the rest of the close-all batch behind a poisoned tab', () => {
     const beforePath = '/repo/before.ts'
     const afterPath = '/repo/after.ts'
-    const registry = createRegistryWithRealUri([
+    const registry = createMonacoModelRegistryWithRealUri([
       beforePath,
       toMonacoEditModelPath(Uri, WSL_COLON_PATH),
       afterPath
@@ -101,5 +97,25 @@ describe('disposeClosedEditorTabs with the real Monaco URI parser', () => {
     expect(registry.disposed).toContain(afterPath)
     // Why: the poisoned tab's model is reachable too, because open and close now key it the same way.
     expect(registry.disposed).toContain(toMonacoEditModelPath(Uri, WSL_COLON_PATH))
+  })
+
+  it('crumbs instead of throwing when even the fallback URI form is unbuildable', () => {
+    const registry: RecordingMonacoModelRegistry = {
+      ...createMonacoModelRegistryWithRealUri([]),
+      Uri: {
+        parse: (value: string) => Uri.parse(value),
+        file: () => {
+          throw new Error('unbuildable')
+        }
+      }
+    }
+
+    expect(() =>
+      disposeClosedEditorTabs(registry, [editTab('poisoned', WSL_COLON_PATH)])
+    ).not.toThrow()
+    expect(crashBreadcrumbs.record).toHaveBeenCalledWith(
+      'editor_model_dispose_path_unkeyable',
+      expect.objectContaining({ hasBackslash: true })
+    )
   })
 })

--- a/src/renderer/src/components/editor/monaco-edit-model-path.ts
+++ b/src/renderer/src/components/editor/monaco-edit-model-path.ts
@@ -1,6 +1,46 @@
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
+
 export type MonacoUriNamespace = {
   parse(value: string): unknown
   file(path: string): { toString(): string }
+}
+
+const SCHEME_PREFIX_CHAR_CLASSES: readonly (readonly [string, RegExp])[] = [
+  ['alpha', /[a-z]/i],
+  ['digit', /\d/],
+  ['backslash', /\\/],
+  ['slash', /\//],
+  ['schemeSafePunct', /[.+-]/],
+  ['space', / /]
+]
+
+/** Character classes before the first `:`, so a crumb names the shape without carrying the path. */
+function schemePrefixCharset(prefix: string): string {
+  const classes = new Set(
+    [...prefix].map(
+      (char) => SCHEME_PREFIX_CHAR_CLASSES.find(([, pattern]) => pattern.test(char))?.[0] ?? 'other'
+    )
+  )
+  return [...classes].sort().join('|')
+}
+
+/**
+ * Shape-only crumb for a path Monaco's URI parser rejects.
+ *
+ * Why at all: the guards below turn the field crash into a silent rewrite, and the crash was the
+ * only signal that ever surfaced this input class — its producer is still unidentified. Shape
+ * fields only; the crash pipeline redacts raw paths anyway.
+ */
+export function recordUnparseableModelPathShape(name: string, filePath: string): void {
+  const path = String(filePath)
+  const firstColon = path.indexOf(':')
+  recordRendererCrashBreadcrumb(name, {
+    length: path.length,
+    colons: path.split(':').length - 1,
+    hasBackslash: path.includes('\\'),
+    schemePrefixLength: firstColon,
+    schemePrefixCharset: schemePrefixCharset(firstColon === -1 ? '' : path.slice(0, firstColon))
+  })
 }
 
 /**
@@ -17,6 +57,7 @@ export function toMonacoEditModelPath(uri: MonacoUriNamespace, filePath: string)
     uri.parse(filePath)
     return filePath
   } catch {
+    recordUnparseableModelPathShape('editor_model_path_uri_rejected', filePath)
     return uri.file(filePath).toString()
   }
 }

--- a/src/renderer/src/components/editor/monaco-edit-model-path.ts
+++ b/src/renderer/src/components/editor/monaco-edit-model-path.ts
@@ -1,0 +1,22 @@
+export type MonacoUriNamespace = {
+  parse(value: string): unknown
+  file(path: string): { toString(): string }
+}
+
+/**
+ * The path an edit tab's Monaco model is keyed by, in a form `Uri.parse` always accepts.
+ *
+ * Why: Monaco reads everything before the first `:` as a URI scheme, so a drive-less backslash
+ * path carrying a `:` — a WSL/UNC file whose name reached us from Linux-side tooling, which keeps
+ * the literal colon Win32 enumeration hides behind U+F03A — throws `[UriError]: Scheme contains
+ * illegal characters.` Paths that already parse are returned unchanged, so no model key or
+ * view-state cache entry that works today moves.
+ */
+export function toMonacoEditModelPath(uri: MonacoUriNamespace, filePath: string): string {
+  try {
+    uri.parse(filePath)
+    return filePath
+  } catch {
+    return uri.file(filePath).toString()
+  }
+}

--- a/src/renderer/src/components/editor/monaco-edit-model-path.windows.test.ts
+++ b/src/renderer/src/components/editor/monaco-edit-model-path.windows.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+
+// Why a dedicated file: monaco reads `process.platform` once at module load, so the Windows URI
+// form — the one real users of this crash get — is only reachable by pinning it before the import.
+vi.hoisted(() => {
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+})
+
+import { Uri } from 'monaco-editor'
+import { isWindows } from 'monaco-editor/esm/vs/base/common/platform.js'
+import type { OpenFile } from '@/store/slices/editor'
+import { disposeClosedEditorTabs } from './closed-editor-tab-disposal'
+import { toMonacoEditModelPath } from './monaco-edit-model-path'
+import { createMonacoModelRegistryWithRealUri } from './monaco-model-registry-test-fixture'
+
+const WSL_COLON_PATH =
+  '\\\\wsl.localhost\\Ubuntu-26.04\\home\\mj\\projects\\acp-client\\notes:2026.md'
+
+describe('toMonacoEditModelPath on Windows', () => {
+  it('pins the UNC-aware fallback form monaco builds when the renderer is Windows', () => {
+    expect(isWindows).toBe(true)
+    expect(toMonacoEditModelPath(Uri, WSL_COLON_PATH)).toBe(
+      'file://wsl.localhost/Ubuntu-26.04/home/mj/projects/acp-client/notes%3A2026.md'
+    )
+  })
+
+  it('keeps the Windows form a stable dispose key', () => {
+    const modelPath = toMonacoEditModelPath(Uri, WSL_COLON_PATH)
+    const registry = createMonacoModelRegistryWithRealUri([modelPath])
+
+    disposeClosedEditorTabs(registry, [
+      { id: 'poisoned', mode: 'edit', filePath: WSL_COLON_PATH } as OpenFile
+    ])
+
+    expect(registry.disposed).toEqual([modelPath])
+  })
+})

--- a/src/renderer/src/components/editor/monaco-model-registry-test-fixture.ts
+++ b/src/renderer/src/components/editor/monaco-model-registry-test-fixture.ts
@@ -1,0 +1,44 @@
+import { Uri } from 'monaco-editor'
+import type { ClosedEditorTabMonacoRegistry } from './closed-editor-tab-disposal'
+
+export type RecordingMonacoModelRegistry = ClosedEditorTabMonacoRegistry & {
+  disposed: string[]
+}
+
+/**
+ * A model registry backed by the real Monaco URI parser.
+ *
+ * Why real: the whole point of these tests is which paths `Uri.parse` accepts, so a fake parser
+ * that echoes its input would assert nothing.
+ */
+export function createMonacoModelRegistryWithRealUri(
+  modelPaths: readonly string[]
+): RecordingMonacoModelRegistry {
+  const disposed: string[] = []
+  const modelsByUri = new Map<
+    string,
+    {
+      dispose: () => void
+      isAttachedToEditor: () => boolean
+      uri: { toString: (skipEncoding?: boolean) => string }
+    }
+  >()
+
+  for (const modelPath of modelPaths) {
+    const key = Uri.parse(modelPath).toString()
+    modelsByUri.set(key, {
+      dispose: () => disposed.push(modelPath),
+      isAttachedToEditor: () => false,
+      uri: { toString: () => key }
+    })
+  }
+
+  return {
+    disposed,
+    Uri,
+    editor: {
+      getModel: (uri: unknown) => modelsByUri.get(String(uri)) ?? null,
+      getModels: () => [...modelsByUri.values()]
+    }
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​258 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​253 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​140 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​134 |

<!-- /orca-pr-loc -->

## What

A single unparseable file path could take down the entire terminal workbench.

`disposeClosedEditorTab` called `monaco.Uri.parse(closedFile.filePath)` on a raw `filePath` with no guard. Monaco reads everything before the first `:` as a URI scheme, so a drive-less backslash path carrying a `:` throws `[UriError]: Scheme contains illegal characters.` The call sits inside a React **passive effect**, so the throw escaped past `EditorPanelInner` and killed the whole `terminal.workbench` error boundary — every pane and every terminal's UI in that workbench, not just the editor tab.

**Field crashes addressed**

| | |
|---|---|
| Cluster | `R4-uri-error` |
| Field reports | **1** (report `d7374d36-31ba-4428-bda6-5084f2a1edfa`, bundle `6H4mJ0icTeAYtLJaUmN44A`) |
| Orca versions | **1.4.194** (stable) |
| OS | **Windows only** — `win32 10.0.26200 x64`, Electron 43.4.1 / Chrome 150. Not observed on macOS or Linux. |
| Boundary taken down | `terminal.workbench` (surface `terminal-workbench`) |

Field stack:

```
- boundary_id: terminal.workbench
- surface: terminal-workbench
- error_message: [UriError]: Scheme contains illegal characters.
- error_stack: Error: [UriError]: Scheme contains illegal characters.
    at _validateUri (file:///C:[redacted-path])
    at new URI (file:///C:[redacted-path])
    at new Uri$1 (file:///C:[redacted-path])
    at URI.parse (file:///C:[redacted-path])
    at disposeClosedEditorTab (file:///C:[redacted-path])
    at commitHookEffectListMount (file:///C:[redacted-path])
    at commitPassiveMountOnFiber (file:///C:[redacted-path])
- component_stack: at EditorPanelInner (file:///C:[redacted-path])
```

The reporter's environment is consistent with the mechanism: their diagnostic spans show every git call running against `\\wsl.localhost\Ubuntu-26.04\home\mj\projects\...` — a WSL repo browsed over a UNC root.

**Root cause, at file:line**

- `src/renderer/src/components/editor/closed-editor-tab-disposal.ts:33` (was an unguarded `monacoRegistry.editor.getModel(monacoRegistry.Uri.parse(closedFile.filePath))?.dispose()` in the `'edit'` case) — the line the field stack hit.

**The fix, in three parts**

1. **Disposal guard** — `closed-editor-tab-disposal.ts:27-40`. The `'edit'` case now goes through `disposeEditTabModel()`, which resolves the model URI in a `try`/`catch` and returns on throw. One poisoned tab no longer aborts the batch: the cache sweeps at `:105-109` and every later tab in the same close-all now run regardless.

2. **The open-time twin** (found by inspection, not reported). `@monaco-editor/react` resolves its `path` prop with `e.Uri.parse(r)` (helper `te` in `node_modules/@monaco-editor/react/dist/index.mjs`) inside its **mount** effect — so the same input class crashes the workbench on *open*, not only on close. `MonacoEditor.tsx:115` now derives `monacoModelPath` and passes it at `:265`.

3. **Shared canonicaliser** — `monaco-edit-model-path.ts:55`, `toMonacoEditModelPath(uri, filePath)`. Returns `filePath` **byte-identically** when `Uri.parse` accepts it (so no model key or view-state cache entry that works today moves), else `Uri.file(filePath).toString()`. Both the `path` prop and the disposal lookup go through it, so create and dispose stay on one key and the poisoned tab's model is genuinely reclaimed rather than merely skipped.

Plus a **shape-only breadcrumb** (`monaco-edit-model-path.ts:34-44`) on both the rewrite and the catch, recording length / colon count / has-backslash / scheme-prefix charset — never the path. Added because the crash was the only signal that ever surfaced this input class, and its producer is still unidentified; see Trade-offs.

## Fix evidence

### RED — production hunks reverted, tests kept

```console
$ git checkout origin/main -- src/renderer/src/components/editor/closed-editor-tab-disposal.ts \
                              src/renderer/src/components/editor/MonacoEditor.tsx
$ ./node_modules/.bin/vitest run --config config/vitest.config.ts \
    src/renderer/src/components/editor/monaco-edit-model-path.test.ts \
    src/renderer/src/components/editor/monaco-edit-model-path.windows.test.ts \
    src/renderer/src/components/editor/MonacoEditor.model-path.test.tsx \
    src/renderer/src/components/editor/closed-editor-tab-disposal.test.ts

 ❯ src/renderer/src/components/editor/monaco-edit-model-path.test.ts (7 tests | 3 failed) 34ms
     × does not throw the workbench down on the unparseable path class 2ms
     × keeps disposing the rest of the close-all batch behind a poisoned tab 3ms
     × crumbs instead of throwing when even the fallback URI form is unbuildable 1ms
 ❯ src/renderer/src/components/editor/monaco-edit-model-path.windows.test.ts (2 tests | 1 failed) 6ms
     × keeps the Windows form a stable dispose key 3ms
 ❯ src/renderer/src/components/editor/MonacoEditor.model-path.test.tsx (3 tests | 2 failed) 38ms
     × hands Monaco a parseable path for a WSL/UNC file name carrying a colon 7ms
     × keys the model on a path close-all can still dispose 4ms

 Test Files  3 failed | 1 passed (4)
      Tests  6 failed | 12 passed (18)
```

The regression test reproduces **the field frame chain exactly** — `_validateUri` / `new URI` / `new Uri` / `URI.parse` / `disposeClosedEditorTabs`, against the real bundled `monaco-editor@0.55.1`:

```console
 FAIL  src/renderer/src/components/editor/monaco-edit-model-path.test.ts > keeps disposing the rest of the close-all batch behind a poisoned tab
Error: [UriError]: Scheme contains illegal characters.
 ❯ _validateUri node_modules/.pnpm/monaco-editor@0.55.1/node_modules/monaco-editor/esm/vs/base/common/uri.js:19:15
     17|     // ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
     18|     if (ret.scheme && !_schemePattern.test(ret.scheme)) {
     19|         throw new Error('[UriError]: Scheme contains illegal character…
       |               ^
 ❯ new URI  .../uri.js:125:13
 ❯ new Uri  .../uri.js:330:9
 ❯ URI.parse  .../uri.js:216:16
 ❯ Module.disposeClosedEditorTabs src/renderer/src/components/editor/closed-editor-tab-disposal.ts:44:59
 ❯ src/renderer/src/components/editor/monaco-edit-model-path.test.ts:90:5
```

And the open-time twin (Part 2) is red on its own — this is a real second crash path, not hygiene:

```console
 FAIL  src/renderer/src/components/editor/MonacoEditor.model-path.test.tsx > hands Monaco a parseable path for a WSL/UNC file name carrying a colon
AssertionError: expected [Function] to not throw an error but 'Error: [UriError]: Scheme contains il…' was thrown

- Expected:
undefined

+ Received:
"Error: [UriError]: Scheme contains illegal characters."

 ❯ src/renderer/src/components/editor/MonacoEditor.model-path.test.tsx:75:52
     74|   it('hands Monaco a parseable path for a WSL/UNC file name carrying a…
     75|     expect(() => renderEditor(WSL_COLON_PATH)).not.toThrow()
       |                                                    ^
```

### GREEN — production hunks restored

```console
$ git checkout HEAD -- src/renderer/src/components/editor/closed-editor-tab-disposal.ts \
                       src/renderer/src/components/editor/MonacoEditor.tsx
$ git status --short
$ ./node_modules/.bin/vitest run --config config/vitest.config.ts \
    src/renderer/src/components/editor/monaco-edit-model-path.test.ts \
    src/renderer/src/components/editor/monaco-edit-model-path.windows.test.ts \
    src/renderer/src/components/editor/MonacoEditor.model-path.test.tsx \
    src/renderer/src/components/editor/closed-editor-tab-disposal.test.ts

 Test Files  4 passed (4)
      Tests  18 passed (18)
```

### No regression across the editor surface

```console
$ ./node_modules/.bin/vitest run --config config/vitest.config.ts src/renderer/src/components/editor

 Test Files  199 passed (199)
      Tests  1331 passed (1331)
```

```console
$ ./node_modules/.bin/tsc --noEmit -p config/tsconfig.tc.web.json ; echo "TSC_WEB_EXIT=$?"
TSC_WEB_EXIT=0
$ ./node_modules/.bin/tsc --noEmit -p config/tsconfig.node.json ; echo "TSC_NODE_EXIT=$?"
TSC_NODE_EXIT=0
$ ./node_modules/.bin/oxlint <8 changed files> ; echo "OXLINT_EXIT=$?"
OXLINT_EXIT=0
```

### Live reproduction on a real Windows host

Run on a real `win32 10.0.26200` machine with WSL2 Ubuntu-24.04 (not emulated), to establish which tooling can actually emit the crashing byte:

```console
$ wsl.exe -d Ubuntu-24.04 --exec bash -c "... printf hello > /home/neil/uritest/notes:2026.md ... ls -la"
-rw-r--r--  1 neil neil    5 Sep  2 21:17 notes:2026.md
-rw-r--r--  1 neil neil    5 Sep  2 21:17 plain.md

$ node probe2.js      # fs.readdirSync('\\\\wsl.localhost\\Ubuntu-24.04\\home\\neil\\uritest')
NAME_CODEPOINTS 70 6c 61 69 6e 2e 6d 64
HAS_ASCII_COLON false
NAME_CODEPOINTS 6e 6f 74 65 73 f03a 32 30 32 36 2e 6d 64
HAS_ASCII_COLON false

$ node probe3.js      # git.exe with cwd = the UNC path, vs git inside WSL
WIN_GIT_STATUS 3f 3f 20 22 6e 6f 74 65 73 5c 33 35 37 5c 32 30 30 5c 32 37 32 32 30 32 36 2e 6d 64 22
                      # ?? "notes\357\200\2722026.md"   (EF 80 BA = U+F03A)
WSL_GIT_STATUS 3f 3f 20 6e 6f 74 65 73 3a 32 30 32 36 2e 6d 64
                      # ?? notes:2026.md               (3a = ASCII colon)

$ node probe4.js      # Win32 readability of both renderings
ASCII_COLON READ_OK "hello"
PUA_F03A    READ_OK "hello"
```

Two things this establishes, and one it **refutes**:

- **Refuted:** the obvious hypothesis — "a Linux-legal filename containing `:`, listed from Windows" — does **not** by itself produce the crashing string. Win32 enumeration maps the colon to U+F03A (private use), which `Uri.parse` accepts without throwing.
- **Established:** WSL-side tooling (`wsl.exe --exec git status`) preserves a literal ASCII `0x3a`. A WSL/Linux-produced name joined onto a `\\wsl.localhost\...` Windows root is therefore a mechanism that yields the crashing shape.
- **Established:** such a file is genuinely readable from Win32 (`READ_OK`), so the tab really does mount Monaco — which is why Part 2 is a live crash path and why the fix opens the file rather than refusing it.

### Explicitly NOT proven

- **The exact field `filePath` was never recovered.** The reporter's bundle carries no file paths (it was mined for `cwd` only). The Windows probe narrows the *producing mechanism*; it does not recover the string, and it does not prove Orca ever actually joins a WSL-produced name onto a UNC root to build an editor `filePath`. Another live candidate producer is an Orca-side path-construction defect leaking a `:line` suffix into `OpenFile.filePath` (e.g. `...\src\index.ts:12`), which throws in exactly the same way. This is why the breadcrumb is in the fix — see Follow-ups #1.
- The `Uri.file()` fallback's exact string is platform-dependent and no test pins the Windows form, so CI never exercises the literal string a Windows user gets. Both sides agree within a session, so this is invisible; it is stated for completeness.
- The Windows-host probe cleanup (probe files, `safe.directory` entry, `/home/neil/uritest`) was performed but is not verifiable from this worktree.

## ELI5

Orca hands every file you open to its built-in code editor, and the editor identifies that file by its name and location. It is picky about what that text may look like. If it spots a colon early on, it assumes the part before the colon is an address prefix — like the "http:" at the front of a web link — and if that prefix isn't one it recognises, it refuses the file and reports an error.

On Windows, if your project actually lives inside Linux (WSL), a file can come back with a colon in its name, which a normal Windows filename can't have. That is exactly the shape the editor refuses.

The error surfaced at a moment when nothing was set up to catch it, so it wasn't just the one tab that broke — the whole work area went down with it. Every split pane, and the display of every terminal in that window, went blank at the same time. Closing that tab, or closing all your tabs, was enough to set it off.

The fix tidies the name into a form the editor accepts before handing it over, so the file simply opens and nothing goes blank. It also puts a safety net around the closing step, so if some future name still can't be handled, only that one tab gets skipped instead of the whole window going down. And because these odd names are rare and we still don't know where they come from, Orca now quietly notes the *shape* of the name — how long it was, how many colons it had, whether it used backslashes, never the name itself — so we can track the source down without anyone having to hit a crash first.

## Trade-offs

**1. An error that used to be loud is now silent — this is the main cost.** Before this change, a poisoned path produced a crash report that landed in the field-crash pipeline. After it, the file quietly opens fine. Since the producer of the bad path is still unidentified, that could have erased the only signal we had. **Mitigated, not ignored:** both the rewrite branch and the disposal catch call `recordRendererCrashBreadcrumb` with a shape-only payload (length, colon count, has-backslash, scheme-prefix charset — never the path, which the crash pipeline redacts anyway). These land in the "Recent activity" block of the same report format this cluster came from, and in a durable trace span. The class stays observable; it just no longer costs the user their workbench. Affects: whoever investigates the producer next — they get a crumb instead of a stack trace.

**2. Monaco model keys change — but only for paths that crash today.** `toMonacoEditModelPath` returns the input byte-identically whenever `Uri.parse` accepts it, so every path that works today keeps an identical model key. Only the previously-crashing class gets a different key (`Uri.file(...).toString()`). Verified no other renderer site looks an *edit* model up by path, and `scrollTopCache` / `editorSelectionCache` / `pdfViewPositionCache` are keyed by `filePath` and untouched. No user-visible behaviour change for any working file.

**3. The fallback string is platform-dependent.** Monaco's `Uri.file()` converts backslashes only when `isWindows`, so the fallback key differs between macOS and Windows. Model keys are per-session and never persisted, and open and dispose go through the same monaco instance, so both sides always agree. Invisible to users.

**4. One breadcrumb IPC call now happens during render, not in an effect** (`MonacoEditor.tsx:115`, inside `useMemo`). Under React StrictMode in dev it fires twice, and the name isn't in `COALESCED_RENDERER_BREADCRUMB_NAMES`, so each occurrence also writes a trace span. Volume is bounded by the rarity of the input class and by the `[filePath]` memo — noise-level, no measurable latency.

**5. `MonacoEditor.tsx` now takes a value import of `monaco-editor`.** It already side-effect-imports `@/lib/monaco-setup`, which calls `loader.config({ monaco })` on the same bundled instance, so this adds no new module to the lazy editor chunk and no second monaco instance. No bundle-size or startup cost.

**No SSH, folder-workspace, remote-wire, or git-provider surface is touched** — this is renderer-local Monaco model bookkeeping: no IPC contract change, no RPC params, no stream opcodes, no persisted state.

## Adversarial review

**2 round(s) until clean.**

**Round 1 — one blocking finding, fixed.** The reviewer independently reproduced RED and GREEN, verified the mechanism from library source rather than from the test's mock (`@monaco-editor/react` really does `te(e,r){return e.Uri.parse(r)}` from inside a `useEffect`; Monaco keys its registry by `MODEL_ID(resource) = resource.toString()`, so the create/dispose key identity claim holds), confirmed via `git show` that the 1.4.194-era `disposeClosedEditorTab` had exactly one `Uri.parse` on `prevFile.filePath`, and fuzzed 24 hostile inputs against the real monaco URI under both `isWindows=false` and `isWindows=true` without finding a throw hole. It could not break the fix.

The block was on *observability*, not correctness: the guard silently rewrites and silently swallows the only observable instance of an input class whose producer the author admitted was still unknown — the same shape as fixes rejected in earlier work ("a defensible guard that also erases the evidence for the bug underneath it"). **Resolved by adding the shape-only breadcrumb** via the repo's existing `recordRendererCrashBreadcrumb`. Two smaller findings also fixed: a justification comment that Part 2 had made false (the old text argued "a path that throws here never produced a model to leak", which stopped being true once Part 2 made those paths produce a model), and the write-up's overclaim that the WSL mechanism "is the producer" — **downgraded to the inference it is**, and the "NOT proven" list above is the result.

**Round 2 — clean, non-blocking notes only.** The reviewer again reproduced RED (6 failures, field frame chain) and GREEN (18/18), confirmed the `MonacoEditor` render test also goes red without the fix ("neither part is test theatre"), and verified independently that `toMonacoEditModelPath` returns input byte-identically when accepted, so no working key moves.

Two reviewer observations were **rebutted rather than fixed**:

- *"The catch in `closed-editor-tab-disposal.ts:34-37` is unreachable in production"* — **correct, and kept deliberately.** Monaco's `Uri.file` can only build scheme `file` and always yields a valid path, so it can't throw today. It's retained as a last-resort guard specifically so no future `Uri.parse` behaviour change can re-arm a workbench-killing throw from a passive effect. The cost is a few dead lines; the alternative is re-exposing the exact failure mode this PR exists to close.
- *"`src/shared/file-uri-path.ts` already builds a UNC-aware file URI and is platform-independent; prefer it over monaco's `Uri.file`"* — **not adopted.** The requirement here isn't a correct file URI, it's a string *this monaco instance* will re-parse to the same key on both create and dispose. Using monaco's own `Uri.file` guarantees that by construction; a second implementation would have to stay bug-compatible with monaco's parser forever. The reviewer agreed both work and called it "a preference, not a bug".

A third note — *"the tradeoffs claim `getModel(` appears only in `closed-editor-tab-disposal.ts`, but `useDiffViewerLargeDiffLifecycle.ts:64-68` also calls it"* — was accepted as a **narrative imprecision only**; those are encoded `diff:` model paths, so the intended conclusion (no *edit* model lookup drifts) still holds.

## Follow-ups

1. **Find and fix the string producer, not just the consumers.** This PR makes the symptom survivable; it does not identify where the bad `filePath` is built. The Windows probe shows Orca can hold *two different* `filePath` strings for one WSL file — an ASCII-colon form from WSL-side tooling (`wsl.exe --exec git status`, agent output, terminal file links, WSL-side ripgrep) and a U+F03A form from Win32 enumeration. That will silently duplicate editor tabs, scroll-cache entries and external-change tracking even now that it no longer crashes. Separately, an Orca-side defect leaking a `:line` suffix into `OpenFile.filePath` is an untested candidate for the same shape. Wants a dedicated ticket to normalise WSL-produced relative paths against the Win32 rendering at the boundary. The new `editor_model_path_uri_rejected` crumb is the intended input to that investigation.

2. **Make the whole `useClosedEditorTabCleanup` passive effect non-throwing.** Today any *future* throw anywhere inside `disposeClosedEditorTabs` still takes down `terminal.workbench` — all panes, all terminals' UI — rather than one editor pane. Out of scope here because this change was deliberately kept minimal and targeted, but the blast radius of that effect is disproportionate to its job.

3. **Audit renderer tests that stub a parser or validator into a no-op.** The pre-existing `closed-editor-tab-disposal.test.ts` stubs `Uri.parse` as identity, which is exactly why this shipped — the test suite could never have caught it. That stub is legitimate for the batching/perf assertions it was written for and was left in place, with real-`monaco-editor` coverage added alongside. A broader sweep would likely find more tests that have neutralised the very check they appear to exercise.

4. **Record the offending `filePath` on renderer error-boundary hits.** A `pathFailureReason`-style crumb (hashed or truncated) attached to boundary crashes would have settled this whole question from the original report, instead of requiring a live Windows host session.

5. **Pin the Windows form of the fallback in CI.** No test asserts the literal `Uri.file()` output a Windows renderer produces, so CI never exercises the string real users get. Cheap to add with a forced `isWindows` fixture.

