### PR TITLE
fix(ssh): pick the eligible expired lease, not the first one matching a pane

### DIFF
--- a/src/main/runtime/expired-ssh-lease-pane-candidacy.test.ts
+++ b/src/main/runtime/expired-ssh-lease-pane-candidacy.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { HEADLESS_LEAF_ID, TEST_WORKTREE_ID, store } from './orca-runtime-test-fixtures.spec'
+import { OrcaRuntimeService } from './orca-runtime'
+import type { SshRemotePtyLease } from '../../shared/ssh-types'
+
+// Which `expired` SSH leases may answer "this pane is still recoverable". A pane accumulates leases
+// as it re-leases under new relay ids, so the pane coordinates alone name several and the reader
+// has to pick the ELIGIBLE orphan rather than the first id match. Lives in a `*.test.ts` because
+// config/vitest.config.ts — the config CI runs — includes only `*.test.ts`.
+
+const TARGET = 'ssh-target'
+const TAB_ID = 'tab-candidacy'
+
+type LeaseReader = {
+  getRecentExpiredSshLease: (
+    worktreeId: string,
+    tabId: string,
+    leafId: string | undefined,
+    ptyId?: string
+  ) => SshRemotePtyLease | null
+  hasRecentExpiredSshLeasePane: (
+    worktreeId: string,
+    tab: { parentTabId: string; leafId: string }
+  ) => boolean
+}
+
+function leaseFor(ptyId: string, marks: Partial<SshRemotePtyLease> = {}): SshRemotePtyLease {
+  const now = Date.now()
+  return {
+    targetId: TARGET,
+    ptyId,
+    worktreeId: TEST_WORKTREE_ID,
+    tabId: TAB_ID,
+    leafId: HEADLESS_LEAF_ID,
+    state: 'expired',
+    createdAt: now,
+    updatedAt: now,
+    ...marks
+  } as SshRemotePtyLease
+}
+
+function readerWithLeases(leases: SshRemotePtyLease[]): LeaseReader {
+  return new OrcaRuntimeService({
+    ...store,
+    getSshRemotePtyLeases: () => leases
+  }) as unknown as LeaseReader
+}
+
+const pane = { parentTabId: TAB_ID, leafId: HEADLESS_LEAF_ID }
+
+describe('recent expired SSH lease candidacy', () => {
+  it('reports a plain expired orphan', () => {
+    // Control: `expired` carrying no retirement mark is an orphan whose reattach merely lost
+    // contact, which is exactly what the recovery affordance exists for.
+    const reader = readerWithLeases([leaseFor('pty-1')])
+
+    expect(reader.hasRecentExpiredSshLeasePane(TEST_WORKTREE_ID, pane)).toBe(true)
+  })
+
+  it('does not report a pane whose only recent lease was superseded', () => {
+    // `supersededBy` names the lease that won this pane, so the id no longer routes to the shell
+    // this lease describes. `recoverTerminalPane` refuses it, so reporting it here offers a paired
+    // viewer a recovery that cannot succeed.
+    const reader = readerWithLeases([leaseFor('pty-1', { supersededBy: 'pty-2' })])
+
+    expect(reader.hasRecentExpiredSshLeasePane(TEST_WORKTREE_ID, pane)).toBe(false)
+  })
+
+  it('does not report a pane whose only recent lease had its relay id recycled', () => {
+    // Same shape, other mark: the relay handed this id to a different shell, so adopting through
+    // it would hand the pane a stranger's process.
+    const reader = readerWithLeases([leaseFor('pty-1', { relayIdRecycled: true })])
+
+    expect(reader.hasRecentExpiredSshLeasePane(TEST_WORKTREE_ID, pane)).toBe(false)
+  })
+
+  it('picks the eligible orphan over a superseded predecessor that matches first', () => {
+    // The pane's coordinates name both leases and the predecessor is stored first, so a reader
+    // that took the first match would answer with the one lease that cannot be reattached.
+    const reader = readerWithLeases([
+      leaseFor('pty-1', { supersededBy: 'pty-2' }),
+      leaseFor('pty-2')
+    ])
+
+    expect(reader.getRecentExpiredSshLease(TEST_WORKTREE_ID, TAB_ID, HEADLESS_LEAF_ID)?.ptyId).toBe(
+      'pty-2'
+    )
+    expect(reader.hasRecentExpiredSshLeasePane(TEST_WORKTREE_ID, pane)).toBe(true)
+  })
+})

--- a/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
+++ b/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
@@ -11,6 +11,7 @@ import { appendBrowserTabOrder } from './mobile-session-browser-group-projection
 import { parseAppSshPtyId, toComparableRelaySshPtyId } from '../../shared/ssh-pty-id'
 import { toSshExecutionHostId } from '../../shared/execution-host'
 import { parsePaneKey } from '../../shared/stable-pane-id'
+import { sshRemotePtyLeaseAllowsReattach } from '../../shared/ssh-types'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import type { RuntimeStore } from './runtime-store-contract'
 import { SSH_PANE_RECOVERY_GRACE_MS } from './orca-runtime-core'
