### PR TITLE
fix(deps): bump electron to 43.5.1 for GHSA-qmv3

### DIFF
--- a/config/scripts/shared-electron-dist-cache.test.ts
+++ b/config/scripts/shared-electron-dist-cache.test.ts
@@ -22,7 +22,7 @@ import {
 } from './shared-electron-dist-cache.mjs'
 import { makeTreeReadOnly } from './space-sharing-copy.mjs'
 
-const VERSION = '43.4.1'
+const VERSION = '43.5.1'
 const PLATFORM_PATH = path.join('Electron.app', 'Contents', 'MacOS', 'Electron')
 const identity = { version: VERSION, platformPath: PLATFORM_PATH }
 const roots: string[] = []
@@ -71,7 +71,7 @@ describe('resolveSharedElectronDistEntry', () => {
     const entry = resolveSharedElectronDistEntry(baseOptions)
     expect(entry?.cacheRoot).toBe(path.join('/repo/.git', 'orca-cache', 'electron'))
     expect(entry?.entryPath).toBe(
-      path.join('/repo/.git', 'orca-cache', 'electron', '43.4.1-darwin-arm64')
+      path.join('/repo/.git', 'orca-cache', 'electron', `${VERSION}-darwin-arm64`)
     )
     expect(entry?.markerPath).toBe(path.join('/repo/node_modules/electron', '.orca-shared-dist'))
   })
