### PR TITLE
fix(ssh): treat a missing git route as an unavailable worktree graph

### DIFF
--- a/src/main/ipc/hosted-review.test.ts
+++ b/src/main/ipc/hosted-review.test.ts
@@ -56,6 +56,7 @@ vi.mock('../repo-worktrees', () => ({
 }))
 
 import { registerHostedReviewHandlers } from './hosted-review'
+import { WorktreeCatalogUnavailableError } from '../../shared/worktree/worktree-catalog-availability'
 
 type HandlerMap = Record<string, (_event: unknown, args: unknown) => unknown>
 
@@ -474,6 +475,28 @@ describe('registerHostedReviewHandlers', () => {
       'ssh-1',
       { localGitExecOptions: { admissionTier: 'interactive' } }
     )
+    expect(createHostedReviewMock).not.toHaveBeenCalled()
+  })
+
+  it('does not rewrite a missing worktree catalog as Access denied', async () => {
+    const catalogError = new WorktreeCatalogUnavailableError(
+      `Worktree catalog unavailable for ${repoPath}: SSH connection "ssh-1" is not connected.`
+    )
+    listRepoWorktreeGraphMock.mockRejectedValue(catalogError)
+
+    registerHostedReviewHandlers(store as never, stats as never)
+
+    await expect(
+      handlers['hostedReview:create'](null, {
+        repoPath,
+        repoId: repo.id,
+        worktreePath,
+        provider: 'github',
+        base: 'main',
+        head: 'feature/pr',
+        title: 'Feature PR'
+      })
+    ).rejects.toBe(catalogError)
     expect(createHostedReviewMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/repo-worktrees.test.ts
+++ b/src/main/repo-worktrees.test.ts
@@ -253,6 +253,44 @@ describe('repo-worktrees', () => {
       expect(listWorktrees).not.toHaveBeenCalled()
       expect(listWorktreesMock).not.toHaveBeenCalled()
     })
+
+    it('never lists an ssh-owned graph with local git when the provider is missing', async () => {
+      await expect(listRepoWorktreeGraph(sshOnlyRepo)).rejects.toThrow(
+        WorktreeCatalogUnavailableError
+      )
+      await expect(listRepoWorktreeGraph(sshOnlyRepo)).rejects.toThrow(
+        'Worktree catalog unavailable for /srv/repo: SSH connection "host-a" is not connected.'
+      )
+      expect(listWorktreeGraphMock).not.toHaveBeenCalled()
+    })
+
+    it('lists an ssh-owned graph through its registered provider', async () => {
+      const listWorktrees = vi.fn().mockResolvedValue([{ path: '/srv/repo' }])
+      registerSshGitProvider('host-a', { listWorktrees } as never)
+
+      await expect(listRepoWorktreeGraph(sshOnlyRepo)).resolves.toEqual([{ path: '/srv/repo' }])
+      expect(listWorktrees).toHaveBeenCalledWith('/srv/repo')
+      expect(listWorktreeGraphMock).not.toHaveBeenCalled()
+    })
+
+    it('refuses to answer a runtime-owned graph from a same-named local target', async () => {
+      const listWorktrees = vi.fn().mockResolvedValue([{ path: '/wrong/host' }])
+      registerSshGitProvider('nested-target', { listWorktrees } as never)
+
+      const runtimeRepo = {
+        ...sshOnlyRepo,
+        executionHostId: 'runtime:env-7' as const,
+        connectionId: 'nested-target'
+      }
+      await expect(listRepoWorktreeGraph(runtimeRepo)).rejects.toThrow(
+        WorktreeCatalogUnavailableError
+      )
+      await expect(listRepoWorktreeGraph(runtimeRepo)).rejects.toThrow(
+        'Worktree catalog unavailable for /srv/repo: host runtime:env-7 is not reachable from this process.'
+      )
+      expect(listWorktrees).not.toHaveBeenCalled()
+      expect(listWorktreeGraphMock).not.toHaveBeenCalled()
+    })
   })
 
   it('treats Windows repo root casing differences as the same local root', () => {

--- a/src/main/repo-worktrees.ts
+++ b/src/main/repo-worktrees.ts
@@ -85,14 +85,18 @@ export async function listRepoWorktreeGraph(
     return [createFolderWorktree(repo)]
   }
   const route = resolveGitRouteForHost(getRepoExecutionHostId(repo))
-  // An unreachable remote host answers `[]` here, unlike listRepoWorktrees above, which throws.
-  // Preserved as-is: this call site's callers treat the graph as best-effort. The inconsistency is
-  // real but is a separate behavior decision from resolving the host correctly.
   if (route.kind === 'runtime') {
-    return []
+    throw new WorktreeCatalogUnavailableError(
+      `Worktree catalog unavailable for ${repo.path}: host ${route.hostId} is not reachable from this process.`
+    )
   }
   if (route.kind === 'ssh') {
-    return route.provider ? await route.provider.listWorktrees(repo.path) : []
+    if (!route.provider) {
+      throw new WorktreeCatalogUnavailableError(
+        `Worktree catalog unavailable for ${repo.path}: SSH connection "${route.connectionId}" is not connected.`
+      )
+    }
+    return await route.provider.listWorktrees(repo.path)
   }
   return hasLocalRepoWorktreeListOptions(options)
     ? await listWorktreeGraph(repo.path, options)


### PR DESCRIPTION
## ELI5

If Orca cannot ask the SSH or runtime host which worktrees exist, it used to pretend the answer was "none." Review and PR actions then said the worktree did not belong to the repo. Now that miss throws "catalog unavailable" instead of looking like an empty list.

## What Changed

`listRepoWorktreeGraph` now shares `listRepoWorktrees`' SSH/runtime miss policy:

- `route.kind === 'runtime'` throws `WorktreeCatalogUnavailableError` with the unreachable-host message.
- `route.kind === 'ssh' && !route.provider` throws with the not-connected message.
- A connected SSH provider still returns `provider.listWorktrees`.
- Folder repos still return one synthetic worktree. Local git still uses probe-free `listWorktreeGraph`.

The miss signal is `resolveGitRouteForHost(getRepoExecutionHostId(repo))`, not `getSshGitProvider`. Hosted-review membership lets the catalog error propagate; it does not rewrite it to `Access denied: worktree does not belong to repository`.

This replaces the first executor's STOP'd attempt on #18287, which still used `getSshGitProvider` as the miss signal. Do not merge #18287.

## Why

`listRepoWorktrees` already failed closed when the git route was unreachable. Path-only callers used the graph listing, which fail-opened `[]`. Hosted-review membership then threw Access denied and blocked PR/review on live remote worktrees until reconnect.

Loss of contact is not evidence of emptiness (`docs/reference/ssh-execution-boundary.md`). This is silent-wrong inventory, not silent local git (SSH/runtime never fall back to local).

## Linked Issue

Fixes #18272

## Visual Proof

N/A — no UI or interaction change. This is a main-process listing error policy; the user-visible difference is the error text on review/PR actions while the host is unreachable.

## Testing

- `pnpm test src/main/repo-worktrees.test.ts` — 17 passed (missing SSH provider throws; connected provider lists; runtime host throws the runtime message and never dials `connectionId` as a local SSH target; folder graph still synthetic)
- `pnpm test src/main/ipc/hosted-review.test.ts` — 13 passed (catalog throw is the same error object, not Access denied)
- `pnpm tc:node` — exit 0
- `pnpm run check:code-quality:changed` — 0 findings
- Platforms actually exercised: unit tests on macOS. Linux/Windows/SSH behavior is covered by the route kinds in those tests (`ssh:host-a`, `runtime:env-7`, local git, folder). No Electron UI session.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Internal contributor — skip.

## Review

Code-reviewer subagent: ready to merge. Graph listing now shares `listRepoWorktrees` SSH/runtime miss policy with identical strings, no local git fallback, and tests for the three required route cases plus hosted-review non-rewriting.

- Cross-platform: path/listing policy is host-route based, not OS-path based. Local Windows casing in `isRepoRoot` is unchanged.
- SSH/remote: SSH miss throws; runtime miss throws and does not treat `connectionId` as a local SSH target; local git unchanged.
- Agents/integrations: no agent, skill, or git-provider surface change. Hosted-review still denies a path absent from an authoritative listing.
- Performance: no extra git execs; unreachable routes throw before listing.
- UI: no visual change.
- Security: fail-closed inventory; does not authorize a worktree from an empty miss. `registered-worktree-roots-cache` already catches per repo; `filesystem-source-control-ai-targets` already catches and returns false.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Review/PR actions on an SSH or runtime worktree while the git route is missing now fail as catalog-unavailable instead of access-denied.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Local verification used the plan commands (`pnpm tc:node`, targeted tests, `check:code-quality:changed`). Full `pnpm lint` / `pnpm build` skipped per executor instructions.