### PR TITLE
fix(settings): indent the Agent sleep "Sleep after" sub-setting

### DIFF
--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -190,30 +190,33 @@ export function ExperimentalPane({
             />
           </div>
           {agentHibernationEnabled ? (
-            <NumberField
-              label={translate(
-                'auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesLabel',
-                'Sleep after'
-              )}
-              description={translate(
-                'auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesDescription',
-                'How many idle minutes a completed background agent must wait before Orca can sleep it.'
-              )}
-              value={agentHibernationIdleMinutes}
-              min={MIN_AGENT_HIBERNATION_IDLE_MS / MS_PER_MINUTE}
-              max={MAX_AGENT_HIBERNATION_IDLE_MS / MS_PER_MINUTE}
-              step={1}
-              suffix={translate(
-                'auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesSuffix',
-                'minutes'
-              )}
-              onChange={(minutes) =>
-                updateSettings({
-                  // Why: settings persist the planner contract, not the display unit.
-                  agentHibernationIdleMs: minutes * MS_PER_MINUTE
-                })
-              }
-            />
+            <div className="ml-4 space-y-3 border-l border-border pl-4">
+              <NumberField
+                className="py-0"
+                label={translate(
+                  'auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesLabel',
+                  'Sleep after'
+                )}
+                description={translate(
+                  'auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesDescription',
+                  'How many idle minutes a completed background agent must wait before Orca can sleep it.'
+                )}
+                value={agentHibernationIdleMinutes}
+                min={MIN_AGENT_HIBERNATION_IDLE_MS / MS_PER_MINUTE}
+                max={MAX_AGENT_HIBERNATION_IDLE_MS / MS_PER_MINUTE}
+                step={1}
+                suffix={translate(
+                  'auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesSuffix',
+                  'minutes'
+                )}
+                onChange={(minutes) =>
+                  updateSettings({
+                    // Why: settings persist the planner contract, not the display unit.
+                    agentHibernationIdleMs: minutes * MS_PER_MINUTE
+                  })
+                }
+              />
+            </div>
           ) : null}
         </SearchableSetting>
       ) : null}

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -270,6 +270,7 @@ type NumberFieldProps = {
   integer?: boolean
   onChange: (value: number) => void
   suffix?: string
+  className?: string
 }
 
 export function ColorField({
@@ -315,7 +316,8 @@ export function NumberField({
   step = 1,
   integer = false,
   onChange,
-  suffix
+  suffix,
+  className
 }: NumberFieldProps): React.JSX.Element {
   const [draft, setDraft] = useState(Number.isFinite(value) ? String(value) : '')
   const [prevValue, setPrevValue] = useState(value)
@@ -346,6 +348,7 @@ export function NumberField({
 
   return (
     <SettingsRow
+      className={className}
       label={label}
       description={
         <>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## Problem

In **Settings → Experimental**, the **Sleep after** field under **Agent sleep** rendered flush with its parent toggle, so it read as a top-level setting rather than a child of Agent sleep. Every other conditional sub-setting on the page — Agent Dashboard's *Open as*, Chat UI's *Default view* / *Use updated structured native chat* — sits inside the indented, left-bordered group.

## Change

- Wrap the `NumberField` in the same `ml-4 space-y-3 border-l border-border pl-4` group the sibling sub-settings already use.
- Add an optional `className` passthrough on `NumberField` (forwarded to `SettingsRow`, which already accepts one) and pass `py-0` so the row doesn't add extra vertical padding on top of the group's own spacing.

Rendering only — no settings, planner, or persistence behavior changes.

## Verification

- `pnpm tc` — clean
- `pnpm test src/renderer/src/components/settings/ExperimentalPane.test.tsx` — 16/16 pass
- `oxlint` on both changed files — clean

## Visual proof

Captured in a dev Orca instance built from this branch (`brennanb2025-fix-agent-sleep-after.app`, CDP :9343, isolated profile), Settings → Experimental with Agent Dashboard, Chat UI, and Agent sleep all enabled so the three conditional sub-settings render side by side. Same scroll position in both shots; "before" was produced by hot-reloading the two files at `HEAD~1`.

**Before** — "Sleep after" sits flush with its parent, no indent group:

![before-flush.png](https://github.com/user-attachments/assets/61ee502a-80f1-439f-9f48-5979413ef3ee)

**After** — it sits in the same indented, left-bordered group as *Open as* and *Default view*:

![after-indented.png](https://github.com/user-attachments/assets/71506eb6-930c-42a9-9b92-52c2e1c5f515)

Measured label offsets in the live DOM (`getBoundingClientRect().left`):

| Label | Before | After |
| --- | --- | --- |
| Agent Dashboard (parent) | 612 | 612 |
| ↳ Open as | 645 | 645 |
| Chat UI (parent) | 612 | 612 |
| ↳ Default view | 645 | 645 |
| Agent sleep (parent) | 612 | 612 |
| ↳ **Sleep after** | **612** | **645** |
