### PR TITLE
fix(editor): always settle a claimed save-quiesce request

### DIFF
--- a/src/renderer/src/components/editor/editor-autosave-controller.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller.test.ts
@@ -511,6 +511,41 @@ describe('attachEditorAutosaveController', () => {
     }
   })
 
+  it('settles the quiesce request when flushing the pending draft throws', async () => {
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+    const eventTarget = new EventTarget()
+    vi.stubGlobal('window', {
+      addEventListener: eventTarget.addEventListener.bind(eventTarget),
+      removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
+      dispatchEvent: eventTarget.dispatchEvent.bind(eventTarget),
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+      api: { fs: { writeFile } }
+    } satisfies WindowStub)
+
+    const store = createEditorStore()
+    store.getState().openFile({
+      filePath: '/repo/file.md',
+      relativePath: 'file.md',
+      worktreeId: 'wt-1',
+      language: 'markdown',
+      mode: 'edit'
+    })
+
+    const unregisterFlush = registerPendingEditorFlush('/repo/file.md', () => {
+      throw new Error('serializer blew up')
+    })
+    const cleanup = attachEditorAutosaveController(store)
+    try {
+      // Why: the controller claims the request, so an unsettled promise hangs its
+      // caller forever with no error — a folder delete never reaches the host (#18371).
+      await expect(requestEditorSaveQuiesce({ fileId: '/repo/file.md' })).resolves.toBeUndefined()
+    } finally {
+      cleanup()
+      unregisterFlush()
+    }
+  }, 1000)
+
   it('drops an autosave already queued when owner migration starts', async () => {
     let releaseFirstWrite!: () => void
     const firstWrite = new Promise<void>((resolve) => {

--- a/src/renderer/src/components/editor/editor-autosave-controller.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller.ts
@@ -96,13 +96,21 @@ export function attachEditorAutosaveController(store: AppStoreApi): () => void {
     }
     detail.claim()
 
-    const matchingFiles =
-      'fileId' in detail
-        ? store.getState().openFiles.filter((file) => file.id === detail.fileId)
-        : getOpenFilesForExternalFileChange(store.getState().openFiles, detail)
+    try {
+      const matchingFiles =
+        'fileId' in detail
+          ? store.getState().openFiles.filter((file) => file.id === detail.fileId)
+          : getOpenFilesForExternalFileChange(store.getState().openFiles, detail)
 
-    await Promise.all(matchingFiles.map((file) => quiesceFileSave(file.id)))
-    detail.resolve()
+      await Promise.all(matchingFiles.map((file) => quiesceFileSave(file.id)))
+    } catch (error) {
+      // Why: claim() makes us the caller's only settler, so a throw here strands it
+      // forever with no error surfaced (folder delete hang, #18371). Quiescing is
+      // best-effort — log and let the caller's mutation proceed.
+      console.error('Editor save quiesce failed', error)
+    } finally {
+      detail.resolve()
+    }
   }
 
   // Why: the root subscriber fires on every store tick; skip the scan unless the four autosave inputs changed.


### PR DESCRIPTION
## Problem

`handleQuiesce` calls `detail.claim()` before doing any work, then resolved the request only on the success path:

```ts
detail.claim()
const matchingFiles = /* … */
await Promise.all(matchingFiles.map((file) => quiesceFileSave(file.id)))
detail.resolve()
```

`claim()` makes the listener the caller's **only** settler — `requestEditorSaveQuiesce` self-resolves solely when nobody claims (`editor-autosave.ts:184-186`). So any throw between `claim()` and `resolve()` leaves the caller's promise pending forever, with no rejection and nothing logged.

The sibling handler directly above, `handleSaveFile` (`:65-89`), wraps its whole body in try/catch and converts failures into `detail.reject(...)`. `handleQuiesce` never got the equivalent — the asymmetry is the defect.

**Reachable trigger:** `quiesceFileSave` calls `flushPendingEditorChange` (`editor-save-queue.ts:160`), which invokes the registered flush callback synchronously and propagates its throw (`editor-pending-flush.ts:13`). One throwing serializer strands every caller of the quiesce.

**Why it matters:** callers have no timeout. The file-explorer delete awaits this sweep for every open tab beneath the target (`useFileDeletion.ts:109-122`), so a folder delete never reaches the host — no error, no toast. Worse, `inFlightRef` is cleared only in `finally` (`useFileDeletion.ts:59`, `:240-242`), so the stranded path stays latched and **every later delete of that folder returns `false` before the confirmation dialog**, for the rest of the session. The same await sits in the rename/move path (`execute-open-editor-path-move.ts:73`), untitled-file rename, the mobile markdown bridge, and restored-owner migration.

## Fix

Catch and log, then resolve in `finally`. Quiescing is best-effort — its job is to stop pending writes before an external mutation, and a failure to flush a draft must not block the mutation (for a delete the draft is going away regardless). Rethrowing instead would only convert the hang into an unhandled rejection, since nothing awaits the listener.

## Verification

| Check | Result |
|---|---|
| New test with the fix reverted | 3 failed |
| New test with the fix applied | 13 passed |
| `editor-autosave`, `execute-open-editor-path-move`, `remote-host-file-delete-repro`, `file-explorer-delete-owner-provenance` | 32 passed |
| `pnpm tc` | clean |
| `pnpm run check:code-quality:changed` | 0 new findings |

The new test registers a throwing flush callback and asserts the quiesce request settles; it fails by timeout without the fix. Note the first version of this patch used `finally` alone — it settled the caller but leaked an unhandled rejection, which the test caught. Hence the explicit `catch`.

## Scope

Renderer-only. No wire change, no relay change, no IPC signature change — so nothing here interacts with remote wire compatibility or the SSH execution boundary.

## Relation to #18371

Found while investigating #18371 (folder delete does nothing in the right-sidebar file tree on an SSH host: confirmation dialog appears, nothing is deleted, no toast ever, plain file deletes work). This defect matches that signature exactly, including its permanence.

Deliberately `Refs`, not `Closes` — the reporter has not yet run the discriminating check (attempt the same folder twice; dialog on the first attempt and **no** dialog on the second is the stuck latch). If that check comes back negative, this is still a real bug fix, just not the cure for #18371.

Refs #18371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
