### PR TITLE
docs(ssh): document keep-alive-until-reset as the default grace

### DIFF
--- a/docs/site/content/docs/ssh.mdx
+++ b/docs/site/content/docs/ssh.mdx
@@ -49,7 +49,7 @@ Remote worktrees show a chip with live SSH status — green connected, yellow re
 
 ## Sessions across app close
 
-Closing the desktop app no longer kills your remote PTY sessions. Remote terminal sessions are leased through the relay running on the remote host, so they survive Orca closing on your laptop. When you reopen the app and reconnect to the target, leased PTYs are restored to their tabs in the **attached** state, with their scrollback intact. A short grace period (5 minutes by default, configurable per target) gives the relay time to ride out a quick reconnect before tearing down detached sessions.
+Closing the desktop app no longer kills your remote PTY sessions. Remote terminal sessions are leased through the relay running on the remote host, so they survive Orca closing on your laptop. When you reopen the app and reconnect to the target, leased PTYs are restored to their tabs in the **attached** state, with their scrollback intact. By default, remote PTYs stay alive until you **Reset Relay** or **End Remote Terminals**. If **Keep terminals alive until reset** is unchecked, the timeout after disconnect is configurable from 60 seconds to 7 days (the form defaults to 24 hours) before the relay tears down detached sessions.
 
 ## Downloading remote files and folders
 


### PR DESCRIPTION
## ELI5

Public SSH docs said remote terminals die 5 minutes after you close Orca. They do not. By default they stay alive until you reset the relay or end remote terminals. If you turn that off, the form default is 24 hours, not 5 minutes. Following the old figure can make an agent start a second session on work that is still running.

## What Changed

Rewrote the “Sessions across app close” paragraph in `docs/site/content/docs/ssh.mdx` so it matches shipped constants and the SSH target form:

- Default: keep-alive until **Reset Relay** / **End Remote Terminals** (`DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS = 0`).
- If **Keep terminals alive until reset** is unchecked: 60s–7d, form default 24 hours (`DEFAULT_BOUNDED_SSH_RELAY_GRACE_PERIOD_SECONDS`).

Reattach and scrollback wording is unchanged. No localized copies of the 5-minute sentence existed under `docs/site/`. Runtime grace behavior is unchanged.

## Why

Users and agents following `/docs/ssh` treated still-live remote PTYs as dead and started a second agent on the same worktree — the duplicate-over-live-work failure `docs/reference/ssh-execution-boundary.md` exists to prevent. Five minutes matches none of the shipped constants (not MIN 60s, not 24h, not the 3h legacy default).

## Linked Issue

Fixes #18277

## Visual Proof

N/A — docs-only wording change; no UI, layout, or interaction change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Plan 010: no new runtime tests. The docs package has no constant-assertion / markdown-parser pattern, so none was added.

Verification on this branch:

- `rg -n "5 minute" docs/site/content/docs/ssh.mdx` — empty
- `rg -n "5 minute|5-minute|cinco minutos|5 分钟|5分" docs/site` — empty
- `rg "5 minute" docs/site docs/reference/ssh-execution-boundary.md` — no SSH-grace hits
- Confirmed `DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS = 0` and `DEFAULT_BOUNDED_SSH_RELAY_GRACE_PERIOD_SECONDS = 24h` in `src/shared/ssh-types.ts`
- UI copy in `SshHostAdvancedFields` already describes keep-alive-until-reset; public docs now use the same labels
- Drift check vs plan commit `074a2366bf`: `ssh-types.ts` gained unrelated lease fields; grace constants and the ssh.mdx 5-minute sentence still matched the plan’s current-state excerpts

Skipped `pnpm lint` / `pnpm build` / typecheck per plan (docs-only).

Platforms: wording is the same for macOS, Linux, and Windows clients; it describes existing remote SSH relay behavior.

## Review

- **Cross-platform:** docs-only; no keyboard shortcuts, path separators, or native modules.
- **SSH / remote:** aligns public docs with the shipped default (keep-alive-until-reset) so loss of contact is not documented as process death.
- **Security:** no secrets, no new attack surface. Accuracy matters because the old 5-minute claim understated how long remote shells stay live.
- **Performance:** none.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)