### PR TITLE
fix(persistence): keep failed session writes dirty until they succeed

### DIFF
--- a/src/main/persistence-loading-store-write-risks.test.ts
+++ b/src/main/persistence-loading-store-write-risks.test.ts
@@ -136,4 +136,28 @@ describe('loading Store write-risk characterization', () => {
     }
     expect(persisted.sshPtyConsumerRecoveries[0]?.clientInstanceId).toBe('client-1')
   })
+
+  it('rejects waitForPendingWrite when a debounced primary write fails, then persists a later flush', async () => {
+    const store = await createStore()
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {})
+    writeControl.failPrimaryOpen = true
+    store.updateUI({ sidebarWidth: 714 })
+    vi.advanceTimersByTime(1_000)
+
+    try {
+      await expect(store.waitForPendingWrite()).rejects.toThrow('profile mount rejected write')
+
+      writeControl.failPrimaryOpen = false
+      store.updateUI({ sidebarWidth: 715 })
+      vi.advanceTimersByTime(1_000)
+      await store.waitForPendingWrite()
+    } finally {
+      errors.mockRestore()
+    }
+
+    const persisted = JSON.parse(readFileSync(join(testState.dir, 'orca-data.json'), 'utf-8')) as {
+      ui: { sidebarWidth: number }
+    }
+    expect(persisted.ui.sidebarWidth).toBe(715)
+  })
 })

--- a/src/main/persistence/loading-store/primary-state-writes.ts
+++ b/src/main/persistence/loading-store/primary-state-writes.ts
@@ -116,21 +116,23 @@ export class PrimaryStateWriteOperations {
 }
 
 export function enqueueWrite(owner: PrimaryStateWriteOperations): Promise<void> {
+  const pendingWrite = owner[primaryStateWriteOperationsContext].runtime.pendingWrite
   const previousWrite = Promise.all([
-    owner[primaryStateWriteOperationsContext].runtime.pendingWrite ??
-      owner[primaryStateWriteOperationsContext].runtime.staleTempCleanup,
+    pendingWrite
+      ? pendingWrite.catch(() => {})
+      : owner[primaryStateWriteOperationsContext].runtime.staleTempCleanup,
     owner[primaryStateWriteOperationsContext].runtime.pendingSnapshotFileWork ?? Promise.resolve()
   ]).then(() => {})
   const write = previousWrite.then(() => writeToDiskAsync(owner))
-  const trackedWrite = write
-    .catch((err) => {
-      console.error('[persistence] Failed to write state:', err)
-    })
-    .finally(() => {
-      if (owner[primaryStateWriteOperationsContext].runtime.pendingWrite === trackedWrite) {
-        owner[primaryStateWriteOperationsContext].runtime.pendingWrite = null
-      }
-    })
+  const trackedWrite = write.finally(() => {
+    if (owner[primaryStateWriteOperationsContext].runtime.pendingWrite === trackedWrite) {
+      owner[primaryStateWriteOperationsContext].runtime.pendingWrite = null
+    }
+  })
+  // Why: waiters still see the rejection; this only logs and marks it handled if nobody is awaiting.
+  void trackedWrite.catch((err) => {
+    console.error('[persistence] Failed to write state:', err)
+  })
   owner[primaryStateWriteOperationsContext].runtime.pendingWrite = trackedWrite
   return write
 }

--- a/src/main/persistence/loading-store/write-scheduling.ts
+++ b/src/main/persistence/loading-store/write-scheduling.ts
@@ -59,7 +59,8 @@ export function scheduleSave(owner: WriteSchedulingOperations): void {
   owner[writeSchedulingOperationsContext].runtime.writeTimer = setTimeout(() => {
     owner[writeSchedulingOperationsContext].runtime.writeTimer = null
     owner[writeSchedulingOperationsContext].runtime.firstPendingSaveAt = null
-    void enqueueWrite(owner[writeSchedulingOperationsContext].writes)
+    // Why: pendingWrite already rejects for waiters; this only silences the debounce caller.
+    void enqueueWrite(owner[writeSchedulingOperationsContext].writes).catch(() => {})
   }, delay)
 }
 


### PR DESCRIPTION
## ELI5

If Orca cannot save `orca-data.json` (disk full, I/O error, missing profile mount), it used to log the error and then pretend the save finished. Quit and later flushes thought the disk was up to date. Now a failed save stays failed until a later write actually succeeds.

## What Changed

- `enqueueWrite` no longer `.catch`es `writeToDiskAsync` into a resolved `pendingWrite`. Waiters of `waitForPendingWrite` see the rejection.
- A side-channel `.catch` still logs `[persistence] Failed to write state:` without swallowing the tracked promise.
- `scheduleSave`'s fire-and-forget `void enqueueWrite(...)` attaches an empty `.catch` so the debounce caller does not create unhandled-rejection noise.
- A later `enqueueWrite` still runs after a failed prior write (`pendingWrite.catch` only on the previous write, not on stale temp cleanup).
- `flushOrThrow` is unchanged and still writes when `quitFlushStarted` is false; failed async writes do not set `lastWrittenStateHash`, so retries are not short-circuited.
- Characterization test: a failed debounced primary write rejects `waitForPendingWrite`, then a later successful mutation persists.

## Why

Debounced session writes caught errors, logged `console.error`, and cleared `pendingWrite`. `waitForPendingWrite` then saw a fulfilled promise and treated the flush as done. After EIO / disk-full / a missing profile mount, in-memory tabs, SSH recovery records, and settings could be ahead of `orca-data.json`. A crash or quit after that lost the state.

## Linked Issue

Fixes #18271

## Visual Proof

N/A — no visual or interaction change. This is main-process persistence write accounting only.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Plan 004 verification (macOS):

- `pnpm test src/main/persistence-loading-store-write-risks.test.ts` — 3 passed (new case failed on current code, then passed after the fix)
- `pnpm test src/main/persistence-flush-and-save-scheduling.test.ts` — 17 passed
- `pnpm test src/main/quit-path-durable-write-blocking.test.ts src/main/persistence-async-write-syscalls.test.ts` — 44 passed
- `pnpm tc:node` — exit 0
- `pnpm run check:code-quality:changed` — exit 0

No live disk-full / EIO quit was run. Full `pnpm lint` / `pnpm build` left to CI per the plan.

## Review

- **Cross-platform**: no path, shortcut, or `metaKey` changes. Writes still go through existing `path` / durable-file helpers (`path.join` in tests). Same `orca-data.json` tmp+rename on macOS, Linux, and Windows.
- **SSH/remote**: control-plane state lives on the client machine even for SSH worktrees. No RPC / stream / wire change (`docs/reference/remote-wire-compatibility.md`). No execution-host substitution (`docs/reference/ssh-execution-boundary.md`). Failed client-side session writes no longer look successful to waiters.
- **Security**: the log is the existing `console.error` of the fs error object, not the persisted payload. No secrets added to the diff.
- **Performance**: one extra `.catch` per write for logging / unhandled-rejection hygiene. No extra I/O.
- **GitLab**: N/A (no provider-specific git/review behavior).
- **STOP check**: `waitForPendingWrite` is not awaited from a UI path (tests only). Production quit uses `flushAsync()`, which already `.catch`es. Write pipeline excerpts still matched `074a2366bf`.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Local: plan verification commands above. Full `pnpm lint` / `pnpm build` left to CI per plan.