### PR TITLE
fix(cleanup): route workspace cleanup by resolved execution host, not repo connectionId

### DIFF
--- a/src/main/ipc/workspace-cleanup-activity.test.ts
+++ b/src/main/ipc/workspace-cleanup-activity.test.ts
@@ -2,17 +2,11 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
-import type { Repo } from '../../shared/repo-types'
 import type { Worktree } from '../../shared/worktree/types'
 import { resolveWorkspaceCleanupActivityWorktree } from './workspace-cleanup-activity'
+import type { WorkspaceCleanupGitRoute } from './workspace-cleanup-git-route'
 
-const REPO: Repo = {
-  id: 'repo-1',
-  path: '/repo',
-  displayName: 'Repo',
-  badgeColor: '#000',
-  addedAt: 1
-}
+const LOCAL_ROUTE: WorkspaceCleanupGitRoute = { kind: 'local', hostId: 'local' }
 
 function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
   return {
@@ -51,7 +45,11 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
       mtimeMs: targetPath.endsWith('.git') ? 20_000 : 10_000
     }))
 
-    const worktree = await resolveWorkspaceCleanupActivityWorktree(REPO, makeWorktree(), statPath)
+    const worktree = await resolveWorkspaceCleanupActivityWorktree(
+      LOCAL_ROUTE,
+      makeWorktree(),
+      statPath
+    )
 
     expect(statPath).toHaveBeenCalledWith('/repo-feature')
     expect(statPath).toHaveBeenCalledWith(path.join('/repo-feature', '.git'))
