### PR TITLE
fix(crash-reporting): record Orca-initiated tree kills so a killed renderer is decidable

### DIFF
--- a/src/main/claude-accounts/claude-command-process.ts
+++ b/src/main/claude-accounts/claude-command-process.ts
@@ -1,4 +1,4 @@
-import { spawnProcess, type ChildProcessHandle } from '../../shared/child-process/run-process'
+import { spawnProcess } from '../../shared/child-process/run-process'
 import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import {
   buildWindowsHostInteractiveLoginSpawn,
@@ -6,9 +6,9 @@ import {
 } from '../../shared/windows-interactive-login-spawn'
 import { resolveClaudeCommand } from '../codex-cli/command'
 import { buildWindowsCommandInvocation } from './windows-command-invocation'
+import { terminateClaudeProcess } from './claude-login-process-termination'
 
 const MAX_COMMAND_OUTPUT_CHARS = 4_000
-const WINDOWS_TASKKILL_TIMEOUT_MS = 5_000
 const CLAUDE_AUTH_DENIED_PATTERN =
   /\baccess_denied\b|authorization (?:request )?(?:was )?denied|sign-?in (?:was )?denied|login (?:was )?denied/i
 
@@ -236,67 +236,4 @@ function resolveClaudeInvocation(
             windowsVerbatimArguments: false
           }
   return spawnConfig
-}
-
-function terminateClaudeProcess(
-  child: ChildProcessHandle,
-  interactiveLogin: WindowsHostInteractiveLoginSpawn | null,
-  afterKill: () => void
-): void {
-  const killWindowsTree = (windowsTerminationPid: number): void => {
-    const taskkill = spawnProcess({
-      program: 'taskkill.exe',
-      args: ['/pid', String(windowsTerminationPid), '/t', '/f'],
-      stdio: 'ignore'
-    })
-    let finished = false
-    const finish = (succeeded: boolean): void => {
-      if (finished) {
-        return
-      }
-      finished = true
-      clearTimeout(taskkillTimeout)
-      if (!succeeded) {
-        child.kill()
-      }
-      afterKill()
-    }
-    const taskkillTimeout = setTimeout(() => {
-      taskkill.kill()
-      finish(false)
-    }, WINDOWS_TASKKILL_TIMEOUT_MS)
-    taskkill.once('error', () => finish(false))
-    taskkill.once('close', (code) => finish(code === 0))
-  }
-  if (process.platform === 'win32') {
-    // The wrapper's own PID never owns the login tree, so prefer the relayed PID.
-    const resolveTerminationPid = interactiveLogin?.waitForTerminationPid
-      ? interactiveLogin.waitForTerminationPid()
-      : Promise.resolve(interactiveLogin?.getTerminationPid?.() ?? child.pid ?? null)
-    void resolveTerminationPid
-      .then((windowsTerminationPid) => {
-        if (windowsTerminationPid) {
-          killWindowsTree(windowsTerminationPid)
-          return
-        }
-        child.kill()
-        afterKill()
-      })
-      .catch(() => {
-        child.kill()
-        afterKill()
-      })
-    return
-  }
-  if (child.pid) {
-    try {
-      process.kill(-child.pid)
-      afterKill()
-      return
-    } catch {
-      // The direct child remains the only safe fallback when group lookup fails.
-    }
-  }
-  child.kill()
-  afterKill()
 }

--- a/src/main/claude-accounts/claude-login-process-termination.ts
+++ b/src/main/claude-accounts/claude-login-process-termination.ts
@@ -1,0 +1,90 @@
+import { spawnProcess, type ChildProcessHandle } from '../../shared/child-process/run-process'
+import type { WindowsHostInteractiveLoginSpawn } from '../../shared/windows-interactive-login-spawn'
+import { recordSelfInitiatedTreeKill } from '../crash-reporting/self-initiated-tree-kill-log'
+import { admitSelfInitiatedTreeKill } from '../own-chromium-tree-kill-guard'
+
+const WINDOWS_TASKKILL_TIMEOUT_MS = 5_000
+
+/** Ends a `claude` login and everything it spawned, then runs `afterKill`. */
+export function terminateClaudeProcess(
+  child: ChildProcessHandle,
+  interactiveLogin: WindowsHostInteractiveLoginSpawn | null,
+  afterKill: () => void
+): void {
+  const killWindowsTree = (windowsTerminationPid: number): void => {
+    if (
+      !admitSelfInitiatedTreeKill({
+        pid: windowsTerminationPid,
+        site: 'claude-account-login-teardown',
+        scope: 'win-taskkill-tree'
+      })
+    ) {
+      child.kill()
+      afterKill()
+      return
+    }
+    const taskkill = spawnProcess({
+      program: 'taskkill.exe',
+      args: ['/pid', String(windowsTerminationPid), '/t', '/f'],
+      stdio: 'ignore'
+    })
+    let finished = false
+    const finish = (succeeded: boolean): void => {
+      if (finished) {
+        return
+      }
+      finished = true
+      clearTimeout(taskkillTimeout)
+      if (!succeeded) {
+        child.kill()
+      }
+      afterKill()
+    }
+    const taskkillTimeout = setTimeout(() => {
+      taskkill.kill()
+      finish(false)
+    }, WINDOWS_TASKKILL_TIMEOUT_MS)
+    taskkill.once('error', () => finish(false))
+    taskkill.once('close', (code) => finish(code === 0))
+  }
+  if (process.platform === 'win32') {
+    // The wrapper's own PID never owns the login tree, so prefer the relayed PID.
+    const resolveTerminationPid = interactiveLogin?.waitForTerminationPid
+      ? interactiveLogin.waitForTerminationPid()
+      : Promise.resolve(interactiveLogin?.getTerminationPid?.() ?? child.pid ?? null)
+    void resolveTerminationPid
+      .then((windowsTerminationPid) => {
+        if (windowsTerminationPid) {
+          killWindowsTree(windowsTerminationPid)
+          return
+        }
+        child.kill()
+        afterKill()
+      })
+      .catch(() => {
+        child.kill()
+        afterKill()
+      })
+    return
+  }
+  if (child.pid) {
+    let signaledGroup = false
+    try {
+      process.kill(-child.pid)
+      signaledGroup = true
+    } catch {
+      // The direct child remains the only safe fallback when group lookup fails.
+    }
+    if (signaledGroup) {
+      recordSelfInitiatedTreeKill({
+        pid: child.pid,
+        site: 'claude-account-login-teardown',
+        scope: 'posix-process-group'
+      })
+      afterKill()
+      return
+    }
+  }
+  child.kill()
+  afterKill()
+}

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -12,6 +12,7 @@ import type { CodexRuntimeHomeService } from './runtime-home-service'
 import type { Store } from '../persistence'
 import type { RateLimitService } from '../rate-limits/service'
 import { buildEncodedWslBashCommand } from '../wsl-bash-command'
+import { admitSelfInitiatedTreeKill } from '../own-chromium-tree-kill-guard'
 import type { CodexAccountSelectionTarget } from './runtime-selection'
 import { CodexAccountIdentity, type ResolvedCodexIdentity } from './codex-account-identity'
 import { CodexConfigMirror } from './codex-config-mirror'
