### PR TITLE
test(wsl): run contained-delete script under sh in Linux CI

### DIFF
--- a/src/main/wsl-contained-delete.script.test.ts
+++ b/src/main/wsl-contained-delete.script.test.ts
@@ -1,0 +1,120 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { runProcess } from '../shared/child-process/run-process'
+import { containedDeleteCommand } from './wsl-contained-delete'
+
+const DISTRO = 'Ubuntu'
+
+function parseLinuxAsWsl(path: string): { distro: string; linuxPath: string } | null {
+  return path.startsWith('/') ? { distro: DISTRO, linuxPath: path } : null
+}
+
+// Script walks /proc/self/cwd and GNU stat -Lc; macOS has neither.
+describe.skipIf(process.platform !== 'linux')('WSL contained-delete script under sh', () => {
+  let fixtureRoot = ''
+
+  afterEach(() => {
+    if (fixtureRoot === '') {
+      return
+    }
+    const tmpRoot = realpathSync(tmpdir())
+    if (fixtureRoot === tmpRoot || !fixtureRoot.startsWith(`${tmpRoot}/`)) {
+      throw new Error(`refusing to clean unexpected fixture ${fixtureRoot}`)
+    }
+    rmSync(fixtureRoot, { recursive: true, force: true })
+    fixtureRoot = ''
+  })
+
+  function makeFixture(): { approvedRoot: string; outsideRoot: string } {
+    fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), 'orca-wsl-contained-delete-')))
+    const approvedRoot = join(fixtureRoot, 'root')
+    const outsideRoot = join(fixtureRoot, 'outside')
+    mkdirSync(approvedRoot)
+    mkdirSync(outsideRoot)
+    return { approvedRoot, outsideRoot }
+  }
+
+  async function runContainedDelete(targetPath: string, approvedRoot: string, recursive: boolean) {
+    const command = containedDeleteCommand(
+      { distro: DISTRO, linuxPath: targetPath },
+      [approvedRoot],
+      parseLinuxAsWsl,
+      recursive
+    )
+    expect(command).not.toBeNull()
+    const [program, ...args] = command ?? []
+    expect(program).toBe('sh')
+    return runProcess({ program, args, timeoutMs: 10_000 })
+  }
+
+  it('deletes an approved directory leaf', async () => {
+    const { approvedRoot, outsideRoot } = makeFixture()
+    const leaf = join(approvedRoot, 'a', 'b')
+    mkdirSync(leaf, { recursive: true })
+    writeFileSync(join(leaf, 'file.txt'), 'inside')
+    const survivor = join(outsideRoot, 'survivor')
+    writeFileSync(survivor, 'keep')
+
+    const result = await runContainedDelete(leaf, approvedRoot, true)
+
+    expect(result.timedOut).toBe(false)
+    expect(result.code).toBe(0)
+    expect(result.stderr).toBe('')
+    expect(existsSync(leaf)).toBe(false)
+    expect(existsSync(join(approvedRoot, 'a'))).toBe(true)
+    expect(existsSync(survivor)).toBe(true)
+  })
+
+  it('rejects a file when the expected kind is directory', async () => {
+    const { approvedRoot } = makeFixture()
+    const leaf = join(approvedRoot, 'a', 'leaf')
+    mkdirSync(join(approvedRoot, 'a'), { recursive: true })
+    writeFileSync(leaf, 'file')
+
+    const result = await runContainedDelete(leaf, approvedRoot, true)
+
+    expect(result.timedOut).toBe(false)
+    expect(result.code).toBe(65)
+    expect(result.stderr).toContain('ORCA_WSL_DELETE_REJECT:kind')
+    expect(existsSync(leaf)).toBe(true)
+  })
+
+  it('rejects a symlink that escapes the approved root', async () => {
+    const { approvedRoot, outsideRoot } = makeFixture()
+    const outsideLeaf = join(outsideRoot, 'b')
+    mkdirSync(outsideLeaf, { recursive: true })
+    writeFileSync(join(outsideLeaf, 'secret'), 'protected')
+    symlinkSync(outsideRoot, join(approvedRoot, 'a'))
+
+    const result = await runContainedDelete(join(approvedRoot, 'a', 'b'), approvedRoot, true)
+
+    expect(result.timedOut).toBe(false)
+    expect(result.code).toBe(65)
+    expect(result.stderr).toContain('ORCA_WSL_DELETE_REJECT:symlink')
+    expect(existsSync(outsideLeaf)).toBe(true)
+    expect(existsSync(join(outsideLeaf, 'secret'))).toBe(true)
+  })
+
+  it('is a no-op when the leaf is already missing', async () => {
+    const { approvedRoot } = makeFixture()
+    mkdirSync(join(approvedRoot, 'a'), { recursive: true })
+    const missing = join(approvedRoot, 'a', 'gone')
+
+    const result = await runContainedDelete(missing, approvedRoot, true)
+
+    expect(result.timedOut).toBe(false)
+    expect(result.code).toBe(0)
+    expect(existsSync(join(approvedRoot, 'a'))).toBe(true)
+    expect(existsSync(missing)).toBe(false)
+  })
+})