@@ -137,6 +138,16 @@ export class OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs extends Or
     return (
       this.store?.getSshRemotePtyLeases?.().find((lease) => {
         if (lease.state !== 'expired' || lease.worktreeId !== worktreeId) {
+          return false
+        }
+        // Why eligibility belongs in the selection, not after it: a pane accumulates leases as it
+        // re-leases under new relay ids, so `(worktreeId, tabId, leafId)` names several. A
+        // superseded or relay-id-recycled predecessor is `expired` for a reason that already names
+        // its successor, and the unqualified callers use this answer to decide a pane is still
+        // recoverable — reporting one would offer paired viewers a recovery `recoverTerminalPane`
+        // then refuses. Picking the first ELIGIBLE orphan also keeps a predecessor from shadowing
+        // the successor that is genuinely reattachable.
+        if (!sshRemotePtyLeaseAllowsReattach(lease)) {
           return false
         }
         // Leaf is the pane's identity; the frozen tabId is only trustworthy while nothing else can

--- a/src/main/runtime/orca-runtime-resolve-terminal-pane.ts
+++ b/src/main/runtime/orca-runtime-resolve-terminal-pane.ts
@@ -7,7 +7,6 @@ import type {
 } from '../../shared/runtime-types'
 import type { RuntimeProviderSnapshotReadOptions } from './runtime-terminal-contracts'
 import { parsePaneKey } from '../../shared/stable-pane-id'
-import { sshRemotePtyLeaseAllowsReattach } from '../../shared/ssh-types'
 import {
   buildVisibleSnapshotReadFallback,
   labelTerminalReadSource,
@@ -85,13 +84,11 @@ export class OrcaRuntimeWithResolveTerminalPane extends OrcaRuntimeWithGetTermin
       pty.ptyId
     )
     if (!expiredLease) {
-      // Why: an explicit close leaves a terminated lease; only relay expiry authorizes shell recreation.
-      throw new Error('terminal_not_recoverable')
-    }
-    // Why: a superseded or relay-id-recycled lease is `expired` for a reason that already names the
-    // successor — the pane's id no longer routes to the shell this lease describes, so recovering
-    // through it would adopt a stranger's process or re-race a pane that already moved on.
-    if (!sshRemotePtyLeaseAllowsReattach(expiredLease)) {
+      // Why: an explicit close leaves a terminated lease; only relay expiry authorizes shell
+      // recreation. `getRecentExpiredSshLease` also refuses a superseded or relay-id-recycled
+      // lease, which is `expired` for a reason that already names the successor — the pane's id no
+      // longer routes to the shell it describes, so recovering through it would adopt a stranger's
+      // process or re-race a pane that already moved on.
       throw new Error('terminal_not_recoverable')
     }
     // Why an `expired` lease is not on its own authority to spawn a replacement: every writer of


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 |

<!-- /orca-pr-loc -->

## The ticket's stated mechanism does not reproduce

STA-6536 (F9, filed against #17969) says pane recovery picks the first lease matching an id rather than the first *eligible* one, and can therefore readopt a pane onto a superseded route. On the path it names — `recoverTerminalPane` → `getRecentExpiredSshLease(..., pty.ptyId)` — that cannot happen:

- Lease identity is `(targetId, ptyId)`, enforced by the `findIndex` upsert key at `src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts:140-142`, so at most one lease matches per target.
- `toComparableRelaySshPtyId` returns the app-form id unchanged when it names a different target (`src/shared/ssh-pty-id.ts:74-80`), so a lease on another host can never match either.

With one candidate, "first match" and "eligible match" are the same lease, and the post-hoc `sshRemotePtyLeaseAllowsReattach` check #17969 added could never be shadowed. **No wrong-route readoption was reachable.**

## What is actually wrong

The same reader has two other callers that pass no `ptyId`:

- `workspaceSessionWorktreeHasRuntimeOwnedPtyCandidate` (`orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts:93`)
- `hasRecentExpiredSshLeasePane` (`:166`), consumed by `hasLiveOrPersistedServeOrSshOwnedPtyBinding` and by the `onlyRuntimeOwnedTerminals` hydrate filter

Both take a bare `!== null`, and neither applies the eligibility predicate — before or after. `(worktreeId, tabId, leafId)` is **not** unique: `supersedeSiblingLeasesForPane` exists because a pane accumulates leases as it re-leases under new relay ids, and it stamps `supersededBy` on an already-expired predecessor precisely so that predecessor stops counting.

So inside the 30s `SSH_PANE_RECOVERY_GRACE_MS` window, a pane whose only recent lease is a superseded or relay-id-recycled corpse was reported as runtime-owned and preserved for recovery — a recovery `recoverTerminalPane` then refuses. Where an eligible successor also exists, the predecessor is stored first and shadowed it.

## Fix

Apply the existing `sshRemotePtyLeaseAllowsReattach` **inside** the selection, matching the shape the two `ssh-relay-session.ts` sites already use (`:2038` predicate-in-`find`, `:2330` `.filter`). The reader now answers with the first *eligible* orphan or nothing, and all three callers agree on what `expired` authorizes. `recoverTerminalPane`'s own check becomes unreachable and is folded into the comment on the branch that now covers it.

No new predicate, no new resolver.

## Severity

An over-report in headless/mobile reconciliation, **not** a wrong-route readoption — the id-qualified recovery path already refused these leases. The ticket currently reads as much worse than it is.

## Tests

`src/main/runtime/expired-ssh-lease-pane-candidacy.test.ts` — 3 of 4 fail on `main`, all pass here; the 4th is the plain-orphan control that must keep passing both ways:

- reports a plain expired orphan (control)
- does not report a pane whose only recent lease was superseded — **fails before**
- does not report a pane whose only recent lease had its relay id recycled — **fails before**
- picks the eligible orphan over a superseded predecessor that matches first — **fails before**

In a `*.test.ts` deliberately: `config/vitest.config.ts` — the config CI runs — includes only `*.test.ts`, so the `orca-runtime-tests/*.spec.ts` neighbours never execute.

## Compatibility

No wire change and no host-semantics change. `expired` still says only that the client lost its route; nothing here asserts a remote shell died.

## Verification against #18013

#18013 merged during this triage and does not close it: it moved `getRecentExpiredSshLease` and changed it to resolve the leaf's *current* tab via `findCurrentTerminalTabIdForLeaf` instead of the lease's frozen `tabId`, but added no predicate to the `.find`. This is based on `720c3299ba7`.