@@ -136,7 +136,7 @@ describe('publishSharedElectronDist', () => {
     const entry = makeEntry(root)
     const dist = writeDist(path.join(root, 'dist'))
     const share = vi.fn((source: string, destination: string) => {
-      expect(path.basename(destination)).toMatch(/^43\.4\.1-darwin-arm64\.staging-/)
+      expect(path.basename(destination)).toMatch(/^43\.5\.1-darwin-arm64\.staging-/)
       writeDist(destination)
       expect(source).toBe(dist)
     })

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "dompurify": "^3.4.13",
-    "electron": "^43.4.1",
+    "electron": "43.5.1",
     "electron-builder": "^26.15.3",
     "electron-builder-squirrel-windows": "^26.15.3",
     "electron-vite": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,10 +123,10 @@ importers:
     dependencies:
       '@electron-toolkit/preload':
         specifier: ^3.0.2
-        version: 3.0.2(electron@43.4.1(supports-color@7.2.0))
+        version: 3.0.2(electron@43.5.1(supports-color@7.2.0))
       '@electron-toolkit/utils':
         specifier: ^4.0.0
-        version: 4.0.0(electron@43.4.1(supports-color@7.2.0))
+        version: 4.0.0(electron@43.5.1(supports-color@7.2.0))
       '@floating-ui/dom':
         specifier: 1.7.6
         version: 1.7.6
@@ -345,8 +345,8 @@ importers:
         specifier: ^3.4.13
         version: 3.4.13
       electron:
-        specifier: ^43.4.1
-        version: 43.4.1(supports-color@7.2.0)
+        specifier: 43.5.1
+        version: 43.5.1(supports-color@7.2.0)
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
@@ -4303,8 +4303,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.4.1:
-    resolution: {integrity: sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA==}
+  electron@43.5.1:
+    resolution: {integrity: sha512-lRHSwzZimdWWeqcTHFRCpicWwxBE6kotKIyGTusums/jvmVVC27rLPFikUz8LsLwV7gVWlYaiEYQAWzitbN6nA==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -7272,17 +7272,17 @@ snapshots:
 
   '@electron-internal/extract-zip@1.0.4': {}
 
-  '@electron-toolkit/preload@3.0.2(electron@43.4.1(supports-color@7.2.0))':
+  '@electron-toolkit/preload@3.0.2(electron@43.5.1(supports-color@7.2.0))':
     dependencies:
-      electron: 43.4.1(supports-color@7.2.0)
+      electron: 43.5.1(supports-color@7.2.0)
 
   '@electron-toolkit/tsconfig@2.0.0(@types/node@25.9.5)':
     dependencies:
       '@types/node': 25.9.5
 
-  '@electron-toolkit/utils@4.0.0(electron@43.4.1(supports-color@7.2.0))':
+  '@electron-toolkit/utils@4.0.0(electron@43.5.1(supports-color@7.2.0))':
     dependencies:
-      electron: 43.4.1(supports-color@7.2.0)
+      electron: 43.5.1(supports-color@7.2.0)
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -10604,7 +10604,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.4.1(supports-color@7.2.0):
+  electron@43.5.1(supports-color@7.2.0):
     dependencies:
       '@electron-internal/extract-zip': 1.0.4
       '@electron/get': 5.0.0(supports-color@7.2.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,11 @@ packages: []
 minimumReleaseAge: 4320
 # 6.3.289 was published 2026-08-29T12:48Z; it clears the 3-day gate on 2026-09-01T12:48Z.
 # zod 4.5.4 was published 2026-08-29T17:55Z; it clears the 3-day gate on 2026-09-01T17:55Z.
+# electron 43.5.1 was published 2026-09-01T18:13Z; GHSA-qmv3 patch, clears the 3-day gate on 2026-09-04T18:13Z.
 minimumReleaseAgeExclude:
   - pdfjs-dist@6.3.289
   - zod@4.5.4
+  - electron@43.5.1
 shamefullyHoist: true
 
 supportedArchitectures:


### PR DESCRIPTION
## ELI5

Electron had a High security bug: a compromised webpage could poison the sandboxed preload cache and run its own code later. We were on 43.4.1, which is in the affected range. This PR moves us to 43.5.1, which already includes the fix.

## What Changed

- Pin `devDependencies.electron` from `^43.4.1` to exact `43.5.1` (latest 43.x; npm has no 43.4.2).
- Refresh `pnpm-lock.yaml` so it resolves 43.5.1.
- Add `electron@43.5.1` to `minimumReleaseAgeExclude` with a GHSA-qmv3 comment — 43.5.1 was published 2026-09-01 and is still inside the 3-day gate.
- Update the shared Electron dist-cache test `VERSION` pin (and the staging-path regex) to 43.5.1.

Did not change `webPreferences`, sandbox, webviewTag, updater signing, or native ABI beyond what `pnpm install` / postinstall already rebuilds.

## Why

[GHSA-qmv3-fv6v-rmhq](https://github.com/electron/electron/security/advisories/GHSA-qmv3-fv6v-rmhq) (High): sandboxed preload code cache did not verify the cached entry matched the preload. Affected: `>= 43.0.0-beta.1, < 43.4.2`. Patched: 43.4.2 / 42.10.0 / 44.0.0-beta.6. 43.4.2 is unpublished on npm; 43.5.1 is the latest 43 line that includes the patch. This app sets `preload` + `sandbox: true` + `webviewTag: true` (untrusted browser guests), so it is in the affected class.

## Linked Issue

Fixes #18270

## Visual Proof

N/A — no visual or interaction change. Dependency bump only.

## Testing

- `npm view electron@43 version` — latest 43.x is 43.5.1; 43.4.2 404s.
- `pnpm install` — exit 0; `node -e "console.log(require('electron/package.json').version)"` prints `43.5.1`; `pnpm exec electron --version` prints `v43.5.1`.
- `pnpm test config/scripts/shared-electron-dist-cache.test.ts` — 22 passed.
- `pnpm test src/main/updater.startup-scheduling.test.ts` — 10 passed, including “does not disable Windows Authenticode verification on win32” and “does not override verifyUpdateCodeSignature on non-Windows platforms”.
- `pnpm tc` — exit 0.
- `pnpm run check:code-quality:changed` — 0 new findings.

Platforms actually exercised locally: macOS arm64 (install + native postinstall rebuild + the tests above). Linux / Windows / SSH: not run here; Electron 43.5.1 is a 43-line patch/minor and `supportedArchitectures` already lists darwin/linux/win32 x64/arm64. CI should cover the other OS natives.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Dist-cache `VERSION` pin and staging-path regex updated to 43.5.1. No new e2e (suite is red on main, #11149).

## AI Disclosure

Internal contributor — ignore.

## Review

- **Cross-platform:** Electron 43.5.1 stays on the 43 line (no 44 major). Native rebuild succeeded on this macOS arm64 machine via postinstall. `supportedArchitectures` already lists darwin/linux/win32 x64/arm64. No hardcoded `metaKey`, path separators, or platform-only Electron APIs.
- **SSH / remote:** No change to execution-host routing, process listing, or remote wire. This is a desktop Chromium/Electron preload-cache CVE. Loss of SSH contact is still not evidence of process death.
- **Security:** This is the GHSA-qmv3 fix. Sandbox/preload/webviewTag remain on. No `verifyUpdateCodeSignature` override. Age-gate exclude is version-exact (`electron@43.5.1`) with a named advisory comment.
- **Performance:** No app-code change. Shared dist cache keys by the new version string, so worktrees will populate a 43.5.1 cache entry on first install.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