### PR DESCRIPTION
## ELI5

The WSL contained-delete helper is a real `sh` program that walks approved roots then deletes one leaf. Default tests only check the argv we would pass to `wsl.exe`; they never run the script. This PR runs that script under `sh` on Linux CI so a broken kind/symlink/missing-leaf path fails the unit shard instead of shipping green.

## What Changed

- Added `src/main/wsl-contained-delete.script.test.ts`.
- The test builds production argv via `containedDeleteCommand`, then `runProcess`s `sh` with that argv (no `shell: true`, no mocked `execFile`).
- Cases: happy-path directory delete, kind mismatch (exit 65 / `ORCA_WSL_DELETE_REJECT:kind`), intermediate symlink escape (`ORCA_WSL_DELETE_REJECT:symlink`, outside leaf survives), missing leaf (exit 0 no-op).
- `describe.skipIf(process.platform !== 'linux')` — the script uses `/proc/self/cwd`, `/proc/self/fd`, and GNU `stat -Lc`, which Darwin and Windows do not provide. Ubuntu unit shards still run it. Existing `wsl-unc-delete.test.ts` argv tests are unchanged.

## Why

PR unit tests run on `ubuntu-latest`. Mocked `execFile` cannot catch a regression in `WSL_CONTAINED_DELETE_SCRIPT`. The script is generic POSIX aside from Linux `/proc` + GNU `stat`, so Linux CI can execute it without `wsl.exe` or `ORCA_REAL_WSL_DELETE_TEST`.

## Linked Issue

Fixes #18284

## Visual Proof

N/A (no visual change). Tests only; no UI, layout, or renderer change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verification:

- `pnpm test src/main/wsl-contained-delete.script.test.ts` — 4 skipped on Darwin (linux-only gate)
- `pnpm test src/main/wsl-unc-delete.test.ts` — 9 passed
- `pnpm tc:node` — exit 0
- `pnpm run check:code-quality:changed` — 0 findings
- Linux Docker (`node:22-bookworm`): the same four cases via `containedDeleteCommand` + `sh` all passed (`happy path`, `kind`, `symlink`, `missing leaf`)

Platforms: macOS (skip path) and Linux (Docker, `/proc` + GNU `stat`). Windows skipped by the linux-only gate. SSH not exercised; this is a local CI characterization of a POSIX script.

## AI Disclosure

## Review

- **Cross-platform**: Tests run only on Linux. Windows and macOS skip. Host fixture paths use `path.join`; `containedDeleteCommand` still emits POSIX components. Spawn goes through `runProcess` (`shell: false`, program `sh`). No `metaKey`.
- **SSH / remote**: No wire, RPC, or execution-host change. The production script still runs inside WSL on Windows; this only executes it under `sh` in Linux CI. Loss of contact is not involved.
- **Security**: Script body is unchanged. Fixtures live under a unique `os.tmpdir()` directory; cleanup refuses paths outside that tmp root. The symlink case asserts an outside leaf is not deleted. Tests never `rm -rf /` and never target the approved root itself (`containedDeleteCommand` returns null for that).
- **Performance**: Four short `sh` invocations with a 10s timeout; no extra CI workflow.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Did not change `WSL_CONTAINED_DELETE_SCRIPT`. Did not enable `ORCA_REAL_WSL_DELETE_TEST` on Windows CI. Did not commit `plans/`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)