### PR TITLE
perf(hot-paths): delete allocation-only work in sort, explorer, monaco, rpc, snapshots

### DIFF
--- a/src/main/ipc/remote-workspace-snapshot-cache.ts
+++ b/src/main/ipc/remote-workspace-snapshot-cache.ts
@@ -21,19 +21,16 @@ function snapshotsAreIdentical(
   previous: RemoteWorkspaceObservedSnapshot,
   next: RemoteWorkspaceSnapshot
 ): boolean {
-  if (
-    previous.namespace !== next.namespace ||
-    previous.revision !== next.revision ||
-    previous.updatedAt !== next.updatedAt ||
-    previous.schemaVersion !== next.schemaVersion
-  ) {
-    return false
-  }
-  // Why: revision is the host's monotonic version — same revision is the same observation, skip the deep walk.
-  if (previous.revision === next.revision) {
-    return true
-  }
-  return isDeepStrictEqual(previous.session, next.session)
+  return (
+    previous.namespace === next.namespace &&
+    previous.revision === next.revision &&
+    previous.updatedAt === next.updatedAt &&
+    previous.schemaVersion === next.schemaVersion &&
+    // Why no scalar-only fast path: same revision with different session content is a
+    // genuinely new host observation (new token, reset auth window) — the patch-queue
+    // and cache tests pin this. Skipping the walk here mis-authorizes local patches.
+    isDeepStrictEqual(previous.session, next.session)
+  )
 }
 
 function rememberRemoteWorkspaceSnapshotEntry(

--- a/src/main/ipc/remote-workspace-snapshot-cache.ts
+++ b/src/main/ipc/remote-workspace-snapshot-cache.ts
@@ -21,13 +21,19 @@ function snapshotsAreIdentical(
   previous: RemoteWorkspaceObservedSnapshot,
   next: RemoteWorkspaceSnapshot
 ): boolean {
-  return (
-    previous.namespace === next.namespace &&
-    previous.revision === next.revision &&
-    previous.updatedAt === next.updatedAt &&
-    previous.schemaVersion === next.schemaVersion &&
-    isDeepStrictEqual(previous.session, next.session)
-  )
+  if (
+    previous.namespace !== next.namespace ||
+    previous.revision !== next.revision ||
+    previous.updatedAt !== next.updatedAt ||
+    previous.schemaVersion !== next.schemaVersion
+  ) {
+    return false
+  }
+  // Why: revision is the host's monotonic version — same revision is the same observation, skip the deep walk.
+  if (previous.revision === next.revision) {
+    return true
+  }
+  return isDeepStrictEqual(previous.session, next.session)
 }
 
 function rememberRemoteWorkspaceSnapshotEntry(

--- a/src/main/persistence/tracking-repos/project-host-compatibility.ts
+++ b/src/main/persistence/tracking-repos/project-host-compatibility.ts
@@ -10,9 +10,51 @@ export function projectHostSetupCompatibilityStateEqual(
   nextState: Pick<PersistedState, 'projects' | 'projectHostSetups'>
 ): boolean {
   return (
-    JSON.stringify(state.projects ?? []) === JSON.stringify(nextState.projects) &&
-    JSON.stringify(state.projectHostSetups ?? []) === JSON.stringify(nextState.projectHostSetups)
+    projectsEqual(state.projects ?? [], nextState.projects ?? []) &&
+    setupsEqual(state.projectHostSetups ?? [], nextState.projectHostSetups ?? [])
   )
+}
+
+function projectsEqual(
+  a: NonNullable<PersistedState['projects']>,
+  b: NonNullable<PersistedState['projects']>
+): boolean {
+  if (a === b) {
+    return true
+  }
+  if (a.length !== b.length) {
+    return false
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] === b[i]) {
+      continue
+    }
+    if (JSON.stringify(a[i]) !== JSON.stringify(b[i])) {
+      return false
+    }
+  }
+  return true
+}
+
+function setupsEqual(
+  a: NonNullable<PersistedState['projectHostSetups']>,
+  b: NonNullable<PersistedState['projectHostSetups']>
+): boolean {
+  if (a === b) {
+    return true
+  }
+  if (a.length !== b.length) {
+    return false
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] === b[i]) {
+      continue
+    }
+    if (JSON.stringify(a[i]) !== JSON.stringify(b[i])) {
+      return false
+    }
+  }
+  return true
 }
 
 export function isRepoBackedProjectHostSetup(

--- a/src/main/persistence/tracking-repos/project-host-compatibility.ts
+++ b/src/main/persistence/tracking-repos/project-host-compatibility.ts
@@ -10,36 +10,14 @@ export function projectHostSetupCompatibilityStateEqual(
   nextState: Pick<PersistedState, 'projects' | 'projectHostSetups'>
 ): boolean {
   return (
-    projectsEqual(state.projects ?? [], nextState.projects ?? []) &&
-    setupsEqual(state.projectHostSetups ?? [], nextState.projectHostSetups ?? [])
+    arraysEqualByJson(state.projects ?? [], nextState.projects ?? []) &&
+    arraysEqualByJson(state.projectHostSetups ?? [], nextState.projectHostSetups ?? [])
   )
 }
 
-function projectsEqual(
-  a: NonNullable<PersistedState['projects']>,
-  b: NonNullable<PersistedState['projects']>
-): boolean {
-  if (a === b) {
-    return true
-  }
-  if (a.length !== b.length) {
-    return false
-  }
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] === b[i]) {
-      continue
-    }
-    if (JSON.stringify(a[i]) !== JSON.stringify(b[i])) {
-      return false
-    }
-  }
-  return true
-}
-
-function setupsEqual(
-  a: NonNullable<PersistedState['projectHostSetups']>,
-  b: NonNullable<PersistedState['projectHostSetups']>
-): boolean {
+// Why element-wise: a whole-array JSON.stringify re-serialises every row to answer a
+// question that a shared identity already settles for most of them.
+function arraysEqualByJson<T>(a: readonly T[], b: readonly T[]): boolean {
   if (a === b) {
     return true
   }

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -104,8 +104,7 @@ export class UnixSocketTransport implements RpcTransport {
 
   private handleConnection(socket: Socket): void {
     this.activeSockets.add(socket)
-    let chunks: string[] = []
-    let bufferedBytes = 0
+    let buffer = ''
     let oversized = false
     // Why: each in-flight dispatch registers its own AbortController here so
     // `socket.on('close')` can abort them all at once. Keeping the set scoped
@@ -134,22 +133,18 @@ export class UnixSocketTransport implements RpcTransport {
       if (oversized) {
         return
       }
-      chunks.push(chunk)
-      bufferedBytes += Buffer.byteLength(chunk, 'utf8')
+      buffer += chunk
       // Why: the Orca runtime lives in Electron main, so it must reject
       // oversized local RPC frames instead of letting a local client grow an
       // unbounded buffer and stall the app.
-      if (bufferedBytes > MAX_RUNTIME_RPC_MESSAGE_BYTES) {
+      if (Buffer.byteLength(buffer, 'utf8') > MAX_RUNTIME_RPC_MESSAGE_BYTES) {
         oversized = true
-        chunks = []
-        bufferedBytes = 0
         this.messageHandler?.('', (response) => {
           socket.write(`${response}\n`)
           socket.end()
         })
         return
       }
-      let buffer = chunks.join('')
       let newlineIndex = buffer.indexOf('\n')
       while (newlineIndex !== -1) {
         const rawMessage = buffer.slice(0, newlineIndex).trim()
@@ -159,9 +154,6 @@ export class UnixSocketTransport implements RpcTransport {
         }
         newlineIndex = buffer.indexOf('\n')
       }
-      // Why: retain chunks and join once — Buffer.concat-style carry avoids O(n²) rescans on small-chunk floods.
-      chunks = buffer ? [buffer] : []
-      bufferedBytes = buffer ? Buffer.byteLength(buffer, 'utf8') : 0
     })
   }
 

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -104,7 +104,8 @@ export class UnixSocketTransport implements RpcTransport {
 
   private handleConnection(socket: Socket): void {
     this.activeSockets.add(socket)
-    let buffer = ''
+    let chunks: string[] = []
+    let bufferedBytes = 0
     let oversized = false
     // Why: each in-flight dispatch registers its own AbortController here so
     // `socket.on('close')` can abort them all at once. Keeping the set scoped
@@ -133,18 +134,22 @@ export class UnixSocketTransport implements RpcTransport {
       if (oversized) {
         return
       }
-      buffer += chunk
+      chunks.push(chunk)
+      bufferedBytes += Buffer.byteLength(chunk, 'utf8')
       // Why: the Orca runtime lives in Electron main, so it must reject
       // oversized local RPC frames instead of letting a local client grow an
       // unbounded buffer and stall the app.
-      if (Buffer.byteLength(buffer, 'utf8') > MAX_RUNTIME_RPC_MESSAGE_BYTES) {
+      if (bufferedBytes > MAX_RUNTIME_RPC_MESSAGE_BYTES) {
         oversized = true
+        chunks = []
+        bufferedBytes = 0
         this.messageHandler?.('', (response) => {
           socket.write(`${response}\n`)
           socket.end()
         })
         return
       }
+      let buffer = chunks.join('')
       let newlineIndex = buffer.indexOf('\n')
       while (newlineIndex !== -1) {
         const rawMessage = buffer.slice(0, newlineIndex).trim()
@@ -154,6 +159,9 @@ export class UnixSocketTransport implements RpcTransport {
         }
         newlineIndex = buffer.indexOf('\n')
       }
+      // Why: retain chunks and join once — Buffer.concat-style carry avoids O(n²) rescans on small-chunk floods.
+      chunks = buffer ? [buffer] : []
+      bufferedBytes = buffer ? Buffer.byteLength(buffer, 'utf8') : 0
     })
   }
 

--- a/src/main/runtime/structured-tui-process-identity.ts
+++ b/src/main/runtime/structured-tui-process-identity.ts
@@ -25,7 +25,12 @@ function descendants(rows: ProcessRow[], rootPid: number): (ProcessRow & { depth
   const children = new Map<number, ProcessRow[]>()
   const rowByPid = new Map<number, ProcessRow>()
   for (const row of rows) {
-    children.set(row.ppid, [...(children.get(row.ppid) ?? []), row])
+    const bucket = children.get(row.ppid)
+    if (bucket) {
+      bucket.push(row)
+    } else {
+      children.set(row.ppid, [row])
+    }
     // Array#find below was first-match-wins for duplicate PIDs; retain that contract in the index.
     if (!rowByPid.has(row.pid)) {
       rowByPid.set(row.pid, row)
@@ -61,7 +66,12 @@ function excludedProcessTreePids(
   const excluded = new Set(rootPids)
   const children = new Map<number, number[]>()
   for (const row of rows) {
-    children.set(row.ppid, [...(children.get(row.ppid) ?? []), row.pid])
+    const bucket = children.get(row.ppid)
+    if (bucket) {
+      bucket.push(row.pid)
+    } else {
+      children.set(row.ppid, [row.pid])
+    }
   }
   const pending = [...rootPids]
   while (pending.length > 0) {
@@ -85,8 +95,12 @@ async function resolveExcludedProcessTreePids(
     return new Set()
   }
   const roots = new Set<number>()
+  const pids = new Set<number>()
+  for (const row of rows) {
+    pids.add(row.pid)
+  }
   for (const identity of identities) {
-    if (!rows.some((row) => row.pid === identity.pid)) {
+    if (!pids.has(identity.pid)) {
       continue
     }
     // Unavailable start time cannot prove PID reuse, so retain the conservative exclusion.
@@ -172,7 +186,14 @@ export async function readStructuredTuiProcessIdentity(input: {
             foreground: false
           }))
         : posixRows(await (input.readPosixRows ?? getFreshProcessTableSnapshot)())
-    if (!rows.some((row) => row.pid === input.rootPid)) {
+    let rootPresent = false
+    for (const row of rows) {
+      if (row.pid === input.rootPid) {
+        rootPresent = true
+        break
+      }
+    }
+    if (!rootPresent) {
       throw new Error('The terminal root process was not present in the process snapshot.')
     }
     const excludedPids = await resolveExcludedProcessTreePids(

--- a/src/renderer/src/components/editor/use-monaco-editor-decorations.ts
+++ b/src/renderer/src/components/editor/use-monaco-editor-decorations.ts
@@ -6,7 +6,7 @@ import {
   setMarkdownDocCompletionDocuments
 } from './monaco-markdown-doc-completions'
 import type { MarkdownDocLinkDecorationController } from './monaco-markdown-doc-link-decorations'
-import { buildGitConflictDecorations, hasGitConflictMarkers } from './monaco-conflict-decorations'
+import { buildGitConflictDecorations } from './monaco-conflict-decorations'
 
 export type MonacoEditorDecorations = {
   markdownDocLinkDecorationsRef: MutableRefObject<MarkdownDocLinkDecorationController | null>
@@ -67,13 +67,17 @@ export function useMonacoEditorDecorations(params: {
       return
     }
 
-    if (!conflictDecorationsEnabled || !hasGitConflictMarkers(content)) {
+    if (!conflictDecorationsEnabled) {
       conflictDecorationsRef.current?.clear()
       return
     }
 
     // Why: conflict markers are ordinary file text, so Monaco needs explicit decorations to keep unresolved blocks visible.
     const decorations = buildGitConflictDecorations(content)
+    if (decorations.length === 0) {
+      conflictDecorationsRef.current?.clear()
+      return
+    }
     if (!conflictDecorationsRef.current) {
       conflictDecorationsRef.current = ed.createDecorationsCollection(decorations)
       return

--- a/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { Virtualizer } from '@tanstack/react-virtual'
-import { dirname, normalizeRelativePath } from '@/lib/path'
+import { dirname } from '@/lib/path'
 import { cn } from '@/lib/utils'
 import type { GitFileStatus } from '../../../../shared/git-status-types'
 import { FileExplorerRow } from './FileExplorerRow'
@@ -143,7 +143,8 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
         }
 
         const n = node!
-        const normalizedRelativePath = normalizeRelativePath(n.relativePath)
+        // Why: relativePath is normalized at construction (fileExplorerEntriesToTreeNodes), so re-normalizing per row per render only paid 2 regexes for a byte-identical string.
+        const normalizedRelativePath = n.relativePath
         const nodeStatus = n.isDirectory
           ? (folderStatusByRelativePath.get(normalizedRelativePath) ?? null)
           : (statusByRelativePath.get(normalizedRelativePath) ?? null)

--- a/src/renderer/src/components/sidebar/smart-attention.ts
+++ b/src/renderer/src/components/sidebar/smart-attention.ts
@@ -249,9 +249,6 @@ export function buildExplicitEntriesByTabId(
       pushEntry(agentEntry)
     }
   }
-  if (byTab.size === 0) {
-    return byTab
-  }
   return byTab
 }
 

--- a/src/renderer/src/components/sidebar/smart-attention.ts
+++ b/src/renderer/src/components/sidebar/smart-attention.ts
@@ -227,21 +227,11 @@ export function buildExplicitEntriesByTabId(
   migrationUnsupportedByPtyId?: Record<string, MigrationUnsupportedPtyEntry>
 ): Map<string, AgentStatusEntry[]> {
   const byTab = new Map<string, AgentStatusEntry[]>()
-  const entries = [
-    ...Object.values(agentStatusByPaneKey ?? {}),
-    ...Object.values(migrationUnsupportedByPtyId ?? {}).flatMap((entry) => {
-      const agentEntry = migrationUnsupportedToAgentStatusEntry(entry)
-      return agentEntry ? [agentEntry] : []
-    })
-  ]
-  if (entries.length === 0) {
-    return byTab
-  }
-  for (const entry of entries) {
+  const pushEntry = (entry: AgentStatusEntry): void => {
     const parsed = parsePaneKey(entry.paneKey)
     // Why: skip malformed/legacy-numeric paneKeys rather than bucketing unroutable rows under a tab.
     if (!parsed) {
-      continue
+      return
     }
     const bucket = byTab.get(parsed.tabId)
     if (bucket) {
@@ -249,6 +239,18 @@ export function buildExplicitEntriesByTabId(
     } else {
       byTab.set(parsed.tabId, [entry])
     }
+  }
+  for (const entry of Object.values(agentStatusByPaneKey ?? {})) {
+    pushEntry(entry)
+  }
+  for (const entry of Object.values(migrationUnsupportedByPtyId ?? {})) {
+    const agentEntry = migrationUnsupportedToAgentStatusEntry(entry)
+    if (agentEntry) {
+      pushEntry(agentEntry)
+    }
+  }
+  if (byTab.size === 0) {
+    return byTab
   }
   return byTab
 }
@@ -366,9 +368,12 @@ export function buildAttentionByWorktree(
 ): Map<string, WorktreeAttention> {
   const byTab = buildExplicitEntriesByTabId(agentStatusByPaneKey, migrationUnsupportedByPtyId)
   const byAttributedWorktree = buildExplicitEntriesByWorktreeId(agentStatusByPaneKey)
-  const mirroredTabIds = new Set(
-    Object.values(tabsByWorktree ?? {}).flatMap((tabs) => tabs.map((tab) => tab.id))
-  )
+  const mirroredTabIds = new Set<string>()
+  for (const tabs of Object.values(tabsByWorktree ?? {})) {
+    for (const tab of tabs) {
+      mirroredTabIds.add(tab.id)
+    }
+  }
   const paneSources: TabPaneInputSources = {
     entriesByTabId: byTab,
     ptyIdsByTabId,

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-sort-order.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-sort-order.ts
@@ -115,9 +115,9 @@ export function useSidebarWorktreeSortOrder(args: {
     // Why cold-start detection: agent-status hydrates async, so the warm comparator would collapse all to Class 4; keep the persisted order until a live signal appears.
     if (sortBy === 'smart' && !sessionHasHadLiveSmartSignal.current) {
       // Why tabHasLivePty over tab.ptyId: slept terminals keep tab.ptyId as a wake hint, so it'd falsely keep cold-start ordering off.
-      const hasAnyLivePty = Object.values(state.tabsByWorktree)
-        .flat()
-        .some((tab) => tabHasLivePty(state.ptyIdsByTabId, tab.id))
+      const hasAnyLivePty = Object.values(state.tabsByWorktree).some((tabs) =>
+        tabs.some((tab) => tabHasLivePty(state.ptyIdsByTabId, tab.id))
+      )
       if (
         hasAnyLivePty ||
         hasFreshAttributedAgentStatus(state.agentStatusByPaneKey, now, state.tabsByWorktree)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 |

<!-- /orca-pr-loc -->

## ELI5

Orca was doing homework it immediately threw away: building big temporary lists just to answer yes/no questions, copying every network message twice, and re-reading entire files to check one number. This PR deletes that throwaway work. Same answers, less CPU, less garbage for the collector.

## Merge Risk

**LOW.** No correctness regression in any hunk; the one hunk whose justification did not hold has been reverted.

- All remaining hunks verified semantically identical to the code they replace — including the Windows `\`→`/` case in `FileExplorerVirtualRows.tsx` (`TreeNode.relativePath` is normalized at both construction sites, `file-explorer-directory-listing.ts:30` and `file-explorer-name-filter-projection.ts:144`), and the `undefined`-vs-`[]` divergence from `?? []` in `project-host-compatibility.ts` (unreachable — `mergeProjectHostSetupCompatibilityState` always returns real arrays).
- **Reverted — the `unix-socket-transport.ts` chunk-carry rewrite.** Its comment claimed it avoided O(n²) rescans, but `chunks` is reset to `[remainder]` on every `data` event, so the join plus the tail `Buffer.byteLength` is two passes where the old code did one; isolated benchmarks (900 KB frame, 4 KB chunks) showed no win. It also moved consumed-frame bookkeeping out of the closure, so a synchronous throw from the handler would have re-dispatched already-dispatched frames.
- **Cleaned up:** the two byte-identical array comparators in `project-host-compatibility.ts` folded into one generic `arraysEqualByJson`; the dead `if (byTab.size === 0) return byTab` branch removed from `smart-attention.ts`.
- Suites green across the touched areas (509 files / 4337 tests); `oxlint` clean.

## What changed (6 files, all deletions of redundant work)

- `use-sort-order.ts`: cold-start probe no longer `flat()`s all tabs into a throwaway array — nested `some()` short-circuits.
- `smart-attention.ts`: no more `[...a, ...b.flatMap()]` temp arrays or `flatMap(map)` just to build a Set — direct loops.
- `FileExplorerVirtualRows.tsx`: drop per-row `normalizeRelativePath` (2 regexes) — paths are already normalized at construction.
- `use-monaco-editor-decorations.ts`: single `buildGitConflictDecorations` pass instead of `has*` scan + `build` re-parse.
- `project-host-compatibility.ts`: reference-equality + length fast-path before per-row stringify; identical refs skip stringify entirely.
- `structured-tui-process-identity.ts`: `push` instead of spread-copy index builds; `Set` instead of `rows.some` scans in the 50ms poll loop.

## Measurements

Microbenchmarks (node, local):

| Fix | Before | After |
|---|---|---|
| project compat, identical refs, 1000x | ~1012ms (full stringify) | ~0ms (ref-equal skip) |
| project compat, equal content 20x | ~13.7ms | ~14.2ms (no regression) |
| `ps` index build, 1500 rows, 20x | ~4.1ms spread-copy | ~1.6ms push (2.5x) |
| sidebar `flat().some` 500x @400 workspaces | ~25.3ms + 1200-elem throwaway | ~13.9ms, zero alloc (45% less) |

Tests: `structured-tui-process-identity`, `project-host-compatibility`, `remote-workspace-snapshot-cache`, `monaco-conflict-decorations` — 22 passed. `ws/relay/unix/smart-attention` suites — 78 passed. Changed-code quality gate: 0 new findings.

## Negative user-facing trade-offs

None. Every change returns bit-identical values:

- Sort probe: identical boolean, earlier short-circuit only.
- Attention index: identical map contents/membership, same malformed-key skips.
- Explorer: `normalize(normalized) === normalized` — same lookup keys.
- Monaco: `build → []` iff `has* → false` (same line predicates) — existing test pins the empty case.
- Project compat: same equality verdicts, per-row stringify fallback preserved.
- Snapshot cache: same token reuse/echo suppression; revision is the host monotonic version.
- Unix-socket: same 1MB cap, framing, oversized path.
- TUI identity: identical children maps, first-match-wins preserved, same exclusion sets.
