### PR TITLE
fix(mobile): let Android split screen inset the window for the keyboard

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -80,6 +80,8 @@
     "plugins": [
       "expo-router",
       "./plugins/android-respect-rotation-lock.js",
+      "./plugins/android-optout-edge-to-edge-enforcement.js",
+      "./plugins/android-fit-system-windows-for-ime.js",
       [
         "expo-splash-screen",
         {
@@ -108,7 +110,8 @@
             "buildReactNativeFromSource": true
           },
           "android": {
-            "usesCleartextTraffic": true
+            "usesCleartextTraffic": true,
+            "targetSdkVersion": 35
           }
         }
       ]

--- a/mobile/plugins/android-fit-system-windows-for-ime.js
+++ b/mobile/plugins/android-fit-system-windows-for-ime.js
@@ -1,0 +1,63 @@
+const { withMainActivity } = require('expo/config-plugins')
+
+// Why: expo-modules-core's EdgeToEdgePackage force-enables edge-to-edge at activity create, so
+// the window keeps decorFitsSystemWindows=false and the system never insets it for the IME. In
+// multi-window the shell owns the IME (imeControlTarget is a RemoteInsetsControlTarget) and
+// reports no ime inset either — measured on a razr fold as a -31.9dp keyboard height — so
+// nothing can lift content off the keyboard there. Fitting system windows restores that inset,
+// but only in multi-window: full screen reports the IME normally and keeps edge-to-edge, and
+// fitting there would double up with the layout's own keyboard lift. Honored only because
+// android-optout-edge-to-edge-enforcement.js opts the theme out of the Android 15+ enforcement.
+//
+// Known gap: freeform and desktop-mode windows are also multi-window but do receive the ime
+// inset, so they get the system inset they do not need. Narrowing this needs a runtime probe of
+// the ime inset, which cannot run before the first keyboard opens.
+const ON_CREATE_ANCHOR = 'super.onCreate(null)'
+const METHODS_ANCHOR = `  /**
+   * Returns the name of the main component registered from JavaScript.`
+const APPLY_ON_CREATE = `${ON_CREATE_ANCHOR}
+    applyMultiWindowImeInsetCompatibility()`
+const MULTI_WINDOW_METHODS = `  private fun applyMultiWindowImeInsetCompatibility() {
+    androidx.core.view.WindowCompat.setDecorFitsSystemWindows(window, isInMultiWindowMode)
+  }
+
+  override fun onMultiWindowModeChanged(
+    isInMultiWindowMode: Boolean,
+    newConfig: android.content.res.Configuration
+  ) {
+    super.onMultiWindowModeChanged(isInMultiWindowMode, newConfig)
+    applyMultiWindowImeInsetCompatibility()
+  }
+
+  // Why: API 24-25 only calls this deprecated single-arg overload, and configChanges keeps the
+  // activity alive across the transition, so without it those devices never re-evaluate.
+  @Deprecated("Deprecated in Java")
+  override fun onMultiWindowModeChanged(isInMultiWindowMode: Boolean) {
+    @Suppress("DEPRECATION")
+    super.onMultiWindowModeChanged(isInMultiWindowMode)
+    applyMultiWindowImeInsetCompatibility()
+  }
+
+${METHODS_ANCHOR}`
+
+module.exports = function withAndroidFitSystemWindowsForIme(config) {
+  return withMainActivity(config, (cfg) => {
+    const contents = cfg.modResults.contents
+    if (contents.includes('applyMultiWindowImeInsetCompatibility')) {
+      return cfg
+    }
+    // Why: a silent no-op would ship an app whose split-screen keyboard is broken again, so fail
+    // the prebuild if the template these anchors come from ever changes.
+    for (const anchor of [ON_CREATE_ANCHOR, METHODS_ANCHOR]) {
+      if (!contents.includes(anchor)) {
+        throw new Error(
+          `android-fit-system-windows-for-ime: MainActivity is missing the anchor ${JSON.stringify(anchor)}`
+        )
+      }
+    }
+    cfg.modResults.contents = contents
+      .replace(ON_CREATE_ANCHOR, APPLY_ON_CREATE)
+      .replace(METHODS_ANCHOR, MULTI_WINDOW_METHODS)
+    return cfg
+  })
+}

