### PR TITLE
Treat domain paths as URLs, not new files

### DIFF
--- a/src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts
@@ -46,6 +46,58 @@ describe('tab create entry classification', () => {
     })
   })
 
+  it('treats domain paths as URLs instead of new files', () => {
+    expect(classifyTabEntryQuery('example.com/profile', readyFiles([]))).toEqual({
+      kind: 'host-url',
+      url: 'https://example.com/profile'
+    })
+    expect(classifyTabEntryQuery('example.com/docs?tab=api#install', readyFiles([]))).toEqual({
+      kind: 'host-url',
+      url: 'https://example.com/docs?tab=api#install'
+    })
+    expect(classifyTabEntryQuery('assistant.ai/profile', readyFiles([]))).toEqual({
+      kind: 'host-url',
+      url: 'https://assistant.ai/profile'
+    })
+  })
+
+  it('keeps source paths and unlisted suffixes as files', () => {
+    expect(
+      classifyTabEntryQuery('example.com/profile', readyFiles(['example.com/profile']))
+    ).toEqual({
+      kind: 'existing-file',
+      matchKind: 'exact-path',
+      relativePath: 'example.com/profile'
+    })
+    expect(
+      getTabEntryOptions('example.com/profile', readyFiles(['example.com/profile'])).map(
+        (option) => option.classification
+      )
+    ).toEqual([
+      { kind: 'existing-file', matchKind: 'exact-path', relativePath: 'example.com/profile' },
+      { kind: 'host-url', url: 'https://example.com/profile' }
+    ])
+    expect(classifyTabEntryQuery('README.md/archive', readyFiles([]))).toEqual({
+      kind: 'new-file',
+      relativePath: 'README.md/archive'
+    })
+    expect(classifyTabEntryQuery('config.local/settings', readyFiles([]))).toEqual({
+      kind: 'new-file',
+      relativePath: 'config.local/settings'
+    })
+    expect(classifyTabEntryQuery('example.test/settings', readyFiles([]))).toEqual({
+      kind: 'new-file',
+      relativePath: 'example.test/settings'
+    })
+  })
+
+  it('accepts any public suffix without a local allowlist', () => {
+    expect(classifyTabEntryQuery('example.museum/exhibit', readyFiles([]))).toEqual({
+      kind: 'host-url',
+      url: 'https://example.museum/exhibit'
+    })
+  })
+
   it('opens local-dev URLs with root suffixes as browser tabs', () => {
     expect(classifyTabEntryQuery('localhost:3000/', readyFiles([]))).toEqual({
       kind: 'host-url',

--- a/src/renderer/src/components/tab-bar/tab-create-entry-url-classification.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-entry-url-classification.ts
@@ -1,4 +1,5 @@
 import { translate } from '@/i18n/i18n'
+import { isValid as isListedDomain } from 'psl'
 import { classifySchemeLessLocalDevAddress } from '../../../../shared/browser-url'
 
 const HOST_FILE_EXTENSIONS = new Set([
@@ -54,12 +55,17 @@ function parseHttpUrl(query: string): ExplicitUrlClassification {
 }
 
 function splitHostCandidate(query: string): { host: string; port: string | null } | null {
-  if (/[\\/\s?#]/.test(query)) {
+  if (/[\\\s]/.test(query)) {
     return null
   }
-  const colonIndex = query.indexOf(':')
-  const host = colonIndex === -1 ? query : query.slice(0, colonIndex)
-  const port = colonIndex === -1 ? null : query.slice(colonIndex + 1)
+
+  // Keep the authority separate from the path/query/hash so domain URLs remain
+  // navigations; known source extensions are excluded and exact files win later.
+  const authorityEnd = query.search(/[/?#]/)
+  const authority = authorityEnd === -1 ? query : query.slice(0, authorityEnd)
+  const colonIndex = authority.indexOf(':')
+  const host = colonIndex === -1 ? authority : authority.slice(0, colonIndex)
+  const port = colonIndex === -1 ? null : authority.slice(colonIndex + 1)
   const extension = host.split('.').pop()?.toLowerCase() ?? ''
   if (HOST_FILE_EXTENSIONS.has(extension)) {
     return null
@@ -67,7 +73,7 @@ function splitHostCandidate(query: string): { host: string; port: string | null 
   if (
     host.toLowerCase() !== 'localhost' &&
     !IPV4_PATTERN.test(host) &&
-    !DOMAIN_PATTERN.test(host)
+    (!DOMAIN_PATTERN.test(host) || (authorityEnd !== -1 && !isListedDomain(host)))
   ) {
     return null
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## Problem

When users type paths like `example.com/profile` into the tab entry field, Orca incorrectly treats them as new file paths to create, rather than recognizing them as URLs to open in a browser.

## Solution

Modified the URL classifier to recognize domain paths (with a valid public suffix from the Public Suffix List) as URLs instead of new files. When a query contains a domain name followed by a path/query/hash, it's treated as a URL navigation. Existing files and paths with unlisted suffixes continue to be treated as files, ensuring no regression.

## Testing

- [x] Automated tests added/updated

Added comprehensive test cases covering:
- Domain paths treated as URLs (example.com/profile, assistant.ai/profile, example.museum/exhibit)
- Query strings and fragments preserved (example.com/docs?tab=api#install)
- Existing files take precedence over URL interpretation
- Paths with unlisted suffixes remain as new files (README.md/archive, config.local/settings, example.test/settings)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason: N/A — behavior change only, no visual changes
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A): N/A — client-side URL classification, no platform dependencies
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)