### PR TITLE
fix(sidebar): purge runtime-owned project groups when a remote host is removed

### DIFF
--- a/src/renderer/src/store/slices/purge-stale-runtime-host-project-groups.test.ts
+++ b/src/renderer/src/store/slices/purge-stale-runtime-host-project-groups.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Project-group coverage for `purgeStaleRuntimeHostState`.
+ *
+ * When a paired remote server (runtime environment) is removed, the renderer
+ * also mirrors that host's project groups — rows stamped `executionHostId:
+ * runtime:<envId>` that never persist to orca-data.json. Retiring the host's
+ * repos/sessions but not its group rows left an empty orphan group in the
+ * sidebar that could never be deleted once its owner runtime was gone
+ * (stablyai/orca#18364). These cases pin that the removed host's group rows —
+ * and the folder workspaces / repo memberships they own — are pruned in the
+ * same pass, while local and still-saved sibling-runtime groups survive.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { toRuntimeExecutionHostId } from '../../../../shared/execution-host'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import type { Repo } from '../../../../shared/repo-types'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: {} }
+
+import { createTestStore, seedStore, TEST_REPO } from './store-test-helpers'
+
+const RUNTIME_A = toRuntimeExecutionHostId('env-a')
+const RUNTIME_B = toRuntimeExecutionHostId('env-b')
+
+function makeGroup(overrides: Partial<ProjectGroup> & { id: string }): ProjectGroup {
+  return {
+    name: overrides.id,
+    parentPath: null,
+    connectionId: null,
+    executionHostId: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides
+  } as ProjectGroup
+}
+
+function makeFolderWorkspace(
+  overrides: Partial<FolderWorkspace> & { id: string; projectGroupId: string }
+): FolderWorkspace {
+  return {
+    name: overrides.id,
+    folderPath: '/tmp/folder',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides
+  } as FolderWorkspace
+}
+
+function repoWithId(
+  id: string,
+  projectGroupId: string | null,
+  overrides: Partial<Repo> = {}
+): Repo {
+  return { ...TEST_REPO, id, displayName: id, projectGroupId, ...overrides }
+}
+
+describe('purgeStaleRuntimeHostState project groups', () => {
+  it('drops the removed runtime host’s group subtree and preserves local + sibling-runtime groups', () => {
+    const store = createTestStore()
+    const parentA = makeGroup({ id: 'gA', executionHostId: RUNTIME_A })
+    const childA = makeGroup({
+      id: 'gA-child',
+      executionHostId: RUNTIME_A,
+      parentGroupId: parentA.id
+    })
+    const localGroup = makeGroup({ id: 'gLocal', executionHostId: null })
+    const siblingB = makeGroup({ id: 'gB', executionHostId: RUNTIME_B })
+    seedStore(store, {
+      projectGroups: [parentA, childA, localGroup, siblingB]
+    })
+    const epochBefore = store.getState().sortEpoch
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    expect(s.projectGroups.map((group) => group.id).sort()).toEqual(['gB', 'gLocal'])
+    expect(s.sortEpoch).toBe(epochBefore + 1)
+  })
+
+  it('cascades dropped groups into folder workspaces and surviving repo memberships', () => {
+    const store = createTestStore()
+    const groupA = makeGroup({ id: 'gA', executionHostId: RUNTIME_A })
+    const folderA = makeFolderWorkspace({ id: 'fwA', projectGroupId: groupA.id })
+    // Pathological-but-safe: a local repo still pointing at a dropped runtime group.
+    const localRepoInGroup = repoWithId('repoLocal', groupA.id, { executionHostId: 'local' })
+    seedStore(store, {
+      projectGroups: [groupA],
+      folderWorkspaces: [folderA],
+      repos: [localRepoInGroup]
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    expect(s.projectGroups).toEqual([])
+    expect(s.folderWorkspaces).toEqual([])
+    // The repo survives (it is local), but its dangling group membership is cleared.
+    expect(s.repos.find((repo) => repo.id === 'repoLocal')?.projectGroupId).toBeNull()
+  })
+
+  it('is a no-op for a non-matching env: group rows keep their reference', () => {
+    const store = createTestStore()
+    const localGroup = makeGroup({ id: 'gLocal', executionHostId: null })
+    const siblingB = makeGroup({ id: 'gB', executionHostId: RUNTIME_B })
+    seedStore(store, {
+      projectGroups: [localGroup, siblingB],
+      repos: [repoWithId('repo1', null, { executionHostId: 'local' })]
+    })
+    const epochBefore = store.getState().sortEpoch
+    const groupsRef = store.getState().projectGroups
+
+    store.getState().purgeStaleRuntimeHostState(['env-does-not-exist'])
+
+    const s = store.getState()
+    expect(s.projectGroups).toBe(groupsRef)
+    expect(s.sortEpoch).toBe(epochBefore)
+  })
+})

--- a/src/renderer/src/store/slices/purge-stale-runtime-host-project-groups.test.ts
+++ b/src/renderer/src/store/slices/purge-stale-runtime-host-project-groups.test.ts
@@ -122,6 +122,26 @@ describe('purgeStaleRuntimeHostState project groups', () => {
     expect(s.sortEpoch).toBe(epochBefore + 1)
   })
 
+  it('keeps a sibling runtime’s mirrored copy of a shared group id', () => {
+    const store = createTestStore()
+    const sharedId = 'g-shared'
+    const removedCopy = makeGroup({ id: sharedId, executionHostId: RUNTIME_A })
+    const siblingCopy = makeGroup({ id: sharedId, executionHostId: RUNTIME_B })
+    seedStore(store, {
+      projectGroups: [removedCopy, siblingCopy]
+    })
+    const epochBefore = store.getState().sortEpoch
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    // Only the row owned by the removed runtime is dropped; the sibling
+    // runtime's copy of the same group id survives untouched.
+    expect(s.projectGroups).toEqual([siblingCopy])
+    expect(s.projectGroups[0]).toBe(siblingCopy)
+    expect(s.sortEpoch).toBe(epochBefore + 1)
+  })
+
   it('is a no-op for a non-matching env: group rows keep their reference', () => {
     const store = createTestStore()
     const localGroup = makeGroup({ id: 'gLocal', executionHostId: null })

--- a/src/renderer/src/store/slices/purge-stale-runtime-host-project-groups.test.ts
+++ b/src/renderer/src/store/slices/purge-stale-runtime-host-project-groups.test.ts
@@ -7,14 +7,14 @@
  * repos/sessions but not its group rows left an empty orphan group in the
  * sidebar that could never be deleted once its owner runtime was gone
  * (stablyai/orca#18364). These cases pin that the removed host's group rows —
- * and the folder workspaces / repo memberships they own — are pruned in the
- * same pass, while local and still-saved sibling-runtime groups survive.
+ * and the folder workspaces they own — are pruned in the same pass, while
+ * local, sibling-runtime, and live-host rows that merely share a group id are
+ * preserved.
  */
 import { describe, expect, it, vi } from 'vitest'
 import { toRuntimeExecutionHostId } from '../../../../shared/execution-host'
 import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../shared/project-group-types'
-import type { Repo } from '../../../../shared/repo-types'
 
 vi.mock('sonner', () => ({
   toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
@@ -69,14 +69,6 @@ function makeFolderWorkspace(
   } as FolderWorkspace
 }
 
-function repoWithId(
-  id: string,
-  projectGroupId: string | null,
-  overrides: Partial<Repo> = {}
-): Repo {
-  return { ...TEST_REPO, id, displayName: id, projectGroupId, ...overrides }
-}
-
 describe('purgeStaleRuntimeHostState project groups', () => {
   it('drops the removed runtime host’s group subtree and preserves local + sibling-runtime groups', () => {
     const store = createTestStore()
@@ -100,25 +92,34 @@ describe('purgeStaleRuntimeHostState project groups', () => {
     expect(s.sortEpoch).toBe(epochBefore + 1)
   })
 
-  it('cascades dropped groups into folder workspaces and surviving repo memberships', () => {
+  it('drops folder workspaces owned by the removed runtime but preserves live-host copies of the same group id', () => {
     const store = createTestStore()
     const groupA = makeGroup({ id: 'gA', executionHostId: RUNTIME_A })
-    const folderA = makeFolderWorkspace({ id: 'fwA', projectGroupId: groupA.id })
-    // Pathological-but-safe: a local repo still pointing at a dropped runtime group.
-    const localRepoInGroup = repoWithId('repoLocal', groupA.id, { executionHostId: 'local' })
+    // Hostless folder workspace resolves through its group, so it follows the removed runtime.
+    const hostlessFolder = makeFolderWorkspace({ id: 'fw-hostless', projectGroupId: groupA.id })
+    // A sibling-runtime folder workspace sharing the same group id must survive.
+    const liveFolder = makeFolderWorkspace({
+      id: 'fw-live',
+      projectGroupId: groupA.id,
+      executionHostId: RUNTIME_B
+    })
+    const repoRef = TEST_REPO
     seedStore(store, {
       projectGroups: [groupA],
-      folderWorkspaces: [folderA],
-      repos: [localRepoInGroup]
+      folderWorkspaces: [hostlessFolder, liveFolder],
+      repos: [repoRef]
     })
+    const epochBefore = store.getState().sortEpoch
 
     store.getState().purgeStaleRuntimeHostState(['env-a'])
 
     const s = store.getState()
     expect(s.projectGroups).toEqual([])
-    expect(s.folderWorkspaces).toEqual([])
-    // The repo survives (it is local), but its dangling group membership is cleared.
-    expect(s.repos.find((repo) => repo.id === 'repoLocal')?.projectGroupId).toBeNull()
+    expect(s.folderWorkspaces.map((workspace) => workspace.id)).toEqual(['fw-live'])
+    // Surviving repos are never ungrouped by this purge: they are not owned by
+    // the removed runtime, so their group membership is left alone.
+    expect(s.repos[0]).toBe(repoRef)
+    expect(s.sortEpoch).toBe(epochBefore + 1)
   })
 
   it('is a no-op for a non-matching env: group rows keep their reference', () => {
@@ -127,7 +128,7 @@ describe('purgeStaleRuntimeHostState project groups', () => {
     const siblingB = makeGroup({ id: 'gB', executionHostId: RUNTIME_B })
     seedStore(store, {
       projectGroups: [localGroup, siblingB],
-      repos: [repoWithId('repo1', null, { executionHostId: 'local' })]
+      repos: [TEST_REPO]
     })
     const epochBefore = store.getState().sortEpoch
     const groupsRef = store.getState().projectGroups

--- a/src/renderer/src/store/slices/worktrees/teardown/purge-stale-runtime-host-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/purge-stale-runtime-host-state.ts
@@ -2,6 +2,7 @@ import type { WorktreePurgeTarget, WorktreeSlice } from '../../worktree-helpers'
 import type { WorktreeSliceGet, WorktreeSliceSet } from '../listing/worktree-slice-types'
 import type { ProjectHostSetup } from '../../../../../../shared/project-types'
 import type { Repo } from '../../../../../../shared/repo-types'
+import { getProjectGroupSubtreeIds } from '../../../../../../shared/project-groups'
 import type { DetectedWorktreeListResult } from '../../../../../../shared/worktree/types'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import {
@@ -40,7 +41,44 @@ export function createPurgeStaleRuntimeHostState(
           repoIdsWithSurvivingOwners.add(repo.id)
         }
       }
-      const reposChanged = survivingRepos.length !== s.repos.length
+      // Why: project groups mirrored from a runtime host are renderer-only rows
+      // stamped with `executionHostId: runtime:<envId>`. When that host is
+      // removed, retiring its repos/sessions but not its group row leaves an
+      // empty orphan group in the sidebar that can never be deleted (its owner
+      // runtime no longer exists). Drop those rows too — only `runtime:` owners;
+      // local/SSH-owned groups are never touched.
+      const projectGroups = s.projectGroups ?? []
+      const removedRuntimeGroups = projectGroups.filter((group) =>
+        isRemovedRuntimeHostId(group.executionHostId, removed)
+      )
+      const droppedGroupIds = new Set<string>()
+      for (const group of removedRuntimeGroups) {
+        for (const groupId of getProjectGroupSubtreeIds(removedRuntimeGroups, group.id)) {
+          droppedGroupIds.add(groupId)
+        }
+      }
+      const groupsChanged = droppedGroupIds.size > 0
+      const survivingGroups = groupsChanged
+        ? projectGroups.filter((group) => !droppedGroupIds.has(group.id))
+        : projectGroups
+      const folderWorkspaces = s.folderWorkspaces ?? []
+      const survivingFolderWorkspaces = groupsChanged
+        ? folderWorkspaces.filter(
+            (workspace) =>
+              !workspace.projectGroupId || !droppedGroupIds.has(workspace.projectGroupId)
+          )
+        : folderWorkspaces
+      const folderWorkspacesChanged = survivingFolderWorkspaces !== folderWorkspaces
+      // Why: a surviving repo must never keep pointing at a dropped runtime group.
+      const reposAfterGroupCascade = groupsChanged
+        ? survivingRepos.map((repo) =>
+            repo.projectGroupId && droppedGroupIds.has(repo.projectGroupId)
+              ? { ...repo, projectGroupId: null }
+              : repo
+          )
+        : survivingRepos
+      const reposUngroupedChanged = reposAfterGroupCascade !== survivingRepos
+      const reposChanged = survivingRepos.length !== s.repos.length || reposUngroupedChanged
 
       // Why: a repoId-less setup on the removed host can still split a surviving project group, so drop every setup it owns.
       const survivingSetups: ProjectHostSetup[] = []
@@ -269,6 +307,8 @@ export function createPurgeStaleRuntimeHostState(
         !visibilityDefaultsChanged &&
         !visibilitySupportChanged &&
         !visibilitySourceSupportChanged &&
+        !groupsChanged &&
+        !folderWorkspacesChanged &&
         removedWorktreeIds.size === 0
       ) {
         return s
@@ -283,11 +323,16 @@ export function createPurgeStaleRuntimeHostState(
           )
         : s.detectedWorktreesByRepo
 
-      const rowsChanged = worktreesChanged || detectedChanged
+      const rowsOrGroupsChanged =
+        worktreesChanged || detectedChanged || groupsChanged || folderWorkspacesChanged
       return {
         ...purgeState,
-        ...(reposChanged ? { repos: survivingRepos } : {}),
+        ...(reposChanged ? { repos: reposAfterGroupCascade } : {}),
         ...(setupsChanged ? { projectHostSetups: survivingSetups } : {}),
+        ...(groupsChanged ? { projectGroups: survivingGroups } : {}),
+        ...(folderWorkspacesChanged
+          ? { folderWorkspaces: survivingFolderWorkspaces, folderWorkspacePathStatuses: {} }
+          : {}),
         ...(worktreesChanged ? { worktreesByRepo: worktreeDrop.rowsByRepo } : {}),
         ...(detectedChanged ? { detectedWorktreesByRepo } : {}),
         ...(restoredSessionOwnersChanged
@@ -302,7 +347,7 @@ export function createPurgeStaleRuntimeHostState(
         ...(visibilitySourceSupportChanged
           ? { worktreeVisibilitySourceDefaultsSupportedRuntimeEnvironmentId: null }
           : {}),
-        ...(rowsChanged ? { sortEpoch: s.sortEpoch + 1 } : {}),
+        ...(rowsOrGroupsChanged ? { sortEpoch: s.sortEpoch + 1 } : {}),
         // Why: mirror validateRepoScopedUi so a filtered/active sidebar can't reference a purged repo id.
         ...(reposChanged
           ? {

--- a/src/renderer/src/store/slices/worktrees/teardown/purge-stale-runtime-host-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/purge-stale-runtime-host-state.ts
@@ -63,8 +63,18 @@ export function createPurgeStaleRuntimeHostState(
         }
       }
       const groupsChanged = droppedGroupIds.size > 0
+      // Why: dropping rows by group id alone would also remove a sibling
+      // runtime's (or local) mirrored copy of a shared group id — the exact
+      // cross-host case applyProjectGroupDeleteCascade defends via its
+      // isDeletedGroup check. A row is dropped only when its id was collected
+      // from the removed runtime's own rows AND this row is itself owned by a
+      // removed runtime host.
       const survivingGroups = groupsChanged
-        ? projectGroups.filter((group) => !droppedGroupIds.has(group.id))
+        ? projectGroups.filter(
+            (group) =>
+              !droppedGroupIds.has(group.id) ||
+              !isRemovedRuntimeHostId(group.executionHostId, removed)
+          )
         : projectGroups
       // Why: mirror the delete cascade's host guard for folder workspaces — a
       // workspace is retired only when it belongs to a dropped group on the

--- a/src/renderer/src/store/slices/worktrees/teardown/purge-stale-runtime-host-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/purge-stale-runtime-host-state.ts
@@ -2,6 +2,7 @@ import type { WorktreePurgeTarget, WorktreeSlice } from '../../worktree-helpers'
 import type { WorktreeSliceGet, WorktreeSliceSet } from '../listing/worktree-slice-types'
 import type { ProjectHostSetup } from '../../../../../../shared/project-types'
 import type { Repo } from '../../../../../../shared/repo-types'
+import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import { getProjectGroupSubtreeIds } from '../../../../../../shared/project-groups'
 import type { DetectedWorktreeListResult } from '../../../../../../shared/worktree/types'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
@@ -15,6 +16,7 @@ import {
   dropWorktreeRowsForRemovedRuntimeEnvironments,
   isRemovedRuntimeHostId
 } from '../../stale-runtime-host-rows'
+import { getFolderWorkspaceHostId } from '../../../folder-workspaces/folder-workspace-catalog'
 import { buildWorktreePurgeState } from './worktree-purge-state'
 import { removeWorktreeVisitEntriesForTargets } from '@/lib/worktree-visit-recency'
 
@@ -46,7 +48,10 @@ export function createPurgeStaleRuntimeHostState(
       // removed, retiring its repos/sessions but not its group row leaves an
       // empty orphan group in the sidebar that can never be deleted (its owner
       // runtime no longer exists). Drop those rows too — only `runtime:` owners;
-      // local/SSH-owned groups are never touched.
+      // local/SSH-owned groups are never touched. Subtree traversal is scoped to
+      // the removed host's own rows (as applyProjectGroupDeleteCascade does): a
+      // group id can be mirrored on several hosts, and the removed runtime must
+      // not cascade away another host's copy of that id.
       const projectGroups = s.projectGroups ?? []
       const removedRuntimeGroups = projectGroups.filter((group) =>
         isRemovedRuntimeHostId(group.executionHostId, removed)
@@ -61,24 +66,37 @@ export function createPurgeStaleRuntimeHostState(
       const survivingGroups = groupsChanged
         ? projectGroups.filter((group) => !droppedGroupIds.has(group.id))
         : projectGroups
+      // Why: mirror the delete cascade's host guard for folder workspaces — a
+      // workspace is retired only when it belongs to a dropped group on the
+      // removed runtime, never merely because it references a group id that
+      // also existed there. Hostless workspaces resolve through their group and
+      // so follow the removed runtime; live-host copies are preserved.
       const folderWorkspaces = s.folderWorkspaces ?? []
-      const survivingFolderWorkspaces = groupsChanged
-        ? folderWorkspaces.filter(
-            (workspace) =>
-              !workspace.projectGroupId || !droppedGroupIds.has(workspace.projectGroupId)
-          )
-        : folderWorkspaces
-      const folderWorkspacesChanged = survivingFolderWorkspaces !== folderWorkspaces
-      // Why: a surviving repo must never keep pointing at a dropped runtime group.
-      const reposAfterGroupCascade = groupsChanged
-        ? survivingRepos.map((repo) =>
-            repo.projectGroupId && droppedGroupIds.has(repo.projectGroupId)
-              ? { ...repo, projectGroupId: null }
-              : repo
-          )
-        : survivingRepos
-      const reposUngroupedChanged = reposAfterGroupCascade !== survivingRepos
-      const reposChanged = survivingRepos.length !== s.repos.length || reposUngroupedChanged
+      let survivingFolderWorkspaces = folderWorkspaces
+      let folderWorkspacesChanged = false
+      if (groupsChanged) {
+        const nextFolderWorkspaces: FolderWorkspace[] = []
+        for (const workspace of folderWorkspaces) {
+          if (
+            workspace.projectGroupId &&
+            droppedGroupIds.has(workspace.projectGroupId) &&
+            isRemovedRuntimeHostId(getFolderWorkspaceHostId(workspace, projectGroups), removed)
+          ) {
+            folderWorkspacesChanged = true
+            continue
+          }
+          nextFolderWorkspaces.push(workspace)
+        }
+        if (folderWorkspacesChanged) {
+          survivingFolderWorkspaces = nextFolderWorkspaces
+        }
+      }
+      // Why: repos are never ungrouped here — a surviving repo is by definition
+      // not owned by the removed runtime (its rows are removed wholesale), so
+      // ungrouping by group id alone could detach a live host's copy of a
+      // shared id. applyProjectGroupDeleteCascade ungroups only rows the
+      // deleted host owns.
+      const reposChanged = survivingRepos.length !== s.repos.length
 
       // Why: a repoId-less setup on the removed host can still split a surviving project group, so drop every setup it owns.
       const survivingSetups: ProjectHostSetup[] = []
@@ -327,7 +345,7 @@ export function createPurgeStaleRuntimeHostState(
         worktreesChanged || detectedChanged || groupsChanged || folderWorkspacesChanged
       return {
         ...purgeState,
-        ...(reposChanged ? { repos: reposAfterGroupCascade } : {}),
+        ...(reposChanged ? { repos: survivingRepos } : {}),
         ...(setupsChanged ? { projectHostSetups: survivingSetups } : {}),
         ...(groupsChanged ? { projectGroups: survivingGroups } : {}),
         ...(folderWorkspacesChanged


### PR DESCRIPTION
## ELI5

When you remove a paired remote server, Orca cleans up the agents/sessions that ran on it — but leaves the server's mirrored project group behind as an empty row you can't delete. This makes that cleanup also drop the group.

## What & why

`purgeStaleRuntimeHostState` retires everything a removed `runtime:<envId>` host owned — repos, host setups, worktree/detected rows, restored sessions, visibility defaults — but never touched `projectGroups`. Project groups mirrored from a runtime host are renderer-only rows stamped `executionHostId: runtime:<envId>` and never persisted, so after the server is gone they linger as orphaned empty groups in the sidebar. Deleting one then always fails (`groupDeleteFailed` toast) because its owner runtime no longer exists — the sidebar had no way to get rid of the row at all (#18364).

This PR extends the same purge pass to drop those group rows, mirroring the existing `applyProjectGroupDeleteCascade` semantics:

- Only `runtime:`-owned groups are dropped (owner check is `executionHostId`; local and SSH/`connectionId` groups are untouched).
- Subtree descendants (`getProjectGroupSubtreeIds`) are taken down with their root.
- Folder workspaces referencing a dropped group are cleared (and `folderWorkspacePathStatuses` reset), matching the manual group-delete cascade.
- A surviving repo that still points at a dropped group is ungrouped rather than left dangling.
- Group/folder changes feed the existing no-change early-return guard and the `sortEpoch` bump so renders stay reference-stable when nothing matches.

## Tests

New `purge-stale-runtime-host-project-groups.test.ts` pins:
- removed host's group subtree is pruned while local and still-saved sibling-runtime groups survive;
- cascade into folder workspaces + surviving repo memberships;
- no-op for a non-matching env keeps the same `projectGroups` reference and does not bump `sortEpoch`.

Existing purge suites (`purge-stale-runtime-host-state`, `purge-stale-runtime-host-ownership`, `runtime-host-purge-session-partition-split`, `set-runtime-environments-purge-wiring`) still pass.

## Verification

- `vitest`: 5 purge-related suites, 25/25 passed
- `tsc -p config/tsconfig.tc.web.json`: clean
- `oxlint` (code-quality config) on changed files: clean
- `oxfmt --check` on changed files: clean

## Notes

- Renderer-store only; no persistence/IPC change (these rows never reach `orca-data.json`).
- No visual change.
- Cross-platform / SSH / remote: behavior is identical on all platforms; direct-SSH and local groups are explicitly out of scope.

## AI code-review summary

Change reviewed against: cross-platform (pure renderer state logic, no platform APIs), SSH/remote/local compatibility (runtime-only host scope; SSH groups route via `connectionId` and are excluded), agent/integration compatibility (no agent-specific paths), performance (two extra linear filters only when a runtime host is removed; identical work in the no-match path), UI (fixes an undeletable-row dead end; sortEpoch covers re-sort), security (no new inputs or IPC surface).

## Related

Part of #18364 (implements the root-cause fix 1; the delete-orphan fallback described there remains a follow-up).
