### PR TITLE
fix(agents): detect agent CLIs installed outside a version manager

### DIFF
--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -137,6 +137,29 @@ describe('patchPackagedProcessPath', () => {
     expect(segments).toContain('/usr/local/bin')
   })
 
+  // Why derived, not a second literal: system-cli-install-dirs.ts documents its
+  // order as matching this seed's system block, and hardcoding the order in the
+  // fallback's own test lets a reorder here break that parity while both stay green.
+  it('seeds the system block in the order the install-dir fallback expects', async () => {
+    const { app } = await import('electron')
+    const { patchPackagedProcessPath } = await import('./configure-process')
+    const { getSystemCliInstallDirectories } = await import('../../shared/system-cli-install-dirs')
+
+    setPlatform('linux')
+    Object.defineProperty(app, 'isPackaged', { configurable: true, value: true })
+    process.env.HOME = '/home/tester'
+    process.env.PATH = '/usr/bin:/bin'
+
+    patchPackagedProcessPath()
+
+    const segments = (process.env.PATH ?? '').split(':')
+    const offsets = getSystemCliInstallDirectories('linux', '/home/tester').map((directory) =>
+      segments.indexOf(directory)
+    )
+    expect(offsets.every((offset) => offset >= 0)).toBe(true)
+    expect([...offsets].sort((a, b) => a - b)).toEqual(offsets)
+  })
+
   // Why this ordering is load-bearing (#18234): a seed exists so a GUI-launched
   // Electron can *find* a tool, not to re-rank tools the user already has.
   // `~/.local/bin` is user-writable and can hold a wrapper for any system tool.

--- a/src/shared/agent-cli-install-dir-fallback.test.ts
+++ b/src/shared/agent-cli-install-dir-fallback.test.ts
@@ -1,5 +1,5 @@
 import { delimiter, join } from 'node:path'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { detectCommandsInInstallDirs } from './local-agent-install-dir-detection'
 import { getVersionManagerBinPaths, resolveCliCommands } from './node-cli-command-resolution'
 import { buildPosixFallbackPathPrelude } from './posix-version-manager-bin-dirs'
