### PR TITLE
chore(release): restore RC schedule or stop documenting release-rc.yml

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -110,7 +110,7 @@ All stable kinds (`patch`, `minor`, `major`) are computed off the latest _stable
 - **One-off RC for a feature branch:** `kind=rc`, `ref=<branch-or-sha>`. Produces an RC tag that does not touch `main`.
 - **Minor or major bump:** `kind=minor` or `kind=major`.
 
-The scheduled 2x/day RC cron in [`release-rc.yml`](../../actions/workflows/release-rc.yml) is independent and continues to run automatically from `main`.
+RCs are cut manually via [Actions → Cut Release](../../actions/workflows/release-cut.yml) (`kind=rc`). There is no scheduled RC workflow.
 
 ## Release Channels
 

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -19,6 +19,7 @@ name: Cut Release
 #   7. Build and publish artifacts from the tag.
 
 on:
+  # No schedule: GitHub cron is UTC, so PT 03:00/15:00 cannot hit both PST and PDT without rewriting the window script.
   workflow_dispatch:
     inputs:
       kind:
@@ -243,6 +244,7 @@ jobs:
           slot=$(TZ=America/Los_Angeles date '+%Y-%m-%d-%H')
           echo "value=$slot" >>"$GITHUB_OUTPUT"
 
+      # schedule cannot fire; still sets allowed=true for manual cuts.
       - name: Validate PT release window
         id: window
         env:
@@ -268,6 +270,7 @@ jobs:
           echo "allowed=false" >>"$GITHUB_OUTPUT"
           echo "reason=outside_target_hour:${pt_hour}:${pt_minute}" >>"$GITHUB_OUTPUT"
 
+      # Unused without schedule; kept for a future DST-safe cron.
       - name: Skip if this PT release window already ran
         id: existing
         if: github.event_name == 'schedule' && steps.window.outputs.allowed == 'true'

--- a/docs/site/content/docs/install.mdx
+++ b/docs/site/content/docs/install.mdx
@@ -60,7 +60,7 @@ On first launch Orca will:
 
 ## Updates
 
-Orca auto-updates by default, tracking the **stable** channel. Stable releases are vetted; **RC (release candidate)** builds ship new features first, often daily.
+Orca auto-updates by default, tracking the **stable** channel. Stable releases are vetted; **RC (release candidate)** builds ship new features first and are cut manually by maintainers.
 
 On Linux, whether Orca can apply an update itself depends on which package you installed. See [Linux](#linux) before you pick one.
 


### PR DESCRIPTION
## ELI5

CONTRIBUTING still pointed at a scheduled RC workflow that no longer exists. GitHub cron is UTC-only, so we cannot hit PT 03:00 and 15:00 in both PST and PDT without rewriting the window script. This PR documents that RCs are cut manually and stops promising automatic daily RCs.

## What Changed

- Stop linking the deleted `release-rc.yml` in `.github/CONTRIBUTING.md`. RCs are cut manually via Actions → Cut Release (`kind=rc`).
- Comment in `.github/workflows/release-cut.yml` that `schedule:` is omitted because a DST-safe cron cannot pass the existing PT 03/15 window check, and mark the schedule-only steps as unused.
- Update `docs/site/content/docs/install.mdx` so RC builds are not described as shipping “often daily.”

## Why

Plan 011 / #18278: incomplete cutover. CONTRIBUTING documented a 2×/day cron in `release-rc.yml`, but that workflow file is absent. Cut Release is `workflow_dispatch` only; its PT window/idempotency steps can never fire. Restoring `schedule:` with `0 10,22 * * *` would skip all winter (PST) slots unless the window script is rewritten.

**STOP condition honored (docs-only):** DST-safe cron cannot be expressed without rewriting the window script. Did not enable `schedule:`. Did not recreate `release-rc.yml`.

## Linked Issue

Fixes #18278

## Visual Proof

N/A (no visual change) — docs and workflow comments only.

## Testing

No application tests (plan: none). Plan verifications:

- `test ! -f .github/workflows/release-rc.yml && echo absent` → `absent`
- `rg release-rc.yml` in `.github/CONTRIBUTING.md` → empty
- PyYAML not installed; YAML parse skipped per plan
- `on:` remains `workflow_dispatch` only; job `if: github.repository == 'stablyai/orca'` unchanged
- `kind` default remains `rc` for manual cuts

Platforms: N/A (docs/workflow comments; no runtime code). SSH: N/A.

- [x] I manually tested these changes locally (plan file/rg checks)
- [x] Automated tests added/updated, or explained why not below

No application tests: this is documentation plus comments on already-dead schedule branches.

## Review

- **Cross-platform (macOS / Linux / Windows):** no app code, shortcuts, or path logic. Docs describe GitHub Actions, which is host-independent.
- **SSH / remote / local:** no execution-host, process, or wire changes.
- **Security:** did not enable `schedule:` (would otherwise run on forks if the repo guard were missing). Existing `if: github.repository == 'stablyai/orca'` is unchanged. No secrets in the diff.
- **Performance:** none.
- **Git provider:** GitHub Actions docs only; no GitLab/source-control behavior change.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

DST-safe cron cannot hit PT 03:00/15:00 in both PST and PDT without rewriting the window script, so this is the plan’s docs-only option. `plans/README.md` was not updated in this PR (operator: do not commit files under `plans/`).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)