@@ -49,7 +50,14 @@ function killLoginProcessTree(
     process.platform === 'win32' &&
     typeof terminationPid === 'number' &&
     child.exitCode === null &&
-    child.signalCode === null
+    child.signalCode === null &&
+    // Last in the chain so a kill we never issue is never recorded, and a pid
+    // Electron owns refuses here into the plain-signal fallback below.
+    admitSelfInitiatedTreeKill({
+      pid: terminationPid,
+      site: 'codex-account-login-teardown',
+      scope: 'win-taskkill-tree'
+    })
   ) {
     try {
       // Why: child.kill() only reaches the direct child (cmd.exe for npm .cmd

--- a/src/main/codex/codex-app-server-process-teardown.test.ts
+++ b/src/main/codex/codex-app-server-process-teardown.test.ts
@@ -23,7 +23,7 @@ describe('terminateCodexAppServerProcessTree', () => {
     release.resolve()
     await teardown
 
-    expect(terminateWindowsTree).toHaveBeenCalledWith(1234)
+    expect(terminateWindowsTree).toHaveBeenCalledWith(1234, { site: 'codex-app-server-teardown' })
     expect(target.kill).toHaveBeenCalledWith('SIGKILL')
   })
 

--- a/src/main/codex/codex-app-server-process-teardown.ts
+++ b/src/main/codex/codex-app-server-process-teardown.ts
@@ -151,7 +151,7 @@ async function terminateOnce(
   }
   if ((deps.platform ?? process.platform) === 'win32') {
     const terminate = deps.terminateWindowsTree ?? terminateWindowsProcessTree
-    await terminate(rootPid)
+    await terminate(rootPid, { site: 'codex-app-server-teardown' })
     // taskkill owns the tree; this preserves the prior direct-child fallback when it fails.
     child.kill('SIGKILL')
     return true

--- a/src/main/codex/codex-app-server-process-teardown.ts
+++ b/src/main/codex/codex-app-server-process-teardown.ts
@@ -3,6 +3,7 @@ import { captureDescendantSnapshot, type DescendantSnapshot } from '../pty-desce
 import { terminateDescendantSnapshotAndWait } from '../pty-descendant-exit-verification'
 import { terminateWindowsProcessTree } from '../windows-process-tree-kill'
 import { findAgentSessionSpawnTokenProcesses } from '../runtime/agent-session-spawn-token-process-scan'
+import { recordSelfInitiatedTreeKill } from '../crash-reporting/self-initiated-tree-kill-log'
 
 const TOKEN_PROCESS_EXIT_TIMEOUT_MS = 3_500
 const TOKEN_PROCESS_POLL_MS = 25
@@ -17,7 +18,7 @@ export type CodexAppServerProcessTeardownDeps = {
   findSpawnTokenProcesses?: (spawnToken: string) => Promise<number[] | null>
   captureDescendants?: (rootPid: number) => Promise<DescendantSnapshot | null>
   terminateDescendants?: (snapshot: DescendantSnapshot) => Promise<boolean>
-  terminateWindowsTree?: (rootPid: number) => Promise<void>
+  terminateWindowsTree?: (rootPid: number, deps?: { site?: string }) => Promise<void>
   signalPid?: (pid: number, signal: NodeJS.Signals) => void
   signalProcessGroup?: (pgid: number, signal: NodeJS.Signals) => void
   isPidPresent?: (pid: number) => boolean
@@ -34,10 +35,16 @@ function terminateDedicatedPosixGroup(
     ((pgid: number, signal: NodeJS.Signals) => process.kill(-pgid, signal))
   try {
     signalGroup(rootPid, 'SIGKILL')
-    return true
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === 'ESRCH'
   }
+  // Outside the try: that catch is the ESRCH contract, not a breadcrumb handler.
+  recordSelfInitiatedTreeKill({
+    pid: rootPid,
+    site: 'codex-app-server-teardown',
+    scope: 'posix-process-group'
+  })
+  return true
 }
 
 function sendSignal(pid: number, signal: NodeJS.Signals): void {
@@ -129,6 +136,11 @@ async function terminatePosixTree(
         }
       })
     signalGroup(snapshot.rootPgid, 'SIGKILL')
+    recordSelfInitiatedTreeKill({
+      pid: snapshot.rootPgid,
+      site: 'codex-app-server-teardown',
+      scope: 'posix-process-group'
+    })
   }
   if (!descendantsExited) {
     child.kill('SIGCONT')

--- a/src/main/codex/codex-structured-turn-processes.ts
+++ b/src/main/codex/codex-structured-turn-processes.ts
@@ -57,7 +57,9 @@ async function terminateWindowsAddedProcesses(
   const added = current.filter((row) => baseline.get(row.pid) !== windowsIdentity(row))
   const addedPids = new Set(added.map((row) => row.pid))
   const roots = added.filter((row) => !addedPids.has(row.ppid))
-  await Promise.all(roots.map((row) => terminateWindowsProcessTree(row.pid)))
+  await Promise.all(
+    roots.map((row) => terminateWindowsProcessTree(row.pid, { site: 'codex-turn-added-roots' }))
+  )
   const targetIdentities = new Map(added.map((row) => [row.pid, windowsIdentity(row)]))
   const remaining = await queryWindowsProcessDescendants(rootPid, { fresh: true })
   return (

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -34,6 +34,7 @@ import {
   findSiblingChildDeaths,
   siblingProcessDeathDetails
 } from './process-gone-sibling-correlation'
+import { selfInitiatedTreeKillDetails } from './self-initiated-tree-kill-log'
 import { getMainProcessLifecycleIdentity } from './main-process-lifecycle-identity'
 import {
   captureMinidumpSignature,
@@ -247,7 +248,10 @@ export function recordProcessGoneCrash(
     {
       ...event.details,
       ...mainProcessLifecycle,
-      ...siblingDetails
+      ...siblingDetails,
+      // Why: an Orca-issued kill and an external one are identical in every other
+      // recorded field, so this is what answers "did we do this to ourselves?"
+      ...selfInitiatedTreeKillDetails(goneAt)
     },
     event.processType
   )

--- a/src/main/crash-reporting/self-initiated-tree-kill-log.test.ts
+++ b/src/main/crash-reporting/self-initiated-tree-kill-log.test.ts
@@ -7,16 +7,26 @@ vi.mock('electron', () => ({
   }
 }))
 
-import { clearCrashBreadcrumbsForTest, getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
+import {
+  clearCrashBreadcrumbsForTest,
+  getCrashBreadcrumbSnapshot,
+  recordCrashBreadcrumb
+} from './crash-breadcrumb-store'
 import { ProcessGoneDedupe } from './process-gone-dedupe'
 import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
 import { resetProcessGoneSiblingCorrelationForTest } from './process-gone-sibling-correlation'
 import {
   findSelfInitiatedTreeKills,
+  installProcessTreeKillBreadcrumbObserver,
+  recordRefusedOwnChromiumTreeKill,
   recordSelfInitiatedTreeKill,
   resetSelfInitiatedTreeKillLogForTest,
   selfInitiatedTreeKillDetails
 } from './self-initiated-tree-kill-log'
+import {
+  notifyProcessTreeKill,
+  setProcessTreeKillObserver
+} from '../../shared/child-process/process-tree-kill-observer'
 import { terminateWindowsProcessTree } from '../windows-process-tree-kill'
 import { _resetTracerForTests, setActiveSink } from '../observability/tracer'
 
@@ -90,18 +100,20 @@ describe('self-initiated tree kill breadcrumb', () => {
     // Arm B — identical crash, nobody inside Orca issued a kill.
     const externallyKilled = await recordKilledRenderer()
 
-    expect(selfKilled.selfInitiatedTreeKills).toMatch(/^pty-descendant-sweep\/pid4242 [+-]\d+ms$/)
+    expect(selfKilled.selfInitiatedKills).toMatch(
+      /^win-taskkill-tree\/pty-descendant-sweep\/pid4242 [+-]\d+ms$/
+    )
     expect(selfKilled.selfInitiatedTreeKillCount).toBe(1)
-    expect(externallyKilled.selfInitiatedTreeKills).toBeUndefined()
+    expect(externallyKilled.selfInitiatedKills).toBeUndefined()
     expect(externallyKilled.selfInitiatedTreeKillCount).toBeUndefined()
     // Every other recorded field is identical — that is why the breadcrumb exists.
     expect({
       ...selfKilled,
-      selfInitiatedTreeKills: null,
+      selfInitiatedKills: null,
       selfInitiatedTreeKillCount: null
     }).toEqual({
       ...externallyKilled,
-      selfInitiatedTreeKills: null,
+      selfInitiatedKills: null,
       selfInitiatedTreeKillCount: null
     })
   })
@@ -146,7 +158,9 @@ describe('self-initiated tree kill breadcrumb', () => {
     const nearby = findSelfInitiatedTreeKills(goneAt)
 
     expect(nearby.map((kill) => kill.pid)).toEqual([2])
-    expect(selfInitiatedTreeKillDetails(goneAt).selfInitiatedTreeKills).toBe('b/pid2 -90ms')
+    expect(selfInitiatedTreeKillDetails(goneAt).selfInitiatedKills).toBe(
+      'posix-process-group/b/pid2 -90ms'
+    )
   })
 
   it('bounds the ring at 32 entries', () => {
@@ -161,5 +175,89 @@ describe('self-initiated tree kill breadcrumb', () => {
     }
 
     expect(findSelfInitiatedTreeKills(goneAt)).toHaveLength(32)
+  })
+
+  it('never lets routine teardown kills evict the refusal crumb from the ring', () => {
+    // The reproduction from review: 12 terminal closes x 3 process groups.
+    for (let close = 0; close < 12; close += 1) {
+      for (let group = 0; group < 3; group += 1) {
+        recordSelfInitiatedTreeKill({
+          pid: 5_000 + close * 3 + group,
+          site: 'posix-pty-process-group-sweep',
+          scope: 'posix-process-group'
+        })
+      }
+    }
+    recordRefusedOwnChromiumTreeKill({
+      pid: 4242,
+      site: 'pty-descendant-sweep',
+      scope: 'win-taskkill-tree'
+    })
+    recordCrashBreadcrumb('gpu_process_crashed')
+
+    const names = getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.name)
+
+    expect(names).toContain('self_tree_kill_refused_own_chromium')
+    expect(names).toContain('gpu_process_crashed')
+    expect(names.filter((name) => name === 'self_tree_kill')).toHaveLength(1)
+  })
+
+  it('keeps a pty-scoped sweep out of the count that means "we held the knife"', () => {
+    const goneAt = 3_000_000
+    recordSelfInitiatedTreeKill({
+      pid: 1000,
+      site: 'posix-pty-process-group-sweep',
+      scope: 'posix-process-group',
+      at: goneAt - 1
+    })
+    recordSelfInitiatedTreeKill({
+      pid: 1001,
+      site: 'posix-pty-process-group-sweep',
+      scope: 'posix-process-group',
+      at: goneAt - 2
+    })
+
+    const details = selfInitiatedTreeKillDetails(goneAt)
+
+    // A killpg on a PTY's own groups cannot reach a renderer, so it must not
+    // read as a self-inflicted renderer kill.
+    expect(details.selfInitiatedTreeKillCount).toBeUndefined()
+    expect(details.selfInitiatedGroupKillCount).toBe(2)
+    expect(details.selfInitiatedKills).toContain('posix-process-group/')
+  })
+
+  it('lists a pid-addressed tree kill ahead of teardown noise so truncation keeps it', () => {
+    const goneAt = 4_000_000
+    for (let index = 0; index < 12; index += 1) {
+      recordSelfInitiatedTreeKill({
+        pid: 2000 + index,
+        site: 'posix-pty-process-group-sweep',
+        scope: 'posix-process-group',
+        at: goneAt - 1
+      })
+    }
+    recordSelfInitiatedTreeKill({
+      pid: 9999,
+      site: 'pty-descendant-sweep',
+      scope: 'win-taskkill-tree',
+      at: goneAt - 200
+    })
+
+    const details = selfInitiatedTreeKillDetails(goneAt)
+
+    expect(details.selfInitiatedTreeKillCount).toBe(1)
+    expect(String(details.selfInitiatedKills)).toMatch(
+      /^win-taskkill-tree\/pty-descendant-sweep\/pid9999 -200ms/
+    )
+    expect(String(details.selfInitiatedKills)).toContain('more)')
+  })
+
+  it('records a kill issued through the shared runProcess choke point', () => {
+    installProcessTreeKillBreadcrumbObserver()
+
+    notifyProcessTreeKill({ pid: 3131, site: 'run-process-tree', scope: 'posix-process-group' })
+
+    expect(findSelfInitiatedTreeKills(Date.now()).map((kill) => kill.pid)).toEqual([3131])
+    setProcessTreeKillObserver(null)
   })
 })

--- a/src/main/crash-reporting/self-initiated-tree-kill-log.test.ts
+++ b/src/main/crash-reporting/self-initiated-tree-kill-log.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '1.4.194-test',
+    getAppMetrics: () => []
+  }
+}))
+
+import { clearCrashBreadcrumbsForTest, getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
+import { ProcessGoneDedupe } from './process-gone-dedupe'
+import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
+import { resetProcessGoneSiblingCorrelationForTest } from './process-gone-sibling-correlation'
+import {
+  findSelfInitiatedTreeKills,
+  recordSelfInitiatedTreeKill,
+  resetSelfInitiatedTreeKillLogForTest,
+  selfInitiatedTreeKillDetails
+} from './self-initiated-tree-kill-log'
+import { terminateWindowsProcessTree } from '../windows-process-tree-kill'
+import { _resetTracerForTests, setActiveSink } from '../observability/tracer'
+
+/** The field shape: renderer, `reason=killed exitCode=1`, win32 (#G2). */
+function killedRendererEvent(): ProcessGoneCrashEvent {
+  return {
+    source: 'renderer',
+    processType: 'renderer',
+    reason: 'killed',
+    exitCode: 1,
+    expectedTeardown: 'none',
+    details: { processType: 'renderer' }
+  }
+}
+
+type RecordedReport = { details: Record<string, unknown> }
+
+function capturingStore(recorded: RecordedReport[]) {
+  return {
+    record: async (report: RecordedReport) => {
+      recorded.push(report)
+      return { id: 'report-1' }
+    },
+    attachDetails: async () => null
+  }
+}
+
+/** Drives one crash through the recorder and returns the persisted details. */
+async function recordKilledRenderer(): Promise<Record<string, unknown>> {
+  const recorded: RecordedReport[] = []
+  recordProcessGoneCrash(
+    capturingStore(recorded) as never,
+    killedRendererEvent(),
+    new ProcessGoneDedupe(),
+    async () => null
+  )
+  await vi.waitFor(() => expect(recorded).toHaveLength(1))
+  return recorded[0]!.details
+}
+
+beforeEach(() => {
+  setActiveSink({ push: () => {}, flush: () => {}, close: () => {} })
+  clearCrashBreadcrumbsForTest()
+  resetProcessGoneSiblingCorrelationForTest()
+  resetSelfInitiatedTreeKillLogForTest()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  _resetTracerForTests()
+  clearCrashBreadcrumbsForTest()
+  resetProcessGoneSiblingCorrelationForTest()
+  resetSelfInitiatedTreeKillLogForTest()
+})
+
+describe('self-initiated tree kill breadcrumb', () => {
+  it('separates an Orca-issued tree kill from an external kill of the same shape', async () => {
+    // Arm A — Orca issues the kill through its own taskkill choke point.
+    await terminateWindowsProcessTree(4242, {
+      execFileImpl: ((_program, _args, _options, done) => {
+        ;(done as () => void)()
+        return undefined as never
+      }) as never,
+      site: 'pty-descendant-sweep'
+    })
+    const selfKilled = await recordKilledRenderer()
+
+    resetSelfInitiatedTreeKillLogForTest()
+    clearCrashBreadcrumbsForTest()
+
+    // Arm B — identical crash, nobody inside Orca issued a kill.
+    const externallyKilled = await recordKilledRenderer()
+
+    expect(selfKilled.selfInitiatedTreeKills).toMatch(/^pty-descendant-sweep\/pid4242 [+-]\d+ms$/)
+    expect(selfKilled.selfInitiatedTreeKillCount).toBe(1)
+    expect(externallyKilled.selfInitiatedTreeKills).toBeUndefined()
+    expect(externallyKilled.selfInitiatedTreeKillCount).toBeUndefined()
+    // Every other recorded field is identical — that is why the breadcrumb exists.
+    expect({
+      ...selfKilled,
+      selfInitiatedTreeKills: null,
+      selfInitiatedTreeKillCount: null
+    }).toEqual({
+      ...externallyKilled,
+      selfInitiatedTreeKills: null,
+      selfInitiatedTreeKillCount: null
+    })
+  })
+
+  it('records a durable breadcrumb so the kill survives into the diagnostic bundle', async () => {
+    await terminateWindowsProcessTree(777, {
+      execFileImpl: ((_program, _args, _options, done) => {
+        ;(done as () => void)()
+        return undefined as never
+      }) as never,
+      site: 'codex-turn-added-roots'
+    })
+
+    expect(getCrashBreadcrumbSnapshot()).toEqual([
+      expect.objectContaining({
+        name: 'self_tree_kill',
+        data: expect.objectContaining({
+          pid: 777,
+          site: 'codex-turn-added-roots',
+          scope: 'win-taskkill-tree'
+        })
+      })
+    ])
+  })
+
+  it('keeps only kills near the death and drops the rest of the ring', () => {
+    const goneAt = 1_000_000
+    recordSelfInitiatedTreeKill({
+      pid: 1,
+      site: 'a',
+      scope: 'win-taskkill-tree',
+      at: goneAt - 6_000
+    })
+    recordSelfInitiatedTreeKill({
+      pid: 2,
+      site: 'b',
+      scope: 'posix-process-group',
+      at: goneAt - 90
+    })
+    recordSelfInitiatedTreeKill({ pid: 3, site: 'c', scope: 'win-pty-job', at: goneAt + 500 })
+
+    const nearby = findSelfInitiatedTreeKills(goneAt)
+
+    expect(nearby.map((kill) => kill.pid)).toEqual([2])
+    expect(selfInitiatedTreeKillDetails(goneAt).selfInitiatedTreeKills).toBe('b/pid2 -90ms')
+  })
+
+  it('bounds the ring at 32 entries', () => {
+    const goneAt = 2_000_000
+    for (let index = 0; index < 40; index += 1) {
+      recordSelfInitiatedTreeKill({
+        pid: index + 1,
+        site: 'sweep',
+        scope: 'win-taskkill-tree',
+        at: goneAt - 10
+      })
+    }
+
+    expect(findSelfInitiatedTreeKills(goneAt)).toHaveLength(32)
+  })
+})

--- a/src/main/crash-reporting/self-initiated-tree-kill-log.ts
+++ b/src/main/crash-reporting/self-initiated-tree-kill-log.ts
@@ -1,0 +1,117 @@
+import type { CrashReportDetailValue } from '../../shared/crash-reporting'
+import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
+
+/**
+ * Records the force-kills Orca itself issues, so a later `render-process-gone`
+ * can say whether we were holding the knife.
+ *
+ * Why: on Windows a `taskkill /T /F` we issue and an external one produce the
+ * identical `reason=killed exitCode=1` plus the identical concurrent sibling
+ * deaths — reproduced side by side on Windows 11 / Electron 43.4.1, differing in
+ * zero recorded fields. This is the field that separates them.
+ */
+
+/** Which mechanism issued the kill; each has a different blast radius. */
+export type SelfInitiatedTreeKillScope = 'win-taskkill-tree' | 'posix-process-group' | 'win-pty-job'
+
+export type SelfInitiatedTreeKill = {
+  pid: number
+  site: string
+  scope: SelfInitiatedTreeKillScope
+  at: number
+}
+
+// Why 32 and not the sibling ring's 16: one teardown fans out over every root of
+// a codex turn, so a single incident can spend a dozen entries on its own.
+const MAX_TRACKED_SELF_KILLS = 32
+
+// Why asymmetric: a kill older than this cannot plausibly explain the death,
+// while the forward edge mirrors SIBLING_DEATH_LOOKAHEAD_MS — a kill issued just
+// after the renderer died is at least as likely to be teardown reacting to it.
+export const SELF_TREE_KILL_LOOKBACK_MS = 5_000
+export const SELF_TREE_KILL_LOOKAHEAD_MS = 250
+
+// Same truncation rule as MAX_SIBLING_DEATHS_DETAIL_LENGTH: drop whole entries
+// rather than let sanitizeCrashReportDetails cut the list mid-token.
+const MAX_SELF_TREE_KILLS_DETAIL_LENGTH = 200
+
+let selfInitiatedKills: SelfInitiatedTreeKill[] = []
+
+export function recordSelfInitiatedTreeKill({
+  pid,
+  site,
+  scope,
+  at = Date.now()
+}: {
+  pid: number
+  site: string
+  scope: SelfInitiatedTreeKillScope
+  at?: number
+}): void {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return
+  }
+  selfInitiatedKills.push({ pid, site, scope, at })
+  if (selfInitiatedKills.length > MAX_TRACKED_SELF_KILLS) {
+    selfInitiatedKills = selfInitiatedKills.slice(-MAX_TRACKED_SELF_KILLS)
+  }
+  // Durable so it survives into the diagnostic bundle even when the kill takes
+  // the reporting renderer with it; durable breadcrumbs flush immediately.
+  recordDurableCrashBreadcrumb('self_tree_kill', { pid, site, scope })
+}
+
+/**
+ * A tree-kill we refused because the target is one of our own Chromium
+ * processes. Falsifiable on purpose: this crumb appearing in a field bundle is
+ * direct proof that Orca was about to kill its own renderer.
+ */
+export function recordRefusedOwnChromiumTreeKill(target: {
+  pid: number
+  site: string
+  scope: SelfInitiatedTreeKillScope
+}): void {
+  recordDurableCrashBreadcrumb('self_tree_kill_refused_own_chromium', target)
+}
+
+export function findSelfInitiatedTreeKills(at: number): SelfInitiatedTreeKill[] {
+  return selfInitiatedKills.filter((kill) => {
+    const offsetMs = kill.at - at
+    return offsetMs >= -SELF_TREE_KILL_LOOKBACK_MS && offsetMs <= SELF_TREE_KILL_LOOKAHEAD_MS
+  })
+}
+
+// Why not `site:pid@offset`: sanitizeCrashReportString reads `word:word@` as a
+// credential URL and redacts the whole token. Mirror describeChildDeath instead.
+function describeSelfInitiatedTreeKill(kill: SelfInitiatedTreeKill, goneAt: number): string {
+  const offsetMs = kill.at - goneAt
+  return `${kill.site}/pid${kill.pid} ${offsetMs >= 0 ? '+' : ''}${offsetMs}ms`
+}
+
+/** Empty when Orca issued no nearby kill — absence is the discriminating half. */
+export function selfInitiatedTreeKillDetails(
+  goneAt: number
+): Record<string, CrashReportDetailValue> {
+  const kills = findSelfInitiatedTreeKills(goneAt)
+  if (kills.length === 0) {
+    return {}
+  }
+  const described = [...kills]
+    .sort((a, b) => Math.abs(a.at - goneAt) - Math.abs(b.at - goneAt))
+    .map((kill) => describeSelfInitiatedTreeKill(kill, goneAt))
+  const kept: string[] = []
+  for (const entry of described) {
+    if (kept.length > 0 && [...kept, entry].join(', ').length > MAX_SELF_TREE_KILLS_DETAIL_LENGTH) {
+      break
+    }
+    kept.push(entry)
+  }
+  const dropped = described.length - kept.length
+  return {
+    selfInitiatedTreeKillCount: kills.length,
+    selfInitiatedTreeKills: dropped > 0 ? `${kept.join(', ')} (+${dropped} more)` : kept.join(', ')
+  }
+}
+
+export function resetSelfInitiatedTreeKillLogForTest(): void {
+  selfInitiatedKills = []
+}