@@ -76,7 +74,7 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     const readTextFile = vi.fn(async () => `gitdir: ${gitDirPath}\n`)
 
     const worktree = await resolveWorkspaceCleanupActivityWorktree(
-      REPO,
+      LOCAL_ROUTE,
       makeWorktree(),
       statPath,
       readTextFile
@@ -104,7 +102,7 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     const readTextFile = vi.fn(async () => `gitdir: ${gitDirPath}\n`)
 
     const worktree = await resolveWorkspaceCleanupActivityWorktree(
-      REPO,
+      LOCAL_ROUTE,
       makeWorktree(),
       statPath,
       readTextFile
@@ -131,7 +129,7 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     )
 
     const worktree = await resolveWorkspaceCleanupActivityWorktree(
-      REPO,
+      LOCAL_ROUTE,
       makeWorktree(),
       statPath,
       readTextFile
@@ -160,7 +158,7 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
       const statPath = vi.fn(async () => ({ mtimeMs: 10_000 }))
 
       const worktree = await resolveWorkspaceCleanupActivityWorktree(
-        REPO,
+        LOCAL_ROUTE,
         makeWorktree({ path: worktreePath }),
         statPath
       )
@@ -179,7 +177,7 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     )
 
     const worktree = await resolveWorkspaceCleanupActivityWorktree(
-      REPO,
+      LOCAL_ROUTE,
       makeWorktree(),
       statPath,
       readTextFile
@@ -197,7 +195,7 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     const readTextFile = vi.fn(async () => 'gitdir: .repo/gitdir\n')
 
     const worktree = await resolveWorkspaceCleanupActivityWorktree(
-      REPO,
+      LOCAL_ROUTE,
       makeWorktree(),
       statPath,
       readTextFile
@@ -224,7 +222,7 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     const readTextFile = vi.fn(async () => 'gitdir: /home/me/repo/.git/worktrees/repo-feature\n')
 
     const worktree = await resolveWorkspaceCleanupActivityWorktree(
-      REPO,
+      LOCAL_ROUTE,
       makeWorktree({ path: worktreePath }),
       statPath,
       readTextFile
@@ -252,7 +250,7 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
       )
 
       const worktree = await resolveWorkspaceCleanupActivityWorktree(
-        REPO,
+        LOCAL_ROUTE,
         makeWorktree({ path: String.raw`C:\Users\me\repo-feature` }),
         statPath,
         readTextFile
@@ -283,7 +281,7 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     const statPath = vi.fn(async () => ({ mtimeMs: 10_000 }))
 
     const worktree = await resolveWorkspaceCleanupActivityWorktree(
-      REPO,
+      LOCAL_ROUTE,
       makeWorktree({ lastActivityAt: 30_000 }),
       statPath
     )
@@ -295,7 +293,7 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     const statPath = vi.fn(async () => ({ mtimeMs: 20_000 }))
 
     const worktree = await resolveWorkspaceCleanupActivityWorktree(
-      { ...REPO, connectionId: 'ssh-1' },
+      { kind: 'ssh', hostId: 'ssh:ssh-1', connectionId: 'ssh-1', provider: null },
       makeWorktree({ createdAt: 10_000 }),
       statPath
     )

--- a/src/main/ipc/workspace-cleanup-activity.ts
+++ b/src/main/ipc/workspace-cleanup-activity.ts
@@ -1,9 +1,9 @@
 import { lstat, open, readFile } from 'node:fs/promises'
 import path from 'node:path'
-import type { Repo } from '../../shared/repo-types'
 import type { Worktree } from '../../shared/worktree/types'
 import { resolveGitMetadataPath } from '../../shared/git-metadata-path'
 import { getPersistedWorkspaceCleanupActivityAt } from '../../shared/workspace-cleanup'
+import type { WorkspaceCleanupGitRoute } from './workspace-cleanup-git-route'
 
 type StatPath = (targetPath: string) => Promise<{ mtimeMs: number }>
 type ReadTextFile = (targetPath: string, options?: { tailBytes?: number }) => Promise<string>
@@ -23,7 +23,7 @@ export function resolvePersistedWorkspaceCleanupActivityWorktree(worktree: Workt
 export type WorkspaceCleanupFsActivityCache = Map<string, Promise<number>>
 
 export async function resolveWorkspaceCleanupActivityWorktree(
-  repo: Repo,
+  route: WorkspaceCleanupGitRoute,
   worktree: Worktree,
   statPath: StatPath = statLocalPath,
   readTextFile: ReadTextFile = readLocalTextFile,
@@ -32,7 +32,7 @@ export async function resolveWorkspaceCleanupActivityWorktree(
   fsActivityCache?: WorkspaceCleanupFsActivityCache
 ): Promise<Worktree> {
   const activityAt = await resolveWorkspaceCleanupActivityAt(
-    repo,
+    route,
     worktree,
     statPath,
     readTextFile,
@@ -74,14 +74,16 @@ async function readLocalTextFile(
 }
 
 async function resolveWorkspaceCleanupActivityAt(
-  repo: Repo,
+  route: WorkspaceCleanupGitRoute,
   worktree: Worktree,
   statPath: StatPath,
   readTextFile: ReadTextFile,
   fsActivityCache?: WorkspaceCleanupFsActivityCache
 ): Promise<number> {
   const persistedActivityAt = getPersistedWorkspaceCleanupActivityAt(worktree)
-  if (repo.connectionId) {
+  // Why: the probes below are local filesystem reads. Statting a remote path here answers
+  // about whatever this machine happens to have at that path, or nothing at all.
+  if (route.kind !== 'local') {
     return persistedActivityAt
   }
 

--- a/src/main/ipc/workspace-cleanup-candidate.ts
+++ b/src/main/ipc/workspace-cleanup-candidate.ts
@@ -1,4 +1,3 @@
-import type { IGitProvider } from '../providers/types'
 import { isFolderRepo } from '../../shared/repo-kind'
 import type { Repo } from '../../shared/repo-types'
 import type { Worktree } from '../../shared/worktree/types'
@@ -17,17 +16,18 @@ import {
   readWorkspaceCleanupGitEvidence
 } from './workspace-cleanup-git-evidence'
 import { appendWorkspaceCleanupItems } from './workspace-cleanup-scan-primitives'
+import type { WorkspaceCleanupGitRoute } from './workspace-cleanup-git-route'
 
 export async function buildWorkspaceCleanupCandidate(args: {
   repo: Repo
   worktree: Worktree
   scannedAt: number
-  provider: IGitProvider | null
+  route: WorkspaceCleanupGitRoute
   skipGit: boolean
   forceGitCheck: boolean
   signal?: AbortSignal
 }): Promise<WorkspaceCleanupCandidate> {
-  const { repo, worktree, scannedAt, provider, skipGit, forceGitCheck, signal } = args
+  const { repo, worktree, scannedAt, route, skipGit, forceGitCheck, signal } = args
   const blockers: WorkspaceCleanupBlocker[] = []
   const reasons = getWorkspaceCleanupInactivityReasonsForWorkspace(worktree, scannedAt)
   const repoIsFolder = isFolderRepo(repo)
@@ -53,7 +53,7 @@ export async function buildWorkspaceCleanupCandidate(args: {
 
   const gitEvidence = !shouldReadGit
     ? createEmptyWorkspaceCleanupGitEvidence()
-    : await readWorkspaceCleanupGitEvidence(worktree, repo, provider, signal)
+    : await readWorkspaceCleanupGitEvidence(worktree, repo, route, signal)
   appendWorkspaceCleanupItems(blockers, gitEvidence.blockers)
 
   const candidateWithoutFingerprint: WorkspaceCleanupCandidate = {

--- a/src/main/ipc/workspace-cleanup-execution-host-routing.test.ts
+++ b/src/main/ipc/workspace-cleanup-execution-host-routing.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type { GitStatusResult } from '../../shared/git-status-types'
+import type { Repo } from '../../shared/repo-types'
+import type { WorktreeMeta } from '../../shared/worktree/meta-types'
+
+const {
+  lstatMock,
+  readFileMock,
+  openMock,
+  listRepoWorktreesMock,
+  getStatusMock,
+  gitExecFileAsyncMock,
+  getSshGitProviderMock,
+  getLocalProjectWorktreeGitOptionsMock
+} = vi.hoisted(() => ({
+  lstatMock: vi.fn(),
+  readFileMock: vi.fn(),
+  openMock: vi.fn(),
+  listRepoWorktreesMock: vi.fn(),
+  getStatusMock: vi.fn(),
+  gitExecFileAsyncMock: vi.fn(),
+  getSshGitProviderMock: vi.fn(),
+  getLocalProjectWorktreeGitOptionsMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  lstat: lstatMock,
+  readFile: readFileMock,
+  open: openMock
+}))
+
+vi.mock('../repo-worktrees', () => ({
+  listRepoWorktrees: listRepoWorktreesMock,
+  createFolderWorktree: vi.fn()
+}))
+
+vi.mock('../git/status', () => ({ getStatus: getStatusMock }))
+vi.mock('../git/runner', () => ({ gitExecFileAsync: gitExecFileAsyncMock }))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock,
+  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE: 'SSH git provider unavailable'
+}))
+
+vi.mock('../project-runtime-git-options', () => ({
+  getLocalProjectWorktreeGitOptions: getLocalProjectWorktreeGitOptionsMock
+}))
+
+import { scanWorkspaceCleanup } from './workspace-cleanup-scan'
+
+const NOW = 1_700_000_000_000
+const INACTIVE_AT = NOW - 90 * 24 * 60 * 60 * 1000
+const REPO_ID = 'repo-1'
+const WORKTREE_PATH = '/remote/repo-feature'
+const WORKTREE_ID = `${REPO_ID}::${WORKTREE_PATH}`
+
+const CLEAN_STATUS: GitStatusResult = {
+  entries: [],
+  conflictOperation: 'unknown',
+  upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+}
+
+/**
+ * Two SSH targets are registered at once for every case: routing that answers with "some
+ * connected host" instead of *this row's* host only shows up when a second one exists.
+ */
+const sshProviders = new Map<string, ReturnType<typeof makeSshGitProvider>>()
+
+function makeSshGitProvider(): {
+  listWorktrees: ReturnType<typeof vi.fn>
+  getStatus: ReturnType<typeof vi.fn>
+  exec: ReturnType<typeof vi.fn>
+} {
+  return {
+    listWorktrees: vi.fn(async () => [
+      {
+        path: WORKTREE_PATH,
+        head: 'abc123',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ]),
+    getStatus: vi.fn(async () => CLEAN_STATUS),
+    exec: vi.fn(async () => ({ stdout: '0\n', stderr: '' }))
+  }
+}
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: REPO_ID,
+    path: '/remote/repo',
+    displayName: 'Repo',
+    badgeColor: '#000',
+    addedAt: NOW,
+    ...overrides
+  }
+}
+
+function makeMeta(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
+  return {
+    displayName: 'feature',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: INACTIVE_AT,
+    ...overrides
+  }
+}
+
+function makeStore(repos: Repo[], allMeta: Record<string, WorktreeMeta> = {}): Store {
+  return {
+    getRepos: () => repos,
+    getWorktreeMeta: (worktreeId: string) => allMeta[worktreeId],
+    getAllWorktreeMeta: () => allMeta,
+    getGitHubCache: () => ({ pr: {}, issue: {} })
+  } as unknown as Store
+}
+
+describe('workspace cleanup execution-host routing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    sshProviders.clear()
+    sshProviders.set('alpha', makeSshGitProvider())
+    sshProviders.set('beta', makeSshGitProvider())
+    lstatMock.mockReset().mockResolvedValue({ mtimeMs: 0 })
+    readFileMock.mockReset().mockRejectedValue(new Error('not a gitdir pointer'))
+    openMock.mockReset().mockRejectedValue(new Error('no reflog'))
+    listRepoWorktreesMock.mockReset().mockResolvedValue([
+      {
+        path: WORKTREE_PATH,
+        head: 'abc123',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    getStatusMock.mockReset().mockResolvedValue(CLEAN_STATUS)
+    gitExecFileAsyncMock.mockReset().mockResolvedValue({ stdout: '0\n', stderr: '' })
+    getLocalProjectWorktreeGitOptionsMock.mockReset().mockReturnValue({})
+    getSshGitProviderMock.mockReset().mockImplementation((id: string) => sshProviders.get(id))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('lists an executionHostId-only SSH repo through its own host, never locally', async () => {
+    const store = makeStore([makeRepo({ executionHostId: 'ssh:alpha' })], {
+      [WORKTREE_ID]: makeMeta()
+    })
+
+    const result = await scanWorkspaceCleanup(store)
+
+    expect(sshProviders.get('alpha')?.listWorktrees).toHaveBeenCalledWith('/remote/repo', {
+      signal: expect.any(AbortSignal)
+    })
+    expect(sshProviders.get('beta')?.listWorktrees).not.toHaveBeenCalled()
+    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0]?.executionHostId).toBe('ssh:alpha')
+  })
+
+  it('reads git status and unpushed commits on the row-named host, not this machine', async () => {
+    const store = makeStore([makeRepo({ executionHostId: 'ssh:alpha' })], {
+      [WORKTREE_ID]: makeMeta()
+    })
+    getStatusMock.mockResolvedValue({
+      ...CLEAN_STATUS,
+      upstreamStatus: { hasUpstream: false }
+    } as GitStatusResult)
+    sshProviders.get('alpha')?.getStatus.mockResolvedValue({
+      ...CLEAN_STATUS,
+      upstreamStatus: { hasUpstream: false }
+    })
+
+    await scanWorkspaceCleanup(store)
+
+    expect(sshProviders.get('alpha')?.getStatus).toHaveBeenCalledWith(WORKTREE_PATH, {
+      includeLineStats: false,
+      signal: expect.any(AbortSignal)
+    })
+    expect(sshProviders.get('alpha')?.exec).toHaveBeenCalled()
+    expect(getStatusMock).not.toHaveBeenCalled()
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('never stats a remote workspace path on this client', async () => {
+    const store = makeStore([makeRepo({ executionHostId: 'ssh:alpha' })], {
+      [WORKTREE_ID]: makeMeta({ lastActivityAt: INACTIVE_AT })
+    })
+
+    await scanWorkspaceCleanup(store, { refreshActivity: true })
+
+    expect(lstatMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps two simultaneously registered SSH hosts apart', async () => {
+    const store = makeStore(
+      [
+        makeRepo({ id: 'repo-alpha', executionHostId: 'ssh:alpha' }),
+        makeRepo({ id: 'repo-beta', connectionId: 'beta' })
+      ],
+      {
+        [`repo-alpha::${WORKTREE_PATH}`]: makeMeta(),
+        [`repo-beta::${WORKTREE_PATH}`]: makeMeta()
+      }
+    )
+
+    await scanWorkspaceCleanup(store)
+
+    expect(sshProviders.get('alpha')?.listWorktrees).toHaveBeenCalledTimes(1)
+    expect(sshProviders.get('beta')?.listWorktrees).toHaveBeenCalledTimes(1)
+    expect(sshProviders.get('alpha')?.getStatus).toHaveBeenCalledTimes(1)
+    expect(sshProviders.get('beta')?.getStatus).toHaveBeenCalledTimes(1)
+    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a runtime host that carries no nested SSH target instead of scanning locally', async () => {
+    const store = makeStore([makeRepo({ executionHostId: 'runtime:env-a' })], {
+      [WORKTREE_ID]: makeMeta()
+    })
+
+    const result = await scanWorkspaceCleanup(store)
+
+    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+    expect(getStatusMock).not.toHaveBeenCalled()
+    expect(result.candidates).toEqual([])
+    // Broad scans omit hosts they cannot inspect rather than bannering them.
+    expect(result.errors).toEqual([])
+  })
+
+  it('refuses a runtime host whose nested SSH target name is also registered on this client', async () => {
+    const store = makeStore(
+      [makeRepo({ executionHostId: 'runtime:env-a', connectionId: 'alpha' })],
+      { [WORKTREE_ID]: makeMeta() }
+    )
+
+    const result = await scanWorkspaceCleanup(store)
+
+    // 'alpha' names this client's own host; the runtime row's nested target lives in
+    // env-a's namespace, so dialing it here would inspect an entirely different machine.
+    expect(sshProviders.get('alpha')?.listWorktrees).not.toHaveBeenCalled()
+    expect(sshProviders.get('alpha')?.getStatus).not.toHaveBeenCalled()
+    expect(sshProviders.get('beta')?.listWorktrees).not.toHaveBeenCalled()
+    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+    expect(result.candidates).toEqual([])
+  })
+
+  it('surfaces the runtime refusal as a scan error on a targeted scan', async () => {
+    const store = makeStore(
+      [makeRepo({ executionHostId: 'runtime:env-a', connectionId: 'alpha' })],
+      { [WORKTREE_ID]: makeMeta() }
+    )
+
+    const result = await scanWorkspaceCleanup(store, { worktreeIds: [WORKTREE_ID] })
+
+    expect(sshProviders.get('alpha')?.listWorktrees).not.toHaveBeenCalled()
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]?.executionHostId).toBe('runtime:env-a')
+  })
+
+  it('synthesizes disconnected rows for an executionHostId-only SSH host that is not connected', async () => {
+    sshProviders.delete('alpha')
+    const store = makeStore([makeRepo({ executionHostId: 'ssh:alpha' })], {
+      [WORKTREE_ID]: makeMeta({ hostId: 'ssh:alpha' })
+    })
+
+    const result = await scanWorkspaceCleanup(store, { includeAllWorkspaces: true })
+
+    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0]?.blockers).toContain('ssh-disconnected')
+    expect(result.candidates[0]?.executionHostId).toBe('ssh:alpha')
+  })
+
+  it('refuses git evidence when the workspace names a different host than the listing', async () => {
+    // One local row owns the id, but its persisted metadata claims an SSH host. Reading this
+    // machine's checkout and labelling the row `ssh:alpha` is the cross-host leak.
+    const store = makeStore([makeRepo({ path: '/local/repo' })], {
+      [`${REPO_ID}::${WORKTREE_PATH}`]: makeMeta({ hostId: 'ssh:alpha' })
+    })
+
+    const result = await scanWorkspaceCleanup(store)
+
+    expect(listRepoWorktreesMock).toHaveBeenCalled()
+    expect(getStatusMock).not.toHaveBeenCalled()
+    expect(sshProviders.get('alpha')?.getStatus).not.toHaveBeenCalled()
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0]?.blockers).toContain('git-status-error')
+    expect(result.candidates[0]?.executionHostId).toBe('ssh:alpha')
+  })
+
+  it('still routes a genuinely local repo to this machine', async () => {
+    const store = makeStore([makeRepo({ path: '/local/repo' })], {
+      [WORKTREE_ID]: makeMeta()
+    })
+
+    const result = await scanWorkspaceCleanup(store)
+
+    expect(listRepoWorktreesMock).toHaveBeenCalled()
+    expect(getStatusMock).toHaveBeenCalled()
+    expect(sshProviders.get('alpha')?.getStatus).not.toHaveBeenCalled()
+    expect(result.candidates[0]?.executionHostId).toBe('local')
+  })
+})

--- a/src/main/ipc/workspace-cleanup-git-evidence.ts
+++ b/src/main/ipc/workspace-cleanup-git-evidence.ts
@@ -1,6 +1,5 @@
 import { getStatus } from '../git/status'
 import { gitExecFileAsync } from '../git/runner'
-import type { IGitProvider } from '../providers/types'
 import type { GitStatusResult } from '../../shared/git-status-types'
 import type { Repo } from '../../shared/repo-types'
 import type { Worktree } from '../../shared/worktree/types'
@@ -11,6 +10,13 @@ import {
   withWorkspaceCleanupTimeout
 } from './workspace-cleanup-scan-primitives'
 import { getWorktreeSharedLinkPaths } from '../git/worktree-shared-directories'
+import { SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE } from '../providers/ssh-git-dispatch'
+import type { SshGitProvider } from '../providers/ssh-git-provider'
+import {
+  resolveWorkspaceCleanupWorktreeGitRoute,
+  type WorkspaceCleanupGitRoute,
+  type WorkspaceCleanupWorktreeGitRoute
+} from './workspace-cleanup-git-route'
 
 export type WorkspaceCleanupGitEvidence = {
   clean: boolean | null
@@ -33,19 +39,31 @@ export function createEmptyWorkspaceCleanupGitEvidence(): WorkspaceCleanupGitEvi
 export async function readWorkspaceCleanupGitEvidence(
   worktree: Worktree,
   repo: Repo,
-  provider: IGitProvider | null,
+  repoRoute: WorkspaceCleanupGitRoute,
   signal?: AbortSignal
 ): Promise<WorkspaceCleanupGitEvidence> {
   const blockers: WorkspaceCleanupBlocker[] = []
   let status: GitStatusResult
   const checkedAt = Date.now()
-  const sharedLinkPaths = repo.connectionId ? [] : getWorktreeSharedLinkPaths(repo)
+  const route = resolveWorkspaceCleanupWorktreeGitRoute(repoRoute, worktree, repo)
+  if (route.kind === 'host-mismatch') {
+    // Refusing beats reading one host's checkout and labelling the row with the other's.
+    console.warn(
+      `Workspace cleanup skipped git for ${worktree.id}: listed on ${route.listedHostId}, owned by ${route.hostId}`
+    )
+    return { ...createEmptyWorkspaceCleanupGitEvidence(), blockers: ['git-status-error'] }
+  }
+  // Shared links are this machine's symlink layout; no remote checkout inherits it.
+  const sharedLinkPaths = route.kind === 'ssh' ? [] : getWorktreeSharedLinkPaths(repo)
 
   try {
     status = await withWorkspaceCleanupTimeout(
       (signal) =>
-        repo.connectionId
-          ? provider!.getStatus(worktree.path, { includeLineStats: false, signal })
+        route.kind === 'ssh'
+          ? requireWorkspaceCleanupGitProvider(route).getStatus(worktree.path, {
+              includeLineStats: false,
+              signal
+            })
           : getStatus(worktree.path, {
               includeLineStats: false,
               signal,
@@ -83,7 +101,7 @@ export async function readWorkspaceCleanupGitEvidence(
     blockers.push('unpushed-commits')
   }
   if (clean && upstreamAhead === null) {
-    const unpushedCommitCount = await readUnpushedCommitCount(worktree, repo, provider, signal)
+    const unpushedCommitCount = await readUnpushedCommitCount(worktree, route, signal)
     if (unpushedCommitCount === null) {
       blockers.push('unknown-base')
     } else if (unpushedCommitCount > 0) {
@@ -102,17 +120,18 @@ export async function readWorkspaceCleanupGitEvidence(
 
 async function readUnpushedCommitCount(
   worktree: Worktree,
-  repo: Repo,
-  provider: IGitProvider | null,
+  route: Exclude<WorkspaceCleanupWorktreeGitRoute, { kind: 'host-mismatch' }>,
   signal?: AbortSignal
 ): Promise<number | null> {
   try {
     const result = await withWorkspaceCleanupTimeout(
       (signal) =>
-        repo.connectionId
-          ? provider!.exec(['rev-list', '--count', 'HEAD', '--not', '--remotes'], worktree.path, {
-              signal
-            })
+        route.kind === 'ssh'
+          ? requireWorkspaceCleanupGitProvider(route).exec(
+              ['rev-list', '--count', 'HEAD', '--not', '--remotes'],
+              worktree.path,
+              { signal }
+            )
           : gitExecFileAsync(['rev-list', '--count', 'HEAD', '--not', '--remotes'], {
               cwd: worktree.path,
               signal
@@ -129,6 +148,16 @@ async function readUnpushedCommitCount(
     }
     return null
   }
+}
+
+/** An unreachable remote host is an error, never a licence to read this machine's checkout. */
+function requireWorkspaceCleanupGitProvider(
+  route: Extract<WorkspaceCleanupGitRoute, { kind: 'ssh' }>
+): SshGitProvider {
+  if (!route.provider) {
+    throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+  }
+  return route.provider
 }
 
 function uniqueWorkspaceCleanupGitBlockers(

--- a/src/main/ipc/workspace-cleanup-git-route.ts
+++ b/src/main/ipc/workspace-cleanup-git-route.ts
@@ -1,0 +1,83 @@
+/**
+ * Which execution host a cleanup scan reads Git from.
+ *
+ * The family used to thread `provider: IGitProvider | null` derived from a raw `repo.connectionId`
+ * read. That `null` spelled "this is local", "the host is remote but unreachable" and "the host is
+ * a runtime environment" with one value, so a row naming its owner only as
+ * `executionHostId: 'ssh:<target>'` listed, statted and `git status`-ed a *remote* path on this
+ * client — the #11163 defect class. The `provider!` assertions in `workspace-cleanup-git-evidence`
+ * were sound only because they re-read that same field, which is why the two moved together.
+ *
+ * `runtime:<env>` is deliberately not a variant. Its Git is executed by that environment's own
+ * server, and the SSH target on its repo row is that server's *nested* one, addressable only as the
+ * pair (environmentId, targetId). Handing it to this client's SSH table dials a same-named target
+ * in the wrong namespace, so it throws rather than routing — the same refusal
+ * `workspace-space-repo-scan` and `runtime-git-command-target` already make.
+ */
+
+import {
+  getRepoExecutionHostId,
+  getWorktreeExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  type ExecutionHostId
+} from '../../shared/execution-host'
+import type { Repo } from '../../shared/repo-types'
+import type { Worktree } from '../../shared/worktree/types'
+import {
+  ExecutionHostNotDispatchableError,
+  resolveGitRouteForHost
+} from '../providers/execution-host-provider-dispatch'
+import type { SshGitProvider } from '../providers/ssh-git-provider'
+
+export type WorkspaceCleanupGitRoute =
+  | { kind: 'local'; hostId: typeof LOCAL_EXECUTION_HOST_ID }
+  /** `provider: null` is "remote and currently unreachable" — never "read it here". */
+  | { kind: 'ssh'; hostId: `ssh:${string}`; connectionId: string; provider: SshGitProvider | null }
+
+/**
+ * The workspace's own host is the authority, and it can disagree with the row that produced the
+ * listing (legacy unqualified metadata on a repo id that has since moved hosts). Reading one host
+ * while the candidate reports the other is the cross-host leak, so the disagreement is its own
+ * answer and the scan refuses instead of guessing.
+ */
+export type WorkspaceCleanupWorktreeGitRoute =
+  | WorkspaceCleanupGitRoute
+  | { kind: 'host-mismatch'; hostId: ExecutionHostId; listedHostId: ExecutionHostId }
+
+/** Throws on a `runtime:` row; callers scan per repo and report the throw as a repo scan error. */
+export function resolveWorkspaceCleanupRepoGitRoute(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): WorkspaceCleanupGitRoute {
+  const route = resolveGitRouteForHost(getRepoExecutionHostId(repo))
+  switch (route.kind) {
+    case 'local':
+      return { kind: 'local', hostId: route.hostId }
+    case 'ssh':
+      return {
+        kind: 'ssh',
+        hostId: route.hostId,
+        connectionId: route.connectionId,
+        provider: route.provider
+      }
+    case 'runtime':
+      throw new ExecutionHostNotDispatchableError(route.hostId)
+  }
+}
+
+export function resolveWorkspaceCleanupWorktreeGitRoute(
+  repoRoute: WorkspaceCleanupGitRoute,
+  worktree: Pick<Worktree, 'hostId'>,
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): WorkspaceCleanupWorktreeGitRoute {
+  const hostId = getWorktreeExecutionHostId(worktree, repo)
+  return hostId === repoRoute.hostId
+    ? repoRoute
+    : { kind: 'host-mismatch', hostId, listedHostId: repoRoute.hostId }
+}
+
+/** True for every host whose files this client cannot stat directly. */
+export function isRemoteWorkspaceCleanupHost(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): boolean {
+  return getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID
+}

--- a/src/main/ipc/workspace-cleanup-scan.ts
+++ b/src/main/ipc/workspace-cleanup-scan.ts
@@ -1,7 +1,5 @@
 import type { Store } from '../persistence'
-import type { IGitProvider } from '../providers/types'
 import { isFolderRepo } from '../../shared/repo-kind'
-import { getRepoExecutionHostId } from '../../shared/execution-host'
 import { readWorktreeMetaForHost } from '../persistence/host-qualified-worktree-meta'
 import type { Repo } from '../../shared/repo-types'
 import type { GitWorktreeInfo, Worktree } from '../../shared/worktree/types'
@@ -16,6 +14,7 @@ import {
   handleRepoWorktreeListError,
   listCleanupGitWorktrees
 } from './workspace-cleanup-worktree-listing'
+import type { WorkspaceCleanupGitRoute } from './workspace-cleanup-git-route'
 import { shouldScanBroadWorkspaceCleanupWorktree } from './workspace-cleanup-scan-eligibility'
 import {
   resolvePersistedWorkspaceCleanupActivityWorktree,
@@ -143,12 +142,12 @@ async function scanRepoWorkspaces(
   } = args
   const errors: WorkspaceCleanupScanResult['errors'] = []
   const repoIsFolder = isFolderRepo(repo)
-  let provider: IGitProvider | null = null
+  let route: WorkspaceCleanupGitRoute
   let gitWorktrees: GitWorktreeInfo[] = []
 
   try {
     const discovered = await listCleanupGitWorktrees(store, repo, repoIsFolder, signal)
-    provider = discovered.provider
+    route = discovered.route
     gitWorktrees = discovered.gitWorktrees
   } catch (error) {
     if (error instanceof WorkspaceCleanupScanCancelledError) {
@@ -163,7 +162,7 @@ async function scanRepoWorkspaces(
     })
   }
 
-  if (repo.connectionId && !provider) {
+  if (route.kind === 'ssh' && !route.provider) {
     // Why: a disconnected host still owns real workspaces; the full list shows
     // them (blocked), while legacy scans keep omitting what they cannot inspect.
     const candidates =
@@ -190,7 +189,7 @@ async function scanRepoWorkspaces(
       : gitWorktrees.map((gitWorktree) => {
           const worktreeId = `${repo.id}::${gitWorktree.path}`
           // Host-qualified first: the same repoId::path is a different checkout on each host.
-          const hostMeta = readWorktreeMetaForHost(store, worktreeId, getRepoExecutionHostId(repo))
+          const hostMeta = readWorktreeMetaForHost(store, worktreeId, route.hostId)
           const meta = store.getWorktreeMeta(worktreeId)
           const ownedMeta =
             hostMeta ?? (isWorktreeMetaOwnedByRepo(repo, meta, repoOwnerCount) ? meta : undefined)
@@ -237,7 +236,7 @@ async function scanRepoWorkspaces(
         (targetWorktreeIds ? !refreshTargetActivity : persistedActivityIsRecent)
           ? persistedActivityWorktree
           : await resolveCleanupActivityWithTimeout(
-              repo,
+              route,
               worktree,
               () => {
                 activityStatsUnavailable = true
@@ -256,7 +255,7 @@ async function scanRepoWorkspaces(
         repo,
         worktree: worktreeWithActivity,
         scannedAt,
-        provider,
+        route,
         // Why: full-fleet scans defer git for recently active rows; removal preflight
         // forces a fresh read before any selected row can be deleted.
         skipGit: skipGitWorktreeIds.has(worktreeWithActivity.id) || !isInactive,
@@ -281,7 +280,7 @@ async function scanRepoWorkspaces(
 }
 
 async function resolveCleanupActivityWithTimeout(
-  repo: Repo,
+  route: WorkspaceCleanupGitRoute,
   worktree: Worktree,
   onActivityStatsUnavailable: () => void,
   signal?: AbortSignal,
@@ -291,7 +290,7 @@ async function resolveCleanupActivityWithTimeout(
     return await withWorkspaceCleanupTimeout(
       () =>
         resolveWorkspaceCleanupActivityWorktree(
-          repo,
+          route,
           worktree,
           undefined,
           undefined,

--- a/src/main/ipc/workspace-cleanup-worktree-listing.ts
+++ b/src/main/ipc/workspace-cleanup-worktree-listing.ts
@@ -1,7 +1,5 @@
 import type { Store } from '../persistence'
 import { listRepoWorktrees, createFolderWorktree } from '../repo-worktrees'
-import { getSshGitProvider } from '../providers/ssh-git-dispatch'
-import type { IGitProvider } from '../providers/types'
 import type { Repo } from '../../shared/repo-types'
 import type { GitWorktreeInfo } from '../../shared/worktree/types'
 import type {
@@ -14,6 +12,12 @@ import {
   toSafeWorkspaceCleanupRepoScanError,
   withWorkspaceCleanupTimeout
 } from './workspace-cleanup-scan-primitives'
+import { ExecutionHostNotDispatchableError } from '../providers/execution-host-provider-dispatch'
+import {
+  isRemoteWorkspaceCleanupHost,
+  resolveWorkspaceCleanupRepoGitRoute,
+  type WorkspaceCleanupGitRoute
+} from './workspace-cleanup-git-route'
 import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
 
 export async function listCleanupGitWorktrees(
@@ -21,21 +25,19 @@ export async function listCleanupGitWorktrees(
   repo: Repo,
   repoIsFolder: boolean,
   signal?: AbortSignal
-): Promise<{ provider: IGitProvider | null; gitWorktrees: GitWorktreeInfo[] }> {
+): Promise<{ route: WorkspaceCleanupGitRoute; gitWorktrees: GitWorktreeInfo[] }> {
+  const route = resolveWorkspaceCleanupRepoGitRoute(repo)
   if (repoIsFolder) {
-    return {
-      provider: repo.connectionId ? (getSshGitProvider(repo.connectionId) ?? null) : null,
-      gitWorktrees: [createFolderWorktree(repo)]
-    }
+    return { route, gitWorktrees: [createFolderWorktree(repo)] }
   }
-  if (repo.connectionId) {
-    const provider = getSshGitProvider(repo.connectionId) ?? null
-    if (!provider) {
+  if (route.kind === 'ssh') {
+    if (!route.provider) {
       // Why: cleanup should reflect only workspaces Orca can currently inspect.
-      return { provider: null, gitWorktrees: [] }
+      return { route, gitWorktrees: [] }
     }
+    const provider = route.provider
     return {
-      provider,
+      route,
       gitWorktrees: await withWorkspaceCleanupTimeout(
         (signal) => provider.listWorktrees(repo.path, { signal }),
         WORKSPACE_CLEANUP_GIT_READ_TIMEOUT_MS,
@@ -46,7 +48,7 @@ export async function listCleanupGitWorktrees(
   }
   const localGitOptions = getLocalProjectWorktreeGitOptions(store, repo)
   return {
-    provider: null,
+    route,
     gitWorktrees: await withWorkspaceCleanupTimeout(
       (signal) => listRepoWorktrees(repo, { ...localGitOptions, signal }),
       WORKSPACE_CLEANUP_GIT_READ_TIMEOUT_MS,
@@ -64,10 +66,15 @@ export function handleRepoWorktreeListError(args: {
   onErrors?: (errors: WorkspaceCleanupScanError[]) => void
 }): WorkspaceCleanupScanResult {
   const { repo, targeted, scannedAt, error, onErrors } = args
-  console.error('Workspace cleanup repo scan failed', error)
-  if (repo.connectionId && !targeted) {
+  if (error instanceof ExecutionHostNotDispatchableError) {
+    // Routine for a runtime host, whose cleanup belongs to that environment's own server.
+    console.warn('Workspace cleanup skipped a host this process does not execute', error.hostId)
+  } else {
+    console.error('Workspace cleanup repo scan failed', error)
+  }
+  if (isRemoteWorkspaceCleanupHost(repo) && !targeted) {
     // Why: broad cleanup only shows remote workspaces Orca can inspect now.
-    // A connected SSH repo that fails mid-scan is omitted, not bannered.
+    // A remote repo that fails mid-scan is omitted, not bannered.
     return { scannedAt, candidates: [], errors: [] }
   }
   const errors = [createWorkspaceCleanupScanError(repo, toSafeWorkspaceCleanupRepoScanError(error))]

--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -55,7 +55,8 @@ vi.mock('../git/runner', () => ({
 }))
 
 vi.mock('../providers/ssh-git-dispatch', () => ({
-  getSshGitProvider: getSshGitProviderMock
+  getSshGitProvider: getSshGitProviderMock,
+  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE: 'SSH git provider unavailable'
 }))
 
 vi.mock('../project-runtime-git-options', () => ({


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​332 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​312 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​167 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​47 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​120 |

<!-- /orca-pr-loc -->

Step 4 of the execution-host routing sweep, after #18296 (host-keyed dispatch), #18307 (`RuntimeGitTarget`) and #18325 (`RuntimeFileTarget`).

## The defect

The `workspace-cleanup-*` family threaded `provider: IGitProvider | null` — derived from a raw `repo.connectionId` read — from `listCleanupGitWorktrees` through the scan into activity resolution and git evidence. That `null` spelled three different things with one value: **"this is local"**, **"the host is remote but unreachable"**, and **"the host is a runtime environment"**. So a repo row naming its owner only as `executionHostId: 'ssh:<target>'` — with `connectionId` absent — listed worktrees with `listRepoWorktrees`, `lstat`ed the remote paths, and ran `getStatus` on *this machine*. That is #11163 exactly.

**The three sites had to move together.** The `provider!` assertions at `workspace-cleanup-git-evidence.ts:46` and `:110` were sound only because they re-read the same `repo.connectionId` that `workspace-cleanup-worktree-listing.ts:31` used to decide whether `provider` was populated. Migrating one alone converts them from a wrong answer into a crash.

## The technique

Same as #18307: the ambiguous carrier is **removed**, not supplemented. `provider: IGitProvider | null` is gone from the internal call chain, replaced by a non-nullable discriminated route. Every reader became a compile error rather than silently inheriting a changed meaning.

**#18325 could not get that guarantee because its family carries `@ts-nocheck`; `workspace-cleanup-*` does not.** All 36 non-test files in `src/main/ipc/workspace-cleanup*`, `src/main/workspace-cleanup*` and `src/shared/workspace-cleanup*` are compiler-checked, so no text ratchet is needed here — the type change alone caught every site, and `pnpm tc` proved it (the only errors were the 11 call sites in `workspace-cleanup-activity.test.ts`).

## What resolves where

No new resolver. Routing goes through the layer that already exists:

- **repo-level** (`listCleanupGitWorktrees`, the listing that produces the worktrees): `getRepoExecutionHostId(repo)` → `resolveGitRouteForHost` from #18296.
- **workspace-level** (`readWorkspaceCleanupGitEvidence`): `getWorktreeExecutionHostId(worktree, repo)`, which reads `worktree.hostId` first. `mergeWorktree` carries `meta.hostId` onto the worktree, so this is live data, not a formality.

When the two disagree — legacy unqualified metadata on a repo id whose row has since moved hosts — that is its own `host-mismatch` answer and the scan refuses. Reading one host's checkout while `candidate.executionHostId` (already `getWorktreeExecutionHostId`) labels the row with the other's is the cross-host leak; the row still appears, `git-status-error`, tier `protected`.

## "What may this client dial", verified not assumed

Every migrated site needs the dial question, as in both prior migrations. Checked explicitly:

- listing, git status, `rev-list --count`, `sharedLinkPaths`, and the local activity stat are all things *this process* executes — a `runtime:` host arriving is a routing error, because its calls are forwarded and normalized to that server's own `local`, and the SSH target on its repo row is that server's **nested** one, addressable only as `(environmentId, targetId)`.
- `runtime:` therefore throws `ExecutionHostNotDispatchableError`, matching `workspace-space-repo-scan` (the closest sibling, already migrated) and `repos:listForExecutionHost`.
- The one site that genuinely wants *"which host holds the files"* is `WorkspaceCleanupCandidate.connectionId` (`repo.connectionId ?? null`), which is **published content** and is left untouched — see out of scope below.

## Behavior changes vs no-ops

**Fixed (behavior changes):**
1. An `executionHostId: 'ssh:<t>'`-only row now lists worktrees through that host instead of locally.
2. …now reads `git status` / `rev-list` through that host instead of locally.
3. …no longer `lstat`s the remote workspace path on this client for activity.
4. …no longer passes this machine's `sharedLinkPaths` into a remote status read.
5. …when disconnected, now synthesizes `ssh-disconnected` rows instead of scanning locally.
6. A `runtime:` row is refused instead of scanning locally (no nested target) or dialing this client's same-named SSH target (nested target present).
7. A contradictory row (`executionHostId: 'local'` **and** `connectionId: 'x'`) now routes local — `getRepoExecutionHostId` prefers the explicit host, and the row declares itself local.
8. A workspace whose own host disagrees with the listing host is refused rather than read on the wrong one.
9. `handleRepoWorktreeListError`'s broad-scan error suppression now keys on "host is not local" rather than `connectionId`, so `executionHostId`-only and `runtime:` rows are omitted rather than bannered — the rule that already applied to every other remote repo.

**Intended no-ops:** every row spelled the legacy way (`connectionId: 'x'`, no `executionHostId`) and every genuinely local row route exactly as before — `getRepoExecutionHostId` maps `connectionId: 'x'` to `ssh:x` and absence to `local`. All 73 pre-existing tests in the family pass unchanged.

**`provider!`:** both assertions are deleted. The SSH branch now goes through `requireWorkspaceCleanupGitProvider`, which throws `SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE` for an unreachable host — never falls through to the local branch. That is `docs/reference/ssh-execution-boundary.md` rule 1: a missing SSH provider is not permission to answer locally.

## Failed-first proof

Patching `resolveWorkspaceCleanupRepoGitRoute` back to `repo.connectionId ? 'ssh:'+connectionId : 'local'`, `resolveWorkspaceCleanupWorktreeGitRoute` back to a passthrough, and `isRemoteWorkspaceCleanupHost` back to `Boolean(repo.connectionId)`:

**9 of 10 new tests fail.** The one that passes — "still routes a genuinely local repo to this machine" — is the deliberate no-op control proving the migration did not push local work onto a remote host. (#18307 got 6/8, #18325 got 7/9.)

Coverage per the brief: every case registers **two distinct SSH hosts (`alpha`, `beta`) simultaneously**, and `runtime:` is covered both with and without a nested SSH target — including the case where the nested target's name (`alpha`) **is also registered on this client**, which is what proves refusal rather than a wrong-host dial.

## No wire change

`WorkspaceCleanupCandidate` (including `connectionId` and `executionHostId`), the `workspaceCleanup:*` IPC args, and the `WorkspaceCleanup` RPC UI-state schema in `src/main/runtime/rpc/methods/workspace-cleanup-ui-schema.ts` are all untouched. The change is confined to how main picks a provider; nothing a paired client and host exchange moved.

## Out of scope, reported not fixed

`workspaceCleanup:hasKillableLocalProcesses` dials `getSshPtyProvider(args.connectionId)` from an IPC argument fed by `candidate.connectionId` (`repo.connectionId ?? null`). For a `runtime:` row that would enumerate PTYs on this client's same-named target — a wrong host. It is **not live**: no renderer code calls `hasKillableLocalProcesses` today (only the preload bridge and test harnesses reference it). Fixing it means changing published content, so it belongs in its own change under `docs/reference/remote-wire-compatibility.md`.

## Verification

- `pnpm tc` — clean.
- `pnpm test src` — whole tree, run twice. 5–6 failures each run in **largely disjoint** sets (`browser-route-webrtc-egress.electron`, `terminal-output-frame-chunks-equivalence` 800-iteration fuzz timeout, `ssh-remote-commands`, `AgentMapTimeRangeField`, `remote-runtime-shared-control-connection`, `structured-tui-transcript-catchup`). Confirmed pre-existing: with this branch **stashed**, the same file set still fails on the base commit. None import anything in this change.
- `pnpm test src/main/ipc/workspace-cleanup` — 7 files, 83 tests, all pass.
- `pnpm run check:code-quality:changed` — 0 new findings across 9 files (oxlint, type-aware, React Doctor).
- `pnpm run check:max-lines-ratchet` — OK, no new bypasses. `max-lines` proven to fire first with a 320-line positive control before clearing the changed files.
- `pnpm run test:e2e:ssh-docker` — **24 passed, exit 0** (18.0m).
