### PR TITLE
feat(mobile): show workspace sidebar on landscape phones

### DIFF
--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { View, StyleSheet, PanResponder } from 'react-native'
 import { Stack, useGlobalSearchParams, usePathname } from 'expo-router'
-import { colors } from '../../src/theme/mobile-theme'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { colors, spacing } from '../../src/theme/mobile-theme'
 import { useResponsiveLayout } from '../../src/layout/responsive-layout'
 import {
   HOST_SIDEBAR_DEFAULT_WIDTH,
@@ -11,11 +12,13 @@ import {
   saveHostSidebarWidth
 } from '../../src/storage/preferences'
 import { HostProtocolGate } from '../../src/components/HostProtocolGate'
+import { HostSidebarToggleButton } from '../../src/components/HostSidebarToggleButton'
 import { HostScreen } from './[hostId]/index'
 
 // Keep at least this much room for the detail pane when resizing the sidebar.
 const MIN_DETAIL_WIDTH = 320
 const RESIZE_EDGE_WIDTH = 24
+const REVEAL_RAIL_WIDTH = 40
 
 // Clamp a sidebar width to the bounds and to the current window, so a width
 // saved on a larger device can't starve the detail pane on a narrower one.
@@ -63,6 +66,7 @@ export default function HostGroupLayout() {
   const { isWideLayout, width: windowWidth } = useResponsiveLayout()
   const { hostId, action } = useGlobalSearchParams<{ hostId?: string; action?: string }>()
   const pathname = usePathname()
+  const insets = useSafeAreaInsets()
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [sidebarWidth, setSidebarWidth] = useState(HOST_SIDEBAR_DEFAULT_WIDTH)
 
@@ -94,13 +98,11 @@ export default function HostGroupLayout() {
   }, [windowWidth])
 
   const hideSidebar = useCallback(() => setSidebarOpen(false), [])
+  const revealSidebar = useCallback(() => setSidebarOpen(true), [])
   const showSidebar = isWideLayout && !!hostId
   const detailHasContent = !!hostId && pathname !== `/h/${hostId}`
   const canCollapseSidebar = showSidebar && detailHasContent
 
-  // Why: there is no reveal button — navigating Back to the base host route brings
-  // the sidebar back (and that route's detail pane is only a placeholder, so a
-  // hidden sidebar would leave nothing useful).
   useEffect(() => {
     if (showSidebar && !detailHasContent) {
       setSidebarOpen(true)
@@ -153,6 +155,20 @@ export default function HostGroupLayout() {
             <View style={styles.resizeHandle} {...resizer.panHandlers} />
           </View>
         ) : null}
+        {showSidebar && !sidebarOpen ? (
+          <View
+            style={[
+              styles.revealRail,
+              {
+                width: REVEAL_RAIL_WIDTH + insets.left,
+                paddingLeft: insets.left,
+                paddingTop: insets.top + spacing.xs
+              }
+            ]}
+          >
+            <HostSidebarToggleButton expanded={false} onPress={revealSidebar} />
+          </View>
+        ) : null}
         <View style={styles.detail}>
           <HostStack animation={showSidebar ? 'none' : 'default'} />
         </View>
@@ -168,6 +184,12 @@ const styles = StyleSheet.create({
     backgroundColor: colors.bgBase
   },
   sidebar: {
+    borderRightWidth: 1,
+    borderRightColor: colors.borderSubtle
+  },
+  revealRail: {
+    alignItems: 'center',
+    backgroundColor: colors.bgPanel,
     borderRightWidth: 1,
     borderRightColor: colors.borderSubtle
   },

--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { View, StyleSheet, PanResponder } from 'react-native'
 import { Stack, useGlobalSearchParams, usePathname } from 'expo-router'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { colors } from '../../src/theme/mobile-theme'
 import { useResponsiveLayout } from '../../src/layout/responsive-layout'
 import { getHostSidebarPresentation } from '../../src/layout/host-sidebar-presentation'
@@ -66,7 +65,6 @@ export default function HostGroupLayout() {
   const { isWideLayout, width: windowWidth } = useResponsiveLayout()
   const { hostId, action } = useGlobalSearchParams<{ hostId?: string; action?: string }>()
   const pathname = usePathname()
-  const insets = useSafeAreaInsets()
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [sidebarWidth, setSidebarWidth] = useState(HOST_SIDEBAR_DEFAULT_WIDTH)
 
@@ -157,7 +155,7 @@ export default function HostGroupLayout() {
           </View>
         ) : null}
         {sidebarPresentation === 'reveal' ? (
-          <View style={[styles.revealTab, { paddingLeft: insets.left }]}>
+          <View style={styles.revealTab}>
             <HostSidebarToggleButton expanded={false} onPress={revealSidebar} />
           </View>
         ) : null}
@@ -182,9 +180,9 @@ const styles = StyleSheet.create({
   revealTab: {
     position: 'absolute',
     left: 0,
-    top: '50%',
+    // Keep the control above a landscape phone's side-mounted camera island.
+    top: '25%',
     transform: [{ translateY: -16 }],
-    backgroundColor: colors.bgPanel,
     zIndex: 20,
     elevation: 20
   },

--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { View, StyleSheet, PanResponder } from 'react-native'
 import { Stack, useGlobalSearchParams, usePathname } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { colors } from '../../src/theme/mobile-theme'
 import { useResponsiveLayout } from '../../src/layout/responsive-layout'
 import { getHostSidebarPresentation } from '../../src/layout/host-sidebar-presentation'
@@ -65,6 +66,7 @@ export default function HostGroupLayout() {
   const { isWideLayout, width: windowWidth } = useResponsiveLayout()
   const { hostId, action } = useGlobalSearchParams<{ hostId?: string; action?: string }>()
   const pathname = usePathname()
+  const insets = useSafeAreaInsets()
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [sidebarWidth, setSidebarWidth] = useState(HOST_SIDEBAR_DEFAULT_WIDTH)
 
@@ -155,7 +157,7 @@ export default function HostGroupLayout() {
           </View>
         ) : null}
         {sidebarPresentation === 'reveal' ? (
-          <View style={styles.revealTab}>
+          <View style={[styles.revealTab, { paddingLeft: insets.left }]}>
             <HostSidebarToggleButton expanded={false} onPress={revealSidebar} />
           </View>
         ) : null}
@@ -182,6 +184,7 @@ const styles = StyleSheet.create({
     left: 0,
     top: '50%',
     transform: [{ translateY: -16 }],
+    backgroundColor: colors.bgPanel,
     zIndex: 20,
     elevation: 20
   },

--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { View, StyleSheet, PanResponder } from 'react-native'
 import { Stack, useGlobalSearchParams, usePathname } from 'expo-router'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { colors, spacing } from '../../src/theme/mobile-theme'
+import { colors } from '../../src/theme/mobile-theme'
 import { useResponsiveLayout } from '../../src/layout/responsive-layout'
+import { getHostSidebarPresentation } from '../../src/layout/host-sidebar-presentation'
 import {
   HOST_SIDEBAR_DEFAULT_WIDTH,
   HOST_SIDEBAR_MAX_WIDTH,
@@ -18,7 +18,6 @@ import { HostScreen } from './[hostId]/index'
 // Keep at least this much room for the detail pane when resizing the sidebar.
 const MIN_DETAIL_WIDTH = 320
 const RESIZE_EDGE_WIDTH = 24
-const REVEAL_RAIL_WIDTH = 40
 
 // Clamp a sidebar width to the bounds and to the current window, so a width
 // saved on a larger device can't starve the detail pane on a narrower one.
@@ -66,7 +65,6 @@ export default function HostGroupLayout() {
   const { isWideLayout, width: windowWidth } = useResponsiveLayout()
   const { hostId, action } = useGlobalSearchParams<{ hostId?: string; action?: string }>()
   const pathname = usePathname()
-  const insets = useSafeAreaInsets()
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [sidebarWidth, setSidebarWidth] = useState(HOST_SIDEBAR_DEFAULT_WIDTH)
 
@@ -102,6 +100,7 @@ export default function HostGroupLayout() {
   const showSidebar = isWideLayout && !!hostId
   const detailHasContent = !!hostId && pathname !== `/h/${hostId}`
   const canCollapseSidebar = showSidebar && detailHasContent
+  const sidebarPresentation = getHostSidebarPresentation(showSidebar, detailHasContent, sidebarOpen)
 
   useEffect(() => {
     if (showSidebar && !detailHasContent) {
@@ -143,7 +142,7 @@ export default function HostGroupLayout() {
   return (
     <HostProtocolGate hostId={hostId}>
       <View style={styles.row}>
-        {showSidebar && sidebarOpen ? (
+        {sidebarPresentation === 'sidebar' ? (
           <View style={[styles.sidebar, { width: sidebarWidth }]}>
             <HostScreen
               embedded
@@ -155,17 +154,8 @@ export default function HostGroupLayout() {
             <View style={styles.resizeHandle} {...resizer.panHandlers} />
           </View>
         ) : null}
-        {showSidebar && !sidebarOpen ? (
-          <View
-            style={[
-              styles.revealRail,
-              {
-                width: REVEAL_RAIL_WIDTH + insets.left,
-                paddingLeft: insets.left,
-                paddingTop: insets.top + spacing.xs
-              }
-            ]}
-          >
+        {sidebarPresentation === 'reveal' ? (
+          <View style={styles.revealTab}>
             <HostSidebarToggleButton expanded={false} onPress={revealSidebar} />
           </View>
         ) : null}
@@ -187,11 +177,13 @@ const styles = StyleSheet.create({
     borderRightWidth: 1,
     borderRightColor: colors.borderSubtle
   },
-  revealRail: {
-    alignItems: 'center',
-    backgroundColor: colors.bgPanel,
-    borderRightWidth: 1,
-    borderRightColor: colors.borderSubtle
+  revealTab: {
+    position: 'absolute',
+    left: 0,
+    top: '50%',
+    transform: [{ translateY: -16 }],
+    zIndex: 20,
+    elevation: 20
   },
   // Invisible grab strip over the sidebar's right edge. Absolute + elevated so it
   // sits above the worktree list and reliably owns the drag on Android.

--- a/mobile/src/components/HostSidebarToggleButton.test.tsx
+++ b/mobile/src/components/HostSidebarToggleButton.test.tsx
@@ -1,0 +1,53 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { HostSidebarToggleButton } from './HostSidebarToggleButton'
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  StyleSheet: { create: <T,>(styles: T) => styles }
+}))
+vi.mock('lucide-react-native', () => ({
+  PanelLeftClose: 'PanelLeftClose',
+  PanelLeftOpen: 'PanelLeftOpen'
+}))
+
+describe('HostSidebarToggleButton', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  async function render(expanded: boolean, onPress = vi.fn()) {
+    await act(async () => {
+      renderer = create(createElement(HostSidebarToggleButton, { expanded, onPress }))
+    })
+    return { button: renderer!.root.findByType('Pressable'), onPress }
+  }
+
+  it('exposes an accessible reveal action when the sidebar is hidden', async () => {
+    const { button, onPress } = await render(false)
+
+    expect(button.props).toMatchObject({
+      accessibilityRole: 'button',
+      accessibilityLabel: 'Show workspace sidebar',
+      accessibilityHint: 'Shows the workspace list',
+      accessibilityState: { expanded: false },
+      hitSlop: 8
+    })
+    expect(renderer!.root.findByType('PanelLeftOpen')).toBeDefined()
+
+    button.props.onPress()
+    expect(onPress).toHaveBeenCalledOnce()
+  })
+
+  it('reuses the control for the expanded sidebar hide action', async () => {
+    const { button } = await render(true)
+
+    expect(button.props.accessibilityLabel).toBe('Hide workspace sidebar')
+    expect(button.props.accessibilityState).toEqual({ expanded: true })
+    expect(renderer!.root.findByType('PanelLeftClose')).toBeDefined()
+  })
+})

--- a/mobile/src/components/HostSidebarToggleButton.tsx
+++ b/mobile/src/components/HostSidebarToggleButton.tsx
@@ -42,7 +42,10 @@ const styles = StyleSheet.create({
   revealButton: {
     backgroundColor: colors.bgPanel,
     borderWidth: 1,
-    borderColor: colors.borderSubtle
+    borderColor: colors.borderSubtle,
+    borderLeftWidth: 0,
+    borderTopLeftRadius: 0,
+    borderBottomLeftRadius: 0
   },
   buttonPressed: {
     backgroundColor: colors.bgRaised

--- a/mobile/src/components/HostSidebarToggleButton.tsx
+++ b/mobile/src/components/HostSidebarToggleButton.tsx
@@ -1,0 +1,50 @@
+import { PanelLeftClose, PanelLeftOpen } from 'lucide-react-native'
+import { Pressable, StyleSheet } from 'react-native'
+import { colors, radii } from '../theme/mobile-theme'
+
+type HostSidebarToggleButtonProps = {
+  expanded: boolean
+  onPress: () => void
+}
+
+export function HostSidebarToggleButton({ expanded, onPress }: HostSidebarToggleButtonProps) {
+  const Icon = expanded ? PanelLeftClose : PanelLeftOpen
+  const action = expanded ? 'Hide' : 'Show'
+
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        styles.button,
+        !expanded && styles.revealButton,
+        pressed && styles.buttonPressed
+      ]}
+      onPress={onPress}
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel={`${action} workspace sidebar`}
+      accessibilityHint={`${action}s the workspace list`}
+      accessibilityState={{ expanded }}
+      hitSlop={8}
+    >
+      <Icon size={expanded ? 14 : 18} color={colors.textSecondary} />
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: 32,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.button
+  },
+  revealButton: {
+    backgroundColor: colors.bgPanel,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle
+  },
+  buttonPressed: {
+    backgroundColor: colors.bgRaised
+  }
+})

--- a/mobile/src/host-screen/host-screen-header.tsx
+++ b/mobile/src/host-screen/host-screen-header.tsx
@@ -4,7 +4,6 @@ import {
   Filter,
   Layers,
   List,
-  PanelLeftClose,
   Plus,
   Search,
   SlidersHorizontal,
@@ -13,6 +12,7 @@ import {
   X
 } from 'lucide-react-native'
 import { StatusDot } from '../components/StatusDot'
+import { HostSidebarToggleButton } from '../components/HostSidebarToggleButton'
 import { classifyConnection, type ConnectionVerdict } from '../transport/connection-health'
 import { colors } from '../theme/mobile-theme'
 import { hostScreenStyles as styles } from './host-screen-styles'
@@ -106,15 +106,7 @@ export function HostScreenHeader({ controller }: { controller: HostScreenControl
           </Pressable>
         ) : null}
         {embedded && onHideSidebar ? (
-          <Pressable
-            style={styles.sidebarCollapseButton}
-            onPress={onHideSidebar}
-            accessibilityRole="button"
-            accessibilityLabel="Hide sidebar"
-            hitSlop={8}
-          >
-            <PanelLeftClose size={14} color={colors.textSecondary} />
-          </Pressable>
+          <HostSidebarToggleButton expanded onPress={onHideSidebar} />
         ) : null}
       </View>
 

--- a/mobile/src/host-screen/host-screen-primary-styles.ts
+++ b/mobile/src/host-screen/host-screen-primary-styles.ts
@@ -26,14 +26,6 @@ export const hostScreenPrimaryStyles = StyleSheet.create({
     justifyContent: 'center',
     marginRight: spacing.xs
   },
-  sidebarCollapseButton: {
-    width: 24,
-    height: 24,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: radii.button,
-    marginLeft: spacing.xs
-  },
   hostIdentity: {
     flex: 1,
     flexDirection: 'row',

--- a/mobile/src/layout/host-sidebar-presentation.test.ts
+++ b/mobile/src/layout/host-sidebar-presentation.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { getHostSidebarPresentation } from './host-sidebar-presentation'
+
+describe('host sidebar presentation', () => {
+  it('keeps the sidebar visible on the base host route', () => {
+    expect(getHostSidebarPresentation(true, false, false)).toBe('sidebar')
+  })
+
+  it('shows the reveal control for collapsed detail content', () => {
+    expect(getHostSidebarPresentation(true, true, false)).toBe('reveal')
+  })
+
+  it('hides both controls outside wide host layouts', () => {
+    expect(getHostSidebarPresentation(false, true, false)).toBe('hidden')
+  })
+})

--- a/mobile/src/layout/host-sidebar-presentation.ts
+++ b/mobile/src/layout/host-sidebar-presentation.ts
@@ -1,0 +1,15 @@
+export type HostSidebarPresentation = 'hidden' | 'sidebar' | 'reveal'
+
+export function getHostSidebarPresentation(
+  showSidebar: boolean,
+  detailHasContent: boolean,
+  sidebarOpen: boolean
+): HostSidebarPresentation {
+  if (!showSidebar) {
+    return 'hidden'
+  }
+  if (sidebarOpen || !detailHasContent) {
+    return 'sidebar'
+  }
+  return 'reveal'
+}

--- a/mobile/src/layout/responsive-layout-metrics.test.ts
+++ b/mobile/src/layout/responsive-layout-metrics.test.ts
@@ -28,12 +28,69 @@ describe('responsive layout metrics', () => {
     })
   })
 
-  it('keeps landscape phones out of wide tablet layout', () => {
+  it('uses wide layout on sufficiently wide landscape phones', () => {
     expect(getResponsiveLayoutMetrics(932, 430)).toMatchObject({
       isLandscape: true,
       isTabletLayout: false,
+      isWideLayout: true,
+      horizontalPadding: spacing.xl
+    })
+  })
+
+  it.each([
+    {
+      width: 699,
+      height: 430,
+      isLandscape: true,
+      isTabletLayout: false,
       isWideLayout: false,
-      horizontalPadding: spacing.lg
+      label: 'landscape phone below 700px'
+    },
+    {
+      width: 700,
+      height: 430,
+      isLandscape: true,
+      isTabletLayout: false,
+      isWideLayout: true,
+      label: 'landscape phone at 700px'
+    },
+    {
+      width: 700,
+      height: 700,
+      isLandscape: false,
+      isTabletLayout: true,
+      isWideLayout: true,
+      label: 'square tablet at 700px'
+    },
+    {
+      width: 699,
+      height: 700,
+      isLandscape: false,
+      isTabletLayout: true,
+      isWideLayout: false,
+      label: 'tablet window below 700px'
+    },
+    {
+      width: 600,
+      height: 900,
+      isLandscape: false,
+      isTabletLayout: true,
+      isWideLayout: false,
+      label: 'tablet short side at 600px'
+    },
+    {
+      width: 599,
+      height: 900,
+      isLandscape: false,
+      isTabletLayout: false,
+      isWideLayout: false,
+      label: 'tablet short side below 600px'
+    }
+  ])('classifies $label', ({ width, height, isLandscape, isTabletLayout, isWideLayout }) => {
+    expect(getResponsiveLayoutMetrics(width, height)).toMatchObject({
+      isLandscape,
+      isTabletLayout,
+      isWideLayout
     })
   })
 })

--- a/mobile/src/layout/responsive-layout-metrics.ts
+++ b/mobile/src/layout/responsive-layout-metrics.ts
@@ -3,8 +3,6 @@ import { spacing } from '../theme/mobile-theme'
 // Use actual window size so narrow iPad splits keep phone-like layouts.
 const WIDE_LAYOUT_MIN_WIDTH = 700
 
-// Why: width alone catches landscape phones; capped tablet layouts need room
-// in both dimensions so phone rotation does not switch UI classes.
 const TABLET_LAYOUT_MIN_SHORT_SIDE = 600
 
 const CONTENT_MAX_WIDTH = 720
@@ -27,13 +25,14 @@ export type ResponsiveLayoutMetrics = {
 }
 
 export function getResponsiveLayoutMetrics(width: number, height: number): ResponsiveLayoutMetrics {
+  const isLandscape = width > height
   const isTabletLayout = Math.min(width, height) >= TABLET_LAYOUT_MIN_SHORT_SIDE
-  const isWideLayout = width >= WIDE_LAYOUT_MIN_WIDTH && isTabletLayout
+  const isWideLayout = width >= WIDE_LAYOUT_MIN_WIDTH && (isTabletLayout || isLandscape)
 
   return {
     width,
     height,
-    isLandscape: width > height,
+    isLandscape,
     isWideLayout,
     isTabletLayout,
     contentMaxWidth: CONTENT_MAX_WIDTH,


### PR DESCRIPTION
## ELI5

Orca Mobile now keeps the workspace list beside the active workspace when a landscape phone is wide enough, just like on a tablet. If the list is hidden, a compact edge tab remains so it can always be reopened without taking width away from the workspace.

## What Changed

- Classify windows as wide when width is at least 700px and the window is either tablet-sized or landscape.
- Preserve the existing 600px tablet short-side classification.
- Reuse one accessible `HostSidebarToggleButton` for both hide and reopen actions.
- Show the reopen action as a compact floating edge tab instead of a full-height rail.
- Keep the base host route sidebar visible synchronously, including the render before its state-reset effect runs.
- Add boundary, accessibility, and sidebar-presentation regression tests.

This change is based on `main` and is independent from keyboard-navigation PR #18195.

## Why

Wide landscape phones have enough room for the tablet-style workspace split view, but were forced into full-screen list navigation. Wide layouts also had no in-place way to recover after hiding the workspace sidebar.

The list, host catalog, and navigation implementation are unchanged, so folder workspaces and git worktrees continue through the same existing paths.

## Linked Issue

Fixes #18365

## Visual Proof

### Before: landscape phone opens the session without a workspace sidebar

![Before: landscape phone with a full-screen session and no workspace sidebar in iPhone Simulator frame](https://github.com/user-attachments/assets/ebf8e644-8fd8-4167-89ea-c4300f88ffff)

### After: landscape phone uses the wide split layout

![After: landscape phone with workspace sidebar and detail in iPhone Simulator frame](https://github.com/user-attachments/assets/fa184a77-2ded-494f-81bc-1103e58ea963)

### After collapse: compact reopen edge tab without an empty rail

![After collapse: compact upper-left reopen tab in iPhone Simulator frame](https://github.com/user-attachments/assets/87ddf32b-5c0d-4394-a976-dae84b95ee31)

## Testing

- [x] I manually tested these changes locally.
- [x] Automated tests added/updated.
- `pnpm --dir mobile test src/layout/responsive-layout-metrics.test.ts src/layout/host-sidebar-presentation.test.ts src/components/HostSidebarToggleButton.test.tsx` — 14 tests passed.
- `pnpm tc` — passed.
- `pnpm run check:code-quality:changed` — passed with 0 findings.
- iPhone 17 Pro simulator, iOS 26.5, landscape — verified before/after layout, hide, accessible reveal tab, reopen, and return to the base host route against the mock runtime.
- iPad mini simulator, iOS 26.5, landscape — verified split layout, hide, reveal, and reopen against the mock runtime.
- Android/Fold hardware was not available; the shared React Native path and deterministic width boundaries are covered by tests.

## Author

- GitHub: @isairz
- X: N/A (no public handle listed)

## AI Disclosure

OpenAI Codex (GPT-5) was used for implementation, tests, review, and simulator validation.

## Review

- Security: no authentication, persistence, secrets, or remote protocol changes.
- Cross-platform: shared React Native layout and pressable behavior only; no platform-specific APIs remain in the implementation.
- SSH/remote/local: no RPC, execution-host, connection, or navigation contract changes.
- Agents/integrations/git providers: no agent, integration, or provider-specific behavior changes.
- Folder workspaces/git worktrees: the existing host workspace catalog and routes are reused unchanged.
- Performance: constant-time dimension and presentation decisions; the hidden sidebar unmount behavior is unchanged.
- UI/accessibility: existing mobile theme tokens and Lucide icons are reused; the control exposes button role, label, hint, expanded state, and 48pt effective hit area.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer source.

## Notes

The base host route resolves directly to the visible-sidebar presentation, so a collapsed detail route cannot flash the reveal control over the empty placeholder while the state-reset effect runs.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why.
- [x] Before/after screenshots are attached.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and compatibility impact considered.
- [x] Scoped tests, `pnpm tc`, and changed-file quality checks pass; remaining full-suite/build coverage is left to CI.