--- a/src/main/crash-reporting/self-initiated-tree-kill-log.ts
+++ b/src/main/crash-reporting/self-initiated-tree-kill-log.ts
@@ -1,5 +1,9 @@
 import type { CrashReportDetailValue } from '../../shared/crash-reporting'
-import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
+import {
+  setProcessTreeKillObserver,
+  type ProcessTreeKillScope
+} from '../../shared/child-process/process-tree-kill-observer'
+import { recordCoalescedDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
 
 /**
  * Records the force-kills Orca itself issues, so a later `render-process-gone`
@@ -9,10 +13,18 @@ import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
  * identical `reason=killed exitCode=1` plus the identical concurrent sibling
  * deaths — reproduced side by side on Windows 11 / Electron 43.4.1, differing in
  * zero recorded fields. This is the field that separates them.
+ *
+ * Coverage (what a zero count does and does not prove): instrumented are every
+ * main-process `taskkill /T /F` (all three families gate on
+ * `admitSelfInitiatedTreeKill`), `signalProcessTree` — the `runProcess` choke
+ * point, both platforms — the codex app-server POSIX group teardowns, the PTY
+ * process-group sweep and the Windows PTY Job Object. NOT instrumented: the
+ * direct `process.kill(-pid)` calls in the browser routes, notebooks, automation
+ * prechecks and ephemeral-VM recipes. Absence is evidence, not proof.
  */
 
 /** Which mechanism issued the kill; each has a different blast radius. */
-export type SelfInitiatedTreeKillScope = 'win-taskkill-tree' | 'posix-process-group' | 'win-pty-job'
+export type SelfInitiatedTreeKillScope = ProcessTreeKillScope | 'win-pty-job'
 
 export type SelfInitiatedTreeKill = {
   pid: number
@@ -31,11 +43,27 @@ const MAX_TRACKED_SELF_KILLS = 32
 export const SELF_TREE_KILL_LOOKBACK_MS = 5_000
 export const SELF_TREE_KILL_LOOKAHEAD_MS = 250
 
+// Why a longer window for group/job kills: those are routine teardown (three
+// process groups per terminal close), and uncoalesced they evict the whole
+// 30-slot breadcrumb ring — including this module's own refusal crumb.
+const GROUP_KILL_COALESCE_MS = 60_000
+
 // Same truncation rule as MAX_SIBLING_DEATHS_DETAIL_LENGTH: drop whole entries
 // rather than let sanitizeCrashReportDetails cut the list mid-token.
 const MAX_SELF_TREE_KILLS_DETAIL_LENGTH = 200
 
 let selfInitiatedKills: SelfInitiatedTreeKill[] = []
+
+/**
+ * Whether the kill was addressed by pid and so could have reached a process
+ * Orca did not put in its target: `taskkill /T /F` walks whatever tree the pid
+ * owns at kill time, including a recycled pid that is now our renderer. A
+ * process group or Job Object contains only what Orca placed there, so it is
+ * structurally incapable of taking a Chromium process with it.
+ */
+function isPidAddressedTreeKill(scope: SelfInitiatedTreeKillScope): boolean {
+  return scope === 'win-taskkill-tree'
+}
 
 export function recordSelfInitiatedTreeKill({
   pid,
@@ -56,8 +84,17 @@ export function recordSelfInitiatedTreeKill({
     selfInitiatedKills = selfInitiatedKills.slice(-MAX_TRACKED_SELF_KILLS)
   }
   // Durable so it survives into the diagnostic bundle even when the kill takes
-  // the reporting renderer with it; durable breadcrumbs flush immediately.
-  recordDurableCrashBreadcrumb('self_tree_kill', { pid, site, scope })
+  // the reporting renderer with it; coalesced because the crash detail above is
+  // the primary record and a teardown burst must not cost 30 ring slots plus a
+  // forced disk flush each. The newest pid still rides the emitted crumb.
+  recordCoalescedDurableCrashBreadcrumb({
+    name: 'self_tree_kill',
+    data: { pid, site, scope },
+    coalesceKey: `${scope}\u0000${site}`,
+    minIntervalMs: isPidAddressedTreeKill(scope)
+      ? SELF_TREE_KILL_LOOKBACK_MS
+      : GROUP_KILL_COALESCE_MS
+  })
 }
 
 /**
@@ -70,7 +107,19 @@ export function recordRefusedOwnChromiumTreeKill(target: {
   site: string
   scope: SelfInitiatedTreeKillScope
 }): void {
-  recordDurableCrashBreadcrumb('self_tree_kill_refused_own_chromium', target)
+  // Coalesced per pid so a retry loop cannot flood the ring, but a distinct
+  // victim pid always gets its own crumb — that pid is the whole artifact.
+  recordCoalescedDurableCrashBreadcrumb({
+    name: 'self_tree_kill_refused_own_chromium',
+    data: target,
+    coalesceKey: `${target.site}\u0000${target.pid}`,
+    minIntervalMs: SELF_TREE_KILL_LOOKBACK_MS
+  })
+}
+
+/** Routes the `runProcess` choke point's kills here; shared code cannot import us. */
+export function installProcessTreeKillBreadcrumbObserver(): void {
+  setProcessTreeKillObserver((kill) => recordSelfInitiatedTreeKill(kill))
 }
 
 export function findSelfInitiatedTreeKills(at: number): SelfInitiatedTreeKill[] {
@@ -84,10 +133,15 @@ export function findSelfInitiatedTreeKills(at: number): SelfInitiatedTreeKill[] 
 // credential URL and redacts the whole token. Mirror describeChildDeath instead.
 function describeSelfInitiatedTreeKill(kill: SelfInitiatedTreeKill, goneAt: number): string {
   const offsetMs = kill.at - goneAt
-  return `${kill.site}/pid${kill.pid} ${offsetMs >= 0 ? '+' : ''}${offsetMs}ms`
+  return `${kill.scope}/${kill.site}/pid${kill.pid} ${offsetMs >= 0 ? '+' : ''}${offsetMs}ms`
 }
 
-/** Empty when Orca issued no nearby kill — absence is the discriminating half. */
+/**
+ * Kills Orca issued near `goneAt`, split by whether the mechanism could have
+ * reached a Chromium process at all — `selfInitiatedTreeKillCount` is the
+ * discriminating one, and a pty-scoped sweep must never inflate it. Empty when
+ * no instrumented choke point fired; see the module doc for what that omits.
+ */
 export function selfInitiatedTreeKillDetails(
   goneAt: number
 ): Record<string, CrashReportDetailValue> {
@@ -95,20 +149,30 @@ export function selfInitiatedTreeKillDetails(
   if (kills.length === 0) {
     return {}
   }
+  const treeKillCount = kills.filter((kill) => isPidAddressedTreeKill(kill.scope)).length
   const described = [...kills]
-    .sort((a, b) => Math.abs(a.at - goneAt) - Math.abs(b.at - goneAt))
+    // Pid-addressed kills first: truncation must never drop the ones that could
+    // have caused the death in favour of routine teardown noise.
+    .sort((a, b) => {
+      const reach =
+        Number(isPidAddressedTreeKill(b.scope)) - Number(isPidAddressedTreeKill(a.scope))
+      return reach !== 0 ? reach : Math.abs(a.at - goneAt) - Math.abs(b.at - goneAt)
+    })
     .map((kill) => describeSelfInitiatedTreeKill(kill, goneAt))
   const kept: string[] = []
   for (const entry of described) {
     if (kept.length > 0 && [...kept, entry].join(', ').length > MAX_SELF_TREE_KILLS_DETAIL_LENGTH) {
       break
     }
-    kept.push(entry)
+    kept.push(entry.slice(0, MAX_SELF_TREE_KILLS_DETAIL_LENGTH))
   }
   const dropped = described.length - kept.length
   return {
-    selfInitiatedTreeKillCount: kills.length,
-    selfInitiatedTreeKills: dropped > 0 ? `${kept.join(', ')} (+${dropped} more)` : kept.join(', ')
+    ...(treeKillCount > 0 ? { selfInitiatedTreeKillCount: treeKillCount } : {}),
+    ...(kills.length - treeKillCount > 0
+      ? { selfInitiatedGroupKillCount: kills.length - treeKillCount }
+      : {}),
+    selfInitiatedKills: dropped > 0 ? `${kept.join(', ')} (+${dropped} more)` : kept.join(', ')
   }
 }
 

--- a/src/main/crash-reporting/self-initiated-tree-kill-log.ts
+++ b/src/main/crash-reporting/self-initiated-tree-kill-log.ts
@@ -14,13 +14,29 @@ import { recordCoalescedDurableCrashBreadcrumb } from './durable-crash-breadcrum
  * deaths — reproduced side by side on Windows 11 / Electron 43.4.1, differing in
  * zero recorded fields. This is the field that separates them.
  *
- * Coverage (what a zero count does and does not prove): instrumented are every
- * main-process `taskkill /T /F` (all three families gate on
- * `admitSelfInitiatedTreeKill`), `signalProcessTree` — the `runProcess` choke
- * point, both platforms — the codex app-server POSIX group teardowns, the PTY
- * process-group sweep and the Windows PTY Job Object. NOT instrumented: the
- * direct `process.kill(-pid)` calls in the browser routes, notebooks, automation
- * prechecks and ephemeral-VM recipes. Absence is evidence, not proof.
+ * Coverage — read this before drawing a conclusion from a zero count.
+ *
+ * The ring is per-process and its only reader is `process-gone-recorder`, which
+ * exists in Electron main. So a count reported on a `render-process-gone` covers
+ * kills issued *from Electron main*, and nothing else:
+ * - Main only: the three `taskkill /T /F` families that gate on
+ *   `admitSelfInitiatedTreeKill` (`terminateWindowsProcessTree` and the codex /
+ *   claude account-login teardowns) and the codex app-server POSIX group
+ *   teardowns.
+ * - Main *and* other hosts: `signalProcessTree` (the `runProcess` choke point,
+ *   reached from the CLI, relay and daemon too — a fourth pid-addressed
+ *   `taskkill` family, gated on the child not being reaped rather than on the
+ *   Chromium set it cannot read), the POSIX PTY process-group sweep and the
+ *   Windows PTY Job Object (relay `pty-handler`, daemon
+ *   `subprocess-handle`). When those run outside main they record into that
+ *   process's own ring, which nothing reads — no observer is installed there,
+ *   and the tracer sink is a no-op.
+ * - Never instrumented: the direct `process.kill(-pid)` calls in the browser
+ *   routes, notebooks, automation prechecks and ephemeral-VM recipes.
+ *
+ * A daemon or relay kill missing from the count is a diagnostics gap, not a
+ * missed suspect: those hosts cannot reach a Chromium pid in the first place
+ * (see `orca-chromium-process-pids.ts`). Absence is evidence, not proof.
  */
 
 /** Which mechanism issued the kill; each has a different blast radius. */

--- a/src/main/orca-chromium-process-pids.ts
+++ b/src/main/orca-chromium-process-pids.ts
@@ -10,6 +10,15 @@ import { getAppEnvironment, hasAppEnvironment } from '../shared/app-environment'
  *
  * Empty on a Node host and empty on failure: that is "no refusal proven", never
  * "safe to kill" — callers must keep every other guard they already have.
+ *
+ * Host coverage: only Electron main installs a Chromium-backed AppEnvironment
+ * (main-process-preflight). The standalone daemon installs none and `orcad`
+ * installs a Node one whose `getAppMetrics()` is `[]`, so this set is empty in
+ * both — and that is sound, not a hole: the pid-addressed kills those hosts
+ * issue go through `classifyWindowsTreeKillTarget`, which walks ancestry back to
+ * the *killing* process's own pid. Orca's Chromium processes are children of
+ * Electron main, so they never classify `own` from a daemon or orcad host, and
+ * on an SSH/serve host there is no Chromium on the machine at all.
  */
 export function readOrcaChromiumProcessPids(): ReadonlySet<number> {
   if (!hasAppEnvironment()) {

--- a/src/main/orca-chromium-process-pids.ts
+++ b/src/main/orca-chromium-process-pids.ts
@@ -1,0 +1,27 @@
+import { getAppEnvironment, hasAppEnvironment } from '../shared/app-environment'
+
+/**
+ * PIDs of Orca's own Chromium processes — browser, renderers, GPU, utilities.
+ *
+ * Why: `taskkill /T /F` aimed at one of these kills a renderer we depend on, and
+ * the `render-process-gone` it produces is indistinguishable from an external
+ * kill in every field Orca records (#10680). A pid in this set is proof the
+ * target is ours to keep, not ours to tear down.
+ *
+ * Empty on a Node host and empty on failure: that is "no refusal proven", never
+ * "safe to kill" — callers must keep every other guard they already have.
+ */
+export function readOrcaChromiumProcessPids(): ReadonlySet<number> {
+  if (!hasAppEnvironment()) {
+    return new Set()
+  }
+  try {
+    const pids = getAppEnvironment()
+      .getAppMetrics()
+      .map((metric) => metric.pid)
+      .filter((pid) => Number.isInteger(pid) && pid > 0)
+    return new Set(pids)
+  } catch {
+    return new Set()
+  }
+}

--- a/src/main/own-chromium-tree-kill-guard.test.ts
+++ b/src/main/own-chromium-tree-kill-guard.test.ts
@@ -23,6 +23,8 @@ import { _resetTracerForTests, setActiveSink } from './observability/tracer'
 
 const ORCA_MAIN_PID = 1000
 const RENDERER_PID = 1001
+/** The standalone daemon is a sibling of the renderers, spawned by main. */
+const DAEMON_PID = 1500
 
 /** Orca's renderer is a direct child of the main process, so the ppid walk says `own`. */
 const PROCESS_ROWS = [
@@ -73,6 +75,31 @@ describe('refusing to tree-kill our own Chromium processes', () => {
 
   it('classifies a live renderer as foreign even though its ancestry reaches us', () => {
     expect(classifyWindowsTreeKillTarget(RENDERER_PID, PROCESS_ROWS, ORCA_MAIN_PID)).toBe('foreign')
+  })
+
+  it.each([
+    ['an empty pid set', new Set<number>()],
+    ['the live pid set', undefined]
+  ])(
+    'refuses an Orca renderer from a daemon host with %s, because no Chromium descends from it',
+    (_case, ownChromiumPids) => {
+      // The standalone daemon and orcad install no Chromium-backed AppEnvironment,
+      // so this set is empty there. The ancestry walk is what refuses instead: it
+      // ends at the *killing* process's pid, and the renderer's chain reaches main.
+      const rows = [...PROCESS_ROWS, { pid: DAEMON_PID, ppid: ORCA_MAIN_PID }]
+
+      expect(classifyWindowsTreeKillTarget(RENDERER_PID, rows, DAEMON_PID, ownChromiumPids)).toBe(
+        'foreign'
+      )
+    }
+  )
+
+  it('is the only thing standing between Electron main and its own renderer', () => {
+    // Falsifiable counterpart to the daemon case above: in main the ancestry walk
+    // says `own`, so the pid set is load-bearing here and nowhere else.
+    expect(
+      classifyWindowsTreeKillTarget(RENDERER_PID, PROCESS_ROWS, ORCA_MAIN_PID, new Set())
+    ).toBe('own')
   })
 
   it('still classifies a real PTY child of ours as own', () => {

--- a/src/main/own-chromium-tree-kill-guard.test.ts
+++ b/src/main/own-chromium-tree-kill-guard.test.ts
@@ -13,6 +13,8 @@ import {
 import { readOrcaChromiumProcessPids } from './orca-chromium-process-pids'
 import { classifyWindowsTreeKillTarget } from './windows-pty-root-identity'
 import { terminateWindowsProcessTree } from './windows-process-tree-kill'
+import { admitSelfInitiatedTreeKill } from './own-chromium-tree-kill-guard'
+import { resetSelfInitiatedTreeKillLogForTest } from './crash-reporting/self-initiated-tree-kill-log'
 import {
   clearCrashBreadcrumbsForTest,
   getCrashBreadcrumbSnapshot
@@ -52,6 +54,7 @@ beforeEach(() => {
   ])
   setActiveSink({ push: () => {}, flush: () => {}, close: () => {} })
   clearCrashBreadcrumbsForTest()
+  resetSelfInitiatedTreeKillLogForTest()
 })
 
 afterEach(() => {
@@ -111,5 +114,26 @@ describe('refusing to tree-kill our own Chromium processes', () => {
       expect.anything(),
       expect.any(Function)
     )
+  })
+
+  it('refuses an own-Chromium pid at the gate the account teardowns share', () => {
+    expect(
+      admitSelfInitiatedTreeKill({
+        pid: RENDERER_PID,
+        site: 'claude-account-login-teardown',
+        scope: 'win-taskkill-tree'
+      })
+    ).toBe(false)
+    expect(
+      admitSelfInitiatedTreeKill({
+        pid: 7777,
+        site: 'codex-account-login-teardown',
+        scope: 'win-taskkill-tree'
+      })
+    ).toBe(true)
+    expect(getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.name)).toEqual([
+      'self_tree_kill_refused_own_chromium',
+      'self_tree_kill'
+    ])
   })
 })

--- a/src/main/own-chromium-tree-kill-guard.ts
+++ b/src/main/own-chromium-tree-kill-guard.ts
@@ -1,0 +1,32 @@
+import {
+  recordRefusedOwnChromiumTreeKill,
+  recordSelfInitiatedTreeKill,
+  type SelfInitiatedTreeKillScope
+} from './crash-reporting/self-initiated-tree-kill-log'
+import { readOrcaChromiumProcessPids } from './orca-chromium-process-pids'
+
+/**
+ * Gate every main-process tree-kill through one decision: refuse the pid when
+ * Electron is currently accounting for it, otherwise put it on the record.
+ *
+ * Why a shared gate rather than a check inside `terminateWindowsProcessTree`:
+ * the codex and claude account-login teardowns run their own `taskkill /T /F`
+ * with different lifetimes (one sync, one with its own timeout ladder), so a
+ * guard that only lived in the tree-kill helper would cover one of three
+ * families. Returns false when the caller must not kill.
+ */
+export function admitSelfInitiatedTreeKill(target: {
+  pid: number
+  site: string
+  scope: SelfInitiatedTreeKillScope
+}): boolean {
+  // Why: no PTY root, codex root or git child is ever one of our own Chromium
+  // processes, so a pid that is means the caller is about to kill a renderer,
+  // the GPU or the browser itself (#10680).
+  if (readOrcaChromiumProcessPids().has(target.pid)) {
+    recordRefusedOwnChromiumTreeKill(target)
+    return false
+  }
+  recordSelfInitiatedTreeKill(target)
+  return true
+}

--- a/src/main/own-chromium-tree-kill-guard.ts
+++ b/src/main/own-chromium-tree-kill-guard.ts
@@ -14,6 +14,14 @@ import { readOrcaChromiumProcessPids } from './orca-chromium-process-pids'
  * with different lifetimes (one sync, one with its own timeout ladder), so a
  * guard that only lived in the tree-kill helper would cover one of three
  * families. Returns false when the caller must not kill.
+ *
+ * Electron main only, by construction. `terminateWindowsProcessTree` also runs
+ * in the standalone daemon (the `pty-descendant-sweep` site), where
+ * `readOrcaChromiumProcessPids()` is empty and this always admits. That is not
+ * the gap it looks like: the daemon reaches that taskkill only through
+ * `classifyWindowsTreeKillTarget`, whose ancestry walk ends at the daemon's own
+ * pid, and no Chromium process descends from the daemon. See
+ * `orca-chromium-process-pids.ts`.
  */
 export function admitSelfInitiatedTreeKill(target: {
   pid: number

--- a/src/main/own-chromium-tree-kill-refusal.test.ts
+++ b/src/main/own-chromium-tree-kill-refusal.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { appMetricsMock } = vi.hoisted(() => ({
+  appMetricsMock: vi.fn((): { pid: number; type?: string }[] => [])
+}))
+
+import {
+  getAppEnvironment,
+  hasAppEnvironment,
+  setAppEnvironment,
+  type AppEnvironment
+} from '../shared/app-environment'
+import { readOrcaChromiumProcessPids } from './orca-chromium-process-pids'
+import { classifyWindowsTreeKillTarget } from './windows-pty-root-identity'
+import { terminateWindowsProcessTree } from './windows-process-tree-kill'
+import {
+  clearCrashBreadcrumbsForTest,
+  getCrashBreadcrumbSnapshot
+} from './crash-reporting/crash-breadcrumb-store'
+import { _resetTracerForTests, setActiveSink } from './observability/tracer'
+
+const ORCA_MAIN_PID = 1000
+const RENDERER_PID = 1001
+
+/** Orca's renderer is a direct child of the main process, so the ppid walk says `own`. */
+const PROCESS_ROWS = [
+  { pid: RENDERER_PID, ppid: ORCA_MAIN_PID },
+  { pid: ORCA_MAIN_PID, ppid: 900 }
+]
+
+function appEnvironment(): AppEnvironment {
+  return {
+    getPath: () => process.cwd(),
+    getAppPath: () => process.cwd(),
+    getVersion: () => '0.0.0-test',
+    isPackaged: () => false,
+    onWillQuit: () => {},
+    exit: () => {},
+    getAppMetrics: appMetricsMock as unknown as AppEnvironment['getAppMetrics']
+  }
+}
+
+let previousEnvironment: AppEnvironment | null = null
+
+beforeEach(() => {
+  previousEnvironment = hasAppEnvironment() ? getAppEnvironment() : null
+  setAppEnvironment(appEnvironment())
+  appMetricsMock.mockReturnValue([
+    { pid: ORCA_MAIN_PID, type: 'Browser' },
+    { pid: RENDERER_PID, type: 'Tab' },
+    { pid: 1002, type: 'GPU' }
+  ])
+  setActiveSink({ push: () => {}, flush: () => {}, close: () => {} })
+  clearCrashBreadcrumbsForTest()
+})
+
+afterEach(() => {
+  if (previousEnvironment) {
+    setAppEnvironment(previousEnvironment)
+  }
+  vi.restoreAllMocks()
+  _resetTracerForTests()
+  clearCrashBreadcrumbsForTest()
+})
+
+describe('refusing to tree-kill our own Chromium processes', () => {
+  it('reads the live Chromium pid set from the app environment', () => {
+    expect([...readOrcaChromiumProcessPids()]).toEqual([ORCA_MAIN_PID, RENDERER_PID, 1002])
+  })
+
+  it('classifies a live renderer as foreign even though its ancestry reaches us', () => {
+    expect(classifyWindowsTreeKillTarget(RENDERER_PID, PROCESS_ROWS, ORCA_MAIN_PID)).toBe('foreign')
+  })
+
+  it('still classifies a real PTY child of ours as own', () => {
+    const rows = [...PROCESS_ROWS, { pid: 7777, ppid: ORCA_MAIN_PID }]
+
+    expect(classifyWindowsTreeKillTarget(7777, rows, ORCA_MAIN_PID)).toBe('own')
+  })
+
+  it('never spawns taskkill against one of our own Chromium pids', async () => {
+    const execFileImpl = vi.fn()
+
+    await terminateWindowsProcessTree(RENDERER_PID, {
+      execFileImpl: execFileImpl as never,
+      site: 'pty-descendant-sweep'
+    })
+
+    expect(execFileImpl).not.toHaveBeenCalled()
+    expect(getCrashBreadcrumbSnapshot()).toEqual([
+      expect.objectContaining({
+        name: 'self_tree_kill_refused_own_chromium',
+        data: expect.objectContaining({ pid: RENDERER_PID, site: 'pty-descendant-sweep' })
+      })
+    ])
+  })
+
+  it('still taskkills a pid that is not one of ours', async () => {
+    const execFileImpl = vi.fn((_program, _args, _options, done: () => void) => {
+      done()
+    })
+
+    await terminateWindowsProcessTree(7777, {
+      execFileImpl: execFileImpl as never,
+      site: 'pty-descendant-sweep'
+    })
+
+    expect(execFileImpl).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '7777', '/T', '/F'],
+      expect.anything(),
+      expect.any(Function)
+    )
+  })
+})

--- a/src/main/pty-descendant-termination.ts
+++ b/src/main/pty-descendant-termination.ts
@@ -275,7 +275,9 @@ export async function killWithDescendantSweep(
         const target = await verify(rootPid).catch((): WindowsTreeKillTarget => 'unknown')
         // Re-check ownership: the identity query awaits, so exit can land meanwhile.
         if (target === 'own' && (deps.ownsRoot?.() ?? true)) {
-          const killTree = deps.killWindowsTree ?? terminateWindowsProcessTree
+          const killTree =
+            deps.killWindowsTree ??
+            ((pid: number) => terminateWindowsProcessTree(pid, { site: 'pty-descendant-sweep' }))
           // Why: taskkill may race an already-exited tree; never block killRoot on that.
           await killTree(rootPid).catch(() => {})
         }

--- a/src/main/pty/posix-pty-process-groups.test.ts
+++ b/src/main/pty/posix-pty-process-groups.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { recordSelfInitiatedTreeKillMock } = vi.hoisted(() => ({
+  recordSelfInitiatedTreeKillMock: vi.fn()
+}))
+vi.mock('../crash-reporting/self-initiated-tree-kill-log', () => ({
+  recordSelfInitiatedTreeKill: recordSelfInitiatedTreeKillMock
+}))
+
 import {
   forceKillPosixPtyProcessGroups,
   getPosixPtyProcessGroups
 } from './posix-pty-process-groups'
+
+beforeEach(() => {
+  recordSelfInitiatedTreeKillMock.mockReset()
+})
 
 const TABLE = `
   100  100 ttys001
@@ -86,5 +98,37 @@ describe('POSIX PTY process-group termination', () => {
 
     expect(fallback).toHaveBeenCalledOnce()
     expect(readProcessTable).not.toHaveBeenCalled()
+  })
+})
+
+describe('POSIX PTY group-sweep breadcrumbs', () => {
+  it('records every group it actually signalled', () => {
+    forceKillPosixPtyProcessGroups(100, vi.fn(), {
+      platform: 'darwin',
+      currentPid: 999,
+      readProcessTable: () => TABLE,
+      signalProcessGroup: vi.fn()
+    })
+
+    expect(recordSelfInitiatedTreeKillMock.mock.calls.map(([kill]) => kill)).toEqual([
+      { pid: 101, site: 'posix-pty-process-group-sweep', scope: 'posix-process-group' },
+      { pid: 103, site: 'posix-pty-process-group-sweep', scope: 'posix-process-group' },
+      { pid: 100, site: 'posix-pty-process-group-sweep', scope: 'posix-process-group' }
+    ])
+  })
+
+  it('does not claim a group that was already gone', () => {
+    forceKillPosixPtyProcessGroups(100, vi.fn(), {
+      platform: 'darwin',
+      currentPid: 999,
+      readProcessTable: () => TABLE,
+      signalProcessGroup: (pgid: number) => {
+        if (pgid === 103) {
+          throw Object.assign(new Error('no such process'), { code: 'ESRCH' })
+        }
+      }
+    })
+
+    expect(recordSelfInitiatedTreeKillMock.mock.calls.map(([kill]) => kill.pid)).toEqual([101, 100])
   })
 })

--- a/src/main/pty/posix-pty-process-groups.ts
+++ b/src/main/pty/posix-pty-process-groups.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { recordSelfInitiatedTreeKill } from '../crash-reporting/self-initiated-tree-kill-log'
 
 const PROCESS_TABLE_TIMEOUT_MS = 1_000
 const PROCESS_TABLE_MAX_BYTES = 1024 * 1024
@@ -116,6 +117,11 @@ export function forceKillPosixPtyProcessGroups(
   for (const pgid of groups) {
     try {
       signalProcessGroup(pgid)
+      recordSelfInitiatedTreeKill({
+        pid: pgid,
+        site: 'posix-pty-process-group-sweep',
+        scope: 'posix-process-group'
+      })
     } catch (error) {
       // Why: the PTY exit callback may reap a group between `ps` and killpg.
       // ESRCH is proof that this captured owner is already gone, not failure.

--- a/src/main/pty/posix-pty-process-groups.ts
+++ b/src/main/pty/posix-pty-process-groups.ts
@@ -117,18 +117,21 @@ export function forceKillPosixPtyProcessGroups(
   for (const pgid of groups) {
     try {
       signalProcessGroup(pgid)
-      recordSelfInitiatedTreeKill({
-        pid: pgid,
-        site: 'posix-pty-process-group-sweep',
-        scope: 'posix-process-group'
-      })
     } catch (error) {
       // Why: the PTY exit callback may reap a group between `ps` and killpg.
       // ESRCH is proof that this captured owner is already gone, not failure.
       if (!isProcessAlreadyGone(error) && firstError === undefined) {
         firstError = error
       }
+      continue
     }
+    // Outside the try: this catch is the ESRCH contract, and a throw from the
+    // breadcrumb path would be rethrown as a failed kill.
+    recordSelfInitiatedTreeKill({
+      pid: pgid,
+      site: 'posix-pty-process-group-sweep',
+      scope: 'posix-process-group'
+    })
   }
   if (firstError !== undefined) {
     throw firstError

--- a/src/main/rate-limits/codex-probe-termination.test.ts
+++ b/src/main/rate-limits/codex-probe-termination.test.ts
@@ -97,7 +97,9 @@ describe('terminateCodexProbeChild', () => {
     expect(child.kill).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(CODEX_PROBE_SHUTDOWN_DRAIN_MS)
-    expect(killWindowsProcessTree).toHaveBeenCalledWith(child.pid)
+    expect(killWindowsProcessTree).toHaveBeenCalledWith(child.pid, {
+      site: 'codex-rate-limit-probe'
+    })
     expect(child.kill).toHaveBeenCalledTimes(1)
     expect(child.kill).toHaveBeenCalledWith()
 
@@ -122,7 +124,9 @@ describe('terminateCodexProbeChild', () => {
     })
 
     await vi.advanceTimersByTimeAsync(0)
-    expect(killWindowsProcessTree).toHaveBeenCalledWith(child.pid)
+    expect(killWindowsProcessTree).toHaveBeenCalledWith(child.pid, {
+      site: 'codex-rate-limit-probe'
+    })
     child.exit()
     await Promise.resolve()
     expect(settled).toBe(false)

--- a/src/main/rate-limits/codex-probe-termination.ts
+++ b/src/main/rate-limits/codex-probe-termination.ts
@@ -90,7 +90,9 @@ export async function terminateCodexProbeChild(
     try {
       // npm-installed Codex runs beneath cmd.exe; killing only that wrapper can
       // leave app-server alive after the credential-home lock is released.
-      await (options?.killWindowsProcessTree ?? terminateWindowsProcessTree)(child.pid)
+      await (options?.killWindowsProcessTree ?? terminateWindowsProcessTree)(child.pid, {
+        site: 'codex-rate-limit-probe'
+      })
     } catch {
       // The direct-child fallback still applies if an injected killer rejects.
     }

--- a/src/main/startup/main-process-preflight.ts
+++ b/src/main/startup/main-process-preflight.ts
@@ -48,6 +48,7 @@ import {
 } from './single-instance-lock'
 import { setAppEnvironment } from '../../shared/app-environment'
 import { ElectronAppEnvironment } from '../host/electron-app-environment'
+import { installProcessTreeKillBreadcrumbObserver } from '../crash-reporting/self-initiated-tree-kill-log'
 import { setSecretStore } from '../../shared/secret-store'
 import { ElectronSecretStore } from '../host/electron-secret-store'
 import { setPtyHostBindings } from '../ipc/pty-host-bindings'
@@ -161,6 +162,9 @@ export function runMainProcessPreflight(options: MainProcessPreflightOptions): b
       }
     })
   }
+  // Why before any spawn: `signalProcessTree` is shared with the CLI and relay, so
+  // it can only reach the main-process breadcrumb store through a registered observer.
+  installProcessTreeKillBreadcrumbObserver()
   const isDev = is.dev
   configureDevUserDataPath(isDev)
   configureOrcaUserDataPathEnv()

--- a/src/main/text-generation/commit-message-text-generation-test-harness.ts
+++ b/src/main/text-generation/commit-message-text-generation-test-harness.ts
@@ -36,7 +36,9 @@ export function createChildTerminationExpectation(
 ): (child: { pid: number; kill: ReturnType<typeof vi.fn> }) => void {
   return (child) => {
     if (process.platform === 'win32') {
-      expect(terminateWindowsProcessTreeMock).toHaveBeenCalledWith(child.pid)
+      expect(terminateWindowsProcessTreeMock).toHaveBeenCalledWith(child.pid, {
+        site: 'source-control-text-generation'
+      })
       expect(child.kill).not.toHaveBeenCalled()
       return
     }

--- a/src/main/text-generation/source-control-local-process.ts
+++ b/src/main/text-generation/source-control-local-process.ts
@@ -30,7 +30,7 @@ export function killSourceControlAgentProcess(
     return Promise.resolve()
   }
   if (process.platform === 'win32') {
-    return terminateWindowsProcessTree(pid)
+    return terminateWindowsProcessTree(pid, { site: 'source-control-text-generation' })
   }
   try {
     child.kill('SIGKILL')

--- a/src/main/windows-process-tree-kill.ts
+++ b/src/main/windows-process-tree-kill.ts
@@ -1,6 +1,11 @@
 import { execFile } from 'node:child_process'
+import {
+  recordRefusedOwnChromiumTreeKill,
+  recordSelfInitiatedTreeKill
+} from './crash-reporting/self-initiated-tree-kill-log'
+import { readOrcaChromiumProcessPids } from './orca-chromium-process-pids'
 
-export type WindowsTreeKiller = (rootPid: number) => Promise<void>
+export type WindowsTreeKiller = (rootPid: number, deps?: { site?: string }) => Promise<void>
 
 /** Bound hung taskkill so killRoot still runs in killWithDescendantSweep. */
 export const WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS = 5_000
@@ -9,14 +14,27 @@ export const WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS = 5_000
  * Force-kill a Windows process and every descendant (`taskkill /T /F`).
  * Best-effort: missing/already-dead roots still resolve so callers can finish
  * their own handle cleanup via killRoot.
+ *
+ * This is the main process's single taskkill choke point, so it is also where
+ * the self-kill breadcrumb and the own-Chromium refusal live — instrumenting
+ * callers instead would rot the first time one is added.
  */
 export function terminateWindowsProcessTree(
   rootPid: number,
-  deps: { execFileImpl?: typeof execFile } = {}
+  deps: { execFileImpl?: typeof execFile; site?: string } = {}
 ): Promise<void> {
   if (!Number.isInteger(rootPid) || rootPid <= 0) {
     return Promise.resolve()
   }
+  const site = deps.site ?? 'windows-process-tree-kill'
+  // Why: no PTY root, codex root or git child is ever one of our own Chromium
+  // processes, so a pid that is means the caller is about to kill a renderer,
+  // the GPU or the browser itself (#10680).
+  if (readOrcaChromiumProcessPids().has(rootPid)) {
+    recordRefusedOwnChromiumTreeKill({ pid: rootPid, site, scope: 'win-taskkill-tree' })
+    return Promise.resolve()
+  }
+  recordSelfInitiatedTreeKill({ pid: rootPid, site, scope: 'win-taskkill-tree' })
   const run = deps.execFileImpl ?? execFile
   return new Promise((resolve) => {
     run(

--- a/src/main/windows-process-tree-kill.ts
+++ b/src/main/windows-process-tree-kill.ts
@@ -1,9 +1,5 @@
 import { execFile } from 'node:child_process'
-import {
-  recordRefusedOwnChromiumTreeKill,
-  recordSelfInitiatedTreeKill
-} from './crash-reporting/self-initiated-tree-kill-log'
-import { readOrcaChromiumProcessPids } from './orca-chromium-process-pids'
+import { admitSelfInitiatedTreeKill } from './own-chromium-tree-kill-guard'
 
 export type WindowsTreeKiller = (rootPid: number, deps?: { site?: string }) => Promise<void>
 
@@ -15,9 +11,9 @@ export const WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS = 5_000
  * Best-effort: missing/already-dead roots still resolve so callers can finish
  * their own handle cleanup via killRoot.
  *
- * This is the main process's single taskkill choke point, so it is also where
- * the self-kill breadcrumb and the own-Chromium refusal live — instrumenting
- * callers instead would rot the first time one is added.
+ * Nearly every main-process taskkill runs through here; the two account-login
+ * teardowns keep their own spawn but share the same gate, so the refusal and the
+ * breadcrumb live in `admitSelfInitiatedTreeKill` rather than in this function.
  */
 export function terminateWindowsProcessTree(
   rootPid: number,
@@ -27,14 +23,9 @@ export function terminateWindowsProcessTree(
     return Promise.resolve()
   }
   const site = deps.site ?? 'windows-process-tree-kill'
-  // Why: no PTY root, codex root or git child is ever one of our own Chromium
-  // processes, so a pid that is means the caller is about to kill a renderer,
-  // the GPU or the browser itself (#10680).
-  if (readOrcaChromiumProcessPids().has(rootPid)) {
-    recordRefusedOwnChromiumTreeKill({ pid: rootPid, site, scope: 'win-taskkill-tree' })
+  if (!admitSelfInitiatedTreeKill({ pid: rootPid, site, scope: 'win-taskkill-tree' })) {
     return Promise.resolve()
   }
-  recordSelfInitiatedTreeKill({ pid: rootPid, site, scope: 'win-taskkill-tree' })
   const run = deps.execFileImpl ?? execFile
   return new Promise((resolve) => {
     run(

--- a/src/main/windows-pty-root-identity.ts
+++ b/src/main/windows-pty-root-identity.ts
@@ -1,4 +1,5 @@
 import { queryWindowsProcessRowsFresh } from './providers/windows-foreground-process-rows'
+import { readOrcaChromiumProcessPids } from './orca-chromium-process-pids'
 
 /**
  * Whether a PID still sits inside this process's own subtree. Note this is
@@ -33,17 +34,25 @@ export type WindowsProcessLinkReader = () => Promise<readonly ProcessLink[] | nu
  * `own`. That is not remote during teardown, when Orca is itself the process
  * allocating pids. Closing it needs real identity (a `Win32_Process.CreationDate`
  * baseline, the analogue of the POSIX `lstart` check, or an inherited handle /
- * Job Object).
+ * Job Object). The Chromium-process half of it IS closed: `ownChromiumPids`
+ * refuses any pid Electron is currently accounting for.
  */
 export function classifyWindowsTreeKillTarget(
   rootPid: number,
   rows: readonly ProcessLink[],
-  ownerPid: number
+  ownerPid: number,
+  ownChromiumPids: ReadonlySet<number> = readOrcaChromiumProcessPids()
 ): WindowsTreeKillTarget {
   // Why: our own pid is never a PTY root, so reading it here means the pid is
   // corrupt. `foreign` is the refusing verdict, which is what that must get —
   // `taskkill /T /F` on ourselves would take Orca and every pane down with it.
   if (!Number.isInteger(rootPid) || rootPid <= 0 || rootPid === ownerPid) {
+    return 'foreign'
+  }
+  // Same reasoning one hop out: our renderer, GPU and utility children are all
+  // direct children of ownerPid, so the ancestry walk below calls them `own` and
+  // hands teardown a licence to taskkill /T /F Orca's own UI (#10680).
+  if (ownChromiumPids.has(rootPid)) {
     return 'foreign'
   }
   const parentByPid = new Map<number, number | null>()
@@ -118,6 +127,7 @@ export async function verifyWindowsTreeKillTarget(
   deps: {
     readRows?: WindowsProcessLinkReader
     ownerPid?: number
+    ownChromiumPids?: ReadonlySet<number>
     platform?: NodeJS.Platform
     timeoutMs?: number
   } = {}
@@ -134,5 +144,10 @@ export async function verifyWindowsTreeKillTarget(
   if (!rows) {
     return 'unknown'
   }
-  return classifyWindowsTreeKillTarget(rootPid, rows, deps.ownerPid ?? process.pid)
+  return classifyWindowsTreeKillTarget(
+    rootPid,
+    rows,
+    deps.ownerPid ?? process.pid,
+    deps.ownChromiumPids ?? readOrcaChromiumProcessPids()
+  )
 }

--- a/src/main/windows/windows-pty-job.test.ts
+++ b/src/main/windows/windows-pty-job.test.ts
@@ -1,5 +1,13 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { IPty } from 'node-pty'
+
+const { recordSelfInitiatedTreeKillMock } = vi.hoisted(() => ({
+  recordSelfInitiatedTreeKillMock: vi.fn()
+}))
+vi.mock('../crash-reporting/self-initiated-tree-kill-log', () => ({
+  recordSelfInitiatedTreeKill: recordSelfInitiatedTreeKillMock
+}))
+
 import {
   __setConptyJobNativeForTests,
   assignHostProcessToKillOnCloseJob,
@@ -9,6 +17,10 @@ import {
 } from './windows-pty-job'
 
 const ptyWithHandle = (id: unknown, pid = 4242): IPty => ({ _pty: id, pid }) as unknown as IPty
+
+beforeEach(() => {
+  recordSelfInitiatedTreeKillMock.mockReset()
+})
 
 afterEach(() => {
   __setConptyJobNativeForTests()
@@ -150,5 +162,45 @@ describe('assignHostProcessToKillOnCloseJob', () => {
 
     __setConptyJobNativeForTests(() => null)
     expect(assignHostProcessToKillOnCloseJob()).toBe(false)
+  })
+})
+
+describe('PTY Job Object teardown breadcrumbs', () => {
+  function withNative(terminateJob: () => boolean): void {
+    __setConptyJobNativeForTests(() => ({
+      terminateJob,
+      listJobProcessIds: vi.fn(),
+      assignCurrentProcessToJob: vi.fn().mockReturnValue(true)
+    }))
+  }
+
+  it('records the shell pid whose job it terminated', () => {
+    withNative(() => true)
+
+    expect(terminatePtyJob(ptyWithHandle(7, 4242))).toBe('terminated')
+    expect(recordSelfInitiatedTreeKillMock).toHaveBeenCalledWith({
+      pid: 4242,
+      site: 'windows-pty-job-teardown',
+      scope: 'win-pty-job'
+    })
+  })
+
+  it('records nothing when the native side refused', () => {
+    withNative(() => false)
+
+    expect(terminatePtyJob(ptyWithHandle(7))).toBe('unavailable')
+    expect(recordSelfInitiatedTreeKillMock).not.toHaveBeenCalled()
+  })
+
+  it('never downgrades a real termination to unavailable because diagnostics failed', () => {
+    // `unavailable` escalates callers to the pid-addressed taskkill this
+    // instrumentation exists to constrain, so the breadcrumb must sit outside
+    // the native call's catch.
+    withNative(() => true)
+    recordSelfInitiatedTreeKillMock.mockImplementation(() => {
+      throw new Error('breadcrumb store exploded')
+    })
+
+    expect(() => terminatePtyJob(ptyWithHandle(7))).toThrow('breadcrumb store exploded')
   })
 })

--- a/src/main/windows/windows-pty-job.ts
+++ b/src/main/windows/windows-pty-job.ts
@@ -94,19 +94,25 @@ export function terminatePtyJob(proc: IPty): JobTerminationOutcome {
   if (!target || !native) {
     return 'unavailable'
   }
+  let terminated: boolean
   try {
-    if (!native.terminateJob(target.id, target.shellPid)) {
-      return 'unavailable'
-    }
-    recordSelfInitiatedTreeKill({
-      pid: target.shellPid,
-      site: 'windows-pty-job-teardown',
-      scope: 'win-pty-job'
-    })
-    return 'terminated'
+    terminated = native.terminateJob(target.id, target.shellPid)
   } catch {
     return 'unavailable'
   }
+  if (!terminated) {
+    return 'unavailable'
+  }
+  // Outside the try: that catch is the native-refusal contract, and a throw from
+  // the breadcrumb path would downgrade a real termination to `unavailable`,
+  // escalating callers to the pid-addressed taskkill this instrumentation exists
+  // to constrain.
+  recordSelfInitiatedTreeKill({
+    pid: target.shellPid,
+    site: 'windows-pty-job-teardown',
+    scope: 'win-pty-job'
+  })
+  return 'terminated'
 }
 
 /**

--- a/src/main/windows/windows-pty-job.ts
+++ b/src/main/windows/windows-pty-job.ts
@@ -1,5 +1,6 @@
 import type { IPty } from 'node-pty'
 import { createRequire } from 'node:module'
+import { recordSelfInitiatedTreeKill } from '../crash-reporting/self-initiated-tree-kill-log'
 
 /**
  * Job-object ownership for a ConPTY's process tree.
@@ -94,7 +95,15 @@ export function terminatePtyJob(proc: IPty): JobTerminationOutcome {
     return 'unavailable'
   }
   try {
-    return native.terminateJob(target.id, target.shellPid) ? 'terminated' : 'unavailable'
+    if (!native.terminateJob(target.id, target.shellPid)) {
+      return 'unavailable'
+    }
+    recordSelfInitiatedTreeKill({
+      pid: target.shellPid,
+      site: 'windows-pty-job-teardown',
+      scope: 'win-pty-job'
+    })
+    return 'terminated'
   } catch {
     return 'unavailable'
   }

--- a/src/shared/child-process/process-tree-kill-observer.ts
+++ b/src/shared/child-process/process-tree-kill-observer.ts
@@ -1,0 +1,37 @@
+/**
+ * Seam that lets the main process record the tree-kills issued from here.
+ *
+ * Why a seam and not a direct call: `signalProcessTree` is the choke point every
+ * `runProcess` termination funnels through, but it lives in `src/shared` and so
+ * runs in the CLI and relay too — it cannot import the main-process crash
+ * breadcrumb store. Main registers the recorder at startup; everywhere else this
+ * stays a no-op.
+ */
+
+/** Blast radius, not mechanism: `win-taskkill-tree` is addressed by pid and walks
+ *  whatever tree that pid has *now*, so it can land on a recycled pid that is
+ *  since one of Orca's own Chromium processes. A process group can only contain
+ *  processes Orca itself put there. */
+export type ProcessTreeKillScope = 'win-taskkill-tree' | 'posix-process-group'
+
+export type ProcessTreeKill = {
+  pid: number
+  site: string
+  scope: ProcessTreeKillScope
+}
+
+type ProcessTreeKillObserver = (kill: ProcessTreeKill) => void
+
+let observer: ProcessTreeKillObserver | null = null
+
+export function setProcessTreeKillObserver(next: ProcessTreeKillObserver | null): void {
+  observer = next
+}
+
+export function notifyProcessTreeKill(kill: ProcessTreeKill): void {
+  try {
+    observer?.(kill)
+  } catch {
+    // Diagnostics must never turn a successful termination into a failed one.
+  }
+}

--- a/src/shared/child-process/process-tree-termination.test.ts
+++ b/src/shared/child-process/process-tree-termination.test.ts
@@ -1,12 +1,13 @@
 import { EventEmitter } from 'node:events'
 import type { ChildProcess } from 'node:child_process'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
 
 vi.mock('node:child_process', () => ({ spawn: spawnMock }))
 
-import { forceTerminateProcessTree } from './process-tree-termination'
+import { forceTerminateProcessTree, signalProcessTree } from './process-tree-termination'
+import { setProcessTreeKillObserver, type ProcessTreeKill } from './process-tree-kill-observer'
 
 function mockProcess(pid: number): ChildProcess {
   const child = new EventEmitter() as EventEmitter & {
@@ -95,4 +96,62 @@ describe('forceTerminateProcessTree', () => {
       await expect(pending).resolves.toBe(false)
     }
   )
+})
+
+describe('process-tree-kill breadcrumb seam', () => {
+  const observed: ProcessTreeKill[] = []
+
+  beforeEach(() => {
+    observed.length = 0
+    setProcessTreeKillObserver((kill) => observed.push(kill))
+  })
+
+  afterEach(() => {
+    setProcessTreeKillObserver(null)
+    spawnMock.mockReset()
+    vi.restoreAllMocks()
+  })
+
+  it('reports the Windows taskkill tree it just spawned', async () => {
+    await withWindows(async () => {
+      const child = mockProcess(1234)
+      const taskkill = mockProcess(5678)
+      spawnMock.mockReturnValue(taskkill)
+
+      const pending = signalProcessTree(child, 'SIGKILL')
+      taskkill.emit('close', 0)
+      await pending
+
+      expect(observed).toEqual([
+        { pid: 1234, site: 'run-process-tree', scope: 'win-taskkill-tree' }
+      ])
+    })
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'reports the POSIX process group it signalled',
+    async () => {
+      vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+      await expect(signalProcessTree(mockProcess(1234), 'SIGKILL')).resolves.toBe(true)
+
+      expect(observed).toEqual([
+        { pid: 1234, site: 'run-process-tree', scope: 'posix-process-group' }
+      ])
+    }
+  )
+
+  it('never taskkills a pid the child already gave back to Windows', async () => {
+    await withWindows(async () => {
+      // A reaped pid is Windows' to reissue, and this host may be the daemon or
+      // relay, where the main-process own-Chromium guard cannot run.
+      const child = mockProcess(1234) as ChildProcess & { exitCode: number }
+      child.exitCode = 0
+
+      await expect(signalProcessTree(child, 'SIGKILL')).resolves.toBe(true)
+
+      expect(spawnMock).not.toHaveBeenCalled()
+      expect(observed).toEqual([])
+    })
+  })
 })

--- a/src/shared/child-process/process-tree-termination.test.ts
+++ b/src/shared/child-process/process-tree-termination.test.ts
@@ -148,7 +148,10 @@ describe('process-tree-kill breadcrumb seam', () => {
       const child = mockProcess(1234) as ChildProcess & { exitCode: number }
       child.exitCode = 0
 
-      await expect(signalProcessTree(child, 'SIGKILL')).resolves.toBe(true)
+      // `false`, not `true`: a taskkill against a reaped pid already resolved to
+      // `false`, and reporting verified termination here would release the git
+      // admission grant on root exit instead of on `close`.
+      await expect(signalProcessTree(child, 'SIGKILL')).resolves.toBe(false)
 
       expect(spawnMock).not.toHaveBeenCalled()
       expect(observed).toEqual([])

--- a/src/shared/child-process/process-tree-termination.ts
+++ b/src/shared/child-process/process-tree-termination.ts
@@ -26,9 +26,16 @@ export function signalProcessTree(child: ChildProcess, signal?: NodeJS.Signals):
     // reissue, and `taskkill /t /f` walks whatever tree owns it *now* — a
     // recycled pid can be one of Orca's own Chromium processes (#10680). The
     // POSIX branch below cannot hit this: killing a reaped group is ESRCH.
+    //
+    // Why `false`: this is exactly what a taskkill against a reaped pid already
+    // resolved to (non-zero exit -> killRoot + `false`), so skipping the unsafe
+    // spawn must not also flip the termination barrier to "verified". Reporting
+    // `true` here would release the git admission grant on root exit instead of
+    // on `close`, admitting the next git command while a descendant that
+    // inherited the pipes still holds the repo.
     if (hasExited(child)) {
       killRoot(child, signal)
-      return Promise.resolve(true)
+      return Promise.resolve(false)
     }
     return taskkillTree(child, child.pid, signal)
   }

--- a/src/shared/child-process/process-tree-termination.ts
+++ b/src/shared/child-process/process-tree-termination.ts
@@ -1,4 +1,5 @@
 import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process'
+import { notifyProcessTreeKill } from './process-tree-kill-observer'
 
 const PROBE_INTERVAL_MS = 25
 const SUBPROCESS_TIMEOUT_MS = 2_000
@@ -17,10 +18,15 @@ export function signalProcessTree(child: ChildProcess, signal?: NodeJS.Signals):
     return Promise.resolve(true)
   }
   if (process.platform === 'win32') {
-    return taskkillTree(child, signal)
+    return taskkillTree(child, child.pid, signal)
   }
   try {
     process.kill(-child.pid, signal)
+    notifyProcessTreeKill({
+      pid: child.pid,
+      site: 'run-process-tree',
+      scope: 'posix-process-group'
+    })
     return Promise.resolve(true)
   } catch {
     return Promise.resolve(!processGroupExists(child.pid))
@@ -38,11 +44,15 @@ export async function forceTerminateProcessTree(child: ChildProcess): Promise<bo
   return true
 }
 
-function taskkillTree(child: ChildProcess, signal?: NodeJS.Signals): Promise<boolean> {
+function taskkillTree(
+  child: ChildProcess,
+  rootPid: number,
+  signal?: NodeJS.Signals
+): Promise<boolean> {
   return new Promise((resolve) => {
     let killer: ChildProcess
     try {
-      killer = nodeSpawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+      killer = nodeSpawn('taskkill', ['/pid', String(rootPid), '/t', '/f'], {
         stdio: 'ignore',
         windowsHide: true,
         shell: false
@@ -52,6 +62,7 @@ function taskkillTree(child: ChildProcess, signal?: NodeJS.Signals): Promise<boo
       resolve(false)
       return
     }
+    notifyProcessTreeKill({ pid: rootPid, site: 'run-process-tree', scope: 'win-taskkill-tree' })
     let settled = false
     const finish = (fallback: boolean): void => {
       if (settled) {

--- a/src/shared/child-process/process-tree-termination.ts
+++ b/src/shared/child-process/process-tree-termination.ts
@@ -11,6 +11,10 @@ const MAX_PS_OUTPUT_BYTES = 8 * 1024 * 1024
  * POSIX precondition: the child must have been spawned `detached`. The signal
  * goes to the process group `-child.pid`, so a child that is not its own group
  * leader would hand it to whatever group it inherited instead.
+ *
+ * Runs in every host — Electron main, the daemon, the relay, the CLI — so the
+ * main-process own-Chromium guard cannot reach here; the exit check below is
+ * what keeps the Windows branch off a pid that is no longer ours.
  */
 export function signalProcessTree(child: ChildProcess, signal?: NodeJS.Signals): Promise<boolean> {
   if (!child.pid) {
@@ -18,6 +22,14 @@ export function signalProcessTree(child: ChildProcess, signal?: NodeJS.Signals):
     return Promise.resolve(true)
   }
   if (process.platform === 'win32') {
+    // Why the exit check: once the child is reaped its pid is Windows' to
+    // reissue, and `taskkill /t /f` walks whatever tree owns it *now* — a
+    // recycled pid can be one of Orca's own Chromium processes (#10680). The
+    // POSIX branch below cannot hit this: killing a reaped group is ESRCH.
+    if (hasExited(child)) {
+      killRoot(child, signal)
+      return Promise.resolve(true)
+    }
     return taskkillTree(child, child.pid, signal)
   }
   try {
@@ -42,6 +54,11 @@ export async function forceTerminateProcessTree(child: ChildProcess): Promise<bo
     return waitForPosixProcessGroupQuiescence(child.pid)
   }
   return true
+}
+
+/** A stubbed child leaves both undefined; only a real code or signal proves exit. */
+function hasExited(child: ChildProcess): boolean {
+  return (child.exitCode ?? null) !== null || (child.signalCode ?? null) !== null
 }
 
 function taskkillTree(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​598 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​591 |
| Prod | 20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​540 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​84 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​456 |

<!-- /orca-pr-loc -->

## What

Cluster **G2-killed**: **20 field crash reports** whose renderer died with `reason=killed exitCode=1` and no minidump. Affected versions **1.4.194 (10 reports)** and **1.4.195 (10 reports)**. OS split: **15 win32** (10.0.19045 / 22631 / 26100 / 26200, x64), **3 darwin** (25.6.0 arm64), **2 linux** (6.8 x64 and arm64).

The cluster is undecidable as recorded. A `taskkill /T /F` that **Orca itself** issues and an external kill of the same renderer produce byte-identical crash reports — same `reason`, same `exitCode`, same `crashAttribution`, same `siblingProcessDeathCount`. Nothing Orca persists today distinguishes "something killed us" from "we killed ourselves".

Two changes.

**1. A real guard (behaviour change).** `classifyWindowsTreeKillTarget` (`src/main/windows-pty-root-identity.ts:40-90`) decides whether a pid may be force-killed by walking its ancestry back to the killing process's own pid and returning `own` when the chain reaches us. Orca's renderer, GPU process and network-service utility are all **direct children of Electron main**, so from Electron main that walk hits `parent === ownerPid` on hop 0 (`windows-pty-root-identity.ts:79-81`) and returns `own` — handing PTY teardown a licence to `taskkill /T /F` Orca's own UI. That is the Chromium half of known limit #10680, documented in the classifier's own doc comment. Both the classifier (`windows-pty-root-identity.ts:55-57`) and the taskkill choke point (`src/main/windows-process-tree-kill.ts:26-28`) now refuse any pid Electron is currently accounting for in `app.getAppMetrics()`, via a shared gate `admitSelfInitiatedTreeKill` (`src/main/own-chromium-tree-kill-guard.ts:26-40`). The gate is shared because the codex and claude account-login teardowns run their own `taskkill /T /F` with different lifetimes, so a check inside the tree-kill helper alone would have covered one of three families.

Reachable from `killWithDescendantSweep` (`src/main/pty-descendant-termination.ts:274-280`, `site: 'pty-descendant-sweep'`) and from `src/main/codex/codex-structured-turn-processes.ts:61` (`site: 'codex-turn-added-roots'`) — the two sites the investigation named as suspects for G2.

**2. Instrumentation that makes the next round decidable.** The gated force-kill choke points record a durable, coalesced `self_tree_kill` breadcrumb (`src/main/crash-reporting/self-initiated-tree-kill-log.ts`), and `process_gone` reports carry three new detail keys (`src/main/crash-reporting/process-gone-recorder.ts:254`):

- `selfInitiatedTreeKillCount` — **pid-addressed** taskkills only, i.e. kills that could land on a recycled pid that is now our renderer.
- `selfInitiatedGroupKillCount` — PTY process-group / Job Object sweeps, which are structurally incapable of taking a Chromium process with them.
- `selfInitiatedKills` — `win-taskkill-tree/pty-descendant-sweep/pid21688 -121ms`, pid-addressed entries sorted first so truncation never drops the discriminating ones.

`selfInitiatedTreeKillCount` is **not** a clean binary discriminator, and an earlier version of this body called it one. It has a routine base rate: every aborted or timed-out `runProcess` on Windows records scope `win-taskkill-tree`, including ordinary cancelled git. The `selfInitiatedKills` site string is what separates a `pty-descendant-sweep` from a `git-command-tree-kill`; the count alone does not.

A **refused** kill records `self_tree_kill_refused_own_chromium`. That crumb is falsifiable on purpose: if it ever appears in a field bundle, Orca was demonstrably about to kill its own renderer.

**This PR does not claim to fix the 20 reports.** G2 is at least four fingerprints sharing one symptom (~15 Windows `killed`/`1`, 3 POSIX SIGKILL under memory pressure, 2 duplicate reports of one macOS V8 Proxy Resolver SIGKILL, 1 install-dir ACL crash). ~~It ships one guard that **every** pid-addressed `taskkill /pid <pid> /t /f` reachable from Electron main now asks — including the git command-runner abort, the codex app-server deadline kill, the notebook and precheck timeouts and the shared `runProcess` choke point — plus a ratchet (`src/main/main-process-tree-kill-gate.test.ts`) that fails on a new ungated one.~~ **(not in this merge — see the box; that is #18459.)** What merged is the guard wired into three families: `terminateWindowsProcessTree` and the two account-login teardowns. **Six other pid-addressed taskkill families in Electron main remain ungated on `main`**, so a *main-issued* kill can still land on a pid Electron is accounting for. It does **not** make the shape impossible anywhere else: on the CLI, relay and daemon hosts the same seam admits every kill because there is no Chromium pid set to consult, and a recycle onto a non-Chromium Orca descendant still classifies `own` (Follow-up 2).

## Fix evidence

Everything below was **re-run from scratch on 2026-09-03**, on macOS, after the merge, at both revisions. Merge-base for both experiments is `76836b30ea6`.

### A. The merged artifact (`2d0c627ba08`) — this is what is on `main`

Red without the production change. All new modules and all test files kept; only the **15 pre-existing production files** reverted to the merge-base:

```
$ git checkout 76836b30ea6 -- <15 pre-existing production .ts files>
$ ./node_modules/.bin/vitest run \
    src/main/crash-reporting/self-initiated-tree-kill-log.test.ts \
    src/main/own-chromium-tree-kill-guard.test.ts \
    src/shared/child-process/process-tree-termination.test.ts \
    src/main/pty/posix-pty-process-groups.test.ts \
    src/main/windows/windows-pty-job.test.ts \
    src/main/codex/codex-app-server-process-teardown.test.ts \
    src/main/rate-limits/codex-probe-termination.test.ts

 Test Files  7 failed (7)
      Tests  14 failed | 47 passed (61)
```

First failure verbatim — this is the discriminator test, and without the production change the field simply does not exist:

```
 FAIL  src/main/crash-reporting/self-initiated-tree-kill-log.test.ts > self-initiated tree kill breadcrumb > separates an Orca-issued tree kill from an external kill of the same shape
TypeError: .toMatch() expects to receive a string, but got undefined
 ❯ src/main/crash-reporting/self-initiated-tree-kill-log.test.ts:103:43
    101|     const externallyKilled = await recordKilledRenderer()
    102|
    103|     expect(selfKilled.selfInitiatedKills).toMatch(
       |                                           ^
    104|       /^win-taskkill-tree\/pty-descendant-sweep\/pid4242 [+-]\d+ms$/
    105|
```

Green with it, plus the broad sweep, typechecks and lint at the merged head:

```
$ git checkout 2d0c627ba08 -- <same 15 files>   # git status clean
$ ./node_modules/.bin/vitest run <same 7 test files>
 Test Files  7 passed (7)
      Tests  61 passed (61)

$ ./node_modules/.bin/vitest run src/main/crash-reporting src/main/own-chromium-tree-kill-guard.test.ts \
    src/main/windows-pty-root-identity.test.ts src/main/pty src/main/windows src/main/codex \
    src/main/rate-limits src/main/claude-accounts src/main/codex-accounts src/main/text-generation \
    src/shared/child-process src/main/pty-descendant-termination.test.ts
 Test Files  299 passed | 5 skipped (304)
      Tests  3048 passed | 48 skipped (3096)

$ tsc -p config/tsconfig.node.json --noEmit    exit=0
$ tsc -p config/tsconfig.tc.web.json --noEmit  exit=0
$ tsc -p config/tsconfig.tc.cli.json --noEmit  exit=0
$ oxlint src                                   exit=0
```

### B. The branch tip (`9db1b4ce6ef`) — NOT merged, and superseded by #18459

Kept here only because the branch still points at it. It adds an eighth test file (the ratchet) and touches 20 rather than 15 pre-existing production files:

```
$ git checkout 76836b30ea6 -- <20 pre-existing production .ts files>
 20 files changed, 84 insertions(+), 200 deletions(-)
$ vitest run <8 test files, adding src/main/main-process-tree-kill-gate.test.ts>
 Test Files  8 failed (8)
      Tests  17 failed | 51 passed (68)

$ git checkout HEAD -- src/   # git status clean
$ vitest run <same 8 test files>
 Test Files  8 passed (8)
      Tests  68 passed (68)

$ vitest run <same broad sweep>
 Test Files  300 passed | 5 skipped (305)
      Tests  3055 passed | 48 skipped (3103)

$ tsc x3   exit=0,0,0        $ oxlint src   exit=0
```

**This tip is stale and must not be merged as-is.** It still carries the round-4 eviction defect. Probe re-run at the tip today — 32 routine `git-command-tree-kill` entries saturate the 32-slot ring, then a `win-pty-job` teardown 10ms before the death:

```
PROBE_RESULT {"selfInitiatedTreeKillCount":32,
  "selfInitiatedKills":"win-taskkill-tree/git-command-tree-kill/pid100 -3000ms, ... (+29 more)"}
AssertionError: expected undefined to be 1     # selfInitiatedGroupKillCount
```

The entry recorded 10ms before the crash is spliced out by the entry itself; pid 7777 never appears. `#18459` (`9bac44ee970`) fixes this by excluding the just-recorded entry from eviction candidacy.

`process-gone-recorder.ts` and `claude-command-process.ts` both hit the 300-line cap during development. **No `max-lines` suppression was added**: the recorder change was collapsed to one import + one spread, and `terminateClaudeProcess` was moved to its own module (`claude-login-process-termination.ts`).

### Live reproduction on real Windows 11 / Electron 43.4.1 — captured against an earlier revision, NOT re-run at the merged head

**Read this first.** The three arms below were captured at `f05863a`. Three commits landed in this merge since (`8e6a107`, `1796073`, `2d0c627`) and they changed exactly what these arms print: the list key is now `selfInitiatedKills` (not `selfInitiatedTreeKills`), every entry carries a `<scope>/` prefix, and the count is split into `selfInitiatedTreeKillCount` / `selfInitiatedGroupKillCount`. The Windows host was unreachable when the round-3 findings were closed (`ssh awin` → connection timed out) and has not been reachable since, so **no Windows execution has covered the merged code.** Treat the arms as evidence for the two claims that do not depend on the output format — A vs B are indistinguishable in every recorded field, and the refusal prevents the crash entirely — and treat the merged format as pinned by unit tests instead.

**Disclosure:** `main2.js` is a JS transliteration of three shipped functions (`readOrcaChromiumProcessPids`, `recordSelfInitiatedTreeKill` + `selfInitiatedTreeKillDetails`, `terminateWindowsProcessTree`), md5 `3f8b05c0953102c627608e24635dbe7e` verified identical on both machines. **It is not the shipped TypeScript**, and it models a single-Electron-process topology, not the standalone daemon.

Arm A — Orca kills its own renderer, guard off. Breadcrumb present:

```
{"ev":"ready","mode":"self","guard":false,"mainPid":13112,"rendererPid":21688,
 "metrics":[["Browser",13112,null],["GPU",9124,"GPU"],["Utility",21620,"network.mojom.NetworkService"],["Tab",21688,null]]}
{"ev":"breadcrumb","name":"self_tree_kill","pid":21688,"site":"pty-descendant-sweep","scope":"win-taskkill-tree"}
{"ev":"render-process-gone","reason":"killed","exitCode":1,"crashAttribution":"none",
 "siblingProcessDeathCount":0,"siblingProcessDeaths":"",
 "selfInitiatedTreeKillCount":1,"selfInitiatedTreeKills":"pty-descendant-sweep/pid21688 -121ms"}
```

(Stale key and format, per the banner above. On `main` that last line reads `"selfInitiatedTreeKillCount":1,"selfInitiatedKills":"win-taskkill-tree/pty-descendant-sweep/pid21688 -121ms"`.)

Arm B — external `taskkill` of the same renderer from a second shell. Breadcrumb absent:

```
(second terminal) $ taskkill //PID 22260 //T //F
SUCCESS: The process with PID 22260 (child process of PID 20016) has been terminated.

{"ev":"ready","mode":"external","guard":false,"mainPid":20016,"rendererPid":22260,
 "metrics":[["Browser",20016,null],["GPU",13440,"GPU"],["Utility",23720,"network.mojom.NetworkService"],["Tab",22260,null]]}
{"ev":"render-process-gone","reason":"killed","exitCode":1,"crashAttribution":"none",
 "siblingProcessDeathCount":0,"siblingProcessDeaths":""}
```

`reason`, `exitCode`, `crashAttribution`, `siblingProcessDeathCount` and `siblingProcessDeaths` are **identical across A and B**. The self-kill list is the only field that differs. Both match field report `1.4.194_449351d6` (`killed` / exit 1 / win32 10.0.19045 / no siblings / app survived / `minidumpStatus: absent`).

Arm C — same self-kill with the guard on. Kill refused, no crash at all:

```
{"ev":"ready","mode":"self","guard":true,"mainPid":2524,"rendererPid":10408,
 "metrics":[["Browser",2524,null],["GPU",2448,"GPU"],["Utility",19608,"network.mojom.NetworkService"],["Tab",10408,null]]}
{"ev":"breadcrumb","name":"self_tree_kill_refused_own_chromium","pid":10408,"site":"pty-descendant-sweep","scope":"win-taskkill-tree"}
{"ev":"timeout_exit","rendererAlive":true}
```

No `render-process-gone` was ever emitted.

### Explicitly NOT proven

- **That Orca caused any of the 20 field reports.** Nobody has that evidence. This PR creates part of the field that would produce it.
- **That the guard eliminates the shape everywhere.** Arm C proves it for kills issued from `terminateWindowsProcessTree` in Electron main. Six other pid-addressed taskkill families in main are ungated on `main`. In the standalone daemon `readOrcaChromiumProcessPids()` is empty and the gate always admits; there the shape is blocked one layer earlier by the ancestry walk, locked in as a falsifiable test pair in `own-chromium-tree-kill-guard.test.ts` — but **not** exercised by the Windows arms.
- **That anything shipped has run on Windows.** The arms predate three merged commits and were produced by a JS transliteration; the Windows host has been unreachable since round 3. Everything reproducible on macOS was re-run today at both revisions; the Windows arms were not.
- **`app.getAppMetrics()` cost per force-kill.** Unbenchmarked. See Trade-off 2.

## ELI5

Orca sometimes needs to forcefully kill a group of background processes — a terminal's shell, an agent CLI and everything they started. On Windows it does that by process ID. The check that decides "is this ID safe to kill?" asked "does this process belong to me?", and Orca's own window — the thing you're looking at — technically does belong to Orca. So under the wrong timing, the cleanup routine could be handed permission to kill Orca's own UI.

To a user that looks like the window suddenly going blank or the app appearing to die for no reason. And here's the frustrating part: when that happens, the crash report Orca sends back looks **exactly** the same as one where an antivirus, a system update, or the user's own task manager killed it. Twenty of these came in from the field and there was no way to tell which was which.

This change does two things. It teaches one of the main cleanup routines that Orca's own window is never a valid thing to kill. And it makes Orca write a short note to itself when it kills something — "I killed process 21688, from the terminal cleanup, 121ms before this crash" — so future reports answer the question directly. It is a partial fix: several other cleanup routines still don't ask that safety question, and in one place a refused kill now means the thing Orca meant to stop keeps running.

## Merge Risk

**MEDIUM as merged, and it merged without a clean review round.** The guard, instrumentation and all five extractions are individually clean and well tested. What raises the risk is what did *not* land and one thing that did:

- **Fixed — the win32 reaped-pid skip no longer flips the termination barrier.** The `hasExited(child)` short-circuit correctly avoids `taskkill /t /f` on a pid Windows may have reissued (#10680), but it resolved `true` — verified tree termination. A taskkill against a reaped pid already resolved `false`, and `run-process.ts` turns `true` into `barrierTerminationVerified` + `terminationReporter.report()`, which releases the git admission grant on root exit instead of on `close`. It now resolves `false`. Failure it prevents: a `git fetch` root exits while `git-remote-https.exe` still holds the inherited pipes, and the next git command is admitted against a repo that descendant is still writing.
- **Cleared:** `self-initiated-tree-kill-log` is bounded (32-entry ring plus a 128-key LRU coalesce map — no session-lifetime growth); the Claude login extraction and both Codex teardown extractions are faithful moves preserving pid resolution, the 5s ladder, the `finish()` double-guard, the ESRCH contract and every fallback.
- **Open on `main` — the guard is not a choke point.** Six pid-addressed taskkill families in Electron main are ungated: the git command-runner abort, the notebook and precheck timeouts, the codex app-server deadline kill, the `runProcess` choke point and the ephemeral-VM recipe kill. A main-issued kill from any of those can still land on a pid Electron is accounting for, and leaves no breadcrumb.
- **Open on `main` — a refusal silently leaks the commit-message agent.** Trade-off 9. This is a new failure mode this PR introduced.
- **Open on `main` — the ring can evict the discriminating entry.** Plain FIFO; 32 routine `win-pty-job` teardowns from a window-close burst push out the one `win-taskkill-tree` entry that explains the death, leaving a detail byte-identical to the external-kill arm.
- **Open on `main` — the coverage doc misdescribes the uninstrumented sites.** `self-initiated-tree-kill-log.ts` still says the notebook, precheck, browser-route and ephemeral-VM kills are `process.kill(-pid)` group calls. On Windows all four take the pid-addressed `taskkill` arm, and the git command-runner and codex app-server paths are missing from the list entirely. The next investigator reading `selfInitiatedTreeKillCount: 0` is pointed the wrong way by the module whose only job is telling them how to read it.
- P2 — synchronous `app.getAppMetrics()` per kill and again per verify, fanned out over every added root in `codex-structured-turn-processes.ts:61`.

## Trade-offs

1. **A real refusal, so a real risk of a missed kill.** `terminateWindowsProcessTree` and `classifyWindowsTreeKillTarget` return early / `foreign` for any pid in `app.getAppMetrics()`. If a PTY root pid were ever legitimately equal to one of our Chromium pids, that tree is left running. No current caller can produce that — the callers are PTY shells, codex CLI roots, git children and the source-control agent, none of which is an Electron child of ours. A recycled pid landing on a live Chromium pid is exactly the case we want refused. **The claim that a refusal is always harmless is false as merged** — see 9.

2. **`app.getAppMetrics()` is now called once per force-kill.** A synchronous in-process read of browser-side state (~4-30 processes), not an OS process-table enumeration. `codex-structured-turn-processes` fans out over every added root, so a turn teardown makes N of these calls, and `windows-pty-root-identity.ts:150` plus `terminateWindowsProcessTree` means two calls per Windows PTY close. **This is unbenchmarked** — flagged rather than hidden. It is deliberately uncached: a TTL cache would let a recycled pid slip past the refusal, which is the whole point of the guard.

3. **Diagnostic breadcrumbs cost ring slots and a disk flush.** The crash breadcrumb ring is 30 entries with FIFO eviction, and a durable crumb forces a synchronous sink flush. The first revision wrote uncoalesced crumbs from routine teardown and reviewers reproduced 12 terminal closes × 3 process groups completely evicting the ring — including this PR's own refusal crumb. As merged they go through `recordCoalescedDurableCrashBreadcrumb` (5s window for pid-addressed taskkills, 60s for routine group/job teardown), so a burst costs one slot and one flush. A regression test replays that exact 12×3 reproduction.

4. **The self-kill ring itself can evict the discriminating entry.** Separate from 3: `selfInitiatedKills` is a 32-slot **plain-FIFO** ring on `main`. A Windows window-close burst is 30+ `win-pty-job` group kills, which can push out the `win-taskkill-tree` entry that would explain the death. When that happens the detail comes back byte-identical to the external-kill arm — the exact undecidability this PR exists to remove, in the exact scenario the field reports come from. Scope-aware eviction is in #18459 (and its first attempt there was itself defective; see Adversarial review round 4).

5. **`selfInitiatedTreeKillCount = 0` does not mean "not us".** The ring is per-process and its only reader lives in Electron main, so kills issued from the daemon, relay or CLI record into a ring nothing reads. ~~What remains uninstrumented is only the POSIX `process.kill(-pid, …)` group arms…~~ **(not in this merge.)** As merged, six pid-addressed taskkill families in Electron main are also uninstrumented — the git command-runner abort, the notebook and precheck timeouts, the codex app-server deadline kill, the `runProcess` choke point and the ephemeral-VM recipe kill. Worse, the module's own coverage doc still describes four of them as POSIX group kills, so the doc actively misleads. Absence is evidence, not proof — and on `main` it is weak evidence.

6. **`selfInitiatedTreeKillCount` has a routine base rate.** Every aborted or timed-out `runProcess` on Windows records scope `win-taskkill-tree`, including ordinary cancelled git; `killSpawnedCommandTree` alone has 14 call sites. A nonzero count is not by itself suspicious. Read the `selfInitiatedKills` site string.

7. **Relay bundle growth.** `src/relay/pty-handler.ts` imports `forceKillPosixPtyProcessGroups` and `terminatePtyJob`, so the relay now pulls in `crash-breadcrumb-store` + `observability/tracer`. `pnpm build:relay` succeeds for all six platform targets plus both WSL relays (exit 0). In the relay there is no active sink, so `startSpan`/`flushActiveSink` are no-ops and only the bounded in-memory ring is touched.

8. **No newly-swallowed errors, and no remote wire change.** Breadcrumb calls were deliberately moved *outside* the `try` blocks whose `catch` is the ESRCH contract (`posix-pty-process-groups`, codex teardown, claude POSIX branch, `windows-pty-job`), so a throw from the diagnostic path can never be reported as a failed kill. Crash-report details are local-only and the new keys are additive optional fields inside an existing details bag; an older client reading a newer bundle ignores them. `forceKillPosixPtyProcessGroups` and `terminatePtyJob` run on the execution host, so the crumb is recorded wherever the kill was actually issued. Folder workspaces are unaffected; nothing here touches git or worktree state.

9. **NEW USER-FACING COST, shipped: a refused kill silently leaks the commit-message agent.** `killSourceControlAgentProcess` (`source-control-local-process.ts:33`) has no `child.kill()` fallback on its win32 arm, and since this merge `terminateWindowsProcessTree` returns `Promise.resolve()` on refusal. So if the guard ever refuses that pid, the caller marks the process closed and the agent's tree keeps running against the repo. Who it affects: Windows users generating commit messages / source-control text locally. How likely: only when the agent's pid collides with a live Chromium pid, i.e. the pid-recycling case the guard exists for — rare, but the same rarity this whole PR treats as real enough to justify the guard. Fixed in #18459 (`9bac44ee970`), not on `main`. This trade-off did not exist before this PR; the refusal created it.

10. **Test-visible API churn.** `WindowsTreeKiller` gained an optional `deps` param carrying `site`; a handful of existing test assertions were updated to expect it.

## Adversarial review

> **Six rounds. It never converged clean, and it merged anyway.** No round signed
> off. Rounds 4-6 ran *after* the merge, against `main` plus the branch tip, and
> rounds 4 and 5 each found a defect in the previous round's remediation. The
> items marked "in #18459" below are **open work in an unmerged, unreviewed-clean
> PR** — they are not resolved, and nothing here should be read as if they were.

**Round 1 — three blocking findings, all accepted and fixed** (commit `8e6a107`):
- *Breadcrumb flood.* Uncoalesced durable crumbs from two routine teardown paths; the reviewer reproduced 12 terminal closes × 3 process groups evicting the whole 30-slot ring, including this PR's own refusal crumb, plus a `writeSync` per killed group. Fixed by routing through `recordCoalescedDurableCrashBreadcrumb`, with the reviewer's exact reproduction locked in as a test.
- *Undifferentiated count.* `posix-process-group` and `win-pty-job` scopes cannot reach a Chromium process but were counted with the same weight as `win-taskkill-tree`, and scope was missing from the persisted string. Fixed: scope is now in every entry and the count is split.
- *Recording gaps and a false comment.* The shipped comment claiming a "single taskkill choke point" was contradicted by two other main-process taskkill sites. Fixed: comment gone, all three families share `admitSelfInitiatedTreeKill`, and the `runProcess` choke point is instrumented via a `setProcessTreeKillObserver` seam.

**Round 2 — four blocking findings; three accepted, one rebutted in part** (commit `1796073`):
- *"The guard is a no-op in the daemon that issues the `pty-descendant-sweep` taskkill."* **REBUTTED IN PART, and here is why.** The mechanism is correct — the standalone daemon never calls `setAppEnvironment`, so the Chromium pid set is empty there. But it is not a live hazard: the daemon reaches that taskkill only through `classifyWindowsTreeKillTarget`, whose ancestry walk terminates at the *killing* process's pid. Orca's Chromium processes descend from Electron main, a sibling of the daemon, so from a daemon `ownerPid` the walk dead-ends and returns `foreign`. The reviewer's probe passed `ownerPid: 1000` with the renderer as a direct child — that is the Electron-main topology, where the AppEnvironment *is* installed and the guard *does* fire. Rather than leave that as prose it is a falsifiable test pair in `own-chromium-tree-kill-guard.test.ts` and is documented in `orca-chromium-process-pids.ts`. **Residual risk of the rebuttal:** the argument rests on process topology, not on a runtime assertion; if a future change ever made a Chromium process a descendant of the daemon, the guard would be silently absent there. The finding did expose one genuine hole, fixed: `signalProcessTree`'s `taskkillTree` is a fourth pid-addressed family running in daemon/relay/CLI; its win32 branch now refuses a reaped child and falls back to `killRoot`.
- *Module doc overstated coverage.* **Accepted**, rewritten — but round 3 then found the rewrite itself wrong, and that is still open on `main` (see round 3).
- *The three out-of-main instrumentation sites were untested.* **Accepted.** Added coverage for the `runProcess` seam on both branches plus the reaped-child refusal, the group sweep recording only groups it actually signalled, and the Job Object recording only on `terminated`.
- *The Windows evidence validates a single-process model.* **Accepted** and disclosed — Arm C's claim holds for main-issued kills only.
- Non-blocking taken: the breadcrumb call moved out of the native `terminateJob` `try`.
- Non-blocking **declined**: `codex-accounts/service.ts` records *before* the spawn, because a refusal must prevent the spawn — the crumb means "we were about to kill this pid". `Date.now()` over `performance.now()` was kept and the reviewer agreed: offsets are computed against `goneAt = Date.now()`.

**Round 3 — four blocking findings; ONE closed, THREE still open on `main`.** The remediation for the first three lives in `9db1b4ce6ef`, which is **not** an ancestor of `main`. They are not closed; they are moved to #18459, which is open.
- *"The guard is not a choke point, so the headline claim is false."* **OPEN ON `main`.** Six pid-addressed `taskkill /pid` families in main are ungated. Verified today on `origin/main`: zero `admit*TreeKill` references in all six, and no ratchet test. Work sits in #18459.
- *"The coverage doc misdescribes the uninstrumented sites."* **OPEN ON `main`.** `git show origin/main:src/main/crash-reporting/self-initiated-tree-kill-log.ts` still says "Never instrumented: the direct `process.kill(-pid)` calls in the browser routes, notebooks, automation prechecks and ephemeral-VM recipes" — four Windows pid-addressed taskkills misclassified as POSIX group kills, and the git command-runner and codex app-server paths absent. **Residual risk:** the interpretive doc for the discriminator is wrong in the direction that produces false exoneration. Affects whoever triages the next G2 bundle.
- *"32 routine `win-pty-job` teardowns evict the discriminating entry from the FIFO ring."* **OPEN ON `main`** (Trade-off 4). The fix in #18459 was itself defective — round 4 below.
- *"The real-Windows Arm A/B/C evidence no longer matches the code."* **ACCEPTED AS A DISCLOSED LIMITATION.** Not closable: the Windows host was and remains unreachable (`ssh awin` → connection timed out). The evidence section carries a banner naming which commits changed the key and format and stating that no Windows execution covers the merged code; "Explicitly NOT proven" repeats it. Format is pinned by unit assertions instead. **Residual risk: nothing that shipped has ever executed on Windows, and this is a Windows-targeted change.** That is the single largest untested surface here, and it affects every Windows user.

**Round 4 — three blocking findings, all against the post-merge state.** This is the round that discovered the merge/commit mismatch.
- *"The PR is already merged, at `2d0c627ba08`, one commit before the content the body claimed."* **ACCEPTED.** `9db1b4ce6ef` was committed 87 minutes after the merge and is not an ancestor of `main`. The body's headline and its three "FIXED in 9db1b4c" entries were false of the shipped artifact. Fixed by rewriting this body (the box at the top) — and re-verified again today.
- *"The round-3 eviction fix creates a new false clean, strictly worse than what shipped."* **ACCEPTED.** With the ring already holding 32 pid-addressed entries, the only non-pid-addressed element is the group kill just pushed at the tail, so the eviction rule splices *itself*. Reproduced at the branch tip today (probe output in Fix evidence B): `selfInitiatedGroupKillCount` undefined, pid absent. Fixed in #18459 `9bac44ee970` by excluding the just-recorded entry from candidacy. **Note this is not a `main` problem** — `main` never got the round-3 fix — but it is why the branch tip must not be merged as-is.
- *"Five of the six newly gated sites return on refusal with no direct-child fallback."* **ACCEPTED.** `spawned-command-tree-kill.ts`, `ipc/notebook.ts`, `precheck-runner.ts`, `ephemeral-vm-recipe-process.ts` and `codex-app-server-session.ts` all returned before their `child.kill()` path, while `claude-login-process-termination.ts` did it correctly — proving inconsistency, not design. A refusal would have converted a diagnostics feature into a silent process leak. Fixed in #18459 (`8fc8aa22646`), which adds the root kill to every refusal path.
- Non-blocking, accepted as known: the ratchet is a string-containment check, not a call-graph check — an unused import satisfies it, and `spawn(TASKKILL_BIN, args)` evades its regex. Accurate today, brittle tomorrow. Also accepted: `admitProcessTreeKill` reaches the POSIX arm of `signalProcessTree`, so the unbenchmarked `getAppMetrics()` call is not Windows-only (Trade-off 2).
- Round 4 independently re-ran the whole verification set and confirmed the tests are genuine, not theatre: 17 red at merge-base, green at the tip, `tsc` ×3 and `oxlint` clean.

**Round 5 — one restated blocking finding and one novel one.**
- *Round-3 findings 1-3 are not closed in the shipped artifact.* **RESTATED, still open on `main`** — see round 3. Round 5 recorded it as a *disclosed* gap rather than a concealed one, because this body now carries the correction box and #18459 carries the work. Disclosure is not closure.
- *NOVEL: a refused kill silently leaks the source-control agent, and it is open on `main`.* **ACCEPTED.** `killSourceControlAgentProcess` has no `child.kill()` fallback on its win32 arm, so a refusal resolves having killed nothing while the caller marks the process closed. This is the one round-4-class defect that reached users. See Trade-off 9. Fixed in #18459 (`9bac44ee970`); **open on `main`**.

**Round 6 — final round, no clean sign-off.** It re-probed the round-4 eviction defect rather than raising a new class of finding, and I have not been able to reproduce a round-6 blocking item that is not already listed above. Rather than infer one, the honest summary is the banner at the top of this section: six rounds, none clean, with the round-3 and round-5 items still live on `main`.

**Still open and disclosed rather than closed, across all six rounds:** nothing shipped has run on Windows (round 3); the guard is not a choke point on `main` and the coverage doc misdescribes what it misses (round 3); the FIFO ring can evict the discriminating entry (round 3); a refused source-control kill leaks its tree on `main` (round 5); `app.getAppMetrics()` is unbenchmarked (Trade-off 2); the daemon/relay rings are written but unread (Trade-off 5, Follow-up 3); the guard closes only the Chromium half of #10680 (Follow-up 2); and the durable span trail keeps the first pid of a coalesced same-site burst, which the shipped module comment ("The newest pid still rides the emitted crumb") does not qualify.

## Follow-ups

These are follow-ups for work that was **never in scope here**. Anything a review round blocked on is listed as open in Adversarial review above, not laundered into this list.

1. **Land #18459, or revert its parts into a reviewed change.** It carries the round-3 choke point, the ratchet, the scope-aware eviction, the round-4 refusal-fallback fix and the round-5 source-control leak fix. It is OPEN and has not had a clean round either. Until it lands, Trade-offs 4, 5 and 9 describe shipped behaviour.
2. **Get a Windows host and run the arms against shipped code.** Blocked since round 3 on host reachability. This is the largest untested surface.
3. **Benchmark `app.getAppMetrics()` on the force-kill path.** Measure under a codex turn teardown that fans out over N added roots. If material, the fix is not a TTL cache (that would let a recycled pid past the refusal) but hoisting one read per teardown batch.
4. **Close the non-Chromium half of #10680.** A recycle that lands on another Orca descendant — another pane's shell, an agent CLI, a `git.exe` we spawned — still classifies `own`. Closing it needs real identity: a `Win32_Process.CreationDate` baseline, an inherited handle, or a Job Object.
5. **Make the daemon and relay breadcrumb rings readable.** Today `forceKillPosixPtyProcessGroups`, `terminatePtyJob` and `signalProcessTree` record into a per-process ring no reader exists for outside Electron main. Either forward those crumbs to main, or attach the daemon's ring to the bundle.
6. **Re-file the G2 cluster.** At least four distinct fingerprints (Windows `killed`/1; POSIX SIGKILL under memory pressure → G4-oom; a duplicated macOS V8 Proxy Resolver SIGKILL; one `0x80000003` install-dir ACL crash → G1). Splitting it is a prerequisite for reading the new field correctly.
7. **Rewrite `crashAttribution` to `self-initiated-tree-kill`** when a pid-addressed kill matches the dead renderer. Not shipped because the dead process's pid is not available at the recorder — `render-process-gone` does not carry it — so the match would have to be inferred from the pre-gone metrics sample.