@@ -63,6 +63,13 @@ function resolveAll(
 
 beforeEach(() => {
   fsFixture.executables.clear()
+  // Why: the no-options entry point reads the ambient PATH, where a dev box's
+  // real /usr/local/bin would answer before the fallback ever runs.
+  vi.stubEnv('PATH', GUI_LAUNCH_PATH)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
 })
 
 describe('agent CLI install-dir fallback', () => {
@@ -118,6 +125,28 @@ describe('agent CLI install-dir fallback', () => {
     })
   })
 
+  // Why pinned: patchPackagedProcessPath seeds these onto PATH in this order and
+  // the POSIX guest prelude appends them in it, so a divergence here would spawn
+  // a different binary than the packaged PATH scan for the same install.
+  it('ranks system install dirs in the same order as the PATH seed', () => {
+    const home = '/home/tester'
+    const dirs = [
+      '/usr/local/bin',
+      '/snap/bin',
+      '/home/linuxbrew/.linuxbrew/bin',
+      '/nix/var/nix/profiles/default/bin',
+      join(home, '.nix-profile', 'bin'),
+      join(home, '.opencode', 'bin')
+    ]
+    stage(...dirs.map((dir) => join(dir, 'opencode')))
+    for (const expected of dirs) {
+      expect(resolveAll(['opencode'], { platform: 'linux', homePath: home })).toEqual({
+        opencode: join(expected, 'opencode')
+      })
+      fsFixture.executables.delete(join(expected, 'opencode'))
+    }
+  })
+
   it('still lets a version-manager install outrank a system one', () => {
     const home = '/Users/tester'
     stage(
@@ -145,6 +174,7 @@ describe('agent CLI install-dir fallback', () => {
     'reports a system-installed CLI as detected, not just resolved',
     () => {
       stage(join('/usr/local/bin', 'codex'), join(MOCK_HOME, '.opencode', 'bin', 'opencode'))
+      // Both come from the fallback: the stubbed PATH holds no system dir.
       expect(detectCommandsInInstallDirs(['codex', 'opencode', 'cursor-agent'])).toEqual(
         new Set(['codex', 'opencode'])
       )
@@ -153,15 +183,19 @@ describe('agent CLI install-dir fallback', () => {
 
   it('carries the system install dirs into the POSIX guest fallback prelude', () => {
     const prelude = buildPosixFallbackPathPrelude()
-    for (const dir of [
-      '"$HOME/.opencode/bin"',
-      '"$HOME/.nix-profile/bin"',
-      '"/home/linuxbrew/.linuxbrew/bin"',
+    const systemDirs = [
+      '"/usr/local/bin"',
       '"/snap/bin"',
-      '"/nix/var/nix/profiles/default/bin"'
-    ]) {
-      expect(prelude).toContain(dir)
-    }
+      '"/home/linuxbrew/.linuxbrew/bin"',
+      '"/nix/var/nix/profiles/default/bin"',
+      '"$HOME/.nix-profile/bin"',
+      '"$HOME/.opencode/bin"'
+    ]
+    const offsets = systemDirs.map((dir) => prelude.indexOf(dir))
+    expect(offsets.every((offset) => offset >= 0)).toBe(true)
+    expect([...offsets].sort((a, b) => a - b)).toEqual(offsets)
+    // Why after: the guest prelude appends, so a version manager must still win.
+    expect(prelude.indexOf('.nvm/versions/node/*/bin')).toBeLessThan(offsets[0])
     // Why absent: a WSL guest is Linux, so /opt/homebrew is never its brew prefix.
     expect(prelude).not.toContain('/opt/homebrew')
   })

--- a/src/shared/agent-cli-install-dir-fallback.test.ts
+++ b/src/shared/agent-cli-install-dir-fallback.test.ts
@@ -1,8 +1,13 @@
 import { delimiter, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { detectCommandsInInstallDirs } from './local-agent-install-dir-detection'
-import { getVersionManagerBinPaths, resolveCliCommands } from './node-cli-command-resolution'
+import {
+  getVersionManagerBinPaths,
+  resolveCliCommand,
+  resolveCliCommands
+} from './node-cli-command-resolution'
 import { buildPosixFallbackPathPrelude } from './posix-version-manager-bin-dirs'
+import { getSystemCliInstallDirectories } from './system-cli-install-dirs'
 
 /**
  * The install-dir fallback answers "is this agent CLI installed?" whenever the
@@ -148,15 +153,40 @@ describe('agent CLI install-dir fallback', () => {
     }
   })
 
-  it('still lets a version-manager install outrank a system one', () => {
-    const home = '/Users/tester'
-    stage(
-      join(home, '.volta', 'bin', 'codex'),
-      join('/opt/homebrew/bin', 'codex'),
-      join('/usr/local/bin', 'codex')
-    )
-    expect(resolveAll(['codex'], { platform: 'darwin', homePath: home })).toEqual({
-      codex: join(home, '.volta', 'bin', 'codex')
+  // Why both resolvers and both platforms: resolveCliCommand is what every
+  // spawn site (codex login, app-server, session-index heal) calls, and its
+  // list was once spelled separately from resolveCliCommands'. A same-named
+  // binary in /usr/local/bin must never shadow the one a version manager owns.
+  describe.each([
+    { platform: 'darwin' as const, home: '/Users/tester', systemDir: '/opt/homebrew/bin' },
+    {
+      platform: 'linux' as const,
+      home: '/home/tester',
+      systemDir: '/home/linuxbrew/.linuxbrew/bin'
+    }
+  ])('$platform: system dirs stay last', ({ platform, home, systemDir }) => {
+    it('lets a version-manager install outrank a system one', () => {
+      const managed = join(home, '.volta', 'bin', 'codex')
+      stage(managed, join(systemDir, 'codex'), join('/usr/local/bin', 'codex'))
+      expect(resolveCliCommand('codex', { platform, homePath: home })).toBe(managed)
+      expect(resolveAll(['codex'], { platform, homePath: home })).toEqual({ codex: managed })
+    })
+
+    it('lets an npm --user (~/.local/bin) install outrank a system one', () => {
+      const managed = join(home, '.local', 'bin', 'codex')
+      stage(managed, join(systemDir, 'codex'))
+      expect(resolveCliCommand('codex', { platform, homePath: home })).toBe(managed)
+      expect(resolveAll(['codex'], { platform, homePath: home })).toEqual({ codex: managed })
+    })
+
+    it('lets a copy already on PATH outrank every install dir', () => {
+      const onPath = join('/custom/bin', 'codex')
+      const pathEnv = [GUI_LAUNCH_PATH, '/custom/bin'].join(delimiter)
+      stage(onPath, join(home, '.volta', 'bin', 'codex'), join(systemDir, 'codex'))
+      expect(resolveCliCommand('codex', { platform, homePath: home, pathEnv })).toBe(onPath)
+      expect(resolveCliCommands(['codex'], { platform, homePath: home, pathEnv })).toEqual(
+        new Map([['codex', onPath]])
+      )
     })
   })
 
@@ -223,5 +253,24 @@ describe('agent CLI install-dir fallback', () => {
     expect(prelude.indexOf('.nvm/versions/node/*/bin')).toBeLessThan(offsets[0])
     // Why absent: a WSL guest is Linux, so /opt/homebrew is never its brew prefix.
     expect(prelude).not.toContain('/opt/homebrew')
+  })
+
+  // Why derived: the native and guest lists drifted apart once by hand. Every
+  // version-manager dir the native resolver knows must precede the guest's
+  // first system dir, and the guest's system block must be the native one.
+  it('keeps the WSL guest prelude in step with the native Linux lists', () => {
+    const prelude = buildPosixFallbackPathPrelude()
+    const asGuest = (dir: string): string => `"${dir.split('\\').join('/')}"`
+    const systemDirs = getSystemCliInstallDirectories('linux', '$HOME').map(asGuest)
+    const firstSystemOffset = prelude.indexOf(systemDirs[0])
+    expect(firstSystemOffset).toBeGreaterThan(0)
+    for (const dir of getVersionManagerBinPaths({ platform: 'linux', homePath: '$HOME' })) {
+      const offset = prelude.indexOf(asGuest(dir))
+      expect(offset, dir).toBeGreaterThanOrEqual(0)
+      expect(offset, dir).toBeLessThan(firstSystemOffset)
+    }
+    const systemOffsets = systemDirs.map((dir) => prelude.indexOf(dir))
+    expect(systemOffsets.every((offset) => offset >= firstSystemOffset)).toBe(true)
+    expect([...systemOffsets].sort((a, b) => a - b)).toEqual(systemOffsets)
   })
 })

--- a/src/shared/agent-cli-install-dir-fallback.test.ts
+++ b/src/shared/agent-cli-install-dir-fallback.test.ts
@@ -1,0 +1,168 @@
+import { delimiter, join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { detectCommandsInInstallDirs } from './local-agent-install-dir-detection'
+import { getVersionManagerBinPaths, resolveCliCommands } from './node-cli-command-resolution'
+import { buildPosixFallbackPathPrelude } from './posix-version-manager-bin-dirs'
+
+/**
+ * The install-dir fallback answers "is this agent CLI installed?" whenever the
+ * login-shell PATH probe does not land. Homebrew, npm's default global prefix
+ * and opencode's own installer are absolute paths, so they cannot be staged
+ * under a temp home -- hence a synthetic fs rather than a fixture tree.
+ *
+ * Every staged path goes through `join`, because the lookup builds candidates
+ * with the host's `join`: a literal `/opt/homebrew/bin/codex` would never match
+ * on a Windows dev machine.
+ */
+const fsFixture = vi.hoisted(() => ({ executables: new Set<string>() }))
+
+const MOCK_HOME = '/home/tester'
+
+vi.mock('node:os', () => ({ homedir: () => MOCK_HOME }))
+
+vi.mock('node:fs', () => ({
+  constants: { X_OK: 1 },
+  statSync: (target: string) => {
+    if (!fsFixture.executables.has(target)) {
+      throw new Error(`ENOENT: ${target}`)
+    }
+    return { isFile: () => true }
+  },
+  accessSync: (target: string) => {
+    if (!fsFixture.executables.has(target)) {
+      throw new Error(`EACCES: ${target}`)
+    }
+  },
+  // No nvm install in any of these cases; the nvm walk is covered by nvm-default-alias.test.ts.
+  existsSync: () => false,
+  readdirSync: () => {
+    throw new Error('ENOENT')
+  },
+  readFileSync: () => {
+    throw new Error('ENOENT')
+  }
+}))
+
+// The PATH a Finder/Dock-launched macOS app inherits with no login shell.
+const GUI_LAUNCH_PATH = ['/usr/bin', '/bin', '/usr/sbin', '/sbin'].join(delimiter)
+
+function stage(...paths: string[]): void {
+  for (const path of paths) {
+    fsFixture.executables.add(path)
+  }
+}
+
+function resolveAll(
+  commands: string[],
+  options: { platform: NodeJS.Platform; homePath: string }
+): Record<string, string> {
+  return Object.fromEntries(
+    resolveCliCommands(commands, { ...options, pathEnv: GUI_LAUNCH_PATH })
+  ) as Record<string, string>
+}
+
+beforeEach(() => {
+  fsFixture.executables.clear()
+})
+
+describe('agent CLI install-dir fallback', () => {
+  it('finds macOS CLIs installed outside a version manager', () => {
+    const home = '/Users/tester'
+    stage(
+      join(home, '.local', 'bin', 'claude'),
+      join('/opt/homebrew/bin', 'codex'),
+      join('/usr/local/bin', 'cursor-agent'),
+      join(home, '.opencode', 'bin', 'opencode')
+    )
+    expect(
+      resolveAll(['claude', 'codex', 'cursor-agent', 'opencode'], {
+        platform: 'darwin',
+        homePath: home
+      })
+    ).toEqual({
+      claude: join(home, '.local', 'bin', 'claude'),
+      codex: join('/opt/homebrew/bin', 'codex'),
+      'cursor-agent': join('/usr/local/bin', 'cursor-agent'),
+      opencode: join(home, '.opencode', 'bin', 'opencode')
+    })
+  })
+
+  it('finds Linux CLIs in Linuxbrew, snap and nix prefixes, not the macOS brew prefix', () => {
+    const home = '/home/tester'
+    stage(
+      join('/home/linuxbrew/.linuxbrew/bin', 'codex'),
+      join('/snap/bin', 'cursor-agent'),
+      join(home, '.nix-profile', 'bin', 'opencode'),
+      join('/opt/homebrew/bin', 'claude')
+    )
+    expect(
+      resolveAll(['codex', 'cursor-agent', 'opencode', 'claude'], {
+        platform: 'linux',
+        homePath: home
+      })
+    ).toEqual({
+      codex: join('/home/linuxbrew/.linuxbrew/bin', 'codex'),
+      'cursor-agent': join('/snap/bin', 'cursor-agent'),
+      opencode: join(home, '.nix-profile', 'bin', 'opencode'),
+      // Why unresolved: /opt/homebrew is an Apple Silicon prefix; Linuxbrew uses another.
+      claude: 'claude'
+    })
+  })
+
+  it('leaves the win32 branch on its own install dirs', () => {
+    const home = 'C:/Users/tester'
+    stage(join(home, 'AppData', 'Roaming', 'npm', 'codex.cmd'), join('/usr/local/bin', 'claude'))
+    expect(resolveAll(['codex', 'claude'], { platform: 'win32', homePath: home })).toEqual({
+      codex: join(home, 'AppData', 'Roaming', 'npm', 'codex.cmd'),
+      claude: 'claude'
+    })
+  })
+
+  it('still lets a version-manager install outrank a system one', () => {
+    const home = '/Users/tester'
+    stage(
+      join(home, '.volta', 'bin', 'codex'),
+      join('/opt/homebrew/bin', 'codex'),
+      join('/usr/local/bin', 'codex')
+    )
+    expect(resolveAll(['codex'], { platform: 'darwin', homePath: home })).toEqual({
+      codex: join(home, '.volta', 'bin', 'codex')
+    })
+  })
+
+  // Why this guard: getVersionManagerBinPaths is PREPENDED onto PATH by
+  // patchPackagedProcessPath and the CLI's addAgentNodePaths, so a system dir
+  // leaking into it would re-rank binaries the user already has (#18234).
+  it('keeps system install dirs out of the PATH seed list', () => {
+    const seeded = getVersionManagerBinPaths({ platform: 'darwin', homePath: '/Users/tester' })
+    expect(seeded).not.toContain('/opt/homebrew/bin')
+    expect(seeded).not.toContain('/usr/local/bin')
+  })
+
+  // Why through this entry point: it is what the `orca` CLI's agent detection
+  // calls, and the "absolute path means installed" contract lives here.
+  it.skipIf(process.platform === 'win32')(
+    'reports a system-installed CLI as detected, not just resolved',
+    () => {
+      stage(join('/usr/local/bin', 'codex'), join(MOCK_HOME, '.opencode', 'bin', 'opencode'))
+      expect(detectCommandsInInstallDirs(['codex', 'opencode', 'cursor-agent'])).toEqual(
+        new Set(['codex', 'opencode'])
+      )
+    }
+  )
+
+  it('carries the system install dirs into the POSIX guest fallback prelude', () => {
+    const prelude = buildPosixFallbackPathPrelude()
+    for (const dir of [
+      '"$HOME/.opencode/bin"',
+      '"$HOME/.nix-profile/bin"',
+      '"/home/linuxbrew/.linuxbrew/bin"',
+      '"/snap/bin"',
+      '"/nix/var/nix/profiles/default/bin"'
+    ]) {
+      expect(prelude).toContain(dir)
+    }
+    // Why absent: a WSL guest is Linux, so /opt/homebrew is never its brew prefix.
+    expect(prelude).not.toContain('/opt/homebrew')
+  })
+})

--- a/src/shared/agent-cli-install-dir-fallback.test.ts
+++ b/src/shared/agent-cli-install-dir-fallback.test.ts
@@ -163,9 +163,24 @@ describe('agent CLI install-dir fallback', () => {
   // patchPackagedProcessPath and the CLI's addAgentNodePaths, so a system dir
   // leaking into it would re-rank binaries the user already has (#18234).
   it('keeps system install dirs out of the PATH seed list', () => {
-    const seeded = getVersionManagerBinPaths({ platform: 'darwin', homePath: '/Users/tester' })
-    expect(seeded).not.toContain('/opt/homebrew/bin')
-    expect(seeded).not.toContain('/usr/local/bin')
+    for (const platform of ['darwin', 'linux'] as const) {
+      const home = platform === 'darwin' ? '/Users/tester' : '/home/tester'
+      const seeded = getVersionManagerBinPaths({ platform, homePath: home })
+      // Spelled out, not derived from the list under test: a guard that iterates
+      // getSystemCliInstallDirectories passes vacuously if that list is emptied
+      // into getBaseVersionManagerDirectories, which is the leak it guards.
+      for (const directory of [
+        '/opt/homebrew/bin',
+        '/usr/local/bin',
+        '/snap/bin',
+        '/home/linuxbrew/.linuxbrew/bin',
+        '/nix/var/nix/profiles/default/bin',
+        join(home, '.nix-profile', 'bin'),
+        join(home, '.opencode', 'bin')
+      ]) {
+        expect(seeded).not.toContain(directory)
+      }
+    }
   })
 
   // Why through this entry point: it is what the `orca` CLI's agent detection

--- a/src/shared/agent-cli-install-dir-fallback.test.ts
+++ b/src/shared/agent-cli-install-dir-fallback.test.ts
@@ -136,7 +136,8 @@ describe('agent CLI install-dir fallback', () => {
       '/home/linuxbrew/.linuxbrew/bin',
       '/nix/var/nix/profiles/default/bin',
       join(home, '.nix-profile', 'bin'),
-      join(home, '.opencode', 'bin')
+      join(home, '.opencode', 'bin'),
+      join(home, '.vite-plus', 'bin')
     ]
     stage(...dirs.map((dir) => join(dir, 'opencode')))
     for (const expected of dirs) {
@@ -176,7 +177,8 @@ describe('agent CLI install-dir fallback', () => {
         '/home/linuxbrew/.linuxbrew/bin',
         '/nix/var/nix/profiles/default/bin',
         join(home, '.nix-profile', 'bin'),
-        join(home, '.opencode', 'bin')
+        join(home, '.opencode', 'bin'),
+        join(home, '.vite-plus', 'bin')
       ]) {
         expect(seeded).not.toContain(directory)
       }
@@ -188,10 +190,17 @@ describe('agent CLI install-dir fallback', () => {
   it.skipIf(process.platform === 'win32')(
     'reports a system-installed CLI as detected, not just resolved',
     () => {
-      stage(join('/usr/local/bin', 'codex'), join(MOCK_HOME, '.opencode', 'bin', 'opencode'))
-      // Both come from the fallback: the stubbed PATH holds no system dir.
-      expect(detectCommandsInInstallDirs(['codex', 'opencode', 'cursor-agent'])).toEqual(
-        new Set(['codex', 'opencode'])
+      stage(
+        join('/usr/local/bin', 'codex'),
+        join(MOCK_HOME, '.opencode', 'bin', 'opencode'),
+        // Why pi: it is a probed detect command on every runtime (tui-agent-config.ts,
+        // no detectUnsupportedRuntimes) and its installer defaults to ~/.vite-plus/bin,
+        // the second dir #829 named and seeded alongside ~/.opencode/bin.
+        join(MOCK_HOME, '.vite-plus', 'bin', 'pi')
+      )
+      // All three come from the fallback: the stubbed PATH holds no system dir.
+      expect(detectCommandsInInstallDirs(['codex', 'opencode', 'pi', 'cursor-agent'])).toEqual(
+        new Set(['codex', 'opencode', 'pi'])
       )
     }
   )
@@ -204,7 +213,8 @@ describe('agent CLI install-dir fallback', () => {
       '"/home/linuxbrew/.linuxbrew/bin"',
       '"/nix/var/nix/profiles/default/bin"',
       '"$HOME/.nix-profile/bin"',
-      '"$HOME/.opencode/bin"'
+      '"$HOME/.opencode/bin"',
+      '"$HOME/.vite-plus/bin"'
     ]
     const offsets = systemDirs.map((dir) => prelude.indexOf(dir))
     expect(offsets.every((offset) => offset >= 0)).toBe(true)

--- a/src/shared/node-cli-command-resolution.ts
+++ b/src/shared/node-cli-command-resolution.ts
@@ -1,6 +1,7 @@
 import { accessSync, constants, existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { delimiter, dirname, isAbsolute, join } from 'node:path'
+import { getSystemCliInstallDirectories } from './system-cli-install-dirs'
 
 type ResolveCommandOptions = {
   pathEnv?: string | null
@@ -267,7 +268,10 @@ export function resolveCliCommand(
     nvmCandidate ??
     findFirstExecutable(
       platform,
-      getBaseVersionManagerDirectories(platform, homePath),
+      [
+        ...getBaseVersionManagerDirectories(platform, homePath),
+        ...getSystemCliInstallDirectories(platform, homePath)
+      ],
       executableNames
     )
   return versionManagerCandidate ?? commandName
@@ -283,7 +287,8 @@ export function resolveCliCommands(
   const homePath = options.homePath ?? homedir()
   const installDirectories = [
     ...getNvmVersionDirectories(homePath),
-    ...getBaseVersionManagerDirectories(platform, homePath)
+    ...getBaseVersionManagerDirectories(platform, homePath),
+    ...getSystemCliInstallDirectories(platform, homePath)
   ]
   const resolved = new Map<string, string>()
 

--- a/src/shared/node-cli-command-resolution.ts
+++ b/src/shared/node-cli-command-resolution.ts
@@ -246,6 +246,17 @@ function getVersionManagerDirectories(
   return directories
 }
 
+// Why one list for both resolvers: the system block must stay LAST so a
+// version-manager install always outranks a Homebrew/npm/snap one, and two
+// hand-spelled spreads is how the native and WSL lists drifted apart before.
+function getCliInstallDirectories(platform: NodeJS.Platform, homePath: string): string[] {
+  return [
+    ...getNvmVersionDirectories(homePath),
+    ...getBaseVersionManagerDirectories(platform, homePath),
+    ...getSystemCliInstallDirectories(platform, homePath)
+  ]
+}
+
 export function resolveCliCommand(
   commandName: string,
   options: ResolveCommandOptions = {}
@@ -259,22 +270,12 @@ export function resolveCliCommand(
   }
 
   const homePath = options.homePath ?? homedir()
-  const nvmCandidate = findFirstExecutable(
+  const installCandidate = findFirstExecutable(
     platform,
-    getNvmVersionDirectories(homePath),
+    getCliInstallDirectories(platform, homePath),
     executableNames
   )
-  const versionManagerCandidate =
-    nvmCandidate ??
-    findFirstExecutable(
-      platform,
-      [
-        ...getBaseVersionManagerDirectories(platform, homePath),
-        ...getSystemCliInstallDirectories(platform, homePath)
-      ],
-      executableNames
-    )
-  return versionManagerCandidate ?? commandName
+  return installCandidate ?? commandName
 }
 
 export function resolveCliCommands(
@@ -285,11 +286,7 @@ export function resolveCliCommands(
   const pathEnv = options.pathEnv ?? process.env.PATH ?? process.env.Path ?? null
   const pathDirectories = splitPath(pathEnv)
   const homePath = options.homePath ?? homedir()
-  const installDirectories = [
-    ...getNvmVersionDirectories(homePath),
-    ...getBaseVersionManagerDirectories(platform, homePath),
-    ...getSystemCliInstallDirectories(platform, homePath)
-  ]
+  const installDirectories = getCliInstallDirectories(platform, homePath)
   const resolved = new Map<string, string>()
 
   for (const commandName of new Set(commandNames)) {

--- a/src/shared/posix-version-manager-bin-dirs.ts
+++ b/src/shared/posix-version-manager-bin-dirs.ts
@@ -42,8 +42,9 @@ const POSIX_VERSION_MANAGER_BIN_DIRS = [
   '"/home/linuxbrew/.linuxbrew/bin"',
   '"/nix/var/nix/profiles/default/bin"',
   '"$HOME/.nix-profile/bin"',
-  // Why: opencode's own installer default, which no version manager owns.
-  '"$HOME/.opencode/bin"'
+  // Why both: the opencode and Pi installers' own defaults, which no version manager owns (#829).
+  '"$HOME/.opencode/bin"',
+  '"$HOME/.vite-plus/bin"'
 ].join(' ')
 
 /**

--- a/src/shared/posix-version-manager-bin-dirs.ts
+++ b/src/shared/posix-version-manager-bin-dirs.ts
@@ -14,9 +14,14 @@
  * on native does not. `/opt/homebrew` stays out because a WSL guest is Linux,
  * where Homebrew installs to the Linuxbrew prefix below.
  *
- * Version-manager dirs lead and the system block trails, in the same relative
- * order as the other two lists, so a CLI present in two of them resolves to the
- * same binary in the guest as it does natively.
+ * Version-manager dirs lead and the system block trails, which took the one
+ * behavior change here: `/usr/local/bin` moved from before the nvm glob to
+ * after it, so the guest ranks a version manager over a system install the way
+ * native does. Bounded, not free: every entry is APPENDED behind a resolved
+ * login PATH, so this can only re-rank a command that BOTH consumers would
+ * otherwise miss, and both only test presence. Not full parity either -- the
+ * glob expands lexicographically, while native orders nvm dirs
+ * default-alias-first (#10932).
  *
  * Each entry is quoted so a `$HOME` containing a space cannot word-split into
  * a relative path -- except the nvm glob, where only the prefix is quoted so

--- a/src/shared/posix-version-manager-bin-dirs.ts
+++ b/src/shared/posix-version-manager-bin-dirs.ts
@@ -7,12 +7,16 @@
  * establish the login PATH reports an nvm-installed claude/codex as not
  * installed, which is #9725.
  *
- * Kept in step with `getBaseVersionManagerDirectories` and
- * `getSystemCliInstallDirectories` in node-cli-command-resolution.ts: a WSL user
- * on asdf, mise, volta or fnm -- or on Linuxbrew, snap or nix -- would otherwise
- * still hit #9725 while the same user on native does not. `/opt/homebrew` stays
- * out because a WSL guest is Linux, where Homebrew installs to the Linuxbrew
- * prefix below.
+ * Kept in step with `getBaseVersionManagerDirectories` in
+ * node-cli-command-resolution.ts and `getSystemCliInstallDirectories` in
+ * system-cli-install-dirs.ts: a WSL user on asdf, mise, volta or fnm -- or on
+ * Linuxbrew, snap or nix -- would otherwise still hit #9725 while the same user
+ * on native does not. `/opt/homebrew` stays out because a WSL guest is Linux,
+ * where Homebrew installs to the Linuxbrew prefix below.
+ *
+ * Version-manager dirs lead and the system block trails, in the same relative
+ * order as the other two lists, so a CLI present in two of them resolves to the
+ * same binary in the guest as it does natively.
  *
  * Each entry is quoted so a `$HOME` containing a space cannot word-split into
  * a relative path -- except the nvm glob, where only the prefix is quoted so
@@ -27,14 +31,14 @@ const POSIX_VERSION_MANAGER_BIN_DIRS = [
   '"$HOME/.asdf/shims"',
   '"$HOME/.fnm/aliases/default/bin"',
   '"$HOME/.local/share/mise/shims"',
-  // Why: opencode's own installer default, which no version manager owns.
-  '"$HOME/.opencode/bin"',
-  '"$HOME/.nix-profile/bin"',
+  '"$HOME"/.nvm/versions/node/*/bin',
   '"/usr/local/bin"',
-  '"/home/linuxbrew/.linuxbrew/bin"',
   '"/snap/bin"',
+  '"/home/linuxbrew/.linuxbrew/bin"',
   '"/nix/var/nix/profiles/default/bin"',
-  '"$HOME"/.nvm/versions/node/*/bin'
+  '"$HOME/.nix-profile/bin"',
+  // Why: opencode's own installer default, which no version manager owns.
+  '"$HOME/.opencode/bin"'
 ].join(' ')
 
 /**

--- a/src/shared/posix-version-manager-bin-dirs.ts
+++ b/src/shared/posix-version-manager-bin-dirs.ts
@@ -7,9 +7,12 @@
  * establish the login PATH reports an nvm-installed claude/codex as not
  * installed, which is #9725.
  *
- * Kept in step with `getBaseVersionManagerDirectories` in
- * node-cli-command-resolution.ts: a WSL user on asdf, mise, volta or fnm would
- * otherwise still hit #9725 while the same user on native does not.
+ * Kept in step with `getBaseVersionManagerDirectories` and
+ * `getSystemCliInstallDirectories` in node-cli-command-resolution.ts: a WSL user
+ * on asdf, mise, volta or fnm -- or on Linuxbrew, snap or nix -- would otherwise
+ * still hit #9725 while the same user on native does not. `/opt/homebrew` stays
+ * out because a WSL guest is Linux, where Homebrew installs to the Linuxbrew
+ * prefix below.
  *
  * Each entry is quoted so a `$HOME` containing a space cannot word-split into
  * a relative path -- except the nvm glob, where only the prefix is quoted so
@@ -24,7 +27,13 @@ const POSIX_VERSION_MANAGER_BIN_DIRS = [
   '"$HOME/.asdf/shims"',
   '"$HOME/.fnm/aliases/default/bin"',
   '"$HOME/.local/share/mise/shims"',
+  // Why: opencode's own installer default, which no version manager owns.
+  '"$HOME/.opencode/bin"',
+  '"$HOME/.nix-profile/bin"',
   '"/usr/local/bin"',
+  '"/home/linuxbrew/.linuxbrew/bin"',
+  '"/snap/bin"',
+  '"/nix/var/nix/profiles/default/bin"',
   '"$HOME"/.nvm/versions/node/*/bin'
 ].join(' ')
 

--- a/src/shared/system-cli-install-dirs.ts
+++ b/src/shared/system-cli-install-dirs.ts
@@ -6,13 +6,19 @@ import { join } from 'node:path'
  * (#829 named `~/.opencode/bin` as the motivating case, but only for the
  * login-shell probe; the fallback used when that probe fails never gained it).
  *
- * Ordered to match what `patchPackagedProcessPath` appends to PATH, so a CLI
- * present in two of these dirs resolves to the same binary here, in the packaged
- * PATH scan, and in `POSIX_VERSION_MANAGER_BIN_DIRS`. Three deliberate gaps vs
- * that seed: the `sbin` dirs and the generic `~/bin` / `~/.local/bin` (no agent
- * CLI installer targets those, and `~/.local/bin` is already a version-manager
- * dir here); `~/.vite-plus/bin`, which no probed agent command maps to; and
- * `/opt/homebrew` off darwin, since a Linux box's brew prefix is Linuxbrew's.
+ * Ordered to match the system block `patchPackagedProcessPath` appends to PATH,
+ * so a CLI present in two of *these* dirs resolves to the same binary here, in
+ * the packaged PATH scan, and in `POSIX_VERSION_MANAGER_BIN_DIRS`. That parity
+ * stops at the block boundary and is not claimed across it: the seed appends
+ * `~/.local/bin` after this block, while here it arrives ahead of it from
+ * `getBaseVersionManagerDirectories`, so a `claude` installed in both
+ * `~/.local/bin` and `/opt/homebrew/bin` resolves to the former via this
+ * fallback and the latter via the seeded PATH. Pre-existing, and left alone
+ * because closing it means hoisting a system dir over a version-manager one.
+ *
+ * Deliberate gaps vs that seed: the `sbin` dirs and the generic `~/bin`;
+ * `~/.vite-plus/bin`, which no probed agent command maps to; and `/opt/homebrew`
+ * off darwin, since a Linux box's brew prefix is Linuxbrew's.
  *
  * Lookup-only, deliberately outside `getBaseVersionManagerDirectories`: that
  * list is PREPENDED to PATH by `getVersionManagerBinPaths` callers, and hoisting

--- a/src/shared/system-cli-install-dirs.ts
+++ b/src/shared/system-cli-install-dirs.ts
@@ -6,10 +6,13 @@ import { join } from 'node:path'
  * (#829 named `~/.opencode/bin` as the motivating case, but only for the
  * login-shell probe; the fallback used when that probe fails never gained it).
  *
- * The same set `patchPackagedProcessPath` appends to PATH, minus the sbin dirs
- * and the generic `~/bin` — no agent CLI installer targets those. Kept in step
- * with it and with `POSIX_VERSION_MANAGER_BIN_DIRS`, or the answer to "is this
- * agent installed?" depends on which of the three lists ran.
+ * Ordered to match what `patchPackagedProcessPath` appends to PATH, so a CLI
+ * present in two of these dirs resolves to the same binary here, in the packaged
+ * PATH scan, and in `POSIX_VERSION_MANAGER_BIN_DIRS`. Three deliberate gaps vs
+ * that seed: the `sbin` dirs and the generic `~/bin` / `~/.local/bin` (no agent
+ * CLI installer targets those, and `~/.local/bin` is already a version-manager
+ * dir here); `~/.vite-plus/bin`, which no probed agent command maps to; and
+ * `/opt/homebrew` off darwin, since a Linux box's brew prefix is Linuxbrew's.
  *
  * Lookup-only, deliberately outside `getBaseVersionManagerDirectories`: that
  * list is PREPENDED to PATH by `getVersionManagerBinPaths` callers, and hoisting
@@ -20,21 +23,26 @@ export function getSystemCliInstallDirectories(
   platform: NodeJS.Platform,
   homePath: string
 ): string[] {
+  // Why nothing here: the PATH seed's system block is POSIX-only too, so
+  // Windows installs outside a version manager (`%USERPROFILE%\.opencode\bin`)
+  // have never had install-dir coverage in either list. Unchanged, not fixed.
   if (platform === 'win32') {
     return []
   }
-  const directories = [join(homePath, '.opencode', 'bin')]
+  const directories: string[] = []
   if (platform === 'darwin') {
     // Apple Silicon Homebrew; Intel Homebrew shares /usr/local with npm's prefix.
     directories.push('/opt/homebrew/bin')
-  } else {
+  }
+  directories.push('/usr/local/bin')
+  if (platform !== 'darwin') {
     // Linuxbrew uses its own prefix, not /opt/homebrew; snap is Linux-only.
-    directories.push('/home/linuxbrew/.linuxbrew/bin', '/snap/bin')
+    directories.push('/snap/bin', '/home/linuxbrew/.linuxbrew/bin')
   }
   directories.push(
-    '/usr/local/bin',
     '/nix/var/nix/profiles/default/bin',
-    join(homePath, '.nix-profile', 'bin')
+    join(homePath, '.nix-profile', 'bin'),
+    join(homePath, '.opencode', 'bin')
   )
   return directories
 }

--- a/src/shared/system-cli-install-dirs.ts
+++ b/src/shared/system-cli-install-dirs.ts
@@ -3,8 +3,9 @@ import { join } from 'node:path'
 /**
  * Where an agent CLI lands when no version manager installed it: Homebrew (both
  * prefixes), npm's default global prefix, snap, nix, or the CLI's own installer
- * (#829 named `~/.opencode/bin` as the motivating case, but only for the
- * login-shell probe; the fallback used when that probe fails never gained it).
+ * (#829 named `~/.opencode/bin` and `~/.vite-plus/bin` as the motivating cases,
+ * but only for the login-shell probe; the fallback used when that probe fails
+ * never gained either).
  *
  * Ordered to match the system block `patchPackagedProcessPath` appends to PATH,
  * so a CLI present in two of *these* dirs resolves to the same binary here, in
@@ -16,14 +17,17 @@ import { join } from 'node:path'
  * fallback and the latter via the seeded PATH. Pre-existing, and left alone
  * because closing it means hoisting a system dir over a version-manager one.
  *
- * Deliberate gaps vs that seed: the `sbin` dirs and the generic `~/bin`;
- * `~/.vite-plus/bin`, which no probed agent command maps to; and `/opt/homebrew`
- * off darwin, since a Linux box's brew prefix is Linuxbrew's.
+ * Deliberate gaps vs that seed: the `sbin` dirs, the generic `~/bin`, and
+ * `/opt/homebrew` off darwin -- the seed does push that prefix on every posix,
+ * but Linux Homebrew installs to the Linuxbrew prefix below, so off darwin it
+ * is a directory no brew install can occupy.
  *
  * Lookup-only, deliberately outside `getBaseVersionManagerDirectories`: that
  * list is PREPENDED to PATH by `getVersionManagerBinPaths` callers, and hoisting
  * a system dir over the inherited PATH re-ranks binaries the user already has
- * (#18234).
+ * (#18234). One bounded exception: when a hit here ships a sibling `node`,
+ * `withCliRuntimeOnPath` prepends that dir onto the *spawned child's* PATH
+ * (#10932 runtime pairing) -- only for a command PATH did not contain at all.
  */
 export function getSystemCliInstallDirectories(
   platform: NodeJS.Platform,
@@ -41,14 +45,16 @@ export function getSystemCliInstallDirectories(
     directories.push('/opt/homebrew/bin')
   }
   directories.push('/usr/local/bin')
-  if (platform !== 'darwin') {
-    // Linuxbrew uses its own prefix, not /opt/homebrew; snap is Linux-only.
+  if (platform === 'linux') {
+    // Gated like the seed: snap and Linuxbrew ship on Linux only, so elsewhere they are phantom stats.
     directories.push('/snap/bin', '/home/linuxbrew/.linuxbrew/bin')
   }
   directories.push(
     '/nix/var/nix/profiles/default/bin',
     join(homePath, '.nix-profile', 'bin'),
-    join(homePath, '.opencode', 'bin')
+    // Why both: the opencode and Pi installers' own defaults, which no version manager owns (#829).
+    join(homePath, '.opencode', 'bin'),
+    join(homePath, '.vite-plus', 'bin')
   )
   return directories
 }

--- a/src/shared/system-cli-install-dirs.ts
+++ b/src/shared/system-cli-install-dirs.ts
@@ -1,0 +1,40 @@
+import { join } from 'node:path'
+
+/**
+ * Where an agent CLI lands when no version manager installed it: Homebrew (both
+ * prefixes), npm's default global prefix, snap, nix, or the CLI's own installer
+ * (#829 named `~/.opencode/bin` as the motivating case, but only for the
+ * login-shell probe; the fallback used when that probe fails never gained it).
+ *
+ * The same set `patchPackagedProcessPath` appends to PATH, minus the sbin dirs
+ * and the generic `~/bin` — no agent CLI installer targets those. Kept in step
+ * with it and with `POSIX_VERSION_MANAGER_BIN_DIRS`, or the answer to "is this
+ * agent installed?" depends on which of the three lists ran.
+ *
+ * Lookup-only, deliberately outside `getBaseVersionManagerDirectories`: that
+ * list is PREPENDED to PATH by `getVersionManagerBinPaths` callers, and hoisting
+ * a system dir over the inherited PATH re-ranks binaries the user already has
+ * (#18234).
+ */
+export function getSystemCliInstallDirectories(
+  platform: NodeJS.Platform,
+  homePath: string
+): string[] {
+  if (platform === 'win32') {
+    return []
+  }
+  const directories = [join(homePath, '.opencode', 'bin')]
+  if (platform === 'darwin') {
+    // Apple Silicon Homebrew; Intel Homebrew shares /usr/local with npm's prefix.
+    directories.push('/opt/homebrew/bin')
+  } else {
+    // Linuxbrew uses its own prefix, not /opt/homebrew; snap is Linux-only.
+    directories.push('/home/linuxbrew/.linuxbrew/bin', '/snap/bin')
+  }
+  directories.push(
+    '/usr/local/bin',
+    '/nix/var/nix/profiles/default/bin',
+    join(homePath, '.nix-profile', 'bin')
+  )
+  return directories
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​299 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​299 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​98 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 |

<!-- /orca-pr-loc -->

## What

Cluster **G6 / `agent-cli-path-resolution`**, **1 field report** (report #3 in the G6 bucket): *"安装的智能体扫描不到，Codex、Cursor、OpenCode，全识别不到"* — "the installed agents can't be scanned, Codex / Cursor / OpenCode, none of them are recognized." Reported on **macOS, Orca v1.4.194**.

Orca answers *"is this agent CLI installed?"* two ways: scan `PATH`, and if that misses, probe a hard-coded list of install directories. That fallback list — `getBaseVersionManagerDirectories`, consumed at `src/shared/node-cli-command-resolution.ts:270` (`resolveCliCommand`) and `:286` (`resolveCliCommands`) on `origin/main` — contained **only version-manager bin dirs** (nvm, asdf, mise, volta, fnm, pnpm, bun, yarn, `~/.local/bin`). It contained no Homebrew prefix, no npm default global prefix, no snap, no nix, and neither of the two installer-owned dirs #829 named (`~/.opencode/bin`, `~/.vite-plus/bin`).

So a `codex` / `cursor-agent` / `opencode` installed by Homebrew, `npm -g`, snap, nix, or the CLI's own installer read as **not installed** whenever the `PATH` scan missed it. `src/main/preflight/agent-detection.ts:160,166` and `src/cli/handlers/skills.ts:167` both route through that list.

Two more asymmetries fixed alongside it, because the whole point of the fallback is that it match what Orca does elsewhere:

- `patchPackagedProcessPath` (`src/main/startup/configure-process.ts:114`) already seeds **every one** of these dirs onto `process.env.PATH` (`:140-156`; eight across darwin and linux, six on any single platform). The fallback list did not, so the same install answered "installed" or "not installed" depending on which list ran.
- The WSL guest prelude (`src/shared/posix-version-manager-bin-dirs.ts`) — whose docstring already claimed parity with the native list — had `/usr/local/bin` and nothing else, so a WSL user on Linuxbrew/snap/nix hit #9725 while the same user on native did not.

The change adds `src/shared/system-cli-install-dirs.ts` (`getSystemCliInstallDirectories` — `/opt/homebrew/bin` on darwin, then `/usr/local/bin`, `/snap/bin` + `/home/linuxbrew/.linuxbrew/bin` on linux, `/nix/var/nix/profiles/default/bin`, `~/.nix-profile/bin`, `~/.opencode/bin`, `~/.vite-plus/bin`), appends it **last** in both resolvers, and mirrors it into the WSL prelude. `win32` returns `[]` — the Windows branch is byte-for-byte unchanged.

### Scope honesty, stated up front

**This does not explain the reporter's packaged macOS v1.4.194 failure, and must not close G6 report #3.** `patchPackagedProcessPath` returns early unless `app.isPackaged` (`configure-process.ts:114-117`), and when packaged it seeds every one of those dirs onto `PATH` at `main-process-preflight.ts:147`, *before* any detection runs; `mergePathSegments` (`hydrate-shell-path.ts:382-385`) never deletes them. So in the packaged desktop app the `PATH` scan reaches those dirs first and this fallback never fires for them.

Round 5 checked this against the reporter's **exact build** rather than against `main`, and it is even more decisive there: `git show v1.4.194:src/main/startup/configure-process.ts` shows all of `/opt/homebrew/bin`, `/usr/local/bin`, `/nix/var/nix/profiles/default/bin`, `~/.nix-profile/bin`, `~/.opencode/bin`, `~/.vite-plus/bin` in `extraPaths`, **prepended** (`[...missing, ...currentPath]`) — not appended as on `main` today. On v1.4.194 those dirs *led* `PATH` before any detection ran. `~/.opencode/bin` has been seeded since #843 (2026-04-19).

The fallback is decisive for exactly these populations: the **`orca` CLI** (`src/cli/handlers/skills.ts:167`, `src/cli/handlers/account.ts:97` — `src/cli/index.ts` seeds no PATH), **unpackaged / dev runs**, and **WSL guests** via the prelude. Earlier revisions of this body also named the SSH host runtime; **that was wrong and is retracted** — see *Trade-offs → SSH hosts* and *Round 4*. That report stays open. This PR must not be merged with a closing keyword pointed at it, and there is none in this body or in any of the four commit messages (`grep -inE 'fixes #|closes #|resolves #'` → no match in either).

## Fix evidence

Every command in this section was re-run at HEAD `2666af8` immediately before this revision was published. Nothing here is quoted from an earlier round.

### Regression test RED with the production hunks reverted to `origin/main`

```
$ git checkout origin/main -- src/shared/node-cli-command-resolution.ts src/shared/posix-version-manager-bin-dirs.ts
$ git diff --stat origin/main -- src/shared/node-cli-command-resolution.ts src/shared/posix-version-manager-bin-dirs.ts
(empty output = files identical to origin/main)

$ ./node_modules/.bin/vitest run --config config/vitest.config.ts src/shared/agent-cli-install-dir-fallback.test.ts

 ❯ src/shared/agent-cli-install-dir-fallback.test.ts (8 tests | 5 failed) 11ms
     × finds macOS CLIs installed outside a version manager 6ms
     × finds Linux CLIs in Linuxbrew, snap and nix prefixes, not the macOS brew prefix 1ms
     × ranks system install dirs in the same order as the PATH seed 0ms
     × reports a system-installed CLI as detected, not just resolved 1ms
     × carries the system install dirs into the POSIX guest fallback prelude 0ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  ... > finds macOS CLIs installed outside a version manager
AssertionError: expected { …(4) } to deeply equal { …(4) }

- Expected
+ Received

  {
    "claude": "/Users/tester/.local/bin/claude",
-   "codex": "/opt/homebrew/bin/codex",
-   "cursor-agent": "/usr/local/bin/cursor-agent",
-   "opencode": "/Users/tester/.opencode/bin/opencode",
+   "codex": "codex",
+   "cursor-agent": "cursor-agent",
+   "opencode": "opencode",
  }

 FAIL  ... > finds Linux CLIs in Linuxbrew, snap and nix prefixes, not the macOS brew prefix
AssertionError: expected { codex: 'codex', …(3) } to deeply equal { …(4) }

  {
    "claude": "claude",
-   "codex": "/home/linuxbrew/.linuxbrew/bin/codex",
-   "cursor-agent": "/snap/bin/cursor-agent",
-   "opencode": "/home/tester/.nix-profile/bin/opencode",
+   "codex": "codex",
+   "cursor-agent": "cursor-agent",
+   "opencode": "opencode",
  }

 FAIL  ... > ranks system install dirs in the same order as the PATH seed
AssertionError: expected { opencode: 'opencode' } to deeply equal { opencode: '/usr/local/bin/opencode' }

 FAIL  ... > reports a system-installed CLI as detected, not just resolved
AssertionError: expected Set{} to deeply equal Set{ 'codex', 'opencode', 'pi' }

- Set {
-   "codex",
-   "opencode",
-   "pi",
- }
+ Set {}

 FAIL  ... > carries the system install dirs into the POSIX guest fallback prelude
AssertionError: expected false to be true // Object.is equality

 Test Files  1 failed (1)
      Tests  5 failed | 3 passed (8)
```

The first red row reproduces the field report's **symptom shape** — `claude` resolves, `codex` + `cursor-agent` + `opencode` do not. It is not a reproduction of the reporter's machine, and per *Scope honesty* above this fallback is not the code path their packaged build took; read it as "this omission is capable of producing that symptom", nothing stronger.

The `reports a system-installed CLI as detected, not just resolved` case asserts through `detectCommandsInInstallDirs` — the exact function `src/cli/handlers/skills.ts:167` and `src/main/preflight/agent-detection.ts:166` call — with a stubbed GUI-launch `PATH`, so it pins the real "absolute path means installed" contract, not just the resolver.

### GREEN with the production hunks restored

```
$ git checkout HEAD -- src/shared/node-cli-command-resolution.ts src/shared/posix-version-manager-bin-dirs.ts
$ git status --short
(clean)

$ ./node_modules/.bin/vitest run --config config/vitest.config.ts src/shared/agent-cli-install-dir-fallback.test.ts

 Test Files  1 passed (1)
      Tests  8 passed (8)
```

The 3 cases green in **both** states are the no-regression guards: `win32` returns `[]`; a version-manager install still outranks a system one; and the system dirs stay out of `getVersionManagerBinPaths`, whose result is *prepended* to `PATH` (#18234).

### Blast-radius suites, typecheck, lint

```
$ ./node_modules/.bin/vitest run --config config/vitest.config.ts \
    src/shared/agent-cli-install-dir-fallback.test.ts src/shared/nvm-default-alias.test.ts \
    src/main/startup/configure-process.test.ts src/main/preflight \
    src/main/ipc/preflight-agent-detection.test.ts \
    src/main/ipc/preflight-wsl-agent-detection.test.ts \
    src/shared/cli-runtime-pairing-boundary.test.ts src/cli/skills.test.ts

 Test Files  7 passed (7)
      Tests  161 passed (161)

$ ./node_modules/.bin/tsc --noEmit -p config/tsconfig.node.json      ; echo exit=$?
exit=0
$ ./node_modules/.bin/tsc --noEmit -p config/tsconfig.tc.cli.json    ; echo exit=$?
exit=0

$ ./node_modules/.bin/oxlint src/shared/agent-cli-install-dir-fallback.test.ts \
    src/shared/node-cli-command-resolution.ts src/shared/posix-version-manager-bin-dirs.ts \
    src/shared/system-cli-install-dirs.ts src/main/startup/configure-process.test.ts ; echo OXLINT_EXIT=$?
OXLINT_EXIT=0

$ node config/scripts/check-changed-code-quality.mjs   # what `pnpm run check:code-quality:changed` invokes
code quality: 0 new finding(s) across 5 changed file(s).
type-aware code quality: 0 new finding(s) across 5 changed file(s).
React Doctor: 0 new finding(s) across 5 changed file(s).
Changed-code quality gate passed since 76836b30ea6c.
```

Note on that last command: an earlier revision quoted it as `pnpm run check:code-quality:changed` reporting **4** changed files. Both details were stale — the branch has covered **5** files since `bcd5948` added `configure-process.test.ts`, and on this machine the `pnpm run` wrapper aborts in its own preinstall step (`ERR_PNPM_CMD_SHIM_CHMOD` on `electron-osx-sign`) before the gate runs, so the underlying script is invoked directly. The gate itself passes.

### Round-4 fix: the `~/.vite-plus/bin` gap, pinned against the previous HEAD

```
$ git checkout HEAD~1 -- src/shared/system-cli-install-dirs.ts src/shared/posix-version-manager-bin-dirs.ts
$ ./node_modules/.bin/vitest run --config config/vitest.config.ts src/shared/agent-cli-install-dir-fallback.test.ts

     × ranks system install dirs in the same order as the PATH seed
     × reports a system-installed CLI as detected, not just resolved
     × carries the system install dirs into the POSIX guest fallback prelude

AssertionError: expected { opencode: 'opencode' } to deeply equal { Object (opencode) }
-   "opencode": "/home/tester/.vite-plus/bin/opencode",
+   "opencode": "opencode",

AssertionError: expected Set{ 'codex', 'opencode' } to deeply equal Set{ 'codex', 'opencode', 'pi' }
  Set {
    "codex",
    "opencode",
-   "pi",

 Tests  3 failed | 5 passed (8)
```

i.e. at round-3 HEAD (`bcd5948`) a `pi` installed by its own installer into `~/.vite-plus/bin` was reported **not installed** by the widened fallback. Green again at `2666af8`. The worktree was restored to clean (`git status --short` empty) after both experiments.

### Round-5 check: is the relay really unreachable from this module?

The claim under *Trade-offs → SSH hosts* is that nothing in the SSH relay can reach `node-cli-command-resolution.ts`. Round 5 falsified the *reason* the previous revision gave for it, so the claim was re-derived by walking the actual import graph from **all 182** non-test `src/relay/*.ts` files (a superset of the real esbuild entrypoints `src/relay/relay.ts`, `ai-vault-service-entry.ts`, `wsl-transcript-fs-process-entry.ts`, …):

```
relay entrypoints: 182
transitive modules reached: 884
node-cli-command-resolution.ts reachable: false
system-cli-install-dirs.ts reachable: false
posix-version-manager-bin-dirs.ts reachable: false
```

### What is NOT proven — stated plainly

- **No live reproduction of the field report exists, and this change probably did not cause it.** As shown in *Scope honesty*, the packaged app — and v1.4.194 in particular, which *prepended* these dirs — already had them on `PATH` before detection ran, so this fallback is not reached for them there. There is no crash dump, no user log, and no repro that ties the reporter's machine to this code path.
- **An investigation artifact produced earlier in this cluster is not evidence and is withdrawn.** It simulated a GUI `PATH` of `/usr/bin:/bin:/usr/sbin:/sbin` with no seed applied. No packaged build has ever had that `PATH`, because `patchPackagedProcessPath` runs first. It demonstrated the mechanism, not the reporter's machine, and is not cited as support anywhere in this body.
- Telemetry gathered during the investigation (PostHog project 406068, `onboarding_agent_picked`, 90d) actively argues **against** the "login-shell hydration failed, so the fallback ran and lost the agents" story: on darwin, sessions that fell back to the seed-only PATH reported *zero detected agents* **2.9%** of the time (198/6936) versus **7.9%** (15205/192306) for sessions with a successful shell hydration. That comparison is confounded by selection, so it is not causal in either direction — but it does not support the hypothesis, and it is reported as it came back rather than omitted.
- What **is** proven is narrower and exactly what the test shows: the fallback list omitted every non-version-manager install location, and that omission makes the reporter's four CLIs resolve as claude-only. This closes a demonstrated asymmetry between three lists that are documented to agree. It is not a proven cure.

## ELI5

To run a coding agent, Orca first has to find its program on your computer. It looks in two places: the list of folders your system normally searches, and — if that comes up empty — a short built-in list of backup folders.

That backup list only had folders used by "version managers": tools some developers use to juggle multiple versions of Node. If you installed Codex or OpenCode or Cursor the ordinary way — Homebrew, npm, snap, or the tool's own installer — your copy lived somewhere that was not on the backup list at all. Orca would look, not find it, and tell you the agent wasn't installed, even though it was sitting right there.

This change adds the ordinary install folders to that backup list, on Mac, Linux and inside the Linux environment that Windows users run Orca through. The backup folders are always checked **last**, after the ones your system already searches, so on Mac and Linux nothing Orca finds today can start pointing at a different copy — the only change is that something previously reported missing is now found. (One small exception, in the Windows-through-Linux case only: two of the backup folders swapped places. That could only matter for someone who keeps two copies of the same tool in exactly those two folders, and even then Orca is only checking whether the tool is there at all.)

Being straight about it: we could not prove this is what happened to the one user who reported it. Their version of Orca already searched those folders a different way. So this fixes a real hole we can demonstrate with a test, but the original report stays open.

## Trade-offs

Everything below is confined to the **"`PATH` missed this command entirely"** branch. In the two native resolvers (`resolveCliCommand`, `resolveCliCommands`) `PATH` is scanned first and the new entries are appended last within the fallback list, so **no command that resolves natively today can resolve differently.** That statement does **not** extend to the WSL guest prelude, which contains one ordering change — see the *WSL guests* bullet below, which states it rather than denying it.

- **Newly-resolving commands.** A command previously returned as a bare name (i.e. reported not-installed) can now resolve to an absolute path under `/opt/homebrew/bin`, `/usr/local/bin`, `/snap/bin`, `/home/linuxbrew/.linuxbrew/bin`, `/nix/var/nix/profiles/default/bin`, `~/.nix-profile/bin`, `~/.opencode/bin` or `~/.vite-plus/bin`. This is the intended behaviour change. Affects `orca` CLI users, dev/unpackaged runs, and WSL guests; packaged desktop users are already covered by the PATH seed.
- **Real cost — runtime pairing.** `withCliRuntimeOnPath` (`node-cli-command-resolution.ts:343`) prepends a resolved binary's own directory onto the *spawned child's* `PATH` when that directory also ships a sibling `node` (the #10932 binary/runtime pairing rule). A fallback hit in `/usr/local/bin` or `/opt/homebrew/bin` therefore now hoists that system dir ahead of the user's version-manager node **for the spawned agent only**. This is a genuine behaviour change, disclosed rather than buried. It fires only when `PATH` contained no copy of the CLI at all — and in that situation the alternative is not running the agent, so the trade is favourable. In the packaged app the PATH scan already returned those same absolute paths, so the prepend already happened before this change.
- **Widened spawn set, and the shadowing it could have introduced.** These resolvers do not only *detect*: `resolveCliCommand` / `resolveCodexCommand` / `resolveClaudeCommand` feed ~15 spawn sites (codex login, app-server, session-index heal, state-dir ops, `orca` CLI account/skills). A fallback hit in `/usr/local/bin` or `/opt/homebrew/bin` is therefore a binary Orca will *run*, and those are shared prefixes where a same-named, unrelated binary can live. Two things bound that, and the second is new in this revision:
  1. The system block is strictly **last**: PATH → nvm → version managers / `~/.local/bin` / pnpm / yarn / bun → system dirs. A CLI the user has anywhere a version manager or their own PATH knows about always wins; a system dir is only ever consulted for a command that *nothing else* on the machine has.
  2. That ordering is now built **once** (`getCliInstallDirectories` in `node-cli-command-resolution.ts`) and shared by both native resolvers instead of being two hand-spelled spreads — the singular resolver (the one every spawn site calls) had its own copy. `agent-cli-install-dir-fallback.test.ts` pins the guarantee on **both** resolvers, on darwin and linux, for a version-manager hit, a `~/.local/bin` hit, and a PATH hit each outranking a staged system copy; and a derived test asserts the WSL guest prelude keeps every native version-manager dir ahead of the native system block, in the native order. All six new assertions go RED when the system block is hoisted first or the guest list drifts (verified by reverting the ordering).

  **Not done, deliberately:** an identity check on the resolved binary (`--version` sniff, shebang read) before spawning. Every spawn site here already runs the tool and surfaces its failure, a probe would cost a process launch per resolution on a path that exists to be cheap, and the packaged app has spawned from exactly these dirs via the PATH seed for months without one. Ordering, not identity, is the guard.
- **WSL guests** get six extra `[ -d ]`-guarded `PATH` entries (`/snap/bin`, `/home/linuxbrew/.linuxbrew/bin`, `/nix/var/nix/profiles/default/bin`, `$HOME/.nix-profile/bin`, `$HOME/.opencode/bin`, `$HOME/.vite-plus/bin`), **appended not prepended**, per that file's own rule.
  **Plus one ordering change to an existing entry, stated explicitly:** `"/usr/local/bin"` moved from *before* `"$HOME"/.nvm/versions/node/*/bin` to *after* it, so the guest ranks version-manager dirs ahead of system ones the way the native lists do. Bounds on it: the whole prelude is appended behind a **resolved login `PATH`**, so it can only re-rank a command the login `PATH` did not contain at all *and* which exists in two different fallback dirs; and both consumers (`detectWslCommandsOnPath`, which discards the resolved path and returns only command names, and `runPreflightCommandInWsl`, used by `isCommandAvailable`/`isCommandOnPath`) test presence, not identity. It is also **not** full parity, and the docstring no longer claims it is: a shell glob expands lexicographically, whereas native `getNvmVersionDirectories` orders nvm dirs default-alias-first for #10932 reasons a glob cannot reproduce.
- **Latency:** up to 7 extra `statSync` probes per *unresolved* command, only on the PATH-miss path. Immeasurable next to the 10s login-shell probe this backstops.
- **Windows:** `getSystemCliInstallDirectories` returns `[]` on `win32`; the Windows branch is unchanged and pinned by a test.
- **Remote wire:** none. No RPC params, stream frames, or published content change; `KNOWN_TUI_AGENT_DETECTION_COMMANDS` and `resolveDetectedTuiAgentIds` are untouched, so the *set* of agent ids a host can publish to an older client is unchanged — only which subset a given machine reports.
- **SSH hosts get nothing from this change — stated as a correction, with the reasoning itself corrected.** An earlier revision claimed "a remote host runs its own copy of this code". It does not. `detectRemoteAgents` (`src/main/preflight/agent-detection.ts:241-252`) sends `preflight.detectAgents` **with a `commands` param**, and the handler for that param is `src/relay/preflight-handler.ts:48` → `detectAgents` (:57) → `isCommandOnPath` (:122-123) → `isCommandOnPathForRelay` (:171-195), which runs `where.exe` on win32 or a trusted POSIX login shell and never calls `resolveCliCommands` / `getSystemCliInstallDirectories`. The other `preflight.detectAgents` (`src/main/runtime/rpc/methods/preflight.ts:28`, `params: null`) is the **client's** runtime per `docs/reference/ssh-execution-boundary.md`, i.e. a packaged desktop already covered by the PATH seed.
  **A second correction, from round 5:** the previous revision justified the unreachability with "the relay is a separate esbuild bundle (`config/tsconfig.relay.json` includes only `../src/relay/**/*` plus two `src/main/pty` files), so it cannot reach this module at all." **That inference was invalid** — `src/relay` imports ~160 files' worth of `src/shared/*` modules despite that `include` list, because a tsconfig `include` does not bound esbuild's import graph. The conclusion survives, but on evidence rather than inference: a transitive walk from all 182 non-test `src/relay/*.ts` files reaches 884 modules and **none** of `node-cli-command-resolution.ts`, `system-cli-install-dirs.ts`, or `posix-version-manager-bin-dirs.ts` (output under *Fix evidence*). **Residual risk, unguarded:** that walk is a one-time manual check, not a test. A future relay file importing any shared module that transitively pulls in the resolver would silently falsify this bullet with every suite still green — Follow-up #8.
  **The relay's login-shell lookup still has no install-dir fallback of any kind; that gap is untouched here and is Follow-up #7.**
- **Newly-swallowed errors:** none. No `catch` was added or widened.
- **Folder workspaces vs git worktrees:** irrelevant to this path; it never touches repo layout.
- **Honest cost:** this ships a small, demonstrably-correct list fix whose field impact is unproven and, per the telemetry above, probably small. Reports #1, #2 and #4 in the G6 bucket are untouched.

## Adversarial review

**5 rounds total; converged clean = true at round 5.** Round 5 returned no blocking findings, having re-run every piece of evidence in this body from scratch rather than reading it. Rounds 1-4 produced **7 blocking findings**; all 7 were accepted, **none was rebutted**. Six were fixed in code or in claims; one — the unproven link to the field report — is carried as an explicit disclosed limitation with G6 report #3 left open, because no code on this branch can close it. Round 5's top-ranked *non-blocking* finding was a live claim defect in this body and is fixed in this revision (details below); it is the reason the *Trade-offs → SSH hosts* bullet now argues from an import walk instead of from a tsconfig `include`.

**Round 1 — 2 blocking, both accepted, neither rebutted.**
1. *The commit message asserted a mechanism that provably cannot occur in the shipped app.* It claimed "a GUI-launched app missed codex/opencode/cursor-agent installed by Homebrew…", but `patchPackagedProcessPath` seeds those exact dirs onto `process.env.PATH` for every packaged posix run, before detection, test-pinned at `configure-process.test.ts:75/76/97/98`. Fixed by rewriting the commit message (and this PR body) to state where the fallback is actually decisive — the `orca` CLI, dev runs, WSL guests — and to say explicitly that G6 report #3 stays open.
2. *The subject claimed Homebrew coverage while omitting Linux Homebrew.* `/opt/homebrew` is macOS-only; Linuxbrew is `/home/linuxbrew/.linuxbrew/bin`, and `/snap/bin` and the nix prefixes were missing too — all four already seeded by `configure-process.ts:140-147`. Fixed by adding them to both the fallback list and the WSL prelude, rather than by narrowing the claim.
   Round 1 also *confirmed* the evidence independently: the reviewer reverted the production files, reproduced the identical red output, restored, and re-ran 10,950 tests across the affected areas clean. "The test is not theatre."

**Round 2 — 1 blocking, accepted; process finding, not a code defect.**
The handoff summary given to the reviewer described a **2-file / +38 line** change with **3** new macOS dirs, while HEAD was **4 files / +227** with **6** lookup dirs plus WSL-prelude entries, the function had moved into a new module, and the quoted failing test names no longer existed — all consequences of the round-1 fixes, but never restated. The reviewer's point was that a decision record authorizing "+38, 3 dirs" cannot authorize something 6× larger that also changes Linux and WSL-guest resolution. Fixed by restating the claims against HEAD (this PR body is written against HEAD, verified by re-running everything above myself).
Round 2's non-blocking findings drove the second commit: (a) the three lists **disagreed on order** while claiming to be kept in step, so a CLI present in both `/usr/local/bin` and `/snap/bin` could resolve to a different binary than the seeded PATH scan found — all three now share the seed's relative order, pinned by a duplicate-install test and an offset assertion; (b) the parity docstring's claim was false — it also omitted `~/.vite-plus/bin` and `/opt/homebrew` off darwin, all three gaps then named as deliberate — round 4 showed the `~/.vite-plus/bin` one was not deliberate but wrong, and it is now closed; (c) the `detectCommandsInInstallDirs` case read the ambient `process.env.PATH`, so on a box with `/usr/local/bin` on PATH it wasn't exercising the fallback — it now stubs a GUI-launch PATH; (d) the test built paths with host `join` so it holds on a Windows dev machine.

**Round 3 — 2 blocking, both accepted, neither rebutted.**

1. *The claims/evidence block handed to the reviewer described `HEAD~2`, not `HEAD`, in six specific ways* — a 2-file/+38 stat against a 4-file/+273 change; `getSystemCliInstallDirectories` cited at `node-cli-command-resolution.ts:124-146` when it lives in `src/shared/system-cli-install-dirs.ts`; 3 claimed lookup dirs against 6 across two platforms; the WSL prelude described as a single added entry; "6 cases / 3 failed | 3 passed" against a file with 8; and a blanket "no existing resolution can change" that the WSL `/usr/local/bin` move contradicts. Round 2 had raised the same class of defect and the restatement never reached the round-3 input. **Accepted.** The stale artifact is retired: this body is the record, and every number in it is re-derived at HEAD `2666af8` (`git diff --stat origin/main...HEAD` = **5 files, +339/-5**; prod 3 files, +89/-5; test 2 files, +250), the function is cited at its real path, all eight dirs are enumerated, the eight test cases and their real names are quoted from a run performed for this revision, and the "nothing can resolve differently" claim is scoped to the native resolvers with the WSL ordering change spelled out in *Trade-offs*. No code change was invented to satisfy it — it was a claims defect and it got a claims fix.

2. *The branch does not fix the report it is filed under*, confirmed independently by the reviewer rather than taken from the author's disclaimer: `patchPackagedProcessPath` seeds all of them at `main-process-preflight.ts:147` before detection, `mergePathSegments` never removes them, and on posix `buildLocalPreflightEnv()` returns `undefined`, so the packaged macOS `PATH` scan reads the seeded env and this fallback is never consulted for those dirs. **Accepted as a disclosed limitation**, not remediable by code on this branch: it is stated in *Scope honesty, stated up front*, in *What is NOT proven*, and in *Follow-up #1*, and **G6 report #3 stays open**. Round 3's verdict named three beneficiary populations as the merge basis — `orca` CLI, unpackaged/dev runs, "and the SSH-host runtime that serves `preflight.detectAgents`". **Round 4 falsified the SSH third of that sentence**, so the merge basis is now `orca` CLI + unpackaged/dev runs + WSL guests.

Round 3 also **confirmed the evidence independently**: it exported `origin/main` with `git archive`, added only the test file, and got 5 failed / 3 passed (8), then 8 passed at HEAD — "the test is not theatre" — and re-derived the ordering safety and the win32/SSH/folder-workspace/remote-wire angles by hand.

Its non-blocking findings drove the third commit (`bcd5948`), all three accepted:
(a) the new docstring's ordering-parity claim was **false across the version-manager/system block boundary** — `claude` in both `~/.local/bin` and `/opt/homebrew/bin` resolves to `~/.local/bin` via the fallback but `/opt/homebrew/bin` via the seeded `PATH`, because `~/.local/bin` comes from `getBaseVersionManagerDirectories`, which leads. The claim is now scoped to *within* the system block and the gap is named, not asserted away; it is left unclosed on purpose, since closing it means hoisting a system dir over a version-manager one (#18234).
(b) the WSL reorder's justification ("a version manager still wins in the guest, as it does natively") was wrong, because a shell glob expands lexicographically while native orders nvm dirs default-alias-first (#10932). Docstring corrected and the move recorded as this file's one behavior change, with its bounds.
(c) the #18234 seed-leak guard asserted only 2 of the 6 new dirs were absent from `getVersionManagerBinPaths`. It now spells out all eight across darwin and linux — spelled out rather than derived from `getSystemCliInstallDirectories`, which would pass vacuously against exactly the refactor it guards.

**Round 4 — 2 blocking, both accepted, neither rebutted.**

1. *The docstring and Follow-up #3 claimed — "verified by enumerating `getTuiAgentDetectionProbeCommands`" — that `~/.vite-plus/bin` maps to no probed agent command.* False, and the repo says so: `src/shared/tui-agent-config.ts:137` defines `pi: { detectCmd: 'pi' }` with no `detectUnsupportedRuntimes`, so `KNOWN_TUI_AGENT_DETECTION_COMMANDS` yields `pi` on every runtime, and `configure-process.ts:155-156` + `configure-process.test.ts:71-73` document `~/.vite-plus/bin` as the Pi installer's location whose absence makes Orca report Pi "Not installed". The branch had added one of the two #829 dirs and skipped the other on a false premise, in the native fallback and the WSL prelude alike. **Fixed in code** (`2666af8`), not by narrowing the claim: `~/.vite-plus/bin` is now in `getSystemCliInstallDirectories` and `POSIX_VERSION_MANAGER_BIN_DIRS`, with a `pi` case in the detection test that goes red against the previous HEAD (evidence above).

2. *The body named "the SSH host runtime that answers `preflight.detectAgents` on the remote side" as a beneficiary and asserted "a remote host runs its own copy of this code".* Neither holds. **Accepted; fixed as a claims defect** — the SSH leg is retracted in *Scope honesty* and replaced by a positive statement of what actually runs there in *Trade-offs → SSH hosts*, with the relay's missing fallback recorded as Follow-up #7. The claim had been imported verbatim from round 3's note rather than re-derived. The shipping beneficiary set is now stated as `orca` CLI invocations with a degraded PATH, plus unpackaged/dev runs, plus WSL guests via the prelude.

Round 4 also **confirmed the evidence independently a second time** (clean `git archive` of `origin/main` + the test file alone: 5 failed / 3 passed of 8; 8/8 at HEAD), re-derived the append-last ordering safety and the `getVersionManagerBinPaths` unreachability by hand, and confirmed `win32` returns `[]`. Its non-blocking findings drove the rest of `2666af8`: the seed-order guard now derives its expected order from `getSystemCliInstallDirectories` inside `configure-process.test.ts` (so reordering *either* list fails, where before both were hardcoded copies); `/snap/bin` + Linuxbrew now gate on `linux` exactly like the seed instead of every non-darwin posix; the `/opt/homebrew`-off-darwin gap is restated without the claim the seed contradicts; and the "lookup-only" paragraph now names the `withCliRuntimeOnPath` prepend exception that the body already disclosed.

**Round 5 — 0 blocking; converged clean. Every attack failed on re-execution, and one non-blocking claim defect was found in this body and is fixed here.**

Round 5 explicitly re-ran the evidence rather than reading it: reverting the production hunks to `origin/main` reproduced **5 failed | 3 passed (8)** byte-matching the quoted output *including the assertion diffs*; restoring gave 8/8; the round-4 `HEAD~1` experiment reproduced **3 failed | 5 passed (8)** with the same `Set{'codex','opencode'}` vs `Set{'codex','opencode','pi'}` diff. Both typechecks exit 0, oxlint on all 5 changed files exits 0, the changed-code quality gate reports 0 findings, and the 7-file / 161-test blast radius passes. A full run of `src/shared src/main/startup src/cli src/main/ipc src/main/preflight src/main/agent-hooks` gave **12,670 passed** with one failure, `src/shared/remote-runtime-shared-control-connection.test.ts:652` — a known load-sensitive `vi.waitFor` flake that passes 28/28 in isolation and lives in a module this diff does not touch. It also strengthened the scope disclaimer independently by reading `v1.4.194` (see *Scope honesty*) and confirmed there is no `Fixes #`/`Closes #`/`Resolves #` keyword in the body or in any of the four commits. I re-ran all of the above myself before publishing this revision; results are quoted verbatim under *Fix evidence*.

Round 5's non-blocking findings, and what happened to each:
1. **Top-ranked — accepted and fixed in this revision.** *The SSH retraction (the round-4 blocking fix) rested on a false premise.* The body argued "the relay is a separate esbuild bundle (`config/tsconfig.relay.json` includes only `../src/relay/**/*` plus two `src/main/pty` files), so it cannot reach this module at all." That inference is invalid — `src/relay` imports `src/shared/*` in ~160 files despite that `include` list, so a tsconfig `include` does not bound esbuild's import graph. This is the same defect class as rounds 1-4: a claim asserted from evidence that does not support it, in a fix for exactly that defect class. The *conclusion* is nonetheless true, and round 5 proved it with a transitive import walk, which I reproduced (884 modules reached from 182 relay files; the resolver is not among them). The bullet now argues from that walk. Its residual risk — nothing guards the property, so a future relay import could silently falsify it with all suites green — is now disclosed in the bullet and tracked as Follow-up #8 rather than left implicit.
2. **The earlier investigation artifact ("live repro") is not valid evidence for report #3** — it simulated a GUI `PATH` with no seed, which no packaged build has. Accepted; it is not cited as support anywhere, and it is now explicitly withdrawn under *What is NOT proven* rather than merely absent.

**Not taken, from earlier rounds, with reasons:**
- **The three-list duplication** (round 4 non-blocking). `configure-process.ts`'s seed, `system-cli-install-dirs.ts`, and `POSIX_VERSION_MANAGER_BIN_DIRS` remain three hand-maintained literals, which is real duplication under AGENTS.md "Reuse Before Reimplementing". Deferred to **Follow-up #5** because the fix is a refactor of a startup-critical PATH seed, not an edit to this diff; the drift it enables is currently caught by the order-parity test in `configure-process.test.ts`, which derives its expectation from `getSystemCliInstallDirectories`.
- **`/opt/homebrew/bin` off darwin** (round 4 non-blocking). Deliberate: a Linux brew install lands in the Linuxbrew prefix, which *is* covered, so the seed's `/opt/homebrew/bin` entry is a phantom stat on Linux. Round 4 correctly noted the seed and the fallback therefore disagree on this one dir; the disagreement is stated in the docstring rather than asserted away, and the residual effect is that a Linux user who manually installed to `/opt/homebrew/bin` is still under-detected by the fallback. Pinned as intended by `agent-cli-install-dir-fallback.test.ts`.
- **Ordering parity across the version-manager/system boundary** (round 3 non-blocking (a)) — **Follow-up #4**. Left open on purpose: closing it means ranking a system dir above a version-manager dir, which is the #18234 defect class.

## Follow-ups

1. **G6 report #3 is not closed by this PR.** "Codex / Cursor / OpenCode all undetected, packaged macOS v1.4.194" still has no established cause. Next step: instrument or obtain a log from a packaged macOS run showing `detectInstalledAgents`' per-command `installedOnPath` result plus the effective `process.env.PATH`, since the seed makes the current hypothesis untestable from telemetry alone.
2. **Windows has no install-dir fallback at all.** `getSystemCliInstallDirectories` returns `[]` on `win32`, and `patchPackagedProcessPath`'s system block is POSIX-only, so `%USERPROFILE%\.opencode\bin` and npm's Windows global prefix have never had coverage in either list. Pre-existing and deliberately unchanged here; worth its own ticket.
3. ~~`~/.vite-plus/bin` is omitted from the fallback list; no probed agent command maps to it.~~ **Withdrawn as false and fixed in `2666af8`.** `pi` is a probed detect command on every runtime (`src/shared/tui-agent-config.ts:137`, no `detectUnsupportedRuntimes`), and `~/.vite-plus/bin` is the Pi installer's default — `configure-process.test.ts:71-73` documents both `~/.opencode/bin` and `~/.vite-plus/bin` as the #829 install locations. Both are now in `getSystemCliInstallDirectories` and `POSIX_VERSION_MANAGER_BIN_DIRS`, pinned by the `pi` case in `reports a system-installed CLI as detected, not just resolved`.
4. **Ordering parity holds inside the system block, not across the boundary above it.** `~/.local/bin` precedes the system dirs in the fallback but follows them in `patchPackagedProcessPath`'s seed, so a CLI installed in both `~/.local/bin` and a Homebrew prefix resolves differently through the two paths. Pre-existing, documented in `system-cli-install-dirs.ts`, and deliberately not closed here — the only fix is to re-rank a version-manager dir against a system one, which is the #18234 defect class.
5. **The three lists are kept in step by convention and a test, not by construction.** `configure-process.ts`'s seed, `system-cli-install-dirs.ts`, and `POSIX_VERSION_MANAGER_BIN_DIRS` are three hand-maintained literals (the two *native* resolvers now share one, `getCliInstallDirectories`, and a derived test checks the guest prelude against the native lists, so drift between native and WSL fails a test rather than shipping — but the seed is still a separate literal). Deriving all three from one source (with per-platform and prepend/append policy as parameters) would remove the whole class of drift these commits fixed.
6. **G6 reports #1, #2 and #4 remain uninvestigated.**
7. **The SSH relay has no install-dir fallback.** `isCommandOnPathForRelay` (`src/relay/preflight-handler.ts:171`) asks a login shell or `where.exe` and stops; if that shell's PATH misses a Homebrew/snap/nix/installer-owned agent, the remote host reports it missing with no backstop. Closing it means either giving the relay bundle its own copy of these dirs or having the client send them — a wire change, so capability-negotiated per `docs/reference/remote-wire-compatibility.md`. Out of scope here; worth its own ticket.
8. **Nothing guards "the relay cannot reach the CLI resolver".** *Trade-offs → SSH hosts* rests on a manual transitive import walk, not a test. A ratchet in the style of `config/scripts/check-runtime-electron-ratchet.mjs` — assert `src/shared/node-cli-command-resolution.ts` is absent from the relay bundle's import graph — would convert it from a claim into an invariant. Until then, a future relay import can falsify that bullet with every suite green.


