### PR TITLE
fix(worktree): refuse unqualified lookups when two hosts share an id

### DIFF
--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -35,8 +35,8 @@ export function runWorktreeDelete(worktreeId: string, options: WorktreeDeleteOpt
   const state = useAppStore.getState()
   // Why (STA-4343): the id-keyed map keeps one row per `repoId::path`, so a caller
   // acting on a specific sidebar row has to name that row's host — otherwise
-  // deleting the SSH row destroys the local checkout at the same path. A caller
-  // that names no host keeps the old first-wins behaviour.
+  // deleting the SSH row destroys the local checkout at the same path. An
+  // unqualified collision fail-closes here instead of first-wins.
   const target = getWorktreeOnHostFromState(state, worktreeId, options.expectedHostId) ?? null
   const instanceChanged =
     Object.hasOwn(options, 'expectedInstanceId') &&

--- a/src/renderer/src/components/sidebar/worktree-delete-host-qualification.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-host-qualification.test.ts
@@ -65,6 +65,7 @@ vi.mock('./delete-worktree-failure-toast', () => ({
   showDeleteWorktreeFailureToast: vi.fn()
 }))
 
+import { toast } from 'sonner'
 import { showDeleteWorktreeFailureToast } from './delete-worktree-failure-toast'
 import { runWorktreeDelete, runWorktreeDeletesInParallel } from './delete-worktree-flow'
 
@@ -234,6 +235,33 @@ describe('STA-4343 sidebar delete: the confirmed row decides the host', () => {
     expect(fs.existsSync(local.markerPath)).toBe(false)
     expect(fs.existsSync(ssh.markerPath)).toBe(true)
     expect(showDeleteWorktreeFailureToast).not.toHaveBeenCalled()
+  })
+
+  it('does not delete either checkout when two hosts share an id and no host is named', async () => {
+    const local = createHostCheckout(LOCAL_HOST)
+    const ssh = createHostCheckout(SSH_HOST)
+    const routedHostIds: string[] = []
+    installRemovalTransports(
+      { remove: mockApi.worktrees.remove, runtimeCall: runtimeEnvironmentCall },
+      { [LOCAL_HOST]: local.root, [SSH_HOST]: ssh.root },
+      routedHostIds
+    )
+    const store = storeRef.current as ReturnType<typeof createTestStore>
+    seedCollidingSidebar(store, SSH_HOST)
+
+    runWorktreeDelete(WORKTREE_ID)
+    await vi.waitFor(() => expect(toast.info).toHaveBeenCalled())
+
+    expect(fs.existsSync(local.markerPath), 'the local checkout must survive').toBe(true)
+    expect(fs.existsSync(ssh.markerPath), 'the SSH checkout must survive').toBe(true)
+    expect(routedHostIds).toEqual([])
+    expect(toast.info).toHaveBeenCalledWith(
+      'Workspace list changed',
+      expect.objectContaining({
+        description: 'Refresh Space and try again if the workspace list looks stale.'
+      })
+    )
+    expect(store.getState().worktreesByRepo.repo1).toHaveLength(2)
   })
 
   it('still deletes an ordinary single-host SSH workspace for real', async () => {

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -204,6 +204,9 @@ export function getWorktreeMapFromState(
  * The row for one id on one host (STA-4343). Prefer this over the id-keyed map
  * anywhere the caller already knows which host's row it is acting on — the map
  * keeps a single row per id and cannot represent a two-host collision.
+ *
+ * When `hostId` is omitted, a single row is unambiguous; two hosts sharing the
+ * id fail closed (`undefined`) instead of first-wins.
  */
 export function getWorktreeOnHostFromState(
   state: Pick<AppState, 'worktreesByRepo'>,
@@ -211,7 +214,10 @@ export function getWorktreeOnHostFromState(
   hostId: ExecutionHostId | undefined
 ): Worktree | undefined {
   const rows = getCachedWorktreesById(state.worktreesByRepo, worktreeId)
-  return hostId ? rows.find((row) => row.hostId === hostId) : rows[0]
+  if (hostId) {
+    return rows.find((row) => row.hostId === hostId)
+  }
+  return rows.length === 1 ? rows[0] : undefined
 }
 
 export function getHasAnyWorktreesFromState(state: Pick<AppState, 'worktreesByRepo'>): boolean {

--- a/src/renderer/src/store/worktree-host-collision-index.test.ts
+++ b/src/renderer/src/store/worktree-host-collision-index.test.ts
@@ -14,6 +14,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Worktree } from '../../../shared/worktree/types'
 import type { AppState } from './types'
+import { getWorktreeOnHostFromState } from './selectors'
 import {
   getIndexedAllWorktrees,
   getIndexedWorktreeMap,
@@ -89,5 +90,28 @@ describe('id-keyed worktree projections keep distinct hosts distinct', () => {
     expect(getIndexedWorktreeMap(worktreesByRepo).get(SHARED_ID)).toBe(
       buildWorktreeByIdIndex(worktreesByRepo).get(SHARED_ID)
     )
+  })
+})
+
+describe('getWorktreeOnHostFromState fails closed on an unqualified collision', () => {
+  const colliding = { worktreesByRepo: byRepo(localRow, sshRow) }
+
+  it('returns undefined when host is omitted and two hosts share the id', () => {
+    expect(getWorktreeOnHostFromState(colliding, SHARED_ID, undefined)).toBeUndefined()
+  })
+
+  it('returns the ssh row when that host is named', () => {
+    expect(getWorktreeOnHostFromState(colliding, SHARED_ID, 'ssh:build-box')).toBe(sshRow)
+  })
+
+  it('returns the single row when host is omitted and the id is unambiguous', () => {
+    const single = { worktreesByRepo: byRepo(localRow) }
+    expect(getWorktreeOnHostFromState(single, SHARED_ID, undefined)).toBe(localRow)
+  })
+
+  it('returns undefined when no row exists', () => {
+    expect(
+      getWorktreeOnHostFromState({ worktreesByRepo: {} }, SHARED_ID, undefined)
+    ).toBeUndefined()
   })
 })


### PR DESCRIPTION
## ELI5

A workspace id is `repoId::path` with no host. Local and SSH can publish the same id for two different checkouts. An unqualified lookup used to pick the first row, so deleting the SSH card could wipe the local directory. If two hosts share an id and nobody names the host, we now refuse to guess.

## What Changed

`getWorktreeOnHostFromState` fail-closes when `hostId` is omitted and more than one host publishes the id:

- 0 rows → `undefined`
- 1 row → that row (unambiguous)
- >1 rows → `undefined` (not `rows[0]`)
- named `hostId` → `rows.find(row => row.hostId === hostId)` as before

`runWorktreeDelete` already looks up through this selector, so a colliding unqualified delete shows the existing "Workspace list changed" toast and does not call remove. Sidebar/row callers already pass `expectedHostId: worktree.hostId`.

## Why

STA-4343: deleting the SSH row without a host destroyed the local checkout at the same path. First-wins is silent-wrong inventory for a destructive action. Fail-closed is the honest outcome until the caller names the host. Follow-up (not this PR): key `worktreeMap` on `composeWorktreeHostIdentity`.

Related open #17799 is host-blind folder `connectionId`, not this map. Do not merge them.

## Linked Issue

Fixes #18279

## Visual Proof

N/A — no UI or interaction change. The user-visible difference is a stale-list toast instead of deleting the wrong host's checkout when two hosts share an id and the caller omitted the host.

## Testing

- `pnpm test src/renderer/src/store/selectors.test.ts src/renderer/src/store/worktree-host-collision-index.test.ts src/renderer/src/components/sidebar` — 290 files, 2479 passed
- New selector tests failed on current `rows[0]`, then passed after the fail-close
- New delete-funnel test: two-host collision with no `expectedHostId` leaves both disk markers, routes to no host, toasts, keeps both store rows
- Existing qualification tests still delete only the named SSH or local row
- `pnpm tc:web` — exit 0
- `pnpm run check:code-quality:changed` — 0 findings
- Platforms actually exercised: unit tests on macOS. Collision fixtures use `local` vs `ssh:ssh-1` / `ssh:build-box` and `path.join`/`os.tmpdir`. No Electron UI session.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Internal contributor — skip.

## Review

Code-reviewer subagent: ready to merge. Selector fail-closes exactly as specified; delete funnel reuses the existing stale-list toast; tests would fail on `rows[0]`.

- Cross-platform: no OS-specific paths, shortcuts, or spawn. Fixture dirs use `path.join` and `os.tmpdir`.
- SSH/remote: named SSH host still deletes only the SSH checkout; unqualified collision deletes neither; local checkout survives an SSH-card delete (existing qualification tests).
- Security: fail-closed identity for a destructive action; does not authorize a delete from an ambiguous id.
- Performance: one extra `rows.length` check on an already-indexed list.
- UI: no visual change.
- `worktree-runtime-owner.ts` left alone: delete does not use it; no test showed a destructive fall-through to `'local'`.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

A collision must not delete the local checkout when the user clicked the SSH card.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Local verification used the plan commands (`pnpm tc:web`, targeted tests, `check:code-quality:changed`). Full `pnpm lint` / `pnpm build` skipped per executor instructions.
