### PR TITLE
perf(renderer): index diff comments, skip no-op hydration, drop duplicate normalizes

### DIFF
--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
@@ -131,7 +131,38 @@ function rendererBreadcrumbCoalesceKey(
           data?.errorMessage
         ]
       : [data?.reasonStack, data?.reasonType, data?.reasonName]
-  return JSON.stringify([name, message, ...sourceIdentity])
+  // Why: error storms re-serialize the same message + up-to-4KB stack per event just to build a map key — reuse the last key on field-equality.
+  if (
+    lastCoalesceKey !== null &&
+    lastCoalesceName === name &&
+    lastCoalesceMessage === message &&
+    arraysShallowEqual(lastCoalesceSource, sourceIdentity)
+  ) {
+    return lastCoalesceKey
+  }
+  const key = JSON.stringify([name, message, ...sourceIdentity])
+  lastCoalesceName = name
+  lastCoalesceMessage = message
+  lastCoalesceSource = sourceIdentity
+  lastCoalesceKey = key
+  return key
+}
+
+let lastCoalesceName: string | null = null
+let lastCoalesceMessage: string | undefined
+let lastCoalesceSource: unknown[] | null = null
+let lastCoalesceKey: string | null = null
+
+function arraysShallowEqual(a: unknown[] | null, b: unknown[]): boolean {
+  if (!a || a.length !== b.length) {
+    return false
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false
+    }
+  }
+  return true
 }
 
 export function recordRendererBreadcrumbFromRenderer(

--- a/src/renderer/src/components/editor/combined-diff/scroll-viewport/combined-diff-section-list.tsx
+++ b/src/renderer/src/components/editor/combined-diff/scroll-viewport/combined-diff-section-list.tsx
@@ -1,4 +1,5 @@
 import type React from 'react'
+import { useMemo } from 'react'
 import type { Virtualizer } from '@tanstack/react-virtual'
 import { joinPath } from '@/lib/path'
 import type { OpenFile } from '@/store/slices/editor'
@@ -69,6 +70,14 @@ export function CombinedDiffSectionList({
   toggleSection: (index: number) => void
   virtualizer: Virtualizer<HTMLDivElement, Element>
 }): React.JSX.Element {
+  // Why: per-row filter() rescanned all worktree comments per visible row per render — index once, same order preserved.
+  const commentCountByFilePath = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const comment of diffCommentsForWorktree) {
+      counts.set(comment.filePath, (counts.get(comment.filePath) ?? 0) + 1)
+    }
+    return counts
+  }, [diffCommentsForWorktree])
   return (
     <div className="relative min-w-0 flex-1">
       <div
@@ -130,10 +139,8 @@ export function CombinedDiffSectionList({
                   modifiedEditorsRef={modifiedEditorsRef}
                   handleSectionSaveRef={handleSectionSaveRef}
                   renderHeaderTrailingContent={(section) => {
-                    const fileNotes = diffCommentsForWorktree.filter(
-                      (comment) => comment.filePath === section.path
-                    )
-                    return fileNotes.length > 0 ? (
+                    const fileNoteCount = commentCountByFilePath.get(section.path) ?? 0
+                    return fileNoteCount > 0 ? (
                       <DiffNotesSendMenu
                         worktreeId={file.worktreeId}
                         groupId={activeGroupId ?? file.worktreeId}

--- a/src/renderer/src/components/right-sidebar/file-explorer-name-filter-projection.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-name-filter-projection.ts
@@ -100,7 +100,8 @@ function relativePathMatchesNameFilter(relativePath: string, tokens: readonly st
   if (tokens.length === 0) {
     return true
   }
-  const haystack = normalizeRelativePath(relativePath).toLocaleLowerCase()
+  // Why: callers pass already-normalized paths — lowercasing only, no second normalize per path per keystroke.
+  const haystack = relativePath.toLocaleLowerCase()
   return tokens.every((token) => haystack.includes(token))
 }
 

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { useAppStore } from '@/store'
 import { isDotfileRelativePath } from './file-explorer-entries'
 import type { DirCache, TreeNode } from './file-explorer-types'
@@ -119,16 +119,25 @@ export function createVisibleFileExplorerRowProjection(
  */
 function useContentStableRelativePaths(relativePaths: string[], enabled: boolean): string[] {
   // Why: filters need fresh identities per keystroke and must not evict the tree signature.
-  // Why: NUL cannot occur in paths, so the signature can reconstruct the list losslessly.
-  const signature = useMemo(
-    () => (enabled ? relativePaths.join('\u0000') : null),
-    [enabled, relativePaths]
-  )
-  const stableTreePaths = useMemo(
-    () => (signature ? signature.split('\u0000') : EMPTY_RELATIVE_PATHS),
-    [signature]
-  )
-  return enabled ? stableTreePaths : relativePaths
+  const prevRef = useRef<string[] | null>(null)
+  if (!enabled) {
+    return relativePaths
+  }
+  const prev = prevRef.current
+  if (prev && prev.length === relativePaths.length) {
+    let equal = true
+    for (let i = 0; i < prev.length; i++) {
+      if (prev[i] !== relativePaths[i]) {
+        equal = false
+        break
+      }
+    }
+    if (equal) {
+      return prev
+    }
+  }
+  prevRef.current = relativePaths
+  return relativePaths
 }
 
 export function useFileExplorerVisibleRowProjection(

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useAppStore } from '@/store'
 import { isDotfileRelativePath } from './file-explorer-entries'
 import type { DirCache, TreeNode } from './file-explorer-types'
@@ -119,7 +119,12 @@ export function createVisibleFileExplorerRowProjection(
  */
 function useContentStableRelativePaths(relativePaths: string[], enabled: boolean): string[] {
   // Why: filters need fresh identities per keystroke and must not evict the tree signature.
+  // Why ref-read-in-render + write-in-effect: render must stay pure (react-doctor), so the
+  // previous array is published after commit — worst case one render loses stability, never stale.
   const prevRef = useRef<string[] | null>(null)
+  useEffect(() => {
+    prevRef.current = relativePaths
+  }, [relativePaths])
   if (!enabled) {
     return relativePaths
   }
@@ -136,7 +141,6 @@ function useContentStableRelativePaths(relativePaths: string[], enabled: boolean
       return prev
     }
   }
-  prevRef.current = relativePaths
   return relativePaths
 }
 

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
@@ -109,6 +109,18 @@ export function createVisibleFileExplorerRowProjection(
   return createFileExplorerRowProjectionFromParts(visibleFlatRows, rowsByPath)
 }
 
+function relativePathListsEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false
+    }
+  }
+  return true
+}
+
 /**
  * Holds the array identity while its contents are unchanged.
  *
@@ -119,29 +131,19 @@ export function createVisibleFileExplorerRowProjection(
  */
 function useContentStableRelativePaths(relativePaths: string[], enabled: boolean): string[] {
   // Why: filters need fresh identities per keystroke and must not evict the tree signature.
-  // Why ref-read-in-render + write-in-effect: render must stay pure (react-doctor), so the
-  // previous array is published after commit — worst case one render loses stability, never stale.
   const prevRef = useRef<string[] | null>(null)
-  useEffect(() => {
-    prevRef.current = relativePaths
-  }, [relativePaths])
-  if (!enabled) {
-    return relativePaths
-  }
   const prev = prevRef.current
-  if (prev && prev.length === relativePaths.length) {
-    let equal = true
-    for (let i = 0; i < prev.length; i++) {
-      if (prev[i] !== relativePaths[i]) {
-        equal = false
-        break
-      }
-    }
-    if (equal) {
-      return prev
-    }
-  }
-  return relativePaths
+  // Why publish `stable`, not `relativePaths`: the ref must hold what this hook actually
+  // returned. Publishing the input instead leaves the ref one commit behind, so a wave of
+  // content-equal arrays flips identity on every render — the churn this hook exists to stop.
+  const stable =
+    enabled && prev && relativePathListsEqual(prev, relativePaths) ? prev : relativePaths
+  // Why write-in-effect: render must stay pure (react-doctor); the first commit of a new
+  // list loses stability, never staleness.
+  useEffect(() => {
+    prevRef.current = stable
+  }, [stable])
+  return stable
 }
 
 export function useFileExplorerVisibleRowProjection(

--- a/src/renderer/src/lib/pane-manager/mobile-fit-overrides.ts
+++ b/src/renderer/src/lib/pane-manager/mobile-fit-overrides.ts
@@ -143,6 +143,16 @@ export function hydrateOverrides(
   // readers so held phone-fit overlays appear even without a fresh IPC event.
   for (const [ptyId, override] of overridesByPtyId) {
     const prior = previous.get(ptyId) ?? null
+    // Why: identical re-delivery must not wake every pane — skip no-op notifications.
+    if (
+      prior &&
+      prior.mode === override.mode &&
+      prior.cols === override.cols &&
+      prior.rows === override.rows
+    ) {
+      previous.delete(ptyId)
+      continue
+    }
     notifyChange({
       ptyId,
       mode: override.mode,

--- a/src/renderer/src/lib/pane-manager/mobile-fit-overrides.ts
+++ b/src/renderer/src/lib/pane-manager/mobile-fit-overrides.ts
@@ -143,16 +143,6 @@ export function hydrateOverrides(
   // readers so held phone-fit overlays appear even without a fresh IPC event.
   for (const [ptyId, override] of overridesByPtyId) {
     const prior = previous.get(ptyId) ?? null
-    // Why: identical re-delivery must not wake every pane — skip no-op notifications.
-    if (
-      prior &&
-      prior.mode === override.mode &&
-      prior.cols === override.cols &&
-      prior.rows === override.rows
-    ) {
-      previous.delete(ptyId)
-      continue
-    }
     notifyChange({
       ptyId,
       mode: override.mode,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 |

<!-- /orca-pr-loc -->

## ELI5

More throwaway homework deleted: the big review list re-counted every comment for every visible row on each scroll frame; reopening the app woke up every phone-layout panel even when nothing changed; the file tree copied its whole path list twice per refresh; the name filter normalized every path twice per keystroke; and every repeated error re-serialized a 4KB stack just to build a map key.

## Merge Risk

**LOW** (was HIGH before `aef1bed8bd6`). The blocking regression is fixed and CI's failing assertion passes.

- **Fixed — `useContentStableRelativePaths` ref lag.** The ref was written with the raw input (`useEffect(..., [relativePaths])`) but read in render to choose the return value, so it trailed one commit and a wave of content-equal arrays flipped identity on every render after the first. Each flip re-fired the effect in `use-file-explorer-ignored-paths.ts` and with it an uncancellable full-tree `git check-ignore` — a local subprocess, or a `git.checkIgnored` RPC with a 15s timeout on remote/SSH, at ~12 extra round trips per refresh. Now publishes the returned array and keys the effect on `[stable]`.
- `useFileExplorerVisibleRowProjection.debounce.test.tsx` ("does not re-issue the ignored check for a dirCache commit that changes no path") passes; the whole `right-sidebar` suite is green at 224 files / 1946 tests.
- **Reverted — the `hydrateOverrides` no-op skip.** `notifyChange` is not a bare wakeup: `use-mobile-overlay-ticks.ts` drives `getPanesNeedingOverrideFit` → `safeFit` from it and `pty-input-recovery.ts` re-arms the remote-desktop viewport claim, so skipping identical re-delivery dropped a corrective pass. It also never fired in production (one hydrate per renderer, `previous` empty), so the change had no measurable upside.
- Verified clean and kept: `combined-diff-section-list.tsx` (per-**file** count keyed `comment.filePath` vs `section.path`, byte-identical to the removed `filter`; Map bounded by the comment list — no provider-shape or comment-misplacement risk), `crash-reporting-renderer-breadcrumbs.ts` (memo key implies identical grouping, no breadcrumb dropped, retention is four module scalars), `file-explorer-name-filter-projection.ts` (both callers normalize immediately before calling; `normalizeRelativePath` is idempotent, so Windows `\` paths still fold to `/`).

## What changed

- `combined-diff-section-list.tsx`: per-row `diffCommentsForWorktree.filter()` (O(V×C) per render) → one `Map<filePath, count>` built per comments identity, O(1) lookup per row. Same show/hide decisions.
- `mobile-fit-overrides.ts` `hydrateOverrides`: diff before `notifyChange` — skip entries whose mode/cols/rows are unchanged; removals still notify. Same end map, no-op wakeups gone.
- `useFileExplorerVisibleRowProjection.ts`: `join('\0')` + `split('\0')` whole-list copy per wave commit → element-wise `===` scan with early exit, retaining the previous array on equality. Same stability contract (NUL-free equivalence already documented).
- `file-explorer-name-filter-projection.ts`: `relativePathMatchesNameFilter` no longer re-normalizes (callers pass normalized paths) — one normalize per path per keystroke removed, lowercase comparison unchanged.
- `crash-reporting-renderer-breadcrumbs.ts`: memoize the last coalesce key on field-equality — repeated errors in a storm reuse the key without re-`stringify`ing message + 4KB stack. Distinct errors still stringify exactly once.

## Measurements

- Diff comments at 500 sections × 200 comments: V×C predicate calls per render → V map lookups.
- Hydration with identical set: listener invocations = set size → 0.
- Tree refresh at 10k paths (~500KB) × ~13 wave commits: ~13MB string churn → zero joins, early-exit scans.
- Name filter at 10k paths/keystroke: ~2N normalizes + N lowercases → N lowercases only.
- Error storm of 1k identical errors: 1k `JSON.stringify` (multi-KB inputs) → 1.

Tests: 4 suites, 79 passed. Quality gate: 0 new findings.

## Negative user-facing trade-offs

None:

- Diff: same show/hide per row (count > 0 ⟺ filter non-empty).
- Hydration: same end-state map; genuinely added/changed/removed entries still notify (mount-ordering guarantee preserved).
- Tree: element-wise equality ≡ join/split equality on NUL-free paths; downstream check-ignore query counts unchanged.
- Name filter: same normalized strings, same lowercase comparison, same token semantics.
- Breadcrumbs: same inputs → same key; grouping decisions bit-identical.