--- a/mobile/plugins/android-optout-edge-to-edge-enforcement.js
+++ b/mobile/plugins/android-optout-edge-to-edge-enforcement.js
@@ -1,0 +1,35 @@
+const { withAndroidStyles } = require('expo/config-plugins')
+
+// Why: Android 15+ enforces edge-to-edge, which pins decorFitsSystemWindows=false and stops the
+// system insetting the window for the IME. Opting out lets
+// android-fit-system-windows-for-ime.js restore that inset in multi-window, where the shell owns
+// the IME and reports no keyboard height at all. The opt-out is a window theme attribute (not a
+// manifest attribute) and Android 16 ignores it above targetSdk 35, which is why
+// expo-build-properties pins targetSdkVersion to 35 in app.json. The window is created with the
+// splash theme and swapped to AppTheme afterwards, so both carry it.
+const OPT_OUT_ATTRIBUTE = 'android:windowOptOutEdgeToEdgeEnforcement'
+const THEMES_TO_OPT_OUT = ['AppTheme', 'Theme.App.SplashScreen']
+
+module.exports = function withAndroidOptOutEdgeToEdgeEnforcement(config) {
+  return withAndroidStyles(config, (cfg) => {
+    const styles = cfg.modResults.resources.style ?? []
+    const optedOut = []
+    for (const style of styles) {
+      if (!THEMES_TO_OPT_OUT.includes(style.$.name)) {
+        continue
+      }
+      style.item = (style.item ?? []).filter((item) => item.$.name !== OPT_OUT_ATTRIBUTE)
+      style.item.push({ $: { name: OPT_OUT_ATTRIBUTE }, _: 'true' })
+      optedOut.push(style.$.name)
+    }
+    // Why: missing either theme leaves edge-to-edge enforced and silently reinstates the broken
+    // split-screen keyboard, so fail the prebuild rather than the runtime.
+    const missing = THEMES_TO_OPT_OUT.filter((name) => !optedOut.includes(name))
+    if (missing.length > 0) {
+      throw new Error(
+        `android-optout-edge-to-edge-enforcement: styles.xml is missing ${missing.join(', ')}`
+      )
+    }
+    return cfg
+  })
+}


### PR DESCRIPTION
## Problem

In Android split screen the keyboard covered the terminal's shortcut row and Live input bar, and nothing lifted out of the way.

## Why it happens

The window is never resized there, and Android reports no keyboard to the app at all. Measured on a motorola razr fold 2026 (Android 16), `keyboardDidShow` arrives with:

```
end.height = -31.9dp   screenY = 1084.5   window = 496x1116 (identical with the IME up)
```

The shell owns the IME — `dumpsys window` shows `imeControlTarget` is a `RemoteInsetsControlTarget` — so the window gets `imeInsets.bottom = 0`, and RN's `ReactRootView.checkForKeyboardEvents` reduces that by the 31.9dp navigation bar, yielding a negative height.

It is an absent inset, not a race: re-reads of `Keyboard.metrics()` at +100 / +300 / +600 / +1200 / +2500ms all returned the same value, and a `useAnimatedKeyboard` listener never fired once. No app-side measurement of the keyboard exists in that mode, so no JS-only fix is possible.

## The fix

Two separate things pin `decorFitsSystemWindows = false`, and undoing either alone changes nothing:

1. **Android 15+ edge-to-edge enforcement.** The opt-out is a window **theme** attribute (`android:windowOptOutEdgeToEdgeEnforcement`), not a manifest attribute — the manifest form was verified to have no effect. Android 16 also ignores it above targetSdk 35, hence the `expo-build-properties` pin. The window is created with the splash theme and swapped to `AppTheme` after, so both carry the attribute.
2. **expo-modules-core's `EdgeToEdgePackage`** calls `enableEdgeToEdge()` at activity create regardless of RN's `isEdgeToEdgeFeatureFlagOn`. `MainActivity` now sets decor fitting back on — **only in multi-window**, since full screen reports the IME normally and fitting there double-compensates with the layout's own keyboard lift (confirmed: an unconditional version left a keyboard-sized black band in full screen).

Both plugins throw during prebuild if their anchors are missing, so a template change fails the build instead of silently shipping the regression.

## Verification

On a motorola razr fold 2026 (Android 16), release build:

- Split screen + keyboard: shortcut row and Live input bar sit above the keyboard. `EDGE_TO_EDGE_ENFORCED` is gone from the window's private flags.
- Full screen + keyboard: unchanged from before, edge-to-edge preserved, no blank band.

## Trade-offs and follow-ups

- **targetSdk is pinned to 35.** Play accepts this today, but when Google requires 36 the opt-out disappears and this approach stops working. The coupling is documented in the opt-out plugin.
- **`isInMultiWindowMode` is a broad proxy.** Freeform and desktop-mode windows are also multi-window but *do* receive the ime inset, so they get a system inset they don't need. Narrowing this needs a runtime probe of the ime inset, which can't run before the first keyboard opens. Noted in the plugin comment.
- **System bars stay transparent** while decor-fitting in multi-window, so the bar strips paint `windowBackground` rather than the themed surface. Not visible on the test device; worth a look if a seam shows up.
- While the keyboard is open in split screen the terminal frame is shorter, so xterm reflows locally. The existing refit deferral (`terminal-viewport-refit-state.ts`) holds the PTY resize until the keyboard closes, at which point the resting size is reasserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZq3xEtzu3nJzg1rdtyQsF